### PR TITLE
Add clearance action readiness evidence summaries

### DIFF
--- a/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
+++ b/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
@@ -50,6 +50,9 @@ All notable changes to this package will be documented in this file.
 - Mesh release ticket handoff disposition-action slot clearance action evidence
   review clearance action readiness evidence rows that capture repair, review,
   dispatch, execution, lineage, and release handoff evidence.
+- Mesh release ticket handoff disposition-action slot clearance action evidence
+  review clearance action readiness evidence summaries that combine evidence
+  readiness with evidence counts and next readiness evidence pointers.
 - Virtual alias entries for product lines supported by another integration or
   standard.
 - Read-only D18D tool descriptors for listing/describing integrations and

--- a/code/packages/rust/smart-home-integration-catalog/README.md
+++ b/code/packages/rust/smart-home-integration-catalog/README.md
@@ -218,6 +218,10 @@ runtime and Chief of Staff tools a typed catalog for:
 - low-level mesh release ticket handoff disposition-action slot clearance
   action evidence review clearance action readiness evidence rows that capture
   repair, review, dispatch, execution, lineage, and release handoff evidence
+- mesh release ticket handoff guardrail audit clearance action evidence review
+  disposition-action slot clearance action evidence review clearance action
+  readiness evidence summaries that combine evidence readiness with evidence
+  counts and next readiness evidence pointers
 - mesh release ticket handoff work-order guardrail readiness summaries that
   combine work-order readiness with guardrail counts and first actionable
   handoff work

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -18982,6 +18982,455 @@ impl
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationMeshReleaseTicketHandoffGuardrailAuditClearanceActionEvidenceReviewDispositionActionSlotClearanceActionEvidenceReviewClearanceActionReadinessEvidenceSummary {
+    pub release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_action_slot_clearance_action_evidence_review_clearance_action_readiness_summary:
+        Box<IntegrationMeshReleaseTicketHandoffGuardrailAuditClearanceActionEvidenceReviewDispositionActionSlotClearanceActionEvidenceReviewClearanceActionReadinessSummary>,
+    pub total_slot_clearance_action_evidence_review_clearance_action_rows: usize,
+    pub total_slot_clearance_action_evidence_review_clearance_action_readiness_evidence_rows:
+        usize,
+    pub required_evidence: usize,
+    pub release_blocking_evidence: usize,
+    pub operator_required_evidence: usize,
+    pub review_required_evidence: usize,
+    pub dispatch_required_evidence: usize,
+    pub execution_required_evidence: usize,
+    pub repair_evidence: usize,
+    pub operator_handoff_evidence: usize,
+    pub review_evidence: usize,
+    pub dispatch_evidence: usize,
+    pub execution_evidence: usize,
+    pub lineage_evidence: usize,
+    pub release_handoff_evidence: usize,
+    pub lineage_complete_evidence: usize,
+    pub ready_evidence: usize,
+    pub first_slot_clearance_action_evidence_review_clearance_action_readiness_evidence_key:
+        Option<String>,
+    pub first_required_evidence_key: Option<String>,
+    pub first_repair_evidence_key: Option<String>,
+    pub first_operator_handoff_evidence_key: Option<String>,
+    pub first_review_evidence_key: Option<String>,
+    pub first_dispatch_evidence_key: Option<String>,
+    pub first_execution_evidence_key: Option<String>,
+    pub first_lineage_evidence_key: Option<String>,
+    pub first_release_handoff_evidence_key: Option<String>,
+    pub first_slot_clearance_action_evidence_review_clearance_action_key: Option<String>,
+    pub first_slot_clearance_action_evidence_review_clearance_key: Option<String>,
+    pub first_slot_clearance_action_evidence_review_key: Option<String>,
+    pub first_slot_clearance_action_evidence_key: Option<String>,
+    pub first_slot_clearance_action_key: Option<String>,
+    pub first_slot_clearance_key: Option<String>,
+    pub first_review_disposition_action_slot_key: Option<String>,
+    pub first_review_disposition_action_key: Option<String>,
+    pub first_work_order_key: Option<String>,
+    pub first_ticket_key: Option<String>,
+    pub first_clearance_action_readiness_evidence_kind: Option<
+        IntegrationMeshReleaseTicketHandoffExecutionWorkOrderGuardrailAuditClearanceActionEvidenceReviewDispositionActionSlotClearanceActionEvidenceReviewClearanceActionReadinessEvidenceKind,
+    >,
+    pub first_clearance_action_kind: Option<
+        IntegrationMeshReleaseTicketHandoffExecutionWorkOrderGuardrailAuditClearanceActionEvidenceReviewDispositionActionSlotClearanceActionEvidenceReviewClearanceActionKind,
+    >,
+    pub first_clearance_kind: Option<
+        IntegrationMeshReleaseTicketHandoffExecutionWorkOrderGuardrailAuditClearanceActionEvidenceReviewDispositionActionSlotClearanceActionEvidenceReviewClearanceKind,
+    >,
+    pub first_action_evidence_review_kind: Option<
+        IntegrationMeshReleaseTicketHandoffExecutionWorkOrderGuardrailAuditClearanceActionEvidenceReviewKind,
+    >,
+    pub first_handoff_lane: Option<IntegrationMeshReleaseDispatchTicketHandoffLane>,
+    pub first_check_kind: Option<IntegrationMeshReleaseReadinessCheckKind>,
+    pub first_check_status: Option<IntegrationMeshReleaseReadinessStatus>,
+    pub next_slot_clearance_action_evidence_review_clearance_action_readiness_evidence_key:
+        Option<String>,
+    pub next_slot_clearance_action_evidence_review_clearance_action_key: Option<String>,
+    pub next_slot_clearance_action_evidence_review_clearance_key: Option<String>,
+    pub next_slot_clearance_action_evidence_review_key: Option<String>,
+    pub next_slot_clearance_action_evidence_key: Option<String>,
+    pub next_slot_clearance_action_key: Option<String>,
+    pub next_slot_clearance_key: Option<String>,
+    pub next_review_disposition_action_slot_key: Option<String>,
+    pub next_review_disposition_action_key: Option<String>,
+    pub next_work_order_key: Option<String>,
+    pub next_ticket_key: Option<String>,
+    pub next_check_kind: Option<IntegrationMeshReleaseReadinessCheckKind>,
+    pub next_check_status: Option<IntegrationMeshReleaseReadinessStatus>,
+    pub next_handoff_lane: Option<IntegrationMeshReleaseDispatchTicketHandoffLane>,
+    pub release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_action_slot_clearance_action_evidence_review_clearance_actions_ready:
+        bool,
+    pub release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_action_slot_clearance_action_evidence_review_clearance_action_readiness_evidence_ready:
+        bool,
+}
+
+impl
+    IntegrationMeshReleaseTicketHandoffGuardrailAuditClearanceActionEvidenceReviewDispositionActionSlotClearanceActionEvidenceReviewClearanceActionReadinessEvidenceSummary
+{
+    pub fn from_summaries<'a>(
+        release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_action_slot_clearance_action_evidence_review_clearance_action_readiness_summary: IntegrationMeshReleaseTicketHandoffGuardrailAuditClearanceActionEvidenceReviewDispositionActionSlotClearanceActionEvidenceReviewClearanceActionReadinessSummary,
+        evidence_rows: impl IntoIterator<
+            Item = &'a IntegrationMeshReleaseTicketHandoffExecutionWorkOrderGuardrailAuditClearanceActionEvidenceReviewDispositionActionSlotClearanceActionEvidenceReviewClearanceActionReadinessEvidenceRow,
+        >,
+    ) -> Self {
+        let evidence_rows = evidence_rows.into_iter().collect::<Vec<_>>();
+        let first_evidence_row = evidence_rows.iter().min_by_key(|row| row.sequence);
+        let first_required_evidence = evidence_rows
+            .iter()
+            .filter(|row| row.requires_attention())
+            .min_by_key(|row| row.sequence);
+        let first_repair_evidence = evidence_rows
+            .iter()
+            .filter(|row| row.is_repair_evidence())
+            .min_by_key(|row| row.sequence);
+        let first_operator_handoff_evidence = evidence_rows
+            .iter()
+            .filter(|row| row.is_operator_handoff_evidence())
+            .min_by_key(|row| row.sequence);
+        let first_review_evidence = evidence_rows
+            .iter()
+            .filter(|row| row.is_review_evidence())
+            .min_by_key(|row| row.sequence);
+        let first_dispatch_evidence = evidence_rows
+            .iter()
+            .filter(|row| row.is_dispatch_evidence())
+            .min_by_key(|row| row.sequence);
+        let first_execution_evidence = evidence_rows
+            .iter()
+            .filter(|row| row.is_execution_evidence())
+            .min_by_key(|row| row.sequence);
+        let first_lineage_evidence = evidence_rows
+            .iter()
+            .filter(|row| row.is_lineage_evidence())
+            .min_by_key(|row| row.sequence);
+        let first_release_handoff_evidence = evidence_rows
+            .iter()
+            .filter(|row| row.is_release_handoff_evidence())
+            .min_by_key(|row| row.sequence);
+        let next_evidence = evidence_rows
+            .iter()
+            .filter(|row| row.requires_attention())
+            .min_by_key(|row| row.sequence);
+        let release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_action_slot_clearance_action_evidence_review_clearance_actions_ready =
+            release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_action_slot_clearance_action_evidence_review_clearance_action_readiness_summary
+                .ready_for_release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_action_slot_clearance_action_evidence_review_clearance_actions();
+        let release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_action_slot_clearance_action_evidence_review_clearance_action_readiness_evidence_ready =
+            release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_action_slot_clearance_action_evidence_review_clearance_actions_ready
+                && !evidence_rows.is_empty()
+                && evidence_rows.iter().all(|row| row.ready_to_release_handoff())
+                && evidence_rows.iter().all(|row| row.has_lineage());
+
+        Self {
+            total_slot_clearance_action_evidence_review_clearance_action_rows:
+                release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_action_slot_clearance_action_evidence_review_clearance_action_readiness_summary
+                    .total_slot_clearance_action_evidence_review_clearance_action_rows,
+            total_slot_clearance_action_evidence_review_clearance_action_readiness_evidence_rows:
+                evidence_rows.len(),
+            required_evidence: evidence_rows
+                .iter()
+                .filter(|row| row.requires_attention())
+                .count(),
+            release_blocking_evidence: evidence_rows
+                .iter()
+                .filter(|row| row.blocks_release())
+                .count(),
+            operator_required_evidence: evidence_rows
+                .iter()
+                .filter(|row| row.needs_operator())
+                .count(),
+            review_required_evidence: evidence_rows
+                .iter()
+                .filter(|row| row.needs_review())
+                .count(),
+            dispatch_required_evidence: evidence_rows
+                .iter()
+                .filter(|row| row.requires_dispatch())
+                .count(),
+            execution_required_evidence: evidence_rows
+                .iter()
+                .filter(|row| row.requires_execution())
+                .count(),
+            repair_evidence: evidence_rows
+                .iter()
+                .filter(|row| row.is_repair_evidence())
+                .count(),
+            operator_handoff_evidence: evidence_rows
+                .iter()
+                .filter(|row| row.is_operator_handoff_evidence())
+                .count(),
+            review_evidence: evidence_rows
+                .iter()
+                .filter(|row| row.is_review_evidence())
+                .count(),
+            dispatch_evidence: evidence_rows
+                .iter()
+                .filter(|row| row.is_dispatch_evidence())
+                .count(),
+            execution_evidence: evidence_rows
+                .iter()
+                .filter(|row| row.is_execution_evidence())
+                .count(),
+            lineage_evidence: evidence_rows
+                .iter()
+                .filter(|row| row.is_lineage_evidence())
+                .count(),
+            release_handoff_evidence: evidence_rows
+                .iter()
+                .filter(|row| row.is_release_handoff_evidence())
+                .count(),
+            lineage_complete_evidence: evidence_rows
+                .iter()
+                .filter(|row| row.has_lineage())
+                .count(),
+            ready_evidence: evidence_rows
+                .iter()
+                .filter(|row| row.ready_to_release_handoff())
+                .count(),
+            first_slot_clearance_action_evidence_review_clearance_action_readiness_evidence_key:
+                first_evidence_row.map(|row| {
+                    row.slot_clearance_action_evidence_review_clearance_action_readiness_evidence_key
+                        .clone()
+                }),
+            first_required_evidence_key: first_required_evidence.map(|row| {
+                row.slot_clearance_action_evidence_review_clearance_action_readiness_evidence_key
+                    .clone()
+            }),
+            first_repair_evidence_key: first_repair_evidence.map(|row| {
+                row.slot_clearance_action_evidence_review_clearance_action_readiness_evidence_key
+                    .clone()
+            }),
+            first_operator_handoff_evidence_key: first_operator_handoff_evidence.map(|row| {
+                row.slot_clearance_action_evidence_review_clearance_action_readiness_evidence_key
+                    .clone()
+            }),
+            first_review_evidence_key: first_review_evidence.map(|row| {
+                row.slot_clearance_action_evidence_review_clearance_action_readiness_evidence_key
+                    .clone()
+            }),
+            first_dispatch_evidence_key: first_dispatch_evidence.map(|row| {
+                row.slot_clearance_action_evidence_review_clearance_action_readiness_evidence_key
+                    .clone()
+            }),
+            first_execution_evidence_key: first_execution_evidence.map(|row| {
+                row.slot_clearance_action_evidence_review_clearance_action_readiness_evidence_key
+                    .clone()
+            }),
+            first_lineage_evidence_key: first_lineage_evidence.map(|row| {
+                row.slot_clearance_action_evidence_review_clearance_action_readiness_evidence_key
+                    .clone()
+            }),
+            first_release_handoff_evidence_key: first_release_handoff_evidence.map(|row| {
+                row.slot_clearance_action_evidence_review_clearance_action_readiness_evidence_key
+                    .clone()
+            }),
+            first_slot_clearance_action_evidence_review_clearance_action_key: first_evidence_row
+                .map(|row| row.slot_clearance_action_evidence_review_clearance_action_key.clone()),
+            first_slot_clearance_action_evidence_review_clearance_key: first_evidence_row
+                .map(|row| row.slot_clearance_action_evidence_review_clearance_key.clone()),
+            first_slot_clearance_action_evidence_review_key: first_evidence_row
+                .map(|row| row.slot_clearance_action_evidence_review_key.clone()),
+            first_slot_clearance_action_evidence_key: first_evidence_row
+                .map(|row| row.slot_clearance_action_evidence_key.clone()),
+            first_slot_clearance_action_key: first_evidence_row
+                .map(|row| row.slot_clearance_action_key.clone()),
+            first_slot_clearance_key: first_evidence_row
+                .map(|row| row.slot_clearance_key.clone()),
+            first_review_disposition_action_slot_key: first_evidence_row
+                .map(|row| row.slot_key.clone()),
+            first_review_disposition_action_key: first_evidence_row
+                .map(|row| row.disposition_action_key.clone()),
+            first_work_order_key: first_evidence_row.map(|row| row.work_order_key.clone()),
+            first_ticket_key: first_evidence_row.map(|row| row.ticket_key.clone()),
+            first_clearance_action_readiness_evidence_kind: first_evidence_row
+                .map(|row| row.clearance_action_readiness_evidence_kind),
+            first_clearance_action_kind: first_evidence_row.map(|row| row.clearance_action_kind),
+            first_clearance_kind: first_evidence_row.map(|row| row.clearance_kind),
+            first_action_evidence_review_kind: first_evidence_row.map(|row| row.review_kind),
+            first_handoff_lane: first_evidence_row.map(|row| row.handoff_lane),
+            first_check_kind: first_evidence_row.map(|row| row.check_kind),
+            first_check_status: first_evidence_row.map(|row| row.status),
+            next_slot_clearance_action_evidence_review_clearance_action_readiness_evidence_key:
+                next_evidence.map(|row| {
+                    row.slot_clearance_action_evidence_review_clearance_action_readiness_evidence_key
+                        .clone()
+                }),
+            next_slot_clearance_action_evidence_review_clearance_action_key: next_evidence
+                .map(|row| row.slot_clearance_action_evidence_review_clearance_action_key.clone())
+                .or_else(|| {
+                    release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_action_slot_clearance_action_evidence_review_clearance_action_readiness_summary
+                        .next_slot_clearance_action_evidence_review_clearance_action_key
+                        .clone()
+                }),
+            next_slot_clearance_action_evidence_review_clearance_key: next_evidence
+                .map(|row| row.slot_clearance_action_evidence_review_clearance_key.clone())
+                .or_else(|| {
+                    release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_action_slot_clearance_action_evidence_review_clearance_action_readiness_summary
+                        .next_slot_clearance_action_evidence_review_clearance_key
+                        .clone()
+                }),
+            next_slot_clearance_action_evidence_review_key: next_evidence
+                .map(|row| row.slot_clearance_action_evidence_review_key.clone())
+                .or_else(|| {
+                    release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_action_slot_clearance_action_evidence_review_clearance_action_readiness_summary
+                        .next_slot_clearance_action_evidence_review_key
+                        .clone()
+                }),
+            next_slot_clearance_action_evidence_key: next_evidence
+                .map(|row| row.slot_clearance_action_evidence_key.clone())
+                .or_else(|| {
+                    release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_action_slot_clearance_action_evidence_review_clearance_action_readiness_summary
+                        .next_slot_clearance_action_evidence_key
+                        .clone()
+                }),
+            next_slot_clearance_action_key: next_evidence
+                .map(|row| row.slot_clearance_action_key.clone())
+                .or_else(|| {
+                    release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_action_slot_clearance_action_evidence_review_clearance_action_readiness_summary
+                        .next_slot_clearance_action_key
+                        .clone()
+                }),
+            next_slot_clearance_key: next_evidence
+                .map(|row| row.slot_clearance_key.clone())
+                .or_else(|| {
+                    release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_action_slot_clearance_action_evidence_review_clearance_action_readiness_summary
+                        .next_slot_clearance_key
+                        .clone()
+                }),
+            next_review_disposition_action_slot_key: next_evidence
+                .map(|row| row.slot_key.clone())
+                .or_else(|| {
+                    release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_action_slot_clearance_action_evidence_review_clearance_action_readiness_summary
+                        .next_review_disposition_action_slot_key
+                        .clone()
+                }),
+            next_review_disposition_action_key: next_evidence
+                .map(|row| row.disposition_action_key.clone())
+                .or_else(|| {
+                    release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_action_slot_clearance_action_evidence_review_clearance_action_readiness_summary
+                        .next_review_disposition_action_key
+                        .clone()
+                }),
+            next_work_order_key: next_evidence
+                .map(|row| row.work_order_key.clone())
+                .or_else(|| {
+                    release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_action_slot_clearance_action_evidence_review_clearance_action_readiness_summary
+                        .next_work_order_key
+                        .clone()
+                }),
+            next_ticket_key: next_evidence
+                .map(|row| row.ticket_key.clone())
+                .or_else(|| {
+                    release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_action_slot_clearance_action_evidence_review_clearance_action_readiness_summary
+                        .next_ticket_key
+                        .clone()
+                }),
+            next_check_kind: next_evidence.map(|row| row.check_kind).or(
+                release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_action_slot_clearance_action_evidence_review_clearance_action_readiness_summary
+                    .next_check_kind,
+            ),
+            next_check_status: next_evidence.map(|row| row.status).or(
+                release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_action_slot_clearance_action_evidence_review_clearance_action_readiness_summary
+                    .next_check_status,
+            ),
+            next_handoff_lane: next_evidence.map(|row| row.handoff_lane).or(
+                release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_action_slot_clearance_action_evidence_review_clearance_action_readiness_summary
+                    .next_handoff_lane,
+            ),
+            release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_action_slot_clearance_action_evidence_review_clearance_actions_ready,
+            release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_action_slot_clearance_action_evidence_review_clearance_action_readiness_evidence_ready,
+            release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_action_slot_clearance_action_evidence_review_clearance_action_readiness_summary:
+                Box::new(
+                    release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_action_slot_clearance_action_evidence_review_clearance_action_readiness_summary,
+                ),
+        }
+    }
+
+    pub fn has_evidence_rows(&self) -> bool {
+        self.total_slot_clearance_action_evidence_review_clearance_action_readiness_evidence_rows
+            > 0
+    }
+
+    pub fn ready_for_release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_action_slot_clearance_action_evidence_review_clearance_action_readiness_evidence(
+        &self,
+    ) -> bool {
+        self.release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_action_slot_clearance_action_evidence_review_clearance_action_readiness_evidence_ready
+            && !self.requires_attention()
+    }
+
+    pub fn has_required_evidence(&self) -> bool {
+        self.required_evidence > 0
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.release_blocking_evidence > 0
+            || self
+                .release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_action_slot_clearance_action_evidence_review_clearance_action_readiness_summary
+                .has_blockers()
+    }
+
+    pub fn has_review_work(&self) -> bool {
+        self.review_required_evidence > 0
+            || self.review_evidence > 0
+            || self
+                .release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_action_slot_clearance_action_evidence_review_clearance_action_readiness_summary
+                .has_review_work()
+    }
+
+    pub fn needs_operator(&self) -> bool {
+        self.operator_required_evidence > 0
+            || self.operator_handoff_evidence > 0
+            || self
+                .release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_action_slot_clearance_action_evidence_review_clearance_action_readiness_summary
+                .needs_operator()
+    }
+
+    pub fn requires_dispatch(&self) -> bool {
+        self.dispatch_required_evidence > 0 || self.dispatch_evidence > 0
+    }
+
+    pub fn requires_execution(&self) -> bool {
+        self.execution_required_evidence > 0
+            || self.execution_evidence > 0
+            || self
+                .release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_action_slot_clearance_action_evidence_review_clearance_action_readiness_summary
+                .requires_execution()
+    }
+
+    pub fn has_lineage_gaps(&self) -> bool {
+        self.lineage_evidence > 0
+            || self.lineage_complete_evidence
+                < self
+                    .total_slot_clearance_action_evidence_review_clearance_action_readiness_evidence_rows
+            || self
+                .release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_action_slot_clearance_action_evidence_review_clearance_action_readiness_summary
+                .has_lineage_gaps()
+    }
+
+    pub fn has_release_handoff_evidence(&self) -> bool {
+        self.release_handoff_evidence > 0
+    }
+
+    pub fn has_complete_lineage(&self) -> bool {
+        self.lineage_complete_evidence
+            == self
+                .total_slot_clearance_action_evidence_review_clearance_action_readiness_evidence_rows
+            && self
+                .release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_action_slot_clearance_action_evidence_review_clearance_action_readiness_summary
+                .has_complete_lineage()
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.requires_dispatch()
+            || self.requires_execution()
+            || self.has_required_evidence()
+            || self.has_blockers()
+            || self.has_review_work()
+            || self.needs_operator()
+            || self.has_lineage_gaps()
+            || self
+                .release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_action_slot_clearance_action_evidence_review_clearance_action_readiness_summary
+                .requires_attention()
+            || !self
+                .release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_action_slot_clearance_action_evidence_review_clearance_action_readiness_evidence_ready
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IntegrationCatalogEntry {
     pub integration_id: IntegrationId,
     pub display_name: String,
@@ -42567,6 +43016,49 @@ pub fn mesh_release_ticket_handoff_execution_work_order_guardrail_audit_clearanc
     )
 }
 
+pub fn mesh_release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_action_slot_clearance_action_evidence_review_clearance_action_readiness_evidence_summary_for_catalog(
+    catalog: &[IntegrationCatalogEntry],
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> IntegrationMeshReleaseTicketHandoffGuardrailAuditClearanceActionEvidenceReviewDispositionActionSlotClearanceActionEvidenceReviewClearanceActionReadinessEvidenceSummary
+{
+    let clearance_action_readiness_summary =
+        mesh_release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_action_slot_clearance_action_evidence_review_clearance_action_readiness_summary_for_catalog(
+            catalog,
+            available_primitives,
+            allowed_capabilities,
+            enabled_integrations,
+        );
+    let evidence_rows =
+        mesh_release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_slot_clearance_action_evidence_review_clearance_action_readiness_evidence_rows_for_catalog(
+            catalog,
+            available_primitives,
+            allowed_capabilities,
+            enabled_integrations,
+        );
+
+    IntegrationMeshReleaseTicketHandoffGuardrailAuditClearanceActionEvidenceReviewDispositionActionSlotClearanceActionEvidenceReviewClearanceActionReadinessEvidenceSummary::from_summaries(
+        clearance_action_readiness_summary,
+        evidence_rows.iter(),
+    )
+}
+
+pub fn mesh_release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_action_slot_clearance_action_evidence_review_clearance_action_readiness_evidence_summary(
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> IntegrationMeshReleaseTicketHandoffGuardrailAuditClearanceActionEvidenceReviewDispositionActionSlotClearanceActionEvidenceReviewClearanceActionReadinessEvidenceSummary
+{
+    let catalog = first_party_catalog();
+    mesh_release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_action_slot_clearance_action_evidence_review_clearance_action_readiness_evidence_summary_for_catalog(
+        &catalog,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    )
+}
+
 fn mesh_protocol_catalog_entries(
     catalog: &[IntegrationCatalogEntry],
 ) -> Vec<IntegrationCatalogEntry> {
@@ -57773,6 +58265,146 @@ mod tests {
         );
         assert!(evidence_rows[0].release_ready_review);
         assert!(evidence_rows[0].has_lineage());
+    }
+
+    #[test]
+    fn mesh_release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_action_slot_clearance_action_evidence_review_clearance_action_readiness_evidence_summary_surfaces_next_evidence(
+    ) {
+        let available_primitives = vec![
+            PrimitiveFamily::Usb,
+            PrimitiveFamily::SerialController,
+            PrimitiveFamily::Radio802154,
+            PrimitiveFamily::Supervision,
+        ];
+        let allowed_capabilities = vec![CapabilityId::trusted("smart_home.read")];
+        let evidence_rows =
+            mesh_release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_slot_clearance_action_evidence_review_clearance_action_readiness_evidence_rows(
+                &available_primitives,
+                &allowed_capabilities,
+                &[],
+            );
+        let summary =
+            mesh_release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_action_slot_clearance_action_evidence_review_clearance_action_readiness_evidence_summary(
+                &available_primitives,
+                &allowed_capabilities,
+                &[],
+            );
+
+        assert_eq!(
+            summary.total_slot_clearance_action_evidence_review_clearance_action_rows,
+            5
+        );
+        assert_eq!(
+            summary
+                .total_slot_clearance_action_evidence_review_clearance_action_readiness_evidence_rows,
+            evidence_rows.len()
+        );
+        assert_eq!(summary.required_evidence, 5);
+        assert_eq!(summary.repair_evidence, 3);
+        assert_eq!(summary.review_evidence, 2);
+        assert_eq!(summary.release_handoff_evidence, 0);
+        assert_eq!(summary.ready_evidence, 0);
+        assert!(summary.has_evidence_rows());
+        assert!(summary.has_required_evidence());
+        assert!(summary.has_blockers());
+        assert!(summary.has_review_work());
+        assert!(summary.needs_operator());
+        assert!(summary.requires_dispatch());
+        assert!(summary.requires_execution());
+        assert!(!summary.has_release_handoff_evidence());
+        assert!(summary.requires_attention());
+        assert!(!summary.ready_for_release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_action_slot_clearance_action_evidence_review_clearance_action_readiness_evidence());
+        assert_eq!(
+            summary
+                .first_slot_clearance_action_evidence_review_clearance_action_readiness_evidence_key,
+            Some(evidence_rows[0].slot_clearance_action_evidence_review_clearance_action_readiness_evidence_key.clone())
+        );
+        assert_eq!(
+            summary
+                .next_slot_clearance_action_evidence_review_clearance_action_readiness_evidence_key,
+            Some(
+                evidence_rows[0]
+                    .slot_clearance_action_evidence_review_clearance_action_readiness_evidence_key
+                    .clone()
+            )
+        );
+        assert_eq!(
+            summary.first_repair_evidence_key,
+            Some(
+                evidence_rows[0]
+                    .slot_clearance_action_evidence_review_clearance_action_readiness_evidence_key
+                    .clone()
+            )
+        );
+        assert_eq!(
+            summary.first_clearance_action_readiness_evidence_kind,
+            Some(IntegrationMeshReleaseTicketHandoffExecutionWorkOrderGuardrailAuditClearanceActionEvidenceReviewDispositionActionSlotClearanceActionEvidenceReviewClearanceActionReadinessEvidenceKind::RepairEvidence)
+        );
+        assert_eq!(
+            summary.next_work_order_key,
+            Some(evidence_rows[0].work_order_key.clone())
+        );
+    }
+
+    #[test]
+    fn mesh_release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_action_slot_clearance_action_evidence_review_clearance_action_readiness_evidence_summary_marks_release_handoff_ready(
+    ) {
+        let catalog = vec![hue_entry()];
+        let allowed_capabilities = vec![
+            CapabilityId::trusted("smart_home.read"),
+            CapabilityId::trusted("smart_home.command.light"),
+            CapabilityId::trusted("smart_home.pair"),
+        ];
+        let evidence_rows =
+            mesh_release_ticket_handoff_execution_work_order_guardrail_audit_clearance_action_evidence_review_disposition_action_slot_clearance_action_evidence_review_clearance_action_readiness_evidence_rows_for_catalog(
+                &catalog,
+                all_primitive_families(),
+                &allowed_capabilities,
+                &[],
+            );
+        let summary =
+            mesh_release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_action_slot_clearance_action_evidence_review_clearance_action_readiness_evidence_summary_for_catalog(
+                &catalog,
+                all_primitive_families(),
+                &allowed_capabilities,
+                &[],
+            );
+
+        assert_eq!(
+            summary
+                .total_slot_clearance_action_evidence_review_clearance_action_readiness_evidence_rows,
+            5
+        );
+        assert_eq!(summary.required_evidence, 0);
+        assert_eq!(summary.release_handoff_evidence, evidence_rows.len());
+        assert_eq!(summary.ready_evidence, evidence_rows.len());
+        assert_eq!(summary.lineage_complete_evidence, evidence_rows.len());
+        assert!(summary.has_release_handoff_evidence());
+        assert!(summary.has_complete_lineage());
+        assert!(!summary.has_blockers());
+        assert!(!summary.has_review_work());
+        assert!(!summary.needs_operator());
+        assert!(!summary.requires_dispatch());
+        assert!(!summary.requires_execution());
+        assert!(!summary.requires_attention());
+        assert!(summary.ready_for_release_ticket_handoff_guardrail_audit_clearance_action_evidence_review_disposition_action_slot_clearance_action_evidence_review_clearance_action_readiness_evidence());
+        assert_eq!(
+            summary.first_release_handoff_evidence_key,
+            Some(
+                evidence_rows[0]
+                    .slot_clearance_action_evidence_review_clearance_action_readiness_evidence_key
+                    .clone()
+            )
+        );
+        assert_eq!(
+            summary
+                .next_slot_clearance_action_evidence_review_clearance_action_readiness_evidence_key,
+            None
+        );
+        assert_eq!(
+            summary.first_clearance_action_readiness_evidence_kind,
+            Some(IntegrationMeshReleaseTicketHandoffExecutionWorkOrderGuardrailAuditClearanceActionEvidenceReviewDispositionActionSlotClearanceActionEvidenceReviewClearanceActionReadinessEvidenceKind::ReleaseHandoffEvidence)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add a clearance action readiness evidence summary for the smart-home mesh release handoff chain
- expose evidence totals, first evidence pointers, next actionable evidence pointers, and readiness predicates
- document the new summary layer in the package README and changelog

## Validation

- `cargo test readiness_evidence_summary -- --nocapture`
- `cargo test`
- `git diff --check`