### PR TITLE
feat(mycin-cranial): ADJ-only cranial-nerve function recall library (7 edges)

### DIFF
--- a/code/specs/data/mycin-2026/recall/cranial-nerve-edges.adj
+++ b/code/specs/data/mycin-2026/recall/cranial-nerve-edges.adj
@@ -1,0 +1,88 @@
+% ============================================================================
+% cranial-nerve-edges — the cranial-nerve function knowledge-graph (MYCIN-2026 CRANIAL).
+% ============================================================================
+% A foundational clinical-neuroanatomy board domain: a named cranial nerve and
+% its primary function (the muscle it innervates, or the sense/autonomic action
+% it carries). "The trochlear nerve has which function?" becomes the binding query
+%     ? cranial_nerve_function(trochlear_nerve, $Function).
+%
+% Direction note: the relation is nerve -> function (`cranial_nerve_function`),
+% the board direction — you name a cranial nerve and must recall WHAT it does
+% (innervates the superior oblique, carries smell, etc.). Each nerve here maps to
+% one canonical primary function, so a query binds a single answer. What matters
+% for grounding is that one self-contained span names BOTH the nerve AND its
+% function in the same sentence.
+%
+% This file is the SHIPPED ARTIFACT and the SOLE source of truth — no generator,
+% no JSON, no manifest (a pure ADJ-only recall domain, like NERVE/EXOTOXIN/EMBRYO).
+% Each fact is a `relate` clause whose byte-provenance lives INLINE:
+%     source   — the VERBATIM span copied from the cited page (byte-stable: it
+%                appears character-for-character in the page's normalized text;
+%                every span here was independently re-fetched and confirmed).
+%     locator  — the URL the span was read from (NCBI StatPearls / Bookshelf).
+%     trust    — authoritative (a primary, citable reference).
+% An LLM (or a human) recalls a fact by writing a tiny query .adj that `import`s
+% this library and asks a binding query — see cranial-nerve-recall.query.adj.
+% Nothing here is asserted "from memory": every edge is defended by a span a reader
+% can re-fetch and check.
+% (See feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+%
+% Object atoms are span-faithful: the abducens span names the IPSILATERAL lateral
+% rectus as its primary target (lateral_rectus_muscle); the vagus span describes
+% parasympathetic action on the viscera of the abdomen and thorax
+% (parasympathetic_innervation_of_viscera); the accessory span names both the
+% sternocleidomastoid and trapezius (sternocleidomastoid_and_trapezius).
+% ============================================================================
+
+dictionary cranial_nerve_vocab {
+    define nerve    : entity   surface "cranial nerve", "named CN"
+    define function : entity   surface "primary function", "muscle or sense served"
+
+    define cranial_nerve_function : relation from nerve to function  % what a cranial nerve does
+}
+
+rulebook cranial_nerve_facts {
+    use cranial_nerve_vocab
+
+    % --- CN I olfactory -> smell -----------------------------------------------
+    relate cranial_nerve_function(olfactory_nerve, smell)
+        source "The olfactory nerve is the first cranial nerve and is instrumental in our sense of smell."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK556051/"
+        trust authoritative
+
+    % --- CN II optic -> vision -------------------------------------------------
+    relate cranial_nerve_function(optic_nerve, vision)
+        source "The optic nerve is the second cranial nerve (CN II) responsible for transmitting visual information."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK507907/"
+        trust authoritative
+
+    % --- CN IV trochlear -> superior oblique muscle ----------------------------
+    relate cranial_nerve_function(trochlear_nerve, superior_oblique_muscle)
+        source "The only muscle the trochlear nerve innervates, the superior oblique muscle, is the longest and thinnest muscle among the extraocular muscles."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK537244/"
+        trust authoritative
+
+    % --- CN VI abducens -> lateral rectus muscle -------------------------------
+    relate cranial_nerve_function(abducens_nerve, lateral_rectus_muscle)
+        source "The abducens nerve functions to innervate the ipsilateral lateral rectus muscle and partially innervate the contralateral medial rectus muscle (at the level of the nucleus - via the medial longitudinal fasciculus)."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK430711/"
+        trust authoritative
+
+    % --- CN X vagus -> parasympathetic innervation of the viscera --------------
+    relate cranial_nerve_function(vagus_nerve, parasympathetic_innervation_of_viscera)
+        source "Cranial nerves carrying parasympathetic functions include the oculomotor nerve (III) acting on the eyes, the facial nerve (VII) working on the lacrimal gland, the salivary glands, and the mucous membranes within the nasal cavity, the glossopharyngeal nerve (IX) acting on the parotid gland, and the vagus nerve (X) acting on the viscera of the abdomen and thorax."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK553141/"
+        trust authoritative
+
+    % --- CN XI accessory -> sternocleidomastoid and trapezius ------------------
+    relate cranial_nerve_function(accessory_nerve, sternocleidomastoid_and_trapezius)
+        source "The spinal accessory nerve (SAN, 11th cranial nerve, CN XI) is essential for neck and shoulder movement, as it innervates the sternocleidomastoid (SCM) and trapezius muscles through its spinal root."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK507722/"
+        trust authoritative
+
+    % --- CN XII hypoglossal -> tongue muscles ----------------------------------
+    relate cranial_nerve_function(hypoglossal_nerve, tongue_muscles)
+        source "The hypoglossal nerve is mainly a somatic efferent (motor) nerve to innervate the tongue musculature"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK532869/"
+        trust authoritative
+}

--- a/code/specs/data/mycin-2026/recall/cranial-nerve-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/cranial-nerve-recall.query.adj
@@ -1,0 +1,23 @@
+% ============================================================================
+% cranial-nerve-recall.query.adj — a worked recall query over the cranial-nerve library.
+% ============================================================================
+% The shape an LLM (or a clinician) produces to ANSWER a "this cranial nerve has
+% which function?" question: it states no neuroanatomy fact — it only `import`s
+% the grounded library and asks binding queries. The native adj-lang engine
+% resolves each `?` against the imported `relate` edges and returns the binding +
+% the citing clause's source/locator/trust. All knowledge is in the library; none
+% is here.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli cranial-nerve-recall.query.adj
+% ============================================================================
+
+import "cranial-nerve-edges.adj"
+
+? cranial_nerve_function(olfactory_nerve, $Function)    % expect smell
+? cranial_nerve_function(optic_nerve, $Function)        % expect vision
+? cranial_nerve_function(trochlear_nerve, $Function)    % expect superior_oblique_muscle
+? cranial_nerve_function(abducens_nerve, $Function)     % expect lateral_rectus_muscle
+? cranial_nerve_function(vagus_nerve, $Function)        % expect parasympathetic_innervation_of_viscera
+? cranial_nerve_function(accessory_nerve, $Function)    % expect sternocleidomastoid_and_trapezius
+? cranial_nerve_function(hypoglossal_nerve, $Function)  % expect tongue_muscles

--- a/code/specs/data/mycin-2026/recall/test_cranial_nerve_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_cranial_nerve_recall.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""test_cranial_nerve_recall.py — the ADJ-only cranial-nerve function recall library (MYCIN-2026 CRANIAL).
+
+A new pure-ADJ recall domain (foundational clinical-neuroanatomy board content): a named
+cranial nerve and its primary function. `cranial-nerve-edges.adj` is the SOLE source of
+truth — facts + byte-provenance inline, no Python gate, no JSON, no manifest. This test
+pins the property that matters: the native adj-lang engine, given a query .adj that only
+`import`s the library and asks binding queries (`cranial-nerve-recall.query.adj` — the
+shape an LLM produces), binds the grounded function for each nerve, each carrying an
+AUTHORITATIVE citation with a real source span + locator. Knowledge lives in ADJ; the
+engine answers.
+
+If the native CLI isn't built (a Python-only CI lane), the engine-backed checks skip —
+the file-shape checks (every clause grounded, no authored-debt) still run.
+
+Run:  python3 test_cranial_nerve_recall.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ADJ = HERE / "cranial-nerve-edges.adj"
+QUERY = HERE / "cranial-nerve-recall.query.adj"
+CLI = HERE.parents[3] / "packages" / "rust" / "target" / "debug" / "adj-lang-cli"
+
+# Every grounded edge: cranial nerve -> the primary function the library binds.
+# Each nerve maps to one canonical function, so each query binds exactly one answer.
+EXPECTED = {
+    "olfactory_nerve": "smell",                                          # NBK556051
+    "optic_nerve": "vision",                                             # NBK507907
+    "trochlear_nerve": "superior_oblique_muscle",                        # NBK537244
+    "abducens_nerve": "lateral_rectus_muscle",                           # NBK430711
+    "vagus_nerve": "parasympathetic_innervation_of_viscera",             # NBK553141
+    "accessory_nerve": "sternocleidomastoid_and_trapezius",              # NBK507722
+    "hypoglossal_nerve": "tongue_muscles",                               # NBK532869
+}
+REL = "cranial_nerve_function"
+VAR = "Function"
+
+
+def _cli_available() -> bool:
+    return CLI.exists()
+
+
+def _run(program: Path) -> dict:
+    out = subprocess.run([str(CLI), str(program)], capture_output=True, text=True,
+                         cwd=str(HERE), timeout=60)
+    assert out.returncode == 0, f"adj-lang-cli failed: {out.stderr}"
+    return json.loads(out.stdout)
+
+
+# ---- 1. the ADJ file is the artifact — every clause grounded, no authored-debt ----
+
+def test_library_is_pure_adj_and_fully_grounded() -> None:
+    text = ADJ.read_text()
+    assert "trust consensus" not in text, "CRANIAL ships no authored-debt; ground or omit"
+    assert "[FLAG:" not in text
+    edge_count = len(EXPECTED)  # 7
+    assert text.count("    relate ") == edge_count
+    assert text.count("trust authoritative") == edge_count
+    assert text.count('\n        locator "') == edge_count
+    assert text.count('\n        source "') == edge_count
+    # every locator is an NCBI primary source
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("locator "):
+            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+    assert not (HERE / "cranial_nerve_edge_ground.py").exists()
+    assert not (HERE / "cranial-nerve-edge-grounding.json").exists()
+    assert not (HERE / "cranial-nerve-edge-manifest.json").exists()
+
+
+# ---- 2. the engine binds each function, each with an authoritative citation --------
+
+def test_engine_binds_every_function_with_authoritative_citation() -> None:
+    if not _cli_available():
+        return
+    result = _run(QUERY)
+    by_query = {r["query"]: r for r in result["recall"]}
+    for nerve, function in EXPECTED.items():
+        q = f"{REL}({nerve}, {VAR})"
+        r = by_query.get(q)
+        assert r is not None and not r["abstained"], f"{q} abstained — edge missing?"
+        bound = {}
+        for a in r["answers"]:
+            bound[a["bindings"][VAR]] = (a.get("citations") or [{}])[0]
+        assert set(bound) == {function}, f"{nerve}: bound {set(bound)} != {{{function}}}"
+        cite = bound[function]
+        assert cite.get("trust") == "authoritative", f"{nerve}/{function} not authoritative"
+        assert cite.get("source"), f"{nerve}/{function} has no source span"
+        assert cite.get("locator", "").startswith("https://www.ncbi.nlm.nih.gov/")
+
+
+# ---- 3. an off-vocabulary cranial nerve abstains, never fabricates ------------------
+
+def test_unknown_nerve_abstains() -> None:
+    if not _cli_available():
+        return
+    import os
+    import tempfile
+    fd, path = tempfile.mkstemp(suffix=".adj", prefix=".cranial_q_", dir=HERE)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            # vestibulocochlear_nerve is not in the library (hearing/balance) -> must abstain
+            fh.write(f'import "cranial-nerve-edges.adj"\n? {REL}(vestibulocochlear_nerve, ${VAR})\n')
+        res = _run(Path(path))
+        r = res["recall"][0] if res["recall"] else None
+        assert r is not None and r["abstained"], "an ungrounded nerve must abstain"
+    finally:
+        os.unlink(path)
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS  {t.__name__}")
+        except AssertionError as exc:
+            failed += 1
+            print(f"  FAIL  {t.__name__}: {exc}")
+    print(f"\ntest_cranial_nerve_recall: {len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())


### PR DESCRIPTION
## What

A new pure-ADJ recall domain for MYCIN-2026: **cranial nerve → primary function** — foundational clinical-neuroanatomy board content. Follows the established ADJ-only pattern (NERVE/EXOTOXIN/EMBRYO/DIURETIC): the shipped `.adj` library is the sole source of truth — no Python generator, no JSON, no manifest.

Each fact is a `relate cranial_nerve_function(<nerve>, <function>)` clause carrying byte-provenance inline (verbatim NCBI source span + locator + `trust authoritative`). An LLM recalls by importing the library and asking a binding query; the native adj-lang engine resolves it.

## Edges (7) — each span independently re-fetched & confirmed verbatim

| cranial nerve | function | source |
|---|---|---|
| olfactory_nerve (CN I) | smell | NBK556051 |
| optic_nerve (CN II) | vision | NBK507907 |
| trochlear_nerve (CN IV) | superior_oblique_muscle | NBK537244 |
| abducens_nerve (CN VI) | lateral_rectus_muscle | NBK430711 |
| vagus_nerve (CN X) | parasympathetic_innervation_of_viscera | NBK553141 |
| accessory_nerve (CN XI) | sternocleidomastoid_and_trapezius | NBK507722 |
| hypoglossal_nerve (CN XII) | tongue_muscles | NBK532869 |

Object atoms are **span-faithful**: abducens span names the ipsilateral lateral rectus as primary target; vagus span describes parasympathetic action on the viscera of the abdomen and thorax; accessory span names both SCM and trapezius.

## Tests

`test_cranial_nerve_recall.py` (3 tests, all pass with the native CLI built): every clause grounded (no authored-debt, NCBI locators only); engine binds each function with an authoritative citation; an off-vocabulary nerve (`vestibulocochlear_nerve`) **abstains** rather than fabricating. Auto-discovered by `.github/workflows/mycin-2026.yml`.

## Deferred (genuine, not dropped)

`vestibulocochlear_nerve` (CN VIII) — no single self-contained StatPearls sentence names CN VIII with both hearing AND balance (cochlear/vestibular functions split across sentences). The multi-function nerves CN III/V/VII/IX are better served by a finer relation modeling their sub-functions than by forcing a single binding; deferred for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)