### PR TITLE
feat(mycin-enzyme): ADJ-only enzyme-deficiency→disease recall (8 grounded edges)

### DIFF
--- a/code/specs/data/mycin-2026/recall/enzyme-deficiency-edges.adj
+++ b/code/specs/data/mycin-2026/recall/enzyme-deficiency-edges.adj
@@ -1,0 +1,94 @@
+% ============================================================================
+% enzyme-deficiency-edges — the enzyme-deficiency disease knowledge-graph (MYCIN-2026 ENZYME).
+% ============================================================================
+% A high-yield biochemistry board domain: the deficient enzyme and the inborn
+% error of metabolism (lysosomal / glycogen storage / amino-acid disorder) it
+% causes. "A deficiency of glucocerebrosidase causes which disease?" becomes the
+% binding query
+%     ? enzyme_deficiency_disease(glucocerebrosidase, $Disease).
+%
+% Direction note: the relation is enzyme -> disease (`enzyme_deficiency_disease`),
+% the board direction — you name the deficient enzyme and must recall the disease
+% its deficiency produces. Each enzyme here maps to one canonical disease, so a
+% query binds a single answer. What matters for grounding is that one
+% self-contained span names BOTH the enzyme AND the disease, stating the
+% deficiency causes it.
+%
+% This file is the SHIPPED ARTIFACT and the SOLE source of truth — no generator,
+% no JSON, no manifest (a pure ADJ-only recall domain, like CRANIAL/NERVE/EXOTOXIN).
+% Each fact is a `relate` clause whose byte-provenance lives INLINE:
+%     source   — the VERBATIM span copied from the cited page (byte-stable: it
+%                appears character-for-character in the page's normalized text;
+%                every span here was independently re-fetched and confirmed).
+%     locator  — the URL the span was read from (NCBI StatPearls / Bookshelf).
+%     trust    — authoritative (a primary, citable reference).
+% An LLM (or a human) recalls a fact by writing a tiny query .adj that `import`s
+% this library and asks a binding query — see enzyme-deficiency-recall.query.adj.
+% Nothing here is asserted "from memory": every edge is defended by a span a reader
+% can re-fetch and check.
+% (See feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+%
+% Note: the Pompe span writes alpha as the Greek letter (acid α-glucosidase),
+% preserved character-for-character; the GALT span spells the enzyme
+% "uridylyltransferase". Atoms are stable identifiers, not required to match the
+% span's exact spelling — each atom names the concept the span states.
+% ============================================================================
+
+dictionary enzyme_vocab {
+    define enzyme  : entity   surface "deficient enzyme", "named enzyme"
+    define disease : entity   surface "metabolic disease", "inborn error of metabolism"
+
+    define enzyme_deficiency_disease : relation from enzyme to disease  % the disease an enzyme deficiency causes
+}
+
+rulebook enzyme_facts {
+    use enzyme_vocab
+
+    % --- glucocerebrosidase -> Gaucher disease ---------------------------------
+    relate enzyme_deficiency_disease(glucocerebrosidase, gaucher_disease)
+        source "The underlying cause of all forms of Gaucher disease is mutations in the GBA1 gene, resulting in a lysosomal deficiency of glucocerebrosidase activity."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK448080/"
+        trust authoritative
+
+    % --- acid sphingomyelinase -> Niemann-Pick disease -------------------------
+    relate enzyme_deficiency_disease(sphingomyelinase, niemann_pick_disease)
+        source "Niemann-Pick disease (NPD) is a lysosomal storage disease caused by acid sphingomyelinase deficiency (ASMD), which catalyzes the hydrolysis of sphingomyelin to ceramide and phosphocholine."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK556129/"
+        trust authoritative
+
+    % --- alpha-galactosidase A -> Fabry disease --------------------------------
+    relate enzyme_deficiency_disease(alpha_galactosidase_a, fabry_disease)
+        source "Fabry disease is a rare, X-linked lysosomal storage disorder caused by deficient activity of the enzyme alpha-galactosidase A, resulting in progressive accumulation of globotriaosylceramide in various organs."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK435996/"
+        trust authoritative
+
+    % --- arylsulfatase A -> metachromatic leukodystrophy -----------------------
+    relate enzyme_deficiency_disease(arylsulfatase_a, metachromatic_leukodystrophy)
+        source "Metachromatic leukodystrophy is a rare lysosomal storage disease caused due to deficient activity of arylsulfatase A."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK560744/"
+        trust authoritative
+
+    % --- glucose-6-phosphatase -> von Gierke disease (GSD I) -------------------
+    relate enzyme_deficiency_disease(glucose_6_phosphatase, von_gierke_disease)
+        source "First described by Dr. Edgar Von Gierke in 1929, GSD I results from mutations affecting glucose-6-phosphatase (G6Pase) activity, leading to excessive glycogen accumulation in the liver and kidneys."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK534196/"
+        trust authoritative
+
+    % --- acid alpha-glucosidase -> Pompe disease (GSD II) ----------------------
+    relate enzyme_deficiency_disease(acid_alpha_glucosidase, pompe_disease)
+        source "Glycogen storage disease type II, or Pompe disease, is a rare inherited disorder caused by a deficiency of the enzyme acid α-glucosidase (GAA)."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK470558/"
+        trust authoritative
+
+    % --- galactose-1-phosphate uridyltransferase -> galactosemia ---------------
+    relate enzyme_deficiency_disease(galactose_1_phosphate_uridyltransferase, galactosemia)
+        source "Classic galactosemia is caused by galactose-1-phosphate uridylyltransferase (GALT) deficiency, whereas galactokinase and UDP-galactose epimerase deficiencies may cause similar clinical consequences by disrupting the normal galactose metabolism (see figure)."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK441957/"
+        trust authoritative
+
+    % --- homogentisate 1,2-dioxygenase -> alkaptonuria -------------------------
+    relate enzyme_deficiency_disease(homogentisate_oxidase, alkaptonuria)
+        source "Alkaptonuria is one of a rare autosomal recessive genetic disorder, which results from the deficiency of homogentisate 1,2 dioxygenase (HGD)."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK560571/"
+        trust authoritative
+}

--- a/code/specs/data/mycin-2026/recall/enzyme-deficiency-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/enzyme-deficiency-recall.query.adj
@@ -1,0 +1,24 @@
+% ============================================================================
+% enzyme-deficiency-recall.query.adj — a worked recall query over the enzyme library.
+% ============================================================================
+% The shape an LLM (or a clinician) produces to ANSWER a "deficiency of this
+% enzyme causes which disease?" question: it states no biochemistry fact — it only
+% `import`s the grounded library and asks binding queries. The native adj-lang
+% engine resolves each `?` against the imported `relate` edges and returns the
+% binding + the citing clause's source/locator/trust. All knowledge is in the
+% library; none is here.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli enzyme-deficiency-recall.query.adj
+% ============================================================================
+
+import "enzyme-deficiency-edges.adj"
+
+? enzyme_deficiency_disease(glucocerebrosidase, $Disease)                       % expect gaucher_disease
+? enzyme_deficiency_disease(sphingomyelinase, $Disease)                         % expect niemann_pick_disease
+? enzyme_deficiency_disease(alpha_galactosidase_a, $Disease)                    % expect fabry_disease
+? enzyme_deficiency_disease(arylsulfatase_a, $Disease)                          % expect metachromatic_leukodystrophy
+? enzyme_deficiency_disease(glucose_6_phosphatase, $Disease)                    % expect von_gierke_disease
+? enzyme_deficiency_disease(acid_alpha_glucosidase, $Disease)                   % expect pompe_disease
+? enzyme_deficiency_disease(galactose_1_phosphate_uridyltransferase, $Disease)  % expect galactosemia
+? enzyme_deficiency_disease(homogentisate_oxidase, $Disease)                    % expect alkaptonuria

--- a/code/specs/data/mycin-2026/recall/test_enzyme_deficiency_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_enzyme_deficiency_recall.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""test_enzyme_deficiency_recall.py — the ADJ-only enzyme-deficiency disease recall library (MYCIN-2026 ENZYME).
+
+A new pure-ADJ recall domain (high-yield biochemistry board content): the deficient enzyme
+and the inborn error of metabolism it causes. `enzyme-deficiency-edges.adj` is the SOLE
+source of truth — facts + byte-provenance inline, no Python gate, no JSON, no manifest.
+This test pins the property that matters: the native adj-lang engine, given a query .adj
+that only `import`s the library and asks binding queries
+(`enzyme-deficiency-recall.query.adj` — the shape an LLM produces), binds the grounded
+disease for each enzyme, each carrying an AUTHORITATIVE citation with a real source span +
+locator. Knowledge lives in ADJ; the engine answers.
+
+If the native CLI isn't built (a Python-only CI lane), the engine-backed checks skip —
+the file-shape checks (every clause grounded, no authored-debt) still run.
+
+Run:  python3 test_enzyme_deficiency_recall.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ADJ = HERE / "enzyme-deficiency-edges.adj"
+QUERY = HERE / "enzyme-deficiency-recall.query.adj"
+CLI = HERE.parents[3] / "packages" / "rust" / "target" / "debug" / "adj-lang-cli"
+
+# Every grounded edge: deficient enzyme -> the disease the library binds.
+# Each enzyme maps to one canonical disease, so each query binds exactly one answer.
+EXPECTED = {
+    "glucocerebrosidase": "gaucher_disease",                                    # NBK448080
+    "sphingomyelinase": "niemann_pick_disease",                                 # NBK556129
+    "alpha_galactosidase_a": "fabry_disease",                                   # NBK435996
+    "arylsulfatase_a": "metachromatic_leukodystrophy",                          # NBK560744
+    "glucose_6_phosphatase": "von_gierke_disease",                              # NBK534196
+    "acid_alpha_glucosidase": "pompe_disease",                                  # NBK470558
+    "galactose_1_phosphate_uridyltransferase": "galactosemia",                  # NBK441957
+    "homogentisate_oxidase": "alkaptonuria",                                    # NBK560571
+}
+REL = "enzyme_deficiency_disease"
+VAR = "Disease"
+
+
+def _cli_available() -> bool:
+    return CLI.exists()
+
+
+def _run(program: Path) -> dict:
+    out = subprocess.run([str(CLI), str(program)], capture_output=True, text=True,
+                         cwd=str(HERE), timeout=60)
+    assert out.returncode == 0, f"adj-lang-cli failed: {out.stderr}"
+    return json.loads(out.stdout)
+
+
+# ---- 1. the ADJ file is the artifact — every clause grounded, no authored-debt ----
+
+def test_library_is_pure_adj_and_fully_grounded() -> None:
+    text = ADJ.read_text()
+    assert "trust consensus" not in text, "ENZYME ships no authored-debt; ground or omit"
+    assert "[FLAG:" not in text
+    edge_count = len(EXPECTED)  # 8
+    assert text.count("    relate ") == edge_count
+    assert text.count("trust authoritative") == edge_count
+    assert text.count('\n        locator "') == edge_count
+    assert text.count('\n        source "') == edge_count
+    # every locator is an NCBI primary source
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("locator "):
+            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+    assert not (HERE / "enzyme_deficiency_edge_ground.py").exists()
+    assert not (HERE / "enzyme-deficiency-edge-grounding.json").exists()
+    assert not (HERE / "enzyme-deficiency-edge-manifest.json").exists()
+
+
+# ---- 2. the engine binds each disease, each with an authoritative citation ---------
+
+def test_engine_binds_every_disease_with_authoritative_citation() -> None:
+    if not _cli_available():
+        return
+    result = _run(QUERY)
+    by_query = {r["query"]: r for r in result["recall"]}
+    for enzyme, disease in EXPECTED.items():
+        q = f"{REL}({enzyme}, {VAR})"
+        r = by_query.get(q)
+        assert r is not None and not r["abstained"], f"{q} abstained — edge missing?"
+        bound = {}
+        for a in r["answers"]:
+            bound[a["bindings"][VAR]] = (a.get("citations") or [{}])[0]
+        assert set(bound) == {disease}, f"{enzyme}: bound {set(bound)} != {{{disease}}}"
+        cite = bound[disease]
+        assert cite.get("trust") == "authoritative", f"{enzyme}/{disease} not authoritative"
+        assert cite.get("source"), f"{enzyme}/{disease} has no source span"
+        assert cite.get("locator", "").startswith("https://www.ncbi.nlm.nih.gov/")
+
+
+# ---- 3. an off-vocabulary enzyme abstains, never fabricates -------------------------
+
+def test_unknown_enzyme_abstains() -> None:
+    if not _cli_available():
+        return
+    import os
+    import tempfile
+    fd, path = tempfile.mkstemp(suffix=".adj", prefix=".enzyme_q_", dir=HERE)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            # hexosaminidase_a (Tay-Sachs) is not in the library -> must abstain
+            fh.write(f'import "enzyme-deficiency-edges.adj"\n? {REL}(hexosaminidase_a, ${VAR})\n')
+        res = _run(Path(path))
+        r = res["recall"][0] if res["recall"] else None
+        assert r is not None and r["abstained"], "an ungrounded enzyme must abstain"
+    finally:
+        os.unlink(path)
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS  {t.__name__}")
+        except AssertionError as exc:
+            failed += 1
+            print(f"  FAIL  {t.__name__}: {exc}")
+    print(f"\ntest_enzyme_deficiency_recall: {len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())


### PR DESCRIPTION
## What

A new pure-ADJ board-recall domain for high-yield biochemistry: the deficient enzyme and the inborn error of metabolism (lysosomal / glycogen-storage / amino-acid disorder) its deficiency causes. Same shape as the merged CRANIAL/NERVE/EXOTOXIN/DIURETIC/EMBRYO domains — facts + byte-provenance live **inline** in the `.adj`; the native `adj-lang` engine answers the binding queries; **no Python gate, no JSON, no manifest**.

Relation `enzyme_deficiency_disease(enzyme, disease)` — the board direction (name the deficient enzyme → recall the disease). 8 edges, each defended by a **self-contained NCBI span naming BOTH endpoints, independently re-fetched and confirmed verbatim**:

| enzyme | disease | source |
|---|---|---|
| glucocerebrosidase | gaucher_disease | NBK448080 |
| sphingomyelinase | niemann_pick_disease | NBK556129 |
| alpha_galactosidase_a | fabry_disease | NBK435996 |
| arylsulfatase_a | metachromatic_leukodystrophy | NBK560744 |
| glucose_6_phosphatase | von_gierke_disease | NBK534196 |
| acid_alpha_glucosidase | pompe_disease | NBK470558 |
| galactose_1_phosphate_uridyltransferase | galactosemia | NBK441957 |
| homogentisate_oxidase | alkaptonuria | NBK560571 |

## Faithfulness notes
- The Pompe span carries the Greek letter (acid α-glucosidase) character-for-character.
- The GALT span spells the enzyme "uridylyltransferase"; the atom uses the common "uridyltransferase" spelling. Atoms are stable identifiers naming the concept, not required to match the span's exact spelling.

## Files
- `code/specs/data/mycin-2026/recall/enzyme-deficiency-edges.adj` — dictionary + 8 grounded `relate` clauses
- `code/specs/data/mycin-2026/recall/enzyme-deficiency-recall.query.adj` — `import` + 8 binding queries (the LLM shape)
- `code/specs/data/mycin-2026/recall/test_enzyme_deficiency_recall.py` — 3 tests: file fully grounded / engine binds each disease with an authoritative citation / off-vocab enzyme (`hexosaminidase_a`, Tay-Sachs — deliberately omitted) abstains

Auto-discovered by `.github/workflows/mycin-2026.yml` (`recall/test_*.py`). All 3 tests green locally against the freshly-built native `adj-lang-cli`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)