### PR TITLE
feat(mycin-coronary): ADJ-only coronary-artery→myocardial-territory recall (7 grounded edges)

### DIFF
--- a/code/specs/data/mycin-2026/recall/coronary-territory-edges.adj
+++ b/code/specs/data/mycin-2026/recall/coronary-territory-edges.adj
@@ -1,0 +1,94 @@
+% ============================================================================
+% coronary-territory-edges — the coronary-artery blood-supply knowledge-graph (MYCIN-2026 CORONARY).
+% ============================================================================
+% A high-yield cardiology/anatomy board domain: which coronary artery supplies
+% which region of the heart. The board reflex — "an inferior-wall STEMI implicates
+% which artery?", "the AV node is fed by which artery?" — is the binding query
+%     ? coronary_artery_territory(right_coronary_artery, $Region).
+%
+% Direction note: the relation is artery -> supplied region
+% (`coronary_artery_territory`), the anatomy direction — you name the artery and
+% recall the myocardial wall / septum / conduction node it perfuses. A single
+% artery can supply several regions (the RCA feeds the inferior wall, the SA node,
+% and the AV node in a right-dominant heart), so a query may bind MORE THAN ONE
+% region; each binding still carries its own citing span.
+%
+% What matters for grounding is that one self-contained span names BOTH the artery
+% AND the region, stating the supply relationship. "Region" here spans myocardial
+% walls (anterior/inferior/lateral), the interventricular septum, and the
+% conduction nodes — all are territories a coronary artery perfuses, so one
+% relation covers them uniformly.
+%
+% This file is the SHIPPED ARTIFACT and the SOLE source of truth — no generator,
+% no JSON, no manifest (a pure ADJ-only recall domain, like ENZYME/CRANIAL/NERVE).
+% Each fact is a `relate` clause whose byte-provenance lives INLINE:
+%     source   — the VERBATIM span copied from the cited page (byte-stable: it
+%                appears character-for-character in the page's normalized text;
+%                every span here was independently re-fetched and confirmed).
+%     locator  — the URL the span was read from (NCBI StatPearls / Bookshelf).
+%     trust    — authoritative (a primary, citable reference).
+% An LLM (or a human) recalls a fact by writing a tiny query .adj that `import`s
+% this library and asks a binding query — see coronary-territory-recall.query.adj.
+% Nothing here is asserted "from memory": every edge is defended by a span a reader
+% can re-fetch and check.
+% (See feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+%
+% Note: two edges (lad -> anterior_wall and lad -> interventricular_septum) are
+% defended by the SAME sentence (NBK482375), which names both regions the LAD
+% supplies; each edge cites it independently. Atoms are stable identifiers naming
+% the concept, not required to match the span's exact wording (e.g. the LCx span
+% says "left ventricular lateral wall"; the atom is lateral_wall).
+% ============================================================================
+
+dictionary coronary_vocab {
+    define artery : entity   surface "coronary artery", "named artery"
+    define region : entity   surface "myocardial territory", "supplied region"
+
+    define coronary_artery_territory : relation from artery to region  % the region a coronary artery supplies
+}
+
+rulebook coronary_facts {
+    use coronary_vocab
+
+    % --- left anterior descending -> anterior wall ----------------------------
+    relate coronary_artery_territory(lad, anterior_wall)
+        source "The LAD, also known as the anterior interventricular branch of the LCA, serves as the principal arterial supply to the anterior left ventricular wall and the majority of the interventricular septum."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK482375/"
+        trust authoritative
+
+    % --- left anterior descending -> interventricular septum ------------------
+    relate coronary_artery_territory(lad, interventricular_septum)
+        source "The LAD, also known as the anterior interventricular branch of the LCA, serves as the principal arterial supply to the anterior left ventricular wall and the majority of the interventricular septum."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK482375/"
+        trust authoritative
+
+    % --- right coronary artery -> inferior wall -------------------------------
+    relate coronary_artery_territory(right_coronary_artery, inferior_wall)
+        source "In right-dominant circulation (75%-80%), the RCA supplies the right atrium, right ventricle, and the inferior wall of the left ventricle via the posterior descending artery (PDA), as well as the sinoatrial (SA) and atrioventricular (AV) nodes."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK470572/"
+        trust authoritative
+
+    % --- left circumflex -> lateral wall --------------------------------------
+    relate coronary_artery_territory(left_circumflex_artery, lateral_wall)
+        source "Branches of the LAD and LCx supply the left ventricular lateral wall."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK537228/"
+        trust authoritative
+
+    % --- right coronary artery -> sinoatrial node -----------------------------
+    relate coronary_artery_territory(right_coronary_artery, sinoatrial_node)
+        source "The sinoatrial nodal artery is a branch of the RCA that supplies the SA node."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK534790/"
+        trust authoritative
+
+    % --- right coronary artery -> atrioventricular node -----------------------
+    relate coronary_artery_territory(right_coronary_artery, atrioventricular_node)
+        source "In a right-dominant heart, the atrioventricular node is supplied by the right coronary artery."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK557664/"
+        trust authoritative
+
+    % --- posterior descending artery -> posterior septum ----------------------
+    relate coronary_artery_territory(posterior_descending_artery, posterior_septum)
+        source "The posterior descending artery supplies the posterior third of the interventricular septum, including the posterior and inferior walls of the left ventricle."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK537207/"
+        trust authoritative
+}

--- a/code/specs/data/mycin-2026/recall/coronary-territory-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/coronary-territory-recall.query.adj
@@ -1,0 +1,21 @@
+% ============================================================================
+% coronary-territory-recall.query.adj — a worked recall query over the coronary library.
+% ============================================================================
+% The shape an LLM (or a clinician) produces to ANSWER a "which region does this
+% artery supply?" question: it states no anatomy fact — it only `import`s the
+% grounded library and asks binding queries. The native adj-lang engine resolves
+% each `?` against the imported `relate` edges and returns the binding + the
+% citing clause's source/locator/trust. A single artery may bind several regions
+% (the RCA feeds the inferior wall, the SA node, and the AV node), and the engine
+% returns one answer per grounded edge. All knowledge is in the library; none is here.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli coronary-territory-recall.query.adj
+% ============================================================================
+
+import "coronary-territory-edges.adj"
+
+? coronary_artery_territory(lad, $Region)                          % expect anterior_wall + interventricular_septum
+? coronary_artery_territory(right_coronary_artery, $Region)        % expect inferior_wall + sinoatrial_node + atrioventricular_node
+? coronary_artery_territory(left_circumflex_artery, $Region)       % expect lateral_wall
+? coronary_artery_territory(posterior_descending_artery, $Region)  % expect posterior_septum

--- a/code/specs/data/mycin-2026/recall/test_coronary_territory_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_coronary_territory_recall.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""test_coronary_territory_recall.py — the ADJ-only coronary-territory recall library (MYCIN-2026 CORONARY).
+
+A new pure-ADJ recall domain (high-yield cardiology/anatomy board content): which
+coronary artery supplies which region of the heart (myocardial wall, the
+interventricular septum, or a conduction node). `coronary-territory-edges.adj` is
+the SOLE source of truth — facts + byte-provenance inline, no Python gate, no JSON,
+no manifest. This test pins the property that matters: the native adj-lang engine,
+given a query .adj that only `import`s the library and asks binding queries
+(`coronary-territory-recall.query.adj` — the shape an LLM produces), binds the
+grounded region(s) for each artery, each carrying an AUTHORITATIVE citation with a
+real source span + locator.
+
+Unlike the one-answer recall domains, an artery here may supply SEVERAL regions
+(the RCA → inferior wall + SA node + AV node), so a query binds a SET of regions;
+the test checks the full set per artery.
+
+If the native CLI isn't built (a Python-only CI lane), the engine-backed checks
+skip — the file-shape checks (every clause grounded, no authored-debt) still run.
+
+Run:  python3 test_coronary_territory_recall.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ADJ = HERE / "coronary-territory-edges.adj"
+QUERY = HERE / "coronary-territory-recall.query.adj"
+CLI = HERE.parents[3] / "packages" / "rust" / "target" / "debug" / "adj-lang-cli"
+
+# Each artery -> the SET of regions the library grounds it to. The RCA and LAD
+# are deliberately multi-region: a single artery perfuses several territories.
+EXPECTED = {
+    "lad": {"anterior_wall", "interventricular_septum"},                          # NBK482375
+    "right_coronary_artery": {"inferior_wall", "sinoatrial_node",                 # NBK470572
+                              "atrioventricular_node"},                           # NBK534790 / NBK557664
+    "left_circumflex_artery": {"lateral_wall"},                                   # NBK537228
+    "posterior_descending_artery": {"posterior_septum"},                          # NBK537207
+}
+REL = "coronary_artery_territory"
+VAR = "Region"
+EDGE_COUNT = sum(len(v) for v in EXPECTED.values())  # 7 grounded clauses
+
+
+def _cli_available() -> bool:
+    return CLI.exists()
+
+
+def _run(program: Path) -> dict:
+    out = subprocess.run([str(CLI), str(program)], capture_output=True, text=True,
+                         cwd=str(HERE), timeout=60)
+    assert out.returncode == 0, f"adj-lang-cli failed: {out.stderr}"
+    return json.loads(out.stdout)
+
+
+# ---- 1. the ADJ file is the artifact — every clause grounded, no authored-debt ----
+
+def test_library_is_pure_adj_and_fully_grounded() -> None:
+    text = ADJ.read_text()
+    assert "trust consensus" not in text, "CORONARY ships no authored-debt; ground or omit"
+    assert "[FLAG:" not in text
+    assert text.count("    relate ") == EDGE_COUNT
+    assert text.count("trust authoritative") == EDGE_COUNT
+    assert text.count('\n        locator "') == EDGE_COUNT
+    assert text.count('\n        source "') == EDGE_COUNT
+    # every locator is an NCBI primary source
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("locator "):
+            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+    assert not (HERE / "coronary_territory_edge_ground.py").exists()
+    assert not (HERE / "coronary-territory-edge-grounding.json").exists()
+    assert not (HERE / "coronary-territory-edge-manifest.json").exists()
+
+
+# ---- 2. the engine binds each region set, each with an authoritative citation ------
+
+def test_engine_binds_every_region_with_authoritative_citation() -> None:
+    if not _cli_available():
+        return
+    result = _run(QUERY)
+    by_query = {r["query"]: r for r in result["recall"]}
+    for artery, regions in EXPECTED.items():
+        q = f"{REL}({artery}, {VAR})"
+        r = by_query.get(q)
+        assert r is not None and not r["abstained"], f"{q} abstained — edges missing?"
+        bound = {}
+        for a in r["answers"]:
+            bound[a["bindings"][VAR]] = (a.get("citations") or [{}])[0]
+        assert set(bound) == regions, f"{artery}: bound {set(bound)} != {regions}"
+        for region, cite in bound.items():
+            assert cite.get("trust") == "authoritative", f"{artery}/{region} not authoritative"
+            assert cite.get("source"), f"{artery}/{region} has no source span"
+            assert cite.get("locator", "").startswith("https://www.ncbi.nlm.nih.gov/")
+
+
+# ---- 3. an off-vocabulary artery abstains, never fabricates -------------------------
+
+def test_unknown_artery_abstains() -> None:
+    if not _cli_available():
+        return
+    import os
+    import tempfile
+    fd, path = tempfile.mkstemp(suffix=".adj", prefix=".coronary_q_", dir=HERE)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            # ramus_intermedius is a real coronary branch but is NOT in the library -> must abstain
+            fh.write(f'import "coronary-territory-edges.adj"\n? {REL}(ramus_intermedius, ${VAR})\n')
+        res = _run(Path(path))
+        r = res["recall"][0] if res["recall"] else None
+        assert r is not None and r["abstained"], "an ungrounded artery must abstain"
+    finally:
+        os.unlink(path)
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS  {t.__name__}")
+        except AssertionError as exc:
+            failed += 1
+            print(f"  FAIL  {t.__name__}: {exc}")
+    print(f"\ntest_coronary_territory_recall: {len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())


### PR DESCRIPTION
## What

A new pure-ADJ board-recall domain for high-yield cardiology/anatomy: which coronary artery supplies which region of the heart (myocardial wall, interventricular septum, or conduction node). Same shape as the merged ENZYME/CRANIAL/NERVE/EXOTOXIN/DIURETIC/EMBRYO domains — facts + byte-provenance live **inline** in the `.adj`; the native `adj-lang` engine answers the binding queries; **no Python gate, no JSON, no manifest**.

Relation `coronary_artery_territory(artery, region)` — the anatomy direction (name the artery → recall the territory it perfuses). **Multi-binding**: unlike the one-answer recall domains, an artery may supply several regions, so a query binds a *set*; the test checks the full set per artery. 7 edges, each defended by a **self-contained NCBI span naming BOTH endpoints, independently re-fetched and confirmed verbatim**:

| artery | region | source |
|---|---|---|
| lad | anterior_wall | NBK482375 |
| lad | interventricular_septum | NBK482375 (same span) |
| right_coronary_artery | inferior_wall | NBK470572 |
| right_coronary_artery | sinoatrial_node | NBK534790 |
| right_coronary_artery | atrioventricular_node | NBK557664 |
| left_circumflex_artery | lateral_wall | NBK537228 |
| posterior_descending_artery | posterior_septum | NBK537207 |

## Faithfulness notes
- The `lad → anterior_wall` and `lad → interventricular_septum` edges are defended by the **same** NBK482375 sentence (it names both regions the LAD supplies); each edge cites it independently.
- Atoms are stable identifiers naming the concept, not required to match span wording (the LCx span says "left ventricular lateral wall"; the atom is `lateral_wall`).
- All node/wall facts are stated for the **right-dominant** circulation (the ~75–80% case), as the spans say.

## Files
- `code/specs/data/mycin-2026/recall/coronary-territory-edges.adj` — dictionary + 7 grounded `relate` clauses
- `code/specs/data/mycin-2026/recall/coronary-territory-recall.query.adj` — `import` + 4 binding queries (the LLM shape)
- `code/specs/data/mycin-2026/recall/test_coronary_territory_recall.py` — 3 tests: file fully grounded / engine binds each artery's full region SET with an authoritative citation / off-vocab artery (`ramus_intermedius` — a real branch deliberately omitted) abstains

Auto-discovered by `.github/workflows/mycin-2026.yml` (`recall/test_*.py`). All 3 tests green locally against the freshly-built native `adj-lang-cli`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)