### PR TITLE
feat(mycin-nephron): ADJ-only nephron-segment→transporter recall (7 grounded edges)

### DIFF
--- a/code/specs/data/mycin-2026/recall/nephron-transporter-edges.adj
+++ b/code/specs/data/mycin-2026/recall/nephron-transporter-edges.adj
@@ -1,0 +1,101 @@
+% ============================================================================
+% nephron-transporter-edges — the nephron-segment transporter knowledge-graph (MYCIN-2026 NEPHRON).
+% ============================================================================
+% A high-yield renal-physiology board domain: which membrane transporter / channel
+% does the work of solute (or water) handling at each segment of the nephron, and
+% therefore where each diuretic class acts. "The thiazide-sensitive cotransporter
+% lives in which segment?" becomes the binding query
+%     ? nephron_segment_transporter(distal_convoluted_tubule, $Transporter).
+%
+% Direction note: the relation is segment -> transporter
+% (`nephron_segment_transporter`), the physiology direction — you name the nephron
+% segment and recall the transporter/channel that operates there. A single segment
+% can carry several transporters (the proximal tubule has both SGLT2 and luminal
+% carbonic anhydrase), so a query may bind MORE THAN ONE answer; each binding still
+% carries its own citing span.
+%
+% What matters for grounding is that one self-contained span names BOTH the segment
+% AND the transporter, stating the transporter operates there. Several spans reach
+% the localization through a drug's mechanism of action (a loop diuretic blocking
+% NKCC2 "at the apical membrane of the thick ascending limb", thiazide inhibiting
+% NCC "in the DCT", SGLT2 inhibitors targeting "SGLT2 proteins in the proximal
+% convoluted tubules") — the localization is stated regardless of the drug framing.
+%
+% This file is the SHIPPED ARTIFACT and the SOLE source of truth — no generator,
+% no JSON, no manifest (a pure ADJ-only recall domain, like CORONARY/ENZYME/NERVE).
+% Each fact is a `relate` clause whose byte-provenance lives INLINE:
+%     source   — the VERBATIM span copied from the cited page (byte-stable: it
+%                appears character-for-character in the page's normalized text;
+%                every span here was independently re-fetched and confirmed).
+%     locator  — the URL the span was read from (NCBI StatPearls / Bookshelf).
+%     trust    — authoritative (a primary, citable reference).
+% An LLM (or a human) recalls a fact by writing a tiny query .adj that `import`s
+% this library and asks a binding query — see nephron-transporter-recall.query.adj.
+% Nothing here is asserted "from memory": every edge is defended by a span a reader
+% can re-fetch and check.
+% (See feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+%
+% Faithfulness notes:
+%   - The ENaC span names "principal cells" (the cells of the collecting duct), not
+%     the duct itself, so the subject atom is span-faithfully `principal_cell`.
+%   - The water-permeability span says "descending limb" (not "thin descending
+%     limb"), so the subject atom is `descending_limb`.
+%   - The AQP2 span contains a source-side typo, "aquaporin-porin (AQP2)", preserved
+%     character-for-character for byte-stability; the atom is aquaporin_2.
+%   - The NCC span uses a Unicode minus in "Na+/Cl−", preserved verbatim.
+% Atoms are stable identifiers naming the concept, not required to match the span's
+% exact spelling.
+% ============================================================================
+
+dictionary nephron_vocab {
+    define segment     : entity   surface "nephron segment", "tubule segment"
+    define transporter : entity   surface "membrane transporter", "ion channel"
+
+    define nephron_segment_transporter : relation from segment to transporter  % the transporter a nephron segment carries
+}
+
+rulebook nephron_facts {
+    use nephron_vocab
+
+    % --- thick ascending limb -> Na-K-2Cl cotransporter (NKCC2) ---------------
+    relate nephron_segment_transporter(thick_ascending_limb, nkcc2)
+        source "Loop diuretics induce its effect by competing with chloride to bind to the Na-K-2Cl (NKCC2) cotransporter at the apical membrane of the thick ascending limb of the loop of Henle and blocking the cotransporter, which inhibits the reabsorption of sodium and chloride."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK546656/"
+        trust authoritative
+
+    % --- distal convoluted tubule -> Na-Cl cotransporter (NCC) ----------------
+    relate nephron_segment_transporter(distal_convoluted_tubule, ncc)
+        source "Hydrochlorothiazide selectively inhibits the Na+/Cl− cotransporter (NCC), the primary pathway for sodium reabsorption on the apical membrane of epithelial cells in the DCT, thereby reducing sodium and chloride reabsorption."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK430766/"
+        trust authoritative
+
+    % --- collecting-duct principal cell -> epithelial sodium channel (ENaC) ---
+    relate nephron_segment_transporter(principal_cell, enac)
+        source "Principal cells contain sodium (epithelial sodium channels or ENaCs) and potassium channels on their apical surfaces."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK549766/"
+        trust authoritative
+
+    % --- proximal convoluted tubule -> sodium-glucose cotransporter 2 (SGLT2) --
+    relate nephron_segment_transporter(proximal_convoluted_tubule, sglt2)
+        source "SGLT2 inhibitors, including canagliflozin, dapagliflozin, empagliflozin, ertugliflozin, and bexagliflozin, target SGLT2 proteins in the proximal convoluted tubules of the kidneys."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK576405/"
+        trust authoritative
+
+    % --- proximal convoluted tubule -> carbonic anhydrase ---------------------
+    relate nephron_segment_transporter(proximal_convoluted_tubule, carbonic_anhydrase)
+        source "Carbonic anhydrase in the lumen of the proximal tubule of the kidney converts carbonic acid to water and carbon dioxide."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK557736/"
+        trust authoritative
+
+    % --- collecting duct -> aquaporin-2 water channel -------------------------
+    relate nephron_segment_transporter(collecting_duct, aquaporin_2)
+        source "These V2 receptors are found in the basolateral membrane of principal cells in the late distal tubule and the whole length of the collecting duct (CD); a G protein couples them to cyclic adenosine monophosphate generation, which ultimately leads to the insertion of aquaporin-porin (AQP2) water channels into the apical membrane of this otherwise water-impermeable segment."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK470458/"
+        trust authoritative
+
+    % --- descending limb of loop of Henle -> water (osmotic reabsorption) -----
+    relate nephron_segment_transporter(descending_limb, water)
+        source "The descending limb functions to reabsorb water via osmosis."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK538339/"
+        trust authoritative
+}

--- a/code/specs/data/mycin-2026/recall/nephron-transporter-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/nephron-transporter-recall.query.adj
@@ -1,0 +1,23 @@
+% ============================================================================
+% nephron-transporter-recall.query.adj — a worked recall query over the nephron library.
+% ============================================================================
+% The shape an LLM (or a clinician) produces to ANSWER a "which transporter acts at
+% this nephron segment?" question: it states no physiology fact — it only `import`s
+% the grounded library and asks binding queries. The native adj-lang engine resolves
+% each `?` against the imported `relate` edges and returns the binding + the citing
+% clause's source/locator/trust. A single segment may bind several transporters (the
+% proximal tubule carries both SGLT2 and luminal carbonic anhydrase), and the engine
+% returns one answer per grounded edge. All knowledge is in the library; none is here.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli nephron-transporter-recall.query.adj
+% ============================================================================
+
+import "nephron-transporter-edges.adj"
+
+? nephron_segment_transporter(proximal_convoluted_tubule, $Transporter)  % expect sglt2 + carbonic_anhydrase
+? nephron_segment_transporter(thick_ascending_limb, $Transporter)        % expect nkcc2
+? nephron_segment_transporter(distal_convoluted_tubule, $Transporter)    % expect ncc
+? nephron_segment_transporter(collecting_duct, $Transporter)             % expect aquaporin_2
+? nephron_segment_transporter(principal_cell, $Transporter)              % expect enac
+? nephron_segment_transporter(descending_limb, $Transporter)             % expect water

--- a/code/specs/data/mycin-2026/recall/test_nephron_transporter_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_nephron_transporter_recall.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""test_nephron_transporter_recall.py — the ADJ-only nephron-transporter recall library (MYCIN-2026 NEPHRON).
+
+A new pure-ADJ recall domain (high-yield renal-physiology board content): which
+membrane transporter / channel operates at each nephron segment (and so where each
+diuretic class acts). `nephron-transporter-edges.adj` is the SOLE source of truth —
+facts + byte-provenance inline, no Python gate, no JSON, no manifest. This test pins
+the property that matters: the native adj-lang engine, given a query .adj that only
+`import`s the library and asks binding queries (`nephron-transporter-recall.query.adj`
+— the shape an LLM produces), binds the grounded transporter(s) for each segment,
+each carrying an AUTHORITATIVE citation with a real source span + locator.
+
+Like the coronary domain, a segment may carry SEVERAL transporters (the proximal
+tubule has SGLT2 + carbonic anhydrase), so a query binds a SET; the test checks the
+full set per segment.
+
+If the native CLI isn't built (a Python-only CI lane), the engine-backed checks
+skip — the file-shape checks (every clause grounded, no authored-debt) still run.
+
+Run:  python3 test_nephron_transporter_recall.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ADJ = HERE / "nephron-transporter-edges.adj"
+QUERY = HERE / "nephron-transporter-recall.query.adj"
+CLI = HERE.parents[3] / "packages" / "rust" / "target" / "debug" / "adj-lang-cli"
+
+# Each nephron segment -> the SET of transporters the library grounds it to.
+# The proximal convoluted tubule is deliberately multi-transporter.
+EXPECTED = {
+    "proximal_convoluted_tubule": {"sglt2", "carbonic_anhydrase"},  # NBK576405 / NBK557736
+    "thick_ascending_limb": {"nkcc2"},                              # NBK546656
+    "distal_convoluted_tubule": {"ncc"},                            # NBK430766
+    "collecting_duct": {"aquaporin_2"},                            # NBK470458
+    "principal_cell": {"enac"},                                    # NBK549766
+    "descending_limb": {"water"},                                 # NBK538339
+}
+REL = "nephron_segment_transporter"
+VAR = "Transporter"
+EDGE_COUNT = sum(len(v) for v in EXPECTED.values())  # 7 grounded clauses
+
+
+def _cli_available() -> bool:
+    return CLI.exists()
+
+
+def _run(program: Path) -> dict:
+    out = subprocess.run([str(CLI), str(program)], capture_output=True, text=True,
+                         cwd=str(HERE), timeout=60)
+    assert out.returncode == 0, f"adj-lang-cli failed: {out.stderr}"
+    return json.loads(out.stdout)
+
+
+# ---- 1. the ADJ file is the artifact — every clause grounded, no authored-debt ----
+
+def test_library_is_pure_adj_and_fully_grounded() -> None:
+    text = ADJ.read_text()
+    assert "trust consensus" not in text, "NEPHRON ships no authored-debt; ground or omit"
+    assert "[FLAG:" not in text
+    assert text.count("    relate ") == EDGE_COUNT
+    assert text.count("trust authoritative") == EDGE_COUNT
+    assert text.count('\n        locator "') == EDGE_COUNT
+    assert text.count('\n        source "') == EDGE_COUNT
+    # every locator is an NCBI primary source
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("locator "):
+            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+    assert not (HERE / "nephron_transporter_edge_ground.py").exists()
+    assert not (HERE / "nephron-transporter-edge-grounding.json").exists()
+    assert not (HERE / "nephron-transporter-edge-manifest.json").exists()
+
+
+# ---- 2. the engine binds each transporter set, each with an authoritative citation -
+
+def test_engine_binds_every_transporter_with_authoritative_citation() -> None:
+    if not _cli_available():
+        return
+    result = _run(QUERY)
+    by_query = {r["query"]: r for r in result["recall"]}
+    for segment, transporters in EXPECTED.items():
+        q = f"{REL}({segment}, {VAR})"
+        r = by_query.get(q)
+        assert r is not None and not r["abstained"], f"{q} abstained — edges missing?"
+        bound = {}
+        for a in r["answers"]:
+            bound[a["bindings"][VAR]] = (a.get("citations") or [{}])[0]
+        assert set(bound) == transporters, f"{segment}: bound {set(bound)} != {transporters}"
+        for transporter, cite in bound.items():
+            assert cite.get("trust") == "authoritative", f"{segment}/{transporter} not authoritative"
+            assert cite.get("source"), f"{segment}/{transporter} has no source span"
+            assert cite.get("locator", "").startswith("https://www.ncbi.nlm.nih.gov/")
+
+
+# ---- 3. an off-vocabulary segment abstains, never fabricates ------------------------
+
+def test_unknown_segment_abstains() -> None:
+    if not _cli_available():
+        return
+    import os
+    import tempfile
+    fd, path = tempfile.mkstemp(suffix=".adj", prefix=".nephron_q_", dir=HERE)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            # macula_densa is a real nephron structure but is NOT in the library -> must abstain
+            fh.write(f'import "nephron-transporter-edges.adj"\n? {REL}(macula_densa, ${VAR})\n')
+        res = _run(Path(path))
+        r = res["recall"][0] if res["recall"] else None
+        assert r is not None and r["abstained"], "an ungrounded segment must abstain"
+    finally:
+        os.unlink(path)
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS  {t.__name__}")
+        except AssertionError as exc:
+            failed += 1
+            print(f"  FAIL  {t.__name__}: {exc}")
+    print(f"\ntest_nephron_transporter_recall: {len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())


### PR DESCRIPTION
## What

A new pure-ADJ board-recall domain for high-yield renal physiology: which membrane transporter / channel operates at each nephron segment (and so where each diuretic class acts). Same shape as the merged CORONARY/ENZYME/CRANIAL/NERVE domains — facts + byte-provenance live **inline** in the `.adj`; the native `adj-lang` engine answers the binding queries; **no Python gate, no JSON, no manifest**.

Relation `nephron_segment_transporter(segment, transporter)` — the physiology direction (name the segment → recall the transporter that acts there). **Multi-binding** (a segment may carry several transporters → query binds a set). 7 edges, each defended by a **self-contained NCBI span naming BOTH endpoints, independently re-fetched and confirmed verbatim**:

| segment | transporter | source |
|---|---|---|
| thick_ascending_limb | nkcc2 | NBK546656 |
| distal_convoluted_tubule | ncc | NBK430766 |
| principal_cell | enac | NBK549766 |
| proximal_convoluted_tubule | sglt2 | NBK576405 |
| proximal_convoluted_tubule | carbonic_anhydrase | NBK557736 |
| collecting_duct | aquaporin_2 | NBK470458 |
| descending_limb | water | NBK538339 |

## Faithfulness notes
- The ENaC span names "principal cells" (not the duct), so the subject is span-faithfully `principal_cell`.
- The water span says "descending limb" (not "thin descending limb").
- The AQP2 span carries a **source-side typo** "aquaporin-porin (AQP2)", preserved character-for-character for byte-stability; the atom is `aquaporin_2`.
- The NCC span uses a Unicode minus "Na+/Cl−", preserved verbatim.
- Several localizations are reached through a drug's mechanism of action (loop diuretic→NKCC2, thiazide→NCC, SGLT2 inhibitors→SGLT2); the localization is stated regardless of the drug framing.

## Genuine deferrals
No single NCBI body sentence co-named both endpoints for: **NHE3**, **ROMK**, and the ADH-mechanism AQP2 phrasing (the localization AQP2 edge is grounded via the V2-receptor span).

## Files
- `code/specs/data/mycin-2026/recall/nephron-transporter-edges.adj` — dictionary + 7 grounded `relate` clauses
- `code/specs/data/mycin-2026/recall/nephron-transporter-recall.query.adj` — `import` + 6 binding queries (the LLM shape)
- `code/specs/data/mycin-2026/recall/test_nephron_transporter_recall.py` — 3 tests: file fully grounded / engine binds each segment's full transporter SET with an authoritative citation / off-vocab segment (`macula_densa`) abstains

Shipped in parallel with the CORONARY batch ([#6599](https://github.com/adhithyan15/coding-adventures/pull/6599)) — disjoint new files, no conflict. Auto-discovered by `.github/workflows/mycin-2026.yml`. All 3 tests green locally against the freshly-built native `adj-lang-cli`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)