### PR TITLE
feat(mycin-brachial): ADJ-only brachial-plexus nerve→origin recall (6 grounded edges)

### DIFF
--- a/code/specs/data/mycin-2026/recall/brachial-plexus-edges.adj
+++ b/code/specs/data/mycin-2026/recall/brachial-plexus-edges.adj
@@ -1,0 +1,85 @@
+% ============================================================================
+% brachial-plexus-edges — the brachial-plexus origin knowledge-graph (MYCIN-2026 BRACHIAL).
+% ============================================================================
+% A high-yield anatomy board domain: which cord (or root) of the brachial plexus
+% each terminal nerve arises from. "The radial nerve is a continuation of which
+% cord?" becomes the binding query
+%     ? brachial_plexus_origin(radial_nerve, $Origin).
+%
+% Direction note: the relation is nerve -> origin (`brachial_plexus_origin`), the
+% board direction — you name the nerve and recall the cord/root it comes from.
+% Each nerve here maps to one canonical origin (the median nerve's origin is the
+% union of two cords, captured as a single atom lateral_and_medial_cords), so a
+% query binds a single answer.
+%
+% What matters for grounding is that one self-contained span names BOTH the nerve
+% AND its cord/root of origin, stating the arises-from relationship. "Origin" here
+% spans the three cords (lateral / posterior / medial) and the plexus roots — all
+% are levels of the brachial plexus a nerve can arise from.
+%
+% This file is the SHIPPED ARTIFACT and the SOLE source of truth — no generator,
+% no JSON, no manifest (a pure ADJ-only recall domain, like NEPHRON/CORONARY/ENZYME).
+% Each fact is a `relate` clause whose byte-provenance lives INLINE:
+%     source   — the VERBATIM span copied from the cited page (byte-stable: it
+%                appears character-for-character in the page's normalized text;
+%                every span here was independently re-fetched and confirmed).
+%     locator  — the URL the span was read from (NCBI StatPearls / Bookshelf).
+%     trust    — authoritative (a primary, citable reference).
+% An LLM (or a human) recalls a fact by writing a tiny query .adj that `import`s
+% this library and asks a binding query — see brachial-plexus-recall.query.adj.
+% Nothing here is asserted "from memory": every edge is defended by a span a reader
+% can re-fetch and check.
+% (See feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+%
+% Note: the long_thoracic span names the C5/C6/C7 nerve roots specifically; the
+% object atom is `roots` (the plexus roots level). The median nerve atom
+% `lateral_and_medial_cords` reflects its dual-cord origin. Atoms are stable
+% identifiers naming the concept, not required to match the span's exact spelling.
+% ============================================================================
+
+dictionary brachial_vocab {
+    define nerve  : entity   surface "terminal nerve", "named nerve"
+    define origin : entity   surface "cord or root of origin", "plexus level"
+
+    define brachial_plexus_origin : relation from nerve to origin  % the cord/root a brachial-plexus nerve arises from
+}
+
+rulebook brachial_facts {
+    use brachial_vocab
+
+    % --- musculocutaneous nerve -> lateral cord -------------------------------
+    relate brachial_plexus_origin(musculocutaneous_nerve, lateral_cord)
+        source "The musculocutaneous nerve (C5-7) is a terminal branch of the lateral cord."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK534199/"
+        trust authoritative
+
+    % --- axillary nerve -> posterior cord -------------------------------------
+    relate brachial_plexus_origin(axillary_nerve, posterior_cord)
+        source "The axillary nerve begins at the ventral rami of C5 and C6 spinal nerves and continues as the smaller branch of the posterior cord of the brachial plexus."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK493212/"
+        trust authoritative
+
+    % --- radial nerve -> posterior cord ---------------------------------------
+    relate brachial_plexus_origin(radial_nerve, posterior_cord)
+        source "The radial nerve is the direct continuation of the posterior cord and the biggest terminal branch of the brachial plexus."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK534840/"
+        trust authoritative
+
+    % --- ulnar nerve -> medial cord -------------------------------------------
+    relate brachial_plexus_origin(ulnar_nerve, medial_cord)
+        source "The ulnar nerve is one of the 5 terminal branches of the brachial plexus, arising from the medial cord."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK499892/"
+        trust authoritative
+
+    % --- long thoracic nerve -> roots (C5-C7) ---------------------------------
+    relate brachial_plexus_origin(long_thoracic_nerve, roots)
+        source "The long thoracic nerve forms as an upper portion originating from the C5 and C6 nerve roots and a lower portion coming from the C7 nerve root."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK535396/"
+        trust authoritative
+
+    % --- median nerve -> lateral + medial cords -------------------------------
+    relate brachial_plexus_origin(median_nerve, lateral_and_medial_cords)
+        source "The median nerve, 1 of the 5 terminal branches of the brachial plexus, is formed by the union of the lateral and medial cords."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK448084/"
+        trust authoritative
+}

--- a/code/specs/data/mycin-2026/recall/brachial-plexus-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/brachial-plexus-recall.query.adj
@@ -1,0 +1,21 @@
+% ============================================================================
+% brachial-plexus-recall.query.adj — a worked recall query over the brachial library.
+% ============================================================================
+% The shape an LLM (or a clinician) produces to ANSWER a "which cord/root does this
+% nerve arise from?" question: it states no anatomy fact — it only `import`s the
+% grounded library and asks binding queries. The native adj-lang engine resolves
+% each `?` against the imported `relate` edges and returns the binding + the citing
+% clause's source/locator/trust. All knowledge is in the library; none is here.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli brachial-plexus-recall.query.adj
+% ============================================================================
+
+import "brachial-plexus-edges.adj"
+
+? brachial_plexus_origin(musculocutaneous_nerve, $Origin)  % expect lateral_cord
+? brachial_plexus_origin(axillary_nerve, $Origin)          % expect posterior_cord
+? brachial_plexus_origin(radial_nerve, $Origin)            % expect posterior_cord
+? brachial_plexus_origin(ulnar_nerve, $Origin)             % expect medial_cord
+? brachial_plexus_origin(long_thoracic_nerve, $Origin)     % expect roots
+? brachial_plexus_origin(median_nerve, $Origin)            % expect lateral_and_medial_cords

--- a/code/specs/data/mycin-2026/recall/test_brachial_plexus_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_brachial_plexus_recall.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""test_brachial_plexus_recall.py — the ADJ-only brachial-plexus origin recall library (MYCIN-2026 BRACHIAL).
+
+A new pure-ADJ recall domain (high-yield anatomy board content): which cord (or
+root) of the brachial plexus each terminal nerve arises from. `brachial-plexus-edges.adj`
+is the SOLE source of truth — facts + byte-provenance inline, no Python gate, no
+JSON, no manifest. This test pins the property that matters: the native adj-lang
+engine, given a query .adj that only `import`s the library and asks binding queries
+(`brachial-plexus-recall.query.adj` — the shape an LLM produces), binds the grounded
+origin for each nerve, each carrying an AUTHORITATIVE citation with a real source
+span + locator. Knowledge lives in ADJ; the engine answers.
+
+If the native CLI isn't built (a Python-only CI lane), the engine-backed checks
+skip — the file-shape checks (every clause grounded, no authored-debt) still run.
+
+Run:  python3 test_brachial_plexus_recall.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ADJ = HERE / "brachial-plexus-edges.adj"
+QUERY = HERE / "brachial-plexus-recall.query.adj"
+CLI = HERE.parents[3] / "packages" / "rust" / "target" / "debug" / "adj-lang-cli"
+
+# Every grounded edge: terminal nerve -> the cord/root the library binds.
+EXPECTED = {
+    "musculocutaneous_nerve": "lateral_cord",                # NBK534199
+    "axillary_nerve": "posterior_cord",                      # NBK493212
+    "radial_nerve": "posterior_cord",                        # NBK534840
+    "ulnar_nerve": "medial_cord",                            # NBK499892
+    "long_thoracic_nerve": "roots",                          # NBK535396
+    "median_nerve": "lateral_and_medial_cords",              # NBK448084
+}
+REL = "brachial_plexus_origin"
+VAR = "Origin"
+
+
+def _cli_available() -> bool:
+    return CLI.exists()
+
+
+def _run(program: Path) -> dict:
+    out = subprocess.run([str(CLI), str(program)], capture_output=True, text=True,
+                         cwd=str(HERE), timeout=60)
+    assert out.returncode == 0, f"adj-lang-cli failed: {out.stderr}"
+    return json.loads(out.stdout)
+
+
+# ---- 1. the ADJ file is the artifact — every clause grounded, no authored-debt ----
+
+def test_library_is_pure_adj_and_fully_grounded() -> None:
+    text = ADJ.read_text()
+    assert "trust consensus" not in text, "BRACHIAL ships no authored-debt; ground or omit"
+    assert "[FLAG:" not in text
+    edge_count = len(EXPECTED)  # 6
+    assert text.count("    relate ") == edge_count
+    assert text.count("trust authoritative") == edge_count
+    assert text.count('\n        locator "') == edge_count
+    assert text.count('\n        source "') == edge_count
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("locator "):
+            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+    assert not (HERE / "brachial_plexus_edge_ground.py").exists()
+    assert not (HERE / "brachial-plexus-edge-grounding.json").exists()
+    assert not (HERE / "brachial-plexus-edge-manifest.json").exists()
+
+
+# ---- 2. the engine binds each origin with an authoritative citation ----------------
+
+def test_engine_binds_every_origin_with_authoritative_citation() -> None:
+    if not _cli_available():
+        return
+    result = _run(QUERY)
+    by_query = {r["query"]: r for r in result["recall"]}
+    for nerve, origin in EXPECTED.items():
+        q = f"{REL}({nerve}, {VAR})"
+        r = by_query.get(q)
+        assert r is not None and not r["abstained"], f"{q} abstained — edge missing?"
+        bound = {}
+        for a in r["answers"]:
+            bound[a["bindings"][VAR]] = (a.get("citations") or [{}])[0]
+        assert set(bound) == {origin}, f"{nerve}: bound {set(bound)} != {{{origin}}}"
+        cite = bound[origin]
+        assert cite.get("trust") == "authoritative", f"{nerve}/{origin} not authoritative"
+        assert cite.get("source"), f"{nerve}/{origin} has no source span"
+        assert cite.get("locator", "").startswith("https://www.ncbi.nlm.nih.gov/")
+
+
+# ---- 3. an off-vocabulary nerve abstains, never fabricates --------------------------
+
+def test_unknown_nerve_abstains() -> None:
+    if not _cli_available():
+        return
+    import os
+    import tempfile
+    fd, path = tempfile.mkstemp(suffix=".adj", prefix=".brachial_q_", dir=HERE)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            # phrenic_nerve is a real nerve but arises from the CERVICAL plexus, not the
+            # brachial plexus — it is deliberately not in the library, so must abstain.
+            fh.write(f'import "brachial-plexus-edges.adj"\n? {REL}(phrenic_nerve, ${VAR})\n')
+        res = _run(Path(path))
+        r = res["recall"][0] if res["recall"] else None
+        assert r is not None and r["abstained"], "an ungrounded nerve must abstain"
+    finally:
+        os.unlink(path)
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS  {t.__name__}")
+        except AssertionError as exc:
+            failed += 1
+            print(f"  FAIL  {t.__name__}: {exc}")
+    print(f"\ntest_brachial_plexus_recall: {len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())


### PR DESCRIPTION
## What

A new pure-ADJ board-recall domain for high-yield anatomy: which cord (or root) of the brachial plexus each terminal nerve arises from. Same shape as the merged NEPHRON/CORONARY/ENZYME/CRANIAL/NERVE domains — facts + byte-provenance live **inline** in the `.adj`; the native `adj-lang` engine answers the binding queries; **no Python gate, no JSON, no manifest**.

Relation `brachial_plexus_origin(nerve, origin)` — the board direction (name the nerve → recall the cord/root it arises from). 6 edges, each defended by a **self-contained NCBI span naming BOTH endpoints, independently re-fetched and confirmed verbatim**:

| nerve | origin | source |
|---|---|---|
| musculocutaneous_nerve | lateral_cord | NBK534199 |
| axillary_nerve | posterior_cord | NBK493212 |
| radial_nerve | posterior_cord | NBK534840 |
| ulnar_nerve | medial_cord | NBK499892 |
| long_thoracic_nerve | roots (C5–C7) | NBK535396 |
| median_nerve | lateral_and_medial_cords | NBK448084 |

## Faithfulness notes
- The `long_thoracic` span names the C5/C6/C7 nerve roots specifically; the object atom is `roots` (the plexus-root level).
- The `median` atom `lateral_and_medial_cords` reflects its dual-cord origin ("formed by the union of the lateral and medial cords").
- Atoms are stable identifiers naming the concept, not required to match span spelling.

## Files
- `code/specs/data/mycin-2026/recall/brachial-plexus-edges.adj` — dictionary + 6 grounded `relate` clauses
- `code/specs/data/mycin-2026/recall/brachial-plexus-recall.query.adj` — `import` + 6 binding queries (the LLM shape)
- `code/specs/data/mycin-2026/recall/test_brachial_plexus_recall.py` — 3 tests: file fully grounded / engine binds each nerve's origin with an authoritative citation / off-vocab nerve (`phrenic_nerve` — a real nerve from the *cervical* plexus, deliberately omitted) abstains

Auto-discovered by `.github/workflows/mycin-2026.yml`. All 3 tests green locally against the freshly-built native `adj-lang-cli`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)