### PR TITLE
feat(mycin-2026): BIOCHEM recall — metabolite→precursor-amino-acid (10 edges)

### DIFF
--- a/code/specs/data/mycin-2026/recall/biochem-amino-acid-edges.adj
+++ b/code/specs/data/mycin-2026/recall/biochem-amino-acid-edges.adj
@@ -1,0 +1,111 @@
+% ============================================================================
+% biochem-amino-acid-edges — the metabolite→precursor-amino-acid knowledge-graph
+% (MYCIN-2026 BIOCHEM).
+% ============================================================================
+% A high-yield biochemistry board domain: which amino acid is the biosynthetic
+% PRECURSOR of a given neurotransmitter / signalling molecule / pigment / heme.
+% "Dopamine is derived from which amino acid?" becomes the binding query
+%     ? derived_from(dopamine, $AminoAcid).
+%
+% Direction note: the relation is metabolite -> precursor amino acid
+% (`derived_from`), the board direction — you name the product (serotonin,
+% dopamine, histamine, …) and recall the amino acid it is synthesized from.
+% Each product here maps to ONE canonical precursor amino acid, so a query binds
+% a single answer (several products share one precursor — the three catecholamines
+% and melanin all derive from tyrosine — which is a many-subjects→one-object map,
+% still single-answer per subject).
+%
+% What matters for grounding is that one self-contained span names BOTH the
+% product AND its precursor amino acid, stating the synthesized-from / derived-from
+% relationship. The catecholamine edges (dopamine / norepinephrine / epinephrine)
+% all cite the SAME StatPearls sentence (NBK507716), which co-names all three
+% products and tyrosine in a single clause — one span legitimately defends three
+% edges.
+%
+% This file is the SHIPPED ARTIFACT and the SOLE source of truth — no generator,
+% no JSON, no manifest (a pure ADJ-only recall domain, like BRACHIAL/NEPHRON/ENZYME).
+% Each fact is a `relate` clause whose byte-provenance lives INLINE:
+%     source   — the VERBATIM span copied from the cited page (byte-stable: it
+%                appears character-for-character in the page's normalized text;
+%                every span here was independently re-fetched and confirmed,
+%                including Unicode characters — the prime ′ in "pyridoxal-5′-phosphate"
+%                and the en dash – in "amino acid–like" are preserved exactly).
+%     locator  — the URL the span was read from (NCBI StatPearls / Bookshelf).
+%     trust    — authoritative (a primary, citable reference).
+% An LLM (or a human) recalls a fact by writing a tiny query .adj that `import`s
+% this library and asks a binding query — see biochem-amino-acid-recall.query.adj.
+% Nothing here is asserted "from memory": every edge is defended by a span a reader
+% can re-fetch and check.
+% (See feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+dictionary biochem_vocab {
+    define metabolite : entity   surface "biochemical product", "neurotransmitter or signalling molecule"
+    define amino_acid : entity   surface "precursor amino acid", "proteinogenic amino acid"
+
+    define derived_from : relation from metabolite to amino_acid  % the amino acid a metabolite is biosynthesized from
+}
+
+rulebook biochem_facts {
+    use biochem_vocab
+
+    % --- serotonin -> tryptophan ----------------------------------------------
+    relate derived_from(serotonin, tryptophan)
+        source "Serotonin forms from the hydroxylation (i.e., the addition of -OH group) and decarboxylation of the tryptophan amino acid."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK560856/"
+        trust authoritative
+
+    % --- dopamine -> tyrosine -------------------------------------------------
+    relate derived_from(dopamine, tyrosine)
+        source "These chemical messengers include dopamine, norepinephrine (noradrenaline), and epinephrine (adrenaline), which are derived from the amino acid tyrosine."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK507716/"
+        trust authoritative
+
+    % --- norepinephrine -> tyrosine (same catecholamine span) -----------------
+    relate derived_from(norepinephrine, tyrosine)
+        source "These chemical messengers include dopamine, norepinephrine (noradrenaline), and epinephrine (adrenaline), which are derived from the amino acid tyrosine."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK507716/"
+        trust authoritative
+
+    % --- epinephrine -> tyrosine (same catecholamine span) --------------------
+    relate derived_from(epinephrine, tyrosine)
+        source "These chemical messengers include dopamine, norepinephrine (noradrenaline), and epinephrine (adrenaline), which are derived from the amino acid tyrosine."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK507716/"
+        trust authoritative
+
+    % --- melanin -> tyrosine --------------------------------------------------
+    relate derived_from(melanin, tyrosine)
+        source "Tyrosine is the key precursor for the synthesis of melanin, the pigment responsible for coloration in the skin, hair, and eyes."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK459156/"
+        trust authoritative
+
+    % --- histamine -> histidine -----------------------------------------------
+    relate derived_from(histamine, histidine)
+        source "Histamine is a biogenic amine synthesized from the amino acid L-histidine exclusively by the enzyme L-histidine decarboxylase (HDC), which requires pyridoxal-5′-phosphate as an essential cofactor."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK557790/"
+        trust authoritative
+
+    % --- GABA -> glutamate ----------------------------------------------------
+    relate derived_from(gaba, glutamate)
+        source "GABA is synthesized from glutamate in the presynaptic neuron by the enzyme glutamate decarboxylase (GAD), which requires pyridoxal phosphate (vitamin B6) as a co-factor."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK551683/"
+        trust authoritative
+
+    % --- nitric oxide -> arginine ---------------------------------------------
+    relate derived_from(nitric_oxide, arginine)
+        source "Nitric oxide (NO) is produced by converting L-arginine into NO via NO synthases (NOS) in various parts of the body."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK554485/"
+        trust authoritative
+
+    % --- creatine -> arginine -------------------------------------------------
+    relate derived_from(creatine, arginine)
+        source "Creatine (N-[aminoiminomethyl]-N-methyl glycine) is an amino acid–like compound that is produced endogenously in the liver, kidney, pancreas, and possibly the brain from the biosynthesis of the essential amino acids methionine, glycine, and arginine, or obtained from dietary sources."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK209321/"
+        trust authoritative
+
+    % --- heme -> glycine ------------------------------------------------------
+    relate derived_from(heme, glycine)
+        source "At the cellular level, heme biosynthesis consists of an 8-step enzymatic pathway distributed between the mitochondria and cytosol, beginning with glycine and succinyl coenzyme A (succinyl-CoA) and culminating in the insertion of ferrous iron into protoporphyrin IX."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK537329/"
+        trust authoritative
+}

--- a/code/specs/data/mycin-2026/recall/biochem-amino-acid-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/biochem-amino-acid-recall.query.adj
@@ -1,0 +1,26 @@
+% ============================================================================
+% biochem-amino-acid-recall.query.adj — a worked recall query over the biochem library.
+% ============================================================================
+% The shape an LLM (or a student) produces to ANSWER a "which amino acid is this
+% molecule derived from?" question: it states no biochemistry fact — it only
+% `import`s the grounded library and asks binding queries. The native adj-lang
+% engine resolves each `?` against the imported `relate` edges and returns the
+% binding + the citing clause's source/locator/trust. All knowledge is in the
+% library; none is here.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli biochem-amino-acid-recall.query.adj
+% ============================================================================
+
+import "biochem-amino-acid-edges.adj"
+
+? derived_from(serotonin, $AminoAcid)       % expect tryptophan
+? derived_from(dopamine, $AminoAcid)        % expect tyrosine
+? derived_from(norepinephrine, $AminoAcid)  % expect tyrosine
+? derived_from(epinephrine, $AminoAcid)     % expect tyrosine
+? derived_from(melanin, $AminoAcid)         % expect tyrosine
+? derived_from(histamine, $AminoAcid)       % expect histidine
+? derived_from(gaba, $AminoAcid)            % expect glutamate
+? derived_from(nitric_oxide, $AminoAcid)    % expect arginine
+? derived_from(creatine, $AminoAcid)        % expect arginine
+? derived_from(heme, $AminoAcid)            % expect glycine

--- a/code/specs/data/mycin-2026/recall/test_biochem_amino_acid_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_biochem_amino_acid_recall.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""test_biochem_amino_acid_recall.py — the ADJ-only metabolite→precursor-amino-acid
+recall library (MYCIN-2026 BIOCHEM).
+
+A new pure-ADJ recall domain (high-yield biochemistry board content): which amino
+acid is the biosynthetic precursor of a neurotransmitter / signalling molecule /
+pigment / heme. `biochem-amino-acid-edges.adj` is the SOLE source of truth — facts
++ byte-provenance inline, no Python gate, no JSON, no manifest. This test pins the
+property that matters: the native adj-lang engine, given a query .adj that only
+`import`s the library and asks binding queries (`biochem-amino-acid-recall.query.adj`
+— the shape an LLM produces), binds the grounded precursor for each metabolite, each
+carrying an AUTHORITATIVE citation with a real source span + locator. Knowledge lives
+in ADJ; the engine answers.
+
+If the native CLI isn't built (a Python-only CI lane), the engine-backed checks
+skip — the file-shape checks (every clause grounded, no authored-debt) still run.
+
+Run:  python3 test_biochem_amino_acid_recall.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ADJ = HERE / "biochem-amino-acid-edges.adj"
+QUERY = HERE / "biochem-amino-acid-recall.query.adj"
+CLI = HERE.parents[3] / "packages" / "rust" / "target" / "debug" / "adj-lang-cli"
+
+# Every grounded edge: metabolite -> the precursor amino acid the library binds.
+EXPECTED = {
+    "serotonin": "tryptophan",        # NBK560856
+    "dopamine": "tyrosine",           # NBK507716
+    "norepinephrine": "tyrosine",     # NBK507716
+    "epinephrine": "tyrosine",        # NBK507716
+    "melanin": "tyrosine",            # NBK459156
+    "histamine": "histidine",         # NBK557790
+    "gaba": "glutamate",              # NBK551683
+    "nitric_oxide": "arginine",       # NBK554485
+    "creatine": "arginine",           # NBK209321
+    "heme": "glycine",                # NBK537329
+}
+REL = "derived_from"
+VAR = "AminoAcid"
+
+
+def _cli_available() -> bool:
+    return CLI.exists()
+
+
+def _run(program: Path) -> dict:
+    out = subprocess.run([str(CLI), str(program)], capture_output=True, text=True,
+                         cwd=str(HERE), timeout=60)
+    assert out.returncode == 0, f"adj-lang-cli failed: {out.stderr}"
+    return json.loads(out.stdout)
+
+
+# ---- 1. the ADJ file is the artifact — every clause grounded, no authored-debt ----
+
+def test_library_is_pure_adj_and_fully_grounded() -> None:
+    text = ADJ.read_text()
+    assert "trust consensus" not in text, "BIOCHEM ships no authored-debt; ground or omit"
+    assert "[FLAG:" not in text
+    edge_count = len(EXPECTED)  # 10
+    assert text.count("    relate ") == edge_count
+    assert text.count("trust authoritative") == edge_count
+    assert text.count('\n        locator "') == edge_count
+    assert text.count('\n        source "') == edge_count
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("locator "):
+            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+    assert not (HERE / "biochem_amino_acid_edge_ground.py").exists()
+    assert not (HERE / "biochem-amino-acid-edge-grounding.json").exists()
+    assert not (HERE / "biochem-amino-acid-edge-manifest.json").exists()
+
+
+# ---- 2. the engine binds each precursor with an authoritative citation -------------
+
+def test_engine_binds_every_precursor_with_authoritative_citation() -> None:
+    if not _cli_available():
+        return
+    result = _run(QUERY)
+    by_query = {r["query"]: r for r in result["recall"]}
+    for metabolite, amino_acid in EXPECTED.items():
+        q = f"{REL}({metabolite}, {VAR})"
+        r = by_query.get(q)
+        assert r is not None and not r["abstained"], f"{q} abstained — edge missing?"
+        bound = {}
+        for a in r["answers"]:
+            bound[a["bindings"][VAR]] = (a.get("citations") or [{}])[0]
+        assert set(bound) == {amino_acid}, f"{metabolite}: bound {set(bound)} != {{{amino_acid}}}"
+        cite = bound[amino_acid]
+        assert cite.get("trust") == "authoritative", f"{metabolite}/{amino_acid} not authoritative"
+        assert cite.get("source"), f"{metabolite}/{amino_acid} has no source span"
+        assert cite.get("locator", "").startswith("https://www.ncbi.nlm.nih.gov/")
+
+
+# ---- 3. an off-vocabulary metabolite abstains, never fabricates --------------------
+
+def test_unknown_metabolite_abstains() -> None:
+    if not _cli_available():
+        return
+    import os
+    import tempfile
+    fd, path = tempfile.mkstemp(suffix=".adj", prefix=".biochem_q_", dir=HERE)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            # acetylcholine is a real neurotransmitter but is synthesized from choline
+            # + acetyl-CoA, NOT from an amino acid precursor — it is deliberately not in
+            # the library, so the engine must abstain rather than fabricate.
+            fh.write(f'import "biochem-amino-acid-edges.adj"\n? {REL}(acetylcholine, ${VAR})\n')
+        res = _run(Path(path))
+        r = res["recall"][0] if res["recall"] else None
+        assert r is not None and r["abstained"], "an ungrounded metabolite must abstain"
+    finally:
+        os.unlink(path)
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS  {t.__name__}")
+        except AssertionError as exc:
+            failed += 1
+            print(f"  FAIL  {t.__name__}: {exc}")
+    print(f"\ntest_biochem_amino_acid_recall: {len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())


### PR DESCRIPTION
## What

New **ADJ-only** board-recall biochemistry domain under `code/specs/data/mycin-2026/recall/`: which amino acid is the biosynthetic **precursor** of a high-yield neurotransmitter / signalling molecule / pigment / heme. Relation `derived_from(metabolite, amino_acid)` — the board direction (name the product, recall its precursor amino acid).

## Edges (10) — each defended by a self-contained VERBATIM NCBI span naming BOTH endpoints

| metabolite | → amino acid | NCBI |
|---|---|---|
| serotonin | tryptophan | NBK560856 |
| dopamine | tyrosine | NBK507716 |
| norepinephrine | tyrosine | NBK507716 (shared catecholamine span) |
| epinephrine | tyrosine | NBK507716 (shared catecholamine span) |
| melanin | tyrosine | NBK459156 |
| histamine | histidine | NBK557790 |
| gaba | glutamate | NBK551683 |
| nitric_oxide | arginine | NBK554485 |
| creatine | arginine | NBK209321 |
| heme | glycine | NBK537329 |

The single StatPearls catecholamine sentence (NBK507716) legitimately defends three edges — it co-names dopamine, norepinephrine, epinephrine **and** tyrosine in one clause. Every span was independently re-fetched and confirmed verbatim. Unicode preserved for byte-stability: prime `′` in "pyridoxal-5′-phosphate" (histamine), en dash `–` in "amino acid–like" (creatine).

## Shape

Pure ADJ-only library (no Python generator, no JSON, no manifest), like BRACHIAL/NEPHRON/ENZYME:
- `biochem-amino-acid-edges.adj` — sole source of truth (dictionary + 10 grounded `relate` clauses with inline `source`/`locator`/`trust authoritative`).
- `biochem-amino-acid-recall.query.adj` — the LLM-shaped binding query (`import` + 10 `?` lines).
- `test_biochem_amino_acid_recall.py` — pins engine bindings + authoritative citations + file-shape grounding + an off-vocab negative control (**acetylcholine** — synthesized from choline, not an amino acid — must abstain).

## Verification

- `cargo build -p adj-lang-cli` ✓
- `python3 test_biochem_amino_acid_recall.py` → **3/3 pass** (engine binds all 10 precursors with authoritative NCBI citations; acetylcholine abstains).
- Security review (inline diff): **PASSED** — no vulnerabilities.

Shipped in parallel while #6602 (BRACHIAL) awaits async merge — disjoint new-file set, zero cross-PR conflict risk. The board-eval scorecard's `EDGE_FILES` discovery is additive, so this standalone domain needs no edits elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)