### PR TITLE
feat(mycin-2026): RATELIMIT recall — pathway→rate-limiting-enzyme (8 edges)

### DIFF
--- a/code/specs/data/mycin-2026/recall/ratelimit-enzyme-edges.adj
+++ b/code/specs/data/mycin-2026/recall/ratelimit-enzyme-edges.adj
@@ -1,0 +1,103 @@
+% ============================================================================
+% ratelimit-enzyme-edges — the metabolic-pathway→rate-limiting-enzyme knowledge-graph
+% (MYCIN-2026 RATELIMIT).
+% ============================================================================
+% A classic high-yield biochemistry board table: the rate-limiting (committed-step)
+% enzyme of each major metabolic pathway. "What is the rate-limiting enzyme of
+% glycolysis?" becomes the binding query
+%     ? rate_limiting_enzyme_of(glycolysis, $Enzyme).
+%
+% Direction note: the relation is pathway -> rate-limiting enzyme
+% (`rate_limiting_enzyme_of`), the board direction — you name the pathway and recall
+% the enzyme that controls its committed/rate-limiting step. Each pathway here maps
+% to ONE canonical rate-limiting enzyme, so a query binds a single answer.
+%
+% What matters for grounding is that one self-contained span names BOTH the pathway
+% AND its rate-limiting (or "first committed step") enzyme, stating that control
+% relationship. A few spans name the enzyme by its standard board abbreviation
+% (e.g. "CPT I" for carnitine palmitoyltransferase I) — the atom is the full enzyme
+% name; atoms are stable identifiers, not required to match the span's exact spelling.
+%
+% This file is the SHIPPED ARTIFACT and the SOLE source of truth — no generator,
+% no JSON, no manifest (a pure ADJ-only recall domain, like BIOCHEM/BRACHIAL/NEPHRON).
+% Each fact is a `relate` clause whose byte-provenance lives INLINE:
+%     source   — the VERBATIM span copied from the cited page (byte-stable: it
+%                appears character-for-character in the page's normalized text;
+%                every span here was independently re-fetched and confirmed,
+%                including verbatim quirks — the spacing in "NAD+ -dependent", the
+%                cross-reference "(see below)", the run-together "ALA synthase1",
+%                and the Unicode α in "α-1-4 bond" are preserved exactly).
+%     locator  — the URL the span was read from (NCBI StatPearls / Bookshelf).
+%     trust    — authoritative (a primary, citable reference).
+% An LLM (or a human) recalls a fact by writing a tiny query .adj that `import`s
+% this library and asks a binding query — see ratelimit-enzyme-recall.query.adj.
+% Nothing here is asserted "from memory": every edge is defended by a span a reader
+% can re-fetch and check.
+% (See feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+%
+% DEFERRED (honest gap, not authored over): gluconeogenesis → fructose-1,6-
+% bisphosphatase. On NBK544346 the rate-limiting designation ("...the rate-limiting
+% step of gluconeogenesis.") and the enzyme name appear in two separate consecutive
+% sentences; NBK541119/NBK550349 call it only "a key enzyme" without "rate-limiting".
+% No single self-contained NCBI sentence co-names both endpoints with the rate-
+% limiting relationship, so the edge is omitted rather than grounded on a split span.
+% ============================================================================
+
+dictionary ratelimit_vocab {
+    define pathway : entity   surface "metabolic pathway", "biochemical pathway"
+    define enzyme  : entity   surface "rate-limiting enzyme", "committed-step enzyme"
+
+    define rate_limiting_enzyme_of : relation from pathway to enzyme  % the enzyme controlling a pathway's rate-limiting step
+}
+
+rulebook ratelimit_facts {
+    use ratelimit_vocab
+
+    % --- glycolysis -> phosphofructokinase-1 ----------------------------------
+    relate rate_limiting_enzyme_of(glycolysis, phosphofructokinase_1)
+        source "The processing of fructose in the liver is not controlled by hormone or allosteric mechanisms, and fructose bypasses the rate-limiting step of glycolysis catalyzed by phosphofructokinase 1 (PFK 1)."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK576428/"
+        trust authoritative
+
+    % --- citric acid cycle (TCA) -> isocitrate dehydrogenase ------------------
+    relate rate_limiting_enzyme_of(citric_acid_cycle, isocitrate_dehydrogenase)
+        source "The oxidative decarboxylation of isocitrate to alpha-ketoglutarate becomes catalyzed by NAD+ -dependent isocitrate dehydrogenase, producing CO2, NADH, and a proton; this is the rate-limiting step of the TCA cycle."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK556032/"
+        trust authoritative
+
+    % --- cholesterol synthesis -> HMG-CoA reductase ---------------------------
+    relate rate_limiting_enzyme_of(cholesterol_synthesis, hmg_coa_reductase)
+        source "Conversion of 3-hydroxy-3-methyl glutaryl-CoA (HMG-CoA) to mevalonate by HMG-CoA reductase in the hepatocytes is the first and rate-limiting step in cholesterol biosynthesis."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK542212/"
+        trust authoritative
+
+    % --- fatty acid synthesis -> acetyl-CoA carboxylase -----------------------
+    relate rate_limiting_enzyme_of(fatty_acid_synthesis, acetyl_coa_carboxylase)
+        source "The first committed step of fatty acid biosynthesis, in which malonyl-CoA is generated from acetyl-CoA, is catalyzed by acetyl-CoA carboxylase (ACC) (see below)."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK2413/"
+        trust authoritative
+
+    % --- fatty acid oxidation -> carnitine palmitoyltransferase I -------------
+    relate rate_limiting_enzyme_of(fatty_acid_oxidation, carnitine_palmitoyltransferase_1)
+        source "The enzymatic transportation and conversion completed by CPT I is the rate-limiting step of fatty acid oxidation in the mitochondria."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK556002/"
+        trust authoritative
+
+    % --- heme synthesis -> ALA synthase ---------------------------------------
+    relate rate_limiting_enzyme_of(heme_synthesis, ala_synthase)
+        source "The rate-limiting enzyme in the formation of heme is the hepatic ALA synthase1 enzyme, which heme inhibits."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK537352/"
+        trust authoritative
+
+    % --- glycogenesis -> glycogen synthase ------------------------------------
+    relate rate_limiting_enzyme_of(glycogenesis, glycogen_synthase)
+        source "Glycogen synthase, the rate-limiting enzyme in glycogen synthesis, exists in 2 interconvertible forms: the active, dephosphorylated glycogen synthase a and the less active, phosphorylated glycogen synthase b."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK539802/"
+        trust authoritative
+
+    % --- glycogenolysis -> glycogen phosphorylase -----------------------------
+    relate rate_limiting_enzyme_of(glycogenolysis, glycogen_phosphorylase)
+        source "Corresponding to cytosolic degradation, glycogen phosphorylase, the rate-limiting enzyme of glycogenolysis, cleaves terminal glucose residue connected to a glycogen branch while substituting a phosphoryl group for the α-1-4 bond."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK549820/"
+        trust authoritative
+}

--- a/code/specs/data/mycin-2026/recall/ratelimit-enzyme-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/ratelimit-enzyme-recall.query.adj
@@ -1,0 +1,23 @@
+% ============================================================================
+% ratelimit-enzyme-recall.query.adj — a worked recall query over the ratelimit library.
+% ============================================================================
+% The shape an LLM (or a student) produces to ANSWER a "what is the rate-limiting
+% enzyme of pathway X?" question: it states no biochemistry fact — it only `import`s
+% the grounded library and asks binding queries. The native adj-lang engine resolves
+% each `?` against the imported `relate` edges and returns the binding + the citing
+% clause's source/locator/trust. All knowledge is in the library; none is here.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli ratelimit-enzyme-recall.query.adj
+% ============================================================================
+
+import "ratelimit-enzyme-edges.adj"
+
+? rate_limiting_enzyme_of(glycolysis, $Enzyme)            % expect phosphofructokinase_1
+? rate_limiting_enzyme_of(citric_acid_cycle, $Enzyme)    % expect isocitrate_dehydrogenase
+? rate_limiting_enzyme_of(cholesterol_synthesis, $Enzyme) % expect hmg_coa_reductase
+? rate_limiting_enzyme_of(fatty_acid_synthesis, $Enzyme)  % expect acetyl_coa_carboxylase
+? rate_limiting_enzyme_of(fatty_acid_oxidation, $Enzyme)  % expect carnitine_palmitoyltransferase_1
+? rate_limiting_enzyme_of(heme_synthesis, $Enzyme)        % expect ala_synthase
+? rate_limiting_enzyme_of(glycogenesis, $Enzyme)          % expect glycogen_synthase
+? rate_limiting_enzyme_of(glycogenolysis, $Enzyme)        % expect glycogen_phosphorylase

--- a/code/specs/data/mycin-2026/recall/test_ratelimit_enzyme_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_ratelimit_enzyme_recall.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""test_ratelimit_enzyme_recall.py — the ADJ-only metabolic-pathway→rate-limiting-enzyme
+recall library (MYCIN-2026 RATELIMIT).
+
+A new pure-ADJ recall domain (classic high-yield biochemistry board table): the
+rate-limiting (committed-step) enzyme of each major metabolic pathway.
+`ratelimit-enzyme-edges.adj` is the SOLE source of truth — facts + byte-provenance
+inline, no Python gate, no JSON, no manifest. This test pins the property that
+matters: the native adj-lang engine, given a query .adj that only `import`s the
+library and asks binding queries (`ratelimit-enzyme-recall.query.adj` — the shape an
+LLM produces), binds the grounded rate-limiting enzyme for each pathway, each
+carrying an AUTHORITATIVE citation with a real source span + locator. Knowledge lives
+in ADJ; the engine answers.
+
+If the native CLI isn't built (a Python-only CI lane), the engine-backed checks
+skip — the file-shape checks (every clause grounded, no authored-debt) still run.
+
+Run:  python3 test_ratelimit_enzyme_recall.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ADJ = HERE / "ratelimit-enzyme-edges.adj"
+QUERY = HERE / "ratelimit-enzyme-recall.query.adj"
+CLI = HERE.parents[3] / "packages" / "rust" / "target" / "debug" / "adj-lang-cli"
+
+# Every grounded edge: pathway -> the rate-limiting enzyme the library binds.
+EXPECTED = {
+    "glycolysis": "phosphofructokinase_1",                 # NBK576428
+    "citric_acid_cycle": "isocitrate_dehydrogenase",       # NBK556032
+    "cholesterol_synthesis": "hmg_coa_reductase",          # NBK542212
+    "fatty_acid_synthesis": "acetyl_coa_carboxylase",      # NBK2413
+    "fatty_acid_oxidation": "carnitine_palmitoyltransferase_1",  # NBK556002
+    "heme_synthesis": "ala_synthase",                      # NBK537352
+    "glycogenesis": "glycogen_synthase",                   # NBK539802
+    "glycogenolysis": "glycogen_phosphorylase",            # NBK549820
+}
+REL = "rate_limiting_enzyme_of"
+VAR = "Enzyme"
+
+
+def _cli_available() -> bool:
+    return CLI.exists()
+
+
+def _run(program: Path) -> dict:
+    out = subprocess.run([str(CLI), str(program)], capture_output=True, text=True,
+                         cwd=str(HERE), timeout=60)
+    assert out.returncode == 0, f"adj-lang-cli failed: {out.stderr}"
+    return json.loads(out.stdout)
+
+
+# ---- 1. the ADJ file is the artifact — every clause grounded, no authored-debt ----
+
+def test_library_is_pure_adj_and_fully_grounded() -> None:
+    text = ADJ.read_text()
+    assert "trust consensus" not in text, "RATELIMIT ships no authored-debt; ground or omit"
+    assert "[FLAG:" not in text
+    edge_count = len(EXPECTED)  # 8
+    assert text.count("    relate ") == edge_count
+    assert text.count("trust authoritative") == edge_count
+    assert text.count('\n        locator "') == edge_count
+    assert text.count('\n        source "') == edge_count
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("locator "):
+            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+    assert not (HERE / "ratelimit_enzyme_edge_ground.py").exists()
+    assert not (HERE / "ratelimit-enzyme-edge-grounding.json").exists()
+    assert not (HERE / "ratelimit-enzyme-edge-manifest.json").exists()
+
+
+# ---- 2. the engine binds each rate-limiting enzyme with an authoritative citation --
+
+def test_engine_binds_every_enzyme_with_authoritative_citation() -> None:
+    if not _cli_available():
+        return
+    result = _run(QUERY)
+    by_query = {r["query"]: r for r in result["recall"]}
+    for pathway, enzyme in EXPECTED.items():
+        q = f"{REL}({pathway}, {VAR})"
+        r = by_query.get(q)
+        assert r is not None and not r["abstained"], f"{q} abstained — edge missing?"
+        bound = {}
+        for a in r["answers"]:
+            bound[a["bindings"][VAR]] = (a.get("citations") or [{}])[0]
+        assert set(bound) == {enzyme}, f"{pathway}: bound {set(bound)} != {{{enzyme}}}"
+        cite = bound[enzyme]
+        assert cite.get("trust") == "authoritative", f"{pathway}/{enzyme} not authoritative"
+        assert cite.get("source"), f"{pathway}/{enzyme} has no source span"
+        assert cite.get("locator", "").startswith("https://www.ncbi.nlm.nih.gov/")
+
+
+# ---- 3. an off-vocabulary pathway abstains, never fabricates ------------------------
+
+def test_unknown_pathway_abstains() -> None:
+    if not _cli_available():
+        return
+    import os
+    import tempfile
+    fd, path = tempfile.mkstemp(suffix=".adj", prefix=".ratelimit_q_", dir=HERE)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            # the urea cycle is a real pathway (rate-limiting enzyme = carbamoyl
+            # phosphate synthetase I) but is deliberately not in the library, so the
+            # engine must abstain rather than fabricate.
+            fh.write(f'import "ratelimit-enzyme-edges.adj"\n? {REL}(urea_cycle, ${VAR})\n')
+        res = _run(Path(path))
+        r = res["recall"][0] if res["recall"] else None
+        assert r is not None and r["abstained"], "an ungrounded pathway must abstain"
+    finally:
+        os.unlink(path)
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS  {t.__name__}")
+        except AssertionError as exc:
+            failed += 1
+            print(f"  FAIL  {t.__name__}: {exc}")
+    print(f"\ntest_ratelimit_enzyme_recall: {len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())


### PR DESCRIPTION
## What

New **ADJ-only** board-recall biochemistry domain under `code/specs/data/mycin-2026/recall/`: the classic "rate-limiting enzyme of each metabolic pathway" table. Relation `rate_limiting_enzyme_of(pathway, enzyme)` — the board direction (name the pathway, recall the enzyme controlling its committed/rate-limiting step).

## Edges (8) — each defended by a self-contained VERBATIM NCBI span naming BOTH endpoints

| pathway | → rate-limiting enzyme | NCBI |
|---|---|---|
| glycolysis | phosphofructokinase-1 | NBK576428 |
| citric_acid_cycle (TCA) | isocitrate dehydrogenase | NBK556032 |
| cholesterol_synthesis | HMG-CoA reductase | NBK542212 |
| fatty_acid_synthesis | acetyl-CoA carboxylase | NBK2413 |
| fatty_acid_oxidation | carnitine palmitoyltransferase I | NBK556002 |
| heme_synthesis | ALA synthase | NBK537352 |
| glycogenesis | glycogen synthase | NBK539802 |
| glycogenolysis | glycogen phosphorylase | NBK549820 |

Every span independently re-fetched and confirmed verbatim. Quirks preserved for byte-stability: spacing in `NAD+ -dependent`, cross-reference `(see below)`, run-together `ALA synthase1`, Unicode `α` in `α-1-4 bond`.

### Deferred (honest gap, documented inline)

**gluconeogenesis → fructose-1,6-bisphosphatase.** On NBK544346 the "rate-limiting step of gluconeogenesis" phrase and the enzyme name fall in two separate consecutive sentences; NBK541119/NBK550349 call it only "a key enzyme" without "rate-limiting". No single self-contained span co-names both endpoints with the relationship, so the edge is omitted rather than grounded on a split span. Re-groundable later from an alternate source.

## Shape

Pure ADJ-only library (no Python generator, no JSON, no manifest), like BIOCHEM/BRACHIAL/NEPHRON/ENZYME:
- `ratelimit-enzyme-edges.adj` — sole source of truth (dictionary + 8 grounded `relate` clauses with inline `source`/`locator`/`trust authoritative`).
- `ratelimit-enzyme-recall.query.adj` — the LLM-shaped binding query (`import` + 8 `?` lines).
- `test_ratelimit_enzyme_recall.py` — pins engine bindings + authoritative citations + file-shape grounding + an off-vocab negative control (**urea_cycle** — deliberately omitted — must abstain).

## Verification

- `cargo build -p adj-lang-cli` ✓
- `python3 test_ratelimit_enzyme_recall.py` → **3/3 pass** (engine binds all 8 enzymes with authoritative NCBI citations; urea_cycle abstains).
- Security review (inline diff): **PASSED** — no vulnerabilities.

Shipped in parallel while #6604 (BIOCHEM) awaits async merge — disjoint new-file set, zero cross-PR conflict risk. The board-eval scorecard's `EDGE_FILES` discovery is additive, so this standalone domain needs no edits elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)