### PR TITLE
feat(mycin-2026): LYSOSOMAL recall — storage-disease→accumulated-substrate (7 edges)

### DIFF
--- a/code/specs/data/mycin-2026/recall/lysosomal-storage-edges.adj
+++ b/code/specs/data/mycin-2026/recall/lysosomal-storage-edges.adj
@@ -1,0 +1,100 @@
+% ============================================================================
+% lysosomal-storage-edges — the lysosomal-storage-disease→accumulated-substrate
+% knowledge-graph (MYCIN-2026 LYSOSOMAL).
+% ============================================================================
+% A classic high-yield biochemistry board table: in each lysosomal storage
+% disease, an enzyme deficiency blocks degradation of a particular substrate, so
+% that substrate accumulates. "What accumulates in Tay-Sachs disease?" becomes the
+% binding query
+%     ? accumulates(tay_sachs, $Substrate).
+%
+% Direction note: the relation is disease -> accumulated substrate (`accumulates`),
+% the board direction — you name the disease and recall the molecule that builds up.
+% Each disease here maps to ONE canonical accumulating substrate, so a query binds
+% a single answer.
+%
+% What matters for grounding is that one self-contained span names BOTH the disease
+% AND its accumulating substrate. Most spans state "accumulation"/"buildup" directly
+% (Tay-Sachs, Gaucher, Fabry, metachromatic leukodystrophy, Pompe). Two spans
+% (Niemann-Pick, Hurler) co-name both endpoints via the canonical MECHANISM — the
+% deficient enzyme is the one that normally degrades/hydrolyzes the substrate, so
+% its deficiency causes that substrate to accumulate; this is the same defeasible
+% byte-grounding the framework uses elsewhere (justification by combined bytes, not
+% verbatim substring). The header flags those two so a reader knows the exact wording.
+%
+% This file is the SHIPPED ARTIFACT and the SOLE source of truth — no generator,
+% no JSON, no manifest (a pure ADJ-only recall domain, like RATELIMIT/BIOCHEM/BRACHIAL).
+% Each fact is a `relate` clause whose byte-provenance lives INLINE:
+%     source   — the VERBATIM span copied from the cited page (byte-stable: it
+%                appears character-for-character in the page's normalized text;
+%                every span here was independently re-fetched and confirmed,
+%                including verbatim quirks — the Unicode α in "α-Gal A" (Fabry) and
+%                the source's own spellings "IUDA" and "heparin sulfate" (Hurler) are
+%                preserved exactly).
+%     locator  — the URL the span was read from (NCBI StatPearls / Bookshelf).
+%     trust    — authoritative (a primary, citable reference).
+% An LLM (or a human) recalls a fact by writing a tiny query .adj that `import`s
+% this library and asks a binding query — see lysosomal-storage-recall.query.adj.
+% Nothing here is asserted "from memory": every edge is defended by a span a reader
+% can re-fetch and check.
+% (See feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+%
+% DEFERRED (honest gap, not authored over): Krabbe disease → galactocerebroside/
+% psychosine. On NBK562315 (StatPearls) and NBK1238 (GeneReviews) the disease name
+% and the substrate-with-accumulation are split across separate sentences; no single
+% self-contained span co-names both with the relationship, so the edge is omitted
+% rather than grounded on a split span. Re-groundable later from an alternate source.
+% ============================================================================
+
+dictionary lysosomal_vocab {
+    define disease   : entity   surface "lysosomal storage disease", "storage disorder"
+    define substrate : entity   surface "accumulated substrate", "storage material"
+
+    define accumulates : relation from disease to substrate  % the molecule that builds up in a storage disease
+}
+
+rulebook lysosomal_facts {
+    use lysosomal_vocab
+
+    % --- Tay-Sachs -> GM2 ganglioside -----------------------------------------
+    relate accumulates(tay_sachs, gm2_ganglioside)
+        source "Tay-Sachs disease is a progressive, lethal neurodegenerative disorder caused by a deficiency of the enzyme hexosaminidase-A that results in the accumulation of GM2 gangliosides."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK564432/"
+        trust authoritative
+
+    % --- Gaucher -> glucocerebroside ------------------------------------------
+    relate accumulates(gaucher, glucocerebroside)
+        source "All forms of Gaucher disease lead to the toxic accumulation of glucocerebroside lipids, primarily in the liver, spleen, and bone marrow."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK448080/"
+        trust authoritative
+
+    % --- Niemann-Pick -> sphingomyelin (mechanism span: deficient enzyme degrades it) --
+    relate accumulates(niemann_pick, sphingomyelin)
+        source "Niemann-Pick disease (NPD) is a lysosomal storage disease caused by acid sphingomyelinase deficiency (ASMD), which catalyzes the hydrolysis of sphingomyelin to ceramide and phosphocholine."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK556129/"
+        trust authoritative
+
+    % --- Fabry -> globotriaosylceramide (Gb3) ---------------------------------
+    relate accumulates(fabry, globotriaosylceramide)
+        source "Fabry disease belongs to the group of X-linked inherited lysosomal storage disorders characterized by α-Gal A deficiency, which leads to lysosomal accumulation of globotriaosylceramide (Gb3)."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK435996/"
+        trust authoritative
+
+    % --- Hurler (MPS I) -> glycosaminoglycans (mechanism span: deficient enzyme breaks them down) --
+    relate accumulates(hurler, glycosaminoglycans)
+        source "Hurler syndrome is caused by a deficiency of a lysosomal enzyme, IUDA, which aids in the breakdown of dermatan sulfate and heparin sulfate (GAG)."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK532261/"
+        trust authoritative
+
+    % --- metachromatic leukodystrophy -> sulfatides ---------------------------
+    relate accumulates(metachromatic_leukodystrophy, sulfatides)
+        source "Metachromatic leukodystrophy is an autosomal recessive lysosomal disorder that results in a buildup of sulfatides that leads to the destruction of the myelin sheath, leading to progressive demyelination of the central and peripheral nervous system."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK560744/"
+        trust authoritative
+
+    % --- Pompe (GSD II) -> glycogen (lysosomal) -------------------------------
+    relate accumulates(pompe, glycogen)
+        source "Pompe disease is driven by lysosomal glycogen accumulation due to GAA enzyme deficiency, leading to lysosomal rupture and the release of glycogen and other toxic materials into the cytoplasm."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK470558/"
+        trust authoritative
+}

--- a/code/specs/data/mycin-2026/recall/lysosomal-storage-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/lysosomal-storage-recall.query.adj
@@ -1,0 +1,22 @@
+% ============================================================================
+% lysosomal-storage-recall.query.adj — a worked recall query over the lysosomal library.
+% ============================================================================
+% The shape an LLM (or a student) produces to ANSWER a "what accumulates in storage
+% disease X?" question: it states no biochemistry fact — it only `import`s the
+% grounded library and asks binding queries. The native adj-lang engine resolves
+% each `?` against the imported `relate` edges and returns the binding + the citing
+% clause's source/locator/trust. All knowledge is in the library; none is here.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli lysosomal-storage-recall.query.adj
+% ============================================================================
+
+import "lysosomal-storage-edges.adj"
+
+? accumulates(tay_sachs, $Substrate)                    % expect gm2_ganglioside
+? accumulates(gaucher, $Substrate)                      % expect glucocerebroside
+? accumulates(niemann_pick, $Substrate)                 % expect sphingomyelin
+? accumulates(fabry, $Substrate)                        % expect globotriaosylceramide
+? accumulates(hurler, $Substrate)                       % expect glycosaminoglycans
+? accumulates(metachromatic_leukodystrophy, $Substrate) % expect sulfatides
+? accumulates(pompe, $Substrate)                        % expect glycogen

--- a/code/specs/data/mycin-2026/recall/test_lysosomal_storage_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_lysosomal_storage_recall.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""test_lysosomal_storage_recall.py — the ADJ-only lysosomal-storage-disease→
+accumulated-substrate recall library (MYCIN-2026 LYSOSOMAL).
+
+A new pure-ADJ recall domain (classic high-yield biochemistry board table): the
+substrate that accumulates in each lysosomal storage disease.
+`lysosomal-storage-edges.adj` is the SOLE source of truth — facts + byte-provenance
+inline, no Python gate, no JSON, no manifest. This test pins the property that
+matters: the native adj-lang engine, given a query .adj that only `import`s the
+library and asks binding queries (`lysosomal-storage-recall.query.adj` — the shape
+an LLM produces), binds the grounded substrate for each disease, each carrying an
+AUTHORITATIVE citation with a real source span + locator. Knowledge lives in ADJ;
+the engine answers.
+
+If the native CLI isn't built (a Python-only CI lane), the engine-backed checks
+skip — the file-shape checks (every clause grounded, no authored-debt) still run.
+
+Run:  python3 test_lysosomal_storage_recall.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ADJ = HERE / "lysosomal-storage-edges.adj"
+QUERY = HERE / "lysosomal-storage-recall.query.adj"
+CLI = HERE.parents[3] / "packages" / "rust" / "target" / "debug" / "adj-lang-cli"
+
+# Every grounded edge: storage disease -> the substrate the library binds.
+EXPECTED = {
+    "tay_sachs": "gm2_ganglioside",                        # NBK564432
+    "gaucher": "glucocerebroside",                         # NBK448080
+    "niemann_pick": "sphingomyelin",                       # NBK556129
+    "fabry": "globotriaosylceramide",                      # NBK435996
+    "hurler": "glycosaminoglycans",                        # NBK532261
+    "metachromatic_leukodystrophy": "sulfatides",          # NBK560744
+    "pompe": "glycogen",                                   # NBK470558
+}
+REL = "accumulates"
+VAR = "Substrate"
+
+
+def _cli_available() -> bool:
+    return CLI.exists()
+
+
+def _run(program: Path) -> dict:
+    out = subprocess.run([str(CLI), str(program)], capture_output=True, text=True,
+                         cwd=str(HERE), timeout=60)
+    assert out.returncode == 0, f"adj-lang-cli failed: {out.stderr}"
+    return json.loads(out.stdout)
+
+
+# ---- 1. the ADJ file is the artifact — every clause grounded, no authored-debt ----
+
+def test_library_is_pure_adj_and_fully_grounded() -> None:
+    text = ADJ.read_text()
+    assert "trust consensus" not in text, "LYSOSOMAL ships no authored-debt; ground or omit"
+    assert "[FLAG:" not in text
+    edge_count = len(EXPECTED)  # 7
+    assert text.count("    relate ") == edge_count
+    assert text.count("trust authoritative") == edge_count
+    assert text.count('\n        locator "') == edge_count
+    assert text.count('\n        source "') == edge_count
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("locator "):
+            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+    assert not (HERE / "lysosomal_storage_edge_ground.py").exists()
+    assert not (HERE / "lysosomal-storage-edge-grounding.json").exists()
+    assert not (HERE / "lysosomal-storage-edge-manifest.json").exists()
+
+
+# ---- 2. the engine binds each substrate with an authoritative citation -------------
+
+def test_engine_binds_every_substrate_with_authoritative_citation() -> None:
+    if not _cli_available():
+        return
+    result = _run(QUERY)
+    by_query = {r["query"]: r for r in result["recall"]}
+    for disease, substrate in EXPECTED.items():
+        q = f"{REL}({disease}, {VAR})"
+        r = by_query.get(q)
+        assert r is not None and not r["abstained"], f"{q} abstained — edge missing?"
+        bound = {}
+        for a in r["answers"]:
+            bound[a["bindings"][VAR]] = (a.get("citations") or [{}])[0]
+        assert set(bound) == {substrate}, f"{disease}: bound {set(bound)} != {{{substrate}}}"
+        cite = bound[substrate]
+        assert cite.get("trust") == "authoritative", f"{disease}/{substrate} not authoritative"
+        assert cite.get("source"), f"{disease}/{substrate} has no source span"
+        assert cite.get("locator", "").startswith("https://www.ncbi.nlm.nih.gov/")
+
+
+# ---- 3. an off-vocabulary disease abstains, never fabricates ------------------------
+
+def test_unknown_disease_abstains() -> None:
+    if not _cli_available():
+        return
+    import os
+    import tempfile
+    fd, path = tempfile.mkstemp(suffix=".adj", prefix=".lysosomal_q_", dir=HERE)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            # cystinosis is a real lysosomal storage disease (cystine accumulates) but
+            # is deliberately not in the library, so the engine must abstain rather
+            # than fabricate.
+            fh.write(f'import "lysosomal-storage-edges.adj"\n? {REL}(cystinosis, ${VAR})\n')
+        res = _run(Path(path))
+        r = res["recall"][0] if res["recall"] else None
+        assert r is not None and r["abstained"], "an ungrounded disease must abstain"
+    finally:
+        os.unlink(path)
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS  {t.__name__}")
+        except AssertionError as exc:
+            failed += 1
+            print(f"  FAIL  {t.__name__}: {exc}")
+    print(f"\ntest_lysosomal_storage_recall: {len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())


### PR DESCRIPTION
## What

New **ADJ-only** board-recall biochemistry domain under `code/specs/data/mycin-2026/recall/`: the classic "lysosomal storage disease → accumulated substrate" table. Relation `accumulates(disease, substrate)` — the board direction (name the disease, recall the molecule that builds up behind the deficient enzyme).

## Edges (7) — each defended by a self-contained VERBATIM NCBI span naming BOTH endpoints

| disease | → accumulated substrate | NCBI |
|---|---|---|
| Tay-Sachs | GM2 ganglioside | NBK564432 |
| Gaucher | glucocerebroside | NBK448080 |
| Niemann-Pick | sphingomyelin | NBK556129 |
| Fabry | globotriaosylceramide (Gb3) | NBK435996 |
| Hurler (MPS I) | glycosaminoglycans | NBK532261 |
| metachromatic leukodystrophy | sulfatides | NBK560744 |
| Pompe (GSD II) | glycogen | NBK470558 |

Five spans state accumulation/buildup directly. Two (**Niemann-Pick, Hurler**) co-name both endpoints via the canonical **mechanism** — the deficient enzyme normally degrades/hydrolyzes the substrate, so its deficiency causes that substrate to accumulate (justification-by-combined-bytes; flagged inline in the header). Every span independently re-fetched and confirmed verbatim. Quirks preserved for byte-stability: Unicode `α` in `α-Gal A` (Fabry); source spellings `IUDA` and `heparin sulfate` (Hurler).

### Deferred (honest gap, documented inline)

**Krabbe disease → galactocerebroside/psychosine.** On NBK562315 (StatPearls) and NBK1238 (GeneReviews) the disease name and the accumulating substrate fall in separate sentences; no single self-contained span co-names both with the relationship, so the edge is omitted rather than grounded on a split span. Re-groundable later from an alternate source.

## Shape

Pure ADJ-only library (no Python generator, no JSON, no manifest), like RATELIMIT/BIOCHEM/BRACHIAL/NEPHRON:
- `lysosomal-storage-edges.adj` — sole source of truth (dictionary + 7 grounded `relate` clauses with inline `source`/`locator`/`trust authoritative`).
- `lysosomal-storage-recall.query.adj` — the LLM-shaped binding query (`import` + 7 `?` lines).
- `test_lysosomal_storage_recall.py` — pins engine bindings + authoritative citations + file-shape grounding + an off-vocab negative control (**cystinosis** — a lysosomal storage disease deliberately omitted — must abstain).

## Verification

- `cargo build -p adj-lang-cli` ✓
- `python3 test_lysosomal_storage_recall.py` → **3/3 pass** (engine binds all 7 substrates with authoritative NCBI citations; cystinosis abstains).
- Security review (inline diff): **PASSED** — no vulnerabilities.

Standalone new-file set; the board-eval scorecard's `EDGE_FILES` discovery is additive, so no edits elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)