### PR TITLE
feat(mycin-collagen): ADJ-only collagen-type→associated-disease recall library

### DIFF
--- a/code/specs/data/mycin-2026/recall/collagen-defect-edges.adj
+++ b/code/specs/data/mycin-2026/recall/collagen-defect-edges.adj
@@ -1,0 +1,92 @@
+% ============================================================================
+% collagen-defect-edges — the collagen-type→associated-disease knowledge-graph
+% (MYCIN-2026 COLLAGEN).
+% ============================================================================
+% A classic high-yield biochemistry/genetics board table: each fibrillar or
+% network collagen type, when defective (mutation in its gene), causes a
+% characteristic heritable connective-tissue disease. "A defect in type I
+% collagen causes which disease?" becomes the binding query
+%     ? defect_causes(type_i, $Disease).
+%
+% Direction note: the relation is collagen type -> the disease its defect causes
+% (`defect_causes`), the board direction — you name the collagen type and recall
+% the disease. Each collagen type here maps to ONE canonical disease, so a query
+% binds a single answer.
+%
+% What matters for grounding is that one self-contained span names BOTH the
+% collagen type AND the disease AND the causal/defect relationship. Several spans
+% name the collagen type directly (Osteogenesis imperfecta -> type I; Alport
+% syndrome -> type 4 collagen; classic Ehlers-Danlos -> type V collagen). Two
+% spans (Stickler, dystrophic epidermolysis bullosa) co-name the endpoints via
+% the canonical GENE symbol — COL2A1 is the gene encoding type II collagen and
+% COL7A1 the gene encoding type VII collagen, so "pathogenic variants in COLnA1
+% cause <disease>" grounds the type-n-collagen→disease edge by combined bytes
+% (the same defeasible byte-grounding the framework uses elsewhere). Gene symbols
+% render in italics on the source pages; the markdown italic markers are a
+% conversion artifact — the real page bytes are the plain symbols (COL2A1, COL7A1),
+% reproduced here exactly.
+%
+% This file is the SHIPPED ARTIFACT and the SOLE source of truth — no generator,
+% no JSON, no manifest (a pure ADJ-only recall domain, like LYSOSOMAL/RATELIMIT/BIOCHEM).
+% Each fact is a `relate` clause whose byte-provenance lives INLINE:
+%     source   — the VERBATIM span copied from the cited page (byte-stable: it
+%                appears character-for-character in the page's normalized text;
+%                every span here was independently re-fetched and confirmed,
+%                including the Unicode α in "collagen 4 α345 network" (Alport)).
+%     locator  — the URL the span was read from (NCBI StatPearls / GeneReviews).
+%     trust    — authoritative (a primary, citable reference).
+% An LLM (or a human) recalls a fact by writing a tiny query .adj that `import`s
+% this library and asks a binding query — see collagen-defect-recall.query.adj.
+% Nothing here is asserted "from memory": every edge is defended by a span a reader
+% can re-fetch and check.
+% (See feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+%
+% DEFERRED (honest gap, not authored over): type III collagen → vascular
+% Ehlers-Danlos syndrome. On NBK549814 (StatPearls) and NBK1494 (GeneReviews) the
+% disease and type III collagen/COL3A1 are split across separate sentences — the
+% collagen-naming sentence calls the disease only "the vascular type"/"It", never
+% the literal "Ehlers-Danlos" or "Vascular EDS", so no single self-contained span
+% co-names both with the relationship. Omitted rather than grounded on a split
+% span; re-groundable later from an alternate source.
+% ============================================================================
+
+dictionary collagen_vocab {
+    define collagen_type : entity   surface "collagen type", "collagen subtype"
+    define disease        : entity   surface "collagen disorder", "connective tissue disease"
+
+    define defect_causes : relation from collagen_type to disease  % the disease a defect in this collagen causes
+}
+
+rulebook collagen_facts {
+    use collagen_vocab
+
+    % --- type I collagen -> osteogenesis imperfecta ---------------------------
+    relate defect_causes(type_i, osteogenesis_imperfecta)
+        source "Osteogenesis imperfecta (OI) is a genetic disorder of connective tissues caused by an abnormality in the synthesis or processing of type I collagen."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK536957/"
+        trust authoritative
+
+    % --- type II collagen -> Stickler syndrome (gene span: COL2A1 = type II) ---
+    relate defect_causes(type_ii, stickler_syndrome)
+        source "Pathogenic variants in COL2A1 that cause Stickler syndrome are typically loss-of-functions variants associated with haploinsufficiency of type II collagen (e.g., nonsense variants, small deletions/duplications, splicing variants that cause a frameshift)."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK1302/"
+        trust authoritative
+
+    % --- type IV collagen -> Alport syndrome ----------------------------------
+    relate defect_causes(type_iv, alport_syndrome)
+        source "Alport syndrome, also known as hereditary nephritis, is a genetic disorder arising from the mutations in the genes encoding alpha-3, alpha-4, and alpha-5 of type 4 collagen (COL4A3, COL4A4, COL4A5) or collagen 4 α345 network."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK470419/"
+        trust authoritative
+
+    % --- type V collagen -> classical Ehlers-Danlos syndrome ------------------
+    relate defect_causes(type_v, classical_ehlers_danlos)
+        source "In classic Ehlers-Danlos syndrome, type V collagen mutations are pivotal."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK549814/"
+        trust authoritative
+
+    % --- type VII collagen -> dystrophic epidermolysis bullosa (gene span: COL7A1 = type VII) --
+    relate defect_causes(type_vii, dystrophic_epidermolysis_bullosa)
+        source "Pathogenic variants in COL7A1 can lead to reduced resistance to minor trauma and the resulting blistering that is the hallmark of dystrophic epidermolysis bullosa (DEB)."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK1304/"
+        trust authoritative
+}

--- a/code/specs/data/mycin-2026/recall/collagen-defect-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/collagen-defect-recall.query.adj
@@ -1,0 +1,21 @@
+% ============================================================================
+% collagen-defect-recall.query.adj — a worked recall query over the collagen library.
+% ============================================================================
+% The shape an LLM (or a student) produces to ANSWER a "which disease does a
+% defect in collagen type X cause?" question: it states no biochemistry fact — it
+% only `import`s the grounded library and asks binding queries. The native adj-lang
+% engine resolves each `?` against the imported `relate` edges and returns the
+% binding + the citing clause's source/locator/trust. All knowledge is in the
+% library; none is here.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli collagen-defect-recall.query.adj
+% ============================================================================
+
+import "collagen-defect-edges.adj"
+
+? defect_causes(type_i, $Disease)     % expect osteogenesis_imperfecta
+? defect_causes(type_ii, $Disease)    % expect stickler_syndrome
+? defect_causes(type_iv, $Disease)    % expect alport_syndrome
+? defect_causes(type_v, $Disease)     % expect classical_ehlers_danlos
+? defect_causes(type_vii, $Disease)   % expect dystrophic_epidermolysis_bullosa

--- a/code/specs/data/mycin-2026/recall/test_collagen_defect_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_collagen_defect_recall.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""test_collagen_defect_recall.py — the ADJ-only collagen-type→associated-disease
+recall library (MYCIN-2026 COLLAGEN).
+
+A new pure-ADJ recall domain (classic high-yield biochemistry/genetics board
+table): the heritable connective-tissue disease caused by a defect in each
+collagen type. `collagen-defect-edges.adj` is the SOLE source of truth — facts +
+byte-provenance inline, no Python gate, no JSON, no manifest. This test pins the
+property that matters: the native adj-lang engine, given a query .adj that only
+`import`s the library and asks binding queries (`collagen-defect-recall.query.adj`
+— the shape an LLM produces), binds the grounded disease for each collagen type,
+each carrying an AUTHORITATIVE citation with a real source span + locator.
+Knowledge lives in ADJ; the engine answers.
+
+If the native CLI isn't built (a Python-only CI lane), the engine-backed checks
+skip — the file-shape checks (every clause grounded, no authored-debt) still run.
+
+Run:  python3 test_collagen_defect_recall.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ADJ = HERE / "collagen-defect-edges.adj"
+QUERY = HERE / "collagen-defect-recall.query.adj"
+CLI = HERE.parents[3] / "packages" / "rust" / "target" / "debug" / "adj-lang-cli"
+
+# Every grounded edge: collagen type -> the disease the library binds.
+EXPECTED = {
+    "type_i": "osteogenesis_imperfecta",                  # NBK536957
+    "type_ii": "stickler_syndrome",                       # NBK1302
+    "type_iv": "alport_syndrome",                         # NBK470419
+    "type_v": "classical_ehlers_danlos",                  # NBK549814
+    "type_vii": "dystrophic_epidermolysis_bullosa",       # NBK1304
+}
+REL = "defect_causes"
+VAR = "Disease"
+
+
+def _cli_available() -> bool:
+    return CLI.exists()
+
+
+def _run(program: Path) -> dict:
+    out = subprocess.run([str(CLI), str(program)], capture_output=True, text=True,
+                         cwd=str(HERE), timeout=60)
+    assert out.returncode == 0, f"adj-lang-cli failed: {out.stderr}"
+    return json.loads(out.stdout)
+
+
+# ---- 1. the ADJ file is the artifact — every clause grounded, no authored-debt ----
+
+def test_library_is_pure_adj_and_fully_grounded() -> None:
+    text = ADJ.read_text()
+    assert "trust consensus" not in text, "COLLAGEN ships no authored-debt; ground or omit"
+    assert "[FLAG:" not in text
+    edge_count = len(EXPECTED)  # 5
+    assert text.count("    relate ") == edge_count
+    assert text.count("trust authoritative") == edge_count
+    assert text.count('\n        locator "') == edge_count
+    assert text.count('\n        source "') == edge_count
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("locator "):
+            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+    assert not (HERE / "collagen_defect_edge_ground.py").exists()
+    assert not (HERE / "collagen-defect-edge-grounding.json").exists()
+    assert not (HERE / "collagen-defect-edge-manifest.json").exists()
+
+
+# ---- 2. the engine binds each disease with an authoritative citation ---------------
+
+def test_engine_binds_every_disease_with_authoritative_citation() -> None:
+    if not _cli_available():
+        return
+    result = _run(QUERY)
+    by_query = {r["query"]: r for r in result["recall"]}
+    for collagen, disease in EXPECTED.items():
+        q = f"{REL}({collagen}, {VAR})"
+        r = by_query.get(q)
+        assert r is not None and not r["abstained"], f"{q} abstained — edge missing?"
+        bound = {}
+        for a in r["answers"]:
+            bound[a["bindings"][VAR]] = (a.get("citations") or [{}])[0]
+        assert set(bound) == {disease}, f"{collagen}: bound {set(bound)} != {{{disease}}}"
+        cite = bound[disease]
+        assert cite.get("trust") == "authoritative", f"{collagen}/{disease} not authoritative"
+        assert cite.get("source"), f"{collagen}/{disease} has no source span"
+        assert cite.get("locator", "").startswith("https://www.ncbi.nlm.nih.gov/")
+
+
+# ---- 3. an off-vocabulary collagen type abstains, never fabricates ------------------
+
+def test_unknown_collagen_type_abstains() -> None:
+    if not _cli_available():
+        return
+    import os
+    import tempfile
+    fd, path = tempfile.mkstemp(suffix=".adj", prefix=".collagen_q_", dir=HERE)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            # type X collagen is a real collagen (defects cause Schmid metaphyseal
+            # chondrodysplasia) but is deliberately not in the library, so the
+            # engine must abstain rather than fabricate.
+            fh.write(f'import "collagen-defect-edges.adj"\n? {REL}(type_x, ${VAR})\n')
+        res = _run(Path(path))
+        r = res["recall"][0] if res["recall"] else None
+        assert r is not None and r["abstained"], "an ungrounded collagen type must abstain"
+    finally:
+        os.unlink(path)
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS  {t.__name__}")
+        except AssertionError as exc:
+            failed += 1
+            print(f"  FAIL  {t.__name__}: {exc}")
+    print(f"\ntest_collagen_defect_recall: {len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())


### PR DESCRIPTION
## Summary

New **pure-ADJ board-recall domain** (MYCIN-2026 COLLAGEN) — the classic high-yield biochemistry/genetics table mapping each collagen type to the heritable connective-tissue disease its defect causes. `collagen-defect-edges.adj` is the SOLE source of truth: facts + byte-provenance inline, **no Python gate, no JSON, no manifest** — exactly the ADJ-only shape of LYSOSOMAL/RATELIMIT/BIOCHEM/BRACHIAL.

A worked query `.adj` `import`s the library and asks binding queries (the shape an LLM produces). The native `adj-lang-cli` engine binds the grounded disease for each collagen type, each carrying an **authoritative** NCBI citation (source span + locator).

## Edges (5) — relation `defect_causes(collagen_type, disease)`

Every span independently re-fetched and confirmed verbatim before commit:

| collagen | disease | source |
|---|---|---|
| type_i | osteogenesis_imperfecta | NBK536957 |
| type_ii | stickler_syndrome | NBK1302 (gene span COL2A1) |
| type_iv | alport_syndrome | NBK470419 (Unicode α preserved) |
| type_v | classical_ehlers_danlos | NBK549814 |
| type_vii | dystrophic_epidermolysis_bullosa | NBK1304 (gene span COL7A1) |

Gene-symbol spans (COL2A1 / COL7A1) ground the type-*n*-collagen→disease edge by **combined bytes** — COL2A1 encodes type II collagen, COL7A1 encodes type VII — the same defeasible byte-grounding the framework uses elsewhere. The source pages italicize the gene symbols; the markdown underscores are a fetch-conversion artifact, so the real page bytes (plain `COL2A1`/`COL7A1`) are reproduced.

## Deferred (honest gap, documented inline)

**type III collagen → vascular Ehlers-Danlos syndrome.** On NBK549814 (StatPearls) and NBK1494 (GeneReviews), the disease and type III collagen/COL3A1 are split across separate sentences — the collagen-naming sentence calls the disease only *"the vascular type"*/*"It"*, never the literal "Ehlers-Danlos" or "Vascular EDS". No single self-contained span co-names both endpoints with the relationship, so the edge is omitted rather than grounded on a split span. Re-groundable later from an alternate source.

## Test (`test_collagen_defect_recall.py`) — 3/3 green locally

1. **file-shape / no authored-debt** — every clause grounded (`trust authoritative`, NCBI locator, source span), no `trust consensus`, no `[FLAG:]`, no Python/JSON/manifest sidecar.
2. **engine binding** — each collagen type binds its single grounded disease with `trust == authoritative`, non-empty source, NCBI locator.
3. **abstention** — off-vocabulary `type_x` collagen (real — Schmid metaphyseal chondrodysplasia — deliberately absent) abstains, never fabricates.

CI auto-discovers `recall/test_*.py`; board_eval EDGE_FILES discovery is additive, so this standalone new domain needs no other edits. Disjoint new-file set → zero cross-PR conflict risk.

## Provenance discipline

Primary-source-first (NCBI StatPearls / GeneReviews); every span verbatim (Unicode/punctuation preserved); security-reviewed (diff inline) — PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)