### PR TITLE
feat(mycin-cerebral-artery): ADJ-only cerebral-artery→territory recall library (7 edges)

### DIFF
--- a/code/specs/data/mycin-2026/recall/cerebral-artery-edges.adj
+++ b/code/specs/data/mycin-2026/recall/cerebral-artery-edges.adj
@@ -1,0 +1,97 @@
+% ============================================================================
+% cerebral-artery-edges — the cerebral-artery→territory knowledge-graph
+% (MYCIN-2026 CEREBRAL-ARTERY).
+% ============================================================================
+% A classic high-yield neuroanatomy / stroke-localization board table: each
+% named cerebral (or orbital) artery and the brain territory it supplies. "The
+% middle cerebral artery supplies which territory?" becomes the binding query
+%     ? supplies(middle_cerebral_artery, $Territory).
+%
+% Direction note: the relation is artery -> the territory it supplies
+% (`supplies`), the board direction for stroke localization — you name the
+% occluded artery and recall the region (and therefore the deficit). Each artery
+% here maps to ONE canonical territory span, so a query binds a single answer.
+%
+% Faithfulness note: each `relate` object is bound to the territory the cited
+% sentence ACTUALLY names, not to a finer label we might have preferred. Two
+% spans name a broader region than the textbook shorthand, and we bind to the
+% span: the basilar-artery sentence says "brainstem" (not "pons" specifically),
+% so the object is `brainstem`; the ophthalmic-artery sentence says "the eye"
+% (not "retina" specifically), so the object is `eye`. Grounding to the literal
+% bytes beats grounding to the label we went looking for.
+%
+% This file is the SHIPPED ARTIFACT and the SOLE source of truth — no generator,
+% no JSON, no manifest (a pure ADJ-only recall domain, like COLLAGEN/LYSOSOMAL/
+% CORONARY). Each fact is a `relate` clause whose byte-provenance lives INLINE:
+%     source   — the VERBATIM span copied from the cited page (byte-stable: it
+%                appears character-for-character in the page's normalized text;
+%                every span here was independently re-fetched and confirmed).
+%     locator  — the URL the span was read from (NCBI StatPearls).
+%     trust    — authoritative (a primary, citable reference).
+% An LLM (or a human) recalls a fact by writing a tiny query .adj that `import`s
+% this library and asks a binding query — see cerebral-artery-recall.query.adj.
+% Nothing here is asserted "from memory": every edge is defended by a span a
+% reader can re-fetch and check.
+% (See feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+%
+% DEFERRED (honest gap, not authored over): posterior inferior cerebellar artery
+% (PICA) -> lateral medulla (the Wallenberg / lateral medullary syndrome
+% territory). On the StatPearls pages read (NBK551670, NBK470174) no single
+% self-contained sentence co-names PICA AND "lateral medulla" AND a supply
+% relationship; the closest used "dorsolateral medulla" across multiple clauses.
+% Omitted rather than grounded on a split or paraphrased span; re-groundable
+% later from an alternate source.
+% ============================================================================
+
+dictionary cerebral_artery_vocab {
+    define artery    : entity   surface "cerebral artery", "intracranial artery"
+    define territory : entity   surface "vascular territory", "brain region supplied"
+
+    define supplies : relation from artery to territory  % the territory this artery supplies
+}
+
+rulebook cerebral_artery_facts {
+    use cerebral_artery_vocab
+
+    % --- middle cerebral artery -> lateral cerebral cortex --------------------
+    relate supplies(middle_cerebral_artery, lateral_cerebral_cortex)
+        source "The MCA's cortical branches supply most of the lateral cerebral hemisphere, including the frontal, parietal, and temporal lobes."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK526002/"
+        trust authoritative
+
+    % --- anterior cerebral artery -> medial cerebral surface ------------------
+    relate supplies(anterior_cerebral_artery, medial_cerebral_surface)
+        source "It then gives off branches supplying the hypothalamus regions via the posterior communicating arteries, the areas surrounding the globus pallidus, and the amygdala via the anterior choroidal arteries, and the medial surfaces of the anterior segment of the brain via the anterior cerebral artery."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK549894/"
+        trust authoritative
+
+    % --- posterior cerebral artery -> occipital lobe --------------------------
+    relate supplies(posterior_cerebral_artery, occipital_lobe)
+        source "The occipital lobe receives vascular supply from the cortical branches of the posterior cerebral artery (PCA)."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK544320/"
+        trust authoritative
+
+    % --- basilar artery -> brainstem (span says "brainstem", not "pons") ------
+    relate supplies(basilar_artery, brainstem)
+        source "The basilar artery serves as the primary source of arterial supply to the brainstem and posterior cerebral hemispheres."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK540995/"
+        trust authoritative
+
+    % --- anterior inferior cerebellar artery -> lateral pons ------------------
+    relate supplies(anterior_inferior_cerebellar_artery, lateral_pons)
+        source "The anterior inferior cerebellar artery supplies the middle cerebellar peduncle, lower lateral pons, anteroinferior surface of the cerebellum, flocculus and the choroid plexus of the lateral ventricle."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK448167/"
+        trust authoritative
+
+    % --- lenticulostriate arteries -> basal ganglia & internal capsule --------
+    relate supplies(lenticulostriate_arteries, basal_ganglia_internal_capsule)
+        source "Deep perforators, the lenticulostriate arteries, arise from the MCA and perfuse the basal ganglia and internal capsule."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK526002/"
+        trust authoritative
+
+    % --- ophthalmic artery -> eye (span says "the eye", not "retina") ---------
+    relate supplies(ophthalmic_artery, eye)
+        source "The branches of the ophthalmic artery comprise the entire arterial supply to the eye."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK537063/"
+        trust authoritative
+}

--- a/code/specs/data/mycin-2026/recall/cerebral-artery-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/cerebral-artery-recall.query.adj
@@ -1,0 +1,23 @@
+% ============================================================================
+% cerebral-artery-recall.query.adj — a worked recall query over the cerebral-artery library.
+% ============================================================================
+% The shape an LLM (or a student) produces to ANSWER a "which territory does
+% artery X supply?" question: it states no neuroanatomy fact — it only `import`s
+% the grounded library and asks binding queries. The native adj-lang engine
+% resolves each `?` against the imported `relate` edges and returns the binding +
+% the citing clause's source/locator/trust. All knowledge is in the library;
+% none is here.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli cerebral-artery-recall.query.adj
+% ============================================================================
+
+import "cerebral-artery-edges.adj"
+
+? supplies(middle_cerebral_artery, $Territory)               % expect lateral_cerebral_cortex
+? supplies(anterior_cerebral_artery, $Territory)             % expect medial_cerebral_surface
+? supplies(posterior_cerebral_artery, $Territory)            % expect occipital_lobe
+? supplies(basilar_artery, $Territory)                       % expect brainstem
+? supplies(anterior_inferior_cerebellar_artery, $Territory)  % expect lateral_pons
+? supplies(lenticulostriate_arteries, $Territory)            % expect basal_ganglia_internal_capsule
+? supplies(ophthalmic_artery, $Territory)                    % expect eye

--- a/code/specs/data/mycin-2026/recall/test_cerebral_artery_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_cerebral_artery_recall.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""test_cerebral_artery_recall.py — the ADJ-only cerebral-artery→territory
+recall library (MYCIN-2026 CEREBRAL-ARTERY).
+
+A new pure-ADJ recall domain (classic high-yield neuroanatomy / stroke-
+localization board table): the brain territory each cerebral (or orbital) artery
+supplies. `cerebral-artery-edges.adj` is the SOLE source of truth — facts +
+byte-provenance inline, no Python gate, no JSON, no manifest. This test pins the
+property that matters: the native adj-lang engine, given a query .adj that only
+`import`s the library and asks binding queries (`cerebral-artery-recall.query.adj`
+— the shape an LLM produces), binds the grounded territory for each artery, each
+carrying an AUTHORITATIVE citation with a real source span + locator. Knowledge
+lives in ADJ; the engine answers.
+
+If the native CLI isn't built (a Python-only CI lane), the engine-backed checks
+skip — the file-shape checks (every clause grounded, no authored-debt) still run.
+
+Run:  python3 test_cerebral_artery_recall.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ADJ = HERE / "cerebral-artery-edges.adj"
+QUERY = HERE / "cerebral-artery-recall.query.adj"
+CLI = HERE.parents[3] / "packages" / "rust" / "target" / "debug" / "adj-lang-cli"
+
+# Every grounded edge: artery -> the territory the library binds.
+EXPECTED = {
+    "middle_cerebral_artery": "lateral_cerebral_cortex",                 # NBK526002
+    "anterior_cerebral_artery": "medial_cerebral_surface",               # NBK549894
+    "posterior_cerebral_artery": "occipital_lobe",                       # NBK544320
+    "basilar_artery": "brainstem",                                       # NBK540995
+    "anterior_inferior_cerebellar_artery": "lateral_pons",               # NBK448167
+    "lenticulostriate_arteries": "basal_ganglia_internal_capsule",       # NBK526002
+    "ophthalmic_artery": "eye",                                          # NBK537063
+}
+REL = "supplies"
+VAR = "Territory"
+
+
+def _cli_available() -> bool:
+    return CLI.exists()
+
+
+def _run(program: Path) -> dict:
+    out = subprocess.run([str(CLI), str(program)], capture_output=True, text=True,
+                         cwd=str(HERE), timeout=60)
+    assert out.returncode == 0, f"adj-lang-cli failed: {out.stderr}"
+    return json.loads(out.stdout)
+
+
+# ---- 1. the ADJ file is the artifact — every clause grounded, no authored-debt ----
+
+def test_library_is_pure_adj_and_fully_grounded() -> None:
+    text = ADJ.read_text()
+    assert "trust consensus" not in text, "CEREBRAL-ARTERY ships no authored-debt; ground or omit"
+    assert "[FLAG:" not in text
+    edge_count = len(EXPECTED)  # 7
+    assert text.count("    relate ") == edge_count
+    assert text.count("trust authoritative") == edge_count
+    assert text.count('\n        locator "') == edge_count
+    assert text.count('\n        source "') == edge_count
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("locator "):
+            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+    assert not (HERE / "cerebral_artery_edge_ground.py").exists()
+    assert not (HERE / "cerebral-artery-edge-grounding.json").exists()
+    assert not (HERE / "cerebral-artery-edge-manifest.json").exists()
+
+
+# ---- 2. the engine binds each territory with an authoritative citation -------------
+
+def test_engine_binds_every_territory_with_authoritative_citation() -> None:
+    if not _cli_available():
+        return
+    result = _run(QUERY)
+    by_query = {r["query"]: r for r in result["recall"]}
+    for artery, territory in EXPECTED.items():
+        q = f"{REL}({artery}, {VAR})"
+        r = by_query.get(q)
+        assert r is not None and not r["abstained"], f"{q} abstained — edge missing?"
+        bound = {}
+        for a in r["answers"]:
+            bound[a["bindings"][VAR]] = (a.get("citations") or [{}])[0]
+        assert set(bound) == {territory}, f"{artery}: bound {set(bound)} != {{{territory}}}"
+        cite = bound[territory]
+        assert cite.get("trust") == "authoritative", f"{artery}/{territory} not authoritative"
+        assert cite.get("source"), f"{artery}/{territory} has no source span"
+        assert cite.get("locator", "").startswith("https://www.ncbi.nlm.nih.gov/")
+
+
+# ---- 3. an off-vocabulary artery abstains, never fabricates -------------------------
+
+def test_unknown_artery_abstains() -> None:
+    if not _cli_available():
+        return
+    import os
+    import tempfile
+    fd, path = tempfile.mkstemp(suffix=".adj", prefix=".cerebral_q_", dir=HERE)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            # the superior cerebellar artery is a real cerebral artery (supplies the
+            # superior cerebellum) but is deliberately not in the library, so the
+            # engine must abstain rather than fabricate.
+            fh.write(f'import "cerebral-artery-edges.adj"\n? {REL}(superior_cerebellar_artery, ${VAR})\n')
+        res = _run(Path(path))
+        r = res["recall"][0] if res["recall"] else None
+        assert r is not None and r["abstained"], "an ungrounded artery must abstain"
+    finally:
+        os.unlink(path)
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS  {t.__name__}")
+        except AssertionError as exc:
+            failed += 1
+            print(f"  FAIL  {t.__name__}: {exc}")
+    print(f"\ntest_cerebral_artery_recall: {len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())


### PR DESCRIPTION
## What

New pure-ADJ board-recall domain (high-yield **neuroanatomy / stroke localization**): the brain territory each cerebral or orbital artery supplies, via `supplies(artery, territory)`. `cerebral-artery-edges.adj` is the SOLE source of truth — facts + byte-provenance inline, **no Python gate, no JSON, no manifest** (same shape as the merged COLLAGEN/LYSOSOMAL/CORONARY domains). An LLM recalls by writing a tiny query `.adj` that imports the library and asks a binding query; the native `adj-lang` engine answers with the citing clause's source/locator/trust.

## Grounded edges (7)

Each defended by a **verbatim** NCBI StatPearls sentence; **every span independently re-fetched and confirmed byte-stable before commit**.

| artery | territory | source |
|---|---|---|
| middle cerebral artery | lateral_cerebral_cortex | NBK526002 |
| anterior cerebral artery | medial_cerebral_surface | NBK549894 |
| posterior cerebral artery | occipital_lobe | NBK544320 |
| basilar artery | brainstem | NBK540995 |
| anterior inferior cerebellar artery | lateral_pons | NBK448167 |
| lenticulostriate arteries | basal_ganglia_internal_capsule | NBK526002 |
| ophthalmic artery | eye | NBK537063 |

## Faithfulness

Two objects are bound to the territory the cited sentence **actually names**, not the textbook shorthand: `basilar → brainstem` (span says "brainstem", not "pons") and `ophthalmic → eye` (span says "the eye", not "retina"). Grounding to literal bytes beats grounding to the label we went looking for.

## Deferred (honest gap, documented inline)

**PICA → lateral medulla (Wallenberg)** — no single self-contained NCBI sentence co-names PICA AND "lateral medulla" AND a supply relationship; closest used "dorsolateral medulla" across clauses. Omitted rather than grounded on a split/paraphrased span; re-groundable later.

## Tests (`test_cerebral_artery_recall.py`, 3/3 pass locally)

1. file-shape / no-authored-debt — `edge_count == 7`, all `trust authoritative`, all NCBI locators, no JSON/manifest sidecars;
2. engine binds each territory with an authoritative citation carrying a real source span + NCBI locator;
3. off-vocabulary artery (superior cerebellar artery — real but deliberately absent) **abstains** rather than fabricates.

Standalone new-file set — zero cross-PR conflict risk; board_eval scorecard auto-discovers the new `test_*.py`. Security review passed (no vulnerabilities).

🤖 Generated with [Claude Code](https://claude.com/claude-code)