### PR TITLE
feat(mycin-spinal-tract): ADJ-only spinal-cord-tract→function recall library (6 edges)

### DIFF
--- a/code/specs/data/mycin-2026/recall/spinal-tract-edges.adj
+++ b/code/specs/data/mycin-2026/recall/spinal-tract-edges.adj
@@ -1,0 +1,93 @@
+% ============================================================================
+% spinal-tract-edges — the spinal-cord-tract→function knowledge-graph
+% (MYCIN-2026 SPINAL-TRACT).
+% ============================================================================
+% A classic high-yield neuroanatomy board table: each ascending or descending
+% spinal cord tract and the sensory/motor function it carries. "The spinothalamic
+% tract carries which modality?" becomes the binding query
+%     ? carries(spinothalamic_tract, $Function).
+%
+% Direction note: the relation is tract -> the function it carries (`carries`),
+% the board direction for cord-lesion localization — you name the tract and recall
+% the modality (and therefore the deficit a lesion produces). Each tract here maps
+% to ONE canonical function span, so a query binds a single answer.
+%
+% Faithfulness note: each `relate` subject/object is bound to what the cited
+% sentence ACTUALLY names, not the textbook shorthand. The spinocerebellar span
+% names the DORSAL spinocerebellar tract specifically, so the subject is
+% `dorsal_spinocerebellar_tract`; the rubrospinal span says it controls "flexor
+% muscles" (and hand/finger movements), so the object is `flexor_muscles`; the
+% anterior-corticospinal span says "axial muscles of the trunk", so the object is
+% `axial_muscles`. Grounding to the literal bytes beats grounding to the label we
+% went looking for.
+%
+% This file is the SHIPPED ARTIFACT and the SOLE source of truth — no generator,
+% no JSON, no manifest (a pure ADJ-only recall domain, like CEREBRAL-ARTERY/
+% COLLAGEN/CORONARY). Each fact is a `relate` clause whose byte-provenance lives
+% INLINE:
+%     source   — the VERBATIM span copied from the cited page (byte-stable: it
+%                appears character-for-character in the page's normalized text;
+%                every span here was independently re-fetched and confirmed).
+%     locator  — the URL the span was read from (NCBI StatPearls).
+%     trust    — authoritative (a primary, citable reference).
+% An LLM (or a human) recalls a fact by writing a tiny query .adj that `import`s
+% this library and asks a binding query — see spinal-tract-recall.query.adj.
+% Nothing here is asserted "from memory": every edge is defended by a span a
+% reader can re-fetch and check.
+% (See feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+%
+% DEFERRED (honest gap, not authored over): vestibulospinal tract -> balance /
+% posture (extensor antigravity tone). Across the StatPearls pages read, no single
+% self-contained sentence co-names the spelled-out "vestibulospinal tract" AND its
+% function AND the relationship; the closest names the tract only by the
+% abbreviation "LVST" and gives the function as "extensor muscles", which is not a
+% clean self-contained co-naming of vestibulospinal -> balance. Omitted rather than
+% grounded on an abbreviation-only span; re-groundable later from an alternate source.
+% ============================================================================
+
+dictionary spinal_tract_vocab {
+    define tract    : entity   surface "spinal cord tract", "spinal pathway"
+    define function : entity   surface "sensory modality", "motor function carried"
+
+    define carries : relation from tract to function  % the function this tract carries
+}
+
+rulebook spinal_tract_facts {
+    use spinal_tract_vocab
+
+    % --- lateral corticospinal tract -> voluntary motor control ---------------
+    relate carries(lateral_corticospinal_tract, voluntary_motor_control)
+        source "The primary responsibility of the lateral corticospinal tract is to control the voluntary movement of contralateral limbs."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK534818/"
+        trust authoritative
+
+    % --- dorsal column (DCML) -> fine touch, proprioception, vibration --------
+    relate carries(dorsal_column, fine_touch_vibration_proprioception)
+        source "The dorsal column, also known as the dorsal column-medial lemniscus (DCML) pathway, mediates the conscious appreciation of fine touch, 2-point discrimination, conscious proprioception, and vibration sensations throughout the body except for the head."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK507888/"
+        trust authoritative
+
+    % --- spinothalamic tract -> pain and temperature --------------------------
+    relate carries(spinothalamic_tract, pain_and_temperature)
+        source "The spinothalamic tract (STT) is a sensory tract that carries nociceptive, temperature, crude touch, and pressure from our skin to the somatosensory area of the thalamus."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK507824/"
+        trust authoritative
+
+    % --- dorsal spinocerebellar tract -> unconscious proprioception -----------
+    relate carries(dorsal_spinocerebellar_tract, unconscious_proprioception)
+        source "The dorsal spinocerebellar tract (DSCT), also known as the posterior spinocerebellar tract or Flechsig tract, is a somatosensory part of the sensory nervous system that relays unconscious proprioceptive information from the lower limbs and trunk of the body to the cerebellum."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK556013/"
+        trust authoritative
+
+    % --- rubrospinal tract -> flexor muscles (span says "flexor muscles") -----
+    relate carries(rubrospinal_tract, flexor_muscles)
+        source "With the corticospinal tract, the rubrospinal tract controls hand and finger movements in addition to flexor muscles."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK554542/"
+        trust authoritative
+
+    % --- anterior corticospinal tract -> axial muscles (span says "axial") ----
+    relate carries(anterior_corticospinal_tract, axial_muscles)
+        source "Fibers of the anterior corticospinal tract innervate axial muscles of the trunk."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK546614/"
+        trust authoritative
+}

--- a/code/specs/data/mycin-2026/recall/spinal-tract-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/spinal-tract-recall.query.adj
@@ -1,0 +1,21 @@
+% ============================================================================
+% spinal-tract-recall.query.adj — a worked recall query over the spinal-tract library.
+% ============================================================================
+% The shape an LLM (or a student) produces to ANSWER a "which function does tract
+% X carry?" question: it states no neuroanatomy fact — it only `import`s the
+% grounded library and asks binding queries. The native adj-lang engine resolves
+% each `?` against the imported `relate` edges and returns the binding + the citing
+% clause's source/locator/trust. All knowledge is in the library; none is here.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli spinal-tract-recall.query.adj
+% ============================================================================
+
+import "spinal-tract-edges.adj"
+
+? carries(lateral_corticospinal_tract, $Function)    % expect voluntary_motor_control
+? carries(dorsal_column, $Function)                  % expect fine_touch_vibration_proprioception
+? carries(spinothalamic_tract, $Function)            % expect pain_and_temperature
+? carries(dorsal_spinocerebellar_tract, $Function)   % expect unconscious_proprioception
+? carries(rubrospinal_tract, $Function)              % expect flexor_muscles
+? carries(anterior_corticospinal_tract, $Function)   % expect axial_muscles

--- a/code/specs/data/mycin-2026/recall/test_spinal_tract_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_spinal_tract_recall.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""test_spinal_tract_recall.py — the ADJ-only spinal-cord-tract→function recall
+library (MYCIN-2026 SPINAL-TRACT).
+
+A new pure-ADJ recall domain (classic high-yield neuroanatomy board table): the
+sensory/motor function each ascending or descending spinal cord tract carries.
+`spinal-tract-edges.adj` is the SOLE source of truth — facts + byte-provenance
+inline, no Python gate, no JSON, no manifest. This test pins the property that
+matters: the native adj-lang engine, given a query .adj that only `import`s the
+library and asks binding queries (`spinal-tract-recall.query.adj` — the shape an
+LLM produces), binds the grounded function for each tract, each carrying an
+AUTHORITATIVE citation with a real source span + locator. Knowledge lives in ADJ;
+the engine answers.
+
+If the native CLI isn't built (a Python-only CI lane), the engine-backed checks
+skip — the file-shape checks (every clause grounded, no authored-debt) still run.
+
+Run:  python3 test_spinal_tract_recall.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ADJ = HERE / "spinal-tract-edges.adj"
+QUERY = HERE / "spinal-tract-recall.query.adj"
+CLI = HERE.parents[3] / "packages" / "rust" / "target" / "debug" / "adj-lang-cli"
+
+# Every grounded edge: tract -> the function the library binds.
+EXPECTED = {
+    "lateral_corticospinal_tract": "voluntary_motor_control",                 # NBK534818
+    "dorsal_column": "fine_touch_vibration_proprioception",                   # NBK507888
+    "spinothalamic_tract": "pain_and_temperature",                            # NBK507824
+    "dorsal_spinocerebellar_tract": "unconscious_proprioception",             # NBK556013
+    "rubrospinal_tract": "flexor_muscles",                                    # NBK554542
+    "anterior_corticospinal_tract": "axial_muscles",                          # NBK546614
+}
+REL = "carries"
+VAR = "Function"
+
+
+def _cli_available() -> bool:
+    return CLI.exists()
+
+
+def _run(program: Path) -> dict:
+    out = subprocess.run([str(CLI), str(program)], capture_output=True, text=True,
+                         cwd=str(HERE), timeout=60)
+    assert out.returncode == 0, f"adj-lang-cli failed: {out.stderr}"
+    return json.loads(out.stdout)
+
+
+# ---- 1. the ADJ file is the artifact — every clause grounded, no authored-debt ----
+
+def test_library_is_pure_adj_and_fully_grounded() -> None:
+    text = ADJ.read_text()
+    assert "trust consensus" not in text, "SPINAL-TRACT ships no authored-debt; ground or omit"
+    assert "[FLAG:" not in text
+    edge_count = len(EXPECTED)  # 6
+    assert text.count("    relate ") == edge_count
+    assert text.count("trust authoritative") == edge_count
+    assert text.count('\n        locator "') == edge_count
+    assert text.count('\n        source "') == edge_count
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("locator "):
+            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+    assert not (HERE / "spinal_tract_edge_ground.py").exists()
+    assert not (HERE / "spinal-tract-edge-grounding.json").exists()
+    assert not (HERE / "spinal-tract-edge-manifest.json").exists()
+
+
+# ---- 2. the engine binds each function with an authoritative citation --------------
+
+def test_engine_binds_every_function_with_authoritative_citation() -> None:
+    if not _cli_available():
+        return
+    result = _run(QUERY)
+    by_query = {r["query"]: r for r in result["recall"]}
+    for tract, function in EXPECTED.items():
+        q = f"{REL}({tract}, {VAR})"
+        r = by_query.get(q)
+        assert r is not None and not r["abstained"], f"{q} abstained — edge missing?"
+        bound = {}
+        for a in r["answers"]:
+            bound[a["bindings"][VAR]] = (a.get("citations") or [{}])[0]
+        assert set(bound) == {function}, f"{tract}: bound {set(bound)} != {{{function}}}"
+        cite = bound[function]
+        assert cite.get("trust") == "authoritative", f"{tract}/{function} not authoritative"
+        assert cite.get("source"), f"{tract}/{function} has no source span"
+        assert cite.get("locator", "").startswith("https://www.ncbi.nlm.nih.gov/")
+
+
+# ---- 3. an off-vocabulary tract abstains, never fabricates --------------------------
+
+def test_unknown_tract_abstains() -> None:
+    if not _cli_available():
+        return
+    import os
+    import tempfile
+    fd, path = tempfile.mkstemp(suffix=".adj", prefix=".spinal_q_", dir=HERE)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            # the tectospinal tract is a real spinal cord tract (coordinates head
+            # and eye movements toward stimuli) but is deliberately not in the
+            # library, so the engine must abstain rather than fabricate.
+            fh.write(f'import "spinal-tract-edges.adj"\n? {REL}(tectospinal_tract, ${VAR})\n')
+        res = _run(Path(path))
+        r = res["recall"][0] if res["recall"] else None
+        assert r is not None and r["abstained"], "an ungrounded tract must abstain"
+    finally:
+        os.unlink(path)
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS  {t.__name__}")
+        except AssertionError as exc:
+            failed += 1
+            print(f"  FAIL  {t.__name__}: {exc}")
+    print(f"\ntest_spinal_tract_recall: {len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())


### PR DESCRIPTION
## What

New pure-ADJ board-recall domain (high-yield **neuroanatomy / cord-lesion localization**): the sensory/motor function each spinal cord tract carries, via `carries(tract, function)`. `spinal-tract-edges.adj` is the SOLE source of truth — facts + byte-provenance inline, **no Python gate, no JSON, no manifest** (same shape as the merged CEREBRAL-ARTERY/COLLAGEN/CORONARY domains). An LLM recalls by writing a tiny query `.adj` that imports the library and asks a binding query; the native `adj-lang` engine answers with the citing clause's source/locator/trust.

## Grounded edges (6)

Each defended by a **verbatim** NCBI StatPearls sentence; **every span independently re-fetched and confirmed byte-stable before commit**.

| tract | function | source |
|---|---|---|
| lateral corticospinal tract | voluntary_motor_control | NBK534818 |
| dorsal column (DCML) | fine_touch_vibration_proprioception | NBK507888 |
| spinothalamic tract | pain_and_temperature | NBK507824 |
| dorsal spinocerebellar tract | unconscious_proprioception | NBK556013 |
| rubrospinal tract | flexor_muscles | NBK554542 |
| anterior corticospinal tract | axial_muscles | NBK546614 |

## Faithfulness

Subject/object bound to what the cited sentence **actually names** — the span names the **dorsal** spinocerebellar tract (subject), says the rubrospinal tract controls "flexor muscles" (object), and "axial muscles of the trunk" for the anterior corticospinal tract. Grounding to literal bytes beats the label we went looking for.

## Deferred (honest gap, documented inline)

**vestibulospinal tract → balance/posture** — no single self-contained NCBI sentence co-names the spelled-out "vestibulospinal tract" AND its function AND the relationship; the closest named the tract only by the abbreviation "LVST" and gave the function as "extensor muscles". Omitted rather than grounded on an abbreviation-only span; re-groundable later.

## Tests (`test_spinal_tract_recall.py`, 3/3 pass locally)

1. file-shape / no-authored-debt — `edge_count == 6`, all `trust authoritative`, all NCBI locators, no JSON/manifest sidecars;
2. engine binds each function with an authoritative citation carrying a real source span + NCBI locator;
3. off-vocabulary tract (tectospinal — real but deliberately absent) **abstains** rather than fabricates.

Standalone new-file set — zero cross-PR conflict risk; board_eval scorecard auto-discovers the new `test_*.py`. Security review passed (no vulnerabilities).

🤖 Generated with [Claude Code](https://claude.com/claude-code)