### PR TITLE
feat(mycin-organelle): ADJ-only cell-organelle→function recall library (6 edges)

### DIFF
--- a/code/specs/data/mycin-2026/recall/organelle-edges.adj
+++ b/code/specs/data/mycin-2026/recall/organelle-edges.adj
@@ -1,0 +1,97 @@
+% ============================================================================
+% organelle-edges — the cell-organelle→function knowledge-graph
+% (MYCIN-2026 ORGANELLE).
+% ============================================================================
+% A foundational high-yield cell-biology / biochemistry board table: each
+% membrane-bound (or ribonucleoprotein) organelle and the principal cellular
+% function it performs. "Which organelle produces ATP?" becomes the binding query
+%     ? performs(mitochondria, $Function).
+%
+% Direction note: the relation is organelle -> the function it performs
+% (`performs`). Each organelle here maps to ONE canonical function span, so a
+% query binds a single answer.
+%
+% Faithfulness note: each `relate` subject/object is bound to what the cited
+% sentence ACTUALLY names. The mitochondria span attributes ATP synthesis to the
+% "mitochondrial matrix" (the full adjectival form of the organelle naming its
+% interior compartment), so it grounds mitochondria->ATP by combined bytes. The
+% Golgi span appears in the source with markdown hyperlink brackets around
+% "proteins", "ER", and "plasma membrane"; those are a fetch-conversion artifact —
+% the real page bytes are the plain words, reproduced here exactly (the same
+% defeasible byte-grounding the framework uses for gene-symbol italics elsewhere).
+%
+% This file is the SHIPPED ARTIFACT and the SOLE source of truth — no generator,
+% no JSON, no manifest (a pure ADJ-only recall domain, like SPINAL-TRACT/
+% CEREBRAL-ARTERY/COLLAGEN). Each fact is a `relate` clause whose byte-provenance
+% lives INLINE:
+%     source   — the VERBATIM span copied from the cited page (byte-stable: it
+%                appears character-for-character in the page's normalized text;
+%                every span here was independently re-fetched and confirmed).
+%     locator  — the URL the span was read from (NCBI StatPearls / Cooper, The Cell).
+%     trust    — authoritative (a primary, citable reference).
+% An LLM (or a human) recalls a fact by writing a tiny query .adj that `import`s
+% this library and asks a binding query — see organelle-recall.query.adj.
+% Nothing here is asserted "from memory": every edge is defended by a span a
+% reader can re-fetch and check.
+% (See feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+%
+% DEFERRED (honest gaps, not authored over):
+%   - rough endoplasmic reticulum -> protein synthesis. On NBK563126 the only
+%     sentence co-naming the organelle with protein synthesis uses the
+%     abbreviation "RER" ("The RER plays a significant role in the synthesis of
+%     various proteins."), never the spelled-out "rough endoplasmic reticulum".
+%   - smooth endoplasmic reticulum -> lipid/steroid synthesis. On NBK9889 the
+%     only co-naming uses the abbreviation "smooth ER" AND is indirect (steroids
+%     "are synthesized ... in the ER", with smooth ER merely "found in" steroid-
+%     producing cells), not a direct organelle->function statement.
+% Both omitted rather than grounded on abbreviation-only / indirect spans
+% (consistent with the SPINAL-TRACT vestibulospinal "LVST" deferral); re-groundable
+% later from an alternate source that spells the organelle out.
+% ============================================================================
+
+dictionary organelle_vocab {
+    define organelle : entity   surface "cell organelle", "subcellular structure"
+    define function  : entity   surface "cellular function", "organelle role"
+
+    define performs : relation from organelle to function  % the function this organelle performs
+}
+
+rulebook organelle_facts {
+    use organelle_vocab
+
+    % --- mitochondria -> ATP production (span names the mitochondrial matrix) --
+    relate performs(mitochondria, atp_production)
+        source "The majority of ATP synthesis occurs during cellular respiration in the mitochondrial matrix, generating approximately 32 ATP molecules per glucose molecule oxidized."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK553175/"
+        trust authoritative
+
+    % --- Golgi apparatus -> protein modification & sorting --------------------
+    relate performs(golgi_apparatus, protein_modification_and_sorting)
+        source "The Golgi apparatus, or Golgi complex, functions as a factory in which proteins received from the ER are further processed and sorted for transport to their eventual destinations: lysosomes, the plasma membrane, or secretion."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK9838/"
+        trust authoritative
+
+    % --- lysosome -> intracellular degradation / digestion --------------------
+    relate performs(lysosome, intracellular_degradation)
+        source "Lysosomes function as the digestive system of the cell, serving both to degrade material taken up from outside the cell and to digest obsolete components of the cell itself."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK9953/"
+        trust authoritative
+
+    % --- peroxisome -> fatty acid oxidation -----------------------------------
+    relate performs(peroxisome, fatty_acid_oxidation)
+        source "The peroxisomes are involved in beta-oxidation of very-long-chain fatty acids (VLCFA), alpha oxidation of branched-chain fatty acids, catabolism of amino acids and ethanol, biosynthesis of bile acids, steroid hormones, gluconeogenesis, and plasmalogen formation which are important constituents of the cell membrane and myelin."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK560676/"
+        trust authoritative
+
+    % --- ribosome -> protein synthesis ----------------------------------------
+    relate performs(ribosome, protein_synthesis)
+        source "Ribosomes are the sites of protein synthesis in both prokaryotic and eukaryotic cells."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK9849/"
+        trust authoritative
+
+    % --- nucleus -> genetic material storage ----------------------------------
+    relate performs(nucleus, genetic_material_storage)
+        source "By housing the cell's genome, the nucleus serves both as the repository of genetic information and as the cell's control center."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK9845/"
+        trust authoritative
+}

--- a/code/specs/data/mycin-2026/recall/organelle-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/organelle-recall.query.adj
@@ -1,0 +1,22 @@
+% ============================================================================
+% organelle-recall.query.adj — a worked recall query over the organelle library.
+% ============================================================================
+% The shape an LLM (or a student) produces to ANSWER a "which function does
+% organelle X perform?" question: it states no cell-biology fact — it only
+% `import`s the grounded library and asks binding queries. The native adj-lang
+% engine resolves each `?` against the imported `relate` edges and returns the
+% binding + the citing clause's source/locator/trust. All knowledge is in the
+% library; none is here.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli organelle-recall.query.adj
+% ============================================================================
+
+import "organelle-edges.adj"
+
+? performs(mitochondria, $Function)      % expect atp_production
+? performs(golgi_apparatus, $Function)   % expect protein_modification_and_sorting
+? performs(lysosome, $Function)          % expect intracellular_degradation
+? performs(peroxisome, $Function)        % expect fatty_acid_oxidation
+? performs(ribosome, $Function)          % expect protein_synthesis
+? performs(nucleus, $Function)           % expect genetic_material_storage

--- a/code/specs/data/mycin-2026/recall/test_organelle_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_organelle_recall.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""test_organelle_recall.py — the ADJ-only cell-organelle→function recall library
+(MYCIN-2026 ORGANELLE).
+
+A new pure-ADJ recall domain (foundational high-yield cell-biology/biochem board
+table): the principal cellular function each organelle performs. `organelle-edges.adj`
+is the SOLE source of truth — facts + byte-provenance inline, no Python gate, no
+JSON, no manifest. This test pins the property that matters: the native adj-lang
+engine, given a query .adj that only `import`s the library and asks binding queries
+(`organelle-recall.query.adj` — the shape an LLM produces), binds the grounded
+function for each organelle, each carrying an AUTHORITATIVE citation with a real
+source span + locator. Knowledge lives in ADJ; the engine answers.
+
+If the native CLI isn't built (a Python-only CI lane), the engine-backed checks
+skip — the file-shape checks (every clause grounded, no authored-debt) still run.
+
+Run:  python3 test_organelle_recall.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ADJ = HERE / "organelle-edges.adj"
+QUERY = HERE / "organelle-recall.query.adj"
+CLI = HERE.parents[3] / "packages" / "rust" / "target" / "debug" / "adj-lang-cli"
+
+# Every grounded edge: organelle -> the function the library binds.
+EXPECTED = {
+    "mitochondria": "atp_production",                              # NBK553175
+    "golgi_apparatus": "protein_modification_and_sorting",        # NBK9838
+    "lysosome": "intracellular_degradation",                      # NBK9953
+    "peroxisome": "fatty_acid_oxidation",                         # NBK560676
+    "ribosome": "protein_synthesis",                              # NBK9849
+    "nucleus": "genetic_material_storage",                        # NBK9845
+}
+REL = "performs"
+VAR = "Function"
+
+
+def _cli_available() -> bool:
+    return CLI.exists()
+
+
+def _run(program: Path) -> dict:
+    out = subprocess.run([str(CLI), str(program)], capture_output=True, text=True,
+                         cwd=str(HERE), timeout=60)
+    assert out.returncode == 0, f"adj-lang-cli failed: {out.stderr}"
+    return json.loads(out.stdout)
+
+
+# ---- 1. the ADJ file is the artifact — every clause grounded, no authored-debt ----
+
+def test_library_is_pure_adj_and_fully_grounded() -> None:
+    text = ADJ.read_text()
+    assert "trust consensus" not in text, "ORGANELLE ships no authored-debt; ground or omit"
+    assert "[FLAG:" not in text
+    edge_count = len(EXPECTED)  # 6
+    assert text.count("    relate ") == edge_count
+    assert text.count("trust authoritative") == edge_count
+    assert text.count('\n        locator "') == edge_count
+    assert text.count('\n        source "') == edge_count
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("locator "):
+            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+    assert not (HERE / "organelle_edge_ground.py").exists()
+    assert not (HERE / "organelle-edge-grounding.json").exists()
+    assert not (HERE / "organelle-edge-manifest.json").exists()
+
+
+# ---- 2. the engine binds each function with an authoritative citation --------------
+
+def test_engine_binds_every_function_with_authoritative_citation() -> None:
+    if not _cli_available():
+        return
+    result = _run(QUERY)
+    by_query = {r["query"]: r for r in result["recall"]}
+    for organelle, function in EXPECTED.items():
+        q = f"{REL}({organelle}, {VAR})"
+        r = by_query.get(q)
+        assert r is not None and not r["abstained"], f"{q} abstained — edge missing?"
+        bound = {}
+        for a in r["answers"]:
+            bound[a["bindings"][VAR]] = (a.get("citations") or [{}])[0]
+        assert set(bound) == {function}, f"{organelle}: bound {set(bound)} != {{{function}}}"
+        cite = bound[function]
+        assert cite.get("trust") == "authoritative", f"{organelle}/{function} not authoritative"
+        assert cite.get("source"), f"{organelle}/{function} has no source span"
+        assert cite.get("locator", "").startswith("https://www.ncbi.nlm.nih.gov/")
+
+
+# ---- 3. an off-vocabulary organelle abstains, never fabricates ----------------------
+
+def test_unknown_organelle_abstains() -> None:
+    if not _cli_available():
+        return
+    import os
+    import tempfile
+    fd, path = tempfile.mkstemp(suffix=".adj", prefix=".organelle_q_", dir=HERE)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            # the centrosome is a real organelle (organizes microtubules / mitotic
+            # spindle) but is deliberately not in the library, so the engine must
+            # abstain rather than fabricate.
+            fh.write(f'import "organelle-edges.adj"\n? {REL}(centrosome, ${VAR})\n')
+        res = _run(Path(path))
+        r = res["recall"][0] if res["recall"] else None
+        assert r is not None and r["abstained"], "an ungrounded organelle must abstain"
+    finally:
+        os.unlink(path)
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS  {t.__name__}")
+        except AssertionError as exc:
+            failed += 1
+            print(f"  FAIL  {t.__name__}: {exc}")
+    print(f"\ntest_organelle_recall: {len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())


### PR DESCRIPTION
## What

New **pure-ADJ** board-recall domain (foundational cell-biology / biochemistry): the principal cellular function each organelle performs, via `performs(organelle, function)`. `organelle-edges.adj` is the **sole source of truth** — facts + byte-provenance inline, no Python gate, no JSON, no manifest (same shape as SPINAL-TRACT / CEREBRAL-ARTERY / COLLAGEN). An LLM recalls by writing a tiny query `.adj` that imports the library and asks a binding query; the native `adj-lang` engine answers with the citing clause's `source`/`locator`/`trust`.

## Edges (6 grounded — each defended by a verbatim NCBI sentence, every span independently re-fetched and confirmed byte-stable)

| organelle | function | locator |
|---|---|---|
| mitochondria | atp_production | NBK553175 |
| golgi_apparatus | protein_modification_and_sorting | NBK9838 |
| lysosome | intracellular_degradation | NBK9953 |
| peroxisome | fatty_acid_oxidation | NBK560676 |
| ribosome | protein_synthesis | NBK9849 |
| nucleus | genetic_material_storage | NBK9845 |

## Faithfulness

- **mitochondria** — the span attributes ATP synthesis to the *"mitochondrial matrix"* (the full adjectival form naming the organelle's interior) → combined-byte grounding.
- **Golgi** — the source sentence carries markdown hyperlink brackets around a few words (fetch artifact); the real page bytes are the plain words, reproduced exactly (same defeasible byte-grounding used for gene-symbol italics elsewhere).

## Deferred (honest gaps, documented inline)

- **rough ER → protein synthesis** and **smooth ER → lipid/steroid synthesis**: on their pages the only organelle↔function co-naming uses the abbreviations *"RER"* / *"smooth ER"* (never the spelled-out organelle), and the smooth-ER one is additionally indirect. Omitted rather than grounded on abbreviation-only / indirect spans (consistent with the SPINAL-TRACT vestibulospinal "LVST" deferral); re-groundable later from a source that spells the organelle out.

## Tests (`test_organelle_recall.py`, 3/3 pass locally)

1. file-shape / no-authored-debt (edge_count == 6, all `trust authoritative`, all NCBI locators, no JSON/manifest sidecars);
2. engine binds each function with an authoritative citation carrying a real `source` span + NCBI `locator`;
3. off-vocabulary organelle (`centrosome` — real but deliberately absent) abstains rather than fabricates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)