### PR TITLE
feat(r-lang): R-41 — triangular solves (backsolve/forwardsolve)

### DIFF
--- a/code/packages/rust/r-runtime/CHANGELOG.md
+++ b/code/packages/rust/r-runtime/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.36.0] - 2026-06-25
+
+### Added (via the shared `s-runtime`)
+
+- **R-41 — `backsolve(r, x)` / `forwardsolve(l, x)` (triangular solves)**,
+  reached through ordinary R syntax. `backsolve` solves the upper-triangular
+  system `r %*% y = x` by back-substitution; `forwardsolve` solves the
+  lower-triangular `l %*% y = x` by forward-substitution.
+  - `backsolve(matrix(c(2,0,1,3), nrow=2), c(5,9))` → `c(1, 3)`, and
+    `r %*% y` reconstructs `c(5,9)`. The right-hand side may be a vector (→ a
+    vector) or a matrix (→ one solved column per right-hand side).
+  - A zero on the diagonal is a clean **singular**-matrix error (never `NaN`/a
+    panic); non-square / dimension-mismatched inputs error cleanly too.
+  - **Reuse**: the `square_matrix` reader (shared with `solve`/`det`/`chol`) and
+    the `solve`-style RHS handling.
+  - **Deferred to R-42:** `k =`, `transpose = TRUE`, `upper.tri = FALSE`.
+
 ## [0.35.0] - 2026-06-22
 
 ### Added (via the shared `s-runtime`)

--- a/code/packages/rust/r-runtime/README.md
+++ b/code/packages/rust/r-runtime/README.md
@@ -317,6 +317,17 @@ reconstructs `x`; `chol(diag(3))` is the identity. The diagonal pivot is checked
 matrix errors before any indexing. `pivot=TRUE` (pivoted Cholesky), `chol2inv()`,
 and complex (Hermitian) matrices are deferred to **R-41**.
 
+**R-41 — `backsolve(r, x)` / `forwardsolve(l, x)` (triangular solves)** solve an
+upper- (resp. lower-) triangular system `r %*% y = x` by back- (resp. forward-)
+substitution, through the shared `s-runtime`. The right-hand side may be a vector
+(→ a vector) or a matrix (→ one solved column per right-hand side), the same
+contract as `solve`. `backsolve(matrix(c(2,0,1,3), nrow=2), c(5,9))` is `c(1, 3)`,
+and `r %*% y` reconstructs `c(5,9)`. They reuse the `square_matrix` reader and the
+`solve`-style RHS handling; a zero on the diagonal is a clean *singular*-matrix
+error (never `NaN`/a panic), and non-square / dimension-mismatched inputs error
+before any indexing. The `k=`, `transpose=TRUE`, and `upper.tri=FALSE` options are
+deferred to **R-42**.
+
 **R-44 — base R Date support** adds R's first calendar type, again through the
 shared `s-runtime`. A **`Date`** is *not* a new value kind: it is a numeric vector
 of **days since the Unix epoch 1970-01-01** carrying class `"Date"` (the existing

--- a/code/packages/rust/r-runtime/src/lib.rs
+++ b/code/packages/rust/r-runtime/src/lib.rs
@@ -3374,6 +3374,66 @@ mod tests {
         assert!(format!("{err}").to_lowercase().contains("square"));
     }
 
+    // --- R-41: backsolve / forwardsolve (triangular solves, R syntax) ---
+
+    #[test]
+    fn backsolve_vector_through_r_syntax() {
+        // r upper-triangular [[2,1],[0,3]]; solve r %*% y = c(5,9) -> c(1,3).
+        let y = nums("backsolve(matrix(c(2,0,1,3), nrow = 2), c(5,9))\n");
+        assert_eq!(y.len(), 2);
+        assert!((y[0] - 1.0).abs() < 1e-9);
+        assert!((y[1] - 3.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn forwardsolve_vector_through_r_syntax() {
+        // l lower-triangular [[2,0],[1,3]]; solve l %*% y = c(4,11) -> c(2,3).
+        let y = nums("forwardsolve(matrix(c(2,1,0,3), nrow = 2), c(4,11))\n");
+        assert_eq!(y.len(), 2);
+        assert!((y[0] - 2.0).abs() < 1e-9);
+        assert!((y[1] - 3.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn backsolve_round_trip_through_r_syntax() {
+        // r %*% backsolve(r, x) reconstructs x within tolerance.
+        let rhs = nums(
+            "r <- matrix(c(2,0,1,3), nrow = 2)\nas.numeric(r %*% backsolve(r, c(5,9)))\n",
+        );
+        assert!((rhs[0] - 5.0).abs() < 1e-9 && (rhs[1] - 9.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn forwardsolve_round_trip_through_r_syntax() {
+        let rhs = nums(
+            "l <- matrix(c(2,1,0,3), nrow = 2)\nas.numeric(l %*% forwardsolve(l, c(4,11)))\n",
+        );
+        assert!((rhs[0] - 4.0).abs() < 1e-9 && (rhs[1] - 11.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn backsolve_matrix_rhs_through_r_syntax() {
+        // Two RHS columns: c(5,9) -> c(1,3) and c(2,6) -> c(0,2).
+        let (data, nrow, ncol) = matrix_data(
+            "backsolve(matrix(c(2,0,1,3), nrow = 2), matrix(c(5,9,2,6), nrow = 2))\n",
+        );
+        assert_eq!((nrow, ncol), (2, 2));
+        assert!(chol_max_abs_diff(&data, &[1.0, 3.0, 0.0, 2.0]) < 1e-9);
+    }
+
+    #[test]
+    fn backsolve_singular_errors_through_r_syntax() {
+        // r[1,1] = 0 -> division by zero in back-substitution -> clean error.
+        let err = eval_r("backsolve(matrix(c(0,0,1,3), nrow = 2), c(1,2))\n").unwrap_err();
+        assert!(format!("{err}").to_lowercase().contains("singular"));
+    }
+
+    #[test]
+    fn forwardsolve_non_square_errors_through_r_syntax() {
+        let err = eval_r("forwardsolve(matrix(1:6, nrow = 2), c(1,2))\n").unwrap_err();
+        assert!(format!("{err}").to_lowercase().contains("square"));
+    }
+
     // --- R-35: ordered factors & cut() label polish (R syntax) ----------
 
     #[test]

--- a/code/packages/rust/s-runtime/CHANGELOG.md
+++ b/code/packages/rust/s-runtime/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.37.0] - 2026-06-25
+
+### Added
+
+- **`backsolve(r, x)` / `forwardsolve(l, x)` — triangular solves (R-41)** —
+  available to both S and R through the shared tree-walker. `backsolve` solves
+  the **upper**-triangular system `r %*% y = x` by back-substitution;
+  `forwardsolve` solves the **lower**-triangular system `l %*% y = x` by
+  forward-substitution. Only the relevant triangle of the coefficient matrix is
+  read.
+  - **Right-hand side.** `x` may be a length-`n` vector (→ a vector result) or an
+    `n × m` matrix (→ an `n × m` result, one solved column per right-hand side) —
+    the same shape contract as `solve`. e.g.
+    `backsolve(matrix(c(2,0,1,3), nrow=2), c(5,9))` → `c(1, 3)` (and
+    `r %*% y == c(5,9)`); a two-column RHS solves both systems at once.
+  - **Algorithm.** Column-major back/forward substitution:
+    `y[i] = (x[i] − Σ_{j>i} R[i,j]·y[j]) / R[i,i]` (back) or
+    `y[i] = (x[i] − Σ_{j<i} L[i,j]·y[j]) / L[i,i]` (forward).
+  - **Reuse.** Built on the existing `square_matrix` reader (shared with
+    `solve`/`det`/`chol`) and the `solve`-style vector/matrix RHS handling.
+  - **Errors (no panics).** A zero on the diagonal makes the system *singular* —
+    a clean error, never a divide-by-zero `NaN`/`Inf`. A non-square or
+    non-numeric coefficient matrix, an `NA`, or a right-hand side whose
+    rows/length don't match `n` are all clean errors raised before any indexing.
+  - **Bounds.** The column count is capped at `MAX_SOLVE_DIM` (as in `solve`) so
+    a wide right-hand side can't blow past the work budget.
+  - **Deferred to R-42:** the `k =`, `transpose = TRUE`, and `upper.tri = FALSE`
+    options of base R's `backsolve`/`forwardsolve`.
+
 ## [0.36.0] - 2026-06-22
 
 ### Added

--- a/code/packages/rust/s-runtime/README.md
+++ b/code/packages/rust/s-runtime/README.md
@@ -310,6 +310,14 @@ a hand-written loop. See [What "S-flavored" means here](#what-s-flavored-means-h
   triangle errors too. `chol(matrix(c(4,2,2,3), nrow=2))` is `[[2,1],[0,√2]]`
   with `t(R) %*% R` reconstructing the input; `chol(diag(3))` is the identity.
   `pivot=TRUE`, `chol2inv()`, and complex matrices are deferred to R-41.
+- **Triangular solves** (R-41): **`backsolve(r, x)`** / **`forwardsolve(l, x)`** —
+  solve an upper- (resp. lower-) triangular system `r %*% y = x` by back- (resp.
+  forward-) substitution. The right-hand side `x` is a length-`n` vector (→ a
+  vector) or an `n × m` matrix (→ one solved column per RHS), the same contract as
+  `solve`. `backsolve(matrix(c(2,0,1,3), nrow=2), c(5,9))` is `c(1, 3)` and
+  `r %*% y` reconstructs `c(5,9)`. Reuses the `square_matrix` reader; a zero on the
+  diagonal is a clean *singular*-matrix error (no `NaN`/panic). `k=`,
+  `transpose=TRUE`, and `upper.tri=FALSE` are deferred to R-42.
 - **Kronecker product** (R-38): **`kronecker(X, Y)`** — the `(m·p)×(n·q)`
   block-outer product of an `m×n` `X` and a `p×q` `Y`, where block `(i, j)` is
   `X[i,j] · Y` and `result[(i-1)·p+k, (j-1)·q+l] = X[i,j] · Y[k,l]`

--- a/code/packages/rust/s-runtime/src/builtins.rs
+++ b/code/packages/rust/s-runtime/src/builtins.rs
@@ -299,6 +299,13 @@ pub fn install(env: &Env) {
     // Reuses the `square_matrix` reader (shared with solve/det) and the
     // SValue::Matrix constructor. pivot=TRUE / chol2inv / complex deferred to R-41.
     define(env, "chol", builtin("chol", b_chol));
+    // Triangular solves (R-41): backsolve solves an upper-triangular system,
+    // forwardsolve a lower-triangular one, by back/forward substitution. Both
+    // reuse `square_matrix` + the solve-style vector/matrix RHS handling; a zero
+    // on the diagonal is a clean "singular" error. transpose=/k=/upper.tri=
+    // deferred to R-42.
+    define(env, "backsolve", builtin("backsolve", b_backsolve));
+    define(env, "forwardsolve", builtin("forwardsolve", b_forwardsolve));
 }
 
 // ===========================================================================
@@ -1494,6 +1501,133 @@ fn b_chol(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
         nrow: n,
         ncol: n,
     })
+}
+
+/// `backsolve(r, x)` / `forwardsolve(l, x)` — solve a TRIANGULAR linear system
+/// `R %*% y = x` (`backsolve`, `r` upper-triangular) or `L %*% y = x`
+/// (`forwardsolve`, `l` lower-triangular) for `y`, by back/forward substitution.
+///
+/// Only the relevant triangle of the coefficient matrix is read. The right-hand
+/// side `x` is either a length-`n` vector (→ a vector result) or an `n × m`
+/// matrix (→ an `n × m` result, one solved column per right-hand side) — the
+/// same shape contract as [`b_solve`]. A zero on the diagonal makes the system
+/// singular: a clean error, never a divide-by-zero `NaN`/`Inf` or a panic.
+///
+/// Worked example (`backsolve`, upper-triangular, column-major):
+///   R = [[2,1],[0,3]],  x = (5, 9)
+///     y[2] = 9 / 3         = 3
+///     y[1] = (5 − 1·3) / 2 = 1      ⇒  y = (1, 3),  and  R %*% y == x.
+fn triangular_solve(args: &[Arg], who: &str, upper: bool) -> SResult<SValue> {
+    // The coefficient matrix: reuse the det/solve/chol square-matrix reader, which
+    // rejects non-matrix, non-square and over-MAX_SOLVE_DIM inputs up front and
+    // returns the data column-major (entry (row i, col j) is at index `j*n + i`).
+    let (a, n) = square_matrix(first_positional(args)?, who)?;
+    if a.iter().any(|v| is_na_real(*v)) {
+        return Err(SError::BadArgs(format!(
+            "{who}: NA in the coefficient matrix"
+        )));
+    }
+
+    // The right-hand side `x`: a matrix (→ matrix result, `m` columns) or a
+    // vector (→ vector result, a single column). Same handling as `solve`.
+    let (b, m, b_is_vector) = match nth_positional(args, 1) {
+        Some(x_val) => {
+            if let Some((bd, bnr, bnc)) = matrix_parts(x_val) {
+                if bnr != n {
+                    return Err(SError::BadArgs(format!(
+                        "{who}: the right-hand side must have {n} rows (got {bnr})"
+                    )));
+                }
+                (bd.data().to_vec(), bnc, false)
+            } else {
+                let bd = x_val.as_double()?;
+                if bd.len() != n {
+                    return Err(SError::BadArgs(format!(
+                        "{who}: the right-hand side must have length {n} (got {})",
+                        bd.len()
+                    )));
+                }
+                (bd.data().to_vec(), 1, true)
+            }
+        }
+        None => {
+            return Err(SError::BadArgs(format!(
+                "{who}: missing the right-hand side 'x'"
+            )))
+        }
+    };
+    if b.iter().any(|v| is_na_real(*v)) {
+        return Err(SError::BadArgs(format!(
+            "{who}: NA in the right-hand side"
+        )));
+    }
+    // The substitution is O(n²·m); cap the column count like `solve` does so a
+    // wide right-hand side can't blow past the MAX_SOLVE_DIM work budget.
+    if m > MAX_SOLVE_DIM {
+        return Err(SError::Index(format!(
+            "{who}: too many right-hand sides ({m}; limit {MAX_SOLVE_DIM})"
+        )));
+    }
+
+    // Solve each right-hand-side column independently. Visit the rows in the order
+    // that makes the already-solved entries available: bottom-up for an upper-
+    // triangular `R`, top-down for a lower-triangular `L`.
+    let mut y = vec![0.0; n * m];
+    for col in 0..m {
+        if upper {
+            for i in (0..n).rev() {
+                let mut s = b[col * n + i];
+                for j in (i + 1)..n {
+                    s -= a[j * n + i] * y[col * n + j];
+                }
+                let diag = a[i * n + i];
+                if diag == 0.0 {
+                    return Err(SError::BadArgs(format!(
+                        "{who}: the matrix is singular (zero on the diagonal, position {})",
+                        i + 1
+                    )));
+                }
+                y[col * n + i] = s / diag;
+            }
+        } else {
+            for i in 0..n {
+                let mut s = b[col * n + i];
+                for j in 0..i {
+                    s -= a[j * n + i] * y[col * n + j];
+                }
+                let diag = a[i * n + i];
+                if diag == 0.0 {
+                    return Err(SError::BadArgs(format!(
+                        "{who}: the matrix is singular (zero on the diagonal, position {})",
+                        i + 1
+                    )));
+                }
+                y[col * n + i] = s / diag;
+            }
+        }
+    }
+
+    if b_is_vector {
+        Ok(SValue::doubles(y))
+    } else {
+        Ok(SValue::Matrix {
+            data: Double::from_values(y),
+            nrow: n,
+            ncol: m,
+        })
+    }
+}
+
+/// `backsolve(r, x)` — solve the UPPER-triangular system `r %*% y = x`.
+/// See [`triangular_solve`].
+fn b_backsolve(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    triangular_solve(args, "backsolve", true)
+}
+
+/// `forwardsolve(l, x)` — solve the LOWER-triangular system `l %*% y = x`.
+/// See [`triangular_solve`].
+fn b_forwardsolve(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    triangular_solve(args, "forwardsolve", false)
 }
 
 // ===========================================================================

--- a/code/packages/rust/s-runtime/src/lib.rs
+++ b/code/packages/rust/s-runtime/src/lib.rs
@@ -2817,6 +2817,115 @@ mod r30_ordering {
         let err = eval_s("chol(matrix(c(0,0,0,1), nrow = 2))\n").unwrap_err();
         assert!(format!("{err}").contains("positive definite"));
     }
+
+    // --- R-41: backsolve / forwardsolve (triangular solves) -------------
+
+    #[test]
+    fn backsolve_vector_rhs() {
+        // r = matrix(c(2,0,1,3), nrow=2) is upper-triangular [[2,1],[0,3]].
+        // Solve r %*% y = c(5,9): y[2]=9/3=3; y[1]=(5-1*3)/2=1 -> c(1,3).
+        let y = nums("backsolve(matrix(c(2,0,1,3), nrow = 2), c(5,9))\n");
+        assert_eq!(y.len(), 2);
+        assert!((y[0] - 1.0).abs() < 1e-9);
+        assert!((y[1] - 3.0).abs() < 1e-9);
+        // Round-trip: r %*% y reconstructs the right-hand side.
+        let rhs = nums(
+            "r <- matrix(c(2,0,1,3), nrow = 2)\ny <- backsolve(r, c(5,9))\nas.numeric(r %*% y)\n",
+        );
+        assert!((rhs[0] - 5.0).abs() < 1e-9 && (rhs[1] - 9.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn forwardsolve_vector_rhs() {
+        // l = matrix(c(2,1,0,3), nrow=2) is lower-triangular [[2,0],[1,3]].
+        // Solve l %*% y = c(4,11): y[1]=4/2=2; y[2]=(11-1*2)/3=3 -> c(2,3).
+        let y = nums("forwardsolve(matrix(c(2,1,0,3), nrow = 2), c(4,11))\n");
+        assert_eq!(y.len(), 2);
+        assert!((y[0] - 2.0).abs() < 1e-9);
+        assert!((y[1] - 3.0).abs() < 1e-9);
+        let rhs = nums(
+            "l <- matrix(c(2,1,0,3), nrow = 2)\ny <- forwardsolve(l, c(4,11))\nas.numeric(l %*% y)\n",
+        );
+        assert!((rhs[0] - 4.0).abs() < 1e-9 && (rhs[1] - 11.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn backsolve_matrix_rhs_multi_column() {
+        // Two right-hand sides at once: x is 2x2 with columns c(5,9) and c(2,6).
+        // Column 1 -> c(1,3) (as above); column 2: y[2]=6/3=2, y[1]=(2-1*2)/2=0.
+        let (data, nrow, ncol) = matrix_data(
+            "backsolve(matrix(c(2,0,1,3), nrow = 2), matrix(c(5,9,2,6), nrow = 2))\n",
+        );
+        assert_eq!((nrow, ncol), (2, 2));
+        // Column-major: [y1_c1, y2_c1, y1_c2, y2_c2] = [1,3,0,2].
+        assert!((data[0] - 1.0).abs() < 1e-9);
+        assert!((data[1] - 3.0).abs() < 1e-9);
+        assert!((data[2] - 0.0).abs() < 1e-9);
+        assert!((data[3] - 2.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn forwardsolve_matrix_rhs_multi_column() {
+        // l = [[2,0],[1,3]]; x columns c(4,11) -> c(2,3) and c(2,8) -> y1=1, y2=(8-1)/3.
+        let (data, nrow, ncol) = matrix_data(
+            "forwardsolve(matrix(c(2,1,0,3), nrow = 2), matrix(c(4,11,2,8), nrow = 2))\n",
+        );
+        assert_eq!((nrow, ncol), (2, 2));
+        assert!((data[0] - 2.0).abs() < 1e-9);
+        assert!((data[1] - 3.0).abs() < 1e-9);
+        assert!((data[2] - 1.0).abs() < 1e-9);
+        assert!((data[3] - 7.0 / 3.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn backsolve_three_by_three_round_trip() {
+        // A larger upper-triangular system to exercise the inner sum.
+        // r upper-triangular [[1,2,3],[0,4,5],[0,0,6]] (column-major).
+        let src = "r <- matrix(c(1,0,0, 2,4,0, 3,5,6), nrow = 3)\n";
+        let rhs = nums(&format!(
+            "{src}y <- backsolve(r, c(14,23,18))\nas.numeric(r %*% y)\n"
+        ));
+        assert!((rhs[0] - 14.0).abs() < 1e-9);
+        assert!((rhs[1] - 23.0).abs() < 1e-9);
+        assert!((rhs[2] - 18.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn backsolve_singular_zero_diagonal_is_an_error() {
+        // r = matrix(c(0,0,1,3), nrow=2) has a 0 on the diagonal (r[1,1]=0): the
+        // back-substitution would divide by 0. Must error, never NaN/Inf/panic.
+        let err = eval_s("backsolve(matrix(c(0,0,1,3), nrow = 2), c(1,2))\n").unwrap_err();
+        let msg = format!("{err}").to_lowercase();
+        assert!(
+            msg.contains("singular"),
+            "expected a singular-matrix error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn forwardsolve_singular_zero_diagonal_is_an_error() {
+        // l = matrix(c(0,1,0,3), nrow=2) has l[1,1]=0: forward-substitution divides
+        // by 0 on the very first step. Clean error, no NaN/Inf/panic.
+        let err = eval_s("forwardsolve(matrix(c(0,1,0,3), nrow = 2), c(1,2))\n").unwrap_err();
+        assert!(format!("{err}").to_lowercase().contains("singular"));
+    }
+
+    #[test]
+    fn backsolve_non_square_is_an_error() {
+        // A 2x3 matrix is not square; backsolve errors before any indexing.
+        let err = eval_s("backsolve(matrix(1:6, nrow = 2), c(1,2))\n").unwrap_err();
+        assert!(format!("{err}").to_lowercase().contains("square"));
+    }
+
+    #[test]
+    fn forwardsolve_rhs_length_mismatch_is_an_error() {
+        // r is 2x2 but x has length 3: a row-count mismatch must error before the
+        // substitution loop indexes out of bounds.
+        let err =
+            eval_s("forwardsolve(matrix(c(2,1,0,3), nrow = 2), c(1,2,3))\n").unwrap_err();
+        let msg = format!("{err}").to_lowercase();
+        assert!(msg.contains("length") || msg.contains("rows"), "got: {msg}");
+    }
 }
 
 #[cfg(test)]

--- a/code/specs/R00-r-language.md
+++ b/code/specs/R00-r-language.md
@@ -1182,6 +1182,61 @@ unchanged.
     **Deferred to R-34:** `dig.lab =` (significant-digit control of auto-label
     formatting) and `ordered_result =` (an ordered factor result). The `%o%` infix
     alias for `outer` remains open for a later grammar pass.
+- **R-41 — `backsolve()` / `forwardsolve()` (triangular solves)** *(this PR)*.
+  An **independent matrix-algebra item** in the same family as R-12/R-40, landed
+  in the shared `s-runtime` (R reuses it verbatim through the shared
+  tree-walker). The two triangular linear solvers that the LU/Cholesky family
+  leans on: given a *triangular* coefficient matrix, recover the solution by
+  substitution instead of full Gaussian elimination.
+  - **`backsolve(r, x)`** solves `r %*% y = x` for `y`, where `r` is an `n×n`
+    **upper**-triangular matrix, by **back-substitution** (last row first). `x`
+    may be an `n`-vector (single right-hand side → an `n`-vector result) or an
+    `n×k` matrix (`k` right-hand-side columns → an `n×k` matrix result).
+  - **`forwardsolve(l, x)`** solves `l %*% y = x` for `y`, where `l` is an `n×n`
+    **lower**-triangular matrix, by **forward-substitution** (first row first),
+    with the same vector-or-matrix right-hand-side convention.
+  - **Algorithm (column-major, 0-based here; the maths is 1-based).** For each
+    right-hand-side column `b`, **back-substitution** runs `i = n-1` down to `0`:
+    `y[i] = (b[i] − Σ_{j>i} r[i,j]·y[j]) / r[i,i]`. **Forward-substitution** runs
+    `i = 0` up to `n-1`: `y[i] = (b[i] − Σ_{j<i} l[i,j]·y[j]) / l[i,i]`. Each is
+    `O(n²·k)` flops — half the work of the `O(n³)` general `solve`, which is the
+    whole point of having a triangular fast path. Only the relevant triangle is
+    read (upper for `backsolve`, lower for `forwardsolve`); the opposite triangle
+    is **never touched**, matching R's defaults (`upper.tri = TRUE`,
+    `transpose = FALSE`).
+  - **Error conditions (faithful to R, no panic / no NaN / no Inf).**
+    * **Non-square / non-matrix / over-cap** `r` (or `l`) → the **shared
+      `square_matrix` helper** (the same one `det`/`solve`/`chol` use) raises the
+      error *before* any indexing, so a non-square input never reads out of
+      bounds.
+    * **Right-hand-side shape mismatch** — `x` must have exactly `n` rows (vector
+      length `n`, or `n×k` matrix); a wrong row count is a clean error raised
+      **before** the substitution loop indexes anything.
+    * **Singular triangular matrix** — a **zero on the diagonal** makes the
+      division `… / r[i,i]` undefined. The diagonal entry is tested for `== 0`
+      **before** dividing, so a singular matrix is a clean *"… apparently
+      singular"* error, never a propagated `NaN`/`Inf` and never a panic.
+    * **`NA` in `r`/`l` or `x`** → a clean error (an `NA` cannot be solved),
+      matching the `solve` convention.
+  - **Reuse of matrix machinery.** The implementation pulls the square matrix out
+    with the existing `square_matrix` helper (column-major data + order `n`),
+    reads the right-hand side with the same vector-vs-matrix / row-count / column
+    cap (`MAX_SOLVE_DIM`) logic `solve` already uses, indexes column-major
+    (`r[i,j]` at `j·n + i`), and emits an `SValue::Matrix` (matrix RHS) or a bare
+    numeric vector (vector RHS) — no new value type. Allocation is the single
+    `n×k` result buffer, bounded by the `MAX_SOLVE_DIM` order/column caps.
+  - **Worked examples (column-major).** `backsolve(matrix(c(2,0,1,3), nrow=2),
+    c(5,9))`: `r` is `[[2,1],[0,3]]`; `y[2]=9/3=3`, `y[1]=(5−1·3)/2=1`, so
+    `c(1,3)`, and `r %*% c(1,3) == c(5,9)`. `forwardsolve(matrix(c(2,1,0,3),
+    nrow=2), c(4,11))`: `l` is `[[2,0],[1,3]]`; `y[1]=4/2=2`,
+    `y[2]=(11−1·2)/3=3`, so `c(2,3)`, and `l %*% c(2,3) == c(4,11)`. A
+    multi-column `x` is solved column-by-column.
+  - **Deferred to R-42.** The optional arguments `k =` (use only the leading
+    `k×k` sub-block), `transpose = TRUE` (solve `t(r) %*% y = x`), and
+    `upper.tri = FALSE` for `backsolve` / `upper.tri = TRUE` for `forwardsolve`
+    (read the other triangle) are **out of scope here** and explicitly deferred
+    to **R-42**. This item ships the default full-triangle dense core (single
+    vector RHS and multi-column matrix RHS) solidly.
 - **R-40 — `chol()` (Cholesky factorization)** *(this PR)*. An **independent
   matrix-algebra item** in the same family as R-36/R-38, landed in the shared
   `s-runtime` (R reuses it verbatim through the shared tree-walker). For a real
@@ -1218,11 +1273,12 @@ unchanged.
     SPD matrix `[[4,2],[2,3]]`. `chol(X)` is `R = [[2,1],[0,√2]]`
     (`R[1,1]=√4=2`, `R[1,2]=2/2=1`, `R[2,2]=√(3−1²)=√2`), and `t(R) %*% R`
     reconstructs `X`. `chol(diag(3))` is the identity.
-  - **Deferred to R-41.** `pivot = TRUE` (pivoted Cholesky for
+  - **Deferred to R-42.** `pivot = TRUE` (pivoted Cholesky for
     positive-*semi*-definite matrices, with the `attr(,"pivot")` permutation and
     `rank` attributes), the `chol2inv()` companion (inverse from a Cholesky
     factor), and complex (Hermitian) matrices are all **out of scope here** and
-    explicitly deferred to **R-41**. This item ships the real-SPD dense core only.
+    explicitly deferred to **R-42** (R-41 ships the triangular solves
+    `backsolve`/`forwardsolve`). This item ships the real-SPD dense core only.
 - **R-38 — `kronecker()` (Kronecker product)** *(this PR)*. An **independent
   matrix-algebra item** in the same family as R-36, landed in the shared
   `s-runtime` (R reuses it verbatim through the shared tree-walker). The

--- a/code/specs/S00-s-language.md
+++ b/code/specs/S00-s-language.md
@@ -326,6 +326,34 @@ needs a string assignment target: `"%between%" <- function(x, r) x >= r[1] & x <
   `tcrossprod` of the same is `[[10,14],[14,20]]`. As in R a bare vector flows
   through `%*%`'s existing vector promotion (left = row, right = column); the
   dense-matrix case is the solid, tested core.
+- **Triangular solves** *(R-41)*: `backsolve(r, x)` and `forwardsolve(l, x)`,
+  the two substitution-based linear solvers for a *triangular* coefficient
+  matrix — available to both S and R through the shared tree-walker.
+  **`backsolve(r, x)`** solves `r %*% y = x` for `y` with `r` **upper**-triangular
+  (`n×n`), by **back-substitution** (last row first):
+  `y[i] = (x[i] − Σ_{j>i} r[i,j]·y[j]) / r[i,i]` for `i = n-1 … 0`.
+  **`forwardsolve(l, x)`** solves `l %*% y = x` with `l` **lower**-triangular, by
+  **forward-substitution** (first row first):
+  `y[i] = (x[i] − Σ_{j<i} l[i,j]·y[j]) / l[i,i]` for `i = 0 … n-1`. In both, `x`
+  is either an `n`-vector (single RHS → an `n`-vector result) or an `n×k` matrix
+  (`k` RHS columns → an `n×k` matrix result, solved column-by-column). Only the
+  relevant triangle is read — upper for `backsolve`, lower for `forwardsolve` —
+  matching R's defaults (`upper.tri = TRUE`, `transpose = FALSE`); this is the
+  `O(n²·k)` fast path, half the work of the `O(n³)` general `solve`. The
+  implementation **reuses** the existing `square_matrix` helper (shared with
+  `det`/`solve`/`chol` — non-matrix / non-square / over-`MAX_SOLVE_DIM`
+  rejection), the same vector-vs-matrix RHS reading (`n`-row check, `MAX_SOLVE_DIM`
+  column cap) `solve` uses, column-major indexing (`r[i,j]` at `j·n + i`), and the
+  `SValue::Matrix` constructor. **Error paths, no panic / no NaN / no Inf:**
+  non-square or non-numeric `r`/`l` → error before any indexing; a RHS whose row
+  count ≠ `n` → error before the loop; a **zero on the diagonal** (singular) is
+  tested `== 0` **before** the division, so it is a clean *"apparently singular"*
+  error rather than a propagated `NaN`/`Inf`; `NA` in `r`/`l`/`x` → error. Worked
+  examples: `backsolve(matrix(c(2,0,1,3), nrow=2), c(5,9))` is `c(1,3)` (and
+  `r %*% c(1,3) == c(5,9)`); `forwardsolve(matrix(c(2,1,0,3), nrow=2), c(4,11))`
+  is `c(2,3)`. The optional `k =`, `transpose = TRUE`, and `upper.tri` flips are
+  **deferred to R-42**; this item ships the default full-triangle dense core
+  (vector and multi-column matrix RHS) only.
 - **Cholesky factorization** *(R-40)*: `chol(X)`, the Cholesky factor of a real
   symmetric positive-definite `n×n` matrix. Returns the **upper-triangular**
   matrix `R` with **`t(R) %*% R == X`** (R's convention — the upper factor, so
@@ -346,8 +374,8 @@ needs a string assignment target: `"%between%" <- function(x, r) x >= r[1] & x <
   panic. Worked example: `chol(matrix(c(4,2,2,3), nrow=2))` is `[[2,1],[0,√2]]`
   and `t(R) %*% R` reconstructs the input; `chol(diag(3))` is the identity.
   `pivot=TRUE` (pivoted Cholesky), the `chol2inv()` companion, and complex
-  (Hermitian) matrices are **deferred to R-41**; this item ships the real-SPD
-  dense core only.
+  (Hermitian) matrices are **deferred to R-42** (R-41 ships the triangular solves
+  `backsolve`/`forwardsolve`); this item ships the real-SPD dense core only.
 - **Kronecker product** *(R-38)*: `kronecker(X, Y)`, the block-outer-product of
   two matrices. For `X` `m×n` and `Y` `p×q` the result is `(m·p)×(n·q)` with
   **`result[(i-1)·p + k, (j-1)·q + l] = X[i, j] · Y[k, l]`** (1-based,


### PR DESCRIPTION
## R-41 — triangular solves

Adds **`backsolve(r, x)`** and **`forwardsolve(l, x)`** to the shared `s-runtime`, reached from both S and R.

- `backsolve` solves the **upper**-triangular system `r %*% y = x` by back-substitution; `forwardsolve` solves the **lower**-triangular `l %*% y = x` by forward-substitution. Only the relevant triangle is read.
- **RHS**: `x` is a length-`n` vector (→ a vector) or an `n × m` matrix (→ one solved column per RHS) — same contract as `solve`. `backsolve(matrix(c(2,0,1,3), nrow=2), c(5,9))` → `c(1,3)`, and `r %*% y == c(5,9)`.
- **Reuse**: the `square_matrix` reader (shared with `solve`/`det`/`chol`) + the `solve`-style vector/matrix RHS handling; column-major throughout.
- **Errors (no panics)**: a zero on the diagonal → clean *singular*-matrix error (never `NaN`/`Inf`); non-square/non-numeric matrix, `NA`, or RHS dimension mismatch all error before any indexing. Column count capped at `MAX_SOLVE_DIM`.
- **Deferred to R-42**: `k=`, `transpose=TRUE`, `upper.tri=FALSE`.

### Tests
`cargo test -p coding-adventures-s-runtime -p coding-adventures-r-runtime`: **s-runtime 328**, **r-runtime 291**, doctests green. Covers vector + multi-column RHS, 3×3 round-trip, singular zero-diagonal error, and non-square/length-mismatch errors.

### Security
Reviewed inline (small, self-contained): zero-diagonal guard precedes any division; RHS dimension checked before indexing; all indices `< n*m`; allocation bounded by `MAX_SOLVE_DIM`. No CRITICAL/HIGH.

Note: spec + tests were committed first (per the workflow); the implementation was completed in the main session after the delegated agent repeatedly hit a transient infra watchdog — checkpoint commits meant no work was lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)