### PR TITLE
feat(mycin-glycogen): ADJ-only glycogen-storage-disease→deficient-enzyme recall library (4 edges)

### DIFF
--- a/code/specs/data/mycin-2026/recall/glycogen-storage-edges.adj
+++ b/code/specs/data/mycin-2026/recall/glycogen-storage-edges.adj
@@ -1,0 +1,90 @@
+% ============================================================================
+% glycogen-storage-edges — the glycogen-storage-disease→deficient-enzyme
+% knowledge-graph (MYCIN-2026 GLYCOGEN).
+% ============================================================================
+% A high-yield biochemistry board table: each glycogen storage disease (GSD)
+% and the enzyme whose deficiency causes it. "Which enzyme is deficient in von
+% Gierke disease?" becomes the binding query
+%     ? deficient_in(gsd_type_i_von_gierke, $Enzyme).
+%
+% Direction note: the relation is disease -> the enzyme it is deficient in
+% (`deficient_in`). Each disease here maps to ONE canonical enzyme span, so a
+% query binds a single answer.
+%
+% Faithfulness note: each `relate` subject/object is bound to what the cited
+% sentence ACTUALLY names. The Pompe span writes the enzyme with a Greek letter,
+% "acid α-glucosidase (GAA)"; the object is bound acid_alpha_glucosidase
+% (spelled-out transliteration of the same enzyme name the sentence carries) and
+% the source preserves the Greek α byte-for-byte. The Cori span names the enzyme
+% as "glycogen debranching enzyme (amylo-1,6-glucosidase)" — object bound to the
+% spelled-out form. Each span was independently re-fetched and confirmed.
+%
+% This file is the SHIPPED ARTIFACT and the SOLE source of truth — no generator,
+% no JSON, no manifest (a pure ADJ-only recall domain, like ORGANELLE/
+% SPINAL-TRACT/CEREBRAL-ARTERY). Each fact is a `relate` clause whose
+% byte-provenance lives INLINE:
+%     source   — the VERBATIM span copied from the cited page (byte-stable: it
+%                appears character-for-character in the page's normalized text;
+%                every span here was independently re-fetched and confirmed).
+%     locator  — the URL the span was read from (NCBI StatPearls / Bookshelf).
+%     trust    — authoritative (a primary, citable reference).
+% An LLM (or a human) recalls a fact by writing a tiny query .adj that `import`s
+% this library and asks a binding query — see glycogen-storage-recall.query.adj.
+% Nothing here is asserted "from memory": every edge is defended by a span a
+% reader can re-fetch and check.
+% (See feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+%
+% DEFERRED (honest gaps, not authored over):
+%   - GSD V / McArdle disease -> muscle glycogen phosphorylase (myophosphorylase).
+%     On NBK470386 the deficiency sentence names the enzyme but its subject is
+%     "This condition" (not the disease), and the disease-naming sentence says
+%     McArdle "results from mutations involving the muscle-specific isoform of
+%     the glycogen phosphorylase enzyme" without a single self-contained
+%     deficiency co-naming. No one sentence binds McArdle/GSD-V to the enzyme as
+%     a deficiency.
+%   - GSD IV / Andersen disease -> glycogen branching enzyme. No single NCBI
+%     sentence co-names the disease AND "glycogen branching enzyme" with a
+%     deficiency relationship (the deficiency sentence's subject is the
+%     diagnosis/demonstration, and the disease-as-subject sentences reference
+%     only the GBE1 gene).
+%   - GSD VII / Tarui disease -> muscle phosphofructokinase. The only
+%     self-contained co-naming sentence found is in a PMC research article
+%     (PMC7010930), not an NCBI StatPearls/Bookshelf page; deferred to keep every
+%     shipped edge on a Bookshelf/StatPearls source. Re-groundable from a future
+%     StatPearls Tarui page.
+% ============================================================================
+
+dictionary glycogen_vocab {
+    define disease : entity   surface "glycogen storage disease", "GSD"
+    define enzyme  : entity   surface "deficient enzyme", "glycogen-metabolism enzyme"
+
+    define deficient_in : relation from disease to enzyme  % the enzyme this GSD lacks
+}
+
+rulebook glycogen_facts {
+    use glycogen_vocab
+
+    % --- GSD I / von Gierke -> glucose-6-phosphatase --------------------------
+    relate deficient_in(gsd_type_i_von_gierke, glucose_6_phosphatase)
+        source "von Gierke Disease: also known as glycogen storage disease type 1A, is an autosomal recessive disorder in which the enzyme glucose-6-phosphatase is deficient, leading to an inability to break down glycogen into glucose."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK554417/"
+        trust authoritative
+
+    % --- GSD II / Pompe -> acid alpha-glucosidase (GAA) ----------------------
+    relate deficient_in(gsd_type_ii_pompe, acid_alpha_glucosidase)
+        source "Glycogen storage disease type II, or Pompe disease, is a rare inherited disorder caused by a deficiency of the enzyme acid α-glucosidase (GAA)."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK470558/"
+        trust authoritative
+
+    % --- GSD III / Cori / Forbes -> glycogen debranching enzyme --------------
+    relate deficient_in(gsd_type_iii_cori, glycogen_debranching_enzyme)
+        source "Cori Disease, also known as glycogen storage disease type III or limit dextrinosis, is a genetic disease caused by a mutation in the AGL gene on chromosome 1p21, which encodes the glycogen debranching enzyme (amylo-1,6-glucosidase), leading to deficient activity of the key enzyme responsible for glycogen degradation."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK554417/"
+        trust authoritative
+
+    % --- GSD VI / Hers -> liver glycogen phosphorylase -----------------------
+    relate deficient_in(gsd_type_vi_hers, liver_glycogen_phosphorylase)
+        source "Glycogen storage disease type VI (GSD VI) results from a loss of function of liver glycogen phosphorylase."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK5941/"
+        trust authoritative
+}

--- a/code/specs/data/mycin-2026/recall/glycogen-storage-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/glycogen-storage-recall.query.adj
@@ -1,0 +1,20 @@
+% ============================================================================
+% glycogen-storage-recall.query.adj — a worked recall query over the GSD library.
+% ============================================================================
+% The shape an LLM (or a student) produces to ANSWER a "which enzyme is deficient
+% in glycogen storage disease X?" question: it states no biochemistry fact — it
+% only `import`s the grounded library and asks binding queries. The native
+% adj-lang engine resolves each `?` against the imported `relate` edges and
+% returns the binding + the citing clause's source/locator/trust. All knowledge
+% is in the library; none is here.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli glycogen-storage-recall.query.adj
+% ============================================================================
+
+import "glycogen-storage-edges.adj"
+
+? deficient_in(gsd_type_i_von_gierke, $Enzyme)    % expect glucose_6_phosphatase
+? deficient_in(gsd_type_ii_pompe, $Enzyme)        % expect acid_alpha_glucosidase
+? deficient_in(gsd_type_iii_cori, $Enzyme)        % expect glycogen_debranching_enzyme
+? deficient_in(gsd_type_vi_hers, $Enzyme)         % expect liver_glycogen_phosphorylase

--- a/code/specs/data/mycin-2026/recall/test_glycogen_storage_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_glycogen_storage_recall.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""test_glycogen_storage_recall.py — the ADJ-only glycogen-storage-disease→
+deficient-enzyme recall library (MYCIN-2026 GLYCOGEN).
+
+A pure-ADJ recall domain (high-yield biochemistry board table): the enzyme whose
+deficiency causes each glycogen storage disease. `glycogen-storage-edges.adj` is
+the SOLE source of truth — facts + byte-provenance inline, no Python gate, no
+JSON, no manifest. This test pins the property that matters: the native adj-lang
+engine, given a query .adj that only `import`s the library and asks binding
+queries (`glycogen-storage-recall.query.adj` — the shape an LLM produces), binds
+the grounded enzyme for each disease, each carrying an AUTHORITATIVE citation
+with a real source span + locator. Knowledge lives in ADJ; the engine answers.
+
+If the native CLI isn't built (a Python-only CI lane), the engine-backed checks
+skip — the file-shape checks (every clause grounded, no authored-debt) still run.
+
+Run:  python3 test_glycogen_storage_recall.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ADJ = HERE / "glycogen-storage-edges.adj"
+QUERY = HERE / "glycogen-storage-recall.query.adj"
+CLI = HERE.parents[3] / "packages" / "rust" / "target" / "debug" / "adj-lang-cli"
+
+# Every grounded edge: GSD -> the deficient enzyme the library binds.
+EXPECTED = {
+    "gsd_type_i_von_gierke": "glucose_6_phosphatase",            # NBK554417
+    "gsd_type_ii_pompe": "acid_alpha_glucosidase",               # NBK470558
+    "gsd_type_iii_cori": "glycogen_debranching_enzyme",          # NBK554417
+    "gsd_type_vi_hers": "liver_glycogen_phosphorylase",          # NBK5941
+}
+REL = "deficient_in"
+VAR = "Enzyme"
+
+
+def _cli_available() -> bool:
+    return CLI.exists()
+
+
+def _run(program: Path) -> dict:
+    out = subprocess.run([str(CLI), str(program)], capture_output=True, text=True,
+                         cwd=str(HERE), timeout=60)
+    assert out.returncode == 0, f"adj-lang-cli failed: {out.stderr}"
+    return json.loads(out.stdout)
+
+
+# ---- 1. the ADJ file is the artifact — every clause grounded, no authored-debt ----
+
+def test_library_is_pure_adj_and_fully_grounded() -> None:
+    text = ADJ.read_text()
+    assert "trust consensus" not in text, "GLYCOGEN ships no authored-debt; ground or omit"
+    assert "[FLAG:" not in text
+    edge_count = len(EXPECTED)  # 4
+    assert text.count("    relate ") == edge_count
+    assert text.count("trust authoritative") == edge_count
+    assert text.count('\n        locator "') == edge_count
+    assert text.count('\n        source "') == edge_count
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("locator "):
+            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+    assert not (HERE / "glycogen_storage_edge_ground.py").exists()
+    assert not (HERE / "glycogen-storage-edge-grounding.json").exists()
+    assert not (HERE / "glycogen-storage-edge-manifest.json").exists()
+
+
+# ---- 2. the engine binds each enzyme with an authoritative citation ----------------
+
+def test_engine_binds_every_enzyme_with_authoritative_citation() -> None:
+    if not _cli_available():
+        return
+    result = _run(QUERY)
+    by_query = {r["query"]: r for r in result["recall"]}
+    for disease, enzyme in EXPECTED.items():
+        q = f"{REL}({disease}, {VAR})"
+        r = by_query.get(q)
+        assert r is not None and not r["abstained"], f"{q} abstained — edge missing?"
+        bound = {}
+        for a in r["answers"]:
+            bound[a["bindings"][VAR]] = (a.get("citations") or [{}])[0]
+        assert set(bound) == {enzyme}, f"{disease}: bound {set(bound)} != {{{enzyme}}}"
+        cite = bound[enzyme]
+        assert cite.get("trust") == "authoritative", f"{disease}/{enzyme} not authoritative"
+        assert cite.get("source"), f"{disease}/{enzyme} has no source span"
+        assert cite.get("locator", "").startswith("https://www.ncbi.nlm.nih.gov/")
+
+
+# ---- 3. an off-vocabulary disease abstains, never fabricates -----------------------
+
+def test_unknown_disease_abstains() -> None:
+    if not _cli_available():
+        return
+    import os
+    import tempfile
+    fd, path = tempfile.mkstemp(suffix=".adj", prefix=".glycogen_q_", dir=HERE)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            # GSD V / McArdle is a real GSD but is deliberately NOT in the library
+            # (its enzyme co-naming was deferred), so the engine must abstain
+            # rather than fabricate.
+            fh.write(f'import "glycogen-storage-edges.adj"\n? {REL}(gsd_type_v_mcardle, ${VAR})\n')
+        res = _run(Path(path))
+        r = res["recall"][0] if res["recall"] else None
+        assert r is not None and r["abstained"], "an ungrounded disease must abstain"
+    finally:
+        os.unlink(path)
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS  {t.__name__}")
+        except AssertionError as exc:
+            failed += 1
+            print(f"  FAIL  {t.__name__}: {exc}")
+    print(f"\ntest_glycogen_storage_recall: {len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())


### PR DESCRIPTION
## What

New **pure-ADJ** board-recall domain (high-yield biochemistry): the enzyme whose deficiency causes each glycogen storage disease, via `deficient_in(disease, enzyme)`. `glycogen-storage-edges.adj` is the **sole source of truth** — facts + byte-provenance inline, no Python gate, no JSON, no manifest (same shape as ORGANELLE / SPINAL-TRACT / CEREBRAL-ARTERY).

## Edges (4 grounded — each defended by a verbatim NCBI sentence, every span independently re-fetched and confirmed)

| GSD | deficient enzyme | locator |
|---|---|---|
| GSD I / von Gierke | glucose-6-phosphatase | NBK554417 |
| GSD II / Pompe | acid α-glucosidase (GAA) | NBK470558 |
| GSD III / Cori (Forbes) | glycogen debranching enzyme | NBK554417 |
| GSD VI / Hers | liver glycogen phosphorylase | NBK5941 |

## Faithfulness

- **Pompe** — the span carries the enzyme with a Greek α (*"acid α-glucosidase (GAA)"*); the source preserves the α byte-for-byte; the object is bound `acid_alpha_glucosidase` (spelled-out transliteration of the same name).
- **Cori** — enzyme bound to the spelled-out *"glycogen debranching enzyme"*.

## Deferred (honest gaps, documented inline)

- **GSD V / McArdle** → muscle glycogen phosphorylase: deficiency sentence's subject is *"This condition"* (not the disease); disease-naming sentence cites only *"the muscle-specific isoform"* — no self-contained co-naming.
- **GSD IV / Andersen** → glycogen branching enzyme: no single sentence co-names disease + enzyme with a deficiency relationship (sentences name only GBE1).
- **GSD VII / Tarui** → muscle phosphofructokinase: only self-contained co-naming is in a PMC research article, not a StatPearls/Bookshelf page; deferred to keep every shipped edge on a Bookshelf source.

## Tests (`test_glycogen_storage_recall.py`, 3/3 pass locally)

1. file-shape / no-authored-debt (edge_count == 4, all `trust authoritative`, all NCBI locators, no JSON/manifest sidecars);
2. engine binds each enzyme with an authoritative citation carrying a real `source` span + NCBI `locator`;
3. off-vocabulary disease (GSD V / McArdle — deferred) abstains rather than fabricates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)