### PR TITLE
feat(mycin-conduction): ADJ-only cardiac-conduction-structure→function recall library (4 edges)

### DIFF
--- a/code/specs/data/mycin-2026/recall/conduction-system-edges.adj
+++ b/code/specs/data/mycin-2026/recall/conduction-system-edges.adj
@@ -1,0 +1,72 @@
+% ============================================================================
+% conduction-system-edges — the cardiac-conduction-structure→function
+% knowledge-graph (MYCIN-2026 CONDUCTION).
+% ============================================================================
+% A high-yield cardiac-physiology board table: each component of the heart's
+% electrical conduction system and the function it performs. "What is the
+% function of the SA node?" becomes the binding query
+%     ? has_function(sinoatrial_node, $Function).
+%
+% Direction note: the relation is conduction-structure -> the function it
+% performs (`has_function`). Each structure here maps to ONE canonical function
+% span, so a query binds a single answer.
+%
+% Faithfulness note: each `relate` subject/object is bound to what the cited
+% sentence ACTUALLY names. The function object names the literal role the
+% sentence states (e.g. the SA node sentence says it is "the heart's natural
+% pacemaker", bound natural_pacemaker; the AV node sentence states it "delays
+% the signal between the atria and the ventricles", bound
+% delays_signal_between_atria_and_ventricles). Each span was independently
+% re-fetched and confirmed (the AV node sentence was verified on two separate
+% fetches of the same page for byte-stability).
+%
+% This file is the SHIPPED ARTIFACT and the SOLE source of truth — no generator,
+% no JSON, no manifest (a pure ADJ-only recall domain, like GLYCOGEN/ORGANELLE/
+% SPINAL-TRACT). Each fact is a `relate` clause whose byte-provenance lives
+% INLINE:
+%     source   — the VERBATIM span copied from the cited page (byte-stable: it
+%                appears character-for-character in the page's normalized text;
+%                every span here was independently re-fetched and confirmed).
+%     locator  — the URL the span was read from (NCBI StatPearls / Bookshelf).
+%     trust    — authoritative (a primary, citable reference).
+% An LLM (or a human) recalls a fact by writing a tiny query .adj that `import`s
+% this library and asks a binding query — see conduction-system-recall.query.adj.
+% Nothing here is asserted "from memory": every edge is defended by a span a
+% reader can re-fetch and check.
+% (See feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+dictionary conduction_vocab {
+    define structure : entity   surface "conduction structure", "cardiac conduction component"
+    define function  : entity   surface "conduction function", "electrical role"
+
+    define has_function : relation from structure to function  % the role this structure performs
+}
+
+rulebook conduction_facts {
+    use conduction_vocab
+
+    % --- SA node -> natural pacemaker ----------------------------------------
+    relate has_function(sinoatrial_node, natural_pacemaker)
+        source "Hence, the SA node is referred to as the heart's natural pacemaker."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK459238/"
+        trust authoritative
+
+    % --- AV node -> delays the impulse between atria and ventricles ----------
+    relate has_function(atrioventricular_node, delays_signal_between_atria_and_ventricles)
+        source "The AV node plays a gatekeeper role delaying the signal between the atria and the ventricles; this prevents premature contractions of the ventricle that has not filled."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK546663/"
+        trust authoritative
+
+    % --- bundle of His -> transmits impulse to bundle branches/ventricles ----
+    relate has_function(bundle_of_his, transmits_impulse_to_bundle_branches_and_ventricles)
+        source "After electrical impulse is sent from the sinoatrial (SA) node to the atrioventricular (AV) node, the bundle of His quickly transmits the impulse to the left and right bundle branches and into the ventricles, resulting in a synchronized contraction of the ventricles."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK531498/"
+        trust authoritative
+
+    % --- Purkinje fibers -> transmit signal to ventricular myocardium --------
+    relate has_function(purkinje_fibers, transmit_signal_to_papillary_muscles_and_ventricular_wall)
+        source "The impulse is then distributed through the Purkinje fibers (subendocardial branches), which transmit the signal to papillary muscles and the ventricular wall."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK482452/"
+        trust authoritative
+}

--- a/code/specs/data/mycin-2026/recall/conduction-system-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/conduction-system-recall.query.adj
@@ -1,0 +1,21 @@
+% ============================================================================
+% conduction-system-recall.query.adj — a worked recall query over the cardiac
+% conduction-system library.
+% ============================================================================
+% The shape an LLM (or a student) produces to ANSWER a "what is the function of
+% cardiac conduction structure X?" question: it states no physiology fact — it
+% only `import`s the grounded library and asks binding queries. The native
+% adj-lang engine resolves each `?` against the imported `relate` edges and
+% returns the binding + the citing clause's source/locator/trust. All knowledge
+% is in the library; none is here.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli conduction-system-recall.query.adj
+% ============================================================================
+
+import "conduction-system-edges.adj"
+
+? has_function(sinoatrial_node, $Function)        % expect natural_pacemaker
+? has_function(atrioventricular_node, $Function)  % expect delays_signal_between_atria_and_ventricles
+? has_function(bundle_of_his, $Function)          % expect transmits_impulse_to_bundle_branches_and_ventricles
+? has_function(purkinje_fibers, $Function)        % expect transmit_signal_to_papillary_muscles_and_ventricular_wall

--- a/code/specs/data/mycin-2026/recall/test_conduction_system_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_conduction_system_recall.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""test_conduction_system_recall.py — the ADJ-only cardiac-conduction-structure→
+function recall library (MYCIN-2026 CONDUCTION).
+
+A pure-ADJ recall domain (high-yield cardiac-physiology board table): the
+function each component of the heart's conduction system performs.
+`conduction-system-edges.adj` is the SOLE source of truth — facts +
+byte-provenance inline, no Python gate, no JSON, no manifest. This test pins the
+property that matters: the native adj-lang engine, given a query .adj that only
+`import`s the library and asks binding queries (`conduction-system-recall.query.adj`
+— the shape an LLM produces), binds the grounded function for each structure,
+each carrying an AUTHORITATIVE citation with a real source span + locator.
+Knowledge lives in ADJ; the engine answers.
+
+If the native CLI isn't built (a Python-only CI lane), the engine-backed checks
+skip — the file-shape checks (every clause grounded, no authored-debt) still run.
+
+Run:  python3 test_conduction_system_recall.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ADJ = HERE / "conduction-system-edges.adj"
+QUERY = HERE / "conduction-system-recall.query.adj"
+CLI = HERE.parents[3] / "packages" / "rust" / "target" / "debug" / "adj-lang-cli"
+
+# Every grounded edge: conduction structure -> the function the library binds.
+EXPECTED = {
+    "sinoatrial_node": "natural_pacemaker",                                          # NBK459238
+    "atrioventricular_node": "delays_signal_between_atria_and_ventricles",           # NBK546663
+    "bundle_of_his": "transmits_impulse_to_bundle_branches_and_ventricles",          # NBK531498
+    "purkinje_fibers": "transmit_signal_to_papillary_muscles_and_ventricular_wall",  # NBK482452
+}
+REL = "has_function"
+VAR = "Function"
+
+
+def _cli_available() -> bool:
+    return CLI.exists()
+
+
+def _run(program: Path) -> dict:
+    out = subprocess.run([str(CLI), str(program)], capture_output=True, text=True,
+                         cwd=str(HERE), timeout=60)
+    assert out.returncode == 0, f"adj-lang-cli failed: {out.stderr}"
+    return json.loads(out.stdout)
+
+
+# ---- 1. the ADJ file is the artifact — every clause grounded, no authored-debt ----
+
+def test_library_is_pure_adj_and_fully_grounded() -> None:
+    text = ADJ.read_text()
+    assert "trust consensus" not in text, "CONDUCTION ships no authored-debt; ground or omit"
+    assert "[FLAG:" not in text
+    edge_count = len(EXPECTED)  # 4
+    assert text.count("    relate ") == edge_count
+    assert text.count("trust authoritative") == edge_count
+    assert text.count('\n        locator "') == edge_count
+    assert text.count('\n        source "') == edge_count
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("locator "):
+            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+    assert not (HERE / "conduction_system_edge_ground.py").exists()
+    assert not (HERE / "conduction-system-edge-grounding.json").exists()
+    assert not (HERE / "conduction-system-edge-manifest.json").exists()
+
+
+# ---- 2. the engine binds each function with an authoritative citation --------------
+
+def test_engine_binds_every_function_with_authoritative_citation() -> None:
+    if not _cli_available():
+        return
+    result = _run(QUERY)
+    by_query = {r["query"]: r for r in result["recall"]}
+    for structure, function in EXPECTED.items():
+        q = f"{REL}({structure}, {VAR})"
+        r = by_query.get(q)
+        assert r is not None and not r["abstained"], f"{q} abstained — edge missing?"
+        bound = {}
+        for a in r["answers"]:
+            bound[a["bindings"][VAR]] = (a.get("citations") or [{}])[0]
+        assert set(bound) == {function}, f"{structure}: bound {set(bound)} != {{{function}}}"
+        cite = bound[function]
+        assert cite.get("trust") == "authoritative", f"{structure}/{function} not authoritative"
+        assert cite.get("source"), f"{structure}/{function} has no source span"
+        assert cite.get("locator", "").startswith("https://www.ncbi.nlm.nih.gov/")
+
+
+# ---- 3. an off-vocabulary structure abstains, never fabricates ---------------------
+
+def test_unknown_structure_abstains() -> None:
+    if not _cli_available():
+        return
+    import os
+    import tempfile
+    fd, path = tempfile.mkstemp(suffix=".adj", prefix=".conduction_q_", dir=HERE)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            # the bachmann_bundle is a real conduction structure (interatrial
+            # conduction) but is deliberately not in the library, so the engine
+            # must abstain rather than fabricate.
+            fh.write(f'import "conduction-system-edges.adj"\n? {REL}(bachmann_bundle, ${VAR})\n')
+        res = _run(Path(path))
+        r = res["recall"][0] if res["recall"] else None
+        assert r is not None and r["abstained"], "an ungrounded structure must abstain"
+    finally:
+        os.unlink(path)
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS  {t.__name__}")
+        except AssertionError as exc:
+            failed += 1
+            print(f"  FAIL  {t.__name__}: {exc}")
+    print(f"\ntest_conduction_system_recall: {len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())


### PR DESCRIPTION
## What

New **pure-ADJ** board-recall domain (high-yield cardiac physiology): the function each component of the heart's electrical conduction system performs, via `has_function(structure, function)`. `conduction-system-edges.adj` is the **sole source of truth** — facts + byte-provenance inline, no Python gate, no JSON, no manifest (same shape as GLYCOGEN / ORGANELLE / SPINAL-TRACT).

## Edges (4 grounded — each defended by a verbatim NCBI sentence, every span independently re-fetched; AV node double-fetch-verified for byte-stability)

| structure | function | locator |
|---|---|---|
| SA node | natural pacemaker | NBK459238 |
| AV node | delays the signal between atria and ventricles | NBK546663 |
| bundle of His | transmits impulse to bundle branches and ventricles | NBK531498 |
| Purkinje fibers | transmit signal to papillary muscles + ventricular wall | NBK482452 |

## Faithfulness

Each function object is bound to the literal role the cited sentence states. The **AV-node** edge was *deferred on a first pass* (the candidate sentence used "this structure", not the node name) and re-grounded only after a self-contained AV-node-naming sentence was found and confirmed on two separate fetches of NBK546663 — ground or omit, never paraphrase.

## Tests (`test_conduction_system_recall.py`, 3/3 pass locally)

1. file-shape / no-authored-debt (edge_count == 4, all `trust authoritative`, all NCBI locators, no JSON/manifest sidecars);
2. engine binds each function with an authoritative citation carrying a real `source` span + NCBI `locator`;
3. off-vocabulary structure (Bachmann bundle — deliberately absent) abstains rather than fabricates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)