### PR TITLE
feat(mycin-gihormone): ADJ-only gastrointestinal-hormone→action recall library (4 edges)

### DIFF
--- a/code/specs/data/mycin-2026/recall/gi-hormone-edges.adj
+++ b/code/specs/data/mycin-2026/recall/gi-hormone-edges.adj
@@ -1,0 +1,72 @@
+% ============================================================================
+% gi-hormone-edges — the gastrointestinal-hormone→action knowledge-graph
+% (MYCIN-2026 GIHORMONE).
+% ============================================================================
+% A high-yield GI-physiology board table: each major gut hormone and the
+% principal physiological action it performs. "What does gastrin do?" becomes
+% the binding query
+%     ? has_action(gastrin, $Action).
+%
+% Direction note: the relation is hormone -> the action it performs
+% (`has_action`). Each hormone here maps to ONE canonical action span, so a
+% query binds a single answer.
+%
+% Faithfulness note: each `relate` subject/object is bound to what the cited
+% sentence ACTUALLY names. The action object names the literal effect the
+% sentence states (gastrin "stimulates acid secretion directly via parietal
+% cells"; secretin "stimulates the secretion of bicarbonate-rich pancreatic
+% fluid"; CCK "stimulates gallbladder wall contraction"; somatostatin "inhibits
+% bile secretion, colonic fluid secretions, gastric acid secretion, ..." — an
+% inhibitory hormone, bound inhibits_secretion). Each span was independently
+% re-fetched and confirmed on two separate fetches of the same page for
+% byte-stability.
+%
+% This file is the SHIPPED ARTIFACT and the SOLE source of truth — no generator,
+% no JSON, no manifest (a pure ADJ-only recall domain, like CONDUCTION/GLYCOGEN/
+% ORGANELLE). Each fact is a `relate` clause whose byte-provenance lives INLINE:
+%     source   — the VERBATIM span copied from the cited page (byte-stable: it
+%                appears character-for-character in the page's normalized text;
+%                every span here was independently re-fetched and confirmed).
+%     locator  — the URL the span was read from (NCBI StatPearls / Bookshelf).
+%     trust    — authoritative (a primary, citable reference).
+% An LLM (or a human) recalls a fact by writing a tiny query .adj that `import`s
+% this library and asks a binding query — see gi-hormone-recall.query.adj.
+% Nothing here is asserted "from memory": every edge is defended by a span a
+% reader can re-fetch and check.
+% (See feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+dictionary gi_hormone_vocab {
+    define hormone : entity   surface "gut hormone", "GI hormone"
+    define action  : entity   surface "physiological action", "hormone effect"
+
+    define has_action : relation from hormone to action  % the action this hormone performs
+}
+
+rulebook gi_hormone_facts {
+    use gi_hormone_vocab
+
+    % --- gastrin -> stimulates gastric acid secretion (parietal cells) -------
+    relate has_action(gastrin, stimulates_gastric_acid_secretion_by_parietal_cells)
+        source "Gastrin stimulates acid secretion directly via parietal cells and activates the ECL cells to secrete histamine, resulting in acid production."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK534822/"
+        trust authoritative
+
+    % --- secretin -> stimulates pancreatic bicarbonate secretion -------------
+    relate has_action(secretin, stimulates_pancreatic_bicarbonate_secretion)
+        source "Secretin stimulates the secretion of bicarbonate-rich pancreatic fluid."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK537116/"
+        trust authoritative
+
+    % --- cholecystokinin -> stimulates gallbladder contraction ---------------
+    relate has_action(cholecystokinin, stimulates_gallbladder_wall_contraction)
+        source "Lipids in the duodenum stimulate the release of cholecystokinin, which stimulates gallbladder wall contraction, resulting in the release of bile into the cystic and common bile duct."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK542254/"
+        trust authoritative
+
+    % --- somatostatin -> inhibits secretion (an inhibitory hormone) ----------
+    relate has_action(somatostatin, inhibits_secretion)
+        source "In the exocrine system, somatostatin inhibits bile secretion, colonic fluid secretions, gastric acid secretion, pancreatic enzymes, cholecystokinin, and vasoactive intestinal peptide (VIP)."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK538327/"
+        trust authoritative
+}

--- a/code/specs/data/mycin-2026/recall/gi-hormone-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/gi-hormone-recall.query.adj
@@ -1,0 +1,19 @@
+% ============================================================================
+% gi-hormone-recall.query.adj — a worked recall query over the GI-hormone library.
+% ============================================================================
+% The shape an LLM (or a student) produces to ANSWER a "what does gut hormone X
+% do?" question: it states no physiology fact — it only `import`s the grounded
+% library and asks binding queries. The native adj-lang engine resolves each `?`
+% against the imported `relate` edges and returns the binding + the citing
+% clause's source/locator/trust. All knowledge is in the library; none is here.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli gi-hormone-recall.query.adj
+% ============================================================================
+
+import "gi-hormone-edges.adj"
+
+? has_action(gastrin, $Action)          % expect stimulates_gastric_acid_secretion_by_parietal_cells
+? has_action(secretin, $Action)         % expect stimulates_pancreatic_bicarbonate_secretion
+? has_action(cholecystokinin, $Action)  % expect stimulates_gallbladder_wall_contraction
+? has_action(somatostatin, $Action)     % expect inhibits_secretion

--- a/code/specs/data/mycin-2026/recall/test_gi_hormone_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_gi_hormone_recall.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""test_gi_hormone_recall.py — the ADJ-only gastrointestinal-hormone→action
+recall library (MYCIN-2026 GIHORMONE).
+
+A pure-ADJ recall domain (high-yield GI-physiology board table): the principal
+physiological action each gut hormone performs. `gi-hormone-edges.adj` is the
+SOLE source of truth — facts + byte-provenance inline, no Python gate, no JSON,
+no manifest. This test pins the property that matters: the native adj-lang
+engine, given a query .adj that only `import`s the library and asks binding
+queries (`gi-hormone-recall.query.adj` — the shape an LLM produces), binds the
+grounded action for each hormone, each carrying an AUTHORITATIVE citation with a
+real source span + locator. Knowledge lives in ADJ; the engine answers.
+
+If the native CLI isn't built (a Python-only CI lane), the engine-backed checks
+skip — the file-shape checks (every clause grounded, no authored-debt) still run.
+
+Run:  python3 test_gi_hormone_recall.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ADJ = HERE / "gi-hormone-edges.adj"
+QUERY = HERE / "gi-hormone-recall.query.adj"
+CLI = HERE.parents[3] / "packages" / "rust" / "target" / "debug" / "adj-lang-cli"
+
+# Every grounded edge: gut hormone -> the action the library binds.
+EXPECTED = {
+    "gastrin": "stimulates_gastric_acid_secretion_by_parietal_cells",  # NBK534822
+    "secretin": "stimulates_pancreatic_bicarbonate_secretion",         # NBK537116
+    "cholecystokinin": "stimulates_gallbladder_wall_contraction",      # NBK542254
+    "somatostatin": "inhibits_secretion",                              # NBK538327
+}
+REL = "has_action"
+VAR = "Action"
+
+
+def _cli_available() -> bool:
+    return CLI.exists()
+
+
+def _run(program: Path) -> dict:
+    out = subprocess.run([str(CLI), str(program)], capture_output=True, text=True,
+                         cwd=str(HERE), timeout=60)
+    assert out.returncode == 0, f"adj-lang-cli failed: {out.stderr}"
+    return json.loads(out.stdout)
+
+
+# ---- 1. the ADJ file is the artifact — every clause grounded, no authored-debt ----
+
+def test_library_is_pure_adj_and_fully_grounded() -> None:
+    text = ADJ.read_text()
+    assert "trust consensus" not in text, "GIHORMONE ships no authored-debt; ground or omit"
+    assert "[FLAG:" not in text
+    edge_count = len(EXPECTED)  # 4
+    assert text.count("    relate ") == edge_count
+    assert text.count("trust authoritative") == edge_count
+    assert text.count('\n        locator "') == edge_count
+    assert text.count('\n        source "') == edge_count
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("locator "):
+            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+    assert not (HERE / "gi_hormone_edge_ground.py").exists()
+    assert not (HERE / "gi-hormone-edge-grounding.json").exists()
+    assert not (HERE / "gi-hormone-edge-manifest.json").exists()
+
+
+# ---- 2. the engine binds each action with an authoritative citation ----------------
+
+def test_engine_binds_every_action_with_authoritative_citation() -> None:
+    if not _cli_available():
+        return
+    result = _run(QUERY)
+    by_query = {r["query"]: r for r in result["recall"]}
+    for hormone, action in EXPECTED.items():
+        q = f"{REL}({hormone}, {VAR})"
+        r = by_query.get(q)
+        assert r is not None and not r["abstained"], f"{q} abstained — edge missing?"
+        bound = {}
+        for a in r["answers"]:
+            bound[a["bindings"][VAR]] = (a.get("citations") or [{}])[0]
+        assert set(bound) == {action}, f"{hormone}: bound {set(bound)} != {{{action}}}"
+        cite = bound[action]
+        assert cite.get("trust") == "authoritative", f"{hormone}/{action} not authoritative"
+        assert cite.get("source"), f"{hormone}/{action} has no source span"
+        assert cite.get("locator", "").startswith("https://www.ncbi.nlm.nih.gov/")
+
+
+# ---- 3. an off-vocabulary hormone abstains, never fabricates -----------------------
+
+def test_unknown_hormone_abstains() -> None:
+    if not _cli_available():
+        return
+    import os
+    import tempfile
+    fd, path = tempfile.mkstemp(suffix=".adj", prefix=".gihormone_q_", dir=HERE)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            # motilin is a real gut hormone (migrating motor complex) but is
+            # deliberately not in the library, so the engine must abstain rather
+            # than fabricate.
+            fh.write(f'import "gi-hormone-edges.adj"\n? {REL}(motilin, ${VAR})\n')
+        res = _run(Path(path))
+        r = res["recall"][0] if res["recall"] else None
+        assert r is not None and r["abstained"], "an ungrounded hormone must abstain"
+    finally:
+        os.unlink(path)
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS  {t.__name__}")
+        except AssertionError as exc:
+            failed += 1
+            print(f"  FAIL  {t.__name__}: {exc}")
+    print(f"\ntest_gi_hormone_recall: {len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())


### PR DESCRIPTION
## What

New **pure-ADJ** board-recall domain (high-yield GI physiology): the principal physiological action each gut hormone performs, via `has_action(hormone, action)`. `gi-hormone-edges.adj` is the **sole source of truth** — facts + byte-provenance inline, no Python gate, no JSON, no manifest (same shape as CONDUCTION / GLYCOGEN / ORGANELLE).

## Edges (4 grounded — each defended by a verbatim NCBI sentence, every span double-fetch-verified for byte-stability)

| hormone | action | locator |
|---|---|---|
| gastrin | stimulates gastric acid secretion (parietal cells) | NBK534822 |
| secretin | stimulates pancreatic bicarbonate secretion | NBK537116 |
| cholecystokinin | stimulates gallbladder wall contraction | NBK542254 |
| somatostatin | inhibits secretion (inhibitory hormone) | NBK538327 |

## Faithfulness

Each action object is bound to the literal effect the cited sentence states. Somatostatin's span enumerates the secretions it inhibits → bound `inhibits_secretion`. Every span names the hormone explicitly (no "this hormone"/"it").

## Tests (`test_gi_hormone_recall.py`, 3/3 pass locally)

1. file-shape / no-authored-debt (edge_count == 4, all `trust authoritative`, all NCBI locators, no JSON/manifest sidecars);
2. engine binds each action with an authoritative citation carrying a real `source` span + NCBI `locator`;
3. off-vocabulary hormone (motilin — deliberately absent) abstains rather than fabricates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)