### PR TITLE
feat(mycin-autonomic): ADJ-only autonomic-receptor→effect recall library (6 edges)

### DIFF
--- a/code/specs/data/mycin-2026/recall/autonomic-receptor-edges.adj
+++ b/code/specs/data/mycin-2026/recall/autonomic-receptor-edges.adj
@@ -1,0 +1,85 @@
+% ============================================================================
+% autonomic-receptor-edges — the autonomic-receptor→effect knowledge-graph
+% (MYCIN-2026 AUTONOMIC).
+% ============================================================================
+% A high-yield autonomic-pharmacology board table: each major adrenergic and
+% cholinergic (muscarinic) receptor subtype and the principal physiological
+% effect its activation mediates. "What does the beta-1 receptor do?" becomes
+% the binding query
+%     ? mediates(beta_1, $Effect).
+%
+% Direction note: the relation is receptor -> the effect its activation
+% produces (`mediates`). Each receptor here maps to ONE canonical effect span,
+% so a query binds a single answer.
+%
+% Faithfulness note: each `relate` subject/object is bound to what the cited
+% sentence ACTUALLY names. The effect object names the literal effect the
+% sentence states (alpha-1 "stimulation causes vasoconstriction"; alpha-2
+% "decrease norepinephrine release"; beta-1 "increasing heart rate and
+% contractility"; beta-2 "relaxation and airway dilation"; M2 "an overall
+% decrease in heart rate"; M3 "contraction of airway smooth muscle"). Each span
+% was independently re-fetched and confirmed on two separate fetches of the
+% same page for byte-stability.
+%
+% This file is the SHIPPED ARTIFACT and the SOLE source of truth — no generator,
+% no JSON, no manifest (a pure ADJ-only recall domain, like GIHORMONE/CONDUCTION/
+% GLYCOGEN/ORGANELLE). Each fact is a `relate` clause whose byte-provenance lives
+% INLINE:
+%     source   — the VERBATIM span copied from the cited page (byte-stable: it
+%                appears character-for-character in the page's normalized text;
+%                every span here was independently re-fetched and confirmed).
+%     locator  — the URL the span was read from (NCBI StatPearls / Bookshelf).
+%     trust    — authoritative (a primary, citable reference).
+% An LLM (or a human) recalls a fact by writing a tiny query .adj that `import`s
+% this library and asks a binding query — see autonomic-receptor-recall.query.adj.
+% Nothing here is asserted "from memory": every edge is defended by a span a
+% reader can re-fetch and check.
+% (See feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+dictionary autonomic_receptor_vocab {
+    define receptor : entity   surface "autonomic receptor", "adrenergic/cholinergic receptor"
+    define effect   : entity   surface "physiological effect", "receptor effect"
+
+    define mediates : relation from receptor to effect  % the effect this receptor's activation produces
+}
+
+rulebook autonomic_receptor_facts {
+    use autonomic_receptor_vocab
+
+    % --- alpha-1 adrenergic -> vasoconstriction ------------------------------
+    relate mediates(alpha_1, vasoconstriction)
+        source "Alpha-1 adrenergic receptors are present on vascular smooth muscle and myocardial tissue; therefore, stimulation causes vasoconstriction and positive inotropic effects, respectively."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK551698/"
+        trust authoritative
+
+    % --- alpha-2 adrenergic -> decreases norepinephrine release --------------
+    relate mediates(alpha_2, decreases_norepinephrine_release)
+        source "Clonidine activates alpha-2 receptors, which decrease the firing rate of presynaptic neurons and decrease norepinephrine release into the prefrontal cortex."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK459124/"
+        trust authoritative
+
+    % --- beta-1 adrenergic -> increases heart rate and contractility ---------
+    relate mediates(beta_1, increases_heart_rate_and_contractility)
+        source "Targeted activation of the beta-1 receptor in the heart increases sinoatrial (SA) nodal, atrioventricular (AV) nodal, and ventricular muscular firing, thus increasing heart rate and contractility."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK532904/"
+        trust authoritative
+
+    % --- beta-2 adrenergic -> smooth muscle relaxation (bronchodilation) -----
+    relate mediates(beta_2, smooth_muscle_relaxation)
+        source "These agents stimulate beta-2 adrenergic receptors in bronchial smooth muscle, leading to cyclic adenosine monophosphate–mediated relaxation and airway dilation."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK542249/"
+        trust authoritative
+
+    % --- M2 muscarinic -> decreases heart rate -------------------------------
+    relate mediates(m2, decreases_heart_rate)
+        source "M2 receptors, when activated, inhibit sympathetic influence on the heart, reducing contractility and reducing firing from the sinoatrial node, causing an overall decrease in heart rate."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK555909/"
+        trust authoritative
+
+    % --- M3 muscarinic -> smooth muscle contraction --------------------------
+    relate mediates(m3, smooth_muscle_contraction)
+        source "M3 receptors mainly control the contraction of airway smooth muscle."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK555909/"
+        trust authoritative
+}

--- a/code/specs/data/mycin-2026/recall/autonomic-receptor-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/autonomic-receptor-recall.query.adj
@@ -1,0 +1,22 @@
+% ============================================================================
+% autonomic-receptor-recall.query.adj — a worked recall query over the
+% autonomic-receptor library.
+% ============================================================================
+% The shape an LLM (or a student) produces to ANSWER a "what does receptor X
+% do?" question: it states no physiology fact — it only `import`s the grounded
+% library and asks binding queries. The native adj-lang engine resolves each `?`
+% against the imported `relate` edges and returns the binding + the citing
+% clause's source/locator/trust. All knowledge is in the library; none is here.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli autonomic-receptor-recall.query.adj
+% ============================================================================
+
+import "autonomic-receptor-edges.adj"
+
+? mediates(alpha_1, $Effect)   % expect vasoconstriction
+? mediates(alpha_2, $Effect)   % expect decreases_norepinephrine_release
+? mediates(beta_1, $Effect)    % expect increases_heart_rate_and_contractility
+? mediates(beta_2, $Effect)    % expect smooth_muscle_relaxation
+? mediates(m2, $Effect)        % expect decreases_heart_rate
+? mediates(m3, $Effect)        % expect smooth_muscle_contraction

--- a/code/specs/data/mycin-2026/recall/test_autonomic_receptor_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_autonomic_receptor_recall.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""test_autonomic_receptor_recall.py — the ADJ-only autonomic-receptor→effect
+recall library (MYCIN-2026 AUTONOMIC).
+
+A pure-ADJ recall domain (high-yield autonomic-pharmacology board table): the
+principal physiological effect each adrenergic / muscarinic receptor subtype
+mediates. `autonomic-receptor-edges.adj` is the SOLE source of truth — facts +
+byte-provenance inline, no Python gate, no JSON, no manifest. This test pins the
+property that matters: the native adj-lang engine, given a query .adj that only
+`import`s the library and asks binding queries (`autonomic-receptor-recall.query.adj`
+— the shape an LLM produces), binds the grounded effect for each receptor, each
+carrying an AUTHORITATIVE citation with a real source span + locator. Knowledge
+lives in ADJ; the engine answers.
+
+If the native CLI isn't built (a Python-only CI lane), the engine-backed checks
+skip — the file-shape checks (every clause grounded, no authored-debt) still run.
+
+Run:  python3 test_autonomic_receptor_recall.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ADJ = HERE / "autonomic-receptor-edges.adj"
+QUERY = HERE / "autonomic-receptor-recall.query.adj"
+CLI = HERE.parents[3] / "packages" / "rust" / "target" / "debug" / "adj-lang-cli"
+
+# Every grounded edge: autonomic receptor -> the effect the library binds.
+EXPECTED = {
+    "alpha_1": "vasoconstriction",                            # NBK551698
+    "alpha_2": "decreases_norepinephrine_release",            # NBK459124
+    "beta_1": "increases_heart_rate_and_contractility",       # NBK532904
+    "beta_2": "smooth_muscle_relaxation",                     # NBK542249
+    "m2": "decreases_heart_rate",                             # NBK555909
+    "m3": "smooth_muscle_contraction",                        # NBK555909
+}
+REL = "mediates"
+VAR = "Effect"
+
+
+def _cli_available() -> bool:
+    return CLI.exists()
+
+
+def _run(program: Path) -> dict:
+    out = subprocess.run([str(CLI), str(program)], capture_output=True, text=True,
+                         cwd=str(HERE), timeout=60)
+    assert out.returncode == 0, f"adj-lang-cli failed: {out.stderr}"
+    return json.loads(out.stdout)
+
+
+# ---- 1. the ADJ file is the artifact — every clause grounded, no authored-debt ----
+
+def test_library_is_pure_adj_and_fully_grounded() -> None:
+    text = ADJ.read_text()
+    assert "trust consensus" not in text, "AUTONOMIC ships no authored-debt; ground or omit"
+    assert "[FLAG:" not in text
+    edge_count = len(EXPECTED)  # 6
+    assert text.count("    relate ") == edge_count
+    assert text.count("trust authoritative") == edge_count
+    assert text.count('\n        locator "') == edge_count
+    assert text.count('\n        source "') == edge_count
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("locator "):
+            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+    assert not (HERE / "autonomic_receptor_edge_ground.py").exists()
+    assert not (HERE / "autonomic-receptor-edge-grounding.json").exists()
+    assert not (HERE / "autonomic-receptor-edge-manifest.json").exists()
+
+
+# ---- 2. the engine binds each effect with an authoritative citation ----------------
+
+def test_engine_binds_every_effect_with_authoritative_citation() -> None:
+    if not _cli_available():
+        return
+    result = _run(QUERY)
+    by_query = {r["query"]: r for r in result["recall"]}
+    for receptor, effect in EXPECTED.items():
+        q = f"{REL}({receptor}, {VAR})"
+        r = by_query.get(q)
+        assert r is not None and not r["abstained"], f"{q} abstained — edge missing?"
+        bound = {}
+        for a in r["answers"]:
+            bound[a["bindings"][VAR]] = (a.get("citations") or [{}])[0]
+        assert set(bound) == {effect}, f"{receptor}: bound {set(bound)} != {{{effect}}}"
+        cite = bound[effect]
+        assert cite.get("trust") == "authoritative", f"{receptor}/{effect} not authoritative"
+        assert cite.get("source"), f"{receptor}/{effect} has no source span"
+        assert cite.get("locator", "").startswith("https://www.ncbi.nlm.nih.gov/")
+
+
+# ---- 3. an off-vocabulary receptor abstains, never fabricates ----------------------
+
+def test_unknown_receptor_abstains() -> None:
+    if not _cli_available():
+        return
+    import os
+    import tempfile
+    fd, path = tempfile.mkstemp(suffix=".adj", prefix=".autonomic_q_", dir=HERE)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            # beta_3 is a real adrenergic receptor (lipolysis / bladder relaxation)
+            # but is deliberately not in the library, so the engine must abstain
+            # rather than fabricate.
+            fh.write(f'import "autonomic-receptor-edges.adj"\n? {REL}(beta_3, ${VAR})\n')
+        res = _run(Path(path))
+        r = res["recall"][0] if res["recall"] else None
+        assert r is not None and r["abstained"], "an ungrounded receptor must abstain"
+    finally:
+        os.unlink(path)
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS  {t.__name__}")
+        except AssertionError as exc:
+            failed += 1
+            print(f"  FAIL  {t.__name__}: {exc}")
+    print(f"\ntest_autonomic_receptor_recall: {len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())


### PR DESCRIPTION
## What

A new **pure-ADJ recall domain** for MYCIN-2026: the autonomic-receptor→effect knowledge graph — a high-yield autonomic-pharmacology board table mapping each major adrenergic and muscarinic receptor subtype to the principal physiological effect its activation mediates.

`autonomic-receptor-edges.adj` is the **SOLE shipped artifact and source of truth** — no Python gate, no JSON, no manifest — following the GIHORMONE / CONDUCTION / GLYCOGEN / ORGANELLE pattern. Each `relate mediates(receptor, effect)` clause carries inline byte-provenance: a VERBATIM NCBI StatPearls/Bookshelf span, an `https` NCBI locator, and `trust authoritative`.

## Edges (6)

Each edge is defended by a **self-contained** NCBI Bookshelf sentence that names BOTH the receptor and its effect AND the relationship, **independently re-fetched and confirmed byte-stable on two separate fetches**:

| Receptor | Effect | Source |
|---|---|---|
| `alpha_1` | vasoconstriction | [NBK551698](https://www.ncbi.nlm.nih.gov/books/NBK551698/) |
| `alpha_2` | decreases_norepinephrine_release | [NBK459124](https://www.ncbi.nlm.nih.gov/books/NBK459124/) |
| `beta_1` | increases_heart_rate_and_contractility | [NBK532904](https://www.ncbi.nlm.nih.gov/books/NBK532904/) |
| `beta_2` | smooth_muscle_relaxation (bronchodilation) | [NBK542249](https://www.ncbi.nlm.nih.gov/books/NBK542249/) |
| `m2` | decreases_heart_rate | [NBK555909](https://www.ncbi.nlm.nih.gov/books/NBK555909/) |
| `m3` | smooth_muscle_contraction | [NBK555909](https://www.ncbi.nlm.nih.gov/books/NBK555909/) |

## Files

- `autonomic-receptor-edges.adj` — the grounded library (dictionary + rulebook)
- `autonomic-receptor-recall.query.adj` — worked binding queries (the LLM-produced shape: imports the library, asks `? mediates(<receptor>, $Effect)`)
- `test_autonomic_receptor_recall.py` — 3-test scaffold: (1) pure-ADJ / no-authored-debt file shape (every clause grounded, all locators NCBI, no JSON/manifest/python sidecars); (2) the native adj-lang engine binds each effect with an authoritative NCBI citation; (3) an off-vocabulary receptor (`beta_3`) abstains rather than fabricates. **3/3 pass locally.**

## Notes

- The query `.adj` states no physiology fact — it only imports the library and asks binding queries; the engine resolves them and returns the binding plus the citing clause's source/locator/trust. Knowledge lives in ADJ; the engine answers.
- No edges deferred: all 6 targeted receptor subtypes yielded a qualifying self-contained Bookshelf span. (`beta_3` and the muscarinic `m1` are out of scope this batch; reserved as future edges.)
- Security review: PASSED (Python test uses list-argv subprocess with timeout, atomic `mkstemp` tempfile, `json.loads` on trusted local-binary output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)