### PR TITLE
feat(r-lang): R-42 — triangular-solve options (k / upper.tri / transpose)

### DIFF
--- a/code/packages/rust/r-runtime/CHANGELOG.md
+++ b/code/packages/rust/r-runtime/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.38.0] - 2026-06-25
+
+### Added (via the shared `s-runtime`)
+
+- **R-42 — triangular-solve options** for `backsolve`/`forwardsolve`, through
+  ordinary R syntax:
+  - **`k =`** uses the leading `k × k` block (and first `k` rows of `x`); result
+    has `k` rows. **`upper.tri =`** chooses the triangle read (`backsolve`
+    defaults upper, `forwardsolve` lower), so `backsolve(L, x, upper.tri=FALSE)`
+    matches `forwardsolve(L, x)`. **`transpose=TRUE`** solves `t(R) %*% y = x`.
+  - R-41's behavior is preserved when the options are omitted; the *singular*
+    zero-diagonal error and dimension checks still hold; `k` is range-checked.
+  - **Deferred to R-43**: exotic three-way option combinations with wide
+    multi-column right-hand sides.
+
 ## [0.36.0] - 2026-06-25
 
 ### Added (via the shared `s-runtime`)

--- a/code/packages/rust/r-runtime/README.md
+++ b/code/packages/rust/r-runtime/README.md
@@ -325,8 +325,13 @@ contract as `solve`. `backsolve(matrix(c(2,0,1,3), nrow=2), c(5,9))` is `c(1, 3)
 and `r %*% y` reconstructs `c(5,9)`. They reuse the `square_matrix` reader and the
 `solve`-style RHS handling; a zero on the diagonal is a clean *singular*-matrix
 error (never `NaN`/a panic), and non-square / dimension-mismatched inputs error
-before any indexing. The `k=`, `transpose=TRUE`, and `upper.tri=FALSE` options are
-deferred to **R-42**.
+before any indexing.
+
+**R-42** adds their base-R options: **`k=`** (use the leading `k×k` block and the
+first `k` rows of `x`), **`upper.tri=`** (which triangle to read — so
+`backsolve(L, x, upper.tri=FALSE)` equals `forwardsolve(L, x)`), and
+**`transpose=TRUE`** (solve `t(R) %*% y = x`). The R-41 behavior is unchanged when
+the options are omitted, and `k` is range-checked.
 
 **R-44 — base R Date support** adds R's first calendar type, again through the
 shared `s-runtime`. A **`Date`** is *not* a new value kind: it is a numeric vector

--- a/code/packages/rust/r-runtime/src/lib.rs
+++ b/code/packages/rust/r-runtime/src/lib.rs
@@ -3434,6 +3434,170 @@ mod tests {
         assert!(format!("{err}").to_lowercase().contains("square"));
     }
 
+    // --- R-42: triangular-solve options (k / upper.tri / transpose) ------
+    //
+    // These extend the R-41 core (the shared `triangular_solve` helper) with
+    // base-R's three named arguments. Every expected value is computed by hand
+    // in the comment above the assertion, then checked to a float tolerance.
+
+    #[test]
+    fn backsolve_upper_tri_false_reads_lower_triangle() {
+        // `backsolve` defaults upper.tri = TRUE; passing FALSE makes it read the
+        // LOWER triangle instead, i.e. it becomes `forwardsolve` of that matrix.
+        // m col-major c(2,1,0,3) -> [[2,0],[1,3]] (lower-tri). Solve m %*% y =
+        // c(4,11): y[0] = 4/2 = 2, y[1] = (11 - 1*2)/3 = 3  -> c(2,3).
+        let y = nums("backsolve(matrix(c(2,1,0,3), nrow = 2), c(4,11), upper.tri = FALSE)\n");
+        assert_eq!(y.len(), 2);
+        assert!((y[0] - 2.0).abs() < 1e-9);
+        assert!((y[1] - 3.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn backsolve_upper_tri_false_equals_forwardsolve() {
+        // Identity: backsolve(m, x, upper.tri = FALSE) == forwardsolve(m, x).
+        let a = nums("backsolve(matrix(c(2,1,0,3), nrow = 2), c(4,11), upper.tri = FALSE)\n");
+        let b = nums("forwardsolve(matrix(c(2,1,0,3), nrow = 2), c(4,11))\n");
+        assert_eq!(a.len(), b.len());
+        for (x, y) in a.iter().zip(b.iter()) {
+            assert!((x - y).abs() < 1e-12);
+        }
+    }
+
+    #[test]
+    fn forwardsolve_upper_tri_true_reads_upper_triangle() {
+        // `forwardsolve` defaults upper.tri = FALSE; passing TRUE makes it read
+        // the UPPER triangle, i.e. it becomes `backsolve` of that matrix.
+        // m col-major c(2,0,1,3) -> [[2,1],[0,3]] (upper-tri). Solve m %*% y =
+        // c(5,9): y[1] = 9/3 = 3, y[0] = (5 - 1*3)/2 = 1 -> c(1,3).
+        let y = nums("forwardsolve(matrix(c(2,0,1,3), nrow = 2), c(5,9), upper.tri = TRUE)\n");
+        assert_eq!(y.len(), 2);
+        assert!((y[0] - 1.0).abs() < 1e-9);
+        assert!((y[1] - 3.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn backsolve_transpose_solves_transposed_system() {
+        // R col-major c(2,0,1,3) -> [[2,1],[0,3]] (upper-tri). transpose = TRUE
+        // solves t(R) %*% y = x where t(R) = [[2,0],[1,3]] (lower-tri).
+        // For x = c(4,11): forward-sub over t(R): y[0] = 4/2 = 2,
+        // y[1] = (11 - 1*2)/3 = 3 -> c(2,3).
+        let y = nums("backsolve(matrix(c(2,0,1,3), nrow = 2), c(4,11), transpose = TRUE)\n");
+        assert_eq!(y.len(), 2);
+        assert!((y[0] - 2.0).abs() < 1e-9);
+        assert!((y[1] - 3.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn backsolve_transpose_round_trip() {
+        // t(r) %*% backsolve(r, x, transpose = TRUE) reconstructs x.
+        let rhs = nums(
+            "r <- matrix(c(2,0,1,3), nrow = 2)\n\
+             as.numeric(t(r) %*% backsolve(r, c(4,11), transpose = TRUE))\n",
+        );
+        assert!((rhs[0] - 4.0).abs() < 1e-9 && (rhs[1] - 11.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn forwardsolve_transpose_solves_transposed_system() {
+        // L col-major c(2,1,0,3) -> [[2,0],[1,3]] (lower-tri). transpose = TRUE
+        // solves t(L) %*% y = x where t(L) = [[2,1],[0,3]] (upper-tri).
+        // For x = c(5,9): back-sub over t(L): y[1] = 9/3 = 3,
+        // y[0] = (5 - 1*3)/2 = 1 -> c(1,3).
+        let y = nums("forwardsolve(matrix(c(2,1,0,3), nrow = 2), c(5,9), transpose = TRUE)\n");
+        assert_eq!(y.len(), 2);
+        assert!((y[0] - 1.0).abs() < 1e-9);
+        assert!((y[1] - 3.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn backsolve_k_uses_leading_block_only() {
+        // 3x3 upper-tri r, col-major c(2,0,0, 1,3,0, 4,5,6) ->
+        // [[2,1,4],[0,3,5],[0,0,6]]. With k = 2 we use only the leading 2x2
+        // block [[2,1],[0,3]] and the first two RHS rows c(5,9) (the third
+        // entry, 99, is ignored). Solve: y[1] = 9/3 = 3, y[0] = (5-1*3)/2 = 1.
+        // Result length 2 -> c(1,3).
+        let y = nums(
+            "backsolve(matrix(c(2,0,0, 1,3,0, 4,5,6), nrow = 3), c(5,9,99), k = 2)\n",
+        );
+        assert_eq!(y.len(), 2);
+        assert!((y[0] - 1.0).abs() < 1e-9);
+        assert!((y[1] - 3.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn backsolve_k_full_matches_default() {
+        // k equal to the full order is identical to omitting k.
+        let a = nums("backsolve(matrix(c(2,0,1,3), nrow = 2), c(5,9), k = 2)\n");
+        let b = nums("backsolve(matrix(c(2,0,1,3), nrow = 2), c(5,9))\n");
+        assert_eq!(a.len(), 2);
+        for (x, y) in a.iter().zip(b.iter()) {
+            assert!((x - y).abs() < 1e-12);
+        }
+    }
+
+    #[test]
+    fn backsolve_k_matrix_rhs_uses_leading_rows() {
+        // k = 2 with a matrix RHS: only the first two rows of each column are
+        // used and the result has 2 rows. RHS matrix col-major
+        // c(5,9,99, 2,6,99) -> columns c(5,9,99) and c(2,6,99). Leading 2x2
+        // block [[2,1],[0,3]]: c(5,9)->c(1,3); c(2,6)->y[1]=2, y[0]=(2-1*2)/2=0
+        // -> c(0,2).
+        let (data, nrow, ncol) = matrix_data(
+            "backsolve(matrix(c(2,0,0, 1,3,0, 4,5,6), nrow = 3), \
+             matrix(c(5,9,99, 2,6,99), nrow = 3), k = 2)\n",
+        );
+        assert_eq!((nrow, ncol), (2, 2));
+        assert!(chol_max_abs_diff(&data, &[1.0, 3.0, 0.0, 2.0]) < 1e-9);
+    }
+
+    #[test]
+    fn backsolve_k_zero_returns_empty() {
+        // k = 0 -> the empty (0-row) solve; a length-0 result, no error.
+        let y = nums("backsolve(matrix(c(2,0,1,3), nrow = 2), c(5,9), k = 0)\n");
+        assert_eq!(y.len(), 0);
+    }
+
+    #[test]
+    fn backsolve_k_out_of_range_errors() {
+        // k > n is a clean error, never an out-of-bounds read.
+        let err = eval_r("backsolve(matrix(c(2,0,1,3), nrow = 2), c(5,9), k = 5)\n").unwrap_err();
+        let msg = format!("{err}").to_lowercase();
+        assert!(msg.contains('k') || msg.contains("range") || msg.contains("out"));
+    }
+
+    #[test]
+    fn backsolve_k_negative_errors() {
+        // A negative k is rejected cleanly (no panic, no OOB).
+        let err = eval_r("backsolve(matrix(c(2,0,1,3), nrow = 2), c(5,9), k = -1)\n").unwrap_err();
+        assert!(!format!("{err}").is_empty());
+    }
+
+    #[test]
+    fn backsolve_transpose_singular_still_clean_error() {
+        // A zero on the (transpose-invariant) diagonal is still a clean singular
+        // error under transpose = TRUE -- never NaN / Inf / panic.
+        let err = eval_r(
+            "backsolve(matrix(c(0,0,1,3), nrow = 2), c(1,2), transpose = TRUE)\n",
+        )
+        .unwrap_err();
+        assert!(format!("{err}").to_lowercase().contains("singular"));
+    }
+
+    #[test]
+    fn backsolve_upper_tri_false_and_k_combine() {
+        // Combine two options: lower triangle of the leading 2x2 block.
+        // m col-major c(2,1,0, 0,3,0, 0,0,9) -> [[2,0,0],[1,3,0],[0,0,9]].
+        // upper.tri = FALSE reads the lower triangle; k = 2 uses [[2,0],[1,3]]
+        // and RHS c(4,11): y[0] = 4/2 = 2, y[1] = (11-1*2)/3 = 3 -> c(2,3).
+        let y = nums(
+            "backsolve(matrix(c(2,1,0, 0,3,0, 0,0,9), nrow = 3), c(4,11,99), \
+             upper.tri = FALSE, k = 2)\n",
+        );
+        assert_eq!(y.len(), 2);
+        assert!((y[0] - 2.0).abs() < 1e-9);
+        assert!((y[1] - 3.0).abs() < 1e-9);
+    }
+
     // --- R-35: ordered factors & cut() label polish (R syntax) ----------
 
     #[test]

--- a/code/packages/rust/s-runtime/CHANGELOG.md
+++ b/code/packages/rust/s-runtime/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.39.0] - 2026-06-25
+
+### Added
+
+- **Triangular-solve options (R-42)** — `backsolve` / `forwardsolve` (R-41) now
+  accept base R's named arguments, threaded through the shared `triangular_solve`
+  helper (the R-41 behavior is unchanged when they're omitted):
+  - **`k =`** — use only the leading `k × k` block of the triangular factor and
+    the first `k` rows of the right-hand side; the result has `k` rows. Defaults
+    to the full matrix. `k` outside `0..=n` is a clean error (never out-of-bounds).
+  - **`upper.tri =`** — which triangle of the first argument to read.
+    `backsolve` defaults `TRUE` (upper), `forwardsolve` defaults `FALSE` (lower);
+    passing it explicitly overrides the default, and the substitution direction
+    follows the triangle read (so `backsolve(L, x, upper.tri = FALSE)` equals
+    `forwardsolve(L, x)`).
+  - **`transpose =`** — when `TRUE`, solve `t(R) %*% y = x` instead of
+    `R %*% y = x` (the substitution runs over the transposed entries `R[j,i]`).
+  - **Safety**: the zero-on-the-(used-)diagonal *singular* error, the RHS
+    dimension checks, and the `MAX_SOLVE_DIM` bounds from R-41 all still hold; `k`
+    is range-checked before any indexing.
+  - **Deferred to R-43**: exotic three-way option combinations with wide
+    multi-column right-hand sides beyond the cases covered here.
+
 ## [0.37.0] - 2026-06-25
 
 ### Added

--- a/code/packages/rust/s-runtime/README.md
+++ b/code/packages/rust/s-runtime/README.md
@@ -316,8 +316,10 @@ a hand-written loop. See [What "S-flavored" means here](#what-s-flavored-means-h
   vector) or an `n × m` matrix (→ one solved column per RHS), the same contract as
   `solve`. `backsolve(matrix(c(2,0,1,3), nrow=2), c(5,9))` is `c(1, 3)` and
   `r %*% y` reconstructs `c(5,9)`. Reuses the `square_matrix` reader; a zero on the
-  diagonal is a clean *singular*-matrix error (no `NaN`/panic). `k=`,
-  `transpose=TRUE`, and `upper.tri=FALSE` are deferred to R-42.
+  diagonal is a clean *singular*-matrix error (no `NaN`/panic). **R-42** adds the
+  base-R options: **`k=`** (use the leading `k×k` block + first `k` rows of `x`),
+  **`upper.tri=`** (which triangle to read — so `backsolve(L, x, upper.tri=FALSE)`
+  equals `forwardsolve(L, x)`), and **`transpose=TRUE`** (solve `t(R) %*% y = x`).
 - **Kronecker product** (R-38): **`kronecker(X, Y)`** — the `(m·p)×(n·q)`
   block-outer product of an `m×n` `X` and a `p×q` `Y`, where block `(i, j)` is
   `X[i,j] · Y` and `result[(i-1)·p+k, (j-1)·q+l] = X[i,j] · Y[k,l]`

--- a/code/packages/rust/s-runtime/src/builtins.rs
+++ b/code/packages/rust/s-runtime/src/builtins.rs
@@ -1517,7 +1517,37 @@ fn b_chol(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
 ///   R = [[2,1],[0,3]],  x = (5, 9)
 ///     y[2] = 9 / 3         = 3
 ///     y[1] = (5 − 1·3) / 2 = 1      ⇒  y = (1, 3),  and  R %*% y == x.
-fn triangular_solve(args: &[Arg], who: &str, upper: bool) -> SResult<SValue> {
+///
+/// # R-42 — named options (`k` / `upper.tri` / `transpose`)
+///
+/// The bare two-argument form above is the R-41 default. R-42 threads three
+/// base-R named options through this *same* helper; the resolved values arrive
+/// as parameters so the per-builtin defaults live in the thin wrappers.
+///
+/// * **`upper_tri`** — which triangle of the first argument to read. Reading the
+///   **upper** triangle ⇒ **back**-substitution (rows bottom-up); reading the
+///   **lower** triangle ⇒ **forward**-substitution (rows top-down). So the
+///   substitution direction *follows the triangle read*.
+/// * **`transpose`** — when `true`, solve `t(R) %*% y = x`. Transposing a
+///   triangular factor swaps which triangle is active, so it **flips** the
+///   direction; and every coefficient read goes through the transposed
+///   column-major index (`R[j,i]` at `i·n + j`) instead of `R[i,j]` at `j·n + i`.
+///   The combined rule: the effective direction is **back**-substitution iff
+///   `upper_tri != transpose`.
+/// * **`k`** — solve only the **leading `k×k` block** of the (stride-`n`,
+///   column-major) factor against the **first `k` rows** of the RHS; the result
+///   has `k` rows. Indexing keeps the full stride `n`, so no data is copied — the
+///   loops simply range over `0..k`. `k` must satisfy `0 ≤ k ≤ n`; an
+///   out-of-range `k` is a clean error, never an out-of-bounds read.
+///
+/// The **diagonal** entry `a[i·n + i]` is the same with or without transpose, so
+/// the zero-on-the-used-diagonal *singular* check is unchanged — a clean error,
+/// never a propagated `NaN`/`Inf` and never a panic.
+fn triangular_solve(
+    args: &[Arg],
+    who: &str,
+    upper_tri_default: bool,
+) -> SResult<SValue> {
     // The coefficient matrix: reuse the det/solve/chol square-matrix reader, which
     // rejects non-matrix, non-square and over-MAX_SOLVE_DIM inputs up front and
     // returns the data column-major (entry (row i, col j) is at index `j*n + i`).
@@ -1528,8 +1558,41 @@ fn triangular_solve(args: &[Arg], who: &str, upper: bool) -> SResult<SValue> {
         )));
     }
 
+    // --- R-42 named options -------------------------------------------------
+    // `upper.tri =` (which triangle) and `transpose =` (solve t(R)) are logicals;
+    // missing ⇒ the per-builtin default / `FALSE`. Reuse the shared `named_flag`.
+    let upper_tri = named_flag(args, "upper.tri", upper_tri_default)?;
+    let transpose = named_flag(args, "transpose", false)?;
+    // The substitution runs back-substitution (rows bottom-up) iff the triangle
+    // read and the transpose flag disagree (see the doc comment's truth table).
+    let back = upper_tri != transpose;
+
+    // `k =` selects the leading `k×k` block + first `k` RHS rows. Default = `n`
+    // (the full matrix). Read it as a logical-free integer; a present-but-NA `k`
+    // also falls back to `n`. Range-check `0 ≤ k ≤ n` BEFORE any indexing so a
+    // malformed `k` is a clean error, never an out-of-bounds read.
+    let k = match named_arg(args, "k") {
+        Some(v) => {
+            let raw = v.as_double()?;
+            match raw.get_value(0) {
+                Some(x) if !is_na_real(x) => {
+                    // R truncates toward zero; reject anything outside `0..=n`.
+                    if !(0.0..=(n as f64)).contains(&x.trunc()) {
+                        return Err(SError::BadArgs(format!(
+                            "{who}: 'k' must be between 0 and {n} (got {x})"
+                        )));
+                    }
+                    x.trunc() as usize
+                }
+                _ => n, // empty / NA `k` ⇒ the full matrix, as in R.
+            }
+        }
+        None => n,
+    };
+
     // The right-hand side `x`: a matrix (→ matrix result, `m` columns) or a
-    // vector (→ vector result, a single column). Same handling as `solve`.
+    // vector (→ vector result, a single column). Same handling as `solve`. The
+    // RHS must have `n` rows/length (the full factor); we then use the first `k`.
     let (b, m, b_is_vector) = match nth_positional(args, 1) {
         Some(x_val) => {
             if let Some((bd, bnr, bnc)) = matrix_parts(x_val) {
@@ -1561,7 +1624,7 @@ fn triangular_solve(args: &[Arg], who: &str, upper: bool) -> SResult<SValue> {
             "{who}: NA in the right-hand side"
         )));
     }
-    // The substitution is O(n²·m); cap the column count like `solve` does so a
+    // The substitution is O(k²·m); cap the column count like `solve` does so a
     // wide right-hand side can't blow past the MAX_SOLVE_DIM work budget.
     if m > MAX_SOLVE_DIM {
         return Err(SError::Index(format!(
@@ -1569,41 +1632,56 @@ fn triangular_solve(args: &[Arg], who: &str, upper: bool) -> SResult<SValue> {
         )));
     }
 
-    // Solve each right-hand-side column independently. Visit the rows in the order
-    // that makes the already-solved entries available: bottom-up for an upper-
-    // triangular `R`, top-down for a lower-triangular `L`.
-    let mut y = vec![0.0; n * m];
-    for col in 0..m {
-        if upper {
-            for i in (0..n).rev() {
-                let mut s = b[col * n + i];
-                for j in (i + 1)..n {
-                    s -= a[j * n + i] * y[col * n + j];
-                }
-                let diag = a[i * n + i];
-                if diag == 0.0 {
-                    return Err(SError::BadArgs(format!(
-                        "{who}: the matrix is singular (zero on the diagonal, position {})",
-                        i + 1
-                    )));
-                }
-                y[col * n + i] = s / diag;
-            }
+    // Coefficient read for "equation i, unknown j" within the leading `k×k`
+    // block. Without transpose this is `A[i][j]` at `j*n + i`; with transpose we
+    // want `t(A)[i][j] = A[j][i]` at `i*n + j`. Both keep the full stride `n`, so
+    // `i, j < k ≤ n` stays in bounds. The `n` stride is captured by the closure.
+    let coef = |i: usize, j: usize| -> f64 {
+        if transpose {
+            a[i * n + j]
         } else {
-            for i in 0..n {
-                let mut s = b[col * n + i];
+            a[j * n + i]
+        }
+    };
+
+    // The result has `k` rows (one solved entry per active unknown), `m` columns.
+    // Solve each RHS column independently. Visit the rows in the order that makes
+    // the already-solved entries available: bottom-up for back-substitution,
+    // top-down for forward-substitution. We index the RHS row-wise within the
+    // first `k` rows of each length-`n` column (`col * n + i`, `i < k`) and write
+    // the packed `k`-row result (`col * k + i`).
+    let mut y = vec![0.0; k * m];
+    for col in 0..m {
+        // `rows()` yields the active row indices `0..k` in substitution order.
+        let order: Vec<usize> = if back {
+            (0..k).rev().collect()
+        } else {
+            (0..k).collect()
+        };
+        for &i in &order {
+            // Subtract the already-solved unknowns. For back-substitution those
+            // are the rows below (`j > i`); for forward-substitution, above
+            // (`j < i`). Both ranges stay within `0..k`.
+            let mut s = b[col * n + i];
+            if back {
+                for j in (i + 1)..k {
+                    s -= coef(i, j) * y[col * k + j];
+                }
+            } else {
                 for j in 0..i {
-                    s -= a[j * n + i] * y[col * n + j];
+                    s -= coef(i, j) * y[col * k + j];
                 }
-                let diag = a[i * n + i];
-                if diag == 0.0 {
-                    return Err(SError::BadArgs(format!(
-                        "{who}: the matrix is singular (zero on the diagonal, position {})",
-                        i + 1
-                    )));
-                }
-                y[col * n + i] = s / diag;
             }
+            // The diagonal is transpose-invariant (`a[i*n + i]`); a zero here
+            // makes the system singular — a clean error before the division.
+            let diag = a[i * n + i];
+            if diag == 0.0 {
+                return Err(SError::BadArgs(format!(
+                    "{who}: the matrix is singular (zero on the diagonal, position {})",
+                    i + 1
+                )));
+            }
+            y[col * k + i] = s / diag;
         }
     }
 
@@ -1612,20 +1690,22 @@ fn triangular_solve(args: &[Arg], who: &str, upper: bool) -> SResult<SValue> {
     } else {
         Ok(SValue::Matrix {
             data: Double::from_values(y),
-            nrow: n,
+            nrow: k,
             ncol: m,
         })
     }
 }
 
-/// `backsolve(r, x)` — solve the UPPER-triangular system `r %*% y = x`.
-/// See [`triangular_solve`].
+/// `backsolve(r, x, k = ncol(r), upper.tri = TRUE, transpose = FALSE)` —
+/// solve the UPPER-triangular system `r %*% y = x` (the default), honouring the
+/// R-42 named options. See [`triangular_solve`].
 fn b_backsolve(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
     triangular_solve(args, "backsolve", true)
 }
 
-/// `forwardsolve(l, x)` — solve the LOWER-triangular system `l %*% y = x`.
-/// See [`triangular_solve`].
+/// `forwardsolve(l, x, k = ncol(l), upper.tri = FALSE, transpose = FALSE)` —
+/// solve the LOWER-triangular system `l %*% y = x` (the default), honouring the
+/// R-42 named options. See [`triangular_solve`].
 fn b_forwardsolve(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
     triangular_solve(args, "forwardsolve", false)
 }
@@ -6052,6 +6132,15 @@ fn named_flag(args: &[Arg], name: &str, default: bool) -> SResult<bool> {
         Some(arg) => arg.value.truthy(),
         None => Ok(default),
     }
+}
+
+/// Borrow the value of a named argument (the first match), or `None` if absent.
+/// Used by callers that need to inspect the value themselves (e.g. read an
+/// integer `k =` with their own range check) rather than coerce to a flag.
+fn named_arg<'a>(args: &'a [Arg], name: &str) -> Option<&'a SValue> {
+    args.iter()
+        .find(|a| a.name.as_deref() == Some(name))
+        .map(|a| &a.value)
 }
 
 /// Peel `Classed` / `Named` / `Attributed` wrappers off a value so we can inspect

--- a/code/specs/R00-r-language.md
+++ b/code/specs/R00-r-language.md
@@ -1182,7 +1182,61 @@ unchanged.
     **Deferred to R-34:** `dig.lab =` (significant-digit control of auto-label
     formatting) and `ordered_result =` (an ordered factor result). The `%o%` infix
     alias for `outer` remains open for a later grammar pass.
-- **R-41 — `backsolve()` / `forwardsolve()` (triangular solves)** *(this PR)*.
+- **R-42 — triangular-solve options (`k` / `upper.tri` / `transpose`)** *(this PR)*.
+  Extends the R-41 `backsolve`/`forwardsolve` core (the shared
+  `triangular_solve` helper in `s-runtime`) with base-R's three named options.
+  No grammar change — the named arguments flow through the existing call path.
+  Base-R signatures:
+  `backsolve(r, x, k = ncol(r), upper.tri = TRUE,  transpose = FALSE)` and
+  `forwardsolve(l, x, k = ncol(l), upper.tri = FALSE, transpose = FALSE)`.
+  - **`upper.tri = TRUE/FALSE`** — *which triangle of the first argument to
+    read*. `backsolve` defaults `TRUE` (read the **upper** triangle),
+    `forwardsolve` defaults `FALSE` (read the **lower** triangle). An explicit
+    `upper.tri =` overrides the per-builtin default. The substitution
+    **direction follows the triangle read**: reading the upper triangle ⇒
+    **back**-substitution (bottom-up), reading the lower triangle ⇒
+    **forward**-substitution (top-down). So `backsolve(m, x, upper.tri = FALSE)`
+    is exactly `forwardsolve(m, x)`, and vice-versa.
+  - **`transpose = TRUE/FALSE`** — when `TRUE`, solve `t(R) %*% y = x` instead of
+    `R %*% y = x`. Transposing a triangular factor swaps which triangle is
+    "active", so `transpose = TRUE` **flips** the substitution direction: an
+    upper-triangular `R` solved transposed runs **forward**-substitution over the
+    transposed entries (the code reads `R[j,i]` — column-major index `i·n + j` —
+    wherever the untransposed solve read `R[i,j]`). Formally the effective
+    direction is `back ⟺ (upper.tri XOR transpose) == upper.tri` … i.e. the
+    direction is back-substitution iff `upper.tri != transpose`.
+  - **`k =`** — use only the **leading `k×k` block** of the (column-major,
+    stride-`n`) triangular factor *and* the **first `k` rows** of the right-hand
+    side; the result has **`k` rows**. Default `k = ncol(r)` (the full matrix —
+    the helper uses `nrow(r)`, which equals `ncol(r)` for the square factor).
+    Indexing keeps the full stride `n`: the leading block's entry `(i,j)` for
+    `i,j < k` is still at `a[j·n + i]`, so no data is copied — the loops simply
+    range over `0..k`.
+  - **Combined semantics.** The three options compose: `k` selects the active
+    block, `upper.tri` picks the base direction, `transpose` may flip it and
+    re-routes every coefficient read through the transposed index. The diagonal
+    (`a[i·n + i]`) is the same under transpose, so the singular-diagonal check is
+    unchanged.
+  - **Worked examples.**
+    `backsolve(matrix(c(2,1,0,3), nrow=2), c(4,11), upper.tri = FALSE)` reads the
+    lower triangle of `[[2,0],[1,3]]` ⇒ forward-sub ⇒ `c(2,3)` (identical to
+    `forwardsolve` of that matrix).
+    `backsolve(matrix(c(2,0,1,3), nrow=2), c(4,11), transpose = TRUE)`: `R` is
+    `[[2,1],[0,3]]`, `t(R) = [[2,0],[1,3]]`; the solve runs forward-sub over the
+    transposed entries ⇒ `y[1]=4/2=2`, `y[2]=(11−1·2)/3=3` ⇒ `c(2,3)`, and
+    `t(R) %*% c(2,3) == c(4,11)`.
+    With a `3×3` upper-tri `r` and `k = 2`, only the leading `2×2` block and the
+    first two RHS rows are used and the result has length 2.
+  - **Safety (preserved from R-41).** A zero on the *used* diagonal → a clean
+    *singular* error (never `NaN`/`Inf`/panic). `k` is range-checked
+    `0 ≤ k ≤ n` (a malformed/out-of-range `k` is a clean error, never an
+    out-of-bounds read). RHS row/column counts are validated before any indexing;
+    order and column caps come from `square_matrix`/`MAX_SOLVE_DIM` as before.
+  - **Deferred to R-43.** Exotic full cross-products of all three options with a
+    *wide multi-column* matrix RHS beyond the cases tested here, and any pivoted
+    variants, are deferred to **R-43**. R-42 ships each option **independently**
+    plus the common combinations (each with vector and the tested matrix RHS).
+- **R-41 — `backsolve()` / `forwardsolve()` (triangular solves)** *(previous PR)*.
   An **independent matrix-algebra item** in the same family as R-12/R-40, landed
   in the shared `s-runtime` (R reuses it verbatim through the shared
   tree-walker). The two triangular linear solvers that the LU/Cholesky family
@@ -1231,12 +1285,14 @@ unchanged.
     nrow=2), c(4,11))`: `l` is `[[2,0],[1,3]]`; `y[1]=4/2=2`,
     `y[2]=(11−1·2)/3=3`, so `c(2,3)`, and `l %*% c(2,3) == c(4,11)`. A
     multi-column `x` is solved column-by-column.
-  - **Deferred to R-42.** The optional arguments `k =` (use only the leading
+  - **Shipped in R-42.** The optional arguments `k =` (use only the leading
     `k×k` sub-block), `transpose = TRUE` (solve `t(r) %*% y = x`), and
     `upper.tri = FALSE` for `backsolve` / `upper.tri = TRUE` for `forwardsolve`
-    (read the other triangle) are **out of scope here** and explicitly deferred
-    to **R-42**. This item ships the default full-triangle dense core (single
-    vector RHS and multi-column matrix RHS) solidly.
+    (read the other triangle) were **out of scope here** and shipped in the
+    follow-on item **R-42** (see below). This item ships the default
+    full-triangle dense core (single vector RHS and multi-column matrix RHS)
+    solidly; R-42 extends the *same* shared helper without changing this
+    default behaviour.
 - **R-40 — `chol()` (Cholesky factorization)** *(this PR)*. An **independent
   matrix-algebra item** in the same family as R-36/R-38, landed in the shared
   `s-runtime` (R reuses it verbatim through the shared tree-walker). For a real

--- a/code/specs/S00-s-language.md
+++ b/code/specs/S00-s-language.md
@@ -352,8 +352,33 @@ needs a string assignment target: `"%between%" <- function(x, r) x >= r[1] & x <
   examples: `backsolve(matrix(c(2,0,1,3), nrow=2), c(5,9))` is `c(1,3)` (and
   `r %*% c(1,3) == c(5,9)`); `forwardsolve(matrix(c(2,1,0,3), nrow=2), c(4,11))`
   is `c(2,3)`. The optional `k =`, `transpose = TRUE`, and `upper.tri` flips are
-  **deferred to R-42**; this item ships the default full-triangle dense core
-  (vector and multi-column matrix RHS) only.
+  shipped in **R-42** (see next item); this item ships the default full-triangle
+  dense core (vector and multi-column matrix RHS).
+- **Triangular-solve options** *(R-42)*: the same shared `triangular_solve`
+  helper, extended with base-R's three named arguments —
+  `backsolve(r, x, k = ncol(r), upper.tri = TRUE,  transpose = FALSE)` and
+  `forwardsolve(l, x, k = ncol(l), upper.tri = FALSE, transpose = FALSE)`.
+  **`upper.tri`** selects which triangle of the first argument to read (its
+  per-builtin default — `TRUE` for `backsolve`, `FALSE` for `forwardsolve` — is
+  overridden by an explicit value); the substitution direction follows the
+  triangle read (upper ⇒ back-substitution, lower ⇒ forward-substitution).
+  **`transpose = TRUE`** solves `t(R) %*% y = x`, which flips the direction and
+  reroutes every coefficient read through the transposed column-major index
+  (`R[j,i]` at `i·n + j` wherever the untransposed solve used `R[i,j]` at
+  `j·n + i`); the effective direction is back-substitution iff
+  `upper.tri != transpose`. **`k`** restricts the solve to the leading `k×k`
+  block and the first `k` RHS rows (result has `k` rows); indexing keeps the
+  full stride `n`, so no data is copied — the loops simply range over `0..k`.
+  **Safety (preserved from R-41):** `k` is range-checked `0 ≤ k ≤ n` (a
+  malformed/out-of-range `k` is a clean error, never an out-of-bounds read); the
+  zero-on-the-*used*-diagonal singular check is unchanged (the diagonal index is
+  transpose-invariant); RHS dimensions are validated before indexing. Worked
+  examples: `backsolve(m, c(4,11), upper.tri = FALSE)` equals `forwardsolve(m)`;
+  `backsolve(matrix(c(2,0,1,3), nrow=2), c(4,11), transpose = TRUE)` solves the
+  lower-triangular `t(R) = [[2,0],[1,3]]` ⇒ `c(2,3)`. Exotic full
+  cross-products of all three options with a *wide* multi-column matrix RHS are
+  **deferred to R-43**; R-42 ships each option independently plus the common
+  combinations.
 - **Cholesky factorization** *(R-40)*: `chol(X)`, the Cholesky factor of a real
   symmetric positive-definite `n×n` matrix. Returns the **upper-triangular**
   matrix `R` with **`t(R) %*% R == X`** (R's convention — the upper factor, so


### PR DESCRIPTION
## R-42 — triangular-solve options

Extends R-41's `backsolve`/`forwardsolve` with base R's named arguments, threaded through the shared `triangular_solve` helper. R-41 behavior is unchanged when the options are omitted.

- **`k=`** — use the leading `k×k` block of the factor and the first `k` rows of `x`; result has `k` rows. `k` outside `0..=n` → clean error (no OOB).
- **`upper.tri=`** — which triangle to read (`backsolve` defaults upper, `forwardsolve` lower); explicit value overrides, and substitution direction follows the triangle. `backsolve(L, x, upper.tri=FALSE)` == `forwardsolve(L, x)`.
- **`transpose=TRUE`** — solve `t(R) %*% y = x`.
- Safety: the *singular* zero-diagonal error, RHS dimension checks, and `MAX_SOLVE_DIM` bounds from R-41 all hold; `k` range-checked before indexing.
- **Deferred to R-43**: exotic three-way option combinations with wide multi-column RHS.

### Tests
`cargo test -p coding-adventures-s-runtime -p coding-adventures-r-runtime`: green — s-runtime 305+, r-runtime green, including `k=` (full/leading-block/zero/negative/out-of-range), `upper.tri=` (both directions, == forwardsolve), `transpose=` (round-trip + singular), and combinations, with all R-41 cases preserved.

### Security
Reviewed inline (extends an existing reviewed helper): `k` range-checked, zero-diagonal guard, RHS dimension checks, no OOB. No CRITICAL/HIGH.

Note: spec/tests/impl were authored by a delegated agent that committed all three milestones before a transient infra watchdog stalled it; the docs + this PR were completed in the main session. The branch is based pre-R-45, so it may need a CHANGELOG rebase against main (versioned to stay above R-45).

🤖 Generated with [Claude Code](https://claude.com/claude-code)