### PR TITLE
feat(mycin-bonecell): ADJ-only bone-cell→function recall library (4 edges)

### DIFF
--- a/code/specs/data/mycin-2026/recall/bone-cell-edges.adj
+++ b/code/specs/data/mycin-2026/recall/bone-cell-edges.adj
@@ -1,0 +1,71 @@
+% ============================================================================
+% bone-cell-edges — the bone-cell→function knowledge-graph (MYCIN-2026 BONECELL).
+% ============================================================================
+% A high-yield histology/physiology board table: each principal bone (and the
+% related cartilage) cell type and the function it performs. "What does the
+% osteoclast do?" becomes the binding query
+%     ? has_function(osteoclast, $Function).
+%
+% Direction note: the relation is cell -> the function it performs
+% (`has_function`). Each cell here maps to ONE canonical function span, so a
+% query binds a single answer.
+%
+% Faithfulness note: each `relate` subject/object is bound to what the cited
+% sentence ACTUALLY names. The function object names the literal role the
+% sentence states (osteoblast "synthesize and deposit organic bone matrix";
+% osteoclast "the cells responsible for bone resorption"; osteocyte
+% "orchestrators of bone remodeling"; chondrocyte "production of collagen and
+% the extracellular matrix ... maintenance of cartilaginous tissues"). Each span
+% was independently re-fetched and confirmed on two separate fetches of the same
+% page for byte-stability.
+%
+% This file is the SHIPPED ARTIFACT and the SOLE source of truth — no generator,
+% no JSON, no manifest (a pure ADJ-only recall domain, like AUTONOMIC/GIHORMONE/
+% CONDUCTION/ORGANELLE). Each fact is a `relate` clause whose byte-provenance
+% lives INLINE:
+%     source   — the VERBATIM span copied from the cited page (byte-stable: it
+%                appears character-for-character in the page's normalized text;
+%                every span here was independently re-fetched and confirmed).
+%     locator  — the URL the span was read from (NCBI StatPearls / Bookshelf).
+%     trust    — authoritative (a primary, citable reference).
+% An LLM (or a human) recalls a fact by writing a tiny query .adj that `import`s
+% this library and asks a binding query — see bone-cell-recall.query.adj.
+% Nothing here is asserted "from memory": every edge is defended by a span a
+% reader can re-fetch and check.
+% (See feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+dictionary bone_cell_vocab {
+    define cell     : entity   surface "bone cell", "skeletal cell"
+    define function : entity   surface "cellular function", "cell role"
+
+    define has_function : relation from cell to function  % the function this cell performs
+}
+
+rulebook bone_cell_facts {
+    use bone_cell_vocab
+
+    % --- osteoblast -> bone formation (synthesizes/deposits bone matrix) ------
+    relate has_function(osteoblast, bone_formation)
+        source "Osteoblasts synthesize and deposit organic bone matrix (osteoid) proteins that will mineralize in both developing skeletons and during the process of bone remodeling that occurs continuously throughout an individual's life."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK557792/"
+        trust authoritative
+
+    % --- osteoclast -> bone resorption ---------------------------------------
+    relate has_function(osteoclast, bone_resorption)
+        source "Osteoclasts serve a vital role in bone metabolism and turnover, being the cells responsible for bone resorption."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK554489/"
+        trust authoritative
+
+    % --- osteocyte -> regulates (orchestrates) bone remodeling ---------------
+    relate has_function(osteocyte, regulates_bone_remodeling)
+        source "Osteocytes act as orchestrators of bone remodeling and as a result, are also considered endocrine cells."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK441968/"
+        trust authoritative
+
+    % --- chondrocyte -> produces cartilage matrix ----------------------------
+    relate has_function(chondrocyte, produces_cartilage_matrix)
+        source "Chondrocytes are mainly responsible for the production of collagen and the extracellular matrix that leads to the maintenance of cartilaginous tissues within joints."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK557576/"
+        trust authoritative
+}

--- a/code/specs/data/mycin-2026/recall/bone-cell-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/bone-cell-recall.query.adj
@@ -1,0 +1,19 @@
+% ============================================================================
+% bone-cell-recall.query.adj — a worked recall query over the bone-cell library.
+% ============================================================================
+% The shape an LLM (or a student) produces to ANSWER a "what does cell X do?"
+% question: it states no histology fact — it only `import`s the grounded library
+% and asks binding queries. The native adj-lang engine resolves each `?` against
+% the imported `relate` edges and returns the binding + the citing clause's
+% source/locator/trust. All knowledge is in the library; none is here.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli bone-cell-recall.query.adj
+% ============================================================================
+
+import "bone-cell-edges.adj"
+
+? has_function(osteoblast, $Function)   % expect bone_formation
+? has_function(osteoclast, $Function)   % expect bone_resorption
+? has_function(osteocyte, $Function)    % expect regulates_bone_remodeling
+? has_function(chondrocyte, $Function)  % expect produces_cartilage_matrix

--- a/code/specs/data/mycin-2026/recall/test_bone_cell_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_bone_cell_recall.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""test_bone_cell_recall.py — the ADJ-only bone-cell→function recall library
+(MYCIN-2026 BONECELL).
+
+A pure-ADJ recall domain (high-yield histology/physiology board table): the
+principal function each bone (and related cartilage) cell type performs.
+`bone-cell-edges.adj` is the SOLE source of truth — facts + byte-provenance
+inline, no Python gate, no JSON, no manifest. This test pins the property that
+matters: the native adj-lang engine, given a query .adj that only `import`s the
+library and asks binding queries (`bone-cell-recall.query.adj` — the shape an LLM
+produces), binds the grounded function for each cell, each carrying an
+AUTHORITATIVE citation with a real source span + locator. Knowledge lives in
+ADJ; the engine answers.
+
+If the native CLI isn't built (a Python-only CI lane), the engine-backed checks
+skip — the file-shape checks (every clause grounded, no authored-debt) still run.
+
+Run:  python3 test_bone_cell_recall.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ADJ = HERE / "bone-cell-edges.adj"
+QUERY = HERE / "bone-cell-recall.query.adj"
+CLI = HERE.parents[3] / "packages" / "rust" / "target" / "debug" / "adj-lang-cli"
+
+# Every grounded edge: bone cell -> the function the library binds.
+EXPECTED = {
+    "osteoblast": "bone_formation",                  # NBK557792
+    "osteoclast": "bone_resorption",                 # NBK554489
+    "osteocyte": "regulates_bone_remodeling",        # NBK441968
+    "chondrocyte": "produces_cartilage_matrix",      # NBK557576
+}
+REL = "has_function"
+VAR = "Function"
+
+
+def _cli_available() -> bool:
+    return CLI.exists()
+
+
+def _run(program: Path) -> dict:
+    out = subprocess.run([str(CLI), str(program)], capture_output=True, text=True,
+                         cwd=str(HERE), timeout=60)
+    assert out.returncode == 0, f"adj-lang-cli failed: {out.stderr}"
+    return json.loads(out.stdout)
+
+
+# ---- 1. the ADJ file is the artifact — every clause grounded, no authored-debt ----
+
+def test_library_is_pure_adj_and_fully_grounded() -> None:
+    text = ADJ.read_text()
+    assert "trust consensus" not in text, "BONECELL ships no authored-debt; ground or omit"
+    assert "[FLAG:" not in text
+    edge_count = len(EXPECTED)  # 4
+    assert text.count("    relate ") == edge_count
+    assert text.count("trust authoritative") == edge_count
+    assert text.count('\n        locator "') == edge_count
+    assert text.count('\n        source "') == edge_count
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("locator "):
+            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+    assert not (HERE / "bone_cell_edge_ground.py").exists()
+    assert not (HERE / "bone-cell-edge-grounding.json").exists()
+    assert not (HERE / "bone-cell-edge-manifest.json").exists()
+
+
+# ---- 2. the engine binds each function with an authoritative citation --------------
+
+def test_engine_binds_every_function_with_authoritative_citation() -> None:
+    if not _cli_available():
+        return
+    result = _run(QUERY)
+    by_query = {r["query"]: r for r in result["recall"]}
+    for cell, function in EXPECTED.items():
+        q = f"{REL}({cell}, {VAR})"
+        r = by_query.get(q)
+        assert r is not None and not r["abstained"], f"{q} abstained — edge missing?"
+        bound = {}
+        for a in r["answers"]:
+            bound[a["bindings"][VAR]] = (a.get("citations") or [{}])[0]
+        assert set(bound) == {function}, f"{cell}: bound {set(bound)} != {{{function}}}"
+        cite = bound[function]
+        assert cite.get("trust") == "authoritative", f"{cell}/{function} not authoritative"
+        assert cite.get("source"), f"{cell}/{function} has no source span"
+        assert cite.get("locator", "").startswith("https://www.ncbi.nlm.nih.gov/")
+
+
+# ---- 3. an off-vocabulary cell abstains, never fabricates --------------------------
+
+def test_unknown_cell_abstains() -> None:
+    if not _cli_available():
+        return
+    import os
+    import tempfile
+    fd, path = tempfile.mkstemp(suffix=".adj", prefix=".bonecell_q_", dir=HERE)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            # fibroblast is a real connective-tissue cell but is deliberately not
+            # in this bone-cell library, so the engine must abstain rather than
+            # fabricate.
+            fh.write(f'import "bone-cell-edges.adj"\n? {REL}(fibroblast, ${VAR})\n')
+        res = _run(Path(path))
+        r = res["recall"][0] if res["recall"] else None
+        assert r is not None and r["abstained"], "an ungrounded cell must abstain"
+    finally:
+        os.unlink(path)
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS  {t.__name__}")
+        except AssertionError as exc:
+            failed += 1
+            print(f"  FAIL  {t.__name__}: {exc}")
+    print(f"\ntest_bone_cell_recall: {len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())


### PR DESCRIPTION
## What

A new **pure-ADJ recall domain** for MYCIN-2026: the bone-cell→function knowledge graph — a high-yield histology/physiology board table mapping each principal bone (and related cartilage) cell type to the function it performs.

`bone-cell-edges.adj` is the **SOLE shipped artifact and source of truth** — no Python gate, no JSON, no manifest — following the AUTONOMIC / GIHORMONE / CONDUCTION / ORGANELLE pattern. Each `relate has_function(cell, function)` clause carries inline byte-provenance: a VERBATIM NCBI StatPearls/Bookshelf span, an `https` NCBI locator, and `trust authoritative`.

## Edges (4)

Each edge is defended by a **self-contained** NCBI Bookshelf sentence that names BOTH the cell and its function AND the relationship, **independently re-fetched and confirmed byte-stable on two separate fetches**:

| Cell | Function | Source |
|---|---|---|
| `osteoblast` | bone_formation | [NBK557792](https://www.ncbi.nlm.nih.gov/books/NBK557792/) |
| `osteoclast` | bone_resorption | [NBK554489](https://www.ncbi.nlm.nih.gov/books/NBK554489/) |
| `osteocyte` | regulates_bone_remodeling | [NBK441968](https://www.ncbi.nlm.nih.gov/books/NBK441968/) |
| `chondrocyte` | produces_cartilage_matrix | [NBK557576](https://www.ncbi.nlm.nih.gov/books/NBK557576/) |

## Files

- `bone-cell-edges.adj` — the grounded library (dictionary + rulebook)
- `bone-cell-recall.query.adj` — worked binding queries (the LLM-produced shape: imports the library, asks `? has_function(<cell>, $Function)`)
- `test_bone_cell_recall.py` — 3-test scaffold: (1) pure-ADJ / no-authored-debt file shape (every clause grounded, all locators NCBI, no JSON/manifest/python sidecars); (2) the native adj-lang engine binds each function with an authoritative NCBI citation; (3) an off-vocabulary cell (`fibroblast`) abstains rather than fabricates. **3/3 pass locally.**

## Notes

- The query `.adj` states no histology fact — it only imports the library and asks binding queries; the engine resolves them and returns the binding plus the citing clause's source/locator/trust. Knowledge lives in ADJ; the engine answers.
- No edges deferred: all 4 targeted cell types yielded a qualifying self-contained Bookshelf span. `osteocyte` is faithfully bound to `regulates_bone_remodeling` per the cited "orchestrators of bone remodeling" phrasing.
- Security review: PASSED (Python test uses list-argv subprocess with timeout, atomic `mkstemp` tempfile, `json.loads` on trusted local-binary output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)