### PR TITLE
feat(mycin-pituitary): ADJ-only pituitary-hormone→target recall library (6 edges)

### DIFF
--- a/code/specs/data/mycin-2026/recall/pituitary-hormone-edges.adj
+++ b/code/specs/data/mycin-2026/recall/pituitary-hormone-edges.adj
@@ -1,0 +1,85 @@
+% ============================================================================
+% pituitary-hormone-edges — the pituitary-hormone→target knowledge-graph
+% (MYCIN-2026 PITUITARY).
+% ============================================================================
+% A high-yield endocrine-physiology board table: each major pituitary hormone
+% (anterior tropic hormones + posterior ADH) and the target organ/effect it acts
+% on. "What does TSH act on?" becomes the binding query
+%     ? targets(tsh, $Target).
+%
+% Direction note: the relation is hormone -> the target organ/effect it acts on
+% (`targets`). Each hormone here maps to ONE canonical target span, so a query
+% binds a single answer.
+%
+% Faithfulness note: each `relate` subject/object is bound to what the cited
+% sentence ACTUALLY names. The target object names the literal target/effect the
+% sentence states (TSH "stimulates receptors ... of the thyroid gland"; ACTH
+% "acts on the adrenal cortex"; prolactin "growth of mammary alveoli ... the
+% mammary gland"; ADH "increase water reabsorption" in the kidney; LH "causes
+% the testes' Leydig cells to produce testosterone"; FSH "stimulates the
+% maturation of ovarian follicles"). Each span was independently re-fetched and
+% confirmed on two separate fetches of the same page for byte-stability.
+%
+% This file is the SHIPPED ARTIFACT and the SOLE source of truth — no generator,
+% no JSON, no manifest (a pure ADJ-only recall domain, like BONECELL/AUTONOMIC/
+% GIHORMONE/CONDUCTION). It is DISTINCT from the legacy endocrine domain: this is
+% a brand-new pure-ADJ file on the pituitary-axis hormone→target topic. Each fact
+% is a `relate` clause whose byte-provenance lives INLINE:
+%     source   — the VERBATIM span copied from the cited page (byte-stable: it
+%                appears character-for-character in the page's normalized text;
+%                every span here was independently re-fetched and confirmed).
+%     locator  — the URL the span was read from (NCBI StatPearls / Bookshelf).
+%     trust    — authoritative (a primary, citable reference).
+% An LLM (or a human) recalls a fact by writing a tiny query .adj that `import`s
+% this library and asks a binding query — see pituitary-hormone-recall.query.adj.
+% Nothing here is asserted "from memory": every edge is defended by a span a
+% reader can re-fetch and check.
+% (See feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+dictionary pituitary_hormone_vocab {
+    define hormone : entity   surface "pituitary hormone", "tropic hormone"
+    define target  : entity   surface "target organ", "hormone target"
+
+    define targets : relation from hormone to target  % the target/effect this hormone acts on
+}
+
+rulebook pituitary_hormone_facts {
+    use pituitary_hormone_vocab
+
+    % --- TSH -> thyroid gland ------------------------------------------------
+    relate targets(tsh, thyroid_gland)
+        source "TSH stimulates receptors found in the follicular cells of the thyroid gland to produce thyroid hormones T4 and T3."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK499898/"
+        trust authoritative
+
+    % --- ACTH -> adrenal cortex ----------------------------------------------
+    relate targets(acth, adrenal_cortex)
+        source "ACTH then acts on the adrenal cortex to promote cortisol synthesis and release."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK500031/"
+        trust authoritative
+
+    % --- prolactin -> mammary gland ------------------------------------------
+    relate targets(prolactin, mammary_gland)
+        source "Prolactin promotes the growth of mammary alveoli, which are the components of the mammary gland, where the actual production of milk occurs."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK507829/"
+        trust authoritative
+
+    % --- ADH (vasopressin) -> kidney water reabsorption ----------------------
+    relate targets(adh, promotes_water_reabsorption)
+        source "ADH primarily affects the ability of the kidney to reabsorb water; when present, ADH induces expression of water transport proteins in the late distal tubule and collecting duct to increase water reabsorption."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK526069/"
+        trust authoritative
+
+    % --- LH -> Leydig cells (testosterone) -----------------------------------
+    relate targets(lh, stimulates_leydig_cells)
+        source "In men, LH causes the testes' Leydig cells to produce testosterone."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK539692/"
+        trust authoritative
+
+    % --- FSH -> ovarian follicle maturation ----------------------------------
+    relate targets(fsh, stimulates_follicle_growth)
+        source "During the follicular phase of the menstrual cycle, FSH stimulates the maturation of ovarian follicles."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK535442/"
+        trust authoritative
+}

--- a/code/specs/data/mycin-2026/recall/pituitary-hormone-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/pituitary-hormone-recall.query.adj
@@ -1,0 +1,22 @@
+% ============================================================================
+% pituitary-hormone-recall.query.adj — a worked recall query over the
+% pituitary-hormone library.
+% ============================================================================
+% The shape an LLM (or a student) produces to ANSWER a "what does hormone X act
+% on?" question: it states no physiology fact — it only `import`s the grounded
+% library and asks binding queries. The native adj-lang engine resolves each `?`
+% against the imported `relate` edges and returns the binding + the citing
+% clause's source/locator/trust. All knowledge is in the library; none is here.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli pituitary-hormone-recall.query.adj
+% ============================================================================
+
+import "pituitary-hormone-edges.adj"
+
+? targets(tsh, $Target)        % expect thyroid_gland
+? targets(acth, $Target)       % expect adrenal_cortex
+? targets(prolactin, $Target)  % expect mammary_gland
+? targets(adh, $Target)        % expect promotes_water_reabsorption
+? targets(lh, $Target)         % expect stimulates_leydig_cells
+? targets(fsh, $Target)        % expect stimulates_follicle_growth

--- a/code/specs/data/mycin-2026/recall/test_pituitary_hormone_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_pituitary_hormone_recall.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""test_pituitary_hormone_recall.py — the ADJ-only pituitary-hormone→target
+recall library (MYCIN-2026 PITUITARY).
+
+A pure-ADJ recall domain (high-yield endocrine-physiology board table): the
+target organ/effect each major pituitary hormone acts on.
+`pituitary-hormone-edges.adj` is the SOLE source of truth — facts +
+byte-provenance inline, no Python gate, no JSON, no manifest. This test pins the
+property that matters: the native adj-lang engine, given a query .adj that only
+`import`s the library and asks binding queries (`pituitary-hormone-recall.query.adj`
+— the shape an LLM produces), binds the grounded target for each hormone, each
+carrying an AUTHORITATIVE citation with a real source span + locator. Knowledge
+lives in ADJ; the engine answers.
+
+If the native CLI isn't built (a Python-only CI lane), the engine-backed checks
+skip — the file-shape checks (every clause grounded, no authored-debt) still run.
+
+Run:  python3 test_pituitary_hormone_recall.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ADJ = HERE / "pituitary-hormone-edges.adj"
+QUERY = HERE / "pituitary-hormone-recall.query.adj"
+CLI = HERE.parents[3] / "packages" / "rust" / "target" / "debug" / "adj-lang-cli"
+
+# Every grounded edge: pituitary hormone -> the target the library binds.
+EXPECTED = {
+    "tsh": "thyroid_gland",                      # NBK499898
+    "acth": "adrenal_cortex",                    # NBK500031
+    "prolactin": "mammary_gland",                # NBK507829
+    "adh": "promotes_water_reabsorption",        # NBK526069
+    "lh": "stimulates_leydig_cells",             # NBK539692
+    "fsh": "stimulates_follicle_growth",         # NBK535442
+}
+REL = "targets"
+VAR = "Target"
+
+
+def _cli_available() -> bool:
+    return CLI.exists()
+
+
+def _run(program: Path) -> dict:
+    out = subprocess.run([str(CLI), str(program)], capture_output=True, text=True,
+                         cwd=str(HERE), timeout=60)
+    assert out.returncode == 0, f"adj-lang-cli failed: {out.stderr}"
+    return json.loads(out.stdout)
+
+
+# ---- 1. the ADJ file is the artifact — every clause grounded, no authored-debt ----
+
+def test_library_is_pure_adj_and_fully_grounded() -> None:
+    text = ADJ.read_text()
+    assert "trust consensus" not in text, "PITUITARY ships no authored-debt; ground or omit"
+    assert "[FLAG:" not in text
+    edge_count = len(EXPECTED)  # 6
+    assert text.count("    relate ") == edge_count
+    assert text.count("trust authoritative") == edge_count
+    assert text.count('\n        locator "') == edge_count
+    assert text.count('\n        source "') == edge_count
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("locator "):
+            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+    assert not (HERE / "pituitary_hormone_edge_ground.py").exists()
+    assert not (HERE / "pituitary-hormone-edge-grounding.json").exists()
+    assert not (HERE / "pituitary-hormone-edge-manifest.json").exists()
+
+
+# ---- 2. the engine binds each target with an authoritative citation ----------------
+
+def test_engine_binds_every_target_with_authoritative_citation() -> None:
+    if not _cli_available():
+        return
+    result = _run(QUERY)
+    by_query = {r["query"]: r for r in result["recall"]}
+    for hormone, target in EXPECTED.items():
+        q = f"{REL}({hormone}, {VAR})"
+        r = by_query.get(q)
+        assert r is not None and not r["abstained"], f"{q} abstained — edge missing?"
+        bound = {}
+        for a in r["answers"]:
+            bound[a["bindings"][VAR]] = (a.get("citations") or [{}])[0]
+        assert set(bound) == {target}, f"{hormone}: bound {set(bound)} != {{{target}}}"
+        cite = bound[target]
+        assert cite.get("trust") == "authoritative", f"{hormone}/{target} not authoritative"
+        assert cite.get("source"), f"{hormone}/{target} has no source span"
+        assert cite.get("locator", "").startswith("https://www.ncbi.nlm.nih.gov/")
+
+
+# ---- 3. an off-vocabulary hormone abstains, never fabricates ------------------------
+
+def test_unknown_hormone_abstains() -> None:
+    if not _cli_available():
+        return
+    import os
+    import tempfile
+    fd, path = tempfile.mkstemp(suffix=".adj", prefix=".pituitary_q_", dir=HERE)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            # oxytocin is a real posterior-pituitary hormone but is deliberately
+            # not in this library, so the engine must abstain rather than
+            # fabricate.
+            fh.write(f'import "pituitary-hormone-edges.adj"\n? {REL}(oxytocin, ${VAR})\n')
+        res = _run(Path(path))
+        r = res["recall"][0] if res["recall"] else None
+        assert r is not None and r["abstained"], "an ungrounded hormone must abstain"
+    finally:
+        os.unlink(path)
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS  {t.__name__}")
+        except AssertionError as exc:
+            failed += 1
+            print(f"  FAIL  {t.__name__}: {exc}")
+    print(f"\ntest_pituitary_hormone_recall: {len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())


### PR DESCRIPTION
## What

A new **pure-ADJ recall domain** for MYCIN-2026: the pituitary-hormone→target knowledge graph — a high-yield endocrine-physiology board table mapping each major pituitary hormone (anterior tropic hormones + posterior ADH) to the target organ/effect it acts on.

`pituitary-hormone-edges.adj` is the **SOLE shipped artifact and source of truth** — no Python gate, no JSON, no manifest — following the BONECELL / AUTONOMIC / GIHORMONE / CONDUCTION pattern. It is **distinct from the legacy endocrine domain**: a brand-new pure-ADJ file on the pituitary-axis hormone→target topic. Each `relate targets(hormone, target)` clause carries inline byte-provenance: a VERBATIM NCBI StatPearls/Bookshelf span, an `https` NCBI locator, and `trust authoritative`.

## Edges (6)

Each edge is defended by a **self-contained** NCBI Bookshelf sentence that names BOTH the hormone and its target/effect AND the relationship, **independently re-fetched and confirmed byte-stable on two separate fetches**:

| Hormone | Target | Source |
|---|---|---|
| `tsh` | thyroid_gland | [NBK499898](https://www.ncbi.nlm.nih.gov/books/NBK499898/) |
| `acth` | adrenal_cortex | [NBK500031](https://www.ncbi.nlm.nih.gov/books/NBK500031/) |
| `prolactin` | mammary_gland | [NBK507829](https://www.ncbi.nlm.nih.gov/books/NBK507829/) |
| `adh` | promotes_water_reabsorption (kidney) | [NBK526069](https://www.ncbi.nlm.nih.gov/books/NBK526069/) |
| `lh` | stimulates_leydig_cells (testosterone) | [NBK539692](https://www.ncbi.nlm.nih.gov/books/NBK539692/) |
| `fsh` | stimulates_follicle_growth (ovarian) | [NBK535442](https://www.ncbi.nlm.nih.gov/books/NBK535442/) |

## Files

- `pituitary-hormone-edges.adj` — the grounded library (dictionary + rulebook)
- `pituitary-hormone-recall.query.adj` — worked binding queries (the LLM-produced shape: imports the library, asks `? targets(<hormone>, $Target)`)
- `test_pituitary_hormone_recall.py` — 3-test scaffold: (1) pure-ADJ / no-authored-debt file shape (every clause grounded, all locators NCBI, no JSON/manifest/python sidecars); (2) the native adj-lang engine binds each target with an authoritative NCBI citation; (3) an off-vocabulary hormone (`oxytocin`) abstains rather than fabricates. **3/3 pass locally.**

## Notes

- The query `.adj` states no physiology fact — it only imports the library and asks binding queries; the engine resolves them and returns the binding plus the citing clause's source/locator/trust. Knowledge lives in ADJ; the engine answers.
- No edges deferred: all 6 targeted hormones yielded a qualifying self-contained Bookshelf span. ADH/LH/FSH are faithfully bound to the effect their cited sentence actually states (kidney water reabsorption; Leydig-cell testosterone; ovarian-follicle maturation). GH and oxytocin are out of scope this batch.
- Security review: PASSED (Python test uses list-argv subprocess with timeout, atomic \`mkstemp\` tempfile, \`json.loads\` on trusted local-binary output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)