### PR TITLE
feat(r-lang): R-43 — matrix norms (norm)

### DIFF
--- a/code/packages/rust/r-runtime/CHANGELOG.md
+++ b/code/packages/rust/r-runtime/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.39.0] - 2026-06-25
+
+### Added (via the shared `s-runtime`)
+
+- **R-43 — `norm(x, type)` matrix norms**, reached through ordinary R syntax.
+  `norm(x, type = "O")` collapses a numeric matrix to a single non-negative
+  number; the one-letter, case-insensitive `type` chooses the norm:
+  - **`"O"`/`"1"`** one-norm (max absolute column sum — R's default), **`"I"`**
+    infinity-norm (max absolute row sum), **`"F"`/`"E"`** Frobenius/Euclidean
+    (`sqrt(sum of squares)`), **`"M"`** max-modulus (max absolute element).
+  - A bare numeric vector is treated as an `n × 1` matrix, so
+    `norm(c(3,4), "F")` is `5`. `type` may be positional or named (`type =`).
+  - `norm(matrix(c(1,2,3,4), nrow=2))` is `7`; `…, "I")` is `6`; `…, "F")` is
+    `sqrt(30) ≈ 5.477`; `norm(matrix(c(1,-5,3,4), nrow=2), "M")` is `5`.
+  - Any `NA` entry → `NA`; an unknown `type` is a clean error (never a panic).
+  - **Deferred to R-48**: `type = "2"` (spectral norm, needs an SVD) is a clear
+    *"type '2' (spectral) not yet supported"* error for now.
+
 ## [0.38.0] - 2026-06-25
 
 ### Added (via the shared `s-runtime`)

--- a/code/packages/rust/r-runtime/README.md
+++ b/code/packages/rust/r-runtime/README.md
@@ -333,6 +333,20 @@ first `k` rows of `x`), **`upper.tri=`** (which triangle to read — so
 **`transpose=TRUE`** (solve `t(R) %*% y = x`). The R-41 behavior is unchanged when
 the options are omitted, and `k` is range-checked.
 
+**R-43 — `norm(x, type)` (matrix norms)** collapses a numeric matrix to a single
+non-negative "size", through the shared `s-runtime`. The one-letter,
+**case-insensitive** `type` chooses the norm: **`"O"`/`"1"`** one-norm (max
+absolute **column** sum — R's default), **`"I"`** infinity-norm (max absolute
+**row** sum), **`"F"`/`"E"`** Frobenius/Euclidean (`sqrt(Σ x[i,j]²)`), **`"M"`**
+max-modulus (max `|x[i,j]|`). A bare numeric vector is treated as an `n×1` matrix,
+so `norm(c(3,4), "F")` is `5`; `type` may be positional or named.
+`norm(matrix(c(1,2,3,4), nrow=2))` is `7`, `…, "I")` is `6`, `…, "F")` is
+`sqrt(30) ≈ 5.477`, `norm(matrix(c(1,-5,3,4), nrow=2), "M")` is `5`. It reuses the
+shared `matrix_parts` reader (column-major, **rectangular** — not `square_matrix`)
+and `as_double` for the vector promotion; any `NA` entry → `NA`, and an unknown
+`type` is a clean error (never a panic). `type = "2"` (the spectral norm, needs an
+SVD) is deferred to **R-48** with a clear *"not yet supported"* error.
+
 **R-44 — base R Date support** adds R's first calendar type, again through the
 shared `s-runtime`. A **`Date`** is *not* a new value kind: it is a numeric vector
 of **days since the Unix epoch 1970-01-01** carrying class `"Date"` (the existing

--- a/code/packages/rust/r-runtime/src/lib.rs
+++ b/code/packages/rust/r-runtime/src/lib.rs
@@ -3598,6 +3598,105 @@ mod tests {
         assert!((y[1] - 3.0).abs() < 1e-9);
     }
 
+    // --- R-43: norm(x, type) — matrix norms (R syntax) ------------------
+
+    #[test]
+    fn norm_default_one_norm_through_r_syntax() {
+        // Default type = "O" (one-norm): max absolute COLUMN sum.
+        // matrix(c(1,2,3,4), nrow=2) col-major -> cols (1,2) and (3,4).
+        // |1|+|2| = 3, |3|+|4| = 7 -> max = 7.
+        assert_eq!(nums("norm(matrix(c(1,2,3,4), nrow = 2))\n"), vec![7.0]);
+        // Explicit "O" and "1" agree with the default.
+        assert_eq!(nums("norm(matrix(c(1,2,3,4), nrow = 2), \"O\")\n"), vec![7.0]);
+        assert_eq!(nums("norm(matrix(c(1,2,3,4), nrow = 2), \"1\")\n"), vec![7.0]);
+    }
+
+    #[test]
+    fn norm_infinity_norm_through_r_syntax() {
+        // type = "I" (infinity-norm): max absolute ROW sum.
+        // rows of [[1,3],[2,4]]: |1|+|3| = 4, |2|+|4| = 6 -> max = 6.
+        assert_eq!(nums("norm(matrix(c(1,2,3,4), nrow = 2), \"I\")\n"), vec![6.0]);
+    }
+
+    #[test]
+    fn norm_frobenius_through_r_syntax() {
+        // type = "F"/"E" (Frobenius): sqrt(sum of squares).
+        // sqrt(1 + 4 + 9 + 16) = sqrt(30) ~= 5.477225575.
+        let f = nums("norm(matrix(c(1,2,3,4), nrow = 2), \"F\")\n");
+        assert_eq!(f.len(), 1);
+        assert!((f[0] - 30f64.sqrt()).abs() < 1e-9);
+        // "E" is an accepted alias for the Euclidean (Frobenius) norm.
+        let e = nums("norm(matrix(c(1,2,3,4), nrow = 2), \"E\")\n");
+        assert!((e[0] - 30f64.sqrt()).abs() < 1e-9);
+    }
+
+    #[test]
+    fn norm_max_modulus_through_r_syntax() {
+        // type = "M": max absolute ELEMENT. Negatives go through abs.
+        assert_eq!(nums("norm(matrix(c(1,-5,3,4), nrow = 2), \"M\")\n"), vec![5.0]);
+    }
+
+    #[test]
+    fn norm_type_is_case_insensitive_through_r_syntax() {
+        // R lower-cases type before matching: "o", "f", "i", "m" all work.
+        assert_eq!(nums("norm(matrix(c(1,2,3,4), nrow = 2), \"o\")\n"), vec![7.0]);
+        assert_eq!(nums("norm(matrix(c(1,2,3,4), nrow = 2), \"i\")\n"), vec![6.0]);
+        assert_eq!(nums("norm(matrix(c(1,-5,3,4), nrow = 2), \"m\")\n"), vec![5.0]);
+        let f = nums("norm(matrix(c(1,2,3,4), nrow = 2), \"f\")\n");
+        assert!((f[0] - 30f64.sqrt()).abs() < 1e-9);
+    }
+
+    #[test]
+    fn norm_named_type_argument_through_r_syntax() {
+        // type may be passed by name as well as positionally.
+        assert_eq!(nums("norm(matrix(c(1,2,3,4), nrow = 2), type = \"I\")\n"), vec![6.0]);
+    }
+
+    #[test]
+    fn norm_vector_promoted_to_one_column_matrix_through_r_syntax() {
+        // A plain numeric vector is treated as an n*1 matrix.
+        // Frobenius of c(3,4) is the 3-4-5 right triangle -> 5.
+        assert_eq!(nums("norm(c(3, 4), \"F\")\n"), vec![5.0]);
+        // One-norm: the single column's absolute sum = 3 + 4 = 7.
+        assert_eq!(nums("norm(c(3, 4), \"O\")\n"), vec![7.0]);
+        // Infinity-norm: the largest single-element row = 4.
+        assert_eq!(nums("norm(c(3, 4), \"I\")\n"), vec![4.0]);
+        // Max-modulus = 4.
+        assert_eq!(nums("norm(c(3, 4), \"M\")\n"), vec![4.0]);
+    }
+
+    #[test]
+    fn norm_handles_negative_entries_through_r_syntax() {
+        // Every norm uses absolute values, so signs do not matter beyond |.|.
+        // matrix(c(-1,-2,-3,-4), nrow=2): one-norm still 7, Frobenius still sqrt(30).
+        assert_eq!(nums("norm(matrix(c(-1,-2,-3,-4), nrow = 2), \"O\")\n"), vec![7.0]);
+        let f = nums("norm(matrix(c(-1,-2,-3,-4), nrow = 2), \"F\")\n");
+        assert!((f[0] - 30f64.sqrt()).abs() < 1e-9);
+    }
+
+    #[test]
+    fn norm_na_propagates_through_r_syntax() {
+        // An NA entry makes the whole result NA (base R semantics).
+        assert_eq!(show("norm(matrix(c(1, NA, 3, 4), nrow = 2))\n"), "[1] NA");
+        assert_eq!(show("norm(matrix(c(1, NA, 3, 4), nrow = 2), \"F\")\n"), "[1] NA");
+    }
+
+    #[test]
+    fn norm_unknown_type_is_clean_error_through_r_syntax() {
+        // An unrecognised type letter is a clean error, never a panic.
+        let err = eval_r("norm(matrix(c(1,2,3,4), nrow = 2), \"Z\")\n").unwrap_err();
+        assert!(!format!("{err}").is_empty());
+    }
+
+    #[test]
+    fn norm_spectral_type_deferred_error_through_r_syntax() {
+        // type = "2" (spectral norm, needs SVD) is deferred to R-48: a clear
+        // error mentioning the unsupported type, not a wrong number or a panic.
+        let err = eval_r("norm(matrix(c(1,2,3,4), nrow = 2), \"2\")\n").unwrap_err();
+        let msg = format!("{err}").to_lowercase();
+        assert!(msg.contains('2') || msg.contains("spectral"));
+    }
+
     // --- R-35: ordered factors & cut() label polish (R syntax) ----------
 
     #[test]

--- a/code/packages/rust/s-runtime/CHANGELOG.md
+++ b/code/packages/rust/s-runtime/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.40.0] - 2026-06-25
+
+### Added
+
+- **Matrix norms — `norm(x, type = "O")` (R-43)** — a new linear-algebra builtin
+  in the shared tree-walker, available to both S and R. `norm` reduces a numeric
+  matrix to a single non-negative number; the one-letter, **case-insensitive**
+  `type` selects which norm:
+  - **`"O"` / `"1"`** — the one-norm: maximum absolute **column** sum (R's
+    default `type`).
+  - **`"I"`** — the infinity-norm: maximum absolute **row** sum.
+  - **`"F"` / `"E"`** — the Frobenius / Euclidean norm: `sqrt(Σ x[i,j]²)`.
+  - **`"M"`** — the max-modulus: maximum absolute element.
+  - A plain numeric **vector** is treated as an `n × 1` column matrix, so
+    `norm(c(3,4), "F")` is `5`. `type` may be positional or named (`type =`).
+  - **Reuse**: dims+data come from the shared `matrix_parts` reader (column-major
+    `(data, nrow, ncol)` — rectangular matrices, not just square); the vector
+    case promotes through `as_double`; `type =` is read as a named/positional
+    string; the result is a `SValue::scalar`.
+  - **Safety**: any `NA` entry → `NA`; an unknown `type` is a clean error (never
+    a panic); an empty matrix does not panic; the Frobenius sum-of-squares
+    accumulates in `f64` (no overflow).
+  - **Deferred to R-48**: `type = "2"` (the spectral norm = largest singular
+    value, needs an SVD) returns a clear *"type '2' (spectral) not yet
+    supported"* error for now.
+
 ## [0.39.0] - 2026-06-25
 
 ### Added

--- a/code/packages/rust/s-runtime/README.md
+++ b/code/packages/rust/s-runtime/README.md
@@ -320,6 +320,19 @@ a hand-written loop. See [What "S-flavored" means here](#what-s-flavored-means-h
   base-R options: **`k=`** (use the leading `k×k` block + first `k` rows of `x`),
   **`upper.tri=`** (which triangle to read — so `backsolve(L, x, upper.tri=FALSE)`
   equals `forwardsolve(L, x)`), and **`transpose=TRUE`** (solve `t(R) %*% y = x`).
+- **Matrix norms** (R-43): **`norm(x, type = "O")`** — collapses a numeric matrix
+  to a single non-negative "size". The one-letter, **case-insensitive** `type`
+  picks the norm: **`"O"`/`"1"`** one-norm (max absolute **column** sum, R's
+  default), **`"I"`** infinity-norm (max absolute **row** sum), **`"F"`/`"E"`**
+  Frobenius/Euclidean (`sqrt(Σ x[i,j]²)`), **`"M"`** max-modulus (max `|x[i,j]|`).
+  A bare numeric vector becomes an `n×1` column, so `norm(c(3,4), "F")` is `5`;
+  `type` may be positional or named. Reuses the shared `matrix_parts` reader
+  (column-major, **rectangular** — not `square_matrix`) and `as_double` for the
+  vector promotion. Any `NA` entry → `NA`; an unknown `type` is a clean error (no
+  panic); the Frobenius sum-of-squares accumulates in `f64` (no overflow).
+  `norm(matrix(c(1,2,3,4), nrow=2))` is `7`, `…, "I")` is `6`, `…, "F")` is
+  `sqrt(30) ≈ 5.477`. `type = "2"` (the spectral norm, needs an SVD) is deferred
+  to R-48 with a clear error.
 - **Kronecker product** (R-38): **`kronecker(X, Y)`** — the `(m·p)×(n·q)`
   block-outer product of an `m×n` `X` and a `p×q` `Y`, where block `(i, j)` is
   `X[i,j] · Y` and `result[(i-1)·p+k, (j-1)·q+l] = X[i,j] · Y[k,l]`

--- a/code/packages/rust/s-runtime/src/builtins.rs
+++ b/code/packages/rust/s-runtime/src/builtins.rs
@@ -299,6 +299,12 @@ pub fn install(env: &Env) {
     define(env, "rbind", builtin("rbind", b_rbind));
     define(env, "solve", builtin("solve", b_solve));
     define(env, "det", builtin("det", b_det));
+    // Matrix norms (R-43): one-norm ("O"/"1"), infinity-norm ("I"), Frobenius/
+    // Euclidean ("F"/"E"), and max-modulus ("M"). Reuses the shared matrix_parts
+    // reader (rectangular matrices, not just square) and as_double for the
+    // vector→1-column promotion. The spectral norm ("2", needs SVD) is deferred
+    // to R-48 with a clear error.
+    define(env, "norm", builtin("norm", b_norm));
     // Cholesky factorization (R-40): upper-triangular R with t(R) %*% R == X.
     // Reuses the `square_matrix` reader (shared with solve/det) and the
     // SValue::Matrix constructor. pivot=TRUE / chol2inv / complex deferred to R-41.
@@ -1292,6 +1298,137 @@ fn b_det(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
         }
     }
     Ok(SValue::scalar(det))
+}
+
+/// `norm(x, type = "O")` — a **matrix norm**: one number measuring the "size" of
+/// a numeric matrix `x`. `type` is a one-letter, case-insensitive string picking
+/// *which* norm; each is a different way of collapsing all the `|x[i,j]|` into a
+/// single non-negative scalar:
+///
+/// ```text
+///   type            name              formula
+///   ----            ----              -------
+///   "O" / "1"       one-norm          max over columns j of  Σ_i |x[i,j]|
+///   "I"             infinity-norm     max over rows    i of  Σ_j |x[i,j]|
+///   "F" / "E"       Frobenius/        sqrt( Σ_{i,j} x[i,j]² )
+///                   Euclidean
+///   "M"             max-modulus       max_{i,j} |x[i,j]|
+/// ```
+///
+/// Intuition: the one-norm asks "which **column** is biggest (in absolute sum)?",
+/// the infinity-norm asks the same of **rows**, the Frobenius norm treats the
+/// matrix as one long vector and takes its Euclidean length, and the max-modulus
+/// is simply the largest single entry by magnitude.
+///
+/// `x` may also be a plain numeric **vector**, which R (and we) treat as an
+/// `n × 1` (single-**column**) matrix. So `norm(c(3,4), "F")` is `sqrt(3²+4²) = 5`
+/// (the 3-4-5 right triangle), `norm(c(3,4), "O")` is the lone column's absolute
+/// sum `7`, and `norm(c(3,4), "I")` is the largest single-element row `4`.
+///
+/// **Reuse.** Dimensions + data come from the shared [`matrix_parts`] reader
+/// (`(data, nrow, ncol)`, column-major), *not* `square_matrix` — norms apply to
+/// rectangular matrices too. The vector case promotes through `as_double`, and
+/// `type =` is read with the same named-or-positional string convention as other
+/// builtins (`as_character` of the first non-`x` argument). The result is a
+/// `SValue::scalar`.
+///
+/// **Safety / NA.** Any `NA` entry makes the result `NA` (base R propagates `NA`
+/// through these reductions). An unknown `type` letter is a clean `BadArgs`
+/// error — never a panic. An empty / 0-row / 0-column matrix does not panic: the
+/// reductions start from `0`. The Frobenius sum-of-squares accumulates in `f64`,
+/// so no `MAX_SEQ_LEN`-legal matrix of finite entries can overflow.
+///
+/// **Deferred.** `type = "2"` is the *spectral* norm (the largest singular value);
+/// it needs an SVD and is deferred to **R-48**. For now it is a clear error
+/// rather than a wrong number.
+fn b_norm(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    // --- 1. Read x as (data, nrow, ncol), promoting a bare vector to n×1. ---
+    let x = first_positional(args)?;
+    let (data, nrow, ncol): (Vec<f64>, usize, usize) = match matrix_parts(x) {
+        Some((d, nr, nc)) => (d.data().to_vec(), nr, nc),
+        // A non-matrix numeric value → a single column (n rows, 1 column).
+        None => {
+            let d = x.as_double()?;
+            let n = d.len();
+            (d.data().to_vec(), n, 1)
+        }
+    };
+
+    // --- 2. NA anywhere ⇒ NA (matches base R for all of these reductions). ---
+    if data.iter().any(|v| is_na_real(*v)) {
+        return Ok(SValue::scalar(na_real()));
+    }
+
+    // --- 3. Read the `type` letter. It may be positional (the 2nd positional
+    // argument) or named `type =`; default "O" (R's default). Lower-case it so
+    // matching is case-insensitive, then look at just the first character. ---
+    let type_value = named_arg(args, "type").or_else(|| nth_positional(args, 1));
+    let type_str: String = match type_value {
+        Some(v) => match v.as_character().into_iter().next().flatten() {
+            // An explicit NA / empty `type` falls back to the default, as in R.
+            Some(s) if !s.is_empty() => s,
+            _ => "O".to_string(),
+        },
+        None => "O".to_string(),
+    };
+    let kind = type_str.trim().to_ascii_uppercase();
+    let first = kind.chars().next().unwrap_or('O');
+
+    // --- 4. Dispatch on the (upper-cased) first letter. Column-major data: the
+    // element at row i, column j lives at `j * nrow + i`. ---
+    let result = match first {
+        // One-norm: maximum absolute column sum. An empty matrix ⇒ 0.
+        'O' | '1' => {
+            let mut best = 0.0_f64;
+            for j in 0..ncol {
+                let mut col_sum = 0.0_f64;
+                for i in 0..nrow {
+                    col_sum += data[j * nrow + i].abs();
+                }
+                if col_sum > best {
+                    best = col_sum;
+                }
+            }
+            best
+        }
+        // Infinity-norm: maximum absolute row sum.
+        'I' => {
+            let mut best = 0.0_f64;
+            for i in 0..nrow {
+                let mut row_sum = 0.0_f64;
+                for j in 0..ncol {
+                    row_sum += data[j * nrow + i].abs();
+                }
+                if row_sum > best {
+                    best = row_sum;
+                }
+            }
+            best
+        }
+        // Frobenius / Euclidean: sqrt of the sum of squares of every entry.
+        'F' | 'E' => {
+            let mut ss = 0.0_f64;
+            for &v in &data {
+                ss += v * v;
+            }
+            ss.sqrt()
+        }
+        // Max-modulus: the largest absolute entry. Empty ⇒ 0.
+        'M' => data.iter().fold(0.0_f64, |m, &v| m.max(v.abs())),
+        // The spectral norm (largest singular value) needs an SVD; deferred.
+        '2' => {
+            return Err(SError::BadArgs(
+                "norm: type '2' (spectral) not yet supported".into(),
+            ));
+        }
+        // Anything else is an unrecognised norm type → a clean error.
+        _ => {
+            return Err(SError::BadArgs(format!(
+                "norm: 'type' must be one of \"O\"/\"1\", \"I\", \"F\"/\"E\", \"M\" (got {type_str:?})"
+            )));
+        }
+    };
+    Ok(SValue::scalar(result))
 }
 
 /// `solve(a)` → the inverse of `a`; `solve(a, b)` → the `x` solving `a %*% x = b`

--- a/code/specs/R00-r-language.md
+++ b/code/specs/R00-r-language.md
@@ -1182,6 +1182,46 @@ unchanged.
     **Deferred to R-34:** `dig.lab =` (significant-digit control of auto-label
     formatting) and `ordered_result =` (an ordered factor result). The `%o%` infix
     alias for `outer` remains open for a later grammar pass.
+- **R-43 — `norm(x, type)` (matrix norms)** *(this PR)*. An **independent
+  matrix-algebra item** in the R-12/R-40/R-41 family: `norm(x, type = "O")`
+  reduces a numeric matrix `x` to a single non-negative number measuring its
+  "size". `type` is a one-letter string, **case-insensitive** (R lower-cases it
+  before matching), and selects which norm:
+  - **`"O"` / `"o"` / `"1"`** — the **one-norm**: the maximum absolute *column*
+    sum, `max_j Σ_i |x[i,j]|`. This is R's **default** `type`.
+  - **`"I"` / `"i"`** — the **infinity-norm**: the maximum absolute *row* sum,
+    `max_i Σ_j |x[i,j]|`.
+  - **`"F"` / `"f"` / `"E"` / `"e"`** — the **Frobenius** (a.k.a. Euclidean)
+    norm: `sqrt(Σ_{i,j} x[i,j]²)`, the entrywise 2-norm. The sum of squares
+    accumulates in `f64` (never an intermediate integer) so it cannot overflow
+    for any `MAX_SEQ_LEN`-legal matrix of finite entries.
+  - **`"M"` / `"m"`** — the **max-modulus**: the maximum absolute element,
+    `max_{i,j} |x[i,j]|`.
+  - **Vector promotion.** A plain numeric **vector** (not a `matrix`) is treated
+    as a single-**column** matrix (`n×1`), exactly as base R does. So
+    `norm(c(3,4), "F") == 5` (a 3-4-5 right triangle), `norm(c(3,4), "O") == 7`
+    (the lone column's absolute sum), and `norm(c(3,4), "I") == 4` (the largest
+    row, here a single element). `norm(c(3,4), "M") == 4`.
+  - **Reuse.** Reads dims+data through the shared **`matrix_parts`** helper
+    (column-major `(data, nrow, ncol)`) — *not* `square_matrix`, because norms
+    apply to **rectangular** matrices too. The vector case promotes through the
+    shared `as_double` coercion. The `type =` argument is read with the same
+    named-/positional-string convention as other builtins (`as_character` of the
+    first non-`x` argument), and the result is a `SValue::scalar`.
+  - **NA / safety.** Any `NA` entry makes the result `NA` (base R propagates `NA`
+    through these reductions). An **unknown `type`** (any letter not in the set
+    above) is a **clean error**, never a panic. An empty / 0-row / 0-column
+    matrix does not panic (the column/row/element reductions start from `0`).
+  - **Worked examples (column-major).**
+    `norm(matrix(c(1,2,3,4), nrow=2))` (default `"O"`): columns `(1,2)→3`,
+    `(3,4)→7` ⇒ **7**.
+    `norm(matrix(c(1,2,3,4), nrow=2), "I")`: rows `|1|+|3|=4`, `|2|+|4|=6` ⇒ **6**.
+    `norm(matrix(c(1,2,3,4), nrow=2), "F") = sqrt(1+4+9+16) = sqrt(30) ≈ 5.477`.
+    `norm(matrix(c(1,-5,3,4), nrow=2), "M") = 5` (negatives go through `abs`).
+  - **Deferred to R-48.** `type = "2"` — the **spectral norm** (the largest
+    singular value) — needs an SVD and is **deferred to R-48**; for now a
+    `type = "2"` request returns a clear *"norm type '2' (spectral) not yet
+    supported"* error rather than a wrong number. No grammar change in this item.
 - **R-42 — triangular-solve options (`k` / `upper.tri` / `transpose`)** *(this PR)*.
   Extends the R-41 `backsolve`/`forwardsolve` core (the shared
   `triangular_solve` helper in `s-runtime`) with base-R's three named options.
@@ -1232,10 +1272,12 @@ unchanged.
     `0 ≤ k ≤ n` (a malformed/out-of-range `k` is a clean error, never an
     out-of-bounds read). RHS row/column counts are validated before any indexing;
     order and column caps come from `square_matrix`/`MAX_SOLVE_DIM` as before.
-  - **Deferred to R-43.** Exotic full cross-products of all three options with a
-    *wide multi-column* matrix RHS beyond the cases tested here, and any pivoted
-    variants, are deferred to **R-43**. R-42 ships each option **independently**
+  - **Deferred to a later item.** Exotic full cross-products of all three options
+    with a *wide multi-column* matrix RHS beyond the cases tested here, and any
+    pivoted variants, are deferred. R-42 ships each option **independently**
     plus the common combinations (each with vector and the tested matrix RHS).
+    (R-43 itself is now `norm()`; the residual triangular-solve corner cases move
+    to a later linear-algebra item.)
 - **R-41 — `backsolve()` / `forwardsolve()` (triangular solves)** *(previous PR)*.
   An **independent matrix-algebra item** in the same family as R-12/R-40, landed
   in the shared `s-runtime` (R reuses it verbatim through the shared

--- a/code/specs/S00-s-language.md
+++ b/code/specs/S00-s-language.md
@@ -377,8 +377,27 @@ needs a string assignment target: `"%between%" <- function(x, r) x >= r[1] & x <
   `backsolve(matrix(c(2,0,1,3), nrow=2), c(4,11), transpose = TRUE)` solves the
   lower-triangular `t(R) = [[2,0],[1,3]]` ⇒ `c(2,3)`. Exotic full
   cross-products of all three options with a *wide* multi-column matrix RHS are
-  **deferred to R-43**; R-42 ships each option independently plus the common
-  combinations.
+  **deferred to a later linear-algebra item** (R-43 itself is now `norm()`); R-42
+  ships each option independently plus the common combinations.
+- **Matrix norms** *(R-43)*: `norm(x, type = "O")` reduces a numeric matrix to a
+  single non-negative "size". `type` is a one-letter, **case-insensitive** string
+  selecting the norm: **`"O"`/`"1"`** the one-norm (max absolute *column* sum,
+  R's default), **`"I"`** the infinity-norm (max absolute *row* sum),
+  **`"F"`/`"E"`** the Frobenius/Euclidean norm (`sqrt(Σ x[i,j]²)`), **`"M"`** the
+  max-modulus (max `|x[i,j]|`). A plain numeric **vector** is treated as an `n×1`
+  matrix, so `norm(c(3,4), "F") == 5`. **Reuse:** dims+data come from the shared
+  **`matrix_parts`** helper (column-major `(data, nrow, ncol)` — *not*
+  `square_matrix`, since norms apply to rectangular matrices); the vector case
+  promotes through `as_double`; `type =` is read as a named-or-positional string
+  (`as_character`); the result is a `SValue::scalar`. **Safety:** any `NA` entry
+  ⇒ `NA`; an **unknown `type`** is a clean error (never a panic); an empty matrix
+  does not panic (reductions start from `0`); the Frobenius sum-of-squares
+  accumulates in `f64` (no integer overflow). Worked examples (column-major):
+  `norm(matrix(c(1,2,3,4), nrow=2))` is `7` (one-norm), `…, "I")` is `6`,
+  `…, "F")` is `sqrt(30) ≈ 5.477`, `norm(matrix(c(1,-5,3,4), nrow=2), "M")` is `5`.
+  **`type = "2"`** (the spectral norm = largest singular value) needs an SVD and
+  is **deferred to R-48**; for now it returns a clear *"norm type '2' (spectral)
+  not yet supported"* error rather than a wrong number.
 - **Cholesky factorization** *(R-40)*: `chol(X)`, the Cholesky factor of a real
   symmetric positive-definite `n×n` matrix. Returns the **upper-triangular**
   matrix `R` with **`t(R) %*% R == X`** (R's convention — the upper factor, so


### PR DESCRIPTION
Implements **R-43 — `norm(x, type)`** in the shared S tree-walker
(`s-runtime/src/builtins.rs`), available to both S and R, with R-syntax tests in
`r-runtime`.

## What

`norm(x, type = "O")` reduces a numeric matrix to a single non-negative number.
The one-letter, **case-insensitive** `type` selects the norm:

| `type` | norm | formula |
| --- | --- | --- |
| `"O"` / `"1"` | one-norm | max absolute **column** sum (R's **default**) |
| `"I"` | infinity-norm | max absolute **row** sum |
| `"F"` / `"E"` | Frobenius / Euclidean | `sqrt(Σ x[i,j]²)` |
| `"M"` | max-modulus | max `|x[i,j]|` |

- **Default** `type = "O"` (R's default).
- **Vector promotion**: a bare numeric vector is treated as an `n × 1` (single-column)
  matrix, so `norm(c(3,4), "F") == 5`.
- `type` may be positional or named (`type =`).

## Reuse (no reinvention)

Reads dims+data through the shared `matrix_parts` reader (column-major
`(data, nrow, ncol)`) — **not** `square_matrix`, since norms apply to rectangular
matrices. The vector case promotes through `as_double`; `type =` is read with the
named/positional string convention; the result is a `SValue::scalar`.

## Safety

Any `NA` entry → `NA` (base R semantics); an unknown `type` is a clean error
(never a panic); an empty/0-row/0-column matrix does not panic (reductions start
from `0`); the Frobenius sum-of-squares accumulates in `f64` (no overflow);
column-major indexing stays in bounds. Inline security review found no issues.

## Worked examples

`norm(matrix(c(1,2,3,4), nrow=2))` is `7`; `…, "I")` is `6`; `…, "F")` is
`sqrt(30) ≈ 5.477`; `norm(matrix(c(1,-5,3,4), nrow=2), "M")` is `5`.

## Deferred

`type = "2"` — the **spectral norm** (largest singular value, needs an SVD) — is
**deferred to R-48**; for now it returns a clear
*"type '2' (spectral) not yet supported"* error rather than a wrong number. No
grammar change.

## Tests

321 `s-runtime` + 347 `r-runtime` tests pass, including 11 new R-syntax `norm`
tests covering all four norm types, case-insensitivity, named `type=`, vector
promotion, negative entries, NA propagation, the unknown-type error, and the
spectral-norm deferral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)