### PR TITLE
feat(closurec): fold "abcd".substring(start[,end]) at SIMPLE/ADVANCED

### DIFF
--- a/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to the `coding-adventures-closure-pass-constant-fold` crate will be documented in this file.
 
+## [0.39.0] - 2026-06-24
+
+### Added — fold `"abcd".substring(start[, end])` on string literals
+
+`String.prototype.substring` now folds to a string literal when the receiver is
+a string literal and any provided arguments are integer literals (ECMAScript
+§22.1.3.24). It is the sibling of the already-folded `slice`, but with two
+distinct semantics, both modelled:
+
+- **Clamping into `[0, len]`** — a negative (or `NaN`) argument becomes `0`; it
+  never counts from the end the way `slice` does. `"abcd".substring(-2)` →
+  `"abcd"` (whereas `"abcd".slice(-2)` → `"cd"`).
+- **Endpoint ordering** — after clamping, the smaller index is the start, so
+  `start > end` makes the two SWAP: `"abcd".substring(3, 1)` and
+  `"abcd".substring(1, 3)` both → `"bc"`.
+
+Examples: `"abcd".substring(1, 3)` → `"bc"`, `"abcd".substring(2)` → `"cd"`,
+`"abc".substring()` → `"abc"`, `"abcd".substring(10)` → `""` (start clamps to
+`len`). Indices are UTF-16 code units (sharing `slice`/`charAt` machinery), so
+`"💩ab".substring(2)` → `"ab"`.
+
+Conservative scope mirrors `slice`: the helper declines (leaving the call for
+the runtime) for a non-integer-literal argument (we don't model `ToInteger`
+coercion), more than two arguments, or a cut that would split a surrogate pair
+into a lone surrogate (a valid JS string but not a Rust `String`).
+
 ## [0.31.0] - 2026-06-22
 
 ### Added — fold `"abc".at(i)` on string literals (negative-from-end indexing)

--- a/code/packages/rust/closure-pass-constant-fold/Cargo.toml
+++ b/code/packages/rust/closure-pass-constant-fold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-constant-fold"
-version = "0.35.0"
+version = "0.39.0"
 edition = "2021"
 description = "Constant-folding optimization pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Folds compile-time-evaluable expressions like `2 + 3 → 5`."
 

--- a/code/packages/rust/closure-pass-constant-fold/src/lib.rs
+++ b/code/packages/rust/closure-pass-constant-fold/src/lib.rs
@@ -569,6 +569,34 @@ fn fold_call(c: &CallExpression, st: &mut FoldState) -> Expression {
                         return stamp_literal_cv(FoldedLiteral::String(result), new_cv);
                     }
                 }
+                // ---- substring(start[, end]) → the clamped, ordered cut ----
+                //
+                // `"abcd".substring(1, 3)` → `"bc"`, `"abcd".substring(2)` →
+                // `"cd"`, `"abcd".substring(3, 1)` → `"bc"` (the endpoints SWAP
+                // when start > end), `"abcd".substring(-2)` → `"abcd"` (a
+                // negative — or `NaN` — clamps to 0; substring NEVER counts from
+                // the end, that is `slice`'s job), `"abc".substring()` → `"abc"`
+                // (ECMAScript §22.1.3.24). Indices are UTF-16 code units.
+                // `fold_string_substring` returns `None` (leaving the call) for a
+                // non-integer-literal argument, more than two arguments, or a cut
+                // that would split a surrogate pair into a lone surrogate.
+                else if id.name == "substring" {
+                    if let Some(result) = fold_string_substring(&s.value, &arguments) {
+                        let parent = c.cv.clone();
+                        let args_src = arguments
+                            .iter()
+                            .map(|a| match a {
+                                Expression::NumericLiteral(n) => format_js_number(n.value),
+                                _ => "?".to_string(),
+                            })
+                            .collect::<Vec<_>>()
+                            .join(",");
+                        let before = format!("\"{}\".substring({})", s.value, args_src);
+                        let after = format!("\"{}\"", result);
+                        let new_cv = st.fork_cv(&parent, &before, &after);
+                        return stamp_literal_cv(FoldedLiteral::String(result), new_cv);
+                    }
+                }
                 // ---- repeat(count) → the string concatenated `count` times ----
                 //
                 // `"ab".repeat(3)` → `"ababab"` (ECMAScript §22.1.3.18). The
@@ -1005,6 +1033,64 @@ fn fold_string_slice(value: &str, args: &[Expression]) -> Option<String> {
 
     let lo = start as usize;
     let hi = end.max(start) as usize; // empty range when end < start
+    if lo >= hi {
+        return Some(String::new());
+    }
+    // A lone surrogate (split pair) can't be a Rust String — decline.
+    String::from_utf16(&units[lo..hi]).ok()
+}
+
+/// Fold `"…".substring(start[, end])` (ECMAScript §22.1.3.24).
+///
+/// `substring` differs from `slice` in two ways, both modelled here:
+///
+///   1. **Clamping.** Each index is clamped into `[0, len]`. A negative (or
+///      `NaN`) argument becomes `0` — it never counts from the end the way
+///      `slice` does. So `"abcd".substring(-2)` is the whole string, whereas
+///      `"abcd".slice(-2)` is `"cd"`.
+///   2. **Ordering.** After clamping, the smaller index is the start: when
+///      `start > end` the two endpoints SWAP. So `"abcd".substring(3, 1)` and
+///      `"abcd".substring(1, 3)` both yield `"bc"`.
+///
+/// Indices are UTF-16 code units (matching `slice`/`charAt`). Returns `None`
+/// (leaving the call for the runtime) for a non-integer-literal argument, more
+/// than two arguments, or a cut that would split a surrogate pair into a lone
+/// surrogate (a valid JS string but not a Rust `String`).
+fn fold_string_substring(value: &str, args: &[Expression]) -> Option<String> {
+    if args.len() > 2 {
+        return None;
+    }
+    // A provided argument must be a finite integer literal.
+    let to_int = |e: &Expression| -> Option<i64> {
+        match e {
+            Expression::NumericLiteral(n)
+                if n.value.is_finite()
+                    && n.value.fract() == 0.0
+                    && n.value.abs() < 9_007_199_254_740_992.0 =>
+            {
+                Some(n.value as i64)
+            }
+            _ => None,
+        }
+    };
+
+    let units: Vec<u16> = value.encode_utf16().collect();
+    let len = units.len() as i64;
+    // Clamp into [0, len]: negatives become 0 (no end-relative indexing).
+    let clamp = |idx: i64| -> i64 { idx.clamp(0, len) };
+
+    let start = match args.first() {
+        None => 0,
+        Some(e) => clamp(to_int(e)?),
+    };
+    let end = match args.get(1) {
+        None => len,
+        Some(e) => clamp(to_int(e)?),
+    };
+
+    // Swap so the cut is always the range [lo, hi).
+    let lo = start.min(end) as usize;
+    let hi = start.max(end) as usize;
     if lo >= hi {
         return Some(String::new());
     }
@@ -4109,6 +4195,114 @@ mod tests {
         });
         let (out, _, changed, _) = run_pass(program_with_expr(c, true));
         assert!(!changed, "s.slice(1) must not fold");
+        assert!(matches!(extract_expr(&out), Expression::CallExpression(_)));
+    }
+
+    // ------------------- substring (clamped, ordered cut) -------------
+
+    /// Build `"<recv>".substring(<args…>)`.
+    fn substring_call(recv: &str, args: &[f64]) -> Expression {
+        Expression::CallExpression(CallExpression {
+            cv: Some("c.cv".to_string()),
+            callee: Box::new(member(string(recv, None), "substring")),
+            arguments: args.iter().map(|&a| num(a, None)).collect(),
+        })
+    }
+
+    #[test]
+    fn fold_string_substring_clamps_and_swaps() {
+        // V8 oracle (node): each row is the exact runtime result.
+        //   "abcd".substring(1,3) === "bc"
+        //   "abcd".substring(2)   === "cd"
+        //   "abcd".substring(3,1) === "bc"   (endpoints swap)
+        //   "abcd".substring(-2)  === "abcd" (negative clamps to 0)
+        //   "abcd".substring(1,-1)=== "a"    (-1 clamps to 0, then swap → [0,1))
+        //   "abcd".substring(2,2) === ""     (empty range)
+        //   "abcd".substring(10)  === ""     (start clamps to len)
+        for (recv, args, expect) in [
+            ("abcd", vec![1.0, 3.0], "bc"),
+            ("abcd", vec![2.0], "cd"),
+            ("abcd", vec![3.0, 1.0], "bc"),
+            ("abcd", vec![-2.0], "abcd"),
+            ("abcd", vec![1.0, -1.0], "a"),
+            ("abcd", vec![2.0, 2.0], ""),
+            ("abcd", vec![10.0], ""),
+        ] {
+            let c = substring_call(recv, &args);
+            let (out, _, changed, _) = run_pass(program_with_expr(c, true));
+            assert!(changed, "\"{recv}\".substring({args:?}) should fold");
+            match extract_expr(&out) {
+                Expression::StringLiteral(s) => {
+                    assert_eq!(s.value, expect, "\"{recv}\".substring({args:?})")
+                }
+                other => panic!("expected \"{expect}\"; got {:?}", other),
+            }
+        }
+    }
+
+    #[test]
+    fn fold_string_substring_no_args_is_identity() {
+        // `"abc".substring()` → "abc" (whole string).
+        let c = Expression::CallExpression(CallExpression {
+            cv: Some("c.cv".to_string()),
+            callee: Box::new(member(string("abc", None), "substring")),
+            arguments: vec![],
+        });
+        let (out, _, changed, _) = run_pass(program_with_expr(c, true));
+        assert!(changed, "\"abc\".substring() should fold");
+        match extract_expr(&out) {
+            Expression::StringLiteral(s) => assert_eq!(s.value, "abc"),
+            other => panic!("expected \"abc\"; got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn substring_counts_utf16_units() {
+        // "💩" is two UTF-16 units; "💩ab".substring(2) drops the astral char
+        // and keeps "ab" — proving UTF-16 (not scalar) indexing.
+        let c = substring_call("💩ab", &[2.0]);
+        let (out, _, _, _) = run_pass(program_with_expr(c, true));
+        match extract_expr(&out) {
+            Expression::StringLiteral(s) => assert_eq!(s.value, "ab"),
+            other => panic!("expected \"ab\"; got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn substring_splitting_a_surrogate_pair_does_not_fold() {
+        // "💩".substring(0, 1) would be a lone high surrogate — a valid JS
+        // string but not a Rust `String`, so we decline (conservative).
+        let c = substring_call("💩", &[0.0, 1.0]);
+        let (out, _, changed, _) = run_pass(program_with_expr(c, true));
+        assert!(!changed, "substring splitting a surrogate pair must not fold");
+        assert!(matches!(extract_expr(&out), Expression::CallExpression(_)));
+    }
+
+    #[test]
+    fn substring_non_integer_or_too_many_args_does_not_fold() {
+        // Fractional argument: don't model ToInteger coercion.
+        let frac = substring_call("abcd", &[1.5]);
+        let (out, _, changed, _) = run_pass(program_with_expr(frac, true));
+        assert!(!changed, "fractional substring index must not fold");
+
+        // Three arguments: not the substring signature we model.
+        let three = substring_call("abcd", &[0.0, 1.0, 2.0]);
+        let (out2, _, changed2, _) = run_pass(program_with_expr(three, true));
+        assert!(!changed2, "three-arg substring must not fold");
+        assert!(matches!(extract_expr(&out), Expression::CallExpression(_)));
+        assert!(matches!(extract_expr(&out2), Expression::CallExpression(_)));
+    }
+
+    #[test]
+    fn substring_on_identifier_receiver_does_not_fold() {
+        // `s.substring(1)` needs the runtime value of `s`.
+        let c = Expression::CallExpression(CallExpression {
+            cv: Some("c.cv".to_string()),
+            callee: Box::new(member(ident("s"), "substring")),
+            arguments: vec![num(1.0, None)],
+        });
+        let (out, _, changed, _) = run_pass(program_with_expr(c, true));
+        assert!(!changed, "s.substring(1) must not fold");
         assert!(matches!(extract_expr(&out), Expression::CallExpression(_)));
     }
 

--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.188.0] - 2026-06-24
+
+### Added — SIMPLE/ADVANCED fold `"abcd".substring(start[, end])`
+
+Wires the new `String.prototype.substring` fold (constant-fold 0.39.0) end to
+end through the closurec CLI. At `--compilation_level SIMPLE` (and ADVANCED,
+which routes through the same typed pipeline), a `"…".substring(startLit[,
+endLit])` call on a string literal collapses to the substring string literal.
+
+`substring` is the sibling of the already-folded `slice` but clamps each index
+into `[0, len]` (a negative argument becomes 0 — it never counts from the end)
+and SWAPS the endpoints when `start > end`. New fixture
+`tests/diff/simple-fold-substring/` exercises exactly those rules:
+`"abcd".substring(1, 3)` → `"bc"`, `"abcd".substring(3, 1)` → `"bc"` (swap),
+`"abcd".substring(-2)` → `"abcd"` (clamp), `"abcd".substring(10)` → `""`, so the
+output is `var a="bc";var b="bc";var c="abcd";var d="";report(a,b,c,d);`.
+Integration test `diff_simple_fold_substring.rs` asserts the folded stdout, that
+no `.substring(` call survives, and that the result is the typed pipeline (not
+the WHITESPACE_ONLY fallback).
+
 ## [0.180.0] - 2026-06-22
 
 ### Added — string `at` fold at SIMPLE/ADVANCED (negative-from-end indexing)

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.184.0"
+version = "0.188.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.184.0",
+  "version": "0.188.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.184.0
+Version: 0.188.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff/simple-fold-substring/README.md
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-substring/README.md
@@ -1,0 +1,36 @@
+# Fixture: `simple-fold-substring`
+
+End-to-end oracle for folding `String.prototype.substring(start[, end])` on a
+string-literal receiver at `--compilation_level SIMPLE`.
+
+| File | Role |
+|------|------|
+| `flags.txt` | CLI args: `--compilation_level SIMPLE --js input/a.js` |
+| `input/a.js` | `"abcd".substring(1, 3)`, `"abcd".substring(3, 1)`, `"abcd".substring(-2)`, `"abcd".substring(10)` |
+| `expected.stdout` | The folded output: `var a="bc";var b="bc";var c="abcd";var d="";report(a,b,c,d);` |
+
+The SIMPLE level runs the typed-AST optimization pipeline, whose `constant-fold`
+pass folds a `"…".substring(startLit[, endLit])` call into the substring string
+literal (ECMAScript §22.1.3.24). `substring` is the sibling of the already-folded
+`slice`, but with two distinct semantics that this fixture is chosen to exercise:
+
+- `"abcd".substring(1, 3)` → `"bc"` — the plain half-open range `[1, 3)`;
+- `"abcd".substring(3, 1)` → `"bc"` — `start > end`, so the endpoints **swap**
+  (this is where `substring` and `slice` differ on argument *order*);
+- `"abcd".substring(-2)` → `"abcd"` — a negative argument **clamps to 0**; it
+  never counts from the end the way `slice` does (`"abcd".slice(-2)` is `"cd"`);
+- `"abcd".substring(10)` → `""` — a start past the end clamps to `len`.
+
+Indices are UTF-16 code units. The fold is left for the runtime (the call
+survives) when an argument is not an integer literal (a fractional value would
+need `ToInteger` coercion we don't model), when there are more than two
+arguments, or when the cut would split a surrogate pair into a lone surrogate.
+The same input under `WHITESPACE_ONLY` keeps the calls intact.
+
+Regenerate the expected file after an intentional behavior change:
+
+```sh
+cargo run -- --compilation_level SIMPLE \
+    --js tests/diff/simple-fold-substring/input/a.js \
+    > tests/diff/simple-fold-substring/expected.stdout
+```

--- a/code/programs/rust/closurec/tests/diff/simple-fold-substring/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-substring/expected.stdout
@@ -1,0 +1,1 @@
+var a="bc";var b="bc";var c="abcd";var d="";report(a,b,c,d);

--- a/code/programs/rust/closurec/tests/diff/simple-fold-substring/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-substring/flags.txt
@@ -1,0 +1,4 @@
+--compilation_level
+SIMPLE
+--js
+tests/diff/simple-fold-substring/input/a.js

--- a/code/programs/rust/closurec/tests/diff/simple-fold-substring/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-substring/input/a.js
@@ -1,0 +1,24 @@
+// SIMPLE-level string-substring fold (String#substring).
+//
+// `"<string>".substring(<start>[, <end>])` is compile-time-evaluable on a
+// string literal with integer-literal arguments; the `constant-fold` pass
+// collapses it to the substring (JS `String.prototype.substring`). Unlike
+// `slice`, `substring` clamps each index into `[0, len]` (a negative argument
+// becomes 0 — it never counts from the end) and SWAPS the endpoints when
+// `start > end`. The four cases below exercise exactly those rules:
+//
+//   "abcd".substring(1, 3) → "bc"    (the plain half-open range [1, 3))
+//   "abcd".substring(3, 1) → "bc"    (start > end → endpoints swap)
+//   "abcd".substring(-2)   → "abcd"  (a negative start clamps to 0)
+//   "abcd".substring(10)   → ""      (a start past the end clamps to len)
+//
+// Under WHITESPACE_ONLY the calls survive; under SIMPLE they all fold.
+//
+// The values flow into `report(...)` so they stay referenced — otherwise
+// remove-unused-vars (the last SIMPLE pass) would delete the declarations and
+// the folds would not be observable.
+var a = "abcd".substring(1, 3);
+var b = "abcd".substring(3, 1);
+var c = "abcd".substring(-2);
+var d = "abcd".substring(10);
+report(a, b, c, d);

--- a/code/programs/rust/closurec/tests/diff_simple_fold_substring.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_fold_substring.rs
@@ -1,0 +1,107 @@
+//! Integration test for the `tests/diff/simple-fold-substring/` fixture.
+//!
+//! End-to-end oracle for `String.prototype.substring(start[, end])` folding in
+//! `closure-pass-constant-fold`. Unlike `slice`, `substring` clamps each index
+//! into `[0, len]` (a negative argument becomes 0 — it never counts from the
+//! end) and SWAPS the endpoints when `start > end`. The fixture is chosen so
+//! both behaviors are observable:
+//!
+//! ```text
+//! var a="bc";var b="bc";var c="abcd";var d="";report(a,b,c,d);
+//! ```
+//!
+//! - `"abcd".substring(1, 3)` → `"bc"` — the plain half-open range `[1, 3)`;
+//! - `"abcd".substring(3, 1)` → `"bc"` — `start > end`, so endpoints swap;
+//! - `"abcd".substring(-2)`   → `"abcd"` — a negative start clamps to 0;
+//! - `"abcd".substring(10)`   → `""` — a start past the end clamps to `len`.
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
+
+fn read_flags() -> Vec<String> {
+    let raw = std::fs::read_to_string("tests/diff/simple-fold-substring/flags.txt")
+        .expect("read flags.txt");
+    raw.lines()
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[test]
+fn simple_fold_substring_fixture_matches_expected_stdout() {
+    let flags = read_flags();
+    let out = Command::new(BINARY)
+        .args(&flags)
+        .output()
+        .expect("run closurec");
+
+    assert!(
+        out.status.success(),
+        "exit: {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let actual = String::from_utf8_lossy(&out.stdout);
+    let expected = std::fs::read_to_string("tests/diff/simple-fold-substring/expected.stdout")
+        .expect("read expected.stdout");
+    assert_eq!(
+        actual.trim_end_matches('\n'),
+        expected.trim_end_matches('\n'),
+        "mismatch.\nflags: {flags:?}\nactual:\n{actual}\nexpected:\n{expected}",
+    );
+}
+
+/// `substring` on string literals folds away — no `.substring(` call survives,
+/// and the clamp (`-2` → whole string) and swap (`3,1` → `"bc"`) rules hold.
+#[test]
+fn simple_fold_substring_clamps_and_swaps() {
+    let out = Command::new(BINARY)
+        .args(read_flags())
+        .output()
+        .expect("run closurec");
+    let actual = String::from_utf8_lossy(&out.stdout);
+
+    // "abcd".substring(1,3) → "bc"; "abcd".substring(3,1) → "bc" (swap).
+    assert!(
+        actual.contains(r#"a="bc""#),
+        "\"abcd\".substring(1,3) → \"bc\"; got:\n{actual}"
+    );
+    assert!(
+        actual.contains(r#"b="bc""#),
+        "\"abcd\".substring(3,1) → \"bc\" (endpoints swap); got:\n{actual}"
+    );
+    // "abcd".substring(-2) → "abcd" (negative clamps to 0, NOT slice's "cd").
+    assert!(
+        actual.contains(r#"c="abcd""#),
+        "\"abcd\".substring(-2) → \"abcd\" (clamp to 0); got:\n{actual}"
+    );
+    // "abcd".substring(10) → "" (start clamps to len).
+    assert!(
+        actual.contains(r#"d="""#),
+        "\"abcd\".substring(10) → \"\"; got:\n{actual}"
+    );
+    assert!(
+        !actual.contains(".substring("),
+        "no `.substring(` call should remain after folding; got:\n{actual}"
+    );
+}
+
+/// Regression guard: the output must be the SIMPLE typed pipeline, not the
+/// `WHITESPACE_ONLY` fallback (which would leave the calls intact).
+#[test]
+fn simple_fold_substring_did_not_fall_back_to_whitespace_only() {
+    let out = Command::new(BINARY)
+        .args(read_flags())
+        .output()
+        .expect("run closurec");
+    let actual = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        !actual.contains(".substring("),
+        "expected the calls to be folded away by the typed pipeline \
+         (proving this is the SIMPLE optimizer, not the whitespace fallback); \
+         got:\n{actual}",
+    );
+}


### PR DESCRIPTION
## What

Adds a constant-fold rule for `String.prototype.substring(start[, end])` on a string-literal receiver with integer-literal arguments (ECMAScript §22.1.3.24) — the sibling of the already-folded `slice`, wired end-to-end through the closurec CLI.

`substring` differs from `slice` in two ways, both modelled:
- **Clamping into `[0, len]`** — a negative (or `NaN`) argument becomes `0`; it never counts from the end. `"abcd".substring(-2)` → `"abcd"` (whereas `slice(-2)` → `"cd"`).
- **Endpoint ordering** — `start > end` makes the two SWAP: `"abcd".substring(3, 1)` and `"abcd".substring(1, 3)` both → `"bc"`.

## Changes

**constant-fold 0.39.0**
- `fold_string_substring` helper: UTF-16-unit indexing (shares `slice`/`charAt` machinery), declines non-integer-literal / >2-arg / surrogate-split cuts
- 6 V8-oracle unit tests (clamp, swap, no-args identity, astral, surrogate-split decline, fractional/3-arg/identifier-receiver decline)

**closurec 0.188.0**
- SIMPLE/ADVANCED wiring via the typed pipeline
- Fixture `tests/diff/simple-fold-substring/` chosen to exercise clamp + swap: output `var a="bc";var b="bc";var c="abcd";var d="";report(a,b,c,d);`
- Integration test `diff_simple_fold_substring.rs` (folded stdout, no `.substring(` survives, not the WHITESPACE_ONLY fallback)
- `cli.spec.json` / `Cargo.toml` version bump + regenerated help-markdown golden

## Verification
- constant-fold: `cargo test --lib` → 133 passed, 0 failed (incl. 6 new substring tests)
- closurec: full `cargo test` → all binaries pass, 0 failures; substring fixture 3/3; `slice` fixture unchanged (no regression)
- Inline security review: PASSED (bounds airtight, contractive allocation, no unsafe/IO/unwrap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)