### PR TITLE
feat(mycin-hypothalamic): ADJ-only hypothalamic-hormone→pituitary-hormone recall library (4 edges)

### DIFF
--- a/code/specs/data/mycin-2026/recall/hypothalamic-hormone-edges.adj
+++ b/code/specs/data/mycin-2026/recall/hypothalamic-hormone-edges.adj
@@ -1,0 +1,75 @@
+% ============================================================================
+% hypothalamic-hormone-edges — the hypothalamic-releasing-hormone→pituitary-hormone
+% knowledge-graph (MYCIN-2026 HYPOTHALAMIC).
+% ============================================================================
+% A high-yield endocrine-physiology board table: each hypothalamic releasing
+% hormone and the anterior-pituitary hormone whose release it stimulates. This
+% completes the hypothalamus→pituitary→target axis (the pituitary→target half is
+% the sibling PITUITARY domain). "What does TRH stimulate?" becomes the binding
+% query
+%     ? stimulates_release_of(trh, $PituitaryHormone).
+%
+% Direction note: the relation is hypothalamic hormone -> the anterior-pituitary
+% hormone it stimulates the release of (`stimulates_release_of`). Each releasing
+% hormone here maps to ONE canonical pituitary-hormone span, so a query binds a
+% single answer (gnrh binds the LH+FSH gonadotropin pair its span names jointly).
+%
+% Faithfulness note: each `relate` subject/object is bound to what the cited
+% sentence ACTUALLY names. The object names the literal pituitary hormone the
+% sentence states the releasing hormone stimulates (TRH "stimulates thyrotrophs
+% ... to secrete TSH"; CRH "stimulates ACTH secretion"; GnRH "stimulates the
+% anterior pituitary to release FSH and LH"; GHRH "GH secretion is stimulated by
+% growth hormone-releasing hormone"). Each span was independently re-fetched and
+% confirmed on two separate fetches of the same page for byte-stability.
+%
+% This file is the SHIPPED ARTIFACT and the SOLE source of truth — no generator,
+% no JSON, no manifest (a pure ADJ-only recall domain, like PITUITARY/BONECELL/
+% AUTONOMIC/GIHORMONE). It is DISTINCT from the legacy endocrine domain: a
+% brand-new pure-ADJ file on the hypothalamic-releasing-hormone topic. Each fact
+% is a `relate` clause whose byte-provenance lives INLINE:
+%     source   — the VERBATIM span copied from the cited page (byte-stable: it
+%                appears character-for-character in the page's normalized text;
+%                every span here was independently re-fetched and confirmed).
+%     locator  — the URL the span was read from (NCBI StatPearls / Bookshelf).
+%     trust    — authoritative (a primary, citable reference).
+% An LLM (or a human) recalls a fact by writing a tiny query .adj that `import`s
+% this library and asks a binding query — see hypothalamic-hormone-recall.query.adj.
+% Nothing here is asserted "from memory": every edge is defended by a span a
+% reader can re-fetch and check.
+% (See feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+dictionary hypothalamic_hormone_vocab {
+    define releasing_hormone : entity   surface "hypothalamic hormone", "releasing hormone"
+    define pituitary_hormone : entity   surface "pituitary hormone", "anterior pituitary hormone"
+
+    define stimulates_release_of : relation from releasing_hormone to pituitary_hormone  % pituitary hormone whose release it triggers
+}
+
+rulebook hypothalamic_hormone_facts {
+    use hypothalamic_hormone_vocab
+
+    % --- TRH -> TSH ----------------------------------------------------------
+    relate stimulates_release_of(trh, tsh)
+        source "Specifically, neurons in the hypothalamus release TRH, or thyroid-releasing hormone, which stimulates thyrotrophs of the anterior pituitary to secrete TSH."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK499850/"
+        trust authoritative
+
+    % --- CRH -> ACTH ---------------------------------------------------------
+    relate stimulates_release_of(crh, acth)
+        source "The hypothalamus, located in the ventral brain, secretes corticotropin-releasing hormone (CRH), which stimulates ACTH secretion from the anterior pituitary."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK500031/"
+        trust authoritative
+
+    % --- GnRH -> FSH and LH --------------------------------------------------
+    relate stimulates_release_of(gnrh, fsh_and_lh)
+        source "The hypothalamus secretes GnRH, which stimulates the anterior pituitary to release FSH and LH."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK535442/"
+        trust authoritative
+
+    % --- GHRH -> GH ----------------------------------------------------------
+    relate stimulates_release_of(ghrh, gh)
+        source "GH secretion is stimulated by growth hormone-releasing hormone (GHRH) but suppressed by another hormone peptide, somatostatin (also known as growth hormone-inhibiting hormone (GHIH))."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK459247/"
+        trust authoritative
+}

--- a/code/specs/data/mycin-2026/recall/hypothalamic-hormone-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/hypothalamic-hormone-recall.query.adj
@@ -1,0 +1,21 @@
+% ============================================================================
+% hypothalamic-hormone-recall.query.adj — a worked recall query over the
+% hypothalamic-hormone library.
+% ============================================================================
+% The shape an LLM (or a student) produces to ANSWER a "what does releasing
+% hormone X stimulate?" question: it states no physiology fact — it only
+% `import`s the grounded library and asks binding queries. The native adj-lang
+% engine resolves each `?` against the imported `relate` edges and returns the
+% binding + the citing clause's source/locator/trust. All knowledge is in the
+% library; none is here.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli hypothalamic-hormone-recall.query.adj
+% ============================================================================
+
+import "hypothalamic-hormone-edges.adj"
+
+? stimulates_release_of(trh, $PituitaryHormone)   % expect tsh
+? stimulates_release_of(crh, $PituitaryHormone)   % expect acth
+? stimulates_release_of(gnrh, $PituitaryHormone)  % expect fsh_and_lh
+? stimulates_release_of(ghrh, $PituitaryHormone)  % expect gh

--- a/code/specs/data/mycin-2026/recall/test_hypothalamic_hormone_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_hypothalamic_hormone_recall.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""test_hypothalamic_hormone_recall.py — the ADJ-only
+hypothalamic-releasing-hormone→pituitary-hormone recall library
+(MYCIN-2026 HYPOTHALAMIC).
+
+A pure-ADJ recall domain (high-yield endocrine-physiology board table): the
+anterior-pituitary hormone whose release each hypothalamic releasing hormone
+stimulates. `hypothalamic-hormone-edges.adj` is the SOLE source of truth — facts
++ byte-provenance inline, no Python gate, no JSON, no manifest. This test pins
+the property that matters: the native adj-lang engine, given a query .adj that
+only `import`s the library and asks binding queries
+(`hypothalamic-hormone-recall.query.adj` — the shape an LLM produces), binds the
+grounded pituitary hormone for each releasing hormone, each carrying an
+AUTHORITATIVE citation with a real source span + locator. Knowledge lives in
+ADJ; the engine answers.
+
+If the native CLI isn't built (a Python-only CI lane), the engine-backed checks
+skip — the file-shape checks (every clause grounded, no authored-debt) still run.
+
+Run:  python3 test_hypothalamic_hormone_recall.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ADJ = HERE / "hypothalamic-hormone-edges.adj"
+QUERY = HERE / "hypothalamic-hormone-recall.query.adj"
+CLI = HERE.parents[3] / "packages" / "rust" / "target" / "debug" / "adj-lang-cli"
+
+# Every grounded edge: hypothalamic releasing hormone -> the pituitary hormone
+# the library binds.
+EXPECTED = {
+    "trh": "tsh",            # NBK499850
+    "crh": "acth",           # NBK500031
+    "gnrh": "fsh_and_lh",    # NBK535442
+    "ghrh": "gh",            # NBK459247
+}
+REL = "stimulates_release_of"
+VAR = "PituitaryHormone"
+
+
+def _cli_available() -> bool:
+    return CLI.exists()
+
+
+def _run(program: Path) -> dict:
+    out = subprocess.run([str(CLI), str(program)], capture_output=True, text=True,
+                         cwd=str(HERE), timeout=60)
+    assert out.returncode == 0, f"adj-lang-cli failed: {out.stderr}"
+    return json.loads(out.stdout)
+
+
+# ---- 1. the ADJ file is the artifact — every clause grounded, no authored-debt ----
+
+def test_library_is_pure_adj_and_fully_grounded() -> None:
+    text = ADJ.read_text()
+    assert "trust consensus" not in text, "HYPOTHALAMIC ships no authored-debt; ground or omit"
+    assert "[FLAG:" not in text
+    edge_count = len(EXPECTED)  # 4
+    assert text.count("    relate ") == edge_count
+    assert text.count("trust authoritative") == edge_count
+    assert text.count('\n        locator "') == edge_count
+    assert text.count('\n        source "') == edge_count
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("locator "):
+            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+    assert not (HERE / "hypothalamic_hormone_edge_ground.py").exists()
+    assert not (HERE / "hypothalamic-hormone-edge-grounding.json").exists()
+    assert not (HERE / "hypothalamic-hormone-edge-manifest.json").exists()
+
+
+# ---- 2. the engine binds each pituitary hormone with an authoritative citation -----
+
+def test_engine_binds_every_target_with_authoritative_citation() -> None:
+    if not _cli_available():
+        return
+    result = _run(QUERY)
+    by_query = {r["query"]: r for r in result["recall"]}
+    for releasing, pituitary in EXPECTED.items():
+        q = f"{REL}({releasing}, {VAR})"
+        r = by_query.get(q)
+        assert r is not None and not r["abstained"], f"{q} abstained — edge missing?"
+        bound = {}
+        for a in r["answers"]:
+            bound[a["bindings"][VAR]] = (a.get("citations") or [{}])[0]
+        assert set(bound) == {pituitary}, f"{releasing}: bound {set(bound)} != {{{pituitary}}}"
+        cite = bound[pituitary]
+        assert cite.get("trust") == "authoritative", f"{releasing}/{pituitary} not authoritative"
+        assert cite.get("source"), f"{releasing}/{pituitary} has no source span"
+        assert cite.get("locator", "").startswith("https://www.ncbi.nlm.nih.gov/")
+
+
+# ---- 3. an off-vocabulary releasing hormone abstains, never fabricates -------------
+
+def test_unknown_hormone_abstains() -> None:
+    if not _cli_available():
+        return
+    import os
+    import tempfile
+    fd, path = tempfile.mkstemp(suffix=".adj", prefix=".hypothalamic_q_", dir=HERE)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            # ghih (somatostatin / growth-hormone-inhibiting hormone) is a real
+            # hypothalamic hormone but is inhibitory and deliberately not in this
+            # library, so the engine must abstain rather than fabricate.
+            fh.write(f'import "hypothalamic-hormone-edges.adj"\n? {REL}(ghih, ${VAR})\n')
+        res = _run(Path(path))
+        r = res["recall"][0] if res["recall"] else None
+        assert r is not None and r["abstained"], "an ungrounded hormone must abstain"
+    finally:
+        os.unlink(path)
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS  {t.__name__}")
+        except AssertionError as exc:
+            failed += 1
+            print(f"  FAIL  {t.__name__}: {exc}")
+    print(f"\ntest_hypothalamic_hormone_recall: {len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())


### PR DESCRIPTION
## What

A new **pure-ADJ recall domain** for MYCIN-2026: the hypothalamic-releasing-hormone→pituitary-hormone knowledge graph — a high-yield endocrine-physiology board table mapping each hypothalamic releasing hormone to the anterior-pituitary hormone whose release it stimulates. This **completes the hypothalamus→pituitary→target axis** (the pituitary→target half is the sibling PITUITARY domain).

`hypothalamic-hormone-edges.adj` is the **SOLE shipped artifact and source of truth** — no Python gate, no JSON, no manifest — following the PITUITARY / BONECELL / AUTONOMIC / GIHORMONE pattern. It is **distinct from the legacy endocrine domain**. Each `relate stimulates_release_of(releasing_hormone, pituitary_hormone)` clause carries inline byte-provenance: a VERBATIM NCBI StatPearls/Bookshelf span, an `https` NCBI locator, and `trust authoritative`.

## Edges (4)

Each edge is defended by a **self-contained** NCBI Bookshelf sentence that names BOTH the releasing hormone and its anterior-pituitary target AND the relationship, **independently re-fetched and confirmed byte-stable on two separate fetches**:

| Releasing hormone | Pituitary hormone | Source |
|---|---|---|
| `trh` | tsh | [NBK499850](https://www.ncbi.nlm.nih.gov/books/NBK499850/) |
| `crh` | acth | [NBK500031](https://www.ncbi.nlm.nih.gov/books/NBK500031/) |
| `gnrh` | fsh_and_lh | [NBK535442](https://www.ncbi.nlm.nih.gov/books/NBK535442/) |
| `ghrh` | gh | [NBK459247](https://www.ncbi.nlm.nih.gov/books/NBK459247/) |

## Files

- `hypothalamic-hormone-edges.adj` — the grounded library (dictionary + rulebook)
- `hypothalamic-hormone-recall.query.adj` — worked binding queries (the LLM-produced shape: imports the library, asks `? stimulates_release_of(<rh>, $PituitaryHormone)`)
- `test_hypothalamic_hormone_recall.py` — 3-test scaffold: (1) pure-ADJ / no-authored-debt file shape (every clause grounded, all locators NCBI, no JSON/manifest/python sidecars); (2) the native adj-lang engine binds each pituitary hormone with an authoritative NCBI citation; (3) an off-vocabulary inhibitory hormone (`ghih`/somatostatin) abstains rather than fabricates. **3/3 pass locally.**

## Notes

- The query `.adj` states no physiology fact — it only imports the library and asks binding queries; the engine resolves them and returns the binding plus the citing clause's source/locator/trust. Knowledge lives in ADJ; the engine answers.
- No edges deferred: all 4 stimulatory releasing hormones yielded a qualifying self-contained Bookshelf span. The inhibitory hypothalamic factors (somatostatin/GHIH, dopamine) are intentionally out of scope to keep the `stimulates_release_of` relation semantically uniform; `ghih` is reused as the abstention probe.
- Security review: PASSED (Python test uses list-argv subprocess with timeout, atomic \`mkstemp\` tempfile, \`json.loads\` on trusted local-binary output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)