### PR TITLE
feat(mycin-duralsinus): ADJ-only dural-venous-sinus→drainage recall library (5 edges)

### DIFF
--- a/code/specs/data/mycin-2026/recall/dural-sinus-edges.adj
+++ b/code/specs/data/mycin-2026/recall/dural-sinus-edges.adj
@@ -1,0 +1,81 @@
+% ============================================================================
+% dural-sinus-edges — the dural-venous-sinus→drainage-destination knowledge-graph
+% (MYCIN-2026 DURALSINUS).
+% ============================================================================
+% A high-yield neuroanatomy board table: each major dural venous sinus and the
+% structure it drains into along the cerebral venous outflow path
+% (superior sagittal / straight → confluence → transverse → sigmoid → internal
+% jugular vein; cavernous → petrosal sinuses). "Where does the sigmoid sinus
+% drain?" becomes the binding query
+%     ? drains_into(sigmoid_sinus, $Destination).
+%
+% Direction note: the relation is sinus -> the structure it drains into
+% (`drains_into`). Each sinus here maps to ONE canonical destination span, so a
+% query binds a single answer.
+%
+% Faithfulness note: each `relate` subject/object is bound to what the cited
+% sentence ACTUALLY names. The destination object names the literal structure the
+% sentence states the sinus drains into (superior sagittal "progresses
+% posteriorly to the confluence of sinuses"; straight "terminates into the
+% confluence of sinuses"; transverse "continues as a sigmoid sinus"; sigmoid
+% "drain venous blood into the internal jugular vein"; cavernous "drains to the
+% superior and inferior petrosal sinuses"). Each span was independently
+% re-fetched and confirmed on two separate fetches of the same page for
+% byte-stability.
+%
+% This file is the SHIPPED ARTIFACT and the SOLE source of truth — no generator,
+% no JSON, no manifest (a pure ADJ-only recall domain, like HYPOTHALAMIC/
+% PITUITARY/BONECELL/AUTONOMIC). Each fact is a `relate` clause whose
+% byte-provenance lives INLINE:
+%     source   — the VERBATIM span copied from the cited page (byte-stable: it
+%                appears character-for-character in the page's normalized text;
+%                every span here was independently re-fetched and confirmed).
+%     locator  — the URL the span was read from (NCBI StatPearls / Bookshelf).
+%     trust    — authoritative (a primary, citable reference).
+% An LLM (or a human) recalls a fact by writing a tiny query .adj that `import`s
+% this library and asks a binding query — see dural-sinus-recall.query.adj.
+% Nothing here is asserted "from memory": every edge is defended by a span a
+% reader can re-fetch and check.
+% (See feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+dictionary dural_sinus_vocab {
+    define sinus       : entity   surface "dural venous sinus", "cerebral venous sinus"
+    define destination : entity   surface "drainage destination", "downstream structure"
+
+    define drains_into : relation from sinus to destination  % the structure this sinus drains into
+}
+
+rulebook dural_sinus_facts {
+    use dural_sinus_vocab
+
+    % --- superior sagittal sinus -> confluence of sinuses --------------------
+    relate drains_into(superior_sagittal_sinus, confluence_of_sinuses)
+        source "The superior sagittal sinus eventually progresses posteriorly to the confluence of sinuses, where it terminates."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK546615/"
+        trust authoritative
+
+    % --- straight sinus -> confluence of sinuses -----------------------------
+    relate drains_into(straight_sinus, confluence_of_sinuses)
+        source "The straight sinus drains contents from inferior sagittal sinus and great cerebral vein and terminates into the confluence of sinuses."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK482257/"
+        trust authoritative
+
+    % --- transverse sinus -> sigmoid sinus -----------------------------------
+    relate drains_into(transverse_sinus, sigmoid_sinus)
+        source "Each transverse sinus descends and continues as a sigmoid sinus."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK546605/"
+        trust authoritative
+
+    % --- sigmoid sinus -> internal jugular vein ------------------------------
+    relate drains_into(sigmoid_sinus, internal_jugular_vein)
+        source "Left and right sigmoid sinuses collectively drain venous blood into the internal jugular vein, which exits at the jugular foramen."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK482257/"
+        trust authoritative
+
+    % --- cavernous sinus -> superior and inferior petrosal sinuses -----------
+    relate drains_into(cavernous_sinus, superior_and_inferior_petrosal_sinuses)
+        source "After collecting venous blood from these different veins, the cavernous sinus drains to the superior and inferior petrosal sinuses, which then join the sigmoid sinus to form the internal jugular vein."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK459244/"
+        trust authoritative
+}

--- a/code/specs/data/mycin-2026/recall/dural-sinus-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/dural-sinus-recall.query.adj
@@ -1,0 +1,20 @@
+% ============================================================================
+% dural-sinus-recall.query.adj — a worked recall query over the dural-sinus library.
+% ============================================================================
+% The shape an LLM (or a student) produces to ANSWER a "where does sinus X drain?"
+% question: it states no anatomy fact — it only `import`s the grounded library
+% and asks binding queries. The native adj-lang engine resolves each `?` against
+% the imported `relate` edges and returns the binding + the citing clause's
+% source/locator/trust. All knowledge is in the library; none is here.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli dural-sinus-recall.query.adj
+% ============================================================================
+
+import "dural-sinus-edges.adj"
+
+? drains_into(superior_sagittal_sinus, $Destination)  % expect confluence_of_sinuses
+? drains_into(straight_sinus, $Destination)           % expect confluence_of_sinuses
+? drains_into(transverse_sinus, $Destination)         % expect sigmoid_sinus
+? drains_into(sigmoid_sinus, $Destination)            % expect internal_jugular_vein
+? drains_into(cavernous_sinus, $Destination)          % expect superior_and_inferior_petrosal_sinuses

--- a/code/specs/data/mycin-2026/recall/test_dural_sinus_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_dural_sinus_recall.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""test_dural_sinus_recall.py — the ADJ-only dural-venous-sinus→drainage recall
+library (MYCIN-2026 DURALSINUS).
+
+A pure-ADJ recall domain (high-yield neuroanatomy board table): the structure
+each major dural venous sinus drains into along the cerebral venous outflow path.
+`dural-sinus-edges.adj` is the SOLE source of truth — facts + byte-provenance
+inline, no Python gate, no JSON, no manifest. This test pins the property that
+matters: the native adj-lang engine, given a query .adj that only `import`s the
+library and asks binding queries (`dural-sinus-recall.query.adj` — the shape an
+LLM produces), binds the grounded destination for each sinus, each carrying an
+AUTHORITATIVE citation with a real source span + locator. Knowledge lives in ADJ;
+the engine answers.
+
+If the native CLI isn't built (a Python-only CI lane), the engine-backed checks
+skip — the file-shape checks (every clause grounded, no authored-debt) still run.
+
+Run:  python3 test_dural_sinus_recall.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ADJ = HERE / "dural-sinus-edges.adj"
+QUERY = HERE / "dural-sinus-recall.query.adj"
+CLI = HERE.parents[3] / "packages" / "rust" / "target" / "debug" / "adj-lang-cli"
+
+# Every grounded edge: dural venous sinus -> the destination the library binds.
+EXPECTED = {
+    "superior_sagittal_sinus": "confluence_of_sinuses",                 # NBK546615
+    "straight_sinus": "confluence_of_sinuses",                          # NBK482257
+    "transverse_sinus": "sigmoid_sinus",                               # NBK546605
+    "sigmoid_sinus": "internal_jugular_vein",                          # NBK482257
+    "cavernous_sinus": "superior_and_inferior_petrosal_sinuses",       # NBK459244
+}
+REL = "drains_into"
+VAR = "Destination"
+
+
+def _cli_available() -> bool:
+    return CLI.exists()
+
+
+def _run(program: Path) -> dict:
+    out = subprocess.run([str(CLI), str(program)], capture_output=True, text=True,
+                         cwd=str(HERE), timeout=60)
+    assert out.returncode == 0, f"adj-lang-cli failed: {out.stderr}"
+    return json.loads(out.stdout)
+
+
+# ---- 1. the ADJ file is the artifact — every clause grounded, no authored-debt ----
+
+def test_library_is_pure_adj_and_fully_grounded() -> None:
+    text = ADJ.read_text()
+    assert "trust consensus" not in text, "DURALSINUS ships no authored-debt; ground or omit"
+    assert "[FLAG:" not in text
+    edge_count = len(EXPECTED)  # 5
+    assert text.count("    relate ") == edge_count
+    assert text.count("trust authoritative") == edge_count
+    assert text.count('\n        locator "') == edge_count
+    assert text.count('\n        source "') == edge_count
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("locator "):
+            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+    assert not (HERE / "dural_sinus_edge_ground.py").exists()
+    assert not (HERE / "dural-sinus-edge-grounding.json").exists()
+    assert not (HERE / "dural-sinus-edge-manifest.json").exists()
+
+
+# ---- 2. the engine binds each destination with an authoritative citation -----------
+
+def test_engine_binds_every_destination_with_authoritative_citation() -> None:
+    if not _cli_available():
+        return
+    result = _run(QUERY)
+    by_query = {r["query"]: r for r in result["recall"]}
+    for sinus, destination in EXPECTED.items():
+        q = f"{REL}({sinus}, {VAR})"
+        r = by_query.get(q)
+        assert r is not None and not r["abstained"], f"{q} abstained — edge missing?"
+        bound = {}
+        for a in r["answers"]:
+            bound[a["bindings"][VAR]] = (a.get("citations") or [{}])[0]
+        assert set(bound) == {destination}, f"{sinus}: bound {set(bound)} != {{{destination}}}"
+        cite = bound[destination]
+        assert cite.get("trust") == "authoritative", f"{sinus}/{destination} not authoritative"
+        assert cite.get("source"), f"{sinus}/{destination} has no source span"
+        assert cite.get("locator", "").startswith("https://www.ncbi.nlm.nih.gov/")
+
+
+# ---- 3. an off-vocabulary sinus abstains, never fabricates --------------------------
+
+def test_unknown_sinus_abstains() -> None:
+    if not _cli_available():
+        return
+    import os
+    import tempfile
+    fd, path = tempfile.mkstemp(suffix=".adj", prefix=".duralsinus_q_", dir=HERE)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            # the inferior sagittal sinus is a real dural venous sinus (it is even
+            # named inside one source span as a tributary) but is deliberately not
+            # a subject in this library, so the engine must abstain rather than
+            # fabricate.
+            fh.write(f'import "dural-sinus-edges.adj"\n? {REL}(inferior_sagittal_sinus, ${VAR})\n')
+        res = _run(Path(path))
+        r = res["recall"][0] if res["recall"] else None
+        assert r is not None and r["abstained"], "an ungrounded sinus must abstain"
+    finally:
+        os.unlink(path)
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS  {t.__name__}")
+        except AssertionError as exc:
+            failed += 1
+            print(f"  FAIL  {t.__name__}: {exc}")
+    print(f"\ntest_dural_sinus_recall: {len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())


### PR DESCRIPTION
## What

A new **pure-ADJ recall domain** for MYCIN-2026: the dural-venous-sinus→drainage knowledge graph — a high-yield neuroanatomy board table mapping each major dural venous sinus to the structure it drains into along the cerebral venous outflow path (superior sagittal / straight → confluence → transverse → sigmoid → internal jugular vein; cavernous → petrosal sinuses).

`dural-sinus-edges.adj` is the **SOLE shipped artifact and source of truth** — no Python gate, no JSON, no manifest — following the HYPOTHALAMIC / PITUITARY / BONECELL / AUTONOMIC pattern. Each `relate drains_into(sinus, destination)` clause carries inline byte-provenance: a VERBATIM NCBI StatPearls/Bookshelf span, an `https` NCBI locator, and `trust authoritative`.

## Edges (5)

Each edge is defended by a **self-contained** NCBI Bookshelf sentence that names BOTH the sinus and its drainage destination AND the relationship, **independently re-fetched and confirmed byte-stable on two separate fetches**:

| Sinus | Drains into | Source |
|---|---|---|
| `superior_sagittal_sinus` | confluence_of_sinuses | [NBK546615](https://www.ncbi.nlm.nih.gov/books/NBK546615/) |
| `straight_sinus` | confluence_of_sinuses | [NBK482257](https://www.ncbi.nlm.nih.gov/books/NBK482257/) |
| `transverse_sinus` | sigmoid_sinus | [NBK546605](https://www.ncbi.nlm.nih.gov/books/NBK546605/) |
| `sigmoid_sinus` | internal_jugular_vein | [NBK482257](https://www.ncbi.nlm.nih.gov/books/NBK482257/) |
| `cavernous_sinus` | superior_and_inferior_petrosal_sinuses | [NBK459244](https://www.ncbi.nlm.nih.gov/books/NBK459244/) |

## Files

- `dural-sinus-edges.adj` — the grounded library (dictionary + rulebook)
- `dural-sinus-recall.query.adj` — worked binding queries (the LLM-produced shape: imports the library, asks `? drains_into(<sinus>, $Destination)`)
- `test_dural_sinus_recall.py` — 3-test scaffold: (1) pure-ADJ / no-authored-debt file shape (every clause grounded, all locators NCBI, no JSON/manifest/python sidecars); (2) the native adj-lang engine binds each destination with an authoritative NCBI citation; (3) an off-vocabulary sinus (`inferior_sagittal_sinus`) abstains rather than fabricates. **3/3 pass locally.**

## Notes

- The query `.adj` states no anatomy fact — it only imports the library and asks binding queries; the engine resolves them and returns the binding plus the citing clause's source/locator/trust. Knowledge lives in ADJ; the engine answers.
- No edges deferred: all 5 targeted sinuses yielded a qualifying self-contained Bookshelf span. The drainage chain is internally consistent (two sinuses converge at the confluence; the cavernous span even names the downstream sigmoid→IJV path).
- Security review: PASSED (Python test uses list-argv subprocess with timeout, atomic \`mkstemp\` tempfile, \`json.loads\` on trusted local-binary output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)