### PR TITLE
feat(mycin-lungvolume): ADJ-only lung-volume/capacity→definition recall library (5 edges)

### DIFF
--- a/code/specs/data/mycin-2026/recall/lung-volume-edges.adj
+++ b/code/specs/data/mycin-2026/recall/lung-volume-edges.adj
@@ -1,0 +1,88 @@
+% ============================================================================
+% lung-volume-edges — the lung-volume/capacity→definition knowledge-graph
+% (MYCIN-2026 LUNGVOLUME).
+% ============================================================================
+% A classic high-yield respiratory-physiology board table: each static lung
+% volume/capacity and its definition. "What is functional residual capacity?"
+% becomes the binding query
+%     ? is_defined_as(functional_residual_capacity, $Definition).
+%
+% Direction note: the relation is volume/capacity -> its definition
+% (`is_defined_as`). Each term here maps to ONE canonical definition span, so a
+% query binds a single answer.
+%
+% Faithfulness note: each `relate` subject/object is bound to what the cited
+% sentence ACTUALLY names. The definition object names the literal definition the
+% sentence states (tidal volume "air that moves in or out ... with each
+% respiratory cycle"; residual volume "air that remains ... after maximum
+% forceful expiration"; inspiratory reserve volume "forcible amount of air
+% inhaled after normal TV"; vital capacity "maximal volume of air that can be
+% expired following maximum inspiration"; functional residual capacity "volume
+% remaining ... after a normal, passive exhalation"). Each span was independently
+% re-fetched and confirmed on two separate fetches of the same page for
+% byte-stability, and each NAMES THE FULL TERM (not an abbreviation alone).
+%
+% Deferred this batch (documented, not shipped): EXPIRATORY RESERVE VOLUME. Its
+% only self-contained StatPearls sentence names the term by abbreviation alone
+% ("The ERV is the volume of air that can be forcefully exhaled after a normal
+% resting expiration..."), with the full term spelled out only in an adjacent
+% sentence — which fails this library's strict "the one sentence must name the
+% full term" bar. It is reused below as the off-vocabulary abstention probe; it
+% can be added when a full-term self-contained span is found.
+%
+% This file is the SHIPPED ARTIFACT and the SOLE source of truth — no generator,
+% no JSON, no manifest (a pure ADJ-only recall domain, like DURALSINUS/
+% HYPOTHALAMIC/PITUITARY/BONECELL). Each fact is a `relate` clause whose
+% byte-provenance lives INLINE:
+%     source   — the VERBATIM span copied from the cited page (byte-stable: it
+%                appears character-for-character in the page's normalized text;
+%                every span here was independently re-fetched and confirmed).
+%     locator  — the URL the span was read from (NCBI StatPearls / Bookshelf).
+%     trust    — authoritative (a primary, citable reference).
+% An LLM (or a human) recalls a fact by writing a tiny query .adj that `import`s
+% this library and asks a binding query — see lung-volume-recall.query.adj.
+% Nothing here is asserted "from memory": every edge is defended by a span a
+% reader can re-fetch and check.
+% (See feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+dictionary lung_volume_vocab {
+    define volume     : entity   surface "lung volume", "lung capacity"
+    define definition : entity   surface "physiological definition", "volume definition"
+
+    define is_defined_as : relation from volume to definition  % the definition of this lung volume/capacity
+}
+
+rulebook lung_volume_facts {
+    use lung_volume_vocab
+
+    % --- tidal volume -> air per respiratory cycle ---------------------------
+    relate is_defined_as(tidal_volume, air_per_respiratory_cycle)
+        source "Tidal volume is the amount of air that moves in or out of the lungs with each respiratory cycle."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK482502/"
+        trust authoritative
+
+    % --- residual volume -> air remaining after maximal forceful expiration --
+    relate is_defined_as(residual_volume, air_remaining_after_maximal_forceful_expiration)
+        source "Residual volume (RV) is the air that remains in the lungs after maximum forceful expiration."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK493170/"
+        trust authoritative
+
+    % --- inspiratory reserve volume -> air inhaled after normal tidal --------
+    relate is_defined_as(inspiratory_reserve_volume, air_inhaled_after_normal_tidal)
+        source "Inspiratory reserve volume (IRV) is the forcible amount of air inhaled after normal TV."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK560526/"
+        trust authoritative
+
+    % --- vital capacity -> max air exhaled after max inspiration -------------
+    relate is_defined_as(vital_capacity, max_air_exhaled_after_max_inspiration)
+        source "Vital capacity (VC) refers to the maximal volume of air that can be expired following maximum inspiration."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK541099/"
+        trust authoritative
+
+    % --- functional residual capacity -> air remaining after normal exhalation
+    relate is_defined_as(functional_residual_capacity, air_remaining_after_normal_passive_exhalation)
+        source "Functional residual capacity (FRC) is the volume remaining in the lungs after a normal, passive exhalation."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK500007/"
+        trust authoritative
+}

--- a/code/specs/data/mycin-2026/recall/lung-volume-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/lung-volume-recall.query.adj
@@ -1,0 +1,20 @@
+% ============================================================================
+% lung-volume-recall.query.adj — a worked recall query over the lung-volume library.
+% ============================================================================
+% The shape an LLM (or a student) produces to ANSWER a "what is lung volume X?"
+% question: it states no physiology fact — it only `import`s the grounded library
+% and asks binding queries. The native adj-lang engine resolves each `?` against
+% the imported `relate` edges and returns the binding + the citing clause's
+% source/locator/trust. All knowledge is in the library; none is here.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli lung-volume-recall.query.adj
+% ============================================================================
+
+import "lung-volume-edges.adj"
+
+? is_defined_as(tidal_volume, $Definition)                 % expect air_per_respiratory_cycle
+? is_defined_as(residual_volume, $Definition)              % expect air_remaining_after_maximal_forceful_expiration
+? is_defined_as(inspiratory_reserve_volume, $Definition)   % expect air_inhaled_after_normal_tidal
+? is_defined_as(vital_capacity, $Definition)               % expect max_air_exhaled_after_max_inspiration
+? is_defined_as(functional_residual_capacity, $Definition) % expect air_remaining_after_normal_passive_exhalation

--- a/code/specs/data/mycin-2026/recall/test_lung_volume_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_lung_volume_recall.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""test_lung_volume_recall.py — the ADJ-only lung-volume/capacity→definition
+recall library (MYCIN-2026 LUNGVOLUME).
+
+A pure-ADJ recall domain (classic high-yield respiratory-physiology board table):
+the definition of each static lung volume/capacity. `lung-volume-edges.adj` is
+the SOLE source of truth — facts + byte-provenance inline, no Python gate, no
+JSON, no manifest. This test pins the property that matters: the native adj-lang
+engine, given a query .adj that only `import`s the library and asks binding
+queries (`lung-volume-recall.query.adj` — the shape an LLM produces), binds the
+grounded definition for each volume, each carrying an AUTHORITATIVE citation with
+a real source span + locator. Knowledge lives in ADJ; the engine answers.
+
+If the native CLI isn't built (a Python-only CI lane), the engine-backed checks
+skip — the file-shape checks (every clause grounded, no authored-debt) still run.
+
+Run:  python3 test_lung_volume_recall.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ADJ = HERE / "lung-volume-edges.adj"
+QUERY = HERE / "lung-volume-recall.query.adj"
+CLI = HERE.parents[3] / "packages" / "rust" / "target" / "debug" / "adj-lang-cli"
+
+# Every grounded edge: lung volume/capacity -> the definition the library binds.
+EXPECTED = {
+    "tidal_volume": "air_per_respiratory_cycle",                                     # NBK482502
+    "residual_volume": "air_remaining_after_maximal_forceful_expiration",            # NBK493170
+    "inspiratory_reserve_volume": "air_inhaled_after_normal_tidal",                  # NBK560526
+    "vital_capacity": "max_air_exhaled_after_max_inspiration",                       # NBK541099
+    "functional_residual_capacity": "air_remaining_after_normal_passive_exhalation", # NBK500007
+}
+REL = "is_defined_as"
+VAR = "Definition"
+
+
+def _cli_available() -> bool:
+    return CLI.exists()
+
+
+def _run(program: Path) -> dict:
+    out = subprocess.run([str(CLI), str(program)], capture_output=True, text=True,
+                         cwd=str(HERE), timeout=60)
+    assert out.returncode == 0, f"adj-lang-cli failed: {out.stderr}"
+    return json.loads(out.stdout)
+
+
+# ---- 1. the ADJ file is the artifact — every clause grounded, no authored-debt ----
+
+def test_library_is_pure_adj_and_fully_grounded() -> None:
+    text = ADJ.read_text()
+    assert "trust consensus" not in text, "LUNGVOLUME ships no authored-debt; ground or omit"
+    assert "[FLAG:" not in text
+    edge_count = len(EXPECTED)  # 5
+    assert text.count("    relate ") == edge_count
+    assert text.count("trust authoritative") == edge_count
+    assert text.count('\n        locator "') == edge_count
+    assert text.count('\n        source "') == edge_count
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("locator "):
+            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+    assert not (HERE / "lung_volume_edge_ground.py").exists()
+    assert not (HERE / "lung-volume-edge-grounding.json").exists()
+    assert not (HERE / "lung-volume-edge-manifest.json").exists()
+
+
+# ---- 2. the engine binds each definition with an authoritative citation ------------
+
+def test_engine_binds_every_definition_with_authoritative_citation() -> None:
+    if not _cli_available():
+        return
+    result = _run(QUERY)
+    by_query = {r["query"]: r for r in result["recall"]}
+    for volume, definition in EXPECTED.items():
+        q = f"{REL}({volume}, {VAR})"
+        r = by_query.get(q)
+        assert r is not None and not r["abstained"], f"{q} abstained — edge missing?"
+        bound = {}
+        for a in r["answers"]:
+            bound[a["bindings"][VAR]] = (a.get("citations") or [{}])[0]
+        assert set(bound) == {definition}, f"{volume}: bound {set(bound)} != {{{definition}}}"
+        cite = bound[definition]
+        assert cite.get("trust") == "authoritative", f"{volume}/{definition} not authoritative"
+        assert cite.get("source"), f"{volume}/{definition} has no source span"
+        assert cite.get("locator", "").startswith("https://www.ncbi.nlm.nih.gov/")
+
+
+# ---- 3. an off-vocabulary volume abstains, never fabricates -------------------------
+
+def test_unknown_volume_abstains() -> None:
+    if not _cli_available():
+        return
+    import os
+    import tempfile
+    fd, path = tempfile.mkstemp(suffix=".adj", prefix=".lungvolume_q_", dir=HERE)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            # expiratory_reserve_volume is a real lung volume but was DEFERRED from
+            # this library (its only self-contained span names the term by
+            # abbreviation alone), so the engine must abstain rather than fabricate.
+            fh.write(f'import "lung-volume-edges.adj"\n? {REL}(expiratory_reserve_volume, ${VAR})\n')
+        res = _run(Path(path))
+        r = res["recall"][0] if res["recall"] else None
+        assert r is not None and r["abstained"], "an ungrounded volume must abstain"
+    finally:
+        os.unlink(path)
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS  {t.__name__}")
+        except AssertionError as exc:
+            failed += 1
+            print(f"  FAIL  {t.__name__}: {exc}")
+    print(f"\ntest_lung_volume_recall: {len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())


### PR DESCRIPTION
## What

A new **pure-ADJ recall domain** for MYCIN-2026: the lung-volume/capacity→definition knowledge graph — a classic high-yield respiratory-physiology board table mapping each static lung volume/capacity to its definition.

`lung-volume-edges.adj` is the **SOLE shipped artifact and source of truth** — no Python gate, no JSON, no manifest — following the DURALSINUS / HYPOTHALAMIC / PITUITARY / BONECELL pattern. Each `relate is_defined_as(volume, definition)` clause carries inline byte-provenance: a VERBATIM NCBI StatPearls/Bookshelf span, an `https` NCBI locator, and `trust authoritative`.

## Edges (5)

Each edge is defended by a **self-contained** NCBI Bookshelf sentence that **names the full term** and states its definition, **independently re-fetched and confirmed byte-stable on two separate fetches**:

| Volume / capacity | Definition | Source |
|---|---|---|
| `tidal_volume` | air_per_respiratory_cycle | [NBK482502](https://www.ncbi.nlm.nih.gov/books/NBK482502/) |
| `residual_volume` | air_remaining_after_maximal_forceful_expiration | [NBK493170](https://www.ncbi.nlm.nih.gov/books/NBK493170/) |
| `inspiratory_reserve_volume` | air_inhaled_after_normal_tidal | [NBK560526](https://www.ncbi.nlm.nih.gov/books/NBK560526/) |
| `vital_capacity` | max_air_exhaled_after_max_inspiration | [NBK541099](https://www.ncbi.nlm.nih.gov/books/NBK541099/) |
| `functional_residual_capacity` | air_remaining_after_normal_passive_exhalation | [NBK500007](https://www.ncbi.nlm.nih.gov/books/NBK500007/) |

## Deferred (1)

**Expiratory reserve volume** — its only self-contained StatPearls sentence names the term by **abbreviation alone** ("The ERV is the volume of air that can be forcefully exhaled after a normal resting expiration..."), with the full term spelled out only in an adjacent sentence. That fails this library's strict "the one sentence must name the full term" bar, so it is **deferred** (documented inline) rather than shipped weak. It is reused as the off-vocabulary abstention probe and can be added when a full-term self-contained span is found.

## Files

- `lung-volume-edges.adj` — the grounded library (dictionary + rulebook)
- `lung-volume-recall.query.adj` — worked binding queries (the LLM-produced shape: imports the library, asks `? is_defined_as(<volume>, $Definition)`)
- `test_lung_volume_recall.py` — 3-test scaffold: (1) pure-ADJ / no-authored-debt file shape (every clause grounded, all locators NCBI, no JSON/manifest/python sidecars); (2) the native adj-lang engine binds each definition with an authoritative NCBI citation; (3) the deferred `expiratory_reserve_volume` abstains rather than fabricates. **3/3 pass locally.**

## Notes

- The query `.adj` states no physiology fact — it only imports the library and asks binding queries; the engine resolves them and returns the binding plus the citing clause's source/locator/trust. Knowledge lives in ADJ; the engine answers.
- Security review: PASSED (Python test uses list-argv subprocess with timeout, atomic \`mkstemp\` tempfile, \`json.loads\` on trusted local-binary output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)