### PR TITLE
feat(mycin-fetalshunt): ADJ-only fetal-structure→adult-remnant recall library (6 edges)

### DIFF
--- a/code/specs/data/mycin-2026/recall/fetal-shunt-edges.adj
+++ b/code/specs/data/mycin-2026/recall/fetal-shunt-edges.adj
@@ -1,0 +1,86 @@
+% ============================================================================
+% fetal-shunt-edges — the fetal-structure→adult-remnant knowledge-graph
+% (MYCIN-2026 FETALSHUNT).
+% ============================================================================
+% A classic high-yield embryology/anatomy board table: each fetal circulatory
+% shunt / vessel and the obliterated adult remnant it becomes after birth.
+% "What does the ductus arteriosus become?" becomes the binding query
+%     ? becomes(ductus_arteriosus, $Remnant).
+%
+% Direction note: the relation is fetal structure -> the adult remnant it
+% becomes (`becomes`). Each fetal structure here maps to ONE canonical remnant
+% span, so a query binds a single answer.
+%
+% Faithfulness note: each `relate` subject/object is bound to what the cited
+% sentence ACTUALLY names. The remnant object names the literal adult structure
+% the sentence states the fetal structure becomes (ductus arteriosus "forming a
+% fibrous cord called the ligamentum arteriosum"; ductus venosus "develops into
+% a ligament called the ligamentum venosum"; umbilical vein "becomes the
+% ligamentum teres hepatis"; foramen ovale "fuse to become the fossa ovalis";
+% umbilical arteries "Medial umbilical ligaments are the remains of obliterated
+% umbilical arteries"; urachus "develops into ... the median umbilical
+% ligament"). Each span was independently re-fetched and confirmed on two
+% separate fetches of the same page for byte-stability.
+%
+% This file is the SHIPPED ARTIFACT and the SOLE source of truth — no generator,
+% no JSON, no manifest (a pure ADJ-only recall domain, like LUNGVOLUME/
+% DURALSINUS/HYPOTHALAMIC/PITUITARY). Each fact is a `relate` clause whose
+% byte-provenance lives INLINE:
+%     source   — the VERBATIM span copied from the cited page (byte-stable: it
+%                appears character-for-character in the page's normalized text;
+%                every span here was independently re-fetched and confirmed).
+%     locator  — the URL the span was read from (NCBI StatPearls / Bookshelf).
+%     trust    — authoritative (a primary, citable reference).
+% An LLM (or a human) recalls a fact by writing a tiny query .adj that `import`s
+% this library and asks a binding query — see fetal-shunt-recall.query.adj.
+% Nothing here is asserted "from memory": every edge is defended by a span a
+% reader can re-fetch and check.
+% (See feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+dictionary fetal_shunt_vocab {
+    define fetal_structure : entity   surface "fetal structure", "fetal shunt"
+    define adult_remnant   : entity   surface "adult remnant", "obliterated remnant"
+
+    define becomes : relation from fetal_structure to adult_remnant  % the adult remnant this fetal structure becomes
+}
+
+rulebook fetal_shunt_facts {
+    use fetal_shunt_vocab
+
+    % --- ductus arteriosus -> ligamentum arteriosum --------------------------
+    relate becomes(ductus_arteriosus, ligamentum_arteriosum)
+        source "The ductus arteriosus typically closes in the first 3 days of life, forming a fibrous cord called the ligamentum arteriosum."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK553173/"
+        trust authoritative
+
+    % --- ductus venosus -> ligamentum venosum --------------------------------
+    relate becomes(ductus_venosus, ligamentum_venosum)
+        source "At birth, the remnant of the ductus venosus gradually develops into a ligament called the ligamentum venosum."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK547759/"
+        trust authoritative
+
+    % --- umbilical vein -> ligamentum teres hepatis --------------------------
+    relate becomes(umbilical_vein, ligamentum_teres_hepatis)
+        source "The remnant of the umbilical vein becomes the ligamentum teres hepatis, which extends superiorly from the umbilicus to connect to the falciform ligament of the liver."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK557490/"
+        trust authoritative
+
+    % --- foramen ovale -> fossa ovalis ---------------------------------------
+    relate becomes(foramen_ovale, fossa_ovalis)
+        source "Over time, the foramen ovale tissues fuse to become the fossa ovalis, a closed remnant of the foramen ovale."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK545203/"
+        trust authoritative
+
+    % --- umbilical arteries -> medial umbilical ligaments --------------------
+    relate becomes(umbilical_arteries, medial_umbilical_ligaments)
+        source "Medial umbilical ligaments are the remains of obliterated umbilical arteries and are visible either side of the median ligament."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK551649/"
+        trust authoritative
+
+    % --- urachus -> median umbilical ligament --------------------------------
+    relate becomes(urachus, median_umbilical_ligament)
+        source "The urachus later develops into a fibrous cord, the median umbilical ligament."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK531465/"
+        trust authoritative
+}

--- a/code/specs/data/mycin-2026/recall/fetal-shunt-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/fetal-shunt-recall.query.adj
@@ -1,0 +1,21 @@
+% ============================================================================
+% fetal-shunt-recall.query.adj — a worked recall query over the fetal-shunt library.
+% ============================================================================
+% The shape an LLM (or a student) produces to ANSWER a "what does fetal structure
+% X become?" question: it states no anatomy fact — it only `import`s the grounded
+% library and asks binding queries. The native adj-lang engine resolves each `?`
+% against the imported `relate` edges and returns the binding + the citing
+% clause's source/locator/trust. All knowledge is in the library; none is here.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli fetal-shunt-recall.query.adj
+% ============================================================================
+
+import "fetal-shunt-edges.adj"
+
+? becomes(ductus_arteriosus, $Remnant)    % expect ligamentum_arteriosum
+? becomes(ductus_venosus, $Remnant)       % expect ligamentum_venosum
+? becomes(umbilical_vein, $Remnant)       % expect ligamentum_teres_hepatis
+? becomes(foramen_ovale, $Remnant)        % expect fossa_ovalis
+? becomes(umbilical_arteries, $Remnant)   % expect medial_umbilical_ligaments
+? becomes(urachus, $Remnant)              % expect median_umbilical_ligament

--- a/code/specs/data/mycin-2026/recall/test_fetal_shunt_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_fetal_shunt_recall.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""test_fetal_shunt_recall.py — the ADJ-only fetal-structure→adult-remnant recall
+library (MYCIN-2026 FETALSHUNT).
+
+A pure-ADJ recall domain (classic high-yield embryology/anatomy board table): the
+obliterated adult remnant each fetal circulatory shunt / vessel becomes after
+birth. `fetal-shunt-edges.adj` is the SOLE source of truth — facts +
+byte-provenance inline, no Python gate, no JSON, no manifest. This test pins the
+property that matters: the native adj-lang engine, given a query .adj that only
+`import`s the library and asks binding queries (`fetal-shunt-recall.query.adj` —
+the shape an LLM produces), binds the grounded remnant for each fetal structure,
+each carrying an AUTHORITATIVE citation with a real source span + locator.
+Knowledge lives in ADJ; the engine answers.
+
+If the native CLI isn't built (a Python-only CI lane), the engine-backed checks
+skip — the file-shape checks (every clause grounded, no authored-debt) still run.
+
+Run:  python3 test_fetal_shunt_recall.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ADJ = HERE / "fetal-shunt-edges.adj"
+QUERY = HERE / "fetal-shunt-recall.query.adj"
+CLI = HERE.parents[3] / "packages" / "rust" / "target" / "debug" / "adj-lang-cli"
+
+# Every grounded edge: fetal structure -> the adult remnant the library binds.
+EXPECTED = {
+    "ductus_arteriosus": "ligamentum_arteriosum",            # NBK553173
+    "ductus_venosus": "ligamentum_venosum",                  # NBK547759
+    "umbilical_vein": "ligamentum_teres_hepatis",            # NBK557490
+    "foramen_ovale": "fossa_ovalis",                         # NBK545203
+    "umbilical_arteries": "medial_umbilical_ligaments",      # NBK551649
+    "urachus": "median_umbilical_ligament",                  # NBK531465
+}
+REL = "becomes"
+VAR = "Remnant"
+
+
+def _cli_available() -> bool:
+    return CLI.exists()
+
+
+def _run(program: Path) -> dict:
+    out = subprocess.run([str(CLI), str(program)], capture_output=True, text=True,
+                         cwd=str(HERE), timeout=60)
+    assert out.returncode == 0, f"adj-lang-cli failed: {out.stderr}"
+    return json.loads(out.stdout)
+
+
+# ---- 1. the ADJ file is the artifact — every clause grounded, no authored-debt ----
+
+def test_library_is_pure_adj_and_fully_grounded() -> None:
+    text = ADJ.read_text()
+    assert "trust consensus" not in text, "FETALSHUNT ships no authored-debt; ground or omit"
+    assert "[FLAG:" not in text
+    edge_count = len(EXPECTED)  # 6
+    assert text.count("    relate ") == edge_count
+    assert text.count("trust authoritative") == edge_count
+    assert text.count('\n        locator "') == edge_count
+    assert text.count('\n        source "') == edge_count
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("locator "):
+            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+    assert not (HERE / "fetal_shunt_edge_ground.py").exists()
+    assert not (HERE / "fetal-shunt-edge-grounding.json").exists()
+    assert not (HERE / "fetal-shunt-edge-manifest.json").exists()
+
+
+# ---- 2. the engine binds each remnant with an authoritative citation ---------------
+
+def test_engine_binds_every_remnant_with_authoritative_citation() -> None:
+    if not _cli_available():
+        return
+    result = _run(QUERY)
+    by_query = {r["query"]: r for r in result["recall"]}
+    for fetal, remnant in EXPECTED.items():
+        q = f"{REL}({fetal}, {VAR})"
+        r = by_query.get(q)
+        assert r is not None and not r["abstained"], f"{q} abstained — edge missing?"
+        bound = {}
+        for a in r["answers"]:
+            bound[a["bindings"][VAR]] = (a.get("citations") or [{}])[0]
+        assert set(bound) == {remnant}, f"{fetal}: bound {set(bound)} != {{{remnant}}}"
+        cite = bound[remnant]
+        assert cite.get("trust") == "authoritative", f"{fetal}/{remnant} not authoritative"
+        assert cite.get("source"), f"{fetal}/{remnant} has no source span"
+        assert cite.get("locator", "").startswith("https://www.ncbi.nlm.nih.gov/")
+
+
+# ---- 3. an off-vocabulary fetal structure abstains, never fabricates ---------------
+
+def test_unknown_structure_abstains() -> None:
+    if not _cli_available():
+        return
+    import os
+    import tempfile
+    fd, path = tempfile.mkstemp(suffix=".adj", prefix=".fetalshunt_q_", dir=HERE)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            # the notochord is a real embryonic structure (it becomes the nucleus
+            # pulposus) but is deliberately not in this fetal-circulation library,
+            # so the engine must abstain rather than fabricate.
+            fh.write(f'import "fetal-shunt-edges.adj"\n? {REL}(notochord, ${VAR})\n')
+        res = _run(Path(path))
+        r = res["recall"][0] if res["recall"] else None
+        assert r is not None and r["abstained"], "an ungrounded structure must abstain"
+    finally:
+        os.unlink(path)
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS  {t.__name__}")
+        except AssertionError as exc:
+            failed += 1
+            print(f"  FAIL  {t.__name__}: {exc}")
+    print(f"\ntest_fetal_shunt_recall: {len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())


### PR DESCRIPTION
## What

A new **pure-ADJ recall domain** for MYCIN-2026: the fetal-structure→adult-remnant knowledge graph — a classic high-yield embryology/anatomy board table mapping each fetal circulatory shunt / vessel to the obliterated adult remnant it becomes after birth.

`fetal-shunt-edges.adj` is the **SOLE shipped artifact and source of truth** — no Python gate, no JSON, no manifest — following the LUNGVOLUME / DURALSINUS / HYPOTHALAMIC / PITUITARY pattern. Each `relate becomes(fetal_structure, adult_remnant)` clause carries inline byte-provenance: a VERBATIM NCBI StatPearls/Bookshelf span, an `https` NCBI locator, and `trust authoritative`.

## Edges (6)

Each edge is defended by a **self-contained** NCBI Bookshelf sentence that names BOTH the fetal structure and its adult remnant AND the becomes relationship, **independently re-fetched and confirmed byte-stable on two separate fetches**:

| Fetal structure | Adult remnant | Source |
|---|---|---|
| `ductus_arteriosus` | ligamentum_arteriosum | [NBK553173](https://www.ncbi.nlm.nih.gov/books/NBK553173/) |
| `ductus_venosus` | ligamentum_venosum | [NBK547759](https://www.ncbi.nlm.nih.gov/books/NBK547759/) |
| `umbilical_vein` | ligamentum_teres_hepatis | [NBK557490](https://www.ncbi.nlm.nih.gov/books/NBK557490/) |
| `foramen_ovale` | fossa_ovalis | [NBK545203](https://www.ncbi.nlm.nih.gov/books/NBK545203/) |
| `umbilical_arteries` | medial_umbilical_ligaments | [NBK551649](https://www.ncbi.nlm.nih.gov/books/NBK551649/) |
| `urachus` | median_umbilical_ligament | [NBK531465](https://www.ncbi.nlm.nih.gov/books/NBK531465/) |

## Files

- `fetal-shunt-edges.adj` — the grounded library (dictionary + rulebook)
- `fetal-shunt-recall.query.adj` — worked binding queries (the LLM-produced shape: imports the library, asks `? becomes(<fetal>, $Remnant)`)
- `test_fetal_shunt_recall.py` — 3-test scaffold: (1) pure-ADJ / no-authored-debt file shape (every clause grounded, all locators NCBI, no JSON/manifest/python sidecars); (2) the native adj-lang engine binds each remnant with an authoritative NCBI citation; (3) an off-vocabulary structure (`notochord`) abstains rather than fabricates. **3/3 pass locally.**

## Notes

- The query `.adj` states no anatomy fact — it only imports the library and asks binding queries; the engine resolves them and returns the binding plus the citing clause's source/locator/trust. Knowledge lives in ADJ; the engine answers.
- No edges deferred: all 6 targeted fetal structures yielded a qualifying self-contained Bookshelf span.
- Security review: PASSED (Python test uses list-argv subprocess with timeout, atomic \`mkstemp\` tempfile, \`json.loads\` on trusted local-binary output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)