### PR TITLE
feat(mycin-pharyngeal): ADJ-only pharyngeal-arch→cranial-nerve recall library (5 edges)

### DIFF
--- a/code/specs/data/mycin-2026/recall/pharyngeal-arch-edges.adj
+++ b/code/specs/data/mycin-2026/recall/pharyngeal-arch-edges.adj
@@ -1,0 +1,77 @@
+% ============================================================================
+% pharyngeal-arch-edges — the pharyngeal-arch→cranial-nerve knowledge-graph
+% (MYCIN-2026 PHARYNGEAL).
+% ============================================================================
+% A classic high-yield embryology board table: each pharyngeal (branchial) arch
+% and the cranial nerve that innervates / derives from it. "Which nerve goes with
+% the third pharyngeal arch?" becomes the binding query
+%     ? innervated_by(third_pharyngeal_arch, $Nerve).
+%
+% Direction note: the relation is arch -> its cranial nerve (`innervated_by`).
+% Each arch here maps to ONE canonical nerve span, so a query binds a single
+% answer. (The 5th arch is rudimentary/absent in humans and is intentionally
+% omitted — it is reused as the off-vocabulary abstention probe in the test.)
+%
+% Faithfulness note: each `relate` subject/object is bound to what the cited
+% sentence ACTUALLY names, by FULL nerve name (not a CN-number abbreviation
+% alone): arch 1 "trigeminal nerve"; arch 2 "facial nerve"; arch 3
+% "glossopharyngeal nerve"; arch 4 "superior laryngeal nerve" (a branch of CN X);
+% arch 6 "recurrent laryngeal nerve". Each span was independently re-fetched and
+% confirmed on two separate fetches of the same page for byte-stability.
+%
+% This file is the SHIPPED ARTIFACT and the SOLE source of truth — no generator,
+% no JSON, no manifest (a pure ADJ-only recall domain, like FETALSHUNT/
+% LUNGVOLUME/DURALSINUS/HYPOTHALAMIC). Each fact is a `relate` clause whose
+% byte-provenance lives INLINE:
+%     source   — the VERBATIM span copied from the cited page (byte-stable: it
+%                appears character-for-character in the page's normalized text;
+%                every span here was independently re-fetched and confirmed).
+%     locator  — the URL the span was read from (NCBI StatPearls / Bookshelf).
+%     trust    — authoritative (a primary, citable reference).
+% An LLM (or a human) recalls a fact by writing a tiny query .adj that `import`s
+% this library and asks a binding query — see pharyngeal-arch-recall.query.adj.
+% Nothing here is asserted "from memory": every edge is defended by a span a
+% reader can re-fetch and check.
+% (See feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+dictionary pharyngeal_arch_vocab {
+    define pharyngeal_arch : entity   surface "pharyngeal arch", "branchial arch"
+    define cranial_nerve   : entity   surface "cranial nerve", "arch nerve"
+
+    define innervated_by : relation from pharyngeal_arch to cranial_nerve  % the cranial nerve of this arch
+}
+
+rulebook pharyngeal_arch_facts {
+    use pharyngeal_arch_vocab
+
+    % --- first arch -> trigeminal nerve (CN V) -------------------------------
+    relate innervated_by(first_pharyngeal_arch, trigeminal_nerve)
+        source "The trigeminal nerve is derived from the first pharyngeal arch."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK507820/"
+        trust authoritative
+
+    % --- second arch -> facial nerve (CN VII) --------------------------------
+    relate innervated_by(second_pharyngeal_arch, facial_nerve)
+        source "While the facial nerve develops from the second pharyngeal arch, the geniculate ganglion develops mainly from the epibranchial placode."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK555950/"
+        trust authoritative
+
+    % --- third arch -> glossopharyngeal nerve (CN IX) ------------------------
+    relate innervated_by(third_pharyngeal_arch, glossopharyngeal_nerve)
+        source "The glossopharyngeal nerve derives from the third pharyngeal arch and is the only structure formed by it, although the third pharyngeal pouch is the embryologic origin of part of the thymus."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK539877/"
+        trust authoritative
+
+    % --- fourth arch -> superior laryngeal nerve (branch of CN X) ------------
+    relate innervated_by(fourth_pharyngeal_arch, superior_laryngeal_nerve)
+        source "The superior laryngeal nerve (a branch of CN X) supplies the part of the larynx that develops from the fourth pharyngeal arch, and the recurrent laryngeal nerve (a branch of CN X) supplies the part that derives from the sixth pharyngeal arch."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK532995/"
+        trust authoritative
+
+    % --- sixth arch -> recurrent laryngeal nerve (branch of CN X) ------------
+    relate innervated_by(sixth_pharyngeal_arch, recurrent_laryngeal_nerve)
+        source "The sixth pharyngeal arch gives rise to the recurrent laryngeal nerve, cricoid cartilage, arytenoid cartilages, corniculate cartilages and the intrinsic musculature of the larynx."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK538307/"
+        trust authoritative
+}

--- a/code/specs/data/mycin-2026/recall/pharyngeal-arch-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/pharyngeal-arch-recall.query.adj
@@ -1,0 +1,22 @@
+% ============================================================================
+% pharyngeal-arch-recall.query.adj — a worked recall query over the
+% pharyngeal-arch library.
+% ============================================================================
+% The shape an LLM (or a student) produces to ANSWER a "which nerve goes with
+% arch X?" question: it states no embryology fact — it only `import`s the
+% grounded library and asks binding queries. The native adj-lang engine resolves
+% each `?` against the imported `relate` edges and returns the binding + the
+% citing clause's source/locator/trust. All knowledge is in the library; none is
+% here.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli pharyngeal-arch-recall.query.adj
+% ============================================================================
+
+import "pharyngeal-arch-edges.adj"
+
+? innervated_by(first_pharyngeal_arch, $Nerve)    % expect trigeminal_nerve
+? innervated_by(second_pharyngeal_arch, $Nerve)   % expect facial_nerve
+? innervated_by(third_pharyngeal_arch, $Nerve)    % expect glossopharyngeal_nerve
+? innervated_by(fourth_pharyngeal_arch, $Nerve)   % expect superior_laryngeal_nerve
+? innervated_by(sixth_pharyngeal_arch, $Nerve)    % expect recurrent_laryngeal_nerve

--- a/code/specs/data/mycin-2026/recall/test_pharyngeal_arch_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_pharyngeal_arch_recall.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""test_pharyngeal_arch_recall.py — the ADJ-only pharyngeal-arch→cranial-nerve
+recall library (MYCIN-2026 PHARYNGEAL).
+
+A pure-ADJ recall domain (classic high-yield embryology board table): the cranial
+nerve that innervates / derives from each pharyngeal (branchial) arch.
+`pharyngeal-arch-edges.adj` is the SOLE source of truth — facts + byte-provenance
+inline, no Python gate, no JSON, no manifest. This test pins the property that
+matters: the native adj-lang engine, given a query .adj that only `import`s the
+library and asks binding queries (`pharyngeal-arch-recall.query.adj` — the shape
+an LLM produces), binds the grounded nerve for each arch, each carrying an
+AUTHORITATIVE citation with a real source span + locator. Knowledge lives in ADJ;
+the engine answers.
+
+If the native CLI isn't built (a Python-only CI lane), the engine-backed checks
+skip — the file-shape checks (every clause grounded, no authored-debt) still run.
+
+Run:  python3 test_pharyngeal_arch_recall.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ADJ = HERE / "pharyngeal-arch-edges.adj"
+QUERY = HERE / "pharyngeal-arch-recall.query.adj"
+CLI = HERE.parents[3] / "packages" / "rust" / "target" / "debug" / "adj-lang-cli"
+
+# Every grounded edge: pharyngeal arch -> the cranial nerve the library binds.
+EXPECTED = {
+    "first_pharyngeal_arch": "trigeminal_nerve",              # NBK507820
+    "second_pharyngeal_arch": "facial_nerve",                 # NBK555950
+    "third_pharyngeal_arch": "glossopharyngeal_nerve",        # NBK539877
+    "fourth_pharyngeal_arch": "superior_laryngeal_nerve",     # NBK532995
+    "sixth_pharyngeal_arch": "recurrent_laryngeal_nerve",     # NBK538307
+}
+REL = "innervated_by"
+VAR = "Nerve"
+
+
+def _cli_available() -> bool:
+    return CLI.exists()
+
+
+def _run(program: Path) -> dict:
+    out = subprocess.run([str(CLI), str(program)], capture_output=True, text=True,
+                         cwd=str(HERE), timeout=60)
+    assert out.returncode == 0, f"adj-lang-cli failed: {out.stderr}"
+    return json.loads(out.stdout)
+
+
+# ---- 1. the ADJ file is the artifact — every clause grounded, no authored-debt ----
+
+def test_library_is_pure_adj_and_fully_grounded() -> None:
+    text = ADJ.read_text()
+    assert "trust consensus" not in text, "PHARYNGEAL ships no authored-debt; ground or omit"
+    assert "[FLAG:" not in text
+    edge_count = len(EXPECTED)  # 5
+    assert text.count("    relate ") == edge_count
+    assert text.count("trust authoritative") == edge_count
+    assert text.count('\n        locator "') == edge_count
+    assert text.count('\n        source "') == edge_count
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("locator "):
+            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+    assert not (HERE / "pharyngeal_arch_edge_ground.py").exists()
+    assert not (HERE / "pharyngeal-arch-edge-grounding.json").exists()
+    assert not (HERE / "pharyngeal-arch-edge-manifest.json").exists()
+
+
+# ---- 2. the engine binds each nerve with an authoritative citation -----------------
+
+def test_engine_binds_every_nerve_with_authoritative_citation() -> None:
+    if not _cli_available():
+        return
+    result = _run(QUERY)
+    by_query = {r["query"]: r for r in result["recall"]}
+    for arch, nerve in EXPECTED.items():
+        q = f"{REL}({arch}, {VAR})"
+        r = by_query.get(q)
+        assert r is not None and not r["abstained"], f"{q} abstained — edge missing?"
+        bound = {}
+        for a in r["answers"]:
+            bound[a["bindings"][VAR]] = (a.get("citations") or [{}])[0]
+        assert set(bound) == {nerve}, f"{arch}: bound {set(bound)} != {{{nerve}}}"
+        cite = bound[nerve]
+        assert cite.get("trust") == "authoritative", f"{arch}/{nerve} not authoritative"
+        assert cite.get("source"), f"{arch}/{nerve} has no source span"
+        assert cite.get("locator", "").startswith("https://www.ncbi.nlm.nih.gov/")
+
+
+# ---- 3. an off-vocabulary arch abstains, never fabricates --------------------------
+
+def test_unknown_arch_abstains() -> None:
+    if not _cli_available():
+        return
+    import os
+    import tempfile
+    fd, path = tempfile.mkstemp(suffix=".adj", prefix=".pharyngeal_q_", dir=HERE)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            # the fifth pharyngeal arch is rudimentary/absent in humans and is
+            # deliberately not in this library, so the engine must abstain rather
+            # than fabricate.
+            fh.write(f'import "pharyngeal-arch-edges.adj"\n? {REL}(fifth_pharyngeal_arch, ${VAR})\n')
+        res = _run(Path(path))
+        r = res["recall"][0] if res["recall"] else None
+        assert r is not None and r["abstained"], "an ungrounded arch must abstain"
+    finally:
+        os.unlink(path)
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS  {t.__name__}")
+        except AssertionError as exc:
+            failed += 1
+            print(f"  FAIL  {t.__name__}: {exc}")
+    print(f"\ntest_pharyngeal_arch_recall: {len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())


### PR DESCRIPTION
## What

A new **pure-ADJ recall domain** for MYCIN-2026: the pharyngeal-arch→cranial-nerve knowledge graph — a classic high-yield embryology board table mapping each pharyngeal (branchial) arch to the cranial nerve that innervates / derives from it.

`pharyngeal-arch-edges.adj` is the **SOLE shipped artifact and source of truth** — no Python gate, no JSON, no manifest — following the FETALSHUNT / LUNGVOLUME / DURALSINUS / HYPOTHALAMIC pattern. Each `relate innervated_by(pharyngeal_arch, cranial_nerve)` clause carries inline byte-provenance: a VERBATIM NCBI StatPearls/Bookshelf span, an `https` NCBI locator, and `trust authoritative`.

## Edges (5)

Each edge is defended by a **self-contained** NCBI Bookshelf sentence that names the arch and the **full nerve name** (not a CN-number abbreviation alone) AND the relationship, **independently re-fetched and confirmed byte-stable on two separate fetches**:

| Pharyngeal arch | Cranial nerve | Source |
|---|---|---|
| `first_pharyngeal_arch` | trigeminal_nerve | [NBK507820](https://www.ncbi.nlm.nih.gov/books/NBK507820/) |
| `second_pharyngeal_arch` | facial_nerve | [NBK555950](https://www.ncbi.nlm.nih.gov/books/NBK555950/) |
| `third_pharyngeal_arch` | glossopharyngeal_nerve | [NBK539877](https://www.ncbi.nlm.nih.gov/books/NBK539877/) |
| `fourth_pharyngeal_arch` | superior_laryngeal_nerve (branch of CN X) | [NBK532995](https://www.ncbi.nlm.nih.gov/books/NBK532995/) |
| `sixth_pharyngeal_arch` | recurrent_laryngeal_nerve (branch of CN X) | [NBK538307](https://www.ncbi.nlm.nih.gov/books/NBK538307/) |

## Faithfulness note

The second-arch edge was **re-grounded** to a span that spells out "facial nerve" (NBK555950) rather than the first candidate which named the nerve only as "CN VII" — keeping every shipped edge bound to a full proper name the reader can verify from the span alone (the same bar that handled the LUNGVOLUME ERV case). The **5th arch** (rudimentary/absent in humans) is intentionally omitted and reused as the off-vocabulary abstention probe.

## Files

- `pharyngeal-arch-edges.adj` — the grounded library (dictionary + rulebook)
- `pharyngeal-arch-recall.query.adj` — worked binding queries (the LLM-produced shape: imports the library, asks `? innervated_by(<arch>, $Nerve)`)
- `test_pharyngeal_arch_recall.py` — 3-test scaffold: (1) pure-ADJ / no-authored-debt file shape (every clause grounded, all locators NCBI, no JSON/manifest/python sidecars); (2) the native adj-lang engine binds each nerve with an authoritative NCBI citation; (3) the off-vocabulary `fifth_pharyngeal_arch` abstains rather than fabricates. **3/3 pass locally.**

## Notes

- The query `.adj` states no embryology fact — it only imports the library and asks binding queries; the engine resolves them and returns the binding plus the citing clause's source/locator/trust. Knowledge lives in ADJ; the engine answers.
- Security review: PASSED (Python test uses list-argv subprocess with timeout, atomic \`mkstemp\` tempfile, \`json.loads\` on trusted local-binary output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)