### PR TITLE
feat(mycin-heartvalve): ADJ-only heart-valve→auscultation-site recall library (4 edges)

### DIFF
--- a/code/specs/data/mycin-2026/recall/heart-valve-edges.adj
+++ b/code/specs/data/mycin-2026/recall/heart-valve-edges.adj
@@ -1,0 +1,73 @@
+% ============================================================================
+% heart-valve-edges — the heart-valve→auscultation-site knowledge-graph
+% (MYCIN-2026 HEARTVALVE).
+% ============================================================================
+% A high-yield cardiac-exam board table: each cardiac valve and the chest-wall
+% location where it is best auscultated. "Where is the mitral valve best heard?"
+% becomes the binding query
+%     ? best_heard_at(mitral_valve, $Location).
+%
+% Direction note: the relation is valve -> the chest-wall site where it is
+% loudest / best heard (`best_heard_at`). Each valve here maps to ONE canonical
+% location span, so a query binds a single answer.
+%
+% Faithfulness note: each `relate` subject/object is bound to what the cited
+% sentence ACTUALLY names. The location object names the literal site the sentence
+% states (aortic "best heard in the 2nd right intercostal space"; pulmonic "best
+% auscultated in the 2nd left intercostal space"; tricuspid "loudest in the 4th
+% left intercostal space"; mitral "loudest in the left 5th intercostal space at
+% the midclavicular line"). The tricuspid and mitral edges cite the SAME
+% self-contained sentence — it names both valves and both sites explicitly. Each
+% span was independently re-fetched and confirmed on two separate fetches of the
+% same page for byte-stability.
+%
+% This file is the SHIPPED ARTIFACT and the SOLE source of truth — no generator,
+% no JSON, no manifest (a pure ADJ-only recall domain, like PHARYNGEAL/FETALSHUNT/
+% LUNGVOLUME/DURALSINUS). Each fact is a `relate` clause whose byte-provenance
+% lives INLINE:
+%     source   — the VERBATIM span copied from the cited page (byte-stable: it
+%                appears character-for-character in the page's normalized text;
+%                every span here was independently re-fetched and confirmed).
+%     locator  — the URL the span was read from (NCBI StatPearls / Bookshelf).
+%     trust    — authoritative (a primary, citable reference).
+% An LLM (or a human) recalls a fact by writing a tiny query .adj that `import`s
+% this library and asks a binding query — see heart-valve-recall.query.adj.
+% Nothing here is asserted "from memory": every edge is defended by a span a
+% reader can re-fetch and check.
+% (See feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+dictionary heart_valve_vocab {
+    define valve    : entity   surface "heart valve", "cardiac valve"
+    define location : entity   surface "auscultation site", "chest-wall location"
+
+    define best_heard_at : relation from valve to location  % the chest-wall site this valve is best auscultated
+}
+
+rulebook heart_valve_facts {
+    use heart_valve_vocab
+
+    % --- aortic valve -> right 2nd intercostal space -------------------------
+    relate best_heard_at(aortic_valve, right_second_intercostal_space)
+        source "The aortic valve is best heard in the 2nd right intercostal space."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK541010/"
+        trust authoritative
+
+    % --- pulmonic valve -> left 2nd intercostal space -----------------------
+    relate best_heard_at(pulmonic_valve, left_second_intercostal_space)
+        source "The pulmonic valve is best auscultated in the 2nd left intercostal space."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK541010/"
+        trust authoritative
+
+    % --- tricuspid valve -> 4th left intercostal space ----------------------
+    relate best_heard_at(tricuspid_valve, fourth_left_intercostal_space)
+        source "The tricuspid valve is loudest in the 4th left intercostal space, and the mitral valve is loudest in the left 5th intercostal space at the midclavicular line."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK541010/"
+        trust authoritative
+
+    % --- mitral valve -> 5th intercostal space, midclavicular line ----------
+    relate best_heard_at(mitral_valve, fifth_intercostal_space_midclavicular_line)
+        source "The tricuspid valve is loudest in the 4th left intercostal space, and the mitral valve is loudest in the left 5th intercostal space at the midclavicular line."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK541010/"
+        trust authoritative
+}

--- a/code/specs/data/mycin-2026/recall/heart-valve-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/heart-valve-recall.query.adj
@@ -1,0 +1,19 @@
+% ============================================================================
+% heart-valve-recall.query.adj — a worked recall query over the heart-valve library.
+% ============================================================================
+% The shape an LLM (or a student) produces to ANSWER a "where is valve X best
+% heard?" question: it states no exam fact — it only `import`s the grounded
+% library and asks binding queries. The native adj-lang engine resolves each `?`
+% against the imported `relate` edges and returns the binding + the citing
+% clause's source/locator/trust. All knowledge is in the library; none is here.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli heart-valve-recall.query.adj
+% ============================================================================
+
+import "heart-valve-edges.adj"
+
+? best_heard_at(aortic_valve, $Location)      % expect right_second_intercostal_space
+? best_heard_at(pulmonic_valve, $Location)    % expect left_second_intercostal_space
+? best_heard_at(tricuspid_valve, $Location)   % expect fourth_left_intercostal_space
+? best_heard_at(mitral_valve, $Location)      % expect fifth_intercostal_space_midclavicular_line

--- a/code/specs/data/mycin-2026/recall/test_heart_valve_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_heart_valve_recall.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""test_heart_valve_recall.py — the ADJ-only heart-valve→auscultation-site recall
+library (MYCIN-2026 HEARTVALVE).
+
+A pure-ADJ recall domain (high-yield cardiac-exam board table): the chest-wall
+site where each cardiac valve is best auscultated. `heart-valve-edges.adj` is the
+SOLE source of truth — facts + byte-provenance inline, no Python gate, no JSON,
+no manifest. This test pins the property that matters: the native adj-lang
+engine, given a query .adj that only `import`s the library and asks binding
+queries (`heart-valve-recall.query.adj` — the shape an LLM produces), binds the
+grounded location for each valve, each carrying an AUTHORITATIVE citation with a
+real source span + locator. Knowledge lives in ADJ; the engine answers.
+
+If the native CLI isn't built (a Python-only CI lane), the engine-backed checks
+skip — the file-shape checks (every clause grounded, no authored-debt) still run.
+
+Run:  python3 test_heart_valve_recall.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ADJ = HERE / "heart-valve-edges.adj"
+QUERY = HERE / "heart-valve-recall.query.adj"
+CLI = HERE.parents[3] / "packages" / "rust" / "target" / "debug" / "adj-lang-cli"
+
+# Every grounded edge: cardiac valve -> the auscultation site the library binds.
+EXPECTED = {
+    "aortic_valve": "right_second_intercostal_space",                    # NBK541010
+    "pulmonic_valve": "left_second_intercostal_space",                   # NBK541010
+    "tricuspid_valve": "fourth_left_intercostal_space",                  # NBK541010
+    "mitral_valve": "fifth_intercostal_space_midclavicular_line",        # NBK541010
+}
+REL = "best_heard_at"
+VAR = "Location"
+
+
+def _cli_available() -> bool:
+    return CLI.exists()
+
+
+def _run(program: Path) -> dict:
+    out = subprocess.run([str(CLI), str(program)], capture_output=True, text=True,
+                         cwd=str(HERE), timeout=60)
+    assert out.returncode == 0, f"adj-lang-cli failed: {out.stderr}"
+    return json.loads(out.stdout)
+
+
+# ---- 1. the ADJ file is the artifact — every clause grounded, no authored-debt ----
+
+def test_library_is_pure_adj_and_fully_grounded() -> None:
+    text = ADJ.read_text()
+    assert "trust consensus" not in text, "HEARTVALVE ships no authored-debt; ground or omit"
+    assert "[FLAG:" not in text
+    edge_count = len(EXPECTED)  # 4
+    assert text.count("    relate ") == edge_count
+    assert text.count("trust authoritative") == edge_count
+    assert text.count('\n        locator "') == edge_count
+    assert text.count('\n        source "') == edge_count
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("locator "):
+            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+    assert not (HERE / "heart_valve_edge_ground.py").exists()
+    assert not (HERE / "heart-valve-edge-grounding.json").exists()
+    assert not (HERE / "heart-valve-edge-manifest.json").exists()
+
+
+# ---- 2. the engine binds each location with an authoritative citation --------------
+
+def test_engine_binds_every_location_with_authoritative_citation() -> None:
+    if not _cli_available():
+        return
+    result = _run(QUERY)
+    by_query = {r["query"]: r for r in result["recall"]}
+    for valve, location in EXPECTED.items():
+        q = f"{REL}({valve}, {VAR})"
+        r = by_query.get(q)
+        assert r is not None and not r["abstained"], f"{q} abstained — edge missing?"
+        bound = {}
+        for a in r["answers"]:
+            bound[a["bindings"][VAR]] = (a.get("citations") or [{}])[0]
+        assert set(bound) == {location}, f"{valve}: bound {set(bound)} != {{{location}}}"
+        cite = bound[location]
+        assert cite.get("trust") == "authoritative", f"{valve}/{location} not authoritative"
+        assert cite.get("source"), f"{valve}/{location} has no source span"
+        assert cite.get("locator", "").startswith("https://www.ncbi.nlm.nih.gov/")
+
+
+# ---- 3. an off-vocabulary valve abstains, never fabricates --------------------------
+
+def test_unknown_valve_abstains() -> None:
+    if not _cli_available():
+        return
+    import os
+    import tempfile
+    fd, path = tempfile.mkstemp(suffix=".adj", prefix=".heartvalve_q_", dir=HERE)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            # the eustachian valve (valve of the inferior vena cava) is a real
+            # cardiac valve but is not one of the four auscultated valves, so it
+            # is deliberately not in this library — the engine must abstain.
+            fh.write(f'import "heart-valve-edges.adj"\n? {REL}(eustachian_valve, ${VAR})\n')
+        res = _run(Path(path))
+        r = res["recall"][0] if res["recall"] else None
+        assert r is not None and r["abstained"], "an ungrounded valve must abstain"
+    finally:
+        os.unlink(path)
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS  {t.__name__}")
+        except AssertionError as exc:
+            failed += 1
+            print(f"  FAIL  {t.__name__}: {exc}")
+    print(f"\ntest_heart_valve_recall: {len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())


### PR DESCRIPTION
## What

A new **pure-ADJ recall domain** for MYCIN-2026: the heart-valve→auscultation-site knowledge graph — a high-yield cardiac-exam board table mapping each cardiac valve to the chest-wall site where it is best auscultated.

`heart-valve-edges.adj` is the **SOLE shipped artifact and source of truth** — no Python gate, no JSON, no manifest — following the PHARYNGEAL / FETALSHUNT / LUNGVOLUME / DURALSINUS pattern. Each `relate best_heard_at(valve, location)` clause carries inline byte-provenance: a VERBATIM NCBI StatPearls/Bookshelf span, an `https` NCBI locator, and `trust authoritative`.

## Edges (4)

Each edge is defended by a **self-contained** NCBI Bookshelf sentence (all from [NBK541010](https://www.ncbi.nlm.nih.gov/books/NBK541010/)) naming BOTH the valve and its site AND the relationship, **independently re-fetched and confirmed byte-stable on two separate fetches**:

| Valve | Best heard at |
|---|---|
| `aortic_valve` | right_second_intercostal_space |
| `pulmonic_valve` | left_second_intercostal_space |
| `tricuspid_valve` | fourth_left_intercostal_space |
| `mitral_valve` | fifth_intercostal_space_midclavicular_line |

The tricuspid & mitral edges cite the **same** self-contained sentence — it names both valves and both sites explicitly — so each clause's subject + object are both present in its source span.

## Files

- `heart-valve-edges.adj` — the grounded library (dictionary + rulebook)
- `heart-valve-recall.query.adj` — worked binding queries (the LLM-produced shape: imports the library, asks `? best_heard_at(<valve>, $Location)`)
- `test_heart_valve_recall.py` — 3-test scaffold: (1) pure-ADJ / no-authored-debt file shape (every clause grounded, all locators NCBI, no JSON/manifest/python sidecars); (2) the native adj-lang engine binds each location with an authoritative NCBI citation; (3) an off-vocabulary valve (`eustachian_valve`) abstains rather than fabricates. **3/3 pass locally.**

## Notes

- The query `.adj` states no exam fact — it only imports the library and asks binding queries; the engine resolves them and returns the binding plus the citing clause's source/locator/trust. Knowledge lives in ADJ; the engine answers.
- Security review: PASSED (Python test uses list-argv subprocess with timeout, atomic \`mkstemp\` tempfile, \`json.loads\` on trusted local-binary output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)