### PR TITLE
feat(closurec): fold static String.fromCharCode(...) into a string literal (CLOC)

### DIFF
--- a/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to the `coding-adventures-closure-pass-constant-fold` crate will be documented in this file.
 
+## [0.43.0] - 2026-06-25
+
+### Added — fold the static `String.fromCharCode(u0, u1, …)` into a string literal
+
+`String.fromCharCode` now folds to a string literal when every argument is a
+non-negative integer literal in `0..=0xFFFF` (ECMAScript §22.1.2.1). The
+arguments are UTF-16 code **units**, so `String.fromCharCode(72, 73)` → `"HI"`,
+an adjacent high+low surrogate pair assembles one astral scalar
+(`String.fromCharCode(0xD83D, 0xDCA9)` → `"💩"`), and `String.fromCharCode()` →
+`""`.
+
+This is the first fold whose receiver is the **bare global identifier
+`String`** rather than a string/number literal — it lands in a new
+identifier-receiver branch of the MemberExpression arm (`window.String.…` and
+other non-identifier receivers never match). Soundness follows the same
+"builtins intact" premise as the rest of the pass, one notch weaker (like
+`parseInt`/`parseFloat`): a local `let String = …` could mask the global, but
+we fold anyway, matching Closure Compiler.
+
+New `fold_string_from_char_code` helper. It **declines** (leaving the call) for
+a fractional, negative, `>0xFFFF`, or non-literal argument — we don't model
+JS's `ToUint16` wrap-around — and for any unit sequence that is not valid
+UTF-16, i.e. a **lone surrogate** (a legal JS string but not a Rust `String`,
+the same guard `slice`/`charAt`/`codePointAt` use). Five V8-oracle unit tests
+(basic + empty, surrogate-pair assembly, lone-surrogate decline,
+out-of-range/fractional decline, non-`String` receiver decline).
+
 ## [0.39.0] - 2026-06-24
 
 ### Added — fold `"abcd".substring(start[, end])` on string literals

--- a/code/packages/rust/closure-pass-constant-fold/Cargo.toml
+++ b/code/packages/rust/closure-pass-constant-fold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-constant-fold"
-version = "0.39.0"
+version = "0.43.0"
 edition = "2021"
 description = "Constant-folding optimization pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Folds compile-time-evaluable expressions like `2 + 3 → 5`."
 

--- a/code/packages/rust/closure-pass-constant-fold/src/lib.rs
+++ b/code/packages/rust/closure-pass-constant-fold/src/lib.rs
@@ -1025,6 +1025,50 @@ fn fold_call(c: &CallExpression, st: &mut FoldState) -> Expression {
                     }
                 }
             }
+            // ---- String.fromCharCode(u0, u1, …) → the built string ----
+            //
+            // The static `String.fromCharCode` (ECMAScript §22.1.2.1) builds a
+            // string from UTF-16 code UNITS: `String.fromCharCode(72, 73)` →
+            // `"HI"`, and an adjacent high+low surrogate pair assembles one
+            // astral character — `String.fromCharCode(0xD83D, 0xDCA9)` → `"💩"`.
+            // No arguments yields `""`.
+            //
+            // SOUNDNESS — this folds under the same "builtins intact" premise as
+            // every fold here, but, like `parseInt`/`parseFloat` below, one notch
+            // weaker: `String` is a *free identifier*, so a local binding
+            // (`let String = …`) could mask it. We fold anyway — matching Closure
+            // Compiler, which treats redefining the global as out of scope — but
+            // ONLY when the receiver is the bare identifier `String` (never a
+            // member access like `window.String`, which would carry a non-
+            // Identifier object). Each argument must be a non-negative integer
+            // literal that fits in 16 bits (`0..=0xFFFF`); JS applies `ToUint16`
+            // (mod 2^16) to every argument, but we stay conservative and DECLINE
+            // for a fractional, negative, out-of-16-bit, or non-literal argument
+            // rather than model that coercion. We also DECLINE when the units do
+            // not form valid UTF-16 — a LONE surrogate is a valid JS string but
+            // cannot be a Rust `String` (the same hazard `slice`/`charAt`/
+            // `codePointAt` guard against).
+            if let (Expression::Identifier(obj), Expression::Identifier(prop)) =
+                (m.object.as_ref(), m.property.as_ref())
+            {
+                if obj.name == "String" && prop.name == "fromCharCode" {
+                    if let Some(result) = fold_string_from_char_code(&arguments) {
+                        let parent = c.cv.clone();
+                        let args_src = arguments
+                            .iter()
+                            .map(|a| match a {
+                                Expression::NumericLiteral(n) => format_js_number(n.value),
+                                _ => "?".to_string(),
+                            })
+                            .collect::<Vec<_>>()
+                            .join(",");
+                        let before = format!("String.fromCharCode({})", args_src);
+                        let after = format!("\"{}\"", result);
+                        let new_cv = st.fork_cv(&parent, &before, &after);
+                        return stamp_literal_cv(FoldedLiteral::String(result), new_cv);
+                    }
+                }
+            }
         }
     }
 
@@ -1205,6 +1249,40 @@ fn fold_string_slice(value: &str, args: &[Expression]) -> Option<String> {
     }
     // A lone surrogate (split pair) can't be a Rust String — decline.
     String::from_utf16(&units[lo..hi]).ok()
+}
+
+/// Fold the static `String.fromCharCode(u0, u1, …)` — build a string from
+/// UTF-16 code units (ECMAScript §22.1.2.1).
+///
+/// Each argument is one UTF-16 code unit, so `String.fromCharCode(72, 73)` →
+/// `"HI"` and an adjacent high+low surrogate pair assembles an astral scalar
+/// (`String.fromCharCode(0xD83D, 0xDCA9)` → `"💩"`). No arguments → `""`.
+///
+/// Conservative scope: every argument must be a non-negative integer literal
+/// that already fits in 16 bits (`0..=0xFFFF`). JS coerces each via `ToUint16`
+/// (mod 2^16), but we decline (returning `None`, leaving the call) for a
+/// fractional, negative, out-of-range, or non-literal argument rather than
+/// model that wrap-around. We also return `None` when the assembled units are
+/// not valid UTF-16 — a LONE surrogate is a legal JS string but cannot be a
+/// Rust `String` (`String::from_utf16` fails), the same guard `slice`/`charAt`/
+/// `codePointAt` use.
+fn fold_string_from_char_code(args: &[Expression]) -> Option<String> {
+    let mut units: Vec<u16> = Vec::with_capacity(args.len());
+    for a in args {
+        match a {
+            Expression::NumericLiteral(n)
+                if n.value.is_finite()
+                    && n.value.fract() == 0.0
+                    && n.value >= 0.0
+                    && n.value <= 0xFFFF as f64 =>
+            {
+                units.push(n.value as u16);
+            }
+            _ => return None,
+        }
+    }
+    // A lone surrogate among the units can't be a Rust String — decline.
+    String::from_utf16(&units).ok()
 }
 
 /// Fold `"…".substring(start[, end])` (ECMAScript §22.1.3.24).
@@ -4727,6 +4805,80 @@ mod tests {
         let c = call1(string("abc", None), "includes", num(1.0, None));
         let (out, _, changed, _) = run_pass(program_with_expr(c, true));
         assert!(!changed, "includes with a numeric arg must not fold");
+        assert!(matches!(extract_expr(&out), Expression::CallExpression(_)));
+    }
+
+    // ------------------- String.fromCharCode (static) ----------------
+
+    /// Build `String.fromCharCode(<args…>)` from numeric literal arguments.
+    fn from_char_code_call(args: &[f64]) -> Expression {
+        Expression::CallExpression(CallExpression {
+            cv: Some("c.cv".to_string()),
+            callee: Box::new(member(ident("String"), "fromCharCode")),
+            arguments: args.iter().map(|&a| num(a, None)).collect(),
+        })
+    }
+
+    #[test]
+    fn fold_from_char_code_basic_and_empty() {
+        // V8 oracle: String.fromCharCode(72,73) === "HI"; fromCharCode() === "".
+        for (args, expect) in [(vec![72.0, 73.0], "HI"), (vec![], ""), (vec![65.0], "A")] {
+            let c = from_char_code_call(&args);
+            let (out, _, changed, _) = run_pass(program_with_expr(c, true));
+            assert!(changed, "String.fromCharCode({args:?}) should fold");
+            match extract_expr(&out) {
+                Expression::StringLiteral(s) => assert_eq!(s.value, expect),
+                other => panic!("expected \"{expect}\"; got {:?}", other),
+            }
+        }
+    }
+
+    #[test]
+    fn fold_from_char_code_assembles_surrogate_pair() {
+        // Adjacent high+low surrogate units assemble the astral scalar U+1F4A9:
+        // String.fromCharCode(0xD83D, 0xDCA9) === "💩" (V8).
+        let c = from_char_code_call(&[0xD83D as f64, 0xDCA9 as f64]);
+        let (out, _, changed, _) = run_pass(program_with_expr(c, true));
+        assert!(changed, "surrogate-pair fromCharCode should fold");
+        match extract_expr(&out) {
+            Expression::StringLiteral(s) => assert_eq!(s.value, "💩"),
+            other => panic!("expected \"💩\"; got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn from_char_code_lone_surrogate_does_not_fold() {
+        // A lone high surrogate is a valid JS string but not a Rust String —
+        // decline (String.fromCharCode(0xD83D) has no literal we can emit).
+        let c = from_char_code_call(&[0xD83D as f64]);
+        let (out, _, changed, _) = run_pass(program_with_expr(c, true));
+        assert!(!changed, "lone-surrogate fromCharCode must not fold");
+        assert!(matches!(extract_expr(&out), Expression::CallExpression(_)));
+    }
+
+    #[test]
+    fn from_char_code_out_of_range_or_fractional_does_not_fold() {
+        // We conservatively decline rather than model ToUint16 wrap-around for
+        // a fractional, negative, or >0xFFFF argument.
+        for args in [vec![65.5], vec![-1.0], vec![70000.0], vec![65.0, 0.5]] {
+            let c = from_char_code_call(&args);
+            let (out, _, changed, _) = run_pass(program_with_expr(c, true));
+            assert!(!changed, "String.fromCharCode({args:?}) must not fold");
+            assert!(matches!(extract_expr(&out), Expression::CallExpression(_)));
+        }
+    }
+
+    #[test]
+    fn from_char_code_on_non_string_receiver_does_not_fold() {
+        // Only the bare global `String` folds; `s.fromCharCode(72)` (some other
+        // receiver) is left untouched.
+        let c = Expression::CallExpression(CallExpression {
+            cv: Some("c.cv".to_string()),
+            callee: Box::new(member(ident("s"), "fromCharCode")),
+            arguments: vec![num(72.0, None)],
+        });
+        let (out, _, changed, _) = run_pass(program_with_expr(c, true));
+        assert!(!changed, "non-String receiver fromCharCode must not fold");
         assert!(matches!(extract_expr(&out), Expression::CallExpression(_)));
     }
 

--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.192.0] - 2026-06-25
+
+### Added — static `String.fromCharCode(...)` folding observable end-to-end at SIMPLE
+
+Picks up `closure-pass-constant-fold` 0.43.0, which folds the static
+`String.fromCharCode(u0, u1, …)` into a string literal when every argument is a
+non-negative integer literal in `0..=0xFFFF` (ECMAScript §22.1.2.1) — the first
+fold whose receiver is the bare global `String` rather than a string/number
+literal. The arguments are UTF-16 code units, so an adjacent high+low surrogate
+pair assembles an astral scalar.
+
+New `tests/diff/simple-fold-fromcharcode/` fixture + `diff_simple_fold_fromcharcode.rs`
+integration test assert the SIMPLE-level output
+`var a="HI";var b="💩";var c="";report(a,b,c);` for
+`String.fromCharCode(72,73)` → `"HI"`, `String.fromCharCode(0xD83D,0xDCA9)` →
+`"💩"` (emitted as its escaped surrogate pair), and `String.fromCharCode()` →
+`""`, and guard that no `fromCharCode` call survives (proving the typed SIMPLE
+pipeline ran, not the WHITESPACE_ONLY fallback).
+
 ## [0.188.0] - 2026-06-24
 
 ### Added — SIMPLE/ADVANCED fold `"abcd".substring(start[, end])`

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.188.0"
+version = "0.192.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.188.0",
+  "version": "0.192.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.188.0
+Version: 0.192.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff/simple-fold-fromcharcode/README.md
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-fromcharcode/README.md
@@ -1,0 +1,28 @@
+# Fixture: `simple-fold-fromcharcode`
+
+End-to-end oracle for the static `String.fromCharCode(...)` fold at
+`--compilation_level SIMPLE`.
+
+| File | Role |
+|------|------|
+| `flags.txt` | CLI args: `--compilation_level SIMPLE --js input/a.js` |
+| `input/a.js` | three `String.fromCharCode(...)` calls into `report(...)` |
+| `expected.stdout` | `var a="HI";var b="💩";var c="";report(a,b,c);` |
+
+The SIMPLE level runs the typed-AST optimization pipeline, whose
+`constant-fold` pass evaluates `String.fromCharCode` (ECMAScript §22.1.2.1) when
+every argument is a non-negative integer literal in `0..=0xFFFF`. The arguments
+are UTF-16 code **units**:
+
+| Call | Result | Why |
+|------|--------|-----|
+| `String.fromCharCode(72, 73)` | `"HI"` | two BMP units `H`,`I` |
+| `String.fromCharCode(0xD83D, 0xDCA9)` | `"💩"` | a high+low surrogate PAIR → `U+1F4A9` |
+| `String.fromCharCode()` | `""` | no arguments |
+
+This is the first fold whose receiver is the bare global `String` (not a
+string/number literal). The emitter prints the astral scalar as its escaped
+UTF-16 surrogate pair `💩` — byte-for-byte equal to `"💩"`. Out-of-
+range / fractional / lone-surrogate arguments are left unfolded. Under
+`WHITESPACE_ONLY` the calls survive untouched; the values flow into `report(...)`
+so they stay referenced past remove-unused-vars and the fold is observable.

--- a/code/programs/rust/closurec/tests/diff/simple-fold-fromcharcode/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-fromcharcode/expected.stdout
@@ -1,0 +1,1 @@
+var a="HI";var b="\ud83d\udca9";var c="";report(a,b,c);

--- a/code/programs/rust/closurec/tests/diff/simple-fold-fromcharcode/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-fromcharcode/flags.txt
@@ -1,0 +1,4 @@
+--compilation_level
+SIMPLE
+--js
+tests/diff/simple-fold-fromcharcode/input/a.js

--- a/code/programs/rust/closurec/tests/diff/simple-fold-fromcharcode/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-fromcharcode/input/a.js
@@ -1,0 +1,19 @@
+// SIMPLE-level static-method fold (String.fromCharCode).
+//
+// `String.fromCharCode(u0, u1, …)` builds a string from UTF-16 code UNITS
+// (ECMAScript §22.1.2.1). The constant-fold pass collapses it to a string
+// literal when every argument is a non-negative integer literal in 0..=0xFFFF.
+// This is the first fold whose receiver is the bare global `String` rather
+// than a string/number literal.
+//
+// Under WHITESPACE_ONLY the calls survive; under SIMPLE they fold:
+//   * fromCharCode(72, 73)       → "HI"   (two BMP units)
+//   * fromCharCode(0xD83D,0xDCA9)→ "💩"   (a high+low surrogate PAIR → U+1F4A9)
+//   * fromCharCode()             → ""     (no arguments)
+//
+// Each value flows into `report(...)` so it stays referenced past the
+// remove-unused-vars pass and the fold is observable.
+var a = String.fromCharCode(72, 73);
+var b = String.fromCharCode(0xD83D, 0xDCA9);
+var c = String.fromCharCode();
+report(a, b, c);

--- a/code/programs/rust/closurec/tests/diff_simple_fold_fromcharcode.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_fold_fromcharcode.rs
@@ -1,0 +1,104 @@
+//! Integration test for the `tests/diff/simple-fold-fromcharcode/` fixture.
+//!
+//! End-to-end oracle for the static `String.fromCharCode(...)` fold in
+//! `closure-pass-constant-fold` — building a string from UTF-16 code units
+//! (ECMAScript §22.1.2.1). It is the first fold whose receiver is the bare
+//! global `String` rather than a string/number literal. The fixture covers two
+//! BMP units, a surrogate PAIR assembling an astral scalar, and the no-arg
+//! empty case:
+//!
+//! ```text
+//! var a="HI";var b="💩";var c="";report(a,b,c);
+//! ```
+//!
+//! - `String.fromCharCode(72, 73)`        → `"HI"`;
+//! - `String.fromCharCode(0xD83D, 0xDCA9)`→ `"💩"` (emitted escaped as the pair);
+//! - `String.fromCharCode()`              → `""`.
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
+
+fn read_flags() -> Vec<String> {
+    let raw = std::fs::read_to_string("tests/diff/simple-fold-fromcharcode/flags.txt")
+        .expect("read flags.txt");
+    raw.lines()
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[test]
+fn simple_fold_fromcharcode_fixture_matches_expected_stdout() {
+    let flags = read_flags();
+    let out = Command::new(BINARY)
+        .args(&flags)
+        .output()
+        .expect("run closurec");
+
+    assert!(
+        out.status.success(),
+        "exit: {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let actual = String::from_utf8_lossy(&out.stdout);
+    let expected = std::fs::read_to_string("tests/diff/simple-fold-fromcharcode/expected.stdout")
+        .expect("read expected.stdout");
+    assert_eq!(
+        actual.trim_end_matches('\n'),
+        expected.trim_end_matches('\n'),
+        "mismatch.\nflags: {flags:?}\nactual:\n{actual}\nexpected:\n{expected}",
+    );
+}
+
+/// `String.fromCharCode(...)` on integer-literal args folds to string literals —
+/// no `fromCharCode(` call survives — and the BMP / surrogate-pair / empty
+/// cases hold.
+#[test]
+fn simple_fold_fromcharcode_folds_to_strings() {
+    let out = Command::new(BINARY)
+        .args(read_flags())
+        .output()
+        .expect("run closurec");
+    let actual = String::from_utf8_lossy(&out.stdout);
+
+    // String.fromCharCode(72,73) → "HI".
+    assert!(
+        actual.contains("a=\"HI\""),
+        "String.fromCharCode(72,73) → \"HI\"; got:\n{actual}"
+    );
+    // String.fromCharCode(0xD83D,0xDCA9) → "💩", emitted as the escaped pair.
+    assert!(
+        actual.contains("b=\"\\ud83d\\udca9\""),
+        "surrogate-pair fromCharCode → 💩 (escaped pair); got:\n{actual}"
+    );
+    // String.fromCharCode() → "".
+    assert!(
+        actual.contains("c=\"\""),
+        "String.fromCharCode() → \"\"; got:\n{actual}"
+    );
+    assert!(
+        !actual.contains("fromCharCode"),
+        "no `fromCharCode` call should remain after folding; got:\n{actual}"
+    );
+}
+
+/// Regression guard: the output must be the SIMPLE typed pipeline, not the
+/// `WHITESPACE_ONLY` fallback (which would leave the calls intact).
+#[test]
+fn simple_fold_fromcharcode_did_not_fall_back_to_whitespace_only() {
+    let out = Command::new(BINARY)
+        .args(read_flags())
+        .output()
+        .expect("run closurec");
+    let actual = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        !actual.contains("fromCharCode"),
+        "expected the calls to be folded away by the typed pipeline \
+         (proving this is the SIMPLE optimizer, not the whitespace fallback); \
+         got:\n{actual}",
+    );
+}


### PR DESCRIPTION
Adds constant-folding of the **static** `String.fromCharCode(u0, u1, …)` into a string literal (ECMAScript §22.1.2.1).

## What

When the receiver is the bare global `String` and every argument is a non-negative integer literal in `0..=0xFFFF`, the call folds to a string literal built from those UTF-16 code **units**. This is the **first fold whose receiver is a bare global identifier** rather than a string/number literal — it lands in a new identifier-receiver branch of the `MemberExpression` arm (`window.String.…` and other non-identifier receivers never match).

| Call | Result | Why |
|------|--------|-----|
| `String.fromCharCode(72, 73)` | `"HI"` | two BMP units |
| `String.fromCharCode(0xD83D, 0xDCA9)` | `"💩"` | high+low surrogate PAIR → `U+1F4A9` |
| `String.fromCharCode()` | `""` | no arguments |

## Changes

- **constant-fold 0.43.0**: `fold_string_from_char_code` helper + identifier-receiver dispatch branch; 5 V8-oracle unit tests (basic+empty, surrogate-pair assembly, lone-surrogate decline, out-of-range/fractional decline, non-`String` receiver decline).
- **closurec 0.192.0**: `tests/diff/simple-fold-fromcharcode/` fixture + `diff_simple_fold_fromcharcode.rs` integration test asserting `var a="HI";var b="💩";var c="";report(a,b,c);` (the astral scalar emitted as its escaped surrogate pair); regenerated help-markdown golden; `cli.spec.json` + `Cargo.toml` bumps; CHANGELOGs.

## Soundness & safety

Conservative scope: declines (leaves the call) for a fractional, negative, `>0xFFFF`, or non-literal argument — we do not model JS `ToUint16` wrap-around — and for any unit sequence that is not valid UTF-16 (a **lone surrogate**, a legal JS string but not a Rust `String`, via `String::from_utf16`). Soundness follows the same "builtins intact" premise as the existing `parseInt`/`parseFloat` fold (a local `let String = …` could shadow the global; we fold anyway, matching Closure Compiler). Inline security review passed — no `unsafe`, no panic paths, no amplification/DoS, V8-faithful in-range, sound lone-surrogate decline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)