### PR TITLE
feat(mycin-acidbase): ADJ-only acid-base disturbance → expected compensation recall

### DIFF
--- a/code/specs/data/mycin-2026/recall/acid-base-edges.adj
+++ b/code/specs/data/mycin-2026/recall/acid-base-edges.adj
@@ -1,0 +1,75 @@
+% ============================================================================
+% acid-base-edges — the primary acid-base disturbance → expected compensation
+% knowledge-graph (MYCIN-2026 ACIDBASE).
+% ============================================================================
+% A high-yield physiology board table: each of the four SIMPLE (primary) acid-base
+% disturbances and the body's EXPECTED compensatory response. "How does the body
+% compensate for a metabolic acidosis?" becomes the binding query
+%     ? compensated_by(metabolic_acidosis, $Compensation).
+%
+% Direction note: the relation is the PRIMARY disturbance -> the compensatory
+% mechanism the body mounts against it (`compensated_by`). A metabolic disturbance
+% is compensated by the RESPIRATORY system (changing PaCO2 in minutes); a
+% respiratory disturbance is compensated by the METABOLIC / RENAL system (changing
+% serum bicarbonate over hours-to-days). Each disturbance here maps to ONE canonical
+% compensation span, so a query binds a single answer.
+%
+% Faithfulness note: each `relate` subject/object is bound to what the cited
+% sentence ACTUALLY names. The compensation object names the literal mechanism the
+% sentence states (metabolic acidosis "respiratory compensation"; metabolic
+% alkalosis "increase in PaCO2"; respiratory acidosis "the metabolic response
+% should increase the amount of bicarbonate via the renal system"; respiratory
+% alkalosis chronic "low to normal HCO3 levels" — the renal lowering of
+% bicarbonate over time). Each span was independently re-fetched and confirmed on
+% two separate fetches of the same page for byte-stability.
+%
+% This file is the SHIPPED ARTIFACT and the SOLE source of truth — no generator,
+% no JSON, no manifest (a pure ADJ-only recall domain, like HEARTVALVE/PHARYNGEAL/
+% FETALSHUNT/LUNGVOLUME). Each fact is a `relate` clause whose byte-provenance
+% lives INLINE:
+%     source   — the VERBATIM span copied from the cited page (byte-stable: it
+%                appears character-for-character in the page's normalized text;
+%                every span here was independently re-fetched and confirmed).
+%     locator  — the URL the span was read from (NCBI StatPearls / Bookshelf).
+%     trust    — authoritative (a primary, citable reference).
+% An LLM (or a human) recalls a fact by writing a tiny query .adj that `import`s
+% this library and asks a binding query — see acid-base-recall.query.adj.
+% Nothing here is asserted "from memory": every edge is defended by a span a
+% reader can re-fetch and check.
+% (See feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+dictionary acid_base_vocab {
+    define disturbance  : entity   surface "acid-base disturbance", "primary acid-base disorder"
+    define compensation : entity   surface "compensatory response", "compensation mechanism"
+
+    define compensated_by : relation from disturbance to compensation  % the expected compensatory response to this primary disturbance
+}
+
+rulebook acid_base_facts {
+    use acid_base_vocab
+
+    % --- metabolic acidosis -> respiratory compensation ---------------------
+    relate compensated_by(metabolic_acidosis, respiratory_compensation)
+        source "Respiratory compensation is the physiologic mechanism to help normalize a metabolic acidosis; however, compensation never completely corrects an acidemia."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK482146/"
+        trust authoritative
+
+    % --- metabolic alkalosis -> increased PaCO2 (respiratory) compensation --
+    relate compensated_by(metabolic_alkalosis, increased_paco2_compensation)
+        source "In metabolic alkalosis, exact values may vary, but an estimate is that there is about a 0.5 mm Hg increase in PaCO2 per 1 mmol/L increase in HCO3."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK545269/"
+        trust authoritative
+
+    % --- respiratory acidosis -> metabolic (renal) bicarbonate increase -----
+    relate compensated_by(respiratory_acidosis, metabolic_response_increased_bicarbonate)
+        source "When respiratory acidosis occurs, the metabolic response should increase the amount of bicarbonate via the renal system."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK507807/"
+        trust authoritative
+
+    % --- respiratory alkalosis -> chronic renal lowering of bicarbonate -----
+    relate compensated_by(respiratory_alkalosis, chronic_lowered_bicarbonate)
+        source "Therefore, acute respiratory alkalosis is associated with high bicarbonate levels since there has not been sufficient time to lower the HCO3 levels and chronic respiratory alkalosis is associated with low to normal HCO3 levels."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK482117/"
+        trust authoritative
+}

--- a/code/specs/data/mycin-2026/recall/acid-base-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/acid-base-recall.query.adj
@@ -1,0 +1,20 @@
+% ============================================================================
+% acid-base-recall.query.adj — a worked recall query over the acid-base library.
+% ============================================================================
+% The shape an LLM (or a student) produces to ANSWER a "how is disturbance X
+% compensated?" question: it states no physiology fact — it only `import`s the
+% grounded library and asks binding queries. The native adj-lang engine resolves
+% each `?` against the imported `relate` edges and returns the binding + the
+% citing clause's source/locator/trust. All knowledge is in the library; none is
+% here.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli acid-base-recall.query.adj
+% ============================================================================
+
+import "acid-base-edges.adj"
+
+? compensated_by(metabolic_acidosis, $Compensation)    % expect respiratory_compensation
+? compensated_by(metabolic_alkalosis, $Compensation)   % expect increased_paco2_compensation
+? compensated_by(respiratory_acidosis, $Compensation)  % expect metabolic_response_increased_bicarbonate
+? compensated_by(respiratory_alkalosis, $Compensation) % expect chronic_lowered_bicarbonate

--- a/code/specs/data/mycin-2026/recall/test_acid_base_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_acid_base_recall.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""test_acid_base_recall.py — the ADJ-only acid-base-disturbance→expected-
+compensation recall library (MYCIN-2026 ACIDBASE).
+
+A pure-ADJ recall domain (high-yield physiology board table): the body's expected
+compensatory response to each of the four simple (primary) acid-base disturbances.
+`acid-base-edges.adj` is the SOLE source of truth — facts + byte-provenance inline,
+no Python gate, no JSON, no manifest. This test pins the property that matters: the
+native adj-lang engine, given a query .adj that only `import`s the library and asks
+binding queries (`acid-base-recall.query.adj` — the shape an LLM produces), binds
+the grounded compensation for each disturbance, each carrying an AUTHORITATIVE
+citation with a real source span + locator. Knowledge lives in ADJ; the engine
+answers.
+
+If the native CLI isn't built (a Python-only CI lane), the engine-backed checks
+skip — the file-shape checks (every clause grounded, no authored-debt) still run.
+
+Run:  python3 test_acid_base_recall.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ADJ = HERE / "acid-base-edges.adj"
+QUERY = HERE / "acid-base-recall.query.adj"
+CLI = HERE.parents[3] / "packages" / "rust" / "target" / "debug" / "adj-lang-cli"
+
+# Every grounded edge: primary disturbance -> the compensation the library binds.
+EXPECTED = {
+    "metabolic_acidosis": "respiratory_compensation",                          # NBK482146
+    "metabolic_alkalosis": "increased_paco2_compensation",                     # NBK545269
+    "respiratory_acidosis": "metabolic_response_increased_bicarbonate",        # NBK507807
+    "respiratory_alkalosis": "chronic_lowered_bicarbonate",                    # NBK482117
+}
+REL = "compensated_by"
+VAR = "Compensation"
+
+
+def _cli_available() -> bool:
+    return CLI.exists()
+
+
+def _run(program: Path) -> dict:
+    out = subprocess.run([str(CLI), str(program)], capture_output=True, text=True,
+                         cwd=str(HERE), timeout=60)
+    assert out.returncode == 0, f"adj-lang-cli failed: {out.stderr}"
+    return json.loads(out.stdout)
+
+
+# ---- 1. the ADJ file is the artifact — every clause grounded, no authored-debt ----
+
+def test_library_is_pure_adj_and_fully_grounded() -> None:
+    text = ADJ.read_text()
+    assert "trust consensus" not in text, "ACIDBASE ships no authored-debt; ground or omit"
+    assert "[FLAG:" not in text
+    edge_count = len(EXPECTED)  # 4
+    assert text.count("    relate ") == edge_count
+    assert text.count("trust authoritative") == edge_count
+    assert text.count('\n        locator "') == edge_count
+    assert text.count('\n        source "') == edge_count
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("locator "):
+            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+    assert not (HERE / "acid_base_edge_ground.py").exists()
+    assert not (HERE / "acid-base-edge-grounding.json").exists()
+    assert not (HERE / "acid-base-edge-manifest.json").exists()
+
+
+# ---- 2. the engine binds each compensation with an authoritative citation ----------
+
+def test_engine_binds_every_compensation_with_authoritative_citation() -> None:
+    if not _cli_available():
+        return
+    result = _run(QUERY)
+    by_query = {r["query"]: r for r in result["recall"]}
+    for disturbance, compensation in EXPECTED.items():
+        q = f"{REL}({disturbance}, {VAR})"
+        r = by_query.get(q)
+        assert r is not None and not r["abstained"], f"{q} abstained — edge missing?"
+        bound = {}
+        for a in r["answers"]:
+            bound[a["bindings"][VAR]] = (a.get("citations") or [{}])[0]
+        assert set(bound) == {compensation}, f"{disturbance}: bound {set(bound)} != {{{compensation}}}"
+        cite = bound[compensation]
+        assert cite.get("trust") == "authoritative", f"{disturbance}/{compensation} not authoritative"
+        assert cite.get("source"), f"{disturbance}/{compensation} has no source span"
+        assert cite.get("locator", "").startswith("https://www.ncbi.nlm.nih.gov/")
+
+
+# ---- 3. an off-vocabulary disturbance abstains, never fabricates --------------------
+
+def test_unknown_disturbance_abstains() -> None:
+    if not _cli_available():
+        return
+    import os
+    import tempfile
+    fd, path = tempfile.mkstemp(suffix=".adj", prefix=".acidbase_q_", dir=HERE)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            # a mixed acid-base disorder is a real acid-base entity but is NOT one
+            # of the four simple (primary) disturbances this library models, so it
+            # is deliberately absent — the engine must abstain rather than guess.
+            fh.write(f'import "acid-base-edges.adj"\n? {REL}(mixed_acid_base_disorder, ${VAR})\n')
+        res = _run(Path(path))
+        r = res["recall"][0] if res["recall"] else None
+        assert r is not None and r["abstained"], "an ungrounded disturbance must abstain"
+    finally:
+        os.unlink(path)
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS  {t.__name__}")
+        except AssertionError as exc:
+            failed += 1
+            print(f"  FAIL  {t.__name__}: {exc}")
+    print(f"\ntest_acid_base_recall: {len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())


### PR DESCRIPTION
## What

New **pure-ADJ recall domain** for MYCIN-2026: the body's expected compensatory response to each of the four simple (primary) acid-base disturbances — a high-yield physiology board table, grounded against primary NCBI StatPearls / Bookshelf pages.

The shipped artifact is `acid-base-edges.adj` — the **SOLE source of truth**. No generator, no JSON, no manifest (a pure ADJ-only recall domain, like HEARTVALVE / PHARYNGEAL / FETALSHUNT / LUNGVOLUME). Each `relate compensated_by(disturbance, compensation)` clause carries its byte-provenance inline: a verbatim `source` span, an NCBI `locator`, and `trust authoritative`. Knowledge lives in ADJ; the native adj-lang engine answers a binding query that only `import`s the library.

## Edges (4)

Each defended by a **self-contained** NCBI sentence naming BOTH the full disturbance term AND its compensatory mechanism, independently **double-fetched** for byte-stability:

| disturbance | → compensation | source |
|---|---|---|
| `metabolic_acidosis` | `respiratory_compensation` | [NBK482146](https://www.ncbi.nlm.nih.gov/books/NBK482146/) |
| `metabolic_alkalosis` | `increased_paco2_compensation` | [NBK545269](https://www.ncbi.nlm.nih.gov/books/NBK545269/) |
| `respiratory_acidosis` | `metabolic_response_increased_bicarbonate` | [NBK507807](https://www.ncbi.nlm.nih.gov/books/NBK507807/) |
| `respiratory_alkalosis` | `chronic_lowered_bicarbonate` | [NBK482117](https://www.ncbi.nlm.nih.gov/books/NBK482117/) |

Direction: the **primary disturbance → the compensatory mechanism the body mounts against it**. Metabolic disturbances are compensated by the respiratory system (changing PaCO2); respiratory disturbances by the metabolic/renal system (changing serum bicarbonate). The respiratory-alkalosis edge is grounded on the chronic-state bicarbonate sentence (acute vs chronic HCO3 association) — the renal lowering of bicarbonate over time.

## Files

- `acid-base-edges.adj` — the grounded knowledge graph (dictionary + rulebook)
- `acid-base-recall.query.adj` — a worked binding query (the shape an LLM emits)
- `test_acid_base_recall.py` — 3 tests: pure-ADJ/fully-grounded shape; engine binds every compensation with an authoritative citation; an off-vocabulary disturbance (`mixed_acid_base_disorder`) **abstains** rather than fabricating.

## Verification

- Tests **3/3 pass** locally against the native `adj-lang-cli`.
- Security review **passed** (inert ADJ data + a list-argv subprocess harness; no injection / traversal / deserialization / SSRF vectors).
- No deferrals — all four spans cleared the self-contained full-term faithfulness bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)