### PR TITLE
feat(closurec): fold static String.fromCodePoint(...) into a string literal (CLOC)

### DIFF
--- a/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to the `coding-adventures-closure-pass-constant-fold` crate will be documented in this file.
 
+## [0.44.0] - 2026-06-25
+
+### Added — fold the static `String.fromCodePoint(cp0, cp1, …)` into a string literal
+
+`String.fromCodePoint` now folds to a string literal when every argument is a
+non-negative integer literal that is a **valid Unicode scalar** — in
+`0..=0x10FFFF` and not a surrogate `0xD800..=0xDFFF` (ECMAScript §22.1.2.2).
+Unlike the sibling `fromCharCode` (whose arguments are 16-bit UTF-16 *units*),
+each argument here is a whole **code point**, so a single astral argument
+suffices: `String.fromCodePoint(128169)` → `"💩"` (U+1F4A9),
+`String.fromCodePoint(72, 73)` → `"HI"`, `String.fromCodePoint(128169, 65)` →
+`"💩A"`, no args → `""`.
+
+Lands in the same bare-global-`String` identifier-receiver dispatch shape as
+`fromCharCode` (`window.String.…` and other non-identifier receivers never
+match); the "builtins intact" soundness note carries over (a local `let String`
+could mask the global, but we fold anyway, matching Closure Compiler).
+
+New `fold_string_from_code_point` helper builds the string via
+`char::from_u32`, which returns `None` for exactly the invalid inputs — a
+**surrogate code point** (a valid JS argument that yields a lone-surrogate
+string no Rust `String` can hold) and anything **past U+10FFFF**. JS throws a
+`RangeError` for an out-of-range / fractional argument, so declining there also
+avoids folding a call that would have thrown. A fractional, negative, or
+non-literal argument likewise declines. Three V8-oracle unit tests (BMP +
+single-astral + empty, surrogate/out-of-range/fractional decline, non-`String`
+receiver decline).
+
 ## [0.40.0] - 2026-06-25
 
 ### Added — fold `"abcde".substr(start[, length])` on string literals

--- a/code/packages/rust/closure-pass-constant-fold/Cargo.toml
+++ b/code/packages/rust/closure-pass-constant-fold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-constant-fold"
-version = "0.40.0"
+version = "0.44.0"
 edition = "2021"
 description = "Constant-folding optimization pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Folds compile-time-evaluable expressions like `2 + 3 → 5`."
 

--- a/code/packages/rust/closure-pass-constant-fold/src/lib.rs
+++ b/code/packages/rust/closure-pass-constant-fold/src/lib.rs
@@ -1055,6 +1055,48 @@ fn fold_call(c: &CallExpression, st: &mut FoldState) -> Expression {
                     }
                 }
             }
+            // ---- String.fromCodePoint(cp0, cp1, …) → the built string ----
+            //
+            // The static `String.fromCodePoint` (ECMAScript §22.1.2.2) builds a
+            // string from Unicode CODE POINTS — unlike `fromCharCode`, whose
+            // arguments are 16-bit UTF-16 *units*. So a single astral argument
+            // suffices: `String.fromCodePoint(128169)` → `"💩"` (U+1F4A9),
+            // `String.fromCodePoint(72, 73)` → `"HI"`, no args → `""`.
+            //
+            // SOUNDNESS — folds under the same "builtins intact" premise as every
+            // fold here, one notch weaker (like `parseInt`/`parseFloat` and
+            // `fromCharCode`): `String` is a free identifier a local binding
+            // could mask, but we fold anyway, matching Closure Compiler, and ONLY
+            // for the bare identifier `String` (never `window.String`, whose
+            // object is not an Identifier). Each argument must be a non-negative
+            // integer literal that is a VALID code point — `0..=0x10FFFF` AND not
+            // a surrogate (`0xD800..=0xDFFF`). JS throws a `RangeError` for an
+            // out-of-range / fractional / non-integer argument, and a surrogate
+            // code point yields a lone-surrogate string no Rust `String` can
+            // hold; `char::from_u32` returns `None` for exactly those, so we
+            // DECLINE (leave the call) in every such case rather than emit a
+            // wrong literal or a value JS would have thrown on.
+            if let (Expression::Identifier(obj), Expression::Identifier(prop)) =
+                (m.object.as_ref(), m.property.as_ref())
+            {
+                if obj.name == "String" && prop.name == "fromCodePoint" {
+                    if let Some(result) = fold_string_from_code_point(&arguments) {
+                        let parent = c.cv.clone();
+                        let args_src = arguments
+                            .iter()
+                            .map(|a| match a {
+                                Expression::NumericLiteral(n) => format_js_number(n.value),
+                                _ => "?".to_string(),
+                            })
+                            .collect::<Vec<_>>()
+                            .join(",");
+                        let before = format!("String.fromCodePoint({})", args_src);
+                        let after = format!("\"{}\"", result);
+                        let new_cv = st.fork_cv(&parent, &before, &after);
+                        return stamp_literal_cv(FoldedLiteral::String(result), new_cv);
+                    }
+                }
+            }
         }
     }
 
@@ -1235,6 +1277,43 @@ fn fold_string_slice(value: &str, args: &[Expression]) -> Option<String> {
     }
     // A lone surrogate (split pair) can't be a Rust String — decline.
     String::from_utf16(&units[lo..hi]).ok()
+}
+
+/// Fold the static `String.fromCodePoint(cp0, cp1, …)` — build a string from
+/// Unicode CODE POINTS (ECMAScript §22.1.2.2).
+///
+/// Unlike `fromCharCode` (whose arguments are 16-bit UTF-16 *units*), each
+/// argument here is a whole code point, so one astral argument is enough:
+/// `String.fromCodePoint(128169)` → `"💩"` (U+1F4A9),
+/// `String.fromCodePoint(72, 73)` → `"HI"`, no arguments → `""`.
+///
+/// Conservative scope: every argument must be a non-negative integer literal
+/// that is a VALID Unicode scalar — in `0..=0x10FFFF` and NOT a surrogate
+/// (`0xD800..=0xDFFF`). In JS an out-of-range / fractional argument throws a
+/// `RangeError`, and a surrogate code point yields a lone-surrogate string a
+/// Rust `String` cannot hold; `char::from_u32` returns `None` for exactly those
+/// inputs, so we return `None` (leaving the call for the runtime) rather than
+/// emit a wrong literal or one for a call JS would have thrown on. A
+/// fractional, negative, `>0x10FFFF`, or non-literal argument also declines.
+fn fold_string_from_code_point(args: &[Expression]) -> Option<String> {
+    let mut result = String::new();
+    for a in args {
+        match a {
+            Expression::NumericLiteral(n)
+                if n.value.is_finite()
+                    && n.value.fract() == 0.0
+                    && n.value >= 0.0
+                    && n.value <= 0x10FFFF as f64 =>
+            {
+                // `char::from_u32` rejects surrogates (D800..DFFF) and anything
+                // past U+10FFFF, exactly the code points that can't be a Rust
+                // `char` — decline (`?`) for those.
+                result.push(char::from_u32(n.value as u32)?);
+            }
+            _ => return None,
+        }
+    }
+    Some(result)
 }
 
 /// Fold `"…".substring(start[, end])` (ECMAScript §22.1.3.24).
@@ -4825,6 +4904,70 @@ mod tests {
         let c = call1(string("abc", None), "includes", num(1.0, None));
         let (out, _, changed, _) = run_pass(program_with_expr(c, true));
         assert!(!changed, "includes with a numeric arg must not fold");
+        assert!(matches!(extract_expr(&out), Expression::CallExpression(_)));
+    }
+
+    // ------------------- String.fromCodePoint (static) ---------------
+
+    /// Build `String.fromCodePoint(<args…>)` from numeric literal arguments.
+    fn from_code_point_call(args: &[f64]) -> Expression {
+        Expression::CallExpression(CallExpression {
+            cv: Some("c.cv".to_string()),
+            callee: Box::new(member(ident("String"), "fromCodePoint")),
+            arguments: args.iter().map(|&a| num(a, None)).collect(),
+        })
+    }
+
+    #[test]
+    fn fold_from_code_point_bmp_astral_and_empty() {
+        // V8 oracle: fromCodePoint(72,73)==="HI"; (128169)==="💩" (a SINGLE
+        // astral arg, unlike fromCharCode which needs the surrogate pair);
+        // ()==="".
+        for (args, expect) in [
+            (vec![72.0, 73.0], "HI"),
+            (vec![128169.0], "💩"),
+            (vec![128169.0, 65.0], "💩A"),
+            (vec![], ""),
+        ] {
+            let c = from_code_point_call(&args);
+            let (out, _, changed, _) = run_pass(program_with_expr(c, true));
+            assert!(changed, "String.fromCodePoint({args:?}) should fold");
+            match extract_expr(&out) {
+                Expression::StringLiteral(s) => assert_eq!(s.value, expect),
+                other => panic!("expected \"{expect}\"; got {:?}", other),
+            }
+        }
+    }
+
+    #[test]
+    fn from_code_point_surrogate_or_out_of_range_does_not_fold() {
+        // A surrogate code point (D800..DFFF) is a valid JS arg but yields a
+        // lone-surrogate string no Rust String can hold; >0x10FFFF, negative,
+        // and fractional all throw RangeError in JS — decline in every case.
+        for args in [
+            vec![0xD83D as f64],   // lone high surrogate
+            vec![0x110000 as f64], // past U+10FFFF
+            vec![-1.0],
+            vec![65.5],
+            vec![65.0, 0.5],
+        ] {
+            let c = from_code_point_call(&args);
+            let (out, _, changed, _) = run_pass(program_with_expr(c, true));
+            assert!(!changed, "String.fromCodePoint({args:?}) must not fold");
+            assert!(matches!(extract_expr(&out), Expression::CallExpression(_)));
+        }
+    }
+
+    #[test]
+    fn from_code_point_on_non_string_receiver_does_not_fold() {
+        // Only the bare global `String` folds; `s.fromCodePoint(65)` is left.
+        let c = Expression::CallExpression(CallExpression {
+            cv: Some("c.cv".to_string()),
+            callee: Box::new(member(ident("s"), "fromCodePoint")),
+            arguments: vec![num(65.0, None)],
+        });
+        let (out, _, changed, _) = run_pass(program_with_expr(c, true));
+        assert!(!changed, "non-String receiver fromCodePoint must not fold");
         assert!(matches!(extract_expr(&out), Expression::CallExpression(_)));
     }
 

--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.193.0] - 2026-06-25
+
+### Added — static `String.fromCodePoint(...)` folding observable end-to-end at SIMPLE
+
+Picks up `closure-pass-constant-fold` 0.44.0, which folds the static
+`String.fromCodePoint(cp0, cp1, …)` into a string literal when every argument is
+a non-negative integer literal that is a valid Unicode scalar (`0..=0x10FFFF`,
+not a surrogate) — ECMAScript §22.1.2.2. Each argument is a whole code point
+(unlike `fromCharCode`'s UTF-16 units), so a single astral argument suffices.
+
+New `tests/diff/simple-fold-fromcodepoint/` fixture + `diff_simple_fold_fromcodepoint.rs`
+integration test assert the SIMPLE-level output
+`var a="HI";var b="💩";var c="💩A";report(a,b,c);` for
+`String.fromCodePoint(72,73)` → `"HI"`, `String.fromCodePoint(128169)` → `"💩"`
+(a single astral arg, emitted as its escaped surrogate pair), and
+`String.fromCodePoint(128169,65)` → `"💩A"`, and guard that no `fromCodePoint`
+call survives (proving the typed SIMPLE pipeline ran, not the WHITESPACE_ONLY
+fallback).
+
 ## [0.189.0] - 2026-06-25
 
 ### Added — SIMPLE/ADVANCED fold `"abcde".substr(start[, length])`

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.189.0"
+version = "0.193.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.189.0",
+  "version": "0.193.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.189.0
+Version: 0.193.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff/simple-fold-fromcodepoint/README.md
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-fromcodepoint/README.md
@@ -1,0 +1,29 @@
+# Fixture: `simple-fold-fromcodepoint`
+
+End-to-end oracle for the static `String.fromCodePoint(...)` fold at
+`--compilation_level SIMPLE`.
+
+| File | Role |
+|------|------|
+| `flags.txt` | CLI args: `--compilation_level SIMPLE --js input/a.js` |
+| `input/a.js` | three `String.fromCodePoint(...)` calls into `report(...)` |
+| `expected.stdout` | `var a="HI";var b="💩";var c="💩A";report(a,b,c);` |
+
+The SIMPLE level runs the typed-AST optimization pipeline, whose
+`constant-fold` pass evaluates `String.fromCodePoint` (ECMAScript §22.1.2.2)
+when every argument is a non-negative integer literal that is a valid Unicode
+scalar (`0..=0x10FFFF`, not a surrogate). Each argument is a whole **code
+point**, the defining difference from `fromCharCode` (UTF-16 *units*):
+
+| Call | Result | Why |
+|------|--------|-----|
+| `String.fromCodePoint(72, 73)` | `"HI"` | two BMP scalars |
+| `String.fromCodePoint(128169)` | `"💩"` | a SINGLE astral arg = `U+1F4A9` |
+| `String.fromCodePoint(128169, 65)` | `"💩A"` | astral + `A` |
+
+The emitter prints the astral scalar as its escaped UTF-16 surrogate pair
+(`💩` → `💩`), byte-for-byte equal to `"💩"`. A surrogate code point,
+an out-of-range (`>0x10FFFF`) / negative / fractional argument (each a JS
+`RangeError`), or a non-literal argument is left unfolded. Under
+`WHITESPACE_ONLY` the calls survive untouched; the values flow into `report(...)`
+so they stay referenced past remove-unused-vars and the fold is observable.

--- a/code/programs/rust/closurec/tests/diff/simple-fold-fromcodepoint/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-fromcodepoint/expected.stdout
@@ -1,0 +1,1 @@
+var a="HI";var b="\ud83d\udca9";var c="\ud83d\udca9A";report(a,b,c);

--- a/code/programs/rust/closurec/tests/diff/simple-fold-fromcodepoint/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-fromcodepoint/flags.txt
@@ -1,0 +1,4 @@
+--compilation_level
+SIMPLE
+--js
+tests/diff/simple-fold-fromcodepoint/input/a.js

--- a/code/programs/rust/closurec/tests/diff/simple-fold-fromcodepoint/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-fromcodepoint/input/a.js
@@ -1,0 +1,19 @@
+// SIMPLE-level static-method fold (String.fromCodePoint).
+//
+// `String.fromCodePoint(cp0, cp1, …)` builds a string from Unicode CODE POINTS
+// (ECMAScript §22.1.2.2). Unlike fromCharCode (UTF-16 units), each argument is
+// a whole code point, so one astral argument suffices. The constant-fold pass
+// collapses it to a string literal when every argument is a non-negative
+// integer literal that is a valid Unicode scalar (0..=0x10FFFF, not a surrogate).
+//
+// Under WHITESPACE_ONLY the calls survive; under SIMPLE they fold:
+//   * fromCodePoint(72, 73)      → "HI"   (two BMP scalars)
+//   * fromCodePoint(128169)      → "💩"   (a SINGLE astral arg = U+1F4A9)
+//   * fromCodePoint(128169, 65)  → "💩A"
+//
+// Each value flows into `report(...)` so it stays referenced past the
+// remove-unused-vars pass and the fold is observable.
+var a = String.fromCodePoint(72, 73);
+var b = String.fromCodePoint(128169);
+var c = String.fromCodePoint(128169, 65);
+report(a, b, c);

--- a/code/programs/rust/closurec/tests/diff_simple_fold_fromcodepoint.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_fold_fromcodepoint.rs
@@ -1,0 +1,103 @@
+//! Integration test for the `tests/diff/simple-fold-fromcodepoint/` fixture.
+//!
+//! End-to-end oracle for the static `String.fromCodePoint(...)` fold in
+//! `closure-pass-constant-fold` — building a string from Unicode CODE POINTS
+//! (ECMAScript §22.1.2.2). Unlike `fromCharCode` (UTF-16 units), each argument
+//! is a whole code point, so a single astral argument suffices. The fixture
+//! covers two BMP scalars, a single astral scalar, and astral+BMP:
+//!
+//! ```text
+//! var a="HI";var b="💩";var c="💩A";report(a,b,c);
+//! ```
+//!
+//! - `String.fromCodePoint(72, 73)`       → `"HI"`;
+//! - `String.fromCodePoint(128169)`       → `"💩"` (U+1F4A9, emitted escaped);
+//! - `String.fromCodePoint(128169, 65)`   → `"💩A"`.
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
+
+fn read_flags() -> Vec<String> {
+    let raw = std::fs::read_to_string("tests/diff/simple-fold-fromcodepoint/flags.txt")
+        .expect("read flags.txt");
+    raw.lines()
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[test]
+fn simple_fold_fromcodepoint_fixture_matches_expected_stdout() {
+    let flags = read_flags();
+    let out = Command::new(BINARY)
+        .args(&flags)
+        .output()
+        .expect("run closurec");
+
+    assert!(
+        out.status.success(),
+        "exit: {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let actual = String::from_utf8_lossy(&out.stdout);
+    let expected = std::fs::read_to_string("tests/diff/simple-fold-fromcodepoint/expected.stdout")
+        .expect("read expected.stdout");
+    assert_eq!(
+        actual.trim_end_matches('\n'),
+        expected.trim_end_matches('\n'),
+        "mismatch.\nflags: {flags:?}\nactual:\n{actual}\nexpected:\n{expected}",
+    );
+}
+
+/// `String.fromCodePoint(...)` on integer-literal args folds to string literals
+/// — no `fromCodePoint(` call survives — and the BMP / single-astral / astral+BMP
+/// cases hold.
+#[test]
+fn simple_fold_fromcodepoint_folds_to_strings() {
+    let out = Command::new(BINARY)
+        .args(read_flags())
+        .output()
+        .expect("run closurec");
+    let actual = String::from_utf8_lossy(&out.stdout);
+
+    // String.fromCodePoint(72,73) → "HI".
+    assert!(
+        actual.contains("a=\"HI\""),
+        "String.fromCodePoint(72,73) → \"HI\"; got:\n{actual}"
+    );
+    // String.fromCodePoint(128169) → "💩" (a SINGLE astral arg), escaped pair.
+    assert!(
+        actual.contains("b=\"\\ud83d\\udca9\""),
+        "single-astral fromCodePoint → 💩 (escaped pair); got:\n{actual}"
+    );
+    // String.fromCodePoint(128169, 65) → "💩A".
+    assert!(
+        actual.contains("c=\"\\ud83d\\udca9A\""),
+        "fromCodePoint(128169,65) → 💩A; got:\n{actual}"
+    );
+    assert!(
+        !actual.contains("fromCodePoint"),
+        "no `fromCodePoint` call should remain after folding; got:\n{actual}"
+    );
+}
+
+/// Regression guard: the output must be the SIMPLE typed pipeline, not the
+/// `WHITESPACE_ONLY` fallback (which would leave the calls intact).
+#[test]
+fn simple_fold_fromcodepoint_did_not_fall_back_to_whitespace_only() {
+    let out = Command::new(BINARY)
+        .args(read_flags())
+        .output()
+        .expect("run closurec");
+    let actual = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        !actual.contains("fromCodePoint"),
+        "expected the calls to be folded away by the typed pipeline \
+         (proving this is the SIMPLE optimizer, not the whitespace fallback); \
+         got:\n{actual}",
+    );
+}


### PR DESCRIPTION
Adds constant-folding of the **static** `String.fromCodePoint(cp0, cp1, …)` into a string literal (ECMAScript §22.1.2.2) — the code-point sibling of the `fromCharCode` fold.

## What

When the receiver is the bare global `String` and every argument is a non-negative integer literal that is a **valid Unicode scalar** (`0..=0x10FFFF`, not a surrogate), the call folds to a string literal built from those code **points**. Unlike `fromCharCode` (UTF-16 *units*), each argument is a whole code point, so a single astral argument suffices.

| Call | Result | Why |
|------|--------|-----|
| `String.fromCodePoint(72, 73)` | `"HI"` | two BMP scalars |
| `String.fromCodePoint(128169)` | `"💩"` | a SINGLE astral arg = `U+1F4A9` |
| `String.fromCodePoint(128169, 65)` | `"💩A"` | astral + `A` |

## Changes

- **constant-fold 0.44.0**: `fold_string_from_code_point` helper (builds via `char::from_u32`) + dispatch in the same bare-global-`String` identifier-receiver block as `fromCharCode`; 3 V8-oracle unit tests (BMP + single-astral + empty, surrogate/out-of-range/fractional decline, non-`String` receiver decline).
- **closurec 0.193.0**: `tests/diff/simple-fold-fromcodepoint/` fixture + `diff_simple_fold_fromcodepoint.rs` asserting `var a="HI";var b="💩";var c="💩A";report(a,b,c);` (astral emitted as its escaped surrogate pair); regenerated help-markdown golden; `cli.spec.json` + `Cargo.toml` bumps; CHANGELOGs.

## Soundness & safety

`char::from_u32` returns `None` for exactly the invalid inputs — a **surrogate** code point (a valid JS arg yielding a lone-surrogate string no Rust `String` can hold) and anything **past U+10FFFF**. JS throws `RangeError` for out-of-range / fractional args, so declining there also avoids folding a call that would throw. Every divergence from V8 is in the safe **decline** direction — never a mis-fold. Soundness follows the same "builtins intact" premise as `parseInt`/`fromCharCode` (a local `let String` could shadow the global; we fold anyway, matching Closure Compiler). Inline security review passed — no `unsafe`, no panic paths, no amplification/DoS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)