### PR TITLE
feat(r-lang): R-46 — POSIXct date-times (as.POSIXct/Sys.time/format.POSIXct, UTC)

### DIFF
--- a/code/packages/rust/r-runtime/CHANGELOG.md
+++ b/code/packages/rust/r-runtime/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.40.0] - 2026-06-25
+
+### Added (via the shared `s-runtime`)
+
+- **R-46 — POSIXct date-times (UTC)**, reached through ordinary R syntax. A
+  `POSIXct` is a numeric vector of **seconds since 1970-01-01 00:00:00 UTC** with
+  class `c("POSIXct", "POSIXt")`, layered on the R-44/R-45 calendar machinery.
+  - `as.POSIXct("YYYY-MM-DD HH:MM:SS")` / `as.POSIXct("YYYY-MM-DD")` (→ midnight)
+    / `as.POSIXct(<numeric seconds>)`; malformed → `NA`. UTC only.
+  - `Sys.time()` — current time as a length-1 POSIXct (wall clock).
+  - `format(x)` / `format.POSIXct(x, fmt)` — default `"%Y-%m-%d %H:%M:%S"`; adds
+    `%H`/`%M`/`%S` and reuses the R-45 date fields (`%Y %m %d %B %b %A %a %j %e`).
+  - `t1 - t2` → seconds; `as.numeric(t)` → seconds since epoch (the transparent
+    class wrapper makes both fall out of the shared kernels for free).
+  - Worked R examples:
+    - `as.numeric(as.POSIXct("1970-01-02 00:00:00"))` → `86400`
+    - `format(as.POSIXct("2021-03-14 09:30:05"))` → `"2021-03-14 09:30:05"`
+    - `as.POSIXct("2021-03-14 09:30:00") - as.POSIXct("2021-03-14 09:00:00")` →
+      `1800`
+  - Deferred to R-47: non-UTC timezones/DST, `POSIXlt`, fractional seconds,
+    `%z`/`%Z`, standalone `strptime`/`strftime`, `as.POSIXlt`.
+
 ## [0.39.0] - 2026-06-25
 
 ### Added (via the shared `s-runtime`)

--- a/code/packages/rust/r-runtime/README.md
+++ b/code/packages/rust/r-runtime/README.md
@@ -387,9 +387,31 @@ and `"N units"` multipliers, and `length.out=` is an alternative to `to`.
 `months(d)` → the full month name; `quarters(d)` → `"Q1"`..`"Q4"`. Security:
 name parsing is table-bounded with ASCII case-folding (no OOB), and `seq.Date`
 caps its length at `MAX_SEQ_LEN` with checked arithmetic before allocating
-(`by = 0` errors; huge spans error rather than OOM). Deferred to **R-46**:
-`POSIXct`/`POSIXlt` & timezones, `%H`/`%M`/`%S`/`%p`, `%U`/`%W` week-of-year,
-locale names, and compound `by=` beyond a single integer multiplier.
+(`by = 0` errors; huge spans error rather than OOM).
+
+**R-46 — POSIXct date-times (UTC)** adds R's first *date-time* type on top of the
+R-44/R-45 calendar machinery. A `POSIXct` is a numeric vector of **seconds since
+1970-01-01 00:00:00 UTC** with class `c("POSIXct", "POSIXt")` (the same
+transparent class wrapper as `Date`), so `as.numeric(t)` peels to raw seconds and
+`t1 - t2` is a difference **in seconds** — both for free. The implementation
+splits a seconds count into `div_euclid(86400)` (the `Date` day count, fed to the
+reused civil kernel) and `rem_euclid(86400)` (intraday seconds → H/M/S), so only
+the time half is new. `as.POSIXct("2021-03-14 09:30:00")` parses a datetime,
+`as.POSIXct("2021-03-14")` is midnight, and `as.POSIXct(86400)` wraps raw
+seconds; a malformed or out-of-range string (`as.POSIXct("garbage")`,
+`as.POSIXct("2021-03-14 25:00:00")`) → `NA`, never a panic. `Sys.time()` is the
+current instant (wall clock; structure-tested). `format(t)` /
+`format.POSIXct(t, fmt)` default to `"%Y-%m-%d %H:%M:%S"`, supporting
+`%H`/`%M`/`%S` plus every reused R-45 date field — so
+`format(as.POSIXct("2021-03-14 09:30:05"))` → `"2021-03-14 09:30:05"` and
+`format(..., "%H:%M")` → `"09:30"`. Worked numbers:
+`as.numeric(as.POSIXct("1970-01-02 00:00:00"))` → `86400`,
+`as.POSIXct("2021-03-14 09:30:00") - as.POSIXct("2021-03-14 09:00:00")` → `1800`.
+Security: a `MAX_POSIXCT_SECONDS` bound rejects absurd seconds before the civil
+kernel, H/M/S are range-checked (0–23 / 0–59 / 0–60), and the days×86400+intraday
+combine uses `checked_mul`/`checked_add`. UTC only. Deferred to **R-47**: non-UTC
+timezones & DST, `POSIXlt`, fractional seconds, `%z`/`%Z`, standalone
+`strptime`/`strftime`, and `as.POSIXlt`.
 
 ## Usage
 

--- a/code/packages/rust/r-runtime/src/lib.rs
+++ b/code/packages/rust/r-runtime/src/lib.rs
@@ -3889,4 +3889,100 @@ mod tests {
             eval_r("seq(as.Date(\"1970-01-01\"), as.Date(\"99999-01-01\"), by = 1)\n").is_err()
         );
     }
+
+    // --- R-46: POSIXct date-times, UTC (through R syntax) ---------------------
+
+    #[test]
+    fn posixct_class_through_r_syntax() {
+        // A POSIXct carries the two-element class c("POSIXct","POSIXt").
+        assert_eq!(
+            show("class(as.POSIXct(\"2021-03-14 09:30:00\"))\n"),
+            "[1] \"POSIXct\" \"POSIXt\""
+        );
+    }
+
+    #[test]
+    fn posixct_as_numeric_is_seconds_through_r_syntax() {
+        // Seconds since the epoch: midnight = 0, +1 min = 60, +1 day = 86400.
+        assert_eq!(
+            nums("as.numeric(as.POSIXct(\"1970-01-01 00:00:00\"))\n"),
+            vec![0.0]
+        );
+        assert_eq!(
+            nums("as.numeric(as.POSIXct(\"1970-01-01 00:01:00\"))\n"),
+            vec![60.0]
+        );
+        assert_eq!(
+            nums("as.numeric(as.POSIXct(\"1970-01-02 00:00:00\"))\n"),
+            vec![86400.0]
+        );
+    }
+
+    #[test]
+    fn posixct_date_only_is_midnight_through_r_syntax() {
+        // A bare "YYYY-MM-DD" is taken as 00:00:00 → days * 86400 seconds.
+        assert_eq!(
+            nums("as.numeric(as.POSIXct(\"2021-03-14\"))\n"),
+            nums("as.numeric(as.Date(\"2021-03-14\")) * 86400\n")
+        );
+    }
+
+    #[test]
+    fn posixct_numeric_wrap_through_r_syntax() {
+        // A numeric is wrapped as raw seconds-since-epoch directly.
+        assert_eq!(
+            show("format(as.POSIXct(86400))\n"),
+            "[1] \"1970-01-02 00:00:00\""
+        );
+    }
+
+    #[test]
+    fn posixct_format_default_and_custom_through_r_syntax() {
+        assert_eq!(
+            show("format(as.POSIXct(\"2021-03-14 09:30:05\"))\n"),
+            "[1] \"2021-03-14 09:30:05\""
+        );
+        assert_eq!(
+            show("format(as.POSIXct(\"2021-03-14 09:30:05\"), \"%H:%M\")\n"),
+            "[1] \"09:30\""
+        );
+        // Reused R-45 date fields work on the date half.
+        assert_eq!(
+            show("format(as.POSIXct(\"2021-01-15 06:07:08\"), \"%B %d, %Y %H:%M:%S\")\n"),
+            "[1] \"January 15, 2021 06:07:08\""
+        );
+    }
+
+    #[test]
+    fn posixct_subtraction_is_seconds_through_r_syntax() {
+        // t1 - t2 flows through the shared arithmetic kernel → seconds difference.
+        assert_eq!(
+            nums("as.POSIXct(\"2021-03-14 09:30:00\") - as.POSIXct(\"2021-03-14 09:00:00\")\n"),
+            vec![1800.0]
+        );
+    }
+
+    #[test]
+    fn posixct_malformed_is_na_through_r_syntax() {
+        // Garbage → NA, never a panic.
+        assert_eq!(show("as.numeric(as.POSIXct(\"garbage\"))\n"), "[1] NA");
+        // Out-of-range H/M/S → NA.
+        assert_eq!(
+            show("as.numeric(as.POSIXct(\"2021-03-14 25:00:00\"))\n"),
+            "[1] NA"
+        );
+        assert_eq!(
+            show("as.numeric(as.POSIXct(\"2021-03-14 09:61:00\"))\n"),
+            "[1] NA"
+        );
+    }
+
+    #[test]
+    fn sys_time_structure_through_r_syntax() {
+        // Non-deterministic: assert only class + single numeric.
+        assert_eq!(show("class(Sys.time())\n"), "[1] \"POSIXct\" \"POSIXt\"");
+        assert_eq!(nums("length(Sys.time())\n"), vec![1.0]);
+        // The wall-clock value is finite (not NA / Inf).
+        assert_eq!(show("is.finite(as.numeric(Sys.time()))\n"), "[1] TRUE");
+    }
 }

--- a/code/packages/rust/r-runtime/src/lib.rs
+++ b/code/packages/rust/r-runtime/src/lib.rs
@@ -3897,7 +3897,9 @@ mod tests {
         // A POSIXct carries the two-element class c("POSIXct","POSIXt").
         assert_eq!(
             show("class(as.POSIXct(\"2021-03-14 09:30:00\"))\n"),
-            "[1] \"POSIXct\" \"POSIXt\""
+            // The character renderer pads to a common width, so "POSIXt" (6) is
+            // one space behind "POSIXct" (7) → two spaces between the quotes.
+            "[1] \"POSIXct\"  \"POSIXt\""
         );
     }
 
@@ -3980,9 +3982,14 @@ mod tests {
     #[test]
     fn sys_time_structure_through_r_syntax() {
         // Non-deterministic: assert only class + single numeric.
-        assert_eq!(show("class(Sys.time())\n"), "[1] \"POSIXct\" \"POSIXt\"");
+        assert_eq!(show("class(Sys.time())\n"), "[1] \"POSIXct\"  \"POSIXt\"");
         assert_eq!(nums("length(Sys.time())\n"), vec![1.0]);
-        // The wall-clock value is finite (not NA / Inf).
-        assert_eq!(show("is.finite(as.numeric(Sys.time()))\n"), "[1] TRUE");
+        // The wall-clock value is a real, post-2000 instant (sanity-checks that
+        // it is a finite numeric, without asserting the exact non-deterministic
+        // value): now is well after 2000-01-01.
+        assert_eq!(
+            show("Sys.time() > as.POSIXct(\"2000-01-01 00:00:00\")\n"),
+            "[1] TRUE"
+        );
     }
 }

--- a/code/packages/rust/s-runtime/CHANGELOG.md
+++ b/code/packages/rust/s-runtime/CHANGELOG.md
@@ -2,6 +2,45 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.41.0] - 2026-06-25
+
+### Added
+
+- **POSIXct date-times — `as.POSIXct` / `Sys.time` / `format.POSIXct` (R-46)** —
+  the first *date-time* type, layered on the R-44/R-45 calendar machinery and
+  shared with R. A **`POSIXct`** is — exactly like `Date` — an ordinary numeric
+  vector, but it counts **seconds since the epoch 1970-01-01 00:00:00 UTC** and
+  carries the two-element class `c("POSIXct", "POSIXt")` via the same transparent
+  `SValue::Classed` wrapper.
+  - **Design = reuse.** `seconds = days * 86400 + intraday`. Splitting a seconds
+    count with `div_euclid(86400)` (day count) and `rem_euclid(86400)` (intraday
+    seconds) means the **date half** feeds straight into the R-44 civil kernel
+    (`civil_from_days` / `days_from_civil`) and the R-45 `format_date_days`
+    `%`-field renderer; only the intraday H:M:S split and the seconds bound are
+    new. `div_euclid` / `rem_euclid` (not `/` / `%`) keep pre-epoch instants
+    correct (`−1s` = `1969-12-31 23:59:59`) with no negative array index.
+  - **`as.POSIXct(x, tz = "UTC")`** — parse `"YYYY-MM-DD HH:MM:SS"` (or
+    `"YYYY-MM-DD"` → midnight) via the reused ISO date parser plus an optional
+    `HH:MM:SS` time half; or wrap a numeric (raw seconds) or a `Date`
+    (`days * 86400`) directly. Malformed / out-of-range → `NA`, never a panic.
+    Only `tz = "UTC"` honoured.
+  - **`Sys.time()`** — current time as a length-1 POSIXct (wall clock; pre-epoch
+    handled without panic). Structure-tested only.
+  - **`format.POSIXct(x, format)` / `format(x, fmt)`** — default
+    `"%Y-%m-%d %H:%M:%S"`; adds `%H`/`%M`/`%S` and reuses every R-44/R-45 date
+    field (`%Y %m %d %B %b %A %a %j %e`) by delegating date-only runs to
+    `format_date_days`. The `format()` generic routes `POSIXct` (checked before
+    `Date`) to this renderer.
+  - **Subtraction & `as.numeric`** — no special case: the transparent wrapper
+    peels to raw seconds, so `t1 - t2` flows through `arithmetic("-", …)` →
+    difference **in seconds**.
+  - **Parse-safety.** A new `MAX_POSIXCT_SECONDS` (= `MAX_DATE_DAYS * 86400`)
+    bounds any parsed/supplied seconds before the civil kernel; H 0–23, M 0–59,
+    S 0–60 (leap-second slot) range-checked; `checked_mul`/`checked_add` combine
+    the `days * 86400 + intraday`.
+  - **Deferred to R-47.** Non-UTC timezones (and DST); `POSIXlt`; fractional
+    seconds; `%z`/`%Z`; standalone `strptime`/`strftime`; `as.POSIXlt`.
+
 ## [0.40.0] - 2026-06-25
 
 ### Added

--- a/code/packages/rust/s-runtime/README.md
+++ b/code/packages/rust/s-runtime/README.md
@@ -374,8 +374,23 @@ a hand-written loop. See [What "S-flavored" means here](#what-s-flavored-means-h
   `"2 weeks"`); month/year steps clamp the day to month length, and
   `length.out=` is an alternative to `to`. Output length is `MAX_SEQ_LEN`-capped
   with checked arithmetic before allocating. **`months(d)`** → full month name;
-  **`quarters(d)`** → `"Q1"`..`"Q4"`. Deferred to R-46: `POSIXct`/`POSIXlt` &
-  timezones, `%H`/`%M`/`%S`/`%p`, `%U`/`%W`, locale names, compound `by=`.
+  **`quarters(d)`** → `"Q1"`..`"Q4"`.
+- **POSIXct date-times (UTC)** (R-46): the first *date-time* type, layered on the
+  R-44/R-45 calendar machinery. A **`POSIXct`** is a numeric vector of **seconds
+  since 1970-01-01 00:00:00 UTC** with class `c("POSIXct", "POSIXt")` (same
+  transparent `Classed` wrapper as `Date`). The reuse trick:
+  `seconds.div_euclid(86400)` is the `Date` day count and
+  `seconds.rem_euclid(86400)` is the intraday seconds, so the civil kernel and
+  the R-45 field renderer are reused unchanged. **`as.POSIXct(x, tz="UTC")`**
+  parses `"YYYY-MM-DD HH:MM:SS"` (or `"YYYY-MM-DD"` → midnight) or wraps a numeric
+  (seconds) / a `Date` (`×86400`); malformed → `NA`. **`Sys.time()`** is now
+  (wall clock; structure-tested). **`format`/`format.POSIXct`** default to
+  `"%Y-%m-%d %H:%M:%S"`, adding `%H`/`%M`/`%S` plus the reused date fields —
+  `format(as.POSIXct("2021-03-14 09:30:05"), "%H:%M")` → `"09:30"`. Subtraction
+  and `as.numeric` give **seconds** for free via the transparent wrapper. Parse
+  safety: `MAX_POSIXCT_SECONDS` bound + H/M/S range checks + `checked_mul`. UTC
+  only. Deferred to R-47: non-UTC timezones/DST, `POSIXlt`, fractional seconds,
+  `%z`/`%Z`, standalone `strptime`/`strftime`.
 - The **`d`/`p`/`q`/`r` distribution family** (R-8) over `statistics-core`:
   density/CDF/quantile/sampling for the normal, uniform, and exponential
   distributions, plus `set.seed` for a reproducible per-session RNG.

--- a/code/packages/rust/s-runtime/src/builtins.rs
+++ b/code/packages/rust/s-runtime/src/builtins.rs
@@ -7387,4 +7387,89 @@ mod date_tests {
     fn format_pre_epoch() {
         assert_eq!(format_date_days(-1, "%Y-%m-%d"), "1969-12-31");
     }
+
+    // -----------------------------------------------------------------------
+    // R-46 — POSIXct: the seconds↔(days, h, m, s) split, parse, and render.
+    // -----------------------------------------------------------------------
+
+    /// The intraday split is `div_euclid`/`rem_euclid` by 86400, so it stays
+    /// correct (and never negatively-indexes) on pre-epoch (negative) seconds.
+    #[test]
+    fn posixct_intraday_split_handles_pre_epoch() {
+        // +1 second past the epoch: 0 days, 1 intraday second.
+        assert_eq!(1i64.div_euclid(86_400), 0);
+        assert_eq!(1i64.rem_euclid(86_400), 1);
+        // -1 second (1969-12-31 23:59:59): -1 day, 86399 intraday seconds.
+        assert_eq!((-1i64).div_euclid(86_400), -1);
+        assert_eq!((-1i64).rem_euclid(86_400), 86_399);
+    }
+
+    /// `parse_posixct_str` reads "YYYY-MM-DD HH:MM:SS" to seconds since epoch.
+    #[test]
+    fn parse_posixct_full_datetime() {
+        assert_eq!(parse_posixct_str("1970-01-01 00:00:00"), Some(0));
+        assert_eq!(parse_posixct_str("1970-01-01 00:01:00"), Some(60));
+        assert_eq!(parse_posixct_str("1970-01-02 00:00:00"), Some(86_400));
+        // 2021-03-14 09:30:05.
+        let z = days_from_civil(2021, 3, 14);
+        assert_eq!(
+            parse_posixct_str("2021-03-14 09:30:05"),
+            Some(z * 86_400 + 9 * 3600 + 30 * 60 + 5)
+        );
+    }
+
+    /// A bare date with no time half is taken as midnight (days * 86400).
+    #[test]
+    fn parse_posixct_date_only_is_midnight() {
+        let z = days_from_civil(2021, 3, 14);
+        assert_eq!(parse_posixct_str("2021-03-14"), Some(z * 86_400));
+    }
+
+    /// Malformed input and out-of-range H/M/S are rejected (None → NA), never a
+    /// panic. The leap-second slot (S = 60) is accepted.
+    #[test]
+    fn parse_posixct_malformed_and_ranges() {
+        assert_eq!(parse_posixct_str("garbage"), None);
+        assert_eq!(parse_posixct_str("2021-03-14 25:00:00"), None); // hour > 23
+        assert_eq!(parse_posixct_str("2021-03-14 09:60:00"), None); // minute > 59
+        assert_eq!(parse_posixct_str("2021-03-14 09:30:61"), None); // second > 60
+        assert!(parse_posixct_str("2021-03-14 09:30:60").is_some()); // leap second OK
+        assert_eq!(parse_posixct_str("2021-13-01 00:00:00"), None); // bad month
+    }
+
+    /// `format_posixct_seconds` renders the default and a custom format, reusing
+    /// the R-45 date fields on the date half.
+    #[test]
+    fn format_posixct_default_and_fields() {
+        let secs = parse_posixct_str("2021-03-14 09:30:05").unwrap();
+        assert_eq!(
+            format_posixct_seconds(secs, "%Y-%m-%d %H:%M:%S"),
+            "2021-03-14 09:30:05"
+        );
+        assert_eq!(format_posixct_seconds(secs, "%H:%M"), "09:30");
+        // Reused %B from the date half.
+        let jan = parse_posixct_str("2021-01-15 06:07:08").unwrap();
+        assert_eq!(format_posixct_seconds(jan, "%B"), "January");
+    }
+
+    /// Pre-epoch seconds render without panic and pick the correct clock time.
+    #[test]
+    fn format_posixct_pre_epoch() {
+        // -1 second = 1969-12-31 23:59:59.
+        assert_eq!(
+            format_posixct_seconds(-1, "%Y-%m-%d %H:%M:%S"),
+            "1969-12-31 23:59:59"
+        );
+    }
+
+    /// The seconds bound rejects absurd magnitudes before the civil kernel sees
+    /// them (→ NA), the numeric counterpart to the digit cap.
+    #[test]
+    fn posixct_seconds_bound() {
+        assert!(checked_posixct_seconds(0.0).is_some());
+        assert!(checked_posixct_seconds(MAX_POSIXCT_SECONDS as f64).is_some());
+        assert!(checked_posixct_seconds(1e300).is_none());
+        assert!(checked_posixct_seconds(f64::NAN).is_none());
+        assert!(checked_posixct_seconds(f64::INFINITY).is_none());
+    }
 }

--- a/code/packages/rust/s-runtime/src/builtins.rs
+++ b/code/packages/rust/s-runtime/src/builtins.rs
@@ -264,6 +264,19 @@ pub fn install(env: &Env) {
     define(env, "months", builtin("months", b_months));
     define(env, "quarters", builtin("quarters", b_quarters));
 
+    // R-46 — base R POSIXct date-times (UTC). A POSIXct is seconds-since-epoch
+    // (1970-01-01 00:00:00 UTC) carried by the transparent `SValue::Classed`
+    // wrapper with class c("POSIXct","POSIXt"); the date half reuses the R-44/R-45
+    // civil kernel and field renderer. `as.numeric`/subtraction need no special
+    // case (the wrapper is transparent → raw seconds).
+    define(env, "as.POSIXct", builtin("as.POSIXct", b_as_posixct));
+    define(env, "Sys.time", builtin("Sys.time", b_sys_time));
+    define(
+        env,
+        "format.POSIXct",
+        builtin("format.POSIXct", b_format_posixct),
+    );
+
     // v2 — data frames.
     define(env, "data.frame", builtin("data.frame", b_data_frame));
     define(env, "nrow", builtin("nrow", b_nrow));
@@ -2525,6 +2538,309 @@ fn b_quarters(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
                 format!("Q{q}")
             })
         })
+        .collect();
+    Ok(SValue::Character(out))
+}
+
+// ===========================================================================
+// R-46 — POSIXct date-times (UTC). A *date-time* layered on the R-44/R-45
+// calendar machinery.
+// ===========================================================================
+//
+// A `POSIXct` is — exactly like `Date` — an ordinary numeric vector, but the
+// number counts **seconds since the epoch 1970-01-01 00:00:00 UTC** instead of
+// whole days. It carries the two-element class `c("POSIXct", "POSIXt")` via the
+// same transparent `SValue::Classed` wrapper that backs `Date`, so it is just as
+// transparent to `as.numeric`, arithmetic, recycling, and indexing.
+//
+//   seconds = days * 86400 + intraday_seconds
+//
+// The whole point of the design is **reuse**: split a seconds count into a day
+// count and an intraday remainder, and *everything else is the existing Date
+// code*. The date half feeds straight into the R-44 civil kernel
+// (`civil_from_days` / `days_from_civil`) and the R-45 `format_date_days`
+// `%`-field renderer; only the intraday H:M:S split and the seconds bound are new.
+//
+//   ┌──────────── seconds (i64, may be negative for pre-epoch) ────────────┐
+//   │  div_euclid(86400) → day count z  ──▶ civil_from_days / format_date  │
+//   │  rem_euclid(86400) → intraday s   ──▶ H = s/3600, M = s/60%60, S=s%60 │
+//   └──────────────────────────────────────────────────────────────────────┘
+//
+// `div_euclid` / `rem_euclid` (NOT `/` and `%`) are essential: for a pre-epoch
+// instant like −1 second (= 1969-12-31 23:59:59) we need day −1 with intraday
+// 86399, which is exactly what the *Euclidean* (floored) operations give; plain
+// truncating division would give day 0 with intraday −1 and a negative array
+// index. This mirrors the `rem_euclid` reasoning already used for `weekday_index`.
+
+/// Seconds in one day — the conversion factor between the `Date` day count and a
+/// `POSIXct` seconds count.
+const SECONDS_PER_DAY: i64 = 86_400;
+
+/// The largest magnitude (in seconds) we admit for a `POSIXct`. It is the
+/// [`MAX_DATE_DAYS`] day bound scaled to seconds, so a POSIXct's *date half* can
+/// never exceed the range the civil kernel safely handles, and the multiply
+/// `MAX_DATE_DAYS * 86400` (≈ 8.64e15) stays well inside `i64` (max ≈ 9.2e18).
+/// This is the numeric counterpart to [`MAX_DATE_DIGITS`] for the seconds path:
+/// `as.POSIXct(1e300)` becomes `NA` rather than overflowing the kernel.
+const MAX_POSIXCT_SECONDS: i64 = MAX_DATE_DAYS * SECONDS_PER_DAY;
+
+/// Clamp-or-reject a raw seconds count: `Some(s)` if it is finite and within
+/// [`MAX_POSIXCT_SECONDS`], else `None` (→ NA). The seconds analogue of
+/// [`checked_date_days`]; every untrusted `f64`→POSIXct boundary funnels through
+/// here so the civil kernel only ever sees an in-range day count.
+fn checked_posixct_seconds(v: f64) -> Option<i64> {
+    if is_na_real(v) || !v.is_finite() {
+        return None;
+    }
+    let s = v.trunc();
+    if s.abs() > MAX_POSIXCT_SECONDS as f64 {
+        None
+    } else {
+        Some(s as i64)
+    }
+}
+
+/// Is `x` a POSIXct — a value whose (explicit) class vector contains "POSIXct"?
+fn is_posixct(x: &SValue) -> bool {
+    class_of(x).iter().any(|c| c == "POSIXct")
+}
+
+/// Wrap a vector of seconds-since-epoch (NA-aware doubles) as a `POSIXct` — class
+/// `c("POSIXct", "POSIXt")` over a plain `Double`. The single constructor every
+/// POSIXct-producing builtin funnels through (mirrors [`make_date`]).
+fn make_posixct(seconds: Vec<f64>) -> SValue {
+    SValue::Classed {
+        inner: Box::new(SValue::doubles(seconds)),
+        class: vec!["POSIXct".to_string(), "POSIXt".to_string()],
+    }
+}
+
+/// Parse a `"YYYY-MM-DD HH:MM:SS"` (or bare `"YYYY-MM-DD"` → midnight) datetime
+/// string to **seconds since the epoch**, or `None` (→ NA) on any malformed or
+/// out-of-range input. Never panics on crafted input.
+///
+/// The date half reuses R-44's [`parse_date_str`] with the ISO `"%Y-%m-%d"`
+/// pattern, so it inherits all of that function's safety (digit cap, calendar
+/// round-trip validation, `MAX_DATE_DIGITS`). The optional time half is then read
+/// as `HH:MM:SS` with the fields range-checked — **hour** 0–23, **minute** 0–59,
+/// **second** 0–60 (the trailing 60 is the POSIX leap-second slot, which base R
+/// also accepts). The resulting seconds are bounded by [`MAX_POSIXCT_SECONDS`]
+/// before return.
+fn parse_posixct_str(string: &str) -> Option<i64> {
+    // Split the date and (optional) time on the first ASCII space. A datetime is
+    // "<date> <time>"; a bare date has no space and is treated as midnight.
+    let (date_part, time_part) = match string.split_once(' ') {
+        Some((d, t)) => (d, Some(t)),
+        None => (string, None),
+    };
+
+    // Reuse the R-44 calendar parser for the date half (ISO only — other date
+    // layouts are out of scope for `as.POSIXct` here).
+    let z = parse_date_str(date_part, "%Y-%m-%d")?;
+
+    // The intraday offset in seconds. Absent time half ⇒ midnight (0).
+    let intraday = match time_part {
+        None => 0,
+        Some(t) => {
+            // Parse exactly "HH:MM:SS" via the same length-bounded uint reader the
+            // date parser uses. Any trailing garbage, missing colon, or extra
+            // field fails the whole parse (→ NA).
+            let chars: Vec<char> = t.chars().collect();
+            let mut i = 0usize;
+            let h = parse_uint_field(&chars, &mut i)?;
+            expect_char(&chars, &mut i, ':')?;
+            let m = parse_uint_field(&chars, &mut i)?;
+            expect_char(&chars, &mut i, ':')?;
+            let s = parse_uint_field(&chars, &mut i)?;
+            // No trailing characters allowed (e.g. fractional seconds → R-47).
+            if i != chars.len() {
+                return None;
+            }
+            // Range-check each field. Second admits 60 (leap-second slot).
+            if !(0..=23).contains(&h) || !(0..=59).contains(&m) || !(0..=60).contains(&s) {
+                return None;
+            }
+            h * 3600 + m * 60 + s
+        }
+    };
+
+    // days * 86400 + intraday. `z` is already bounded by MAX_DATE_DAYS (from
+    // parse_date_str), so this multiply stays inside i64; the final bound check
+    // is belt-and-suspenders against the additive intraday term.
+    let seconds = z.checked_mul(SECONDS_PER_DAY)?.checked_add(intraday)?;
+    if seconds.abs() > MAX_POSIXCT_SECONDS {
+        return None;
+    }
+    Some(seconds)
+}
+
+/// Match a single literal character at `chars[*idx]`, advancing past it; `None`
+/// (→ the whole parse fails → NA) if the input is exhausted or the char differs.
+/// A tiny helper so the time parser reads literally like its grammar `HH:MM:SS`.
+fn expect_char(chars: &[char], idx: &mut usize, want: char) -> Option<()> {
+    if *idx < chars.len() && chars[*idx] == want {
+        *idx += 1;
+        Some(())
+    } else {
+        None
+    }
+}
+
+/// Render one seconds count to a string under `format`. Supports the new sub-day
+/// fields `%H` (00–23), `%M` (00–59), `%S` (00–60) and **every R-44/R-45 date
+/// field** (`%Y %m %d %B %b %A %a %j %e` and literals), since the date half is
+/// just the day count fed into [`format_date_days`]. Total — never panics; the
+/// `div_euclid`/`rem_euclid` split keeps pre-epoch instants correct.
+///
+/// Implementation note: rather than re-implement the whole `%`-field scanner, we
+/// pre-substitute *only* the three time fields into the format string and let the
+/// reused date renderer handle the rest. The time fields render to fixed two-digit
+/// numbers with no `%`, so they cannot collide with the date renderer's scan, and
+/// a `%%` escape is preserved (the date renderer passes unknown `%x` through
+/// literally, and we never touch `%%`).
+fn format_posixct_seconds(seconds: i64, format: &str) -> String {
+    // Floored split: day count for the date half, intraday seconds for the clock.
+    let z = seconds.div_euclid(SECONDS_PER_DAY);
+    let intraday = seconds.rem_euclid(SECONDS_PER_DAY); // 0..86400
+    let hh = intraday / 3600;
+    let mm = (intraday % 3600) / 60;
+    let ss = intraday % 60;
+
+    // Walk the format, emitting %H/%M/%S ourselves and delegating each maximal run
+    // of date-only text to `format_date_days`. We accumulate non-time format
+    // characters into `date_run` and flush them (rendered against `z`) whenever we
+    // hit a time field, so reused fields like %B/%A still resolve correctly.
+    let fmt: Vec<char> = format.chars().collect();
+    let mut out = String::new();
+    let mut date_run = String::new();
+    let mut fi = 0;
+    while fi < fmt.len() {
+        if fmt[fi] == '%' && fi + 1 < fmt.len() {
+            match fmt[fi + 1] {
+                'H' | 'M' | 'S' => {
+                    // Flush any pending date-only run first (preserves order).
+                    if !date_run.is_empty() {
+                        out.push_str(&format_date_days(z, &date_run));
+                        date_run.clear();
+                    }
+                    let val = match fmt[fi + 1] {
+                        'H' => hh,
+                        'M' => mm,
+                        _ => ss,
+                    };
+                    out.push_str(&format!("{val:02}"));
+                }
+                // Any other conversion belongs to the date renderer — buffer it
+                // verbatim (both the '%' and the letter) for the next flush.
+                other => {
+                    date_run.push('%');
+                    date_run.push(other);
+                }
+            }
+            fi += 2;
+        } else {
+            date_run.push(fmt[fi]);
+            fi += 1;
+        }
+    }
+    if !date_run.is_empty() {
+        out.push_str(&format_date_days(z, &date_run));
+    }
+    out
+}
+
+/// `as.POSIXct(x, tz = "UTC")` — build a `POSIXct` (R-46).
+///
+/// - **Character `x`:** each element is parsed as `"YYYY-MM-DD HH:MM:SS"` (or
+///   `"YYYY-MM-DD"` → midnight) to seconds since the epoch. Unparseable or
+///   out-of-range strings become `NA` — never a panic.
+/// - **Numeric `x`:** taken directly as raw seconds-since-epoch (bounded by
+///   [`MAX_POSIXCT_SECONDS`]; out-of-range / non-finite → `NA`).
+///
+/// Only `tz = "UTC"` is honoured; a different `tz` is currently ignored (R-47).
+/// Vectorised; the result carries class `c("POSIXct", "POSIXt")`.
+fn b_as_posixct(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    let x = first_positional(args)?;
+    // Already a POSIXct? Return as-is (idempotent), seeing through the wrapper.
+    if is_posixct(x) {
+        return Ok(x.clone());
+    }
+    // A `Date` converts by scaling its day count to seconds (midnight UTC).
+    if is_date(x) {
+        let days = x.as_double()?;
+        let seconds: Vec<f64> = days
+            .iter()
+            .map(|v| {
+                checked_date_days(v)
+                    .map(|z| (z * SECONDS_PER_DAY) as f64)
+                    .unwrap_or_else(na_real)
+            })
+            .collect();
+        return Ok(make_posixct(seconds));
+    }
+
+    let seconds: Vec<f64> = match peel_structural(x) {
+        SValue::Character(strs) => strs
+            .iter()
+            .map(|opt| match opt {
+                Some(s) => parse_posixct_str(s)
+                    .map(|secs| secs as f64)
+                    .unwrap_or_else(na_real),
+                None => na_real(),
+            })
+            .collect(),
+        other => {
+            // Numeric (or coercible) input → raw seconds, bounded so an
+            // out-of-range value (`as.POSIXct(1e300)`) becomes NA rather than
+            // overflowing the kernel downstream.
+            let d = other.as_double()?;
+            d.iter()
+                .map(|v| {
+                    checked_posixct_seconds(v)
+                        .map(|s| s as f64)
+                        .unwrap_or_else(na_real)
+                })
+                .collect()
+        }
+    };
+    Ok(make_posixct(seconds))
+}
+
+/// `Sys.time()` — the current time as a length-1 `POSIXct` (R-46).
+///
+/// Like [`b_sys_date`], the runtime has no deterministic clock hook, so we read
+/// the wall clock directly: seconds since `UNIX_EPOCH`. A clock set *before* the
+/// epoch yields a negative count, handled without panic. Non-deterministic, so
+/// tests assert only its structure (class `c("POSIXct","POSIXt")` + a single
+/// finite numeric), never the exact instant.
+fn b_sys_time(_interp: &Interpreter, _args: &[Arg]) -> SResult<SValue> {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let now = SystemTime::now();
+    let seconds = match now.duration_since(UNIX_EPOCH) {
+        Ok(dur) => dur.as_secs() as i64,
+        Err(e) => -(e.duration().as_secs() as i64),
+    };
+    Ok(make_posixct(vec![seconds as f64]))
+}
+
+/// `format.POSIXct(x, format = "%Y-%m-%d %H:%M:%S")` — render a `POSIXct` to a
+/// character vector (R-46). Supports `%H`/`%M`/`%S` plus every reused R-44/R-45
+/// date field; `NA` seconds stay `NA`. Reached directly and via the `format()`
+/// generic's dispatch (which checks `"POSIXct"` before `"Date"`).
+fn b_format_posixct(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
+    let x = first_positional(args)?;
+    let format = named_str(args, "format")
+        .or_else(|| {
+            nth_positional(args, 1).and_then(|v| v.as_character().into_iter().next().flatten())
+        })
+        .unwrap_or_else(|| "%Y-%m-%d %H:%M:%S".to_string());
+
+    let secs = x.as_double()?;
+    let out: Vec<Option<String>> = secs
+        .iter()
+        // `checked_posixct_seconds` rejects NA / non-finite / out-of-range → NA,
+        // so an out-of-range seconds count can never overflow the civil kernel.
+        .map(|v| checked_posixct_seconds(v).map(|s| format_posixct_seconds(s, &format)))
         .collect();
     Ok(SValue::Character(out))
 }
@@ -5015,6 +5331,13 @@ fn b_format(_interp: &Interpreter, args: &[Arg]) -> SResult<SValue> {
     // R-44: `format()` is an S3 generic. A value carrying class "Date" routes to
     // the Date renderer (`format.Date`) — so `format(as.Date("2021-03-14"))`
     // yields "2021-03-14" rather than the bare day count.
+    //
+    // R-46: check "POSIXct" *first* — a POSIXct's class is c("POSIXct","POSIXt")
+    // and does NOT contain "Date", but ordering the date-time renderer ahead keeps
+    // the intent explicit and is robust to any future shared class.
+    if is_posixct(x) {
+        return b_format_posixct(_interp, args);
+    }
     if is_date(x) {
         return b_format_date(_interp, args);
     }

--- a/code/specs/R00-r-language.md
+++ b/code/specs/R00-r-language.md
@@ -1693,6 +1693,54 @@ unchanged.
     names; and any compound `"N units"` `by=` shapes beyond a single leading
     integer multiplier.
 
+- **R-46 — POSIXct date-times (UTC).** Adds R's first *date-time* type on top of
+  R-44/R-45's calendar machinery. A **`POSIXct`** is — exactly like `Date` — *not*
+  a new value kind: it is an ordinary numeric vector of **seconds since the epoch
+  1970-01-01 00:00:00 UTC**, carrying the two-element class
+  `c("POSIXct", "POSIXt")`. We model it with the same transparent
+  `SValue::Classed { inner: Double, class: ["POSIXct", "POSIXt"] }` wrapper that
+  backs `Date`. The single insight that makes this nearly free: a POSIXct's
+  **date part** is `seconds.div_euclid(86400)` (days since epoch — exactly the
+  R-44 `Date` representation) and its **time part** is `seconds.rem_euclid(86400)`
+  (intraday seconds, split into H/M/S). So the civil-date kernel (`days_from_civil`
+  / `civil_from_days`), the English name tables, and the `%`-field renderer are all
+  **reused unchanged**; only the seconds↔(days, h, m, s) split is new.
+  - **`as.POSIXct(x, tz = "UTC")`** — parse a **character** vector of
+    `"YYYY-MM-DD HH:MM:SS"` (or `"YYYY-MM-DD"`, taken as midnight) to a POSIXct, or
+    wrap a **numeric** vector as raw seconds-since-epoch directly. Parsing reuses
+    the R-44 `parse_date_str` calendar parse for the date half, then adds an
+    optional `" HH:MM:SS"` time half (H 0–23, M 0–59, S 0–60 — the leap-second
+    slot is accepted). Malformed input → `NA`, never a panic. Only `tz = "UTC"`
+    is honoured (any other `tz` is currently ignored — see deferrals).
+  - **`Sys.time()`** — the current time as a length-1 POSIXct. Like `Sys.Date`,
+    the runtime has no deterministic clock hook, so it reads the wall clock
+    (`SystemTime::now()` → seconds since `UNIX_EPOCH`); a pre-epoch clock yields a
+    negative count without panicking. Non-deterministic, so tests assert only its
+    structure (class `c("POSIXct","POSIXt")` + a single finite numeric).
+  - **`format.POSIXct(x, format =)` / `format(x, fmt)`** — render a POSIXct to a
+    character vector. Default `"%Y-%m-%d %H:%M:%S"`. Supports the new sub-day
+    fields `%H` (00–23), `%M` (00–59), `%S` (00–60) **plus every R-44/R-45 date
+    field** (`%Y %m %d %B %b %A %a %j %e`), since the date half is just the day
+    count fed straight into the reused `format_date_days` field machinery. The
+    `format()` generic checks for class `"POSIXct"` *before* `"Date"` and routes
+    accordingly.
+  - **POSIXct subtraction & `as.numeric`** — need **no special case**: the
+    transparent `Classed` wrapper means `as.numeric(t)` peels to the raw seconds
+    and `t1 - t2` flows through the shared `arithmetic("-", …)` kernel, yielding
+    the difference **in seconds**. So
+    `as.POSIXct("2021-03-14 09:30:00") - as.POSIXct("2021-03-14 09:00:00")` is
+    `1800`, and `as.numeric(as.POSIXct("1970-01-02 00:00:00"))` is `86400`.
+  - **Parse-safety.** Untrusted datetime strings must never panic or overflow.
+    A new `MAX_POSIXCT_SECONDS` (≈ `MAX_DATE_DAYS * 86400`) bounds any parsed or
+    directly-supplied seconds count *before* it reaches the civil kernel; the
+    date half still passes through R-44's `MAX_DATE_DAYS` / `MAX_DATE_DIGITS`
+    caps; H/M/S are range-checked (0–23 / 0–59 / 0–60); and the seconds→(days,
+    intraday) split uses `div_euclid`/`rem_euclid` so pre-epoch (negative)
+    seconds split correctly without a negative array index. Malformed → `NA`.
+  - **Deferred to R-47.** Non-UTC timezones (and DST); `POSIXlt` (the broken-down
+    list form); fractional (sub-)seconds; `%z`/`%Z` offset/zone fields;
+    `strptime`/`strftime` as standalone functions; and `as.POSIXlt`.
+
 ## §4 Reuse strategy
 
 - **Lexer/parser:** the grammar-tools framework, exactly as S uses it. `r.tokens`

--- a/code/specs/S00-s-language.md
+++ b/code/specs/S00-s-language.md
@@ -784,6 +784,40 @@ essential: `switch("a", a = stop("no"), b = "ok")` must not raise, and a
      `%H`/`%M`/`%S`/`%p`; `%U`/`%W` week-of-year; locale (non-English) names;
      compound `"N units"` `by=` beyond a single leading integer multiplier.
 
+13. **POSIXct date-times (R-46, shared builtins).** Adds the first *date-time*
+   type on top of the R-44/R-45 calendar machinery, again **in place** and with
+   **no new dependency**. A `POSIXct` is — exactly like `Date` — an ordinary
+   numeric vector, but of **seconds since 1970-01-01 00:00:00 UTC**, carrying the
+   two-element class `c("POSIXct", "POSIXt")` via the same transparent
+   `SValue::Classed` wrapper. The key reuse: a POSIXct's **date part** is
+   `seconds.div_euclid(86400)` (= the R-44 `Date` day count) and its **time part**
+   is `seconds.rem_euclid(86400)` (intraday seconds → H/M/S), so the civil kernel
+   (`days_from_civil`/`civil_from_days`), the English name tables, and the
+   `format_date_days` `%`-field renderer are all reused **unchanged** — only the
+   seconds↔(days, h, m, s) split is new.
+   - **`as.POSIXct(x, tz = "UTC")`** — parse a character vector of
+     `"YYYY-MM-DD HH:MM:SS"` (or `"YYYY-MM-DD"` → midnight) to a POSIXct, or wrap a
+     numeric vector as raw seconds directly. The date half reuses R-44's
+     `parse_date_str`; an optional ` HH:MM:SS` time half is parsed with H 0–23,
+     M 0–59, S 0–60 (leap-second slot accepted). Malformed → `NA`, never a panic.
+     Only `tz = "UTC"` honoured.
+   - **`Sys.time()`** — current time as a length-1 POSIXct (reads the wall clock
+     like `Sys.Date`; pre-epoch handled without panic). Structure-tested only.
+   - **`format.POSIXct(x, format =)` / `format(x, fmt)`** — render to character.
+     Default `"%Y-%m-%d %H:%M:%S"`. New fields `%H`/`%M`/`%S`; reuses every R-44/
+     R-45 date field (`%Y %m %d %B %b %A %a %j %e`) by feeding the day count to
+     `format_date_days`. The `format()` generic checks `"POSIXct"` before `"Date"`.
+   - **POSIXct subtraction & `as.numeric`** — no special case: `as.numeric` peels
+     the wrapper to raw seconds, and `t1 - t2` flows through `arithmetic("-", …)`,
+     giving the difference **in seconds**.
+   - **Parse-safety.** A new `MAX_POSIXCT_SECONDS` (≈ `MAX_DATE_DAYS * 86400`)
+     bounds any parsed/supplied seconds *before* the civil kernel; the date half
+     still passes through `MAX_DATE_DAYS`/`MAX_DATE_DIGITS`; H/M/S range-checked;
+     the seconds→(days, intraday) split uses `div_euclid`/`rem_euclid` so negative
+     (pre-epoch) seconds split without a negative index.
+   - **Deferred to R-47.** Non-UTC timezones (and DST); `POSIXlt`; fractional
+     seconds; `%z`/`%Z`; standalone `strptime`/`strftime`; `as.POSIXlt`.
+
 ## §10 References
 
 Internal: [`ST00-r-stats-roadmap.md`](ST00-r-stats-roadmap.md),


### PR DESCRIPTION
## R-46 — POSIXct date-times (deferred from R-45)

A **POSIXct** is seconds since the epoch 1970-01-01 00:00:00 UTC, class `c("POSIXct","POSIXt")` — reusing the R-44/R-45 Date class machinery and Howard Hinnant civil-date kernel (date part = `seconds.div_euclid(86400)` days, time part = `seconds.rem_euclid(86400)`).

- **`as.POSIXct(x, tz="UTC")`** — parse `"YYYY-MM-DD HH:MM:SS"` (and `"YYYY-MM-DD"` → midnight), or convert a numeric (seconds). Malformed → `NA`, never panic. UTC only.
- **`Sys.time()`** — real clock → POSIXct.
- **`format.POSIXct` / `format(x, fmt)`** — `%Y %m %d %H %M %S` plus the reused R-45 date fields; default `"%Y-%m-%d %H:%M:%S"`.
- **POSIXct subtraction** → seconds; `as.numeric(posixct)` → seconds since epoch.
- **Deferred to R-47**: non-UTC timezones, POSIXlt, DST, fractional seconds, `%z`/`%Z`, strptime/strftime.

### Notes
Authored by a delegated agent that committed all four milestones (spec/tests/impl/docs) before a transient infra watchdog stalled it at the PR-creation step; the push + this PR were completed in the main session. Tests were green at the impl/docs milestones (`cargo test -p coding-adventures-s-runtime -p coding-adventures-r-runtime`). Parse-safety bounds (a `MAX_POSIXCT_SECONDS`-style cap, H/M/S range checks, `rem_euclid`/`div_euclid`) are in the impl per the spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)