### PR TITLE
feat(mycin-germlayer): ADJ-only germ layer → derivative recall

### DIFF
--- a/code/specs/data/mycin-2026/recall/germ-layer-edges.adj
+++ b/code/specs/data/mycin-2026/recall/germ-layer-edges.adj
@@ -1,0 +1,86 @@
+% ============================================================================
+% germ-layer-edges — the primary germ layer → derivative knowledge-graph
+% (MYCIN-2026 GERMLAYER).
+% ============================================================================
+% A high-yield embryology board table: each of the three primary embryonic germ
+% layers (ectoderm, mesoderm, endoderm) and representative adult structures it
+% gives rise to. "What does the ectoderm give rise to?" becomes the binding query
+%     ? gives_rise_to(ectoderm, $Derivative).
+%
+% Direction note: the relation is germ layer -> a structure that DEVELOPS FROM it
+% (`gives_rise_to`). Each germ layer here maps to TWO representative derivatives,
+% so a query for a given layer binds two answers (each with its own citation).
+%
+% Faithfulness note: each `relate` subject/object is bound to what the cited
+% sentence ACTUALLY names. The derivative object names a structure the sentence
+% explicitly states the layer forms (ectoderm "will form the epidermis"; surface
+% ectoderm "give rise to ... anterior pituitary"; intermediate mesoderm "gives
+% rise to ... kidneys"; paraxial mesoderm somites "develop into ... dermis";
+% endoderm "gives rise to the gastrointestinal tract"; endoderm precursor to the
+% "liver"). Each cited sentence names the germ layer by its FULL term (including
+% the subtype prefix where present — surface/intermediate/paraxial mesoderm is
+% still the mesoderm). Each span was independently re-fetched and confirmed on two
+% separate fetches of the same page for byte-stability.
+%
+% This file is the SHIPPED ARTIFACT and the SOLE source of truth — no generator,
+% no JSON, no manifest (a pure ADJ-only recall domain, like ACIDBASE/HEARTVALVE/
+% PHARYNGEAL/FETALSHUNT). Each fact is a `relate` clause whose byte-provenance
+% lives INLINE:
+%     source   — the VERBATIM span copied from the cited page (byte-stable: it
+%                appears character-for-character in the page's normalized text;
+%                every span here was independently re-fetched and confirmed).
+%     locator  — the URL the span was read from (NCBI StatPearls / Bookshelf).
+%     trust    — authoritative (a primary, citable reference).
+% An LLM (or a human) recalls a fact by writing a tiny query .adj that `import`s
+% this library and asks a binding query — see germ-layer-recall.query.adj.
+% Nothing here is asserted "from memory": every edge is defended by a span a
+% reader can re-fetch and check.
+% (See feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+dictionary germ_layer_vocab {
+    define germ_layer : entity   surface "germ layer", "primary embryonic germ layer"
+    define derivative : entity   surface "germ-layer derivative", "adult structure"
+
+    define gives_rise_to : relation from germ_layer to derivative  % a structure that develops from this germ layer
+}
+
+rulebook germ_layer_facts {
+    use germ_layer_vocab
+
+    % --- ectoderm -> epidermis ----------------------------------------------
+    relate gives_rise_to(ectoderm, epidermis)
+        source "The ectoderm that fails to involute will form the epidermis of the skin, hair, exocrine glands, and the anterior pituitary."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK539836/"
+        trust authoritative
+
+    % --- ectoderm -> anterior pituitary -------------------------------------
+    relate gives_rise_to(ectoderm, anterior_pituitary)
+        source "The surface ectoderm will give rise to the epidermis, external glands, hair, nails, anterior pituitary, and the apical ectodermal ridge amongst others."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK539836/"
+        trust authoritative
+
+    % --- mesoderm -> kidney -------------------------------------------------
+    relate gives_rise_to(mesoderm, kidney)
+        source "The intermediate mesoderm gives rise to the gonads, kidneys, and other urogenital structures."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK526024/"
+        trust authoritative
+
+    % --- mesoderm -> dermis -------------------------------------------------
+    relate gives_rise_to(mesoderm, dermis)
+        source "The paraxial mesoderm consists primarily of somites, which develop into the axial skeleton, dermis, and skeletal muscles."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK526024/"
+        trust authoritative
+
+    % --- endoderm -> gastrointestinal tract ---------------------------------
+    relate gives_rise_to(endoderm, gastrointestinal_tract)
+        source "The endoderm is the innermost layer, which gives rise to the gastrointestinal tract, the lining of the gut, the liver, the pancreas, and portions of the lungs and glandular tissues."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK554394/"
+        trust authoritative
+
+    % --- endoderm -> liver --------------------------------------------------
+    relate gives_rise_to(endoderm, liver)
+        source "Endoderm is the embryonic precursor to the thyroid, lungs, pancreas, liver, and intestines, which evolve from 4 consecutive developmental steps: proliferation and induction of pluripotent stem cells, the separation of stem cell-derived endoderm versus mesoderm germ layers, anterior-posterior patterning, and bifurcation of the liver and pancreas."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK554394/"
+        trust authoritative
+}

--- a/code/specs/data/mycin-2026/recall/germ-layer-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/germ-layer-recall.query.adj
@@ -1,0 +1,19 @@
+% ============================================================================
+% germ-layer-recall.query.adj — a worked recall query over the germ-layer library.
+% ============================================================================
+% The shape an LLM (or a student) produces to ANSWER a "what does germ layer X
+% give rise to?" question: it states no embryology fact — it only `import`s the
+% grounded library and asks binding queries. The native adj-lang engine resolves
+% each `?` against the imported `relate` edges and returns the binding(s) + each
+% citing clause's source/locator/trust. A germ layer with two grounded derivatives
+% binds two answers. All knowledge is in the library; none is here.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli germ-layer-recall.query.adj
+% ============================================================================
+
+import "germ-layer-edges.adj"
+
+? gives_rise_to(ectoderm, $Derivative)   % expect epidermis, anterior_pituitary
+? gives_rise_to(mesoderm, $Derivative)   % expect kidney, dermis
+? gives_rise_to(endoderm, $Derivative)   % expect gastrointestinal_tract, liver

--- a/code/specs/data/mycin-2026/recall/test_germ_layer_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_germ_layer_recall.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""test_germ_layer_recall.py — the ADJ-only germ-layer→derivative recall library
+(MYCIN-2026 GERMLAYER).
+
+A pure-ADJ recall domain (high-yield embryology board table): representative adult
+structures each of the three primary embryonic germ layers gives rise to.
+`germ-layer-edges.adj` is the SOLE source of truth — facts + byte-provenance inline,
+no Python gate, no JSON, no manifest. This test pins the property that matters: the
+native adj-lang engine, given a query .adj that only `import`s the library and asks
+binding queries (`germ-layer-recall.query.adj` — the shape an LLM produces), binds
+the grounded derivatives for each germ layer, each carrying an AUTHORITATIVE
+citation with a real source span + locator. Each germ layer maps to TWO derivatives,
+so a query binds two answers. Knowledge lives in ADJ; the engine answers.
+
+If the native CLI isn't built (a Python-only CI lane), the engine-backed checks
+skip — the file-shape checks (every clause grounded, no authored-debt) still run.
+
+Run:  python3 test_germ_layer_recall.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ADJ = HERE / "germ-layer-edges.adj"
+QUERY = HERE / "germ-layer-recall.query.adj"
+CLI = HERE.parents[3] / "packages" / "rust" / "target" / "debug" / "adj-lang-cli"
+
+# Every grounded germ layer -> the SET of derivatives the library binds for it.
+EXPECTED = {
+    "ectoderm": {"epidermis", "anterior_pituitary"},                  # NBK539836
+    "mesoderm": {"kidney", "dermis"},                                 # NBK526024
+    "endoderm": {"gastrointestinal_tract", "liver"},                  # NBK554394
+}
+EDGE_COUNT = sum(len(v) for v in EXPECTED.values())  # 6
+REL = "gives_rise_to"
+VAR = "Derivative"
+
+
+def _cli_available() -> bool:
+    return CLI.exists()
+
+
+def _run(program: Path) -> dict:
+    out = subprocess.run([str(CLI), str(program)], capture_output=True, text=True,
+                         cwd=str(HERE), timeout=60)
+    assert out.returncode == 0, f"adj-lang-cli failed: {out.stderr}"
+    return json.loads(out.stdout)
+
+
+# ---- 1. the ADJ file is the artifact — every clause grounded, no authored-debt ----
+
+def test_library_is_pure_adj_and_fully_grounded() -> None:
+    text = ADJ.read_text()
+    assert "trust consensus" not in text, "GERMLAYER ships no authored-debt; ground or omit"
+    assert "[FLAG:" not in text
+    assert text.count("    relate ") == EDGE_COUNT
+    assert text.count("trust authoritative") == EDGE_COUNT
+    assert text.count('\n        locator "') == EDGE_COUNT
+    assert text.count('\n        source "') == EDGE_COUNT
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("locator "):
+            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+    assert not (HERE / "germ_layer_edge_ground.py").exists()
+    assert not (HERE / "germ-layer-edge-grounding.json").exists()
+    assert not (HERE / "germ-layer-edge-manifest.json").exists()
+
+
+# ---- 2. the engine binds every derivative with an authoritative citation -----------
+
+def test_engine_binds_every_derivative_with_authoritative_citation() -> None:
+    if not _cli_available():
+        return
+    result = _run(QUERY)
+    by_query = {r["query"]: r for r in result["recall"]}
+    for germ_layer, derivatives in EXPECTED.items():
+        q = f"{REL}({germ_layer}, {VAR})"
+        r = by_query.get(q)
+        assert r is not None and not r["abstained"], f"{q} abstained — edges missing?"
+        bound = {}
+        for a in r["answers"]:
+            bound[a["bindings"][VAR]] = (a.get("citations") or [{}])[0]
+        assert set(bound) == derivatives, f"{germ_layer}: bound {set(bound)} != {derivatives}"
+        for deriv, cite in bound.items():
+            assert cite.get("trust") == "authoritative", f"{germ_layer}/{deriv} not authoritative"
+            assert cite.get("source"), f"{germ_layer}/{deriv} has no source span"
+            assert cite.get("locator", "").startswith("https://www.ncbi.nlm.nih.gov/")
+
+
+# ---- 3. an off-vocabulary germ layer abstains, never fabricates ---------------------
+
+def test_unknown_germ_layer_abstains() -> None:
+    if not _cli_available():
+        return
+    import os
+    import tempfile
+    fd, path = tempfile.mkstemp(suffix=".adj", prefix=".germlayer_q_", dir=HERE)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            # the trophoblast is a real early-embryonic structure but is NOT one of
+            # the three primary germ layers this library models, so it is
+            # deliberately absent — the engine must abstain rather than guess.
+            fh.write(f'import "germ-layer-edges.adj"\n? {REL}(trophoblast, ${VAR})\n')
+        res = _run(Path(path))
+        r = res["recall"][0] if res["recall"] else None
+        assert r is not None and r["abstained"], "an ungrounded germ layer must abstain"
+    finally:
+        os.unlink(path)
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS  {t.__name__}")
+        except AssertionError as exc:
+            failed += 1
+            print(f"  FAIL  {t.__name__}: {exc}")
+    print(f"\ntest_germ_layer_recall: {len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())


### PR DESCRIPTION
## What

New **pure-ADJ recall domain** for MYCIN-2026: representative adult structures each of the three primary embryonic germ layers gives rise to — a high-yield embryology board table, grounded against primary NCBI StatPearls / Bookshelf pages. Distinct from the existing `embryo` domain (structure→origin); this maps the three **germ layers → their derivatives**.

The shipped artifact is `germ-layer-edges.adj` — the **SOLE source of truth**. No generator, no JSON, no manifest (a pure ADJ-only recall domain, like ACIDBASE / HEARTVALVE / PHARYNGEAL / FETALSHUNT). Each `relate gives_rise_to(germ_layer, derivative)` clause carries its byte-provenance inline: a verbatim `source` span, an NCBI `locator`, and `trust authoritative`. Knowledge lives in ADJ; the native adj-lang engine answers a binding query that only `import`s the library.

## Edges (6 — 2 per layer)

Each defended by a **self-contained** NCBI sentence naming BOTH the full germ-layer term AND a specific derivative, independently **double-fetched** for byte-stability:

| germ layer | → derivative | source |
|---|---|---|
| `ectoderm` | `epidermis` | [NBK539836](https://www.ncbi.nlm.nih.gov/books/NBK539836/) |
| `ectoderm` | `anterior_pituitary` | [NBK539836](https://www.ncbi.nlm.nih.gov/books/NBK539836/) |
| `mesoderm` | `kidney` | [NBK526024](https://www.ncbi.nlm.nih.gov/books/NBK526024/) |
| `mesoderm` | `dermis` | [NBK526024](https://www.ncbi.nlm.nih.gov/books/NBK526024/) |
| `endoderm` | `gastrointestinal_tract` | [NBK554394](https://www.ncbi.nlm.nih.gov/books/NBK554394/) |
| `endoderm` | `liver` | [NBK554394](https://www.ncbi.nlm.nih.gov/books/NBK554394/) |

Direction: **germ layer → a structure that develops from it**. Each layer maps to two derivatives, so a query binds two answers; the test groups expected derivatives per layer as a set. Each cited sentence names the germ layer by its full term (including the subtype prefix where present — surface/intermediate/paraxial mesoderm is still the mesoderm).

## Files

- `germ-layer-edges.adj` — the grounded knowledge graph (dictionary + rulebook)
- `germ-layer-recall.query.adj` — a worked binding query (the shape an LLM emits)
- `test_germ_layer_recall.py` — 3 tests: pure-ADJ/fully-grounded shape; engine binds every derivative with an authoritative citation; an off-vocabulary structure (`trophoblast` — not one of the 3 primary germ layers) **abstains** rather than fabricating.

## Verification

- Tests **3/3 pass** locally against the native `adj-lang-cli`.
- Security review **passed** (inert ADJ data + a list-argv subprocess harness; no injection / traversal / deserialization / SSRF vectors).
- No deferrals — all six spans cleared the self-contained full-term faithfulness bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)