### PR TITLE
feat(mycin-giwall): ADJ-only GI-tract wall layer → tissue recall

### DIFF
--- a/code/specs/data/mycin-2026/recall/gi-wall-edges.adj
+++ b/code/specs/data/mycin-2026/recall/gi-wall-edges.adj
@@ -1,0 +1,72 @@
+% ============================================================================
+% gi-wall-edges — the GI-tract wall layer → tissue knowledge-graph
+% (MYCIN-2026 GIWALL).
+% ============================================================================
+% A high-yield histology board table: the four concentric layers of the
+% gastrointestinal (GI) tract wall (mucosa, submucosa, muscularis externa, serosa)
+% and the characteristic tissue each is composed of. "What tissue makes up the
+% muscularis externa?" becomes the binding query
+%     ? composed_of(muscularis_externa, $Tissue).
+%
+% Direction note: the relation is wall layer -> the tissue it is composed of
+% (`composed_of`). Each layer here maps to ONE canonical tissue span, so a query
+% binds a single answer.
+%
+% Faithfulness note: each `relate` subject/object is bound to what the cited
+% sentence ACTUALLY names. The tissue object names the tissue the sentence states
+% (mucosa "a single layer of epithelium"; submucosa "a connective tissue layer";
+% muscularis externa "2 major smooth muscle layers"; serosa "consisting of
+% mesothelium"). Each cited sentence names the layer by its FULL term. Each span
+% was independently re-fetched and confirmed on two separate fetches of the same
+% page for byte-stability.
+%
+% This file is the SHIPPED ARTIFACT and the SOLE source of truth — no generator,
+% no JSON, no manifest (a pure ADJ-only recall domain, like MUSCLEFIBER/GERMLAYER/
+% ACIDBASE/HEARTVALVE). Each fact is a `relate` clause whose byte-provenance lives
+% INLINE:
+%     source   — the VERBATIM span copied from the cited page (byte-stable: it
+%                appears character-for-character in the page's normalized text;
+%                every span here was independently re-fetched and confirmed).
+%     locator  — the URL the span was read from (NCBI StatPearls / Bookshelf).
+%     trust    — authoritative (a primary, citable reference).
+% An LLM (or a human) recalls a fact by writing a tiny query .adj that `import`s
+% this library and asks a binding query — see gi-wall-recall.query.adj.
+% Nothing here is asserted "from memory": every edge is defended by a span a
+% reader can re-fetch and check.
+% (See feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+dictionary gi_wall_vocab {
+    define wall_layer : entity   surface "GI tract wall layer", "gastrointestinal wall layer"
+    define tissue     : entity   surface "tissue", "tissue composition"
+
+    define composed_of : relation from wall_layer to tissue  % the tissue this wall layer is composed of
+}
+
+rulebook gi_wall_facts {
+    use gi_wall_vocab
+
+    % --- mucosa -> epithelium -----------------------------------------------
+    relate composed_of(mucosa, epithelium)
+        source "The mucosa consists of a single layer of epithelium, which is highly folded to increase its surface area for absorption."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK537103/"
+        trust authoritative
+
+    % --- submucosa -> connective tissue -------------------------------------
+    relate composed_of(submucosa, connective_tissue)
+        source "The submucosa, a connective tissue layer, houses blood and lymphatic vessels that support the gastrointestinal tract."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK537103/"
+        trust authoritative
+
+    % --- muscularis externa -> smooth muscle --------------------------------
+    relate composed_of(muscularis_externa, smooth_muscle)
+        source "The muscularis externa comprises 2 major smooth muscle layers: an inner circular and an outer longitudinal muscular layer."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK537103/"
+        trust authoritative
+
+    % --- serosa -> mesothelium ----------------------------------------------
+    relate composed_of(serosa, mesothelium)
+        source "The serosa is the outermost small intestinal layer, consisting of mesothelium and epithelium."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK459366/"
+        trust authoritative
+}

--- a/code/specs/data/mycin-2026/recall/gi-wall-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/gi-wall-recall.query.adj
@@ -1,0 +1,20 @@
+% ============================================================================
+% gi-wall-recall.query.adj — a worked recall query over the gi-wall library.
+% ============================================================================
+% The shape an LLM (or a student) produces to ANSWER a "what tissue makes up GI
+% wall layer X?" question: it states no histology fact — it only `import`s the
+% grounded library and asks binding queries. The native adj-lang engine resolves
+% each `?` against the imported `relate` edges and returns the binding + the
+% citing clause's source/locator/trust. All knowledge is in the library; none is
+% here.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli gi-wall-recall.query.adj
+% ============================================================================
+
+import "gi-wall-edges.adj"
+
+? composed_of(mucosa, $Tissue)              % expect epithelium
+? composed_of(submucosa, $Tissue)           % expect connective_tissue
+? composed_of(muscularis_externa, $Tissue)  % expect smooth_muscle
+? composed_of(serosa, $Tissue)              % expect mesothelium

--- a/code/specs/data/mycin-2026/recall/test_gi_wall_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_gi_wall_recall.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""test_gi_wall_recall.py — the ADJ-only GI-tract-wall-layer→tissue recall library
+(MYCIN-2026 GIWALL).
+
+A pure-ADJ recall domain (high-yield histology board table): the characteristic
+tissue composing each of the four concentric layers of the gastrointestinal tract
+wall (mucosa, submucosa, muscularis externa, serosa). `gi-wall-edges.adj` is the
+SOLE source of truth — facts + byte-provenance inline, no Python gate, no JSON, no
+manifest. This test pins the property that matters: the native adj-lang engine,
+given a query .adj that only `import`s the library and asks binding queries
+(`gi-wall-recall.query.adj` — the shape an LLM produces), binds the grounded tissue
+for each wall layer, each carrying an AUTHORITATIVE citation with a real source span
++ locator. Knowledge lives in ADJ; the engine answers.
+
+If the native CLI isn't built (a Python-only CI lane), the engine-backed checks
+skip — the file-shape checks (every clause grounded, no authored-debt) still run.
+
+Run:  python3 test_gi_wall_recall.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ADJ = HERE / "gi-wall-edges.adj"
+QUERY = HERE / "gi-wall-recall.query.adj"
+CLI = HERE.parents[3] / "packages" / "rust" / "target" / "debug" / "adj-lang-cli"
+
+# Every grounded edge: GI-wall layer -> the tissue the library binds.
+EXPECTED = {
+    "mucosa": "epithelium",                    # NBK537103
+    "submucosa": "connective_tissue",          # NBK537103
+    "muscularis_externa": "smooth_muscle",     # NBK537103
+    "serosa": "mesothelium",                   # NBK459366
+}
+REL = "composed_of"
+VAR = "Tissue"
+
+
+def _cli_available() -> bool:
+    return CLI.exists()
+
+
+def _run(program: Path) -> dict:
+    out = subprocess.run([str(CLI), str(program)], capture_output=True, text=True,
+                         cwd=str(HERE), timeout=60)
+    assert out.returncode == 0, f"adj-lang-cli failed: {out.stderr}"
+    return json.loads(out.stdout)
+
+
+# ---- 1. the ADJ file is the artifact — every clause grounded, no authored-debt ----
+
+def test_library_is_pure_adj_and_fully_grounded() -> None:
+    text = ADJ.read_text()
+    assert "trust consensus" not in text, "GIWALL ships no authored-debt; ground or omit"
+    assert "[FLAG:" not in text
+    edge_count = len(EXPECTED)  # 4
+    assert text.count("    relate ") == edge_count
+    assert text.count("trust authoritative") == edge_count
+    assert text.count('\n        locator "') == edge_count
+    assert text.count('\n        source "') == edge_count
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("locator "):
+            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+    assert not (HERE / "gi_wall_edge_ground.py").exists()
+    assert not (HERE / "gi-wall-edge-grounding.json").exists()
+    assert not (HERE / "gi-wall-edge-manifest.json").exists()
+
+
+# ---- 2. the engine binds each tissue with an authoritative citation ----------------
+
+def test_engine_binds_every_tissue_with_authoritative_citation() -> None:
+    if not _cli_available():
+        return
+    result = _run(QUERY)
+    by_query = {r["query"]: r for r in result["recall"]}
+    for layer, tissue in EXPECTED.items():
+        q = f"{REL}({layer}, {VAR})"
+        r = by_query.get(q)
+        assert r is not None and not r["abstained"], f"{q} abstained — edge missing?"
+        bound = {}
+        for a in r["answers"]:
+            bound[a["bindings"][VAR]] = (a.get("citations") or [{}])[0]
+        assert set(bound) == {tissue}, f"{layer}: bound {set(bound)} != {{{tissue}}}"
+        cite = bound[tissue]
+        assert cite.get("trust") == "authoritative", f"{layer}/{tissue} not authoritative"
+        assert cite.get("source"), f"{layer}/{tissue} has no source span"
+        assert cite.get("locator", "").startswith("https://www.ncbi.nlm.nih.gov/")
+
+
+# ---- 3. an off-vocabulary structure abstains, never fabricates ----------------------
+
+def test_unknown_layer_abstains() -> None:
+    if not _cli_available():
+        return
+    import os
+    import tempfile
+    fd, path = tempfile.mkstemp(suffix=".adj", prefix=".giwall_q_", dir=HERE)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            # the lumen is the central cavity of the GI tract, NOT one of the four
+            # concentric wall layers this library models, so it is deliberately
+            # absent — the engine must abstain rather than fabricate a tissue.
+            fh.write(f'import "gi-wall-edges.adj"\n? {REL}(lumen, ${VAR})\n')
+        res = _run(Path(path))
+        r = res["recall"][0] if res["recall"] else None
+        assert r is not None and r["abstained"], "an ungrounded structure must abstain"
+    finally:
+        os.unlink(path)
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS  {t.__name__}")
+        except AssertionError as exc:
+            failed += 1
+            print(f"  FAIL  {t.__name__}: {exc}")
+    print(f"\ntest_gi_wall_recall: {len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())


### PR DESCRIPTION
## What

New **pure-ADJ recall domain** for MYCIN-2026: the characteristic tissue composing each of the four concentric layers of the gastrointestinal tract wall (mucosa, submucosa, muscularis externa, serosa) — a high-yield histology board table, grounded against primary NCBI StatPearls / Bookshelf pages.

The shipped artifact is `gi-wall-edges.adj` — the **SOLE source of truth**. No generator, no JSON, no manifest (a pure ADJ-only recall domain, like MUSCLEFIBER / GERMLAYER / ACIDBASE / HEARTVALVE). Each `relate composed_of(wall_layer, tissue)` clause carries its byte-provenance inline: a verbatim `source` span, an NCBI `locator`, and `trust authoritative`. Knowledge lives in ADJ; the native adj-lang engine answers a binding query that only `import`s the library.

## Edges (4)

Each defended by a **self-contained** NCBI sentence naming BOTH the full layer term AND the tissue, independently **double-fetched** for byte-stability:

| wall layer | → tissue | source |
|---|---|---|
| `mucosa` | `epithelium` | [NBK537103](https://www.ncbi.nlm.nih.gov/books/NBK537103/) |
| `submucosa` | `connective_tissue` | [NBK537103](https://www.ncbi.nlm.nih.gov/books/NBK537103/) |
| `muscularis_externa` | `smooth_muscle` | [NBK537103](https://www.ncbi.nlm.nih.gov/books/NBK537103/) |
| `serosa` | `mesothelium` | [NBK459366](https://www.ncbi.nlm.nih.gov/books/NBK459366/) |

Direction: **wall layer → the tissue it is composed of**. Each layer maps to one canonical tissue, so a query binds a single answer.

## Files

- `gi-wall-edges.adj` — the grounded knowledge graph (dictionary + rulebook)
- `gi-wall-recall.query.adj` — a worked binding query (the shape an LLM emits)
- `test_gi_wall_recall.py` — 3 tests: pure-ADJ/fully-grounded shape; engine binds every tissue with an authoritative citation; an off-vocabulary structure (`lumen` — the GI cavity, not a wall layer) **abstains** rather than fabricating.

## Verification

- Tests **3/3 pass** locally against the native `adj-lang-cli`.
- Security review **passed** (inert ADJ data + a list-argv subprocess harness; no injection / traversal / deserialization / SSRF vectors).
- No deferrals — all four spans cleared the self-contained full-term faithfulness bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)