### PR TITLE
feat(mycin-wbc): ADJ-only white-blood-cell type → function recall

### DIFF
--- a/code/specs/data/mycin-2026/recall/test_wbc_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_wbc_recall.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""test_wbc_recall.py — the ADJ-only white-blood-cell-type→function recall library
+(MYCIN-2026 WBC).
+
+A pure-ADJ recall domain (high-yield hematology/immunology board table): the primary
+immune function of each of the five circulating white blood cell types. `wbc-edges.adj`
+is the SOLE source of truth — facts + byte-provenance inline, no Python gate, no JSON,
+no manifest. This test pins the property that matters: the native adj-lang engine,
+given a query .adj that only `import`s the library and asks binding queries
+(`wbc-recall.query.adj` — the shape an LLM produces), binds the grounded function for
+each leukocyte, each carrying an AUTHORITATIVE citation with a real source span +
+locator. Knowledge lives in ADJ; the engine answers.
+
+If the native CLI isn't built (a Python-only CI lane), the engine-backed checks
+skip — the file-shape checks (every clause grounded, no authored-debt) still run.
+
+Run:  python3 test_wbc_recall.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ADJ = HERE / "wbc-edges.adj"
+QUERY = HERE / "wbc-recall.query.adj"
+CLI = HERE.parents[3] / "packages" / "rust" / "target" / "debug" / "adj-lang-cli"
+
+# Every grounded edge: white blood cell -> the function the library binds.
+EXPECTED = {
+    "neutrophil": "phagocytosis_of_bacteria",                                  # NBK507702
+    "eosinophil": "defense_against_parasites",                                 # NBK563148
+    "basophil": "synthesize_store_histamine",                                  # NBK535365
+    "monocyte": "differentiate_into_macrophages_and_dendritic_cells",          # NBK557618
+    "lymphocyte": "adaptive_immunity",                                         # NBK459471
+}
+REL = "has_function"
+VAR = "Function"
+
+
+def _cli_available() -> bool:
+    return CLI.exists()
+
+
+def _run(program: Path) -> dict:
+    out = subprocess.run([str(CLI), str(program)], capture_output=True, text=True,
+                         cwd=str(HERE), timeout=60)
+    assert out.returncode == 0, f"adj-lang-cli failed: {out.stderr}"
+    return json.loads(out.stdout)
+
+
+# ---- 1. the ADJ file is the artifact — every clause grounded, no authored-debt ----
+
+def test_library_is_pure_adj_and_fully_grounded() -> None:
+    text = ADJ.read_text()
+    assert "trust consensus" not in text, "WBC ships no authored-debt; ground or omit"
+    assert "[FLAG:" not in text
+    edge_count = len(EXPECTED)  # 5
+    assert text.count("    relate ") == edge_count
+    assert text.count("trust authoritative") == edge_count
+    assert text.count('\n        locator "') == edge_count
+    assert text.count('\n        source "') == edge_count
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("locator "):
+            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+    assert not (HERE / "wbc_edge_ground.py").exists()
+    assert not (HERE / "wbc-edge-grounding.json").exists()
+    assert not (HERE / "wbc-edge-manifest.json").exists()
+
+
+# ---- 2. the engine binds each function with an authoritative citation --------------
+
+def test_engine_binds_every_function_with_authoritative_citation() -> None:
+    if not _cli_available():
+        return
+    result = _run(QUERY)
+    by_query = {r["query"]: r for r in result["recall"]}
+    for cell, function in EXPECTED.items():
+        q = f"{REL}({cell}, {VAR})"
+        r = by_query.get(q)
+        assert r is not None and not r["abstained"], f"{q} abstained — edge missing?"
+        bound = {}
+        for a in r["answers"]:
+            bound[a["bindings"][VAR]] = (a.get("citations") or [{}])[0]
+        assert set(bound) == {function}, f"{cell}: bound {set(bound)} != {{{function}}}"
+        cite = bound[function]
+        assert cite.get("trust") == "authoritative", f"{cell}/{function} not authoritative"
+        assert cite.get("source"), f"{cell}/{function} has no source span"
+        assert cite.get("locator", "").startswith("https://www.ncbi.nlm.nih.gov/")
+
+
+# ---- 3. an off-vocabulary cell abstains, never fabricates ---------------------------
+
+def test_unknown_cell_abstains() -> None:
+    if not _cli_available():
+        return
+    import os
+    import tempfile
+    fd, path = tempfile.mkstemp(suffix=".adj", prefix=".wbc_q_", dir=HERE)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            # the erythrocyte (red blood cell) is a real blood cell but is NOT a
+            # white blood cell, so it is deliberately not in this library — the
+            # engine must abstain rather than fabricate an immune function.
+            fh.write(f'import "wbc-edges.adj"\n? {REL}(erythrocyte, ${VAR})\n')
+        res = _run(Path(path))
+        r = res["recall"][0] if res["recall"] else None
+        assert r is not None and r["abstained"], "an ungrounded cell must abstain"
+    finally:
+        os.unlink(path)
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS  {t.__name__}")
+        except AssertionError as exc:
+            failed += 1
+            print(f"  FAIL  {t.__name__}: {exc}")
+    print(f"\ntest_wbc_recall: {len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())

--- a/code/specs/data/mycin-2026/recall/wbc-edges.adj
+++ b/code/specs/data/mycin-2026/recall/wbc-edges.adj
@@ -1,0 +1,78 @@
+% ============================================================================
+% wbc-edges — the white-blood-cell type → primary function knowledge-graph
+% (MYCIN-2026 WBC).
+% ============================================================================
+% A high-yield hematology/immunology board table: each of the five circulating
+% white blood cell (leukocyte) types and its primary immune function. "What is the
+% main function of an eosinophil?" becomes the binding query
+%     ? has_function(eosinophil, $Function).
+%
+% Direction note: the relation is leukocyte -> its defining functional role
+% (`has_function`). Each cell here maps to ONE canonical function span, so a query
+% binds a single answer.
+%
+% Faithfulness note: each `relate` subject/object is bound to what the cited
+% sentence ACTUALLY names. The function object names the role the sentence states
+% (neutrophil "ingest, kill, and digest ... bacteria"; eosinophil "combat parasitic
+% infections"; basophil "synthesize and store histamine"; monocyte "differentiates
+% into ... macrophages and dendritic cells"; lymphocyte "antigen-specific immune
+% response"). Each cited sentence names the cell by its FULL term. Each span was
+% independently re-fetched and confirmed on two separate fetches of the same page
+% for byte-stability.
+%
+% This file is the SHIPPED ARTIFACT and the SOLE source of truth — no generator,
+% no JSON, no manifest (a pure ADJ-only recall domain, like GIWALL/MUSCLEFIBER/
+% GERMLAYER/ACIDBASE). Each fact is a `relate` clause whose byte-provenance lives
+% INLINE:
+%     source   — the VERBATIM span copied from the cited page (byte-stable: it
+%                appears character-for-character in the page's normalized text;
+%                every span here was independently re-fetched and confirmed).
+%     locator  — the URL the span was read from (NCBI StatPearls / Bookshelf).
+%     trust    — authoritative (a primary, citable reference).
+% An LLM (or a human) recalls a fact by writing a tiny query .adj that `import`s
+% this library and asks a binding query — see wbc-recall.query.adj.
+% Nothing here is asserted "from memory": every edge is defended by a span a
+% reader can re-fetch and check.
+% (See feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+dictionary wbc_vocab {
+    define white_blood_cell : entity   surface "white blood cell", "leukocyte"
+    define function         : entity   surface "immune function", "functional role"
+
+    define has_function : relation from white_blood_cell to function  % the primary immune function of this leukocyte
+}
+
+rulebook wbc_facts {
+    use wbc_vocab
+
+    % --- neutrophil -> phagocytosis of bacteria -----------------------------
+    relate has_function(neutrophil, phagocytosis_of_bacteria)
+        source "Neutrophils ingest, kill, and digest invading microorganisms such as fungi and bacteria."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK507702/"
+        trust authoritative
+
+    % --- eosinophil -> defense against parasites ----------------------------
+    relate has_function(eosinophil, defense_against_parasites)
+        source "Eosinophils combat parasitic infections by releasing their specific granules, of which the cationic protein, a major basic protein, has toxicity against helminth parasites."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK563148/"
+        trust authoritative
+
+    % --- basophil -> synthesize and store histamine -------------------------
+    relate has_function(basophil, synthesize_store_histamine)
+        source "Basophils can synthesize and store histamine and eosinophil chemotactic factors of anaphylaxis (ECF-A)."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK535365/"
+        trust authoritative
+
+    % --- monocyte -> differentiates into macrophages and dendritic cells ----
+    relate has_function(monocyte, differentiate_into_macrophages_and_dendritic_cells)
+        source "A monocyte is a type of white blood cell that differentiates into populations of macrophages and dendritic cells to regulate cellular homeostasis, especially in the setting of infection and inflammation."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK557618/"
+        trust authoritative
+
+    % --- lymphocyte -> adaptive (antigen-specific) immunity -----------------
+    relate has_function(lymphocyte, adaptive_immunity)
+        source "The T and B lymphocytes (T and B Cells) are involved in the acquired or antigen-specific immune response given that they are the only cells in the organism able to recognize and respond specifically to each antigenic epitope."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK459471/"
+        trust authoritative
+}

--- a/code/specs/data/mycin-2026/recall/wbc-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/wbc-recall.query.adj
@@ -1,0 +1,21 @@
+% ============================================================================
+% wbc-recall.query.adj — a worked recall query over the wbc library.
+% ============================================================================
+% The shape an LLM (or a student) produces to ANSWER a "what is the function of
+% white blood cell X?" question: it states no immunology fact — it only `import`s
+% the grounded library and asks binding queries. The native adj-lang engine
+% resolves each `?` against the imported `relate` edges and returns the binding +
+% the citing clause's source/locator/trust. All knowledge is in the library; none
+% is here.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli wbc-recall.query.adj
+% ============================================================================
+
+import "wbc-edges.adj"
+
+? has_function(neutrophil, $Function)   % expect phagocytosis_of_bacteria
+? has_function(eosinophil, $Function)   % expect defense_against_parasites
+? has_function(basophil, $Function)     % expect synthesize_store_histamine
+? has_function(monocyte, $Function)     % expect differentiate_into_macrophages_and_dendritic_cells
+? has_function(lymphocyte, $Function)   % expect adaptive_immunity


### PR DESCRIPTION
## What

New **pure-ADJ recall domain** for MYCIN-2026: the primary immune function of each of the five circulating white blood cell types — a high-yield hematology/immunology board table, grounded against primary NCBI StatPearls / Bookshelf pages.

The shipped artifact is `wbc-edges.adj` — the **SOLE source of truth**. No generator, no JSON, no manifest (a pure ADJ-only recall domain, like GIWALL / MUSCLEFIBER / GERMLAYER / ACIDBASE). Each `relate has_function(white_blood_cell, function)` clause carries its byte-provenance inline: a verbatim `source` span, an NCBI `locator`, and `trust authoritative`. Knowledge lives in ADJ; the native adj-lang engine answers a binding query that only `import`s the library.

## Edges (5)

Each defended by a **self-contained** NCBI sentence naming BOTH the full cell term AND its function, independently **double-fetched** for byte-stability:

| white blood cell | → function | source |
|---|---|---|
| `neutrophil` | `phagocytosis_of_bacteria` | [NBK507702](https://www.ncbi.nlm.nih.gov/books/NBK507702/) |
| `eosinophil` | `defense_against_parasites` | [NBK563148](https://www.ncbi.nlm.nih.gov/books/NBK563148/) |
| `basophil` | `synthesize_store_histamine` | [NBK535365](https://www.ncbi.nlm.nih.gov/books/NBK535365/) |
| `monocyte` | `differentiate_into_macrophages_and_dendritic_cells` | [NBK557618](https://www.ncbi.nlm.nih.gov/books/NBK557618/) |
| `lymphocyte` | `adaptive_immunity` | [NBK459471](https://www.ncbi.nlm.nih.gov/books/NBK459471/) |

Direction: **leukocyte → its defining functional role**. Each cell maps to one canonical function, so a query binds a single answer.

## Files

- `wbc-edges.adj` — the grounded knowledge graph (dictionary + rulebook)
- `wbc-recall.query.adj` — a worked binding query (the shape an LLM emits)
- `test_wbc_recall.py` — 3 tests: pure-ADJ/fully-grounded shape; engine binds every function with an authoritative citation; an off-vocabulary cell (`erythrocyte` — a red cell, not a leukocyte) **abstains** rather than fabricating.

## Verification

- Tests **3/3 pass** locally against the native `adj-lang-cli`.
- Security review **passed** (inert ADJ data + a list-argv subprocess harness; no injection / traversal / deserialization / SSRF vectors).
- No deferrals — all five spans cleared the self-contained full-term faithfulness bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)