### PR TITLE
feat(mycin-hypersensitivity): ADJ-only hypersensitivity type → mechanism recall

### DIFF
--- a/code/specs/data/mycin-2026/recall/hypersensitivity-edges.adj
+++ b/code/specs/data/mycin-2026/recall/hypersensitivity-edges.adj
@@ -1,0 +1,70 @@
+% ============================================================================
+% hypersensitivity-edges — the hypersensitivity type → immune mechanism
+% knowledge-graph (MYCIN-2026 HYPERSENSITIVITY).
+% ============================================================================
+% A high-yield immunology board table: the four Gell-Coombs hypersensitivity types
+% and the immune mechanism that mediates each. "What mediates a Type II
+% hypersensitivity reaction?" becomes the binding query
+%     ? mediated_by(type_ii_hypersensitivity, $Mechanism).
+%
+% Direction note: the relation is hypersensitivity type -> the immune mechanism
+% that mediates it (`mediated_by`). Each type here maps to ONE canonical mechanism
+% span, so a query binds a single answer.
+%
+% Faithfulness note: each `relate` subject/object is bound to what the cited
+% sentence ACTUALLY names. The mechanism object names the mediator the sentence
+% states (Type I "IgE-mediated"; Type II "IgG ... or IgM ... antibodies bind to
+% antigens on cell surfaces"; Type III "immune complex-mediated"; Type IV
+% "T-cell–mediated"). Each cited sentence names the type by its FULL term ("Type I
+% ... hypersensitivity", etc.). Each span was independently re-fetched and
+% confirmed on two separate fetches of the same page for byte-stability.
+%
+% This file is the SHIPPED ARTIFACT and the SOLE source of truth — no generator,
+% no JSON, no manifest (a pure ADJ-only recall domain, like WBC/GIWALL/MUSCLEFIBER/
+% GERMLAYER). Each fact is a `relate` clause whose byte-provenance lives INLINE:
+%     source   — the VERBATIM span copied from the cited page (byte-stable: it
+%                appears character-for-character in the page's normalized text;
+%                every span here was independently re-fetched and confirmed).
+%     locator  — the URL the span was read from (NCBI StatPearls / Bookshelf).
+%     trust    — authoritative (a primary, citable reference).
+% An LLM (or a human) recalls a fact by writing a tiny query .adj that `import`s
+% this library and asks a binding query — see hypersensitivity-recall.query.adj.
+% Nothing here is asserted "from memory": every edge is defended by a span a
+% reader can re-fetch and check.
+% (See feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+dictionary hypersensitivity_vocab {
+    define hypersensitivity_type : entity   surface "hypersensitivity type", "Gell-Coombs hypersensitivity type"
+    define mechanism             : entity   surface "immune mechanism", "mediating mechanism"
+
+    define mediated_by : relation from hypersensitivity_type to mechanism  % the immune mechanism that mediates this hypersensitivity type
+}
+
+rulebook hypersensitivity_facts {
+    use hypersensitivity_vocab
+
+    % --- Type I -> IgE-mediated ---------------------------------------------
+    relate mediated_by(type_i_hypersensitivity, ige_mediated)
+        source "Type I or immediate hypersensitivity: IgE-mediated mast cell and basophil degranulation leading to histamine and cytokine release as seen in anaphylaxis and atopic dermatitis."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK559122/"
+        trust authoritative
+
+    % --- Type II -> IgG/IgM bind cell-surface antigens ----------------------
+    relate mediated_by(type_ii_hypersensitivity, igg_igm_bind_cell_surface_antigens)
+        source "Type II hypersensitivity reactions are antibody-mediated immune processes in which immunoglobulin G (IgG) or immunoglobulin M (IgM) antibodies bind to antigens on cell surfaces or within the extracellular matrix."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK563264/"
+        trust authoritative
+
+    % --- Type III -> immune complex-mediated --------------------------------
+    relate mediated_by(type_iii_hypersensitivity, immune_complex_mediated)
+        source "Type III or immune complex-mediated hypersensitivity: Circulating antigen-antibody complexes deposit in tissues, activating complement and recruiting neutrophils, leading to inflammation and tissue injury, causing conditions such as serum sickness, systemic lupus erythematosus (SLE), post-streptococcal glomerulonephritis (PSGN), and hypersensitivity vasculitides such as IgA vasculitis or cryoglobulinemia."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK559122/"
+        trust authoritative
+
+    % --- Type IV -> T-cell-mediated (delayed) -------------------------------
+    relate mediated_by(type_iv_hypersensitivity, t_cell_mediated)
+        source "Type IV hypersensitivity, or delayed hypersensitivity reactions, are T-cell–mediated immune responses that typically manifest 48 to 72 hours after antigen exposure, although they can take weeks to manifest."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK562228/"
+        trust authoritative
+}

--- a/code/specs/data/mycin-2026/recall/hypersensitivity-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/hypersensitivity-recall.query.adj
@@ -1,0 +1,21 @@
+% ============================================================================
+% hypersensitivity-recall.query.adj — a worked recall query over the
+% hypersensitivity library.
+% ============================================================================
+% The shape an LLM (or a student) produces to ANSWER a "what mediates
+% hypersensitivity type X?" question: it states no immunology fact — it only
+% `import`s the grounded library and asks binding queries. The native adj-lang
+% engine resolves each `?` against the imported `relate` edges and returns the
+% binding + the citing clause's source/locator/trust. All knowledge is in the
+% library; none is here.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli hypersensitivity-recall.query.adj
+% ============================================================================
+
+import "hypersensitivity-edges.adj"
+
+? mediated_by(type_i_hypersensitivity, $Mechanism)     % expect ige_mediated
+? mediated_by(type_ii_hypersensitivity, $Mechanism)    % expect igg_igm_bind_cell_surface_antigens
+? mediated_by(type_iii_hypersensitivity, $Mechanism)   % expect immune_complex_mediated
+? mediated_by(type_iv_hypersensitivity, $Mechanism)    % expect t_cell_mediated

--- a/code/specs/data/mycin-2026/recall/test_hypersensitivity_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_hypersensitivity_recall.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""test_hypersensitivity_recall.py — the ADJ-only hypersensitivity-type→mechanism
+recall library (MYCIN-2026 HYPERSENSITIVITY).
+
+A pure-ADJ recall domain (high-yield immunology board table): the immune mechanism
+mediating each of the four Gell-Coombs hypersensitivity types. `hypersensitivity-edges.adj`
+is the SOLE source of truth — facts + byte-provenance inline, no Python gate, no JSON,
+no manifest. This test pins the property that matters: the native adj-lang engine,
+given a query .adj that only `import`s the library and asks binding queries
+(`hypersensitivity-recall.query.adj` — the shape an LLM produces), binds the grounded
+mechanism for each type, each carrying an AUTHORITATIVE citation with a real source
+span + locator. Knowledge lives in ADJ; the engine answers.
+
+If the native CLI isn't built (a Python-only CI lane), the engine-backed checks
+skip — the file-shape checks (every clause grounded, no authored-debt) still run.
+
+Run:  python3 test_hypersensitivity_recall.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ADJ = HERE / "hypersensitivity-edges.adj"
+QUERY = HERE / "hypersensitivity-recall.query.adj"
+CLI = HERE.parents[3] / "packages" / "rust" / "target" / "debug" / "adj-lang-cli"
+
+# Every grounded edge: hypersensitivity type -> the mechanism the library binds.
+EXPECTED = {
+    "type_i_hypersensitivity": "ige_mediated",                                 # NBK559122
+    "type_ii_hypersensitivity": "igg_igm_bind_cell_surface_antigens",          # NBK563264
+    "type_iii_hypersensitivity": "immune_complex_mediated",                    # NBK559122
+    "type_iv_hypersensitivity": "t_cell_mediated",                             # NBK562228
+}
+REL = "mediated_by"
+VAR = "Mechanism"
+
+
+def _cli_available() -> bool:
+    return CLI.exists()
+
+
+def _run(program: Path) -> dict:
+    out = subprocess.run([str(CLI), str(program)], capture_output=True, text=True,
+                         cwd=str(HERE), timeout=60)
+    assert out.returncode == 0, f"adj-lang-cli failed: {out.stderr}"
+    return json.loads(out.stdout)
+
+
+# ---- 1. the ADJ file is the artifact — every clause grounded, no authored-debt ----
+
+def test_library_is_pure_adj_and_fully_grounded() -> None:
+    text = ADJ.read_text()
+    assert "trust consensus" not in text, "HYPERSENSITIVITY ships no authored-debt; ground or omit"
+    assert "[FLAG:" not in text
+    edge_count = len(EXPECTED)  # 4
+    assert text.count("    relate ") == edge_count
+    assert text.count("trust authoritative") == edge_count
+    assert text.count('\n        locator "') == edge_count
+    assert text.count('\n        source "') == edge_count
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("locator "):
+            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+    assert not (HERE / "hypersensitivity_edge_ground.py").exists()
+    assert not (HERE / "hypersensitivity-edge-grounding.json").exists()
+    assert not (HERE / "hypersensitivity-edge-manifest.json").exists()
+
+
+# ---- 2. the engine binds each mechanism with an authoritative citation --------------
+
+def test_engine_binds_every_mechanism_with_authoritative_citation() -> None:
+    if not _cli_available():
+        return
+    result = _run(QUERY)
+    by_query = {r["query"]: r for r in result["recall"]}
+    for hs_type, mechanism in EXPECTED.items():
+        q = f"{REL}({hs_type}, {VAR})"
+        r = by_query.get(q)
+        assert r is not None and not r["abstained"], f"{q} abstained — edge missing?"
+        bound = {}
+        for a in r["answers"]:
+            bound[a["bindings"][VAR]] = (a.get("citations") or [{}])[0]
+        assert set(bound) == {mechanism}, f"{hs_type}: bound {set(bound)} != {{{mechanism}}}"
+        cite = bound[mechanism]
+        assert cite.get("trust") == "authoritative", f"{hs_type}/{mechanism} not authoritative"
+        assert cite.get("source"), f"{hs_type}/{mechanism} has no source span"
+        assert cite.get("locator", "").startswith("https://www.ncbi.nlm.nih.gov/")
+
+
+# ---- 3. an off-vocabulary type abstains, never fabricates ----------------------------
+
+def test_unknown_type_abstains() -> None:
+    if not _cli_available():
+        return
+    import os
+    import tempfile
+    fd, path = tempfile.mkstemp(suffix=".adj", prefix=".hypersensitivity_q_", dir=HERE)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            # "Type V hypersensitivity" is a sometimes-proposed extension but is NOT
+            # part of the classic four-type Gell-Coombs classification this library
+            # models, so it is deliberately absent — the engine must abstain rather
+            # than fabricate a mechanism.
+            fh.write(f'import "hypersensitivity-edges.adj"\n? {REL}(type_v_hypersensitivity, ${VAR})\n')
+        res = _run(Path(path))
+        r = res["recall"][0] if res["recall"] else None
+        assert r is not None and r["abstained"], "an ungrounded type must abstain"
+    finally:
+        os.unlink(path)
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS  {t.__name__}")
+        except AssertionError as exc:
+            failed += 1
+            print(f"  FAIL  {t.__name__}: {exc}")
+    print(f"\ntest_hypersensitivity_recall: {len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())


### PR DESCRIPTION
## What

New **pure-ADJ recall domain** for MYCIN-2026: the immune mechanism mediating each of the four Gell-Coombs hypersensitivity types — a high-yield immunology board table, grounded against primary NCBI StatPearls / Bookshelf pages. Distinct from the existing `immuno` domain (HLA / immunodeficiency genes).

The shipped artifact is `hypersensitivity-edges.adj` — the **SOLE source of truth**. No generator, no JSON, no manifest (a pure ADJ-only recall domain, like WBC / GIWALL / MUSCLEFIBER / GERMLAYER). Each `relate mediated_by(hypersensitivity_type, mechanism)` clause carries its byte-provenance inline: a verbatim `source` span, an NCBI `locator`, and `trust authoritative`. Knowledge lives in ADJ; the native adj-lang engine answers a binding query that only `import`s the library.

## Edges (4)

Each defended by a **self-contained** NCBI sentence naming BOTH the full type term AND its mechanism, independently **double-fetched** for byte-stability:

| hypersensitivity type | → mechanism | source |
|---|---|---|
| `type_i_hypersensitivity` | `ige_mediated` | [NBK559122](https://www.ncbi.nlm.nih.gov/books/NBK559122/) |
| `type_ii_hypersensitivity` | `igg_igm_bind_cell_surface_antigens` | [NBK563264](https://www.ncbi.nlm.nih.gov/books/NBK563264/) |
| `type_iii_hypersensitivity` | `immune_complex_mediated` | [NBK559122](https://www.ncbi.nlm.nih.gov/books/NBK559122/) |
| `type_iv_hypersensitivity` | `t_cell_mediated` | [NBK562228](https://www.ncbi.nlm.nih.gov/books/NBK562228/) |

Direction: **type → its mediating immune mechanism**. Each type maps to one canonical mechanism, so a query binds a single answer.

## Grounding notes

- **Type I re-grounded** on the Gell-Coombs overview page ([NBK559122](https://www.ncbi.nlm.nih.gov/books/NBK559122/)): the dedicated Type I page failed the self-contained bar — it names "Type I hypersensitivity" and "IgE" only in *separate* sentences, never combined verbatim. The overview page's parallel list entry ("Type I or immediate hypersensitivity: IgE-mediated…") cleared the bar.
- The **Type IV span preserves the source's Unicode en-dash** in "T-cell–mediated"; verified to round-trip through the engine.

## Files

- `hypersensitivity-edges.adj` — the grounded knowledge graph (dictionary + rulebook)
- `hypersensitivity-recall.query.adj` — a worked binding query (the shape an LLM emits)
- `test_hypersensitivity_recall.py` — 3 tests: pure-ADJ/fully-grounded shape; engine binds every mechanism with an authoritative citation; an off-vocabulary type (`type_v_hypersensitivity` — not in the classic 4-type classification) **abstains** rather than fabricating.

## Verification

- Tests **3/3 pass** locally against the native `adj-lang-cli`.
- Security review **passed** (inert ADJ data + a list-argv subprocess harness; no injection / traversal / deserialization / SSRF vectors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)