### PR TITLE
feat(mycin-recall): IG-ISOTYPE immunoglobulin-isotype→function recall library

### DIFF
--- a/code/specs/data/mycin-2026/recall/ig-isotype-edges.adj
+++ b/code/specs/data/mycin-2026/recall/ig-isotype-edges.adj
@@ -1,0 +1,73 @@
+% ============================================================================
+% ig-isotype-edges — the immunoglobulin isotype → function knowledge-graph
+% (MYCIN-2026 IG-ISOTYPE).
+% ============================================================================
+% A high-yield immunology board table: the five-isotype antibody family and the
+% defining function/role of each. "What is the function of IgM?" becomes the
+% binding query
+%     ? has_function(igm, $Function).
+%
+% Direction note: the relation is immunoglobulin isotype -> the defining function
+% the cited sentence states for it (`has_function`). Each isotype here maps to
+% ONE canonical function span, so a query binds a single answer.
+%
+% Faithfulness note: each `relate` subject/object is bound to what the cited
+% sentence ACTUALLY names. The function object names the role the sentence states
+% (IgG "the only immunoglobulin that crosses the placenta"; IgA "the dominant
+% antibody of immunity" in mucosal homeostasis; IgM "the first antibody secreted
+% by the adaptive immune system"; IgE "inducing immediate hypersensitivity
+% reactions"). Each cited sentence names the isotype by its term ("IgG", "IgA" /
+% "Immunoglobulin A (IgA)", "IgM", "IgE" / "immunoglobulin E (IgE)"). Each span
+% was independently re-fetched and confirmed on two separate fetches of the same
+% page for byte-stability.
+%
+% This file is the SHIPPED ARTIFACT and the SOLE source of truth — no generator,
+% no JSON, no manifest (a pure ADJ-only recall domain, like WBC/HYPERSENSITIVITY/
+% GIWALL/MUSCLEFIBER). Each fact is a `relate` clause whose byte-provenance lives
+% INLINE:
+%     source   — the VERBATIM span copied from the cited page (byte-stable: it
+%                appears character-for-character in the page's normalized text;
+%                every span here was independently re-fetched and confirmed).
+%     locator  — the URL the span was read from (NCBI StatPearls / Bookshelf).
+%     trust    — authoritative (a primary, citable reference).
+% An LLM (or a human) recalls a fact by writing a tiny query .adj that `import`s
+% this library and asks a binding query — see ig-isotype-recall.query.adj.
+% Nothing here is asserted "from memory": every edge is defended by a span a
+% reader can re-fetch and check.
+% (See feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+dictionary ig_isotype_vocab {
+    define immunoglobulin_isotype : entity   surface "immunoglobulin isotype", "antibody isotype"
+    define function               : entity   surface "function", "defining role"
+
+    define has_function : relation from immunoglobulin_isotype to function  % the defining function of this immunoglobulin isotype
+}
+
+rulebook ig_isotype_facts {
+    use ig_isotype_vocab
+
+    % --- IgG -> crosses the placenta ----------------------------------------
+    relate has_function(igg, crosses_placenta)
+        source "IgG is the only immunoglobulin that crosses the placenta as its Fc portion binds to the receptors present on the surface of the placenta, protecting the neonate from infectious diseases."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK513460/"
+        trust authoritative
+
+    % --- IgA -> dominant antibody of mucosal immunity -----------------------
+    relate has_function(iga, mucosal_secretory_immunity)
+        source "Immunoglobulin A (IgA), one of the five primary immunoglobulins, plays a pivotal role in mucosal homeostasis in the gastrointestinal, respiratory, and genitourinary tracts, functioning as the dominant antibody of immunity in this role."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK551516/"
+        trust authoritative
+
+    % --- IgM -> first antibody of the primary response ----------------------
+    relate has_function(igm, first_antibody_primary_response)
+        source "IgM is the first antibody secreted by the adaptive immune system in response to a foreign antigen."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK555995/"
+        trust authoritative
+
+    % --- IgE -> mediates immediate (type I) hypersensitivity ----------------
+    relate has_function(ige, mediates_type_i_hypersensitivity)
+        source "As one of the five designated immunoglobulin isotypes, immunoglobulin E (IgE) plays a significant role in atopic conditions by inducing immediate hypersensitivity reactions."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK482212/"
+        trust authoritative
+}

--- a/code/specs/data/mycin-2026/recall/ig-isotype-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/ig-isotype-recall.query.adj
@@ -1,0 +1,21 @@
+% ============================================================================
+% ig-isotype-recall.query.adj — a worked recall query over the
+% immunoglobulin-isotype library.
+% ============================================================================
+% The shape an LLM (or a student) produces to ANSWER a "what is the function of
+% immunoglobulin isotype X?" question: it states no immunology fact — it only
+% `import`s the grounded library and asks binding queries. The native adj-lang
+% engine resolves each `?` against the imported `relate` edges and returns the
+% binding + the citing clause's source/locator/trust. All knowledge is in the
+% library; none is here.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli ig-isotype-recall.query.adj
+% ============================================================================
+
+import "ig-isotype-edges.adj"
+
+? has_function(igg, $Function)     % expect crosses_placenta
+? has_function(iga, $Function)     % expect mucosal_secretory_immunity
+? has_function(igm, $Function)     % expect first_antibody_primary_response
+? has_function(ige, $Function)     % expect mediates_type_i_hypersensitivity

--- a/code/specs/data/mycin-2026/recall/test_ig_isotype_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_ig_isotype_recall.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""test_ig_isotype_recall.py — the ADJ-only immunoglobulin-isotype→function
+recall library (MYCIN-2026 IG-ISOTYPE).
+
+A pure-ADJ recall domain (high-yield immunology board table): the defining
+function of each of the major immunoglobulin isotypes. `ig-isotype-edges.adj`
+is the SOLE source of truth — facts + byte-provenance inline, no Python gate,
+no JSON, no manifest. This test pins the property that matters: the native
+adj-lang engine, given a query .adj that only `import`s the library and asks
+binding queries (`ig-isotype-recall.query.adj` — the shape an LLM produces),
+binds the grounded function for each isotype, each carrying an AUTHORITATIVE
+citation with a real source span + locator. Knowledge lives in ADJ; the engine
+answers.
+
+If the native CLI isn't built (a Python-only CI lane), the engine-backed checks
+skip — the file-shape checks (every clause grounded, no authored-debt) still run.
+
+Run:  python3 test_ig_isotype_recall.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ADJ = HERE / "ig-isotype-edges.adj"
+QUERY = HERE / "ig-isotype-recall.query.adj"
+CLI = HERE.parents[3] / "packages" / "rust" / "target" / "debug" / "adj-lang-cli"
+
+# Every grounded edge: immunoglobulin isotype -> the function the library binds.
+EXPECTED = {
+    "igg": "crosses_placenta",                        # NBK513460
+    "iga": "mucosal_secretory_immunity",              # NBK551516
+    "igm": "first_antibody_primary_response",         # NBK555995
+    "ige": "mediates_type_i_hypersensitivity",        # NBK482212
+}
+REL = "has_function"
+VAR = "Function"
+
+
+def _cli_available() -> bool:
+    return CLI.exists()
+
+
+def _run(program: Path) -> dict:
+    out = subprocess.run([str(CLI), str(program)], capture_output=True, text=True,
+                         cwd=str(HERE), timeout=60)
+    assert out.returncode == 0, f"adj-lang-cli failed: {out.stderr}"
+    return json.loads(out.stdout)
+
+
+# ---- 1. the ADJ file is the artifact — every clause grounded, no authored-debt ----
+
+def test_library_is_pure_adj_and_fully_grounded() -> None:
+    text = ADJ.read_text()
+    assert "trust consensus" not in text, "IG-ISOTYPE ships no authored-debt; ground or omit"
+    assert "[FLAG:" not in text
+    edge_count = len(EXPECTED)  # 4
+    assert text.count("    relate ") == edge_count
+    assert text.count("trust authoritative") == edge_count
+    assert text.count('\n        locator "') == edge_count
+    assert text.count('\n        source "') == edge_count
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("locator "):
+            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+    assert not (HERE / "ig_isotype_edge_ground.py").exists()
+    assert not (HERE / "ig-isotype-edge-grounding.json").exists()
+    assert not (HERE / "ig-isotype-edge-manifest.json").exists()
+
+
+# ---- 2. the engine binds each function with an authoritative citation ----------------
+
+def test_engine_binds_every_function_with_authoritative_citation() -> None:
+    if not _cli_available():
+        return
+    result = _run(QUERY)
+    by_query = {r["query"]: r for r in result["recall"]}
+    for isotype, function in EXPECTED.items():
+        q = f"{REL}({isotype}, {VAR})"
+        r = by_query.get(q)
+        assert r is not None and not r["abstained"], f"{q} abstained — edge missing?"
+        bound = {}
+        for a in r["answers"]:
+            bound[a["bindings"][VAR]] = (a.get("citations") or [{}])[0]
+        assert set(bound) == {function}, f"{isotype}: bound {set(bound)} != {{{function}}}"
+        cite = bound[function]
+        assert cite.get("trust") == "authoritative", f"{isotype}/{function} not authoritative"
+        assert cite.get("source"), f"{isotype}/{function} has no source span"
+        assert cite.get("locator", "").startswith("https://www.ncbi.nlm.nih.gov/")
+
+
+# ---- 3. an off-vocabulary isotype abstains, never fabricates --------------------------
+
+def test_unknown_isotype_abstains() -> None:
+    if not _cli_available():
+        return
+    import os
+    import tempfile
+    fd, path = tempfile.mkstemp(suffix=".adj", prefix=".ig_isotype_q_", dir=HERE)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            # "IgD" is a real isotype but its defining function is not modeled by
+            # this library (no self-contained grounded span was committed for it),
+            # so it is deliberately absent — the engine must abstain rather than
+            # fabricate a function.
+            fh.write(f'import "ig-isotype-edges.adj"\n? {REL}(igd, ${VAR})\n')
+        res = _run(Path(path))
+        r = res["recall"][0] if res["recall"] else None
+        assert r is not None and r["abstained"], "an ungrounded isotype must abstain"
+    finally:
+        os.unlink(path)
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS  {t.__name__}")
+        except AssertionError as exc:
+            failed += 1
+            print(f"  FAIL  {t.__name__}: {exc}")
+    print(f"\ntest_ig_isotype_recall: {len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())


### PR DESCRIPTION
## What

New **pure-ADJ** MYCIN-2026 recall domain: the defining function of each major **immunoglobulin isotype** (high-yield immunology board table). The shipped artifact is the ADJ library itself — facts + byte-provenance inline, **no Python gate, no JSON, no manifest** (same shape as WBC / HYPERSENSITIVITY / GIWALL / MUSCLEFIBER).

## Edges (4, single-answer)

`has_function(immunoglobulin_isotype, function)`:

| isotype | function | source |
|---|---|---|
| IgG | crosses_placenta | NBK513460 |
| IgA | mucosal_secretory_immunity | NBK551516 |
| IgM | first_antibody_primary_response | NBK555995 |
| IgE | mediates_type_i_hypersensitivity | NBK482212 |

Each `source` span is a **self-contained NCBI StatPearls/Bookshelf sentence** naming the isotype (full term or canonical abbreviation) AND its function in one sentence. Every span was **independently re-fetched twice** for byte-stability.

Abstain probe: `igd` — a real isotype whose defining function is not modeled here → the engine **abstains** rather than fabricate.

## Files

- `ig-isotype-edges.adj` — the grounded knowledge graph (sole source of truth)
- `ig-isotype-recall.query.adj` — worked binding query (the shape an LLM emits)
- `test_ig_isotype_recall.py` — 3-test scaffold (pure-ADJ shape; engine binds with authoritative citation; unknown isotype abstains)

## Verification

- Local: **3/3** tests pass against the native `adj-lang-cli`.
- Security review: **PASSED** (list-form subprocess, atomic `mkstemp`+`os.unlink`, `json.loads` only, no network/eval/secrets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)