### PR TITLE
Add mesh readiness handoff action evidence summary

### DIFF
--- a/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
+++ b/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
@@ -101,6 +101,9 @@ All notable changes to this package will be documented in this file.
 - Mesh release ticket handoff readiness-evidence review disposition-action
   readiness execution handoff action evidence rows that preserve action
   lineage, release evidence, and handoff readiness flags.
+- Mesh release ticket handoff readiness-evidence review disposition-action
+  readiness execution handoff action evidence summaries that combine evidence
+  rows with next repair, review, and release handoff pointers.
 - Virtual alias entries for product lines supported by another integration or
   standard.
 - Read-only D18D tool descriptors for listing/describing integrations and

--- a/code/packages/rust/smart-home-integration-catalog/README.md
+++ b/code/packages/rust/smart-home-integration-catalog/README.md
@@ -272,6 +272,9 @@ runtime and Chief of Staff tools a typed catalog for:
 - low-level mesh release ticket handoff readiness-evidence review
   disposition-action readiness execution handoff action evidence rows that
   preserve action lineage, release evidence, and handoff readiness flags
+- mesh release ticket handoff readiness-evidence review disposition-action
+  readiness execution handoff action evidence summaries that combine evidence
+  rows with next repair, review, and release handoff pointers
 - mesh release ticket handoff work-order guardrail readiness summaries that
   combine work-order readiness with guardrail counts and first actionable
   handoff work

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -22687,6 +22687,289 @@ impl
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationMeshReleaseTicketHandoffReadinessEvidenceReviewDispositionActionReadinessExecutionHandoffActionEvidenceSummary {
+    pub release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_summary:
+        Box<IntegrationMeshReleaseTicketHandoffReadinessEvidenceReviewDispositionActionReadinessExecutionHandoffActionSummary>,
+    pub total_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_rows:
+        usize,
+    pub total_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_rows:
+        usize,
+    pub required_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_rows:
+        usize,
+    pub release_blocking_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_rows:
+        usize,
+    pub repair_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_rows:
+        usize,
+    pub review_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_rows:
+        usize,
+    pub operator_required_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_rows:
+        usize,
+    pub dispatch_required_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_rows:
+        usize,
+    pub execution_required_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_rows:
+        usize,
+    pub lineage_complete_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_rows:
+        usize,
+    pub release_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_rows:
+        usize,
+    pub release_ready_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_rows:
+        usize,
+    pub first_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_row_key:
+        Option<String>,
+    pub first_required_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_row_key:
+        Option<String>,
+    pub first_repair_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_row_key:
+        Option<String>,
+    pub first_review_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_row_key:
+        Option<String>,
+    pub first_release_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_row_key:
+        Option<String>,
+    pub first_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_row_key:
+        Option<String>,
+    pub first_readiness_evidence_review_disposition_action_readiness_execution_handoff_row_key:
+        Option<String>,
+    pub first_readiness_evidence_review_disposition_action_readiness_execution_slot_key:
+        Option<String>,
+    pub first_readiness_evidence_review_disposition_action_key: Option<String>,
+    pub first_work_order_key: Option<String>,
+    pub first_ticket_key: Option<String>,
+    pub first_handoff_action_kind: Option<
+        IntegrationMeshReleaseTicketHandoffReadinessEvidenceReviewDispositionActionReadinessExecutionHandoffActionKind,
+    >,
+    pub first_handoff_lane: Option<IntegrationMeshReleaseDispatchTicketHandoffLane>,
+    pub first_check_kind: Option<IntegrationMeshReleaseReadinessCheckKind>,
+    pub first_check_status: Option<IntegrationMeshReleaseReadinessStatus>,
+    pub next_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_row_key:
+        Option<String>,
+    pub next_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_row_key:
+        Option<String>,
+    pub next_readiness_evidence_review_disposition_action_readiness_execution_handoff_row_key:
+        Option<String>,
+    pub next_readiness_evidence_review_disposition_action_readiness_execution_slot_key:
+        Option<String>,
+    pub next_readiness_evidence_review_disposition_action_key: Option<String>,
+    pub next_work_order_key: Option<String>,
+    pub next_ticket_key: Option<String>,
+    pub next_check_kind: Option<IntegrationMeshReleaseReadinessCheckKind>,
+    pub next_check_status: Option<IntegrationMeshReleaseReadinessStatus>,
+    pub next_handoff_lane: Option<IntegrationMeshReleaseDispatchTicketHandoffLane>,
+    pub release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_actions_ready:
+        bool,
+    pub release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_ready:
+        bool,
+}
+
+impl
+    IntegrationMeshReleaseTicketHandoffReadinessEvidenceReviewDispositionActionReadinessExecutionHandoffActionEvidenceSummary
+{
+    pub fn from_summaries<'a>(
+        release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_summary: IntegrationMeshReleaseTicketHandoffReadinessEvidenceReviewDispositionActionReadinessExecutionHandoffActionSummary,
+        evidence_rows: impl IntoIterator<
+            Item = &'a IntegrationMeshReleaseTicketHandoffReadinessEvidenceReviewDispositionActionReadinessExecutionHandoffActionEvidenceRow,
+        >,
+    ) -> Self {
+        let evidence_rows: Vec<&IntegrationMeshReleaseTicketHandoffReadinessEvidenceReviewDispositionActionReadinessExecutionHandoffActionEvidenceRow> =
+            evidence_rows.into_iter().collect();
+        let first_row = evidence_rows.first().copied();
+        let first_required_row = evidence_rows
+            .iter()
+            .copied()
+            .find(|row| row.requires_attention());
+        let first_repair_row = evidence_rows
+            .iter()
+            .copied()
+            .find(|row| row.is_repair_action());
+        let first_review_row = evidence_rows
+            .iter()
+            .copied()
+            .find(|row| row.is_review_action());
+        let first_release_handoff_row = evidence_rows
+            .iter()
+            .copied()
+            .find(|row| row.is_release_handoff_action());
+        let next_row = first_required_row;
+        let release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_ready =
+            evidence_rows.len()
+                == release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_summary
+                    .total_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_rows
+                && evidence_rows
+                    .iter()
+                    .all(|row| row.ready_for_release_handoff());
+
+        Self {
+            total_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_rows:
+                release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_summary
+                    .total_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_rows,
+            total_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_rows:
+                evidence_rows.len(),
+            required_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_rows:
+                evidence_rows.iter().filter(|row| row.requires_attention()).count(),
+            release_blocking_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_rows:
+                evidence_rows.iter().filter(|row| row.blocks_release()).count(),
+            repair_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_rows:
+                evidence_rows.iter().filter(|row| row.is_repair_action()).count(),
+            review_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_rows:
+                evidence_rows.iter().filter(|row| row.is_review_action()).count(),
+            operator_required_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_rows:
+                evidence_rows.iter().filter(|row| row.needs_operator()).count(),
+            dispatch_required_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_rows:
+                evidence_rows.iter().filter(|row| row.requires_dispatch()).count(),
+            execution_required_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_rows:
+                evidence_rows.iter().filter(|row| row.requires_execution()).count(),
+            lineage_complete_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_rows:
+                evidence_rows.iter().filter(|row| row.has_lineage()).count(),
+            release_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_rows:
+                evidence_rows
+                    .iter()
+                    .filter(|row| row.is_release_handoff_action())
+                    .count(),
+            release_ready_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_rows:
+                evidence_rows
+                    .iter()
+                    .filter(|row| row.ready_for_release_handoff())
+                    .count(),
+            first_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_row_key:
+                first_row.map(|row| row.handoff_action_evidence_row_key.clone()),
+            first_required_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_row_key:
+                first_required_row.map(|row| row.handoff_action_evidence_row_key.clone()),
+            first_repair_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_row_key:
+                first_repair_row.map(|row| row.handoff_action_evidence_row_key.clone()),
+            first_review_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_row_key:
+                first_review_row.map(|row| row.handoff_action_evidence_row_key.clone()),
+            first_release_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_row_key:
+                first_release_handoff_row.map(|row| row.handoff_action_evidence_row_key.clone()),
+            first_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_row_key:
+                first_row.map(|row| row.handoff_action_row_key.clone()),
+            first_readiness_evidence_review_disposition_action_readiness_execution_handoff_row_key:
+                first_row.map(|row| row.handoff_row_key.clone()),
+            first_readiness_evidence_review_disposition_action_readiness_execution_slot_key:
+                first_row.map(|row| {
+                    row.readiness_evidence_review_disposition_action_readiness_execution_slot_key
+                        .clone()
+                }),
+            first_readiness_evidence_review_disposition_action_key:
+                first_row.map(|row| row.readiness_evidence_review_disposition_action_key.clone()),
+            first_work_order_key: first_row.map(|row| row.work_order_key.clone()),
+            first_ticket_key: first_row.map(|row| row.ticket_key.clone()),
+            first_handoff_action_kind: first_row.map(|row| row.handoff_action_kind),
+            first_handoff_lane: first_row.map(|row| row.handoff_lane),
+            first_check_kind: first_row.map(|row| row.check_kind),
+            first_check_status: first_row.map(|row| row.status),
+            next_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_row_key:
+                next_row.map(|row| row.handoff_action_evidence_row_key.clone()),
+            next_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_row_key:
+                next_row.map(|row| row.handoff_action_row_key.clone()),
+            next_readiness_evidence_review_disposition_action_readiness_execution_handoff_row_key:
+                next_row.map(|row| row.handoff_row_key.clone()),
+            next_readiness_evidence_review_disposition_action_readiness_execution_slot_key:
+                next_row.map(|row| {
+                    row.readiness_evidence_review_disposition_action_readiness_execution_slot_key
+                        .clone()
+                }),
+            next_readiness_evidence_review_disposition_action_key:
+                next_row.map(|row| row.readiness_evidence_review_disposition_action_key.clone()),
+            next_work_order_key: next_row.map(|row| row.work_order_key.clone()),
+            next_ticket_key: next_row.map(|row| row.ticket_key.clone()),
+            next_check_kind: next_row.map(|row| row.check_kind),
+            next_check_status: next_row.map(|row| row.status),
+            next_handoff_lane: next_row.map(|row| row.handoff_lane),
+            release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_actions_ready:
+                release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_summary
+                    .ready_for_release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_actions(),
+            release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_ready,
+            release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_summary:
+                Box::new(
+                    release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_summary,
+                ),
+        }
+    }
+
+    pub fn has_handoff_action_evidence_rows(&self) -> bool {
+        self.total_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_rows > 0
+    }
+
+    pub fn ready_for_release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence(
+        &self,
+    ) -> bool {
+        self.release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_actions_ready
+            && self.release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_ready
+            && !self.requires_attention()
+    }
+
+    pub fn has_required_evidence(&self) -> bool {
+        self.required_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_rows
+            > 0
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.release_blocking_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_rows
+            > 0
+            || self.repair_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_rows
+                > 0
+            || self
+                .release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_summary
+                .has_blockers()
+    }
+
+    pub fn has_review_work(&self) -> bool {
+        self.review_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_rows
+            > 0
+            || self
+                .release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_summary
+                .has_review_work()
+    }
+
+    pub fn needs_operator(&self) -> bool {
+        self.operator_required_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_rows
+            > 0
+            || self
+                .release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_summary
+                .needs_operator()
+    }
+
+    pub fn requires_dispatch(&self) -> bool {
+        self.dispatch_required_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_rows
+            > 0
+            || self
+                .release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_summary
+                .requires_dispatch()
+    }
+
+    pub fn requires_execution(&self) -> bool {
+        self.execution_required_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_rows
+            > 0
+            || self
+                .release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_summary
+                .requires_execution()
+    }
+
+    pub fn has_lineage_gaps(&self) -> bool {
+        self.lineage_complete_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_rows
+            < self.total_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_rows
+            || self
+                .release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_summary
+                .has_lineage_gaps()
+    }
+
+    pub fn has_release_handoff_evidence(&self) -> bool {
+        self.release_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_rows
+            > 0
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.has_required_evidence()
+            || self.has_blockers()
+            || self.has_review_work()
+            || self.needs_operator()
+            || self.requires_dispatch()
+            || self.requires_execution()
+            || self.has_lineage_gaps()
+            || !self
+                .release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_ready
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IntegrationMeshReleaseTicketHandoffReadinessEvidenceReviewDispositionActionReadinessExecutionHandoffSummary {
     pub release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_slot_summary:
         Box<IntegrationMeshReleaseTicketHandoffGuardrailAuditClearanceActionEvidenceReviewDispositionActionSlotClearanceActionEvidenceReviewClearanceActionReadinessEvidenceReviewDispositionActionReadinessExecutionSlotSummary>,
@@ -47118,6 +47401,49 @@ pub fn mesh_release_ticket_handoff_readiness_evidence_review_disposition_action_
     )
 }
 
+pub fn mesh_release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_summary_for_catalog(
+    catalog: &[IntegrationCatalogEntry],
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> IntegrationMeshReleaseTicketHandoffReadinessEvidenceReviewDispositionActionReadinessExecutionHandoffActionEvidenceSummary
+{
+    let action_summary =
+        mesh_release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_summary_for_catalog(
+            catalog,
+            available_primitives,
+            allowed_capabilities,
+            enabled_integrations,
+        );
+    let evidence_rows =
+        mesh_release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_rows_for_catalog(
+            catalog,
+            available_primitives,
+            allowed_capabilities,
+            enabled_integrations,
+        );
+
+    IntegrationMeshReleaseTicketHandoffReadinessEvidenceReviewDispositionActionReadinessExecutionHandoffActionEvidenceSummary::from_summaries(
+        action_summary,
+        evidence_rows.iter(),
+    )
+}
+
+pub fn mesh_release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_summary(
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> IntegrationMeshReleaseTicketHandoffReadinessEvidenceReviewDispositionActionReadinessExecutionHandoffActionEvidenceSummary
+{
+    let catalog = first_party_catalog();
+    mesh_release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_summary_for_catalog(
+        &catalog,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    )
+}
+
 pub fn mesh_release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_summary_for_catalog(
     catalog: &[IntegrationCatalogEntry],
     available_primitives: &[PrimitiveFamily],
@@ -64571,6 +64897,222 @@ mod tests {
         assert!(evidence_rows
             .iter()
             .all(|row| row.has_release_handoff_evidence()));
+    }
+
+    #[test]
+    fn mesh_release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_summary_surfaces_attention(
+    ) {
+        let available_primitives = vec![
+            PrimitiveFamily::Usb,
+            PrimitiveFamily::SerialController,
+            PrimitiveFamily::Radio802154,
+            PrimitiveFamily::Supervision,
+        ];
+        let allowed_capabilities = vec![CapabilityId::trusted("smart_home.read")];
+        let summary =
+            mesh_release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_summary(
+                &available_primitives,
+                &allowed_capabilities,
+                &[],
+            );
+
+        assert_eq!(
+            summary
+                .total_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_rows,
+            5
+        );
+        assert_eq!(
+            summary
+                .total_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_rows,
+            5
+        );
+        assert_eq!(
+            summary
+                .required_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_rows,
+            5
+        );
+        assert_eq!(
+            summary
+                .release_blocking_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_rows,
+            3
+        );
+        assert_eq!(
+            summary
+                .repair_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_rows,
+            3
+        );
+        assert_eq!(
+            summary
+                .review_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_rows,
+            2
+        );
+        assert_eq!(
+            summary
+                .execution_required_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_rows,
+            5
+        );
+        assert_eq!(
+            summary
+                .release_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_rows,
+            0
+        );
+        assert_eq!(
+            summary.first_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_row_key,
+            Some(
+                "release-ticket-handoff-readiness-evidence-review-disposition-action-readiness-handoff-action-evidence-01-repair_handoff-substrate_actions"
+                    .to_string()
+            )
+        );
+        assert_eq!(
+            summary.first_required_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_row_key,
+            summary
+                .first_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_row_key
+        );
+        assert_eq!(
+            summary.first_repair_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_row_key,
+            summary
+                .first_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_row_key
+        );
+        assert_eq!(
+            summary.first_review_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_row_key,
+            Some(
+                "release-ticket-handoff-readiness-evidence-review-disposition-action-readiness-handoff-action-evidence-02-review_handoff-evidence_remediation"
+                    .to_string()
+            )
+        );
+        assert_eq!(
+            summary.next_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_row_key,
+            summary
+                .first_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_row_key
+        );
+        assert_eq!(
+            summary.next_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_row_key,
+            summary
+                .first_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_row_key
+        );
+        assert_eq!(
+            summary.next_readiness_evidence_review_disposition_action_readiness_execution_handoff_row_key,
+            summary
+                .first_readiness_evidence_review_disposition_action_readiness_execution_handoff_row_key
+        );
+        assert_eq!(summary.next_work_order_key, summary.first_work_order_key);
+        assert_eq!(summary.next_ticket_key, summary.first_ticket_key);
+        assert_eq!(
+            summary.next_handoff_lane,
+            Some(IntegrationMeshReleaseDispatchTicketHandoffLane::Repair)
+        );
+        assert!(!summary
+            .release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_actions_ready);
+        assert!(!summary
+            .release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_ready);
+        assert!(!summary
+            .ready_for_release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence());
+        assert!(summary.has_handoff_action_evidence_rows());
+        assert!(summary.has_required_evidence());
+        assert!(summary.has_blockers());
+        assert!(summary.has_review_work());
+        assert!(summary.needs_operator());
+        assert!(summary.requires_dispatch());
+        assert!(summary.requires_execution());
+        assert!(!summary.has_lineage_gaps());
+        assert!(!summary.has_release_handoff_evidence());
+        assert!(summary.requires_attention());
+    }
+
+    #[test]
+    fn mesh_release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_summary_marks_release_ready(
+    ) {
+        let catalog = vec![hue_entry()];
+        let allowed_capabilities = vec![
+            CapabilityId::trusted("smart_home.read"),
+            CapabilityId::trusted("smart_home.command.light"),
+            CapabilityId::trusted("smart_home.pair"),
+        ];
+        let summary =
+            mesh_release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_summary_for_catalog(
+                &catalog,
+                all_primitive_families(),
+                &allowed_capabilities,
+                &[],
+            );
+
+        assert_eq!(
+            summary
+                .total_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_rows,
+            5
+        );
+        assert_eq!(
+            summary
+                .required_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_rows,
+            0
+        );
+        assert_eq!(
+            summary
+                .release_blocking_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_rows,
+            0
+        );
+        assert_eq!(
+            summary
+                .repair_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_rows,
+            0
+        );
+        assert_eq!(
+            summary
+                .review_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_rows,
+            0
+        );
+        assert_eq!(
+            summary
+                .release_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_rows,
+            5
+        );
+        assert_eq!(
+            summary
+                .release_ready_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_rows,
+            5
+        );
+        assert_eq!(
+            summary.first_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_row_key,
+            Some(
+                "release-ticket-handoff-readiness-evidence-review-disposition-action-readiness-handoff-action-evidence-01-release_handoff-substrate_actions"
+                    .to_string()
+            )
+        );
+        assert_eq!(
+            summary.first_required_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_row_key,
+            None
+        );
+        assert_eq!(
+            summary.first_repair_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_row_key,
+            None
+        );
+        assert_eq!(
+            summary.first_release_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_row_key,
+            summary
+                .first_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_row_key
+        );
+        assert_eq!(
+            summary.next_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_row_key,
+            None
+        );
+        assert_eq!(summary.next_work_order_key, None);
+        assert_eq!(summary.next_ticket_key, None);
+        assert!(summary
+            .release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_actions_ready);
+        assert!(summary
+            .release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_ready);
+        assert!(summary
+            .ready_for_release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence());
+        assert!(summary.has_handoff_action_evidence_rows());
+        assert!(!summary.has_required_evidence());
+        assert!(!summary.has_blockers());
+        assert!(!summary.has_review_work());
+        assert!(!summary.needs_operator());
+        assert!(!summary.requires_dispatch());
+        assert!(!summary.requires_execution());
+        assert!(!summary.has_lineage_gaps());
+        assert!(summary.has_release_handoff_evidence());
+        assert!(!summary.requires_attention());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a handoff action evidence summary that rolls up evidence rows with first/next pointers and readiness flags
- expose catalog and first-party helper functions for the summary
- document the new smart-home mesh readiness surface

## Tests
- cargo test --manifest-path code/packages/rust/smart-home-integration-catalog/Cargo.toml handoff_action_evidence_summary -- --nocapture
- cargo test --manifest-path code/packages/rust/smart-home-integration-catalog/Cargo.toml
- git diff --check