### PR TITLE
feat(mycin-recall): COMPLEMENT complement-protein→function recall library

### DIFF
--- a/code/specs/data/mycin-2026/recall/complement-protein-edges.adj
+++ b/code/specs/data/mycin-2026/recall/complement-protein-edges.adj
@@ -1,0 +1,70 @@
+% ============================================================================
+% complement-protein-edges — the complement protein → function knowledge-graph
+% (MYCIN-2026 COMPLEMENT).
+% ============================================================================
+% A high-yield immunology board table: complement system components and the
+% effector function each performs. "What does C3b do?" becomes the binding query
+%     ? has_function(c3b, $Function).
+%
+% Direction note: the relation is complement component -> the effector function
+% the cited sentence states for it (`has_function`). Each component here maps to
+% ONE canonical function span, so a query binds a single answer.
+%
+% Faithfulness note: each `relate` subject/object is bound to what the cited
+% sentence ACTUALLY names. The function object names the role the sentence states
+% (C3b "opsonizing activity"; C5a "neutrophil chemotactic agent"; the membrane
+% attack complex "leads to cell death"; C3a "anaphylatoxin"). Each cited sentence
+% names the component by the term it uses ("C3b", "C5a", "membrane attack
+% complex", "C3a"). Each span was independently re-fetched and confirmed on two
+% separate fetches of the same page for byte-stability.
+%
+% This file is the SHIPPED ARTIFACT and the SOLE source of truth — no generator,
+% no JSON, no manifest (a pure ADJ-only recall domain, like WBC/IG-ISOTYPE/
+% HYPERSENSITIVITY/GIWALL). Each fact is a `relate` clause whose byte-provenance
+% lives INLINE:
+%     source   — the VERBATIM span copied from the cited page (byte-stable: it
+%                appears character-for-character in the page's normalized text;
+%                every span here was independently re-fetched and confirmed).
+%     locator  — the URL the span was read from (NCBI StatPearls / Bookshelf).
+%     trust    — authoritative (a primary, citable reference).
+% An LLM (or a human) recalls a fact by writing a tiny query .adj that `import`s
+% this library and asks a binding query — see complement-protein-recall.query.adj.
+% Nothing here is asserted "from memory": every edge is defended by a span a
+% reader can re-fetch and check.
+% (See feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+dictionary complement_protein_vocab {
+    define complement_protein : entity   surface "complement protein", "complement component"
+    define function           : entity   surface "function", "effector function"
+
+    define has_function : relation from complement_protein to function  % the effector function of this complement component
+}
+
+rulebook complement_protein_facts {
+    use complement_protein_vocab
+
+    % --- C3b -> opsonization ------------------------------------------------
+    relate has_function(c3b, opsonization)
+        source "C3b is best known for its opsonizing activity because when it coats the microbe, phagocytosis activity is increased."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK534215/"
+        trust authoritative
+
+    % --- C5a -> neutrophil chemotactic agent --------------------------------
+    relate has_function(c5a, neutrophil_chemotactic_agent)
+        source "C5a is also an anaphylatoxin, in addition to a neutrophil chemotactic agent."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK544229/"
+        trust authoritative
+
+    % --- membrane attack complex -> cell lysis ------------------------------
+    relate has_function(membrane_attack_complex, causes_cell_lysis)
+        source "One goal of the complement system is the formation of a membrane attack complex (MAC), which compromises the pathogen's cell wall, causing swelling that ultimately leads to cell death."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK544229/"
+        trust authoritative
+
+    % --- C3a -> anaphylatoxin -----------------------------------------------
+    relate has_function(c3a, anaphylatoxin)
+        source "The C3a fragment is an anaphylatoxin that mediates inflammation in two ways: it triggers histamine release from mast cells and increases vascular permeability."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK544229/"
+        trust authoritative
+}

--- a/code/specs/data/mycin-2026/recall/complement-protein-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/complement-protein-recall.query.adj
@@ -1,0 +1,21 @@
+% ============================================================================
+% complement-protein-recall.query.adj — a worked recall query over the
+% complement-protein library.
+% ============================================================================
+% The shape an LLM (or a student) produces to ANSWER a "what does complement
+% component X do?" question: it states no immunology fact — it only `import`s the
+% grounded library and asks binding queries. The native adj-lang engine resolves
+% each `?` against the imported `relate` edges and returns the binding + the
+% citing clause's source/locator/trust. All knowledge is in the library; none is
+% here.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli complement-protein-recall.query.adj
+% ============================================================================
+
+import "complement-protein-edges.adj"
+
+? has_function(c3b, $Function)                       % expect opsonization
+? has_function(c5a, $Function)                       % expect neutrophil_chemotactic_agent
+? has_function(membrane_attack_complex, $Function)   % expect causes_cell_lysis
+? has_function(c3a, $Function)                       % expect anaphylatoxin

--- a/code/specs/data/mycin-2026/recall/test_complement_protein_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_complement_protein_recall.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""test_complement_protein_recall.py — the ADJ-only complement-protein→function
+recall library (MYCIN-2026 COMPLEMENT).
+
+A pure-ADJ recall domain (high-yield immunology board table): the effector
+function of each major complement component. `complement-protein-edges.adj` is
+the SOLE source of truth — facts + byte-provenance inline, no Python gate, no
+JSON, no manifest. This test pins the property that matters: the native adj-lang
+engine, given a query .adj that only `import`s the library and asks binding
+queries (`complement-protein-recall.query.adj` — the shape an LLM produces),
+binds the grounded function for each component, each carrying an AUTHORITATIVE
+citation with a real source span + locator. Knowledge lives in ADJ; the engine
+answers.
+
+If the native CLI isn't built (a Python-only CI lane), the engine-backed checks
+skip — the file-shape checks (every clause grounded, no authored-debt) still run.
+
+Run:  python3 test_complement_protein_recall.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ADJ = HERE / "complement-protein-edges.adj"
+QUERY = HERE / "complement-protein-recall.query.adj"
+CLI = HERE.parents[3] / "packages" / "rust" / "target" / "debug" / "adj-lang-cli"
+
+# Every grounded edge: complement component -> the function the library binds.
+EXPECTED = {
+    "c3b": "opsonization",                            # NBK534215
+    "c5a": "neutrophil_chemotactic_agent",            # NBK544229
+    "membrane_attack_complex": "causes_cell_lysis",   # NBK544229
+    "c3a": "anaphylatoxin",                           # NBK544229
+}
+REL = "has_function"
+VAR = "Function"
+
+
+def _cli_available() -> bool:
+    return CLI.exists()
+
+
+def _run(program: Path) -> dict:
+    out = subprocess.run([str(CLI), str(program)], capture_output=True, text=True,
+                         cwd=str(HERE), timeout=60)
+    assert out.returncode == 0, f"adj-lang-cli failed: {out.stderr}"
+    return json.loads(out.stdout)
+
+
+# ---- 1. the ADJ file is the artifact — every clause grounded, no authored-debt ----
+
+def test_library_is_pure_adj_and_fully_grounded() -> None:
+    text = ADJ.read_text()
+    assert "trust consensus" not in text, "COMPLEMENT ships no authored-debt; ground or omit"
+    assert "[FLAG:" not in text
+    edge_count = len(EXPECTED)  # 4
+    assert text.count("    relate ") == edge_count
+    assert text.count("trust authoritative") == edge_count
+    assert text.count('\n        locator "') == edge_count
+    assert text.count('\n        source "') == edge_count
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("locator "):
+            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+    assert not (HERE / "complement_protein_edge_ground.py").exists()
+    assert not (HERE / "complement-protein-edge-grounding.json").exists()
+    assert not (HERE / "complement-protein-edge-manifest.json").exists()
+
+
+# ---- 2. the engine binds each function with an authoritative citation ----------------
+
+def test_engine_binds_every_function_with_authoritative_citation() -> None:
+    if not _cli_available():
+        return
+    result = _run(QUERY)
+    by_query = {r["query"]: r for r in result["recall"]}
+    for component, function in EXPECTED.items():
+        q = f"{REL}({component}, {VAR})"
+        r = by_query.get(q)
+        assert r is not None and not r["abstained"], f"{q} abstained — edge missing?"
+        bound = {}
+        for a in r["answers"]:
+            bound[a["bindings"][VAR]] = (a.get("citations") or [{}])[0]
+        assert set(bound) == {function}, f"{component}: bound {set(bound)} != {{{function}}}"
+        cite = bound[function]
+        assert cite.get("trust") == "authoritative", f"{component}/{function} not authoritative"
+        assert cite.get("source"), f"{component}/{function} has no source span"
+        assert cite.get("locator", "").startswith("https://www.ncbi.nlm.nih.gov/")
+
+
+# ---- 3. an off-vocabulary component abstains, never fabricates ------------------------
+
+def test_unknown_component_abstains() -> None:
+    if not _cli_available():
+        return
+    import os
+    import tempfile
+    fd, path = tempfile.mkstemp(suffix=".adj", prefix=".complement_q_", dir=HERE)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            # "C4b" is a real complement fragment, but its function is not modeled
+            # by this library (no self-contained grounded span was committed for
+            # it), so it is deliberately absent — the engine must abstain rather
+            # than fabricate a function.
+            fh.write(f'import "complement-protein-edges.adj"\n? {REL}(c4b, ${VAR})\n')
+        res = _run(Path(path))
+        r = res["recall"][0] if res["recall"] else None
+        assert r is not None and r["abstained"], "an ungrounded component must abstain"
+    finally:
+        os.unlink(path)
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS  {t.__name__}")
+        except AssertionError as exc:
+            failed += 1
+            print(f"  FAIL  {t.__name__}: {exc}")
+    print(f"\ntest_complement_protein_recall: {len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())


### PR DESCRIPTION
## What

New **pure-ADJ** MYCIN-2026 recall domain: the effector function of each major **complement component** (high-yield immunology board table). The shipped artifact is the ADJ library itself — facts + byte-provenance inline, **no Python gate, no JSON, no manifest** (same shape as IG-ISOTYPE / WBC / HYPERSENSITIVITY / GIWALL).

## Edges (4, single-answer)

`has_function(complement_protein, function)`:

| component | function | source |
|---|---|---|
| C3b | opsonization | NBK534215 |
| C5a | neutrophil_chemotactic_agent | NBK544229 |
| membrane attack complex (MAC) | causes_cell_lysis | NBK544229 |
| C3a | anaphylatoxin | NBK544229 |

Each `source` span is a **self-contained NCBI StatPearls/Bookshelf sentence** naming the component AND its function in one sentence (the MAC edge names the **full term** "membrane attack complex"). Every span was **independently re-fetched twice** for byte-stability.

Abstain probe: `c4b` — a real complement fragment whose function is not modeled here → the engine **abstains** rather than fabricate.

## Files

- `complement-protein-edges.adj` — the grounded knowledge graph (sole source of truth)
- `complement-protein-recall.query.adj` — worked binding query (the shape an LLM emits)
- `test_complement_protein_recall.py` — 3-test scaffold (pure-ADJ shape; engine binds with authoritative citation; unknown component abstains)

## Verification

- Local: **3/3** tests pass against the native `adj-lang-cli`.
- Security review: **PASSED** (list-form subprocess, atomic `mkstemp`+`os.unlink`, `json.loads` only, no network/eval/secrets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)