### PR TITLE
Add mesh readiness handoff action evidence review summary

### DIFF
--- a/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
+++ b/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
@@ -106,6 +106,9 @@ All notable changes to this package will be documented in this file.
   handoff-action evidence into blocker, operator, review, lineage, and
   release-ready outcomes.
 - Mesh release ticket handoff readiness-evidence review disposition-action
+  readiness execution handoff action evidence review summaries that combine
+  review rows with next blocker, review, lineage, and release-ready pointers.
+- Mesh release ticket handoff readiness-evidence review disposition-action
   readiness execution handoff action evidence summaries that combine evidence
   rows with next repair, review, and release handoff pointers.
 - Virtual alias entries for product lines supported by another integration or

--- a/code/packages/rust/smart-home-integration-catalog/README.md
+++ b/code/packages/rust/smart-home-integration-catalog/README.md
@@ -277,6 +277,9 @@ runtime and Chief of Staff tools a typed catalog for:
   that classify handoff-action evidence into blocker, operator, review,
   lineage, and release-ready outcomes
 - mesh release ticket handoff readiness-evidence review disposition-action
+  readiness execution handoff action evidence review summaries that combine
+  review rows with next blocker, review, lineage, and release-ready pointers
+- mesh release ticket handoff readiness-evidence review disposition-action
   readiness execution handoff action evidence summaries that combine evidence
   rows with next repair, review, and release handoff pointers
 - mesh release ticket handoff work-order guardrail readiness summaries that

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -23165,6 +23165,286 @@ impl
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationMeshReleaseTicketHandoffReadinessEvidenceReviewDispositionActionReadinessExecutionHandoffActionEvidenceReviewSummary {
+    pub release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_summary:
+        Box<IntegrationMeshReleaseTicketHandoffReadinessEvidenceReviewDispositionActionReadinessExecutionHandoffActionEvidenceSummary>,
+    pub total_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_rows:
+        usize,
+    pub total_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_rows:
+        usize,
+    pub required_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_rows:
+        usize,
+    pub blocker_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_rows:
+        usize,
+    pub operator_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_rows:
+        usize,
+    pub review_gate_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_rows:
+        usize,
+    pub lineage_gap_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_rows:
+        usize,
+    pub release_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_rows:
+        usize,
+    pub release_ready_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_rows:
+        usize,
+    pub first_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_row_key:
+        Option<String>,
+    pub first_required_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_row_key:
+        Option<String>,
+    pub first_blocker_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_row_key:
+        Option<String>,
+    pub first_operator_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_row_key:
+        Option<String>,
+    pub first_review_gate_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_row_key:
+        Option<String>,
+    pub first_lineage_gap_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_row_key:
+        Option<String>,
+    pub first_release_ready_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_row_key:
+        Option<String>,
+    pub first_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_row_key:
+        Option<String>,
+    pub first_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_row_key:
+        Option<String>,
+    pub first_readiness_evidence_review_disposition_action_readiness_execution_handoff_row_key:
+        Option<String>,
+    pub first_readiness_evidence_review_disposition_action_readiness_execution_slot_key:
+        Option<String>,
+    pub first_readiness_evidence_review_disposition_action_key: Option<String>,
+    pub first_work_order_key: Option<String>,
+    pub first_ticket_key: Option<String>,
+    pub first_handoff_action_kind: Option<
+        IntegrationMeshReleaseTicketHandoffReadinessEvidenceReviewDispositionActionReadinessExecutionHandoffActionKind,
+    >,
+    pub first_handoff_lane: Option<IntegrationMeshReleaseDispatchTicketHandoffLane>,
+    pub first_check_kind: Option<IntegrationMeshReleaseReadinessCheckKind>,
+    pub first_check_status: Option<IntegrationMeshReleaseReadinessStatus>,
+    pub next_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_row_key:
+        Option<String>,
+    pub next_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_row_key:
+        Option<String>,
+    pub next_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_row_key:
+        Option<String>,
+    pub next_readiness_evidence_review_disposition_action_readiness_execution_handoff_row_key:
+        Option<String>,
+    pub next_readiness_evidence_review_disposition_action_readiness_execution_slot_key:
+        Option<String>,
+    pub next_readiness_evidence_review_disposition_action_key: Option<String>,
+    pub next_work_order_key: Option<String>,
+    pub next_ticket_key: Option<String>,
+    pub next_check_kind: Option<IntegrationMeshReleaseReadinessCheckKind>,
+    pub next_check_status: Option<IntegrationMeshReleaseReadinessStatus>,
+    pub next_handoff_lane: Option<IntegrationMeshReleaseDispatchTicketHandoffLane>,
+    pub release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_ready:
+        bool,
+    pub release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_reviews_ready:
+        bool,
+}
+
+impl
+    IntegrationMeshReleaseTicketHandoffReadinessEvidenceReviewDispositionActionReadinessExecutionHandoffActionEvidenceReviewSummary
+{
+    pub fn from_summaries<'a>(
+        release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_summary: IntegrationMeshReleaseTicketHandoffReadinessEvidenceReviewDispositionActionReadinessExecutionHandoffActionEvidenceSummary,
+        review_rows: impl IntoIterator<
+            Item = &'a IntegrationMeshReleaseTicketHandoffReadinessEvidenceReviewDispositionActionReadinessExecutionHandoffActionEvidenceReviewRow,
+        >,
+    ) -> Self {
+        let review_rows: Vec<&IntegrationMeshReleaseTicketHandoffReadinessEvidenceReviewDispositionActionReadinessExecutionHandoffActionEvidenceReviewRow> =
+            review_rows.into_iter().collect();
+        let first_row = review_rows.first().copied();
+        let first_required_row = review_rows
+            .iter()
+            .copied()
+            .find(|row| row.requires_attention());
+        let first_blocker_row = review_rows
+            .iter()
+            .copied()
+            .find(|row| row.is_blocker_review());
+        let first_operator_row = review_rows
+            .iter()
+            .copied()
+            .find(|row| row.is_operator_review());
+        let first_review_gate_row = review_rows
+            .iter()
+            .copied()
+            .find(|row| row.is_review_gate());
+        let first_lineage_gap_row = review_rows
+            .iter()
+            .copied()
+            .find(|row| row.is_lineage_gap());
+        let first_release_ready_row = review_rows
+            .iter()
+            .copied()
+            .find(|row| row.is_release_ready_review());
+        let next_row = first_required_row;
+        let release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_reviews_ready =
+            review_rows.len()
+                == release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_summary
+                    .total_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_rows
+                && review_rows
+                    .iter()
+                    .all(|row| row.ready_to_release_handoff());
+
+        Self {
+            total_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_rows:
+                release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_summary
+                    .total_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_rows,
+            total_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_rows:
+                review_rows.len(),
+            required_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_rows:
+                review_rows.iter().filter(|row| row.requires_attention()).count(),
+            blocker_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_rows:
+                review_rows.iter().filter(|row| row.is_blocker_review()).count(),
+            operator_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_rows:
+                review_rows.iter().filter(|row| row.is_operator_review()).count(),
+            review_gate_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_rows:
+                review_rows.iter().filter(|row| row.is_review_gate()).count(),
+            lineage_gap_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_rows:
+                review_rows.iter().filter(|row| row.is_lineage_gap()).count(),
+            release_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_rows:
+                review_rows
+                    .iter()
+                    .filter(|row| row.is_release_handoff_evidence())
+                    .count(),
+            release_ready_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_rows:
+                review_rows
+                    .iter()
+                    .filter(|row| row.is_release_ready_review())
+                    .count(),
+            first_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_row_key:
+                first_row.map(|row| row.handoff_action_evidence_review_row_key.clone()),
+            first_required_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_row_key:
+                first_required_row.map(|row| row.handoff_action_evidence_review_row_key.clone()),
+            first_blocker_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_row_key:
+                first_blocker_row.map(|row| row.handoff_action_evidence_review_row_key.clone()),
+            first_operator_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_row_key:
+                first_operator_row.map(|row| row.handoff_action_evidence_review_row_key.clone()),
+            first_review_gate_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_row_key:
+                first_review_gate_row.map(|row| row.handoff_action_evidence_review_row_key.clone()),
+            first_lineage_gap_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_row_key:
+                first_lineage_gap_row.map(|row| row.handoff_action_evidence_review_row_key.clone()),
+            first_release_ready_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_row_key:
+                first_release_ready_row.map(|row| row.handoff_action_evidence_review_row_key.clone()),
+            first_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_row_key:
+                first_row.map(|row| row.handoff_action_evidence_row_key.clone()),
+            first_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_row_key:
+                first_row.map(|row| row.handoff_action_row_key.clone()),
+            first_readiness_evidence_review_disposition_action_readiness_execution_handoff_row_key:
+                first_row.map(|row| row.handoff_row_key.clone()),
+            first_readiness_evidence_review_disposition_action_readiness_execution_slot_key:
+                first_row.map(|row| {
+                    row.readiness_evidence_review_disposition_action_readiness_execution_slot_key
+                        .clone()
+                }),
+            first_readiness_evidence_review_disposition_action_key:
+                first_row.map(|row| row.readiness_evidence_review_disposition_action_key.clone()),
+            first_work_order_key: first_row.map(|row| row.work_order_key.clone()),
+            first_ticket_key: first_row.map(|row| row.ticket_key.clone()),
+            first_handoff_action_kind: first_row.map(|row| row.handoff_action_kind),
+            first_handoff_lane: first_row.map(|row| row.handoff_lane),
+            first_check_kind: first_row.map(|row| row.check_kind),
+            first_check_status: first_row.map(|row| row.status),
+            next_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_row_key:
+                next_row.map(|row| row.handoff_action_evidence_review_row_key.clone()),
+            next_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_row_key:
+                next_row.map(|row| row.handoff_action_evidence_row_key.clone()),
+            next_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_row_key:
+                next_row.map(|row| row.handoff_action_row_key.clone()),
+            next_readiness_evidence_review_disposition_action_readiness_execution_handoff_row_key:
+                next_row.map(|row| row.handoff_row_key.clone()),
+            next_readiness_evidence_review_disposition_action_readiness_execution_slot_key:
+                next_row.map(|row| {
+                    row.readiness_evidence_review_disposition_action_readiness_execution_slot_key
+                        .clone()
+                }),
+            next_readiness_evidence_review_disposition_action_key:
+                next_row.map(|row| row.readiness_evidence_review_disposition_action_key.clone()),
+            next_work_order_key: next_row.map(|row| row.work_order_key.clone()),
+            next_ticket_key: next_row.map(|row| row.ticket_key.clone()),
+            next_check_kind: next_row.map(|row| row.check_kind),
+            next_check_status: next_row.map(|row| row.status),
+            next_handoff_lane: next_row.map(|row| row.handoff_lane),
+            release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_ready:
+                release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_summary
+                    .ready_for_release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence(),
+            release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_reviews_ready,
+            release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_summary:
+                Box::new(
+                    release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_summary,
+                ),
+        }
+    }
+
+    pub fn has_handoff_action_evidence_review_rows(&self) -> bool {
+        self.total_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_rows > 0
+    }
+
+    pub fn ready_for_release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_reviews(
+        &self,
+    ) -> bool {
+        self.release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_ready
+            && self.release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_reviews_ready
+            && !self.requires_attention()
+    }
+
+    pub fn has_required_reviews(&self) -> bool {
+        self.required_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_rows
+            > 0
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.blocker_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_rows
+            > 0
+            || self
+                .release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_summary
+                .has_blockers()
+    }
+
+    pub fn needs_operator(&self) -> bool {
+        self.operator_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_rows
+            > 0
+            || self
+                .release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_summary
+                .needs_operator()
+    }
+
+    pub fn has_review_work(&self) -> bool {
+        self.review_gate_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_rows
+            > 0
+            || self
+                .release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_summary
+                .has_review_work()
+    }
+
+    pub fn has_lineage_gaps(&self) -> bool {
+        self.lineage_gap_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_rows
+            > 0
+            || self
+                .release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_summary
+                .has_lineage_gaps()
+    }
+
+    pub fn has_release_handoff_reviews(&self) -> bool {
+        self.release_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_rows
+            > 0
+    }
+
+    pub fn has_release_ready_reviews(&self) -> bool {
+        self.release_ready_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_rows
+            > 0
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.has_required_reviews()
+            || self.has_blockers()
+            || self.needs_operator()
+            || self.has_review_work()
+            || self.has_lineage_gaps()
+            || !self
+                .release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_reviews_ready
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IntegrationMeshReleaseTicketHandoffReadinessEvidenceReviewDispositionActionReadinessExecutionHandoffSummary {
     pub release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_slot_summary:
         Box<IntegrationMeshReleaseTicketHandoffGuardrailAuditClearanceActionEvidenceReviewDispositionActionSlotClearanceActionEvidenceReviewClearanceActionReadinessEvidenceReviewDispositionActionReadinessExecutionSlotSummary>,
@@ -47691,6 +47971,49 @@ pub fn mesh_release_ticket_handoff_readiness_evidence_review_disposition_action_
     )
 }
 
+pub fn mesh_release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_summary_for_catalog(
+    catalog: &[IntegrationCatalogEntry],
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> IntegrationMeshReleaseTicketHandoffReadinessEvidenceReviewDispositionActionReadinessExecutionHandoffActionEvidenceReviewSummary
+{
+    let evidence_summary =
+        mesh_release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_summary_for_catalog(
+            catalog,
+            available_primitives,
+            allowed_capabilities,
+            enabled_integrations,
+        );
+    let review_rows =
+        mesh_release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_rows_for_catalog(
+            catalog,
+            available_primitives,
+            allowed_capabilities,
+            enabled_integrations,
+        );
+
+    IntegrationMeshReleaseTicketHandoffReadinessEvidenceReviewDispositionActionReadinessExecutionHandoffActionEvidenceReviewSummary::from_summaries(
+        evidence_summary,
+        review_rows.iter(),
+    )
+}
+
+pub fn mesh_release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_summary(
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> IntegrationMeshReleaseTicketHandoffReadinessEvidenceReviewDispositionActionReadinessExecutionHandoffActionEvidenceReviewSummary
+{
+    let catalog = first_party_catalog();
+    mesh_release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_summary_for_catalog(
+        &catalog,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    )
+}
+
 pub fn mesh_release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_summary_for_catalog(
     catalog: &[IntegrationCatalogEntry],
     available_primitives: &[PrimitiveFamily],
@@ -65289,6 +65612,220 @@ mod tests {
             review_rows[0].handoff_action_kind,
             IntegrationMeshReleaseTicketHandoffReadinessEvidenceReviewDispositionActionReadinessExecutionHandoffActionKind::ReleaseHandoff
         );
+    }
+
+    #[test]
+    fn mesh_release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_summary_surfaces_attention(
+    ) {
+        let available_primitives = vec![
+            PrimitiveFamily::Usb,
+            PrimitiveFamily::SerialController,
+            PrimitiveFamily::Radio802154,
+            PrimitiveFamily::Supervision,
+        ];
+        let allowed_capabilities = vec![CapabilityId::trusted("smart_home.read")];
+        let summary =
+            mesh_release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_summary(
+                &available_primitives,
+                &allowed_capabilities,
+                &[],
+            );
+
+        assert_eq!(
+            summary
+                .total_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_rows,
+            5
+        );
+        assert_eq!(
+            summary
+                .total_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_rows,
+            5
+        );
+        assert_eq!(
+            summary
+                .required_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_rows,
+            5
+        );
+        assert_eq!(
+            summary
+                .blocker_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_rows,
+            3
+        );
+        assert_eq!(
+            summary
+                .operator_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_rows,
+            0
+        );
+        assert_eq!(
+            summary
+                .review_gate_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_rows,
+            2
+        );
+        assert_eq!(
+            summary
+                .lineage_gap_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_rows,
+            0
+        );
+        assert_eq!(
+            summary
+                .release_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_rows,
+            0
+        );
+        assert_eq!(
+            summary
+                .release_ready_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_rows,
+            0
+        );
+        assert_eq!(
+            summary.first_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_row_key,
+            Some(
+                "release-ticket-handoff-readiness-evidence-review-disposition-action-readiness-handoff-action-evidence-review-01-blocker_review-substrate_actions"
+                    .to_string()
+            )
+        );
+        assert_eq!(
+            summary.first_required_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_row_key,
+            summary
+                .first_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_row_key
+        );
+        assert_eq!(
+            summary.first_blocker_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_row_key,
+            summary
+                .first_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_row_key
+        );
+        assert_eq!(
+            summary.first_review_gate_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_row_key,
+            Some(
+                "release-ticket-handoff-readiness-evidence-review-disposition-action-readiness-handoff-action-evidence-review-02-review_gate-evidence_remediation"
+                    .to_string()
+            )
+        );
+        assert_eq!(
+            summary.first_operator_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_row_key,
+            None
+        );
+        assert_eq!(
+            summary.next_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_row_key,
+            summary
+                .first_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_row_key
+        );
+        assert_eq!(
+            summary.next_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_row_key,
+            summary
+                .first_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_row_key
+        );
+        assert_eq!(summary.next_work_order_key, summary.first_work_order_key);
+        assert_eq!(summary.next_ticket_key, summary.first_ticket_key);
+        assert_eq!(
+            summary.next_handoff_lane,
+            Some(IntegrationMeshReleaseDispatchTicketHandoffLane::Repair)
+        );
+        assert!(!summary
+            .release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_ready);
+        assert!(!summary
+            .release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_reviews_ready);
+        assert!(!summary
+            .ready_for_release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_reviews());
+        assert!(summary.has_handoff_action_evidence_review_rows());
+        assert!(summary.has_required_reviews());
+        assert!(summary.has_blockers());
+        assert!(summary.has_review_work());
+        assert!(summary.needs_operator());
+        assert!(!summary.has_lineage_gaps());
+        assert!(!summary.has_release_handoff_reviews());
+        assert!(!summary.has_release_ready_reviews());
+        assert!(summary.requires_attention());
+    }
+
+    #[test]
+    fn mesh_release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_summary_marks_release_ready(
+    ) {
+        let catalog = vec![hue_entry()];
+        let allowed_capabilities = vec![
+            CapabilityId::trusted("smart_home.read"),
+            CapabilityId::trusted("smart_home.command.light"),
+            CapabilityId::trusted("smart_home.pair"),
+        ];
+        let summary =
+            mesh_release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_summary_for_catalog(
+                &catalog,
+                all_primitive_families(),
+                &allowed_capabilities,
+                &[],
+            );
+
+        assert_eq!(
+            summary
+                .total_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_rows,
+            5
+        );
+        assert_eq!(
+            summary
+                .required_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_rows,
+            0
+        );
+        assert_eq!(
+            summary
+                .blocker_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_rows,
+            0
+        );
+        assert_eq!(
+            summary
+                .operator_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_rows,
+            0
+        );
+        assert_eq!(
+            summary
+                .review_gate_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_rows,
+            0
+        );
+        assert_eq!(
+            summary
+                .release_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_rows,
+            5
+        );
+        assert_eq!(
+            summary
+                .release_ready_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_rows,
+            5
+        );
+        assert_eq!(
+            summary.first_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_row_key,
+            Some(
+                "release-ticket-handoff-readiness-evidence-review-disposition-action-readiness-handoff-action-evidence-review-01-release_ready-substrate_actions"
+                    .to_string()
+            )
+        );
+        assert_eq!(
+            summary.first_required_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_row_key,
+            None
+        );
+        assert_eq!(
+            summary.first_release_ready_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_row_key,
+            summary
+                .first_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_row_key
+        );
+        assert_eq!(
+            summary.next_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_row_key,
+            None
+        );
+        assert_eq!(summary.next_work_order_key, None);
+        assert_eq!(summary.next_ticket_key, None);
+        assert!(summary
+            .release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_ready);
+        assert!(summary
+            .release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_reviews_ready);
+        assert!(summary
+            .ready_for_release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_reviews());
+        assert!(summary.has_handoff_action_evidence_review_rows());
+        assert!(!summary.has_required_reviews());
+        assert!(!summary.has_blockers());
+        assert!(!summary.needs_operator());
+        assert!(!summary.has_review_work());
+        assert!(!summary.has_lineage_gaps());
+        assert!(summary.has_release_handoff_reviews());
+        assert!(summary.has_release_ready_reviews());
+        assert!(!summary.requires_attention());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a handoff action evidence review summary that rolls up review rows with first/next review pointers and readiness flags
- expose catalog and first-party helper functions for the summary
- document the new smart-home mesh readiness summary surface

## Tests
- cargo test --manifest-path code/packages/rust/smart-home-integration-catalog/Cargo.toml handoff_action_evidence_review_summary -- --nocapture
- cargo test --manifest-path code/packages/rust/smart-home-integration-catalog/Cargo.toml
- git diff --check