### PR TITLE
Add smart-home runtime maintenance work-order tools

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
@@ -265,6 +265,10 @@ All notable changes to this package will be documented in this file.
   `smart_home.get_runtime_maintenance_ticket_summary` over the D23 runtime read
   facade so Chief of Staff jobs can inspect ticket-ready maintenance queues
   without owning platform mutation logic.
+- Added `smart_home.list_runtime_maintenance_work_orders` and
+  `smart_home.get_runtime_maintenance_work_order_summary` over the D23 runtime
+  read facade so Chief of Staff jobs can inspect execution work-order handoffs
+  without owning platform mutation logic.
 - Added `smart_home.list_workers` and
   `smart_home.get_worker_heartbeat_schedule` over the D23 runtime read facade
   so Chief of Staff jobs can inspect supervised bridge workers and heartbeat

--- a/code/packages/rust/chief-of-staff-smart-home-tools/README.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/README.md
@@ -93,7 +93,7 @@ Chief of Staff job/session/agent
   -> runtime snapshot, desired-state, and pairing-session inventory reads
   -> desired-state target set/clear through runtime authorization
   -> non-mutating supervision plan previews
-  -> supervision remediation and runtime maintenance-window/action/plan/ticket reads
+  -> supervision remediation and runtime maintenance-window/action/plan/ticket/work-order reads
   -> authorized desired-state reconciliation and supervision ticks
   -> supervised worker inventory and heartbeat schedule reads
   -> device command acceptance
@@ -280,6 +280,8 @@ Chief of Staff job/session/agent
 - `smart_home.get_runtime_maintenance_plan_summary`
 - `smart_home.list_runtime_maintenance_tickets`
 - `smart_home.get_runtime_maintenance_ticket_summary`
+- `smart_home.list_runtime_maintenance_work_orders`
+- `smart_home.get_runtime_maintenance_work_order_summary`
 - `smart_home.reconcile_desired_states`
 - `smart_home.run_supervision_tick`
 - `smart_home.pair_bridge`

--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -336,6 +336,10 @@ pub const SMART_HOME_LIST_RUNTIME_MAINTENANCE_TICKETS_TOOL_ID: &str =
     "smart_home.list_runtime_maintenance_tickets";
 pub const SMART_HOME_GET_RUNTIME_MAINTENANCE_TICKET_SUMMARY_TOOL_ID: &str =
     "smart_home.get_runtime_maintenance_ticket_summary";
+pub const SMART_HOME_LIST_RUNTIME_MAINTENANCE_WORK_ORDERS_TOOL_ID: &str =
+    "smart_home.list_runtime_maintenance_work_orders";
+pub const SMART_HOME_GET_RUNTIME_MAINTENANCE_WORK_ORDER_SUMMARY_TOOL_ID: &str =
+    "smart_home.get_runtime_maintenance_work_order_summary";
 pub const SMART_HOME_SET_DESIRED_STATE_TOOL_ID: &str = "smart_home.set_desired_state";
 pub const SMART_HOME_CLEAR_DESIRED_STATE_TOOL_ID: &str = "smart_home.clear_desired_state";
 pub const SMART_HOME_LIST_PAIRING_SESSIONS_TOOL_ID: &str = "smart_home.list_pairing_sessions";
@@ -2465,6 +2469,24 @@ impl SmartHomeToolBridge {
                 SMART_HOME_GET_RUNTIME_MAINTENANCE_TICKET_SUMMARY_TOOL_ID => {
                     let query = runtime_maintenance_ticket_query(&arguments)?;
                     get_runtime_maintenance_ticket_summary_output_handler_output(
+                        &mut runtime,
+                        principal_id,
+                        now_ms,
+                        query,
+                    )
+                }
+                SMART_HOME_LIST_RUNTIME_MAINTENANCE_WORK_ORDERS_TOOL_ID => {
+                    let query = runtime_maintenance_work_order_query(&arguments)?;
+                    list_runtime_maintenance_work_orders_output_handler_output(
+                        &mut runtime,
+                        principal_id,
+                        now_ms,
+                        query,
+                    )
+                }
+                SMART_HOME_GET_RUNTIME_MAINTENANCE_WORK_ORDER_SUMMARY_TOOL_ID => {
+                    let query = runtime_maintenance_work_order_query(&arguments)?;
+                    get_runtime_maintenance_work_order_summary_output_handler_output(
                         &mut runtime,
                         principal_id,
                         now_ms,
@@ -6206,6 +6228,8 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
         get_runtime_maintenance_plan_summary_definition(),
         list_runtime_maintenance_tickets_definition(),
         get_runtime_maintenance_ticket_summary_definition(),
+        list_runtime_maintenance_work_orders_definition(),
+        get_runtime_maintenance_work_order_summary_definition(),
         set_desired_state_definition(),
         clear_desired_state_definition(),
         list_pairing_sessions_definition(),
@@ -7397,6 +7421,74 @@ fn get_runtime_maintenance_ticket_summary_definition() -> ToolDefinition {
         "Summarize Chief-visible maintenance tickets grouped from D23 runtime remediation plans.",
         runtime_maintenance_ticket_query_schema(),
         runtime_maintenance_ticket_summary_output_schema(),
+    )
+}
+
+fn runtime_maintenance_work_order_query_schema() -> JsonSchema {
+    object_schema(
+        vec![
+            SchemaProperty::new("window_kind", JsonSchema::String),
+            SchemaProperty::new("window_kinds", string_array_schema()),
+            SchemaProperty::new("remediation_kind", JsonSchema::String),
+            SchemaProperty::new("remediation_kinds", string_array_schema()),
+            SchemaProperty::new("ticket_status", JsonSchema::String),
+            SchemaProperty::new("ticket_statuses", string_array_schema()),
+            SchemaProperty::new("work_order_status", JsonSchema::String),
+            SchemaProperty::new("work_order_statuses", string_array_schema()),
+            SchemaProperty::new("risk_lane", JsonSchema::String),
+            SchemaProperty::new("recommended_tool", JsonSchema::String),
+            SchemaProperty::new("max_priority", JsonSchema::Integer),
+            SchemaProperty::new("blocked_only", JsonSchema::Boolean),
+            SchemaProperty::new("requires_attention_only", JsonSchema::Boolean),
+            SchemaProperty::new("limit", JsonSchema::Integer),
+        ],
+        vec![],
+        false,
+    )
+}
+
+fn runtime_maintenance_work_order_list_output_schema() -> JsonSchema {
+    object_schema(
+        vec![
+            SchemaProperty::new(
+                "runtime_maintenance_work_orders",
+                JsonSchema::Array {
+                    items: Box::new(JsonSchema::Any),
+                },
+            ),
+            SchemaProperty::new("summary", JsonSchema::Any),
+            SchemaProperty::new("count", JsonSchema::Integer),
+        ],
+        vec!["runtime_maintenance_work_orders", "summary", "count"],
+        false,
+    )
+}
+
+fn runtime_maintenance_work_order_summary_output_schema() -> JsonSchema {
+    object_schema(
+        vec![SchemaProperty::new("summary", JsonSchema::Any)],
+        vec!["summary"],
+        false,
+    )
+}
+
+fn list_runtime_maintenance_work_orders_definition() -> ToolDefinition {
+    read_definition(
+        SMART_HOME_LIST_RUNTIME_MAINTENANCE_WORK_ORDERS_TOOL_ID,
+        "List smart-home runtime maintenance work orders",
+        "List Chief work-order records derived from runtime maintenance tickets without mutating the D23 runtime.",
+        runtime_maintenance_work_order_query_schema(),
+        runtime_maintenance_work_order_list_output_schema(),
+    )
+}
+
+fn get_runtime_maintenance_work_order_summary_definition() -> ToolDefinition {
+    read_definition(
+        SMART_HOME_GET_RUNTIME_MAINTENANCE_WORK_ORDER_SUMMARY_TOOL_ID,
+        "Summarize smart-home runtime maintenance work orders",
+        "Summarize Chief-visible work orders derived from D23 runtime maintenance tickets.",
+        runtime_maintenance_work_order_query_schema(),
+        runtime_maintenance_work_order_summary_output_schema(),
     )
 }
 
@@ -8882,6 +8974,75 @@ fn runtime_maintenance_ticket_query(
             .into_iter()
             .map(|status| parse_runtime_maintenance_ticket_status(&status))
             .collect::<Result<Vec<_>, _>>()?,
+        risk_lane: optional_string(arguments, "risk_lane")?,
+        recommended_tool: optional_string(arguments, "recommended_tool")?,
+        max_priority: optional_u64(arguments, "max_priority")?.map(|value| value as u8),
+        blocked_only: optional_bool(arguments, "blocked_only")?.unwrap_or(false),
+        requires_attention_only: optional_bool(arguments, "requires_attention_only")?
+            .unwrap_or(false),
+        limit: optional_u64(arguments, "limit")?.map(|value| value as usize),
+    })
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RuntimeMaintenanceWorkOrderQuery {
+    window_kinds: Vec<RuntimeMaintenanceWindowKind>,
+    remediation_kinds: Vec<SupervisionRemediationKind>,
+    ticket_statuses: Vec<&'static str>,
+    work_order_statuses: Vec<&'static str>,
+    risk_lane: Option<String>,
+    recommended_tool: Option<String>,
+    max_priority: Option<u8>,
+    blocked_only: bool,
+    requires_attention_only: bool,
+    limit: Option<usize>,
+}
+
+impl RuntimeMaintenanceWorkOrderQuery {
+    fn ticket_query(&self) -> RuntimeMaintenanceTicketQuery {
+        RuntimeMaintenanceTicketQuery {
+            window_kinds: self.window_kinds.clone(),
+            remediation_kinds: self.remediation_kinds.clone(),
+            ticket_statuses: self.ticket_statuses.clone(),
+            risk_lane: self.risk_lane.clone(),
+            recommended_tool: self.recommended_tool.clone(),
+            max_priority: self.max_priority,
+            blocked_only: self.blocked_only,
+            requires_attention_only: self.requires_attention_only,
+            limit: None,
+        }
+    }
+}
+
+fn runtime_maintenance_work_order_query(
+    arguments: &JsonValue,
+) -> Result<RuntimeMaintenanceWorkOrderQuery, ToolCallError> {
+    let _ = expect_object(arguments)?;
+    Ok(RuntimeMaintenanceWorkOrderQuery {
+        window_kinds: optional_string_list(arguments, "window_kind", "window_kinds")?
+            .into_iter()
+            .map(|kind| parse_runtime_maintenance_window_kind(&kind))
+            .collect::<Result<Vec<_>, _>>()?,
+        remediation_kinds: optional_string_list(
+            arguments,
+            "remediation_kind",
+            "remediation_kinds",
+        )?
+        .into_iter()
+        .map(|kind| parse_supervision_remediation_kind(&kind))
+        .collect::<Result<Vec<_>, _>>()?,
+        ticket_statuses: optional_string_list(arguments, "ticket_status", "ticket_statuses")?
+            .into_iter()
+            .map(|status| parse_runtime_maintenance_ticket_status(&status))
+            .collect::<Result<Vec<_>, _>>()?,
+        work_order_statuses: optional_string_list(
+            arguments,
+            "work_order_status",
+            "work_order_statuses",
+        )?
+        .into_iter()
+        .map(|status| parse_runtime_maintenance_work_order_status(&status))
+        .collect::<Result<Vec<_>, _>>()?,
         risk_lane: optional_string(arguments, "risk_lane")?,
         recommended_tool: optional_string(arguments, "recommended_tool")?,
         max_priority: optional_u64(arguments, "max_priority")?.map(|value| value as u8),
@@ -37086,6 +37247,301 @@ fn runtime_maintenance_ticket_title(kind: RuntimeMaintenanceWindowKind) -> &'sta
     }
 }
 
+#[derive(Debug, Clone, PartialEq)]
+struct RuntimeMaintenanceWorkOrderRow {
+    work_order_id: String,
+    ticket_id: String,
+    plan_id: String,
+    window_id: String,
+    window_kind: RuntimeMaintenanceWindowKind,
+    priority: u8,
+    execution_order: usize,
+    work_order_status: &'static str,
+    work_order_type: &'static str,
+    assignment_lane: &'static str,
+    recommended_tool: &'static str,
+    recommended_action: &'static str,
+    action_count: usize,
+    blocked_action_count: usize,
+    requires_attention_count: usize,
+    overdue_action_count: usize,
+    first_due_at_ms: Option<u64>,
+    max_overdue_by_ms: Option<u64>,
+    next_action_ids: Vec<String>,
+    remediation_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct RuntimeMaintenanceWorkOrderSummary {
+    total_work_orders: usize,
+    critical_recovery_work_orders: usize,
+    state_refresh_work_orders: usize,
+    desired_state_reconciliation_work_orders: usize,
+    discovery_worker_run_work_orders: usize,
+    blocking_work_orders: usize,
+    operator_required_work_orders: usize,
+    ready_to_execute_work_orders: usize,
+    total_actions: usize,
+    blocked_actions: usize,
+    requires_attention_actions: usize,
+    overdue_actions: usize,
+    first_due_at_ms: Option<u64>,
+    max_overdue_by_ms: Option<u64>,
+    highest_priority: Option<u8>,
+}
+
+impl RuntimeMaintenanceWorkOrderSummary {
+    fn from_rows(rows: &[RuntimeMaintenanceWorkOrderRow]) -> Self {
+        let mut summary = Self::default();
+
+        for row in rows {
+            summary.total_work_orders += 1;
+            summary.total_actions += row.action_count;
+            summary.blocked_actions += row.blocked_action_count;
+            summary.requires_attention_actions += row.requires_attention_count;
+            summary.overdue_actions += row.overdue_action_count;
+            if row.has_blockers() {
+                summary.blocking_work_orders += 1;
+            }
+            if row.operator_required() {
+                summary.operator_required_work_orders += 1;
+            }
+            if row.ready_to_execute() {
+                summary.ready_to_execute_work_orders += 1;
+            }
+            summary.first_due_at_ms =
+                min_optional_u64(summary.first_due_at_ms, row.first_due_at_ms);
+            summary.max_overdue_by_ms =
+                max_optional_u64(summary.max_overdue_by_ms, row.max_overdue_by_ms);
+            summary.highest_priority =
+                min_optional_u8(summary.highest_priority, Some(row.priority));
+
+            match row.window_kind {
+                RuntimeMaintenanceWindowKind::CriticalRecovery => {
+                    summary.critical_recovery_work_orders += 1;
+                }
+                RuntimeMaintenanceWindowKind::StateRefresh => {
+                    summary.state_refresh_work_orders += 1;
+                }
+                RuntimeMaintenanceWindowKind::DesiredStateReconciliation => {
+                    summary.desired_state_reconciliation_work_orders += 1;
+                }
+                RuntimeMaintenanceWindowKind::DiscoveryWorkerRun => {
+                    summary.discovery_worker_run_work_orders += 1;
+                }
+            }
+        }
+
+        summary
+    }
+
+    fn has_work_orders(&self) -> bool {
+        self.total_work_orders > 0
+    }
+
+    fn execution_work_orders_ready(&self) -> bool {
+        self.total_work_orders > 0 && self.ready_to_execute_work_orders == self.total_work_orders
+    }
+}
+
+fn list_runtime_maintenance_work_orders_output_handler_output(
+    runtime: &mut SmartHomeRuntime,
+    principal_id: AgentId,
+    now_ms: u64,
+    query: RuntimeMaintenanceWorkOrderQuery,
+) -> Result<ToolHandlerOutput, ToolCallError> {
+    let (mut rows, summary) =
+        runtime_maintenance_work_order_rows(runtime, principal_id, now_ms, &query)?;
+    if let Some(limit) = query.limit {
+        rows.truncate(limit);
+    }
+
+    Ok(ToolHandlerOutput::new(object([
+        (
+            "runtime_maintenance_work_orders",
+            JsonValue::Array(
+                rows.iter()
+                    .map(runtime_maintenance_work_order_json)
+                    .collect(),
+            ),
+        ),
+        (
+            "summary",
+            runtime_maintenance_work_order_summary_json(&summary),
+        ),
+        ("count", integer(rows.len() as i64)),
+    ]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            ("operation", string("list_runtime_maintenance_work_orders")),
+            ("count", integer(rows.len() as i64)),
+            (
+                "total_work_orders",
+                integer(summary.total_work_orders as i64),
+            ),
+            (
+                "blocking_work_orders",
+                integer(summary.blocking_work_orders as i64),
+            ),
+            (
+                "operator_required_work_orders",
+                integer(summary.operator_required_work_orders as i64),
+            ),
+            (
+                "ready_to_execute_work_orders",
+                integer(summary.ready_to_execute_work_orders as i64),
+            ),
+        ]),
+    ))
+}
+
+fn get_runtime_maintenance_work_order_summary_output_handler_output(
+    runtime: &mut SmartHomeRuntime,
+    principal_id: AgentId,
+    now_ms: u64,
+    query: RuntimeMaintenanceWorkOrderQuery,
+) -> Result<ToolHandlerOutput, ToolCallError> {
+    let (_, summary) = runtime_maintenance_work_order_rows(runtime, principal_id, now_ms, &query)?;
+
+    Ok(ToolHandlerOutput::new(object([(
+        "summary",
+        runtime_maintenance_work_order_summary_json(&summary),
+    )]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("get_runtime_maintenance_work_order_summary"),
+            ),
+            (
+                "total_work_orders",
+                integer(summary.total_work_orders as i64),
+            ),
+            (
+                "blocking_work_orders",
+                integer(summary.blocking_work_orders as i64),
+            ),
+            (
+                "operator_required_work_orders",
+                integer(summary.operator_required_work_orders as i64),
+            ),
+            (
+                "ready_to_execute_work_orders",
+                integer(summary.ready_to_execute_work_orders as i64),
+            ),
+        ]),
+    ))
+}
+
+fn runtime_maintenance_work_order_rows(
+    runtime: &mut SmartHomeRuntime,
+    principal_id: AgentId,
+    now_ms: u64,
+    query: &RuntimeMaintenanceWorkOrderQuery,
+) -> Result<
+    (
+        Vec<RuntimeMaintenanceWorkOrderRow>,
+        RuntimeMaintenanceWorkOrderSummary,
+    ),
+    ToolCallError,
+> {
+    let ticket_query = query.ticket_query();
+    let (tickets, _) =
+        runtime_maintenance_ticket_rows(runtime, principal_id, now_ms, &ticket_query)?;
+    let mut work_orders = tickets
+        .iter()
+        .map(RuntimeMaintenanceWorkOrderRow::from_ticket)
+        .filter(|row| runtime_maintenance_work_order_matches(row, query))
+        .collect::<Vec<_>>();
+    work_orders.sort_by(|left, right| {
+        left.priority
+            .cmp(&right.priority)
+            .then_with(|| {
+                runtime_maintenance_work_order_status_rank(left.work_order_status).cmp(
+                    &runtime_maintenance_work_order_status_rank(right.work_order_status),
+                )
+            })
+            .then_with(|| left.first_due_at_ms.cmp(&right.first_due_at_ms))
+            .then_with(|| left.work_order_id.cmp(&right.work_order_id))
+    });
+    for (index, row) in work_orders.iter_mut().enumerate() {
+        row.execution_order = index + 1;
+    }
+
+    let summary = RuntimeMaintenanceWorkOrderSummary::from_rows(&work_orders);
+    Ok((work_orders, summary))
+}
+
+impl RuntimeMaintenanceWorkOrderRow {
+    fn from_ticket(row: &RuntimeMaintenanceTicketRow) -> Self {
+        let label = runtime_maintenance_window_kind_label(row.window_kind);
+        Self {
+            work_order_id: format!("maintenance_work_order:{label}"),
+            ticket_id: row.ticket_id.clone(),
+            plan_id: row.plan_id.clone(),
+            window_id: row.window_id.clone(),
+            window_kind: row.window_kind,
+            priority: row.priority,
+            execution_order: row.execution_order,
+            work_order_status: runtime_maintenance_work_order_status(row.ticket_status),
+            work_order_type: "runtime_maintenance_execution",
+            assignment_lane: row.assignment_lane,
+            recommended_tool: row.recommended_tool,
+            recommended_action: row.recommended_action,
+            action_count: row.action_count,
+            blocked_action_count: row.blocked_action_count,
+            requires_attention_count: row.requires_attention_count,
+            overdue_action_count: row.overdue_action_count,
+            first_due_at_ms: row.first_due_at_ms,
+            max_overdue_by_ms: row.max_overdue_by_ms,
+            next_action_ids: row.next_action_ids.clone(),
+            remediation_ids: row.remediation_ids.clone(),
+        }
+    }
+
+    fn has_blockers(&self) -> bool {
+        self.blocked_action_count > 0
+    }
+
+    fn operator_required(&self) -> bool {
+        self.work_order_status != "ready_to_execute"
+    }
+
+    fn ready_to_execute(&self) -> bool {
+        self.work_order_status == "ready_to_execute"
+    }
+}
+
+fn runtime_maintenance_work_order_matches(
+    row: &RuntimeMaintenanceWorkOrderRow,
+    query: &RuntimeMaintenanceWorkOrderQuery,
+) -> bool {
+    query.work_order_statuses.is_empty()
+        || query.work_order_statuses.contains(&row.work_order_status)
+}
+
+fn runtime_maintenance_work_order_status(ticket_status: &str) -> &'static str {
+    match ticket_status {
+        "ready" => "ready_to_execute",
+        "blocked" => "blocked",
+        "overdue" => "overdue",
+        "attention_required" => "attention_required",
+        _ => "attention_required",
+    }
+}
+
+fn runtime_maintenance_work_order_status_rank(status: &str) -> u8 {
+    match status {
+        "blocked" => 0,
+        "overdue" => 1,
+        "attention_required" => 2,
+        "ready_to_execute" => 3,
+        _ => 4,
+    }
+}
+
 fn min_optional_u64(left: Option<u64>, right: Option<u64>) -> Option<u64> {
     match (left, right) {
         (Some(left), Some(right)) => Some(left.min(right)),
@@ -61430,6 +61886,140 @@ fn runtime_maintenance_ticket_summary_json(summary: &RuntimeMaintenanceTicketSum
     ])
 }
 
+fn runtime_maintenance_work_order_json(row: &RuntimeMaintenanceWorkOrderRow) -> JsonValue {
+    object([
+        ("work_order_id", string(&row.work_order_id)),
+        ("ticket_id", string(&row.ticket_id)),
+        ("plan_id", string(&row.plan_id)),
+        ("window_id", string(&row.window_id)),
+        (
+            "window_kind",
+            string(runtime_maintenance_window_kind_label(row.window_kind)),
+        ),
+        ("priority", integer(row.priority as i64)),
+        ("execution_order", integer(row.execution_order as i64)),
+        ("work_order_status", string(row.work_order_status)),
+        ("work_order_type", string(row.work_order_type)),
+        ("assignment_lane", string(row.assignment_lane)),
+        ("recommended_tool", string(row.recommended_tool)),
+        ("recommended_action", string(row.recommended_action)),
+        ("action_count", integer(row.action_count as i64)),
+        (
+            "blocked_action_count",
+            integer(row.blocked_action_count as i64),
+        ),
+        (
+            "requires_attention_count",
+            integer(row.requires_attention_count as i64),
+        ),
+        (
+            "overdue_action_count",
+            integer(row.overdue_action_count as i64),
+        ),
+        (
+            "first_due_at_ms",
+            row.first_due_at_ms
+                .map(|value| integer(value as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "max_overdue_by_ms",
+            row.max_overdue_by_ms
+                .map(|value| integer(value as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_action_ids",
+            JsonValue::Array(row.next_action_ids.iter().map(string).collect()),
+        ),
+        (
+            "remediation_ids",
+            JsonValue::Array(row.remediation_ids.iter().map(string).collect()),
+        ),
+        ("has_blockers", JsonValue::Bool(row.has_blockers())),
+        (
+            "operator_required",
+            JsonValue::Bool(row.operator_required()),
+        ),
+        ("ready_to_execute", JsonValue::Bool(row.ready_to_execute())),
+    ])
+}
+
+fn runtime_maintenance_work_order_summary_json(
+    summary: &RuntimeMaintenanceWorkOrderSummary,
+) -> JsonValue {
+    object([
+        (
+            "total_work_orders",
+            integer(summary.total_work_orders as i64),
+        ),
+        (
+            "critical_recovery_work_orders",
+            integer(summary.critical_recovery_work_orders as i64),
+        ),
+        (
+            "state_refresh_work_orders",
+            integer(summary.state_refresh_work_orders as i64),
+        ),
+        (
+            "desired_state_reconciliation_work_orders",
+            integer(summary.desired_state_reconciliation_work_orders as i64),
+        ),
+        (
+            "discovery_worker_run_work_orders",
+            integer(summary.discovery_worker_run_work_orders as i64),
+        ),
+        (
+            "blocking_work_orders",
+            integer(summary.blocking_work_orders as i64),
+        ),
+        (
+            "operator_required_work_orders",
+            integer(summary.operator_required_work_orders as i64),
+        ),
+        (
+            "ready_to_execute_work_orders",
+            integer(summary.ready_to_execute_work_orders as i64),
+        ),
+        ("total_actions", integer(summary.total_actions as i64)),
+        ("blocked_actions", integer(summary.blocked_actions as i64)),
+        (
+            "requires_attention_actions",
+            integer(summary.requires_attention_actions as i64),
+        ),
+        ("overdue_actions", integer(summary.overdue_actions as i64)),
+        (
+            "first_due_at_ms",
+            summary
+                .first_due_at_ms
+                .map(|value| integer(value as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "max_overdue_by_ms",
+            summary
+                .max_overdue_by_ms
+                .map(|value| integer(value as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "highest_priority",
+            summary
+                .highest_priority
+                .map(|value| integer(value as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "has_work_orders",
+            JsonValue::Bool(summary.has_work_orders()),
+        ),
+        (
+            "execution_work_orders_ready",
+            JsonValue::Bool(summary.execution_work_orders_ready()),
+        ),
+    ])
+}
+
 fn event_log_summary_json(summary: &RuntimeEventLogSummary) -> JsonValue {
     object([
         ("total_events", integer(summary.total_events as i64)),
@@ -64345,6 +64935,18 @@ fn parse_runtime_maintenance_ticket_status(value: &str) -> Result<&'static str, 
         "ready" | "open" => Ok("ready"),
         _ => Err(validation_error(format!(
             "unsupported runtime maintenance ticket status `{value}`"
+        ))),
+    }
+}
+
+fn parse_runtime_maintenance_work_order_status(value: &str) -> Result<&'static str, ToolCallError> {
+    match value {
+        "blocked" | "blocker" => Ok("blocked"),
+        "overdue" | "late" => Ok("overdue"),
+        "attention_required" | "requires_attention" | "attention" => Ok("attention_required"),
+        "ready_to_execute" | "ready" | "open" => Ok("ready_to_execute"),
+        _ => Err(validation_error(format!(
+            "unsupported runtime maintenance work order status `{value}`"
         ))),
     }
 }
@@ -68187,7 +68789,7 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 264);
+        assert_eq!(definitions.len(), 266);
         assert!(
             export.ok(),
             "tool export validation failed: {:?}",
@@ -68942,9 +69544,15 @@ mod tests {
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_GET_RUNTIME_MAINTENANCE_TICKET_SUMMARY_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_LIST_RUNTIME_MAINTENANCE_WORK_ORDERS_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_GET_RUNTIME_MAINTENANCE_WORK_ORDER_SUMMARY_TOOL_ID));
         assert_eq!(
             export.summary.required_capability_count("smart_home:read"),
-            256
+            258
         );
         assert_eq!(
             export
@@ -69588,6 +70196,14 @@ mod tests {
             SMART_HOME_GET_RUNTIME_MAINTENANCE_TICKET_SUMMARY_TOOL_ID
         )
         .is_some());
+        assert!(smart_home_tool_definition(
+            SMART_HOME_LIST_RUNTIME_MAINTENANCE_WORK_ORDERS_TOOL_ID
+        )
+        .is_some());
+        assert!(smart_home_tool_definition(
+            SMART_HOME_GET_RUNTIME_MAINTENANCE_WORK_ORDER_SUMMARY_TOOL_ID
+        )
+        .is_some());
         assert!(smart_home_tool_definition(SMART_HOME_COMPLETE_PAIRING_TOOL_ID).is_some());
         assert!(smart_home_tool_definition(SMART_HOME_REPORT_EVENT_TOOL_ID).is_some());
         assert!(smart_home_tool_definition(SMART_HOME_LIST_ROOMS_TOOL_ID).is_some());
@@ -69822,11 +70438,11 @@ mod tests {
         let tool_catalog_summary = field(tool_catalog_summary_output, "summary").unwrap();
         assert_eq!(
             field(tool_catalog_summary, "total_tools"),
-            Some(&integer(264))
+            Some(&integer(266))
         );
         assert_eq!(
             field(tool_catalog_summary, "read_tools"),
-            Some(&integer(256))
+            Some(&integer(258))
         );
         assert_eq!(
             field(tool_catalog_summary, "risky_tool_count"),
@@ -84428,7 +85044,7 @@ mod tests {
     }
 
     #[test]
-    fn runtime_maintenance_plan_and_ticket_tools_group_action_pressure_end_to_end() {
+    fn runtime_maintenance_plan_ticket_and_work_order_tools_group_action_pressure_end_to_end() {
         let runtime = Rc::new(RefCell::new(hue_lighting_runtime()));
         runtime
             .borrow_mut()
@@ -84702,18 +85318,125 @@ mod tests {
             Some(&JsonValue::Bool(true))
         );
 
+        let work_order_list_request = request(
+            "call-list-runtime-maintenance-work-orders",
+            SMART_HOME_LIST_RUNTIME_MAINTENANCE_WORK_ORDERS_TOOL_ID,
+            object([
+                ("work_order_status", string("blocked")),
+                ("requires_attention_only", JsonValue::Bool(true)),
+                ("blocked_only", JsonValue::Bool(true)),
+                ("max_priority", integer(1)),
+                ("limit", integer(10)),
+            ]),
+            2_004,
+        );
+        let work_order_list_trace = tool_runtime.invoke_with_events(&work_order_list_request);
+        assert!(work_order_list_trace.result.ok);
+        assert_eq!(work_order_list_trace.summary().progress_event_count, 1);
+        let work_order_list_output = work_order_list_trace.result.output.as_ref().unwrap();
+        let work_orders = field(work_order_list_output, "runtime_maintenance_work_orders").unwrap();
+        let work_order_summary = field(work_order_list_output, "summary").unwrap();
+        assert!(
+            array_len(work_orders).unwrap() >= 3,
+            "maintenance work orders should expose blocked runtime execution lanes"
+        );
+        assert!(
+            integer_value(field(work_order_summary, "total_work_orders").unwrap()).unwrap() >= 3
+        );
+        assert_eq!(
+            field(work_order_summary, "critical_recovery_work_orders"),
+            Some(&integer(1))
+        );
+        assert_eq!(
+            field(
+                work_order_summary,
+                "desired_state_reconciliation_work_orders"
+            ),
+            Some(&integer(1))
+        );
+        assert!(
+            integer_value(field(work_order_summary, "blocking_work_orders").unwrap()).unwrap() >= 3
+        );
+        assert!(
+            integer_value(field(work_order_summary, "operator_required_work_orders").unwrap())
+                .unwrap()
+                >= 3
+        );
+        assert_eq!(
+            field(work_order_summary, "execution_work_orders_ready"),
+            Some(&JsonValue::Bool(false))
+        );
+
+        let JsonValue::Array(work_order_rows) = work_orders else {
+            panic!("runtime_maintenance_work_orders should be an array");
+        };
+        assert!(work_order_rows.iter().any(|row| field(row, "window_kind")
+            == Some(&string("critical_recovery"))
+            && field(row, "work_order_status") == Some(&string("blocked"))
+            && field(row, "work_order_type") == Some(&string("runtime_maintenance_execution"))
+            && field(row, "assignment_lane") == Some(&string("critical_recovery"))
+            && field(row, "recommended_tool")
+                == Some(&string(SMART_HOME_RUN_SUPERVISION_TICK_TOOL_ID))
+            && field(row, "operator_required") == Some(&JsonValue::Bool(true))
+            && integer_value(field(row, "action_count").unwrap()).unwrap() >= 2));
+        assert!(work_order_rows.iter().any(|row| field(row, "window_kind")
+            == Some(&string("desired_state_reconciliation"))
+            && field(row, "work_order_status") == Some(&string("blocked"))
+            && field(row, "recommended_tool")
+                == Some(&string(SMART_HOME_RECONCILE_DESIRED_STATES_TOOL_ID))
+            && field(row, "recommended_action") == Some(&string("reconcile_desired_state"))
+            && field(row, "has_blockers") == Some(&JsonValue::Bool(true))));
+
+        let work_order_summary_request = request(
+            "call-runtime-maintenance-work-order-summary",
+            SMART_HOME_GET_RUNTIME_MAINTENANCE_WORK_ORDER_SUMMARY_TOOL_ID,
+            object([
+                ("window_kind", string("desired_state_reconciliation")),
+                ("work_order_status", string("blocked")),
+                ("blocked_only", JsonValue::Bool(true)),
+            ]),
+            2_005,
+        );
+        let work_order_summary_trace = tool_runtime.invoke_with_events(&work_order_summary_request);
+        assert!(work_order_summary_trace.result.ok);
+        assert_eq!(work_order_summary_trace.summary().progress_event_count, 1);
+        let work_order_summary_output = work_order_summary_trace.result.output.as_ref().unwrap();
+        let work_order_rollup = field(work_order_summary_output, "summary").unwrap();
+        assert_eq!(
+            field(work_order_rollup, "total_work_orders"),
+            Some(&integer(1))
+        );
+        assert_eq!(field(work_order_rollup, "total_actions"), Some(&integer(1)));
+        assert_eq!(
+            field(
+                work_order_rollup,
+                "desired_state_reconciliation_work_orders"
+            ),
+            Some(&integer(1))
+        );
+        assert_eq!(
+            field(work_order_rollup, "blocking_work_orders"),
+            Some(&integer(1))
+        );
+        assert_eq!(
+            field(work_order_rollup, "execution_work_orders_ready"),
+            Some(&JsonValue::Bool(false))
+        );
+
         let mut journal = ToolExecutionJournal::new();
         journal.record_trace(list_request, list_trace);
         journal.record_trace(summary_request, summary_trace);
         journal.record_trace(ticket_list_request, ticket_list_trace);
         journal.record_trace(ticket_summary_request, ticket_summary_trace);
+        journal.record_trace(work_order_list_request, work_order_list_trace);
+        journal.record_trace(work_order_summary_request, work_order_summary_trace);
         let journal_summary = journal.summary();
-        assert_eq!(journal_summary.invocation_count, 4);
-        assert_eq!(journal_summary.completed_count, 4);
+        assert_eq!(journal_summary.invocation_count, 6);
+        assert_eq!(journal_summary.completed_count, 6);
         assert_eq!(
             runtime.borrow().registry().counts().authorization_decisions,
-            4,
-            "maintenance plan and ticket reads authorize through runtime read tools"
+            6,
+            "maintenance plan, ticket, and work-order reads authorize through runtime read tools"
         );
     }
 

--- a/code/packages/rust/smart-home-core/CHANGELOG.md
+++ b/code/packages/rust/smart-home-core/CHANGELOG.md
@@ -270,6 +270,9 @@ All notable changes to this package will be documented in this file.
 - `smart_home.list_runtime_maintenance_tickets` and
   `smart_home.get_runtime_maintenance_ticket_summary` tool descriptors for
   read-only Chief maintenance tickets derived from runtime supervision work.
+- `smart_home.list_runtime_maintenance_work_orders` and
+  `smart_home.get_runtime_maintenance_work_order_summary` tool descriptors for
+  read-only Chief maintenance work orders derived from runtime supervision work.
 - `smart_home.reconcile_desired_states` and `smart_home.run_supervision_tick`
   tool descriptors for authorized runtime supervision execution.
 - Health and command-result status helpers for shared supervision/read-side

--- a/code/packages/rust/smart-home-core/README.md
+++ b/code/packages/rust/smart-home-core/README.md
@@ -180,6 +180,8 @@ Current scope:
   plans over supervision work
 - D18D runtime maintenance-ticket descriptors for Chief-visible ticket queues
   over grouped supervision work
+- D18D runtime maintenance-work-order descriptors for Chief-visible execution
+  handoff over maintenance tickets
 - D18D supervision execution tool descriptors for authorized desired-state
   reconciliation and runtime supervision ticks
 - compact smart-home tool catalog summaries for read-side inspection

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1698,6 +1698,8 @@ pub enum SmartHomeTool {
     GetRuntimeMaintenancePlanSummary,
     ListRuntimeMaintenanceTickets,
     GetRuntimeMaintenanceTicketSummary,
+    ListRuntimeMaintenanceWorkOrders,
+    GetRuntimeMaintenanceWorkOrderSummary,
     SetDesiredState,
     ClearDesiredState,
     ListPairingSessions,
@@ -2421,6 +2423,12 @@ impl SmartHomeTool {
             }
             Self::GetRuntimeMaintenanceTicketSummary => {
                 read_tool("smart_home.get_runtime_maintenance_ticket_summary")
+            }
+            Self::ListRuntimeMaintenanceWorkOrders => {
+                read_tool("smart_home.list_runtime_maintenance_work_orders")
+            }
+            Self::GetRuntimeMaintenanceWorkOrderSummary => {
+                read_tool("smart_home.get_runtime_maintenance_work_order_summary")
             }
             Self::SetDesiredState => ToolDescriptor {
                 tool_id: "smart_home.set_desired_state",
@@ -3225,6 +3233,8 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::GetRuntimeMaintenancePlanSummary,
         SmartHomeTool::ListRuntimeMaintenanceTickets,
         SmartHomeTool::GetRuntimeMaintenanceTicketSummary,
+        SmartHomeTool::ListRuntimeMaintenanceWorkOrders,
+        SmartHomeTool::GetRuntimeMaintenanceWorkOrderSummary,
         SmartHomeTool::SetDesiredState,
         SmartHomeTool::ClearDesiredState,
         SmartHomeTool::ListPairingSessions,
@@ -4031,7 +4041,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 264);
+        assert_eq!(catalog.len(), 266);
         assert!(catalog
             .iter()
             .any(|tool| tool.tool_id == "smart_home.list_command_risk_audit"
@@ -4104,6 +4114,14 @@ mod tests {
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
         assert!(catalog.iter().any(|tool| tool.tool_id
             == "smart_home.get_runtime_maintenance_ticket_summary"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.list_runtime_maintenance_work_orders"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.get_runtime_maintenance_work_order_summary"
             && tool.side_effects == ToolSideEffects::Read
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
         assert!(catalog
@@ -5072,15 +5090,15 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 264);
-        assert_eq!(summary.read_tools, 256);
+        assert_eq!(summary.total_tools, 266);
+        assert_eq!(summary.read_tools, 258);
         assert_eq!(summary.write_tools, 2);
         assert_eq!(summary.external_tools, 6);
-        assert_eq!(summary.read_only_tier_tools, 256);
+        assert_eq!(summary.read_only_tier_tools, 258);
         assert_eq!(summary.low_risk_tier_tools, 6);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 2);
-        assert_eq!(summary.total_required_capabilities, 264);
+        assert_eq!(summary.total_required_capabilities, 266);
         assert_eq!(summary.risky_tool_count(), 8);
         assert_eq!(summary.approval_gated_tool_count(), 2);
         assert!(pair_bridge.requires_human_approval());


### PR DESCRIPTION
## Summary
- add shared smart-home descriptors for runtime maintenance work-order list and summary reads
- expose Chief bridge definitions, schemas, dispatch, filters, rows, summaries, and JSON output for work orders derived from runtime maintenance tickets
- extend the maintenance plan/ticket E2E to cover work-order handoff rows and authorization journaling

## Validation
- cargo fmt -p smart-home-core -p chief-of-staff-smart-home-tools --check
- cargo test -p smart-home-core
- cargo test -p smart-home-integration-catalog
- cargo test -p hue-core
- cargo test -p smart-home-runtime
- cargo test -p smart-home-testkit
- cargo test -p smart-home-local-http
- cargo test -p smart-home-discovery
- cargo test -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-runtime discover_tool -- --nocapture
- sh BUILD in smart-home-core, smart-home-integration-catalog, hue-core, smart-home-runtime, smart-home-testkit, smart-home-local-http, smart-home-discovery, chief-of-staff-smart-home-tools