### PR TITLE
feat(mycin-recall): EXOCRINE-GLAND exocrine-gland→characteristic recall library

### DIFF
--- a/code/specs/data/mycin-2026/recall/exocrine-gland-edges.adj
+++ b/code/specs/data/mycin-2026/recall/exocrine-gland-edges.adj
@@ -1,0 +1,83 @@
+% ============================================================================
+% exocrine-gland-edges — the exocrine gland → defining characteristic
+% knowledge-graph (MYCIN-2026 EXOCRINE-GLAND).
+% ============================================================================
+% A high-yield histology/physiology board table: the major exocrine glands of the
+% head/skin and the feature that distinguishes each — the three paired salivary
+% glands (by secretion type) and the two sweat glands (by function / distribution).
+% "What kind of secretion does the parotid gland produce?" becomes the binding
+% query
+%     ? characterized_by(parotid_gland, $Characteristic).
+%
+% Direction note: the relation is exocrine gland -> the defining characteristic the
+% cited sentence states for it (`characterized_by`). The characteristic is whatever
+% the sentence actually pins down — secretion type (serous / mucous / mixed),
+% physiologic function (thermoregulation), or anatomic distribution. Each gland
+% maps to ONE canonical characteristic span, so a query binds a single answer.
+%
+% Faithfulness note: each `relate` subject/object is bound to what the cited
+% sentence ACTUALLY names. The characteristic object names the feature the
+% sentence states (parotid "serous acini"; sublingual "mostly mucous acini";
+% submandibular "a predominance of serous cells with some mucous cells"; eccrine
+% "a thermoregulatory function"; apocrine "distributed in the axillae, anogenital
+% region ..."). Each cited sentence names the gland by its FULL term ("parotid
+% gland", "eccrine sweat glands", "apocrine glands", etc.). Each span was
+% independently re-fetched and confirmed on two separate fetches of the same page
+% for byte-stability.
+%
+% This file is the SHIPPED ARTIFACT and the SOLE source of truth — no generator,
+% no JSON, no manifest (a pure ADJ-only recall domain, like EPIDERMIS/COMPLEMENT/
+% IG-ISOTYPE/WBC). Each fact is a `relate` clause whose byte-provenance lives
+% INLINE:
+%     source   — the VERBATIM span copied from the cited page (byte-stable: it
+%                appears character-for-character in the page's normalized text;
+%                every span here was independently re-fetched and confirmed).
+%     locator  — the URL the span was read from (NCBI StatPearls / Bookshelf).
+%     trust    — authoritative (a primary, citable reference).
+% An LLM (or a human) recalls a fact by writing a tiny query .adj that `import`s
+% this library and asks a binding query — see exocrine-gland-recall.query.adj.
+% Nothing here is asserted "from memory": every edge is defended by a span a
+% reader can re-fetch and check.
+% (See feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+dictionary exocrine_gland_vocab {
+    define exocrine_gland : entity   surface "exocrine gland", "gland"
+    define characteristic : entity   surface "characteristic", "defining feature"
+
+    define characterized_by : relation from exocrine_gland to characteristic  % the defining feature of this exocrine gland
+}
+
+rulebook exocrine_gland_facts {
+    use exocrine_gland_vocab
+
+    % --- parotid gland -> serous --------------------------------------------
+    relate characterized_by(parotid_gland, serous)
+        source "The parotid gland is composed primarily of serous acini and produces watery saliva, which lubricates the oral cavity and helps with swallowing, talking, and maintaining homeostasis."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK551688/"
+        trust authoritative
+
+    % --- sublingual gland -> mucous -----------------------------------------
+    relate characterized_by(sublingual_gland, mucous)
+        source "The sublingual gland is composed of mostly mucous acini and thus produces the thickest and most viscous saliva."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK551688/"
+        trust authoritative
+
+    % --- submandibular gland -> mixed (predominantly serous) ----------------
+    relate characterized_by(submandibular_gland, mixed_predominantly_serous)
+        source "The submandibular gland has a predominance of serous cells with some mucous cells."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK551688/"
+        trust authoritative
+
+    % --- eccrine sweat gland -> thermoregulation ----------------------------
+    relate characterized_by(eccrine_gland, thermoregulatory_sweat)
+        source "Eccrine sweat glands serve a thermoregulatory function via evaporative heat loss."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK482278/"
+        trust authoritative
+
+    % --- apocrine sweat gland -> axillary / anogenital distribution ---------
+    relate characterized_by(apocrine_gland, axillary_anogenital)
+        source "Apocrine glands are distributed in the axillae, anogenital region, periumbilical region, areolae, external auditory canals, and eyelids."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK482199/"
+        trust authoritative
+}

--- a/code/specs/data/mycin-2026/recall/exocrine-gland-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/exocrine-gland-recall.query.adj
@@ -1,0 +1,22 @@
+% ============================================================================
+% exocrine-gland-recall.query.adj — a worked recall query over the
+% exocrine-gland library.
+% ============================================================================
+% The shape an LLM (or a student) produces to ANSWER a "what characterizes
+% exocrine gland X?" question: it states no anatomy/physiology fact — it only
+% `import`s the grounded library and asks binding queries. The native adj-lang
+% engine resolves each `?` against the imported `relate` edges and returns the
+% binding + the citing clause's source/locator/trust. All knowledge is in the
+% library; none is here.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli exocrine-gland-recall.query.adj
+% ============================================================================
+
+import "exocrine-gland-edges.adj"
+
+? characterized_by(parotid_gland, $Characteristic)        % expect serous
+? characterized_by(sublingual_gland, $Characteristic)     % expect mucous
+? characterized_by(submandibular_gland, $Characteristic)  % expect mixed_predominantly_serous
+? characterized_by(eccrine_gland, $Characteristic)        % expect thermoregulatory_sweat
+? characterized_by(apocrine_gland, $Characteristic)       % expect axillary_anogenital

--- a/code/specs/data/mycin-2026/recall/test_exocrine_gland_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_exocrine_gland_recall.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""test_exocrine_gland_recall.py — the ADJ-only exocrine-gland→characteristic
+recall library (MYCIN-2026 EXOCRINE-GLAND).
+
+A pure-ADJ recall domain (high-yield histology/physiology board table): the
+distinguishing feature of each major head/skin exocrine gland — the three paired
+salivary glands (by secretion type) and the two sweat glands (by function /
+distribution). `exocrine-gland-edges.adj` is the SOLE source of truth — facts +
+byte-provenance inline, no Python gate, no JSON, no manifest. This test pins the
+property that matters: the native adj-lang engine, given a query .adj that only
+`import`s the library and asks binding queries (`exocrine-gland-recall.query.adj`
+— the shape an LLM produces), binds the grounded characteristic for each gland,
+each carrying an AUTHORITATIVE citation with a real source span + locator.
+Knowledge lives in ADJ; the engine answers.
+
+If the native CLI isn't built (a Python-only CI lane), the engine-backed checks
+skip — the file-shape checks (every clause grounded, no authored-debt) still run.
+
+Run:  python3 test_exocrine_gland_recall.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ADJ = HERE / "exocrine-gland-edges.adj"
+QUERY = HERE / "exocrine-gland-recall.query.adj"
+CLI = HERE.parents[3] / "packages" / "rust" / "target" / "debug" / "adj-lang-cli"
+
+# Every grounded edge: exocrine gland -> the characteristic the library binds.
+EXPECTED = {
+    "parotid_gland": "serous",                                # NBK551688
+    "sublingual_gland": "mucous",                             # NBK551688
+    "submandibular_gland": "mixed_predominantly_serous",      # NBK551688
+    "eccrine_gland": "thermoregulatory_sweat",                # NBK482278
+    "apocrine_gland": "axillary_anogenital",                  # NBK482199
+}
+REL = "characterized_by"
+VAR = "Characteristic"
+
+
+def _cli_available() -> bool:
+    return CLI.exists()
+
+
+def _run(program: Path) -> dict:
+    out = subprocess.run([str(CLI), str(program)], capture_output=True, text=True,
+                         cwd=str(HERE), timeout=60)
+    assert out.returncode == 0, f"adj-lang-cli failed: {out.stderr}"
+    return json.loads(out.stdout)
+
+
+# ---- 1. the ADJ file is the artifact — every clause grounded, no authored-debt ----
+
+def test_library_is_pure_adj_and_fully_grounded() -> None:
+    text = ADJ.read_text()
+    assert "trust consensus" not in text, "EXOCRINE-GLAND ships no authored-debt; ground or omit"
+    assert "[FLAG:" not in text
+    edge_count = len(EXPECTED)  # 5
+    assert text.count("    relate ") == edge_count
+    assert text.count("trust authoritative") == edge_count
+    assert text.count('\n        locator "') == edge_count
+    assert text.count('\n        source "') == edge_count
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("locator "):
+            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+    assert not (HERE / "exocrine_gland_edge_ground.py").exists()
+    assert not (HERE / "exocrine-gland-edge-grounding.json").exists()
+    assert not (HERE / "exocrine-gland-edge-manifest.json").exists()
+
+
+# ---- 2. the engine binds each characteristic with an authoritative citation ----------
+
+def test_engine_binds_every_characteristic_with_authoritative_citation() -> None:
+    if not _cli_available():
+        return
+    result = _run(QUERY)
+    by_query = {r["query"]: r for r in result["recall"]}
+    for gland, characteristic in EXPECTED.items():
+        q = f"{REL}({gland}, {VAR})"
+        r = by_query.get(q)
+        assert r is not None and not r["abstained"], f"{q} abstained — edge missing?"
+        bound = {}
+        for a in r["answers"]:
+            bound[a["bindings"][VAR]] = (a.get("citations") or [{}])[0]
+        assert set(bound) == {characteristic}, f"{gland}: bound {set(bound)} != {{{characteristic}}}"
+        cite = bound[characteristic]
+        assert cite.get("trust") == "authoritative", f"{gland}/{characteristic} not authoritative"
+        assert cite.get("source"), f"{gland}/{characteristic} has no source span"
+        assert cite.get("locator", "").startswith("https://www.ncbi.nlm.nih.gov/")
+
+
+# ---- 3. an off-vocabulary gland abstains, never fabricates ----------------------------
+
+def test_unknown_gland_abstains() -> None:
+    if not _cli_available():
+        return
+    import os
+    import tempfile
+    fd, path = tempfile.mkstemp(suffix=".adj", prefix=".exocrine_q_", dir=HERE)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            # "sebaceous_gland" is a real exocrine gland of the skin (it secretes
+            # sebum), but it is NOT one of the salivary/sweat glands this library
+            # models, so it is deliberately absent — the engine must abstain rather
+            # than fabricate a characteristic.
+            fh.write(f'import "exocrine-gland-edges.adj"\n? {REL}(sebaceous_gland, ${VAR})\n')
+        res = _run(Path(path))
+        r = res["recall"][0] if res["recall"] else None
+        assert r is not None and r["abstained"], "an ungrounded gland must abstain"
+    finally:
+        os.unlink(path)
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS  {t.__name__}")
+        except AssertionError as exc:
+            failed += 1
+            print(f"  FAIL  {t.__name__}: {exc}")
+    print(f"\ntest_exocrine_gland_recall: {len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())


### PR DESCRIPTION
## What

New **pure-ADJ** MYCIN-2026 recall domain: the distinguishing feature of each major head/skin **exocrine gland** — the three paired salivary glands (by secretion type) and the two sweat glands (by function / distribution). High-yield histology/physiology board table. The shipped artifact is the ADJ library itself — facts + byte-provenance inline, **no Python gate, no JSON, no manifest** (same shape as EPIDERMIS / COMPLEMENT / IG-ISOTYPE).

## Edges (5, single-answer)

`characterized_by(exocrine_gland, characteristic)`:

| gland | characteristic | source |
|---|---|---|
| parotid gland | serous | NBK551688 |
| sublingual gland | mucous | NBK551688 |
| submandibular gland | mixed (predominantly serous) | NBK551688 |
| eccrine sweat gland | thermoregulatory_sweat | NBK482278 |
| apocrine sweat gland | axillary_anogenital | NBK482199 |

Each `source` span is a **self-contained NCBI StatPearls/Bookshelf sentence** naming the gland by its **full term** AND its characteristic in one sentence. Every span was **independently re-fetched twice** for byte-stability.

The relation is intentionally general (`characterized_by`) so it carries whatever the cited sentence actually pins down — secretion type, physiologic function, or anatomic distribution.

Abstain probe: `sebaceous_gland` — a real skin exocrine gland not among the salivary/sweat set → the engine **abstains** rather than fabricate.

## Files

- `exocrine-gland-edges.adj` — the grounded knowledge graph (sole source of truth)
- `exocrine-gland-recall.query.adj` — worked binding query (the shape an LLM emits)
- `test_exocrine_gland_recall.py` — 3-test scaffold (pure-ADJ shape; engine binds with authoritative citation; unknown gland abstains)

## Verification

- Local: **3/3** tests pass against the native `adj-lang-cli`.
- Security review: **PASSED** (list-form subprocess, atomic `mkstemp`+`os.unlink`, `json.loads` only, no network/eval/secrets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)