### PR TITLE
Add mesh readiness handoff action evidence review disposition summary

### DIFF
--- a/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
+++ b/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
@@ -110,6 +110,10 @@ All notable changes to this package will be documented in this file.
   turn evidence review outcomes into repair, review, lineage, operator, and
   release handoff actions.
 - Mesh release ticket handoff readiness-evidence review disposition-action
+  readiness execution handoff action evidence review disposition summaries
+  that combine disposition rows with next repair, review, lineage, and release
+  handoff pointers.
+- Mesh release ticket handoff readiness-evidence review disposition-action
   readiness execution handoff action evidence review summaries that combine
   review rows with next blocker, review, lineage, and release-ready pointers.
 - Mesh release ticket handoff readiness-evidence review disposition-action

--- a/code/packages/rust/smart-home-integration-catalog/README.md
+++ b/code/packages/rust/smart-home-integration-catalog/README.md
@@ -281,6 +281,10 @@ runtime and Chief of Staff tools a typed catalog for:
   disposition rows that turn evidence review outcomes into repair, review,
   lineage, operator, and release handoff actions
 - mesh release ticket handoff readiness-evidence review disposition-action
+  readiness execution handoff action evidence review disposition summaries
+  that combine disposition rows with next repair, review, lineage, and release
+  handoff pointers
+- mesh release ticket handoff readiness-evidence review disposition-action
   readiness execution handoff action evidence review summaries that combine
   review rows with next blocker, review, lineage, and release-ready pointers
 - mesh release ticket handoff readiness-evidence review disposition-action

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -23633,6 +23633,301 @@ impl
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationMeshReleaseTicketHandoffReadinessEvidenceReviewDispositionActionReadinessExecutionHandoffActionEvidenceReviewDispositionSummary {
+    pub release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_summary:
+        Box<IntegrationMeshReleaseTicketHandoffReadinessEvidenceReviewDispositionActionReadinessExecutionHandoffActionEvidenceReviewSummary>,
+    pub total_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_rows:
+        usize,
+    pub total_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_rows:
+        usize,
+    pub required_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_rows:
+        usize,
+    pub repair_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_rows:
+        usize,
+    pub operator_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_rows:
+        usize,
+    pub review_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_rows:
+        usize,
+    pub lineage_repair_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_rows:
+        usize,
+    pub release_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_rows:
+        usize,
+    pub release_ready_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_rows:
+        usize,
+    pub first_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_row_key:
+        Option<String>,
+    pub first_required_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_row_key:
+        Option<String>,
+    pub first_repair_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_row_key:
+        Option<String>,
+    pub first_operator_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_row_key:
+        Option<String>,
+    pub first_review_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_row_key:
+        Option<String>,
+    pub first_lineage_repair_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_row_key:
+        Option<String>,
+    pub first_release_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_row_key:
+        Option<String>,
+    pub first_release_ready_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_row_key:
+        Option<String>,
+    pub first_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_row_key:
+        Option<String>,
+    pub first_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_row_key:
+        Option<String>,
+    pub first_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_row_key:
+        Option<String>,
+    pub first_readiness_evidence_review_disposition_action_readiness_execution_handoff_row_key:
+        Option<String>,
+    pub first_readiness_evidence_review_disposition_action_readiness_execution_slot_key:
+        Option<String>,
+    pub first_readiness_evidence_review_disposition_action_key: Option<String>,
+    pub first_work_order_key: Option<String>,
+    pub first_ticket_key: Option<String>,
+    pub first_handoff_action_kind: Option<
+        IntegrationMeshReleaseTicketHandoffReadinessEvidenceReviewDispositionActionReadinessExecutionHandoffActionKind,
+    >,
+    pub first_handoff_action_evidence_review_disposition_action_kind: Option<
+        IntegrationMeshReleaseTicketHandoffExecutionWorkOrderGuardrailAuditClearanceActionEvidenceReviewDispositionActionSlotClearanceActionEvidenceReviewClearanceActionReadinessEvidenceReviewDispositionActionKind,
+    >,
+    pub first_handoff_lane: Option<IntegrationMeshReleaseDispatchTicketHandoffLane>,
+    pub first_check_kind: Option<IntegrationMeshReleaseReadinessCheckKind>,
+    pub first_check_status: Option<IntegrationMeshReleaseReadinessStatus>,
+    pub next_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_row_key:
+        Option<String>,
+    pub next_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_row_key:
+        Option<String>,
+    pub next_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_row_key:
+        Option<String>,
+    pub next_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_row_key:
+        Option<String>,
+    pub next_readiness_evidence_review_disposition_action_readiness_execution_handoff_row_key:
+        Option<String>,
+    pub next_readiness_evidence_review_disposition_action_readiness_execution_slot_key:
+        Option<String>,
+    pub next_readiness_evidence_review_disposition_action_key: Option<String>,
+    pub next_work_order_key: Option<String>,
+    pub next_ticket_key: Option<String>,
+    pub next_check_kind: Option<IntegrationMeshReleaseReadinessCheckKind>,
+    pub next_check_status: Option<IntegrationMeshReleaseReadinessStatus>,
+    pub next_handoff_lane: Option<IntegrationMeshReleaseDispatchTicketHandoffLane>,
+    pub release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_reviews_ready:
+        bool,
+    pub release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_dispositions_ready:
+        bool,
+}
+
+impl
+    IntegrationMeshReleaseTicketHandoffReadinessEvidenceReviewDispositionActionReadinessExecutionHandoffActionEvidenceReviewDispositionSummary
+{
+    pub fn from_summaries<'a>(
+        release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_summary: IntegrationMeshReleaseTicketHandoffReadinessEvidenceReviewDispositionActionReadinessExecutionHandoffActionEvidenceReviewSummary,
+        disposition_rows: impl IntoIterator<
+            Item = &'a IntegrationMeshReleaseTicketHandoffReadinessEvidenceReviewDispositionActionReadinessExecutionHandoffActionEvidenceReviewDispositionRow,
+        >,
+    ) -> Self {
+        let disposition_rows: Vec<&IntegrationMeshReleaseTicketHandoffReadinessEvidenceReviewDispositionActionReadinessExecutionHandoffActionEvidenceReviewDispositionRow> =
+            disposition_rows.into_iter().collect();
+        let first_row = disposition_rows.first().copied();
+        let first_required_row = disposition_rows
+            .iter()
+            .copied()
+            .find(|row| row.requires_attention());
+        let first_repair_row = disposition_rows
+            .iter()
+            .copied()
+            .find(|row| row.is_repair_disposition());
+        let first_operator_row = disposition_rows
+            .iter()
+            .copied()
+            .find(|row| row.is_operator_disposition());
+        let first_review_row = disposition_rows
+            .iter()
+            .copied()
+            .find(|row| row.is_review_disposition());
+        let first_lineage_repair_row = disposition_rows
+            .iter()
+            .copied()
+            .find(|row| row.is_lineage_repair_disposition());
+        let first_release_handoff_row = disposition_rows
+            .iter()
+            .copied()
+            .find(|row| row.is_release_handoff_disposition());
+        let first_release_ready_row = disposition_rows
+            .iter()
+            .copied()
+            .find(|row| row.is_release_ready_disposition());
+        let next_row = first_required_row;
+        let release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_dispositions_ready =
+            disposition_rows.len()
+                == release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_summary
+                    .total_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_rows
+                && disposition_rows
+                    .iter()
+                    .all(|row| row.ready_to_release_handoff());
+
+        Self {
+            total_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_rows:
+                release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_summary
+                    .total_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_rows,
+            total_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_rows:
+                disposition_rows.len(),
+            required_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_rows:
+                disposition_rows.iter().filter(|row| row.requires_attention()).count(),
+            repair_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_rows:
+                disposition_rows.iter().filter(|row| row.is_repair_disposition()).count(),
+            operator_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_rows:
+                disposition_rows.iter().filter(|row| row.is_operator_disposition()).count(),
+            review_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_rows:
+                disposition_rows.iter().filter(|row| row.is_review_disposition()).count(),
+            lineage_repair_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_rows:
+                disposition_rows.iter().filter(|row| row.is_lineage_repair_disposition()).count(),
+            release_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_rows:
+                disposition_rows.iter().filter(|row| row.is_release_handoff_disposition()).count(),
+            release_ready_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_rows:
+                disposition_rows.iter().filter(|row| row.is_release_ready_disposition()).count(),
+            first_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_row_key:
+                first_row.map(|row| row.handoff_action_evidence_review_disposition_row_key.clone()),
+            first_required_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_row_key:
+                first_required_row.map(|row| row.handoff_action_evidence_review_disposition_row_key.clone()),
+            first_repair_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_row_key:
+                first_repair_row.map(|row| row.handoff_action_evidence_review_disposition_row_key.clone()),
+            first_operator_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_row_key:
+                first_operator_row.map(|row| row.handoff_action_evidence_review_disposition_row_key.clone()),
+            first_review_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_row_key:
+                first_review_row.map(|row| row.handoff_action_evidence_review_disposition_row_key.clone()),
+            first_lineage_repair_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_row_key:
+                first_lineage_repair_row.map(|row| row.handoff_action_evidence_review_disposition_row_key.clone()),
+            first_release_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_row_key:
+                first_release_handoff_row.map(|row| row.handoff_action_evidence_review_disposition_row_key.clone()),
+            first_release_ready_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_row_key:
+                first_release_ready_row.map(|row| row.handoff_action_evidence_review_disposition_row_key.clone()),
+            first_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_row_key:
+                first_row.map(|row| row.handoff_action_evidence_review_row_key.clone()),
+            first_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_row_key:
+                first_row.map(|row| row.handoff_action_evidence_row_key.clone()),
+            first_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_row_key:
+                first_row.map(|row| row.handoff_action_row_key.clone()),
+            first_readiness_evidence_review_disposition_action_readiness_execution_handoff_row_key:
+                first_row.map(|row| row.handoff_row_key.clone()),
+            first_readiness_evidence_review_disposition_action_readiness_execution_slot_key:
+                first_row.map(|row| {
+                    row.readiness_evidence_review_disposition_action_readiness_execution_slot_key
+                        .clone()
+                }),
+            first_readiness_evidence_review_disposition_action_key:
+                first_row.map(|row| row.readiness_evidence_review_disposition_action_key.clone()),
+            first_work_order_key: first_row.map(|row| row.work_order_key.clone()),
+            first_ticket_key: first_row.map(|row| row.ticket_key.clone()),
+            first_handoff_action_kind: first_row.map(|row| row.handoff_action_kind),
+            first_handoff_action_evidence_review_disposition_action_kind:
+                first_row.map(|row| row.handoff_action_evidence_review_disposition_action_kind),
+            first_handoff_lane: first_row.map(|row| row.handoff_lane),
+            first_check_kind: first_row.map(|row| row.check_kind),
+            first_check_status: first_row.map(|row| row.status),
+            next_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_row_key:
+                next_row.map(|row| row.handoff_action_evidence_review_disposition_row_key.clone()),
+            next_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_row_key:
+                next_row.map(|row| row.handoff_action_evidence_review_row_key.clone()),
+            next_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_row_key:
+                next_row.map(|row| row.handoff_action_evidence_row_key.clone()),
+            next_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_row_key:
+                next_row.map(|row| row.handoff_action_row_key.clone()),
+            next_readiness_evidence_review_disposition_action_readiness_execution_handoff_row_key:
+                next_row.map(|row| row.handoff_row_key.clone()),
+            next_readiness_evidence_review_disposition_action_readiness_execution_slot_key:
+                next_row.map(|row| {
+                    row.readiness_evidence_review_disposition_action_readiness_execution_slot_key
+                        .clone()
+                }),
+            next_readiness_evidence_review_disposition_action_key:
+                next_row.map(|row| row.readiness_evidence_review_disposition_action_key.clone()),
+            next_work_order_key: next_row.map(|row| row.work_order_key.clone()),
+            next_ticket_key: next_row.map(|row| row.ticket_key.clone()),
+            next_check_kind: next_row.map(|row| row.check_kind),
+            next_check_status: next_row.map(|row| row.status),
+            next_handoff_lane: next_row.map(|row| row.handoff_lane),
+            release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_reviews_ready:
+                release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_summary
+                    .ready_for_release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_reviews(),
+            release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_dispositions_ready,
+            release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_summary:
+                Box::new(
+                    release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_summary,
+                ),
+        }
+    }
+
+    pub fn has_handoff_action_evidence_review_disposition_rows(&self) -> bool {
+        self.total_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_rows > 0
+    }
+
+    pub fn ready_for_release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_dispositions(
+        &self,
+    ) -> bool {
+        self.release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_reviews_ready
+            && self.release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_dispositions_ready
+            && !self.requires_attention()
+    }
+
+    pub fn has_required_dispositions(&self) -> bool {
+        self.required_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_rows
+            > 0
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.repair_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_rows
+            > 0
+            || self
+                .release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_summary
+                .has_blockers()
+    }
+
+    pub fn needs_operator(&self) -> bool {
+        self.operator_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_rows
+            > 0
+            || self
+                .release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_summary
+                .needs_operator()
+    }
+
+    pub fn has_review_work(&self) -> bool {
+        self.review_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_rows
+            > 0
+            || self
+                .release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_summary
+                .has_review_work()
+    }
+
+    pub fn has_lineage_repairs(&self) -> bool {
+        self.lineage_repair_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_rows
+            > 0
+            || self
+                .release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_summary
+                .has_lineage_gaps()
+    }
+
+    pub fn has_release_handoff_dispositions(&self) -> bool {
+        self.release_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_rows
+            > 0
+    }
+
+    pub fn has_release_ready_dispositions(&self) -> bool {
+        self.release_ready_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_rows
+            > 0
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.has_required_dispositions()
+            || self.has_blockers()
+            || self.needs_operator()
+            || self.has_review_work()
+            || self.has_lineage_repairs()
+            || !self
+                .release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_dispositions_ready
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IntegrationMeshReleaseTicketHandoffReadinessEvidenceReviewDispositionActionReadinessExecutionHandoffSummary {
     pub release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_slot_summary:
         Box<IntegrationMeshReleaseTicketHandoffGuardrailAuditClearanceActionEvidenceReviewDispositionActionSlotClearanceActionEvidenceReviewClearanceActionReadinessEvidenceReviewDispositionActionReadinessExecutionSlotSummary>,
@@ -48254,6 +48549,49 @@ pub fn mesh_release_ticket_handoff_readiness_evidence_review_disposition_action_
     )
 }
 
+pub fn mesh_release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_summary_for_catalog(
+    catalog: &[IntegrationCatalogEntry],
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> IntegrationMeshReleaseTicketHandoffReadinessEvidenceReviewDispositionActionReadinessExecutionHandoffActionEvidenceReviewDispositionSummary
+{
+    let review_summary =
+        mesh_release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_summary_for_catalog(
+            catalog,
+            available_primitives,
+            allowed_capabilities,
+            enabled_integrations,
+        );
+    let disposition_rows =
+        mesh_release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_rows_for_catalog(
+            catalog,
+            available_primitives,
+            allowed_capabilities,
+            enabled_integrations,
+        );
+
+    IntegrationMeshReleaseTicketHandoffReadinessEvidenceReviewDispositionActionReadinessExecutionHandoffActionEvidenceReviewDispositionSummary::from_summaries(
+        review_summary,
+        disposition_rows.iter(),
+    )
+}
+
+pub fn mesh_release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_summary(
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> IntegrationMeshReleaseTicketHandoffReadinessEvidenceReviewDispositionActionReadinessExecutionHandoffActionEvidenceReviewDispositionSummary
+{
+    let catalog = first_party_catalog();
+    mesh_release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_summary_for_catalog(
+        &catalog,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    )
+}
+
 pub fn mesh_release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_summary_for_catalog(
     catalog: &[IntegrationCatalogEntry],
     available_primitives: &[PrimitiveFamily],
@@ -66021,6 +66359,223 @@ mod tests {
             disposition_rows[0].handoff_action_kind,
             IntegrationMeshReleaseTicketHandoffReadinessEvidenceReviewDispositionActionReadinessExecutionHandoffActionKind::ReleaseHandoff
         );
+    }
+
+    #[test]
+    fn mesh_release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_summary_surfaces_attention(
+    ) {
+        let available_primitives = vec![
+            PrimitiveFamily::Usb,
+            PrimitiveFamily::SerialController,
+            PrimitiveFamily::Radio802154,
+            PrimitiveFamily::Supervision,
+        ];
+        let allowed_capabilities = vec![CapabilityId::trusted("smart_home.read")];
+        let summary =
+            mesh_release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_summary(
+                &available_primitives,
+                &allowed_capabilities,
+                &[],
+            );
+
+        assert_eq!(
+            summary
+                .total_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_rows,
+            5
+        );
+        assert_eq!(
+            summary
+                .total_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_rows,
+            5
+        );
+        assert_eq!(
+            summary
+                .required_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_rows,
+            5
+        );
+        assert_eq!(
+            summary
+                .repair_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_rows,
+            3
+        );
+        assert_eq!(
+            summary
+                .review_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_rows,
+            2
+        );
+        assert_eq!(
+            summary
+                .operator_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_rows,
+            0
+        );
+        assert_eq!(
+            summary
+                .lineage_repair_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_rows,
+            0
+        );
+        assert_eq!(
+            summary
+                .release_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_rows,
+            0
+        );
+        assert_eq!(
+            summary
+                .release_ready_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_rows,
+            0
+        );
+        assert_eq!(
+            summary.first_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_row_key,
+            Some(
+                "release-ticket-handoff-readiness-evidence-review-disposition-action-readiness-handoff-action-evidence-review-disposition-01-schedule_release_blocker_repair-substrate_actions"
+                    .to_string()
+            )
+        );
+        assert_eq!(
+            summary.first_required_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_row_key,
+            summary
+                .first_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_row_key
+        );
+        assert_eq!(
+            summary.first_repair_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_row_key,
+            summary
+                .first_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_row_key
+        );
+        assert_eq!(
+            summary.first_review_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_row_key,
+            Some(
+                "release-ticket-handoff-readiness-evidence-review-disposition-action-readiness-handoff-action-evidence-review-disposition-02-complete_evidence_review-evidence_remediation"
+                    .to_string()
+            )
+        );
+        assert_eq!(
+            summary.first_operator_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_row_key,
+            None
+        );
+        assert_eq!(
+            summary.next_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_row_key,
+            summary
+                .first_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_row_key
+        );
+        assert_eq!(
+            summary.next_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_row_key,
+            summary
+                .first_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_row_key
+        );
+        assert_eq!(summary.next_work_order_key, summary.first_work_order_key);
+        assert_eq!(summary.next_ticket_key, summary.first_ticket_key);
+        assert_eq!(
+            summary.next_handoff_lane,
+            Some(IntegrationMeshReleaseDispatchTicketHandoffLane::Repair)
+        );
+        assert!(!summary
+            .release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_reviews_ready);
+        assert!(!summary
+            .release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_dispositions_ready);
+        assert!(!summary.ready_for_release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_dispositions());
+        assert!(summary.has_handoff_action_evidence_review_disposition_rows());
+        assert!(summary.has_required_dispositions());
+        assert!(summary.has_blockers());
+        assert!(summary.has_review_work());
+        assert!(summary.needs_operator());
+        assert!(!summary.has_lineage_repairs());
+        assert!(!summary.has_release_handoff_dispositions());
+        assert!(!summary.has_release_ready_dispositions());
+        assert!(summary.requires_attention());
+    }
+
+    #[test]
+    fn mesh_release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_summary_marks_release_ready(
+    ) {
+        let catalog = vec![hue_entry()];
+        let allowed_capabilities = vec![
+            CapabilityId::trusted("smart_home.read"),
+            CapabilityId::trusted("smart_home.command.light"),
+            CapabilityId::trusted("smart_home.pair"),
+        ];
+        let summary =
+            mesh_release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_summary_for_catalog(
+                &catalog,
+                all_primitive_families(),
+                &allowed_capabilities,
+                &[],
+            );
+
+        assert_eq!(
+            summary
+                .total_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_rows,
+            5
+        );
+        assert_eq!(
+            summary
+                .required_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_rows,
+            0
+        );
+        assert_eq!(
+            summary
+                .repair_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_rows,
+            0
+        );
+        assert_eq!(
+            summary
+                .review_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_rows,
+            0
+        );
+        assert_eq!(
+            summary
+                .lineage_repair_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_rows,
+            0
+        );
+        assert_eq!(
+            summary
+                .release_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_rows,
+            5
+        );
+        assert_eq!(
+            summary
+                .release_ready_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_rows,
+            5
+        );
+        assert_eq!(
+            summary.first_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_row_key,
+            Some(
+                "release-ticket-handoff-readiness-evidence-review-disposition-action-readiness-handoff-action-evidence-review-disposition-01-release_handoff-substrate_actions"
+                    .to_string()
+            )
+        );
+        assert_eq!(
+            summary.first_required_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_row_key,
+            None
+        );
+        assert_eq!(
+            summary.first_release_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_row_key,
+            summary
+                .first_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_row_key
+        );
+        assert_eq!(
+            summary.first_release_ready_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_row_key,
+            summary
+                .first_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_row_key
+        );
+        assert_eq!(
+            summary.next_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_disposition_row_key,
+            None
+        );
+        assert_eq!(summary.next_work_order_key, None);
+        assert_eq!(summary.next_ticket_key, None);
+        assert!(summary
+            .release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_reviews_ready);
+        assert!(summary
+            .release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_dispositions_ready);
+        assert!(summary.ready_for_release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_dispositions());
+        assert!(summary.has_handoff_action_evidence_review_disposition_rows());
+        assert!(!summary.has_required_dispositions());
+        assert!(!summary.has_blockers());
+        assert!(!summary.needs_operator());
+        assert!(!summary.has_review_work());
+        assert!(!summary.has_lineage_repairs());
+        assert!(summary.has_release_handoff_dispositions());
+        assert!(summary.has_release_ready_dispositions());
+        assert!(!summary.requires_attention());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a handoff action evidence review disposition summary over the new disposition rows
- expose catalog/default constructors and ready/attention helpers
- document the summary helper in the smart-home catalog README and changelog

## Tests
- cargo test --manifest-path code/packages/rust/smart-home-integration-catalog/Cargo.toml handoff_action_evidence_review_disposition_summary -- --nocapture
- cargo test --manifest-path code/packages/rust/smart-home-integration-catalog/Cargo.toml
- git diff --check