### PR TITLE
feat(visicalc-flutter): find/replace in the Flutter demo

### DIFF
--- a/demo/visicalc-flutter/lib/engine.dart
+++ b/demo/visicalc-flutter/lib/engine.dart
@@ -80,6 +80,14 @@ typedef _SortRangeC = Int32 Function(
 typedef _SortRangeD = int Function(
     Pointer<Void>, Pointer<Uint8>, Pointer<Uint8>, int, int);
 
+// sc_find_all(session, query, in_formulas, match_case) → char* JSON
+// {"matches":["A1",…]} (free with sc_string_free).
+typedef _FindAllC = Pointer<Uint8> Function(Pointer<Void>, Pointer<Uint8>, Int32, Int32);
+typedef _FindAllD = Pointer<Uint8> Function(Pointer<Void>, Pointer<Uint8>, int, int);
+// sc_replace_all(session, query, replacement, match_case) → int (count changed).
+typedef _ReplaceAllC = Int32 Function(Pointer<Void>, Pointer<Uint8>, Pointer<Uint8>, Int32);
+typedef _ReplaceAllD = int Function(Pointer<Void>, Pointer<Uint8>, Pointer<Uint8>, int);
+
 // sc_insert_rows / sc_delete_rows / sc_insert_cols / sc_delete_cols(session, at,
 // count) → void. Structural edits at a 1-based position; the engine shifts
 // formula references across the band.
@@ -110,6 +118,8 @@ class SpreadsheetSession {
   late final _SetFormatD _setFormatFn;
   late final _FillD _fillFn;
   late final _SortRangeD _sortRangeFn;
+  late final _FindAllD _findAllFn;
+  late final _ReplaceAllD _replaceAllFn;
   late final _ClipD _copyFn;
   late final _ClipD _cutFn;
   late final _PasteD _pasteFn;
@@ -147,6 +157,8 @@ class SpreadsheetSession {
     _setFormatFn = _lib.lookupFunction<_SetFormatC, _SetFormatD>('sc_set_format');
     _fillFn = _lib.lookupFunction<_FillC, _FillD>('sc_fill');
     _sortRangeFn = _lib.lookupFunction<_SortRangeC, _SortRangeD>('sc_sort_range');
+    _findAllFn = _lib.lookupFunction<_FindAllC, _FindAllD>('sc_find_all');
+    _replaceAllFn = _lib.lookupFunction<_ReplaceAllC, _ReplaceAllD>('sc_replace_all');
     _copyFn = _lib.lookupFunction<_ClipC, _ClipD>('sc_copy');
     _cutFn = _lib.lookupFunction<_ClipC, _ClipD>('sc_cut');
     _pasteFn = _lib.lookupFunction<_PasteC, _PasteD>('sc_paste');
@@ -340,6 +352,36 @@ class SpreadsheetSession {
     } finally {
       _freeCString(startPtr);
       _freeCString(endPtr);
+    }
+  }
+
+  /// Find every cell whose text contains [query] — the A1 addresses, parsed from
+  /// the engine's `{"matches":[...]}` JSON. [inFormulas] searches each cell's
+  /// source when true, its computed display value when false; [matchCase]=false
+  /// folds ASCII case. Empty query → empty list. Read-only.
+  List<String> findAll(String query, bool inFormulas, bool matchCase) {
+    final qPtr = _toCString(query);
+    try {
+      final json = _takeString(_findAllFn(_handle, qPtr, inFormulas ? 1 : 0, matchCase ? 1 : 0));
+      final obj = jsonDecode(json) as Map<String, dynamic>;
+      return (obj['matches'] as List).cast<String>();
+    } finally {
+      _freeCString(qPtr);
+    }
+  }
+
+  /// Replace [query] with [replacement] in the source of every matching cell (the
+  /// engine rewrites + recomputes; the facade keeps its source echo in step).
+  /// [matchCase]=false folds ASCII case. Returns the count of cells changed; an
+  /// empty query is a no-op (0).
+  int replaceAll(String query, String replacement, bool matchCase) {
+    final qPtr = _toCString(query);
+    final rPtr = _toCString(replacement);
+    try {
+      return _replaceAllFn(_handle, qPtr, rPtr, matchCase ? 1 : 0);
+    } finally {
+      _freeCString(qPtr);
+      _freeCString(rPtr);
     }
   }
 
@@ -682,6 +724,29 @@ class InfiniteSheetModel {
     final ok = _session.sortRange('A1', 'E4', keyCol, ascending);
     computeExtent();
     return ok;
+  }
+
+  /// Find: the A1 addresses whose source contains [query] (case-insensitive).
+  List<String> findAll(String query) => _session.findAll(query, true, false);
+
+  /// Replace [query] → [replacement] in every matching cell's source (the engine
+  /// recomputes); returns the count changed and regrows the extent.
+  int replaceAll(String query, String replacement) {
+    final n = _session.replaceAll(query, replacement, false);
+    computeExtent();
+    return n;
+  }
+
+  /// Select the cell at an A1 address (e.g. "B3"); a no-op for a malformed ref.
+  void selectA1(String a1) {
+    final m = RegExp(r'^([A-Za-z]+)(\d+)$').firstMatch(a1);
+    if (m == null) return;
+    final letters = m.group(1)!.toUpperCase();
+    var col = 0;
+    for (var i = 0; i < letters.length; i++) {
+      col = col * 26 + (letters.codeUnitAt(i) - 64);
+    }
+    selectInf(int.parse(m.group(2)!), col);
   }
 
   /// Structural edits: insert / delete the selected cell's row or column. The

--- a/demo/visicalc-flutter/lib/infinite_grid.dart
+++ b/demo/visicalc-flutter/lib/infinite_grid.dart
@@ -79,6 +79,10 @@ class _InfiniteGridState extends State<InfiniteGrid> {
   // Drives the formula field's accent focus ring (rebuild on focus changes).
   final _formulaFocus = FocusNode();
 
+  // Find / replace inputs.
+  final _findCtrl = TextEditingController();
+  final _replaceCtrl = TextEditingController();
+
   // In-memory "saved file" slot for the Save / Load buttons: Save stows the
   // serialized workbook here, Load restores from it. (A real app would write
   // this string to a file; the demo keeps the round trip self-contained.)
@@ -112,6 +116,8 @@ class _InfiniteGridState extends State<InfiniteGrid> {
     _headerH.dispose();
     _formulaCtrl.dispose();
     _formulaFocus.dispose();
+    _findCtrl.dispose();
+    _replaceCtrl.dispose();
     _model.dispose();
     super.dispose();
   }
@@ -197,6 +203,29 @@ class _InfiniteGridState extends State<InfiniteGrid> {
   // ascending/descending. A setState rebuild re-reads the reordered rows.
   void _sortBlock(bool ascending) => setState(() => _model.sortBlock(ascending));
 
+  // Find: select the first cell whose source contains the find text.
+  void _find() {
+    final q = _findCtrl.text;
+    if (q.isEmpty) return;
+    final hits = _model.findAll(q);
+    if (hits.isEmpty) return;
+    setState(() {
+      _model.selectA1(hits.first);
+      _formulaCtrl.text = _model.formula;
+    });
+  }
+
+  // Replace all: rewrite the find text → replacement in every matching cell's
+  // source (the engine recomputes); the grid re-reads.
+  void _replaceAll() {
+    final q = _findCtrl.text;
+    if (q.isEmpty) return;
+    setState(() {
+      _model.replaceAll(q, _replaceCtrl.text);
+      _formulaCtrl.text = _model.formula;
+    });
+  }
+
   // A compact, modern toolbar button (rounded chip with hover/down/disabled
   // states) — the Flutter analog of the web demo's segmented controls and the
   // Qt port's `component ToolButton`. `enabled: null` disables it (Undo/Redo/
@@ -217,6 +246,32 @@ class _InfiniteGridState extends State<InfiniteGrid> {
         height: 22,
         margin: const EdgeInsets.symmetric(horizontal: 6),
         color: _cLine,
+      );
+
+  // A compact toolbar text field for the find / replace inputs.
+  Widget _findField(TextEditingController ctrl, String hint) => SizedBox(
+        width: 96,
+        child: Container(
+          height: 30,
+          padding: const EdgeInsets.symmetric(horizontal: 8),
+          decoration: BoxDecoration(
+            color: _cField,
+            borderRadius: BorderRadius.circular(5),
+            border: Border.all(color: _cLineStrong),
+          ),
+          alignment: Alignment.centerLeft,
+          child: TextField(
+            controller: ctrl,
+            style: const TextStyle(color: _cInk, fontSize: 12, fontFamily: _mono),
+            cursorColor: _cAccent,
+            decoration: InputDecoration(
+              isCollapsed: true,
+              border: InputBorder.none,
+              hintText: hint,
+              hintStyle: const TextStyle(color: Color(0xFF5F6672), fontSize: 12, fontFamily: _mono),
+            ),
+          ),
+        ),
       );
 
   @override
@@ -298,6 +353,7 @@ class _InfiniteGridState extends State<InfiniteGrid> {
               ),
               alignment: Alignment.centerLeft,
               child: TextField(
+                key: const Key('formulaField'),
                 controller: _formulaCtrl,
                 focusNode: _formulaFocus,
                 onSubmitted: (_) => _commit(),
@@ -367,6 +423,18 @@ class _InfiniteGridState extends State<InfiniteGrid> {
           _toolButton('▼ Sort',
               'Sort the budget block A1:E4 by the selected column, descending',
               () => _sortBlock(false)),
+          _toolSep(),
+          // ── Find / replace (locate cells by text; bulk-edit their source) ──
+          _findField(_findCtrl, 'find'),
+          const SizedBox(width: 6),
+          _findField(_replaceCtrl, 'replace'),
+          const SizedBox(width: 6),
+          _toolButton('Find',
+              'Select the first cell whose source contains the find text', _find),
+          const SizedBox(width: 6),
+          _toolButton('Replace all',
+              "Replace the find text with the replacement in every matching cell's source",
+              _replaceAll),
           _toolSep(),
           // ── History (undo / redo) ──
           _toolButton('↶ Undo', 'Undo the last edit', _undo,

--- a/demo/visicalc-flutter/test/infinite_grid_test.dart
+++ b/demo/visicalc-flutter/test/infinite_grid_test.dart
@@ -63,7 +63,7 @@ void main() {
     await tester.tap(cell('15'));
     await tester.pumpAndSettle();
 
-    final field = tester.widget<TextField>(find.byType(TextField));
+    final field = tester.widget<TextField>(find.byKey(const Key('formulaField')));
     expect(field.controller!.text, '15');
     expect(find.text('A1'), findsOneWidget);
   });
@@ -75,7 +75,7 @@ void main() {
     // Select A1 and change 15 -> 115 through the formula bar.
     await tester.tap(cell('15'));
     await tester.pumpAndSettle();
-    await tester.enterText(find.byType(TextField), '115');
+    await tester.enterText(find.byKey(const Key('formulaField')), '115');
     await tester.testTextInput.receiveAction(TextInputAction.done);
     await tester.pumpAndSettle();
 

--- a/demo/visicalc-flutter/test/window_test.dart
+++ b/demo/visicalc-flutter/test/window_test.dart
@@ -306,5 +306,31 @@ void main() {
       expect(s.sortRange('A1', 'A1', 1, true), isFalse); // single-row range
       expect(s.sortRange('A1', 'E4', 9, true), isFalse); // key column outside range
     });
+
+    // Find / replace (the Find / Replace-all buttons drive findAll/replaceAll):
+    // locate cells by text and bulk-edit their source.
+    test('findAll and replaceAll locate and rewrite cells', () {
+      final s = SpreadsheetSession();
+      addTearDown(s.dispose);
+      s.setCell('A1', '100');
+      s.setCell('A2', '100');
+      s.setCell('B1', '=A1+1'); // displays 101
+      // find by computed value: "10" is in 100/100/101.
+      final byVal = s.findAll('10', false, true);
+      expect(byVal.toSet(), {'A1', 'A2', 'B1'});
+      // find by source: "A1" only in B1's formula text.
+      expect(s.findAll('A1', true, true), ['B1']);
+      // empty query → no matches.
+      expect(s.findAll('', false, true), isEmpty);
+      // replace the literal 100 → 7 in the two number cells (count 2).
+      expect(s.replaceAll('100', '7', true), 2);
+      expect(s.window(1, 1, 1, 1)[0][0], '7'); // A1
+      // replace A1 → A2 in the formula source; it re-parses + recomputes (=A2+1 = 8).
+      expect(s.replaceAll('A1', 'A2', true), 1);
+      expect(s.window(1, 2, 1, 2)[0][0], '8'); // B1
+      // no-match / empty query → 0.
+      expect(s.replaceAll('zzz', 'q', true), 0);
+      expect(s.replaceAll('', 'q', true), 0);
+    });
   });
 }


### PR DESCRIPTION
## What

Third demo of the find/replace rollout (after web [#6678](https://github.com/adhithyan15/coding-adventures/pull/6678), Qt [#6680](https://github.com/adhithyan15/coding-adventures/pull/6680)). Adds a **"Find / Replace"** toolbar group to `infinite_grid.dart` — find field + replace field + **Find** + **Replace all** buttons — over new `dart:ffi` bindings:

- `engine.dart`: `findAll(query,inFormulas,matchCase) -> List<String>` (binds `sc_find_all`, `jsonDecode` of `{"matches":[…]}`, frees the char* via the existing `_takeString`) + `replaceAll(...) -> int` (`sc_replace_all`). Same `_toCString`/`_freeCString` try/finally as `sortRange`.
- model: `findAll`/`replaceAll` + `selectA1` (regex-parses an A1 → `selectInf`, which clamps).
- UI: two `TextEditingController`s (disposed) + find/replace fields + Find (selects first match) / Replace-all buttons. The formula `TextField` is keyed so the widget test disambiguates among the three fields.

## Verification

Re-vendored the capi cdylib (now carries `sc_find_all`/`sc_replace_all`). **`flutter test` → 22/22** (incl. widget tests + the new `findAll and replaceAll locate and rewrite cells`: find by value/source + empty; replace `100→7` count 2; formula-ref `A1→A2` count 1, `B1` recomputes to 8; no-match/empty → 0). **`flutter analyze` clean**. Security review **passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)