### PR TITLE
feat(mycin-recall): ISLET-CELL pancreatic-islet-cell→hormone recall library

### DIFF
--- a/code/specs/data/mycin-2026/recall/islet-cell-edges.adj
+++ b/code/specs/data/mycin-2026/recall/islet-cell-edges.adj
@@ -1,0 +1,77 @@
+% ============================================================================
+% islet-cell-edges — the pancreatic islet cell → secreted hormone knowledge-graph
+% (MYCIN-2026 ISLET-CELL).
+% ============================================================================
+% A high-yield endocrine-histology board table: the cell types of the islets of
+% Langerhans and the hormone each secretes. "What does a pancreatic beta cell
+% secrete?" becomes the binding query
+%     ? secretes(beta_cell, $Hormone).
+%
+% Direction note: the relation is islet cell type -> the hormone the cited sentence
+% states it secretes (`secretes`). Each cell maps to ONE canonical hormone span, so
+% a query binds a single answer.
+%
+% Faithfulness note: each `relate` subject/object is bound to what the cited
+% sentence ACTUALLY names. The hormone object names the product the sentence states
+% (beta "insulin"; alpha "glucagon"; delta "somatostatin"; PP "pancreatic
+% polypeptide"; epsilon "ghrelin"). Each cited sentence names the cell by its FULL
+% term ("beta cells", "alpha cells", etc.) AND the hormone in the same sentence.
+% Each span was independently re-fetched and confirmed on two separate fetches of
+% the same page for byte-stability.
+%
+% This file is the SHIPPED ARTIFACT and the SOLE source of truth — no generator,
+% no JSON, no manifest (a pure ADJ-only recall domain, like EXOCRINE-GLAND/
+% EPIDERMIS/COMPLEMENT/IG-ISOTYPE). Each fact is a `relate` clause whose
+% byte-provenance lives INLINE:
+%     source   — the VERBATIM span copied from the cited page (byte-stable: it
+%                appears character-for-character in the page's normalized text;
+%                every span here was independently re-fetched and confirmed).
+%     locator  — the URL the span was read from (NCBI StatPearls / Bookshelf).
+%     trust    — authoritative (a primary, citable reference).
+% An LLM (or a human) recalls a fact by writing a tiny query .adj that `import`s
+% this library and asks a binding query — see islet-cell-recall.query.adj.
+% Nothing here is asserted "from memory": every edge is defended by a span a
+% reader can re-fetch and check.
+% (See feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+dictionary islet_cell_vocab {
+    define islet_cell : entity   surface "pancreatic islet cell", "islet of Langerhans cell"
+    define hormone    : entity   surface "hormone", "secreted hormone"
+
+    define secretes : relation from islet_cell to hormone  % the hormone this islet cell type secretes
+}
+
+rulebook islet_cell_facts {
+    use islet_cell_vocab
+
+    % --- beta cell -> insulin -----------------------------------------------
+    relate secretes(beta_cell, insulin)
+        source "Insulin is a peptide hormone secreted in the body by beta cells of islets of Langerhans of the pancreas and regulates blood glucose levels."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK560688/"
+        trust authoritative
+
+    % --- alpha cell -> glucagon ---------------------------------------------
+    relate secretes(alpha_cell, glucagon)
+        source "The alpha cells release glucagon, a peptide hormone that raises the concentration of glucose and fatty acids in the bloodstream and is the primary catabolic hormone in the body."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK542302/"
+        trust authoritative
+
+    % --- delta cell -> somatostatin -----------------------------------------
+    relate secretes(delta_cell, somatostatin)
+        source "The delta cells release somatostatin, which inhibits glucagon and insulin secretion."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK542302/"
+        trust authoritative
+
+    % --- PP cell -> pancreatic polypeptide ----------------------------------
+    relate secretes(pp_cell, pancreatic_polypeptide)
+        source "The PP cells release pancreatic polypeptide, a satiety hormone that decreases gastric acid secretion, emptying, and upper intestinal motility."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK542302/"
+        trust authoritative
+
+    % --- epsilon cell -> ghrelin --------------------------------------------
+    relate secretes(epsilon_cell, ghrelin)
+        source "The epsilon cells release ghrelin, a hormone that stimulates appetite, increases fat storage, and stimulates the growth hormone release from the pituitary gland."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK542302/"
+        trust authoritative
+}

--- a/code/specs/data/mycin-2026/recall/islet-cell-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/islet-cell-recall.query.adj
@@ -1,0 +1,21 @@
+% ============================================================================
+% islet-cell-recall.query.adj — a worked recall query over the islet-cell library.
+% ============================================================================
+% The shape an LLM (or a student) produces to ANSWER a "what hormone does
+% pancreatic islet cell X secrete?" question: it states no endocrinology fact — it
+% only `import`s the grounded library and asks binding queries. The native adj-lang
+% engine resolves each `?` against the imported `relate` edges and returns the
+% binding + the citing clause's source/locator/trust. All knowledge is in the
+% library; none is here.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli islet-cell-recall.query.adj
+% ============================================================================
+
+import "islet-cell-edges.adj"
+
+? secretes(beta_cell, $Hormone)      % expect insulin
+? secretes(alpha_cell, $Hormone)     % expect glucagon
+? secretes(delta_cell, $Hormone)     % expect somatostatin
+? secretes(pp_cell, $Hormone)        % expect pancreatic_polypeptide
+? secretes(epsilon_cell, $Hormone)   % expect ghrelin

--- a/code/specs/data/mycin-2026/recall/test_islet_cell_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_islet_cell_recall.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""test_islet_cell_recall.py — the ADJ-only pancreatic-islet-cell→hormone recall
+library (MYCIN-2026 ISLET-CELL).
+
+A pure-ADJ recall domain (high-yield endocrine-histology board table): the hormone
+each cell type of the islets of Langerhans secretes. `islet-cell-edges.adj` is the
+SOLE source of truth — facts + byte-provenance inline, no Python gate, no JSON, no
+manifest. This test pins the property that matters: the native adj-lang engine,
+given a query .adj that only `import`s the library and asks binding queries
+(`islet-cell-recall.query.adj` — the shape an LLM produces), binds the grounded
+hormone for each cell, each carrying an AUTHORITATIVE citation with a real source
+span + locator. Knowledge lives in ADJ; the engine answers.
+
+If the native CLI isn't built (a Python-only CI lane), the engine-backed checks
+skip — the file-shape checks (every clause grounded, no authored-debt) still run.
+
+Run:  python3 test_islet_cell_recall.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ADJ = HERE / "islet-cell-edges.adj"
+QUERY = HERE / "islet-cell-recall.query.adj"
+CLI = HERE.parents[3] / "packages" / "rust" / "target" / "debug" / "adj-lang-cli"
+
+# Every grounded edge: islet cell type -> the hormone the library binds.
+EXPECTED = {
+    "beta_cell": "insulin",                       # NBK560688
+    "alpha_cell": "glucagon",                     # NBK542302
+    "delta_cell": "somatostatin",                 # NBK542302
+    "pp_cell": "pancreatic_polypeptide",          # NBK542302
+    "epsilon_cell": "ghrelin",                    # NBK542302
+}
+REL = "secretes"
+VAR = "Hormone"
+
+
+def _cli_available() -> bool:
+    return CLI.exists()
+
+
+def _run(program: Path) -> dict:
+    out = subprocess.run([str(CLI), str(program)], capture_output=True, text=True,
+                         cwd=str(HERE), timeout=60)
+    assert out.returncode == 0, f"adj-lang-cli failed: {out.stderr}"
+    return json.loads(out.stdout)
+
+
+# ---- 1. the ADJ file is the artifact — every clause grounded, no authored-debt ----
+
+def test_library_is_pure_adj_and_fully_grounded() -> None:
+    text = ADJ.read_text()
+    assert "trust consensus" not in text, "ISLET-CELL ships no authored-debt; ground or omit"
+    assert "[FLAG:" not in text
+    edge_count = len(EXPECTED)  # 5
+    assert text.count("    relate ") == edge_count
+    assert text.count("trust authoritative") == edge_count
+    assert text.count('\n        locator "') == edge_count
+    assert text.count('\n        source "') == edge_count
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("locator "):
+            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+    assert not (HERE / "islet_cell_edge_ground.py").exists()
+    assert not (HERE / "islet-cell-edge-grounding.json").exists()
+    assert not (HERE / "islet-cell-edge-manifest.json").exists()
+
+
+# ---- 2. the engine binds each hormone with an authoritative citation -----------------
+
+def test_engine_binds_every_hormone_with_authoritative_citation() -> None:
+    if not _cli_available():
+        return
+    result = _run(QUERY)
+    by_query = {r["query"]: r for r in result["recall"]}
+    for cell, hormone in EXPECTED.items():
+        q = f"{REL}({cell}, {VAR})"
+        r = by_query.get(q)
+        assert r is not None and not r["abstained"], f"{q} abstained — edge missing?"
+        bound = {}
+        for a in r["answers"]:
+            bound[a["bindings"][VAR]] = (a.get("citations") or [{}])[0]
+        assert set(bound) == {hormone}, f"{cell}: bound {set(bound)} != {{{hormone}}}"
+        cite = bound[hormone]
+        assert cite.get("trust") == "authoritative", f"{cell}/{hormone} not authoritative"
+        assert cite.get("source"), f"{cell}/{hormone} has no source span"
+        assert cite.get("locator", "").startswith("https://www.ncbi.nlm.nih.gov/")
+
+
+# ---- 3. an off-vocabulary cell abstains, never fabricates -----------------------------
+
+def test_unknown_cell_abstains() -> None:
+    if not _cli_available():
+        return
+    import os
+    import tempfile
+    fd, path = tempfile.mkstemp(suffix=".adj", prefix=".islet_q_", dir=HERE)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            # "acinar_cell" is a real pancreatic cell, but it is EXOCRINE (it
+            # secretes digestive enzymes) — not one of the endocrine islet cells
+            # this library models, so it is deliberately absent — the engine must
+            # abstain rather than fabricate a hormone.
+            fh.write(f'import "islet-cell-edges.adj"\n? {REL}(acinar_cell, ${VAR})\n')
+        res = _run(Path(path))
+        r = res["recall"][0] if res["recall"] else None
+        assert r is not None and r["abstained"], "an ungrounded cell must abstain"
+    finally:
+        os.unlink(path)
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS  {t.__name__}")
+        except AssertionError as exc:
+            failed += 1
+            print(f"  FAIL  {t.__name__}: {exc}")
+    print(f"\ntest_islet_cell_recall: {len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())


### PR DESCRIPTION
## What

New **pure-ADJ** MYCIN-2026 recall domain: the hormone each cell type of the **islets of Langerhans** secretes (high-yield endocrine-histology board table). The shipped artifact is the ADJ library itself — facts + byte-provenance inline, **no Python gate, no JSON, no manifest** (same shape as EXOCRINE-GLAND / EPIDERMIS / COMPLEMENT).

## Edges (5, single-answer)

`secretes(islet_cell, hormone)`:

| cell | hormone | source |
|---|---|---|
| beta cell | insulin | NBK560688 |
| alpha cell | glucagon | NBK542302 |
| delta cell | somatostatin | NBK542302 |
| PP cell | pancreatic polypeptide | NBK542302 |
| epsilon cell | ghrelin | NBK542302 |

Each `source` span is a **self-contained NCBI StatPearls/Bookshelf sentence** naming the cell by its **full term** ("beta cells", "alpha cells", …) AND the hormone in one sentence. Every span was **independently re-fetched twice** for byte-stability.

Abstain probe: `acinar_cell` — a real pancreatic cell but **exocrine** (secretes digestive enzymes, not an islet hormone) → the engine **abstains** rather than fabricate.

## Files

- `islet-cell-edges.adj` — the grounded knowledge graph (sole source of truth)
- `islet-cell-recall.query.adj` — worked binding query (the shape an LLM emits)
- `test_islet_cell_recall.py` — 3-test scaffold (pure-ADJ shape; engine binds with authoritative citation; unknown cell abstains)

## Verification

- Local: **3/3** tests pass against the native `adj-lang-cli`.
- Security review: **PASSED** (list-form subprocess, atomic `mkstemp`+`os.unlink`, `json.loads` only, no network/eval/secrets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)