### PR TITLE
[codex] Add SPICE control policy table export artifacts

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Added
 
+- **Deck control policy table export artifacts** —
+  selected `run_deck_analysis()` executions now include `control-policy` and
+  `control-policy-summary` entries in `tables`, selected-run `TableList`
+  metadata, and ordered `table_artifacts` with stable table, CSV, compact JSON,
+  and header-keyed record payloads, matching Rust and TypeScript.
+
 - **Deck control policy run-artifact inventories** —
   selected `run_deck_analysis()` run artifacts now carry
   `ControlPolicyArtifacts`, `ControlPolicyCategoryList`,

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -2747,12 +2747,15 @@ def _deck_analysis_directives(plan: DeckAnalysisPlan) -> list[str]:
 def _deck_stable_tables(
     measurements: list[ProbeMeasurement],
     fourier: list[FourierResult],
+    control_policy_artifacts: list[DeckControlPolicyArtifact],
 ) -> list[str]:
     tables = ["result"]
     if measurements:
         tables.append("measurement")
     if fourier:
         tables.append("fourier")
+    if control_policy_artifacts:
+        tables.extend(["control-policy", "control-policy-summary"])
     tables.append("run-artifact")
     return tables
 
@@ -2773,7 +2776,7 @@ def _deck_run_artifacts(
 ) -> list[DeckRunArtifact]:
     is_transient = plan.analysis == "tran"
     analysis_directives = _deck_analysis_directives(plan)
-    tables = _deck_stable_tables(measurements, fourier)
+    tables = _deck_stable_tables(measurements, fourier, control_policy_artifacts)
     control_policy_summaries = _deck_control_policy_summary_artifacts(
         control_policy_artifacts
     )
@@ -3014,12 +3017,27 @@ def _deck_table_artifacts(
     run_artifact_table: str,
     measurements: list[ProbeMeasurement],
     fourier: list[FourierResult],
+    control_policy_artifacts: list[DeckControlPolicyArtifact],
+    control_policy_artifact_table: str,
+    control_policy_summary_artifacts: list[DeckControlPolicySummaryArtifact],
+    control_policy_summary_artifact_table: str,
 ) -> list[DeckTableArtifact]:
     artifacts = [_deck_table_artifact("result", result_table)]
     if measurements:
         artifacts.append(_deck_table_artifact("measurement", measurement_table))
     if fourier:
         artifacts.append(_deck_table_artifact("fourier", fourier_table))
+    if control_policy_artifacts:
+        artifacts.append(
+            _deck_table_artifact("control-policy", control_policy_artifact_table)
+        )
+    if control_policy_summary_artifacts:
+        artifacts.append(
+            _deck_table_artifact(
+                "control-policy-summary",
+                control_policy_summary_artifact_table,
+            )
+        )
     artifacts.append(_deck_table_artifact("run-artifact", run_artifact_table))
     return artifacts
 
@@ -3687,6 +3705,17 @@ def run_deck_analysis(
     write_markers = _deck_control_write_markers(netlist)
     rawfile_options = _deck_control_rawfile_options(netlist)
     control_policy_artifacts = _deck_control_policy_artifacts(netlist)
+    control_policy_artifact_table = format_deck_control_policy_artifact_table(
+        control_policy_artifacts
+    )
+    control_policy_summary_artifacts = _deck_control_policy_summary_artifacts(
+        control_policy_artifacts
+    )
+    control_policy_summary_artifact_table = (
+        format_deck_control_policy_summary_artifact_table(
+            control_policy_summary_artifacts
+        )
+    )
     analysis_directives = _deck_analysis_directives(plan)
     if plan.analysis == "op":
         result = dc_op(circuit)
@@ -3714,7 +3743,11 @@ def run_deck_analysis(
         measurement_table = format_measurement_table(measurements)
         fourier_table = format_deck_fourier_table(fourier)
         run_artifact_table = format_deck_run_artifact_table(run_artifacts)
-        tables = _deck_stable_tables(measurements, fourier)
+        tables = _deck_stable_tables(
+            measurements,
+            fourier,
+            control_policy_artifacts,
+        )
         table_artifacts = _deck_table_artifacts(
             table,
             measurement_table,
@@ -3722,6 +3755,10 @@ def run_deck_analysis(
             run_artifact_table,
             measurements,
             fourier,
+            control_policy_artifacts,
+            control_policy_artifact_table,
+            control_policy_summary_artifacts,
+            control_policy_summary_artifact_table,
         )
         return DeckAnalysisExecution(
             plan=plan,
@@ -3781,7 +3818,11 @@ def run_deck_analysis(
         measurement_table = format_measurement_table(measurements)
         fourier_table = format_deck_fourier_table(fourier)
         run_artifact_table = format_deck_run_artifact_table(run_artifacts)
-        tables = _deck_stable_tables(measurements, fourier)
+        tables = _deck_stable_tables(
+            measurements,
+            fourier,
+            control_policy_artifacts,
+        )
         table_artifacts = _deck_table_artifacts(
             table,
             measurement_table,
@@ -3789,6 +3830,10 @@ def run_deck_analysis(
             run_artifact_table,
             measurements,
             fourier,
+            control_policy_artifacts,
+            control_policy_artifact_table,
+            control_policy_summary_artifacts,
+            control_policy_summary_artifact_table,
         )
         return DeckAnalysisExecution(
             plan=plan,
@@ -3850,7 +3895,11 @@ def run_deck_analysis(
         measurement_table = format_measurement_table(measurements)
         fourier_table = format_deck_fourier_table(fourier)
         run_artifact_table = format_deck_run_artifact_table(run_artifacts)
-        tables = _deck_stable_tables(measurements, fourier)
+        tables = _deck_stable_tables(
+            measurements,
+            fourier,
+            control_policy_artifacts,
+        )
         table_artifacts = _deck_table_artifacts(
             table,
             measurement_table,
@@ -3858,6 +3907,10 @@ def run_deck_analysis(
             run_artifact_table,
             measurements,
             fourier,
+            control_policy_artifacts,
+            control_policy_artifact_table,
+            control_policy_summary_artifacts,
+            control_policy_summary_artifact_table,
         )
         return DeckAnalysisExecution(
             plan=plan,
@@ -3925,7 +3978,11 @@ def run_deck_analysis(
         measurement_table = format_measurement_table(measurements)
         fourier_table = format_deck_fourier_table(fourier)
         run_artifact_table = format_deck_run_artifact_table(run_artifacts)
-        tables = _deck_stable_tables(measurements, fourier)
+        tables = _deck_stable_tables(
+            measurements,
+            fourier,
+            control_policy_artifacts,
+        )
         table_artifacts = _deck_table_artifacts(
             table,
             measurement_table,
@@ -3933,6 +3990,10 @@ def run_deck_analysis(
             run_artifact_table,
             measurements,
             fourier,
+            control_policy_artifacts,
+            control_policy_artifact_table,
+            control_policy_summary_artifacts,
+            control_policy_summary_artifact_table,
         )
         return DeckAnalysisExecution(
             plan=plan,
@@ -3988,7 +4049,11 @@ def run_deck_analysis(
         measurement_table = format_measurement_table(measurements)
         fourier_table = format_deck_fourier_table(fourier)
         run_artifact_table = format_deck_run_artifact_table(run_artifacts)
-        tables = _deck_stable_tables(measurements, fourier)
+        tables = _deck_stable_tables(
+            measurements,
+            fourier,
+            control_policy_artifacts,
+        )
         table_artifacts = _deck_table_artifacts(
             table,
             measurement_table,
@@ -3996,6 +4061,10 @@ def run_deck_analysis(
             run_artifact_table,
             measurements,
             fourier,
+            control_policy_artifacts,
+            control_policy_artifact_table,
+            control_policy_summary_artifacts,
+            control_policy_summary_artifact_table,
         )
         return DeckAnalysisExecution(
             plan=plan,
@@ -4050,7 +4119,11 @@ def run_deck_analysis(
         measurement_table = format_measurement_table(measurements)
         fourier_table = format_deck_fourier_table(fourier)
         run_artifact_table = format_deck_run_artifact_table(run_artifacts)
-        tables = _deck_stable_tables(measurements, fourier)
+        tables = _deck_stable_tables(
+            measurements,
+            fourier,
+            control_policy_artifacts,
+        )
         table_artifacts = _deck_table_artifacts(
             table,
             measurement_table,
@@ -4058,6 +4131,10 @@ def run_deck_analysis(
             run_artifact_table,
             measurements,
             fourier,
+            control_policy_artifacts,
+            control_policy_artifact_table,
+            control_policy_summary_artifacts,
+            control_policy_summary_artifact_table,
         )
         return DeckAnalysisExecution(
             plan=plan,
@@ -4131,7 +4208,11 @@ def run_deck_analysis(
         measurement_table = format_measurement_table(measurements)
         fourier_table = format_deck_fourier_table(fourier)
         run_artifact_table = format_deck_run_artifact_table(run_artifacts)
-        tables = _deck_stable_tables(measurements, fourier)
+        tables = _deck_stable_tables(
+            measurements,
+            fourier,
+            control_policy_artifacts,
+        )
         table_artifacts = _deck_table_artifacts(
             table,
             measurement_table,
@@ -4139,6 +4220,10 @@ def run_deck_analysis(
             run_artifact_table,
             measurements,
             fourier,
+            control_policy_artifacts,
+            control_policy_artifact_table,
+            control_policy_summary_artifacts,
+            control_policy_summary_artifact_table,
         )
         return DeckAnalysisExecution(
             plan=plan,

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -7458,6 +7458,12 @@ let gain = 2
         "if v(in) > 0",
         "let gain = 2",
     ]
+    expected_table_names = [
+        "result",
+        "control-policy",
+        "control-policy-summary",
+        "run-artifact",
+    ]
 
     assert execution.control_line_count == len(expected_control_lines)
     assert execution.control_lines == expected_control_lines
@@ -7650,8 +7656,39 @@ let gain = 2
     assert summary_json[3]["CommandList"] == "let gain = 2"
     assert execution.diagnostic_count == len(expected_codes)
     assert execution.diagnostic_codes == expected_codes
+    assert execution.table_count == len(expected_table_names)
+    assert execution.tables == expected_table_names
+    assert [artifact.name for artifact in execution.table_artifacts] == (
+        expected_table_names
+    )
+    policy_table_artifact = execution.table_artifacts[-3]
+    assert policy_table_artifact.name == "control-policy"
+    assert policy_table_artifact.table == execution.control_policy_artifact_table
+    assert policy_table_artifact.csv == execution.control_policy_artifact_csv
+    assert policy_table_artifact.json == execution.control_policy_artifact_json
+    assert policy_table_artifact.records == execution.control_policy_artifact_records
+    summary_table_artifact = execution.table_artifacts[-2]
+    assert summary_table_artifact.name == "control-policy-summary"
+    assert (
+        summary_table_artifact.table
+        == execution.control_policy_summary_artifact_table
+    )
+    assert (
+        summary_table_artifact.csv
+        == execution.control_policy_summary_artifact_csv
+    )
+    assert (
+        summary_table_artifact.json
+        == execution.control_policy_summary_artifact_json
+    )
+    assert (
+        summary_table_artifact.records
+        == execution.control_policy_summary_artifact_records
+    )
     assert execution.run_artifacts[0].control_line_count == len(expected_control_lines)
     assert execution.run_artifacts[0].control_lines == expected_control_lines
+    assert execution.run_artifacts[0].table_count == len(expected_table_names)
+    assert execution.run_artifacts[0].tables == expected_table_names
     assert execution.run_artifacts[0].write_marker_count == len(expected_write_markers)
     assert execution.run_artifacts[0].write_markers == expected_write_markers
     assert execution.run_artifacts[0].rawfile_option_count == len(
@@ -7670,6 +7707,8 @@ let gain = 2
     assert execution.run_artifacts[0].diagnostic_count == len(expected_codes)
     assert execution.run_artifacts[0].diagnostic_codes == expected_codes
     record = deck_table_records(execution.run_artifact_table)[0]
+    assert record["Tables"] == str(len(expected_table_names))
+    assert record["TableList"] == ";".join(expected_table_names)
     assert record["ControlLines"] == str(len(expected_control_lines))
     assert record["ControlLineList"] == control_line_list
     assert record["WriteMarkers"] == str(len(expected_write_markers))

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Include policy-blocked `.control` row and summary tables in selected
+  `run_deck_analysis` execution `tables`, selected-run `TableList` metadata,
+  and ordered `table_artifacts` as `control-policy` and
+  `control-policy-summary` exports with stable table, CSV, JSON, and
+  header-keyed records, matching Python and TypeScript.
 - Carry policy-blocked `.control` command inventories through selected
   `run_deck_analysis` run artifacts as stable `ControlPolicyArtifacts`,
   `ControlPolicyCategoryList`, `ControlPolicyCodeList`, and

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -10276,7 +10276,7 @@ fn deck_run_artifacts(
 ) -> Vec<DeckRunArtifact> {
     let is_transient = plan.analysis == "tran";
     let analysis_directives = deck_analysis_directives(plan);
-    let tables = deck_stable_tables(measurements, fourier);
+    let tables = deck_stable_tables(measurements, fourier, control_policy_artifacts);
     let control_policy_summaries = deck_control_policy_summary_artifacts(control_policy_artifacts);
     let control_policy_categories = control_policy_summaries
         .iter()
@@ -10354,13 +10354,21 @@ fn deck_analysis_directives(plan: &DeckAnalysisPlan) -> Vec<String> {
     }
 }
 
-fn deck_stable_tables(measurements: &[ProbeMeasurement], fourier: &[FourierResult]) -> Vec<String> {
+fn deck_stable_tables(
+    measurements: &[ProbeMeasurement],
+    fourier: &[FourierResult],
+    control_policy_artifacts: &[DeckControlPolicyArtifact],
+) -> Vec<String> {
     let mut tables = vec!["result".to_string()];
     if !measurements.is_empty() {
         tables.push("measurement".to_string());
     }
     if !fourier.is_empty() {
         tables.push("fourier".to_string());
+    }
+    if !control_policy_artifacts.is_empty() {
+        tables.push("control-policy".to_string());
+        tables.push("control-policy-summary".to_string());
     }
     tables.push("run-artifact".to_string());
     tables
@@ -10605,6 +10613,10 @@ fn deck_table_artifacts(
     run_artifact_table: &str,
     measurements: &[ProbeMeasurement],
     fourier: &[FourierResult],
+    control_policy_artifacts: &[DeckControlPolicyArtifact],
+    control_policy_artifact_table: &str,
+    control_policy_summary_artifacts: &[DeckControlPolicySummaryArtifact],
+    control_policy_summary_artifact_table: &str,
 ) -> Vec<DeckTableArtifact> {
     let mut artifacts = vec![deck_table_artifact("result", result_table)];
     if !measurements.is_empty() {
@@ -10612,6 +10624,18 @@ fn deck_table_artifacts(
     }
     if !fourier.is_empty() {
         artifacts.push(deck_table_artifact("fourier", fourier_table));
+    }
+    if !control_policy_artifacts.is_empty() {
+        artifacts.push(deck_table_artifact(
+            "control-policy",
+            control_policy_artifact_table,
+        ));
+    }
+    if !control_policy_summary_artifacts.is_empty() {
+        artifacts.push(deck_table_artifact(
+            "control-policy-summary",
+            control_policy_summary_artifact_table,
+        ));
     }
     artifacts.push(deck_table_artifact("run-artifact", run_artifact_table));
     artifacts
@@ -11502,6 +11526,10 @@ pub fn run_deck_analysis(
                 &run_artifact_table,
                 &measurements,
                 &fourier,
+                &control_policy_artifacts,
+                &control_policy_artifact_table,
+                &control_policy_summary_artifacts,
+                &control_policy_summary_artifact_table,
             );
             let rawfile_artifacts =
                 deck_rawfile_artifacts(&plan, &table, &write_markers, &rawfile_options);
@@ -11514,7 +11542,7 @@ pub fn run_deck_analysis(
             let wrdata_artifact_csv = format_deck_wrdata_artifact_csv(&wrdata_artifacts);
             let wrdata_artifact_json = format_deck_wrdata_artifact_json(&wrdata_artifacts);
             let wrdata_artifact_records = deck_wrdata_artifact_records(&wrdata_artifacts);
-            let tables = deck_stable_tables(&measurements, &fourier);
+            let tables = deck_stable_tables(&measurements, &fourier, &control_policy_artifacts);
             Ok(DeckAnalysisExecution {
                 plan,
                 result: DeckAnalysisExecutionResult::Op(result),
@@ -11606,6 +11634,10 @@ pub fn run_deck_analysis(
                 &run_artifact_table,
                 &measurements,
                 &fourier,
+                &control_policy_artifacts,
+                &control_policy_artifact_table,
+                &control_policy_summary_artifacts,
+                &control_policy_summary_artifact_table,
             );
             let rawfile_artifacts =
                 deck_rawfile_artifacts(&plan, &table, &write_markers, &rawfile_options);
@@ -11618,7 +11650,7 @@ pub fn run_deck_analysis(
             let wrdata_artifact_csv = format_deck_wrdata_artifact_csv(&wrdata_artifacts);
             let wrdata_artifact_json = format_deck_wrdata_artifact_json(&wrdata_artifacts);
             let wrdata_artifact_records = deck_wrdata_artifact_records(&wrdata_artifacts);
-            let tables = deck_stable_tables(&measurements, &fourier);
+            let tables = deck_stable_tables(&measurements, &fourier, &control_policy_artifacts);
             Ok(DeckAnalysisExecution {
                 plan,
                 result: DeckAnalysisExecutionResult::DcSweep(result),
@@ -11711,6 +11743,10 @@ pub fn run_deck_analysis(
                 &run_artifact_table,
                 &measurements,
                 &fourier,
+                &control_policy_artifacts,
+                &control_policy_artifact_table,
+                &control_policy_summary_artifacts,
+                &control_policy_summary_artifact_table,
             );
             let rawfile_artifacts =
                 deck_rawfile_artifacts(&plan, &table, &write_markers, &rawfile_options);
@@ -11723,7 +11759,7 @@ pub fn run_deck_analysis(
             let wrdata_artifact_csv = format_deck_wrdata_artifact_csv(&wrdata_artifacts);
             let wrdata_artifact_json = format_deck_wrdata_artifact_json(&wrdata_artifacts);
             let wrdata_artifact_records = deck_wrdata_artifact_records(&wrdata_artifacts);
-            let tables = deck_stable_tables(&measurements, &fourier);
+            let tables = deck_stable_tables(&measurements, &fourier, &control_policy_artifacts);
             Ok(DeckAnalysisExecution {
                 plan,
                 result: DeckAnalysisExecutionResult::Ac(result),
@@ -11819,6 +11855,10 @@ pub fn run_deck_analysis(
                 &run_artifact_table,
                 &measurements,
                 &fourier,
+                &control_policy_artifacts,
+                &control_policy_artifact_table,
+                &control_policy_summary_artifacts,
+                &control_policy_summary_artifact_table,
             );
             let rawfile_artifacts =
                 deck_rawfile_artifacts(&plan, &table, &write_markers, &rawfile_options);
@@ -11831,7 +11871,7 @@ pub fn run_deck_analysis(
             let wrdata_artifact_csv = format_deck_wrdata_artifact_csv(&wrdata_artifacts);
             let wrdata_artifact_json = format_deck_wrdata_artifact_json(&wrdata_artifacts);
             let wrdata_artifact_records = deck_wrdata_artifact_records(&wrdata_artifacts);
-            let tables = deck_stable_tables(&measurements, &fourier);
+            let tables = deck_stable_tables(&measurements, &fourier, &control_policy_artifacts);
             Ok(DeckAnalysisExecution {
                 plan,
                 result: DeckAnalysisExecutionResult::Tran(result),
@@ -11921,6 +11961,10 @@ pub fn run_deck_analysis(
                 &run_artifact_table,
                 &measurements,
                 &fourier,
+                &control_policy_artifacts,
+                &control_policy_artifact_table,
+                &control_policy_summary_artifacts,
+                &control_policy_summary_artifact_table,
             );
             let rawfile_artifacts =
                 deck_rawfile_artifacts(&plan, &table, &write_markers, &rawfile_options);
@@ -11933,7 +11977,7 @@ pub fn run_deck_analysis(
             let wrdata_artifact_csv = format_deck_wrdata_artifact_csv(&wrdata_artifacts);
             let wrdata_artifact_json = format_deck_wrdata_artifact_json(&wrdata_artifacts);
             let wrdata_artifact_records = deck_wrdata_artifact_records(&wrdata_artifacts);
-            let tables = deck_stable_tables(&measurements, &fourier);
+            let tables = deck_stable_tables(&measurements, &fourier, &control_policy_artifacts);
             Ok(DeckAnalysisExecution {
                 plan,
                 result: DeckAnalysisExecutionResult::Tf(result.clone()),
@@ -12021,6 +12065,10 @@ pub fn run_deck_analysis(
                 &run_artifact_table,
                 &measurements,
                 &fourier,
+                &control_policy_artifacts,
+                &control_policy_artifact_table,
+                &control_policy_summary_artifacts,
+                &control_policy_summary_artifact_table,
             );
             let rawfile_artifacts =
                 deck_rawfile_artifacts(&plan, &table, &write_markers, &rawfile_options);
@@ -12033,7 +12081,7 @@ pub fn run_deck_analysis(
             let wrdata_artifact_csv = format_deck_wrdata_artifact_csv(&wrdata_artifacts);
             let wrdata_artifact_json = format_deck_wrdata_artifact_json(&wrdata_artifacts);
             let wrdata_artifact_records = deck_wrdata_artifact_records(&wrdata_artifacts);
-            let tables = deck_stable_tables(&measurements, &fourier);
+            let tables = deck_stable_tables(&measurements, &fourier, &control_policy_artifacts);
             Ok(DeckAnalysisExecution {
                 plan,
                 result: DeckAnalysisExecutionResult::Sens(result.clone()),
@@ -12133,6 +12181,10 @@ pub fn run_deck_analysis(
                 &run_artifact_table,
                 &measurements,
                 &fourier,
+                &control_policy_artifacts,
+                &control_policy_artifact_table,
+                &control_policy_summary_artifacts,
+                &control_policy_summary_artifact_table,
             );
             let rawfile_artifacts =
                 deck_rawfile_artifacts(&plan, &table, &write_markers, &rawfile_options);
@@ -12145,7 +12197,7 @@ pub fn run_deck_analysis(
             let wrdata_artifact_csv = format_deck_wrdata_artifact_csv(&wrdata_artifacts);
             let wrdata_artifact_json = format_deck_wrdata_artifact_json(&wrdata_artifacts);
             let wrdata_artifact_records = deck_wrdata_artifact_records(&wrdata_artifacts);
-            let tables = deck_stable_tables(&measurements, &fourier);
+            let tables = deck_stable_tables(&measurements, &fourier, &control_policy_artifacts);
             Ok(DeckAnalysisExecution {
                 plan,
                 result: DeckAnalysisExecutionResult::Noise(result.clone()),

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -2814,6 +2814,13 @@ let gain = 2
         "if v(in) > 0".to_string(),
         "let gain = 2".to_string(),
     ];
+    let expected_table_names = vec![
+        "result".to_string(),
+        "control-policy".to_string(),
+        "control-policy-summary".to_string(),
+        "run-artifact".to_string(),
+    ];
+    let table_list = expected_table_names.join(";");
 
     assert_eq!(execution.control_line_count, expected_control_lines.len());
     assert_eq!(execution.control_lines, expected_control_lines);
@@ -3259,6 +3266,52 @@ let gain = 2
         .contains("\"CommandList\":\"let gain = 2\""));
     assert_eq!(execution.diagnostic_count, expected_codes.len());
     assert_eq!(execution.diagnostic_codes, expected_codes);
+    assert_eq!(execution.table_count, expected_table_names.len());
+    assert_eq!(execution.tables, expected_table_names);
+    assert_eq!(
+        execution
+            .table_artifacts
+            .iter()
+            .map(|artifact| artifact.name.clone())
+            .collect::<Vec<_>>(),
+        expected_table_names
+    );
+    let policy_table_artifact = &execution.table_artifacts[execution.table_artifacts.len() - 3];
+    assert_eq!(policy_table_artifact.name, "control-policy");
+    assert_eq!(
+        policy_table_artifact.table,
+        execution.control_policy_artifact_table
+    );
+    assert_eq!(
+        policy_table_artifact.csv,
+        execution.control_policy_artifact_csv
+    );
+    assert_eq!(
+        policy_table_artifact.json,
+        format_deck_table_json(&execution.control_policy_artifact_table)
+    );
+    assert_eq!(
+        policy_table_artifact.records,
+        execution.control_policy_artifact_records
+    );
+    let summary_table_artifact = &execution.table_artifacts[execution.table_artifacts.len() - 2];
+    assert_eq!(summary_table_artifact.name, "control-policy-summary");
+    assert_eq!(
+        summary_table_artifact.table,
+        execution.control_policy_summary_artifact_table
+    );
+    assert_eq!(
+        summary_table_artifact.csv,
+        execution.control_policy_summary_artifact_csv
+    );
+    assert_eq!(
+        summary_table_artifact.json,
+        format_deck_table_json(&execution.control_policy_summary_artifact_table)
+    );
+    assert_eq!(
+        summary_table_artifact.records,
+        execution.control_policy_summary_artifact_records
+    );
     assert_eq!(
         execution.run_artifacts[0].control_line_count,
         expected_control_lines.len()
@@ -3300,11 +3353,21 @@ let gain = 2
         vec!["error".to_string()]
     );
     assert_eq!(
+        execution.run_artifacts[0].table_count,
+        expected_table_names.len()
+    );
+    assert_eq!(execution.run_artifacts[0].tables, expected_table_names);
+    assert_eq!(
         execution.run_artifacts[0].diagnostic_count,
         expected_codes.len()
     );
     assert_eq!(execution.run_artifacts[0].diagnostic_codes, expected_codes);
     let records = deck_table_records(&execution.run_artifact_table);
+    assert_eq!(records[0].get("Tables").map(String::as_str), Some("4"));
+    assert_eq!(
+        records[0].get("TableList").map(String::as_str),
+        Some(table_list.as_str())
+    );
     assert_eq!(
         records[0].get("ControlLines").map(String::as_str),
         Some("2")

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Include policy-blocked `.control` row and summary tables in selected
+  `runDeckAnalysis` execution `tables`, selected-run `TableList` metadata, and
+  ordered `tableArtifacts` as `control-policy` and `control-policy-summary`
+  exports with stable table, CSV, JSON, and header-keyed records, matching
+  Python and Rust.
 - Carry policy-blocked `.control` command inventories through selected
   `runDeckAnalysis` run artifacts as stable `ControlPolicyArtifacts`,
   `ControlPolicyCategoryList`, `ControlPolicyCodeList`, and

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -141,9 +141,12 @@ exports. The selected-run artifact row also carries
 `ControlPolicyCodeList`, and `ControlPolicySeverityList` inventory columns.
 `controlPolicySummaryArtifacts` groups the same policy artifacts by
 category with stable count, line-list, command-list, code-list, and severity-list
-table, CSV, compact JSON, and record exports. `formatDeckTableCsv` also converts
-any stable tab-separated deck table to CSV, `formatDeckTableJson` converts the
-same tables to compact JSON records, and `deckTableRecords` returns header-keyed
+table, CSV, compact JSON, and record exports. The same policy row and summary
+tables also appear as `control-policy` and `control-policy-summary` entries in
+`tables`, selected-run `TableList` metadata, and ordered `tableArtifacts`.
+`formatDeckTableCsv` also converts any stable tab-separated deck table to CSV,
+`formatDeckTableJson` converts the same tables to compact JSON records, and
+`deckTableRecords` returns header-keyed
 native records for browser and host integrations.
 `resolveDeckOutputs` and `selectDeckOutputProbes` extract `.save`, scoped or
 global `.probe`, scoped `.print <analysis> ...`, and scoped

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -8059,7 +8059,7 @@ function deckRunArtifacts(
 ): DeckRunArtifact[] {
   const isTransient = plan.analysis === "tran";
   const analysisDirectives = deckAnalysisDirectives(plan);
-  const tables = deckStableTables(measurements, fourier);
+    const tables = deckStableTables(measurements, fourier, controlPolicyArtifacts);
   const controlPolicySummaries = deckControlPolicySummaryArtifacts(controlPolicyArtifacts);
   const controlPolicyCategories = controlPolicySummaries.map((artifact) => artifact.category);
   const controlPolicyCodes = controlPolicySummaries.flatMap((artifact) => artifact.codes);
@@ -8126,6 +8126,7 @@ function deckAnalysisDirectives(plan: DeckAnalysisPlan): string[] {
 function deckStableTables(
   measurements: readonly ProbeMeasurement[],
   fourier: readonly FourierResult[],
+  controlPolicyArtifacts: readonly DeckControlPolicyArtifact[],
 ): string[] {
   const tables = ["result"];
   if (measurements.length > 0) {
@@ -8133,6 +8134,9 @@ function deckStableTables(
   }
   if (fourier.length > 0) {
     tables.push("fourier");
+  }
+  if (controlPolicyArtifacts.length > 0) {
+    tables.push("control-policy", "control-policy-summary");
   }
   tables.push("run-artifact");
   return tables;
@@ -8354,6 +8358,10 @@ function deckTableArtifacts(
   runArtifactTable: string,
   measurements: readonly ProbeMeasurement[],
   fourier: readonly FourierResult[],
+  controlPolicyArtifacts: readonly DeckControlPolicyArtifact[],
+  controlPolicyArtifactTable: string,
+  controlPolicySummaryArtifacts: readonly DeckControlPolicySummaryArtifact[],
+  controlPolicySummaryArtifactTable: string,
 ): DeckTableArtifact[] {
   const artifacts = [deckTableArtifact("result", resultTable)];
   if (measurements.length > 0) {
@@ -8361,6 +8369,14 @@ function deckTableArtifacts(
   }
   if (fourier.length > 0) {
     artifacts.push(deckTableArtifact("fourier", fourierTable));
+  }
+  if (controlPolicyArtifacts.length > 0) {
+    artifacts.push(deckTableArtifact("control-policy", controlPolicyArtifactTable));
+  }
+  if (controlPolicySummaryArtifacts.length > 0) {
+    artifacts.push(
+      deckTableArtifact("control-policy-summary", controlPolicySummaryArtifactTable),
+    );
   }
   artifacts.push(deckTableArtifact("run-artifact", runArtifactTable));
   return artifacts;
@@ -9028,7 +9044,7 @@ export function runDeckAnalysis(
       diagnosticCodes,
       controlPolicyArtifacts,
     );
-    const tables = deckStableTables(measurements, fourier);
+  const tables = deckStableTables(measurements, fourier, controlPolicyArtifacts);
     const measurementTable = formatMeasurementTable(measurements);
     const fourierTable = formatDeckFourierTable(fourier);
     const runArtifactTable = formatDeckRunArtifactTable(runArtifacts);
@@ -9039,6 +9055,10 @@ export function runDeckAnalysis(
       runArtifactTable,
       measurements,
       fourier,
+      controlPolicyArtifacts,
+      controlPolicyArtifactTable,
+      controlPolicySummaryArtifacts,
+      controlPolicySummaryArtifactTable,
     );
     const rawfileArtifacts = deckRawfileArtifacts(plan, table, writeMarkers, rawfileOptions);
     const rawfileArtifactTable = formatDeckRawfileArtifactTable(rawfileArtifacts);
@@ -9129,7 +9149,7 @@ export function runDeckAnalysis(
       diagnosticCodes,
       controlPolicyArtifacts,
     );
-    const tables = deckStableTables(measurements, fourier);
+    const tables = deckStableTables(measurements, fourier, controlPolicyArtifacts);
     const measurementTable = formatMeasurementTable(measurements);
     const fourierTable = formatDeckFourierTable(fourier);
     const runArtifactTable = formatDeckRunArtifactTable(runArtifacts);
@@ -9140,6 +9160,10 @@ export function runDeckAnalysis(
       runArtifactTable,
       measurements,
       fourier,
+      controlPolicyArtifacts,
+      controlPolicyArtifactTable,
+      controlPolicySummaryArtifacts,
+      controlPolicySummaryArtifactTable,
     );
     const rawfileArtifacts = deckRawfileArtifacts(plan, table, writeMarkers, rawfileOptions);
     const rawfileArtifactTable = formatDeckRawfileArtifactTable(rawfileArtifacts);
@@ -9241,7 +9265,7 @@ export function runDeckAnalysis(
       diagnosticCodes,
       controlPolicyArtifacts,
     );
-    const tables = deckStableTables(measurements, fourier);
+    const tables = deckStableTables(measurements, fourier, controlPolicyArtifacts);
     const measurementTable = formatMeasurementTable(measurements);
     const fourierTable = formatDeckFourierTable(fourier);
     const runArtifactTable = formatDeckRunArtifactTable(runArtifacts);
@@ -9252,6 +9276,10 @@ export function runDeckAnalysis(
       runArtifactTable,
       measurements,
       fourier,
+      controlPolicyArtifacts,
+      controlPolicyArtifactTable,
+      controlPolicySummaryArtifacts,
+      controlPolicySummaryArtifactTable,
     );
     const rawfileArtifacts = deckRawfileArtifacts(plan, table, writeMarkers, rawfileOptions);
     const rawfileArtifactTable = formatDeckRawfileArtifactTable(rawfileArtifacts);
@@ -9348,7 +9376,7 @@ export function runDeckAnalysis(
       diagnosticCodes,
       controlPolicyArtifacts,
     );
-    const tables = deckStableTables(measurements, fourier);
+    const tables = deckStableTables(measurements, fourier, controlPolicyArtifacts);
     const measurementTable = formatMeasurementTable(measurements);
     const fourierTable = formatDeckFourierTable(fourier);
     const runArtifactTable = formatDeckRunArtifactTable(runArtifacts);
@@ -9359,6 +9387,10 @@ export function runDeckAnalysis(
       runArtifactTable,
       measurements,
       fourier,
+      controlPolicyArtifacts,
+      controlPolicyArtifactTable,
+      controlPolicySummaryArtifacts,
+      controlPolicySummaryArtifactTable,
     );
     const rawfileArtifacts = deckRawfileArtifacts(plan, table, writeMarkers, rawfileOptions);
     const rawfileArtifactTable = formatDeckRawfileArtifactTable(rawfileArtifacts);
@@ -9445,7 +9477,7 @@ export function runDeckAnalysis(
       diagnosticCodes,
       controlPolicyArtifacts,
     );
-    const tables = deckStableTables(measurements, fourier);
+    const tables = deckStableTables(measurements, fourier, controlPolicyArtifacts);
     const measurementTable = formatMeasurementTable(measurements);
     const fourierTable = formatDeckFourierTable(fourier);
     const runArtifactTable = formatDeckRunArtifactTable(runArtifacts);
@@ -9456,6 +9488,10 @@ export function runDeckAnalysis(
       runArtifactTable,
       measurements,
       fourier,
+      controlPolicyArtifacts,
+      controlPolicyArtifactTable,
+      controlPolicySummaryArtifacts,
+      controlPolicySummaryArtifactTable,
     );
     const rawfileArtifacts = deckRawfileArtifacts(plan, table, writeMarkers, rawfileOptions);
     const rawfileArtifactTable = formatDeckRawfileArtifactTable(rawfileArtifacts);
@@ -9541,7 +9577,7 @@ export function runDeckAnalysis(
       diagnosticCodes,
       controlPolicyArtifacts,
     );
-    const tables = deckStableTables(measurements, fourier);
+    const tables = deckStableTables(measurements, fourier, controlPolicyArtifacts);
     const measurementTable = formatMeasurementTable(measurements);
     const fourierTable = formatDeckFourierTable(fourier);
     const runArtifactTable = formatDeckRunArtifactTable(runArtifacts);
@@ -9552,6 +9588,10 @@ export function runDeckAnalysis(
       runArtifactTable,
       measurements,
       fourier,
+      controlPolicyArtifacts,
+      controlPolicyArtifactTable,
+      controlPolicySummaryArtifacts,
+      controlPolicySummaryArtifactTable,
     );
     const rawfileArtifacts = deckRawfileArtifacts(plan, table, writeMarkers, rawfileOptions);
     const rawfileArtifactTable = formatDeckRawfileArtifactTable(rawfileArtifacts);
@@ -9647,7 +9687,7 @@ export function runDeckAnalysis(
       diagnosticCodes,
       controlPolicyArtifacts,
     );
-    const tables = deckStableTables(measurements, fourier);
+    const tables = deckStableTables(measurements, fourier, controlPolicyArtifacts);
     const measurementTable = formatMeasurementTable(measurements);
     const fourierTable = formatDeckFourierTable(fourier);
     const runArtifactTable = formatDeckRunArtifactTable(runArtifacts);
@@ -9658,6 +9698,10 @@ export function runDeckAnalysis(
       runArtifactTable,
       measurements,
       fourier,
+      controlPolicyArtifacts,
+      controlPolicyArtifactTable,
+      controlPolicySummaryArtifacts,
+      controlPolicySummaryArtifactTable,
     );
     const rawfileArtifacts = deckRawfileArtifacts(plan, table, writeMarkers, rawfileOptions);
     const rawfileArtifactTable = formatDeckRawfileArtifactTable(rawfileArtifacts);

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -2127,6 +2127,12 @@ let gain = 2
       "if v(in) > 0",
       "let gain = 2",
     ];
+    const expectedTableNames = [
+      "result",
+      "control-policy",
+      "control-policy-summary",
+      "run-artifact",
+    ];
 
     expect(execution.controlLineCount).toBe(expectedControlLines.length);
     expect(execution.controlLines).toEqual(expectedControlLines);
@@ -2305,6 +2311,25 @@ let gain = 2
     expect(summaryJson[3].CommandList).toBe("let gain = 2");
     expect(execution.diagnosticCount).toBe(expectedCodes.length);
     expect(execution.diagnosticCodes).toEqual(expectedCodes);
+    expect(execution.tableCount).toBe(expectedTableNames.length);
+    expect(execution.tables).toEqual(expectedTableNames);
+    expect(execution.tableArtifacts.map((artifact) => artifact.name)).toEqual(
+      expectedTableNames,
+    );
+    const policyTableArtifact = execution.tableArtifacts.at(-3)!;
+    expect(policyTableArtifact.name).toBe("control-policy");
+    expect(policyTableArtifact.table).toBe(execution.controlPolicyArtifactTable);
+    expect(policyTableArtifact.csv).toBe(execution.controlPolicyArtifactCsv);
+    expect(policyTableArtifact.json).toBe(execution.controlPolicyArtifactJson);
+    expect(policyTableArtifact.records).toEqual(execution.controlPolicyArtifactRecords);
+    const summaryTableArtifact = execution.tableArtifacts.at(-2)!;
+    expect(summaryTableArtifact.name).toBe("control-policy-summary");
+    expect(summaryTableArtifact.table).toBe(execution.controlPolicySummaryArtifactTable);
+    expect(summaryTableArtifact.csv).toBe(execution.controlPolicySummaryArtifactCsv);
+    expect(summaryTableArtifact.json).toBe(execution.controlPolicySummaryArtifactJson);
+    expect(summaryTableArtifact.records).toEqual(
+      execution.controlPolicySummaryArtifactRecords,
+    );
     expect(execution.runArtifacts[0]?.controlLineCount).toBe(expectedControlLines.length);
     expect(execution.runArtifacts[0]?.controlLines).toEqual(expectedControlLines);
     expect(execution.runArtifacts[0]?.writeMarkerCount).toBe(expectedWriteMarkers.length);
@@ -2317,9 +2342,13 @@ let gain = 2
     );
     expect(execution.runArtifacts[0]?.controlPolicyCodes).toEqual(expectedCodes);
     expect(execution.runArtifacts[0]?.controlPolicySeverities).toEqual(["error"]);
+    expect(execution.runArtifacts[0]?.tableCount).toBe(expectedTableNames.length);
+    expect(execution.runArtifacts[0]?.tables).toEqual(expectedTableNames);
     expect(execution.runArtifacts[0]?.diagnosticCount).toBe(expectedCodes.length);
     expect(execution.runArtifacts[0]?.diagnosticCodes).toEqual(expectedCodes);
     const record = deckTableRecords(execution.runArtifactTable)[0]!;
+    expect(record["Tables"]).toBe(String(expectedTableNames.length));
+    expect(record["TableList"]).toBe(expectedTableNames.join(";"));
     expect(record["ControlLines"]).toBe(String(expectedControlLines.length));
     expect(record["ControlLineList"]).toBe(controlLineList);
     expect(record["WriteMarkers"]).toBe(String(expectedWriteMarkers.length));

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -131,7 +131,9 @@ downstream tools to compare.
      remain metadata-only, and policy-blocked `.control` commands now have
      direct selected-execution artifacts with line, category, command, code,
      severity, message, stable table, CSV, compact JSON, and host-native record
-     exports.
+     exports, and those row-level and category-summary policy tables now also
+     travel through ordered table export artifacts plus selected-run `TableList`
+     metadata.
    - Expand remaining deck-controlled analyses toward full SPICE compatibility
      while keeping unsupported control-flow diagnostics explicit.
 
@@ -1121,6 +1123,16 @@ downstream tools to compare.
     - Stable run-artifact table, CSV, compact JSON, `table_artifacts`, and
       host-native record exports now surface the policy inventory without
       requiring callers to parse separate policy artifact tables.
+
+103. Deck control policy table export artifacts.
+    - Status: completed in this deck control policy table export artifact slice.
+    - Python, Rust, and TypeScript selected executions now include
+      `control-policy` and `control-policy-summary` entries in stable table
+      inventories whenever policy-blocked `.control` commands are present.
+    - The ordered table export artifacts now carry those row-level and
+      category-summary policy tables with stable table, CSV, compact JSON, and
+      host-native record payloads, and selected-run `TableList` metadata names
+      the exported policy tables beside result and run-artifact tables.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- Adds stable `control-policy` and `control-policy-summary` table names when deck control policy artifacts exist.
- Exports both policy row and summary tables through ordered deck table artifacts in Python, Rust, and TypeScript.
- Updates SPICE package tests, changelogs, README notes, and the full implementation plan.

## Verification
- `PYTHONPATH=... /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python -m ruff check code/packages/python/spice-engine/src code/packages/python/spice-engine/tests/test_engine.py`
- `PYTHONPATH=... /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python -m pytest code/packages/python/spice-engine/tests/test_engine.py -q`
- `cargo fmt --manifest-path code/packages/rust/spice-engine/Cargo.toml -- --check`
- `cargo test --manifest-path code/packages/rust/spice-engine/Cargo.toml --quiet`
- `npm --prefix code/packages/typescript/spice-engine run build`
- `npm --prefix code/packages/typescript/spice-engine test`
- `git diff --check HEAD~1 HEAD`