### PR TITLE
feat(visicalc-compose): find/replace in the Compose demo

### DIFF
--- a/demo/visicalc-compose/README.md
+++ b/demo/visicalc-compose/README.md
@@ -116,6 +116,17 @@ The **.00 / % / $ / Gen** buttons apply a number **format** to the selected cell
 `#,##0.00`, `0.0%`, `$#,##0.00`, or `""` to clear). The format is display-only —
 the engine renders the stored value through the code, so the underlying number is
 unchanged.
+The **find / replace** group (a `find` box + a `replace` box + **Find** /
+**Replace** buttons) searches and rewrites cell SOURCES:
+`InfiniteSheetModel.findAll` (over the C ABI's `sc_find_all`) returns the A1
+addresses whose formula text contains the query (case-insensitive) and the
+**Find** button jumps the selection to the first hit (`selectA1` parses column
+letters past Z); `InfiniteSheetModel.replaceAll` (over `sc_replace_all`) rewrites
+the query → replacement in every cell's source and recomputes, with the footer
+echoing the match / replace count. Because the engine re-parses each rewrite
+through its centralised coerce (`set_raw`), a rewritten formula stays live
+(`H1`→`H2` turns `=H1+5` into a recomputed `=H2+5`) and a rewritten literal stays
+typed (`15`→`99` re-totals every dependent).
 `InfiniteSheetModel` (in `Engine.kt`) seeds far-flung
 sparse cells (`Z1000`, `BA50`, `BB50`) and derives the extent from `usedRange()`
 + a margin.
@@ -131,8 +142,9 @@ echoing the web demo's CSS custom properties. From those it builds: a
 panel-wrapped **toolbar** with an address **pill**, an italic `fx` marker, then a
 grown formula field with an accent **focus ring** (driven by the field's
 `MutableInteractionSource` focus state); the actions are **segmented button
-groups** (drag-fill · clipboard · file · history) — a reusable `toolButton`
-composable with hover/pressed/disabled states — separated by thin rules. The grid
+groups** (drag-fill · clipboard · file · history · find/replace) — a reusable
+`toolButton` composable with hover/pressed/disabled states, plus a compact
+`searchField` for the find/replace inputs — separated by thin rules. The grid
 gets subtle **zebra** row banding, a 2-px **accent selection ring**, and the
 selected cell's **row + column headers tint to the accent**; a hairline-separated
 **status footer** echoes the live virtual-grid size and revision.
@@ -153,7 +165,11 @@ save/load round trip (`saveBook` → mutate A1 ⇒ E1 523.00 → `loadBook` rest
 A1 15 / E1 38.00, the loaded formula stays live with A1=5 ⇒ E1 28.00, and
 malformed input is rejected), and an undo/redo walk on a fresh session (two
 edits → undo both → redo both with the formula recomputing live → a fresh edit
-forks history).
+forks history). And it drives **find / replace**: `findAll("15")` locates the one
+literal (`A1`), a case-insensitive `findAll("sum")` finds the total formulas,
+empty / no-match queries return nothing, `selectA1("Z1000")` parses a far address,
+and `replaceAll` rewrites both a literal (`15`→`99` ⇒ E1 122.00) and a formula
+reference (`H1`→`H2` ⇒ `=H1+5` recomputes to 25) keeping each live.
 
 The Compose UI itself (`InfiniteSheet.kt` + the `Main.kt` toggle) is verified to
 compile against the real Compose Desktop APIs via `gradle compileKotlin`; the

--- a/demo/visicalc-compose/src/main/kotlin/Engine.kt
+++ b/demo/visicalc-compose/src/main/kotlin/Engine.kt
@@ -74,6 +74,11 @@ class SpreadsheetSession(libraryPath: String = resolveLibraryPath()) : AutoClose
     private val scRedo = handle("sc_redo", FunctionDescriptor.of(i32, ptr))
     private val scCanUndo = handle("sc_can_undo", FunctionDescriptor.of(i32, ptr))
     private val scCanRedo = handle("sc_can_redo", FunctionDescriptor.of(i32, ptr))
+    // sc_find_all(session, query, in_formulas, match_case) -> char* JSON object
+    //   {"matches":[<a1>,...]}; sc_replace_all(session, query, replacement,
+    //   match_case) -> int (count of cells whose source was rewritten).
+    private val scFindAll = handle("sc_find_all", FunctionDescriptor.of(ptr, ptr, ptr, i32, i32))
+    private val scReplaceAll = handle("sc_replace_all", FunctionDescriptor.of(i32, ptr, ptr, ptr, i32))
     private val scUsedRange = handle("sc_used_range", FunctionDescriptor.of(ptr, ptr))
     private val scColumnLetters = handle("sc_column_letters", FunctionDescriptor.of(ptr, ptr, i32))
     private val scCurrentRevision = handle("sc_current_revision", FunctionDescriptor.of(i64, ptr))
@@ -243,6 +248,41 @@ class SpreadsheetSession(libraryPath: String = resolveLibraryPath()) : AutoClose
             (row as List<*>).map { it as? String ?: "" }
         }
     }
+
+    /// Find every cell whose source (when [inFormulas]) or computed display text
+    /// (otherwise) contains [query], case-sensitively when [matchCase]. Returns
+    /// the matching A1 addresses, engine-sorted row-major. The engine scans only
+    /// the populated cells, so the cost is bounded by the data, not the u32 grid.
+    /// An empty query returns no matches. Reaches sc_find_all — the same engine
+    /// path the web/Qt/Flutter demos drive.
+    fun findAll(query: String, inFormulas: Boolean, matchCase: Boolean): List<String> =
+        Arena.ofConfined().use { a ->
+            val json = take(
+                scFindAll.invoke(
+                    session,
+                    a.allocateUtf8String(query),
+                    if (inFormulas) 1 else 0,
+                    if (matchCase) 1 else 0,
+                ) as MemorySegment,
+            )
+            val obj = parseJson(json) as? Map<*, *> ?: return emptyList()
+            (obj["matches"] as? List<*>)?.map { it as String } ?: emptyList()
+        }
+
+    /// Replace every occurrence of [query] with [replacement] in the SOURCE of
+    /// every cell, case-sensitively when [matchCase]; returns the number of cells
+    /// rewritten. The engine re-parses each rewritten source through its centralised
+    /// coerce (set_raw), so a rewritten "=A1" stays a live formula and a rewritten
+    /// literal stays typed, then recomputes every dependent. Reaches sc_replace_all.
+    fun replaceAll(query: String, replacement: String, matchCase: Boolean): Int =
+        Arena.ofConfined().use { a ->
+            scReplaceAll.invoke(
+                session,
+                a.allocateUtf8String(query),
+                a.allocateUtf8String(replacement),
+                if (matchCase) 1 else 0,
+            ) as Int
+        }
 
     /// The data extent {minRow,minCol,maxRow,maxCol}, or null if the sheet is
     /// empty (the engine returns the JSON literal `null`).
@@ -512,6 +552,36 @@ class InfiniteSheetModel(
         val ok = session.sortRange("A1", "E4", keyCol, ascending)
         computeExtent()
         return ok
+    }
+
+    /// Find: every cell whose SOURCE contains [query] (case-insensitive), as A1
+    /// addresses in row-major order. The Kotlin sibling of the web demo's findAll
+    /// and the Qt/Flutter ports — it searches formula text, so "=SUM" or a literal
+    /// like "15" both hit. An empty query returns no matches.
+    fun findAll(query: String): List<String> = session.findAll(query, true, false)
+
+    /// Replace: rewrite [query] → [replacement] in every cell's source
+    /// (case-insensitive), returning the number of cells changed. The engine
+    /// re-parses each rewrite (so a formula stays live, a literal stays typed) and
+    /// recomputes dependents; regrow the extent and re-sync the formula bar so the
+    /// view re-reads.
+    fun replaceAll(query: String, replacement: String): Int {
+        val n = session.replaceAll(query, replacement, false)
+        computeExtent()
+        formula = session.getRaw(infAddress())
+        return n
+    }
+
+    /// Move the selection onto an A1 address (e.g. a find hit like "Z1000"),
+    /// parsing the column letters (past Z) and row digits and clamping into the
+    /// grid. A no-op on a malformed address.
+    fun selectA1(a1: String) {
+        val m = Regex("^([A-Za-z]+)([0-9]+)$").find(a1.trim()) ?: return
+        val (letters, digits) = m.destructured
+        var col = 0
+        for (ch in letters.uppercase()) col = col * 26 + (ch - 'A' + 1)
+        val row = digits.toIntOrNull() ?: return
+        selectInf(row, col)
     }
 
     /// Clipboard: copy/cut the selected cell, then paste it at the selection. The

--- a/demo/visicalc-compose/src/main/kotlin/InfiniteSheet.kt
+++ b/demo/visicalc-compose/src/main/kotlin/InfiniteSheet.kt
@@ -122,6 +122,12 @@ fun InfiniteSheet() {
     // it to a file; the demo keeps the round trip self-contained.)
     var savedSnapshot by remember { mutableStateOf("") }
 
+    // Find / replace fields + a short status echoed in the footer (match/replace
+    // count). The query searches every cell's SOURCE (case-insensitive).
+    var findText by remember { mutableStateOf("") }
+    var replaceText by remember { mutableStateOf("") }
+    var findStatus by remember { mutableStateOf("") }
+
     // Drives the formula field's accent focus ring.
     val fieldInteraction = remember { MutableInteractionSource() }
     val fieldFocused by fieldInteraction.collectIsFocusedAsState()
@@ -199,6 +205,32 @@ fun InfiniteSheet() {
     // Range sort: reorder the budget block A1:E4 by the selected column,
     // ascending/descending. Bump rev so the reordered rows re-read.
     fun sortBlock(ascending: Boolean) { model.sortBlock(ascending); rev++ }
+
+    // Find: locate every cell whose source contains the query (case-insensitive)
+    // and jump the selection to the first hit; the footer shows the match count.
+    fun runFind() {
+        val hits = model.findAll(findText)
+        if (hits.isNotEmpty()) {
+            model.selectA1(hits.first())
+            selRow = model.selRow
+            selCol = model.selCol
+            formula = model.formula
+        }
+        findStatus = when {
+            findText.isEmpty() -> ""
+            hits.isEmpty() -> "no match"
+            else -> "${hits.size} match${if (hits.size == 1) "" else "es"}"
+        }
+    }
+
+    // Replace: rewrite the query → replacement in every cell's source and
+    // recompute; the footer shows how many cells changed.
+    fun runReplace() {
+        val n = model.replaceAll(findText, replaceText)
+        formula = model.formula
+        rev++
+        findStatus = "$n replaced"
+    }
 
     Column(modifier = Modifier.fillMaxSize().background(BG)) {
         // ── Formula bar: a panel holding the address pill, an `fx` marker, the
@@ -312,6 +344,15 @@ fun InfiniteSheet() {
             toolButton("↶ Undo", enabled = rev.let { model.canUndo() }) { undo() }
             Spacer(Modifier.width(6.dp))
             toolButton("↷ Redo", enabled = rev.let { model.canRedo() }) { redo() }
+            toolSep()
+            // ── Find / replace (search cell sources; rewrite matches) ──
+            searchField(findText, "find", { findText = it }) { runFind() }
+            Spacer(Modifier.width(6.dp))
+            toolButton("Find") { runFind() }
+            Spacer(Modifier.width(6.dp))
+            searchField(replaceText, "replace", { replaceText = it }) { runReplace() }
+            Spacer(Modifier.width(6.dp))
+            toolButton("Replace") { runReplace() }
         }
 
         // ── Column-letter header (frozen vertically, follows horizontal pan) ──
@@ -354,11 +395,51 @@ fun InfiniteSheet() {
         Box(modifier = Modifier.fillMaxWidth().padding(horizontal = 10.dp).height(1.dp).background(LINE))
         androidx.compose.material.Text(
             "Virtual grid: ${model.totalRows} rows × ${model.totalCols} cols" +
-                "  ·  revision ${rev.let { model.revision() }}",
+                "  ·  revision ${rev.let { model.revision() }}" +
+                (if (findStatus.isNotEmpty()) "  ·  $findStatus" else ""),
             color = MUTED,
             fontSize = 12.sp,
             fontFamily = MONO,
             modifier = Modifier.padding(start = 10.dp, end = 10.dp, top = 6.dp, bottom = 10.dp),
+        )
+    }
+}
+
+/// A compact search input for the find / replace group — a narrow well with the
+/// same accent focus ring as the formula field, a muted placeholder when empty,
+/// and Enter-to-submit. The Compose analog of the web demo's find/replace boxes
+/// and the Qt/Flutter ports' search fields.
+@Composable
+private fun searchField(value: String, hint: String, onValueChange: (String) -> Unit, onSubmit: () -> Unit) {
+    val interaction = remember { MutableInteractionSource() }
+    val focused by interaction.collectIsFocusedAsState()
+    Box(
+        modifier = Modifier
+            .width(96.dp)
+            .height(30.dp)
+            .clip(RoundedCornerShape(5.dp))
+            .background(FIELD)
+            .border(
+                if (focused) 2.dp else 1.dp,
+                if (focused) ACCENT else LINE_STRONG,
+                RoundedCornerShape(5.dp),
+            )
+            .padding(horizontal = 8.dp),
+        contentAlignment = Alignment.CenterStart,
+    ) {
+        if (value.isEmpty()) {
+            androidx.compose.material.Text(hint, color = MUTED, fontSize = 12.sp, fontFamily = MONO)
+        }
+        BasicTextField(
+            value = value,
+            onValueChange = onValueChange,
+            singleLine = true,
+            interactionSource = interaction,
+            textStyle = TextStyle(color = INK, fontSize = 12.sp, fontFamily = MONO),
+            cursorBrush = androidx.compose.ui.graphics.SolidColor(ACCENT),
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+            keyboardActions = KeyboardActions(onDone = { onSubmit() }),
+            modifier = Modifier.fillMaxWidth(),
         )
     }
 }

--- a/demo/visicalc-compose/test/EngineSmoke.kt
+++ b/demo/visicalc-compose/test/EngineSmoke.kt
@@ -260,6 +260,35 @@ fun main() {
     check("sort bad key no-op", so.sortRange("A1", "E4", 9, true).toString(), "false")
     so.close()
 
+    // Find / replace (the find/replace fields + Find/Replace buttons drive
+    // findAll/replaceAll): findAll returns the A1 addresses whose SOURCE contains
+    // the query (case-insensitive); replaceAll rewrites the query in every cell's
+    // source and recomputes, returning the count. A rewritten formula stays live;
+    // a rewritten literal stays typed.
+    val fr = InfiniteSheetModel()
+    // The seed has the literal "15" only at A1, and "=SUM(" in every total formula.
+    check("find literal 15", fr.findAll("15").joinToString(","), "A1")
+    checkContains("find formula SUM has E1", fr.findAll("sum").joinToString(","), "E1")
+    check("find empty query", fr.findAll("").size.toString(), "0")
+    check("find no match", fr.findAll("zzz").size.toString(), "0")
+    // selectA1 moves the cursor onto a hit (parsing column letters past Z).
+    fr.selectA1("Z1000")
+    check("selectA1 Z1000 addr", fr.infAddress(), "Z1000")
+    // Replace a literal: A1 "15" → "99"; E1 = 99+3+12+8 = 122 (#,##0.00 format).
+    check("replace 15→99 count", fr.replaceAll("15", "99").toString(), "1")
+    fr.selectA1("A1")
+    check("replaced A1 value", fr.rowCells(1)[0], "99")
+    check("replaced E1 recomputed", fr.rowCells(1)[4], "122.00")
+    // Replace inside a formula reference keeps it LIVE: H1=10, H2=20, H3 = =H1+5
+    // (15). Rewrite "H1" → "H2" → H3 becomes =H2+5 = 25, recomputed by the engine.
+    fr.selectInf(1, 8); fr.commitInf("10")     // H1
+    fr.selectInf(2, 8); fr.commitInf("20")     // H2
+    fr.selectInf(3, 8); fr.commitInf("=H1+5")  // H3 = 15
+    check("pre-replace H3", fr.rowCells(3)[7], "15")
+    check("replace H1→H2 count", fr.replaceAll("H1", "H2").toString(), "1")
+    check("H3 recomputed live", fr.rowCells(3)[7], "25") // =H2+5
+    fr.close()
+
     println(if (failures == 0) "\nALL PASS" else "\n$failures FAILURE(S)")
     kotlin.system.exitProcess(if (failures == 0) 0 else 1)
 }


### PR DESCRIPTION
Rolls out **find/replace** to the **Compose Desktop** demo — the 5th of 6 backends in the engine-homed find/replace campaign (engine #6669, facades #6673, web #6678, Qt #6680, Flutter #6682 already merged/open).

Computes on the shared Rust `spreadsheet-core` engine through the C ABI via the Java FFM API — the same `sc_find_all` / `sc_replace_all` path the web/Qt/Flutter demos drive. No spreadsheet logic in this layer.

## What changed
- **Engine.kt** — two new FFM downcalls: `sc_find_all` (heap `char*` JSON `{"matches":[<a1>,...]}`, freed via the existing `take` → `sc_string_free`) and `sc_replace_all` (`int` count). `SpreadsheetSession.findAll/replaceAll` wrappers; `InfiniteSheetModel.findAll(query)`, `replaceAll(query, replacement)` (re-derives the extent + re-syncs the formula bar), and `selectA1(a1)` to jump onto a find hit (parses column letters past Z; clamped by `selectInf`).
- **InfiniteSheet.kt** — a Find/Replace toolbar group: a compact `searchField` composable (accent focus ring, muted placeholder, Enter-to-submit), Find/Replace buttons, and a footer status echoing the match/replace count. Find jumps to the first hit; Replace recomputes live.
- **EngineSmoke.kt** — headless proof (see below).
- **README.md** — documents the group + the new verification cases.

Because the engine re-parses each rewrite through its centralised coerce (`set_raw`), a rewritten formula stays a live formula and a rewritten literal stays typed.

## Verification
- `scripts/verify.sh` (kotlinc + FFM, loads the vendored engine lib) → **ALL PASS**. New cases: `findAll("15")` locates the one literal (A1); case-insensitive `findAll("sum")` finds the total formulas; empty/no-match queries return nothing; `selectA1("Z1000")` parses a far address; `replaceAll` rewrites a literal (`15`→`99` ⇒ E1 122.00) and a formula reference (`H1`→`H2` ⇒ `=H1+5` recomputes to 25), each staying live.
- Compose UI compiles against the real Compose Desktop APIs (`gradle compileKotlin`, executed).
- `/security-review` (FFI string lifetime, char* leak, ReDoS, A1-parser overflow, JSON injection) → **PASSED**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)