### PR TITLE
feat(visicalc-xaml): find/replace in the XAML demo

### DIFF
--- a/demo/visicalc-xaml/Engine.cs
+++ b/demo/visicalc-xaml/Engine.cs
@@ -105,6 +105,18 @@ internal static class ScNative
     [DllImport("spreadsheet_capi")] internal static extern int sc_redo(IntPtr s);
     [DllImport("spreadsheet_capi")] internal static extern int sc_can_undo(IntPtr s);
     [DllImport("spreadsheet_capi")] internal static extern int sc_can_redo(IntPtr s);
+    // sc_find_all(session, query, in_formulas, match_case) → char* JSON object
+    //   {"matches":[<a1>,...]}; sc_replace_all(session, query, replacement,
+    //   match_case) → int (count of cells whose source was rewritten).
+    [DllImport("spreadsheet_capi")]
+    internal static extern IntPtr sc_find_all(IntPtr s,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string query,
+        int inFormulas, int matchCase);
+    [DllImport("spreadsheet_capi")]
+    internal static extern int sc_replace_all(IntPtr s,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string query,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string replacement,
+        int matchCase);
     [DllImport("spreadsheet_capi")] internal static extern IntPtr sc_used_range(IntPtr s);
     [DllImport("spreadsheet_capi")] internal static extern IntPtr sc_column_letters(IntPtr s, uint index);
     [DllImport("spreadsheet_capi")] internal static extern ulong sc_current_revision(IntPtr s);
@@ -356,6 +368,35 @@ public sealed class SpreadsheetSession : IDisposable
         }
     }
 
+    /// Find every cell whose source (when `inFormulas`) or computed display text
+    /// (otherwise) contains `query`, case-sensitively when `matchCase`. Returns
+    /// the matching A1 addresses, engine-sorted row-major. The engine scans only
+    /// the populated cells, so the cost is bounded by the data, not the u32 grid.
+    /// An empty query returns no matches. Reaches sc_find_all — the same engine
+    /// path every other backend drives.
+    public IReadOnlyList<string> FindAll(string query, bool inFormulas, bool matchCase)
+    {
+        string json = Take(ScNative.sc_find_all(_handle, query, inFormulas ? 1 : 0, matchCase ? 1 : 0));
+        var matches = new List<string>();
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            if (doc.RootElement.TryGetProperty("matches", out var arr))
+                foreach (var m in arr.EnumerateArray()) matches.Add(m.GetString() ?? string.Empty);
+        }
+        catch (Exception ex) when (ex is JsonException or KeyNotFoundException or InvalidOperationException) { /* bad response → no matches */ }
+        return matches;
+    }
+
+    /// Replace every occurrence of `query` with `replacement` in the SOURCE of
+    /// every cell, case-sensitively when `matchCase`; returns the number of cells
+    /// rewritten. The engine re-parses each rewritten source through its
+    /// centralised coerce (set_raw), so a rewritten formula stays live and a
+    /// rewritten literal stays typed, then recomputes every dependent. Reaches
+    /// sc_replace_all.
+    public int ReplaceAll(string query, string replacement, bool matchCase) =>
+        ScNative.sc_replace_all(_handle, query, replacement, matchCase ? 1 : 0);
+
     public void Dispose()
     {
         if (_handle != IntPtr.Zero)
@@ -594,6 +635,38 @@ public sealed class InfiniteSheetModel : IDisposable
         bool ok = _session.SortRange("A1", "E4", keyCol, ascending);
         ComputeExtent();
         return ok;
+    }
+
+    /// Find: every cell whose SOURCE contains `query` (case-insensitive), as A1
+    /// addresses in row-major order. The .NET sibling of the web demo's findAll
+    /// and the Qt/Flutter/Compose ports — it searches formula text, so "=SUM" or a
+    /// literal like "15" both hit. An empty query returns no matches.
+    public IReadOnlyList<string> FindAll(string query) => _session.FindAll(query, true, false);
+
+    /// Replace: rewrite `query` → `replacement` in every cell's source
+    /// (case-insensitive), returning the number of cells changed. The engine
+    /// re-parses each rewrite (so a formula stays live, a literal stays typed) and
+    /// recomputes dependents; regrow the extent and re-sync the formula bar so the
+    /// view re-reads.
+    public int ReplaceAll(string query, string replacement)
+    {
+        int n = _session.ReplaceAll(query, replacement, false);
+        ComputeExtent();
+        Formula = _session.GetRaw(InfAddress);
+        return n;
+    }
+
+    /// Move the selection onto an A1 address (e.g. a find hit like "Z1000"),
+    /// parsing the column letters (past Z) and row digits and clamping into the
+    /// grid via <see cref="SelectInf"/>. A no-op on a malformed address.
+    public void SelectA1(string a1)
+    {
+        var m = System.Text.RegularExpressions.Regex.Match(a1.Trim(), "^([A-Za-z]+)([0-9]+)$");
+        if (!m.Success) return;
+        int col = 0;
+        foreach (char ch in m.Groups[1].Value.ToUpperInvariant()) col = col * 26 + (ch - 'A' + 1);
+        if (!int.TryParse(m.Groups[2].Value, out int row)) return;
+        SelectInf(row, col);
     }
 
     /// Clipboard: copy/cut the selected cell, then paste it at the selection. The

--- a/demo/visicalc-xaml/InfiniteSheet.xaml
+++ b/demo/visicalc-xaml/InfiniteSheet.xaml
@@ -198,6 +198,32 @@
                             Content="↷ Redo"
                             ToolTipService.ToolTip="Redo the last undone edit"
                             Click="RedoButton_Click"/>
+                    <Border Width="1" Height="22" Margin="6,0,6,0" Background="#2C313A"/>
+                    <!-- Find / replace (search cell sources; rewrite matches) -->
+                    <Border Width="96" Height="30" CornerRadius="5" Margin="0,0,6,0"
+                            Background="#0F1115" BorderBrush="#3A404B" BorderThickness="1">
+                        <TextBox x:Name="FindBox" PlaceholderText="find"
+                                 Background="Transparent" BorderThickness="0"
+                                 Foreground="#E8EAED" FontSize="12" FontFamily="Consolas"
+                                 VerticalAlignment="Center"
+                                 KeyDown="FindBox_KeyDown"/>
+                    </Border>
+                    <Button x:Name="FindButton" Style="{StaticResource ToolChip}" Margin="0,0,6,0"
+                            Content="Find"
+                            ToolTipService.ToolTip="Find every cell whose source contains the query (case-insensitive) and jump to the first hit"
+                            Click="FindButton_Click"/>
+                    <Border Width="96" Height="30" CornerRadius="5" Margin="0,0,6,0"
+                            Background="#0F1115" BorderBrush="#3A404B" BorderThickness="1">
+                        <TextBox x:Name="ReplaceBox" PlaceholderText="replace"
+                                 Background="Transparent" BorderThickness="0"
+                                 Foreground="#E8EAED" FontSize="12" FontFamily="Consolas"
+                                 VerticalAlignment="Center"
+                                 KeyDown="ReplaceBox_KeyDown"/>
+                    </Border>
+                    <Button x:Name="ReplaceButton" Style="{StaticResource ToolChip}"
+                            Content="Replace"
+                            ToolTipService.ToolTip="Replace the query with the replacement in every cell's source and recompute"
+                            Click="ReplaceButton_Click"/>
                 </StackPanel>
             </Grid>
         </Border>

--- a/demo/visicalc-xaml/InfiniteSheet.xaml.cs
+++ b/demo/visicalc-xaml/InfiniteSheet.xaml.cs
@@ -62,6 +62,9 @@ public sealed partial class InfiniteSheet : UserControl
     // serialized workbook here, Load restores from it. (A real app would write it
     // to a file; the demo keeps the round trip self-contained.)
     private string _savedSnapshot = string.Empty;
+
+    /// Short find/replace status (match/replace count) echoed in the footer.
+    private string _findStatus = string.Empty;
     private ScrollViewer? _bodyInnerSv, _gutterInnerSv;
 
     public InfiniteSheet()
@@ -331,11 +334,60 @@ public sealed partial class InfiniteSheet : UserControl
         UpdateStatus();
     }
 
+    /// Find: locate every cell whose source contains the query (case-insensitive)
+    /// and jump the selection to the first hit; the footer shows the match count.
+    /// The .NET sibling of the web demo's Find button and the Qt/Flutter/Compose
+    /// ports — it searches formula text, so "=SUM" or a literal like "15" both hit.
+    private void FindButton_Click(object sender, RoutedEventArgs e) => RunFind();
+    private void FindBox_KeyDown(object sender, KeyRoutedEventArgs e)
+    {
+        if (e.Key != VirtualKey.Enter) return;
+        RunFind();
+        e.Handled = true;
+    }
+
+    private void RunFind()
+    {
+        string query = FindBox.Text;
+        var hits = _model.FindAll(query);
+        if (hits.Count > 0)
+        {
+            _model.SelectA1(hits[0]);
+            RefreshFormulaBar();
+            RepaintRealizedRows();
+        }
+        _findStatus = query.Length == 0 ? string.Empty
+            : hits.Count == 0 ? "no match"
+            : $"{hits.Count} match{(hits.Count == 1 ? "" : "es")}";
+        UpdateStatus();
+    }
+
+    /// Replace: rewrite the query → replacement in every cell's source and
+    /// recompute; the footer shows how many cells changed. The engine re-parses
+    /// each rewrite (so a formula stays live, a literal stays typed).
+    private void ReplaceButton_Click(object sender, RoutedEventArgs e) => RunReplace();
+    private void ReplaceBox_KeyDown(object sender, KeyRoutedEventArgs e)
+    {
+        if (e.Key != VirtualKey.Enter) return;
+        RunReplace();
+        e.Handled = true;
+    }
+
+    private void RunReplace()
+    {
+        int n = _model.ReplaceAll(FindBox.Text, ReplaceBox.Text);
+        _findStatus = $"{n} replaced";
+        RefreshFormulaBar();
+        RepaintRealizedRows();
+    }
+
     /// The hairline footer: the live virtual-grid size + the per-edit revision
-    /// clock (mirrors the web/Qt/Flutter/Compose status lines).
+    /// clock (mirrors the web/Qt/Flutter/Compose status lines), with the
+    /// find/replace count appended when present.
     private void UpdateStatus() =>
         StatusText.Text =
-            $"Virtual grid: {_model.TotalRows} rows × {_model.TotalCols} cols  ·  revision {_model.Revision}";
+            $"Virtual grid: {_model.TotalRows} rows × {_model.TotalCols} cols  ·  revision {_model.Revision}"
+            + (_findStatus.Length > 0 ? $"  ·  {_findStatus}" : string.Empty);
 
     /// Rebuild only the currently-realized rows (body + gutter) and the header so
     /// the selection highlight, accent-tinted row/column headers, and recomputed

--- a/demo/visicalc-xaml/README.md
+++ b/demo/visicalc-xaml/README.md
@@ -177,6 +177,16 @@ The **.00 / % / $ / Gen** buttons apply a number **format** to the selected cell
 `#,##0.00`, `0.0%`, `$#,##0.00`, or `""` to clear). The format is display-only —
 the engine renders the stored value through the code, so the underlying number is
 unchanged.
+The **find / replace** group (a `find` box + a `replace` box + **Find** /
+**Replace** buttons) searches and rewrites cell SOURCES: `InfiniteSheetModel.FindAll`
+(over the C ABI's `sc_find_all`) returns the A1 addresses whose formula text contains
+the query (case-insensitive) and **Find** jumps the selection to the first hit
+(`SelectA1` parses column letters past Z); `InfiniteSheetModel.ReplaceAll` (over
+`sc_replace_all`) rewrites the query → replacement in every cell's source and
+recomputes, with the footer echoing the match / replace count. Because the engine
+re-parses each rewrite through its centralised coerce (`set_raw`), a rewritten formula
+stays live (`H1`→`H2` turns `=H1+5` into a recomputed `=H2+5`) and a rewritten literal
+stays typed (`15`→`99` re-totals every dependent).
 
 `InfiniteSheetModel` (in `Engine.cs`, WinUI-free) seeds far-flung sparse cells
 (`Z1000`, `BA50`, `BB50`) and derives the extent from `UsedRange()` + a margin
@@ -194,7 +204,7 @@ web demo's CSS custom properties. From those it builds: a panel-wrapped **toolba
 with an address **pill**, an italic `fx` marker, then a grown formula field with
 an accent **focus ring** (the wrapping `Border` thickens + tints to the accent on
 `GotFocus`); the actions are **segmented button groups** (drag-fill · clipboard ·
-file · history) — a rounded `ToolChip` button style whose hover/pressed/disabled
+file · history · find/replace) — a rounded `ToolChip` button style whose hover/pressed/disabled
 chrome is recolored by overriding the stock WinUI `Button*` theme brushes in
 `UserControl.Resources` (no custom `ControlTemplate`) — separated by thin rules.
 The grid gets subtle **zebra** row banding (`rowNum % 2`), a 2-px **accent
@@ -221,7 +231,11 @@ clipboard copy/cut/paste, and a save/load round trip (`SaveBook` → mutate A1 �
 E1 523.00 → `LoadBook` restores A1 15 / E1 38.00, the loaded formula stays live
 with A1=5 ⇒ E1 28.00, and malformed input is rejected), and an undo/redo walk on
 a fresh session (two edits → undo both → redo both with the formula recomputing
-live → a fresh edit forks history).
+live → a fresh edit forks history). And it drives **find / replace**: `FindAll("15")`
+locates the one literal (`A1`), a case-insensitive `FindAll("sum")` finds the total
+formulas, empty / no-match queries return nothing, `SelectA1("Z1000")` parses a far
+address, and `ReplaceAll` rewrites both a literal (`15`→`99` ⇒ E1 122.00) and a
+formula reference (`H1`→`H2` ⇒ `=H1+5` recomputes to 25) keeping each live.
 
 ## Where this fits in the cross-backend demo plan
 

--- a/demo/visicalc-xaml/test/Program.cs
+++ b/demo/visicalc-xaml/test/Program.cs
@@ -269,5 +269,35 @@ using (var so = new SpreadsheetSession())
     Check("sort bad key no-op", so.SortRange("A1", "E4", 9, true).ToString(), "False");
 }
 
+// ── Find / replace (the find/replace boxes + Find/Replace buttons drive
+// FindAll/ReplaceAll): FindAll returns the A1 addresses whose SOURCE contains
+// the query (case-insensitive); ReplaceAll rewrites the query in every cell's
+// source and recomputes, returning the count. A rewritten formula stays live;
+// a rewritten literal stays typed.
+using (var fr = new InfiniteSheetModel())
+{
+    // The seed has the literal "15" only at A1, and "=SUM(" in every total formula.
+    Check("find literal 15", string.Join(",", fr.FindAll("15")), "A1");
+    Contains("find formula SUM has E1", string.Join(",", fr.FindAll("sum")), "E1");
+    Check("find empty query", fr.FindAll("").Count.ToString(), "0");
+    Check("find no match", fr.FindAll("zzz").Count.ToString(), "0");
+    // SelectA1 moves the cursor onto a hit (parsing column letters past Z).
+    fr.SelectA1("Z1000");
+    Check("selectA1 Z1000 addr", fr.InfAddress, "Z1000");
+    // Replace a literal: A1 "15" → "99"; E1 = 99+3+12+8 = 122 (#,##0.00 format).
+    Check("replace 15->99 count", fr.ReplaceAll("15", "99").ToString(), "1");
+    fr.SelectA1("A1");
+    Check("replaced A1 value", fr.RowCells(1)[0], "99");
+    Check("replaced E1 recomputed", fr.RowCells(1)[4], "122.00");
+    // Replace inside a formula reference keeps it LIVE: H1=10, H2=20, H3 = =H1+5
+    // (15). Rewrite "H1" → "H2" → H3 becomes =H2+5 = 25, recomputed by the engine.
+    fr.SelectInf(1, 8); fr.CommitInf("10");     // H1
+    fr.SelectInf(2, 8); fr.CommitInf("20");     // H2
+    fr.SelectInf(3, 8); fr.CommitInf("=H1+5");  // H3 = 15
+    Check("pre-replace H3", fr.RowCells(3)[7], "15");
+    Check("replace H1->H2 count", fr.ReplaceAll("H1", "H2").ToString(), "1");
+    Check("H3 recomputed live", fr.RowCells(3)[7], "25"); // =H2+5
+}
+
 Console.WriteLine(failures == 0 ? "\nALL PASS" : $"\n{failures} FAILURE(S)");
 return failures == 0 ? 0 : 1;


### PR DESCRIPTION
Rolls out **find/replace** to the **WinUI/XAML** demo — the 5th of 6 backends in the engine-homed find/replace campaign (engine #6669, facades #6673, web #6678, Qt #6680, Flutter #6682, Compose #6685 already merged/open).

Computes on the shared Rust `spreadsheet-core` engine through the C ABI via P/Invoke — the same `sc_find_all` / `sc_replace_all` path the web/Qt/Flutter/Compose demos drive. No spreadsheet logic in this layer.

## What changed
- **Engine.cs** — two new `DllImport`s: `sc_find_all` (heap `char*` JSON `{"matches":[<a1>,...]}`, freed via the existing `Take()`→`sc_string_free`) and `sc_replace_all` (`int` count). `SpreadsheetSession.FindAll/ReplaceAll`; `InfiniteSheetModel.FindAll(query)`, `ReplaceAll(query, replacement)` (re-derives the extent + re-syncs the formula bar), and `SelectA1(a1)` to jump onto a find hit (parses column letters past Z; clamped by `SelectInf` via `Math.Clamp`).
- **InfiniteSheet.xaml / .xaml.cs** — a Find/Replace toolbar group: a find box, a Find button, a replace box, a Replace button (Enter-to-submit on both), and a footer status echoing the match/replace count. Find jumps to the first hit; Replace recomputes live.
- **test/Program.cs** — headless proof (below).
- **README.md** — documents the group + the new verification cases.

Because the engine re-parses each rewrite through its centralised coerce (`set_raw`), a rewritten formula stays a live formula and a rewritten literal stays typed.

## Verification
- `scripts/verify.sh` (the `test/` console P/Invoke harness, runs on macOS/Linux/Windows) → **ALL PASS**. New cases: `FindAll("15")` locates the one literal (A1); case-insensitive `FindAll("sum")` finds the total formulas; empty/no-match queries return nothing; `SelectA1("Z1000")` parses a far address; `ReplaceAll` rewrites a literal (`15`→`99` ⇒ E1 122.00) and a formula reference (`H1`→`H2` ⇒ `=H1+5` recomputes to 25), each staying live.
- The WinUI view is Windows-only (can't `dotnet build` on macOS); the engine-backed logic it drives is the headlessly-proven model above (same boundary as every prior XAML demo PR).
- `/security-review` (P/Invoke string lifetime, char* leak, A1-parser overflow, ReDoS, JSON-injection) → **PASSED**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)