### PR TITLE
feat(visicalc-swiftui): find/replace in the SwiftUI demo

### DIFF
--- a/demo/visicalc-swiftui/README.md
+++ b/demo/visicalc-swiftui/README.md
@@ -116,6 +116,16 @@ number-format code to the selected cell's *display only*
 `#,##0.00` (`1234` → `1,234.00`), `%` → `0.0%`, `$` → `$#,##0.00`, and `Gen` →
 `""` (clears, back to General). The stored value is untouched — `getRaw` still
 returns the source and dependent formulas keep computing on the real number.
+The **find / replace** group (a `find` box + a `replace` box + **Find** /
+**Replace** buttons) searches and rewrites cell SOURCES: `WindowedSheetModel.findAll`
+(over the C ABI's `sc_find_all`) returns the A1 addresses whose formula text contains
+the query (case-insensitive) and **Find** jumps the selection to the first hit
+(`selectA1` parses column letters past Z); `WindowedSheetModel.replaceAll` (over
+`sc_replace_all`) rewrites the query → replacement in every cell's source and
+recomputes, with the footer echoing the match / replace count. Because the engine
+re-parses each rewrite through its centralised coerce (`set_raw`), a rewritten formula
+stays live (`H1`→`H2` turns `=H1+5` into a recomputed `=H2+5`) and a rewritten literal
+stays typed (`15`→`99` re-totals every dependent).
 
 ### Visual design
 
@@ -128,8 +138,9 @@ tokens at the top of the view (`cBg`/`cPanel`/`cSurface`/`line`/`ink`/`muted`/
 panel-wrapped **toolbar** with an address **pill**, an italic `fx` marker, then a
 grown formula field with an accent **focus ring** (a `@FocusState`-driven 2-px
 overlay stroke); the actions are **segmented button groups** (drag-fill ·
-clipboard · file · history) — a reusable `ChipButtonStyle` with hover/pressed/
-disabled states — separated by thin rules. The grid gets subtle **zebra** row
+clipboard · file · history · find/replace) — a reusable `ChipButtonStyle` with
+hover/pressed/disabled states, plus compact find/replace text fields — separated
+by thin rules. The grid gets subtle **zebra** row
 banding, a 2-px **accent selection ring**, and the selected cell's **row + column
 headers tint to the accent**; a hairline-separated **status footer** echoes the
 live virtual-grid size and revision.
@@ -145,7 +156,11 @@ no-op), and a save/load round trip (`saveBook` → mutate A1 ⇒ E1 523.00 →
 `loadBook` restores A1 15 / E1 38.00, the loaded formula stays live with A1=5 ⇒
 E1 28.00, and malformed input is rejected), and an undo/redo walk (two edits →
 undo both → redo both with the formula recomputing live → a fresh edit forks
-history). Run with `swift test`.
+history), and **find / replace** (`findAll("15")` locates the one literal `A1`, a
+case-insensitive `findAll("sum")` finds the total formulas, empty / no-match queries
+return nothing, `selectA1("Z1000")` parses a far address, and `replaceAll` rewrites
+both a literal `15`→`99` ⇒ E1 122.00 and a formula reference `H1`→`H2` ⇒ `=H1+5`
+recomputes to 25, keeping each live). Run with `swift test`.
 
 ## Notes
 

--- a/demo/visicalc-swiftui/Sources/CSpreadsheetEngine/include/spreadsheet.h
+++ b/demo/visicalc-swiftui/Sources/CSpreadsheetEngine/include/spreadsheet.h
@@ -85,6 +85,17 @@ int   sc_paste(ScSession *s, const char *dst_start);
 int   sc_sort_range(ScSession *s, const char *start, const char *end,
                     uint32_t key_col, int ascending);
 
+/* Find / replace. sc_find_all() returns a heap char* JSON object
+   {"matches":["A1",...]} of the A1 addresses whose text contains `query`, in
+   (row,col) order — free it with sc_string_free(). `in_formulas` is a flag
+   (non-zero searches each cell's source; 0 its computed display value);
+   `match_case` is a flag (0 folds ASCII case); an empty query → empty list.
+   sc_replace_all() replaces `query` with `replacement` in the source of every
+   matching cell (engine rewrites + recomputes) and returns the count of cells
+   changed (empty query → 0). The host re-reads via sc_get_window / sc_get_raw. */
+char *sc_find_all(ScSession *s, const char *query, int in_formulas, int match_case);
+int   sc_replace_all(ScSession *s, const char *query, const char *replacement, int match_case);
+
 /* Save / load. sc_serialize() returns a self-contained JSON document holding the
    workbook's SOURCE (formula text + typed literals) and per-cell formats — not the
    computed values, which recompute on load (small file, can't disagree with itself).

--- a/demo/visicalc-swiftui/Sources/VisiCalc/Engine.swift
+++ b/demo/visicalc-swiftui/Sources/VisiCalc/Engine.swift
@@ -203,6 +203,32 @@ final class SpreadsheetSession {
         if obj["stale"] as? Bool == true { return ([], true) }
         return (obj["changed"] as? [String] ?? [], false)
     }
+
+    /// Find every cell whose source (when `inFormulas`) or computed display text
+    /// (otherwise) contains `query`, case-sensitively when `matchCase`. Returns
+    /// the matching A1 addresses, engine-sorted row-major. The engine scans only
+    /// the populated cells, so the cost is bounded by the data, not the u32 grid.
+    /// An empty query returns no matches. Reaches `sc_find_all` — the same engine
+    /// path every other backend drives.
+    func findAll(_ query: String, _ inFormulas: Bool, _ matchCase: Bool) -> [String] {
+        let json = take(sc_find_all(handle, query, inFormulas ? 1 : 0, matchCase ? 1 : 0))
+        guard
+            let data = json.data(using: .utf8),
+            let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let matches = obj["matches"] as? [String]
+        else { return [] }
+        return matches
+    }
+
+    /// Replace every occurrence of `query` with `replacement` in the SOURCE of
+    /// every cell, case-sensitively when `matchCase`; returns the number of cells
+    /// rewritten. The engine re-parses each rewritten source through its
+    /// centralised coerce (`set_raw`), so a rewritten formula stays live and a
+    /// rewritten literal stays typed, then recomputes every dependent. Reaches
+    /// `sc_replace_all`.
+    func replaceAll(_ query: String, _ replacement: String, _ matchCase: Bool) -> Int {
+        Int(sc_replace_all(handle, query, replacement, matchCase ? 1 : 0))
+    }
 }
 
 /// SwiftUI model: an engine-backed 5×5 spreadsheet. `@Published` properties

--- a/demo/visicalc-swiftui/Sources/VisiCalc/InfiniteGrid.swift
+++ b/demo/visicalc-swiftui/Sources/VisiCalc/InfiniteGrid.swift
@@ -30,6 +30,11 @@ final class WindowedSheetModel: ObservableObject {
     @Published private(set) var selectedCol: Int = 1
     /// The formula bar's text — the selected cell's source, edited in place.
     @Published var formulaText: String = ""
+    /// The find/replace boxes' text + a short status (match/replace count) shown
+    /// in the footer. The query searches every cell's SOURCE (case-insensitive).
+    @Published var findText: String = ""
+    @Published var replaceText: String = ""
+    @Published private(set) var findStatus: String = ""
 
     /// Column letters cached once per resize (`columnLetters` is a pure engine
     /// call, but the header would otherwise re-issue it for every column on
@@ -189,6 +194,72 @@ final class WindowedSheetModel: ObservableObject {
         return ok
     }
 
+    /// Find: every cell whose SOURCE contains `query` (case-insensitive), as A1
+    /// addresses in row-major order. The SwiftUI sibling of the web demo's findAll
+    /// and the Qt/Flutter/Compose/XAML ports — it searches formula text, so "=SUM"
+    /// or a literal like "15" both hit. An empty query returns no matches.
+    func findAll(_ query: String) -> [String] { session.findAll(query, true, false) }
+
+    /// Replace: rewrite `query` → `replacement` in every cell's source
+    /// (case-insensitive), returning the number of cells changed. The engine
+    /// re-parses each rewrite (so a formula stays live, a literal stays typed) and
+    /// recomputes dependents; resize the extent, re-sync the formula bar, and bump
+    /// `revision` so the visible rows re-fetch.
+    @discardableResult
+    func replaceAll(_ query: String, _ replacement: String) -> Int {
+        let n = session.replaceAll(query, replacement, false)
+        resize()
+        formulaText = session.getRaw(address(selectedRow, selectedCol))
+        revision += 1
+        return n
+    }
+
+    /// Find button: locate the matches for `findText`, jump the selection to the
+    /// first hit, and set `findStatus` to the match count for the footer. An empty
+    /// query clears the status and does nothing.
+    func runFind() {
+        let hits = findAll(findText)
+        if let first = hits.first { selectA1(first) }
+        if findText.isEmpty {
+            findStatus = ""
+        } else if hits.isEmpty {
+            findStatus = "no match"
+        } else {
+            findStatus = "\(hits.count) match\(hits.count == 1 ? "" : "es")"
+        }
+    }
+
+    /// Replace button: rewrite `findText` → `replaceText` everywhere and recompute;
+    /// `findStatus` shows how many cells changed.
+    func runReplace() {
+        let n = replaceAll(findText, replaceText)
+        findStatus = "\(n) replaced"
+    }
+
+    /// Move the selection onto an A1 address (e.g. a find hit like "Z1000"),
+    /// parsing the column letters (past Z) and row digits and clamping into the
+    /// grid via `select`. A no-op on a malformed address.
+    func selectA1(_ a1: String) {
+        let trimmed = a1.trimmingCharacters(in: .whitespaces)
+        var letters = "", digits = ""
+        for ch in trimmed {
+            if ch.isLetter, digits.isEmpty { letters.append(ch) }
+            else if ch.isNumber { digits.append(ch) }
+            else { return } // malformed: bail out
+        }
+        // A u32-bounded sheet's widest column ("FXSHRXW", 2^32) is 7 letters, so a
+        // longer run is malformed — bail before the `col * 26` accumulate (which
+        // would otherwise trap on Int overflow for a ~13+ letter run; `select`
+        // clamps the result, but only after the multiply).
+        guard !letters.isEmpty, letters.count <= 7, let row = Int(digits) else { return }
+        var col = 0
+        for ch in letters.uppercased() {
+            guard let v = ch.asciiValue, v >= 65, v <= 90 else { return }
+            col = col * 26 + Int(v - 64) // 'A' = 1
+        }
+        select(row: row, col: col)
+    }
+
     /// Clipboard: copy/cut the selected cell, then paste it at the selection. The
     /// engine shifts the pasted formula's relative references by the
     /// destination's offset, pins absolute (`$`) refs, carries the format; a cut
@@ -333,7 +404,8 @@ struct InfiniteGridView: View {
         VStack(spacing: 0) {
             Rectangle().fill(line).frame(height: 1)
             HStack {
-                Text("Virtual grid: \(model.totalRows) rows × \(model.totalCols) cols  ·  revision \(model.revision)")
+                Text("Virtual grid: \(model.totalRows) rows × \(model.totalCols) cols  ·  revision \(model.revision)"
+                    + (model.findStatus.isEmpty ? "" : "  ·  \(model.findStatus)"))
                     .font(.system(size: 11, design: .monospaced))
                     .foregroundColor(muted)
                 Spacer()
@@ -430,6 +502,32 @@ struct InfiniteGridView: View {
             Button("↷ Redo") { model.redoEdit() }
                 .disabled(!model.canRedo())
                 .help("Redo the last undone edit")
+            toolSep
+            // ── Find / replace (search cell sources; rewrite matches) ──
+            TextField("find", text: $model.findText)
+                .textFieldStyle(.plain)
+                .font(.system(size: 12, design: .monospaced))
+                .foregroundColor(ink)
+                .padding(.horizontal, 8)
+                .frame(width: 96, height: 30)
+                .background(cField)
+                .overlay(RoundedRectangle(cornerRadius: 5).stroke(lineStrong, lineWidth: 1))
+                .cornerRadius(5)
+                .onSubmit { model.runFind() }
+            Button("Find") { model.runFind() }
+                .help("Find every cell whose source contains the query (case-insensitive) and jump to the first hit")
+            TextField("replace", text: $model.replaceText)
+                .textFieldStyle(.plain)
+                .font(.system(size: 12, design: .monospaced))
+                .foregroundColor(ink)
+                .padding(.horizontal, 8)
+                .frame(width: 96, height: 30)
+                .background(cField)
+                .overlay(RoundedRectangle(cornerRadius: 5).stroke(lineStrong, lineWidth: 1))
+                .cornerRadius(5)
+                .onSubmit { model.runReplace() }
+            Button("Replace") { model.runReplace() }
+                .help("Replace the query with the replacement in every cell's source and recompute")
         }
         .buttonStyle(ChipButtonStyle())
         .padding(8)

--- a/demo/visicalc-swiftui/Tests/VisiCalcTests/WindowedModelTests.swift
+++ b/demo/visicalc-swiftui/Tests/VisiCalcTests/WindowedModelTests.swift
@@ -249,4 +249,34 @@ final class WindowedModelTests: XCTestCase {
         XCTAssertEqual(m.window(rows: 1...1, cols: 1...1)[0][0], "15")
         XCTAssertEqual(m.window(rows: 4...4, cols: 1...1)[0][0], "4")
     }
+
+    /// Find / replace (the find/replace boxes + Find/Replace buttons drive
+    /// findAll/replaceAll): findAll returns the A1 addresses whose SOURCE contains
+    /// the query (case-insensitive); replaceAll rewrites the query in every cell's
+    /// source and recomputes, returning the count. A rewritten formula stays live;
+    /// a rewritten literal stays typed.
+    func testFindAndReplaceLocatesAndRewritesCells() {
+        let m = WindowedSheetModel()
+        // The seed has the literal "15" only at A1, and "=SUM(" in every total formula.
+        XCTAssertEqual(m.findAll("15"), ["A1"])
+        XCTAssertTrue(m.findAll("sum").contains("E1"))  // case-insensitive
+        XCTAssertEqual(m.findAll(""), [])
+        XCTAssertEqual(m.findAll("zzz"), [])
+        // selectA1 moves the cursor onto a hit (parsing column letters past Z).
+        m.selectA1("Z1000")
+        XCTAssertEqual(m.selectedRow, 1000)
+        XCTAssertEqual(m.selectedCol, 26)
+        // Replace a literal: A1 "15" → "99"; E1 = 99+3+12+8 = 122 ("#,##0.00").
+        XCTAssertEqual(m.replaceAll("15", "99"), 1)
+        XCTAssertEqual(m.rowCells(1)[0], "99")
+        XCTAssertEqual(m.rowCells(1)[4], "122.00")
+        // Replace inside a formula reference keeps it LIVE: H1=10, H2=20, H3 = =H1+5
+        // (15). Rewrite "H1" → "H2" → H3 becomes =H2+5 = 25, recomputed by the engine.
+        m.setCell("H1", "10")
+        m.setCell("H2", "20")
+        m.setCell("H3", "=H1+5") // 15
+        XCTAssertEqual(m.rowCells(3)[7], "15")
+        XCTAssertEqual(m.replaceAll("H1", "H2"), 1)
+        XCTAssertEqual(m.rowCells(3)[7], "25") // =H2+5
+    }
 }


### PR DESCRIPTION
Rolls out **find/replace** to the **SwiftUI** demo — the **6th and final** backend in the engine-homed find/replace campaign (engine #6669, facades #6673, web #6678, Qt #6680, Flutter #6682, Compose #6685, XAML #6687 already merged/open).

Computes on the shared Rust `spreadsheet-core` engine through the C ABI via the module-map C functions — the same `sc_find_all` / `sc_replace_all` path every other backend drives. No spreadsheet logic in this layer.

## What changed
- **Engine.swift** — `SpreadsheetSession.findAll` (reads `sc_find_all`'s heap `char*` JSON `{"matches":[<a1>,...]}` via the existing `take()`→`sc_string_free`) and `replaceAll` (`sc_replace_all` → `Int` count).
- **InfiniteGrid.swift** — `WindowedSheetModel.findAll(query)`, `replaceAll(query, replacement)` (re-derives the extent + re-syncs the formula bar + bumps `revision`), `selectA1(a1)` to jump onto a find hit (parses column letters past Z, capped at 7 to stay clear of the `Int`-overflow trap and clamped by `select`), and `runFind`/`runReplace` driving the `@Published findText`/`replaceText`/`findStatus`. The view gains a Find/Replace toolbar group (two compact `TextField`s + Find/Replace buttons, `onSubmit`-wired) + a footer match/replace count.
- **WindowedModelTests.swift** — headless proof (below).
- **spreadsheet.h** — refreshed from the canonical capi header (adds the find/replace declarations the module exposes).
- **README.md** — documents the group + the new verification cases.

Because the engine re-parses each rewrite through its centralised coerce (`set_raw`), a rewritten formula stays a live formula and a rewritten literal stays typed.

## Verification
- `swift test` → **16/16 pass** (the full app + the `InfiniteGridView` with the find/replace UI compile against real SwiftUI). New cases: `findAll("15")` locates the one literal (A1); case-insensitive `findAll("sum")` finds the total formulas; empty/no-match queries return nothing; `selectA1("Z1000")` parses a far address; `replaceAll` rewrites a literal (`15`→`99` ⇒ E1 122.00) and a formula reference (`H1`→`H2` ⇒ `=H1+5` recomputes to 25), each staying live.
- `/security-review` (C-interop string lifetime, char* double-free/leak, A1-parser overflow, JSON-injection) → **PASSED**; added a defensive 7-letter cap on the column parser.

This is the **last of the six** find/replace demos — find/replace is now live on **every VisiCalc backend**, all computing on the one shared Rust engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)