### PR TITLE
fix(lang-matrix): wire BASIC's BA2 putchar print model into the test harness (fixes red matrix on main)

### DIFF
--- a/code/packages/rust/lang-aot/tests/lang_matrix.rs
+++ b/code/packages/rust/lang-aot/tests/lang_matrix.rs
@@ -1383,7 +1383,12 @@ fn run_wasm(p: &Prog) -> Option<(Option<i32>, String)> {
             .collect::<Vec<_>>()
             .join("\n")
     } else {
-        String::from_utf8_lossy(&printed_bytes).to_string()
+        // `.trim()` to match the six sibling `run_*` columns (all trim): since
+        // BA2, BASIC's `PRINT` ends each line with a `putchar('\n')`, so the raw
+        // byte stream for `PRINT 42` is `"42\n"`. Without trimming the Wasm column
+        // alone disagreed with the others on every BASIC `Stdout` cell. Inner
+        // newlines (multi-line output) are preserved.
+        String::from_utf8_lossy(&printed_bytes).trim().to_string()
     };
     Some((code, stdout))
 }
@@ -1579,7 +1584,14 @@ fn run_jvm(p: &Prog) -> Option<(Option<i32>, String)> {
         // Pick the host class the program's I/O lowers to: Brainfuck's `.`/`,` +
         // tape use `env.BFRuntime`; Dartmouth BASIC's `PRINT` uses
         // `env.BasicRuntime`. Compile it onto the classpath with `javac`.
-        let (file, source) = if p.lang == Language::Brainfuck {
+        // Both Brainfuck's `.`/`,` and — since BA2 — Dartmouth BASIC's `PRINT`
+        // lower to the generic `putchar` builtin (`invokestatic
+        // env/BFRuntime.putchar(I)V`), so both need `env.BFRuntime` on the
+        // classpath. (The legacy `env.BasicRuntime.println` path is retained for
+        // any future language that lowers `print_i64`.)
+        let (file, source) = if p.lang == Language::Brainfuck
+            || p.lang == Language::DartmouthBasic
+        {
             ("BFRuntime.java", BF_RUNTIME_JAVA)
         } else {
             ("BasicRuntime.java", BASIC_RUNTIME_JAVA)
@@ -1752,7 +1764,9 @@ fn run_vm(p: &Prog) -> Option<(Option<i32>, String)> {
             .collect::<Vec<_>>()
             .join("\n")
     } else {
-        String::from_utf8_lossy(&byte_buf).to_string()
+        // `.trim()` like the subprocess columns: BA2 BASIC `PRINT` ends each
+        // line with `putchar('\n')`, so the byte stream is e.g. `"42\n"`.
+        String::from_utf8_lossy(&byte_buf).trim().to_string()
     };
     Some((code, stdout))
 }
@@ -1849,7 +1863,9 @@ fn run_jit(p: &Prog) -> Option<(Option<i32>, String)> {
             .collect::<Vec<_>>()
             .join("\n")
     } else {
-        String::from_utf8_lossy(&byte_buf).to_string()
+        // `.trim()` like the subprocess columns: BA2 BASIC `PRINT` ends each
+        // line with `putchar('\n')`, so the byte stream is e.g. `"42\n"`.
+        String::from_utf8_lossy(&byte_buf).trim().to_string()
     };
     Some((code, stdout))
 }


### PR DESCRIPTION
## Fixes origin/main's red BASIC matrix

BA2 (#6670) switched Dartmouth BASIC's `PRINT` from the line-buffered `print_i64` builtin to character-level output via the universal `putchar` builtin — but the `lang_matrix.rs` per-backend **host wiring** still assumed `print_i64`. On a fresh build, origin/main's BASIC matrix is **red on three columns** (it escaped CI — only a clean local build surfaces it):

| Column | Symptom | Cause → Fix |
|--------|---------|-------------|
| **JVM** | `PRINT 42` ⇒ exit 1, `""` | `run_jvm` compiled `env.BasicRuntime` (println), but BASIC now lowers `PRINT` to `invokestatic env/BFRuntime.putchar(I)V` → unresolved. **Fix:** compile `env.BFRuntime` for BASIC too (it already discards the entry result for `Stdout` programs, so output comes from putchar's `System.out` — exactly like Brainfuck). |
| **VM** & **JIT** | `PRINT 42` ⇒ `"42\n"` | putchar byte-buffer stdout wasn't trimmed; BA2 ends each `PRINT` line with `putchar('\n')`. **Fix:** `.trim()` the byte buffer, matching the subprocess columns. |
| **Wasm** | `PRINT 42` ⇒ `"42\n"` | same untrimmed-byte-stream issue in `run_wasm`. Same `.trim()` fix. |

Inner newlines (multi-line output) are preserved by `.trim()`.

**Test-harness only** (`lang_matrix.rs`) — no production code changes. Verified locally: both matrix guards (`matrix_every_proven_cell_agrees`, `proven_columns_do_not_silently_skip`) now pass on **all 7 backends** for every existing BASIC cell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)