### PR TITLE
feat(spreadsheet-core): cross-sheet reference AST + parser (multi-sheet PR-1)

### DIFF
--- a/code/packages/rust/spreadsheet-core/CHANGELOG.md
+++ b/code/packages/rust/spreadsheet-core/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## 0.12.0
+
+**Cross-sheet references — formula layer (multi-sheet workbooks, PR-1 of the arc).**
+The workbook container and the dependency graph were already multi-sheet
+(`Workbook.sheets` / `sheet_by_name`, `dag::Node = (SheetId, CellAddress)`); this
+release teaches the **formula layer** to *represent, parse, and re-emit* a
+cross-sheet reference (`=Summary!A1`). Evaluation of a qualified reference is
+deferred to the next release and yields `#REF!` in the meantime (a clean "not
+wired" signal, never a wrong value). The single-sheet path is byte-identical.
+
+- `FormulaAst::Ref` / `Range` gain an `Option<String>` **sheet qualifier**
+  (`ast.rs`): `None` = the formula's own sheet (the unchanged common case),
+  `Some(name)` = a cross-sheet reference, holding the sheet name *as written*
+  (resolved to a `SheetId` later, by a workbook). New ergonomic constructors
+  `FormulaAst::cell` / `sheet_cell` / `cell_range` / `sheet_range`.
+- Parser (`parser.rs`): `Name!A1`, `Name!A1:B2`, and single-quoted
+  `'Q1 Budget'!A1` / `'O''Brien'!A1` (doubled `''` → a literal apostrophe). A `!`
+  makes the preceding token a **sheet name**, never a cell, so `'A1'!B2` is
+  unambiguous. An unknown sheet is not a parse error — it becomes `#REF!` at
+  evaluation, so formulas can load in any order.
+- Re-emit (`to_formula_string`): a qualified reference prints `Name!A1`,
+  single-quoting the name only when it isn't a bare token (spaces, punctuation,
+  a leading digit, or a name that itself spells a cell address).
+- `shift` (fill/copy) and `adjust` (structural edits) **preserve the qualifier**:
+  a cross-sheet ref shifts its address but keeps its sheet, and a structural edit
+  on a formula's own sheet leaves its cross-sheet refs untouched (their target
+  lives elsewhere — inbound cross-sheet propagation is a later slice).
+- Evaluation + dependency extraction (`recalc.rs`): unqualified refs are
+  unchanged; a qualified ref evaluates to `#REF!` and registers no precedent
+  (pending the resolver slice).
+
 ## 0.11.1
 
 - Make `Workbook::cell_source_text` **public** so a facade can resync its

--- a/code/packages/rust/spreadsheet-core/Cargo.toml
+++ b/code/packages/rust/spreadsheet-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spreadsheet-core"
-version = "0.11.1"
+version = "0.12.0"
 edition = "2021"
 description = "Headless spreadsheet engine — cell model, formula AST, dependency DAG, recalc, dispatch to Layer-1 cores. The engine VisiCalc Modern and any other Mosaic-rendered spreadsheet sits on top of."
 

--- a/code/packages/rust/spreadsheet-core/src/ast.rs
+++ b/code/packages/rust/spreadsheet-core/src/ast.rs
@@ -9,10 +9,31 @@ use crate::errors::SpreadsheetError;
 pub enum FormulaAst {
     /// A literal value (number, text, bool, error).
     Literal(CellValue),
-    /// A single-cell reference.
-    Ref(CellAddress),
-    /// A rectangular range reference.
-    Range(CellRange),
+    /// A single-cell reference, optionally qualified by a sheet name.
+    ///
+    /// `sheet` is `None` for the common same-sheet reference (`A1`) — that case
+    /// resolves against the formula's own sheet and is byte-identical to the
+    /// pre-multi-sheet behaviour. `Some(name)` is a cross-sheet reference
+    /// (`Summary!A1`); the name is the sheet *as written* (resolved to a
+    /// `SheetId` later, at evaluation/dependency time, by a workbook that knows
+    /// its sheets). See [`FormulaAst::cell`] / [`FormulaAst::sheet_cell`].
+    Ref {
+        /// The qualifying sheet name, or `None` for the formula's own sheet.
+        sheet: Option<String>,
+        /// The cell address (column/row, with `$`-absolute flags).
+        addr: CellAddress,
+    },
+    /// A rectangular range reference, optionally qualified by a sheet name.
+    ///
+    /// Both endpoints share the one qualifier (`Summary!A1:B2`); split-sheet
+    /// 3-D ranges (`Sheet1:Sheet3!A1`) are intentionally out of scope. See
+    /// [`FormulaAst::cell_range`] / [`FormulaAst::sheet_range`].
+    Range {
+        /// The qualifying sheet name, or `None` for the formula's own sheet.
+        sheet: Option<String>,
+        /// The rectangular range (start/end addresses).
+        range: CellRange,
+    },
     /// Unary prefix operator.
     Unary {
         /// The operator.
@@ -122,6 +143,32 @@ impl BinaryOp {
 }
 
 impl FormulaAst {
+    /// A same-sheet single-cell reference (`A1`) — the common case.
+    pub fn cell(addr: CellAddress) -> FormulaAst {
+        FormulaAst::Ref { sheet: None, addr }
+    }
+
+    /// A sheet-qualified single-cell reference (`Summary!A1`).
+    pub fn sheet_cell(sheet: impl Into<String>, addr: CellAddress) -> FormulaAst {
+        FormulaAst::Ref {
+            sheet: Some(sheet.into()),
+            addr,
+        }
+    }
+
+    /// A same-sheet range reference (`A1:B2`).
+    pub fn cell_range(range: CellRange) -> FormulaAst {
+        FormulaAst::Range { sheet: None, range }
+    }
+
+    /// A sheet-qualified range reference (`Summary!A1:B2`).
+    pub fn sheet_range(sheet: impl Into<String>, range: CellRange) -> FormulaAst {
+        FormulaAst::Range {
+            sheet: Some(sheet.into()),
+            range,
+        }
+    }
+
     /// Render this AST back to a formula string (without the leading `=`).
     ///
     /// Binary operators are **fully parenthesised**, so the output always
@@ -134,8 +181,13 @@ impl FormulaAst {
     pub fn to_formula_string(&self) -> String {
         match self {
             FormulaAst::Literal(v) => literal_source(v),
-            FormulaAst::Ref(addr) => addr.to_a1(),
-            FormulaAst::Range(range) => format!("{}:{}", range.start.to_a1(), range.end.to_a1()),
+            FormulaAst::Ref { sheet, addr } => format!("{}{}", sheet_prefix(sheet), addr.to_a1()),
+            FormulaAst::Range { sheet, range } => format!(
+                "{}{}:{}",
+                sheet_prefix(sheet),
+                range.start.to_a1(),
+                range.end.to_a1()
+            ),
             FormulaAst::Unary { op, operand } => {
                 let inner = operand.to_formula_string();
                 match op {
@@ -178,15 +230,23 @@ impl FormulaAst {
     pub fn shift(&self, d_row: i32, d_col: i32) -> FormulaAst {
         match self {
             FormulaAst::Literal(v) => FormulaAst::Literal(v.clone()),
-            FormulaAst::Ref(addr) => match addr.shift(d_row, d_col) {
-                Ok(a) => FormulaAst::Ref(a),
+            // The sheet qualifier rides along unchanged — filling `=Detail!A1`
+            // down a column gives `=Detail!A2` (same sheet, shifted address).
+            FormulaAst::Ref { sheet, addr } => match addr.shift(d_row, d_col) {
+                Ok(a) => FormulaAst::Ref {
+                    sheet: sheet.clone(),
+                    addr: a,
+                },
                 Err(_) => ref_error(),
             },
             // A range shifts both corners; if either falls off-grid the whole
             // range is a dangling reference → `#REF!`.
-            FormulaAst::Range(range) => {
+            FormulaAst::Range { sheet, range } => {
                 match (range.start.shift(d_row, d_col), range.end.shift(d_row, d_col)) {
-                    (Ok(start), Ok(end)) => FormulaAst::Range(CellRange::new(start, end)),
+                    (Ok(start), Ok(end)) => FormulaAst::Range {
+                        sheet: sheet.clone(),
+                        range: CellRange::new(start, end),
+                    },
                     _ => ref_error(),
                 }
             }
@@ -213,6 +273,48 @@ impl FormulaAst {
 /// stay in their own modules.)
 fn ref_error() -> FormulaAst {
     FormulaAst::Literal(CellValue::Error(SpreadsheetError::Ref))
+}
+
+/// Render a reference's sheet qualifier for source re-emission: `""` for an
+/// unqualified (`None`) reference, otherwise `Name!`, single-quoting the name
+/// when it isn't a bare token. The quoting rule matches Excel/Sheets: a name is
+/// safe to write bare only when it is all letters/digits/underscore, does not
+/// start with a digit, and does not itself spell a cell address (`A1`) — anything
+/// else (spaces, punctuation, leading digit, an A1-looking name, or an empty
+/// name) is wrapped in single quotes with internal quotes doubled (`'O''Brien'`).
+fn sheet_prefix(sheet: &Option<String>) -> String {
+    match sheet {
+        None => String::new(),
+        Some(name) => {
+            if needs_quoting(name) {
+                format!("'{}'!", name.replace('\'', "''"))
+            } else {
+                format!("{name}!")
+            }
+        }
+    }
+}
+
+/// Whether a sheet name must be single-quoted when written in a formula.
+fn needs_quoting(name: &str) -> bool {
+    if name.is_empty() {
+        return true;
+    }
+    // Any character outside the bare set forces quoting.
+    if !name
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '_')
+    {
+        return true;
+    }
+    // A leading digit would read as a number, not a name.
+    if name.chars().next().is_some_and(|c| c.is_ascii_digit()) {
+        return true;
+    }
+    // A name that itself spells a cell address (`A1`, `BZ400`) must be quoted so
+    // `A1!B2` can't be misread — the parser treats the token before `!` as the
+    // sheet, but quoting keeps the round-trip unambiguous.
+    CellAddress::parse(name).is_ok()
 }
 
 /// Render a literal value back to its formula-source form: numbers bare
@@ -263,9 +365,52 @@ mod tests {
             "=A1&\" txt\"",
             "=2^3^2",          // right-assoc
             "=A1<=B1",
+            "=Summary!A1",       // cross-sheet ref
+            "=Summary!A1:B10",   // cross-sheet range
+            "=Summary!B2+Detail!B2", // two cross-sheet refs in one formula
+            "=SUM(Detail!A1:A4)",    // qualified range as a function arg
         ] {
             round_trips(src);
         }
+    }
+
+    #[test]
+    fn cross_sheet_qualifier_quotes_only_when_needed() {
+        use crate::parser::parse;
+        // A bare alphanumeric name needs no quoting.
+        assert_eq!(parse("=Summary!A1").unwrap().to_formula_string(), "Summary!A1");
+        // A name with a space must be single-quoted.
+        assert_eq!(
+            parse("='Q1 Budget'!A1").unwrap().to_formula_string(),
+            "'Q1 Budget'!A1"
+        );
+        // An apostrophe inside the name is doubled.
+        assert_eq!(
+            parse("='O''Brien'!A1").unwrap().to_formula_string(),
+            "'O''Brien'!A1"
+        );
+        // A name that itself spells a cell address is quoted to stay unambiguous.
+        assert_eq!(parse("='A1'!B2").unwrap().to_formula_string(), "'A1'!B2");
+        // A leading-digit name is quoted.
+        assert_eq!(parse("='2024'!A1").unwrap().to_formula_string(), "'2024'!A1");
+    }
+
+    #[test]
+    fn shift_preserves_the_sheet_qualifier() {
+        use crate::parser::parse;
+        // Filling =Detail!A1 one row down → =Detail!A2 (same sheet, shifted addr).
+        assert_eq!(
+            parse("=Detail!A1").unwrap().shift(1, 0).to_formula_string(),
+            "Detail!A2"
+        );
+        // A quoted qualifier rides along too, and a range shifts both corners.
+        assert_eq!(
+            parse("='Q1 Budget'!A1:B2")
+                .unwrap()
+                .shift(0, 1)
+                .to_formula_string(),
+            "'Q1 Budget'!B1:C2"
+        );
     }
 
     #[test]

--- a/code/packages/rust/spreadsheet-core/src/edit.rs
+++ b/code/packages/rust/spreadsheet-core/src/edit.rs
@@ -205,14 +205,29 @@ impl FormulaAst {
     pub fn adjust(&self, edit: StructuralEdit) -> FormulaAst {
         match self {
             FormulaAst::Literal(v) => FormulaAst::Literal(v.clone()),
-            FormulaAst::Ref(addr) => match addr.adjust(edit) {
-                Some(a) => FormulaAst::Ref(a),
+            // An unqualified reference points into this formula's own sheet — the
+            // sheet being edited — so it shifts (or collapses to `#REF!` if its
+            // band was deleted).
+            FormulaAst::Ref { sheet: None, addr } => match addr.adjust(edit) {
+                Some(a) => FormulaAst::cell(a),
                 None => ref_error(),
             },
-            FormulaAst::Range(range) => match range.adjust(edit) {
-                Some(r) => FormulaAst::Range(r),
+            FormulaAst::Range { sheet: None, range } => match range.adjust(edit) {
+                Some(r) => FormulaAst::cell_range(r),
                 None => ref_error(),
             },
+            // A cross-sheet reference targets another sheet, so a structural edit
+            // on this formula's sheet leaves it untouched. (Propagating an edit on
+            // sheet S to inbound `S!`-qualified refs that live on *other* sheets is
+            // a separate workbook-level pass, handled in a later slice.)
+            FormulaAst::Ref {
+                sheet: Some(s),
+                addr,
+            } => FormulaAst::sheet_cell(s.clone(), *addr),
+            FormulaAst::Range {
+                sheet: Some(s),
+                range,
+            } => FormulaAst::sheet_range(s.clone(), *range),
             FormulaAst::Unary { op, operand } => FormulaAst::Unary {
                 op: *op,
                 operand: Box::new(operand.adjust(edit)),
@@ -366,7 +381,7 @@ mod tests {
         match ast {
             FormulaAst::Binary { lhs, rhs, .. } => {
                 assert_eq!(*lhs, ref_error());
-                assert_eq!(*rhs, FormulaAst::Ref(a("A4")));
+                assert_eq!(*rhs, FormulaAst::cell(a("A4")));
             }
             other => panic!("expected a binary op, got {other:?}"),
         }

--- a/code/packages/rust/spreadsheet-core/src/parser.rs
+++ b/code/packages/rust/spreadsheet-core/src/parser.rs
@@ -271,6 +271,7 @@ impl<'a> Parser<'a> {
                 Ok(inner)
             }
             '"' => self.parse_string(),
+            '\'' => self.parse_quoted_sheet_ref(),
             '#' => self.parse_error_literal(),
             '0'..='9' | '.' => self.parse_number(),
             c if c.is_ascii_alphabetic() || c == '$' || c == '@' => self.parse_ident_or_ref(),
@@ -388,6 +389,18 @@ impl<'a> Parser<'a> {
         // Lotus-style `@SUM` — strip the leading `@`.
         let core_text = text.strip_prefix('@').unwrap_or(text);
 
+        // Sheet-qualified reference: `Summary!A1` / `Summary!A1:B2`. A `!`
+        // immediately after a bareword makes that word a **sheet name** (never a
+        // cell), per the disambiguation rule — so `A1!B2` reads as "cell B2 on a
+        // sheet literally named A1". The name is kept as written and resolved to a
+        // `SheetId` later (by a workbook); an unknown sheet becomes `#REF!` at
+        // evaluation, not a parse error.
+        if self.peek() == Some('!') {
+            self.advance(); // consume '!'
+            let token = self.read_ref_token();
+            return self.finish_ref_or_range(Some(core_text.to_string()), &token);
+        }
+
         // Boolean literals.
         match core_text.to_ascii_uppercase().as_str() {
             "TRUE" => {
@@ -412,29 +425,10 @@ impl<'a> Parser<'a> {
             return self.finish_function_call(core_text.to_string());
         }
 
-        // Cell or range reference?
-        if let Ok(addr) = CellAddress::parse(core_text) {
-            // Range?
-            if self.peek() == Some(':') {
-                self.advance();
-                let next_start = self.pos;
-                while let Some(c) = self.peek() {
-                    if c.is_ascii_alphanumeric() || c == '$' {
-                        self.advance();
-                    } else {
-                        break;
-                    }
-                }
-                let next_text =
-                    std::str::from_utf8(&self.input[next_start..self.pos]).unwrap();
-                let end_addr = CellAddress::parse(next_text).map_err(|_| {
-                    ParseError::BadReference {
-                        text: next_text.to_string(),
-                    }
-                })?;
-                return Ok(FormulaAst::Range(CellRange::new(addr, end_addr)));
-            }
-            return Ok(FormulaAst::Ref(addr));
+        // Cell or range reference (unqualified — resolves against the formula's
+        // own sheet).
+        if CellAddress::parse(core_text).is_ok() {
+            return self.finish_ref_or_range(None, core_text);
         }
 
         // Otherwise: bare name — treat as a zero-arg function call
@@ -443,6 +437,80 @@ impl<'a> Parser<'a> {
         Err(ParseError::BadReference {
             text: core_text.to_string(),
         })
+    }
+
+    /// Read a bare cell/range token (`A1`, `$B$5`) from the cursor — the
+    /// letters/digits/`$` run — and return it as an owned string. Stops at the
+    /// first character that can't be part of an A1 address.
+    fn read_ref_token(&mut self) -> String {
+        let start = self.pos;
+        while let Some(c) = self.peek() {
+            if c.is_ascii_alphanumeric() || c == '$' {
+                self.advance();
+            } else {
+                break;
+            }
+        }
+        std::str::from_utf8(&self.input[start..self.pos])
+            .unwrap()
+            .to_string()
+    }
+
+    /// Build a [`FormulaAst::Ref`] or [`FormulaAst::Range`] from a first A1 token
+    /// (already read) and an optional sheet qualifier, consuming a `:end` token if
+    /// the reference is a range. A token that doesn't parse as an address is a
+    /// `BadReference`.
+    fn finish_ref_or_range(
+        &mut self,
+        sheet: Option<String>,
+        first_token: &str,
+    ) -> Result<FormulaAst, ParseError> {
+        let addr = CellAddress::parse(first_token).map_err(|_| ParseError::BadReference {
+            text: first_token.to_string(),
+        })?;
+        if self.peek() == Some(':') {
+            self.advance();
+            let next_text = self.read_ref_token();
+            let end_addr =
+                CellAddress::parse(&next_text).map_err(|_| ParseError::BadReference {
+                    text: next_text.clone(),
+                })?;
+            return Ok(FormulaAst::Range {
+                sheet,
+                range: CellRange::new(addr, end_addr),
+            });
+        }
+        Ok(FormulaAst::Ref { sheet, addr })
+    }
+
+    /// Parse a single-quoted sheet name and the reference it qualifies:
+    /// `'Q1 Budget'!A1` / `'O''Brien'!A1:B2`. A doubled `''` inside the quotes is
+    /// a literal apostrophe (the Excel rule). The `!` is required.
+    fn parse_quoted_sheet_ref(&mut self) -> Result<FormulaAst, ParseError> {
+        self.advance(); // opening quote
+        let mut name = String::new();
+        loop {
+            match self.advance() {
+                None => return Err(ParseError::UnexpectedEof),
+                Some('\'') => {
+                    if self.peek() == Some('\'') {
+                        self.advance(); // doubled '' → a literal apostrophe
+                        name.push('\'');
+                    } else {
+                        break; // closing quote
+                    }
+                }
+                Some(c) => name.push(c),
+            }
+        }
+        if self.advance() != Some('!') {
+            return Err(ParseError::ExpectedToken {
+                expected: "!",
+                found: "quoted sheet name without '!'".into(),
+            });
+        }
+        let token = self.read_ref_token();
+        self.finish_ref_or_range(Some(name), &token)
     }
 
     fn finish_function_call(&mut self, name: String) -> Result<FormulaAst, ParseError> {
@@ -540,20 +608,66 @@ mod tests {
     #[test]
     fn parse_cell_ref() {
         let r = parse("A1").unwrap();
-        assert_eq!(r, FormulaAst::Ref(CellAddress::new(1, 1)));
+        assert_eq!(r, FormulaAst::cell(CellAddress::new(1, 1)));
         let r = parse("$B$5").unwrap();
-        assert_eq!(r, FormulaAst::Ref(CellAddress::absolute(5, 2)));
+        assert_eq!(r, FormulaAst::cell(CellAddress::absolute(5, 2)));
     }
 
     #[test]
     fn parse_range() {
         let r = parse("A1:B10").unwrap();
-        if let FormulaAst::Range(r) = r {
+        if let FormulaAst::Range { range: r, .. } = r {
             assert_eq!(r.start, CellAddress::new(1, 1));
             assert_eq!(r.end, CellAddress::new(10, 2));
         } else {
             panic!("expected Range, got {r:?}");
         }
+    }
+
+    #[test]
+    fn parse_cross_sheet_ref() {
+        // An unqualified ref carries no sheet.
+        assert_eq!(
+            parse("A1").unwrap(),
+            FormulaAst::Ref {
+                sheet: None,
+                addr: CellAddress::new(1, 1)
+            }
+        );
+        // `Summary!A1` qualifies the ref with the sheet name (as written).
+        assert_eq!(
+            parse("Summary!A1").unwrap(),
+            FormulaAst::sheet_cell("Summary", CellAddress::new(1, 1))
+        );
+        // `Summary!A1:B2` qualifies a range; both endpoints share the qualifier.
+        assert_eq!(
+            parse("Summary!A1:B2").unwrap(),
+            FormulaAst::sheet_range("Summary", CellRange::new(CellAddress::new(1, 1), CellAddress::new(2, 2)))
+        );
+    }
+
+    #[test]
+    fn parse_quoted_cross_sheet_ref() {
+        // A single-quoted name allows spaces/punctuation.
+        assert_eq!(
+            parse("'Q1 Budget'!A1").unwrap(),
+            FormulaAst::sheet_cell("Q1 Budget", CellAddress::new(1, 1))
+        );
+        // Doubled '' inside the quotes is a literal apostrophe.
+        assert_eq!(
+            parse("'O''Brien'!A1").unwrap(),
+            FormulaAst::sheet_cell("O'Brien", CellAddress::new(1, 1))
+        );
+    }
+
+    #[test]
+    fn cross_sheet_ref_disambiguates_a1_named_sheet() {
+        // A `!` makes the token before it a sheet name, never a cell — so
+        // `'A1'!B2` is "cell B2 on the sheet named A1", not a range.
+        assert_eq!(
+            parse("'A1'!B2").unwrap(),
+            FormulaAst::sheet_cell("A1", CellAddress::new(2, 2))
+        );
     }
 
     #[test]
@@ -592,7 +706,7 @@ mod tests {
         if let FormulaAst::Call { name, args } = r {
             assert_eq!(name, "SUM");
             assert_eq!(args.len(), 1);
-            assert!(matches!(args[0], FormulaAst::Range(_)));
+            assert!(matches!(args[0], FormulaAst::Range { .. }));
         } else {
             panic!("expected Call");
         }
@@ -635,7 +749,7 @@ mod tests {
         let r = parse("-A1").unwrap();
         if let FormulaAst::Unary { op, operand } = r {
             assert_eq!(op, UnaryOp::Negate);
-            assert_eq!(*operand, FormulaAst::Ref(CellAddress::new(1, 1)));
+            assert_eq!(*operand, FormulaAst::cell(CellAddress::new(1, 1)));
         } else {
             panic!("expected Unary");
         }

--- a/code/packages/rust/spreadsheet-core/src/recalc.rs
+++ b/code/packages/rust/spreadsheet-core/src/recalc.rs
@@ -22,8 +22,16 @@ where
 {
     match ast {
         FormulaAst::Literal(v) => Ok(v.clone()),
-        FormulaAst::Ref(addr) => Ok(lookup(current_sheet, *addr)),
-        FormulaAst::Range(r) => evaluate_range(*r, current_sheet, lookup),
+        FormulaAst::Ref { sheet: None, addr } => Ok(lookup(current_sheet, *addr)),
+        FormulaAst::Range { sheet: None, range } => evaluate_range(*range, current_sheet, lookup),
+        // Cross-sheet references parse and round-trip, but resolving a sheet name
+        // to a `SheetId` needs a workbook the evaluator doesn't hold yet, so they
+        // evaluate to `#REF!` for now — a clean "not wired" signal, never a wrong
+        // value. The next slice threads a name resolver through and reads the
+        // target sheet.
+        FormulaAst::Ref { sheet: Some(_), .. } | FormulaAst::Range { sheet: Some(_), .. } => {
+            Err(SpreadsheetError::Ref)
+        }
         FormulaAst::Percent(inner) => {
             let v = evaluate(inner, current_sheet, lookup)?.coerce_number()?;
             Ok(CellValue::Number(v / 100.0))
@@ -63,13 +71,18 @@ where
             // surrogate from `evaluate_range`.
             let mut resolved = Vec::with_capacity(args.len());
             for a in args {
-                if let FormulaAst::Range(r) = a {
-                    // Reject an adversarially huge range before it can
-                    // allocate billions of argument values.
-                    if r.is_oversized() {
+                if let FormulaAst::Range { sheet, range } = a {
+                    // Cross-sheet range arg: same "#REF! until wired" rule as a
+                    // standalone cross-sheet ref.
+                    if sheet.is_some() {
                         return Err(SpreadsheetError::Ref);
                     }
-                    for addr in r.iter() {
+                    // Reject an adversarially huge range before it can
+                    // allocate billions of argument values.
+                    if range.is_oversized() {
+                        return Err(SpreadsheetError::Ref);
+                    }
+                    for addr in range.iter() {
                         resolved.push(lookup(current_sheet, addr));
                     }
                 } else {
@@ -307,19 +320,25 @@ pub fn collect_refs(ast: &FormulaAst, current_sheet: SheetId, out: &mut Vec<(She
         // is keyed by position, so a `$A$1` precedent points at the same node as
         // `A1` — otherwise the edge would never match and `set_value` wouldn't
         // recompute a dependent that referenced it absolutely.
-        FormulaAst::Ref(a) => out.push((current_sheet, a.without_absolute())),
-        FormulaAst::Range(r) => {
+        FormulaAst::Ref { sheet: None, addr } => {
+            out.push((current_sheet, addr.without_absolute()))
+        }
+        FormulaAst::Range { sheet: None, range } => {
             // Skip expansion of an oversized range: registering one
             // dependency per cell for `=SUM(A1:XFD1048576)` would
             // exhaust memory. Such a formula evaluates to `#REF!`
             // anyway (see the call-arg expansion and `evaluate_range`),
             // so it has no meaningful precedents to track.
-            if !r.is_oversized() {
-                for addr in r.iter() {
+            if !range.is_oversized() {
+                for addr in range.iter() {
                     out.push((current_sheet, addr.without_absolute()));
                 }
             }
         }
+        // A cross-sheet reference evaluates to `#REF!` until the resolver lands,
+        // so it has no precedent to register yet. The next slice resolves the
+        // sheet name and pushes `(target_sheet, addr)` here.
+        FormulaAst::Ref { sheet: Some(_), .. } | FormulaAst::Range { sheet: Some(_), .. } => {}
         FormulaAst::Unary { operand, .. } => collect_refs(operand, current_sheet, out),
         FormulaAst::Binary { lhs, rhs, .. } => {
             collect_refs(lhs, current_sheet, out);
@@ -430,6 +449,34 @@ mod tests {
         collect_refs(&ast, SheetId(0), &mut refs);
         // A1, B2, B3, B4, C1 — five refs.
         assert_eq!(refs.len(), 5);
+    }
+
+    #[test]
+    fn cross_sheet_ref_evaluates_to_ref_error_until_resolver_lands() {
+        // A qualified reference parses and round-trips, but the evaluator can't
+        // resolve a sheet name to a SheetId yet, so it yields #REF! — a clean
+        // "not wired" signal, never a wrong value. The next slice replaces this.
+        let r = evaluate(&parse("=Summary!A1").unwrap(), SheetId(0), &empty_lookup);
+        assert_eq!(r, Err(SpreadsheetError::Ref));
+        // …including a qualified range, standalone or as a SUM arg.
+        assert_eq!(
+            evaluate(&parse("=Summary!A1:B2").unwrap(), SheetId(0), &empty_lookup),
+            Err(SpreadsheetError::Ref)
+        );
+        assert_eq!(
+            evaluate(&parse("=SUM(Summary!A1:A4)").unwrap(), SheetId(0), &empty_lookup),
+            Err(SpreadsheetError::Ref)
+        );
+    }
+
+    #[test]
+    fn collect_refs_skips_unresolved_cross_sheet_refs() {
+        // A cross-sheet ref has no resolvable precedent yet, so it registers none
+        // (its value is #REF! regardless). Same-sheet refs around it still count.
+        let ast = parse("=A1 + Summary!B2 + C3").unwrap();
+        let mut refs = Vec::new();
+        collect_refs(&ast, SheetId(0), &mut refs);
+        assert_eq!(refs.len(), 2); // A1 and C3 only
     }
 
     #[test]

--- a/code/specs/spreadsheet-core.md
+++ b/code/specs/spreadsheet-core.md
@@ -206,9 +206,25 @@ behavior — copying a formula from A1 to A2 increments relative rows
 but not absolute. The recalc engine itself does not care about
 absoluteness; it sees the resolved address.
 
-Sheet IDs are dense `u32`s, separately tracked from sheet names so
-that renaming a sheet does not require rewriting every formula. The
-formula AST holds `SheetId`; the parser converts names at parse time.
+Sheet IDs are dense `u32`s, separately tracked from sheet names.
+
+**Cross-sheet references (implemented; diverged from the original plan).** A
+formula reference may be sheet-qualified (`=Summary!A1`, `='Q1 Budget'!A1:B2`).
+The reference AST carries an **optional sheet *name*** — `FormulaAst::Ref { sheet:
+Option<String>, addr }` / `Range { sheet, range }`, where `None` is the formula's
+own sheet (the common case, byte-identical to single-sheet behaviour). The name is
+resolved to a `SheetId` later, at *evaluation / dependency-collection* time, by a
+workbook that knows its sheets.
+
+This **reverses** the earlier note here ("the AST holds `SheetId`; the parser
+converts names at parse time"): the bare `parse()` is workbook-free, so it cannot
+resolve a name, and keeping it pure means a formula that references a not-yet-created
+sheet is a clean `#REF!` at evaluation rather than a parse error (formulas can load
+in any order). The trade-off — accepted deliberately — is that **renaming a sheet
+must rewrite the stored name** in every referencing formula's AST, rather than being
+a free no-op. The parser disambiguates `Name!A1` (a `!` makes the preceding token a
+sheet name, never a cell) and single-quotes a name on re-emit only when it isn't a
+bare token. See `code/specs/visicalc-multi-sheet.md` for the full multi-sheet arc.
 
 ---
 

--- a/code/specs/visicalc-multi-sheet.md
+++ b/code/specs/visicalc-multi-sheet.md
@@ -59,13 +59,15 @@ Extend `parse_ident_or_ref` so a bareword (or a single-quoted name) **followed b
   starting with a digit, and not a legal A1 address — disambiguation rule below).
 - `'Q1 Budget'!B2` — single-quoted names allow spaces/punctuation; `''` escapes a
   literal quote inside the name (Excel rule).
-- The sheet **name** is resolved to a `SheetId` at *parse-against-a-workbook* time,
-  not at bare-`parse()` time (the bare parser has no workbook). Two options, decided
-  in the engine PR: (a) the AST stores the *name* string until bound, or (b) parsing
-  stays workbook-aware. Leaning (a) — a `Ref { sheet: Option<SheetName>, … }` at the
-  AST layer, lowered to `SheetId` when set on a workbook — so `parse()` stays pure
-  and a formula referencing a not-yet-created sheet is a clean `#REF!` rather than a
-  parse error. The engine PR will pin this down and document the choice.
+- **Decided (PR-1, shipped): option (a) — the AST stores the sheet *name* string.**
+  `FormulaAst::Ref { sheet: Option<String>, addr }` / `Range { sheet, range }`,
+  `None` = own sheet. `parse()` stays pure (no workbook), so a formula referencing a
+  not-yet-created sheet is a clean `#REF!` at evaluation, never a parse error, and
+  formulas can load in any order. The name → `SheetId` resolution happens at
+  *evaluation / dependency* time (PR-2), where a workbook is in hand. Trade-off
+  accepted: **rename-sheet** must rewrite the stored name in every referencing
+  formula (PR-4) — chosen over option (b)'s free-rename because keeping `parse()`
+  workbook-free and forward-references clean is worth more than rename being a no-op.
 - Unknown sheet name → the reference evaluates to `#REF!` (not a parse error), so a
   workbook can load formulas in any order.
 - Ambiguity: `A1!B2` — `A1` is both a valid A1 address and a candidate sheet name.
@@ -175,6 +177,10 @@ the existing formula bar just works once the engine resolves it. Per backend:
 
 - 3-D refs (`Sheet1:Sheet3!A1`) — the AST single-sheet-qualifier choice keeps the
   door open but does not build it.
+- Non-ASCII sheet names. The formula parser uses an ASCII byte cursor (the
+  pre-existing engine assumption — string literals behave the same way), so a
+  multibyte-UTF-8 sheet name round-trips as mojibake. Demos name sheets in ASCII
+  (`Sheet1`, `Summary`); a UTF-8-aware cursor is a separate, orthogonal change.
 - Sheet-level formatting/visibility, sheet colors, very-hidden sheets.
 - Workbook-level named ranges (a separate candidate feature).
 


### PR DESCRIPTION
First engine slice of the **multi-sheet workbook** arc (spec: [#6691](https://github.com/adhithyan15/coding-adventures/pull/6691)). You chose multi-sheet + cross-sheet refs as the next feature after find/replace.

## Context
`spreadsheet-core` **already** has the multi-sheet container (`Workbook.sheets` / `sheet_by_name`) and a cross-sheet dependency graph (`dag::Node = (SheetId, CellAddress)`). The gap is the **formula layer**: `FormulaAst::Ref`/`Range` carried no sheet, so `=Summary!A1` couldn't be parsed/re-emitted. This PR closes the *parse + represent + re-emit* half. Evaluating a qualified ref is **PR-2** — until then it yields `#REF!` (a clean "not wired" signal, **never a wrong value**), so nothing observable regresses.

## Changes
- **ast.rs** — `Ref { sheet: Option<String>, addr }` / `Range { sheet, range }` (`None` = own sheet → the single-sheet path is byte-identical). Constructors `cell`/`sheet_cell`/`cell_range`/`sheet_range`. `to_formula_string` prints the qualifier, single-quoting only when the name isn't a bare token. `shift` preserves it (`=Detail!A1` filled down → `=Detail!A2`).
- **parser.rs** — `Name!A1`, `Name!A1:B2`, quoted `'Q1 Budget'!A1` / `'O''Brien'!A1` (doubled `''` → literal apostrophe). A `!` makes the preceding token a **sheet name**, never a cell, so `'A1'!B2` is unambiguous. Unknown sheet → `#REF!` at eval, not a parse error.
- **edit.rs** — `adjust` shifts an unqualified ref (own sheet); a qualified ref targets another sheet, so a structural edit on this formula's sheet leaves it untouched (inbound cross-sheet propagation is PR-3).
- **recalc.rs** — unqualified eval unchanged; qualified ref → `Err(Ref)` and registers no precedent (pending PR-2's resolver). Qualified range as a SUM arg short-circuits to `#REF!`.

## Verification
- **184 tests pass** (177 prior, unchanged → single-sheet byte-identical; **+7 new**: qualified parse/round-trip, quoting rules, `A1`-named-sheet disambiguation, `shift` preserves qualifier, qualified eval → `#REF!`, `collect_refs` skips qualified).
- Facades (`spreadsheet-core-wasm` 36 tests, `spreadsheet-capi`/`spreadsheet-wasm`) build on 0.12.0 via path deps — no change needed.
- clippy-clean in the changed files; `#![forbid(unsafe_code)]` kept.
- `/security-review` (parser DoS / no-panic on untrusted formula text / parse↔re-emit round-trip identity) → **PASSED**.

Spec firmed: the AST stores the sheet **name** (keeps `parse()` workbook-free; rename rewrites names in PR-4). Bumps `spreadsheet-core` 0.11.1 → 0.12.0 + CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)