### PR TITLE
SPICE: export output-plan table artifacts

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Added
 
+- **Deck output-plan table export artifacts** —
+  selected `run_deck_analysis()` executions now include `output-plan` in
+  `tables`, selected-run `TableList` metadata, and ordered `table_artifacts`
+  with stable table, CSV, compact JSON, and header-keyed record payloads,
+  matching Rust and TypeScript.
+
 - **Deck output-plan inventory artifacts** —
   selected `run_deck_analysis()` executions now expose
   `output_plan_artifacts` with stable result-column, output-probe,

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -112,8 +112,11 @@ that produced the table, plus selected
 `.measure` results and a stable measurement table for `.dc`, `.ac`, and `.tran`
 executions. Execution `table_artifacts` preserve the same order as `tables` and
 carry each stable table's text, CSV, compact JSON, and header-keyed records.
-Selected
-`.tran` plans also return selected `.four` harmonic results and a stable
+Execution `output_plan_artifacts` summarize the selected result columns,
+output probes, output directives, and stable table names, and the `output-plan`
+entry in `table_artifacts` carries the same table, CSV, compact JSON, and
+header-keyed record exports.
+Selected `.tran` plans also return selected `.four` harmonic results and a stable
 Fourier table. Executions also include a selected-run artifact summary plus
 `format_deck_run_artifact_table()` and `format_deck_run_artifact_csv()` output
 for stable result-row, table, analysis-directive, output-probe,

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -2778,6 +2778,7 @@ def _deck_stable_tables(
         tables.append("fourier")
     if control_policy_artifacts:
         tables.extend(["control-policy", "control-policy-summary"])
+    tables.append("output-plan")
     tables.append("run-artifact")
     return tables
 
@@ -3163,6 +3164,7 @@ def _deck_table_artifact(name: str, table: str) -> DeckTableArtifact:
 
 
 def _deck_table_artifacts(
+    plan: DeckAnalysisPlan,
     result_table: str,
     measurement_table: str,
     fourier_table: str,
@@ -3173,6 +3175,9 @@ def _deck_table_artifacts(
     control_policy_artifact_table: str,
     control_policy_summary_artifacts: list[DeckControlPolicySummaryArtifact],
     control_policy_summary_artifact_table: str,
+    output_probes: list[str],
+    output_directives: list[str],
+    tables: list[str],
 ) -> list[DeckTableArtifact]:
     artifacts = [_deck_table_artifact("result", result_table)]
     if measurements:
@@ -3190,6 +3195,14 @@ def _deck_table_artifacts(
                 control_policy_summary_artifact_table,
             )
         )
+    output_plan_artifact_table = _deck_output_plan_artifact_bundle(
+        plan,
+        result_table,
+        output_probes,
+        output_directives,
+        tables,
+    )[1]
+    artifacts.append(_deck_table_artifact("output-plan", output_plan_artifact_table))
     artifacts.append(_deck_table_artifact("run-artifact", run_artifact_table))
     return artifacts
 
@@ -3901,6 +3914,7 @@ def run_deck_analysis(
             control_policy_artifacts,
         )
         table_artifacts = _deck_table_artifacts(
+            plan,
             table,
             measurement_table,
             fourier_table,
@@ -3911,6 +3925,9 @@ def run_deck_analysis(
             control_policy_artifact_table,
             control_policy_summary_artifacts,
             control_policy_summary_artifact_table,
+            output_probes,
+            output_directives,
+            tables,
         )
         (
             output_plan_artifacts,
@@ -3995,6 +4012,7 @@ def run_deck_analysis(
             control_policy_artifacts,
         )
         table_artifacts = _deck_table_artifacts(
+            plan,
             table,
             measurement_table,
             fourier_table,
@@ -4005,6 +4023,9 @@ def run_deck_analysis(
             control_policy_artifact_table,
             control_policy_summary_artifacts,
             control_policy_summary_artifact_table,
+            output_probes,
+            output_directives,
+            tables,
         )
         (
             output_plan_artifacts,
@@ -4091,6 +4112,7 @@ def run_deck_analysis(
             control_policy_artifacts,
         )
         table_artifacts = _deck_table_artifacts(
+            plan,
             table,
             measurement_table,
             fourier_table,
@@ -4101,6 +4123,9 @@ def run_deck_analysis(
             control_policy_artifact_table,
             control_policy_summary_artifacts,
             control_policy_summary_artifact_table,
+            output_probes,
+            output_directives,
+            tables,
         )
         (
             output_plan_artifacts,
@@ -4193,6 +4218,7 @@ def run_deck_analysis(
             control_policy_artifacts,
         )
         table_artifacts = _deck_table_artifacts(
+            plan,
             table,
             measurement_table,
             fourier_table,
@@ -4203,6 +4229,9 @@ def run_deck_analysis(
             control_policy_artifact_table,
             control_policy_summary_artifacts,
             control_policy_summary_artifact_table,
+            output_probes,
+            output_directives,
+            tables,
         )
         (
             output_plan_artifacts,
@@ -4283,6 +4312,7 @@ def run_deck_analysis(
             control_policy_artifacts,
         )
         table_artifacts = _deck_table_artifacts(
+            plan,
             table,
             measurement_table,
             fourier_table,
@@ -4293,6 +4323,9 @@ def run_deck_analysis(
             control_policy_artifact_table,
             control_policy_summary_artifacts,
             control_policy_summary_artifact_table,
+            output_probes,
+            output_directives,
+            tables,
         )
         (
             output_plan_artifacts,
@@ -4372,6 +4405,7 @@ def run_deck_analysis(
             control_policy_artifacts,
         )
         table_artifacts = _deck_table_artifacts(
+            plan,
             table,
             measurement_table,
             fourier_table,
@@ -4382,6 +4416,9 @@ def run_deck_analysis(
             control_policy_artifact_table,
             control_policy_summary_artifacts,
             control_policy_summary_artifact_table,
+            output_probes,
+            output_directives,
+            tables,
         )
         (
             output_plan_artifacts,
@@ -4480,6 +4517,7 @@ def run_deck_analysis(
             control_policy_artifacts,
         )
         table_artifacts = _deck_table_artifacts(
+            plan,
             table,
             measurement_table,
             fourier_table,
@@ -4490,6 +4528,9 @@ def run_deck_analysis(
             control_policy_artifact_table,
             control_policy_summary_artifacts,
             control_policy_summary_artifact_table,
+            output_probes,
+            output_directives,
+            tables,
         )
         (
             output_plan_artifacts,

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -6842,8 +6842,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert op_execution.output_probes == ["V(mid)"]
     assert op_execution.output_directives == [".save"]
     assert op_execution.analysis_directives == [".op"]
-    assert op_execution.table_count == 2
-    assert op_execution.tables == ["result", "run-artifact"]
+    assert op_execution.table_count == 3
+    assert op_execution.tables == ["result", "output-plan", "run-artifact"]
     assert [artifact.name for artifact in op_execution.table_artifacts] == (
         op_execution.tables
     )
@@ -6870,7 +6870,7 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     expected_output_plan_table = (
         "Analysis\tDirective\tResultColumns\tResultColumnList\tOutputProbes\t"
         "OutputProbeList\tOutputDirectives\tOutputDirectiveList\tTables\tTableList\n"
-        "op\t.op\t2\tIndex;V(mid)\t1\tV(mid)\t1\t.save\t2\tresult;run-artifact\n"
+        "op\t.op\t2\tIndex;V(mid)\t1\tV(mid)\t1\t.save\t3\tresult;output-plan;run-artifact\n"
     )
     expected_output_plan_records = [
         {
@@ -6882,8 +6882,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
             "OutputProbeList": "V(mid)",
             "OutputDirectives": "1",
             "OutputDirectiveList": ".save",
-            "Tables": "2",
-            "TableList": "result;run-artifact",
+            "Tables": "3",
+            "TableList": "result;output-plan;run-artifact",
         }
     ]
     assert op_execution.output_plan_artifact_count == 1
@@ -6894,7 +6894,7 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert output_plan_artifact.result_columns == ["Index", "V(mid)"]
     assert output_plan_artifact.output_probes == ["V(mid)"]
     assert output_plan_artifact.output_directives == [".save"]
-    assert output_plan_artifact.tables == ["result", "run-artifact"]
+    assert output_plan_artifact.tables == ["result", "output-plan", "run-artifact"]
     assert op_execution.output_plan_artifact_table == expected_output_plan_table
     assert op_execution.output_plan_artifact_table == (
         format_deck_output_plan_artifact_table(op_execution.output_plan_artifacts)
@@ -6902,7 +6902,7 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert op_execution.output_plan_artifact_csv == (
         "Analysis,Directive,ResultColumns,ResultColumnList,OutputProbes,"
         "OutputProbeList,OutputDirectives,OutputDirectiveList,Tables,TableList\n"
-        "op,.op,2,Index;V(mid),1,V(mid),1,.save,2,result;run-artifact\n"
+        "op,.op,2,Index;V(mid),1,V(mid),1,.save,3,result;output-plan;run-artifact\n"
     )
     assert op_execution.output_plan_artifact_csv == (
         format_deck_output_plan_artifact_csv(op_execution.output_plan_artifacts)
@@ -6920,8 +6920,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert op_execution.run_artifacts[0].result_rows == 1
     assert op_execution.run_artifacts[0].result_column_count == 2
     assert op_execution.run_artifacts[0].result_columns == ["Index", "V(mid)"]
-    assert op_execution.run_artifacts[0].table_count == 2
-    assert op_execution.run_artifacts[0].tables == ["result", "run-artifact"]
+    assert op_execution.run_artifacts[0].table_count == 3
+    assert op_execution.run_artifacts[0].tables == ["result", "output-plan", "run-artifact"]
     assert op_execution.run_artifacts[0].source_name is None
     assert op_execution.run_artifacts[0].output_node is None
     assert op_execution.run_artifacts[0].sweep_kind is None
@@ -6942,11 +6942,18 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert op_execution.run_artifacts[0].diagnostic_codes == []
     assert op_execution.run_artifact_table == (
         "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tControlPolicyArtifacts\tControlPolicyCategoryList\tControlPolicyCodeList\tControlPolicySeverityList\tDiagnostics\tDiagnosticCodeList\n"
-        f"op\t.op\t1\t.op\t{op_execution.plan.line_number}\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t1\t2\tIndex;V(mid)\t2\tresult;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n"
+        f"op\t.op\t1\t.op\t{op_execution.plan.line_number}\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t1\t2\tIndex;V(mid)\t3\tresult;output-plan;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n"
     )
-    assert op_execution.table_artifacts[1].name == "run-artifact"
-    assert op_execution.table_artifacts[1].table == op_execution.run_artifact_table
-    assert op_execution.table_artifacts[1].records == deck_table_records(
+    assert op_execution.table_artifacts[1].name == "output-plan"
+    assert op_execution.table_artifacts[1].table == op_execution.output_plan_artifact_table
+    assert op_execution.table_artifacts[1].csv == op_execution.output_plan_artifact_csv
+    assert op_execution.table_artifacts[1].json == op_execution.output_plan_artifact_json
+    assert op_execution.table_artifacts[1].records == (
+        op_execution.output_plan_artifact_records
+    )
+    assert op_execution.table_artifacts[2].name == "run-artifact"
+    assert op_execution.table_artifacts[2].table == op_execution.run_artifact_table
+    assert op_execution.table_artifacts[2].records == deck_table_records(
         op_execution.run_artifact_table
     )
     assert format_deck_table_csv(
@@ -6960,7 +6967,7 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     )
     assert format_deck_run_artifact_csv(op_execution.run_artifacts) == (
         "Analysis,Directive,AnalysisDirectives,AnalysisDirectiveList,Line,SourceName,OutputNode,SweepKind,StartValue,StopValue,StepValue,PointCount,StartFrequencyHz,StopFrequencyHz,StepTime,StopTime,StartTime,MaxStep,UseInitialConditions,ResultRows,ResultColumns,ResultColumnList,Tables,TableList,OutputProbes,OutputProbeList,OutputDirectives,OutputDirectiveList,Measurements,MeasurementList,Fourier,FourierList,ControlLines,ControlLineList,WriteMarkers,WriteMarkerList,RawfileOptions,RawfileOptionList,ControlPolicyArtifacts,ControlPolicyCategoryList,ControlPolicyCodeList,ControlPolicySeverityList,Diagnostics,DiagnosticCodeList\n"
-        f"op,.op,1,.op,{op_execution.plan.line_number},,,,,,,,,,,,,,,1,2,Index;V(mid),2,result;run-artifact,1,V(mid),1,.save,0,,0,,0,,0,,0,,0,,,,0,\n"
+        f"op,.op,1,.op,{op_execution.plan.line_number},,,,,,,,,,,,,,,1,2,Index;V(mid),3,result;output-plan;run-artifact,1,V(mid),1,.save,0,,0,,0,,0,,0,,0,,,,0,\n"
     )
     assert format_deck_table_csv('Name\tValue\nprobe\tSPICE,"QUOTED"\n') == (
         'Name,Value\nprobe,"SPICE,""QUOTED"""\n'
@@ -7043,8 +7050,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
             "ResultRows": "1",
             "ResultColumns": "2",
             "ResultColumnList": "Index;V(mid)",
-            "Tables": "2",
-            "TableList": "result;run-artifact",
+            "Tables": "3",
+            "TableList": "result;output-plan;run-artifact",
             "OutputProbes": "1",
             "OutputProbeList": "V(mid)",
             "OutputDirectives": "1",
@@ -7096,8 +7103,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert dc_execution.output_probes == ["V(mid)", "I(V1)"]
     assert dc_execution.output_directives == [".save", ".probe"]
     assert dc_execution.analysis_directives == [".dc"]
-    assert dc_execution.table_count == 3
-    assert dc_execution.tables == ["result", "measurement", "run-artifact"]
+    assert dc_execution.table_count == 4
+    assert dc_execution.tables == ["result", "measurement", "output-plan", "run-artifact"]
     assert [artifact.name for artifact in dc_execution.table_artifacts] == (
         dc_execution.tables
     )
@@ -7137,10 +7144,11 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
         "V(mid)",
         "I(V1)",
     ]
-    assert dc_execution.run_artifacts[0].table_count == 3
+    assert dc_execution.run_artifacts[0].table_count == 4
     assert dc_execution.run_artifacts[0].tables == [
         "result",
         "measurement",
+        "output-plan",
         "run-artifact",
     ]
     assert dc_execution.run_artifacts[0].step_time is None
@@ -7152,15 +7160,15 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert dc_execution.run_artifacts[0].fourier_probes == []
     assert dc_execution.run_artifact_table == (
         "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tControlPolicyArtifacts\tControlPolicyCategoryList\tControlPolicyCodeList\tControlPolicySeverityList\tDiagnostics\tDiagnosticCodeList\n"
-        f"dc\t.dc\t1\t.dc\t{dc_execution.plan.line_number}\tV1\t\t\t0.000000e+00\t1.000000e+00\t1.000000e+00\t\t\t\t\t\t\t\t\t2\t5\tIndex;Source;Value;V(mid);I(V1)\t3\tresult;measurement;run-artifact\t2\tV(mid);I(V1)\t2\t.save;.probe\t1\tmid_avg\t0\t\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n"
+        f"dc\t.dc\t1\t.dc\t{dc_execution.plan.line_number}\tV1\t\t\t0.000000e+00\t1.000000e+00\t1.000000e+00\t\t\t\t\t\t\t\t\t2\t5\tIndex;Source;Value;V(mid);I(V1)\t4\tresult;measurement;output-plan;run-artifact\t2\tV(mid);I(V1)\t2\t.save;.probe\t1\tmid_avg\t0\t\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n"
     )
 
     ac_execution = run_deck_analysis(circuit, netlist, "ac")
     assert ac_execution.output_probes == ["V(mid)"]
     assert ac_execution.output_directives == [".save"]
     assert ac_execution.analysis_directives == [".ac"]
-    assert ac_execution.table_count == 3
-    assert ac_execution.tables == ["result", "measurement", "run-artifact"]
+    assert ac_execution.table_count == 4
+    assert ac_execution.tables == ["result", "measurement", "output-plan", "run-artifact"]
     assert [measurement.name for measurement in ac_execution.measurements] == ["mid_peak"]
     assert ac_execution.measurement_table == (
         "Name\tAnalysis\tProbe\tMode\tFrom\tTo\tValue\n"
@@ -7189,10 +7197,11 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
         "Magnitude",
         "Phase",
     ]
-    assert ac_execution.run_artifacts[0].table_count == 3
+    assert ac_execution.run_artifacts[0].table_count == 4
     assert ac_execution.run_artifacts[0].tables == [
         "result",
         "measurement",
+        "output-plan",
         "run-artifact",
     ]
     assert ac_execution.run_artifacts[0].step_time is None
@@ -7202,15 +7211,15 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert ac_execution.run_artifacts[0].fourier_probes == []
     assert ac_execution.run_artifact_table == (
         "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tControlPolicyArtifacts\tControlPolicyCategoryList\tControlPolicyCodeList\tControlPolicySeverityList\tDiagnostics\tDiagnosticCodeList\n"
-        f"ac\t.ac\t1\t.ac\t{ac_execution.plan.line_number}\t\t\tdec\t\t\t\t1\t1.000000e+03\t1.000000e+03\t\t\t\t\t\t1\t7\tIndex;Frequency;Probe;Real;Imaginary;Magnitude;Phase\t3\tresult;measurement;run-artifact\t1\tV(mid)\t1\t.save\t1\tmid_peak\t0\t\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n"
+        f"ac\t.ac\t1\t.ac\t{ac_execution.plan.line_number}\t\t\tdec\t\t\t\t1\t1.000000e+03\t1.000000e+03\t\t\t\t\t\t1\t7\tIndex;Frequency;Probe;Real;Imaginary;Magnitude;Phase\t4\tresult;measurement;output-plan;run-artifact\t1\tV(mid)\t1\t.save\t1\tmid_peak\t0\t\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n"
     )
 
     tran_execution = run_deck_analysis(circuit, netlist, "tran")
     assert tran_execution.output_probes == ["V(mid)"]
     assert tran_execution.output_directives == [".save"]
     assert tran_execution.analysis_directives == [".tran"]
-    assert tran_execution.table_count == 3
-    assert tran_execution.tables == ["result", "measurement", "run-artifact"]
+    assert tran_execution.table_count == 4
+    assert tran_execution.tables == ["result", "measurement", "output-plan", "run-artifact"]
     assert [measurement.name for measurement in tran_execution.measurements] == [
         "mid_final"
     ]
@@ -7231,10 +7240,11 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert tran_execution.run_artifacts[0].stop_time == pytest.approx(1.0e-3)
     assert tran_execution.run_artifacts[0].result_column_count == 3
     assert tran_execution.run_artifacts[0].result_columns == ["Index", "Time", "V(mid)"]
-    assert tran_execution.run_artifacts[0].table_count == 3
+    assert tran_execution.run_artifacts[0].table_count == 4
     assert tran_execution.run_artifacts[0].tables == [
         "result",
         "measurement",
+        "output-plan",
         "run-artifact",
     ]
     assert tran_execution.run_artifacts[0].start_time is None
@@ -7247,7 +7257,7 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert tran_execution.run_artifacts[0].diagnostic_codes == []
     assert tran_execution.run_artifact_table == (
         "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tControlPolicyArtifacts\tControlPolicyCategoryList\tControlPolicyCodeList\tControlPolicySeverityList\tDiagnostics\tDiagnosticCodeList\n"
-        f"tran\t.tran\t1\t.tran\t{tran_execution.plan.line_number}\t\t\t\t\t\t\t\t\t\t1.000000e-03\t1.000000e-03\t\t\tfalse\t2\t3\tIndex;Time;V(mid)\t3\tresult;measurement;run-artifact\t1\tV(mid)\t1\t.save\t1\tmid_final\t0\t\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n"
+        f"tran\t.tran\t1\t.tran\t{tran_execution.plan.line_number}\t\t\t\t\t\t\t\t\t\t1.000000e-03\t1.000000e-03\t\t\tfalse\t2\t3\tIndex;Time;V(mid)\t4\tresult;measurement;output-plan;run-artifact\t1\tV(mid)\t1\t.save\t1\tmid_final\t0\t\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n"
     )
 
     tf_execution = run_deck_analysis(circuit, netlist, "tf")
@@ -7260,8 +7270,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert tf_execution.output_probes == ["V(mid)"]
     assert tf_execution.output_directives == []
     assert tf_execution.analysis_directives == [".tf"]
-    assert tf_execution.table_count == 2
-    assert tf_execution.tables == ["result", "run-artifact"]
+    assert tf_execution.table_count == 3
+    assert tf_execution.tables == ["result", "output-plan", "run-artifact"]
     assert tf_execution.measurements == []
     assert tf_execution.measurement_table == "Name\tAnalysis\tProbe\tMode\tFrom\tTo\tValue\n"
     assert tf_execution.table == (
@@ -7278,8 +7288,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
         "InputImpedance",
         "OutputImpedance",
     ]
-    assert tf_execution.run_artifacts[0].table_count == 2
-    assert tf_execution.run_artifacts[0].tables == ["result", "run-artifact"]
+    assert tf_execution.run_artifacts[0].table_count == 3
+    assert tf_execution.run_artifacts[0].tables == ["result", "output-plan", "run-artifact"]
     assert tf_execution.run_artifacts[0].step_time is None
     assert tf_execution.run_artifacts[0].use_initial_conditions is None
     assert tf_execution.run_artifacts[0].output_probes == ["V(mid)"]
@@ -7288,7 +7298,7 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert tf_execution.run_artifacts[0].fourier_probes == []
     assert tf_execution.run_artifact_table == (
         "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tControlPolicyArtifacts\tControlPolicyCategoryList\tControlPolicyCodeList\tControlPolicySeverityList\tDiagnostics\tDiagnosticCodeList\n"
-        f"tf\t.tf\t1\t.tf\t{tf_execution.plan.line_number}\tV1\tmid\t\t\t\t\t\t\t\t\t\t\t\t\t1\t3\tTransferRatio;InputImpedance;OutputImpedance\t2\tresult;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n"
+        f"tf\t.tf\t1\t.tf\t{tf_execution.plan.line_number}\tV1\tmid\t\t\t\t\t\t\t\t\t\t\t\t\t1\t3\tTransferRatio;InputImpedance;OutputImpedance\t3\tresult;output-plan;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n"
     )
 
     sens_execution = run_deck_analysis(circuit, netlist, "sens")
@@ -7299,8 +7309,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert len(sens_execution.result.entries) == 3
     assert sens_execution.output_probes == ["V(mid)"]
     assert sens_execution.analysis_directives == [".sens"]
-    assert sens_execution.table_count == 2
-    assert sens_execution.tables == ["result", "run-artifact"]
+    assert sens_execution.table_count == 3
+    assert sens_execution.tables == ["result", "output-plan", "run-artifact"]
     assert sens_execution.measurements == []
     assert sens_execution.measurement_table == "Name\tAnalysis\tProbe\tMode\tFrom\tTo\tValue\n"
     assert sens_execution.table.startswith(
@@ -7320,8 +7330,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
         "Sensitivity",
         "RelativeSensitivity",
     ]
-    assert sens_execution.run_artifacts[0].table_count == 2
-    assert sens_execution.run_artifacts[0].tables == ["result", "run-artifact"]
+    assert sens_execution.run_artifacts[0].table_count == 3
+    assert sens_execution.run_artifacts[0].tables == ["result", "output-plan", "run-artifact"]
     assert sens_execution.run_artifacts[0].step_time is None
     assert sens_execution.run_artifacts[0].use_initial_conditions is None
     assert sens_execution.run_artifacts[0].output_probes == ["V(mid)"]
@@ -7330,7 +7340,7 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert sens_execution.run_artifacts[0].fourier_probes == []
     assert sens_execution.run_artifact_table == (
         "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tControlPolicyArtifacts\tControlPolicyCategoryList\tControlPolicyCodeList\tControlPolicySeverityList\tDiagnostics\tDiagnosticCodeList\n"
-        f"sens\t.sens\t1\t.sens\t{sens_execution.plan.line_number}\t\tmid\t\t\t\t\t\t\t\t\t\t\t\t\t1\t7\tOutputNode;NominalVoltage;Element;Parameter;NominalValue;Sensitivity;RelativeSensitivity\t2\tresult;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n"
+        f"sens\t.sens\t1\t.sens\t{sens_execution.plan.line_number}\t\tmid\t\t\t\t\t\t\t\t\t\t\t\t\t1\t7\tOutputNode;NominalVoltage;Element;Parameter;NominalValue;Sensitivity;RelativeSensitivity\t3\tresult;output-plan;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n"
     )
 
     noise_execution = run_deck_analysis(circuit, netlist, "noise")
@@ -7346,8 +7356,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert len(noise_execution.result.points) == 1
     assert noise_execution.output_probes == ["V(mid)"]
     assert noise_execution.analysis_directives == [".noise"]
-    assert noise_execution.table_count == 2
-    assert noise_execution.tables == ["result", "run-artifact"]
+    assert noise_execution.table_count == 3
+    assert noise_execution.tables == ["result", "output-plan", "run-artifact"]
     assert noise_execution.measurements == []
     assert noise_execution.measurement_table == "Name\tAnalysis\tProbe\tMode\tFrom\tTo\tValue\n"
     assert noise_execution.table == format_deck_noise_table(noise_execution.result)
@@ -7376,8 +7386,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
         "SourcePSD",
         "ContributionPSD",
     ]
-    assert noise_execution.run_artifacts[0].table_count == 2
-    assert noise_execution.run_artifacts[0].tables == ["result", "run-artifact"]
+    assert noise_execution.run_artifacts[0].table_count == 3
+    assert noise_execution.run_artifacts[0].tables == ["result", "output-plan", "run-artifact"]
     assert noise_execution.run_artifacts[0].step_time is None
     assert noise_execution.run_artifacts[0].use_initial_conditions is None
     assert noise_execution.run_artifacts[0].output_probes == ["V(mid)"]
@@ -7386,7 +7396,7 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert noise_execution.run_artifacts[0].fourier_probes == []
     assert noise_execution.run_artifact_table == (
         "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tControlPolicyArtifacts\tControlPolicyCategoryList\tControlPolicyCodeList\tControlPolicySeverityList\tDiagnostics\tDiagnosticCodeList\n"
-        f"noise\t.noise\t1\t.noise\t{noise_execution.plan.line_number}\tV1\tmid\tlin\t\t\t\t1\t1.000000e+03\t1.000000e+03\t\t\t\t\t\t1\t10\tIndex;Frequency;OutputNode;InputSource;OutputPSD;InputReferredPSD;Element;Type;SourcePSD;ContributionPSD\t2\tresult;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n"
+        f"noise\t.noise\t1\t.noise\t{noise_execution.plan.line_number}\tV1\tmid\tlin\t\t\t\t1\t1.000000e+03\t1.000000e+03\t\t\t\t\t\t1\t10\tIndex;Frequency;OutputNode;InputSource;OutputPSD;InputReferredPSD;Element;Type;SourcePSD;ContributionPSD\t3\tresult;output-plan;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n"
     )
 
     tran_window_execution = run_deck_analysis(
@@ -7407,13 +7417,14 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
         "Time",
         "V(mid)",
     ]
-    assert tran_window_execution.run_artifacts[0].table_count == 2
+    assert tran_window_execution.run_artifacts[0].table_count == 3
     assert tran_window_execution.run_artifacts[0].tables == [
         "result",
+        "output-plan",
         "run-artifact",
     ]
-    assert tran_window_execution.table_count == 2
-    assert tran_window_execution.tables == ["result", "run-artifact"]
+    assert tran_window_execution.table_count == 3
+    assert tran_window_execution.tables == ["result", "output-plan", "run-artifact"]
     assert tran_window_execution.output_probes == ["V(mid)"]
     assert isinstance(tran_window_execution.result, TransientResult)
     assert [point.time for point in tran_window_execution.result.points] == pytest.approx(
@@ -7427,7 +7438,7 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     )
     assert tran_window_execution.run_artifact_table == (
         "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tControlPolicyArtifacts\tControlPolicyCategoryList\tControlPolicyCodeList\tControlPolicySeverityList\tDiagnostics\tDiagnosticCodeList\n"
-        f"tran\t.tran\t1\t.tran\t{tran_window_execution.plan.line_number}\t\t\t\t\t\t\t\t\t\t2.000000e-03\t6.000000e-03\t2.000000e-03\t1.000000e-03\ttrue\t3\t3\tIndex;Time;V(mid)\t2\tresult;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n"
+        f"tran\t.tran\t1\t.tran\t{tran_window_execution.plan.line_number}\t\t\t\t\t\t\t\t\t\t2.000000e-03\t6.000000e-03\t2.000000e-03\t1.000000e-03\ttrue\t3\t3\tIndex;Time;V(mid)\t3\tresult;output-plan;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n"
     )
 
     with pytest.raises(ValueError, match="multiple analysis cards"):
@@ -7516,6 +7527,7 @@ let gain = 2
         "result",
         "control-policy",
         "control-policy-summary",
+        "output-plan",
         "run-artifact",
     ]
 
@@ -7715,13 +7727,13 @@ let gain = 2
     assert [artifact.name for artifact in execution.table_artifacts] == (
         expected_table_names
     )
-    policy_table_artifact = execution.table_artifacts[-3]
+    policy_table_artifact = execution.table_artifacts[-4]
     assert policy_table_artifact.name == "control-policy"
     assert policy_table_artifact.table == execution.control_policy_artifact_table
     assert policy_table_artifact.csv == execution.control_policy_artifact_csv
     assert policy_table_artifact.json == execution.control_policy_artifact_json
     assert policy_table_artifact.records == execution.control_policy_artifact_records
-    summary_table_artifact = execution.table_artifacts[-2]
+    summary_table_artifact = execution.table_artifacts[-3]
     assert summary_table_artifact.name == "control-policy-summary"
     assert (
         summary_table_artifact.table
@@ -7739,6 +7751,12 @@ let gain = 2
         summary_table_artifact.records
         == execution.control_policy_summary_artifact_records
     )
+    output_plan_table_artifact = execution.table_artifacts[-2]
+    assert output_plan_table_artifact.name == "output-plan"
+    assert output_plan_table_artifact.table == execution.output_plan_artifact_table
+    assert output_plan_table_artifact.csv == execution.output_plan_artifact_csv
+    assert output_plan_table_artifact.json == execution.output_plan_artifact_json
+    assert output_plan_table_artifact.records == execution.output_plan_artifact_records
     assert execution.run_artifacts[0].control_line_count == len(expected_control_lines)
     assert execution.run_artifacts[0].control_lines == expected_control_lines
     assert execution.run_artifacts[0].table_count == len(expected_table_names)
@@ -7895,13 +7913,13 @@ def test_run_deck_analysis_exposes_selected_fourier_artifacts() -> None:
     op_execution = run_deck_analysis(circuit, netlist, "op")
     assert op_execution.fourier == []
     assert op_execution.fourier_table == ""
-    assert op_execution.table_count == 2
-    assert op_execution.tables == ["result", "run-artifact"]
+    assert op_execution.table_count == 3
+    assert op_execution.tables == ["result", "output-plan", "run-artifact"]
 
     tran_execution = run_deck_analysis(circuit, netlist, "tran")
     assert len(tran_execution.fourier) == 1
-    assert tran_execution.table_count == 3
-    assert tran_execution.tables == ["result", "fourier", "run-artifact"]
+    assert tran_execution.table_count == 4
+    assert tran_execution.tables == ["result", "fourier", "output-plan", "run-artifact"]
     assert [artifact.name for artifact in tran_execution.table_artifacts] == (
         tran_execution.tables
     )
@@ -7927,10 +7945,11 @@ def test_run_deck_analysis_exposes_selected_fourier_artifacts() -> None:
     assert tran_execution.run_artifacts[0].stop_time == pytest.approx(1.0e-3)
     assert tran_execution.run_artifacts[0].result_column_count == 3
     assert tran_execution.run_artifacts[0].result_columns == ["Index", "Time", "V(mid)"]
-    assert tran_execution.run_artifacts[0].table_count == 3
+    assert tran_execution.run_artifacts[0].table_count == 4
     assert tran_execution.run_artifacts[0].tables == [
         "result",
         "fourier",
+        "output-plan",
         "run-artifact",
     ]
     assert tran_execution.run_artifacts[0].start_time is None
@@ -7942,7 +7961,7 @@ def test_run_deck_analysis_exposes_selected_fourier_artifacts() -> None:
     assert tran_execution.run_artifacts[0].fourier_probes == ["V(mid)"]
     assert tran_execution.run_artifact_table == (
         "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tControlPolicyArtifacts\tControlPolicyCategoryList\tControlPolicyCodeList\tControlPolicySeverityList\tDiagnostics\tDiagnosticCodeList\n"
-        f"tran\t.tran\t1\t.tran\t{tran_execution.plan.line_number}\t\t\t\t\t\t\t\t\t\t5.000000e-04\t1.000000e-03\t\t\tfalse\t3\t3\tIndex;Time;V(mid)\t3\tresult;fourier;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n"
+        f"tran\t.tran\t1\t.tran\t{tran_execution.plan.line_number}\t\t\t\t\t\t\t\t\t\t5.000000e-04\t1.000000e-03\t\t\tfalse\t3\t3\tIndex;Time;V(mid)\t4\tresult;fourier;output-plan;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n"
     )
 
 

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Include selected `run_deck_analysis` output-plan tables in execution
+  `tables`, selected-run `TableList` metadata, and ordered `table_artifacts`
+  with stable table, CSV, compact JSON, and header-keyed record payloads,
+  matching Python and TypeScript.
 - Expose selected `run_deck_analysis` output-plan inventories as
   `output_plan_artifacts` with stable result-column, output-probe,
   output-directive, and table lists plus table, CSV, compact JSON, and

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -180,8 +180,12 @@ table count/name list, output probes, and output directives that produced the
 table, plus selected `.measure` results and
 a stable measurement table for `.dc`, `.ac`, and `.tran` executions.
 Execution `table_artifacts` preserve the same order as `tables` and carry each
-stable table's text, CSV, compact JSON, and header-keyed records. Selected
-`.tran` plans route
+stable table's text, CSV, compact JSON, and header-keyed records.
+Execution `output_plan_artifacts` summarize the selected result columns,
+output probes, output directives, and stable table names, and the `output-plan`
+entry in `table_artifacts` carries the same table, CSV, compact JSON, and
+header-keyed record exports.
+Selected `.tran` plans route
 `START` output filtering, `.tran TSTEP` as the output print grid, `MAXSTEP` as
 an internal fixed-step cap, and `UIC` initial-condition intent through that
 stable transient table surface. They also return selected `.four` harmonic

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -10526,6 +10526,7 @@ fn deck_stable_tables(
         tables.push("control-policy".to_string());
         tables.push("control-policy-summary".to_string());
     }
+    tables.push("output-plan".to_string());
     tables.push("run-artifact".to_string());
     tables
 }
@@ -10763,6 +10764,7 @@ fn deck_table_artifact(name: &str, table: &str) -> DeckTableArtifact {
 }
 
 fn deck_table_artifacts(
+    plan: &DeckAnalysisPlan,
     result_table: &str,
     measurement_table: &str,
     fourier_table: &str,
@@ -10773,6 +10775,9 @@ fn deck_table_artifacts(
     control_policy_artifact_table: &str,
     control_policy_summary_artifacts: &[DeckControlPolicySummaryArtifact],
     control_policy_summary_artifact_table: &str,
+    output_probes: &[String],
+    output_directives: &[String],
+    tables: &[String],
 ) -> Vec<DeckTableArtifact> {
     let mut artifacts = vec![deck_table_artifact("result", result_table)];
     if !measurements.is_empty() {
@@ -10793,6 +10798,26 @@ fn deck_table_artifacts(
             control_policy_summary_artifact_table,
         ));
     }
+    let (
+        _,
+        output_plan_artifact_table,
+        output_plan_artifact_csv,
+        output_plan_artifact_json,
+        output_plan_artifact_records,
+    ) = deck_output_plan_artifact_bundle(
+        plan,
+        result_table,
+        output_probes,
+        output_directives,
+        tables,
+    );
+    artifacts.push(DeckTableArtifact {
+        name: "output-plan".to_string(),
+        table: output_plan_artifact_table,
+        csv: output_plan_artifact_csv,
+        json: output_plan_artifact_json,
+        records: output_plan_artifact_records,
+    });
     artifacts.push(deck_table_artifact("run-artifact", run_artifact_table));
     artifacts
 }
@@ -11675,7 +11700,9 @@ pub fn run_deck_analysis(
                 &control_policy_artifacts,
             );
             let run_artifact_table = format_deck_run_artifact_table(&run_artifacts);
+            let tables = deck_stable_tables(&measurements, &fourier, &control_policy_artifacts);
             let table_artifacts = deck_table_artifacts(
+                &plan,
                 &table,
                 &measurement_table,
                 &fourier_table,
@@ -11686,6 +11713,9 @@ pub fn run_deck_analysis(
                 &control_policy_artifact_table,
                 &control_policy_summary_artifacts,
                 &control_policy_summary_artifact_table,
+                &output_probes,
+                &output_directives,
+                &tables,
             );
             let rawfile_artifacts =
                 deck_rawfile_artifacts(&plan, &table, &write_markers, &rawfile_options);
@@ -11698,8 +11728,6 @@ pub fn run_deck_analysis(
             let wrdata_artifact_csv = format_deck_wrdata_artifact_csv(&wrdata_artifacts);
             let wrdata_artifact_json = format_deck_wrdata_artifact_json(&wrdata_artifacts);
             let wrdata_artifact_records = deck_wrdata_artifact_records(&wrdata_artifacts);
-            let tables = deck_stable_tables(&measurements, &fourier, &control_policy_artifacts);
-
             let (
                 output_plan_artifacts,
                 output_plan_artifact_table,
@@ -11809,7 +11837,9 @@ pub fn run_deck_analysis(
                 &control_policy_artifacts,
             );
             let run_artifact_table = format_deck_run_artifact_table(&run_artifacts);
+            let tables = deck_stable_tables(&measurements, &fourier, &control_policy_artifacts);
             let table_artifacts = deck_table_artifacts(
+                &plan,
                 &table,
                 &measurement_table,
                 &fourier_table,
@@ -11820,6 +11850,9 @@ pub fn run_deck_analysis(
                 &control_policy_artifact_table,
                 &control_policy_summary_artifacts,
                 &control_policy_summary_artifact_table,
+                &output_probes,
+                &output_directives,
+                &tables,
             );
             let rawfile_artifacts =
                 deck_rawfile_artifacts(&plan, &table, &write_markers, &rawfile_options);
@@ -11832,8 +11865,6 @@ pub fn run_deck_analysis(
             let wrdata_artifact_csv = format_deck_wrdata_artifact_csv(&wrdata_artifacts);
             let wrdata_artifact_json = format_deck_wrdata_artifact_json(&wrdata_artifacts);
             let wrdata_artifact_records = deck_wrdata_artifact_records(&wrdata_artifacts);
-            let tables = deck_stable_tables(&measurements, &fourier, &control_policy_artifacts);
-
             let (
                 output_plan_artifacts,
                 output_plan_artifact_table,
@@ -11944,7 +11975,9 @@ pub fn run_deck_analysis(
                 &control_policy_artifacts,
             );
             let run_artifact_table = format_deck_run_artifact_table(&run_artifacts);
+            let tables = deck_stable_tables(&measurements, &fourier, &control_policy_artifacts);
             let table_artifacts = deck_table_artifacts(
+                &plan,
                 &table,
                 &measurement_table,
                 &fourier_table,
@@ -11955,6 +11988,9 @@ pub fn run_deck_analysis(
                 &control_policy_artifact_table,
                 &control_policy_summary_artifacts,
                 &control_policy_summary_artifact_table,
+                &output_probes,
+                &output_directives,
+                &tables,
             );
             let rawfile_artifacts =
                 deck_rawfile_artifacts(&plan, &table, &write_markers, &rawfile_options);
@@ -11967,8 +12003,6 @@ pub fn run_deck_analysis(
             let wrdata_artifact_csv = format_deck_wrdata_artifact_csv(&wrdata_artifacts);
             let wrdata_artifact_json = format_deck_wrdata_artifact_json(&wrdata_artifacts);
             let wrdata_artifact_records = deck_wrdata_artifact_records(&wrdata_artifacts);
-            let tables = deck_stable_tables(&measurements, &fourier, &control_policy_artifacts);
-
             let (
                 output_plan_artifacts,
                 output_plan_artifact_table,
@@ -12082,7 +12116,9 @@ pub fn run_deck_analysis(
                 &control_policy_artifacts,
             );
             let run_artifact_table = format_deck_run_artifact_table(&run_artifacts);
+            let tables = deck_stable_tables(&measurements, &fourier, &control_policy_artifacts);
             let table_artifacts = deck_table_artifacts(
+                &plan,
                 &table,
                 &measurement_table,
                 &fourier_table,
@@ -12093,6 +12129,9 @@ pub fn run_deck_analysis(
                 &control_policy_artifact_table,
                 &control_policy_summary_artifacts,
                 &control_policy_summary_artifact_table,
+                &output_probes,
+                &output_directives,
+                &tables,
             );
             let rawfile_artifacts =
                 deck_rawfile_artifacts(&plan, &table, &write_markers, &rawfile_options);
@@ -12105,8 +12144,6 @@ pub fn run_deck_analysis(
             let wrdata_artifact_csv = format_deck_wrdata_artifact_csv(&wrdata_artifacts);
             let wrdata_artifact_json = format_deck_wrdata_artifact_json(&wrdata_artifacts);
             let wrdata_artifact_records = deck_wrdata_artifact_records(&wrdata_artifacts);
-            let tables = deck_stable_tables(&measurements, &fourier, &control_policy_artifacts);
-
             let (
                 output_plan_artifacts,
                 output_plan_artifact_table,
@@ -12214,7 +12251,9 @@ pub fn run_deck_analysis(
                 &control_policy_artifacts,
             );
             let run_artifact_table = format_deck_run_artifact_table(&run_artifacts);
+            let tables = deck_stable_tables(&measurements, &fourier, &control_policy_artifacts);
             let table_artifacts = deck_table_artifacts(
+                &plan,
                 &table,
                 &measurement_table,
                 &fourier_table,
@@ -12225,6 +12264,9 @@ pub fn run_deck_analysis(
                 &control_policy_artifact_table,
                 &control_policy_summary_artifacts,
                 &control_policy_summary_artifact_table,
+                &output_probes,
+                &output_directives,
+                &tables,
             );
             let rawfile_artifacts =
                 deck_rawfile_artifacts(&plan, &table, &write_markers, &rawfile_options);
@@ -12237,8 +12279,6 @@ pub fn run_deck_analysis(
             let wrdata_artifact_csv = format_deck_wrdata_artifact_csv(&wrdata_artifacts);
             let wrdata_artifact_json = format_deck_wrdata_artifact_json(&wrdata_artifacts);
             let wrdata_artifact_records = deck_wrdata_artifact_records(&wrdata_artifacts);
-            let tables = deck_stable_tables(&measurements, &fourier, &control_policy_artifacts);
-
             let (
                 output_plan_artifacts,
                 output_plan_artifact_table,
@@ -12344,7 +12384,9 @@ pub fn run_deck_analysis(
                 &control_policy_artifacts,
             );
             let run_artifact_table = format_deck_run_artifact_table(&run_artifacts);
+            let tables = deck_stable_tables(&measurements, &fourier, &control_policy_artifacts);
             let table_artifacts = deck_table_artifacts(
+                &plan,
                 &table,
                 &measurement_table,
                 &fourier_table,
@@ -12355,6 +12397,9 @@ pub fn run_deck_analysis(
                 &control_policy_artifact_table,
                 &control_policy_summary_artifacts,
                 &control_policy_summary_artifact_table,
+                &output_probes,
+                &output_directives,
+                &tables,
             );
             let rawfile_artifacts =
                 deck_rawfile_artifacts(&plan, &table, &write_markers, &rawfile_options);
@@ -12367,8 +12412,6 @@ pub fn run_deck_analysis(
             let wrdata_artifact_csv = format_deck_wrdata_artifact_csv(&wrdata_artifacts);
             let wrdata_artifact_json = format_deck_wrdata_artifact_json(&wrdata_artifacts);
             let wrdata_artifact_records = deck_wrdata_artifact_records(&wrdata_artifacts);
-            let tables = deck_stable_tables(&measurements, &fourier, &control_policy_artifacts);
-
             let (
                 output_plan_artifacts,
                 output_plan_artifact_table,
@@ -12486,7 +12529,9 @@ pub fn run_deck_analysis(
                 &control_policy_artifacts,
             );
             let run_artifact_table = format_deck_run_artifact_table(&run_artifacts);
+            let tables = deck_stable_tables(&measurements, &fourier, &control_policy_artifacts);
             let table_artifacts = deck_table_artifacts(
+                &plan,
                 &table,
                 &measurement_table,
                 &fourier_table,
@@ -12497,6 +12542,9 @@ pub fn run_deck_analysis(
                 &control_policy_artifact_table,
                 &control_policy_summary_artifacts,
                 &control_policy_summary_artifact_table,
+                &output_probes,
+                &output_directives,
+                &tables,
             );
             let rawfile_artifacts =
                 deck_rawfile_artifacts(&plan, &table, &write_markers, &rawfile_options);
@@ -12509,8 +12557,6 @@ pub fn run_deck_analysis(
             let wrdata_artifact_csv = format_deck_wrdata_artifact_csv(&wrdata_artifacts);
             let wrdata_artifact_json = format_deck_wrdata_artifact_json(&wrdata_artifacts);
             let wrdata_artifact_records = deck_wrdata_artifact_records(&wrdata_artifacts);
-            let tables = deck_stable_tables(&measurements, &fourier, &control_policy_artifacts);
-
             let (
                 output_plan_artifacts,
                 output_plan_artifact_table,

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -1923,10 +1923,14 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(op_execution.table, "Index\tV(mid)\n0\t5.000000e-01\n");
     assert_eq!(op_execution.output_directives, vec![".save".to_string()]);
     assert_eq!(op_execution.analysis_directives, vec![".op".to_string()]);
-    assert_eq!(op_execution.table_count, 2);
+    assert_eq!(op_execution.table_count, 3);
     assert_eq!(
         op_execution.tables,
-        vec!["result".to_string(), "run-artifact".to_string()]
+        vec![
+            "result".to_string(),
+            "output-plan".to_string(),
+            "run-artifact".to_string()
+        ]
     );
     assert_eq!(
         format_deck_table_csv(&op_execution.table),
@@ -1949,7 +1953,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
             .iter()
             .map(|artifact| artifact.name.as_str())
             .collect::<Vec<_>>(),
-        vec!["result", "run-artifact"]
+        vec!["result", "output-plan", "run-artifact"]
     );
     assert_eq!(op_execution.table_artifacts[0].table, op_execution.table);
     assert_eq!(
@@ -1979,11 +1983,15 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     );
     assert_eq!(
         output_plan_artifact.tables,
-        vec!["result".to_string(), "run-artifact".to_string()]
+        vec![
+            "result".to_string(),
+            "output-plan".to_string(),
+            "run-artifact".to_string()
+        ]
     );
     assert_eq!(
         op_execution.output_plan_artifact_table,
-        "Analysis\tDirective\tResultColumns\tResultColumnList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tTables\tTableList\nop\t.op\t2\tIndex;V(mid)\t1\tV(mid)\t1\t.save\t2\tresult;run-artifact\n"
+        "Analysis\tDirective\tResultColumns\tResultColumnList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tTables\tTableList\nop\t.op\t2\tIndex;V(mid)\t1\tV(mid)\t1\t.save\t3\tresult;output-plan;run-artifact\n"
     );
     assert_eq!(
         op_execution.output_plan_artifact_table,
@@ -1991,7 +1999,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     );
     assert_eq!(
         op_execution.output_plan_artifact_csv,
-        "Analysis,Directive,ResultColumns,ResultColumnList,OutputProbes,OutputProbeList,OutputDirectives,OutputDirectiveList,Tables,TableList\nop,.op,2,Index;V(mid),1,V(mid),1,.save,2,result;run-artifact\n"
+        "Analysis,Directive,ResultColumns,ResultColumnList,OutputProbes,OutputProbeList,OutputDirectives,OutputDirectiveList,Tables,TableList\nop,.op,2,Index;V(mid),1,V(mid),1,.save,3,result;output-plan;run-artifact\n"
     );
     assert_eq!(
         op_execution.output_plan_artifact_csv,
@@ -2021,7 +2029,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
         op_execution.output_plan_artifact_records[0]
             .get("TableList")
             .map(String::as_str),
-        Some("result;run-artifact")
+        Some("result;output-plan;run-artifact")
     );
     assert_eq!(op_execution.run_artifacts[0].result_rows, 1);
     assert_eq!(op_execution.run_artifacts[0].result_column_count, 2);
@@ -2029,10 +2037,14 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
         op_execution.run_artifacts[0].result_columns,
         vec!["Index".to_string(), "V(mid)".to_string()]
     );
-    assert_eq!(op_execution.run_artifacts[0].table_count, 2);
+    assert_eq!(op_execution.run_artifacts[0].table_count, 3);
     assert_eq!(
         op_execution.run_artifacts[0].tables,
-        vec!["result".to_string(), "run-artifact".to_string()]
+        vec![
+            "result".to_string(),
+            "output-plan".to_string(),
+            "run-artifact".to_string()
+        ]
     );
     assert_eq!(op_execution.run_artifacts[0].source_name, None);
     assert_eq!(op_execution.run_artifacts[0].output_node, None);
@@ -2064,7 +2076,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         op_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tControlPolicyArtifacts\tControlPolicyCategoryList\tControlPolicyCodeList\tControlPolicySeverityList\tDiagnostics\tDiagnosticCodeList\nop\t.op\t1\t.op\t{}\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t1\t2\tIndex;V(mid)\t2\tresult;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n",
+            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tControlPolicyArtifacts\tControlPolicyCategoryList\tControlPolicyCodeList\tControlPolicySeverityList\tDiagnostics\tDiagnosticCodeList\nop\t.op\t1\t.op\t{}\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t1\t2\tIndex;V(mid)\t3\tresult;output-plan;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n",
             op_execution.plan.line_number
         )
     );
@@ -2077,15 +2089,32 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
         format_deck_run_artifact_json(&op_execution.run_artifacts)
     );
     let artifact_records = deck_table_records(&op_execution.run_artifact_table);
+    assert_eq!(op_execution.table_artifacts[1].name.as_str(), "output-plan");
     assert_eq!(
-        op_execution.table_artifacts[1].name.as_str(),
+        op_execution.table_artifacts[1].table,
+        op_execution.output_plan_artifact_table
+    );
+    assert_eq!(
+        op_execution.table_artifacts[1].csv,
+        op_execution.output_plan_artifact_csv
+    );
+    assert_eq!(
+        op_execution.table_artifacts[1].json,
+        op_execution.output_plan_artifact_json
+    );
+    assert_eq!(
+        &op_execution.table_artifacts[1].records,
+        &op_execution.output_plan_artifact_records
+    );
+    assert_eq!(
+        op_execution.table_artifacts[2].name.as_str(),
         "run-artifact"
     );
     assert_eq!(
-        op_execution.table_artifacts[1].table,
+        op_execution.table_artifacts[2].table,
         op_execution.run_artifact_table
     );
-    assert_eq!(&op_execution.table_artifacts[1].records, &artifact_records);
+    assert_eq!(&op_execution.table_artifacts[2].records, &artifact_records);
     assert_eq!(artifact_records.len(), 1);
     assert_eq!(
         artifact_records[0].get("Analysis").map(String::as_str),
@@ -2099,7 +2128,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     );
     assert_eq!(
         artifact_records[0].get("TableList").map(String::as_str),
-        Some("result;run-artifact")
+        Some("result;output-plan;run-artifact")
     );
     assert_eq!(
         artifact_records[0]
@@ -2116,7 +2145,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         format_deck_run_artifact_csv(&op_execution.run_artifacts),
         format!(
-            "Analysis,Directive,AnalysisDirectives,AnalysisDirectiveList,Line,SourceName,OutputNode,SweepKind,StartValue,StopValue,StepValue,PointCount,StartFrequencyHz,StopFrequencyHz,StepTime,StopTime,StartTime,MaxStep,UseInitialConditions,ResultRows,ResultColumns,ResultColumnList,Tables,TableList,OutputProbes,OutputProbeList,OutputDirectives,OutputDirectiveList,Measurements,MeasurementList,Fourier,FourierList,ControlLines,ControlLineList,WriteMarkers,WriteMarkerList,RawfileOptions,RawfileOptionList,ControlPolicyArtifacts,ControlPolicyCategoryList,ControlPolicyCodeList,ControlPolicySeverityList,Diagnostics,DiagnosticCodeList\nop,.op,1,.op,{},,,,,,,,,,,,,,,1,2,Index;V(mid),2,result;run-artifact,1,V(mid),1,.save,0,,0,,0,,0,,0,,0,,,,0,\n",
+            "Analysis,Directive,AnalysisDirectives,AnalysisDirectiveList,Line,SourceName,OutputNode,SweepKind,StartValue,StopValue,StepValue,PointCount,StartFrequencyHz,StopFrequencyHz,StepTime,StopTime,StartTime,MaxStep,UseInitialConditions,ResultRows,ResultColumns,ResultColumnList,Tables,TableList,OutputProbes,OutputProbeList,OutputDirectives,OutputDirectiveList,Measurements,MeasurementList,Fourier,FourierList,ControlLines,ControlLineList,WriteMarkers,WriteMarkerList,RawfileOptions,RawfileOptionList,ControlPolicyArtifacts,ControlPolicyCategoryList,ControlPolicyCodeList,ControlPolicySeverityList,Diagnostics,DiagnosticCodeList\nop,.op,1,.op,{},,,,,,,,,,,,,,,1,2,Index;V(mid),3,result;output-plan;run-artifact,1,V(mid),1,.save,0,,0,,0,,0,,0,,0,,,,0,\n",
             op_execution.plan.line_number
         )
     );
@@ -2140,7 +2169,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
         op_execution.plan.line_number
     )));
     assert!(artifact_json.contains("\"ResultColumnList\":\"Index;V(mid)\""));
-    assert!(artifact_json.contains("\"TableList\":\"result;run-artifact\""));
+    assert!(artifact_json.contains("\"TableList\":\"result;output-plan;run-artifact\""));
     assert!(artifact_json.contains("\"OutputProbeList\":\"V(mid)\""));
     assert!(artifact_json.ends_with(
         "\"ControlLines\":\"0\",\"ControlLineList\":\"\",\"WriteMarkers\":\"0\",\"WriteMarkerList\":\"\",\"RawfileOptions\":\"0\",\"RawfileOptionList\":\"\",\"ControlPolicyArtifacts\":\"0\",\"ControlPolicyCategoryList\":\"\",\"ControlPolicyCodeList\":\"\",\"ControlPolicySeverityList\":\"\",\"Diagnostics\":\"0\",\"DiagnosticCodeList\":\"\"}]\n"
@@ -2189,12 +2218,13 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
         vec![".save".to_string(), ".probe".to_string()]
     );
     assert_eq!(dc_execution.analysis_directives, vec![".dc".to_string()]);
-    assert_eq!(dc_execution.table_count, 3);
+    assert_eq!(dc_execution.table_count, 4);
     assert_eq!(
         dc_execution.tables,
         vec![
             "result".to_string(),
             "measurement".to_string(),
+            "output-plan".to_string(),
             "run-artifact".to_string()
         ]
     );
@@ -2209,7 +2239,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
             .iter()
             .map(|artifact| artifact.name.as_str())
             .collect::<Vec<_>>(),
-        vec!["result", "measurement", "run-artifact"]
+        vec!["result", "measurement", "output-plan", "run-artifact"]
     );
     assert_eq!(
         dc_execution.table_artifacts[1].table,
@@ -2255,12 +2285,13 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
             "I(V1)".to_string()
         ]
     );
-    assert_eq!(dc_execution.run_artifacts[0].table_count, 3);
+    assert_eq!(dc_execution.run_artifacts[0].table_count, 4);
     assert_eq!(
         dc_execution.run_artifacts[0].tables,
         vec![
             "result".to_string(),
             "measurement".to_string(),
+            "output-plan".to_string(),
             "run-artifact".to_string()
         ]
     );
@@ -2286,7 +2317,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         dc_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tControlPolicyArtifacts\tControlPolicyCategoryList\tControlPolicyCodeList\tControlPolicySeverityList\tDiagnostics\tDiagnosticCodeList\ndc\t.dc\t1\t.dc\t{}\tV1\t\t\t0.000000e+00\t1.000000e+00\t1.000000e+00\t\t\t\t\t\t\t\t\t2\t5\tIndex;Source;Value;V(mid);I(V1)\t3\tresult;measurement;run-artifact\t2\tV(mid);I(V1)\t2\t.save;.probe\t1\tmid_avg\t0\t\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n",
+            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tControlPolicyArtifacts\tControlPolicyCategoryList\tControlPolicyCodeList\tControlPolicySeverityList\tDiagnostics\tDiagnosticCodeList\ndc\t.dc\t1\t.dc\t{}\tV1\t\t\t0.000000e+00\t1.000000e+00\t1.000000e+00\t\t\t\t\t\t\t\t\t2\t5\tIndex;Source;Value;V(mid);I(V1)\t4\tresult;measurement;output-plan;run-artifact\t2\tV(mid);I(V1)\t2\t.save;.probe\t1\tmid_avg\t0\t\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n",
             dc_execution.plan.line_number
         )
     );
@@ -2295,12 +2326,13 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(ac_execution.output_probes, vec!["V(mid)".to_string()]);
     assert_eq!(ac_execution.output_directives, vec![".save".to_string()]);
     assert_eq!(ac_execution.analysis_directives, vec![".ac".to_string()]);
-    assert_eq!(ac_execution.table_count, 3);
+    assert_eq!(ac_execution.table_count, 4);
     assert_eq!(
         ac_execution.tables,
         vec![
             "result".to_string(),
             "measurement".to_string(),
+            "output-plan".to_string(),
             "run-artifact".to_string()
         ]
     );
@@ -2346,12 +2378,13 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
             "Phase".to_string()
         ]
     );
-    assert_eq!(ac_execution.run_artifacts[0].table_count, 3);
+    assert_eq!(ac_execution.run_artifacts[0].table_count, 4);
     assert_eq!(
         ac_execution.run_artifacts[0].tables,
         vec![
             "result".to_string(),
             "measurement".to_string(),
+            "output-plan".to_string(),
             "run-artifact".to_string()
         ]
     );
@@ -2369,7 +2402,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         ac_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tControlPolicyArtifacts\tControlPolicyCategoryList\tControlPolicyCodeList\tControlPolicySeverityList\tDiagnostics\tDiagnosticCodeList\nac\t.ac\t1\t.ac\t{}\t\t\tdec\t\t\t\t1\t1.000000e+03\t1.000000e+03\t\t\t\t\t\t1\t7\tIndex;Frequency;Probe;Real;Imaginary;Magnitude;Phase\t3\tresult;measurement;run-artifact\t1\tV(mid)\t1\t.save\t1\tmid_peak\t0\t\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n",
+            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tControlPolicyArtifacts\tControlPolicyCategoryList\tControlPolicyCodeList\tControlPolicySeverityList\tDiagnostics\tDiagnosticCodeList\nac\t.ac\t1\t.ac\t{}\t\t\tdec\t\t\t\t1\t1.000000e+03\t1.000000e+03\t\t\t\t\t\t1\t7\tIndex;Frequency;Probe;Real;Imaginary;Magnitude;Phase\t4\tresult;measurement;output-plan;run-artifact\t1\tV(mid)\t1\t.save\t1\tmid_peak\t0\t\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n",
             ac_execution.plan.line_number
         )
     );
@@ -2381,12 +2414,13 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
         tran_execution.analysis_directives,
         vec![".tran".to_string()]
     );
-    assert_eq!(tran_execution.table_count, 3);
+    assert_eq!(tran_execution.table_count, 4);
     assert_eq!(
         tran_execution.tables,
         vec![
             "result".to_string(),
             "measurement".to_string(),
+            "output-plan".to_string(),
             "run-artifact".to_string()
         ]
     );
@@ -2420,12 +2454,13 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
             "V(mid)".to_string()
         ]
     );
-    assert_eq!(tran_execution.run_artifacts[0].table_count, 3);
+    assert_eq!(tran_execution.run_artifacts[0].table_count, 4);
     assert_eq!(
         tran_execution.run_artifacts[0].tables,
         vec![
             "result".to_string(),
             "measurement".to_string(),
+            "output-plan".to_string(),
             "run-artifact".to_string()
         ]
     );
@@ -2449,7 +2484,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         tran_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tControlPolicyArtifacts\tControlPolicyCategoryList\tControlPolicyCodeList\tControlPolicySeverityList\tDiagnostics\tDiagnosticCodeList\ntran\t.tran\t1\t.tran\t{}\t\t\t\t\t\t\t\t\t\t1.000000e-03\t1.000000e-03\t\t\tfalse\t1\t3\tIndex;Time;V(mid)\t3\tresult;measurement;run-artifact\t1\tV(mid)\t1\t.save\t1\tmid_final\t0\t\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n",
+            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tControlPolicyArtifacts\tControlPolicyCategoryList\tControlPolicyCodeList\tControlPolicySeverityList\tDiagnostics\tDiagnosticCodeList\ntran\t.tran\t1\t.tran\t{}\t\t\t\t\t\t\t\t\t\t1.000000e-03\t1.000000e-03\t\t\tfalse\t1\t3\tIndex;Time;V(mid)\t4\tresult;measurement;output-plan;run-artifact\t1\tV(mid)\t1\t.save\t1\tmid_final\t0\t\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n",
             tran_execution.plan.line_number
         )
     );
@@ -2468,10 +2503,14 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(tf_execution.output_probes, vec!["V(mid)".to_string()]);
     assert!(tf_execution.output_directives.is_empty());
     assert_eq!(tf_execution.analysis_directives, vec![".tf".to_string()]);
-    assert_eq!(tf_execution.table_count, 2);
+    assert_eq!(tf_execution.table_count, 3);
     assert_eq!(
         tf_execution.tables,
-        vec!["result".to_string(), "run-artifact".to_string()]
+        vec![
+            "result".to_string(),
+            "output-plan".to_string(),
+            "run-artifact".to_string()
+        ]
     );
     assert!(tf_execution.measurements.is_empty());
     assert_eq!(
@@ -2501,10 +2540,14 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
             "OutputImpedance".to_string()
         ]
     );
-    assert_eq!(tf_execution.run_artifacts[0].table_count, 2);
+    assert_eq!(tf_execution.run_artifacts[0].table_count, 3);
     assert_eq!(
         tf_execution.run_artifacts[0].tables,
-        vec!["result".to_string(), "run-artifact".to_string()]
+        vec![
+            "result".to_string(),
+            "output-plan".to_string(),
+            "run-artifact".to_string()
+        ]
     );
     assert_eq!(tf_execution.run_artifacts[0].step_time, None);
     assert_eq!(tf_execution.run_artifacts[0].use_initial_conditions, None);
@@ -2518,7 +2561,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         tf_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tControlPolicyArtifacts\tControlPolicyCategoryList\tControlPolicyCodeList\tControlPolicySeverityList\tDiagnostics\tDiagnosticCodeList\ntf\t.tf\t1\t.tf\t{}\tV1\tmid\t\t\t\t\t\t\t\t\t\t\t\t\t1\t3\tTransferRatio;InputImpedance;OutputImpedance\t2\tresult;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n",
+            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tControlPolicyArtifacts\tControlPolicyCategoryList\tControlPolicyCodeList\tControlPolicySeverityList\tDiagnostics\tDiagnosticCodeList\ntf\t.tf\t1\t.tf\t{}\tV1\tmid\t\t\t\t\t\t\t\t\t\t\t\t\t1\t3\tTransferRatio;InputImpedance;OutputImpedance\t3\tresult;output-plan;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n",
             tf_execution.plan.line_number
         )
     );
@@ -2538,10 +2581,14 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
         sens_execution.analysis_directives,
         vec![".sens".to_string()]
     );
-    assert_eq!(sens_execution.table_count, 2);
+    assert_eq!(sens_execution.table_count, 3);
     assert_eq!(
         sens_execution.tables,
-        vec!["result".to_string(), "run-artifact".to_string()]
+        vec![
+            "result".to_string(),
+            "output-plan".to_string(),
+            "run-artifact".to_string()
+        ]
     );
     assert!(sens_execution.measurements.is_empty());
     assert_eq!(
@@ -2571,10 +2618,14 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
             "RelativeSensitivity".to_string()
         ]
     );
-    assert_eq!(sens_execution.run_artifacts[0].table_count, 2);
+    assert_eq!(sens_execution.run_artifacts[0].table_count, 3);
     assert_eq!(
         sens_execution.run_artifacts[0].tables,
-        vec!["result".to_string(), "run-artifact".to_string()]
+        vec![
+            "result".to_string(),
+            "output-plan".to_string(),
+            "run-artifact".to_string()
+        ]
     );
     assert_eq!(sens_execution.run_artifacts[0].step_time, None);
     assert_eq!(sens_execution.run_artifacts[0].use_initial_conditions, None);
@@ -2588,7 +2639,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         sens_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tControlPolicyArtifacts\tControlPolicyCategoryList\tControlPolicyCodeList\tControlPolicySeverityList\tDiagnostics\tDiagnosticCodeList\nsens\t.sens\t1\t.sens\t{}\t\tmid\t\t\t\t\t\t\t\t\t\t\t\t\t1\t7\tOutputNode;NominalVoltage;Element;Parameter;NominalValue;Sensitivity;RelativeSensitivity\t2\tresult;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n",
+            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tControlPolicyArtifacts\tControlPolicyCategoryList\tControlPolicyCodeList\tControlPolicySeverityList\tDiagnostics\tDiagnosticCodeList\nsens\t.sens\t1\t.sens\t{}\t\tmid\t\t\t\t\t\t\t\t\t\t\t\t\t1\t7\tOutputNode;NominalVoltage;Element;Parameter;NominalValue;Sensitivity;RelativeSensitivity\t3\tresult;output-plan;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n",
             sens_execution.plan.line_number
         )
     );
@@ -2614,10 +2665,14 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
         noise_execution.analysis_directives,
         vec![".noise".to_string()]
     );
-    assert_eq!(noise_execution.table_count, 2);
+    assert_eq!(noise_execution.table_count, 3);
     assert_eq!(
         noise_execution.tables,
-        vec!["result".to_string(), "run-artifact".to_string()]
+        vec![
+            "result".to_string(),
+            "output-plan".to_string(),
+            "run-artifact".to_string()
+        ]
     );
     assert!(noise_execution.measurements.is_empty());
     assert_eq!(
@@ -2666,10 +2721,14 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
             "ContributionPSD".to_string()
         ]
     );
-    assert_eq!(noise_execution.run_artifacts[0].table_count, 2);
+    assert_eq!(noise_execution.run_artifacts[0].table_count, 3);
     assert_eq!(
         noise_execution.run_artifacts[0].tables,
-        vec!["result".to_string(), "run-artifact".to_string()]
+        vec![
+            "result".to_string(),
+            "output-plan".to_string(),
+            "run-artifact".to_string()
+        ]
     );
     assert_eq!(noise_execution.run_artifacts[0].step_time, None);
     assert_eq!(
@@ -2690,7 +2749,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         noise_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tControlPolicyArtifacts\tControlPolicyCategoryList\tControlPolicyCodeList\tControlPolicySeverityList\tDiagnostics\tDiagnosticCodeList\nnoise\t.noise\t1\t.noise\t{}\tV1\tmid\tlin\t\t\t\t1\t1.000000e+03\t1.000000e+03\t\t\t\t\t\t1\t10\tIndex;Frequency;OutputNode;InputSource;OutputPSD;InputReferredPSD;Element;Type;SourcePSD;ContributionPSD\t2\tresult;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n",
+            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tControlPolicyArtifacts\tControlPolicyCategoryList\tControlPolicyCodeList\tControlPolicySeverityList\tDiagnostics\tDiagnosticCodeList\nnoise\t.noise\t1\t.noise\t{}\tV1\tmid\tlin\t\t\t\t1\t1.000000e+03\t1.000000e+03\t\t\t\t\t\t1\t10\tIndex;Frequency;OutputNode;InputSource;OutputPSD;InputReferredPSD;Element;Type;SourcePSD;ContributionPSD\t3\tresult;output-plan;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n",
             noise_execution.plan.line_number
         )
     );
@@ -2736,15 +2795,23 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
             "V(mid)".to_string()
         ]
     );
-    assert_eq!(tran_window_execution.run_artifacts[0].table_count, 2);
+    assert_eq!(tran_window_execution.run_artifacts[0].table_count, 3);
     assert_eq!(
         tran_window_execution.run_artifacts[0].tables,
-        vec!["result".to_string(), "run-artifact".to_string()]
+        vec![
+            "result".to_string(),
+            "output-plan".to_string(),
+            "run-artifact".to_string()
+        ]
     );
-    assert_eq!(tran_window_execution.table_count, 2);
+    assert_eq!(tran_window_execution.table_count, 3);
     assert_eq!(
         tran_window_execution.tables,
-        vec!["result".to_string(), "run-artifact".to_string()]
+        vec![
+            "result".to_string(),
+            "output-plan".to_string(),
+            "run-artifact".to_string()
+        ]
     );
     assert_eq!(
         tran_window_execution.output_probes,
@@ -2767,7 +2834,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         tran_window_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tControlPolicyArtifacts\tControlPolicyCategoryList\tControlPolicyCodeList\tControlPolicySeverityList\tDiagnostics\tDiagnosticCodeList\ntran\t.tran\t1\t.tran\t{}\t\t\t\t\t\t\t\t\t\t2.000000e-03\t6.000000e-03\t2.000000e-03\t1.000000e-03\ttrue\t3\t3\tIndex;Time;V(mid)\t2\tresult;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n",
+            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tControlPolicyArtifacts\tControlPolicyCategoryList\tControlPolicyCodeList\tControlPolicySeverityList\tDiagnostics\tDiagnosticCodeList\ntran\t.tran\t1\t.tran\t{}\t\t\t\t\t\t\t\t\t\t2.000000e-03\t6.000000e-03\t2.000000e-03\t1.000000e-03\ttrue\t3\t3\tIndex;Time;V(mid)\t3\tresult;output-plan;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n",
             tran_window_execution.plan.line_number
         )
     );
@@ -2882,6 +2949,7 @@ let gain = 2
         "result".to_string(),
         "control-policy".to_string(),
         "control-policy-summary".to_string(),
+        "output-plan".to_string(),
         "run-artifact".to_string(),
     ];
     let table_list = expected_table_names.join(";");
@@ -3340,7 +3408,7 @@ let gain = 2
             .collect::<Vec<_>>(),
         expected_table_names
     );
-    let policy_table_artifact = &execution.table_artifacts[execution.table_artifacts.len() - 3];
+    let policy_table_artifact = &execution.table_artifacts[execution.table_artifacts.len() - 4];
     assert_eq!(policy_table_artifact.name, "control-policy");
     assert_eq!(
         policy_table_artifact.table,
@@ -3358,7 +3426,7 @@ let gain = 2
         policy_table_artifact.records,
         execution.control_policy_artifact_records
     );
-    let summary_table_artifact = &execution.table_artifacts[execution.table_artifacts.len() - 2];
+    let summary_table_artifact = &execution.table_artifacts[execution.table_artifacts.len() - 3];
     assert_eq!(summary_table_artifact.name, "control-policy-summary");
     assert_eq!(
         summary_table_artifact.table,
@@ -3375,6 +3443,25 @@ let gain = 2
     assert_eq!(
         summary_table_artifact.records,
         execution.control_policy_summary_artifact_records
+    );
+    let output_plan_table_artifact =
+        &execution.table_artifacts[execution.table_artifacts.len() - 2];
+    assert_eq!(output_plan_table_artifact.name, "output-plan");
+    assert_eq!(
+        output_plan_table_artifact.table,
+        execution.output_plan_artifact_table
+    );
+    assert_eq!(
+        output_plan_table_artifact.csv,
+        execution.output_plan_artifact_csv
+    );
+    assert_eq!(
+        output_plan_table_artifact.json,
+        execution.output_plan_artifact_json
+    );
+    assert_eq!(
+        output_plan_table_artifact.records,
+        execution.output_plan_artifact_records
     );
     assert_eq!(
         execution.run_artifacts[0].control_line_count,
@@ -3427,7 +3514,7 @@ let gain = 2
     );
     assert_eq!(execution.run_artifacts[0].diagnostic_codes, expected_codes);
     let records = deck_table_records(&execution.run_artifact_table);
-    assert_eq!(records[0].get("Tables").map(String::as_str), Some("4"));
+    assert_eq!(records[0].get("Tables").map(String::as_str), Some("5"));
     assert_eq!(
         records[0].get("TableList").map(String::as_str),
         Some(table_list.as_str())
@@ -3556,20 +3643,25 @@ fn run_deck_analysis_exposes_selected_fourier_artifacts() {
     let op_execution = run_deck_analysis(&circuit, netlist, Some("op")).unwrap();
     assert!(op_execution.fourier.is_empty());
     assert_eq!(op_execution.fourier_table, "");
-    assert_eq!(op_execution.table_count, 2);
+    assert_eq!(op_execution.table_count, 3);
     assert_eq!(
         op_execution.tables,
-        vec!["result".to_string(), "run-artifact".to_string()]
+        vec![
+            "result".to_string(),
+            "output-plan".to_string(),
+            "run-artifact".to_string()
+        ]
     );
 
     let tran_execution = run_deck_analysis(&circuit, netlist, Some("tran")).unwrap();
     assert_eq!(tran_execution.fourier.len(), 1);
-    assert_eq!(tran_execution.table_count, 3);
+    assert_eq!(tran_execution.table_count, 4);
     assert_eq!(
         tran_execution.tables,
         vec![
             "result".to_string(),
             "fourier".to_string(),
+            "output-plan".to_string(),
             "run-artifact".to_string()
         ]
     );
@@ -3579,7 +3671,7 @@ fn run_deck_analysis_exposes_selected_fourier_artifacts() {
             .iter()
             .map(|artifact| artifact.name.as_str())
             .collect::<Vec<_>>(),
-        vec!["result", "fourier", "run-artifact"]
+        vec!["result", "fourier", "output-plan", "run-artifact"]
     );
     let result = &tran_execution.fourier[0];
     assert!((result.fundamental_frequency_hz - 2_000.0).abs() < 1.0e-12);
@@ -3616,12 +3708,13 @@ fn run_deck_analysis_exposes_selected_fourier_artifacts() {
             "V(mid)".to_string()
         ]
     );
-    assert_eq!(tran_execution.run_artifacts[0].table_count, 3);
+    assert_eq!(tran_execution.run_artifacts[0].table_count, 4);
     assert_eq!(
         tran_execution.run_artifacts[0].tables,
         vec![
             "result".to_string(),
             "fourier".to_string(),
+            "output-plan".to_string(),
             "run-artifact".to_string()
         ]
     );
@@ -3647,7 +3740,7 @@ fn run_deck_analysis_exposes_selected_fourier_artifacts() {
     assert_eq!(
         tran_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tControlPolicyArtifacts\tControlPolicyCategoryList\tControlPolicyCodeList\tControlPolicySeverityList\tDiagnostics\tDiagnosticCodeList\ntran\t.tran\t1\t.tran\t{}\t\t\t\t\t\t\t\t\t\t5.000000e-04\t1.000000e-03\t\t\tfalse\t2\t3\tIndex;Time;V(mid)\t3\tresult;fourier;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n",
+            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tControlPolicyArtifacts\tControlPolicyCategoryList\tControlPolicyCodeList\tControlPolicySeverityList\tDiagnostics\tDiagnosticCodeList\ntran\t.tran\t1\t.tran\t{}\t\t\t\t\t\t\t\t\t\t5.000000e-04\t1.000000e-03\t\t\tfalse\t2\t3\tIndex;Time;V(mid)\t4\tresult;fourier;output-plan;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n",
             tran_execution.plan.line_number
         )
     );

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Include selected `runDeckAnalysis` output-plan tables in execution `tables`,
+  selected-run `TableList` metadata, and ordered `tableArtifacts` with stable
+  table, CSV, compact JSON, and header-keyed record payloads, matching Python
+  and Rust.
 - Expose selected `runDeckAnalysis` output-plan inventories as
   `outputPlanArtifacts` with stable result-column, output-probe,
   output-directive, and table lists plus table, CSV, compact JSON, and

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -99,8 +99,11 @@ Execution `outputPlanArtifacts` summarize the selected result columns, output
 probes, output directives, and stable table names with table, CSV, compact JSON,
 and header-keyed record exports.
 Execution `tableArtifacts` preserve the same order as `tables` and carry each
-stable table's text, CSV, compact JSON, and header-keyed records. Selected
-`.tran` plans route
+stable table's text, CSV, compact JSON, and header-keyed records.
+The `output-plan` entry in `tableArtifacts` carries the same
+`outputPlanArtifactTable` data, CSV, compact JSON, and header-keyed record
+exports.
+Selected `.tran` plans route
 `START` output filtering, `.tran TSTEP` as the output print grid, `MAXSTEP` as
 an internal fixed-step cap, and `UIC` initial-condition intent through that
 stable transient table surface. They also return selected `.four` harmonic

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -8157,6 +8157,7 @@ function deckStableTables(
   if (controlPolicyArtifacts.length > 0) {
     tables.push("control-policy", "control-policy-summary");
   }
+  tables.push("output-plan");
   tables.push("run-artifact");
   return tables;
 }
@@ -8491,6 +8492,7 @@ function deckTableArtifact(name: string, table: string): DeckTableArtifact {
 }
 
 function deckTableArtifacts(
+  plan: DeckAnalysisPlan,
   resultTable: string,
   measurementTable: string,
   fourierTable: string,
@@ -8501,6 +8503,9 @@ function deckTableArtifacts(
   controlPolicyArtifactTable: string,
   controlPolicySummaryArtifacts: readonly DeckControlPolicySummaryArtifact[],
   controlPolicySummaryArtifactTable: string,
+  outputProbes: readonly string[],
+  outputDirectives: readonly string[],
+  tables: readonly string[],
 ): DeckTableArtifact[] {
   const artifacts = [deckTableArtifact("result", resultTable)];
   if (measurements.length > 0) {
@@ -8517,6 +8522,14 @@ function deckTableArtifacts(
       deckTableArtifact("control-policy-summary", controlPolicySummaryArtifactTable),
     );
   }
+  const outputPlanArtifactTable = deckOutputPlanArtifactBundle(
+    plan,
+    resultTable,
+    outputProbes,
+    outputDirectives,
+    tables,
+  ).table;
+  artifacts.push(deckTableArtifact("output-plan", outputPlanArtifactTable));
   artifacts.push(deckTableArtifact("run-artifact", runArtifactTable));
   return artifacts;
 }
@@ -9195,6 +9208,7 @@ export function runDeckAnalysis(
     const fourierTable = formatDeckFourierTable(fourier);
     const runArtifactTable = formatDeckRunArtifactTable(runArtifacts);
     const tableArtifacts = deckTableArtifacts(
+      plan,
       table,
       measurementTable,
       fourierTable,
@@ -9205,6 +9219,9 @@ export function runDeckAnalysis(
       controlPolicyArtifactTable,
       controlPolicySummaryArtifacts,
       controlPolicySummaryArtifactTable,
+      outputProbes,
+      outputDirectives,
+      tables,
     );
     const rawfileArtifacts = deckRawfileArtifacts(plan, table, writeMarkers, rawfileOptions);
     const rawfileArtifactTable = formatDeckRawfileArtifactTable(rawfileArtifacts);
@@ -9314,6 +9331,7 @@ export function runDeckAnalysis(
     const fourierTable = formatDeckFourierTable(fourier);
     const runArtifactTable = formatDeckRunArtifactTable(runArtifacts);
     const tableArtifacts = deckTableArtifacts(
+      plan,
       table,
       measurementTable,
       fourierTable,
@@ -9324,6 +9342,9 @@ export function runDeckAnalysis(
       controlPolicyArtifactTable,
       controlPolicySummaryArtifacts,
       controlPolicySummaryArtifactTable,
+      outputProbes,
+      outputDirectives,
+      tables,
     );
     const rawfileArtifacts = deckRawfileArtifacts(plan, table, writeMarkers, rawfileOptions);
     const rawfileArtifactTable = formatDeckRawfileArtifactTable(rawfileArtifacts);
@@ -9444,6 +9465,7 @@ export function runDeckAnalysis(
     const fourierTable = formatDeckFourierTable(fourier);
     const runArtifactTable = formatDeckRunArtifactTable(runArtifacts);
     const tableArtifacts = deckTableArtifacts(
+      plan,
       table,
       measurementTable,
       fourierTable,
@@ -9454,6 +9476,9 @@ export function runDeckAnalysis(
       controlPolicyArtifactTable,
       controlPolicySummaryArtifacts,
       controlPolicySummaryArtifactTable,
+      outputProbes,
+      outputDirectives,
+      tables,
     );
     const rawfileArtifacts = deckRawfileArtifacts(plan, table, writeMarkers, rawfileOptions);
     const rawfileArtifactTable = formatDeckRawfileArtifactTable(rawfileArtifacts);
@@ -9569,6 +9594,7 @@ export function runDeckAnalysis(
     const fourierTable = formatDeckFourierTable(fourier);
     const runArtifactTable = formatDeckRunArtifactTable(runArtifacts);
     const tableArtifacts = deckTableArtifacts(
+      plan,
       table,
       measurementTable,
       fourierTable,
@@ -9579,6 +9605,9 @@ export function runDeckAnalysis(
       controlPolicyArtifactTable,
       controlPolicySummaryArtifacts,
       controlPolicySummaryArtifactTable,
+      outputProbes,
+      outputDirectives,
+      tables,
     );
     const rawfileArtifacts = deckRawfileArtifacts(plan, table, writeMarkers, rawfileOptions);
     const rawfileArtifactTable = formatDeckRawfileArtifactTable(rawfileArtifacts);
@@ -9684,6 +9713,7 @@ export function runDeckAnalysis(
     const fourierTable = formatDeckFourierTable(fourier);
     const runArtifactTable = formatDeckRunArtifactTable(runArtifacts);
     const tableArtifacts = deckTableArtifacts(
+      plan,
       table,
       measurementTable,
       fourierTable,
@@ -9694,6 +9724,9 @@ export function runDeckAnalysis(
       controlPolicyArtifactTable,
       controlPolicySummaryArtifacts,
       controlPolicySummaryArtifactTable,
+      outputProbes,
+      outputDirectives,
+      tables,
     );
     const rawfileArtifacts = deckRawfileArtifacts(plan, table, writeMarkers, rawfileOptions);
     const rawfileArtifactTable = formatDeckRawfileArtifactTable(rawfileArtifacts);
@@ -9798,6 +9831,7 @@ export function runDeckAnalysis(
     const fourierTable = formatDeckFourierTable(fourier);
     const runArtifactTable = formatDeckRunArtifactTable(runArtifacts);
     const tableArtifacts = deckTableArtifacts(
+      plan,
       table,
       measurementTable,
       fourierTable,
@@ -9808,6 +9842,9 @@ export function runDeckAnalysis(
       controlPolicyArtifactTable,
       controlPolicySummaryArtifacts,
       controlPolicySummaryArtifactTable,
+      outputProbes,
+      outputDirectives,
+      tables,
     );
     const rawfileArtifacts = deckRawfileArtifacts(plan, table, writeMarkers, rawfileOptions);
     const rawfileArtifactTable = formatDeckRawfileArtifactTable(rawfileArtifacts);
@@ -9922,6 +9959,7 @@ export function runDeckAnalysis(
     const fourierTable = formatDeckFourierTable(fourier);
     const runArtifactTable = formatDeckRunArtifactTable(runArtifacts);
     const tableArtifacts = deckTableArtifacts(
+      plan,
       table,
       measurementTable,
       fourierTable,
@@ -9932,6 +9970,9 @@ export function runDeckAnalysis(
       controlPolicyArtifactTable,
       controlPolicySummaryArtifacts,
       controlPolicySummaryArtifactTable,
+      outputProbes,
+      outputDirectives,
+      tables,
     );
     const rawfileArtifacts = deckRawfileArtifacts(plan, table, writeMarkers, rawfileOptions);
     const rawfileArtifactTable = formatDeckRawfileArtifactTable(rawfileArtifacts);

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -1514,8 +1514,8 @@ describe("transient", () => {
     expect(opExecution.outputProbes).toEqual(["V(mid)"]);
     expect(opExecution.outputDirectives).toEqual([".save"]);
     expect(opExecution.analysisDirectives).toEqual([".op"]);
-    expect(opExecution.tableCount).toBe(2);
-    expect(opExecution.tables).toEqual(["result", "run-artifact"]);
+    expect(opExecution.tableCount).toBe(3);
+    expect(opExecution.tables).toEqual(["result", "output-plan", "run-artifact"]);
     expect(opExecution.tableArtifacts.map((artifact) => artifact.name)).toEqual(
       opExecution.tables,
     );
@@ -1546,8 +1546,8 @@ describe("transient", () => {
         OutputProbeList: "V(mid)",
         OutputDirectives: "1",
         OutputDirectiveList: ".save",
-        Tables: "2",
-        TableList: "result;run-artifact",
+        Tables: "3",
+        TableList: "result;output-plan;run-artifact",
       },
     ];
     expect(opExecution.outputPlanArtifactCount).toBe(1);
@@ -1561,19 +1561,19 @@ describe("transient", () => {
       outputProbes: ["V(mid)"],
       outputDirectiveCount: 1,
       outputDirectives: [".save"],
-      tableCount: 2,
-      tables: ["result", "run-artifact"],
+      tableCount: 3,
+      tables: ["result", "output-plan", "run-artifact"],
     });
     expect(opExecution.outputPlanArtifactTable).toBe(
       "Analysis\tDirective\tResultColumns\tResultColumnList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tTables\tTableList\n" +
-        "op\t.op\t2\tIndex;V(mid)\t1\tV(mid)\t1\t.save\t2\tresult;run-artifact\n",
+        "op\t.op\t2\tIndex;V(mid)\t1\tV(mid)\t1\t.save\t3\tresult;output-plan;run-artifact\n",
     );
     expect(opExecution.outputPlanArtifactTable).toBe(
       formatDeckOutputPlanArtifactTable(opExecution.outputPlanArtifacts),
     );
     expect(opExecution.outputPlanArtifactCsv).toBe(
       "Analysis,Directive,ResultColumns,ResultColumnList,OutputProbes,OutputProbeList,OutputDirectives,OutputDirectiveList,Tables,TableList\n" +
-        "op,.op,2,Index;V(mid),1,V(mid),1,.save,2,result;run-artifact\n",
+        "op,.op,2,Index;V(mid),1,V(mid),1,.save,3,result;output-plan;run-artifact\n",
     );
     expect(opExecution.outputPlanArtifactCsv).toBe(
       formatDeckOutputPlanArtifactCsv(opExecution.outputPlanArtifacts),
@@ -1589,8 +1589,8 @@ describe("transient", () => {
     expect(opExecution.runArtifacts[0]?.resultRows).toBe(1);
     expect(opExecution.runArtifacts[0]?.resultColumnCount).toBe(2);
     expect(opExecution.runArtifacts[0]?.resultColumns).toEqual(["Index", "V(mid)"]);
-    expect(opExecution.runArtifacts[0]?.tableCount).toBe(2);
-    expect(opExecution.runArtifacts[0]?.tables).toEqual(["result", "run-artifact"]);
+    expect(opExecution.runArtifacts[0]?.tableCount).toBe(3);
+    expect(opExecution.runArtifacts[0]?.tables).toEqual(["result", "output-plan", "run-artifact"]);
     expect(opExecution.runArtifacts[0]?.sourceName).toBeUndefined();
     expect(opExecution.runArtifacts[0]?.outputNode).toBeUndefined();
     expect(opExecution.runArtifacts[0]?.sweepKind).toBeUndefined();
@@ -1611,11 +1611,18 @@ describe("transient", () => {
     expect(opExecution.runArtifacts[0]?.diagnosticCodes).toEqual([]);
     expect(opExecution.runArtifactTable).toBe(
       "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tControlPolicyArtifacts\tControlPolicyCategoryList\tControlPolicyCodeList\tControlPolicySeverityList\tDiagnostics\tDiagnosticCodeList\n" +
-        `op\t.op\t1\t.op\t${opExecution.plan.lineNumber}\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t1\t2\tIndex;V(mid)\t2\tresult;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n`,
+        `op\t.op\t1\t.op\t${opExecution.plan.lineNumber}\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t1\t2\tIndex;V(mid)\t3\tresult;output-plan;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n`,
     );
-    expect(opExecution.tableArtifacts[1]?.name).toBe("run-artifact");
-    expect(opExecution.tableArtifacts[1]?.table).toBe(opExecution.runArtifactTable);
+    expect(opExecution.tableArtifacts[1]?.name).toBe("output-plan");
+    expect(opExecution.tableArtifacts[1]?.table).toBe(opExecution.outputPlanArtifactTable);
+    expect(opExecution.tableArtifacts[1]?.csv).toBe(opExecution.outputPlanArtifactCsv);
+    expect(opExecution.tableArtifacts[1]?.json).toBe(opExecution.outputPlanArtifactJson);
     expect(opExecution.tableArtifacts[1]?.records).toEqual(
+      opExecution.outputPlanArtifactRecords,
+    );
+    expect(opExecution.tableArtifacts[2]?.name).toBe("run-artifact");
+    expect(opExecution.tableArtifacts[2]?.table).toBe(opExecution.runArtifactTable);
+    expect(opExecution.tableArtifacts[2]?.records).toEqual(
       deckTableRecords(opExecution.runArtifactTable),
     );
     expect(formatDeckTableCsv(opExecution.runArtifactTable)).toBe(
@@ -1629,7 +1636,7 @@ describe("transient", () => {
     );
     expect(formatDeckRunArtifactCsv(opExecution.runArtifacts)).toBe(
       "Analysis,Directive,AnalysisDirectives,AnalysisDirectiveList,Line,SourceName,OutputNode,SweepKind,StartValue,StopValue,StepValue,PointCount,StartFrequencyHz,StopFrequencyHz,StepTime,StopTime,StartTime,MaxStep,UseInitialConditions,ResultRows,ResultColumns,ResultColumnList,Tables,TableList,OutputProbes,OutputProbeList,OutputDirectives,OutputDirectiveList,Measurements,MeasurementList,Fourier,FourierList,ControlLines,ControlLineList,WriteMarkers,WriteMarkerList,RawfileOptions,RawfileOptionList,ControlPolicyArtifacts,ControlPolicyCategoryList,ControlPolicyCodeList,ControlPolicySeverityList,Diagnostics,DiagnosticCodeList\n" +
-        `op,.op,1,.op,${opExecution.plan.lineNumber},,,,,,,,,,,,,,,1,2,Index;V(mid),2,result;run-artifact,1,V(mid),1,.save,0,,0,,0,,0,,0,,0,,,,0,\n`,
+        `op,.op,1,.op,${opExecution.plan.lineNumber},,,,,,,,,,,,,,,1,2,Index;V(mid),3,result;output-plan;run-artifact,1,V(mid),1,.save,0,,0,,0,,0,,0,,0,,,,0,\n`,
     );
     expect(formatDeckTableCsv('Name\tValue\nprobe\tSPICE,"QUOTED"\n')).toBe(
       'Name,Value\nprobe,"SPICE,""QUOTED"""\n',
@@ -1712,8 +1719,8 @@ describe("transient", () => {
         ResultRows: "1",
         ResultColumns: "2",
         ResultColumnList: "Index;V(mid)",
-        Tables: "2",
-        TableList: "result;run-artifact",
+        Tables: "3",
+        TableList: "result;output-plan;run-artifact",
         OutputProbes: "1",
         OutputProbeList: "V(mid)",
         OutputDirectives: "1",
@@ -1767,8 +1774,8 @@ describe("transient", () => {
     expect(dcExecution.outputProbes).toEqual(["V(mid)", "I(V1)"]);
     expect(dcExecution.outputDirectives).toEqual([".save", ".probe"]);
     expect(dcExecution.analysisDirectives).toEqual([".dc"]);
-    expect(dcExecution.tableCount).toBe(3);
-    expect(dcExecution.tables).toEqual(["result", "measurement", "run-artifact"]);
+    expect(dcExecution.tableCount).toBe(4);
+    expect(dcExecution.tables).toEqual(["result", "measurement", "output-plan", "run-artifact"]);
     expect(dcExecution.tableArtifacts.map((artifact) => artifact.name)).toEqual(
       dcExecution.tables,
     );
@@ -1804,10 +1811,11 @@ describe("transient", () => {
       "V(mid)",
       "I(V1)",
     ]);
-    expect(dcExecution.runArtifacts[0]?.tableCount).toBe(3);
+    expect(dcExecution.runArtifacts[0]?.tableCount).toBe(4);
     expect(dcExecution.runArtifacts[0]?.tables).toEqual([
       "result",
       "measurement",
+      "output-plan",
       "run-artifact",
     ]);
     expect(dcExecution.runArtifacts[0]?.stepTime).toBeUndefined();
@@ -1819,15 +1827,15 @@ describe("transient", () => {
     expect(dcExecution.runArtifacts[0]?.fourierProbes).toEqual([]);
     expect(dcExecution.runArtifactTable).toBe(
       "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tControlPolicyArtifacts\tControlPolicyCategoryList\tControlPolicyCodeList\tControlPolicySeverityList\tDiagnostics\tDiagnosticCodeList\n" +
-        `dc\t.dc\t1\t.dc\t${dcExecution.plan.lineNumber}\tV1\t\t\t0.000000e+00\t1.000000e+00\t1.000000e+00\t\t\t\t\t\t\t\t\t2\t5\tIndex;Source;Value;V(mid);I(V1)\t3\tresult;measurement;run-artifact\t2\tV(mid);I(V1)\t2\t.save;.probe\t1\tmid_avg\t0\t\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n`,
+        `dc\t.dc\t1\t.dc\t${dcExecution.plan.lineNumber}\tV1\t\t\t0.000000e+00\t1.000000e+00\t1.000000e+00\t\t\t\t\t\t\t\t\t2\t5\tIndex;Source;Value;V(mid);I(V1)\t4\tresult;measurement;output-plan;run-artifact\t2\tV(mid);I(V1)\t2\t.save;.probe\t1\tmid_avg\t0\t\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n`,
     );
 
     const acExecution = runDeckAnalysis(circuit, netlist, "ac");
     expect(acExecution.outputProbes).toEqual(["V(mid)"]);
     expect(acExecution.outputDirectives).toEqual([".save"]);
     expect(acExecution.analysisDirectives).toEqual([".ac"]);
-    expect(acExecution.tableCount).toBe(3);
-    expect(acExecution.tables).toEqual(["result", "measurement", "run-artifact"]);
+    expect(acExecution.tableCount).toBe(4);
+    expect(acExecution.tables).toEqual(["result", "measurement", "output-plan", "run-artifact"]);
     expect(acExecution.measurements.map((measurement) => measurement.name)).toEqual(["mid_peak"]);
     expect(acExecution.measurementTable).toBe(
       "Name\tAnalysis\tProbe\tMode\tFrom\tTo\tValue\n" +
@@ -1855,10 +1863,11 @@ describe("transient", () => {
       "Magnitude",
       "Phase",
     ]);
-    expect(acExecution.runArtifacts[0]?.tableCount).toBe(3);
+    expect(acExecution.runArtifacts[0]?.tableCount).toBe(4);
     expect(acExecution.runArtifacts[0]?.tables).toEqual([
       "result",
       "measurement",
+      "output-plan",
       "run-artifact",
     ]);
     expect(acExecution.runArtifacts[0]?.stepTime).toBeUndefined();
@@ -1868,15 +1877,15 @@ describe("transient", () => {
     expect(acExecution.runArtifacts[0]?.fourierProbes).toEqual([]);
     expect(acExecution.runArtifactTable).toBe(
       "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tControlPolicyArtifacts\tControlPolicyCategoryList\tControlPolicyCodeList\tControlPolicySeverityList\tDiagnostics\tDiagnosticCodeList\n" +
-        `ac\t.ac\t1\t.ac\t${acExecution.plan.lineNumber}\t\t\tdec\t\t\t\t1\t1.000000e+03\t1.000000e+03\t\t\t\t\t\t1\t7\tIndex;Frequency;Probe;Real;Imaginary;Magnitude;Phase\t3\tresult;measurement;run-artifact\t1\tV(mid)\t1\t.save\t1\tmid_peak\t0\t\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n`,
+        `ac\t.ac\t1\t.ac\t${acExecution.plan.lineNumber}\t\t\tdec\t\t\t\t1\t1.000000e+03\t1.000000e+03\t\t\t\t\t\t1\t7\tIndex;Frequency;Probe;Real;Imaginary;Magnitude;Phase\t4\tresult;measurement;output-plan;run-artifact\t1\tV(mid)\t1\t.save\t1\tmid_peak\t0\t\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n`,
     );
 
     const tranExecution = runDeckAnalysis(circuit, netlist, "tran");
     expect(tranExecution.outputProbes).toEqual(["V(mid)"]);
     expect(tranExecution.outputDirectives).toEqual([".save"]);
     expect(tranExecution.analysisDirectives).toEqual([".tran"]);
-    expect(tranExecution.tableCount).toBe(3);
-    expect(tranExecution.tables).toEqual(["result", "measurement", "run-artifact"]);
+    expect(tranExecution.tableCount).toBe(4);
+    expect(tranExecution.tables).toEqual(["result", "measurement", "output-plan", "run-artifact"]);
     expect(tranExecution.measurements.map((measurement) => measurement.name)).toEqual(["mid_final"]);
     expect(tranExecution.measurementTable).toBe(
       "Name\tAnalysis\tProbe\tMode\tFrom\tTo\tValue\n" +
@@ -1894,10 +1903,11 @@ describe("transient", () => {
     expect(tranExecution.runArtifacts[0]?.stopTime).toBeCloseTo(1.0e-3, 12);
     expect(tranExecution.runArtifacts[0]?.resultColumnCount).toBe(3);
     expect(tranExecution.runArtifacts[0]?.resultColumns).toEqual(["Index", "Time", "V(mid)"]);
-    expect(tranExecution.runArtifacts[0]?.tableCount).toBe(3);
+    expect(tranExecution.runArtifacts[0]?.tableCount).toBe(4);
     expect(tranExecution.runArtifacts[0]?.tables).toEqual([
       "result",
       "measurement",
+      "output-plan",
       "run-artifact",
     ]);
     expect(tranExecution.runArtifacts[0]?.startTime).toBeUndefined();
@@ -1910,7 +1920,7 @@ describe("transient", () => {
     expect(tranExecution.runArtifacts[0]?.diagnosticCodes).toEqual([]);
     expect(tranExecution.runArtifactTable).toBe(
       "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tControlPolicyArtifacts\tControlPolicyCategoryList\tControlPolicyCodeList\tControlPolicySeverityList\tDiagnostics\tDiagnosticCodeList\n" +
-        `tran\t.tran\t1\t.tran\t${tranExecution.plan.lineNumber}\t\t\t\t\t\t\t\t\t\t1.000000e-03\t1.000000e-03\t\t\tfalse\t1\t3\tIndex;Time;V(mid)\t3\tresult;measurement;run-artifact\t1\tV(mid)\t1\t.save\t1\tmid_final\t0\t\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n`,
+        `tran\t.tran\t1\t.tran\t${tranExecution.plan.lineNumber}\t\t\t\t\t\t\t\t\t\t1.000000e-03\t1.000000e-03\t\t\tfalse\t1\t3\tIndex;Time;V(mid)\t4\tresult;measurement;output-plan;run-artifact\t1\tV(mid)\t1\t.save\t1\tmid_final\t0\t\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n`,
     );
 
     const tfExecution = runDeckAnalysis(circuit, netlist, "tf");
@@ -1927,8 +1937,8 @@ describe("transient", () => {
     expect(tfExecution.outputProbes).toEqual(["V(mid)"]);
     expect(tfExecution.outputDirectives).toEqual([]);
     expect(tfExecution.analysisDirectives).toEqual([".tf"]);
-    expect(tfExecution.tableCount).toBe(2);
-    expect(tfExecution.tables).toEqual(["result", "run-artifact"]);
+    expect(tfExecution.tableCount).toBe(3);
+    expect(tfExecution.tables).toEqual(["result", "output-plan", "run-artifact"]);
     expect(tfExecution.measurements).toEqual([]);
     expect(tfExecution.measurementTable).toBe("Name\tAnalysis\tProbe\tMode\tFrom\tTo\tValue\n");
     expect(tfExecution.table).toBe(
@@ -1945,8 +1955,8 @@ describe("transient", () => {
       "InputImpedance",
       "OutputImpedance",
     ]);
-    expect(tfExecution.runArtifacts[0]?.tableCount).toBe(2);
-    expect(tfExecution.runArtifacts[0]?.tables).toEqual(["result", "run-artifact"]);
+    expect(tfExecution.runArtifacts[0]?.tableCount).toBe(3);
+    expect(tfExecution.runArtifacts[0]?.tables).toEqual(["result", "output-plan", "run-artifact"]);
     expect(tfExecution.runArtifacts[0]?.stepTime).toBeUndefined();
     expect(tfExecution.runArtifacts[0]?.useInitialConditions).toBeUndefined();
     expect(tfExecution.runArtifacts[0]?.outputProbes).toEqual(["V(mid)"]);
@@ -1955,7 +1965,7 @@ describe("transient", () => {
     expect(tfExecution.runArtifacts[0]?.fourierProbes).toEqual([]);
     expect(tfExecution.runArtifactTable).toBe(
       "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tControlPolicyArtifacts\tControlPolicyCategoryList\tControlPolicyCodeList\tControlPolicySeverityList\tDiagnostics\tDiagnosticCodeList\n" +
-        `tf\t.tf\t1\t.tf\t${tfExecution.plan.lineNumber}\tV1\tmid\t\t\t\t\t\t\t\t\t\t\t\t\t1\t3\tTransferRatio;InputImpedance;OutputImpedance\t2\tresult;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n`,
+        `tf\t.tf\t1\t.tf\t${tfExecution.plan.lineNumber}\tV1\tmid\t\t\t\t\t\t\t\t\t\t\t\t\t1\t3\tTransferRatio;InputImpedance;OutputImpedance\t3\tresult;output-plan;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n`,
     );
 
     const sensExecution = runDeckAnalysis(circuit, netlist, "sens");
@@ -1969,8 +1979,8 @@ describe("transient", () => {
     expect(sensResult.entries).toHaveLength(3);
     expect(sensExecution.outputProbes).toEqual(["V(mid)"]);
     expect(sensExecution.analysisDirectives).toEqual([".sens"]);
-    expect(sensExecution.tableCount).toBe(2);
-    expect(sensExecution.tables).toEqual(["result", "run-artifact"]);
+    expect(sensExecution.tableCount).toBe(3);
+    expect(sensExecution.tables).toEqual(["result", "output-plan", "run-artifact"]);
     expect(sensExecution.measurements).toEqual([]);
     expect(sensExecution.measurementTable).toBe("Name\tAnalysis\tProbe\tMode\tFrom\tTo\tValue\n");
     expect(sensExecution.table.startsWith(
@@ -1990,8 +2000,8 @@ describe("transient", () => {
       "Sensitivity",
       "RelativeSensitivity",
     ]);
-    expect(sensExecution.runArtifacts[0]?.tableCount).toBe(2);
-    expect(sensExecution.runArtifacts[0]?.tables).toEqual(["result", "run-artifact"]);
+    expect(sensExecution.runArtifacts[0]?.tableCount).toBe(3);
+    expect(sensExecution.runArtifacts[0]?.tables).toEqual(["result", "output-plan", "run-artifact"]);
     expect(sensExecution.runArtifacts[0]?.stepTime).toBeUndefined();
     expect(sensExecution.runArtifacts[0]?.useInitialConditions).toBeUndefined();
     expect(sensExecution.runArtifacts[0]?.outputProbes).toEqual(["V(mid)"]);
@@ -2000,7 +2010,7 @@ describe("transient", () => {
     expect(sensExecution.runArtifacts[0]?.fourierProbes).toEqual([]);
     expect(sensExecution.runArtifactTable).toBe(
       "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tControlPolicyArtifacts\tControlPolicyCategoryList\tControlPolicyCodeList\tControlPolicySeverityList\tDiagnostics\tDiagnosticCodeList\n" +
-        `sens\t.sens\t1\t.sens\t${sensExecution.plan.lineNumber}\t\tmid\t\t\t\t\t\t\t\t\t\t\t\t\t1\t7\tOutputNode;NominalVoltage;Element;Parameter;NominalValue;Sensitivity;RelativeSensitivity\t2\tresult;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n`,
+        `sens\t.sens\t1\t.sens\t${sensExecution.plan.lineNumber}\t\tmid\t\t\t\t\t\t\t\t\t\t\t\t\t1\t7\tOutputNode;NominalVoltage;Element;Parameter;NominalValue;Sensitivity;RelativeSensitivity\t3\tresult;output-plan;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n`,
     );
 
     const noiseExecution = runDeckAnalysis(circuit, netlist, "noise");
@@ -2016,8 +2026,8 @@ describe("transient", () => {
     expect(noiseResult.points).toHaveLength(1);
     expect(noiseExecution.outputProbes).toEqual(["V(mid)"]);
     expect(noiseExecution.analysisDirectives).toEqual([".noise"]);
-    expect(noiseExecution.tableCount).toBe(2);
-    expect(noiseExecution.tables).toEqual(["result", "run-artifact"]);
+    expect(noiseExecution.tableCount).toBe(3);
+    expect(noiseExecution.tables).toEqual(["result", "output-plan", "run-artifact"]);
     expect(noiseExecution.measurements).toEqual([]);
     expect(noiseExecution.measurementTable).toBe("Name\tAnalysis\tProbe\tMode\tFrom\tTo\tValue\n");
     expect(noiseExecution.table).toBe(formatDeckNoiseTable(noiseResult));
@@ -2045,8 +2055,8 @@ describe("transient", () => {
       "SourcePSD",
       "ContributionPSD",
     ]);
-    expect(noiseExecution.runArtifacts[0]?.tableCount).toBe(2);
-    expect(noiseExecution.runArtifacts[0]?.tables).toEqual(["result", "run-artifact"]);
+    expect(noiseExecution.runArtifacts[0]?.tableCount).toBe(3);
+    expect(noiseExecution.runArtifacts[0]?.tables).toEqual(["result", "output-plan", "run-artifact"]);
     expect(noiseExecution.runArtifacts[0]?.stepTime).toBeUndefined();
     expect(noiseExecution.runArtifacts[0]?.useInitialConditions).toBeUndefined();
     expect(noiseExecution.runArtifacts[0]?.outputProbes).toEqual(["V(mid)"]);
@@ -2055,7 +2065,7 @@ describe("transient", () => {
     expect(noiseExecution.runArtifacts[0]?.fourierProbes).toEqual([]);
     expect(noiseExecution.runArtifactTable).toBe(
       "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tControlPolicyArtifacts\tControlPolicyCategoryList\tControlPolicyCodeList\tControlPolicySeverityList\tDiagnostics\tDiagnosticCodeList\n" +
-        `noise\t.noise\t1\t.noise\t${noiseExecution.plan.lineNumber}\tV1\tmid\tlin\t\t\t\t1\t1.000000e+03\t1.000000e+03\t\t\t\t\t\t1\t10\tIndex;Frequency;OutputNode;InputSource;OutputPSD;InputReferredPSD;Element;Type;SourcePSD;ContributionPSD\t2\tresult;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n`,
+        `noise\t.noise\t1\t.noise\t${noiseExecution.plan.lineNumber}\tV1\tmid\tlin\t\t\t\t1\t1.000000e+03\t1.000000e+03\t\t\t\t\t\t1\t10\tIndex;Frequency;OutputNode;InputSource;OutputPSD;InputReferredPSD;Element;Type;SourcePSD;ContributionPSD\t3\tresult;output-plan;run-artifact\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n`,
     );
 
     const tranWindowExecution = runDeckAnalysis(
@@ -2072,13 +2082,14 @@ describe("transient", () => {
     expect(tranWindowExecution.runArtifacts[0]?.useInitialConditions).toBe(true);
     expect(tranWindowExecution.runArtifacts[0]?.resultColumnCount).toBe(3);
     expect(tranWindowExecution.runArtifacts[0]?.resultColumns).toEqual(["Index", "Time", "V(mid)"]);
-    expect(tranWindowExecution.runArtifacts[0]?.tableCount).toBe(2);
+    expect(tranWindowExecution.runArtifacts[0]?.tableCount).toBe(3);
     expect(tranWindowExecution.runArtifacts[0]?.tables).toEqual([
       "result",
+      "output-plan",
       "run-artifact",
     ]);
-    expect(tranWindowExecution.tableCount).toBe(2);
-    expect(tranWindowExecution.tables).toEqual(["result", "run-artifact"]);
+    expect(tranWindowExecution.tableCount).toBe(3);
+    expect(tranWindowExecution.tables).toEqual(["result", "output-plan", "run-artifact"]);
     expect(tranWindowExecution.outputProbes).toEqual(["V(mid)"]);
     const tranWindowPoints = tranWindowExecution.result as { time: number }[];
     expect(tranWindowPoints).toHaveLength(3);
@@ -2097,7 +2108,7 @@ describe("transient", () => {
     );
     expect(tranWindowExecution.runArtifactTable).toBe(
       "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tControlPolicyArtifacts\tControlPolicyCategoryList\tControlPolicyCodeList\tControlPolicySeverityList\tDiagnostics\tDiagnosticCodeList\n" +
-        `tran\t.tran\t1\t.tran\t${tranWindowExecution.plan.lineNumber}\t\t\t\t\t\t\t\t\t\t2.000000e-03\t6.000000e-03\t2.000000e-03\t1.000000e-03\ttrue\t3\t3\tIndex;Time;V(mid)\t2\tresult;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n`,
+        `tran\t.tran\t1\t.tran\t${tranWindowExecution.plan.lineNumber}\t\t\t\t\t\t\t\t\t\t2.000000e-03\t6.000000e-03\t2.000000e-03\t1.000000e-03\ttrue\t3\t3\tIndex;Time;V(mid)\t3\tresult;output-plan;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t0\t\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n`,
     );
 
     expect(() => runDeckAnalysis(circuit, netlist)).toThrow(/multiple analysis cards/);
@@ -2185,6 +2196,7 @@ let gain = 2
       "result",
       "control-policy",
       "control-policy-summary",
+      "output-plan",
       "run-artifact",
     ];
 
@@ -2370,13 +2382,13 @@ let gain = 2
     expect(execution.tableArtifacts.map((artifact) => artifact.name)).toEqual(
       expectedTableNames,
     );
-    const policyTableArtifact = execution.tableArtifacts.at(-3)!;
+    const policyTableArtifact = execution.tableArtifacts.at(-4)!;
     expect(policyTableArtifact.name).toBe("control-policy");
     expect(policyTableArtifact.table).toBe(execution.controlPolicyArtifactTable);
     expect(policyTableArtifact.csv).toBe(execution.controlPolicyArtifactCsv);
     expect(policyTableArtifact.json).toBe(execution.controlPolicyArtifactJson);
     expect(policyTableArtifact.records).toEqual(execution.controlPolicyArtifactRecords);
-    const summaryTableArtifact = execution.tableArtifacts.at(-2)!;
+    const summaryTableArtifact = execution.tableArtifacts.at(-3)!;
     expect(summaryTableArtifact.name).toBe("control-policy-summary");
     expect(summaryTableArtifact.table).toBe(execution.controlPolicySummaryArtifactTable);
     expect(summaryTableArtifact.csv).toBe(execution.controlPolicySummaryArtifactCsv);
@@ -2384,6 +2396,12 @@ let gain = 2
     expect(summaryTableArtifact.records).toEqual(
       execution.controlPolicySummaryArtifactRecords,
     );
+    const outputPlanTableArtifact = execution.tableArtifacts.at(-2)!;
+    expect(outputPlanTableArtifact.name).toBe("output-plan");
+    expect(outputPlanTableArtifact.table).toBe(execution.outputPlanArtifactTable);
+    expect(outputPlanTableArtifact.csv).toBe(execution.outputPlanArtifactCsv);
+    expect(outputPlanTableArtifact.json).toBe(execution.outputPlanArtifactJson);
+    expect(outputPlanTableArtifact.records).toEqual(execution.outputPlanArtifactRecords);
     expect(execution.runArtifacts[0]?.controlLineCount).toBe(expectedControlLines.length);
     expect(execution.runArtifacts[0]?.controlLines).toEqual(expectedControlLines);
     expect(execution.runArtifacts[0]?.writeMarkerCount).toBe(expectedWriteMarkers.length);
@@ -2446,13 +2464,13 @@ let gain = 2
     const opExecution = runDeckAnalysis(circuit, netlist, "op");
     expect(opExecution.fourier).toEqual([]);
     expect(opExecution.fourierTable).toBe("");
-    expect(opExecution.tableCount).toBe(2);
-    expect(opExecution.tables).toEqual(["result", "run-artifact"]);
+    expect(opExecution.tableCount).toBe(3);
+    expect(opExecution.tables).toEqual(["result", "output-plan", "run-artifact"]);
 
     const tranExecution = runDeckAnalysis(circuit, netlist, "tran");
     expect(tranExecution.fourier).toHaveLength(1);
-    expect(tranExecution.tableCount).toBe(3);
-    expect(tranExecution.tables).toEqual(["result", "fourier", "run-artifact"]);
+    expect(tranExecution.tableCount).toBe(4);
+    expect(tranExecution.tables).toEqual(["result", "fourier", "output-plan", "run-artifact"]);
     expect(tranExecution.tableArtifacts.map((artifact) => artifact.name)).toEqual(
       tranExecution.tables,
     );
@@ -2475,10 +2493,11 @@ let gain = 2
     expect(tranExecution.runArtifacts[0]?.stopTime).toBeCloseTo(1.0e-3, 12);
     expect(tranExecution.runArtifacts[0]?.resultColumnCount).toBe(3);
     expect(tranExecution.runArtifacts[0]?.resultColumns).toEqual(["Index", "Time", "V(mid)"]);
-    expect(tranExecution.runArtifacts[0]?.tableCount).toBe(3);
+    expect(tranExecution.runArtifacts[0]?.tableCount).toBe(4);
     expect(tranExecution.runArtifacts[0]?.tables).toEqual([
       "result",
       "fourier",
+      "output-plan",
       "run-artifact",
     ]);
     expect(tranExecution.runArtifacts[0]?.startTime).toBeUndefined();
@@ -2490,7 +2509,7 @@ let gain = 2
     expect(tranExecution.runArtifacts[0]?.fourierProbes).toEqual(["V(mid)"]);
     expect(tranExecution.runArtifactTable).toBe(
       "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tControlPolicyArtifacts\tControlPolicyCategoryList\tControlPolicyCodeList\tControlPolicySeverityList\tDiagnostics\tDiagnosticCodeList\n" +
-        `tran\t.tran\t1\t.tran\t${tranExecution.plan.lineNumber}\t\t\t\t\t\t\t\t\t\t5.000000e-04\t1.000000e-03\t\t\tfalse\t2\t3\tIndex;Time;V(mid)\t3\tresult;fourier;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n`,
+        `tran\t.tran\t1\t.tran\t${tranExecution.plan.lineNumber}\t\t\t\t\t\t\t\t\t\t5.000000e-04\t1.000000e-03\t\t\tfalse\t2\t3\tIndex;Time;V(mid)\t4\tresult;fourier;output-plan;run-artifact\t1\tV(mid)\t1\t.save\t0\t\t1\tV(mid)\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n`,
     );
   });
 

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -1143,13 +1143,21 @@ downstream tools to compare.
       host and browser integrations audit the output plan without reparsing
       selected result tables or selected-run artifact rows.
 
+105. Deck output-plan table export artifacts.
+    - Status: completed in this deck output-plan table export artifact slice.
+    - Python, Rust, and TypeScript selected executions now include
+      `output-plan` in stable table inventories and selected-run `TableList`
+      metadata.
+    - Ordered table export artifacts now carry the output-plan table with
+      stable table, CSV, compact JSON, and host-native record payloads beside
+      result, optional side tables, and selected-run artifact exports.
+
 ## Backlog
 
 1. Deck execution layer.
    - Expand selected-plan execution beyond fixed-step transient basics,
      including richer deck-owned run artifacts beyond selected table inventory, output,
-     output-directive, measurement, Fourier, and transfer-function probe lists,
-     plus output-plan integration beyond stable table routing.
+     output-directive, measurement, Fourier, and transfer-function probe lists.
    - Expand deck-controlled output-plan integration beyond stable table
      routing and scoped `.save`, `.probe`, `.print`, `.plot`, and `.four`
      selection toward full SPICE compatibility.


### PR DESCRIPTION
## Summary
- include the selected output-plan table in stable execution table inventories and selected-run TableList metadata
- add ordered output-plan table artifacts with table, CSV, JSON, and record payloads across Python, Rust, and TypeScript
- update package docs/changelogs and mark the SPICE plan item complete

## Verification
- PYTHONPATH=... /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python -m ruff check src tests
- PYTHONPATH=... /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python -m pytest
- cargo fmt -p spice-engine -- --check
- cargo test -p spice-engine
- npm run build
- npm test