### PR TITLE
feat(adj-lang): native LaTeX math in let expressions (\times \cdot \div \frac)

### DIFF
--- a/code/grammars/adj_lang.grammar
+++ b/code/grammars/adj_lang.grammar
@@ -146,9 +146,13 @@ let_decl  = "let" IDENT EQUALS expr ;
 
 expr      = term_expr { ( PLUS | MINUS ) term_expr } ;
 
-term_expr = factor { ( STAR | SLASH ) factor } ;
+# `*` and `\times`/`\cdot` are the same multiply; `/` and `\div` the same
+# divide — the LaTeX operators sit at this precedence and lower identically.
+term_expr = factor { ( STAR | SLASH | LTIMES | LCDOT | LDIV ) factor } ;
 
-factor    = agg | NUMBER | IDENT | LPAREN expr RPAREN ;
+# `\frac{A}{B}` is sugar for `A / B` (the adapter lowers it to the same Div).
+factor    = agg | NUMBER | IDENT | LPAREN expr RPAREN
+          | LFRAC LBRACE expr RBRACE LBRACE expr RBRACE ;
 
 agg       = ( "sum" | "count" | "min" | "max" | "avg" ) LPAREN IDENT RPAREN ;
 

--- a/code/grammars/adj_lang.tokens
+++ b/code/grammars/adj_lang.tokens
@@ -130,6 +130,31 @@ SLASH             = "/"
 EQUALS            = "="
 
 # ----------------------------------------------------------------
+# LaTeX math commands. Math-tuned models (Gemma, etc.) routinely write
+# arithmetic as LaTeX — `a \times b`, `a \cdot b`, `a \div b`,
+# `\frac{a}{b}`. adj-lang understands these NATIVELY: they lex to their
+# own tokens and lower to the SAME multiply/divide as `*` and `/`
+# (identical computed value AND provenance), so a decomposed formula
+# never has to be "normalised" by an upstream regex in some tool — the
+# language owns the syntax.
+#
+# Written in REGEX form (not a quoted literal) so the leading backslash
+# is matched literally and never escape-processed (a quoted "\times"
+# risks `\t` → TAB). Nothing else starts with `\`, so there is no
+# collision with IDENT (`[a-z_]…`) or any operator above. `\frac` reuses
+# the existing LBRACE/RBRACE for its `{…}{…}` arguments.
+#
+# (`$` is the VAR sigil — see VAR above — so LaTeX `$…$` display
+# delimiters are intentionally NOT tokens; the supported form is the
+# bare `a \times b`, which is what decomposers emit anyway.)
+# ----------------------------------------------------------------
+
+LTIMES            = /\\times/
+LCDOT             = /\\cdot/
+LDIV              = /\\div/
+LFRAC             = /\\frac/
+
+# ----------------------------------------------------------------
 # Keywords — recognised at the lexer level so the parser grammar
 # can match by token kind rather than by value.
 # ----------------------------------------------------------------

--- a/code/packages/rust/adj-lang-cli/tests/worked_examples.rs
+++ b/code/packages/rust/adj-lang-cli/tests/worked_examples.rs
@@ -63,6 +63,17 @@ fn proration_computes_and_clears_the_floor() {
 }
 
 #[test]
+fn latex_math_computes_a_weight_based_dose() {
+    let (ok, s) = run_example("latex_math.adj");
+    assert!(ok, "non-zero exit: {s}");
+    // per_dose = \frac{12 \times 15}{3} = 180 / 3 = 60 — the LaTeX lowers to the
+    // same Mul/Div as plain arithmetic, so the engine computes 60 and selects it.
+    assert!(s.contains("\"slot\":\"per_dose\""), "{s}");
+    assert!(s.contains("\"observed\":60"), "{s}");
+    assert!(s.contains("\"leader\":\"dose_60\""), "{s}");
+}
+
+#[test]
 fn break_even_solves_for_the_unit_price() {
     let (ok, s) = run_example("break_even.adj");
     assert!(ok, "non-zero exit: {s}");

--- a/code/packages/rust/adj-lang/CHANGELOG.md
+++ b/code/packages/rust/adj-lang/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## [0.18.0] - 2026-06-26 — native LaTeX math in `let` expressions
+
+### Added
+
+- **LaTeX math operators in `let`/compute expressions.** Math-tuned models (Gemma,
+  etc.) routinely emit arithmetic as LaTeX; adj-lang now reads it NATIVELY rather
+  than relying on an upstream regex to "normalise" a decomposed formula:
+  - `\times` and `\cdot` → multiplication (same as `*`)
+  - `\div` → division (same as `/`)
+  - `\frac{A}{B}` → `A / B` (the brace groups may themselves be full expressions,
+    e.g. `\frac{12 \times 2}{6}`)
+
+  All forms lex to their own tokens (`LTIMES`/`LCDOT`/`LDIV`/`LFRAC`) and **lower
+  to the same `ArithOp::{Mul,Div}`**, so they compute to identical values with an
+  identical proof tree — the engine never sees a difference between `7 * 8` and
+  `7 \times 8`. Grammar: `term_expr` gains the three LaTeX infix operators;
+  `factor` gains the `\frac{…}{…}` alternative. Adapter: `arith_op_from_value`
+  maps the LaTeX spellings; `adapt_factor` lowers `\frac` to `Div`.
+- New worked example `code/specs/data/adj-language-expansion/examples/latex_math.adj`
+  (weight-based pediatric dose `\frac{12 \times 15}{3} = 60`).
+- New adapter tests: `latex_times_and_cdot_are_multiplication`,
+  `latex_div_is_division`, `latex_frac_is_division_of_its_two_groups`,
+  `latex_frac_args_may_themselves_be_expressions`,
+  `latex_and_ascii_operators_mix_in_one_formula`.
+
+### Notes
+
+- `$…$` display delimiters are intentionally NOT tokens — `$` is the VAR sigil
+  (`$Var`), so the supported form is the bare `a \times b`, which is what
+  decomposers emit. `^`/power is deferred (the compute engine has no `Pow` op yet
+  and exponent dimensionality, e.g. `m^2`, needs its own design).
+- Generated `_lexer_grammar.rs` / `_parser_grammar.rs` regenerated via
+  `cargo run -p adj-lang --bin regen_grammars`.
+
 ## [0.17.0] - 2026-06-21 — multi-source corroboration (`cites … locator …`, ADJ-A9)
 
 ### Added

--- a/code/packages/rust/adj-lang/Cargo.toml
+++ b/code/packages/rust/adj-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 description = "Surface-syntax frontend for the adjudication framework's probabilistic-logic rulebooks. Lexes, parses, and lowers a domain-expert-readable DSL into a `logic-engine` KnowledgeBase. Dissolves ADJ46 awkwardness items A10 (rulebook syntax) and A4 (joint contributions syntactically distinct)."
 

--- a/code/packages/rust/adj-lang/src/_lexer_grammar.rs
+++ b/code/packages/rust/adj-lang/src/_lexer_grammar.rs
@@ -6,9 +6,7 @@
 // Call `token_grammar()` instead of reading and parsing the .tokens file.
 
 #[allow(unused_imports)]
-use grammar_tools::token_grammar::{
-    ModeTransition, PatternGroup, TokenDefinition, TokenGrammar, TransitionAction,
-};
+use grammar_tools::token_grammar::{ModeTransition, PatternGroup, TokenDefinition, TokenGrammar, TransitionAction};
 #[allow(unused_imports)]
 use std::collections::HashMap;
 
@@ -183,28 +181,36 @@ pub fn token_grammar() -> TokenGrammar {
                 line_number: 130,
                 alias: None,
             },
+            TokenDefinition {
+                name: r#"LTIMES"#.to_string(),
+                pattern: r#"\\times"#.to_string(),
+                is_regex: true,
+                line_number: 152,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"LCDOT"#.to_string(),
+                pattern: r#"\\cdot"#.to_string(),
+                is_regex: true,
+                line_number: 153,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"LDIV"#.to_string(),
+                pattern: r#"\\div"#.to_string(),
+                is_regex: true,
+                line_number: 154,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"LFRAC"#.to_string(),
+                pattern: r#"\\frac"#.to_string(),
+                is_regex: true,
+                line_number: 155,
+                alias: None,
+            },
         ],
-        keywords: vec![
-            r#"prior"#.to_string(),
-            r#"for"#.to_string(),
-            r#"contributes"#.to_string(),
-            r#"from"#.to_string(),
-            r#"to"#.to_string(),
-            r#"interacts"#.to_string(),
-            r#"when"#.to_string(),
-            r#"and"#.to_string(),
-            r#"observe"#.to_string(),
-            r#"uncertain"#.to_string(),
-            r#"source"#.to_string(),
-            r#"trust"#.to_string(),
-            r#"locator"#.to_string(),
-            r#"cites"#.to_string(),
-            r#"consensus"#.to_string(),
-            r#"authoritative"#.to_string(),
-            r#"empirical"#.to_string(),
-            r#"inferred"#.to_string(),
-            r#"unattributed"#.to_string(),
-        ],
+        keywords: vec![r#"prior"#.to_string(), r#"for"#.to_string(), r#"contributes"#.to_string(), r#"from"#.to_string(), r#"to"#.to_string(), r#"interacts"#.to_string(), r#"when"#.to_string(), r#"and"#.to_string(), r#"observe"#.to_string(), r#"uncertain"#.to_string(), r#"source"#.to_string(), r#"trust"#.to_string(), r#"locator"#.to_string(), r#"cites"#.to_string(), r#"consensus"#.to_string(), r#"authoritative"#.to_string(), r#"empirical"#.to_string(), r#"inferred"#.to_string(), r#"unattributed"#.to_string()],
         mode: None,
         skip_definitions: vec![
             TokenDefinition {

--- a/code/packages/rust/adj-lang/src/_parser_grammar.rs
+++ b/code/packages/rust/adj-lang/src/_parser_grammar.rs
@@ -10,1148 +10,526 @@ use grammar_tools::parser_grammar::{GrammarElement, GrammarRule, ParserGrammar};
 pub fn parser_grammar() -> ParserGrammar {
     ParserGrammar {
         rules: vec![
-            GrammarRule {
-                name: r#"program"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Repetition {
-                            element: Box::new(GrammarElement::RuleReference {
-                                name: r#"statement"#.to_string(),
-                            }),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"EOF"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 20,
-            },
-            GrammarRule {
-                name: r#"statement"#.to_string(),
-                body: GrammarElement::Alternation {
-                    choices: vec![
-                        GrammarElement::RuleReference {
-                            name: r#"prior_decl"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"contributes_decl"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"interacts_decl"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"uncertain_decl"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"observe_decl"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"relate_decl"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"rule_decl"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"functional_decl"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"context_order_decl"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"query_decl"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"let_decl"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"symbol_decl"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"constrain_decl"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"solve_decl"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"check_decl"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"optimize_decl"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"dictionary_decl"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"define_decl"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"rulebook_decl"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"use_decl"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"import_decl"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 22,
-            },
-            GrammarRule {
-                name: r#"prior_decl"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"prior"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"NUMBER"#.to_string(),
-                        },
-                        GrammarElement::Literal {
-                            value: r#"for"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"term"#.to_string(),
-                        },
-                        GrammarElement::Repetition {
-                            element: Box::new(GrammarElement::RuleReference {
-                                name: r#"annotation"#.to_string(),
-                            }),
-                        },
-                    ],
-                },
-                line_number: 50,
-            },
-            GrammarRule {
-                name: r#"contributes_decl"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"contributes"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"NUMBER"#.to_string(),
-                        },
-                        GrammarElement::Literal {
-                            value: r#"from"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"evidence"#.to_string(),
-                        },
-                        GrammarElement::Literal {
-                            value: r#"to"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"term"#.to_string(),
-                        },
-                        GrammarElement::Repetition {
-                            element: Box::new(GrammarElement::RuleReference {
-                                name: r#"annotation"#.to_string(),
-                            }),
-                        },
-                    ],
-                },
-                line_number: 52,
-            },
-            GrammarRule {
-                name: r#"evidence"#.to_string(),
-                body: GrammarElement::Alternation {
-                    choices: vec![
-                        GrammarElement::RuleReference {
-                            name: r#"predicate"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"term"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 62,
-            },
-            GrammarRule {
-                name: r#"predicate"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::TokenReference {
-                            name: r#"IDENT"#.to_string(),
-                        },
-                        GrammarElement::Group {
-                            element: Box::new(GrammarElement::Alternation {
-                                choices: vec![
-                                    GrammarElement::TokenReference {
-                                        name: r#"GE"#.to_string(),
-                                    },
-                                    GrammarElement::TokenReference {
-                                        name: r#"LE"#.to_string(),
-                                    },
-                                    GrammarElement::TokenReference {
-                                        name: r#"GT"#.to_string(),
-                                    },
-                                    GrammarElement::TokenReference {
-                                        name: r#"LT"#.to_string(),
-                                    },
-                                    GrammarElement::TokenReference {
-                                        name: r#"EQEQ"#.to_string(),
-                                    },
-                                ],
-                            }),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"NUMBER"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 64,
-            },
-            GrammarRule {
-                name: r#"interacts_decl"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"interacts"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"NUMBER"#.to_string(),
-                        },
-                        GrammarElement::Literal {
-                            value: r#"when"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"term"#.to_string(),
-                        },
-                        GrammarElement::Literal {
-                            value: r#"and"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"term"#.to_string(),
-                        },
-                        GrammarElement::Repetition {
-                            element: Box::new(GrammarElement::Sequence {
-                                elements: vec![
-                                    GrammarElement::Literal {
-                                        value: r#"and"#.to_string(),
-                                    },
-                                    GrammarElement::RuleReference {
-                                        name: r#"term"#.to_string(),
-                                    },
-                                ],
-                            }),
-                        },
-                        GrammarElement::Literal {
-                            value: r#"for"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"term"#.to_string(),
-                        },
-                        GrammarElement::Repetition {
-                            element: Box::new(GrammarElement::RuleReference {
-                                name: r#"annotation"#.to_string(),
-                            }),
-                        },
-                    ],
-                },
-                line_number: 66,
-            },
-            GrammarRule {
-                name: r#"uncertain_decl"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"uncertain"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"LBRACE"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"term"#.to_string(),
-                        },
-                        GrammarElement::Repetition {
-                            element: Box::new(GrammarElement::Sequence {
-                                elements: vec![
-                                    GrammarElement::TokenReference {
-                                        name: r#"COMMA"#.to_string(),
-                                    },
-                                    GrammarElement::RuleReference {
-                                        name: r#"term"#.to_string(),
-                                    },
-                                ],
-                            }),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"RBRACE"#.to_string(),
-                        },
-                        GrammarElement::Literal {
-                            value: r#"for"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"term"#.to_string(),
-                        },
-                        GrammarElement::Repetition {
-                            element: Box::new(GrammarElement::RuleReference {
-                                name: r#"annotation"#.to_string(),
-                            }),
-                        },
-                    ],
-                },
-                line_number: 68,
-            },
-            GrammarRule {
-                name: r#"observe_decl"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"observe"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"term"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 70,
-            },
-            GrammarRule {
-                name: r#"relate_decl"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"relate"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"term"#.to_string(),
-                        },
-                        GrammarElement::Repetition {
-                            element: Box::new(GrammarElement::RuleReference {
-                                name: r#"annotation"#.to_string(),
-                            }),
-                        },
-                    ],
-                },
-                line_number: 83,
-            },
-            GrammarRule {
-                name: r#"rule_decl"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"rule"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"LBRACE"#.to_string(),
-                        },
-                        GrammarElement::Literal {
-                            value: r#"head"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"COLON"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"term"#.to_string(),
-                        },
-                        GrammarElement::Literal {
-                            value: r#"when"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"COLON"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"body_literal"#.to_string(),
-                        },
-                        GrammarElement::Repetition {
-                            element: Box::new(GrammarElement::Sequence {
-                                elements: vec![
-                                    GrammarElement::TokenReference {
-                                        name: r#"COMMA"#.to_string(),
-                                    },
-                                    GrammarElement::RuleReference {
-                                        name: r#"body_literal"#.to_string(),
-                                    },
-                                ],
-                            }),
-                        },
-                        GrammarElement::Repetition {
-                            element: Box::new(GrammarElement::RuleReference {
-                                name: r#"annotation"#.to_string(),
-                            }),
-                        },
-                        GrammarElement::Optional {
-                            element: Box::new(GrammarElement::Sequence {
-                                elements: vec![
-                                    GrammarElement::Literal {
-                                        value: r#"priority"#.to_string(),
-                                    },
-                                    GrammarElement::TokenReference {
-                                        name: r#"COLON"#.to_string(),
-                                    },
-                                    GrammarElement::TokenReference {
-                                        name: r#"IDENT"#.to_string(),
-                                    },
-                                ],
-                            }),
-                        },
-                        GrammarElement::Optional {
-                            element: Box::new(GrammarElement::Sequence {
-                                elements: vec![
-                                    GrammarElement::Literal {
-                                        value: r#"context"#.to_string(),
-                                    },
-                                    GrammarElement::TokenReference {
-                                        name: r#"COLON"#.to_string(),
-                                    },
-                                    GrammarElement::TokenReference {
-                                        name: r#"IDENT"#.to_string(),
-                                    },
-                                ],
-                            }),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"RBRACE"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 105,
-            },
-            GrammarRule {
-                name: r#"body_literal"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Optional {
-                            element: Box::new(GrammarElement::Literal {
-                                value: r#"not"#.to_string(),
-                            }),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"term"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 107,
-            },
-            GrammarRule {
-                name: r#"context_order_decl"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"context_order"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"LBRACE"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"IDENT"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"GT"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"IDENT"#.to_string(),
-                        },
-                        GrammarElement::Repetition {
-                            element: Box::new(GrammarElement::Sequence {
-                                elements: vec![
-                                    GrammarElement::TokenReference {
-                                        name: r#"COMMA"#.to_string(),
-                                    },
-                                    GrammarElement::TokenReference {
-                                        name: r#"IDENT"#.to_string(),
-                                    },
-                                    GrammarElement::TokenReference {
-                                        name: r#"GT"#.to_string(),
-                                    },
-                                    GrammarElement::TokenReference {
-                                        name: r#"IDENT"#.to_string(),
-                                    },
-                                ],
-                            }),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"RBRACE"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 118,
-            },
-            GrammarRule {
-                name: r#"functional_decl"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"functional"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"term"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 129,
-            },
-            GrammarRule {
-                name: r#"query_decl"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::TokenReference {
-                            name: r#"QUESTION"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"term"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 131,
-            },
-            GrammarRule {
-                name: r#"let_decl"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"let"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"IDENT"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"EQUALS"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"expr"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 145,
-            },
-            GrammarRule {
-                name: r#"expr"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::RuleReference {
-                            name: r#"term_expr"#.to_string(),
-                        },
-                        GrammarElement::Repetition {
-                            element: Box::new(GrammarElement::Sequence {
-                                elements: vec![
-                                    GrammarElement::Group {
-                                        element: Box::new(GrammarElement::Alternation {
-                                            choices: vec![
-                                                GrammarElement::TokenReference {
-                                                    name: r#"PLUS"#.to_string(),
-                                                },
-                                                GrammarElement::TokenReference {
-                                                    name: r#"MINUS"#.to_string(),
-                                                },
-                                            ],
-                                        }),
-                                    },
-                                    GrammarElement::RuleReference {
-                                        name: r#"term_expr"#.to_string(),
-                                    },
-                                ],
-                            }),
-                        },
-                    ],
-                },
-                line_number: 147,
-            },
-            GrammarRule {
-                name: r#"term_expr"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::RuleReference {
-                            name: r#"factor"#.to_string(),
-                        },
-                        GrammarElement::Repetition {
-                            element: Box::new(GrammarElement::Sequence {
-                                elements: vec![
-                                    GrammarElement::Group {
-                                        element: Box::new(GrammarElement::Alternation {
-                                            choices: vec![
-                                                GrammarElement::TokenReference {
-                                                    name: r#"STAR"#.to_string(),
-                                                },
-                                                GrammarElement::TokenReference {
-                                                    name: r#"SLASH"#.to_string(),
-                                                },
-                                            ],
-                                        }),
-                                    },
-                                    GrammarElement::RuleReference {
-                                        name: r#"factor"#.to_string(),
-                                    },
-                                ],
-                            }),
-                        },
-                    ],
-                },
-                line_number: 149,
-            },
-            GrammarRule {
-                name: r#"factor"#.to_string(),
-                body: GrammarElement::Alternation {
-                    choices: vec![
-                        GrammarElement::RuleReference {
-                            name: r#"agg"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"NUMBER"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"IDENT"#.to_string(),
-                        },
-                        GrammarElement::Sequence {
-                            elements: vec![
-                                GrammarElement::TokenReference {
-                                    name: r#"LPAREN"#.to_string(),
-                                },
-                                GrammarElement::RuleReference {
-                                    name: r#"expr"#.to_string(),
-                                },
-                                GrammarElement::TokenReference {
-                                    name: r#"RPAREN"#.to_string(),
-                                },
-                            ],
-                        },
-                    ],
-                },
-                line_number: 151,
-            },
-            GrammarRule {
-                name: r#"agg"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Group {
-                            element: Box::new(GrammarElement::Alternation {
-                                choices: vec![
-                                    GrammarElement::Literal {
-                                        value: r#"sum"#.to_string(),
-                                    },
-                                    GrammarElement::Literal {
-                                        value: r#"count"#.to_string(),
-                                    },
-                                    GrammarElement::Literal {
-                                        value: r#"min"#.to_string(),
-                                    },
-                                    GrammarElement::Literal {
-                                        value: r#"max"#.to_string(),
-                                    },
-                                    GrammarElement::Literal {
-                                        value: r#"avg"#.to_string(),
-                                    },
-                                ],
-                            }),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"LPAREN"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"IDENT"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"RPAREN"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 153,
-            },
-            GrammarRule {
-                name: r#"symbol_decl"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"symbol"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"IDENT"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"COLON"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"term"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 163,
-            },
-            GrammarRule {
-                name: r#"constrain_decl"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"constrain"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"expr"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"relop"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"expr"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 165,
-            },
-            GrammarRule {
-                name: r#"relop"#.to_string(),
-                body: GrammarElement::Alternation {
-                    choices: vec![
-                        GrammarElement::TokenReference {
-                            name: r#"GE"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"LE"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"GT"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"LT"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"EQEQ"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"EQUALS"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"NE"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 167,
-            },
-            GrammarRule {
-                name: r#"solve_decl"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"solve"#.to_string(),
-                        },
-                        GrammarElement::Literal {
-                            value: r#"for"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"LBRACE"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"IDENT"#.to_string(),
-                        },
-                        GrammarElement::Repetition {
-                            element: Box::new(GrammarElement::Sequence {
-                                elements: vec![
-                                    GrammarElement::TokenReference {
-                                        name: r#"COMMA"#.to_string(),
-                                    },
-                                    GrammarElement::TokenReference {
-                                        name: r#"IDENT"#.to_string(),
-                                    },
-                                ],
-                            }),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"RBRACE"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 169,
-            },
-            GrammarRule {
-                name: r#"check_decl"#.to_string(),
-                body: GrammarElement::Literal {
-                    value: r#"check"#.to_string(),
-                },
-                line_number: 171,
-            },
-            GrammarRule {
-                name: r#"optimize_decl"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Group {
-                            element: Box::new(GrammarElement::Alternation {
-                                choices: vec![
-                                    GrammarElement::Literal {
-                                        value: r#"minimize"#.to_string(),
-                                    },
-                                    GrammarElement::Literal {
-                                        value: r#"maximize"#.to_string(),
-                                    },
-                                ],
-                            }),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"expr"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 178,
-            },
-            GrammarRule {
-                name: r#"dictionary_decl"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"dictionary"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"IDENT"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"LBRACE"#.to_string(),
-                        },
-                        GrammarElement::Repetition {
-                            element: Box::new(GrammarElement::RuleReference {
-                                name: r#"define_decl"#.to_string(),
-                            }),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"RBRACE"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 190,
-            },
-            GrammarRule {
-                name: r#"define_decl"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"define"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"IDENT"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"COLON"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"define_kind"#.to_string(),
-                        },
-                        GrammarElement::Repetition {
-                            element: Box::new(GrammarElement::RuleReference {
-                                name: r#"surface_clause"#.to_string(),
-                            }),
-                        },
-                    ],
-                },
-                line_number: 192,
-            },
-            GrammarRule {
-                name: r#"define_kind"#.to_string(),
-                body: GrammarElement::Alternation {
-                    choices: vec![
-                        GrammarElement::Literal {
-                            value: r#"hypothesis"#.to_string(),
-                        },
-                        GrammarElement::Sequence {
-                            elements: vec![
-                                GrammarElement::Literal {
-                                    value: r#"finding"#.to_string(),
-                                },
-                                GrammarElement::Optional {
-                                    element: Box::new(GrammarElement::Sequence {
-                                        elements: vec![
-                                            GrammarElement::Literal {
-                                                value: r#"values"#.to_string(),
-                                            },
-                                            GrammarElement::TokenReference {
-                                                name: r#"LBRACK"#.to_string(),
-                                            },
-                                            GrammarElement::TokenReference {
-                                                name: r#"IDENT"#.to_string(),
-                                            },
-                                            GrammarElement::Repetition {
-                                                element: Box::new(GrammarElement::Sequence {
-                                                    elements: vec![
-                                                        GrammarElement::TokenReference {
-                                                            name: r#"COMMA"#.to_string(),
-                                                        },
-                                                        GrammarElement::TokenReference {
-                                                            name: r#"IDENT"#.to_string(),
-                                                        },
-                                                    ],
-                                                }),
-                                            },
-                                            GrammarElement::TokenReference {
-                                                name: r#"RBRACK"#.to_string(),
-                                            },
-                                        ],
-                                    }),
-                                },
-                            ],
-                        },
-                        GrammarElement::Literal {
-                            value: r#"entity"#.to_string(),
-                        },
-                        GrammarElement::Sequence {
-                            elements: vec![
-                                GrammarElement::Literal {
-                                    value: r#"relation"#.to_string(),
-                                },
-                                GrammarElement::Literal {
-                                    value: r#"from"#.to_string(),
-                                },
-                                GrammarElement::TokenReference {
-                                    name: r#"IDENT"#.to_string(),
-                                },
-                                GrammarElement::Literal {
-                                    value: r#"to"#.to_string(),
-                                },
-                                GrammarElement::TokenReference {
-                                    name: r#"IDENT"#.to_string(),
-                                },
-                            ],
-                        },
-                    ],
-                },
-                line_number: 194,
-            },
-            GrammarRule {
-                name: r#"surface_clause"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"surface"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"STRING"#.to_string(),
-                        },
-                        GrammarElement::Repetition {
-                            element: Box::new(GrammarElement::Sequence {
-                                elements: vec![
-                                    GrammarElement::TokenReference {
-                                        name: r#"COMMA"#.to_string(),
-                                    },
-                                    GrammarElement::TokenReference {
-                                        name: r#"STRING"#.to_string(),
-                                    },
-                                ],
-                            }),
-                        },
-                    ],
-                },
-                line_number: 200,
-            },
-            GrammarRule {
-                name: r#"rulebook_decl"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"rulebook"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"IDENT"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"LBRACE"#.to_string(),
-                        },
-                        GrammarElement::Repetition {
-                            element: Box::new(GrammarElement::RuleReference {
-                                name: r#"statement"#.to_string(),
-                            }),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"RBRACE"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 217,
-            },
-            GrammarRule {
-                name: r#"use_decl"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"use"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"IDENT"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 219,
-            },
-            GrammarRule {
-                name: r#"import_decl"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"import"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"STRING"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 235,
-            },
-            GrammarRule {
-                name: r#"annotation"#.to_string(),
-                body: GrammarElement::Alternation {
-                    choices: vec![
-                        GrammarElement::RuleReference {
-                            name: r#"source_annotation"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"locator_annotation"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"trust_annotation"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"cites_annotation"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 247,
-            },
-            GrammarRule {
-                name: r#"source_annotation"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"source"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"STRING"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 253,
-            },
-            GrammarRule {
-                name: r#"locator_annotation"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"locator"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"STRING"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 254,
-            },
-            GrammarRule {
-                name: r#"trust_annotation"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"trust"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"trust_tier"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 255,
-            },
-            GrammarRule {
-                name: r#"cites_annotation"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"cites"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"STRING"#.to_string(),
-                        },
-                        GrammarElement::Literal {
-                            value: r#"locator"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"STRING"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 256,
-            },
-            GrammarRule {
-                name: r#"trust_tier"#.to_string(),
-                body: GrammarElement::Alternation {
-                    choices: vec![
-                        GrammarElement::Literal {
-                            value: r#"consensus"#.to_string(),
-                        },
-                        GrammarElement::Literal {
-                            value: r#"authoritative"#.to_string(),
-                        },
-                        GrammarElement::Literal {
-                            value: r#"empirical"#.to_string(),
-                        },
-                        GrammarElement::Literal {
-                            value: r#"inferred"#.to_string(),
-                        },
-                        GrammarElement::Literal {
-                            value: r#"unattributed"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 258,
-            },
-            GrammarRule {
-                name: r#"term"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::TokenReference {
-                            name: r#"IDENT"#.to_string(),
-                        },
-                        GrammarElement::Optional {
-                            element: Box::new(GrammarElement::Sequence {
-                                elements: vec![
-                                    GrammarElement::TokenReference {
-                                        name: r#"LPAREN"#.to_string(),
-                                    },
-                                    GrammarElement::Group {
-                                        element: Box::new(GrammarElement::Alternation {
-                                            choices: vec![
-                                                GrammarElement::RuleReference {
-                                                    name: r#"term"#.to_string(),
-                                                },
-                                                GrammarElement::TokenReference {
-                                                    name: r#"NUMBER"#.to_string(),
-                                                },
-                                                GrammarElement::TokenReference {
-                                                    name: r#"VAR"#.to_string(),
-                                                },
-                                            ],
-                                        }),
-                                    },
-                                    GrammarElement::Repetition {
-                                        element: Box::new(GrammarElement::Sequence {
-                                            elements: vec![
-                                                GrammarElement::TokenReference {
-                                                    name: r#"COMMA"#.to_string(),
-                                                },
-                                                GrammarElement::Group {
-                                                    element: Box::new(
-                                                        GrammarElement::Alternation {
-                                                            choices: vec![
-                                                                GrammarElement::RuleReference {
-                                                                    name: r#"term"#.to_string(),
-                                                                },
-                                                                GrammarElement::TokenReference {
-                                                                    name: r#"NUMBER"#.to_string(),
-                                                                },
-                                                                GrammarElement::TokenReference {
-                                                                    name: r#"VAR"#.to_string(),
-                                                                },
-                                                            ],
-                                                        },
-                                                    ),
-                                                },
-                                            ],
-                                        }),
-                                    },
-                                    GrammarElement::TokenReference {
-                                        name: r#"RPAREN"#.to_string(),
-                                    },
-                                ],
-                            }),
-                        },
-                    ],
-                },
-                line_number: 280,
-            },
-        ],
+        GrammarRule {
+            name: r#"program"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"statement"#.to_string() }) },
+                GrammarElement::TokenReference { name: r#"EOF"#.to_string() },
+            ] },
+            line_number: 20,
+        },
+        GrammarRule {
+            name: r#"statement"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::RuleReference { name: r#"prior_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"contributes_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"interacts_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"uncertain_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"observe_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"relate_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"rule_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"functional_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"context_order_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"query_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"let_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"symbol_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"constrain_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"solve_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"check_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"optimize_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"dictionary_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"define_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"rulebook_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"use_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"import_decl"#.to_string() },
+            ] },
+            line_number: 22,
+        },
+        GrammarRule {
+            name: r#"prior_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"prior"#.to_string() },
+                GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() },
+                GrammarElement::Literal { value: r#"for"#.to_string() },
+                GrammarElement::RuleReference { name: r#"term"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
+            ] },
+            line_number: 50,
+        },
+        GrammarRule {
+            name: r#"contributes_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"contributes"#.to_string() },
+                GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() },
+                GrammarElement::Literal { value: r#"from"#.to_string() },
+                GrammarElement::RuleReference { name: r#"evidence"#.to_string() },
+                GrammarElement::Literal { value: r#"to"#.to_string() },
+                GrammarElement::RuleReference { name: r#"term"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
+            ] },
+            line_number: 52,
+        },
+        GrammarRule {
+            name: r#"evidence"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::RuleReference { name: r#"predicate"#.to_string() },
+                GrammarElement::RuleReference { name: r#"term"#.to_string() },
+            ] },
+            line_number: 62,
+        },
+        GrammarRule {
+            name: r#"predicate"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                        GrammarElement::TokenReference { name: r#"GE"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"LE"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"GT"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"LT"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"EQEQ"#.to_string() },
+                    ] }) },
+                GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() },
+            ] },
+            line_number: 64,
+        },
+        GrammarRule {
+            name: r#"interacts_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"interacts"#.to_string() },
+                GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() },
+                GrammarElement::Literal { value: r#"when"#.to_string() },
+                GrammarElement::RuleReference { name: r#"term"#.to_string() },
+                GrammarElement::Literal { value: r#"and"#.to_string() },
+                GrammarElement::RuleReference { name: r#"term"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Literal { value: r#"and"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"term"#.to_string() },
+                    ] }) },
+                GrammarElement::Literal { value: r#"for"#.to_string() },
+                GrammarElement::RuleReference { name: r#"term"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
+            ] },
+            line_number: 66,
+        },
+        GrammarRule {
+            name: r#"uncertain_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"uncertain"#.to_string() },
+                GrammarElement::TokenReference { name: r#"LBRACE"#.to_string() },
+                GrammarElement::RuleReference { name: r#"term"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"term"#.to_string() },
+                    ] }) },
+                GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
+                GrammarElement::Literal { value: r#"for"#.to_string() },
+                GrammarElement::RuleReference { name: r#"term"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
+            ] },
+            line_number: 68,
+        },
+        GrammarRule {
+            name: r#"observe_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"observe"#.to_string() },
+                GrammarElement::RuleReference { name: r#"term"#.to_string() },
+            ] },
+            line_number: 70,
+        },
+        GrammarRule {
+            name: r#"relate_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"relate"#.to_string() },
+                GrammarElement::RuleReference { name: r#"term"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
+            ] },
+            line_number: 83,
+        },
+        GrammarRule {
+            name: r#"rule_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"rule"#.to_string() },
+                GrammarElement::TokenReference { name: r#"LBRACE"#.to_string() },
+                GrammarElement::Literal { value: r#"head"#.to_string() },
+                GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
+                GrammarElement::RuleReference { name: r#"term"#.to_string() },
+                GrammarElement::Literal { value: r#"when"#.to_string() },
+                GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
+                GrammarElement::RuleReference { name: r#"body_literal"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"body_literal"#.to_string() },
+                    ] }) },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Literal { value: r#"priority"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                    ] }) },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Literal { value: r#"context"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                    ] }) },
+                GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
+            ] },
+            line_number: 105,
+        },
+        GrammarRule {
+            name: r#"body_literal"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Optional { element: Box::new(GrammarElement::Literal { value: r#"not"#.to_string() }) },
+                GrammarElement::RuleReference { name: r#"term"#.to_string() },
+            ] },
+            line_number: 107,
+        },
+        GrammarRule {
+            name: r#"context_order_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"context_order"#.to_string() },
+                GrammarElement::TokenReference { name: r#"LBRACE"#.to_string() },
+                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                GrammarElement::TokenReference { name: r#"GT"#.to_string() },
+                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"GT"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                    ] }) },
+                GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
+            ] },
+            line_number: 118,
+        },
+        GrammarRule {
+            name: r#"functional_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"functional"#.to_string() },
+                GrammarElement::RuleReference { name: r#"term"#.to_string() },
+            ] },
+            line_number: 129,
+        },
+        GrammarRule {
+            name: r#"query_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"QUESTION"#.to_string() },
+                GrammarElement::RuleReference { name: r#"term"#.to_string() },
+            ] },
+            line_number: 131,
+        },
+        GrammarRule {
+            name: r#"let_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"let"#.to_string() },
+                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                GrammarElement::TokenReference { name: r#"EQUALS"#.to_string() },
+                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+            ] },
+            line_number: 145,
+        },
+        GrammarRule {
+            name: r#"expr"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"term_expr"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                                GrammarElement::TokenReference { name: r#"PLUS"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"MINUS"#.to_string() },
+                            ] }) },
+                        GrammarElement::RuleReference { name: r#"term_expr"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 147,
+        },
+        GrammarRule {
+            name: r#"term_expr"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"factor"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                                GrammarElement::TokenReference { name: r#"STAR"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"SLASH"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"LTIMES"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"LCDOT"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"LDIV"#.to_string() },
+                            ] }) },
+                        GrammarElement::RuleReference { name: r#"factor"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 151,
+        },
+        GrammarRule {
+            name: r#"factor"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::RuleReference { name: r#"agg"#.to_string() },
+                GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() },
+                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::TokenReference { name: r#"LPAREN"#.to_string() },
+                    GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                    GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
+                ] },
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::TokenReference { name: r#"LFRAC"#.to_string() },
+                    GrammarElement::TokenReference { name: r#"LBRACE"#.to_string() },
+                    GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                    GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
+                    GrammarElement::TokenReference { name: r#"LBRACE"#.to_string() },
+                    GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                    GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
+                ] },
+            ] },
+            line_number: 154,
+        },
+        GrammarRule {
+            name: r#"agg"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                        GrammarElement::Literal { value: r#"sum"#.to_string() },
+                        GrammarElement::Literal { value: r#"count"#.to_string() },
+                        GrammarElement::Literal { value: r#"min"#.to_string() },
+                        GrammarElement::Literal { value: r#"max"#.to_string() },
+                        GrammarElement::Literal { value: r#"avg"#.to_string() },
+                    ] }) },
+                GrammarElement::TokenReference { name: r#"LPAREN"#.to_string() },
+                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
+            ] },
+            line_number: 157,
+        },
+        GrammarRule {
+            name: r#"symbol_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"symbol"#.to_string() },
+                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
+                GrammarElement::RuleReference { name: r#"term"#.to_string() },
+            ] },
+            line_number: 167,
+        },
+        GrammarRule {
+            name: r#"constrain_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"constrain"#.to_string() },
+                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                GrammarElement::RuleReference { name: r#"relop"#.to_string() },
+                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+            ] },
+            line_number: 169,
+        },
+        GrammarRule {
+            name: r#"relop"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::TokenReference { name: r#"GE"#.to_string() },
+                GrammarElement::TokenReference { name: r#"LE"#.to_string() },
+                GrammarElement::TokenReference { name: r#"GT"#.to_string() },
+                GrammarElement::TokenReference { name: r#"LT"#.to_string() },
+                GrammarElement::TokenReference { name: r#"EQEQ"#.to_string() },
+                GrammarElement::TokenReference { name: r#"EQUALS"#.to_string() },
+                GrammarElement::TokenReference { name: r#"NE"#.to_string() },
+            ] },
+            line_number: 171,
+        },
+        GrammarRule {
+            name: r#"solve_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"solve"#.to_string() },
+                GrammarElement::Literal { value: r#"for"#.to_string() },
+                GrammarElement::TokenReference { name: r#"LBRACE"#.to_string() },
+                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                    ] }) },
+                GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
+            ] },
+            line_number: 173,
+        },
+        GrammarRule {
+            name: r#"check_decl"#.to_string(),
+            body: GrammarElement::Literal { value: r#"check"#.to_string() },
+            line_number: 175,
+        },
+        GrammarRule {
+            name: r#"optimize_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                        GrammarElement::Literal { value: r#"minimize"#.to_string() },
+                        GrammarElement::Literal { value: r#"maximize"#.to_string() },
+                    ] }) },
+                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+            ] },
+            line_number: 182,
+        },
+        GrammarRule {
+            name: r#"dictionary_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"dictionary"#.to_string() },
+                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                GrammarElement::TokenReference { name: r#"LBRACE"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"define_decl"#.to_string() }) },
+                GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
+            ] },
+            line_number: 194,
+        },
+        GrammarRule {
+            name: r#"define_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"define"#.to_string() },
+                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
+                GrammarElement::RuleReference { name: r#"define_kind"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"surface_clause"#.to_string() }) },
+            ] },
+            line_number: 196,
+        },
+        GrammarRule {
+            name: r#"define_kind"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::Literal { value: r#"hypothesis"#.to_string() },
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::Literal { value: r#"finding"#.to_string() },
+                    GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                            GrammarElement::Literal { value: r#"values"#.to_string() },
+                            GrammarElement::TokenReference { name: r#"LBRACK"#.to_string() },
+                            GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                            GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                                    GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
+                                    GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                                ] }) },
+                            GrammarElement::TokenReference { name: r#"RBRACK"#.to_string() },
+                        ] }) },
+                ] },
+                GrammarElement::Literal { value: r#"entity"#.to_string() },
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::Literal { value: r#"relation"#.to_string() },
+                    GrammarElement::Literal { value: r#"from"#.to_string() },
+                    GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                    GrammarElement::Literal { value: r#"to"#.to_string() },
+                    GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                ] },
+            ] },
+            line_number: 198,
+        },
+        GrammarRule {
+            name: r#"surface_clause"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"surface"#.to_string() },
+                GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 204,
+        },
+        GrammarRule {
+            name: r#"rulebook_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"rulebook"#.to_string() },
+                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                GrammarElement::TokenReference { name: r#"LBRACE"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"statement"#.to_string() }) },
+                GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
+            ] },
+            line_number: 221,
+        },
+        GrammarRule {
+            name: r#"use_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"use"#.to_string() },
+                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+            ] },
+            line_number: 223,
+        },
+        GrammarRule {
+            name: r#"import_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"import"#.to_string() },
+                GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
+            ] },
+            line_number: 239,
+        },
+        GrammarRule {
+            name: r#"annotation"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::RuleReference { name: r#"source_annotation"#.to_string() },
+                GrammarElement::RuleReference { name: r#"locator_annotation"#.to_string() },
+                GrammarElement::RuleReference { name: r#"trust_annotation"#.to_string() },
+                GrammarElement::RuleReference { name: r#"cites_annotation"#.to_string() },
+            ] },
+            line_number: 251,
+        },
+        GrammarRule {
+            name: r#"source_annotation"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"source"#.to_string() },
+                GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
+            ] },
+            line_number: 257,
+        },
+        GrammarRule {
+            name: r#"locator_annotation"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"locator"#.to_string() },
+                GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
+            ] },
+            line_number: 258,
+        },
+        GrammarRule {
+            name: r#"trust_annotation"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"trust"#.to_string() },
+                GrammarElement::RuleReference { name: r#"trust_tier"#.to_string() },
+            ] },
+            line_number: 259,
+        },
+        GrammarRule {
+            name: r#"cites_annotation"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"cites"#.to_string() },
+                GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
+                GrammarElement::Literal { value: r#"locator"#.to_string() },
+                GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
+            ] },
+            line_number: 260,
+        },
+        GrammarRule {
+            name: r#"trust_tier"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::Literal { value: r#"consensus"#.to_string() },
+                GrammarElement::Literal { value: r#"authoritative"#.to_string() },
+                GrammarElement::Literal { value: r#"empirical"#.to_string() },
+                GrammarElement::Literal { value: r#"inferred"#.to_string() },
+                GrammarElement::Literal { value: r#"unattributed"#.to_string() },
+            ] },
+            line_number: 262,
+        },
+        GrammarRule {
+            name: r#"term"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"LPAREN"#.to_string() },
+                        GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                                GrammarElement::RuleReference { name: r#"term"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"VAR"#.to_string() },
+                            ] }) },
+                        GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                                GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
+                                GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                                        GrammarElement::RuleReference { name: r#"term"#.to_string() },
+                                        GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() },
+                                        GrammarElement::TokenReference { name: r#"VAR"#.to_string() },
+                                    ] }) },
+                            ] }) },
+                        GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 284,
+        },
+    ],
         version: 1,
     }
 }

--- a/code/packages/rust/adj-lang/src/adapter.rs
+++ b/code/packages/rust/adj-lang/src/adapter.rs
@@ -787,12 +787,46 @@ fn fold_binary(
     })
 }
 
-/// `factor = agg | NUMBER | IDENT | LPAREN expr RPAREN`.
+/// `factor = agg | NUMBER | IDENT | LPAREN expr RPAREN
+///         | LFRAC LBRACE expr RBRACE LBRACE expr RBRACE`.
 fn adapt_factor(node: &GrammarASTNode) -> Result<ExprAst, AdapterError> {
     // A parsed `agg` or parenthesised `expr` appears as a named child node;
     // a bare NUMBER or IDENT appears as a token. Check nodes first.
     if let Some(agg) = first_named_child(node, "agg") {
         return adapt_agg(agg);
+    }
+    // `\frac{A}{B}` → `A / B`. Detected BEFORE the single-`expr` paren branch
+    // below, because a frac factor carries TWO `expr` children (numerator and
+    // denominator) and we must bind both, not just the first. It lowers to the
+    // same Div as `/`, so the engine computes and proves it identically.
+    if node
+        .children
+        .iter()
+        .any(|c| matches!(c, ASTNodeOrToken::Token(t) if t.value == "\\frac"))
+    {
+        let exprs: Vec<&GrammarASTNode> = node
+            .children
+            .iter()
+            .filter_map(|c| match c {
+                ASTNodeOrToken::Node(n) if n.rule_name == "expr" => Some(n),
+                _ => None,
+            })
+            .collect();
+        match (exprs.first(), exprs.get(1)) {
+            (Some(num), Some(den)) => {
+                return Ok(ExprAst::Bin(
+                    ArithOp::Div,
+                    Box::new(adapt_expr(num)?),
+                    Box::new(adapt_expr(den)?),
+                ));
+            }
+            _ => {
+                return Err(AdapterError::MissingChild {
+                    rule: "factor".into(),
+                    position: "\\frac numerator and denominator",
+                });
+            }
+        }
     }
     if let Some(inner) = first_named_child(node, "expr") {
         return adapt_expr(inner);
@@ -846,8 +880,11 @@ fn arith_op_from_value(v: &str) -> Option<ArithOp> {
     match v {
         "+" => Some(ArithOp::Add),
         "-" => Some(ArithOp::Sub),
-        "*" => Some(ArithOp::Mul),
-        "/" => Some(ArithOp::Div),
+        // `*`, `\times`, `\cdot` all denote multiplication; `/`, `\div` division.
+        // The LaTeX spellings lower to the SAME ArithOp, so they compute and prove
+        // identically — the engine never sees a difference (see adj_lang.tokens).
+        "*" | "\\times" | "\\cdot" => Some(ArithOp::Mul),
+        "/" | "\\div" => Some(ArithOp::Div),
         _ => None,
     }
 }
@@ -1148,6 +1185,69 @@ mod tests {
             .into_iter()
             .next()
             .expect("at least one statement")
+    }
+
+    /// Parse a single `let name = <expr>` and return its expression AST.
+    fn parse_let_expr(src: &str) -> ExprAst {
+        match parse_one(src) {
+            Statement::Let { expr, .. } => expr,
+            other => panic!("expected Let, got {other:?}"),
+        }
+    }
+
+    // ---- LaTeX math: lexes to its own tokens, lowers to the SAME ArithOp -------
+    // Math-tuned models emit `\times`/`\cdot`/`\div`/`\frac`; the language reads them
+    // natively so no upstream regex ever has to rewrite a decomposed formula.
+
+    #[test]
+    fn latex_times_and_cdot_are_multiplication() {
+        // `\times` and `\cdot` must produce the identical AST to `*`.
+        let plain = parse_let_expr("let a = 7 * 8");
+        assert_eq!(parse_let_expr(r"let a = 7 \times 8"), plain);
+        assert_eq!(parse_let_expr(r"let a = 7 \cdot 8"), plain);
+        assert!(matches!(plain, ExprAst::Bin(ArithOp::Mul, _, _)));
+    }
+
+    #[test]
+    fn latex_div_is_division() {
+        assert_eq!(parse_let_expr(r"let a = 56 \div 8"), parse_let_expr("let a = 56 / 8"));
+        assert!(matches!(parse_let_expr(r"let a = 56 \div 8"), ExprAst::Bin(ArithOp::Div, _, _)));
+    }
+
+    #[test]
+    fn latex_frac_is_division_of_its_two_groups() {
+        // `\frac{A}{B}` lowers to `A / B` — here `\frac{100}{4}`.
+        match parse_let_expr(r"let a = \frac{100}{4}") {
+            ExprAst::Bin(ArithOp::Div, num, den) => {
+                assert_eq!(*num, ExprAst::Lit(100.0));
+                assert_eq!(*den, ExprAst::Lit(4.0));
+            }
+            other => panic!("expected Div, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn latex_frac_args_may_themselves_be_expressions() {
+        // `\frac{12 \times 2}{6}` → (12*2) / 6 — LaTeX nested inside the braces.
+        match parse_let_expr(r"let a = \frac{12 \times 2}{6}") {
+            ExprAst::Bin(ArithOp::Div, num, den) => {
+                assert!(matches!(*num, ExprAst::Bin(ArithOp::Mul, _, _)));
+                assert_eq!(*den, ExprAst::Lit(6.0));
+            }
+            other => panic!("expected Div, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn latex_and_ascii_operators_mix_in_one_formula() {
+        // `3 \cdot 6 + \frac{20}{5}` parses as (3*6) + (20/5).
+        match parse_let_expr(r"let a = 3 \cdot 6 + \frac{20}{5}") {
+            ExprAst::Bin(ArithOp::Add, lhs, rhs) => {
+                assert!(matches!(*lhs, ExprAst::Bin(ArithOp::Mul, _, _)));
+                assert!(matches!(*rhs, ExprAst::Bin(ArithOp::Div, _, _)));
+            }
+            other => panic!("expected Add at the root, got {other:?}"),
+        }
     }
 
     #[test]

--- a/code/specs/data/adj-language-expansion/examples/README.md
+++ b/code/specs/data/adj-language-expansion/examples/README.md
@@ -18,6 +18,7 @@ cargo build -p adj-lang-cli
 | [`eligibility.adj`](eligibility.adj) | a **predicate over a typed value** (`gross_income >= 14600` over `money(18000, usd)`) — a deterministic rule as a saturating LR | `required_to_file` ≈ 1.0, determinate; proof shows the `>= 14600 / observed 18000` comparison + IRS citation |
 | [`debt_to_income.adj`](debt_to_income.adj) | a **computed ratio** (`money / money → dimensionless`) driving a rule | `dti = 0.30 <= 0.43` fires → `mortgage_eligible` ≈ 1.0 |
 | [`proration.adj`](proration.adj) | **`let` arithmetic** (`annual_bonus * months_worked / 12`) feeding a predicate | `prorated = 9000 >= 8000` fires → `senior_tier` ≈ 1.0 |
+| [`latex_math.adj`](latex_math.adj) | **native LaTeX math** in a `let` (`\frac{12 \times 15}{3}`) — lowers to the same Mul/Div as `*`/`/` | `per_dose = 60` → `dose_60` ≈ 1.0 |
 | [`break_even.adj`](break_even.adj) | **solving for an unknown** (`p * 1000 = 5000 + 3 * 1000`) | `solve → { p = 8 }`, cited to constraint `[0]` |
 | [`grant_allocation.adj`](grant_allocation.adj) | **linear optimization** — `maximize 3·outreach + 2·training` under a budget + capacity (an LP) | `optimize → optimal 26` at `{ outreach = 6, training = 4 }`, binding constraints `[0, 1]` |
 

--- a/code/specs/data/adj-language-expansion/examples/latex_math.adj
+++ b/code/specs/data/adj-language-expansion/examples/latex_math.adj
@@ -1,0 +1,25 @@
+% Worked example — LaTeX math in a `let` formula (adj-lang understands it natively).
+%
+% Math-tuned models (Gemma, etc.) routinely emit arithmetic as LaTeX. adj-lang
+% reads `\times`, `\cdot`, `\div`, and `\frac{A}{B}` directly: they lex to their
+% own tokens and lower to the SAME multiply/divide as `*` and `/`, so the engine
+% computes them identically and the proof tree is the same. No upstream regex ever
+% rewrites the model's formula — the language owns the syntax.
+%
+% Here a weight-based pediatric dose: 12 mg/kg for a 15 kg child, given in 3 equal
+% divided doses. The model wrote the formula in LaTeX; the ENGINE computes it on the
+% CPU into 60, and the predicate `per_dose == 60` selects the matching option.
+%
+% Expected: per_dose = \frac{12 \times 15}{3} = 180 / 3 = 60 → dose_60 ≈ 1.0.
+
+prior 0.001 for dose_60
+prior 0.001 for dose_45
+
+let per_dose = \frac{12 \times 15}{3}
+
+contributes 1000000 from per_dose == 60 to dose_60
+  source "weight-based dosing: 12 mg/kg × 15 kg ÷ 3 divided doses" trust authoritative
+contributes 1000000 from per_dose == 45 to dose_45
+
+? dose_60
+? dose_45


### PR DESCRIPTION
## adj-lang understands LaTeX math natively

Math-tuned local models (Gemma, etc.) routinely emit arithmetic as **LaTeX**. Rather than "normalising" a decomposed formula with an ad-hoc regex in some upstream tool, **the language owns the syntax**: `let` / compute expressions now read LaTeX directly and lower it to the *same* arithmetic the engine already computes — identical value, identical proof tree.

### What's supported
| LaTeX | meaning | lowers to |
|-------|---------|-----------|
| `\times`, `\cdot` | multiply | `ArithOp::Mul` (same as `*`) |
| `\div` | divide | `ArithOp::Div` (same as `/`) |
| `\frac{A}{B}` | divide | `A / B` (braces hold full exprs, e.g. `\frac{12 \times 2}{6}`) |

`7 * 8` and `7 \times 8` produce a byte-identical AST and proof. LaTeX and ASCII operators mix freely in one formula.

### Implementation (small, contained)
- **tokens** (`adj_lang.tokens`): `LTIMES`/`LCDOT`/`LDIV`/`LFRAC` as regex tokens (backslash matched literally; nothing else starts with `\`).
- **grammar** (`adj_lang.grammar`): `term_expr` gains the three LaTeX infix operators; `factor` gains `LFRAC LBRACE expr RBRACE LBRACE expr RBRACE`.
- **adapter** (`adapter.rs`): `arith_op_from_value` maps the LaTeX spellings to the existing `ArithOp::{Mul,Div}`; `adapt_factor` lowers `\frac` to `Div` (before the paren branch, binding both brace-groups). **No new compute op, no engine change.**
- regenerated `_lexer_grammar.rs` / `_parser_grammar.rs` (deterministic / idempotent; main's generated parser was stale, hence the large generated-file delta).

### Verification
- `cargo test -p adj-lang -p adj-lang-cli` green (86 + 30 integration), incl. **5 new adapter tests** and a worked-example golden test.
- New worked example `latex_math.adj` (weight-based dose `\frac{12 \times 15}{3} = 60` → `dose_60`), wired into the examples README + golden suite.
- adj-lang `0.17.0 → 0.18.0`; CHANGELOG updated.

### Scope notes
- `$…$` display delimiters intentionally **not** tokens — `$` is the VAR sigil (`$Var`); bare `a \times b` is the supported form (what decomposers emit).
- `^`/power **deferred** — no `ComputeOp::Pow` yet, and exponent dimensionality (`m^2`) needs its own design.

This is the principled home for LaTeX agreed in discussion: the ADJ-LADDER eval harness stays strict ASCII and passes the model's math **through** to the engine, which now parses it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)