### PR TITLE
spice: expose output-plan directive kinds

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Added
 
+- **Deck output-plan directive-kind artifacts** —
+  selected `run_deck_analysis()` output-plan artifacts now expose normalized
+  output directive kind counts/lists beside the selected directive tokens in
+  table, CSV, compact JSON, and header-keyed record exports, matching Rust and
+  TypeScript.
+
 - **Deck output-plan table export artifacts** —
   selected `run_deck_analysis()` executions now include `output-plan` in
   `tables`, selected-run `TableList` metadata, and ordered `table_artifacts`

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -113,9 +113,9 @@ that produced the table, plus selected
 executions. Execution `table_artifacts` preserve the same order as `tables` and
 carry each stable table's text, CSV, compact JSON, and header-keyed records.
 Execution `output_plan_artifacts` summarize the selected result columns,
-output probes, output directives, and stable table names, and the `output-plan`
-entry in `table_artifacts` carries the same table, CSV, compact JSON, and
-header-keyed record exports.
+output probes, output directives, normalized output directive kinds, and stable
+table names, and the `output-plan` entry in `table_artifacts` carries the same
+table, CSV, compact JSON, and header-keyed record exports.
 Selected `.tran` plans also return selected `.four` harmonic results and a stable
 Fourier table. Executions also include a selected-run artifact summary plus
 `format_deck_run_artifact_table()` and `format_deck_run_artifact_csv()` output

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -2388,6 +2388,8 @@ class DeckOutputPlanArtifact:
     output_probes: list[str]
     output_directive_count: int
     output_directives: list[str]
+    output_directive_kind_count: int
+    output_directive_kinds: list[str]
     table_count: int
     tables: list[str]
 
@@ -2783,6 +2785,23 @@ def _deck_stable_tables(
     return tables
 
 
+def _deck_output_directive_kind(directive: str) -> str:
+    token = directive.strip().split(maxsplit=1)[0].lower()
+    return token[1:] if token.startswith(".") else token
+
+
+def _deck_output_directive_kinds(output_directives: Iterable[str]) -> list[str]:
+    selected: list[str] = []
+    seen: set[str] = set()
+    for directive in output_directives:
+        kind = _deck_output_directive_kind(directive)
+        if not kind or kind in seen:
+            continue
+        seen.add(kind)
+        selected.append(kind)
+    return selected
+
+
 def _deck_run_artifacts(
     plan: DeckAnalysisPlan,
     result: DcResult | DcSweepResult | AcResult | TransientResult | TfResult | SensResult | NoiseResult,
@@ -2875,6 +2894,7 @@ def _deck_output_plan_artifacts(
     output_directives: list[str],
     tables: list[str],
 ) -> list[DeckOutputPlanArtifact]:
+    output_directive_kinds = _deck_output_directive_kinds(output_directives)
     return [
         DeckOutputPlanArtifact(
             analysis=plan.analysis,
@@ -2885,6 +2905,8 @@ def _deck_output_plan_artifacts(
             output_probes=list(output_probes),
             output_directive_count=len(output_directives),
             output_directives=list(output_directives),
+            output_directive_kind_count=len(output_directive_kinds),
+            output_directive_kinds=output_directive_kinds,
             table_count=len(tables),
             tables=list(tables),
         )
@@ -2900,6 +2922,8 @@ _DECK_OUTPUT_PLAN_ARTIFACT_COLUMNS = [
     "OutputProbeList",
     "OutputDirectives",
     "OutputDirectiveList",
+    "OutputDirectiveKinds",
+    "OutputDirectiveKindList",
     "Tables",
     "TableList",
 ]
@@ -2915,6 +2939,8 @@ def _deck_output_plan_artifact_cells(artifact: DeckOutputPlanArtifact) -> list[s
         ";".join(artifact.output_probes),
         str(artifact.output_directive_count),
         ";".join(artifact.output_directives),
+        str(artifact.output_directive_kind_count),
+        ";".join(artifact.output_directive_kinds),
         str(artifact.table_count),
         ";".join(artifact.tables),
     ]

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -6824,6 +6824,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     netlist = """
 .save V(mid)
 .probe dc I(V1)
+.print dc V(mid)
+.plot ac V(mid)
 .op
 .dc V1 0 1 1
 .ac dec 1 1k 1k
@@ -6869,8 +6871,10 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     )
     expected_output_plan_table = (
         "Analysis\tDirective\tResultColumns\tResultColumnList\tOutputProbes\t"
-        "OutputProbeList\tOutputDirectives\tOutputDirectiveList\tTables\tTableList\n"
-        "op\t.op\t2\tIndex;V(mid)\t1\tV(mid)\t1\t.save\t3\tresult;output-plan;run-artifact\n"
+        "OutputProbeList\tOutputDirectives\tOutputDirectiveList\t"
+        "OutputDirectiveKinds\tOutputDirectiveKindList\tTables\tTableList\n"
+        "op\t.op\t2\tIndex;V(mid)\t1\tV(mid)\t1\t.save\t1\tsave\t3\t"
+        "result;output-plan;run-artifact\n"
     )
     expected_output_plan_records = [
         {
@@ -6882,6 +6886,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
             "OutputProbeList": "V(mid)",
             "OutputDirectives": "1",
             "OutputDirectiveList": ".save",
+            "OutputDirectiveKinds": "1",
+            "OutputDirectiveKindList": "save",
             "Tables": "3",
             "TableList": "result;output-plan;run-artifact",
         }
@@ -6894,6 +6900,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert output_plan_artifact.result_columns == ["Index", "V(mid)"]
     assert output_plan_artifact.output_probes == ["V(mid)"]
     assert output_plan_artifact.output_directives == [".save"]
+    assert output_plan_artifact.output_directive_kind_count == 1
+    assert output_plan_artifact.output_directive_kinds == ["save"]
     assert output_plan_artifact.tables == ["result", "output-plan", "run-artifact"]
     assert op_execution.output_plan_artifact_table == expected_output_plan_table
     assert op_execution.output_plan_artifact_table == (
@@ -6901,8 +6909,10 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     )
     assert op_execution.output_plan_artifact_csv == (
         "Analysis,Directive,ResultColumns,ResultColumnList,OutputProbes,"
-        "OutputProbeList,OutputDirectives,OutputDirectiveList,Tables,TableList\n"
-        "op,.op,2,Index;V(mid),1,V(mid),1,.save,3,result;output-plan;run-artifact\n"
+        "OutputProbeList,OutputDirectives,OutputDirectiveList,"
+        "OutputDirectiveKinds,OutputDirectiveKindList,Tables,TableList\n"
+        "op,.op,2,Index;V(mid),1,V(mid),1,.save,1,save,3,"
+        "result;output-plan;run-artifact\n"
     )
     assert op_execution.output_plan_artifact_csv == (
         format_deck_output_plan_artifact_csv(op_execution.output_plan_artifacts)
@@ -7101,7 +7111,15 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     dc_execution = run_deck_analysis(circuit, netlist, "dc")
     assert dc_execution.plan.source_name == "V1"
     assert dc_execution.output_probes == ["V(mid)", "I(V1)"]
-    assert dc_execution.output_directives == [".save", ".probe"]
+    assert dc_execution.output_directives == [".save", ".probe", ".print"]
+    assert dc_execution.output_plan_artifacts[0].output_directive_kinds == [
+        "save",
+        "probe",
+        "print",
+    ]
+    assert dc_execution.output_plan_artifact_records[0][
+        "OutputDirectiveKindList"
+    ] == "save;probe;print"
     assert dc_execution.analysis_directives == [".dc"]
     assert dc_execution.table_count == 4
     assert dc_execution.tables == ["result", "measurement", "output-plan", "run-artifact"]
@@ -7154,18 +7172,29 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert dc_execution.run_artifacts[0].step_time is None
     assert dc_execution.run_artifacts[0].use_initial_conditions is None
     assert dc_execution.run_artifacts[0].output_probes == ["V(mid)", "I(V1)"]
-    assert dc_execution.run_artifacts[0].output_directives == [".save", ".probe"]
+    assert dc_execution.run_artifacts[0].output_directives == [
+        ".save",
+        ".probe",
+        ".print",
+    ]
     assert dc_execution.run_artifacts[0].analysis_directives == [".dc"]
     assert dc_execution.run_artifacts[0].measurement_names == ["mid_avg"]
     assert dc_execution.run_artifacts[0].fourier_probes == []
     assert dc_execution.run_artifact_table == (
         "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tControlPolicyArtifacts\tControlPolicyCategoryList\tControlPolicyCodeList\tControlPolicySeverityList\tDiagnostics\tDiagnosticCodeList\n"
-        f"dc\t.dc\t1\t.dc\t{dc_execution.plan.line_number}\tV1\t\t\t0.000000e+00\t1.000000e+00\t1.000000e+00\t\t\t\t\t\t\t\t\t2\t5\tIndex;Source;Value;V(mid);I(V1)\t4\tresult;measurement;output-plan;run-artifact\t2\tV(mid);I(V1)\t2\t.save;.probe\t1\tmid_avg\t0\t\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n"
+        f"dc\t.dc\t1\t.dc\t{dc_execution.plan.line_number}\tV1\t\t\t0.000000e+00\t1.000000e+00\t1.000000e+00\t\t\t\t\t\t\t\t\t2\t5\tIndex;Source;Value;V(mid);I(V1)\t4\tresult;measurement;output-plan;run-artifact\t2\tV(mid);I(V1)\t3\t.save;.probe;.print\t1\tmid_avg\t0\t\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n"
     )
 
     ac_execution = run_deck_analysis(circuit, netlist, "ac")
     assert ac_execution.output_probes == ["V(mid)"]
-    assert ac_execution.output_directives == [".save"]
+    assert ac_execution.output_directives == [".save", ".plot"]
+    assert ac_execution.output_plan_artifacts[0].output_directive_kinds == [
+        "save",
+        "plot",
+    ]
+    assert ac_execution.output_plan_artifact_records[0][
+        "OutputDirectiveKindList"
+    ] == "save;plot"
     assert ac_execution.analysis_directives == [".ac"]
     assert ac_execution.table_count == 4
     assert ac_execution.tables == ["result", "measurement", "output-plan", "run-artifact"]
@@ -7206,12 +7235,12 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     ]
     assert ac_execution.run_artifacts[0].step_time is None
     assert ac_execution.run_artifacts[0].use_initial_conditions is None
-    assert ac_execution.run_artifacts[0].output_directives == [".save"]
+    assert ac_execution.run_artifacts[0].output_directives == [".save", ".plot"]
     assert ac_execution.run_artifacts[0].measurement_names == ["mid_peak"]
     assert ac_execution.run_artifacts[0].fourier_probes == []
     assert ac_execution.run_artifact_table == (
         "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tControlPolicyArtifacts\tControlPolicyCategoryList\tControlPolicyCodeList\tControlPolicySeverityList\tDiagnostics\tDiagnosticCodeList\n"
-        f"ac\t.ac\t1\t.ac\t{ac_execution.plan.line_number}\t\t\tdec\t\t\t\t1\t1.000000e+03\t1.000000e+03\t\t\t\t\t\t1\t7\tIndex;Frequency;Probe;Real;Imaginary;Magnitude;Phase\t4\tresult;measurement;output-plan;run-artifact\t1\tV(mid)\t1\t.save\t1\tmid_peak\t0\t\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n"
+        f"ac\t.ac\t1\t.ac\t{ac_execution.plan.line_number}\t\t\tdec\t\t\t\t1\t1.000000e+03\t1.000000e+03\t\t\t\t\t\t1\t7\tIndex;Frequency;Probe;Real;Imaginary;Magnitude;Phase\t4\tresult;measurement;output-plan;run-artifact\t1\tV(mid)\t2\t.save;.plot\t1\tmid_peak\t0\t\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n"
     )
 
     tran_execution = run_deck_analysis(circuit, netlist, "tran")

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Expose normalized selected output directive kind inventories in
+  `run_deck_analysis` output-plan artifacts beside the selected directive
+  tokens, with stable table, CSV, compact JSON, and header-keyed record exports,
+  matching Python and TypeScript.
 - Include selected `run_deck_analysis` output-plan tables in execution
   `tables`, selected-run `TableList` metadata, and ordered `table_artifacts`
   with stable table, CSV, compact JSON, and header-keyed record payloads,

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -182,9 +182,9 @@ a stable measurement table for `.dc`, `.ac`, and `.tran` executions.
 Execution `table_artifacts` preserve the same order as `tables` and carry each
 stable table's text, CSV, compact JSON, and header-keyed records.
 Execution `output_plan_artifacts` summarize the selected result columns,
-output probes, output directives, and stable table names, and the `output-plan`
-entry in `table_artifacts` carries the same table, CSV, compact JSON, and
-header-keyed record exports.
+output probes, output directives, normalized output directive kinds, and stable
+table names, and the `output-plan` entry in `table_artifacts` carries the same
+table, CSV, compact JSON, and header-keyed record exports.
 Selected `.tran` plans route
 `START` output filtering, `.tran TSTEP` as the output print grid, `MAXSTEP` as
 an internal fixed-step cap, and `UIC` initial-condition intent through that

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -3472,6 +3472,8 @@ pub struct DeckOutputPlanArtifact {
     pub output_probes: Vec<String>,
     pub output_directive_count: usize,
     pub output_directives: Vec<String>,
+    pub output_directive_kind_count: usize,
+    pub output_directive_kinds: Vec<String>,
     pub table_count: usize,
     pub tables: Vec<String>,
 }
@@ -10373,6 +10375,7 @@ fn deck_output_plan_artifacts(
     output_directives: &[String],
     tables: &[String],
 ) -> Vec<DeckOutputPlanArtifact> {
+    let output_directive_kinds = deck_output_directive_kinds(output_directives);
     vec![DeckOutputPlanArtifact {
         analysis: plan.analysis.clone(),
         directive: plan.directive.clone(),
@@ -10382,9 +10385,34 @@ fn deck_output_plan_artifacts(
         output_probes: output_probes.to_vec(),
         output_directive_count: output_directives.len(),
         output_directives: output_directives.to_vec(),
+        output_directive_kind_count: output_directive_kinds.len(),
+        output_directive_kinds,
         table_count: tables.len(),
         tables: tables.to_vec(),
     }]
+}
+
+fn deck_output_directive_kind(directive: &str) -> String {
+    let token = directive
+        .trim()
+        .split_whitespace()
+        .next()
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    token.strip_prefix('.').unwrap_or(&token).to_string()
+}
+
+fn deck_output_directive_kinds(output_directives: &[String]) -> Vec<String> {
+    let mut selected = Vec::new();
+    let mut seen = HashSet::new();
+    for directive in output_directives {
+        let kind = deck_output_directive_kind(directive);
+        if kind.is_empty() || !seen.insert(kind.clone()) {
+            continue;
+        }
+        selected.push(kind);
+    }
+    selected
 }
 
 const DECK_OUTPUT_PLAN_ARTIFACT_COLUMNS: &[&str] = &[
@@ -10396,6 +10424,8 @@ const DECK_OUTPUT_PLAN_ARTIFACT_COLUMNS: &[&str] = &[
     "OutputProbeList",
     "OutputDirectives",
     "OutputDirectiveList",
+    "OutputDirectiveKinds",
+    "OutputDirectiveKindList",
     "Tables",
     "TableList",
 ];
@@ -10410,6 +10440,8 @@ fn deck_output_plan_artifact_cells(artifact: &DeckOutputPlanArtifact) -> Vec<Str
         artifact.output_probes.join(";"),
         artifact.output_directive_count.to_string(),
         artifact.output_directives.join(";"),
+        artifact.output_directive_kind_count.to_string(),
+        artifact.output_directive_kinds.join(";"),
         artifact.table_count.to_string(),
         artifact.tables.join(";"),
     ]

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -1899,6 +1899,8 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     let netlist = "
 .save V(mid)
 .probe dc I(V1)
+.print dc V(mid)
+.plot ac V(mid)
 .op
 .dc V1 0 1 1
 .ac dec 1 1k 1k
@@ -1981,6 +1983,11 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
         output_plan_artifact.output_directives,
         vec![".save".to_string()]
     );
+    assert_eq!(output_plan_artifact.output_directive_kind_count, 1);
+    assert_eq!(
+        output_plan_artifact.output_directive_kinds,
+        vec!["save".to_string()]
+    );
     assert_eq!(
         output_plan_artifact.tables,
         vec![
@@ -1991,7 +1998,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     );
     assert_eq!(
         op_execution.output_plan_artifact_table,
-        "Analysis\tDirective\tResultColumns\tResultColumnList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tTables\tTableList\nop\t.op\t2\tIndex;V(mid)\t1\tV(mid)\t1\t.save\t3\tresult;output-plan;run-artifact\n"
+        "Analysis\tDirective\tResultColumns\tResultColumnList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tOutputDirectiveKinds\tOutputDirectiveKindList\tTables\tTableList\nop\t.op\t2\tIndex;V(mid)\t1\tV(mid)\t1\t.save\t1\tsave\t3\tresult;output-plan;run-artifact\n"
     );
     assert_eq!(
         op_execution.output_plan_artifact_table,
@@ -1999,7 +2006,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     );
     assert_eq!(
         op_execution.output_plan_artifact_csv,
-        "Analysis,Directive,ResultColumns,ResultColumnList,OutputProbes,OutputProbeList,OutputDirectives,OutputDirectiveList,Tables,TableList\nop,.op,2,Index;V(mid),1,V(mid),1,.save,3,result;output-plan;run-artifact\n"
+        "Analysis,Directive,ResultColumns,ResultColumnList,OutputProbes,OutputProbeList,OutputDirectives,OutputDirectiveList,OutputDirectiveKinds,OutputDirectiveKindList,Tables,TableList\nop,.op,2,Index;V(mid),1,V(mid),1,.save,1,save,3,result;output-plan;run-artifact\n"
     );
     assert_eq!(
         op_execution.output_plan_artifact_csv,
@@ -2024,6 +2031,12 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
             .get("OutputDirectiveList")
             .map(String::as_str),
         Some(".save")
+    );
+    assert_eq!(
+        op_execution.output_plan_artifact_records[0]
+            .get("OutputDirectiveKindList")
+            .map(String::as_str),
+        Some("save")
     );
     assert_eq!(
         op_execution.output_plan_artifact_records[0]
@@ -2215,7 +2228,21 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     );
     assert_eq!(
         dc_execution.output_directives,
-        vec![".save".to_string(), ".probe".to_string()]
+        vec![
+            ".save".to_string(),
+            ".probe".to_string(),
+            ".print".to_string()
+        ]
+    );
+    assert_eq!(
+        dc_execution.output_plan_artifacts[0].output_directive_kinds,
+        vec!["save".to_string(), "probe".to_string(), "print".to_string()]
+    );
+    assert_eq!(
+        dc_execution.output_plan_artifact_records[0]
+            .get("OutputDirectiveKindList")
+            .map(String::as_str),
+        Some("save;probe;print")
     );
     assert_eq!(dc_execution.analysis_directives, vec![".dc".to_string()]);
     assert_eq!(dc_execution.table_count, 4);
@@ -2303,7 +2330,11 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     );
     assert_eq!(
         dc_execution.run_artifacts[0].output_directives,
-        vec![".save".to_string(), ".probe".to_string()]
+        vec![
+            ".save".to_string(),
+            ".probe".to_string(),
+            ".print".to_string()
+        ]
     );
     assert_eq!(
         dc_execution.run_artifacts[0].analysis_directives,
@@ -2317,14 +2348,27 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         dc_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tControlPolicyArtifacts\tControlPolicyCategoryList\tControlPolicyCodeList\tControlPolicySeverityList\tDiagnostics\tDiagnosticCodeList\ndc\t.dc\t1\t.dc\t{}\tV1\t\t\t0.000000e+00\t1.000000e+00\t1.000000e+00\t\t\t\t\t\t\t\t\t2\t5\tIndex;Source;Value;V(mid);I(V1)\t4\tresult;measurement;output-plan;run-artifact\t2\tV(mid);I(V1)\t2\t.save;.probe\t1\tmid_avg\t0\t\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n",
+            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tControlPolicyArtifacts\tControlPolicyCategoryList\tControlPolicyCodeList\tControlPolicySeverityList\tDiagnostics\tDiagnosticCodeList\ndc\t.dc\t1\t.dc\t{}\tV1\t\t\t0.000000e+00\t1.000000e+00\t1.000000e+00\t\t\t\t\t\t\t\t\t2\t5\tIndex;Source;Value;V(mid);I(V1)\t4\tresult;measurement;output-plan;run-artifact\t2\tV(mid);I(V1)\t3\t.save;.probe;.print\t1\tmid_avg\t0\t\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n",
             dc_execution.plan.line_number
         )
     );
 
     let ac_execution = run_deck_analysis(&circuit, netlist, Some("ac")).unwrap();
     assert_eq!(ac_execution.output_probes, vec!["V(mid)".to_string()]);
-    assert_eq!(ac_execution.output_directives, vec![".save".to_string()]);
+    assert_eq!(
+        ac_execution.output_directives,
+        vec![".save".to_string(), ".plot".to_string()]
+    );
+    assert_eq!(
+        ac_execution.output_plan_artifacts[0].output_directive_kinds,
+        vec!["save".to_string(), "plot".to_string()]
+    );
+    assert_eq!(
+        ac_execution.output_plan_artifact_records[0]
+            .get("OutputDirectiveKindList")
+            .map(String::as_str),
+        Some("save;plot")
+    );
     assert_eq!(ac_execution.analysis_directives, vec![".ac".to_string()]);
     assert_eq!(ac_execution.table_count, 4);
     assert_eq!(
@@ -2392,7 +2436,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(ac_execution.run_artifacts[0].use_initial_conditions, None);
     assert_eq!(
         ac_execution.run_artifacts[0].output_directives,
-        vec![".save".to_string()]
+        vec![".save".to_string(), ".plot".to_string()]
     );
     assert_eq!(
         ac_execution.run_artifacts[0].measurement_names,
@@ -2402,7 +2446,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         ac_execution.run_artifact_table,
         format!(
-            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tControlPolicyArtifacts\tControlPolicyCategoryList\tControlPolicyCodeList\tControlPolicySeverityList\tDiagnostics\tDiagnosticCodeList\nac\t.ac\t1\t.ac\t{}\t\t\tdec\t\t\t\t1\t1.000000e+03\t1.000000e+03\t\t\t\t\t\t1\t7\tIndex;Frequency;Probe;Real;Imaginary;Magnitude;Phase\t4\tresult;measurement;output-plan;run-artifact\t1\tV(mid)\t1\t.save\t1\tmid_peak\t0\t\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n",
+            "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tControlPolicyArtifacts\tControlPolicyCategoryList\tControlPolicyCodeList\tControlPolicySeverityList\tDiagnostics\tDiagnosticCodeList\nac\t.ac\t1\t.ac\t{}\t\t\tdec\t\t\t\t1\t1.000000e+03\t1.000000e+03\t\t\t\t\t\t1\t7\tIndex;Frequency;Probe;Real;Imaginary;Magnitude;Phase\t4\tresult;measurement;output-plan;run-artifact\t1\tV(mid)\t2\t.save;.plot\t1\tmid_peak\t0\t\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n",
             ac_execution.plan.line_number
         )
     );

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Expose normalized selected output directive kind inventories in
+  `runDeckAnalysis` output-plan artifacts beside the selected directive tokens,
+  with stable table, CSV, compact JSON, and header-keyed record exports,
+  matching Python and Rust.
 - Include selected `runDeckAnalysis` output-plan tables in execution `tables`,
   selected-run `TableList` metadata, and ordered `tableArtifacts` with stable
   table, CSV, compact JSON, and header-keyed record payloads, matching Python

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -96,8 +96,8 @@ table count/name list, output probes, and output directives that produced the
 table, plus selected `.measure` results and
 a stable measurement table for `.dc`, `.ac`, and `.tran` executions.
 Execution `outputPlanArtifacts` summarize the selected result columns, output
-probes, output directives, and stable table names with table, CSV, compact JSON,
-and header-keyed record exports.
+probes, output directives, normalized output directive kinds, and stable table
+names with table, CSV, compact JSON, and header-keyed record exports.
 Execution `tableArtifacts` preserve the same order as `tables` and carry each
 stable table's text, CSV, compact JSON, and header-keyed records.
 The `output-plan` entry in `tableArtifacts` carries the same

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -725,6 +725,8 @@ export interface DeckOutputPlanArtifact {
   readonly outputProbes: readonly string[];
   readonly outputDirectiveCount: number;
   readonly outputDirectives: readonly string[];
+  readonly outputDirectiveKindCount: number;
+  readonly outputDirectiveKinds: readonly string[];
   readonly tableCount: number;
   readonly tables: readonly string[];
 }
@@ -8315,6 +8317,7 @@ function deckOutputPlanArtifacts(
   outputDirectives: readonly string[],
   tables: readonly string[],
 ): DeckOutputPlanArtifact[] {
+  const outputDirectiveKinds = deckOutputDirectiveKinds(outputDirectives);
   return [
     {
       analysis: plan.analysis,
@@ -8325,10 +8328,31 @@ function deckOutputPlanArtifacts(
       outputProbes: [...outputProbes],
       outputDirectiveCount: outputDirectives.length,
       outputDirectives: [...outputDirectives],
+      outputDirectiveKindCount: outputDirectiveKinds.length,
+      outputDirectiveKinds,
       tableCount: tables.length,
       tables: [...tables],
     },
   ];
+}
+
+function deckOutputDirectiveKind(directive: string): string {
+  const token = directive.trim().split(/\s+/u)[0]?.toLowerCase() ?? "";
+  return token.startsWith(".") ? token.slice(1) : token;
+}
+
+function deckOutputDirectiveKinds(outputDirectives: readonly string[]): string[] {
+  const selected: string[] = [];
+  const seen = new Set<string>();
+  for (const directive of outputDirectives) {
+    const kind = deckOutputDirectiveKind(directive);
+    if (kind.length === 0 || seen.has(kind)) {
+      continue;
+    }
+    seen.add(kind);
+    selected.push(kind);
+  }
+  return selected;
 }
 
 const DECK_OUTPUT_PLAN_ARTIFACT_COLUMNS = [
@@ -8340,6 +8364,8 @@ const DECK_OUTPUT_PLAN_ARTIFACT_COLUMNS = [
   "OutputProbeList",
   "OutputDirectives",
   "OutputDirectiveList",
+  "OutputDirectiveKinds",
+  "OutputDirectiveKindList",
   "Tables",
   "TableList",
 ] as const;
@@ -8354,6 +8380,8 @@ function deckOutputPlanArtifactCells(artifact: DeckOutputPlanArtifact): string[]
     artifact.outputProbes.join(";"),
     String(artifact.outputDirectiveCount),
     artifact.outputDirectives.join(";"),
+    String(artifact.outputDirectiveKindCount),
+    artifact.outputDirectiveKinds.join(";"),
     String(artifact.tableCount),
     artifact.tables.join(";"),
   ];

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -1496,6 +1496,8 @@ describe("transient", () => {
     const netlist = `
 .save V(mid)
 .probe dc I(V1)
+.print dc V(mid)
+.plot ac V(mid)
 .op
 .dc V1 0 1 1
 .ac dec 1 1k 1k
@@ -1546,6 +1548,8 @@ describe("transient", () => {
         OutputProbeList: "V(mid)",
         OutputDirectives: "1",
         OutputDirectiveList: ".save",
+        OutputDirectiveKinds: "1",
+        OutputDirectiveKindList: "save",
         Tables: "3",
         TableList: "result;output-plan;run-artifact",
       },
@@ -1561,19 +1565,21 @@ describe("transient", () => {
       outputProbes: ["V(mid)"],
       outputDirectiveCount: 1,
       outputDirectives: [".save"],
+      outputDirectiveKindCount: 1,
+      outputDirectiveKinds: ["save"],
       tableCount: 3,
       tables: ["result", "output-plan", "run-artifact"],
     });
     expect(opExecution.outputPlanArtifactTable).toBe(
-      "Analysis\tDirective\tResultColumns\tResultColumnList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tTables\tTableList\n" +
-        "op\t.op\t2\tIndex;V(mid)\t1\tV(mid)\t1\t.save\t3\tresult;output-plan;run-artifact\n",
+      "Analysis\tDirective\tResultColumns\tResultColumnList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tOutputDirectiveKinds\tOutputDirectiveKindList\tTables\tTableList\n" +
+        "op\t.op\t2\tIndex;V(mid)\t1\tV(mid)\t1\t.save\t1\tsave\t3\tresult;output-plan;run-artifact\n",
     );
     expect(opExecution.outputPlanArtifactTable).toBe(
       formatDeckOutputPlanArtifactTable(opExecution.outputPlanArtifacts),
     );
     expect(opExecution.outputPlanArtifactCsv).toBe(
-      "Analysis,Directive,ResultColumns,ResultColumnList,OutputProbes,OutputProbeList,OutputDirectives,OutputDirectiveList,Tables,TableList\n" +
-        "op,.op,2,Index;V(mid),1,V(mid),1,.save,3,result;output-plan;run-artifact\n",
+      "Analysis,Directive,ResultColumns,ResultColumnList,OutputProbes,OutputProbeList,OutputDirectives,OutputDirectiveList,OutputDirectiveKinds,OutputDirectiveKindList,Tables,TableList\n" +
+        "op,.op,2,Index;V(mid),1,V(mid),1,.save,1,save,3,result;output-plan;run-artifact\n",
     );
     expect(opExecution.outputPlanArtifactCsv).toBe(
       formatDeckOutputPlanArtifactCsv(opExecution.outputPlanArtifacts),
@@ -1772,7 +1778,15 @@ describe("transient", () => {
     const dcExecution = runDeckAnalysis(circuit, netlist, "dc");
     expect(dcExecution.plan.sourceName).toBe("V1");
     expect(dcExecution.outputProbes).toEqual(["V(mid)", "I(V1)"]);
-    expect(dcExecution.outputDirectives).toEqual([".save", ".probe"]);
+    expect(dcExecution.outputDirectives).toEqual([".save", ".probe", ".print"]);
+    expect(dcExecution.outputPlanArtifacts[0]?.outputDirectiveKinds).toEqual([
+      "save",
+      "probe",
+      "print",
+    ]);
+    expect(dcExecution.outputPlanArtifactRecords[0]?.OutputDirectiveKindList).toBe(
+      "save;probe;print",
+    );
     expect(dcExecution.analysisDirectives).toEqual([".dc"]);
     expect(dcExecution.tableCount).toBe(4);
     expect(dcExecution.tables).toEqual(["result", "measurement", "output-plan", "run-artifact"]);
@@ -1821,18 +1835,29 @@ describe("transient", () => {
     expect(dcExecution.runArtifacts[0]?.stepTime).toBeUndefined();
     expect(dcExecution.runArtifacts[0]?.useInitialConditions).toBeUndefined();
     expect(dcExecution.runArtifacts[0]?.outputProbes).toEqual(["V(mid)", "I(V1)"]);
-    expect(dcExecution.runArtifacts[0]?.outputDirectives).toEqual([".save", ".probe"]);
+    expect(dcExecution.runArtifacts[0]?.outputDirectives).toEqual([
+      ".save",
+      ".probe",
+      ".print",
+    ]);
     expect(dcExecution.runArtifacts[0]?.analysisDirectives).toEqual([".dc"]);
     expect(dcExecution.runArtifacts[0]?.measurementNames).toEqual(["mid_avg"]);
     expect(dcExecution.runArtifacts[0]?.fourierProbes).toEqual([]);
     expect(dcExecution.runArtifactTable).toBe(
       "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tControlPolicyArtifacts\tControlPolicyCategoryList\tControlPolicyCodeList\tControlPolicySeverityList\tDiagnostics\tDiagnosticCodeList\n" +
-        `dc\t.dc\t1\t.dc\t${dcExecution.plan.lineNumber}\tV1\t\t\t0.000000e+00\t1.000000e+00\t1.000000e+00\t\t\t\t\t\t\t\t\t2\t5\tIndex;Source;Value;V(mid);I(V1)\t4\tresult;measurement;output-plan;run-artifact\t2\tV(mid);I(V1)\t2\t.save;.probe\t1\tmid_avg\t0\t\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n`,
+        `dc\t.dc\t1\t.dc\t${dcExecution.plan.lineNumber}\tV1\t\t\t0.000000e+00\t1.000000e+00\t1.000000e+00\t\t\t\t\t\t\t\t\t2\t5\tIndex;Source;Value;V(mid);I(V1)\t4\tresult;measurement;output-plan;run-artifact\t2\tV(mid);I(V1)\t3\t.save;.probe;.print\t1\tmid_avg\t0\t\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n`,
     );
 
     const acExecution = runDeckAnalysis(circuit, netlist, "ac");
     expect(acExecution.outputProbes).toEqual(["V(mid)"]);
-    expect(acExecution.outputDirectives).toEqual([".save"]);
+    expect(acExecution.outputDirectives).toEqual([".save", ".plot"]);
+    expect(acExecution.outputPlanArtifacts[0]?.outputDirectiveKinds).toEqual([
+      "save",
+      "plot",
+    ]);
+    expect(acExecution.outputPlanArtifactRecords[0]?.OutputDirectiveKindList).toBe(
+      "save;plot",
+    );
     expect(acExecution.analysisDirectives).toEqual([".ac"]);
     expect(acExecution.tableCount).toBe(4);
     expect(acExecution.tables).toEqual(["result", "measurement", "output-plan", "run-artifact"]);
@@ -1872,12 +1897,12 @@ describe("transient", () => {
     ]);
     expect(acExecution.runArtifacts[0]?.stepTime).toBeUndefined();
     expect(acExecution.runArtifacts[0]?.useInitialConditions).toBeUndefined();
-    expect(acExecution.runArtifacts[0]?.outputDirectives).toEqual([".save"]);
+    expect(acExecution.runArtifacts[0]?.outputDirectives).toEqual([".save", ".plot"]);
     expect(acExecution.runArtifacts[0]?.measurementNames).toEqual(["mid_peak"]);
     expect(acExecution.runArtifacts[0]?.fourierProbes).toEqual([]);
     expect(acExecution.runArtifactTable).toBe(
       "Analysis\tDirective\tAnalysisDirectives\tAnalysisDirectiveList\tLine\tSourceName\tOutputNode\tSweepKind\tStartValue\tStopValue\tStepValue\tPointCount\tStartFrequencyHz\tStopFrequencyHz\tStepTime\tStopTime\tStartTime\tMaxStep\tUseInitialConditions\tResultRows\tResultColumns\tResultColumnList\tTables\tTableList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tMeasurements\tMeasurementList\tFourier\tFourierList\tControlLines\tControlLineList\tWriteMarkers\tWriteMarkerList\tRawfileOptions\tRawfileOptionList\tControlPolicyArtifacts\tControlPolicyCategoryList\tControlPolicyCodeList\tControlPolicySeverityList\tDiagnostics\tDiagnosticCodeList\n" +
-        `ac\t.ac\t1\t.ac\t${acExecution.plan.lineNumber}\t\t\tdec\t\t\t\t1\t1.000000e+03\t1.000000e+03\t\t\t\t\t\t1\t7\tIndex;Frequency;Probe;Real;Imaginary;Magnitude;Phase\t4\tresult;measurement;output-plan;run-artifact\t1\tV(mid)\t1\t.save\t1\tmid_peak\t0\t\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n`,
+        `ac\t.ac\t1\t.ac\t${acExecution.plan.lineNumber}\t\t\tdec\t\t\t\t1\t1.000000e+03\t1.000000e+03\t\t\t\t\t\t1\t7\tIndex;Frequency;Probe;Real;Imaginary;Magnitude;Phase\t4\tresult;measurement;output-plan;run-artifact\t1\tV(mid)\t2\t.save;.plot\t1\tmid_peak\t0\t\t0\t\t0\t\t0\t\t0\t\t\t\t0\t\n`,
     );
 
     const tranExecution = runDeckAnalysis(circuit, netlist, "tran");

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -133,7 +133,10 @@ downstream tools to compare.
      severity, message, stable table, CSV, compact JSON, and host-native record
      exports, and those row-level and category-summary policy tables now also
      travel through ordered table export artifacts plus selected-run `TableList`
-     metadata.
+     metadata; selected output-plan artifacts now also expose normalized
+     `.save`, `.probe`, `.print`, and `.plot` directive kind counts/lists
+     beside the selected directive tokens in table, CSV, compact JSON, and
+     host-native record exports.
    - Expand remaining deck-controlled analyses toward full SPICE compatibility
      while keeping unsupported control-flow diagnostics explicit.
 
@@ -1151,6 +1154,15 @@ downstream tools to compare.
     - Ordered table export artifacts now carry the output-plan table with
       stable table, CSV, compact JSON, and host-native record payloads beside
       result, optional side tables, and selected-run artifact exports.
+
+106. Deck output-plan directive-kind artifacts.
+    - Status: completed in this deck output-plan directive-kind artifact slice.
+    - Python, Rust, and TypeScript selected output-plan artifacts now expose
+      normalized selected output directive kind counts/lists beside selected
+      directive tokens.
+    - Table, CSV, compact JSON, and host-native record exports make `.save`,
+      `.probe`, `.print`, and `.plot` selection provenance auditable without
+      parsing directive strings.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- add normalized output directive kind count/list metadata to Python, Rust, and TypeScript output-plan artifacts
- include the new fields in output-plan table, CSV, compact JSON, and record exports
- update selected-execution fixtures, package docs/changelogs, and the full-SPICE implementation plan

## Verification
- PYTHONPATH=... python -m ruff check src tests
- PYTHONPATH=... python -m pytest
- cargo fmt -p spice-engine -- --check
- cargo test -p spice-engine
- npm run build
- npm test