### PR TITLE
feat(closurec): fold static Number.isInteger/isFinite/isNaN() → boolean

### DIFF
--- a/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to the `coding-adventures-closure-pass-constant-fold` crate will be documented in this file.
 
+## [0.52.0] - 2026-06-26
+
+### Added — fold static `Number.isInteger/isFinite/isNaN(…)` → boolean literal
+
+The ES2015 static numeric predicates `Number.isInteger(x)` / `Number.isFinite(x)`
+/ `Number.isNaN(x)` (ECMAScript §21.1.2.2/.3/.4) now fold to a boolean literal.
+**Unlike** the global `isNaN`/`isFinite`, these do **no** `ToNumber` coercion —
+the argument must already be a Number or the answer is `false`:
+
+- a NUMBER literal classifies its value directly: `Number.isInteger(42)` →
+  `true`, `Number.isInteger(3.5)` → `false`, `Number.isInteger(1e21)` → `true`
+  (every f64 magnitude ≥ 2⁵² is integer-valued), `Number.isFinite(42)` → `true`,
+  `Number.isNaN(NaN)` → `true`, and `Infinity`/`NaN` → `false` for `isInteger`
+  and `isFinite`;
+- a STRING / BOOLEAN / NULL literal → `false` for all three, with no coercion
+  (`Number.isNaN("NaN")` === `false`, `Number.isInteger("5")` === `false`).
+
+These are STATIC METHOD calls, so they dispatch through the `MemberExpression`
+callee arm (alongside `String.fromCharCode`/`fromCodePoint`) — only the bare
+global `Number.isX(...)` folds, never a shadowed receiver (`n.isInteger(5)`). An
+identifier/array/object argument, or any call with ≠1 argument, is left for the
+runtime. Added five unit tests (a V8-oracle table over number literals incl.
+`Infinity`/`NaN`/`1e21`, the non-number-literal `false` cases, and
+non-literal/second-arg/non-`Number`-receiver guards).
+
 ## [0.48.0] - 2026-06-26
 
 ### Added — fold global `encodeURIComponent(str)` / `decodeURIComponent(str)` over a string literal

--- a/code/packages/rust/closure-pass-constant-fold/Cargo.toml
+++ b/code/packages/rust/closure-pass-constant-fold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-constant-fold"
-version = "0.48.0"
+version = "0.52.0"
 edition = "2021"
 description = "Constant-folding optimization pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Folds compile-time-evaluable expressions like `2 + 3 → 5`."
 

--- a/code/packages/rust/closure-pass-constant-fold/src/lib.rs
+++ b/code/packages/rust/closure-pass-constant-fold/src/lib.rs
@@ -1197,6 +1197,64 @@ fn fold_call(c: &CallExpression, st: &mut FoldState) -> Expression {
                         return stamp_literal_cv(FoldedLiteral::String(result), new_cv);
                     }
                 }
+
+                // ---- Number.isInteger / isFinite / isNaN (x) → boolean ----
+                //
+                // The ES2015 static predicates (ECMAScript §21.1.2.2/.3/.4). UNLIKE
+                // the *global* `isNaN`/`isFinite`, these do **no** coercion: their
+                // argument must already BE a Number, otherwise the answer is
+                // `false` with no `ToNumber` step (`Number.isNaN("NaN")` → `false`,
+                // `Number.isInteger("5")` → `false`). So:
+                //
+                //   * a NUMBER literal → classify its value directly —
+                //     `Number.isNaN(v)` = `v` is `NaN` (never, for a literal),
+                //     `Number.isFinite(v)` = `v` is finite,
+                //     `Number.isInteger(v)` = `v` is finite AND has no fraction
+                //     (so `Number.isInteger(1e21)` → `true`, `…(3.5)` → `false`,
+                //     `…(Infinity)` → `false`);
+                //   * a STRING / BOOLEAN / NULL literal → `false` for all three
+                //     (it is provably not a Number, and there is no coercion).
+                //
+                // Any other argument (an identifier, an array/object, a missing or
+                // extra argument) is left for the runtime — we can't prove its type
+                // at compile time. Same bare-global-`Number` soundness premise as
+                // the `String.from*` statics (a member access, not a free
+                // identifier, so only the literal `Number.isX(...)` callee folds).
+                if obj.name == "Number"
+                    && matches!(prop.name.as_str(), "isInteger" | "isFinite" | "isNaN")
+                    && arguments.len() == 1
+                {
+                    let folded: Option<bool> = match arguments.first() {
+                        Some(Expression::NumericLiteral(n)) => Some(match prop.name.as_str() {
+                            "isNaN" => n.value.is_nan(),
+                            "isFinite" => n.value.is_finite(),
+                            // Integer ⟺ finite with a zero fractional part. Every
+                            // f64 magnitude ≥ 2^52 is integer-valued (`fract()==0`),
+                            // matching V8 for large literals like `1e21`.
+                            _ => n.value.is_finite() && n.value.fract() == 0.0,
+                        }),
+                        // A non-number literal is provably not a Number — all three
+                        // predicates are `false`, with no coercion.
+                        Some(Expression::StringLiteral(_))
+                        | Some(Expression::BooleanLiteral(_))
+                        | Some(Expression::NullLiteral(_)) => Some(false),
+                        _ => None,
+                    };
+                    if let Some(value) = folded {
+                        let parent = c.cv.clone();
+                        let arg_src = match arguments.first() {
+                            Some(Expression::NumericLiteral(n)) => format_js_number(n.value),
+                            Some(Expression::StringLiteral(s)) => format!("\"{}\"", s.value),
+                            Some(Expression::BooleanLiteral(b)) => b.value.to_string(),
+                            Some(Expression::NullLiteral(_)) => "null".to_string(),
+                            _ => "?".to_string(),
+                        };
+                        let before = format!("Number.{}({})", prop.name, arg_src);
+                        let after = if value { "!0" } else { "!1" };
+                        let new_cv = st.fork_cv(&parent, &before, after);
+                        return stamp_literal_cv(FoldedLiteral::Boolean(value), new_cv);
+                    }
+                }
             }
         }
     }
@@ -6071,6 +6129,109 @@ mod tests {
         });
         let (out, _, changed, _) = run_pass(program_with_expr(c, true));
         assert!(!changed, "non-String receiver fromCodePoint must not fold");
+        assert!(matches!(extract_expr(&out), Expression::CallExpression(_)));
+    }
+
+    // ------------------- Number.isInteger/isFinite/isNaN (static) ----
+
+    /// Build `Number.<method>(<arg>)`.
+    fn number_static_call(method: &str, arg: Expression) -> Expression {
+        Expression::CallExpression(CallExpression {
+            cv: Some("c.cv".to_string()),
+            callee: Box::new(member(ident("Number"), method)),
+            arguments: vec![arg],
+        })
+    }
+
+    #[test]
+    fn fold_number_static_on_number_literals() {
+        // (method, value, expected) — every classification confirmed against V8's
+        // `Number.isInteger` / `Number.isFinite` / `Number.isNaN` (NO coercion).
+        for (method, v, expect) in [
+            ("isInteger", 42.0, true),
+            ("isInteger", -7.0, true),
+            ("isInteger", 0.0, true),
+            ("isInteger", 3.5, false),
+            ("isInteger", 1e21, true), // huge but integer-valued f64 (≥ 2^52)
+            ("isInteger", f64::INFINITY, false),
+            ("isInteger", f64::NAN, false),
+            ("isFinite", 42.0, true),
+            ("isFinite", 3.5, true),
+            ("isFinite", f64::INFINITY, false),
+            ("isFinite", f64::NAN, false),
+            ("isNaN", f64::NAN, true),
+            ("isNaN", 42.0, false),
+            ("isNaN", f64::INFINITY, false), // Infinity is a number, not NaN
+        ] {
+            let c = number_static_call(method, num(v, None));
+            let (out, _, changed, _) = run_pass(program_with_expr(c, true));
+            assert!(changed, "Number.{method}({v}) should fold");
+            match extract_expr(&out) {
+                Expression::BooleanLiteral(b) => assert_eq!(b.value, expect, "Number.{method}({v})"),
+                other => panic!("expected bool; got {:?}", other),
+            }
+        }
+    }
+
+    #[test]
+    fn fold_number_static_on_non_number_literals_is_false() {
+        // A non-number literal is provably NOT a Number — all three predicates
+        // are `false`, with no `ToNumber` coercion (Number.isNaN("NaN") === false).
+        for method in ["isInteger", "isFinite", "isNaN"] {
+            let args = [
+                string("42", None),
+                Expression::BooleanLiteral(BooleanLiteral {
+                    cv: None,
+                    value: true,
+                }),
+                Expression::NullLiteral(NullLiteral { cv: None }),
+            ];
+            for arg in args {
+                let c = number_static_call(method, arg);
+                let (out, _, changed, _) = run_pass(program_with_expr(c, true));
+                assert!(changed, "Number.{method}(non-number-literal) should fold to false");
+                match extract_expr(&out) {
+                    Expression::BooleanLiteral(b) => {
+                        assert!(!b.value, "Number.{method}(non-number) → false")
+                    }
+                    other => panic!("expected false; got {:?}", other),
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn number_static_non_literal_argument_does_not_fold() {
+        // An identifier arg has unknown runtime type — we cannot prove the class.
+        let c = number_static_call("isInteger", ident("x"));
+        let (out, _, changed, _) = run_pass(program_with_expr(c, true));
+        assert!(!changed, "Number.isInteger(x) must not fold");
+        assert!(matches!(extract_expr(&out), Expression::CallExpression(_)));
+    }
+
+    #[test]
+    fn number_static_second_argument_does_not_fold() {
+        // We model only the single-argument form; `Number.isInteger(5, y)` is left.
+        let c = Expression::CallExpression(CallExpression {
+            cv: Some("c.cv".to_string()),
+            callee: Box::new(member(ident("Number"), "isInteger")),
+            arguments: vec![num(5.0, None), ident("y")],
+        });
+        let (out, _, changed, _) = run_pass(program_with_expr(c, true));
+        assert!(!changed, "Number.isInteger(5, y) must not fold");
+        assert!(matches!(extract_expr(&out), Expression::CallExpression(_)));
+    }
+
+    #[test]
+    fn number_static_on_non_number_receiver_does_not_fold() {
+        // Only the bare global `Number` folds; `n.isInteger(5)` is left alone.
+        let c = Expression::CallExpression(CallExpression {
+            cv: Some("c.cv".to_string()),
+            callee: Box::new(member(ident("n"), "isInteger")),
+            arguments: vec![num(5.0, None)],
+        });
+        let (out, _, changed, _) = run_pass(program_with_expr(c, true));
+        assert!(!changed, "n.isInteger(5) must not fold");
         assert!(matches!(extract_expr(&out), Expression::CallExpression(_)));
     }
 

--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.201.0] - 2026-06-26
+
+### Added — SIMPLE/ADVANCED fold static `Number.isInteger/isFinite/isNaN(…)`
+
+At `--compilation_level SIMPLE` (and ADVANCED, which routes through the same
+pipeline) the typed constant-fold pass now collapses the ES2015 static numeric
+predicates `Number.isInteger(x)` / `Number.isFinite(x)` / `Number.isNaN(x)`
+(ECMAScript §21.1.2.2/.3/.4) to a boolean literal — via the new
+`MemberExpression`-arm dispatch in `closure-pass-constant-fold` 0.52.0.
+
+Unlike the *global* `isNaN`/`isFinite`, these do **no** coercion: a NUMBER
+literal classifies its value directly (`Number.isInteger(42)` → `true`,
+`Number.isInteger(3.5)` → `false`, `Number.isInteger(1e21)` → `true`,
+`Number.isFinite(42)` → `true`, `Number.isNaN(42)` → `false`), while a STRING /
+BOOLEAN / NULL literal is provably not a Number and folds to `false`
+(`Number.isInteger("42")` → `false`, `Number.isFinite(null)` → `false`). Only
+the bare global `Number.isX(...)` folds — never a shadowed receiver.
+
+New end-to-end fixture `tests/diff/simple-fold-number-static/` and integration
+test `tests/diff_simple_fold_number_static.rs` assert byte-exact SIMPLE output,
+the per-binding boolean folds (incl. the no-coercion `isInteger("42")` and
+large-integer `isInteger(1e21)` cases), and a WHITESPACE_ONLY-fallback
+regression guard (zero `Number.is…(` calls remain). Help-markdown regenerated to
+Version 0.201.0.
+
 ## [0.197.0] - 2026-06-26
 
 ### Added — global `encodeURIComponent` / `decodeURIComponent` folding observable end-to-end at SIMPLE

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.197.0"
+version = "0.201.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.197.0",
+  "version": "0.201.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.197.0
+Version: 0.201.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff/simple-fold-number-static/README.md
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-number-static/README.md
@@ -1,0 +1,48 @@
+# `simple-fold-number-static` — static `Number.isInteger/isFinite/isNaN` → boolean
+
+End-to-end fixture proving that, at `--compilation_level SIMPLE`, the typed
+constant-fold pass collapses the ES2015 static numeric predicates
+`Number.isInteger(x)`, `Number.isFinite(x)`, and `Number.isNaN(x)` (ECMAScript
+§21.1.2.2/.3/.4) to a boolean literal when the single argument is a literal we
+can classify.
+
+**Unlike** the *global* `isNaN`/`isFinite`, these do **no** `ToNumber` coercion:
+the argument must already be a Number, otherwise the answer is `false`.
+
+| call                     | result  | note                                       |
+|--------------------------|---------|--------------------------------------------|
+| `Number.isInteger(42)`   | `true`  | a whole number                             |
+| `Number.isInteger(3.5)`  | `false` | has a fractional part                      |
+| `Number.isInteger(1e21)` | `true`  | huge, but integer-valued (f64 ≥ 2⁵²)       |
+| `Number.isFinite(42)`    | `true`  | finite                                     |
+| `Number.isNaN(42)`       | `false` | a clean number is not `NaN`                |
+| `Number.isInteger("42")` | `false` | a STRING is not a Number — **no coercion** |
+| `Number.isFinite(null)`  | `false` | `null` is not a Number                     |
+
+## Soundness
+
+These are STATIC METHOD calls, so they dispatch through the `MemberExpression`
+callee arm (alongside `String.fromCharCode`/`fromCodePoint`) — only the bare
+global `Number.isX(...)` folds, never a shadowed receiver (`n.isInteger(5)` is
+left alone). A NUMBER literal is classified directly from its `f64`
+(`is_nan()` / `is_finite()` / `is_finite() && fract()==0.0`); a STRING / BOOLEAN
+/ NULL literal is provably not a Number, so all three fold to `false`. Any other
+argument (an identifier, array, object) or a call with ≠1 argument has unknown
+type at compile time and is left for the runtime.
+
+## Files
+
+- `flags.txt` — CLI flags (`--compilation_level SIMPLE --js input/a.js`).
+- `input/a.js` — seven `var` bindings flowing into `report(...)` so each stays
+  referenced past remove-unused-vars and the fold is observable.
+- `expected.stdout` — the byte-exact SIMPLE output:
+
+  ```text
+  var a=true;var b=false;var c=true;var d=true;var e=false;var f=false;var g=false;report(a,b,c,d,e,f,g);
+  ```
+
+The integration test `tests/diff_simple_fold_number_static.rs` runs the binary
+against these flags and asserts byte-exact stdout, the per-binding boolean folds
+(including the no-coercion `isInteger("42")` → false and large-integer
+`isInteger(1e21)` → true cases), and a regression guard that the typed SIMPLE
+pipeline ran (not the WHITESPACE_ONLY fallback): zero `Number.is…(` calls remain.

--- a/code/programs/rust/closurec/tests/diff/simple-fold-number-static/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-number-static/expected.stdout
@@ -1,0 +1,1 @@
+var a=true;var b=false;var c=true;var d=true;var e=false;var f=false;var g=false;report(a,b,c,d,e,f,g);

--- a/code/programs/rust/closurec/tests/diff/simple-fold-number-static/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-number-static/flags.txt
@@ -1,0 +1,4 @@
+--compilation_level
+SIMPLE
+--js
+tests/diff/simple-fold-number-static/input/a.js

--- a/code/programs/rust/closurec/tests/diff/simple-fold-number-static/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-number-static/input/a.js
@@ -1,0 +1,26 @@
+// SIMPLE-level static Number.isInteger / isFinite / isNaN fold → boolean.
+//
+// The ES2015 static predicates (ECMAScript §21.1.2.2/.3/.4) are STATIC METHODS
+// on the global Number — modelled like String.fromCharCode. UNLIKE the global
+// isNaN/isFinite, they do NO coercion: the argument must already be a Number,
+// otherwise the answer is false. The fold collapses a call to a boolean literal
+// when the single argument is a literal we can classify:
+//   * Number.isInteger(42)   → true     a whole number
+//   * Number.isInteger(3.5)  → false    has a fractional part
+//   * Number.isInteger(1e21) → true     huge, but integer-valued
+//   * Number.isFinite(42)    → true     finite
+//   * Number.isNaN(42)       → false    a clean number is not NaN
+//   * Number.isInteger("42") → false    a STRING is not a Number (no coercion!)
+//   * Number.isFinite(null)  → false    null is not a Number
+//
+// Under WHITESPACE_ONLY every call survives; under SIMPLE they all collapse.
+// Each value flows into report(...) so it stays referenced past
+// remove-unused-vars and the fold is observable.
+var a = Number.isInteger(42);
+var b = Number.isInteger(3.5);
+var c = Number.isInteger(1e21);
+var d = Number.isFinite(42);
+var e = Number.isNaN(42);
+var f = Number.isInteger("42");
+var g = Number.isFinite(null);
+report(a, b, c, d, e, f, g);

--- a/code/programs/rust/closurec/tests/diff_simple_fold_number_static.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_fold_number_static.rs
@@ -1,0 +1,90 @@
+//! Integration test for the `tests/diff/simple-fold-number-static/` fixture.
+//!
+//! End-to-end oracle for static `Number.isInteger` / `Number.isFinite` /
+//! `Number.isNaN` folding in `closure-pass-constant-fold`: a call whose single
+//! argument is a literal collapses to the boolean V8 would produce (ECMAScript
+//! §21.1.2.2/.3/.4). Unlike the *global* `isNaN`/`isFinite`, these do NO
+//! coercion — a non-Number argument is always `false`.
+//!
+//! At SIMPLE the fixture optimizes to:
+//!
+//! ```text
+//! var a=true;var b=false;var c=true;var d=true;var e=false;var f=false;var g=false;report(a,b,c,d,e,f,g);
+//! ```
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
+
+fn read_flags() -> Vec<String> {
+    let raw = std::fs::read_to_string("tests/diff/simple-fold-number-static/flags.txt")
+        .expect("read flags.txt");
+    raw.lines()
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[test]
+fn simple_fold_number_static_fixture_matches_expected_stdout() {
+    let flags = read_flags();
+    let out = Command::new(BINARY)
+        .args(&flags)
+        .output()
+        .expect("run closurec");
+
+    assert!(
+        out.status.success(),
+        "exit: {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let actual = String::from_utf8_lossy(&out.stdout);
+    let expected = std::fs::read_to_string("tests/diff/simple-fold-number-static/expected.stdout")
+        .expect("read expected.stdout");
+    assert_eq!(
+        actual.trim_end_matches('\n'),
+        expected.trim_end_matches('\n'),
+        "mismatch.\nflags: {flags:?}\nactual:\n{actual}\nexpected:\n{expected}",
+    );
+}
+
+/// Each call collapses to the boolean its class implies — including the
+/// no-coercion `Number.isInteger("42")` → false (a string is not a Number) and
+/// the large-integer `Number.isInteger(1e21)` → true.
+#[test]
+fn simple_fold_number_static_folds_to_booleans() {
+    let out = Command::new(BINARY)
+        .args(read_flags())
+        .output()
+        .expect("run closurec");
+    let actual = String::from_utf8_lossy(&out.stdout);
+
+    assert!(actual.contains("a=true"), "Number.isInteger(42) → true; got:\n{actual}");
+    assert!(actual.contains("b=false"), "Number.isInteger(3.5) → false; got:\n{actual}");
+    assert!(actual.contains("c=true"), "Number.isInteger(1e21) → true (integer-valued); got:\n{actual}");
+    assert!(actual.contains("d=true"), "Number.isFinite(42) → true; got:\n{actual}");
+    assert!(actual.contains("e=false"), "Number.isNaN(42) → false; got:\n{actual}");
+    assert!(actual.contains("f=false"), "Number.isInteger(\"42\") → false (no coercion); got:\n{actual}");
+    assert!(actual.contains("g=false"), "Number.isFinite(null) → false; got:\n{actual}");
+}
+
+/// Regression guard: the output must be the SIMPLE typed pipeline, not the
+/// `WHITESPACE_ONLY` fallback (which would leave every call intact). Every
+/// `Number.isX` call folds, so none may remain.
+#[test]
+fn simple_fold_number_static_did_not_fall_back_to_whitespace_only() {
+    let out = Command::new(BINARY)
+        .args(read_flags())
+        .output()
+        .expect("run closurec");
+    let actual = String::from_utf8_lossy(&out.stdout);
+
+    assert_eq!(
+        actual.matches("Number.is").count(),
+        0,
+        "every Number.isInteger/isFinite/isNaN call should fold — proving the \
+         typed SIMPLE optimizer ran, not the whitespace fallback; got:\n{actual}",
+    );
+}


### PR DESCRIPTION
## What

Constant-folds the ES2015 static numeric predicates **`Number.isInteger(x)` / `Number.isFinite(x)` / `Number.isNaN(x)`** (ECMAScript §21.1.2.2/.3/.4) at SIMPLE/ADVANCED: a call whose single argument is a literal collapses to the boolean V8 would produce.

**Unlike** the *global* `isNaN`/`isFinite`, these do **no** `ToNumber` coercion — the argument must already be a Number or the answer is `false`.

| call | result | note |
|------|--------|------|
| `Number.isInteger(42)` | `true` | whole number |
| `Number.isInteger(3.5)` | `false` | fractional |
| `Number.isInteger(1e21)` | `true` | huge but integer-valued (f64 ≥ 2⁵²) |
| `Number.isFinite(42)` | `true` | finite |
| `Number.isNaN(42)` | `false` | not NaN |
| `Number.isInteger("42")` | `false` | a STRING is not a Number — **no coercion** |
| `Number.isFinite(null)` | `false` | `null` is not a Number |

## How

- Dispatches through the `MemberExpression` callee arm (alongside the static `String.fromCharCode`/`fromCodePoint` folds) — only the bare global `Number.isX(...)` folds, never a shadowed receiver (`n.isInteger(5)`).
- NUMBER literal classified directly: `isInteger` = `is_finite() && fract()==0.0`, `isFinite` = `is_finite()`, `isNaN` = `is_nan()`. STRING/BOOLEAN/NULL literal → `false` (provably not a Number). Identifier/array/object arg or ≠1 argument → declined.

## Tests

- `constant-fold` 0.48.0 → **0.52.0**; **+5 unit tests** (V8-oracle table over number literals incl. `Infinity`/`NaN`/`1e21`, the non-number-literal `false` cases, non-literal/second-arg/non-`Number`-receiver guards). 216 cf lib tests pass.
- `closurec` 0.197.0 → **0.201.0**; cli.spec.json + help-markdown regenerated.
- New fixture `tests/diff/simple-fold-number-static/` + integration test — byte-exact stdout (incl. the no-coercion `isInteger("42")=false` and large-integer `isInteger(1e21)=true` cases) and a WHITESPACE_ONLY-fallback regression guard. All 74 cc test suites pass.

## Security

Inline security review **passed** — every fold branch matches V8 (incl. `-0`, `1e21`, `Infinity`/`NaN`, and the no-coercion non-number cases); declining is safe everywhere; no panics, no `unsafe`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)