### PR TITLE
docs(specs): pluggable parser frontends (PFE01) + full LaTeX parser (LTX01)

### DIFF
--- a/code/specs/LTX01-full-latex-parser.md
+++ b/code/specs/LTX01-full-latex-parser.md
@@ -1,0 +1,159 @@
+# LTX01 — Full LaTeX Parser (`latex` crate)
+
+**Status:** Specs-first. The first frontend for [PFE01](PFE01-pluggable-parser-frontends.md).
+**Author:** architecture pass, 2026-06-26.
+**Goal:** **Full LaTeX compatibility** — parse real-world LaTeX (documents *and* math),
+not a math subset — into a faithful AST. Standalone and reusable; also implements
+`math-frontend::MathFrontend`.
+
+## 1. What "full LaTeX" means here (and its honest limit)
+
+LaTeX rests on TeX, whose macro layer is **Turing-complete** (token-list manipulation,
+runtime category-code reassignment, `\csname`, conditionals, `\expandafter`). A parser that
+*executes arbitrary TeX* is a TeX engine, not a parser. So we draw a principled line:
+
+- **In scope — "full LaTeX surface + standard semantics":** parse the complete surface
+  syntax (catcodes, control sequences, groups, both modes, environments, scripts,
+  delimiters, accents, special characters, the preamble) into a faithful AST, **and**
+  support the macro mechanisms authors actually use — `\newcommand`/`\renewcommand`/`\def`
+  with positional (`#1`..`#9`) and optional arguments, plus expansion of *user-defined* and
+  *common built-in* macros.
+- **Asymptote — documented, best-effort or rejected-with-a-clear-error:** runtime catcode
+  reassignment (`\catcode`), full `\expandafter`/`\noexpand`/`\csname` gymnastics,
+  arbitrary `\if…` programming, `\input`/`\include` of external files. These are reported as
+  `Unsupported { construct, span }` nodes/errors, never silently mis-parsed.
+
+This gives genuine full-document fidelity for human- and model-written LaTeX while being
+explicit about the TeX-programmability tail. The conformance ladder (§5) makes the covered
+surface precise and testable.
+
+## 2. The model — catcodes, modes, groups
+
+LaTeX meaning is **stateful**; the parser mirrors TeX's own machine:
+
+- **Category codes (catcodes).** Each character has a category: escape `\`, group-begin
+  `{`, group-end `}`, math-shift `$`, alignment `&`, end-of-line, parameter `#`,
+  superscript `^`, subscript `_`, ignored, space, letter, other, active `~`, comment `%`,
+  invalid. The tokenizer is catcode-driven (defaults per the LaTeX standard). Runtime
+  `\catcode` changes are in the asymptote (§1).
+- **Modes.** **Text mode is primary** (LaTeX starts in paragraph/horizontal mode). Math
+  mode is entered by `$ … $` / `\( … \)` (inline) and `$$ … $$` / `\[ … \]` /
+  `\begin{equation}` (display), and exited at the matching shift. This is the inverse of a
+  math-only parser and is the central state in the machine.
+- **Groups.** `{ … }`, `\begingroup … \endgroup`, and environments open/close scopes.
+  Brace depth + a mode/scope stack are tracked so closes match the right open.
+- **Control sequences.** *Control words* (`\` + letters, e.g. `\frac`, `\section`) and
+  *control symbols* (`\` + one non-letter, e.g. `\,`, `\\`, `\{`). Active characters (e.g.
+  `~`) behave like single-token macros.
+
+## 3. The AST (document tree)
+
+```rust
+pub enum Node {
+    Text(String),                         // a run of ordinary text
+    Space,                                // significant inter-word space
+    Group(Vec<Node>),                     // { … } scope
+    Command { name: String, opt: Vec<Vec<Node>>, args: Vec<Vec<Node>> },  // \cmd[opt]{arg}…
+    Environment { name: String, opt: Vec<Vec<Node>>, args: Vec<Vec<Node>>, body: Vec<Node> },
+    Math { display: bool, body: Vec<MathNode> },   // $…$ / \[…\] — math subtree (§4)
+    MacroDef { /* \newcommand/\def: name, params, optional-default, body */ },
+    Comment(String),
+    Special(SpecialChar),                 // ~ (nbsp), -- (en), --- (em), \& \% \$ \_ …
+    Unsupported { construct: String, span: (usize, usize) },  // the asymptote (§1)
+}
+```
+
+Math is its own subtree (`MathNode`) so the math grammar (precedence, scripts, big
+operators) is clean and so the `MathFrontend` adapter can lift it directly to the neutral
+`MathExpr` of [PFE01](PFE01-pluggable-parser-frontends.md).
+
+```rust
+pub enum MathNode {
+    Num(String), Sym(String),
+    Bin(BinOp, Box<MathNode>, Box<MathNode>),       // + - * / \times \cdot \div \pm \mp …
+    Unary(UnaryOp, Box<MathNode>),
+    Frac(Box<MathNode>, Box<MathNode>), Binom(Box<MathNode>, Box<MathNode>),
+    Root { degree: Option<Box<MathNode>>, radicand: Box<MathNode> },
+    Script { base: Box<MathNode>, sup: Option<Box<MathNode>>, sub: Option<Box<MathNode>> },
+    BigOp { op: String, lower: Option<Box<MathNode>>, upper: Option<Box<MathNode>>,
+            body: Box<MathNode> },                  // \sum \prod \int \lim …
+    Call { func: String, arg: Box<MathNode> },      // \sin \ln \exp …
+    Accent { kind: String, body: Box<MathNode> },   // \hat \bar \vec …
+    Fenced { left: Delim, body: Box<MathNode>, right: Delim },   // \left( … \right)
+    Group(Box<MathNode>), Text(String),
+    Rel(RelOp, Box<MathNode>, Box<MathNode>),
+    Matrix { env: String, rows: Vec<Vec<MathNode>> },
+}
+```
+
+Every node records a byte span. The parser is **total and panic-free**: malformed input
+yields a spanned `ParseError`, never a panic.
+
+## 4. Public API (`latex` crate)
+
+```rust
+pub fn tokenize(src: &str) -> Result<Vec<Token>, LexError>;   // catcode-driven scanner
+pub fn parse(src: &str) -> Result<Vec<Node>, ParseError>;     // full document
+pub fn parse_math(src: &str) -> Result<MathNode, ParseError>; // a bare math expression
+impl Node { pub fn to_latex(&self) -> String }                // round-trip pretty-printer
+// math-frontend integration (behind a feature or thin adapter module):
+impl math_frontend::MathFrontend for Latex { /* name="latex"; parse → MathExpr */ }
+```
+
+## 5. Conformance ladder = PR staging
+
+Each rung is a small, reviewable, fully-tested PR; each builds on the prior. The **final
+state is full LaTeX compat** per §1. (The earlier math-only tokenizer experiment on the
+parked branch `feat/latex-math-parser` is a reference for L0/L2 — reuse what fits, but L0
+is text-primary, which is a different mode model.)
+
+- **L0 — catcode tokenizer.** Scaffold the `latex` crate; the catcode-driven state machine:
+  text/math mode stack, group/brace depth, control words + control symbols, comments,
+  active chars, escaped specials, math-shift detection (`$`, `\(`, `\[`, `$$`). Spanned
+  `LexError`; exhaustive tokenizer tests.
+- **L1 — structural document parser.** Groups; generic `\cmd[opt]{arg}…` with argument
+  capture (mandatory `{}` + optional `[]`); generic `\begin{env}…\end{env}` with matched
+  close; text runs, spaces, comments, special chars (`~`, `--`, `---`, `\&` …); `Math`
+  nodes delimited but body left as raw tokens for L2. `to_latex()` round-trip.
+- **L2 — math mode (full fidelity).** Parse `MathNode`: precedence climbing, atoms, groups,
+  `\left\right` fences, infix ops, unary, implicit multiplication, `\frac`/`\binom`,
+  `\sqrt[n]{}`, scripts `^`/`_`, functions, big operators with bounds, accents,
+  greek/constants/symbols, relations.
+- **L3 — environment semantics.** Row/column structure for `tabular`/`array` and the math
+  matrix family (`matrix`/`pmatrix`/`bmatrix`/`vmatrix`/`cases`/`aligned`/`align`) via `&`
+  and `\\`; list environments (`itemize`/`enumerate`/`description`) with `\item`.
+- **L4 — macros.** `\newcommand`/`\renewcommand`/`\def` with `#1`..`#9` and one optional
+  arg with default; expansion of user-defined and a built-in starter set. Recursion/loop
+  guard (bounded expansion depth → `Unsupported`/error, never hang).
+- **L5 — text-mode breadth.** Sectioning (`\section` …), font/style commands, text accents
+  (`\'e`, `\"o`, `\~n`), `\verb`/`verbatim`, cross-refs (`\label`/`\ref`/`\cite` as nodes),
+  `\documentclass`/`\usepackage` parsed structurally.
+- **L6 — `math-frontend` adapter.** Implement `MathFrontend` for `latex`: lift `Math`/`MathNode`
+  subtrees to the neutral `MathExpr`; declare capabilities; register in the builtin registry.
+  (This is where LaTeX becomes a *plugin*; [PFE01](PFE01-pluggable-parser-frontends.md)'s
+  `math-frontend` crate can land independently before this.)
+
+**Asymptote (documented in README, not built):** runtime `\catcode`, `\expandafter`/
+`\noexpand`/`\csname`, arbitrary `\if…` programming, external `\input`/`\include`. Hit →
+`Unsupported { construct, span }`.
+
+## 6. Crates & files
+
+- New crate `code/packages/rust/latex/` (scaffold like `bitset/`: Cargo.toml edition 2021 /
+  MIT / minimal deps, `BUILD`, `BUILD_windows`, `README.md`, `CHANGELOG.md`,
+  `required_capabilities.json`, `src/{lib.rs,catcode.rs,token.rs,lexer.rs,ast.rs,parser.rs,
+  math.rs,macros.rs,error.rs}`); add to workspace `members`.
+- Depends on `math-frontend` only for the L6 adapter (gate so L0–L5 stay dependency-free).
+
+## 7. Verification
+
+- `cargo test -p latex` and `cargo clippy -p latex -- -D warnings` green at every rung;
+  no `unsafe`.
+- **Round-trip corpus:** real LaTeX snippets (a paragraph with inline `$…$`, a `pmatrix`,
+  an `align`, a `\newcommand` use, a sectioned document) where `parse(s).to_latex()`
+  re-parses to an equal AST.
+- **Error spans:** unbalanced braces, `\begin{a}…\end{b}` mismatch, `\frac{1}`, unknown
+  environment, unterminated math → spanned `ParseError`, never a panic.
+- **Asymptote:** `\catcode`, `\csname…\endcsname` → `Unsupported` node with a correct span.
+- **Frontend conformance (L6):** passes PFE01's shared harness; `latex"\frac{a}{b}"`-style
+  math lifts to the expected `MathExpr`.

--- a/code/specs/PFE01-pluggable-parser-frontends.md
+++ b/code/specs/PFE01-pluggable-parser-frontends.md
@@ -1,0 +1,150 @@
+# PFE01 — Pluggable Parser Frontends
+
+**Status:** Specs-first. Defines the framework; LaTeX (see [LTX01](LTX01-full-latex-parser.md))
+is the first frontend built against it.
+**Author:** architecture pass, 2026-06-26.
+
+## 1. Motivation
+
+A reasoning/adjudication system must accept mathematics and structured knowledge in the
+**many notations people and models actually write**: LaTeX, AsciiMath, MathML,
+Unicode/plain math, MathJSON, content-MathML, spreadsheet formulae, … A model trained on
+math emits LaTeX by reflex; a chemist writes one notation, an economist another. We must
+**not** hard-code each notation into every consumer (the ADJ language, a CAS, a renderer).
+
+Instead: a **pluggable frontend registry**. A *frontend* is a parser that turns a source
+string in one notation into a **common neutral math AST**. Consumers depend on the neutral
+AST, never on a specific notation. Adding support for a new notation is "register one more
+frontend" — zero changes to consumers. LaTeX is frontend #1; the framework anticipates the
+rest.
+
+This mirrors how the workspace already plugs in interchangeable implementations behind a
+common contract (grammar-driven language frontends; the constraint-solver backends behind
+one solver interface; the many `*-parser` crates). Frontends are the same idea for input
+notations.
+
+## 2. The neutral target: `MathExpr`
+
+All frontends produce the **same** AST, so a consumer lowers it **once**. The neutral tree
+is notation-agnostic (it is *not* LaTeX-shaped):
+
+```rust
+pub enum MathExpr {
+    Number(Number),                 // exact-preserving numeric literal (see §2.1)
+    Symbol(String),                 // a variable or named constant: "x", "pi", "alpha"
+    Bin(BinOp, Box<MathExpr>, Box<MathExpr>),   // Add Sub Mul Div Pow (Mul carries no
+                                                //   surface style — \cdot vs \times vs
+                                                //   juxtaposition all become Mul)
+    Unary(UnaryOp, Box<MathExpr>),              // Neg, Pos
+    Frac(Box<MathExpr>, Box<MathExpr>),         // numerator / denominator (a Div with intent)
+    Root { degree: Option<Box<MathExpr>>, radicand: Box<MathExpr> },  // nth root
+    Call { func: Func, arg: Box<MathExpr> },    // sin, cos, ln, exp, … (named functions)
+    BigOp { op: BigOp, lower: Option<Box<MathExpr>>, upper: Option<Box<MathExpr>>,
+            body: Box<MathExpr> },              // sum, prod, int, lim with bounds
+    Subscript(Box<MathExpr>, Box<MathExpr>),    // indexing: a_i  (distinct from Pow)
+    Rel(RelOp, Box<MathExpr>, Box<MathExpr>),   // = < > <= >= != ≈ ≡
+    Group(Box<MathExpr>),                       // explicit grouping (parens/braces)
+    Text(String),                               // \text{…}: prose inside math (units, labels)
+    Matrix(Vec<Vec<MathExpr>>),                 // rows × cols
+}
+```
+
+### 2.1 Numbers are exact-preserving
+
+`Number` keeps the literal form (an arbitrary-precision rational or the original digit
+string), **not** an `f64`. Lossy float conversion is a *consumer's* choice at lowering
+time, never the frontend's — a frontend must not silently round `0.1`. (This protects the
+"engine does the math, exactly" principle downstream.)
+
+### 2.2 What the neutral AST deliberately omits
+
+Presentation-only distinctions that don't change meaning are **normalized away**:
+`\times` / `\cdot` / juxtaposition → `Mul`; `\dfrac` / `\tfrac` / `\frac` → `Frac`; font
+styling (`\mathbf`, `\mathrm`) → the bare symbol (with the styled spelling preserved only
+inside `Text`). Two source strings that mean the same math produce the same `MathExpr`.
+This is what lets a consumer compare/compute without caring which notation was typed.
+
+## 3. The frontend contract
+
+```rust
+pub trait MathFrontend {
+    /// Stable identifier, e.g. "latex", "asciimath", "mathml".
+    fn name(&self) -> &str;
+
+    /// Parse one source string in this notation into the neutral AST.
+    fn parse(&self, src: &str) -> Result<MathExpr, FrontendError>;
+
+    /// Which neutral constructs this frontend can currently emit (so a consumer can
+    /// gate before relying on, say, matrices). See §5.
+    fn capabilities(&self) -> Capabilities;
+}
+
+pub struct FrontendError {
+    pub frontend: String,        // which frontend raised it
+    pub message: String,
+    pub span: (usize, usize),    // half-open byte span into `src`
+}
+```
+
+A frontend MUST be **total and panic-free**: every input yields either a `MathExpr` or a
+spanned `FrontendError`. A frontend MUST be **pure**: no I/O, no global state, no network.
+
+### 3.1 Registry
+
+```rust
+pub struct FrontendRegistry { /* name -> Box<dyn MathFrontend> */ }
+impl FrontendRegistry {
+    pub fn with_builtins() -> Self;             // registers latex (+ future frontends)
+    pub fn register(&mut self, f: Box<dyn MathFrontend>);
+    pub fn get(&self, name: &str) -> Option<&dyn MathFrontend>;
+    pub fn parse(&self, name: &str, src: &str) -> Result<MathExpr, FrontendError>;
+}
+```
+
+Lookup is by `name`. Unknown name → a `FrontendError` naming the unknown frontend and
+listing the registered ones (never a panic).
+
+## 4. Consumer surface (informative — not built here)
+
+How a consumer *selects* a frontend is the consumer's concern. The expected ADJ surface is
+a **tagged literal** keyed by frontend name — `latex"\frac{a}{b}"`, `asciimath"a/b"` — so
+the same `let` can ingest any registered notation. That wiring (and any lowering of
+`MathExpr` into the engine's compute IR, plus an engine power op for `^`/roots) is a
+**separate** effort that *consumes* this framework. Per the standing direction, the parser
+work and the consumption work are kept distinct.
+
+## 5. Capabilities & conformance
+
+`Capabilities` is a bitset over `MathExpr` variants (plus sub-features like
+`implicit_mul`, `big_op_bounds`, `matrices`). A consumer can ask "does this frontend emit
+matrices yet?" and gate gracefully instead of failing at parse time.
+
+**Conformance harness (shared):** a notation-agnostic test battery asserts, for every
+registered frontend, that (a) parsing its sample corpus never panics; (b) errors carry a
+valid in-range span; (c) declared capabilities match what the frontend actually emits. Each
+frontend additionally ships notation-specific golden tests.
+
+## 6. Crates
+
+- `math-frontend` — this framework: `MathExpr`/`Number`/op enums, the `MathFrontend` trait,
+  `FrontendRegistry`, `FrontendError`, `Capabilities`, the shared conformance harness.
+  Zero deps.
+- `latex` — the first frontend (full LaTeX; see [LTX01](LTX01-full-latex-parser.md)). It is
+  a standalone full-LaTeX parser in its own right and *also* implements `MathFrontend` via a
+  thin adapter (math nodes of its document AST → `MathExpr`).
+- Future: `asciimath`, `mathml`, `unicode-math`, … each a small crate implementing the
+  trait. None require changes to consumers.
+
+## 7. Non-goals
+
+Evaluation, simplification, and rendering are **not** frontend concerns — a frontend only
+*parses*. Lowering `MathExpr` into any particular engine IR belongs to the consumer.
+
+## 8. Delivery
+
+1. `math-frontend` crate: neutral AST + trait + registry + error + capabilities + harness.
+2. `latex` crate implements `MathFrontend` (after LTX01's parser exists).
+3. Each later notation = one more small frontend crate.
+
+(LaTeX itself is staged per [LTX01](LTX01-full-latex-parser.md); this framework can land in
+parallel since it only depends on the neutral AST.)


### PR DESCRIPTION
Spec-first reframe: (1) PFE01 — pluggable parser frontends: a MathFrontend trait + registry where each notation parser produces ONE neutral MathExpr AST; LaTeX is plugin #1, AsciiMath/MathML/etc. follow with zero consumer changes. New math-frontend crate; exact-preserving numbers; parsing only. (2) LTX01 — full LaTeX parser (latex crate): complete, catcode-driven, text-mode-primary parser for documents AND math; full surface + standard macros in scope, Turing-complete TeX programmability is the documented asymptote (Unsupported{construct,span}); total/panic-free/spanned; to_latex() round-trip. 7-rung conformance ladder (L0 tokenizer→L6 frontend adapter) = PR staging. Parked branch feat/latex-math-parser (math-only, never merged) is a reference; this supersedes it. Specs only — no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)