### PR TITLE
feat(spreadsheet-core): cross-sheet structural/fill/sort propagation (multi-sheet PR-3)

### DIFF
--- a/code/packages/rust/spreadsheet-core/CHANGELOG.md
+++ b/code/packages/rust/spreadsheet-core/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## 0.14.0
+
+**Cross-sheet references — structural-edit / fill / sort propagation (multi-sheet
+PR-3).** Cross-sheet references now survive the operations that move cells around:
+a structural edit on one sheet ripples into *inbound* references from other sheets,
+fill replicates a qualified relative ref correctly, and sort leaves cross-sheet refs
+pinned.
+
+- `FormulaAst::adjust_for_sheet_edit(edit, edited_is_host, edited_name)` (`edit.rs`):
+  a reference shifts (or → `#REF!` on a deleted band) **only if it points into the
+  edited sheet** — an unqualified ref when the formula's own sheet is edited, or a
+  qualified ref whose name matches the edited sheet. `apply_structural_edit` now
+  relocates the edited sheet's own cells with `edited_is_host = true`, then walks
+  **every other sheet** and rewrites only their `EditedSheet!…` references
+  (`edited_is_host = false`) — so inserting/deleting rows or columns on `Summary`
+  shifts a `=Summary!A5` reference living on `Sheet1` to `=Summary!A6` (and a
+  reference to a deleted band becomes `#REF!`).
+- `FormulaAst::shift_local(d_row, d_col)` (`ast.rs`): like `shift`, but **only
+  same-sheet refs move** — a qualified ref names a fixed cell on another sheet.
+  `sort_range` now uses `shift_local`, so sorting rows within a sheet no longer
+  mis-shifts a row's `=Summary!A1` reference (whereas *drag-fill* still uses `shift`,
+  which correctly shifts a qualified *relative* ref — `=Summary!A1` filled down is
+  `=Summary!A2`).
+- Tests: inbound structural shift + deleted-band → `#REF!`, an own-sheet edit leaving
+  the formula's outbound cross-sheet refs alone, fill shifting a qualified relative
+  ref (keeping the qualifier), and sort pinning cross-sheet refs while reordering rows.
+
 ## 0.13.0
 
 **Cross-sheet references — evaluation + dependencies (multi-sheet PR-2).** A

--- a/code/packages/rust/spreadsheet-core/Cargo.toml
+++ b/code/packages/rust/spreadsheet-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spreadsheet-core"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 description = "Headless spreadsheet engine — cell model, formula AST, dependency DAG, recalc, dispatch to Layer-1 cores. The engine VisiCalc Modern and any other Mosaic-rendered spreadsheet sits on top of."
 

--- a/code/packages/rust/spreadsheet-core/src/ast.rs
+++ b/code/packages/rust/spreadsheet-core/src/ast.rs
@@ -266,6 +266,54 @@ impl FormulaAst {
             },
         }
     }
+
+    /// Like [`shift`](FormulaAst::shift), but **only same-sheet references move** —
+    /// a cross-sheet (qualified) reference is left exactly as-is.
+    ///
+    /// This is the transform a **range sort** needs: sorting rows *within* a sheet
+    /// relocates each moved formula's references to cells on *that* sheet (so the
+    /// record keeps naming its own data), but a reference into *another* sheet
+    /// (`Summary!A1`) names a fixed cell elsewhere and must not move just because a
+    /// row was reordered here. (Drag-fill, by contrast, replicates the formula and
+    /// *does* shift qualified relative refs — use [`shift`] there.)
+    ///
+    /// Pure: returns a new tree.
+    pub fn shift_local(&self, d_row: i32, d_col: i32) -> FormulaAst {
+        match self {
+            FormulaAst::Literal(v) => FormulaAst::Literal(v.clone()),
+            // Same-sheet refs move exactly as in `shift`.
+            FormulaAst::Ref { sheet: None, addr } => match addr.shift(d_row, d_col) {
+                Ok(a) => FormulaAst::cell(a),
+                Err(_) => ref_error(),
+            },
+            FormulaAst::Range { sheet: None, range } => {
+                match (range.start.shift(d_row, d_col), range.end.shift(d_row, d_col)) {
+                    (Ok(start), Ok(end)) => FormulaAst::cell_range(CellRange::new(start, end)),
+                    _ => ref_error(),
+                }
+            }
+            // Cross-sheet refs name cells on another sheet — a sort here leaves them.
+            FormulaAst::Ref { sheet: Some(_), .. } | FormulaAst::Range { sheet: Some(_), .. } => {
+                self.clone()
+            }
+            FormulaAst::Unary { op, operand } => FormulaAst::Unary {
+                op: *op,
+                operand: Box::new(operand.shift_local(d_row, d_col)),
+            },
+            FormulaAst::Binary { op, lhs, rhs } => FormulaAst::Binary {
+                op: *op,
+                lhs: Box::new(lhs.shift_local(d_row, d_col)),
+                rhs: Box::new(rhs.shift_local(d_row, d_col)),
+            },
+            FormulaAst::Percent(inner) => {
+                FormulaAst::Percent(Box::new(inner.shift_local(d_row, d_col)))
+            }
+            FormulaAst::Call { name, args } => FormulaAst::Call {
+                name: name.clone(),
+                args: args.iter().map(|a| a.shift_local(d_row, d_col)).collect(),
+            },
+        }
+    }
 }
 
 /// The `#REF!` error as a formula literal — what a reference shifted off the grid
@@ -393,6 +441,29 @@ mod tests {
         assert_eq!(parse("='A1'!B2").unwrap().to_formula_string(), "'A1'!B2");
         // A leading-digit name is quoted.
         assert_eq!(parse("='2024'!A1").unwrap().to_formula_string(), "'2024'!A1");
+    }
+
+    #[test]
+    fn shift_local_moves_same_sheet_refs_but_pins_cross_sheet() {
+        use crate::parser::parse;
+        // Same-sheet (unqualified) ref tracks the offset, exactly like `shift`.
+        assert_eq!(
+            parse("=A1").unwrap().shift_local(1, 0).to_formula_string(),
+            "A2"
+        );
+        // A cross-sheet ref names a fixed cell elsewhere → unchanged by a local move.
+        assert_eq!(
+            parse("=Summary!A1").unwrap().shift_local(5, 5).to_formula_string(),
+            "Summary!A1"
+        );
+        // Mixed: only the same-sheet side of the sum moves.
+        assert_eq!(
+            parse("=A1+Summary!A1")
+                .unwrap()
+                .shift_local(1, 0)
+                .to_formula_string(),
+            "(A2+Summary!A1)"
+        );
     }
 
     #[test]

--- a/code/packages/rust/spreadsheet-core/src/edit.rs
+++ b/code/packages/rust/spreadsheet-core/src/edit.rs
@@ -244,6 +244,101 @@ impl FormulaAst {
             },
         }
     }
+
+    /// Adjust this formula's references for a structural [`edit`] applied to a
+    /// **specific** sheet, identified by `edited_name` and whether it is this
+    /// formula's own (host) sheet (`edited_is_host`).
+    ///
+    /// A reference shifts (or collapses to `#REF!` if its band was deleted) **only
+    /// if it points into the edited sheet** — that is, an *unqualified* ref when
+    /// the formula's host sheet is the one edited, or a *qualified* ref whose name
+    /// matches `edited_name`. Every other reference (an unqualified ref on a
+    /// non-edited sheet, or a qualified ref to a different sheet) is left exactly
+    /// as-is. This is what lets an edit on sheet `S` ripple into inbound `S!…`
+    /// references that live on *other* sheets (the workbook walks every sheet and
+    /// calls this with `edited_is_host = false` for the non-edited ones), while a
+    /// formula's references into untouched sheets stay put.
+    ///
+    /// Pure: returns a new tree.
+    pub fn adjust_for_sheet_edit(
+        &self,
+        edit: StructuralEdit,
+        edited_is_host: bool,
+        edited_name: &str,
+    ) -> FormulaAst {
+        match self {
+            FormulaAst::Literal(_) => self.clone(),
+            // Unqualified ref → points into the host sheet; shifts iff that sheet
+            // is the one being edited.
+            FormulaAst::Ref { sheet: None, addr } => {
+                if edited_is_host {
+                    match addr.adjust(edit) {
+                        Some(a) => FormulaAst::cell(a),
+                        None => ref_error(),
+                    }
+                } else {
+                    self.clone()
+                }
+            }
+            FormulaAst::Range { sheet: None, range } => {
+                if edited_is_host {
+                    match range.adjust(edit) {
+                        Some(r) => FormulaAst::cell_range(r),
+                        None => ref_error(),
+                    }
+                } else {
+                    self.clone()
+                }
+            }
+            // Qualified ref → points into the named sheet; shifts iff that name is
+            // the edited sheet (a cross-sheet ref into `S` follows `S`'s edit).
+            FormulaAst::Ref {
+                sheet: Some(name),
+                addr,
+            } => {
+                if name == edited_name {
+                    match addr.adjust(edit) {
+                        Some(a) => FormulaAst::sheet_cell(name.clone(), a),
+                        None => ref_error(),
+                    }
+                } else {
+                    self.clone()
+                }
+            }
+            FormulaAst::Range {
+                sheet: Some(name),
+                range,
+            } => {
+                if name == edited_name {
+                    match range.adjust(edit) {
+                        Some(r) => FormulaAst::sheet_range(name.clone(), r),
+                        None => ref_error(),
+                    }
+                } else {
+                    self.clone()
+                }
+            }
+            FormulaAst::Unary { op, operand } => FormulaAst::Unary {
+                op: *op,
+                operand: Box::new(operand.adjust_for_sheet_edit(edit, edited_is_host, edited_name)),
+            },
+            FormulaAst::Binary { op, lhs, rhs } => FormulaAst::Binary {
+                op: *op,
+                lhs: Box::new(lhs.adjust_for_sheet_edit(edit, edited_is_host, edited_name)),
+                rhs: Box::new(rhs.adjust_for_sheet_edit(edit, edited_is_host, edited_name)),
+            },
+            FormulaAst::Percent(inner) => FormulaAst::Percent(Box::new(
+                inner.adjust_for_sheet_edit(edit, edited_is_host, edited_name),
+            )),
+            FormulaAst::Call { name, args } => FormulaAst::Call {
+                name: name.clone(),
+                args: args
+                    .iter()
+                    .map(|a| a.adjust_for_sheet_edit(edit, edited_is_host, edited_name))
+                    .collect(),
+            },
+        }
+    }
 }
 
 /// The `#REF!` error as a formula literal — what a reference to a deleted cell
@@ -265,6 +360,36 @@ mod tests {
     }
     fn r(a1: &str, a2: &str) -> CellRange {
         CellRange::new(a(a1), a(a2))
+    }
+
+    // ── adjust_for_sheet_edit (cross-sheet structural propagation) ──
+    #[test]
+    fn adjust_for_sheet_edit_targets_only_refs_into_the_edited_sheet() {
+        use crate::parser::parse;
+        let e = StructuralEdit::InsertRows { at: 1, count: 1 };
+        // On the edited sheet itself (edited_is_host = true): the unqualified ref
+        // shifts; a ref into another sheet ("Other") is left alone.
+        let host = parse("=A1+Other!A1").unwrap();
+        assert_eq!(
+            host.adjust_for_sheet_edit(e, true, "Summary").to_formula_string(),
+            "(A2+Other!A1)"
+        );
+        // On a DIFFERENT sheet (edited_is_host = false), only refs qualified with
+        // the edited sheet's name shift; the formula's own (unqualified) ref stays.
+        let inbound = parse("=A1+Summary!A1").unwrap();
+        assert_eq!(
+            inbound.adjust_for_sheet_edit(e, false, "Summary").to_formula_string(),
+            "(A1+Summary!A2)"
+        );
+        // A qualified ref to a deleted band becomes #REF!.
+        let del = StructuralEdit::DeleteRows { at: 1, count: 1 };
+        assert_eq!(
+            parse("=Summary!A1")
+                .unwrap()
+                .adjust_for_sheet_edit(del, false, "Summary")
+                .to_formula_string(),
+            "#REF!"
+        );
     }
 
     // ── Address: insert rows ────────────────────────────────────────

--- a/code/packages/rust/spreadsheet-core/src/workbook.rs
+++ b/code/packages/rust/spreadsheet-core/src/workbook.rs
@@ -509,14 +509,22 @@ impl Workbook {
             return; // reject the whole edit rather than lose cells
         }
 
-        // 1. Relocate cells + rewrite formula references. A cell's *position*
-        //    and its formula's *references* both follow the same edit. Build a
+        // The name of the edited sheet — so an inbound `S!…` reference on another
+        // sheet can be recognised and shifted (see step 1c). Always `Some` for a
+        // valid sheet; default to "" (no real sheet is named "") if somehow absent.
+        let edited_name = s.name.clone();
+
+        // 1. Relocate the EDITED sheet's cells + rewrite each formula's references.
+        //    A cell's *position* and its formula's *references into this sheet*
+        //    both follow the edit. `adjust_for_sheet_edit(.., edited_is_host=true,
+        //    ..)` shifts this sheet's unqualified refs (and any self-qualified
+        //    `S!…` refs), while leaving refs into *other* sheets untouched. Build a
         //    fresh map: a cell on a deleted line has no new address → dropped.
         let old = std::mem::take(&mut s.cells);
         let mut moved: HashMap<CellAddress, Cell> = HashMap::with_capacity(old.len());
         for (addr, mut cell) in old {
             if let CellContent::Formula { ast, text, cached } = &mut cell.content {
-                *ast = ast.adjust(edit);
+                *ast = ast.adjust_for_sheet_edit(edit, true, &edited_name);
                 *text = ast.to_formula_string(); // keep the echo text honest
                 *cached = None; // recomputed below
             }
@@ -525,6 +533,35 @@ impl Workbook {
             }
         }
         self.sheets[sheet.0 as usize].cells = moved;
+
+        // 1c. Inbound cross-sheet propagation: every OTHER sheet's formulas may hold
+        //     a `S!…` reference into the edited sheet, which must shift too (the
+        //     grid those refs name just moved). Walk each non-edited sheet and
+        //     adjust only its refs qualified with `edited_name`
+        //     (`edited_is_host = false`), leaving its own-sheet and other-sheet refs
+        //     alone. Cells are NOT relocated here — only the *edited* sheet's cells
+        //     move; these are just reference rewrites on cells that stay put.
+        for other in 0..self.sheets.len() {
+            if other == sheet.0 as usize {
+                continue;
+            }
+            let cells = std::mem::take(&mut self.sheets[other].cells);
+            let rewritten = cells
+                .into_iter()
+                .map(|(addr, mut cell)| {
+                    if let CellContent::Formula { ast, text, cached } = &mut cell.content {
+                        let new_ast = ast.adjust_for_sheet_edit(edit, false, &edited_name);
+                        if new_ast != *ast {
+                            *ast = new_ast;
+                            *text = ast.to_formula_string();
+                            *cached = None;
+                        }
+                    }
+                    (addr, cell)
+                })
+                .collect();
+            self.sheets[other].cells = rewritten;
+        }
 
         // 1b. Relocate the format store the same way (formats ride with the cell
         //     they decorate; a format on a deleted line is dropped).
@@ -1010,7 +1047,11 @@ impl Workbook {
                     None | Some(CellContent::Empty) => CellContent::Empty,
                     Some(CellContent::Value(v)) => CellContent::Value(v.clone()),
                     Some(CellContent::Formula { ast, .. }) => {
-                        let shifted = ast.shift(d_row, 0);
+                        // `shift_local`, not `shift`: a sort relocates rows *within*
+                        // this sheet, so a moved formula's same-sheet refs track the
+                        // row displacement, but a cross-sheet (`Summary!A1`) ref names
+                        // a fixed cell on another sheet and must not move.
+                        let shifted = ast.shift_local(d_row, 0);
                         CellContent::Formula {
                             text: shifted.to_formula_string(),
                             ast: shifted,
@@ -1709,6 +1750,84 @@ mod tests {
         // The cross-sheet qualifier is preserved in the cell's stored source.
         wb.set_formula(s1, cell(4, 2), "=Summary!A1+1").unwrap();
         assert_eq!(wb.cell_source_text(s1, cell(4, 2)), "=Summary!A1+1");
+    }
+
+    #[test]
+    fn structural_edit_propagates_into_inbound_cross_sheet_refs() {
+        // Sheet1!B1 = =Summary!A5*1; Summary!A5 = 99. Inserting a row ABOVE row 5
+        // on Summary pushes its A5 down to A6, and the inbound `Summary!A5` ref on
+        // Sheet1 must follow to `Summary!A6` (and keep computing 99).
+        let mut wb = Workbook::new();
+        let s1 = wb.add_sheet("Sheet1");
+        let summary = wb.add_sheet("Summary");
+        wb.set_value(summary, cell(5, 1), CellValue::Number(99.0)); // Summary!A5
+        wb.set_formula(s1, cell(1, 2), "=Summary!A5*1").unwrap(); // Sheet1!B1
+        assert_eq!(wb.cell_value(s1, cell(1, 2)), CellValue::Number(99.0));
+
+        wb.insert_rows(summary, 3, 1); // insert above row 5 → A5 slides to A6
+        // A structural edit re-emits the source from the AST (no leading `=`,
+        // fully parenthesised) — the inbound ref now names Summary!A6.
+        assert_eq!(wb.cell_source_text(s1, cell(1, 2)), "(Summary!A6*1)");
+        assert_eq!(wb.cell_value(s1, cell(1, 2)), CellValue::Number(99.0));
+
+        // Deleting the band the inbound ref points at turns it into #REF!.
+        wb.delete_rows(summary, 6, 1); // delete the row holding the (moved) value
+        assert_eq!(
+            wb.cell_value(s1, cell(1, 2)),
+            CellValue::Error(SpreadsheetError::Ref)
+        );
+
+        // A structural edit on Sheet1 does NOT disturb its OWN cross-sheet refs
+        // (they point into Summary, which wasn't edited): re-seed and insert on s1.
+        wb.set_value(summary, cell(1, 1), CellValue::Number(5.0));
+        wb.set_formula(s1, cell(10, 2), "=Summary!A1").unwrap();
+        wb.insert_rows(s1, 1, 1); // moves the formula down a row but leaves its ref
+        assert_eq!(wb.cell_source_text(s1, cell(11, 2)), "Summary!A1");
+        assert_eq!(wb.cell_value(s1, cell(11, 2)), CellValue::Number(5.0));
+    }
+
+    #[test]
+    fn fill_shifts_cross_sheet_relative_refs_keeping_the_qualifier() {
+        // Drag-fill replicates a formula and shifts its relative refs by the copy
+        // offset — including a qualified relative ref. Filling =Summary!A1 down a
+        // column gives =Summary!A2, =Summary!A3, … (the qualifier rides along).
+        let mut wb = Workbook::new();
+        let s1 = wb.add_sheet("Sheet1");
+        let summary = wb.add_sheet("Summary");
+        wb.set_value(summary, cell(1, 1), CellValue::Number(11.0)); // Summary!A1
+        wb.set_value(summary, cell(2, 1), CellValue::Number(22.0)); // Summary!A2
+        wb.set_value(summary, cell(3, 1), CellValue::Number(33.0)); // Summary!A3
+        wb.set_formula(s1, cell(1, 1), "=Summary!A1").unwrap(); // Sheet1!A1
+        // Fill A1 down into A2:A3.
+        wb.fill(s1, cell(1, 1), CellRange::new(cell(2, 1), cell(3, 1)));
+        assert_eq!(wb.cell_source_text(s1, cell(2, 1)), "Summary!A2");
+        assert_eq!(wb.cell_source_text(s1, cell(3, 1)), "Summary!A3");
+        assert_eq!(wb.cell_value(s1, cell(2, 1)), CellValue::Number(22.0));
+        assert_eq!(wb.cell_value(s1, cell(3, 1)), CellValue::Number(33.0));
+    }
+
+    #[test]
+    fn sort_does_not_shift_cross_sheet_refs() {
+        // Two-row block on Sheet1 where each row's B holds a cross-sheet ref to a
+        // FIXED Summary cell. Sorting the block by column A (descending) reorders
+        // the rows, but the `Summary!…` refs must stay pinned (they name cells on
+        // another sheet that didn't move).
+        let mut wb = Workbook::new();
+        let s1 = wb.add_sheet("Sheet1");
+        let summary = wb.add_sheet("Summary");
+        wb.set_value(summary, cell(1, 1), CellValue::Number(100.0)); // Summary!A1
+        wb.set_value(s1, cell(1, 1), CellValue::Number(1.0)); // A1 key
+        wb.set_value(s1, cell(2, 1), CellValue::Number(2.0)); // A2 key
+        wb.set_formula(s1, cell(1, 2), "=Summary!A1").unwrap(); // B1
+        wb.set_formula(s1, cell(2, 2), "=Summary!A1+1").unwrap(); // B2
+        // Sort A1:B2 by column A descending → rows swap (2 then 1).
+        wb.sort_range(s1, CellRange::new(cell(1, 1), cell(2, 2)), 1, false);
+        // The cross-sheet refs travelled with their row but did NOT shift address
+        // (sort re-emits from the AST, so no leading `=`).
+        assert_eq!(wb.cell_source_text(s1, cell(1, 2)), "(Summary!A1+1)"); // was B2
+        assert_eq!(wb.cell_source_text(s1, cell(2, 2)), "Summary!A1"); // was B1
+        assert_eq!(wb.cell_value(s1, cell(1, 2)), CellValue::Number(101.0));
+        assert_eq!(wb.cell_value(s1, cell(2, 2)), CellValue::Number(100.0));
     }
 
     #[test]

--- a/code/specs/visicalc-multi-sheet.md
+++ b/code/specs/visicalc-multi-sheet.md
@@ -98,23 +98,27 @@ Extend `parse_ident_or_ref` so a bareword (or a single-quoted name) **followed b
   refinement). Loading a serialized workbook is unaffected as long as sheets are
   created before (or the graph is rebuilt after) the formulas load.
 
-### 2.4 Structural-edit + fill/sort interaction (the subtle part)
+### 2.4 Structural-edit + fill/sort interaction — **DONE (PR-3)** (the subtle part)
 
-- `shift(d_row, d_col)` on a **same-sheet** (`None`) ref is unchanged.
-- A **cross-sheet** ref shifts its *address* under fill/copy like any ref but
-  **keeps its sheet qualifier** (filling `=Detail!A1` down a column gives
-  `=Detail!A2`).
-- Structural edits (insert/delete rows/cols, sort) on sheet *S* must shift **every
-  reference that points into S** — including qualified refs living on *other*
-  sheets. Today structural edits walk one sheet's cells; they must also walk other
-  sheets' formulas for inbound qualified refs. A reference whose whole band is
-  deleted becomes `#REF!` (qualifier preserved or dropped — match Excel: the whole
-  ref becomes `#REF!`).
-- **Rename a sheet** ⇒ rewrite the qualifier string in every formula that names it
-  (the stored `SheetId` is stable, so eval is unaffected; only the *display/source*
-  name changes — handled at re-emit time if the AST holds `SheetId`, or by a
-  rewrite pass if it holds the name). **Delete a sheet** ⇒ inbound qualified refs
-  become `#REF!`.
+Three *different* transforms, now each correct for qualified refs:
+
+- **Fill / copy** (`shift`, unchanged): a **cross-sheet** ref shifts its *address*
+  like any relative ref but **keeps its sheet qualifier** — filling `=Detail!A1`
+  down a column gives `=Detail!A2`. Absolute (`$`) refs pin. (Shipped: PR-1's `shift`
+  already preserves the qualifier; PR-3 adds the workbook fill test.)
+- **Sort** (`shift_local`, new): sorting rows *within* a sheet shifts a moved
+  formula's **same-sheet** refs by the row displacement, but **leaves cross-sheet
+  refs pinned** (a `=Summary!A1` in a sorted row names a fixed cell on another sheet
+  that didn't move). `sort_range` switched from `shift` to `shift_local`.
+- **Structural edit** (`adjust_for_sheet_edit`, new): an insert/delete on sheet *S*
+  shifts **every reference that points into S** — `S`'s own unqualified refs *and*
+  inbound `S!…` qualified refs living on **other** sheets. `apply_structural_edit`
+  relocates `S`'s cells (`edited_is_host = true`) then walks every other sheet and
+  rewrites only its `S!…` refs (`edited_is_host = false`). A reference whose whole
+  band is deleted becomes `#REF!`. A formula's *outbound* refs into untouched sheets
+  stay put.
+- **Rename / delete a sheet** ⇒ deferred to PR-4 (rename rewrites the stored
+  qualifier in every referencing formula; delete → inbound qualified refs `#REF!`).
 
 ### 2.5 Sheet-management API on `Workbook`
 


### PR DESCRIPTION
Third engine slice of the **multi-sheet** arc (spec [#6691](https://github.com/adhithyan15/coding-adventures/pull/6691); builds on PR-1 [#6696](https://github.com/adhithyan15/coding-adventures/pull/6696) + PR-2 [#6702](https://github.com/adhithyan15/coding-adventures/pull/6702)). Cross-sheet references now **survive the operations that move cells around**.

Three *different* transforms, each now correct for qualified refs:

- **Structural edit** (`adjust_for_sheet_edit`, new) — an insert/delete on sheet `S` shifts every reference *into* `S`: `S`'s own unqualified refs **and inbound `S!…` refs living on other sheets**. `apply_structural_edit` relocates `S`'s cells (`edited_is_host=true`), then walks every other sheet and rewrites only its `S!…` refs (`edited_is_host=false`). Inserting a row on `Summary` shifts a `=Summary!A5` ref on `Sheet1` → `=Summary!A6`; a deleted band → `#REF!`. (The other-sheets loop rewrites ASTs in place under the same address key — no cell relocation there, so no collision; the overflow guard correctly stays edited-sheet-only.)
- **Fill** (`shift`, unchanged) — a qualified *relative* ref tracks the copy offset: `=Summary!A1` filled down → `=Summary!A2` (qualifier kept). PR-3 adds the workbook test.
- **Sort** (`shift_local`, new) — sorting rows *within* a sheet shifts a moved formula's same-sheet refs but **pins cross-sheet refs** (`=Summary!A1` in a sorted row names a fixed cell elsewhere). `sort_range` switched `shift` → `shift_local`.

## Verification
- **191 tests** (+5): inbound structural shift + deleted-band → `#REF!`; an own-sheet edit leaving the formula's *outbound* cross-sheet refs alone; fill shifting a qualified relative ref; sort pinning cross-sheet refs; ast/edit unit tests for `shift_local` / `adjust_for_sheet_edit`.
- Cross-sheet cycles still caught by the iterative Tarjan guard (graph rebuilt from scratch after the rewrite).
- Facades build on 0.14.0 via path deps (36 tests); clippy-clean in changed code (`workbook.rs:985` `question_mark` is the pre-existing `sort_range` warning, green on main); `#![forbid(unsafe_code)]` kept.
- Both specs synced (`visicalc-multi-sheet` §2.4).
- `/security-review` (panics/index-OOB, collision/data-loss guard scope, DoS of the all-sheets walk, cross-sheet cycles/stale edges) → **PASSED**.

Bumps `spreadsheet-core` 0.13.0 → 0.14.0 + CHANGELOG. Next: PR-4 (sheet management — rename/delete/move + serialize all sheets; rename rewrites the qualifier, delete → `#REF!`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)