### PR TITLE
[codex] Expose output directive analysis scopes

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Added
 
+- **Deck output-plan directive analysis-kind artifacts** —
+  selected `run_deck_analysis()` output-plan artifacts now expose normalized
+  output directive analysis scope counts/lists beside directive kind
+  inventories, distinguishing global `.save` / `.probe` selections from
+  scoped `.probe`, `.print`, and `.plot` selections in table, CSV, compact
+  JSON, and header-keyed record exports, matching Rust and TypeScript.
+
 - **Deck output-plan directive-kind artifacts** —
   selected `run_deck_analysis()` output-plan artifacts now expose normalized
   output directive kind counts/lists beside the selected directive tokens in

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -113,9 +113,10 @@ that produced the table, plus selected
 executions. Execution `table_artifacts` preserve the same order as `tables` and
 carry each stable table's text, CSV, compact JSON, and header-keyed records.
 Execution `output_plan_artifacts` summarize the selected result columns,
-output probes, output directives, normalized output directive kinds, and stable
-table names, and the `output-plan` entry in `table_artifacts` carries the same
-table, CSV, compact JSON, and header-keyed record exports.
+output probes, output directives, normalized output directive kinds, normalized
+directive analysis scopes, and stable table names, and the `output-plan` entry
+in `table_artifacts` carries the same table, CSV, compact JSON, and
+header-keyed record exports.
 Selected `.tran` plans also return selected `.four` harmonic results and a stable
 Fourier table. Executions also include a selected-run artifact summary plus
 `format_deck_run_artifact_table()` and `format_deck_run_artifact_csv()` output

--- a/code/packages/python/spice-engine/src/spice_engine/__init__.py
+++ b/code/packages/python/spice-engine/src/spice_engine/__init__.py
@@ -45,6 +45,7 @@ from spice_engine.compatibility import (
     resolve_deck_parameters,
     resolve_deck_sources,
     select_deck_analysis_plan,
+    select_deck_output_directive_analysis_kinds,
     select_deck_output_directives,
     select_deck_output_probes,
 )
@@ -643,6 +644,7 @@ __all__ = [
     "resolve_deck_parameters",
     "run_deck_analysis",
     "select_deck_analysis_plan",
+    "select_deck_output_directive_analysis_kinds",
     "select_deck_output_directives",
     "select_deck_output_probes",
     "sens_dc",

--- a/code/packages/python/spice-engine/src/spice_engine/compatibility.py
+++ b/code/packages/python/spice-engine/src/spice_engine/compatibility.py
@@ -995,6 +995,35 @@ def select_deck_output_directives(netlist: str, analysis: str) -> list[str]:
     return selected
 
 
+def select_deck_output_directive_analysis_kinds(
+    netlist: str,
+    analysis: str,
+) -> list[str]:
+    """Return deduplicated output directive analysis scopes for an analysis."""
+
+    summary = resolve_deck_outputs(netlist)
+    if summary.diagnostics:
+        diagnostic = summary.diagnostics[0]
+        raise ValueError(
+            "select_deck_output_directive_analysis_kinds: "
+            f"line {diagnostic.line_number}: {diagnostic.message}"
+        )
+    selected: list[str] = []
+    seen: set[str] = set()
+    for selection in summary.selections:
+        if selection.analysis is not None and not _deck_output_analysis_matches(
+            selection.analysis,
+            analysis,
+        ):
+            continue
+        analysis_kind = selection.analysis or "global"
+        if analysis_kind in seen:
+            continue
+        seen.add(analysis_kind)
+        selected.append(analysis_kind)
+    return selected
+
+
 def resolve_deck_analyses(netlist: str) -> DeckAnalysisSummary:
     """Extract supported top-level analysis directives before ``.end``."""
 

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -76,6 +76,7 @@ from spice_engine.compatibility import (
     resolve_deck_fourier,
     resolve_deck_measurements,
     select_deck_analysis_plan,
+    select_deck_output_directive_analysis_kinds,
     select_deck_output_directives,
     select_deck_output_probes,
 )
@@ -2390,6 +2391,8 @@ class DeckOutputPlanArtifact:
     output_directives: list[str]
     output_directive_kind_count: int
     output_directive_kinds: list[str]
+    output_directive_analysis_kind_count: int
+    output_directive_analysis_kinds: list[str]
     table_count: int
     tables: list[str]
 
@@ -2892,6 +2895,7 @@ def _deck_output_plan_artifacts(
     result_columns: list[str],
     output_probes: list[str],
     output_directives: list[str],
+    output_directive_analysis_kinds: list[str],
     tables: list[str],
 ) -> list[DeckOutputPlanArtifact]:
     output_directive_kinds = _deck_output_directive_kinds(output_directives)
@@ -2907,6 +2911,10 @@ def _deck_output_plan_artifacts(
             output_directives=list(output_directives),
             output_directive_kind_count=len(output_directive_kinds),
             output_directive_kinds=output_directive_kinds,
+            output_directive_analysis_kind_count=len(
+                output_directive_analysis_kinds
+            ),
+            output_directive_analysis_kinds=list(output_directive_analysis_kinds),
             table_count=len(tables),
             tables=list(tables),
         )
@@ -2924,6 +2932,8 @@ _DECK_OUTPUT_PLAN_ARTIFACT_COLUMNS = [
     "OutputDirectiveList",
     "OutputDirectiveKinds",
     "OutputDirectiveKindList",
+    "OutputDirectiveAnalysisKinds",
+    "OutputDirectiveAnalysisKindList",
     "Tables",
     "TableList",
 ]
@@ -2941,6 +2951,8 @@ def _deck_output_plan_artifact_cells(artifact: DeckOutputPlanArtifact) -> list[s
         ";".join(artifact.output_directives),
         str(artifact.output_directive_kind_count),
         ";".join(artifact.output_directive_kinds),
+        str(artifact.output_directive_analysis_kind_count),
+        ";".join(artifact.output_directive_analysis_kinds),
         str(artifact.table_count),
         ";".join(artifact.tables),
     ]
@@ -3006,6 +3018,7 @@ def _deck_output_plan_artifact_bundle(
     result_table: str,
     output_probes: list[str],
     output_directives: list[str],
+    output_directive_analysis_kinds: list[str],
     tables: list[str],
 ) -> tuple[list[DeckOutputPlanArtifact], str, str, str, list[dict[str, str]]]:
     artifacts = _deck_output_plan_artifacts(
@@ -3013,6 +3026,7 @@ def _deck_output_plan_artifact_bundle(
         _deck_table_columns(result_table),
         output_probes,
         output_directives,
+        output_directive_analysis_kinds,
         tables,
     )
     return (
@@ -3203,6 +3217,7 @@ def _deck_table_artifacts(
     control_policy_summary_artifact_table: str,
     output_probes: list[str],
     output_directives: list[str],
+    output_directive_analysis_kinds: list[str],
     tables: list[str],
 ) -> list[DeckTableArtifact]:
     artifacts = [_deck_table_artifact("result", result_table)]
@@ -3226,6 +3241,7 @@ def _deck_table_artifacts(
         result_table,
         output_probes,
         output_directives,
+        output_directive_analysis_kinds,
         tables,
     )[1]
     artifacts.append(_deck_table_artifact("output-plan", output_plan_artifact_table))
@@ -3917,6 +3933,10 @@ def run_deck_analysis(
         measurements: list[ProbeMeasurement] = []
         output_probes = select_deck_output_probes(netlist, plan.analysis)
         output_directives = select_deck_output_directives(netlist, plan.analysis)
+        output_directive_analysis_kinds = select_deck_output_directive_analysis_kinds(
+            netlist,
+            plan.analysis,
+        )
         run_artifacts = _deck_run_artifacts(
             plan,
             result,
@@ -3953,6 +3973,7 @@ def run_deck_analysis(
             control_policy_summary_artifact_table,
             output_probes,
             output_directives,
+            output_directive_analysis_kinds,
             tables,
         )
         (
@@ -3966,6 +3987,7 @@ def run_deck_analysis(
             table,
             output_probes,
             output_directives,
+            output_directive_analysis_kinds,
             tables,
         )
         return DeckAnalysisExecution(
@@ -4015,6 +4037,10 @@ def run_deck_analysis(
         _select_deck_fourier_cards_for_analysis(netlist, plan.analysis)
         output_probes = select_deck_output_probes(netlist, plan.analysis)
         output_directives = select_deck_output_directives(netlist, plan.analysis)
+        output_directive_analysis_kinds = select_deck_output_directive_analysis_kinds(
+            netlist,
+            plan.analysis,
+        )
         run_artifacts = _deck_run_artifacts(
             plan,
             result,
@@ -4051,6 +4077,7 @@ def run_deck_analysis(
             control_policy_summary_artifact_table,
             output_probes,
             output_directives,
+            output_directive_analysis_kinds,
             tables,
         )
         (
@@ -4064,6 +4091,7 @@ def run_deck_analysis(
             table,
             output_probes,
             output_directives,
+            output_directive_analysis_kinds,
             tables,
         )
         return DeckAnalysisExecution(
@@ -4115,6 +4143,10 @@ def run_deck_analysis(
         _select_deck_fourier_cards_for_analysis(netlist, plan.analysis)
         output_probes = select_deck_output_probes(netlist, plan.analysis)
         output_directives = select_deck_output_directives(netlist, plan.analysis)
+        output_directive_analysis_kinds = select_deck_output_directive_analysis_kinds(
+            netlist,
+            plan.analysis,
+        )
         run_artifacts = _deck_run_artifacts(
             plan,
             result,
@@ -4151,6 +4183,7 @@ def run_deck_analysis(
             control_policy_summary_artifact_table,
             output_probes,
             output_directives,
+            output_directive_analysis_kinds,
             tables,
         )
         (
@@ -4164,6 +4197,7 @@ def run_deck_analysis(
             table,
             output_probes,
             output_directives,
+            output_directive_analysis_kinds,
             tables,
         )
         return DeckAnalysisExecution(
@@ -4221,6 +4255,10 @@ def run_deck_analysis(
         )
         output_probes = select_deck_output_probes(netlist, plan.analysis)
         output_directives = select_deck_output_directives(netlist, plan.analysis)
+        output_directive_analysis_kinds = select_deck_output_directive_analysis_kinds(
+            netlist,
+            plan.analysis,
+        )
         run_artifacts = _deck_run_artifacts(
             plan,
             result,
@@ -4257,6 +4295,7 @@ def run_deck_analysis(
             control_policy_summary_artifact_table,
             output_probes,
             output_directives,
+            output_directive_analysis_kinds,
             tables,
         )
         (
@@ -4270,6 +4309,7 @@ def run_deck_analysis(
             table,
             output_probes,
             output_directives,
+            output_directive_analysis_kinds,
             tables,
         )
         return DeckAnalysisExecution(
@@ -4314,6 +4354,7 @@ def run_deck_analysis(
         fourier = []
         output_probes = [f"V({output_node})"]
         output_directives: list[str] = []
+        output_directive_analysis_kinds: list[str] = []
         table = format_deck_tf_table(result)
         run_artifacts = _deck_run_artifacts(
             plan,
@@ -4351,6 +4392,7 @@ def run_deck_analysis(
             control_policy_summary_artifact_table,
             output_probes,
             output_directives,
+            output_directive_analysis_kinds,
             tables,
         )
         (
@@ -4364,6 +4406,7 @@ def run_deck_analysis(
             table,
             output_probes,
             output_directives,
+            output_directive_analysis_kinds,
             tables,
         )
         return DeckAnalysisExecution(
@@ -4407,6 +4450,7 @@ def run_deck_analysis(
         fourier = []
         output_probes = [f"V({output_node})"]
         output_directives = []
+        output_directive_analysis_kinds: list[str] = []
         table = format_deck_sens_table(result)
         run_artifacts = _deck_run_artifacts(
             plan,
@@ -4444,6 +4488,7 @@ def run_deck_analysis(
             control_policy_summary_artifact_table,
             output_probes,
             output_directives,
+            output_directive_analysis_kinds,
             tables,
         )
         (
@@ -4457,6 +4502,7 @@ def run_deck_analysis(
             table,
             output_probes,
             output_directives,
+            output_directive_analysis_kinds,
             tables,
         )
         return DeckAnalysisExecution(
@@ -4519,6 +4565,7 @@ def run_deck_analysis(
         fourier = []
         output_probes = [f"V({output_node})"]
         output_directives = []
+        output_directive_analysis_kinds: list[str] = []
         table = format_deck_noise_table(result)
         run_artifacts = _deck_run_artifacts(
             plan,
@@ -4556,6 +4603,7 @@ def run_deck_analysis(
             control_policy_summary_artifact_table,
             output_probes,
             output_directives,
+            output_directive_analysis_kinds,
             tables,
         )
         (
@@ -4569,6 +4617,7 @@ def run_deck_analysis(
             table,
             output_probes,
             output_directives,
+            output_directive_analysis_kinds,
             tables,
         )
         return DeckAnalysisExecution(

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -6872,8 +6872,11 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     expected_output_plan_table = (
         "Analysis\tDirective\tResultColumns\tResultColumnList\tOutputProbes\t"
         "OutputProbeList\tOutputDirectives\tOutputDirectiveList\t"
-        "OutputDirectiveKinds\tOutputDirectiveKindList\tTables\tTableList\n"
-        "op\t.op\t2\tIndex;V(mid)\t1\tV(mid)\t1\t.save\t1\tsave\t3\t"
+        "OutputDirectiveKinds\tOutputDirectiveKindList\t"
+        "OutputDirectiveAnalysisKinds\tOutputDirectiveAnalysisKindList\t"
+        "Tables\tTableList\n"
+        "op\t.op\t2\tIndex;V(mid)\t1\tV(mid)\t1\t.save\t1\tsave\t"
+        "1\tglobal\t3\t"
         "result;output-plan;run-artifact\n"
     )
     expected_output_plan_records = [
@@ -6888,6 +6891,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
             "OutputDirectiveList": ".save",
             "OutputDirectiveKinds": "1",
             "OutputDirectiveKindList": "save",
+            "OutputDirectiveAnalysisKinds": "1",
+            "OutputDirectiveAnalysisKindList": "global",
             "Tables": "3",
             "TableList": "result;output-plan;run-artifact",
         }
@@ -6902,6 +6907,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert output_plan_artifact.output_directives == [".save"]
     assert output_plan_artifact.output_directive_kind_count == 1
     assert output_plan_artifact.output_directive_kinds == ["save"]
+    assert output_plan_artifact.output_directive_analysis_kind_count == 1
+    assert output_plan_artifact.output_directive_analysis_kinds == ["global"]
     assert output_plan_artifact.tables == ["result", "output-plan", "run-artifact"]
     assert op_execution.output_plan_artifact_table == expected_output_plan_table
     assert op_execution.output_plan_artifact_table == (
@@ -6910,8 +6917,10 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert op_execution.output_plan_artifact_csv == (
         "Analysis,Directive,ResultColumns,ResultColumnList,OutputProbes,"
         "OutputProbeList,OutputDirectives,OutputDirectiveList,"
-        "OutputDirectiveKinds,OutputDirectiveKindList,Tables,TableList\n"
-        "op,.op,2,Index;V(mid),1,V(mid),1,.save,1,save,3,"
+        "OutputDirectiveKinds,OutputDirectiveKindList,"
+        "OutputDirectiveAnalysisKinds,OutputDirectiveAnalysisKindList,"
+        "Tables,TableList\n"
+        "op,.op,2,Index;V(mid),1,V(mid),1,.save,1,save,1,global,3,"
         "result;output-plan;run-artifact\n"
     )
     assert op_execution.output_plan_artifact_csv == (
@@ -7120,6 +7129,13 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert dc_execution.output_plan_artifact_records[0][
         "OutputDirectiveKindList"
     ] == "save;probe;print"
+    assert dc_execution.output_plan_artifacts[0].output_directive_analysis_kinds == [
+        "global",
+        "dc",
+    ]
+    assert dc_execution.output_plan_artifact_records[0][
+        "OutputDirectiveAnalysisKindList"
+    ] == "global;dc"
     assert dc_execution.analysis_directives == [".dc"]
     assert dc_execution.table_count == 4
     assert dc_execution.tables == ["result", "measurement", "output-plan", "run-artifact"]
@@ -7195,6 +7211,13 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert ac_execution.output_plan_artifact_records[0][
         "OutputDirectiveKindList"
     ] == "save;plot"
+    assert ac_execution.output_plan_artifacts[0].output_directive_analysis_kinds == [
+        "global",
+        "ac",
+    ]
+    assert ac_execution.output_plan_artifact_records[0][
+        "OutputDirectiveAnalysisKindList"
+    ] == "global;ac"
     assert ac_execution.analysis_directives == [".ac"]
     assert ac_execution.table_count == 4
     assert ac_execution.tables == ["result", "measurement", "output-plan", "run-artifact"]

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Expose normalized selected output directive analysis scope inventories in
+  `run_deck_analysis` output-plan artifacts beside directive kind inventories,
+  distinguishing global `.save` / `.probe` selections from scoped `.probe`,
+  `.print`, and `.plot` selections in stable table, CSV, compact JSON, and
+  header-keyed record exports, matching Python and TypeScript.
 - Expose normalized selected output directive kind inventories in
   `run_deck_analysis` output-plan artifacts beside the selected directive
   tokens, with stable table, CSV, compact JSON, and header-keyed record exports,

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -182,9 +182,10 @@ a stable measurement table for `.dc`, `.ac`, and `.tran` executions.
 Execution `table_artifacts` preserve the same order as `tables` and carry each
 stable table's text, CSV, compact JSON, and header-keyed records.
 Execution `output_plan_artifacts` summarize the selected result columns,
-output probes, output directives, normalized output directive kinds, and stable
-table names, and the `output-plan` entry in `table_artifacts` carries the same
-table, CSV, compact JSON, and header-keyed record exports.
+output probes, output directives, normalized output directive kinds, normalized
+directive analysis scopes, and stable table names, and the `output-plan` entry
+in `table_artifacts` carries the same table, CSV, compact JSON, and
+header-keyed record exports.
 Selected `.tran` plans route
 `START` output filtering, `.tran TSTEP` as the output print grid, `MAXSTEP` as
 an internal fixed-step cap, and `UIC` initial-condition intent through that

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -3474,6 +3474,8 @@ pub struct DeckOutputPlanArtifact {
     pub output_directives: Vec<String>,
     pub output_directive_kind_count: usize,
     pub output_directive_kinds: Vec<String>,
+    pub output_directive_analysis_kind_count: usize,
+    pub output_directive_analysis_kinds: Vec<String>,
     pub table_count: usize,
     pub tables: Vec<String>,
 }
@@ -4127,6 +4129,33 @@ pub fn select_deck_output_directives(
         }
         if seen.insert(selection.directive.clone()) {
             selected.push(selection.directive);
+        }
+    }
+    Ok(selected)
+}
+
+pub fn select_deck_output_directive_analysis_kinds(
+    netlist: &str,
+    analysis: &str,
+) -> Result<Vec<String>, SpiceError> {
+    let summary = resolve_deck_outputs(netlist);
+    if let Some(diagnostic) = summary.diagnostics.first() {
+        return Err(table_error(
+            "select_deck_output_directive_analysis_kinds",
+            &format!("line {}: {}", diagnostic.line_number, diagnostic.message),
+        ));
+    }
+    let mut selected = Vec::new();
+    let mut seen = HashSet::new();
+    for selection in summary.selections {
+        if !selection.analysis.as_deref().map_or(true, |requested| {
+            deck_output_analysis_matches(requested, analysis)
+        }) {
+            continue;
+        }
+        let analysis_kind = selection.analysis.unwrap_or_else(|| "global".to_string());
+        if seen.insert(analysis_kind.clone()) {
+            selected.push(analysis_kind);
         }
     }
     Ok(selected)
@@ -10373,6 +10402,7 @@ fn deck_output_plan_artifacts(
     result_columns: &[String],
     output_probes: &[String],
     output_directives: &[String],
+    output_directive_analysis_kinds: &[String],
     tables: &[String],
 ) -> Vec<DeckOutputPlanArtifact> {
     let output_directive_kinds = deck_output_directive_kinds(output_directives);
@@ -10387,6 +10417,8 @@ fn deck_output_plan_artifacts(
         output_directives: output_directives.to_vec(),
         output_directive_kind_count: output_directive_kinds.len(),
         output_directive_kinds,
+        output_directive_analysis_kind_count: output_directive_analysis_kinds.len(),
+        output_directive_analysis_kinds: output_directive_analysis_kinds.to_vec(),
         table_count: tables.len(),
         tables: tables.to_vec(),
     }]
@@ -10426,6 +10458,8 @@ const DECK_OUTPUT_PLAN_ARTIFACT_COLUMNS: &[&str] = &[
     "OutputDirectiveList",
     "OutputDirectiveKinds",
     "OutputDirectiveKindList",
+    "OutputDirectiveAnalysisKinds",
+    "OutputDirectiveAnalysisKindList",
     "Tables",
     "TableList",
 ];
@@ -10442,6 +10476,8 @@ fn deck_output_plan_artifact_cells(artifact: &DeckOutputPlanArtifact) -> Vec<Str
         artifact.output_directives.join(";"),
         artifact.output_directive_kind_count.to_string(),
         artifact.output_directive_kinds.join(";"),
+        artifact.output_directive_analysis_kind_count.to_string(),
+        artifact.output_directive_analysis_kinds.join(";"),
         artifact.table_count.to_string(),
         artifact.tables.join(";"),
     ]
@@ -10512,6 +10548,7 @@ fn deck_output_plan_artifact_bundle(
     result_table: &str,
     output_probes: &[String],
     output_directives: &[String],
+    output_directive_analysis_kinds: &[String],
     tables: &[String],
 ) -> (
     Vec<DeckOutputPlanArtifact>,
@@ -10525,6 +10562,7 @@ fn deck_output_plan_artifact_bundle(
         &deck_table_columns(result_table),
         output_probes,
         output_directives,
+        output_directive_analysis_kinds,
         tables,
     );
     let table = format_deck_output_plan_artifact_table(&artifacts);
@@ -10809,6 +10847,7 @@ fn deck_table_artifacts(
     control_policy_summary_artifact_table: &str,
     output_probes: &[String],
     output_directives: &[String],
+    output_directive_analysis_kinds: &[String],
     tables: &[String],
 ) -> Vec<DeckTableArtifact> {
     let mut artifacts = vec![deck_table_artifact("result", result_table)];
@@ -10841,6 +10880,7 @@ fn deck_table_artifacts(
         result_table,
         output_probes,
         output_directives,
+        output_directive_analysis_kinds,
         tables,
     );
     artifacts.push(DeckTableArtifact {
@@ -11717,6 +11757,8 @@ pub fn run_deck_analysis(
             let fourier_table = format_deck_fourier_table(&fourier);
             let output_probes = select_deck_output_probes(netlist, "op")?;
             let output_directives = select_deck_output_directives(netlist, "op")?;
+            let output_directive_analysis_kinds =
+                select_deck_output_directive_analysis_kinds(netlist, "op")?;
             let run_artifacts = deck_run_artifacts(
                 &plan,
                 1,
@@ -11747,6 +11789,7 @@ pub fn run_deck_analysis(
                 &control_policy_summary_artifact_table,
                 &output_probes,
                 &output_directives,
+                &output_directive_analysis_kinds,
                 &tables,
             );
             let rawfile_artifacts =
@@ -11771,6 +11814,7 @@ pub fn run_deck_analysis(
                 &table,
                 &output_probes,
                 &output_directives,
+                &output_directive_analysis_kinds,
                 &tables,
             );
             Ok(DeckAnalysisExecution {
@@ -11854,6 +11898,8 @@ pub fn run_deck_analysis(
             let fourier_table = format_deck_fourier_table(&fourier);
             let output_probes = select_deck_output_probes(netlist, "dc")?;
             let output_directives = select_deck_output_directives(netlist, "dc")?;
+            let output_directive_analysis_kinds =
+                select_deck_output_directive_analysis_kinds(netlist, "dc")?;
             let run_artifacts = deck_run_artifacts(
                 &plan,
                 result.len(),
@@ -11884,6 +11930,7 @@ pub fn run_deck_analysis(
                 &control_policy_summary_artifact_table,
                 &output_probes,
                 &output_directives,
+                &output_directive_analysis_kinds,
                 &tables,
             );
             let rawfile_artifacts =
@@ -11908,6 +11955,7 @@ pub fn run_deck_analysis(
                 &table,
                 &output_probes,
                 &output_directives,
+                &output_directive_analysis_kinds,
                 &tables,
             );
             Ok(DeckAnalysisExecution {
@@ -11992,6 +12040,8 @@ pub fn run_deck_analysis(
             let fourier_table = format_deck_fourier_table(&fourier);
             let output_probes = select_deck_output_probes(netlist, "ac")?;
             let output_directives = select_deck_output_directives(netlist, "ac")?;
+            let output_directive_analysis_kinds =
+                select_deck_output_directive_analysis_kinds(netlist, "ac")?;
             let run_artifacts = deck_run_artifacts(
                 &plan,
                 result.len(),
@@ -12022,6 +12072,7 @@ pub fn run_deck_analysis(
                 &control_policy_summary_artifact_table,
                 &output_probes,
                 &output_directives,
+                &output_directive_analysis_kinds,
                 &tables,
             );
             let rawfile_artifacts =
@@ -12046,6 +12097,7 @@ pub fn run_deck_analysis(
                 &table,
                 &output_probes,
                 &output_directives,
+                &output_directive_analysis_kinds,
                 &tables,
             );
             Ok(DeckAnalysisExecution {
@@ -12133,6 +12185,8 @@ pub fn run_deck_analysis(
             let fourier_table = format_deck_fourier_table(&fourier);
             let output_probes = select_deck_output_probes(netlist, "tran")?;
             let output_directives = select_deck_output_directives(netlist, "tran")?;
+            let output_directive_analysis_kinds =
+                select_deck_output_directive_analysis_kinds(netlist, "tran")?;
             let run_artifacts = deck_run_artifacts(
                 &plan,
                 result.len(),
@@ -12163,6 +12217,7 @@ pub fn run_deck_analysis(
                 &control_policy_summary_artifact_table,
                 &output_probes,
                 &output_directives,
+                &output_directive_analysis_kinds,
                 &tables,
             );
             let rawfile_artifacts =
@@ -12187,6 +12242,7 @@ pub fn run_deck_analysis(
                 &table,
                 &output_probes,
                 &output_directives,
+                &output_directive_analysis_kinds,
                 &tables,
             );
             Ok(DeckAnalysisExecution {
@@ -12267,6 +12323,7 @@ pub fn run_deck_analysis(
             let fourier_table = format_deck_fourier_table(&fourier);
             let output_probes = vec![format!("V({output_node})")];
             let output_directives = Vec::new();
+            let output_directive_analysis_kinds = Vec::new();
             let table = format_deck_tf_table(&result);
             let run_artifacts = deck_run_artifacts(
                 &plan,
@@ -12298,6 +12355,7 @@ pub fn run_deck_analysis(
                 &control_policy_summary_artifact_table,
                 &output_probes,
                 &output_directives,
+                &output_directive_analysis_kinds,
                 &tables,
             );
             let rawfile_artifacts =
@@ -12322,6 +12380,7 @@ pub fn run_deck_analysis(
                 &table,
                 &output_probes,
                 &output_directives,
+                &output_directive_analysis_kinds,
                 &tables,
             );
             Ok(DeckAnalysisExecution {
@@ -12400,6 +12459,7 @@ pub fn run_deck_analysis(
             let fourier_table = format_deck_fourier_table(&fourier);
             let output_probes = vec![format!("V({output_node})")];
             let output_directives = Vec::new();
+            let output_directive_analysis_kinds = Vec::new();
             let table = format_deck_sens_table(&result);
             let run_artifacts = deck_run_artifacts(
                 &plan,
@@ -12431,6 +12491,7 @@ pub fn run_deck_analysis(
                 &control_policy_summary_artifact_table,
                 &output_probes,
                 &output_directives,
+                &output_directive_analysis_kinds,
                 &tables,
             );
             let rawfile_artifacts =
@@ -12455,6 +12516,7 @@ pub fn run_deck_analysis(
                 &table,
                 &output_probes,
                 &output_directives,
+                &output_directive_analysis_kinds,
                 &tables,
             );
             Ok(DeckAnalysisExecution {
@@ -12545,6 +12607,7 @@ pub fn run_deck_analysis(
             let fourier_table = format_deck_fourier_table(&fourier);
             let output_probes = vec![format!("V({output_node})")];
             let output_directives = Vec::new();
+            let output_directive_analysis_kinds = Vec::new();
             let table = format_deck_noise_table(&result);
             let run_artifacts = deck_run_artifacts(
                 &plan,
@@ -12576,6 +12639,7 @@ pub fn run_deck_analysis(
                 &control_policy_summary_artifact_table,
                 &output_probes,
                 &output_directives,
+                &output_directive_analysis_kinds,
                 &tables,
             );
             let rawfile_artifacts =
@@ -12600,6 +12664,7 @@ pub fn run_deck_analysis(
                 &table,
                 &output_probes,
                 &output_directives,
+                &output_directive_analysis_kinds,
                 &tables,
             );
             Ok(DeckAnalysisExecution {

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -1988,6 +1988,11 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
         output_plan_artifact.output_directive_kinds,
         vec!["save".to_string()]
     );
+    assert_eq!(output_plan_artifact.output_directive_analysis_kind_count, 1);
+    assert_eq!(
+        output_plan_artifact.output_directive_analysis_kinds,
+        vec!["global".to_string()]
+    );
     assert_eq!(
         output_plan_artifact.tables,
         vec![
@@ -1998,7 +2003,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     );
     assert_eq!(
         op_execution.output_plan_artifact_table,
-        "Analysis\tDirective\tResultColumns\tResultColumnList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tOutputDirectiveKinds\tOutputDirectiveKindList\tTables\tTableList\nop\t.op\t2\tIndex;V(mid)\t1\tV(mid)\t1\t.save\t1\tsave\t3\tresult;output-plan;run-artifact\n"
+        "Analysis\tDirective\tResultColumns\tResultColumnList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tOutputDirectiveKinds\tOutputDirectiveKindList\tOutputDirectiveAnalysisKinds\tOutputDirectiveAnalysisKindList\tTables\tTableList\nop\t.op\t2\tIndex;V(mid)\t1\tV(mid)\t1\t.save\t1\tsave\t1\tglobal\t3\tresult;output-plan;run-artifact\n"
     );
     assert_eq!(
         op_execution.output_plan_artifact_table,
@@ -2006,7 +2011,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     );
     assert_eq!(
         op_execution.output_plan_artifact_csv,
-        "Analysis,Directive,ResultColumns,ResultColumnList,OutputProbes,OutputProbeList,OutputDirectives,OutputDirectiveList,OutputDirectiveKinds,OutputDirectiveKindList,Tables,TableList\nop,.op,2,Index;V(mid),1,V(mid),1,.save,1,save,3,result;output-plan;run-artifact\n"
+        "Analysis,Directive,ResultColumns,ResultColumnList,OutputProbes,OutputProbeList,OutputDirectives,OutputDirectiveList,OutputDirectiveKinds,OutputDirectiveKindList,OutputDirectiveAnalysisKinds,OutputDirectiveAnalysisKindList,Tables,TableList\nop,.op,2,Index;V(mid),1,V(mid),1,.save,1,save,1,global,3,result;output-plan;run-artifact\n"
     );
     assert_eq!(
         op_execution.output_plan_artifact_csv,
@@ -2025,6 +2030,12 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
             .get("ResultColumnList")
             .map(String::as_str),
         Some("Index;V(mid)")
+    );
+    assert_eq!(
+        op_execution.output_plan_artifact_records[0]
+            .get("OutputDirectiveAnalysisKindList")
+            .map(String::as_str),
+        Some("global")
     );
     assert_eq!(
         op_execution.output_plan_artifact_records[0]
@@ -2244,6 +2255,16 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
             .map(String::as_str),
         Some("save;probe;print")
     );
+    assert_eq!(
+        dc_execution.output_plan_artifacts[0].output_directive_analysis_kinds,
+        vec!["global".to_string(), "dc".to_string()]
+    );
+    assert_eq!(
+        dc_execution.output_plan_artifact_records[0]
+            .get("OutputDirectiveAnalysisKindList")
+            .map(String::as_str),
+        Some("global;dc")
+    );
     assert_eq!(dc_execution.analysis_directives, vec![".dc".to_string()]);
     assert_eq!(dc_execution.table_count, 4);
     assert_eq!(
@@ -2368,6 +2389,16 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
             .get("OutputDirectiveKindList")
             .map(String::as_str),
         Some("save;plot")
+    );
+    assert_eq!(
+        ac_execution.output_plan_artifacts[0].output_directive_analysis_kinds,
+        vec!["global".to_string(), "ac".to_string()]
+    );
+    assert_eq!(
+        ac_execution.output_plan_artifact_records[0]
+            .get("OutputDirectiveAnalysisKindList")
+            .map(String::as_str),
+        Some("global;ac")
     );
     assert_eq!(ac_execution.analysis_directives, vec![".ac".to_string()]);
     assert_eq!(ac_execution.table_count, 4);

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Expose normalized selected output directive analysis scope inventories in
+  `runDeckAnalysis` output-plan artifacts beside directive kind inventories,
+  distinguishing global `.save` / `.probe` selections from scoped `.probe`,
+  `.print`, and `.plot` selections in stable table, CSV, compact JSON, and
+  header-keyed record exports, matching Python and Rust.
 - Expose normalized selected output directive kind inventories in
   `runDeckAnalysis` output-plan artifacts beside the selected directive tokens,
   with stable table, CSV, compact JSON, and header-keyed record exports,

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -96,8 +96,9 @@ table count/name list, output probes, and output directives that produced the
 table, plus selected `.measure` results and
 a stable measurement table for `.dc`, `.ac`, and `.tran` executions.
 Execution `outputPlanArtifacts` summarize the selected result columns, output
-probes, output directives, normalized output directive kinds, and stable table
-names with table, CSV, compact JSON, and header-keyed record exports.
+probes, output directives, normalized output directive kinds, normalized
+directive analysis scopes, and stable table names with table, CSV, compact
+JSON, and header-keyed record exports.
 Execution `tableArtifacts` preserve the same order as `tables` and carry each
 stable table's text, CSV, compact JSON, and header-keyed records.
 The `output-plan` entry in `tableArtifacts` carries the same

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -727,6 +727,8 @@ export interface DeckOutputPlanArtifact {
   readonly outputDirectives: readonly string[];
   readonly outputDirectiveKindCount: number;
   readonly outputDirectiveKinds: readonly string[];
+  readonly outputDirectiveAnalysisKindCount: number;
+  readonly outputDirectiveAnalysisKinds: readonly string[];
   readonly tableCount: number;
   readonly tables: readonly string[];
 }
@@ -3488,6 +3490,31 @@ export function selectDeckOutputDirectives(netlist: string, analysis: string): s
     }
     seen.add(selection.directive);
     selected.push(selection.directive);
+  }
+  return selected;
+}
+
+export function selectDeckOutputDirectiveAnalysisKinds(netlist: string, analysis: string): string[] {
+  const summary = resolveDeckOutputs(netlist);
+  if (summary.diagnostics.length > 0) {
+    const diagnostic = summary.diagnostics[0];
+    throw invalidElement(
+      "selectDeckOutputDirectiveAnalysisKinds",
+      `line ${diagnostic.lineNumber}: ${diagnostic.message}`,
+    );
+  }
+  const selected: string[] = [];
+  const seen = new Set<string>();
+  for (const selection of summary.selections) {
+    if (selection.analysis !== undefined && !deckOutputAnalysisMatches(selection.analysis, analysis)) {
+      continue;
+    }
+    const analysisKind = selection.analysis ?? "global";
+    if (seen.has(analysisKind)) {
+      continue;
+    }
+    seen.add(analysisKind);
+    selected.push(analysisKind);
   }
   return selected;
 }
@@ -8315,6 +8342,7 @@ function deckOutputPlanArtifacts(
   resultColumns: readonly string[],
   outputProbes: readonly string[],
   outputDirectives: readonly string[],
+  outputDirectiveAnalysisKinds: readonly string[],
   tables: readonly string[],
 ): DeckOutputPlanArtifact[] {
   const outputDirectiveKinds = deckOutputDirectiveKinds(outputDirectives);
@@ -8330,6 +8358,8 @@ function deckOutputPlanArtifacts(
       outputDirectives: [...outputDirectives],
       outputDirectiveKindCount: outputDirectiveKinds.length,
       outputDirectiveKinds,
+      outputDirectiveAnalysisKindCount: outputDirectiveAnalysisKinds.length,
+      outputDirectiveAnalysisKinds: [...outputDirectiveAnalysisKinds],
       tableCount: tables.length,
       tables: [...tables],
     },
@@ -8366,6 +8396,8 @@ const DECK_OUTPUT_PLAN_ARTIFACT_COLUMNS = [
   "OutputDirectiveList",
   "OutputDirectiveKinds",
   "OutputDirectiveKindList",
+  "OutputDirectiveAnalysisKinds",
+  "OutputDirectiveAnalysisKindList",
   "Tables",
   "TableList",
 ] as const;
@@ -8382,6 +8414,8 @@ function deckOutputPlanArtifactCells(artifact: DeckOutputPlanArtifact): string[]
     artifact.outputDirectives.join(";"),
     String(artifact.outputDirectiveKindCount),
     artifact.outputDirectiveKinds.join(";"),
+    String(artifact.outputDirectiveAnalysisKindCount),
+    artifact.outputDirectiveAnalysisKinds.join(";"),
     String(artifact.tableCount),
     artifact.tables.join(";"),
   ];
@@ -8432,6 +8466,7 @@ function deckOutputPlanArtifactBundle(
   resultTable: string,
   outputProbes: readonly string[],
   outputDirectives: readonly string[],
+  outputDirectiveAnalysisKinds: readonly string[],
   tables: readonly string[],
 ): {
   artifacts: DeckOutputPlanArtifact[];
@@ -8445,6 +8480,7 @@ function deckOutputPlanArtifactBundle(
     deckTableColumns(resultTable),
     outputProbes,
     outputDirectives,
+    outputDirectiveAnalysisKinds,
     tables,
   );
   return {
@@ -8533,6 +8569,7 @@ function deckTableArtifacts(
   controlPolicySummaryArtifactTable: string,
   outputProbes: readonly string[],
   outputDirectives: readonly string[],
+  outputDirectiveAnalysisKinds: readonly string[],
   tables: readonly string[],
 ): DeckTableArtifact[] {
   const artifacts = [deckTableArtifact("result", resultTable)];
@@ -8555,6 +8592,7 @@ function deckTableArtifacts(
     resultTable,
     outputProbes,
     outputDirectives,
+    outputDirectiveAnalysisKinds,
     tables,
   ).table;
   artifacts.push(deckTableArtifact("output-plan", outputPlanArtifactTable));
@@ -9210,6 +9248,10 @@ export function runDeckAnalysis(
     const fourier: FourierResult[] = [];
     const outputProbes = selectDeckOutputProbes(netlist, plan.analysis);
     const outputDirectives = selectDeckOutputDirectives(netlist, plan.analysis);
+    const outputDirectiveAnalysisKinds = selectDeckOutputDirectiveAnalysisKinds(
+      netlist,
+      plan.analysis,
+    );
     const runArtifacts = deckRunArtifacts(
       plan,
       result,
@@ -9230,6 +9272,7 @@ export function runDeckAnalysis(
       table,
       outputProbes,
       outputDirectives,
+      outputDirectiveAnalysisKinds,
       tables,
     );
     const measurementTable = formatMeasurementTable(measurements);
@@ -9249,6 +9292,7 @@ export function runDeckAnalysis(
       controlPolicySummaryArtifactTable,
       outputProbes,
       outputDirectives,
+      outputDirectiveAnalysisKinds,
       tables,
     );
     const rawfileArtifacts = deckRawfileArtifacts(plan, table, writeMarkers, rawfileOptions);
@@ -9332,6 +9376,10 @@ export function runDeckAnalysis(
     const fourier: FourierResult[] = [];
     const outputProbes = selectDeckOutputProbes(netlist, plan.analysis);
     const outputDirectives = selectDeckOutputDirectives(netlist, plan.analysis);
+    const outputDirectiveAnalysisKinds = selectDeckOutputDirectiveAnalysisKinds(
+      netlist,
+      plan.analysis,
+    );
     const runArtifacts = deckRunArtifacts(
       plan,
       result,
@@ -9353,6 +9401,7 @@ export function runDeckAnalysis(
       table,
       outputProbes,
       outputDirectives,
+      outputDirectiveAnalysisKinds,
       tables,
     );
     const measurementTable = formatMeasurementTable(measurements);
@@ -9372,6 +9421,7 @@ export function runDeckAnalysis(
       controlPolicySummaryArtifactTable,
       outputProbes,
       outputDirectives,
+      outputDirectiveAnalysisKinds,
       tables,
     );
     const rawfileArtifacts = deckRawfileArtifacts(plan, table, writeMarkers, rawfileOptions);
@@ -9466,6 +9516,10 @@ export function runDeckAnalysis(
     const fourier: FourierResult[] = [];
     const outputProbes = selectDeckOutputProbes(netlist, plan.analysis);
     const outputDirectives = selectDeckOutputDirectives(netlist, plan.analysis);
+    const outputDirectiveAnalysisKinds = selectDeckOutputDirectiveAnalysisKinds(
+      netlist,
+      plan.analysis,
+    );
     const runArtifacts = deckRunArtifacts(
       plan,
       result,
@@ -9487,6 +9541,7 @@ export function runDeckAnalysis(
       table,
       outputProbes,
       outputDirectives,
+      outputDirectiveAnalysisKinds,
       tables,
     );
     const measurementTable = formatMeasurementTable(measurements);
@@ -9506,6 +9561,7 @@ export function runDeckAnalysis(
       controlPolicySummaryArtifactTable,
       outputProbes,
       outputDirectives,
+      outputDirectiveAnalysisKinds,
       tables,
     );
     const rawfileArtifacts = deckRawfileArtifacts(plan, table, writeMarkers, rawfileOptions);
@@ -9595,6 +9651,10 @@ export function runDeckAnalysis(
     );
     const outputProbes = selectDeckOutputProbes(netlist, plan.analysis);
     const outputDirectives = selectDeckOutputDirectives(netlist, plan.analysis);
+    const outputDirectiveAnalysisKinds = selectDeckOutputDirectiveAnalysisKinds(
+      netlist,
+      plan.analysis,
+    );
     const runArtifacts = deckRunArtifacts(
       plan,
       result,
@@ -9616,6 +9676,7 @@ export function runDeckAnalysis(
       table,
       outputProbes,
       outputDirectives,
+      outputDirectiveAnalysisKinds,
       tables,
     );
     const measurementTable = formatMeasurementTable(measurements);
@@ -9635,6 +9696,7 @@ export function runDeckAnalysis(
       controlPolicySummaryArtifactTable,
       outputProbes,
       outputDirectives,
+      outputDirectiveAnalysisKinds,
       tables,
     );
     const rawfileArtifacts = deckRawfileArtifacts(plan, table, writeMarkers, rawfileOptions);
@@ -9713,6 +9775,7 @@ export function runDeckAnalysis(
     const fourier: FourierResult[] = [];
     const outputProbes = [`V(${outputNode})`];
     const outputDirectives: string[] = [];
+    const outputDirectiveAnalysisKinds: string[] = [];
     const table = formatDeckTfTable(result);
     const runArtifacts = deckRunArtifacts(
       plan,
@@ -9735,6 +9798,7 @@ export function runDeckAnalysis(
       table,
       outputProbes,
       outputDirectives,
+      outputDirectiveAnalysisKinds,
       tables,
     );
     const measurementTable = formatMeasurementTable(measurements);
@@ -9754,6 +9818,7 @@ export function runDeckAnalysis(
       controlPolicySummaryArtifactTable,
       outputProbes,
       outputDirectives,
+      outputDirectiveAnalysisKinds,
       tables,
     );
     const rawfileArtifacts = deckRawfileArtifacts(plan, table, writeMarkers, rawfileOptions);
@@ -9831,6 +9896,7 @@ export function runDeckAnalysis(
     const fourier: FourierResult[] = [];
     const outputProbes = [`V(${outputNode})`];
     const outputDirectives: string[] = [];
+    const outputDirectiveAnalysisKinds: string[] = [];
     const table = formatDeckSensTable(result);
     const runArtifacts = deckRunArtifacts(
       plan,
@@ -9853,6 +9919,7 @@ export function runDeckAnalysis(
       table,
       outputProbes,
       outputDirectives,
+      outputDirectiveAnalysisKinds,
       tables,
     );
     const measurementTable = formatMeasurementTable(measurements);
@@ -9872,6 +9939,7 @@ export function runDeckAnalysis(
       controlPolicySummaryArtifactTable,
       outputProbes,
       outputDirectives,
+      outputDirectiveAnalysisKinds,
       tables,
     );
     const rawfileArtifacts = deckRawfileArtifacts(plan, table, writeMarkers, rawfileOptions);
@@ -9959,6 +10027,7 @@ export function runDeckAnalysis(
     const fourier: FourierResult[] = [];
     const outputProbes = [`V(${outputNode})`];
     const outputDirectives: string[] = [];
+    const outputDirectiveAnalysisKinds: string[] = [];
     const table = formatDeckNoiseTable(result);
     const runArtifacts = deckRunArtifacts(
       plan,
@@ -9981,6 +10050,7 @@ export function runDeckAnalysis(
       table,
       outputProbes,
       outputDirectives,
+      outputDirectiveAnalysisKinds,
       tables,
     );
     const measurementTable = formatMeasurementTable(measurements);
@@ -10000,6 +10070,7 @@ export function runDeckAnalysis(
       controlPolicySummaryArtifactTable,
       outputProbes,
       outputDirectives,
+      outputDirectiveAnalysisKinds,
       tables,
     );
     const rawfileArtifacts = deckRawfileArtifacts(plan, table, writeMarkers, rawfileOptions);

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -1550,6 +1550,8 @@ describe("transient", () => {
         OutputDirectiveList: ".save",
         OutputDirectiveKinds: "1",
         OutputDirectiveKindList: "save",
+        OutputDirectiveAnalysisKinds: "1",
+        OutputDirectiveAnalysisKindList: "global",
         Tables: "3",
         TableList: "result;output-plan;run-artifact",
       },
@@ -1567,19 +1569,21 @@ describe("transient", () => {
       outputDirectives: [".save"],
       outputDirectiveKindCount: 1,
       outputDirectiveKinds: ["save"],
+      outputDirectiveAnalysisKindCount: 1,
+      outputDirectiveAnalysisKinds: ["global"],
       tableCount: 3,
       tables: ["result", "output-plan", "run-artifact"],
     });
     expect(opExecution.outputPlanArtifactTable).toBe(
-      "Analysis\tDirective\tResultColumns\tResultColumnList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tOutputDirectiveKinds\tOutputDirectiveKindList\tTables\tTableList\n" +
-        "op\t.op\t2\tIndex;V(mid)\t1\tV(mid)\t1\t.save\t1\tsave\t3\tresult;output-plan;run-artifact\n",
+      "Analysis\tDirective\tResultColumns\tResultColumnList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tOutputDirectiveKinds\tOutputDirectiveKindList\tOutputDirectiveAnalysisKinds\tOutputDirectiveAnalysisKindList\tTables\tTableList\n" +
+        "op\t.op\t2\tIndex;V(mid)\t1\tV(mid)\t1\t.save\t1\tsave\t1\tglobal\t3\tresult;output-plan;run-artifact\n",
     );
     expect(opExecution.outputPlanArtifactTable).toBe(
       formatDeckOutputPlanArtifactTable(opExecution.outputPlanArtifacts),
     );
     expect(opExecution.outputPlanArtifactCsv).toBe(
-      "Analysis,Directive,ResultColumns,ResultColumnList,OutputProbes,OutputProbeList,OutputDirectives,OutputDirectiveList,OutputDirectiveKinds,OutputDirectiveKindList,Tables,TableList\n" +
-        "op,.op,2,Index;V(mid),1,V(mid),1,.save,1,save,3,result;output-plan;run-artifact\n",
+      "Analysis,Directive,ResultColumns,ResultColumnList,OutputProbes,OutputProbeList,OutputDirectives,OutputDirectiveList,OutputDirectiveKinds,OutputDirectiveKindList,OutputDirectiveAnalysisKinds,OutputDirectiveAnalysisKindList,Tables,TableList\n" +
+        "op,.op,2,Index;V(mid),1,V(mid),1,.save,1,save,1,global,3,result;output-plan;run-artifact\n",
     );
     expect(opExecution.outputPlanArtifactCsv).toBe(
       formatDeckOutputPlanArtifactCsv(opExecution.outputPlanArtifacts),
@@ -1787,6 +1791,13 @@ describe("transient", () => {
     expect(dcExecution.outputPlanArtifactRecords[0]?.OutputDirectiveKindList).toBe(
       "save;probe;print",
     );
+    expect(dcExecution.outputPlanArtifacts[0]?.outputDirectiveAnalysisKinds).toEqual([
+      "global",
+      "dc",
+    ]);
+    expect(dcExecution.outputPlanArtifactRecords[0]?.OutputDirectiveAnalysisKindList).toBe(
+      "global;dc",
+    );
     expect(dcExecution.analysisDirectives).toEqual([".dc"]);
     expect(dcExecution.tableCount).toBe(4);
     expect(dcExecution.tables).toEqual(["result", "measurement", "output-plan", "run-artifact"]);
@@ -1857,6 +1868,13 @@ describe("transient", () => {
     ]);
     expect(acExecution.outputPlanArtifactRecords[0]?.OutputDirectiveKindList).toBe(
       "save;plot",
+    );
+    expect(acExecution.outputPlanArtifacts[0]?.outputDirectiveAnalysisKinds).toEqual([
+      "global",
+      "ac",
+    ]);
+    expect(acExecution.outputPlanArtifactRecords[0]?.OutputDirectiveAnalysisKindList).toBe(
+      "global;ac",
     );
     expect(acExecution.analysisDirectives).toEqual([".ac"]);
     expect(acExecution.tableCount).toBe(4);

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -136,7 +136,10 @@ downstream tools to compare.
      metadata; selected output-plan artifacts now also expose normalized
      `.save`, `.probe`, `.print`, and `.plot` directive kind counts/lists
      beside the selected directive tokens in table, CSV, compact JSON, and
-     host-native record exports.
+     host-native record exports, and selected output-plan artifacts now also
+     expose normalized output directive analysis scope counts/lists that
+     distinguish global `.save` / `.probe` selections from scoped `.probe`,
+     `.print`, and `.plot` selections in the same exports.
    - Expand remaining deck-controlled analyses toward full SPICE compatibility
      while keeping unsupported control-flow diagnostics explicit.
 
@@ -1163,6 +1166,16 @@ downstream tools to compare.
     - Table, CSV, compact JSON, and host-native record exports make `.save`,
       `.probe`, `.print`, and `.plot` selection provenance auditable without
       parsing directive strings.
+
+107. Deck output-plan directive analysis-kind artifacts.
+    - Status: completed in this deck output-plan directive analysis-kind
+      artifact slice.
+    - Python, Rust, and TypeScript selected output-plan artifacts now expose
+      normalized selected output directive analysis scope counts/lists beside
+      directive kind inventories.
+    - Table, CSV, compact JSON, and host-native record exports distinguish
+      global `.save` / `.probe` selections from scoped `.probe`, `.print`, and
+      `.plot` selections without reparsing directive cards.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- add selected output directive analysis scope inventories to SPICE deck output-plan artifacts across Python, Rust, and TypeScript
- expose `global`, `dc`, `ac`, and other scoped directive selection provenance in table, CSV, compact JSON, and record exports
- update package docs/changelogs and mark the completed slice in the full SPICE implementation plan

## Verification
- `/Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python -m ruff check code/packages/python/spice-engine/src/spice_engine code/packages/python/spice-engine/tests/test_engine.py`
- `PYTHONPATH=code/packages/python/spice-engine/src:code/packages/python/mosfet-models/src:code/packages/python/device-physics/src /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python -m pytest code/packages/python/spice-engine/tests/test_engine.py --no-cov`
- `cargo fmt -p spice-engine --check`
- `cargo test -p spice-engine`
- `npm run build`
- `npm test -- transient.test.ts`
- `npm test`
- `git diff --check`