### PR TITLE
feat(math-frontend): pluggable parser-frontend framework (PFE01)

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -219,6 +219,7 @@ members = [
     "logic-core",
     "lookup-core",
     "logic-engine",
+    "math-frontend",
     "adjudication-ir",
     "llm-cache",
     "llm-gateway",

--- a/code/packages/rust/math-frontend/BUILD
+++ b/code/packages/rust/math-frontend/BUILD
@@ -1,0 +1,1 @@
+cargo test -p math-frontend -- --nocapture

--- a/code/packages/rust/math-frontend/BUILD_windows
+++ b/code/packages/rust/math-frontend/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p math-frontend -- --nocapture

--- a/code/packages/rust/math-frontend/CHANGELOG.md
+++ b/code/packages/rust/math-frontend/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog — math-frontend
+
+All notable changes to the pluggable parser-frontend framework.
+
+## [0.1.0] — 2026-06-26
+
+### Added — PFE01 implementation: the framework
+
+- New standalone, **zero-dependency** crate `math-frontend` (added to the Rust workspace
+  members). The shared substrate for plugging in math-notation parsers.
+- **`MathExpr`** — the notation-agnostic neutral AST: `Number`, `Symbol`, `Bin` (`Add Sub
+  Mul Div Pow`), `Unary`, `Frac`, `Root`, `Call` (named `Func`), `BigOp` (with bounds),
+  `Subscript`, `Rel`, `Group`, `Text`, `Matrix`. Presentation-only distinctions normalize
+  away (`\times`/`\cdot`/juxtaposition → `Mul`).
+- **`Number`** — **exact-preserving** numeric literal: parses decimal numerals (sign,
+  integer/fraction, `e`-exponent) into a normalized `±digits×10^exp` triple, so `1`/`1.0`/
+  `01`/`1e0` compare equal and `0.1` is never silently rounded. Keeps the written form;
+  `to_f64()` is explicit and lossy. Zero is canonical (never `-0`). No big-int dependency.
+- **`MathFrontend`** trait (total, panic-free, pure) + **`FrontendError`** (spanned, names
+  the frontend) + **`Capabilities`** (builder over the constructs a frontend can emit).
+- **`FrontendRegistry`** — name-keyed install/lookup/parse; unknown frontend yields a
+  spanned error listing the installed ones (never a panic); `with_builtins()` is empty by
+  design (LaTeX, the first frontend, registers here once its crate lands).
+- **`check_frontend`** — shared conformance harness enforcing the contract: parsing never
+  panics (`catch_unwind`), errors are well-formed (correct frontend name + in-range,
+  non-inverted span), and capabilities are honest (a frontend may not emit a construct it
+  didn't advertise).
+- 19 unit tests + 1 doc test; `cargo clippy -- -D warnings` clean; no `unsafe`.
+
+### Notes
+
+- Parsing only — evaluation/lowering is a consumer concern. The LaTeX frontend (full
+  LaTeX, per LTX01) and any consumer wiring (e.g. an ADJ `latex"…"` literal) are separate
+  efforts that depend on this crate.

--- a/code/packages/rust/math-frontend/Cargo.toml
+++ b/code/packages/rust/math-frontend/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "math-frontend"
+version = "0.1.0"
+edition = "2021"
+description = "A pluggable parser-frontend framework: a neutral math AST (MathExpr), a MathFrontend trait + registry, and a shared conformance harness. Notation parsers (LaTeX, AsciiMath, MathML, …) implement the trait so any consumer lowers ONE neutral tree."
+license = "MIT"
+
+[dependencies]
+# No dependencies — this is the neutral framework every frontend and consumer shares.

--- a/code/packages/rust/math-frontend/README.md
+++ b/code/packages/rust/math-frontend/README.md
@@ -1,0 +1,75 @@
+# math-frontend
+
+A **pluggable parser-frontend framework** for mathematics, built as a standalone,
+dependency-free Rust crate. It is the shared substrate that lets a reasoning system accept
+math in *many* notations — LaTeX, AsciiMath, MathML, Unicode/plain math — without
+hard-coding any of them into its consumers.
+
+Spec: [`code/specs/PFE01-pluggable-parser-frontends.md`](../../../specs/PFE01-pluggable-parser-frontends.md).
+
+## The idea
+
+A **frontend** is a parser for one notation that produces **one common neutral AST**,
+`MathExpr`. Every consumer (a rule/inference engine, a computer-algebra system, a renderer)
+depends on `MathExpr`, never on a specific notation. So:
+
+```
+   LaTeX  ─┐
+ AsciiMath ─┼─▶ MathExpr ─▶ (consumer lowers ONCE)
+   MathML ─┘
+```
+
+Adding a notation later is "register one more frontend" — zero consumer changes.
+
+## What's here
+
+| Piece | Role |
+|-------|------|
+| `MathExpr` (+ `Number`, `BinOp`, `Func`, `BigOp`, `RelOp`, …) | the notation-agnostic AST |
+| `MathFrontend` | the contract a notation parser implements |
+| `FrontendError` / `Capabilities` | spanned errors; what a frontend can emit |
+| `FrontendRegistry` | look up a frontend by name and parse through it |
+| `check_frontend` | shared conformance harness (total/panic-free, well-formed errors, honest capabilities) |
+
+### Two design rules worth knowing
+
+- **Numbers are exact-preserving.** `Number` keeps a literal's exact decimal value
+  (normalized `±digits×10^exp`), so `1`, `1.0`, `01`, `1e0` compare equal and `0.1` is
+  never silently rounded. Lossy `to_f64()` is an explicit choice the *consumer* makes.
+- **Presentation normalizes away; meaning is kept.** `\times`, `\cdot`, and juxtaposition
+  all become `Mul`; `\frac`/`\dfrac`/`/` all mean division. Two strings that mean the same
+  math produce the same `MathExpr`.
+
+## Status
+
+This crate is the framework. There are **no built-in frontends yet** —
+`FrontendRegistry::with_builtins()` is empty by design until LaTeX (the first frontend,
+its own `latex` crate) implements `MathFrontend` and registers here. See
+[`LTX01`](../../../specs/LTX01-full-latex-parser.md).
+
+## Usage
+
+```rust
+use math_frontend::{FrontendRegistry, MathFrontend, MathExpr, Number, Capabilities, FrontendError};
+
+struct Int;
+impl MathFrontend for Int {
+    fn name(&self) -> &str { "int" }
+    fn parse(&self, s: &str) -> Result<MathExpr, FrontendError> {
+        Number::parse(s).map(MathExpr::Number)
+            .ok_or_else(|| FrontendError::new("int", "not an integer", (0, s.len())))
+    }
+    fn capabilities(&self) -> Capabilities { Capabilities::none() }
+}
+
+let mut reg = FrontendRegistry::new();
+reg.register(Box::new(Int));
+assert_eq!(reg.parse("int", "42").unwrap(), MathExpr::Number(Number::from_i64(42)));
+```
+
+## Tests
+
+```
+cargo test -p math-frontend
+cargo clippy -p math-frontend -- -D warnings
+```

--- a/code/packages/rust/math-frontend/required_capabilities.json
+++ b/code/packages/rust/math-frontend/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/math-frontend",
+  "capabilities": [],
+  "justification": "Pure computation: a neutral AST, a trait, a registry, and a conformance harness. No filesystem, network, process, or environment access."
+}

--- a/code/packages/rust/math-frontend/src/conformance.rs
+++ b/code/packages/rust/math-frontend/src/conformance.rs
@@ -1,0 +1,263 @@
+//! A **shared conformance harness** every frontend can be run through.
+//!
+//! It enforces the three invariants the [`MathFrontend`](crate::MathFrontend) contract
+//! promises, so a consumer can trust any registered frontend:
+//!
+//! 1. **Total & panic-free** — parsing a sample never panics (caught via
+//!    [`std::panic::catch_unwind`]); a failure must be a returned `Err`, not a crash.
+//! 2. **Well-formed errors** — every `FrontendError` names this frontend and carries an
+//!    in-range, non-inverted byte span.
+//! 3. **Honest capabilities** — the frontend never emits a neutral construct it did not
+//!    advertise in [`capabilities`](crate::MathFrontend::capabilities). (Declaring a
+//!    capability you simply didn't exercise on the sample set is fine — under-claiming is
+//!    safe; over-emitting is the bug.)
+//!
+//! Each frontend ships its own notation-specific golden tests on top of this.
+
+use crate::expr::MathExpr;
+use crate::frontend::{Capabilities, MathFrontend};
+use std::panic::AssertUnwindSafe;
+
+/// The outcome of running a frontend through the harness.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConformanceReport {
+    pub frontend: String,
+    pub samples_checked: usize,
+    /// Empty iff the frontend conformed on every sample.
+    pub issues: Vec<String>,
+}
+
+impl ConformanceReport {
+    pub fn passed(&self) -> bool {
+        self.issues.is_empty()
+    }
+}
+
+/// Run `frontend` over `samples`, checking the three contract invariants. Never panics —
+/// even if the frontend under test does (that panic becomes a recorded issue).
+pub fn check_frontend(frontend: &dyn MathFrontend, samples: &[&str]) -> ConformanceReport {
+    let name = frontend.name().to_string();
+    let declared = frontend.capabilities();
+    let mut issues = Vec::new();
+
+    for &sample in samples {
+        // (1) total & panic-free
+        let result = std::panic::catch_unwind(AssertUnwindSafe(|| frontend.parse(sample)));
+        let parsed = match result {
+            Ok(r) => r,
+            Err(_) => {
+                issues.push(format!("panicked while parsing {sample:?}"));
+                continue;
+            }
+        };
+
+        match parsed {
+            Ok(expr) => {
+                // (3) honest capabilities
+                let mut used = Capabilities::none();
+                collect_used(&expr, &mut used);
+                for missing in over_emitted(used, declared) {
+                    issues.push(format!(
+                        "{sample:?}: emits `{missing}` but capabilities().{missing} is false"
+                    ));
+                }
+            }
+            Err(e) => {
+                // (2) well-formed errors
+                if e.frontend != name {
+                    issues.push(format!(
+                        "{sample:?}: error names frontend {:?}, expected {:?}",
+                        e.frontend, name
+                    ));
+                }
+                let (s, end) = e.span;
+                if s > end {
+                    issues.push(format!("{sample:?}: inverted error span {s}..{end}"));
+                }
+                if end > sample.len() {
+                    issues.push(format!(
+                        "{sample:?}: error span end {end} exceeds source length {}",
+                        sample.len()
+                    ));
+                }
+            }
+        }
+    }
+
+    ConformanceReport {
+        frontend: name,
+        samples_checked: samples.len(),
+        issues,
+    }
+}
+
+/// Names of capabilities that `used` requires but `declared` did not advertise.
+fn over_emitted(used: Capabilities, declared: Capabilities) -> Vec<&'static str> {
+    let mut v = Vec::new();
+    let pairs: [(&str, bool, bool); 9] = [
+        ("fractions", used.fractions, declared.fractions),
+        ("roots", used.roots, declared.roots),
+        ("powers", used.powers, declared.powers),
+        ("functions", used.functions, declared.functions),
+        ("big_operators", used.big_operators, declared.big_operators),
+        ("relations", used.relations, declared.relations),
+        ("matrices", used.matrices, declared.matrices),
+        ("implicit_mul", used.implicit_mul, declared.implicit_mul),
+        ("text", used.text, declared.text),
+    ];
+    for (label, used_it, declared_it) in pairs {
+        if used_it && !declared_it {
+            v.push(label);
+        }
+    }
+    v
+}
+
+/// Walk an expression, switching on each capability flag the tree actually uses.
+/// (`implicit_mul` cannot be detected structurally — `Mul` is `Mul` however it was
+/// written — so it is not inferred here; it is a parser-behavior claim the frontend's
+/// own golden tests cover.)
+fn collect_used(e: &MathExpr, caps: &mut Capabilities) {
+    match e {
+        MathExpr::Number(_) | MathExpr::Symbol(_) => {}
+        MathExpr::Bin(crate::BinOp::Pow, a, b) => {
+            caps.powers = true;
+            collect_used(a, caps);
+            collect_used(b, caps);
+        }
+        MathExpr::Bin(_, a, b) => {
+            collect_used(a, caps);
+            collect_used(b, caps);
+        }
+        MathExpr::Unary(_, a) => collect_used(a, caps),
+        MathExpr::Frac(a, b) => {
+            caps.fractions = true;
+            collect_used(a, caps);
+            collect_used(b, caps);
+        }
+        MathExpr::Root { degree, radicand } => {
+            caps.roots = true;
+            if let Some(d) = degree {
+                collect_used(d, caps);
+            }
+            collect_used(radicand, caps);
+        }
+        MathExpr::Call { arg, .. } => {
+            caps.functions = true;
+            collect_used(arg, caps);
+        }
+        MathExpr::BigOp { lower, upper, body, .. } => {
+            caps.big_operators = true;
+            if let Some(l) = lower {
+                collect_used(l, caps);
+            }
+            if let Some(u) = upper {
+                collect_used(u, caps);
+            }
+            collect_used(body, caps);
+        }
+        MathExpr::Subscript(a, b) => {
+            collect_used(a, caps);
+            collect_used(b, caps);
+        }
+        MathExpr::Rel(_, a, b) => {
+            caps.relations = true;
+            collect_used(a, caps);
+            collect_used(b, caps);
+        }
+        MathExpr::Group(a) => collect_used(a, caps),
+        MathExpr::Text(_) => caps.text = true,
+        MathExpr::Matrix(rows) => {
+            caps.matrices = true;
+            for row in rows {
+                for cell in row {
+                    collect_used(cell, caps);
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::expr::{MathExpr, Number};
+    use crate::frontend::{Capabilities, FrontendError};
+
+    /// Honest frontend: emits only a Number, declares nothing extra → conforms.
+    struct Honest;
+    impl MathFrontend for Honest {
+        fn name(&self) -> &str { "honest" }
+        fn parse(&self, src: &str) -> Result<MathExpr, FrontendError> {
+            Number::parse(src)
+                .map(MathExpr::Number)
+                .ok_or_else(|| FrontendError::new("honest", "nope", (0, src.len())))
+        }
+        fn capabilities(&self) -> Capabilities { Capabilities::none() }
+    }
+
+    /// Dishonest frontend: emits a Frac but declares no fractions capability.
+    struct OverClaimer;
+    impl MathFrontend for OverClaimer {
+        fn name(&self) -> &str { "over" }
+        fn parse(&self, _src: &str) -> Result<MathExpr, FrontendError> {
+            Ok(MathExpr::Frac(
+                Box::new(MathExpr::Number(Number::from_i64(1))),
+                Box::new(MathExpr::Number(Number::from_i64(2))),
+            ))
+        }
+        fn capabilities(&self) -> Capabilities { Capabilities::none() }
+    }
+
+    /// Buggy frontend: returns an out-of-range error span.
+    struct BadSpan;
+    impl MathFrontend for BadSpan {
+        fn name(&self) -> &str { "badspan" }
+        fn parse(&self, src: &str) -> Result<MathExpr, FrontendError> {
+            Err(FrontendError::new("badspan", "x", (0, src.len() + 99)))
+        }
+        fn capabilities(&self) -> Capabilities { Capabilities::none() }
+    }
+
+    /// Crashing frontend: the harness must convert the panic into an issue, not crash.
+    struct Panicker;
+    impl MathFrontend for Panicker {
+        fn name(&self) -> &str { "panic" }
+        fn parse(&self, _src: &str) -> Result<MathExpr, FrontendError> {
+            panic!("boom")
+        }
+        fn capabilities(&self) -> Capabilities { Capabilities::none() }
+    }
+
+    #[test]
+    fn honest_frontend_conforms() {
+        let r = check_frontend(&Honest, &["1", "2", "x"]);
+        assert!(r.passed(), "{:?}", r.issues);
+        assert_eq!(r.samples_checked, 3);
+    }
+
+    #[test]
+    fn over_claiming_capabilities_is_flagged() {
+        let r = check_frontend(&OverClaimer, &["anything"]);
+        assert!(!r.passed());
+        assert!(r.issues.iter().any(|i| i.contains("fractions")));
+    }
+
+    #[test]
+    fn out_of_range_error_span_is_flagged() {
+        let r = check_frontend(&BadSpan, &["abc"]);
+        assert!(!r.passed());
+        assert!(r.issues.iter().any(|i| i.contains("exceeds source length")));
+    }
+
+    #[test]
+    fn a_panic_becomes_an_issue_not_a_crash() {
+        // Silence the default panic hook so the expected panic doesn't spam test output.
+        let prev = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {}));
+        let r = check_frontend(&Panicker, &["1"]);
+        std::panic::set_hook(prev);
+        assert!(!r.passed());
+        assert!(r.issues.iter().any(|i| i.contains("panicked")));
+    }
+}

--- a/code/packages/rust/math-frontend/src/expr.rs
+++ b/code/packages/rust/math-frontend/src/expr.rs
@@ -86,14 +86,17 @@ impl Number {
         }
 
         // Combine into digits × 10^exponent: the fraction shifts the exponent down.
+        // All exponent arithmetic is CHECKED so an adversarial literal (e.g. an
+        // exponent near i64::MAX) returns None rather than overflow-panicking — the
+        // parser must stay total, never panic.
         let mut all_digits = String::with_capacity(int_part.len() + frac_part.len());
         all_digits.push_str(int_part);
         all_digits.push_str(frac_part);
-        let mut exponent = exp - frac_part.len() as i64;
+        let mut exponent = exp.checked_sub(frac_part.len() as i64)?;
 
         // Normalize: strip trailing zeros (raising the exponent) then leading zeros.
         let trimmed_trailing = all_digits.trim_end_matches('0');
-        exponent += (all_digits.len() - trimmed_trailing.len()) as i64;
+        exponent = exponent.checked_add((all_digits.len() - trimmed_trailing.len()) as i64)?;
         let normalized: String = trimmed_trailing.trim_start_matches('0').to_string();
 
         let (digits, exponent, negative) = if normalized.is_empty() {
@@ -128,7 +131,11 @@ impl Number {
             return Some(0.0);
         }
         let mantissa: f64 = self.digits.parse().ok()?;
-        let v = mantissa * 10f64.powi(self.exponent as i32);
+        // Range-check the exponent rather than truncating with `as i32`: a magnitude
+        // too extreme for i32 is exactly the "cannot be represented" case → None,
+        // never a silently-wrong finite value.
+        let exp = i32::try_from(self.exponent).ok()?;
+        let v = mantissa * 10f64.powi(exp);
         if v.is_finite() {
             Some(if self.negative { -v } else { v })
         } else {
@@ -293,6 +300,20 @@ mod tests {
         assert!(Number::parse("1e").is_none());
         assert!(Number::parse("1e+").is_none());
         assert!(Number::parse("0x10").is_none());
+    }
+
+    #[test]
+    fn adversarial_exponents_stay_total_and_honest() {
+        // A near-i64::MAX exponent with trailing-zero normalization must NOT overflow-
+        // panic in parse — it returns None (the value isn't a representable numeral here).
+        assert!(Number::parse("100e9223372036854775807").is_none());
+        // A huge but parseable exponent: to_f64 must return None (too extreme), never a
+        // truncated finite lie.
+        if let Some(n) = Number::parse("1e3000000000") {
+            assert_eq!(n.to_f64(), None);
+        }
+        // Sanity: a normal large-ish exponent still works.
+        assert_eq!(Number::parse("1e3").unwrap().to_f64(), Some(1000.0));
     }
 
     #[test]

--- a/code/packages/rust/math-frontend/src/expr.rs
+++ b/code/packages/rust/math-frontend/src/expr.rs
@@ -1,0 +1,303 @@
+//! The **neutral math AST** every frontend produces and every consumer lowers.
+//!
+//! This tree is deliberately *notation-agnostic*: it is not LaTeX-shaped, not
+//! AsciiMath-shaped. Two source strings that mean the same mathematics — `a \times b`
+//! and `a \cdot b` and `ab`, or `\frac{1}{2}` and `1/2` — produce the **same**
+//! `MathExpr`. That is what lets a consumer (a rule engine, a CAS, a renderer) treat
+//! every input notation uniformly: write the lowering once, get every frontend free.
+//!
+//! Presentation-only distinctions are normalized away on purpose (see [`BinOp`]).
+//! Meaning-bearing structure is kept faithfully.
+
+/// A numeric literal that **preserves exactness**.
+///
+/// A frontend must never silently turn `0.1` into the nearest `f64` — lossy float
+/// conversion is a *consumer's* decision at lowering time, made explicitly via
+/// [`Number::to_f64`]. So a `Number` keeps the literal's exact decimal value as a
+/// normalized `(negative, digits, exponent)` triple (value = `±digits × 10^exponent`),
+/// where `digits` has no leading or trailing zeros. This is exact for every decimal
+/// numeral a notation can write, needs no big-integer dependency, and gives a correct
+/// `==` (so `1.0`, `1`, `01`, and `1e0` all compare equal).
+#[derive(Debug, Clone)]
+pub struct Number {
+    negative: bool,
+    /// Significant digits, no leading/trailing zeros. Empty string means the value 0.
+    digits: String,
+    /// Power-of-ten exponent applied to `digits` interpreted as an integer.
+    exponent: i64,
+    /// The literal exactly as written by the source notation (for round-tripping).
+    raw: String,
+}
+
+impl Number {
+    /// Parse a decimal numeral: optional sign, integer and/or fraction part, optional
+    /// `e`/`E` exponent (`-12`, `3.14`, `.5`, `6.022e23`, `1E-3`). Returns `None` if the
+    /// text is not a well-formed decimal numeral.
+    pub fn parse(raw: &str) -> Option<Number> {
+        let s = raw.trim();
+        if s.is_empty() {
+            return None;
+        }
+        let bytes = s.as_bytes();
+        let mut i = 0;
+        let negative = match bytes.first() {
+            Some(b'+') => { i += 1; false }
+            Some(b'-') => { i += 1; true }
+            _ => false,
+        };
+        let int_start = i;
+        while i < bytes.len() && bytes[i].is_ascii_digit() {
+            i += 1;
+        }
+        let int_part = &s[int_start..i];
+        let mut frac_part = "";
+        if i < bytes.len() && bytes[i] == b'.' {
+            i += 1;
+            let frac_start = i;
+            while i < bytes.len() && bytes[i].is_ascii_digit() {
+                i += 1;
+            }
+            frac_part = &s[frac_start..i];
+        }
+        // need at least one digit overall
+        if int_part.is_empty() && frac_part.is_empty() {
+            return None;
+        }
+        let mut exp: i64 = 0;
+        if i < bytes.len() && (bytes[i] == b'e' || bytes[i] == b'E') {
+            i += 1;
+            let neg_exp = match bytes.get(i) {
+                Some(b'+') => { i += 1; false }
+                Some(b'-') => { i += 1; true }
+                _ => false,
+            };
+            let exp_start = i;
+            while i < bytes.len() && bytes[i].is_ascii_digit() {
+                i += 1;
+            }
+            if exp_start == i {
+                return None; // `e` with no exponent digits
+            }
+            let mag: i64 = s[exp_start..i].parse().ok()?;
+            exp = if neg_exp { -mag } else { mag };
+        }
+        if i != bytes.len() {
+            return None; // trailing junk
+        }
+
+        // Combine into digits × 10^exponent: the fraction shifts the exponent down.
+        let mut all_digits = String::with_capacity(int_part.len() + frac_part.len());
+        all_digits.push_str(int_part);
+        all_digits.push_str(frac_part);
+        let mut exponent = exp - frac_part.len() as i64;
+
+        // Normalize: strip trailing zeros (raising the exponent) then leading zeros.
+        let trimmed_trailing = all_digits.trim_end_matches('0');
+        exponent += (all_digits.len() - trimmed_trailing.len()) as i64;
+        let normalized: String = trimmed_trailing.trim_start_matches('0').to_string();
+
+        let (digits, exponent, negative) = if normalized.is_empty() {
+            (String::new(), 0, false) // canonical zero (never "-0")
+        } else {
+            (normalized, exponent, negative)
+        };
+
+        Some(Number {
+            negative,
+            digits,
+            exponent,
+            raw: raw.to_string(),
+        })
+    }
+
+    /// True if this number is exactly zero.
+    pub fn is_zero(&self) -> bool {
+        self.digits.is_empty()
+    }
+
+    /// The literal exactly as the source notation wrote it.
+    pub fn as_written(&self) -> &str {
+        &self.raw
+    }
+
+    /// **Lossy** conversion to `f64` — an explicit choice the consumer makes when it is
+    /// willing to leave exact arithmetic. Returns `None` only if the magnitude is so
+    /// extreme it cannot be represented.
+    pub fn to_f64(&self) -> Option<f64> {
+        if self.is_zero() {
+            return Some(0.0);
+        }
+        let mantissa: f64 = self.digits.parse().ok()?;
+        let v = mantissa * 10f64.powi(self.exponent as i32);
+        if v.is_finite() {
+            Some(if self.negative { -v } else { v })
+        } else {
+            None
+        }
+    }
+
+    /// Construct directly from an integer (convenience for tests and consumers).
+    pub fn from_i64(n: i64) -> Number {
+        Number::parse(&n.to_string()).expect("integer is a valid numeral")
+    }
+}
+
+/// Two numbers are equal iff they denote the same exact value (normalized form), so
+/// `1`, `1.0`, `01`, and `1e0` all compare equal. The `raw` spelling is *not* compared.
+impl PartialEq for Number {
+    fn eq(&self, other: &Self) -> bool {
+        self.negative == other.negative
+            && self.digits == other.digits
+            && self.exponent == other.exponent
+    }
+}
+impl Eq for Number {}
+
+/// Binary operators. **`Mul` and `Div` carry no surface style** — `\times`, `\cdot`,
+/// and juxtaposition all become `Mul`; `\frac`, `\dfrac`, `/` all become `Div` (or the
+/// intent-carrying [`MathExpr::Frac`]). Presentation, not meaning, is dropped here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BinOp {
+    Add,
+    Sub,
+    Mul,
+    Div,
+    Pow,
+}
+
+/// Unary prefix operators.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UnaryOp {
+    Neg,
+    Pos,
+}
+
+/// Relational operators.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RelOp {
+    Eq,
+    Ne,
+    Lt,
+    Le,
+    Gt,
+    Ge,
+    Approx,
+    Equiv,
+}
+
+/// Named functions. The common ones are closed variants (so consumers can `match`
+/// exhaustively on what they support); anything else is preserved by name in `Other`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Func {
+    Sin, Cos, Tan, Cot, Sec, Csc,
+    Asin, Acos, Atan,
+    Sinh, Cosh, Tanh,
+    Ln, Log, Exp,
+    Min, Max, Gcd, Lcm, Det,
+    Other(String),
+}
+
+/// Big operators that take optional lower/upper bounds and a body.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BigOp {
+    Sum, Prod, Int, Oint, Coprod, Lim,
+    Other(String),
+}
+
+/// A node in the neutral math AST. See the module docs for the normalization contract.
+#[derive(Debug, Clone, PartialEq)]
+pub enum MathExpr {
+    /// An exact numeric literal.
+    Number(Number),
+    /// A variable or named constant: `"x"`, `"pi"`, `"alpha"`.
+    Symbol(String),
+    /// A binary operation.
+    Bin(BinOp, Box<MathExpr>, Box<MathExpr>),
+    /// A unary operation.
+    Unary(UnaryOp, Box<MathExpr>),
+    /// A fraction `numerator / denominator` (a `Div` that the source wrote as a built-up
+    /// fraction; kept distinct so a renderer can reproduce it, but it means division).
+    Frac(Box<MathExpr>, Box<MathExpr>),
+    /// An nth root: `degree` is `None` for a square root.
+    Root {
+        degree: Option<Box<MathExpr>>,
+        radicand: Box<MathExpr>,
+    },
+    /// A named-function application: `sin(x)`, `ln(x)`.
+    Call { func: Func, arg: Box<MathExpr> },
+    /// A big operator with optional bounds: `\sum_{i=1}^{n} body`.
+    BigOp {
+        op: BigOp,
+        lower: Option<Box<MathExpr>>,
+        upper: Option<Box<MathExpr>>,
+        body: Box<MathExpr>,
+    },
+    /// Indexing (subscript), kept distinct from `Pow`: `a_i`.
+    Subscript(Box<MathExpr>, Box<MathExpr>),
+    /// A relation: `a = b`, `x <= y`.
+    Rel(RelOp, Box<MathExpr>, Box<MathExpr>),
+    /// Explicit grouping (parentheses/braces) — preserved so precedence intent is exact.
+    Group(Box<MathExpr>),
+    /// Prose embedded in math (`\text{…}`): units, labels.
+    Text(String),
+    /// A matrix as rows of cells.
+    Matrix(Vec<Vec<MathExpr>>),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn number_normalizes_equal_values() {
+        assert_eq!(Number::parse("1").unwrap(), Number::parse("1.0").unwrap());
+        assert_eq!(Number::parse("1").unwrap(), Number::parse("01").unwrap());
+        assert_eq!(Number::parse("1").unwrap(), Number::parse("1e0").unwrap());
+        assert_eq!(Number::parse("100").unwrap(), Number::parse("1e2").unwrap());
+        assert_eq!(Number::parse("0.5").unwrap(), Number::parse(".5").unwrap());
+        assert_eq!(Number::parse("0.5").unwrap(), Number::parse("5e-1").unwrap());
+    }
+
+    #[test]
+    fn number_distinguishes_different_values() {
+        assert_ne!(Number::parse("1").unwrap(), Number::parse("2").unwrap());
+        assert_ne!(Number::parse("0.1").unwrap(), Number::parse("0.10001").unwrap());
+        assert_ne!(Number::parse("1").unwrap(), Number::parse("-1").unwrap());
+    }
+
+    #[test]
+    fn zero_is_canonical_and_never_negative() {
+        assert_eq!(Number::parse("0").unwrap(), Number::parse("-0").unwrap());
+        assert_eq!(Number::parse("0").unwrap(), Number::parse("0.000").unwrap());
+        assert!(Number::parse("0").unwrap().is_zero());
+    }
+
+    #[test]
+    fn number_preserves_the_written_form() {
+        assert_eq!(Number::parse("3.140").unwrap().as_written(), "3.140");
+    }
+
+    #[test]
+    fn number_to_f64_is_explicit_and_lossy() {
+        assert_eq!(Number::parse("0.5").unwrap().to_f64(), Some(0.5));
+        assert_eq!(Number::parse("100").unwrap().to_f64(), Some(100.0));
+        assert_eq!(Number::parse("-2.5").unwrap().to_f64(), Some(-2.5));
+        assert_eq!(Number::parse("0").unwrap().to_f64(), Some(0.0));
+    }
+
+    #[test]
+    fn number_rejects_non_numerals() {
+        assert!(Number::parse("").is_none());
+        assert!(Number::parse("x").is_none());
+        assert!(Number::parse("1.2.3").is_none());
+        assert!(Number::parse("1e").is_none());
+        assert!(Number::parse("1e+").is_none());
+        assert!(Number::parse("0x10").is_none());
+    }
+
+    #[test]
+    fn from_i64_round_trips() {
+        assert_eq!(Number::from_i64(42), Number::parse("42").unwrap());
+        assert_eq!(Number::from_i64(-7).to_f64(), Some(-7.0));
+    }
+}

--- a/code/packages/rust/math-frontend/src/frontend.rs
+++ b/code/packages/rust/math-frontend/src/frontend.rs
@@ -1,0 +1,140 @@
+//! The frontend contract: the [`MathFrontend`] trait, its [`FrontendError`], and the
+//! [`Capabilities`] a frontend advertises.
+//!
+//! A *frontend* is a parser for one input notation (LaTeX, AsciiMath, MathML, …) that
+//! produces the neutral [`crate::MathExpr`]. Consumers depend on this trait, never on a
+//! concrete notation — so supporting a new notation is "add one more frontend", with no
+//! change to any consumer.
+
+use crate::expr::MathExpr;
+
+/// A parse failure from a frontend, carrying a byte span into the source so a caller can
+/// underline the exact offending slice. `span` is half-open `[start, end)`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FrontendError {
+    /// Which frontend raised the error (its [`MathFrontend::name`]).
+    pub frontend: String,
+    /// Human-readable description.
+    pub message: String,
+    /// Half-open byte span `[start, end)` into the source.
+    pub span: (usize, usize),
+}
+
+impl FrontendError {
+    pub fn new(frontend: impl Into<String>, message: impl Into<String>, span: (usize, usize)) -> Self {
+        FrontendError {
+            frontend: frontend.into(),
+            message: message.into(),
+            span,
+        }
+    }
+}
+
+impl std::fmt::Display for FrontendError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{} frontend: {} (bytes {}..{})",
+            self.frontend, self.message, self.span.0, self.span.1
+        )
+    }
+}
+
+impl std::error::Error for FrontendError {}
+
+/// What neutral constructs a frontend can currently emit. A consumer inspects this to
+/// **gate gracefully** — e.g. "does this frontend support matrices yet?" — instead of
+/// discovering a gap only when a parse unexpectedly fails. As a frontend matures it flips
+/// more flags on; the shared conformance harness checks that the flags match reality.
+///
+/// All flags default to `false`; build with the `with_*` setters:
+/// `Capabilities::none().with_fractions().with_powers()`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct Capabilities {
+    pub fractions: bool,
+    pub roots: bool,
+    pub powers: bool,
+    pub functions: bool,
+    pub big_operators: bool,
+    pub relations: bool,
+    pub matrices: bool,
+    pub implicit_mul: bool,
+    pub text: bool,
+}
+
+impl Capabilities {
+    /// A frontend that supports nothing beyond the always-present core (numbers,
+    /// symbols, the four arithmetic ops, grouping, unary minus).
+    pub fn none() -> Self {
+        Capabilities::default()
+    }
+
+    /// Everything on — handy for a fully-featured frontend's declaration.
+    pub fn all() -> Self {
+        Capabilities {
+            fractions: true,
+            roots: true,
+            powers: true,
+            functions: true,
+            big_operators: true,
+            relations: true,
+            matrices: true,
+            implicit_mul: true,
+            text: true,
+        }
+    }
+
+    pub fn with_fractions(mut self) -> Self { self.fractions = true; self }
+    pub fn with_roots(mut self) -> Self { self.roots = true; self }
+    pub fn with_powers(mut self) -> Self { self.powers = true; self }
+    pub fn with_functions(mut self) -> Self { self.functions = true; self }
+    pub fn with_big_operators(mut self) -> Self { self.big_operators = true; self }
+    pub fn with_relations(mut self) -> Self { self.relations = true; self }
+    pub fn with_matrices(mut self) -> Self { self.matrices = true; self }
+    pub fn with_implicit_mul(mut self) -> Self { self.implicit_mul = true; self }
+    pub fn with_text(mut self) -> Self { self.text = true; self }
+}
+
+/// The contract every notation parser implements.
+///
+/// Implementors MUST be:
+/// * **total & panic-free** — every input yields `Ok(MathExpr)` or `Err(FrontendError)`;
+/// * **pure** — no I/O, no global mutable state, no network;
+/// * **honest** — [`capabilities`](MathFrontend::capabilities) reflects what `parse`
+///   actually emits (the conformance harness enforces this).
+pub trait MathFrontend {
+    /// A stable identifier, e.g. `"latex"`, `"asciimath"`, `"mathml"`.
+    fn name(&self) -> &str;
+
+    /// Parse one source string in this notation into the neutral AST.
+    fn parse(&self, src: &str) -> Result<MathExpr, FrontendError>;
+
+    /// Which neutral constructs this frontend can currently emit.
+    fn capabilities(&self) -> Capabilities;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn capabilities_builder_sets_only_named_flags() {
+        let c = Capabilities::none().with_fractions().with_powers();
+        assert!(c.fractions && c.powers);
+        assert!(!c.matrices && !c.functions);
+    }
+
+    #[test]
+    fn capabilities_all_and_none() {
+        assert_eq!(Capabilities::none(), Capabilities::default());
+        let a = Capabilities::all();
+        assert!(a.fractions && a.matrices && a.text && a.relations);
+    }
+
+    #[test]
+    fn error_displays_with_frontend_and_span() {
+        let e = FrontendError::new("latex", "unbalanced braces", (3, 5));
+        let s = format!("{e}");
+        assert!(s.contains("latex") && s.contains("unbalanced braces") && s.contains("3..5"));
+    }
+}

--- a/code/packages/rust/math-frontend/src/lib.rs
+++ b/code/packages/rust/math-frontend/src/lib.rs
@@ -1,0 +1,51 @@
+//! # math-frontend — a pluggable parser-frontend framework
+//!
+//! Reasoning and adjudication systems must accept mathematics in the **many notations**
+//! people and models actually write: LaTeX, AsciiMath, MathML, Unicode/plain math, … We
+//! must not hard-code each notation into every consumer. Instead, a *frontend* is a parser
+//! for one notation that produces **one common neutral AST** — [`MathExpr`] — and every
+//! consumer (a rule engine, a computer-algebra system, a renderer) lowers that single
+//! tree. Adding a notation is "register one more frontend"; consumers don't change.
+//!
+//! This crate is the framework all frontends and consumers share:
+//!
+//! * [`MathExpr`] (+ [`Number`], [`BinOp`], …) — the notation-agnostic AST. Two source
+//!   strings that mean the same math produce the same tree (`a \times b` ≡ `a \cdot b`);
+//!   numbers are **exact-preserving** ([`Number`] never silently rounds to `f64`).
+//! * [`MathFrontend`] — the contract a notation parser implements (total, panic-free,
+//!   pure), with [`FrontendError`] (spanned) and [`Capabilities`] (what it can emit).
+//! * [`FrontendRegistry`] — look a frontend up by name and parse through it.
+//! * [`check_frontend`] — a shared conformance harness enforcing the contract.
+//!
+//! Parsing only: evaluation, simplification, and rendering belong to consumers, never to a
+//! frontend. The first frontend (LaTeX) lands as its own crate and registers here.
+//!
+//! ## Example
+//!
+//! ```
+//! use math_frontend::{FrontendRegistry, MathFrontend, MathExpr, Number, Capabilities, FrontendError};
+//!
+//! struct Int;                              // a toy frontend: parse a bare integer
+//! impl MathFrontend for Int {
+//!     fn name(&self) -> &str { "int" }
+//!     fn parse(&self, s: &str) -> Result<MathExpr, FrontendError> {
+//!         Number::parse(s).map(MathExpr::Number)
+//!             .ok_or_else(|| FrontendError::new("int", "not an integer", (0, s.len())))
+//!     }
+//!     fn capabilities(&self) -> Capabilities { Capabilities::none() }
+//! }
+//!
+//! let mut reg = FrontendRegistry::new();
+//! reg.register(Box::new(Int));
+//! assert_eq!(reg.parse("int", "42").unwrap(), MathExpr::Number(Number::from_i64(42)));
+//! ```
+
+mod conformance;
+mod expr;
+mod frontend;
+mod registry;
+
+pub use conformance::{check_frontend, ConformanceReport};
+pub use expr::{BigOp, BinOp, Func, MathExpr, Number, RelOp, UnaryOp};
+pub use frontend::{Capabilities, FrontendError, MathFrontend};
+pub use registry::FrontendRegistry;

--- a/code/packages/rust/math-frontend/src/registry.rs
+++ b/code/packages/rust/math-frontend/src/registry.rs
@@ -1,0 +1,133 @@
+//! The [`FrontendRegistry`]: look up a frontend by name and parse through it.
+//!
+//! Consumers hold one registry and call `registry.parse("latex", src)`. Adding support
+//! for a new notation is `registry.register(Box::new(MyFrontend))` — nothing else in the
+//! consumer changes.
+
+use crate::expr::MathExpr;
+use crate::frontend::{FrontendError, MathFrontend};
+use std::collections::BTreeMap;
+
+/// A name-keyed set of installed frontends.
+#[derive(Default)]
+pub struct FrontendRegistry {
+    // BTreeMap so `names()` is stable/sorted (deterministic error messages and listings).
+    frontends: BTreeMap<String, Box<dyn MathFrontend>>,
+}
+
+impl FrontendRegistry {
+    /// An empty registry.
+    pub fn new() -> Self {
+        FrontendRegistry::default()
+    }
+
+    /// A registry pre-loaded with the built-in frontends.
+    ///
+    /// There are no built-in frontends yet — LaTeX (the first) lands as its own crate and
+    /// will be registered here once it implements [`MathFrontend`]. Until then this is
+    /// empty, by design, rather than pretending to support a notation it cannot parse.
+    pub fn with_builtins() -> Self {
+        FrontendRegistry::new()
+    }
+
+    /// Install a frontend, replacing any existing one with the same name. Returns the
+    /// displaced frontend, if any.
+    pub fn register(&mut self, frontend: Box<dyn MathFrontend>) -> Option<Box<dyn MathFrontend>> {
+        self.frontends.insert(frontend.name().to_string(), frontend)
+    }
+
+    /// Look up a frontend by name.
+    pub fn get(&self, name: &str) -> Option<&dyn MathFrontend> {
+        self.frontends.get(name).map(|b| b.as_ref())
+    }
+
+    /// The names of all installed frontends, sorted.
+    pub fn names(&self) -> Vec<&str> {
+        self.frontends.keys().map(|s| s.as_str()).collect()
+    }
+
+    /// Parse `src` through the named frontend. If the name is unknown, returns a
+    /// `FrontendError` (frontend `"<registry>"`) naming the unknown frontend and listing
+    /// the installed ones — never a panic.
+    pub fn parse(&self, name: &str, src: &str) -> Result<MathExpr, FrontendError> {
+        match self.get(name) {
+            Some(f) => f.parse(src),
+            None => Err(FrontendError::new(
+                "<registry>",
+                format!(
+                    "unknown frontend {:?}; installed: [{}]",
+                    name,
+                    self.names().join(", ")
+                ),
+                (0, src.len()),
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::expr::{MathExpr, Number};
+    use crate::frontend::Capabilities;
+
+    /// A trivial frontend used only to exercise the registry machinery: it parses a bare
+    /// non-negative integer into `MathExpr::Number`, else errors.
+    struct IntFrontend;
+    impl MathFrontend for IntFrontend {
+        fn name(&self) -> &str {
+            "int"
+        }
+        fn parse(&self, src: &str) -> Result<MathExpr, FrontendError> {
+            Number::parse(src)
+                .map(MathExpr::Number)
+                .ok_or_else(|| FrontendError::new("int", "not an integer", (0, src.len())))
+        }
+        fn capabilities(&self) -> Capabilities {
+            Capabilities::none()
+        }
+    }
+
+    #[test]
+    fn register_get_and_names() {
+        let mut r = FrontendRegistry::new();
+        assert!(r.names().is_empty());
+        assert!(r.register(Box::new(IntFrontend)).is_none());
+        assert_eq!(r.names(), vec!["int"]);
+        assert!(r.get("int").is_some());
+        assert!(r.get("nope").is_none());
+    }
+
+    #[test]
+    fn parse_through_named_frontend() {
+        let mut r = FrontendRegistry::new();
+        r.register(Box::new(IntFrontend));
+        assert_eq!(r.parse("int", "42").unwrap(), MathExpr::Number(Number::from_i64(42)));
+        assert!(r.parse("int", "x").is_err());
+    }
+
+    #[test]
+    fn unknown_frontend_lists_installed_and_does_not_panic() {
+        let mut r = FrontendRegistry::new();
+        r.register(Box::new(IntFrontend));
+        let err = r.parse("latex", "1").unwrap_err();
+        assert_eq!(err.frontend, "<registry>");
+        assert!(err.message.contains("unknown frontend"));
+        assert!(err.message.contains("int")); // lists what IS installed
+    }
+
+    #[test]
+    fn register_replaces_and_returns_displaced() {
+        let mut r = FrontendRegistry::new();
+        r.register(Box::new(IntFrontend));
+        let displaced = r.register(Box::new(IntFrontend));
+        assert!(displaced.is_some());
+        assert_eq!(r.names().len(), 1);
+    }
+
+    #[test]
+    fn with_builtins_is_currently_empty() {
+        // Documented: no built-in frontends yet (latex arrives as its own crate).
+        assert!(FrontendRegistry::with_builtins().names().is_empty());
+    }
+}


### PR DESCRIPTION
Implements [`PFE01`](code/specs/PFE01-pluggable-parser-frontends.md) — the substrate that makes **LaTeX one of many pluggable parser frontends**.

A *frontend* parses one notation (LaTeX, AsciiMath, MathML, …) into **one common neutral AST** (`MathExpr`); every consumer (ADJ, a CAS, a renderer) lowers that single tree, so adding a notation later is "register one more frontend" with zero consumer changes. Parsing only — evaluation/lowering stays the consumer's job (not conflated).

### New zero-dependency crate `math-frontend`
- **`MathExpr`** — notation-agnostic AST (Number / Symbol / Bin / Unary / Frac / Root / Call / BigOp / Subscript / Rel / Group / Text / Matrix). Presentation normalizes away (`\times`/`\cdot`/juxtaposition → `Mul`); meaning is kept.
- **`Number`** — **exact-preserving**: decimal numerals parse to a normalized `±digits×10^exp` triple, so `1`/`1.0`/`01`/`1e0` compare equal and `0.1` is never silently rounded; `to_f64()` is explicit + lossy; zero canonical; no big-int dep. Hardened against adversarial exponents (checked arithmetic; `i32::try_from` not `as i32`) so it stays total/panic-free.
- **`MathFrontend`** trait (total, panic-free, pure) + spanned **`FrontendError`** + **`Capabilities`** (what a frontend can emit).
- **`FrontendRegistry`** — name-keyed install/lookup/parse; unknown frontend → spanned error listing the installed ones; `with_builtins()` empty by design until `latex` lands.
- **`check_frontend`** — shared conformance harness: no panic (`catch_unwind`), well-formed spanned errors, honest capabilities.

### Verification
`cargo test -p math-frontend` → 20 unit + 1 doc test; `cargo clippy -p math-frontend -- -D warnings` clean; no `unsafe`. Security review: 2 LOW findings (adversarial-exponent overflow/truncation) found and fixed.

Next on the ladder: the `latex` crate (LTX01 L0 catcode tokenizer), which will implement `MathFrontend` and register here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)