### PR TITLE
feat(spreadsheet-core): sheet management + multi-sheet load fix (multi-sheet PR-4)

### DIFF
--- a/code/packages/rust/spreadsheet-core/CHANGELOG.md
+++ b/code/packages/rust/spreadsheet-core/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## 0.15.0
+
+**Sheet management + multi-sheet load fix (multi-sheet PR-4 — the last engine
+slice).** Rename / delete / reorder sheets, list them for a tab bar, and a fix so a
+loaded workbook's cross-sheet dependencies are live.
+
+- `Workbook::sheet_names() -> Vec<&str>` (tab order), `rename_sheet(id, new)`,
+  `delete_sheet(id)`, `move_sheet(id, to_index)`. Dense `SheetId`s are the sheet
+  `Vec`'s indices, so delete/move rebuild the `name → SheetId` index and the
+  dependency graph (`rebuild_sheet_index` helper); names — and therefore formula
+  qualifiers and computed values — are unaffected by a reorder.
+- **Rename** rewrites the qualifier in every formula that named the sheet
+  (`=Old!A1` → `=New!A1`, via `FormulaAst::rename_qualifier`); the `SheetId` and all
+  values are unchanged. Rejects an empty or duplicate name.
+- **Delete** refuses to remove the last sheet, reindexes the survivors, and rewrites
+  every inbound reference to the gone sheet to the `#REF!` literal
+  (`FormulaAst::sheet_refs_to_error`) — permanent, so re-adding a same-named sheet
+  doesn't resurrect it (Excel behaviour).
+- **Fix (`deserialize`)**: a workbook is loaded sheet-by-sheet in file order, so a
+  cross-sheet formula loaded *before* its target sheet couldn't resolve its
+  qualifier at `set_formula` time and its dependency edge was skipped — values were
+  right (a full `recalc_all` resolves names) but a later edit of the precedent didn't
+  recompute the dependent. `deserialize` now rebuilds the dependency graph after all
+  sheets exist, so a loaded cross-sheet formula is fully live.
+- Tests: rename rewrites qualifiers + keeps values + recomputes; delete reindexes,
+  inbound → `#REF!`, can't-delete-last; move reorders + preserves cross-sheet values;
+  multi-sheet serialize round-trip with a live cross-sheet formula.
+
 ## 0.14.0
 
 **Cross-sheet references — structural-edit / fill / sort propagation (multi-sheet

--- a/code/packages/rust/spreadsheet-core/Cargo.toml
+++ b/code/packages/rust/spreadsheet-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spreadsheet-core"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 description = "Headless spreadsheet engine — cell model, formula AST, dependency DAG, recalc, dispatch to Layer-1 cores. The engine VisiCalc Modern and any other Mosaic-rendered spreadsheet sits on top of."
 

--- a/code/packages/rust/spreadsheet-core/src/ast.rs
+++ b/code/packages/rust/spreadsheet-core/src/ast.rs
@@ -314,6 +314,71 @@ impl FormulaAst {
             },
         }
     }
+
+    /// Rewrite the **sheet qualifier** of every reference named `old` to `new`,
+    /// leaving the address untouched — the source-text side of renaming a sheet.
+    /// References to other sheets and unqualified references are unchanged. Pure.
+    pub fn rename_qualifier(&self, old: &str, new: &str) -> FormulaAst {
+        match self {
+            FormulaAst::Ref {
+                sheet: Some(name),
+                addr,
+            } if name == old => FormulaAst::sheet_cell(new, *addr),
+            FormulaAst::Range {
+                sheet: Some(name),
+                range,
+            } if name == old => FormulaAst::sheet_range(new, *range),
+            FormulaAst::Literal(_) | FormulaAst::Ref { .. } | FormulaAst::Range { .. } => {
+                self.clone()
+            }
+            FormulaAst::Unary { op, operand } => FormulaAst::Unary {
+                op: *op,
+                operand: Box::new(operand.rename_qualifier(old, new)),
+            },
+            FormulaAst::Binary { op, lhs, rhs } => FormulaAst::Binary {
+                op: *op,
+                lhs: Box::new(lhs.rename_qualifier(old, new)),
+                rhs: Box::new(rhs.rename_qualifier(old, new)),
+            },
+            FormulaAst::Percent(inner) => {
+                FormulaAst::Percent(Box::new(inner.rename_qualifier(old, new)))
+            }
+            FormulaAst::Call { name, args } => FormulaAst::Call {
+                name: name.clone(),
+                args: args.iter().map(|a| a.rename_qualifier(old, new)).collect(),
+            },
+        }
+    }
+
+    /// Replace every reference qualified with the sheet `name` by the `#REF!`
+    /// error literal — what deleting a sheet does to the references that pointed
+    /// into it (permanent, so re-adding a same-named sheet doesn't resurrect them,
+    /// matching Excel). Other references are unchanged. Pure.
+    pub fn sheet_refs_to_error(&self, name: &str) -> FormulaAst {
+        match self {
+            FormulaAst::Ref { sheet: Some(n), .. } if n == name => ref_error(),
+            FormulaAst::Range { sheet: Some(n), .. } if n == name => ref_error(),
+            FormulaAst::Literal(_) | FormulaAst::Ref { .. } | FormulaAst::Range { .. } => {
+                self.clone()
+            }
+            FormulaAst::Unary { op, operand } => FormulaAst::Unary {
+                op: *op,
+                operand: Box::new(operand.sheet_refs_to_error(name)),
+            },
+            FormulaAst::Binary { op, lhs, rhs } => FormulaAst::Binary {
+                op: *op,
+                lhs: Box::new(lhs.sheet_refs_to_error(name)),
+                rhs: Box::new(rhs.sheet_refs_to_error(name)),
+            },
+            FormulaAst::Percent(inner) => {
+                FormulaAst::Percent(Box::new(inner.sheet_refs_to_error(name)))
+            }
+            FormulaAst::Call { name: fname, args } => FormulaAst::Call {
+                name: fname.clone(),
+                args: args.iter().map(|a| a.sheet_refs_to_error(name)).collect(),
+            },
+        }
+    }
 }
 
 /// The `#REF!` error as a formula literal — what a reference shifted off the grid

--- a/code/packages/rust/spreadsheet-core/src/workbook.rs
+++ b/code/packages/rust/spreadsheet-core/src/workbook.rs
@@ -140,6 +140,125 @@ impl Workbook {
         self.sheets.get(sheet.0 as usize).map(|s| s.name.as_str())
     }
 
+    /// All sheet names in tab order (`SheetId(i)` is the i-th name). Drives a
+    /// host's sheet tab bar.
+    pub fn sheet_names(&self) -> Vec<&str> {
+        self.sheets.iter().map(|s| s.name.as_str()).collect()
+    }
+
+    /// Rebuild the `name → SheetId` index from the current sheet order. Called
+    /// after any operation that changes names or reorders/removes sheets (so the
+    /// dense `SheetId` indices stay in sync with the `Vec`).
+    fn rebuild_sheet_index(&mut self) {
+        self.sheet_by_name.clear();
+        for (i, s) in self.sheets.iter().enumerate() {
+            self.sheet_by_name.insert(s.name.clone(), SheetId(i as u32));
+        }
+    }
+
+    /// Rename a sheet. The sheet's `SheetId` is unchanged (so the dependency graph
+    /// and computed values are untouched — a rename is purely cosmetic), but every
+    /// formula that *names* the old sheet has its qualifier rewritten to the new
+    /// name in its stored source (`=Old!A1` → `=New!A1`). Rejects an empty name or
+    /// one already used by a different sheet; renaming to the current name is a
+    /// no-op. Bumps the revision so a host re-reads the affected sources.
+    pub fn rename_sheet(
+        &mut self,
+        sheet: SheetId,
+        new_name: impl Into<String>,
+    ) -> Result<(), String> {
+        let new_name = new_name.into();
+        let idx = sheet.0 as usize;
+        if idx >= self.sheets.len() {
+            return Err("unknown sheet".to_string());
+        }
+        if new_name.is_empty() {
+            return Err("sheet name must not be empty".to_string());
+        }
+        let old_name = self.sheets[idx].name.clone();
+        if old_name == new_name {
+            return Ok(());
+        }
+        if let Some(existing) = self.sheet_by_name.get(&new_name) {
+            if *existing != sheet {
+                return Err(format!("a sheet named {new_name:?} already exists"));
+            }
+        }
+        self.sheets[idx].name = new_name.clone();
+        self.rebuild_sheet_index();
+        // Rewrite the qualifier in every formula that named the old sheet (any
+        // sheet may reference it). Values are unchanged, so no recalc is needed.
+        for s in &mut self.sheets {
+            for cell in s.cells.values_mut() {
+                if let CellContent::Formula { ast, text, .. } = &mut cell.content {
+                    let renamed = ast.rename_qualifier(&old_name, &new_name);
+                    if renamed != *ast {
+                        *ast = renamed;
+                        *text = ast.to_formula_string();
+                    }
+                }
+            }
+        }
+        self.revision = self.revision.wrapping_add(1);
+        Ok(())
+    }
+
+    /// Delete a sheet. Refuses to remove the last sheet (a workbook always has at
+    /// least one). Removing the sheet shifts every later sheet's dense `SheetId`
+    /// down by one, so the name index and dependency graph are rebuilt afterwards.
+    /// Every reference that pointed *into* the deleted sheet is rewritten to the
+    /// `#REF!` error literal (permanent — re-adding a same-named sheet doesn't
+    /// resurrect it), then the workbook recomputes.
+    pub fn delete_sheet(&mut self, sheet: SheetId) -> Result<(), String> {
+        let idx = sheet.0 as usize;
+        if idx >= self.sheets.len() {
+            return Err("unknown sheet".to_string());
+        }
+        if self.sheets.len() <= 1 {
+            return Err("cannot delete the last sheet".to_string());
+        }
+        let removed_name = self.sheets[idx].name.clone();
+        self.sheets.remove(idx);
+        self.rebuild_sheet_index();
+        // Inbound refs to the now-gone sheet collapse to #REF!.
+        for s in &mut self.sheets {
+            for cell in s.cells.values_mut() {
+                if let CellContent::Formula { ast, text, cached } = &mut cell.content {
+                    let rewritten = ast.sheet_refs_to_error(&removed_name);
+                    if rewritten != *ast {
+                        *ast = rewritten;
+                        *text = ast.to_formula_string();
+                        *cached = None;
+                    }
+                }
+            }
+        }
+        self.rebuild_dependency_graph();
+        self.recalc_all(); // bumps revision + epoch
+        Ok(())
+    }
+
+    /// Reorder a sheet to a new 0-based tab position (clamped into range). The
+    /// move changes dense `SheetId`s, so the name index and dependency graph are
+    /// rebuilt; names — and therefore every formula's qualifiers and computed
+    /// values — are unaffected. A move to the current position is a no-op.
+    pub fn move_sheet(&mut self, sheet: SheetId, to_index: usize) -> Result<(), String> {
+        let idx = sheet.0 as usize;
+        if idx >= self.sheets.len() {
+            return Err("unknown sheet".to_string());
+        }
+        let to = to_index.min(self.sheets.len() - 1);
+        if to == idx {
+            return Ok(());
+        }
+        let s = self.sheets.remove(idx);
+        self.sheets.insert(to, s);
+        self.rebuild_sheet_index();
+        self.rebuild_dependency_graph();
+        self.recalc_all(); // re-resolve names → new ids; values unchanged
+        Ok(())
+    }
+
     /// Get the recalc epoch — bumped on every successful
     /// `recalc_all`.
     pub fn epoch(&self) -> u64 {
@@ -1421,6 +1540,12 @@ impl Workbook {
             }
         }
 
+        // Rebuild the dependency graph now that ALL sheets exist: a cross-sheet
+        // formula loaded before its target sheet (sheets load in file order)
+        // couldn't resolve its qualifier at `set_formula` time, so its edge was
+        // skipped. A full rebuild re-resolves every name → SheetId, registering the
+        // cross-sheet edges so a later edit recomputes its dependents.
+        self.rebuild_dependency_graph();
         self.recalc_all();
         self.revision = self.revision.wrapping_add(1);
         Ok(())
@@ -1784,6 +1909,104 @@ mod tests {
         wb.insert_rows(s1, 1, 1); // moves the formula down a row but leaves its ref
         assert_eq!(wb.cell_source_text(s1, cell(11, 2)), "Summary!A1");
         assert_eq!(wb.cell_value(s1, cell(11, 2)), CellValue::Number(5.0));
+    }
+
+    #[test]
+    fn rename_sheet_rewrites_qualifiers_and_keeps_values() {
+        let mut wb = Workbook::new();
+        let s1 = wb.add_sheet("Sheet1");
+        let summary = wb.add_sheet("Summary");
+        wb.set_value(summary, cell(1, 1), CellValue::Number(7.0));
+        wb.set_formula(s1, cell(1, 1), "=Summary!A1*2").unwrap(); // 14
+        assert_eq!(wb.cell_value(s1, cell(1, 1)), CellValue::Number(14.0));
+
+        // Rename Summary → Totals: the qualifier in Sheet1's formula follows, the
+        // value is unchanged, and the new name resolves while the old does not.
+        wb.rename_sheet(summary, "Totals").unwrap();
+        assert_eq!(wb.sheet_names(), vec!["Sheet1", "Totals"]);
+        // Rename re-emits the source from the AST (no leading `=`, parenthesised).
+        assert_eq!(wb.cell_source_text(s1, cell(1, 1)), "(Totals!A1*2)");
+        assert_eq!(wb.cell_value(s1, cell(1, 1)), CellValue::Number(14.0));
+        // Editing the renamed sheet still recomputes the dependent (deps intact).
+        wb.set_value(summary, cell(1, 1), CellValue::Number(10.0));
+        assert_eq!(wb.cell_value(s1, cell(1, 1)), CellValue::Number(20.0));
+
+        // Guards: empty name and a duplicate of another sheet are rejected.
+        assert!(wb.rename_sheet(summary, "").is_err());
+        assert!(wb.rename_sheet(summary, "Sheet1").is_err());
+    }
+
+    #[test]
+    fn delete_sheet_reindexes_and_makes_inbound_refs_ref_error() {
+        let mut wb = Workbook::new();
+        let s1 = wb.add_sheet("Sheet1");
+        let mid = wb.add_sheet("Mid");
+        let last = wb.add_sheet("Last");
+        wb.set_value(last, cell(1, 1), CellValue::Number(5.0));
+        wb.set_value(mid, cell(1, 1), CellValue::Number(9.0));
+        wb.set_formula(s1, cell(1, 1), "=Mid!A1").unwrap(); // → 9
+        wb.set_formula(s1, cell(2, 1), "=Last!A1").unwrap(); // → 5
+        assert_eq!(wb.cell_value(s1, cell(1, 1)), CellValue::Number(9.0));
+
+        // Delete the middle sheet: Last's SheetId shifts from 2 → 1, the name index
+        // follows, the inbound `=Mid!A1` ref becomes #REF!, and `=Last!A1` still
+        // resolves (by NAME) to the reindexed sheet.
+        wb.delete_sheet(mid).unwrap();
+        assert_eq!(wb.sheet_names(), vec!["Sheet1", "Last"]);
+        assert_eq!(wb.sheet_id("Last"), Some(SheetId(1)));
+        assert_eq!(
+            wb.cell_value(s1, cell(1, 1)),
+            CellValue::Error(SpreadsheetError::Ref)
+        );
+        assert_eq!(wb.cell_value(s1, cell(2, 1)), CellValue::Number(5.0));
+        // Re-adding a sheet named Mid does NOT resurrect the dead ref (now #REF!).
+        let _ = wb.add_sheet("Mid");
+        assert_eq!(
+            wb.cell_value(s1, cell(1, 1)),
+            CellValue::Error(SpreadsheetError::Ref)
+        );
+
+        // Can't delete the last remaining sheet.
+        let mut single = Workbook::new();
+        let only = single.add_sheet("Only");
+        assert!(single.delete_sheet(only).is_err());
+    }
+
+    #[test]
+    fn move_sheet_reorders_tabs_and_preserves_cross_sheet_values() {
+        let mut wb = Workbook::new();
+        let a = wb.add_sheet("A");
+        let b = wb.add_sheet("B");
+        let _c = wb.add_sheet("C");
+        wb.set_value(b, cell(1, 1), CellValue::Number(8.0));
+        wb.set_formula(a, cell(1, 1), "=B!A1+1").unwrap(); // 9
+        // Move A to the end: tab order becomes B, C, A; the cross-sheet value holds
+        // (refs resolve by name, not by the shifted id).
+        wb.move_sheet(a, 2).unwrap();
+        assert_eq!(wb.sheet_names(), vec!["B", "C", "A"]);
+        let a_now = wb.sheet_id("A").unwrap();
+        assert_eq!(wb.cell_value(a_now, cell(1, 1)), CellValue::Number(9.0));
+        wb.set_value(wb.sheet_id("B").unwrap(), cell(1, 1), CellValue::Number(20.0));
+        assert_eq!(wb.cell_value(a_now, cell(1, 1)), CellValue::Number(21.0));
+    }
+
+    #[test]
+    fn serialize_round_trips_multiple_sheets_and_cross_sheet_refs() {
+        let mut wb = Workbook::new();
+        let s1 = wb.add_sheet("Sheet1");
+        let summary = wb.add_sheet("Summary");
+        wb.set_value(summary, cell(1, 1), CellValue::Number(50.0));
+        wb.set_formula(s1, cell(1, 1), "=Summary!A1+1").unwrap(); // 51
+        let doc = wb.serialize();
+
+        let mut loaded = Workbook::new();
+        loaded.deserialize(&doc).unwrap();
+        assert_eq!(loaded.sheet_names(), vec!["Sheet1", "Summary"]);
+        let ls1 = loaded.sheet_id("Sheet1").unwrap();
+        // The cross-sheet formula reloaded live: it recomputes against Summary.
+        assert_eq!(loaded.cell_value(ls1, cell(1, 1)), CellValue::Number(51.0));
+        loaded.set_value(loaded.sheet_id("Summary").unwrap(), cell(1, 1), CellValue::Number(99.0));
+        assert_eq!(loaded.cell_value(ls1, cell(1, 1)), CellValue::Number(100.0));
     }
 
     #[test]

--- a/code/specs/spreadsheet-core.md
+++ b/code/specs/spreadsheet-core.md
@@ -233,7 +233,12 @@ resolved target sheet and registers a dependency edge `(target_sheet, addr)`, so
 cross-sheet dependency graph (`Node = (SheetId, CellAddress)`) recomputes a formula
 on one sheet when a precedent on another sheet changes. An unknown sheet name → `None`
 → `#REF!`, registering no precedent. Because edges are resolved when a formula is
-*set*, a forward reference to a not-yet-created sheet reads `#REF!` until re-entered.
+*set*, a forward reference to a not-yet-created sheet reads `#REF!` until re-entered
+— **except** on load: `deserialize` rebuilds the dependency graph after all sheets
+exist, so a workbook loaded with cross-sheet formulas (in any sheet order) is fully
+live. Sheet management — `rename_sheet` (rewrites every qualifier, keeps the id and
+values), `delete_sheet` (reindexes; inbound refs → permanent `#REF!`), `move_sheet`
+(reorders + reindexes), `sheet_names()` — rounds out the multi-sheet surface.
 
 ---
 

--- a/code/specs/visicalc-multi-sheet.md
+++ b/code/specs/visicalc-multi-sheet.md
@@ -120,20 +120,28 @@ Three *different* transforms, now each correct for qualified refs:
 - **Rename / delete a sheet** ⇒ deferred to PR-4 (rename rewrites the stored
   qualifier in every referencing formula; delete → inbound qualified refs `#REF!`).
 
-### 2.5 Sheet-management API on `Workbook`
+### 2.5 Sheet-management API on `Workbook` — **DONE (PR-4)**
 
-Add the operations a host needs (some exist):
+Shipped:
 
-- `add_sheet(name) -> SheetId` (exists), `sheet_count`, `sheet_id`, `sheet_name`
-  (exist).
-- `rename_sheet(id, new_name) -> Result<(), _>` (reject duplicate/empty names),
-- `delete_sheet(id)` (inbound refs → `#REF!`; reject deleting the last sheet),
-- `move_sheet(id, to_index)` (reorder for the tab bar),
-- `sheet_names() -> Vec<&str>` in tab order.
+- `add_sheet(name) -> SheetId`, `sheet_count`, `sheet_id`, `sheet_name` (existed).
+- `sheet_names() -> Vec<&str>` in tab order (drives the tab bar).
+- `rename_sheet(id, new_name) -> Result<(), String>` — rejects empty/duplicate names;
+  rewrites the qualifier in every referencing formula (`=Old!A1` → `=New!A1`) but
+  keeps the `SheetId` and all values (a rename is cosmetic).
+- `delete_sheet(id) -> Result<(), String>` — refuses to remove the last sheet;
+  reindexes survivors (dense `SheetId` = `Vec` index) and rebuilds the graph; inbound
+  refs to the gone sheet become `#REF!` **permanently** (re-adding a same-named sheet
+  doesn't resurrect them).
+- `move_sheet(id, to_index) -> Result<(), String>` — reorders the tab; reindexes +
+  rebuilds the graph; names/values unaffected.
 
-`serialize`/`deserialize` already rebuild "the sheets in file order"; extend the
-document to carry **all** sheets' sources + formats + the tab order, and round-trip
-cross-sheet qualifiers.
+`serialize`/`deserialize` already carry **all** sheets' sources + formats + tab order
+and round-trip cross-sheet qualifiers (the qualifier rides in the stored formula
+text). **Load fix (PR-4):** `deserialize` now rebuilds the dependency graph *after*
+all sheets are loaded — a cross-sheet formula loaded before its target sheet (file
+order) previously registered no edge, so a later edit of the precedent didn't
+recompute it; the rebuild makes a loaded cross-sheet formula fully live.
 
 ### 2.6 Engine PR slicing (each its own PR, tests + spec sync)
 


### PR DESCRIPTION
**Final engine slice** of the multi-sheet arc (spec [#6691](https://github.com/adhithyan15/coding-adventures/pull/6691); after PR-1 [#6696](https://github.com/adhithyan15/coding-adventures/pull/6696) / PR-2 [#6702](https://github.com/adhithyan15/coding-adventures/pull/6702) / PR-3 [#6707](https://github.com/adhithyan15/coding-adventures/pull/6707)). Sheet management + a `deserialize` fix.

## Changes
- **workbook.rs** — `sheet_names()` (tab order), `rename_sheet`, `delete_sheet`, `move_sheet`. Dense `SheetId` = sheet `Vec` index, so delete/move rebuild the `name → SheetId` index + dependency graph.
  - **Rename** rewrites the qualifier in every referencing formula (`=Old!A1` → `=New!A1`) but keeps the `SheetId` and all values (cosmetic); rejects empty/duplicate names.
  - **Delete** refuses the last sheet, reindexes survivors, and rewrites inbound refs to the gone sheet → `#REF!` **permanently** (re-adding a same-named sheet doesn't resurrect them).
  - **Move** reorders + reindexes; names/values unaffected.
- **ast.rs** — `FormulaAst::rename_qualifier(old, new)` + `sheet_refs_to_error(name)`, pure name-keyed AST rewrites.
- **Fix — `deserialize`**: a workbook loads sheet-by-sheet in file order, so a cross-sheet formula loaded *before* its target sheet couldn't resolve its qualifier at `set_formula` time and its dependency **edge was skipped** — values were right (a full `recalc_all` resolves names) but a later edit of the precedent didn't recompute the dependent. `deserialize` now rebuilds the dependency graph after all sheets exist, so a loaded cross-sheet formula is fully live.

## Verification
- **195 tests** (+4): rename rewrites qualifiers + keeps/recomputes values + guards; delete reindexes + inbound → `#REF!` + can't-delete-last + no-resurrect; move reorders + preserves cross-sheet values; **multi-sheet serialize round-trip with a live cross-sheet formula** (proves the deserialize fix). `serialize`/`deserialize` already carried all sheets.
- Facades build on 0.15.0 via path deps (36 tests); clippy-clean in changed code (`workbook.rs:1104` `question_mark` is the pre-existing `sort_range` warning); `#![forbid(unsafe_code)]` kept.
- Both specs synced (`visicalc-multi-sheet` §2.5 + `spreadsheet-core.md` §3 — the forward-ref caveat is now load-handled).
- `/security-review` (panics/index-OOB, `move` off-by-one, untrusted-JSON cyclic graphs, DoS, stale-edge correctness) → **PASSED**.

Bumps `spreadsheet-core` 0.14.0 → 0.15.0 + CHANGELOG. **This completes the engine half (PR-1..4).** Next: the facades PR (core-wasm active-sheet + add/rename/delete/move/sheet_names, capi `sc_*` sheet ops + header, wasm exports + JS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)