### PR TITLE
feat(latex): catcode tokenizer for full LaTeX (LTX01 L0)

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -220,6 +220,7 @@ members = [
     "lookup-core",
     "logic-engine",
     "math-frontend",
+    "latex",
     "adjudication-ir",
     "llm-cache",
     "llm-gateway",

--- a/code/packages/rust/latex/BUILD
+++ b/code/packages/rust/latex/BUILD
@@ -1,0 +1,1 @@
+cargo test -p latex -- --nocapture

--- a/code/packages/rust/latex/BUILD_windows
+++ b/code/packages/rust/latex/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p latex -- --nocapture

--- a/code/packages/rust/latex/CHANGELOG.md
+++ b/code/packages/rust/latex/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog — latex
+
+All notable changes to the full-fidelity LaTeX parser crate.
+
+## [0.1.0] — 2026-06-26
+
+### Added — LTX01 L0: crate scaffold + catcode tokenizer
+
+- New standalone, **zero-dependency** crate `latex` (added to the Rust workspace members).
+  A full-fidelity LaTeX parser for documents *and* math; first frontend of the
+  `math-frontend` framework.
+- **`catcode(c)`** — TeX category codes (default plain-LaTeX assignments): Escape,
+  BeginGroup, EndGroup, MathShift, AlignTab, EndLine, Parameter, Superscript, Subscript,
+  Space, Letter, Other, Active, Comment.
+- **`tokenize(&str) -> Result<Vec<Token>, LexError>`** — a catcode-driven, **text-mode-
+  primary** state machine:
+  - mode stack: Text (primary) ↔ Math (pushed by `$`/`\(`/`\[`, display via `$$`/`\[`,
+    popped by the matching close); whitespace is significant in text, ignored in math;
+  - control words (`\`+letters, with TeX space-absorption) and control symbols
+    (`\`+non-letter, incl. `\\` line break, `\{`, `\,`, …);
+  - groups `{ }`, math on/off (`MathOn`/`MathOff` with inline/display flag), `&`, `#`,
+    `^`, `_`, active `~`, comments (`%` to end of line, eating the newline);
+  - whitespace: a run collapses to one `Space`; a blank line (≥2 newlines) is `Par`;
+  - ordinary characters emitted one-per-`Char` (faithful to TeX; the parser coalesces).
+- **`Token` / `TokenKind` / `Span`** — every token carries a half-open byte span.
+- **`LexError`** — spanned; the scanner **never panics** (trailing `\` → spanned error;
+  a stray `\)`/`$` in text mode does not underflow the mode stack).
+- 20 unit + 1 doc test; `cargo clippy -- -D warnings` clean; no `unsafe`.
+
+### Notes
+
+- Scope is full LaTeX surface; the Turing-complete TeX tail is the documented asymptote
+  (see LTX01). The structural parser (L1), math AST (L2), environments (L3), macros (L4),
+  text breadth (L5), and the `MathFrontend` adapter (L6) arrive in subsequent layers.

--- a/code/packages/rust/latex/Cargo.toml
+++ b/code/packages/rust/latex/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "latex"
+version = "0.1.0"
+edition = "2021"
+description = "A full-fidelity LaTeX parser (documents and math): a catcode-driven, text-mode-primary tokenizer and (in later layers) a structural + math parser producing a faithful AST. Standalone and reusable; will also implement the math-frontend MathFrontend trait."
+license = "MIT"
+
+[dependencies]
+# No dependencies yet. The math-frontend adapter (a later layer) will add it behind a
+# thin module so the core parser stays dependency-free.

--- a/code/packages/rust/latex/README.md
+++ b/code/packages/rust/latex/README.md
@@ -1,0 +1,59 @@
+# latex
+
+A **full-fidelity LaTeX parser** (documents *and* math, not a math subset), built as a
+standalone, reusable Rust crate. It turns LaTeX source into a faithful AST that any
+consumer can use — a reasoning engine, a computer-algebra system, a renderer. It is the
+first frontend of the pluggable [`math-frontend`](../math-frontend) framework (it will
+implement `MathFrontend` in a later layer) and is useful on its own.
+
+Spec: [`code/specs/LTX01-full-latex-parser.md`](../../../specs/LTX01-full-latex-parser.md);
+framework: [`code/specs/PFE01-pluggable-parser-frontends.md`](../../../specs/PFE01-pluggable-parser-frontends.md).
+
+## Honest scope
+
+LaTeX rests on TeX, whose macro layer is Turing-complete. This crate parses the full LaTeX
+**surface** and supports the macro mechanisms authors actually use (`\newcommand`/`\def`).
+The programmable TeX tail — runtime `\catcode` reassignment, `\expandafter`/`\csname`,
+`\if…` programming, external `\input` — is the **documented asymptote**, surfaced as an
+explicit "unsupported" node rather than mis-parsed.
+
+## Why a catcode state machine
+
+A character's meaning in LaTeX depends on its **category code** and the scanner's state:
+`\` begins a control sequence, `%` skips to end of line, `$` toggles math, a blank line is
+a paragraph break. The tokenizer is therefore a hand-written, catcode-driven state machine
+with a **text-mode-primary** mode stack (LaTeX starts in text mode; math is entered by
+`$`/`\(`/`\[`/`$$`) — the inverse of a math-only tokenizer. (This mirrors how
+`grammar-tools` hand-writes its own `.tokens` scanner; the pattern is established here.)
+
+## Status / roadmap (conformance ladder)
+
+| Layer | Contents | Status |
+|-------|----------|--------|
+| **L0 tokenizer** | catcode state machine → flat `Token` stream w/ byte spans | ✅ this release |
+| L1 structural | groups, `\cmd[opt]{arg}`, `\begin{env}…\end{env}`, text runs | ⏳ |
+| L2 math | full math AST (frac, scripts, big ops, accents, `\left\right`, …) | ⏳ |
+| L3 environments | matrices / tabular / lists (`&`, `\\`) | ⏳ |
+| L4 macros | `\newcommand`/`\def` + expansion (bounded) | ⏳ |
+| L5 text breadth | sectioning, fonts, accents, `\verb`, refs | ⏳ |
+| L6 frontend | implement `math-frontend::MathFrontend` (LaTeX becomes plugin #1) | ⏳ |
+
+## Usage
+
+```rust
+use latex::{tokenize, TokenKind};
+
+let toks = tokenize(r"Let $x$ be.").unwrap();
+assert_eq!(toks[0].kind, TokenKind::Char('L'));
+assert!(toks.iter().any(|t| matches!(t.kind, TokenKind::MathOn { .. })));
+```
+
+Every token carries a half-open byte `Span`; `tokenize` returns a spanned `LexError` on
+malformed input rather than panicking.
+
+## Tests
+
+```
+cargo test -p latex
+cargo clippy -p latex -- -D warnings
+```

--- a/code/packages/rust/latex/required_capabilities.json
+++ b/code/packages/rust/latex/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/latex",
+  "capabilities": [],
+  "justification": "Pure computation: turns a LaTeX string into tokens/AST. No filesystem, network, process, or environment access."
+}

--- a/code/packages/rust/latex/src/catcode.rs
+++ b/code/packages/rust/latex/src/catcode.rs
@@ -1,0 +1,94 @@
+//! Category codes — TeX's classification of every input character.
+//!
+//! In TeX, a character's *meaning* is governed by its **category code** (catcode), not
+//! its glyph: `\` begins a control sequence, `{` opens a group, `$` shifts into math,
+//! `%` starts a comment, and so on. The tokenizer ([`crate::lexer`]) is driven by these
+//! categories — it is, quite literally, a catcode state machine, exactly as TeX's "mouth"
+//! is. We use TeX's *default* (plain-LaTeX) assignments; runtime `\catcode` reassignment
+//! is out of scope (the documented asymptote — see the crate docs).
+//!
+//! The classic 16 categories, with the ones LaTeX source actually exercises:
+//!
+//! | code | category      | characters (default)        |
+//! |------|---------------|-----------------------------|
+//! | 0    | Escape        | `\`                         |
+//! | 1    | BeginGroup    | `{`                         |
+//! | 2    | EndGroup      | `}`                         |
+//! | 3    | MathShift     | `$`                         |
+//! | 4    | AlignTab      | `&`                         |
+//! | 5    | EndLine       | carriage return / newline   |
+//! | 6    | Parameter     | `#`                         |
+//! | 7    | Superscript   | `^`                         |
+//! | 8    | Subscript     | `_`                         |
+//! | 9    | Ignored       | NUL                         |
+//! | 10   | Space         | space, tab                  |
+//! | 11   | Letter        | `A..Z`, `a..z`              |
+//! | 12   | Other         | digits, punctuation, …      |
+//! | 13   | Active        | `~`                         |
+//! | 14   | Comment       | `%`                         |
+//! | 15   | Invalid       | DEL                         |
+
+/// A TeX category code. (Codes 9/15 — Ignored/Invalid — are folded into the handling of
+/// their rare characters; every other category is represented.)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Catcode {
+    Escape,
+    BeginGroup,
+    EndGroup,
+    MathShift,
+    AlignTab,
+    EndLine,
+    Parameter,
+    Superscript,
+    Subscript,
+    Space,
+    Letter,
+    Other,
+    Active,
+    Comment,
+}
+
+/// The default (plain-LaTeX) category code of a character.
+pub fn catcode(c: char) -> Catcode {
+    match c {
+        '\\' => Catcode::Escape,
+        '{' => Catcode::BeginGroup,
+        '}' => Catcode::EndGroup,
+        '$' => Catcode::MathShift,
+        '&' => Catcode::AlignTab,
+        '\n' | '\r' => Catcode::EndLine,
+        '#' => Catcode::Parameter,
+        '^' => Catcode::Superscript,
+        '_' => Catcode::Subscript,
+        ' ' | '\t' => Catcode::Space,
+        'a'..='z' | 'A'..='Z' => Catcode::Letter,
+        '~' => Catcode::Active,
+        '%' => Catcode::Comment,
+        _ => Catcode::Other,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_assignments() {
+        assert_eq!(catcode('\\'), Catcode::Escape);
+        assert_eq!(catcode('{'), Catcode::BeginGroup);
+        assert_eq!(catcode('}'), Catcode::EndGroup);
+        assert_eq!(catcode('$'), Catcode::MathShift);
+        assert_eq!(catcode('&'), Catcode::AlignTab);
+        assert_eq!(catcode('\n'), Catcode::EndLine);
+        assert_eq!(catcode('#'), Catcode::Parameter);
+        assert_eq!(catcode('^'), Catcode::Superscript);
+        assert_eq!(catcode('_'), Catcode::Subscript);
+        assert_eq!(catcode(' '), Catcode::Space);
+        assert_eq!(catcode('\t'), Catcode::Space);
+        assert_eq!(catcode('x'), Catcode::Letter);
+        assert_eq!(catcode('7'), Catcode::Other);
+        assert_eq!(catcode('+'), Catcode::Other);
+        assert_eq!(catcode('~'), Catcode::Active);
+        assert_eq!(catcode('%'), Catcode::Comment);
+    }
+}

--- a/code/packages/rust/latex/src/error.rs
+++ b/code/packages/rust/latex/src/error.rs
@@ -1,0 +1,30 @@
+//! Error types for the LaTeX front-end.
+//!
+//! Every error carries a half-open byte [`span`](LexError::span) `(start, end)` into the
+//! source so a caller can underline the exact offending slice. The tokenizer reports
+//! [`LexError`]; later layers (the structural and math parsers) report a `ParseError`.
+
+/// A lexical error: the input could not be split into LaTeX tokens.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LexError {
+    pub message: String,
+    /// Half-open byte span `[start, end)` into the source.
+    pub span: (usize, usize),
+}
+
+impl LexError {
+    pub fn new(message: impl Into<String>, start: usize, end: usize) -> Self {
+        LexError {
+            message: message.into(),
+            span: (start, end),
+        }
+    }
+}
+
+impl std::fmt::Display for LexError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "lex error at bytes {}..{}: {}", self.span.0, self.span.1, self.message)
+    }
+}
+
+impl std::error::Error for LexError {}

--- a/code/packages/rust/latex/src/lexer.rs
+++ b/code/packages/rust/latex/src/lexer.rs
@@ -1,0 +1,364 @@
+//! The tokenizer — a catcode-driven **state machine** over the source bytes.
+//!
+//! # Why a state machine (TeX is one)
+//!
+//! A character's meaning in LaTeX depends on what the scanner is doing and on its
+//! [category code](crate::catcode): `\` begins a control sequence (and what follows —
+//! letters vs one symbol — changes how much is consumed), `%` skips to end of line, `$`
+//! toggles math mode, a blank line means a paragraph break. None of that is a regular
+//! language; it is a stateful scan, mirroring TeX's "mouth".
+//!
+//! # The two pieces of state
+//!
+//! 1. **A mode stack** (`Text` is primary; `Math{display}` is pushed by `$`/`\(`/`\[`/`$$`
+//!    and popped by the matching close). LaTeX *starts in text mode* — the inverse of a
+//!    math-only tokenizer — and whitespace is significant in text but not in math, so the
+//!    current mode changes how spaces are handled.
+//! 2. **A position cursor** over a pre-collected `(byte_offset, char)` vector, so every
+//!    emitted token carries an exact byte span while we still iterate by Unicode scalar.
+//!
+//! ```text
+//!   TEXT ──$ / \( / \[ / $$──▶ MATH{display}
+//!     ▲                          │
+//!     └────── $ / \) / \] ───────┘
+//! ```
+//!
+//! Ordinary characters are emitted one-per-`Char` (as TeX does); coalescing runs into
+//! words is the parser's job, not the tokenizer's.
+
+use crate::catcode::{catcode, Catcode};
+use crate::error::LexError;
+use crate::token::{Token, TokenKind};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Mode {
+    Text,
+    Math { display: bool },
+}
+
+/// Tokenize a LaTeX string into a flat token stream ending in [`TokenKind::Eof`]. Returns
+/// a spanned [`LexError`] on a malformed control sequence (e.g. a trailing `\`); never
+/// panics.
+pub fn tokenize(src: &str) -> Result<Vec<Token>, LexError> {
+    let chars: Vec<(usize, char)> = src.char_indices().collect();
+    let end = src.len();
+    let n = chars.len();
+    let off = |i: usize| chars.get(i).map(|&(o, _)| o).unwrap_or(end);
+
+    let mut out: Vec<Token> = Vec::new();
+    let mut modes: Vec<Mode> = vec![Mode::Text];
+    let mut i = 0;
+
+    while i < n {
+        let (start, c) = chars[i];
+        match catcode(c) {
+            // ---- escape: a control sequence ------------------------------------
+            Catcode::Escape => {
+                i += 1;
+                if i >= n {
+                    return Err(LexError::new(
+                        "trailing '\\' at end of input (expected a control-sequence name)",
+                        start,
+                        end,
+                    ));
+                }
+                let d = chars[i].1;
+                if catcode(d) == Catcode::Letter {
+                    // control WORD: a run of letters
+                    let name_start = i;
+                    while i < n && catcode(chars[i].1) == Catcode::Letter {
+                        i += 1;
+                    }
+                    let name: String = chars[name_start..i].iter().map(|&(_, ch)| ch).collect();
+                    out.push(Token::new(TokenKind::ControlWord(name), start, off(i)));
+                    // TeX absorbs the spaces (and tabs) following a control word.
+                    while i < n && matches!(chars[i].1, ' ' | '\t') {
+                        i += 1;
+                    }
+                } else {
+                    // control SYMBOL — or a math-delimiter control symbol.
+                    match d {
+                        '(' => {
+                            modes.push(Mode::Math { display: false });
+                            i += 1;
+                            out.push(Token::new(TokenKind::MathOn { display: false }, start, off(i)));
+                        }
+                        '[' => {
+                            modes.push(Mode::Math { display: true });
+                            i += 1;
+                            out.push(Token::new(TokenKind::MathOn { display: true }, start, off(i)));
+                        }
+                        ')' => {
+                            pop_math(&mut modes);
+                            i += 1;
+                            out.push(Token::new(TokenKind::MathOff { display: false }, start, off(i)));
+                        }
+                        ']' => {
+                            pop_math(&mut modes);
+                            i += 1;
+                            out.push(Token::new(TokenKind::MathOff { display: true }, start, off(i)));
+                        }
+                        _ => {
+                            i += 1;
+                            out.push(Token::new(TokenKind::ControlSymbol(d), start, off(i)));
+                        }
+                    }
+                }
+            }
+
+            // ---- group braces --------------------------------------------------
+            Catcode::BeginGroup => {
+                i += 1;
+                out.push(Token::new(TokenKind::BeginGroup, start, off(i)));
+            }
+            Catcode::EndGroup => {
+                i += 1;
+                out.push(Token::new(TokenKind::EndGroup, start, off(i)));
+            }
+
+            // ---- math shift: `$` or `$$` --------------------------------------
+            Catcode::MathShift => {
+                let display = i + 1 < n && chars[i + 1].1 == '$';
+                i += if display { 2 } else { 1 };
+                let in_math = matches!(modes.last(), Some(Mode::Math { .. }));
+                if in_math {
+                    pop_math(&mut modes);
+                    out.push(Token::new(TokenKind::MathOff { display }, start, off(i)));
+                } else {
+                    modes.push(Mode::Math { display });
+                    out.push(Token::new(TokenKind::MathOn { display }, start, off(i)));
+                }
+            }
+
+            // ---- single-character categories -----------------------------------
+            Catcode::AlignTab => {
+                i += 1;
+                out.push(Token::new(TokenKind::AlignTab, start, off(i)));
+            }
+            Catcode::Parameter => {
+                i += 1;
+                out.push(Token::new(TokenKind::Parameter, start, off(i)));
+            }
+            Catcode::Superscript => {
+                i += 1;
+                out.push(Token::new(TokenKind::Superscript, start, off(i)));
+            }
+            Catcode::Subscript => {
+                i += 1;
+                out.push(Token::new(TokenKind::Subscript, start, off(i)));
+            }
+            Catcode::Active => {
+                i += 1;
+                out.push(Token::new(TokenKind::Active(c), start, off(i)));
+            }
+
+            // ---- comment: `%` to end of line -----------------------------------
+            Catcode::Comment => {
+                i += 1; // past '%'
+                let text_start = i;
+                while i < n && chars[i].1 != '\n' && chars[i].1 != '\r' {
+                    i += 1;
+                }
+                let text: String = chars[text_start..i].iter().map(|&(_, ch)| ch).collect();
+                let comment_end = off(i);
+                // TeX eats the line ending after a comment (so no spurious space).
+                if i < n && chars[i].1 == '\r' {
+                    i += 1;
+                }
+                if i < n && chars[i].1 == '\n' {
+                    i += 1;
+                }
+                out.push(Token::new(TokenKind::Comment(text), start, comment_end));
+            }
+
+            // ---- whitespace: significant in text, ignored in math --------------
+            Catcode::Space | Catcode::EndLine => {
+                let run_start = i;
+                let mut newlines = 0usize;
+                while i < n && matches!(catcode(chars[i].1), Catcode::Space | Catcode::EndLine) {
+                    if chars[i].1 == '\n' {
+                        newlines += 1;
+                    }
+                    i += 1;
+                }
+                if matches!(modes.last(), Some(Mode::Math { .. })) {
+                    // insignificant in math mode — emit nothing
+                } else if newlines >= 2 {
+                    out.push(Token::new(TokenKind::Par, chars[run_start].0, off(i)));
+                } else {
+                    out.push(Token::new(TokenKind::Space, chars[run_start].0, off(i)));
+                }
+            }
+
+            // ---- ordinary characters (letters and others) ----------------------
+            Catcode::Letter | Catcode::Other => {
+                i += 1;
+                out.push(Token::new(TokenKind::Char(c), start, off(i)));
+            }
+        }
+    }
+
+    out.push(Token::new(TokenKind::Eof, end, end));
+    Ok(out)
+}
+
+/// Pop one `Math` mode if the top is math; never pop the bottom `Text` (a stray `\)`/`$`
+/// in text mode leaves the stack intact rather than underflowing).
+fn pop_math(modes: &mut Vec<Mode>) {
+    if matches!(modes.last(), Some(Mode::Math { .. })) {
+        modes.pop();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::token::TokenKind::*;
+
+    fn kinds(src: &str) -> Vec<TokenKind> {
+        let mut t: Vec<TokenKind> =
+            tokenize(src).expect("tokenize").into_iter().map(|t| t.kind).collect();
+        assert_eq!(t.pop(), Some(Eof), "stream must end in Eof");
+        t
+    }
+
+    #[test]
+    fn plain_text_is_chars_and_spaces() {
+        assert_eq!(
+            kinds("ab c"),
+            vec![Char('a'), Char('b'), Space, Char('c')]
+        );
+    }
+
+    #[test]
+    fn runs_of_space_collapse_to_one_space() {
+        assert_eq!(kinds("a   \t b"), vec![Char('a'), Space, Char('b')]);
+    }
+
+    #[test]
+    fn single_newline_is_a_space_two_is_a_paragraph() {
+        assert_eq!(kinds("a\nb"), vec![Char('a'), Space, Char('b')]);
+        assert_eq!(kinds("a\n\nb"), vec![Char('a'), Par, Char('b')]);
+        assert_eq!(kinds("a\n  \n  b"), vec![Char('a'), Par, Char('b')]); // blank line w/ spaces
+    }
+
+    #[test]
+    fn control_word_and_absorbed_spaces() {
+        // `\alpha  x` → ControlWord("alpha") then Char('x') (the spaces are absorbed).
+        assert_eq!(kinds(r"\alpha  x"), vec![ControlWord("alpha".into()), Char('x')]);
+    }
+
+    #[test]
+    fn control_word_stops_at_nonletter() {
+        assert_eq!(kinds(r"\section*"), vec![ControlWord("section".into()), Char('*')]);
+    }
+
+    #[test]
+    fn control_symbols_and_line_break() {
+        assert_eq!(kinds(r"\,"), vec![ControlSymbol(',')]);
+        assert_eq!(kinds(r"\{"), vec![ControlSymbol('{')]);
+        assert_eq!(kinds(r"\%"), vec![ControlSymbol('%')]);
+        assert_eq!(kinds(r"a \\ b"), vec![Char('a'), Space, ControlSymbol('\\'), Space, Char('b')]);
+    }
+
+    #[test]
+    fn groups_and_scripts_and_params() {
+        assert_eq!(
+            kinds("{a}^_#&"),
+            vec![BeginGroup, Char('a'), EndGroup, Superscript, Subscript, Parameter, AlignTab]
+        );
+    }
+
+    #[test]
+    fn dollar_toggles_inline_math() {
+        assert_eq!(
+            kinds("a$x$b"),
+            vec![Char('a'), MathOn { display: false }, Char('x'), MathOff { display: false }, Char('b')]
+        );
+    }
+
+    #[test]
+    fn double_dollar_is_display_math() {
+        assert_eq!(
+            kinds("$$x$$"),
+            vec![MathOn { display: true }, Char('x'), MathOff { display: true }]
+        );
+    }
+
+    #[test]
+    fn latex_delimiters_open_and_close_math() {
+        assert_eq!(
+            kinds(r"\(x\)"),
+            vec![MathOn { display: false }, Char('x'), MathOff { display: false }]
+        );
+        assert_eq!(
+            kinds(r"\[x\]"),
+            vec![MathOn { display: true }, Char('x'), MathOff { display: true }]
+        );
+    }
+
+    #[test]
+    fn whitespace_is_insignificant_inside_math() {
+        // spaces between `$ … $` emit no Space tokens.
+        assert_eq!(
+            kinds("$a   b$"),
+            vec![MathOn { display: false }, Char('a'), Char('b'), MathOff { display: false }]
+        );
+    }
+
+    #[test]
+    fn comment_runs_to_end_of_line_and_eats_the_newline() {
+        // `a% foo\nb` → Char(a), Comment(" foo"), Char(b) — no Space from the newline.
+        assert_eq!(
+            kinds("a% foo\nb"),
+            vec![Char('a'), Comment(" foo".into()), Char('b')]
+        );
+    }
+
+    #[test]
+    fn tilde_is_an_active_character() {
+        assert_eq!(kinds("a~b"), vec![Char('a'), Active('~'), Char('b')]);
+    }
+
+    #[test]
+    fn a_realistic_snippet() {
+        // "Let $x$ be." — text, inline math, text.
+        assert_eq!(
+            kinds(r"Let $x$ be."),
+            vec![
+                Char('L'), Char('e'), Char('t'), Space,
+                MathOn { display: false }, Char('x'), MathOff { display: false },
+                Space, Char('b'), Char('e'), Char('.'),
+            ]
+        );
+    }
+
+    #[test]
+    fn spans_are_correct_including_multibyte() {
+        let toks = tokenize("é$x$").unwrap();
+        // 'é' is 2 bytes (0..2); '$' at 2..3; 'x' at 3..4; '$' at 4..5; Eof at 5..5.
+        assert_eq!(toks[0].kind, TokenKind::Char('é'));
+        assert_eq!((toks[0].span.start, toks[0].span.end), (0, 2));
+        assert_eq!(toks[1].kind, TokenKind::MathOn { display: false });
+        assert_eq!((toks[1].span.start, toks[1].span.end), (2, 3));
+        assert_eq!(toks.last().unwrap().kind, TokenKind::Eof);
+    }
+
+    #[test]
+    fn trailing_backslash_errors_with_span() {
+        let e = tokenize(r"a \").unwrap_err();
+        assert!(e.message.contains("trailing '\\'"));
+        assert_eq!(e.span, (2, 3));
+    }
+
+    #[test]
+    fn stray_close_math_in_text_does_not_underflow() {
+        // `\)` with no open math: emits MathOff, stack stays sane, no panic.
+        assert_eq!(kinds(r"a\)b"), vec![Char('a'), MathOff { display: false }, Char('b')]);
+    }
+
+    #[test]
+    fn empty_input_is_just_eof() {
+        assert_eq!(tokenize("").unwrap().len(), 1);
+    }
+}

--- a/code/packages/rust/latex/src/lib.rs
+++ b/code/packages/rust/latex/src/lib.rs
@@ -1,0 +1,40 @@
+//! # latex — a full-fidelity LaTeX parser
+//!
+//! A standalone parser for LaTeX **documents and math** (not just a math subset). It turns
+//! LaTeX source into a faithful AST that any consumer can use — a reasoning engine, a
+//! computer-algebra system, a renderer. It is the first frontend of the pluggable
+//! [`math-frontend`](https://docs.rs/) framework (it will implement `MathFrontend` in a
+//! later layer) and is also useful on its own.
+//!
+//! ## Honest scope
+//!
+//! LaTeX rests on TeX, whose macro layer is Turing-complete. This crate parses the full
+//! LaTeX **surface** and supports the macro mechanisms authors actually use; the
+//! programmable TeX tail (runtime `\catcode` reassignment, `\expandafter`/`\csname`,
+//! `\if…` programming, external `\input`) is the documented asymptote and is surfaced as
+//! an explicit "unsupported" node rather than mis-parsed. See `code/specs/LTX01-full-latex-parser.md`.
+//!
+//! ## Layers (built incrementally)
+//!
+//! 1. [`tokenize`] — a catcode-driven, **text-mode-primary** state machine from source to
+//!    a flat [`Token`] stream. **Implemented (this release).**
+//! 2. `parse` / `parse_math` — the structural and math parsers. *(Later layers.)*
+//!
+//! ## Example
+//!
+//! ```
+//! use latex::{tokenize, TokenKind};
+//! let toks = tokenize(r"Let $x$ be.").unwrap();
+//! assert_eq!(toks[0].kind, TokenKind::Char('L'));
+//! assert!(toks.iter().any(|t| matches!(t.kind, TokenKind::MathOn { .. })));
+//! ```
+
+pub mod catcode;
+mod error;
+mod lexer;
+mod token;
+
+pub use catcode::{catcode, Catcode};
+pub use error::LexError;
+pub use lexer::tokenize;
+pub use token::{Span, Token, TokenKind};

--- a/code/packages/rust/latex/src/token.rs
+++ b/code/packages/rust/latex/src/token.rs
@@ -1,0 +1,82 @@
+//! Tokens — the alphabet the catcode [`crate::lexer`] emits.
+//!
+//! A LaTeX token is the smallest meaningful unit: a control sequence, a group brace, a
+//! math-mode shift, an ordinary character, a run of whitespace, a paragraph break, a
+//! comment. Unlike a programming-language lexer, the LaTeX tokenizer does **not** coalesce
+//! ordinary characters into words — in TeX each ordinary character is its own token, and
+//! grouping them into runs of text is the *parser's* job (the next layer). This keeps the
+//! tokenizer a faithful image of TeX's mouth.
+//!
+//! Every token records its half-open byte [`Span`].
+
+/// A half-open byte range `[start, end)` into the source. `&src[start..end]` is the slice.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Span {
+    pub start: usize,
+    pub end: usize,
+}
+
+impl Span {
+    pub fn new(start: usize, end: usize) -> Self {
+        Span { start, end }
+    }
+}
+
+/// One lexical token plus its source span.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Token {
+    pub kind: TokenKind,
+    pub span: Span,
+}
+
+impl Token {
+    pub fn new(kind: TokenKind, start: usize, end: usize) -> Self {
+        Token { kind, span: Span::new(start, end) }
+    }
+}
+
+/// The kinds of LaTeX token.
+///
+/// Math-mode shifts are emitted as paired [`TokenKind::MathOn`] / [`TokenKind::MathOff`]
+/// rather than a raw `$`, because the tokenizer tracks the math/text mode stack and so
+/// already knows whether a given `$` opens or closes — handing the parser an unambiguous
+/// on/off (with the inline-vs-display flag) instead of a toggle it would have to track.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TokenKind {
+    /// A control word: `\` followed by one or more letters — `\frac`, `\begin`, `\alpha`.
+    ControlWord(String),
+    /// A control symbol: `\` followed by a single non-letter — `\,`, `\{`, `\%`, and `\\`
+    /// (stored as the char `\\`, the line break).
+    ControlSymbol(char),
+    /// `{` — begin a group.
+    BeginGroup,
+    /// `}` — end a group.
+    EndGroup,
+    /// Enter math mode (`$`, `$$`, `\(`, `\[`). `display` distinguishes `$$`/`\[` (true)
+    /// from `$`/`\(` (false).
+    MathOn { display: bool },
+    /// Leave math mode (`$`, `$$`, `\)`, `\]`).
+    MathOff { display: bool },
+    /// `&` — alignment tab (table/matrix column separator).
+    AlignTab,
+    /// `#` — a macro parameter marker (the following digit, if any, is a separate `Char`;
+    /// the macro layer interprets the pairing).
+    Parameter,
+    /// `^` — superscript marker.
+    Superscript,
+    /// `_` — subscript marker.
+    Subscript,
+    /// An active character that behaves like a macro — `~` (a non-breaking space).
+    Active(char),
+    /// A run of inter-word whitespace, collapsed to one token (text mode only; in math
+    /// mode whitespace is insignificant and emits nothing).
+    Space,
+    /// A paragraph break — a blank line (two or more newlines) in text mode (`\par`).
+    Par,
+    /// An ordinary character (a letter or "other": digit, punctuation, …).
+    Char(char),
+    /// A comment from `%` to end of line (text kept, without the `%` or the newline).
+    Comment(String),
+    /// End of input — always the final token.
+    Eof,
+}


### PR DESCRIPTION
First rung of the full LaTeX parser ([`LTX01`](code/specs/LTX01-full-latex-parser.md)) — the `latex` crate, **L0: a catcode-driven, text-mode-primary tokenizer**. This is the first frontend of the [`math-frontend`](code/specs/PFE01-pluggable-parser-frontends.md) framework (it will implement `MathFrontend` at L6).

**Full LaTeX, not a math subset** — and text-mode-primary (LaTeX starts in text; math is *entered*), the inverse of the parked math-only experiment.

### What's here (zero-dependency crate `latex`)
- **`catcode(c)`** — TeX category codes (default plain-LaTeX): Escape/BeginGroup/EndGroup/MathShift/AlignTab/EndLine/Parameter/Superscript/Subscript/Space/Letter/Other/Active/Comment. The classification that *drives* the scanner, as TeX's mouth is catcode-driven.
- **`tokenize()`** — the state machine:
  - **mode stack** Text↔Math (pushed by `$`/`\(`/`\[`, display via `$$`/`\[`, popped by the matching close); whitespace significant in text, ignored in math;
  - control **words** (`\`+letters, with TeX space-absorption) and **symbols** (`\`+non-letter, incl. `\\`, `\{`, `\,`);
  - groups, `MathOn`/`MathOff` (inline/display flag), `&`, `#`, `^`, `_`, active `~`, `%` comments (eating the newline);
  - whitespace → one `Space`; blank line (≥2 newlines) → `Par`; ordinary chars one-per-`Char` (faithful to TeX; the parser coalesces).
- Byte **spans** on every token; spanned `LexError`; **never panics** (trailing `\` → error; stray `\)`/`$` in text doesn't underflow the stack).

### Verification
`cargo test -p latex` → 20 unit + 1 doc test; `cargo clippy -p latex -- -D warnings` clean; **no `unsafe`**. Security review passed (pure iterative scan, all `chars` accesses bounds-guarded, `usize` counters bounded by input, no recursion).

Next: **L1** structural parser (groups, `\cmd[opt]{arg}`, `\begin{env}…\end{env}`), then L2 math → L3 environments → L4 macros → L5 text breadth → L6 frontend adapter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)