### PR TITLE
[codex] Expose output directive line artifacts

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Added
 
+- **Deck output-plan directive line artifacts** —
+  selected `run_deck_analysis()` output-plan artifacts now expose selected
+  output directive source line counts/lists beside directive scope inventories
+  in table, CSV, compact JSON, and header-keyed record exports, matching Rust
+  and TypeScript.
+
 - **Deck output-plan directive analysis-kind artifacts** —
   selected `run_deck_analysis()` output-plan artifacts now expose normalized
   output directive analysis scope counts/lists beside directive kind

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -114,9 +114,9 @@ executions. Execution `table_artifacts` preserve the same order as `tables` and
 carry each stable table's text, CSV, compact JSON, and header-keyed records.
 Execution `output_plan_artifacts` summarize the selected result columns,
 output probes, output directives, normalized output directive kinds, normalized
-directive analysis scopes, and stable table names, and the `output-plan` entry
-in `table_artifacts` carries the same table, CSV, compact JSON, and
-header-keyed record exports.
+directive analysis scopes, selected output directive source lines, and stable
+table names, and the `output-plan` entry in `table_artifacts` carries the same
+table, CSV, compact JSON, and header-keyed record exports.
 Selected `.tran` plans also return selected `.four` harmonic results and a stable
 Fourier table. Executions also include a selected-run artifact summary plus
 `format_deck_run_artifact_table()` and `format_deck_run_artifact_csv()` output

--- a/code/packages/python/spice-engine/src/spice_engine/__init__.py
+++ b/code/packages/python/spice-engine/src/spice_engine/__init__.py
@@ -46,6 +46,7 @@ from spice_engine.compatibility import (
     resolve_deck_sources,
     select_deck_analysis_plan,
     select_deck_output_directive_analysis_kinds,
+    select_deck_output_directive_lines,
     select_deck_output_directives,
     select_deck_output_probes,
 )
@@ -645,6 +646,7 @@ __all__ = [
     "run_deck_analysis",
     "select_deck_analysis_plan",
     "select_deck_output_directive_analysis_kinds",
+    "select_deck_output_directive_lines",
     "select_deck_output_directives",
     "select_deck_output_probes",
     "sens_dc",

--- a/code/packages/python/spice-engine/src/spice_engine/compatibility.py
+++ b/code/packages/python/spice-engine/src/spice_engine/compatibility.py
@@ -1024,6 +1024,31 @@ def select_deck_output_directive_analysis_kinds(
     return selected
 
 
+def select_deck_output_directive_lines(netlist: str, analysis: str) -> list[int]:
+    """Return deduplicated output directive source lines selected for an analysis."""
+
+    summary = resolve_deck_outputs(netlist)
+    if summary.diagnostics:
+        diagnostic = summary.diagnostics[0]
+        raise ValueError(
+            "select_deck_output_directive_lines: "
+            f"line {diagnostic.line_number}: {diagnostic.message}"
+        )
+    selected: list[int] = []
+    seen: set[int] = set()
+    for selection in summary.selections:
+        if selection.analysis is not None and not _deck_output_analysis_matches(
+            selection.analysis,
+            analysis,
+        ):
+            continue
+        if selection.line_number in seen:
+            continue
+        seen.add(selection.line_number)
+        selected.append(selection.line_number)
+    return selected
+
+
 def resolve_deck_analyses(netlist: str) -> DeckAnalysisSummary:
     """Extract supported top-level analysis directives before ``.end``."""
 

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -77,6 +77,7 @@ from spice_engine.compatibility import (
     resolve_deck_measurements,
     select_deck_analysis_plan,
     select_deck_output_directive_analysis_kinds,
+    select_deck_output_directive_lines,
     select_deck_output_directives,
     select_deck_output_probes,
 )
@@ -2393,6 +2394,8 @@ class DeckOutputPlanArtifact:
     output_directive_kinds: list[str]
     output_directive_analysis_kind_count: int
     output_directive_analysis_kinds: list[str]
+    output_directive_line_count: int
+    output_directive_lines: list[int]
     table_count: int
     tables: list[str]
 
@@ -2896,6 +2899,7 @@ def _deck_output_plan_artifacts(
     output_probes: list[str],
     output_directives: list[str],
     output_directive_analysis_kinds: list[str],
+    output_directive_lines: list[int],
     tables: list[str],
 ) -> list[DeckOutputPlanArtifact]:
     output_directive_kinds = _deck_output_directive_kinds(output_directives)
@@ -2915,6 +2919,8 @@ def _deck_output_plan_artifacts(
                 output_directive_analysis_kinds
             ),
             output_directive_analysis_kinds=list(output_directive_analysis_kinds),
+            output_directive_line_count=len(output_directive_lines),
+            output_directive_lines=list(output_directive_lines),
             table_count=len(tables),
             tables=list(tables),
         )
@@ -2934,6 +2940,8 @@ _DECK_OUTPUT_PLAN_ARTIFACT_COLUMNS = [
     "OutputDirectiveKindList",
     "OutputDirectiveAnalysisKinds",
     "OutputDirectiveAnalysisKindList",
+    "OutputDirectiveLines",
+    "OutputDirectiveLineList",
     "Tables",
     "TableList",
 ]
@@ -2953,6 +2961,8 @@ def _deck_output_plan_artifact_cells(artifact: DeckOutputPlanArtifact) -> list[s
         ";".join(artifact.output_directive_kinds),
         str(artifact.output_directive_analysis_kind_count),
         ";".join(artifact.output_directive_analysis_kinds),
+        str(artifact.output_directive_line_count),
+        ";".join(str(line) for line in artifact.output_directive_lines),
         str(artifact.table_count),
         ";".join(artifact.tables),
     ]
@@ -3019,6 +3029,7 @@ def _deck_output_plan_artifact_bundle(
     output_probes: list[str],
     output_directives: list[str],
     output_directive_analysis_kinds: list[str],
+    output_directive_lines: list[int],
     tables: list[str],
 ) -> tuple[list[DeckOutputPlanArtifact], str, str, str, list[dict[str, str]]]:
     artifacts = _deck_output_plan_artifacts(
@@ -3027,6 +3038,7 @@ def _deck_output_plan_artifact_bundle(
         output_probes,
         output_directives,
         output_directive_analysis_kinds,
+        output_directive_lines,
         tables,
     )
     return (
@@ -3218,6 +3230,7 @@ def _deck_table_artifacts(
     output_probes: list[str],
     output_directives: list[str],
     output_directive_analysis_kinds: list[str],
+    output_directive_lines: list[int],
     tables: list[str],
 ) -> list[DeckTableArtifact]:
     artifacts = [_deck_table_artifact("result", result_table)]
@@ -3242,6 +3255,7 @@ def _deck_table_artifacts(
         output_probes,
         output_directives,
         output_directive_analysis_kinds,
+        output_directive_lines,
         tables,
     )[1]
     artifacts.append(_deck_table_artifact("output-plan", output_plan_artifact_table))
@@ -3937,6 +3951,10 @@ def run_deck_analysis(
             netlist,
             plan.analysis,
         )
+        output_directive_lines = select_deck_output_directive_lines(
+            netlist,
+            plan.analysis,
+        )
         run_artifacts = _deck_run_artifacts(
             plan,
             result,
@@ -3974,6 +3992,7 @@ def run_deck_analysis(
             output_probes,
             output_directives,
             output_directive_analysis_kinds,
+            output_directive_lines,
             tables,
         )
         (
@@ -3988,6 +4007,7 @@ def run_deck_analysis(
             output_probes,
             output_directives,
             output_directive_analysis_kinds,
+            output_directive_lines,
             tables,
         )
         return DeckAnalysisExecution(
@@ -4041,6 +4061,10 @@ def run_deck_analysis(
             netlist,
             plan.analysis,
         )
+        output_directive_lines = select_deck_output_directive_lines(
+            netlist,
+            plan.analysis,
+        )
         run_artifacts = _deck_run_artifacts(
             plan,
             result,
@@ -4078,6 +4102,7 @@ def run_deck_analysis(
             output_probes,
             output_directives,
             output_directive_analysis_kinds,
+            output_directive_lines,
             tables,
         )
         (
@@ -4092,6 +4117,7 @@ def run_deck_analysis(
             output_probes,
             output_directives,
             output_directive_analysis_kinds,
+            output_directive_lines,
             tables,
         )
         return DeckAnalysisExecution(
@@ -4147,6 +4173,10 @@ def run_deck_analysis(
             netlist,
             plan.analysis,
         )
+        output_directive_lines = select_deck_output_directive_lines(
+            netlist,
+            plan.analysis,
+        )
         run_artifacts = _deck_run_artifacts(
             plan,
             result,
@@ -4184,6 +4214,7 @@ def run_deck_analysis(
             output_probes,
             output_directives,
             output_directive_analysis_kinds,
+            output_directive_lines,
             tables,
         )
         (
@@ -4198,6 +4229,7 @@ def run_deck_analysis(
             output_probes,
             output_directives,
             output_directive_analysis_kinds,
+            output_directive_lines,
             tables,
         )
         return DeckAnalysisExecution(
@@ -4259,6 +4291,10 @@ def run_deck_analysis(
             netlist,
             plan.analysis,
         )
+        output_directive_lines = select_deck_output_directive_lines(
+            netlist,
+            plan.analysis,
+        )
         run_artifacts = _deck_run_artifacts(
             plan,
             result,
@@ -4296,6 +4332,7 @@ def run_deck_analysis(
             output_probes,
             output_directives,
             output_directive_analysis_kinds,
+            output_directive_lines,
             tables,
         )
         (
@@ -4310,6 +4347,7 @@ def run_deck_analysis(
             output_probes,
             output_directives,
             output_directive_analysis_kinds,
+            output_directive_lines,
             tables,
         )
         return DeckAnalysisExecution(
@@ -4355,6 +4393,7 @@ def run_deck_analysis(
         output_probes = [f"V({output_node})"]
         output_directives: list[str] = []
         output_directive_analysis_kinds: list[str] = []
+        output_directive_lines: list[int] = []
         table = format_deck_tf_table(result)
         run_artifacts = _deck_run_artifacts(
             plan,
@@ -4393,6 +4432,7 @@ def run_deck_analysis(
             output_probes,
             output_directives,
             output_directive_analysis_kinds,
+            output_directive_lines,
             tables,
         )
         (
@@ -4407,6 +4447,7 @@ def run_deck_analysis(
             output_probes,
             output_directives,
             output_directive_analysis_kinds,
+            output_directive_lines,
             tables,
         )
         return DeckAnalysisExecution(
@@ -4451,6 +4492,7 @@ def run_deck_analysis(
         output_probes = [f"V({output_node})"]
         output_directives = []
         output_directive_analysis_kinds: list[str] = []
+        output_directive_lines: list[int] = []
         table = format_deck_sens_table(result)
         run_artifacts = _deck_run_artifacts(
             plan,
@@ -4489,6 +4531,7 @@ def run_deck_analysis(
             output_probes,
             output_directives,
             output_directive_analysis_kinds,
+            output_directive_lines,
             tables,
         )
         (
@@ -4503,6 +4546,7 @@ def run_deck_analysis(
             output_probes,
             output_directives,
             output_directive_analysis_kinds,
+            output_directive_lines,
             tables,
         )
         return DeckAnalysisExecution(
@@ -4566,6 +4610,7 @@ def run_deck_analysis(
         output_probes = [f"V({output_node})"]
         output_directives = []
         output_directive_analysis_kinds: list[str] = []
+        output_directive_lines: list[int] = []
         table = format_deck_noise_table(result)
         run_artifacts = _deck_run_artifacts(
             plan,
@@ -4604,6 +4649,7 @@ def run_deck_analysis(
             output_probes,
             output_directives,
             output_directive_analysis_kinds,
+            output_directive_lines,
             tables,
         )
         (
@@ -4618,6 +4664,7 @@ def run_deck_analysis(
             output_probes,
             output_directives,
             output_directive_analysis_kinds,
+            output_directive_lines,
             tables,
         )
         return DeckAnalysisExecution(

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -6838,6 +6838,27 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
 .measure tran mid_final final V(mid)
 .end
 """
+    netlist_lines = netlist.splitlines()
+    save_line = next(
+        index
+        for index, line in enumerate(netlist_lines, start=1)
+        if line.strip().startswith(".save")
+    )
+    probe_dc_line = next(
+        index
+        for index, line in enumerate(netlist_lines, start=1)
+        if line.strip().startswith(".probe dc")
+    )
+    print_dc_line = next(
+        index
+        for index, line in enumerate(netlist_lines, start=1)
+        if line.strip().startswith(".print dc")
+    )
+    plot_ac_line = next(
+        index
+        for index, line in enumerate(netlist_lines, start=1)
+        if line.strip().startswith(".plot ac")
+    )
 
     op_execution = run_deck_analysis(circuit, netlist, "op")
     assert op_execution.plan.analysis == "op"
@@ -6874,9 +6895,10 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
         "OutputProbeList\tOutputDirectives\tOutputDirectiveList\t"
         "OutputDirectiveKinds\tOutputDirectiveKindList\t"
         "OutputDirectiveAnalysisKinds\tOutputDirectiveAnalysisKindList\t"
+        "OutputDirectiveLines\tOutputDirectiveLineList\t"
         "Tables\tTableList\n"
         "op\t.op\t2\tIndex;V(mid)\t1\tV(mid)\t1\t.save\t1\tsave\t"
-        "1\tglobal\t3\t"
+        f"1\tglobal\t1\t{save_line}\t3\t"
         "result;output-plan;run-artifact\n"
     )
     expected_output_plan_records = [
@@ -6893,6 +6915,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
             "OutputDirectiveKindList": "save",
             "OutputDirectiveAnalysisKinds": "1",
             "OutputDirectiveAnalysisKindList": "global",
+            "OutputDirectiveLines": "1",
+            "OutputDirectiveLineList": str(save_line),
             "Tables": "3",
             "TableList": "result;output-plan;run-artifact",
         }
@@ -6909,6 +6933,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert output_plan_artifact.output_directive_kinds == ["save"]
     assert output_plan_artifact.output_directive_analysis_kind_count == 1
     assert output_plan_artifact.output_directive_analysis_kinds == ["global"]
+    assert output_plan_artifact.output_directive_line_count == 1
+    assert output_plan_artifact.output_directive_lines == [save_line]
     assert output_plan_artifact.tables == ["result", "output-plan", "run-artifact"]
     assert op_execution.output_plan_artifact_table == expected_output_plan_table
     assert op_execution.output_plan_artifact_table == (
@@ -6919,8 +6945,9 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
         "OutputProbeList,OutputDirectives,OutputDirectiveList,"
         "OutputDirectiveKinds,OutputDirectiveKindList,"
         "OutputDirectiveAnalysisKinds,OutputDirectiveAnalysisKindList,"
+        "OutputDirectiveLines,OutputDirectiveLineList,"
         "Tables,TableList\n"
-        "op,.op,2,Index;V(mid),1,V(mid),1,.save,1,save,1,global,3,"
+        f"op,.op,2,Index;V(mid),1,V(mid),1,.save,1,save,1,global,1,{save_line},3,"
         "result;output-plan;run-artifact\n"
     )
     assert op_execution.output_plan_artifact_csv == (
@@ -7133,9 +7160,17 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
         "global",
         "dc",
     ]
+    dc_output_directive_lines = [save_line, probe_dc_line, print_dc_line]
+    assert (
+        dc_execution.output_plan_artifacts[0].output_directive_lines
+        == dc_output_directive_lines
+    )
     assert dc_execution.output_plan_artifact_records[0][
         "OutputDirectiveAnalysisKindList"
     ] == "global;dc"
+    assert dc_execution.output_plan_artifact_records[0][
+        "OutputDirectiveLineList"
+    ] == ";".join(str(line) for line in dc_output_directive_lines)
     assert dc_execution.analysis_directives == [".dc"]
     assert dc_execution.table_count == 4
     assert dc_execution.tables == ["result", "measurement", "output-plan", "run-artifact"]
@@ -7215,9 +7250,17 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
         "global",
         "ac",
     ]
+    ac_output_directive_lines = [save_line, plot_ac_line]
+    assert (
+        ac_execution.output_plan_artifacts[0].output_directive_lines
+        == ac_output_directive_lines
+    )
     assert ac_execution.output_plan_artifact_records[0][
         "OutputDirectiveAnalysisKindList"
     ] == "global;ac"
+    assert ac_execution.output_plan_artifact_records[0][
+        "OutputDirectiveLineList"
+    ] == ";".join(str(line) for line in ac_output_directive_lines)
     assert ac_execution.analysis_directives == [".ac"]
     assert ac_execution.table_count == 4
     assert ac_execution.tables == ["result", "measurement", "output-plan", "run-artifact"]
@@ -7269,6 +7312,9 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     tran_execution = run_deck_analysis(circuit, netlist, "tran")
     assert tran_execution.output_probes == ["V(mid)"]
     assert tran_execution.output_directives == [".save"]
+    assert tran_execution.output_plan_artifacts[0].output_directive_lines == [
+        save_line
+    ]
     assert tran_execution.analysis_directives == [".tran"]
     assert tran_execution.table_count == 4
     assert tran_execution.tables == ["result", "measurement", "output-plan", "run-artifact"]

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Expose selected output directive source line inventories in
+  `run_deck_analysis` output-plan artifacts beside directive scope
+  inventories, with stable table, CSV, compact JSON, and header-keyed record
+  exports, matching Python and TypeScript.
 - Expose normalized selected output directive analysis scope inventories in
   `run_deck_analysis` output-plan artifacts beside directive kind inventories,
   distinguishing global `.save` / `.probe` selections from scoped `.probe`,

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -183,9 +183,9 @@ Execution `table_artifacts` preserve the same order as `tables` and carry each
 stable table's text, CSV, compact JSON, and header-keyed records.
 Execution `output_plan_artifacts` summarize the selected result columns,
 output probes, output directives, normalized output directive kinds, normalized
-directive analysis scopes, and stable table names, and the `output-plan` entry
-in `table_artifacts` carries the same table, CSV, compact JSON, and
-header-keyed record exports.
+directive analysis scopes, selected output directive source lines, and stable
+table names, and the `output-plan` entry in `table_artifacts` carries the same
+table, CSV, compact JSON, and header-keyed record exports.
 Selected `.tran` plans route
 `START` output filtering, `.tran TSTEP` as the output print grid, `MAXSTEP` as
 an internal fixed-step cap, and `UIC` initial-condition intent through that

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -3476,6 +3476,8 @@ pub struct DeckOutputPlanArtifact {
     pub output_directive_kinds: Vec<String>,
     pub output_directive_analysis_kind_count: usize,
     pub output_directive_analysis_kinds: Vec<String>,
+    pub output_directive_line_count: usize,
+    pub output_directive_lines: Vec<usize>,
     pub table_count: usize,
     pub tables: Vec<String>,
 }
@@ -4156,6 +4158,32 @@ pub fn select_deck_output_directive_analysis_kinds(
         let analysis_kind = selection.analysis.unwrap_or_else(|| "global".to_string());
         if seen.insert(analysis_kind.clone()) {
             selected.push(analysis_kind);
+        }
+    }
+    Ok(selected)
+}
+
+pub fn select_deck_output_directive_lines(
+    netlist: &str,
+    analysis: &str,
+) -> Result<Vec<usize>, SpiceError> {
+    let summary = resolve_deck_outputs(netlist);
+    if let Some(diagnostic) = summary.diagnostics.first() {
+        return Err(table_error(
+            "select_deck_output_directive_lines",
+            &format!("line {}: {}", diagnostic.line_number, diagnostic.message),
+        ));
+    }
+    let mut selected = Vec::new();
+    let mut seen = HashSet::new();
+    for selection in summary.selections {
+        if !selection.analysis.as_deref().map_or(true, |requested| {
+            deck_output_analysis_matches(requested, analysis)
+        }) {
+            continue;
+        }
+        if seen.insert(selection.line_number) {
+            selected.push(selection.line_number);
         }
     }
     Ok(selected)
@@ -10403,6 +10431,7 @@ fn deck_output_plan_artifacts(
     output_probes: &[String],
     output_directives: &[String],
     output_directive_analysis_kinds: &[String],
+    output_directive_lines: &[usize],
     tables: &[String],
 ) -> Vec<DeckOutputPlanArtifact> {
     let output_directive_kinds = deck_output_directive_kinds(output_directives);
@@ -10419,6 +10448,8 @@ fn deck_output_plan_artifacts(
         output_directive_kinds,
         output_directive_analysis_kind_count: output_directive_analysis_kinds.len(),
         output_directive_analysis_kinds: output_directive_analysis_kinds.to_vec(),
+        output_directive_line_count: output_directive_lines.len(),
+        output_directive_lines: output_directive_lines.to_vec(),
         table_count: tables.len(),
         tables: tables.to_vec(),
     }]
@@ -10460,6 +10491,8 @@ const DECK_OUTPUT_PLAN_ARTIFACT_COLUMNS: &[&str] = &[
     "OutputDirectiveKindList",
     "OutputDirectiveAnalysisKinds",
     "OutputDirectiveAnalysisKindList",
+    "OutputDirectiveLines",
+    "OutputDirectiveLineList",
     "Tables",
     "TableList",
 ];
@@ -10478,6 +10511,13 @@ fn deck_output_plan_artifact_cells(artifact: &DeckOutputPlanArtifact) -> Vec<Str
         artifact.output_directive_kinds.join(";"),
         artifact.output_directive_analysis_kind_count.to_string(),
         artifact.output_directive_analysis_kinds.join(";"),
+        artifact.output_directive_line_count.to_string(),
+        artifact
+            .output_directive_lines
+            .iter()
+            .map(usize::to_string)
+            .collect::<Vec<_>>()
+            .join(";"),
         artifact.table_count.to_string(),
         artifact.tables.join(";"),
     ]
@@ -10549,6 +10589,7 @@ fn deck_output_plan_artifact_bundle(
     output_probes: &[String],
     output_directives: &[String],
     output_directive_analysis_kinds: &[String],
+    output_directive_lines: &[usize],
     tables: &[String],
 ) -> (
     Vec<DeckOutputPlanArtifact>,
@@ -10563,6 +10604,7 @@ fn deck_output_plan_artifact_bundle(
         output_probes,
         output_directives,
         output_directive_analysis_kinds,
+        output_directive_lines,
         tables,
     );
     let table = format_deck_output_plan_artifact_table(&artifacts);
@@ -10848,6 +10890,7 @@ fn deck_table_artifacts(
     output_probes: &[String],
     output_directives: &[String],
     output_directive_analysis_kinds: &[String],
+    output_directive_lines: &[usize],
     tables: &[String],
 ) -> Vec<DeckTableArtifact> {
     let mut artifacts = vec![deck_table_artifact("result", result_table)];
@@ -10881,6 +10924,7 @@ fn deck_table_artifacts(
         output_probes,
         output_directives,
         output_directive_analysis_kinds,
+        output_directive_lines,
         tables,
     );
     artifacts.push(DeckTableArtifact {
@@ -11759,6 +11803,7 @@ pub fn run_deck_analysis(
             let output_directives = select_deck_output_directives(netlist, "op")?;
             let output_directive_analysis_kinds =
                 select_deck_output_directive_analysis_kinds(netlist, "op")?;
+            let output_directive_lines = select_deck_output_directive_lines(netlist, "op")?;
             let run_artifacts = deck_run_artifacts(
                 &plan,
                 1,
@@ -11790,6 +11835,7 @@ pub fn run_deck_analysis(
                 &output_probes,
                 &output_directives,
                 &output_directive_analysis_kinds,
+                &output_directive_lines,
                 &tables,
             );
             let rawfile_artifacts =
@@ -11815,6 +11861,7 @@ pub fn run_deck_analysis(
                 &output_probes,
                 &output_directives,
                 &output_directive_analysis_kinds,
+                &output_directive_lines,
                 &tables,
             );
             Ok(DeckAnalysisExecution {
@@ -11900,6 +11947,7 @@ pub fn run_deck_analysis(
             let output_directives = select_deck_output_directives(netlist, "dc")?;
             let output_directive_analysis_kinds =
                 select_deck_output_directive_analysis_kinds(netlist, "dc")?;
+            let output_directive_lines = select_deck_output_directive_lines(netlist, "dc")?;
             let run_artifacts = deck_run_artifacts(
                 &plan,
                 result.len(),
@@ -11931,6 +11979,7 @@ pub fn run_deck_analysis(
                 &output_probes,
                 &output_directives,
                 &output_directive_analysis_kinds,
+                &output_directive_lines,
                 &tables,
             );
             let rawfile_artifacts =
@@ -11956,6 +12005,7 @@ pub fn run_deck_analysis(
                 &output_probes,
                 &output_directives,
                 &output_directive_analysis_kinds,
+                &output_directive_lines,
                 &tables,
             );
             Ok(DeckAnalysisExecution {
@@ -12042,6 +12092,7 @@ pub fn run_deck_analysis(
             let output_directives = select_deck_output_directives(netlist, "ac")?;
             let output_directive_analysis_kinds =
                 select_deck_output_directive_analysis_kinds(netlist, "ac")?;
+            let output_directive_lines = select_deck_output_directive_lines(netlist, "ac")?;
             let run_artifacts = deck_run_artifacts(
                 &plan,
                 result.len(),
@@ -12073,6 +12124,7 @@ pub fn run_deck_analysis(
                 &output_probes,
                 &output_directives,
                 &output_directive_analysis_kinds,
+                &output_directive_lines,
                 &tables,
             );
             let rawfile_artifacts =
@@ -12098,6 +12150,7 @@ pub fn run_deck_analysis(
                 &output_probes,
                 &output_directives,
                 &output_directive_analysis_kinds,
+                &output_directive_lines,
                 &tables,
             );
             Ok(DeckAnalysisExecution {
@@ -12187,6 +12240,7 @@ pub fn run_deck_analysis(
             let output_directives = select_deck_output_directives(netlist, "tran")?;
             let output_directive_analysis_kinds =
                 select_deck_output_directive_analysis_kinds(netlist, "tran")?;
+            let output_directive_lines = select_deck_output_directive_lines(netlist, "tran")?;
             let run_artifacts = deck_run_artifacts(
                 &plan,
                 result.len(),
@@ -12218,6 +12272,7 @@ pub fn run_deck_analysis(
                 &output_probes,
                 &output_directives,
                 &output_directive_analysis_kinds,
+                &output_directive_lines,
                 &tables,
             );
             let rawfile_artifacts =
@@ -12243,6 +12298,7 @@ pub fn run_deck_analysis(
                 &output_probes,
                 &output_directives,
                 &output_directive_analysis_kinds,
+                &output_directive_lines,
                 &tables,
             );
             Ok(DeckAnalysisExecution {
@@ -12324,6 +12380,7 @@ pub fn run_deck_analysis(
             let output_probes = vec![format!("V({output_node})")];
             let output_directives = Vec::new();
             let output_directive_analysis_kinds = Vec::new();
+            let output_directive_lines = Vec::new();
             let table = format_deck_tf_table(&result);
             let run_artifacts = deck_run_artifacts(
                 &plan,
@@ -12356,6 +12413,7 @@ pub fn run_deck_analysis(
                 &output_probes,
                 &output_directives,
                 &output_directive_analysis_kinds,
+                &output_directive_lines,
                 &tables,
             );
             let rawfile_artifacts =
@@ -12381,6 +12439,7 @@ pub fn run_deck_analysis(
                 &output_probes,
                 &output_directives,
                 &output_directive_analysis_kinds,
+                &output_directive_lines,
                 &tables,
             );
             Ok(DeckAnalysisExecution {
@@ -12460,6 +12519,7 @@ pub fn run_deck_analysis(
             let output_probes = vec![format!("V({output_node})")];
             let output_directives = Vec::new();
             let output_directive_analysis_kinds = Vec::new();
+            let output_directive_lines = Vec::new();
             let table = format_deck_sens_table(&result);
             let run_artifacts = deck_run_artifacts(
                 &plan,
@@ -12492,6 +12552,7 @@ pub fn run_deck_analysis(
                 &output_probes,
                 &output_directives,
                 &output_directive_analysis_kinds,
+                &output_directive_lines,
                 &tables,
             );
             let rawfile_artifacts =
@@ -12517,6 +12578,7 @@ pub fn run_deck_analysis(
                 &output_probes,
                 &output_directives,
                 &output_directive_analysis_kinds,
+                &output_directive_lines,
                 &tables,
             );
             Ok(DeckAnalysisExecution {
@@ -12608,6 +12670,7 @@ pub fn run_deck_analysis(
             let output_probes = vec![format!("V({output_node})")];
             let output_directives = Vec::new();
             let output_directive_analysis_kinds = Vec::new();
+            let output_directive_lines = Vec::new();
             let table = format_deck_noise_table(&result);
             let run_artifacts = deck_run_artifacts(
                 &plan,
@@ -12640,6 +12703,7 @@ pub fn run_deck_analysis(
                 &output_probes,
                 &output_directives,
                 &output_directive_analysis_kinds,
+                &output_directive_lines,
                 &tables,
             );
             let rawfile_artifacts =
@@ -12665,6 +12729,7 @@ pub fn run_deck_analysis(
                 &output_probes,
                 &output_directives,
                 &output_directive_analysis_kinds,
+                &output_directive_lines,
                 &tables,
             );
             Ok(DeckAnalysisExecution {

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -1913,6 +1913,26 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
 .measure tran mid_final final V(mid)
 .end
 ";
+    let save_line = netlist
+        .lines()
+        .position(|line| line.trim_start().starts_with(".save"))
+        .unwrap()
+        + 1;
+    let probe_dc_line = netlist
+        .lines()
+        .position(|line| line.trim_start().starts_with(".probe dc"))
+        .unwrap()
+        + 1;
+    let print_dc_line = netlist
+        .lines()
+        .position(|line| line.trim_start().starts_with(".print dc"))
+        .unwrap()
+        + 1;
+    let plot_ac_line = netlist
+        .lines()
+        .position(|line| line.trim_start().starts_with(".plot ac"))
+        .unwrap()
+        + 1;
 
     let op_execution = run_deck_analysis(&circuit, netlist, Some("op")).unwrap();
     assert_eq!(op_execution.plan.analysis, "op");
@@ -1993,6 +2013,8 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
         output_plan_artifact.output_directive_analysis_kinds,
         vec!["global".to_string()]
     );
+    assert_eq!(output_plan_artifact.output_directive_line_count, 1);
+    assert_eq!(output_plan_artifact.output_directive_lines, vec![save_line]);
     assert_eq!(
         output_plan_artifact.tables,
         vec![
@@ -2003,7 +2025,10 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     );
     assert_eq!(
         op_execution.output_plan_artifact_table,
-        "Analysis\tDirective\tResultColumns\tResultColumnList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tOutputDirectiveKinds\tOutputDirectiveKindList\tOutputDirectiveAnalysisKinds\tOutputDirectiveAnalysisKindList\tTables\tTableList\nop\t.op\t2\tIndex;V(mid)\t1\tV(mid)\t1\t.save\t1\tsave\t1\tglobal\t3\tresult;output-plan;run-artifact\n"
+        format!(
+            "Analysis\tDirective\tResultColumns\tResultColumnList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tOutputDirectiveKinds\tOutputDirectiveKindList\tOutputDirectiveAnalysisKinds\tOutputDirectiveAnalysisKindList\tOutputDirectiveLines\tOutputDirectiveLineList\tTables\tTableList\nop\t.op\t2\tIndex;V(mid)\t1\tV(mid)\t1\t.save\t1\tsave\t1\tglobal\t1\t{}\t3\tresult;output-plan;run-artifact\n",
+            save_line
+        )
     );
     assert_eq!(
         op_execution.output_plan_artifact_table,
@@ -2011,7 +2036,10 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     );
     assert_eq!(
         op_execution.output_plan_artifact_csv,
-        "Analysis,Directive,ResultColumns,ResultColumnList,OutputProbes,OutputProbeList,OutputDirectives,OutputDirectiveList,OutputDirectiveKinds,OutputDirectiveKindList,OutputDirectiveAnalysisKinds,OutputDirectiveAnalysisKindList,Tables,TableList\nop,.op,2,Index;V(mid),1,V(mid),1,.save,1,save,1,global,3,result;output-plan;run-artifact\n"
+        format!(
+            "Analysis,Directive,ResultColumns,ResultColumnList,OutputProbes,OutputProbeList,OutputDirectives,OutputDirectiveList,OutputDirectiveKinds,OutputDirectiveKindList,OutputDirectiveAnalysisKinds,OutputDirectiveAnalysisKindList,OutputDirectiveLines,OutputDirectiveLineList,Tables,TableList\nop,.op,2,Index;V(mid),1,V(mid),1,.save,1,save,1,global,1,{},3,result;output-plan;run-artifact\n",
+            save_line
+        )
     );
     assert_eq!(
         op_execution.output_plan_artifact_csv,
@@ -2036,6 +2064,13 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
             .get("OutputDirectiveAnalysisKindList")
             .map(String::as_str),
         Some("global")
+    );
+    let save_line_list = save_line.to_string();
+    assert_eq!(
+        op_execution.output_plan_artifact_records[0]
+            .get("OutputDirectiveLineList")
+            .map(String::as_str),
+        Some(save_line_list.as_str())
     );
     assert_eq!(
         op_execution.output_plan_artifact_records[0]
@@ -2259,11 +2294,27 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
         dc_execution.output_plan_artifacts[0].output_directive_analysis_kinds,
         vec!["global".to_string(), "dc".to_string()]
     );
+    let dc_output_directive_lines = vec![save_line, probe_dc_line, print_dc_line];
+    assert_eq!(
+        dc_execution.output_plan_artifacts[0].output_directive_lines,
+        dc_output_directive_lines
+    );
+    let dc_output_directive_line_list = dc_output_directive_lines
+        .iter()
+        .map(usize::to_string)
+        .collect::<Vec<_>>()
+        .join(";");
     assert_eq!(
         dc_execution.output_plan_artifact_records[0]
             .get("OutputDirectiveAnalysisKindList")
             .map(String::as_str),
         Some("global;dc")
+    );
+    assert_eq!(
+        dc_execution.output_plan_artifact_records[0]
+            .get("OutputDirectiveLineList")
+            .map(String::as_str),
+        Some(dc_output_directive_line_list.as_str())
     );
     assert_eq!(dc_execution.analysis_directives, vec![".dc".to_string()]);
     assert_eq!(dc_execution.table_count, 4);
@@ -2394,11 +2445,27 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
         ac_execution.output_plan_artifacts[0].output_directive_analysis_kinds,
         vec!["global".to_string(), "ac".to_string()]
     );
+    let ac_output_directive_lines = vec![save_line, plot_ac_line];
+    assert_eq!(
+        ac_execution.output_plan_artifacts[0].output_directive_lines,
+        ac_output_directive_lines
+    );
+    let ac_output_directive_line_list = ac_output_directive_lines
+        .iter()
+        .map(usize::to_string)
+        .collect::<Vec<_>>()
+        .join(";");
     assert_eq!(
         ac_execution.output_plan_artifact_records[0]
             .get("OutputDirectiveAnalysisKindList")
             .map(String::as_str),
         Some("global;ac")
+    );
+    assert_eq!(
+        ac_execution.output_plan_artifact_records[0]
+            .get("OutputDirectiveLineList")
+            .map(String::as_str),
+        Some(ac_output_directive_line_list.as_str())
     );
     assert_eq!(ac_execution.analysis_directives, vec![".ac".to_string()]);
     assert_eq!(ac_execution.table_count, 4);
@@ -2485,6 +2552,10 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     let tran_execution = run_deck_analysis(&circuit, netlist, Some("tran")).unwrap();
     assert_eq!(tran_execution.output_probes, vec!["V(mid)".to_string()]);
     assert_eq!(tran_execution.output_directives, vec![".save".to_string()]);
+    assert_eq!(
+        tran_execution.output_plan_artifacts[0].output_directive_lines,
+        vec![save_line]
+    );
     assert_eq!(
         tran_execution.analysis_directives,
         vec![".tran".to_string()]

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Expose selected output directive source line inventories in
+  `runDeckAnalysis` output-plan artifacts beside directive scope inventories,
+  with stable table, CSV, compact JSON, and header-keyed record exports,
+  matching Python and Rust.
 - Expose normalized selected output directive analysis scope inventories in
   `runDeckAnalysis` output-plan artifacts beside directive kind inventories,
   distinguishing global `.save` / `.probe` selections from scoped `.probe`,

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -97,8 +97,8 @@ table, plus selected `.measure` results and
 a stable measurement table for `.dc`, `.ac`, and `.tran` executions.
 Execution `outputPlanArtifacts` summarize the selected result columns, output
 probes, output directives, normalized output directive kinds, normalized
-directive analysis scopes, and stable table names with table, CSV, compact
-JSON, and header-keyed record exports.
+directive analysis scopes, selected output directive source lines, and stable
+table names with table, CSV, compact JSON, and header-keyed record exports.
 Execution `tableArtifacts` preserve the same order as `tables` and carry each
 stable table's text, CSV, compact JSON, and header-keyed records.
 The `output-plan` entry in `tableArtifacts` carries the same

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -729,6 +729,8 @@ export interface DeckOutputPlanArtifact {
   readonly outputDirectiveKinds: readonly string[];
   readonly outputDirectiveAnalysisKindCount: number;
   readonly outputDirectiveAnalysisKinds: readonly string[];
+  readonly outputDirectiveLineCount: number;
+  readonly outputDirectiveLines: readonly number[];
   readonly tableCount: number;
   readonly tables: readonly string[];
 }
@@ -3515,6 +3517,30 @@ export function selectDeckOutputDirectiveAnalysisKinds(netlist: string, analysis
     }
     seen.add(analysisKind);
     selected.push(analysisKind);
+  }
+  return selected;
+}
+
+export function selectDeckOutputDirectiveLines(netlist: string, analysis: string): number[] {
+  const summary = resolveDeckOutputs(netlist);
+  if (summary.diagnostics.length > 0) {
+    const diagnostic = summary.diagnostics[0];
+    throw invalidElement(
+      "selectDeckOutputDirectiveLines",
+      `line ${diagnostic.lineNumber}: ${diagnostic.message}`,
+    );
+  }
+  const selected: number[] = [];
+  const seen = new Set<number>();
+  for (const selection of summary.selections) {
+    if (selection.analysis !== undefined && !deckOutputAnalysisMatches(selection.analysis, analysis)) {
+      continue;
+    }
+    if (seen.has(selection.lineNumber)) {
+      continue;
+    }
+    seen.add(selection.lineNumber);
+    selected.push(selection.lineNumber);
   }
   return selected;
 }
@@ -8343,6 +8369,7 @@ function deckOutputPlanArtifacts(
   outputProbes: readonly string[],
   outputDirectives: readonly string[],
   outputDirectiveAnalysisKinds: readonly string[],
+  outputDirectiveLines: readonly number[],
   tables: readonly string[],
 ): DeckOutputPlanArtifact[] {
   const outputDirectiveKinds = deckOutputDirectiveKinds(outputDirectives);
@@ -8360,6 +8387,8 @@ function deckOutputPlanArtifacts(
       outputDirectiveKinds,
       outputDirectiveAnalysisKindCount: outputDirectiveAnalysisKinds.length,
       outputDirectiveAnalysisKinds: [...outputDirectiveAnalysisKinds],
+      outputDirectiveLineCount: outputDirectiveLines.length,
+      outputDirectiveLines: [...outputDirectiveLines],
       tableCount: tables.length,
       tables: [...tables],
     },
@@ -8398,6 +8427,8 @@ const DECK_OUTPUT_PLAN_ARTIFACT_COLUMNS = [
   "OutputDirectiveKindList",
   "OutputDirectiveAnalysisKinds",
   "OutputDirectiveAnalysisKindList",
+  "OutputDirectiveLines",
+  "OutputDirectiveLineList",
   "Tables",
   "TableList",
 ] as const;
@@ -8416,6 +8447,8 @@ function deckOutputPlanArtifactCells(artifact: DeckOutputPlanArtifact): string[]
     artifact.outputDirectiveKinds.join(";"),
     String(artifact.outputDirectiveAnalysisKindCount),
     artifact.outputDirectiveAnalysisKinds.join(";"),
+    String(artifact.outputDirectiveLineCount),
+    artifact.outputDirectiveLines.map(String).join(";"),
     String(artifact.tableCount),
     artifact.tables.join(";"),
   ];
@@ -8467,6 +8500,7 @@ function deckOutputPlanArtifactBundle(
   outputProbes: readonly string[],
   outputDirectives: readonly string[],
   outputDirectiveAnalysisKinds: readonly string[],
+  outputDirectiveLines: readonly number[],
   tables: readonly string[],
 ): {
   artifacts: DeckOutputPlanArtifact[];
@@ -8481,6 +8515,7 @@ function deckOutputPlanArtifactBundle(
     outputProbes,
     outputDirectives,
     outputDirectiveAnalysisKinds,
+    outputDirectiveLines,
     tables,
   );
   return {
@@ -8570,6 +8605,7 @@ function deckTableArtifacts(
   outputProbes: readonly string[],
   outputDirectives: readonly string[],
   outputDirectiveAnalysisKinds: readonly string[],
+  outputDirectiveLines: readonly number[],
   tables: readonly string[],
 ): DeckTableArtifact[] {
   const artifacts = [deckTableArtifact("result", resultTable)];
@@ -8593,6 +8629,7 @@ function deckTableArtifacts(
     outputProbes,
     outputDirectives,
     outputDirectiveAnalysisKinds,
+    outputDirectiveLines,
     tables,
   ).table;
   artifacts.push(deckTableArtifact("output-plan", outputPlanArtifactTable));
@@ -9252,6 +9289,7 @@ export function runDeckAnalysis(
       netlist,
       plan.analysis,
     );
+    const outputDirectiveLines = selectDeckOutputDirectiveLines(netlist, plan.analysis);
     const runArtifacts = deckRunArtifacts(
       plan,
       result,
@@ -9273,6 +9311,7 @@ export function runDeckAnalysis(
       outputProbes,
       outputDirectives,
       outputDirectiveAnalysisKinds,
+      outputDirectiveLines,
       tables,
     );
     const measurementTable = formatMeasurementTable(measurements);
@@ -9293,6 +9332,7 @@ export function runDeckAnalysis(
       outputProbes,
       outputDirectives,
       outputDirectiveAnalysisKinds,
+      outputDirectiveLines,
       tables,
     );
     const rawfileArtifacts = deckRawfileArtifacts(plan, table, writeMarkers, rawfileOptions);
@@ -9380,6 +9420,7 @@ export function runDeckAnalysis(
       netlist,
       plan.analysis,
     );
+    const outputDirectiveLines = selectDeckOutputDirectiveLines(netlist, plan.analysis);
     const runArtifacts = deckRunArtifacts(
       plan,
       result,
@@ -9402,6 +9443,7 @@ export function runDeckAnalysis(
       outputProbes,
       outputDirectives,
       outputDirectiveAnalysisKinds,
+      outputDirectiveLines,
       tables,
     );
     const measurementTable = formatMeasurementTable(measurements);
@@ -9422,6 +9464,7 @@ export function runDeckAnalysis(
       outputProbes,
       outputDirectives,
       outputDirectiveAnalysisKinds,
+      outputDirectiveLines,
       tables,
     );
     const rawfileArtifacts = deckRawfileArtifacts(plan, table, writeMarkers, rawfileOptions);
@@ -9520,6 +9563,7 @@ export function runDeckAnalysis(
       netlist,
       plan.analysis,
     );
+    const outputDirectiveLines = selectDeckOutputDirectiveLines(netlist, plan.analysis);
     const runArtifacts = deckRunArtifacts(
       plan,
       result,
@@ -9542,6 +9586,7 @@ export function runDeckAnalysis(
       outputProbes,
       outputDirectives,
       outputDirectiveAnalysisKinds,
+      outputDirectiveLines,
       tables,
     );
     const measurementTable = formatMeasurementTable(measurements);
@@ -9562,6 +9607,7 @@ export function runDeckAnalysis(
       outputProbes,
       outputDirectives,
       outputDirectiveAnalysisKinds,
+      outputDirectiveLines,
       tables,
     );
     const rawfileArtifacts = deckRawfileArtifacts(plan, table, writeMarkers, rawfileOptions);
@@ -9655,6 +9701,7 @@ export function runDeckAnalysis(
       netlist,
       plan.analysis,
     );
+    const outputDirectiveLines = selectDeckOutputDirectiveLines(netlist, plan.analysis);
     const runArtifacts = deckRunArtifacts(
       plan,
       result,
@@ -9677,6 +9724,7 @@ export function runDeckAnalysis(
       outputProbes,
       outputDirectives,
       outputDirectiveAnalysisKinds,
+      outputDirectiveLines,
       tables,
     );
     const measurementTable = formatMeasurementTable(measurements);
@@ -9697,6 +9745,7 @@ export function runDeckAnalysis(
       outputProbes,
       outputDirectives,
       outputDirectiveAnalysisKinds,
+      outputDirectiveLines,
       tables,
     );
     const rawfileArtifacts = deckRawfileArtifacts(plan, table, writeMarkers, rawfileOptions);
@@ -9776,6 +9825,7 @@ export function runDeckAnalysis(
     const outputProbes = [`V(${outputNode})`];
     const outputDirectives: string[] = [];
     const outputDirectiveAnalysisKinds: string[] = [];
+    const outputDirectiveLines: number[] = [];
     const table = formatDeckTfTable(result);
     const runArtifacts = deckRunArtifacts(
       plan,
@@ -9799,6 +9849,7 @@ export function runDeckAnalysis(
       outputProbes,
       outputDirectives,
       outputDirectiveAnalysisKinds,
+      outputDirectiveLines,
       tables,
     );
     const measurementTable = formatMeasurementTable(measurements);
@@ -9819,6 +9870,7 @@ export function runDeckAnalysis(
       outputProbes,
       outputDirectives,
       outputDirectiveAnalysisKinds,
+      outputDirectiveLines,
       tables,
     );
     const rawfileArtifacts = deckRawfileArtifacts(plan, table, writeMarkers, rawfileOptions);
@@ -9897,6 +9949,7 @@ export function runDeckAnalysis(
     const outputProbes = [`V(${outputNode})`];
     const outputDirectives: string[] = [];
     const outputDirectiveAnalysisKinds: string[] = [];
+    const outputDirectiveLines: number[] = [];
     const table = formatDeckSensTable(result);
     const runArtifacts = deckRunArtifacts(
       plan,
@@ -9920,6 +9973,7 @@ export function runDeckAnalysis(
       outputProbes,
       outputDirectives,
       outputDirectiveAnalysisKinds,
+      outputDirectiveLines,
       tables,
     );
     const measurementTable = formatMeasurementTable(measurements);
@@ -9940,6 +9994,7 @@ export function runDeckAnalysis(
       outputProbes,
       outputDirectives,
       outputDirectiveAnalysisKinds,
+      outputDirectiveLines,
       tables,
     );
     const rawfileArtifacts = deckRawfileArtifacts(plan, table, writeMarkers, rawfileOptions);
@@ -10028,6 +10083,7 @@ export function runDeckAnalysis(
     const outputProbes = [`V(${outputNode})`];
     const outputDirectives: string[] = [];
     const outputDirectiveAnalysisKinds: string[] = [];
+    const outputDirectiveLines: number[] = [];
     const table = formatDeckNoiseTable(result);
     const runArtifacts = deckRunArtifacts(
       plan,
@@ -10051,6 +10107,7 @@ export function runDeckAnalysis(
       outputProbes,
       outputDirectives,
       outputDirectiveAnalysisKinds,
+      outputDirectiveLines,
       tables,
     );
     const measurementTable = formatMeasurementTable(measurements);
@@ -10071,6 +10128,7 @@ export function runDeckAnalysis(
       outputProbes,
       outputDirectives,
       outputDirectiveAnalysisKinds,
+      outputDirectiveLines,
       tables,
     );
     const rawfileArtifacts = deckRawfileArtifacts(plan, table, writeMarkers, rawfileOptions);

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -1510,6 +1510,13 @@ describe("transient", () => {
 .measure tran mid_final final V(mid)
 .end
 `;
+    const netlistLines = netlist.split(/\r?\n/u);
+    const directiveLine = (prefix: string) =>
+      netlistLines.findIndex((line) => line.trimStart().startsWith(prefix)) + 1;
+    const saveLine = directiveLine(".save");
+    const probeDcLine = directiveLine(".probe dc");
+    const printDcLine = directiveLine(".print dc");
+    const plotAcLine = directiveLine(".plot ac");
 
     const opExecution = runDeckAnalysis(circuit, netlist, "op");
     expect(opExecution.plan.analysis).toBe("op");
@@ -1552,6 +1559,8 @@ describe("transient", () => {
         OutputDirectiveKindList: "save",
         OutputDirectiveAnalysisKinds: "1",
         OutputDirectiveAnalysisKindList: "global",
+        OutputDirectiveLines: "1",
+        OutputDirectiveLineList: String(saveLine),
         Tables: "3",
         TableList: "result;output-plan;run-artifact",
       },
@@ -1571,19 +1580,21 @@ describe("transient", () => {
       outputDirectiveKinds: ["save"],
       outputDirectiveAnalysisKindCount: 1,
       outputDirectiveAnalysisKinds: ["global"],
+      outputDirectiveLineCount: 1,
+      outputDirectiveLines: [saveLine],
       tableCount: 3,
       tables: ["result", "output-plan", "run-artifact"],
     });
     expect(opExecution.outputPlanArtifactTable).toBe(
-      "Analysis\tDirective\tResultColumns\tResultColumnList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tOutputDirectiveKinds\tOutputDirectiveKindList\tOutputDirectiveAnalysisKinds\tOutputDirectiveAnalysisKindList\tTables\tTableList\n" +
-        "op\t.op\t2\tIndex;V(mid)\t1\tV(mid)\t1\t.save\t1\tsave\t1\tglobal\t3\tresult;output-plan;run-artifact\n",
+      "Analysis\tDirective\tResultColumns\tResultColumnList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tOutputDirectiveKinds\tOutputDirectiveKindList\tOutputDirectiveAnalysisKinds\tOutputDirectiveAnalysisKindList\tOutputDirectiveLines\tOutputDirectiveLineList\tTables\tTableList\n" +
+        `op\t.op\t2\tIndex;V(mid)\t1\tV(mid)\t1\t.save\t1\tsave\t1\tglobal\t1\t${saveLine}\t3\tresult;output-plan;run-artifact\n`,
     );
     expect(opExecution.outputPlanArtifactTable).toBe(
       formatDeckOutputPlanArtifactTable(opExecution.outputPlanArtifacts),
     );
     expect(opExecution.outputPlanArtifactCsv).toBe(
-      "Analysis,Directive,ResultColumns,ResultColumnList,OutputProbes,OutputProbeList,OutputDirectives,OutputDirectiveList,OutputDirectiveKinds,OutputDirectiveKindList,OutputDirectiveAnalysisKinds,OutputDirectiveAnalysisKindList,Tables,TableList\n" +
-        "op,.op,2,Index;V(mid),1,V(mid),1,.save,1,save,1,global,3,result;output-plan;run-artifact\n",
+      "Analysis,Directive,ResultColumns,ResultColumnList,OutputProbes,OutputProbeList,OutputDirectives,OutputDirectiveList,OutputDirectiveKinds,OutputDirectiveKindList,OutputDirectiveAnalysisKinds,OutputDirectiveAnalysisKindList,OutputDirectiveLines,OutputDirectiveLineList,Tables,TableList\n" +
+        `op,.op,2,Index;V(mid),1,V(mid),1,.save,1,save,1,global,1,${saveLine},3,result;output-plan;run-artifact\n`,
     );
     expect(opExecution.outputPlanArtifactCsv).toBe(
       formatDeckOutputPlanArtifactCsv(opExecution.outputPlanArtifacts),
@@ -1795,8 +1806,15 @@ describe("transient", () => {
       "global",
       "dc",
     ]);
+    const dcOutputDirectiveLines = [saveLine, probeDcLine, printDcLine];
+    expect(dcExecution.outputPlanArtifacts[0]?.outputDirectiveLines).toEqual(
+      dcOutputDirectiveLines,
+    );
     expect(dcExecution.outputPlanArtifactRecords[0]?.OutputDirectiveAnalysisKindList).toBe(
       "global;dc",
+    );
+    expect(dcExecution.outputPlanArtifactRecords[0]?.OutputDirectiveLineList).toBe(
+      dcOutputDirectiveLines.join(";"),
     );
     expect(dcExecution.analysisDirectives).toEqual([".dc"]);
     expect(dcExecution.tableCount).toBe(4);
@@ -1873,8 +1891,15 @@ describe("transient", () => {
       "global",
       "ac",
     ]);
+    const acOutputDirectiveLines = [saveLine, plotAcLine];
+    expect(acExecution.outputPlanArtifacts[0]?.outputDirectiveLines).toEqual(
+      acOutputDirectiveLines,
+    );
     expect(acExecution.outputPlanArtifactRecords[0]?.OutputDirectiveAnalysisKindList).toBe(
       "global;ac",
+    );
+    expect(acExecution.outputPlanArtifactRecords[0]?.OutputDirectiveLineList).toBe(
+      acOutputDirectiveLines.join(";"),
     );
     expect(acExecution.analysisDirectives).toEqual([".ac"]);
     expect(acExecution.tableCount).toBe(4);
@@ -1926,6 +1951,7 @@ describe("transient", () => {
     const tranExecution = runDeckAnalysis(circuit, netlist, "tran");
     expect(tranExecution.outputProbes).toEqual(["V(mid)"]);
     expect(tranExecution.outputDirectives).toEqual([".save"]);
+    expect(tranExecution.outputPlanArtifacts[0]?.outputDirectiveLines).toEqual([saveLine]);
     expect(tranExecution.analysisDirectives).toEqual([".tran"]);
     expect(tranExecution.tableCount).toBe(4);
     expect(tranExecution.tables).toEqual(["result", "measurement", "output-plan", "run-artifact"]);

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -139,7 +139,9 @@ downstream tools to compare.
      host-native record exports, and selected output-plan artifacts now also
      expose normalized output directive analysis scope counts/lists that
      distinguish global `.save` / `.probe` selections from scoped `.probe`,
-     `.print`, and `.plot` selections in the same exports.
+     `.print`, and `.plot` selections in the same exports, and selected
+     output-plan artifacts now also expose selected output directive source
+     line counts/lists beside those directive provenance inventories.
    - Expand remaining deck-controlled analyses toward full SPICE compatibility
      while keeping unsupported control-flow diagnostics explicit.
 
@@ -1176,6 +1178,16 @@ downstream tools to compare.
     - Table, CSV, compact JSON, and host-native record exports distinguish
       global `.save` / `.probe` selections from scoped `.probe`, `.print`, and
       `.plot` selections without reparsing directive cards.
+
+108. Deck output-plan directive line artifacts.
+    - Status: completed in this deck output-plan directive line artifact
+      slice.
+    - Python, Rust, and TypeScript selected output-plan artifacts now expose
+      selected output directive source line counts/lists beside directive
+      scope inventories.
+    - Table, CSV, compact JSON, and host-native record exports make selected
+      `.save`, `.probe`, `.print`, and `.plot` provenance traceable back to
+      deck source lines without reparsing directive cards.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- expose selected output directive source-line counts/lists in Python, Rust, and TypeScript output-plan artifacts
- add `OutputDirectiveLines` / `OutputDirectiveLineList` to table, CSV, compact JSON, and host-native record exports
- update package docs/changelogs and mark Slice 108 complete in the SPICE implementation plan

## Verification
- `/Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python -m ruff check code/packages/python/spice-engine/src/spice_engine code/packages/python/spice-engine/tests/test_engine.py`
- `PYTHONPATH=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-spice-deck-output-plan-line-artifacts/code/packages/python/spice-engine/src:/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-spice-deck-output-plan-line-artifacts/code/packages/python/mosfet-models/src:/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-spice-deck-output-plan-line-artifacts/code/packages/python/device-physics/src /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python -m pytest code/packages/python/spice-engine/tests/test_engine.py --no-cov`
- `cargo fmt -p spice-engine --check`
- `cargo test -p spice-engine`
- `npm ci`
- `npm run build`
- `npm test -- transient.test.ts`
- `npm test`
- `git diff --check`
