### PR TITLE
feat(closurec): fold static Object.keys/values/entries({}) → []

### DIFF
--- a/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to the `coding-adventures-closure-pass-constant-fold` crate will be documented in this file.
 
+## [0.59.0] - 2026-06-26
+
+### Added — fold static `Object.keys/values/entries({})` → `[]`
+
+The static `Object.keys(x)` / `Object.values(x)` / `Object.entries(x)`
+(ECMAScript §20.1.2.16/.22/.5) now fold to the empty array literal `[]` when the
+single argument is an **empty object literal** `{}`. An empty object has no own
+enumerable keys, and evaluating `{}` has no observable side effect, so collapsing
+the call to `[]` is sound for all three methods.
+
+Only the empty-object case folds. A **non-empty** object literal is declined: its
+property values (and any computed keys / spreads) may have side effects that
+collapsing to `[]` would drop, and the result is non-empty anyway. An array
+literal, a primitive (`Object.keys("ab")` → `["0","1"]`), an identifier, or any
+call with ≠1 argument is also declined. Dispatches through the `MemberExpression`
+callee arm (alongside the `String.from*` / `Number.isX`/`parseX` statics) — only
+the bare global `Object.keys/values/entries(...)` folds, never a shadowed
+receiver. Emits an empty `ArrayExpression` (like the `split` fold). Added five
+unit tests (the empty-object `[]` for all three methods, and the
+non-empty-object / array-primitive-identifier / second-argument /
+non-`Object`-receiver declines).
+
 ## [0.55.0] - 2026-06-26
 
 ### Added — fold legacy global `escape(…)` / `unescape(…)` → string literal

--- a/code/packages/rust/closure-pass-constant-fold/Cargo.toml
+++ b/code/packages/rust/closure-pass-constant-fold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-constant-fold"
-version = "0.55.0"
+version = "0.59.0"
 edition = "2021"
 description = "Constant-folding optimization pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Folds compile-time-evaluable expressions like `2 + 3 → 5`."
 

--- a/code/packages/rust/closure-pass-constant-fold/src/lib.rs
+++ b/code/packages/rust/closure-pass-constant-fold/src/lib.rs
@@ -1309,6 +1309,41 @@ fn fold_call(c: &CallExpression, st: &mut FoldState) -> Expression {
                         return stamp_literal_cv(FoldedLiteral::Boolean(value), new_cv);
                     }
                 }
+
+                // ---- Object.keys / values / entries ({}) → [] ----
+                //
+                // The static `Object.keys`/`values`/`entries` (ECMAScript
+                // §20.1.2.16/.22/.5) enumerate an object's own enumerable string
+                // keys. For an EMPTY object literal `{}` the result is ALWAYS the
+                // empty array `[]` — there are no keys, and evaluating `{}` has no
+                // observable side effect, so collapsing the call to `[]` is sound.
+                //
+                // We fold ONLY the empty-object-literal case. A NON-empty object
+                // literal is declined: its property *values* (and computed keys /
+                // spreads) may have side effects that collapsing to `[]` would
+                // drop, and the result is non-empty anyway. An array literal, a
+                // primitive (`Object.keys("ab")` → `["0","1"]`), an identifier, or
+                // a call with ≠1 argument is also declined (the result isn't a
+                // known empty array, or the type is unknown at compile time). Same
+                // bare-global-`Object` premise as the other statics — only the
+                // literal `Object.keys(...)` callee folds, never a shadowed
+                // receiver (`o.keys(...)` is left alone).
+                if obj.name == "Object"
+                    && matches!(prop.name.as_str(), "keys" | "values" | "entries")
+                    && arguments.len() == 1
+                {
+                    if let Some(Expression::ObjectExpression(o)) = arguments.first() {
+                        if o.properties.is_empty() {
+                            let parent = c.cv.clone();
+                            let before = format!("Object.{}({{}})", prop.name);
+                            let new_cv = st.fork_cv(&parent, &before, "[]");
+                            return Expression::ArrayExpression(ArrayExpression {
+                                cv: new_cv,
+                                elements: vec![],
+                            });
+                        }
+                    }
+                }
             }
         }
     }
@@ -6904,6 +6939,111 @@ mod tests {
         });
         let (out, _, changed, _) = run_pass(program_with_expr(c, true));
         assert!(!changed, "n.isInteger(5) must not fold");
+        assert!(matches!(extract_expr(&out), Expression::CallExpression(_)));
+    }
+
+    // ------------------- Object.keys/values/entries (static) ---------
+
+    /// Build `Object.<method>(<arg>)`.
+    fn object_static_call(method: &str, arg: Expression) -> Expression {
+        Expression::CallExpression(CallExpression {
+            cv: Some("c.cv".to_string()),
+            callee: Box::new(member(ident("Object"), method)),
+            arguments: vec![arg],
+        })
+    }
+
+    fn empty_object() -> Expression {
+        Expression::ObjectExpression(ObjectExpression {
+            cv: None,
+            properties: vec![],
+        })
+    }
+
+    #[test]
+    fn fold_object_keys_values_entries_empty_object_to_empty_array() {
+        // `Object.keys/values/entries({})` → `[]` for all three methods.
+        for method in ["keys", "values", "entries"] {
+            let c = object_static_call(method, empty_object());
+            let (out, _, changed, _) = run_pass(program_with_expr(c, true));
+            assert!(changed, "Object.{method}({{}}) should fold to []");
+            match extract_expr(&out) {
+                Expression::ArrayExpression(a) => {
+                    assert!(a.elements.is_empty(), "Object.{method}({{}}) → []")
+                }
+                other => panic!("expected []; got {:?}", other),
+            }
+        }
+    }
+
+    #[test]
+    fn object_static_non_empty_object_does_not_fold() {
+        // A non-empty object literal is declined — its property values may have
+        // side effects, and the result is non-empty anyway.
+        let obj = Expression::ObjectExpression(ObjectExpression {
+            cv: None,
+            properties: vec![Property {
+                cv: None,
+                kind: coding_adventures_javascript_ast::PropertyKind::Init,
+                key: PropertyKey::Identifier(coding_adventures_javascript_ast::Identifier {
+                    cv: None,
+                    name: "a".to_string(),
+                }),
+                value: Box::new(num(1.0, None)),
+                shorthand: false,
+                computed: false,
+                method: false,
+            }],
+        });
+        let c = object_static_call("keys", obj);
+        let (out, _, changed, _) = run_pass(program_with_expr(c, true));
+        assert!(!changed, "Object.keys({{a:1}}) must not fold");
+        assert!(matches!(extract_expr(&out), Expression::CallExpression(_)));
+    }
+
+    #[test]
+    fn object_static_array_primitive_or_identifier_does_not_fold() {
+        // An array, a primitive (Object.keys("ab")→["0","1"]), and an identifier
+        // are all declined.
+        let args = [
+            Expression::ArrayExpression(ArrayExpression {
+                cv: None,
+                elements: vec![],
+            }),
+            string("ab", None),
+            ident("x"),
+        ];
+        for arg in args {
+            let c = object_static_call("keys", arg);
+            let (out, _, changed, _) = run_pass(program_with_expr(c, true));
+            assert!(!changed, "Object.keys(array/primitive/ident) must not fold");
+            assert!(matches!(extract_expr(&out), Expression::CallExpression(_)));
+        }
+    }
+
+    #[test]
+    fn object_static_second_argument_does_not_fold() {
+        // We model only the single-argument form.
+        let c = Expression::CallExpression(CallExpression {
+            cv: Some("c.cv".to_string()),
+            callee: Box::new(member(ident("Object"), "keys")),
+            arguments: vec![empty_object(), ident("y")],
+        });
+        let (out, _, changed, _) = run_pass(program_with_expr(c, true));
+        assert!(!changed, "Object.keys({{}}, y) must not fold");
+        assert!(matches!(extract_expr(&out), Expression::CallExpression(_)));
+    }
+
+    #[test]
+    fn object_static_on_non_object_receiver_does_not_fold() {
+        // Only the bare global `Object` folds; `o.keys({})` is left alone.
+        let c = Expression::CallExpression(CallExpression {
+            cv: Some("c.cv".to_string()),
+            callee: Box::new(member(ident("o"), "keys")),
+            arguments: vec![empty_object()],
+        });
+        let (out, _, changed, _) = run_pass(program_with_expr(c, true));
+        assert!(!changed, "o.keys({{}}) must not fold");
         assert!(matches!(extract_expr(&out), Expression::CallExpression(_)));
     }
 

--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.208.0] - 2026-06-26
+
+### Added — SIMPLE/ADVANCED fold static `Object.keys/values/entries({})` → `[]`
+
+At `--compilation_level SIMPLE` (and ADVANCED, which routes through the same
+pipeline) the typed constant-fold pass now collapses the static `Object.keys(x)`
+/ `Object.values(x)` / `Object.entries(x)` (ECMAScript §20.1.2.16/.22/.5) to the
+empty array literal `[]` when the single argument is an empty object literal `{}`
+— via the new `MemberExpression`-arm dispatch in `closure-pass-constant-fold`
+0.59.0.
+
+An empty object has no own enumerable keys and `{}` has no side effect, so `[]`
+is exact for all three methods. A non-empty object literal is declined (its
+property values may have side effects, and the result is non-empty), as are
+arrays, primitives, identifiers, and any call with ≠1 argument. Only the bare
+global `Object.keys/values/entries(...)` folds, never a shadowed receiver.
+
+New end-to-end fixture `tests/diff/simple-fold-object-keys/` and integration test
+`tests/diff_simple_fold_object_keys.rs` assert byte-exact SIMPLE output, the
+three `[]` folds, the declined non-empty-object and array calls, and a
+WHITESPACE_ONLY-fallback regression guard (exactly two `Object.` calls remain).
+Help-markdown regenerated to Version 0.208.0.
+
 ## [0.204.0] - 2026-06-26
 
 ### Added — SIMPLE/ADVANCED fold legacy global `escape(…)` / `unescape(…)`

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.204.0"
+version = "0.208.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.204.0",
+  "version": "0.208.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.204.0
+Version: 0.208.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff/simple-fold-object-keys/README.md
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-object-keys/README.md
@@ -1,0 +1,44 @@
+# `simple-fold-object-keys` — static `Object.keys/values/entries({})` → `[]`
+
+End-to-end fixture proving that, at `--compilation_level SIMPLE`, the typed
+constant-fold pass collapses the static `Object.keys(x)` / `Object.values(x)` /
+`Object.entries(x)` (ECMAScript §20.1.2.16/.22/.5) to the empty array literal
+`[]` when the single argument is an **empty object literal** `{}`.
+
+| call                   | result      | note                                       |
+|------------------------|-------------|--------------------------------------------|
+| `Object.keys({})`      | `[]`        | no own enumerable keys                      |
+| `Object.values({})`    | `[]`        |                                            |
+| `Object.entries({})`   | `[]`        |                                            |
+| `Object.keys({a:1})`   | *unfolded*  | non-empty → property values may have effects|
+| `Object.keys([])`      | *unfolded*  | an array is declined (conservative)         |
+
+## Soundness
+
+An empty object has no own enumerable keys, and evaluating `{}` has no observable
+side effect, so collapsing `Object.keys/values/entries({})` to `[]` is exact and
+sound for all three methods. We fold **only** the empty-object-literal case: a
+non-empty object literal is declined because its property values (and any
+computed keys / spreads) may have side effects that collapsing to `[]` would drop
+(and the result is non-empty anyway). An array literal, a primitive
+(`Object.keys("ab")` → `["0","1"]`), an identifier, or any non-literal is also
+declined. `Object.keys/values/entries` are STATIC METHODS, so they dispatch
+through the `MemberExpression` callee arm — only the bare global
+`Object.keys(...)` folds, never a shadowed receiver (`o.keys(...)` is left alone).
+
+## Files
+
+- `flags.txt` — CLI flags (`--compilation_level SIMPLE --js input/a.js`).
+- `input/a.js` — five `var` bindings flowing into `report(...)` so each stays
+  referenced past remove-unused-vars and the fold is observable.
+- `expected.stdout` — the byte-exact SIMPLE output:
+
+  ```text
+  var a=[];var b=[];var c=[];var d=Object.keys({a:1});var e=Object.keys([]);report(a,b,c,d,e);
+  ```
+
+The integration test `tests/diff_simple_fold_object_keys.rs` runs the binary
+against these flags and asserts byte-exact stdout, the three empty-object `[]`
+folds, the declined non-empty-object and array calls, and a regression guard that
+the typed SIMPLE pipeline ran (not the WHITESPACE_ONLY fallback): exactly two
+`Object.` calls (the two declines) remain.

--- a/code/programs/rust/closurec/tests/diff/simple-fold-object-keys/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-object-keys/expected.stdout
@@ -1,0 +1,1 @@
+var a=[];var b=[];var c=[];var d=Object.keys({a:1});var e=Object.keys([]);report(a,b,c,d,e);

--- a/code/programs/rust/closurec/tests/diff/simple-fold-object-keys/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-object-keys/flags.txt
@@ -1,0 +1,4 @@
+--compilation_level
+SIMPLE
+--js
+tests/diff/simple-fold-object-keys/input/a.js

--- a/code/programs/rust/closurec/tests/diff/simple-fold-object-keys/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-object-keys/input/a.js
@@ -1,0 +1,22 @@
+// SIMPLE-level static Object.keys/values/entries({}) fold → [].
+//
+// Object.keys/values/entries(x) (ECMAScript §20.1.2) enumerate an object's own
+// enumerable keys. For an EMPTY object literal {} the result is ALWAYS the empty
+// array [] — no keys, and evaluating {} has no side effect — so the fold
+// collapses the call to []:
+//   * Object.keys({})    → []
+//   * Object.values({})  → []
+//   * Object.entries({}) → []
+//   * Object.keys({a:1}) → declined (property values may have side effects)
+//   * Object.keys([])    → declined (an array's keys are its indices)
+//
+// A non-empty object, an array, a primitive, or a non-literal is left intact.
+// Under WHITESPACE_ONLY every call survives; under SIMPLE the foldable ones
+// collapse. Each value flows into report(...) so it stays referenced past
+// remove-unused-vars and the fold is observable.
+var a = Object.keys({});
+var b = Object.values({});
+var c = Object.entries({});
+var d = Object.keys({a: 1});
+var e = Object.keys([]);
+report(a, b, c, d, e);

--- a/code/programs/rust/closurec/tests/diff_simple_fold_object_keys.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_fold_object_keys.rs
@@ -1,0 +1,95 @@
+//! Integration test for the `tests/diff/simple-fold-object-keys/` fixture.
+//!
+//! End-to-end oracle for static `Object.keys`/`values`/`entries` folding in
+//! `closure-pass-constant-fold`: a call whose single argument is an EMPTY object
+//! literal `{}` collapses to the empty array literal `[]` V8 would produce
+//! (ECMAScript §20.1.2.16/.22/.5). A non-empty object and an array are left
+//! intact.
+//!
+//! At SIMPLE the fixture optimizes to:
+//!
+//! ```text
+//! var a=[];var b=[];var c=[];var d=Object.keys({a:1});var e=Object.keys([]);report(a,b,c,d,e);
+//! ```
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
+
+fn read_flags() -> Vec<String> {
+    let raw = std::fs::read_to_string("tests/diff/simple-fold-object-keys/flags.txt")
+        .expect("read flags.txt");
+    raw.lines()
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[test]
+fn simple_fold_object_keys_fixture_matches_expected_stdout() {
+    let flags = read_flags();
+    let out = Command::new(BINARY)
+        .args(&flags)
+        .output()
+        .expect("run closurec");
+
+    assert!(
+        out.status.success(),
+        "exit: {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let actual = String::from_utf8_lossy(&out.stdout);
+    let expected = std::fs::read_to_string("tests/diff/simple-fold-object-keys/expected.stdout")
+        .expect("read expected.stdout");
+    assert_eq!(
+        actual.trim_end_matches('\n'),
+        expected.trim_end_matches('\n'),
+        "mismatch.\nflags: {flags:?}\nactual:\n{actual}\nexpected:\n{expected}",
+    );
+}
+
+/// `Object.keys/values/entries({})` each collapse to `[]`, while the non-empty
+/// object and the array argument survive untouched.
+#[test]
+fn simple_fold_object_keys_folds_empty_object_to_empty_array() {
+    let out = Command::new(BINARY)
+        .args(read_flags())
+        .output()
+        .expect("run closurec");
+    let actual = String::from_utf8_lossy(&out.stdout);
+
+    assert!(actual.contains("a=[]"), "Object.keys({{}}) → []; got:\n{actual}");
+    assert!(actual.contains("b=[]"), "Object.values({{}}) → []; got:\n{actual}");
+    assert!(actual.contains("c=[]"), "Object.entries({{}}) → []; got:\n{actual}");
+    // The non-empty object and the array are NOT folded — the calls must remain.
+    assert!(
+        actual.contains("d=Object.keys({a:1})"),
+        "Object.keys({{a:1}}) must NOT fold (property side effects); got:\n{actual}"
+    );
+    assert!(
+        actual.contains("e=Object.keys([])"),
+        "Object.keys([]) must NOT fold (array declined); got:\n{actual}"
+    );
+}
+
+/// Regression guard: the output must be the SIMPLE typed pipeline, not the
+/// `WHITESPACE_ONLY` fallback (which would leave every call intact). Exactly two
+/// calls — the declined non-empty object and the array — may remain.
+#[test]
+fn simple_fold_object_keys_did_not_fall_back_to_whitespace_only() {
+    let out = Command::new(BINARY)
+        .args(read_flags())
+        .output()
+        .expect("run closurec");
+    let actual = String::from_utf8_lossy(&out.stdout);
+
+    assert_eq!(
+        actual.matches("Object.").count(),
+        2,
+        "exactly two Object. calls (the non-empty-object + array declines) should \
+         remain — proving the typed SIMPLE optimizer ran, not the whitespace \
+         fallback; got:\n{actual}",
+    );
+}


### PR DESCRIPTION
## What

Constant-folds the static **`Object.keys(x)` / `Object.values(x)` / `Object.entries(x)`** (ECMAScript §20.1.2.16/.22/.5) at SIMPLE/ADVANCED to the empty array literal `[]` when the single argument is an **empty object literal** `{}`.

| call | result | note |
|------|--------|------|
| `Object.keys({})` | `[]` | no own enumerable keys |
| `Object.values({})` | `[]` | |
| `Object.entries({})` | `[]` | |
| `Object.keys({a:1})` | *unfolded* | non-empty → property values may have effects |
| `Object.keys([])` | *unfolded* | an array is declined (conservative) |

## How / Soundness

- An empty object has no own enumerable keys, and evaluating `{}` has no observable side effect, so `[]` is exact for all three methods.
- Only the empty-object case folds. A **non-empty** object literal declines — its property values / computed keys / spreads may have side effects that collapsing to `[]` would drop. Arrays, primitives, identifiers, and any call with ≠1 argument also decline.
- Dispatches through the `MemberExpression` callee arm (alongside the `String.from*` / `Number.isX`/`parseX` statics) — only the bare global `Object.keys/values/entries(...)` folds, never a shadowed receiver. Emits an empty `ArrayExpression` (like the `split` fold).

## Tests

- `constant-fold` 0.55.0 → **0.59.0**; **+5 unit tests** (empty-object `[]` for all three methods, and the non-empty-object / array-primitive-identifier / second-argument / non-`Object`-receiver declines). 244 cf lib tests pass.
- `closurec` 0.204.0 → **0.208.0**; cli.spec.json + help-markdown regenerated.
- New fixture `tests/diff/simple-fold-object-keys/` + integration test — byte-exact stdout (incl. the three `[]` folds and two declined calls) and a WHITESPACE_ONLY-fallback regression guard. All 78 cc test suites pass.

## Security

Inline security review **passed** — empty-object-only is byte-correct and side-effect-safe (any spread/computed/value-bearing object declines via its `properties` entries; primitives/arrays/identifiers fall through). No panics, no `unsafe`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)