### PR TITLE
[codex] Expose deck output-plan probe source artifacts

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Added
 
+- **Deck output-plan probe source line artifacts** —
+  selected `run_deck_analysis()` output-plan artifacts now expose selected
+  output probe source line counts/lists aligned with the selected output-probe
+  inventories in table, CSV, compact JSON, and header-keyed record exports,
+  matching Rust and TypeScript.
+
 - **Deck output-plan directive line artifacts** —
   selected `run_deck_analysis()` output-plan artifacts now expose selected
   output directive source line counts/lists beside directive scope inventories

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -113,9 +113,10 @@ that produced the table, plus selected
 executions. Execution `table_artifacts` preserve the same order as `tables` and
 carry each stable table's text, CSV, compact JSON, and header-keyed records.
 Execution `output_plan_artifacts` summarize the selected result columns,
-output probes, output directives, normalized output directive kinds, normalized
-directive analysis scopes, selected output directive source lines, and stable
-table names, and the `output-plan` entry in `table_artifacts` carries the same
+output probes, selected output probe source lines, output directives,
+normalized output directive kinds, normalized directive analysis scopes,
+selected output directive source lines, and stable table names, and the
+`output-plan` entry in `table_artifacts` carries the same
 table, CSV, compact JSON, and header-keyed record exports.
 Selected `.tran` plans also return selected `.four` harmonic results and a stable
 Fourier table. Executions also include a selected-run artifact summary plus

--- a/code/packages/python/spice-engine/src/spice_engine/__init__.py
+++ b/code/packages/python/spice-engine/src/spice_engine/__init__.py
@@ -48,6 +48,7 @@ from spice_engine.compatibility import (
     select_deck_output_directive_analysis_kinds,
     select_deck_output_directive_lines,
     select_deck_output_directives,
+    select_deck_output_probe_lines,
     select_deck_output_probes,
 )
 from spice_engine.elements import (
@@ -648,6 +649,7 @@ __all__ = [
     "select_deck_output_directive_analysis_kinds",
     "select_deck_output_directive_lines",
     "select_deck_output_directives",
+    "select_deck_output_probe_lines",
     "select_deck_output_probes",
     "sens_dc",
     "s_parameters",

--- a/code/packages/python/spice-engine/src/spice_engine/compatibility.py
+++ b/code/packages/python/spice-engine/src/spice_engine/compatibility.py
@@ -971,6 +971,33 @@ def select_deck_output_probes(netlist: str, analysis: str) -> list[str]:
     return selected
 
 
+def select_deck_output_probe_lines(netlist: str, analysis: str) -> list[int]:
+    """Return source lines for deduplicated output probes selected for an analysis."""
+
+    summary = resolve_deck_outputs(netlist)
+    if summary.diagnostics:
+        diagnostic = summary.diagnostics[0]
+        raise ValueError(
+            "select_deck_output_probe_lines: "
+            f"line {diagnostic.line_number}: {diagnostic.message}"
+        )
+    selected: list[int] = []
+    seen: set[str] = set()
+    for selection in summary.selections:
+        if selection.analysis is not None and not _deck_output_analysis_matches(
+            selection.analysis,
+            analysis,
+        ):
+            continue
+        for probe in selection.probes:
+            key = _deck_output_probe_key(probe)
+            if key in seen:
+                continue
+            seen.add(key)
+            selected.append(selection.line_number)
+    return selected
+
+
 def select_deck_output_directives(netlist: str, analysis: str) -> list[str]:
     """Return deduplicated output directive kinds selected for an analysis."""
 

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -79,6 +79,7 @@ from spice_engine.compatibility import (
     select_deck_output_directive_analysis_kinds,
     select_deck_output_directive_lines,
     select_deck_output_directives,
+    select_deck_output_probe_lines,
     select_deck_output_probes,
 )
 from spice_engine.elements import (
@@ -2388,6 +2389,8 @@ class DeckOutputPlanArtifact:
     result_columns: list[str]
     output_probe_count: int
     output_probes: list[str]
+    output_probe_line_count: int
+    output_probe_lines: list[int]
     output_directive_count: int
     output_directives: list[str]
     output_directive_kind_count: int
@@ -2897,6 +2900,7 @@ def _deck_output_plan_artifacts(
     plan: DeckAnalysisPlan,
     result_columns: list[str],
     output_probes: list[str],
+    output_probe_lines: list[int],
     output_directives: list[str],
     output_directive_analysis_kinds: list[str],
     output_directive_lines: list[int],
@@ -2911,6 +2915,8 @@ def _deck_output_plan_artifacts(
             result_columns=list(result_columns),
             output_probe_count=len(output_probes),
             output_probes=list(output_probes),
+            output_probe_line_count=len(output_probe_lines),
+            output_probe_lines=list(output_probe_lines),
             output_directive_count=len(output_directives),
             output_directives=list(output_directives),
             output_directive_kind_count=len(output_directive_kinds),
@@ -2934,6 +2940,8 @@ _DECK_OUTPUT_PLAN_ARTIFACT_COLUMNS = [
     "ResultColumnList",
     "OutputProbes",
     "OutputProbeList",
+    "OutputProbeLines",
+    "OutputProbeLineList",
     "OutputDirectives",
     "OutputDirectiveList",
     "OutputDirectiveKinds",
@@ -2955,6 +2963,8 @@ def _deck_output_plan_artifact_cells(artifact: DeckOutputPlanArtifact) -> list[s
         ";".join(artifact.result_columns),
         str(artifact.output_probe_count),
         ";".join(artifact.output_probes),
+        str(artifact.output_probe_line_count),
+        ";".join(str(line) for line in artifact.output_probe_lines),
         str(artifact.output_directive_count),
         ";".join(artifact.output_directives),
         str(artifact.output_directive_kind_count),
@@ -3027,6 +3037,7 @@ def _deck_output_plan_artifact_bundle(
     plan: DeckAnalysisPlan,
     result_table: str,
     output_probes: list[str],
+    output_probe_lines: list[int],
     output_directives: list[str],
     output_directive_analysis_kinds: list[str],
     output_directive_lines: list[int],
@@ -3036,6 +3047,7 @@ def _deck_output_plan_artifact_bundle(
         plan,
         _deck_table_columns(result_table),
         output_probes,
+        output_probe_lines,
         output_directives,
         output_directive_analysis_kinds,
         output_directive_lines,
@@ -3228,6 +3240,7 @@ def _deck_table_artifacts(
     control_policy_summary_artifacts: list[DeckControlPolicySummaryArtifact],
     control_policy_summary_artifact_table: str,
     output_probes: list[str],
+    output_probe_lines: list[int],
     output_directives: list[str],
     output_directive_analysis_kinds: list[str],
     output_directive_lines: list[int],
@@ -3253,6 +3266,7 @@ def _deck_table_artifacts(
         plan,
         result_table,
         output_probes,
+        output_probe_lines,
         output_directives,
         output_directive_analysis_kinds,
         output_directive_lines,
@@ -3946,6 +3960,7 @@ def run_deck_analysis(
         _select_deck_fourier_cards_for_analysis(netlist, plan.analysis)
         measurements: list[ProbeMeasurement] = []
         output_probes = select_deck_output_probes(netlist, plan.analysis)
+        output_probe_lines = select_deck_output_probe_lines(netlist, plan.analysis)
         output_directives = select_deck_output_directives(netlist, plan.analysis)
         output_directive_analysis_kinds = select_deck_output_directive_analysis_kinds(
             netlist,
@@ -3990,6 +4005,7 @@ def run_deck_analysis(
             control_policy_summary_artifacts,
             control_policy_summary_artifact_table,
             output_probes,
+            output_probe_lines,
             output_directives,
             output_directive_analysis_kinds,
             output_directive_lines,
@@ -4005,6 +4021,7 @@ def run_deck_analysis(
             plan,
             table,
             output_probes,
+            output_probe_lines,
             output_directives,
             output_directive_analysis_kinds,
             output_directive_lines,
@@ -4056,6 +4073,7 @@ def run_deck_analysis(
         fourier = []
         _select_deck_fourier_cards_for_analysis(netlist, plan.analysis)
         output_probes = select_deck_output_probes(netlist, plan.analysis)
+        output_probe_lines = select_deck_output_probe_lines(netlist, plan.analysis)
         output_directives = select_deck_output_directives(netlist, plan.analysis)
         output_directive_analysis_kinds = select_deck_output_directive_analysis_kinds(
             netlist,
@@ -4100,6 +4118,7 @@ def run_deck_analysis(
             control_policy_summary_artifacts,
             control_policy_summary_artifact_table,
             output_probes,
+            output_probe_lines,
             output_directives,
             output_directive_analysis_kinds,
             output_directive_lines,
@@ -4115,6 +4134,7 @@ def run_deck_analysis(
             plan,
             table,
             output_probes,
+            output_probe_lines,
             output_directives,
             output_directive_analysis_kinds,
             output_directive_lines,
@@ -4168,6 +4188,7 @@ def run_deck_analysis(
         fourier = []
         _select_deck_fourier_cards_for_analysis(netlist, plan.analysis)
         output_probes = select_deck_output_probes(netlist, plan.analysis)
+        output_probe_lines = select_deck_output_probe_lines(netlist, plan.analysis)
         output_directives = select_deck_output_directives(netlist, plan.analysis)
         output_directive_analysis_kinds = select_deck_output_directive_analysis_kinds(
             netlist,
@@ -4212,6 +4233,7 @@ def run_deck_analysis(
             control_policy_summary_artifacts,
             control_policy_summary_artifact_table,
             output_probes,
+            output_probe_lines,
             output_directives,
             output_directive_analysis_kinds,
             output_directive_lines,
@@ -4227,6 +4249,7 @@ def run_deck_analysis(
             plan,
             table,
             output_probes,
+            output_probe_lines,
             output_directives,
             output_directive_analysis_kinds,
             output_directive_lines,
@@ -4286,6 +4309,7 @@ def run_deck_analysis(
             _select_deck_fourier_cards_for_analysis(netlist, plan.analysis),
         )
         output_probes = select_deck_output_probes(netlist, plan.analysis)
+        output_probe_lines = select_deck_output_probe_lines(netlist, plan.analysis)
         output_directives = select_deck_output_directives(netlist, plan.analysis)
         output_directive_analysis_kinds = select_deck_output_directive_analysis_kinds(
             netlist,
@@ -4330,6 +4354,7 @@ def run_deck_analysis(
             control_policy_summary_artifacts,
             control_policy_summary_artifact_table,
             output_probes,
+            output_probe_lines,
             output_directives,
             output_directive_analysis_kinds,
             output_directive_lines,
@@ -4345,6 +4370,7 @@ def run_deck_analysis(
             plan,
             table,
             output_probes,
+            output_probe_lines,
             output_directives,
             output_directive_analysis_kinds,
             output_directive_lines,
@@ -4391,6 +4417,7 @@ def run_deck_analysis(
         _select_deck_fourier_cards_for_analysis(netlist, plan.analysis)
         fourier = []
         output_probes = [f"V({output_node})"]
+        output_probe_lines: list[int] = []
         output_directives: list[str] = []
         output_directive_analysis_kinds: list[str] = []
         output_directive_lines: list[int] = []
@@ -4430,6 +4457,7 @@ def run_deck_analysis(
             control_policy_summary_artifacts,
             control_policy_summary_artifact_table,
             output_probes,
+            output_probe_lines,
             output_directives,
             output_directive_analysis_kinds,
             output_directive_lines,
@@ -4445,6 +4473,7 @@ def run_deck_analysis(
             plan,
             table,
             output_probes,
+            output_probe_lines,
             output_directives,
             output_directive_analysis_kinds,
             output_directive_lines,
@@ -4490,6 +4519,7 @@ def run_deck_analysis(
         _select_deck_fourier_cards_for_analysis(netlist, plan.analysis)
         fourier = []
         output_probes = [f"V({output_node})"]
+        output_probe_lines: list[int] = []
         output_directives = []
         output_directive_analysis_kinds: list[str] = []
         output_directive_lines: list[int] = []
@@ -4529,6 +4559,7 @@ def run_deck_analysis(
             control_policy_summary_artifacts,
             control_policy_summary_artifact_table,
             output_probes,
+            output_probe_lines,
             output_directives,
             output_directive_analysis_kinds,
             output_directive_lines,
@@ -4544,6 +4575,7 @@ def run_deck_analysis(
             plan,
             table,
             output_probes,
+            output_probe_lines,
             output_directives,
             output_directive_analysis_kinds,
             output_directive_lines,
@@ -4608,6 +4640,7 @@ def run_deck_analysis(
         _select_deck_fourier_cards_for_analysis(netlist, plan.analysis)
         fourier = []
         output_probes = [f"V({output_node})"]
+        output_probe_lines: list[int] = []
         output_directives = []
         output_directive_analysis_kinds: list[str] = []
         output_directive_lines: list[int] = []
@@ -4647,6 +4680,7 @@ def run_deck_analysis(
             control_policy_summary_artifacts,
             control_policy_summary_artifact_table,
             output_probes,
+            output_probe_lines,
             output_directives,
             output_directive_analysis_kinds,
             output_directive_lines,
@@ -4662,6 +4696,7 @@ def run_deck_analysis(
             plan,
             table,
             output_probes,
+            output_probe_lines,
             output_directives,
             output_directive_analysis_kinds,
             output_directive_lines,

--- a/code/packages/python/spice-engine/tests/test_compatibility.py
+++ b/code/packages/python/spice-engine/tests/test_compatibility.py
@@ -18,6 +18,7 @@ from spice_engine import (
     resolve_deck_parameters,
     resolve_deck_sources,
     select_deck_analysis_plan,
+    select_deck_output_probe_lines,
     select_deck_output_probes,
 )
 
@@ -797,6 +798,17 @@ V1 in 0 DC 1
 """,
         "transient",
     ) == ["V(out)", "I(V1)", "V(clk)", "I(V2)", "V(extra)"]
+    assert select_deck_output_probe_lines(
+        "\n".join(
+            [
+                ".save V(out)",
+                ".print dc V(out) I(V1)",
+                ".probe ac V(freq)",
+                ".end",
+            ]
+        ),
+        "dc",
+    ) == [1, 2]
 
 
 def test_resolve_deck_analyses_extracts_supported_cards() -> None:
@@ -1040,6 +1052,14 @@ def test_resolve_deck_outputs_reports_invalid_cards() -> None:
 
     with pytest.raises(ValueError, match=r"line 2: \.save requires"):
         select_deck_output_probes(
+            """
+.save
+.end
+""",
+            "dc",
+        )
+    with pytest.raises(ValueError, match=r"line 2: \.save requires"):
+        select_deck_output_probe_lines(
             """
 .save
 .end

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -6892,13 +6892,14 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     )
     expected_output_plan_table = (
         "Analysis\tDirective\tResultColumns\tResultColumnList\tOutputProbes\t"
-        "OutputProbeList\tOutputDirectives\tOutputDirectiveList\t"
+        "OutputProbeList\tOutputProbeLines\tOutputProbeLineList\t"
+        "OutputDirectives\tOutputDirectiveList\t"
         "OutputDirectiveKinds\tOutputDirectiveKindList\t"
         "OutputDirectiveAnalysisKinds\tOutputDirectiveAnalysisKindList\t"
         "OutputDirectiveLines\tOutputDirectiveLineList\t"
         "Tables\tTableList\n"
-        "op\t.op\t2\tIndex;V(mid)\t1\tV(mid)\t1\t.save\t1\tsave\t"
-        f"1\tglobal\t1\t{save_line}\t3\t"
+        "op\t.op\t2\tIndex;V(mid)\t1\tV(mid)\t"
+        f"1\t{save_line}\t1\t.save\t1\tsave\t1\tglobal\t1\t{save_line}\t3\t"
         "result;output-plan;run-artifact\n"
     )
     expected_output_plan_records = [
@@ -6909,6 +6910,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
             "ResultColumnList": "Index;V(mid)",
             "OutputProbes": "1",
             "OutputProbeList": "V(mid)",
+            "OutputProbeLines": "1",
+            "OutputProbeLineList": str(save_line),
             "OutputDirectives": "1",
             "OutputDirectiveList": ".save",
             "OutputDirectiveKinds": "1",
@@ -6928,6 +6931,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert output_plan_artifact.directive == ".op"
     assert output_plan_artifact.result_columns == ["Index", "V(mid)"]
     assert output_plan_artifact.output_probes == ["V(mid)"]
+    assert output_plan_artifact.output_probe_line_count == 1
+    assert output_plan_artifact.output_probe_lines == [save_line]
     assert output_plan_artifact.output_directives == [".save"]
     assert output_plan_artifact.output_directive_kind_count == 1
     assert output_plan_artifact.output_directive_kinds == ["save"]
@@ -6942,12 +6947,13 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     )
     assert op_execution.output_plan_artifact_csv == (
         "Analysis,Directive,ResultColumns,ResultColumnList,OutputProbes,"
-        "OutputProbeList,OutputDirectives,OutputDirectiveList,"
+        "OutputProbeList,OutputProbeLines,OutputProbeLineList,"
+        "OutputDirectives,OutputDirectiveList,"
         "OutputDirectiveKinds,OutputDirectiveKindList,"
         "OutputDirectiveAnalysisKinds,OutputDirectiveAnalysisKindList,"
         "OutputDirectiveLines,OutputDirectiveLineList,"
         "Tables,TableList\n"
-        f"op,.op,2,Index;V(mid),1,V(mid),1,.save,1,save,1,global,1,{save_line},3,"
+        f"op,.op,2,Index;V(mid),1,V(mid),1,{save_line},1,.save,1,save,1,global,1,{save_line},3,"
         "result;output-plan;run-artifact\n"
     )
     assert op_execution.output_plan_artifact_csv == (
@@ -7161,6 +7167,11 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
         "dc",
     ]
     dc_output_directive_lines = [save_line, probe_dc_line, print_dc_line]
+    dc_output_probe_lines = [save_line, probe_dc_line]
+    assert (
+        dc_execution.output_plan_artifacts[0].output_probe_lines
+        == dc_output_probe_lines
+    )
     assert (
         dc_execution.output_plan_artifacts[0].output_directive_lines
         == dc_output_directive_lines
@@ -7168,6 +7179,9 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert dc_execution.output_plan_artifact_records[0][
         "OutputDirectiveAnalysisKindList"
     ] == "global;dc"
+    assert dc_execution.output_plan_artifact_records[0][
+        "OutputProbeLineList"
+    ] == ";".join(str(line) for line in dc_output_probe_lines)
     assert dc_execution.output_plan_artifact_records[0][
         "OutputDirectiveLineList"
     ] == ";".join(str(line) for line in dc_output_directive_lines)
@@ -7251,6 +7265,7 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
         "ac",
     ]
     ac_output_directive_lines = [save_line, plot_ac_line]
+    assert ac_execution.output_plan_artifacts[0].output_probe_lines == [save_line]
     assert (
         ac_execution.output_plan_artifacts[0].output_directive_lines
         == ac_output_directive_lines
@@ -7315,6 +7330,7 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert tran_execution.output_plan_artifacts[0].output_directive_lines == [
         save_line
     ]
+    assert tran_execution.output_plan_artifacts[0].output_probe_lines == [save_line]
     assert tran_execution.analysis_directives == [".tran"]
     assert tran_execution.table_count == 4
     assert tran_execution.tables == ["result", "measurement", "output-plan", "run-artifact"]

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Expose selected output probe source line inventories in `run_deck_analysis`
+  output-plan artifacts aligned with selected output-probe inventories, with
+  stable table, CSV, compact JSON, and header-keyed record exports, matching
+  Python and TypeScript.
 - Expose selected output directive source line inventories in
   `run_deck_analysis` output-plan artifacts beside directive scope
   inventories, with stable table, CSV, compact JSON, and header-keyed record

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -182,9 +182,10 @@ a stable measurement table for `.dc`, `.ac`, and `.tran` executions.
 Execution `table_artifacts` preserve the same order as `tables` and carry each
 stable table's text, CSV, compact JSON, and header-keyed records.
 Execution `output_plan_artifacts` summarize the selected result columns,
-output probes, output directives, normalized output directive kinds, normalized
-directive analysis scopes, selected output directive source lines, and stable
-table names, and the `output-plan` entry in `table_artifacts` carries the same
+output probes, selected output probe source lines, output directives,
+normalized output directive kinds, normalized directive analysis scopes,
+selected output directive source lines, and stable table names, and the
+`output-plan` entry in `table_artifacts` carries the same
 table, CSV, compact JSON, and header-keyed record exports.
 Selected `.tran` plans route
 `START` output filtering, `.tran TSTEP` as the output print grid, `MAXSTEP` as

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -3470,6 +3470,8 @@ pub struct DeckOutputPlanArtifact {
     pub result_columns: Vec<String>,
     pub output_probe_count: usize,
     pub output_probes: Vec<String>,
+    pub output_probe_line_count: usize,
+    pub output_probe_lines: Vec<usize>,
     pub output_directive_count: usize,
     pub output_directives: Vec<String>,
     pub output_directive_kind_count: usize,
@@ -4104,6 +4106,35 @@ pub fn select_deck_output_probes(netlist: &str, analysis: &str) -> Result<Vec<St
             let key = deck_output_probe_key(&probe);
             if seen.insert(key) {
                 selected.push(probe);
+            }
+        }
+    }
+    Ok(selected)
+}
+
+pub fn select_deck_output_probe_lines(
+    netlist: &str,
+    analysis: &str,
+) -> Result<Vec<usize>, SpiceError> {
+    let summary = resolve_deck_outputs(netlist);
+    if let Some(diagnostic) = summary.diagnostics.first() {
+        return Err(table_error(
+            "select_deck_output_probe_lines",
+            &format!("line {}: {}", diagnostic.line_number, diagnostic.message),
+        ));
+    }
+    let mut selected = Vec::new();
+    let mut seen = HashSet::new();
+    for selection in summary.selections {
+        if !selection.analysis.as_deref().map_or(true, |requested| {
+            deck_output_analysis_matches(requested, analysis)
+        }) {
+            continue;
+        }
+        for probe in selection.probes {
+            let key = deck_output_probe_key(&probe);
+            if seen.insert(key) {
+                selected.push(selection.line_number);
             }
         }
     }
@@ -10429,6 +10460,7 @@ fn deck_output_plan_artifacts(
     plan: &DeckAnalysisPlan,
     result_columns: &[String],
     output_probes: &[String],
+    output_probe_lines: &[usize],
     output_directives: &[String],
     output_directive_analysis_kinds: &[String],
     output_directive_lines: &[usize],
@@ -10442,6 +10474,8 @@ fn deck_output_plan_artifacts(
         result_columns: result_columns.to_vec(),
         output_probe_count: output_probes.len(),
         output_probes: output_probes.to_vec(),
+        output_probe_line_count: output_probe_lines.len(),
+        output_probe_lines: output_probe_lines.to_vec(),
         output_directive_count: output_directives.len(),
         output_directives: output_directives.to_vec(),
         output_directive_kind_count: output_directive_kinds.len(),
@@ -10485,6 +10519,8 @@ const DECK_OUTPUT_PLAN_ARTIFACT_COLUMNS: &[&str] = &[
     "ResultColumnList",
     "OutputProbes",
     "OutputProbeList",
+    "OutputProbeLines",
+    "OutputProbeLineList",
     "OutputDirectives",
     "OutputDirectiveList",
     "OutputDirectiveKinds",
@@ -10505,6 +10541,13 @@ fn deck_output_plan_artifact_cells(artifact: &DeckOutputPlanArtifact) -> Vec<Str
         artifact.result_columns.join(";"),
         artifact.output_probe_count.to_string(),
         artifact.output_probes.join(";"),
+        artifact.output_probe_line_count.to_string(),
+        artifact
+            .output_probe_lines
+            .iter()
+            .map(usize::to_string)
+            .collect::<Vec<_>>()
+            .join(";"),
         artifact.output_directive_count.to_string(),
         artifact.output_directives.join(";"),
         artifact.output_directive_kind_count.to_string(),
@@ -10587,6 +10630,7 @@ fn deck_output_plan_artifact_bundle(
     plan: &DeckAnalysisPlan,
     result_table: &str,
     output_probes: &[String],
+    output_probe_lines: &[usize],
     output_directives: &[String],
     output_directive_analysis_kinds: &[String],
     output_directive_lines: &[usize],
@@ -10602,6 +10646,7 @@ fn deck_output_plan_artifact_bundle(
         plan,
         &deck_table_columns(result_table),
         output_probes,
+        output_probe_lines,
         output_directives,
         output_directive_analysis_kinds,
         output_directive_lines,
@@ -10888,6 +10933,7 @@ fn deck_table_artifacts(
     control_policy_summary_artifacts: &[DeckControlPolicySummaryArtifact],
     control_policy_summary_artifact_table: &str,
     output_probes: &[String],
+    output_probe_lines: &[usize],
     output_directives: &[String],
     output_directive_analysis_kinds: &[String],
     output_directive_lines: &[usize],
@@ -10922,6 +10968,7 @@ fn deck_table_artifacts(
         plan,
         result_table,
         output_probes,
+        output_probe_lines,
         output_directives,
         output_directive_analysis_kinds,
         output_directive_lines,
@@ -11800,6 +11847,7 @@ pub fn run_deck_analysis(
             let fourier = Vec::new();
             let fourier_table = format_deck_fourier_table(&fourier);
             let output_probes = select_deck_output_probes(netlist, "op")?;
+            let output_probe_lines = select_deck_output_probe_lines(netlist, "op")?;
             let output_directives = select_deck_output_directives(netlist, "op")?;
             let output_directive_analysis_kinds =
                 select_deck_output_directive_analysis_kinds(netlist, "op")?;
@@ -11833,6 +11881,7 @@ pub fn run_deck_analysis(
                 &control_policy_summary_artifacts,
                 &control_policy_summary_artifact_table,
                 &output_probes,
+                &output_probe_lines,
                 &output_directives,
                 &output_directive_analysis_kinds,
                 &output_directive_lines,
@@ -11859,6 +11908,7 @@ pub fn run_deck_analysis(
                 &plan,
                 &table,
                 &output_probes,
+                &output_probe_lines,
                 &output_directives,
                 &output_directive_analysis_kinds,
                 &output_directive_lines,
@@ -11944,6 +11994,7 @@ pub fn run_deck_analysis(
             let fourier = Vec::new();
             let fourier_table = format_deck_fourier_table(&fourier);
             let output_probes = select_deck_output_probes(netlist, "dc")?;
+            let output_probe_lines = select_deck_output_probe_lines(netlist, "dc")?;
             let output_directives = select_deck_output_directives(netlist, "dc")?;
             let output_directive_analysis_kinds =
                 select_deck_output_directive_analysis_kinds(netlist, "dc")?;
@@ -11977,6 +12028,7 @@ pub fn run_deck_analysis(
                 &control_policy_summary_artifacts,
                 &control_policy_summary_artifact_table,
                 &output_probes,
+                &output_probe_lines,
                 &output_directives,
                 &output_directive_analysis_kinds,
                 &output_directive_lines,
@@ -12003,6 +12055,7 @@ pub fn run_deck_analysis(
                 &plan,
                 &table,
                 &output_probes,
+                &output_probe_lines,
                 &output_directives,
                 &output_directive_analysis_kinds,
                 &output_directive_lines,
@@ -12089,6 +12142,7 @@ pub fn run_deck_analysis(
             let fourier = Vec::new();
             let fourier_table = format_deck_fourier_table(&fourier);
             let output_probes = select_deck_output_probes(netlist, "ac")?;
+            let output_probe_lines = select_deck_output_probe_lines(netlist, "ac")?;
             let output_directives = select_deck_output_directives(netlist, "ac")?;
             let output_directive_analysis_kinds =
                 select_deck_output_directive_analysis_kinds(netlist, "ac")?;
@@ -12122,6 +12176,7 @@ pub fn run_deck_analysis(
                 &control_policy_summary_artifacts,
                 &control_policy_summary_artifact_table,
                 &output_probes,
+                &output_probe_lines,
                 &output_directives,
                 &output_directive_analysis_kinds,
                 &output_directive_lines,
@@ -12148,6 +12203,7 @@ pub fn run_deck_analysis(
                 &plan,
                 &table,
                 &output_probes,
+                &output_probe_lines,
                 &output_directives,
                 &output_directive_analysis_kinds,
                 &output_directive_lines,
@@ -12237,6 +12293,7 @@ pub fn run_deck_analysis(
             let fourier = fourier_transient_cards(&result, &fourier_cards)?;
             let fourier_table = format_deck_fourier_table(&fourier);
             let output_probes = select_deck_output_probes(netlist, "tran")?;
+            let output_probe_lines = select_deck_output_probe_lines(netlist, "tran")?;
             let output_directives = select_deck_output_directives(netlist, "tran")?;
             let output_directive_analysis_kinds =
                 select_deck_output_directive_analysis_kinds(netlist, "tran")?;
@@ -12270,6 +12327,7 @@ pub fn run_deck_analysis(
                 &control_policy_summary_artifacts,
                 &control_policy_summary_artifact_table,
                 &output_probes,
+                &output_probe_lines,
                 &output_directives,
                 &output_directive_analysis_kinds,
                 &output_directive_lines,
@@ -12296,6 +12354,7 @@ pub fn run_deck_analysis(
                 &plan,
                 &table,
                 &output_probes,
+                &output_probe_lines,
                 &output_directives,
                 &output_directive_analysis_kinds,
                 &output_directive_lines,
@@ -12378,6 +12437,7 @@ pub fn run_deck_analysis(
             let fourier = Vec::new();
             let fourier_table = format_deck_fourier_table(&fourier);
             let output_probes = vec![format!("V({output_node})")];
+            let output_probe_lines = Vec::new();
             let output_directives = Vec::new();
             let output_directive_analysis_kinds = Vec::new();
             let output_directive_lines = Vec::new();
@@ -12411,6 +12471,7 @@ pub fn run_deck_analysis(
                 &control_policy_summary_artifacts,
                 &control_policy_summary_artifact_table,
                 &output_probes,
+                &output_probe_lines,
                 &output_directives,
                 &output_directive_analysis_kinds,
                 &output_directive_lines,
@@ -12437,6 +12498,7 @@ pub fn run_deck_analysis(
                 &plan,
                 &table,
                 &output_probes,
+                &output_probe_lines,
                 &output_directives,
                 &output_directive_analysis_kinds,
                 &output_directive_lines,
@@ -12517,6 +12579,7 @@ pub fn run_deck_analysis(
             let fourier = Vec::new();
             let fourier_table = format_deck_fourier_table(&fourier);
             let output_probes = vec![format!("V({output_node})")];
+            let output_probe_lines = Vec::new();
             let output_directives = Vec::new();
             let output_directive_analysis_kinds = Vec::new();
             let output_directive_lines = Vec::new();
@@ -12550,6 +12613,7 @@ pub fn run_deck_analysis(
                 &control_policy_summary_artifacts,
                 &control_policy_summary_artifact_table,
                 &output_probes,
+                &output_probe_lines,
                 &output_directives,
                 &output_directive_analysis_kinds,
                 &output_directive_lines,
@@ -12576,6 +12640,7 @@ pub fn run_deck_analysis(
                 &plan,
                 &table,
                 &output_probes,
+                &output_probe_lines,
                 &output_directives,
                 &output_directive_analysis_kinds,
                 &output_directive_lines,
@@ -12668,6 +12733,7 @@ pub fn run_deck_analysis(
             let fourier = Vec::new();
             let fourier_table = format_deck_fourier_table(&fourier);
             let output_probes = vec![format!("V({output_node})")];
+            let output_probe_lines = Vec::new();
             let output_directives = Vec::new();
             let output_directive_analysis_kinds = Vec::new();
             let output_directive_lines = Vec::new();
@@ -12701,6 +12767,7 @@ pub fn run_deck_analysis(
                 &control_policy_summary_artifacts,
                 &control_policy_summary_artifact_table,
                 &output_probes,
+                &output_probe_lines,
                 &output_directives,
                 &output_directive_analysis_kinds,
                 &output_directive_lines,
@@ -12727,6 +12794,7 @@ pub fn run_deck_analysis(
                 &plan,
                 &table,
                 &output_probes,
+                &output_probe_lines,
                 &output_directives,
                 &output_directive_analysis_kinds,
                 &output_directive_lines,

--- a/code/packages/rust/spice-engine/tests/compatibility_tests.rs
+++ b/code/packages/rust/spice-engine/tests/compatibility_tests.rs
@@ -5,8 +5,8 @@ use spice_engine::{
     format_release_readiness_report, release_readiness_gates, resolve_deck_analyses,
     resolve_deck_fourier, resolve_deck_functions, resolve_deck_initial_conditions,
     resolve_deck_measurements, resolve_deck_outputs, resolve_deck_parameters, resolve_deck_sources,
-    select_deck_analysis_plan, select_deck_output_probes, CompatibilityDeck,
-    CompatibilityGoldenValue, CompatibilityOracle,
+    select_deck_analysis_plan, select_deck_output_probe_lines, select_deck_output_probes,
+    CompatibilityDeck, CompatibilityGoldenValue, CompatibilityOracle,
 };
 
 #[test]
@@ -1147,6 +1147,20 @@ V1 in 0 DC 1
         )
         .unwrap(),
         vec!["V(out)", "I(V1)", "V(clk)", "I(V2)", "V(extra)"]
+    );
+    assert_eq!(
+        select_deck_output_probe_lines(
+            &[
+                ".save V(out)",
+                ".print dc V(out) I(V1)",
+                ".probe ac V(freq)",
+                ".end",
+            ]
+            .join("\n"),
+            "dc",
+        )
+        .unwrap(),
+        vec![1, 2]
     );
 }
 

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -1999,6 +1999,8 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
         output_plan_artifact.output_probes,
         vec!["V(mid)".to_string()]
     );
+    assert_eq!(output_plan_artifact.output_probe_line_count, 1);
+    assert_eq!(output_plan_artifact.output_probe_lines, vec![save_line]);
     assert_eq!(
         output_plan_artifact.output_directives,
         vec![".save".to_string()]
@@ -2026,8 +2028,8 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         op_execution.output_plan_artifact_table,
         format!(
-            "Analysis\tDirective\tResultColumns\tResultColumnList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tOutputDirectiveKinds\tOutputDirectiveKindList\tOutputDirectiveAnalysisKinds\tOutputDirectiveAnalysisKindList\tOutputDirectiveLines\tOutputDirectiveLineList\tTables\tTableList\nop\t.op\t2\tIndex;V(mid)\t1\tV(mid)\t1\t.save\t1\tsave\t1\tglobal\t1\t{}\t3\tresult;output-plan;run-artifact\n",
-            save_line
+            "Analysis\tDirective\tResultColumns\tResultColumnList\tOutputProbes\tOutputProbeList\tOutputProbeLines\tOutputProbeLineList\tOutputDirectives\tOutputDirectiveList\tOutputDirectiveKinds\tOutputDirectiveKindList\tOutputDirectiveAnalysisKinds\tOutputDirectiveAnalysisKindList\tOutputDirectiveLines\tOutputDirectiveLineList\tTables\tTableList\nop\t.op\t2\tIndex;V(mid)\t1\tV(mid)\t1\t{}\t1\t.save\t1\tsave\t1\tglobal\t1\t{}\t3\tresult;output-plan;run-artifact\n",
+            save_line, save_line
         )
     );
     assert_eq!(
@@ -2037,8 +2039,8 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         op_execution.output_plan_artifact_csv,
         format!(
-            "Analysis,Directive,ResultColumns,ResultColumnList,OutputProbes,OutputProbeList,OutputDirectives,OutputDirectiveList,OutputDirectiveKinds,OutputDirectiveKindList,OutputDirectiveAnalysisKinds,OutputDirectiveAnalysisKindList,OutputDirectiveLines,OutputDirectiveLineList,Tables,TableList\nop,.op,2,Index;V(mid),1,V(mid),1,.save,1,save,1,global,1,{},3,result;output-plan;run-artifact\n",
-            save_line
+            "Analysis,Directive,ResultColumns,ResultColumnList,OutputProbes,OutputProbeList,OutputProbeLines,OutputProbeLineList,OutputDirectives,OutputDirectiveList,OutputDirectiveKinds,OutputDirectiveKindList,OutputDirectiveAnalysisKinds,OutputDirectiveAnalysisKindList,OutputDirectiveLines,OutputDirectiveLineList,Tables,TableList\nop,.op,2,Index;V(mid),1,V(mid),1,{},1,.save,1,save,1,global,1,{},3,result;output-plan;run-artifact\n",
+            save_line, save_line
         )
     );
     assert_eq!(
@@ -2066,6 +2068,12 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
         Some("global")
     );
     let save_line_list = save_line.to_string();
+    assert_eq!(
+        op_execution.output_plan_artifact_records[0]
+            .get("OutputProbeLineList")
+            .map(String::as_str),
+        Some(save_line_list.as_str())
+    );
     assert_eq!(
         op_execution.output_plan_artifact_records[0]
             .get("OutputDirectiveLineList")
@@ -2295,10 +2303,20 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
         vec!["global".to_string(), "dc".to_string()]
     );
     let dc_output_directive_lines = vec![save_line, probe_dc_line, print_dc_line];
+    let dc_output_probe_lines = vec![save_line, probe_dc_line];
+    assert_eq!(
+        dc_execution.output_plan_artifacts[0].output_probe_lines,
+        dc_output_probe_lines
+    );
     assert_eq!(
         dc_execution.output_plan_artifacts[0].output_directive_lines,
         dc_output_directive_lines
     );
+    let dc_output_probe_line_list = dc_output_probe_lines
+        .iter()
+        .map(usize::to_string)
+        .collect::<Vec<_>>()
+        .join(";");
     let dc_output_directive_line_list = dc_output_directive_lines
         .iter()
         .map(usize::to_string)
@@ -2309,6 +2327,12 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
             .get("OutputDirectiveAnalysisKindList")
             .map(String::as_str),
         Some("global;dc")
+    );
+    assert_eq!(
+        dc_execution.output_plan_artifact_records[0]
+            .get("OutputProbeLineList")
+            .map(String::as_str),
+        Some(dc_output_probe_line_list.as_str())
     );
     assert_eq!(
         dc_execution.output_plan_artifact_records[0]
@@ -2447,6 +2471,10 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     );
     let ac_output_directive_lines = vec![save_line, plot_ac_line];
     assert_eq!(
+        ac_execution.output_plan_artifacts[0].output_probe_lines,
+        vec![save_line]
+    );
+    assert_eq!(
         ac_execution.output_plan_artifacts[0].output_directive_lines,
         ac_output_directive_lines
     );
@@ -2554,6 +2582,10 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(tran_execution.output_directives, vec![".save".to_string()]);
     assert_eq!(
         tran_execution.output_plan_artifacts[0].output_directive_lines,
+        vec![save_line]
+    );
+    assert_eq!(
+        tran_execution.output_plan_artifacts[0].output_probe_lines,
         vec![save_line]
     );
     assert_eq!(

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Expose selected output probe source line inventories in `runDeckAnalysis`
+  output-plan artifacts aligned with selected output-probe inventories, with
+  stable table, CSV, compact JSON, and header-keyed record exports, matching
+  Python and Rust.
 - Expose selected output directive source line inventories in
   `runDeckAnalysis` output-plan artifacts beside directive scope inventories,
   with stable table, CSV, compact JSON, and header-keyed record exports,

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -96,9 +96,10 @@ table count/name list, output probes, and output directives that produced the
 table, plus selected `.measure` results and
 a stable measurement table for `.dc`, `.ac`, and `.tran` executions.
 Execution `outputPlanArtifacts` summarize the selected result columns, output
-probes, output directives, normalized output directive kinds, normalized
-directive analysis scopes, selected output directive source lines, and stable
-table names with table, CSV, compact JSON, and header-keyed record exports.
+probes, selected output probe source lines, output directives, normalized
+output directive kinds, normalized directive analysis scopes, selected output
+directive source lines, and stable table names with table, CSV, compact JSON,
+and header-keyed record exports.
 Execution `tableArtifacts` preserve the same order as `tables` and carry each
 stable table's text, CSV, compact JSON, and header-keyed records.
 The `output-plan` entry in `tableArtifacts` carries the same

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -723,6 +723,8 @@ export interface DeckOutputPlanArtifact {
   readonly resultColumns: readonly string[];
   readonly outputProbeCount: number;
   readonly outputProbes: readonly string[];
+  readonly outputProbeLineCount: number;
+  readonly outputProbeLines: readonly number[];
   readonly outputDirectiveCount: number;
   readonly outputDirectives: readonly string[];
   readonly outputDirectiveKindCount: number;
@@ -3467,6 +3469,33 @@ export function selectDeckOutputProbes(netlist: string, analysis: string): strin
       }
       seen.add(key);
       selected.push(probe);
+    }
+  }
+  return selected;
+}
+
+export function selectDeckOutputProbeLines(netlist: string, analysis: string): number[] {
+  const summary = resolveDeckOutputs(netlist);
+  if (summary.diagnostics.length > 0) {
+    const diagnostic = summary.diagnostics[0];
+    throw invalidElement(
+      "selectDeckOutputProbeLines",
+      `line ${diagnostic.lineNumber}: ${diagnostic.message}`,
+    );
+  }
+  const selected: number[] = [];
+  const seen = new Set<string>();
+  for (const selection of summary.selections) {
+    if (selection.analysis !== undefined && !deckOutputAnalysisMatches(selection.analysis, analysis)) {
+      continue;
+    }
+    for (const probe of selection.probes) {
+      const key = deckOutputProbeKey(probe);
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      selected.push(selection.lineNumber);
     }
   }
   return selected;
@@ -8367,6 +8396,7 @@ function deckOutputPlanArtifacts(
   plan: DeckAnalysisPlan,
   resultColumns: readonly string[],
   outputProbes: readonly string[],
+  outputProbeLines: readonly number[],
   outputDirectives: readonly string[],
   outputDirectiveAnalysisKinds: readonly string[],
   outputDirectiveLines: readonly number[],
@@ -8381,6 +8411,8 @@ function deckOutputPlanArtifacts(
       resultColumns: [...resultColumns],
       outputProbeCount: outputProbes.length,
       outputProbes: [...outputProbes],
+      outputProbeLineCount: outputProbeLines.length,
+      outputProbeLines: [...outputProbeLines],
       outputDirectiveCount: outputDirectives.length,
       outputDirectives: [...outputDirectives],
       outputDirectiveKindCount: outputDirectiveKinds.length,
@@ -8421,6 +8453,8 @@ const DECK_OUTPUT_PLAN_ARTIFACT_COLUMNS = [
   "ResultColumnList",
   "OutputProbes",
   "OutputProbeList",
+  "OutputProbeLines",
+  "OutputProbeLineList",
   "OutputDirectives",
   "OutputDirectiveList",
   "OutputDirectiveKinds",
@@ -8441,6 +8475,8 @@ function deckOutputPlanArtifactCells(artifact: DeckOutputPlanArtifact): string[]
     artifact.resultColumns.join(";"),
     String(artifact.outputProbeCount),
     artifact.outputProbes.join(";"),
+    String(artifact.outputProbeLineCount),
+    artifact.outputProbeLines.map(String).join(";"),
     String(artifact.outputDirectiveCount),
     artifact.outputDirectives.join(";"),
     String(artifact.outputDirectiveKindCount),
@@ -8498,6 +8534,7 @@ function deckOutputPlanArtifactBundle(
   plan: DeckAnalysisPlan,
   resultTable: string,
   outputProbes: readonly string[],
+  outputProbeLines: readonly number[],
   outputDirectives: readonly string[],
   outputDirectiveAnalysisKinds: readonly string[],
   outputDirectiveLines: readonly number[],
@@ -8513,6 +8550,7 @@ function deckOutputPlanArtifactBundle(
     plan,
     deckTableColumns(resultTable),
     outputProbes,
+    outputProbeLines,
     outputDirectives,
     outputDirectiveAnalysisKinds,
     outputDirectiveLines,
@@ -8603,6 +8641,7 @@ function deckTableArtifacts(
   controlPolicySummaryArtifacts: readonly DeckControlPolicySummaryArtifact[],
   controlPolicySummaryArtifactTable: string,
   outputProbes: readonly string[],
+  outputProbeLines: readonly number[],
   outputDirectives: readonly string[],
   outputDirectiveAnalysisKinds: readonly string[],
   outputDirectiveLines: readonly number[],
@@ -8627,6 +8666,7 @@ function deckTableArtifacts(
     plan,
     resultTable,
     outputProbes,
+    outputProbeLines,
     outputDirectives,
     outputDirectiveAnalysisKinds,
     outputDirectiveLines,
@@ -9284,6 +9324,7 @@ export function runDeckAnalysis(
     const measurements: ProbeMeasurement[] = [];
     const fourier: FourierResult[] = [];
     const outputProbes = selectDeckOutputProbes(netlist, plan.analysis);
+    const outputProbeLines = selectDeckOutputProbeLines(netlist, plan.analysis);
     const outputDirectives = selectDeckOutputDirectives(netlist, plan.analysis);
     const outputDirectiveAnalysisKinds = selectDeckOutputDirectiveAnalysisKinds(
       netlist,
@@ -9309,6 +9350,7 @@ export function runDeckAnalysis(
       plan,
       table,
       outputProbes,
+      outputProbeLines,
       outputDirectives,
       outputDirectiveAnalysisKinds,
       outputDirectiveLines,
@@ -9330,6 +9372,7 @@ export function runDeckAnalysis(
       controlPolicySummaryArtifacts,
       controlPolicySummaryArtifactTable,
       outputProbes,
+      outputProbeLines,
       outputDirectives,
       outputDirectiveAnalysisKinds,
       outputDirectiveLines,
@@ -9415,6 +9458,7 @@ export function runDeckAnalysis(
     selectDeckFourierCardsForAnalysis(netlist, plan.analysis);
     const fourier: FourierResult[] = [];
     const outputProbes = selectDeckOutputProbes(netlist, plan.analysis);
+    const outputProbeLines = selectDeckOutputProbeLines(netlist, plan.analysis);
     const outputDirectives = selectDeckOutputDirectives(netlist, plan.analysis);
     const outputDirectiveAnalysisKinds = selectDeckOutputDirectiveAnalysisKinds(
       netlist,
@@ -9441,6 +9485,7 @@ export function runDeckAnalysis(
       plan,
       table,
       outputProbes,
+      outputProbeLines,
       outputDirectives,
       outputDirectiveAnalysisKinds,
       outputDirectiveLines,
@@ -9462,6 +9507,7 @@ export function runDeckAnalysis(
       controlPolicySummaryArtifacts,
       controlPolicySummaryArtifactTable,
       outputProbes,
+      outputProbeLines,
       outputDirectives,
       outputDirectiveAnalysisKinds,
       outputDirectiveLines,
@@ -9558,6 +9604,7 @@ export function runDeckAnalysis(
     selectDeckFourierCardsForAnalysis(netlist, plan.analysis);
     const fourier: FourierResult[] = [];
     const outputProbes = selectDeckOutputProbes(netlist, plan.analysis);
+    const outputProbeLines = selectDeckOutputProbeLines(netlist, plan.analysis);
     const outputDirectives = selectDeckOutputDirectives(netlist, plan.analysis);
     const outputDirectiveAnalysisKinds = selectDeckOutputDirectiveAnalysisKinds(
       netlist,
@@ -9584,6 +9631,7 @@ export function runDeckAnalysis(
       plan,
       table,
       outputProbes,
+      outputProbeLines,
       outputDirectives,
       outputDirectiveAnalysisKinds,
       outputDirectiveLines,
@@ -9605,6 +9653,7 @@ export function runDeckAnalysis(
       controlPolicySummaryArtifacts,
       controlPolicySummaryArtifactTable,
       outputProbes,
+      outputProbeLines,
       outputDirectives,
       outputDirectiveAnalysisKinds,
       outputDirectiveLines,
@@ -9696,6 +9745,7 @@ export function runDeckAnalysis(
       selectDeckFourierCardsForAnalysis(netlist, plan.analysis),
     );
     const outputProbes = selectDeckOutputProbes(netlist, plan.analysis);
+    const outputProbeLines = selectDeckOutputProbeLines(netlist, plan.analysis);
     const outputDirectives = selectDeckOutputDirectives(netlist, plan.analysis);
     const outputDirectiveAnalysisKinds = selectDeckOutputDirectiveAnalysisKinds(
       netlist,
@@ -9722,6 +9772,7 @@ export function runDeckAnalysis(
       plan,
       table,
       outputProbes,
+      outputProbeLines,
       outputDirectives,
       outputDirectiveAnalysisKinds,
       outputDirectiveLines,
@@ -9743,6 +9794,7 @@ export function runDeckAnalysis(
       controlPolicySummaryArtifacts,
       controlPolicySummaryArtifactTable,
       outputProbes,
+      outputProbeLines,
       outputDirectives,
       outputDirectiveAnalysisKinds,
       outputDirectiveLines,
@@ -9823,6 +9875,7 @@ export function runDeckAnalysis(
     const measurements: ProbeMeasurement[] = [];
     const fourier: FourierResult[] = [];
     const outputProbes = [`V(${outputNode})`];
+    const outputProbeLines: number[] = [];
     const outputDirectives: string[] = [];
     const outputDirectiveAnalysisKinds: string[] = [];
     const outputDirectiveLines: number[] = [];
@@ -9847,6 +9900,7 @@ export function runDeckAnalysis(
       plan,
       table,
       outputProbes,
+      outputProbeLines,
       outputDirectives,
       outputDirectiveAnalysisKinds,
       outputDirectiveLines,
@@ -9868,6 +9922,7 @@ export function runDeckAnalysis(
       controlPolicySummaryArtifacts,
       controlPolicySummaryArtifactTable,
       outputProbes,
+      outputProbeLines,
       outputDirectives,
       outputDirectiveAnalysisKinds,
       outputDirectiveLines,
@@ -9947,6 +10002,7 @@ export function runDeckAnalysis(
     const measurements: ProbeMeasurement[] = [];
     const fourier: FourierResult[] = [];
     const outputProbes = [`V(${outputNode})`];
+    const outputProbeLines: number[] = [];
     const outputDirectives: string[] = [];
     const outputDirectiveAnalysisKinds: string[] = [];
     const outputDirectiveLines: number[] = [];
@@ -9971,6 +10027,7 @@ export function runDeckAnalysis(
       plan,
       table,
       outputProbes,
+      outputProbeLines,
       outputDirectives,
       outputDirectiveAnalysisKinds,
       outputDirectiveLines,
@@ -9992,6 +10049,7 @@ export function runDeckAnalysis(
       controlPolicySummaryArtifacts,
       controlPolicySummaryArtifactTable,
       outputProbes,
+      outputProbeLines,
       outputDirectives,
       outputDirectiveAnalysisKinds,
       outputDirectiveLines,
@@ -10081,6 +10139,7 @@ export function runDeckAnalysis(
     const measurements: ProbeMeasurement[] = [];
     const fourier: FourierResult[] = [];
     const outputProbes = [`V(${outputNode})`];
+    const outputProbeLines: number[] = [];
     const outputDirectives: string[] = [];
     const outputDirectiveAnalysisKinds: string[] = [];
     const outputDirectiveLines: number[] = [];
@@ -10105,6 +10164,7 @@ export function runDeckAnalysis(
       plan,
       table,
       outputProbes,
+      outputProbeLines,
       outputDirectives,
       outputDirectiveAnalysisKinds,
       outputDirectiveLines,
@@ -10126,6 +10186,7 @@ export function runDeckAnalysis(
       controlPolicySummaryArtifacts,
       controlPolicySummaryArtifactTable,
       outputProbes,
+      outputProbeLines,
       outputDirectives,
       outputDirectiveAnalysisKinds,
       outputDirectiveLines,

--- a/code/packages/typescript/spice-engine/tests/compatibility.test.ts
+++ b/code/packages/typescript/spice-engine/tests/compatibility.test.ts
@@ -15,6 +15,7 @@ import {
   resolveDeckParameters,
   resolveDeckSources,
   selectDeckAnalysisPlan,
+  selectDeckOutputProbeLines,
   selectDeckOutputProbes,
 } from "../src/index.js";
 
@@ -855,6 +856,17 @@ V1 in 0 DC 1
         "transient",
       ),
     ).toStrictEqual(["V(out)", "I(V1)", "V(clk)", "I(V2)", "V(extra)"]);
+    expect(
+      selectDeckOutputProbeLines(
+        [
+          ".save V(out)",
+          ".print dc V(out) I(V1)",
+          ".probe ac V(freq)",
+          ".end",
+        ].join("\n"),
+        "dc",
+      ),
+    ).toStrictEqual([1, 2]);
   });
 
   it("reports invalid .save, .probe, .print, and .plot output cards", () => {
@@ -886,6 +898,7 @@ V1 in 0 DC 1
     ]);
     expect(summary.selections[0].probes).toStrictEqual(["V(out)"]);
     expect(() => selectDeckOutputProbes("\n.save\n.end\n", "dc")).toThrow(/line 2/);
+    expect(() => selectDeckOutputProbeLines("\n.save\n.end\n", "dc")).toThrow(/line 2/);
   });
 
   it("extracts supported deck analysis cards", () => {

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -1553,6 +1553,8 @@ describe("transient", () => {
         ResultColumnList: "Index;V(mid)",
         OutputProbes: "1",
         OutputProbeList: "V(mid)",
+        OutputProbeLines: "1",
+        OutputProbeLineList: String(saveLine),
         OutputDirectives: "1",
         OutputDirectiveList: ".save",
         OutputDirectiveKinds: "1",
@@ -1574,6 +1576,8 @@ describe("transient", () => {
       resultColumns: ["Index", "V(mid)"],
       outputProbeCount: 1,
       outputProbes: ["V(mid)"],
+      outputProbeLineCount: 1,
+      outputProbeLines: [saveLine],
       outputDirectiveCount: 1,
       outputDirectives: [".save"],
       outputDirectiveKindCount: 1,
@@ -1586,15 +1590,15 @@ describe("transient", () => {
       tables: ["result", "output-plan", "run-artifact"],
     });
     expect(opExecution.outputPlanArtifactTable).toBe(
-      "Analysis\tDirective\tResultColumns\tResultColumnList\tOutputProbes\tOutputProbeList\tOutputDirectives\tOutputDirectiveList\tOutputDirectiveKinds\tOutputDirectiveKindList\tOutputDirectiveAnalysisKinds\tOutputDirectiveAnalysisKindList\tOutputDirectiveLines\tOutputDirectiveLineList\tTables\tTableList\n" +
-        `op\t.op\t2\tIndex;V(mid)\t1\tV(mid)\t1\t.save\t1\tsave\t1\tglobal\t1\t${saveLine}\t3\tresult;output-plan;run-artifact\n`,
+      "Analysis\tDirective\tResultColumns\tResultColumnList\tOutputProbes\tOutputProbeList\tOutputProbeLines\tOutputProbeLineList\tOutputDirectives\tOutputDirectiveList\tOutputDirectiveKinds\tOutputDirectiveKindList\tOutputDirectiveAnalysisKinds\tOutputDirectiveAnalysisKindList\tOutputDirectiveLines\tOutputDirectiveLineList\tTables\tTableList\n" +
+        `op\t.op\t2\tIndex;V(mid)\t1\tV(mid)\t1\t${saveLine}\t1\t.save\t1\tsave\t1\tglobal\t1\t${saveLine}\t3\tresult;output-plan;run-artifact\n`,
     );
     expect(opExecution.outputPlanArtifactTable).toBe(
       formatDeckOutputPlanArtifactTable(opExecution.outputPlanArtifacts),
     );
     expect(opExecution.outputPlanArtifactCsv).toBe(
-      "Analysis,Directive,ResultColumns,ResultColumnList,OutputProbes,OutputProbeList,OutputDirectives,OutputDirectiveList,OutputDirectiveKinds,OutputDirectiveKindList,OutputDirectiveAnalysisKinds,OutputDirectiveAnalysisKindList,OutputDirectiveLines,OutputDirectiveLineList,Tables,TableList\n" +
-        `op,.op,2,Index;V(mid),1,V(mid),1,.save,1,save,1,global,1,${saveLine},3,result;output-plan;run-artifact\n`,
+      "Analysis,Directive,ResultColumns,ResultColumnList,OutputProbes,OutputProbeList,OutputProbeLines,OutputProbeLineList,OutputDirectives,OutputDirectiveList,OutputDirectiveKinds,OutputDirectiveKindList,OutputDirectiveAnalysisKinds,OutputDirectiveAnalysisKindList,OutputDirectiveLines,OutputDirectiveLineList,Tables,TableList\n" +
+        `op,.op,2,Index;V(mid),1,V(mid),1,${saveLine},1,.save,1,save,1,global,1,${saveLine},3,result;output-plan;run-artifact\n`,
     );
     expect(opExecution.outputPlanArtifactCsv).toBe(
       formatDeckOutputPlanArtifactCsv(opExecution.outputPlanArtifacts),
@@ -1807,11 +1811,18 @@ describe("transient", () => {
       "dc",
     ]);
     const dcOutputDirectiveLines = [saveLine, probeDcLine, printDcLine];
+    const dcOutputProbeLines = [saveLine, probeDcLine];
+    expect(dcExecution.outputPlanArtifacts[0]?.outputProbeLines).toEqual(
+      dcOutputProbeLines,
+    );
     expect(dcExecution.outputPlanArtifacts[0]?.outputDirectiveLines).toEqual(
       dcOutputDirectiveLines,
     );
     expect(dcExecution.outputPlanArtifactRecords[0]?.OutputDirectiveAnalysisKindList).toBe(
       "global;dc",
+    );
+    expect(dcExecution.outputPlanArtifactRecords[0]?.OutputProbeLineList).toBe(
+      dcOutputProbeLines.join(";"),
     );
     expect(dcExecution.outputPlanArtifactRecords[0]?.OutputDirectiveLineList).toBe(
       dcOutputDirectiveLines.join(";"),
@@ -1892,6 +1903,7 @@ describe("transient", () => {
       "ac",
     ]);
     const acOutputDirectiveLines = [saveLine, plotAcLine];
+    expect(acExecution.outputPlanArtifacts[0]?.outputProbeLines).toEqual([saveLine]);
     expect(acExecution.outputPlanArtifacts[0]?.outputDirectiveLines).toEqual(
       acOutputDirectiveLines,
     );
@@ -1951,6 +1963,7 @@ describe("transient", () => {
     const tranExecution = runDeckAnalysis(circuit, netlist, "tran");
     expect(tranExecution.outputProbes).toEqual(["V(mid)"]);
     expect(tranExecution.outputDirectives).toEqual([".save"]);
+    expect(tranExecution.outputPlanArtifacts[0]?.outputProbeLines).toEqual([saveLine]);
     expect(tranExecution.outputPlanArtifacts[0]?.outputDirectiveLines).toEqual([saveLine]);
     expect(tranExecution.analysisDirectives).toEqual([".tran"]);
     expect(tranExecution.tableCount).toBe(4);

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -141,7 +141,9 @@ downstream tools to compare.
      distinguish global `.save` / `.probe` selections from scoped `.probe`,
      `.print`, and `.plot` selections in the same exports, and selected
      output-plan artifacts now also expose selected output directive source
-     line counts/lists beside those directive provenance inventories.
+     line counts/lists beside those directive provenance inventories, and
+     selected output-plan artifacts now also expose selected output probe
+     source line counts/lists aligned with the selected output-probe list.
    - Expand remaining deck-controlled analyses toward full SPICE compatibility
      while keeping unsupported control-flow diagnostics explicit.
 
@@ -1188,6 +1190,16 @@ downstream tools to compare.
     - Table, CSV, compact JSON, and host-native record exports make selected
       `.save`, `.probe`, `.print`, and `.plot` provenance traceable back to
       deck source lines without reparsing directive cards.
+
+109. Deck output-plan probe source line artifacts.
+    - Status: completed in this deck output-plan probe source line artifact
+      slice.
+    - Python, Rust, and TypeScript selected output-plan artifacts now expose
+      selected output probe source line counts/lists aligned with selected
+      output-probe inventories.
+    - Table, CSV, compact JSON, and host-native record exports make each
+      deduplicated selected output probe traceable to the deck source line that
+      first selected it for that analysis.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- add cross-language output-plan probe source-line selectors for deduplicated selected probes
- expose OutputProbeLines / OutputProbeLineList in Python, Rust, and TypeScript output-plan artifacts
- update package docs/changelogs and mark the completed SPICE plan slice

## Verification
- PYTHONPATH=code/packages/python/spice-engine/src:code/packages/python/mosfet-models/src:code/packages/python/device-physics/src /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python -m pytest code/packages/python/spice-engine/tests/test_compatibility.py code/packages/python/spice-engine/tests/test_engine.py -q
- cargo test -p spice-engine
- npm test -- compatibility.test.ts transient.test.ts
- npm run build
- npm test
- git diff --check