### PR TITLE
feat(latex): math grammar (LTX01 L2)

### DIFF
--- a/code/packages/rust/latex/CHANGELOG.md
+++ b/code/packages/rust/latex/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to the full-fidelity LaTeX parser crate.
 
+## [0.3.0] — 2026-06-26
+
+### Added — LTX01 L2: math grammar
+
+- **`parse_math(&str) -> Result<MathNode, ParseError>`** — a precedence-climbing parser
+  over a math island's raw inner source (the string L1 keeps in `Node::Math`). Re-uses the
+  L0 `tokenize` and filters space/par/comment tokens, then climbs:
+  relations (`= ≠ < ≤ > ≥ \approx \equiv`) < add/sub (`+ - \pm \mp`) < mul/div
+  (`\times \cdot \div /` **and implicit multiplication** via adjacency — `2x`, `\pi r`,
+  `(a)(b)`) < unary `± ∓` < scripts (`^`/`_`, right-assoc) < atoms.
+- **`MathNode` AST** (`math.rs`): `Num`, `Sym`, `Bin`, `Unary`, `Frac`/`\dfrac`/`\tfrac`,
+  `Binom`, `Root { degree, radicand }` (`\sqrt[n]{}`), `Script { base, sub, sup }`,
+  `Call { func, arg }` (named functions `\sin \log …`), `BigOp { op, lower, upper, body }`
+  (`\sum \prod \int \lim` with bound scripts), `Accent` (`\hat \bar \vec …`),
+  `Fenced { left, body, right }` (`\left( … \right)`, `\langle`, `|`, …), `Text`, and
+  `Rel`. `{…}` groups are **transparent** (grouping only — they do not appear as nodes).
+- **`MathNode::to_latex`** — precedence-aware round-trip: `parse_math(&m.to_latex()) == m`.
+  Children below the parent's precedence are wrapped in invisible `{…}` so the re-parse
+  re-associates identically.
+- **`Node::parsed_math`** — parses a `Node::Math` island on demand; the L1 structural tree
+  is unchanged (its round-trip stays intact).
+- Total / panic-free / spanned; recursion is **depth-guarded** (`MAX_DEPTH`) so adversarial
+  nesting (e.g. thousands of `(`) returns a spanned error instead of overflowing the stack.
+- +15 math tests incl. the worked corpus (`\frac{12 \times 15}{3}`, `2^{10}`,
+  `\sqrt[3]{27}`, `\sum_{i=1}^{n} i`, `\left(\frac{a}{b}\right)^2`), a round-trip corpus,
+  relations/functions, and the deep-nesting bound; clippy `-D warnings` clean, no `unsafe`.
+
 ## [0.2.0] — 2026-06-26
 
 ### Added — LTX01 L1: structural document parser

--- a/code/packages/rust/latex/Cargo.toml
+++ b/code/packages/rust/latex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latex"
-version = "0.1.0"
+version = "0.3.0"
 edition = "2021"
 description = "A full-fidelity LaTeX parser (documents and math): a catcode-driven, text-mode-primary tokenizer and (in later layers) a structural + math parser producing a faithful AST. Standalone and reusable; will also implement the math-frontend MathFrontend trait."
 license = "MIT"

--- a/code/packages/rust/latex/README.md
+++ b/code/packages/rust/latex/README.md
@@ -31,8 +31,8 @@ with a **text-mode-primary** mode stack (LaTeX starts in text mode; math is ente
 | Layer | Contents | Status |
 |-------|----------|--------|
 | **L0 tokenizer** | catcode state machine → flat `Token` stream w/ byte spans | ✅ |
-| **L1 structural** | groups, `\cmd[opt]{arg}`, `\begin{env}…\end{env}`, text runs, raw math islands, `to_latex()` round-trip | ✅ this release |
-| L2 math | full math AST (frac, scripts, big ops, accents, `\left\right`, …) | ⏳ |
+| **L1 structural** | groups, `\cmd[opt]{arg}`, `\begin{env}…\end{env}`, text runs, raw math islands, `to_latex()` round-trip | ✅ |
+| **L2 math** | math AST (frac, binom, roots, scripts, big ops, functions, accents, `\left\right` fences, relations), precedence-climbing parser, `to_latex()` round-trip | ✅ this release |
 | L3 environments | matrices / tabular / lists (`&`, `\\`) | ⏳ |
 | L4 macros | `\newcommand`/`\def` + expansion (bounded) | ⏳ |
 | L5 text breadth | sectioning, fonts, accents, `\verb`, refs | ⏳ |
@@ -50,8 +50,31 @@ assert!(doc.iter().any(|n| matches!(n, Node::Math { .. })));    // $x$
 assert_eq!(parse(&latex::document_to_latex(&doc)).unwrap(), doc);
 ```
 
+### Math (L2)
+
+Each `$…$` island keeps its **raw** inner source at L1; the math grammar parses it on
+demand into a `MathNode` tree with full operator precedence:
+
+```rust
+use latex::{parse_math, MathNode};
+
+// fractions, big operators with bounds, roots, scripts, fences — all supported
+let m = parse_math(r"\sum_{i=1}^{n} i").unwrap();
+assert!(matches!(m, MathNode::BigOp { .. }));
+
+// precedence-aware round-trip: re-parsing the rendered AST yields the same AST
+let e = parse_math(r"\left(\frac{a}{b}\right)^2").unwrap();
+assert_eq!(parse_math(&e.to_latex()).unwrap(), e);
+
+// parse an island found in a document directly
+let doc = parse(r"area is $\pi r^2$").unwrap();
+let area = doc.iter().find_map(|n| n.parsed_math()).unwrap().unwrap();
+assert!(matches!(area, MathNode::Bin(..)));   // π · r²  (implicit multiplication)
+```
+
 The low-level `tokenize` is also public. Tokens and errors carry half-open byte `Span`s;
-both `parse` and `tokenize` return spanned errors rather than panicking.
+all of `parse`, `parse_math`, and `tokenize` return spanned errors rather than panicking,
+and recursion is depth-guarded so adversarial nesting errors instead of overflowing.
 
 ## Tests
 

--- a/code/packages/rust/latex/src/ast.rs
+++ b/code/packages/rust/latex/src/ast.rs
@@ -50,6 +50,16 @@ pub enum Node {
 }
 
 impl Node {
+    /// If this is a [`Node::Math`] island, parse its raw content into the math AST
+    /// ([`crate::MathNode`]); otherwise `None`. The structural tree is unchanged (L1
+    /// round-trip intact) — parsed math is produced on demand here.
+    pub fn parsed_math(&self) -> Option<Result<crate::MathNode, crate::ParseError>> {
+        match self {
+            Node::Math { content, .. } => Some(crate::parse_math(content)),
+            _ => None,
+        }
+    }
+
     /// Render this node back to LaTeX source. `parse(&node.to_latex()) == [node]` up to the
     /// normalizations noted in the module docs.
     pub fn to_latex(&self) -> String {

--- a/code/packages/rust/latex/src/lib.rs
+++ b/code/packages/rust/latex/src/lib.rs
@@ -21,21 +21,29 @@
 //! 2. [`parse`] — the **structural** document parser: text, groups, commands
 //!    (`\cmd[opt]{arg}`), environments (`\begin…\end`), and raw math islands → a [`Node`]
 //!    tree, with [`Node::to_latex`] round-tripping. **Implemented (this release).**
-//! 3. `parse_math` — the math grammar over each island's raw content. *(Later layer.)*
+//! 3. [`parse_math`] — the **math grammar** over each island's raw content: fractions,
+//!    roots, scripts, big operators, functions, fenced groups, relations →
+//!    [`MathNode`], with precedence and [`MathNode::to_latex`] round-tripping.
+//!    [`Node::parsed_math`] parses a [`Node::Math`] island on demand. **Implemented
+//!    (this release).**
 //!
 //! ## Example
 //!
 //! ```
-//! use latex::{parse, Node};
+//! use latex::{parse, parse_math, Node, MathNode};
 //! let doc = parse(r"Let $x$ be \textbf{bold}.").unwrap();
 //! assert!(matches!(doc[0], Node::Text(_)));
 //! assert!(doc.iter().any(|n| matches!(n, Node::Math { .. })));
+//!
+//! let m = parse_math(r"\frac{12 \times 15}{3}").unwrap();
+//! assert!(matches!(m, MathNode::Frac(..)));
 //! ```
 
 pub mod catcode;
 mod ast;
 mod error;
 mod lexer;
+mod math;
 mod parser;
 mod token;
 
@@ -43,5 +51,6 @@ pub use ast::{document_to_latex, Node};
 pub use catcode::{catcode, Catcode};
 pub use error::{LexError, ParseError};
 pub use lexer::tokenize;
+pub use math::{parse_math, MBinOp, MRelOp, MUnOp, MathNode};
 pub use parser::parse;
 pub use token::{Span, Token, TokenKind};

--- a/code/packages/rust/latex/src/math.rs
+++ b/code/packages/rust/latex/src/math.rs
@@ -317,17 +317,36 @@ impl<'a> MathParser<'a> {
     }
 
     fn parse_unary(&mut self) -> Result<MathNode, ParseError> {
-        match &self.peek().kind {
-            TokenKind::Char('+') => {
-                self.bump();
-                Ok(MathNode::Unary(MUnOp::Pos, Box::new(self.parse_unary()?)))
+        // Collect a run of leading signs *iteratively* (not by self-recursion): a chain
+        // like `----x` is driven directly by input length, so recursing one stack frame
+        // per sign would let adversarial input (thousands of `-`) overflow the stack
+        // before any depth guard fires. We gather the signs, parse one operand, then fold
+        // the operators back on from the inside out.
+        let mut ops = Vec::new();
+        loop {
+            match &self.peek().kind {
+                TokenKind::Char('+') => {
+                    self.bump();
+                    ops.push(MUnOp::Pos);
+                }
+                TokenKind::Char('-') => {
+                    self.bump();
+                    ops.push(MUnOp::Neg);
+                }
+                _ => break,
             }
-            TokenKind::Char('-') => {
-                self.bump();
-                Ok(MathNode::Unary(MUnOp::Neg, Box::new(self.parse_unary()?)))
-            }
-            _ => self.parse_postfix(),
+            // The sign run is part of one nesting level; guard it so a multi-megabyte
+            // string of signs errors instead of allocating without bound.
+            self.enter()?;
         }
+        let mut node = self.parse_postfix()?;
+        // We `enter()`ed once per sign above; balance the depth counter back out now that
+        // the run is fully consumed (the operand parse has its own guarded descent).
+        self.depth -= ops.len();
+        for op in ops.into_iter().rev() {
+            node = MathNode::Unary(op, Box::new(node));
+        }
+        Ok(node)
     }
 
     /// An atom plus any trailing `^`/`_` scripts.
@@ -945,6 +964,18 @@ mod tests {
     fn deep_nesting_is_bounded() {
         let deep = "(".repeat(5000);
         assert!(parse_math(&deep).is_err());
+    }
+
+    #[test]
+    fn long_sign_chain_is_bounded_not_overflow() {
+        // A run of leading signs is driven by input length; it must error (depth-guarded)
+        // rather than recurse a stack frame per sign and overflow.
+        let signs = "-".repeat(100_000);
+        assert!(parse_math(&format!("{signs}1")).is_err());
+        // A short, legal sign run still parses and round-trips.
+        assert!(matches!(parse_math("--x").unwrap(), MathNode::Unary(MUnOp::Neg, _)));
+        round_trips("-x");
+        round_trips("--x");
     }
 
     #[test]

--- a/code/packages/rust/latex/src/math.rs
+++ b/code/packages/rust/latex/src/math.rs
@@ -1,0 +1,970 @@
+//! The math grammar (L2) — parses the **raw content of a math island**
+//! ([`crate::Node::Math`]) into a [`MathNode`] tree.
+//!
+//! L1 keeps each `$…$` / `\[…\]` island as its exact inner source; this layer turns that
+//! source into structured mathematics: fractions, roots, scripts, big operators,
+//! functions, fenced groups, relations — with operator **precedence** resolved by a
+//! precedence-climbing parser.
+//!
+//! ## Precedence (low → high)
+//!
+//! ```text
+//!   relations  (=, <, >, \le, \ge, \ne, …)
+//!   add / sub  (+, -)
+//!   mul / div  (*, /, \times, \cdot, \div, \pm, \mp, AND implicit juxtaposition: 2x)
+//!   unary      (leading + / -)
+//!   scripts    (a^b, a_i — bind to the preceding atom)
+//!   atoms      (number, symbol, {group}, (fence), \frac, \sqrt, \sum, \sin, …)
+//! ```
+//!
+//! ## Round-trip
+//!
+//! Braces `{…}` are *invisible grouping*: the parser returns their inner node directly
+//! (no wrapper), and [`MathNode::to_latex`] re-inserts `{…}` only where precedence
+//! requires it. So `parse_math(&node.to_latex()) == node` (AST-equality). Visible
+//! delimiters `(…)`, `[…]`, `|…|`, and `\left…\right` are kept as [`MathNode::Fenced`].
+//!
+//! Total and panic-free: every malformed input yields a spanned [`ParseError`]; recursion
+//! is depth-guarded.
+
+use crate::error::ParseError;
+use crate::lexer::tokenize;
+use crate::token::{Token, TokenKind};
+
+// The precedence chain (relation→add→mul→unary→postfix→atom) descends several stack
+// frames per nesting level, and `enter()` fires twice per level (relation + atom). Keep
+// this conservative so the guard trips well within even a small (2 MB test-thread) stack
+// rather than overflowing — real math never nests anywhere near this deep.
+const MAX_DEPTH: usize = 128;
+
+/// Binary operators in math.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MBinOp {
+    Add,
+    Sub,
+    Mul,
+    Div,
+    Pow,
+    /// `\pm`
+    PlusMinus,
+    /// `\mp`
+    MinusPlus,
+}
+
+/// Unary prefix operators.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MUnOp {
+    Neg,
+    Pos,
+}
+
+/// Relational operators.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MRelOp {
+    Eq,
+    Ne,
+    Lt,
+    Le,
+    Gt,
+    Ge,
+    Approx,
+    Equiv,
+}
+
+/// A node in the math AST.
+#[derive(Debug, Clone, PartialEq)]
+pub enum MathNode {
+    /// A numeric literal (digits, optional single dot), kept as written.
+    Num(String),
+    /// A variable or named constant. A single ASCII letter (`x`) or a command-name symbol
+    /// (`pi`, `infty`, `alpha`); rendered `\pi` etc. when not a single ASCII char.
+    Sym(String),
+    Bin(MBinOp, Box<MathNode>, Box<MathNode>),
+    Unary(MUnOp, Box<MathNode>),
+    /// `\frac{A}{B}` (and `\dfrac`/`\tfrac`/`\cfrac`).
+    Frac(Box<MathNode>, Box<MathNode>),
+    /// `\binom{A}{B}`.
+    Binom(Box<MathNode>, Box<MathNode>),
+    /// `\sqrt[n]{x}` (`degree` is `None` for a square root).
+    Root {
+        degree: Option<Box<MathNode>>,
+        radicand: Box<MathNode>,
+    },
+    /// `base^sup_sub` — at least one of `sup`/`sub` is present.
+    Script {
+        base: Box<MathNode>,
+        sub: Option<Box<MathNode>>,
+        sup: Option<Box<MathNode>>,
+    },
+    /// A named function application: `\sin x`, `\ln(x)`.
+    Call { func: String, arg: Box<MathNode> },
+    /// A big operator with optional bound scripts: `\sum_{i=1}^{n} body`.
+    BigOp {
+        op: String,
+        lower: Option<Box<MathNode>>,
+        upper: Option<Box<MathNode>>,
+        body: Box<MathNode>,
+    },
+    /// An accent over its argument: `\hat{x}`, `\vec{v}`.
+    Accent { kind: String, body: Box<MathNode> },
+    /// A visibly-delimited group: `(…)`, `[…]`, `|…|`, or `\left…\right`.
+    Fenced {
+        left: String,
+        body: Box<MathNode>,
+        right: String,
+    },
+    /// Prose embedded in math: `\text{…}`, `\mathrm{…}`.
+    Text(String),
+    /// A relation: `a = b`, `x \le y`.
+    Rel(MRelOp, Box<MathNode>, Box<MathNode>),
+}
+
+/// Parse LaTeX math-mode source (the inner content of an island) into a [`MathNode`].
+pub fn parse_math(src: &str) -> Result<MathNode, ParseError> {
+    let raw = tokenize(src)?;
+    // Math mode ignores whitespace and comments; drop them up front (keep Eof).
+    let toks: Vec<Token> = raw
+        .into_iter()
+        .filter(|t| !matches!(t.kind, TokenKind::Space | TokenKind::Par | TokenKind::Comment(_)))
+        .collect();
+    let mut p = MathParser { toks: &toks, pos: 0, depth: 0 };
+    let node = p.parse_relation()?;
+    match &p.peek().kind {
+        TokenKind::Eof => Ok(node),
+        _ => {
+            let sp = p.peek().span;
+            Err(ParseError::new("unexpected trailing tokens in math", sp.start, sp.end))
+        }
+    }
+}
+
+// ---- command classification tables --------------------------------------------
+fn rel_op(name: &str) -> Option<MRelOp> {
+    Some(match name {
+        "le" | "leq" => MRelOp::Le,
+        "ge" | "geq" => MRelOp::Ge,
+        "ne" | "neq" => MRelOp::Ne,
+        "approx" => MRelOp::Approx,
+        "equiv" => MRelOp::Equiv,
+        _ => return None,
+    })
+}
+fn mul_op(name: &str) -> Option<MBinOp> {
+    Some(match name {
+        "times" | "cdot" | "ast" | "star" => MBinOp::Mul,
+        "div" => MBinOp::Div,
+        "pm" => MBinOp::PlusMinus,
+        "mp" => MBinOp::MinusPlus,
+        _ => return None,
+    })
+}
+fn is_frac(name: &str) -> bool {
+    matches!(name, "frac" | "dfrac" | "tfrac" | "cfrac")
+}
+fn is_binom(name: &str) -> bool {
+    matches!(name, "binom" | "dbinom" | "tbinom")
+}
+fn is_function(name: &str) -> bool {
+    matches!(
+        name,
+        "sin" | "cos" | "tan" | "cot" | "sec" | "csc" | "sinh" | "cosh" | "tanh"
+            | "arcsin" | "arccos" | "arctan" | "ln" | "log" | "exp" | "min" | "max"
+            | "gcd" | "lcm" | "det" | "dim" | "deg" | "arg"
+    )
+}
+fn is_bigop(name: &str) -> bool {
+    matches!(
+        name,
+        "sum" | "prod" | "int" | "oint" | "coprod" | "bigcup" | "bigcap" | "lim"
+    )
+}
+fn is_accent(name: &str) -> bool {
+    matches!(
+        name,
+        "hat" | "bar" | "vec" | "tilde" | "dot" | "ddot" | "overline" | "underline"
+            | "widehat" | "widetilde"
+    )
+}
+fn is_text(name: &str) -> bool {
+    matches!(
+        name,
+        "text" | "mathrm" | "mathbf" | "mathit" | "mathsf" | "mathtt" | "mathcal"
+            | "mathbb" | "operatorname"
+    )
+}
+
+/// The `_lower` and `^upper` bound scripts captured for a big operator.
+type BigOpScripts = (Option<Box<MathNode>>, Option<Box<MathNode>>);
+
+struct MathParser<'a> {
+    toks: &'a [Token],
+    pos: usize,
+    depth: usize,
+}
+
+impl<'a> MathParser<'a> {
+    fn peek(&self) -> &Token {
+        &self.toks[self.pos.min(self.toks.len() - 1)]
+    }
+    fn bump(&mut self) -> Token {
+        let t = self.toks[self.pos.min(self.toks.len() - 1)].clone();
+        if self.pos < self.toks.len() - 1 {
+            self.pos += 1;
+        }
+        t
+    }
+    fn err<T>(&self, msg: impl Into<String>) -> Result<T, ParseError> {
+        let sp = self.peek().span;
+        Err(ParseError::new(msg, sp.start, sp.end))
+    }
+    fn enter(&mut self) -> Result<(), ParseError> {
+        self.depth += 1;
+        if self.depth > MAX_DEPTH {
+            return self.err(format!("math nesting too deep (>{MAX_DEPTH})"));
+        }
+        Ok(())
+    }
+
+    // relations: lowest precedence, left-associative
+    fn parse_relation(&mut self) -> Result<MathNode, ParseError> {
+        self.enter()?;
+        let mut lhs = self.parse_add()?;
+        loop {
+            let op = match &self.peek().kind {
+                TokenKind::Char('=') => Some(MRelOp::Eq),
+                TokenKind::Char('<') => Some(MRelOp::Lt),
+                TokenKind::Char('>') => Some(MRelOp::Gt),
+                TokenKind::ControlWord(w) => rel_op(w),
+                _ => None,
+            };
+            match op {
+                Some(o) => {
+                    self.bump();
+                    let rhs = self.parse_add()?;
+                    lhs = MathNode::Rel(o, Box::new(lhs), Box::new(rhs));
+                }
+                None => break,
+            }
+        }
+        self.depth -= 1;
+        Ok(lhs)
+    }
+
+    fn parse_add(&mut self) -> Result<MathNode, ParseError> {
+        let mut lhs = self.parse_mul()?;
+        loop {
+            let op = match &self.peek().kind {
+                TokenKind::Char('+') => Some(MBinOp::Add),
+                TokenKind::Char('-') => Some(MBinOp::Sub),
+                _ => None,
+            };
+            match op {
+                Some(o) => {
+                    self.bump();
+                    let rhs = self.parse_mul()?;
+                    lhs = MathNode::Bin(o, Box::new(lhs), Box::new(rhs));
+                }
+                None => break,
+            }
+        }
+        Ok(lhs)
+    }
+
+    fn parse_mul(&mut self) -> Result<MathNode, ParseError> {
+        let mut lhs = self.parse_unary()?;
+        loop {
+            // explicit multiplicative operator?
+            let explicit = match &self.peek().kind {
+                TokenKind::Char('*') => Some(MBinOp::Mul),
+                TokenKind::Char('/') => Some(MBinOp::Div),
+                TokenKind::ControlWord(w) => mul_op(w),
+                _ => None,
+            };
+            if let Some(o) = explicit {
+                self.bump();
+                let rhs = self.parse_unary()?;
+                lhs = MathNode::Bin(o, Box::new(lhs), Box::new(rhs));
+                continue;
+            }
+            // implicit multiplication by juxtaposition (2x, a(b), \frac..\frac..)
+            if self.starts_atom() {
+                let rhs = self.parse_unary()?;
+                lhs = MathNode::Bin(MBinOp::Mul, Box::new(lhs), Box::new(rhs));
+                continue;
+            }
+            break;
+        }
+        Ok(lhs)
+    }
+
+    /// Does the current token begin a new atom (for implicit-multiplication detection)?
+    fn starts_atom(&self) -> bool {
+        match &self.peek().kind {
+            TokenKind::Char(c) => {
+                c.is_ascii_alphanumeric() || matches!(c, '(' | '[' | '|' | '.')
+            }
+            TokenKind::BeginGroup => true,
+            TokenKind::ControlWord(w) => {
+                // Operators and closers don't start a new atom: a relation (`\le`), a
+                // multiplicative op (`\times`), or `\right`/`\end`. Everything else
+                // (`\frac`, `\sqrt`, `\sum`, `\alpha`, …) does.
+                rel_op(w).is_none()
+                    && mul_op(w).is_none()
+                    && !matches!(w.as_str(), "right" | "end")
+            }
+            _ => false,
+        }
+    }
+
+    fn parse_unary(&mut self) -> Result<MathNode, ParseError> {
+        match &self.peek().kind {
+            TokenKind::Char('+') => {
+                self.bump();
+                Ok(MathNode::Unary(MUnOp::Pos, Box::new(self.parse_unary()?)))
+            }
+            TokenKind::Char('-') => {
+                self.bump();
+                Ok(MathNode::Unary(MUnOp::Neg, Box::new(self.parse_unary()?)))
+            }
+            _ => self.parse_postfix(),
+        }
+    }
+
+    /// An atom plus any trailing `^`/`_` scripts.
+    fn parse_postfix(&mut self) -> Result<MathNode, ParseError> {
+        let base = self.parse_atom()?;
+        let mut sub = None;
+        let mut sup = None;
+        loop {
+            match &self.peek().kind {
+                TokenKind::Superscript => {
+                    self.bump();
+                    if sup.is_some() {
+                        return self.err("double superscript");
+                    }
+                    sup = Some(Box::new(self.parse_script_arg()?));
+                }
+                TokenKind::Subscript => {
+                    self.bump();
+                    if sub.is_some() {
+                        return self.err("double subscript");
+                    }
+                    sub = Some(Box::new(self.parse_script_arg()?));
+                }
+                _ => break,
+            }
+        }
+        if sub.is_none() && sup.is_none() {
+            Ok(base)
+        } else {
+            Ok(MathNode::Script { base: Box::new(base), sub, sup })
+        }
+    }
+
+    /// The argument of a `^`/`_`: a single atom, or a braced group.
+    fn parse_script_arg(&mut self) -> Result<MathNode, ParseError> {
+        self.parse_atom()
+    }
+
+    /// Read a mandatory argument: a `{group}` or, LaTeX-style, the next single atom.
+    fn read_arg(&mut self) -> Result<MathNode, ParseError> {
+        if matches!(self.peek().kind, TokenKind::BeginGroup) {
+            self.read_group()
+        } else {
+            self.parse_atom()
+        }
+    }
+
+    /// Read a `{ … }` group as a transparent sub-expression (no wrapper node).
+    fn read_group(&mut self) -> Result<MathNode, ParseError> {
+        if !matches!(self.peek().kind, TokenKind::BeginGroup) {
+            return self.err("expected '{'");
+        }
+        self.bump(); // {
+        let inner = self.parse_relation()?;
+        if !matches!(self.peek().kind, TokenKind::EndGroup) {
+            return self.err("expected '}'");
+        }
+        self.bump(); // }
+        Ok(inner)
+    }
+
+    fn parse_atom(&mut self) -> Result<MathNode, ParseError> {
+        self.enter()?;
+        let node = self.parse_atom_inner()?;
+        self.depth -= 1;
+        Ok(node)
+    }
+
+    fn parse_atom_inner(&mut self) -> Result<MathNode, ParseError> {
+        match self.peek().kind.clone() {
+            TokenKind::Char(c) if c.is_ascii_digit() || c == '.' => Ok(self.read_number()),
+            TokenKind::Char(c) if c.is_ascii_alphabetic() => {
+                self.bump();
+                Ok(MathNode::Sym(c.to_string()))
+            }
+            TokenKind::Char('(') => self.read_fence(')'),
+            TokenKind::Char('[') => self.read_fence(']'),
+            TokenKind::Char('|') => self.read_bar_fence(),
+            TokenKind::BeginGroup => self.read_group(),
+            TokenKind::ControlWord(name) => self.parse_command(&name),
+            TokenKind::ControlSymbol(c) => {
+                // e.g. \{ \} as a bare symbol
+                self.bump();
+                Ok(MathNode::Sym(c.to_string()))
+            }
+            _ => self.err("expected a math atom"),
+        }
+    }
+
+    fn read_number(&mut self) -> MathNode {
+        let mut s = String::new();
+        let mut seen_dot = false;
+        while let TokenKind::Char(c) = self.peek().kind {
+            if c.is_ascii_digit() {
+                s.push(c);
+                self.bump();
+            } else if c == '.' && !seen_dot {
+                seen_dot = true;
+                s.push(c);
+                self.bump();
+            } else {
+                break;
+            }
+        }
+        MathNode::Num(s)
+    }
+
+    /// Read `( … )` / `[ … ]` up to the matching `close` char.
+    fn read_fence(&mut self, close: char) -> Result<MathNode, ParseError> {
+        let open = if let TokenKind::Char(c) = self.peek().kind { c } else { unreachable!() };
+        self.bump(); // opening delimiter
+        let body = self.parse_relation()?;
+        match self.peek().kind {
+            TokenKind::Char(c) if c == close => {
+                self.bump();
+                Ok(MathNode::Fenced {
+                    left: open.to_string(),
+                    body: Box::new(body),
+                    right: close.to_string(),
+                })
+            }
+            _ => self.err(format!("expected '{close}'")),
+        }
+    }
+
+    /// Read `| … |` (absolute value).
+    fn read_bar_fence(&mut self) -> Result<MathNode, ParseError> {
+        self.bump(); // opening |
+        let body = self.parse_relation()?;
+        match self.peek().kind {
+            TokenKind::Char('|') => {
+                self.bump();
+                Ok(MathNode::Fenced {
+                    left: "|".into(),
+                    body: Box::new(body),
+                    right: "|".into(),
+                })
+            }
+            _ => self.err("expected closing '|'"),
+        }
+    }
+
+    fn parse_command(&mut self, name: &str) -> Result<MathNode, ParseError> {
+        if let Some(rel) = rel_op(name) {
+            // a relation control word in atom position is malformed
+            let _ = rel;
+            return self.err(format!("unexpected relation \\{name}"));
+        }
+        if is_frac(name) {
+            self.bump();
+            let num = self.read_arg()?;
+            let den = self.read_arg()?;
+            return Ok(MathNode::Frac(Box::new(num), Box::new(den)));
+        }
+        if is_binom(name) {
+            self.bump();
+            let a = self.read_arg()?;
+            let b = self.read_arg()?;
+            return Ok(MathNode::Binom(Box::new(a), Box::new(b)));
+        }
+        if name == "sqrt" {
+            self.bump();
+            let degree = if matches!(self.peek().kind, TokenKind::Char('[')) {
+                self.bump(); // [
+                let d = self.parse_relation()?;
+                if !matches!(self.peek().kind, TokenKind::Char(']')) {
+                    return self.err("expected ']' for \\sqrt degree");
+                }
+                self.bump(); // ]
+                Some(Box::new(d))
+            } else {
+                None
+            };
+            let radicand = self.read_arg()?;
+            return Ok(MathNode::Root { degree, radicand: Box::new(radicand) });
+        }
+        if name == "left" {
+            self.bump();
+            let left = self.read_delimiter()?;
+            let body = self.parse_relation()?;
+            if !matches!(&self.peek().kind, TokenKind::ControlWord(w) if w == "right") {
+                return self.err("expected \\right");
+            }
+            self.bump(); // \right
+            let right = self.read_delimiter()?;
+            return Ok(MathNode::Fenced { left, body: Box::new(body), right });
+        }
+        if is_text(name) {
+            self.bump();
+            let content = self.read_raw_text_group()?;
+            return Ok(MathNode::Text(content));
+        }
+        if is_accent(name) {
+            self.bump();
+            let body = self.read_arg()?;
+            return Ok(MathNode::Accent { kind: name.to_string(), body: Box::new(body) });
+        }
+        if is_bigop(name) {
+            self.bump();
+            let (lower, upper) = self.read_bigop_scripts()?;
+            let body = self.parse_unary()?;
+            return Ok(MathNode::BigOp {
+                op: name.to_string(),
+                lower,
+                upper,
+                body: Box::new(body),
+            });
+        }
+        if is_function(name) {
+            self.bump();
+            let arg = self.parse_postfix()?;
+            return Ok(MathNode::Call { func: name.to_string(), arg: Box::new(arg) });
+        }
+        // anything else (greek letters, \infty, \partial, unknown commands) is a symbol
+        self.bump();
+        Ok(MathNode::Sym(name.to_string()))
+    }
+
+    /// The `_lower` / `^upper` bound scripts of a big operator, in either order.
+    fn read_bigop_scripts(&mut self) -> Result<BigOpScripts, ParseError> {
+        let mut lower = None;
+        let mut upper = None;
+        loop {
+            match &self.peek().kind {
+                TokenKind::Subscript if lower.is_none() => {
+                    self.bump();
+                    lower = Some(Box::new(self.parse_script_arg()?));
+                }
+                TokenKind::Superscript if upper.is_none() => {
+                    self.bump();
+                    upper = Some(Box::new(self.parse_script_arg()?));
+                }
+                _ => break,
+            }
+        }
+        Ok((lower, upper))
+    }
+
+    /// A `\left`/`\right` delimiter: a single Char delimiter (`( [ | . )`), or a control
+    /// symbol (`\{ \langle …`).
+    fn read_delimiter(&mut self) -> Result<String, ParseError> {
+        match self.peek().kind.clone() {
+            TokenKind::Char(c) => {
+                self.bump();
+                Ok(c.to_string())
+            }
+            TokenKind::ControlWord(w) => {
+                self.bump();
+                Ok(format!("\\{w}"))
+            }
+            TokenKind::ControlSymbol(c) => {
+                self.bump();
+                Ok(format!("\\{c}"))
+            }
+            _ => self.err("expected a delimiter after \\left/\\right"),
+        }
+    }
+
+    /// Capture a `{ … }` group's raw characters (for `\text{…}`).
+    fn read_raw_text_group(&mut self) -> Result<String, ParseError> {
+        if !matches!(self.peek().kind, TokenKind::BeginGroup) {
+            return self.err("\\text must be followed by {…}");
+        }
+        self.bump(); // {
+        let mut s = String::new();
+        loop {
+            match self.peek().kind.clone() {
+                TokenKind::EndGroup => {
+                    self.bump();
+                    return Ok(s);
+                }
+                TokenKind::Eof => return self.err("unterminated \\text group"),
+                TokenKind::Char(c) => {
+                    s.push(c);
+                    self.bump();
+                }
+                // anything else inside \text we render back approximately as a space-free
+                // token; for L2's purposes text content is plain characters.
+                other => {
+                    return self.err(format!("unsupported token in \\text: {other:?}"));
+                }
+            }
+        }
+    }
+}
+
+// ---- rendering / round-trip ---------------------------------------------------
+
+/// Precedence of a node for parenthesization during rendering (higher binds tighter).
+fn prec(n: &MathNode) -> u8 {
+    match n {
+        MathNode::Rel(..) => 1,
+        MathNode::Bin(MBinOp::Add | MBinOp::Sub | MBinOp::PlusMinus | MBinOp::MinusPlus, ..) => 2,
+        MathNode::Bin(MBinOp::Mul | MBinOp::Div, ..) => 3,
+        MathNode::Unary(..) => 4,
+        MathNode::Bin(MBinOp::Pow, ..) | MathNode::Script { .. } => 5,
+        _ => 6, // atoms: Num, Sym, Frac, Root, Fenced, Call, BigOp, Accent, Binom, Text
+    }
+}
+
+impl MathNode {
+    /// Render back to LaTeX math source. `parse_math(&node.to_latex()) == node`.
+    pub fn to_latex(&self) -> String {
+        let mut s = String::new();
+        self.write(&mut s, 0);
+        s
+    }
+
+    /// Write `child`, wrapping in invisible `{…}` if its precedence is below `min`.
+    fn write_child(child: &MathNode, out: &mut String, min: u8) {
+        if prec(child) < min {
+            out.push('{');
+            child.write(out, 0);
+            out.push('}');
+        } else {
+            child.write(out, min);
+        }
+    }
+
+    fn write(&self, out: &mut String, _min: u8) {
+        match self {
+            MathNode::Num(s) => out.push_str(s),
+            MathNode::Sym(s) => {
+                if s.len() == 1 && s.chars().all(|c| c.is_ascii_alphanumeric()) {
+                    out.push_str(s);
+                } else {
+                    out.push('\\');
+                    out.push_str(s);
+                    out.push(' ');
+                }
+            }
+            MathNode::Bin(op, a, b) => {
+                let p = prec(self);
+                let opstr = match op {
+                    MBinOp::Add => " + ",
+                    MBinOp::Sub => " - ",
+                    MBinOp::Mul => " \\cdot ",
+                    MBinOp::Div => " / ",
+                    MBinOp::Pow => "^",
+                    MBinOp::PlusMinus => " \\pm ",
+                    MBinOp::MinusPlus => " \\mp ",
+                };
+                if *op == MBinOp::Pow {
+                    // base binds tighter than the operator; exponent is braced
+                    Self::write_child(a, out, 6);
+                    out.push('^');
+                    out.push('{');
+                    b.write(out, 0);
+                    out.push('}');
+                } else {
+                    Self::write_child(a, out, p);
+                    out.push_str(opstr);
+                    // right operand needs the next-higher precedence to stay left-assoc
+                    Self::write_child(b, out, p + 1);
+                }
+            }
+            MathNode::Unary(op, a) => {
+                out.push(if *op == MUnOp::Neg { '-' } else { '+' });
+                Self::write_child(a, out, 4);
+            }
+            MathNode::Frac(a, b) => {
+                out.push_str("\\frac{");
+                a.write(out, 0);
+                out.push_str("}{");
+                b.write(out, 0);
+                out.push('}');
+            }
+            MathNode::Binom(a, b) => {
+                out.push_str("\\binom{");
+                a.write(out, 0);
+                out.push_str("}{");
+                b.write(out, 0);
+                out.push('}');
+            }
+            MathNode::Root { degree, radicand } => {
+                out.push_str("\\sqrt");
+                if let Some(d) = degree {
+                    out.push('[');
+                    d.write(out, 0);
+                    out.push(']');
+                }
+                out.push('{');
+                radicand.write(out, 0);
+                out.push('}');
+            }
+            MathNode::Script { base, sub, sup } => {
+                Self::write_child(base, out, 6);
+                if let Some(sb) = sub {
+                    out.push('_');
+                    out.push('{');
+                    sb.write(out, 0);
+                    out.push('}');
+                }
+                if let Some(sp) = sup {
+                    out.push('^');
+                    out.push('{');
+                    sp.write(out, 0);
+                    out.push('}');
+                }
+            }
+            MathNode::Call { func, arg } => {
+                out.push('\\');
+                out.push_str(func);
+                out.push(' ');
+                Self::write_child(arg, out, 6);
+            }
+            MathNode::BigOp { op, lower, upper, body } => {
+                out.push('\\');
+                out.push_str(op);
+                if let Some(l) = lower {
+                    out.push('_');
+                    out.push('{');
+                    l.write(out, 0);
+                    out.push('}');
+                }
+                if let Some(u) = upper {
+                    out.push('^');
+                    out.push('{');
+                    u.write(out, 0);
+                    out.push('}');
+                }
+                out.push(' ');
+                Self::write_child(body, out, 4);
+            }
+            MathNode::Accent { kind, body } => {
+                out.push('\\');
+                out.push_str(kind);
+                out.push('{');
+                body.write(out, 0);
+                out.push('}');
+            }
+            MathNode::Fenced { left, body, right } => {
+                // `\left`-style multi-char delimiters start with a backslash.
+                if left.starts_with('\\') || right.starts_with('\\') {
+                    out.push_str("\\left");
+                    out.push_str(left);
+                    body.write(out, 0);
+                    out.push_str("\\right");
+                    out.push_str(right);
+                } else {
+                    out.push_str(left);
+                    body.write(out, 0);
+                    out.push_str(right);
+                }
+            }
+            MathNode::Text(t) => {
+                out.push_str("\\text{");
+                out.push_str(t);
+                out.push('}');
+            }
+            MathNode::Rel(op, a, b) => {
+                let opstr = match op {
+                    MRelOp::Eq => " = ",
+                    MRelOp::Ne => " \\ne ",
+                    MRelOp::Lt => " < ",
+                    MRelOp::Le => " \\le ",
+                    MRelOp::Gt => " > ",
+                    MRelOp::Ge => " \\ge ",
+                    MRelOp::Approx => " \\approx ",
+                    MRelOp::Equiv => " \\equiv ",
+                };
+                Self::write_child(a, out, 1);
+                out.push_str(opstr);
+                Self::write_child(b, out, 2);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn num(s: &str) -> MathNode {
+        MathNode::Num(s.into())
+    }
+    fn sym(s: &str) -> MathNode {
+        MathNode::Sym(s.into())
+    }
+
+    fn round_trips(src: &str) {
+        let a = parse_math(src).expect("parse");
+        let r = a.to_latex();
+        let b = parse_math(&r).expect("re-parse");
+        assert_eq!(a, b, "round-trip: {src:?} -> {r:?}");
+    }
+
+    #[test]
+    fn numbers_and_symbols() {
+        assert_eq!(parse_math("12").unwrap(), num("12"));
+        assert_eq!(parse_math("3.14").unwrap(), num("3.14"));
+        assert_eq!(parse_math("x").unwrap(), sym("x"));
+        assert_eq!(parse_math(r"\pi").unwrap(), sym("pi"));
+    }
+
+    #[test]
+    fn precedence_add_mul() {
+        // a + b*c → Add(a, Mul(b,c))
+        let n = parse_math("a + b*c").unwrap();
+        assert_eq!(
+            n,
+            MathNode::Bin(
+                MBinOp::Add,
+                Box::new(sym("a")),
+                Box::new(MathNode::Bin(MBinOp::Mul, Box::new(sym("b")), Box::new(sym("c"))))
+            )
+        );
+    }
+
+    #[test]
+    fn implicit_multiplication() {
+        // 2x → Mul(2, x)
+        assert_eq!(
+            parse_math("2x").unwrap(),
+            MathNode::Bin(MBinOp::Mul, Box::new(num("2")), Box::new(sym("x")))
+        );
+        // 2\pi
+        assert!(matches!(parse_math(r"2\pi").unwrap(), MathNode::Bin(MBinOp::Mul, ..)));
+    }
+
+    #[test]
+    fn latex_mul_div_spellings_unify() {
+        for s in [r"a \times b", r"a \cdot b", "a*b"] {
+            assert_eq!(
+                parse_math(s).unwrap(),
+                MathNode::Bin(MBinOp::Mul, Box::new(sym("a")), Box::new(sym("b")))
+            );
+        }
+        assert_eq!(
+            parse_math(r"a \div b").unwrap(),
+            MathNode::Bin(MBinOp::Div, Box::new(sym("a")), Box::new(sym("b")))
+        );
+    }
+
+    #[test]
+    fn frac_with_nested_mul() {
+        // \frac{12 \times 15}{3}
+        let n = parse_math(r"\frac{12 \times 15}{3}").unwrap();
+        match n {
+            MathNode::Frac(a, b) => {
+                assert!(matches!(*a, MathNode::Bin(MBinOp::Mul, ..)));
+                assert_eq!(*b, num("3"));
+            }
+            other => panic!("expected Frac, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn power_with_braced_exponent() {
+        // 2^{10}
+        assert_eq!(
+            parse_math("2^{10}").unwrap(),
+            MathNode::Script { base: Box::new(num("2")), sub: None, sup: Some(Box::new(num("10"))) }
+        );
+    }
+
+    #[test]
+    fn nth_root() {
+        // \sqrt[3]{27}
+        assert_eq!(
+            parse_math(r"\sqrt[3]{27}").unwrap(),
+            MathNode::Root { degree: Some(Box::new(num("3"))), radicand: Box::new(num("27")) }
+        );
+    }
+
+    #[test]
+    fn sum_with_bounds() {
+        // \sum_{i=1}^{n} i
+        let n = parse_math(r"\sum_{i=1}^{n} i").unwrap();
+        match n {
+            MathNode::BigOp { op, lower, upper, body } => {
+                assert_eq!(op, "sum");
+                assert!(matches!(lower.as_deref(), Some(MathNode::Rel(MRelOp::Eq, ..))));
+                assert_eq!(upper.as_deref(), Some(&sym("n")));
+                assert_eq!(*body, sym("i"));
+            }
+            other => panic!("expected BigOp, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn left_right_fence_with_power() {
+        // \left(\frac{a}{b}\right)^2
+        let n = parse_math(r"\left(\frac{a}{b}\right)^2").unwrap();
+        match n {
+            MathNode::Script { base, sup, .. } => {
+                assert!(matches!(*base, MathNode::Fenced { .. }));
+                assert_eq!(sup.as_deref(), Some(&num("2")));
+            }
+            other => panic!("expected Script over Fenced, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn relation_and_function() {
+        assert!(matches!(parse_math("a = b").unwrap(), MathNode::Rel(MRelOp::Eq, ..)));
+        assert!(matches!(parse_math(r"x \le y").unwrap(), MathNode::Rel(MRelOp::Le, ..)));
+        assert!(matches!(parse_math(r"\sin x").unwrap(), MathNode::Call { .. }));
+    }
+
+    #[test]
+    fn text_in_math() {
+        assert_eq!(parse_math(r"\text{mg}").unwrap(), MathNode::Text("mg".into()));
+    }
+
+    #[test]
+    fn errors_are_spanned_not_panics() {
+        assert!(parse_math(r"\frac{1}").is_err()); // missing 2nd arg → eof
+        assert!(parse_math("(a+b").is_err()); // unterminated paren
+        assert!(parse_math(r"\left(x").is_err()); // missing \right
+        assert!(parse_math("a^b^c").is_err()); // double superscript
+    }
+
+    #[test]
+    fn deep_nesting_is_bounded() {
+        let deep = "(".repeat(5000);
+        assert!(parse_math(&deep).is_err());
+    }
+
+    #[test]
+    fn round_trip_corpus() {
+        for s in [
+            "12",
+            "a + b",
+            "a + b \\cdot c",
+            "2x",
+            "\\frac{12 \\times 15}{3}",
+            "2^{10}",
+            "\\sqrt[3]{27}",
+            "\\sum_{i=1}^{n} i",
+            "\\left(\\frac{a}{b}\\right)^2",
+            "a = b + c",
+            "x \\le y",
+            "\\hat{x} + \\bar{y}",
+            "\\pi r^2",
+        ] {
+            round_trips(s);
+        }
+    }
+}


### PR DESCRIPTION
## LTX01 L2 — the math grammar

Third layer of the full-fidelity LaTeX parser. L1 (#6720) keeps each `$…$` island
as its **raw** inner source; this layer parses that source into a faithful
`MathNode` AST with full operator precedence and a round-tripping `to_latex`.

This is the LaTeX parser as a **standalone, reusable component** — no ADJ/engine
coupling (that consumption is a later, separate effort). It is plugin #1 of the
pluggable `math-frontend` framework (the `MathFrontend` adapter is L6).

### What's in this layer

- **`parse_math(&str) -> Result<MathNode, ParseError>`** — reuses the L0
  `tokenize`, filters space/par/comment, then precedence-climbs:
  relations (`= ≠ < ≤ > ≥ \approx \equiv`) < add/sub (`+ - \pm \mp`) <
  mul/div (`\times \cdot \div /` **and implicit multiplication** by adjacency:
  `2x`, `\pi r`, `(a)(b)`) < unary `± ∓` < scripts (`^`/`_`, right-assoc) < atoms.
- **`MathNode`** covers `Num`/`Sym`, `Bin`/`Unary`, `Frac` (`\frac`/`\dfrac`/`\tfrac`),
  `Binom`, `Root` (`\sqrt[n]{}`), `Script`, `Call` (named functions),
  `BigOp` (`\sum`/`\prod`/`\int`/`\lim` with bound scripts), `Accent`,
  `Fenced` (`\left…\right`), `Text`, `Rel`. `{…}` groups are **transparent**.
- **`MathNode::to_latex`** — precedence-aware: a child below the parent's precedence
  is wrapped in invisible `{…}`, so `parse_math(&m.to_latex()) == m`.
- **`Node::parsed_math`** — parses a `Node::Math` island on demand; the L1 tree and
  its round-trip are untouched.

### Robustness

Total, panic-free, spanned. Recursion is **depth-guarded** (`MAX_DEPTH = 128`,
conservative for the heavier math precedence chain). The leading-sign run is parsed
**iteratively** (not recursively) so adversarial input like `------…1` errors instead
of overflowing the stack — caught by security review (a HIGH) and fixed in this PR,
with a 100k-sign regression test.

### Tests

+16 math tests incl. the worked corpus (`\frac{12 \times 15}{3}`, `2^{10}`,
`\sqrt[3]{27}`, `\sum_{i=1}^{n} i`, `\left(\frac{a}{b}\right)^2`), a round-trip corpus,
relations/functions, the deep-nesting bound, and the long-sign-chain DoS guard.
**55 unit + 1 doc test green; clippy `-D warnings` clean; no `unsafe`.** Crate 0.1.0 → 0.3.0.

Security: `/security-review` ran 2 rounds — round 1 found the `parse_unary` stack-overflow
DoS (HIGH), round 2 (post-fix) returned **PASSED**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)