### PR TITLE
feat(visicalc-qt): multi-sheet workbook in the Qt demo

### DIFF
--- a/demo/visicalc-qt/InfiniteSheet.qml
+++ b/demo/visicalc-qt/InfiniteSheet.qml
@@ -390,6 +390,77 @@ Item {
             }
         }
 
+        // ── Sheet tab bar ────────────────────────────────────────────────
+        // One tab per sheet, the active one highlighted. Click a tab to switch the
+        // sheet bare-A1 ops address; a formula can still reference another sheet by
+        // name (=Summary!A1) and recomputes live. Right-click a tab to delete it;
+        // the + button adds one. `sheetTick` re-reads sheetNames() on sheetsChanged.
+        RowLayout {
+            id: sheetTabs
+            Layout.fillWidth: true
+            Layout.leftMargin: 8
+            Layout.rightMargin: 8
+            Layout.topMargin: 6
+            spacing: 2
+            property int sheetTick: 0
+            property var info: {
+                sheetTabs.sheetTick; // re-evaluate when a sheet op fires
+                return doc ? doc.sheetNames() : ({ sheets: [], active: 0 });
+            }
+            Connections {
+                target: doc
+                function onSheetsChanged() { sheetTabs.sheetTick++ }
+            }
+            Repeater {
+                model: sheetTabs.info.sheets
+                delegate: Button {
+                    id: tab
+                    required property int index
+                    required property string modelData
+                    text: modelData
+                    implicitHeight: 26
+                    padding: 6
+                    leftPadding: 12
+                    rightPadding: 12
+                    font.pixelSize: 12
+                    contentItem: Text {
+                        text: tab.text
+                        color: index === sheetTabs.info.active ? "#e8eaed" : "#9aa3b2"
+                        font: tab.font
+                        verticalAlignment: Text.AlignVCenter
+                    }
+                    background: Rectangle {
+                        color: index === sheetTabs.info.active ? "#1b1e24"
+                             : (tab.hovered ? "#2b313a" : "#21252c")
+                        border.color: "#3a404b"
+                        radius: 5
+                        // accent top-border on the active tab
+                        Rectangle {
+                            visible: index === sheetTabs.info.active
+                            anchors.top: parent.top; anchors.left: parent.left; anchors.right: parent.right
+                            height: 2; color: "#4aa3ff"; radius: 1
+                        }
+                    }
+                    ToolTip.visible: hovered
+                    ToolTip.text: "Switch to " + modelData + " · right-click to delete"
+                    onClicked: if (doc) doc.selectSheet(index)
+                    MouseArea {
+                        anchors.fill: parent
+                        acceptedButtons: Qt.RightButton
+                        onClicked: if (doc && doc.sheetNames().sheets.length > 1) doc.deleteSheet(tab.index)
+                    }
+                }
+            }
+            Button {
+                text: "+"
+                implicitHeight: 26
+                padding: 6; leftPadding: 10; rightPadding: 10
+                ToolTip.visible: hovered
+                ToolTip.text: "Add a sheet"
+                onClicked: if (doc) doc.addSheet("Sheet" + (doc.sheetNames().sheets.length + 1))
+            }
+        }
+
         // ── Column-letter header (frozen vertically, scrolls horizontally) ──
         RowLayout {
             Layout.fillWidth: true

--- a/demo/visicalc-qt/src/SpreadsheetModel.cpp
+++ b/demo/visicalc-qt/src/SpreadsheetModel.cpp
@@ -120,6 +120,16 @@ void SpreadsheetModel::seed() {
     for (const auto &f : formats) {
         sc_set_format(session_, f.a1, f.code);
     }
+
+    // Seed a second "Summary" sheet so cross-sheet references are demoable out of
+    // the box: type =Summary!A3 on Sheet1 and it tracks Summary's running total,
+    // recomputing live when Summary changes. add_sheet makes it active, so switch
+    // back to Sheet1 (index 0) as the default active sheet.
+    sc_add_sheet(session_, "Summary");
+    takeString(sc_set_cell(session_, "A1", "100"));
+    takeString(sc_set_cell(session_, "A2", "200"));
+    takeString(sc_set_cell(session_, "A3", "=A1+A2")); // 300
+    sc_set_active_sheet(session_, 0);
 }
 
 QString SpreadsheetModel::display(const QString &a1) const {
@@ -525,4 +535,71 @@ bool SpreadsheetModel::redo() {
         emit revisionChanged();
     }
     return ok;
+}
+
+// ── Multi-sheet workbook ─────────────────────────────────────────────
+
+// Shared tail after a sheet op that changed the active sheet (add/select/rename/
+// delete): reset the infinite-view selection to the active sheet's top-left,
+// re-read the grid, resync the formula bar, regrow the extent, bump the revision,
+// and fire the rebind signals (grid + tab bar).
+void SpreadsheetModel::refreshAfterSheetOp() {
+    infRow_ = 1;
+    infCol_ = 1;
+    recompute();
+    computeExtent();
+    infFormula_ = rawAt(infAddress());
+    revision_++;
+    emit changed();
+    emit infSelectionChanged();
+    emit revisionChanged();
+    emit sheetsChanged();
+}
+
+QVariantMap SpreadsheetModel::sheetNames() const {
+    QVariantMap out;
+    const QString json = takeString(sc_sheet_names(session_));
+    const QJsonDocument doc = QJsonDocument::fromJson(json.toUtf8());
+    if (!doc.isObject()) return out;
+    const QJsonObject obj = doc.object();
+    QStringList names;
+    for (const QJsonValue &v : obj.value(QStringLiteral("sheets")).toArray()) {
+        names.append(v.toString());
+    }
+    out.insert(QStringLiteral("sheets"), names);
+    out.insert(QStringLiteral("active"), obj.value(QStringLiteral("active")).toInt());
+    return out;
+}
+
+int SpreadsheetModel::activeSheet() const {
+    return static_cast<int>(sc_active_sheet(session_));
+}
+
+bool SpreadsheetModel::selectSheet(int index) {
+    if (sc_set_active_sheet(session_, static_cast<unsigned>(std::max(0, index))) == 0)
+        return false;
+    refreshAfterSheetOp();
+    return true;
+}
+
+bool SpreadsheetModel::addSheet(const QString &name) {
+    const QByteArray n = name.toUtf8();
+    if (sc_add_sheet(session_, n.constData()) == 0) return false;
+    refreshAfterSheetOp();
+    return true;
+}
+
+bool SpreadsheetModel::renameSheet(int index, const QString &newName) {
+    const QByteArray n = newName.toUtf8();
+    if (sc_rename_sheet(session_, static_cast<unsigned>(std::max(0, index)), n.constData()) == 0)
+        return false;
+    refreshAfterSheetOp();
+    return true;
+}
+
+bool SpreadsheetModel::deleteSheet(int index) {
+    if (sc_delete_sheet(session_, static_cast<unsigned>(std::max(0, index))) == 0)
+        return false;
+    refreshAfterSheetOp();
+    return true;
 }

--- a/demo/visicalc-qt/src/SpreadsheetModel.h
+++ b/demo/visicalc-qt/src/SpreadsheetModel.h
@@ -177,8 +177,23 @@ public:
     // canUndo/canRedo bindings).
     Q_INVOKABLE bool undo();
     Q_INVOKABLE bool redo();
+    // ── Multi-sheet workbook ─────────────────────────────────────────
+    // Bare-A1 ops address the ACTIVE sheet; a formula may reference another
+    // (=Summary!A1) and recompute live when it changes. sheetNames() returns a map
+    // { "sheets": [names…], "active": index }; the mutators return true on success
+    // (false for a bad index / empty-or-duplicate name / can't-delete-last sheet);
+    // selectSheet switches the active sheet. After a sheet op the grid re-reads the
+    // active sheet from its top, the formula bar resyncs, and sheetsChanged() fires.
+    Q_INVOKABLE QVariantMap sheetNames() const;
+    Q_INVOKABLE int activeSheet() const;
+    Q_INVOKABLE bool selectSheet(int index);
+    Q_INVOKABLE bool addSheet(const QString &name);
+    Q_INVOKABLE bool renameSheet(int index, const QString &newName);
+    Q_INVOKABLE bool deleteSheet(int index);
 
 signals:
+    // The set of sheets or the active sheet changed — QML rebinds the tab bar.
+    void sheetsChanged();
     // viewportRows changed (after a recompute) — QML rebinds the grid.
     void changed();
     // The selection moved — QML rebinds cellAddress / selectedRaw / highlight.
@@ -200,6 +215,11 @@ private:
 
     // Re-derive totalRows_/totalCols_ from the engine's used_range + a margin.
     void computeExtent();
+    // Shared refresh after a sheet op (select/add/rename/delete): reset the
+    // infinite-view selection to the active sheet's top-left, recompute, regrow
+    // the extent, resync the formula bar, bump the revision, and emit the rebind
+    // signals (grid + tab bar).
+    void refreshAfterSheetOp();
     // The raw source of an A1 cell (the formula bar's text).
     QString rawAt(const QString &a1) const;
 

--- a/demo/visicalc-qt/test/tst_window.cpp
+++ b/demo/visicalc-qt/test/tst_window.cpp
@@ -30,6 +30,7 @@ private slots:
     void numberFormatAppliesToSelectedCell();
     void sortRangeReordersRowsByKeyColumn();
     void findAndReplaceLocatesAndRewritesCells();
+    void multiSheetWorkbookAndCrossSheetRefs();
 };
 
 // Helper: the display string at window (1-based) cell (row, col), given the
@@ -368,6 +369,55 @@ void TstWindow::findAndReplaceLocatesAndRewritesCells() {
     // no-match / empty query → 0.
     QCOMPARE(m.replaceAll("zzz", "q", false), 0);
     QCOMPARE(m.replaceAll("", "q", false), 0);
+}
+
+// Multi-sheet workbook + cross-sheet references: the model seeds Sheet1 (active)
+// plus a Summary sheet (A3 = A1+A2 = 300). A formula on Sheet1 can reference it
+// (=Summary!A3) and recompute live; add/rename/delete reindex + rewrite/#REF!.
+void TstWindow::multiSheetWorkbookAndCrossSheetRefs() {
+    SpreadsheetModel m;
+    QCOMPARE(m.sheetNames().value("sheets").toStringList(),
+             (QStringList{"Sheet1", "Summary"}));
+    QCOMPARE(m.activeSheet(), 0);
+
+    // Cross-sheet ref on Sheet1: G1 = =Summary!A3 → 300.
+    m.setCell("G1", "=Summary!A3");
+    QCOMPARE(at(m.window(1, 7, 1, 7), 1, 7, 1, 7), QStringLiteral("300"));
+    // Switch to Summary, edit A1 100→500 (A3 → 700), switch back → recompute live.
+    QVERIFY(m.selectSheet(1));
+    m.setCell("A1", "500");
+    QVERIFY(m.selectSheet(0));
+    QCOMPARE(at(m.window(1, 7, 1, 7), 1, 7, 1, 7), QStringLiteral("700"));
+
+    // Add a sheet → becomes active; duplicate/empty names rejected.
+    QVERIFY(m.addSheet("Detail"));
+    QCOMPARE(m.activeSheet(), 2);
+    QVERIFY(!m.addSheet("Sheet1"));
+    QVERIFY(!m.addSheet(""));
+
+    // Rename Summary → Totals: the qualifier follows, value holds.
+    QVERIFY(m.selectSheet(0));
+    QVERIFY(m.renameSheet(1, "Totals"));
+    QCOMPARE(m.sheetNames().value("sheets").toStringList(),
+             (QStringList{"Sheet1", "Totals", "Detail"}));
+    QCOMPARE(at(m.window(1, 7, 1, 7), 1, 7, 1, 7), QStringLiteral("700"));
+
+    // Delete Totals → the inbound ref becomes #REF!; can't delete the last sheet.
+    QVERIFY(m.deleteSheet(1));
+    QCOMPARE(m.sheetNames().value("sheets").toStringList(),
+             (QStringList{"Sheet1", "Detail"}));
+    QVERIFY(m.valueJson("G1").contains("#REF!"));
+
+    // Save/load round-trips a second sheet + a live cross-sheet formula.
+    QVERIFY(m.addSheet("Data"));
+    m.setCell("A1", "9"); // Data!A1
+    QVERIFY(m.selectSheet(0));
+    m.setCell("F1", "=Data!A1"); // 9
+    const QString docJson = m.serialize();
+    SpreadsheetModel m2;
+    QVERIFY(m2.deserialize(docJson));
+    QVERIFY(m2.sheetNames().value("sheets").toStringList().contains("Data"));
+    QCOMPARE(at(m2.window(1, 6, 1, 6), 1, 6, 1, 6), QStringLiteral("9"));
 }
 
 QTEST_MAIN(TstWindow)


### PR DESCRIPTION
**2nd of the 6 multi-sheet demo rollouts** (after web [#6723](https://github.com/adhithyan15/coding-adventures/pull/6723)). Adds a sheet **tab bar** to the Qt/QML infinite-sheet demo, on the shared Rust engine through the C ABI's new sheet ops.

## What changed
- **SpreadsheetModel** — `Q_INVOKABLE` `sheetNames()` (→ `{sheets:[…], active:i}` parsed from `sc_sheet_names`' JSON `char*`, freed via the existing `takeString`), `activeSheet()`, `selectSheet`/`addSheet`/`renameSheet`/`deleteSheet` (→ the `sc_*` sheet ops, index clamped ≥0). A shared `refreshAfterSheetOp()` resets the infinite-view selection to the new active sheet's top-left, recomputes, regrows the extent, resyncs the formula bar, bumps revision, and emits a new `sheetsChanged()` signal. `seed()` adds a **Summary** sheet (`A1=100`, `A2=200`, `A3==A1+A2`) so cross-sheet refs work out of the box.
- **InfiniteSheet.qml** — a tab bar below the toolbar: a Repeater of tabs (active highlighted with an accent top-border), **click** = switch, **right-click** = delete (guarded against the last sheet), **+** to add. A `Connections`/`sheetTick` re-reads `sheetNames()` on `sheetsChanged`.

## Verification
- **`tst_window` 15/15 pass** (qmake; capi re-vendored from the worktree). New `multiSheetWorkbookAndCrossSheetRefs`: cross-sheet `=Summary!A3` = 300 → **700** after editing `Summary!A1` (100→500); add (becomes active) + duplicate/empty rejected; rename keeps the value; delete → inbound `#REF!` + reindex; save/load round-trips a second sheet with a live cross-sheet formula.
- QML tab labels render as `Text` (no injection). `/security-review` (FFI string lifetime, dangling `.constData()`, index clamp, QML re-entrancy) → **PASSED**.
- `Vendor/*.a` + header are gitignored (CI re-vendors).

Next: Flutter → Compose → XAML → SwiftUI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)