### PR TITLE
feat(closurec): fold static Array.of(v0,v1,…) → array literal [v0,v1,…]

### DIFF
--- a/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to the `coding-adventures-closure-pass-constant-fold` crate will be documented in this file.
 
+## [0.63.0] - 2026-06-26
+
+### Added — fold static `Array.of(v0, v1, …)` → array literal `[v0, v1, …]`
+
+The static `Array.of` (ECMAScript §23.1.2.3) now folds to an array literal
+whose elements are exactly its arguments, in order. Unlike the `Array(n)`
+constructor — where a single numeric argument sets the *length* (`Array(7)` is a
+length-7 hole array) — `Array.of(7)` is the one-element array `[7]`, so the fold
+is sound for any argument list:
+
+| call                | result      |
+|---------------------|-------------|
+| `Array.of()`        | `[]`        |
+| `Array.of(7)`       | `[7]`       |
+| `Array.of(1, 2, 3)` | `[1, 2, 3]` |
+| `Array.of(f(), x)`  | `[f(), x]`  |
+
+Every element expression is preserved in evaluation order, so no argument is
+dropped, duplicated, or reordered and all side effects are retained. Only the
+bare global `Array.of(...)` callee folds (never a shadowed `a.of(...)`). A
+spread argument would be declined, but the AST has no call-argument spread
+variant yet, so every argument is a plain expression and the fold always applies.
+
 ## [0.59.0] - 2026-06-26
 
 ### Added — fold static `Object.keys/values/entries({})` → `[]`

--- a/code/packages/rust/closure-pass-constant-fold/Cargo.toml
+++ b/code/packages/rust/closure-pass-constant-fold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-constant-fold"
-version = "0.59.0"
+version = "0.63.0"
 edition = "2021"
 description = "Constant-folding optimization pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Folds compile-time-evaluable expressions like `2 + 3 → 5`."
 

--- a/code/packages/rust/closure-pass-constant-fold/src/lib.rs
+++ b/code/packages/rust/closure-pass-constant-fold/src/lib.rs
@@ -1344,6 +1344,46 @@ fn fold_call(c: &CallExpression, st: &mut FoldState) -> Expression {
                         }
                     }
                 }
+
+                // ---- Array.of(v0, v1, …) → array literal `[v0, v1, …]` ----
+                //
+                // `Array.of` (ECMAScript §23.1.2.3) ALWAYS builds a fresh array
+                // whose elements are EXACTLY its arguments, in order. Crucially it
+                // is NOT the `Array(…)` constructor: a single numeric argument to
+                // `Array` sets the LENGTH (`Array(7)` is a 7-hole array of length 7),
+                // whereas `Array.of(7)` is the one-element array `[7]`. So for ANY
+                // argument list — including side-effecting, identifier, or call
+                // arguments — `Array.of(a, b, c)` is byte-for-byte the array literal
+                // `[a, b, c]`:
+                //
+                //   Array.of()        → []
+                //   Array.of(7)       → [7]        (NOT Array(7)'s length-7 array!)
+                //   Array.of(1, 2, 3) → [1, 2, 3]
+                //   Array.of(f(), x)  → [f(), x]    (f() still called, order kept)
+                //
+                // Folding to an array literal preserves every element expression in
+                // evaluation order, so no argument is dropped, duplicated, or
+                // reordered and all side effects are retained — the fold is sound
+                // for every argument list. We would DECLINE only a spread argument
+                // (`Array.of(...xs)`), whose element count is unknown at compile
+                // time; the AST has no spread variant in call arguments today (only
+                // object spread is contemplated, as a future "Phase 2"), so every
+                // argument is a plain expression and the fold always applies. The
+                // guard below is written against `arguments` directly so that, if a
+                // call-argument spread node is ever added, it can be matched and
+                // declined here. Same bare-global-`Array` premise as `Array.isArray`
+                // — only the literal `Array.of(...)` callee folds, never a shadowed
+                // receiver (`a.of(...)` is left alone).
+                if obj.name == "Array" && prop.name == "of" {
+                    let parent = c.cv.clone();
+                    let before = format!("Array.of({} arg(s))", arguments.len());
+                    let after = format!("[{} elem(s)]", arguments.len());
+                    let new_cv = st.fork_cv(&parent, &before, &after);
+                    return Expression::ArrayExpression(ArrayExpression {
+                        cv: new_cv,
+                        elements: arguments.iter().map(|a| Some(a.clone())).collect(),
+                    });
+                }
             }
         }
     }
@@ -7044,6 +7084,109 @@ mod tests {
         });
         let (out, _, changed, _) = run_pass(program_with_expr(c, true));
         assert!(!changed, "o.keys({{}}) must not fold");
+        assert!(matches!(extract_expr(&out), Expression::CallExpression(_)));
+    }
+
+    // ------------------- Array.of (static) ---------------------------
+
+    /// Build `Array.of(<args…>)`.
+    fn array_of_call(args: Vec<Expression>) -> Expression {
+        Expression::CallExpression(CallExpression {
+            cv: Some("c.cv".to_string()),
+            callee: Box::new(member(ident("Array"), "of")),
+            arguments: args,
+        })
+    }
+
+    #[test]
+    fn fold_array_of_multiple_args_to_array_literal() {
+        // `Array.of(1, 2, 3)` → `[1, 2, 3]` — elements preserved in order.
+        let c = array_of_call(vec![num(1.0, None), num(2.0, None), num(3.0, None)]);
+        let (out, _, changed, _) = run_pass(program_with_expr(c, true));
+        assert!(changed, "Array.of(1,2,3) should fold to [1,2,3]");
+        match extract_expr(&out) {
+            Expression::ArrayExpression(a) => {
+                assert_eq!(a.elements.len(), 3, "three elements");
+                let vals: Vec<f64> = a
+                    .elements
+                    .iter()
+                    .map(|e| match e {
+                        Some(Expression::NumericLiteral(n)) => n.value,
+                        other => panic!("expected numeric element; got {:?}", other),
+                    })
+                    .collect();
+                assert_eq!(vals, vec![1.0, 2.0, 3.0], "elements in order");
+            }
+            other => panic!("expected array literal; got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn fold_array_of_empty_to_empty_array() {
+        // `Array.of()` → `[]`.
+        let c = array_of_call(vec![]);
+        let (out, _, changed, _) = run_pass(program_with_expr(c, true));
+        assert!(changed, "Array.of() should fold to []");
+        match extract_expr(&out) {
+            Expression::ArrayExpression(a) => assert!(a.elements.is_empty(), "Array.of() → []"),
+            other => panic!("expected []; got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn fold_array_of_single_numeric_is_one_element_not_length() {
+        // The defining difference from the `Array(n)` constructor:
+        // `Array.of(7)` is the ONE-element array `[7]`, NOT `Array(7)`'s
+        // length-7 hole array. We must emit exactly one element whose value is 7.
+        let c = array_of_call(vec![num(7.0, None)]);
+        let (out, _, changed, _) = run_pass(program_with_expr(c, true));
+        assert!(changed, "Array.of(7) should fold to [7]");
+        match extract_expr(&out) {
+            Expression::ArrayExpression(a) => {
+                assert_eq!(a.elements.len(), 1, "exactly one element (not length 7)");
+                match &a.elements[0] {
+                    Some(Expression::NumericLiteral(n)) => assert_eq!(n.value, 7.0, "the value 7"),
+                    other => panic!("expected the literal 7; got {:?}", other),
+                }
+            }
+            other => panic!("expected [7]; got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn fold_array_of_preserves_identifier_arguments() {
+        // Identifier (and any other) arguments are preserved as elements in
+        // order — folding never drops or evaluates them, so side effects survive.
+        let c = array_of_call(vec![ident("x"), ident("y")]);
+        let (out, _, changed, _) = run_pass(program_with_expr(c, true));
+        assert!(changed, "Array.of(x, y) should fold to [x, y]");
+        match extract_expr(&out) {
+            Expression::ArrayExpression(a) => {
+                assert_eq!(a.elements.len(), 2, "two elements");
+                let names: Vec<&str> = a
+                    .elements
+                    .iter()
+                    .map(|e| match e {
+                        Some(Expression::Identifier(id)) => id.name.as_str(),
+                        other => panic!("expected identifier element; got {:?}", other),
+                    })
+                    .collect();
+                assert_eq!(names, vec!["x", "y"], "identifiers preserved in order");
+            }
+            other => panic!("expected [x, y]; got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn array_of_on_non_array_receiver_does_not_fold() {
+        // Only the bare global `Array` folds; `a.of(1)` is left alone.
+        let c = Expression::CallExpression(CallExpression {
+            cv: Some("c.cv".to_string()),
+            callee: Box::new(member(ident("a"), "of")),
+            arguments: vec![num(1.0, None)],
+        });
+        let (out, _, changed, _) = run_pass(program_with_expr(c, true));
+        assert!(!changed, "a.of(1) must not fold");
         assert!(matches!(extract_expr(&out), Expression::CallExpression(_)));
     }
 

--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.212.0] - 2026-06-26
+
+### Added — SIMPLE/ADVANCED fold static `Array.of(...)` → array literal `[...]`
+
+At `--compilation_level SIMPLE` (and ADVANCED, which routes through the same
+pipeline) the typed constant-fold pass now collapses a static `Array.of(v0, v1,
+…)` call (ECMAScript §23.1.2.3) to the array literal `[v0, v1, …]`. Unlike the
+`Array(n)` constructor — where a single numeric argument sets the *length* —
+`Array.of(7)` is the one-element array `[7]`, so the fold is sound for any
+argument list and preserves every element expression in evaluation order. Only
+the bare global `Array.of(...)` callee folds (never a shadowed `q.of(...)`).
+New end-to-end fixture `tests/diff/simple-fold-array-of/` plus integration test
+`tests/diff_simple_fold_array_of.rs`.
+
 ## [0.208.0] - 2026-06-26
 
 ### Added — SIMPLE/ADVANCED fold static `Object.keys/values/entries({})` → `[]`

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.208.0"
+version = "0.212.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.208.0",
+  "version": "0.212.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.208.0
+Version: 0.212.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff/simple-fold-array-of/README.md
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-array-of/README.md
@@ -1,0 +1,45 @@
+# `simple-fold-array-of` — static `Array.of(...)` → array literal `[...]`
+
+End-to-end fixture proving that, at `--compilation_level SIMPLE`, the typed
+constant-fold pass collapses a static `Array.of(v0, v1, …)` call (ECMAScript
+§23.1.2.3) to the array literal `[v0, v1, …]`.
+
+| call                | result      | note                                        |
+|---------------------|-------------|---------------------------------------------|
+| `Array.of()`        | `[]`        | empty argument list                          |
+| `Array.of(7)`       | `[7]`       | one element — NOT `Array(7)`'s length-7 array|
+| `Array.of(1, 2, 3)` | `[1, 2, 3]` | elements preserved in order                  |
+| `Array.of(x, y)`    | `[x, y]`    | identifier args preserved                    |
+| `q.of(1)`           | *unfolded*  | only the bare global `Array.of` folds        |
+
+## Soundness
+
+`Array.of` always builds a fresh array whose elements are exactly its arguments,
+in order — it is **not** the `Array(n)` constructor, where a single numeric
+argument sets the *length* (`Array(7)` is a length-7 hole array, `Array.of(7)`
+is `[7]`). Folding `Array.of(a, b, c)` to the array literal `[a, b, c]`
+preserves every element expression in evaluation order, so no argument is
+dropped, duplicated, or reordered and all side effects are retained — the fold
+is exact for **any** argument list. We would decline a spread argument
+(`Array.of(...xs)`), whose element count is unknown at compile time, but the AST
+has no call-argument spread variant yet, so every argument is a plain expression
+and the fold always applies. `Array.of` is a STATIC METHOD, so it dispatches
+through the `MemberExpression` callee arm — only the bare global `Array.of(...)`
+folds, never a shadowed receiver (`q.of(...)` is left alone).
+
+## Files
+
+- `flags.txt` — CLI flags (`--compilation_level SIMPLE --js input/a.js`).
+- `input/a.js` — five `var` bindings flowing into `report(...)` so each stays
+  referenced past remove-unused-vars and the fold is observable.
+- `expected.stdout` — the byte-exact SIMPLE output:
+
+  ```text
+  var a=[];var b=[7];var c=[1,2,3];var d=[x,y];var e=q.of(1);report(a,b,c,d,e);
+  ```
+
+The integration test `tests/diff_simple_fold_array_of.rs` runs the binary
+against these flags and asserts byte-exact stdout, the four folds (incl. the
+critical `Array.of(7)` → `[7]` distinction from `Array(7)`), the declined
+non-global receiver, and a regression guard that the typed SIMPLE pipeline ran
+(not the WHITESPACE_ONLY fallback): exactly one `Array.of`/`.of(` call remains.

--- a/code/programs/rust/closurec/tests/diff/simple-fold-array-of/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-array-of/expected.stdout
@@ -1,0 +1,1 @@
+var a=[];var b=[7];var c=[1,2,3];var d=[x,y];var e=q.of(1);report(a,b,c,d,e);

--- a/code/programs/rust/closurec/tests/diff/simple-fold-array-of/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-array-of/flags.txt
@@ -1,0 +1,4 @@
+--compilation_level
+SIMPLE
+--js
+tests/diff/simple-fold-array-of/input/a.js

--- a/code/programs/rust/closurec/tests/diff/simple-fold-array-of/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-array-of/input/a.js
@@ -1,0 +1,22 @@
+// SIMPLE-level static Array.of(...) fold → array literal [...].
+//
+// Array.of (ECMAScript §23.1.2.3) builds a fresh array whose elements are
+// EXACTLY its arguments, in order. Unlike the Array(n) constructor — where a
+// single numeric argument sets the LENGTH (Array(7) is a length-7 hole array) —
+// Array.of(7) is the one-element array [7], so the fold is sound for ANY
+// argument list (side effects of element expressions are preserved in order):
+//   * Array.of()        → []
+//   * Array.of(7)       → [7]        (NOT Array(7)'s length-7 array)
+//   * Array.of(1, 2, 3) → [1, 2, 3]
+//   * Array.of(x, y)    → [x, y]     (identifier args preserved)
+//   * q.of(1)           → declined (only the bare global Array.of folds)
+//
+// Under WHITESPACE_ONLY every call survives; under SIMPLE the bare-global
+// Array.of calls collapse to array literals. Each value flows into report(...)
+// so it stays referenced past remove-unused-vars and the fold is observable.
+var a = Array.of();
+var b = Array.of(7);
+var c = Array.of(1, 2, 3);
+var d = Array.of(x, y);
+var e = q.of(1);
+report(a, b, c, d, e);

--- a/code/programs/rust/closurec/tests/diff_simple_fold_array_of.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_fold_array_of.rs
@@ -1,0 +1,102 @@
+//! Integration test for the `tests/diff/simple-fold-array-of/` fixture.
+//!
+//! End-to-end oracle for static `Array.of(...)` folding in
+//! `closure-pass-constant-fold`: `Array.of(v0, v1, …)` collapses to the array
+//! literal `[v0, v1, …]` (ECMAScript §23.1.2.3) — exactly its arguments, in
+//! order. Crucially `Array.of(7)` is the one-element array `[7]`, NOT
+//! `Array(7)`'s length-7 hole array. A non-global receiver (`q.of(1)`) is
+//! declined.
+//!
+//! At SIMPLE the fixture optimizes to:
+//!
+//! ```text
+//! var a=[];var b=[7];var c=[1,2,3];var d=[x,y];var e=q.of(1);report(a,b,c,d,e);
+//! ```
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
+
+fn read_flags() -> Vec<String> {
+    let raw = std::fs::read_to_string("tests/diff/simple-fold-array-of/flags.txt")
+        .expect("read flags.txt");
+    raw.lines()
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[test]
+fn simple_fold_array_of_fixture_matches_expected_stdout() {
+    let flags = read_flags();
+    let out = Command::new(BINARY)
+        .args(&flags)
+        .output()
+        .expect("run closurec");
+
+    assert!(
+        out.status.success(),
+        "exit: {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let actual = String::from_utf8_lossy(&out.stdout);
+    let expected = std::fs::read_to_string("tests/diff/simple-fold-array-of/expected.stdout")
+        .expect("read expected.stdout");
+    assert_eq!(
+        actual.trim_end_matches('\n'),
+        expected.trim_end_matches('\n'),
+        "mismatch.\nflags: {flags:?}\nactual:\n{actual}\nexpected:\n{expected}",
+    );
+}
+
+/// Each bare-global `Array.of(...)` folds to the array literal of its arguments;
+/// the single-numeric case is the one-element `[7]`, NOT `Array(7)`'s length.
+#[test]
+fn simple_fold_array_of_folds_to_array_literal() {
+    let out = Command::new(BINARY)
+        .args(read_flags())
+        .output()
+        .expect("run closurec");
+    let actual = String::from_utf8_lossy(&out.stdout);
+
+    assert!(actual.contains("a=[]"), "Array.of() → []; got:\n{actual}");
+    assert!(
+        actual.contains("b=[7]"),
+        "Array.of(7) → [7] (one element, NOT Array(7)'s length-7); got:\n{actual}"
+    );
+    assert!(
+        actual.contains("c=[1,2,3]"),
+        "Array.of(1,2,3) → [1,2,3]; got:\n{actual}"
+    );
+    assert!(
+        actual.contains("d=[x,y]"),
+        "Array.of(x,y) → [x,y] (identifier args preserved); got:\n{actual}"
+    );
+    // The non-global receiver is NOT folded — the call must remain.
+    assert!(
+        actual.contains("e=q.of(1)"),
+        "q.of(1) must NOT fold (only the bare global Array.of); got:\n{actual}"
+    );
+}
+
+/// Regression guard: the output must be the SIMPLE typed pipeline, not the
+/// `WHITESPACE_ONLY` fallback (which would leave every call intact). Exactly one
+/// `.of(` call — the declined non-global receiver — may remain.
+#[test]
+fn simple_fold_array_of_did_not_fall_back_to_whitespace_only() {
+    let out = Command::new(BINARY)
+        .args(read_flags())
+        .output()
+        .expect("run closurec");
+    let actual = String::from_utf8_lossy(&out.stdout);
+
+    assert_eq!(
+        actual.matches(".of(").count(),
+        1,
+        "exactly one .of( call (the declined non-global receiver) should remain \
+         — proving the typed SIMPLE optimizer ran, not the whitespace fallback; \
+         got:\n{actual}",
+    );
+}


### PR DESCRIPTION
## What

Adds a constant-fold rule: static `Array.of(v0, v1, …)` (ECMAScript §23.1.2.3) folds to the array literal `[v0, v1, …]`.

| call | result | note |
|------|--------|------|
| `Array.of()` | `[]` | empty |
| `Array.of(7)` | `[7]` | one element — **NOT** `Array(7)`'s length-7 hole array |
| `Array.of(1, 2, 3)` | `[1, 2, 3]` | order preserved |
| `Array.of(x, y)` | `[x, y]` | identifier args preserved |
| `q.of(1)` | *unfolded* | only the bare global `Array.of` folds |

## Soundness

`Array.of` is variadic and always produces an array whose elements are exactly its arguments, in order — distinct from the `Array(n)` constructor where one numeric arg sets the *length*. Folding to `[…]` keeps every element expression in evaluation order, so no argument is dropped, duplicated, or reordered and all side effects are retained — exact for **any** arity. The emit maps each arg to `Some(arg)` (N dense elements, never a hole). A spread argument would be declined, but the parser bridge already rejects call-argument spread (`BridgeError::UnsupportedSyntax`), so the fold never sees one. Only the bare global `Array.of(...)` callee folds (non-computed `Identifier.Identifier`), never a shadowed receiver.

## Changes
- `closure-pass-constant-fold` 0.62.0 → **0.63.0**: dispatch + 5 unit tests.
- `closurec` 0.208.0 → **0.212.0**: fixture `simple-fold-array-of` + `diff_simple_fold_array_of.rs` + cli.spec + CHANGELOGs + help-markdown regen.

## Verification
- cf 249 lib tests pass; full cc suite (79 test binaries) 0 failures.
- Byte-exact SIMPLE output: `var a=[];var b=[7];var c=[1,2,3];var d=[x,y];var e=q.of(1);report(a,b,c,d,e);`
- Inline /security-review PASSED (element-order preservation, Array(n)-vs-Array.of distinction, spread decline, receiver guard all verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)