### PR TITLE
feat(visicalc-flutter): multi-sheet workbook in the Flutter demo

### DIFF
--- a/demo/visicalc-flutter/README.md
+++ b/demo/visicalc-flutter/README.md
@@ -151,6 +151,22 @@ unchanged. `InfiniteSheetModel`
 there's something to scroll to, and derives the extent from `usedRange()` + a
 margin.
 
+The bottom **sheet tab bar** drives a multi-sheet **workbook**: the workbook
+holds several sheets and bare-`A1` ops address the *active* one, while a formula
+reaches **across** with a qualifier (`=Summary!B3`). Each tab is a chip (the
+active one tints to the accent); **tap** to switch, **double-tap** to rename,
+**right-click / long-press** to delete, and **+ Sheet** adds one
+(`InfiniteSheetModel.selectSheet`/`renameSheet`/`deleteSheet`/`addSheet` over the
+C ABI's `sc_set_active_sheet`/`sc_rename_sheet`/`sc_delete_sheet`/`sc_add_sheet`,
+with `sc_sheet_names`/`sc_active_sheet` reading the tab list). The seed adds a
+second sheet, **Summary**, whose `B3` sums its own `A1`+`A2` (=300), and back on
+the first sheet `G1` = `=Summary!B3` pulls that value **across the sheets**;
+editing a Summary input recomputes the cross-sheet dependent live. Renaming
+`Summary` rewrites every referencing qualifier (the dependents stay live);
+deleting a referenced sheet turns the dangling reference into `#REF!`. The engine
+keeps at least one sheet, so deleting the last is a no-op. The single-sheet path
+is byte-identical — an unqualified `A1` still means the active sheet.
+
 #### Visual design
 
 `lib/infinite_grid.dart` mirrors the **reference visual language** defined by the
@@ -180,7 +196,11 @@ clamping + source load, `commitInf` recompute, drag-fill, clipboard copy/cut/
 paste, a save/load round trip — serialize → mutate → restore, with the loaded
 formula staying live and malformed input rejected — and an undo/redo walk on a
 fresh session (two edits → undo both → redo both with the formula recomputing
-live → a fresh edit forks history)).
+live → a fresh edit forks history)). A **multi-sheet** group proves the workbook
+over the C ABI: a cross-sheet `=Summary!B3` computes and stays live as its
+precedent changes, a rename rewrites the referencing qualifier, deleting a
+referenced sheet yields `#REF!` (and the last sheet can't be deleted), and the
+`InfiniteSheetModel` seed exposes `Sheet1`/`Summary` with a live cross-ref.
 
 `test/infinite_grid_test.dart` is a **widget test** that pumps the real
 `InfiniteGrid` tree on the live engine, taps the A1 cell, edits `15`→`115` in the

--- a/demo/visicalc-flutter/lib/engine.dart
+++ b/demo/visicalc-flutter/lib/engine.dart
@@ -88,6 +88,22 @@ typedef _FindAllD = Pointer<Uint8> Function(Pointer<Void>, Pointer<Uint8>, int, 
 typedef _ReplaceAllC = Int32 Function(Pointer<Void>, Pointer<Uint8>, Pointer<Uint8>, Int32);
 typedef _ReplaceAllD = int Function(Pointer<Void>, Pointer<Uint8>, Pointer<Uint8>, int);
 
+// Multi-sheet workbook. sc_sheet_names(session) → char* JSON
+// {"sheets":[…],"active":i} (free with sc_string_free); sc_active_sheet → u32;
+// sc_set_active_sheet/sc_add_sheet/sc_rename_sheet/sc_delete_sheet → int 1/0.
+typedef _SheetNamesC = Pointer<Uint8> Function(Pointer<Void>);
+typedef _SheetNamesD = Pointer<Uint8> Function(Pointer<Void>);
+typedef _ActiveSheetC = Uint32 Function(Pointer<Void>);
+typedef _ActiveSheetD = int Function(Pointer<Void>);
+typedef _SetActiveSheetC = Int32 Function(Pointer<Void>, Uint32);
+typedef _SetActiveSheetD = int Function(Pointer<Void>, int);
+typedef _AddSheetC = Int32 Function(Pointer<Void>, Pointer<Uint8>);
+typedef _AddSheetD = int Function(Pointer<Void>, Pointer<Uint8>);
+typedef _RenameSheetC = Int32 Function(Pointer<Void>, Uint32, Pointer<Uint8>);
+typedef _RenameSheetD = int Function(Pointer<Void>, int, Pointer<Uint8>);
+typedef _DeleteSheetC = Int32 Function(Pointer<Void>, Uint32);
+typedef _DeleteSheetD = int Function(Pointer<Void>, int);
+
 // sc_insert_rows / sc_delete_rows / sc_insert_cols / sc_delete_cols(session, at,
 // count) → void. Structural edits at a 1-based position; the engine shifts
 // formula references across the band.
@@ -120,6 +136,12 @@ class SpreadsheetSession {
   late final _SortRangeD _sortRangeFn;
   late final _FindAllD _findAllFn;
   late final _ReplaceAllD _replaceAllFn;
+  late final _SheetNamesD _sheetNamesFn;
+  late final _ActiveSheetD _activeSheetFn;
+  late final _SetActiveSheetD _setActiveSheetFn;
+  late final _AddSheetD _addSheetFn;
+  late final _RenameSheetD _renameSheetFn;
+  late final _DeleteSheetD _deleteSheetFn;
   late final _ClipD _copyFn;
   late final _ClipD _cutFn;
   late final _PasteD _pasteFn;
@@ -159,6 +181,12 @@ class SpreadsheetSession {
     _sortRangeFn = _lib.lookupFunction<_SortRangeC, _SortRangeD>('sc_sort_range');
     _findAllFn = _lib.lookupFunction<_FindAllC, _FindAllD>('sc_find_all');
     _replaceAllFn = _lib.lookupFunction<_ReplaceAllC, _ReplaceAllD>('sc_replace_all');
+    _sheetNamesFn = _lib.lookupFunction<_SheetNamesC, _SheetNamesD>('sc_sheet_names');
+    _activeSheetFn = _lib.lookupFunction<_ActiveSheetC, _ActiveSheetD>('sc_active_sheet');
+    _setActiveSheetFn = _lib.lookupFunction<_SetActiveSheetC, _SetActiveSheetD>('sc_set_active_sheet');
+    _addSheetFn = _lib.lookupFunction<_AddSheetC, _AddSheetD>('sc_add_sheet');
+    _renameSheetFn = _lib.lookupFunction<_RenameSheetC, _RenameSheetD>('sc_rename_sheet');
+    _deleteSheetFn = _lib.lookupFunction<_DeleteSheetC, _DeleteSheetD>('sc_delete_sheet');
     _copyFn = _lib.lookupFunction<_ClipC, _ClipD>('sc_copy');
     _cutFn = _lib.lookupFunction<_ClipC, _ClipD>('sc_cut');
     _pasteFn = _lib.lookupFunction<_PasteC, _PasteD>('sc_paste');
@@ -384,6 +412,42 @@ class SpreadsheetSession {
       _freeCString(rPtr);
     }
   }
+
+  // ── Multi-sheet workbook ───────────────────────────────────────────
+  // Bare-A1 ops address the ACTIVE sheet; a formula may reference another
+  // (=Summary!A1). sheetNames() → { 'sheets': [names…], 'active': index }.
+
+  // Defensive, like [window]/[usedRange]/[changedSince]: a malformed/empty
+  // engine payload yields an empty workbook view rather than a thrown cast.
+  Map<String, dynamic> sheetNames() {
+    final json = _takeString(_sheetNamesFn(_handle));
+    final Object? obj = json.isEmpty ? null : jsonDecode(json);
+    return obj is Map
+        ? obj.cast<String, dynamic>()
+        : <String, dynamic>{'sheets': <String>[], 'active': 0};
+  }
+
+  int activeSheet() => _activeSheetFn(_handle);
+  bool setActiveSheet(int index) => _setActiveSheetFn(_handle, _u32(index)) != 0;
+  bool addSheet(String name) {
+    final p = _toCString(name);
+    try {
+      return _addSheetFn(_handle, p) != 0;
+    } finally {
+      _freeCString(p);
+    }
+  }
+
+  bool renameSheet(int index, String newName) {
+    final p = _toCString(newName);
+    try {
+      return _renameSheetFn(_handle, _u32(index), p) != 0;
+    } finally {
+      _freeCString(p);
+    }
+  }
+
+  bool deleteSheet(int index) => _deleteSheetFn(_handle, _u32(index)) != 0;
 
   /// Structural edits: insert / delete [count] rows or columns at the 1-based
   /// position [at]. The engine shifts every formula reference at or after the
@@ -651,6 +715,18 @@ class InfiniteSheetModel {
     for (final f in formats) {
       _session.setFormat(f[0], f[1]);
     }
+
+    // A second sheet, "Summary", proves cross-sheet references compute live:
+    // its B3 sums two of its own cells, and back on the first sheet G1 reaches
+    // ACROSS with a qualifier (`=Summary!B3`) — identical seed to the web/Qt
+    // demos. The first sheet stays active (bare-A1 ops still address it).
+    _session.addSheet('Summary');
+    _session.setActiveSheet(1);
+    _session.setCell('A1', '100');
+    _session.setCell('A2', '200');
+    _session.setCell('B3', '=A1+A2'); // 300, on the Summary sheet
+    _session.setActiveSheet(0);
+    _session.setCell('G1', '=Summary!B3'); // 300, pulled across the sheets
   }
 
   /// Re-derive the virtual grid size from the engine's data extent plus a
@@ -821,5 +897,56 @@ class InfiniteSheetModel {
       formula = _session.getRaw(infAddress);
     }
     return ok;
+  }
+
+  // ── Multi-sheet workbook ───────────────────────────────────────────
+  // The workbook holds several sheets; bare-A1 ops address the ACTIVE one,
+  // while a formula may reach across with a qualifier (`=Summary!A1`). The
+  // tab bar reads [sheetNames]/[activeSheet] and drives the mutators below;
+  // each refreshes the extent + formula bar so the windowed view re-reads.
+
+  /// The sheet names in tab order.
+  List<String> get sheetNames {
+    final m = _session.sheetNames();
+    return (m['sheets'] as List?)?.cast<String>() ?? const [];
+  }
+
+  /// The active sheet's 0-based index.
+  int get activeSheet => _session.activeSheet();
+
+  /// Switch the active sheet (bare-A1 ops now address it). Reselects A1's
+  /// neighbourhood by re-priming the formula bar at the current cursor.
+  void selectSheet(int index) {
+    if (_session.setActiveSheet(index)) {
+      computeExtent();
+      selectInf(selRow, selCol);
+    }
+  }
+
+  /// Add a new empty sheet and switch to it.
+  void addSheet(String name) {
+    if (_session.addSheet(name)) {
+      _session.setActiveSheet(sheetNames.length - 1);
+      computeExtent();
+      selectInf(1, 1);
+    }
+  }
+
+  /// Rename a sheet by index; cross-sheet references that named it are
+  /// rewritten by the engine, so dependents stay live.
+  void renameSheet(int index, String newName) {
+    if (_session.renameSheet(index, newName)) {
+      computeExtent();
+      selectInf(selRow, selCol);
+    }
+  }
+
+  /// Delete a sheet by index. References into it become `#REF!`; the engine
+  /// keeps at least one sheet, so this is a no-op on the last one.
+  void deleteSheet(int index) {
+    if (_session.deleteSheet(index)) {
+      computeExtent();
+      selectInf(1, 1);
+    }
   }
 }

--- a/demo/visicalc-flutter/lib/infinite_grid.dart
+++ b/demo/visicalc-flutter/lib/infinite_grid.dart
@@ -226,6 +226,63 @@ class _InfiniteGridState extends State<InfiniteGrid> {
     });
   }
 
+  // ── Multi-sheet tab handlers ──
+  // Switch the active sheet, add one, rename via a small dialog, or delete the
+  // active sheet. Each re-syncs the formula bar to the (re-primed) selection.
+  void _selectSheet(int index) => setState(() {
+        _model.selectSheet(index);
+        _formulaCtrl.text = _model.formula;
+      });
+
+  void _addSheet() {
+    // Name the new sheet "SheetN" where N avoids a clash with existing names.
+    final names = _model.sheetNames.toSet();
+    var n = names.length + 1;
+    while (names.contains('Sheet$n')) {
+      n++;
+    }
+    setState(() {
+      _model.addSheet('Sheet$n');
+      _formulaCtrl.text = _model.formula;
+    });
+  }
+
+  Future<void> _renameSheet(int index) async {
+    final ctrl = TextEditingController(text: _model.sheetNames[index]);
+    final newName = await showDialog<String>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: _cPanel,
+        title: const Text('Rename sheet', style: TextStyle(color: _cInk, fontSize: 14)),
+        content: TextField(
+          controller: ctrl,
+          autofocus: true,
+          style: const TextStyle(color: _cInk, fontFamily: _mono),
+          cursorColor: _cAccent,
+          onSubmitted: (v) => Navigator.of(ctx).pop(v),
+          decoration: const InputDecoration(border: OutlineInputBorder()),
+        ),
+        actions: [
+          TextButton(onPressed: () => Navigator.of(ctx).pop(), child: const Text('Cancel')),
+          TextButton(
+              onPressed: () => Navigator.of(ctx).pop(ctrl.text),
+              child: const Text('Rename')),
+        ],
+      ),
+    );
+    ctrl.dispose();
+    if (newName == null || newName.trim().isEmpty) return;
+    setState(() {
+      _model.renameSheet(index, newName.trim());
+      _formulaCtrl.text = _model.formula;
+    });
+  }
+
+  void _deleteSheet(int index) => setState(() {
+        _model.deleteSheet(index);
+        _formulaCtrl.text = _model.formula;
+      });
+
   // A compact, modern toolbar button (rounded chip with hover/down/disabled
   // states) — the Flutter analog of the web demo's segmented controls and the
   // Qt port's `component ToolButton`. `enabled: null` disables it (Undo/Redo/
@@ -284,6 +341,7 @@ class _InfiniteGridState extends State<InfiniteGrid> {
           _formulaBar(),
           _header(),
           Expanded(child: _bodyRow()),
+          _sheetTabs(),
           _statusBar(),
         ],
       ),
@@ -444,6 +502,72 @@ class _InfiniteGridState extends State<InfiniteGrid> {
               enabled: _model.canRedo),
         ],
         ),
+      ),
+    );
+  }
+
+  // ── Sheet tab bar (Excel-style, along the bottom) ──
+  // One chip per sheet; the active one tints to the accent. Tap to switch,
+  // double-tap to rename, right-click (or long-press) to delete; the trailing
+  // "+" adds a sheet. A formula like `=Summary!B3` reaches across the tabs, so
+  // switching sheets and editing here updates every cross-sheet dependent live.
+  Widget _sheetTabs() {
+    final names = _model.sheetNames;
+    final active = _model.activeSheet;
+    return Container(
+      height: 34,
+      margin: const EdgeInsets.fromLTRB(10, 4, 10, 0),
+      decoration: const BoxDecoration(
+        border: Border(top: BorderSide(color: _cLine)),
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: ListView.builder(
+              scrollDirection: Axis.horizontal,
+              itemCount: names.length,
+              itemBuilder: (_, i) {
+                final selected = i == active;
+                return Padding(
+                  padding: const EdgeInsets.only(right: 4, top: 4),
+                  child: Tooltip(
+                    message: 'Tap to switch · double-tap to rename · right-click to delete',
+                    child: GestureDetector(
+                      onTap: () => _selectSheet(i),
+                      onDoubleTap: () => _renameSheet(i),
+                      onSecondaryTap: () => _deleteSheet(i),
+                      onLongPress: () => _deleteSheet(i),
+                      child: Container(
+                        key: Key('sheetTab_$i'),
+                        padding: const EdgeInsets.symmetric(horizontal: 12),
+                        alignment: Alignment.center,
+                        decoration: BoxDecoration(
+                          color: selected ? _cSel : _cSurface,
+                          borderRadius: const BorderRadius.vertical(top: Radius.circular(6)),
+                          border: Border.all(
+                            color: selected ? _cAccent : _cLineStrong,
+                            width: selected ? 2 : 1,
+                          ),
+                        ),
+                        child: Text(
+                          names[i],
+                          style: TextStyle(
+                            color: selected ? Colors.white : _cInk,
+                            fontSize: 12,
+                            fontWeight: selected ? FontWeight.bold : FontWeight.normal,
+                            fontFamily: _mono,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                );
+              },
+            ),
+          ),
+          const SizedBox(width: 6),
+          _toolButton('+ Sheet', 'Add a new sheet', _addSheet),
+        ],
       ),
     );
   }

--- a/demo/visicalc-flutter/test/window_test.dart
+++ b/demo/visicalc-flutter/test/window_test.dart
@@ -333,4 +333,94 @@ void main() {
       expect(s.replaceAll('', 'q', true), 0);
     });
   });
+
+  // ── Multi-sheet workbook + cross-sheet references ──
+  // The workbook holds several sheets; bare-A1 ops address the ACTIVE sheet,
+  // while a formula reaches across with a qualifier (`=Summary!B3`). This proves
+  // the Dart ↔ C ABI path drives sheet management and cross-sheet recompute —
+  // the Flutter sibling of verify-infinite.mjs's multi-sheet section and the Qt
+  // tst_window multiSheet test.
+  group('multi-sheet workbook over dart:ffi', () {
+    test('cross-sheet reference computes and stays live', () {
+      final s = SpreadsheetSession();
+      addTearDown(s.dispose);
+
+      // Start on Sheet1 (the default). Add a second sheet and fill it.
+      expect(s.sheetNames()['sheets'], ['Sheet1']);
+      expect(s.addSheet('Summary'), isTrue);
+      expect(s.sheetNames()['sheets'], ['Sheet1', 'Summary']);
+
+      // Edit the Summary sheet (index 1): B3 = A1 + A2 = 300.
+      expect(s.setActiveSheet(1), isTrue);
+      expect(s.activeSheet(), 1);
+      s.setCell('A1', '100');
+      s.setCell('A2', '200');
+      s.setCell('B3', '=A1+A2');
+      expect(s.window(3, 2, 3, 2)[0][0], '300'); // Summary!B3
+
+      // Back on Sheet1, reach ACROSS with a qualifier.
+      expect(s.setActiveSheet(0), isTrue);
+      s.setCell('G1', '=Summary!B3');
+      expect(s.window(1, 7, 1, 7)[0][0], '300'); // Sheet1!G1 pulled across
+
+      // Editing a Summary input recomputes the cross-sheet dependent live.
+      expect(s.setActiveSheet(1), isTrue);
+      s.setCell('A1', '150'); // Summary!A1: 100 → 150, so B3 = 350
+      expect(s.setActiveSheet(0), isTrue);
+      expect(s.window(1, 7, 1, 7)[0][0], '350'); // Sheet1!G1 follows
+    });
+
+    test('renaming a sheet rewrites cross-sheet references', () {
+      final s = SpreadsheetSession();
+      addTearDown(s.dispose);
+      s.addSheet('Summary');
+      s.setActiveSheet(1);
+      s.setCell('B3', '=10+20'); // 30
+      s.setActiveSheet(0);
+      s.setCell('G1', '=Summary!B3');
+      expect(s.window(1, 7, 1, 7)[0][0], '30');
+
+      // Rename Summary → Totals; the qualifier in G1 is rewritten by the engine.
+      expect(s.renameSheet(1, 'Totals'), isTrue);
+      expect(s.sheetNames()['sheets'], ['Sheet1', 'Totals']);
+      expect(s.getRaw('G1'), contains('Totals')); // source now names Totals
+      expect(s.window(1, 7, 1, 7)[0][0], '30'); // still live after the rename
+    });
+
+    test('deleting a referenced sheet yields #REF!', () {
+      final s = SpreadsheetSession();
+      addTearDown(s.dispose);
+      s.addSheet('Summary');
+      s.setActiveSheet(1);
+      s.setCell('B3', '=5+5'); // 10
+      s.setActiveSheet(0);
+      s.setCell('G1', '=Summary!B3');
+      expect(s.window(1, 7, 1, 7)[0][0], '10');
+
+      // Delete Summary (index 1); the dangling cross-sheet ref becomes #REF!.
+      expect(s.deleteSheet(1), isTrue);
+      expect(s.sheetNames()['sheets'], ['Sheet1']);
+      expect(s.window(1, 7, 1, 7)[0][0], contains('#REF!'));
+
+      // The engine keeps at least one sheet: deleting the last one is a no-op.
+      expect(s.deleteSheet(0), isFalse);
+      expect(s.sheetNames()['sheets'], ['Sheet1']);
+    });
+
+    test('InfiniteSheetModel seeds a Summary sheet with a live cross-ref', () {
+      final m = InfiniteSheetModel();
+      addTearDown(m.dispose);
+
+      // The seed leaves Sheet1 active with a cross-sheet G1 = Summary!B3 = 300.
+      expect(m.sheetNames, ['Sheet1', 'Summary']);
+      expect(m.activeSheet, 0);
+      m.selectA1('G1');
+      expect(m.rowCells(1)[6], '300'); // Sheet1!G1 (col 7, 0-based index 6)
+
+      // Switch to Summary and confirm its own cells compute there.
+      m.selectSheet(1);
+      expect(m.activeSheet, 1);
+      expect(m.rowCells(3)[1], '300'); // Summary!B3 = A1+A2 = 100+200
+    });
+  });
 }


### PR DESCRIPTION
Roll out **multi-sheet + cross-sheet references** to the **Flutter** VisiCalc demo — the **3rd of 6** backends, after the web ([#6723](https://github.com/adhithyan15/coding-adventures/pull/6723)) and Qt ([#6726](https://github.com/adhithyan15/coding-adventures/pull/6726)) demos. The workbook holds several sheets; bare-`A1` ops address the **active** sheet, while a formula reaches **across** with a qualifier (`=Summary!B3`). The single-sheet path stays **byte-identical** — an unqualified `A1` still means the active sheet.

## What changed

**Engine binding** (`lib/engine.dart`, `SpreadsheetSession` over the C ABI)
- 6 sheet ops wired through `dart:ffi` — `sc_sheet_names` / `sc_active_sheet` / `sc_set_active_sheet` / `sc_add_sheet` / `sc_rename_sheet` / `sc_delete_sheet` — with typedefs, fields, lookups, and exception-safe `_toCString`/`_freeCString` for the name-passing calls (matching the find/replace pattern).
- `sheetNames()` decodes **defensively** (empty/malformed engine payload → empty workbook view, like `window`/`usedRange`/`changedSince`); index mutators clamp through the existing `_u32` helper before crossing the ABI.

**Model** (`InfiniteSheetModel`): `sheetNames`/`activeSheet` getters + `selectSheet`/`addSheet`/`renameSheet`/`deleteSheet` passthrough, each refreshing the extent and re-priming the formula bar. The seed adds a second sheet, **Summary** (`B3 = A1+A2 = 300`), and `Sheet1!G1 = =Summary!B3` pulls it across.

**UI** (`lib/infinite_grid.dart`): an Excel-style **sheet tab bar** along the bottom — one chip per sheet (active tints to the accent); **tap** to switch, **double-tap** to rename (dialog), **right-click / long-press** to delete, **+ Sheet** to add. Names render as `Text` only (no interpolation into markup).

## Proof
- A new **multi-sheet group** in `test/window_test.dart` over the C ABI: cross-sheet `=Summary!B3` computes and stays live as its precedent changes, a rename rewrites the referencing qualifier, deleting a referenced sheet yields `#REF!` (and the last sheet can't be deleted), and the `InfiniteSheetModel` seed exposes `Sheet1`/`Summary` with a live cross-ref.
- `flutter test` green (engine + window + widget); `flutter analyze` clean (only the pre-existing generated-file warnings). README updated.

## Security review
PASSED — two LOW findings (unguarded `jsonDecode` cast; index not clamped before the ABI) fixed by adopting the file's own defensive-decode and `_u32` conventions. No memory-safety issues (the Rust C ABI is `#![forbid(unsafe_code)]`, null- and range-guarded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)