### PR TITLE
feat(visicalc-compose): multi-sheet workbook in the Compose demo

### DIFF
--- a/demo/visicalc-compose/README.md
+++ b/demo/visicalc-compose/README.md
@@ -130,6 +130,21 @@ typed (`15`→`99` re-totals every dependent).
 `InfiniteSheetModel` (in `Engine.kt`) seeds far-flung
 sparse cells (`Z1000`, `BA50`, `BB50`) and derives the extent from `usedRange()`
 + a margin.
+The bottom **sheet tab bar** drives a multi-sheet **workbook**: the workbook
+holds several sheets and bare-`A1` ops address the *active* one, while a formula
+reaches **across** with a qualifier (`=Summary!B3`). Each tab is a chip (the
+active one tints to the accent); **click** to switch, the active tab carries
+inline **✎ rename** (a dialog) and **✕ delete** affordances, and **+ Sheet** adds
+one (`InfiniteSheetModel.selectSheet`/`addSheet`/`renameSheet`/`deleteSheet` over
+the C ABI's `sc_set_active_sheet`/`sc_add_sheet`/`sc_rename_sheet`/
+`sc_delete_sheet`, with `sc_sheet_names`/`sc_active_sheet` reading the tab list).
+The seed adds a second sheet, **Summary** (`B3 = A1+A2 = 300`), and `Sheet1!G1 =
+=Summary!B3` pulls that value across; editing a Summary input recomputes the
+cross-sheet dependent live. Renaming `Summary` rewrites every referencing
+qualifier; deleting a referenced sheet turns the dangling reference into `#REF!`,
+and the engine keeps at least one sheet (deleting the last is a no-op). The
+single-sheet path is byte-identical — an unqualified `A1` still means the active
+sheet.
 
 #### Visual design
 
@@ -169,7 +184,12 @@ forks history). And it drives **find / replace**: `findAll("15")` locates the on
 literal (`A1`), a case-insensitive `findAll("sum")` finds the total formulas,
 empty / no-match queries return nothing, `selectA1("Z1000")` parses a far address,
 and `replaceAll` rewrites both a literal (`15`→`99` ⇒ E1 122.00) and a formula
-reference (`H1`→`H2` ⇒ `=H1+5` recomputes to 25) keeping each live.
+reference (`H1`→`H2` ⇒ `=H1+5` recomputes to 25) keeping each live. Finally a
+**multi-sheet** section proves the workbook over the C ABI: a cross-sheet
+`=Summary!B3` computes and stays live as its precedent changes (300 → 350), a
+rename rewrites the referencing qualifier (`Summary` → `Totals`), deleting a
+referenced sheet yields `#REF!` (and the last sheet can't be deleted), and the
+`InfiniteSheetModel` seed exposes `Sheet1`/`Summary` with a live cross-ref.
 
 The Compose UI itself (`InfiniteSheet.kt` + the `Main.kt` toggle) is verified to
 compile against the real Compose Desktop APIs via `gradle compileKotlin`; the

--- a/demo/visicalc-compose/src/main/kotlin/Engine.kt
+++ b/demo/visicalc-compose/src/main/kotlin/Engine.kt
@@ -83,6 +83,18 @@ class SpreadsheetSession(libraryPath: String = resolveLibraryPath()) : AutoClose
     private val scColumnLetters = handle("sc_column_letters", FunctionDescriptor.of(ptr, ptr, i32))
     private val scCurrentRevision = handle("sc_current_revision", FunctionDescriptor.of(i64, ptr))
     private val scChangedSince = handle("sc_changed_since", FunctionDescriptor.of(ptr, ptr, i64))
+    // Multi-sheet workbook. sc_sheet_names(session) -> char* JSON
+    //   {"sheets":[<name>,...],"active":<i>}; sc_active_sheet(session) -> u32;
+    //   sc_set_active_sheet/sc_delete_sheet(session, index) -> int 1/0;
+    //   sc_add_sheet(session, name) -> int; sc_rename_sheet(session, index, name)
+    //   -> int. (Every descriptor includes the session ptr arg — omitting it
+    //   would mismatch the native arity and trip a WrongMethodTypeException.)
+    private val scSheetNames = handle("sc_sheet_names", FunctionDescriptor.of(ptr, ptr))
+    private val scActiveSheet = handle("sc_active_sheet", FunctionDescriptor.of(i32, ptr))
+    private val scSetActiveSheet = handle("sc_set_active_sheet", FunctionDescriptor.of(i32, ptr, i32))
+    private val scAddSheet = handle("sc_add_sheet", FunctionDescriptor.of(i32, ptr, ptr))
+    private val scRenameSheet = handle("sc_rename_sheet", FunctionDescriptor.of(i32, ptr, i32, ptr))
+    private val scDeleteSheet = handle("sc_delete_sheet", FunctionDescriptor.of(i32, ptr, i32))
 
     private val session = scNew.invoke() as MemorySegment
 
@@ -313,6 +325,48 @@ class SpreadsheetSession(libraryPath: String = resolveLibraryPath()) : AutoClose
         return Pair(changed, false)
     }
 
+    // ── Multi-sheet workbook ──────────────────────────────────────────
+    // The workbook holds several sheets; bare-A1 ops address the ACTIVE one,
+    // while a formula reaches across with a qualifier (=Summary!A1). These
+    // manage the sheet set + the active sheet; the host re-reads afterwards.
+    // The single-sheet path is unchanged — an unqualified A1 is the active sheet.
+
+    /// The sheet names in tab order plus the active 0-based index. A malformed
+    /// engine payload yields an empty workbook view (defensive, like [window]).
+    fun sheetNames(): Pair<List<String>, Int> {
+        val obj = parseJson(take(scSheetNames.invoke(session) as MemorySegment)) as? Map<*, *>
+            ?: return Pair(emptyList(), 0)
+        val names = (obj["sheets"] as? List<*>)?.map { it as? String ?: "" } ?: emptyList()
+        val active = (obj["active"] as? Number)?.toInt() ?: 0
+        return Pair(names, active)
+    }
+
+    /// The active sheet's 0-based index.
+    fun activeSheet(): Int = scActiveSheet.invoke(session) as Int
+
+    /// Switch the active sheet by 0-based index; false for an out-of-range index.
+    /// [index] is clamped to ≥ 0 before the call (Kotlin Int maxes below u32, so
+    /// no high-end truncation); the engine validates the upper bound.
+    fun setActiveSheet(index: Int): Boolean =
+        (scSetActiveSheet.invoke(session, maxOf(0, index)) as Int) != 0
+
+    /// Add a new sheet named [name] and make it active; false for an empty or
+    /// duplicate name.
+    fun addSheet(name: String): Boolean = Arena.ofConfined().use { a ->
+        (scAddSheet.invoke(session, a.allocateUtf8String(name)) as Int) != 0
+    }
+
+    /// Rename the sheet at [index] to [newName] (the engine rewrites every
+    /// referencing formula's qualifier). False for a bad index / empty / duplicate.
+    fun renameSheet(index: Int, newName: String): Boolean = Arena.ofConfined().use { a ->
+        (scRenameSheet.invoke(session, maxOf(0, index), a.allocateUtf8String(newName)) as Int) != 0
+    }
+
+    /// Delete the sheet at [index] (inbound references become `#REF!`). False for
+    /// a bad index or an attempt to delete the last remaining sheet.
+    fun deleteSheet(index: Int): Boolean =
+        (scDeleteSheet.invoke(session, maxOf(0, index)) as Int) != 0
+
     override fun close() {
         scFree.invoke(session)
     }
@@ -455,6 +509,19 @@ class InfiniteSheetModel(
             "Z1000" to "0.0%", // 39 -> "3900.0%": proves the format applies far off-origin
         )
         for ((a1, code) in formats) session.setFormat(a1, code)
+
+        // A second sheet, "Summary", proves cross-sheet references compute live:
+        // its B3 sums two of its own cells, and back on the first sheet G1 reaches
+        // ACROSS with a qualifier (=Summary!B3) — identical seed to the
+        // web/Qt/Flutter demos. The first sheet stays active (bare-A1 ops still
+        // address it).
+        session.addSheet("Summary")
+        session.setActiveSheet(1)
+        session.setCell("A1", "100")
+        session.setCell("A2", "200")
+        session.setCell("B3", "=A1+A2") // 300, on the Summary sheet
+        session.setActiveSheet(0)
+        session.setCell("G1", "=Summary!B3") // 300, pulled across the sheets
     }
 
     /// Re-derive the virtual grid size from the engine's data extent plus a
@@ -632,6 +699,52 @@ class InfiniteSheetModel(
             formula = session.getRaw(infAddress())
         }
         return ok
+    }
+
+    // ── Multi-sheet workbook ──────────────────────────────────────────
+    // The workbook holds several sheets; bare-A1 ops address the ACTIVE one,
+    // while a formula reaches across with a qualifier (=Summary!A1). The tab bar
+    // reads [sheetNames]/[activeSheet] and drives the mutators below; each
+    // refreshes the extent + re-primes the formula bar so the windowed view re-reads.
+
+    /// The sheet names in tab order.
+    fun sheetNames(): List<String> = session.sheetNames().first
+
+    /// The active sheet's 0-based index.
+    fun activeSheet(): Int = session.activeSheet()
+
+    /// Switch the active sheet (bare-A1 ops now address it); re-prime the bar.
+    fun selectSheet(index: Int) {
+        if (session.setActiveSheet(index)) {
+            computeExtent()
+            selectInf(selRow, selCol)
+        }
+    }
+
+    /// Add a new empty sheet and switch to it.
+    fun addSheet(name: String) {
+        if (session.addSheet(name)) {
+            computeExtent()
+            selectInf(1, 1)
+        }
+    }
+
+    /// Rename a sheet by index; cross-sheet references that named it are
+    /// rewritten by the engine, so dependents stay live.
+    fun renameSheet(index: Int, newName: String) {
+        if (session.renameSheet(index, newName)) {
+            computeExtent()
+            selectInf(selRow, selCol)
+        }
+    }
+
+    /// Delete a sheet by index. References into it become `#REF!`; the engine
+    /// keeps at least one sheet, so this is a no-op on the last one.
+    fun deleteSheet(index: Int) {
+        if (session.deleteSheet(index)) {
+            computeExtent()
+            selectInf(1, 1)
+        }
     }
 
     override fun close() = session.close()

--- a/demo/visicalc-compose/src/main/kotlin/InfiniteSheet.kt
+++ b/demo/visicalc-compose/src/main/kotlin/InfiniteSheet.kt
@@ -232,6 +232,42 @@ fun InfiniteSheet() {
         findStatus = "$n replaced"
     }
 
+    // ── Multi-sheet workbook ──
+    // `sheetRev` is bumped on every sheet op so the tab bar recomposes. After a
+    // switch/add/delete the model re-primes the selection, so we mirror it back
+    // into the Compose state. `renaming` (≥ 0) opens the rename dialog for that
+    // tab index; `renameText` holds the in-progress name.
+    var sheetRev by remember { mutableStateOf(0) }
+    var renaming by remember { mutableStateOf(-1) }
+    var renameText by remember { mutableStateOf("") }
+
+    fun syncFromModel() {
+        selRow = model.selRow
+        selCol = model.selCol
+        formula = model.formula
+        rev++
+        sheetRev++
+    }
+
+    fun switchSheet(i: Int) { model.selectSheet(i); syncFromModel() }
+    fun deleteSheet(i: Int) { model.deleteSheet(i); syncFromModel() }
+    fun addSheet() {
+        // Name the new sheet "SheetN" where N avoids a clash with existing names.
+        val existing = model.sheetNames().toSet()
+        var n = existing.size + 1
+        while (existing.contains("Sheet$n")) n++
+        model.addSheet("Sheet$n")
+        syncFromModel()
+    }
+    fun commitRename() {
+        val i = renaming
+        if (i >= 0 && renameText.isNotBlank()) {
+            model.renameSheet(i, renameText.trim())
+            syncFromModel()
+        }
+        renaming = -1
+    }
+
     Column(modifier = Modifier.fillMaxSize().background(BG)) {
         // ── Formula bar: a panel holding the address pill, an `fx` marker, the
         // editable source line (with an accent focus ring), and segmented button
@@ -385,6 +421,123 @@ fun InfiniteSheet() {
                                 dataCell(text, rowNum, selected) { select(rowNum, c) }
                             }
                         }
+                    }
+                }
+            }
+        }
+
+        // ── Sheet tab bar (Excel-style, along the bottom) ──
+        // One chip per sheet; the active one tints to the accent. Click a tab to
+        // switch (bare-A1 ops then address it); the active tab carries inline
+        // ✎ rename and ✕ delete affordances, and "+ Sheet" adds one. A formula
+        // like `=Summary!B3` reaches across the tabs, so switching and editing
+        // here updates every cross-sheet dependent live. Reading `sheetRev`
+        // recomposes the bar after any sheet op.
+        val (sheetNames, activeSheet) = sheetRev.let { model.sheetNames() to model.activeSheet() }
+        Box(modifier = Modifier.fillMaxWidth().padding(horizontal = 10.dp).height(1.dp).background(LINE))
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .fillMaxWidth()
+                .horizontalScroll(rememberScrollState())
+                .padding(start = 10.dp, end = 10.dp, top = 6.dp),
+        ) {
+            sheetNames.forEachIndexed { i, name ->
+                val selected = i == activeSheet
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier
+                        .padding(end = 4.dp)
+                        .clip(RoundedCornerShape(6.dp))
+                        .background(if (selected) SEL else SURFACE)
+                        .border(
+                            if (selected) 2.dp else 1.dp,
+                            if (selected) ACCENT else LINE_STRONG,
+                            RoundedCornerShape(6.dp),
+                        )
+                        .clickable { switchSheet(i) }
+                        .padding(horizontal = 10.dp, vertical = 5.dp),
+                ) {
+                    androidx.compose.material.Text(
+                        name,
+                        color = if (selected) Color.White else INK,
+                        fontSize = 12.sp,
+                        fontWeight = if (selected) FontWeight.Bold else FontWeight.Normal,
+                        fontFamily = MONO,
+                    )
+                    if (selected) {
+                        // Inline rename / delete affordances on the active tab.
+                        Spacer(Modifier.width(8.dp))
+                        androidx.compose.material.Text(
+                            "✎",
+                            color = MUTED,
+                            fontSize = 12.sp,
+                            fontFamily = MONO,
+                            modifier = Modifier
+                                .clip(RoundedCornerShape(3.dp))
+                                .clickable { renaming = i; renameText = name }
+                                .padding(horizontal = 3.dp),
+                        )
+                        Spacer(Modifier.width(2.dp))
+                        androidx.compose.material.Text(
+                            "✕",
+                            color = MUTED,
+                            fontSize = 12.sp,
+                            fontFamily = MONO,
+                            modifier = Modifier
+                                .clip(RoundedCornerShape(3.dp))
+                                .clickable { deleteSheet(i) }
+                                .padding(horizontal = 3.dp),
+                        )
+                    }
+                }
+            }
+            Spacer(Modifier.width(6.dp))
+            toolButton("+ Sheet") { addSheet() }
+        }
+
+        // Rename dialog — a small panel with a text field, opened when `renaming`
+        // ≥ 0 (the ✎ on the active tab). Enter or "Rename" commits; "Cancel"
+        // dismisses. The engine rewrites every referencing qualifier on commit.
+        if (renaming >= 0) {
+            androidx.compose.ui.window.Dialog(onDismissRequest = { renaming = -1 }) {
+                Column(
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(PANEL)
+                        .border(1.dp, LINE, RoundedCornerShape(8.dp))
+                        .padding(16.dp),
+                ) {
+                    androidx.compose.material.Text(
+                        "Rename sheet", color = INK, fontSize = 14.sp, fontFamily = MONO,
+                    )
+                    Spacer(Modifier.height(10.dp))
+                    Box(
+                        modifier = Modifier
+                            .width(220.dp)
+                            .height(30.dp)
+                            .clip(RoundedCornerShape(5.dp))
+                            .background(FIELD)
+                            .border(1.dp, LINE_STRONG, RoundedCornerShape(5.dp))
+                            .padding(horizontal = 8.dp),
+                        contentAlignment = Alignment.CenterStart,
+                    ) {
+                        BasicTextField(
+                            value = renameText,
+                            onValueChange = { renameText = it },
+                            singleLine = true,
+                            textStyle = TextStyle(color = INK, fontSize = 13.sp, fontFamily = MONO),
+                            cursorBrush = androidx.compose.ui.graphics.SolidColor(ACCENT),
+                            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                            keyboardActions = KeyboardActions(onDone = { commitRename() }),
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                    }
+                    Spacer(Modifier.height(12.dp))
+                    Row {
+                        toolButton("Cancel") { renaming = -1 }
+                        Spacer(Modifier.width(8.dp))
+                        toolButton("Rename") { commitRename() }
                     }
                 }
             }

--- a/demo/visicalc-compose/test/EngineSmoke.kt
+++ b/demo/visicalc-compose/test/EngineSmoke.kt
@@ -289,6 +289,52 @@ fun main() {
     check("H3 recomputed live", fr.rowCells(3)[7], "25") // =H2+5
     fr.close()
 
+    // Multi-sheet workbook + cross-sheet references (the sheet tab bar drives
+    // sheetNames/activeSheet/selectSheet/addSheet/renameSheet/deleteSheet): the
+    // workbook holds several sheets; bare-A1 ops address the ACTIVE sheet, while a
+    // formula reaches ACROSS with a qualifier (=Summary!B3). This proves the
+    // Kotlin ↔ FFM ↔ C ABI path drives sheet management + cross-sheet recompute.
+    val ms = SpreadsheetSession()
+    check("ms initial sheets", ms.sheetNames().first.joinToString(","), "Sheet1")
+    check("ms add Summary", ms.addSheet("Summary").toString(), "true")
+    check("ms sheets after add", ms.sheetNames().first.joinToString(","), "Sheet1,Summary")
+    // Edit the Summary sheet (index 1): B3 = A1+A2 = 300.
+    check("ms activate Summary", ms.setActiveSheet(1).toString(), "true")
+    check("ms active index", ms.activeSheet().toString(), "1")
+    ms.setCell("A1", "100"); ms.setCell("A2", "200"); ms.setCell("B3", "=A1+A2")
+    check("ms Summary B3", ms.window(3, 2, 3, 2)[0][0], "300")
+    // Back on Sheet1, reach ACROSS with a qualifier.
+    check("ms back to Sheet1", ms.setActiveSheet(0).toString(), "true")
+    ms.setCell("G1", "=Summary!B3")
+    check("ms cross-sheet G1", ms.window(1, 7, 1, 7)[0][0], "300")
+    // Editing a Summary input recomputes the cross-sheet dependent live.
+    ms.setActiveSheet(1); ms.setCell("A1", "150") // Summary!A1: 100 → 150, B3 = 350
+    ms.setActiveSheet(0)
+    check("ms cross-sheet live", ms.window(1, 7, 1, 7)[0][0], "350")
+    // Rename Summary → Totals; the qualifier in G1 is rewritten by the engine.
+    check("ms rename", ms.renameSheet(1, "Totals").toString(), "true")
+    check("ms sheets after rename", ms.sheetNames().first.joinToString(","), "Sheet1,Totals")
+    checkContains("ms G1 names Totals", ms.getRaw("G1"), "Totals")
+    check("ms cross-sheet after rename", ms.window(1, 7, 1, 7)[0][0], "350")
+    // Delete the referenced sheet → the dangling cross-sheet ref becomes #REF!.
+    check("ms delete", ms.deleteSheet(1).toString(), "true")
+    check("ms sheets after delete", ms.sheetNames().first.joinToString(","), "Sheet1")
+    checkContains("ms G1 #REF!", ms.window(1, 7, 1, 7)[0][0], "#REF!")
+    // The engine keeps at least one sheet: deleting the last one is a no-op.
+    check("ms cannot delete last", ms.deleteSheet(0).toString(), "false")
+    ms.close()
+
+    // The InfiniteSheetModel seed exposes Sheet1/Summary with a live cross-ref.
+    val msm = InfiniteSheetModel()
+    check("msm sheets", msm.sheetNames().joinToString(","), "Sheet1,Summary")
+    check("msm active", msm.activeSheet().toString(), "0")
+    msm.selectA1("G1")
+    check("msm Sheet1 G1 cross-ref", msm.rowCells(1)[6], "300") // col 7, index 6
+    msm.selectSheet(1)
+    check("msm switched to Summary", msm.activeSheet().toString(), "1")
+    check("msm Summary B3", msm.rowCells(3)[1], "300") // B3 = A1+A2 = 100+200
+    msm.close()
+
     println(if (failures == 0) "\nALL PASS" else "\n$failures FAILURE(S)")
     kotlin.system.exitProcess(if (failures == 0) 0 else 1)
 }


### PR DESCRIPTION
Roll out **multi-sheet + cross-sheet references** to the **Compose Desktop** VisiCalc demo — the **4th of 6** backends, after web ([#6723](https://github.com/adhithyan15/coding-adventures/pull/6723)), Qt ([#6726](https://github.com/adhithyan15/coding-adventures/pull/6726)), and Flutter ([#6729](https://github.com/adhithyan15/coding-adventures/pull/6729)). The workbook holds several sheets; bare-`A1` ops address the **active** sheet, while a formula reaches **across** with a qualifier (`=Summary!B3`). The single-sheet path stays **byte-identical**.

## What changed

**Engine binding** (`Engine.kt`, `SpreadsheetSession` over the Java FFM API)
- 6 sheet ops wired through `java.lang.foreign` — `sc_sheet_names` / `sc_active_sheet` / `sc_set_active_sheet` / `sc_add_sheet` / `sc_rename_sheet` / `sc_delete_sheet` — each `FunctionDescriptor` **including the session ptr** (an arity mismatch trips `WrongMethodTypeException`), with `Arena.ofConfined` for the name-passing calls.
- `sheetNames()` parses the engine JSON **defensively** (every cast `as?`, so a malformed/empty payload degrades to an empty workbook view); index mutators clamp through `maxOf(0, index)` before the u32 ABI.

**Model** (`InfiniteSheetModel`): `sheetNames`/`activeSheet` + `selectSheet`/`addSheet`/`renameSheet`/`deleteSheet` passthrough, each refreshing the extent and re-priming the formula bar. The seed adds a second sheet, **Summary** (`B3 = A1+A2 = 300`), and `Sheet1!G1 = =Summary!B3` pulls it across.

**UI** (`InfiniteSheet.kt`): an Excel-style **sheet tab bar** along the bottom — one chip per sheet (active tints to the accent); **click** to switch, the active tab carries inline **✎ rename** (a Compose Desktop `Dialog`) and **✕ delete** affordances, **+ Sheet** adds one. Sheet names render as `Text` only.

## Proof
- A new **multi-sheet section** in `test/EngineSmoke.kt` (the kotlinc + FFM harness): cross-sheet `=Summary!B3` computes and stays live as its precedent changes (300 → 350), a rename rewrites the referencing qualifier (`Summary` → `Totals`), deleting a referenced sheet yields `#REF!` (and the last sheet can't be deleted), and the `InfiniteSheetModel` seed exposes `Sheet1`/`Summary` with a live cross-ref.
- `scripts/verify.sh` **ALL PASS**; the Compose UI compiles via `gradle compileKotlin`. README updated.

## Security review
PASSED (1 round). FFM alloc/free contracts correct (single free via `take`/`sc_string_free`; confined-arena input strings don't escape), descriptor arity matches the native signatures, indices clamped, the `addSheet` collision loop is bounded, and `parseJson` casts are defensive. No memory-safety issues (the Rust C ABI is `#![forbid(unsafe_code)]`, null- and range-guarded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)