### PR TITLE
[codex] Expose deck output-plan result row artifacts

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Added
 
+- **Deck output-plan result row artifacts** —
+  selected `run_deck_analysis()` output-plan artifacts now expose selected
+  result row counts beside result-column inventories in table, CSV, compact
+  JSON, and header-keyed record exports, matching Rust and TypeScript.
+
 - **Deck output-plan probe source line artifacts** —
   selected `run_deck_analysis()` output-plan artifacts now expose selected
   output probe source line counts/lists aligned with the selected output-probe

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -112,8 +112,8 @@ that produced the table, plus selected
 `.measure` results and a stable measurement table for `.dc`, `.ac`, and `.tran`
 executions. Execution `table_artifacts` preserve the same order as `tables` and
 carry each stable table's text, CSV, compact JSON, and header-keyed records.
-Execution `output_plan_artifacts` summarize the selected result columns,
-output probes, selected output probe source lines, output directives,
+Execution `output_plan_artifacts` summarize the selected result row count,
+result columns, output probes, selected output probe source lines, output directives,
 normalized output directive kinds, normalized directive analysis scopes,
 selected output directive source lines, and stable table names, and the
 `output-plan` entry in `table_artifacts` carries the same

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -2385,6 +2385,7 @@ class DeckOutputPlanArtifact:
 
     analysis: str
     directive: str
+    result_row_count: int
     result_column_count: int
     result_columns: list[str]
     output_probe_count: int
@@ -2898,6 +2899,7 @@ def _deck_run_artifacts(
 
 def _deck_output_plan_artifacts(
     plan: DeckAnalysisPlan,
+    result_row_count: int,
     result_columns: list[str],
     output_probes: list[str],
     output_probe_lines: list[int],
@@ -2911,6 +2913,7 @@ def _deck_output_plan_artifacts(
         DeckOutputPlanArtifact(
             analysis=plan.analysis,
             directive=plan.directive,
+            result_row_count=result_row_count,
             result_column_count=len(result_columns),
             result_columns=list(result_columns),
             output_probe_count=len(output_probes),
@@ -2936,6 +2939,7 @@ def _deck_output_plan_artifacts(
 _DECK_OUTPUT_PLAN_ARTIFACT_COLUMNS = [
     "Analysis",
     "Directive",
+    "ResultRows",
     "ResultColumns",
     "ResultColumnList",
     "OutputProbes",
@@ -2959,6 +2963,7 @@ def _deck_output_plan_artifact_cells(artifact: DeckOutputPlanArtifact) -> list[s
     return [
         artifact.analysis,
         artifact.directive,
+        str(artifact.result_row_count),
         str(artifact.result_column_count),
         ";".join(artifact.result_columns),
         str(artifact.output_probe_count),
@@ -3045,6 +3050,7 @@ def _deck_output_plan_artifact_bundle(
 ) -> tuple[list[DeckOutputPlanArtifact], str, str, str, list[dict[str, str]]]:
     artifacts = _deck_output_plan_artifacts(
         plan,
+        _deck_table_row_count(result_table),
         _deck_table_columns(result_table),
         output_probes,
         output_probe_lines,
@@ -3060,6 +3066,11 @@ def _deck_output_plan_artifact_bundle(
         format_deck_output_plan_artifact_json(artifacts),
         deck_output_plan_artifact_records(artifacts),
     )
+
+
+def _deck_table_row_count(table: str) -> int:
+    rows = table.splitlines()
+    return max(len(rows) - 1, 0) if rows else 0
 
 
 def _deck_analysis_diagnostic_codes(

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -6891,14 +6891,14 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
         op_execution.table
     )
     expected_output_plan_table = (
-        "Analysis\tDirective\tResultColumns\tResultColumnList\tOutputProbes\t"
+        "Analysis\tDirective\tResultRows\tResultColumns\tResultColumnList\tOutputProbes\t"
         "OutputProbeList\tOutputProbeLines\tOutputProbeLineList\t"
         "OutputDirectives\tOutputDirectiveList\t"
         "OutputDirectiveKinds\tOutputDirectiveKindList\t"
         "OutputDirectiveAnalysisKinds\tOutputDirectiveAnalysisKindList\t"
         "OutputDirectiveLines\tOutputDirectiveLineList\t"
         "Tables\tTableList\n"
-        "op\t.op\t2\tIndex;V(mid)\t1\tV(mid)\t"
+        "op\t.op\t1\t2\tIndex;V(mid)\t1\tV(mid)\t"
         f"1\t{save_line}\t1\t.save\t1\tsave\t1\tglobal\t1\t{save_line}\t3\t"
         "result;output-plan;run-artifact\n"
     )
@@ -6906,6 +6906,7 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
         {
             "Analysis": "op",
             "Directive": ".op",
+            "ResultRows": "1",
             "ResultColumns": "2",
             "ResultColumnList": "Index;V(mid)",
             "OutputProbes": "1",
@@ -6929,6 +6930,7 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     output_plan_artifact = op_execution.output_plan_artifacts[0]
     assert output_plan_artifact.analysis == "op"
     assert output_plan_artifact.directive == ".op"
+    assert output_plan_artifact.result_row_count == 1
     assert output_plan_artifact.result_columns == ["Index", "V(mid)"]
     assert output_plan_artifact.output_probes == ["V(mid)"]
     assert output_plan_artifact.output_probe_line_count == 1
@@ -6946,14 +6948,14 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
         format_deck_output_plan_artifact_table(op_execution.output_plan_artifacts)
     )
     assert op_execution.output_plan_artifact_csv == (
-        "Analysis,Directive,ResultColumns,ResultColumnList,OutputProbes,"
+        "Analysis,Directive,ResultRows,ResultColumns,ResultColumnList,OutputProbes,"
         "OutputProbeList,OutputProbeLines,OutputProbeLineList,"
         "OutputDirectives,OutputDirectiveList,"
         "OutputDirectiveKinds,OutputDirectiveKindList,"
         "OutputDirectiveAnalysisKinds,OutputDirectiveAnalysisKindList,"
         "OutputDirectiveLines,OutputDirectiveLineList,"
         "Tables,TableList\n"
-        f"op,.op,2,Index;V(mid),1,V(mid),1,{save_line},1,.save,1,save,1,global,1,{save_line},3,"
+        f"op,.op,1,2,Index;V(mid),1,V(mid),1,{save_line},1,.save,1,save,1,global,1,{save_line},3,"
         "result;output-plan;run-artifact\n"
     )
     assert op_execution.output_plan_artifact_csv == (

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Expose selected result row counts in `run_deck_analysis` output-plan
+  artifacts beside result-column inventories, with stable table, CSV, compact
+  JSON, and header-keyed record exports, matching Python and TypeScript.
 - Expose selected output probe source line inventories in `run_deck_analysis`
   output-plan artifacts aligned with selected output-probe inventories, with
   stable table, CSV, compact JSON, and header-keyed record exports, matching

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -181,8 +181,8 @@ table, plus selected `.measure` results and
 a stable measurement table for `.dc`, `.ac`, and `.tran` executions.
 Execution `table_artifacts` preserve the same order as `tables` and carry each
 stable table's text, CSV, compact JSON, and header-keyed records.
-Execution `output_plan_artifacts` summarize the selected result columns,
-output probes, selected output probe source lines, output directives,
+Execution `output_plan_artifacts` summarize the selected result row count,
+result columns, output probes, selected output probe source lines, output directives,
 normalized output directive kinds, normalized directive analysis scopes,
 selected output directive source lines, and stable table names, and the
 `output-plan` entry in `table_artifacts` carries the same

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -3466,6 +3466,7 @@ pub struct DeckTableArtifact {
 pub struct DeckOutputPlanArtifact {
     pub analysis: String,
     pub directive: String,
+    pub result_row_count: usize,
     pub result_column_count: usize,
     pub result_columns: Vec<String>,
     pub output_probe_count: usize,
@@ -10458,6 +10459,7 @@ fn deck_run_artifacts(
 
 fn deck_output_plan_artifacts(
     plan: &DeckAnalysisPlan,
+    result_row_count: usize,
     result_columns: &[String],
     output_probes: &[String],
     output_probe_lines: &[usize],
@@ -10470,6 +10472,7 @@ fn deck_output_plan_artifacts(
     vec![DeckOutputPlanArtifact {
         analysis: plan.analysis.clone(),
         directive: plan.directive.clone(),
+        result_row_count,
         result_column_count: result_columns.len(),
         result_columns: result_columns.to_vec(),
         output_probe_count: output_probes.len(),
@@ -10515,6 +10518,7 @@ fn deck_output_directive_kinds(output_directives: &[String]) -> Vec<String> {
 const DECK_OUTPUT_PLAN_ARTIFACT_COLUMNS: &[&str] = &[
     "Analysis",
     "Directive",
+    "ResultRows",
     "ResultColumns",
     "ResultColumnList",
     "OutputProbes",
@@ -10537,6 +10541,7 @@ fn deck_output_plan_artifact_cells(artifact: &DeckOutputPlanArtifact) -> Vec<Str
     vec![
         artifact.analysis.clone(),
         artifact.directive.clone(),
+        artifact.result_row_count.to_string(),
         artifact.result_column_count.to_string(),
         artifact.result_columns.join(";"),
         artifact.output_probe_count.to_string(),
@@ -10644,6 +10649,7 @@ fn deck_output_plan_artifact_bundle(
 ) {
     let artifacts = deck_output_plan_artifacts(
         plan,
+        deck_table_row_count(result_table),
         &deck_table_columns(result_table),
         output_probes,
         output_probe_lines,
@@ -10852,6 +10858,15 @@ fn deck_table_columns(table: &str) -> Vec<String> {
                 .collect()
         })
         .unwrap_or_default()
+}
+
+fn deck_table_row_count(table: &str) -> usize {
+    let mut lines = table.lines();
+    if lines.next().is_none() {
+        0
+    } else {
+        lines.count()
+    }
 }
 
 pub fn format_deck_run_artifact_table(artifacts: &[DeckRunArtifact]) -> String {

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -1991,6 +1991,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     let output_plan_artifact = &op_execution.output_plan_artifacts[0];
     assert_eq!(output_plan_artifact.analysis, "op");
     assert_eq!(output_plan_artifact.directive, ".op");
+    assert_eq!(output_plan_artifact.result_row_count, 1);
     assert_eq!(
         output_plan_artifact.result_columns,
         vec!["Index".to_string(), "V(mid)".to_string()]
@@ -2028,7 +2029,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         op_execution.output_plan_artifact_table,
         format!(
-            "Analysis\tDirective\tResultColumns\tResultColumnList\tOutputProbes\tOutputProbeList\tOutputProbeLines\tOutputProbeLineList\tOutputDirectives\tOutputDirectiveList\tOutputDirectiveKinds\tOutputDirectiveKindList\tOutputDirectiveAnalysisKinds\tOutputDirectiveAnalysisKindList\tOutputDirectiveLines\tOutputDirectiveLineList\tTables\tTableList\nop\t.op\t2\tIndex;V(mid)\t1\tV(mid)\t1\t{}\t1\t.save\t1\tsave\t1\tglobal\t1\t{}\t3\tresult;output-plan;run-artifact\n",
+            "Analysis\tDirective\tResultRows\tResultColumns\tResultColumnList\tOutputProbes\tOutputProbeList\tOutputProbeLines\tOutputProbeLineList\tOutputDirectives\tOutputDirectiveList\tOutputDirectiveKinds\tOutputDirectiveKindList\tOutputDirectiveAnalysisKinds\tOutputDirectiveAnalysisKindList\tOutputDirectiveLines\tOutputDirectiveLineList\tTables\tTableList\nop\t.op\t1\t2\tIndex;V(mid)\t1\tV(mid)\t1\t{}\t1\t.save\t1\tsave\t1\tglobal\t1\t{}\t3\tresult;output-plan;run-artifact\n",
             save_line, save_line
         )
     );
@@ -2039,7 +2040,7 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         op_execution.output_plan_artifact_csv,
         format!(
-            "Analysis,Directive,ResultColumns,ResultColumnList,OutputProbes,OutputProbeList,OutputProbeLines,OutputProbeLineList,OutputDirectives,OutputDirectiveList,OutputDirectiveKinds,OutputDirectiveKindList,OutputDirectiveAnalysisKinds,OutputDirectiveAnalysisKindList,OutputDirectiveLines,OutputDirectiveLineList,Tables,TableList\nop,.op,2,Index;V(mid),1,V(mid),1,{},1,.save,1,save,1,global,1,{},3,result;output-plan;run-artifact\n",
+            "Analysis,Directive,ResultRows,ResultColumns,ResultColumnList,OutputProbes,OutputProbeList,OutputProbeLines,OutputProbeLineList,OutputDirectives,OutputDirectiveList,OutputDirectiveKinds,OutputDirectiveKindList,OutputDirectiveAnalysisKinds,OutputDirectiveAnalysisKindList,OutputDirectiveLines,OutputDirectiveLineList,Tables,TableList\nop,.op,1,2,Index;V(mid),1,V(mid),1,{},1,.save,1,save,1,global,1,{},3,result;output-plan;run-artifact\n",
             save_line, save_line
         )
     );
@@ -2054,6 +2055,12 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         op_execution.output_plan_artifact_records,
         deck_output_plan_artifact_records(&op_execution.output_plan_artifacts)
+    );
+    assert_eq!(
+        op_execution.output_plan_artifact_records[0]
+            .get("ResultRows")
+            .map(String::as_str),
+        Some("1")
     );
     assert_eq!(
         op_execution.output_plan_artifact_records[0]

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Expose selected result row counts in `runDeckAnalysis` output-plan artifacts
+  beside result-column inventories, with stable table, CSV, compact JSON, and
+  header-keyed record exports, matching Python and Rust.
 - Expose selected output probe source line inventories in `runDeckAnalysis`
   output-plan artifacts aligned with selected output-probe inventories, with
   stable table, CSV, compact JSON, and header-keyed record exports, matching

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -98,8 +98,8 @@ a stable measurement table for `.dc`, `.ac`, and `.tran` executions.
 Execution `outputPlanArtifacts` summarize the selected result columns, output
 probes, selected output probe source lines, output directives, normalized
 output directive kinds, normalized directive analysis scopes, selected output
-directive source lines, and stable table names with table, CSV, compact JSON,
-and header-keyed record exports.
+directive source lines, selected result row counts, and stable table names with
+table, CSV, compact JSON, and header-keyed record exports.
 Execution `tableArtifacts` preserve the same order as `tables` and carry each
 stable table's text, CSV, compact JSON, and header-keyed records.
 The `output-plan` entry in `tableArtifacts` carries the same

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -719,6 +719,7 @@ export interface DeckTableArtifact {
 export interface DeckOutputPlanArtifact {
   readonly analysis: DeckAnalysisPlan["analysis"];
   readonly directive: DeckAnalysisPlan["directive"];
+  readonly resultRowCount: number;
   readonly resultColumnCount: number;
   readonly resultColumns: readonly string[];
   readonly outputProbeCount: number;
@@ -8394,6 +8395,7 @@ function deckRunArtifactRecord(artifact: DeckRunArtifact): DeckRunArtifactRecord
 
 function deckOutputPlanArtifacts(
   plan: DeckAnalysisPlan,
+  resultRowCount: number,
   resultColumns: readonly string[],
   outputProbes: readonly string[],
   outputProbeLines: readonly number[],
@@ -8407,6 +8409,7 @@ function deckOutputPlanArtifacts(
     {
       analysis: plan.analysis,
       directive: plan.directive,
+      resultRowCount,
       resultColumnCount: resultColumns.length,
       resultColumns: [...resultColumns],
       outputProbeCount: outputProbes.length,
@@ -8449,6 +8452,7 @@ function deckOutputDirectiveKinds(outputDirectives: readonly string[]): string[]
 const DECK_OUTPUT_PLAN_ARTIFACT_COLUMNS = [
   "Analysis",
   "Directive",
+  "ResultRows",
   "ResultColumns",
   "ResultColumnList",
   "OutputProbes",
@@ -8471,6 +8475,7 @@ function deckOutputPlanArtifactCells(artifact: DeckOutputPlanArtifact): string[]
   return [
     artifact.analysis,
     artifact.directive,
+    String(artifact.resultRowCount),
     String(artifact.resultColumnCount),
     artifact.resultColumns.join(";"),
     String(artifact.outputProbeCount),
@@ -8548,6 +8553,7 @@ function deckOutputPlanArtifactBundle(
 } {
   const artifacts = deckOutputPlanArtifacts(
     plan,
+    deckTableRowCount(resultTable),
     deckTableColumns(resultTable),
     outputProbes,
     outputProbeLines,
@@ -8568,6 +8574,11 @@ function deckOutputPlanArtifactBundle(
 function deckTableColumns(table: string): string[] {
   const header = table.split("\n", 1)[0] ?? "";
   return header.length === 0 ? [] : header.split("\t");
+}
+
+function deckTableRowCount(table: string): number {
+  const rows = deckTableRows(table);
+  return rows.length === 0 ? 0 : rows.length - 1;
 }
 
 export function formatDeckRunArtifactTable(artifacts: readonly DeckRunArtifact[]): string {

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -1549,6 +1549,7 @@ describe("transient", () => {
       {
         Analysis: "op",
         Directive: ".op",
+        ResultRows: "1",
         ResultColumns: "2",
         ResultColumnList: "Index;V(mid)",
         OutputProbes: "1",
@@ -1572,6 +1573,7 @@ describe("transient", () => {
     expect(opExecution.outputPlanArtifacts[0]).toMatchObject({
       analysis: "op",
       directive: ".op",
+      resultRowCount: 1,
       resultColumnCount: 2,
       resultColumns: ["Index", "V(mid)"],
       outputProbeCount: 1,
@@ -1590,15 +1592,15 @@ describe("transient", () => {
       tables: ["result", "output-plan", "run-artifact"],
     });
     expect(opExecution.outputPlanArtifactTable).toBe(
-      "Analysis\tDirective\tResultColumns\tResultColumnList\tOutputProbes\tOutputProbeList\tOutputProbeLines\tOutputProbeLineList\tOutputDirectives\tOutputDirectiveList\tOutputDirectiveKinds\tOutputDirectiveKindList\tOutputDirectiveAnalysisKinds\tOutputDirectiveAnalysisKindList\tOutputDirectiveLines\tOutputDirectiveLineList\tTables\tTableList\n" +
-        `op\t.op\t2\tIndex;V(mid)\t1\tV(mid)\t1\t${saveLine}\t1\t.save\t1\tsave\t1\tglobal\t1\t${saveLine}\t3\tresult;output-plan;run-artifact\n`,
+      "Analysis\tDirective\tResultRows\tResultColumns\tResultColumnList\tOutputProbes\tOutputProbeList\tOutputProbeLines\tOutputProbeLineList\tOutputDirectives\tOutputDirectiveList\tOutputDirectiveKinds\tOutputDirectiveKindList\tOutputDirectiveAnalysisKinds\tOutputDirectiveAnalysisKindList\tOutputDirectiveLines\tOutputDirectiveLineList\tTables\tTableList\n" +
+        `op\t.op\t1\t2\tIndex;V(mid)\t1\tV(mid)\t1\t${saveLine}\t1\t.save\t1\tsave\t1\tglobal\t1\t${saveLine}\t3\tresult;output-plan;run-artifact\n`,
     );
     expect(opExecution.outputPlanArtifactTable).toBe(
       formatDeckOutputPlanArtifactTable(opExecution.outputPlanArtifacts),
     );
     expect(opExecution.outputPlanArtifactCsv).toBe(
-      "Analysis,Directive,ResultColumns,ResultColumnList,OutputProbes,OutputProbeList,OutputProbeLines,OutputProbeLineList,OutputDirectives,OutputDirectiveList,OutputDirectiveKinds,OutputDirectiveKindList,OutputDirectiveAnalysisKinds,OutputDirectiveAnalysisKindList,OutputDirectiveLines,OutputDirectiveLineList,Tables,TableList\n" +
-        `op,.op,2,Index;V(mid),1,V(mid),1,${saveLine},1,.save,1,save,1,global,1,${saveLine},3,result;output-plan;run-artifact\n`,
+      "Analysis,Directive,ResultRows,ResultColumns,ResultColumnList,OutputProbes,OutputProbeList,OutputProbeLines,OutputProbeLineList,OutputDirectives,OutputDirectiveList,OutputDirectiveKinds,OutputDirectiveKindList,OutputDirectiveAnalysisKinds,OutputDirectiveAnalysisKindList,OutputDirectiveLines,OutputDirectiveLineList,Tables,TableList\n" +
+        `op,.op,1,2,Index;V(mid),1,V(mid),1,${saveLine},1,.save,1,save,1,global,1,${saveLine},3,result;output-plan;run-artifact\n`,
     );
     expect(opExecution.outputPlanArtifactCsv).toBe(
       formatDeckOutputPlanArtifactCsv(opExecution.outputPlanArtifacts),

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -143,7 +143,9 @@ downstream tools to compare.
      output-plan artifacts now also expose selected output directive source
      line counts/lists beside those directive provenance inventories, and
      selected output-plan artifacts now also expose selected output probe
-     source line counts/lists aligned with the selected output-probe list.
+     source line counts/lists aligned with the selected output-probe list, and
+     selected output-plan artifacts now also expose selected result row counts
+     beside result-column inventories.
    - Expand remaining deck-controlled analyses toward full SPICE compatibility
      while keeping unsupported control-flow diagnostics explicit.
 
@@ -1200,6 +1202,14 @@ downstream tools to compare.
     - Table, CSV, compact JSON, and host-native record exports make each
       deduplicated selected output probe traceable to the deck source line that
       first selected it for that analysis.
+
+110. Deck output-plan result row artifacts.
+    - Status: completed in this deck output-plan result row artifact slice.
+    - Python, Rust, and TypeScript selected output-plan artifacts now expose
+      selected result row counts beside result-column inventories.
+    - Table, CSV, compact JSON, and host-native record exports make the shape
+      of the selected result table auditable from the output-plan artifact
+      without reparsing the result table itself.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- expose selected result row counts on deck output-plan artifacts across Python, Rust, and TypeScript
- add stable ResultRows table/CSV/JSON/record exports beside ResultColumns
- update cross-language golden tests, README/changelog notes, and the SPICE implementation plan

## Verification
- PYTHONPATH=code/packages/python/spice-engine/src:code/packages/python/mosfet-models/src:code/packages/python/device-physics/src /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python -m pytest code/packages/python/spice-engine/tests/test_compatibility.py code/packages/python/spice-engine/tests/test_engine.py -q
- cargo test -p spice-engine
- npm ci
- npm run build && npm test
- git diff --check
