### PR TITLE
feat(latex): math environments — matrix family + cases + aligned (LTX01 L3a)

### DIFF
--- a/code/packages/rust/latex/CHANGELOG.md
+++ b/code/packages/rust/latex/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to the full-fidelity LaTeX parser crate.
 
+## [0.4.0] — 2026-06-26
+
+### Added — LTX01 L3: math environments
+
+- **`MathNode::Matrix { env, rows: Vec<Vec<MathNode>> }`** — math environments with
+  row/column structure. `parse_math` now handles `\begin{env} … \end{env}` inside a math
+  island: `&` separates columns, `\\` separates rows, and each cell is a full math
+  expression. Supported environments (case-sensitive — `bmatrix` ≠ `Bmatrix`): `matrix`,
+  `pmatrix`, `bmatrix`, `Bmatrix`, `vmatrix`, `Vmatrix`, `smallmatrix`, `cases`, `dcases`,
+  `aligned`, `gathered`, `align`, `align*`, `split`.
+- Environments **nest** (a cell may itself be an environment — depth-guarded via the
+  enclosing atom), and a `Matrix` is an **atom**, so postfix scripts attach
+  (`\begin{pmatrix}…\end{pmatrix}^2`).
+- **`MathNode::to_latex`** renders the grid back and **round-trips**
+  (`parse_math(&m.to_latex()) == m`); a trailing `\\` before `\end` is tolerated and does
+  not create an empty final row.
+- Total / panic-free / spanned: `\begin`/`\end` name mismatch, unterminated environment,
+  unknown environment, a missing `{` after `\begin`, and a stray `\end` each return a
+  spanned `ParseError`. Empty cells (`a & & b`) are a documented limitation (spanned error,
+  never a silent empty node), as are `array`/`tabular` column-specs and document-mode list
+  environments — those arrive in a later layer.
+- +9 environment tests + 5 round-trip-corpus entries; **64 unit + 1 doc test** green;
+  clippy `-D warnings` clean; no `unsafe`.
+
 ## [0.3.0] — 2026-06-26
 
 ### Added — LTX01 L2: math grammar

--- a/code/packages/rust/latex/Cargo.toml
+++ b/code/packages/rust/latex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latex"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "A full-fidelity LaTeX parser (documents and math): a catcode-driven, text-mode-primary tokenizer and (in later layers) a structural + math parser producing a faithful AST. Standalone and reusable; will also implement the math-frontend MathFrontend trait."
 license = "MIT"

--- a/code/packages/rust/latex/README.md
+++ b/code/packages/rust/latex/README.md
@@ -32,8 +32,8 @@ with a **text-mode-primary** mode stack (LaTeX starts in text mode; math is ente
 |-------|----------|--------|
 | **L0 tokenizer** | catcode state machine → flat `Token` stream w/ byte spans | ✅ |
 | **L1 structural** | groups, `\cmd[opt]{arg}`, `\begin{env}…\end{env}`, text runs, raw math islands, `to_latex()` round-trip | ✅ |
-| **L2 math** | math AST (frac, binom, roots, scripts, big ops, functions, accents, `\left\right` fences, relations), precedence-climbing parser, `to_latex()` round-trip | ✅ this release |
-| L3 environments | matrices / tabular / lists (`&`, `\\`) | ⏳ |
+| **L2 math** | math AST (frac, binom, roots, scripts, big ops, functions, accents, `\left\right` fences, relations), precedence-climbing parser, `to_latex()` round-trip | ✅ |
+| **L3 environments** | math env family — `matrix`/`pmatrix`/`bmatrix`/`vmatrix`/`cases`/`aligned`/`align` split on `&` and `\\` → `MathNode::Matrix`, round-trip; nesting + scripts | ✅ this release |
 | L4 macros | `\newcommand`/`\def` + expansion (bounded) | ⏳ |
 | L5 text breadth | sectioning, fonts, accents, `\verb`, refs | ⏳ |
 | L6 frontend | implement `math-frontend::MathFrontend` (LaTeX becomes plugin #1) | ⏳ |
@@ -71,6 +71,28 @@ let doc = parse(r"area is $\pi r^2$").unwrap();
 let area = doc.iter().find_map(|n| n.parsed_math()).unwrap().unwrap();
 assert!(matches!(area, MathNode::Bin(..)));   // π · r²  (implicit multiplication)
 ```
+
+### Environments (L3)
+
+The math environment family parses into `MathNode::Matrix { env, rows }` — `&` splits
+columns, `\\` splits rows. Supported: `matrix`/`pmatrix`/`bmatrix`/`Bmatrix`/`vmatrix`/
+`Vmatrix`/`smallmatrix`, `cases`, and the alignment environments (`aligned`/`align`/…).
+Cells hold arbitrary math, environments nest, and a matrix is an atom (so `…^2` attaches):
+
+```rust
+use latex::{parse_math, MathNode};
+
+let m = parse_math(r"\begin{pmatrix} a & b \\ c & d \end{pmatrix}").unwrap();
+if let MathNode::Matrix { env, rows } = &m {
+    assert_eq!(env, "pmatrix");
+    assert_eq!(rows.len(), 2);          // two rows
+    assert_eq!(rows[0].len(), 2);       // two columns
+}
+assert_eq!(parse_math(&m.to_latex()).unwrap(), m);   // round-trips
+```
+
+`array`/`tabular` (which take a column-spec argument) and document-mode list environments
+are a later layer; an unknown `\begin{…}` is rejected with a spanned error, never mis-parsed.
 
 The low-level `tokenize` is also public. Tokens and errors carry half-open byte `Span`s;
 all of `parse`, `parse_math`, and `tokenize` return spanned errors rather than panicking,

--- a/code/packages/rust/latex/src/lib.rs
+++ b/code/packages/rust/latex/src/lib.rs
@@ -22,7 +22,8 @@
 //!    (`\cmd[opt]{arg}`), environments (`\begin…\end`), and raw math islands → a [`Node`]
 //!    tree, with [`Node::to_latex`] round-tripping. **Implemented (this release).**
 //! 3. [`parse_math`] — the **math grammar** over each island's raw content: fractions,
-//!    roots, scripts, big operators, functions, fenced groups, relations →
+//!    roots, scripts, big operators, functions, fenced groups, relations, and **math
+//!    environments** (`matrix`/`pmatrix`/`cases`/`aligned`/… with `&` and `\\`) →
 //!    [`MathNode`], with precedence and [`MathNode::to_latex`] round-tripping.
 //!    [`Node::parsed_math`] parses a [`Node::Math`] island on demand. **Implemented
 //!    (this release).**
@@ -37,6 +38,9 @@
 //!
 //! let m = parse_math(r"\frac{12 \times 15}{3}").unwrap();
 //! assert!(matches!(m, MathNode::Frac(..)));
+//!
+//! let grid = parse_math(r"\begin{pmatrix} a & b \\ c & d \end{pmatrix}").unwrap();
+//! assert!(matches!(grid, MathNode::Matrix { .. }));
 //! ```
 
 pub mod catcode;

--- a/code/packages/rust/latex/src/math.rs
+++ b/code/packages/rust/latex/src/math.rs
@@ -117,6 +117,20 @@ pub enum MathNode {
     Text(String),
     /// A relation: `a = b`, `x \le y`.
     Rel(MRelOp, Box<MathNode>, Box<MathNode>),
+    /// A math environment with row/column structure (L3): the `matrix` family
+    /// (`matrix`/`pmatrix`/`bmatrix`/`vmatrix`/…), `cases`, and the alignment environments
+    /// (`aligned`/`align`). `rows` is a list of rows; each row is a list of cells, split on
+    /// `&` (columns) and `\\` (rows). `env` is the environment name verbatim (case-sensitive,
+    /// so `bmatrix` ≠ `Bmatrix`), which also fixes the delimiters when rendered.
+    ///
+    /// ```text
+    ///   \begin{pmatrix} a & b \\ c & d \end{pmatrix}
+    ///   → Matrix { env: "pmatrix", rows: [[a, b], [c, d]] }
+    /// ```
+    Matrix {
+        env: String,
+        rows: Vec<Vec<MathNode>>,
+    },
 }
 
 /// Parse LaTeX math-mode source (the inner content of an island) into a [`MathNode`].
@@ -190,6 +204,30 @@ fn is_text(name: &str) -> bool {
         name,
         "text" | "mathrm" | "mathbf" | "mathit" | "mathsf" | "mathtt" | "mathcal"
             | "mathbb" | "operatorname"
+    )
+}
+/// Math environments with `&`/`\\` row/column structure (L3). Case-sensitive — `bmatrix`
+/// (square brackets) and `Bmatrix` (braces) are different environments. The `array`/`tabular`
+/// family (which take a mandatory column-spec argument) and document-mode list environments
+/// are deliberately **not** here — they need an extra field on the node and arrive in a
+/// later layer; an unknown `\begin{…}` is rejected with a spanned error, never mis-parsed.
+fn is_math_env(name: &str) -> bool {
+    matches!(
+        name,
+        "matrix"
+            | "pmatrix"
+            | "bmatrix"
+            | "Bmatrix"
+            | "vmatrix"
+            | "Vmatrix"
+            | "smallmatrix"
+            | "cases"
+            | "dcases"
+            | "aligned"
+            | "gathered"
+            | "align"
+            | "align*"
+            | "split"
     )
 }
 
@@ -495,6 +533,14 @@ impl<'a> MathParser<'a> {
             let _ = rel;
             return self.err(format!("unexpected relation \\{name}"));
         }
+        if name == "begin" {
+            return self.parse_environment();
+        }
+        if name == "end" {
+            // `\end` only ever closes an environment opened by `parse_environment`; reaching
+            // it here means there was no matching `\begin`.
+            return self.err("unexpected \\end without matching \\begin");
+        }
         if is_frac(name) {
             self.bump();
             let num = self.read_arg()?;
@@ -628,6 +674,92 @@ impl<'a> MathParser<'a> {
                 other => {
                     return self.err(format!("unsupported token in \\text: {other:?}"));
                 }
+            }
+        }
+    }
+
+    // ---- environments (L3) ----------------------------------------------------
+
+    /// Parse `\begin{env} … \end{env}` into [`MathNode::Matrix`]. Called with the cursor on
+    /// the `\begin` control word. The body is a grid of cells: `&` separates columns, `\\`
+    /// separates rows. Nested environments work because each cell is parsed recursively (the
+    /// inner `\begin…\end` is consumed by its own call), and the whole descent is
+    /// depth-guarded by the enclosing [`Self::parse_atom`].
+    fn parse_environment(&mut self) -> Result<MathNode, ParseError> {
+        self.bump(); // \begin
+        let env = self.read_env_name()?;
+        if !is_math_env(&env) {
+            return self.err(format!("unsupported environment: {env}"));
+        }
+        let rows = self.parse_env_rows(&env)?;
+        Ok(MathNode::Matrix { env, rows })
+    }
+
+    /// Read an environment name from the `{…}` after `\begin`/`\end`. Names are letters with
+    /// an optional trailing `*` (`align*`).
+    fn read_env_name(&mut self) -> Result<String, ParseError> {
+        if !matches!(self.peek().kind, TokenKind::BeginGroup) {
+            return self.err("expected '{' after \\begin/\\end");
+        }
+        self.bump(); // {
+        let mut s = String::new();
+        loop {
+            match self.peek().kind.clone() {
+                TokenKind::EndGroup => {
+                    self.bump();
+                    return Ok(s);
+                }
+                TokenKind::Char(c) => {
+                    s.push(c);
+                    self.bump();
+                }
+                TokenKind::Eof => return self.err("unterminated environment name"),
+                other => return self.err(format!("unexpected token in environment name: {other:?}")),
+            }
+        }
+    }
+
+    /// Parse the grid body up to the matching `\end{env}`. Each cell is one math expression;
+    /// truly-empty cells (e.g. `a & & b`) are a documented limitation and produce a spanned
+    /// error rather than a silent empty node.
+    fn parse_env_rows(&mut self, env: &str) -> Result<Vec<Vec<MathNode>>, ParseError> {
+        let mut rows: Vec<Vec<MathNode>> = Vec::new();
+        let mut row: Vec<MathNode> = Vec::new();
+        loop {
+            // Terminator: \end{name} — verify the name matches the open.
+            if matches!(&self.peek().kind, TokenKind::ControlWord(w) if w == "end") {
+                self.bump(); // \end
+                let close = self.read_env_name()?;
+                if close != env {
+                    return self.err(format!("\\begin{{{env}}} closed by \\end{{{close}}}"));
+                }
+                if !row.is_empty() {
+                    rows.push(row);
+                }
+                return Ok(rows);
+            }
+            if matches!(self.peek().kind, TokenKind::Eof) {
+                return self.err(format!("unterminated environment \\begin{{{env}}}"));
+            }
+            // A cell. `parse_relation` stops at `&`, `\\`, and `\end` (none of them start an
+            // atom), so it consumes exactly one cell and always makes progress.
+            let cell = self.parse_relation()?;
+            row.push(cell);
+            // The separator that follows the cell.
+            match &self.peek().kind {
+                TokenKind::AlignTab => {
+                    self.bump(); // & → next column in this row
+                }
+                TokenKind::ControlSymbol('\\') => {
+                    self.bump(); // \\ → end this row, start a new one
+                    rows.push(std::mem::take(&mut row));
+                }
+                // \end on the next turn closes the environment (handled at loop top).
+                TokenKind::ControlWord(w) if w == "end" => {}
+                TokenKind::Eof => {
+                    return self.err(format!("unterminated environment \\begin{{{env}}}"));
+                }
+                _ => return self.err("expected '&', '\\\\', or \\end in environment"),
             }
         }
     }
@@ -812,6 +944,25 @@ impl MathNode {
                 out.push_str(opstr);
                 Self::write_child(b, out, 2);
             }
+            MathNode::Matrix { env, rows } => {
+                out.push_str("\\begin{");
+                out.push_str(env);
+                out.push('}');
+                for (ri, row) in rows.iter().enumerate() {
+                    if ri > 0 {
+                        out.push_str(" \\\\ ");
+                    }
+                    for (ci, cell) in row.iter().enumerate() {
+                        if ci > 0 {
+                            out.push_str(" & ");
+                        }
+                        cell.write(out, 0);
+                    }
+                }
+                out.push_str("\\end{");
+                out.push_str(env);
+                out.push('}');
+            }
         }
     }
 }
@@ -994,8 +1145,133 @@ mod tests {
             "x \\le y",
             "\\hat{x} + \\bar{y}",
             "\\pi r^2",
+            "\\begin{pmatrix} a & b \\\\ c & d \\end{pmatrix}",
+            "\\begin{bmatrix} 1 & 0 \\\\ 0 & 1 \\end{bmatrix}",
+            "\\begin{cases} 1 & x > 0 \\\\ 0 & x \\le 0 \\end{cases}",
+            "\\begin{matrix} a \\\\ b \\\\ c \\end{matrix}",
+            "\\begin{pmatrix} a & b \\\\ c & d \\end{pmatrix}^2",
         ] {
             round_trips(s);
         }
+    }
+
+    // ---- L3: environments -----------------------------------------------------
+
+    #[test]
+    fn pmatrix_two_by_two() {
+        let n = parse_math(r"\begin{pmatrix} a & b \\ c & d \end{pmatrix}").unwrap();
+        match n {
+            MathNode::Matrix { env, rows } => {
+                assert_eq!(env, "pmatrix");
+                assert_eq!(
+                    rows,
+                    vec![
+                        vec![sym("a"), sym("b")],
+                        vec![sym("c"), sym("d")],
+                    ]
+                );
+            }
+            other => panic!("expected Matrix, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn bracket_delimiters_are_case_sensitive() {
+        // bmatrix (square) vs Bmatrix (braces) are distinct environments.
+        assert!(matches!(
+            parse_math(r"\begin{bmatrix} 1 \end{bmatrix}").unwrap(),
+            MathNode::Matrix { ref env, .. } if env == "bmatrix"
+        ));
+        assert!(matches!(
+            parse_math(r"\begin{Bmatrix} 1 \end{Bmatrix}").unwrap(),
+            MathNode::Matrix { ref env, .. } if env == "Bmatrix"
+        ));
+    }
+
+    #[test]
+    fn cases_with_conditions() {
+        // \begin{cases} f & cond \\ g & cond \end{cases}
+        let n = parse_math(r"\begin{cases} 1 & x > 0 \\ 0 & x \le 0 \end{cases}").unwrap();
+        match n {
+            MathNode::Matrix { env, rows } => {
+                assert_eq!(env, "cases");
+                assert_eq!(rows.len(), 2);
+                assert_eq!(rows[0].len(), 2);
+                assert!(matches!(rows[0][1], MathNode::Rel(MRelOp::Gt, ..)));
+                assert!(matches!(rows[1][1], MathNode::Rel(MRelOp::Le, ..)));
+            }
+            other => panic!("expected Matrix, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cells_hold_full_expressions() {
+        let n = parse_math(r"\begin{matrix} \frac{a}{b} & x^2 \\ 1+1 & c \end{matrix}").unwrap();
+        match n {
+            MathNode::Matrix { rows, .. } => {
+                assert!(matches!(rows[0][0], MathNode::Frac(..)));
+                assert!(matches!(rows[0][1], MathNode::Script { .. }));
+                assert!(matches!(rows[1][0], MathNode::Bin(MBinOp::Add, ..)));
+            }
+            other => panic!("expected Matrix, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn single_column_multiple_rows() {
+        let n = parse_math(r"\begin{matrix} a \\ b \\ c \end{matrix}").unwrap();
+        match n {
+            MathNode::Matrix { rows, .. } => {
+                assert_eq!(rows, vec![vec![sym("a")], vec![sym("b")], vec![sym("c")]]);
+            }
+            other => panic!("expected Matrix, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn trailing_row_separator_is_tolerated() {
+        // A trailing `\\` before `\end` does not create an empty final row.
+        let n = parse_math(r"\begin{matrix} a \\ b \\ \end{matrix}").unwrap();
+        match n {
+            MathNode::Matrix { rows, .. } => assert_eq!(rows.len(), 2),
+            other => panic!("expected Matrix, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn nested_environments() {
+        let n = parse_math(
+            r"\begin{pmatrix} \begin{pmatrix} a \end{pmatrix} & b \\ c & d \end{pmatrix}",
+        )
+        .unwrap();
+        match n {
+            MathNode::Matrix { rows, .. } => {
+                assert!(matches!(rows[0][0], MathNode::Matrix { .. }));
+            }
+            other => panic!("expected nested Matrix, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn matrix_can_be_scripted() {
+        // \begin{pmatrix}…\end{pmatrix}^2 — a matrix is an atom, so postfix scripts attach.
+        let n = parse_math(r"\begin{pmatrix} a & b \\ c & d \end{pmatrix}^2").unwrap();
+        match n {
+            MathNode::Script { base, sup, .. } => {
+                assert!(matches!(*base, MathNode::Matrix { .. }));
+                assert_eq!(sup.as_deref(), Some(&num("2")));
+            }
+            other => panic!("expected Script over Matrix, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn environment_errors_are_spanned_not_panics() {
+        assert!(parse_math(r"\begin{matrix} a \end{pmatrix}").is_err()); // begin/end mismatch
+        assert!(parse_math(r"\begin{matrix} a & b").is_err()); // unterminated
+        assert!(parse_math(r"\begin{foobar} a \end{foobar}").is_err()); // unsupported env
+        assert!(parse_math(r"\begin{matrix} & b \end{matrix}").is_err()); // empty cell (limitation)
+        assert!(parse_math(r"\end{matrix}").is_err()); // stray \end
+        assert!(parse_math(r"\begin matrix").is_err()); // missing { after \begin
     }
 }

--- a/code/specs/LTX01-full-latex-parser.md
+++ b/code/specs/LTX01-full-latex-parser.md
@@ -119,9 +119,18 @@ is text-primary, which is a different mode model.)
   `\left\right` fences, infix ops, unary, implicit multiplication, `\frac`/`\binom`,
   `\sqrt[n]{}`, scripts `^`/`_`, functions, big operators with bounds, accents,
   greek/constants/symbols, relations.
-- **L3 — environment semantics.** Row/column structure for `tabular`/`array` and the math
-  matrix family (`matrix`/`pmatrix`/`bmatrix`/`vmatrix`/`cases`/`aligned`/`align`) via `&`
-  and `\\`; list environments (`itemize`/`enumerate`/`description`) with `\item`.
+- **L3 — environment semantics.** Split into two sub-rungs:
+  - **L3a (shipped) — math environment family.** The matrix family
+    (`matrix`/`pmatrix`/`bmatrix`/`Bmatrix`/`vmatrix`/`Vmatrix`/`smallmatrix`), `cases`,
+    and the alignment environments (`aligned`/`gathered`/`align`/`align*`/`split`) parsed
+    inside math islands via `&` (columns) and `\\` (rows) → `MathNode::Matrix { env, rows }`,
+    with `to_latex` round-trip, nesting, and postfix scripts. Empty cells are a documented
+    limitation (spanned error). Implemented in the `latex` crate (math.rs).
+  - **L3b (later) — document-mode tables & lists.** Row/column structure for `tabular`/`array`
+    (which take a mandatory column-spec argument) and list environments
+    (`itemize`/`enumerate`/`description`) with `\item`, operating on the document `Node` tree.
+    Deferred because they need an extra column-spec field on the node; an unknown
+    `\begin{…}` is rejected with a spanned error in the meantime, never mis-parsed.
 - **L4 — macros.** `\newcommand`/`\renewcommand`/`\def` with `#1`..`#9` and one optional
   arg with default; expansion of user-defined and a built-in starter set. Recursion/loop
   guard (bounded expansion depth → `Unsupported`/error, never hang).


### PR DESCRIPTION
## LTX01 L3a — math environments

Fourth rung of the full-fidelity LaTeX parser (standalone, reusable; no ADJ/engine
coupling). `parse_math` now understands `\begin{env} … \end{env}` inside a math island,
producing a new **`MathNode::Matrix { env, rows: Vec<Vec<MathNode>> }`** with a
round-tripping `to_latex`.

### What's in this rung

- `&` separates columns, `\\` separates rows; each cell is a full math expression (the
  existing precedence climber naturally stops at `&`, `\\`, and `\end`, so a cell consumes
  exactly one expression and always makes progress).
- Supported environments (case-sensitive — `bmatrix` ≠ `Bmatrix`): `matrix`, `pmatrix`,
  `bmatrix`, `Bmatrix`, `vmatrix`, `Vmatrix`, `smallmatrix`, `cases`, `dcases`, `aligned`,
  `gathered`, `align`, `align*`, `split`. The env name fixes the rendered delimiters.
- Environments **nest** (a cell may itself be an environment — depth-guarded by the
  enclosing `parse_atom`), and a `Matrix` is an **atom**, so postfix scripts attach
  (`\begin{pmatrix}…\end{pmatrix}^2`).

### Robustness

Total / panic-free / spanned: begin/end name mismatch, unterminated environment, unknown
environment, a missing `{` after `\begin`, and a stray `\end` each return a spanned
`ParseError`. A trailing `\\` before `\end` is tolerated (no empty final row). Nesting is
depth-guarded (`MAX_DEPTH=128`); the row loop provably makes progress every iteration.

### Honest scope

This is **L3a**, the math-mode environment family. Document-mode `tabular`/`array` (which
take a column-spec argument) and list environments (`itemize`/`enumerate` with `\item`) are
**L3b** — deferred because they need an extra node field and operate on the document `Node`
tree; an unknown `\begin{…}` is rejected with a spanned error meanwhile, never mis-parsed.
Empty cells (`a & & b`) are likewise a documented limitation (spanned error). Spec §5
updated to split L3 into L3a/L3b.

### Tests

+9 environment tests (2×2 pmatrix, case-sensitive delimiters, `cases` with conditions,
expression cells, single-column multi-row, trailing `\\`, nesting, scripted matrix, and the
error family) + 5 round-trip-corpus entries. **64 unit + 1 doc test green; clippy
`-D warnings` clean; no `unsafe`.** Crate 0.3.0 → 0.4.0.

Security: `/security-review` ran on the diff (DoS/panic focus — loop termination, nesting
depth, memory growth, index/underflow) and returned **PASSED — no vulnerabilities found**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)