### PR TITLE
feat(visicalc-xaml): multi-sheet workbook in the XAML demo

### DIFF
--- a/demo/visicalc-xaml/Engine.cs
+++ b/demo/visicalc-xaml/Engine.cs
@@ -121,6 +121,20 @@ internal static class ScNative
     [DllImport("spreadsheet_capi")] internal static extern IntPtr sc_column_letters(IntPtr s, uint index);
     [DllImport("spreadsheet_capi")] internal static extern ulong sc_current_revision(IntPtr s);
     [DllImport("spreadsheet_capi")] internal static extern IntPtr sc_changed_since(IntPtr s, ulong since);
+    // Multi-sheet workbook. sc_sheet_names(session) → char* JSON
+    //   {"sheets":[<name>,...],"active":<i>}; sc_active_sheet(session) → u32;
+    //   sc_set_active_sheet/sc_delete_sheet(session, index) → int 1/0;
+    //   sc_add_sheet(session, name) → int; sc_rename_sheet(session, index, name) → int.
+    [DllImport("spreadsheet_capi")] internal static extern IntPtr sc_sheet_names(IntPtr s);
+    [DllImport("spreadsheet_capi")] internal static extern uint sc_active_sheet(IntPtr s);
+    [DllImport("spreadsheet_capi")] internal static extern int sc_set_active_sheet(IntPtr s, uint index);
+    [DllImport("spreadsheet_capi")]
+    internal static extern int sc_add_sheet(IntPtr s,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string name);
+    [DllImport("spreadsheet_capi")]
+    internal static extern int sc_rename_sheet(IntPtr s, uint index,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string newName);
+    [DllImport("spreadsheet_capi")] internal static extern int sc_delete_sheet(IntPtr s, uint index);
 
     [DllImport("spreadsheet_capi")] internal static extern void sc_string_free(IntPtr p);
 
@@ -397,6 +411,54 @@ public sealed class SpreadsheetSession : IDisposable
     public int ReplaceAll(string query, string replacement, bool matchCase) =>
         ScNative.sc_replace_all(_handle, query, replacement, matchCase ? 1 : 0);
 
+    // ── Multi-sheet workbook ──────────────────────────────────────────
+    // The workbook holds several sheets; bare-A1 ops address the ACTIVE one,
+    // while a formula reaches across with a qualifier (=Summary!A1). These manage
+    // the sheet set + the active sheet; the host re-reads cells/raw afterwards.
+    // The single-sheet path is unchanged — an unqualified A1 is the active sheet.
+
+    /// The sheet names in tab order plus the active 0-based index. A malformed
+    /// engine payload yields an empty workbook view (defensive, like <see cref="Window"/>).
+    public (IReadOnlyList<string> names, int active) SheetNames()
+    {
+        string json = Take(ScNative.sc_sheet_names(_handle));
+        var names = new List<string>();
+        int active = 0;
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            var r = doc.RootElement;
+            if (r.TryGetProperty("sheets", out var arr))
+                foreach (var n in arr.EnumerateArray()) names.Add(n.GetString() ?? string.Empty);
+            if (r.TryGetProperty("active", out var a)) active = a.GetInt32();
+        }
+        catch (Exception ex) when (ex is JsonException or KeyNotFoundException or InvalidOperationException) { /* bad response → empty workbook view */ }
+        return (names, active);
+    }
+
+    /// The active sheet's 0-based index.
+    public int ActiveSheet() => (int)ScNative.sc_active_sheet(_handle);
+
+    /// Switch the active sheet by 0-based index; false for an out-of-range index.
+    /// `index` is clamped to ≥ 0 before the uint cast (a negative would otherwise
+    /// wrap to a huge unsigned index); the engine validates the upper bound.
+    public bool SetActiveSheet(int index) =>
+        ScNative.sc_set_active_sheet(_handle, (uint)Math.Max(0, index)) != 0;
+
+    /// Add a new sheet named `name` and make it active; false for an empty or
+    /// duplicate name.
+    public bool AddSheet(string name) => ScNative.sc_add_sheet(_handle, name) != 0;
+
+    /// Rename the sheet at `index` to `newName` (the engine rewrites every
+    /// referencing formula's qualifier). False for a bad index / empty / duplicate.
+    public bool RenameSheet(int index, string newName) =>
+        ScNative.sc_rename_sheet(_handle, (uint)Math.Max(0, index), newName) != 0;
+
+    /// Delete the sheet at `index` (inbound references become `#REF!`). False for
+    /// a bad index or an attempt to delete the last remaining sheet.
+    public bool DeleteSheet(int index) =>
+        ScNative.sc_delete_sheet(_handle, (uint)Math.Max(0, index)) != 0;
+
     public void Dispose()
     {
         if (_handle != IntPtr.Zero)
@@ -529,6 +591,19 @@ public sealed class InfiniteSheetModel : IDisposable
             ("Z1000", "0.0%"), // 39 → "3900.0%": proves the format applies far off-origin
         };
         foreach (var (a1, code) in formats) _session.SetFormat(a1, code);
+
+        // A second sheet, "Summary", proves cross-sheet references compute live:
+        // its B3 sums two of its own cells, and back on the first sheet G1 reaches
+        // ACROSS with a qualifier (=Summary!B3) — identical seed to the
+        // web/Qt/Flutter/Compose demos. The first sheet stays active (bare-A1 ops
+        // still address it).
+        _session.AddSheet("Summary");
+        _session.SetActiveSheet(1);
+        _session.SetCell("A1", "100");
+        _session.SetCell("A2", "200");
+        _session.SetCell("B3", "=A1+A2"); // 300, on the Summary sheet
+        _session.SetActiveSheet(0);
+        _session.SetCell("G1", "=Summary!B3"); // 300, pulled across the sheets
     }
 
     /// Re-derive the virtual grid size from the engine's data extent plus a
@@ -724,6 +799,61 @@ public sealed class InfiniteSheetModel : IDisposable
             Formula = _session.GetRaw(InfAddress);
         }
         return ok;
+    }
+
+    // ── Multi-sheet workbook ──────────────────────────────────────────
+    // The workbook holds several sheets; bare-A1 ops address the ACTIVE one,
+    // while a formula reaches across with a qualifier (=Summary!A1). The tab bar
+    // reads <see cref="SheetNames"/>/<see cref="ActiveSheet"/> and drives the
+    // mutators below; each refreshes the extent + re-primes the formula bar so the
+    // windowed view re-reads.
+
+    /// The sheet names in tab order.
+    public IReadOnlyList<string> SheetNames() => _session.SheetNames().names;
+
+    /// The active sheet's 0-based index.
+    public int ActiveSheet() => _session.ActiveSheet();
+
+    /// Switch the active sheet (bare-A1 ops now address it); re-prime the bar.
+    public void SelectSheet(int index)
+    {
+        if (_session.SetActiveSheet(index))
+        {
+            ComputeExtent();
+            SelectInf(SelRow, SelCol);
+        }
+    }
+
+    /// Add a new empty sheet and switch to it.
+    public void AddSheet(string name)
+    {
+        if (_session.AddSheet(name))
+        {
+            ComputeExtent();
+            SelectInf(1, 1);
+        }
+    }
+
+    /// Rename a sheet by index; cross-sheet references that named it are rewritten
+    /// by the engine, so dependents stay live.
+    public void RenameSheet(int index, string newName)
+    {
+        if (_session.RenameSheet(index, newName))
+        {
+            ComputeExtent();
+            SelectInf(SelRow, SelCol);
+        }
+    }
+
+    /// Delete a sheet by index. References into it become `#REF!`; the engine
+    /// keeps at least one sheet, so this is a no-op on the last one.
+    public void DeleteSheet(int index)
+    {
+        if (_session.DeleteSheet(index))
+        {
+            ComputeExtent();
+            SelectInf(1, 1);
+        }
     }
 
     public void Dispose() => _session.Dispose();

--- a/demo/visicalc-xaml/InfiniteSheet.xaml
+++ b/demo/visicalc-xaml/InfiniteSheet.xaml
@@ -70,6 +70,7 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
         <!-- Formula bar: a rounded panel holding the address pill, an `fx` marker,
@@ -290,9 +291,33 @@
             </ScrollViewer>
         </Grid>
 
+        <!-- Sheet tab bar (Excel-style, along the bottom): one chip per sheet, the
+             active one tinted to the accent (rebuilt in the code-behind). Click a
+             tab to switch; the active tab carries inline ✎ rename / ✕ delete
+             affordances, and "+ Sheet" adds one. A formula like =Summary!B3 reaches
+             across the tabs, so switching + editing updates cross-sheet dependents. -->
+        <Grid Grid.Row="3" Margin="10,4,10,0">
+            <Border Height="1" Background="#2C313A" VerticalAlignment="Top"/>
+            <Grid Margin="0,6,0,0">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <ScrollViewer Grid.Column="0"
+                              HorizontalScrollMode="Enabled" HorizontalScrollBarVisibility="Auto"
+                              VerticalScrollMode="Disabled" VerticalScrollBarVisibility="Disabled">
+                    <StackPanel x:Name="SheetTabsPanel" Orientation="Horizontal"/>
+                </ScrollViewer>
+                <Button x:Name="AddSheetButton" Grid.Column="1" Style="{StaticResource ToolChip}"
+                        Margin="6,0,0,0" Content="+ Sheet"
+                        ToolTipService.ToolTip="Add a new sheet"
+                        Click="AddSheetButton_Click"/>
+            </Grid>
+        </Grid>
+
         <!-- Status line: a hairline-separated footer echoing the live virtual-grid
              size and the per-edit revision clock (mirrors the sibling demos). -->
-        <StackPanel Grid.Row="3" Margin="10,0,10,10">
+        <StackPanel Grid.Row="4" Margin="10,0,10,10">
             <Border Height="1" Background="#2C313A"/>
             <TextBlock x:Name="StatusText" Margin="0,6,0,0"
                        Foreground="#9AA3B2" FontSize="12" FontFamily="Consolas"/>

--- a/demo/visicalc-xaml/InfiniteSheet.xaml.cs
+++ b/demo/visicalc-xaml/InfiniteSheet.xaml.cs
@@ -77,6 +77,7 @@ public sealed partial class InfiniteSheet : UserControl
         BodyList.Width = _model.TotalCols * ColW;
 
         BuildHeader();
+        BuildSheetTabs();
         RefreshFormulaBar();
 
         Loaded += OnLoaded;
@@ -102,6 +103,131 @@ public sealed partial class InfiniteSheet : UserControl
         HeaderPanel.Children.Clear();
         for (int c = 1; c <= _model.TotalCols; c++)
             HeaderPanel.Children.Add(ChromeCell(ColW, HeadH, _model.ColumnLetters(c), _model.SelCol == c));
+    }
+
+    // ── Sheet tab bar (multi-sheet workbook) ─────────────────────────
+    // One chip per sheet; the active one tints to the accent. Click a tab to
+    // switch (bare-A1 ops then address it); the active tab carries inline ✎ rename
+    // and ✕ delete affordances. A formula like =Summary!B3 reaches across the
+    // tabs, so switching + editing updates every cross-sheet dependent live.
+    private void BuildSheetTabs()
+    {
+        SheetTabsPanel.Children.Clear();
+        IReadOnlyList<string> names = _model.SheetNames();
+        int active = _model.ActiveSheet();
+        for (int i = 0; i < names.Count; i++)
+            SheetTabsPanel.Children.Add(SheetTab(i, names[i], i == active));
+    }
+
+    /// One sheet tab chip: the name, plus (when active) inline ✎ rename and ✕
+    /// delete glyphs. The whole chip is tap-to-switch; the glyphs handle their own
+    /// tap (and mark it handled so they don't also switch).
+    private Border SheetTab(int index, string name, bool selected)
+    {
+        var row = new StackPanel { Orientation = Orientation.Horizontal, VerticalAlignment = VerticalAlignment.Center };
+        row.Children.Add(new TextBlock
+        {
+            Text = name,
+            Foreground = selected ? White : Ink,
+            FontSize = 12,
+            FontFamily = Mono,
+            FontWeight = selected ? FontWeights.SemiBold : FontWeights.Normal,
+            VerticalAlignment = VerticalAlignment.Center,
+        });
+        if (selected)
+        {
+            row.Children.Add(Glyph("✎", () => RenameSheetAsync(index)));
+            row.Children.Add(Glyph("✕", () => DeleteSheet(index)));
+        }
+
+        var chip = new Border
+        {
+            Background = selected ? Sel : New(0x21, 0x25, 0x2C),
+            BorderBrush = selected ? Accent : LineStrong,
+            BorderThickness = new Thickness(selected ? 2 : 1),
+            CornerRadius = new CornerRadius(6),
+            Padding = new Thickness(10, 5, 10, 5),
+            Margin = new Thickness(0, 0, 4, 0),
+            Child = row,
+        };
+        chip.Tapped += (_, _) => SwitchSheet(index);
+        return chip;
+    }
+
+    /// A small inline action glyph (✎ / ✕) inside the active sheet tab. Tapping it
+    /// runs `action` and marks the event handled so the parent chip's switch-tap
+    /// doesn't also fire.
+    private TextBlock Glyph(string text, Action action)
+    {
+        var tb = new TextBlock
+        {
+            Text = text,
+            Foreground = Muted,
+            FontSize = 12,
+            FontFamily = Mono,
+            Margin = new Thickness(8, 0, 0, 0),
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+        tb.Tapped += (_, e) => { e.Handled = true; action(); };
+        return tb;
+    }
+
+    private void SwitchSheet(int index) { _model.SelectSheet(index); AfterSheetOp(); }
+    private void DeleteSheet(int index) { _model.DeleteSheet(index); AfterSheetOp(); }
+
+    private void AddSheetButton_Click(object sender, RoutedEventArgs e)
+    {
+        // Name the new sheet "SheetN" where N avoids a clash with existing names.
+        var existing = new HashSet<string>(_model.SheetNames());
+        int n = existing.Count + 1;
+        while (existing.Contains($"Sheet{n}")) n++;
+        _model.AddSheet($"Sheet{n}");
+        AfterSheetOp();
+    }
+
+    /// Rename the sheet at `index` via a small text dialog; the engine rewrites
+    /// every referencing formula's qualifier on commit.
+    private async void RenameSheetAsync(int index)
+    {
+        IReadOnlyList<string> names = _model.SheetNames();
+        if (index < 0 || index >= names.Count) return;
+        var input = new TextBox
+        {
+            Text = names[index],
+            FontFamily = Mono,
+            SelectionStart = 0,
+        };
+        var dialog = new ContentDialog
+        {
+            Title = "Rename sheet",
+            Content = input,
+            PrimaryButtonText = "Rename",
+            CloseButtonText = "Cancel",
+            DefaultButton = ContentDialogButton.Primary,
+            XamlRoot = XamlRoot,
+        };
+        var result = await dialog.ShowAsync();
+        if (result != ContentDialogResult.Primary) return;
+        string newName = input.Text.Trim();
+        if (newName.Length == 0) return;
+        _model.RenameSheet(index, newName);
+        AfterSheetOp();
+    }
+
+    /// After any sheet op (switch / add / rename / delete) the active sheet — and
+    /// thus the extent, the cells, and the selection — may have changed wholesale.
+    /// Rebuild the row-number source (the new sheet's extent), re-tile the header,
+    /// re-sync the formula bar, and rebuild the tab bar.
+    private void AfterSheetOp()
+    {
+        _rowNumbers = Enumerable.Range(1, _model.TotalRows).ToList();
+        BodyList.ItemsSource = _rowNumbers;
+        GutterList.ItemsSource = _rowNumbers;
+        BodyList.Width = _model.TotalCols * ColW;
+        BuildHeader();
+        BuildSheetTabs();
+        RefreshFormulaBar();
+        RepaintRealizedRows();
     }
 
     // ── Virtualized body + gutter population ─────────────────────────

--- a/demo/visicalc-xaml/README.md
+++ b/demo/visicalc-xaml/README.md
@@ -191,6 +191,21 @@ stays typed (`15`→`99` re-totals every dependent).
 `InfiniteSheetModel` (in `Engine.cs`, WinUI-free) seeds far-flung sparse cells
 (`Z1000`, `BA50`, `BB50`) and derives the extent from `UsedRange()` + a margin
 (saturated in `long` then clamped to `int`, guarding the u32-overflow case).
+The bottom **sheet tab bar** drives a multi-sheet **workbook**: the workbook
+holds several sheets and bare-`A1` ops address the *active* one, while a formula
+reaches **across** with a qualifier (`=Summary!B3`). Each tab is a chip (the
+active one tints to the accent); **click** to switch, the active tab carries
+inline **✎ rename** (a `ContentDialog`) and **✕ delete** affordances, and
+**+ Sheet** adds one (`InfiniteSheetModel.SelectSheet`/`AddSheet`/`RenameSheet`/
+`DeleteSheet` over the C ABI's `sc_set_active_sheet`/`sc_add_sheet`/
+`sc_rename_sheet`/`sc_delete_sheet`, with `sc_sheet_names`/`sc_active_sheet`
+reading the tab list). The seed adds a second sheet, **Summary** (`B3 = A1+A2 =
+300`), and `Sheet1!G1 = =Summary!B3` pulls that value across; editing a Summary
+input recomputes the cross-sheet dependent live. Renaming `Summary` rewrites
+every referencing qualifier; deleting a referenced sheet turns the dangling
+reference into `#REF!`, and the engine keeps at least one sheet (deleting the
+last is a no-op). The single-sheet path is byte-identical — an unqualified `A1`
+still means the active sheet.
 
 #### Visual design
 
@@ -236,6 +251,11 @@ locates the one literal (`A1`), a case-insensitive `FindAll("sum")` finds the to
 formulas, empty / no-match queries return nothing, `SelectA1("Z1000")` parses a far
 address, and `ReplaceAll` rewrites both a literal (`15`→`99` ⇒ E1 122.00) and a
 formula reference (`H1`→`H2` ⇒ `=H1+5` recomputes to 25) keeping each live.
+Finally a **multi-sheet** section proves the workbook over the C ABI: a
+cross-sheet `=Summary!B3` computes and stays live as its precedent changes (300
+→ 350), a rename rewrites the referencing qualifier (`Summary` → `Totals`),
+deleting a referenced sheet yields `#REF!` (and the last sheet can't be deleted),
+and the `InfiniteSheetModel` seed exposes `Sheet1`/`Summary` with a live cross-ref.
 
 ## Where this fits in the cross-backend demo plan
 

--- a/demo/visicalc-xaml/test/Program.cs
+++ b/demo/visicalc-xaml/test/Program.cs
@@ -299,5 +299,53 @@ using (var fr = new InfiniteSheetModel())
     Check("H3 recomputed live", fr.RowCells(3)[7], "25"); // =H2+5
 }
 
+// ── Multi-sheet workbook + cross-sheet references (the sheet tab bar drives
+// SheetNames/ActiveSheet/SelectSheet/AddSheet/RenameSheet/DeleteSheet): the
+// workbook holds several sheets; bare-A1 ops address the ACTIVE sheet, while a
+// formula reaches ACROSS with a qualifier (=Summary!B3). This proves the .NET ↔
+// P/Invoke ↔ C ABI path drives sheet management + cross-sheet recompute.
+using (var ms = new SpreadsheetSession())
+{
+    Check("ms initial sheets", string.Join(",", ms.SheetNames().names), "Sheet1");
+    Check("ms add Summary", ms.AddSheet("Summary").ToString(), "True");
+    Check("ms sheets after add", string.Join(",", ms.SheetNames().names), "Sheet1,Summary");
+    // Edit the Summary sheet (index 1): B3 = A1+A2 = 300.
+    Check("ms activate Summary", ms.SetActiveSheet(1).ToString(), "True");
+    Check("ms active index", ms.ActiveSheet().ToString(), "1");
+    ms.SetCell("A1", "100"); ms.SetCell("A2", "200"); ms.SetCell("B3", "=A1+A2");
+    Check("ms Summary B3", ms.Window(3, 2, 3, 2)[0][0], "300");
+    // Back on Sheet1, reach ACROSS with a qualifier.
+    Check("ms back to Sheet1", ms.SetActiveSheet(0).ToString(), "True");
+    ms.SetCell("G1", "=Summary!B3");
+    Check("ms cross-sheet G1", ms.Window(1, 7, 1, 7)[0][0], "300");
+    // Editing a Summary input recomputes the cross-sheet dependent live.
+    ms.SetActiveSheet(1); ms.SetCell("A1", "150"); // Summary!A1: 100 → 150, B3 = 350
+    ms.SetActiveSheet(0);
+    Check("ms cross-sheet live", ms.Window(1, 7, 1, 7)[0][0], "350");
+    // Rename Summary → Totals; the qualifier in G1 is rewritten by the engine.
+    Check("ms rename", ms.RenameSheet(1, "Totals").ToString(), "True");
+    Check("ms sheets after rename", string.Join(",", ms.SheetNames().names), "Sheet1,Totals");
+    Contains("ms G1 names Totals", ms.GetRaw("G1"), "Totals");
+    Check("ms cross-sheet after rename", ms.Window(1, 7, 1, 7)[0][0], "350");
+    // Delete the referenced sheet → the dangling cross-sheet ref becomes #REF!.
+    Check("ms delete", ms.DeleteSheet(1).ToString(), "True");
+    Check("ms sheets after delete", string.Join(",", ms.SheetNames().names), "Sheet1");
+    Contains("ms G1 #REF!", ms.Window(1, 7, 1, 7)[0][0], "#REF!");
+    // The engine keeps at least one sheet: deleting the last one is a no-op.
+    Check("ms cannot delete last", ms.DeleteSheet(0).ToString(), "False");
+}
+
+// The InfiniteSheetModel seed exposes Sheet1/Summary with a live cross-ref.
+using (var msm = new InfiniteSheetModel())
+{
+    Check("msm sheets", string.Join(",", msm.SheetNames()), "Sheet1,Summary");
+    Check("msm active", msm.ActiveSheet().ToString(), "0");
+    msm.SelectA1("G1");
+    Check("msm Sheet1 G1 cross-ref", msm.RowCells(1)[6], "300"); // col 7, index 6
+    msm.SelectSheet(1);
+    Check("msm switched to Summary", msm.ActiveSheet().ToString(), "1");
+    Check("msm Summary B3", msm.RowCells(3)[1], "300"); // B3 = A1+A2 = 100+200
+}
+
 Console.WriteLine(failures == 0 ? "\nALL PASS" : $"\n{failures} FAILURE(S)");
 return failures == 0 ? 0 : 1;


### PR DESCRIPTION
Roll out **multi-sheet + cross-sheet references** to the **WinUI 3 / XAML** VisiCalc demo — the **5th of 6** backends, after web ([#6723](https://github.com/adhithyan15/coding-adventures/pull/6723)), Qt ([#6726](https://github.com/adhithyan15/coding-adventures/pull/6726)), Flutter ([#6729](https://github.com/adhithyan15/coding-adventures/pull/6729)), and Compose ([#6730](https://github.com/adhithyan15/coding-adventures/pull/6730)). The workbook holds several sheets; bare-`A1` ops address the **active** sheet, while a formula reaches **across** with a qualifier (`=Summary!B3`). The single-sheet path stays **byte-identical**.

## What changed

**Engine binding** (`Engine.cs`, `SpreadsheetSession` over P/Invoke)
- 6 sheet ops wired through `System.Runtime.InteropServices` — `sc_sheet_names` / `sc_active_sheet` / `sc_set_active_sheet` / `sc_add_sheet` / `sc_rename_sheet` / `sc_delete_sheet` — with `[MarshalAs(LPUTF8Str)]` for the name-passing calls.
- `SheetNames()` parses the engine JSON **defensively** (the codebase's `JsonException`/`KeyNotFoundException`/`InvalidOperationException` catch); index mutators clamp through `(uint)Math.Max(0, index)` before the u32 ABI.

**Model** (`InfiniteSheetModel`): `SheetNames`/`ActiveSheet` + `SelectSheet`/`AddSheet`/`RenameSheet`/`DeleteSheet` passthrough, each refreshing the extent and re-priming the formula bar. The seed adds a second sheet, **Summary** (`B3 = A1+A2 = 300`), and `Sheet1!G1 = =Summary!B3` pulls it across.

**UI** (`InfiniteSheet.xaml` + `.xaml.cs`): an Excel-style **sheet tab bar** along the bottom — one chip per sheet (active tints to the accent); **click** to switch, the active tab carries inline **✎ rename** (a `ContentDialog`) and **✕ delete** glyphs (each marks the tap handled so it doesn't also switch), **+ Sheet** adds one. `AfterSheetOp()` rebuilds the row source (the new sheet's extent), re-tiles the header, and rebuilds the tab bar.

## Proof
- A new **multi-sheet section** in `test/Program.cs` (the cross-platform P/Invoke console harness): cross-sheet `=Summary!B3` computes and stays live as its precedent changes (300 → 350), a rename rewrites the referencing qualifier (`Summary` → `Totals`), deleting a referenced sheet yields `#REF!` (and the last sheet can't be deleted), and the `InfiniteSheetModel` seed exposes `Sheet1`/`Summary` with a live cross-ref.
- `scripts/verify.sh` **ALL PASS**. (The WinUI view itself is Windows-only — this macOS checkout can't `dotnet build` it; the engine-backed logic it drives is the headlessly-proven model.) README updated.

## Security review
PASSED. P/Invoke marshalling + `char*` free contract correct (single `sc_string_free` via `Take`), descriptor signatures match the native ABI, indices clamped, the `AddSheet` collision loop is bounded, JSON parse is defensive, and the `async void` rename's post-await path is unreachable (modal dialog) and range-guarded regardless. No memory-safety issues (the Rust C ABI is `#![forbid(unsafe_code)]`, null- and range-guarded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)