### PR TITLE
feat(visicalc-swiftui): multi-sheet workbook in the SwiftUI demo

### DIFF
--- a/demo/visicalc-swiftui/README.md
+++ b/demo/visicalc-swiftui/README.md
@@ -127,6 +127,22 @@ re-parses each rewrite through its centralised coerce (`set_raw`), a rewritten f
 stays live (`H1`→`H2` turns `=H1+5` into a recomputed `=H2+5`) and a rewritten literal
 stays typed (`15`→`99` re-totals every dependent).
 
+The bottom **sheet tab bar** drives a multi-sheet **workbook**: the workbook
+holds several sheets and bare-`A1` ops address the *active* one, while a formula
+reaches **across** with a qualifier (`=Summary!B3`). Each tab is a chip (the
+active one tints to the accent); **tap** to switch, the active tab carries inline
+**✎ rename** (an `.alert` with a text field) and **✕ delete** buttons, and
+**+ Sheet** adds one (`WindowedSheetModel.selectSheet`/`addSheet`/`renameSheet`/
+`deleteSheet` over the C ABI's `sc_set_active_sheet`/`sc_add_sheet`/
+`sc_rename_sheet`/`sc_delete_sheet`, with `sc_sheet_names`/`sc_active_sheet`
+reading the tab list). The seed adds a second sheet, **Summary** (`B3 = A1+A2 =
+300`), and `Sheet1!G1 = =Summary!B3` pulls that value across; editing a Summary
+input recomputes the cross-sheet dependent live. Renaming `Summary` rewrites every
+referencing qualifier; deleting a referenced sheet turns the dangling reference
+into `#REF!`, and the engine keeps at least one sheet (deleting the last is a
+no-op). The single-sheet path is byte-identical — an unqualified `A1` still means
+the active sheet.
+
 ### Visual design
 
 `InfiniteGridView` mirrors the **reference visual language** defined by the web
@@ -160,7 +176,12 @@ history), and **find / replace** (`findAll("15")` locates the one literal `A1`, 
 case-insensitive `findAll("sum")` finds the total formulas, empty / no-match queries
 return nothing, `selectA1("Z1000")` parses a far address, and `replaceAll` rewrites
 both a literal `15`→`99` ⇒ E1 122.00 and a formula reference `H1`→`H2` ⇒ `=H1+5`
-recomputes to 25, keeping each live). Run with `swift test`.
+recomputes to 25, keeping each live). A **multi-sheet** pair of tests proves the
+workbook over the C ABI: a cross-sheet `=Summary!B3` computes and stays live as
+its precedent changes (300 → 350), a rename rewrites the referencing qualifier
+(`Summary` → `Totals`), deleting a referenced sheet yields `#REF!` (and the last
+sheet can't be deleted), and the `WindowedSheetModel` seed exposes
+`Sheet1`/`Summary` with a live cross-ref. Run with `swift test`.
 
 ## Notes
 

--- a/demo/visicalc-swiftui/Sources/CSpreadsheetEngine/include/spreadsheet.h
+++ b/demo/visicalc-swiftui/Sources/CSpreadsheetEngine/include/spreadsheet.h
@@ -96,6 +96,24 @@ int   sc_sort_range(ScSession *s, const char *start, const char *end,
 char *sc_find_all(ScSession *s, const char *query, int in_formulas, int match_case);
 int   sc_replace_all(ScSession *s, const char *query, const char *replacement, int match_case);
 
+/* Multi-sheet workbook. A session has one or more named sheets; bare-A1 cell ops
+   address the ACTIVE sheet, and a formula may reference another (=Summary!A1).
+   sc_sheet_names() returns a heap char* JSON object
+   {"sheets":["Sheet1",...],"active":0} (names in tab order + the active 0-based
+   index) — free with sc_string_free(). sc_active_sheet() is the active index.
+   The mutators return 1 on success, 0 on rejection (bad index / empty-or-duplicate
+   name / can't-delete-last-sheet); the host re-reads cells/raw afterwards.
+   sc_set_active_sheet switches by index; sc_add_sheet appends a sheet and makes
+   it active; sc_rename_sheet rewrites referencing formulas' qualifiers;
+   sc_delete_sheet turns inbound refs into #REF!; sc_move_sheet reorders a tab. */
+char    *sc_sheet_names(ScSession *s);
+uint32_t sc_active_sheet(ScSession *s);
+int      sc_set_active_sheet(ScSession *s, uint32_t index);
+int      sc_add_sheet(ScSession *s, const char *name);
+int      sc_rename_sheet(ScSession *s, uint32_t index, const char *new_name);
+int      sc_delete_sheet(ScSession *s, uint32_t index);
+int      sc_move_sheet(ScSession *s, uint32_t index, uint32_t to_index);
+
 /* Save / load. sc_serialize() returns a self-contained JSON document holding the
    workbook's SOURCE (formula text + typed literals) and per-cell formats — not the
    computed values, which recompute on load (small file, can't disagree with itself).

--- a/demo/visicalc-swiftui/Sources/VisiCalc/Engine.swift
+++ b/demo/visicalc-swiftui/Sources/VisiCalc/Engine.swift
@@ -229,6 +229,51 @@ final class SpreadsheetSession {
     func replaceAll(_ query: String, _ replacement: String, _ matchCase: Bool) -> Int {
         Int(sc_replace_all(handle, query, replacement, matchCase ? 1 : 0))
     }
+
+    // MARK: - Multi-sheet workbook
+    // The workbook holds several sheets; bare-A1 ops address the ACTIVE one, while
+    // a formula reaches across with a qualifier (=Summary!A1). These manage the
+    // sheet set + the active sheet; the host re-reads cells/raw afterwards. The
+    // single-sheet path is unchanged — an unqualified A1 is the active sheet.
+
+    /// The sheet names in tab order plus the active 0-based index. A malformed
+    /// engine payload yields an empty workbook view (defensive, like `window`).
+    func sheetNames() -> (names: [String], active: Int) {
+        let json = take(sc_sheet_names(handle))
+        guard
+            let data = json.data(using: .utf8),
+            let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return ([], 0) }
+        let names = obj["sheets"] as? [String] ?? []
+        let active = obj["active"] as? Int ?? 0
+        return (names, active)
+    }
+
+    /// The active sheet's 0-based index.
+    func activeSheet() -> Int { Int(sc_active_sheet(handle)) }
+
+    /// Switch the active sheet by 0-based index; false for an out-of-range index.
+    /// `index` is clamped to ≥ 0 before the UInt32 conversion (a negative would
+    /// otherwise trap); the engine validates the upper bound.
+    @discardableResult
+    func setActiveSheet(_ index: Int) -> Bool { sc_set_active_sheet(handle, UInt32(max(0, index))) != 0 }
+
+    /// Add a new sheet named `name` and make it active; false for an empty or
+    /// duplicate name.
+    @discardableResult
+    func addSheet(_ name: String) -> Bool { sc_add_sheet(handle, name) != 0 }
+
+    /// Rename the sheet at `index` to `newName` (the engine rewrites every
+    /// referencing formula's qualifier). False for a bad index / empty / duplicate.
+    @discardableResult
+    func renameSheet(_ index: Int, _ newName: String) -> Bool {
+        sc_rename_sheet(handle, UInt32(max(0, index)), newName) != 0
+    }
+
+    /// Delete the sheet at `index` (inbound references become `#REF!`). False for
+    /// a bad index or an attempt to delete the last remaining sheet.
+    @discardableResult
+    func deleteSheet(_ index: Int) -> Bool { sc_delete_sheet(handle, UInt32(max(0, index))) != 0 }
 }
 
 /// SwiftUI model: an engine-backed 5×5 spreadsheet. `@Published` properties

--- a/demo/visicalc-swiftui/Sources/VisiCalc/InfiniteGrid.swift
+++ b/demo/visicalc-swiftui/Sources/VisiCalc/InfiniteGrid.swift
@@ -75,6 +75,19 @@ final class WindowedSheetModel: ObservableObject {
             ("Z1000", "0.0%"), // 39 → "3900.0%": proves the format applies far off-origin
         ]
         for (a, code) in formats { session.setFormat(a, code) }
+
+        // A second sheet, "Summary", proves cross-sheet references compute live:
+        // its B3 sums two of its own cells, and back on the first sheet G1 reaches
+        // ACROSS with a qualifier (=Summary!B3) — identical seed to the
+        // web/Qt/Flutter/Compose/XAML demos. The first sheet stays active (bare-A1
+        // ops still address it).
+        session.addSheet("Summary")
+        session.setActiveSheet(1)
+        session.setCell("A1", "100")
+        session.setCell("A2", "200")
+        session.setCell("B3", "=A1+A2") // 300, on the Summary sheet
+        session.setActiveSheet(0)
+        session.setCell("G1", "=Summary!B3") // 300, pulled across the sheets
     }
 
     /// Size the virtual grid to the data extent plus a comfortable margin, and
@@ -330,6 +343,52 @@ final class WindowedSheetModel: ObservableObject {
         return ok
     }
 
+    // ── Multi-sheet workbook ──────────────────────────────────────────
+    // The workbook holds several sheets; bare-A1 ops address the ACTIVE one, while
+    // a formula reaches across with a qualifier (=Summary!A1). The tab bar reads
+    // `sheetNames`/`activeSheet` and drives the mutators below; each resizes the
+    // extent + re-primes the formula bar and bumps `revision` so the view re-reads.
+
+    /// The sheet names in tab order.
+    func sheetNames() -> [String] { session.sheetNames().names }
+
+    /// The active sheet's 0-based index.
+    func activeSheet() -> Int { session.activeSheet() }
+
+    /// Switch the active sheet (bare-A1 ops now address it); re-prime the bar.
+    func selectSheet(_ index: Int) {
+        guard session.setActiveSheet(index) else { return }
+        resize()
+        select(row: selectedRow, col: selectedCol)
+        revision += 1
+    }
+
+    /// Add a new empty sheet and switch to it.
+    func addSheet(_ name: String) {
+        guard session.addSheet(name) else { return }
+        resize()
+        select(row: 1, col: 1)
+        revision += 1
+    }
+
+    /// Rename a sheet by index; cross-sheet references that named it are rewritten
+    /// by the engine, so dependents stay live.
+    func renameSheet(_ index: Int, _ newName: String) {
+        guard session.renameSheet(index, newName) else { return }
+        resize()
+        select(row: selectedRow, col: selectedCol)
+        revision += 1
+    }
+
+    /// Delete a sheet by index. References into it become `#REF!`; the engine
+    /// keeps at least one sheet, so this is a no-op on the last one.
+    func deleteSheet(_ index: Int) {
+        guard session.deleteSheet(index) else { return }
+        resize()
+        select(row: 1, col: 1)
+        revision += 1
+    }
+
     /// Write `raw` into an explicit A1 cell and return the cells it dirtied.
     /// (Kept for the headless `WindowedModelTests`.)
     @discardableResult
@@ -352,6 +411,10 @@ struct InfiniteGridView: View {
     @State private var savedSnapshot = ""
     // Drives the formula field's accent focus ring.
     @FocusState private var formulaFocused: Bool
+    // Multi-sheet: the index being renamed (non-nil shows the rename alert) and
+    // the in-progress name.
+    @State private var renamingIndex: Int?
+    @State private var renameText = ""
 
     // Roomier geometry, to match the web reference.
     static let rowH: CGFloat = 26
@@ -393,9 +456,89 @@ struct InfiniteGridView: View {
                 }
             }
             .background(cBg)
+            sheetTabBar
             statusBar
         }
         .background(cBg)
+        .alert("Rename sheet", isPresented: Binding(
+            get: { renamingIndex != nil },
+            set: { if !$0 { renamingIndex = nil } }
+        )) {
+            TextField("Sheet name", text: $renameText)
+            Button("Cancel", role: .cancel) { renamingIndex = nil }
+            Button("Rename") {
+                if let i = renamingIndex {
+                    let name = renameText.trimmingCharacters(in: .whitespacesAndNewlines)
+                    if !name.isEmpty { model.renameSheet(i, name) }
+                }
+                renamingIndex = nil
+            }
+        }
+    }
+
+    // Sheet tab bar (Excel-style, along the bottom): one chip per sheet, the
+    // active one tinted to the accent. Tap a tab to switch (bare-A1 ops then
+    // address it); the active tab carries inline ✎ rename / ✕ delete buttons, and
+    // "+ Sheet" adds one. A formula like =Summary!B3 reaches across the tabs, so
+    // switching + editing here updates every cross-sheet dependent live.
+    private var sheetTabBar: some View {
+        let names = model.sheetNames()
+        let active = model.activeSheet()
+        return VStack(spacing: 0) {
+            Rectangle().fill(line).frame(height: 1)
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 4) {
+                    ForEach(Array(names.enumerated()), id: \.offset) { i, name in
+                        sheetTab(index: i, name: name, selected: i == active)
+                    }
+                    Button("+ Sheet") {
+                        // Name the new sheet "SheetN", avoiding a clash.
+                        let existing = Set(model.sheetNames())
+                        var n = existing.count + 1
+                        while existing.contains("Sheet\(n)") { n += 1 }
+                        model.addSheet("Sheet\(n)")
+                    }
+                    .buttonStyle(ChipButtonStyle())
+                    .help("Add a new sheet")
+                }
+                .padding(.horizontal, 10)
+                .padding(.top, 6)
+            }
+        }
+    }
+
+    private func sheetTab(index: Int, name: String, selected: Bool) -> some View {
+        HStack(spacing: 6) {
+            Text(name)
+                .font(.system(size: 12, weight: selected ? .semibold : .regular, design: .monospaced))
+                .foregroundColor(selected ? .white : ink)
+            if selected {
+                // Inline rename / delete affordances on the active tab.
+                Button {
+                    renameText = name
+                    renamingIndex = index
+                } label: {
+                    Text("✎").font(.system(size: 12, design: .monospaced)).foregroundColor(muted)
+                }
+                .buttonStyle(.plain)
+                .help("Rename this sheet")
+                Button {
+                    model.deleteSheet(index)
+                } label: {
+                    Text("✕").font(.system(size: 12, design: .monospaced)).foregroundColor(muted)
+                }
+                .buttonStyle(.plain)
+                .help("Delete this sheet")
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 5)
+        .background(selected ? sel : cSurface)
+        .overlay(RoundedRectangle(cornerRadius: 6)
+            .stroke(selected ? accent : lineStrong, lineWidth: selected ? 2 : 1))
+        .cornerRadius(6)
+        .contentShape(Rectangle())
+        .onTapGesture { model.selectSheet(index) }
     }
 
     // Hairline-separated footer: the live virtual-grid size + per-edit revision

--- a/demo/visicalc-swiftui/Tests/VisiCalcTests/WindowedModelTests.swift
+++ b/demo/visicalc-swiftui/Tests/VisiCalcTests/WindowedModelTests.swift
@@ -279,4 +279,51 @@ final class WindowedModelTests: XCTestCase {
         XCTAssertEqual(m.replaceAll("H1", "H2"), 1)
         XCTAssertEqual(m.rowCells(3)[7], "25") // =H2+5
     }
+
+    // Multi-sheet workbook + cross-sheet references (the sheet tab bar drives
+    // sheetNames/activeSheet/selectSheet/addSheet/renameSheet/deleteSheet): the
+    // workbook holds several sheets; bare-A1 ops address the ACTIVE sheet, while a
+    // formula reaches ACROSS with a qualifier (=Summary!B3). This proves the
+    // Swift ↔ C ABI path drives sheet management + cross-sheet recompute.
+    func testMultiSheetCrossSheetReferences() {
+        let s = SpreadsheetSession()
+        XCTAssertEqual(s.sheetNames().names, ["Sheet1"])
+        XCTAssertTrue(s.addSheet("Summary"))
+        XCTAssertEqual(s.sheetNames().names, ["Sheet1", "Summary"])
+        // Edit the Summary sheet (index 1): B3 = A1+A2 = 300.
+        XCTAssertTrue(s.setActiveSheet(1))
+        XCTAssertEqual(s.activeSheet(), 1)
+        s.setCell("A1", "100"); s.setCell("A2", "200"); s.setCell("B3", "=A1+A2")
+        XCTAssertEqual(s.window(3, 2, 3, 2)[0][0], "300")
+        // Back on Sheet1, reach ACROSS with a qualifier.
+        XCTAssertTrue(s.setActiveSheet(0))
+        s.setCell("G1", "=Summary!B3")
+        XCTAssertEqual(s.window(1, 7, 1, 7)[0][0], "300")
+        // Editing a Summary input recomputes the cross-sheet dependent live.
+        s.setActiveSheet(1); s.setCell("A1", "150") // Summary!A1: 100 → 150, B3 = 350
+        s.setActiveSheet(0)
+        XCTAssertEqual(s.window(1, 7, 1, 7)[0][0], "350")
+        // Rename Summary → Totals; the qualifier in G1 is rewritten by the engine.
+        XCTAssertTrue(s.renameSheet(1, "Totals"))
+        XCTAssertEqual(s.sheetNames().names, ["Sheet1", "Totals"])
+        XCTAssertTrue(s.getRaw("G1").contains("Totals"))
+        XCTAssertEqual(s.window(1, 7, 1, 7)[0][0], "350")
+        // Delete the referenced sheet → the dangling cross-sheet ref becomes #REF!.
+        XCTAssertTrue(s.deleteSheet(1))
+        XCTAssertEqual(s.sheetNames().names, ["Sheet1"])
+        XCTAssertTrue(s.window(1, 7, 1, 7)[0][0].contains("#REF!"))
+        // The engine keeps at least one sheet: deleting the last one is a no-op.
+        XCTAssertFalse(s.deleteSheet(0))
+    }
+
+    // The WindowedSheetModel seed exposes Sheet1/Summary with a live cross-ref.
+    func testWindowedModelSeedsSummarySheet() {
+        let m = WindowedSheetModel()
+        XCTAssertEqual(m.sheetNames(), ["Sheet1", "Summary"])
+        XCTAssertEqual(m.activeSheet(), 0)
+        XCTAssertEqual(m.rowCells(1)[6], "300") // Sheet1!G1 (col 7, index 6)
+        m.selectSheet(1)
+        XCTAssertEqual(m.activeSheet(), 1)
+        XCTAssertEqual(m.rowCells(3)[1], "300") // Summary!B3 = A1+A2 = 100+200
+    }
 }


### PR DESCRIPTION
Roll out **multi-sheet + cross-sheet references** to the **SwiftUI** VisiCalc demo — the **6th and last** of 6 backends, completing the rollout after web ([#6723](https://github.com/adhithyan15/coding-adventures/pull/6723)), Qt ([#6726](https://github.com/adhithyan15/coding-adventures/pull/6726)), Flutter ([#6729](https://github.com/adhithyan15/coding-adventures/pull/6729)), Compose ([#6730](https://github.com/adhithyan15/coding-adventures/pull/6730)), and XAML ([#6734](https://github.com/adhithyan15/coding-adventures/pull/6734)). The workbook holds several sheets; bare-`A1` ops address the **active** sheet, while a formula reaches **across** with a qualifier (`=Summary!B3`). The single-sheet path stays **byte-identical**.

## What changed

**Tracked C header**: synced `Sources/CSpreadsheetEngine/include/spreadsheet.h` to the canonical capi header (adds the `sc_sheet_names` / `sc_active_sheet` / `sc_set_active_sheet` / `sc_add_sheet` / `sc_rename_sheet` / `sc_delete_sheet` / `sc_move_sheet` declarations; signatures verified field-by-field against the Rust ABI).

**Engine binding** (`Engine.swift`, `SpreadsheetSession` over the module-map C ABI)
- 6 sheet ops; `sheetNames()` parses the engine JSON **defensively** (`guard let`); index mutators clamp through `UInt32(max(0, index))` so a negative can't trap on the conversion. Returned `char*` freed via `take`/`sc_string_free`.

**Model** (`WindowedSheetModel`): `sheetNames`/`activeSheet` + `selectSheet`/`addSheet`/`renameSheet`/`deleteSheet` passthrough, each resizing the extent, re-priming the formula bar, and bumping `revision`. The seed adds a second sheet, **Summary** (`B3 = A1+A2 = 300`), and `Sheet1!G1 = =Summary!B3` pulls it across.

**UI** (`InfiniteGridView`): an Excel-style **sheet tab bar** along the bottom — one chip per sheet (active tints to the accent); **tap** to switch, the active tab carries inline **✎ rename** (a SwiftUI `.alert` with a text field) and **✕ delete** buttons, **+ Sheet** adds one. Sheet names render through `Text` (auto-escaped).

## Proof
- A new **multi-sheet pair of tests** in `WindowedModelTests.swift`: cross-sheet `=Summary!B3` computes and stays live as its precedent changes (300 → 350), a rename rewrites the referencing qualifier (`Summary` → `Totals`), deleting a referenced sheet yields `#REF!` (and the last sheet can't be deleted), and the `WindowedSheetModel` seed exposes `Sheet1`/`Summary` with a live cross-ref.
- `swift test` green (**18 tests**). README updated.

## Security review
PASSED, no findings. C-string free contract correct (single `sc_string_free` via `take`), integer narrowing trap-safe, the `addSheet` collision loop is bounded, JSON parse is defensively guarded, the synced header matches the Rust ABI field-by-field, and the rename-alert's captured index is range-guarded by the engine. No memory-safety issues (the Rust C ABI is `#![forbid(unsafe_code)]`, null- and range-guarded).

This is the **final demo** of the multi-sheet rollout — engine (4 PRs) + facades + all 6 demos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)