### PR TITLE
Expose deck output-plan analysis source artifacts

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Added
 
+- **Deck output-plan analysis source artifacts** —
+  selected `run_deck_analysis()` output-plan artifacts now expose the selected
+  analysis line number and source name beside directive metadata in table, CSV,
+  compact JSON, and header-keyed record exports, matching Rust and TypeScript.
+
 - **Deck output-plan result row artifacts** —
   selected `run_deck_analysis()` output-plan artifacts now expose selected
   result row counts beside result-column inventories in table, CSV, compact

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -113,9 +113,10 @@ that produced the table, plus selected
 executions. Execution `table_artifacts` preserve the same order as `tables` and
 carry each stable table's text, CSV, compact JSON, and header-keyed records.
 Execution `output_plan_artifacts` summarize the selected result row count,
-result columns, output probes, selected output probe source lines, output directives,
-normalized output directive kinds, normalized directive analysis scopes,
-selected output directive source lines, and stable table names, and the
+result columns, selected analysis line/source metadata, output probes, selected
+output probe source lines, output directives, normalized output directive
+kinds, normalized directive analysis scopes, selected output directive source
+lines, and stable table names, and the
 `output-plan` entry in `table_artifacts` carries the same
 table, CSV, compact JSON, and header-keyed record exports.
 Selected `.tran` plans also return selected `.four` harmonic results and a stable

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -2385,6 +2385,8 @@ class DeckOutputPlanArtifact:
 
     analysis: str
     directive: str
+    line_number: int
+    source_name: str | None
     result_row_count: int
     result_column_count: int
     result_columns: list[str]
@@ -2913,6 +2915,8 @@ def _deck_output_plan_artifacts(
         DeckOutputPlanArtifact(
             analysis=plan.analysis,
             directive=plan.directive,
+            line_number=plan.line_number,
+            source_name=plan.source_name,
             result_row_count=result_row_count,
             result_column_count=len(result_columns),
             result_columns=list(result_columns),
@@ -2939,6 +2943,8 @@ def _deck_output_plan_artifacts(
 _DECK_OUTPUT_PLAN_ARTIFACT_COLUMNS = [
     "Analysis",
     "Directive",
+    "Line",
+    "SourceName",
     "ResultRows",
     "ResultColumns",
     "ResultColumnList",
@@ -2963,6 +2969,8 @@ def _deck_output_plan_artifact_cells(artifact: DeckOutputPlanArtifact) -> list[s
     return [
         artifact.analysis,
         artifact.directive,
+        str(artifact.line_number),
+        artifact.source_name or "",
         str(artifact.result_row_count),
         str(artifact.result_column_count),
         ";".join(artifact.result_columns),

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -6891,14 +6891,15 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
         op_execution.table
     )
     expected_output_plan_table = (
-        "Analysis\tDirective\tResultRows\tResultColumns\tResultColumnList\tOutputProbes\t"
+        "Analysis\tDirective\tLine\tSourceName\tResultRows\tResultColumns\t"
+        "ResultColumnList\tOutputProbes\t"
         "OutputProbeList\tOutputProbeLines\tOutputProbeLineList\t"
         "OutputDirectives\tOutputDirectiveList\t"
         "OutputDirectiveKinds\tOutputDirectiveKindList\t"
         "OutputDirectiveAnalysisKinds\tOutputDirectiveAnalysisKindList\t"
         "OutputDirectiveLines\tOutputDirectiveLineList\t"
         "Tables\tTableList\n"
-        "op\t.op\t1\t2\tIndex;V(mid)\t1\tV(mid)\t"
+        f"op\t.op\t{op_execution.plan.line_number}\t\t1\t2\tIndex;V(mid)\t1\tV(mid)\t"
         f"1\t{save_line}\t1\t.save\t1\tsave\t1\tglobal\t1\t{save_line}\t3\t"
         "result;output-plan;run-artifact\n"
     )
@@ -6906,6 +6907,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
         {
             "Analysis": "op",
             "Directive": ".op",
+            "Line": str(op_execution.plan.line_number),
+            "SourceName": "",
             "ResultRows": "1",
             "ResultColumns": "2",
             "ResultColumnList": "Index;V(mid)",
@@ -6930,6 +6933,8 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     output_plan_artifact = op_execution.output_plan_artifacts[0]
     assert output_plan_artifact.analysis == "op"
     assert output_plan_artifact.directive == ".op"
+    assert output_plan_artifact.line_number == op_execution.plan.line_number
+    assert output_plan_artifact.source_name is None
     assert output_plan_artifact.result_row_count == 1
     assert output_plan_artifact.result_columns == ["Index", "V(mid)"]
     assert output_plan_artifact.output_probes == ["V(mid)"]
@@ -6948,14 +6953,15 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
         format_deck_output_plan_artifact_table(op_execution.output_plan_artifacts)
     )
     assert op_execution.output_plan_artifact_csv == (
-        "Analysis,Directive,ResultRows,ResultColumns,ResultColumnList,OutputProbes,"
+        "Analysis,Directive,Line,SourceName,ResultRows,ResultColumns,"
+        "ResultColumnList,OutputProbes,"
         "OutputProbeList,OutputProbeLines,OutputProbeLineList,"
         "OutputDirectives,OutputDirectiveList,"
         "OutputDirectiveKinds,OutputDirectiveKindList,"
         "OutputDirectiveAnalysisKinds,OutputDirectiveAnalysisKindList,"
         "OutputDirectiveLines,OutputDirectiveLineList,"
         "Tables,TableList\n"
-        f"op,.op,1,2,Index;V(mid),1,V(mid),1,{save_line},1,.save,1,save,1,global,1,{save_line},3,"
+        f"op,.op,{op_execution.plan.line_number},,1,2,Index;V(mid),1,V(mid),1,{save_line},1,.save,1,save,1,global,1,{save_line},3,"
         "result;output-plan;run-artifact\n"
     )
     assert op_execution.output_plan_artifact_csv == (
@@ -7156,6 +7162,12 @@ def test_run_deck_analysis_routes_selected_plan_and_output_table() -> None:
     assert dc_execution.plan.source_name == "V1"
     assert dc_execution.output_probes == ["V(mid)", "I(V1)"]
     assert dc_execution.output_directives == [".save", ".probe", ".print"]
+    assert dc_execution.output_plan_artifacts[0].line_number == dc_execution.plan.line_number
+    assert dc_execution.output_plan_artifacts[0].source_name == "V1"
+    assert dc_execution.output_plan_artifact_records[0]["Line"] == str(
+        dc_execution.plan.line_number
+    )
+    assert dc_execution.output_plan_artifact_records[0]["SourceName"] == "V1"
     assert dc_execution.output_plan_artifacts[0].output_directive_kinds == [
         "save",
         "probe",

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Expose selected analysis line/source metadata in `run_deck_analysis`
+  output-plan artifacts beside directive metadata, with stable table, CSV,
+  compact JSON, and header-keyed record exports, matching Python and
+  TypeScript.
 - Expose selected result row counts in `run_deck_analysis` output-plan
   artifacts beside result-column inventories, with stable table, CSV, compact
   JSON, and header-keyed record exports, matching Python and TypeScript.

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -182,9 +182,10 @@ a stable measurement table for `.dc`, `.ac`, and `.tran` executions.
 Execution `table_artifacts` preserve the same order as `tables` and carry each
 stable table's text, CSV, compact JSON, and header-keyed records.
 Execution `output_plan_artifacts` summarize the selected result row count,
-result columns, output probes, selected output probe source lines, output directives,
-normalized output directive kinds, normalized directive analysis scopes,
-selected output directive source lines, and stable table names, and the
+result columns, selected analysis line/source metadata, output probes, selected
+output probe source lines, output directives, normalized output directive
+kinds, normalized directive analysis scopes, selected output directive source
+lines, and stable table names, and the
 `output-plan` entry in `table_artifacts` carries the same
 table, CSV, compact JSON, and header-keyed record exports.
 Selected `.tran` plans route

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -3466,6 +3466,8 @@ pub struct DeckTableArtifact {
 pub struct DeckOutputPlanArtifact {
     pub analysis: String,
     pub directive: String,
+    pub line_number: usize,
+    pub source_name: Option<String>,
     pub result_row_count: usize,
     pub result_column_count: usize,
     pub result_columns: Vec<String>,
@@ -10472,6 +10474,8 @@ fn deck_output_plan_artifacts(
     vec![DeckOutputPlanArtifact {
         analysis: plan.analysis.clone(),
         directive: plan.directive.clone(),
+        line_number: plan.line_number,
+        source_name: plan.source_name.clone(),
         result_row_count,
         result_column_count: result_columns.len(),
         result_columns: result_columns.to_vec(),
@@ -10518,6 +10522,8 @@ fn deck_output_directive_kinds(output_directives: &[String]) -> Vec<String> {
 const DECK_OUTPUT_PLAN_ARTIFACT_COLUMNS: &[&str] = &[
     "Analysis",
     "Directive",
+    "Line",
+    "SourceName",
     "ResultRows",
     "ResultColumns",
     "ResultColumnList",
@@ -10541,6 +10547,8 @@ fn deck_output_plan_artifact_cells(artifact: &DeckOutputPlanArtifact) -> Vec<Str
     vec![
         artifact.analysis.clone(),
         artifact.directive.clone(),
+        artifact.line_number.to_string(),
+        artifact.source_name.clone().unwrap_or_default(),
         artifact.result_row_count.to_string(),
         artifact.result_column_count.to_string(),
         artifact.result_columns.join(";"),

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -1991,6 +1991,11 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     let output_plan_artifact = &op_execution.output_plan_artifacts[0];
     assert_eq!(output_plan_artifact.analysis, "op");
     assert_eq!(output_plan_artifact.directive, ".op");
+    assert_eq!(
+        output_plan_artifact.line_number,
+        op_execution.plan.line_number
+    );
+    assert_eq!(output_plan_artifact.source_name, None);
     assert_eq!(output_plan_artifact.result_row_count, 1);
     assert_eq!(
         output_plan_artifact.result_columns,
@@ -2029,8 +2034,8 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         op_execution.output_plan_artifact_table,
         format!(
-            "Analysis\tDirective\tResultRows\tResultColumns\tResultColumnList\tOutputProbes\tOutputProbeList\tOutputProbeLines\tOutputProbeLineList\tOutputDirectives\tOutputDirectiveList\tOutputDirectiveKinds\tOutputDirectiveKindList\tOutputDirectiveAnalysisKinds\tOutputDirectiveAnalysisKindList\tOutputDirectiveLines\tOutputDirectiveLineList\tTables\tTableList\nop\t.op\t1\t2\tIndex;V(mid)\t1\tV(mid)\t1\t{}\t1\t.save\t1\tsave\t1\tglobal\t1\t{}\t3\tresult;output-plan;run-artifact\n",
-            save_line, save_line
+            "Analysis\tDirective\tLine\tSourceName\tResultRows\tResultColumns\tResultColumnList\tOutputProbes\tOutputProbeList\tOutputProbeLines\tOutputProbeLineList\tOutputDirectives\tOutputDirectiveList\tOutputDirectiveKinds\tOutputDirectiveKindList\tOutputDirectiveAnalysisKinds\tOutputDirectiveAnalysisKindList\tOutputDirectiveLines\tOutputDirectiveLineList\tTables\tTableList\nop\t.op\t{}\t\t1\t2\tIndex;V(mid)\t1\tV(mid)\t1\t{}\t1\t.save\t1\tsave\t1\tglobal\t1\t{}\t3\tresult;output-plan;run-artifact\n",
+            op_execution.plan.line_number, save_line, save_line
         )
     );
     assert_eq!(
@@ -2040,8 +2045,8 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         op_execution.output_plan_artifact_csv,
         format!(
-            "Analysis,Directive,ResultRows,ResultColumns,ResultColumnList,OutputProbes,OutputProbeList,OutputProbeLines,OutputProbeLineList,OutputDirectives,OutputDirectiveList,OutputDirectiveKinds,OutputDirectiveKindList,OutputDirectiveAnalysisKinds,OutputDirectiveAnalysisKindList,OutputDirectiveLines,OutputDirectiveLineList,Tables,TableList\nop,.op,1,2,Index;V(mid),1,V(mid),1,{},1,.save,1,save,1,global,1,{},3,result;output-plan;run-artifact\n",
-            save_line, save_line
+            "Analysis,Directive,Line,SourceName,ResultRows,ResultColumns,ResultColumnList,OutputProbes,OutputProbeList,OutputProbeLines,OutputProbeLineList,OutputDirectives,OutputDirectiveList,OutputDirectiveKinds,OutputDirectiveKindList,OutputDirectiveAnalysisKinds,OutputDirectiveAnalysisKindList,OutputDirectiveLines,OutputDirectiveLineList,Tables,TableList\nop,.op,{},,1,2,Index;V(mid),1,V(mid),1,{},1,.save,1,save,1,global,1,{},3,result;output-plan;run-artifact\n",
+            op_execution.plan.line_number, save_line, save_line
         )
     );
     assert_eq!(
@@ -2055,6 +2060,19 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
     assert_eq!(
         op_execution.output_plan_artifact_records,
         deck_output_plan_artifact_records(&op_execution.output_plan_artifacts)
+    );
+    let op_line = op_execution.plan.line_number.to_string();
+    assert_eq!(
+        op_execution.output_plan_artifact_records[0]
+            .get("Line")
+            .map(String::as_str),
+        Some(op_line.as_str())
+    );
+    assert_eq!(
+        op_execution.output_plan_artifact_records[0]
+            .get("SourceName")
+            .map(String::as_str),
+        Some("")
     );
     assert_eq!(
         op_execution.output_plan_artifact_records[0]
@@ -2294,6 +2312,27 @@ fn run_deck_analysis_routes_selected_plan_and_output_table() {
             ".probe".to_string(),
             ".print".to_string()
         ]
+    );
+    assert_eq!(
+        dc_execution.output_plan_artifacts[0].line_number,
+        dc_execution.plan.line_number
+    );
+    assert_eq!(
+        dc_execution.output_plan_artifacts[0].source_name.as_deref(),
+        Some("V1")
+    );
+    let dc_line = dc_execution.plan.line_number.to_string();
+    assert_eq!(
+        dc_execution.output_plan_artifact_records[0]
+            .get("Line")
+            .map(String::as_str),
+        Some(dc_line.as_str())
+    );
+    assert_eq!(
+        dc_execution.output_plan_artifact_records[0]
+            .get("SourceName")
+            .map(String::as_str),
+        Some("V1")
     );
     assert_eq!(
         dc_execution.output_plan_artifacts[0].output_directive_kinds,

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Expose selected analysis line/source metadata in `runDeckAnalysis`
+  output-plan artifacts beside directive metadata, with stable table, CSV,
+  compact JSON, and header-keyed record exports, matching Python and Rust.
 - Expose selected result row counts in `runDeckAnalysis` output-plan artifacts
   beside result-column inventories, with stable table, CSV, compact JSON, and
   header-keyed record exports, matching Python and Rust.

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -96,10 +96,11 @@ table count/name list, output probes, and output directives that produced the
 table, plus selected `.measure` results and
 a stable measurement table for `.dc`, `.ac`, and `.tran` executions.
 Execution `outputPlanArtifacts` summarize the selected result columns, output
-probes, selected output probe source lines, output directives, normalized
-output directive kinds, normalized directive analysis scopes, selected output
-directive source lines, selected result row counts, and stable table names with
-table, CSV, compact JSON, and header-keyed record exports.
+probes, selected analysis line/source metadata, selected output probe source
+lines, output directives, normalized output directive kinds, normalized
+directive analysis scopes, selected output directive source lines, selected
+result row counts, and stable table names with table, CSV, compact JSON, and
+header-keyed record exports.
 Execution `tableArtifacts` preserve the same order as `tables` and carry each
 stable table's text, CSV, compact JSON, and header-keyed records.
 The `output-plan` entry in `tableArtifacts` carries the same

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -719,6 +719,8 @@ export interface DeckTableArtifact {
 export interface DeckOutputPlanArtifact {
   readonly analysis: DeckAnalysisPlan["analysis"];
   readonly directive: DeckAnalysisPlan["directive"];
+  readonly lineNumber: number;
+  readonly sourceName?: string;
   readonly resultRowCount: number;
   readonly resultColumnCount: number;
   readonly resultColumns: readonly string[];
@@ -8409,6 +8411,8 @@ function deckOutputPlanArtifacts(
     {
       analysis: plan.analysis,
       directive: plan.directive,
+      lineNumber: plan.lineNumber,
+      sourceName: plan.sourceName,
       resultRowCount,
       resultColumnCount: resultColumns.length,
       resultColumns: [...resultColumns],
@@ -8452,6 +8456,8 @@ function deckOutputDirectiveKinds(outputDirectives: readonly string[]): string[]
 const DECK_OUTPUT_PLAN_ARTIFACT_COLUMNS = [
   "Analysis",
   "Directive",
+  "Line",
+  "SourceName",
   "ResultRows",
   "ResultColumns",
   "ResultColumnList",
@@ -8475,6 +8481,8 @@ function deckOutputPlanArtifactCells(artifact: DeckOutputPlanArtifact): string[]
   return [
     artifact.analysis,
     artifact.directive,
+    String(artifact.lineNumber),
+    artifact.sourceName ?? "",
     String(artifact.resultRowCount),
     String(artifact.resultColumnCount),
     artifact.resultColumns.join(";"),

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -1549,6 +1549,8 @@ describe("transient", () => {
       {
         Analysis: "op",
         Directive: ".op",
+        Line: String(opExecution.plan.lineNumber),
+        SourceName: "",
         ResultRows: "1",
         ResultColumns: "2",
         ResultColumnList: "Index;V(mid)",
@@ -1573,6 +1575,8 @@ describe("transient", () => {
     expect(opExecution.outputPlanArtifacts[0]).toMatchObject({
       analysis: "op",
       directive: ".op",
+      lineNumber: opExecution.plan.lineNumber,
+      sourceName: undefined,
       resultRowCount: 1,
       resultColumnCount: 2,
       resultColumns: ["Index", "V(mid)"],
@@ -1592,15 +1596,15 @@ describe("transient", () => {
       tables: ["result", "output-plan", "run-artifact"],
     });
     expect(opExecution.outputPlanArtifactTable).toBe(
-      "Analysis\tDirective\tResultRows\tResultColumns\tResultColumnList\tOutputProbes\tOutputProbeList\tOutputProbeLines\tOutputProbeLineList\tOutputDirectives\tOutputDirectiveList\tOutputDirectiveKinds\tOutputDirectiveKindList\tOutputDirectiveAnalysisKinds\tOutputDirectiveAnalysisKindList\tOutputDirectiveLines\tOutputDirectiveLineList\tTables\tTableList\n" +
-        `op\t.op\t1\t2\tIndex;V(mid)\t1\tV(mid)\t1\t${saveLine}\t1\t.save\t1\tsave\t1\tglobal\t1\t${saveLine}\t3\tresult;output-plan;run-artifact\n`,
+      "Analysis\tDirective\tLine\tSourceName\tResultRows\tResultColumns\tResultColumnList\tOutputProbes\tOutputProbeList\tOutputProbeLines\tOutputProbeLineList\tOutputDirectives\tOutputDirectiveList\tOutputDirectiveKinds\tOutputDirectiveKindList\tOutputDirectiveAnalysisKinds\tOutputDirectiveAnalysisKindList\tOutputDirectiveLines\tOutputDirectiveLineList\tTables\tTableList\n" +
+        `op\t.op\t${opExecution.plan.lineNumber}\t\t1\t2\tIndex;V(mid)\t1\tV(mid)\t1\t${saveLine}\t1\t.save\t1\tsave\t1\tglobal\t1\t${saveLine}\t3\tresult;output-plan;run-artifact\n`,
     );
     expect(opExecution.outputPlanArtifactTable).toBe(
       formatDeckOutputPlanArtifactTable(opExecution.outputPlanArtifacts),
     );
     expect(opExecution.outputPlanArtifactCsv).toBe(
-      "Analysis,Directive,ResultRows,ResultColumns,ResultColumnList,OutputProbes,OutputProbeList,OutputProbeLines,OutputProbeLineList,OutputDirectives,OutputDirectiveList,OutputDirectiveKinds,OutputDirectiveKindList,OutputDirectiveAnalysisKinds,OutputDirectiveAnalysisKindList,OutputDirectiveLines,OutputDirectiveLineList,Tables,TableList\n" +
-        `op,.op,1,2,Index;V(mid),1,V(mid),1,${saveLine},1,.save,1,save,1,global,1,${saveLine},3,result;output-plan;run-artifact\n`,
+      "Analysis,Directive,Line,SourceName,ResultRows,ResultColumns,ResultColumnList,OutputProbes,OutputProbeList,OutputProbeLines,OutputProbeLineList,OutputDirectives,OutputDirectiveList,OutputDirectiveKinds,OutputDirectiveKindList,OutputDirectiveAnalysisKinds,OutputDirectiveAnalysisKindList,OutputDirectiveLines,OutputDirectiveLineList,Tables,TableList\n" +
+        `op,.op,${opExecution.plan.lineNumber},,1,2,Index;V(mid),1,V(mid),1,${saveLine},1,.save,1,save,1,global,1,${saveLine},3,result;output-plan;run-artifact\n`,
     );
     expect(opExecution.outputPlanArtifactCsv).toBe(
       formatDeckOutputPlanArtifactCsv(opExecution.outputPlanArtifacts),
@@ -1800,6 +1804,12 @@ describe("transient", () => {
     expect(dcExecution.plan.sourceName).toBe("V1");
     expect(dcExecution.outputProbes).toEqual(["V(mid)", "I(V1)"]);
     expect(dcExecution.outputDirectives).toEqual([".save", ".probe", ".print"]);
+    expect(dcExecution.outputPlanArtifacts[0]?.lineNumber).toBe(dcExecution.plan.lineNumber);
+    expect(dcExecution.outputPlanArtifacts[0]?.sourceName).toBe("V1");
+    expect(dcExecution.outputPlanArtifactRecords[0]?.Line).toBe(
+      String(dcExecution.plan.lineNumber),
+    );
+    expect(dcExecution.outputPlanArtifactRecords[0]?.SourceName).toBe("V1");
     expect(dcExecution.outputPlanArtifacts[0]?.outputDirectiveKinds).toEqual([
       "save",
       "probe",

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -145,7 +145,9 @@ downstream tools to compare.
      selected output-plan artifacts now also expose selected output probe
      source line counts/lists aligned with the selected output-probe list, and
      selected output-plan artifacts now also expose selected result row counts
-     beside result-column inventories.
+     beside result-column inventories, and selected output-plan artifacts now
+     also expose selected analysis line/source metadata beside directive
+     inventories.
    - Expand remaining deck-controlled analyses toward full SPICE compatibility
      while keeping unsupported control-flow diagnostics explicit.
 
@@ -1210,6 +1212,15 @@ downstream tools to compare.
     - Table, CSV, compact JSON, and host-native record exports make the shape
       of the selected result table auditable from the output-plan artifact
       without reparsing the result table itself.
+
+111. Deck output-plan analysis source artifacts.
+    - Status: completed in this deck output-plan analysis source artifact
+      slice.
+    - Python, Rust, and TypeScript selected output-plan artifacts now expose
+      selected analysis line/source metadata beside directive inventories.
+    - Table, CSV, compact JSON, and host-native record exports make the
+      selected plan's analysis line and source name auditable from the
+      output-plan artifact without reparsing the analysis plan.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- add selected analysis line/source metadata to Python, Rust, and TypeScript deck output-plan artifacts
- include Line and SourceName in output-plan table, CSV, JSON, and record exports
- update cross-language tests, package docs/changelogs, and the SPICE implementation plan

## Tests
- PYTHONPATH=code/packages/python/spice-engine/src:code/packages/python/mosfet-models/src:code/packages/python/device-physics/src /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python -m pytest code/packages/python/spice-engine/tests/test_compatibility.py code/packages/python/spice-engine/tests/test_engine.py -q
- cargo test -p spice-engine
- npm ci && npm run build && npm test
- git diff --check