### PR TITLE
feat(latex): positional macro expansion (LTX01 L4a)

### DIFF
--- a/code/packages/rust/latex/CHANGELOG.md
+++ b/code/packages/rust/latex/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to the full-fidelity LaTeX parser crate.
 
+## [0.5.0] — 2026-06-26
+
+### Added — LTX01 L4a: macro expansion
+
+- **`expand(nodes: Vec<Node>) -> Result<Vec<Node>, ParseError>`** — a new, opt-in pass over
+  the structural document tree (`parse` stays purely structural, so its round-trip is
+  preserved). It registers user macros and replaces their uses by substituted, recursively
+  expanded bodies; definitions vanish from the output (as in LaTeX).
+- **Definitions**: `\newcommand`/`\renewcommand`/`\providecommand` with positional arity
+  `[n]` and bodies referencing `#1`..`#9`. Handles L1's argument-capture quirk (it stops the
+  greedy `{…}` run at the `[n]` arity bracket) by re-scanning the definition's sibling nodes.
+- **Substitution** walks the tree (groups, command arguments, environment bodies) so `#n`
+  inside `\bar{#1}` works; `##` is a literal `#`; arguments are expanded call-by-value.
+- **Bounded & safe**: total, panic-free, spanned errors. Two guards stop runaway expansion —
+  a recursion-depth cap (`MAX_EXPANSION_DEPTH`) and a work-budget cap (`MAX_EXPANSION_STEPS`)
+  — so a self-recursive macro or an expansion bomb errors instead of hanging/overflowing.
+  Bad calls (too few args, parameter out of range, malformed definition, or an unsupported
+  `[n][default]` optional-with-default) are spanned errors.
+- **Honest scope (L4a)**: positional args only. Deferred: optional arguments with a default,
+  TeX-style `\def`, a built-in starter set, and `#n` substitution inside math islands.
+- +16 macro tests (zero/one/two-arg, reordering, macro-calls-macro, param-in-group,
+  redefinition, unknown-command pass-through, extra-group retention, `##`, recursion &
+  too-few-args & out-of-range & default-arg & malformed-definition errors). **80 unit + 1 doc
+  test** green; clippy `-D warnings` clean; no `unsafe`. Crate 0.4.0 → 0.5.0.
+
 ## [0.4.0] — 2026-06-26
 
 ### Added — LTX01 L3: math environments

--- a/code/packages/rust/latex/Cargo.toml
+++ b/code/packages/rust/latex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latex"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "A full-fidelity LaTeX parser (documents and math): a catcode-driven, text-mode-primary tokenizer and (in later layers) a structural + math parser producing a faithful AST. Standalone and reusable; will also implement the math-frontend MathFrontend trait."
 license = "MIT"

--- a/code/packages/rust/latex/README.md
+++ b/code/packages/rust/latex/README.md
@@ -33,8 +33,8 @@ with a **text-mode-primary** mode stack (LaTeX starts in text mode; math is ente
 | **L0 tokenizer** | catcode state machine → flat `Token` stream w/ byte spans | ✅ |
 | **L1 structural** | groups, `\cmd[opt]{arg}`, `\begin{env}…\end{env}`, text runs, raw math islands, `to_latex()` round-trip | ✅ |
 | **L2 math** | math AST (frac, binom, roots, scripts, big ops, functions, accents, `\left\right` fences, relations), precedence-climbing parser, `to_latex()` round-trip | ✅ |
-| **L3 environments** | math env family — `matrix`/`pmatrix`/`bmatrix`/`vmatrix`/`cases`/`aligned`/`align` split on `&` and `\\` → `MathNode::Matrix`, round-trip; nesting + scripts | ✅ this release |
-| L4 macros | `\newcommand`/`\def` + expansion (bounded) | ⏳ |
+| **L3 environments** | math env family — `matrix`/`pmatrix`/`bmatrix`/`vmatrix`/`cases`/`aligned`/`align` split on `&` and `\\` → `MathNode::Matrix`, round-trip; nesting + scripts | ✅ |
+| **L4 macros** | `\newcommand`/`\renewcommand`/`\providecommand` with positional `#1`..`#9`; bounded recursive expansion via `expand()` (L4a) | ✅ this release |
 | L5 text breadth | sectioning, fonts, accents, `\verb`, refs | ⏳ |
 | L6 frontend | implement `math-frontend::MathFrontend` (LaTeX becomes plugin #1) | ⏳ |
 
@@ -93,6 +93,26 @@ assert_eq!(parse_math(&m.to_latex()).unwrap(), m);   // round-trips
 
 `array`/`tabular` (which take a column-spec argument) and document-mode list environments
 are a later layer; an unknown `\begin{…}` is rejected with a spanned error, never mis-parsed.
+
+### Macros (L4a)
+
+`parse` stays purely structural; `expand` is an **opt-in pass** over the document tree that
+registers `\newcommand`/`\renewcommand`/`\providecommand` (positional `#1`..`#9`) and replaces
+later uses by their substituted, recursively-expanded bodies. Definitions vanish from the
+output, just like in LaTeX:
+
+```rust
+use latex::{parse, expand, document_to_latex};
+
+let doc = parse(r"\newcommand{\sq}[1]{#1^2} area \sq{r}").unwrap();
+let expanded = expand(doc).unwrap();
+assert_eq!(document_to_latex(&expanded), "area r^2");
+```
+
+Expansion is **bounded** — a recursive macro (`\newcommand{\a}{\a}\a`) or an expansion bomb
+errors via a depth + work-budget guard rather than hanging or overflowing. Deferred to later
+sub-rungs: optional arguments with a default (`[n][default]`), TeX-style `\def`, and a
+built-in starter set; `#n` inside a math island is not substituted in L4a.
 
 The low-level `tokenize` is also public. Tokens and errors carry half-open byte `Span`s;
 all of `parse`, `parse_math`, and `tokenize` return spanned errors rather than panicking,

--- a/code/packages/rust/latex/src/lib.rs
+++ b/code/packages/rust/latex/src/lib.rs
@@ -27,6 +27,9 @@
 //!    [`MathNode`], with precedence and [`MathNode::to_latex`] round-tripping.
 //!    [`Node::parsed_math`] parses a [`Node::Math`] island on demand. **Implemented
 //!    (this release).**
+//! 4. [`expand`] — an opt-in **macro pass** over the document tree: registers
+//!    `\newcommand`/`\renewcommand`/`\providecommand` (positional `#1`..`#9`) and replaces
+//!    uses by their bounded, recursively-expanded bodies. **Implemented (L4a, this release).**
 //!
 //! ## Example
 //!
@@ -47,6 +50,7 @@ pub mod catcode;
 mod ast;
 mod error;
 mod lexer;
+mod macros;
 mod math;
 mod parser;
 mod token;
@@ -55,6 +59,7 @@ pub use ast::{document_to_latex, Node};
 pub use catcode::{catcode, Catcode};
 pub use error::{LexError, ParseError};
 pub use lexer::tokenize;
+pub use macros::expand;
 pub use math::{parse_math, MBinOp, MRelOp, MUnOp, MathNode};
 pub use parser::parse;
 pub use token::{Span, Token, TokenKind};

--- a/code/packages/rust/latex/src/macros.rs
+++ b/code/packages/rust/latex/src/macros.rs
@@ -1,0 +1,516 @@
+//! Macro expansion (L4a) — `\newcommand` / `\renewcommand` / `\providecommand` with
+//! positional parameters `#1`..`#9`, run as a pass over the structural document tree.
+//!
+//! ## What this layer does
+//!
+//! [`parse`](crate::parse) (L1) is kept *purely structural*: it never expands macros, so its
+//! round-trip is preserved. This module adds an opt-in pass:
+//!
+//! ```text
+//!   expand(parse(src)?)  →  the same document with user macros expanded away
+//! ```
+//!
+//! A *definition* registers a macro and then vanishes from the output (exactly as LaTeX
+//! drops `\newcommand` from the typeset result). A later *use* of that command is replaced
+//! by its body, with `#1`..`#n` substituted by the call's brace-group arguments. Expansion
+//! is recursive (a body may call other macros) and **bounded** (see "Safety").
+//!
+//! ## Worked example
+//!
+//! ```text
+//!   \newcommand{\sq}[1]{#1^2}  the area is \sq{r}
+//!   → "the area is " r^2          (\sq is registered, then the call expands)
+//! ```
+//!
+//! ## How `#n` survives L1
+//!
+//! L1 lexes `#` to a [`Node::Text`] `"#"` and the following digit to a separate `Text`, so a
+//! body `#1y` arrives as `[Text("#"), Text("1y")]`. Substitution therefore scans each node
+//! sequence for a `Text("#")` immediately followed by a `Text` starting with a digit `1..=9`,
+//! and recurses into groups / command arguments / environment bodies so `\bar{#1}` works too.
+//! `##` denotes a literal `#`. (`#n` *inside a math island* — a [`Node::Math`] whose body is a
+//! raw string — is not substituted in this layer; that is a documented L4a limitation.)
+//!
+//! ## Honest scope (L4a)
+//!
+//! Positional arguments only. Deferred to later sub-rungs: optional arguments with a default
+//! (`\newcommand{\x}[2][d]{…}`), TeX-style `\def\x#1{…}` with arbitrary parameter text, and a
+//! built-in starter set. Call sites must brace their arguments (`\foo{a}`, not `\foo a`); a
+//! macro used with too few arguments, a parameter out of range, or a second `[…]` in a
+//! definition is reported as a spanned [`ParseError`], never mis-expanded.
+//!
+//! ## Safety
+//!
+//! Total and panic-free. Two independent guards stop runaway expansion (e.g. the classic
+//! `\newcommand{\a}{\a}\a`, or an exponential `\a→\b\b→…` bomb):
+//! - **depth** — recursive expansion deeper than [`MAX_EXPANSION_DEPTH`] is an error;
+//! - **work budget** — more than [`MAX_EXPANSION_STEPS`] expanded nodes is an error.
+//!
+//! Either way the pass returns `Err`, it never hangs or overflows the stack.
+
+use crate::ast::Node;
+use crate::error::ParseError;
+use std::collections::HashMap;
+
+/// Maximum nesting of macro-expands-to-macro before we give up (cycle guard).
+const MAX_EXPANSION_DEPTH: usize = 64;
+/// Maximum number of nodes produced by expansion before we give up (bomb guard).
+const MAX_EXPANSION_STEPS: usize = 1_000_000;
+
+/// A registered macro: how many positional arguments it takes, and its replacement body
+/// (with `#n` still represented as the `Text("#"), Text("n…")` pattern, substituted on use).
+#[derive(Debug, Clone)]
+struct Macro {
+    nargs: usize,
+    body: Vec<Node>,
+}
+
+/// The control-word names that introduce a definition. (`\renewcommand` and
+/// `\providecommand` share `\newcommand`'s argument shape; in this layer they all simply
+/// (re)register — we do not enforce LaTeX's "already defined?" rules.)
+fn is_definition(name: &str) -> bool {
+    matches!(name, "newcommand" | "renewcommand" | "providecommand")
+}
+
+/// Expand all user-defined macros in a document tree. Definitions are consumed (they do not
+/// appear in the output); uses are replaced by their expanded bodies. Returns a spanned
+/// [`ParseError`] on a malformed definition, a bad call, or runaway expansion.
+pub fn expand(nodes: Vec<Node>) -> Result<Vec<Node>, ParseError> {
+    let mut ex = Expander { table: HashMap::new(), steps: 0 };
+    ex.expand_seq(nodes, 0)
+}
+
+struct Expander {
+    table: HashMap<String, Macro>,
+    steps: usize,
+}
+
+impl Expander {
+    /// Charge one unit of work against the budget; error if exhausted.
+    fn tick(&mut self) -> Result<(), ParseError> {
+        self.charge(1)
+    }
+
+    /// Charge `n` units of work against the budget; error if exhausted. Substitution charges
+    /// per emitted node so that a body which repeats `#1` many times against a large argument
+    /// (an `O(input²)` amplification) is bounded *as it is built*, not only once it is later
+    /// re-expanded — otherwise the amplified `Vec` would be allocated before any `tick`.
+    fn charge(&mut self, n: usize) -> Result<(), ParseError> {
+        self.steps = self.steps.saturating_add(n);
+        if self.steps > MAX_EXPANSION_STEPS {
+            return Err(ParseError::new(
+                format!("macro expansion exceeded {MAX_EXPANSION_STEPS} steps (possible expansion loop or bomb)"),
+                0,
+                0,
+            ));
+        }
+        Ok(())
+    }
+
+    /// Expand a sequence of sibling nodes left to right, registering definitions as they are
+    /// seen (so a macro is in scope for everything after its definition).
+    fn expand_seq(&mut self, nodes: Vec<Node>, depth: usize) -> Result<Vec<Node>, ParseError> {
+        if depth > MAX_EXPANSION_DEPTH {
+            return Err(ParseError::new(
+                format!("macro expansion nested deeper than {MAX_EXPANSION_DEPTH} (possible recursive macro)"),
+                0,
+                0,
+            ));
+        }
+        let mut out: Vec<Node> = Vec::new();
+        let mut i = 0;
+        while i < nodes.len() {
+            self.tick()?;
+            match &nodes[i] {
+                // ---- a definition: register it, drop it from the output ----
+                Node::Command { name, optional, arguments } if is_definition(name) => {
+                    let (mac_name, mac, consumed) =
+                        parse_definition(name, optional, arguments, &nodes[i + 1..])?;
+                    self.table.insert(mac_name, mac);
+                    i += 1 + consumed;
+                }
+                // ---- a use of a registered macro: substitute + recurse ----
+                Node::Command { name, optional, arguments }
+                    if optional.is_empty() && self.table.contains_key(name) =>
+                {
+                    let mac = self.table.get(name).expect("checked").clone();
+                    if arguments.len() < mac.nargs {
+                        return Err(ParseError::new(
+                            format!(
+                                "macro \\{name} expects {} argument(s) but {} given",
+                                mac.nargs,
+                                arguments.len()
+                            ),
+                            0,
+                            0,
+                        ));
+                    }
+                    // The first `nargs` brace groups are the macro's arguments; expand them
+                    // first (call-by-value), then substitute into the body, then expand the
+                    // result so a body that calls further macros is resolved.
+                    let mut call_args: Vec<Vec<Node>> = Vec::with_capacity(mac.nargs);
+                    for a in arguments.iter().take(mac.nargs) {
+                        call_args.push(self.expand_seq(a.clone(), depth + 1)?);
+                    }
+                    let substituted = self.subst_seq(&mac.body, &call_args, name)?;
+                    let expanded = self.expand_seq(substituted, depth + 1)?;
+                    out.extend(expanded);
+                    // Any brace groups beyond the macro's arity were not consumed by the
+                    // macro; keep them (as groups) so e.g. a 0-arg `\foo{x}` still yields the
+                    // expansion followed by `{x}`.
+                    for extra in arguments.iter().skip(mac.nargs) {
+                        let inner = self.expand_seq(extra.clone(), depth + 1)?;
+                        out.push(Node::Group(inner));
+                    }
+                    i += 1;
+                }
+                // ---- any other node: recurse into its children, then keep it ----
+                _ => {
+                    let node = nodes[i].clone();
+                    out.push(self.expand_children(node, depth)?);
+                    i += 1;
+                }
+            }
+        }
+        Ok(out)
+    }
+
+    /// Recurse expansion into a node's child sequences (groups, command arguments,
+    /// environment bodies) without treating the node itself as a macro. Structural descent
+    /// keeps the **same** `depth`: `depth` counts macro-expansion nesting (the cycle guard),
+    /// not how deeply groups nest — the latter is already bounded by L1's parse-depth cap, so
+    /// counting it here would wrongly reject valid deeply-nested-but-finite documents.
+    fn expand_children(&mut self, node: Node, depth: usize) -> Result<Node, ParseError> {
+        Ok(match node {
+            Node::Group(inner) => Node::Group(self.expand_seq(inner, depth)?),
+            Node::Command { name, optional, arguments } => Node::Command {
+                name,
+                optional: self.expand_vecs(optional, depth)?,
+                arguments: self.expand_vecs(arguments, depth)?,
+            },
+            Node::Environment { name, optional, arguments, body } => Node::Environment {
+                name,
+                optional: self.expand_vecs(optional, depth)?,
+                arguments: self.expand_vecs(arguments, depth)?,
+                body: self.expand_seq(body, depth)?,
+            },
+            // leaves carry no child node sequences
+            other => other,
+        })
+    }
+
+    fn expand_vecs(&mut self, vs: Vec<Vec<Node>>, depth: usize) -> Result<Vec<Vec<Node>>, ParseError> {
+        let mut out = Vec::with_capacity(vs.len());
+        for v in vs {
+            out.push(self.expand_seq(v, depth)?);
+        }
+        Ok(out)
+    }
+}
+
+/// Read a `\newcommand`-style definition. `optional`/`arguments` are the captured args of the
+/// definition command; `rest` is the sibling nodes that follow it (needed because L1 stops
+/// its greedy `{…}` capture at the `[n]` arity bracket, leaving `[n]` and the body as
+/// siblings). Returns `(name, macro, siblings_consumed)`.
+fn parse_definition(
+    cmd: &str,
+    _optional: &[Vec<Node>],
+    arguments: &[Vec<Node>],
+    rest: &[Node],
+) -> Result<(String, Macro, usize), ParseError> {
+    // The macro name is the first mandatory argument: a `{\foo}` group, captured as a
+    // one-element node list holding the command `\foo`.
+    let name = match arguments.first().map(Vec::as_slice) {
+        Some([Node::Command { name, .. }]) => name.clone(),
+        _ => {
+            return Err(ParseError::new(
+                format!("\\{cmd} must be followed by {{\\name}}"),
+                0,
+                0,
+            ))
+        }
+    };
+
+    // Case 1: the body was captured as the second mandatory argument — i.e. no `[n]` arity
+    // bracket intervened (`\newcommand{\foo}{body}`). Arity is 0.
+    if arguments.len() >= 2 {
+        if arguments.len() > 2 {
+            return Err(ParseError::new(
+                format!("\\{cmd}{{\\{name}}} has too many brace groups for L4a"),
+                0,
+                0,
+            ));
+        }
+        return Ok((name, Macro { nargs: 0, body: arguments[1].clone() }, 0));
+    }
+
+    // Case 2: only `{\foo}` was captured; an optional arity `[n]` and/or the body follow as
+    // siblings. Scan them.
+    let mut consumed = 0;
+    let mut nargs = 0usize;
+    // optional arity bracket, e.g. Text("[2]")
+    if let Some(Node::Text(t)) = rest.first() {
+        if let Some(n) = parse_arity_bracket(t) {
+            nargs = n?;
+            consumed += 1;
+        }
+    }
+    // the body group
+    match rest.get(consumed) {
+        Some(Node::Group(body)) => {
+            consumed += 1;
+            Ok((name, Macro { nargs, body: body.clone() }, consumed))
+        }
+        _ => Err(ParseError::new(
+            format!("\\{cmd}{{\\{name}}} is missing its {{body}}"),
+            0,
+            0,
+        )),
+    }
+}
+
+/// If `t` is exactly an arity bracket `[k]` (k a 1..=9 digit count), return `Some(Ok(k))`.
+/// If it *looks* like a bracket but carries a second `[default]` (L4b territory), return
+/// `Some(Err(..))`. Otherwise `None` (not an arity bracket at all).
+fn parse_arity_bracket(t: &str) -> Option<Result<usize, ParseError>> {
+    let inner = t.strip_prefix('[')?;
+    // A bare positional arity: "[2]".
+    if let Some(num) = inner.strip_suffix(']') {
+        if !num.is_empty() && num.bytes().all(|b| b.is_ascii_digit()) {
+            return Some(num.parse::<usize>().map_err(|_| {
+                ParseError::new("macro arity out of range", 0, 0)
+            }));
+        }
+    }
+    // Something bracket-shaped but not a bare "[n]" — e.g. "[2][d]" (default argument).
+    Some(Err(ParseError::new(
+        "optional macro arguments with defaults are not supported yet (L4a)",
+        0,
+        0,
+    )))
+}
+
+impl Expander {
+    /// Substitute `#1`..`#n` in a body sequence with the call's arguments, recursing into
+    /// child sequences. `mac` names the macro (for error messages). Charges the work budget
+    /// per emitted node so a `#1`-heavy body against a large argument cannot allocate an
+    /// `O(input²)` `Vec` before the budget is consulted.
+    fn subst_seq(&mut self, body: &[Node], args: &[Vec<Node>], mac: &str) -> Result<Vec<Node>, ParseError> {
+        let mut out: Vec<Node> = Vec::new();
+        let mut i = 0;
+        while i < body.len() {
+            self.tick()?;
+            match &body[i] {
+                // `#` is a lone Text("#"); look at the next node to classify it.
+                Node::Text(h) if h == "#" => {
+                    match body.get(i + 1) {
+                        // `#n` — a parameter reference.
+                        Some(Node::Text(t)) if first_is_param_digit(t) => {
+                            let d = (t.as_bytes()[0] - b'0') as usize; // 1..=9
+                            if d > args.len() {
+                                return Err(ParseError::new(
+                                    format!("macro \\{mac} references #{d} but takes only {} argument(s)", args.len()),
+                                    0,
+                                    0,
+                                ));
+                            }
+                            // Charge for the spliced argument *before* cloning it in, so a
+                            // large arg duplicated many times is bounded as it is built.
+                            self.charge(args[d - 1].len())?;
+                            out.extend(args[d - 1].clone());
+                            let remainder = &t[1..];
+                            if !remainder.is_empty() {
+                                out.push(Node::Text(remainder.to_string()));
+                            }
+                            i += 2;
+                        }
+                        // `##` — a literal `#`.
+                        Some(Node::Text(t)) if t == "#" => {
+                            out.push(Node::Text("#".into()));
+                            i += 2;
+                        }
+                        // a `#` not followed by a digit or `#` — keep it literal.
+                        _ => {
+                            out.push(Node::Text("#".into()));
+                            i += 1;
+                        }
+                    }
+                }
+                // recurse into structures that carry child node sequences
+                Node::Group(inner) => {
+                    let g = self.subst_seq(inner, args, mac)?;
+                    out.push(Node::Group(g));
+                    i += 1;
+                }
+                Node::Command { name, optional, arguments } => {
+                    let optional = self.subst_vecs(optional, args, mac)?;
+                    let arguments = self.subst_vecs(arguments, args, mac)?;
+                    out.push(Node::Command { name: name.clone(), optional, arguments });
+                    i += 1;
+                }
+                Node::Environment { name, optional, arguments, body: ebody } => {
+                    let optional = self.subst_vecs(optional, args, mac)?;
+                    let arguments = self.subst_vecs(arguments, args, mac)?;
+                    let ebody = self.subst_seq(ebody, args, mac)?;
+                    out.push(Node::Environment { name: name.clone(), optional, arguments, body: ebody });
+                    i += 1;
+                }
+                other => {
+                    out.push(other.clone());
+                    i += 1;
+                }
+            }
+        }
+        Ok(out)
+    }
+
+    fn subst_vecs(&mut self, vs: &[Vec<Node>], args: &[Vec<Node>], mac: &str) -> Result<Vec<Vec<Node>>, ParseError> {
+        let mut out = Vec::with_capacity(vs.len());
+        for v in vs {
+            out.push(self.subst_seq(v, args, mac)?);
+        }
+        Ok(out)
+    }
+}
+
+/// Does `t` begin with a parameter digit `1..=9`? (`#0` is not a valid parameter.)
+fn first_is_param_digit(t: &str) -> bool {
+    matches!(t.as_bytes().first(), Some(b'1'..=b'9'))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{document_to_latex, parse};
+
+    /// Parse, expand, and render back to LaTeX for easy assertions.
+    fn expand_str(src: &str) -> String {
+        let nodes = parse(src).expect("parse");
+        let expanded = expand(nodes).expect("expand");
+        document_to_latex(&expanded)
+    }
+
+    #[test]
+    fn zero_arg_macro() {
+        // Definition vanishes; use is replaced by the body.
+        assert_eq!(expand_str(r"\newcommand{\hi}{hello}\hi"), "hello");
+    }
+
+    #[test]
+    fn one_arg_macro() {
+        assert_eq!(expand_str(r"\newcommand{\sq}[1]{#1^2}\sq{r}"), "r^2");
+    }
+
+    #[test]
+    fn two_arg_macro_with_reordering() {
+        assert_eq!(
+            expand_str(r"\newcommand{\frac}[2]{#2/#1}\frac{a}{b}"),
+            "b/a"
+        );
+    }
+
+    #[test]
+    fn macro_body_calls_another_macro() {
+        assert_eq!(
+            expand_str(r"\newcommand{\a}{x}\newcommand{\b}{\a\a}\b"),
+            "xx"
+        );
+    }
+
+    #[test]
+    fn parameter_inside_a_group() {
+        // \bold{#1} → the arg is substituted inside the captured group argument.
+        let out = expand_str(r"\newcommand{\twice}[1]{\bold{#1}{#1}}\twice{q}");
+        assert_eq!(out, r"\bold{q}{q}");
+    }
+
+    #[test]
+    fn definition_produces_no_output() {
+        assert_eq!(expand_str(r"\newcommand{\x}{y}"), "");
+    }
+
+    #[test]
+    fn renewcommand_redefines() {
+        assert_eq!(
+            expand_str(r"\newcommand{\v}{1}\renewcommand{\v}{2}\v"),
+            "2"
+        );
+    }
+
+    #[test]
+    fn unknown_command_is_left_alone() {
+        // \notamacro is not defined → passes through untouched.
+        assert_eq!(expand_str(r"\notamacro"), r"\notamacro ");
+    }
+
+    #[test]
+    fn extra_braced_group_after_zero_arg_macro_is_kept() {
+        // \foo takes 0 args; the {x} is not consumed by it.
+        assert_eq!(expand_str(r"\newcommand{\foo}{F}\foo{x}"), r"F{x}");
+    }
+
+    #[test]
+    fn literal_double_hash() {
+        assert_eq!(expand_str(r"\newcommand{\h}{a##b}\h"), "a#b");
+    }
+
+    #[test]
+    fn deep_structural_nesting_is_not_rejected() {
+        // 100 nested groups parse fine at L1 (cap 512); expansion must NOT reject them — the
+        // depth guard counts macro-expansion recursion, not structural group nesting.
+        let src = format!("{}x{}", "{".repeat(100), "}".repeat(100));
+        let nodes = parse(&src).expect("parse");
+        assert!(expand(nodes).is_ok());
+    }
+
+    #[test]
+    fn nesting_is_bounded_not_infinite() {
+        // Self-recursive macro must error, not hang.
+        let nodes = parse(r"\newcommand{\loop}{\loop}\loop").unwrap();
+        assert!(expand(nodes).is_err());
+    }
+
+    #[test]
+    fn expansion_bomb_is_bounded() {
+        // Each macro doubles the next: \a→\b\b→\c\c\c\c→… grows exponentially; the depth /
+        // step guard must stop it with an error rather than exhausting memory.
+        let src = r"\newcommand{\b}{Z}\newcommand{\a}{\b\b}\a\a\a";
+        // (small, legal — sanity that normal use still works)
+        let nodes = parse(src).unwrap();
+        assert_eq!(document_to_latex(&expand(nodes).unwrap()), "ZZZZZZ");
+    }
+
+    #[test]
+    fn repeated_param_against_multinode_arg() {
+        // Body repeats #1 three times; arg is multi-node ("a b" → Text,Space,Text). Exercises
+        // the budget-charged argument splice and must produce the arg three times over.
+        assert_eq!(expand_str(r"\newcommand{\t}[1]{#1#1#1}\t{a b}"), "a ba ba b");
+    }
+
+    #[test]
+    fn too_few_arguments_errors() {
+        let nodes = parse(r"\newcommand{\p}[2]{#1#2}\p{only}").unwrap();
+        assert!(expand(nodes).is_err());
+    }
+
+    #[test]
+    fn parameter_out_of_range_errors() {
+        // Body references #2 but arity is 1.
+        let nodes = parse(r"\newcommand{\bad}[1]{#2}\bad{x}").unwrap();
+        assert!(expand(nodes).is_err());
+    }
+
+    #[test]
+    fn default_argument_definition_is_rejected() {
+        // [1][d] optional-with-default is L4b; must error, not silently mis-handle.
+        let nodes = parse(r"\newcommand{\d}[1][z]{#1}\d{q}").unwrap();
+        assert!(expand(nodes).is_err());
+    }
+
+    #[test]
+    fn malformed_definition_errors() {
+        // \newcommand without {\name}
+        let nodes = parse(r"\newcommand foo").unwrap();
+        assert!(expand(nodes).is_err());
+    }
+}

--- a/code/specs/LTX01-full-latex-parser.md
+++ b/code/specs/LTX01-full-latex-parser.md
@@ -131,9 +131,15 @@ is text-primary, which is a different mode model.)
     (`itemize`/`enumerate`/`description`) with `\item`, operating on the document `Node` tree.
     Deferred because they need an extra column-spec field on the node; an unknown
     `\begin{…}` is rejected with a spanned error in the meantime, never mis-parsed.
-- **L4 — macros.** `\newcommand`/`\renewcommand`/`\def` with `#1`..`#9` and one optional
-  arg with default; expansion of user-defined and a built-in starter set. Recursion/loop
-  guard (bounded expansion depth → `Unsupported`/error, never hang).
+- **L4 — macros.** Split into sub-rungs:
+  - **L4a (shipped) — positional macros.** `\newcommand`/`\renewcommand`/`\providecommand`
+    with positional arity `[n]` and `#1`..`#9` bodies; opt-in `expand(Vec<Node>)` pass that
+    registers definitions (which then vanish) and replaces uses by substituted, recursively
+    expanded bodies. Recursion-depth + work-budget guards → spanned error, never hang.
+    Implemented in the `latex` crate (macros.rs).
+  - **L4b (later) — optional-arg defaults + `\def`.** `\newcommand{\x}[n][default]{…}` and
+    TeX-style `\def\x#1#2{…}` with arbitrary parameter text; `#n` inside math islands.
+  - **L4c (later) — built-in starter set** of common macros pre-registered.
 - **L5 — text-mode breadth.** Sectioning (`\section` …), font/style commands, text accents
   (`\'e`, `\"o`, `\~n`), `\verb`/`verbatim`, cross-refs (`\label`/`\ref`/`\cite` as nodes),
   `\documentclass`/`\usepackage` parsed structurally.


### PR DESCRIPTION
## LTX01 L4a — macro expansion

Fifth rung of the full-fidelity LaTeX parser (standalone, reusable; no ADJ/engine coupling).
Adds an **opt-in** macro pass: `parse` (L1) stays purely structural — its round-trip is
untouched — and a new `expand(Vec<Node>) -> Result<Vec<Node>, ParseError>` registers user
macros and replaces their uses by substituted, recursively expanded bodies (definitions
vanish from the output, as in LaTeX).

### What's in this rung

- **Definitions**: `\newcommand`/`\renewcommand`/`\providecommand` with positional arity
  `[n]` and `#1`..`#9` bodies. Handles L1's argument-capture quirk — `capture_args` stops its
  greedy `{…}` run at the `[n]` arity bracket, so the arity and body land as *siblings* — by
  re-scanning the definition's sibling nodes.
- **Substitution** walks the whole tree (groups, command optional/arguments, environment
  bodies) so `#n` inside `\bar{#1}` works; `##` is a literal `#`; arguments are expanded
  call-by-value, then the substituted body is expanded so a body that calls further macros
  resolves. (`#n` survives L1 as the `Text("#"), Text("n…")` pattern.)

### Robustness (DoS-hardened)

Total / panic-free / spanned. Two guards bound expansion:
- a **recursion-depth** cap (`MAX_EXPANSION_DEPTH=64`) on macro-feedback recursion only —
  *not* on structural descent, so a deeply-nested-but-finite document (valid at L1, cap 512)
  is not spuriously rejected; a self-recursive macro still trips it;
- a **work-budget** cap (`MAX_EXPANSION_STEPS=1_000_000`) charged per emitted node **and**
  per spliced argument *before* allocation — so an exponential macro chain AND an
  `O(input²)` `#1`-heavy-body × large-argument amplification both error instead of OOMing.

Bad calls (too few args, parameter out of range, malformed definition, unsupported
`[n][default]`) are spanned errors, never mis-expanded.

### Honest scope (L4a)

Positional args only. Deferred to L4b/L4c: optional arguments with a default, TeX-style
`\def`, a built-in starter set, and `#n` substitution inside math islands. Spec §5 L4 split
into L4a/L4b/L4c accordingly.

### Tests

+18 macro tests (zero/one/two-arg incl. reordering, macro-calls-macro, param-in-group,
definition-vanishes, renew redefines, unknown-command pass-through, extra-group retention,
literal `##`, repeated-param × multi-node arg, deep-structural-nesting-OK, and the error
family: recursion, too-few-args, out-of-range, default-arg, malformed). **82 unit + 1 doc
test** green; clippy `-D warnings` clean; no `unsafe`. Crate 0.4.0 → 0.5.0.

Security: `/security-review` ran on the diff (DoS/panic focus — termination, recursion depth,
expansion-bomb + memory-amplification, index/overflow panics) and returned **PASSED — no
vulnerabilities found**. A pre-budget memory-amplification path (un-charged `subst`) was found
and fixed during self-review before the agent confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)