### PR TITLE
feat(latex): inline \verb verbatim (LTX01 L5a)

### DIFF
--- a/code/packages/rust/latex/CHANGELOG.md
+++ b/code/packages/rust/latex/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to the full-fidelity LaTeX parser crate.
 
+## [0.6.0] — 2026-06-26
+
+### Added — LTX01 L5a: inline `\verb` verbatim
+
+- **Inline verbatim** `\verb<delim>…<delim>` and the `\verb*` visible-space variant. The
+  tokenizer now intercepts `\verb` and reads its body **raw** — catcodes are suspended, so
+  `{ } $ # \` etc. are literal characters (previously L1 mis-tokenized them). New
+  `TokenKind::Verb { star, delim, content }` → `Node::Verb { star, delim, content }`, with a
+  round-tripping `to_latex`.
+- Total / panic-free / spanned: an unterminated `\verb`, a body that runs past the end of the
+  line, `\verb` at end of input, or a `*`/space delimiter each return a spanned `LexError` —
+  never a panic or a mis-parse. The body is bounded by the input (single line).
+- +7 tests (lexer: raw body with `{}$#\`, `\verb*`, the error family; parser: `Verb` node,
+  surrounding text undisturbed; +2 round-trip-corpus entries). **87 unit + 1 doc test** green;
+  clippy `-D warnings` clean; no `unsafe`. Crate 0.5.0 → 0.6.0.
+- Scope: this is L5a. The `verbatim` environment, text accents (`\'e`…), sectioning/font
+  recognition, and cross-refs are later L5 sub-rungs (spec §5).
+
 ## [0.5.0] — 2026-06-26
 
 ### Added — LTX01 L4a: macro expansion

--- a/code/packages/rust/latex/Cargo.toml
+++ b/code/packages/rust/latex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latex"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "A full-fidelity LaTeX parser (documents and math): a catcode-driven, text-mode-primary tokenizer and (in later layers) a structural + math parser producing a faithful AST. Standalone and reusable; will also implement the math-frontend MathFrontend trait."
 license = "MIT"

--- a/code/packages/rust/latex/README.md
+++ b/code/packages/rust/latex/README.md
@@ -34,8 +34,8 @@ with a **text-mode-primary** mode stack (LaTeX starts in text mode; math is ente
 | **L1 structural** | groups, `\cmd[opt]{arg}`, `\begin{env}…\end{env}`, text runs, raw math islands, `to_latex()` round-trip | ✅ |
 | **L2 math** | math AST (frac, binom, roots, scripts, big ops, functions, accents, `\left\right` fences, relations), precedence-climbing parser, `to_latex()` round-trip | ✅ |
 | **L3 environments** | math env family — `matrix`/`pmatrix`/`bmatrix`/`vmatrix`/`cases`/`aligned`/`align` split on `&` and `\\` → `MathNode::Matrix`, round-trip; nesting + scripts | ✅ |
-| **L4 macros** | `\newcommand`/`\renewcommand`/`\providecommand` with positional `#1`..`#9`; bounded recursive expansion via `expand()` (L4a) | ✅ this release |
-| L5 text breadth | sectioning, fonts, accents, `\verb`, refs | ⏳ |
+| **L4 macros** | `\newcommand`/`\renewcommand`/`\providecommand` with positional `#1`..`#9`; bounded recursive expansion via `expand()` (L4a) | ✅ |
+| **L5 text breadth** | inline `\verb`/`\verb*` raw verbatim (L5a); accents, sectioning, refs, `verbatim` env to follow | 🚧 this release (L5a) |
 | L6 frontend | implement `math-frontend::MathFrontend` (LaTeX becomes plugin #1) | ⏳ |
 
 ## Usage
@@ -113,6 +113,23 @@ Expansion is **bounded** — a recursive macro (`\newcommand{\a}{\a}\a`) or an e
 errors via a depth + work-budget guard rather than hanging or overflowing. Deferred to later
 sub-rungs: optional arguments with a default (`[n][default]`), TeX-style `\def`, and a
 built-in starter set; `#n` inside a math island is not substituted in L4a.
+
+### Verbatim (L5a)
+
+`\verb<delim>…<delim>` (and the `\verb*` visible-space variant) read their body **raw** — the
+tokenizer suspends catcodes inside, so `{ } $ # \` are literal — producing a `Node::Verb`
+that round-trips:
+
+```rust
+use latex::{parse, Node};
+
+let doc = parse(r"call \verb|x{y}$z| now").unwrap();
+assert!(matches!(doc[1], Node::Verb { delim: '|', .. }));   // body "x{y}$z" kept verbatim
+```
+
+An unterminated `\verb`, a body running past the end of the line, or a `*`/space delimiter is
+a spanned error — never a mis-parse. (The `verbatim` environment, text accents, sectioning,
+and cross-refs arrive in later L5 sub-rungs.)
 
 The low-level `tokenize` is also public. Tokens and errors carry half-open byte `Span`s;
 all of `parse`, `parse_math`, and `tokenize` return spanned errors rather than panicking,

--- a/code/packages/rust/latex/src/ast.rs
+++ b/code/packages/rust/latex/src/ast.rs
@@ -41,6 +41,10 @@ pub enum Node {
     Math { display: bool, content: String },
     /// A comment (text without the `%` or trailing newline).
     Comment(String),
+    /// Inline verbatim (`\verb<delim>…<delim>` / `\verb*…`): the body is the **raw** inner
+    /// text (catcodes suspended), kept verbatim. `star` is the visible-space variant; `delim`
+    /// is the chosen delimiter, preserved so the node round-trips.
+    Verb { star: bool, delim: char, content: String },
     /// An active character that acts like a command — `~`.
     Active(char),
     /// A construct deliberately out of scope (the TeX-programmability asymptote — e.g.
@@ -127,6 +131,15 @@ impl Node {
                 out.push('%');
                 out.push_str(c);
                 out.push('\n');
+            }
+            Node::Verb { star, delim, content } => {
+                out.push_str("\\verb");
+                if *star {
+                    out.push('*');
+                }
+                out.push(*delim);
+                out.push_str(content);
+                out.push(*delim);
             }
             Node::Active(c) => out.push(*c),
             Node::Unsupported { construct, .. } => out.push_str(construct),

--- a/code/packages/rust/latex/src/lexer.rs
+++ b/code/packages/rust/latex/src/lexer.rs
@@ -70,10 +70,61 @@ pub fn tokenize(src: &str) -> Result<Vec<Token>, LexError> {
                         i += 1;
                     }
                     let name: String = chars[name_start..i].iter().map(|&(_, ch)| ch).collect();
-                    out.push(Token::new(TokenKind::ControlWord(name), start, off(i)));
-                    // TeX absorbs the spaces (and tabs) following a control word.
-                    while i < n && matches!(chars[i].1, ' ' | '\t') {
+                    if name == "verb" {
+                        // `\verb` reads its argument **raw**, with catcodes suspended — so the
+                        // body may contain `{ } $ # \` etc. as literal characters. An optional
+                        // `*` selects the visible-space variant; the next character is the
+                        // delimiter (anything but `*` or a space), and the body runs to the
+                        // matching delimiter on the same line.
+                        let star = i < n && chars[i].1 == '*';
+                        if star {
+                            i += 1;
+                        }
+                        if i >= n {
+                            return Err(LexError::new(
+                                "\\verb at end of input (expected a delimiter)",
+                                start,
+                                end,
+                            ));
+                        }
+                        let delim = chars[i].1;
+                        if matches!(delim, '*' | ' ' | '\t' | '\n') {
+                            return Err(LexError::new(
+                                "\\verb delimiter must be a visible character (not '*' or a space)",
+                                start,
+                                off(i),
+                            ));
+                        }
                         i += 1;
+                        let body_start = i;
+                        while i < n && chars[i].1 != delim {
+                            // `\verb` may not span a line break (a classic runaway source).
+                            if chars[i].1 == '\n' {
+                                return Err(LexError::new(
+                                    "\\verb argument runs past the end of the line (missing closing delimiter)",
+                                    start,
+                                    off(i),
+                                ));
+                            }
+                            i += 1;
+                        }
+                        if i >= n {
+                            return Err(LexError::new(
+                                "unterminated \\verb (missing closing delimiter)",
+                                start,
+                                end,
+                            ));
+                        }
+                        let content: String =
+                            chars[body_start..i].iter().map(|&(_, ch)| ch).collect();
+                        i += 1; // consume the closing delimiter
+                        out.push(Token::new(TokenKind::Verb { star, delim, content }, start, off(i)));
+                    } else {
+                        out.push(Token::new(TokenKind::ControlWord(name), start, off(i)));
+                        // TeX absorbs the spaces (and tabs) following a control word.
+                        while i < n && matches!(chars[i].1, ' ' | '\t') {
+                            i += 1;
+                        }
                     }
                 } else {
                     // control SYMBOL — or a math-delimiter control symbol.
@@ -360,5 +411,30 @@ mod tests {
     #[test]
     fn empty_input_is_just_eof() {
         assert_eq!(tokenize("").unwrap().len(), 1);
+    }
+
+    #[test]
+    fn verb_reads_body_raw() {
+        // Catcodes suspended inside: `{`, `}`, `$`, `#`, `\` are all literal.
+        assert_eq!(
+            kinds(r"\verb|a{b}$#\|"),
+            vec![Verb { star: false, delim: '|', content: r"a{b}$#\".into() }]
+        );
+    }
+
+    #[test]
+    fn verb_star_variant() {
+        assert_eq!(
+            kinds(r"\verb*+x y+"),
+            vec![Verb { star: true, delim: '+', content: "x y".into() }]
+        );
+    }
+
+    #[test]
+    fn verb_errors_are_spanned_not_panics() {
+        assert!(tokenize(r"\verb|abc").is_err()); // unterminated (EOF before close)
+        assert!(tokenize("\\verb|ab\ncd|").is_err()); // runs past end of line
+        assert!(tokenize(r"\verb").is_err()); // no delimiter at EOF
+        assert!(tokenize(r"\verb a|").is_err()); // delimiter may not be a space
     }
 }

--- a/code/packages/rust/latex/src/parser.rs
+++ b/code/packages/rust/latex/src/parser.rs
@@ -164,6 +164,10 @@ impl<'a> Parser<'a> {
                 self.bump();
                 Ok(Node::Active(c))
             }
+            TokenKind::Verb { star, delim, content } => {
+                self.bump();
+                Ok(Node::Verb { star, delim, content })
+            }
             // In text mode these four are literal characters; they only carry structural
             // meaning inside math/environments, which are handled elsewhere (L2/L3).
             TokenKind::AlignTab => { self.bump(); Ok(Node::Text("&".into())) }
@@ -504,8 +508,36 @@ mod tests {
             r"\begin{tabular}{cc}a&b\end{tabular}",
             r"a~b and \, thin",
             r"nested {groups {deep}} ok",
+            r"use \verb|x{y}$z| inline",
+            r"\verb*+two words+ here",
         ] {
             assert_round_trips(src);
         }
+    }
+
+    #[test]
+    fn verb_is_a_node_with_raw_body() {
+        // `\verb|...|` becomes a Verb node whose body keeps catcode-significant chars literal.
+        assert_eq!(
+            p(r"\verb|a{b}$c|"),
+            vec![Verb { star: false, delim: '|', content: "a{b}$c".into() }]
+        );
+        // starred variant
+        assert_eq!(
+            p(r"\verb*!x!"),
+            vec![Verb { star: true, delim: '!', content: "x".into() }]
+        );
+    }
+
+    #[test]
+    fn verb_does_not_disturb_surrounding_text() {
+        assert_eq!(
+            p(r"a\verb|b|c"),
+            vec![
+                Text("a".into()),
+                Verb { star: false, delim: '|', content: "b".into() },
+                Text("c".into()),
+            ]
+        );
     }
 }

--- a/code/packages/rust/latex/src/token.rs
+++ b/code/packages/rust/latex/src/token.rs
@@ -77,6 +77,11 @@ pub enum TokenKind {
     Char(char),
     /// A comment from `%` to end of line (text kept, without the `%` or the newline).
     Comment(String),
+    /// Inline verbatim: `\verb<delim>…<delim>` (or `\verb*…` for the visible-space variant).
+    /// The lexer reads the body **raw** — catcodes are suspended inside it, so `{ $ # \` etc.
+    /// are literal characters. `delim` is the chosen delimiter (e.g. `|`), `star` is the `*`
+    /// variant, and `content` is the raw inner text.
+    Verb { star: bool, delim: char, content: String },
     /// End of input — always the final token.
     Eof,
 }

--- a/code/specs/LTX01-full-latex-parser.md
+++ b/code/specs/LTX01-full-latex-parser.md
@@ -140,9 +140,18 @@ is text-primary, which is a different mode model.)
   - **L4b (later) — optional-arg defaults + `\def`.** `\newcommand{\x}[n][default]{…}` and
     TeX-style `\def\x#1#2{…}` with arbitrary parameter text; `#n` inside math islands.
   - **L4c (later) — built-in starter set** of common macros pre-registered.
-- **L5 — text-mode breadth.** Sectioning (`\section` …), font/style commands, text accents
-  (`\'e`, `\"o`, `\~n`), `\verb`/`verbatim`, cross-refs (`\label`/`\ref`/`\cite` as nodes),
-  `\documentclass`/`\usepackage` parsed structurally.
+- **L5 — text-mode breadth.** Split into sub-rungs:
+  - **L5a (shipped) — inline `\verb`.** `\verb<delim>…<delim>` and `\verb*` read raw at the
+    tokenizer (catcodes suspended) → `Node::Verb { star, delim, content }`, round-tripping;
+    spanned errors on unterminated / line-spanning / bad-delimiter. Implemented in
+    lexer.rs + parser.rs + ast.rs.
+  - **L5b (later) — `verbatim` environment** (`\begin{verbatim}…\end{verbatim}`, `verbatim*`)
+    read raw to the matching `\end`.
+  - **L5c (later) — text accents** (`\'e`, `\"o`, `\~n`, `\^o`, `\=`, `\u`, `\v`, `\c`, …)
+    recognized over the next char/group.
+  - **L5d (later) — sectioning/font recognition + cross-refs + preamble**: `\section`(+`*`),
+    font/style commands, `\label`/`\ref`/`\cite`, `\documentclass`/`\usepackage` as
+    recognized nodes (mostly classification over the generic Commands L1 already produces).
 - **L6 — `math-frontend` adapter.** Implement `MathFrontend` for `latex`: lift `Math`/`MathNode`
   subtrees to the neutral `MathExpr`; declare capabilities; register in the builtin registry.
   (This is where LaTeX becomes a *plugin*; [PFE01](PFE01-pluggable-parser-frontends.md)'s


### PR DESCRIPTION
## LTX01 L5a — inline `\verb` verbatim

Sixth rung of the full-fidelity LaTeX parser (standalone, reusable; no ADJ/engine coupling).
Adds inline verbatim — `\verb<delim>…<delim>` and the `\verb*` visible-space variant — at the
tokenizer level.

### Why this is a correctness fix (not just breadth)

L1 had **no** verbatim handling, so `\verb|{$#\|` mis-tokenized (`{`→BeginGroup, `$`→MathOn,
`#`→Parameter, …). The lexer now intercepts `\verb` and reads its body **raw**, catcodes
suspended, so those bytes are literal.

### What's in this rung

- New `TokenKind::Verb { star, delim, content }` (lexer) → `Node::Verb { star, delim, content }`
  (parser/AST), with a round-tripping `to_latex` (`\verb`/`\verb*` + delimiter + raw body).
- Delimiter rules mirror LaTeX: optional `*`, then the delimiter (anything but `*` or a space),
  then the body to the matching delimiter on the same line.

### Robustness

Total / panic-free / spanned: an unterminated `\verb`, a body running past the end of the
line, `\verb` at end of input, or a `*`/space delimiter each return a spanned `LexError` —
never a panic or a mis-parse. The raw body is single-line, bounded by the input.

### Honest scope (L5a)

Inline `\verb` only. The `verbatim` environment (L5b), text accents `\'e`… (L5c), and
sectioning/font/ref/preamble recognition (L5d) are later L5 sub-rungs. Spec §5 L5 split
accordingly.

### Tests

+7 (lexer: raw body with `{}$#\`, `\verb*`, and the error family — unterminated /
line-spanning / no-delimiter / space-delimiter; parser: `Verb` node + surrounding text
undisturbed; +2 round-trip-corpus entries). **87 unit + 1 doc test** green; clippy
`-D warnings` clean; no `unsafe`. Crate 0.5.0 → 0.6.0.

Security: `/security-review` ran on the diff (verbatim-scan termination, unbounded read,
index/char-boundary panics) and returned **PASSED — no vulnerabilities found**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)