### PR TITLE
feat(latex): verbatim environment (LTX01 L5b)

### DIFF
--- a/code/packages/rust/latex/CHANGELOG.md
+++ b/code/packages/rust/latex/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to the full-fidelity LaTeX parser crate.
 
+## [0.7.0] — 2026-06-27
+
+### Added — LTX01 L5b: `verbatim` environment
+
+- **`\begin{verbatim}…\end{verbatim}`** (and `verbatim*`) read their whole body **raw** —
+  catcodes suspended, newlines included — up to the matching `\end{<env>}`. New
+  `TokenKind::VerbatimEnv { env, content }` → `Node::VerbatimEnv { env, content }`, with a
+  round-tripping `to_latex`. The lexer peeks after `\begin` (consuming nothing) and only
+  diverts to raw scanning for `verbatim`/`verbatim*`; every other `\begin{…}` is still parsed
+  structurally. `\end{…}` for a different name inside the body stays literal.
+- Total / panic-free / spanned: an unterminated `verbatim` environment (or one closed with the
+  wrong name) is a spanned `LexError`; the raw scan advances one char per step and terminates
+  at EOF. No `unsafe`.
+
+### Fixed
+
+- Lowered the structural-parser nesting cap `MAX_DEPTH` 512 → 256. The new owned-`String`
+  token/AST variants enlarged recursive-descent frames enough that 512-deep pathological input
+  could overflow a small (2 MB) test-thread stack; 256 trips the spanned "nesting too deep"
+  guard well within it. Real documents never nest this deep.
+
+### Tests
+
+- +9 (lexer: verbatim-env raw body incl. `{}$#`+newline, `verbatim*`, non-verbatim `\begin`
+  left to the parser, inner wrong-`\end` stays literal, unterminated/wrong-close errors;
+  parser: `VerbatimEnv` node + 2 round-trips). **94 unit + 1 doc test** green; clippy
+  `-D warnings` clean; no `unsafe`. Crate 0.6.0 → 0.7.0.
+
 ## [0.6.0] — 2026-06-26
 
 ### Added — LTX01 L5a: inline `\verb` verbatim

--- a/code/packages/rust/latex/Cargo.toml
+++ b/code/packages/rust/latex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latex"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 description = "A full-fidelity LaTeX parser (documents and math): a catcode-driven, text-mode-primary tokenizer and (in later layers) a structural + math parser producing a faithful AST. Standalone and reusable; will also implement the math-frontend MathFrontend trait."
 license = "MIT"

--- a/code/packages/rust/latex/README.md
+++ b/code/packages/rust/latex/README.md
@@ -35,7 +35,7 @@ with a **text-mode-primary** mode stack (LaTeX starts in text mode; math is ente
 | **L2 math** | math AST (frac, binom, roots, scripts, big ops, functions, accents, `\left\right` fences, relations), precedence-climbing parser, `to_latex()` round-trip | ✅ |
 | **L3 environments** | math env family — `matrix`/`pmatrix`/`bmatrix`/`vmatrix`/`cases`/`aligned`/`align` split on `&` and `\\` → `MathNode::Matrix`, round-trip; nesting + scripts | ✅ |
 | **L4 macros** | `\newcommand`/`\renewcommand`/`\providecommand` with positional `#1`..`#9`; bounded recursive expansion via `expand()` (L4a) | ✅ |
-| **L5 text breadth** | inline `\verb`/`\verb*` raw verbatim (L5a); accents, sectioning, refs, `verbatim` env to follow | 🚧 this release (L5a) |
+| **L5 text breadth** | inline `\verb`/`\verb*` (L5a) + `verbatim`/`verbatim*` environment (L5b), both raw; accents, sectioning, refs to follow | 🚧 this release (L5b) |
 | L6 frontend | implement `math-frontend::MathFrontend` (LaTeX becomes plugin #1) | ⏳ |
 
 ## Usage
@@ -114,7 +114,7 @@ errors via a depth + work-budget guard rather than hanging or overflowing. Defer
 sub-rungs: optional arguments with a default (`[n][default]`), TeX-style `\def`, and a
 built-in starter set; `#n` inside a math island is not substituted in L4a.
 
-### Verbatim (L5a)
+### Verbatim (L5a/L5b)
 
 `\verb<delim>…<delim>` (and the `\verb*` visible-space variant) read their body **raw** — the
 tokenizer suspends catcodes inside, so `{ } $ # \` are literal — producing a `Node::Verb`
@@ -127,9 +127,20 @@ let doc = parse(r"call \verb|x{y}$z| now").unwrap();
 assert!(matches!(doc[1], Node::Verb { delim: '|', .. }));   // body "x{y}$z" kept verbatim
 ```
 
-An unterminated `\verb`, a body running past the end of the line, or a `*`/space delimiter is
-a spanned error — never a mis-parse. (The `verbatim` environment, text accents, sectioning,
-and cross-refs arrive in later L5 sub-rungs.)
+The **`verbatim` environment** (and `verbatim*`) reads its whole body raw — newlines included —
+up to the matching `\end{verbatim}`, producing a `Node::VerbatimEnv` that also round-trips:
+
+```rust
+use latex::{parse, Node};
+
+let doc = parse("\\begin{verbatim}let x = {1};\n$y$\\end{verbatim}").unwrap();
+assert!(matches!(doc[0], Node::VerbatimEnv { .. }));   // body kept literal, $/{} not special
+```
+
+Only `verbatim`/`verbatim*` divert to raw scanning; every other `\begin{…}` is parsed
+structurally. An unterminated `\verb` (or a `*`/space delimiter, or a body past the line end)
+and an unterminated `verbatim` environment are spanned errors — never a mis-parse. (Text
+accents, sectioning, and cross-refs arrive in later L5 sub-rungs.)
 
 The low-level `tokenize` is also public. Tokens and errors carry half-open byte `Span`s;
 all of `parse`, `parse_math`, and `tokenize` return spanned errors rather than panicking,

--- a/code/packages/rust/latex/src/ast.rs
+++ b/code/packages/rust/latex/src/ast.rs
@@ -45,6 +45,10 @@ pub enum Node {
     /// text (catcodes suspended), kept verbatim. `star` is the visible-space variant; `delim`
     /// is the chosen delimiter, preserved so the node round-trips.
     Verb { star: bool, delim: char, content: String },
+    /// A verbatim *environment* (`\begin{verbatim}…\end{verbatim}` / `verbatim*`): the body is
+    /// the **raw** inner text (catcodes suspended, newlines kept). `env` is the environment
+    /// name verbatim, preserved so the node round-trips.
+    VerbatimEnv { env: String, content: String },
     /// An active character that acts like a command — `~`.
     Active(char),
     /// A construct deliberately out of scope (the TeX-programmability asymptote — e.g.
@@ -140,6 +144,15 @@ impl Node {
                 out.push(*delim);
                 out.push_str(content);
                 out.push(*delim);
+            }
+            Node::VerbatimEnv { env, content } => {
+                out.push_str("\\begin{");
+                out.push_str(env);
+                out.push('}');
+                out.push_str(content);
+                out.push_str("\\end{");
+                out.push_str(env);
+                out.push('}');
             }
             Node::Active(c) => out.push(*c),
             Node::Unsupported { construct, .. } => out.push_str(construct),

--- a/code/packages/rust/latex/src/lexer.rs
+++ b/code/packages/rust/latex/src/lexer.rs
@@ -36,6 +36,23 @@ enum Mode {
     Math { display: bool },
 }
 
+/// Peek (consuming nothing): does the source at `i` spell `{verbatim}` or `{verbatim*}`? Used
+/// right after `\begin` to decide whether to read a verbatim environment body raw. Only these
+/// two environment names divert to raw scanning; every other `\begin{…}` is parsed structurally.
+fn verbatim_env_at(chars: &[(usize, char)], i: usize) -> bool {
+    let n = chars.len();
+    if i >= n || chars[i].1 != '{' {
+        return false;
+    }
+    let name_start = i + 1;
+    let mut j = name_start;
+    while j < n && (catcode(chars[j].1) == Catcode::Letter || chars[j].1 == '*') {
+        j += 1;
+    }
+    let name: String = chars[name_start..j].iter().map(|&(_, ch)| ch).collect();
+    j < n && chars[j].1 == '}' && matches!(name.as_str(), "verbatim" | "verbatim*")
+}
+
 /// Tokenize a LaTeX string into a flat token stream ending in [`TokenKind::Eof`]. Returns
 /// a spanned [`LexError`] on a malformed control sequence (e.g. a trailing `\`); never
 /// panics.
@@ -119,6 +136,44 @@ pub fn tokenize(src: &str) -> Result<Vec<Token>, LexError> {
                             chars[body_start..i].iter().map(|&(_, ch)| ch).collect();
                         i += 1; // consume the closing delimiter
                         out.push(Token::new(TokenKind::Verb { star, delim, content }, start, off(i)));
+                    } else if name == "begin" && verbatim_env_at(&chars, i) {
+                        // `\begin{verbatim}` / `\begin{verbatim*}` — read the body **raw** up to
+                        // the matching `\end{<env>}`, catcodes suspended (newlines included),
+                        // exactly like `\verb` but block-level. We only divert when the env is a
+                        // verbatim one; every other `\begin{…}` stays a normal control word for
+                        // the structural parser.
+                        i += 1; // consume '{'
+                        let env_start = i;
+                        while i < n && (catcode(chars[i].1) == Catcode::Letter || chars[i].1 == '*') {
+                            i += 1;
+                        }
+                        let env: String = chars[env_start..i].iter().map(|&(_, ch)| ch).collect();
+                        i += 1; // consume '}' (presence guaranteed by verbatim_env_at)
+                        let body_start = i;
+                        let close: Vec<char> = format!("\\end{{{env}}}").chars().collect();
+                        // Scan for the matching close sequence. Each step advances `i`, so the
+                        // loop terminates at EOF (→ spanned error) — no runaway.
+                        let mut found = false;
+                        while i < n {
+                            if i + close.len() <= n
+                                && (0..close.len()).all(|m| chars[i + m].1 == close[m])
+                            {
+                                found = true;
+                                break;
+                            }
+                            i += 1;
+                        }
+                        if !found {
+                            return Err(LexError::new(
+                                format!("unterminated \\begin{{{env}}} (missing \\end{{{env}}})"),
+                                start,
+                                end,
+                            ));
+                        }
+                        let content: String =
+                            chars[body_start..i].iter().map(|&(_, ch)| ch).collect();
+                        i += close.len(); // consume the `\end{<env>}`
+                        out.push(Token::new(TokenKind::VerbatimEnv { env, content }, start, off(i)));
                     } else {
                         out.push(Token::new(TokenKind::ControlWord(name), start, off(i)));
                         // TeX absorbs the spaces (and tabs) following a control word.
@@ -436,5 +491,47 @@ mod tests {
         assert!(tokenize("\\verb|ab\ncd|").is_err()); // runs past end of line
         assert!(tokenize(r"\verb").is_err()); // no delimiter at EOF
         assert!(tokenize(r"\verb a|").is_err()); // delimiter may not be a space
+    }
+
+    #[test]
+    fn verbatim_environment_reads_body_raw() {
+        // catcodes suspended in the body: `{ } $ #` and newlines are literal.
+        assert_eq!(
+            kinds("\\begin{verbatim}a {b} $x\nc\\end{verbatim}"),
+            vec![VerbatimEnv { env: "verbatim".into(), content: "a {b} $x\nc".into() }]
+        );
+    }
+
+    #[test]
+    fn verbatim_star_environment() {
+        assert_eq!(
+            kinds(r"\begin{verbatim*}x y\end{verbatim*}"),
+            vec![VerbatimEnv { env: "verbatim*".into(), content: "x y".into() }]
+        );
+    }
+
+    #[test]
+    fn non_verbatim_begin_is_left_to_the_parser() {
+        // A normal environment stays a ControlWord("begin") + structural tokens.
+        assert_eq!(
+            kinds(r"\begin{itemize}"),
+            vec![ControlWord("begin".into()), BeginGroup, Char('i'), Char('t'), Char('e'),
+                 Char('m'), Char('i'), Char('z'), Char('e'), EndGroup]
+        );
+    }
+
+    #[test]
+    fn verbatim_inner_wrong_end_does_not_close() {
+        // `\end{foo}` inside the body is literal; only `\end{verbatim}` closes.
+        assert_eq!(
+            kinds(r"\begin{verbatim}\end{foo}\end{verbatim}"),
+            vec![VerbatimEnv { env: "verbatim".into(), content: r"\end{foo}".into() }]
+        );
+    }
+
+    #[test]
+    fn unterminated_verbatim_environment_errors() {
+        assert!(tokenize(r"\begin{verbatim}abc").is_err());
+        assert!(tokenize(r"\begin{verbatim}abc\end{verbatim*}").is_err()); // wrong close name
     }
 }

--- a/code/packages/rust/latex/src/lib.rs
+++ b/code/packages/rust/latex/src/lib.rs
@@ -29,7 +29,10 @@
 //!    (this release).**
 //! 4. [`expand`] — an opt-in **macro pass** over the document tree: registers
 //!    `\newcommand`/`\renewcommand`/`\providecommand` (positional `#1`..`#9`) and replaces
-//!    uses by their bounded, recursively-expanded bodies. **Implemented (L4a, this release).**
+//!    uses by their bounded, recursively-expanded bodies. **Implemented (L4a).**
+//! 5. **Verbatim** — `\verb`/`\verb*` ([`Node::Verb`]) and the `verbatim`/`verbatim*`
+//!    environment ([`Node::VerbatimEnv`]) read their bodies **raw** (catcodes suspended).
+//!    **Implemented (L5a/L5b).** Text accents, sectioning, and refs are later L5 sub-rungs.
 //!
 //! ## Example
 //!

--- a/code/packages/rust/latex/src/parser.rs
+++ b/code/packages/rust/latex/src/parser.rs
@@ -65,7 +65,12 @@ type CapturedArgs = (Vec<Vec<Node>>, Vec<Vec<Node>>);
 /// recursive descent as deep as it nests; this bound turns a pathological input into a
 /// spanned error instead of a stack overflow, keeping the parser total. Real documents
 /// nest only a handful deep, so this is generous.
-const MAX_DEPTH: usize = 512;
+// Each `Token` carries a `TokenKind` whose largest variants now hold owned `String`s
+// (`Verb`, `VerbatimEnv`, …), so recursive-descent frames are heavier than they were at L1.
+// Keep the structural nesting cap low enough that pathological input (thousands of `{`) trips
+// the guard well within even a small (2 MB test-thread) stack instead of overflowing — real
+// documents never nest anywhere near this deep.
+const MAX_DEPTH: usize = 256;
 
 struct Parser<'a> {
     toks: &'a [Token],
@@ -167,6 +172,10 @@ impl<'a> Parser<'a> {
             TokenKind::Verb { star, delim, content } => {
                 self.bump();
                 Ok(Node::Verb { star, delim, content })
+            }
+            TokenKind::VerbatimEnv { env, content } => {
+                self.bump();
+                Ok(Node::VerbatimEnv { env, content })
             }
             // In text mode these four are literal characters; they only carry structural
             // meaning inside math/environments, which are handled elsewhere (L2/L3).
@@ -539,5 +548,22 @@ mod tests {
                 Text("c".into()),
             ]
         );
+    }
+
+    #[test]
+    fn verbatim_environment_is_a_node() {
+        assert_eq!(
+            p("\\begin{verbatim}let x = {1};\n$y$\\end{verbatim}"),
+            vec![VerbatimEnv {
+                env: "verbatim".into(),
+                content: "let x = {1};\n$y$".into(),
+            }]
+        );
+    }
+
+    #[test]
+    fn verbatim_environment_round_trips() {
+        assert_round_trips("before \\begin{verbatim}raw {code} $here$\\end{verbatim} after");
+        assert_round_trips(r"\begin{verbatim*}v s\end{verbatim*}");
     }
 }

--- a/code/packages/rust/latex/src/token.rs
+++ b/code/packages/rust/latex/src/token.rs
@@ -82,6 +82,11 @@ pub enum TokenKind {
     /// are literal characters. `delim` is the chosen delimiter (e.g. `|`), `star` is the `*`
     /// variant, and `content` is the raw inner text.
     Verb { star: bool, delim: char, content: String },
+    /// A verbatim *environment* body: `\begin{verbatim}…\end{verbatim}` (or `verbatim*`). The
+    /// lexer reads everything between the opening `}` and the matching `\end{<env>}` **raw**
+    /// (catcodes suspended, newlines included). `env` is the environment name verbatim
+    /// (`verbatim` / `verbatim*`), `content` the raw body.
+    VerbatimEnv { env: String, content: String },
     /// End of input — always the final token.
     Eof,
 }

--- a/code/specs/LTX01-full-latex-parser.md
+++ b/code/specs/LTX01-full-latex-parser.md
@@ -145,8 +145,10 @@ is text-primary, which is a different mode model.)
     tokenizer (catcodes suspended) → `Node::Verb { star, delim, content }`, round-tripping;
     spanned errors on unterminated / line-spanning / bad-delimiter. Implemented in
     lexer.rs + parser.rs + ast.rs.
-  - **L5b (later) — `verbatim` environment** (`\begin{verbatim}…\end{verbatim}`, `verbatim*`)
-    read raw to the matching `\end`.
+  - **L5b (shipped) — `verbatim` environment** (`\begin{verbatim}…\end{verbatim}`, `verbatim*`)
+    read raw to the matching `\end` (catcodes suspended, newlines kept) → `Node::VerbatimEnv`,
+    round-tripping; lexer peeks after `\begin` and only diverts for these env names; spanned
+    error on unterminated/wrong close. Implemented in lexer.rs + parser.rs + ast.rs.
   - **L5c (later) — text accents** (`\'e`, `\"o`, `\~n`, `\^o`, `\=`, `\u`, `\v`, `\c`, …)
     recognized over the next char/group.
   - **L5d (later) — sectioning/font recognition + cross-refs + preamble**: `\section`(+`*`),


### PR DESCRIPTION
## LTX01 L5b — `verbatim` environment

Completes block-level verbatim alongside L5a's inline `\verb`. `\begin{verbatim}…\end{verbatim}`
and `verbatim*` read their whole body **raw** — catcodes suspended, newlines included — up to
the matching `\end{<env>}`.

### What's in this rung

- New `TokenKind::VerbatimEnv { env, content }` → `Node::VerbatimEnv { env, content }`, with a
  round-tripping `to_latex`.
- The lexer **peeks** after a `\begin` control word (consuming nothing) and only diverts to raw
  scanning for `verbatim`/`verbatim*`; every other `\begin{…}` is still parsed structurally
  (L1). An `\end{…}` for a different name inside the body stays literal — only the exact
  matching `\end{<env>}` closes.

### Robustness

Total / panic-free / spanned: an unterminated environment (or one closed with the wrong name)
returns a spanned `LexError`; the raw close-scan advances one char per step and terminates at
EOF. No `unsafe`.

### Also fixed (surfaced here)

Lowered the structural-parser nesting cap `MAX_DEPTH` 512 → 256. The accumulated owned-`String`
token/AST variants (`Verb`, `VerbatimEnv`) enlarged recursive-descent frames enough that
512-deep pathological input (`"{".repeat(5000)`) could overflow a 2 MB test-thread stack; 256
trips the spanned "nesting too deep" guard well within it. Real documents never nest this deep
(same lesson as L2's math-depth cap).

### Honest scope (L5b)

Text accents `\'e`… (L5c) and sectioning/font/ref/preamble recognition (L5d) remain. Spec §5 L5
updated (L5b marked shipped).

### Tests

+9 (lexer: verbatim-env raw body incl. `{}$#`+newline, `verbatim*`, non-verbatim `\begin` left
to the parser, inner wrong-`\end` literal, unterminated/wrong-close errors; parser:
`VerbatimEnv` node + 2 round-trips). **94 unit + 1 doc test** green; clippy `-D warnings` clean;
no `unsafe`. Crate 0.6.0 → 0.7.0.

Security: `/security-review` ran on the diff (raw-scan termination, bounds/index, `}`-consume
reasoning, memory, overflow) and returned **PASSED — no vulnerabilities found**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)