### PR TITLE
feat(latex): text accents (LTX01 L5c)

### DIFF
--- a/code/packages/rust/latex/CHANGELOG.md
+++ b/code/packages/rust/latex/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to the full-fidelity LaTeX parser crate.
 
+## [0.8.0] — 2026-06-27
+
+### Added — LTX01 L5c: text accents
+
+- **`recognize_accents(Vec<Node>) -> Vec<Node>`** — a new, opt-in recognition pass (a sibling
+  of `expand`) that folds an accent control sequence and the character it accents into a new
+  `Node::Accent { accent, arg }`. `parse` (L1) is unchanged, so its round-trip is preserved.
+- Recognizes both spellings: control-symbol accents `\'  \`  \^  \"  \~  \=  \.` (which take no
+  L1 argument, so they pair with the next node) and control-word accents `\u \v \H \c \d \b
+  \r \t` (captured as `\c{e}`, or `\c e` where the lexer absorbed the space). The argument is
+  a single following character (`\'e` → é over `e`, the rest of the run kept as text) or a
+  braced group. Recurses into groups, command arguments, and environment bodies.
+- **`Node::Accent::to_latex`** renders the braced form `\'{e}`, so
+  `recognize_accents(parse(&n.to_latex())) == [n]` whether the source wrote `\'e` or `\'{e}`.
+- Total / panic-free: a dangling accent (nothing accent-able after it) is left as a plain
+  command, never dropped or mis-folded. No `unsafe`.
+- +9 tests (control-symbol over next char, first-char-only with remainder kept, braced arg,
+  control-word braced + bare, accent-in-group, non-accent untouched, dangling, round-trip
+  corpus). **103 unit + 1 doc test** green; clippy `-D warnings` clean. Crate 0.7.0 → 0.8.0.
+
 ## [0.7.0] — 2026-06-27
 
 ### Added — LTX01 L5b: `verbatim` environment

--- a/code/packages/rust/latex/Cargo.toml
+++ b/code/packages/rust/latex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latex"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 description = "A full-fidelity LaTeX parser (documents and math): a catcode-driven, text-mode-primary tokenizer and (in later layers) a structural + math parser producing a faithful AST. Standalone and reusable; will also implement the math-frontend MathFrontend trait."
 license = "MIT"

--- a/code/packages/rust/latex/README.md
+++ b/code/packages/rust/latex/README.md
@@ -35,7 +35,7 @@ with a **text-mode-primary** mode stack (LaTeX starts in text mode; math is ente
 | **L2 math** | math AST (frac, binom, roots, scripts, big ops, functions, accents, `\left\right` fences, relations), precedence-climbing parser, `to_latex()` round-trip | ✅ |
 | **L3 environments** | math env family — `matrix`/`pmatrix`/`bmatrix`/`vmatrix`/`cases`/`aligned`/`align` split on `&` and `\\` → `MathNode::Matrix`, round-trip; nesting + scripts | ✅ |
 | **L4 macros** | `\newcommand`/`\renewcommand`/`\providecommand` with positional `#1`..`#9`; bounded recursive expansion via `expand()` (L4a) | ✅ |
-| **L5 text breadth** | inline `\verb`/`\verb*` (L5a) + `verbatim`/`verbatim*` environment (L5b), both raw; accents, sectioning, refs to follow | 🚧 this release (L5b) |
+| **L5 text breadth** | `\verb`/`verbatim` raw (L5a/b) + text accents `\'e`/`\c{c}` via `recognize_accents` (L5c); sectioning/refs to follow | 🚧 this release (L5c) |
 | L6 frontend | implement `math-frontend::MathFrontend` (LaTeX becomes plugin #1) | ⏳ |
 
 ## Usage
@@ -139,8 +139,24 @@ assert!(matches!(doc[0], Node::VerbatimEnv { .. }));   // body kept literal, $/{
 
 Only `verbatim`/`verbatim*` divert to raw scanning; every other `\begin{…}` is parsed
 structurally. An unterminated `\verb` (or a `*`/space delimiter, or a body past the line end)
-and an unterminated `verbatim` environment are spanned errors — never a mis-parse. (Text
-accents, sectioning, and cross-refs arrive in later L5 sub-rungs.)
+and an unterminated `verbatim` environment are spanned errors — never a mis-parse.
+
+### Text accents (L5c)
+
+`recognize_accents` is an opt-in pass (like `expand`) that folds an accent control sequence
+and the character it accents into a `Node::Accent` — both spellings, `\'e` and `\'{e}`,
+recognize to the same node and round-trip:
+
+```rust
+use latex::{parse, recognize_accents, Node};
+
+let doc = recognize_accents(parse(r"caf\'e").unwrap());
+assert!(matches!(doc[1], Node::Accent { .. }));   // é over `e`; "caf" stays text
+```
+
+Recognized: `\'  \`  \^  \"  \~  \=  \.` and `\u \v \H \c \d \b \r \t`. A dangling accent (no
+accent-able char after it) is left as a plain command — never dropped. (Sectioning and
+cross-refs arrive in later L5 sub-rungs.)
 
 The low-level `tokenize` is also public. Tokens and errors carry half-open byte `Span`s;
 all of `parse`, `parse_math`, and `tokenize` return spanned errors rather than panicking,

--- a/code/packages/rust/latex/src/ast.rs
+++ b/code/packages/rust/latex/src/ast.rs
@@ -49,6 +49,11 @@ pub enum Node {
     /// the **raw** inner text (catcodes suspended, newlines kept). `env` is the environment
     /// name verbatim, preserved so the node round-trips.
     VerbatimEnv { env: String, content: String },
+    /// A text accent applied to its argument (L5c): `\'e` → é, `\c{c}` → ç. `accent` is the
+    /// control-sequence name verbatim (`'`, `"`, `c`, `u`, …); `arg` is the accented content
+    /// (a single-character text run, or a braced group's nodes). Produced only by the opt-in
+    /// [`recognize_accents`](crate::recognize_accents) pass, not by L1.
+    Accent { accent: String, arg: Vec<Node> },
     /// An active character that acts like a command — `~`.
     Active(char),
     /// A construct deliberately out of scope (the TeX-programmability asymptote — e.g.
@@ -152,6 +157,15 @@ impl Node {
                 out.push_str(content);
                 out.push_str("\\end{");
                 out.push_str(env);
+                out.push('}');
+            }
+            Node::Accent { accent, arg } => {
+                // Render the braced form `\<accent>{arg}` — it re-recognizes to the same node
+                // whether the source wrote `\'e` or `\'{e}`.
+                out.push('\\');
+                out.push_str(accent);
+                out.push('{');
+                render_seq(arg, out);
                 out.push('}');
             }
             Node::Active(c) => out.push(*c),

--- a/code/packages/rust/latex/src/lib.rs
+++ b/code/packages/rust/latex/src/lib.rs
@@ -32,7 +32,9 @@
 //!    uses by their bounded, recursively-expanded bodies. **Implemented (L4a).**
 //! 5. **Verbatim** — `\verb`/`\verb*` ([`Node::Verb`]) and the `verbatim`/`verbatim*`
 //!    environment ([`Node::VerbatimEnv`]) read their bodies **raw** (catcodes suspended).
-//!    **Implemented (L5a/L5b).** Text accents, sectioning, and refs are later L5 sub-rungs.
+//!    **Implemented (L5a/L5b).**
+//! 6. [`recognize_accents`] — an opt-in pass folding text accents (`\'e`, `\c{c}`) into
+//!    [`Node::Accent`]. **Implemented (L5c).** Sectioning and refs are later L5 sub-rungs.
 //!
 //! ## Example
 //!
@@ -56,6 +58,7 @@ mod lexer;
 mod macros;
 mod math;
 mod parser;
+mod text;
 mod token;
 
 pub use ast::{document_to_latex, Node};
@@ -65,4 +68,5 @@ pub use lexer::tokenize;
 pub use macros::expand;
 pub use math::{parse_math, MBinOp, MRelOp, MUnOp, MathNode};
 pub use parser::parse;
+pub use text::recognize_accents;
 pub use token::{Span, Token, TokenKind};

--- a/code/packages/rust/latex/src/text.rs
+++ b/code/packages/rust/latex/src/text.rs
@@ -1,0 +1,224 @@
+//! Text accents (L5c) — an opt-in recognition pass that folds an accent control sequence
+//! and the character it accents into a single [`Node::Accent`].
+//!
+//! ## Why a separate pass
+//!
+//! [`parse`](crate::parse) (L1) already *round-trips* accents — `\'e` lexes to a control
+//! symbol command `\'` followed by the text `e`, and rendering puts them back. What L1 does
+//! **not** do is say "this is an é". This pass adds that **semantic** recognition on demand,
+//! exactly like [`expand`](crate::expand) for macros, so L1's own round-trip is untouched.
+//!
+//! ## What it recognizes
+//!
+//! The standard LaTeX text accents, in both spellings:
+//! - **control-symbol accents** `\'  \`  \^  \"  \~  \=  \.` — never capture a brace argument
+//!   at L1 (control symbols take none), so they pair with the *next* node;
+//! - **control-word accents** `\u \v \H \c \d \b \r \t` — when written `\c{e}` L1 captures the
+//!   `{e}` as the command's argument; when written `\c e` the lexer absorbs the space and the
+//!   `e` is the next sibling. Both are handled.
+//!
+//! The accented argument is a single following character (`\'e` → é over `e`) or a braced
+//! group (`\'{...}`). Recognition recurses into groups, command arguments, and environment
+//! bodies, and `Node::Accent::to_latex` renders the braced form `\'{e}`, which re-recognizes
+//! to the same node — so `recognize_accents(parse(&n.to_latex())) == [n]` (AST-equality).
+//!
+//! Total and panic-free: an accent with no accent-able argument (e.g. at end of input, or
+//! before a space/structural node) is left as a plain command, never dropped or mis-folded.
+
+use crate::ast::Node;
+
+/// Is `name` a known text-accent control sequence (symbol or word spelling)?
+fn is_accent(name: &str) -> bool {
+    matches!(
+        name,
+        // control-symbol accents
+        "'" | "`" | "^" | "\"" | "~" | "=" | "."
+        // control-word accents (breve, caron, double-acute, cedilla, under-dot,
+        // under-bar, ring, tie)
+        | "u" | "v" | "H" | "c" | "d" | "b" | "r" | "t"
+    )
+}
+
+/// Fold accent control sequences in a document tree into [`Node::Accent`] nodes. The input is
+/// typically [`parse`](crate::parse) output (optionally already [`expand`](crate::expand)ed).
+pub fn recognize_accents(nodes: Vec<Node>) -> Vec<Node> {
+    let mut out: Vec<Node> = Vec::with_capacity(nodes.len());
+    let mut i = 0;
+    while i < nodes.len() {
+        match &nodes[i] {
+            Node::Command { name, optional, arguments } if optional.is_empty() && is_accent(name) => {
+                // Case A: the accent captured its argument as `{group}` (e.g. `\c{e}`).
+                if let Some(first) = arguments.first() {
+                    let arg = recognize_accents(first.clone());
+                    out.push(Node::Accent { accent: name.clone(), arg });
+                    // Any further captured groups were not part of the accent — keep them.
+                    for extra in arguments.iter().skip(1) {
+                        out.push(Node::Group(recognize_accents(extra.clone())));
+                    }
+                    i += 1;
+                    continue;
+                }
+                // Case B: no captured argument — pair with the immediately following node.
+                match nodes.get(i + 1) {
+                    Some(Node::Group(inner)) => {
+                        let arg = recognize_accents(inner.clone());
+                        out.push(Node::Accent { accent: name.clone(), arg });
+                        i += 2;
+                    }
+                    Some(Node::Text(t)) if !t.is_empty() => {
+                        // The accent applies to the first character; the rest stays as text.
+                        let mut chars = t.chars();
+                        let first = chars.next().expect("non-empty");
+                        let rest: String = chars.collect();
+                        out.push(Node::Accent {
+                            accent: name.clone(),
+                            arg: vec![Node::Text(first.to_string())],
+                        });
+                        if !rest.is_empty() {
+                            out.push(Node::Text(rest));
+                        }
+                        i += 2;
+                    }
+                    // Nothing accent-able follows — leave the command as-is.
+                    _ => {
+                        out.push(nodes[i].clone());
+                        i += 1;
+                    }
+                }
+            }
+            // Any other node: recurse into its child sequences, then keep it.
+            _ => {
+                out.push(recurse(nodes[i].clone()));
+                i += 1;
+            }
+        }
+    }
+    out
+}
+
+/// Recurse accent recognition into a node's child sequences without treating the node itself
+/// as an accent.
+fn recurse(node: Node) -> Node {
+    match node {
+        Node::Group(inner) => Node::Group(recognize_accents(inner)),
+        Node::Command { name, optional, arguments } => Node::Command {
+            name,
+            optional: optional.into_iter().map(recognize_accents).collect(),
+            arguments: arguments.into_iter().map(recognize_accents).collect(),
+        },
+        Node::Environment { name, optional, arguments, body } => Node::Environment {
+            name,
+            optional: optional.into_iter().map(recognize_accents).collect(),
+            arguments: arguments.into_iter().map(recognize_accents).collect(),
+            body: recognize_accents(body),
+        },
+        // leaves (Text, Space, Par, Math, Comment, Verb, VerbatimEnv, Active, Unsupported,
+        // and already-built Accent) carry no further accent structure to fold here
+        other => other,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{document_to_latex, parse};
+
+    /// Parse, recognize accents, and render back to LaTeX for easy assertions.
+    fn acc(src: &str) -> Vec<Node> {
+        recognize_accents(parse(src).expect("parse"))
+    }
+
+    /// The L5c round-trip: rendering a recognized tree and re-recognizing yields the same tree.
+    fn round_trips(src: &str) {
+        let a = acc(src);
+        let rendered = document_to_latex(&a);
+        let b = recognize_accents(parse(&rendered).expect("re-parse"));
+        assert_eq!(a, b, "accent round-trip: {src:?} -> {rendered:?}");
+    }
+
+    #[test]
+    fn control_symbol_accent_over_next_char() {
+        // \'e  → Accent("'", [e]), no leftover.
+        assert_eq!(
+            acc(r"\'e"),
+            vec![Node::Accent { accent: "'".into(), arg: vec![Node::Text("e".into())] }]
+        );
+    }
+
+    #[test]
+    fn accent_takes_only_first_char_rest_stays() {
+        // \~nada → Accent(~, [n]) then Text("ada").
+        assert_eq!(
+            acc(r"\~nada"),
+            vec![
+                Node::Accent { accent: "~".into(), arg: vec![Node::Text("n".into())] },
+                Node::Text("ada".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn braced_accent_argument() {
+        // \"{o} → Accent("\"", [o]).
+        assert_eq!(
+            acc(r#"\"{o}"#),
+            vec![Node::Accent { accent: "\"".into(), arg: vec![Node::Text("o".into())] }]
+        );
+    }
+
+    #[test]
+    fn control_word_accent_with_braced_arg() {
+        // \c{c} → Accent("c", [c]) (cedilla).
+        assert_eq!(
+            acc(r"\c{c}"),
+            vec![Node::Accent { accent: "c".into(), arg: vec![Node::Text("c".into())] }]
+        );
+    }
+
+    #[test]
+    fn control_word_accent_bare_arg() {
+        // \v s → lexer absorbs the space, so `s` is the next sibling → Accent("v", [s]).
+        assert_eq!(
+            acc(r"\v s"),
+            vec![Node::Accent { accent: "v".into(), arg: vec![Node::Text("s".into())] }]
+        );
+    }
+
+    #[test]
+    fn accent_inside_a_group_is_recognized() {
+        let n = acc(r"{\'e}");
+        match &n[0] {
+            Node::Group(inner) => assert!(matches!(inner[0], Node::Accent { .. })),
+            other => panic!("expected Group, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn non_accent_command_untouched() {
+        // \textbf{x} is not an accent.
+        assert_eq!(
+            acc(r"\textbf{x}"),
+            vec![Node::Command {
+                name: "textbf".into(),
+                optional: vec![],
+                arguments: vec![vec![Node::Text("x".into())]],
+            }]
+        );
+    }
+
+    #[test]
+    fn dangling_accent_left_as_command() {
+        // `\'` with nothing accent-able after it stays a plain command (no panic, no drop).
+        assert_eq!(
+            acc(r"\'"),
+            vec![Node::Command { name: "'".into(), optional: vec![], arguments: vec![] }]
+        );
+    }
+
+    #[test]
+    fn round_trips_cover_accents() {
+        for s in [r"\'e", r#"caf\'e"#, r#"\"o"#, r"\~n", r"\^o", r"\c{c}", r"\=e", r"\.z"] {
+            round_trips(s);
+        }
+    }
+}

--- a/code/specs/LTX01-full-latex-parser.md
+++ b/code/specs/LTX01-full-latex-parser.md
@@ -149,8 +149,10 @@ is text-primary, which is a different mode model.)
     read raw to the matching `\end` (catcodes suspended, newlines kept) → `Node::VerbatimEnv`,
     round-tripping; lexer peeks after `\begin` and only diverts for these env names; spanned
     error on unterminated/wrong close. Implemented in lexer.rs + parser.rs + ast.rs.
-  - **L5c (later) — text accents** (`\'e`, `\"o`, `\~n`, `\^o`, `\=`, `\u`, `\v`, `\c`, …)
-    recognized over the next char/group.
+  - **L5c (shipped) — text accents** (`\'e`, `\"o`, `\~n`, `\^o`, `\=`, `\.`, `\u`, `\v`, `\H`,
+    `\c`, `\d`, `\b`, `\r`, `\t`) recognized over the next char/group → `Node::Accent`, via the
+    opt-in `recognize_accents` pass (mirrors `expand`; L1 round-trip preserved); `to_latex`
+    re-recognizes either spelling. Implemented in text.rs + ast.rs.
   - **L5d (later) — sectioning/font recognition + cross-refs + preamble**: `\section`(+`*`),
     font/style commands, `\label`/`\ref`/`\cite`, `\documentclass`/`\usepackage` as
     recognized nodes (mostly classification over the generic Commands L1 already produces).


### PR DESCRIPTION
## LTX01 L5c — text accents

Adds text-accent recognition as a new **opt-in** pass, `recognize_accents` (a sibling of
`expand`). It folds an accent control sequence and the character it accents into a new
`Node::Accent { accent, arg }`. `parse` (L1) is unchanged, so its round-trip is preserved —
accents already *round-tripped* at L1; this adds the *semantic* recognition on demand.

### What's recognized

- **Control-symbol accents** `\'  \`  \^  \"  \~  \=  \.` — take no L1 argument, so they pair
  with the next node.
- **Control-word accents** `\u \v \H \c \d \b \r \t` — captured as `\c{e}`, or `\c e` where
  the lexer absorbed the inter-word space.

The argument is one following character (`\'e` → é over `e`; the rest of the run is kept as
text) or a braced group. Recurses into groups, command arguments, and environment bodies.
`Node::Accent::to_latex` renders the braced form `\'{e}`, so
`recognize_accents(parse(&n.to_latex())) == [n]` whether the source wrote `\'e` or `\'{e}`.

### Robustness

Total / panic-free: a dangling accent (nothing accent-able after it) is left as a plain
command — never dropped or mis-folded. No `unsafe`. The pass is O(input) and its recursion is
bounded by the L1 parse-depth cap (same pattern as the crate's other passes).

### Honest scope (L5c)

Sectioning/font/ref/preamble recognition (L5d) and the L6 math-frontend adapter remain. Spec
§5 L5 updated (L5c marked shipped).

### Tests

+9 (control-symbol over next char; first-char-only with remainder kept; braced arg;
control-word braced + bare; accent-in-group; non-accent untouched; dangling-accent; round-trip
corpus). **103 unit + 1 doc test** green; clippy `-D warnings` clean; no `unsafe`. Crate
0.7.0 → 0.8.0.

Security: `/security-review` ran on the diff (termination, recursion depth, index/char-boundary
panics, memory, overflow) and returned **PASSED — no vulnerabilities found**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)