### PR TITLE
feat(latex): document-structure recognition (LTX01 L5d)

### DIFF
--- a/code/packages/rust/latex/CHANGELOG.md
+++ b/code/packages/rust/latex/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 All notable changes to the full-fidelity LaTeX parser crate.
 
+## [0.9.0] — 2026-06-27
+
+### Added — LTX01 L5d: document-structure recognition
+
+- **`recognize_structure(Vec<Node>) -> Vec<Node>`** — a new, opt-in recognition pass (a sibling
+  of `expand` / `recognize_accents`) that classifies the *generic* `Node::Command`s produced by
+  `parse` (L1) into **semantic** structure nodes. `parse` (L1) is unchanged, so its round-trip
+  is preserved; run the pass, or don't.
+- Four new `Node` variants (+ a `SectionLevel` enum):
+  - **`Node::Section { level, starred, short, title }`** — `\part`/`\chapter`/`\section`/
+    `\subsection`/`\subsubsection`/`\paragraph`/`\subparagraph`, including the starred form
+    `\section*{T}` (the intervening `Text("*")` sibling is folded) and the optional short TOC
+    title `\section[Short]{Title}`.
+  - **`Node::CrossRef { command, note, target }`** — `\label`/`\ref`/`\eqref`/`\pageref`/
+    `\autoref`/`\nameref`/`\cite`/`\citep`/`\citet`, keeping the `\cite[note]{key}` optional.
+  - **`Node::Preamble { command, options, name }`** — `\documentclass`/`\usepackage`/
+    `\RequirePackage` with their `[options]`.
+  - **`Node::Styled { command, content }`** — argument-form text font commands (`\textbf`,
+    `\textit`, `\texttt`, `\emph`, `\underline`, …). Font *declarations* (`\bfseries`,
+    `\itshape`, …) stay plain `Command`s — their effect is positional, not a wrapped argument.
+- **`to_latex`** renders each recognized node back to the exact shape the pass folds, so
+  `recognize_structure(parse(&n.to_latex())) == [n]`. The pass recurses into groups, command
+  arguments, environment bodies, and the parts of already-recognized nodes, so it is idempotent
+  and composes with itself.
+- Total / panic-free: a command that does not match its expected shape (a sectioning command
+  with no title, a cross-ref with no key, a styled command with the wrong argument count) is
+  left as a plain `Command`, never dropped or mis-folded. Recursion is bounded by the L1 tree
+  depth (`MAX_DEPTH`). No `unsafe`; no `MAX_DEPTH` change (Node size still dominated by
+  `Environment`).
+- +14 tests (plain/starred/short sectioning, all seven levels, title-less command left alone,
+  cross-refs, citation note, preamble, styled, declaration-stays-command, recursion into
+  titles, surrounding text preserved, idempotence, round-trip corpus). **117 unit + 1 doc
+  test** green; clippy `-D warnings` clean. Crate 0.8.0 → 0.9.0.
+
 ## [0.8.0] — 2026-06-27
 
 ### Added — LTX01 L5c: text accents

--- a/code/packages/rust/latex/Cargo.toml
+++ b/code/packages/rust/latex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latex"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 description = "A full-fidelity LaTeX parser (documents and math): a catcode-driven, text-mode-primary tokenizer and (in later layers) a structural + math parser producing a faithful AST. Standalone and reusable; will also implement the math-frontend MathFrontend trait."
 license = "MIT"

--- a/code/packages/rust/latex/README.md
+++ b/code/packages/rust/latex/README.md
@@ -35,7 +35,7 @@ with a **text-mode-primary** mode stack (LaTeX starts in text mode; math is ente
 | **L2 math** | math AST (frac, binom, roots, scripts, big ops, functions, accents, `\left\right` fences, relations), precedence-climbing parser, `to_latex()` round-trip | ✅ |
 | **L3 environments** | math env family — `matrix`/`pmatrix`/`bmatrix`/`vmatrix`/`cases`/`aligned`/`align` split on `&` and `\\` → `MathNode::Matrix`, round-trip; nesting + scripts | ✅ |
 | **L4 macros** | `\newcommand`/`\renewcommand`/`\providecommand` with positional `#1`..`#9`; bounded recursive expansion via `expand()` (L4a) | ✅ |
-| **L5 text breadth** | `\verb`/`verbatim` raw (L5a/b) + text accents `\'e`/`\c{c}` via `recognize_accents` (L5c); sectioning/refs to follow | 🚧 this release (L5c) |
+| **L5 text breadth** | `\verb`/`verbatim` raw (L5a/b) + text accents `\'e`/`\c{c}` via `recognize_accents` (L5c) + sectioning/refs/preamble/font via `recognize_structure` (L5d) | ✅ |
 | L6 frontend | implement `math-frontend::MathFrontend` (LaTeX becomes plugin #1) | ⏳ |
 
 ## Usage
@@ -155,8 +155,40 @@ assert!(matches!(doc[1], Node::Accent { .. }));   // é over `e`; "caf" stays te
 ```
 
 Recognized: `\'  \`  \^  \"  \~  \=  \.` and `\u \v \H \c \d \b \r \t`. A dangling accent (no
-accent-able char after it) is left as a plain command — never dropped. (Sectioning and
-cross-refs arrive in later L5 sub-rungs.)
+accent-able char after it) is left as a plain command — never dropped.
+
+### Document structure (L5d)
+
+`recognize_structure` is the second opt-in classification pass (like `recognize_accents`). It
+turns the *generic* commands L1 produces into **semantic** structure nodes — headings,
+cross-references, preamble directives, and argument-form font commands — while leaving L1's
+round-trip intact:
+
+```rust
+use latex::{parse, recognize_structure, Node, SectionLevel};
+
+let doc = recognize_structure(parse(r"\section*{Intro} see \ref{fig:1}").unwrap());
+assert!(matches!(doc[0], Node::Section { level: SectionLevel::Section, starred: true, .. }));
+assert!(doc.iter().any(|n| matches!(n, Node::CrossRef { .. })));   // \ref{fig:1}
+```
+
+Recognized:
+
+- **`Node::Section`** — `\part`/`\chapter`/`\section`/`\subsection`/`\subsubsection`/
+  `\paragraph`/`\subparagraph`, the starred `\section*{…}` form (the `*` sibling is folded),
+  and the optional short TOC title `\section[Short]{Title}`;
+- **`Node::CrossRef`** — `\label`/`\ref`/`\eqref`/`\pageref`/`\autoref`/`\nameref`/`\cite`/
+  `\citep`/`\citet` (the `\cite[note]{key}` optional is kept);
+- **`Node::Preamble`** — `\documentclass`/`\usepackage`/`\RequirePackage` with `[options]`;
+- **`Node::Styled`** — argument-form font commands (`\textbf`, `\textit`, `\texttt`, `\emph`,
+  `\underline`, …).
+
+A command that does not match its expected shape (a sectioning command with no title, a
+cross-ref with no key) is left as a plain command — never dropped or mis-folded. Font
+*declarations* (`\bfseries`, `\itshape`, `\large`, …) also stay plain commands: their effect is
+positional (until end of group), so wrapping them in an argument node would misrepresent them.
+The pass is idempotent and round-trips: `recognize_structure(parse(&n.to_latex())) == [n]`.
+(The two passes — `recognize_accents` and `recognize_structure` — are independent and compose.)
 
 The low-level `tokenize` is also public. Tokens and errors carry half-open byte `Span`s;
 all of `parse`, `parse_math`, and `tokenize` return spanned errors rather than panicking,

--- a/code/packages/rust/latex/src/ast.rs
+++ b/code/packages/rust/latex/src/ast.rs
@@ -10,6 +10,43 @@
 //! `parse(&render(ast)) == ast` (AST-equality, not byte-equality — surface spacing and the
 //! `$…$` vs `\(…\)` delimiter choice are normalized).
 
+/// A sectioning level, in document-hierarchy order from coarsest (`\part`) to finest
+/// (`\subparagraph`). Produced by the L5d [`recognize_structure`](crate::recognize_structure)
+/// pass as part of [`Node::Section`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SectionLevel {
+    /// `\part`
+    Part,
+    /// `\chapter`
+    Chapter,
+    /// `\section`
+    Section,
+    /// `\subsection`
+    Subsection,
+    /// `\subsubsection`
+    Subsubsection,
+    /// `\paragraph` (a run-in heading, *not* a paragraph break — see [`Node::Par`])
+    Paragraph,
+    /// `\subparagraph`
+    Subparagraph,
+}
+
+impl SectionLevel {
+    /// The LaTeX control word for this level (without the leading backslash), used to render a
+    /// [`Node::Section`] back to source.
+    pub fn command(self) -> &'static str {
+        match self {
+            SectionLevel::Part => "part",
+            SectionLevel::Chapter => "chapter",
+            SectionLevel::Section => "section",
+            SectionLevel::Subsection => "subsection",
+            SectionLevel::Subsubsection => "subsubsection",
+            SectionLevel::Paragraph => "paragraph",
+            SectionLevel::Subparagraph => "subparagraph",
+        }
+    }
+}
+
 /// One node of the document tree.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Node {
@@ -54,6 +91,27 @@ pub enum Node {
     /// (a single-character text run, or a braced group's nodes). Produced only by the opt-in
     /// [`recognize_accents`](crate::recognize_accents) pass, not by L1.
     Accent { accent: String, arg: Vec<Node> },
+    /// A sectioning heading (L5d): `\section{Title}`, `\section*{Title}`, `\section[Short]{Title}`
+    /// (and the `\part`…`\subparagraph` family). `starred` is the no-number `*` form; `short` is
+    /// the optional TOC/running-head title; `title` is the heading body. Produced only by the
+    /// opt-in [`recognize_structure`](crate::recognize_structure) pass, not by L1.
+    Section { level: SectionLevel, starred: bool, short: Option<Vec<Node>>, title: Vec<Node> },
+    /// A cross-reference or citation (L5d): `\label{k}`, `\ref{k}`, `\eqref{k}`, `\cite[note]{k}`,
+    /// … `command` is the control-word verbatim; `note` is the optional bracketed argument (the
+    /// citation note); `target` is the mandatory key argument. Produced only by the opt-in
+    /// [`recognize_structure`](crate::recognize_structure) pass, not by L1.
+    CrossRef { command: String, note: Option<Vec<Node>>, target: Vec<Node> },
+    /// A preamble directive (L5d): `\documentclass[opt]{article}`, `\usepackage[opt]{pkg}`,
+    /// `\RequirePackage{pkg}`. `command` is the control-word verbatim; `options` is the optional
+    /// bracketed package/class options; `name` is the mandatory class/package name. Produced only
+    /// by the opt-in [`recognize_structure`](crate::recognize_structure) pass, not by L1.
+    Preamble { command: String, options: Option<Vec<Node>>, name: Vec<Node> },
+    /// An argument-form text font command (L5d): `\textbf{x}`, `\emph{x}`, `\underline{x}`, …
+    /// `command` is the control-word verbatim; `content` is the wrapped argument. (Declaration-
+    /// form font commands like `\bfseries` stay plain [`Node::Command`]s — their effect is
+    /// positional, not a wrapped argument.) Produced only by the opt-in
+    /// [`recognize_structure`](crate::recognize_structure) pass, not by L1.
+    Styled { command: String, content: Vec<Node> },
     /// An active character that acts like a command — `~`.
     Active(char),
     /// A construct deliberately out of scope (the TeX-programmability asymptote — e.g.
@@ -166,6 +224,54 @@ impl Node {
                 out.push_str(accent);
                 out.push('{');
                 render_seq(arg, out);
+                out.push('}');
+            }
+            Node::Section { level, starred, short, title } => {
+                // `\section` (+ `*` if starred) (+ `[short]` if present) `{title}`. Renders back
+                // to the exact shape `recognize_structure` folds, so it re-recognizes equal.
+                out.push('\\');
+                out.push_str(level.command());
+                if *starred {
+                    out.push('*');
+                }
+                if let Some(short) = short {
+                    out.push('[');
+                    render_seq(short, out);
+                    out.push(']');
+                }
+                out.push('{');
+                render_seq(title, out);
+                out.push('}');
+            }
+            Node::CrossRef { command, note, target } => {
+                out.push('\\');
+                out.push_str(command);
+                if let Some(note) = note {
+                    out.push('[');
+                    render_seq(note, out);
+                    out.push(']');
+                }
+                out.push('{');
+                render_seq(target, out);
+                out.push('}');
+            }
+            Node::Preamble { command, options, name } => {
+                out.push('\\');
+                out.push_str(command);
+                if let Some(options) = options {
+                    out.push('[');
+                    render_seq(options, out);
+                    out.push(']');
+                }
+                out.push('{');
+                render_seq(name, out);
+                out.push('}');
+            }
+            Node::Styled { command, content } => {
+                out.push('\\');
+                out.push_str(command);
+                out.push('{');
+                render_seq(content, out);
                 out.push('}');
             }
             Node::Active(c) => out.push(*c),

--- a/code/packages/rust/latex/src/lib.rs
+++ b/code/packages/rust/latex/src/lib.rs
@@ -34,7 +34,11 @@
 //!    environment ([`Node::VerbatimEnv`]) read their bodies **raw** (catcodes suspended).
 //!    **Implemented (L5a/L5b).**
 //! 6. [`recognize_accents`] — an opt-in pass folding text accents (`\'e`, `\c{c}`) into
-//!    [`Node::Accent`]. **Implemented (L5c).** Sectioning and refs are later L5 sub-rungs.
+//!    [`Node::Accent`]. **Implemented (L5c).**
+//! 7. [`recognize_structure`] — an opt-in pass classifying generic commands into structure
+//!    nodes: sectioning ([`Node::Section`]), cross-refs/citations ([`Node::CrossRef`]),
+//!    preamble directives ([`Node::Preamble`]), and argument-form font commands
+//!    ([`Node::Styled`]). **Implemented (L5d).**
 //!
 //! ## Example
 //!
@@ -58,15 +62,17 @@ mod lexer;
 mod macros;
 mod math;
 mod parser;
+mod structure;
 mod text;
 mod token;
 
-pub use ast::{document_to_latex, Node};
+pub use ast::{document_to_latex, Node, SectionLevel};
 pub use catcode::{catcode, Catcode};
 pub use error::{LexError, ParseError};
 pub use lexer::tokenize;
 pub use macros::expand;
 pub use math::{parse_math, MBinOp, MRelOp, MUnOp, MathNode};
 pub use parser::parse;
+pub use structure::recognize_structure;
 pub use text::recognize_accents;
 pub use token::{Span, Token, TokenKind};

--- a/code/packages/rust/latex/src/structure.rs
+++ b/code/packages/rust/latex/src/structure.rs
@@ -1,0 +1,453 @@
+//! Document structure recognition (L5d) — an opt-in pass that classifies the *generic*
+//! command nodes [`parse`](crate::parse) (L1) produces into **semantic** structure nodes:
+//! sectioning, cross-references, preamble directives, and argument-form font commands.
+//!
+//! ## Why a separate pass
+//!
+//! Just like [`expand`](crate::expand) (macros) and [`recognize_accents`](crate::recognize_accents)
+//! (accents), L1 already *round-trips* every one of these — `\section{Intro}` lexes to a
+//! generic [`Node::Command`] and renders straight back. What L1 deliberately does **not** do
+//! is say "this is a level-2 heading titled *Intro*", or "this is a citation of key *foo*".
+//! This pass adds that **semantic** recognition on demand, so L1's own structure and
+//! round-trip stay untouched (run it, or don't — the L1 tree is unchanged either way).
+//!
+//! ## What it recognizes
+//!
+//! | Source | Recognized node |
+//! |--------|-----------------|
+//! | `\section{T}`, `\section*{T}`, `\section[s]{T}` (+ the `\part`…`\subparagraph` family) | [`Node::Section`] |
+//! | `\label{k}`, `\ref{k}`, `\eqref{k}`, `\cite[note]{k}`, … | [`Node::CrossRef`] |
+//! | `\documentclass[opt]{article}`, `\usepackage[opt]{amsmath}`, `\RequirePackage{…}` | [`Node::Preamble`] |
+//! | `\textbf{x}`, `\emph{x}`, `\underline{x}`, … (argument-form font cmds) | [`Node::Styled`] |
+//!
+//! ## The starred-form subtlety
+//!
+//! `\section{T}` captures its `{T}` as the command's argument at L1, so we read the title
+//! straight off the command. But in `\section*{T}` the `*` (an *other* character) sits between
+//! the control word and the brace, so L1 captures **no** argument — the tree is
+//! `[Command("section"), Text("*"), Group([T])]`. This pass folds that `Text("*")` sibling and
+//! the following group into one starred [`Node::Section`]. (Standard starred sections take no
+//! optional TOC title, so the starred branch never carries `short`.)
+//!
+//! ## Totality
+//!
+//! Every branch either folds a well-formed construct or leaves the original command untouched
+//! (recursing into its children) — a sectioning command with no title, a cross-ref with no
+//! key, a styled command with the wrong argument count are all left as plain commands. Nothing
+//! is dropped, nothing panics. Recursion is bounded by the tree depth, which the L1 parser
+//! already caps (`MAX_DEPTH`), so adversarial nesting cannot overflow here.
+//!
+//! ## Font *declarations* stay plain
+//!
+//! Only the **argument-form** font commands (`\textbf{…}`) become [`Node::Styled`]. The
+//! *declaration* forms (`\bfseries`, `\itshape`, `\large`, …) are intentionally **not**
+//! recognized: their effect runs from the declaration to the end of the enclosing group, so
+//! they have no single wrapped argument — modeling them as an argument node would misrepresent
+//! their scope. They round-trip fine as plain commands.
+
+use crate::ast::{Node, SectionLevel};
+
+/// Map a sectioning control word to its [`SectionLevel`], or `None` if `name` is not a
+/// sectioning command.
+fn section_level(name: &str) -> Option<SectionLevel> {
+    Some(match name {
+        "part" => SectionLevel::Part,
+        "chapter" => SectionLevel::Chapter,
+        "section" => SectionLevel::Section,
+        "subsection" => SectionLevel::Subsection,
+        "subsubsection" => SectionLevel::Subsubsection,
+        "paragraph" => SectionLevel::Paragraph,
+        "subparagraph" => SectionLevel::Subparagraph,
+        _ => return None,
+    })
+}
+
+/// Is `name` a cross-reference / citation command (one mandatory key argument, optional note)?
+fn is_crossref(name: &str) -> bool {
+    matches!(
+        name,
+        "label" | "ref" | "eqref" | "pageref" | "autoref" | "nameref" | "cite" | "citep" | "citet"
+    )
+}
+
+/// Is `name` a preamble directive (`[options]` + one mandatory name argument)?
+fn is_preamble(name: &str) -> bool {
+    matches!(name, "documentclass" | "usepackage" | "RequirePackage")
+}
+
+/// Is `name` an **argument-form** text font command (wraps exactly one mandatory argument)?
+fn is_style(name: &str) -> bool {
+    matches!(
+        name,
+        "textbf"
+            | "textit"
+            | "texttt"
+            | "textrm"
+            | "textsf"
+            | "textsc"
+            | "textsl"
+            | "textmd"
+            | "textup"
+            | "textnormal"
+            | "emph"
+            | "underline"
+    )
+}
+
+/// Recognize document-structure commands in `nodes` into semantic [`Node`]s. The input is
+/// typically [`parse`](crate::parse) output (optionally already [`expand`](crate::expand)ed or
+/// [`recognize_accents`](crate::recognize_accents)-folded — the passes are independent).
+pub fn recognize_structure(nodes: Vec<Node>) -> Vec<Node> {
+    let mut out: Vec<Node> = Vec::with_capacity(nodes.len());
+    let mut i = 0;
+    while i < nodes.len() {
+        if let Node::Command { name, optional, arguments } = &nodes[i] {
+            // --- Sectioning: \section{T} / \section*{T} / \section[s]{T} -------------------
+            if let Some(level) = section_level(name) {
+                if let Some(first) = arguments.first() {
+                    // Captured-argument form (no `*` intervened): \section[short]{title}.
+                    let short = optional.first().map(|o| recognize_structure(o.clone()));
+                    let title = recognize_structure(first.clone());
+                    out.push(Node::Section { level, starred: false, short, title });
+                    // Any further captured groups were not part of the heading — keep them.
+                    for extra in arguments.iter().skip(1) {
+                        out.push(Node::Group(recognize_structure(extra.clone())));
+                    }
+                    i += 1;
+                    continue;
+                }
+                // No captured argument: try the starred form `\section*{title}`.
+                if optional.is_empty() {
+                    if let Some(title) = starred_title(&nodes, i) {
+                        out.push(Node::Section { level, starred: true, short: None, title });
+                        i += 3; // command + Text("*") + Group
+                        continue;
+                    }
+                }
+                // Not a well-formed heading — leave the command as-is.
+                out.push(recurse(nodes[i].clone()));
+                i += 1;
+                continue;
+            }
+
+            // --- Cross-references / citations: \ref{k}, \cite[note]{k} --------------------
+            if is_crossref(name) {
+                if let Some(first) = arguments.first() {
+                    let note = optional.first().map(|o| recognize_structure(o.clone()));
+                    let target = recognize_structure(first.clone());
+                    out.push(Node::CrossRef { command: name.clone(), note, target });
+                    for extra in arguments.iter().skip(1) {
+                        out.push(Node::Group(recognize_structure(extra.clone())));
+                    }
+                    i += 1;
+                    continue;
+                }
+                out.push(recurse(nodes[i].clone()));
+                i += 1;
+                continue;
+            }
+
+            // --- Preamble: \documentclass[opt]{cls}, \usepackage[opt]{pkg} ----------------
+            if is_preamble(name) {
+                if let Some(first) = arguments.first() {
+                    let options = optional.first().map(|o| recognize_structure(o.clone()));
+                    let name_arg = recognize_structure(first.clone());
+                    out.push(Node::Preamble { command: name.clone(), options, name: name_arg });
+                    for extra in arguments.iter().skip(1) {
+                        out.push(Node::Group(recognize_structure(extra.clone())));
+                    }
+                    i += 1;
+                    continue;
+                }
+                out.push(recurse(nodes[i].clone()));
+                i += 1;
+                continue;
+            }
+
+            // --- Argument-form font commands: \textbf{x}, \emph{x} -----------------------
+            if is_style(name) && optional.is_empty() && arguments.len() == 1 {
+                let content = recognize_structure(arguments[0].clone());
+                out.push(Node::Styled { command: name.clone(), content });
+                i += 1;
+                continue;
+            }
+        }
+
+        // Any other node (or a command that did not match): recurse into its children.
+        out.push(recurse(nodes[i].clone()));
+        i += 1;
+    }
+    out
+}
+
+/// If `nodes[i+1]` is exactly `Text("*")` and `nodes[i+2]` is a group, return the recognized
+/// group as the starred heading's title; otherwise `None` (so the caller leaves the command
+/// untouched). Only the canonical `\section*{title}` shape folds — unusual spacings such as
+/// `\section* foo` are deliberately left alone, since they round-trip fine as plain nodes.
+fn starred_title(nodes: &[Node], i: usize) -> Option<Vec<Node>> {
+    match nodes.get(i + 1) {
+        Some(Node::Text(star)) if star == "*" => match nodes.get(i + 2) {
+            Some(Node::Group(inner)) => Some(recognize_structure(inner.clone())),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+/// Recurse structure recognition into a node's child sequences without treating the node
+/// itself as a structure command (mirrors `text::recurse`).
+fn recurse(node: Node) -> Node {
+    match node {
+        Node::Group(inner) => Node::Group(recognize_structure(inner)),
+        Node::Command { name, optional, arguments } => Node::Command {
+            name,
+            optional: optional.into_iter().map(recognize_structure).collect(),
+            arguments: arguments.into_iter().map(recognize_structure).collect(),
+        },
+        Node::Environment { name, optional, arguments, body } => Node::Environment {
+            name,
+            optional: optional.into_iter().map(recognize_structure).collect(),
+            arguments: arguments.into_iter().map(recognize_structure).collect(),
+            body: recognize_structure(body),
+        },
+        // Recurse into the parts of already-recognized structure nodes too, so the pass is
+        // idempotent and composes with itself (e.g. a section title containing a `\ref`).
+        Node::Section { level, starred, short, title } => Node::Section {
+            level,
+            starred,
+            short: short.map(recognize_structure),
+            title: recognize_structure(title),
+        },
+        Node::CrossRef { command, note, target } => Node::CrossRef {
+            command,
+            note: note.map(recognize_structure),
+            target: recognize_structure(target),
+        },
+        Node::Preamble { command, options, name } => Node::Preamble {
+            command,
+            options: options.map(recognize_structure),
+            name: recognize_structure(name),
+        },
+        Node::Styled { command, content } => Node::Styled {
+            command,
+            content: recognize_structure(content),
+        },
+        // leaves (Text, Space, Par, Math, Comment, Verb, VerbatimEnv, Accent, Active,
+        // Unsupported) carry no further structure to fold here
+        other => other,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{document_to_latex, parse};
+
+    /// Parse and recognize structure, for concise assertions.
+    fn st(src: &str) -> Vec<Node> {
+        recognize_structure(parse(src).expect("parse"))
+    }
+
+    /// The L5d round-trip: rendering a recognized tree and re-recognizing yields the same tree.
+    fn round_trips(src: &str) {
+        let a = st(src);
+        let rendered = document_to_latex(&a);
+        let b = recognize_structure(parse(&rendered).expect("re-parse"));
+        assert_eq!(a, b, "structure round-trip: {src:?} -> {rendered:?}");
+    }
+
+    #[test]
+    fn plain_section() {
+        assert_eq!(
+            st(r"\section{Intro}"),
+            vec![Node::Section {
+                level: SectionLevel::Section,
+                starred: false,
+                short: None,
+                title: vec![Node::Text("Intro".into())],
+            }]
+        );
+    }
+
+    #[test]
+    fn starred_section_folds_the_star() {
+        // \section*{Intro} → starred heading; the intervening Text("*") is consumed.
+        assert_eq!(
+            st(r"\section*{Intro}"),
+            vec![Node::Section {
+                level: SectionLevel::Section,
+                starred: true,
+                short: None,
+                title: vec![Node::Text("Intro".into())],
+            }]
+        );
+    }
+
+    #[test]
+    fn section_with_short_toc_title() {
+        // \section[Intro]{Introduction} → optional short TOC title preserved.
+        assert_eq!(
+            st(r"\section[Intro]{Introduction}"),
+            vec![Node::Section {
+                level: SectionLevel::Section,
+                starred: false,
+                short: Some(vec![Node::Text("Intro".into())]),
+                title: vec![Node::Text("Introduction".into())],
+            }]
+        );
+    }
+
+    #[test]
+    fn all_seven_levels_recognized() {
+        let cases = [
+            (r"\part{a}", SectionLevel::Part),
+            (r"\chapter{a}", SectionLevel::Chapter),
+            (r"\section{a}", SectionLevel::Section),
+            (r"\subsection{a}", SectionLevel::Subsection),
+            (r"\subsubsection{a}", SectionLevel::Subsubsection),
+            (r"\paragraph{a}", SectionLevel::Paragraph),
+            (r"\subparagraph{a}", SectionLevel::Subparagraph),
+        ];
+        for (src, level) in cases {
+            match &st(src)[0] {
+                Node::Section { level: got, .. } => assert_eq!(*got, level, "{src}"),
+                other => panic!("expected Section for {src}, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn section_without_title_stays_command() {
+        // A bare `\section` (nothing accent-able / no title) is left untouched.
+        assert_eq!(
+            st(r"\section"),
+            vec![Node::Command { name: "section".into(), optional: vec![], arguments: vec![] }]
+        );
+    }
+
+    #[test]
+    fn cross_references() {
+        assert_eq!(
+            st(r"\label{eq:1}"),
+            vec![Node::CrossRef {
+                command: "label".into(),
+                note: None,
+                target: vec![Node::Text("eq:1".into())],
+            }]
+        );
+        assert_eq!(
+            st(r"\ref{eq:1}"),
+            vec![Node::CrossRef {
+                command: "ref".into(),
+                note: None,
+                target: vec![Node::Text("eq:1".into())],
+            }]
+        );
+    }
+
+    #[test]
+    fn citation_with_note() {
+        // \cite[p.~5]{foo} keeps the optional note.
+        match &st(r"\cite[p]{foo}")[0] {
+            Node::CrossRef { command, note, target } => {
+                assert_eq!(command, "cite");
+                assert_eq!(note, &Some(vec![Node::Text("p".into())]));
+                assert_eq!(target, &vec![Node::Text("foo".into())]);
+            }
+            other => panic!("expected CrossRef, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn preamble_directives() {
+        assert_eq!(
+            st(r"\documentclass[a4paper]{article}"),
+            vec![Node::Preamble {
+                command: "documentclass".into(),
+                options: Some(vec![Node::Text("a4paper".into())]),
+                name: vec![Node::Text("article".into())],
+            }]
+        );
+        assert_eq!(
+            st(r"\usepackage{amsmath}"),
+            vec![Node::Preamble {
+                command: "usepackage".into(),
+                options: None,
+                name: vec![Node::Text("amsmath".into())],
+            }]
+        );
+    }
+
+    #[test]
+    fn styled_font_commands() {
+        assert_eq!(
+            st(r"\textbf{bold}"),
+            vec![Node::Styled {
+                command: "textbf".into(),
+                content: vec![Node::Text("bold".into())],
+            }]
+        );
+        assert_eq!(
+            st(r"\emph{x}"),
+            vec![Node::Styled { command: "emph".into(), content: vec![Node::Text("x".into())] }]
+        );
+    }
+
+    #[test]
+    fn font_declaration_stays_command() {
+        // \bfseries is a declaration (no wrapped argument) — left as a plain command.
+        assert_eq!(
+            st(r"\bfseries"),
+            vec![Node::Command { name: "bfseries".into(), optional: vec![], arguments: vec![] }]
+        );
+    }
+
+    #[test]
+    fn recognition_recurses_into_groups_and_titles() {
+        // A \ref inside a section title is itself recognized.
+        match &st(r"\section{see \ref{x}}")[0] {
+            Node::Section { title, .. } => {
+                assert!(title.iter().any(|n| matches!(n, Node::CrossRef { .. })));
+            }
+            other => panic!("expected Section, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn surrounding_text_is_preserved() {
+        // Heading then a paragraph: the text after the heading stays put.
+        let nodes = st("\\section{Intro}\nhello");
+        assert!(matches!(nodes[0], Node::Section { .. }));
+        assert!(nodes.iter().any(|n| matches!(n, Node::Text(t) if t.contains("hello"))));
+    }
+
+    #[test]
+    fn idempotent() {
+        // Running the pass twice changes nothing.
+        let once = st(r"\section*{Intro} \textbf{x} \cite[p]{k}");
+        let twice = recognize_structure(once.clone());
+        assert_eq!(once, twice);
+    }
+
+    #[test]
+    fn round_trips_cover_structure() {
+        for s in [
+            r"\section{Intro}",
+            r"\section*{Intro}",
+            r"\subsection[Short]{Long title}",
+            r"\chapter{One}",
+            r"\label{eq:1}",
+            r"\ref{fig:2}",
+            r"\eqref{e}",
+            r"\cite{foo}",
+            r"\cite[p]{foo}",
+            r"\documentclass[a4paper]{article}",
+            r"\usepackage{amsmath}",
+            r"\textbf{bold}",
+            r"\emph{x}",
+            r"\underline{y}",
+        ] {
+            round_trips(s);
+        }
+    }
+}

--- a/code/specs/LTX01-full-latex-parser.md
+++ b/code/specs/LTX01-full-latex-parser.md
@@ -153,9 +153,27 @@ is text-primary, which is a different mode model.)
     `\c`, `\d`, `\b`, `\r`, `\t`) recognized over the next char/group → `Node::Accent`, via the
     opt-in `recognize_accents` pass (mirrors `expand`; L1 round-trip preserved); `to_latex`
     re-recognizes either spelling. Implemented in text.rs + ast.rs.
-  - **L5d (later) — sectioning/font recognition + cross-refs + preamble**: `\section`(+`*`),
-    font/style commands, `\label`/`\ref`/`\cite`, `\documentclass`/`\usepackage` as
-    recognized nodes (mostly classification over the generic Commands L1 already produces).
+  - **L5d (shipped) — sectioning/font recognition + cross-refs + preamble.** The opt-in
+    `recognize_structure` pass (mirrors `recognize_accents`/`expand`; L1 round-trip preserved)
+    classifies the generic `Command` nodes L1 already produces into semantic nodes:
+    - `Node::Section { level, starred, short, title }` — `\part`/`\chapter`/`\section`/
+      `\subsection`/`\subsubsection`/`\paragraph`/`\subparagraph`, the starred form
+      (`\section*{T}` — the intervening `Text("*")` sibling is folded), and the optional short
+      TOC title (`\section[short]{Title}`);
+    - `Node::CrossRef { command, note, target }` — `\label`/`\ref`/`\eqref`/`\pageref`/
+      `\autoref`/`\nameref`/`\cite`/`\citep`/`\citet` (the `\cite[note]{key}` optional kept);
+    - `Node::Preamble { command, options, name }` — `\documentclass`/`\usepackage`/
+      `\RequirePackage` with their `[options]`;
+    - `Node::Styled { command, content }` — the argument-form text font commands
+      (`\textbf`/`\textit`/`\texttt`/`\emph`/`\underline`/…).
+
+    A command that does not match its expected shape (a sectioning command with no title, a
+    cross-ref with no key, …) is left as a plain `Command` — never dropped or mis-folded. Font
+    *declarations* (`\bfseries`, `\itshape`, `\large`, …) stay plain commands: their effect is
+    positional (until end of group), so wrapping them in an argument node would misrepresent
+    them. `to_latex` re-renders each recognized node to a form that re-recognizes to the same
+    node, so `recognize_structure(parse(&n.to_latex())) == [n]`. Implemented in structure.rs +
+    ast.rs.
 - **L6 — `math-frontend` adapter.** Implement `MathFrontend` for `latex`: lift `Math`/`MathNode`
   subtrees to the neutral `MathExpr`; declare capabilities; register in the builtin registry.
   (This is where LaTeX becomes a *plugin*; [PFE01](PFE01-pluggable-parser-frontends.md)'s


### PR DESCRIPTION
## LTX01 L5d — document-structure recognition

The next rung of the full-fidelity LaTeX parser ladder. Adds **`recognize_structure`**, an opt-in pass (a sibling of `expand` and `recognize_accents`) that classifies the *generic* `Node::Command`s produced by L1 into **semantic** structure nodes — leaving L1's own tree and `to_latex` round-trip completely untouched (run the pass, or don't).

### What it recognizes

| Source | Recognized node |
|--------|-----------------|
| `\section{T}`, `\section*{T}`, `\section[s]{T}` (+ `\part`…`\subparagraph`) | `Node::Section { level, starred, short, title }` |
| `\label{k}`, `\ref{k}`, `\eqref{k}`, `\cite[note]{k}`, … | `Node::CrossRef { command, note, target }` |
| `\documentclass[opt]{article}`, `\usepackage[opt]{pkg}`, `\RequirePackage{…}` | `Node::Preamble { command, options, name }` |
| `\textbf{x}`, `\emph{x}`, `\underline{x}`, … (argument-form font cmds) | `Node::Styled { command, content }` |

### Design notes

- **Starred-form folding:** `\section*{T}` captures *no* argument at L1 (the `*` is an *other* char that sits between the control word and the brace), so L1 yields `[Command("section"), Text("*"), Group([T])]`. The pass folds that `Text("*")` sibling and the following group into one starred `Section`.
- **Totality:** a command that doesn't match its expected shape (a sectioning command with no title, a cross-ref with no key, a styled command with the wrong arg count) is left as a plain `Command` — never dropped or mis-folded.
- **Font declarations stay plain:** only *argument-form* font commands become `Styled`. Declaration forms (`\bfseries`, `\itshape`, …) stay plain `Command`s — their effect is positional (until end of group), so wrapping them in an argument node would misrepresent them.
- **Round-trip + idempotent:** `to_latex` re-renders each recognized node to the exact shape the pass folds, so `recognize_structure(parse(&n.to_latex())) == [n]`; the pass also recurses into already-recognized nodes, so it's idempotent and composes with `recognize_accents`.
- **No `MAX_DEPTH` change:** recursion is bounded by the L1 tree depth; `Node`'s size is still dominated by `Environment`'s four `Vec`s, so frames don't grow. No `unsafe`.

### Verification

- **117 unit + 1 doc test** green (+14 new); `cargo clippy -p latex --all-targets -- -D warnings` clean.
- Security review (DoS/panic focus — termination, recursion depth, indexing/overflow, memory amplification) **PASSED**.
- Spec `code/specs/LTX01-full-latex-parser.md` §5 L5d marked shipped.

Crate `0.8.0 → 0.9.0`. Ladder: L0–L5d ✅ → **L6** (the `math-frontend` adapter capstone) remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)