### PR TITLE
feat(math-frontend): neutral AST for ± / ∓ and binomials

### DIFF
--- a/code/packages/rust/math-frontend/CHANGELOG.md
+++ b/code/packages/rust/math-frontend/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to the pluggable parser-frontend framework.
 
+## [0.2.0] — 2026-06-27
+
+### Added — neutral-AST coverage for ± / ∓ and binomials
+
+Closes the two honest gaps the LaTeX frontend (LTX01 L6) had to error on because the neutral
+AST could not represent them:
+
+- **`BinOp::PlusMinus` / `BinOp::MinusPlus`** — the `±` / `∓` operators (`a ± b` denotes the
+  pair {a+b, a−b}; `∓` the opposite pairing). Meaning-bearing binary operators, not
+  presentation.
+- **`MathExpr::Binom(n, k)`** — a binomial coefficient "n choose k", distinct from `Frac`
+  (no division bar).
+- **`Capabilities`** gains `plusminus` and `binomials` flags (set by `all()` and the new
+  `with_plusminus()` / `with_binomials()` builders); the conformance harness's
+  `collect_used`/`over_emitted` now detect and police both, so a frontend emitting ± or a
+  binomial without declaring it is flagged (verified by new over-claimer tests).
+- Backward-compatible additive enum/struct changes (no removals). Downstream `latex` builds and
+  its 136 tests pass unchanged; the `latex` frontend will start *emitting* these in a follow-up.
+- +3 tests; **23 unit + 1 doc test** green; clippy `-D warnings` clean. Crate 0.1.0 → 0.2.0.
+
 ## [0.1.0] — 2026-06-26
 
 ### Added — PFE01 implementation: the framework

--- a/code/packages/rust/math-frontend/Cargo.toml
+++ b/code/packages/rust/math-frontend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "math-frontend"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "A pluggable parser-frontend framework: a neutral math AST (MathExpr), a MathFrontend trait + registry, and a shared conformance harness. Notation parsers (LaTeX, AsciiMath, MathML, …) implement the trait so any consumer lowers ONE neutral tree."
 license = "MIT"

--- a/code/packages/rust/math-frontend/README.md
+++ b/code/packages/rust/math-frontend/README.md
@@ -25,7 +25,7 @@ Adding a notation later is "register one more frontend" — zero consumer change
 
 | Piece | Role |
 |-------|------|
-| `MathExpr` (+ `Number`, `BinOp`, `Func`, `BigOp`, `RelOp`, …) | the notation-agnostic AST |
+| `MathExpr` (+ `Number`, `BinOp`, `Func`, `BigOp`, `RelOp`, …) | the notation-agnostic AST — includes `BinOp::PlusMinus`/`MinusPlus` (± / ∓) and `MathExpr::Binom` (binomial coefficient) |
 | `MathFrontend` | the contract a notation parser implements |
 | `FrontendError` / `Capabilities` | spanned errors; what a frontend can emit |
 | `FrontendRegistry` | look up a frontend by name and parse through it |

--- a/code/packages/rust/math-frontend/src/conformance.rs
+++ b/code/packages/rust/math-frontend/src/conformance.rs
@@ -94,7 +94,7 @@ pub fn check_frontend(frontend: &dyn MathFrontend, samples: &[&str]) -> Conforma
 /// Names of capabilities that `used` requires but `declared` did not advertise.
 fn over_emitted(used: Capabilities, declared: Capabilities) -> Vec<&'static str> {
     let mut v = Vec::new();
-    let pairs: [(&str, bool, bool); 9] = [
+    let pairs: [(&str, bool, bool); 11] = [
         ("fractions", used.fractions, declared.fractions),
         ("roots", used.roots, declared.roots),
         ("powers", used.powers, declared.powers),
@@ -104,6 +104,8 @@ fn over_emitted(used: Capabilities, declared: Capabilities) -> Vec<&'static str>
         ("matrices", used.matrices, declared.matrices),
         ("implicit_mul", used.implicit_mul, declared.implicit_mul),
         ("text", used.text, declared.text),
+        ("plusminus", used.plusminus, declared.plusminus),
+        ("binomials", used.binomials, declared.binomials),
     ];
     for (label, used_it, declared_it) in pairs {
         if used_it && !declared_it {
@@ -125,6 +127,11 @@ fn collect_used(e: &MathExpr, caps: &mut Capabilities) {
             collect_used(a, caps);
             collect_used(b, caps);
         }
+        MathExpr::Bin(crate::BinOp::PlusMinus | crate::BinOp::MinusPlus, a, b) => {
+            caps.plusminus = true;
+            collect_used(a, caps);
+            collect_used(b, caps);
+        }
         MathExpr::Bin(_, a, b) => {
             collect_used(a, caps);
             collect_used(b, caps);
@@ -132,6 +139,11 @@ fn collect_used(e: &MathExpr, caps: &mut Capabilities) {
         MathExpr::Unary(_, a) => collect_used(a, caps),
         MathExpr::Frac(a, b) => {
             caps.fractions = true;
+            collect_used(a, caps);
+            collect_used(b, caps);
+        }
+        MathExpr::Binom(a, b) => {
+            caps.binomials = true;
             collect_used(a, caps);
             collect_used(b, caps);
         }
@@ -229,11 +241,52 @@ mod tests {
         fn capabilities(&self) -> Capabilities { Capabilities::none() }
     }
 
+    /// Dishonest frontend: emits ± / a binomial but declares neither capability.
+    struct PmBinomOverClaimer;
+    impl MathFrontend for PmBinomOverClaimer {
+        fn name(&self) -> &str { "pmbinom" }
+        fn parse(&self, src: &str) -> Result<MathExpr, FrontendError> {
+            let one = || Box::new(MathExpr::Number(Number::from_i64(1)));
+            if src == "pm" {
+                Ok(MathExpr::Bin(crate::BinOp::PlusMinus, one(), one()))
+            } else {
+                Ok(MathExpr::Binom(one(), one()))
+            }
+        }
+        fn capabilities(&self) -> Capabilities { Capabilities::none() }
+    }
+
     #[test]
     fn honest_frontend_conforms() {
         let r = check_frontend(&Honest, &["1", "2", "x"]);
         assert!(r.passed(), "{:?}", r.issues);
         assert_eq!(r.samples_checked, 3);
+    }
+
+    #[test]
+    fn over_claiming_plusminus_and_binomials_is_flagged() {
+        let r = check_frontend(&PmBinomOverClaimer, &["pm", "binom"]);
+        assert!(!r.passed());
+        assert!(r.issues.iter().any(|i| i.contains("plusminus")));
+        assert!(r.issues.iter().any(|i| i.contains("binomials")));
+    }
+
+    #[test]
+    fn all_caps_admits_plusminus_and_binom() {
+        // A frontend declaring all() may emit ± and Binom without being flagged.
+        struct Full;
+        impl MathFrontend for Full {
+            fn name(&self) -> &str { "full" }
+            fn parse(&self, _src: &str) -> Result<MathExpr, FrontendError> {
+                let one = || Box::new(MathExpr::Number(Number::from_i64(1)));
+                Ok(MathExpr::Binom(
+                    one(),
+                    Box::new(MathExpr::Bin(crate::BinOp::MinusPlus, one(), one())),
+                ))
+            }
+            fn capabilities(&self) -> Capabilities { Capabilities::all() }
+        }
+        assert!(check_frontend(&Full, &["x"]).passed());
     }
 
     #[test]

--- a/code/packages/rust/math-frontend/src/expr.rs
+++ b/code/packages/rust/math-frontend/src/expr.rs
@@ -170,6 +170,11 @@ pub enum BinOp {
     Mul,
     Div,
     Pow,
+    /// `a ± b` — denotes the *pair* {a+b, a−b}. A meaning-bearing operator (not presentation),
+    /// kept binary so a consumer can interpret both branches.
+    PlusMinus,
+    /// `a ∓ b` — the opposite pairing to [`BinOp::PlusMinus`] ({a−b, a+b}).
+    MinusPlus,
 }
 
 /// Unary prefix operators.
@@ -225,6 +230,9 @@ pub enum MathExpr {
     /// A fraction `numerator / denominator` (a `Div` that the source wrote as a built-up
     /// fraction; kept distinct so a renderer can reproduce it, but it means division).
     Frac(Box<MathExpr>, Box<MathExpr>),
+    /// A binomial coefficient `C(n, k)` = "n choose k" — `Binom(n, k)`. Distinct from `Frac`
+    /// (no division bar) and meaning-bearing, so consumers can evaluate or render it.
+    Binom(Box<MathExpr>, Box<MathExpr>),
     /// An nth root: `degree` is `None` for a square root.
     Root {
         degree: Option<Box<MathExpr>>,
@@ -254,6 +262,20 @@ pub enum MathExpr {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn plusminus_and_binom_are_constructible_and_compare() {
+        let one = || Box::new(MathExpr::Number(Number::from_i64(1)));
+        let pm = MathExpr::Bin(BinOp::PlusMinus, one(), one());
+        let mp = MathExpr::Bin(BinOp::MinusPlus, one(), one());
+        // ± and ∓ are distinct operators.
+        assert_ne!(pm, mp);
+        assert_eq!(pm, MathExpr::Bin(BinOp::PlusMinus, one(), one()));
+        // Binom is distinct from Frac with the same operands.
+        let binom = MathExpr::Binom(one(), one());
+        assert_eq!(binom, MathExpr::Binom(one(), one()));
+        assert_ne!(binom, MathExpr::Frac(one(), one()));
+    }
 
     #[test]
     fn number_normalizes_equal_values() {

--- a/code/packages/rust/math-frontend/src/frontend.rs
+++ b/code/packages/rust/math-frontend/src/frontend.rs
@@ -60,6 +60,10 @@ pub struct Capabilities {
     pub matrices: bool,
     pub implicit_mul: bool,
     pub text: bool,
+    /// Emits the ± / ∓ operators ([`crate::BinOp::PlusMinus`] / [`crate::BinOp::MinusPlus`]).
+    pub plusminus: bool,
+    /// Emits binomial coefficients ([`crate::MathExpr::Binom`]).
+    pub binomials: bool,
 }
 
 impl Capabilities {
@@ -81,6 +85,8 @@ impl Capabilities {
             matrices: true,
             implicit_mul: true,
             text: true,
+            plusminus: true,
+            binomials: true,
         }
     }
 
@@ -93,6 +99,8 @@ impl Capabilities {
     pub fn with_matrices(mut self) -> Self { self.matrices = true; self }
     pub fn with_implicit_mul(mut self) -> Self { self.implicit_mul = true; self }
     pub fn with_text(mut self) -> Self { self.text = true; self }
+    pub fn with_plusminus(mut self) -> Self { self.plusminus = true; self }
+    pub fn with_binomials(mut self) -> Self { self.binomials = true; self }
 }
 
 /// The contract every notation parser implements.
@@ -129,6 +137,11 @@ mod tests {
         assert_eq!(Capabilities::none(), Capabilities::default());
         let a = Capabilities::all();
         assert!(a.fractions && a.matrices && a.text && a.relations);
+        assert!(a.plusminus && a.binomials);
+        // none() leaves the new flags off; builders flip exactly them.
+        assert!(!Capabilities::none().plusminus && !Capabilities::none().binomials);
+        let c = Capabilities::none().with_plusminus().with_binomials();
+        assert!(c.plusminus && c.binomials && !c.fractions);
     }
 
     #[test]

--- a/code/specs/PFE01-pluggable-parser-frontends.md
+++ b/code/specs/PFE01-pluggable-parser-frontends.md
@@ -32,11 +32,13 @@ is notation-agnostic (it is *not* LaTeX-shaped):
 pub enum MathExpr {
     Number(Number),                 // exact-preserving numeric literal (see §2.1)
     Symbol(String),                 // a variable or named constant: "x", "pi", "alpha"
-    Bin(BinOp, Box<MathExpr>, Box<MathExpr>),   // Add Sub Mul Div Pow (Mul carries no
-                                                //   surface style — \cdot vs \times vs
-                                                //   juxtaposition all become Mul)
+    Bin(BinOp, Box<MathExpr>, Box<MathExpr>),   // Add Sub Mul Div Pow PlusMinus MinusPlus
+                                                //   (Mul carries no surface style — \cdot vs
+                                                //   \times vs juxtaposition all become Mul;
+                                                //   PlusMinus/MinusPlus = ± / ∓)
     Unary(UnaryOp, Box<MathExpr>),              // Neg, Pos
     Frac(Box<MathExpr>, Box<MathExpr>),         // numerator / denominator (a Div with intent)
+    Binom(Box<MathExpr>, Box<MathExpr>),        // binomial coefficient C(n,k) (no division bar)
     Root { degree: Option<Box<MathExpr>>, radicand: Box<MathExpr> },  // nth root
     Call { func: Func, arg: Box<MathExpr> },    // sin, cos, ln, exp, … (named functions)
     BigOp { op: BigOp, lower: Option<Box<MathExpr>>, upper: Option<Box<MathExpr>>,


### PR DESCRIPTION
## Close the LTX01 L6 honest neutral-AST gaps (PR 1 of 2)

The LaTeX frontend (LTX01 L6, #6762) had to return a spanned `FrontendError` for `\pm`/`\mp` and `\binom` because the neutral `math_frontend::MathExpr` couldn't represent them. This PR extends the neutral AST so they're representable; **PR 2** (in the `latex` crate) then wires `LatexMath`'s `lower` to emit them.

### Added (all additive / backward-compatible)
- **`BinOp::PlusMinus` / `BinOp::MinusPlus`** — the `±` / `∓` operators. `a ± b` denotes the pair {a+b, a−b} (∓ the opposite pairing); meaning-bearing binary operators, not presentation.
- **`MathExpr::Binom(n, k)`** — a binomial coefficient "n choose k", kept distinct from `Frac` (no division bar).
- **`Capabilities`** gains `plusminus` and `binomials` flags — set by `all()`, plus new `with_plusminus()` / `with_binomials()` builders. The conformance harness (`collect_used` + `over_emitted`) now detects and polices both, so a frontend that emits `±`/binomial without declaring the capability is flagged (new over-claimer tests verify this).

### Verification
- **23 unit + 1 doc test** green (+3 new); `clippy -D warnings` clean.
- Downstream consumer unaffected: `cargo test -p latex` (136 tests) passes, and `cargo build -p latex --no-default-features` still builds — the additive enum/struct changes don't touch `latex`'s existing matches.
- Security review **PASSED** (data-only additions; no new panics/recursion class/overflow).
- PFE01 spec AST section updated. Crate `0.1.0 → 0.2.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)