### PR TITLE
[codex] Add SPICE nonlinear Newton step limiting

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Added
 
+- **Nonlinear Newton damping diagnostics** —
+  `dc_op()` now applies a configurable `newton_step_limit` to nonlinear
+  Newton updates and reports `newton_step_limit`, `limited_newton_steps`, and
+  `minimum_damping_factor` in `DcResult.diagnostics`, matching Rust and
+  TypeScript.
+
 - **Production solver profiles** —
   `DcResult.diagnostics` now carries a nested `solver_profile` with matrix
   size, solver kind, backend, structural nonzero count, density, peak fill-in,

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -189,6 +189,10 @@ density, fill-in, and fallback metadata. Large real DC solves use an optional
 SciPy sparse-LU backend when available and fall back to the native sparse-row
 solver with an explicit fallback reason; large complex AC solves use the native
 sparse-row path when the matrix size reaches the package threshold.
+For nonlinear operating points, `dc_op(newton_step_limit=...)` bounds each
+Newton update per unknown. Diagnostics report the active limit, how many steps
+were clipped, and the minimum damping factor; pass `newton_step_limit=None` to
+disable the limiter.
 
 `normalize_model_card()`, `diode_from_model_card()`,
 `bjt_from_model_card()`, `jfet_from_model_card()`, and

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -110,6 +110,8 @@ from spice_engine.elements import (
     waveform_period,
 )
 
+_DEFAULT_NEWTON_STEP_LIMIT = 5.0
+
 
 @dataclass
 class Circuit:
@@ -609,6 +611,9 @@ class DcSolverDiagnostics:
     tolerance: float
     max_delta: float
     convergence_aid: str
+    newton_step_limit: float | None = None
+    limited_newton_steps: int = 0
+    minimum_damping_factor: float = 1.0
     solver_profile: LinearSolverProfile = field(
         default_factory=lambda: LinearSolverProfile(
             matrix_size=0,
@@ -7308,6 +7313,9 @@ def _dc_diagnostics(
     max_delta: float,
     convergence_aid: str,
     solver_profile: LinearSolverProfile | None = None,
+    newton_step_limit: float | None = None,
+    limited_newton_steps: int = 0,
+    minimum_damping_factor: float = 1.0,
 ) -> DcSolverDiagnostics:
     return DcSolverDiagnostics(
         matrix_size=matrix_size,
@@ -7315,10 +7323,63 @@ def _dc_diagnostics(
         tolerance=tol,
         max_delta=max_delta,
         convergence_aid=convergence_aid,
+        newton_step_limit=newton_step_limit,
+        limited_newton_steps=limited_newton_steps,
+        minimum_damping_factor=minimum_damping_factor,
         solver_profile=solver_profile
         if solver_profile is not None
         else _empty_solver_profile(matrix_size),
     )
+
+
+def _has_nonlinear_element(circuit: Circuit) -> bool:
+    return any(
+        isinstance(el, (BSource, CustomModel, Diode, JFET, Mosfet, BJT))
+        for el in circuit.elements
+    )
+
+
+def _validate_newton_step_limit(value: float | None) -> float | None:
+    if value is None:
+        return None
+    if not math.isfinite(value) or value <= 0.0:
+        raise ValueError("newton_step_limit must be finite and positive")
+    return value
+
+
+def _limit_newton_step(
+    previous: list[float],
+    candidate: list[float],
+    step_limit: float | None,
+) -> tuple[list[float], float, float, bool]:
+    if step_limit is None or not previous:
+        max_delta = (
+            max(abs(a - bv) for a, bv in zip(previous, candidate, strict=False))
+            if previous
+            else 0.0
+        )
+        return candidate, max_delta, 1.0, False
+
+    raw_delta = max(abs(a - bv) for a, bv in zip(previous, candidate, strict=False))
+    if raw_delta <= step_limit:
+        return candidate, raw_delta, 1.0, False
+
+    if not math.isfinite(raw_delta):
+        limited = []
+        for old, new in zip(previous, candidate, strict=False):
+            delta = new - old
+            if math.isfinite(delta):
+                limited.append(old + math.copysign(step_limit, delta))
+            else:
+                limited.append(old)
+        return limited, step_limit, 0.0, True
+
+    damping_factor = step_limit / raw_delta
+    limited = [
+        old + (new - old) * damping_factor
+        for old, new in zip(previous, candidate, strict=False)
+    ]
+    return limited, step_limit, damping_factor, True
 
 
 # ---------------------------------------------------------------------------
@@ -7332,6 +7393,7 @@ def _dc_newton(
     max_iterations: int = 50,
     tol: float = 1e-6,
     x_init: list[float] | None = None,
+    newton_step_limit: float | None = _DEFAULT_NEWTON_STEP_LIMIT,
 ) -> DcResult:
     """Run Newton-Raphson DC solve, optionally warm-started from *x_init*.
 
@@ -7359,6 +7421,13 @@ def _dc_newton(
     size = n + m
 
     x = list(x_init) if x_init is not None else [0.0] * size
+    active_step_limit = (
+        _validate_newton_step_limit(newton_step_limit)
+        if _has_nonlinear_element(circuit)
+        else None
+    )
+    limited_newton_steps = 0
+    minimum_damping_factor = 1.0
 
     max_delta = float("inf")
     for it in range(max_iterations):
@@ -7384,10 +7453,20 @@ def _dc_newton(
                     max_delta=float("inf"),
                     convergence_aid="newton",
                     solver_profile=solver_profile,
+                    newton_step_limit=active_step_limit,
+                    limited_newton_steps=limited_newton_steps,
+                    minimum_damping_factor=minimum_damping_factor,
                 ),
             )
 
-        max_delta = max(abs(a - bv) for a, bv in zip(x, x_new, strict=False)) if x else 0.0
+        x_new, max_delta, damping_factor, was_limited = _limit_newton_step(
+            x,
+            x_new,
+            active_step_limit,
+        )
+        if was_limited:
+            limited_newton_steps += 1
+            minimum_damping_factor = min(minimum_damping_factor, damping_factor)
         x = x_new
         if max_delta < tol:
             break
@@ -7405,6 +7484,9 @@ def _dc_newton(
             max_delta=max_delta,
             convergence_aid="newton",
             solver_profile=solver_profile,
+            newton_step_limit=active_step_limit,
+            limited_newton_steps=limited_newton_steps,
+            minimum_damping_factor=minimum_damping_factor,
         ),
     )
 
@@ -7440,6 +7522,7 @@ def _dc_gmin_step(
     tol: float = 1e-6,
     gmin_start: float = 1e-3,
     n_steps: int = 10,
+    newton_step_limit: float | None = _DEFAULT_NEWTON_STEP_LIMIT,
 ) -> DcResult | None:
     """DC operating point via Gmin stepping (convergence aid #1).
 
@@ -7513,7 +7596,13 @@ def _dc_gmin_step(
             # Final step: original circuit, warm-started from the last Gmin solve.
             aug = circuit
 
-        result = _dc_newton(aug, max_iterations=max_iterations, tol=tol, x_init=x_init)
+        result = _dc_newton(
+            aug,
+            max_iterations=max_iterations,
+            tol=tol,
+            x_init=x_init,
+            newton_step_limit=newton_step_limit,
+        )
         if not result.converged:
             return None  # This step diverged — Gmin stepping has failed.
 
@@ -7531,6 +7620,7 @@ def _dc_source_step(
     max_iterations: int = 50,
     tol: float = 1e-6,
     n_steps: int = 10,
+    newton_step_limit: float | None = _DEFAULT_NEWTON_STEP_LIMIT,
 ) -> DcResult | None:
     """DC operating point via source stepping (convergence aid #2).
 
@@ -7608,7 +7698,11 @@ def _dc_source_step(
         scaled_circuit = Circuit(elements=scaled_elements)
 
         result = _dc_newton(
-            scaled_circuit, max_iterations=max_iterations, tol=tol, x_init=x_init
+            scaled_circuit,
+            max_iterations=max_iterations,
+            tol=tol,
+            x_init=x_init,
+            newton_step_limit=newton_step_limit,
         )
         if not result.converged:
             return None  # This step diverged — source stepping has failed.
@@ -7628,6 +7722,7 @@ def _dc_pseudo_transient(
     tol: float = 1e-6,
     n_steps: int = 20,
     shunt_conductance: float = 1e-3,
+    newton_step_limit: float | None = _DEFAULT_NEWTON_STEP_LIMIT,
 ) -> DcResult | None:
     """DC continuation through artificial backward-Euler node capacitors."""
     if n_steps <= 0 or not math.isfinite(shunt_conductance) or shunt_conductance <= 0.0:
@@ -7665,6 +7760,7 @@ def _dc_pseudo_transient(
             max_iterations=max_iterations,
             tol=tol,
             x_init=x_init,
+            newton_step_limit=newton_step_limit,
         )
         if not result.converged:
             return None
@@ -7758,6 +7854,7 @@ def dc_op(
     pseudo_transient_shunt_conductance: float = 1e-3,
     pseudo_transient_max_iterations: int | None = None,
     initial_vector: list[float] | None = None,
+    newton_step_limit: float | None = _DEFAULT_NEWTON_STEP_LIMIT,
 ) -> DcResult:
     """Solve DC operating point via Newton-Raphson on a linearized MNA.
 
@@ -7803,9 +7900,13 @@ def dc_op(
     initial_vector:
         Optional MNA warm-start vector.  Prefer
         :func:`dc_op_with_initial_conditions` for parsed deck hints.
+    newton_step_limit:
+        Maximum absolute Newton update per unknown for nonlinear circuits.
+        Set to ``None`` to disable damping.
     """
     if initial_vector is not None:
         _validate_dc_initial_vector(circuit, initial_vector)
+    newton_step_limit = _validate_newton_step_limit(newton_step_limit)
 
     # Attempt 1: plain Newton-Raphson.
     result = _dc_newton(
@@ -7813,6 +7914,7 @@ def dc_op(
         max_iterations=max_iterations,
         tol=tol,
         x_init=initial_vector,
+        newton_step_limit=newton_step_limit,
     )
     if result.converged:
         return replace(
@@ -7828,7 +7930,12 @@ def dc_op(
         )
 
     # Attempt 2: Gmin stepping.
-    gmin_result = _dc_gmin_step(circuit, max_iterations=max_iterations, tol=tol)
+    gmin_result = _dc_gmin_step(
+        circuit,
+        max_iterations=max_iterations,
+        tol=tol,
+        newton_step_limit=newton_step_limit,
+    )
     if gmin_result is not None and gmin_result.converged:
         return replace(
             gmin_result,
@@ -7837,7 +7944,12 @@ def dc_op(
         )
 
     # Attempt 3: source stepping.
-    src_result = _dc_source_step(circuit, max_iterations=max_iterations, tol=tol)
+    src_result = _dc_source_step(
+        circuit,
+        max_iterations=max_iterations,
+        tol=tol,
+        newton_step_limit=newton_step_limit,
+    )
     if src_result is not None and src_result.converged:
         return replace(
             src_result,
@@ -7856,6 +7968,7 @@ def dc_op(
         tol=tol,
         n_steps=pseudo_transient_steps,
         shunt_conductance=pseudo_transient_shunt_conductance,
+        newton_step_limit=newton_step_limit,
     )
     if pseudo_result is not None and pseudo_result.converged:
         return replace(
@@ -7885,6 +7998,7 @@ def dc_op_with_initial_conditions(
     pseudo_transient_steps: int = 20,
     pseudo_transient_shunt_conductance: float = 1e-3,
     pseudo_transient_max_iterations: int | None = None,
+    newton_step_limit: float | None = _DEFAULT_NEWTON_STEP_LIMIT,
 ) -> DcResult:
     """Solve DC operating point using parsed ``.ic``/``.nodeset`` node hints."""
 
@@ -7902,6 +8016,7 @@ def dc_op_with_initial_conditions(
         pseudo_transient_shunt_conductance=pseudo_transient_shunt_conductance,
         pseudo_transient_max_iterations=pseudo_transient_max_iterations,
         initial_vector=initial_vector,
+        newton_step_limit=newton_step_limit,
     )
 
 

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -990,6 +990,9 @@ def test_large_resistor_ladder_uses_sparse_real_solver_path():
     assert r.diagnostics.convergence_aid == "newton"
     assert r.diagnostics.tolerance == pytest.approx(1.0e-6)
     assert math.isfinite(r.diagnostics.max_delta)
+    assert r.diagnostics.newton_step_limit is None
+    assert r.diagnostics.limited_newton_steps == 0
+    assert r.diagnostics.minimum_damping_factor == pytest.approx(1.0)
     profile = r.diagnostics.solver_profile
     assert profile.matrix_size == 36
     assert profile.solver == "sparse_real"
@@ -8964,6 +8967,34 @@ def test_dc_op_reports_no_convergence_aid_when_disabled_solve_fails() -> None:
     result = dc_op(c, max_iterations=1, convergence_aids=False)
     assert not result.converged
     assert result.convergence_aid == "none"
+
+
+def test_dc_op_newton_step_limit_reports_damped_nonlinear_step() -> None:
+    c = Circuit([
+        VoltageSource("Vs", "in", "0", 10.0),
+        Diode("D1", anode="in", cathode="out", Is=1e-15, Vt=0.02585),
+        Resistor("Rload", "out", "0", 100.0),
+    ])
+
+    result = dc_op(
+        c,
+        max_iterations=1,
+        convergence_aids=False,
+        newton_step_limit=0.25,
+    )
+
+    assert not result.converged
+    assert result.convergence_aid == "none"
+    assert result.diagnostics.newton_step_limit == pytest.approx(0.25)
+    assert result.diagnostics.limited_newton_steps == 1
+    assert 0.0 < result.diagnostics.minimum_damping_factor < 1.0
+    assert result.diagnostics.max_delta == pytest.approx(0.25)
+    assert max(abs(value) for value in result.node_voltages.values()) <= 0.25 + 1e-12
+
+
+def test_dc_op_rejects_invalid_newton_step_limit() -> None:
+    with pytest.raises(ValueError, match="newton_step_limit must be finite and positive"):
+        dc_op(Circuit(), newton_step_limit=0.0)
 
 
 def test_dc_op_pseudo_transient_recovers_after_earlier_aids_fail() -> None:

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add configurable nonlinear Newton damping through
+  `DcOpOptions::newton_step_limit`, plus stable diagnostics for
+  `newton_step_limit`, `limited_newton_steps`, and `minimum_damping_factor`,
+  matching Python and TypeScript.
 - Add `DcResult::diagnostics.solver_profile` with matrix size, solver kind,
   backend, structural nonzero count, density, peak fill-in, and fallback
   metadata for production sparse-solver audits, matching Python and TypeScript.

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -8,6 +8,8 @@ The initial slices implement:
   (MNA), with stable `DcResult::diagnostics` metadata for matrix size, selected
   real solver path, tolerance, convergence aid, final Newton delta, and a
   nested solver profile for backend, structural nonzeros, density, and fill-in.
+  Nonlinear operating points can bound Newton updates with
+  `DcOpOptions::newton_step_limit`, and diagnostics report limiter activity.
 - DC operating-point sweeps across explicit analysis temperatures, including
   named corner sweeps and order-preserving parallel named corner DC sweeps.
 - DC source sweeps over independent voltage and current sources, including
@@ -81,6 +83,10 @@ aliases, node voltages, and voltage source branch currents.
 Large real DC and complex AC matrix solves use native sparse-row solver paths
 when the matrix size reaches the package threshold. DC diagnostics expose the
 actual real-solver backend and matrix sparsity profile for production audits.
+For nonlinear DC solves, `DcOpOptions::newton_step_limit` bounds each Newton
+update per unknown. `DcResult::diagnostics` reports the active limit, clipped
+step count, and minimum damping factor; set the option to `None` to disable
+the limiter.
 
 ```rust
 use spice_engine::{

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -4,6 +4,7 @@ use std::thread;
 
 const PIVOT_EPSILON: f64 = 1.0e-12;
 const SPARSE_SOLVER_THRESHOLD: usize = 30;
+const DEFAULT_NEWTON_STEP_LIMIT: f64 = 5.0;
 const TWO_PI: f64 = std::f64::consts::PI * 2.0;
 const BOLTZMANN: f64 = 1.380_649e-23;
 const ELECTRON_CHARGE: f64 = 1.602_176_634e-19;
@@ -7943,6 +7944,9 @@ pub struct DcSolverDiagnostics {
     pub tolerance: f64,
     pub max_delta: f64,
     pub convergence_aid: DcConvergenceAid,
+    pub newton_step_limit: Option<f64>,
+    pub limited_newton_steps: usize,
+    pub minimum_damping_factor: f64,
     pub solver_profile: LinearSolverProfile,
 }
 
@@ -8029,6 +8033,7 @@ pub struct DcOpOptions {
     pub pseudo_transient_steps: usize,
     pub pseudo_transient_conductance: f64,
     pub pseudo_transient_max_iterations: usize,
+    pub newton_step_limit: Option<f64>,
 }
 
 impl Default for DcOpOptions {
@@ -8040,6 +8045,7 @@ impl Default for DcOpOptions {
             pseudo_transient_steps: 20,
             pseudo_transient_conductance: 1.0e-3,
             pseudo_transient_max_iterations: 80,
+            newton_step_limit: Some(DEFAULT_NEWTON_STEP_LIMIT),
         }
     }
 }
@@ -15174,6 +15180,9 @@ fn dc_result_from_linear_solution(
             tolerance,
             max_delta: solution.max_delta,
             convergence_aid,
+            newton_step_limit: solution.newton_step_limit,
+            limited_newton_steps: solution.limited_newton_steps,
+            minimum_damping_factor: solution.minimum_damping_factor,
             solver_profile: solution.solver_profile,
         },
     }
@@ -15205,6 +15214,14 @@ fn validate_dc_op_options(options: DcOpOptions) -> Result<(), SpiceError> {
             name: "dc_op".to_string(),
             reason: "pseudo_transient_max_iterations must be positive".to_string(),
         });
+    }
+    if let Some(limit) = options.newton_step_limit {
+        if !limit.is_finite() || limit <= 0.0 {
+            return Err(SpiceError::InvalidElement {
+                name: "dc_op".to_string(),
+                reason: "newton_step_limit must be finite and positive".to_string(),
+            });
+        }
     }
     Ok(())
 }
@@ -17735,6 +17752,9 @@ struct LinearSolution {
     iterations: usize,
     converged: bool,
     max_delta: f64,
+    newton_step_limit: Option<f64>,
+    limited_newton_steps: usize,
+    minimum_damping_factor: f64,
     solver_profile: LinearSolverProfile,
 }
 
@@ -17750,6 +17770,7 @@ struct LinearSolveOptions<'a> {
     tolerance: f64,
     initial_vector: Option<&'a [f64]>,
     return_singular_as_unconverged: bool,
+    newton_step_limit: Option<f64>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -17789,6 +17810,7 @@ fn solve_linear_circuit(
             tolerance: 1.0e-9,
             initial_vector: None,
             return_singular_as_unconverged: false,
+            newton_step_limit: None,
         },
     )
 }
@@ -17808,6 +17830,7 @@ fn solve_dc_newton(
             tolerance: options.tolerance,
             initial_vector,
             return_singular_as_unconverged: true,
+            newton_step_limit: options.newton_step_limit,
         },
     )
 }
@@ -17833,6 +17856,9 @@ fn solve_linear_circuit_with_options(
             iterations: 0,
             converged: true,
             max_delta: 0.0,
+            newton_step_limit: None,
+            limited_newton_steps: 0,
+            minimum_damping_factor: 1.0,
             solver_profile: empty_solver_profile(0),
         });
     }
@@ -17865,6 +17891,13 @@ fn solve_linear_circuit_with_options(
         &operating_point,
         return_singular_as_unconverged,
     )?;
+    let active_step_limit = if has_nonlinear {
+        options.newton_step_limit
+    } else {
+        None
+    };
+    let mut limited_newton_steps = 0;
+    let mut minimum_damping_factor: f64 = 1.0;
     if !has_nonlinear {
         return Ok(LinearSolution {
             iterations: 1,
@@ -17872,6 +17905,28 @@ fn solve_linear_circuit_with_options(
             ..solution
         });
     }
+    if solution.converged {
+        let step = limit_newton_step(&operating_point, &solution.vector, active_step_limit);
+        if step.limited {
+            limited_newton_steps += 1;
+            minimum_damping_factor = minimum_damping_factor.min(step.damping_factor);
+        }
+        let solver_profile = solution.solver_profile.clone();
+        solution = linear_solution_from_vector(
+            circuit,
+            inductor_states,
+            &node_indices,
+            &voltage_sources,
+            node_count,
+            &step.vector,
+            solution.converged,
+            step.max_delta,
+            solver_profile,
+        );
+    }
+    solution.newton_step_limit = active_step_limit;
+    solution.limited_newton_steps = limited_newton_steps;
+    solution.minimum_damping_factor = minimum_damping_factor;
 
     let mut iterations = 1;
     while iterations < options.max_iterations {
@@ -17880,16 +17935,22 @@ fn solve_linear_circuit_with_options(
                 iterations,
                 converged: false,
                 max_delta: f64::INFINITY,
+                newton_step_limit: active_step_limit,
+                limited_newton_steps,
+                minimum_damping_factor,
                 ..solution
             });
         }
-        let delta = max_vector_delta(&solution.vector, &operating_point);
+        let delta = solution.max_delta;
         operating_point = solution.vector.clone();
         if delta < options.tolerance {
             return Ok(LinearSolution {
                 iterations,
                 converged: true,
                 max_delta: delta,
+                newton_step_limit: active_step_limit,
+                limited_newton_steps,
+                minimum_damping_factor,
                 ..solution
             });
         }
@@ -17905,14 +17966,39 @@ fn solve_linear_circuit_with_options(
             &operating_point,
             return_singular_as_unconverged,
         )?;
+        if solution.converged {
+            let step = limit_newton_step(&operating_point, &solution.vector, active_step_limit);
+            if step.limited {
+                limited_newton_steps += 1;
+                minimum_damping_factor = minimum_damping_factor.min(step.damping_factor);
+            }
+            let solver_profile = solution.solver_profile.clone();
+            solution = linear_solution_from_vector(
+                circuit,
+                inductor_states,
+                &node_indices,
+                &voltage_sources,
+                node_count,
+                &step.vector,
+                solution.converged,
+                step.max_delta,
+                solver_profile,
+            );
+        }
+        solution.newton_step_limit = active_step_limit;
+        solution.limited_newton_steps = limited_newton_steps;
+        solution.minimum_damping_factor = minimum_damping_factor;
         iterations += 1;
     }
 
-    let delta = max_vector_delta(&solution.vector, &operating_point);
+    let delta = solution.max_delta;
     Ok(LinearSolution {
         iterations,
         converged: delta < options.tolerance,
         max_delta: delta,
+        newton_step_limit: active_step_limit,
+        limited_newton_steps,
+        minimum_damping_factor,
         ..solution
     })
 }
@@ -18120,6 +18206,9 @@ fn linear_solution_from_vector(
         iterations: 1,
         converged,
         max_delta,
+        newton_step_limit: None,
+        limited_newton_steps: 0,
+        minimum_damping_factor: 1.0,
         solver_profile,
     }
 }
@@ -18129,6 +18218,71 @@ fn max_vector_delta(left: &[f64], right: &[f64]) -> f64 {
         .zip(right.iter())
         .map(|(left, right)| (left - right).abs())
         .fold(0.0, f64::max)
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct NewtonStepLimitResult {
+    vector: Vec<f64>,
+    max_delta: f64,
+    damping_factor: f64,
+    limited: bool,
+}
+
+fn limit_newton_step(
+    previous: &[f64],
+    candidate: &[f64],
+    step_limit: Option<f64>,
+) -> NewtonStepLimitResult {
+    let Some(step_limit) = step_limit else {
+        return NewtonStepLimitResult {
+            vector: candidate.to_vec(),
+            max_delta: max_vector_delta(previous, candidate),
+            damping_factor: 1.0,
+            limited: false,
+        };
+    };
+    let raw_delta = max_vector_delta(previous, candidate);
+    if raw_delta <= step_limit {
+        return NewtonStepLimitResult {
+            vector: candidate.to_vec(),
+            max_delta: raw_delta,
+            damping_factor: 1.0,
+            limited: false,
+        };
+    }
+    if !raw_delta.is_finite() {
+        let vector = previous
+            .iter()
+            .zip(candidate.iter())
+            .map(|(old, new)| {
+                let delta = *new - *old;
+                if delta.is_finite() {
+                    *old + step_limit.copysign(delta)
+                } else {
+                    *old
+                }
+            })
+            .collect();
+        return NewtonStepLimitResult {
+            vector,
+            max_delta: step_limit,
+            damping_factor: 0.0,
+            limited: true,
+        };
+    }
+
+    let damping_factor = step_limit / raw_delta;
+    let vector = previous
+        .iter()
+        .zip(candidate.iter())
+        .map(|(old, new)| *old + (*new - *old) * damping_factor)
+        .collect();
+    NewtonStepLimitResult {
+        vector,
+        max_delta: step_limit,
+        damping_factor,
+        limited: true,
+    }
 }
 
 fn solve_ac_circuit(circuit: &Circuit, omega: f64) -> Result<AcSolution, SpiceError> {

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -251,6 +251,9 @@ fn dc_large_resistor_ladder_uses_sparse_real_solver_path() {
     assert_eq!(result.diagnostics.convergence_aid, DcConvergenceAid::Newton);
     assert_close(result.diagnostics.tolerance, 1.0e-9);
     assert!(result.diagnostics.max_delta.is_finite());
+    assert_eq!(result.diagnostics.newton_step_limit, None);
+    assert_eq!(result.diagnostics.limited_newton_steps, 0);
+    assert_close(result.diagnostics.minimum_damping_factor, 1.0);
     assert_eq!(result.diagnostics.solver_profile.matrix_size, 36);
     assert_eq!(result.diagnostics.solver_profile.solver, "sparse_real");
     assert_eq!(
@@ -908,6 +911,43 @@ fn dc_op_reports_unconverged_nonlinear_result_when_aids_are_disabled() {
 }
 
 #[test]
+fn dc_op_newton_step_limit_reports_damped_nonlinear_step() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vs", "in", "0", 10.0,
+    )));
+    circuit.add(Element::Diode(Diode::with_model(
+        "D1", "in", "out", 1.0e-15, 0.02585,
+    )));
+    circuit.add(Element::Resistor(Resistor::new("Rload", "out", "0", 100.0)));
+
+    let result = dc_op_with_options(
+        &circuit,
+        DcOpOptions {
+            max_iterations: 1,
+            convergence_aids: false,
+            newton_step_limit: Some(0.25),
+            ..DcOpOptions::default()
+        },
+    )
+    .unwrap();
+
+    assert!(!result.converged);
+    assert_eq!(result.convergence_aid, DcConvergenceAid::None);
+    assert_eq!(result.diagnostics.newton_step_limit, Some(0.25));
+    assert_eq!(result.diagnostics.limited_newton_steps, 1);
+    assert!(result.diagnostics.minimum_damping_factor > 0.0);
+    assert!(result.diagnostics.minimum_damping_factor < 1.0);
+    assert_close(result.diagnostics.max_delta, 0.25);
+    let max_voltage = result
+        .node_voltages
+        .values()
+        .map(|value| value.abs())
+        .fold(0.0, f64::max);
+    assert!(max_voltage <= 0.25 + 1.0e-12);
+}
+
+#[test]
 fn dc_op_pseudo_transient_recovers_after_earlier_aids_fail() {
     let mut circuit = Circuit::new();
     circuit.add(Element::VoltageSource(VoltageSource::new(
@@ -1152,6 +1192,17 @@ fn dc_op_rejects_invalid_options() {
         ),
         Err(SpiceError::InvalidElement { name, reason })
             if name == "dc_op" && reason == "tolerance must be finite and positive"
+    ));
+    assert!(matches!(
+        dc_op_with_options(
+            &circuit,
+            DcOpOptions {
+                newton_step_limit: Some(0.0),
+                ..DcOpOptions::default()
+            },
+        ),
+        Err(SpiceError::InvalidElement { name, reason })
+            if name == "dc_op" && reason == "newton_step_limit must be finite and positive"
     ));
 }
 

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add configurable nonlinear Newton damping through
+  `dcOp(..., { newtonStepLimit })`, plus stable diagnostics for
+  `newtonStepLimit`, `limitedNewtonSteps`, and `minimumDampingFactor`,
+  matching Python and Rust.
 - Add `dcOp(...).diagnostics.solverProfile` with matrix size, solver kind,
   backend, structural nonzero count, density, peak fill-in, and fallback
   metadata for production sparse-solver audits, matching Python and Rust.

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -60,6 +60,10 @@ Newton delta, and a nested `solverProfile` with backend, structural nonzero
 count, density, fill-in, and fallback metadata. Large real DC and complex AC
 matrix solves use native sparse-row solver paths when the matrix size reaches
 the package threshold.
+For nonlinear operating points, `dcOp(circuit, { newtonStepLimit })` bounds
+each Newton update per unknown. Diagnostics report the active limit, how many
+steps were clipped, and the minimum damping factor; pass
+`newtonStepLimit: null` to disable the limiter.
 
 `diodeAtTemperature`, `bjtAtTemperature`, `mosfetAtTemperature`, and
 `circuitAtTemperature` provide operating-temperature footholds for diode, BJT,

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -1,5 +1,6 @@
 const PIVOT_EPSILON = 1.0e-12;
 const SPARSE_SOLVER_THRESHOLD = 30;
+const DEFAULT_NEWTON_STEP_LIMIT = 5.0;
 const TWO_PI = Math.PI * 2.0;
 const BOLTZMANN = 1.380_649e-23;
 const ELECTRON_CHARGE = 1.602_176_634e-19;
@@ -1064,6 +1065,9 @@ export interface DcSolverDiagnostics {
   readonly tolerance: number;
   readonly maxDelta: number;
   readonly convergenceAid: DcConvergenceAid;
+  readonly newtonStepLimit?: number;
+  readonly limitedNewtonSteps: number;
+  readonly minimumDampingFactor: number;
   readonly solverProfile: LinearSolverProfile;
 }
 
@@ -1074,6 +1078,7 @@ export interface DcOpOptions {
   readonly pseudoTransientSteps?: number;
   readonly pseudoTransientConductance?: number;
   readonly pseudoTransientMaxIterations?: number;
+  readonly newtonStepLimit?: number | null;
 }
 
 export interface CornerOverride {
@@ -11375,6 +11380,11 @@ function dcDiagnosticsFromLinearSolution(
     tolerance,
     maxDelta: solution.maxDelta,
     convergenceAid,
+    ...(solution.newtonStepLimit === undefined
+      ? {}
+      : { newtonStepLimit: solution.newtonStepLimit }),
+    limitedNewtonSteps: solution.limitedNewtonSteps,
+    minimumDampingFactor: solution.minimumDampingFactor,
     solverProfile: solution.solverProfile,
   };
 }
@@ -13916,6 +13926,9 @@ interface LinearSolution {
   readonly iterations: number;
   readonly converged: boolean;
   readonly maxDelta: number;
+  readonly newtonStepLimit?: number;
+  readonly limitedNewtonSteps: number;
+  readonly minimumDampingFactor: number;
   readonly solverProfile: LinearSolverProfile;
 }
 
@@ -13929,6 +13942,7 @@ interface LinearSolveOptions {
   readonly tolerance: number;
   readonly initialVector?: readonly number[];
   readonly returnSingularAsUnconverged?: boolean;
+  readonly newtonStepLimit?: number;
 }
 
 interface ResolvedDcOpOptions {
@@ -13938,6 +13952,7 @@ interface ResolvedDcOpOptions {
   readonly pseudoTransientSteps: number;
   readonly pseudoTransientConductance: number;
   readonly pseudoTransientMaxIterations: number;
+  readonly newtonStepLimit?: number;
 }
 
 interface AcSolution {
@@ -13969,6 +13984,7 @@ function solveLinearCircuit(
     {
       maxIterations: 80,
       tolerance: 1.0e-9,
+      newtonStepLimit: undefined,
     },
   );
 }
@@ -13988,6 +14004,7 @@ function solveDcNewton(
       tolerance: options.tolerance,
       initialVector,
       returnSingularAsUnconverged: true,
+      newtonStepLimit: options.newtonStepLimit,
     },
   );
 }
@@ -14046,6 +14063,8 @@ function solveLinearCircuitWithOptions(
       iterations: 0,
       converged: true,
       maxDelta: 0.0,
+      limitedNewtonSteps: 0,
+      minimumDampingFactor: 1.0,
       solverProfile: emptySolverProfile(0),
     };
   }
@@ -14069,16 +14088,51 @@ function solveLinearCircuitWithOptions(
     operatingPoint,
     returnSingularAsUnconverged,
   );
+  const activeStepLimit = hasNonlinearElement ? options.newtonStepLimit : undefined;
+  let limitedNewtonSteps = 0;
+  let minimumDampingFactor = 1.0;
+  const applyNewtonStepLimit = (candidate: LinearSolution): LinearSolution => {
+    if (!candidate.converged) {
+      return {
+        ...candidate,
+        newtonStepLimit: activeStepLimit,
+        limitedNewtonSteps,
+        minimumDampingFactor,
+      };
+    }
+    const step = limitNewtonStep(operatingPoint, candidate.vector, activeStepLimit);
+    if (step.limited) {
+      limitedNewtonSteps += 1;
+      minimumDampingFactor = Math.min(minimumDampingFactor, step.dampingFactor);
+    }
+    return {
+      ...linearSolutionFromVector(
+        circuit,
+        inductorStates,
+        nodeIndices,
+        voltageSources,
+        nodeCount,
+        step.vector,
+        candidate.converged,
+        step.maxDelta,
+        candidate.solverProfile,
+      ),
+      newtonStepLimit: activeStepLimit,
+      limitedNewtonSteps,
+      minimumDampingFactor,
+    };
+  };
   if (!hasNonlinearElement) {
     return { ...solution, iterations: 1, converged: solution.converged };
   }
+  solution = applyNewtonStepLimit(solution);
 
   let iterations = 1;
   while (iterations < options.maxIterations) {
     if (!solution.converged) {
       return { ...solution, iterations, converged: false, maxDelta: Number.POSITIVE_INFINITY };
     }
-    const delta = maxVectorDelta(solution.vector, operatingPoint);
+    const delta = solution.maxDelta;
     operatingPoint = [...solution.vector];
     if (delta < options.tolerance) {
       return { ...solution, iterations, converged: true, maxDelta: delta };
@@ -14095,10 +14149,11 @@ function solveLinearCircuitWithOptions(
       operatingPoint,
       returnSingularAsUnconverged,
     );
+    solution = applyNewtonStepLimit(solution);
     iterations += 1;
   }
 
-  const delta = maxVectorDelta(solution.vector, operatingPoint);
+  const delta = solution.maxDelta;
   return { ...solution, iterations, converged: delta < options.tolerance, maxDelta: delta };
 }
 
@@ -14155,6 +14210,10 @@ function validatedDcOpOptions(options: DcOpOptions): ResolvedDcOpOptions {
   const pseudoTransientSteps = options.pseudoTransientSteps ?? 20;
   const pseudoTransientConductance = options.pseudoTransientConductance ?? 1.0e-3;
   const pseudoTransientMaxIterations = options.pseudoTransientMaxIterations ?? maxIterations;
+  const newtonStepLimit =
+    options.newtonStepLimit === null
+      ? undefined
+      : options.newtonStepLimit ?? DEFAULT_NEWTON_STEP_LIMIT;
   if (!Number.isInteger(maxIterations) || maxIterations < 1) {
     throw invalidElement("dcOp", "maxIterations must be a positive integer");
   }
@@ -14170,6 +14229,12 @@ function validatedDcOpOptions(options: DcOpOptions): ResolvedDcOpOptions {
   if (!Number.isInteger(pseudoTransientMaxIterations) || pseudoTransientMaxIterations < 1) {
     throw invalidElement("dcOp", "pseudoTransientMaxIterations must be a positive integer");
   }
+  if (
+    newtonStepLimit !== undefined &&
+    (!Number.isFinite(newtonStepLimit) || newtonStepLimit <= 0.0)
+  ) {
+    throw invalidElement("dcOp", "newtonStepLimit must be finite and positive");
+  }
   return {
     maxIterations,
     tolerance,
@@ -14177,6 +14242,7 @@ function validatedDcOpOptions(options: DcOpOptions): ResolvedDcOpOptions {
     pseudoTransientSteps,
     pseudoTransientConductance,
     pseudoTransientMaxIterations,
+    newtonStepLimit,
   };
 }
 
@@ -14807,6 +14873,8 @@ function linearSolutionFromVector(
     iterations: 1,
     converged,
     maxDelta,
+    limitedNewtonSteps: 0,
+    minimumDampingFactor: 1.0,
     solverProfile,
   };
 }
@@ -14817,6 +14885,63 @@ function maxVectorDelta(left: readonly number[], right: readonly number[]): numb
     max = Math.max(max, Math.abs(left[index] - right[index]));
   }
   return max;
+}
+
+interface NewtonStepLimitResult {
+  readonly vector: readonly number[];
+  readonly maxDelta: number;
+  readonly dampingFactor: number;
+  readonly limited: boolean;
+}
+
+function limitNewtonStep(
+  previous: readonly number[],
+  candidate: readonly number[],
+  stepLimit?: number,
+): NewtonStepLimitResult {
+  if (stepLimit === undefined) {
+    return {
+      vector: [...candidate],
+      maxDelta: maxVectorDelta(previous, candidate),
+      dampingFactor: 1.0,
+      limited: false,
+    };
+  }
+
+  const rawDelta = maxVectorDelta(previous, candidate);
+  if (rawDelta <= stepLimit) {
+    return {
+      vector: [...candidate],
+      maxDelta: rawDelta,
+      dampingFactor: 1.0,
+      limited: false,
+    };
+  }
+
+  if (!Number.isFinite(rawDelta)) {
+    return {
+      vector: candidate.map((value, index) => {
+        const delta = value - previous[index];
+        if (!Number.isFinite(delta)) {
+          return previous[index];
+        }
+        return previous[index] + Math.sign(delta) * stepLimit;
+      }),
+      maxDelta: stepLimit,
+      dampingFactor: 0.0,
+      limited: true,
+    };
+  }
+
+  const dampingFactor = stepLimit / rawDelta;
+  return {
+    vector: candidate.map(
+      (value, index) => previous[index] + (value - previous[index]) * dampingFactor,
+    ),
+    maxDelta: stepLimit,
+    dampingFactor,
+    limited: true,
+  };
 }
 
 function buildSmallSignalMatrix(
@@ -15119,6 +15244,8 @@ function makeDcResult(
     tolerance: 0.0,
     maxDelta: 0.0,
     convergenceAid,
+    limitedNewtonSteps: 0,
+    minimumDampingFactor: 1.0,
     solverProfile: emptySolverProfile(0),
   },
 ): DcResult {

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -237,6 +237,9 @@ describe("dcOp", () => {
     expect(result.diagnostics.convergenceAid).toBe("newton");
     expectClose(result.diagnostics.tolerance, 1.0e-9);
     expect(Number.isFinite(result.diagnostics.maxDelta)).toBe(true);
+    expect(result.diagnostics.newtonStepLimit).toBeUndefined();
+    expect(result.diagnostics.limitedNewtonSteps).toBe(0);
+    expectClose(result.diagnostics.minimumDampingFactor, 1.0);
     expect(result.diagnostics.solverProfile.matrixSize).toBe(36);
     expect(result.diagnostics.solverProfile.solver).toBe("sparse_real");
     expect(result.diagnostics.solverProfile.backend).toBe("native_sparse_gaussian");
@@ -657,6 +660,30 @@ describe("dcOp", () => {
     expect(result.iterations).toBe(1);
   });
 
+  it("reports damped nonlinear Newton steps from the step limiter", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vs", "in", "0", 10.0));
+    circuit.add(diode("D1", "in", "out", 1.0e-15, 0.02585));
+    circuit.add(resistor("Rload", "out", "0", 100.0));
+
+    const result = dcOp(circuit, {
+      maxIterations: 1,
+      convergenceAids: false,
+      newtonStepLimit: 0.25,
+    });
+
+    expect(result.converged).toBe(false);
+    expect(result.convergenceAid).toBe("none");
+    expectClose(result.diagnostics.newtonStepLimit ?? 0.0, 0.25);
+    expect(result.diagnostics.limitedNewtonSteps).toBe(1);
+    expect(result.diagnostics.minimumDampingFactor).toBeGreaterThan(0.0);
+    expect(result.diagnostics.minimumDampingFactor).toBeLessThan(1.0);
+    expectClose(result.diagnostics.maxDelta, 0.25);
+    expect(Math.max(...Array.from(result.nodeVoltages.values()).map(Math.abs))).toBeLessThanOrEqual(
+      0.25 + 1.0e-12,
+    );
+  });
+
   it("recovers with pseudo-transient continuation after earlier aids fail", () => {
     const circuit = new Circuit();
     circuit.add(voltageSource("Vs", "in", "0", 10.0));
@@ -850,6 +877,9 @@ describe("dcOp", () => {
     );
     expect(() => dcOp(circuit, { tolerance: 0.0 })).toThrowError(
       "tolerance must be finite and positive",
+    );
+    expect(() => dcOp(circuit, { newtonStepLimit: 0.0 })).toThrowError(
+      "newtonStepLimit must be finite and positive",
     );
   });
 

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -15,20 +15,16 @@ downstream tools to compare.
 
 ## Current PR Slice
 
-1. Production solver core.
+1. Nonlinear convergence hardening.
    - Status: current PR completion candidate.
-   - Python now routes large real DC solves through an optional SciPy sparse-LU
-     backend when available and falls back to the native sparse-row Gaussian
-     solver with an explicit fallback reason.
-   - Rust and TypeScript keep their native sparse-row real solver paths and now
-     report the actual backend used for large DC solves.
-   - Python, Rust, and TypeScript `DcResult.diagnostics` now carry a stable
-     solver profile with matrix size, selected solver kind, backend,
-     structural nonzero count, density, peak fill-in count, and fallback
-     metadata so production integrations can audit sparse activation without
-     reparsing matrices.
-   - Sparse large-ladder parity tests cover the profile contract across all
-     three packages while preserving existing real and complex solver behavior.
+   - Python, Rust, and TypeScript DC operating-point solves now apply a
+     configurable Newton update limit only when nonlinear devices are present,
+     keeping linear one-pass solves unchanged.
+   - `DcResult.diagnostics` now reports the active Newton step limit, clipped
+     Newton-step count, and minimum damping factor so difficult deck
+     convergence is auditable without reparsing iteration traces.
+   - Cross-language tests cover both the inactive linear sparse-ladder path and
+     a damped nonlinear first-step solve with convergence aids disabled.
 
 ## Completed Slices
 


### PR DESCRIPTION
## Summary

- Add a configurable nonlinear Newton step limiter to Python, Rust, and TypeScript SPICE DC operating-point solves.
- Report limiter diagnostics (`newton_step_limit` / `newtonStepLimit`, limited step count, minimum damping factor) alongside existing DC solver diagnostics.
- Keep linear solves unaffected and document the current nonlinear convergence-hardening slice in package docs and the full implementation plan.

## Validation

- `PYTHONPATH=$PWD/code/packages/python/spice-engine/src:$PWD/code/packages/python/mosfet-models/src:$PWD/code/packages/python/device-physics/src /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python -m pytest code/packages/python/spice-engine/tests/test_engine.py`
- `cargo test --manifest-path code/packages/rust/spice-engine/Cargo.toml`
- `npm test` in `code/packages/typescript/spice-engine`
- `npm run build` in `code/packages/typescript/spice-engine`
- `/Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/ruff check code/packages/python/spice-engine/src/spice_engine/engine.py code/packages/python/spice-engine/tests/test_engine.py`
- `git diff --check`
