### PR TITLE
Add smart-home dashboard brightness controls

### DIFF
--- a/code/packages/rust/smart-home-platform-http/CHANGELOG.md
+++ b/code/packages/rust/smart-home-platform-http/CHANGELOG.md
@@ -29,6 +29,9 @@ All notable changes to this package will be documented in this file.
 - Extended the embedded dashboard shell with scene activation,
   desired-state clearing, and recent state-history previews over existing
   runtime-authorized API routes.
+- Added browser dashboard light brightness controls that discover commandable
+  ranged capabilities and dispatch through the existing `set_brightness`
+  service path.
 - Added a native readiness checklist route with actionable links for registry,
   topology, state coverage, event bus, discovery, supervisor, authorization,
   and desired-state checks.

--- a/code/packages/rust/smart-home-platform-http/README.md
+++ b/code/packages/rust/smart-home-platform-http/README.md
@@ -87,9 +87,9 @@ the Home Assistant-style history route accepts `filter_entity_id`.
 The browser routes serve an embedded local dashboard shell over the same
 `web-core::WebApp`. The shell loads bootstrap, readiness, state, scene,
 desired-state, state-history, and audit data from the native API routes and
-sends light, scene, and desired-state actions through the existing
-Home Assistant-compatible and native service endpoints, preserving runtime
-authorization.
+sends light on/off, light brightness, scene, and desired-state actions through
+the existing Home Assistant-compatible and native service endpoints, preserving
+runtime authorization.
 
 ## Dependencies
 

--- a/code/packages/rust/smart-home-platform-http/src/lib.rs
+++ b/code/packages/rust/smart-home-platform-http/src/lib.rs
@@ -228,6 +228,16 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
       margin-top: 10px;
     }
 
+    .range-control {
+      display: grid;
+      gap: 6px;
+      margin-top: 10px;
+    }
+
+    .range-control input {
+      width: 100%;
+    }
+
     .log {
       max-height: 170px;
       overflow: auto;
@@ -359,6 +369,16 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
     const deltasText = (deltas) => (deltas || [])
       .map((delta) => `${delta.capability_id}: ${valueText(delta.value)}`)
       .join(", ") || "No targets";
+    const capability = (entity, capabilityId) => (entity.capabilities || [])
+      .find((item) => item.capability_id === capabilityId);
+    const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
+    const brightnessValue = (entity, min, max) => {
+      const value = entity.value;
+      const raw = value && typeof value === "object" ? value["light.brightness"] : undefined;
+      return clamp(typeof raw === "number" ? raw : max, min, max);
+    };
+    const brightnessInputFor = (entityId) => Array.from(document.querySelectorAll("[data-brightness-input]"))
+      .find((input) => input.dataset.brightnessInput === entityId);
     const observedText = (ms) => {
       if (typeof ms !== "number") {
         return "";
@@ -405,6 +425,12 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
       els.entities.innerHTML = states.states.map((entity) => {
         const value = entity.value === null ? "No state" : JSON.stringify(entity.value);
         const canToggle = entity.domain === "light";
+        const brightness = capability(entity, "light.brightness");
+        const canSetBrightness = canToggle && brightness && brightness.commandable;
+        const brightnessMin = Number.isFinite(brightness?.min) ? brightness.min : 0;
+        const brightnessMax = Number.isFinite(brightness?.max) ? brightness.max : 100;
+        const brightnessStep = Number.isFinite(brightness?.step) && brightness.step > 0 ? brightness.step : 1;
+        const brightnessCurrent = brightnessValue(entity, brightnessMin, brightnessMax);
         return `
           <article class="entity-card">
             <div class="row" style="justify-content: space-between;">
@@ -418,6 +444,13 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
             <div class="actions row">
               ${canToggle ? `<button type="button" data-service="turn_on" data-entity="${entity.home_assistant_entity_id}">Turn on</button><button type="button" data-service="turn_off" data-entity="${entity.home_assistant_entity_id}">Turn off</button>` : ""}
             </div>
+            ${canSetBrightness ? `
+              <label class="range-control">
+                <span class="muted">Brightness <strong data-brightness-value="${entity.home_assistant_entity_id}">${brightnessCurrent}%</strong></span>
+                <input type="range" min="${brightnessMin}" max="${brightnessMax}" step="${brightnessStep}" value="${brightnessCurrent}" data-brightness-input="${entity.home_assistant_entity_id}">
+                <button type="button" data-service="set_brightness" data-entity="${entity.home_assistant_entity_id}" data-brightness-for="${entity.home_assistant_entity_id}">Set brightness</button>
+              </label>
+            ` : ""}
           </article>
         `;
       }).join("");
@@ -503,6 +536,17 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
       }
     };
 
+    document.addEventListener("input", (event) => {
+      const input = event.target.closest("input[data-brightness-input]");
+      if (!input) {
+        return;
+      }
+      const value = document.querySelector(`[data-brightness-value="${input.dataset.brightnessInput}"]`);
+      if (value) {
+        value.textContent = `${input.value}%`;
+      }
+    });
+
     document.addEventListener("click", async (event) => {
       const serviceButton = event.target.closest("button[data-service]");
       const sceneButton = event.target.closest("button[data-scene]");
@@ -514,10 +558,15 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
       button.disabled = true;
       try {
         if (serviceButton) {
+          const body = {entity_id: serviceButton.dataset.entity};
+          if (serviceButton.dataset.service === "set_brightness") {
+            const input = brightnessInputFor(serviceButton.dataset.brightnessFor);
+            body.brightness_pct = input ? Number(input.value) : 100;
+          }
           await json(`/api/services/light/${serviceButton.dataset.service}`, {
             method: "POST",
             headers: {"content-type": "application/json"},
-            body: JSON.stringify({entity_id: serviceButton.dataset.entity})
+            body: JSON.stringify(body)
           });
           log(`${serviceButton.dataset.service} accepted for ${serviceButton.dataset.entity}`);
         } else if (sceneButton) {
@@ -6287,6 +6336,8 @@ mod tests {
             assert!(body.contains("json(\"/api/smart_home/desired_states?limit=12\")"));
             assert!(body.contains("json(\"/api/smart_home/state_history?limit=12\")"));
             assert!(body.contains("/api/services/light/"));
+            assert!(body.contains("data-service=\"set_brightness\""));
+            assert!(body.contains("brightness_pct"));
             assert!(body.contains("/api/services/scene/turn_on"));
             assert!(body.contains("/api/smart_home/desired_states/"));
         }
@@ -7317,6 +7368,8 @@ mod tests {
         assert!(body.contains("json(\"/api/smart_home/desired_states?limit=12\")"));
         assert!(body.contains("json(\"/api/smart_home/state_history?limit=12\")"));
         assert!(body.contains("/api/services/light/"));
+        assert!(body.contains("data-brightness-input"));
+        assert!(body.contains("brightness_pct"));
         assert!(body.contains("/api/services/scene/turn_on"));
         assert!(body.contains("/api/smart_home/desired_states/"));
     }


### PR DESCRIPTION
## Summary
- add capability-aware brightness sliders to light cards in the embedded Codex Home dashboard
- dispatch brightness changes through the existing `/api/services/light/set_brightness` route with `brightness_pct`
- document the browser dashboard now covers light on/off, brightness, scenes, desired-state clearing, and state-history previews over the repo-owned HTTP stack

## Validation
- `cargo fmt -p smart-home-platform-http`
- `cargo test -p smart-home-platform-http -- --nocapture`
- `sh BUILD` from `code/packages/rust/smart-home-platform-http`
- `git diff --check`
