### PR TITLE
[codex] Add SPICE device model behavior fixtures

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Added
 
+- **Device model behavior audit fixtures** —
+  `device_model_behavior_audit_fixtures()` now exposes runnable one-device DC
+  bias fixtures with reference deck lines and stable probe-voltage windows for
+  diode, BJT, JFET, and Level-1 MOS model-depth audits, matching Rust and
+  TypeScript.
+
 - **Nonlinear Newton damping diagnostics** —
   `dc_op()` now applies a configurable `newton_step_limit` to nonlinear
   Newton updates and reports `newton_step_limit`, `limited_newton_steps`, and

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -199,7 +199,10 @@ disable the limiter.
 `mosfet_from_model_card()` provide the shared `.model` alias surface for diode,
 BJT, JFET, and Level-1 MOS cards. `device_model_audit_fixtures()` returns the
 canonical cross-language fixture cards used to keep the Python, Rust, and
-TypeScript ports aligned.
+TypeScript ports aligned. `device_model_behavior_audit_fixtures()` extends
+those cards into runnable one-device DC bias fixtures with reference deck lines
+and stable expected probe-voltage windows for diode, BJT, JFET, and Level-1 MOS
+model-depth audits.
 
 `DigitalEventStream`, `DigitalLogicLevels`, and `DigitalThresholds` provide the
 first mixed-signal bridge surface: digital event streams can drive finite-edge

--- a/code/packages/python/spice-engine/src/spice_engine/__init__.py
+++ b/code/packages/python/spice-engine/src/spice_engine/__init__.py
@@ -330,9 +330,11 @@ from spice_engine.engine import (
     transient_with_digital_event_streams_corners,
 )
 from spice_engine.model_cards import (
+    DeviceModelBehaviorFixture,
     NormalizedModelCard,
     bjt_from_model_card,
     device_model_audit_fixtures,
+    device_model_behavior_audit_fixtures,
     diode_from_model_card,
     jfet_from_model_card,
     mosfet_from_model_card,
@@ -452,7 +454,9 @@ __all__ = [
     "DistortionPoint",
     "DistortionResult",
     "Element",
+    "DeviceModelBehaviorFixture",
     "device_model_audit_fixtures",
+    "device_model_behavior_audit_fixtures",
     "ExpWaveform",
     "FourierHarmonic",
     "FourierProbeResult",

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -12,7 +12,8 @@ from dataclasses import dataclass, replace
 
 from mosfet_models import MOSFET, Level1Model, Level1Params, MosfetType
 
-from spice_engine.elements import BJT, JFET, Diode, Mosfet
+from spice_engine.elements import BJT, JFET, Diode, Mosfet, Resistor, VoltageSource
+from spice_engine.engine import Circuit
 
 
 @dataclass(frozen=True, slots=True)
@@ -23,6 +24,20 @@ class NormalizedModelCard:
     kind: str
     parameters: dict[str, float]
     unsupported_parameters: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class DeviceModelBehaviorFixture:
+    """A runnable device-model reference fixture with a stable DC probe window."""
+
+    name: str
+    kind: str
+    model: NormalizedModelCard
+    circuit: Circuit
+    probe_node: str
+    expected_min: float
+    expected_max: float
+    deck_lines: tuple[str, ...]
 
 
 _MODEL_TYPE_ALIASES: dict[str, str] = {
@@ -311,5 +326,127 @@ def device_model_audit_fixtures() -> tuple[NormalizedModelCard, ...]:
             "Mn",
             "nmos",
             {"LEVEL": 1.0, "VTO": 0.55, "LAM": 0.04, "NSUB": 1.6, "CJD": 3.0e-13},
+        ),
+    )
+
+
+def _model_card_by_name() -> dict[str, NormalizedModelCard]:
+    return {model.name: model for model in device_model_audit_fixtures()}
+
+
+def device_model_behavior_audit_fixtures() -> tuple[DeviceModelBehaviorFixture, ...]:
+    """Return runnable one-device bias fixtures for model-depth audits.
+
+    The circuits are intentionally small and DC-only.  They make the current
+    diode, BJT, JFET, and Level-1 MOS behavior executable while carrying deck
+    lines that future parser-backed reference-deck tests can consume.
+    """
+
+    models = _model_card_by_name()
+
+    diode_circuit = Circuit()
+    diode_circuit.add(VoltageSource("Vbias", "vin", "0", 0.8))
+    diode_circuit.add(Resistor("Rlimit", "vin", "out", 1_000.0))
+    diode_circuit.add(diode_from_model_card("D1", "out", "0", models["Dfast"]))
+
+    bjt_circuit = Circuit()
+    bjt_circuit.add(VoltageSource("Vcc", "vcc", "0", 5.0))
+    bjt_circuit.add(VoltageSource("Vbase", "base", "0", 0.72))
+    bjt_circuit.add(Resistor("Rload", "out", "0", 1_000.0))
+    bjt_circuit.add(bjt_from_model_card("Q1", "vcc", "base", "out", models["Qsmall"]))
+
+    jfet_circuit = Circuit()
+    jfet_circuit.add(VoltageSource("Vdd", "vdd", "0", 10.0))
+    jfet_circuit.add(VoltageSource("Vg", "gate", "0", 0.0))
+    jfet_circuit.add(Resistor("Rd", "vdd", "drain", 2_000.0))
+    jfet_circuit.add(Resistor("Rs", "source", "0", 1_000.0))
+    jfet_circuit.add(jfet_from_model_card("J1", "drain", "gate", "source", models["Jn"]))
+
+    mos_circuit = Circuit()
+    mos_circuit.add(VoltageSource("Vdd", "vdd", "0", 1.8))
+    mos_circuit.add(VoltageSource("Vgate", "gate", "0", 1.8))
+    mos_circuit.add(Resistor("Rload", "vdd", "out", 1_000.0))
+    mos_circuit.add(mosfet_from_model_card("M1", "out", "gate", "0", "0", models["Mn"]))
+
+    return (
+        DeviceModelBehaviorFixture(
+            name="diode-forward-bias",
+            kind=models["Dfast"].kind,
+            model=models["Dfast"],
+            circuit=diode_circuit,
+            probe_node="out",
+            expected_min=0.55,
+            expected_max=0.65,
+            deck_lines=(
+                "* device-model behavior fixture: diode-forward-bias",
+                ".model Dfast D(IS=2e-14 CJO=1.5e-12 TT=4e-9)",
+                "Vbias vin 0 0.8",
+                "Rlimit vin out 1k",
+                "D1 out 0 Dfast",
+                ".op",
+                ".save V(out)",
+                ".end",
+            ),
+        ),
+        DeviceModelBehaviorFixture(
+            name="bjt-emitter-follower",
+            kind=models["Qsmall"].kind,
+            model=models["Qsmall"],
+            circuit=bjt_circuit,
+            probe_node="out",
+            expected_min=0.08,
+            expected_max=0.18,
+            deck_lines=(
+                "* device-model behavior fixture: bjt-emitter-follower",
+                ".model Qsmall NPN(BF=125 CJE=2e-12 TF=1e-10)",
+                "Vcc vcc 0 5",
+                "Vbase base 0 0.72",
+                "Q1 vcc base out Qsmall",
+                "Rload out 0 1k",
+                ".op",
+                ".save V(out)",
+                ".end",
+            ),
+        ),
+        DeviceModelBehaviorFixture(
+            name="jfet-source-bias",
+            kind=models["Jn"].kind,
+            model=models["Jn"],
+            circuit=jfet_circuit,
+            probe_node="source",
+            expected_min=0.80,
+            expected_max=0.95,
+            deck_lines=(
+                "* device-model behavior fixture: jfet-source-bias",
+                ".model Jn NJF(BETA=9e-4 VTO=-1.8 LAMBDA=0.02)",
+                "Vdd vdd 0 10",
+                "Vg gate 0 0",
+                "Rd vdd drain 2k",
+                "Rs source 0 1k",
+                "J1 drain gate source Jn",
+                ".op",
+                ".save V(source)",
+                ".end",
+            ),
+        ),
+        DeviceModelBehaviorFixture(
+            name="mos-level1-common-source",
+            kind=models["Mn"].kind,
+            model=models["Mn"],
+            circuit=mos_circuit,
+            probe_node="out",
+            expected_min=0.55,
+            expected_max=0.85,
+            deck_lines=(
+                "* device-model behavior fixture: mos-level1-common-source",
+                ".model Mn NMOS(LEVEL=1 VTO=0.55 LAMBDA=0.04 NSUB=1.6 CBD=3e-13)",
+                "Vdd vdd 0 1.8",
+                "Vgate gate 0 1.8",
+                "Rload vdd out 1k",
+                "M1 out gate 0 0 Mn",
+                ".op",
+                ".save V(out)",
+                ".end",
+            ),
         ),
     )

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -181,6 +181,7 @@ from spice_engine import (
     deck_output_plan_artifact_records,
     deck_table_records,
     device_model_audit_fixtures,
+    device_model_behavior_audit_fixtures,
     digital_event_streams_to_bridge_schedule,
     digital_event_streams_to_voltage_sources,
     digital_events_to_pwl_waveform,
@@ -403,6 +404,25 @@ def test_model_card_audit_fixtures_cover_supported_device_families() -> None:
     assert fixtures[1].parameters["BF"] == pytest.approx(125.0)
     assert fixtures[2].parameters["VTO"] == pytest.approx(-1.8)
     assert fixtures[3].parameters["VT0"] == pytest.approx(0.55)
+
+
+def test_device_model_behavior_audit_fixtures_run_reference_bias_points() -> None:
+    fixtures = device_model_behavior_audit_fixtures()
+    assert [fixture.name for fixture in fixtures] == [
+        "diode-forward-bias",
+        "bjt-emitter-follower",
+        "jfet-source-bias",
+        "mos-level1-common-source",
+    ]
+
+    for fixture in fixtures:
+        result = dc_op(fixture.circuit)
+        value = result.node_voltages[fixture.probe_node]
+        assert result.converged
+        assert fixture.expected_min <= value <= fixture.expected_max
+        assert fixture.deck_lines[0].startswith("* device-model behavior fixture:")
+        assert ".op" in fixture.deck_lines
+        assert any(line.startswith(".model ") for line in fixture.deck_lines)
 
 
 def test_non_level_one_mos_model_cards_are_explicitly_rejected() -> None:

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add `device_model_behavior_audit_fixtures` runnable one-device DC bias
+  fixtures with reference deck lines and stable probe-voltage windows for
+  diode, BJT, JFET, and Level-1 MOS model-depth audits, matching Python and
+  TypeScript.
 - Add configurable nonlinear Newton damping through
   `DcOpOptions::newton_step_limit`, plus stable diagnostics for
   `newton_step_limit`, `limited_newton_steps`, and `minimum_damping_factor`,

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -123,6 +123,9 @@ BJT, and Level-1 MOSFET models before running an analysis.
 `.model` alias surface for diode, BJT, JFET, and Level-1 MOS cards.
 `device_model_audit_fixtures` returns the canonical cross-language fixture
 cards used to keep the Rust, Python, and TypeScript ports aligned.
+`device_model_behavior_audit_fixtures` extends those cards into runnable
+one-device DC bias fixtures with reference deck lines and stable expected
+probe-voltage windows for diode, BJT, JFET, and Level-1 MOS model-depth audits.
 
 `analyze_custom_model_source` accepts only a two-terminal `I(p,n) <+ ...`
 module shape and rejects dynamic/event/system constructs; it is not a full

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -2814,6 +2814,18 @@ pub struct NormalizedModelCard {
     pub unsupported_parameters: Vec<String>,
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct DeviceModelBehaviorFixture {
+    pub name: String,
+    pub kind: ModelCardKind,
+    pub model: NormalizedModelCard,
+    pub circuit: Circuit,
+    pub probe_node: String,
+    pub expected_min: f64,
+    pub expected_max: f64,
+    pub deck_lines: Vec<String>,
+}
+
 fn model_type_key(text: &str) -> String {
     text.trim()
         .chars()
@@ -3132,6 +3144,182 @@ pub fn device_model_audit_fixtures() -> Result<Vec<NormalizedModelCard>, SpiceEr
                 ("CJD", 3.0e-13),
             ],
         )?,
+    ])
+}
+
+fn model_card_by_name(
+    models: &[NormalizedModelCard],
+) -> Result<BTreeMap<String, NormalizedModelCard>, SpiceError> {
+    Ok(models
+        .iter()
+        .map(|model| (model.name.clone(), model.clone()))
+        .collect())
+}
+
+pub fn device_model_behavior_audit_fixtures() -> Result<Vec<DeviceModelBehaviorFixture>, SpiceError>
+{
+    let models = model_card_by_name(&device_model_audit_fixtures()?)?;
+
+    let diode_model = models
+        .get("Dfast")
+        .ok_or_else(|| SpiceError::InvalidElement {
+            name: "device_model_behavior_audit_fixtures".to_string(),
+            reason: "missing Dfast model fixture".to_string(),
+        })?;
+    let mut diode_circuit = Circuit::new();
+    diode_circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vbias", "vin", "0", 0.8,
+    )));
+    diode_circuit.add(Element::Resistor(Resistor::new(
+        "Rlimit", "vin", "out", 1_000.0,
+    )));
+    diode_circuit.add(Element::Diode(diode_from_model_card(
+        "D1",
+        "out",
+        "0",
+        diode_model,
+    )?));
+
+    let bjt_model = models
+        .get("Qsmall")
+        .ok_or_else(|| SpiceError::InvalidElement {
+            name: "device_model_behavior_audit_fixtures".to_string(),
+            reason: "missing Qsmall model fixture".to_string(),
+        })?;
+    let mut bjt_circuit = Circuit::new();
+    bjt_circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vcc", "vcc", "0", 5.0,
+    )));
+    bjt_circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vbase", "base", "0", 0.72,
+    )));
+    bjt_circuit.add(Element::Resistor(Resistor::new(
+        "Rload", "out", "0", 1_000.0,
+    )));
+    bjt_circuit.add(Element::Bjt(bjt_from_model_card(
+        "Q1", "vcc", "base", "out", bjt_model,
+    )?));
+
+    let jfet_model = models.get("Jn").ok_or_else(|| SpiceError::InvalidElement {
+        name: "device_model_behavior_audit_fixtures".to_string(),
+        reason: "missing Jn model fixture".to_string(),
+    })?;
+    let mut jfet_circuit = Circuit::new();
+    jfet_circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vdd", "vdd", "0", 10.0,
+    )));
+    jfet_circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vg", "gate", "0", 0.0,
+    )));
+    jfet_circuit.add(Element::Resistor(Resistor::new(
+        "Rd", "vdd", "drain", 2_000.0,
+    )));
+    jfet_circuit.add(Element::Resistor(Resistor::new(
+        "Rs", "source", "0", 1_000.0,
+    )));
+    jfet_circuit.add(Element::Jfet(jfet_from_model_card(
+        "J1", "drain", "gate", "source", jfet_model,
+    )?));
+
+    let mos_model = models.get("Mn").ok_or_else(|| SpiceError::InvalidElement {
+        name: "device_model_behavior_audit_fixtures".to_string(),
+        reason: "missing Mn model fixture".to_string(),
+    })?;
+    let mut mos_circuit = Circuit::new();
+    mos_circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vdd", "vdd", "0", 1.8,
+    )));
+    mos_circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vgate", "gate", "0", 1.8,
+    )));
+    mos_circuit.add(Element::Resistor(Resistor::new(
+        "Rload", "vdd", "out", 1_000.0,
+    )));
+    mos_circuit.add(Element::Mosfet(mosfet_from_model_card(
+        "M1", "out", "gate", "0", "0", mos_model,
+    )?));
+
+    Ok(vec![
+        DeviceModelBehaviorFixture {
+            name: "diode-forward-bias".to_string(),
+            kind: diode_model.kind,
+            model: diode_model.clone(),
+            circuit: diode_circuit,
+            probe_node: "out".to_string(),
+            expected_min: 0.55,
+            expected_max: 0.65,
+            deck_lines: vec![
+                "* device-model behavior fixture: diode-forward-bias".to_string(),
+                ".model Dfast D(IS=2e-14 CJO=1.5e-12 TT=4e-9)".to_string(),
+                "Vbias vin 0 0.8".to_string(),
+                "Rlimit vin out 1k".to_string(),
+                "D1 out 0 Dfast".to_string(),
+                ".op".to_string(),
+                ".save V(out)".to_string(),
+                ".end".to_string(),
+            ],
+        },
+        DeviceModelBehaviorFixture {
+            name: "bjt-emitter-follower".to_string(),
+            kind: bjt_model.kind,
+            model: bjt_model.clone(),
+            circuit: bjt_circuit,
+            probe_node: "out".to_string(),
+            expected_min: 0.08,
+            expected_max: 0.18,
+            deck_lines: vec![
+                "* device-model behavior fixture: bjt-emitter-follower".to_string(),
+                ".model Qsmall NPN(BF=125 CJE=2e-12 TF=1e-10)".to_string(),
+                "Vcc vcc 0 5".to_string(),
+                "Vbase base 0 0.72".to_string(),
+                "Q1 vcc base out Qsmall".to_string(),
+                "Rload out 0 1k".to_string(),
+                ".op".to_string(),
+                ".save V(out)".to_string(),
+                ".end".to_string(),
+            ],
+        },
+        DeviceModelBehaviorFixture {
+            name: "jfet-source-bias".to_string(),
+            kind: jfet_model.kind,
+            model: jfet_model.clone(),
+            circuit: jfet_circuit,
+            probe_node: "source".to_string(),
+            expected_min: 0.80,
+            expected_max: 0.95,
+            deck_lines: vec![
+                "* device-model behavior fixture: jfet-source-bias".to_string(),
+                ".model Jn NJF(BETA=9e-4 VTO=-1.8 LAMBDA=0.02)".to_string(),
+                "Vdd vdd 0 10".to_string(),
+                "Vg gate 0 0".to_string(),
+                "Rd vdd drain 2k".to_string(),
+                "Rs source 0 1k".to_string(),
+                "J1 drain gate source Jn".to_string(),
+                ".op".to_string(),
+                ".save V(source)".to_string(),
+                ".end".to_string(),
+            ],
+        },
+        DeviceModelBehaviorFixture {
+            name: "mos-level1-common-source".to_string(),
+            kind: mos_model.kind,
+            model: mos_model.clone(),
+            circuit: mos_circuit,
+            probe_node: "out".to_string(),
+            expected_min: 0.55,
+            expected_max: 0.85,
+            deck_lines: vec![
+                "* device-model behavior fixture: mos-level1-common-source".to_string(),
+                ".model Mn NMOS(LEVEL=1 VTO=0.55 LAMBDA=0.04 NSUB=1.6 CBD=3e-13)".to_string(),
+                "Vdd vdd 0 1.8".to_string(),
+                "Vgate gate 0 1.8".to_string(),
+                "Rload vdd out 1k".to_string(),
+                "M1 out gate 0 0 Mn".to_string(),
+                ".op".to_string(),
+                ".save V(out)".to_string(),
+                ".end".to_string(),
+            ],
+        },
     ])
 }
 

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -3,10 +3,10 @@ use spice_engine::{
     dc_corners_parallel, dc_initial_vector_from_conditions, dc_op, dc_op_with_initial_conditions,
     dc_op_with_options, dc_sweep, dc_sweep_corners, dc_sweep_corners_parallel,
     dc_temperature_sweep, dc_temperature_sweep_corners, device_model_audit_fixtures,
-    diode_from_model_card, format_corner_dc_sweep_table, format_corner_dc_table,
-    format_corner_temperature_dc_table, format_dc_sweep_table, format_measurement_table,
-    format_temperature_dc_table, jfet_from_model_card, measure_dc_sweep_deck,
-    measure_dc_sweep_probe, mosfet_from_model_card, normalize_model_card,
+    device_model_behavior_audit_fixtures, diode_from_model_card, format_corner_dc_sweep_table,
+    format_corner_dc_table, format_corner_temperature_dc_table, format_dc_sweep_table,
+    format_measurement_table, format_temperature_dc_table, jfet_from_model_card,
+    measure_dc_sweep_deck, measure_dc_sweep_probe, mosfet_from_model_card, normalize_model_card,
     normalize_model_card_type, resolve_deck_initial_conditions, BSource, Bjt, BjtPolarity, Cccs,
     Ccvs, Circuit, CornerOverride, CornerSpec, CornerTemperatureDcResult, CurrentSource,
     CustomModel, DcConvergenceAid, DcOpOptions, Diode, Element, Inductor, Jfet, JfetPolarity,
@@ -126,6 +126,46 @@ fn model_card_audit_fixtures_cover_supported_device_families() {
     assert_close(*fixtures[1].parameters.get("BF").unwrap(), 125.0);
     assert_close(*fixtures[2].parameters.get("VTO").unwrap(), -1.8);
     assert_close(*fixtures[3].parameters.get("VT0").unwrap(), 0.55);
+}
+
+#[test]
+fn device_model_behavior_audit_fixtures_run_reference_bias_points() {
+    let fixtures = device_model_behavior_audit_fixtures().unwrap();
+    assert_eq!(
+        fixtures
+            .iter()
+            .map(|fixture| fixture.name.as_str())
+            .collect::<Vec<_>>(),
+        vec![
+            "diode-forward-bias",
+            "bjt-emitter-follower",
+            "jfet-source-bias",
+            "mos-level1-common-source"
+        ]
+    );
+
+    for fixture in fixtures {
+        let result = dc_op(&fixture.circuit).unwrap();
+        let value = *result
+            .node_voltages
+            .get(&fixture.probe_node)
+            .expect("fixture probe node should be present");
+        assert!(result.converged);
+        assert!(
+            value >= fixture.expected_min && value <= fixture.expected_max,
+            "{} expected {} <= {} <= {}",
+            fixture.name,
+            fixture.expected_min,
+            value,
+            fixture.expected_max
+        );
+        assert!(fixture.deck_lines[0].starts_with("* device-model behavior fixture:"));
+        assert!(fixture.deck_lines.iter().any(|line| line == ".op"));
+        assert!(fixture
+            .deck_lines
+            .iter()
+            .any(|line| line.starts_with(".model ")));
+    }
 }
 
 #[test]

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add `deviceModelBehaviorAuditFixtures` runnable one-device DC bias fixtures
+  with reference deck lines and stable probe-voltage windows for diode, BJT,
+  JFET, and Level-1 MOS model-depth audits, matching Python and Rust.
 - Add configurable nonlinear Newton damping through
   `dcOp(..., { newtonStepLimit })`, plus stable diagnostics for
   `newtonStepLimit`, `limitedNewtonSteps`, and `minimumDampingFactor`,

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -188,6 +188,9 @@ with optional `HARMONICS=` and `FROM=` controls.
 alias surface for diode, BJT, JFET, and Level-1 MOS cards.
 `deviceModelAuditFixtures` returns the canonical cross-language fixture cards
 used to keep the TypeScript, Python, and Rust ports aligned.
+`deviceModelBehaviorAuditFixtures` extends those cards into runnable one-device
+DC bias fixtures with reference deck lines and stable expected probe-voltage
+windows for diode, BJT, JFET, and Level-1 MOS model-depth audits.
 
 `CustomModel`, `CustomModelEvaluation`, `customLinearConductanceModel`, and
 `analyzeCustomModelSource` provide the first native-web custom-model foothold.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -994,6 +994,17 @@ export interface NormalizedModelCard {
   readonly unsupportedParameters: readonly string[];
 }
 
+export interface DeviceModelBehaviorFixture {
+  readonly name: string;
+  readonly kind: ModelCardKind;
+  readonly model: NormalizedModelCard;
+  readonly circuit: Circuit;
+  readonly probeNode: string;
+  readonly expectedMin: number;
+  readonly expectedMax: number;
+  readonly deckLines: readonly string[];
+}
+
 export interface Vccs {
   readonly kind: "vccs";
   readonly name: string;
@@ -7028,6 +7039,136 @@ export function deviceModelAuditFixtures(): readonly NormalizedModelCard[] {
       NSUB: 1.6,
       CJD: 3.0e-13,
     }),
+  ];
+}
+
+function modelCardByName(models: readonly NormalizedModelCard[]): Map<string, NormalizedModelCard> {
+  return new Map(models.map((model) => [model.name, model]));
+}
+
+function requiredModel(
+  models: ReadonlyMap<string, NormalizedModelCard>,
+  name: string,
+): NormalizedModelCard {
+  const model = models.get(name);
+  if (model === undefined) {
+    throw invalidElement("deviceModelBehaviorAuditFixtures", `missing ${name} model fixture`);
+  }
+  return model;
+}
+
+export function deviceModelBehaviorAuditFixtures(): readonly DeviceModelBehaviorFixture[] {
+  const models = modelCardByName(deviceModelAuditFixtures());
+
+  const diodeModel = requiredModel(models, "Dfast");
+  const diodeCircuit = new Circuit();
+  diodeCircuit.add(voltageSource("Vbias", "vin", "0", 0.8));
+  diodeCircuit.add(resistor("Rlimit", "vin", "out", 1_000.0));
+  diodeCircuit.add(diodeFromModelCard("D1", "out", "0", diodeModel));
+
+  const bjtModel = requiredModel(models, "Qsmall");
+  const bjtCircuit = new Circuit();
+  bjtCircuit.add(voltageSource("Vcc", "vcc", "0", 5.0));
+  bjtCircuit.add(voltageSource("Vbase", "base", "0", 0.72));
+  bjtCircuit.add(resistor("Rload", "out", "0", 1_000.0));
+  bjtCircuit.add(bjtFromModelCard("Q1", "vcc", "base", "out", bjtModel));
+
+  const jfetModel = requiredModel(models, "Jn");
+  const jfetCircuit = new Circuit();
+  jfetCircuit.add(voltageSource("Vdd", "vdd", "0", 10.0));
+  jfetCircuit.add(voltageSource("Vg", "gate", "0", 0.0));
+  jfetCircuit.add(resistor("Rd", "vdd", "drain", 2_000.0));
+  jfetCircuit.add(resistor("Rs", "source", "0", 1_000.0));
+  jfetCircuit.add(jfetFromModelCard("J1", "drain", "gate", "source", jfetModel));
+
+  const mosModel = requiredModel(models, "Mn");
+  const mosCircuit = new Circuit();
+  mosCircuit.add(voltageSource("Vdd", "vdd", "0", 1.8));
+  mosCircuit.add(voltageSource("Vgate", "gate", "0", 1.8));
+  mosCircuit.add(resistor("Rload", "vdd", "out", 1_000.0));
+  mosCircuit.add(mosfetFromModelCard("M1", "out", "gate", "0", "0", mosModel));
+
+  return [
+    {
+      name: "diode-forward-bias",
+      kind: diodeModel.kind,
+      model: diodeModel,
+      circuit: diodeCircuit,
+      probeNode: "out",
+      expectedMin: 0.55,
+      expectedMax: 0.65,
+      deckLines: [
+        "* device-model behavior fixture: diode-forward-bias",
+        ".model Dfast D(IS=2e-14 CJO=1.5e-12 TT=4e-9)",
+        "Vbias vin 0 0.8",
+        "Rlimit vin out 1k",
+        "D1 out 0 Dfast",
+        ".op",
+        ".save V(out)",
+        ".end",
+      ],
+    },
+    {
+      name: "bjt-emitter-follower",
+      kind: bjtModel.kind,
+      model: bjtModel,
+      circuit: bjtCircuit,
+      probeNode: "out",
+      expectedMin: 0.08,
+      expectedMax: 0.18,
+      deckLines: [
+        "* device-model behavior fixture: bjt-emitter-follower",
+        ".model Qsmall NPN(BF=125 CJE=2e-12 TF=1e-10)",
+        "Vcc vcc 0 5",
+        "Vbase base 0 0.72",
+        "Q1 vcc base out Qsmall",
+        "Rload out 0 1k",
+        ".op",
+        ".save V(out)",
+        ".end",
+      ],
+    },
+    {
+      name: "jfet-source-bias",
+      kind: jfetModel.kind,
+      model: jfetModel,
+      circuit: jfetCircuit,
+      probeNode: "source",
+      expectedMin: 0.80,
+      expectedMax: 0.95,
+      deckLines: [
+        "* device-model behavior fixture: jfet-source-bias",
+        ".model Jn NJF(BETA=9e-4 VTO=-1.8 LAMBDA=0.02)",
+        "Vdd vdd 0 10",
+        "Vg gate 0 0",
+        "Rd vdd drain 2k",
+        "Rs source 0 1k",
+        "J1 drain gate source Jn",
+        ".op",
+        ".save V(source)",
+        ".end",
+      ],
+    },
+    {
+      name: "mos-level1-common-source",
+      kind: mosModel.kind,
+      model: mosModel,
+      circuit: mosCircuit,
+      probeNode: "out",
+      expectedMin: 0.55,
+      expectedMax: 0.85,
+      deckLines: [
+        "* device-model behavior fixture: mos-level1-common-source",
+        ".model Mn NMOS(LEVEL=1 VTO=0.55 LAMBDA=0.04 NSUB=1.6 CBD=3e-13)",
+        "Vdd vdd 0 1.8",
+        "Vgate gate 0 1.8",
+        "Rload vdd out 1k",
+        "M1 out gate 0 0 Mn",
+        ".op",
+        ".save V(out)",
+        ".end",
+      ],
+    },
   ];
 }
 

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -22,6 +22,7 @@ import {
   dcTemperatureSweep,
   dcTemperatureSweepCorners,
   deviceModelAuditFixtures,
+  deviceModelBehaviorAuditFixtures,
   diode,
   diodeFromModelCard,
   formatCornerDcSweepTable,
@@ -120,6 +121,28 @@ describe("dcOp", () => {
     expectClose(fixtures[1]!.parameters.BF, 125.0);
     expectClose(fixtures[2]!.parameters.VTO, -1.8);
     expectClose(fixtures[3]!.parameters.VT0, 0.55);
+  });
+
+  it("runs device model behavior audit fixtures as reference bias points", () => {
+    const fixtures = deviceModelBehaviorAuditFixtures();
+    expect(fixtures.map((fixture) => fixture.name)).toStrictEqual([
+      "diode-forward-bias",
+      "bjt-emitter-follower",
+      "jfet-source-bias",
+      "mos-level1-common-source",
+    ]);
+
+    for (const fixture of fixtures) {
+      const result = dcOp(fixture.circuit);
+      const value = result.voltage(fixture.probeNode);
+      expect(result.converged).toBe(true);
+      expect(value).not.toBeUndefined();
+      expect(value!).toBeGreaterThanOrEqual(fixture.expectedMin);
+      expect(value!).toBeLessThanOrEqual(fixture.expectedMax);
+      expect(fixture.deckLines[0]!.startsWith("* device-model behavior fixture:")).toBe(true);
+      expect(fixture.deckLines).toContain(".op");
+      expect(fixture.deckLines.some((line) => line.startsWith(".model "))).toBe(true);
+    }
   });
 
   it("rejects non-Level-1 MOS model cards explicitly", () => {

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -15,16 +15,18 @@ downstream tools to compare.
 
 ## Current PR Slice
 
-1. Nonlinear convergence hardening.
+1. Device model behavior audit fixtures.
    - Status: current PR completion candidate.
-   - Python, Rust, and TypeScript DC operating-point solves now apply a
-     configurable Newton update limit only when nonlinear devices are present,
-     keeping linear one-pass solves unchanged.
-   - `DcResult.diagnostics` now reports the active Newton step limit, clipped
-     Newton-step count, and minimum damping factor so difficult deck
-     convergence is auditable without reparsing iteration traces.
-   - Cross-language tests cover both the inactive linear sparse-ladder path and
-     a damped nonlinear first-step solve with convergence aids disabled.
+   - Python, Rust, and TypeScript now expose matching runnable
+     `device_model_behavior_audit_fixtures` /
+     `deviceModelBehaviorAuditFixtures` one-device DC bias fixtures for diode,
+     BJT, JFET, and Level-1 MOS models.
+   - Each fixture carries the normalized model card, a constructed executable
+     circuit, reference deck lines, selected probe node, and stable expected
+     probe-voltage window so device-depth audits can compare behavior rather
+     than only model-card aliases.
+   - Cross-language tests execute every fixture through DC operating-point
+     solving and verify the probe window plus reference-deck metadata.
 
 ## Completed Slices
 
@@ -1135,6 +1137,17 @@ downstream tools to compare.
       selected-run artifact now carries whole-deck analysis kind/directive
       inventories beside the selected analysis directive metadata.
 
+115. Nonlinear convergence hardening.
+   - Status: completed in this nonlinear convergence hardening slice.
+   - Python, Rust, and TypeScript DC operating-point solves now apply a
+     configurable Newton update limit only when nonlinear devices are present,
+     keeping linear one-pass solves unchanged.
+   - `DcResult.diagnostics` now reports the active Newton step limit, clipped
+     Newton-step count, and minimum damping factor so difficult deck
+     convergence is auditable without reparsing iteration traces.
+   - Cross-language tests cover both the inactive linear sparse-ladder path and
+     a damped nonlinear first-step solve with convergence aids disabled.
+
 ## Backlog
 
 1. Deck compatibility follow-up.
@@ -1189,6 +1202,6 @@ downstream tools to compare.
 
 ## Suggested PR Queue
 
-1. Nonlinear convergence hardening.
-2. Device model depth.
-3. Analysis completion.
+1. Device model depth.
+2. Analysis completion.
+3. Mixed-signal integration.


### PR DESCRIPTION
## Summary
- add cross-language runnable SPICE device model behavior audit fixtures for diode, BJT, JFET, and Level-1 MOS cards
- include normalized model cards, executable bias circuits, reference deck lines, probe nodes, and expected voltage windows
- update the full implementation plan and package docs/changelogs for the device-depth slice

## Validation
- `PYTHONPATH=$PWD/code/packages/python/spice-engine/src:$PWD/code/packages/python/mosfet-models/src:$PWD/code/packages/python/device-physics/src /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python -m pytest code/packages/python/spice-engine/tests/test_engine.py`
- `cargo test --manifest-path code/packages/rust/spice-engine/Cargo.toml`
- `npm ci`
- `npm test`
- `npm run build`
- `/Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/ruff check code/packages/python/spice-engine/src/spice_engine/model_cards.py code/packages/python/spice-engine/src/spice_engine/__init__.py code/packages/python/spice-engine/tests/test_engine.py && git diff --check`