### PR TITLE
[codex] feat(adj-ladder): Gemma result and LaTeX formula bridge

### DIFF
--- a/code/packages/rust/latex/Cargo.toml
+++ b/code/packages/rust/latex/Cargo.toml
@@ -18,3 +18,8 @@ math-frontend = { path = "../math-frontend", optional = true }
 # `--no-default-features` for the zero-dependency document/math parser alone.
 default = ["frontend"]
 frontend = ["dep:math-frontend"]
+
+[[bin]]
+name = "latex-math-to-adj"
+path = "src/bin/latex_math_to_adj.rs"
+required-features = ["frontend"]

--- a/code/packages/rust/latex/src/bin/latex_math_to_adj.rs
+++ b/code/packages/rust/latex/src/bin/latex_math_to_adj.rs
@@ -1,0 +1,165 @@
+use std::env;
+use std::io::{self, Read};
+
+use math_frontend::{BinOp, MathExpr, UnaryOp};
+
+fn main() {
+    let mut src = env::args().skip(1).collect::<Vec<_>>().join(" ");
+    if src.trim().is_empty() {
+        let mut stdin = String::new();
+        if let Err(e) = io::stdin().read_to_string(&mut stdin) {
+            eprintln!("failed to read stdin: {e}");
+            std::process::exit(2);
+        }
+        src = stdin;
+    }
+
+    match to_adj_formula_from_latex(&src) {
+        Ok(formula) => println!("{formula}"),
+        Err(e) => {
+            eprintln!("{e}");
+            std::process::exit(1);
+        }
+    }
+}
+
+fn to_adj_formula_from_latex(src: &str) -> Result<String, String> {
+    let math = strip_math_delimiters(src);
+    let reg = latex::registry();
+    let expr = reg
+        .parse("latex", math)
+        .map_err(|e| format!("latex parse failed: {}", e.message))?;
+    let rendered = render_expr(&expr)?;
+    Ok(rendered.text)
+}
+
+fn strip_math_delimiters(src: &str) -> &str {
+    let mut s = src.trim();
+    loop {
+        let next = if s.starts_with("\\(") && s.ends_with("\\)") && s.len() >= 4 {
+            Some(&s[2..s.len() - 2])
+        } else if s.starts_with("\\[") && s.ends_with("\\]") && s.len() >= 4 {
+            Some(&s[2..s.len() - 2])
+        } else if s.starts_with("$$") && s.ends_with("$$") && s.len() >= 4 {
+            Some(&s[2..s.len() - 2])
+        } else if s.starts_with('$') && s.ends_with('$') && s.len() >= 2 {
+            Some(&s[1..s.len() - 1])
+        } else {
+            None
+        };
+        match next {
+            Some(inner) => s = inner.trim(),
+            None => return s,
+        }
+    }
+}
+
+struct Rendered {
+    text: String,
+    prec: u8,
+}
+
+fn render_expr(expr: &MathExpr) -> Result<Rendered, String> {
+    match expr {
+        MathExpr::Number(n) => Ok(Rendered {
+            text: n.as_written().to_string(),
+            prec: 5,
+        }),
+        MathExpr::Group(x) => {
+            let x = render_expr(x)?;
+            Ok(Rendered {
+                text: format!("({})", x.text),
+                prec: 5,
+            })
+        }
+        MathExpr::Unary(UnaryOp::Neg, x) => render_unary("-", x),
+        MathExpr::Unary(UnaryOp::Pos, x) => render_unary("+", x),
+        MathExpr::Bin(op, x, y) => render_bin(*op, x, y),
+        MathExpr::Frac(x, y) => render_binary("/", 2, true, x, y),
+        other => Err(format!("unsupported ADJ arithmetic subset: {other:?}")),
+    }
+}
+
+fn render_unary(prefix: &str, x: &MathExpr) -> Result<Rendered, String> {
+    let x = render_expr(x)?;
+    let body = if x.prec < 4 {
+        format!("({})", x.text)
+    } else {
+        x.text
+    };
+    Ok(Rendered {
+        text: format!("{prefix}{body}"),
+        prec: 4,
+    })
+}
+
+fn render_bin(op: BinOp, x: &MathExpr, y: &MathExpr) -> Result<Rendered, String> {
+    match op {
+        BinOp::Add => render_binary("+", 1, false, x, y),
+        BinOp::Sub => render_binary("-", 1, true, x, y),
+        BinOp::Mul => render_binary("*", 2, false, x, y),
+        BinOp::Div => render_binary("/", 2, true, x, y),
+        BinOp::Pow | BinOp::PlusMinus | BinOp::MinusPlus => {
+            Err(format!("unsupported ADJ arithmetic operator: {op:?}"))
+        }
+    }
+}
+
+fn render_binary(
+    op: &str,
+    prec: u8,
+    right_assoc_sensitive: bool,
+    x: &MathExpr,
+    y: &MathExpr,
+) -> Result<Rendered, String> {
+    let left = render_expr(x)?;
+    let right = render_expr(y)?;
+    let left_text = if left.prec < prec {
+        format!("({})", left.text)
+    } else {
+        left.text
+    };
+    let right_text = if right.prec < prec || (right_assoc_sensitive && right.prec == prec) {
+        format!("({})", right.text)
+    } else {
+        right.text
+    };
+    Ok(Rendered {
+        text: format!("{left_text} {op} {right_text}"),
+        prec,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{strip_math_delimiters, to_adj_formula_from_latex};
+
+    #[test]
+    fn strips_common_math_delimiters() {
+        assert_eq!(strip_math_delimiters(r"$5 \times 12$"), r"5 \times 12");
+        assert_eq!(strip_math_delimiters(r"\(5 + 12\)"), "5 + 12");
+        assert_eq!(strip_math_delimiters(r"\[\frac{12}{3}\]"), r"\frac{12}{3}");
+    }
+
+    #[test]
+    fn lowers_latex_arithmetic_to_adj_formula() {
+        assert_eq!(
+            to_adj_formula_from_latex(r"$5 \times 12$").unwrap(),
+            "5 * 12"
+        );
+        assert_eq!(
+            to_adj_formula_from_latex(r"\frac{12}{3}").unwrap(),
+            "12 / 3"
+        );
+        assert_eq!(
+            to_adj_formula_from_latex(r"5 \cdot (12 + 3)").unwrap(),
+            "5 * (12 + 3)"
+        );
+    }
+
+    #[test]
+    fn rejects_non_arithmetic_subset() {
+        assert!(to_adj_formula_from_latex(r"x + 1").is_err());
+        assert!(to_adj_formula_from_latex(r"5^2").is_err());
+    }
+}

--- a/code/specs/ADJ-LADDER.md
+++ b/code/specs/ADJ-LADDER.md
@@ -182,11 +182,13 @@ of record (this file + ADJ-REASON-MATH + MLE-PASS). **No engine/grammar change.*
 
 **Verification (reproduce):**
 1. `cargo build -p adj-lang-cli`
-2. `python3 contamination_check.py rung0_arithmetic` → clean.
-3. `python3 ladder_eval.py rung0_arithmetic` → Arm B raw **100%**, wrong **0**
+2. Optional for model runs that emit LaTeX: `cargo build -p latex --bin latex-math-to-adj`
+   so Gemma formulas such as `\frac{12}{3}` go through the real LaTeX frontend.
+3. `python3 contamination_check.py rung0_arithmetic` → clean.
+4. `python3 ladder_eval.py rung0_arithmetic` → Arm B raw **100%**, wrong **0**
    (engine-correctness sanity; no model).
-4. `python3 -m pytest test_ladder_eval.py -q` → green.
-5. (where a local model exists) `python3 ladder_eval.py rung0_arithmetic --model
+5. `python3 -m pytest test_ladder_eval.py -q` → green.
+6. (where a local model exists) `python3 ladder_eval.py rung0_arithmetic --model
    mlx:<repo>` → the first real two-arm number + divergence.
 
 **Result — engine sanity (cached, no model):** rung-0 Arm B = **20/20 correct, 0

--- a/code/specs/ADJ-LADDER.md
+++ b/code/specs/ADJ-LADDER.md
@@ -33,6 +33,13 @@ USMLE (where contamination and knowledge-breadth confound everything), we climb 
 In Arm B the model's only job is to **decompose** the question into an ADJ program;
 the engine evaluates it and selects an answer, emitting a machine-checkable proof.
 
+**Base target: Gemma.** The canonical model is **Gemma** — a small, non-frontier model
+that runs **fully locally** (no API, offline, on commodity Apple-silicon via MLX). The
+default is `gemma-3-4b-it`; `gemma-3-1b-it` is available for an even-smaller probe where
+the gap should appear earlier. This is a deliberate choice: the standing claim is
+"a Haiku- or **Gemma**-class model + ADJ passes an exam the model alone cannot", and a
+local model makes the whole pipeline reproducible end-to-end with zero network.
+
 **The headline number is the divergence, B − A.** At the bottom of the ladder the gap
 is small (a small model can do `7 * 8 + 3`). As computation deepens, Arm A degrades
 while Arm B stays pinned near 100% — because the engine never makes an arithmetic
@@ -182,9 +189,25 @@ of record (this file + ADJ-REASON-MATH + MLE-PASS). **No engine/grammar change.*
 5. (where a local model exists) `python3 ladder_eval.py rung0_arithmetic --model
    mlx:<repo>` → the first real two-arm number + divergence.
 
-**Result on first run:** rung-0 Arm B = **20/20 correct, 0 wrong, 0 abstain** — the
-engine computed every answer exactly and selected the gold option, with the computed
-value visible in each item's proof. The mechanism is proven; the ladder can climb.
+**Result — engine sanity (cached, no model):** rung-0 Arm B = **20/20 correct, 0
+wrong, 0 abstain** — the engine computed every answer exactly and selected the gold
+option, with the computed value visible in each item's proof.
+
+**Result — first real two-arm run (Gemma-3-4b, greedy, fully local):**
+
+| Arm | raw accuracy | wrong (fabrications) | defensibility |
+|-----|--------------|----------------------|---------------|
+| **A** — Gemma alone | **60%** (12/20) | **8** | 0.60 |
+| **B** — Gemma + ADJ | **95%** (19/20) | **0** | **1.00** |
+
+**Divergence B − A = +35% (+7 items).** The money curve is visible at the very bottom
+of the ladder: even on grade-school arithmetic a small local model fabricates 8 wrong
+answers, while the engine arm makes **zero** — its single miss is a *decompose* error
+(bucket `b`) the engine caught and **abstained** on, not a fabrication. The defensibility
+gap (0.60 → 1.00) is the headline the ladder will widen rung by rung. (Artifact:
+`code/specs/data/adj-ladder/ladder-scorecard.gemma.json`.)
+
+The mechanism is proven; the ladder can climb.
 
 ---
 

--- a/code/specs/data/adj-ladder/CHANGELOG.md
+++ b/code/specs/data/adj-ladder/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to the ADJ-LADDER two-arm reasoning scoreboard.
 
+## [0.2.0] — 2026-06-26
+
+### Added — Gemma as the canonical local base target + first real two-arm number
+
+- **Gemma base target.** `--model gemma` / `--model gemma-1b` aliases load the cached
+  `mlx-community/gemma-3-{4b,1b}-it-bf16` instruct checkpoints via MLX — a small,
+  non-frontier, **fully-local** model (no API, offline). MLX loading now applies the
+  tokenizer chat template and greedy sampling (`temp=0`) for reproducible runs.
+- **First real two-arm result (rung 0, Gemma-3-4b, greedy):** Arm A (model alone)
+  **60%** (12/20, **8 wrong**); Arm B (model+ADJ) **95%** (19/20, **0 wrong**,
+  defensibility **1.00**); **divergence +35% (+7 items)**. Arm B's single miss is a
+  decompose error the engine caught and abstained on — zero fabrications.
+  Artifact: `ladder-scorecard.gemma.json`.
+- **Formula extraction stays strict.** A few-shot decompose prompt steers the model to
+  plain ASCII arithmetic; `extract_formula` accepts only a plain `+ - * / ()` line
+  (stripping an echoed `Formula:` label) and **abstains** on anything else. LaTeX/unicode
+  math is deliberately NOT normalized in the harness — that is a parsing concern owned
+  by the engine (adj-lang will understand LaTeX math natively; tracked as its own PR),
+  not an ad-hoc regex in the eval layer. The harness never rewrites the model's math.
+- **Per-model scorecards.** Model runs write `ladder-scorecard.<model>.json`; cached
+  runs write `ladder-scorecard.json` — a cached CI run never clobbers a committed
+  two-arm headline. Scorecard summary now records the `model`.
+- Tests: +2 (glyph/label normalization, alias resolution) → 20 total.
+
 ## [0.1.0] — 2026-06-26
 
 ### Added — PR-0: the two-arm instrument + rung 0 (no engine change)

--- a/code/specs/data/adj-ladder/CHANGELOG.md
+++ b/code/specs/data/adj-ladder/CHANGELOG.md
@@ -15,16 +15,25 @@ All notable changes to the ADJ-LADDER two-arm reasoning scoreboard.
   defensibility **1.00**); **divergence +35% (+7 items)**. Arm B's single miss is a
   decompose error the engine caught and abstained on — zero fabrications.
   Artifact: `ladder-scorecard.gemma.json`.
-- **Formula extraction stays strict.** A few-shot decompose prompt steers the model to
-  plain ASCII arithmetic; `extract_formula` accepts only a plain `+ - * / ()` line
-  (stripping an echoed `Formula:` label) and **abstains** on anything else. LaTeX/unicode
-  math is deliberately NOT normalized in the harness — that is a parsing concern owned
-  by the engine (adj-lang will understand LaTeX math natively; tracked as its own PR),
-  not an ad-hoc regex in the eval layer. The harness never rewrites the model's math.
+- **Formula extraction stays strict, now through the real LaTeX parser.** A few-shot
+  decompose prompt steers the model to plain ASCII arithmetic; `extract_formula` still
+  accepts a plain `+ - * / ()` line directly (stripping an echoed `Formula:` label).
+  When Gemma emits LaTeX math (`\times`, `\cdot`, `\frac`, `$...$`, `\(...\)`), the
+  harness calls the `latex` crate's `MathFrontend` adapter via `latex-math-to-adj` and
+  lowers only the supported arithmetic subset into ADJ's ASCII `let` syntax. Unsupported
+  math still **abstains**; the harness never regex-rewrites the model's math.
 - **Per-model scorecards.** Model runs write `ladder-scorecard.<model>.json`; cached
   runs write `ladder-scorecard.json` — a cached CI run never clobbers a committed
   two-arm headline. Scorecard summary now records the `model`.
-- Tests: +2 (glyph/label normalization, alias resolution) → 20 total.
+- Tests: +5 (label stripping, LaTeX helper hook/integration, unsupported-math
+  abstention, alias resolution) → 23 total.
+
+### Added — LaTeX arithmetic bridge
+
+- **`latex-math-to-adj`** — a tiny binary in the `latex` crate that parses LaTeX math
+  with `latex::registry()` and lowers the arithmetic subset needed by rung 0 into ADJ
+  formulas (`\times`/`\cdot` → `*`, `\frac{a}{b}` → `a / b`, parentheses preserved).
+  This is the first direct consumer of the new LaTeX parser from the LADDER harness.
 
 ## [0.1.0] — 2026-06-26
 

--- a/code/specs/data/adj-ladder/README.md
+++ b/code/specs/data/adj-ladder/README.md
@@ -12,6 +12,22 @@ The headline is the **divergence B − A**, which widens as complexity rises. Se
 spec of record: [`code/specs/ADJ-LADDER.md`](../../ADJ-LADDER.md) (and its siblings
 [`ADJ-REASON-MATH.md`](../../ADJ-REASON-MATH.md), [`MLE-PASS.md`](../../MLE-PASS.md)).
 
+The **canonical base target is Gemma** — a small, non-frontier model that runs
+**fully locally** (no API, offline). `--model gemma` loads the cached
+`mlx-community/gemma-3-4b-it-bf16` via MLX; `--model gemma-1b` the 1B variant.
+
+### First real two-arm number (rung 0, Gemma-3-4b, greedy)
+
+| Arm | raw accuracy | wrong (fabrications) | defensibility |
+|-----|--------------|----------------------|---------------|
+| **A** — Gemma alone | **60%** (12/20) | **8** | 0.60 |
+| **B** — Gemma + ADJ | **95%** (19/20) | **0** | **1.00** |
+
+**Divergence B − A = +35% (+7 items).** Even at grade-school arithmetic a small local
+model fabricates 8 wrong answers; the engine arm makes **zero** — its one miss is a
+*decompose* error (bucket `b`) the engine caught and **abstained** on. The gap is
+expected to widen as the ladder climbs. (Artifact: `ladder-scorecard.gemma.json`.)
+
 ## Layout
 
 ```
@@ -57,10 +73,17 @@ python3 ladder_eval.py rung0_arithmetic
 # 4. tests
 python3 -m pytest test_ladder_eval.py -q
 
-# 5. two-arm run with a local model (Apple-silicon MLX, or any cmd: wrapper)
-python3 ladder_eval.py rung0_arithmetic --model mlx:mlx-community/Qwen2.5-0.5B-Instruct-4bit
-python3 ladder_eval.py rung0_arithmetic --model 'cmd:my-local-llm --prompt-stdin'
+# 5. two-arm run with the local Gemma base target (needs mlx-lm; cache-only load)
+pip install mlx-lm                                   # one-time, into your run env
+HF_HUB_OFFLINE=1 python3 ladder_eval.py rung0_arithmetic --model gemma      # 4B
+HF_HUB_OFFLINE=1 python3 ladder_eval.py rung0_arithmetic --model gemma-1b   # 1B
+# any other local model works too:
+python3 ladder_eval.py rung0_arithmetic --model mlx:<hf-repo>
+python3 ladder_eval.py rung0_arithmetic --model 'cmd:ollama run <model>'
 ```
+
+`--model gemma` writes its scorecard to `ladder-scorecard.gemma.json` (per-model files,
+so a cached CI run never clobbers a committed two-arm headline).
 
 If the `adj-lang-cli` binary lives somewhere non-standard, point `ADJ_LANG_CLI` at it.
 

--- a/code/specs/data/adj-ladder/README.md
+++ b/code/specs/data/adj-ladder/README.md
@@ -63,6 +63,7 @@ arithmetic and the selection are the engine's.
 ```bash
 # 1. build the engine
 cargo build -p adj-lang-cli          # from code/packages/rust/
+cargo build -p latex --bin latex-math-to-adj  # optional: accepts Gemma's LaTeX formulas
 
 # 2. bank integrity (off the answer path)
 python3 contamination_check.py rung0_arithmetic
@@ -86,6 +87,7 @@ python3 ladder_eval.py rung0_arithmetic --model 'cmd:ollama run <model>'
 so a cached CI run never clobbers a committed two-arm headline).
 
 If the `adj-lang-cli` binary lives somewhere non-standard, point `ADJ_LANG_CLI` at it.
+If the LaTeX helper lives somewhere non-standard, point `LADDER_LATEX_HELPER` at it.
 
 ## Adding a rung
 

--- a/code/specs/data/adj-ladder/ladder-scorecard.gemma.json
+++ b/code/specs/data/adj-ladder/ladder-scorecard.gemma.json
@@ -1,38 +1,40 @@
 {
   "summary": {
     "rung": "rung0_arithmetic",
-    "mode": "cached",
-    "model": null,
+    "mode": "model",
+    "model": "gemma",
     "arm_a_model_alone": {
       "total": 20,
-      "correct": 0,
-      "abstained": 20,
-      "wrong": 0,
-      "raw_accuracy": 0.0,
-      "defensibility": 1.0,
-      "accuracy_on_attempted": null
+      "correct": 12,
+      "abstained": 0,
+      "wrong": 8,
+      "raw_accuracy": 0.6,
+      "defensibility": 0.6,
+      "accuracy_on_attempted": 0.6
     },
     "arm_b_model_plus_adj": {
       "total": 20,
-      "correct": 20,
-      "abstained": 0,
+      "correct": 19,
+      "abstained": 1,
       "wrong": 0,
-      "raw_accuracy": 1.0,
+      "raw_accuracy": 0.95,
       "defensibility": 1.0,
       "accuracy_on_attempted": 1.0
     },
     "divergence": {
-      "raw_accuracy": 1.0,
-      "correct": 20
+      "raw_accuracy": 0.35,
+      "correct": 7
     },
-    "arm_b_failure_buckets": {}
+    "arm_b_failure_buckets": {
+      "b": 1
+    }
   },
   "results": [
     {
       "id": "r0-01",
       "gold": "A",
-      "arm_a": null,
-      "arm_a_outcome": "abstained",
+      "arm_a": "B",
+      "arm_a_outcome": "wrong",
       "arm_b": "A",
       "arm_b_outcome": "correct",
       "bucket": null
@@ -40,8 +42,8 @@
     {
       "id": "r0-02",
       "gold": "C",
-      "arm_a": null,
-      "arm_a_outcome": "abstained",
+      "arm_a": "A",
+      "arm_a_outcome": "wrong",
       "arm_b": "C",
       "arm_b_outcome": "correct",
       "bucket": null
@@ -49,8 +51,8 @@
     {
       "id": "r0-03",
       "gold": "B",
-      "arm_a": null,
-      "arm_a_outcome": "abstained",
+      "arm_a": "A",
+      "arm_a_outcome": "wrong",
       "arm_b": "B",
       "arm_b_outcome": "correct",
       "bucket": null
@@ -58,8 +60,8 @@
     {
       "id": "r0-04",
       "gold": "B",
-      "arm_a": null,
-      "arm_a_outcome": "abstained",
+      "arm_a": "B",
+      "arm_a_outcome": "correct",
       "arm_b": "B",
       "arm_b_outcome": "correct",
       "bucket": null
@@ -67,8 +69,8 @@
     {
       "id": "r0-05",
       "gold": "A",
-      "arm_a": null,
-      "arm_a_outcome": "abstained",
+      "arm_a": "A",
+      "arm_a_outcome": "correct",
       "arm_b": "A",
       "arm_b_outcome": "correct",
       "bucket": null
@@ -76,8 +78,8 @@
     {
       "id": "r0-06",
       "gold": "B",
-      "arm_a": null,
-      "arm_a_outcome": "abstained",
+      "arm_a": "C",
+      "arm_a_outcome": "wrong",
       "arm_b": "B",
       "arm_b_outcome": "correct",
       "bucket": null
@@ -85,8 +87,8 @@
     {
       "id": "r0-07",
       "gold": "A",
-      "arm_a": null,
-      "arm_a_outcome": "abstained",
+      "arm_a": "A",
+      "arm_a_outcome": "correct",
       "arm_b": "A",
       "arm_b_outcome": "correct",
       "bucket": null
@@ -94,8 +96,8 @@
     {
       "id": "r0-08",
       "gold": "C",
-      "arm_a": null,
-      "arm_a_outcome": "abstained",
+      "arm_a": "B",
+      "arm_a_outcome": "wrong",
       "arm_b": "C",
       "arm_b_outcome": "correct",
       "bucket": null
@@ -103,17 +105,17 @@
     {
       "id": "r0-09",
       "gold": "B",
-      "arm_a": null,
-      "arm_a_outcome": "abstained",
-      "arm_b": "B",
-      "arm_b_outcome": "correct",
-      "bucket": null
+      "arm_a": "B",
+      "arm_a_outcome": "correct",
+      "arm_b": null,
+      "arm_b_outcome": "abstained",
+      "bucket": "b"
     },
     {
       "id": "r0-10",
       "gold": "B",
-      "arm_a": null,
-      "arm_a_outcome": "abstained",
+      "arm_a": "A",
+      "arm_a_outcome": "wrong",
       "arm_b": "B",
       "arm_b_outcome": "correct",
       "bucket": null
@@ -121,8 +123,8 @@
     {
       "id": "r0-11",
       "gold": "C",
-      "arm_a": null,
-      "arm_a_outcome": "abstained",
+      "arm_a": "C",
+      "arm_a_outcome": "correct",
       "arm_b": "C",
       "arm_b_outcome": "correct",
       "bucket": null
@@ -130,8 +132,8 @@
     {
       "id": "r0-12",
       "gold": "B",
-      "arm_a": null,
-      "arm_a_outcome": "abstained",
+      "arm_a": "A",
+      "arm_a_outcome": "wrong",
       "arm_b": "B",
       "arm_b_outcome": "correct",
       "bucket": null
@@ -139,8 +141,8 @@
     {
       "id": "r0-13",
       "gold": "B",
-      "arm_a": null,
-      "arm_a_outcome": "abstained",
+      "arm_a": "B",
+      "arm_a_outcome": "correct",
       "arm_b": "B",
       "arm_b_outcome": "correct",
       "bucket": null
@@ -148,8 +150,8 @@
     {
       "id": "r0-14",
       "gold": "B",
-      "arm_a": null,
-      "arm_a_outcome": "abstained",
+      "arm_a": "B",
+      "arm_a_outcome": "correct",
       "arm_b": "B",
       "arm_b_outcome": "correct",
       "bucket": null
@@ -157,8 +159,8 @@
     {
       "id": "r0-15",
       "gold": "B",
-      "arm_a": null,
-      "arm_a_outcome": "abstained",
+      "arm_a": "C",
+      "arm_a_outcome": "wrong",
       "arm_b": "B",
       "arm_b_outcome": "correct",
       "bucket": null
@@ -166,8 +168,8 @@
     {
       "id": "r0-16",
       "gold": "B",
-      "arm_a": null,
-      "arm_a_outcome": "abstained",
+      "arm_a": "B",
+      "arm_a_outcome": "correct",
       "arm_b": "B",
       "arm_b_outcome": "correct",
       "bucket": null
@@ -175,8 +177,8 @@
     {
       "id": "r0-17",
       "gold": "C",
-      "arm_a": null,
-      "arm_a_outcome": "abstained",
+      "arm_a": "C",
+      "arm_a_outcome": "correct",
       "arm_b": "C",
       "arm_b_outcome": "correct",
       "bucket": null
@@ -184,8 +186,8 @@
     {
       "id": "r0-18",
       "gold": "B",
-      "arm_a": null,
-      "arm_a_outcome": "abstained",
+      "arm_a": "B",
+      "arm_a_outcome": "correct",
       "arm_b": "B",
       "arm_b_outcome": "correct",
       "bucket": null
@@ -193,8 +195,8 @@
     {
       "id": "r0-19",
       "gold": "A",
-      "arm_a": null,
-      "arm_a_outcome": "abstained",
+      "arm_a": "A",
+      "arm_a_outcome": "correct",
       "arm_b": "A",
       "arm_b_outcome": "correct",
       "bucket": null
@@ -202,8 +204,8 @@
     {
       "id": "r0-20",
       "gold": "B",
-      "arm_a": null,
-      "arm_a_outcome": "abstained",
+      "arm_a": "B",
+      "arm_a_outcome": "correct",
       "arm_b": "B",
       "arm_b_outcome": "correct",
       "bucket": null

--- a/code/specs/data/adj-ladder/ladder_eval.py
+++ b/code/specs/data/adj-ladder/ladder_eval.py
@@ -261,6 +261,7 @@ def classify_bucket(arm_b_outcome: str, faithful: bool) -> str | None:
 class Scorecard:
     rung: str
     mode: str
+    model: str | None = None
     results: list[ItemResult] = field(default_factory=list)
 
     def _arm_summary(self, arm: str) -> dict:
@@ -290,6 +291,7 @@ class Scorecard:
         return {
             "rung": self.rung,
             "mode": self.mode,
+            "model": self.model,
             "arm_a_model_alone": a,
             "arm_b_model_plus_adj": b,
             # The money number: how much the engine arm out-scores the model alone.
@@ -338,31 +340,57 @@ def score_item(item: dict, gen) -> ItemResult:
 # Model decomposition (only used in --model mode).
 # ----------------------------------------------------------------------------------
 def decompose_prompt(item: dict) -> str:
+    # Two worked examples (a bare expression and a one-step word problem) give a small
+    # model a fair shot at the FORMAT — we are measuring its decomposition ability, not
+    # its prompt-guessing. The examples carry no overlap with any bank item's numbers.
     return (
-        "Translate the arithmetic in this question into a single formula using only "
-        "the numbers that appear in the question and the operators + - * / and "
-        "parentheses. Do NOT compute the answer — output only the formula.\n\n"
-        f"Question: {item['stem']}\n\nFormula:"
+        "Translate the arithmetic in a question into a SINGLE formula using ONLY the "
+        "numbers that appear in the question and the operators + - * / and "
+        "parentheses. Do NOT compute the answer. Output ONLY the formula, on one line.\n\n"
+        "Question: What is 11 * 4 - 6?\nFormula: 11 * 4 - 6\n\n"
+        "Question: A box holds 8 pens. How many pens are in 3 boxes?\nFormula: 3 * 8\n\n"
+        f"Question: {item['stem']}\nFormula:"
     )
 
 
 _FORMULA_OK = re.compile(r"^[\d\s+\-*/().]+$")
+_LABEL = re.compile(r"(?i)^\s*formula\s*[:=]?\s*")
 
 
 def extract_formula(text: str) -> str | None:
-    """Take the model's reply and keep the first line that is a pure arithmetic
-    expression (digits, operators, parens, spaces). Anything else → None (abstain)."""
-    for line in (text or "").splitlines():
-        line = line.strip().rstrip(".")
+    """Take the model's reply and return the first line that is a plain ASCII
+    arithmetic expression — digits, the four operators + - * /, and parentheses.
+    Anything else → None (abstain).
+
+    The only cosmetic step is stripping a leading "Formula:" label the model may echo;
+    we never rewrite the math. In particular we do NOT normalize LaTeX or unicode math
+    glyphs here — that is a parsing concern owned by the engine (adj-lang understands
+    LaTeX math natively), not an ad-hoc regex in the eval harness. An expression the
+    engine can't yet parse is honestly abstained on, never silently repaired."""
+    for raw in (text or "").splitlines():
+        line = _LABEL.sub("", raw.strip()).rstrip(".")
         if line and _FORMULA_OK.match(line):
             return line
     return None
 
 
+# Gemma is the canonical base target for the ladder: a small, fully-LOCAL, non-frontier
+# model (no API, runs offline on commodity Apple-silicon via MLX). The headline claim is
+# explicitly "a Haiku- or Gemma-class model + ADJ passes an exam the model alone cannot",
+# so these aliases let `--model gemma` Just Work against the cached instruct checkpoints.
+MODEL_ALIASES = {
+    "gemma": "mlx:mlx-community/gemma-3-4b-it-bf16",      # default base target (4B)
+    "gemma-4b": "mlx:mlx-community/gemma-3-4b-it-bf16",
+    "gemma-1b": "mlx:mlx-community/gemma-3-1b-it-bf16",   # even smaller — wider gap earlier
+}
+
+
 def load_gen(spec: str):
-    """Build a prompt→text callable from a --model spec. `mlx:<repo>` loads a local
-    MLX model (Apple silicon); `cmd:<shell>` pipes the prompt to a command's stdin and
-    reads its stdout (works with any local inference server / wrapper)."""
+    """Build a prompt→text callable from a --model spec. Accepts a Gemma alias
+    (`gemma`, `gemma-1b`, …), `mlx:<repo>` for any local MLX checkpoint (Apple
+    silicon), or `cmd:<shell>` which pipes the prompt to a command's stdin and reads
+    its stdout (works with any local inference server / wrapper, e.g. ollama)."""
+    spec = MODEL_ALIASES.get(spec, spec)
     if spec.startswith("cmd:"):
         shell = spec[4:]
 
@@ -374,24 +402,29 @@ def load_gen(spec: str):
         return gen
     if spec.startswith("mlx:"):
         repo = spec[4:]
-        from mlx_lm import generate, load           # lazy: only needed in model mode
+        from mlx_lm import generate, load              # lazy: only needed in model mode
+        from mlx_lm.sample_utils import make_sampler
 
         model, tok = load(repo)
+        sampler = make_sampler(temp=0.0)              # greedy → reproducible runs
 
         def gen(prompt: str) -> str:
-            return generate(model, tok, prompt=prompt, max_tokens=64, verbose=False)
+            msgs = [{"role": "user", "content": prompt}]
+            templated = tok.apply_chat_template(msgs, add_generation_prompt=True, tokenize=False)
+            return generate(model, tok, prompt=templated, max_tokens=64,
+                            sampler=sampler, verbose=False)
 
         return gen
-    raise SystemExit(f"unknown --model spec {spec!r} (use mlx:<repo> or cmd:<shell>)")
+    raise SystemExit(f"unknown --model spec {spec!r} (use a gemma alias, mlx:<repo>, or cmd:<shell>)")
 
 
 # ----------------------------------------------------------------------------------
 # Driver.
 # ----------------------------------------------------------------------------------
-def run(rung: str, gen) -> Scorecard:
+def run(rung: str, gen, model: str | None = None) -> Scorecard:
     items = json.loads((HERE / rung / "items.json").read_text())["items"]
     mode = "cached" if gen is None else "model"
-    card = Scorecard(rung, mode)
+    card = Scorecard(rung, mode, model)
     for it in items:
         card.results.append(score_item(it, gen))
     return card
@@ -400,12 +433,12 @@ def run(rung: str, gen) -> Scorecard:
 def main(argv: list[str]) -> int:
     ap = argparse.ArgumentParser(description="ADJ-LADDER two-arm scoreboard")
     ap.add_argument("rung", help="rung directory name, e.g. rung0_arithmetic")
-    ap.add_argument("--model", help="model spec: mlx:<repo> or cmd:<shell> (omit for cached engine-only run)")
+    ap.add_argument("--model", help="model spec: a gemma alias (gemma, gemma-1b), mlx:<repo>, or cmd:<shell> (omit for cached engine-only run)")
     ap.add_argument("--quiet", action="store_true", help="emit scorecard JSON only")
     args = ap.parse_args(argv)
 
     gen = load_gen(args.model) if args.model else None
-    card = run(args.rung, gen)
+    card = run(args.rung, gen, args.model)
     summary = card.summary()
 
     scorecard = {
@@ -418,7 +451,14 @@ def main(argv: list[str]) -> int:
             for r in card.results
         ],
     }
-    (HERE / "ladder-scorecard.json").write_text(json.dumps(scorecard, indent=2) + "\n")
+    # Write per-mode/model files so a cached CI run never clobbers a committed two-arm
+    # headline: cached → ladder-scorecard.json; model → ladder-scorecard.<model>.json.
+    if card.mode == "cached":
+        out_name = "ladder-scorecard.json"
+    else:
+        slug = re.sub(r"[^a-z0-9.-]+", "-", args.model.lower()).strip("-")
+        out_name = f"ladder-scorecard.{slug}.json"
+    (HERE / out_name).write_text(json.dumps(scorecard, indent=2) + "\n")
 
     if not args.quiet:
         _pretty(card, summary)

--- a/code/specs/data/adj-ladder/ladder_eval.py
+++ b/code/specs/data/adj-ladder/ladder_eval.py
@@ -355,22 +355,68 @@ def decompose_prompt(item: dict) -> str:
 
 _FORMULA_OK = re.compile(r"^[\d\s+\-*/().]+$")
 _LABEL = re.compile(r"(?i)^\s*formula\s*[:=]?\s*")
+_LATEX_HINT = re.compile(r"(\\[A-Za-z]+|\\\(|\\\[|\$)")
+
+
+def _find_latex_helper() -> Path | None:
+    override = os.environ.get("LADDER_LATEX_HELPER")
+    if override and Path(override).exists():
+        return Path(override)
+    rust = HERE.parents[2] / "packages" / "rust"
+    candidates = [
+        rust / "target" / "debug" / "latex-math-to-adj",
+        rust / "target" / "release" / "latex-math-to-adj",
+    ]
+    for c in candidates:
+        if c.exists():
+            return c
+    return None
+
+
+_LATEX_HELPER = _find_latex_helper()
+
+
+def latex_to_adj_formula(text: str) -> str | None:
+    """Parse a LaTeX math expression with the repo's LaTeX frontend and lower the
+    arithmetic subset to ADJ's ASCII `let` formula syntax.
+
+    The helper is intentionally a Rust binary from `code/packages/rust/latex`: it
+    routes Gemma's LaTeX output through the actual parser/frontend stack instead of
+    teaching this Python harness a second, unofficial math parser. If the helper is
+    not built, or the expression is outside the arithmetic subset, the item abstains."""
+    if _LATEX_HELPER is None:
+        return None
+    if not _LATEX_HINT.search(text):
+        return None
+    try:
+        out = subprocess.run(
+            [str(_LATEX_HELPER), text],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if out.returncode != 0:
+        return None
+    formula = out.stdout.strip()
+    return formula if formula and _FORMULA_OK.match(formula) else None
 
 
 def extract_formula(text: str) -> str | None:
-    """Take the model's reply and return the first line that is a plain ASCII
-    arithmetic expression — digits, the four operators + - * /, and parentheses.
-    Anything else → None (abstain).
+    """Take the model's reply and return the first usable arithmetic expression.
 
     The only cosmetic step is stripping a leading "Formula:" label the model may echo;
-    we never rewrite the math. In particular we do NOT normalize LaTeX or unicode math
-    glyphs here — that is a parsing concern owned by the engine (adj-lang understands
-    LaTeX math natively), not an ad-hoc regex in the eval harness. An expression the
-    engine can't yet parse is honestly abstained on, never silently repaired."""
+    plain ASCII arithmetic passes through directly. If the line looks like LaTeX math,
+    it is parsed by the Rust `latex` frontend helper and lowered to the same ASCII
+    subset. Unsupported notation still abstains — no ad-hoc regex repair here."""
     for raw in (text or "").splitlines():
         line = _LABEL.sub("", raw.strip()).rstrip(".")
         if line and _FORMULA_OK.match(line):
             return line
+        formula = latex_to_adj_formula(line)
+        if formula is not None:
+            return formula
     return None
 
 

--- a/code/specs/data/adj-ladder/test_ladder_eval.py
+++ b/code/specs/data/adj-ladder/test_ladder_eval.py
@@ -82,6 +82,24 @@ def test_extract_formula_rejects_prose():
     assert le.extract_formula("fifty nine") is None
 
 
+def test_extract_formula_strips_label_only():
+    # a "Formula:" label the model echoes is stripped; plain arithmetic passes through.
+    assert le.extract_formula("Formula: 5 * 12") == "5 * 12"
+
+
+def test_extract_formula_abstains_on_latex():
+    # LaTeX/unicode math is NOT normalized in the harness — that is the engine's job
+    # (adj-lang understands LaTeX natively). An un-plain reply abstains here.
+    assert le.extract_formula("$5 \\times 12$") is None
+    assert le.extract_formula("5 × 12") is None
+
+
+def test_model_aliases_resolve():
+    assert le.MODEL_ALIASES["gemma"].startswith("mlx:")
+    assert "gemma" in le.MODEL_ALIASES["gemma"]
+    assert le.MODEL_ALIASES["gemma-1b"].endswith("gemma-3-1b-it-bf16")
+
+
 # ---- scoring / divergence -----------------------------------------------------
 def test_outcome():
     assert le.outcome("A", "A") == "correct"

--- a/code/specs/data/adj-ladder/test_ladder_eval.py
+++ b/code/specs/data/adj-ladder/test_ladder_eval.py
@@ -87,10 +87,24 @@ def test_extract_formula_strips_label_only():
     assert le.extract_formula("Formula: 5 * 12") == "5 * 12"
 
 
-def test_extract_formula_abstains_on_latex():
-    # LaTeX/unicode math is NOT normalized in the harness — that is the engine's job
-    # (adj-lang understands LaTeX natively). An un-plain reply abstains here.
-    assert le.extract_formula("$5 \\times 12$") is None
+def test_extract_formula_accepts_latex_via_helper(monkeypatch):
+    def fake_helper(line: str) -> str | None:
+        return "5 * 12" if line == "$5 \\times 12$" else None
+
+    monkeypatch.setattr(le, "latex_to_adj_formula", fake_helper)
+    assert le.extract_formula("$5 \\times 12$") == "5 * 12"
+
+
+def test_latex_helper_normalizes_basic_math_when_built():
+    if le._LATEX_HELPER is None:
+        import pytest
+        pytest.skip("latex-math-to-adj not built")
+    assert le.latex_to_adj_formula("$5 \\times 12$") == "5 * 12"
+    assert le.latex_to_adj_formula("\\frac{12}{3}") == "12 / 3"
+
+
+def test_extract_formula_abstains_on_unsupported_math(monkeypatch):
+    monkeypatch.setattr(le, "latex_to_adj_formula", lambda line: None)
     assert le.extract_formula("5 × 12") is None
 
 


### PR DESCRIPTION
## What changed

- Preserves the first real ADJ-LADDER two-arm Gemma result from the advanced `feat/adj-ladder-pr0` branch, including `ladder-scorecard.gemma.json` and docs updates.
- Adds `latex-math-to-adj`, a tiny helper binary in the `latex` crate that parses LaTeX math through `latex::registry()` / `MathFrontend` and lowers the numeric arithmetic subset into ADJ `let` formula syntax.
- Wires `ladder_eval.py` to accept Gemma LaTeX formula output such as `\times`, `\cdot`, and `\frac` through that helper while still abstaining on unsupported notation.

## Why

Gemma produced some LaTeX-shaped decomposition output during the first model run. Since the LaTeX lexer/parser/frontend has landed, LADDER should use that real parser path instead of treating parser-supported LaTeX arithmetic as an automatic decompose miss.

## Validation

- `cargo build -p latex --bin latex-math-to-adj`
- `code/packages/rust/target/debug/latex-math-to-adj '$5 \\times 12$'`
- `code/packages/rust/target/debug/latex-math-to-adj '\\frac{12}{3}'`
- `code/packages/rust/target/debug/latex-math-to-adj '5 \\cdot (12 + 3)'`
- `cargo test -p latex --bin latex-math-to-adj`
- `cargo test -p latex`
- `python3 -m pytest test_ladder_eval.py -q`
- `python3 contamination_check.py rung0_arithmetic`
- `python3 ladder_eval.py rung0_arithmetic --quiet`