### PR TITLE
Add mesh protocol package handoff execution slots

### DIFF
--- a/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
+++ b/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
@@ -179,6 +179,10 @@ All notable changes to this package will be documented in this file.
   readiness execution handoff action protocol-evidence package handoff
   summaries that combine package handoff rows with next actionable protocol
   and evidence pointers.
+- Low-level mesh release ticket handoff readiness-evidence review
+  disposition-action readiness execution handoff action protocol-evidence
+  package handoff execution slots that order Zigbee, Z-Wave, and Thread
+  package handoff work into deterministic release lanes.
 - Virtual alias entries for product lines supported by another integration or
   standard.
 - Read-only D18D tool descriptors for listing/describing integrations and

--- a/code/packages/rust/smart-home-integration-catalog/README.md
+++ b/code/packages/rust/smart-home-integration-catalog/README.md
@@ -350,6 +350,10 @@ runtime and Chief of Staff tools a typed catalog for:
   readiness execution handoff action protocol-evidence package handoff
   summaries that combine package handoff rows with next actionable protocol
   and evidence pointers
+- low-level mesh release ticket handoff readiness-evidence review
+  disposition-action readiness execution handoff action protocol-evidence
+  package handoff execution slots that order Zigbee, Z-Wave, and Thread
+  package handoff work into deterministic release lanes
 - mesh release ticket handoff work-order guardrail readiness summaries that
   combine work-order readiness with guardrail counts and first actionable
   handoff work

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -26699,6 +26699,174 @@ impl
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationMeshReleaseTicketHandoffReadinessEvidenceReviewDispositionActionReadinessExecutionHandoffActionProtocolEvidencePackageHandoffExecutionSlot
+{
+    pub sequence: usize,
+    pub protocol_evidence_package_handoff_execution_slot_key: String,
+    pub protocol_evidence_package_handoff_row_sequence: usize,
+    pub protocol_evidence_package_handoff_row_key: String,
+    pub protocol_evidence_package_key: String,
+    pub protocol_evidence_packet_key: String,
+    pub protocol: ProtocolFamily,
+    pub handoff_lane: IntegrationMeshReleaseDispatchTicketHandoffLane,
+    pub total_substrate_rows: usize,
+    pub ready_substrate_rows: usize,
+    pub blocked_substrate_rows: usize,
+    pub total_handoff_action_evidence_rows: usize,
+    pub required_handoff_action_evidence_rows: usize,
+    pub release_blocking_handoff_action_evidence_rows: usize,
+    pub operator_required_handoff_action_evidence_rows: usize,
+    pub review_required_handoff_action_evidence_rows: usize,
+    pub dispatch_required_handoff_action_evidence_rows: usize,
+    pub execution_required_handoff_action_evidence_rows: usize,
+    pub release_handoff_evidence_rows: usize,
+    pub release_ready_handoff_action_evidence_rows: usize,
+    pub first_handoff_action_evidence_row_key: Option<String>,
+    pub first_required_handoff_action_evidence_row_key: Option<String>,
+    pub first_blocked_substrate_stage: Option<IntegrationMeshProtocolSubstrateStage>,
+    pub handoff_action_evidence_ready: bool,
+    pub protocol_substrate_ready: bool,
+    pub protocol_evidence_packet_ready: bool,
+    pub protocol_evidence_package_ready: bool,
+    pub package_handoff_ready: bool,
+    pub protocol_evidence_package_handoff_ready: bool,
+    pub ready_for_package_handoff_execution: bool,
+}
+
+impl
+    IntegrationMeshReleaseTicketHandoffReadinessEvidenceReviewDispositionActionReadinessExecutionHandoffActionProtocolEvidencePackageHandoffExecutionSlot
+{
+    pub fn from_handoff_row(
+        sequence: usize,
+        row: &IntegrationMeshReleaseTicketHandoffReadinessEvidenceReviewDispositionActionReadinessExecutionHandoffActionProtocolEvidencePackageHandoffRow,
+        protocol_evidence_package_handoff_ready: bool,
+    ) -> Self {
+        let handoff_lane = if row.ready_for_package_handoff() {
+            IntegrationMeshReleaseDispatchTicketHandoffLane::Release
+        } else if row.has_review_work() {
+            IntegrationMeshReleaseDispatchTicketHandoffLane::Review
+        } else if row.needs_operator() {
+            IntegrationMeshReleaseDispatchTicketHandoffLane::Operator
+        } else {
+            IntegrationMeshReleaseDispatchTicketHandoffLane::Repair
+        };
+        let ready_for_package_handoff_execution =
+            protocol_evidence_package_handoff_ready && row.ready_for_package_handoff();
+
+        Self {
+            sequence,
+            protocol_evidence_package_handoff_execution_slot_key: format!(
+                "release-ticket-handoff-readiness-evidence-review-disposition-action-readiness-handoff-action-protocol-evidence-package-handoff-execution-slot-{sequence:02}-{}",
+                protocol_sort_token(&row.protocol)
+            ),
+            protocol_evidence_package_handoff_row_sequence: row.sequence,
+            protocol_evidence_package_handoff_row_key: row
+                .protocol_evidence_package_handoff_row_key
+                .clone(),
+            protocol_evidence_package_key: row.protocol_evidence_package_key.clone(),
+            protocol_evidence_packet_key: row.protocol_evidence_packet_key.clone(),
+            protocol: row.protocol.clone(),
+            handoff_lane,
+            total_substrate_rows: row.total_substrate_rows,
+            ready_substrate_rows: row.ready_substrate_rows,
+            blocked_substrate_rows: row.blocked_substrate_rows,
+            total_handoff_action_evidence_rows: row.total_handoff_action_evidence_rows,
+            required_handoff_action_evidence_rows: row.required_handoff_action_evidence_rows,
+            release_blocking_handoff_action_evidence_rows: row
+                .release_blocking_handoff_action_evidence_rows,
+            operator_required_handoff_action_evidence_rows: row
+                .operator_required_handoff_action_evidence_rows,
+            review_required_handoff_action_evidence_rows: row
+                .review_required_handoff_action_evidence_rows,
+            dispatch_required_handoff_action_evidence_rows: row
+                .dispatch_required_handoff_action_evidence_rows,
+            execution_required_handoff_action_evidence_rows: row
+                .execution_required_handoff_action_evidence_rows,
+            release_handoff_evidence_rows: row.release_handoff_evidence_rows,
+            release_ready_handoff_action_evidence_rows: row.release_ready_handoff_action_evidence_rows,
+            first_handoff_action_evidence_row_key: row
+                .first_handoff_action_evidence_row_key
+                .clone(),
+            first_required_handoff_action_evidence_row_key: row
+                .first_required_handoff_action_evidence_row_key
+                .clone(),
+            first_blocked_substrate_stage: row.first_blocked_substrate_stage,
+            handoff_action_evidence_ready: row.handoff_action_evidence_ready,
+            protocol_substrate_ready: row.protocol_substrate_ready,
+            protocol_evidence_packet_ready: row.protocol_evidence_packet_ready,
+            protocol_evidence_package_ready: row.protocol_evidence_package_ready,
+            package_handoff_ready: row.package_handoff_ready,
+            protocol_evidence_package_handoff_ready,
+            ready_for_package_handoff_execution,
+        }
+    }
+
+    pub fn has_blocked_substrate(&self) -> bool {
+        self.blocked_substrate_rows > 0
+    }
+
+    pub fn has_required_evidence(&self) -> bool {
+        self.required_handoff_action_evidence_rows > 0
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.has_blocked_substrate() || self.release_blocking_handoff_action_evidence_rows > 0
+    }
+
+    pub fn needs_operator(&self) -> bool {
+        self.operator_required_handoff_action_evidence_rows > 0
+    }
+
+    pub fn has_review_work(&self) -> bool {
+        self.review_required_handoff_action_evidence_rows > 0
+    }
+
+    pub fn requires_dispatch(&self) -> bool {
+        self.dispatch_required_handoff_action_evidence_rows > 0
+    }
+
+    pub fn requires_execution(&self) -> bool {
+        self.execution_required_handoff_action_evidence_rows > 0
+    }
+
+    pub fn is_repair_slot(&self) -> bool {
+        self.handoff_lane == IntegrationMeshReleaseDispatchTicketHandoffLane::Repair
+    }
+
+    pub fn is_operator_slot(&self) -> bool {
+        self.handoff_lane == IntegrationMeshReleaseDispatchTicketHandoffLane::Operator
+    }
+
+    pub fn is_review_slot(&self) -> bool {
+        self.handoff_lane == IntegrationMeshReleaseDispatchTicketHandoffLane::Review
+    }
+
+    pub fn is_release_slot(&self) -> bool {
+        self.handoff_lane == IntegrationMeshReleaseDispatchTicketHandoffLane::Release
+    }
+
+    pub fn ready_for_package_handoff_execution(&self) -> bool {
+        self.ready_for_package_handoff_execution && !self.requires_attention()
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.has_blockers()
+            || self.has_required_evidence()
+            || self.needs_operator()
+            || self.has_review_work()
+            || self.requires_dispatch()
+            || self.requires_execution()
+            || !self.handoff_action_evidence_ready
+            || !self.protocol_substrate_ready
+            || !self.protocol_evidence_packet_ready
+            || !self.protocol_evidence_package_ready
+            || !self.package_handoff_ready
+            || !self.protocol_evidence_package_handoff_ready
+            || !self.ready_for_package_handoff_execution
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IntegrationMeshReleaseTicketHandoffReadinessEvidenceReviewDispositionActionReadinessExecutionHandoffActionEvidenceReviewSummary {
     pub release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_summary:
         Box<IntegrationMeshReleaseTicketHandoffReadinessEvidenceReviewDispositionActionReadinessExecutionHandoffActionEvidenceSummary>,
@@ -52537,6 +52705,62 @@ pub fn mesh_release_ticket_handoff_readiness_evidence_review_disposition_action_
     )
 }
 
+pub fn mesh_release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_protocol_evidence_package_handoff_execution_slots_for_catalog(
+    catalog: &[IntegrationCatalogEntry],
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> Vec<IntegrationMeshReleaseTicketHandoffReadinessEvidenceReviewDispositionActionReadinessExecutionHandoffActionProtocolEvidencePackageHandoffExecutionSlot>
+{
+    let package_readiness_summary =
+        mesh_release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_protocol_evidence_package_readiness_summary_for_catalog(
+            catalog,
+            available_primitives,
+            allowed_capabilities,
+            enabled_integrations,
+        );
+    let rows =
+        mesh_release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_protocol_evidence_package_handoff_rows_for_catalog(
+            catalog,
+            available_primitives,
+            allowed_capabilities,
+            enabled_integrations,
+        );
+    let handoff_summary =
+        IntegrationMeshReleaseTicketHandoffReadinessEvidenceReviewDispositionActionReadinessExecutionHandoffActionProtocolEvidencePackageHandoffSummary::from_summaries(
+            package_readiness_summary,
+            rows.iter(),
+        );
+    let protocol_evidence_package_handoff_ready =
+        handoff_summary.ready_for_release_ticket_handoff_protocol_evidence_package_handoff();
+
+    rows.iter()
+        .enumerate()
+        .map(|(index, row)| {
+            IntegrationMeshReleaseTicketHandoffReadinessEvidenceReviewDispositionActionReadinessExecutionHandoffActionProtocolEvidencePackageHandoffExecutionSlot::from_handoff_row(
+                index + 1,
+                row,
+                protocol_evidence_package_handoff_ready,
+            )
+        })
+        .collect()
+}
+
+pub fn mesh_release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_protocol_evidence_package_handoff_execution_slots(
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> Vec<IntegrationMeshReleaseTicketHandoffReadinessEvidenceReviewDispositionActionReadinessExecutionHandoffActionProtocolEvidencePackageHandoffExecutionSlot>
+{
+    let catalog = first_party_catalog();
+    mesh_release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_protocol_evidence_package_handoff_execution_slots_for_catalog(
+        &catalog,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    )
+}
+
 pub fn mesh_release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_summary_for_catalog(
     catalog: &[IntegrationCatalogEntry],
     available_primitives: &[PrimitiveFamily],
@@ -73158,6 +73382,135 @@ mod tests {
         assert!(!summary.requires_dispatch());
         assert!(!summary.requires_execution());
         assert!(!summary.requires_attention());
+    }
+
+    #[test]
+    fn mesh_release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_protocol_evidence_package_handoff_execution_slots_surface_attention(
+    ) {
+        let available_primitives = vec![
+            PrimitiveFamily::Usb,
+            PrimitiveFamily::SerialController,
+            PrimitiveFamily::Radio802154,
+            PrimitiveFamily::Supervision,
+        ];
+        let allowed_capabilities = vec![CapabilityId::trusted("smart_home.read")];
+        let slots =
+            mesh_release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_protocol_evidence_package_handoff_execution_slots(
+                &available_primitives,
+                &allowed_capabilities,
+                &[],
+            );
+
+        assert_eq!(slots.len(), 3);
+        assert_eq!(slots[0].protocol, ProtocolFamily::Zigbee);
+        assert_eq!(
+            slots[0].protocol_evidence_package_handoff_execution_slot_key,
+            "release-ticket-handoff-readiness-evidence-review-disposition-action-readiness-handoff-action-protocol-evidence-package-handoff-execution-slot-01-Zigbee"
+        );
+        assert_eq!(slots[0].protocol_evidence_package_handoff_row_sequence, 1);
+        assert_eq!(
+            slots[0].protocol_evidence_package_handoff_row_key,
+            "release-ticket-handoff-readiness-evidence-review-disposition-action-readiness-handoff-action-protocol-evidence-package-handoff-row-01-Zigbee"
+        );
+        assert_eq!(
+            slots[0].protocol_evidence_packet_key,
+            "release-ticket-handoff-readiness-evidence-review-disposition-action-readiness-handoff-action-protocol-evidence-packet-01-Zigbee"
+        );
+        assert_eq!(
+            slots[0].handoff_lane,
+            IntegrationMeshReleaseDispatchTicketHandoffLane::Review
+        );
+        assert_eq!(slots[0].total_substrate_rows, 5);
+        assert_eq!(slots[0].ready_substrate_rows, 4);
+        assert_eq!(slots[0].blocked_substrate_rows, 1);
+        assert_eq!(slots[0].required_handoff_action_evidence_rows, 5);
+        assert_eq!(slots[0].release_blocking_handoff_action_evidence_rows, 3);
+        assert_eq!(slots[0].operator_required_handoff_action_evidence_rows, 4);
+        assert_eq!(slots[0].review_required_handoff_action_evidence_rows, 2);
+        assert_eq!(slots[0].dispatch_required_handoff_action_evidence_rows, 5);
+        assert_eq!(slots[0].execution_required_handoff_action_evidence_rows, 5);
+        assert_eq!(
+            slots[0].first_required_handoff_action_evidence_row_key,
+            Some(
+                "release-ticket-handoff-readiness-evidence-review-disposition-action-readiness-handoff-action-evidence-01-repair_handoff-substrate_actions"
+                    .to_string()
+            )
+        );
+        assert_eq!(
+            slots[0].first_blocked_substrate_stage,
+            Some(IntegrationMeshProtocolSubstrateStage::NetworkSecurity)
+        );
+        assert!(!slots[0].handoff_action_evidence_ready);
+        assert!(!slots[0].protocol_substrate_ready);
+        assert!(!slots[0].protocol_evidence_packet_ready);
+        assert!(!slots[0].protocol_evidence_package_ready);
+        assert!(!slots[0].package_handoff_ready);
+        assert!(!slots[0].protocol_evidence_package_handoff_ready);
+        assert!(!slots[0].ready_for_package_handoff_execution());
+        assert!(!slots[0].is_release_slot());
+        assert!(slots[0].is_review_slot());
+        assert!(slots[0].has_blockers());
+        assert!(slots[0].has_required_evidence());
+        assert!(slots[0].needs_operator());
+        assert!(slots[0].has_review_work());
+        assert!(slots[0].requires_dispatch());
+        assert!(slots[0].requires_execution());
+        assert!(slots[0].requires_attention());
+    }
+
+    #[test]
+    fn mesh_release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_protocol_evidence_package_handoff_execution_slots_mark_release_ready(
+    ) {
+        let catalog = vec![hue_entry()];
+        let allowed_capabilities = vec![
+            CapabilityId::trusted("smart_home.read"),
+            CapabilityId::trusted("smart_home.command.light"),
+            CapabilityId::trusted("smart_home.pair"),
+        ];
+        let slots =
+            mesh_release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_protocol_evidence_package_handoff_execution_slots_for_catalog(
+                &catalog,
+                all_primitive_families(),
+                &allowed_capabilities,
+                &[],
+            );
+
+        assert_eq!(slots.len(), 3);
+        assert_eq!(slots[0].protocol, ProtocolFamily::Zigbee);
+        assert_eq!(
+            slots[0].handoff_lane,
+            IntegrationMeshReleaseDispatchTicketHandoffLane::Release
+        );
+        assert_eq!(slots[0].blocked_substrate_rows, 0);
+        assert_eq!(slots[0].required_handoff_action_evidence_rows, 0);
+        assert_eq!(slots[0].release_blocking_handoff_action_evidence_rows, 0);
+        assert_eq!(slots[0].operator_required_handoff_action_evidence_rows, 0);
+        assert_eq!(slots[0].review_required_handoff_action_evidence_rows, 0);
+        assert_eq!(slots[0].dispatch_required_handoff_action_evidence_rows, 0);
+        assert_eq!(slots[0].execution_required_handoff_action_evidence_rows, 0);
+        assert_eq!(slots[0].release_handoff_evidence_rows, 5);
+        assert_eq!(slots[0].release_ready_handoff_action_evidence_rows, 5);
+        assert_eq!(
+            slots[0].first_required_handoff_action_evidence_row_key,
+            None
+        );
+        assert_eq!(slots[0].first_blocked_substrate_stage, None);
+        assert!(slots[0].handoff_action_evidence_ready);
+        assert!(slots[0].protocol_substrate_ready);
+        assert!(slots[0].protocol_evidence_packet_ready);
+        assert!(slots[0].protocol_evidence_package_ready);
+        assert!(slots[0].package_handoff_ready);
+        assert!(slots[0].protocol_evidence_package_handoff_ready);
+        assert!(slots[0].ready_for_package_handoff_execution());
+        assert!(slots[0].is_release_slot());
+        assert!(!slots[0].is_repair_slot());
+        assert!(!slots[0].has_blockers());
+        assert!(!slots[0].has_required_evidence());
+        assert!(!slots[0].needs_operator());
+        assert!(!slots[0].has_review_work());
+        assert!(!slots[0].requires_dispatch());
+        assert!(!slots[0].requires_execution());
+        assert!(!slots[0].requires_attention());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add package handoff execution slots for the mesh protocol-evidence package handoff path
- map Zigbee, Z-Wave, and Thread package handoff rows into deterministic handoff lanes with ready/attention predicates
- document the new low-level slot surface in the smart-home catalog README and changelog

## Validation
- cargo fmt --manifest-path code/packages/rust/smart-home-integration-catalog/Cargo.toml
- cargo test --manifest-path code/packages/rust/smart-home-integration-catalog/Cargo.toml protocol_evidence_package
- cargo check --manifest-path code/packages/rust/smart-home-integration-catalog/Cargo.toml --message-format short
- git diff --check