### PR TITLE
Add smart-home dashboard audit panels

### DIFF
--- a/code/packages/rust/smart-home-platform-http/CHANGELOG.md
+++ b/code/packages/rust/smart-home-platform-http/CHANGELOG.md
@@ -37,6 +37,8 @@ All notable changes to this package will be documented in this file.
 - Added browser dashboard desired-state target controls for light on/off and
   brightness so the local controller can supervise intended state through the
   existing runtime-authorized native API.
+- Added browser dashboard command-result and authorization-decision audit
+  panels backed by the existing local-controller audit routes.
 - Added a native readiness checklist route with actionable links for registry,
   topology, state coverage, event bus, discovery, supervisor, authorization,
   and desired-state checks.

--- a/code/packages/rust/smart-home-platform-http/README.md
+++ b/code/packages/rust/smart-home-platform-http/README.md
@@ -86,10 +86,11 @@ the Home Assistant-style history route accepts `filter_entity_id`.
 
 The browser routes serve an embedded local dashboard shell over the same
 `web-core::WebApp`. The shell loads bootstrap, readiness, state, scene,
-desired-state, state-history, service catalog, API catalog, and audit data from
-the native API routes and sends light on/off, light brightness, scene, and
-desired-state set/clear actions through the existing Home Assistant-compatible
-and native service endpoints, preserving runtime authorization.
+desired-state, state-history, command-result audit, authorization audit,
+service catalog, API catalog, and audit summary data from the native API routes
+and sends light on/off, light brightness, scene, and desired-state set/clear
+actions through the existing Home Assistant-compatible and native service
+endpoints, preserving runtime authorization.
 
 ## Dependencies
 

--- a/code/packages/rust/smart-home-platform-http/src/lib.rs
+++ b/code/packages/rust/smart-home-platform-http/src/lib.rs
@@ -338,6 +338,24 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
         </table>
       </div>
       <div class="panel">
+        <h2>Commands</h2>
+        <table>
+          <thead>
+            <tr><th>Command</th><th>Status</th><th>Bridge</th><th>Sequence</th></tr>
+          </thead>
+          <tbody id="command-results"></tbody>
+        </table>
+      </div>
+      <div class="panel">
+        <h2>Authorization</h2>
+        <table>
+          <thead>
+            <tr><th>Principal</th><th>Subject</th><th>Outcome</th><th>Tier</th></tr>
+          </thead>
+          <tbody id="authorization-decisions"></tbody>
+        </table>
+      </div>
+      <div class="panel">
         <h2>Log</h2>
         <div id="log" class="log"></div>
       </div>
@@ -346,7 +364,9 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
   <script>
     const els = {
       activity: document.querySelector("#activity"),
+      authorizationDecisions: document.querySelector("#authorization-decisions"),
       checks: document.querySelector("#checks"),
+      commandResults: document.querySelector("#command-results"),
       desired: document.querySelector("#desired"),
       entities: document.querySelector("#entities"),
       gaps: document.querySelector("#gaps"),
@@ -394,6 +414,15 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
         return "";
       }
       return ms > 1000000000000 ? new Date(ms).toLocaleString() : `${ms} ms`;
+    };
+    const subjectText = (subject) => {
+      if (!subject) {
+        return "unknown";
+      }
+      if (subject.kind === "tool") {
+        return subject.tool_id || "tool";
+      }
+      return [subject.command_type, subject.entity_id].filter(Boolean).join(" ") || subject.kind || "subject";
     };
 
     const log = (message) => {
@@ -535,10 +564,48 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
       }).join("") || `<tr><td colspan="4" class="muted">No state history</td></tr>`;
     };
 
+    const renderCommandResults = (audit) => {
+      const results = audit.results || [];
+      els.commandResults.innerHTML = results.map((record) => {
+        const result = record.result || {};
+        return `
+          <tr>
+            <td>${result.command_id || "unknown"}<br><span class="muted">${result.correlation_id || ""}</span></td>
+            <td><span class="${statusClass(result.status || "ok")}">${result.status || "unknown"}</span></td>
+            <td>${result.bridge_id || ""}</td>
+            <td>${record.sequence}</td>
+          </tr>
+        `;
+      }).join("") || `<tr><td colspan="4" class="muted">No command results</td></tr>`;
+    };
+
+    const renderAuthorizationDecisions = (audit) => {
+      const decisions = audit.decisions || [];
+      els.authorizationDecisions.innerHTML = decisions.map((record) => `
+        <tr>
+          <td>${record.principal_id}<br><span class="muted">${observedText(record.decided_at_ms)}</span></td>
+          <td>${subjectText(record.subject)}</td>
+          <td><span class="${statusClass(record.outcome || "ok")}">${record.outcome}</span></td>
+          <td>${record.required_tier}</td>
+        </tr>
+      `).join("") || `<tr><td colspan="4" class="muted">No authorization decisions</td></tr>`;
+    };
+
     const render = async () => {
       els.refresh.disabled = true;
       try {
-        const [bootstrap, readiness, states, scenes, desiredStates, history, services, routes] = await Promise.all([
+        const [
+          bootstrap,
+          readiness,
+          states,
+          scenes,
+          desiredStates,
+          history,
+          services,
+          routes,
+          commandResults,
+          authorizationDecisions
+        ] = await Promise.all([
           json("/api/smart_home/bootstrap"),
           json("/api/smart_home/readiness"),
           json("/api/smart_home/states?limit=24"),
@@ -546,7 +613,9 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
           json("/api/smart_home/desired_states?limit=12"),
           json("/api/smart_home/state_history?limit=12"),
           json("/api/smart_home/services?limit=8"),
-          json("/api/smart_home/api?mutating=true&authorized=true")
+          json("/api/smart_home/api?mutating=true&authorized=true"),
+          json("/api/smart_home/command_results?limit=8"),
+          json("/api/smart_home/authorization_decisions?limit=8")
         ]);
         const summary = bootstrap.dashboard.summary;
         els.location.textContent = bootstrap.dashboard.config.location_name;
@@ -572,6 +641,8 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
         renderDesiredStates(desiredStates);
         renderGaps(bootstrap.state_gaps);
         renderHistory(history);
+        renderCommandResults(commandResults);
+        renderAuthorizationDecisions(authorizationDecisions);
         log("Dashboard refreshed");
       } catch (error) {
         els.status.className = statusClass("blocked");
@@ -6402,6 +6473,8 @@ mod tests {
             assert!(body.contains("json(\"/api/smart_home/state_history?limit=12\")"));
             assert!(body.contains("json(\"/api/smart_home/services?limit=8\")"));
             assert!(body.contains("json(\"/api/smart_home/api?mutating=true&authorized=true\")"));
+            assert!(body.contains("json(\"/api/smart_home/command_results?limit=8\")"));
+            assert!(body.contains("json(\"/api/smart_home/authorization_decisions?limit=8\")"));
             assert!(body.contains("/api/services/light/"));
             assert!(body.contains("data-service=\"set_brightness\""));
             assert!(body.contains("brightness_pct"));
@@ -7436,6 +7509,8 @@ mod tests {
         assert!(body.contains("json(\"/api/smart_home/state_history?limit=12\")"));
         assert!(body.contains("json(\"/api/smart_home/services?limit=8\")"));
         assert!(body.contains("json(\"/api/smart_home/api?mutating=true&authorized=true\")"));
+        assert!(body.contains("json(\"/api/smart_home/command_results?limit=8\")"));
+        assert!(body.contains("json(\"/api/smart_home/authorization_decisions?limit=8\")"));
         assert!(body.contains("/api/services/light/"));
         assert!(body.contains("data-brightness-input"));
         assert!(body.contains("brightness_pct"));


### PR DESCRIPTION
## Summary
- add browser dashboard tables for recent command results and authorization decisions
- fetch the existing native audit routes instead of adding a parallel HTTP surface
- document the dashboard audit panels and assert the embedded shell loads those audit APIs

## Validation
- `cargo fmt -p smart-home-platform-http`
- `cargo test -p smart-home-platform-http -- --nocapture`
- `sh BUILD` from `code/packages/rust/smart-home-platform-http`
- `git diff --check`