### PR TITLE
[codex] Support exact rational predicate expressions

### DIFF
--- a/code/grammars/adj_lang.grammar
+++ b/code/grammars/adj_lang.grammar
@@ -53,7 +53,8 @@ prior_decl       = "prior" NUMBER "for" term { annotation } ;
 contributes_decl = "contributes" NUMBER "from" evidence "to" term { annotation } ;
 
 # Evidence is either a numeric PREDICATE over a valued slot
-# (`gross_income >= 14600`) or an ordinary term (`pmh(hypertension)`).
+# (`gross_income >= 14600`, `answer == 3 / 10`) or an ordinary term
+# (`pmh(hypertension)`).
 # The predicate alternative is tried first; because both start with an
 # IDENT, the parser relies on full backtracking — `predicate` consumes
 # the IDENT, fails when it does not find a comparison operator, and the
@@ -62,7 +63,7 @@ contributes_decl = "contributes" NUMBER "from" evidence "to" term { annotation }
 # very large LR over a CPU-evaluated comparison, not a second engine.
 evidence  = predicate | term ;
 
-predicate = IDENT ( GE | LE | GT | LT | EQEQ ) NUMBER ;
+predicate = IDENT ( GE | LE | GT | LT | EQEQ ) expr ;
 
 interacts_decl   = "interacts" NUMBER "when" term "and" term { "and" term } "for" term { annotation } ;
 

--- a/code/packages/rust/adj-lang-cli/tests/cli_golden.rs
+++ b/code/packages/rust/adj-lang-cli/tests/cli_golden.rs
@@ -131,6 +131,27 @@ fn let_computed_value_drives_a_predicate() {
 }
 
 #[test]
+fn predicate_rhs_expression_matches_fraction_result() {
+    // Rung-1 hardening: the option predicate can compare a computed answer
+    // against another ADJ arithmetic expression, so a model can emit
+    // `answer == 3 / 10` instead of relying on a decimal literal.
+    let (ok, s) = run(
+        "adjcli_fraction_rhs.adj",
+        "let answer = 1 / 10 + 2 / 10\n\
+         prior 0.10 for opt_a\n\
+         contributes 1000000 from answer == 3 / 10 to opt_a\n\
+         ? opt_a\n",
+    );
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(s.contains("\"kind\":\"predicate\""), "{s}");
+    assert!(s.contains("\"slot\":\"answer\""), "{s}");
+    assert!(
+        s.contains("\"posterior\":0.99") || s.contains("\"posterior\":1"),
+        "fraction expression predicate should fire: {s}"
+    );
+}
+
+#[test]
 fn predicate_below_threshold_does_not_fire() {
     // Income under the threshold: the predicate step never appears, and the
     // posterior stays at the prior.

--- a/code/packages/rust/adj-lang/CHANGELOG.md
+++ b/code/packages/rust/adj-lang/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.19.0] - 2026-06-27 — predicate RHS expressions
+
+### Added
+
+- Predicate evidence now accepts a full arithmetic expression on the right-hand
+  side: `contributes 1000000 from answer == 3 / 10 to opt_a`. This lets a
+  decomposer emit the printed option expression directly while ADJ evaluates and
+  compares the values.
+- Lowering now preserves the predicate RHS as a `ComputeExpr` through
+  `logic_engine::PredicateContributionClause::from_lr_expr`.
+
 ## [0.18.0] - 2026-06-27 — native LaTeX math expressions and equations
 
 ### Added

--- a/code/packages/rust/adj-lang/README.md
+++ b/code/packages/rust/adj-lang/README.md
@@ -35,9 +35,11 @@ observe gross_income(18000)
 ```
 
 The engine evaluates `gross_income >= 14600` on the CPU at decision time —
-the model that authored the rulebook never ran the comparison. The proof
-step records the literal comparison that fired (`slot`, `op`, `threshold`,
-`observed`), so the audit trail shows the numbers, not a model's claim.
+the model that authored the rulebook never ran the comparison. The right-hand
+side may be a full arithmetic expression such as `answer == 3 / 10`, including
+native `latex "<math>"` wherever an expression is legal. The proof step records
+the comparison that fired (`slot`, `op`, `threshold`, `observed`), so the audit
+trail shows the numbers, not a model's claim.
 DETERMINATE / INDETERMINATE / CONFLICT still fall out of the differential
 (leader / insufficient-evidence / kickback) — **one engine, not two**.
 Operators: `>= <= > < ==`.

--- a/code/packages/rust/adj-lang/src/_parser_grammar.rs
+++ b/code/packages/rust/adj-lang/src/_parser_grammar.rs
@@ -168,7 +168,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         },
                     ],
                 },
-                line_number: 63,
+                line_number: 64,
             },
             GrammarRule {
                 name: r#"predicate"#.to_string(),
@@ -198,12 +198,12 @@ pub fn parser_grammar() -> ParserGrammar {
                                 ],
                             }),
                         },
-                        GrammarElement::TokenReference {
-                            name: r#"NUMBER"#.to_string(),
+                        GrammarElement::RuleReference {
+                            name: r#"expr"#.to_string(),
                         },
                     ],
                 },
-                line_number: 65,
+                line_number: 66,
             },
             GrammarRule {
                 name: r#"interacts_decl"#.to_string(),
@@ -252,7 +252,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         },
                     ],
                 },
-                line_number: 67,
+                line_number: 68,
             },
             GrammarRule {
                 name: r#"uncertain_decl"#.to_string(),
@@ -295,7 +295,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         },
                     ],
                 },
-                line_number: 69,
+                line_number: 70,
             },
             GrammarRule {
                 name: r#"observe_decl"#.to_string(),
@@ -309,7 +309,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         },
                     ],
                 },
-                line_number: 71,
+                line_number: 72,
             },
             GrammarRule {
                 name: r#"relate_decl"#.to_string(),
@@ -328,7 +328,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         },
                     ],
                 },
-                line_number: 84,
+                line_number: 85,
             },
             GrammarRule {
                 name: r#"rule_decl"#.to_string(),
@@ -410,7 +410,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         },
                     ],
                 },
-                line_number: 106,
+                line_number: 107,
             },
             GrammarRule {
                 name: r#"body_literal"#.to_string(),
@@ -426,7 +426,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         },
                     ],
                 },
-                line_number: 108,
+                line_number: 109,
             },
             GrammarRule {
                 name: r#"context_order_decl"#.to_string(),
@@ -470,7 +470,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         },
                     ],
                 },
-                line_number: 119,
+                line_number: 120,
             },
             GrammarRule {
                 name: r#"functional_decl"#.to_string(),
@@ -484,7 +484,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         },
                     ],
                 },
-                line_number: 130,
+                line_number: 131,
             },
             GrammarRule {
                 name: r#"query_decl"#.to_string(),
@@ -498,7 +498,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         },
                     ],
                 },
-                line_number: 132,
+                line_number: 133,
             },
             GrammarRule {
                 name: r#"let_decl"#.to_string(),
@@ -518,7 +518,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         },
                     ],
                 },
-                line_number: 146,
+                line_number: 147,
             },
             GrammarRule {
                 name: r#"expr"#.to_string(),
@@ -550,7 +550,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         },
                     ],
                 },
-                line_number: 148,
+                line_number: 149,
             },
             GrammarRule {
                 name: r#"term_expr"#.to_string(),
@@ -582,7 +582,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         },
                     ],
                 },
-                line_number: 150,
+                line_number: 151,
             },
             GrammarRule {
                 name: r#"factor"#.to_string(),
@@ -615,7 +615,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         },
                     ],
                 },
-                line_number: 152,
+                line_number: 153,
             },
             GrammarRule {
                 name: r#"agg"#.to_string(),
@@ -653,7 +653,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         },
                     ],
                 },
-                line_number: 154,
+                line_number: 155,
             },
             GrammarRule {
                 name: r#"latex_expr"#.to_string(),
@@ -667,7 +667,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         },
                     ],
                 },
-                line_number: 161,
+                line_number: 162,
             },
             GrammarRule {
                 name: r#"symbol_decl"#.to_string(),
@@ -687,7 +687,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         },
                     ],
                 },
-                line_number: 171,
+                line_number: 172,
             },
             GrammarRule {
                 name: r#"constrain_latex_decl"#.to_string(),
@@ -701,7 +701,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         },
                     ],
                 },
-                line_number: 173,
+                line_number: 174,
             },
             GrammarRule {
                 name: r#"constrain_decl"#.to_string(),
@@ -721,7 +721,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         },
                     ],
                 },
-                line_number: 175,
+                line_number: 176,
             },
             GrammarRule {
                 name: r#"latex_relation"#.to_string(),
@@ -735,7 +735,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         },
                     ],
                 },
-                line_number: 177,
+                line_number: 178,
             },
             GrammarRule {
                 name: r#"relop"#.to_string(),
@@ -764,7 +764,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         },
                     ],
                 },
-                line_number: 179,
+                line_number: 180,
             },
             GrammarRule {
                 name: r#"solve_decl"#.to_string(),
@@ -799,14 +799,14 @@ pub fn parser_grammar() -> ParserGrammar {
                         },
                     ],
                 },
-                line_number: 181,
+                line_number: 182,
             },
             GrammarRule {
                 name: r#"check_decl"#.to_string(),
                 body: GrammarElement::Literal {
                     value: r#"check"#.to_string(),
                 },
-                line_number: 183,
+                line_number: 184,
             },
             GrammarRule {
                 name: r#"optimize_decl"#.to_string(),
@@ -829,7 +829,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         },
                     ],
                 },
-                line_number: 190,
+                line_number: 191,
             },
             GrammarRule {
                 name: r#"dictionary_decl"#.to_string(),
@@ -854,7 +854,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         },
                     ],
                 },
-                line_number: 202,
+                line_number: 203,
             },
             GrammarRule {
                 name: r#"define_decl"#.to_string(),
@@ -879,7 +879,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         },
                     ],
                 },
-                line_number: 204,
+                line_number: 205,
             },
             GrammarRule {
                 name: r#"define_kind"#.to_string(),
@@ -949,7 +949,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         },
                     ],
                 },
-                line_number: 206,
+                line_number: 207,
             },
             GrammarRule {
                 name: r#"surface_clause"#.to_string(),
@@ -975,7 +975,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         },
                     ],
                 },
-                line_number: 212,
+                line_number: 213,
             },
             GrammarRule {
                 name: r#"rulebook_decl"#.to_string(),
@@ -1000,7 +1000,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         },
                     ],
                 },
-                line_number: 229,
+                line_number: 230,
             },
             GrammarRule {
                 name: r#"use_decl"#.to_string(),
@@ -1014,7 +1014,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         },
                     ],
                 },
-                line_number: 231,
+                line_number: 232,
             },
             GrammarRule {
                 name: r#"import_decl"#.to_string(),
@@ -1028,7 +1028,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         },
                     ],
                 },
-                line_number: 247,
+                line_number: 248,
             },
             GrammarRule {
                 name: r#"annotation"#.to_string(),
@@ -1048,7 +1048,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         },
                     ],
                 },
-                line_number: 259,
+                line_number: 260,
             },
             GrammarRule {
                 name: r#"source_annotation"#.to_string(),
@@ -1062,7 +1062,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         },
                     ],
                 },
-                line_number: 265,
+                line_number: 266,
             },
             GrammarRule {
                 name: r#"locator_annotation"#.to_string(),
@@ -1076,7 +1076,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         },
                     ],
                 },
-                line_number: 266,
+                line_number: 267,
             },
             GrammarRule {
                 name: r#"trust_annotation"#.to_string(),
@@ -1090,7 +1090,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         },
                     ],
                 },
-                line_number: 267,
+                line_number: 268,
             },
             GrammarRule {
                 name: r#"cites_annotation"#.to_string(),
@@ -1110,7 +1110,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         },
                     ],
                 },
-                line_number: 268,
+                line_number: 269,
             },
             GrammarRule {
                 name: r#"trust_tier"#.to_string(),
@@ -1133,7 +1133,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         },
                     ],
                 },
-                line_number: 270,
+                line_number: 271,
             },
             GrammarRule {
                 name: r#"term"#.to_string(),
@@ -1197,7 +1197,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         },
                     ],
                 },
-                line_number: 292,
+                line_number: 293,
             },
         ],
         version: 1,

--- a/code/packages/rust/adj-lang/src/adapter.rs
+++ b/code/packages/rust/adj-lang/src/adapter.rs
@@ -207,7 +207,7 @@ fn adapt_evidence(node: &GrammarASTNode) -> Result<Evidence, AdapterError> {
 }
 
 fn adapt_predicate(node: &GrammarASTNode) -> Result<Evidence, AdapterError> {
-    // predicate = IDENT ( GE | LE | GT | LT | EQEQ ) NUMBER
+    // predicate = IDENT ( GE | LE | GT | LT | EQEQ ) expr
     //
     // The slot IDENT and the operator are both lexed as TokenType::Name
     // (the operator carries a custom type_name like "GE"), so we
@@ -215,7 +215,6 @@ fn adapt_predicate(node: &GrammarASTNode) -> Result<Evidence, AdapterError> {
     // comparison symbols; everything else Name-typed is the slot.
     let mut slot: Option<String> = None;
     let mut op: Option<CmpOp> = None;
-    let mut value: Option<f64> = None;
     for c in &node.children {
         if let ASTNodeOrToken::Token(t) = c {
             match t.value.as_str() {
@@ -224,9 +223,6 @@ fn adapt_predicate(node: &GrammarASTNode) -> Result<Evidence, AdapterError> {
                 ">" => op = Some(CmpOp::Gt),
                 "<" => op = Some(CmpOp::Lt),
                 "==" => op = Some(CmpOp::Eq),
-                _ if t.type_ == TokenType::Number => {
-                    value = Some(parse_finite(&t.value, t.type_, "predicate")?);
-                }
                 _ if t.type_ == TokenType::Name && slot.is_none() => {
                     slot = Some(t.value.clone());
                 }
@@ -242,11 +238,26 @@ fn adapt_predicate(node: &GrammarASTNode) -> Result<Evidence, AdapterError> {
         rule: "predicate".into(),
         position: "comparison operator",
     })?;
-    let value = value.ok_or(AdapterError::MissingChild {
-        rule: "predicate".into(),
-        position: "threshold NUMBER",
-    })?;
-    Ok(Evidence::Predicate { slot, op, value })
+    let rhs = if let Some(expr) = first_named_child(node, "expr") {
+        adapt_expr(expr)?
+    } else {
+        // Bootstrap compatibility while regenerating from the previous grammar,
+        // whose predicate RHS was a direct NUMBER token.
+        node.children
+            .iter()
+            .find_map(|c| match c {
+                ASTNodeOrToken::Token(t) if t.type_ == TokenType::Number => {
+                    Some(parse_finite(&t.value, t.type_, "predicate").map(ExprAst::Lit))
+                }
+                _ => None,
+            })
+            .transpose()?
+            .ok_or(AdapterError::MissingChild {
+                rule: "predicate".into(),
+                position: "right-hand expression",
+            })?
+    };
+    Ok(Evidence::Predicate { slot, op, rhs })
 }
 
 fn adapt_interacts(node: &GrammarASTNode) -> Result<Statement, AdapterError> {
@@ -1404,10 +1415,10 @@ mod tests {
             } => {
                 assert_eq!(lr, 1_000_000.0);
                 match evidence {
-                    Evidence::Predicate { slot, op, value } => {
+                    Evidence::Predicate { slot, op, rhs } => {
                         assert_eq!(slot, "gross_income");
                         assert_eq!(op, CmpOp::Ge);
-                        assert_eq!(value, 14600.0);
+                        assert!(matches!(rhs, ExprAst::Lit(v) if v == 14600.0));
                     }
                     other => panic!("expected predicate evidence, got {other:?}"),
                 }
@@ -1429,15 +1440,31 @@ mod tests {
             let src = format!("contributes 2.0 from age {sym} 18 to adult");
             match parse_one(&src) {
                 Statement::Contributes {
-                    evidence: Evidence::Predicate { op, value, slot },
+                    evidence: Evidence::Predicate { op, rhs, slot },
                     ..
                 } => {
                     assert_eq!(op, *expected, "operator {sym}");
-                    assert_eq!(value, 18.0);
+                    assert!(matches!(rhs, ExprAst::Lit(v) if v == 18.0));
                     assert_eq!(slot, "age");
                 }
                 other => panic!("expected predicate Contributes for {sym}, got {other:?}"),
             }
+        }
+    }
+
+    #[test]
+    fn predicate_rhs_can_be_an_arithmetic_expression() {
+        let src = "contributes 1000000 from answer == 3 / 10 to opt_a";
+        match parse_one(src) {
+            Statement::Contributes {
+                evidence: Evidence::Predicate { slot, op, rhs },
+                ..
+            } => {
+                assert_eq!(slot, "answer");
+                assert_eq!(op, CmpOp::Eq);
+                assert!(matches!(rhs, ExprAst::Bin(ArithOp::Div, _, _)));
+            }
+            other => panic!("expected predicate Contributes, got {other:?}"),
         }
     }
 

--- a/code/packages/rust/adj-lang/src/ast.rs
+++ b/code/packages/rust/adj-lang/src/ast.rs
@@ -41,6 +41,7 @@ pub enum Term {
 ///
 /// `from pmh(hypertension) to acs`  →  [`Evidence::Term`]
 /// `from gross_income >= 14600 to required_to_file`  →  [`Evidence::Predicate`]
+/// `from answer == 3 / 10 to opt_a`  →  [`Evidence::Predicate`]
 ///
 /// The predicate form is the surface syntax for a deterministic rule:
 /// it lowers to a predicate-gated contribution whose likelihood ratio
@@ -50,7 +51,11 @@ pub enum Term {
 #[derive(Debug, Clone, PartialEq)]
 pub enum Evidence {
     Term(Term),
-    Predicate { slot: String, op: CmpOp, value: f64 },
+    Predicate {
+        slot: String,
+        op: CmpOp,
+        rhs: ExprAst,
+    },
 }
 
 /// A numeric comparison operator in a predicate. Mirrors

--- a/code/packages/rust/adj-lang/src/lower.rs
+++ b/code/packages/rust/adj-lang/src/lower.rs
@@ -225,12 +225,12 @@ pub fn lower(program: &Program) -> Result<LoweredProgram, LowerError> {
                     // Numeric predicate evidence → predicate-gated contribution.
                     // The comparison is evaluated on the CPU at decision time;
                     // a saturating `lr` makes the rule deterministic.
-                    Evidence::Predicate { slot, op, value } => {
-                        let clause = PredicateContributionClause::from_lr(
+                    Evidence::Predicate { slot, op, rhs } => {
+                        let clause = PredicateContributionClause::from_lr_expr(
                             lower_term(conclusion),
                             slot.clone(),
                             lower_cmp_op(*op),
-                            *value,
+                            lower_expr(rhs),
                             *lr,
                         )
                         .with_provenance(prov);
@@ -1380,6 +1380,19 @@ mod tests {
             }
             other => panic!("expected LRAggregateResult, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn predicate_rhs_expression_fires_over_fraction_result() {
+        let d = crate::compile_and_decide(
+            r#"let answer = 1 / 10 + 2 / 10
+prior 0.10 for opt_a
+contributes 1000000 from answer == 3 / 10 to opt_a
+? opt_a
+"#,
+        )
+        .unwrap();
+        assert!(d.ranked[0].posterior > 0.99, "{d:?}");
     }
 
     #[test]

--- a/code/packages/rust/logic-engine/CHANGELOG.md
+++ b/code/packages/rust/logic-engine/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.24.0] - 2026-06-27 — exact rational predicate comparisons
+
+### Added
+
+- `compute::ExactRational` sidecars for integer/rational arithmetic. `compute`
+  still exposes `f64` magnitudes for compatibility, but derived values now keep
+  an exact value when literals, references, and binary arithmetic stay inside
+  exact integer/rational operations.
+- `PredicateContributionClause::from_lr_expr` and `CmpOp::eval_values`, allowing
+  predicate gates to compare against a computed right-hand expression and use
+  exact rational equality when both sides carry exact values.
+- `KnowledgeBase::observed_numeric` and `observed_exact_value_with_fact` so
+  predicate gates can read observed or derived magnitudes with their exact
+  sidecars when available.
+
 ## [0.23.0] - 2026-06-21 — multi-source corroboration on `Provenance` (ADJ-A9)
 
 ### Added

--- a/code/packages/rust/logic-engine/src/compute.rs
+++ b/code/packages/rust/logic-engine/src/compute.rs
@@ -49,6 +49,99 @@
 use crate::dimension::{DimOp, Dimension};
 use crate::{FactId, KnowledgeBase};
 
+/// An exact rational sidecar for CPU arithmetic whose operands are exact
+/// integers/rationals. The public engine still exposes `f64` magnitudes for
+/// compatibility, but equality-sensitive consumers can use this when present.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ExactRational {
+    pub num: i128,
+    pub den: i128,
+}
+
+impl ExactRational {
+    pub fn new(num: i128, den: i128) -> Option<Self> {
+        if den == 0 || num == i128::MIN || den == i128::MIN {
+            return None;
+        }
+        let (mut n, mut d) = (num, den);
+        if d < 0 {
+            n = n.checked_neg()?;
+            d = d.checked_neg()?;
+        }
+        let g = gcd_i128(n.unsigned_abs(), d.unsigned_abs()) as i128;
+        Some(Self {
+            num: n / g,
+            den: d / g,
+        })
+    }
+
+    pub fn from_i128(n: i128) -> Self {
+        Self { num: n, den: 1 }
+    }
+
+    pub fn from_integer_f64(value: f64) -> Option<Self> {
+        if value.is_finite()
+            && value.fract() == 0.0
+            && value >= i64::MIN as f64
+            && value <= i64::MAX as f64
+        {
+            Some(Self::from_i128(value as i64 as i128))
+        } else {
+            None
+        }
+    }
+
+    pub fn add(self, rhs: Self) -> Option<Self> {
+        let left = self.num.checked_mul(rhs.den)?;
+        let right = rhs.num.checked_mul(self.den)?;
+        let num = left.checked_add(right)?;
+        let den = self.den.checked_mul(rhs.den)?;
+        Self::new(num, den)
+    }
+
+    pub fn sub(self, rhs: Self) -> Option<Self> {
+        let left = self.num.checked_mul(rhs.den)?;
+        let right = rhs.num.checked_mul(self.den)?;
+        let num = left.checked_sub(right)?;
+        let den = self.den.checked_mul(rhs.den)?;
+        Self::new(num, den)
+    }
+
+    pub fn mul(self, rhs: Self) -> Option<Self> {
+        Self::new(
+            self.num.checked_mul(rhs.num)?,
+            self.den.checked_mul(rhs.den)?,
+        )
+    }
+
+    pub fn div(self, rhs: Self) -> Option<Self> {
+        if rhs.num == 0 {
+            return None;
+        }
+        Self::new(
+            self.num.checked_mul(rhs.den)?,
+            self.den.checked_mul(rhs.num)?,
+        )
+    }
+
+    pub fn to_f64(self) -> f64 {
+        self.num as f64 / self.den as f64
+    }
+}
+
+fn gcd_i128(a: u128, b: u128) -> u128 {
+    let (mut a, mut b) = (a, b);
+    if a == 0 && b == 0 {
+        return 1;
+    }
+    while b != 0 {
+        let t = b;
+        b = a % b;
+        a = t;
+    }
+    a.max(1)
+}
+
 /// A computation operator. Binary ops (`Add`/`Sub`/`Mul`/`Div`) take two
 /// operands; aggregation ops (`Sum`/`Count`/`Min`/`Max`/`Avg`) reduce a list
 /// of same-slot observations.
@@ -144,6 +237,8 @@ impl DerivationNode {
 pub struct Derived {
     pub name: String,
     pub value: f64,
+    /// Exact value when the expression stayed inside integer/rational arithmetic.
+    pub exact: Option<ExactRational>,
     pub dim: Dimension,
     pub tree: DerivationNode,
 }
@@ -202,11 +297,12 @@ pub fn compute(
     expr: &ComputeExpr,
     kb: &KnowledgeBase,
 ) -> Result<Derived, ComputeError> {
-    let (tree, dim) = eval(expr, kb, 0)?;
+    let (tree, dim, exact) = eval(expr, kb, 0)?;
     let value = tree.value();
     Ok(Derived {
         name: name.into(),
         value,
+        exact,
         dim,
         tree,
     })
@@ -234,7 +330,7 @@ fn eval(
     expr: &ComputeExpr,
     kb: &KnowledgeBase,
     depth: usize,
-) -> Result<(DerivationNode, Dimension), ComputeError> {
+) -> Result<(DerivationNode, Dimension, Option<ExactRational>), ComputeError> {
     if depth >= MAX_EVAL_DEPTH {
         return Err(ComputeError::TooDeep {
             limit: MAX_EVAL_DEPTH,
@@ -243,12 +339,23 @@ fn eval(
     match expr {
         // A literal is dimensionless (Scalar). The no-magic-numbers gate (3d)
         // will check it's a declared constant; dimensionally it's the identity.
-        ComputeExpr::Lit(x) => Ok((DerivationNode::Lit { value: *x }, Dimension::Scalar)),
+        ComputeExpr::Lit(x) => Ok((
+            DerivationNode::Lit { value: *x },
+            Dimension::Scalar,
+            ExactRational::from_integer_f64(*x),
+        )),
 
         ComputeExpr::Ref(slot) => {
             // Observed fact first (carries a FactId for byte provenance + its
             // dimension); then a previously-bound derived value (with its dim).
             if let Some((d, fact_id)) = kb.observed_dimensioned(slot) {
+                let exact = kb.observed_exact_value_with_fact(slot).and_then(|(x, id)| {
+                    if id == fact_id {
+                        Some(x)
+                    } else {
+                        None
+                    }
+                });
                 Ok((
                     DerivationNode::Leaf {
                         slot: slot.clone(),
@@ -256,6 +363,7 @@ fn eval(
                         fact_id,
                     },
                     d.dim,
+                    exact,
                 ))
             } else if let Some(derived) = kb.derived_for(slot) {
                 Ok((
@@ -264,6 +372,7 @@ fn eval(
                         value: derived.value,
                     },
                     derived.dim.clone(),
+                    derived.exact,
                 ))
             } else {
                 Err(ComputeError::UnknownSlot { slot: slot.clone() })
@@ -271,23 +380,18 @@ fn eval(
         }
 
         ComputeExpr::Bin(op, a, b) => {
-            let (lhs, dim_l) = eval(a, kb, depth + 1)?;
-            let (rhs, dim_r) = eval(b, kb, depth + 1)?;
+            let (lhs, dim_l, exact_l) = eval(a, kb, depth + 1)?;
+            let (rhs, dim_r, exact_r) = eval(b, kb, depth + 1)?;
             // Dimensional check FIRST: usd + days is a category error regardless
             // of the magnitudes.
             let dimop = dim_op(*op).ok_or(ComputeError::MalformedExpr {
                 detail: "aggregation operator in binary position",
             })?;
-            let result_dim =
-                Dimension::combine(dimop, &dim_l, &dim_r).map_err(|e| match e {
-                    crate::DimError::Mismatch { lhs, rhs, .. } => {
-                        ComputeError::DimensionMismatch {
-                            op: *op,
-                            lhs,
-                            rhs,
-                        }
-                    }
-                })?;
+            let result_dim = Dimension::combine(dimop, &dim_l, &dim_r).map_err(|e| match e {
+                crate::DimError::Mismatch { lhs, rhs, .. } => {
+                    ComputeError::DimensionMismatch { op: *op, lhs, rhs }
+                }
+            })?;
             let (x, y) = (lhs.value(), rhs.value());
             let result = match op {
                 ComputeOp::Add => x + y,
@@ -304,6 +408,16 @@ fn eval(
             if !result.is_finite() {
                 return Err(ComputeError::NonFinite { op: *op });
             }
+            let exact = match (exact_l, exact_r) {
+                (Some(a), Some(b)) => match op {
+                    ComputeOp::Add => a.add(b),
+                    ComputeOp::Sub => a.sub(b),
+                    ComputeOp::Mul => a.mul(b),
+                    ComputeOp::Div => a.div(b),
+                    _ => None,
+                },
+                _ => None,
+            };
             Ok((
                 DerivationNode::Op {
                     op: *op,
@@ -311,6 +425,7 @@ fn eval(
                     result,
                 },
                 result_dim,
+                exact,
             ))
         }
 
@@ -362,6 +477,7 @@ fn eval(
                     result,
                 },
                 result_dim,
+                None,
             ))
         }
     }
@@ -384,7 +500,10 @@ mod tests {
     // ---- the dimensional faithfulness gate (track A4) ----
 
     fn money(slot: &str, amount: i64, ccy: &str) -> crate::Fact {
-        crate::Fact::certain(compound(slot, vec![compound("money", vec![int(amount), atom(ccy)])]))
+        crate::Fact::certain(compound(
+            slot,
+            vec![compound("money", vec![int(amount), atom(ccy)])],
+        ))
     }
     fn refexpr(slot: &str) -> ComputeExpr {
         ComputeExpr::Ref(slot.into())
@@ -396,7 +515,12 @@ mod tests {
     #[test]
     fn same_currency_add_is_allowed_and_keeps_the_dimension() {
         let kb = kb_with(vec![money("a", 100, "usd"), money("b", 50, "usd")]);
-        let d = compute("total", &bin(ComputeOp::Add, refexpr("a"), refexpr("b")), &kb).unwrap();
+        let d = compute(
+            "total",
+            &bin(ComputeOp::Add, refexpr("a"), refexpr("b")),
+            &kb,
+        )
+        .unwrap();
         assert_eq!(d.value, 150.0);
         assert_eq!(d.dim, Dimension::Money("usd".into()));
     }
@@ -407,7 +531,10 @@ mod tests {
         let err = compute("x", &bin(ComputeOp::Add, refexpr("a"), refexpr("b")), &kb).unwrap_err();
         assert!(matches!(
             err,
-            ComputeError::DimensionMismatch { op: ComputeOp::Add, .. }
+            ComputeError::DimensionMismatch {
+                op: ComputeOp::Add,
+                ..
+            }
         ));
     }
 
@@ -415,18 +542,38 @@ mod tests {
     fn money_plus_days_is_a_category_error() {
         let kb = kb_with(vec![
             money("price", 100, "usd"),
-            Fact::certain(compound("age", vec![compound("duration", vec![int(5), atom("days")])])),
+            Fact::certain(compound(
+                "age",
+                vec![compound("duration", vec![int(5), atom("days")])],
+            )),
         ]);
-        let err = compute("x", &bin(ComputeOp::Add, refexpr("price"), refexpr("age")), &kb).unwrap_err();
+        let err = compute(
+            "x",
+            &bin(ComputeOp::Add, refexpr("price"), refexpr("age")),
+            &kb,
+        )
+        .unwrap_err();
         assert!(matches!(err, ComputeError::DimensionMismatch { .. }));
     }
 
     #[test]
     fn money_over_money_is_a_dimensionless_ratio() {
-        let kb = kb_with(vec![money("debt", 3000, "usd"), money("income", 10000, "usd")]);
-        let d = compute("dti", &bin(ComputeOp::Div, refexpr("debt"), refexpr("income")), &kb).unwrap();
+        let kb = kb_with(vec![
+            money("debt", 3000, "usd"),
+            money("income", 10000, "usd"),
+        ]);
+        let d = compute(
+            "dti",
+            &bin(ComputeOp::Div, refexpr("debt"), refexpr("income")),
+            &kb,
+        )
+        .unwrap();
         assert!((d.value - 0.3).abs() < 1e-12);
-        assert_eq!(d.dim, Dimension::Scalar, "a ratio of like dimensions is dimensionless");
+        assert_eq!(
+            d.dim,
+            Dimension::Scalar,
+            "a ratio of like dimensions is dimensionless"
+        );
     }
 
     #[test]
@@ -490,6 +637,27 @@ mod tests {
             }
             other => panic!("expected an Op node, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn integer_fraction_arithmetic_carries_exact_rational_sidecar() {
+        let kb = KnowledgeBase::new();
+        let expr = ComputeExpr::Bin(
+            ComputeOp::Add,
+            Box::new(ComputeExpr::Bin(
+                ComputeOp::Div,
+                Box::new(ComputeExpr::Lit(1.0)),
+                Box::new(ComputeExpr::Lit(10.0)),
+            )),
+            Box::new(ComputeExpr::Bin(
+                ComputeOp::Div,
+                Box::new(ComputeExpr::Lit(2.0)),
+                Box::new(ComputeExpr::Lit(10.0)),
+            )),
+        );
+        let d = compute("answer", &expr, &kb).unwrap();
+        assert!((d.value - 0.3).abs() < 1e-12);
+        assert_eq!(d.exact, ExactRational::new(3, 10));
     }
 
     #[test]
@@ -620,7 +788,9 @@ mod tests {
         }
         assert_eq!(
             compute("deep", &e, &kb).unwrap_err(),
-            ComputeError::TooDeep { limit: MAX_EVAL_DEPTH }
+            ComputeError::TooDeep {
+                limit: MAX_EVAL_DEPTH
+            }
         );
     }
 

--- a/code/packages/rust/logic-engine/src/lib.rs
+++ b/code/packages/rust/logic-engine/src/lib.rs
@@ -816,6 +816,24 @@ impl KnowledgeBase {
             .or_else(|| self.derived_for(slot).map(|d| d.value))
     }
 
+    /// Read an observed or derived numeric value together with its exact
+    /// rational sidecar when one is available. This is used by equality-heavy
+    /// predicate gates such as `answer == 3 / 10`: the public magnitude remains
+    /// `f64`, but exact integer/rational arithmetic can avoid float artifacts.
+    pub fn observed_numeric(
+        &self,
+        slot: &str,
+    ) -> Option<(f64, Option<crate::compute::ExactRational>)> {
+        self.observed_value_with_fact(slot)
+            .map(|(v, id)| {
+                let exact = self
+                    .observed_exact_value_with_fact(slot)
+                    .and_then(|(x, exact_id)| if exact_id == id { Some(x) } else { None });
+                (v, exact)
+            })
+            .or_else(|| self.derived_for(slot).map(|d| (d.value, d.exact)))
+    }
+
     /// Like [`observed_value`](Self::observed_value) but also returns the
     /// [`FactId`] of the winning observation — used by
     /// [`compute`](crate::compute) so a derivation-tree leaf can cite the byte-
@@ -834,6 +852,27 @@ impl KnowledgeBase {
             })
             // Largest FactId wins — facts are inserted in program order,
             // so a later `observe` of the same slot supersedes an earlier.
+            .max_by_key(|(id, _)| id.0)
+            .map(|(id, v)| (v, id))
+    }
+
+    /// Exact counterpart to [`observed_value_with_fact`](Self::observed_value_with_fact).
+    /// Returns a value only when the fact's leading magnitude is exactly
+    /// representable as an integer/rational sidecar.
+    pub fn observed_exact_value_with_fact(
+        &self,
+        slot: &str,
+    ) -> Option<(crate::compute::ExactRational, FactId)> {
+        self.facts
+            .values()
+            .flatten()
+            .filter(|f| f.probability == Probability::Certain)
+            .filter_map(|f| match &f.term {
+                Term::Compound { functor, args } if functor == slot && args.len() == 1 => {
+                    numeric_exact_magnitude(&args[0]).map(|v| (f.id, v))
+                }
+                _ => None,
+            })
             .max_by_key(|(id, _)| id.0)
             .map(|(id, v)| (v, id))
     }
@@ -984,6 +1023,27 @@ pub fn numeric_magnitude(value: &Term) -> Option<f64> {
         Term::Compound { args, .. } => match args.first() {
             Some(Term::Num(Number::Int(i))) => Some(*i as f64),
             Some(Term::Num(Number::Float(x))) => Some(*x),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+/// Exact counterpart to [`numeric_magnitude`]. It intentionally returns `None`
+/// for non-integral floats; exact decimal parsing belongs at the language
+/// adapter layer, while this engine helper only trusts values that arrived as
+/// integer terms or integer-valued floats.
+pub fn numeric_exact_magnitude(value: &Term) -> Option<crate::compute::ExactRational> {
+    match value {
+        Term::Num(Number::Int(i)) => Some(crate::compute::ExactRational::from_i128(*i as i128)),
+        Term::Num(Number::Float(x)) => crate::compute::ExactRational::from_integer_f64(*x),
+        Term::Compound { args, .. } => match args.first() {
+            Some(Term::Num(Number::Int(i))) => {
+                Some(crate::compute::ExactRational::from_i128(*i as i128))
+            }
+            Some(Term::Num(Number::Float(x))) => {
+                crate::compute::ExactRational::from_integer_f64(*x)
+            }
             _ => None,
         },
         _ => None,

--- a/code/packages/rust/logic-engine/src/lr_aggregate.rs
+++ b/code/packages/rust/logic-engine/src/lr_aggregate.rs
@@ -36,6 +36,7 @@
 
 use logic_core::{Substitution, Term};
 
+use crate::compute::{compute, ComputeExpr, ExactRational};
 use crate::proof_dag::{DerivationOrigin, Proof, ProofDAG, ProofStep};
 use crate::{
     ContributionClauseId, FactId, JointContributionClauseId, KnowledgeBase,
@@ -189,6 +190,28 @@ impl CmpOp {
         }
     }
 
+    /// Evaluate with exact rational sidecars when both sides have them.
+    /// This keeps legacy f64 behaviour for ordinary thresholds while making
+    /// fraction equality such as `1 / 10 + 2 / 10 == 3 / 10` exact.
+    pub fn eval_values(
+        &self,
+        lhs: f64,
+        rhs: f64,
+        lhs_exact: Option<ExactRational>,
+        rhs_exact: Option<ExactRational>,
+    ) -> bool {
+        match (lhs_exact, rhs_exact) {
+            (Some(a), Some(b)) => match self {
+                CmpOp::Ge => cmp_exact(a, b) >= 0,
+                CmpOp::Le => cmp_exact(a, b) <= 0,
+                CmpOp::Gt => cmp_exact(a, b) > 0,
+                CmpOp::Lt => cmp_exact(a, b) < 0,
+                CmpOp::Eq => a == b,
+            },
+            _ => self.eval(lhs, rhs),
+        }
+    }
+
     pub fn symbol(&self) -> &'static str {
         match self {
             CmpOp::Ge => ">=",
@@ -197,6 +220,24 @@ impl CmpOp {
             CmpOp::Lt => "<",
             CmpOp::Eq => "==",
         }
+    }
+}
+
+fn cmp_exact(lhs: ExactRational, rhs: ExactRational) -> i8 {
+    let Some(a) = lhs.num.checked_mul(rhs.den) else {
+        return ordering_i8(lhs.to_f64().total_cmp(&rhs.to_f64()));
+    };
+    let Some(b) = rhs.num.checked_mul(lhs.den) else {
+        return ordering_i8(lhs.to_f64().total_cmp(&rhs.to_f64()));
+    };
+    ordering_i8(a.cmp(&b))
+}
+
+fn ordering_i8(ordering: std::cmp::Ordering) -> i8 {
+    match ordering {
+        std::cmp::Ordering::Less => -1,
+        std::cmp::Ordering::Equal => 0,
+        std::cmp::Ordering::Greater => 1,
     }
 }
 
@@ -216,7 +257,7 @@ pub struct PredicateContributionClause {
     pub conclusion: Term,
     pub slot: String,
     pub op: CmpOp,
-    pub value: f64,
+    pub rhs: ComputeExpr,
     pub logit_delta: f64,
     pub provenance: Provenance,
 }
@@ -234,7 +275,25 @@ impl PredicateContributionClause {
             conclusion,
             slot: slot.into(),
             op,
-            value,
+            rhs: ComputeExpr::Lit(value),
+            logit_delta,
+            provenance: Provenance::unattributed(),
+        }
+    }
+
+    pub fn new_expr(
+        conclusion: Term,
+        slot: impl Into<String>,
+        op: CmpOp,
+        rhs: ComputeExpr,
+        logit_delta: f64,
+    ) -> Self {
+        Self {
+            id: PredicateContributionClauseId(u64::MAX),
+            conclusion,
+            slot: slot.into(),
+            op,
+            rhs,
             logit_delta,
             provenance: Provenance::unattributed(),
         }
@@ -253,6 +312,22 @@ impl PredicateContributionClause {
             "PredicateContributionClause::from_lr requires lr > 0.0; got {lr}"
         );
         Self::new(conclusion, slot, op, value, lr.ln())
+    }
+
+    /// Construct a predicate contribution whose right-hand side is a full
+    /// compute expression (`from answer == 3 / 10 to opt_a`).
+    pub fn from_lr_expr(
+        conclusion: Term,
+        slot: impl Into<String>,
+        op: CmpOp,
+        rhs: ComputeExpr,
+        lr: f64,
+    ) -> Self {
+        assert!(
+            lr > 0.0,
+            "PredicateContributionClause::from_lr_expr requires lr > 0.0; got {lr}"
+        );
+        Self::new_expr(conclusion, slot, op, rhs, lr.ln())
     }
 
     pub fn with_provenance(mut self, provenance: Provenance) -> Self {
@@ -788,8 +863,14 @@ pub fn lr_aggregate(query: &Term, kb: &KnowledgeBase) -> LRAggregateResult {
     // value of its slot and evaluate the predicate on CPU; if true, apply its
     // logit_delta. A saturating logit_delta makes this a deterministic rule.
     for pc in kb.predicate_contributions_for(query) {
-        if let Some(observed) = kb.observed_value(&pc.slot) {
-            if pc.op.eval(observed, pc.value) {
+        if let Some((observed, observed_exact)) = kb.observed_numeric(&pc.slot) {
+            let Ok(rhs) = compute("__predicate_rhs", &pc.rhs, kb) else {
+                continue;
+            };
+            if pc
+                .op
+                .eval_values(observed, rhs.value, observed_exact, rhs.exact)
+            {
                 any_contribution_active = true;
                 steps.push(ProofStep {
                     goal: query.clone(),
@@ -797,7 +878,7 @@ pub fn lr_aggregate(query: &Term, kb: &KnowledgeBase) -> LRAggregateResult {
                         clause_id: pc.id,
                         slot: pc.slot.clone(),
                         op: pc.op,
-                        threshold: pc.value,
+                        threshold: rhs.value,
                         observed,
                         logit_delta: pc.logit_delta,
                     },
@@ -888,7 +969,7 @@ pub fn lr_aggregate(query: &Term, kb: &KnowledgeBase) -> LRAggregateResult {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Fact, KnowledgeBase};
+    use crate::{ComputeOp, Fact, KnowledgeBase};
     use logic_core::{atom, compound};
 
     fn approx_eq(a: f64, b: f64, tol: f64) -> bool {
@@ -1137,6 +1218,51 @@ mod tests {
             })
             .expect("a predicate step should be present");
         assert_eq!(step, ("gross_income".to_string(), ">=", 14600.0, 18000.0));
+    }
+
+    #[test]
+    fn predicate_expression_rhs_uses_exact_fraction_equality() {
+        let mut kb = KnowledgeBase::new();
+        kb.add_prior(PriorClause::from_probability(atom("opt_a"), 0.10))
+            .unwrap();
+        let answer = crate::compute(
+            "answer",
+            &ComputeExpr::Bin(
+                ComputeOp::Add,
+                Box::new(ComputeExpr::Bin(
+                    ComputeOp::Div,
+                    Box::new(ComputeExpr::Lit(1.0)),
+                    Box::new(ComputeExpr::Lit(10.0)),
+                )),
+                Box::new(ComputeExpr::Bin(
+                    ComputeOp::Div,
+                    Box::new(ComputeExpr::Lit(2.0)),
+                    Box::new(ComputeExpr::Lit(10.0)),
+                )),
+            ),
+            &kb,
+        )
+        .unwrap();
+        assert_eq!(answer.exact, ExactRational::new(3, 10));
+        kb.add_derived(answer);
+        kb.add_predicate_contribution(PredicateContributionClause::from_lr_expr(
+            atom("opt_a"),
+            "answer",
+            CmpOp::Eq,
+            ComputeExpr::Bin(
+                ComputeOp::Div,
+                Box::new(ComputeExpr::Lit(3.0)),
+                Box::new(ComputeExpr::Lit(10.0)),
+            ),
+            1e6,
+        ));
+
+        let result = lr_aggregate(&atom("opt_a"), &kb);
+        assert!(result.posterior > 0.9999, "got {}", result.posterior);
+        assert!(result.dag.proofs[0]
+            .steps
+            .iter()
+            .any(|s| matches!(s.origin, DerivationOrigin::FromPredicateContribution { .. })));
     }
 
     #[test]

--- a/code/specs/ADJ-LADDER.md
+++ b/code/specs/ADJ-LADDER.md
@@ -84,12 +84,12 @@ contributes 1000000 from answer == 62 to opt_e
 
 The engine evaluates `answer` (= 59), the predicate `answer == 59` fires, opt_a's
 log-odds jump decisively, and the decision returns `determinate` with `leader = opt_a`
-→ letter **A**. If the computed answer matches **no** option (or, via a duplicate-value
-accident, two) the hypotheses stay tied → `kickback` → the harness **ABSTAINS** rather
-than guess. The harness supplies only the formula and the printed option values; the
-arithmetic, the comparison, and the selection are all the engine's. (This is the
-`let` + predicate-`contributes` mechanism from `proration.adj`; it needs **zero engine
-change** — the first audited rung is answerable today.)
+→ letter **A**. Fractional options use the same path with an expression RHS, for
+example `contributes 1000000 from answer == 3 / 10 to opt_a`. If the computed answer
+matches **no** option (or, via a duplicate-value accident, two) the hypotheses stay tied
+→ `kickback` → the harness **ABSTAINS** rather than guess. The harness supplies only
+the formula and the printed option values; the arithmetic, the comparison, and the
+selection are all the engine's.
 
 ---
 
@@ -161,7 +161,7 @@ engine gap that blocks it, and every rung ships a two-arm divergence number.
 | Rung | Content | Engine capability it pulls |
 |------|---------|----------------------------|
 | **0** | grade-school arithmetic + 1-step word problems | **none** (value-math exists) — shipped |
-| **1** | fractions / percent | starter scaffold uses terminating cases today; exact rationals (ADJ-REASON-MATH PR-3) for arbitrary fraction equality |
+| **1** | fractions / percent | native predicate RHS expressions plus exact rational sidecars for fractional equality; harder banks climb from here |
 | 2 | pre-algebra / algebra word problems | multi-step deduction→evidence bridge (PR-1) + CAS solve (PR-6) |
 | 3 | algebra / calculus | CAS wiring (PR-6) + rewrite trail (PR-4) |
 | 4 | physics / chem with units | dimensional engine (exists) + exact compute (PR-3) |
@@ -214,7 +214,7 @@ The mechanism is proven; the ladder can climb.
 
 ## 7. Next
 
-Continue rung 1 by hardening exact rational equality, then PR-1 = the
+Continue rung 1 with harder fraction/percent banks, then PR-1 = the
 ADJ-REASON-MATH **deduction→evidence bridge** (`logic-engine` — `observed_evidence`
 falls back to SLD provability + attenuates confidence + threads rule provenance), the
 unlock for every multi-step rung. Then rungs 2→5 in order, each gating the next engine

--- a/code/specs/ADJ-REASON-MATH.md
+++ b/code/specs/ADJ-REASON-MATH.md
@@ -49,7 +49,7 @@ giving it a derivation trail**.
 |---|---|---|
 | `prior N for T` | `:50` | Seeds LR log-odds prior (`PriorClause`) |
 | `contributes N from <evidence> to T` | `:52` | Single-source likelihood ratio; `evidence = predicate \| term` (`:62`) |
-| `predicate = IDENT (GE\|LE\|GT\|LT\|EQEQ) NUMBER` | `:64` | **Predicate-gated** (deterministic = saturating LR over a CPU comparison) |
+| `predicate = IDENT (GE\|LE\|GT\|LT\|EQEQ) expr` | `:64` | **Predicate-gated** (deterministic = saturating LR over a CPU comparison; RHS can be arithmetic/LaTeX) |
 | `interacts N when T and T … for T` | `:66` | Joint/synergy/explaining-away LR |
 | `uncertain {T,…} for T` | `:68` | Uncertainty marker (what would shift the answer) |
 | `observe T` | `:70` | Assert a `Certain` Fact |

--- a/code/specs/data/adj-ladder/README.md
+++ b/code/specs/data/adj-ladder/README.md
@@ -56,11 +56,12 @@ contributes 1000000 from answer == 59 to opt_a
 ```
 
 The formula can be plain ADJ arithmetic or native ADJ LaTeX syntax such as
-`latex "$5 \times 12$"`; either way, `adj-lang-cli` owns parsing and execution. The
-engine computes `answer`, the matching predicate fires, and the decision returns
-`determinate` with `leader = opt_a` → **A**. No match (or a tie) → `kickback` →
-**abstain**. The harness supplies only the formula and the printed option values; the
-arithmetic and the selection are the engine's.
+`latex "$5 \times 12$"`; option values can be numeric literals or ADJ expressions
+such as `3 / 10`. Either way, `adj-lang-cli` owns parsing and execution. The engine
+computes `answer`, compares it against each option expression, the matching predicate
+fires, and the decision returns `determinate` with `leader = opt_a` → **A**. No match
+(or a tie) → `kickback` → **abstain**. The harness supplies only the formula and the
+printed option values; the arithmetic and the selection are the engine's.
 
 ## Run it
 
@@ -100,7 +101,8 @@ the engine imports; reuse `ladder_eval.py` unchanged. Each rung pulls in the nex
 engine capability from ADJ-REASON-MATH (exact rationals, CAS wiring, dimensional
 units, the deduction↔evidence bridge) — see ADJ-LADDER.md §5.
 
-`rung1_fractions_percent` is intentionally a starter scaffold: its current bank sticks
-to terminating fractions and integer percent answers so the existing engine can own
-the arithmetic today. Harder arbitrary fraction equality still belongs to the exact
-rational work called out in ADJ-REASON-MATH.
+`rung1_fractions_percent` is intentionally a starter scaffold. It now has the native
+surface it needs for fractional option matching (`answer == 3 / 10`), with exact
+rational sidecars carrying integer/rational arithmetic through predicate equality.
+The next climb is using that surface in harder banks and then connecting multi-step
+deductions into probabilistic evidence.

--- a/code/specs/data/adj-ladder/contamination_check.py
+++ b/code/specs/data/adj-ladder/contamination_check.py
@@ -66,6 +66,14 @@ def safe_eval(expr: str) -> float:
     return ev(ast.parse(expr, mode="eval"))
 
 
+def option_value(value) -> float:
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        return float(safe_eval(value))
+    raise ValueError(f"unsupported option value {value!r}")
+
+
 def check(rung: str) -> list[str]:
     items = json.loads((HERE / rung / "items.json").read_text())["items"]
     errors: list[str] = []
@@ -79,8 +87,20 @@ def check(rung: str) -> list[str]:
         opts = it.get("options", {})
         if sorted(opts) != list("ABCDE"):
             errors.append(f"{iid}: options must be exactly A..E, got {sorted(opts)}")
-        if len(set(opts.values())) != len(opts):
-            errors.append(f"{iid}: option values must be distinct, got {opts}")
+        numeric_opts: dict[str, float] = {}
+        for ltr, value in opts.items():
+            try:
+                numeric_opts[ltr] = option_value(value)
+            except (ValueError, SyntaxError, ZeroDivisionError) as e:
+                errors.append(f"{iid}: option {ltr} value {value!r} did not evaluate: {e}")
+        duplicates = [
+            (a, b)
+            for i, (a, av) in enumerate(numeric_opts.items())
+            for b, bv in list(numeric_opts.items())[i + 1 :]
+            if abs(av - bv) <= 1e-9
+        ]
+        if duplicates:
+            errors.append(f"{iid}: option values must be distinct, got duplicates {duplicates}")
 
         gold = it.get("gold_letter")
         if gold not in opts:
@@ -92,7 +112,7 @@ def check(rung: str) -> list[str]:
         except (ValueError, SyntaxError, ZeroDivisionError) as e:
             errors.append(f"{iid}: formula {it['formula']!r} did not evaluate: {e}")
             continue
-        if abs(computed - opts[gold]) > 1e-9:
+        if gold in numeric_opts and abs(computed - numeric_opts[gold]) > 1e-9:
             errors.append(f"{iid}: gold {gold}={opts[gold]} ≠ formula value {computed}")
 
         stem_nums = set(_NUM.findall(it.get("stem", "")))

--- a/code/specs/data/adj-ladder/ladder_eval.py
+++ b/code/specs/data/adj-ladder/ladder_eval.py
@@ -104,6 +104,7 @@ import sys
 import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Union
 
 HERE = Path(__file__).resolve().parent
 
@@ -140,21 +141,36 @@ _LETTER = re.compile(r"\b([A-E])\b")
 # ----------------------------------------------------------------------------------
 # Arm B — build the ADJ program and read the engine's selection.
 # ----------------------------------------------------------------------------------
-def build_arm_b_program(formula: str, options: dict[str, float]) -> str:
+OptionValue = Union[int, float, str]
+
+
+def _render_option_expr(value: OptionValue) -> str:
+    if isinstance(value, str):
+        value = value.strip()
+        if not value:
+            raise ValueError("option expression must not be empty")
+        return value
+    v = float(value)
+    return str(int(v)) if v.is_integer() else str(value)
+
+
+def build_arm_b_program(formula: str, options: dict[str, OptionValue]) -> str:
     """Render the option-selection ADJ program described in the module docstring.
 
-    `options` maps letters (A..E) to their numeric value as printed in the question.
-    We declare one equal-prior hypothesis per option and one `contributes` predicate
-    that fires when the engine-computed `answer` equals that option's value. The huge
-    likelihood ratio (1e6) makes a single matching option dominate decisively; if
-    none match, the hypotheses stay tied and the engine returns a kickback."""
+    `options` maps letters (A..E) to their numeric value or ADJ arithmetic expression
+    as printed in the question. We declare one equal-prior hypothesis per option and
+    one `contributes` predicate that fires when the engine-computed `answer` equals
+    that option's value. The huge likelihood ratio (1e6) makes a single matching
+    option dominate decisively; if none match, the hypotheses stay tied and the
+    engine returns a kickback."""
     lines = [f"prior 0.0001 for opt_{ltr.lower()}" for ltr in options]
     lines.append(f"let answer = {formula}")
     for ltr, val in options.items():
-        # Render whole-valued floats as ints so the predicate threshold reads cleanly
-        # (59 not 59.0); the engine compares numerically either way.
-        v = int(val) if float(val).is_integer() else val
-        lines.append(f"contributes 1000000 from answer == {v} to opt_{ltr.lower()}")
+        # Render whole-valued floats as ints so the predicate reads cleanly (59 not
+        # 59.0). String values are already ADJ expressions such as `3 / 10`.
+        lines.append(
+            f"contributes 1000000 from answer == {_render_option_expr(val)} to opt_{ltr.lower()}"
+        )
     lines += [f"? opt_{ltr.lower()}" for ltr in options]
     return "\n".join(lines) + "\n"
 

--- a/code/specs/data/adj-ladder/test_ladder_eval.py
+++ b/code/specs/data/adj-ladder/test_ladder_eval.py
@@ -40,6 +40,13 @@ def test_build_program_renders_int_thresholds():
     assert "answer == 5 to opt_b" in prog
 
 
+def test_build_program_accepts_option_expressions():
+    prog = le.build_arm_b_program("1 / 10 + 2 / 10", {"A": "3 / 10", "B": "1 / 2"})
+    assert "let answer = 1 / 10 + 2 / 10" in prog
+    assert "contributes 1000000 from answer == 3 / 10 to opt_a" in prog
+    assert "contributes 1000000 from answer == 1 / 2 to opt_b" in prog
+
+
 # ---- faithfulness / no-result-literals ----------------------------------------
 def test_faithful_formula_passes():
     assert le.formula_is_faithful("7 * 8 + 3", "What is 7 * 8 + 3?")
@@ -160,10 +167,34 @@ def test_native_adj_latex_formula_runs_through_engine():
     assert le.decision_to_letter(decision) == "A"
 
 
+def test_option_expression_predicate_runs_through_engine():
+    if le._CLI is None:
+        pytest.skip("adj-lang-cli not built")
+    decision = le.run_decision(
+        le.build_arm_b_program("1 / 10 + 2 / 10", {"A": "3 / 10", "B": "1 / 2"})
+    )
+    assert le.decision_to_letter(decision) == "A"
+
+
 # ---- bank integrity -----------------------------------------------------------
 @pytest.mark.parametrize("rung", SELF_CONTAINED_RUNGS)
 def test_contamination_check_clean(rung):
     assert cc.check(rung) == []
+
+
+def test_contamination_check_accepts_option_expressions(tmp_path, monkeypatch):
+    rung = tmp_path / "expr_options"
+    rung.mkdir()
+    (rung / "items.json").write_text(json.dumps({"items": [{
+        "id": "frac_expr_001",
+        "qtype": "fraction",
+        "stem": "What is 1/10 + 2/10?",
+        "formula": "1 / 10 + 2 / 10",
+        "options": {"A": "3 / 10", "B": "1 / 2", "C": "1 / 10", "D": "2 / 10", "E": "4 / 10"},
+        "gold_letter": "A",
+    }]}) + "\n")
+    monkeypatch.setattr(cc, "HERE", tmp_path)
+    assert cc.check("expr_options") == []
 
 
 def test_safe_eval_rejects_code():


### PR DESCRIPTION
## Summary

This is the next small ADJ-LADDER rung-1 hardening slice. It lets the decomposer emit option comparisons as native ADJ expressions, so ADJ owns the math instead of requiring decimal thresholds.

- Allow predicate evidence RHS values to be full `expr`s, e.g. `contributes 1000000 from answer == 3 / 10 to opt_a`.
- Carry exact rational sidecars through integer/rational `let` arithmetic and use them for predicate comparisons when both sides are exact.
- Extend the ladder harness so option values can be ADJ expressions like `3 / 10`, with the contamination gate still validating item integrity off the answer path.
- Refresh the ADJ-LADDER / ADJ-REASON-MATH docs and package changelogs for the new rung-1 surface.

## Validation

- `cargo test -p logic-engine -p adj-lang`
- `cargo test -p adj-lang-cli --test cli_golden`
- `python3 -m pytest test_ladder_eval.py -q`
- `git diff --check`

Known existing warnings remain unchanged: the `logic-engine` dimension unreachable-pattern warning, the existing unused `Term` test import, and the `adj-lang-cli` unused `mut` warning.