### PR TITLE
Stamp SPICE diode transient charge

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Added
 
+- **Diode transient charge stamping** —
+  Diode `Cjo`/`Tt` model-card storage now stamps transient anode-cathode
+  companions, matching Rust and TypeScript, with regression coverage for
+  junction-capacitance current-step delay and transit-time turnoff charge.
+
 - **Device model charge audit fixtures** —
   `device_model_charge_audit_fixtures()` now exposes runnable one-device
   `.tran` fixtures with reference deck lines, explicit terminal storage

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -213,7 +213,9 @@ JFET and Level-1 MOS channel thermal noise audits.
 `device_model_charge_audit_fixtures()` adds matching `.tran` reference-deck
 metadata, explicit terminal storage capacitance metadata, stable first/final
 probe-voltage windows, and charge-behavior notes for diode, BJT, JFET, and
-Level-1 MOS charge audits.
+Level-1 MOS charge audits. Diode `Cjo` and `Tt` model-card parameters also
+stamp transient anode-cathode storage, matching their small-signal AC
+capacitance semantics.
 
 `DigitalEventStream`, `DigitalLogicLevels`, and `DigitalThresholds` provide the
 first mixed-signal bridge surface: digital event streams can drive finite-edge

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -8659,6 +8659,23 @@ def _diode_current_conductance(el: Diode, vd: float, *, clamp_forward: bool = Tr
     return current, conductance
 
 
+def _diode_charge_state_name(el: Diode) -> str:
+    return f"_D_{el.name}_charge"
+
+
+def _diode_has_charge_storage(el: Diode) -> bool:
+    return el.Cjo > 0.0 or el.Tt > 0.0
+
+
+def _diode_dynamic_capacitance(el: Diode, vd: float) -> float:
+    _, gd = _diode_current_conductance(el, vd)
+    return el.Cjo + el.Tt * gd
+
+
+def _diode_charge_voltage(el: Diode, node_voltages: dict[str, float]) -> float:
+    return _node_voltage(el.anode, node_voltages) - _node_voltage(el.cathode, node_voltages)
+
+
 def _stamp_mosfet(
     G: list[list[float]],
     b: list[float],
@@ -9541,6 +9558,36 @@ def _build_transient_companions(
                 current=I_eq,
             ))
 
+        # ---- Diode model-card charge companion ----------------------------
+        elif isinstance(el, Diode) and _diode_has_charge_storage(el):
+            state_name = _diode_charge_state_name(el)
+            v_prev = cap_voltages.get(state_name, 0.0)
+            capacitance = _diode_dynamic_capacitance(el, v_prev)
+            if capacitance > 0.0:
+                if method == "trap":
+                    g_eq = 2.0 * capacitance / h
+                    I_eq = g_eq * v_prev + cap_currents.get(state_name, 0.0)
+                elif method == "gear2":
+                    v_older = cap_voltages_older.get(state_name, v_prev)
+                    g_eq = 3.0 * capacitance / (2.0 * h)
+                    I_eq = capacitance * (4.0 * v_prev - v_older) / (2.0 * h)
+                else:
+                    g_eq = capacitance / h
+                    I_eq = g_eq * v_prev
+
+                aug.elements.append(Resistor(
+                    name=f"_D_{el.name}_charge_R",
+                    n_plus=el.anode,
+                    n_minus=el.cathode,
+                    resistance=1.0 / g_eq,
+                ))
+                aug.elements.append(CurrentSource(
+                    name=f"_D_{el.name}_charge_I",
+                    n_plus=el.cathode,
+                    n_minus=el.anode,
+                    current=I_eq,
+                ))
+
         # ---- Inductor companion ------------------------------------------
         elif isinstance(el, Inductor) and el.name not in coupled_names:
             I_prev = ind_currents.get(el.name, 0.0)
@@ -9674,6 +9721,30 @@ def _update_reactive_state(
             cap_voltages_older[el.name] = v_prev
             cap_voltages[el.name] = v_new
 
+        elif isinstance(el, Diode) and _diode_has_charge_storage(el):
+            state_name = _diode_charge_state_name(el)
+            v_new = _diode_charge_voltage(el, op.node_voltages)
+            v_prev = cap_voltages.get(state_name, v_new)
+            v_older = cap_voltages_older.get(state_name, v_prev)
+            capacitance = _diode_dynamic_capacitance(el, v_prev)
+
+            if capacitance > 0.0:
+                if method == "trap":
+                    g_eq = 2.0 * capacitance / h
+                    I_prev = cap_currents.get(state_name, 0.0)
+                    cap_currents[state_name] = g_eq * (v_new - v_prev) - I_prev
+                elif method == "gear2":
+                    cap_currents[state_name] = (
+                        capacitance * (3.0 * v_new - 4.0 * v_prev + v_older)
+                        / (2.0 * h)
+                    )
+                else:
+                    g_eq = capacitance / h
+                    cap_currents[state_name] = g_eq * (v_new - v_prev)
+
+            cap_voltages_older[state_name] = v_prev
+            cap_voltages[state_name] = v_new
+
         elif isinstance(el, Inductor) and el.name not in coupled_names:
             v_plus = _node_voltage(el.n_plus, op.node_voltages)
             v_minus = _node_voltage(el.n_minus, op.node_voltages)
@@ -9727,6 +9798,14 @@ def _lte_estimate(
             v1 = cap_voltages_now.get(el.name, 0.0)
             v0 = cap_voltages_prev.get(el.name, el.initial_voltage)
             vm1 = cap_voltages_prev2.get(el.name, el.initial_voltage)
+            lte_c = abs(v1 - 2.0 * v0 + vm1) / 2.0
+            if lte_c > max_lte:
+                max_lte = lte_c
+        elif isinstance(el, Diode) and _diode_has_charge_storage(el):
+            state_name = _diode_charge_state_name(el)
+            v1 = cap_voltages_now.get(state_name, 0.0)
+            v0 = cap_voltages_prev.get(state_name, 0.0)
+            vm1 = cap_voltages_prev2.get(state_name, 0.0)
             lte_c = abs(v1 - 2.0 * v0 + vm1) / 2.0
             if lte_c > max_lte:
                 max_lte = lte_c
@@ -9890,10 +9969,16 @@ def transient(
         el.name: el.initial_voltage
         for el in circuit.elements if isinstance(el, Capacitor)
     }
+    for el in circuit.elements:
+        if isinstance(el, Diode) and _diode_has_charge_storage(el):
+            cap_voltages[_diode_charge_state_name(el)] = _diode_charge_voltage(el, op.node_voltages)
     cap_currents: dict[str, float] = {
         el.name: 0.0
         for el in circuit.elements if isinstance(el, Capacitor)
     }
+    for el in circuit.elements:
+        if isinstance(el, Diode) and _diode_has_charge_storage(el):
+            cap_currents[_diode_charge_state_name(el)] = 0.0
     cap_voltages_older: dict[str, float] = dict(cap_voltages)
     ind_currents: dict[str, float] = {
         el.name: el.initial_current
@@ -9958,6 +10043,11 @@ def transient(
                     v_plus = _node_voltage(el.n_plus, op.node_voltages)
                     v_minus = _node_voltage(el.n_minus, op.node_voltages)
                     cap_voltages_new[el.name] = v_plus - v_minus
+                elif isinstance(el, Diode) and _diode_has_charge_storage(el):
+                    cap_voltages_new[_diode_charge_state_name(el)] = _diode_charge_voltage(
+                        el,
+                        op.node_voltages,
+                    )
 
             lte = _lte_estimate(circuit, cap_voltages_new,
                                  cap_voltages, cap_voltages_prev)

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -880,10 +880,9 @@ def device_model_noise_audit_fixtures() -> tuple[DeviceModelNoiseBehaviorFixture
 def device_model_charge_audit_fixtures() -> tuple[DeviceModelChargeBehaviorFixture, ...]:
     """Return runnable transient storage fixtures for charge model-depth audits.
 
-    The current nonlinear diode/BJT/JFET/MOS charge state is intentionally
-    audited through explicit terminal storage capacitors.  Model-card
-    capacitance parameters remain AC small-signal inputs until a nonlinear
-    transient charge-stamping policy lands.
+    Diode CJO/TT model-card storage is transient-stamped by the simulator.
+    BJT, JFET, and MOS charge state is still audited through explicit terminal
+    storage capacitors until their nonlinear charge policies land.
     """
 
     models = _model_card_by_name()
@@ -934,8 +933,8 @@ def device_model_charge_audit_fixtures() -> tuple[DeviceModelChargeBehaviorFixtu
             expected_final_min=0.58,
             expected_final_max=0.61,
             charge_behavior=(
-                "diode terminal charge is conserved through explicit Cstore; "
-                "CJO/TT remain AC-only until nonlinear charge stamping lands"
+                "diode CJO/TT contribute transient anode-cathode storage; "
+                "explicit Cstore keeps the fixture comparable with other charge audits"
             ),
             deck_lines=(
                 "* device-model charge fixture: diode-storage-charge",

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -554,6 +554,56 @@ def test_device_model_charge_audit_fixtures_run_reference_transients() -> None:
     assert "external-only" in jfet_fixture.charge_behavior
 
 
+def test_transient_diode_junction_capacitance_slows_current_step() -> None:
+    def run(cjo: float) -> TransientResult:
+        circuit = Circuit()
+        circuit.add(CurrentSource(
+            "Istep",
+            "0",
+            "out",
+            0.0,
+            waveform=PwlWaveform(((0.0, 0.0), (1.0e-9, 1.0e-6), (5.0e-9, 1.0e-6))),
+        ))
+        circuit.add(Resistor("Rshunt", "out", "0", 1.0e12))
+        circuit.add(Diode("D1", "out", "0", Is=1.0e-15, Vt=0.02585, Cjo=cjo))
+        return transient(circuit, t_stop=5.0e-9, t_step=1.0e-9, method="euler")
+
+    uncharged = run(0.0)
+    charged = run(1.0e-12)
+
+    assert uncharged.converged
+    assert charged.converged
+    uncharged_first = uncharged.points[1].node_voltages["out"]
+    charged_first = charged.points[1].node_voltages["out"]
+    assert uncharged_first > 0.5
+    assert charged_first < 0.01
+    assert charged_first < uncharged_first
+
+
+def test_transient_diode_transit_time_holds_forward_charge_on_turnoff() -> None:
+    def run(transit_time: float) -> TransientResult:
+        circuit = Circuit()
+        circuit.add(CurrentSource(
+            "Istep",
+            "0",
+            "out",
+            0.0,
+            waveform=PwlWaveform(((0.0, 1.0e-3), (1.0e-9, 0.0), (5.0e-9, 0.0))),
+        ))
+        circuit.add(Resistor("Rshunt", "out", "0", 1.0e12))
+        circuit.add(Diode("D1", "out", "0", Is=1.0e-15, Vt=0.02585, Tt=transit_time))
+        return transient(circuit, t_stop=5.0e-9, t_step=1.0e-9, method="euler")
+
+    no_storage = run(0.0)
+    stored = run(1.0e-9)
+
+    assert no_storage.converged
+    assert stored.converged
+    assert no_storage.points[1].node_voltages["out"] == pytest.approx(0.0, abs=1.0e-12)
+    assert stored.points[1].node_voltages["out"] > 0.6
+    assert stored.points[1].node_voltages["out"] < stored.points[0].node_voltages["out"]
+
+
 def test_non_level_one_mos_model_cards_are_explicitly_rejected() -> None:
     with pytest.raises(ValueError, match="only MOS LEVEL=1"):
         normalize_model_card("Mbad", "nmos", {"LEVEL": 2.0})

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Stamp diode `junction_capacitance` and `transit_time` model-card storage as
+  transient anode-cathode companions, matching Python and TypeScript, with
+  regression coverage for current-step delay and turnoff charge retention.
 - Add `device_model_charge_audit_fixtures` runnable one-device `.tran`
   fixtures with reference deck lines, explicit terminal storage capacitance
   metadata, stable first/final probe-voltage windows, and charge-behavior notes

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -137,7 +137,9 @@ JFET and Level-1 MOS channel thermal noise audits.
 `device_model_charge_audit_fixtures` adds matching `.tran` reference-deck
 metadata, explicit terminal storage capacitance metadata, stable first/final
 probe-voltage windows, and charge-behavior notes for diode, BJT, JFET, and
-Level-1 MOS charge audits.
+Level-1 MOS charge audits. Diode `junction_capacitance` and `transit_time`
+model-card parameters also stamp transient anode-cathode storage, matching
+their small-signal AC capacitance semantics.
 
 `analyze_custom_model_source` accepts only a two-terminal `I(p,n) <+ ...`
 module shape and rejects dynamic/event/system constructs; it is not a full

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -4002,7 +4002,7 @@ pub fn device_model_charge_audit_fixtures(
             expected_initial_max: 1.0,
             expected_final_min: 0.58,
             expected_final_max: 0.61,
-            charge_behavior: "diode terminal charge is conserved through explicit Cstore; CJO/TT remain AC-only until nonlinear charge stamping lands".to_string(),
+            charge_behavior: "diode CJO/TT contribute transient anode-cathode storage; explicit Cstore keeps the fixture comparable with other charge audits".to_string(),
             deck_lines: vec![
                 "* device-model charge fixture: diode-storage-charge".to_string(),
                 ".model Dfast D(IS=2e-14 CJO=1.5e-12 TT=4e-9)".to_string(),
@@ -17513,6 +17513,11 @@ pub fn transient_with_method(
         &inductor_states,
         Some(0.0),
     )?;
+    seed_diode_capacitor_states(
+        circuit,
+        &initial_solution.node_voltages,
+        &mut capacitor_states,
+    );
     update_transmission_line_states(
         circuit,
         &initial_solution.node_voltages,
@@ -17648,6 +17653,11 @@ pub fn transient_adaptive(
         &inductor_states,
         Some(0.0),
     )?;
+    seed_diode_capacitor_states(
+        circuit,
+        &initial_solution.node_voltages,
+        &mut capacitor_states,
+    );
     update_transmission_line_states(
         circuit,
         &initial_solution.node_voltages,
@@ -19093,9 +19103,14 @@ fn solve_linear_circuit_at_operating_point(
             Element::CustomModel(model) => {
                 stamp_custom_model(model, node_indices, &mut matrix, &mut rhs, operating_point)?
             }
-            Element::Diode(diode) => {
-                stamp_diode(diode, node_indices, &mut matrix, &mut rhs, operating_point)?
-            }
+            Element::Diode(diode) => stamp_diode(
+                diode,
+                capacitor_states,
+                node_indices,
+                &mut matrix,
+                &mut rhs,
+                operating_point,
+            )?,
             Element::Jfet(jfet) => {
                 stamp_jfet(jfet, node_indices, &mut matrix, &mut rhs, operating_point)?
             }
@@ -20219,6 +20234,7 @@ fn stamp_custom_model(
 
 fn stamp_diode(
     diode: &Diode,
+    capacitor_states: &[CapacitorState],
     node_indices: &HashMap<String, usize>,
     matrix: &mut [Vec<f64>],
     rhs: &mut [f64],
@@ -20238,6 +20254,51 @@ fn stamp_diode(
     }
     if let Some(index) = cathode {
         rhs[index] += equivalent_current;
+    }
+    stamp_diode_charge(diode, capacitor_states, node_indices, matrix, rhs)?;
+    Ok(())
+}
+
+fn stamp_diode_charge(
+    diode: &Diode,
+    capacitor_states: &[CapacitorState],
+    node_indices: &HashMap<String, usize>,
+    matrix: &mut [Vec<f64>],
+    rhs: &mut [f64],
+) -> Result<(), SpiceError> {
+    let state_name = diode_charge_state_name(diode);
+    let Some(state) = capacitor_states
+        .iter()
+        .find(|state| state.name == state_name)
+    else {
+        return Ok(());
+    };
+    let capacitance = diode_dynamic_capacitance(diode, state.previous_voltage);
+    if capacitance <= 0.0 {
+        return Ok(());
+    }
+
+    let conductance = match state.method {
+        TransientMethod::Trap => 2.0 * capacitance / state.time_step,
+        TransientMethod::Gear2 => 3.0 * capacitance / (2.0 * state.time_step),
+        TransientMethod::Euler => capacitance / state.time_step,
+    };
+    let history_current = match state.method {
+        TransientMethod::Trap => conductance * state.previous_voltage + state.previous_current,
+        TransientMethod::Gear2 => {
+            capacitance * (4.0 * state.previous_voltage - state.previous_previous_voltage)
+                / (2.0 * state.time_step)
+        }
+        TransientMethod::Euler => conductance * state.previous_voltage,
+    };
+    let anode = node_index(node_indices, &diode.anode);
+    let cathode = node_index(node_indices, &diode.cathode);
+    stamp_conductance(matrix, anode, cathode, conductance);
+    if let Some(index) = anode {
+        rhs[index] += history_current;
+    }
+    if let Some(index) = cathode {
+        rhs[index] -= history_current;
     }
     Ok(())
 }
@@ -20766,6 +20827,23 @@ fn diode_current_conductance(diode: &Diode, voltage: f64) -> (f64, f64) {
     (current, conductance)
 }
 
+fn diode_charge_state_name(diode: &Diode) -> String {
+    format!("_D_{}_charge", diode.name)
+}
+
+fn diode_has_charge_storage(diode: &Diode) -> bool {
+    diode.junction_capacitance > 0.0 || diode.transit_time > 0.0
+}
+
+fn diode_dynamic_capacitance(diode: &Diode, voltage: f64) -> f64 {
+    let (_, conductance) = diode_current_conductance(diode, voltage);
+    diode.junction_capacitance + diode.transit_time * conductance
+}
+
+fn diode_charge_voltage(diode: &Diode, node_voltages: &BTreeMap<String, f64>) -> f64 {
+    voltage_at(node_voltages, &diode.anode) - voltage_at(node_voltages, &diode.cathode)
+}
+
 fn validate_diode(diode: &Diode) -> Result<(), SpiceError> {
     if !diode.saturation_current.is_finite() || diode.saturation_current <= 0.0 {
         return Err(SpiceError::InvalidElement {
@@ -21023,6 +21101,14 @@ fn initial_capacitor_states(
                 time_step,
                 method,
             }),
+            Element::Diode(diode) if diode_has_charge_storage(diode) => Some(CapacitorState {
+                name: diode_charge_state_name(diode),
+                previous_voltage: 0.0,
+                previous_previous_voltage: 0.0,
+                previous_current: 0.0,
+                time_step,
+                method,
+            }),
             _ => None,
         })
         .collect()
@@ -21088,6 +21174,10 @@ fn capacitor_voltages(
                 capacitor.name.clone(),
                 voltage_at(node_voltages, &capacitor.n1) - voltage_at(node_voltages, &capacitor.n2),
             )),
+            Element::Diode(diode) if diode_has_charge_storage(diode) => Some((
+                diode_charge_state_name(diode),
+                diode_charge_voltage(diode, node_voltages),
+            )),
             _ => None,
         })
         .collect()
@@ -21116,6 +21206,16 @@ fn transient_lte_estimate(
                     .get(&capacitor.name)
                     .copied()
                     .unwrap_or(capacitor.initial_voltage);
+                Some((current - 2.0 * previous + previous_previous).abs() / 2.0)
+            }
+            Element::Diode(diode) if diode_has_charge_storage(diode) => {
+                let state_name = diode_charge_state_name(diode);
+                let current = current_voltages.get(&state_name).copied().unwrap_or(0.0);
+                let previous = previous_voltages.get(&state_name).copied().unwrap_or(0.0);
+                let previous_previous = previous_previous_voltages
+                    .get(&state_name)
+                    .copied()
+                    .unwrap_or(0.0);
                 Some((current - 2.0 * previous + previous_previous).abs() / 2.0)
             }
             _ => None,
@@ -21293,32 +21393,58 @@ fn update_capacitor_states(
     capacitor_states: &mut [CapacitorState],
 ) {
     for state in capacitor_states {
-        let Some(capacitor) = circuit.elements().iter().find_map(|element| match element {
-            Element::Capacitor(capacitor) if capacitor.name == state.name => Some(capacitor),
+        let update = circuit.elements().iter().find_map(|element| match element {
+            Element::Capacitor(capacitor) if capacitor.name == state.name => Some((
+                voltage_at(node_voltages, &capacitor.n1) - voltage_at(node_voltages, &capacitor.n2),
+                capacitor.capacitance_farads,
+            )),
+            Element::Diode(diode) if diode_charge_state_name(diode) == state.name => Some((
+                diode_charge_voltage(diode, node_voltages),
+                diode_dynamic_capacitance(diode, state.previous_voltage),
+            )),
             _ => None,
-        }) else {
+        });
+        let Some((voltage, capacitance)) = update else {
             continue;
         };
         let previous_voltage = state.previous_voltage;
         let previous_current = state.previous_current;
-        let voltage =
-            voltage_at(node_voltages, &capacitor.n1) - voltage_at(node_voltages, &capacitor.n2);
         state.previous_current = match state.method {
             TransientMethod::Trap => {
-                let conductance = 2.0 * capacitor.capacitance_farads / state.time_step;
+                let conductance = 2.0 * capacitance / state.time_step;
                 conductance * (voltage - previous_voltage) - previous_current
             }
             TransientMethod::Gear2 => {
-                capacitor.capacitance_farads
+                capacitance
                     * (3.0 * voltage - 4.0 * previous_voltage + state.previous_previous_voltage)
                     / (2.0 * state.time_step)
             }
-            TransientMethod::Euler => {
-                capacitor.capacitance_farads * (voltage - previous_voltage) / state.time_step
-            }
+            TransientMethod::Euler => capacitance * (voltage - previous_voltage) / state.time_step,
         };
         state.previous_voltage = voltage;
         state.previous_previous_voltage = previous_voltage;
+    }
+}
+
+fn seed_diode_capacitor_states(
+    circuit: &Circuit,
+    node_voltages: &BTreeMap<String, f64>,
+    capacitor_states: &mut [CapacitorState],
+) {
+    for element in circuit.elements() {
+        let Element::Diode(diode) = element else {
+            continue;
+        };
+        let state_name = diode_charge_state_name(diode);
+        if let Some(state) = capacitor_states
+            .iter_mut()
+            .find(|state| state.name == state_name)
+        {
+            let voltage = diode_charge_voltage(diode, node_voltages);
+            state.previous_voltage = voltage;
+            state.previous_previous_voltage = voltage;
+            state.previous_current = 0.0;
+        }
     }
 }
 

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -39,7 +39,7 @@ use spice_engine::{
     transient_with_method, AdaptiveTransientOptions, AdaptiveTransientResult, Capacitor, Cccs,
     Ccvs, Circuit, CornerDistortionPoint, CornerDistortionResult, CornerOverride, CornerSpec,
     CurrentSource, DeckAnalysisExecution, DeckAnalysisExecutionResult, DigitalBridgeSchedule,
-    DigitalEvent, DigitalEventStream, DigitalLogicLevels, DigitalState, DigitalThresholds,
+    DigitalEvent, DigitalEventStream, DigitalLogicLevels, DigitalState, DigitalThresholds, Diode,
     DistortionHarmonic, DistortionPoint, DistortionResult, Element, ExpWaveform, FourierHarmonic,
     FourierProbeResult, FourierResult, Inductor, Jfet, JfetPolarity, MutualInductor, PoleZeroEntry,
     PoleZeroEntryKind, PoleZeroResult, PoleZeroTopology, PssNewtonCandidateResult,
@@ -178,6 +178,96 @@ fn device_model_charge_audit_fixtures_run_reference_transients() {
         .find(|fixture| fixture.kind.as_str() == "NJF")
         .expect("expected JFET charge fixture");
     assert!(jfet_fixture.charge_behavior.contains("external-only"));
+}
+
+#[test]
+fn transient_diode_junction_capacitance_slows_current_step() {
+    fn run(junction_capacitance: f64) -> Vec<TransientPoint> {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::CurrentSource(CurrentSource::with_waveform(
+            "Istep",
+            "0",
+            "out",
+            0.0,
+            Waveform::Pwl(PwlWaveform::new(vec![
+                (0.0, 0.0),
+                (1.0e-9, 1.0e-6),
+                (5.0e-9, 1.0e-6),
+            ])),
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rshunt", "out", "0", 1.0e12,
+        )));
+        circuit.add(Element::Diode(Diode::with_model_and_breakdown(
+            "D1",
+            "out",
+            "0",
+            1.0e-15,
+            0.02585,
+            1.0,
+            None,
+            1.0e-3,
+            junction_capacitance,
+            0.0,
+        )));
+        transient(&circuit, 1.0e-9, 5.0e-9).unwrap()
+    }
+
+    let uncharged = run(0.0);
+    let charged = run(1.0e-12);
+    let uncharged_first = uncharged[0].voltage("out").unwrap();
+    let charged_first = charged[0].voltage("out").unwrap();
+
+    assert!(uncharged_first > 0.5);
+    assert!(charged_first < 0.01);
+    assert!(charged_first < uncharged_first);
+}
+
+#[test]
+fn transient_diode_transit_time_holds_forward_charge_on_turnoff() {
+    fn run(transit_time: f64) -> Vec<TransientPoint> {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::CurrentSource(CurrentSource::with_waveform(
+            "Istep",
+            "0",
+            "out",
+            0.0,
+            Waveform::Pwl(PwlWaveform::new(vec![
+                (0.0, 1.0e-3),
+                (1.0e-9, 0.0),
+                (5.0e-9, 0.0),
+            ])),
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rshunt", "out", "0", 1.0e12,
+        )));
+        circuit.add(Element::Diode(Diode::with_model_and_breakdown(
+            "D1",
+            "out",
+            "0",
+            1.0e-15,
+            0.02585,
+            1.0,
+            None,
+            1.0e-3,
+            0.0,
+            transit_time,
+        )));
+        transient(&circuit, 1.0e-9, 5.0e-9).unwrap()
+    }
+
+    let no_storage = run(0.0);
+    let stored = run(1.0e-9);
+    let no_storage_first = no_storage[0].voltage("out").unwrap();
+    let stored_first = stored[0].voltage("out").unwrap();
+    let stored_last = stored
+        .last()
+        .and_then(|point| point.voltage("out"))
+        .unwrap();
+
+    assert_close(no_storage_first, 0.0);
+    assert!(stored_first > 0.6);
+    assert!(stored_last < stored_first);
 }
 
 #[test]

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Stamp diode `junctionCapacitance` and `transitTime` model-card storage as
+  transient anode-cathode companions, matching Python and Rust, with regression
+  coverage for current-step delay and turnoff charge retention.
 - Add `deviceModelChargeAuditFixtures` runnable one-device `.tran` fixtures
   with reference deck lines, explicit terminal storage capacitance metadata,
   stable first/final probe-voltage windows, and charge-behavior notes for

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -202,7 +202,9 @@ and Level-1 MOS channel thermal noise audits.
 `deviceModelChargeAuditFixtures` adds matching `.tran` reference-deck metadata,
 explicit terminal storage capacitance metadata, stable first/final
 probe-voltage windows, and charge-behavior notes for diode, BJT, JFET, and
-Level-1 MOS charge audits.
+Level-1 MOS charge audits. Diode `junctionCapacitance` and `transitTime`
+model-card parameters also stamp transient anode-cathode storage, matching
+their small-signal AC capacitance semantics.
 
 `CustomModel`, `CustomModelEvaluation`, `customLinearConductanceModel`, and
 `analyzeCustomModelSource` provide the first native-web custom-model foothold.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -7636,7 +7636,7 @@ export function deviceModelChargeAuditFixtures(): readonly DeviceModelChargeBeha
       expectedFinalMin: 0.58,
       expectedFinalMax: 0.61,
       chargeBehavior:
-        "diode terminal charge is conserved through explicit Cstore; CJO/TT remain AC-only until nonlinear charge stamping lands",
+        "diode CJO/TT contribute transient anode-cathode storage; explicit Cstore keeps the fixture comparable with other charge audits",
       deckLines: [
         "* device-model charge fixture: diode-storage-charge",
         ".model Dfast D(IS=2e-14 CJO=1.5e-12 TT=4e-9)",
@@ -12816,6 +12816,7 @@ export function transient(
     inductorStates,
     0.0,
   );
+  seedDiodeCapacitorStates(circuit, initialSolution.nodeVoltages, capacitorStates);
   updateTransmissionLineStates(circuit, initialSolution.nodeVoltages, lineStates, 0.0);
   const points: TransientPoint[] = [];
   for (let time = timeStep; time <= stopTime + timeStep * 1.0e-9; time += timeStep) {
@@ -13119,6 +13120,7 @@ export function transientAdaptive(
     inductorStates,
     0.0,
   );
+  seedDiodeCapacitorStates(circuit, initialSolution.nodeVoltages, capacitorStates);
   updateTransmissionLineStates(circuit, initialSolution.nodeVoltages, lineStates, 0.0);
 
   const points: TransientPoint[] = [];
@@ -15490,7 +15492,7 @@ function solveLinearCircuitAtOperatingPoint(
         stampCustomModel(element, nodeIndices, matrix, rhs, operatingPoint);
         break;
       case "diode":
-        stampDiode(element, nodeIndices, matrix, rhs, operatingPoint);
+        stampDiode(element, capacitorStates, nodeIndices, matrix, rhs, operatingPoint);
         break;
       case "jfet":
         stampJfet(element, nodeIndices, matrix, rhs, operatingPoint);
@@ -16697,6 +16699,7 @@ function customModelConductance(
 
 function stampDiode(
   element: Diode,
+  capacitorStates: readonly CapacitorState[],
   nodeIndices: ReadonlyMap<string, number>,
   matrix: number[][],
   rhs: number[],
@@ -16717,6 +16720,49 @@ function stampDiode(
   }
   if (cathode !== undefined) {
     rhs[cathode] += equivalentCurrent;
+  }
+  stampDiodeCharge(element, capacitorStates, nodeIndices, matrix, rhs);
+}
+
+function stampDiodeCharge(
+  element: Diode,
+  capacitorStates: readonly CapacitorState[],
+  nodeIndices: ReadonlyMap<string, number>,
+  matrix: number[][],
+  rhs: number[],
+): void {
+  const state = capacitorStates.find(
+    (candidate) => candidate.name === diodeChargeStateName(element),
+  );
+  if (state === undefined) {
+    return;
+  }
+  const capacitance = diodeDynamicCapacitance(element, state.previousVoltage);
+  if (capacitance <= 0.0) {
+    return;
+  }
+  const conductance =
+    state.method === "trap"
+      ? (2.0 * capacitance) / state.timeStep
+      : state.method === "gear2"
+        ? (3.0 * capacitance) / (2.0 * state.timeStep)
+        : capacitance / state.timeStep;
+  const historyCurrent =
+    state.method === "trap"
+      ? conductance * state.previousVoltage + state.previousCurrent
+      : state.method === "gear2"
+        ? capacitance *
+          (4.0 * state.previousVoltage - state.previousPreviousVoltage) /
+          (2.0 * state.timeStep)
+        : conductance * state.previousVoltage;
+  const anode = nodeIndex(nodeIndices, element.anode);
+  const cathode = nodeIndex(nodeIndices, element.cathode);
+  stampConductance(matrix, anode, cathode, conductance);
+  if (anode !== undefined) {
+    rhs[anode] += historyCurrent;
+  }
+  if (cathode !== undefined) {
+    rhs[cathode] -= historyCurrent;
   }
 }
 
@@ -17064,6 +17110,23 @@ function diodeCurrentConductance(element: Diode, voltage: number): [number, numb
   return [current, conductance];
 }
 
+function diodeChargeStateName(element: Diode): string {
+  return `_D_${element.name}_charge`;
+}
+
+function diodeHasChargeStorage(element: Diode): boolean {
+  return element.junctionCapacitance > 0.0 || element.transitTime > 0.0;
+}
+
+function diodeDynamicCapacitance(element: Diode, voltage: number): number {
+  const [, conductance] = diodeCurrentConductance(element, voltage);
+  return element.junctionCapacitance + element.transitTime * conductance;
+}
+
+function diodeChargeVoltage(element: Diode, nodeVoltages: ReadonlyMap<string, number>): number {
+  return voltageAt(nodeVoltages, element.anode) - voltageAt(nodeVoltages, element.cathode);
+}
+
 function validateBjt(element: Bjt): void {
   if (element.polarity !== "NPN" && element.polarity !== "PNP") {
     throw invalidElement(element.name, "BJT polarity must be NPN or PNP");
@@ -17158,6 +17221,15 @@ function initialCapacitorStates(
         timeStep,
         method,
       });
+    } else if (element.kind === "diode" && diodeHasChargeStorage(element)) {
+      states.push({
+        name: diodeChargeStateName(element),
+        previousVoltage: 0.0,
+        previousPreviousVoltage: 0.0,
+        previousCurrent: 0.0,
+        timeStep,
+        method,
+      });
     }
   }
   return states;
@@ -17221,6 +17293,8 @@ function capacitorVoltages(
         element.name,
         voltageAt(nodeVoltages, element.n1) - voltageAt(nodeVoltages, element.n2),
       );
+    } else if (element.kind === "diode" && diodeHasChargeStorage(element)) {
+      voltages.set(diodeChargeStateName(element), diodeChargeVoltage(element, nodeVoltages));
     }
   }
   return voltages;
@@ -17235,6 +17309,13 @@ function transientLteEstimate(
   let maxLte = 0.0;
   for (const element of circuit.elements()) {
     if (element.kind !== "capacitor") {
+      if (element.kind === "diode" && diodeHasChargeStorage(element)) {
+        const stateName = diodeChargeStateName(element);
+        const current = currentVoltages.get(stateName) ?? 0.0;
+        const previous = previousVoltages.get(stateName) ?? 0.0;
+        const previousPrevious = previousPreviousVoltages.get(stateName) ?? 0.0;
+        maxLte = Math.max(maxLte, Math.abs(current - 2.0 * previous + previousPrevious) / 2.0);
+      }
       continue;
     }
     const current = currentVoltages.get(element.name) ?? element.initialVoltage;
@@ -17383,33 +17464,70 @@ function updateCapacitorStates(
   capacitorStates: CapacitorState[],
 ): void {
   for (const state of capacitorStates) {
-    const element = circuit
+    const capacitorElement = circuit
       .elements()
       .find(
         (candidate): candidate is Capacitor =>
           candidate.kind === "capacitor" && candidate.name === state.name,
       );
-    if (element === undefined) {
+    const diodeElement =
+      capacitorElement === undefined
+        ? circuit
+            .elements()
+            .find(
+              (candidate): candidate is Diode =>
+                candidate.kind === "diode" && diodeChargeStateName(candidate) === state.name,
+            )
+        : undefined;
+    if (capacitorElement === undefined && diodeElement === undefined) {
       continue;
     }
     const previousVoltage = state.previousVoltage;
     const previousCurrent = state.previousCurrent;
     const voltage =
-      voltageAt(nodeVoltages, element.n1) - voltageAt(nodeVoltages, element.n2);
+      capacitorElement !== undefined
+        ? voltageAt(nodeVoltages, capacitorElement.n1) - voltageAt(nodeVoltages, capacitorElement.n2)
+        : diodeChargeVoltage(diodeElement!, nodeVoltages);
+    const capacitance =
+      capacitorElement !== undefined
+        ? capacitorElement.capacitanceFarads
+        : diodeDynamicCapacitance(diodeElement!, previousVoltage);
     if (state.method === "trap") {
-      const conductance = (2.0 * element.capacitanceFarads) / state.timeStep;
+      const conductance = (2.0 * capacitance) / state.timeStep;
       state.previousCurrent = conductance * (voltage - previousVoltage) - previousCurrent;
     } else if (state.method === "gear2") {
       state.previousCurrent =
-        element.capacitanceFarads *
+        capacitance *
         (3.0 * voltage - 4.0 * previousVoltage + state.previousPreviousVoltage) /
         (2.0 * state.timeStep);
     } else {
       state.previousCurrent =
-        (element.capacitanceFarads / state.timeStep) * (voltage - previousVoltage);
+        (capacitance / state.timeStep) * (voltage - previousVoltage);
     }
     state.previousVoltage = voltage;
     state.previousPreviousVoltage = previousVoltage;
+  }
+}
+
+function seedDiodeCapacitorStates(
+  circuit: Circuit,
+  nodeVoltages: ReadonlyMap<string, number>,
+  capacitorStates: CapacitorState[],
+): void {
+  for (const element of circuit.elements()) {
+    if (element.kind !== "diode") {
+      continue;
+    }
+    const state = capacitorStates.find(
+      (candidate) => candidate.name === diodeChargeStateName(element),
+    );
+    if (state === undefined) {
+      continue;
+    }
+    const voltage = diodeChargeVoltage(element, nodeVoltages);
+    state.previousVoltage = voltage;
+    state.previousPreviousVoltage = voltage;
+    state.previousCurrent = 0.0;
   }
 }
 

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -22,6 +22,7 @@ import {
   currentSourceWithWaveform,
   dcOp,
   deviceModelChargeAuditFixtures,
+  diode,
   digitalEventStreamsToBridgeSchedule,
   digitalEventStreamsToVoltageSources,
   digitalEventsToPwlWaveform,
@@ -210,6 +211,60 @@ describe("transient", () => {
 
     const jfetFixture = fixtures.find((fixture) => fixture.kind === "NJF");
     expect(jfetFixture?.chargeBehavior).toContain("external-only");
+  });
+
+  it("uses diode junction capacitance during transient current steps", () => {
+    function run(junctionCapacitance: number): TransientPoint[] {
+      const circuit = new Circuit();
+      circuit.add(currentSourceWithWaveform(
+        "Istep",
+        "0",
+        "out",
+        0.0,
+        new PwlWaveform([
+          [0.0, 0.0],
+          [1.0e-9, 1.0e-6],
+          [5.0e-9, 1.0e-6],
+        ]),
+      ));
+      circuit.add(resistor("Rshunt", "out", "0", 1.0e12));
+      circuit.add(diode("D1", "out", "0", 1.0e-15, 0.02585, 1.0, undefined, 1.0e-3, junctionCapacitance));
+      return transient(circuit, 1.0e-9, 5.0e-9);
+    }
+
+    const unchargedFirst = run(0.0)[0].voltage("out");
+    const chargedFirst = run(1.0e-12)[0].voltage("out");
+    expect(unchargedFirst).not.toBeUndefined();
+    expect(chargedFirst).not.toBeUndefined();
+    expect(unchargedFirst!).toBeGreaterThan(0.5);
+    expect(chargedFirst!).toBeLessThan(0.01);
+    expect(chargedFirst!).toBeLessThan(unchargedFirst!);
+  });
+
+  it("uses diode transit time to hold forward charge on turnoff", () => {
+    function run(transitTime: number): TransientPoint[] {
+      const circuit = new Circuit();
+      circuit.add(currentSourceWithWaveform(
+        "Istep",
+        "0",
+        "out",
+        0.0,
+        new PwlWaveform([
+          [0.0, 1.0e-3],
+          [1.0e-9, 0.0],
+          [5.0e-9, 0.0],
+        ]),
+      ));
+      circuit.add(resistor("Rshunt", "out", "0", 1.0e12));
+      circuit.add(diode("D1", "out", "0", 1.0e-15, 0.02585, 1.0, undefined, 1.0e-3, 0.0, transitTime));
+      return transient(circuit, 1.0e-9, 5.0e-9);
+    }
+
+    const noStorage = run(0.0);
+    const stored = run(1.0e-9);
+    expectClose(noStorage[0].voltage("out"), 0.0);
+    expect(stored[0].voltage("out")!).toBeGreaterThan(0.6);
+    expect(stored[stored.length - 1].voltage("out")!).toBeLessThan(stored[0].voltage("out")!);
   });
 
   it("reports periods for periodic source waveforms", () => {

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -15,21 +15,20 @@ downstream tools to compare.
 
 ## Current PR Slice
 
-1. Device model charge audit fixtures.
+1. Diode model-card transient charge stamping.
    - Status: current PR completion candidate.
-   - Python, Rust, and TypeScript now expose matching runnable
-     `device_model_charge_audit_fixtures` /
-     `deviceModelChargeAuditFixtures` one-device `.tran` fixtures for diode,
-     BJT, JFET, and Level-1 MOS model cards.
-   - Each fixture carries the normalized model card, an executable circuit,
-     `.tran` reference deck lines, selected probe node, timestep, stoptime,
-     explicit terminal storage capacitance, stable first/final probe-voltage
-     windows, and a short charge-behavior note.
-   - The fixtures deliberately audit charge storage through explicit terminal
-     capacitors, recording that model-card capacitances remain AC small-signal
-     inputs until nonlinear transient charge stamping lands.
-   - Cross-language tests execute every fixture through transient solving and
-     verify the probe windows plus reference-deck metadata.
+   - Python, Rust, and TypeScript transient solvers now stamp diode
+     model-card `CJO` / `junction_capacitance` / `junctionCapacitance` and
+     `TT` / `transit_time` / `transitTime` as an anode-cathode storage
+     companion.
+   - The transient companion uses the previous diode bias to derive
+     `C = Cjo + Tt * gd`, reuses the existing Euler/trapezoidal/Gear-2
+     capacitor history policy, and seeds the synthetic diode charge state from
+     the initial operating point.
+   - Cross-language tests cover both junction-capacitance current-step delay
+     and transit-time forward-charge retention after turnoff.
+   - BJT, JFET, and Level-1 MOS charge storage remain audited through explicit
+     terminal storage capacitors until their nonlinear charge policies land.
 
 ## Completed Slices
 
@@ -1211,6 +1210,22 @@ downstream tools to compare.
      point, matching Python and Rust.
    - Cross-language tests execute every fixture through `.noise` solving and
      verify the PSD windows plus reference-deck metadata.
+
+120. Device model charge audit fixtures.
+   - Status: completed in PR 6794.
+   - Python, Rust, and TypeScript now expose matching runnable
+     `device_model_charge_audit_fixtures` /
+     `deviceModelChargeAuditFixtures` one-device `.tran` fixtures for diode,
+     BJT, JFET, and Level-1 MOS model cards.
+   - Each fixture carries the normalized model card, an executable circuit,
+     `.tran` reference deck lines, selected probe node, timestep, stoptime,
+     explicit terminal storage capacitance, stable first/final probe-voltage
+     windows, and a short charge-behavior note.
+   - The fixtures deliberately audit charge storage through explicit terminal
+     capacitors, recording that BJT, JFET, and MOS model-card charge remains
+     explicit-storage-only until nonlinear transient charge policies land.
+   - Cross-language tests execute every fixture through transient solving and
+     verify the probe windows plus reference-deck metadata.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- stamp diode CJO/junctionCapacitance and TT/transitTime as transient anode-cathode storage companions across Python, Rust, and TypeScript
- seed diode charge state from the initial operating point and include it in adaptive LTE/reactive-state updates
- add cross-language regression tests for junction-capacitance current-step delay and transit-time turnoff charge retention; update charge-audit metadata/docs/plan

## Verification
- PYTHONPATH=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-spice-diode-transient-charge-stamping/code/packages/python/spice-engine/src:/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-spice-diode-transient-charge-stamping/code/packages/python/mosfet-models/src:/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-spice-diode-transient-charge-stamping/code/packages/python/device-physics/src /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python -m pytest code/packages/python/spice-engine/tests/test_engine.py
- /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python -m ruff check code/packages/python/spice-engine/src/spice_engine/engine.py code/packages/python/spice-engine/src/spice_engine/model_cards.py code/packages/python/spice-engine/tests/test_engine.py
- cargo test --manifest-path code/packages/rust/spice-engine/Cargo.toml
- cargo fmt --manifest-path code/packages/rust/spice-engine/Cargo.toml --check
- npm ci
- npm test
- npm run build
- git diff --check