### PR TITLE
[codex] Support rule-derived LR evidence

### DIFF
--- a/code/packages/rust/adj-lang-cli/CHANGELOG.md
+++ b/code/packages/rust/adj-lang-cli/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.10.0] - 2026-06-28 — render derived evidence proofs
+
+### Added
+
+- LR contribution proof JSON now includes an `"evidence_proof"` array when the
+  contribution fired from a rule-derived evidence atom. The nested proof lists the
+  SLD fact/rule steps and their provenance, so a `.adj` program that emits
+  observations plus `rule { ... }` can show how the derived premise licensed the
+  probabilistic verdict.
+
 ## [0.9.0] - 2026-06-21 — render corroborating citations (ADJ-A9)
 
 ### Added

--- a/code/packages/rust/adj-lang-cli/src/main.rs
+++ b/code/packages/rust/adj-lang-cli/src/main.rs
@@ -38,7 +38,7 @@ use logic_core::{atom, LogicVar, Term};
 use logic_engine::govern::Standing;
 use logic_engine::{
     enumerate_all, enumerate_governing, DerivationOrigin, DifferentialDecision, Fact, GovernStatus,
-    KnowledgeBase, LRAggregateResult, Provenance, TrustTier,
+    KnowledgeBase, LRAggregateResult, Proof, Provenance, TrustTier,
 };
 
 const SPEC: &str = r#"{
@@ -117,6 +117,41 @@ fn prov(p: &Provenance) -> String {
     )
 }
 
+fn sld_proof_json(proof: &Proof, kb: &KnowledgeBase) -> String {
+    let mut steps = Vec::new();
+    for st in &proof.steps {
+        match &st.origin {
+            DerivationOrigin::FromFact(id) => {
+                let pv = kb.fact(*id).map(|f| prov(&f.provenance)).unwrap_or_else(|| {
+                    "\"source\":\"\",\"locator\":null,\"trust\":\"unattributed\",\"corroborations\":[]"
+                        .to_string()
+                });
+                steps.push(format!(
+                    "{{\"kind\":\"fact\",\"goal\":\"{}\",{}}}",
+                    esc(&format!("{}", st.goal)),
+                    pv
+                ));
+            }
+            DerivationOrigin::FromRule(id) => {
+                let pv = kb
+                    .find_rule_by_id(*id)
+                    .map(|r| prov(&r.provenance))
+                    .unwrap_or_else(|| {
+                        "\"source\":\"\",\"locator\":null,\"trust\":\"unattributed\",\"corroborations\":[]"
+                            .to_string()
+                    });
+                steps.push(format!(
+                    "{{\"kind\":\"rule\",\"goal\":\"{}\",{}}}",
+                    esc(&format!("{}", st.goal)),
+                    pv
+                ));
+            }
+            _ => {}
+        }
+    }
+    format!("[{}]", steps.join(","))
+}
+
 /// Serialize the proof DAG for one hypothesis: walk each step and join its
 /// `clause_id` back to the firing clause's evidence term + cited provenance.
 /// `certs` maps a constraint STATUS atom to its solver certificate JSON (E3); a
@@ -150,6 +185,7 @@ fn proof_json(
                 DerivationOrigin::FromContribution {
                     clause_id,
                     logit_delta,
+                    evidence_proof,
                     ..
                 } => {
                     if let Some(c) = contribs.iter().find(|c| c.id == *clause_id) {
@@ -161,11 +197,18 @@ fn proof_json(
                             .find(|(k, _)| *k == ev.as_str())
                             .map(|(_, cert)| format!(",\"solver\":{}", cert))
                             .unwrap_or_default();
+                        let evidence_proof = evidence_proof
+                            .as_ref()
+                            .map(|proof| {
+                                format!(",\"evidence_proof\":{}", sld_proof_json(proof, kb))
+                            })
+                            .unwrap_or_default();
                         steps.push(format!(
-                            "{{\"kind\":\"contribution\",\"evidence\":\"{}\",\"logit\":{},{}{}}}",
+                            "{{\"kind\":\"contribution\",\"evidence\":\"{}\",\"logit\":{},{}{}{}}}",
                             esc(&ev),
                             jnum(*logit_delta),
                             prov(&c.provenance),
+                            evidence_proof,
                             solver
                         ));
                     }
@@ -173,6 +216,7 @@ fn proof_json(
                 DerivationOrigin::FromJointContribution {
                     clause_id,
                     joint_logit_delta,
+                    evidence_proofs,
                     ..
                 } => {
                     if let Some(j) = joints.iter().find(|j| j.id == *clause_id) {
@@ -181,11 +225,24 @@ fn proof_json(
                             .iter()
                             .map(|t| format!("\"{}\"", esc(&format!("{}", t))))
                             .collect();
+                        let evidence_proofs = if evidence_proofs.is_empty() {
+                            String::new()
+                        } else {
+                            format!(
+                                ",\"evidence_proofs\":[{}]",
+                                evidence_proofs
+                                    .iter()
+                                    .map(|proof| sld_proof_json(proof, kb))
+                                    .collect::<Vec<_>>()
+                                    .join(",")
+                            )
+                        };
                         steps.push(format!(
-                            "{{\"kind\":\"interaction\",\"evidence\":[{}],\"logit\":{},{}}}",
+                            "{{\"kind\":\"interaction\",\"evidence\":[{}],\"logit\":{},{}{}}}",
                             ev.join(","),
                             jnum(*joint_logit_delta),
-                            prov(&j.provenance)
+                            prov(&j.provenance),
+                            evidence_proofs
                         ));
                     }
                 }
@@ -244,7 +301,7 @@ fn status_certificates(
     optimize: &Option<OptimizeOutcome>,
 ) -> Vec<(&'static str, String)> {
     let mut out: Vec<(&'static str, String)> = Vec::new();
-    let mut add = |out: &mut Vec<(&'static str, String)>, s: &'static str, cert: String| {
+    let add = |out: &mut Vec<(&'static str, String)>, s: &'static str, cert: String| {
         if !out.iter().any(|(k, _)| *k == s) {
             out.push((s, cert));
         }

--- a/code/packages/rust/adj-lang-cli/tests/cli_golden.rs
+++ b/code/packages/rust/adj-lang-cli/tests/cli_golden.rs
@@ -152,6 +152,31 @@ fn predicate_rhs_expression_matches_fraction_result() {
 }
 
 #[test]
+fn rule_derived_evidence_drives_contribution() {
+    // The model can emit observations + a Horn rule; the engine proves the
+    // derived evidence term and uses that proof to license the LR contribution.
+    let (ok, s) = run(
+        "adjcli_derived_evidence.adj",
+        "prior 0.10 for bacterial\n  source \"base rate\" trust empirical\n\
+         contributes 10 from infection_present to bacterial\n  source \"clinical LR\" trust authoritative\n\
+         observe fever\n\
+         observe positive_culture\n\
+         rule { head: infection_present when: fever, positive_culture\n\
+                source \"case decomposition\" trust inferred }\n\
+         ? bacterial\n",
+    );
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(s.contains("\"kind\":\"contribution\""), "{s}");
+    assert!(s.contains("\"evidence\":\"infection_present\""), "{s}");
+    assert!(s.contains("\"evidence_proof\""), "{s}");
+    assert!(s.contains("\"kind\":\"rule\""), "{s}");
+    assert!(s.contains("\"goal\":\"infection_present\""), "{s}");
+    assert!(s.contains("\"source\":\"case decomposition\""), "{s}");
+    // prior odds 1/9, LR 10 => posterior 10/19 ≈ 0.526.
+    assert!(s.contains("\"posterior\":0.526"), "{s}");
+}
+
+#[test]
 fn predicate_below_threshold_does_not_fire() {
     // Income under the threshold: the predicate step never appears, and the
     // posterior stays at the prior.

--- a/code/packages/rust/logic-engine/CHANGELOG.md
+++ b/code/packages/rust/logic-engine/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.25.0] - 2026-06-28 — rule-derived evidence gates LR contributions
+
+### Added
+
+- `KnowledgeBase::observed_evidence` now falls back to SLD proof enumeration when
+  an LR evidence term is not directly asserted as a `Certain` fact. A derived atom
+  such as `infection_present` can now fire `contributes ... from infection_present`
+  if rules prove it from observed case facts.
+- `ObservedEvidence` records the direct fact ids, derived rule ids, optional SLD
+  proof, and confidence factor for the evidence gate.
+- LR aggregation attenuates a contribution's applied logit delta by the selected
+  proof's confidence, computed as the product of fact/rule probabilities along the
+  proof. Certain proof chains remain fully backward-compatible with confidence 1.0.
+- `DerivationOrigin::FromContribution` and `FromJointContribution` can carry nested
+  evidence proofs, so aggregate proofs expose the rule/fact chain that licensed a
+  probabilistic step.
+
 ## [0.24.0] - 2026-06-27 — exact rational predicate comparisons
 
 ### Added

--- a/code/packages/rust/logic-engine/src/lib.rs
+++ b/code/packages/rust/logic-engine/src/lib.rs
@@ -361,6 +361,22 @@ impl ClauseIndex {
     }
 }
 
+/// Evidence that can gate an LR contribution.
+///
+/// A direct `observe e` remains the common fast path: `fact_ids` names the
+/// observed fact(s), `proof` is absent, and `confidence` is exactly 1.0. When
+/// `e` is only derivable through rules, `proof` carries the SLD derivation and
+/// `confidence` is the product of the probabilities on the facts/rules used by
+/// that proof. LR aggregation uses that confidence to attenuate the
+/// contribution instead of forcing a brittle all-or-nothing bridge.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ObservedEvidence {
+    pub fact_ids: Vec<FactId>,
+    pub rule_ids: Vec<RuleId>,
+    pub proof: Option<Box<Proof>>,
+    pub confidence: f64,
+}
+
 /// A collection of Facts and Rules, indexed for clause selection by
 /// the head's functor/arity. Per LP19e, also stores prior /
 /// contribution / joint-contribution clauses in parallel maps; the
@@ -969,28 +985,72 @@ impl KnowledgeBase {
             .collect()
     }
 
-    /// LP19e "observation gate." If `evidence_term` is asserted in
-    /// the KB as a `Certain` Fact (one or more), return the
-    /// `FactId`s; otherwise `None`.
-    ///
-    /// **Current scope** (LP19e v0.1): only `Certain` Facts gate
-    /// contributions. Probabilistic Facts and Rule-derived evidence
-    /// are deliberately not yet routed here — the spec defers their
-    /// careful treatment to v0.2 because each interacts non-trivially
-    /// with the "probability of observation vs probability of truth"
-    /// distinction in ADJ14.
-    pub fn observed_evidence(&self, evidence_term: &Term) -> Option<Vec<FactId>> {
+    /// LP19e "observation gate." If `evidence_term` is asserted in the KB as a
+    /// `Certain` Fact, return that direct observation. Otherwise fall back to
+    /// SLD proof enumeration: if the evidence is derivable by rules (or by
+    /// probabilistic facts), return the strongest proof and its probability
+    /// product as an attenuation factor for the LR step.
+    pub fn observed_evidence(&self, evidence_term: &Term) -> Option<ObservedEvidence> {
         let matched: Vec<FactId> = self
             .facts_for(evidence_term)
             .iter()
             .filter(|f| f.probability == Probability::Certain && &f.term == evidence_term)
             .map(|f| f.id)
             .collect();
-        if matched.is_empty() {
-            None
-        } else {
-            Some(matched)
+        if !matched.is_empty() {
+            return Some(ObservedEvidence {
+                fact_ids: matched,
+                rule_ids: Vec::new(),
+                proof: None,
+                confidence: 1.0,
+            });
         }
+
+        let dag = enumerate_all(evidence_term, self);
+        dag.proofs
+            .into_iter()
+            .map(|proof| {
+                let confidence = proof_confidence(&proof, self);
+                (proof, confidence)
+            })
+            .filter(|(_, confidence)| *confidence > 0.0)
+            .max_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal))
+            .map(|(proof, confidence)| ObservedEvidence {
+                fact_ids: proof.via_facts.clone(),
+                rule_ids: proof.via_rules.clone(),
+                proof: Some(Box::new(proof)),
+                confidence,
+            })
+    }
+}
+
+fn proof_confidence(proof: &Proof, kb: &KnowledgeBase) -> f64 {
+    let fact_confidence = proof
+        .via_facts
+        .iter()
+        .map(|id| {
+            kb.find_fact_by_id(*id)
+                .map(|fact| probability_confidence(fact.probability))
+                .unwrap_or(0.0)
+        })
+        .product::<f64>();
+    let rule_confidence = proof
+        .via_rules
+        .iter()
+        .map(|id| {
+            kb.find_rule_by_id(*id)
+                .map(|rule| probability_confidence(rule.probability))
+                .unwrap_or(0.0)
+        })
+        .product::<f64>();
+    fact_confidence * rule_confidence
+}
+
+fn probability_confidence(probability: Probability) -> f64 {
+    match probability {
+        Probability::Certain => 1.0,
+        Probability::Value(p) if p.is_finite() => p.clamp(0.0, 1.0),
+        Probability::Value(_) => 0.0,
     }
 }
 

--- a/code/packages/rust/logic-engine/src/lr_aggregate.rs
+++ b/code/packages/rust/logic-engine/src/lr_aggregate.rs
@@ -11,8 +11,10 @@
 //! Each conclusion carries one Bayesian prior `prior(p, c)`. Every
 //! independent piece of evidence carries a likelihood ratio
 //! `contributes(LR, evidence_term, c)`. When the KB *observes* an
-//! evidence term (via a Certain Fact, see [`KnowledgeBase::observed_evidence`]),
-//! the contribution's `log(LR)` is added to the running log-odds.
+//! evidence term (via a Certain Fact or an SLD proof, see
+//! [`KnowledgeBase::observed_evidence`]), the contribution's `log(LR)`
+//! is added to the running log-odds. Rule-derived evidence attenuates
+//! that delta by the confidence of the proof that established it.
 //! Joint evidence interactions — synergy or explaining-away — are
 //! handled by `contributes_jointly(LR, [e1, …, en], c)`, which adds
 //! `log(joint LR)` to the log-odds iff *every* term in `evidence_set`
@@ -121,7 +123,9 @@ impl PriorClause {
 /// A single-source likelihood-ratio contribution.
 ///
 /// "When `evidence_term` is observed, multiply the conclusion's odds
-/// by `exp(logit_delta)`." Multiple contributions per
+/// by `exp(logit_delta)`." When the evidence is derived rather than directly
+/// observed, the applied delta is attenuated by the proof confidence. Multiple
+/// contributions per
 /// `(conclusion, evidence_term)` pair sum in log-odds — that is the
 /// LP19e semantics for combining LR sources (e.g., one LR per
 /// reviewing physician for the same finding, or one LR per cited
@@ -766,9 +770,10 @@ pub enum LrAggregateWarning {
 /// 1. Look up the prior on `query`. If absent, proceed with
 ///    `prior_logit = 0` and emit [`LrAggregateWarning::NoPriorDeclared`].
 /// 2. For every single-source contribution naming `query` as its
-///    conclusion, check whether the evidence term is observed
-///    (`kb.observed_evidence`). If so, add `logit_delta` to the
-///    running log-odds and record a `FromContribution` step.
+///    conclusion, check whether the evidence term is observed or provable
+///    (`kb.observed_evidence`). If so, add the possibly attenuated
+///    `logit_delta` to the running log-odds and record a
+///    `FromContribution` step.
 /// 3. For every joint contribution naming `query`, check whether
 ///    *every* term in `evidence_set` is observed. If so, add
 ///    `joint_logit_delta` and record a `FromJointContribution` step.
@@ -784,6 +789,7 @@ pub fn lr_aggregate(query: &Term, kb: &KnowledgeBase) -> LRAggregateResult {
     let mut warnings: Vec<LrAggregateWarning> = Vec::new();
     let mut steps: Vec<ProofStep> = Vec::new();
     let mut via_facts: Vec<FactId> = Vec::new();
+    let mut via_rules = Vec::new();
 
     // Step 1: prior (or warned absence).
     let prior_logit = match kb.prior_for(query) {
@@ -810,9 +816,10 @@ pub fn lr_aggregate(query: &Term, kb: &KnowledgeBase) -> LRAggregateResult {
     let mut any_contribution_active = false;
     let contributions = kb.contributions_for(query);
     for contrib in &contributions {
-        if let Some(observed_facts) = kb.observed_evidence(&contrib.evidence_term) {
+        if let Some(observed) = kb.observed_evidence(&contrib.evidence_term) {
             any_contribution_active = true;
-            if contrib.logit_delta == 0.0 {
+            let logit_delta = contrib.logit_delta * observed.confidence;
+            if logit_delta == 0.0 {
                 warnings.push(LrAggregateWarning::DegenerateContribution {
                     clause_id: contrib.id,
                 });
@@ -821,12 +828,14 @@ pub fn lr_aggregate(query: &Term, kb: &KnowledgeBase) -> LRAggregateResult {
                 goal: query.clone(),
                 origin: DerivationOrigin::FromContribution {
                     clause_id: contrib.id,
-                    evidence_fact_ids: observed_facts.clone(),
-                    logit_delta: contrib.logit_delta,
+                    evidence_fact_ids: observed.fact_ids.clone(),
+                    evidence_proof: observed.proof.clone(),
+                    logit_delta,
                 },
             });
-            running_logit += contrib.logit_delta;
-            via_facts.extend(observed_facts);
+            running_logit += logit_delta;
+            via_facts.extend(observed.fact_ids);
+            via_rules.extend(observed.rule_ids);
         }
     }
 
@@ -835,9 +844,19 @@ pub fn lr_aggregate(query: &Term, kb: &KnowledgeBase) -> LRAggregateResult {
     for joint in &joints {
         let mut every_evidence_observed = true;
         let mut joint_evidence_facts: Vec<FactId> = Vec::new();
+        let mut joint_evidence_rules = Vec::new();
+        let mut joint_evidence_proofs = Vec::new();
+        let mut joint_confidence = 1.0;
         for ev_term in &joint.evidence_set {
             match kb.observed_evidence(ev_term) {
-                Some(ids) => joint_evidence_facts.extend(ids),
+                Some(observed) => {
+                    joint_confidence *= observed.confidence;
+                    joint_evidence_facts.extend(observed.fact_ids);
+                    joint_evidence_rules.extend(observed.rule_ids);
+                    if let Some(proof) = observed.proof {
+                        joint_evidence_proofs.push(*proof);
+                    }
+                }
                 None => {
                     every_evidence_observed = false;
                     break;
@@ -846,16 +865,19 @@ pub fn lr_aggregate(query: &Term, kb: &KnowledgeBase) -> LRAggregateResult {
         }
         if every_evidence_observed {
             any_contribution_active = true;
+            let joint_logit_delta = joint.joint_logit_delta * joint_confidence;
             steps.push(ProofStep {
                 goal: query.clone(),
                 origin: DerivationOrigin::FromJointContribution {
                     clause_id: joint.id,
                     evidence_fact_ids: joint_evidence_facts.clone(),
-                    joint_logit_delta: joint.joint_logit_delta,
+                    evidence_proofs: joint_evidence_proofs,
+                    joint_logit_delta,
                 },
             });
-            running_logit += joint.joint_logit_delta;
+            running_logit += joint_logit_delta;
             via_facts.extend(joint_evidence_facts);
+            via_rules.extend(joint_evidence_rules);
         }
     }
 
@@ -942,6 +964,8 @@ pub fn lr_aggregate(query: &Term, kb: &KnowledgeBase) -> LRAggregateResult {
     // Step 5: package the proof.
     via_facts.sort();
     via_facts.dedup();
+    via_rules.sort();
+    via_rules.dedup();
     let posterior = sigmoid(running_logit);
     LRAggregateResult {
         dag: ProofDAG {
@@ -950,7 +974,7 @@ pub fn lr_aggregate(query: &Term, kb: &KnowledgeBase) -> LRAggregateResult {
                 bindings: Substitution::empty(),
                 steps,
                 via_facts,
-                via_rules: Vec::new(),
+                via_rules,
                 posterior_logit: Some(running_logit),
                 posterior_probability: Some(posterior),
             }],

--- a/code/packages/rust/logic-engine/src/proof_dag.rs
+++ b/code/packages/rust/logic-engine/src/proof_dag.rs
@@ -55,11 +55,14 @@ pub enum DerivationOrigin {
     FromContribution {
         clause_id: ContributionClauseId,
         /// FactIds for every Fact that satisfied the evidence term.
-        /// Empty if the evidence was satisfied by a Rule head — the
-        /// engine does not currently expose Rule provenance for
-        /// LR-aggregation evidence; v0.2 will route Rule-derived
-        /// evidence through this field too.
+        /// Directly observed facts appear here, and rule-derived
+        /// evidence also repeats the proof's leaf facts so the
+        /// aggregate proof can expose a flat fact index.
         evidence_fact_ids: Vec<FactId>,
+        /// If the evidence term was not directly observed but was
+        /// proved by SLD resolution, this is the derivation that
+        /// licensed the contribution.
+        evidence_proof: Option<Box<Proof>>,
         /// log(LR) for this contribution. Inline for the same audit
         /// reason as `prior_logit`.
         logit_delta: f64,
@@ -72,6 +75,9 @@ pub enum DerivationOrigin {
         /// Union of FactIds satisfying every evidence term in the
         /// joint set.
         evidence_fact_ids: Vec<FactId>,
+        /// SLD derivations for any joint evidence terms that were
+        /// rule-derived rather than directly observed.
+        evidence_proofs: Vec<Proof>,
         /// log(joint LR). Inline.
         joint_logit_delta: f64,
     },
@@ -190,17 +196,32 @@ pub(crate) fn collect_ids(steps: &[ProofStep]) -> (Vec<FactId>, Vec<RuleId>) {
         match &s.origin {
             DerivationOrigin::FromFact(f) => facts.push(*f),
             DerivationOrigin::FromRule(r) => rules.push(*r),
-            // The LR-aggregation variants carry their evidence Fact
-            // ids inline so that the via_facts list of an
-            // LR-aggregated Proof can be reconstructed from the
-            // steps. (Rules don't contribute to LR proofs.)
+            // The LR-aggregation variants carry their direct evidence
+            // Fact ids inline. If evidence was rule-derived, the nested
+            // SLD proof carries the facts and rules that licensed it.
             DerivationOrigin::FromPrior { .. } => {}
             DerivationOrigin::FromContribution {
-                evidence_fact_ids, ..
-            } => facts.extend(evidence_fact_ids.iter().copied()),
+                evidence_fact_ids,
+                evidence_proof,
+                ..
+            } => {
+                facts.extend(evidence_fact_ids.iter().copied());
+                if let Some(proof) = evidence_proof {
+                    facts.extend(proof.via_facts.iter().copied());
+                    rules.extend(proof.via_rules.iter().copied());
+                }
+            }
             DerivationOrigin::FromJointContribution {
-                evidence_fact_ids, ..
-            } => facts.extend(evidence_fact_ids.iter().copied()),
+                evidence_fact_ids,
+                evidence_proofs,
+                ..
+            } => {
+                facts.extend(evidence_fact_ids.iter().copied());
+                for proof in evidence_proofs {
+                    facts.extend(proof.via_facts.iter().copied());
+                    rules.extend(proof.via_rules.iter().copied());
+                }
+            }
             // Predicate-gated contributions read a Certain valued slot
             // on CPU; the fired comparison (observed/op/threshold) is the
             // provenance carried inline on the step. They contribute no

--- a/code/packages/rust/logic-engine/tests/test_lr_aggregation.rs
+++ b/code/packages/rust/logic-engine/tests/test_lr_aggregation.rs
@@ -3,10 +3,10 @@
 //! semantically — what the rulebook says directly, not the ADJ46
 //! awkward synthetic-`contrib`-marker workaround.
 
-use logic_core::{atom, compound, Term};
+use logic_core::{atom, compound};
 use logic_engine::{
-    counterfactual, search, source_disagreements, ContributionClause, Fact,
-    JointContributionClause, KnowledgeBase, LrAggregateWarning, PriorClause, Provenance,
+    counterfactual, search, source_disagreements, BodyLiteral, ContributionClause, Fact,
+    JointContributionClause, KnowledgeBase, LrAggregateWarning, PriorClause, Provenance, Rule,
     SearchMode, SearchResult, TrustTier, UncertaintyMarker,
 };
 
@@ -195,11 +195,7 @@ fn missing_prior_produces_uniform_posterior_with_warning() {
     let mut kb = KnowledgeBase::new();
     // Contribution without a prior — algorithm proceeds at P=0.5
     // and emits a NoPriorDeclared warning per LP19e §"Edge cases."
-    kb.add_contribution(ContributionClause::from_lr(
-        atom("c"),
-        atom("ev"),
-        3.0,
-    ));
+    kb.add_contribution(ContributionClause::from_lr(atom("c"), atom("ev"), 3.0));
     kb.add_fact(Fact::certain(atom("ev")));
 
     let result = search(&atom("c"), &kb, SearchMode::LRAggregate);
@@ -250,6 +246,98 @@ fn proof_dag_carries_evidence_fact_ids_through_lr_steps() {
 }
 
 #[test]
+fn rule_derived_evidence_gates_contribution_and_carries_proof() {
+    use logic_engine::DerivationOrigin;
+
+    let mut kb = KnowledgeBase::new();
+    kb.add_prior(PriorClause::from_probability(atom("bacterial"), 0.10))
+        .unwrap();
+    kb.add_contribution(ContributionClause::from_lr(
+        atom("bacterial"),
+        atom("infection_present"),
+        10.0,
+    ));
+    let fever_id = kb.add_fact(Fact::certain(atom("fever")));
+    let culture_id = kb.add_fact(Fact::certain(atom("positive_culture")));
+    let rule_id = kb.add_rule(Rule::certain(
+        atom("infection_present"),
+        vec![
+            BodyLiteral::Pos(atom("fever")),
+            BodyLiteral::Pos(atom("positive_culture")),
+        ],
+    ));
+
+    let result = search(&atom("bacterial"), &kb, SearchMode::LRAggregate);
+    if let SearchResult::LRAggregateResult { dag, posterior, .. } = result {
+        // prior odds 1/9, LR 10 => odds 10/9 => posterior 10/19.
+        assert!(approx_eq(posterior, 10.0 / 19.0, 1e-12));
+        let proof = &dag.proofs[0];
+        assert!(proof.via_facts.contains(&fever_id));
+        assert!(proof.via_facts.contains(&culture_id));
+        assert!(proof.via_rules.contains(&rule_id));
+        let contribution_step = proof
+            .steps
+            .iter()
+            .find(|s| matches!(s.origin, DerivationOrigin::FromContribution { .. }))
+            .expect("a contribution step should be present");
+        if let DerivationOrigin::FromContribution {
+            evidence_fact_ids,
+            evidence_proof,
+            logit_delta,
+            ..
+        } = &contribution_step.origin
+        {
+            assert!(evidence_fact_ids.contains(&fever_id));
+            assert!(evidence_fact_ids.contains(&culture_id));
+            let evidence_proof = evidence_proof
+                .as_ref()
+                .expect("rule-derived evidence should carry its SLD proof");
+            assert!(evidence_proof.via_rules.contains(&rule_id));
+            assert!(approx_eq(*logit_delta, 10.0_f64.ln(), 1e-12));
+        }
+    } else {
+        panic!("expected LRAggregateResult");
+    }
+}
+
+#[test]
+fn probabilistic_rule_derived_evidence_attenuates_contribution() {
+    use logic_engine::DerivationOrigin;
+
+    let mut kb = KnowledgeBase::new();
+    kb.add_prior(PriorClause::from_probability(atom("bacterial"), 0.10))
+        .unwrap();
+    kb.add_contribution(ContributionClause::from_lr(
+        atom("bacterial"),
+        atom("infection_present"),
+        16.0,
+    ));
+    kb.add_fact(Fact::certain(atom("fever")));
+    let rule_id = kb.add_rule(Rule::with_probability(
+        atom("infection_present"),
+        vec![BodyLiteral::Pos(atom("fever"))],
+        0.5,
+    ));
+
+    let result = search(&atom("bacterial"), &kb, SearchMode::LRAggregate);
+    if let SearchResult::LRAggregateResult { dag, posterior, .. } = result {
+        // ln(16) attenuated by rule confidence 0.5 is ln(4).
+        assert!(approx_eq(posterior, 4.0 / 13.0, 1e-12));
+        assert!(dag.proofs[0].via_rules.contains(&rule_id));
+        let contribution_step = dag.proofs[0]
+            .steps
+            .iter()
+            .find(|s| matches!(s.origin, DerivationOrigin::FromContribution { .. }))
+            .expect("a contribution step should be present");
+        if let DerivationOrigin::FromContribution { logit_delta, .. } = &contribution_step.origin {
+            assert!(approx_eq(*logit_delta, 16.0_f64.ln() * 0.5, 1e-12));
+        }
+    } else {
+        panic!("expected LRAggregateResult");
+    }
+}
+
+#[test]
 fn term_equality_on_compounds_works_for_contribution_lookup() {
     // Confirms the linear-scan KB representation (Vec, not HashMap)
     // is correct for compound-term contributions.
@@ -290,10 +378,9 @@ fn provenance_is_recoverable_from_kb_after_aggregation() {
     let mut kb = KnowledgeBase::new();
     let prior_id = kb
         .add_prior(
-            PriorClause::from_probability(atom("acs"), 0.10)
-                .with_provenance(Provenance::cited(
-                    "Pope JH et al., NEJM 1995;342(16):1163-70",
-                )),
+            PriorClause::from_probability(atom("acs"), 0.10).with_provenance(Provenance::cited(
+                "Pope JH et al., NEJM 1995;342(16):1163-70",
+            )),
         )
         .unwrap();
     let contrib_id = kb.add_contribution(
@@ -324,7 +411,10 @@ fn provenance_is_recoverable_from_kb_after_aggregation() {
                 assert_eq!(*clause_id, prior_id);
                 let p = kb.prior_for(&atom("acs")).unwrap();
                 assert_eq!(p.provenance.trust_tier, TrustTier::Authoritative);
-                assert_eq!(p.provenance.source, "Pope JH et al., NEJM 1995;342(16):1163-70");
+                assert_eq!(
+                    p.provenance.source,
+                    "Pope JH et al., NEJM 1995;342(16):1163-70"
+                );
             }
             DerivationOrigin::FromContribution { clause_id, .. } => {
                 assert_eq!(*clause_id, contrib_id);
@@ -454,7 +544,8 @@ fn uncertainty_marker_with_no_matching_contributions_has_zero_voi() {
     // but every if_observed_logit_delta is 0.0 and VOI is 0.0 —
     // a "rulebook gap" the modeller should know about.
     let mut kb = KnowledgeBase::new();
-    kb.add_prior(PriorClause::from_probability(atom("c"), 0.10)).unwrap();
+    kb.add_prior(PriorClause::from_probability(atom("c"), 0.10))
+        .unwrap();
     kb.add_contribution(ContributionClause::from_lr(
         atom("c"),
         atom("some_evidence"),
@@ -470,10 +561,7 @@ fn uncertainty_marker_with_no_matching_contributions_has_zero_voi() {
     let result = search(&atom("c"), &kb, SearchMode::LRAggregate);
     if let SearchResult::LRAggregateResult { uncertainties, .. } = result {
         assert_eq!(uncertainties.len(), 1);
-        assert_eq!(
-            uncertainties[0].if_observed_logit_delta,
-            vec![0.0, 0.0]
-        );
+        assert_eq!(uncertainties[0].if_observed_logit_delta, vec![0.0, 0.0]);
         assert_eq!(uncertainties[0].voi_logit_range, 0.0);
     } else {
         panic!("expected LRAggregateResult");

--- a/code/specs/ADJ-LADDER.md
+++ b/code/specs/ADJ-LADDER.md
@@ -214,8 +214,14 @@ The mechanism is proven; the ladder can climb.
 
 ## 7. Next
 
-Continue rung 1 with harder fraction/percent banks, then PR-1 = the
-ADJ-REASON-MATH **deduction→evidence bridge** (`logic-engine` — `observed_evidence`
-falls back to SLD provability + attenuates confidence + threads rule provenance), the
-unlock for every multi-step rung. Then rungs 2→5 in order, each gating the next engine
-PR, culminating in the MLE-PASS clinical rung and the pediatrics apex.
+PR-1 is the ADJ-REASON-MATH **deduction→evidence bridge**: `logic-engine`
+`observed_evidence` falls back to SLD provability, attenuates an LR contribution by
+the proof confidence, and threads the rule/fact proof into the aggregate evidence
+step. This unlocks the first true multi-step Arm B programs: the model can emit
+observations plus a rule, and ADJ can derive the intermediate premise before weighing
+it probabilistically.
+
+After this bridge, continue rung 1 with harder fraction/percent banks and start rung
+2 pre-algebra/algebra word problems that mix deduction with equation solving. Then
+rungs 3→5 gate the CAS/dimensional/clinical slices in order, culminating in the
+MLE-PASS clinical rung and the pediatrics apex.

--- a/code/specs/ADJ-REASON-MATH.md
+++ b/code/specs/ADJ-REASON-MATH.md
@@ -246,6 +246,15 @@ licensed it. This is the unification that makes deduction + probability one quer
 **Cost:** small, localized to `lib.rs:943` + `lr_aggregate.rs` evidence lookup +
 `proof_dag.rs` (one optional field). High risk-adjusted leverage.
 
+**Implementation note (2026-06-28):** the core bridge is now implemented in
+`logic-engine`: direct `Certain` facts remain the fast path, otherwise
+`observed_evidence` enumerates SLD proofs, selects the strongest proof, attenuates
+the LR delta by the fact/rule probability product, and stores the nested proof under
+the LR step. `adj-lang-cli` renders that nested `"evidence_proof"` so the `.adj`
+program path can show the deduction that licensed the probabilistic contribution.
+The later unified-proof pass can still collapse trust-tier summaries and verifier
+checks across SLD + LR + solver/CAS steps.
+
 ### B. Symbolic algebra as first-class ADJ — **wiring + new trail (CAS already exists)**
 
 **B1 — surface.** Add statements that name the existing CAS operations. New grammar

--- a/code/specs/data/adj-ladder/CHANGELOG.md
+++ b/code/specs/data/adj-ladder/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to the ADJ-LADDER two-arm reasoning scoreboard.
 
+## [0.4.0] — 2026-06-28
+
+### Added — PR-1 deduction to evidence bridge
+
+- `logic-engine` now lets a rule-derived atom gate an LR contribution. This is the
+  first multi-step reasoning bridge the ladder needs: a small model can emit
+  observations and rules, and ADJ can prove the intermediate premise before weighing
+  it probabilistically.
+- Derived evidence carries its SLD proof into the LR proof DAG and CLI JSON. The
+  audit trail can now show both the deduction that established a premise and the
+  likelihood-ratio step that used it.
+- Probabilistic proof chains attenuate the applied LR delta by their fact/rule
+  confidence; all-certain chains keep the old exact behavior.
+
 ## [0.3.0] — 2026-06-27
 
 ### Added — rung 1 fractions/percent scaffold

--- a/code/specs/data/adj-ladder/README.md
+++ b/code/specs/data/adj-ladder/README.md
@@ -104,5 +104,6 @@ units, the deduction↔evidence bridge) — see ADJ-LADDER.md §5.
 `rung1_fractions_percent` is intentionally a starter scaffold. It now has the native
 surface it needs for fractional option matching (`answer == 3 / 10`), with exact
 rational sidecars carrying integer/rational arithmetic through predicate equality.
-The next climb is using that surface in harder banks and then connecting multi-step
-deductions into probabilistic evidence.
+The next climb connects multi-step deductions into probabilistic evidence: ADJ can
+derive an intermediate premise with `rule { ... }`, then let that derived atom fire a
+`contributes ... from <premise>` clause with the SLD proof attached to the audit trail.


### PR DESCRIPTION
## Summary

This is the next ADJ-LADDER PR-1 slice: connect deduction to probabilistic evidence so a Gemma-style decomposer can emit observations plus rules, and ADJ can prove an intermediate premise before weighing it.

- Extend `KnowledgeBase::observed_evidence` with an SLD fallback that selects the strongest derived proof when an evidence atom is not directly observed.
- Attenuate applied LR deltas by the proof confidence, computed from fact/rule probabilities, while keeping direct `Certain` observations at confidence 1.0.
- Thread nested evidence proofs through LR `ProofDAG` contribution/interactions and render `evidence_proof` in `adj-lang-cli` JSON.
- Add engine and CLI coverage for rule-derived evidence, plus ladder/spec/changelog updates for the PR-1 bridge.

## Validation

- `cargo test -p logic-engine -p adj-lang`
- `cargo test -p adj-lang-cli --test cli_golden`
- `python3 -m pytest test_ladder_eval.py -q`
- `git diff --check`

Known existing warning remains: `logic-engine/src/dimension.rs:142` unreachable pattern.