### PR TITLE
Add smart-home dashboard event stream panel

### DIFF
--- a/code/packages/rust/smart-home-platform-http/CHANGELOG.md
+++ b/code/packages/rust/smart-home-platform-http/CHANGELOG.md
@@ -41,6 +41,8 @@ All notable changes to this package will be documented in this file.
   panels backed by the existing local-controller audit routes.
 - Added browser dashboard room, device, and bridge topology panels backed by
   the existing local-controller inventory routes.
+- Added a browser dashboard event-log panel backed by the existing native
+  runtime event stream route.
 - Added a native readiness checklist route with actionable links for registry,
   topology, state coverage, event bus, discovery, supervisor, authorization,
   and desired-state checks.

--- a/code/packages/rust/smart-home-platform-http/README.md
+++ b/code/packages/rust/smart-home-platform-http/README.md
@@ -87,10 +87,11 @@ the Home Assistant-style history route accepts `filter_entity_id`.
 The browser routes serve an embedded local dashboard shell over the same
 `web-core::WebApp`. The shell loads bootstrap, readiness, state, scene,
 desired-state, room, device, bridge, state-history, command-result audit,
-authorization audit, service catalog, API catalog, and audit summary data from
-the native API routes and sends light on/off, light brightness, scene, and
-desired-state set/clear actions through the existing Home Assistant-compatible
-and native service endpoints, preserving runtime authorization.
+runtime event-log, authorization audit, service catalog, API catalog, and audit
+summary data from the native API routes and sends light on/off, light brightness,
+scene, and desired-state set/clear actions through the existing Home
+Assistant-compatible and native service endpoints, preserving runtime
+authorization.
 
 ## Dependencies
 
@@ -135,6 +136,7 @@ curl 'http://127.0.0.1:8123/api/smart_home/bridges?integration_id=hue&transport=
 curl 'http://127.0.0.1:8123/api/smart_home/rooms?sort=scene_count&state_gaps_only=true'
 curl 'http://127.0.0.1:8123/api/smart_home/scenes?room_id=kitchen&scope=room'
 curl 'http://127.0.0.1:8123/api/smart_home/scenes/scene.scene_kitchen_bright'
+curl 'http://127.0.0.1:8123/api/smart_home/events?limit=12'
 curl 'http://127.0.0.1:8123/api/smart_home/events/0'
 curl 'http://127.0.0.1:8123/api/smart_home/command_results?limit=10'
 curl 'http://127.0.0.1:8123/api/smart_home/command_results?bridge_id=bridge-1'

--- a/code/packages/rust/smart-home-platform-http/src/lib.rs
+++ b/code/packages/rust/smart-home-platform-http/src/lib.rs
@@ -359,6 +359,15 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
         </table>
       </div>
       <div class="panel">
+        <h2>Events</h2>
+        <table>
+          <thead>
+            <tr><th>Sequence</th><th>Kind</th><th>Subject</th><th>Status</th></tr>
+          </thead>
+          <tbody id="events"></tbody>
+        </table>
+      </div>
+      <div class="panel">
         <h2>Commands</h2>
         <table>
           <thead>
@@ -392,6 +401,7 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
       desired: document.querySelector("#desired"),
       devices: document.querySelector("#devices"),
       entities: document.querySelector("#entities"),
+      events: document.querySelector("#events"),
       gaps: document.querySelector("#gaps"),
       history: document.querySelector("#history"),
       location: document.querySelector("#location"),
@@ -447,6 +457,24 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
         return subject.tool_id || "tool";
       }
       return [subject.command_type, subject.entity_id].filter(Boolean).join(" ") || subject.kind || "subject";
+    };
+    const eventSubject = (event) => {
+      if (!event) {
+        return "unknown";
+      }
+      if (event.kind === "command_result") {
+        return event.result?.command_id || event.result?.bridge_id || "command";
+      }
+      return event.entity_id || event.device_id || event.bridge_id || event.integration_id || event.event_id || "runtime";
+    };
+    const eventStatus = (event) => {
+      if (!event) {
+        return "unknown";
+      }
+      if (event.kind === "command_result") {
+        return event.result?.status || "command";
+      }
+      return event.health || event.reason || event.event_type || event.kind || "event";
     };
 
     const log = (message) => {
@@ -633,6 +661,21 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
       }).join("") || `<tr><td colspan="4" class="muted">No state history</td></tr>`;
     };
 
+    const renderEvents = (eventLog) => {
+      const entries = eventLog.events || [];
+      els.events.innerHTML = entries.map((entry) => {
+        const event = entry.event || {};
+        return `
+          <tr>
+            <td>${entry.sequence}<br><span class="muted">next ${entry.next_sequence}</span></td>
+            <td>${event.kind || "event"}</td>
+            <td>${eventSubject(event)}</td>
+            <td><span class="${statusClass(eventStatus(event))}">${eventStatus(event)}</span></td>
+          </tr>
+        `;
+      }).join("") || `<tr><td colspan="4" class="muted">No runtime events</td></tr>`;
+    };
+
     const renderCommandResults = (audit) => {
       const results = audit.results || [];
       els.commandResults.innerHTML = results.map((record) => {
@@ -675,6 +718,7 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
           rooms,
           devices,
           bridges,
+          events,
           commandResults,
           authorizationDecisions
         ] = await Promise.all([
@@ -689,6 +733,7 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
           json("/api/smart_home/rooms?sort=scene_count"),
           json("/api/smart_home/devices?limit=8"),
           json("/api/smart_home/bridges?limit=8"),
+          json("/api/smart_home/events?limit=12"),
           json("/api/smart_home/command_results?limit=8"),
           json("/api/smart_home/authorization_decisions?limit=8")
         ]);
@@ -719,6 +764,7 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
         renderDesiredStates(desiredStates);
         renderGaps(bootstrap.state_gaps);
         renderHistory(history);
+        renderEvents(events);
         renderCommandResults(commandResults);
         renderAuthorizationDecisions(authorizationDecisions);
         log("Dashboard refreshed");
@@ -6554,8 +6600,10 @@ mod tests {
             assert!(body.contains("json(\"/api/smart_home/rooms?sort=scene_count\")"));
             assert!(body.contains("json(\"/api/smart_home/devices?limit=8\")"));
             assert!(body.contains("json(\"/api/smart_home/bridges?limit=8\")"));
+            assert!(body.contains("json(\"/api/smart_home/events?limit=12\")"));
             assert!(body.contains("json(\"/api/smart_home/command_results?limit=8\")"));
             assert!(body.contains("json(\"/api/smart_home/authorization_decisions?limit=8\")"));
+            assert!(body.contains("<tbody id=\"events\"></tbody>"));
             assert!(body.contains("/api/services/light/"));
             assert!(body.contains("data-service=\"set_brightness\""));
             assert!(body.contains("brightness_pct"));


### PR DESCRIPTION
## Summary
- add an embedded dashboard Events panel backed by the native /api/smart_home/events route
- render event sequence, kind, subject, and status for local-controller audit drilldown
- update dashboard shell assertions plus README/CHANGELOG inventory

## Validation
- cargo fmt -p smart-home-platform-http
- cargo test -p smart-home-platform-http -- --nocapture
- sh BUILD (from code/packages/rust/smart-home-platform-http)
- git diff --check
- removed generated code/packages/rust/Cargo.lock