### PR TITLE
Stamp BJT transient charge

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Added
 
+- **BJT transient charge stamping** —
+  BJT `Cje`/`Cjc`/`Tf`/`Tr` model-card storage now stamps transient
+  base-emitter and base-collector companions, matching Rust and TypeScript,
+  with regression coverage for base current-step delay and forward transit-time
+  turnoff charge.
+
 - **Diode transient charge stamping** —
   Diode `Cjo`/`Tt` model-card storage now stamps transient anode-cathode
   companions, matching Rust and TypeScript, with regression coverage for

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -213,9 +213,9 @@ JFET and Level-1 MOS channel thermal noise audits.
 `device_model_charge_audit_fixtures()` adds matching `.tran` reference-deck
 metadata, explicit terminal storage capacitance metadata, stable first/final
 probe-voltage windows, and charge-behavior notes for diode, BJT, JFET, and
-Level-1 MOS charge audits. Diode `Cjo` and `Tt` model-card parameters also
-stamp transient anode-cathode storage, matching their small-signal AC
-capacitance semantics.
+Level-1 MOS charge audits. Diode `Cjo` / `Tt` and BJT `Cje` / `Cjc` / `Tf` /
+`Tr` model-card parameters also stamp transient storage, matching their
+small-signal AC capacitance semantics.
 
 `DigitalEventStream`, `DigitalLogicLevels`, and `DigitalThresholds` provide the
 first mixed-signal bridge surface: digital event streams can drive finite-edge

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -8676,6 +8676,45 @@ def _diode_charge_voltage(el: Diode, node_voltages: dict[str, float]) -> float:
     return _node_voltage(el.anode, node_voltages) - _node_voltage(el.cathode, node_voltages)
 
 
+def _bjt_base_emitter_charge_state_name(el: BJT) -> str:
+    return f"_Q_{el.name}_be_charge"
+
+
+def _bjt_base_collector_charge_state_name(el: BJT) -> str:
+    return f"_Q_{el.name}_bc_charge"
+
+
+def _bjt_junction_transconductance(el: BJT, voltage: float) -> float:
+    exponent = max(-40.0, min(40.0, voltage / el.Vt))
+    return (el.Is / el.Vt) * math.exp(exponent)
+
+
+def _bjt_charge_dynamic_capacitance(el: BJT, state_kind: str, voltage: float) -> float:
+    conductance = _bjt_junction_transconductance(el, voltage)
+    if state_kind == "be":
+        return el.Cje + el.Tf * conductance
+    return el.Cjc + el.Tr * conductance
+
+
+def _bjt_charge_state_specs(el: BJT) -> list[tuple[str, str, str, str]]:
+    specs: list[tuple[str, str, str, str]] = []
+    if el.Cje > 0.0 or el.Tf > 0.0:
+        if el.polarity == "NPN":
+            specs.append((_bjt_base_emitter_charge_state_name(el), el.base, el.emitter, "be"))
+        else:
+            specs.append((_bjt_base_emitter_charge_state_name(el), el.emitter, el.base, "be"))
+    if el.Cjc > 0.0 or el.Tr > 0.0:
+        if el.polarity == "NPN":
+            specs.append((_bjt_base_collector_charge_state_name(el), el.base, el.collector, "bc"))
+        else:
+            specs.append((_bjt_base_collector_charge_state_name(el), el.collector, el.base, "bc"))
+    return specs
+
+
+def _bjt_charge_state_voltage(n_plus: str, n_minus: str, node_voltages: dict[str, float]) -> float:
+    return _node_voltage(n_plus, node_voltages) - _node_voltage(n_minus, node_voltages)
+
+
 def _stamp_mosfet(
     G: list[list[float]],
     b: list[float],
@@ -9588,6 +9627,37 @@ def _build_transient_companions(
                     current=I_eq,
                 ))
 
+        # ---- BJT model-card charge companions ------------------------------
+        elif isinstance(el, BJT):
+            for state_name, n_plus, n_minus, state_kind in _bjt_charge_state_specs(el):
+                v_prev = cap_voltages.get(state_name, 0.0)
+                capacitance = _bjt_charge_dynamic_capacitance(el, state_kind, v_prev)
+                if capacitance <= 0.0:
+                    continue
+                if method == "trap":
+                    g_eq = 2.0 * capacitance / h
+                    I_eq = g_eq * v_prev + cap_currents.get(state_name, 0.0)
+                elif method == "gear2":
+                    v_older = cap_voltages_older.get(state_name, v_prev)
+                    g_eq = 3.0 * capacitance / (2.0 * h)
+                    I_eq = capacitance * (4.0 * v_prev - v_older) / (2.0 * h)
+                else:
+                    g_eq = capacitance / h
+                    I_eq = g_eq * v_prev
+
+                aug.elements.append(Resistor(
+                    name=f"{state_name}_R",
+                    n_plus=n_plus,
+                    n_minus=n_minus,
+                    resistance=1.0 / g_eq,
+                ))
+                aug.elements.append(CurrentSource(
+                    name=f"{state_name}_I",
+                    n_plus=n_minus,
+                    n_minus=n_plus,
+                    current=I_eq,
+                ))
+
         # ---- Inductor companion ------------------------------------------
         elif isinstance(el, Inductor) and el.name not in coupled_names:
             I_prev = ind_currents.get(el.name, 0.0)
@@ -9745,6 +9815,30 @@ def _update_reactive_state(
             cap_voltages_older[state_name] = v_prev
             cap_voltages[state_name] = v_new
 
+        elif isinstance(el, BJT):
+            for state_name, n_plus, n_minus, state_kind in _bjt_charge_state_specs(el):
+                v_new = _bjt_charge_state_voltage(n_plus, n_minus, op.node_voltages)
+                v_prev = cap_voltages.get(state_name, v_new)
+                v_older = cap_voltages_older.get(state_name, v_prev)
+                capacitance = _bjt_charge_dynamic_capacitance(el, state_kind, v_prev)
+
+                if capacitance > 0.0:
+                    if method == "trap":
+                        g_eq = 2.0 * capacitance / h
+                        I_prev = cap_currents.get(state_name, 0.0)
+                        cap_currents[state_name] = g_eq * (v_new - v_prev) - I_prev
+                    elif method == "gear2":
+                        cap_currents[state_name] = (
+                            capacitance * (3.0 * v_new - 4.0 * v_prev + v_older)
+                            / (2.0 * h)
+                        )
+                    else:
+                        g_eq = capacitance / h
+                        cap_currents[state_name] = g_eq * (v_new - v_prev)
+
+                cap_voltages_older[state_name] = v_prev
+                cap_voltages[state_name] = v_new
+
         elif isinstance(el, Inductor) and el.name not in coupled_names:
             v_plus = _node_voltage(el.n_plus, op.node_voltages)
             v_minus = _node_voltage(el.n_minus, op.node_voltages)
@@ -9809,6 +9903,14 @@ def _lte_estimate(
             lte_c = abs(v1 - 2.0 * v0 + vm1) / 2.0
             if lte_c > max_lte:
                 max_lte = lte_c
+        elif isinstance(el, BJT):
+            for state_name, _, _, _ in _bjt_charge_state_specs(el):
+                v1 = cap_voltages_now.get(state_name, 0.0)
+                v0 = cap_voltages_prev.get(state_name, 0.0)
+                vm1 = cap_voltages_prev2.get(state_name, 0.0)
+                lte_c = abs(v1 - 2.0 * v0 + vm1) / 2.0
+                if lte_c > max_lte:
+                    max_lte = lte_c
     return max_lte
 
 
@@ -9972,6 +10074,13 @@ def transient(
     for el in circuit.elements:
         if isinstance(el, Diode) and _diode_has_charge_storage(el):
             cap_voltages[_diode_charge_state_name(el)] = _diode_charge_voltage(el, op.node_voltages)
+        elif isinstance(el, BJT):
+            for state_name, n_plus, n_minus, _ in _bjt_charge_state_specs(el):
+                cap_voltages[state_name] = _bjt_charge_state_voltage(
+                    n_plus,
+                    n_minus,
+                    op.node_voltages,
+                )
     cap_currents: dict[str, float] = {
         el.name: 0.0
         for el in circuit.elements if isinstance(el, Capacitor)
@@ -9979,6 +10088,9 @@ def transient(
     for el in circuit.elements:
         if isinstance(el, Diode) and _diode_has_charge_storage(el):
             cap_currents[_diode_charge_state_name(el)] = 0.0
+        elif isinstance(el, BJT):
+            for state_name, _, _, _ in _bjt_charge_state_specs(el):
+                cap_currents[state_name] = 0.0
     cap_voltages_older: dict[str, float] = dict(cap_voltages)
     ind_currents: dict[str, float] = {
         el.name: el.initial_current
@@ -10048,6 +10160,13 @@ def transient(
                         el,
                         op.node_voltages,
                     )
+                elif isinstance(el, BJT):
+                    for state_name, n_plus, n_minus, _ in _bjt_charge_state_specs(el):
+                        cap_voltages_new[state_name] = _bjt_charge_state_voltage(
+                            n_plus,
+                            n_minus,
+                            op.node_voltages,
+                        )
 
             lte = _lte_estimate(circuit, cap_voltages_new,
                                  cap_voltages, cap_voltages_prev)

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -880,9 +880,10 @@ def device_model_noise_audit_fixtures() -> tuple[DeviceModelNoiseBehaviorFixture
 def device_model_charge_audit_fixtures() -> tuple[DeviceModelChargeBehaviorFixture, ...]:
     """Return runnable transient storage fixtures for charge model-depth audits.
 
-    Diode CJO/TT model-card storage is transient-stamped by the simulator.
-    BJT, JFET, and MOS charge state is still audited through explicit terminal
-    storage capacitors until their nonlinear charge policies land.
+    Diode CJO/TT and BJT CJE/CJC/TF/TR model-card storage is
+    transient-stamped by the simulator. JFET and MOS charge state is still
+    audited through explicit terminal storage capacitors until their nonlinear
+    charge policies land.
     """
 
     models = _model_card_by_name()
@@ -962,8 +963,9 @@ def device_model_charge_audit_fixtures() -> tuple[DeviceModelChargeBehaviorFixtu
             expected_final_min=0.10,
             expected_final_max=0.14,
             charge_behavior=(
-                "BJT terminal charge is conserved through explicit Cstore; "
-                "CJE/CJC/TF/TR remain AC-only until nonlinear charge stamping lands"
+                "BJT CJE/CJC/TF/TR contribute transient base-emitter and "
+                "base-collector storage; explicit Cstore keeps the fixture "
+                "comparable with other charge audits"
             ),
             deck_lines=(
                 "* device-model charge fixture: bjt-storage-charge",

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -604,6 +604,72 @@ def test_transient_diode_transit_time_holds_forward_charge_on_turnoff() -> None:
     assert stored.points[1].node_voltages["out"] < stored.points[0].node_voltages["out"]
 
 
+def test_transient_bjt_base_emitter_capacitance_slows_base_current_step() -> None:
+    def run(base_emitter_capacitance: float) -> TransientResult:
+        circuit = Circuit()
+        circuit.add(VoltageSource("Vcc", "collector", "0", 5.0))
+        circuit.add(CurrentSource(
+            "Istep",
+            "0",
+            "base",
+            0.0,
+            waveform=PwlWaveform(((0.0, 0.0), (1.0e-9, 1.0e-6), (5.0e-9, 1.0e-6))),
+        ))
+        circuit.add(Resistor("Rshunt", "base", "0", 1.0e12))
+        circuit.add(BJT(
+            "Q1",
+            collector="collector",
+            base="base",
+            emitter="0",
+            Is=1.0e-15,
+            Cje=base_emitter_capacitance,
+        ))
+        return transient(circuit, t_stop=5.0e-9, t_step=1.0e-9, method="euler")
+
+    uncharged = run(0.0)
+    charged = run(1.0e-12)
+
+    assert uncharged.converged
+    assert charged.converged
+    uncharged_first = uncharged.points[1].node_voltages["base"]
+    charged_first = charged.points[1].node_voltages["base"]
+    assert uncharged_first > 0.5
+    assert charged_first < 0.01
+    assert charged_first < uncharged_first
+
+
+def test_transient_bjt_forward_transit_time_holds_base_charge_on_turnoff() -> None:
+    def run(forward_transit_time: float) -> TransientResult:
+        circuit = Circuit()
+        circuit.add(VoltageSource("Vcc", "collector", "0", 5.0))
+        circuit.add(CurrentSource(
+            "Istep",
+            "0",
+            "base",
+            0.0,
+            waveform=PwlWaveform(((0.0, 1.0e-3), (1.0e-9, 0.0), (5.0e-9, 0.0))),
+        ))
+        circuit.add(Resistor("Rshunt", "base", "0", 1.0e12))
+        circuit.add(BJT(
+            "Q1",
+            collector="collector",
+            base="base",
+            emitter="0",
+            Is=1.0e-15,
+            Tf=forward_transit_time,
+        ))
+        return transient(circuit, t_stop=5.0e-9, t_step=1.0e-9, method="euler")
+
+    no_storage = run(0.0)
+    stored = run(1.0e-9)
+
+    assert no_storage.converged
+    assert stored.converged
+    assert no_storage.points[1].node_voltages["base"] == pytest.approx(0.0, abs=1.0e-12)
+    assert stored.points[1].node_voltages["base"] > 0.6
+    assert stored.points[1].node_voltages["base"] < stored.points[0].node_voltages["base"]
+
+
 def test_non_level_one_mos_model_cards_are_explicitly_rejected() -> None:
     with pytest.raises(ValueError, match="only MOS LEVEL=1"):
         normalize_model_card("Mbad", "nmos", {"LEVEL": 2.0})

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Stamp BJT `base_emitter_capacitance`, `base_collector_capacitance`,
+  `forward_transit_time`, and `reverse_transit_time` model-card storage as
+  transient base-emitter and base-collector companions, matching Python and
+  TypeScript, with regression coverage for base current-step delay and forward
+  transit-time turnoff charge.
 - Stamp diode `junction_capacitance` and `transit_time` model-card storage as
   transient anode-cathode companions, matching Python and TypeScript, with
   regression coverage for current-step delay and turnoff charge retention.

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -137,9 +137,10 @@ JFET and Level-1 MOS channel thermal noise audits.
 `device_model_charge_audit_fixtures` adds matching `.tran` reference-deck
 metadata, explicit terminal storage capacitance metadata, stable first/final
 probe-voltage windows, and charge-behavior notes for diode, BJT, JFET, and
-Level-1 MOS charge audits. Diode `junction_capacitance` and `transit_time`
-model-card parameters also stamp transient anode-cathode storage, matching
-their small-signal AC capacitance semantics.
+Level-1 MOS charge audits. Diode `junction_capacitance` / `transit_time` and
+BJT `base_emitter_capacitance` / `base_collector_capacitance` /
+`forward_transit_time` / `reverse_transit_time` model-card parameters also
+stamp transient storage, matching their small-signal AC capacitance semantics.
 
 `analyze_custom_model_source` accepts only a two-terminal `I(p,n) <+ ...`
 module shape and rejects dynamic/event/system constructs; it is not a full

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -4028,7 +4028,7 @@ pub fn device_model_charge_audit_fixtures(
             expected_initial_max: 1.0,
             expected_final_min: 0.10,
             expected_final_max: 0.14,
-            charge_behavior: "BJT terminal charge is conserved through explicit Cstore; CJE/CJC/TF/TR remain AC-only until nonlinear charge stamping lands".to_string(),
+            charge_behavior: "BJT CJE/CJC/TF/TR contribute transient base-emitter and base-collector storage; explicit Cstore keeps the fixture comparable with other charge audits".to_string(),
             deck_lines: vec![
                 "* device-model charge fixture: bjt-storage-charge".to_string(),
                 ".model Qsmall NPN(BF=125 CJE=2e-12 TF=1e-10)".to_string(),
@@ -17513,7 +17513,7 @@ pub fn transient_with_method(
         &inductor_states,
         Some(0.0),
     )?;
-    seed_diode_capacitor_states(
+    seed_device_capacitor_states(
         circuit,
         &initial_solution.node_voltages,
         &mut capacitor_states,
@@ -17653,7 +17653,7 @@ pub fn transient_adaptive(
         &inductor_states,
         Some(0.0),
     )?;
-    seed_diode_capacitor_states(
+    seed_device_capacitor_states(
         circuit,
         &initial_solution.node_voltages,
         &mut capacitor_states,
@@ -19114,9 +19114,14 @@ fn solve_linear_circuit_at_operating_point(
             Element::Jfet(jfet) => {
                 stamp_jfet(jfet, node_indices, &mut matrix, &mut rhs, operating_point)?
             }
-            Element::Bjt(bjt) => {
-                stamp_bjt(bjt, node_indices, &mut matrix, &mut rhs, operating_point)?
-            }
+            Element::Bjt(bjt) => stamp_bjt(
+                bjt,
+                capacitor_states,
+                node_indices,
+                &mut matrix,
+                &mut rhs,
+                operating_point,
+            )?,
             Element::Mosfet(mosfet) => {
                 stamp_mosfet(mosfet, node_indices, &mut matrix, &mut rhs, operating_point)?
             }
@@ -20305,6 +20310,7 @@ fn stamp_diode_charge(
 
 fn stamp_bjt(
     bjt: &Bjt,
+    capacitor_states: &[CapacitorState],
     node_indices: &HashMap<String, usize>,
     matrix: &mut [Vec<f64>],
     rhs: &mut [f64],
@@ -20341,6 +20347,51 @@ fn stamp_bjt(
             stamp_transconductance(matrix, emitter, collector, emitter, base, gm);
             stamp_equivalent_current_source(rhs, emitter, base, equivalent_base_current);
             stamp_equivalent_current_source(rhs, emitter, collector, equivalent_collector_current);
+        }
+    }
+    stamp_bjt_charge(bjt, capacitor_states, node_indices, matrix, rhs)?;
+    Ok(())
+}
+
+fn stamp_bjt_charge(
+    bjt: &Bjt,
+    capacitor_states: &[CapacitorState],
+    node_indices: &HashMap<String, usize>,
+    matrix: &mut [Vec<f64>],
+    rhs: &mut [f64],
+) -> Result<(), SpiceError> {
+    for spec in bjt_charge_state_specs(bjt) {
+        let Some(state) = capacitor_states
+            .iter()
+            .find(|state| state.name == spec.name)
+        else {
+            continue;
+        };
+        let capacitance = bjt_charge_dynamic_capacitance(bjt, spec.kind, state.previous_voltage);
+        if capacitance <= 0.0 {
+            continue;
+        }
+        let conductance = match state.method {
+            TransientMethod::Trap => 2.0 * capacitance / state.time_step,
+            TransientMethod::Gear2 => 3.0 * capacitance / (2.0 * state.time_step),
+            TransientMethod::Euler => capacitance / state.time_step,
+        };
+        let history_current = match state.method {
+            TransientMethod::Trap => conductance * state.previous_voltage + state.previous_current,
+            TransientMethod::Gear2 => {
+                capacitance * (4.0 * state.previous_voltage - state.previous_previous_voltage)
+                    / (2.0 * state.time_step)
+            }
+            TransientMethod::Euler => conductance * state.previous_voltage,
+        };
+        let positive = node_index(node_indices, spec.positive);
+        let negative = node_index(node_indices, spec.negative);
+        stamp_conductance(matrix, positive, negative, conductance);
+        if let Some(index) = positive {
+            rhs[index] += history_current;
+        }
+        if let Some(index) = negative {
+            rhs[index] -= history_current;
         }
     }
     Ok(())
@@ -20844,6 +20895,80 @@ fn diode_charge_voltage(diode: &Diode, node_voltages: &BTreeMap<String, f64>) ->
     voltage_at(node_voltages, &diode.anode) - voltage_at(node_voltages, &diode.cathode)
 }
 
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+enum BjtChargeStateKind {
+    BaseEmitter,
+    BaseCollector,
+}
+
+struct BjtChargeStateSpec<'a> {
+    name: String,
+    positive: &'a str,
+    negative: &'a str,
+    kind: BjtChargeStateKind,
+}
+
+fn bjt_base_emitter_charge_state_name(bjt: &Bjt) -> String {
+    format!("_Q_{}_be_charge", bjt.name)
+}
+
+fn bjt_base_collector_charge_state_name(bjt: &Bjt) -> String {
+    format!("_Q_{}_bc_charge", bjt.name)
+}
+
+fn bjt_junction_transconductance(bjt: &Bjt, voltage: f64) -> f64 {
+    bjt.saturation_current / bjt.thermal_voltage
+        * (voltage / bjt.thermal_voltage).clamp(-40.0, 40.0).exp()
+}
+
+fn bjt_charge_dynamic_capacitance(bjt: &Bjt, kind: BjtChargeStateKind, voltage: f64) -> f64 {
+    let conductance = bjt_junction_transconductance(bjt, voltage);
+    match kind {
+        BjtChargeStateKind::BaseEmitter => {
+            bjt.base_emitter_capacitance + bjt.forward_transit_time * conductance
+        }
+        BjtChargeStateKind::BaseCollector => {
+            bjt.base_collector_capacitance + bjt.reverse_transit_time * conductance
+        }
+    }
+}
+
+fn bjt_charge_state_specs(bjt: &Bjt) -> Vec<BjtChargeStateSpec<'_>> {
+    let mut specs = Vec::new();
+    if bjt.base_emitter_capacitance > 0.0 || bjt.forward_transit_time > 0.0 {
+        let (positive, negative) = match bjt.polarity {
+            BjtPolarity::Npn => (bjt.base.as_str(), bjt.emitter.as_str()),
+            BjtPolarity::Pnp => (bjt.emitter.as_str(), bjt.base.as_str()),
+        };
+        specs.push(BjtChargeStateSpec {
+            name: bjt_base_emitter_charge_state_name(bjt),
+            positive,
+            negative,
+            kind: BjtChargeStateKind::BaseEmitter,
+        });
+    }
+    if bjt.base_collector_capacitance > 0.0 || bjt.reverse_transit_time > 0.0 {
+        let (positive, negative) = match bjt.polarity {
+            BjtPolarity::Npn => (bjt.base.as_str(), bjt.collector.as_str()),
+            BjtPolarity::Pnp => (bjt.collector.as_str(), bjt.base.as_str()),
+        };
+        specs.push(BjtChargeStateSpec {
+            name: bjt_base_collector_charge_state_name(bjt),
+            positive,
+            negative,
+            kind: BjtChargeStateKind::BaseCollector,
+        });
+    }
+    specs
+}
+
+fn bjt_charge_state_voltage(
+    spec: &BjtChargeStateSpec<'_>,
+    node_voltages: &BTreeMap<String, f64>,
+) -> f64 {
+    voltage_at(node_voltages, spec.positive) - voltage_at(node_voltages, spec.negative)
+}
+
 fn validate_diode(diode: &Diode) -> Result<(), SpiceError> {
     if !diode.saturation_current.is_finite() || diode.saturation_current <= 0.0 {
         return Err(SpiceError::InvalidElement {
@@ -21089,11 +21214,10 @@ fn initial_capacitor_states(
     time_step: f64,
     method: TransientMethod,
 ) -> Vec<CapacitorState> {
-    circuit
-        .elements()
-        .iter()
-        .filter_map(|element| match element {
-            Element::Capacitor(capacitor) => Some(CapacitorState {
+    let mut states = Vec::new();
+    for element in circuit.elements() {
+        match element {
+            Element::Capacitor(capacitor) => states.push(CapacitorState {
                 name: capacitor.name.clone(),
                 previous_voltage: capacitor.initial_voltage,
                 previous_previous_voltage: capacitor.initial_voltage,
@@ -21101,17 +21225,32 @@ fn initial_capacitor_states(
                 time_step,
                 method,
             }),
-            Element::Diode(diode) if diode_has_charge_storage(diode) => Some(CapacitorState {
-                name: diode_charge_state_name(diode),
-                previous_voltage: 0.0,
-                previous_previous_voltage: 0.0,
-                previous_current: 0.0,
-                time_step,
-                method,
-            }),
-            _ => None,
-        })
-        .collect()
+            Element::Diode(diode) if diode_has_charge_storage(diode) => {
+                states.push(CapacitorState {
+                    name: diode_charge_state_name(diode),
+                    previous_voltage: 0.0,
+                    previous_previous_voltage: 0.0,
+                    previous_current: 0.0,
+                    time_step,
+                    method,
+                });
+            }
+            Element::Bjt(bjt) => {
+                for spec in bjt_charge_state_specs(bjt) {
+                    states.push(CapacitorState {
+                        name: spec.name,
+                        previous_voltage: 0.0,
+                        previous_previous_voltage: 0.0,
+                        previous_current: 0.0,
+                        time_step,
+                        method,
+                    });
+                }
+            }
+            _ => {}
+        }
+    }
+    states
 }
 
 fn initial_inductor_states(
@@ -21166,21 +21305,34 @@ fn capacitor_voltages(
     circuit: &Circuit,
     node_voltages: &BTreeMap<String, f64>,
 ) -> BTreeMap<String, f64> {
-    circuit
-        .elements()
-        .iter()
-        .filter_map(|element| match element {
-            Element::Capacitor(capacitor) => Some((
-                capacitor.name.clone(),
-                voltage_at(node_voltages, &capacitor.n1) - voltage_at(node_voltages, &capacitor.n2),
-            )),
-            Element::Diode(diode) if diode_has_charge_storage(diode) => Some((
-                diode_charge_state_name(diode),
-                diode_charge_voltage(diode, node_voltages),
-            )),
-            _ => None,
-        })
-        .collect()
+    let mut voltages = BTreeMap::new();
+    for element in circuit.elements() {
+        match element {
+            Element::Capacitor(capacitor) => {
+                voltages.insert(
+                    capacitor.name.clone(),
+                    voltage_at(node_voltages, &capacitor.n1)
+                        - voltage_at(node_voltages, &capacitor.n2),
+                );
+            }
+            Element::Diode(diode) if diode_has_charge_storage(diode) => {
+                voltages.insert(
+                    diode_charge_state_name(diode),
+                    diode_charge_voltage(diode, node_voltages),
+                );
+            }
+            Element::Bjt(bjt) => {
+                for spec in bjt_charge_state_specs(bjt) {
+                    voltages.insert(
+                        spec.name.clone(),
+                        bjt_charge_state_voltage(&spec, node_voltages),
+                    );
+                }
+            }
+            _ => {}
+        }
+    }
+    voltages
 }
 
 fn transient_lte_estimate(
@@ -21189,10 +21341,9 @@ fn transient_lte_estimate(
     previous_voltages: &BTreeMap<String, f64>,
     previous_previous_voltages: &BTreeMap<String, f64>,
 ) -> f64 {
-    circuit
-        .elements()
-        .iter()
-        .filter_map(|element| match element {
+    let mut max_lte = 0.0_f64;
+    for element in circuit.elements() {
+        match element {
             Element::Capacitor(capacitor) => {
                 let current = current_voltages
                     .get(&capacitor.name)
@@ -21206,7 +21357,7 @@ fn transient_lte_estimate(
                     .get(&capacitor.name)
                     .copied()
                     .unwrap_or(capacitor.initial_voltage);
-                Some((current - 2.0 * previous + previous_previous).abs() / 2.0)
+                max_lte = max_lte.max((current - 2.0 * previous + previous_previous).abs() / 2.0);
             }
             Element::Diode(diode) if diode_has_charge_storage(diode) => {
                 let state_name = diode_charge_state_name(diode);
@@ -21216,11 +21367,24 @@ fn transient_lte_estimate(
                     .get(&state_name)
                     .copied()
                     .unwrap_or(0.0);
-                Some((current - 2.0 * previous + previous_previous).abs() / 2.0)
+                max_lte = max_lte.max((current - 2.0 * previous + previous_previous).abs() / 2.0);
             }
-            _ => None,
-        })
-        .fold(0.0, f64::max)
+            Element::Bjt(bjt) => {
+                for spec in bjt_charge_state_specs(bjt) {
+                    let current = current_voltages.get(&spec.name).copied().unwrap_or(0.0);
+                    let previous = previous_voltages.get(&spec.name).copied().unwrap_or(0.0);
+                    let previous_previous = previous_previous_voltages
+                        .get(&spec.name)
+                        .copied()
+                        .unwrap_or(0.0);
+                    max_lte =
+                        max_lte.max((current - 2.0 * previous + previous_previous).abs() / 2.0);
+                }
+            }
+            _ => {}
+        }
+    }
+    max_lte
 }
 
 fn initial_transmission_line_states(circuit: &Circuit) -> Vec<TransmissionLineState> {
@@ -21402,6 +21566,15 @@ fn update_capacitor_states(
                 diode_charge_voltage(diode, node_voltages),
                 diode_dynamic_capacitance(diode, state.previous_voltage),
             )),
+            Element::Bjt(bjt) => bjt_charge_state_specs(bjt)
+                .into_iter()
+                .find(|spec| spec.name == state.name)
+                .map(|spec| {
+                    (
+                        bjt_charge_state_voltage(&spec, node_voltages),
+                        bjt_charge_dynamic_capacitance(bjt, spec.kind, state.previous_voltage),
+                    )
+                }),
             _ => None,
         });
         let Some((voltage, capacitance)) = update else {
@@ -21426,24 +21599,39 @@ fn update_capacitor_states(
     }
 }
 
-fn seed_diode_capacitor_states(
+fn seed_device_capacitor_states(
     circuit: &Circuit,
     node_voltages: &BTreeMap<String, f64>,
     capacitor_states: &mut [CapacitorState],
 ) {
     for element in circuit.elements() {
-        let Element::Diode(diode) = element else {
-            continue;
-        };
-        let state_name = diode_charge_state_name(diode);
-        if let Some(state) = capacitor_states
-            .iter_mut()
-            .find(|state| state.name == state_name)
-        {
-            let voltage = diode_charge_voltage(diode, node_voltages);
-            state.previous_voltage = voltage;
-            state.previous_previous_voltage = voltage;
-            state.previous_current = 0.0;
+        match element {
+            Element::Diode(diode) => {
+                let state_name = diode_charge_state_name(diode);
+                if let Some(state) = capacitor_states
+                    .iter_mut()
+                    .find(|state| state.name == state_name)
+                {
+                    let voltage = diode_charge_voltage(diode, node_voltages);
+                    state.previous_voltage = voltage;
+                    state.previous_previous_voltage = voltage;
+                    state.previous_current = 0.0;
+                }
+            }
+            Element::Bjt(bjt) => {
+                for spec in bjt_charge_state_specs(bjt) {
+                    if let Some(state) = capacitor_states
+                        .iter_mut()
+                        .find(|state| state.name == spec.name)
+                    {
+                        let voltage = bjt_charge_state_voltage(&spec, node_voltages);
+                        state.previous_voltage = voltage;
+                        state.previous_previous_voltage = voltage;
+                        state.previous_current = 0.0;
+                    }
+                }
+            }
+            _ => {}
         }
     }
 }

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -36,17 +36,17 @@ use spice_engine::{
     transient_adaptive_corners, transient_adaptive_with_digital_event_streams,
     transient_adaptive_with_digital_event_streams_corners, transient_corners,
     transient_with_digital_event_streams, transient_with_digital_event_streams_corners,
-    transient_with_method, AdaptiveTransientOptions, AdaptiveTransientResult, Capacitor, Cccs,
-    Ccvs, Circuit, CornerDistortionPoint, CornerDistortionResult, CornerOverride, CornerSpec,
-    CurrentSource, DeckAnalysisExecution, DeckAnalysisExecutionResult, DigitalBridgeSchedule,
-    DigitalEvent, DigitalEventStream, DigitalLogicLevels, DigitalState, DigitalThresholds, Diode,
-    DistortionHarmonic, DistortionPoint, DistortionResult, Element, ExpWaveform, FourierHarmonic,
-    FourierProbeResult, FourierResult, Inductor, Jfet, JfetPolarity, MutualInductor, PoleZeroEntry,
-    PoleZeroEntryKind, PoleZeroResult, PoleZeroTopology, PssNewtonCandidateResult,
-    PssNewtonIterationResult, PssNewtonSolveResult, PssNewtonUpdateResult,
-    PssResidualJacobianResult, PssResidualResult, PssResult, PulseWaveform, PwlWaveform, Resistor,
-    SinWaveform, SpiceError, TransientMethod, TransientPoint, TransmissionLine, VoltageSource,
-    Waveform,
+    transient_with_method, AdaptiveTransientOptions, AdaptiveTransientResult, Bjt, BjtPolarity,
+    Capacitor, Cccs, Ccvs, Circuit, CornerDistortionPoint, CornerDistortionResult, CornerOverride,
+    CornerSpec, CurrentSource, DeckAnalysisExecution, DeckAnalysisExecutionResult,
+    DigitalBridgeSchedule, DigitalEvent, DigitalEventStream, DigitalLogicLevels, DigitalState,
+    DigitalThresholds, Diode, DistortionHarmonic, DistortionPoint, DistortionResult, Element,
+    ExpWaveform, FourierHarmonic, FourierProbeResult, FourierResult, Inductor, Jfet, JfetPolarity,
+    MutualInductor, PoleZeroEntry, PoleZeroEntryKind, PoleZeroResult, PoleZeroTopology,
+    PssNewtonCandidateResult, PssNewtonIterationResult, PssNewtonSolveResult,
+    PssNewtonUpdateResult, PssResidualJacobianResult, PssResidualResult, PssResult, PulseWaveform,
+    PwlWaveform, Resistor, SinWaveform, SpiceError, TransientMethod, TransientPoint,
+    TransmissionLine, VoltageSource, Waveform,
 };
 
 fn assert_close(actual: f64, expected: f64) {
@@ -268,6 +268,114 @@ fn transient_diode_transit_time_holds_forward_charge_on_turnoff() {
     assert_close(no_storage_first, 0.0);
     assert!(stored_first > 0.6);
     assert!(stored_last < stored_first);
+}
+
+#[test]
+fn transient_bjt_base_emitter_capacitance_slows_base_current_step() {
+    fn run(base_emitter_capacitance: f64) -> Vec<TransientPoint> {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::new(
+            "Vcc",
+            "collector",
+            "0",
+            5.0,
+        )));
+        circuit.add(Element::CurrentSource(CurrentSource::with_waveform(
+            "Istep",
+            "0",
+            "base",
+            0.0,
+            Waveform::Pwl(PwlWaveform::new(vec![
+                (0.0, 0.0),
+                (1.0e-9, 1.0e-6),
+                (5.0e-9, 1.0e-6),
+            ])),
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rshunt", "base", "0", 1.0e12,
+        )));
+        circuit.add(Element::Bjt(Bjt::with_model(
+            "Q1",
+            "collector",
+            "base",
+            "0",
+            BjtPolarity::Npn,
+            1.0e-15,
+            100.0,
+            0.02585,
+            base_emitter_capacitance,
+            0.0,
+            0.0,
+            0.0,
+        )));
+        transient(&circuit, 1.0e-9, 5.0e-9).unwrap()
+    }
+
+    let uncharged = run(0.0);
+    let charged = run(1.0e-12);
+    let uncharged_first = uncharged[0].voltage("base").unwrap();
+    let charged_first = charged[0].voltage("base").unwrap();
+
+    assert!(uncharged_first > 0.5);
+    assert!(charged_first < 0.01);
+    assert!(charged_first < uncharged_first);
+}
+
+#[test]
+fn transient_bjt_forward_transit_time_holds_base_charge_on_turnoff() {
+    fn run(forward_transit_time: f64) -> Vec<TransientPoint> {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::new(
+            "Vcc",
+            "collector",
+            "0",
+            5.0,
+        )));
+        circuit.add(Element::CurrentSource(CurrentSource::with_waveform(
+            "Istep",
+            "0",
+            "base",
+            0.0,
+            Waveform::Pwl(PwlWaveform::new(vec![
+                (0.0, 1.0e-3),
+                (1.0e-9, 0.0),
+                (5.0e-9, 0.0),
+            ])),
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rshunt", "base", "0", 1.0e12,
+        )));
+        circuit.add(Element::Bjt(Bjt::with_model(
+            "Q1",
+            "collector",
+            "base",
+            "0",
+            BjtPolarity::Npn,
+            1.0e-15,
+            100.0,
+            0.02585,
+            0.0,
+            0.0,
+            forward_transit_time,
+            0.0,
+        )));
+        transient(&circuit, 1.0e-9, 5.0e-9).unwrap()
+    }
+
+    let no_storage = run(0.0);
+    let stored = run(1.0e-9);
+    let no_storage_first = no_storage[0].voltage("base").unwrap();
+    let stored_first = stored[0].voltage("base").unwrap();
+
+    assert_close(no_storage_first, 0.0);
+    assert!(stored_first > 0.6);
+    assert!(
+        stored
+            .last()
+            .and_then(|point| point.voltage("base"))
+            .unwrap()
+            < stored_first
+    );
 }
 
 #[test]

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Stamp BJT `baseEmitterCapacitance`, `baseCollectorCapacitance`,
+  `forwardTransitTime`, and `reverseTransitTime` model-card storage as
+  transient base-emitter and base-collector companions, matching Python and
+  Rust, with regression coverage for base current-step delay and forward
+  transit-time turnoff charge.
 - Stamp diode `junctionCapacitance` and `transitTime` model-card storage as
   transient anode-cathode companions, matching Python and Rust, with regression
   coverage for current-step delay and turnoff charge retention.

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -202,9 +202,10 @@ and Level-1 MOS channel thermal noise audits.
 `deviceModelChargeAuditFixtures` adds matching `.tran` reference-deck metadata,
 explicit terminal storage capacitance metadata, stable first/final
 probe-voltage windows, and charge-behavior notes for diode, BJT, JFET, and
-Level-1 MOS charge audits. Diode `junctionCapacitance` and `transitTime`
-model-card parameters also stamp transient anode-cathode storage, matching
-their small-signal AC capacitance semantics.
+Level-1 MOS charge audits. Diode `junctionCapacitance` / `transitTime` and BJT
+`baseEmitterCapacitance` / `baseCollectorCapacitance` / `forwardTransitTime` /
+`reverseTransitTime` model-card parameters also stamp transient storage,
+matching their small-signal AC capacitance semantics.
 
 `CustomModel`, `CustomModelEvaluation`, `customLinearConductanceModel`, and
 `analyzeCustomModelSource` provide the first native-web custom-model foothold.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -7663,7 +7663,7 @@ export function deviceModelChargeAuditFixtures(): readonly DeviceModelChargeBeha
       expectedFinalMin: 0.10,
       expectedFinalMax: 0.14,
       chargeBehavior:
-        "BJT terminal charge is conserved through explicit Cstore; CJE/CJC/TF/TR remain AC-only until nonlinear charge stamping lands",
+        "BJT CJE/CJC/TF/TR contribute transient base-emitter and base-collector storage; explicit Cstore keeps the fixture comparable with other charge audits",
       deckLines: [
         "* device-model charge fixture: bjt-storage-charge",
         ".model Qsmall NPN(BF=125 CJE=2e-12 TF=1e-10)",
@@ -12816,7 +12816,7 @@ export function transient(
     inductorStates,
     0.0,
   );
-  seedDiodeCapacitorStates(circuit, initialSolution.nodeVoltages, capacitorStates);
+  seedDeviceCapacitorStates(circuit, initialSolution.nodeVoltages, capacitorStates);
   updateTransmissionLineStates(circuit, initialSolution.nodeVoltages, lineStates, 0.0);
   const points: TransientPoint[] = [];
   for (let time = timeStep; time <= stopTime + timeStep * 1.0e-9; time += timeStep) {
@@ -13120,7 +13120,7 @@ export function transientAdaptive(
     inductorStates,
     0.0,
   );
-  seedDiodeCapacitorStates(circuit, initialSolution.nodeVoltages, capacitorStates);
+  seedDeviceCapacitorStates(circuit, initialSolution.nodeVoltages, capacitorStates);
   updateTransmissionLineStates(circuit, initialSolution.nodeVoltages, lineStates, 0.0);
 
   const points: TransientPoint[] = [];
@@ -15498,7 +15498,7 @@ function solveLinearCircuitAtOperatingPoint(
         stampJfet(element, nodeIndices, matrix, rhs, operatingPoint);
         break;
       case "bjt":
-        stampBjt(element, nodeIndices, matrix, rhs, operatingPoint);
+        stampBjt(element, capacitorStates, nodeIndices, matrix, rhs, operatingPoint);
         break;
       case "mosfet":
         stampMosfet(element, nodeIndices, matrix, rhs, operatingPoint);
@@ -16768,6 +16768,7 @@ function stampDiodeCharge(
 
 function stampBjt(
   element: Bjt,
+  capacitorStates: readonly CapacitorState[],
   nodeIndices: ReadonlyMap<string, number>,
   matrix: number[][],
   rhs: number[],
@@ -16805,6 +16806,49 @@ function stampBjt(
     stampTransconductance(matrix, emitter, collector, emitter, base, transconductance);
     stampCurrentSourceEquivalent(rhs, emitter, base, equivalentBaseCurrent);
     stampCurrentSourceEquivalent(rhs, emitter, collector, equivalentCollectorCurrent);
+  }
+  stampBjtCharge(element, capacitorStates, nodeIndices, matrix, rhs);
+}
+
+function stampBjtCharge(
+  element: Bjt,
+  capacitorStates: readonly CapacitorState[],
+  nodeIndices: ReadonlyMap<string, number>,
+  matrix: number[][],
+  rhs: number[],
+): void {
+  for (const spec of bjtChargeStateSpecs(element)) {
+    const state = capacitorStates.find((candidate) => candidate.name === spec.name);
+    if (state === undefined) {
+      continue;
+    }
+    const capacitance = bjtChargeDynamicCapacitance(element, spec.kind, state.previousVoltage);
+    if (capacitance <= 0.0) {
+      continue;
+    }
+    const conductance =
+      state.method === "trap"
+        ? (2.0 * capacitance) / state.timeStep
+        : state.method === "gear2"
+          ? (3.0 * capacitance) / (2.0 * state.timeStep)
+          : capacitance / state.timeStep;
+    const historyCurrent =
+      state.method === "trap"
+        ? conductance * state.previousVoltage + state.previousCurrent
+        : state.method === "gear2"
+          ? capacitance *
+            (4.0 * state.previousVoltage - state.previousPreviousVoltage) /
+            (2.0 * state.timeStep)
+          : conductance * state.previousVoltage;
+    const positive = nodeIndex(nodeIndices, spec.positive);
+    const negative = nodeIndex(nodeIndices, spec.negative);
+    stampConductance(matrix, positive, negative, conductance);
+    if (positive !== undefined) {
+      rhs[positive] += historyCurrent;
+    }
+    if (negative !== undefined) {
+      rhs[negative] -= historyCurrent;
+    }
   }
 }
 
@@ -17127,6 +17171,76 @@ function diodeChargeVoltage(element: Diode, nodeVoltages: ReadonlyMap<string, nu
   return voltageAt(nodeVoltages, element.anode) - voltageAt(nodeVoltages, element.cathode);
 }
 
+type BjtChargeStateKind = "base-emitter" | "base-collector";
+
+interface BjtChargeStateSpec {
+  readonly name: string;
+  readonly positive: string;
+  readonly negative: string;
+  readonly kind: BjtChargeStateKind;
+}
+
+function bjtBaseEmitterChargeStateName(element: Bjt): string {
+  return `_Q_${element.name}_be_charge`;
+}
+
+function bjtBaseCollectorChargeStateName(element: Bjt): string {
+  return `_Q_${element.name}_bc_charge`;
+}
+
+function bjtJunctionTransconductance(element: Bjt, voltage: number): number {
+  const exponent = Math.max(-40.0, Math.min(40.0, voltage / element.thermalVoltage));
+  return (element.saturationCurrent / element.thermalVoltage) * Math.exp(exponent);
+}
+
+function bjtChargeDynamicCapacitance(
+  element: Bjt,
+  kind: BjtChargeStateKind,
+  voltage: number,
+): number {
+  const conductance = bjtJunctionTransconductance(element, voltage);
+  if (kind === "base-emitter") {
+    return element.baseEmitterCapacitance + element.forwardTransitTime * conductance;
+  }
+  return element.baseCollectorCapacitance + element.reverseTransitTime * conductance;
+}
+
+function bjtChargeStateSpecs(element: Bjt): BjtChargeStateSpec[] {
+  const specs: BjtChargeStateSpec[] = [];
+  if (element.baseEmitterCapacitance > 0.0 || element.forwardTransitTime > 0.0) {
+    const [positive, negative] =
+      element.polarity === "NPN"
+        ? [element.base, element.emitter]
+        : [element.emitter, element.base];
+    specs.push({
+      name: bjtBaseEmitterChargeStateName(element),
+      positive,
+      negative,
+      kind: "base-emitter",
+    });
+  }
+  if (element.baseCollectorCapacitance > 0.0 || element.reverseTransitTime > 0.0) {
+    const [positive, negative] =
+      element.polarity === "NPN"
+        ? [element.base, element.collector]
+        : [element.collector, element.base];
+    specs.push({
+      name: bjtBaseCollectorChargeStateName(element),
+      positive,
+      negative,
+      kind: "base-collector",
+    });
+  }
+  return specs;
+}
+
+function bjtChargeStateVoltage(
+  spec: BjtChargeStateSpec,
+  nodeVoltages: ReadonlyMap<string, number>,
+): number {
+  return voltageAt(nodeVoltages, spec.positive) - voltageAt(nodeVoltages, spec.negative);
+}
+
 function validateBjt(element: Bjt): void {
   if (element.polarity !== "NPN" && element.polarity !== "PNP") {
     throw invalidElement(element.name, "BJT polarity must be NPN or PNP");
@@ -17230,6 +17344,17 @@ function initialCapacitorStates(
         timeStep,
         method,
       });
+    } else if (element.kind === "bjt") {
+      for (const spec of bjtChargeStateSpecs(element)) {
+        states.push({
+          name: spec.name,
+          previousVoltage: 0.0,
+          previousPreviousVoltage: 0.0,
+          previousCurrent: 0.0,
+          timeStep,
+          method,
+        });
+      }
     }
   }
   return states;
@@ -17295,6 +17420,10 @@ function capacitorVoltages(
       );
     } else if (element.kind === "diode" && diodeHasChargeStorage(element)) {
       voltages.set(diodeChargeStateName(element), diodeChargeVoltage(element, nodeVoltages));
+    } else if (element.kind === "bjt") {
+      for (const spec of bjtChargeStateSpecs(element)) {
+        voltages.set(spec.name, bjtChargeStateVoltage(spec, nodeVoltages));
+      }
     }
   }
   return voltages;
@@ -17315,6 +17444,13 @@ function transientLteEstimate(
         const previous = previousVoltages.get(stateName) ?? 0.0;
         const previousPrevious = previousPreviousVoltages.get(stateName) ?? 0.0;
         maxLte = Math.max(maxLte, Math.abs(current - 2.0 * previous + previousPrevious) / 2.0);
+      } else if (element.kind === "bjt") {
+        for (const spec of bjtChargeStateSpecs(element)) {
+          const current = currentVoltages.get(spec.name) ?? 0.0;
+          const previous = previousVoltages.get(spec.name) ?? 0.0;
+          const previousPrevious = previousPreviousVoltages.get(spec.name) ?? 0.0;
+          maxLte = Math.max(maxLte, Math.abs(current - 2.0 * previous + previousPrevious) / 2.0);
+        }
       }
       continue;
     }
@@ -17479,7 +17615,21 @@ function updateCapacitorStates(
                 candidate.kind === "diode" && diodeChargeStateName(candidate) === state.name,
             )
         : undefined;
-    if (capacitorElement === undefined && diodeElement === undefined) {
+    const bjtElement =
+      capacitorElement === undefined && diodeElement === undefined
+        ? circuit
+            .elements()
+            .find(
+              (candidate): candidate is Bjt =>
+                candidate.kind === "bjt" &&
+                bjtChargeStateSpecs(candidate).some((spec) => spec.name === state.name),
+            )
+        : undefined;
+    const bjtSpec =
+      bjtElement === undefined
+        ? undefined
+        : bjtChargeStateSpecs(bjtElement).find((spec) => spec.name === state.name);
+    if (capacitorElement === undefined && diodeElement === undefined && bjtSpec === undefined) {
       continue;
     }
     const previousVoltage = state.previousVoltage;
@@ -17487,11 +17637,15 @@ function updateCapacitorStates(
     const voltage =
       capacitorElement !== undefined
         ? voltageAt(nodeVoltages, capacitorElement.n1) - voltageAt(nodeVoltages, capacitorElement.n2)
-        : diodeChargeVoltage(diodeElement!, nodeVoltages);
+        : diodeElement !== undefined
+          ? diodeChargeVoltage(diodeElement, nodeVoltages)
+          : bjtChargeStateVoltage(bjtSpec!, nodeVoltages);
     const capacitance =
       capacitorElement !== undefined
         ? capacitorElement.capacitanceFarads
-        : diodeDynamicCapacitance(diodeElement!, previousVoltage);
+        : diodeElement !== undefined
+          ? diodeDynamicCapacitance(diodeElement, previousVoltage)
+          : bjtChargeDynamicCapacitance(bjtElement!, bjtSpec!.kind, previousVoltage);
     if (state.method === "trap") {
       const conductance = (2.0 * capacitance) / state.timeStep;
       state.previousCurrent = conductance * (voltage - previousVoltage) - previousCurrent;
@@ -17509,25 +17663,35 @@ function updateCapacitorStates(
   }
 }
 
-function seedDiodeCapacitorStates(
+function seedDeviceCapacitorStates(
   circuit: Circuit,
   nodeVoltages: ReadonlyMap<string, number>,
   capacitorStates: CapacitorState[],
 ): void {
   for (const element of circuit.elements()) {
-    if (element.kind !== "diode") {
-      continue;
+    if (element.kind === "diode") {
+      const state = capacitorStates.find(
+        (candidate) => candidate.name === diodeChargeStateName(element),
+      );
+      if (state === undefined) {
+        continue;
+      }
+      const voltage = diodeChargeVoltage(element, nodeVoltages);
+      state.previousVoltage = voltage;
+      state.previousPreviousVoltage = voltage;
+      state.previousCurrent = 0.0;
+    } else if (element.kind === "bjt") {
+      for (const spec of bjtChargeStateSpecs(element)) {
+        const state = capacitorStates.find((candidate) => candidate.name === spec.name);
+        if (state === undefined) {
+          continue;
+        }
+        const voltage = bjtChargeStateVoltage(spec, nodeVoltages);
+        state.previousVoltage = voltage;
+        state.previousPreviousVoltage = voltage;
+        state.previousCurrent = 0.0;
+      }
     }
-    const state = capacitorStates.find(
-      (candidate) => candidate.name === diodeChargeStateName(element),
-    );
-    if (state === undefined) {
-      continue;
-    }
-    const voltage = diodeChargeVoltage(element, nodeVoltages);
-    state.previousVoltage = voltage;
-    state.previousPreviousVoltage = voltage;
-    state.previousCurrent = 0.0;
   }
 }
 

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -16,6 +16,7 @@ import {
   SpiceError,
   capacitor,
   capacitorWithInitialVoltage,
+  bjt,
   cccs,
   ccvs,
   currentSource,
@@ -265,6 +266,84 @@ describe("transient", () => {
     expectClose(noStorage[0].voltage("out"), 0.0);
     expect(stored[0].voltage("out")!).toBeGreaterThan(0.6);
     expect(stored[stored.length - 1].voltage("out")!).toBeLessThan(stored[0].voltage("out")!);
+  });
+
+  it("uses BJT base-emitter capacitance during transient base current steps", () => {
+    function run(baseEmitterCapacitance: number): TransientPoint[] {
+      const circuit = new Circuit();
+      circuit.add(voltageSource("Vcc", "collector", "0", 5.0));
+      circuit.add(currentSourceWithWaveform(
+        "Istep",
+        "0",
+        "base",
+        0.0,
+        new PwlWaveform([
+          [0.0, 0.0],
+          [1.0e-9, 1.0e-6],
+          [5.0e-9, 1.0e-6],
+        ]),
+      ));
+      circuit.add(resistor("Rshunt", "base", "0", 1.0e12));
+      circuit.add(bjt(
+        "Q1",
+        "collector",
+        "base",
+        "0",
+        "NPN",
+        1.0e-15,
+        100.0,
+        0.02585,
+        baseEmitterCapacitance,
+      ));
+      return transient(circuit, 1.0e-9, 5.0e-9);
+    }
+
+    const unchargedFirst = run(0.0)[0].voltage("base");
+    const chargedFirst = run(1.0e-12)[0].voltage("base");
+    expect(unchargedFirst).not.toBeUndefined();
+    expect(chargedFirst).not.toBeUndefined();
+    expect(unchargedFirst!).toBeGreaterThan(0.5);
+    expect(chargedFirst!).toBeLessThan(0.01);
+    expect(chargedFirst!).toBeLessThan(unchargedFirst!);
+  });
+
+  it("uses BJT forward transit time to hold base charge on turnoff", () => {
+    function run(forwardTransitTime: number): TransientPoint[] {
+      const circuit = new Circuit();
+      circuit.add(voltageSource("Vcc", "collector", "0", 5.0));
+      circuit.add(currentSourceWithWaveform(
+        "Istep",
+        "0",
+        "base",
+        0.0,
+        new PwlWaveform([
+          [0.0, 1.0e-3],
+          [1.0e-9, 0.0],
+          [5.0e-9, 0.0],
+        ]),
+      ));
+      circuit.add(resistor("Rshunt", "base", "0", 1.0e12));
+      circuit.add(bjt(
+        "Q1",
+        "collector",
+        "base",
+        "0",
+        "NPN",
+        1.0e-15,
+        100.0,
+        0.02585,
+        0.0,
+        0.0,
+        forwardTransitTime,
+      ));
+      return transient(circuit, 1.0e-9, 5.0e-9);
+    }
+
+    const noStorage = run(0.0);
+    const stored = run(1.0e-9);
+    expectClose(noStorage[0].voltage("base"), 0.0);
+    expect(stored[0].voltage("base")!).toBeGreaterThan(0.6);
+    expect(stored[stored.length - 1].voltage("base")!).toBeLessThan(stored[0].voltage("base")!);
   });
 
   it("reports periods for periodic source waveforms", () => {

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -15,19 +15,21 @@ downstream tools to compare.
 
 ## Current PR Slice
 
-1. Diode model-card transient charge stamping.
+1. BJT model-card transient charge stamping.
    - Status: current PR completion candidate.
-   - Python, Rust, and TypeScript transient solvers now stamp diode
-     model-card `CJO` / `junction_capacitance` / `junctionCapacitance` and
-     `TT` / `transit_time` / `transitTime` as an anode-cathode storage
-     companion.
-   - The transient companion uses the previous diode bias to derive
-     `C = Cjo + Tt * gd`, reuses the existing Euler/trapezoidal/Gear-2
-     capacitor history policy, and seeds the synthetic diode charge state from
-     the initial operating point.
-   - Cross-language tests cover both junction-capacitance current-step delay
-     and transit-time forward-charge retention after turnoff.
-   - BJT, JFET, and Level-1 MOS charge storage remain audited through explicit
+   - Python, Rust, and TypeScript transient solvers now stamp BJT model-card
+     `CJE` / `base_emitter_capacitance` / `baseEmitterCapacitance`,
+     `CJC` / `base_collector_capacitance` / `baseCollectorCapacitance`,
+     `TF` / `forward_transit_time` / `forwardTransitTime`, and
+     `TR` / `reverse_transit_time` / `reverseTransitTime` as base-emitter and
+     base-collector storage companions.
+   - The companions use the previous junction bias to derive
+     `Cbe = Cje + Tf * gm_forward` and `Cbc = Cjc + Tr * gm_reverse`, reuse the
+     existing Euler/trapezoidal/Gear-2 capacitor history policy, and seed the
+     synthetic BJT charge states from the initial operating point.
+   - Cross-language tests cover base-emitter capacitance current-step delay and
+     forward transit-time charge retention after turnoff.
+   - JFET and Level-1 MOS charge storage remain audited through explicit
      terminal storage capacitors until their nonlinear charge policies land.
 
 ## Completed Slices
@@ -1221,11 +1223,25 @@ downstream tools to compare.
      `.tran` reference deck lines, selected probe node, timestep, stoptime,
      explicit terminal storage capacitance, stable first/final probe-voltage
      windows, and a short charge-behavior note.
-   - The fixtures deliberately audit charge storage through explicit terminal
-     capacitors, recording that BJT, JFET, and MOS model-card charge remains
-     explicit-storage-only until nonlinear transient charge policies land.
+   - The fixtures deliberately keep explicit terminal capacitors for comparable
+     probe windows while recording which model-card charge terms are
+     transient-stamped and which JFET/MOS charge policies remain
+     explicit-storage-only.
    - Cross-language tests execute every fixture through transient solving and
      verify the probe windows plus reference-deck metadata.
+
+121. Diode model-card transient charge stamping.
+   - Status: completed in PR 6798.
+   - Python, Rust, and TypeScript transient solvers now stamp diode
+     model-card `CJO` / `junction_capacitance` / `junctionCapacitance` and
+     `TT` / `transit_time` / `transitTime` as an anode-cathode storage
+     companion.
+   - The transient companion uses the previous diode bias to derive
+     `C = Cjo + Tt * gd`, reuses the existing Euler/trapezoidal/Gear-2
+     capacitor history policy, and seeds the synthetic diode charge state from
+     the initial operating point.
+   - Cross-language tests cover both junction-capacitance current-step delay
+     and transit-time forward-charge retention after turnoff.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- stamp BJT model-card CJE/CJC/TF/TR as transient base-emitter/base-collector charge companions across Python, Rust, and TypeScript
- add cross-language transient regressions for base-emitter capacitance current-step delay and forward transit-time turnoff charge
- refresh SPICE plan, READMEs, changelogs, and charge audit fixture notes for the new BJT transient storage support

## Verification
- PYTHONPATH=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-spice-bjt-transient-charge-stamping/code/packages/python/spice-engine/src:/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-spice-bjt-transient-charge-stamping/code/packages/python/mosfet-models/src:/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-spice-bjt-transient-charge-stamping/code/packages/python/device-physics/src /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python -m pytest -o addopts='' code/packages/python/spice-engine/tests/test_engine.py -q
- cargo test -p spice-engine
- npm run build && npm test