### PR TITLE
[codex] prove BASIC string equality concat

### DIFF
--- a/code/packages/rust/dartmouth-basic-iir-compiler/CHANGELOG.md
+++ b/code/packages/rust/dartmouth-basic-iir-compiler/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog — `dartmouth-basic-iir-compiler`
 
+## 0.30.0 — 2026-06-28 — BA4 variable-variable string concat in IF equality
+
+String `IF` now has an explicit unit and matrix proof for a concatenation
+expression whose operands are both scalar string variables and whose result
+feeds the standard `=` relop:
+
+```basic
+10 LET A$ = "O"
+20 LET B$ = "K"
+30 IF A$ + B$ = "OK" THEN 60
+40 PRINT "BAD"
+50 END
+60 PRINT "OK"
+70 END
+```
+
+The compiler still lowers through E4 `str_concat` plus `str_eq`; the equality
+path branches with `jmp_if_true`, proving the true-equality branch for a
+variable-variable string expression without adding a new string-compare opcode.
+
 ## 0.29.0 — 2026-06-27 — BA4 variable-variable string concat in IF inequality
 
 String `IF` now has an explicit unit and matrix proof for a concatenation

--- a/code/packages/rust/dartmouth-basic-iir-compiler/Cargo.toml
+++ b/code/packages/rust/dartmouth-basic-iir-compiler/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "dartmouth-basic-iir-compiler"
-version = "0.29.0"
+version = "0.30.0"
 edition = "2021"
-description = "Dartmouth BASIC frontend for the LANG VM AOT chain — lowers parsed BASIC into interpreter_ir::IIRModule. v0.29.0 proves variable-variable string concat in IF inequality on all seven backends; v0.28.0 proved variable-variable string concat in PRINT."
+description = "Dartmouth BASIC frontend for the LANG VM AOT chain — lowers parsed BASIC into interpreter_ir::IIRModule. v0.30.0 proves variable-variable string concat in IF equality on all seven backends; v0.29.0 proved variable-variable string concat in IF inequality."
 
 [dependencies]
 coding-adventures-dartmouth-basic-parser = { path = "../dartmouth-basic-parser" }

--- a/code/packages/rust/dartmouth-basic-iir-compiler/README.md
+++ b/code/packages/rust/dartmouth-basic-iir-compiler/README.md
@@ -60,8 +60,9 @@ without numeric formatting helpers, and comma-separated string printing
 `PRINT A$ + "K"` also consumes a temporary E4 `str_concat` result directly, and
 `PRINT A$ + B$` proves both concat operands can be scalar string slots in that
 direct-print path. `IF A$ + "K" = "OK" THEN ...` feeds the same expression path
-into `str_eq` line-control branching, and `IF A$ + B$ <> "NO"` proves
-variable-variable concat on the inequality branch path. `LET B$ = A$ + "K"; PRINT B$` stores the variable-backed
+into `str_eq` line-control branching, `IF A$ + B$ = "OK"` proves
+variable-variable concat on the equality branch path, and
+`IF A$ + B$ <> "NO"` proves the sibling inequality branch path. `LET B$ = A$ + "K"; PRINT B$` stores the variable-backed
 concat directly into another scalar string slot, and
 `LET B$ = A$ + "B" + "C"; PRINT B$` proves chained left-associative concat
 through repeated E4 `str_concat`. Richer dynamic string storage, string arrays,

--- a/code/packages/rust/dartmouth-basic-iir-compiler/src/lib.rs
+++ b/code/packages/rust/dartmouth-basic-iir-compiler/src/lib.rs
@@ -2786,6 +2786,35 @@ mod tests {
     }
 
     #[test]
+    fn compiles_string_variable_concat_if_expression_equality() {
+        let src = "10 LET A$ = \"O\"\n\
+                   20 LET B$ = \"K\"\n\
+                   30 IF A$ + B$ = \"OK\" THEN 60\n\
+                   40 PRINT \"BAD\"\n\
+                   50 END\n\
+                   60 PRINT \"OK\"\n\
+                   70 END\n";
+        let m = compile(src).expect("ok");
+        let body = &m.functions[0].instructions;
+        let concat_dest = body.iter()
+            .find(|i| i.op == "str_concat"
+                && matches!(i.srcs.as_slice(), [
+                    Operand::Var(left),
+                    Operand::Var(right)
+                ] if left == "__basic_str_A" && right == "__basic_str_B"))
+            .and_then(|i| i.dest.as_deref())
+            .expect("IF A$ + B$ should lower through str_concat");
+        assert!(body.iter().any(|i| i.op == "str_eq"
+            && matches!(i.srcs.as_slice(), [
+                Operand::Var(left),
+                Operand::Var(_right)
+            ] if left == concat_dest)),
+            "string expression equality should compare the concat temp");
+        assert!(body.iter().any(|i| i.op == "jmp_if_true"),
+            "string expression equality should branch when str_eq is true");
+    }
+
+    #[test]
     fn compiles_string_variable_concat_if_expression_inequality() {
         let src = "10 LET A$ = \"O\"\n\
                    20 LET B$ = \"K\"\n\

--- a/code/packages/rust/lang-aot/CHANGELOG.md
+++ b/code/packages/rust/lang-aot/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog — `lang-aot`
 
+## 0.145.0 — 2026-06-28 — BASIC variable-variable string IF equality runs on all seven backends (LANG-FULL BA4)
+
+The matrix now proves a BASIC string concat expression whose two operands are
+both scalar string variables and whose result feeds the standard `=` branch:
+
+```basic
+10 LET A$ = "O"
+20 LET B$ = "K"
+30 IF A$ + B$ = "OK" THEN 60
+40 PRINT "BAD"
+50 END
+60 PRINT "OK"
+70 END
+```
+
+Expected stdout is `OK` on native-AOT + LLVM + WASM + JVM + CLR + VM + JIT.
+`dartmouth-basic-iir-compiler` 0.30.0 lowers the expression to E4
+`str_concat`, compares it with E4 `str_eq`, and branches on true equality.
+
 ## 0.144.0 — 2026-06-27 — BASIC variable-variable string IF inequality runs on all seven backends (LANG-FULL BA4)
 
 The matrix now proves a BASIC string concat expression whose two operands are

--- a/code/packages/rust/lang-aot/Cargo.toml
+++ b/code/packages/rust/lang-aot/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "lang-aot"
-version = "0.144.0"
+version = "0.145.0"
 edition = "2021"
-description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, and McCarthy Lisp to native executables through the shared IIR pipeline.  v0.144.0 (LANG-FULL BA4): `tests/lang_matrix.rs` proves BASIC variable-variable string concat in IF inequality on native/LLVM/WASM/JVM/CLR/VM/JIT.  v0.143.0 proved variable-variable string concat in PRINT."
+description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, and McCarthy Lisp to native executables through the shared IIR pipeline.  v0.145.0 (LANG-FULL BA4): `tests/lang_matrix.rs` proves BASIC variable-variable string concat in IF equality on native/LLVM/WASM/JVM/CLR/VM/JIT.  v0.144.0 proved variable-variable string concat in IF inequality."
 
 [dependencies]
 twig-aot              = { path = "../twig-aot" }

--- a/code/packages/rust/lang-aot/tests/lang_matrix.rs
+++ b/code/packages/rust/lang-aot/tests/lang_matrix.rs
@@ -1241,6 +1241,17 @@ const PROGRAMS: &[Prog] = &[
         expect: Expect::Stdout("OK"),
         backends: &[NativeAot, Llvm, Wasm, Jvm, Clr, Vm, Jit],
     },
+    // Dartmouth BASIC — BA4 variable-variable string expression in IF
+    // equality. This extends the equality branch proof beyond `A$ + literal`:
+    // both concat operands are scalar string slots, the temporary feeds E4
+    // `str_eq`, and `jmp_if_true` takes the line-control target.
+    Prog {
+        lang: Language::DartmouthBasic,
+        ext: "bas",
+        src: "10 LET A$ = \"O\"\n20 LET B$ = \"K\"\n30 IF A$ + B$ = \"OK\" THEN 60\n40 PRINT \"BAD\"\n50 END\n60 PRINT \"OK\"\n70 END\n",
+        expect: Expect::Stdout("OK"),
+        backends: &[NativeAot, Llvm, Wasm, Jvm, Clr, Vm, Jit],
+    },
     // Dartmouth BASIC — BA4 string expression in IF inequality. This composes
     // the variable-variable concat proof with the `<>` branch path: E4
     // `str_eq` is still the only compare op, but the line-control jump is

--- a/code/specs/LANG-FULL-IMPLEMENTATION.md
+++ b/code/specs/LANG-FULL-IMPLEMENTATION.md
@@ -526,6 +526,9 @@ backend immediately) come before the enabler-dependent items.
   proves both concat operands can be scalar string slots in that direct-print path.
   `LET A$ = "O"; IF A$ + "K" = "OK" THEN n`
   proves that same expression path before `str_eq` line-control branching.
+  `LET A$ = "O"; LET B$ = "K"; IF A$ + B$ = "OK" THEN n` proves the
+  variable-variable concat expression also feeds the standard equality branch
+  path (`str_eq` plus `jmp_if_true`).
   `LET A$ = "O"; LET B$ = "K"; IF A$ + B$ <> "NO" THEN n` proves the
   variable-variable concat expression also feeds the standard inequality branch
   path (`str_eq` plus `jmp_if_false`).

--- a/code/specs/lang-full-e4-strings.md
+++ b/code/specs/lang-full-e4-strings.md
@@ -163,8 +163,9 @@ E4. This is the one genuinely new piece of host surface E4 adds beyond E5.
   temporary E4 string-expression result, and `LET B$ = "K"; PRINT A$ + B$`
   proves both concat operands can be scalar string slots in that direct-print path.
   `IF A$ + "K" = "OK" THEN ...` proves the same temporary expression path before
-  `str_eq`, while `IF A$ + B$ <> "NO" THEN ...` proves variable-variable concat
-  on the `<>` branch path through `str_eq` plus `jmp_if_false`.
+  `str_eq`, while `IF A$ + B$ = "OK" THEN ...` and
+  `IF A$ + B$ <> "NO" THEN ...` prove variable-variable concat on the `=` and
+  `<>` branch paths through `str_eq` plus `jmp_if_true` / `jmp_if_false`.
   `LET B$ = A$ + "K"; PRINT B$` proves variable-backed concat
   assignment into another scalar string slot. String compares in `IF A$ = "Y"` and
   `IF A$ <> "Y"` lower to `str_eq` (the latter branches with `jmp_if_false`) and
@@ -263,6 +264,7 @@ merge before the next:
    stdout `HI` on native-AOT + VM + JIT + LLVM + WASM + JVM + CLR. Literal
    reassignment, literal concat assignment, scalar copy, variable-backed concat
    assignment, concat expressions in `PRINT`/`IF` including `PRINT A$ + B$`,
+   expression-backed equality branches,
    expression-backed inequality branches,
    copied-slot equality, tight multi-item string `PRINT` (`PRINT A$; B$`), and
    comma-separated string `PRINT` (`PRINT A$, B$` => `O K`) all now run on the


### PR DESCRIPTION
## Summary
- Add a LANG-FULL BA4 proof that `IF A$ + B$ = "OK" THEN ...` lowers through E4 `str_concat` + `str_eq` and branches with `jmp_if_true`.
- Add the all-seven `lang_matrix` row for native-AOT, LLVM, WASM, JVM, CLR, VM, and JIT.
- Bump/update `dartmouth-basic-iir-compiler` to 0.30.0 and `lang-aot` to 0.145.0 with roadmap/spec notes.

## Validation
- `cargo test -p dartmouth-basic-iir-compiler compiles_string_variable_concat_if_expression_equality -q`
- `cargo check -p dartmouth-basic-iir-compiler -p lang-aot -q`
- `cargo test -p lang-aot --test lang_matrix proven_columns_do_not_silently_skip -q`
- `cargo test -p lang-aot --test lang_matrix matrix_every_proven_cell_agrees -q`
- `cargo test -p dartmouth-basic-iir-compiler -q`
- `git diff --check`