### PR TITLE
Summarize mesh protocol action evidence

### DIFF
--- a/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
+++ b/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
@@ -107,6 +107,9 @@ All notable changes to this package will be documented in this file.
 - Mesh release ticket handoff protocol-evidence package handoff execution
   action evidence rows that preserve action, slot, package, packet, blocker,
   and release evidence lineage.
+- Mesh release ticket handoff protocol-evidence package handoff execution
+  action evidence summaries that combine evidence-row counts with next
+  blocker, protocol, and release handoff pointers.
 - Mesh release ticket handoff readiness-evidence review disposition-action
   readiness execution handoff action evidence rows that preserve action
   lineage, release evidence, and handoff readiness flags.

--- a/code/packages/rust/smart-home-integration-catalog/README.md
+++ b/code/packages/rust/smart-home-integration-catalog/README.md
@@ -145,6 +145,9 @@ runtime and Chief of Staff tools a typed catalog for:
 - low-level mesh protocol-evidence package handoff execution action evidence
   rows that preserve action, slot, package, packet, blocker, and release
   evidence lineage
+- mesh protocol-evidence package handoff execution action evidence summaries
+  that combine evidence-row counts with next blocker, protocol, and release
+  handoff pointers
 - low-level mesh release ticket handoff execution work-order guardrail audit
   rows that expose release blockers, operator handoffs, review gates, and
   ready-to-execute checks for audit/release coordination

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -27650,6 +27650,269 @@ impl
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationMeshReleaseTicketHandoffReadinessEvidenceReviewDispositionActionReadinessExecutionHandoffActionProtocolEvidencePackageHandoffExecutionActionEvidenceSummary
+{
+    pub release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_protocol_evidence_package_handoff_execution_action_summary:
+        Box<IntegrationMeshReleaseTicketHandoffReadinessEvidenceReviewDispositionActionReadinessExecutionHandoffActionProtocolEvidencePackageHandoffExecutionActionSummary>,
+    pub total_protocol_evidence_package_handoff_execution_action_rows: usize,
+    pub total_protocol_evidence_package_handoff_execution_action_evidence_rows: usize,
+    pub required_protocol_evidence_package_handoff_execution_action_evidence_rows: usize,
+    pub release_blocking_protocol_evidence_package_handoff_execution_action_evidence_rows: usize,
+    pub repair_protocol_evidence_package_handoff_execution_action_evidence_rows: usize,
+    pub review_protocol_evidence_package_handoff_execution_action_evidence_rows: usize,
+    pub operator_protocol_evidence_package_handoff_execution_action_evidence_rows: usize,
+    pub dispatch_protocol_evidence_package_handoff_execution_action_evidence_rows: usize,
+    pub execution_protocol_evidence_package_handoff_execution_action_evidence_rows: usize,
+    pub lineage_complete_protocol_evidence_package_handoff_execution_action_evidence_rows: usize,
+    pub release_handoff_protocol_evidence_package_handoff_execution_action_evidence_rows: usize,
+    pub release_ready_protocol_evidence_package_handoff_execution_action_evidence_rows: usize,
+    pub first_protocol_evidence_package_handoff_execution_action_evidence_row_key:
+        Option<String>,
+    pub first_required_protocol_evidence_package_handoff_execution_action_evidence_row_key:
+        Option<String>,
+    pub first_repair_protocol_evidence_package_handoff_execution_action_evidence_row_key:
+        Option<String>,
+    pub first_review_protocol_evidence_package_handoff_execution_action_evidence_row_key:
+        Option<String>,
+    pub first_release_protocol_evidence_package_handoff_execution_action_evidence_row_key:
+        Option<String>,
+    pub first_protocol_evidence_package_handoff_execution_action_row_key: Option<String>,
+    pub first_protocol_evidence_package_handoff_execution_slot_key: Option<String>,
+    pub first_protocol_evidence_package_handoff_row_key: Option<String>,
+    pub first_protocol_evidence_package_key: Option<String>,
+    pub first_protocol_evidence_packet_key: Option<String>,
+    pub first_protocol: Option<ProtocolFamily>,
+    pub first_handoff_action_kind: Option<
+        IntegrationMeshReleaseTicketHandoffReadinessEvidenceReviewDispositionActionReadinessExecutionHandoffActionKind,
+    >,
+    pub first_handoff_lane: Option<IntegrationMeshReleaseDispatchTicketHandoffLane>,
+    pub next_protocol_evidence_package_handoff_execution_action_evidence_row_key:
+        Option<String>,
+    pub next_protocol_evidence_package_handoff_execution_action_row_key: Option<String>,
+    pub next_protocol_evidence_package_handoff_execution_slot_key: Option<String>,
+    pub next_protocol_evidence_package_handoff_row_key: Option<String>,
+    pub next_protocol_evidence_package_key: Option<String>,
+    pub next_protocol_evidence_packet_key: Option<String>,
+    pub next_handoff_action_evidence_row_key: Option<String>,
+    pub next_protocol: Option<ProtocolFamily>,
+    pub next_blocked_substrate_stage: Option<IntegrationMeshProtocolSubstrateStage>,
+    pub next_handoff_lane: Option<IntegrationMeshReleaseDispatchTicketHandoffLane>,
+    pub protocol_evidence_package_handoff_execution_actions_ready: bool,
+    pub protocol_evidence_package_handoff_execution_action_evidence_ready: bool,
+}
+
+impl
+    IntegrationMeshReleaseTicketHandoffReadinessEvidenceReviewDispositionActionReadinessExecutionHandoffActionProtocolEvidencePackageHandoffExecutionActionEvidenceSummary
+{
+    pub fn from_summaries<'a>(
+        action_summary: IntegrationMeshReleaseTicketHandoffReadinessEvidenceReviewDispositionActionReadinessExecutionHandoffActionProtocolEvidencePackageHandoffExecutionActionSummary,
+        evidence_rows: impl IntoIterator<
+            Item = &'a IntegrationMeshReleaseTicketHandoffReadinessEvidenceReviewDispositionActionReadinessExecutionHandoffActionProtocolEvidencePackageHandoffExecutionActionEvidenceRow,
+        >,
+    ) -> Self {
+        let evidence_rows: Vec<&IntegrationMeshReleaseTicketHandoffReadinessEvidenceReviewDispositionActionReadinessExecutionHandoffActionProtocolEvidencePackageHandoffExecutionActionEvidenceRow> =
+            evidence_rows.into_iter().collect();
+        let first_row = evidence_rows.first().copied();
+        let first_required_row = evidence_rows
+            .iter()
+            .copied()
+            .find(|row| row.requires_attention());
+        let first_repair_row = evidence_rows
+            .iter()
+            .copied()
+            .find(|row| row.is_repair_action());
+        let first_review_row = evidence_rows
+            .iter()
+            .copied()
+            .find(|row| row.is_review_action());
+        let first_release_row = evidence_rows
+            .iter()
+            .copied()
+            .find(|row| row.is_release_handoff_action());
+        let release_ready_protocol_evidence_package_handoff_execution_action_evidence_rows =
+            evidence_rows
+                .iter()
+                .filter(|row| row.ready_for_package_handoff_execution_action_evidence())
+                .count();
+        let protocol_evidence_package_handoff_execution_actions_ready = action_summary
+            .ready_for_release_ticket_handoff_protocol_evidence_package_handoff_execution_actions(
+            );
+        let protocol_evidence_package_handoff_execution_action_evidence_ready =
+            !evidence_rows.is_empty()
+                && evidence_rows.len()
+                    == action_summary
+                        .total_protocol_evidence_package_handoff_execution_action_rows
+                && release_ready_protocol_evidence_package_handoff_execution_action_evidence_rows
+                    == evidence_rows.len()
+                && protocol_evidence_package_handoff_execution_actions_ready;
+
+        Self {
+            total_protocol_evidence_package_handoff_execution_action_rows: action_summary
+                .total_protocol_evidence_package_handoff_execution_action_rows,
+            total_protocol_evidence_package_handoff_execution_action_evidence_rows:
+                evidence_rows.len(),
+            required_protocol_evidence_package_handoff_execution_action_evidence_rows:
+                evidence_rows.iter().filter(|row| row.requires_attention()).count(),
+            release_blocking_protocol_evidence_package_handoff_execution_action_evidence_rows:
+                evidence_rows.iter().filter(|row| row.blocks_release()).count(),
+            repair_protocol_evidence_package_handoff_execution_action_evidence_rows:
+                evidence_rows.iter().filter(|row| row.is_repair_action()).count(),
+            review_protocol_evidence_package_handoff_execution_action_evidence_rows:
+                evidence_rows.iter().filter(|row| row.is_review_action()).count(),
+            operator_protocol_evidence_package_handoff_execution_action_evidence_rows:
+                evidence_rows.iter().filter(|row| row.needs_operator()).count(),
+            dispatch_protocol_evidence_package_handoff_execution_action_evidence_rows:
+                evidence_rows.iter().filter(|row| row.requires_dispatch()).count(),
+            execution_protocol_evidence_package_handoff_execution_action_evidence_rows:
+                evidence_rows.iter().filter(|row| row.requires_execution()).count(),
+            lineage_complete_protocol_evidence_package_handoff_execution_action_evidence_rows:
+                evidence_rows.iter().filter(|row| row.has_lineage()).count(),
+            release_handoff_protocol_evidence_package_handoff_execution_action_evidence_rows:
+                evidence_rows
+                    .iter()
+                    .filter(|row| row.is_release_handoff_action())
+                    .count(),
+            release_ready_protocol_evidence_package_handoff_execution_action_evidence_rows,
+            first_protocol_evidence_package_handoff_execution_action_evidence_row_key: first_row
+                .map(|row| {
+                    row.protocol_evidence_package_handoff_execution_action_evidence_row_key
+                        .clone()
+                }),
+            first_required_protocol_evidence_package_handoff_execution_action_evidence_row_key:
+                first_required_row.map(|row| {
+                    row.protocol_evidence_package_handoff_execution_action_evidence_row_key
+                        .clone()
+                }),
+            first_repair_protocol_evidence_package_handoff_execution_action_evidence_row_key:
+                first_repair_row.map(|row| {
+                    row.protocol_evidence_package_handoff_execution_action_evidence_row_key
+                        .clone()
+                }),
+            first_review_protocol_evidence_package_handoff_execution_action_evidence_row_key:
+                first_review_row.map(|row| {
+                    row.protocol_evidence_package_handoff_execution_action_evidence_row_key
+                        .clone()
+                }),
+            first_release_protocol_evidence_package_handoff_execution_action_evidence_row_key:
+                first_release_row.map(|row| {
+                    row.protocol_evidence_package_handoff_execution_action_evidence_row_key
+                        .clone()
+                }),
+            first_protocol_evidence_package_handoff_execution_action_row_key: first_row.map(
+                |row| row.protocol_evidence_package_handoff_execution_action_row_key.clone(),
+            ),
+            first_protocol_evidence_package_handoff_execution_slot_key: first_row.map(|row| {
+                row.protocol_evidence_package_handoff_execution_slot_key
+                    .clone()
+            }),
+            first_protocol_evidence_package_handoff_row_key: first_row
+                .map(|row| row.protocol_evidence_package_handoff_row_key.clone()),
+            first_protocol_evidence_package_key: first_row
+                .map(|row| row.protocol_evidence_package_key.clone()),
+            first_protocol_evidence_packet_key: first_row
+                .map(|row| row.protocol_evidence_packet_key.clone()),
+            first_protocol: first_row.map(|row| row.protocol.clone()),
+            first_handoff_action_kind: first_row.map(|row| row.handoff_action_kind),
+            first_handoff_lane: first_row.map(|row| row.handoff_lane),
+            next_protocol_evidence_package_handoff_execution_action_evidence_row_key:
+                first_required_row.map(|row| {
+                    row.protocol_evidence_package_handoff_execution_action_evidence_row_key
+                        .clone()
+                }),
+            next_protocol_evidence_package_handoff_execution_action_row_key: first_required_row
+                .map(|row| row.protocol_evidence_package_handoff_execution_action_row_key.clone()),
+            next_protocol_evidence_package_handoff_execution_slot_key: first_required_row.map(
+                |row| {
+                    row.protocol_evidence_package_handoff_execution_slot_key
+                        .clone()
+                },
+            ),
+            next_protocol_evidence_package_handoff_row_key: first_required_row
+                .map(|row| row.protocol_evidence_package_handoff_row_key.clone()),
+            next_protocol_evidence_package_key: first_required_row
+                .map(|row| row.protocol_evidence_package_key.clone()),
+            next_protocol_evidence_packet_key: first_required_row
+                .map(|row| row.protocol_evidence_packet_key.clone()),
+            next_handoff_action_evidence_row_key: first_required_row
+                .and_then(|row| row.next_handoff_action_evidence_row_key.clone()),
+            next_protocol: first_required_row.map(|row| row.protocol.clone()),
+            next_blocked_substrate_stage: first_required_row
+                .and_then(|row| row.next_blocked_substrate_stage),
+            next_handoff_lane: first_required_row.map(|row| row.handoff_lane),
+            protocol_evidence_package_handoff_execution_actions_ready,
+            protocol_evidence_package_handoff_execution_action_evidence_ready,
+            release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_protocol_evidence_package_handoff_execution_action_summary:
+                Box::new(action_summary),
+        }
+    }
+
+    pub fn ready_for_release_ticket_handoff_protocol_evidence_package_handoff_execution_action_evidence(
+        &self,
+    ) -> bool {
+        self.protocol_evidence_package_handoff_execution_actions_ready
+            && self.protocol_evidence_package_handoff_execution_action_evidence_ready
+            && !self.requires_attention()
+    }
+
+    pub fn has_action_evidence_rows(&self) -> bool {
+        self.total_protocol_evidence_package_handoff_execution_action_evidence_rows > 0
+    }
+
+    pub fn has_required_evidence(&self) -> bool {
+        self.required_protocol_evidence_package_handoff_execution_action_evidence_rows > 0
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.release_blocking_protocol_evidence_package_handoff_execution_action_evidence_rows > 0
+            || self.repair_protocol_evidence_package_handoff_execution_action_evidence_rows > 0
+    }
+
+    pub fn needs_operator(&self) -> bool {
+        self.operator_protocol_evidence_package_handoff_execution_action_evidence_rows > 0
+    }
+
+    pub fn has_review_work(&self) -> bool {
+        self.review_protocol_evidence_package_handoff_execution_action_evidence_rows > 0
+    }
+
+    pub fn requires_dispatch(&self) -> bool {
+        self.dispatch_protocol_evidence_package_handoff_execution_action_evidence_rows > 0
+    }
+
+    pub fn requires_execution(&self) -> bool {
+        self.execution_protocol_evidence_package_handoff_execution_action_evidence_rows > 0
+    }
+
+    pub fn has_lineage_gaps(&self) -> bool {
+        self.lineage_complete_protocol_evidence_package_handoff_execution_action_evidence_rows
+            < self.total_protocol_evidence_package_handoff_execution_action_evidence_rows
+    }
+
+    pub fn has_release_handoff_evidence(&self) -> bool {
+        self.release_handoff_protocol_evidence_package_handoff_execution_action_evidence_rows > 0
+    }
+
+    pub fn has_ready_evidence(&self) -> bool {
+        self.release_ready_protocol_evidence_package_handoff_execution_action_evidence_rows > 0
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.has_required_evidence()
+            || self.has_blockers()
+            || self.needs_operator()
+            || self.has_review_work()
+            || self.requires_dispatch()
+            || self.requires_execution()
+            || self.has_lineage_gaps()
+            || self
+                .release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_protocol_evidence_package_handoff_execution_action_summary
+                .requires_attention()
+            || !self.protocol_evidence_package_handoff_execution_actions_ready
+            || !self.protocol_evidence_package_handoff_execution_action_evidence_ready
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IntegrationMeshReleaseTicketHandoffReadinessEvidenceReviewDispositionActionReadinessExecutionHandoffActionEvidenceReviewSummary {
     pub release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_summary:
         Box<IntegrationMeshReleaseTicketHandoffReadinessEvidenceReviewDispositionActionReadinessExecutionHandoffActionEvidenceSummary>,
@@ -53724,6 +53987,49 @@ pub fn mesh_release_ticket_handoff_readiness_evidence_review_disposition_action_
     )
 }
 
+pub fn mesh_release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_protocol_evidence_package_handoff_execution_action_evidence_summary_for_catalog(
+    catalog: &[IntegrationCatalogEntry],
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> IntegrationMeshReleaseTicketHandoffReadinessEvidenceReviewDispositionActionReadinessExecutionHandoffActionProtocolEvidencePackageHandoffExecutionActionEvidenceSummary
+{
+    let action_summary =
+        mesh_release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_protocol_evidence_package_handoff_execution_action_summary_for_catalog(
+            catalog,
+            available_primitives,
+            allowed_capabilities,
+            enabled_integrations,
+        );
+    let evidence_rows =
+        mesh_release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_protocol_evidence_package_handoff_execution_action_evidence_rows_for_catalog(
+            catalog,
+            available_primitives,
+            allowed_capabilities,
+            enabled_integrations,
+        );
+
+    IntegrationMeshReleaseTicketHandoffReadinessEvidenceReviewDispositionActionReadinessExecutionHandoffActionProtocolEvidencePackageHandoffExecutionActionEvidenceSummary::from_summaries(
+        action_summary,
+        evidence_rows.iter(),
+    )
+}
+
+pub fn mesh_release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_protocol_evidence_package_handoff_execution_action_evidence_summary(
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> IntegrationMeshReleaseTicketHandoffReadinessEvidenceReviewDispositionActionReadinessExecutionHandoffActionProtocolEvidencePackageHandoffExecutionActionEvidenceSummary
+{
+    let catalog = first_party_catalog();
+    mesh_release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_protocol_evidence_package_handoff_execution_action_evidence_summary_for_catalog(
+        &catalog,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    )
+}
+
 pub fn mesh_release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_evidence_review_summary_for_catalog(
     catalog: &[IntegrationCatalogEntry],
     available_primitives: &[PrimitiveFamily],
@@ -75200,6 +75506,233 @@ mod tests {
         assert!(evidence_rows
             .iter()
             .all(|row| row.handoff_action_evidence_ready));
+    }
+
+    #[test]
+    fn mesh_release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_protocol_evidence_package_handoff_execution_action_evidence_summary_surfaces_attention(
+    ) {
+        let available_primitives = vec![
+            PrimitiveFamily::Usb,
+            PrimitiveFamily::SerialController,
+            PrimitiveFamily::Radio802154,
+            PrimitiveFamily::Supervision,
+        ];
+        let allowed_capabilities = vec![CapabilityId::trusted("smart_home.read")];
+        let summary =
+            mesh_release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_protocol_evidence_package_handoff_execution_action_evidence_summary(
+                &available_primitives,
+                &allowed_capabilities,
+                &[],
+            );
+
+        assert_eq!(
+            summary.total_protocol_evidence_package_handoff_execution_action_rows,
+            3
+        );
+        assert_eq!(
+            summary.total_protocol_evidence_package_handoff_execution_action_evidence_rows,
+            3
+        );
+        assert_eq!(
+            summary.required_protocol_evidence_package_handoff_execution_action_evidence_rows,
+            3
+        );
+        assert_eq!(
+            summary
+                .release_blocking_protocol_evidence_package_handoff_execution_action_evidence_rows,
+            3
+        );
+        assert_eq!(
+            summary.repair_protocol_evidence_package_handoff_execution_action_evidence_rows,
+            3
+        );
+        assert_eq!(
+            summary.review_protocol_evidence_package_handoff_execution_action_evidence_rows,
+            0
+        );
+        assert_eq!(
+            summary.operator_protocol_evidence_package_handoff_execution_action_evidence_rows,
+            3
+        );
+        assert_eq!(
+            summary.dispatch_protocol_evidence_package_handoff_execution_action_evidence_rows,
+            3
+        );
+        assert_eq!(
+            summary.execution_protocol_evidence_package_handoff_execution_action_evidence_rows,
+            3
+        );
+        assert_eq!(
+            summary
+                .lineage_complete_protocol_evidence_package_handoff_execution_action_evidence_rows,
+            3
+        );
+        assert_eq!(
+            summary
+                .release_handoff_protocol_evidence_package_handoff_execution_action_evidence_rows,
+            0
+        );
+        assert_eq!(
+            summary.release_ready_protocol_evidence_package_handoff_execution_action_evidence_rows,
+            0
+        );
+        assert_eq!(
+            summary.first_protocol_evidence_package_handoff_execution_action_evidence_row_key,
+            Some(
+                "release-ticket-handoff-readiness-evidence-review-disposition-action-readiness-handoff-action-protocol-evidence-package-handoff-execution-action-evidence-01-repair_handoff-Zigbee"
+                    .to_string()
+            )
+        );
+        assert_eq!(
+            summary
+                .first_required_protocol_evidence_package_handoff_execution_action_evidence_row_key,
+            summary.first_protocol_evidence_package_handoff_execution_action_evidence_row_key
+        );
+        assert_eq!(
+            summary
+                .first_repair_protocol_evidence_package_handoff_execution_action_evidence_row_key,
+            summary.first_protocol_evidence_package_handoff_execution_action_evidence_row_key
+        );
+        assert_eq!(
+            summary
+                .first_release_protocol_evidence_package_handoff_execution_action_evidence_row_key,
+            None
+        );
+        assert_eq!(
+            summary.next_protocol_evidence_package_handoff_execution_action_evidence_row_key,
+            summary.first_protocol_evidence_package_handoff_execution_action_evidence_row_key
+        );
+        assert_eq!(
+            summary.next_protocol_evidence_package_handoff_execution_action_row_key,
+            Some(
+                "release-ticket-handoff-readiness-evidence-review-disposition-action-readiness-handoff-action-protocol-evidence-package-handoff-execution-action-01-repair_handoff-Zigbee"
+                    .to_string()
+            )
+        );
+        assert_eq!(
+            summary.next_protocol_evidence_package_handoff_execution_slot_key,
+            Some(
+                "release-ticket-handoff-readiness-evidence-review-disposition-action-readiness-handoff-action-protocol-evidence-package-handoff-execution-slot-01-Zigbee"
+                    .to_string()
+            )
+        );
+        assert_eq!(
+            summary.next_handoff_action_evidence_row_key,
+            Some(
+                "release-ticket-handoff-readiness-evidence-review-disposition-action-readiness-handoff-action-evidence-01-repair_handoff-substrate_actions"
+                    .to_string()
+            )
+        );
+        assert_eq!(summary.next_protocol, Some(ProtocolFamily::Zigbee));
+        assert_eq!(
+            summary.next_blocked_substrate_stage,
+            Some(IntegrationMeshProtocolSubstrateStage::NetworkSecurity)
+        );
+        assert_eq!(
+            summary.next_handoff_lane,
+            Some(IntegrationMeshReleaseDispatchTicketHandoffLane::Review)
+        );
+        assert!(!summary.protocol_evidence_package_handoff_execution_actions_ready);
+        assert!(!summary.protocol_evidence_package_handoff_execution_action_evidence_ready);
+        assert!(summary.has_action_evidence_rows());
+        assert!(summary.has_required_evidence());
+        assert!(summary.has_blockers());
+        assert!(summary.needs_operator());
+        assert!(summary.requires_dispatch());
+        assert!(summary.requires_execution());
+        assert!(!summary.has_lineage_gaps());
+        assert!(!summary.has_release_handoff_evidence());
+        assert!(!summary.has_ready_evidence());
+        assert!(summary.requires_attention());
+        assert!(!summary
+            .ready_for_release_ticket_handoff_protocol_evidence_package_handoff_execution_action_evidence());
+    }
+
+    #[test]
+    fn mesh_release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_protocol_evidence_package_handoff_execution_action_evidence_summary_marks_release_ready(
+    ) {
+        let catalog = vec![hue_entry()];
+        let allowed_capabilities = vec![
+            CapabilityId::trusted("smart_home.read"),
+            CapabilityId::trusted("smart_home.command.light"),
+            CapabilityId::trusted("smart_home.pair"),
+        ];
+        let summary =
+            mesh_release_ticket_handoff_readiness_evidence_review_disposition_action_readiness_execution_handoff_action_protocol_evidence_package_handoff_execution_action_evidence_summary_for_catalog(
+                &catalog,
+                all_primitive_families(),
+                &allowed_capabilities,
+                &[],
+            );
+
+        assert_eq!(
+            summary.total_protocol_evidence_package_handoff_execution_action_rows,
+            3
+        );
+        assert_eq!(
+            summary.total_protocol_evidence_package_handoff_execution_action_evidence_rows,
+            3
+        );
+        assert_eq!(
+            summary.required_protocol_evidence_package_handoff_execution_action_evidence_rows,
+            0
+        );
+        assert_eq!(
+            summary
+                .release_blocking_protocol_evidence_package_handoff_execution_action_evidence_rows,
+            0
+        );
+        assert_eq!(
+            summary.repair_protocol_evidence_package_handoff_execution_action_evidence_rows,
+            0
+        );
+        assert_eq!(
+            summary
+                .release_handoff_protocol_evidence_package_handoff_execution_action_evidence_rows,
+            3
+        );
+        assert_eq!(
+            summary.release_ready_protocol_evidence_package_handoff_execution_action_evidence_rows,
+            3
+        );
+        assert_eq!(
+            summary
+                .first_release_protocol_evidence_package_handoff_execution_action_evidence_row_key,
+            summary.first_protocol_evidence_package_handoff_execution_action_evidence_row_key
+        );
+        assert_eq!(
+            summary
+                .first_required_protocol_evidence_package_handoff_execution_action_evidence_row_key,
+            None
+        );
+        assert_eq!(
+            summary.next_protocol_evidence_package_handoff_execution_action_evidence_row_key,
+            None
+        );
+        assert_eq!(
+            summary.next_protocol_evidence_package_handoff_execution_action_row_key,
+            None
+        );
+        assert_eq!(summary.next_protocol_evidence_packet_key, None);
+        assert_eq!(summary.next_handoff_action_evidence_row_key, None);
+        assert_eq!(summary.next_protocol, None);
+        assert_eq!(summary.next_blocked_substrate_stage, None);
+        assert_eq!(summary.next_handoff_lane, None);
+        assert!(summary.protocol_evidence_package_handoff_execution_actions_ready);
+        assert!(summary.protocol_evidence_package_handoff_execution_action_evidence_ready);
+        assert!(summary.has_action_evidence_rows());
+        assert!(!summary.has_required_evidence());
+        assert!(!summary.has_blockers());
+        assert!(!summary.needs_operator());
+        assert!(!summary.has_review_work());
+        assert!(!summary.requires_dispatch());
+        assert!(!summary.requires_execution());
+        assert!(!summary.has_lineage_gaps());
+        assert!(summary.has_release_handoff_evidence());
+        assert!(summary.has_ready_evidence());
+        assert!(!summary.requires_attention());
+        assert!(summary
+            .ready_for_release_ticket_handoff_protocol_evidence_package_handoff_execution_action_evidence());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add protocol-evidence package handoff execution action evidence summaries
- combine evidence-row counts with next blocker, protocol, handoff, packet, and release-ready pointers
- document the new smart-home catalog summary surface

## Validation
- cargo fmt --manifest-path code/packages/rust/smart-home-integration-catalog/Cargo.toml
- cargo test --manifest-path code/packages/rust/smart-home-integration-catalog/Cargo.toml protocol_evidence_package
- cargo check --manifest-path code/packages/rust/smart-home-integration-catalog/Cargo.toml --message-format short
- git diff --check