### PR TITLE
[codex] Add JFET transient charge stamping

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Added
 
+- **JFET transient charge stamping** —
+  JFET `Cgs`/`Cgd` model-card storage now stamps transient gate-source and
+  gate-drain companions and contributes AC susceptance, matching Rust and
+  TypeScript, with regression coverage for gate-step delay and high-frequency
+  gate-drive shunting.
+
 - **BJT transient charge stamping** —
   BJT `Cje`/`Cjc`/`Tf`/`Tr` model-card storage now stamps transient
   base-emitter and base-collector companions, matching Rust and TypeScript,

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -206,16 +206,17 @@ model-depth audits. `device_model_temperature_audit_fixtures()` adds matching
 `.temp` reference-deck metadata and stable per-temperature probe windows for
 those same fixture circuits. `device_model_capacitance_audit_fixtures()` adds
 matching `.ac` reference-deck metadata and stable high-frequency probe
-magnitude windows for capacitance and current JFET invariant audits.
+magnitude windows for diode, BJT, JFET `CGS`/`CGD`, and Level-1 MOS
+capacitance audits.
 `device_model_noise_audit_fixtures()` adds matching `.noise` reference-deck
 metadata and stable source/output PSD windows for diode and BJT shot noise plus
 JFET and Level-1 MOS channel thermal noise audits.
 `device_model_charge_audit_fixtures()` adds matching `.tran` reference-deck
 metadata, explicit terminal storage capacitance metadata, stable first/final
 probe-voltage windows, and charge-behavior notes for diode, BJT, JFET, and
-Level-1 MOS charge audits. Diode `Cjo` / `Tt` and BJT `Cje` / `Cjc` / `Tf` /
-`Tr` model-card parameters also stamp transient storage, matching their
-small-signal AC capacitance semantics.
+Level-1 MOS charge audits. Diode `Cjo` / `Tt`, BJT `Cje` / `Cjc` / `Tf` /
+`Tr`, and JFET `Cgs` / `Cgd` model-card parameters also stamp transient
+storage, matching their small-signal AC capacitance semantics.
 
 `DigitalEventStream`, `DigitalLogicLevels`, and `DigitalThresholds` provide the
 first mixed-signal bridge surface: digital event streams can drive finite-edge

--- a/code/packages/python/spice-engine/src/spice_engine/elements.py
+++ b/code/packages/python/spice-engine/src/spice_engine/elements.py
@@ -502,6 +502,8 @@ class JFET:
     beta: float = 1.0e-4
     vto: float = -2.0
     lambda_: float = 0.0
+    Cgs: float = 0.0
+    Cgd: float = 0.0
 
 
 @dataclass(frozen=True, slots=True)

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -573,7 +573,7 @@ def _clone_subckt_element(element: Element, instance_name: str, node_map: dict[s
             element.Tt,
         )
     if isinstance(element, JFET):
-        return JFET(name, _map_subckt_node(element.drain, instance_name, node_map), _map_subckt_node(element.gate, instance_name, node_map), _map_subckt_node(element.source, instance_name, node_map), element.polarity, element.beta, element.vto, element.lambda_)
+        return JFET(name, _map_subckt_node(element.drain, instance_name, node_map), _map_subckt_node(element.gate, instance_name, node_map), _map_subckt_node(element.source, instance_name, node_map), element.polarity, element.beta, element.vto, element.lambda_, element.Cgs, element.Cgd)
     if isinstance(element, Mosfet):
         return Mosfet(name, _map_subckt_node(element.drain, instance_name, node_map), _map_subckt_node(element.gate, instance_name, node_map), _map_subckt_node(element.source, instance_name, node_map), _map_subckt_node(element.body, instance_name, node_map), element.model)
     if isinstance(element, BJT):
@@ -8715,6 +8715,27 @@ def _bjt_charge_state_voltage(n_plus: str, n_minus: str, node_voltages: dict[str
     return _node_voltage(n_plus, node_voltages) - _node_voltage(n_minus, node_voltages)
 
 
+def _jfet_gate_source_charge_state_name(el: JFET) -> str:
+    return f"_J_{el.name}_gs_charge"
+
+
+def _jfet_gate_drain_charge_state_name(el: JFET) -> str:
+    return f"_J_{el.name}_gd_charge"
+
+
+def _jfet_charge_state_specs(el: JFET) -> list[tuple[str, str, str, float]]:
+    specs: list[tuple[str, str, str, float]] = []
+    if el.Cgs > 0.0:
+        specs.append((_jfet_gate_source_charge_state_name(el), el.gate, el.source, el.Cgs))
+    if el.Cgd > 0.0:
+        specs.append((_jfet_gate_drain_charge_state_name(el), el.gate, el.drain, el.Cgd))
+    return specs
+
+
+def _jfet_charge_state_voltage(n_plus: str, n_minus: str, node_voltages: dict[str, float]) -> float:
+    return _node_voltage(n_plus, node_voltages) - _node_voltage(n_minus, node_voltages)
+
+
 def _stamp_mosfet(
     G: list[list[float]],
     b: list[float],
@@ -8768,6 +8789,10 @@ def _eval_jfet(el: JFET, vgs: float, vds: float) -> tuple[float, float, float]:
         raise ValueError(f"JFET '{el.name}' VTO must be finite")
     if not math.isfinite(el.lambda_):
         raise ValueError(f"JFET '{el.name}' LAMBDA must be finite")
+    if not math.isfinite(el.Cgs) or el.Cgs < 0.0:
+        raise ValueError(f"JFET '{el.name}' CGS must be finite and non-negative")
+    if not math.isfinite(el.Cgd) or el.Cgd < 0.0:
+        raise ValueError(f"JFET '{el.name}' CGD must be finite and non-negative")
     if el.polarity == "PJF":
         ids, gm, gds = _eval_njf(-vgs, -vds, -el.vto, el.beta, el.lambda_)
         return -ids, gm, gds
@@ -9627,6 +9652,34 @@ def _build_transient_companions(
                     current=I_eq,
                 ))
 
+        # ---- JFET model-card charge companions -----------------------------
+        elif isinstance(el, JFET):
+            for state_name, n_plus, n_minus, capacitance in _jfet_charge_state_specs(el):
+                v_prev = cap_voltages.get(state_name, 0.0)
+                if method == "trap":
+                    g_eq = 2.0 * capacitance / h
+                    I_eq = g_eq * v_prev + cap_currents.get(state_name, 0.0)
+                elif method == "gear2":
+                    v_older = cap_voltages_older.get(state_name, v_prev)
+                    g_eq = 3.0 * capacitance / (2.0 * h)
+                    I_eq = capacitance * (4.0 * v_prev - v_older) / (2.0 * h)
+                else:
+                    g_eq = capacitance / h
+                    I_eq = g_eq * v_prev
+
+                aug.elements.append(Resistor(
+                    name=f"{state_name}_R",
+                    n_plus=n_plus,
+                    n_minus=n_minus,
+                    resistance=1.0 / g_eq,
+                ))
+                aug.elements.append(CurrentSource(
+                    name=f"{state_name}_I",
+                    n_plus=n_minus,
+                    n_minus=n_plus,
+                    current=I_eq,
+                ))
+
         # ---- BJT model-card charge companions ------------------------------
         elif isinstance(el, BJT):
             for state_name, n_plus, n_minus, state_kind in _bjt_charge_state_specs(el):
@@ -9815,6 +9868,28 @@ def _update_reactive_state(
             cap_voltages_older[state_name] = v_prev
             cap_voltages[state_name] = v_new
 
+        elif isinstance(el, JFET):
+            for state_name, n_plus, n_minus, capacitance in _jfet_charge_state_specs(el):
+                v_new = _jfet_charge_state_voltage(n_plus, n_minus, op.node_voltages)
+                v_prev = cap_voltages.get(state_name, v_new)
+                v_older = cap_voltages_older.get(state_name, v_prev)
+
+                if method == "trap":
+                    g_eq = 2.0 * capacitance / h
+                    I_prev = cap_currents.get(state_name, 0.0)
+                    cap_currents[state_name] = g_eq * (v_new - v_prev) - I_prev
+                elif method == "gear2":
+                    cap_currents[state_name] = (
+                        capacitance * (3.0 * v_new - 4.0 * v_prev + v_older)
+                        / (2.0 * h)
+                    )
+                else:
+                    g_eq = capacitance / h
+                    cap_currents[state_name] = g_eq * (v_new - v_prev)
+
+                cap_voltages_older[state_name] = v_prev
+                cap_voltages[state_name] = v_new
+
         elif isinstance(el, BJT):
             for state_name, n_plus, n_minus, state_kind in _bjt_charge_state_specs(el):
                 v_new = _bjt_charge_state_voltage(n_plus, n_minus, op.node_voltages)
@@ -9903,6 +9978,14 @@ def _lte_estimate(
             lte_c = abs(v1 - 2.0 * v0 + vm1) / 2.0
             if lte_c > max_lte:
                 max_lte = lte_c
+        elif isinstance(el, JFET):
+            for state_name, _, _, _ in _jfet_charge_state_specs(el):
+                v1 = cap_voltages_now.get(state_name, 0.0)
+                v0 = cap_voltages_prev.get(state_name, 0.0)
+                vm1 = cap_voltages_prev2.get(state_name, 0.0)
+                lte_c = abs(v1 - 2.0 * v0 + vm1) / 2.0
+                if lte_c > max_lte:
+                    max_lte = lte_c
         elif isinstance(el, BJT):
             for state_name, _, _, _ in _bjt_charge_state_specs(el):
                 v1 = cap_voltages_now.get(state_name, 0.0)
@@ -10074,6 +10157,13 @@ def transient(
     for el in circuit.elements:
         if isinstance(el, Diode) and _diode_has_charge_storage(el):
             cap_voltages[_diode_charge_state_name(el)] = _diode_charge_voltage(el, op.node_voltages)
+        elif isinstance(el, JFET):
+            for state_name, n_plus, n_minus, _ in _jfet_charge_state_specs(el):
+                cap_voltages[state_name] = _jfet_charge_state_voltage(
+                    n_plus,
+                    n_minus,
+                    op.node_voltages,
+                )
         elif isinstance(el, BJT):
             for state_name, n_plus, n_minus, _ in _bjt_charge_state_specs(el):
                 cap_voltages[state_name] = _bjt_charge_state_voltage(
@@ -10088,6 +10178,9 @@ def transient(
     for el in circuit.elements:
         if isinstance(el, Diode) and _diode_has_charge_storage(el):
             cap_currents[_diode_charge_state_name(el)] = 0.0
+        elif isinstance(el, JFET):
+            for state_name, _, _, _ in _jfet_charge_state_specs(el):
+                cap_currents[state_name] = 0.0
         elif isinstance(el, BJT):
             for state_name, _, _, _ in _bjt_charge_state_specs(el):
                 cap_currents[state_name] = 0.0
@@ -10160,6 +10253,13 @@ def transient(
                         el,
                         op.node_voltages,
                     )
+                elif isinstance(el, JFET):
+                    for state_name, n_plus, n_minus, _ in _jfet_charge_state_specs(el):
+                        cap_voltages_new[state_name] = _jfet_charge_state_voltage(
+                            n_plus,
+                            n_minus,
+                            op.node_voltages,
+                        )
                 elif isinstance(el, BJT):
                     for state_name, n_plus, n_minus, _ in _bjt_charge_state_specs(el):
                         cap_voltages_new[state_name] = _bjt_charge_state_voltage(
@@ -11965,6 +12065,10 @@ def _stamp_ac(
         Vs = 0.0 if _is_ground(el.source) else dc_x[node_to_idx[el.source]]
         _, gm_j, gds_j = _eval_jfet(el, Vg - Vs, Vd - Vs)
         _stamp_g_c(G, node_to_idx, el.drain, el.source, gds_j + 0j)
+        if el.Cgs > 0.0:
+            _stamp_g_c(G, node_to_idx, el.gate, el.source, 1j * omega * el.Cgs)
+        if el.Cgd > 0.0:
+            _stamp_g_c(G, node_to_idx, el.gate, el.drain, 1j * omega * el.Cgd)
         if not _is_ground(el.drain):
             d = node_to_idx[el.drain]
             if not _is_ground(el.gate):

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -188,6 +188,10 @@ _JFET_PARAMETER_ALIASES: dict[str, str] = {
     "VTH": "VTO",
     "LAMBDA": "LAMBDA",
     "LAM": "LAMBDA",
+    "CGS": "CGS",
+    "CGS0": "CGS",
+    "CGD": "CGD",
+    "CGD0": "CGD",
 }
 
 _MOS_LEVEL1_PARAMETER_ALIASES: dict[str, str] = {
@@ -359,6 +363,8 @@ def jfet_from_model_card(
         beta=p.get("BETA", 1.0e-4),
         vto=p.get("VTO", -2.0 if model.kind == "NJF" else 2.0),
         lambda_=p.get("LAMBDA", 0.0),
+        Cgs=p.get("CGS", 0.0),
+        Cgd=p.get("CGD", 0.0),
     )
 
 
@@ -627,12 +633,17 @@ def device_model_capacitance_audit_fixtures() -> tuple[DeviceModelCapacitanceBeh
     bjt_circuit.add(Resistor("Rc", "col", "0", 1_000.0))
     bjt_circuit.add(bjt_from_model_card("Q1", "col", "base", "0", models["Qsmall"]))
 
+    jfet_model = normalize_model_card(
+        "Jn",
+        "NJF",
+        {"BETA": 9.0e-4, "VTO": -1.8, "LAMBDA": 0.02, "CGS": 2.0e-9, "CGD": 1.0e-10},
+    )
     jfet_circuit = Circuit()
     jfet_circuit.add(VoltageSource("Vdrive", "in", "0", 0.0, ac=AcSource(1.0)))
     jfet_circuit.add(Resistor("Rin", "in", "source", 1_000.0))
     jfet_circuit.add(Resistor("Rd", "drain", "0", 2_000.0))
     jfet_circuit.add(VoltageSource("Vgate", "gate", "0", 0.0))
-    jfet_circuit.add(jfet_from_model_card("J1", "drain", "gate", "source", models["Jn"]))
+    jfet_circuit.add(jfet_from_model_card("J1", "drain", "gate", "source", jfet_model))
 
     mos_circuit = Circuit()
     mos_circuit.add(VoltageSource("Vdrive", "in", "0", 0.0, ac=AcSource(1.0)))
@@ -685,21 +696,18 @@ def device_model_capacitance_audit_fixtures() -> tuple[DeviceModelCapacitanceBeh
             ),
         ),
         DeviceModelCapacitanceBehaviorFixture(
-            name="jfet-capacitance-invariant-ac",
-            kind=models["Jn"].kind,
-            model=models["Jn"],
+            name="jfet-capacitance-ac",
+            kind=jfet_model.kind,
+            model=jfet_model,
             circuit=jfet_circuit,
             probe_node="source",
             frequency_hz=frequency_hz,
-            expected_magnitude_min=0.69,
-            expected_magnitude_max=0.71,
-            capacitance_behavior=(
-                "JFET capacitance is intentionally unmodeled; fixture records "
-                "conductance-only AC response"
-            ),
+            expected_magnitude_min=0.50,
+            expected_magnitude_max=0.54,
+            capacitance_behavior="JFET CGS/CGD contribute high-frequency gate-channel capacitance",
             deck_lines=(
-                "* device-model capacitance fixture: jfet-capacitance-invariant-ac",
-                ".model Jn NJF(BETA=9e-4 VTO=-1.8 LAMBDA=0.02)",
+                "* device-model capacitance fixture: jfet-capacitance-ac",
+                ".model Jn NJF(BETA=9e-4 VTO=-1.8 LAMBDA=0.02 CGS=2n CGD=100p)",
                 "Vdrive in 0 0 AC 1",
                 "Rin in source 1k",
                 "Rd drain 0 2k",
@@ -881,9 +889,10 @@ def device_model_charge_audit_fixtures() -> tuple[DeviceModelChargeBehaviorFixtu
     """Return runnable transient storage fixtures for charge model-depth audits.
 
     Diode CJO/TT and BJT CJE/CJC/TF/TR model-card storage is
-    transient-stamped by the simulator. JFET and MOS charge state is still
-    audited through explicit terminal storage capacitors until their nonlinear
-    charge policies land.
+    transient-stamped by the simulator. JFET fixed gate-source/gate-drain
+    storage is also transient-stamped; Level-1 MOS charge state is still
+    audited through explicit terminal storage capacitors until nonlinear charge
+    policies land.
     """
 
     models = _model_card_by_name()
@@ -904,12 +913,17 @@ def device_model_charge_audit_fixtures() -> tuple[DeviceModelChargeBehaviorFixtu
     bjt_circuit.add(bjt_from_model_card("Q1", "vcc", "base", "out", models["Qsmall"]))
     bjt_circuit.add(Capacitor("Cstore", "out", "0", storage_capacitance_f))
 
+    jfet_model = normalize_model_card(
+        "Jn",
+        "NJF",
+        {"BETA": 9.0e-4, "VTO": -1.8, "LAMBDA": 0.02, "CGS": 2.0e-11, "CGD": 5.0e-12},
+    )
     jfet_circuit = Circuit()
     jfet_circuit.add(VoltageSource("Vdd", "vdd", "0", 10.0))
     jfet_circuit.add(VoltageSource("Vg", "gate", "0", 0.0))
     jfet_circuit.add(Resistor("Rd", "vdd", "drain", 2_000.0))
     jfet_circuit.add(Resistor("Rs", "source", "0", 1_000.0))
-    jfet_circuit.add(jfet_from_model_card("J1", "drain", "gate", "source", models["Jn"]))
+    jfet_circuit.add(jfet_from_model_card("J1", "drain", "gate", "source", jfet_model))
     jfet_circuit.add(Capacitor("Cstore", "source", "0", storage_capacitance_f))
 
     mos_circuit = Circuit()
@@ -982,8 +996,8 @@ def device_model_charge_audit_fixtures() -> tuple[DeviceModelChargeBehaviorFixtu
         ),
         DeviceModelChargeBehaviorFixture(
             name="jfet-storage-charge",
-            kind=models["Jn"].kind,
-            model=models["Jn"],
+            kind=jfet_model.kind,
+            model=jfet_model,
             circuit=jfet_circuit,
             probe_node="source",
             time_step_s=time_step_s,
@@ -994,12 +1008,12 @@ def device_model_charge_audit_fixtures() -> tuple[DeviceModelChargeBehaviorFixtu
             expected_final_min=0.86,
             expected_final_max=0.90,
             charge_behavior=(
-                "JFET transient charge is intentionally external-only; "
-                "fixture records explicit source storage until a JFET capacitance policy lands"
+                "JFET CGS/CGD contribute transient gate-source and gate-drain storage; "
+                "explicit Cstore keeps the fixture comparable with other charge audits"
             ),
             deck_lines=(
                 "* device-model charge fixture: jfet-storage-charge",
-                ".model Jn NJF(BETA=9e-4 VTO=-1.8 LAMBDA=0.02)",
+                ".model Jn NJF(BETA=9e-4 VTO=-1.8 LAMBDA=0.02 CGS=20p CGD=5p)",
                 "Vdd vdd 0 10",
                 "Vg gate 0 0",
                 "Rd vdd drain 2k",

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -463,7 +463,7 @@ def test_device_model_capacitance_audit_fixtures_run_reference_ac_points() -> No
     assert [fixture.name for fixture in fixtures] == [
         "diode-capacitance-ac",
         "bjt-capacitance-ac",
-        "jfet-capacitance-invariant-ac",
+        "jfet-capacitance-ac",
         "mos-level1-capacitance-ac",
     ]
 
@@ -486,7 +486,7 @@ def test_device_model_capacitance_audit_fixtures_run_reference_ac_points() -> No
         assert fixture.capacitance_behavior
 
     jfet_fixture = next(fixture for fixture in fixtures if fixture.kind == "NJF")
-    assert "intentionally unmodeled" in jfet_fixture.capacitance_behavior
+    assert "CGS/CGD" in jfet_fixture.capacitance_behavior
 
 
 def test_device_model_noise_audit_fixtures_run_reference_noise_points() -> None:
@@ -551,7 +551,7 @@ def test_device_model_charge_audit_fixtures_run_reference_transients() -> None:
         assert fixture.charge_behavior
 
     jfet_fixture = next(fixture for fixture in fixtures if fixture.kind == "NJF")
-    assert "external-only" in jfet_fixture.charge_behavior
+    assert "CGS/CGD" in jfet_fixture.charge_behavior
 
 
 def test_transient_diode_junction_capacitance_slows_current_step() -> None:
@@ -575,6 +575,33 @@ def test_transient_diode_junction_capacitance_slows_current_step() -> None:
     assert charged.converged
     uncharged_first = uncharged.points[1].node_voltages["out"]
     charged_first = charged.points[1].node_voltages["out"]
+    assert uncharged_first > 0.5
+    assert charged_first < 0.01
+    assert charged_first < uncharged_first
+
+
+def test_transient_jfet_gate_source_capacitance_slows_gate_step() -> None:
+    def run(cgs: float) -> TransientResult:
+        circuit = Circuit()
+        circuit.add(VoltageSource(
+            "Vstep",
+            "in",
+            "0",
+            0.0,
+            waveform=PwlWaveform(((0.0, 0.0), (1.0e-9, 1.0), (5.0e-9, 1.0))),
+        ))
+        circuit.add(Resistor("Rin", "in", "gate", 1_000.0))
+        circuit.add(Resistor("Rdrain", "drain", "0", 1_000.0))
+        circuit.add(JFET("J1", "drain", "gate", "0", beta=1.0e-12, vto=-2.0, Cgs=cgs))
+        return transient(circuit, t_stop=5.0e-9, t_step=1.0e-9, method="euler")
+
+    uncharged = run(0.0)
+    charged = run(1.0e-9)
+
+    assert uncharged.converged
+    assert charged.converged
+    uncharged_first = uncharged.points[1].node_voltages["gate"]
+    charged_first = charged.points[1].node_voltages["gate"]
     assert uncharged_first > 0.5
     assert charged_first < 0.01
     assert charged_first < uncharged_first
@@ -2049,6 +2076,25 @@ def test_jfet_common_source_ac_gain_from_bias_point() -> None:
     out = result.points[0].node_voltages["drain"]
     assert out.real == pytest.approx(-4.0, abs=1.0e-6)
     assert out.imag == pytest.approx(0.0, abs=1.0e-12)
+
+
+def test_ac_jfet_gate_source_capacitance_shunts_high_frequency_gate_drive() -> None:
+    """JFET CGS contributes gate-source AC susceptance."""
+
+    def gate_amplitude(cgs: float) -> float:
+        c = Circuit()
+        c.add(VoltageSource("Vac", "in", "0", 0.0, ac=AcSource(1.0)))
+        c.add(Resistor("Rin", "in", "gate", 1_000.0))
+        c.add(Resistor("Rdrain", "drain", "0", 1_000.0))
+        c.add(JFET("J1", "drain", "gate", "0", beta=1.0e-12, vto=-2.0, Cgs=cgs))
+        result = ac_sweep(c, f_start=100_000.0, f_stop=100_000.0, n_points=1)
+        return abs(result.points[0].node_voltages["gate"])
+
+    without_capacitance = gate_amplitude(0.0)
+    with_capacitance = gate_amplitude(1.0e-6)
+
+    assert without_capacitance > 0.9
+    assert with_capacitance < without_capacitance / 100.0
 
 
 def test_jfet_transient_source_follower_charges_output_capacitor() -> None:

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Stamp JFET `gate_source_capacitance` and `gate_drain_capacitance`
+  model-card storage as transient gate-source and gate-drain companions and AC
+  susceptance, matching Python and TypeScript, with regression coverage for
+  gate-step delay and high-frequency gate-drive shunting.
 - Stamp BJT `base_emitter_capacitance`, `base_collector_capacitance`,
   `forward_transit_time`, and `reverse_transit_time` model-card storage as
   transient base-emitter and base-collector companions, matching Python and

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -130,7 +130,7 @@ probe-voltage windows for diode, BJT, JFET, and Level-1 MOS model-depth audits.
 reference-deck metadata and stable per-temperature probe windows for those same
 fixture circuits. `device_model_capacitance_audit_fixtures` adds matching
 `.ac` reference-deck metadata and stable high-frequency probe magnitude windows
-for capacitance and current JFET invariant audits.
+for diode, BJT, JFET `CGS`/`CGD`, and Level-1 MOS capacitance audits.
 `device_model_noise_audit_fixtures` adds matching `.noise` reference-deck
 metadata and stable source/output PSD windows for diode and BJT shot noise plus
 JFET and Level-1 MOS channel thermal noise audits.
@@ -139,8 +139,10 @@ metadata, explicit terminal storage capacitance metadata, stable first/final
 probe-voltage windows, and charge-behavior notes for diode, BJT, JFET, and
 Level-1 MOS charge audits. Diode `junction_capacitance` / `transit_time` and
 BJT `base_emitter_capacitance` / `base_collector_capacitance` /
-`forward_transit_time` / `reverse_transit_time` model-card parameters also
-stamp transient storage, matching their small-signal AC capacitance semantics.
+`forward_transit_time` / `reverse_transit_time`, and JFET
+`gate_source_capacitance` / `gate_drain_capacitance` model-card parameters
+also stamp transient storage, matching their small-signal AC capacitance
+semantics.
 
 `analyze_custom_model_source` accepts only a two-terminal `I(p,n) <+ ...`
 module shape and rejects dynamic/event/system constructs; it is not a full

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -392,7 +392,7 @@ fn clone_subckt_element(
             element.junction_capacitance,
             element.transit_time,
         )),
-        Element::Jfet(element) => Element::Jfet(Jfet::with_model(
+        Element::Jfet(element) => Element::Jfet(Jfet::with_model_and_capacitance(
             format!("{instance_name}.{}", element.name),
             map_subckt_node(&element.drain, instance_name, node_map),
             map_subckt_node(&element.gate, instance_name, node_map),
@@ -401,6 +401,8 @@ fn clone_subckt_element(
             element.beta,
             element.threshold_voltage,
             element.channel_length_modulation,
+            element.gate_source_capacitance,
+            element.gate_drain_capacitance,
         )),
         Element::Bjt(element) => Element::Bjt(Bjt::with_model(
             format!("{instance_name}.{}", element.name),
@@ -2563,6 +2565,8 @@ pub struct Jfet {
     pub beta: f64,
     pub threshold_voltage: f64,
     pub channel_length_modulation: f64,
+    pub gate_source_capacitance: f64,
+    pub gate_drain_capacitance: f64,
 }
 
 impl Jfet {
@@ -2594,6 +2598,32 @@ impl Jfet {
         threshold_voltage: f64,
         channel_length_modulation: f64,
     ) -> Self {
+        Self::with_model_and_capacitance(
+            name,
+            drain,
+            gate,
+            source,
+            polarity,
+            beta,
+            threshold_voltage,
+            channel_length_modulation,
+            0.0,
+            0.0,
+        )
+    }
+
+    pub fn with_model_and_capacitance(
+        name: impl Into<String>,
+        drain: impl Into<String>,
+        gate: impl Into<String>,
+        source: impl Into<String>,
+        polarity: JfetPolarity,
+        beta: f64,
+        threshold_voltage: f64,
+        channel_length_modulation: f64,
+        gate_source_capacitance: f64,
+        gate_drain_capacitance: f64,
+    ) -> Self {
         Self {
             name: name.into(),
             drain: drain.into(),
@@ -2603,6 +2633,8 @@ impl Jfet {
             beta,
             threshold_voltage,
             channel_length_modulation,
+            gate_source_capacitance,
+            gate_drain_capacitance,
         }
     }
 }
@@ -2961,6 +2993,8 @@ fn model_card_parameter_alias(kind: ModelCardKind, key: &str) -> Option<&'static
             "BETA" | "BET" => Some("BETA"),
             "VTO" | "VT0" | "VTH" => Some("VTO"),
             "LAMBDA" | "LAM" => Some("LAMBDA"),
+            "CGS" | "CGS0" => Some("CGS"),
+            "CGD" | "CGD0" => Some("CGD"),
             _ => None,
         },
         ModelCardKind::Nmos | ModelCardKind::Pmos => match key {
@@ -3097,7 +3131,7 @@ pub fn jfet_from_model_card(
         ModelCardKind::Pjf => JfetPolarity::Pjf,
         _ => return Err(model_card_kind_error(&name, "JFET", model.kind)),
     };
-    Ok(Jfet::with_model(
+    Ok(Jfet::with_model_and_capacitance(
         name,
         drain,
         gate,
@@ -3114,6 +3148,8 @@ pub fn jfet_from_model_card(
             },
         ),
         model_card_value(model, "LAMBDA", 0.0),
+        model_card_value(model, "CGS", 0.0),
+        model_card_value(model, "CGD", 0.0),
     ))
 }
 
@@ -3290,7 +3326,11 @@ pub fn device_model_behavior_audit_fixtures() -> Result<Vec<DeviceModelBehaviorF
         "Rs", "source", "0", 1_000.0,
     )));
     jfet_circuit.add(Element::Jfet(jfet_from_model_card(
-        "J1", "drain", "gate", "source", jfet_model,
+        "J1",
+        "drain",
+        "gate",
+        "source",
+        &jfet_model,
     )?));
 
     let mos_model = models.get("Mn").ok_or_else(|| SpiceError::InvalidElement {
@@ -3542,10 +3582,17 @@ pub fn device_model_capacitance_audit_fixtures(
         "Q1", "col", "base", "0", bjt_model,
     )?));
 
-    let jfet_model = models.get("Jn").ok_or_else(|| SpiceError::InvalidElement {
-        name: "device_model_capacitance_audit_fixtures".to_string(),
-        reason: "missing Jn model fixture".to_string(),
-    })?;
+    let jfet_model = normalize_model_card(
+        "Jn",
+        "NJF",
+        &[
+            ("BETA", 9.0e-4),
+            ("VTO", -1.8),
+            ("LAMBDA", 0.02),
+            ("CGS", 2.0e-9),
+            ("CGD", 1.0e-10),
+        ],
+    )?;
     let mut jfet_circuit = Circuit::new();
     jfet_circuit.add(Element::VoltageSource(VoltageSource::with_ac(
         "Vdrive", "in", "0", 0.0, 1.0, 0.0,
@@ -3560,7 +3607,11 @@ pub fn device_model_capacitance_audit_fixtures(
         "Vgate", "gate", "0", 0.0,
     )));
     jfet_circuit.add(Element::Jfet(jfet_from_model_card(
-        "J1", "drain", "gate", "source", jfet_model,
+        "J1",
+        "drain",
+        "gate",
+        "source",
+        &jfet_model,
     )?));
 
     let mos_model = models.get("Mn").ok_or_else(|| SpiceError::InvalidElement {
@@ -3594,8 +3645,8 @@ pub fn device_model_capacitance_audit_fixtures(
             frequency_hz,
             expected_magnitude_min: 0.72,
             expected_magnitude_max: 0.74,
-            capacitance_behavior:
-                "diode CJO and TT contribute high-frequency shunt capacitance".to_string(),
+            capacitance_behavior: "diode CJO and TT contribute high-frequency shunt capacitance"
+                .to_string(),
             deck_lines: vec![
                 "* device-model capacitance fixture: diode-capacitance-ac".to_string(),
                 ".model Dfast D(IS=2e-14 CJO=1.5e-12 TT=4e-9)".to_string(),
@@ -3616,8 +3667,8 @@ pub fn device_model_capacitance_audit_fixtures(
             frequency_hz,
             expected_magnitude_min: 0.61,
             expected_magnitude_max: 0.64,
-            capacitance_behavior:
-                "BJT CJE and TF contribute base-emitter AC capacitance".to_string(),
+            capacitance_behavior: "BJT CJE and TF contribute base-emitter AC capacitance"
+                .to_string(),
             deck_lines: vec![
                 "* device-model capacitance fixture: bjt-capacitance-ac".to_string(),
                 ".model Qsmall NPN(BF=125 CJE=2e-12 TF=1e-10)".to_string(),
@@ -3631,18 +3682,19 @@ pub fn device_model_capacitance_audit_fixtures(
             ],
         },
         DeviceModelCapacitanceBehaviorFixture {
-            name: "jfet-capacitance-invariant-ac".to_string(),
+            name: "jfet-capacitance-ac".to_string(),
             kind: jfet_model.kind,
             model: jfet_model.clone(),
             circuit: jfet_circuit,
             probe_node: "source".to_string(),
             frequency_hz,
-            expected_magnitude_min: 0.69,
-            expected_magnitude_max: 0.71,
-            capacitance_behavior: "JFET capacitance is intentionally unmodeled; fixture records conductance-only AC response".to_string(),
+            expected_magnitude_min: 0.50,
+            expected_magnitude_max: 0.54,
+            capacitance_behavior: "JFET CGS/CGD contribute high-frequency gate-channel capacitance"
+                .to_string(),
             deck_lines: vec![
-                "* device-model capacitance fixture: jfet-capacitance-invariant-ac".to_string(),
-                ".model Jn NJF(BETA=9e-4 VTO=-1.8 LAMBDA=0.02)".to_string(),
+                "* device-model capacitance fixture: jfet-capacitance-ac".to_string(),
+                ".model Jn NJF(BETA=9e-4 VTO=-1.8 LAMBDA=0.02 CGS=2n CGD=100p)".to_string(),
                 "Vdrive in 0 0 AC 1".to_string(),
                 "Rin in source 1k".to_string(),
                 "Rd drain 0 2k".to_string(),
@@ -3662,8 +3714,8 @@ pub fn device_model_capacitance_audit_fixtures(
             frequency_hz,
             expected_magnitude_min: 0.72,
             expected_magnitude_max: 0.74,
-            capacitance_behavior:
-                "Level-1 MOS CBD contributes drain-bulk AC capacitance".to_string(),
+            capacitance_behavior: "Level-1 MOS CBD contributes drain-bulk AC capacitance"
+                .to_string(),
             deck_lines: vec![
                 "* device-model capacitance fixture: mos-level1-capacitance-ac".to_string(),
                 ".model Mn NMOS(LEVEL=1 VTO=0.55 LAMBDA=0.04 NSUB=1.6 CBD=3e-13)".to_string(),
@@ -3742,7 +3794,11 @@ pub fn device_model_noise_audit_fixtures(
         "Rs", "source", "0", 1_000.0,
     )));
     jfet_circuit.add(Element::Jfet(jfet_from_model_card(
-        "J1", "drain", "gate", "source", jfet_model,
+        "J1",
+        "drain",
+        "gate",
+        "source",
+        &jfet_model,
     )?));
 
     let mos_model = models.get("Mn").ok_or_else(|| SpiceError::InvalidElement {
@@ -3937,10 +3993,17 @@ pub fn device_model_charge_audit_fixtures(
         storage_capacitance_f,
     )));
 
-    let jfet_model = models.get("Jn").ok_or_else(|| SpiceError::InvalidElement {
-        name: "device_model_charge_audit_fixtures".to_string(),
-        reason: "missing Jn model fixture".to_string(),
-    })?;
+    let jfet_model = normalize_model_card(
+        "Jn",
+        "NJF",
+        &[
+            ("BETA", 9.0e-4),
+            ("VTO", -1.8),
+            ("LAMBDA", 0.02),
+            ("CGS", 2.0e-11),
+            ("CGD", 5.0e-12),
+        ],
+    )?;
     let mut jfet_circuit = Circuit::new();
     jfet_circuit.add(Element::VoltageSource(VoltageSource::new(
         "Vdd", "vdd", "0", 10.0,
@@ -3955,7 +4018,11 @@ pub fn device_model_charge_audit_fixtures(
         "Rs", "source", "0", 1_000.0,
     )));
     jfet_circuit.add(Element::Jfet(jfet_from_model_card(
-        "J1", "drain", "gate", "source", jfet_model,
+        "J1",
+        "drain",
+        "gate",
+        "source",
+        &jfet_model,
     )?));
     jfet_circuit.add(Element::Capacitor(Capacitor::new(
         "Cstore",
@@ -4055,10 +4122,10 @@ pub fn device_model_charge_audit_fixtures(
             expected_initial_max: 1.0,
             expected_final_min: 0.86,
             expected_final_max: 0.90,
-            charge_behavior: "JFET transient charge is intentionally external-only; fixture records explicit source storage until a JFET capacitance policy lands".to_string(),
+            charge_behavior: "JFET CGS/CGD contribute transient gate-source and gate-drain storage; explicit Cstore keeps the fixture comparable with other charge audits".to_string(),
             deck_lines: vec![
                 "* device-model charge fixture: jfet-storage-charge".to_string(),
-                ".model Jn NJF(BETA=9e-4 VTO=-1.8 LAMBDA=0.02)".to_string(),
+                ".model Jn NJF(BETA=9e-4 VTO=-1.8 LAMBDA=0.02 CGS=20p CGD=5p)".to_string(),
                 "Vdd vdd 0 10".to_string(),
                 "Vg gate 0 0".to_string(),
                 "Rd vdd drain 2k".to_string(),
@@ -19111,9 +19178,14 @@ fn solve_linear_circuit_at_operating_point(
                 &mut rhs,
                 operating_point,
             )?,
-            Element::Jfet(jfet) => {
-                stamp_jfet(jfet, node_indices, &mut matrix, &mut rhs, operating_point)?
-            }
+            Element::Jfet(jfet) => stamp_jfet(
+                jfet,
+                capacitor_states,
+                node_indices,
+                &mut matrix,
+                &mut rhs,
+                operating_point,
+            )?,
             Element::Bjt(bjt) => stamp_bjt(
                 bjt,
                 capacitor_states,
@@ -19423,7 +19495,7 @@ fn build_ac_matrix(
                 );
             }
             Element::Jfet(jfet) => {
-                stamp_ac_jfet_small_signal(jfet, node_indices, &mut matrix, operating_point)?
+                stamp_ac_jfet_small_signal(jfet, node_indices, &mut matrix, operating_point, omega)?
             }
             Element::Bjt(bjt) => {
                 stamp_ac_bjt_small_signal(bjt, node_indices, &mut matrix, operating_point, omega)?
@@ -20518,6 +20590,7 @@ struct JfetDcResult {
 
 fn stamp_jfet(
     jfet: &Jfet,
+    capacitor_states: &[CapacitorState],
     node_indices: &HashMap<String, usize>,
     matrix: &mut [Vec<f64>],
     rhs: &mut [f64],
@@ -20538,6 +20611,51 @@ fn stamp_jfet(
     stamp_conductance(matrix, drain, source, result.gds);
     stamp_transconductance(matrix, drain, source, gate, source, result.gm);
     stamp_equivalent_current_source(rhs, drain, source, equivalent_current);
+    stamp_jfet_charge(jfet, capacitor_states, node_indices, matrix, rhs)?;
+    Ok(())
+}
+
+fn stamp_jfet_charge(
+    jfet: &Jfet,
+    capacitor_states: &[CapacitorState],
+    node_indices: &HashMap<String, usize>,
+    matrix: &mut [Vec<f64>],
+    rhs: &mut [f64],
+) -> Result<(), SpiceError> {
+    for spec in jfet_charge_state_specs(jfet) {
+        let Some(state) = capacitor_states
+            .iter()
+            .find(|state| state.name == spec.name)
+        else {
+            continue;
+        };
+        let capacitance = spec.capacitance;
+        if capacitance <= 0.0 {
+            continue;
+        }
+        let conductance = match state.method {
+            TransientMethod::Trap => 2.0 * capacitance / state.time_step,
+            TransientMethod::Gear2 => 3.0 * capacitance / (2.0 * state.time_step),
+            TransientMethod::Euler => capacitance / state.time_step,
+        };
+        let history_current = match state.method {
+            TransientMethod::Trap => conductance * state.previous_voltage + state.previous_current,
+            TransientMethod::Gear2 => {
+                capacitance * (4.0 * state.previous_voltage - state.previous_previous_voltage)
+                    / (2.0 * state.time_step)
+            }
+            TransientMethod::Euler => conductance * state.previous_voltage,
+        };
+        let positive = node_index(node_indices, spec.positive);
+        let negative = node_index(node_indices, spec.negative);
+        stamp_conductance(matrix, positive, negative, conductance);
+        if let Some(index) = positive {
+            rhs[index] += history_current;
+        }
+        if let Some(index) = negative {
+            rhs[index] -= history_current;
+        }
+    }
     Ok(())
 }
 
@@ -20819,6 +20937,7 @@ fn stamp_ac_jfet_small_signal(
     node_indices: &HashMap<String, usize>,
     matrix: &mut [Vec<Complex>],
     operating_point: &[f64],
+    omega: f64,
 ) -> Result<(), SpiceError> {
     validate_jfet(jfet)?;
     let drain = node_index(node_indices, &jfet.drain);
@@ -20833,6 +20952,18 @@ fn stamp_ac_jfet_small_signal(
         drain_voltage - source_voltage,
     );
     stamp_complex_conductance(matrix, drain, source, Complex::new(result.gds, 0.0));
+    stamp_complex_conductance(
+        matrix,
+        gate,
+        source,
+        Complex::new(0.0, omega * jfet.gate_source_capacitance),
+    );
+    stamp_complex_conductance(
+        matrix,
+        gate,
+        drain,
+        Complex::new(0.0, omega * jfet.gate_drain_capacitance),
+    );
     stamp_complex_transconductance(
         matrix,
         drain,
@@ -20969,6 +21100,49 @@ fn bjt_charge_state_voltage(
     voltage_at(node_voltages, spec.positive) - voltage_at(node_voltages, spec.negative)
 }
 
+struct JfetChargeStateSpec<'a> {
+    name: String,
+    positive: &'a str,
+    negative: &'a str,
+    capacitance: f64,
+}
+
+fn jfet_gate_source_charge_state_name(jfet: &Jfet) -> String {
+    format!("_J_{}_gs_charge", jfet.name)
+}
+
+fn jfet_gate_drain_charge_state_name(jfet: &Jfet) -> String {
+    format!("_J_{}_gd_charge", jfet.name)
+}
+
+fn jfet_charge_state_specs(jfet: &Jfet) -> Vec<JfetChargeStateSpec<'_>> {
+    let mut specs = Vec::new();
+    if jfet.gate_source_capacitance > 0.0 {
+        specs.push(JfetChargeStateSpec {
+            name: jfet_gate_source_charge_state_name(jfet),
+            positive: jfet.gate.as_str(),
+            negative: jfet.source.as_str(),
+            capacitance: jfet.gate_source_capacitance,
+        });
+    }
+    if jfet.gate_drain_capacitance > 0.0 {
+        specs.push(JfetChargeStateSpec {
+            name: jfet_gate_drain_charge_state_name(jfet),
+            positive: jfet.gate.as_str(),
+            negative: jfet.drain.as_str(),
+            capacitance: jfet.gate_drain_capacitance,
+        });
+    }
+    specs
+}
+
+fn jfet_charge_state_voltage(
+    spec: &JfetChargeStateSpec<'_>,
+    node_voltages: &BTreeMap<String, f64>,
+) -> f64 {
+    voltage_at(node_voltages, spec.positive) - voltage_at(node_voltages, spec.negative)
+}
+
 fn validate_diode(diode: &Diode) -> Result<(), SpiceError> {
     if !diode.saturation_current.is_finite() || diode.saturation_current <= 0.0 {
         return Err(SpiceError::InvalidElement {
@@ -21080,6 +21254,18 @@ fn validate_jfet(jfet: &Jfet) -> Result<(), SpiceError> {
         return Err(SpiceError::InvalidElement {
             name: jfet.name.clone(),
             reason: "channel length modulation must be finite".to_string(),
+        });
+    }
+    if !jfet.gate_source_capacitance.is_finite() || jfet.gate_source_capacitance < 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: jfet.name.clone(),
+            reason: "gate-source capacitance must be finite and non-negative".to_string(),
+        });
+    }
+    if !jfet.gate_drain_capacitance.is_finite() || jfet.gate_drain_capacitance < 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: jfet.name.clone(),
+            reason: "gate-drain capacitance must be finite and non-negative".to_string(),
         });
     }
     Ok(())
@@ -21247,6 +21433,18 @@ fn initial_capacitor_states(
                     });
                 }
             }
+            Element::Jfet(jfet) => {
+                for spec in jfet_charge_state_specs(jfet) {
+                    states.push(CapacitorState {
+                        name: spec.name,
+                        previous_voltage: 0.0,
+                        previous_previous_voltage: 0.0,
+                        previous_current: 0.0,
+                        time_step,
+                        method,
+                    });
+                }
+            }
             _ => {}
         }
     }
@@ -21329,6 +21527,14 @@ fn capacitor_voltages(
                     );
                 }
             }
+            Element::Jfet(jfet) => {
+                for spec in jfet_charge_state_specs(jfet) {
+                    voltages.insert(
+                        spec.name.clone(),
+                        jfet_charge_state_voltage(&spec, node_voltages),
+                    );
+                }
+            }
             _ => {}
         }
     }
@@ -21371,6 +21577,18 @@ fn transient_lte_estimate(
             }
             Element::Bjt(bjt) => {
                 for spec in bjt_charge_state_specs(bjt) {
+                    let current = current_voltages.get(&spec.name).copied().unwrap_or(0.0);
+                    let previous = previous_voltages.get(&spec.name).copied().unwrap_or(0.0);
+                    let previous_previous = previous_previous_voltages
+                        .get(&spec.name)
+                        .copied()
+                        .unwrap_or(0.0);
+                    max_lte =
+                        max_lte.max((current - 2.0 * previous + previous_previous).abs() / 2.0);
+                }
+            }
+            Element::Jfet(jfet) => {
+                for spec in jfet_charge_state_specs(jfet) {
                     let current = current_voltages.get(&spec.name).copied().unwrap_or(0.0);
                     let previous = previous_voltages.get(&spec.name).copied().unwrap_or(0.0);
                     let previous_previous = previous_previous_voltages
@@ -21575,6 +21793,15 @@ fn update_capacitor_states(
                         bjt_charge_dynamic_capacitance(bjt, spec.kind, state.previous_voltage),
                     )
                 }),
+            Element::Jfet(jfet) => jfet_charge_state_specs(jfet)
+                .into_iter()
+                .find(|spec| spec.name == state.name)
+                .map(|spec| {
+                    (
+                        jfet_charge_state_voltage(&spec, node_voltages),
+                        spec.capacitance,
+                    )
+                }),
             _ => None,
         });
         let Some((voltage, capacitance)) = update else {
@@ -21625,6 +21852,19 @@ fn seed_device_capacitor_states(
                         .find(|state| state.name == spec.name)
                     {
                         let voltage = bjt_charge_state_voltage(&spec, node_voltages);
+                        state.previous_voltage = voltage;
+                        state.previous_previous_voltage = voltage;
+                        state.previous_current = 0.0;
+                    }
+                }
+            }
+            Element::Jfet(jfet) => {
+                for spec in jfet_charge_state_specs(jfet) {
+                    if let Some(state) = capacitor_states
+                        .iter_mut()
+                        .find(|state| state.name == spec.name)
+                    {
+                        let voltage = jfet_charge_state_voltage(&spec, node_voltages);
                         state.previous_voltage = voltage;
                         state.previous_previous_voltage = voltage;
                         state.previous_current = 0.0;

--- a/code/packages/rust/spice-engine/tests/ac_tests.rs
+++ b/code/packages/rust/spice-engine/tests/ac_tests.rs
@@ -157,7 +157,7 @@ fn device_model_capacitance_audit_fixtures_run_reference_ac_points() {
         vec![
             "diode-capacitance-ac",
             "bjt-capacitance-ac",
-            "jfet-capacitance-invariant-ac",
+            "jfet-capacitance-ac",
             "mos-level1-capacitance-ac"
         ]
     );
@@ -198,9 +198,7 @@ fn device_model_capacitance_audit_fixtures_run_reference_ac_points() {
         .iter()
         .find(|fixture| fixture.kind.as_str() == "NJF")
         .expect("JFET capacitance fixture should be present");
-    assert!(jfet_fixture
-        .capacitance_behavior
-        .contains("intentionally unmodeled"));
+    assert!(jfet_fixture.capacitance_behavior.contains("CGS/CGD"));
 }
 
 #[test]
@@ -915,6 +913,44 @@ fn ac_jfet_common_source_uses_dc_bias_for_small_signal_gain() {
     assert_close(out.real, -4.0);
     assert_close(out.imag, 0.0);
     assert_close(points[0].voltage("vdd").unwrap().abs(), 0.0);
+}
+
+#[test]
+fn ac_jfet_gate_source_capacitance_shunts_high_frequency_gate_drive() {
+    fn gate_amplitude(gate_source_capacitance: f64) -> f64 {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::with_ac(
+            "Vac", "in", "0", 0.0, 1.0, 0.0,
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rin", "in", "gate", 1_000.0,
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rdrain", "drain", "0", 1_000.0,
+        )));
+        circuit.add(Element::Jfet(Jfet::with_model_and_capacitance(
+            "J1",
+            "drain",
+            "gate",
+            "0",
+            JfetPolarity::Njf,
+            1.0e-12,
+            -2.0,
+            0.0,
+            gate_source_capacitance,
+            0.0,
+        )));
+        ac_sweep(&circuit, 100_000.0, 100_000.0, 1).unwrap()[0]
+            .voltage("gate")
+            .unwrap()
+            .abs()
+    }
+
+    let without_capacitance = gate_amplitude(0.0);
+    let with_capacitance = gate_amplitude(1.0e-6);
+
+    assert!(without_capacitance > 0.9);
+    assert!(with_capacitance < without_capacitance / 100.0);
 }
 
 #[test]

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -177,7 +177,7 @@ fn device_model_charge_audit_fixtures_run_reference_transients() {
         .iter()
         .find(|fixture| fixture.kind.as_str() == "NJF")
         .expect("expected JFET charge fixture");
-    assert!(jfet_fixture.charge_behavior.contains("external-only"));
+    assert!(jfet_fixture.charge_behavior.contains("CGS/CGD"));
 }
 
 #[test]
@@ -217,6 +217,52 @@ fn transient_diode_junction_capacitance_slows_current_step() {
     let charged = run(1.0e-12);
     let uncharged_first = uncharged[0].voltage("out").unwrap();
     let charged_first = charged[0].voltage("out").unwrap();
+
+    assert!(uncharged_first > 0.5);
+    assert!(charged_first < 0.01);
+    assert!(charged_first < uncharged_first);
+}
+
+#[test]
+fn transient_jfet_gate_source_capacitance_slows_gate_step() {
+    fn run(gate_source_capacitance: f64) -> Vec<TransientPoint> {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::with_waveform(
+            "Vstep",
+            "in",
+            "0",
+            0.0,
+            Waveform::Pwl(PwlWaveform::new(vec![
+                (0.0, 0.0),
+                (1.0e-9, 1.0),
+                (5.0e-9, 1.0),
+            ])),
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rin", "in", "gate", 1_000.0,
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rdrain", "drain", "0", 1_000.0,
+        )));
+        circuit.add(Element::Jfet(Jfet::with_model_and_capacitance(
+            "J1",
+            "drain",
+            "gate",
+            "0",
+            JfetPolarity::Njf,
+            1.0e-12,
+            -2.0,
+            0.0,
+            gate_source_capacitance,
+            0.0,
+        )));
+        transient_with_method(&circuit, 1.0e-9, 5.0e-9, TransientMethod::Euler).unwrap()
+    }
+
+    let uncharged = run(0.0);
+    let charged = run(1.0e-9);
+    let uncharged_first = uncharged[0].voltage("gate").unwrap();
+    let charged_first = charged[0].voltage("gate").unwrap();
 
     assert!(uncharged_first > 0.5);
     assert!(charged_first < 0.01);

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Stamp JFET `gateSourceCapacitance` and `gateDrainCapacitance` model-card
+  storage as transient gate-source and gate-drain companions and AC
+  susceptance, matching Python and Rust, with regression coverage for gate-step
+  delay and high-frequency gate-drive shunting.
 - Stamp BJT `baseEmitterCapacitance`, `baseCollectorCapacitance`,
   `forwardTransitTime`, and `reverseTransitTime` model-card storage as
   transient base-emitter and base-collector companions, matching Python and

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -195,16 +195,17 @@ windows for diode, BJT, JFET, and Level-1 MOS model-depth audits.
 metadata and stable per-temperature probe windows for those same fixture
 circuits. `deviceModelCapacitanceAuditFixtures` adds matching `.ac`
 reference-deck metadata and stable high-frequency probe magnitude windows for
-capacitance and current JFET invariant audits.
+diode, BJT, JFET `CGS`/`CGD`, and Level-1 MOS capacitance audits.
 `deviceModelNoiseAuditFixtures` adds matching `.noise` reference-deck metadata
 and stable source/output PSD windows for diode and BJT shot noise plus JFET
 and Level-1 MOS channel thermal noise audits.
 `deviceModelChargeAuditFixtures` adds matching `.tran` reference-deck metadata,
 explicit terminal storage capacitance metadata, stable first/final
 probe-voltage windows, and charge-behavior notes for diode, BJT, JFET, and
-Level-1 MOS charge audits. Diode `junctionCapacitance` / `transitTime` and BJT
+Level-1 MOS charge audits. Diode `junctionCapacitance` / `transitTime`, BJT
 `baseEmitterCapacitance` / `baseCollectorCapacitance` / `forwardTransitTime` /
-`reverseTransitTime` model-card parameters also stamp transient storage,
+`reverseTransitTime`, and JFET `gateSourceCapacitance` /
+`gateDrainCapacitance` model-card parameters also stamp transient storage,
 matching their small-signal AC capacitance semantics.
 
 `CustomModel`, `CustomModelEvaluation`, `customLinearConductanceModel`, and

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -933,6 +933,8 @@ export interface Jfet {
   readonly beta: number;
   readonly thresholdVoltage: number;
   readonly channelLengthModulation: number;
+  readonly gateSourceCapacitance: number;
+  readonly gateDrainCapacitance: number;
 }
 
 export type BjtPolarity = "NPN" | "PNP";
@@ -2653,7 +2655,7 @@ function cloneSubcktElement(
     case "diode":
       return diode(name, mapSubcktNode(element.anode, instanceName, nodeMap), mapSubcktNode(element.cathode, instanceName, nodeMap), element.saturationCurrent, element.thermalVoltage, element.emissionCoefficient, element.breakdownVoltage, element.breakdownCurrent, element.junctionCapacitance, element.transitTime);
     case "jfet":
-      return jfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), element.polarity, element.beta, element.thresholdVoltage, element.channelLengthModulation);
+      return jfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), element.polarity, element.beta, element.thresholdVoltage, element.channelLengthModulation, element.gateSourceCapacitance, element.gateDrainCapacitance);
     case "bjt":
       return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime, element.reverseTransitTime);
     case "mosfet":
@@ -6756,6 +6758,8 @@ export function jfet(
   beta = 1.0e-4,
   thresholdVoltage = polarity === "NJF" ? -2.0 : 2.0,
   channelLengthModulation = 0.0,
+  gateSourceCapacitance = 0.0,
+  gateDrainCapacitance = 0.0,
 ): Jfet {
   return {
     kind: "jfet",
@@ -6767,6 +6771,8 @@ export function jfet(
     beta,
     thresholdVoltage,
     channelLengthModulation,
+    gateSourceCapacitance,
+    gateDrainCapacitance,
   };
 }
 
@@ -6900,6 +6906,10 @@ const JFET_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
   VTH: "VTO",
   LAMBDA: "LAMBDA",
   LAM: "LAMBDA",
+  CGS: "CGS",
+  CGS0: "CGS",
+  CGD: "CGD",
+  CGD0: "CGD",
 };
 
 const MOS_LEVEL1_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
@@ -7059,6 +7069,8 @@ export function jfetFromModelCard(
     p.BETA ?? 1.0e-4,
     p.VTO ?? (model.kind === "NJF" ? -2.0 : 2.0),
     p.LAMBDA ?? 0.0,
+    p.CGS ?? 0.0,
+    p.CGD ?? 0.0,
   );
 }
 
@@ -7329,7 +7341,13 @@ export function deviceModelCapacitanceAuditFixtures(): readonly DeviceModelCapac
   bjtCircuit.add(resistor("Rc", "col", "0", 1_000.0));
   bjtCircuit.add(bjtFromModelCard("Q1", "col", "base", "0", bjtModel));
 
-  const jfetModel = requiredModel(models, "Jn", helperName);
+  const jfetModel = normalizeModelCard("Jn", "NJF", {
+    BETA: 9.0e-4,
+    VTO: -1.8,
+    LAMBDA: 0.02,
+    CGS: 2.0e-9,
+    CGD: 1.0e-10,
+  });
   const jfetCircuit = new Circuit();
   jfetCircuit.add(voltageSourceWithAc("Vdrive", "in", "0", 0.0, 1.0, 0.0));
   jfetCircuit.add(resistor("Rin", "in", "source", 1_000.0));
@@ -7389,19 +7407,18 @@ export function deviceModelCapacitanceAuditFixtures(): readonly DeviceModelCapac
       ],
     },
     {
-      name: "jfet-capacitance-invariant-ac",
+      name: "jfet-capacitance-ac",
       kind: jfetModel.kind,
       model: jfetModel,
       circuit: jfetCircuit,
       probeNode: "source",
       frequencyHz,
-      expectedMagnitudeMin: 0.69,
-      expectedMagnitudeMax: 0.71,
-      capacitanceBehavior:
-        "JFET capacitance is intentionally unmodeled; fixture records conductance-only AC response",
+      expectedMagnitudeMin: 0.50,
+      expectedMagnitudeMax: 0.54,
+      capacitanceBehavior: "JFET CGS/CGD contribute high-frequency gate-channel capacitance",
       deckLines: [
-        "* device-model capacitance fixture: jfet-capacitance-invariant-ac",
-        ".model Jn NJF(BETA=9e-4 VTO=-1.8 LAMBDA=0.02)",
+        "* device-model capacitance fixture: jfet-capacitance-ac",
+        ".model Jn NJF(BETA=9e-4 VTO=-1.8 LAMBDA=0.02 CGS=2n CGD=100p)",
         "Vdrive in 0 0 AC 1",
         "Rin in source 1k",
         "Rd drain 0 2k",
@@ -7604,7 +7621,13 @@ export function deviceModelChargeAuditFixtures(): readonly DeviceModelChargeBeha
   bjtCircuit.add(bjtFromModelCard("Q1", "vcc", "base", "out", bjtModel));
   bjtCircuit.add(capacitor("Cstore", "out", "0", storageCapacitanceFarads));
 
-  const jfetModel = requiredModel(models, "Jn", helperName);
+  const jfetModel = normalizeModelCard("Jn", "NJF", {
+    BETA: 9.0e-4,
+    VTO: -1.8,
+    LAMBDA: 0.02,
+    CGS: 2.0e-11,
+    CGD: 5.0e-12,
+  });
   const jfetCircuit = new Circuit();
   jfetCircuit.add(voltageSource("Vdd", "vdd", "0", 10.0));
   jfetCircuit.add(voltageSource("Vg", "gate", "0", 0.0));
@@ -7691,10 +7714,10 @@ export function deviceModelChargeAuditFixtures(): readonly DeviceModelChargeBeha
       expectedFinalMin: 0.86,
       expectedFinalMax: 0.90,
       chargeBehavior:
-        "JFET transient charge is intentionally external-only; fixture records explicit source storage until a JFET capacitance policy lands",
+        "JFET CGS/CGD contribute transient gate-source and gate-drain storage; explicit Cstore keeps the fixture comparable with other charge audits",
       deckLines: [
         "* device-model charge fixture: jfet-storage-charge",
-        ".model Jn NJF(BETA=9e-4 VTO=-1.8 LAMBDA=0.02)",
+        ".model Jn NJF(BETA=9e-4 VTO=-1.8 LAMBDA=0.02 CGS=20p CGD=5p)",
         "Vdd vdd 0 10",
         "Vg gate 0 0",
         "Rd vdd drain 2k",
@@ -15495,7 +15518,7 @@ function solveLinearCircuitAtOperatingPoint(
         stampDiode(element, capacitorStates, nodeIndices, matrix, rhs, operatingPoint);
         break;
       case "jfet":
-        stampJfet(element, nodeIndices, matrix, rhs, operatingPoint);
+        stampJfet(element, capacitorStates, nodeIndices, matrix, rhs, operatingPoint);
         break;
       case "bjt":
         stampBjt(element, capacitorStates, nodeIndices, matrix, rhs, operatingPoint);
@@ -15902,7 +15925,7 @@ function buildAcMatrix(
         );
         break;
       case "jfet":
-        stampAcJfetSmallSignal(element, nodeIndices, matrix, operatingPoint);
+        stampAcJfetSmallSignal(element, nodeIndices, matrix, operatingPoint, omega);
         break;
       case "bjt":
         stampAcBjtSmallSignal(element, nodeIndices, matrix, operatingPoint, omega);
@@ -16880,10 +16903,17 @@ function validateJfet(element: Jfet): void {
   if (!Number.isFinite(element.channelLengthModulation)) {
     throw invalidElement(element.name, "channel length modulation must be finite");
   }
+  if (!Number.isFinite(element.gateSourceCapacitance) || element.gateSourceCapacitance < 0.0) {
+    throw invalidElement(element.name, "gate-source capacitance must be finite and non-negative");
+  }
+  if (!Number.isFinite(element.gateDrainCapacitance) || element.gateDrainCapacitance < 0.0) {
+    throw invalidElement(element.name, "gate-drain capacitance must be finite and non-negative");
+  }
 }
 
 function stampJfet(
   element: Jfet,
+  capacitorStates: readonly CapacitorState[],
   nodeIndices: ReadonlyMap<string, number>,
   matrix: number[][],
   rhs: number[],
@@ -16905,6 +16935,45 @@ function stampJfet(
   stampConductance(matrix, drain, source, result.gds);
   stampTransconductance(matrix, drain, source, gate, source, result.gm);
   stampCurrentSourceEquivalent(rhs, drain, source, equivalentCurrent);
+  stampJfetCharge(element, capacitorStates, nodeIndices, matrix, rhs);
+}
+
+function stampJfetCharge(
+  element: Jfet,
+  capacitorStates: readonly CapacitorState[],
+  nodeIndices: ReadonlyMap<string, number>,
+  matrix: number[][],
+  rhs: number[],
+): void {
+  for (const spec of jfetChargeStateSpecs(element)) {
+    const state = capacitorStates.find((candidate) => candidate.name === spec.name);
+    if (state === undefined || spec.capacitance <= 0.0) {
+      continue;
+    }
+    const conductance =
+      state.method === "trap"
+        ? (2.0 * spec.capacitance) / state.timeStep
+        : state.method === "gear2"
+          ? (3.0 * spec.capacitance) / (2.0 * state.timeStep)
+          : spec.capacitance / state.timeStep;
+    const historyCurrent =
+      state.method === "trap"
+        ? conductance * state.previousVoltage + state.previousCurrent
+        : state.method === "gear2"
+          ? (spec.capacitance *
+              (4.0 * state.previousVoltage - state.previousPreviousVoltage)) /
+            (2.0 * state.timeStep)
+          : conductance * state.previousVoltage;
+    const positive = nodeIndex(nodeIndices, spec.positive);
+    const negative = nodeIndex(nodeIndices, spec.negative);
+    stampConductance(matrix, positive, negative, conductance);
+    if (positive !== undefined) {
+      rhs[positive] += historyCurrent;
+    }
+    if (negative !== undefined) {
+      rhs[negative] -= historyCurrent;
+    }
+  }
 }
 
 function evaluateJfet(element: Jfet, vgs: number, vds: number): JfetDcResult {
@@ -17241,6 +17310,49 @@ function bjtChargeStateVoltage(
   return voltageAt(nodeVoltages, spec.positive) - voltageAt(nodeVoltages, spec.negative);
 }
 
+interface JfetChargeStateSpec {
+  readonly name: string;
+  readonly positive: string;
+  readonly negative: string;
+  readonly capacitance: number;
+}
+
+function jfetGateSourceChargeStateName(element: Jfet): string {
+  return `_J_${element.name}_gs_charge`;
+}
+
+function jfetGateDrainChargeStateName(element: Jfet): string {
+  return `_J_${element.name}_gd_charge`;
+}
+
+function jfetChargeStateSpecs(element: Jfet): JfetChargeStateSpec[] {
+  const specs: JfetChargeStateSpec[] = [];
+  if (element.gateSourceCapacitance > 0.0) {
+    specs.push({
+      name: jfetGateSourceChargeStateName(element),
+      positive: element.gate,
+      negative: element.source,
+      capacitance: element.gateSourceCapacitance,
+    });
+  }
+  if (element.gateDrainCapacitance > 0.0) {
+    specs.push({
+      name: jfetGateDrainChargeStateName(element),
+      positive: element.gate,
+      negative: element.drain,
+      capacitance: element.gateDrainCapacitance,
+    });
+  }
+  return specs;
+}
+
+function jfetChargeStateVoltage(
+  spec: JfetChargeStateSpec,
+  nodeVoltages: ReadonlyMap<string, number>,
+): number {
+  return voltageAt(nodeVoltages, spec.positive) - voltageAt(nodeVoltages, spec.negative);
+}
+
 function validateBjt(element: Bjt): void {
   if (element.polarity !== "NPN" && element.polarity !== "PNP") {
     throw invalidElement(element.name, "BJT polarity must be NPN or PNP");
@@ -17355,6 +17467,17 @@ function initialCapacitorStates(
           method,
         });
       }
+    } else if (element.kind === "jfet") {
+      for (const spec of jfetChargeStateSpecs(element)) {
+        states.push({
+          name: spec.name,
+          previousVoltage: 0.0,
+          previousPreviousVoltage: 0.0,
+          previousCurrent: 0.0,
+          timeStep,
+          method,
+        });
+      }
     }
   }
   return states;
@@ -17424,6 +17547,10 @@ function capacitorVoltages(
       for (const spec of bjtChargeStateSpecs(element)) {
         voltages.set(spec.name, bjtChargeStateVoltage(spec, nodeVoltages));
       }
+    } else if (element.kind === "jfet") {
+      for (const spec of jfetChargeStateSpecs(element)) {
+        voltages.set(spec.name, jfetChargeStateVoltage(spec, nodeVoltages));
+      }
     }
   }
   return voltages;
@@ -17446,6 +17573,13 @@ function transientLteEstimate(
         maxLte = Math.max(maxLte, Math.abs(current - 2.0 * previous + previousPrevious) / 2.0);
       } else if (element.kind === "bjt") {
         for (const spec of bjtChargeStateSpecs(element)) {
+          const current = currentVoltages.get(spec.name) ?? 0.0;
+          const previous = previousVoltages.get(spec.name) ?? 0.0;
+          const previousPrevious = previousPreviousVoltages.get(spec.name) ?? 0.0;
+          maxLte = Math.max(maxLte, Math.abs(current - 2.0 * previous + previousPrevious) / 2.0);
+        }
+      } else if (element.kind === "jfet") {
+        for (const spec of jfetChargeStateSpecs(element)) {
           const current = currentVoltages.get(spec.name) ?? 0.0;
           const previous = previousVoltages.get(spec.name) ?? 0.0;
           const previousPrevious = previousPreviousVoltages.get(spec.name) ?? 0.0;
@@ -17629,7 +17763,26 @@ function updateCapacitorStates(
       bjtElement === undefined
         ? undefined
         : bjtChargeStateSpecs(bjtElement).find((spec) => spec.name === state.name);
-    if (capacitorElement === undefined && diodeElement === undefined && bjtSpec === undefined) {
+    const jfetElement =
+      capacitorElement === undefined && diodeElement === undefined && bjtSpec === undefined
+        ? circuit
+            .elements()
+            .find(
+              (candidate): candidate is Jfet =>
+                candidate.kind === "jfet" &&
+                jfetChargeStateSpecs(candidate).some((spec) => spec.name === state.name),
+            )
+        : undefined;
+    const jfetSpec =
+      jfetElement === undefined
+        ? undefined
+        : jfetChargeStateSpecs(jfetElement).find((spec) => spec.name === state.name);
+    if (
+      capacitorElement === undefined &&
+      diodeElement === undefined &&
+      bjtSpec === undefined &&
+      jfetSpec === undefined
+    ) {
       continue;
     }
     const previousVoltage = state.previousVoltage;
@@ -17639,13 +17792,17 @@ function updateCapacitorStates(
         ? voltageAt(nodeVoltages, capacitorElement.n1) - voltageAt(nodeVoltages, capacitorElement.n2)
         : diodeElement !== undefined
           ? diodeChargeVoltage(diodeElement, nodeVoltages)
-          : bjtChargeStateVoltage(bjtSpec!, nodeVoltages);
+          : bjtSpec !== undefined
+            ? bjtChargeStateVoltage(bjtSpec, nodeVoltages)
+            : jfetChargeStateVoltage(jfetSpec!, nodeVoltages);
     const capacitance =
       capacitorElement !== undefined
         ? capacitorElement.capacitanceFarads
         : diodeElement !== undefined
           ? diodeDynamicCapacitance(diodeElement, previousVoltage)
-          : bjtChargeDynamicCapacitance(bjtElement!, bjtSpec!.kind, previousVoltage);
+          : bjtSpec !== undefined
+            ? bjtChargeDynamicCapacitance(bjtElement!, bjtSpec.kind, previousVoltage)
+            : jfetSpec!.capacitance;
     if (state.method === "trap") {
       const conductance = (2.0 * capacitance) / state.timeStep;
       state.previousCurrent = conductance * (voltage - previousVoltage) - previousCurrent;
@@ -17687,6 +17844,17 @@ function seedDeviceCapacitorStates(
           continue;
         }
         const voltage = bjtChargeStateVoltage(spec, nodeVoltages);
+        state.previousVoltage = voltage;
+        state.previousPreviousVoltage = voltage;
+        state.previousCurrent = 0.0;
+      }
+    } else if (element.kind === "jfet") {
+      for (const spec of jfetChargeStateSpecs(element)) {
+        const state = capacitorStates.find((candidate) => candidate.name === spec.name);
+        if (state === undefined) {
+          continue;
+        }
+        const voltage = jfetChargeStateVoltage(spec, nodeVoltages);
         state.previousVoltage = voltage;
         state.previousPreviousVoltage = voltage;
         state.previousCurrent = 0.0;
@@ -19129,6 +19297,7 @@ function stampAcJfetSmallSignal(
   nodeIndices: ReadonlyMap<string, number>,
   matrix: Complex[][],
   operatingPoint: readonly number[],
+  omega: number,
 ): void {
   validateJfet(element);
   const drain = nodeIndex(nodeIndices, element.drain);
@@ -19143,6 +19312,18 @@ function stampAcJfetSmallSignal(
     drainVoltage - sourceVoltage,
   );
   stampComplexConductance(matrix, drain, source, complex(result.gds, 0.0));
+  stampComplexConductance(
+    matrix,
+    gate,
+    source,
+    complex(0.0, omega * element.gateSourceCapacitance),
+  );
+  stampComplexConductance(
+    matrix,
+    gate,
+    drain,
+    complex(0.0, omega * element.gateDrainCapacitance),
+  );
   stampComplexTransconductance(
     matrix,
     drain,

--- a/code/packages/typescript/spice-engine/tests/ac.test.ts
+++ b/code/packages/typescript/spice-engine/tests/ac.test.ts
@@ -157,7 +157,7 @@ describe("acSweep", () => {
     expect(fixtures.map((fixture) => fixture.name)).toStrictEqual([
       "diode-capacitance-ac",
       "bjt-capacitance-ac",
-      "jfet-capacitance-invariant-ac",
+      "jfet-capacitance-ac",
       "mos-level1-capacitance-ac",
     ]);
 
@@ -175,7 +175,7 @@ describe("acSweep", () => {
     }
 
     const jfetFixture = fixtures.find((fixture) => fixture.kind === "NJF");
-    expect(jfetFixture?.capacitanceBehavior).toContain("intentionally unmodeled");
+    expect(jfetFixture?.capacitanceBehavior).toContain("CGS/CGD");
   });
 
   it("places an RC low-pass at the minus-three-dB corner", () => {
@@ -429,6 +429,33 @@ describe("acSweep", () => {
     expectClose(out!.real, -4.0);
     expectClose(out!.imag, 0.0);
     expectClose(complexAbs(points[0].voltage("vdd")!), 0.0);
+  });
+
+  it("uses JFET gate-source capacitance in AC analysis", () => {
+    function gateAmplitude(gateSourceCapacitance: number): number {
+      const circuit = new Circuit();
+      circuit.add(voltageSourceWithAc("Vac", "in", "0", 0.0, 1.0));
+      circuit.add(resistor("Rin", "in", "gate", 1_000.0));
+      circuit.add(resistor("Rdrain", "drain", "0", 1_000.0));
+      circuit.add(jfet(
+        "J1",
+        "drain",
+        "gate",
+        "0",
+        "NJF",
+        1.0e-12,
+        -2.0,
+        0.0,
+        gateSourceCapacitance,
+      ));
+      return complexAbs(acSweep(circuit, 100_000.0, 100_000.0, 1)[0].voltage("gate")!);
+    }
+
+    const withoutCapacitance = gateAmplitude(0.0);
+    const withCapacitance = gateAmplitude(1.0e-6);
+
+    expect(withoutCapacitance).toBeGreaterThan(0.9);
+    expect(withCapacitance).toBeLessThan(withoutCapacitance / 100.0);
   });
 
   it("uses MOSFET overlap capacitance in AC analysis", () => {

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -211,7 +211,7 @@ describe("transient", () => {
     }
 
     const jfetFixture = fixtures.find((fixture) => fixture.kind === "NJF");
-    expect(jfetFixture?.chargeBehavior).toContain("external-only");
+    expect(jfetFixture?.chargeBehavior).toContain("CGS/CGD");
   });
 
   it("uses diode junction capacitance during transient current steps", () => {
@@ -235,6 +235,45 @@ describe("transient", () => {
 
     const unchargedFirst = run(0.0)[0].voltage("out");
     const chargedFirst = run(1.0e-12)[0].voltage("out");
+    expect(unchargedFirst).not.toBeUndefined();
+    expect(chargedFirst).not.toBeUndefined();
+    expect(unchargedFirst!).toBeGreaterThan(0.5);
+    expect(chargedFirst!).toBeLessThan(0.01);
+    expect(chargedFirst!).toBeLessThan(unchargedFirst!);
+  });
+
+  it("uses JFET gate-source capacitance during transient gate steps", () => {
+    function run(gateSourceCapacitance: number): TransientPoint[] {
+      const circuit = new Circuit();
+      circuit.add(voltageSourceWithWaveform(
+        "Vstep",
+        "in",
+        "0",
+        0.0,
+        new PwlWaveform([
+          [0.0, 0.0],
+          [1.0e-9, 1.0],
+          [5.0e-9, 1.0],
+        ]),
+      ));
+      circuit.add(resistor("Rin", "in", "gate", 1_000.0));
+      circuit.add(resistor("Rdrain", "drain", "0", 1_000.0));
+      circuit.add(jfet(
+        "J1",
+        "drain",
+        "gate",
+        "0",
+        "NJF",
+        1.0e-12,
+        -2.0,
+        0.0,
+        gateSourceCapacitance,
+      ));
+      return transient(circuit, 1.0e-9, 5.0e-9, "euler");
+    }
+
+    const unchargedFirst = run(0.0)[0].voltage("gate");
+    const chargedFirst = run(1.0e-9)[0].voltage("gate");
     expect(unchargedFirst).not.toBeUndefined();
     expect(chargedFirst).not.toBeUndefined();
     expect(unchargedFirst!).toBeGreaterThan(0.5);


### PR DESCRIPTION
## Summary
- Add JFET CGS/CGD model-card aliases and public capacitance fields across Python, Rust, and TypeScript.
- Stamp JFET gate-source and gate-drain capacitance into transient companion state and AC small-signal admittance.
- Update device-model capacitance/charge fixtures, docs, and regression coverage for AC gate shunting plus transient gate-step delay.

## Validation
- PYTHONPATH=/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-spice-jfet-transient-charge-stamping/code/packages/python/spice-engine/src:/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-spice-jfet-transient-charge-stamping/code/packages/python/mosfet-models/src:/Users/adhithya/Downloads/Codex/worktrees/coding-adventures-spice-jfet-transient-charge-stamping/code/packages/python/device-physics/src /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python -m pytest -o addopts='' code/packages/python/spice-engine/tests/test_engine.py -q
- cargo test -p spice-engine
- npm run build
- npm test