### PR TITLE
Add smart-home fixture controller launch help

### DIFF
--- a/code/packages/rust/smart-home-platform-http/BUILD
+++ b/code/packages/rust/smart-home-platform-http/BUILD
@@ -1,1 +1,2 @@
 cargo test -p smart-home-platform-http -- --nocapture
+cargo test -p smart-home-platform-http --example hue_fixture_controller -- --nocapture

--- a/code/packages/rust/smart-home-platform-http/CHANGELOG.md
+++ b/code/packages/rust/smart-home-platform-http/CHANGELOG.md
@@ -45,6 +45,8 @@ All notable changes to this package will be documented in this file.
   runtime event stream route.
 - Added browser dashboard detail actions for history, event-log,
   command-result, and authorization audit rows.
+- Added fixture-controller launch help, smoke-test URLs, and example-level tests
+  to keep the local controller startup path usable.
 - Added a native readiness checklist route with actionable links for registry,
   topology, state coverage, event bus, discovery, supervisor, authorization,
   and desired-state checks.

--- a/code/packages/rust/smart-home-platform-http/README.md
+++ b/code/packages/rust/smart-home-platform-http/README.md
@@ -112,7 +112,16 @@ bash BUILD
 Run the deterministic Hue fixture controller locally:
 
 ```bash
-cargo run -p smart-home-platform-http --example hue_fixture_controller -- 127.0.0.1:8123
+cargo run -p smart-home-platform-http --example hue_fixture_controller
+```
+
+The controller defaults to `127.0.0.1:8123`, accepts either a positional bind
+address or `--bind`, and prints dashboard, health, readiness, API catalog, and
+smoke-test URLs after the repo HTTP server binds:
+
+```bash
+cargo run -p smart-home-platform-http --example hue_fixture_controller -- --bind 127.0.0.1:8123
+cargo run -p smart-home-platform-http --example hue_fixture_controller -- --help
 ```
 
 Then query it from another shell:

--- a/code/packages/rust/smart-home-platform-http/examples/hue_fixture_controller.rs
+++ b/code/packages/rust/smart-home-platform-http/examples/hue_fixture_controller.rs
@@ -5,13 +5,19 @@ use smart_home_platform_http::{
 use smart_home_testkit::hue_lighting_runtime;
 use std::env;
 use std::error::Error;
+use std::io;
+use std::net::SocketAddr;
 use std::sync::Arc;
 use web_core::WebServer;
 
+const DEFAULT_BIND_ADDR: &str = "127.0.0.1:8123";
+const USAGE: &str = "Usage: cargo run -p smart-home-platform-http --example hue_fixture_controller -- [BIND_ADDR]\n       cargo run -p smart-home-platform-http --example hue_fixture_controller -- --bind 127.0.0.1:8123";
+
 fn main() -> Result<(), Box<dyn Error>> {
-    let bind_addr = env::args()
-        .nth(1)
-        .unwrap_or_else(|| "127.0.0.1:8123".to_string());
+    let Some(bind_addr) = bind_addr_from_args(env::args().skip(1))? else {
+        println!("{USAGE}");
+        return Ok(());
+    };
     let runtime = SmartHomePlatformHttpRuntime::new(
         hue_lighting_runtime(),
         SmartHomePlatformHttpConfig::new("Codex Home").with_time_zone("America/Los_Angeles"),
@@ -35,10 +41,113 @@ fn main() -> Result<(), Box<dyn Error>> {
     #[cfg(target_os = "windows")]
     let mut server = WebServer::bind_windows(&bind_addr, HttpServerOptions::default(), app)?;
 
-    println!(
-        "serving smart-home fixture controller on http://{}",
-        server.local_addr()
-    );
+    println!("{}", launch_guide(server.local_addr()));
     server.serve()?;
     Ok(())
+}
+
+fn bind_addr_from_args(
+    args: impl IntoIterator<Item = String>,
+) -> Result<Option<String>, io::Error> {
+    let mut bind_addr = None;
+    let mut args = args.into_iter();
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "-h" | "--help" => return Ok(None),
+            "--bind" => {
+                let Some(value) = args.next() else {
+                    return Err(invalid_input("--bind requires an address"));
+                };
+                set_bind_addr(&mut bind_addr, value)?;
+            }
+            _ if arg.starts_with("--bind=") => {
+                set_bind_addr(&mut bind_addr, arg["--bind=".len()..].to_string())?;
+            }
+            _ if arg.starts_with('-') => {
+                return Err(invalid_input(format!("unknown option `{arg}`")));
+            }
+            _ => set_bind_addr(&mut bind_addr, arg)?,
+        }
+    }
+    Ok(Some(
+        bind_addr.unwrap_or_else(|| DEFAULT_BIND_ADDR.to_string()),
+    ))
+}
+
+fn set_bind_addr(bind_addr: &mut Option<String>, value: String) -> Result<(), io::Error> {
+    if bind_addr.is_some() {
+        return Err(invalid_input("expected at most one bind address"));
+    }
+    *bind_addr = Some(value);
+    Ok(())
+}
+
+fn invalid_input(message: impl Into<String>) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidInput, message.into())
+}
+
+fn launch_guide(local_addr: SocketAddr) -> String {
+    let base_url = format!("http://{local_addr}");
+    format!(
+        "serving smart-home fixture controller\n  Dashboard: {base_url}/\n  Smart Home: {base_url}/smart-home\n  Health: {base_url}/api/smart_home/health\n  Readiness: {base_url}/api/smart_home/readiness\n  API catalog: {base_url}/api/smart_home/api\n\nSmoke commands:\n  curl {base_url}/api/smart_home/bootstrap\n  curl {base_url}/api/smart_home/events?limit=12\n  curl -X POST {base_url}/api/services/light/turn_on -H 'Content-Type: application/json' -d '{{\"entity_id\":\"light.entity_light_1\",\"brightness_pct\":75}}'"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bind_addr_defaults_to_local_home_assistant_port() {
+        assert_eq!(
+            bind_addr_from_args(Vec::<String>::new()).expect("default bind addr"),
+            Some(DEFAULT_BIND_ADDR.to_string())
+        );
+    }
+
+    #[test]
+    fn bind_addr_accepts_positional_and_flag_forms() {
+        assert_eq!(
+            bind_addr_from_args(["127.0.0.1:9999".to_string()]).expect("positional bind addr"),
+            Some("127.0.0.1:9999".to_string())
+        );
+        assert_eq!(
+            bind_addr_from_args(["--bind".to_string(), "127.0.0.1:7777".to_string()])
+                .expect("flag bind addr"),
+            Some("127.0.0.1:7777".to_string())
+        );
+        assert_eq!(
+            bind_addr_from_args(["--bind=127.0.0.1:6666".to_string()])
+                .expect("inline flag bind addr"),
+            Some("127.0.0.1:6666".to_string())
+        );
+    }
+
+    #[test]
+    fn bind_addr_reports_help_without_starting_server() {
+        assert_eq!(
+            bind_addr_from_args(["--help".to_string()]).expect("help should parse"),
+            None
+        );
+    }
+
+    #[test]
+    fn bind_addr_rejects_ambiguous_launches() {
+        assert!(
+            bind_addr_from_args(["127.0.0.1:1".to_string(), "127.0.0.1:2".to_string()]).is_err()
+        );
+        assert!(bind_addr_from_args(["--bind".to_string()]).is_err());
+        assert!(bind_addr_from_args(["--unknown".to_string()]).is_err());
+    }
+
+    #[test]
+    fn launch_guide_lists_dashboard_and_smoke_routes() {
+        let guide = launch_guide("127.0.0.1:8123".parse().expect("socket addr"));
+        assert!(guide.contains("Dashboard: http://127.0.0.1:8123/"));
+        assert!(guide.contains("Smart Home: http://127.0.0.1:8123/smart-home"));
+        assert!(guide.contains("curl http://127.0.0.1:8123/api/smart_home/bootstrap"));
+        assert!(guide.contains("curl http://127.0.0.1:8123/api/smart_home/events?limit=12"));
+        assert!(guide.contains("light.entity_light_1"));
+        assert!(guide.contains("brightness_pct"));
+    }
 }


### PR DESCRIPTION
## Summary
- add fixture-controller help and --bind parsing while preserving the existing positional bind address
- print dashboard, health, readiness, API catalog, and smoke-test URLs after the repo HTTP server binds
- add example-level tests and include them in the package BUILD script

## Validation
- cargo fmt -p smart-home-platform-http
- cargo test -p smart-home-platform-http -- --nocapture
- cargo test -p smart-home-platform-http --example hue_fixture_controller -- --nocapture
- sh BUILD (from code/packages/rust/smart-home-platform-http)
- git diff --check
- removed generated code/packages/rust/Cargo.lock