### PR TITLE
[codex] Add MOS Level-1 transient overlap charge stamping

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Added
 
+- **MOS Level-1 transient overlap charge stamping** —
+  Level-1 MOS `CGSO`/`CGDO`/`CGBO` model-card storage now stamps transient
+  gate-source, gate-drain, and gate-body companions, matching Rust and
+  TypeScript, with regression coverage for gate-step delay. Bulk junction
+  `CBS`/`CBD` storage remains AC-only until nonlinear junction-charge stamping
+  lands.
+
 - **JFET transient charge stamping** —
   JFET `Cgs`/`Cgd` model-card storage now stamps transient gate-source and
   gate-drain companions and contributes AC susceptance, matching Rust and

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -215,8 +215,10 @@ JFET and Level-1 MOS channel thermal noise audits.
 metadata, explicit terminal storage capacitance metadata, stable first/final
 probe-voltage windows, and charge-behavior notes for diode, BJT, JFET, and
 Level-1 MOS charge audits. Diode `Cjo` / `Tt`, BJT `Cje` / `Cjc` / `Tf` /
-`Tr`, and JFET `Cgs` / `Cgd` model-card parameters also stamp transient
-storage, matching their small-signal AC capacitance semantics.
+`Tr`, JFET `Cgs` / `Cgd`, and Level-1 MOS `CGSO` / `CGDO` / `CGBO`
+model-card parameters also stamp transient storage, matching their
+small-signal AC capacitance semantics. MOS bulk junction `CBS` / `CBD` remains
+AC-only until nonlinear junction-charge stamping lands.
 
 `DigitalEventStream`, `DigitalLogicLevels`, and `DigitalThresholds` provide the
 first mixed-signal bridge surface: digital event streams can drive finite-edge

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -8736,6 +8736,41 @@ def _jfet_charge_state_voltage(n_plus: str, n_minus: str, node_voltages: dict[st
     return _node_voltage(n_plus, node_voltages) - _node_voltage(n_minus, node_voltages)
 
 
+def _mosfet_gate_source_charge_state_name(el: Mosfet) -> str:
+    return f"_M_{el.name}_gs_charge"
+
+
+def _mosfet_gate_drain_charge_state_name(el: Mosfet) -> str:
+    return f"_M_{el.name}_gd_charge"
+
+
+def _mosfet_gate_body_charge_state_name(el: Mosfet) -> str:
+    return f"_M_{el.name}_gb_charge"
+
+
+def _mosfet_charge_state_specs(el: Mosfet) -> list[tuple[str, str, str, float]]:
+    params = getattr(getattr(el.model, "model", None), "params", None)
+    if params is None:
+        return []
+    width = getattr(params, "W", 0.0)
+    length = getattr(params, "L", 0.0)
+    specs: list[tuple[str, str, str, float]] = []
+    cgs = getattr(params, "CGSO", 0.0) * width
+    cgd = getattr(params, "CGDO", 0.0) * width
+    cgb = getattr(params, "CGBO", 0.0) * length
+    if cgs > 0.0:
+        specs.append((_mosfet_gate_source_charge_state_name(el), el.gate, el.source, cgs))
+    if cgd > 0.0:
+        specs.append((_mosfet_gate_drain_charge_state_name(el), el.gate, el.drain, cgd))
+    if cgb > 0.0:
+        specs.append((_mosfet_gate_body_charge_state_name(el), el.gate, el.body, cgb))
+    return specs
+
+
+def _mosfet_charge_state_voltage(n_plus: str, n_minus: str, node_voltages: dict[str, float]) -> float:
+    return _node_voltage(n_plus, node_voltages) - _node_voltage(n_minus, node_voltages)
+
+
 def _stamp_mosfet(
     G: list[list[float]],
     b: list[float],
@@ -9680,6 +9715,34 @@ def _build_transient_companions(
                     current=I_eq,
                 ))
 
+        # ---- MOS Level-1 overlap charge companions -------------------------
+        elif isinstance(el, Mosfet):
+            for state_name, n_plus, n_minus, capacitance in _mosfet_charge_state_specs(el):
+                v_prev = cap_voltages.get(state_name, 0.0)
+                if method == "trap":
+                    g_eq = 2.0 * capacitance / h
+                    I_eq = g_eq * v_prev + cap_currents.get(state_name, 0.0)
+                elif method == "gear2":
+                    v_older = cap_voltages_older.get(state_name, v_prev)
+                    g_eq = 3.0 * capacitance / (2.0 * h)
+                    I_eq = capacitance * (4.0 * v_prev - v_older) / (2.0 * h)
+                else:
+                    g_eq = capacitance / h
+                    I_eq = g_eq * v_prev
+
+                aug.elements.append(Resistor(
+                    name=f"{state_name}_R",
+                    n_plus=n_plus,
+                    n_minus=n_minus,
+                    resistance=1.0 / g_eq,
+                ))
+                aug.elements.append(CurrentSource(
+                    name=f"{state_name}_I",
+                    n_plus=n_minus,
+                    n_minus=n_plus,
+                    current=I_eq,
+                ))
+
         # ---- BJT model-card charge companions ------------------------------
         elif isinstance(el, BJT):
             for state_name, n_plus, n_minus, state_kind in _bjt_charge_state_specs(el):
@@ -9890,6 +9953,28 @@ def _update_reactive_state(
                 cap_voltages_older[state_name] = v_prev
                 cap_voltages[state_name] = v_new
 
+        elif isinstance(el, Mosfet):
+            for state_name, n_plus, n_minus, capacitance in _mosfet_charge_state_specs(el):
+                v_new = _mosfet_charge_state_voltage(n_plus, n_minus, op.node_voltages)
+                v_prev = cap_voltages.get(state_name, v_new)
+                v_older = cap_voltages_older.get(state_name, v_prev)
+
+                if method == "trap":
+                    g_eq = 2.0 * capacitance / h
+                    I_prev = cap_currents.get(state_name, 0.0)
+                    cap_currents[state_name] = g_eq * (v_new - v_prev) - I_prev
+                elif method == "gear2":
+                    cap_currents[state_name] = (
+                        capacitance * (3.0 * v_new - 4.0 * v_prev + v_older)
+                        / (2.0 * h)
+                    )
+                else:
+                    g_eq = capacitance / h
+                    cap_currents[state_name] = g_eq * (v_new - v_prev)
+
+                cap_voltages_older[state_name] = v_prev
+                cap_voltages[state_name] = v_new
+
         elif isinstance(el, BJT):
             for state_name, n_plus, n_minus, state_kind in _bjt_charge_state_specs(el):
                 v_new = _bjt_charge_state_voltage(n_plus, n_minus, op.node_voltages)
@@ -9980,6 +10065,14 @@ def _lte_estimate(
                 max_lte = lte_c
         elif isinstance(el, JFET):
             for state_name, _, _, _ in _jfet_charge_state_specs(el):
+                v1 = cap_voltages_now.get(state_name, 0.0)
+                v0 = cap_voltages_prev.get(state_name, 0.0)
+                vm1 = cap_voltages_prev2.get(state_name, 0.0)
+                lte_c = abs(v1 - 2.0 * v0 + vm1) / 2.0
+                if lte_c > max_lte:
+                    max_lte = lte_c
+        elif isinstance(el, Mosfet):
+            for state_name, _, _, _ in _mosfet_charge_state_specs(el):
                 v1 = cap_voltages_now.get(state_name, 0.0)
                 v0 = cap_voltages_prev.get(state_name, 0.0)
                 vm1 = cap_voltages_prev2.get(state_name, 0.0)
@@ -10164,6 +10257,13 @@ def transient(
                     n_minus,
                     op.node_voltages,
                 )
+        elif isinstance(el, Mosfet):
+            for state_name, n_plus, n_minus, _ in _mosfet_charge_state_specs(el):
+                cap_voltages[state_name] = _mosfet_charge_state_voltage(
+                    n_plus,
+                    n_minus,
+                    op.node_voltages,
+                )
         elif isinstance(el, BJT):
             for state_name, n_plus, n_minus, _ in _bjt_charge_state_specs(el):
                 cap_voltages[state_name] = _bjt_charge_state_voltage(
@@ -10180,6 +10280,9 @@ def transient(
             cap_currents[_diode_charge_state_name(el)] = 0.0
         elif isinstance(el, JFET):
             for state_name, _, _, _ in _jfet_charge_state_specs(el):
+                cap_currents[state_name] = 0.0
+        elif isinstance(el, Mosfet):
+            for state_name, _, _, _ in _mosfet_charge_state_specs(el):
                 cap_currents[state_name] = 0.0
         elif isinstance(el, BJT):
             for state_name, _, _, _ in _bjt_charge_state_specs(el):
@@ -10256,6 +10359,13 @@ def transient(
                 elif isinstance(el, JFET):
                     for state_name, n_plus, n_minus, _ in _jfet_charge_state_specs(el):
                         cap_voltages_new[state_name] = _jfet_charge_state_voltage(
+                            n_plus,
+                            n_minus,
+                            op.node_voltages,
+                        )
+                elif isinstance(el, Mosfet):
+                    for state_name, n_plus, n_minus, _ in _mosfet_charge_state_specs(el):
+                        cap_voltages_new[state_name] = _mosfet_charge_state_voltage(
                             n_plus,
                             n_minus,
                             op.node_voltages,

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -888,11 +888,10 @@ def device_model_noise_audit_fixtures() -> tuple[DeviceModelNoiseBehaviorFixture
 def device_model_charge_audit_fixtures() -> tuple[DeviceModelChargeBehaviorFixture, ...]:
     """Return runnable transient storage fixtures for charge model-depth audits.
 
-    Diode CJO/TT and BJT CJE/CJC/TF/TR model-card storage is
-    transient-stamped by the simulator. JFET fixed gate-source/gate-drain
-    storage is also transient-stamped; Level-1 MOS charge state is still
-    audited through explicit terminal storage capacitors until nonlinear charge
-    policies land.
+    Diode CJO/TT, BJT CJE/CJC/TF/TR, JFET fixed gate-source/gate-drain, and
+    Level-1 MOS fixed gate-overlap storage are transient-stamped by the
+    simulator. Level-1 MOS bulk junction charge is still audited through
+    explicit terminal storage capacitors until nonlinear charge policies land.
     """
 
     models = _model_card_by_name()
@@ -926,11 +925,25 @@ def device_model_charge_audit_fixtures() -> tuple[DeviceModelChargeBehaviorFixtu
     jfet_circuit.add(jfet_from_model_card("J1", "drain", "gate", "source", jfet_model))
     jfet_circuit.add(Capacitor("Cstore", "source", "0", storage_capacitance_f))
 
+    mos_model = normalize_model_card(
+        "Mn",
+        "NMOS",
+        {
+            "LEVEL": 1.0,
+            "VTO": 0.55,
+            "LAMBDA": 0.04,
+            "NSUB": 1.6,
+            "CGSO": 2.0e-11,
+            "CGDO": 5.0e-12,
+            "CGBO": 1.0e-12,
+            "CBD": 3.0e-13,
+        },
+    )
     mos_circuit = Circuit()
     mos_circuit.add(VoltageSource("Vdd", "vdd", "0", 1.8))
     mos_circuit.add(VoltageSource("Vgate", "gate", "0", 1.8))
     mos_circuit.add(Resistor("Rload", "vdd", "out", 1_000.0))
-    mos_circuit.add(mosfet_from_model_card("M1", "out", "gate", "0", "0", models["Mn"]))
+    mos_circuit.add(mosfet_from_model_card("M1", "out", "gate", "0", "0", mos_model))
     mos_circuit.add(Capacitor("Cstore", "out", "0", storage_capacitance_f))
 
     return (
@@ -1027,8 +1040,8 @@ def device_model_charge_audit_fixtures() -> tuple[DeviceModelChargeBehaviorFixtu
         ),
         DeviceModelChargeBehaviorFixture(
             name="mos-level1-storage-charge",
-            kind=models["Mn"].kind,
-            model=models["Mn"],
+            kind=mos_model.kind,
+            model=mos_model,
             circuit=mos_circuit,
             probe_node="out",
             time_step_s=time_step_s,
@@ -1039,12 +1052,12 @@ def device_model_charge_audit_fixtures() -> tuple[DeviceModelChargeBehaviorFixtu
             expected_final_min=0.68,
             expected_final_max=0.73,
             charge_behavior=(
-                "Level-1 MOS terminal charge is conserved through explicit Cstore; "
-                "overlap and junction capacitances remain AC-only until nonlinear charge stamping lands"
+                "Level-1 MOS CGSO/CGDO/CGBO contribute transient gate-overlap storage; "
+                "explicit Cstore keeps the fixture comparable while bulk junction charge remains AC-only"
             ),
             deck_lines=(
                 "* device-model charge fixture: mos-level1-storage-charge",
-                ".model Mn NMOS(LEVEL=1 VTO=0.55 LAMBDA=0.04 NSUB=1.6 CBD=3e-13)",
+                ".model Mn NMOS(LEVEL=1 VTO=0.55 LAMBDA=0.04 NSUB=1.6 CGSO=20p CGDO=5p CGBO=1p CBD=3e-13)",
                 "Vdd vdd 0 1.8",
                 "Vgate gate 0 1.8",
                 "Rload vdd out 1k",

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -552,6 +552,8 @@ def test_device_model_charge_audit_fixtures_run_reference_transients() -> None:
 
     jfet_fixture = next(fixture for fixture in fixtures if fixture.kind == "NJF")
     assert "CGS/CGD" in jfet_fixture.charge_behavior
+    mos_fixture = next(fixture for fixture in fixtures if fixture.kind == "NMOS")
+    assert "CGSO/CGDO/CGBO" in mos_fixture.charge_behavior
 
 
 def test_transient_diode_junction_capacitance_slows_current_step() -> None:
@@ -593,6 +595,43 @@ def test_transient_jfet_gate_source_capacitance_slows_gate_step() -> None:
         circuit.add(Resistor("Rin", "in", "gate", 1_000.0))
         circuit.add(Resistor("Rdrain", "drain", "0", 1_000.0))
         circuit.add(JFET("J1", "drain", "gate", "0", beta=1.0e-12, vto=-2.0, Cgs=cgs))
+        return transient(circuit, t_stop=5.0e-9, t_step=1.0e-9, method="euler")
+
+    uncharged = run(0.0)
+    charged = run(1.0e-9)
+
+    assert uncharged.converged
+    assert charged.converged
+    uncharged_first = uncharged.points[1].node_voltages["gate"]
+    charged_first = charged.points[1].node_voltages["gate"]
+    assert uncharged_first > 0.5
+    assert charged_first < 0.01
+    assert charged_first < uncharged_first
+
+
+def test_transient_mosfet_overlap_capacitance_slows_gate_step() -> None:
+    def run(cgso: float) -> TransientResult:
+        circuit = Circuit()
+        circuit.add(VoltageSource(
+            "Vstep",
+            "in",
+            "0",
+            0.0,
+            waveform=PwlWaveform(((0.0, 0.0), (1.0e-9, 1.0), (5.0e-9, 1.0))),
+        ))
+        circuit.add(Resistor("Rin", "in", "gate", 1_000.0))
+        circuit.add(Resistor("Rdrain", "drain", "0", 1_000.0))
+        circuit.add(Mosfet(
+            "M1",
+            "drain",
+            "gate",
+            "0",
+            "0",
+            MOSFET(
+                MosfetType.NMOS,
+                Level1Model(Level1Params(KP=1.0e-12, W=1.0, L=1.0, CGSO=cgso)),
+            ),
+        ))
         return transient(circuit, t_stop=5.0e-9, t_step=1.0e-9, method="euler")
 
     uncharged = run(0.0)

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- Stamp Level-1 MOS `gate_source_overlap_capacitance`,
+  `gate_drain_overlap_capacitance`, and `gate_bulk_overlap_capacitance`
+  model-card storage as transient gate-source, gate-drain, and gate-body
+  companions, matching Python and TypeScript, with regression coverage for
+  gate-step delay. Bulk junction capacitance remains AC-only until nonlinear
+  junction-charge stamping lands.
 - Stamp JFET `gate_source_capacitance` and `gate_drain_capacitance`
   model-card storage as transient gate-source and gate-drain companions and AC
   susceptance, matching Python and TypeScript, with regression coverage for

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -140,9 +140,12 @@ probe-voltage windows, and charge-behavior notes for diode, BJT, JFET, and
 Level-1 MOS charge audits. Diode `junction_capacitance` / `transit_time` and
 BJT `base_emitter_capacitance` / `base_collector_capacitance` /
 `forward_transit_time` / `reverse_transit_time`, and JFET
-`gate_source_capacitance` / `gate_drain_capacitance` model-card parameters
-also stamp transient storage, matching their small-signal AC capacitance
-semantics.
+`gate_source_capacitance` / `gate_drain_capacitance` plus Level-1 MOS
+`gate_source_overlap_capacitance`, `gate_drain_overlap_capacitance`, and
+`gate_bulk_overlap_capacitance` model-card parameters also stamp transient
+storage, matching their small-signal AC capacitance semantics. MOS bulk
+junction capacitance remains AC-only until nonlinear junction-charge stamping
+lands.
 
 `analyze_custom_model_source` accepts only a two-terminal `I(p,n) <+ ...`
 module shape and rejects dynamic/event/system constructs; it is not a full

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -4031,10 +4031,20 @@ pub fn device_model_charge_audit_fixtures(
         storage_capacitance_f,
     )));
 
-    let mos_model = models.get("Mn").ok_or_else(|| SpiceError::InvalidElement {
-        name: "device_model_charge_audit_fixtures".to_string(),
-        reason: "missing Mn model fixture".to_string(),
-    })?;
+    let mos_model = normalize_model_card(
+        "Mn",
+        "NMOS",
+        &[
+            ("LEVEL", 1.0),
+            ("VTO", 0.55),
+            ("LAMBDA", 0.04),
+            ("NSUB", 1.6),
+            ("CGSO", 2.0e-11),
+            ("CGDO", 5.0e-12),
+            ("CGBO", 1.0e-12),
+            ("CBD", 3.0e-13),
+        ],
+    )?;
     let mut mos_circuit = Circuit::new();
     mos_circuit.add(Element::VoltageSource(VoltageSource::new(
         "Vdd", "vdd", "0", 1.8,
@@ -4046,7 +4056,7 @@ pub fn device_model_charge_audit_fixtures(
         "Rload", "vdd", "out", 1_000.0,
     )));
     mos_circuit.add(Element::Mosfet(mosfet_from_model_card(
-        "M1", "out", "gate", "0", "0", mos_model,
+        "M1", "out", "gate", "0", "0", &mos_model,
     )?));
     mos_circuit.add(Element::Capacitor(Capacitor::new(
         "Cstore",
@@ -4140,7 +4150,7 @@ pub fn device_model_charge_audit_fixtures(
         DeviceModelChargeBehaviorFixture {
             name: "mos-level1-storage-charge".to_string(),
             kind: mos_model.kind,
-            model: mos_model.clone(),
+            model: mos_model,
             circuit: mos_circuit,
             probe_node: "out".to_string(),
             time_step_s,
@@ -4150,10 +4160,10 @@ pub fn device_model_charge_audit_fixtures(
             expected_initial_max: 1.0,
             expected_final_min: 0.68,
             expected_final_max: 0.73,
-            charge_behavior: "Level-1 MOS terminal charge is conserved through explicit Cstore; overlap and junction capacitances remain AC-only until nonlinear charge stamping lands".to_string(),
+            charge_behavior: "Level-1 MOS CGSO/CGDO/CGBO contribute transient gate-overlap storage; explicit Cstore keeps the fixture comparable while bulk junction charge remains AC-only".to_string(),
             deck_lines: vec![
                 "* device-model charge fixture: mos-level1-storage-charge".to_string(),
-                ".model Mn NMOS(LEVEL=1 VTO=0.55 LAMBDA=0.04 NSUB=1.6 CBD=3e-13)".to_string(),
+                ".model Mn NMOS(LEVEL=1 VTO=0.55 LAMBDA=0.04 NSUB=1.6 CGSO=20p CGDO=5p CGBO=1p CBD=3e-13)".to_string(),
                 "Vdd vdd 0 1.8".to_string(),
                 "Vgate gate 0 1.8".to_string(),
                 "Rload vdd out 1k".to_string(),
@@ -19194,9 +19204,14 @@ fn solve_linear_circuit_at_operating_point(
                 &mut rhs,
                 operating_point,
             )?,
-            Element::Mosfet(mosfet) => {
-                stamp_mosfet(mosfet, node_indices, &mut matrix, &mut rhs, operating_point)?
-            }
+            Element::Mosfet(mosfet) => stamp_mosfet(
+                mosfet,
+                capacitor_states,
+                node_indices,
+                &mut matrix,
+                &mut rhs,
+                operating_point,
+            )?,
             Element::Vccs(source) => stamp_vccs(source, node_indices, &mut matrix)?,
             Element::Vcvs(source) => stamp_vcvs(
                 source,
@@ -20719,6 +20734,7 @@ fn evaluate_njf(
 
 fn stamp_mosfet(
     mosfet: &Mosfet,
+    capacitor_states: &[CapacitorState],
     node_indices: &HashMap<String, usize>,
     matrix: &mut [Vec<f64>],
     rhs: &mut [f64],
@@ -20744,6 +20760,51 @@ fn stamp_mosfet(
     stamp_transconductance(matrix, drain, source, gate, source, result.gm);
     stamp_transconductance(matrix, drain, source, body, source, result.gmb);
     stamp_equivalent_current_source(rhs, drain, source, equivalent_current);
+    stamp_mosfet_charge(mosfet, capacitor_states, node_indices, matrix, rhs)?;
+    Ok(())
+}
+
+fn stamp_mosfet_charge(
+    mosfet: &Mosfet,
+    capacitor_states: &[CapacitorState],
+    node_indices: &HashMap<String, usize>,
+    matrix: &mut [Vec<f64>],
+    rhs: &mut [f64],
+) -> Result<(), SpiceError> {
+    for spec in mosfet_charge_state_specs(mosfet) {
+        let Some(state) = capacitor_states
+            .iter()
+            .find(|state| state.name == spec.name)
+        else {
+            continue;
+        };
+        let capacitance = spec.capacitance;
+        if capacitance <= 0.0 {
+            continue;
+        }
+        let conductance = match state.method {
+            TransientMethod::Trap => 2.0 * capacitance / state.time_step,
+            TransientMethod::Gear2 => 3.0 * capacitance / (2.0 * state.time_step),
+            TransientMethod::Euler => capacitance / state.time_step,
+        };
+        let history_current = match state.method {
+            TransientMethod::Trap => conductance * state.previous_voltage + state.previous_current,
+            TransientMethod::Gear2 => {
+                capacitance * (4.0 * state.previous_voltage - state.previous_previous_voltage)
+                    / (2.0 * state.time_step)
+            }
+            TransientMethod::Euler => conductance * state.previous_voltage,
+        };
+        let positive = node_index(node_indices, spec.positive);
+        let negative = node_index(node_indices, spec.negative);
+        stamp_conductance(matrix, positive, negative, conductance);
+        if let Some(index) = positive {
+            rhs[index] += history_current;
+        }
+        if let Some(index) = negative {
+            rhs[index] -= history_current;
+        }
+    }
     Ok(())
 }
 
@@ -21143,6 +21204,65 @@ fn jfet_charge_state_voltage(
     voltage_at(node_voltages, spec.positive) - voltage_at(node_voltages, spec.negative)
 }
 
+struct MosfetChargeStateSpec<'a> {
+    name: String,
+    positive: &'a str,
+    negative: &'a str,
+    capacitance: f64,
+}
+
+fn mosfet_gate_source_charge_state_name(mosfet: &Mosfet) -> String {
+    format!("_M_{}_gs_charge", mosfet.name)
+}
+
+fn mosfet_gate_drain_charge_state_name(mosfet: &Mosfet) -> String {
+    format!("_M_{}_gd_charge", mosfet.name)
+}
+
+fn mosfet_gate_body_charge_state_name(mosfet: &Mosfet) -> String {
+    format!("_M_{}_gb_charge", mosfet.name)
+}
+
+fn mosfet_charge_state_specs(mosfet: &Mosfet) -> Vec<MosfetChargeStateSpec<'_>> {
+    let mut specs = Vec::new();
+    let params = mosfet.params;
+    let gate_source_capacitance = params.gate_source_overlap_capacitance * params.w;
+    let gate_drain_capacitance = params.gate_drain_overlap_capacitance * params.w;
+    let gate_body_capacitance = params.gate_bulk_overlap_capacitance * params.l;
+    if gate_source_capacitance > 0.0 {
+        specs.push(MosfetChargeStateSpec {
+            name: mosfet_gate_source_charge_state_name(mosfet),
+            positive: mosfet.gate.as_str(),
+            negative: mosfet.source.as_str(),
+            capacitance: gate_source_capacitance,
+        });
+    }
+    if gate_drain_capacitance > 0.0 {
+        specs.push(MosfetChargeStateSpec {
+            name: mosfet_gate_drain_charge_state_name(mosfet),
+            positive: mosfet.gate.as_str(),
+            negative: mosfet.drain.as_str(),
+            capacitance: gate_drain_capacitance,
+        });
+    }
+    if gate_body_capacitance > 0.0 {
+        specs.push(MosfetChargeStateSpec {
+            name: mosfet_gate_body_charge_state_name(mosfet),
+            positive: mosfet.gate.as_str(),
+            negative: mosfet.body.as_str(),
+            capacitance: gate_body_capacitance,
+        });
+    }
+    specs
+}
+
+fn mosfet_charge_state_voltage(
+    spec: &MosfetChargeStateSpec<'_>,
+    node_voltages: &BTreeMap<String, f64>,
+) -> f64 {
+    voltage_at(node_voltages, spec.positive) - voltage_at(node_voltages, spec.negative)
+}
+
 fn validate_diode(diode: &Diode) -> Result<(), SpiceError> {
     if !diode.saturation_current.is_finite() || diode.saturation_current <= 0.0 {
         return Err(SpiceError::InvalidElement {
@@ -21445,6 +21565,18 @@ fn initial_capacitor_states(
                     });
                 }
             }
+            Element::Mosfet(mosfet) => {
+                for spec in mosfet_charge_state_specs(mosfet) {
+                    states.push(CapacitorState {
+                        name: spec.name,
+                        previous_voltage: 0.0,
+                        previous_previous_voltage: 0.0,
+                        previous_current: 0.0,
+                        time_step,
+                        method,
+                    });
+                }
+            }
             _ => {}
         }
     }
@@ -21535,6 +21667,14 @@ fn capacitor_voltages(
                     );
                 }
             }
+            Element::Mosfet(mosfet) => {
+                for spec in mosfet_charge_state_specs(mosfet) {
+                    voltages.insert(
+                        spec.name.clone(),
+                        mosfet_charge_state_voltage(&spec, node_voltages),
+                    );
+                }
+            }
             _ => {}
         }
     }
@@ -21589,6 +21729,18 @@ fn transient_lte_estimate(
             }
             Element::Jfet(jfet) => {
                 for spec in jfet_charge_state_specs(jfet) {
+                    let current = current_voltages.get(&spec.name).copied().unwrap_or(0.0);
+                    let previous = previous_voltages.get(&spec.name).copied().unwrap_or(0.0);
+                    let previous_previous = previous_previous_voltages
+                        .get(&spec.name)
+                        .copied()
+                        .unwrap_or(0.0);
+                    max_lte =
+                        max_lte.max((current - 2.0 * previous + previous_previous).abs() / 2.0);
+                }
+            }
+            Element::Mosfet(mosfet) => {
+                for spec in mosfet_charge_state_specs(mosfet) {
                     let current = current_voltages.get(&spec.name).copied().unwrap_or(0.0);
                     let previous = previous_voltages.get(&spec.name).copied().unwrap_or(0.0);
                     let previous_previous = previous_previous_voltages
@@ -21802,6 +21954,15 @@ fn update_capacitor_states(
                         spec.capacitance,
                     )
                 }),
+            Element::Mosfet(mosfet) => mosfet_charge_state_specs(mosfet)
+                .into_iter()
+                .find(|spec| spec.name == state.name)
+                .map(|spec| {
+                    (
+                        mosfet_charge_state_voltage(&spec, node_voltages),
+                        spec.capacitance,
+                    )
+                }),
             _ => None,
         });
         let Some((voltage, capacitance)) = update else {
@@ -21865,6 +22026,19 @@ fn seed_device_capacitor_states(
                         .find(|state| state.name == spec.name)
                     {
                         let voltage = jfet_charge_state_voltage(&spec, node_voltages);
+                        state.previous_voltage = voltage;
+                        state.previous_previous_voltage = voltage;
+                        state.previous_current = 0.0;
+                    }
+                }
+            }
+            Element::Mosfet(mosfet) => {
+                for spec in mosfet_charge_state_specs(mosfet) {
+                    if let Some(state) = capacitor_states
+                        .iter_mut()
+                        .find(|state| state.name == spec.name)
+                    {
+                        let voltage = mosfet_charge_state_voltage(&spec, node_voltages);
                         state.previous_voltage = voltage;
                         state.previous_previous_voltage = voltage;
                         state.previous_current = 0.0;

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -42,11 +42,11 @@ use spice_engine::{
     DigitalBridgeSchedule, DigitalEvent, DigitalEventStream, DigitalLogicLevels, DigitalState,
     DigitalThresholds, Diode, DistortionHarmonic, DistortionPoint, DistortionResult, Element,
     ExpWaveform, FourierHarmonic, FourierProbeResult, FourierResult, Inductor, Jfet, JfetPolarity,
-    MutualInductor, PoleZeroEntry, PoleZeroEntryKind, PoleZeroResult, PoleZeroTopology,
-    PssNewtonCandidateResult, PssNewtonIterationResult, PssNewtonSolveResult,
-    PssNewtonUpdateResult, PssResidualJacobianResult, PssResidualResult, PssResult, PulseWaveform,
-    PwlWaveform, Resistor, SinWaveform, SpiceError, TransientMethod, TransientPoint,
-    TransmissionLine, VoltageSource, Waveform,
+    Mosfet, MosfetLevel1Params, MosfetType, MutualInductor, PoleZeroEntry, PoleZeroEntryKind,
+    PoleZeroResult, PoleZeroTopology, PssNewtonCandidateResult, PssNewtonIterationResult,
+    PssNewtonSolveResult, PssNewtonUpdateResult, PssResidualJacobianResult, PssResidualResult,
+    PssResult, PulseWaveform, PwlWaveform, Resistor, SinWaveform, SpiceError, TransientMethod,
+    TransientPoint, TransmissionLine, VoltageSource, Waveform,
 };
 
 fn assert_close(actual: f64, expected: f64) {
@@ -178,6 +178,11 @@ fn device_model_charge_audit_fixtures_run_reference_transients() {
         .find(|fixture| fixture.kind.as_str() == "NJF")
         .expect("expected JFET charge fixture");
     assert!(jfet_fixture.charge_behavior.contains("CGS/CGD"));
+    let mos_fixture = fixtures
+        .iter()
+        .find(|fixture| fixture.kind.as_str() == "NMOS")
+        .expect("expected MOS charge fixture");
+    assert!(mos_fixture.charge_behavior.contains("CGSO/CGDO/CGBO"));
 }
 
 #[test]
@@ -255,6 +260,55 @@ fn transient_jfet_gate_source_capacitance_slows_gate_step() {
             0.0,
             gate_source_capacitance,
             0.0,
+        )));
+        transient_with_method(&circuit, 1.0e-9, 5.0e-9, TransientMethod::Euler).unwrap()
+    }
+
+    let uncharged = run(0.0);
+    let charged = run(1.0e-9);
+    let uncharged_first = uncharged[0].voltage("gate").unwrap();
+    let charged_first = charged[0].voltage("gate").unwrap();
+
+    assert!(uncharged_first > 0.5);
+    assert!(charged_first < 0.01);
+    assert!(charged_first < uncharged_first);
+}
+
+#[test]
+fn transient_mosfet_overlap_capacitance_slows_gate_step() {
+    fn run(gate_source_overlap_capacitance: f64) -> Vec<TransientPoint> {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::with_waveform(
+            "Vstep",
+            "in",
+            "0",
+            0.0,
+            Waveform::Pwl(PwlWaveform::new(vec![
+                (0.0, 0.0),
+                (1.0e-9, 1.0),
+                (5.0e-9, 1.0),
+            ])),
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rin", "in", "gate", 1_000.0,
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rdrain", "drain", "0", 1_000.0,
+        )));
+        circuit.add(Element::Mosfet(Mosfet::with_model(
+            "M1",
+            "drain",
+            "gate",
+            "0",
+            "0",
+            MosfetType::Nmos,
+            MosfetLevel1Params {
+                kp: 1.0e-12,
+                w: 1.0,
+                l: 1.0,
+                gate_source_overlap_capacitance,
+                ..MosfetLevel1Params::default()
+            },
         )));
         transient_with_method(&circuit, 1.0e-9, 5.0e-9, TransientMethod::Euler).unwrap()
     }

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Stamp Level-1 MOS `CGSO`, `CGDO`, and `CGBO` model-card storage as
+  transient gate-source, gate-drain, and gate-body companions, matching Python
+  and Rust, with regression coverage for gate-step delay. Bulk junction
+  `CBS`/`CBD` storage remains AC-only until nonlinear junction-charge stamping
+  lands.
 - Stamp JFET `gateSourceCapacitance` and `gateDrainCapacitance` model-card
   storage as transient gate-source and gate-drain companions and AC
   susceptance, matching Python and Rust, with regression coverage for gate-step

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -205,8 +205,10 @@ probe-voltage windows, and charge-behavior notes for diode, BJT, JFET, and
 Level-1 MOS charge audits. Diode `junctionCapacitance` / `transitTime`, BJT
 `baseEmitterCapacitance` / `baseCollectorCapacitance` / `forwardTransitTime` /
 `reverseTransitTime`, and JFET `gateSourceCapacitance` /
-`gateDrainCapacitance` model-card parameters also stamp transient storage,
-matching their small-signal AC capacitance semantics.
+`gateDrainCapacitance` plus Level-1 MOS `CGSO` / `CGDO` / `CGBO` model-card
+parameters also stamp transient storage, matching their small-signal AC
+capacitance semantics. MOS bulk junction `CBS` / `CBD` remains AC-only until
+nonlinear junction-charge stamping lands.
 
 `CustomModel`, `CustomModelEvaluation`, `customLinearConductanceModel`, and
 `analyzeCustomModelSource` provide the first native-web custom-model foothold.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -7636,7 +7636,16 @@ export function deviceModelChargeAuditFixtures(): readonly DeviceModelChargeBeha
   jfetCircuit.add(jfetFromModelCard("J1", "drain", "gate", "source", jfetModel));
   jfetCircuit.add(capacitor("Cstore", "source", "0", storageCapacitanceFarads));
 
-  const mosModel = requiredModel(models, "Mn", helperName);
+  const mosModel = normalizeModelCard("Mn", "NMOS", {
+    LEVEL: 1.0,
+    VTO: 0.55,
+    LAMBDA: 0.04,
+    NSUB: 1.6,
+    CGSO: 2.0e-11,
+    CGDO: 5.0e-12,
+    CGBO: 1.0e-12,
+    CBD: 3.0e-13,
+  });
   const mosCircuit = new Circuit();
   mosCircuit.add(voltageSource("Vdd", "vdd", "0", 1.8));
   mosCircuit.add(voltageSource("Vgate", "gate", "0", 1.8));
@@ -7743,10 +7752,10 @@ export function deviceModelChargeAuditFixtures(): readonly DeviceModelChargeBeha
       expectedFinalMin: 0.68,
       expectedFinalMax: 0.73,
       chargeBehavior:
-        "Level-1 MOS terminal charge is conserved through explicit Cstore; overlap and junction capacitances remain AC-only until nonlinear charge stamping lands",
+        "Level-1 MOS CGSO/CGDO/CGBO contribute transient gate-overlap storage; explicit Cstore keeps the fixture comparable while bulk junction charge remains AC-only",
       deckLines: [
         "* device-model charge fixture: mos-level1-storage-charge",
-        ".model Mn NMOS(LEVEL=1 VTO=0.55 LAMBDA=0.04 NSUB=1.6 CBD=3e-13)",
+        ".model Mn NMOS(LEVEL=1 VTO=0.55 LAMBDA=0.04 NSUB=1.6 CGSO=20p CGDO=5p CGBO=1p CBD=3e-13)",
         "Vdd vdd 0 1.8",
         "Vgate gate 0 1.8",
         "Rload vdd out 1k",
@@ -15524,7 +15533,7 @@ function solveLinearCircuitAtOperatingPoint(
         stampBjt(element, capacitorStates, nodeIndices, matrix, rhs, operatingPoint);
         break;
       case "mosfet":
-        stampMosfet(element, nodeIndices, matrix, rhs, operatingPoint);
+        stampMosfet(element, capacitorStates, nodeIndices, matrix, rhs, operatingPoint);
         break;
       case "vccs":
         stampVccs(element, nodeIndices, matrix);
@@ -17032,6 +17041,7 @@ function evaluateNjf(
 
 function stampMosfet(
   element: Mosfet,
+  capacitorStates: readonly CapacitorState[],
   nodeIndices: ReadonlyMap<string, number>,
   matrix: number[][],
   rhs: number[],
@@ -17057,6 +17067,45 @@ function stampMosfet(
   stampTransconductance(matrix, drain, source, gate, source, result.gm);
   stampTransconductance(matrix, drain, source, body, source, result.gmb);
   stampCurrentSourceEquivalent(rhs, drain, source, equivalentCurrent);
+  stampMosfetCharge(element, capacitorStates, nodeIndices, matrix, rhs);
+}
+
+function stampMosfetCharge(
+  element: Mosfet,
+  capacitorStates: readonly CapacitorState[],
+  nodeIndices: ReadonlyMap<string, number>,
+  matrix: number[][],
+  rhs: number[],
+): void {
+  for (const spec of mosfetChargeStateSpecs(element)) {
+    const state = capacitorStates.find((candidate) => candidate.name === spec.name);
+    if (state === undefined || spec.capacitance <= 0.0) {
+      continue;
+    }
+    const conductance =
+      state.method === "trap"
+        ? (2.0 * spec.capacitance) / state.timeStep
+        : state.method === "gear2"
+          ? (3.0 * spec.capacitance) / (2.0 * state.timeStep)
+          : spec.capacitance / state.timeStep;
+    const historyCurrent =
+      state.method === "trap"
+        ? conductance * state.previousVoltage + state.previousCurrent
+        : state.method === "gear2"
+          ? (spec.capacitance *
+              (4.0 * state.previousVoltage - state.previousPreviousVoltage)) /
+            (2.0 * state.timeStep)
+          : conductance * state.previousVoltage;
+    const positive = nodeIndex(nodeIndices, spec.positive);
+    const negative = nodeIndex(nodeIndices, spec.negative);
+    stampConductance(matrix, positive, negative, conductance);
+    if (positive !== undefined) {
+      rhs[positive] += historyCurrent;
+    }
+    if (negative !== undefined) {
+      rhs[negative] -= historyCurrent;
+    }
+  }
 }
 
 function evaluateMosfetLevel1(
@@ -17353,6 +17402,64 @@ function jfetChargeStateVoltage(
   return voltageAt(nodeVoltages, spec.positive) - voltageAt(nodeVoltages, spec.negative);
 }
 
+interface MosfetChargeStateSpec {
+  readonly name: string;
+  readonly positive: string;
+  readonly negative: string;
+  readonly capacitance: number;
+}
+
+function mosfetGateSourceChargeStateName(element: Mosfet): string {
+  return `_M_${element.name}_gs_charge`;
+}
+
+function mosfetGateDrainChargeStateName(element: Mosfet): string {
+  return `_M_${element.name}_gd_charge`;
+}
+
+function mosfetGateBodyChargeStateName(element: Mosfet): string {
+  return `_M_${element.name}_gb_charge`;
+}
+
+function mosfetChargeStateSpecs(element: Mosfet): MosfetChargeStateSpec[] {
+  const specs: MosfetChargeStateSpec[] = [];
+  const gateSourceCapacitance = element.params.CGSO * element.params.W;
+  const gateDrainCapacitance = element.params.CGDO * element.params.W;
+  const gateBodyCapacitance = element.params.CGBO * element.params.L;
+  if (gateSourceCapacitance > 0.0) {
+    specs.push({
+      name: mosfetGateSourceChargeStateName(element),
+      positive: element.gate,
+      negative: element.source,
+      capacitance: gateSourceCapacitance,
+    });
+  }
+  if (gateDrainCapacitance > 0.0) {
+    specs.push({
+      name: mosfetGateDrainChargeStateName(element),
+      positive: element.gate,
+      negative: element.drain,
+      capacitance: gateDrainCapacitance,
+    });
+  }
+  if (gateBodyCapacitance > 0.0) {
+    specs.push({
+      name: mosfetGateBodyChargeStateName(element),
+      positive: element.gate,
+      negative: element.body,
+      capacitance: gateBodyCapacitance,
+    });
+  }
+  return specs;
+}
+
+function mosfetChargeStateVoltage(
+  spec: MosfetChargeStateSpec,
+  nodeVoltages: ReadonlyMap<string, number>,
+): number {
+  return voltageAt(nodeVoltages, spec.positive) - voltageAt(nodeVoltages, spec.negative);
+}
+
 function validateBjt(element: Bjt): void {
   if (element.polarity !== "NPN" && element.polarity !== "PNP") {
     throw invalidElement(element.name, "BJT polarity must be NPN or PNP");
@@ -17478,6 +17585,17 @@ function initialCapacitorStates(
           method,
         });
       }
+    } else if (element.kind === "mosfet") {
+      for (const spec of mosfetChargeStateSpecs(element)) {
+        states.push({
+          name: spec.name,
+          previousVoltage: 0.0,
+          previousPreviousVoltage: 0.0,
+          previousCurrent: 0.0,
+          timeStep,
+          method,
+        });
+      }
     }
   }
   return states;
@@ -17551,6 +17669,10 @@ function capacitorVoltages(
       for (const spec of jfetChargeStateSpecs(element)) {
         voltages.set(spec.name, jfetChargeStateVoltage(spec, nodeVoltages));
       }
+    } else if (element.kind === "mosfet") {
+      for (const spec of mosfetChargeStateSpecs(element)) {
+        voltages.set(spec.name, mosfetChargeStateVoltage(spec, nodeVoltages));
+      }
     }
   }
   return voltages;
@@ -17580,6 +17702,13 @@ function transientLteEstimate(
         }
       } else if (element.kind === "jfet") {
         for (const spec of jfetChargeStateSpecs(element)) {
+          const current = currentVoltages.get(spec.name) ?? 0.0;
+          const previous = previousVoltages.get(spec.name) ?? 0.0;
+          const previousPrevious = previousPreviousVoltages.get(spec.name) ?? 0.0;
+          maxLte = Math.max(maxLte, Math.abs(current - 2.0 * previous + previousPrevious) / 2.0);
+        }
+      } else if (element.kind === "mosfet") {
+        for (const spec of mosfetChargeStateSpecs(element)) {
           const current = currentVoltages.get(spec.name) ?? 0.0;
           const previous = previousVoltages.get(spec.name) ?? 0.0;
           const previousPrevious = previousPreviousVoltages.get(spec.name) ?? 0.0;
@@ -17777,11 +17906,29 @@ function updateCapacitorStates(
       jfetElement === undefined
         ? undefined
         : jfetChargeStateSpecs(jfetElement).find((spec) => spec.name === state.name);
-    if (
+    const mosfetElement =
       capacitorElement === undefined &&
       diodeElement === undefined &&
       bjtSpec === undefined &&
       jfetSpec === undefined
+        ? circuit
+            .elements()
+            .find(
+              (candidate): candidate is Mosfet =>
+                candidate.kind === "mosfet" &&
+                mosfetChargeStateSpecs(candidate).some((spec) => spec.name === state.name),
+            )
+        : undefined;
+    const mosfetSpec =
+      mosfetElement === undefined
+        ? undefined
+        : mosfetChargeStateSpecs(mosfetElement).find((spec) => spec.name === state.name);
+    if (
+      capacitorElement === undefined &&
+      diodeElement === undefined &&
+      bjtSpec === undefined &&
+      jfetSpec === undefined &&
+      mosfetSpec === undefined
     ) {
       continue;
     }
@@ -17794,7 +17941,9 @@ function updateCapacitorStates(
           ? diodeChargeVoltage(diodeElement, nodeVoltages)
           : bjtSpec !== undefined
             ? bjtChargeStateVoltage(bjtSpec, nodeVoltages)
-            : jfetChargeStateVoltage(jfetSpec!, nodeVoltages);
+            : jfetSpec !== undefined
+              ? jfetChargeStateVoltage(jfetSpec, nodeVoltages)
+              : mosfetChargeStateVoltage(mosfetSpec!, nodeVoltages);
     const capacitance =
       capacitorElement !== undefined
         ? capacitorElement.capacitanceFarads
@@ -17802,7 +17951,9 @@ function updateCapacitorStates(
           ? diodeDynamicCapacitance(diodeElement, previousVoltage)
           : bjtSpec !== undefined
             ? bjtChargeDynamicCapacitance(bjtElement!, bjtSpec.kind, previousVoltage)
-            : jfetSpec!.capacitance;
+            : jfetSpec !== undefined
+              ? jfetSpec.capacitance
+              : mosfetSpec!.capacitance;
     if (state.method === "trap") {
       const conductance = (2.0 * capacitance) / state.timeStep;
       state.previousCurrent = conductance * (voltage - previousVoltage) - previousCurrent;
@@ -17855,6 +18006,17 @@ function seedDeviceCapacitorStates(
           continue;
         }
         const voltage = jfetChargeStateVoltage(spec, nodeVoltages);
+        state.previousVoltage = voltage;
+        state.previousPreviousVoltage = voltage;
+        state.previousCurrent = 0.0;
+      }
+    } else if (element.kind === "mosfet") {
+      for (const spec of mosfetChargeStateSpecs(element)) {
+        const state = capacitorStates.find((candidate) => candidate.name === spec.name);
+        if (state === undefined) {
+          continue;
+        }
+        const voltage = mosfetChargeStateVoltage(spec, nodeVoltages);
         state.previousVoltage = voltage;
         state.previousPreviousVoltage = voltage;
         state.previousCurrent = 0.0;

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -84,6 +84,7 @@ import {
   inductor,
   inductorWithInitialCurrent,
   jfet,
+  mosfet,
   mutualInductor,
   pss,
   pssCorners,
@@ -212,6 +213,8 @@ describe("transient", () => {
 
     const jfetFixture = fixtures.find((fixture) => fixture.kind === "NJF");
     expect(jfetFixture?.chargeBehavior).toContain("CGS/CGD");
+    const mosFixture = fixtures.find((fixture) => fixture.kind === "NMOS");
+    expect(mosFixture?.chargeBehavior).toContain("CGSO/CGDO/CGBO");
   });
 
   it("uses diode junction capacitance during transient current steps", () => {
@@ -269,6 +272,40 @@ describe("transient", () => {
         0.0,
         gateSourceCapacitance,
       ));
+      return transient(circuit, 1.0e-9, 5.0e-9, "euler");
+    }
+
+    const unchargedFirst = run(0.0)[0].voltage("gate");
+    const chargedFirst = run(1.0e-9)[0].voltage("gate");
+    expect(unchargedFirst).not.toBeUndefined();
+    expect(chargedFirst).not.toBeUndefined();
+    expect(unchargedFirst!).toBeGreaterThan(0.5);
+    expect(chargedFirst!).toBeLessThan(0.01);
+    expect(chargedFirst!).toBeLessThan(unchargedFirst!);
+  });
+
+  it("uses MOSFET overlap capacitance during transient gate steps", () => {
+    function run(gateSourceOverlapCapacitance: number): TransientPoint[] {
+      const circuit = new Circuit();
+      circuit.add(voltageSourceWithWaveform(
+        "Vstep",
+        "in",
+        "0",
+        0.0,
+        new PwlWaveform([
+          [0.0, 0.0],
+          [1.0e-9, 1.0],
+          [5.0e-9, 1.0],
+        ]),
+      ));
+      circuit.add(resistor("Rin", "in", "gate", 1_000.0));
+      circuit.add(resistor("Rdrain", "drain", "0", 1_000.0));
+      circuit.add(mosfet("M1", "drain", "gate", "0", "0", "NMOS", {
+        KP: 1.0e-12,
+        W: 1.0,
+        L: 1.0,
+        CGSO: gateSourceOverlapCapacitance,
+      }));
       return transient(circuit, 1.0e-9, 5.0e-9, "euler");
     }
 

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -15,22 +15,21 @@ downstream tools to compare.
 
 ## Current PR Slice
 
-1. BJT model-card transient charge stamping.
+1. MOS Level-1 transient overlap charge stamping.
    - Status: current PR completion candidate.
-   - Python, Rust, and TypeScript transient solvers now stamp BJT model-card
-     `CJE` / `base_emitter_capacitance` / `baseEmitterCapacitance`,
-     `CJC` / `base_collector_capacitance` / `baseCollectorCapacitance`,
-     `TF` / `forward_transit_time` / `forwardTransitTime`, and
-     `TR` / `reverse_transit_time` / `reverseTransitTime` as base-emitter and
-     base-collector storage companions.
-   - The companions use the previous junction bias to derive
-     `Cbe = Cje + Tf * gm_forward` and `Cbc = Cjc + Tr * gm_reverse`, reuse the
-     existing Euler/trapezoidal/Gear-2 capacitor history policy, and seed the
-     synthetic BJT charge states from the initial operating point.
-   - Cross-language tests cover base-emitter capacitance current-step delay and
-     forward transit-time charge retention after turnoff.
-   - JFET and Level-1 MOS charge storage remain audited through explicit
-     terminal storage capacitors until their nonlinear charge policies land.
+   - Python, Rust, and TypeScript transient solvers now stamp Level-1 MOS
+     model-card `CGSO` / `gate_source_overlap_capacitance`, `CGDO` /
+     `gate_drain_overlap_capacitance`, and `CGBO` /
+     `gate_bulk_overlap_capacitance` as fixed gate-source, gate-drain, and
+     gate-body overlap storage companions.
+   - The companions reuse the existing Euler/trapezoidal/Gear-2 capacitor
+     history policy and seed the synthetic MOS overlap charge states from the
+     initial operating point.
+   - Cross-language tests cover MOS gate-step delay through `CGSO` overlap
+     storage, and charge-audit fixtures now record the MOS overlap terms as
+     transient-stamped.
+   - MOS `CBS` / `CBD` bulk junction charge remains AC-only until a nonlinear
+     junction-charge policy lands.
 
 ## Completed Slices
 
@@ -1242,6 +1241,33 @@ downstream tools to compare.
      the initial operating point.
    - Cross-language tests cover both junction-capacitance current-step delay
      and transit-time forward-charge retention after turnoff.
+
+122. BJT model-card transient charge stamping.
+   - Status: completed in PR 6803.
+   - Python, Rust, and TypeScript transient solvers now stamp BJT model-card
+     `CJE` / `base_emitter_capacitance` / `baseEmitterCapacitance`,
+     `CJC` / `base_collector_capacitance` / `baseCollectorCapacitance`,
+     `TF` / `forward_transit_time` / `forwardTransitTime`, and
+     `TR` / `reverse_transit_time` / `reverseTransitTime` as base-emitter and
+     base-collector storage companions.
+   - The companions use the previous junction bias to derive
+     `Cbe = Cje + Tf * gm_forward` and `Cbc = Cjc + Tr * gm_reverse`, reuse the
+     existing Euler/trapezoidal/Gear-2 capacitor history policy, and seed the
+     synthetic BJT charge states from the initial operating point.
+   - Cross-language tests cover base-emitter capacitance current-step delay and
+     forward transit-time charge retention after turnoff.
+
+123. JFET model-card transient charge stamping.
+   - Status: completed in PR 6812.
+   - Python, Rust, and TypeScript transient solvers now stamp JFET model-card
+     `CGS` / `gate_source_capacitance` / `gateSourceCapacitance` and `CGD` /
+     `gate_drain_capacitance` / `gateDrainCapacitance` as fixed gate-source and
+     gate-drain storage companions.
+   - The companions reuse the existing Euler/trapezoidal/Gear-2 capacitor
+     history policy, seed synthetic JFET charge states from the initial
+     operating point, and contribute matching small-signal AC susceptance.
+   - Cross-language tests cover gate-step delay and high-frequency gate-drive
+     shunting.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- stamp Level-1 MOS CGSO/CGDO/CGBO fixed overlap capacitances as transient gate-source, gate-drain, and gate-body companions across Python, Rust, and TypeScript
- seed/update MOS overlap charge states through the existing Euler/trap/Gear-2 capacitor history paths
- update charge audit fixture metadata, package docs/changelogs, and the SPICE implementation plan while leaving MOS bulk junction CBS/CBD charge as AC-only future work

## Verification
- Python: `PYTHONPATH=... python -m pytest -o addopts='' code/packages/python/spice-engine/tests/test_engine.py -q` (454 passed)
- Rust: `cargo test -p spice-engine`
- TypeScript: `npm run build && npm test` (238 passed)
- `git diff --check`