### PR TITLE
[codex] Add MOS bulk junction transient charge stamping

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,12 +4,15 @@
 
 ### Added
 
+- **MOS Level-1 transient bulk-junction charge stamping** —
+  Level-1 MOS zero-bias bulk-junction `CBS`/`CBD` model-card storage now
+  stamps transient source-body and drain-body companions, matching Rust and
+  TypeScript, with regression coverage for drain-step delay.
+
 - **MOS Level-1 transient overlap charge stamping** —
   Level-1 MOS `CGSO`/`CGDO`/`CGBO` model-card storage now stamps transient
   gate-source, gate-drain, and gate-body companions, matching Rust and
-  TypeScript, with regression coverage for gate-step delay. Bulk junction
-  `CBS`/`CBD` storage remains AC-only until nonlinear junction-charge stamping
-  lands.
+  TypeScript, with regression coverage for gate-step delay.
 
 - **JFET transient charge stamping** —
   JFET `Cgs`/`Cgd` model-card storage now stamps transient gate-source and

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -215,10 +215,9 @@ JFET and Level-1 MOS channel thermal noise audits.
 metadata, explicit terminal storage capacitance metadata, stable first/final
 probe-voltage windows, and charge-behavior notes for diode, BJT, JFET, and
 Level-1 MOS charge audits. Diode `Cjo` / `Tt`, BJT `Cje` / `Cjc` / `Tf` /
-`Tr`, JFET `Cgs` / `Cgd`, and Level-1 MOS `CGSO` / `CGDO` / `CGBO`
-model-card parameters also stamp transient storage, matching their
-small-signal AC capacitance semantics. MOS bulk junction `CBS` / `CBD` remains
-AC-only until nonlinear junction-charge stamping lands.
+`Tr`, JFET `Cgs` / `Cgd`, and Level-1 MOS `CGSO` / `CGDO` / `CGBO` plus
+zero-bias bulk-junction `CBS` / `CBD` model-card parameters also stamp
+transient storage, matching their small-signal AC capacitance semantics.
 
 `DigitalEventStream`, `DigitalLogicLevels`, and `DigitalThresholds` provide the
 first mixed-signal bridge surface: digital event streams can drive finite-edge

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -8748,6 +8748,14 @@ def _mosfet_gate_body_charge_state_name(el: Mosfet) -> str:
     return f"_M_{el.name}_gb_charge"
 
 
+def _mosfet_source_body_charge_state_name(el: Mosfet) -> str:
+    return f"_M_{el.name}_sb_charge"
+
+
+def _mosfet_drain_body_charge_state_name(el: Mosfet) -> str:
+    return f"_M_{el.name}_db_charge"
+
+
 def _mosfet_charge_state_specs(el: Mosfet) -> list[tuple[str, str, str, float]]:
     params = getattr(getattr(el.model, "model", None), "params", None)
     if params is None:
@@ -8758,12 +8766,18 @@ def _mosfet_charge_state_specs(el: Mosfet) -> list[tuple[str, str, str, float]]:
     cgs = getattr(params, "CGSO", 0.0) * width
     cgd = getattr(params, "CGDO", 0.0) * width
     cgb = getattr(params, "CGBO", 0.0) * length
+    cbs = getattr(params, "CBS", 0.0)
+    cbd = getattr(params, "CBD", 0.0)
     if cgs > 0.0:
         specs.append((_mosfet_gate_source_charge_state_name(el), el.gate, el.source, cgs))
     if cgd > 0.0:
         specs.append((_mosfet_gate_drain_charge_state_name(el), el.gate, el.drain, cgd))
     if cgb > 0.0:
         specs.append((_mosfet_gate_body_charge_state_name(el), el.gate, el.body, cgb))
+    if cbs > 0.0:
+        specs.append((_mosfet_source_body_charge_state_name(el), el.source, el.body, cbs))
+    if cbd > 0.0:
+        specs.append((_mosfet_drain_body_charge_state_name(el), el.drain, el.body, cbd))
     return specs
 
 

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -889,9 +889,8 @@ def device_model_charge_audit_fixtures() -> tuple[DeviceModelChargeBehaviorFixtu
     """Return runnable transient storage fixtures for charge model-depth audits.
 
     Diode CJO/TT, BJT CJE/CJC/TF/TR, JFET fixed gate-source/gate-drain, and
-    Level-1 MOS fixed gate-overlap storage are transient-stamped by the
-    simulator. Level-1 MOS bulk junction charge is still audited through
-    explicit terminal storage capacitors until nonlinear charge policies land.
+    Level-1 MOS fixed gate-overlap plus zero-bias bulk-junction storage are
+    transient-stamped by the simulator.
     """
 
     models = _model_card_by_name()
@@ -936,6 +935,7 @@ def device_model_charge_audit_fixtures() -> tuple[DeviceModelChargeBehaviorFixtu
             "CGSO": 2.0e-11,
             "CGDO": 5.0e-12,
             "CGBO": 1.0e-12,
+            "CBS": 4.0e-13,
             "CBD": 3.0e-13,
         },
     )
@@ -1052,12 +1052,13 @@ def device_model_charge_audit_fixtures() -> tuple[DeviceModelChargeBehaviorFixtu
             expected_final_min=0.68,
             expected_final_max=0.73,
             charge_behavior=(
-                "Level-1 MOS CGSO/CGDO/CGBO contribute transient gate-overlap storage; "
-                "explicit Cstore keeps the fixture comparable while bulk junction charge remains AC-only"
+                "Level-1 MOS CGSO/CGDO/CGBO plus CBS/CBD contribute transient "
+                "gate-overlap and zero-bias bulk-junction storage; explicit "
+                "Cstore keeps the fixture comparable with other charge audits"
             ),
             deck_lines=(
                 "* device-model charge fixture: mos-level1-storage-charge",
-                ".model Mn NMOS(LEVEL=1 VTO=0.55 LAMBDA=0.04 NSUB=1.6 CGSO=20p CGDO=5p CGBO=1p CBD=3e-13)",
+                ".model Mn NMOS(LEVEL=1 VTO=0.55 LAMBDA=0.04 NSUB=1.6 CGSO=20p CGDO=5p CGBO=1p CBS=4e-13 CBD=3e-13)",
                 "Vdd vdd 0 1.8",
                 "Vgate gate 0 1.8",
                 "Rload vdd out 1k",

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -554,6 +554,7 @@ def test_device_model_charge_audit_fixtures_run_reference_transients() -> None:
     assert "CGS/CGD" in jfet_fixture.charge_behavior
     mos_fixture = next(fixture for fixture in fixtures if fixture.kind == "NMOS")
     assert "CGSO/CGDO/CGBO" in mos_fixture.charge_behavior
+    assert "CBS/CBD" in mos_fixture.charge_behavior
 
 
 def test_transient_diode_junction_capacitance_slows_current_step() -> None:
@@ -641,6 +642,42 @@ def test_transient_mosfet_overlap_capacitance_slows_gate_step() -> None:
     assert charged.converged
     uncharged_first = uncharged.points[1].node_voltages["gate"]
     charged_first = charged.points[1].node_voltages["gate"]
+    assert uncharged_first > 0.5
+    assert charged_first < 0.01
+    assert charged_first < uncharged_first
+
+
+def test_transient_mosfet_bulk_junction_capacitance_slows_drain_step() -> None:
+    def run(cbd: float) -> TransientResult:
+        circuit = Circuit()
+        circuit.add(VoltageSource(
+            "Vstep",
+            "in",
+            "0",
+            0.0,
+            waveform=PwlWaveform(((0.0, 0.0), (1.0e-9, 1.0), (5.0e-9, 1.0))),
+        ))
+        circuit.add(Resistor("Rin", "in", "drain", 1_000.0))
+        circuit.add(Mosfet(
+            "M1",
+            "drain",
+            "0",
+            "0",
+            "0",
+            MOSFET(
+                MosfetType.NMOS,
+                Level1Model(Level1Params(KP=1.0e-12, W=1.0, L=1.0, CBD=cbd)),
+            ),
+        ))
+        return transient(circuit, t_stop=5.0e-9, t_step=1.0e-9, method="euler")
+
+    uncharged = run(0.0)
+    charged = run(1.0e-9)
+
+    assert uncharged.converged
+    assert charged.converged
+    uncharged_first = uncharged.points[1].node_voltages["drain"]
+    charged_first = charged.points[1].node_voltages["drain"]
     assert uncharged_first > 0.5
     assert charged_first < 0.01
     assert charged_first < uncharged_first

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,12 +2,15 @@
 
 ## Unreleased
 
+- Stamp Level-1 MOS zero-bias bulk-junction
+  `source_bulk_capacitance` and `drain_bulk_capacitance` model-card storage as
+  transient source-body and drain-body companions, matching Python and
+  TypeScript, with regression coverage for drain-step delay.
 - Stamp Level-1 MOS `gate_source_overlap_capacitance`,
   `gate_drain_overlap_capacitance`, and `gate_bulk_overlap_capacitance`
   model-card storage as transient gate-source, gate-drain, and gate-body
   companions, matching Python and TypeScript, with regression coverage for
-  gate-step delay. Bulk junction capacitance remains AC-only until nonlinear
-  junction-charge stamping lands.
+  gate-step delay.
 - Stamp JFET `gate_source_capacitance` and `gate_drain_capacitance`
   model-card storage as transient gate-source and gate-drain companions and AC
   susceptance, matching Python and TypeScript, with regression coverage for

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -141,11 +141,11 @@ Level-1 MOS charge audits. Diode `junction_capacitance` / `transit_time` and
 BJT `base_emitter_capacitance` / `base_collector_capacitance` /
 `forward_transit_time` / `reverse_transit_time`, and JFET
 `gate_source_capacitance` / `gate_drain_capacitance` plus Level-1 MOS
-`gate_source_overlap_capacitance`, `gate_drain_overlap_capacitance`, and
-`gate_bulk_overlap_capacitance` model-card parameters also stamp transient
-storage, matching their small-signal AC capacitance semantics. MOS bulk
-junction capacitance remains AC-only until nonlinear junction-charge stamping
-lands.
+`gate_source_overlap_capacitance`, `gate_drain_overlap_capacitance`,
+`gate_bulk_overlap_capacitance`, and zero-bias bulk-junction
+`source_bulk_capacitance` / `drain_bulk_capacitance` model-card parameters
+also stamp transient storage, matching their small-signal AC capacitance
+semantics.
 
 `analyze_custom_model_source` accepts only a two-terminal `I(p,n) <+ ...`
 module shape and rejects dynamic/event/system constructs; it is not a full

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -4042,6 +4042,7 @@ pub fn device_model_charge_audit_fixtures(
             ("CGSO", 2.0e-11),
             ("CGDO", 5.0e-12),
             ("CGBO", 1.0e-12),
+            ("CBS", 4.0e-13),
             ("CBD", 3.0e-13),
         ],
     )?;
@@ -4160,10 +4161,10 @@ pub fn device_model_charge_audit_fixtures(
             expected_initial_max: 1.0,
             expected_final_min: 0.68,
             expected_final_max: 0.73,
-            charge_behavior: "Level-1 MOS CGSO/CGDO/CGBO contribute transient gate-overlap storage; explicit Cstore keeps the fixture comparable while bulk junction charge remains AC-only".to_string(),
+            charge_behavior: "Level-1 MOS CGSO/CGDO/CGBO plus CBS/CBD contribute transient gate-overlap and zero-bias bulk-junction storage; explicit Cstore keeps the fixture comparable with other charge audits".to_string(),
             deck_lines: vec![
                 "* device-model charge fixture: mos-level1-storage-charge".to_string(),
-                ".model Mn NMOS(LEVEL=1 VTO=0.55 LAMBDA=0.04 NSUB=1.6 CGSO=20p CGDO=5p CGBO=1p CBD=3e-13)".to_string(),
+                ".model Mn NMOS(LEVEL=1 VTO=0.55 LAMBDA=0.04 NSUB=1.6 CGSO=20p CGDO=5p CGBO=1p CBS=4e-13 CBD=3e-13)".to_string(),
                 "Vdd vdd 0 1.8".to_string(),
                 "Vgate gate 0 1.8".to_string(),
                 "Rload vdd out 1k".to_string(),
@@ -21223,12 +21224,22 @@ fn mosfet_gate_body_charge_state_name(mosfet: &Mosfet) -> String {
     format!("_M_{}_gb_charge", mosfet.name)
 }
 
+fn mosfet_source_body_charge_state_name(mosfet: &Mosfet) -> String {
+    format!("_M_{}_sb_charge", mosfet.name)
+}
+
+fn mosfet_drain_body_charge_state_name(mosfet: &Mosfet) -> String {
+    format!("_M_{}_db_charge", mosfet.name)
+}
+
 fn mosfet_charge_state_specs(mosfet: &Mosfet) -> Vec<MosfetChargeStateSpec<'_>> {
     let mut specs = Vec::new();
     let params = mosfet.params;
     let gate_source_capacitance = params.gate_source_overlap_capacitance * params.w;
     let gate_drain_capacitance = params.gate_drain_overlap_capacitance * params.w;
     let gate_body_capacitance = params.gate_bulk_overlap_capacitance * params.l;
+    let source_body_capacitance = params.source_bulk_capacitance;
+    let drain_body_capacitance = params.drain_bulk_capacitance;
     if gate_source_capacitance > 0.0 {
         specs.push(MosfetChargeStateSpec {
             name: mosfet_gate_source_charge_state_name(mosfet),
@@ -21251,6 +21262,22 @@ fn mosfet_charge_state_specs(mosfet: &Mosfet) -> Vec<MosfetChargeStateSpec<'_>> 
             positive: mosfet.gate.as_str(),
             negative: mosfet.body.as_str(),
             capacitance: gate_body_capacitance,
+        });
+    }
+    if source_body_capacitance > 0.0 {
+        specs.push(MosfetChargeStateSpec {
+            name: mosfet_source_body_charge_state_name(mosfet),
+            positive: mosfet.source.as_str(),
+            negative: mosfet.body.as_str(),
+            capacitance: source_body_capacitance,
+        });
+    }
+    if drain_body_capacitance > 0.0 {
+        specs.push(MosfetChargeStateSpec {
+            name: mosfet_drain_body_charge_state_name(mosfet),
+            positive: mosfet.drain.as_str(),
+            negative: mosfet.body.as_str(),
+            capacitance: drain_body_capacitance,
         });
     }
     specs

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -183,6 +183,7 @@ fn device_model_charge_audit_fixtures_run_reference_transients() {
         .find(|fixture| fixture.kind.as_str() == "NMOS")
         .expect("expected MOS charge fixture");
     assert!(mos_fixture.charge_behavior.contains("CGSO/CGDO/CGBO"));
+    assert!(mos_fixture.charge_behavior.contains("CBS/CBD"));
 }
 
 #[test]
@@ -317,6 +318,52 @@ fn transient_mosfet_overlap_capacitance_slows_gate_step() {
     let charged = run(1.0e-9);
     let uncharged_first = uncharged[0].voltage("gate").unwrap();
     let charged_first = charged[0].voltage("gate").unwrap();
+
+    assert!(uncharged_first > 0.5);
+    assert!(charged_first < 0.01);
+    assert!(charged_first < uncharged_first);
+}
+
+#[test]
+fn transient_mosfet_bulk_junction_capacitance_slows_drain_step() {
+    fn run(drain_bulk_capacitance: f64) -> Vec<TransientPoint> {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::with_waveform(
+            "Vstep",
+            "in",
+            "0",
+            0.0,
+            Waveform::Pwl(PwlWaveform::new(vec![
+                (0.0, 0.0),
+                (1.0e-9, 1.0),
+                (5.0e-9, 1.0),
+            ])),
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rin", "in", "drain", 1_000.0,
+        )));
+        circuit.add(Element::Mosfet(Mosfet::with_model(
+            "M1",
+            "drain",
+            "0",
+            "0",
+            "0",
+            MosfetType::Nmos,
+            MosfetLevel1Params {
+                kp: 1.0e-12,
+                w: 1.0,
+                l: 1.0,
+                drain_bulk_capacitance,
+                ..MosfetLevel1Params::default()
+            },
+        )));
+        transient_with_method(&circuit, 1.0e-9, 5.0e-9, TransientMethod::Euler).unwrap()
+    }
+
+    let uncharged = run(0.0);
+    let charged = run(1.0e-9);
+    let uncharged_first = uncharged[0].voltage("drain").unwrap();
+    let charged_first = charged[0].voltage("drain").unwrap();
 
     assert!(uncharged_first > 0.5);
     assert!(charged_first < 0.01);

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 ## Unreleased
 
+- Stamp Level-1 MOS zero-bias bulk-junction `CBS` and `CBD` model-card storage
+  as transient source-body and drain-body companions, matching Python and
+  Rust, with regression coverage for drain-step delay.
 - Stamp Level-1 MOS `CGSO`, `CGDO`, and `CGBO` model-card storage as
   transient gate-source, gate-drain, and gate-body companions, matching Python
-  and Rust, with regression coverage for gate-step delay. Bulk junction
-  `CBS`/`CBD` storage remains AC-only until nonlinear junction-charge stamping
-  lands.
+  and Rust, with regression coverage for gate-step delay.
 - Stamp JFET `gateSourceCapacitance` and `gateDrainCapacitance` model-card
   storage as transient gate-source and gate-drain companions and AC
   susceptance, matching Python and Rust, with regression coverage for gate-step

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -206,9 +206,9 @@ Level-1 MOS charge audits. Diode `junctionCapacitance` / `transitTime`, BJT
 `baseEmitterCapacitance` / `baseCollectorCapacitance` / `forwardTransitTime` /
 `reverseTransitTime`, and JFET `gateSourceCapacitance` /
 `gateDrainCapacitance` plus Level-1 MOS `CGSO` / `CGDO` / `CGBO` model-card
-parameters also stamp transient storage, matching their small-signal AC
-capacitance semantics. MOS bulk junction `CBS` / `CBD` remains AC-only until
-nonlinear junction-charge stamping lands.
+parameters plus zero-bias bulk-junction `CBS` / `CBD` model-card parameters
+also stamp transient storage, matching their small-signal AC capacitance
+semantics.
 
 `CustomModel`, `CustomModelEvaluation`, `customLinearConductanceModel`, and
 `analyzeCustomModelSource` provide the first native-web custom-model foothold.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -7644,6 +7644,7 @@ export function deviceModelChargeAuditFixtures(): readonly DeviceModelChargeBeha
     CGSO: 2.0e-11,
     CGDO: 5.0e-12,
     CGBO: 1.0e-12,
+    CBS: 4.0e-13,
     CBD: 3.0e-13,
   });
   const mosCircuit = new Circuit();
@@ -7752,10 +7753,10 @@ export function deviceModelChargeAuditFixtures(): readonly DeviceModelChargeBeha
       expectedFinalMin: 0.68,
       expectedFinalMax: 0.73,
       chargeBehavior:
-        "Level-1 MOS CGSO/CGDO/CGBO contribute transient gate-overlap storage; explicit Cstore keeps the fixture comparable while bulk junction charge remains AC-only",
+        "Level-1 MOS CGSO/CGDO/CGBO plus CBS/CBD contribute transient gate-overlap and zero-bias bulk-junction storage; explicit Cstore keeps the fixture comparable with other charge audits",
       deckLines: [
         "* device-model charge fixture: mos-level1-storage-charge",
-        ".model Mn NMOS(LEVEL=1 VTO=0.55 LAMBDA=0.04 NSUB=1.6 CGSO=20p CGDO=5p CGBO=1p CBD=3e-13)",
+        ".model Mn NMOS(LEVEL=1 VTO=0.55 LAMBDA=0.04 NSUB=1.6 CGSO=20p CGDO=5p CGBO=1p CBS=4e-13 CBD=3e-13)",
         "Vdd vdd 0 1.8",
         "Vgate gate 0 1.8",
         "Rload vdd out 1k",
@@ -17421,11 +17422,21 @@ function mosfetGateBodyChargeStateName(element: Mosfet): string {
   return `_M_${element.name}_gb_charge`;
 }
 
+function mosfetSourceBodyChargeStateName(element: Mosfet): string {
+  return `_M_${element.name}_sb_charge`;
+}
+
+function mosfetDrainBodyChargeStateName(element: Mosfet): string {
+  return `_M_${element.name}_db_charge`;
+}
+
 function mosfetChargeStateSpecs(element: Mosfet): MosfetChargeStateSpec[] {
   const specs: MosfetChargeStateSpec[] = [];
   const gateSourceCapacitance = element.params.CGSO * element.params.W;
   const gateDrainCapacitance = element.params.CGDO * element.params.W;
   const gateBodyCapacitance = element.params.CGBO * element.params.L;
+  const sourceBodyCapacitance = element.params.CBS;
+  const drainBodyCapacitance = element.params.CBD;
   if (gateSourceCapacitance > 0.0) {
     specs.push({
       name: mosfetGateSourceChargeStateName(element),
@@ -17448,6 +17459,22 @@ function mosfetChargeStateSpecs(element: Mosfet): MosfetChargeStateSpec[] {
       positive: element.gate,
       negative: element.body,
       capacitance: gateBodyCapacitance,
+    });
+  }
+  if (sourceBodyCapacitance > 0.0) {
+    specs.push({
+      name: mosfetSourceBodyChargeStateName(element),
+      positive: element.source,
+      negative: element.body,
+      capacitance: sourceBodyCapacitance,
+    });
+  }
+  if (drainBodyCapacitance > 0.0) {
+    specs.push({
+      name: mosfetDrainBodyChargeStateName(element),
+      positive: element.drain,
+      negative: element.body,
+      capacitance: drainBodyCapacitance,
     });
   }
   return specs;

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -215,6 +215,7 @@ describe("transient", () => {
     expect(jfetFixture?.chargeBehavior).toContain("CGS/CGD");
     const mosFixture = fixtures.find((fixture) => fixture.kind === "NMOS");
     expect(mosFixture?.chargeBehavior).toContain("CGSO/CGDO/CGBO");
+    expect(mosFixture?.chargeBehavior).toContain("CBS/CBD");
   });
 
   it("uses diode junction capacitance during transient current steps", () => {
@@ -311,6 +312,39 @@ describe("transient", () => {
 
     const unchargedFirst = run(0.0)[0].voltage("gate");
     const chargedFirst = run(1.0e-9)[0].voltage("gate");
+    expect(unchargedFirst).not.toBeUndefined();
+    expect(chargedFirst).not.toBeUndefined();
+    expect(unchargedFirst!).toBeGreaterThan(0.5);
+    expect(chargedFirst!).toBeLessThan(0.01);
+    expect(chargedFirst!).toBeLessThan(unchargedFirst!);
+  });
+
+  it("uses MOSFET bulk junction capacitance during transient drain steps", () => {
+    function run(drainBulkCapacitance: number): TransientPoint[] {
+      const circuit = new Circuit();
+      circuit.add(voltageSourceWithWaveform(
+        "Vstep",
+        "in",
+        "0",
+        0.0,
+        new PwlWaveform([
+          [0.0, 0.0],
+          [1.0e-9, 1.0],
+          [5.0e-9, 1.0],
+        ]),
+      ));
+      circuit.add(resistor("Rin", "in", "drain", 1_000.0));
+      circuit.add(mosfet("M1", "drain", "0", "0", "0", "NMOS", {
+        KP: 1.0e-12,
+        W: 1.0,
+        L: 1.0,
+        CBD: drainBulkCapacitance,
+      }));
+      return transient(circuit, 1.0e-9, 5.0e-9, "euler");
+    }
+
+    const unchargedFirst = run(0.0)[0].voltage("drain");
+    const chargedFirst = run(1.0e-9)[0].voltage("drain");
     expect(unchargedFirst).not.toBeUndefined();
     expect(chargedFirst).not.toBeUndefined();
     expect(unchargedFirst!).toBeGreaterThan(0.5);

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -15,21 +15,21 @@ downstream tools to compare.
 
 ## Current PR Slice
 
-1. MOS Level-1 transient overlap charge stamping.
+1. MOS Level-1 transient bulk-junction charge stamping.
    - Status: current PR completion candidate.
    - Python, Rust, and TypeScript transient solvers now stamp Level-1 MOS
-     model-card `CGSO` / `gate_source_overlap_capacitance`, `CGDO` /
-     `gate_drain_overlap_capacitance`, and `CGBO` /
-     `gate_bulk_overlap_capacitance` as fixed gate-source, gate-drain, and
-     gate-body overlap storage companions.
+     model-card `CBS` / `source_bulk_capacitance` / source-bulk
+     capacitance and `CBD` / `drain_bulk_capacitance` / drain-bulk
+     capacitance as zero-bias source-body and drain-body storage companions.
    - The companions reuse the existing Euler/trapezoidal/Gear-2 capacitor
-     history policy and seed the synthetic MOS overlap charge states from the
-     initial operating point.
-   - Cross-language tests cover MOS gate-step delay through `CGSO` overlap
-     storage, and charge-audit fixtures now record the MOS overlap terms as
+     history policy and seed the synthetic MOS bulk-junction charge states
+     from the initial operating point.
+   - Cross-language tests cover drain-step delay through `CBD` bulk-junction
+     storage, and charge-audit fixtures now record the MOS bulk terms as
      transient-stamped.
-   - MOS `CBS` / `CBD` bulk junction charge remains AC-only until a nonlinear
-     junction-charge policy lands.
+   - Voltage-dependent MOS depletion-shaping parameters remain future
+     model-card depth work; this slice stamps the Level-1 zero-bias
+     capacitance terms already exposed by the package surfaces.
 
 ## Completed Slices
 
@@ -1268,6 +1268,20 @@ downstream tools to compare.
      operating point, and contribute matching small-signal AC susceptance.
    - Cross-language tests cover gate-step delay and high-frequency gate-drive
      shunting.
+
+124. MOS Level-1 transient overlap charge stamping.
+   - Status: completed in PR 6816.
+   - Python, Rust, and TypeScript transient solvers now stamp Level-1 MOS
+     model-card `CGSO` / `gate_source_overlap_capacitance`, `CGDO` /
+     `gate_drain_overlap_capacitance`, and `CGBO` /
+     `gate_bulk_overlap_capacitance` as fixed gate-source, gate-drain, and
+     gate-body overlap storage companions.
+   - The companions reuse the existing Euler/trapezoidal/Gear-2 capacitor
+     history policy and seed the synthetic MOS overlap charge states from the
+     initial operating point.
+   - Cross-language tests cover MOS gate-step delay through `CGSO` overlap
+     storage, and charge-audit fixtures now record the MOS overlap terms as
+     transient-stamped.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- stamp Level-1 MOS zero-bias `CBS`/`CBD` storage as source-body and drain-body transient companions in Python, Rust, and TypeScript
- add cross-language drain-step regressions for MOS bulk junction capacitance
- update charge audit fixtures, README/changelog notes, and the SPICE implementation plan

## Verification
- `PYTHONPATH=code/packages/python/spice-engine/src:code/packages/python/mosfet-models/src:code/packages/python/device-physics/src /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python -m pytest code/packages/python/spice-engine/tests/test_engine.py`
- `cargo test -p spice-engine`
- `npm run build && npm test`
- `git diff --check`