### PR TITLE
[codex] Add LANG E4 substring slice proof

### DIFF
--- a/code/packages/rust/algol-iir-compiler/tests/backend_compat.rs
+++ b/code/packages/rust/algol-iir-compiler/tests/backend_compat.rs
@@ -5,7 +5,8 @@ use algol_iir_compiler::compile_source;
 const ALGOL_SUM: &str =
     "begin integer i, result; result := 0; for i := 1 step 1 until 6 do result := result + i end";
 
-const ALGOL_MOD: &str = "begin integer result; result := 17 mod 5 end";
+const ALGOL_MOD: &str =
+    "begin integer a, b, result; a := 17; b := 5; result := a mod b end";
 
 const ALGOL_BOOL_OPS: &str = "begin boolean a, b; integer result; a := true; b := false; if (a and not b) and ((b impl a) eqv (a or b)) then result := 42 else result := 1 end";
 

--- a/code/packages/rust/iir-to-cil-bytecode/CHANGELOG.md
+++ b/code/packages/rust/iir-to-cil-bytecode/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog — iir-to-cil-bytecode
 
+## [0.30.0] — 2026-06-28 — textual CLR literal string slice (LANG-FULL E4)
+
+The textual `.il` path now lowers `str_slice` by loading the source string,
+start, and end, computing `end - start`, and calling
+`System.String::Substring(int32, int32)`. The result is stored as a managed
+string local that can feed the existing `str_index`, `str_len`, and `str_eq`
+paths.
+
 ## [0.29.0] — 2026-06-27 — textual CLR literal string index (LANG-FULL E4)
 
 The textual `.il` path now lowers direct-literal `str_index`:

--- a/code/packages/rust/iir-to-cil-bytecode/src/il_text.rs
+++ b/code/packages/rust/iir-to-cil-bytecode/src/il_text.rs
@@ -608,6 +608,27 @@ fn emit_method(
                 );
                 store_var(il, &regs, dest)?;
             }
+            // str_slice <dest>, <src>, <start>, <end>
+            //     -> System.String::Substring(start, end - start)
+            "str_slice" => {
+                let dest = instr.dest.as_deref().ok_or_else(|| IIRClrError::InvalidOperand {
+                    function: f.name.clone(),
+                    detail: "str_slice must have a dest".to_string(),
+                })?;
+                let src = var_src(f, instr, 0, "str_slice")?;
+                let start = var_src(f, instr, 1, "str_slice")?;
+                let end = var_src(f, instr, 2, "str_slice")?;
+                load_var(il, &regs, src)?;
+                load_var(il, &regs, start)?;
+                load_var(il, &regs, end)?;
+                load_var(il, &regs, start)?;
+                let _ = writeln!(il, "    sub");
+                let _ = writeln!(
+                    il,
+                    "    callvirt instance string [System.Runtime]System.String::Substring(int32, int32)"
+                );
+                store_var(il, &regs, dest)?;
+            }
             // str_len <dest>, <src>  ->  System.String::get_Length()
             //
             // The v1 literal slice accepts only printable ASCII strings, so
@@ -1839,6 +1860,56 @@ mod tests {
         assert!(
             il.contains("callvirt instance int32 [System.Runtime]System.String::get_Length()"),
             "str_len must call System.String::get_Length(); got:\n{il}"
+        );
+    }
+
+    #[test]
+    fn string_literal_slice_index_emits_string_substring() {
+        let instrs = vec![
+            IIRInstr::new(
+                "str_const",
+                Some("s".into()),
+                vec![Operand::Str("ABCDE".into())],
+                "str",
+            ),
+            IIRInstr::new("const", Some("start".into()), vec![Operand::Int(1)], "i32"),
+            IIRInstr::new("const", Some("end".into()), vec![Operand::Int(4)], "i32"),
+            IIRInstr::new(
+                "str_slice",
+                Some("sub".into()),
+                vec![
+                    Operand::Var("s".into()),
+                    Operand::Var("start".into()),
+                    Operand::Var("end".into()),
+                ],
+                "str",
+            ),
+            IIRInstr::new("const", Some("i".into()), vec![Operand::Int(1)], "i32"),
+            IIRInstr::new(
+                "str_index",
+                Some("b".into()),
+                vec![Operand::Var("sub".into()), Operand::Var("i".into())],
+                "i32",
+            ),
+            IIRInstr::new("ret", None, vec![Operand::Var("b".into())], "i32"),
+        ];
+        let mut m = IIRModule::new("Main", "test");
+        m.functions.push(IIRFunction::new("main", vec![], "i32", instrs));
+        m.entry_point = Some("main".into());
+        let il = emit_il(&m, &IIRClrConfig::new("Main")).unwrap();
+        assert!(
+            il.contains("    sub"),
+            "str_slice must compute end-start for System.String::Substring; got:\n{il}"
+        );
+        assert!(
+            il.contains(
+                "callvirt instance string [System.Runtime]System.String::Substring(int32, int32)"
+            ),
+            "str_slice must call System.String::Substring(int32,int32); got:\n{il}"
+        );
+        assert!(
+            il.contains("callvirt instance char [System.Runtime]System.String::get_Chars(int32)"),
+            "str_index after str_slice must call System.String::get_Chars(int32); got:\n{il}"
         );
     }
 

--- a/code/packages/rust/iir-to-cil-bytecode/src/validate.rs
+++ b/code/packages/rust/iir-to-cil-bytecode/src/validate.rs
@@ -355,10 +355,12 @@ pub fn validate_iir_for_clr(module: &IIRModule) -> Vec<String> {
             //   - `jmp_if_true` / `jmp_if_false` — used for pattern-match dispatch
             //
             // All other ops remain rejected for `ref<LispyPair>`.
-            if instr.type_hint == "str" && !matches!(instr.op.as_str(), "str_const" | "str_concat") {
+            if instr.type_hint == "str"
+                && !matches!(instr.op.as_str(), "str_const" | "str_concat" | "str_slice")
+            {
                 errors.push(format!(
                     "UnsupportedType: function {:?}, op {:?} has type_hint \"str\"; \
-                     only str_const and str_concat literals are supported in this CLR backend",
+                     only str_const, str_concat, and str_slice literals are supported in this CLR backend",
                     func.name, instr.op
                 ));
             } else if instr.type_hint.starts_with("ref<") {
@@ -466,6 +468,19 @@ pub fn validate_iir_for_clr(module: &IIRModule) -> Vec<String> {
                         errors.push(format!(
                             "UnsupportedOp: function {:?}, op \"str_concat\" requires \
                              dest, two Operand::Var sources, and str result type",
+                            func.name
+                        ));
+                    }
+                }
+            } else if instr.op == "str_slice" {
+                match (instr.dest.as_ref(), instr.srcs.as_slice(), instr.type_hint.as_str()) {
+                    (Some(_), [Operand::Var(_), Operand::Var(_), Operand::Var(_)], "str") => {
+                        // Accepted — il_text.rs calls System.String::Substring(int32,int32).
+                    }
+                    _ => {
+                        errors.push(format!(
+                            "UnsupportedOp: function {:?}, op \"str_slice\" requires \
+                             dest, string/start/end Operand::Var sources, and str result type",
                             func.name
                         ));
                     }
@@ -711,6 +726,37 @@ mod tests {
         assert!(
             errs.is_empty(),
             "str_concat over direct literals should pass: {:?}",
+            errs
+        );
+    }
+
+    #[test]
+    fn str_slice_literal_accepted() {
+        let errs = validate_iir_for_clr(&single_fn_module(vec![
+            IIRInstr::new(
+                "str_const",
+                Some("s".into()),
+                vec![Operand::Str("ABCDE".into())],
+                "str",
+            ),
+            IIRInstr::new("const", Some("start".into()), vec![Operand::Int(1)], "i64"),
+            IIRInstr::new("const", Some("end".into()), vec![Operand::Int(4)], "i64"),
+            IIRInstr::new(
+                "str_slice",
+                Some("sub".into()),
+                vec![
+                    Operand::Var("s".into()),
+                    Operand::Var("start".into()),
+                    Operand::Var("end".into()),
+                ],
+                "str",
+            ),
+            IIRInstr::new("str_len", Some("n".into()), vec![Operand::Var("sub".into())], "i64"),
+            IIRInstr::new("ret", None, vec![Operand::Var("n".into())], "i64"),
+        ]));
+        assert!(
+            errs.is_empty(),
+            "str_slice over direct literals should pass: {:?}",
             errs
         );
     }

--- a/code/packages/rust/iir-to-jvm-class-file/CHANGELOG.md
+++ b/code/packages/rust/iir-to-jvm-class-file/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this crate are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.22.0] — 2026-06-28 (literal string slice — LANG-FULL E4)
+
+The JVM backend now lowers `str_slice` over managed `String` locals by loading
+the source, narrowing i64 start/end bounds with `l2i` when needed, and invoking
+`java/lang/String.substring(II)Ljava/lang/String;`. The resulting string local
+can feed the existing `str_index`, `str_len`, `str_eq`, and `print_str` paths.
+
 ## [0.21.0] — 2026-06-27 (literal string index — LANG-FULL E4)
 
 The JVM backend now lowers the direct-literal `str_index` shape:

--- a/code/packages/rust/iir-to-jvm-class-file/src/lower.rs
+++ b/code/packages/rust/iir-to-jvm-class-file/src/lower.rs
@@ -1995,6 +1995,68 @@ fn lower_function(
                 emit_astore(&mut code, dest_slot);
             }
 
+            "str_slice" => {
+                let dest_name = instr.dest.as_deref().ok_or_else(|| IIRJvmError::InvalidOperand {
+                    function: fname.clone(),
+                    detail: "str_slice instruction has no dest".to_string(),
+                })?;
+                let src = match instr.srcs.first() {
+                    Some(Operand::Var(s)) => s,
+                    other => {
+                        return Err(IIRJvmError::InvalidOperand {
+                            function: fname.clone(),
+                            detail: format!("str_slice expects a string variable, got {other:?}"),
+                        })
+                    }
+                };
+                let start = match instr.srcs.get(1) {
+                    Some(Operand::Var(s)) => s,
+                    other => {
+                        return Err(IIRJvmError::InvalidOperand {
+                            function: fname.clone(),
+                            detail: format!("str_slice expects a start variable, got {other:?}"),
+                        })
+                    }
+                };
+                let end = match instr.srcs.get(2) {
+                    Some(Operand::Var(s)) => s,
+                    other => {
+                        return Err(IIRJvmError::InvalidOperand {
+                            function: fname.clone(),
+                            detail: format!("str_slice expects an end variable, got {other:?}"),
+                        })
+                    }
+                };
+                let (src_slot, src_type) = lookup_var(src)?;
+                let (start_slot, start_type) = lookup_var(start)?;
+                let (end_slot, end_type) = lookup_var(end)?;
+                let (dest_slot, dest_type) = lookup_var(dest_name)?;
+                if src_type != JvmType::Ref
+                    || dest_type != JvmType::Ref
+                    || (start_type != JvmType::Int && start_type != JvmType::Long)
+                    || (end_type != JvmType::Int && end_type != JvmType::Long)
+                {
+                    return Err(IIRJvmError::UnsupportedType {
+                        function: fname.clone(),
+                        type_hint: "str_slice".to_string(),
+                    });
+                }
+                emit_aload(&mut code, src_slot);
+                emit_typed_load(&mut code, start_slot, start_type);
+                if start_type == JvmType::Long {
+                    code.push(L2I);
+                }
+                emit_typed_load(&mut code, end_slot, end_type);
+                if end_type == JvmType::Long {
+                    code.push(L2I);
+                }
+                let substring_ref =
+                    cp.add_methodref("java/lang/String", "substring", "(II)Ljava/lang/String;");
+                code.push(INVOKEVIRTUAL);
+                code.extend_from_slice(&substring_ref.to_be_bytes());
+                emit_astore(&mut code, dest_slot);
+            }
+
             "str_len" => {
                 let dest_name = instr.dest.as_deref().ok_or_else(|| IIRJvmError::InvalidOperand {
                     function: fname.clone(),

--- a/code/packages/rust/iir-to-jvm-class-file/src/validate.rs
+++ b/code/packages/rust/iir-to-jvm-class-file/src/validate.rs
@@ -285,10 +285,12 @@ pub fn validate_for_jvm(module: &IIRModule) -> Vec<String> {
             // `"f32"` and `"f64"` are intentionally NOT rejected here.  The JVM
             // has first-class float/double operations (`fload`, `dload`, `fadd`,
             // `dadd`, etc.) that this backend emits.
-            if instr.type_hint == "str" && !matches!(instr.op.as_str(), "str_const" | "str_concat") {
+            if instr.type_hint == "str"
+                && !matches!(instr.op.as_str(), "str_const" | "str_concat" | "str_slice")
+            {
                 errors.push(format!(
                     "UnsupportedType: function {:?}, op {:?} has type_hint \"str\"; \
-                     only str_const and str_concat literals are supported in this JVM backend",
+                     only str_const, str_concat, and str_slice literals are supported in this JVM backend",
                     func.name, instr.op
                 ));
             } else if instr.type_hint.starts_with("ref<")
@@ -341,6 +343,19 @@ pub fn validate_for_jvm(module: &IIRModule) -> Vec<String> {
                         errors.push(format!(
                             "UnsupportedOp: function {:?}, op \"str_concat\" requires \
                              dest, two Operand::Var sources, and str result type",
+                            func.name
+                        ));
+                    }
+                }
+            } else if instr.op == "str_slice" {
+                match (instr.dest.as_ref(), instr.srcs.as_slice(), instr.type_hint.as_str()) {
+                    (Some(_), [Operand::Var(_), Operand::Var(_), Operand::Var(_)], "str") => {
+                        // Accepted — lower.rs calls java/lang/String.substring(II).
+                    }
+                    _ => {
+                        errors.push(format!(
+                            "UnsupportedOp: function {:?}, op \"str_slice\" requires \
+                             dest, string/start/end Operand::Var sources, and str result type",
                             func.name
                         ));
                     }
@@ -611,6 +626,37 @@ mod tests {
         assert!(
             errs.is_empty(),
             "str_concat over direct literals should pass: {:?}",
+            errs
+        );
+    }
+
+    #[test]
+    fn str_slice_literal_accepted() {
+        let errs = validate_for_jvm(&single_fn_module(vec![
+            IIRInstr::new(
+                "str_const",
+                Some("s".into()),
+                vec![Operand::Str("ABCDE".into())],
+                "str",
+            ),
+            IIRInstr::new("const", Some("start".into()), vec![Operand::Int(1)], "i64"),
+            IIRInstr::new("const", Some("end".into()), vec![Operand::Int(4)], "i64"),
+            IIRInstr::new(
+                "str_slice",
+                Some("sub".into()),
+                vec![
+                    Operand::Var("s".into()),
+                    Operand::Var("start".into()),
+                    Operand::Var("end".into()),
+                ],
+                "str",
+            ),
+            IIRInstr::new("str_len", Some("n".into()), vec![Operand::Var("sub".into())], "i64"),
+            IIRInstr::new("ret", None, vec![Operand::Var("n".into())], "i64"),
+        ]));
+        assert!(
+            errs.is_empty(),
+            "str_slice over direct literals should pass: {:?}",
             errs
         );
     }

--- a/code/packages/rust/iir-to-jvm-class-file/tests/test_backend.rs
+++ b/code/packages/rust/iir-to-jvm-class-file/tests/test_backend.rs
@@ -2557,6 +2557,86 @@ fn e4_string_concat_len_lowers_to_string_concat_and_length() {
 }
 
 #[test]
+fn e4_string_slice_index_lowers_to_string_substring_and_char_at() {
+    let f = IIRFunction::new(
+        "slice_index",
+        vec![],
+        "i64",
+        vec![
+            IIRInstr::new(
+                "str_const",
+                Some("s".into()),
+                vec![Operand::Str("ABCDE".into())],
+                "str",
+            ),
+            IIRInstr::new("const", Some("start".into()), vec![Operand::Int(1)], "i64"),
+            IIRInstr::new("const", Some("end".into()), vec![Operand::Int(4)], "i64"),
+            IIRInstr::new(
+                "str_slice",
+                Some("sub".into()),
+                vec![
+                    Operand::Var("s".into()),
+                    Operand::Var("start".into()),
+                    Operand::Var("end".into()),
+                ],
+                "str",
+            ),
+            IIRInstr::new("const", Some("i".into()), vec![Operand::Int(1)], "i64"),
+            IIRInstr::new(
+                "str_index",
+                Some("b".into()),
+                vec![Operand::Var("sub".into()), Operand::Var("i".into())],
+                "i64",
+            ),
+            IIRInstr::new("ret", None, vec![Operand::Var("b".into())], "i64"),
+        ],
+    );
+    let module = module_with(f);
+    let errors = validate_for_jvm(&module);
+    assert!(
+        errors.is_empty(),
+        "string literal slice/index should validate: {:?}",
+        errors
+    );
+
+    let class = lower(&module);
+    let method = class
+        .methods
+        .iter()
+        .find(|m| m.name == "slice_index")
+        .expect("slice_index method must exist");
+    let code = &method.code_attribute().unwrap().code;
+
+    assert!(
+        code.iter().filter(|&&b| b == 0xB6).count() >= 2,
+        "str_slice + str_index should use invokevirtual for substring and charAt; got: {:?}",
+        code
+    );
+    assert!(
+        code.iter().filter(|&&b| b == 0x88).count() >= 3,
+        "i64 start/end/index operands should narrow with L2I; got: {:?}",
+        code
+    );
+
+    let substring_ref = find_methodref_in_cp(
+        &class.constant_pool,
+        "java/lang/String",
+        "substring",
+        "(II)Ljava/lang/String;",
+    );
+    assert_ne!(
+        substring_ref, 0,
+        "constant pool must contain java/lang/String.substring(II)"
+    );
+    let char_at_ref =
+        find_methodref_in_cp(&class.constant_pool, "java/lang/String", "charAt", "(I)C");
+    assert_ne!(
+        char_at_ref, 0,
+        "constant pool must contain java/lang/String.charAt(I)C"
+    );
+}
+
+#[test]
 fn e4_string_eq_lowers_to_string_equals() {
     let f = IIRFunction::new(
         "eq_hello",

--- a/code/packages/rust/iir-to-llvm/CHANGELOG.md
+++ b/code/packages/rust/iir-to-llvm/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this crate are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.23.0] — 2026-06-28 — literal string slice metadata reaches LLVM (LANG-FULL E4)
+
+Literal-only `str_slice` now participates in the LLVM string metadata pass.
+When the source string and start/end bounds are constant, the backend interns
+the derived slice as a length-prefixed private constant and binds the slice
+destination to that metadata. This lets `str_slice` feed `str_index`, `str_len`,
+`str_eq`, or `print_str` without adding a runtime string API.
+
 ## [0.22.0] — 2026-06-28 — computed string index metadata reaches LLVM (LANG-FULL E4)
 
 Literal-only `str_len` results can now feed typed `i64` arithmetic in the LLVM

--- a/code/packages/rust/iir-to-llvm/src/lib.rs
+++ b/code/packages/rust/iir-to-llvm/src/lib.rs
@@ -270,9 +270,10 @@ const SUPPORTED_OPS: &[&str] = &[
     "int_to_real", "real_to_int_trunc", "real_to_int_floor",
     // LANG-FULL E4 — string literal foothold for the static LLVM column.
     // `str_const` materialises a length-prefixed private constant. `str_index`,
-    // `str_concat`, `str_len`, and `str_eq` read literal metadata, and `print_str` calls the
-    // generic C runtime. Richer dynamic byte-string ops remain unsupported.
-    "str_const", "str_index", "str_concat", "str_len", "str_eq", "print_str",
+    // `str_concat`, `str_slice`, `str_len`, and `str_eq` read literal metadata,
+    // and `print_str` calls the generic C runtime. Richer dynamic byte-string
+    // ops remain unsupported.
+    "str_const", "str_index", "str_concat", "str_slice", "str_len", "str_eq", "print_str",
 ];
 
 /// Builtins the LLVM backend knows how to lower.
@@ -398,6 +399,10 @@ pub fn validate_for_llvm(module: &IIRModule) -> Vec<String> {
                 validate_str_concat(func, instr, &mut errors);
                 continue;
             }
+            if instr.op == "str_slice" {
+                validate_str_slice(func, instr, &mut errors);
+                continue;
+            }
             if instr.op == "str_index" {
                 validate_str_index(func, instr, &mut errors);
                 continue;
@@ -521,6 +526,28 @@ fn validate_str_concat(func: &IIRFunction, instr: &IIRInstr, errors: &mut Vec<St
         [Operand::Var(_), Operand::Var(_)] => {}
         _ => errors.push(format!(
             "InvalidOperand: function {:?}, str_concat requires exactly two Operand::Var sources",
+            func.name
+        )),
+    }
+}
+
+fn validate_str_slice(func: &IIRFunction, instr: &IIRInstr, errors: &mut Vec<String>) {
+    if instr.dest.is_none() {
+        errors.push(format!(
+            "InvalidOperand: function {:?}, str_slice requires a dest",
+            func.name
+        ));
+    }
+    if instr.type_hint != "str" {
+        errors.push(format!(
+            "UnsupportedType: function {:?}, str_slice result type {:?} must be \"str\"",
+            func.name, instr.type_hint
+        ));
+    }
+    match instr.srcs.as_slice() {
+        [Operand::Var(_), Operand::Var(_), Operand::Var(_)] => {}
+        _ => errors.push(format!(
+            "InvalidOperand: function {:?}, str_slice requires string, start, and end Operand::Var sources",
             func.name
         )),
     }
@@ -808,8 +835,54 @@ fn collect_string_literals(
     }
     for func in &module.functions {
         let mut fn_values: HashMap<String, String> = HashMap::new();
+        let mut fn_ints: HashMap<String, i64> = HashMap::new();
         for instr in &func.instructions {
             match instr.op.as_str() {
+                "const" => {
+                    if let (Some(dest), Some(Operand::Int(value))) =
+                        (instr.dest.as_ref(), instr.srcs.first())
+                    {
+                        fn_ints.insert(dest.clone(), *value);
+                    }
+                }
+                "mov" => {
+                    let (Some(dest), Some(Operand::Var(src))) =
+                        (instr.dest.as_ref(), instr.srcs.first())
+                    else {
+                        continue;
+                    };
+                    if let Some(value) = fn_values.get(src).cloned() {
+                        fn_values.insert(dest.clone(), value);
+                    }
+                    if let Some(value) = fn_ints.get(src).copied() {
+                        fn_ints.insert(dest.clone(), value);
+                    }
+                }
+                "add" | "sub" | "mul" | "div" => {
+                    let Some(dest) = instr.dest.as_ref() else {
+                        continue;
+                    };
+                    let left = instr.srcs.first().and_then(|src| match src {
+                        Operand::Int(value) => Some(*value),
+                        Operand::Var(name) => fn_ints.get(name).copied(),
+                        _ => None,
+                    });
+                    let right = instr.srcs.get(1).and_then(|src| match src {
+                        Operand::Int(value) => Some(*value),
+                        Operand::Var(name) => fn_ints.get(name).copied(),
+                        _ => None,
+                    });
+                    let value = match (instr.op.as_str(), left, right) {
+                        ("add", Some(left), Some(right)) => left.checked_add(right),
+                        ("sub", Some(left), Some(right)) => left.checked_sub(right),
+                        ("mul", Some(left), Some(right)) => left.checked_mul(right),
+                        ("div", Some(left), Some(right)) if right != 0 => left.checked_div(right),
+                        _ => None,
+                    };
+                    if let Some(value) = value {
+                        fn_ints.insert(dest.clone(), value);
+                    }
+                }
                 "str_const" => {
                     let Some(Operand::Str(s)) = instr.srcs.first() else {
                         continue;
@@ -834,6 +907,47 @@ fn collect_string_literals(
                     let value = format!("{left}{right}");
                     intern_string_literal(&value, &mut defs, &mut map);
                     fn_values.insert(dest.clone(), value);
+                }
+                "str_slice" => {
+                    let (
+                        Some(dest),
+                        Some(Operand::Var(src)),
+                        Some(Operand::Var(start)),
+                        Some(Operand::Var(end)),
+                    ) = (
+                        instr.dest.as_ref(),
+                        instr.srcs.first(),
+                        instr.srcs.get(1),
+                        instr.srcs.get(2),
+                    ) else {
+                        continue;
+                    };
+                    let (Some(source), Some(start), Some(end)) = (
+                        fn_values.get(src),
+                        fn_ints.get(start).copied(),
+                        fn_ints.get(end).copied(),
+                    ) else {
+                        continue;
+                    };
+                    if start < 0 || end < start || end as usize > source.len() {
+                        continue;
+                    }
+                    let bytes = source.as_bytes()[start as usize..end as usize].to_vec();
+                    let Ok(value) = String::from_utf8(bytes) else {
+                        continue;
+                    };
+                    intern_string_literal(&value, &mut defs, &mut map);
+                    fn_values.insert(dest.clone(), value);
+                }
+                "str_len" => {
+                    let (Some(dest), Some(Operand::Var(src))) =
+                        (instr.dest.as_ref(), instr.srcs.first())
+                    else {
+                        continue;
+                    };
+                    if let Some(value) = fn_values.get(src) {
+                        fn_ints.insert(dest.clone(), value.len() as i64);
+                    }
                 }
                 _ => {}
             }
@@ -1398,6 +1512,7 @@ fn lower_instr(
         // ── strings (LANG-FULL E4 literal-output foothold) ─────────────────
         "str_const" => lower_str_const(instr, state),
         "str_concat" => lower_str_concat(instr, state),
+        "str_slice" => lower_str_slice(instr, state, out),
         "str_index" => lower_str_index(instr, state, out),
         "str_len" => lower_str_len(instr, state),
         "str_eq" => lower_str_eq(instr, state),
@@ -1540,6 +1655,87 @@ fn lower_str_concat(
         IIRLlvmError::InvalidOperand {
             function: state.fn_name.into(),
             detail: format!("str_concat value {value:?} was not collected"),
+        }
+    })?;
+    state.env.insert(dest.clone(), info.symbol.clone());
+    state.str_lens.insert(dest.clone(), info.len);
+    state.str_values.insert(dest, value);
+    Ok(())
+}
+
+fn lower_str_slice(
+    instr: &IIRInstr,
+    state: &mut FnState,
+    out: &mut String,
+) -> Result<(), IIRLlvmError> {
+    let dest = require_dest(instr, "str_slice", state.fn_name)?.to_string();
+    let src = match instr.srcs.first() {
+        Some(Operand::Var(s)) => s,
+        _ => {
+            return Err(IIRLlvmError::InvalidOperand {
+                function: state.fn_name.into(),
+                detail: "str_slice requires srcs[0] = Operand::Var(str)".into(),
+            });
+        }
+    };
+    let start = match instr.srcs.get(1) {
+        Some(Operand::Var(s)) => s,
+        _ => {
+            return Err(IIRLlvmError::InvalidOperand {
+                function: state.fn_name.into(),
+                detail: "str_slice requires srcs[1] = Operand::Var(start)".into(),
+            });
+        }
+    };
+    let end = match instr.srcs.get(2) {
+        Some(Operand::Var(s)) => s,
+        _ => {
+            return Err(IIRLlvmError::InvalidOperand {
+                function: state.fn_name.into(),
+                detail: "str_slice requires srcs[2] = Operand::Var(end)".into(),
+            });
+        }
+    };
+    let literal = state.str_values.get(src).ok_or_else(|| {
+        IIRLlvmError::InvalidOperand {
+            function: state.fn_name.into(),
+            detail: format!("str_slice source {src:?} is not a string literal value"),
+        }
+    })?;
+    let start_value = state
+        .env
+        .get(start)
+        .and_then(|value| value.parse::<i64>().ok())
+        .ok_or_else(|| IIRLlvmError::InvalidOperand {
+            function: state.fn_name.into(),
+            detail: format!("str_slice start {start:?} is not a constant integer value"),
+        })?;
+    let end_value = state
+        .env
+        .get(end)
+        .and_then(|value| value.parse::<i64>().ok())
+        .ok_or_else(|| IIRLlvmError::InvalidOperand {
+            function: state.fn_name.into(),
+            detail: format!("str_slice end {end:?} is not a constant integer value"),
+        })?;
+    if start_value < 0 || end_value < start_value || end_value as usize > literal.len() {
+        out.push_str("  call void @llvm.trap()\n");
+        state.env.insert(dest.clone(), "null".to_string());
+        state.str_lens.insert(dest.clone(), 0);
+        state.str_values.insert(dest, String::new());
+        return Ok(());
+    }
+    let value = String::from_utf8(
+        literal.as_bytes()[start_value as usize..end_value as usize].to_vec(),
+    )
+    .map_err(|_| IIRLlvmError::InvalidOperand {
+        function: state.fn_name.into(),
+        detail: format!("str_slice range {start_value}..{end_value} does not preserve UTF-8"),
+    })?;
+    let info = state.string_literals.get(&value).ok_or_else(|| {
+        IIRLlvmError::InvalidOperand {
+            function: state.fn_name.into(),
+            detail: format!("str_slice value {value:?} was not collected"),
         }
     })?;
     state.env.insert(dest.clone(), info.symbol.clone());

--- a/code/packages/rust/iir-to-llvm/tests/test_backend.rs
+++ b/code/packages/rust/iir-to-llvm/tests/test_backend.rs
@@ -1128,6 +1128,58 @@ fn e4_string_literal_concat_print_emits_derived_constant_and_runtime_call() {
 }
 
 #[test]
+fn e4_string_literal_slice_index_folds_to_integer_return() {
+    let f = IIRFunction::new(
+        "main",
+        vec![],
+        "i64",
+        vec![
+            IIRInstr::new(
+                "str_const",
+                Some("s".into()),
+                vec![Operand::Str("ABCDE".into())],
+                "str",
+            ),
+            IIRInstr::new("const", Some("start".into()), vec![Operand::Int(1)], "i64"),
+            IIRInstr::new("const", Some("end".into()), vec![Operand::Int(4)], "i64"),
+            IIRInstr::new(
+                "str_slice",
+                Some("sub".into()),
+                vec![
+                    Operand::Var("s".into()),
+                    Operand::Var("start".into()),
+                    Operand::Var("end".into()),
+                ],
+                "str",
+            ),
+            IIRInstr::new("const", Some("i".into()), vec![Operand::Int(1)], "i64"),
+            IIRInstr::new(
+                "str_index",
+                Some("b".into()),
+                vec![Operand::Var("sub".into()), Operand::Var("i".into())],
+                "i64",
+            ),
+            IIRInstr::new("ret", None, vec![Operand::Var("b".into())], "i64"),
+        ],
+    );
+    let module = module_with(f);
+    assert!(
+        validate_for_llvm(&module).is_empty(),
+        "literal string slice/index should validate"
+    );
+    let ll = lower(&module);
+
+    assert!(
+        ll.contains("@__twig_str_1 = private unnamed_addr constant { i64, [3 x i8] } { i64 3, [3 x i8] c\"\\42\\43\\44\" }, align 8"),
+        "str_slice should materialise BCD metadata:\n{ll}"
+    );
+    assert!(
+        ll.contains("ret i64 67"),
+        "str_slice feeding str_index should materialise byte 67:\n{ll}"
+    );
+}
+
+#[test]
 fn e4_string_literal_index_folds_to_integer_return() {
     let f = IIRFunction::new(
         "main",

--- a/code/packages/rust/iir-to-wasm/CHANGELOG.md
+++ b/code/packages/rust/iir-to-wasm/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this crate are documented here.  The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.22.0] — 2026-06-28 (LANG-FULL E4 — literal string slice on WASM)
+
+The WASM backend now accepts and lowers literal-only `str_slice`. The module
+feature pass derives the sliced byte range from prior string metadata and
+constant start/end bounds, appends it to the string data segment, and binds the
+slice destination to that offset so downstream `str_index` still emits the same
+guarded `i32.load8_u` path.
+
 ## [0.21.0] — 2026-06-27 (LANG-FULL E4 — literal string index on WASM)
 
 The WASM backend now accepts and lowers direct-literal `str_index`:

--- a/code/packages/rust/iir-to-wasm/README.md
+++ b/code/packages/rust/iir-to-wasm/README.md
@@ -64,18 +64,20 @@ through a deprecated intermediate.
   (or `f64`) at `wrap(handle)+idx*elemsize` offset 8; `array_len` reads the header.
   The wasm sibling of the LLVM `@calloc` + `icmp uge` + `llvm.trap` lowering. `i64`
   and `f64` elements (the ALGOL `integer`/`real` arrays).
-- **String literal foothold (v0.21.0 — LANG-FULL E4 / BA4)**: `str_const` writes
+- **String literal foothold (v0.22.0 — LANG-FULL E4 / BA4)**: `str_const` writes
   printable ASCII literal bytes into a linear-memory data segment and stores the
   byte pointer in an `i32` local; `print_str` calls the host import
   `env.__print_str(ptr,len)`. `str_len` over a direct literal materialises that
   literal's byte count as an integer constant, `str_eq` over two direct literals
   materialises byte equality as `1`/`0`, and literal `str_concat` creates another
-  data entry for the combined bytes. `str_index` over a direct literal emits a
+  data entry for the combined bytes. Literal `str_slice` derives another data
+  entry for a constant byte range. `str_index` over a direct literal emits a
   guarded `i32.load8_u` from the same data segment. This covers BASIC
   `PRINT "HELLO"` plus Twig `(string-length "HELLO")` and
   `(string-ref "ABC" 1)`, `(string=? "HELLO" "HELLO")`, and
-  `(string-length (string-append "AB" "CDE"))`; non-literal string values still
-  fail closed until the full byte-string runtime lands.
+  `(string-length (string-append "AB" "CDE"))`, plus
+  `(string-ref (substring "ABCDE" 1 4) 1)`; non-literal string values still fail
+  closed until the full byte-string runtime lands.
 - **All functions exported**: every function in the IIR module is exported by
   name so host runtimes can invoke them.
 

--- a/code/packages/rust/iir-to-wasm/src/lower.rs
+++ b/code/packages/rust/iir-to-wasm/src/lower.rs
@@ -905,6 +905,21 @@ fn emit_instr(
             code.extend(encode_local_set(rd));
         }
 
+        // ── str_slice → literal data-segment metadata ────────────────────────
+        "str_slice" => {
+            let dest = instr.dest.as_deref().ok_or_else(|| IIRWasmError::InvalidOperand {
+                function: fn_name.to_string(),
+                detail: "str_slice must have a dest".to_string(),
+            })?;
+            let rd = get_reg(dest)?;
+            let lit = string_literals.get(dest).ok_or_else(|| IIRWasmError::InvalidOperand {
+                function: fn_name.to_string(),
+                detail: format!("str_slice missing module string table entry for {dest:?}"),
+            })?;
+            code.extend(encode_i32_const(lit.offset as i32));
+            code.extend(encode_local_set(rd));
+        }
+
         // ── str_index → bounds-checked literal byte load ───────────────────────
         "str_index" => {
             let dest = instr.dest.as_deref().ok_or_else(|| IIRWasmError::InvalidOperand {
@@ -2978,6 +2993,7 @@ fn collect_module_features(module: &IIRModule) -> ModuleFeatures {
     let mut string_literals: ModuleStringLiterals = HashMap::new();
     let mut string_data: Vec<u8> = Vec::new();
     for fn_ in &module.functions {
+        let mut fn_ints: HashMap<String, i64> = HashMap::new();
         for instr in &fn_.instructions {
             match instr.op.as_str() {
                 "global_load" | "global_store" => {
@@ -2989,6 +3005,13 @@ fn collect_module_features(module: &IIRModule) -> ModuleFeatures {
                 }
                 "io_out" => {
                     uses_io_out = true;
+                }
+                "const" => {
+                    if let (Some(dest), Some(Operand::Int(value))) =
+                        (instr.dest.as_ref(), instr.srcs.first())
+                    {
+                        fn_ints.insert(dest.clone(), *value);
+                    }
                 }
                 "str_const" => {
                     if let (Some(dest), Some(Operand::Str(s))) =
@@ -3024,6 +3047,79 @@ fn collect_module_features(module: &IIRModule) -> ModuleFeatures {
                         };
                         let mut bytes = left_lit.bytes;
                         bytes.extend_from_slice(&right_lit.bytes);
+                        let offset = string_data.len() as u32;
+                        let len = bytes.len() as u32;
+                        string_data.extend_from_slice(&bytes);
+                        string_literals
+                            .entry(fn_.name.clone())
+                            .or_default()
+                            .insert(dest.clone(), WasmStringLiteral {
+                                offset,
+                                len,
+                                bytes,
+                            });
+                    }
+                }
+                "str_len" => {
+                    if let (Some(dest), [Operand::Var(src)]) =
+                        (instr.dest.as_ref(), instr.srcs.as_slice())
+                    {
+                        let Some(lit) = string_literals
+                            .get(&fn_.name)
+                            .and_then(|fn_strings| fn_strings.get(src))
+                        else {
+                            continue;
+                        };
+                        fn_ints.insert(dest.clone(), lit.len as i64);
+                    }
+                }
+                "add" | "sub" | "mul" | "div" => {
+                    if let (Some(dest), [Operand::Var(left), Operand::Var(right)]) =
+                        (instr.dest.as_ref(), instr.srcs.as_slice())
+                    {
+                        let (Some(left), Some(right)) =
+                            (fn_ints.get(left).copied(), fn_ints.get(right).copied())
+                        else {
+                            continue;
+                        };
+                        let value = match instr.op.as_str() {
+                            "add" => left.checked_add(right),
+                            "sub" => left.checked_sub(right),
+                            "mul" => left.checked_mul(right),
+                            "div" if right != 0 => left.checked_div(right),
+                            _ => None,
+                        };
+                        if let Some(value) = value {
+                            fn_ints.insert(dest.clone(), value);
+                        }
+                    }
+                }
+                "str_slice" => {
+                    if let (
+                        Some(dest),
+                        [Operand::Var(src), Operand::Var(start), Operand::Var(end)],
+                    ) = (instr.dest.as_ref(), instr.srcs.as_slice())
+                    {
+                        let Some(src_lit) = string_literals
+                            .get(&fn_.name)
+                            .and_then(|fn_strings| fn_strings.get(src))
+                        else {
+                            continue;
+                        };
+                        let (Some(start), Some(end)) =
+                            (fn_ints.get(start).copied(), fn_ints.get(end).copied())
+                        else {
+                            continue;
+                        };
+                        let (Ok(start), Ok(end)) =
+                            (usize::try_from(start), usize::try_from(end))
+                        else {
+                            continue;
+                        };
+                        if end < start || end > src_lit.bytes.len() {
+                            continue;
+                        }
+                        let bytes = src_lit.bytes[start..end].to_vec();
                         let offset = string_data.len() as u32;
                         let len = bytes.len() as u32;
                         string_data.extend_from_slice(&bytes);

--- a/code/packages/rust/iir-to-wasm/src/validate.rs
+++ b/code/packages/rust/iir-to-wasm/src/validate.rs
@@ -277,7 +277,7 @@ pub fn validate_for_wasm(module: &IIRModule) -> Vec<String> {
             // ── Check 4: UnsupportedType ─────────────────────────────────────
             //
             // `"str"` — accepted for the E4 literal-output/metadata foothold's
-            // direct string producers (`str_const`, `str_concat`). `str_len`,
+            // direct string producers (`str_const`, `str_concat`, `str_slice`). `str_len`,
             // `str_index`, and `str_eq` produce integers, not string values.
             // Richer dynamic string ops still fail explicitly below.
             //
@@ -287,10 +287,12 @@ pub fn validate_for_wasm(module: &IIRModule) -> Vec<String> {
             //
             // NOTE: float types (`"f32"`, `"f64"`) are NOT rejected here.
             // WASM has native float arithmetic, so they are fully supported.
-            if instr.type_hint == "str" && !matches!(instr.op.as_str(), "str_const" | "str_concat") {
+            if instr.type_hint == "str"
+                && !matches!(instr.op.as_str(), "str_const" | "str_concat" | "str_slice")
+            {
                 errors.push(format!(
                     "UnsupportedType: function {:?}, op {:?} has type_hint \"str\"; \
-                     only str_const + str_concat + str_len + str_index + str_eq + print_str literal output is supported in this WASM backend",
+                     only str_const + str_concat + str_slice + str_len + str_index + str_eq + print_str literal output is supported in this WASM backend",
                     func.name, instr.op
                 ));
             } else if instr.type_hint.starts_with("ref<")
@@ -356,6 +358,27 @@ pub fn validate_for_wasm(module: &IIRModule) -> Vec<String> {
                         errors.push(format!(
                             "UnsupportedOp: function {:?}, op \"str_concat\" requires \
                              dest, two Operand::Var sources, and str result type",
+                            func.name
+                        ));
+                    }
+                }
+            } else if instr.op == "str_slice" {
+                match (instr.dest.as_ref(), instr.srcs.as_slice(), instr.type_hint.as_str()) {
+                    (
+                        Some(_),
+                        [
+                            interpreter_ir::Operand::Var(_),
+                            interpreter_ir::Operand::Var(_),
+                            interpreter_ir::Operand::Var(_),
+                        ],
+                        "str",
+                    ) => {
+                        // Accepted — lower.rs materialises literal slice metadata.
+                    }
+                    _ => {
+                        errors.push(format!(
+                            "UnsupportedOp: function {:?}, op \"str_slice\" requires \
+                             dest, string/start/end Operand::Var sources, and str result type",
                             func.name
                         ));
                     }
@@ -694,6 +717,43 @@ mod tests {
         assert!(
             errs.is_empty(),
             "str_concat + str_len over direct literals should be accepted; got: {:?}",
+            errs
+        );
+    }
+
+    #[test]
+    fn e4_literal_str_slice_index_accepted() {
+        let errs = validate_for_wasm(&module_with(vec![
+            IIRInstr::new(
+                "str_const",
+                Some("s".into()),
+                vec![Operand::Str("ABCDE".into())],
+                "str",
+            ),
+            IIRInstr::new("const", Some("start".into()), vec![Operand::Int(1)], "i64"),
+            IIRInstr::new("const", Some("end".into()), vec![Operand::Int(4)], "i64"),
+            IIRInstr::new(
+                "str_slice",
+                Some("sub".into()),
+                vec![
+                    Operand::Var("s".into()),
+                    Operand::Var("start".into()),
+                    Operand::Var("end".into()),
+                ],
+                "str",
+            ),
+            IIRInstr::new("const", Some("i".into()), vec![Operand::Int(1)], "i64"),
+            IIRInstr::new(
+                "str_index",
+                Some("b".into()),
+                vec![Operand::Var("sub".into()), Operand::Var("i".into())],
+                "i64",
+            ),
+            IIRInstr::new("ret", None, vec![Operand::Var("b".into())], "i64"),
+        ]));
+        assert!(
+            errs.is_empty(),
+            "str_slice + str_index over direct literals should be accepted; got: {:?}",
             errs
         );
     }

--- a/code/packages/rust/iir-to-wasm/tests/test_backend.rs
+++ b/code/packages/rust/iir-to-wasm/tests/test_backend.rs
@@ -1695,6 +1695,54 @@ fn e4_string_concat_len_lowers_to_literal_length() {
 }
 
 #[test]
+fn e4_string_slice_index_lowers_to_literal_byte_load() {
+    let m = module_one("main", vec![], "i64", vec![
+        IIRInstr::new(
+            "str_const",
+            Some("s".into()),
+            vec![Operand::Str("ABCDE".into())],
+            "str",
+        ),
+        IIRInstr::new("const", Some("start".into()), vec![Operand::Int(1)], "i64"),
+        IIRInstr::new("const", Some("end".into()), vec![Operand::Int(4)], "i64"),
+        IIRInstr::new(
+            "str_slice",
+            Some("sub".into()),
+            vec![
+                Operand::Var("s".into()),
+                Operand::Var("start".into()),
+                Operand::Var("end".into()),
+            ],
+            "str",
+        ),
+        IIRInstr::new("const", Some("i".into()), vec![Operand::Int(1)], "i64"),
+        IIRInstr::new(
+            "str_index",
+            Some("b".into()),
+            vec![Operand::Var("sub".into()), Operand::Var("i".into())],
+            "i64",
+        ),
+        IIRInstr::new("ret", None, vec![Operand::Var("b".into())], "i64"),
+    ]);
+
+    let errs = validate_for_wasm(&m);
+    assert!(
+        errs.is_empty(),
+        "E4: str_slice + str_index should validate: {errs:?}"
+    );
+    let wm = lower_iir_to_wasm(&m, &IIRWasmConfig::default())
+        .expect("E4: str_slice + str_index should lower");
+    assert_eq!(
+        wm.data[0].data, b"ABCDEBCD",
+        "E4: string data should contain the source and sliced literal"
+    );
+    assert!(
+        wm.code[0].code.contains(&0x2D),
+        "E4: str_index over a slice should still emit i32.load8_u"
+    );
+}
+
+#[test]
 fn e4_string_index_lowers_to_literal_byte_load() {
     let m = module_one("main", vec![], "i64", vec![
         IIRInstr::new(

--- a/code/packages/rust/lang-aot/CHANGELOG.md
+++ b/code/packages/rust/lang-aot/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog — `lang-aot`
 
+## 0.148.0 — 2026-06-28 — Twig substring feeds string indexing on all seven backends (LANG-FULL E4)
+
+The matrix now proves a typed Twig lexical string can be sliced and then byte
+indexed:
+
+```scheme
+(let ((s "ABCDE")) (string-ref (substring s 1 4) 1))
+```
+
+Expected exit code is `67` (`C` in `BCD`) on native-AOT + LLVM + WASM + JVM +
+CLR + VM + JIT. `twig-ir-compiler` 0.33.0 lowers `substring` to the shared
+`str_slice` op, and the static backends either fold the derived literal slice
+or map it to their managed string substring primitive.
+
 ## 0.147.0 — 2026-06-28 — Twig string length computes string indexing on all seven backends (LANG-FULL E4)
 
 The matrix now proves a typed Twig lexical string length can feed integer

--- a/code/packages/rust/lang-aot/tests/lang_matrix.rs
+++ b/code/packages/rust/lang-aot/tests/lang_matrix.rs
@@ -309,6 +309,17 @@ const PROGRAMS: &[Prog] = &[
         expect: Expect::Exit(69),
         backends: &[NativeAot, Llvm, Wasm, Jvm, Clr, Vm, Jit],
     },
+    // Twig — E4 `substring` feeding `string-ref`. This proves the shared
+    // `str_slice` op produces a string value that all seven proven columns can
+    // consume with the existing byte-indexing contract. `substring` 1..4 is
+    // `BCD`, and index 1 is byte `C` (67).
+    Prog {
+        lang: Language::Twig,
+        ext: "twig",
+        src: "(let ((s \"ABCDE\")) (string-ref (substring s 1 4) 1))",
+        expect: Expect::Exit(67),
+        backends: &[NativeAot, Llvm, Wasm, Jvm, Clr, Vm, Jit],
+    },
     // Twig — *top-level value `define`* read from `main` (`(define x 40) (define
     // y 2) (+ x y)` = 42).  A value define previously lowered to
     // `call_builtin "global_set"` (and reads to `global_get`), `type_hint =

--- a/code/packages/rust/twig-aot/CHANGELOG.md
+++ b/code/packages/rust/twig-aot/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog — `twig-aot`
 
+## 0.21.0 — 2026-06-28 — native substring metadata folding (LANG-FULL E4)
+
+`prepare_module_for_aot` now folds literal-only `str_slice` results into the
+same native byte-buffer metadata used by `str_const` and `str_concat`. This lets
+Twig `(let ((s "ABCDE")) (string-ref (substring s 1 4) 1))` fold the slice to
+`BCD` and the final `str_index` to byte `67` before direct native lowering.
+
 ## 0.20.0 — 2026-06-28 — native computed string index metadata (LANG-FULL E4)
 
 `prepare_module_for_aot` now records folded `str_len` results as integer

--- a/code/packages/rust/twig-aot/README.md
+++ b/code/packages/rust/twig-aot/README.md
@@ -50,10 +50,11 @@ LANG-FULL E4 / BA4 literal string output reuses this runtime path: native AOT
 preparation lowers `str_const` + `print_str` to `alloc_bytes`, `store_byte`, and
 `call_builtin "print_string"`, so source-level BASIC `PRINT "HELLO"` runs through
 the same object/link/runtime pipeline as byte-tape programs. Direct-literal
-`str_len`, `str_index`, `str_eq`, and literal `str_concat` metadata over direct
-literals fold before machine-code lowering, so Twig `(string-length "HELLO")`,
-`(string-ref "ABC" 1)`, `(string=? "HELLO" "HELLO")`, and
-`(string-length (string-append "AB" "CDE"))` run natively through the same
+`str_len`, `str_index`, `str_eq`, literal `str_concat`, and literal `str_slice`
+metadata over direct literals fold before machine-code lowering, so Twig
+`(string-length "HELLO")`, `(string-ref "ABC" 1)`,
+`(string=? "HELLO" "HELLO")`, `(string-length (string-append "AB" "CDE"))`,
+and `(string-ref (substring "ABCDE" 1 4) 1)` run natively through the same
 preparation pass. Folded `str_len` metadata can also flow through typed integer
 arithmetic, so `(let ((s "ABCDE")) (string-ref s (- (string-length s) 1)))`
 folds to byte `69` before native lowering.

--- a/code/packages/rust/twig-aot/src/lib.rs
+++ b/code/packages/rust/twig-aot/src/lib.rs
@@ -1453,6 +1453,58 @@ fn strip_dead_string_consts(func: &mut IIRFunction) {
 /// pass reuses that path for `str_const` + `print_str` and folds direct
 /// literal `str_len`/`str_eq`; richer string ops remain unsupported until the
 /// full byte-string runtime lands.
+fn push_aot_string_literal(
+    lowered: &mut Vec<IIRInstr>,
+    next: &mut usize,
+    literal: String,
+) -> (String, String, String) {
+    let base = format!("__aot_str{next}");
+    *next += 1;
+    let len_var = format!("{base}_len");
+    let buf_var = format!("{base}_buf");
+
+    lowered.push(IIRInstr::new(
+        "const",
+        Some(len_var.clone()),
+        vec![Operand::Int(literal.len() as i64)],
+        "i64",
+    ));
+    lowered.push(IIRInstr::new(
+        "alloc_bytes",
+        Some(buf_var.clone()),
+        vec![Operand::Var(len_var.clone())],
+        "i64",
+    ));
+    for (idx, byte) in literal.bytes().enumerate() {
+        let off_var = format!("{base}_off{idx}");
+        let byte_var = format!("{base}_byte{idx}");
+        lowered.push(IIRInstr::new(
+            "const",
+            Some(off_var.clone()),
+            vec![Operand::Int(idx as i64)],
+            "i64",
+        ));
+        lowered.push(IIRInstr::new(
+            "const",
+            Some(byte_var.clone()),
+            vec![Operand::Int(byte as i64)],
+            "i64",
+        ));
+        lowered.push(IIRInstr::new(
+            "store_byte",
+            None,
+            vec![
+                Operand::Var(buf_var.clone()),
+                Operand::Var(off_var),
+                Operand::Var(byte_var),
+            ],
+            "void",
+        ));
+    }
+
+    (buf_var, len_var, literal)
+}
+
 fn lower_string_literals_for_aot(func: &mut IIRFunction) {
     let mut lowered = Vec::with_capacity(func.instructions.len());
     let mut strings: HashMap<String, (String, String, String)> = HashMap::new();
@@ -1524,50 +1576,8 @@ fn lower_string_literals_for_aot(func: &mut IIRFunction) {
                 continue;
             }
 
-            let base = format!("__aot_str{next}");
-            next += 1;
-            let len_var = format!("{base}_len");
-            let buf_var = format!("{base}_buf");
-
-            lowered.push(IIRInstr::new(
-                "const",
-                Some(len_var.clone()),
-                vec![Operand::Int(literal.len() as i64)],
-                "i64",
-            ));
-            lowered.push(IIRInstr::new(
-                "alloc_bytes",
-                Some(buf_var.clone()),
-                vec![Operand::Var(len_var.clone())],
-                "i64",
-            ));
-            for (idx, byte) in literal.bytes().enumerate() {
-                let off_var = format!("{base}_off{idx}");
-                let byte_var = format!("{base}_byte{idx}");
-                lowered.push(IIRInstr::new(
-                    "const",
-                    Some(off_var.clone()),
-                    vec![Operand::Int(idx as i64)],
-                    "i64",
-                ));
-                lowered.push(IIRInstr::new(
-                    "const",
-                    Some(byte_var.clone()),
-                    vec![Operand::Int(byte as i64)],
-                    "i64",
-                ));
-                lowered.push(IIRInstr::new(
-                    "store_byte",
-                    None,
-                    vec![
-                        Operand::Var(buf_var.clone()),
-                        Operand::Var(off_var),
-                        Operand::Var(byte_var),
-                    ],
-                    "void",
-                ));
-            }
-            strings.insert(dest, (buf_var, len_var, literal));
+            let string = push_aot_string_literal(&mut lowered, &mut next, literal);
+            strings.insert(dest, string);
             continue;
         }
 
@@ -1594,50 +1604,47 @@ fn lower_string_literals_for_aot(func: &mut IIRFunction) {
                 continue;
             }
 
-            let base = format!("__aot_str{next}");
-            next += 1;
-            let len_var = format!("{base}_len");
-            let buf_var = format!("{base}_buf");
+            let string = push_aot_string_literal(&mut lowered, &mut next, literal);
+            strings.insert(dest, string);
+            continue;
+        }
 
-            lowered.push(IIRInstr::new(
-                "const",
-                Some(len_var.clone()),
-                vec![Operand::Int(literal.len() as i64)],
-                "i64",
-            ));
-            lowered.push(IIRInstr::new(
-                "alloc_bytes",
-                Some(buf_var.clone()),
-                vec![Operand::Var(len_var.clone())],
-                "i64",
-            ));
-            for (idx, byte) in literal.bytes().enumerate() {
-                let off_var = format!("{base}_off{idx}");
-                let byte_var = format!("{base}_byte{idx}");
-                lowered.push(IIRInstr::new(
-                    "const",
-                    Some(off_var.clone()),
-                    vec![Operand::Int(idx as i64)],
-                    "i64",
-                ));
-                lowered.push(IIRInstr::new(
-                    "const",
-                    Some(byte_var.clone()),
-                    vec![Operand::Int(byte as i64)],
-                    "i64",
-                ));
-                lowered.push(IIRInstr::new(
-                    "store_byte",
-                    None,
-                    vec![
-                        Operand::Var(buf_var.clone()),
-                        Operand::Var(off_var),
-                        Operand::Var(byte_var),
-                    ],
-                    "void",
-                ));
+        if instr.op == "str_slice" {
+            let Some(dest) = instr.dest.clone() else {
+                lowered.push(instr);
+                continue;
+            };
+            let [Operand::Var(src), Operand::Var(start), Operand::Var(end)] = instr.srcs.as_slice()
+            else {
+                lowered.push(instr);
+                continue;
+            };
+            let Some((_, _, literal)) = strings.get(src).cloned() else {
+                lowered.push(instr);
+                continue;
+            };
+            let (Some(start), Some(end)) = (ints.get(start).copied(), ints.get(end).copied())
+            else {
+                lowered.push(instr);
+                continue;
+            };
+            if start < 0 || end < start || end as usize > literal.len() {
+                lowered.push(IIRInstr::new("type_assert", None, vec![], "void"));
+                let string = push_aot_string_literal(&mut lowered, &mut next, String::new());
+                strings.insert(dest, string);
+                continue;
             }
-            strings.insert(dest, (buf_var, len_var, literal));
+            let slice = literal.as_bytes()[start as usize..end as usize].to_vec();
+            let Ok(literal) = String::from_utf8(slice) else {
+                lowered.push(instr);
+                continue;
+            };
+            if !is_printable_ascii_str(&literal) {
+                lowered.push(instr);
+                continue;
+            }
+            let string = push_aot_string_literal(&mut lowered, &mut next, literal);
+            strings.insert(dest, string);
             continue;
         }
 
@@ -2422,6 +2429,62 @@ mod tests {
         assert!(
             f.instructions.iter().all(|i| i.op != "str_concat" && i.op != "str_len"),
             "native lowering should remove folded str_concat + str_len: {:?}",
+            f.instructions
+        );
+    }
+
+    #[test]
+    fn string_literal_slice_index_lowers_to_i64_const() {
+        let mut f = IIRFunction::new(
+            "main",
+            vec![],
+            "i64",
+            vec![
+                IIRInstr::new(
+                    "str_const",
+                    Some("s".into()),
+                    vec![Operand::Str("ABCDE".into())],
+                    "str",
+                ),
+                IIRInstr::new("const", Some("start".into()), vec![Operand::Int(1)], "i64"),
+                IIRInstr::new("const", Some("end".into()), vec![Operand::Int(4)], "i64"),
+                IIRInstr::new(
+                    "str_slice",
+                    Some("sub".into()),
+                    vec![
+                        Operand::Var("s".into()),
+                        Operand::Var("start".into()),
+                        Operand::Var("end".into()),
+                    ],
+                    "str",
+                ),
+                IIRInstr::new("const", Some("i".into()), vec![Operand::Int(1)], "i64"),
+                IIRInstr::new(
+                    "str_index",
+                    Some("b".into()),
+                    vec![Operand::Var("sub".into()), Operand::Var("i".into())],
+                    "i64",
+                ),
+                IIRInstr::new("ret", None, vec![Operand::Var("b".into())], "i64"),
+            ],
+        );
+
+        lower_string_literals_for_aot(&mut f);
+
+        let byte_const = f
+            .instructions
+            .iter()
+            .find(|i| i.dest.as_deref() == Some("b"));
+        assert!(
+            matches!(byte_const, Some(i) if i.op == "const" && i.srcs == vec![Operand::Int(67)]),
+            "str_slice feeding str_index should fold to byte 67: {:?}",
+            f.instructions
+        );
+        assert!(
+            f.instructions
+                .iter()
+                .all(|i| i.op != "str_slice" && i.op != "str_index"),
+            "native lowering should remove folded str_slice + str_index: {:?}",
             f.instructions
         );
     }

--- a/code/packages/rust/twig-ir-compiler/CHANGELOG.md
+++ b/code/packages/rust/twig-ir-compiler/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog — twig-ir-compiler
 
+## [0.33.0] — 2026-06-28 (LANG-FULL E4 — substring feeds string-ref proof)
+
+Lexical string bindings can now feed `substring`, and the resulting string can
+feed `string-ref` through shared E4 ops:
+
+```scheme
+(let ((s "ABCDE")) (string-ref (substring s 1 4) 1))
+```
+
+The compiler emits `str_slice` for `substring` when the source is a known E4
+string expression and both bounds are known E4 index expressions. The indexed
+byte is `67` (`C` in `BCD`), with no dynamic string builtin fallback.
+
 ## [0.32.0] — 2026-06-28 (LANG-FULL E4 — computed string index proof)
 
 Lexical string bindings can now compute a `string-ref` index with typed integer

--- a/code/packages/rust/twig-ir-compiler/README.md
+++ b/code/packages/rust/twig-ir-compiler/README.md
@@ -23,18 +23,21 @@ Anonymous lambdas have their captured free variables prepended to the parameter 
 Top-level value defines lower one of two ways (TW2/E4). A value define that is **not captured by any lambda** is read only from `main`, so its statically-typed (`i64`/`bool` and immutable top-level `str`) value is kept in a `main` register and reads return it directly — fully typed, accepted by every code-gen backend. A value define **captured by a closure** (read inside a lambda body, which compiles to a separate function) stays on the host global table via `call_builtin "global_set" name value` / `global_get`, as does a top-level forward reference.
 
 Literal `(string-length "...")`, `(string-ref "..." i)`, `(string=? "..." "...")`,
-and `(string-length (string-append "..." "..."))` lower to typed E4 string
+`(substring "..." i j)`, and `(string-length (string-append "..." "..."))`
+lower to typed E4 string
 metadata ops: `str_const` for each direct literal, then `str_len`, `str_index`,
-`str_eq`, or `str_concat` for the result path. The same E4 lowering also handles
-immutable top-level string values, so `(define s "ABC") (string-ref s 2)` and
-named-string `string-append`/`string=?` proofs avoid the dynamic builtin path.
+`str_eq`, `str_slice`, or `str_concat` for the result path. The same E4
+lowering also handles immutable top-level string values, so `(define s "ABC")
+(string-ref s 2)` and named-string `string-append`/`string=?` proofs avoid the
+dynamic builtin path.
 Lexical `let`/`let*` string literal bindings use the same typed registers, so
 local strings can feed `string-ref`, `string-length`, `string=?`, and
 `string-append` without dynamic builtins; a `string-append` result can also feed
 `string-ref` directly through `str_concat` -> `str_index`, and `string-length`
-can compute a typed arithmetic index that feeds `str_index`. Reassignable
-strings, captured strings, and broader dynamic string values remain follow-up
-work.
+can compute a typed arithmetic index that feeds `str_index`. `substring` over a
+known string and known index expressions lowers to `str_slice`, so its result
+can feed `string-ref` through `str_index`. Reassignable strings, captured
+strings, and broader dynamic string values remain follow-up work.
 
 All emitted instructions carry `type_hint = "any"` because Twig is dynamically typed. Functions therefore have `type_status = Untyped`. The vm-core profiler observes runtime types; the JIT specialises later.
 
@@ -46,7 +49,7 @@ The compiler decides at compile time:
 |-----------------------------|---------------------------------------------|
 | Top-level user fn           | `call <name>, ...args`                      |
 | Typed arithmetic (`+`,`-`,`*`,`/`) on `i64` args | a chain of typed `add`/`sub`/`mul`/`div` |
-| Direct literal, immutable top-level, or lexical-local string metadata (`string-length`, `string-ref`, `string=?`, `string-append`) | `str_const` + `str_len`/`str_index`/`str_eq`/`str_concat`, with typed index arithmetic for `string-ref` |
+| Direct literal, immutable top-level, or lexical-local string metadata (`string-length`, `string-ref`, `substring`, `string=?`, `string-append`) | `str_const` + `str_len`/`str_index`/`str_slice`/`str_eq`/`str_concat`, with typed index arithmetic for `string-ref` and `substring` bounds |
 | Builtin (`cons`, `<`, …)    | `call_builtin <name>, ...args`              |
 | Anything else (locals etc.) | `call_builtin "apply_closure", h, ...args`  |
 

--- a/code/packages/rust/twig-ir-compiler/src/compiler.rs
+++ b/code/packages/rust/twig-ir-compiler/src/compiler.rs
@@ -1386,10 +1386,20 @@ impl Compiler {
             Expr::VarRef(v) => self.is_known_value_type(&v.name, ctx, "str"),
             Expr::Apply(apply) => {
                 if let Expr::VarRef(f) = apply.fn_expr.as_ref() {
-                    f.name == "string-append"
-                        && apply.args.len() == 2
-                        && self.can_compile_e4_string_expr(&apply.args[0], ctx)
-                        && self.can_compile_e4_string_expr(&apply.args[1], ctx)
+                    match f.name.as_str() {
+                        "string-append" => {
+                            apply.args.len() == 2
+                                && self.can_compile_e4_string_expr(&apply.args[0], ctx)
+                                && self.can_compile_e4_string_expr(&apply.args[1], ctx)
+                        }
+                        "substring" => {
+                            apply.args.len() == 3
+                                && self.can_compile_e4_string_expr(&apply.args[0], ctx)
+                                && self.can_compile_e4_index_expr(&apply.args[1], ctx)
+                                && self.can_compile_e4_index_expr(&apply.args[2], ctx)
+                        }
+                        _ => false,
+                    }
                 } else {
                     false
                 }
@@ -1519,6 +1529,32 @@ impl Compiler {
                     loc,
                 );
                 ctx.record_type(&dest, "i64");
+                Ok(Some(dest))
+            }
+            "substring"
+                if args.len() == 3
+                    && self.can_compile_e4_string_expr(&args[0], ctx)
+                    && self.can_compile_e4_index_expr(&args[1], ctx)
+                    && self.can_compile_e4_index_expr(&args[2], ctx) =>
+            {
+                let string_reg = self.compile_e4_string_expr(&args[0], ctx)?;
+                let start_reg = self.compile_expr(&args[1], ctx)?;
+                let end_reg = self.compile_expr(&args[2], ctx)?;
+                let dest = ctx.fresh_var("s");
+                ctx.emit(
+                    IIRInstr::new(
+                        "str_slice",
+                        Some(dest.clone()),
+                        vec![
+                            Operand::Var(string_reg),
+                            Operand::Var(start_reg),
+                            Operand::Var(end_reg),
+                        ],
+                        "str",
+                    ),
+                    loc,
+                );
+                ctx.record_type(&dest, "str");
                 Ok(Some(dest))
             }
             _ => Ok(None),

--- a/code/packages/rust/twig-ir-compiler/src/lib.rs
+++ b/code/packages/rust/twig-ir-compiler/src/lib.rs
@@ -1677,6 +1677,37 @@ mod tests {
         assert_eq!(main.return_type, "i64");
     }
 
+    #[test]
+    fn let_string_binding_feeds_e4_substring_ref() {
+        let m = compile_source(
+            "(let ((s \"ABCDE\")) (string-ref (substring s 1 4) 1))",
+            "string_let_substring_ref",
+        )
+        .expect("let string binding should feed E4 substring");
+        let main = m.functions.iter().find(|f| f.name == "main").unwrap();
+        let ops: Vec<&str> = main.instructions.iter().map(|i| i.op.as_str()).collect();
+        assert_eq!(
+            ops,
+            vec![
+                "str_const",
+                "const",
+                "const",
+                "str_slice",
+                "const",
+                "str_index",
+                "ret"
+            ]
+        );
+        assert!(
+            main.instructions.iter().all(|i| i.op != "call_builtin"),
+            "let substring/ref should avoid dynamic builtin path: {:?}",
+            main.instructions
+        );
+        assert_eq!(main.instructions[3].type_hint, "str");
+        assert_eq!(main.instructions[5].type_hint, "i64");
+        assert_eq!(main.return_type, "i64");
+    }
+
     // =========================================================================
     // LANG51: String literal tests
     // =========================================================================

--- a/code/packages/rust/vm-core/CHANGELOG.md
+++ b/code/packages/rust/vm-core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog — vm-core
 
+## [0.11.0] — 2026-06-28 (LANG-FULL E4 — reference string slicing)
+
+The reference VM now implements shared E4 `str_slice` semantics over
+`Value::Str`: source string plus start/end integer bounds produce a fresh
+substring. The operation is byte-indexed, traps on negative, inverted, or
+out-of-bounds ranges, and rejects ranges that do not preserve UTF-8 boundaries.
+
 ## [0.10.0] — 2026-06-27 (LANG-FULL E4 — reference string ops, VM slice)
 
 Reference VM semantics for the six shared E4 string opcodes:

--- a/code/packages/rust/vm-core/src/dispatch.rs
+++ b/code/packages/rust/vm-core/src/dispatch.rs
@@ -797,6 +797,40 @@ fn handle_str_concat(ctx: &mut DispatchCtx, instr: &IIRInstr) -> Result<Option<V
     Ok(Some(value))
 }
 
+fn handle_str_slice(ctx: &mut DispatchCtx, instr: &IIRInstr) -> Result<Option<Value>, VMError> {
+    let value = {
+        let frame = ctx.frames.last().ok_or_else(|| VMError::Custom("no frame".into()))?;
+        let s = string_src(frame, &instr.srcs, 0, "str_slice")?;
+        let start_value = resolve_src(frame, &instr.srcs, 1)?;
+        let end_value = resolve_src(frame, &instr.srcs, 2)?;
+        let start = start_value.as_i64().ok_or_else(|| VMError::TypeError {
+            expected: "i64".into(),
+            actual: start_value.iir_type_name().into(),
+            context: "str_slice".into(),
+        })?;
+        let end = end_value.as_i64().ok_or_else(|| VMError::TypeError {
+            expected: "i64".into(),
+            actual: end_value.iir_type_name().into(),
+            context: "str_slice".into(),
+        })?;
+        if start < 0 || end < start || end as usize > s.len() {
+            return Err(VMError::Custom(format!(
+                "str_slice: range {start}..{end} out of bounds for string of length {}",
+                s.len()
+            )));
+        }
+        let bytes = &s.as_bytes()[start as usize..end as usize];
+        let sliced = String::from_utf8(bytes.to_vec()).map_err(|_| {
+            VMError::Custom("str_slice: range does not preserve UTF-8 boundaries".into())
+        })?;
+        Value::Str(sliced)
+    };
+    if let Some(dest) = &instr.dest {
+        ctx.frames.last_mut().unwrap().assign(dest, value.clone());
+    }
+    Ok(Some(value))
+}
+
 fn handle_str_eq(ctx: &mut DispatchCtx, instr: &IIRInstr) -> Result<Option<Value>, VMError> {
     let same = {
         let frame = ctx.frames.last().ok_or_else(|| VMError::Custom("no frame".into()))?;
@@ -1328,6 +1362,7 @@ pub(crate) fn lookup_standard(op: &str) -> Option<StdHandlerFn> {
         "str_len"      => Some(handle_str_len),
         "str_index"    => Some(handle_str_index),
         "str_concat"   => Some(handle_str_concat),
+        "str_slice"    => Some(handle_str_slice),
         "str_eq"       => Some(handle_str_eq),
         "print_str"    => Some(handle_print_str),
         "alloc_array"  => Some(handle_alloc_array),

--- a/code/packages/rust/vm-core/tests/e4_strings.rs
+++ b/code/packages/rust/vm-core/tests/e4_strings.rs
@@ -55,6 +55,56 @@ fn str_concat_and_eq_return_i64_bool() {
 }
 
 #[test]
+fn str_slice_produces_substring_value() {
+    let result = run(
+        vec![
+            ins("str_const", Some("s"), vec![Operand::Str("ABCDE".into())], "str"),
+            ins("const", Some("start"), vec![Operand::Int(1)], "i64"),
+            ins("const", Some("end"), vec![Operand::Int(4)], "i64"),
+            ins(
+                "str_slice",
+                Some("sub"),
+                vec![
+                    Operand::Var("s".into()),
+                    Operand::Var("start".into()),
+                    Operand::Var("end".into()),
+                ],
+                "str",
+            ),
+            ins("str_len", Some("n"), vec![Operand::Var("sub".into())], "i64"),
+            ins("ret", None, vec![Operand::Var("n".into())], "i64"),
+        ],
+        "i64",
+    )
+    .unwrap();
+    assert_eq!(result, Some(Value::Int(3)));
+}
+
+#[test]
+fn str_slice_traps_out_of_bounds() {
+    let err = run(
+        vec![
+            ins("str_const", Some("s"), vec![Operand::Str("ABC".into())], "str"),
+            ins("const", Some("start"), vec![Operand::Int(2)], "i64"),
+            ins("const", Some("end"), vec![Operand::Int(4)], "i64"),
+            ins(
+                "str_slice",
+                Some("sub"),
+                vec![
+                    Operand::Var("s".into()),
+                    Operand::Var("start".into()),
+                    Operand::Var("end".into()),
+                ],
+                "str",
+            ),
+        ],
+        "str",
+    )
+    .unwrap_err();
+    assert!(err.to_string().contains("str_slice"));
+}
+
+#[test]
 fn str_index_returns_unsigned_byte() {
     let result = run(
         vec![


### PR DESCRIPTION
## Summary

- Lower Twig `substring` over known E4 string/index expressions to shared `str_slice`.
- Add reference VM `str_slice` semantics plus static/backend lowering across native AOT, LLVM, WASM, JVM, and CLR.
- Add a LANG matrix row proving `(let ((s "ABCDE")) (string-ref (substring s 1 4) 1))` exits `67` across NativeAot, Llvm, Wasm, Jvm, Clr, Vm, and Jit.

## Validation

- `cargo test -p twig-ir-compiler let_string_binding_feeds_e4_substring_ref -q`
- `cargo test -p vm-core str_slice -q`
- `cargo test -p twig-aot string_literal_slice_index_lowers_to_i64_const -q`
- `cargo test -p iir-to-llvm e4_string_literal_slice_index_folds_to_integer_return -q`
- `cargo test -p iir-to-wasm e4_string_slice_index_lowers_to_literal_byte_load -q`
- `cargo test -p iir-to-wasm e4_literal_str_slice_index_accepted -q`
- `cargo test -p iir-to-jvm-class-file e4_string_slice_index_lowers_to_string_substring_and_char_at -q`
- `cargo test -p iir-to-jvm-class-file str_slice_literal_accepted -q`
- `cargo test -p iir-to-cil-bytecode string_literal_slice_index_emits_string_substring -q`
- `cargo test -p iir-to-cil-bytecode str_slice_literal_accepted -q`
- `cargo check -p twig-ir-compiler -p twig-aot -p vm-core -p iir-to-llvm -p iir-to-wasm -p iir-to-jvm-class-file -p iir-to-cil-bytecode -p lang-aot -q`
- `cargo test -p lang-aot --test lang_matrix matrix_every_proven_cell_agrees -q`
- `cargo test -p lang-aot --test lang_matrix proven_columns_do_not_silently_skip -q`
- `git diff --check`
- `cargo test -p algol-iir-compiler --test backend_compat -q`