### PR TITLE
[codex] Add MOS bulk depletion charge shaping

### DIFF
--- a/code/packages/python/mosfet-models/CHANGELOG.md
+++ b/code/packages/python/mosfet-models/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Added
 - `Level1Params` now includes MOS Level-1 capacitance footholds (`CGSO`,
   `CGDO`, `CGBO`, `CBS`, `CBD`) and reports them through `MosResult`.
+- `Level1Params.PB` and `Level1Params.MJ` now shape zero-bias bulk-junction
+  `CBS`/`CBD` capacitance under reverse source-bulk and drain-bulk bias.
 - `Level1Params`: SPICE Level-1 parameter set (VT0, KP, LAMBDA, GAMMA, PHI, W, L, IS, N_SUB, T_NOM, subthreshold_enable).
 - `evaluate_level1(params, V_GS, V_DS, V_BS, T)`: classical square-law I-V with body effect, channel-length modulation, and optional subthreshold current.
 - `MosResult`: Id + small-signal Jacobian (gm, gds, gmb) + Meyer capacitances + region label.

--- a/code/packages/python/mosfet-models/README.md
+++ b/code/packages/python/mosfet-models/README.md
@@ -22,7 +22,7 @@ print(r.Id, r.gm, r.gds, r.region)
 
 ## v0.1.0 scope
 
-- `Level1Params`: Level-1 DC plus capacitance parameter set with sane defaults for 130 nm-style NMOS.
+- `Level1Params`: Level-1 DC plus capacitance parameter set with sane defaults for 130 nm-style NMOS, including `PB` / `MJ` bulk-junction depletion shaping for `CBS` / `CBD`.
 - `evaluate_level1(params, V_GS, V_DS, V_BS, T)`: returns `MosResult` with Id, gm, gds, gmb, Cgs/Cgd/Cgb/Cbs/Cbd, region.
 - Region detection: cutoff (subthreshold-aware), triode, saturation.
 - Body effect via gamma * (sqrt(PHI-V_BS) - sqrt(PHI)) shift.

--- a/code/packages/python/mosfet-models/src/mosfet_models/__init__.py
+++ b/code/packages/python/mosfet-models/src/mosfet_models/__init__.py
@@ -7,6 +7,7 @@ subsets land in v0.2.0 alongside the SPICE engine integration.
 from mosfet_models.level1 import (
     Level1Params,
     MosResult,
+    bulk_junction_capacitance,
     evaluate_level1,
 )
 from mosfet_models.mosfet import MOSFET, Level1Model, MosfetModel, MosfetType
@@ -21,5 +22,6 @@ __all__ = [
     "MosfetModel",
     "MosfetType",
     "__version__",
+    "bulk_junction_capacitance",
     "evaluate_level1",
 ]

--- a/code/packages/python/mosfet-models/src/mosfet_models/level1.py
+++ b/code/packages/python/mosfet-models/src/mosfet_models/level1.py
@@ -33,6 +33,8 @@ class Level1Params:
     CGBO: float = 0.0  # gate-bulk overlap capacitance per width (F/m)
     CBS: float = 0.0  # source-bulk zero-bias junction capacitance (F)
     CBD: float = 0.0  # drain-bulk zero-bias junction capacitance (F)
+    PB: float = 0.8  # bulk junction potential (V)
+    MJ: float = 0.5  # bulk junction grading coefficient
     subthreshold_enable: bool = True
 
 
@@ -50,6 +52,26 @@ class MosResult:
     Cbs: float
     Cbd: float
     region: str  # 'cutoff', 'subthreshold', 'triode', 'saturation'
+
+
+def bulk_junction_capacitance(
+    zero_bias_capacitance: float,
+    junction_voltage: float,
+    junction_potential: float,
+    grading_coefficient: float,
+) -> float:
+    """Return the Level-1 bulk-junction depletion capacitance.
+
+    ``junction_voltage`` follows the diode convention: positive is forward
+    body-to-terminal bias, negative is reverse bias.
+    """
+
+    if zero_bias_capacitance <= 0.0:
+        return zero_bias_capacitance
+    if junction_potential <= 0.0 or grading_coefficient == 0.0:
+        return zero_bias_capacitance
+    reverse_scale = max(0.0, -junction_voltage) / junction_potential
+    return zero_bias_capacitance / ((1.0 + reverse_scale) ** grading_coefficient)
 
 
 def evaluate_level1(
@@ -84,8 +106,8 @@ def evaluate_level1(
     Cgs_intrinsic = (2.0 / 3.0) * p.W * p.L * p.KP / 1.0  # placeholder; Meyer model
     Cgd_intrinsic = 0.0
     Cgb_intrinsic = 0.0
-    Cbs_bulk = p.CBS
-    Cbd_bulk = p.CBD
+    Cbs_bulk = bulk_junction_capacitance(p.CBS, V_BS, p.PB, p.MJ)
+    Cbd_bulk = bulk_junction_capacitance(p.CBD, V_BS - V_DS, p.PB, p.MJ)
 
     if V_OV <= 0:
         # Cutoff — optionally subthreshold.

--- a/code/packages/python/mosfet-models/tests/test_models.py
+++ b/code/packages/python/mosfet-models/tests/test_models.py
@@ -145,6 +145,20 @@ def test_overlap_and_bulk_capacitances_are_reported():
     assert r.Cbd == 7e-12
 
 
+def test_bulk_junction_capacitance_uses_pb_mj_for_reverse_bias():
+    p = Level1Params(
+        CBS=4e-12,
+        CBD=8e-12,
+        PB=1.0,
+        MJ=0.5,
+        subthreshold_enable=False,
+    )
+    r = evaluate_level1(p, V_GS=0.0, V_DS=2.0, V_BS=-1.0)
+
+    assert r.Cbs == pytest.approx(4e-12 / (2.0 ** 0.5))
+    assert r.Cbd == pytest.approx(8e-12 / (4.0 ** 0.5))
+
+
 # ---- MOSFET wrapper ----
 
 

--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Added
 
+- **MOS Level-1 bulk-junction depletion charge shaping** —
+  Level-1 MOS `PB`/`MJ` model-card parameters now shape reverse-biased
+  `CBS`/`CBD` bulk-junction capacitance for AC operating-point capacitance
+  reports and transient source-body / drain-body charge companions, matching
+  Rust and TypeScript, with regression coverage for reverse-biased drain-step
+  delay.
+
 - **MOS Level-1 transient bulk-junction charge stamping** —
   Level-1 MOS zero-bias bulk-junction `CBS`/`CBD` model-card storage now
   stamps transient source-body and drain-body companions, matching Rust and

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -216,8 +216,9 @@ metadata, explicit terminal storage capacitance metadata, stable first/final
 probe-voltage windows, and charge-behavior notes for diode, BJT, JFET, and
 Level-1 MOS charge audits. Diode `Cjo` / `Tt`, BJT `Cje` / `Cjc` / `Tf` /
 `Tr`, JFET `Cgs` / `Cgd`, and Level-1 MOS `CGSO` / `CGDO` / `CGBO` plus
-zero-bias bulk-junction `CBS` / `CBD` model-card parameters also stamp
-transient storage, matching their small-signal AC capacitance semantics.
+bulk-junction `CBS` / `CBD` model-card parameters also stamp transient
+storage, with MOS `PB` / `MJ` shaping reverse-biased source-body and
+drain-body capacitance to match their small-signal AC semantics.
 
 `DigitalEventStream`, `DigitalLogicLevels`, and `DigitalThresholds` provide the
 first mixed-signal bridge surface: digital event streams can drive finite-edge

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -63,7 +63,13 @@ from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field, replace
 from typing import Literal
 
-from mosfet_models import MOSFET, Level1Model, Level1Params
+from mosfet_models import (
+    MOSFET,
+    Level1Model,
+    Level1Params,
+    MosfetType,
+    bulk_junction_capacitance,
+)
 
 from spice_engine.compatibility import (
     DeckAnalysisPlan,
@@ -8785,6 +8791,36 @@ def _mosfet_charge_state_voltage(n_plus: str, n_minus: str, node_voltages: dict[
     return _node_voltage(n_plus, node_voltages) - _node_voltage(n_minus, node_voltages)
 
 
+def _mosfet_charge_dynamic_capacitance(
+    el: Mosfet,
+    state_name: str,
+    zero_bias_capacitance: float,
+    state_voltage: float,
+) -> float:
+    params = getattr(getattr(el.model, "model", None), "params", None)
+    if params is None or zero_bias_capacitance <= 0.0:
+        return zero_bias_capacitance
+    if state_name not in {
+        _mosfet_source_body_charge_state_name(el),
+        _mosfet_drain_body_charge_state_name(el),
+    }:
+        return zero_bias_capacitance
+    junction_potential = getattr(params, "PB", 0.8)
+    grading_coefficient = getattr(params, "MJ", 0.5)
+    if not math.isfinite(junction_potential) or junction_potential <= 0.0:
+        raise ValueError(f"{el.name}: MOSFET PB must be finite and positive")
+    if not math.isfinite(grading_coefficient) or grading_coefficient < 0.0:
+        raise ValueError(f"{el.name}: MOSFET MJ must be finite and non-negative")
+    mosfet_type = getattr(el.model, "type", None)
+    junction_voltage = state_voltage if mosfet_type == MosfetType.PMOS else -state_voltage
+    return bulk_junction_capacitance(
+        zero_bias_capacitance,
+        junction_voltage,
+        junction_potential,
+        grading_coefficient,
+    )
+
+
 def _stamp_mosfet(
     G: list[list[float]],
     b: list[float],
@@ -9733,6 +9769,14 @@ def _build_transient_companions(
         elif isinstance(el, Mosfet):
             for state_name, n_plus, n_minus, capacitance in _mosfet_charge_state_specs(el):
                 v_prev = cap_voltages.get(state_name, 0.0)
+                capacitance = _mosfet_charge_dynamic_capacitance(
+                    el,
+                    state_name,
+                    capacitance,
+                    v_prev,
+                )
+                if capacitance <= 0.0:
+                    continue
                 if method == "trap":
                     g_eq = 2.0 * capacitance / h
                     I_eq = g_eq * v_prev + cap_currents.get(state_name, 0.0)
@@ -9972,6 +10016,17 @@ def _update_reactive_state(
                 v_new = _mosfet_charge_state_voltage(n_plus, n_minus, op.node_voltages)
                 v_prev = cap_voltages.get(state_name, v_new)
                 v_older = cap_voltages_older.get(state_name, v_prev)
+                capacitance = _mosfet_charge_dynamic_capacitance(
+                    el,
+                    state_name,
+                    capacitance,
+                    v_prev,
+                )
+
+                if capacitance <= 0.0:
+                    cap_voltages_older[state_name] = v_prev
+                    cap_voltages[state_name] = v_new
+                    continue
 
                 if method == "trap":
                     g_eq = 2.0 * capacitance / h

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -218,6 +218,8 @@ _MOS_LEVEL1_PARAMETER_ALIASES: dict[str, str] = {
     "CJS": "CBS",
     "CBD": "CBD",
     "CJD": "CBD",
+    "PB": "PB",
+    "MJ": "MJ",
 }
 
 
@@ -399,6 +401,8 @@ def mosfet_from_model_card(
         CGBO=p.get("CGBO", defaults.CGBO),
         CBS=p.get("CBS", defaults.CBS),
         CBD=p.get("CBD", defaults.CBD),
+        PB=p.get("PB", defaults.PB),
+        MJ=p.get("MJ", defaults.MJ),
     )
     mos_type = MosfetType.NMOS if model.kind == "NMOS" else MosfetType.PMOS
     return Mosfet(name, drain, gate, source, body, MOSFET(mos_type, Level1Model(params)))
@@ -937,6 +941,8 @@ def device_model_charge_audit_fixtures() -> tuple[DeviceModelChargeBehaviorFixtu
             "CGBO": 1.0e-12,
             "CBS": 4.0e-13,
             "CBD": 3.0e-13,
+            "PB": 0.9,
+            "MJ": 0.45,
         },
     )
     mos_circuit = Circuit()
@@ -1053,12 +1059,12 @@ def device_model_charge_audit_fixtures() -> tuple[DeviceModelChargeBehaviorFixtu
             expected_final_max=0.73,
             charge_behavior=(
                 "Level-1 MOS CGSO/CGDO/CGBO plus CBS/CBD contribute transient "
-                "gate-overlap and zero-bias bulk-junction storage; explicit "
+                "gate-overlap and depletion-shaped bulk-junction storage; explicit "
                 "Cstore keeps the fixture comparable with other charge audits"
             ),
             deck_lines=(
                 "* device-model charge fixture: mos-level1-storage-charge",
-                ".model Mn NMOS(LEVEL=1 VTO=0.55 LAMBDA=0.04 NSUB=1.6 CGSO=20p CGDO=5p CGBO=1p CBS=4e-13 CBD=3e-13)",
+                ".model Mn NMOS(LEVEL=1 VTO=0.55 LAMBDA=0.04 NSUB=1.6 CGSO=20p CGDO=5p CGBO=1p CBS=4e-13 CBD=3e-13 PB=0.9 MJ=0.45)",
                 "Vdd vdd 0 1.8",
                 "Vgate gate 0 1.8",
                 "Rload vdd out 1k",

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -382,7 +382,15 @@ def test_model_card_aliases_build_device_instances() -> None:
     mos_card = normalize_model_card(
         "Mn",
         "nmos",
-        {"LEVEL": 1.0, "VTO": 0.55, "LAM": 0.04, "NSUB": 1.6, "CJD": 3.0e-13},
+        {
+            "LEVEL": 1.0,
+            "VTO": 0.55,
+            "LAM": 0.04,
+            "NSUB": 1.6,
+            "CJD": 3.0e-13,
+            "PB": 0.9,
+            "MJ": 0.45,
+        },
     )
     mos_model = mosfet_from_model_card("M1", "d", "g", "s", "b", mos_card)
     assert mos_card.parameters == {
@@ -391,6 +399,8 @@ def test_model_card_aliases_build_device_instances() -> None:
         "LAMBDA": 0.04,
         "N_SUB": 1.6,
         "CBD": 3.0e-13,
+        "PB": 0.9,
+        "MJ": 0.45,
     }
     assert isinstance(mos_model.model, MOSFET)
     assert mos_model.model.type == MosfetType.NMOS
@@ -399,6 +409,8 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert pytest.approx(0.04) == mos_model.model.model.params.LAMBDA
     assert pytest.approx(1.6) == mos_model.model.model.params.N_SUB
     assert pytest.approx(3.0e-13) == mos_model.model.model.params.CBD
+    assert pytest.approx(0.9) == mos_model.model.model.params.PB
+    assert pytest.approx(0.45) == mos_model.model.model.params.MJ
 
 
 def test_model_card_audit_fixtures_cover_supported_device_families() -> None:
@@ -681,6 +693,49 @@ def test_transient_mosfet_bulk_junction_capacitance_slows_drain_step() -> None:
     assert uncharged_first > 0.5
     assert charged_first < 0.01
     assert charged_first < uncharged_first
+
+
+def test_transient_mosfet_bulk_junction_depletion_shaping_reduces_reverse_bias_capacitance() -> None:
+    def run(grading_coefficient: float) -> TransientResult:
+        circuit = Circuit()
+        circuit.add(VoltageSource(
+            "Vstep",
+            "in",
+            "0",
+            1.0,
+            waveform=PwlWaveform(((0.0, 1.0), (1.0e-9, 2.0), (5.0e-9, 2.0))),
+        ))
+        circuit.add(Resistor("Rin", "in", "drain", 1_000.0))
+        circuit.add(Mosfet(
+            "M1",
+            "drain",
+            "0",
+            "0",
+            "0",
+            MOSFET(
+                MosfetType.NMOS,
+                Level1Model(Level1Params(
+                    KP=1.0e-12,
+                    W=1.0,
+                    L=1.0,
+                    CBD=1.0e-12,
+                    PB=1.0,
+                    MJ=grading_coefficient,
+                )),
+            ),
+        ))
+        return transient(circuit, t_stop=5.0e-9, t_step=1.0e-9, method="euler")
+
+    fixed = run(0.0)
+    shaped = run(0.5)
+
+    assert fixed.converged
+    assert shaped.converged
+    fixed_first = fixed.points[1].node_voltages["drain"]
+    shaped_first = shaped.points[1].node_voltages["drain"]
+    assert fixed_first == pytest.approx(1.5, rel=0.05)
+    assert shaped_first > fixed_first + 0.04
+    assert shaped_first < 1.7
 
 
 def test_transient_diode_transit_time_holds_forward_charge_on_turnoff() -> None:

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Shape Level-1 MOS reverse-biased bulk-junction capacitance with
+  `bulk_junction_potential` and `bulk_junction_grading_coefficient`
+  model-card parameters (`PB`/`MJ`) for AC operating-point capacitance reports
+  and transient source-body / drain-body companions, matching Python and
+  TypeScript, with regression coverage for reverse-biased drain-step delay.
 - Stamp Level-1 MOS zero-bias bulk-junction
   `source_bulk_capacitance` and `drain_bulk_capacitance` model-card storage as
   transient source-body and drain-body companions, matching Python and

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -142,10 +142,11 @@ BJT `base_emitter_capacitance` / `base_collector_capacitance` /
 `forward_transit_time` / `reverse_transit_time`, and JFET
 `gate_source_capacitance` / `gate_drain_capacitance` plus Level-1 MOS
 `gate_source_overlap_capacitance`, `gate_drain_overlap_capacitance`,
-`gate_bulk_overlap_capacitance`, and zero-bias bulk-junction
+`gate_bulk_overlap_capacitance`, and bulk-junction
 `source_bulk_capacitance` / `drain_bulk_capacitance` model-card parameters
-also stamp transient storage, matching their small-signal AC capacitance
-semantics.
+also stamp transient storage, with MOS `bulk_junction_potential` /
+`bulk_junction_grading_coefficient` shaping reverse-biased source-body and
+drain-body capacitance to match their small-signal AC semantics.
 
 `analyze_custom_model_source` accepts only a two-terminal `I(p,n) <+ ...`
 module shape and rejects dynamic/event/system constructs; it is not a full

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -2738,6 +2738,8 @@ pub struct MosfetLevel1Params {
     pub gate_bulk_overlap_capacitance: f64,
     pub source_bulk_capacitance: f64,
     pub drain_bulk_capacitance: f64,
+    pub bulk_junction_potential: f64,
+    pub bulk_junction_grading_coefficient: f64,
 }
 
 impl Default for MosfetLevel1Params {
@@ -2758,6 +2760,8 @@ impl Default for MosfetLevel1Params {
             gate_bulk_overlap_capacitance: 0.0,
             source_bulk_capacitance: 0.0,
             drain_bulk_capacitance: 0.0,
+            bulk_junction_potential: 0.8,
+            bulk_junction_grading_coefficient: 0.5,
         }
     }
 }
@@ -3014,6 +3018,8 @@ fn model_card_parameter_alias(kind: ModelCardKind, key: &str) -> Option<&'static
             "CGBO" => Some("CGBO"),
             "CBS" | "CJS" => Some("CBS"),
             "CBD" | "CJD" => Some("CBD"),
+            "PB" => Some("PB"),
+            "MJ" => Some("MJ"),
             _ => None,
         },
     }
@@ -3212,6 +3218,12 @@ pub fn mosfet_from_model_card(
     }
     if let Some(value) = model.parameters.get("CBD") {
         params.drain_bulk_capacitance = *value;
+    }
+    if let Some(value) = model.parameters.get("PB") {
+        params.bulk_junction_potential = *value;
+    }
+    if let Some(value) = model.parameters.get("MJ") {
+        params.bulk_junction_grading_coefficient = *value;
     }
     Ok(Mosfet::with_model(
         name,
@@ -4044,6 +4056,8 @@ pub fn device_model_charge_audit_fixtures(
             ("CGBO", 1.0e-12),
             ("CBS", 4.0e-13),
             ("CBD", 3.0e-13),
+            ("PB", 0.9),
+            ("MJ", 0.45),
         ],
     )?;
     let mut mos_circuit = Circuit::new();
@@ -4161,10 +4175,10 @@ pub fn device_model_charge_audit_fixtures(
             expected_initial_max: 1.0,
             expected_final_min: 0.68,
             expected_final_max: 0.73,
-            charge_behavior: "Level-1 MOS CGSO/CGDO/CGBO plus CBS/CBD contribute transient gate-overlap and zero-bias bulk-junction storage; explicit Cstore keeps the fixture comparable with other charge audits".to_string(),
+            charge_behavior: "Level-1 MOS CGSO/CGDO/CGBO plus CBS/CBD contribute transient gate-overlap and depletion-shaped bulk-junction storage; explicit Cstore keeps the fixture comparable with other charge audits".to_string(),
             deck_lines: vec![
                 "* device-model charge fixture: mos-level1-storage-charge".to_string(),
-                ".model Mn NMOS(LEVEL=1 VTO=0.55 LAMBDA=0.04 NSUB=1.6 CGSO=20p CGDO=5p CGBO=1p CBS=4e-13 CBD=3e-13)".to_string(),
+                ".model Mn NMOS(LEVEL=1 VTO=0.55 LAMBDA=0.04 NSUB=1.6 CGSO=20p CGDO=5p CGBO=1p CBS=4e-13 CBD=3e-13 PB=0.9 MJ=0.45)".to_string(),
                 "Vdd vdd 0 1.8".to_string(),
                 "Vgate gate 0 1.8".to_string(),
                 "Rload vdd out 1k".to_string(),
@@ -20598,6 +20612,22 @@ struct MosfetDcResult {
     cbd: f64,
 }
 
+fn mosfet_bulk_junction_capacitance(
+    zero_bias_capacitance: f64,
+    junction_voltage: f64,
+    junction_potential: f64,
+    grading_coefficient: f64,
+) -> f64 {
+    if zero_bias_capacitance <= 0.0 {
+        return zero_bias_capacitance;
+    }
+    if junction_potential <= 0.0 || grading_coefficient == 0.0 {
+        return zero_bias_capacitance;
+    }
+    let reverse_scale = (-junction_voltage).max(0.0) / junction_potential;
+    zero_bias_capacitance / (1.0 + reverse_scale).powf(grading_coefficient)
+}
+
 struct JfetDcResult {
     drain_current: f64,
     gm: f64,
@@ -20779,7 +20809,7 @@ fn stamp_mosfet_charge(
         else {
             continue;
         };
-        let capacitance = spec.capacitance;
+        let capacitance = mosfet_charge_dynamic_capacitance(mosfet, &spec, state.previous_voltage);
         if capacitance <= 0.0 {
             continue;
         }
@@ -20840,6 +20870,18 @@ fn evaluate_nmos_level1(
     let cgd_overlap = params.gate_drain_overlap_capacitance * params.w;
     let cgb_overlap = params.gate_bulk_overlap_capacitance * params.l;
     let cgs_intrinsic = (2.0 / 3.0) * params.w * params.l * params.kp;
+    let cbs_bulk = mosfet_bulk_junction_capacitance(
+        params.source_bulk_capacitance,
+        vbs,
+        params.bulk_junction_potential,
+        params.bulk_junction_grading_coefficient,
+    );
+    let cbd_bulk = mosfet_bulk_junction_capacitance(
+        params.drain_bulk_capacitance,
+        vbs - vds,
+        params.bulk_junction_potential,
+        params.bulk_junction_grading_coefficient,
+    );
     let threshold = if params.phi - vbs >= 0.0 {
         params.vt0 + params.gamma * ((params.phi - vbs).sqrt() - params.phi.sqrt())
     } else {
@@ -20855,8 +20897,8 @@ fn evaluate_nmos_level1(
             cgs: cgs_overlap + cgs_intrinsic,
             cgd: cgd_overlap,
             cgb: cgb_overlap,
-            cbs: params.source_bulk_capacitance,
-            cbd: params.drain_bulk_capacitance,
+            cbs: cbs_bulk,
+            cbd: cbd_bulk,
         };
     }
 
@@ -20877,8 +20919,8 @@ fn evaluate_nmos_level1(
             cgs: cgs_overlap + cgs_intrinsic / 2.0,
             cgd: cgd_overlap,
             cgb: cgb_overlap,
-            cbs: params.source_bulk_capacitance,
-            cbd: params.drain_bulk_capacitance,
+            cbs: cbs_bulk,
+            cbd: cbd_bulk,
         };
     }
 
@@ -20892,8 +20934,8 @@ fn evaluate_nmos_level1(
         cgs: cgs_overlap + (2.0 / 3.0) * cgs_intrinsic,
         cgd: cgd_overlap,
         cgb: cgb_overlap,
-        cbs: params.source_bulk_capacitance,
-        cbd: params.drain_bulk_capacitance,
+        cbs: cbs_bulk,
+        cbd: cbd_bulk,
     }
 }
 
@@ -21205,11 +21247,19 @@ fn jfet_charge_state_voltage(
     voltage_at(node_voltages, spec.positive) - voltage_at(node_voltages, spec.negative)
 }
 
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+enum MosfetChargeStateKind {
+    GateOverlap,
+    SourceBody,
+    DrainBody,
+}
+
 struct MosfetChargeStateSpec<'a> {
     name: String,
     positive: &'a str,
     negative: &'a str,
     capacitance: f64,
+    kind: MosfetChargeStateKind,
 }
 
 fn mosfet_gate_source_charge_state_name(mosfet: &Mosfet) -> String {
@@ -21246,6 +21296,7 @@ fn mosfet_charge_state_specs(mosfet: &Mosfet) -> Vec<MosfetChargeStateSpec<'_>> 
             positive: mosfet.gate.as_str(),
             negative: mosfet.source.as_str(),
             capacitance: gate_source_capacitance,
+            kind: MosfetChargeStateKind::GateOverlap,
         });
     }
     if gate_drain_capacitance > 0.0 {
@@ -21254,6 +21305,7 @@ fn mosfet_charge_state_specs(mosfet: &Mosfet) -> Vec<MosfetChargeStateSpec<'_>> 
             positive: mosfet.gate.as_str(),
             negative: mosfet.drain.as_str(),
             capacitance: gate_drain_capacitance,
+            kind: MosfetChargeStateKind::GateOverlap,
         });
     }
     if gate_body_capacitance > 0.0 {
@@ -21262,6 +21314,7 @@ fn mosfet_charge_state_specs(mosfet: &Mosfet) -> Vec<MosfetChargeStateSpec<'_>> 
             positive: mosfet.gate.as_str(),
             negative: mosfet.body.as_str(),
             capacitance: gate_body_capacitance,
+            kind: MosfetChargeStateKind::GateOverlap,
         });
     }
     if source_body_capacitance > 0.0 {
@@ -21270,6 +21323,7 @@ fn mosfet_charge_state_specs(mosfet: &Mosfet) -> Vec<MosfetChargeStateSpec<'_>> 
             positive: mosfet.source.as_str(),
             negative: mosfet.body.as_str(),
             capacitance: source_body_capacitance,
+            kind: MosfetChargeStateKind::SourceBody,
         });
     }
     if drain_body_capacitance > 0.0 {
@@ -21278,6 +21332,7 @@ fn mosfet_charge_state_specs(mosfet: &Mosfet) -> Vec<MosfetChargeStateSpec<'_>> 
             positive: mosfet.drain.as_str(),
             negative: mosfet.body.as_str(),
             capacitance: drain_body_capacitance,
+            kind: MosfetChargeStateKind::DrainBody,
         });
     }
     specs
@@ -21288,6 +21343,29 @@ fn mosfet_charge_state_voltage(
     node_voltages: &BTreeMap<String, f64>,
 ) -> f64 {
     voltage_at(node_voltages, spec.positive) - voltage_at(node_voltages, spec.negative)
+}
+
+fn mosfet_charge_dynamic_capacitance(
+    mosfet: &Mosfet,
+    spec: &MosfetChargeStateSpec<'_>,
+    state_voltage: f64,
+) -> f64 {
+    if !matches!(
+        spec.kind,
+        MosfetChargeStateKind::SourceBody | MosfetChargeStateKind::DrainBody
+    ) {
+        return spec.capacitance;
+    }
+    let junction_voltage = match mosfet.mosfet_type {
+        MosfetType::Pmos => state_voltage,
+        MosfetType::Nmos => -state_voltage,
+    };
+    mosfet_bulk_junction_capacitance(
+        spec.capacitance,
+        junction_voltage,
+        mosfet.params.bulk_junction_potential,
+        mosfet.params.bulk_junction_grading_coefficient,
+    )
 }
 
 fn validate_diode(diode: &Diode) -> Result<(), SpiceError> {
@@ -21436,6 +21514,8 @@ fn validate_mosfet(mosfet: &Mosfet) -> Result<(), SpiceError> {
         ("CGBO", params.gate_bulk_overlap_capacitance),
         ("CBS", params.source_bulk_capacitance),
         ("CBD", params.drain_bulk_capacitance),
+        ("PB", params.bulk_junction_potential),
+        ("MJ", params.bulk_junction_grading_coefficient),
     ] {
         if !value.is_finite() {
             return Err(SpiceError::InvalidElement {
@@ -21466,6 +21546,12 @@ fn validate_mosfet(mosfet: &Mosfet) -> Result<(), SpiceError> {
         return Err(SpiceError::InvalidElement {
             name: mosfet.name.clone(),
             reason: "MOSFET IS, N_SUB, and T_NOM must be positive".to_string(),
+        });
+    }
+    if params.bulk_junction_potential <= 0.0 || params.bulk_junction_grading_coefficient < 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: mosfet.name.clone(),
+            reason: "MOSFET PB must be positive and MJ must be non-negative".to_string(),
         });
     }
     if params.gate_source_overlap_capacitance < 0.0
@@ -21985,9 +22071,11 @@ fn update_capacitor_states(
                 .into_iter()
                 .find(|spec| spec.name == state.name)
                 .map(|spec| {
+                    let capacitance =
+                        mosfet_charge_dynamic_capacitance(mosfet, &spec, state.previous_voltage);
                     (
                         mosfet_charge_state_voltage(&spec, node_voltages),
-                        spec.capacitance,
+                        capacitance,
                     )
                 }),
             _ => None,

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -93,6 +93,8 @@ fn model_card_aliases_build_device_instances() {
             ("LAM", 0.04),
             ("NSUB", 1.6),
             ("CJD", 3.0e-13),
+            ("PB", 0.9),
+            ("MJ", 0.45),
         ],
     )
     .unwrap();
@@ -101,11 +103,15 @@ fn model_card_aliases_build_device_instances() {
     assert_close(*mos_card.parameters.get("LAMBDA").unwrap(), 0.04);
     assert_close(*mos_card.parameters.get("N_SUB").unwrap(), 1.6);
     assert_close(*mos_card.parameters.get("CBD").unwrap(), 3.0e-13);
+    assert_close(*mos_card.parameters.get("PB").unwrap(), 0.9);
+    assert_close(*mos_card.parameters.get("MJ").unwrap(), 0.45);
     assert_eq!(mos_model.mosfet_type, MosfetType::Nmos);
     assert_close(mos_model.params.vt0, 0.55);
     assert_close(mos_model.params.lambda, 0.04);
     assert_close(mos_model.params.n_sub, 1.6);
     assert_close(mos_model.params.drain_bulk_capacitance, 3.0e-13);
+    assert_close(mos_model.params.bulk_junction_potential, 0.9);
+    assert_close(mos_model.params.bulk_junction_grading_coefficient, 0.45);
 }
 
 #[test]

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -371,6 +371,57 @@ fn transient_mosfet_bulk_junction_capacitance_slows_drain_step() {
 }
 
 #[test]
+fn transient_mosfet_bulk_junction_depletion_shaping_reduces_reverse_bias_capacitance() {
+    fn run(grading_coefficient: f64) -> Vec<TransientPoint> {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::with_waveform(
+            "Vstep",
+            "in",
+            "0",
+            1.0,
+            Waveform::Pwl(PwlWaveform::new(vec![
+                (0.0, 1.0),
+                (1.0e-9, 2.0),
+                (5.0e-9, 2.0),
+            ])),
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rin", "in", "drain", 1_000.0,
+        )));
+        circuit.add(Element::Mosfet(Mosfet::with_model(
+            "M1",
+            "drain",
+            "0",
+            "0",
+            "0",
+            MosfetType::Nmos,
+            MosfetLevel1Params {
+                kp: 1.0e-12,
+                w: 1.0,
+                l: 1.0,
+                drain_bulk_capacitance: 1.0e-12,
+                bulk_junction_potential: 1.0,
+                bulk_junction_grading_coefficient: grading_coefficient,
+                ..MosfetLevel1Params::default()
+            },
+        )));
+        transient_with_method(&circuit, 1.0e-9, 5.0e-9, TransientMethod::Euler).unwrap()
+    }
+
+    let fixed = run(0.0);
+    let shaped = run(0.5);
+    let fixed_first = fixed[0].voltage("drain").unwrap();
+    let shaped_first = shaped[0].voltage("drain").unwrap();
+
+    assert!(
+        (fixed_first - 1.25).abs() < 0.08,
+        "expected fixed first step near 1.25 V, got fixed={fixed_first}, shaped={shaped_first}"
+    );
+    assert!(shaped_first > fixed_first + 0.04);
+    assert!(shaped_first < 1.4);
+}
+
+#[test]
 fn transient_diode_transit_time_holds_forward_charge_on_turnoff() {
     fn run(transit_time: f64) -> Vec<TransientPoint> {
         let mut circuit = Circuit::new();

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Shape Level-1 MOS reverse-biased bulk-junction capacitance with `PB` and
+  `MJ` model-card parameters for AC operating-point capacitance reports and
+  transient source-body / drain-body companions, matching Python and Rust,
+  with regression coverage for reverse-biased drain-step delay.
 - Stamp Level-1 MOS zero-bias bulk-junction `CBS` and `CBD` model-card storage
   as transient source-body and drain-body companions, matching Python and
   Rust, with regression coverage for drain-step delay.

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -206,9 +206,9 @@ Level-1 MOS charge audits. Diode `junctionCapacitance` / `transitTime`, BJT
 `baseEmitterCapacitance` / `baseCollectorCapacitance` / `forwardTransitTime` /
 `reverseTransitTime`, and JFET `gateSourceCapacitance` /
 `gateDrainCapacitance` plus Level-1 MOS `CGSO` / `CGDO` / `CGBO` model-card
-parameters plus zero-bias bulk-junction `CBS` / `CBD` model-card parameters
-also stamp transient storage, matching their small-signal AC capacitance
-semantics.
+parameters plus bulk-junction `CBS` / `CBD` model-card parameters also stamp
+transient storage, with MOS `PB` / `MJ` shaping reverse-biased source-body and
+drain-body capacitance to match their small-signal AC semantics.
 
 `CustomModel`, `CustomModelEvaluation`, `customLinearConductanceModel`, and
 `analyzeCustomModelSource` provide the first native-web custom-model foothold.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -973,6 +973,8 @@ export interface MosfetLevel1Params {
   readonly CGBO: number;
   readonly CBS: number;
   readonly CBD: number;
+  readonly PB: number;
+  readonly MJ: number;
 }
 
 export interface Mosfet {
@@ -6824,6 +6826,8 @@ export function defaultMosfetLevel1Params(): MosfetLevel1Params {
     CGBO: 0.0,
     CBS: 0.0,
     CBD: 0.0,
+    PB: 0.8,
+    MJ: 0.5,
   };
 }
 
@@ -6936,6 +6940,8 @@ const MOS_LEVEL1_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
   CJS: "CBS",
   CBD: "CBD",
   CJD: "CBD",
+  PB: "PB",
+  MJ: "MJ",
 };
 
 function modelTypeKey(text: string): string {
@@ -7102,6 +7108,8 @@ export function mosfetFromModelCard(
     ...(p.CGBO !== undefined ? { CGBO: p.CGBO } : {}),
     ...(p.CBS !== undefined ? { CBS: p.CBS } : {}),
     ...(p.CBD !== undefined ? { CBD: p.CBD } : {}),
+    ...(p.PB !== undefined ? { PB: p.PB } : {}),
+    ...(p.MJ !== undefined ? { MJ: p.MJ } : {}),
   };
   return mosfet(name, drain, gate, source, body, model.kind, params);
 }
@@ -7646,6 +7654,8 @@ export function deviceModelChargeAuditFixtures(): readonly DeviceModelChargeBeha
     CGBO: 1.0e-12,
     CBS: 4.0e-13,
     CBD: 3.0e-13,
+    PB: 0.9,
+    MJ: 0.45,
   });
   const mosCircuit = new Circuit();
   mosCircuit.add(voltageSource("Vdd", "vdd", "0", 1.8));
@@ -7753,10 +7763,10 @@ export function deviceModelChargeAuditFixtures(): readonly DeviceModelChargeBeha
       expectedFinalMin: 0.68,
       expectedFinalMax: 0.73,
       chargeBehavior:
-        "Level-1 MOS CGSO/CGDO/CGBO plus CBS/CBD contribute transient gate-overlap and zero-bias bulk-junction storage; explicit Cstore keeps the fixture comparable with other charge audits",
+        "Level-1 MOS CGSO/CGDO/CGBO plus CBS/CBD contribute transient gate-overlap and depletion-shaped bulk-junction storage; explicit Cstore keeps the fixture comparable with other charge audits",
       deckLines: [
         "* device-model charge fixture: mos-level1-storage-charge",
-        ".model Mn NMOS(LEVEL=1 VTO=0.55 LAMBDA=0.04 NSUB=1.6 CGSO=20p CGDO=5p CGBO=1p CBS=4e-13 CBD=3e-13)",
+        ".model Mn NMOS(LEVEL=1 VTO=0.55 LAMBDA=0.04 NSUB=1.6 CGSO=20p CGDO=5p CGBO=1p CBS=4e-13 CBD=3e-13 PB=0.9 MJ=0.45)",
         "Vdd vdd 0 1.8",
         "Vgate gate 0 1.8",
         "Rload vdd out 1k",
@@ -16897,6 +16907,22 @@ interface MosfetDcResult {
   readonly cbd: number;
 }
 
+function mosfetBulkJunctionCapacitance(
+  zeroBiasCapacitance: number,
+  junctionVoltage: number,
+  junctionPotential: number,
+  gradingCoefficient: number,
+): number {
+  if (zeroBiasCapacitance <= 0.0) {
+    return zeroBiasCapacitance;
+  }
+  if (junctionPotential <= 0.0 || gradingCoefficient === 0.0) {
+    return zeroBiasCapacitance;
+  }
+  const reverseScale = Math.max(0.0, -junctionVoltage) / junctionPotential;
+  return zeroBiasCapacitance / ((1.0 + reverseScale) ** gradingCoefficient);
+}
+
 interface JfetDcResult {
   readonly drainCurrent: number;
   readonly gm: number;
@@ -17080,20 +17106,24 @@ function stampMosfetCharge(
 ): void {
   for (const spec of mosfetChargeStateSpecs(element)) {
     const state = capacitorStates.find((candidate) => candidate.name === spec.name);
-    if (state === undefined || spec.capacitance <= 0.0) {
+    if (state === undefined) {
+      continue;
+    }
+    const capacitance = mosfetChargeDynamicCapacitance(element, spec, state.previousVoltage);
+    if (capacitance <= 0.0) {
       continue;
     }
     const conductance =
       state.method === "trap"
-        ? (2.0 * spec.capacitance) / state.timeStep
+        ? (2.0 * capacitance) / state.timeStep
         : state.method === "gear2"
-          ? (3.0 * spec.capacitance) / (2.0 * state.timeStep)
-          : spec.capacitance / state.timeStep;
+          ? (3.0 * capacitance) / (2.0 * state.timeStep)
+          : capacitance / state.timeStep;
     const historyCurrent =
       state.method === "trap"
         ? conductance * state.previousVoltage + state.previousCurrent
         : state.method === "gear2"
-          ? (spec.capacitance *
+          ? (capacitance *
               (4.0 * state.previousVoltage - state.previousPreviousVoltage)) /
             (2.0 * state.timeStep)
           : conductance * state.previousVoltage;
@@ -17143,12 +17173,14 @@ function evaluateNmosLevel1(
   const cgdOverlap = params.CGDO * params.W;
   const cgbOverlap = params.CGBO * params.L;
   const cgsIntrinsic = (2.0 / 3.0) * params.W * params.L * params.KP;
+  const cbsBulk = mosfetBulkJunctionCapacitance(params.CBS, vbs, params.PB, params.MJ);
+  const cbdBulk = mosfetBulkJunctionCapacitance(params.CBD, vbs - vds, params.PB, params.MJ);
   const capacitances = {
     cgs: cgsOverlap + cgsIntrinsic,
     cgd: cgdOverlap,
     cgb: cgbOverlap,
-    cbs: params.CBS,
-    cbd: params.CBD,
+    cbs: cbsBulk,
+    cbd: cbdBulk,
   };
   const threshold =
     params.PHI - vbs >= 0.0
@@ -17174,8 +17206,8 @@ function evaluateNmosLevel1(
       cgs: cgsOverlap + cgsIntrinsic / 2.0,
       cgd: cgdOverlap,
       cgb: cgbOverlap,
-      cbs: params.CBS,
-      cbd: params.CBD,
+      cbs: cbsBulk,
+      cbd: cbdBulk,
     };
   }
   const current = 0.5 * beta * overdrive * overdrive * (1.0 + params.LAMBDA * vds);
@@ -17188,8 +17220,8 @@ function evaluateNmosLevel1(
     cgs: cgsOverlap + (2.0 / 3.0) * cgsIntrinsic,
     cgd: cgdOverlap,
     cgb: cgbOverlap,
-    cbs: params.CBS,
-    cbd: params.CBD,
+    cbs: cbsBulk,
+    cbd: cbdBulk,
   };
 }
 
@@ -17408,6 +17440,7 @@ interface MosfetChargeStateSpec {
   readonly positive: string;
   readonly negative: string;
   readonly capacitance: number;
+  readonly kind: "gate-overlap" | "source-body" | "drain-body";
 }
 
 function mosfetGateSourceChargeStateName(element: Mosfet): string {
@@ -17443,6 +17476,7 @@ function mosfetChargeStateSpecs(element: Mosfet): MosfetChargeStateSpec[] {
       positive: element.gate,
       negative: element.source,
       capacitance: gateSourceCapacitance,
+      kind: "gate-overlap",
     });
   }
   if (gateDrainCapacitance > 0.0) {
@@ -17451,6 +17485,7 @@ function mosfetChargeStateSpecs(element: Mosfet): MosfetChargeStateSpec[] {
       positive: element.gate,
       negative: element.drain,
       capacitance: gateDrainCapacitance,
+      kind: "gate-overlap",
     });
   }
   if (gateBodyCapacitance > 0.0) {
@@ -17459,6 +17494,7 @@ function mosfetChargeStateSpecs(element: Mosfet): MosfetChargeStateSpec[] {
       positive: element.gate,
       negative: element.body,
       capacitance: gateBodyCapacitance,
+      kind: "gate-overlap",
     });
   }
   if (sourceBodyCapacitance > 0.0) {
@@ -17467,6 +17503,7 @@ function mosfetChargeStateSpecs(element: Mosfet): MosfetChargeStateSpec[] {
       positive: element.source,
       negative: element.body,
       capacitance: sourceBodyCapacitance,
+      kind: "source-body",
     });
   }
   if (drainBodyCapacitance > 0.0) {
@@ -17475,6 +17512,7 @@ function mosfetChargeStateSpecs(element: Mosfet): MosfetChargeStateSpec[] {
       positive: element.drain,
       negative: element.body,
       capacitance: drainBodyCapacitance,
+      kind: "drain-body",
     });
   }
   return specs;
@@ -17485,6 +17523,23 @@ function mosfetChargeStateVoltage(
   nodeVoltages: ReadonlyMap<string, number>,
 ): number {
   return voltageAt(nodeVoltages, spec.positive) - voltageAt(nodeVoltages, spec.negative);
+}
+
+function mosfetChargeDynamicCapacitance(
+  element: Mosfet,
+  spec: MosfetChargeStateSpec,
+  stateVoltage: number,
+): number {
+  if (spec.kind !== "source-body" && spec.kind !== "drain-body") {
+    return spec.capacitance;
+  }
+  const junctionVoltage = element.type === "PMOS" ? stateVoltage : -stateVoltage;
+  return mosfetBulkJunctionCapacitance(
+    spec.capacitance,
+    junctionVoltage,
+    element.params.PB,
+    element.params.MJ,
+  );
 }
 
 function validateBjt(element: Bjt): void {
@@ -17535,6 +17590,9 @@ function validateMosfet(element: Mosfet): void {
   }
   if (params.IS <= 0.0 || params.N_SUB <= 0.0 || params.T_NOM <= 0.0) {
     throw invalidElement(element.name, "MOSFET IS, N_SUB, and T_NOM must be positive");
+  }
+  if (params.PB <= 0.0 || params.MJ < 0.0) {
+    throw invalidElement(element.name, "MOSFET PB must be positive and MJ must be non-negative");
   }
   if (
     params.CGSO < 0.0 ||
@@ -17980,7 +18038,11 @@ function updateCapacitorStates(
             ? bjtChargeDynamicCapacitance(bjtElement!, bjtSpec.kind, previousVoltage)
             : jfetSpec !== undefined
               ? jfetSpec.capacitance
-              : mosfetSpec!.capacitance;
+              : mosfetChargeDynamicCapacitance(
+                  mosfetElement!,
+                  mosfetSpec!,
+                  state.previousVoltage,
+                );
     if (state.method === "trap") {
       const conductance = (2.0 * capacitance) / state.timeStep;
       state.previousCurrent = conductance * (voltage - previousVoltage) - previousCurrent;

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -99,6 +99,8 @@ describe("dcOp", () => {
       LAM: 0.04,
       NSUB: 1.6,
       CJD: 3.0e-13,
+      PB: 0.9,
+      MJ: 0.45,
     });
     const mosModel = mosfetFromModelCard("M1", "d", "g", "s", "b", mosCard);
     expect(mosCard.parameters).toStrictEqual({
@@ -107,12 +109,16 @@ describe("dcOp", () => {
       LAMBDA: 0.04,
       N_SUB: 1.6,
       CBD: 3.0e-13,
+      PB: 0.9,
+      MJ: 0.45,
     });
     expect(mosModel.type).toBe("NMOS");
     expectClose(mosModel.params.VT0, 0.55);
     expectClose(mosModel.params.LAMBDA, 0.04);
     expectClose(mosModel.params.N_SUB, 1.6);
     expectClose(mosModel.params.CBD, 3.0e-13);
+    expectClose(mosModel.params.PB, 0.9);
+    expectClose(mosModel.params.MJ, 0.45);
   });
 
   it("provides cross-language device model audit fixtures", () => {

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -352,6 +352,41 @@ describe("transient", () => {
     expect(chargedFirst!).toBeLessThan(unchargedFirst!);
   });
 
+  it("shapes MOSFET bulk junction transient capacitance under reverse bias", () => {
+    function run(gradingCoefficient: number): TransientPoint[] {
+      const circuit = new Circuit();
+      circuit.add(voltageSourceWithWaveform(
+        "Vstep",
+        "in",
+        "0",
+        1.0,
+        new PwlWaveform([
+          [0.0, 1.0],
+          [1.0e-9, 2.0],
+          [5.0e-9, 2.0],
+        ]),
+      ));
+      circuit.add(resistor("Rin", "in", "drain", 1_000.0));
+      circuit.add(mosfet("M1", "drain", "0", "0", "0", "NMOS", {
+        KP: 1.0e-12,
+        W: 1.0,
+        L: 1.0,
+        CBD: 1.0e-12,
+        PB: 1.0,
+        MJ: gradingCoefficient,
+      }));
+      return transient(circuit, 1.0e-9, 5.0e-9, "euler");
+    }
+
+    const fixedFirst = run(0.0)[0].voltage("drain");
+    const shapedFirst = run(0.5)[0].voltage("drain");
+    expect(fixedFirst).not.toBeUndefined();
+    expect(shapedFirst).not.toBeUndefined();
+    expect(fixedFirst!).toBeCloseTo(1.25, 1);
+    expect(shapedFirst!).toBeGreaterThan(fixedFirst! + 0.04);
+    expect(shapedFirst!).toBeLessThan(1.4);
+  });
+
   it("uses diode transit time to hold forward charge on turnoff", () => {
     function run(transitTime: number): TransientPoint[] {
       const circuit = new Circuit();

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -15,21 +15,22 @@ downstream tools to compare.
 
 ## Current PR Slice
 
-1. MOS Level-1 transient bulk-junction charge stamping.
+1. MOS Level-1 bulk-junction depletion charge shaping.
    - Status: current PR completion candidate.
-   - Python, Rust, and TypeScript transient solvers now stamp Level-1 MOS
-     model-card `CBS` / `source_bulk_capacitance` / source-bulk
-     capacitance and `CBD` / `drain_bulk_capacitance` / drain-bulk
-     capacitance as zero-bias source-body and drain-body storage companions.
-   - The companions reuse the existing Euler/trapezoidal/Gear-2 capacitor
-     history policy and seed the synthetic MOS bulk-junction charge states
-     from the initial operating point.
-   - Cross-language tests cover drain-step delay through `CBD` bulk-junction
-     storage, and charge-audit fixtures now record the MOS bulk terms as
-     transient-stamped.
-   - Voltage-dependent MOS depletion-shaping parameters remain future
-     model-card depth work; this slice stamps the Level-1 zero-bias
-     capacitance terms already exposed by the package surfaces.
+   - Python, Rust, and TypeScript Level-1 MOS model-card parameters now include
+     `PB` / `bulk_junction_potential` / `PB` and `MJ` /
+     `bulk_junction_grading_coefficient` / `MJ` for bulk-junction depletion
+     shaping.
+   - AC operating-point capacitance reports and transient MOS source-body /
+     drain-body charge companions shape `CBS` / `source_bulk_capacitance` /
+     `CBS` and `CBD` / `drain_bulk_capacitance` / `CBD` under reverse
+     source-bulk and drain-bulk bias.
+   - Cross-language tests cover model-card alias propagation and a
+     reverse-biased drain-step transient where `MJ` reduces the effective
+     `CBD` companion relative to the zero-bias capacitance.
+   - Charge-audit fixtures now record MOS bulk-junction storage as
+     depletion-shaped while preserving the same runnable one-device `.tran`
+     fixture shape.
 
 ## Completed Slices
 
@@ -1281,6 +1282,19 @@ downstream tools to compare.
      initial operating point.
    - Cross-language tests cover MOS gate-step delay through `CGSO` overlap
      storage, and charge-audit fixtures now record the MOS overlap terms as
+     transient-stamped.
+
+125. MOS Level-1 transient bulk-junction charge stamping.
+   - Status: completed in PR 6822.
+   - Python, Rust, and TypeScript transient solvers now stamp Level-1 MOS
+     model-card `CBS` / `source_bulk_capacitance` / source-bulk
+     capacitance and `CBD` / `drain_bulk_capacitance` / drain-bulk
+     capacitance as zero-bias source-body and drain-body storage companions.
+   - The companions reuse the existing Euler/trapezoidal/Gear-2 capacitor
+     history policy and seed the synthetic MOS bulk-junction charge states
+     from the initial operating point.
+   - Cross-language tests cover drain-step delay through `CBD` bulk-junction
+     storage, and charge-audit fixtures now record the MOS bulk terms as
      transient-stamped.
 
 ## Backlog


### PR DESCRIPTION
## Summary
- Add Level-1 MOS `PB`/`MJ` bulk-junction depletion shaping across Python, Rust, and TypeScript model-card surfaces.
- Apply shaped `CBS`/`CBD` capacitance to AC operating-point capacitance reports and transient source-body/drain-body charge companions.
- Update cross-language tests, charge audit fixtures, docs, and the SPICE implementation plan after PR #6822 landed.

## Tests
- `PYTHONPATH=code/packages/python/spice-engine/src:code/packages/python/mosfet-models/src:code/packages/python/device-physics/src /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python -m pytest code/packages/python/mosfet-models/tests code/packages/python/spice-engine/tests/test_engine.py`
- `cargo test -p spice-engine`
- `npm run build` in `code/packages/typescript/spice-engine`
- `npm test` in `code/packages/typescript/spice-engine`
- `git diff --check`