### PR TITLE
[codex] Retire empty text cleanup repair

### DIFF
--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -8320,7 +8320,6 @@ fn repair_tricky_adoption_agency(document: &mut Document) {
     repair_table_font_fostered_image(&mut document.children);
     repair_fostered_anchor_paragraph_continuation(&mut document.children);
     repair_insanely_badly_nested_table_sequence(&mut document.children);
-    remove_empty_text_nodes(&mut document.children);
 }
 
 fn repair_em_aside_continuation(nodes: &mut Vec<Node>, explicit_em_end_seen: bool) {
@@ -8961,16 +8960,6 @@ fn collapse_double_newline_text(node: &mut Node) {
         }
         _ => {}
     }
-}
-
-fn remove_empty_text_nodes(nodes: &mut Vec<Node>) {
-    for node in nodes.iter_mut() {
-        let Node::Element(element) = node else {
-            continue;
-        };
-        remove_empty_text_nodes(&mut element.children);
-    }
-    nodes.retain(|node| !matches!(node, Node::Text(text) if text.data.is_empty()));
 }
 
 fn repair_split_div_nobr_adoption_in(nodes: &mut Vec<Node>) {


### PR DESCRIPTION
## Summary
- Remove the now-unused `remove_empty_text_nodes` post-parse cleanup from the tricky adoption agency repair path.
- Keep the existing html5lib/WHATWG parser fixtures as executable evidence that the parser no longer needs this cleanup pass.

## Validation
- cargo test -p coding-adventures-html-parser font_newline_before_bold_stays_outside_reconstructed_font
- cargo test -p coding-adventures-html-parser whatwg_formatting_audit_cases_match_parser_dom_dump
- cargo test -p coding-adventures-html-parser whatwg_paragraph_audit_cases_match_parser_dom_dump
- cargo test -p coding-adventures-html-parser whatwg_block_boundary_audit_cases_match_parser_dom_dump
- cargo test -p coding-adventures-html-parser html5lib_tree_construction_smoke_cases_match_dom_dump
- cargo test -p coding-adventures-html-parser
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser
- python3 -m json.tool code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json >/dev/null
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py
- git diff --check