### PR TITLE
[codex] Add LANG E4 string comparison proof

### DIFF
--- a/code/packages/rust/iir-to-cil-bytecode/CHANGELOG.md
+++ b/code/packages/rust/iir-to-cil-bytecode/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog — iir-to-cil-bytecode
 
+## [0.31.0] — 2026-06-28 — textual CLR literal string comparison (LANG-FULL E4)
+
+The textual `.il` path now lowers `str_cmp` over managed string locals by
+calling `System.String::CompareOrdinal(string,string)` and
+`System.Math::Sign(int32)`.
+
 ## [0.30.0] — 2026-06-28 — textual CLR literal string slice (LANG-FULL E4)
 
 The textual `.il` path now lowers `str_slice` by loading the source string,

--- a/code/packages/rust/iir-to-cil-bytecode/README.md
+++ b/code/packages/rust/iir-to-cil-bytecode/README.md
@@ -123,7 +123,7 @@ the program artifact whenever any `alloc_closure` instruction appears.
 | Heap | `alloc` (`ref<LispyPair>` only), `field_load`, `field_store`, `is_null` |
 | Register | `load_reg`, `store_reg` |
 | Coercion | `type_assert` (becomes `nop`) |
-| Strings | `str_const`, `str_concat`, `str_len`, `str_eq`, `print_str` on the textual `.il` path (ASCII literal foothold) |
+| Strings | `str_const`, `str_concat`, `str_slice`, `str_len`, `str_index`, `str_eq`, `str_cmp`, `print_str` on the textual `.il` path (ASCII literal foothold) |
 
 As of 0.16.0 the **textual `.il`** emitter (`emit_il`, the `ilasm`/`dotnet` path) also
 covers the integer **arithmetic** (`add`/`sub`/`mul`/`div`/`mod` → `add`/`sub`/`mul`/`div`/`rem`)
@@ -148,10 +148,12 @@ As of 0.29.0 the textual `.il` path emits the **E4 literal string** foothold:
 `Console.Write(string)`, and direct-literal `str_len` calls
 `String::get_Length()` while direct-literal `str_index` calls
 `String::get_Chars(int32)`, direct-literal `str_eq` calls
-`String::Equals(string,string)`, and direct-literal `str_concat` calls
+`String::Equals(string,string)`, direct-literal `str_cmp` calls
+`String::CompareOrdinal(string,string)` plus `Math::Sign(int32)`, and direct-literal `str_concat` calls
 `String::Concat(string,string)`. This proves Dartmouth BASIC `PRINT "HELLO"` plus
 Twig `(string-length "HELLO")`, `(string-ref "ABC" 1)`,
-`(string=? "HELLO" "HELLO")`, and `(string-length (string-append "AB" "CDE"))`
+`(string=? "HELLO" "HELLO")`, `(string<? "ALPHA" "BETA")`, and
+`(string-length (string-append "AB" "CDE"))`
 on real CoreCLR while non-literal string values remain rejected until the CLR
 representation owns the shared UTF-8 byte semantics.
 

--- a/code/packages/rust/iir-to-cil-bytecode/src/il_text.rs
+++ b/code/packages/rust/iir-to-cil-bytecode/src/il_text.rs
@@ -569,8 +569,8 @@ fn emit_method(
             //
             // LANG-FULL E4 first managed foothold: Dartmouth BASIC string
             // literal PRINT lowers to `str_const` + `print_str`; literal
-            // string length, equality, and append lower to `str_len`, `str_eq`,
-            // and `str_concat`. These map naturally to CoreCLR's
+            // string length, equality, ordering, and append lower to `str_len`,
+            // `str_eq`, `str_cmp`, and `str_concat`. These map naturally to CoreCLR's
             // `System.String`.
             // The richer byte-oriented string algebra remains deliberately
             // unsupported here until the representation is specified for
@@ -680,6 +680,24 @@ fn emit_method(
                     il,
                     "    call bool [System.Runtime]System.String::Equals(string, string)"
                 );
+                store_var(il, &regs, dest)?;
+            }
+            // str_cmp <dest>, <left>, <right>
+            //     -> Math.Sign(String.CompareOrdinal(left, right))
+            "str_cmp" => {
+                let dest = instr.dest.as_deref().ok_or_else(|| IIRClrError::InvalidOperand {
+                    function: f.name.clone(),
+                    detail: "str_cmp must have a dest".to_string(),
+                })?;
+                let left = var_src(f, instr, 0, "str_cmp")?;
+                let right = var_src(f, instr, 1, "str_cmp")?;
+                load_var(il, &regs, left)?;
+                load_var(il, &regs, right)?;
+                let _ = writeln!(
+                    il,
+                    "    call int32 [System.Runtime]System.String::CompareOrdinal(string, string)"
+                );
+                let _ = writeln!(il, "    call int32 [System.Runtime]System.Math::Sign(int32)");
                 store_var(il, &regs, dest)?;
             }
             // print_str <src>  ->  Console.Write(string)
@@ -1942,6 +1960,41 @@ mod tests {
         assert!(
             il.contains("call bool [System.Runtime]System.String::Equals(string, string)"),
             "str_eq must call System.String::Equals(string,string); got:\n{il}"
+        );
+    }
+
+    #[test]
+    fn string_literal_cmp_emits_compare_ordinal_and_sign() {
+        let instrs = vec![
+            IIRInstr::new(
+                "str_const",
+                Some("a".into()),
+                vec![Operand::Str("ALPHA".into())],
+                "str",
+            ),
+            IIRInstr::new(
+                "str_const",
+                Some("b".into()),
+                vec![Operand::Str("BETA".into())],
+                "str",
+            ),
+            IIRInstr::new("str_cmp", Some("ord".into()), vec![
+                Operand::Var("a".into()),
+                Operand::Var("b".into()),
+            ], "i32"),
+            IIRInstr::new("ret", None, vec![Operand::Var("ord".into())], "i32"),
+        ];
+        let mut m = IIRModule::new("Main", "test");
+        m.functions.push(IIRFunction::new("main", vec![], "i32", instrs));
+        m.entry_point = Some("main".into());
+        let il = emit_il(&m, &IIRClrConfig::new("Main")).unwrap();
+        assert!(
+            il.contains("call int32 [System.Runtime]System.String::CompareOrdinal(string, string)"),
+            "str_cmp must call System.String::CompareOrdinal(string,string); got:\n{il}"
+        );
+        assert!(
+            il.contains("call int32 [System.Runtime]System.Math::Sign(int32)"),
+            "str_cmp must normalize via System.Math::Sign(int32); got:\n{il}"
         );
     }
 

--- a/code/packages/rust/iir-to-cil-bytecode/src/validate.rs
+++ b/code/packages/rust/iir-to-cil-bytecode/src/validate.rs
@@ -46,7 +46,7 @@
 //! Remaining unsupported ops: `call_builtin`, `io_in`, `io_out`, `cast`,
 //! `load_mem`, `store_mem`, `box`, `unbox`, `safepoint`, and the byte-oriented
 //! E4 string algebra beyond `str_const` + `str_len` + `str_index` +
-//! `str_eq` + `str_concat` + `print_str`.
+//! `str_eq` + `str_cmp` + `str_concat` + `print_str`.
 //! Previously unsupported but now accepted: `alloc` (LispyPair only),
 //! `field_load`, `field_store`, `is_null`.
 
@@ -335,7 +335,7 @@ pub fn validate_iir_for_clr(module: &IIRModule) -> Vec<String> {
             //
             // `"str"` — The textual CLR path can now load ASCII literals and
             // concatenate them through `System.String` for the narrow E4
-            // foothold. `str_len` and `str_eq` produce integers. Other
+            // foothold. `str_len`, `str_eq`, and `str_cmp` produce integers. Other
             // string-typed producers still need a fuller byte-oriented
             // representation before we can map them to `System.String` safely.
             //
@@ -506,6 +506,19 @@ pub fn validate_iir_for_clr(module: &IIRModule) -> Vec<String> {
                     _ => {
                         errors.push(format!(
                             "UnsupportedOp: function {:?}, op \"str_eq\" requires \
+                             dest, two Operand::Var sources, and i64/i32 result type",
+                            func.name
+                        ));
+                    }
+                }
+            } else if instr.op == "str_cmp" {
+                match (instr.dest.as_ref(), instr.srcs.as_slice(), instr.type_hint.as_str()) {
+                    (Some(_), [Operand::Var(_), Operand::Var(_)], "i64" | "i32") => {
+                        // Accepted — il_text.rs calls String.CompareOrdinal and Math.Sign.
+                    }
+                    _ => {
+                        errors.push(format!(
+                            "UnsupportedOp: function {:?}, op \"str_cmp\" requires \
                              dest, two Operand::Var sources, and i64/i32 result type",
                             func.name
                         ));
@@ -697,6 +710,34 @@ mod tests {
         assert!(
             errs.is_empty(),
             "str_eq over direct literals should pass: {:?}",
+            errs
+        );
+    }
+
+    #[test]
+    fn str_cmp_literal_accepted() {
+        let errs = validate_iir_for_clr(&single_fn_module(vec![
+            IIRInstr::new(
+                "str_const",
+                Some("a".into()),
+                vec![Operand::Str("ALPHA".into())],
+                "str",
+            ),
+            IIRInstr::new(
+                "str_const",
+                Some("b".into()),
+                vec![Operand::Str("BETA".into())],
+                "str",
+            ),
+            IIRInstr::new("str_cmp", Some("ord".into()), vec![
+                Operand::Var("a".into()),
+                Operand::Var("b".into()),
+            ], "i64"),
+            IIRInstr::new("ret", None, vec![Operand::Var("ord".into())], "i64"),
+        ]));
+        assert!(
+            errs.is_empty(),
+            "str_cmp over direct literals should pass: {:?}",
             errs
         );
     }

--- a/code/packages/rust/iir-to-jvm-class-file/CHANGELOG.md
+++ b/code/packages/rust/iir-to-jvm-class-file/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this crate are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.23.0] — 2026-06-28 (literal string comparison — LANG-FULL E4)
+
+The JVM backend now lowers `str_cmp` over managed `String` locals by invoking
+`java/lang/String.compareTo(String)` and normalizing the result with
+`java/lang/Integer.signum(int)`.
+
 ## [0.22.0] — 2026-06-28 (literal string slice — LANG-FULL E4)
 
 The JVM backend now lowers `str_slice` over managed `String` locals by loading

--- a/code/packages/rust/iir-to-jvm-class-file/README.md
+++ b/code/packages/rust/iir-to-jvm-class-file/README.md
@@ -132,6 +132,7 @@ assert_eq!(class_file.this_class_name, "MyClass");
 | `str_len`        | `aload s; invokevirtual java/lang/String.length()I; [i2l]; store dest` — literal length foothold (E4) |
 | `str_index`      | `aload s; <idx>; invokevirtual java/lang/String.charAt(I)C; [i2l]; store dest` — literal index foothold (E4) |
 | `str_eq`         | `aload a; aload b; invokevirtual java/lang/String.equals(Object)Z; [i2l]; store dest` — literal equality foothold (E4) |
+| `str_cmp`        | `aload a; aload b; invokevirtual java/lang/String.compareTo(String)I; invokestatic java/lang/Integer.signum(I)I; [i2l]; store dest` — literal ordering foothold (E4) |
 | `print_str`      | `getstatic System.out; aload s; invokevirtual PrintStream.print(String)` — E4 |
 
 The byte-tape ops (`alloc_bytes`/`load_byte`/`store_byte`) are how Brainfuck runs on
@@ -143,6 +144,7 @@ The E4 string rows are intentionally a narrow literal-output slice: Dartmouth BA
 `PRINT "HELLO"` now runs on real `java`, and Twig `(string-length "HELLO")`
 uses `String.length()`, `(string-ref "ABC" 1)` uses `String.charAt(I)`,
 `(string=? "HELLO" "HELLO")` uses `String.equals(Object)`, and
+`(string<? "ALPHA" "BETA")` uses `String.compareTo(String)`, while
 `(string-length (string-append "AB" "CDE"))` uses `String.concat(String)` plus
 `String.length()`. Non-literal string values remain rejected until the JVM
 backend owns the shared UTF-8 byte semantics.

--- a/code/packages/rust/iir-to-jvm-class-file/src/lower.rs
+++ b/code/packages/rust/iir-to-jvm-class-file/src/lower.rs
@@ -1919,8 +1919,9 @@ fn lower_function(
             // ── LANG-FULL E4: string literal output foothold ────────────────
             //
             // Dartmouth BASIC `PRINT "..."` lowers to `str_const` +
-            // `print_str`; literal Twig `string-length`, `string=?`, and
-            // `string-append` lower to `str_len`, `str_eq`, and `str_concat`.
+            // `print_str`; literal Twig `string-length`, `string=?`, `string<?` /
+            // `string>?`, and `string-append` lower to `str_len`, `str_eq`,
+            // `str_cmp`, and `str_concat`.
             // Use Java's native `String` only for this literal foothold; richer
             // byte-oriented string algebra remains rejected by the validator
             // until the JVM representation owns those semantics explicitly.
@@ -2191,6 +2192,59 @@ fn lower_function(
                     cp.add_methodref("java/lang/String", "equals", "(Ljava/lang/Object;)Z");
                 code.push(INVOKEVIRTUAL);
                 code.extend_from_slice(&equals_ref.to_be_bytes());
+                if dest_type == JvmType::Long {
+                    code.push(I2L);
+                }
+                emit_typed_store(&mut code, dest_slot, dest_type);
+            }
+
+            "str_cmp" => {
+                let dest_name = instr.dest.as_deref().ok_or_else(|| IIRJvmError::InvalidOperand {
+                    function: fname.clone(),
+                    detail: "str_cmp instruction has no dest".to_string(),
+                })?;
+                let left = match instr.srcs.first() {
+                    Some(Operand::Var(s)) => s,
+                    other => {
+                        return Err(IIRJvmError::InvalidOperand {
+                            function: fname.clone(),
+                            detail: format!("str_cmp expects left string variable, got {other:?}"),
+                        })
+                    }
+                };
+                let right = match instr.srcs.get(1) {
+                    Some(Operand::Var(s)) => s,
+                    other => {
+                        return Err(IIRJvmError::InvalidOperand {
+                            function: fname.clone(),
+                            detail: format!("str_cmp expects right string variable, got {other:?}"),
+                        })
+                    }
+                };
+                let (left_slot, left_type) = lookup_var(left)?;
+                let (right_slot, right_type) = lookup_var(right)?;
+                if left_type != JvmType::Ref || right_type != JvmType::Ref {
+                    return Err(IIRJvmError::UnsupportedType {
+                        function: fname.clone(),
+                        type_hint: "str".to_string(),
+                    });
+                }
+                let (dest_slot, dest_type) = lookup_var(dest_name)?;
+                if dest_type != JvmType::Int && dest_type != JvmType::Long {
+                    return Err(IIRJvmError::UnsupportedType {
+                        function: fname.clone(),
+                        type_hint: instr.type_hint.clone(),
+                    });
+                }
+                emit_aload(&mut code, left_slot);
+                emit_aload(&mut code, right_slot);
+                let compare_ref =
+                    cp.add_methodref("java/lang/String", "compareTo", "(Ljava/lang/String;)I");
+                code.push(INVOKEVIRTUAL);
+                code.extend_from_slice(&compare_ref.to_be_bytes());
+                let signum_ref = cp.add_methodref("java/lang/Integer", "signum", "(I)I");
+                code.push(INVOKESTATIC);
+                code.extend_from_slice(&signum_ref.to_be_bytes());
                 if dest_type == JvmType::Long {
                     code.push(I2L);
                 }

--- a/code/packages/rust/iir-to-jvm-class-file/src/validate.rs
+++ b/code/packages/rust/iir-to-jvm-class-file/src/validate.rs
@@ -32,7 +32,8 @@
 //!
 //! `call_builtin`, `io_in`, `io_out`, `cast`, `load_mem`, `store_mem`,
 //! `box`, `unbox`, `safepoint`, and the byte-oriented E4 string algebra beyond
-//! `str_const` + `str_len` + `str_index` + `str_eq` + `str_concat` + `print_str`.
+//! `str_const` + `str_len` + `str_index` + `str_eq` + `str_cmp` + `str_concat`
+//! + `print_str`.
 //!
 //! The following ops are now SUPPORTED via `Object[]` cons cells (Phase 2):
 //! `alloc` (when `type_hint == "ref<LispyPair>"`), `field_load`, `field_store`,
@@ -273,8 +274,8 @@ pub fn validate_for_jvm(module: &IIRModule) -> Vec<String> {
             // ── Check 4: UnsupportedType ─────────────────────────────────────
             //
             // `"str"` — The backend can now load ASCII literals and concatenate
-            // them through Java `String` for the narrow E4 foothold. `str_len`
-            // and `str_eq` produce integers. Other string-typed producers still
+            // them through Java `String` for the narrow E4 foothold. `str_len`,
+            // `str_eq`, and `str_cmp` produce integers. Other string-typed producers still
             // need a fuller byte-oriented representation before Java `String`
             // is safe for them.
             //
@@ -381,6 +382,19 @@ pub fn validate_for_jvm(module: &IIRModule) -> Vec<String> {
                     _ => {
                         errors.push(format!(
                             "UnsupportedOp: function {:?}, op \"str_eq\" requires \
+                             dest, two Operand::Var sources, and i64/i32 result type",
+                            func.name
+                        ));
+                    }
+                }
+            } else if instr.op == "str_cmp" {
+                match (instr.dest.as_ref(), instr.srcs.as_slice(), instr.type_hint.as_str()) {
+                    (Some(_), [Operand::Var(_), Operand::Var(_)], "i64" | "i32") => {
+                        // Accepted — lower.rs calls java/lang/String.compareTo(String).
+                    }
+                    _ => {
+                        errors.push(format!(
+                            "UnsupportedOp: function {:?}, op \"str_cmp\" requires \
                              dest, two Operand::Var sources, and i64/i32 result type",
                             func.name
                         ));
@@ -597,6 +611,34 @@ mod tests {
         assert!(
             errs.is_empty(),
             "str_eq over direct literals should pass: {:?}",
+            errs
+        );
+    }
+
+    #[test]
+    fn str_cmp_literal_accepted() {
+        let errs = validate_for_jvm(&single_fn_module(vec![
+            IIRInstr::new(
+                "str_const",
+                Some("a".into()),
+                vec![Operand::Str("ALPHA".into())],
+                "str",
+            ),
+            IIRInstr::new(
+                "str_const",
+                Some("b".into()),
+                vec![Operand::Str("BETA".into())],
+                "str",
+            ),
+            IIRInstr::new("str_cmp", Some("ord".into()), vec![
+                Operand::Var("a".into()),
+                Operand::Var("b".into()),
+            ], "i64"),
+            IIRInstr::new("ret", None, vec![Operand::Var("ord".into())], "i64"),
+        ]));
+        assert!(
+            errs.is_empty(),
+            "str_cmp over direct literals should pass: {:?}",
             errs
         );
     }

--- a/code/packages/rust/iir-to-jvm-class-file/tests/test_backend.rs
+++ b/code/packages/rust/iir-to-jvm-class-file/tests/test_backend.rs
@@ -2694,6 +2694,75 @@ fn e4_string_eq_lowers_to_string_equals() {
     assert_ne!(equals_ref, 0, "constant pool must contain java/lang/String.equals(Object)");
 }
 
+#[test]
+fn e4_string_cmp_lowers_to_compare_to_and_signum() {
+    let f = IIRFunction::new(
+        "cmp_hello",
+        vec![],
+        "i64",
+        vec![
+            IIRInstr::new(
+                "str_const",
+                Some("a".into()),
+                vec![Operand::Str("ALPHA".into())],
+                "str",
+            ),
+            IIRInstr::new(
+                "str_const",
+                Some("b".into()),
+                vec![Operand::Str("BETA".into())],
+                "str",
+            ),
+            IIRInstr::new("str_cmp", Some("ord".into()), vec![
+                Operand::Var("a".into()),
+                Operand::Var("b".into()),
+            ], "i64"),
+            IIRInstr::new("ret", None, vec![Operand::Var("ord".into())], "i64"),
+        ],
+    );
+    let module = module_with(f);
+    let errors = validate_for_jvm(&module);
+    assert!(errors.is_empty(), "string literal cmp should validate: {:?}", errors);
+
+    let class = lower(&module);
+    let method = class
+        .methods
+        .iter()
+        .find(|m| m.name == "cmp_hello")
+        .expect("cmp_hello method must exist");
+    let code = &method.code_attribute().unwrap().code;
+
+    assert!(
+        code.contains(&0xB6),
+        "str_cmp must invokevirtual java/lang/String.compareTo; got: {:?}",
+        code
+    );
+    assert!(
+        code.contains(&0xB8),
+        "str_cmp must invokestatic java/lang/Integer.signum; got: {:?}",
+        code
+    );
+    assert!(
+        code.contains(&0x85),
+        "i64 str_cmp result must widen signum int with I2L; got: {:?}",
+        code
+    );
+
+    let compare_ref = find_methodref_in_cp(
+        &class.constant_pool,
+        "java/lang/String",
+        "compareTo",
+        "(Ljava/lang/String;)I",
+    );
+    assert_ne!(compare_ref, 0, "constant pool must contain java/lang/String.compareTo(String)");
+    let signum_ref =
+        find_methodref_in_cp(&class.constant_pool, "java/lang/Integer", "signum", "(I)I");
+    assert_ne!(
+        signum_ref, 0,
+        "constant pool must contain java/lang/Integer.signum(int)"
+    );
+}
+
 /// McCarthy W3b: `box` lowers to `Integer.valueOf(I)` (invokestatic 0xB8) and
 /// `unbox` to `checkcast` (0xC0) + `Integer.intValue()` (invokevirtual 0xB6).
 #[test]

--- a/code/packages/rust/iir-to-llvm/CHANGELOG.md
+++ b/code/packages/rust/iir-to-llvm/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this crate are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.24.0] — 2026-06-28 — literal string comparison metadata reaches LLVM (LANG-FULL E4)
+
+Literal-only `str_cmp` now folds through the LLVM string metadata pass. The
+lowered value follows the shared E4 three-way ordering convention.
+
 ## [0.23.0] — 2026-06-28 — literal string slice metadata reaches LLVM (LANG-FULL E4)
 
 Literal-only `str_slice` now participates in the LLVM string metadata pass.

--- a/code/packages/rust/iir-to-llvm/README.md
+++ b/code/packages/rust/iir-to-llvm/README.md
@@ -3,11 +3,11 @@
 IIR → textual LLVM IR backend.  Emits a `.ll` source string for an LLVM
 target triple, without depending on `llvm-sys` or a native LLVM install.
 
-**Status: v0.22.0 — LANG-FULL E4 literal string metadata.**  The backend now
+**Status: v0.24.0 — LANG-FULL E4 literal string comparison.**  The backend now
 lowers scalar control/data ops, Brainfuck byte-tape I/O, arrays, globals,
 numeric conversions, and the `str_const` + `print_str` literal-output slice.
-It also materialises `str_len`, `str_index`, `str_eq`, and literal `str_concat`
-for direct literals from compile-time metadata, including derived concat
+It also materialises `str_len`, `str_index`, `str_eq`, `str_cmp`, and literal
+`str_concat` for direct literals from compile-time metadata, including derived concat
 constants that feed `print_str` and `str_len`-computed indexes that feed
 `str_index`. Dynamic byte-string ops remain outside this release.
 
@@ -100,6 +100,7 @@ you actually intend to run `llc` for a non-default architecture.
 | v0.17.0 | **String literal output** (LANG-FULL E4 / BA4). `str_const` emits a private length-prefixed string constant and `print_str` calls `@__print_str(ptr,i64)` with the payload pointer plus byte length. Richer byte-string ops stay rejected. |
 | v0.18.0 | **Literal string metadata** (LANG-FULL E4). `str_len`/`str_eq`/`str_concat` over direct `str_const` literals lower to compile-time results, proving `(string-length "HELLO")`, `(string=? "HELLO" "HELLO")`, and `(string-length (string-append "AB" "CDE"))` on LLVM while dynamic string algebra stays rejected. |
 | v0.22.0 | **Computed string indexes** (LANG-FULL E4). Literal-only `str_len` constants can flow through typed `i64` arithmetic and feed `str_index`. |
+| v0.24.0 | **Literal string comparison** (LANG-FULL E4). Literal-only `str_cmp` lowers to the shared `-1`/`0`/`1` ordering result. |
 | (later) | GC, debug info via `!dbg`. |
 
 ### Bounds-checked arrays (v0.14.0)

--- a/code/packages/rust/iir-to-llvm/src/lib.rs
+++ b/code/packages/rust/iir-to-llvm/src/lib.rs
@@ -82,6 +82,7 @@
 
 use interpreter_ir::opcodes::array_elem_type;
 use interpreter_ir::{IIRFunction, IIRInstr, IIRModule, Operand};
+use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::fmt;
 
@@ -270,10 +271,11 @@ const SUPPORTED_OPS: &[&str] = &[
     "int_to_real", "real_to_int_trunc", "real_to_int_floor",
     // LANG-FULL E4 — string literal foothold for the static LLVM column.
     // `str_const` materialises a length-prefixed private constant. `str_index`,
-    // `str_concat`, `str_slice`, `str_len`, and `str_eq` read literal metadata,
+    // `str_concat`, `str_slice`, `str_len`, `str_eq`, and `str_cmp` read literal metadata,
     // and `print_str` calls the generic C runtime. Richer dynamic byte-string
     // ops remain unsupported.
-    "str_const", "str_index", "str_concat", "str_slice", "str_len", "str_eq", "print_str",
+    "str_const", "str_index", "str_concat", "str_slice", "str_len", "str_eq", "str_cmp",
+    "print_str",
 ];
 
 /// Builtins the LLVM backend knows how to lower.
@@ -413,6 +415,10 @@ pub fn validate_for_llvm(module: &IIRModule) -> Vec<String> {
             }
             if instr.op == "str_eq" {
                 validate_str_eq(func, instr, &mut errors);
+                continue;
+            }
+            if instr.op == "str_cmp" {
+                validate_str_cmp(func, instr, &mut errors);
                 continue;
             }
             if instr.op == "print_str" {
@@ -597,6 +603,28 @@ fn validate_str_eq(func: &IIRFunction, instr: &IIRInstr, errors: &mut Vec<String
     }
 }
 
+fn validate_str_cmp(func: &IIRFunction, instr: &IIRInstr, errors: &mut Vec<String>) {
+    if instr.dest.is_none() {
+        errors.push(format!(
+            "InvalidOperand: function {:?}, str_cmp requires a dest",
+            func.name
+        ));
+    }
+    if llvm_type_for(&instr.type_hint, &func.name).is_err() {
+        errors.push(format!(
+            "UnsupportedType: function {:?}, str_cmp result type {:?} is not supported",
+            func.name, instr.type_hint
+        ));
+    }
+    match instr.srcs.as_slice() {
+        [Operand::Var(_), Operand::Var(_)] => {}
+        _ => errors.push(format!(
+            "InvalidOperand: function {:?}, str_cmp requires exactly two Operand::Var sources",
+            func.name
+        )),
+    }
+}
+
 fn is_printable_ascii_str(s: &str) -> bool {
     s.bytes()
         .all(|b| matches!(b, b'\n' | b'\r' | b'\t' | 0x20..=0x7e))
@@ -766,7 +794,7 @@ pub fn lower_iir_to_llvm(
     //
     // Static backends use the unmanaged string layout from `lang-full-e4-strings`:
     // an `i64` byte-length header followed by the bytes. `str_const` binds a
-    // pointer to this header, `str_len`/`str_eq` materialise literal metadata,
+    // pointer to this header, `str_len`/`str_eq`/`str_cmp` materialise literal metadata,
     // and `print_str` passes `header+8,len` to the C runtime. Richer ops
     // (`str_index`, `str_concat`) remain literal-only in this slice, but this
     // representation leaves the header in place for those later loads/checks.
@@ -1516,6 +1544,7 @@ fn lower_instr(
         "str_index" => lower_str_index(instr, state, out),
         "str_len" => lower_str_len(instr, state),
         "str_eq" => lower_str_eq(instr, state),
+        "str_cmp" => lower_str_cmp(instr, state),
         "print_str" => lower_print_str(instr, state, out),
 
         other => Err(IIRLlvmError::UnsupportedOp {
@@ -1831,6 +1860,47 @@ fn lower_str_eq(
         }
     })?;
     state.env.insert(dest, if left_value == right_value { "1" } else { "0" }.into());
+    Ok(())
+}
+
+fn lower_str_cmp(instr: &IIRInstr, state: &mut FnState) -> Result<(), IIRLlvmError> {
+    let dest = require_dest(instr, "str_cmp", state.fn_name)?.to_string();
+    let left = match instr.srcs.first() {
+        Some(Operand::Var(s)) => s,
+        _ => {
+            return Err(IIRLlvmError::InvalidOperand {
+                function: state.fn_name.into(),
+                detail: "str_cmp requires srcs[0] = Operand::Var(str)".into(),
+            });
+        }
+    };
+    let right = match instr.srcs.get(1) {
+        Some(Operand::Var(s)) => s,
+        _ => {
+            return Err(IIRLlvmError::InvalidOperand {
+                function: state.fn_name.into(),
+                detail: "str_cmp requires srcs[1] = Operand::Var(str)".into(),
+            });
+        }
+    };
+    let left_value = state.str_values.get(left).ok_or_else(|| {
+        IIRLlvmError::InvalidOperand {
+            function: state.fn_name.into(),
+            detail: format!("str_cmp left source {left:?} is not a string literal value"),
+        }
+    })?;
+    let right_value = state.str_values.get(right).ok_or_else(|| {
+        IIRLlvmError::InvalidOperand {
+            function: state.fn_name.into(),
+            detail: format!("str_cmp right source {right:?} is not a string literal value"),
+        }
+    })?;
+    let value = match left_value.as_bytes().cmp(right_value.as_bytes()) {
+        Ordering::Less => "-1",
+        Ordering::Equal => "0",
+        Ordering::Greater => "1",
+    };
+    state.env.insert(dest, value.into());
     Ok(())
 }
 

--- a/code/packages/rust/iir-to-llvm/tests/test_backend.rs
+++ b/code/packages/rust/iir-to-llvm/tests/test_backend.rs
@@ -1278,24 +1278,32 @@ fn e4_string_literal_index_out_of_bounds_traps() {
 }
 
 #[test]
-fn e4_unknown_string_ops_still_fail_closed() {
+fn e4_string_literal_cmp_folds_to_integer_return() {
     let f = IIRFunction::new(
         "main",
         vec![],
         "i64",
         vec![
-            IIRInstr::new("str_const", Some("s".into()), vec![Operand::Str("AB".into())], "str"),
-            IIRInstr::new("str_cmp", Some("c".into()), vec![
-                Operand::Var("s".into()),
-                Operand::Var("s".into()),
+            IIRInstr::new("str_const", Some("a".into()), vec![Operand::Str("ALPHA".into())], "str"),
+            IIRInstr::new("str_const", Some("b".into()), vec![Operand::Str("BETA".into())], "str"),
+            IIRInstr::new("str_cmp", Some("ord".into()), vec![
+                Operand::Var("a".into()),
+                Operand::Var("b".into()),
             ], "i64"),
-            IIRInstr::new("ret", None, vec![Operand::Var("c".into())], "i64"),
+            IIRInstr::new("ret", None, vec![Operand::Var("ord".into())], "i64"),
         ],
     );
-    let errors = validate_for_llvm(&module_with(f));
+    let module = module_with(f);
+    assert!(validate_for_llvm(&module).is_empty(), "literal string cmp should validate");
+    let ll = lower(&module);
+
     assert!(
-        errors.iter().any(|e| e.contains("UnsupportedOp") && e.contains("str_cmp")),
-        "unknown string ops should remain rejected; got {errors:?}"
+        ll.contains("ret i64 -1"),
+        "str_cmp over ordered literals should materialise -1:\n{ll}"
+    );
+    assert!(
+        !ll.contains("@__print_str"),
+        "str_cmp alone should not pull in the string print runtime:\n{ll}"
     );
 }
 

--- a/code/packages/rust/iir-to-wasm/CHANGELOG.md
+++ b/code/packages/rust/iir-to-wasm/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this crate are documented here.  The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.23.0] — 2026-06-28 (LANG-FULL E4 — literal string comparison on WASM)
+
+The WASM backend now accepts and lowers literal-only `str_cmp`, materialising
+`-1`, `0`, or `1` as an `i64.const`/`i32.const` from literal byte metadata.
+
 ## [0.22.0] — 2026-06-28 (LANG-FULL E4 — literal string slice on WASM)
 
 The WASM backend now accepts and lowers literal-only `str_slice`. The module

--- a/code/packages/rust/iir-to-wasm/README.md
+++ b/code/packages/rust/iir-to-wasm/README.md
@@ -64,17 +64,19 @@ through a deprecated intermediate.
   (or `f64`) at `wrap(handle)+idx*elemsize` offset 8; `array_len` reads the header.
   The wasm sibling of the LLVM `@calloc` + `icmp uge` + `llvm.trap` lowering. `i64`
   and `f64` elements (the ALGOL `integer`/`real` arrays).
-- **String literal foothold (v0.22.0 — LANG-FULL E4 / BA4)**: `str_const` writes
+- **String literal foothold (v0.23.0 — LANG-FULL E4 / BA4)**: `str_const` writes
   printable ASCII literal bytes into a linear-memory data segment and stores the
   byte pointer in an `i32` local; `print_str` calls the host import
   `env.__print_str(ptr,len)`. `str_len` over a direct literal materialises that
   literal's byte count as an integer constant, `str_eq` over two direct literals
-  materialises byte equality as `1`/`0`, and literal `str_concat` creates another
+  materialises byte equality as `1`/`0`, `str_cmp` materialises `-1`/`0`/`1`
+  from byte ordering, and literal `str_concat` creates another
   data entry for the combined bytes. Literal `str_slice` derives another data
   entry for a constant byte range. `str_index` over a direct literal emits a
   guarded `i32.load8_u` from the same data segment. This covers BASIC
   `PRINT "HELLO"` plus Twig `(string-length "HELLO")` and
-  `(string-ref "ABC" 1)`, `(string=? "HELLO" "HELLO")`, and
+  `(string-ref "ABC" 1)`, `(string=? "HELLO" "HELLO")`,
+  `(string<? "ALPHA" "BETA")`, and
   `(string-length (string-append "AB" "CDE"))`, plus
   `(string-ref (substring "ABCDE" 1 4) 1)`; non-literal string values still fail
   closed until the full byte-string runtime lands.

--- a/code/packages/rust/iir-to-wasm/src/lower.rs
+++ b/code/packages/rust/iir-to-wasm/src/lower.rs
@@ -133,6 +133,7 @@
 //! local.set $dest_local
 //! ```
 
+use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 
 use interpreter_ir::{IIRFunction, IIRInstr, IIRModule, Operand};
@@ -1046,6 +1047,48 @@ fn emit_instr(
                 detail: format!("str_eq right source {right:?} is not a direct str_const local"),
             })?;
             let value = if left_lit.bytes == right_lit.bytes { 1 } else { 0 };
+            if slot_is_i64(rd) {
+                code.extend(encode_i64_const(value));
+            } else {
+                code.extend(encode_i32_const(value as i32));
+            }
+            code.extend(encode_local_set(rd));
+        }
+
+        // ── str_cmp → literal byte ordering ─────────────────────────────────
+        "str_cmp" => {
+            let dest = instr.dest.as_deref().ok_or_else(|| IIRWasmError::InvalidOperand {
+                function: fn_name.to_string(),
+                detail: "str_cmp must have a dest".to_string(),
+            })?;
+            let rd = get_reg(dest)?;
+            let left = match instr.srcs.first() {
+                Some(Operand::Var(v)) => v.as_str(),
+                _ => return Err(IIRWasmError::InvalidOperand {
+                    function: fn_name.to_string(),
+                    detail: "str_cmp requires srcs[0] = Operand::Var(str)".to_string(),
+                }),
+            };
+            let right = match instr.srcs.get(1) {
+                Some(Operand::Var(v)) => v.as_str(),
+                _ => return Err(IIRWasmError::InvalidOperand {
+                    function: fn_name.to_string(),
+                    detail: "str_cmp requires srcs[1] = Operand::Var(str)".to_string(),
+                }),
+            };
+            let left_lit = string_literals.get(left).ok_or_else(|| IIRWasmError::InvalidOperand {
+                function: fn_name.to_string(),
+                detail: format!("str_cmp left source {left:?} is not a direct str_const local"),
+            })?;
+            let right_lit = string_literals.get(right).ok_or_else(|| IIRWasmError::InvalidOperand {
+                function: fn_name.to_string(),
+                detail: format!("str_cmp right source {right:?} is not a direct str_const local"),
+            })?;
+            let value = match left_lit.bytes.cmp(&right_lit.bytes) {
+                Ordering::Less => -1,
+                Ordering::Equal => 0,
+                Ordering::Greater => 1,
+            };
             if slot_is_i64(rd) {
                 code.extend(encode_i64_const(value));
             } else {

--- a/code/packages/rust/iir-to-wasm/src/validate.rs
+++ b/code/packages/rust/iir-to-wasm/src/validate.rs
@@ -8,7 +8,7 @@
 //! - WASM has no "any" type — every local and stack slot must have a concrete
 //!   numeric type (`i32`, `i64`, `f32`, `f64`) or a known GC reference type.
 //! - WASM has only the E4 literal string foothold in this lowering:
-//!   `str_const` + `str_len` + `str_index` + `str_eq` + `str_concat` +
+//!   `str_const` + `str_len` + `str_index` + `str_eq` + `str_cmp` + `str_concat` +
 //!   `print_str`; richer dynamic string ops remain rejected.
 //! - Runtime / I/O opcodes have no WASM equivalent without a host import,
 //!   which this direct lowering does not provide.
@@ -278,7 +278,7 @@ pub fn validate_for_wasm(module: &IIRModule) -> Vec<String> {
             //
             // `"str"` — accepted for the E4 literal-output/metadata foothold's
             // direct string producers (`str_const`, `str_concat`, `str_slice`). `str_len`,
-            // `str_index`, and `str_eq` produce integers, not string values.
+            // `str_index`, `str_eq`, and `str_cmp` produce integers, not string values.
             // Richer dynamic string ops still fail explicitly below.
             //
             // `"ref<X>"` — reference types require WasmGC.  We accept
@@ -292,7 +292,7 @@ pub fn validate_for_wasm(module: &IIRModule) -> Vec<String> {
             {
                 errors.push(format!(
                     "UnsupportedType: function {:?}, op {:?} has type_hint \"str\"; \
-                     only str_const + str_concat + str_slice + str_len + str_index + str_eq + print_str literal output is supported in this WASM backend",
+                     only str_const + str_concat + str_slice + str_len + str_index + str_eq + str_cmp + print_str literal output is supported in this WASM backend",
                     func.name, instr.op
                 ));
             } else if instr.type_hint.starts_with("ref<")
@@ -431,6 +431,26 @@ pub fn validate_for_wasm(module: &IIRModule) -> Vec<String> {
                     _ => {
                         errors.push(format!(
                             "UnsupportedOp: function {:?}, op \"str_eq\" requires \
+                             dest, two Operand::Var sources, and i64/i32 result type",
+                            func.name
+                        ));
+                    }
+                }
+            } else if instr.op == "str_cmp" {
+                match (instr.dest.as_ref(), instr.srcs.as_slice(), instr.type_hint.as_str()) {
+                    (
+                        Some(_),
+                        [
+                            interpreter_ir::Operand::Var(_),
+                            interpreter_ir::Operand::Var(_),
+                        ],
+                        "i64" | "i32",
+                    ) => {
+                        // Accepted — lower.rs materialises literal ordering.
+                    }
+                    _ => {
+                        errors.push(format!(
+                            "UnsupportedOp: function {:?}, op \"str_cmp\" requires \
                              dest, two Operand::Var sources, and i64/i32 result type",
                             func.name
                         ));
@@ -688,6 +708,34 @@ mod tests {
         assert!(
             errs.is_empty(),
             "str_eq over direct literals should be accepted; got: {:?}",
+            errs
+        );
+    }
+
+    #[test]
+    fn e4_literal_str_cmp_accepted() {
+        let errs = validate_for_wasm(&module_with(vec![
+            IIRInstr::new(
+                "str_const",
+                Some("a".into()),
+                vec![Operand::Str("ALPHA".into())],
+                "str",
+            ),
+            IIRInstr::new(
+                "str_const",
+                Some("b".into()),
+                vec![Operand::Str("BETA".into())],
+                "str",
+            ),
+            IIRInstr::new("str_cmp", Some("ord".into()), vec![
+                Operand::Var("a".into()),
+                Operand::Var("b".into()),
+            ], "i64"),
+            IIRInstr::new("ret", None, vec![Operand::Var("ord".into())], "i64"),
+        ]));
+        assert!(
+            errs.is_empty(),
+            "str_cmp over direct literals should be accepted; got: {:?}",
             errs
         );
     }

--- a/code/packages/rust/iir-to-wasm/tests/test_backend.rs
+++ b/code/packages/rust/iir-to-wasm/tests/test_backend.rs
@@ -1695,6 +1695,37 @@ fn e4_string_concat_len_lowers_to_literal_length() {
 }
 
 #[test]
+fn e4_string_cmp_lowers_to_literal_ordering() {
+    let m = module_one("main", vec![], "i64", vec![
+        IIRInstr::new(
+            "str_const",
+            Some("a".into()),
+            vec![Operand::Str("ALPHA".into())],
+            "str",
+        ),
+        IIRInstr::new(
+            "str_const",
+            Some("b".into()),
+            vec![Operand::Str("BETA".into())],
+            "str",
+        ),
+        IIRInstr::new("str_cmp", Some("ord".into()), vec![
+            Operand::Var("a".into()),
+            Operand::Var("b".into()),
+        ], "i64"),
+        IIRInstr::new("ret", None, vec![Operand::Var("ord".into())], "i64"),
+    ]);
+
+    let errs = validate_for_wasm(&m);
+    assert!(errs.is_empty(), "E4: str_cmp should validate: {errs:?}");
+    let wm = lower_iir_to_wasm(&m, &IIRWasmConfig::default()).expect("E4: str_cmp should lower");
+    assert!(
+        wm.code[0].code.windows(2).any(|w| w == [0x42, 0x7f]),
+        "E4: str_cmp over ALPHA/BETA should emit i64.const -1"
+    );
+}
+
+#[test]
 fn e4_string_slice_index_lowers_to_literal_byte_load() {
     let m = module_one("main", vec![], "i64", vec![
         IIRInstr::new(

--- a/code/packages/rust/lang-aot/CHANGELOG.md
+++ b/code/packages/rust/lang-aot/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog — `lang-aot`
 
+## 0.149.0 — 2026-06-28 — Twig lexical string ordering on all seven backends (LANG-FULL E4)
+
+The matrix now proves nested `string<?` and `string>?` predicates via the shared
+`str_cmp` op on native-AOT + LLVM + WASM + JVM + CLR + VM + JIT.
+
 ## 0.148.0 — 2026-06-28 — Twig substring feeds string indexing on all seven backends (LANG-FULL E4)
 
 The matrix now proves a typed Twig lexical string can be sliced and then byte

--- a/code/packages/rust/lang-aot/tests/lang_matrix.rs
+++ b/code/packages/rust/lang-aot/tests/lang_matrix.rs
@@ -320,6 +320,16 @@ const PROGRAMS: &[Prog] = &[
         expect: Expect::Exit(67),
         backends: &[NativeAot, Llvm, Wasm, Jvm, Clr, Vm, Jit],
     },
+    // Twig — E4 `str_cmp` driving lexical string predicates. The frontend lowers
+    // `string<?`/`string>?` to shared `str_cmp` followed by typed comparison
+    // against zero, so every proven column observes the same byte ordering.
+    Prog {
+        lang: Language::Twig,
+        ext: "twig",
+        src: "(if (string<? \"ALPHA\" \"BETA\") (if (string>? \"BETA\" \"ALPHA\") 42 0) 0)",
+        expect: Expect::Exit(42),
+        backends: &[NativeAot, Llvm, Wasm, Jvm, Clr, Vm, Jit],
+    },
     // Twig — *top-level value `define`* read from `main` (`(define x 40) (define
     // y 2) (+ x y)` = 42).  A value define previously lowered to
     // `call_builtin "global_set"` (and reads to `global_get`), `type_hint =

--- a/code/packages/rust/twig-aot/CHANGELOG.md
+++ b/code/packages/rust/twig-aot/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog — `twig-aot`
 
+## 0.22.0 — 2026-06-28 — native string comparison metadata folding (LANG-FULL E4)
+
+`prepare_module_for_aot` now folds literal-only `str_cmp` to the shared `-1`,
+`0`, or `1` integer convention before direct native lowering.
+
 ## 0.21.0 — 2026-06-28 — native substring metadata folding (LANG-FULL E4)
 
 `prepare_module_for_aot` now folds literal-only `str_slice` results into the

--- a/code/packages/rust/twig-aot/README.md
+++ b/code/packages/rust/twig-aot/README.md
@@ -50,10 +50,11 @@ LANG-FULL E4 / BA4 literal string output reuses this runtime path: native AOT
 preparation lowers `str_const` + `print_str` to `alloc_bytes`, `store_byte`, and
 `call_builtin "print_string"`, so source-level BASIC `PRINT "HELLO"` runs through
 the same object/link/runtime pipeline as byte-tape programs. Direct-literal
-`str_len`, `str_index`, `str_eq`, literal `str_concat`, and literal `str_slice`
+`str_len`, `str_index`, `str_eq`, `str_cmp`, literal `str_concat`, and literal `str_slice`
 metadata over direct literals fold before machine-code lowering, so Twig
 `(string-length "HELLO")`, `(string-ref "ABC" 1)`,
-`(string=? "HELLO" "HELLO")`, `(string-length (string-append "AB" "CDE"))`,
+`(string=? "HELLO" "HELLO")`, `(string<? "ALPHA" "BETA")`,
+`(string-length (string-append "AB" "CDE"))`,
 and `(string-ref (substring "ABCDE" 1 4) 1)` run natively through the same
 preparation pass. Folded `str_len` metadata can also flow through typed integer
 arithmetic, so `(let ((s "ABCDE")) (string-ref s (- (string-length s) 1)))`

--- a/code/packages/rust/twig-aot/src/lib.rs
+++ b/code/packages/rust/twig-aot/src/lib.rs
@@ -50,6 +50,7 @@
 #![warn(missing_docs)]
 #![warn(rust_2018_idioms)]
 
+use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
@@ -1451,7 +1452,7 @@ fn strip_dead_string_consts(func: &mut IIRFunction) {
 /// The direct native backends already know how to allocate bytes, store bytes,
 /// and call the portable `__twig_print_string(ptr,len)` runtime helper. This
 /// pass reuses that path for `str_const` + `print_str` and folds direct
-/// literal `str_len`/`str_eq`; richer string ops remain unsupported until the
+/// literal `str_len`/`str_eq`/`str_cmp`; richer string ops remain unsupported until the
 /// full byte-string runtime lands.
 fn push_aot_string_literal(
     lowered: &mut Vec<IIRInstr>,
@@ -1732,6 +1733,38 @@ fn lower_string_literals_for_aot(func: &mut IIRFunction) {
                 "const",
                 Some(dest),
                 vec![Operand::Int((left_literal == right_literal) as i64)],
+                &instr.type_hint,
+            ));
+            continue;
+        }
+
+        if instr.op == "str_cmp" {
+            let Some(dest) = instr.dest.clone() else {
+                lowered.push(instr);
+                continue;
+            };
+            let [Operand::Var(left), Operand::Var(right)] = instr.srcs.as_slice() else {
+                lowered.push(instr);
+                continue;
+            };
+            let Some((_, _, left_literal)) = strings.get(left).cloned() else {
+                lowered.push(instr);
+                continue;
+            };
+            let Some((_, _, right_literal)) = strings.get(right).cloned() else {
+                lowered.push(instr);
+                continue;
+            };
+            let value = match left_literal.as_bytes().cmp(right_literal.as_bytes()) {
+                Ordering::Less => -1,
+                Ordering::Equal => 0,
+                Ordering::Greater => 1,
+            };
+            ints.insert(dest.clone(), value);
+            lowered.push(IIRInstr::new(
+                "const",
+                Some(dest),
+                vec![Operand::Int(value)],
                 &instr.type_hint,
             ));
             continue;
@@ -2517,6 +2550,38 @@ mod tests {
         assert!(
             f.instructions.iter().all(|i| i.op != "str_eq"),
             "native lowering should remove folded str_eq: {:?}",
+            f.instructions
+        );
+    }
+
+    #[test]
+    fn string_literal_cmp_lowers_to_i64_const() {
+        let mut f = IIRFunction::new(
+            "main",
+            vec![],
+            "i64",
+            vec![
+                IIRInstr::new("str_const", Some("a".into()), vec![Operand::Str("ALPHA".into())], "str"),
+                IIRInstr::new("str_const", Some("b".into()), vec![Operand::Str("BETA".into())], "str"),
+                IIRInstr::new("str_cmp", Some("ord".into()), vec![
+                    Operand::Var("a".into()),
+                    Operand::Var("b".into()),
+                ], "i64"),
+                IIRInstr::new("ret", None, vec![Operand::Var("ord".into())], "i64"),
+            ],
+        );
+
+        lower_string_literals_for_aot(&mut f);
+
+        let cmp_const = f.instructions.iter().find(|i| i.dest.as_deref() == Some("ord"));
+        assert!(
+            matches!(cmp_const, Some(i) if i.op == "const" && i.srcs == vec![Operand::Int(-1)]),
+            "str_cmp over ordered literals should fold to const -1: {:?}",
+            f.instructions
+        );
+        assert!(
+            f.instructions.iter().all(|i| i.op != "str_cmp"),
+            "native lowering should remove folded str_cmp: {:?}",
             f.instructions
         );
     }

--- a/code/packages/rust/twig-ir-compiler/CHANGELOG.md
+++ b/code/packages/rust/twig-ir-compiler/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog — twig-ir-compiler
 
+## [0.34.0] — 2026-06-28 (LANG-FULL E4 — lexical string ordering predicates)
+
+Literal and known local `string<?` / `string>?` expressions now lower through
+the shared `str_cmp` op followed by typed integer comparison against zero.
+
 ## [0.33.0] — 2026-06-28 (LANG-FULL E4 — substring feeds string-ref proof)
 
 Lexical string bindings can now feed `substring`, and the resulting string can

--- a/code/packages/rust/twig-ir-compiler/README.md
+++ b/code/packages/rust/twig-ir-compiler/README.md
@@ -23,15 +23,17 @@ Anonymous lambdas have their captured free variables prepended to the parameter 
 Top-level value defines lower one of two ways (TW2/E4). A value define that is **not captured by any lambda** is read only from `main`, so its statically-typed (`i64`/`bool` and immutable top-level `str`) value is kept in a `main` register and reads return it directly — fully typed, accepted by every code-gen backend. A value define **captured by a closure** (read inside a lambda body, which compiles to a separate function) stays on the host global table via `call_builtin "global_set" name value` / `global_get`, as does a top-level forward reference.
 
 Literal `(string-length "...")`, `(string-ref "..." i)`, `(string=? "..." "...")`,
-`(substring "..." i j)`, and `(string-length (string-append "..." "..."))`
+`(string<? "..." "...")`, `(string>? "..." "...")`, `(substring "..." i j)`,
+and `(string-length (string-append "..." "..."))`
 lower to typed E4 string
 metadata ops: `str_const` for each direct literal, then `str_len`, `str_index`,
-`str_eq`, `str_slice`, or `str_concat` for the result path. The same E4
+`str_eq`, `str_cmp`, `str_slice`, or `str_concat` for the result path. The same E4
 lowering also handles immutable top-level string values, so `(define s "ABC")
 (string-ref s 2)` and named-string `string-append`/`string=?` proofs avoid the
 dynamic builtin path.
 Lexical `let`/`let*` string literal bindings use the same typed registers, so
-local strings can feed `string-ref`, `string-length`, `string=?`, and
+local strings can feed `string-ref`, `string-length`, `string=?`, `string<?`,
+`string>?`, and
 `string-append` without dynamic builtins; a `string-append` result can also feed
 `string-ref` directly through `str_concat` -> `str_index`, and `string-length`
 can compute a typed arithmetic index that feeds `str_index`. `substring` over a
@@ -49,7 +51,7 @@ The compiler decides at compile time:
 |-----------------------------|---------------------------------------------|
 | Top-level user fn           | `call <name>, ...args`                      |
 | Typed arithmetic (`+`,`-`,`*`,`/`) on `i64` args | a chain of typed `add`/`sub`/`mul`/`div` |
-| Direct literal, immutable top-level, or lexical-local string metadata (`string-length`, `string-ref`, `substring`, `string=?`, `string-append`) | `str_const` + `str_len`/`str_index`/`str_slice`/`str_eq`/`str_concat`, with typed index arithmetic for `string-ref` and `substring` bounds |
+| Direct literal, immutable top-level, or lexical-local string metadata (`string-length`, `string-ref`, `substring`, `string=?`, `string<?`, `string>?`, `string-append`) | `str_const` + `str_len`/`str_index`/`str_slice`/`str_eq`/`str_cmp`/`str_concat`, with typed index arithmetic for `string-ref` and `substring` bounds |
 | Builtin (`cons`, `<`, …)    | `call_builtin <name>, ...args`              |
 | Anything else (locals etc.) | `call_builtin "apply_closure", h, ...args`  |
 

--- a/code/packages/rust/twig-ir-compiler/src/compiler.rs
+++ b/code/packages/rust/twig-ir-compiler/src/compiler.rs
@@ -1511,6 +1511,46 @@ impl Compiler {
                 ctx.record_type(&dest, "i64");
                 Ok(Some(dest))
             }
+            "string<?" | "string>?"
+                if args.len() == 2
+                    && self.can_compile_e4_string_expr(&args[0], ctx)
+                    && self.can_compile_e4_string_expr(&args[1], ctx) =>
+            {
+                let left = self.compile_e4_string_expr(&args[0], ctx)?;
+                let right = self.compile_e4_string_expr(&args[1], ctx)?;
+                let cmp = ctx.fresh_var("r");
+                ctx.emit(
+                    IIRInstr::new(
+                        "str_cmp",
+                        Some(cmp.clone()),
+                        vec![Operand::Var(left), Operand::Var(right)],
+                        "i64",
+                    ),
+                    loc,
+                );
+                ctx.record_type(&cmp, "i64");
+
+                let zero = ctx.fresh_var("n");
+                ctx.emit(
+                    IIRInstr::new("const", Some(zero.clone()), vec![Operand::Int(0)], "i64"),
+                    loc,
+                );
+                ctx.record_type(&zero, "i64");
+
+                let dest = ctx.fresh_var("r");
+                let op = if name == "string<?" { "cmp_lt" } else { "cmp_gt" };
+                ctx.emit(
+                    IIRInstr::new(
+                        op,
+                        Some(dest.clone()),
+                        vec![Operand::Var(cmp), Operand::Var(zero)],
+                        "i64",
+                    ),
+                    loc,
+                );
+                ctx.record_type(&dest, "bool");
+                Ok(Some(dest))
+            }
             "string-ref"
                 if args.len() == 2
                     && self.can_compile_e4_string_expr(&args[0], ctx)

--- a/code/packages/rust/twig-ir-compiler/src/lib.rs
+++ b/code/packages/rust/twig-ir-compiler/src/lib.rs
@@ -1512,6 +1512,26 @@ mod tests {
     }
 
     #[test]
+    fn string_order_literals_use_e4_str_cmp() {
+        let m = compile_source(
+            "(if (and (string<? \"ALPHA\" \"BETA\") (string>? \"BETA\" \"ALPHA\")) 42 0)",
+            "string_order_branch",
+        )
+        .expect("literal string ordering should compile");
+        let main = m.functions.iter().find(|f| f.name == "main").unwrap();
+        let ops: Vec<&str> = main.instructions.iter().map(|i| i.op.as_str()).collect();
+        assert_eq!(ops.iter().filter(|op| **op == "str_cmp").count(), 2, "{ops:?}");
+        assert!(ops.contains(&"cmp_lt"), "expected cmp_lt in {ops:?}");
+        assert!(ops.contains(&"cmp_gt"), "expected cmp_gt in {ops:?}");
+        assert!(
+            main.instructions.iter().all(|i| i.op != "call_builtin"),
+            "literal string ordering should avoid the dynamic builtin path: {:?}",
+            main.instructions
+        );
+        assert_eq!(main.return_type, "i64");
+    }
+
+    #[test]
     fn string_append_literal_length_uses_e4_str_concat() {
         let m = compile_source("(string-length (string-append \"AB\" \"CDE\"))", "string_concat_len")
             .expect("literal string-append length should compile");

--- a/code/packages/rust/vm-core/CHANGELOG.md
+++ b/code/packages/rust/vm-core/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog — vm-core
 
+## [0.12.0] — 2026-06-28 (LANG-FULL E4 — reference string comparison)
+
+The reference VM now implements `str_cmp`, returning the shared E4 three-way
+byte ordering convention: `-1`, `0`, or `1`.
+
 ## [0.11.0] — 2026-06-28 (LANG-FULL E4 — reference string slicing)
 
 The reference VM now implements shared E4 `str_slice` semantics over

--- a/code/packages/rust/vm-core/src/dispatch.rs
+++ b/code/packages/rust/vm-core/src/dispatch.rs
@@ -32,6 +32,7 @@
 //! is masked with `& 0xFF`.  The mask is applied inside each arithmetic handler,
 //! not in the dispatch loop.
 
+use std::cmp::Ordering;
 use std::collections::HashMap;
 use interpreter_ir::instr::{IIRInstr, Operand};
 use crate::errors::VMError;
@@ -845,6 +846,24 @@ fn handle_str_eq(ctx: &mut DispatchCtx, instr: &IIRInstr) -> Result<Option<Value
     Ok(Some(value))
 }
 
+fn handle_str_cmp(ctx: &mut DispatchCtx, instr: &IIRInstr) -> Result<Option<Value>, VMError> {
+    let ordering = {
+        let frame = ctx.frames.last().ok_or_else(|| VMError::Custom("no frame".into()))?;
+        let a = string_src(frame, &instr.srcs, 0, "str_cmp")?;
+        let b = string_src(frame, &instr.srcs, 1, "str_cmp")?;
+        a.as_bytes().cmp(b.as_bytes())
+    };
+    let value = Value::Int(match ordering {
+        Ordering::Less => -1,
+        Ordering::Equal => 0,
+        Ordering::Greater => 1,
+    });
+    if let Some(dest) = &instr.dest {
+        ctx.frames.last_mut().unwrap().assign(dest, value.clone());
+    }
+    Ok(Some(value))
+}
+
 fn handle_print_str(ctx: &mut DispatchCtx, instr: &IIRInstr) -> Result<Option<Value>, VMError> {
     let s = {
         let frame = ctx.frames.last().ok_or_else(|| VMError::Custom("no frame".into()))?;
@@ -1364,6 +1383,7 @@ pub(crate) fn lookup_standard(op: &str) -> Option<StdHandlerFn> {
         "str_concat"   => Some(handle_str_concat),
         "str_slice"    => Some(handle_str_slice),
         "str_eq"       => Some(handle_str_eq),
+        "str_cmp"      => Some(handle_str_cmp),
         "print_str"    => Some(handle_print_str),
         "alloc_array"  => Some(handle_alloc_array),
         "array_len"    => Some(handle_array_len),

--- a/code/packages/rust/vm-core/tests/e4_strings.rs
+++ b/code/packages/rust/vm-core/tests/e4_strings.rs
@@ -55,6 +55,25 @@ fn str_concat_and_eq_return_i64_bool() {
 }
 
 #[test]
+fn str_cmp_returns_three_way_order() {
+    let result = run(
+        vec![
+            ins("str_const", Some("a"), vec![Operand::Str("ALPHA".into())], "str"),
+            ins("str_const", Some("b"), vec![Operand::Str("BETA".into())], "str"),
+            ins("str_cmp", Some("lt"), vec![Operand::Var("a".into()), Operand::Var("b".into())], "i64"),
+            ins("str_cmp", Some("eq"), vec![Operand::Var("a".into()), Operand::Var("a".into())], "i64"),
+            ins("str_cmp", Some("gt"), vec![Operand::Var("b".into()), Operand::Var("a".into())], "i64"),
+            ins("add", Some("sum"), vec![Operand::Var("lt".into()), Operand::Var("eq".into())], "i64"),
+            ins("add", Some("sum2"), vec![Operand::Var("sum".into()), Operand::Var("gt".into())], "i64"),
+            ins("ret", None, vec![Operand::Var("sum2".into())], "i64"),
+        ],
+        "i64",
+    )
+    .unwrap();
+    assert_eq!(result, Some(Value::Int(0)));
+}
+
+#[test]
 fn str_slice_produces_substring_value() {
     let result = run(
         vec![

--- a/code/specs/lang-full-e4-strings.md
+++ b/code/specs/lang-full-e4-strings.md
@@ -65,7 +65,7 @@ representation that is natural and safe for its target.
 
 ## 2. IIR surface
 
-Six new ops. A string value rides the `type_hint` `str`; it flows as a `Var`
+Seven new ops. A string value rides the `type_hint` `str`; it flows as a `Var`
 (a managed reference or a fat handle), exactly like an `array<T>` value.
 
 | Op | Form | Result | Semantics |
@@ -75,11 +75,11 @@ Six new ops. A string value rides the `type_hint` `str`; it flows as a `Var`
 | `str_concat` | `dest <- a, b` | `str` | A new string = bytes of `a` followed by bytes of `b`. Neither input is mutated. |
 | `str_index` | `dest <- s, idx` | `i64` | **Bounds-checked** byte load: if `idx < 0 \|\| idx >= str_len(s)` → **trap**; else `dest` = the unsigned byte value `s[idx]` (0–255). |
 | `str_eq` | `dest <- a, b` | `i64` (bool) | `1` if `a` and `b` have identical bytes, else `0`. |
+| `str_cmp` | `dest <- a, b` | `i64` | Lexicographic byte ordering: `-1` if `a < b`, `0` if equal, `1` if `a > b`. |
 | `print_str` | `s` | — | Write the bytes of `s` to stdout (no implicit newline). The text-I/O primitive — the string sibling of `call_builtin "print_i64"`. |
 
-`str_cmp` (lexicographic `-1/0/1`) and `str_substr` are **follow-ups**, not v1 —
-`str_eq` covers the first runnable proofs (`PRINT`, equality), and lexical
-ordering can layer on `str_index` + `str_len` later.
+Broader dynamic allocation, captured/reassigned strings, and richer frontend
+string APIs remain follow-ups beyond this literal/known-value foothold.
 
 ### 2.1 Type model
 
@@ -109,16 +109,16 @@ explicit `cmp idx,len` + branch-to-trap.
 
 ## 3. Per-backend representation
 
-| Backend | Family | Representation | `str_const` | `str_len` | `str_eq` | `str_index` | `str_concat` | `print_str` |
-|---|---|---|---|---|---|---|---|---|
-| **vm-core** | (interp) | `Value::Str(Vec<u8>)` (new value variant) or a handle into `memory` | intern the literal bytes | `.len()` | byte equality | range-checked byte index | allocate a new buffer | write bytes to the host stdout sink |
-| **jit-core** | (interp) | same as vm-core (CIR mirrors it) | — | — | — | — | — | — |
-| **JVM** | GC | `java.lang.String` for the landed literal-output/metadata/index slice; byte-string representation still under E4-managed | `ldc` string CP entry ✅ for ASCII literals | `String.length()` ✅ for ASCII literals | `String.equals(Object)` ✅ for ASCII literals | `String.charAt(I)` ✅ for ASCII literals | `String.concat(String)` ✅ for ASCII literals | `PrintStream.print(String)` ✅ |
-| **CLR** | GC | `System.String` for the landed literal-output/metadata/index slice; byte-string representation still under E4-managed | `ldstr "…"` ✅ for ASCII literals | `String.Length` ✅ for ASCII literals | `String.Equals(string,string)` ✅ for ASCII literals | `String.get_Chars(int32)` ✅ for ASCII literals | `String.Concat(string,string)` ✅ for ASCII literals | `Console.Write(string)` ✅ |
-| **WASM** | linear-memory foothold now; WasmGC later | `i32` pointer into a data segment for the landed literal-output/metadata/index slice; richer byte-string representation still under E4-managed | data segment ✅ for ASCII literals | literal side-table length ✅ | literal side-table byte equality ✅ | guarded `i32.load8_u` ✅ for ASCII literals | literal data entry ✅ | host import `env.__print_str(ptr,len)` ✅ |
-| **LLVM** | static | length-prefixed buffer `[i64 len][bytes…]`; literals in a `private constant` global | private `{len,bytes}` global ✅ for ASCII literals | literal side-table length ✅ | literal side-table byte equality ✅ | folded literal byte ✅ | literal metadata ✅ | `@__print_str(i8* base+8, i64 len)` C-runtime ✅ |
-| **x86_64** | static | heap-byte literal-output foothold now; full length-prefixed rodata model later | `alloc_bytes` + `store_byte` ✅ for ASCII literals | folded literal length ✅ | folded literal equality ✅ | folded literal byte ✅ | folded literal concat ✅ | `call __twig_print_string(ptr,len)` ✅ |
-| **aarch64** | static | heap-byte literal-output foothold now; full length-prefixed rodata model later | `alloc_bytes` + `store_byte` ✅ for ASCII literals | folded literal length ✅ | folded literal equality ✅ | folded literal byte ✅ | folded literal concat ✅ | `bl __twig_print_string(ptr,len)` ✅ |
+| Backend | Family | Representation | `str_const` | `str_len` | `str_eq` | `str_cmp` | `str_index` | `str_concat` | `print_str` |
+|---|---|---|---|---|---|---|---|---|---|
+| **vm-core** | (interp) | `Value::Str(Vec<u8>)` (new value variant) or a handle into `memory` | intern the literal bytes | `.len()` | byte equality | byte ordering | range-checked byte index | allocate a new buffer | write bytes to the host stdout sink |
+| **jit-core** | (interp) | same as vm-core (CIR mirrors it) | — | — | — | — | — | — | — |
+| **JVM** | GC | `java.lang.String` for the landed literal-output/metadata/index slice; byte-string representation still under E4-managed | `ldc` string CP entry ✅ for ASCII literals | `String.length()` ✅ for ASCII literals | `String.equals(Object)` ✅ for ASCII literals | `String.compareTo` + `Integer.signum` ✅ | `String.charAt(I)` ✅ for ASCII literals | `String.concat(String)` ✅ for ASCII literals | `PrintStream.print(String)` ✅ |
+| **CLR** | GC | `System.String` for the landed literal-output/metadata/index slice; byte-string representation still under E4-managed | `ldstr "…"` ✅ for ASCII literals | `String.Length` ✅ for ASCII literals | `String.Equals(string,string)` ✅ for ASCII literals | `String.CompareOrdinal` + `Math.Sign` ✅ | `String.get_Chars(int32)` ✅ for ASCII literals | `String.Concat(string,string)` ✅ for ASCII literals | `Console.Write(string)` ✅ |
+| **WASM** | linear-memory foothold now; WasmGC later | `i32` pointer into a data segment for the landed literal-output/metadata/index slice; richer byte-string representation still under E4-managed | data segment ✅ for ASCII literals | literal side-table length ✅ | literal side-table byte equality ✅ | literal side-table ordering ✅ | guarded `i32.load8_u` ✅ for ASCII literals | literal data entry ✅ | host import `env.__print_str(ptr,len)` ✅ |
+| **LLVM** | static | length-prefixed buffer `[i64 len][bytes…]`; literals in a `private constant` global | private `{len,bytes}` global ✅ for ASCII literals | literal side-table length ✅ | literal side-table byte equality ✅ | literal side-table ordering ✅ | folded literal byte ✅ | literal metadata ✅ | `@__print_str(i8* base+8, i64 len)` C-runtime ✅ |
+| **x86_64** | static | heap-byte literal-output foothold now; full length-prefixed rodata model later | `alloc_bytes` + `store_byte` ✅ for ASCII literals | folded literal length ✅ | folded literal equality ✅ | folded literal ordering ✅ | folded literal byte ✅ | folded literal concat ✅ | `call __twig_print_string(ptr,len)` ✅ |
+| **aarch64** | static | heap-byte literal-output foothold now; full length-prefixed rodata model later | `alloc_bytes` + `store_byte` ✅ for ASCII literals | folded literal length ✅ | folded literal equality ✅ | folded literal ordering ✅ | folded literal byte ✅ | folded literal concat ✅ | `bl __twig_print_string(ptr,len)` ✅ |
 
 **Unmanaged header layout** (LLVM / x86_64 / aarch64): identical to E5's array
 header — word 0 is the byte count, bytes start at offset 8. String literals are
@@ -184,9 +184,10 @@ E4. This is the one genuinely new piece of host surface E4 adds beyond E5.
   `print_str` calls. Captured/`own` strings, arrays, parameters, and broader
   dynamic strings remain follow-ups.
 - **Twig (TW4)** — Twig string literals + `print` lower to `str_const` +
-  `print_str`; `++`/`string-append` to `str_concat`, `string=?` to `str_eq`, and
-  `string-ref` to `str_index`. Direct literals, immutable top-level values, and
-  lexical `let`/`let*` locals can now feed `str_len`, `str_index`, `str_eq`, and
+  `print_str`; `++`/`string-append` to `str_concat`, `string=?` to `str_eq`,
+  `string<?`/`string>?` to `str_cmp` plus typed comparisons, and `string-ref`
+  to `str_index`. Direct literals, immutable top-level values, and
+  lexical `let`/`let*` locals can now feed `str_len`, `str_index`, `str_eq`, `str_cmp`, and
   `str_concat` on all seven backends; local `string-append` results can also feed
   `string-ref` directly through `str_concat` followed by `str_index`, and
   local `string-length` results can compute `string-ref` indexes through typed
@@ -212,8 +213,8 @@ proof:
 ```
 
 ⇒ stdout `HELLO` on every backend the toolchain is present for. The landed Twig
-footholds also prove direct literal `str_len`, `str_index`, `str_eq`, and
-`str_concat`-feeding-`str_len` via exit codes `5`/`66`/`1`/`5`. The named-value
+footholds also prove direct literal `str_len`, `str_index`, `str_eq`, `str_cmp`, and
+`str_concat`-feeding-`str_len` via exit codes `5`/`66`/`1`/`42`/`5`. The named-value
 proofs exercise immutable top-level string values with `str_concat` + `str_len`,
 `str_eq` driving an `if`, and `str_index` via exit codes `5`/`42`/`67` on every
 backend. Lexical string locals now run through indexing, `let*` length, equality
@@ -224,7 +225,9 @@ branches, and concat: `(let ((s "ABC") (i 2)) (string-ref s i))` returns `67`,
 everywhere; `(let ((a "AB") (b "CDE") (i 3)) (string-ref (string-append a b) i))`
 returns `68`, proving a concat temporary can feed byte indexing, and
 `(let ((s "ABCDE")) (string-ref s (- (string-length s) 1)))` returns `69`,
-proving `str_len` can compute a byte-index operand. The matrix also covers the **bounds-trap** case: `(string-ref "ABC"
+proving `str_len` can compute a byte-index operand. `(if (string<? "ALPHA"
+"BETA") (if (string>? "BETA" "ALPHA") 42 0) 0)` returns `42`, proving lexical
+ordering through `str_cmp`. The matrix also covers the **bounds-trap** case: `(string-ref "ABC"
 3)` must fail closed on native-AOT + LLVM + WASM + JVM + CLR + VM + JIT.
 Dartmouth BASIC proves source-language string variables, reassignment, scalar
 copy, copied-slot equality, literal/variable-backed concat, concat expressions in
@@ -330,9 +333,10 @@ merge before the next:
    this item is now the richer ops/representation slice.
 6. ✅ **E4-ops-proofs** — named-value `str_concat`+`str_len`, `str_eq` driving a
    branch, named/local `str_index`, local `str_concat` feeding `str_index`, and
-   local `str_len` computing a `str_index` operand, plus the `str_index`
-   out-of-bounds **trap** proof now run across every backend.
-7. **(follow-ups, not v1)** `str_cmp` (lexical ordering) + `str_substr`;
+   local `str_len` computing a `str_index` operand, `str_cmp` driving lexical
+   predicates, plus the `str_index` out-of-bounds **trap** proof now run across
+   every backend.
+7. **Follow-ups beyond v1** `str_substr`;
    captured/reassigned dynamic strings, string arrays/input/parameters in each
    frontend, runtime byte-string allocation beyond the current immutable scalar
    foothold, Unicode codepoint/grapheme semantics, the dynamic-`any` Twig string


### PR DESCRIPTION
## Summary
- add shared E4 `str_cmp` semantics to the reference VM and literal metadata folds
- lower Twig `string<?` / `string>?` through `str_cmp` plus typed comparisons
- wire literal-only `str_cmp` through LLVM, WASM, JVM, and CLR backends with focused tests
- add a seven-backend LANG matrix proof row and update E4 docs/changelogs

## Validation
- `git diff --check`
- `cargo test -p vm-core str_cmp_returns_three_way_order -q`
- `cargo test -p twig-ir-compiler string_order_literals_use_e4_str_cmp -q`
- `cargo test -p twig-aot string_literal_cmp_lowers_to_i64_const -q`
- `cargo test -p iir-to-llvm e4_string_literal_cmp_folds_to_integer_return -q`
- `cargo test -p iir-to-wasm e4_literal_str_cmp_accepted -q`
- `cargo test -p iir-to-wasm --test test_backend e4_string_cmp_lowers_to_literal_ordering -q`
- `cargo test -p iir-to-jvm-class-file str_cmp_literal_accepted -q`
- `cargo test -p iir-to-jvm-class-file --test test_backend e4_string_cmp_lowers_to_compare_to_and_signum -q`
- `cargo test -p iir-to-cil-bytecode str_cmp_literal_accepted -q`
- `cargo test -p iir-to-cil-bytecode string_literal_cmp_emits_compare_ordinal_and_sign -q`
- `cargo test -p lang-aot --test lang_matrix matrix_every_proven_cell_agrees -q`
- `cargo test -p lang-aot --test lang_matrix proven_columns_do_not_silently_skip -q`
