### PR TITLE
[codex] Add BASIC string ordering proof

### DIFF
--- a/code/packages/rust/dartmouth-basic-iir-compiler/CHANGELOG.md
+++ b/code/packages/rust/dartmouth-basic-iir-compiler/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog — `dartmouth-basic-iir-compiler`
 
+## 0.31.0 — 2026-06-28 — BA4 lexical string ordering in IF branches
+
+String `IF` now lowers the standard lexical ordering relops through the shared
+E4 `str_cmp` op:
+
+```basic
+10 LET A$ = "ALPHA"
+20 IF A$ < "BETA" THEN 40
+30 END
+40 IF "BETA" > A$ THEN 60
+50 END
+60 PRINT "OK"
+```
+
+The compiler compares the `str_cmp` result with zero using the existing typed
+`cmp_lt` / `cmp_gt` / `cmp_le` / `cmp_ge` instructions, then reuses the normal
+`jmp_if_true` line-control path. Equality and inequality continue to use
+`str_eq` plus `jmp_if_true` / `jmp_if_false`.
+
 ## 0.30.0 — 2026-06-28 — BA4 variable-variable string concat in IF equality
 
 String `IF` now has an explicit unit and matrix proof for a concatenation

--- a/code/packages/rust/dartmouth-basic-iir-compiler/Cargo.toml
+++ b/code/packages/rust/dartmouth-basic-iir-compiler/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "dartmouth-basic-iir-compiler"
-version = "0.30.0"
+version = "0.31.0"
 edition = "2021"
-description = "Dartmouth BASIC frontend for the LANG VM AOT chain — lowers parsed BASIC into interpreter_ir::IIRModule. v0.30.0 proves variable-variable string concat in IF equality on all seven backends; v0.29.0 proved variable-variable string concat in IF inequality."
+description = "Dartmouth BASIC frontend for the LANG VM AOT chain — lowers parsed BASIC into interpreter_ir::IIRModule. v0.31.0 proves BA4 lexical string ordering in IF branches on all seven backends; v0.30.0 proved variable-variable string concat in IF equality."
 
 [dependencies]
 coding-adventures-dartmouth-basic-parser = { path = "../dartmouth-basic-parser" }

--- a/code/packages/rust/dartmouth-basic-iir-compiler/README.md
+++ b/code/packages/rust/dartmouth-basic-iir-compiler/README.md
@@ -50,7 +50,9 @@ helper. String literal `PRINT`, literal-backed string variables
 (`LET A$ = "HI"` / `PRINT A$`), literal reassignment
 (`LET A$ = "NO"; LET A$ = "OK"; PRINT A$`), and `IF A$ = "Y"` / `IF A$ <> "Y"`
 string branches now lower through the shared E4 path on all seven matrix
-backends. Literal `+` concatenation (`LET A$ = "O" + "K"; PRINT A$`) uses E4
+backends. Lexical string ordering in `IF` (`A$ < "B"` / `"B" > A$`) lowers
+through E4 `str_cmp` plus typed zero comparisons on the same targets. Literal
+`+` concatenation (`LET A$ = "O" + "K"; PRINT A$`) uses E4
 `str_concat` on the same backends, and literal-backed scalar string copies
 (`LET A$ = "OK"; LET B$ = A$; PRINT B$`) reuse that E4 path with an empty
 suffix. Copied slots can participate in control flow too (`IF B$ = A$ THEN ...`).
@@ -95,8 +97,8 @@ synthetic recursive helper that renders digits one at a time via the universal
 inserts a space (`PRINT 4, 2` ⇒ `4 2`), and a trailing separator suppresses the
 line-ending newline.  Because the helpers reuse only ops every backend already
 runs, BA2 needed **zero** backend changes.  String literal/scalar string
-printing, literal concat, equality/inequality branches, and literal reassignment
-now use E4 on all seven backends.
+printing, literal concat, equality/inequality/order branches, and literal
+reassignment now use E4 on all seven backends.
 (`,` is a single space rather than a true 14-column print zone — a documented,
 deferred approximation.)
 

--- a/code/packages/rust/dartmouth-basic-iir-compiler/src/lib.rs
+++ b/code/packages/rust/dartmouth-basic-iir-compiler/src/lib.rs
@@ -905,21 +905,39 @@ impl Compiler {
                 return Err(CompileError::Unsupported(
                     "mixed string/numeric IF comparison".into()));
             };
-            let branch_op = match cmp_op {
-                "cmp_eq" => "jmp_if_true",
-                "cmp_ne" => "jmp_if_false",
+            let target_line = extract_if_target(stmt)?;
+            match cmp_op {
+                "cmp_eq" | "cmp_ne" => {
+                    let branch_op = if cmp_op == "cmp_eq" {
+                        "jmp_if_true"
+                    } else {
+                        "jmp_if_false"
+                    };
+                    let cond = self.fresh_temp();
+                    self.emit("str_eq", Some(&cond),
+                        vec![Operand::Var(lhs), Operand::Var(rhs)], "i64");
+                    self.emit(branch_op, None,
+                        vec![Operand::Var(cond), Operand::Var(format!("line_{target_line}"))],
+                        "void");
+                }
+                "cmp_lt" | "cmp_le" | "cmp_gt" | "cmp_ge" => {
+                    let ordering = self.fresh_temp();
+                    self.emit("str_cmp", Some(&ordering),
+                        vec![Operand::Var(lhs), Operand::Var(rhs)], "i64");
+                    let zero = self.fresh_temp();
+                    self.emit("const", Some(&zero), vec![Operand::Int(0)], "i64");
+                    let cond = self.fresh_temp();
+                    self.emit(cmp_op, Some(&cond),
+                        vec![Operand::Var(ordering), Operand::Var(zero)], "i64");
+                    self.emit("jmp_if_true", None,
+                        vec![Operand::Var(cond), Operand::Var(format!("line_{target_line}"))],
+                        "void");
+                }
                 _ => {
                     return Err(CompileError::Unsupported(
-                        "string IF comparisons currently support `=` and `<>` only".into()))
+                        "unsupported string IF comparison".into()))
                 }
-            };
-            let cond = self.fresh_temp();
-            self.emit("str_eq", Some(&cond),
-                vec![Operand::Var(lhs), Operand::Var(rhs)], "i64");
-            let target_line = extract_if_target(stmt)?;
-            self.emit(branch_op, None,
-                vec![Operand::Var(cond), Operand::Var(format!("line_{target_line}"))],
-                "void");
+            }
             return Ok(());
         }
 
@@ -1816,7 +1834,7 @@ fn numeric_scalar_variable_name(var: &GrammarASTNode)
     let name = scalar_variable_name(var)?;
     if is_basic_string_name(&name) {
         return Err(CompileError::Unsupported(format!(
-            "string variable `{name}` is only supported in literal assignment, PRINT, and IF equality/inequality")));
+            "string variable `{name}` is only supported in literal assignment, PRINT, and IF string comparisons")));
     }
     Ok(name)
 }
@@ -3010,6 +3028,66 @@ mod tests {
             "IF A$ <> literal should reuse E4 str_eq");
         assert!(body.iter().any(|i| i.op == "jmp_if_false"),
             "string inequality should branch when str_eq is false");
+    }
+
+    #[test]
+    fn compiles_string_variable_if_ordering() {
+        let src = "10 LET A$ = \"ALPHA\"\n\
+                   20 IF A$ < \"BETA\" THEN 50\n\
+                   30 PRINT \"BAD\"\n\
+                   40 END\n\
+                   50 IF \"BETA\" > A$ THEN 80\n\
+                   60 PRINT \"BAD\"\n\
+                   70 END\n\
+                   80 PRINT \"OK\"\n\
+                   90 END\n";
+        let m = compile(src).expect("ok");
+        let body = &m.functions[0].instructions;
+        assert_eq!(
+            body.iter().filter(|i| i.op == "str_cmp").count(),
+            2,
+            "strict string ordering should lower through E4 str_cmp twice"
+        );
+        assert!(body.iter().any(|i| i.op == "cmp_lt"
+            && i.type_hint == "i64"
+            && matches!(i.srcs.as_slice(), [
+                Operand::Var(ordering),
+                Operand::Var(zero)
+            ] if body.iter().any(|j| j.dest.as_deref() == Some(ordering.as_str()) && j.op == "str_cmp")
+                && body.iter().any(|j| j.dest.as_deref() == Some(zero.as_str())
+                    && j.op == "const"
+                    && matches!(j.srcs.first(), Some(Operand::Int(0)))))),
+            "A$ < literal should compare str_cmp output with zero");
+        assert!(body.iter().any(|i| i.op == "cmp_gt" && i.type_hint == "i64"),
+            "literal > A$ should use the existing numeric cmp_gt over str_cmp");
+        assert!(
+            body.iter().filter(|i| i.op == "jmp_if_true").count() >= 2,
+            "strict string ordering should branch when the ordering predicate is true"
+        );
+    }
+
+    #[test]
+    fn compiles_string_variable_if_inclusive_ordering() {
+        let src = "10 LET A$ = \"BETA\"\n\
+                   20 IF A$ <= \"BETA\" THEN 50\n\
+                   30 PRINT \"BAD\"\n\
+                   40 END\n\
+                   50 IF \"BETA\" >= A$ THEN 80\n\
+                   60 PRINT \"BAD\"\n\
+                   70 END\n\
+                   80 PRINT \"OK\"\n\
+                   90 END\n";
+        let m = compile(src).expect("ok");
+        let body = &m.functions[0].instructions;
+        assert_eq!(
+            body.iter().filter(|i| i.op == "str_cmp").count(),
+            2,
+            "inclusive string ordering should lower through E4 str_cmp twice"
+        );
+        assert!(body.iter().any(|i| i.op == "cmp_le" && i.type_hint == "i64"),
+            "A$ <= literal should compare str_cmp output with zero");
+        assert!(body.iter().any(|i| i.op == "cmp_ge" && i.type_hint == "i64"),
+            "literal >= A$ should compare str_cmp output with zero");
     }
 
     #[test]

--- a/code/packages/rust/lang-aot/CHANGELOG.md
+++ b/code/packages/rust/lang-aot/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog — `lang-aot`
 
+## 0.150.0 — 2026-06-28 — BASIC lexical string ordering on all seven backends (LANG-FULL BA4)
+
+The matrix now proves Dartmouth BASIC `$` string ordering branches through the
+shared E4 `str_cmp` op:
+
+```basic
+10 LET A$ = "ALPHA"
+20 IF A$ < "BETA" THEN 40
+30 END
+40 IF "BETA" > A$ THEN 60
+50 END
+60 PRINT "OK"
+```
+
+Expected stdout is `OK` on native-AOT + LLVM + WASM + JVM + CLR + VM + JIT.
+`dartmouth-basic-iir-compiler` 0.31.0 lowers the string ordering result to
+typed zero comparisons before reusing the standard BASIC line-control branch.
+
 ## 0.149.0 — 2026-06-28 — Twig lexical string ordering on all seven backends (LANG-FULL E4)
 
 The matrix now proves nested `string<?` and `string>?` predicates via the shared

--- a/code/packages/rust/lang-aot/Cargo.toml
+++ b/code/packages/rust/lang-aot/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "lang-aot"
-version = "0.147.0"
+version = "0.150.0"
 edition = "2021"
-description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, and McCarthy Lisp to native executables through the shared IIR pipeline.  v0.146.0 (LANG-FULL E4): `tests/lang_matrix.rs` proves Twig lexical `string-append` / `str_concat` feeding `string-ref` / `str_index` on native/LLVM/WASM/JVM/CLR/VM/JIT.  v0.145.0 proved BASIC variable-variable string concat in IF equality."
+description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, and McCarthy Lisp to native executables through the shared IIR pipeline.  v0.150.0 (LANG-FULL BA4): `tests/lang_matrix.rs` proves BASIC lexical string ordering in IF branches on native/LLVM/WASM/JVM/CLR/VM/JIT.  v0.149.0 proved Twig lexical string ordering."
 
 [dependencies]
 twig-aot              = { path = "../twig-aot" }

--- a/code/packages/rust/lang-aot/tests/lang_matrix.rs
+++ b/code/packages/rust/lang-aot/tests/lang_matrix.rs
@@ -1358,6 +1358,17 @@ const PROGRAMS: &[Prog] = &[
         expect: Expect::Stdout("OK"),
         backends: &[NativeAot, Llvm, Wasm, Jvm, Clr, Vm, Jit],
     },
+    // Dartmouth BASIC — BA4 lexical string ordering drives control flow. The
+    // frontend lowers `$` string `<` / `>` relops through E4 `str_cmp`, compares
+    // the ordering result with zero using typed `cmp_lt` / `cmp_gt`, and then
+    // uses the existing line-control `jmp_if_true` path.
+    Prog {
+        lang: Language::DartmouthBasic,
+        ext: "bas",
+        src: "10 LET A$ = \"ALPHA\"\n20 IF A$ < \"BETA\" THEN 40\n30 END\n40 IF \"BETA\" > A$ THEN 60\n50 END\n60 PRINT \"OK\"\n70 END\n",
+        expect: Expect::Stdout("OK"),
+        backends: &[NativeAot, Llvm, Wasm, Jvm, Clr, Vm, Jit],
+    },
     // Dartmouth BASIC — `FOR`/`NEXT` loop with an accumulator (LANG-FULL BA0). Sums
     // 1..5 into S and prints 15. FOR/NEXT lowers to `cmp_le`, which the WASM and LLVM
     // backends could not run correctly until this slice (LLVM compared at `i1` width;

--- a/code/specs/lang-full-e4-strings.md
+++ b/code/specs/lang-full-e4-strings.md
@@ -1,10 +1,10 @@
 # LANG-FULL E4 — Strings (design spec)
 
 **Status:** IR + reference VM slice implemented. BASIC BA4 literal/scalar
-strings, reassignment, equality/inequality, copied-slot equality, literal and
-variable-backed concat, expression concat in `PRINT`/`IF`, and multi-item string
-`PRINT` with `;` and `,` run on all seven backends, including `PRINT A$ + B$`
-over two scalar string slots. ALGOL AL4 literal output,
+strings, reassignment, equality/inequality, lexical ordering, copied-slot
+equality, literal and variable-backed concat, expression concat in `PRINT`/`IF`,
+and multi-item string `PRINT` with `;` and `,` run on all seven backends,
+including `PRINT A$ + B$` over two scalar string slots. ALGOL AL4 literal output,
 `output`, multi-argument `output`, scalar variables, scalar copies, and copy
 snapshots run on all seven backends. Twig
 literal, immutable top-level, and lexical-local string ops run on all seven
@@ -168,10 +168,11 @@ E4. This is the one genuinely new piece of host surface E4 adds beyond E5.
   `<>` branch paths through `str_eq` plus `jmp_if_true` / `jmp_if_false`.
   `LET B$ = A$ + "K"; PRINT B$` proves variable-backed concat
   assignment into another scalar string slot. String compares in `IF A$ = "Y"` and
-  `IF A$ <> "Y"` lower to `str_eq` (the latter branches with `jmp_if_false`) and
-  now drive line-control branching on all seven backends; string arrays, string
-  `INPUT`, captured/dynamic string storage, and broader runtime byte-string
-  operations remain follow-ups.
+  `IF A$ <> "Y"` lower to `str_eq` (the latter branches with `jmp_if_false`),
+  while `IF A$ < "B"` / `IF "B" > A$` lower through `str_cmp` plus typed zero
+  comparisons. These paths now drive line-control branching on all seven
+  backends; string arrays, string `INPUT`, captured/dynamic string storage, and
+  broader runtime byte-string operations remain follow-ups.
 - **ALGOL 60 (AL4)** — `string` is already a `type` keyword; `algol-parser`
   produces string literals. The current foothold recognises undeclared
   statement-position `print`/`output` calls and lowers string literal actuals to
@@ -275,6 +276,7 @@ merge before the next:
    assignment, concat expressions in `PRINT`/`IF` including `PRINT A$ + B$`,
    expression-backed equality branches,
    expression-backed inequality branches,
+   lexical string ordering branches,
    copied-slot equality, tight multi-item string `PRINT` (`PRINT A$; B$`), and
    comma-separated string `PRINT` (`PRINT A$, B$` => `O K`) all now run on the
    same seven backends. String arrays, string `INPUT`, captured/dynamic storage,


### PR DESCRIPTION
## Summary
- lower Dartmouth BASIC string `<`, `>`, `<=`, and `>=` IF relops through E4 `str_cmp` plus typed zero comparisons
- add compiler regression coverage for strict and inclusive string ordering
- add a LANG matrix proof for BASIC `$` string ordering on native-AOT, LLVM, WASM, JVM, CLR, VM, and JIT
- update BA4/E4 roadmap metadata and changelogs

## Validation
- `cargo test -p dartmouth-basic-iir-compiler string_variable_if`
- `cargo test -p lang-aot --test lang_matrix matrix_every_proven_cell_agrees -- --nocapture` (`548 proven cells exercised`)
- `cargo test -p lang-aot --test lang_matrix proven_columns_do_not_silently_skip -- --nocapture`
