### PR TITLE
[codex] Add smart home room detail route

### DIFF
--- a/code/packages/rust/smart-home-platform-http/CHANGELOG.md
+++ b/code/packages/rust/smart-home-platform-http/CHANGELOG.md
@@ -41,6 +41,8 @@ All notable changes to this package will be documented in this file.
   panels backed by the existing local-controller audit routes.
 - Added browser dashboard room, device, and bridge topology panels backed by
   the existing local-controller inventory routes.
+- Added a dashboard-ready room detail route and matching browser room inspect
+  action.
 - Added a browser dashboard event-log panel backed by the existing native
   runtime event stream route.
 - Added browser dashboard detail actions for history, event-log,

--- a/code/packages/rust/smart-home-platform-http/README.md
+++ b/code/packages/rust/smart-home-platform-http/README.md
@@ -39,6 +39,7 @@ stable local API responses for:
 - `/api/smart_home/bridges`
 - `/api/smart_home/bridges/:bridge_id`
 - `/api/smart_home/rooms`
+- `/api/smart_home/rooms/:room_id`
 - `/api/smart_home/scenes`
 - `/api/smart_home/scenes/:scene_id`
 - `/api/smart_home/events`
@@ -71,16 +72,17 @@ tool.
 The `GET /api/smart_home/*` routes expose dashboard-ready read models for the
 same runtime: pending-work snapshot counts, entity and capability registry
 records, a compact health probe, a capability catalog grouped across entities,
-device and bridge inventory, room topology summaries, a readiness checklist
-with actionable links, a dashboard overview, a bootstrap payload that composes
-startup links, route discovery, state gaps, and recent audit summaries, an API
-route catalog with surface/method/authorization filters, checkpointed event-log
-entries with detail lookups, a native service catalog for command affordances
-and Home Assistant target aliases, a native current-state registry with
-confidence/source/staleness filters and detail lookups, a scene registry with
-room/action projections, command-result audit records with command, bridge,
-correlation, status, and sort filters, indexed authorization decisions with
-principal, outcome, and sort filters, and desired-state supervision targets.
+device and bridge inventory, room topology summaries with detail lookups, a
+readiness checklist with actionable links, a dashboard overview, a bootstrap
+payload that composes startup links, route discovery, state gaps, and recent
+audit summaries, an API route catalog with surface/method/authorization filters,
+checkpointed event-log entries with detail lookups, a native service catalog for
+command affordances and Home Assistant target aliases, a native current-state
+registry with confidence/source/staleness filters and detail lookups, a scene
+registry with room/action projections, command-result audit records with
+command, bridge, correlation, status, and sort filters, indexed authorization
+decisions with principal, outcome, and sort filters, and desired-state
+supervision targets.
 State-history reads expose registry-backed device events with Home Assistant
 entity aliases, state deltas, timestamp filters, and event-id detail lookups;
 the Home Assistant-style history route accepts `filter_entity_id`.

--- a/code/packages/rust/smart-home-platform-http/src/lib.rs
+++ b/code/packages/rust/smart-home-platform-http/src/lib.rs
@@ -622,6 +622,8 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
         ? `/api/smart_home/services/${encodeURIComponent(domain)}/${encodeURIComponent(serviceName)}`
         : "/api/smart_home/services";
     };
+    const roomDetailUrl = (room) =>
+      `/api/smart_home/rooms/${encodeURIComponent(room.room_id)}`;
 
     const log = (message) => {
       const at = new Date().toLocaleTimeString();
@@ -703,6 +705,7 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
           </div>
           <p>${room.device_count} devices | ${room.entity_count} entities | ${room.scene_count} scenes</p>
           <p class="muted">${room.online_devices} online, ${room.scene_action_count} scene actions</p>
+          <div class="actions row">${inspectButton(roomDetailUrl(room), "room detail")}</div>
         </article>
       `).join("") || `<p class="muted">No rooms</p>`;
     };
@@ -1538,6 +1541,13 @@ pub fn home_assistant_runtime_web_app(runtime: SmartHomePlatformHttpRuntime) -> 
 
     {
         let runtime = runtime.clone();
+        app.get("/api/smart_home/rooms/:room_id", move |request| {
+            runtime_room_response(&runtime, request)
+        });
+    }
+
+    {
+        let runtime = runtime.clone();
         app.get("/api/smart_home/scenes", move |request| {
             runtime_scenes_response(&runtime, request)
         });
@@ -2268,6 +2278,15 @@ const API_ROUTE_CATALOG: &[ApiRouteDescriptor] = &[
     },
     ApiRouteDescriptor {
         method: "GET",
+        path: "/api/smart_home/rooms/:room_id",
+        category: "rooms",
+        surface: "smart_home",
+        mutates_runtime: false,
+        runtime_authorized: false,
+        query_params: &[],
+    },
+    ApiRouteDescriptor {
+        method: "GET",
         path: "/api/smart_home/scenes",
         category: "scenes",
         surface: "smart_home",
@@ -2745,6 +2764,27 @@ fn runtime_rooms_response(
         .expect("smart-home runtime mutex should not be poisoned");
     let rooms = runtime_guard.query_room_summaries_at(&query, runtime.now_ms);
     WebResponse::json(rooms_json(&rooms, &runtime_guard).into_bytes())
+}
+
+fn runtime_room_response(
+    runtime: &SmartHomePlatformHttpRuntime,
+    request: &WebRequest,
+) -> WebResponse {
+    let Some(room_id) = request.route_params.get("room_id") else {
+        return json_error(400, "missing room_id");
+    };
+    let runtime_guard = runtime
+        .runtime
+        .lock()
+        .expect("smart-home runtime mutex should not be poisoned");
+    let query = RuntimeRoomQuery::new()
+        .for_room(room_id.as_str())
+        .with_limit(1);
+    let rooms = runtime_guard.query_room_summaries_at(&query, runtime.now_ms);
+    let Some(room) = rooms.first() else {
+        return api_error_response(ApiError::not_found(format!("room `{room_id}` not found")));
+    };
+    WebResponse::json(room_json(room).into_bytes())
 }
 
 fn runtime_scenes_response(
@@ -7144,6 +7184,7 @@ mod tests {
             assert!(body.contains("entityDetailUrl(entity)"));
             assert!(body.contains("sceneDetailUrl(scene)"));
             assert!(body.contains("serviceDetailUrl(service)"));
+            assert!(body.contains("roomDetailUrl(room)"));
             assert!(
                 body.contains("/api/smart_home/devices/${encodeURIComponent(device.device_id)}")
             );
@@ -7583,6 +7624,7 @@ mod tests {
         assert!(catalog.contains(r#""path":"/api/smart_home/readiness""#));
         assert!(catalog.contains(r#""path":"/api/smart_home/dashboard""#));
         assert!(catalog.contains(r#""path":"/api/smart_home/smoke""#));
+        assert!(catalog.contains(r#""path":"/api/smart_home/rooms/:room_id""#));
         assert!(catalog.contains(r#""path":"/api/services/:domain/:service""#));
         assert!(catalog
             .contains(r#""query_params":["authorized","category","method","mutating","surface"]"#));
@@ -7866,6 +7908,20 @@ mod tests {
         assert!(body.contains(r#""scene_action_count":1"#));
         assert!(body.contains(r#""has_state_gaps":true"#));
         assert!(body.contains(r#""has_scene_actions":true"#));
+
+        let detail = response_body(
+            app.handle(request("GET", "/api/smart_home/rooms/kitchen"))
+                .into(),
+        );
+        assert!(detail.contains(r#""room_id":"kitchen""#));
+        assert!(detail.contains(r#""device_count":1"#));
+        assert!(detail.contains(r#""entity_count":2"#));
+        assert!(detail.contains(r#""scene_action_count":1"#));
+
+        let missing: web_core::WebResponse = app
+            .handle(request("GET", "/api/smart_home/rooms/missing"))
+            .into();
+        assert_eq!(missing.status, 404);
     }
 
     #[test]
@@ -8235,6 +8291,7 @@ mod tests {
         assert!(body.contains("queryUrl(\"/api/smart_home/authorization_decisions\", {"));
         assert!(body.contains("stateDetailUrl(entity)"));
         assert!(body.contains("serviceDetailUrl(service)"));
+        assert!(body.contains("roomDetailUrl(room)"));
         assert!(body.contains("/api/smart_home/devices/${encodeURIComponent(device.device_id)}"));
         assert!(body.contains("/api/services/light/"));
         assert!(body.contains("data-brightness-input"));


### PR DESCRIPTION
## Summary
- add `GET /api/smart_home/rooms/:room_id` for dashboard-ready room detail lookups
- add a browser dashboard room inspect action that opens the room detail route
- document the route and keep it listed in the API catalog

## Validation
- `cargo test -p smart-home-platform-http -- --nocapture`
- `sh BUILD` from `code/packages/rust/smart-home-platform-http`
- `git diff --check`
- removed generated `code/packages/rust/Cargo.lock`