### PR TITLE
[codex] Add ALGOL string predicate proof

### DIFF
--- a/code/packages/rust/algol-iir-compiler/CHANGELOG.md
+++ b/code/packages/rust/algol-iir-compiler/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.16.0 — 2026-06-28 — Literal-backed string predicates (LANG-FULL AL4 on E4)
+
+ALGOL 60 string comparisons now lower through the shared E4 string ops when both
+operands are string literals or literal-backed scalar string variables:
+
+```algol
+begin string s; s := 'ALPHA';
+  if (s = 'ALPHA' and s != 'OMEGA') and
+     (s < 'BETA' and 'BETA' > s) then print('OK') else print('BAD')
+end
+```
+
+`=`/`!=` use `str_eq` plus a typed zero comparison so the expression result is a
+normal boolean. Ordering operators use `str_cmp` plus the corresponding typed
+zero comparison. The slice remains intentionally fail-closed for unassigned
+strings, captured/`own` strings, arrays, parameters, and dynamic string storage.
+
 ## 0.15.0 — 2026-06-27 — Multi-argument string output proof (LANG-FULL AL4 on E4)
 
 ALGOL 60 `output` now has an explicit proof for multiple literal-backed scalar

--- a/code/packages/rust/algol-iir-compiler/Cargo.toml
+++ b/code/packages/rust/algol-iir-compiler/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "algol-iir-compiler"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
-description = "ALGOL 60 scalar frontend for the LANG VM Rust chain, lowering parsed ALGOL into interpreter_ir::IIRModule. v0.15.0 proves AL4 multi-argument output over literal-backed scalar string slots on every LANG backend; v0.14.0 proved scalar string copy snapshots."
+description = "ALGOL 60 scalar frontend for the LANG VM Rust chain, lowering parsed ALGOL into interpreter_ir::IIRModule. v0.16.0 proves AL4 string equality and ordering over literal-backed scalar string slots; v0.15.0 proved multi-argument output."
 
 [dependencies]
 coding-adventures-algol-parser = { path = "../algol-parser" }

--- a/code/packages/rust/algol-iir-compiler/README.md
+++ b/code/packages/rust/algol-iir-compiler/README.md
@@ -86,9 +86,13 @@ Literal-backed scalar copies now reuse E4 `str_concat` with an empty suffix:
 after the copy does not change the copied `t` slot. Multi-argument output over
 literal-backed scalar string variables also stays on the same path:
 `string s, t; s := 'O'; t := 'K'; output(s, t)` emits ordered `print_str`
-calls and writes `OK`. This is deliberately not a dynamic string model yet:
-unassigned string variables, captured/`own` strings, arrays, parameters, and
-non-literal string expressions still fail closed.
+calls and writes `OK`. Literal-backed scalar string predicates now lower through
+the shared E4 comparison ops too: `s = 'OK'` / `s != 'NO'` use `str_eq` plus a
+typed zero comparison, while `s < 'BETA'` / `'BETA' > s` use `str_cmp` plus the
+corresponding typed zero comparison before the normal ALGOL conditional branch.
+This is deliberately not a dynamic string model yet: unassigned string
+variables, captured/`own` strings, arrays, parameters, and non-literal string
+expressions still fail closed.
 
 `real` values lower to the IIR `f64` type and **run on the VM and JIT today**
 (LANG-FULL AL1 / enabler E3 phase 1); `2.5 * 2.0`, `7.0 / 2.0`, and real

--- a/code/packages/rust/algol-iir-compiler/src/lib.rs
+++ b/code/packages/rust/algol-iir-compiler/src/lib.rs
@@ -2428,7 +2428,20 @@ impl Compiler {
                     ty: ScalarType::Real,
                 })
             }
-            ("STRING_LIT", _) => Err(CompileError::Unsupported("string literals".into())),
+            ("STRING_LIT", _) => {
+                let slot = self.fresh_temp();
+                self.emit(IIRInstr::new(
+                    "str_const",
+                    Some(slot.clone()),
+                    vec![Operand::Str(unquote_algol_string(&token.value))],
+                    "str",
+                ));
+                self.literal_string_slots.insert(slot.clone());
+                Ok(ExprValue {
+                    slot,
+                    ty: ScalarType::String,
+                })
+            }
             ("KEYWORD", "true") => {
                 let slot = self.emit_const(ScalarType::Boolean, Operand::Bool(true));
                 Ok(ExprValue {
@@ -2635,6 +2648,75 @@ impl Compiler {
                         lhs.ty.name(),
                         rhs.ty.name()
                     )));
+                }
+                if lhs.ty == ScalarType::String {
+                    if !self.literal_string_slots.contains(&lhs.slot)
+                        || !self.literal_string_slots.contains(&rhs.slot)
+                    {
+                        return Err(CompileError::Unsupported(
+                            "string comparisons require literal-backed string operands".into(),
+                        ));
+                    }
+                    let dest = self.fresh_temp();
+                    match op {
+                        "=" | "!=" | "<>" => {
+                            let equal = self.fresh_temp();
+                            self.emit(IIRInstr::new(
+                                "str_eq",
+                                Some(equal.clone()),
+                                vec![Operand::Var(lhs.slot), Operand::Var(rhs.slot)],
+                                "i64",
+                            ));
+                            let zero = self.fresh_temp();
+                            self.emit(IIRInstr::new(
+                                "const",
+                                Some(zero.clone()),
+                                vec![Operand::Int(0)],
+                                "i64",
+                            ));
+                            let cmp_op = if op == "=" { "cmp_ne" } else { "cmp_eq" };
+                            self.emit(IIRInstr::new(
+                                cmp_op,
+                                Some(dest.clone()),
+                                vec![Operand::Var(equal), Operand::Var(zero)],
+                                "i64",
+                            ));
+                        }
+                        "<" | "<=" | ">" | ">=" => {
+                            let ordering = self.fresh_temp();
+                            self.emit(IIRInstr::new(
+                                "str_cmp",
+                                Some(ordering.clone()),
+                                vec![Operand::Var(lhs.slot), Operand::Var(rhs.slot)],
+                                "i64",
+                            ));
+                            let zero = self.fresh_temp();
+                            self.emit(IIRInstr::new(
+                                "const",
+                                Some(zero.clone()),
+                                vec![Operand::Int(0)],
+                                "i64",
+                            ));
+                            let cmp_op = match op {
+                                "<" => "cmp_lt",
+                                "<=" => "cmp_le",
+                                ">" => "cmp_gt",
+                                ">=" => "cmp_ge",
+                                _ => unreachable!(),
+                            };
+                            self.emit(IIRInstr::new(
+                                cmp_op,
+                                Some(dest.clone()),
+                                vec![Operand::Var(ordering), Operand::Var(zero)],
+                                "i64",
+                            ));
+                        }
+                        _ => unreachable!(),
+                    }
+                    return Ok(ExprValue {
+                        slot: dest,
+                        ty: ScalarType::Boolean,
+                    });
                 }
                 if lhs.ty == ScalarType::Boolean && !matches!(op, "=" | "!=" | "<>") {
                     return Err(CompileError::Type(
@@ -3607,6 +3689,60 @@ mod tests {
         let err = compile_source("begin string s, t; t := s; print(t) end", "test")
             .expect_err("unassigned string variable copies are not literal-backed");
         assert!(format!("{err:?}").contains("literal-backed string variable"));
+    }
+
+    #[test]
+    fn al4_string_equality_lowers_to_str_eq_zero_comparisons() {
+        let module = compile_source(
+            "begin string s; s := 'OK'; if s = 'OK' and s != 'NO' then print('YES') else print('NO') end",
+            "test",
+        )
+        .expect("literal-backed string equality compiles");
+        let main = module
+            .functions
+            .iter()
+            .find(|f| f.name == "main")
+            .expect("has main");
+        assert_eq!(
+            main.instructions.iter().filter(|i| i.op == "str_eq").count(),
+            2,
+            "equality and inequality should both lower through E4 str_eq"
+        );
+        assert!(
+            main.instructions.iter().any(|i| i.op == "cmp_ne" && i.type_hint == "i64"),
+            "string equality should compare str_eq output against zero"
+        );
+        assert!(
+            main.instructions.iter().any(|i| i.op == "cmp_eq" && i.type_hint == "i64"),
+            "string inequality should compare str_eq output against zero"
+        );
+    }
+
+    #[test]
+    fn al4_string_ordering_lowers_to_str_cmp_zero_comparisons() {
+        let module = compile_source(
+            "begin string s; s := 'ALPHA'; if s < 'BETA' and 'BETA' > s then print('OK') else print('BAD') end",
+            "test",
+        )
+        .expect("literal-backed string ordering compiles");
+        let main = module
+            .functions
+            .iter()
+            .find(|f| f.name == "main")
+            .expect("has main");
+        assert_eq!(
+            main.instructions.iter().filter(|i| i.op == "str_cmp").count(),
+            2,
+            "strict ordering in both operand orders should lower through E4 str_cmp"
+        );
+        assert!(
+            main.instructions.iter().any(|i| i.op == "cmp_lt" && i.type_hint == "i64"),
+            "s < literal should compare str_cmp output against zero"
+        );
+        assert!(
+            main.instructions.iter().any(|i| i.op == "cmp_gt" && i.type_hint == "i64"),
+            "literal > s should compare str_cmp output against zero"
+        );
     }
 
     // ── AL8 — standard functions (§3.2.4) ───────────────────────────────────

--- a/code/packages/rust/lang-aot/CHANGELOG.md
+++ b/code/packages/rust/lang-aot/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog — `lang-aot`
 
+## 0.151.0 — 2026-06-28 — ALGOL string predicates on all seven backends (LANG-FULL AL4)
+
+The matrix now proves ALGOL 60 literal-backed scalar string equality and
+ordering branches through the shared E4 `str_eq` / `str_cmp` ops:
+
+```algol
+begin string s; s := 'ALPHA';
+  if (s = 'ALPHA' and s != 'OMEGA') and
+     (s < 'BETA' and 'BETA' > s) then print('OK') else print('BAD')
+end
+```
+
+Expected stdout is `OK` on native-AOT + LLVM + WASM + JVM + CLR + VM + JIT.
+`algol-iir-compiler` 0.16.0 lowers the string predicate results to typed zero
+comparisons before reusing the standard ALGOL conditional branch.
+
 ## 0.150.0 — 2026-06-28 — BASIC lexical string ordering on all seven backends (LANG-FULL BA4)
 
 The matrix now proves Dartmouth BASIC `$` string ordering branches through the

--- a/code/packages/rust/lang-aot/Cargo.toml
+++ b/code/packages/rust/lang-aot/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "lang-aot"
-version = "0.150.0"
+version = "0.151.0"
 edition = "2021"
-description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, and McCarthy Lisp to native executables through the shared IIR pipeline.  v0.150.0 (LANG-FULL BA4): `tests/lang_matrix.rs` proves BASIC lexical string ordering in IF branches on native/LLVM/WASM/JVM/CLR/VM/JIT.  v0.149.0 proved Twig lexical string ordering."
+description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, and McCarthy Lisp to native executables through the shared IIR pipeline.  v0.151.0 (LANG-FULL AL4): `tests/lang_matrix.rs` proves ALGOL string equality and ordering on native/LLVM/WASM/JVM/CLR/VM/JIT.  v0.150.0 proved BASIC lexical string ordering."
 
 [dependencies]
 twig-aot              = { path = "../twig-aot" }

--- a/code/packages/rust/lang-aot/tests/lang_matrix.rs
+++ b/code/packages/rust/lang-aot/tests/lang_matrix.rs
@@ -801,6 +801,20 @@ const PROGRAMS: &[Prog] = &[
         expect: Expect::Stdout("OK"),
         backends: &[NativeAot, Llvm, Wasm, Jvm, Clr, Vm, Jit],
     },
+    // ALGOL 60 — literal-backed scalar string predicates. AL4 now lowers
+    // comparisons over string literals and literal-backed scalar variables
+    // through the shared E4 `str_eq` / `str_cmp` ops, then compares their
+    // integer results against typed zero before the normal `if` branch consumes
+    // the boolean. This row proves equality, inequality, and both ordering
+    // operand orders without widening into captured strings, arrays, or dynamic
+    // string storage.
+    Prog {
+        lang: Language::Algol60,
+        ext: "alg",
+        src: "begin string s; s := 'ALPHA'; if (s = 'ALPHA' and s != 'OMEGA') and (s < 'BETA' and 'BETA' > s) then print('OK') else print('BAD') end",
+        expect: Expect::Stdout("OK"),
+        backends: &[NativeAot, Llvm, Wasm, Jvm, Clr, Vm, Jit],
+    },
     // ALGOL 60 — the `abs` **standard function** (§3.2.4, LANG-FULL AL8). `abs`
     // is built into the language, not a user procedure, so `algol-iir-compiler`
     // resolves it by name and lowers `abs(0 - 42)` inline to the value of

--- a/code/specs/lang-full-e4-strings.md
+++ b/code/specs/lang-full-e4-strings.md
@@ -5,8 +5,9 @@ strings, reassignment, equality/inequality, lexical ordering, copied-slot
 equality, literal and variable-backed concat, expression concat in `PRINT`/`IF`,
 and multi-item string `PRINT` with `;` and `,` run on all seven backends,
 including `PRINT A$ + B$` over two scalar string slots. ALGOL AL4 literal output,
-`output`, multi-argument `output`, scalar variables, scalar copies, and copy
-snapshots run on all seven backends. Twig
+`output`, multi-argument `output`, scalar variables, scalar copies, copy
+snapshots, and literal-backed string equality/ordering predicates run on all
+seven backends. Twig
 literal, immutable top-level, and lexical-local string ops run on all seven
 backends, including `str_concat` feeding `str_index`. Captured/dynamic strings, arrays/input/parameters, and fuller backend
 byte-string representations remain.
@@ -182,8 +183,11 @@ E4. This is the one genuinely new piece of host surface E4 adds beyond E5.
   suffix. Reassigning the source after a copy leaves the target printable as a
   snapshot, matching the immutable E4 value model. `output(s, t)` over two
   literal-backed scalar strings preserves actual order through two E4
-  `print_str` calls. Captured/`own` strings, arrays, parameters, and broader
-  dynamic strings remain follow-ups.
+  `print_str` calls. Literal-backed scalar string predicates lower through E4
+  too: `s = 'OK'` / `s != 'NO'` use `str_eq` plus typed zero comparisons, while
+  `s < 'BETA'` / `'BETA' > s` use `str_cmp` plus typed zero comparisons before
+  the normal ALGOL conditional branch. Captured/`own` strings, arrays,
+  parameters, and broader dynamic strings remain follow-ups.
 - **Twig (TW4)** — Twig string literals + `print` lower to `str_const` +
   `print_str`; `++`/`string-append` to `str_concat`, `string=?` to `str_eq`,
   `string<?`/`string>?` to `str_cmp` plus typed comparisons, and `string-ref`
@@ -235,7 +239,18 @@ copy, copied-slot equality, literal/variable-backed concat, concat expressions i
 `PRINT`/`IF` including `PRINT A$ + B$`, equality/inequality branches, and multi-item string `PRINT` with
 both `;` and `,` on all seven backends. ALGOL proves literal output, the
 `output` alias, multi-argument `output`, scalar string variables, scalar copies,
-and copy snapshots on the same all-seven E4 path.
+copy snapshots, and literal-backed scalar string predicates on the same
+all-seven E4 path:
+
+```algol
+begin string s; s := 'ALPHA';
+  if (s = 'ALPHA' and s != 'OMEGA') and
+     (s < 'BETA' and 'BETA' > s) then print('OK') else print('BAD')
+end
+```
+
+The program writes `OK` through native-AOT + LLVM + WASM + JVM + CLR + VM +
+JIT.
 Follow-up proofs now focus on string arrays/input/parameters, captured or
 reassigned dynamic strings, and runtime byte-string operations beyond the current
 immutable scalar/local subset.


### PR DESCRIPTION
## Summary
- Lower ALGOL literal-backed string comparisons through shared E4 `str_eq` / `str_cmp` plus typed zero comparisons.
- Add a LANG matrix row proving ALGOL string equality, inequality, and ordering predicates across the proven backend set.
- Update AL4 package metadata, changelogs, README, and the E4 string proof ledger.

## Validation
- `cargo test -p algol-iir-compiler al4_string -- --nocapture`
- `cargo test -p lang-aot --test lang_matrix matrix_every_proven_cell_agrees -- --nocapture` (`550 proven cells exercised`)
- `git diff --check`

## Local note
- `cargo test -p lang-aot --test lang_matrix proven_columns_do_not_silently_skip -- --nocapture` still fails locally on macOS native-AOT for the first existing ALGOL native row with `AotError(BackendRefused { function: "main" })`; the proven-cell matrix passes by skipping that unavailable local native cell.