### PR TITLE
[codex] Classify full E4 string opcode surface

### DIFF
--- a/code/packages/rust/interpreter-ir/CHANGELOG.md
+++ b/code/packages/rust/interpreter-ir/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog — interpreter-ir
 
+## [0.10.0] — 2026-06-28 (LANG-FULL E4 — string opcode classification truth-up)
+
+The shared opcode taxonomy now covers the full E4 string surface that later
+backend/frontend slices have already implemented and matrix-proven:
+
+- `is_string_op(op)` recognises `str_slice` and `str_cmp` in addition to the
+  original literal/length/index/concat/equality/output ops.
+- `str_slice` and `str_cmp` are value-producing, so generic passes no longer
+  miss them when scanning for destination-producing string work.
+- `str_slice` is marked allocating, matching the immutable string contract: it
+  produces a fresh string value just like `str_concat`.
+
 ## [0.9.0] — 2026-06-27 (LANG-FULL E4 — string op taxonomy, VM slice)
 
 Defines the shared string type helper and six E4 string opcodes for downstream

--- a/code/packages/rust/interpreter-ir/Cargo.toml
+++ b/code/packages/rust/interpreter-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "interpreter-ir"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 description = "InterpreterIR (IIR) — the bytecode for the LANG JIT/AOT pipeline"
 

--- a/code/packages/rust/interpreter-ir/README.md
+++ b/code/packages/rust/interpreter-ir/README.md
@@ -28,7 +28,7 @@ Source
 | `IIRModule` | Top-level container: functions + entry point + language tag |
 | `IIRFunction` | Named, parameterised sequence of `IIRInstr` |
 | `IIRInstr` | One instruction: `op`, `dest`, `srcs`, `type_hint`, profiling fields |
-| `Operand` | Instruction operand: `Var(name)`, `Int`, `Float`, or `Bool` |
+| `Operand` | Instruction operand: `Var(name)`, `Int`, `Float`, `Bool`, or `Str` |
 | `SlotState` | Per-instruction type-feedback slot (V8 Ignition–style) |
 | `FunctionTypeStatus` | `FullyTyped` / `PartiallyTyped` / `Untyped` |
 
@@ -49,6 +49,7 @@ Standard opcodes (handled by `vm-core`):
 | Flat memory / I/O | `load_mem store_mem io_in io_out` |
 | Calls | `call call_builtin` |
 | Type system | `cast type_assert` |
+| Strings | `str_const str_len str_index str_concat str_slice str_eq str_cmp print_str` |
 
 Type strings: `u8 u16 u32 u64 i8 i16 i32 i64 bool f32 f64 str void any`
 
@@ -127,4 +128,4 @@ src/
 cargo test -p interpreter-ir
 ```
 
-38 unit tests + 11 doctests, all green.
+86 unit tests + 37 doctests, all green.

--- a/code/packages/rust/interpreter-ir/src/opcodes.rs
+++ b/code/packages/rust/interpreter-ir/src/opcodes.rs
@@ -209,11 +209,12 @@ pub fn is_array_op(op: &str) -> bool {
 // String opcode helpers (LANG-FULL E4)
 // ---------------------------------------------------------------------------
 //
-// A v1 string is an immutable byte sequence. `str_index` and `str_len` operate
-// on byte positions/counts, `str_eq` returns an i64-style truth value (1/0), and
-// `print_str` is a side-effecting stdout primitive with no implicit newline.
+// A v1 string is an immutable byte sequence. `str_index`, `str_slice`, and
+// `str_len` operate on byte positions/counts, `str_eq` returns an i64-style
+// truth value (1/0), `str_cmp` returns a normalized lexical ordering (-1/0/1),
+// and `print_str` is a side-effecting stdout primitive with no implicit newline.
 
-/// Return `true` if `op` is one of the six LANG-FULL E4 string opcodes.
+/// Return `true` if `op` is one of the LANG-FULL E4 string opcodes.
 ///
 /// ```
 /// use interpreter_ir::opcodes::is_string_op;
@@ -223,7 +224,8 @@ pub fn is_array_op(op: &str) -> bool {
 pub fn is_string_op(op: &str) -> bool {
     matches!(
         op,
-        "str_const" | "str_len" | "str_index" | "str_concat" | "str_eq" | "print_str"
+        "str_const" | "str_len" | "str_index" | "str_concat" | "str_slice"
+            | "str_eq" | "str_cmp" | "print_str"
     )
 }
 
@@ -412,7 +414,9 @@ pub fn is_value_producing(op: &str) -> bool {
                 | "str_len"
                 | "str_index"
                 | "str_concat"
+                | "str_slice"
                 | "str_eq"
+                | "str_cmp"
                 // Global variable read (LANG32)
                 | "global_load"
                 // Numeric conversions integer↔real (LANG-FULL E8)
@@ -512,6 +516,7 @@ pub fn is_allocating(op: &str) -> bool {
         "alloc" | "box" | "safepoint"
             // Runtime-built strings allocate a fresh immutable byte buffer.
             | "str_concat"
+            | "str_slice"
             // Array allocation (LANG-FULL E5)
             | "alloc_array"
             // Closure allocation (LANG34)
@@ -949,7 +954,15 @@ mod tests {
 
     #[test]
     fn string_ops_are_classified() {
-        for op in &["str_const", "str_len", "str_index", "str_concat", "str_eq"] {
+        for op in &[
+            "str_const",
+            "str_len",
+            "str_index",
+            "str_concat",
+            "str_slice",
+            "str_eq",
+            "str_cmp",
+        ] {
             assert!(is_string_op(op), "{op}");
             assert!(is_value_producing(op), "{op}");
             assert!(is_known_op(op), "{op}");
@@ -958,6 +971,7 @@ mod tests {
         assert!(has_side_effects("print_str"));
         assert!(!is_value_producing("print_str"));
         assert!(is_allocating("str_concat"));
+        assert!(is_allocating("str_slice"));
         assert!(is_str_type(STR_TYPE));
         assert!(!is_str_type("array<u8>"));
     }

--- a/code/specs/LANG-FULL-IMPLEMENTATION.md
+++ b/code/specs/LANG-FULL-IMPLEMENTATION.md
@@ -9,12 +9,12 @@ program per language**, and each frontend is a **deliberate subset**:
 
 | Language | What the matrix actually runs end-to-end on the code-gen backends | The subset gap |
 |---|---|---|
-| Twig | `42`, variadic arithmetic, top-level value `define`, and typed E4 string literal/named/local proofs | rich Lisp frontend; lists/lambdas/dynamic globals/records/symbols still need E5/E6, and captured/reassigned strings stay on the dynamic path |
+| Twig | `42`, variadic arithmetic, top-level value `define`, and typed E4 string literal/named/local proofs, including substring/index and lexical ordering | rich Lisp frontend; lists/lambdas/dynamic globals/records/symbols still need E5/E6, and captured/reassigned strings stay on the dynamic path |
 | Nib | typed calls, `*`/`/`, `for`, bitwise, short-circuit logic, logical `!`, consts, const/static-expression folding, wrap/sat arithmetic, and module `static`s all run on all 7 backends | BCD semantics and Intel-4004 RAM mapping remain |
 | Brainfuck | 1-loop "print A", nested-loop multiply (`"HA"`), two sequential loops (`"OK"`), stdin echo/transform, and canonical cat all run on all 7 backends | all 8 ops are cross-backend-proven by B1/B1-stdin/B1-eof; no current BF subset gap remains beyond adding more regression programs |
-| Dartmouth BASIC | `PRINT 42`, `PRINT "HELLO"` on all 7 backends, `GOSUB`/`RETURN`, arrays, data, functions, scalar real arithmetic, historical real formatting | literal-backed string variables, literal reassignment, literal `+` concat, variable-backed and chained concat assignment, `PRINT`/`IF` string concat expressions, multi-item string `PRINT` with `;` and `,`, literal-backed scalar string copy, copied-slot string equality, and `IF A$ =/<> "Y"` string branches ✅ (BA4/E4); integer-literal `^` ✅ (BA-^); richer string ops and general runtime-math `^` remain; `FOR`/`NEXT`, `IF`/`GOTO`, `DEF FN` (BA5), `DIM` real arrays (BA3/BA7), `READ`/`DATA`/`RESTORE` over real data (BA6/BA7), `GOSUB`/`RETURN` (BA1), and BA7 `f64` arithmetic/formatting all run on every backend |
+| Dartmouth BASIC | `PRINT 42`, `PRINT "HELLO"` on all 7 backends, `GOSUB`/`RETURN`, arrays, data, functions, scalar real arithmetic, historical real formatting | literal-backed string variables, literal reassignment, literal `+` concat, variable-backed and chained concat assignment, `PRINT`/`IF` string concat expressions, multi-item string `PRINT` with `;` and `,`, literal-backed scalar string copy, copied-slot string equality, and equality/inequality/lexical-ordering string branches ✅ (BA4/E4); integer-literal `^` ✅ (BA-^); string arrays/input and general runtime-math `^` remain; `FOR`/`NEXT`, `IF`/`GOTO`, `DEF FN` (BA5), `DIM` real arrays (BA3/BA7), `READ`/`DATA`/`RESTORE` over real data (BA6/BA7), `GOSUB`/`RETURN` (BA1), and BA7 `f64` arithmetic/formatting all run on every backend |
 | Oct | `let`/`if` | rejects **all 10 Intel-8008 intrinsics** (its raison d'être); `&&`/`||` short-circuit ✅ (O1), u8 wrap + `~` ✅ (O2), `static` module globals ✅ (O3), logical `!` ✅ (O-!); intrinsics remain |
-| ALGOL 60 | `result := 17 mod 5` → 2 | `integer`/`real`/`boolean` scalars, typed procedures, switches, 1-D arrays, `own` static-lifetime variables ✅ (AL6, all 7 backends), `abs`/`sign`/`entier` standard functions ✅ (AL8 + E8, all 7 backends), literal `print`/`output` string I/O ✅, literal-backed string variables, scalar copy snapshots, and multi-argument string `output` ✅ (AL4 foothold); no call-by-name, dynamic string variables/arrays, or multidim arrays |
+| ALGOL 60 | `result := 17 mod 5` → 2 | `integer`/`real`/`boolean` scalars, typed procedures, switches, 1-D arrays, `own` static-lifetime variables ✅ (AL6, all 7 backends), `abs`/`sign`/`entier` standard functions ✅ (AL8 + E8, all 7 backends), literal `print`/`output` string I/O ✅, literal-backed string variables, scalar copy snapshots, multi-argument string `output`, and literal-backed string equality/ordering predicates ✅ (AL4 foothold); no call-by-name, dynamic string variables/arrays, or multidim arrays |
 
 **Goal of this campaign:** make every language a *full* implementation —
 every construct in its grammar lowered to the shared IIR, running correctly on
@@ -204,8 +204,8 @@ multiple languages; close an enabler before the features that depend on it.
     later follow-up; the real-CLR path is textual.)
 - **E4 — Strings.** ◑ *IR + reference VM slice landed; see
   **[`lang-full-e4-strings.md`](lang-full-e4-strings.md)** for the full backend plan.*
-  An IIR string value model (six ops: `str_const`, `str_len`, `str_index`,
-  `str_concat`, `str_eq`, `print_str`) + per-backend support, lowered to all 7 backends and
+  An IIR string value model (`str_const`, `str_len`, `str_index`, `str_concat`,
+  `str_slice`, `str_eq`, `str_cmp`, `print_str`) + per-backend support, lowered to all 7 backends and
   verified by RUNNING (observable via **stdout**). A v1 string is an **immutable,
   length-counted byte buffer** — it reuses the E5 array substrate (length-prefixed flat
   buffer on the static backends; native `String` / managed `(array i8)` on the managed
@@ -224,7 +224,9 @@ multiple languages; close an enabler before the features that depend on it.
   while `(let ((a "AB") (b "CDE") (i 3)) (string-ref (string-append a b) i))`
   returns `68` by feeding a concat temporary into `str_index`, and
   `(let ((s "ABCDE")) (string-ref s (- (string-length s) 1)))` returns `69`
-  by feeding `str_len` through typed arithmetic into `str_index`, on all 7 backends. The
+  by feeding `str_len` through typed arithmetic into `str_index`, and
+  `(let ((s "ABCDE")) (string-ref (substring s 1 4) 1))` returns `67` by
+  feeding `str_slice` into `str_index`, on all 7 backends. The
   matrix now also proves the E4 bounds contract: `(string-ref "ABC" 3)` traps on
   native-AOT + LLVM + WASM + JVM + CLR + VM + JIT. WASM owns the literal-output
   shape with a linear-memory data segment + `env.__print_str(ptr,len)`, LLVM owns
@@ -238,10 +240,12 @@ multiple languages; close an enabler before the features that depend on it.
   `begin string s, t; s := 'O'; t := 'K'; output(s, t) end` proves ordered
   multi-argument string output.
   ALGOL scalar string copies are snapshots (`begin string s, t; s := 'OK'; t := s;
-  s := 'NO'; print(t) end` still prints `OK`). BASIC also proves literal
+  s := 'NO'; print(t) end` still prints `OK`). ALGOL literal-backed scalar string
+  predicates lower through `str_eq`/`str_cmp` and run on every backend. BASIC also proves literal
   reassignment (`LET A$ = "NO"; LET A$ = "OK"; PRINT A$`) through the same slot,
   multi-item string `PRINT` (`PRINT A$; B$` and `PRINT A$, B$`), and copied-slot equality
-  (`LET A$ = "OK"; LET B$ = A$; IF B$ = A$ THEN ...`) through `str_eq`.
+  (`LET A$ = "OK"; LET B$ = A$; IF B$ = A$ THEN ...`) through `str_eq`, plus
+  lexical string ordering branches through `str_cmp`.
   Captured string variables and broader dynamic string values remain.
   Unlocks BASIC strings + string `PRINT` (BA4), ALGOL strings/I-O (AL4), Twig strings (TW4).
 - **E5 — Arrays / linear aggregates.** ✅ **COMPLETE** *(PR-1..4c — runs on all 7 backends:
@@ -544,6 +548,8 @@ backend immediately) come before the enabler-dependent items.
   `IF A$ = "Y" THEN n` / `IF A$ <> "Y" THEN n` lower to `str_eq` in the frontend
   and now drive real line-control branching on all seven backends (`OK`/`BAD`
   matrix proofs).
+  `IF A$ < "B" THEN n` / `IF "B" > A$ THEN n` lower through `str_cmp` plus typed
+  zero comparisons and also run on every backend.
   String arrays, string `INPUT`, and broader dynamic string expressions remain.
 - ✅ **BA5** — `DEF FN` single-line user functions. `DEF FNx(P) = expr` lowers to a
   sibling `IIRFunction` (one numeric param, `FullyTyped`) and `FNx(arg)` lowers to the
@@ -624,7 +630,7 @@ backend immediately) come before the enabler-dependent items.
   (`string s; s := 'HI'; print(s)`) now run the same way. The matrix also proves
   the `output(s)` spelling, multi-argument `output(s, t)`, plus literal-backed
   scalar copy snapshot semantics (`string s, t; s := 'OK'; t := s; s := 'NO';
-  print(t)`), all on
+  print(t)`), plus string equality/inequality and lexical ordering predicates, all on
   native/LLVM/WASM/JVM/CLR/VM/JIT. Captured/`own` strings, arrays, parameters,
   and broader dynamic string expressions remain.
 - ✅ **AL5** — switches (computed goto) + conditional designational expressions.
@@ -677,13 +683,14 @@ backend immediately) come before the enabler-dependent items.
 - ☐ **TW3** — list / cons ops on code-gen backends (needs **E5**/**E6**).
 - ✅ **TW4** — typed E4 strings on code-gen backends. Direct literals,
   immutable top-level string value defines, and lexical `let`/`let*` string
-  locals lower to shared `str_const`/`str_len`/`str_index`/`str_eq`/`str_concat`
+  locals lower to shared `str_const`/`str_len`/`str_index`/`str_slice`/`str_eq`/`str_cmp`/`str_concat`
   ops instead of the dynamic `call_builtin` path. **Verified by running** literal
   `string-length`/`string-ref`/`string=?`/`string-append`, named string
   concat/equality/index, the `str_index` out-of-bounds trap, local string index,
   `let*` string length, local string equality branches, and local string concat
-  plus local concat and computed `string-length` indexes feeding string indexing
-  across native/LLVM/WASM/JVM/CLR/VM/JIT
+  plus local concat, `substring`, computed `string-length` indexes feeding string
+  indexing, and lexical `string<?`/`string>?` ordering across
+  native/LLVM/WASM/JVM/CLR/VM/JIT
   (`lang_matrix.rs`). **Limits:** captured or reassigned strings and the
   dynamic-`any` string path still need **E6**/dynamic representation work.
 - ☐ **TW5** — closures / lambdas / general `call_builtin` on code-gen backends (needs **E6**).

--- a/code/specs/lang-full-e4-strings.md
+++ b/code/specs/lang-full-e4-strings.md
@@ -9,7 +9,8 @@ including `PRINT A$ + B$` over two scalar string slots. ALGOL AL4 literal output
 snapshots, and literal-backed string equality/ordering predicates run on all
 seven backends. Twig
 literal, immutable top-level, and lexical-local string ops run on all seven
-backends, including `str_concat` feeding `str_index`. Captured/dynamic strings, arrays/input/parameters, and fuller backend
+backends, including `str_concat` and `str_slice` feeding `str_index`.
+Captured/dynamic strings, arrays/input/parameters, and fuller backend
 byte-string representations remain.
 **Enabler:** E4 in [`LANG-FULL-IMPLEMENTATION.md`](LANG-FULL-IMPLEMENTATION.md).
 **Unlocks:** Dartmouth BASIC strings + string `PRINT` (BA4), ALGOL 60 strings +
@@ -66,7 +67,7 @@ representation that is natural and safe for its target.
 
 ## 2. IIR surface
 
-Seven new ops. A string value rides the `type_hint` `str`; it flows as a `Var`
+Eight string ops. A string value rides the `type_hint` `str`; it flows as a `Var`
 (a managed reference or a fat handle), exactly like an `array<T>` value.
 
 | Op | Form | Result | Semantics |
@@ -75,6 +76,7 @@ Seven new ops. A string value rides the `type_hint` `str`; it flows as a `Var`
 | `str_len` | `dest <- s` | `i64` | The **byte** length of `s`. |
 | `str_concat` | `dest <- a, b` | `str` | A new string = bytes of `a` followed by bytes of `b`. Neither input is mutated. |
 | `str_index` | `dest <- s, idx` | `i64` | **Bounds-checked** byte load: if `idx < 0 \|\| idx >= str_len(s)` → **trap**; else `dest` = the unsigned byte value `s[idx]` (0–255). |
+| `str_slice` | `dest <- s, start, end` | `str` | **Bounds-checked** byte slice `[start,end)`: invalid ranges trap; valid ranges produce a new immutable string. |
 | `str_eq` | `dest <- a, b` | `i64` (bool) | `1` if `a` and `b` have identical bytes, else `0`. |
 | `str_cmp` | `dest <- a, b` | `i64` | Lexicographic byte ordering: `-1` if `a < b`, `0` if equal, `1` if `a > b`. |
 | `print_str` | `s` | — | Write the bytes of `s` to stdout (no implicit newline). The text-I/O primitive — the string sibling of `call_builtin "print_i64"`. |
@@ -110,16 +112,16 @@ explicit `cmp idx,len` + branch-to-trap.
 
 ## 3. Per-backend representation
 
-| Backend | Family | Representation | `str_const` | `str_len` | `str_eq` | `str_cmp` | `str_index` | `str_concat` | `print_str` |
-|---|---|---|---|---|---|---|---|---|---|
-| **vm-core** | (interp) | `Value::Str(Vec<u8>)` (new value variant) or a handle into `memory` | intern the literal bytes | `.len()` | byte equality | byte ordering | range-checked byte index | allocate a new buffer | write bytes to the host stdout sink |
-| **jit-core** | (interp) | same as vm-core (CIR mirrors it) | — | — | — | — | — | — | — |
-| **JVM** | GC | `java.lang.String` for the landed literal-output/metadata/index slice; byte-string representation still under E4-managed | `ldc` string CP entry ✅ for ASCII literals | `String.length()` ✅ for ASCII literals | `String.equals(Object)` ✅ for ASCII literals | `String.compareTo` + `Integer.signum` ✅ | `String.charAt(I)` ✅ for ASCII literals | `String.concat(String)` ✅ for ASCII literals | `PrintStream.print(String)` ✅ |
-| **CLR** | GC | `System.String` for the landed literal-output/metadata/index slice; byte-string representation still under E4-managed | `ldstr "…"` ✅ for ASCII literals | `String.Length` ✅ for ASCII literals | `String.Equals(string,string)` ✅ for ASCII literals | `String.CompareOrdinal` + `Math.Sign` ✅ | `String.get_Chars(int32)` ✅ for ASCII literals | `String.Concat(string,string)` ✅ for ASCII literals | `Console.Write(string)` ✅ |
-| **WASM** | linear-memory foothold now; WasmGC later | `i32` pointer into a data segment for the landed literal-output/metadata/index slice; richer byte-string representation still under E4-managed | data segment ✅ for ASCII literals | literal side-table length ✅ | literal side-table byte equality ✅ | literal side-table ordering ✅ | guarded `i32.load8_u` ✅ for ASCII literals | literal data entry ✅ | host import `env.__print_str(ptr,len)` ✅ |
-| **LLVM** | static | length-prefixed buffer `[i64 len][bytes…]`; literals in a `private constant` global | private `{len,bytes}` global ✅ for ASCII literals | literal side-table length ✅ | literal side-table byte equality ✅ | literal side-table ordering ✅ | folded literal byte ✅ | literal metadata ✅ | `@__print_str(i8* base+8, i64 len)` C-runtime ✅ |
-| **x86_64** | static | heap-byte literal-output foothold now; full length-prefixed rodata model later | `alloc_bytes` + `store_byte` ✅ for ASCII literals | folded literal length ✅ | folded literal equality ✅ | folded literal ordering ✅ | folded literal byte ✅ | folded literal concat ✅ | `call __twig_print_string(ptr,len)` ✅ |
-| **aarch64** | static | heap-byte literal-output foothold now; full length-prefixed rodata model later | `alloc_bytes` + `store_byte` ✅ for ASCII literals | folded literal length ✅ | folded literal equality ✅ | folded literal ordering ✅ | folded literal byte ✅ | folded literal concat ✅ | `bl __twig_print_string(ptr,len)` ✅ |
+| Backend | Family | Representation | `str_const` | `str_len` | `str_eq` | `str_cmp` | `str_index` | `str_concat` | `str_slice` | `print_str` |
+|---|---|---|---|---|---|---|---|---|---|---|
+| **vm-core** | (interp) | `Value::Str(Vec<u8>)` (new value variant) or a handle into `memory` | intern the literal bytes | `.len()` | byte equality | byte ordering | range-checked byte index | allocate a new buffer | allocate a sliced buffer | write bytes to the host stdout sink |
+| **jit-core** | (interp) | same as vm-core (CIR mirrors it) | — | — | — | — | — | — | — | — |
+| **JVM** | GC | `java.lang.String` for the landed literal-output/metadata/index slice; byte-string representation still under E4-managed | `ldc` string CP entry ✅ for ASCII literals | `String.length()` ✅ for ASCII literals | `String.equals(Object)` ✅ for ASCII literals | `String.compareTo` + `Integer.signum` ✅ | `String.charAt(I)` ✅ for ASCII literals | `String.concat(String)` ✅ for ASCII literals | `String.substring(II)` ✅ for ASCII literals | `PrintStream.print(String)` ✅ |
+| **CLR** | GC | `System.String` for the landed literal-output/metadata/index slice; byte-string representation still under E4-managed | `ldstr "…"` ✅ for ASCII literals | `String.Length` ✅ for ASCII literals | `String.Equals(string,string)` ✅ for ASCII literals | `String.CompareOrdinal` + `Math.Sign` ✅ | `String.get_Chars(int32)` ✅ for ASCII literals | `String.Concat(string,string)` ✅ for ASCII literals | `String.Substring(int32,int32)` ✅ for ASCII literals | `Console.Write(string)` ✅ |
+| **WASM** | linear-memory foothold now; WasmGC later | `i32` pointer into a data segment for the landed literal-output/metadata/index slice; richer byte-string representation still under E4-managed | data segment ✅ for ASCII literals | literal side-table length ✅ | literal side-table byte equality ✅ | literal side-table ordering ✅ | guarded `i32.load8_u` ✅ for ASCII literals | literal data entry ✅ | literal side-table slice ✅ | host import `env.__print_str(ptr,len)` ✅ |
+| **LLVM** | static | length-prefixed buffer `[i64 len][bytes…]`; literals in a `private constant` global | private `{len,bytes}` global ✅ for ASCII literals | literal side-table length ✅ | literal side-table byte equality ✅ | literal side-table ordering ✅ | folded literal byte ✅ | literal metadata ✅ | literal metadata slice ✅ | `@__print_str(i8* base+8, i64 len)` C-runtime ✅ |
+| **x86_64** | static | heap-byte literal-output foothold now; full length-prefixed rodata model later | `alloc_bytes` + `store_byte` ✅ for ASCII literals | folded literal length ✅ | folded literal equality ✅ | folded literal ordering ✅ | folded literal byte ✅ | folded literal concat ✅ | folded literal slice ✅ | `call __twig_print_string(ptr,len)` ✅ |
+| **aarch64** | static | heap-byte literal-output foothold now; full length-prefixed rodata model later | `alloc_bytes` + `store_byte` ✅ for ASCII literals | folded literal length ✅ | folded literal equality ✅ | folded literal ordering ✅ | folded literal byte ✅ | folded literal concat ✅ | folded literal slice ✅ | `bl __twig_print_string(ptr,len)` ✅ |
 
 **Unmanaged header layout** (LLVM / x86_64 / aarch64): identical to E5's array
 header — word 0 is the byte count, bytes start at offset 8. String literals are
@@ -193,7 +195,8 @@ E4. This is the one genuinely new piece of host surface E4 adds beyond E5.
   `string<?`/`string>?` to `str_cmp` plus typed comparisons, and `string-ref`
   to `str_index`. Direct literals, immutable top-level values, and
   lexical `let`/`let*` locals can now feed `str_len`, `str_index`, `str_eq`, `str_cmp`, and
-  `str_concat` on all seven backends; local `string-append` results can also feed
+  `str_concat` on all seven backends; local `substring` lowers to `str_slice`,
+  and local `string-append` results can also feed
   `string-ref` directly through `str_concat` followed by `str_index`, and
   local `string-length` results can compute `string-ref` indexes through typed
   arithmetic. The dynamic-`any`, captured, and reassigned
@@ -201,7 +204,7 @@ E4. This is the one genuinely new piece of host surface E4 adds beyond E5.
   string slice here is the statically-typed subset that clears the code-gen
   validators, mirroring how E5/E6 carved a typed slice out of Twig.
 
-The frontends emit `str` values and the six ops; no backend learns anything
+The frontends emit `str` values and the shared E4 string ops; no backend learns anything
 language-specific.
 
 ---
@@ -230,7 +233,9 @@ branches, and concat: `(let ((s "ABC") (i 2)) (string-ref s i))` returns `67`,
 everywhere; `(let ((a "AB") (b "CDE") (i 3)) (string-ref (string-append a b) i))`
 returns `68`, proving a concat temporary can feed byte indexing, and
 `(let ((s "ABCDE")) (string-ref s (- (string-length s) 1)))` returns `69`,
-proving `str_len` can compute a byte-index operand. `(if (string<? "ALPHA"
+proving `str_len` can compute a byte-index operand.
+`(let ((s "ABCDE")) (string-ref (substring s 1 4) 1))` returns `67`,
+proving `str_slice` can feed byte indexing. `(if (string<? "ALPHA"
 "BETA") (if (string>? "BETA" "ALPHA") 42 0) 0)` returns `42`, proving lexical
 ordering through `str_cmp`. The matrix also covers the **bounds-trap** case: `(string-ref "ABC"
 3)` must fail closed on native-AOT + LLVM + WASM + JVM + CLR + VM + JIT.
@@ -267,7 +272,7 @@ E4 is large, so it ships as a sequence, each a `feat(lang-full): …` PR babysat
 merge before the next:
 
 0. **E4-spec** (this document) — committed specs-first, for design sign-off.
-1. ✅ **E4-ir + vm** — define the six ops + the `str` type helper in
+1. ✅ **E4-ir + vm** — define the string ops + the `str` type helper in
    `interpreter-ir`; implement them in `vm-core`: a string value model,
    `str_len`/`str_index` (bounds-checked)/`str_concat`/`str_eq`, and `print_str`
    to the host sink. Unit tests incl. an out-of-bounds trap. *No matrix Prog yet
@@ -339,6 +344,7 @@ merge before the next:
    and `(let ((a "AB") (b "CDE") (i 3)) (string-ref (string-append a b) i))`
    returns `68`, and
    `(let ((s "ABCDE")) (string-ref s (- (string-length s) 1)))` returns `69`,
+   `(let ((s "ABCDE")) (string-ref (substring s 1 4) 1))` returns `67`,
    on native-AOT + VM + JIT + LLVM + WASM + JVM + CLR. Captured/reassigned
    strings still wait for the broader dynamic representation.
 4. **E4-managed-backends** — richer WASM/JVM/CLR byte-string ops once their
@@ -350,11 +356,11 @@ merge before the next:
    this item is now the richer ops/representation slice.
 6. ✅ **E4-ops-proofs** — named-value `str_concat`+`str_len`, `str_eq` driving a
    branch, named/local `str_index`, local `str_concat` feeding `str_index`, and
-   local `str_len` computing a `str_index` operand, `str_cmp` driving lexical
-   predicates, plus the `str_index` out-of-bounds **trap** proof now run across
-   every backend.
-7. **Follow-ups beyond v1** `str_substr`;
-   captured/reassigned dynamic strings, string arrays/input/parameters in each
+   local `str_len` computing a `str_index` operand, `str_slice` feeding
+   `str_index`, `str_cmp` driving lexical predicates, plus the `str_index`
+   out-of-bounds **trap** proof now run across every backend.
+7. **Follow-ups beyond v1** captured/reassigned dynamic strings,
+   string arrays/input/parameters in each
    frontend, runtime byte-string allocation beyond the current immutable scalar
    foothold, Unicode codepoint/grapheme semantics, the dynamic-`any` Twig string
    path (needs broader E6), and string interpolation.


### PR DESCRIPTION
## Summary

- classify `str_slice` and `str_cmp` as E4 string ops in `interpreter-ir`
- mark `str_slice`/`str_cmp` as value-producing and `str_slice` as allocating
- truth up the interpreter-ir metadata plus LANG-FULL E4 roadmap/spec text for the eight-op string surface and recent BA4/AL4/TW4 proofs

## Validation

- `cargo test -p interpreter-ir`
- `git diff --check`

## Local note

- `cargo test -p lang-aot --test lang_matrix proven_columns_do_not_silently_skip -- --nocapture` still fails locally on the existing native-AOT ALGOL availability path: `native-AOT present but failed to run Algol60`. This slice does not change matrix execution or backend lowering.
