### PR TITLE
[codex] Add smart home room detail links

### DIFF
--- a/code/packages/rust/smart-home-platform-http/CHANGELOG.md
+++ b/code/packages/rust/smart-home-platform-http/CHANGELOG.md
@@ -45,6 +45,8 @@ All notable changes to this package will be documented in this file.
   action.
 - Expanded the dashboard-ready room detail route with member devices, entities,
   and scenes.
+- Added room-scoped entity/state filters and navigation links on room detail
+  responses.
 - Added a browser dashboard event-log panel backed by the existing native
   runtime event stream route.
 - Added browser dashboard detail actions for history, event-log,

--- a/code/packages/rust/smart-home-platform-http/README.md
+++ b/code/packages/rust/smart-home-platform-http/README.md
@@ -72,14 +72,15 @@ tool.
 The `GET /api/smart_home/*` routes expose dashboard-ready read models for the
 same runtime: pending-work snapshot counts, entity and capability registry
 records, a compact health probe, a capability catalog grouped across entities,
-device and bridge inventory, room topology summaries with member detail lookups,
-a readiness checklist with actionable links, a dashboard overview, a bootstrap
-payload that composes startup links, route discovery, state gaps, and recent
-audit summaries, an API route catalog with surface/method/authorization filters,
-checkpointed event-log entries with detail lookups, a native service catalog for
-command affordances and Home Assistant target aliases, a native current-state
-registry with confidence/source/staleness filters and detail lookups, a scene
-registry with room/action projections, command-result audit records with
+device and bridge inventory, room topology summaries with member detail lookups
+and room-scoped links, a readiness checklist with actionable links, a dashboard
+overview, a bootstrap payload that composes startup links, route discovery, state
+gaps, and recent audit summaries, an API route catalog with
+surface/method/authorization filters, checkpointed event-log entries with detail
+lookups, a native service catalog for command affordances and Home Assistant
+target aliases, a native current-state registry with confidence/source/staleness
+filters plus room filters and detail lookups, a scene registry with room/action
+projections, command-result audit records with
 command, bridge, correlation, status, and sort filters, indexed authorization
 decisions with principal, outcome, and sort filters, and desired-state
 supervision targets.
@@ -151,14 +152,17 @@ curl http://127.0.0.1:8123/api/smart_home/smoke
 curl 'http://127.0.0.1:8123/api/smart_home/api?surface=home_assistant&method=POST'
 curl 'http://127.0.0.1:8123/api/smart_home/api?mutating=true&authorized=true'
 curl 'http://127.0.0.1:8123/api/smart_home/states?domain=light&stale=true'
+curl 'http://127.0.0.1:8123/api/smart_home/states?room_id=kitchen&stale=true'
 curl 'http://127.0.0.1:8123/api/smart_home/states/light.entity_light_1'
 curl 'http://127.0.0.1:8123/api/smart_home/services?domain=light'
 curl 'http://127.0.0.1:8123/api/smart_home/services/light/turn_on'
 curl 'http://127.0.0.1:8123/api/smart_home/entities?domain=light&commandable=true'
+curl 'http://127.0.0.1:8123/api/smart_home/entities?room_id=kitchen'
 curl 'http://127.0.0.1:8123/api/smart_home/capabilities?domain=light&commandable=true'
 curl 'http://127.0.0.1:8123/api/smart_home/devices?room_id=kitchen&health=online'
 curl 'http://127.0.0.1:8123/api/smart_home/bridges?integration_id=hue&transport=lan_http'
 curl 'http://127.0.0.1:8123/api/smart_home/rooms?sort=scene_count&state_gaps_only=true'
+curl 'http://127.0.0.1:8123/api/smart_home/rooms/kitchen'
 curl 'http://127.0.0.1:8123/api/smart_home/scenes?room_id=kitchen&scope=room'
 curl 'http://127.0.0.1:8123/api/smart_home/scenes/scene.scene_kitchen_bright'
 curl 'http://127.0.0.1:8123/api/smart_home/events?limit=12'

--- a/code/packages/rust/smart-home-platform-http/src/lib.rs
+++ b/code/packages/rust/smart-home-platform-http/src/lib.rs
@@ -2154,6 +2154,7 @@ const API_ROUTE_CATALOG: &[ApiRouteDescriptor] = &[
             "has_state",
             "kind",
             "limit",
+            "room_id",
             "source",
             "stale",
         ],
@@ -2199,7 +2200,14 @@ const API_ROUTE_CATALOG: &[ApiRouteDescriptor] = &[
         surface: "smart_home",
         mutates_runtime: false,
         runtime_authorized: false,
-        query_params: &["capability_id", "commandable", "domain", "kind", "limit"],
+        query_params: &[
+            "capability_id",
+            "commandable",
+            "domain",
+            "kind",
+            "limit",
+            "room_id",
+        ],
     },
     ApiRouteDescriptor {
         method: "GET",
@@ -4683,8 +4691,9 @@ fn room_detail_json(room: &RuntimeRoomSummary, runtime: &SmartHomeRuntime, now_m
     let entities = runtime_room_entities(runtime, &room.room_id);
     let scenes = runtime_room_scenes(runtime, &room.room_id);
     format!(
-        "{{\"room\":{},\"members\":{{\"device_count\":{},\"entity_count\":{},\"scene_count\":{},\"devices\":[{}],\"entities\":[{}],\"scenes\":[{}]}}}}",
+        "{{\"room\":{},\"links\":{},\"members\":{{\"device_count\":{},\"entity_count\":{},\"scene_count\":{},\"devices\":[{}],\"entities\":[{}],\"scenes\":[{}]}}}}",
         room_json(room),
+        room_links_json(&room.room_id),
         devices.len(),
         entities.len(),
         scenes.len(),
@@ -4706,6 +4715,20 @@ fn room_detail_json(room: &RuntimeRoomSummary, runtime: &SmartHomeRuntime, now_m
     )
 }
 
+fn room_links_json(room_id: &str) -> String {
+    let room = url_component(room_id);
+    format!(
+        "{{\"self\":{},\"rooms\":{},\"devices\":{},\"entities\":{},\"states\":{},\"state_gaps\":{},\"scenes\":{}}}",
+        json_string(format!("/api/smart_home/rooms/{room}")),
+        json_string(format!("/api/smart_home/rooms?room_id={room}")),
+        json_string(format!("/api/smart_home/devices?room_id={room}")),
+        json_string(format!("/api/smart_home/entities?room_id={room}")),
+        json_string(format!("/api/smart_home/states?room_id={room}")),
+        json_string(format!("/api/smart_home/states?room_id={room}&stale=true")),
+        json_string(format!("/api/smart_home/scenes?room_id={room}")),
+    )
+}
+
 fn runtime_room_devices<'a>(runtime: &'a SmartHomeRuntime, room_id: &str) -> Vec<&'a Device> {
     let mut devices = runtime
         .registry()
@@ -4716,17 +4739,18 @@ fn runtime_room_devices<'a>(runtime: &'a SmartHomeRuntime, room_id: &str) -> Vec
     devices
 }
 
+fn entity_room_id<'a>(runtime: &'a SmartHomeRuntime, entity: &Entity) -> Option<&'a str> {
+    runtime
+        .registry()
+        .device(&entity.device_id)
+        .and_then(|device| device.room_id.as_deref())
+}
+
 fn runtime_room_entities<'a>(runtime: &'a SmartHomeRuntime, room_id: &str) -> Vec<&'a Entity> {
     let mut entities = runtime
         .registry()
         .entities()
-        .filter(|entity| {
-            runtime
-                .registry()
-                .device(&entity.device_id)
-                .and_then(|device| device.room_id.as_deref())
-                == Some(room_id)
-        })
+        .filter(|entity| entity_room_id(runtime, entity) == Some(room_id))
         .collect::<Vec<_>>();
     entities.sort_by(|left, right| left.entity_id.as_str().cmp(right.entity_id.as_str()));
     entities
@@ -5114,6 +5138,7 @@ fn runtime_entities<'a>(
     request: &WebRequest,
 ) -> Result<Vec<&'a Entity>, ApiError> {
     let domain = query_string(request, "domain");
+    let room_id = query_string(request, "room_id");
     let kind = query_string(request, "kind")
         .map(entity_kind_from_label)
         .transpose()?;
@@ -5125,6 +5150,9 @@ fn runtime_entities<'a>(
         .registry()
         .entities()
         .filter(|entity| domain.is_none_or(|domain| entity_domain(entity.kind) == domain))
+        .filter(|entity| {
+            room_id.is_none_or(|room_id| entity_room_id(runtime, entity) == Some(room_id))
+        })
         .filter(|entity| kind.is_none_or(|kind| entity.kind == kind))
         .filter(|entity| {
             capability_id.is_none_or(|capability_id| {
@@ -5152,6 +5180,7 @@ fn runtime_state_entities<'a>(
     now_ms: u64,
 ) -> Result<Vec<&'a Entity>, ApiError> {
     let domain = query_string(request, "domain");
+    let room_id = query_string(request, "room_id");
     let kind = query_string(request, "kind")
         .map(entity_kind_from_label)
         .transpose()?;
@@ -5170,6 +5199,9 @@ fn runtime_state_entities<'a>(
         .registry()
         .entities()
         .filter(|entity| domain.is_none_or(|domain| entity_domain(entity.kind) == domain))
+        .filter(|entity| {
+            room_id.is_none_or(|room_id| entity_room_id(runtime, entity) == Some(room_id))
+        })
         .filter(|entity| kind.is_none_or(|kind| entity.kind == kind))
         .filter(|entity| {
             capability_id.is_none_or(|capability_id| {
@@ -6941,6 +6973,21 @@ fn optional_str_json(value: Option<&str>) -> String {
     value.map(json_string).unwrap_or_else(|| "null".to_string())
 }
 
+fn url_component(value: &str) -> String {
+    const HEX: &[u8; 16] = b"0123456789ABCDEF";
+    let mut encoded = String::new();
+    for byte in value.bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'.' | b'_' | b'~') {
+            encoded.push(byte as char);
+        } else {
+            encoded.push('%');
+            encoded.push(HEX[(byte >> 4) as usize] as char);
+            encoded.push(HEX[(byte & 0x0f) as usize] as char);
+        }
+    }
+    encoded
+}
+
 fn json_string(value: impl AsRef<str>) -> String {
     let mut escaped = String::from("\"");
     for ch in value.as_ref().chars() {
@@ -7696,6 +7743,12 @@ mod tests {
         assert!(catalog.contains(r#""path":"/api/services/:domain/:service""#));
         assert!(catalog
             .contains(r#""query_params":["authorized","category","method","mutating","surface"]"#));
+        assert!(catalog.contains(
+            r#""path":"/api/smart_home/entities","category":"entities","surface":"smart_home","mutates_runtime":false,"runtime_authorized":false,"query_params":["capability_id","commandable","domain","kind","limit","room_id"]"#
+        ));
+        assert!(catalog.contains(
+            r#""path":"/api/smart_home/states","category":"states","surface":"smart_home","mutates_runtime":false,"runtime_authorized":false,"query_params":["capability_id","confidence","domain","has_state","kind","limit","room_id","source","stale"]"#
+        ));
         let catalog_json: JsonValue =
             serde_json::from_str(&catalog).expect("API catalog response is JSON");
         assert!(
@@ -7830,6 +7883,18 @@ mod tests {
         assert!(body.contains(r#""min":0"#));
         assert!(body.contains(r#""max":100"#));
 
+        let room_entities = response_body(
+            app.handle(request(
+                "GET",
+                "/api/smart_home/entities?room_id=kitchen&kind=sensor",
+            ))
+            .into(),
+        );
+        assert!(room_entities.contains(r#""total_entities":1"#));
+        assert!(room_entities.contains(r#""entity_id":"entity-sensor-1""#));
+        assert!(room_entities.contains(r#""room_id":"kitchen""#));
+        assert!(!room_entities.contains(r#""entity_id":"entity-light-1""#));
+
         let one_response: web_core::WebResponse = app
             .handle(request(
                 "GET",
@@ -7860,6 +7925,18 @@ mod tests {
         assert!(missing_states.contains(r#""has_state":false"#));
         assert!(missing_states.contains(r#""value":null"#));
         assert!(missing_states.contains(r#""stale":true"#));
+
+        let room_states = response_body(
+            app.handle(request(
+                "GET",
+                "/api/smart_home/states?room_id=kitchen&stale=true",
+            ))
+            .into(),
+        );
+        assert!(room_states.contains(r#""total_entities":2"#));
+        assert!(room_states.contains(r#""entities_without_state":2"#));
+        assert!(room_states.contains(r#""home_assistant_entity_id":"light.entity_light_1""#));
+        assert!(room_states.contains(r#""home_assistant_entity_id":"sensor.entity_sensor_1""#));
 
         let response: web_core::WebResponse = app
             .handle(request_with_body(
@@ -7986,6 +8063,9 @@ mod tests {
         assert!(detail.contains(r#""entity_count":2"#));
         assert!(detail.contains(r#""scene_action_count":1"#));
         assert!(detail.contains(r#""room":{"room_id":"kitchen""#));
+        assert!(detail.contains(
+            r#""links":{"self":"/api/smart_home/rooms/kitchen","rooms":"/api/smart_home/rooms?room_id=kitchen","devices":"/api/smart_home/devices?room_id=kitchen","entities":"/api/smart_home/entities?room_id=kitchen","states":"/api/smart_home/states?room_id=kitchen","state_gaps":"/api/smart_home/states?room_id=kitchen&stale=true","scenes":"/api/smart_home/scenes?room_id=kitchen"}"#
+        ));
         assert!(detail.contains(r#""members":{"device_count":1,"entity_count":2,"scene_count":1"#));
         assert!(detail.contains(r#""devices":[{"device_id":"device-1""#));
         assert!(detail.contains(


### PR DESCRIPTION
## Summary
- add room-scoped navigation links to `GET /api/smart_home/rooms/:room_id`
- add `room_id` filters to dashboard-ready entity and state registry routes
- expose the new filters in the API catalog and docs

## Validation
- `cargo test -p smart-home-platform-http -- --nocapture`
- `sh BUILD` from `code/packages/rust/smart-home-platform-http`
- `git diff --check`
- removed generated `code/packages/rust/Cargo.lock`