### PR TITLE
[codex] Retire fostered anchor paragraph repair

### DIFF
--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -5169,6 +5169,17 @@ impl HtmlParser {
             {
                 if !acknowledges_self_closing && !is_void {
                     self.open_elements.push(path);
+                    for (formatting_name, formatting_attributes) in formatting_inside {
+                        let child_index =
+                            self.append_node(Node::element(formatting_name, formatting_attributes));
+                        let mut path = self.current_parent_path().to_vec();
+                        path.push(child_index);
+                        if prunes_empty_formatting_inside {
+                            self.prunable_empty_reconstructed_formatting_paths
+                                .push(path.clone());
+                        }
+                        self.open_elements.push(path);
+                    }
                 }
             }
             return;
@@ -8434,7 +8445,6 @@ fn repair_div_fostered_nobr_adoption(document: &mut Document) {
 
 fn repair_tricky_adoption_agency(document: &mut Document) {
     repair_tricky_adoption_agency_in(&mut document.children);
-    repair_fostered_anchor_paragraph_continuation(&mut document.children);
     repair_insanely_badly_nested_table_sequence(&mut document.children);
 }
 
@@ -8813,53 +8823,6 @@ fn previous_sibling_carries_font_size_seven_context(node: Option<&Node>) -> bool
                     if child.name == "font" && child.attribute("size") == Some("7")
             )
         })
-}
-
-fn repair_fostered_anchor_paragraph_continuation(nodes: &mut Vec<Node>) {
-    for node in nodes.iter_mut() {
-        let Node::Element(element) = node else {
-            continue;
-        };
-        repair_fostered_anchor_paragraph_continuation(&mut element.children);
-    }
-
-    let mut index = 0;
-    while index + 2 < nodes.len() {
-        let first_paragraph_has_empty_anchor = matches!(
-            nodes.get(index),
-            Some(Node::Element(paragraph))
-                if paragraph.name == "p"
-                    && paragraph.children.len() == 1
-                    && matches!(
-                        paragraph.children.first(),
-                        Some(Node::Element(anchor)) if anchor.name == "a" && anchor.children.is_empty()
-                    )
-        );
-        let next_is_plain_paragraph = matches!(
-            nodes.get(index + 1),
-            Some(Node::Element(paragraph))
-                if paragraph.name == "p"
-                    && !paragraph.children.is_empty()
-                    && !matches!(paragraph.children.first(), Some(Node::Element(anchor)) if anchor.name == "a")
-        );
-        let followed_by_table = matches!(
-            nodes.get(index + 2),
-            Some(Node::Element(table)) if table.name == "table"
-        );
-
-        if first_paragraph_has_empty_anchor && next_is_plain_paragraph && followed_by_table {
-            let Some(Node::Element(paragraph)) = nodes.get_mut(index + 1) else {
-                index += 1;
-                continue;
-            };
-            let mut anchor = Node::element("a".to_string(), Vec::new());
-            if let Node::Element(anchor_element) = &mut anchor {
-                anchor_element.children = std::mem::take(&mut paragraph.children);
-            }
-            paragraph.children.push(anchor);
-        }
-        index += 1;
-    }
 }
 
 fn repair_insanely_badly_nested_table_sequence(nodes: &mut Vec<Node>) {

--- a/code/packages/rust/html-parser/tests/whatwg_formatting_audit_test.rs
+++ b/code/packages/rust/html-parser/tests/whatwg_formatting_audit_test.rs
@@ -6,10 +6,8 @@ use std::collections::{BTreeMap, HashMap};
 
 const TREE_CONSTRUCTION_SMOKE: &str = include_str!("fixtures/html5lib-tree-construction-smoke.dat");
 const WHATWG_FORMATTING_AUDIT: &str = include_str!("fixtures/whatwg-formatting-audit.json");
-const POST_PARSE_REPAIR_EVIDENCE: &[(&str, &str)] = &[
-    ("tricky01-dat-7", "interactive-formatting-boundary"),
-    ("tricky01-dat-8", "interactive-formatting-boundary"),
-];
+const POST_PARSE_REPAIR_EVIDENCE: &[(&str, &str)] =
+    &[("tricky01-dat-8", "interactive-formatting-boundary")];
 
 #[derive(Debug, Deserialize)]
 struct FormattingAuditSuite {


### PR DESCRIPTION
## Summary
- replay captured formatting wrappers inside fostered paragraph insertion before an open table
- remove the finish-time `repair_fostered_anchor_paragraph_continuation` post-parse repair
- retire `tricky01-dat-7` from the post-parse repair evidence list while keeping `tricky01-dat-8` as the remaining tricky-adoption repair witness

## Validation
- `cargo test -p coding-adventures-html-parser font_newline_before_bold_stays_outside_reconstructed_font`
- `cargo test -p coding-adventures-html-parser whatwg_formatting_audit_cases_match_parser_dom_dump`
- `cargo test -p coding-adventures-html-parser whatwg_paragraph_audit_cases_match_parser_dom_dump`
- `cargo test -p coding-adventures-html-parser whatwg_block_boundary_audit_cases_match_parser_dom_dump`
- `cargo test -p coding-adventures-html-parser html5lib_tree_construction_smoke_cases_match_dom_dump`
- `cargo test -p coding-adventures-html-parser`
- `cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser`
- `python3 -m json.tool code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json >/dev/null`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py`
- `git diff --check`
