### PR TITLE
[codex] Add Berkeley SPICE grammar foundation

### DIFF
--- a/code/grammars/spice/berkeley.grammar
+++ b/code/grammars/spice/berkeley.grammar
@@ -1,0 +1,89 @@
+# Berkeley SPICE logical-card parser grammar.
+# @version 1
+#
+# Input is a stream of normalized logical cards. The grammar recognizes the
+# stable card shapes and leaves device arity, model parameter legality,
+# expression evaluation, include/lib resolution, and dialect-specific behavior
+# to semantic passes.
+
+deck = { line } [ end_card ] EOF ;
+
+line = blank_line
+     | subckt_block
+     | model_card
+     | param_card
+     | func_card
+     | options_card
+     | condition_card
+     | analysis_card
+     | output_card
+     | source_card
+     | control_card
+     | unknown_directive_card
+     | element_card
+     ;
+
+blank_line = NEWLINE ;
+
+end_card = DOT_END NEWLINE ;
+
+subckt_block = subckt_card { line } ends_card ;
+subckt_card  = DOT_SUBCKT ATOM { card_item } NEWLINE ;
+ends_card    = DOT_ENDS [ ATOM ] NEWLINE ;
+
+model_card = DOT_MODEL ATOM ATOM [ parameter_list ] NEWLINE ;
+
+param_card   = DOT_PARAM { assignment } NEWLINE ;
+func_card    = DOT_FUNC function_signature card_value NEWLINE ;
+options_card = DOT_OPTIONS { option_item } NEWLINE ;
+
+condition_card = ( DOT_TEMP | DOT_IC | DOT_NODESET ) { option_item } NEWLINE ;
+
+analysis_card = ( DOT_OP
+                | DOT_DC
+                | DOT_AC
+                | DOT_TRAN
+                | DOT_TF
+                | DOT_SENS
+                | DOT_NOISE
+                | DOT_DISTO
+                | DOT_PZ
+                ) { card_item } NEWLINE ;
+
+output_card = ( DOT_PRINT
+              | DOT_PLOT
+              | DOT_SAVE
+              | DOT_PROBE
+              | DOT_MEASURE
+              | DOT_MEAS
+              | DOT_FOUR
+              ) { card_item } NEWLINE ;
+
+source_card = ( DOT_INCLUDE | DOT_LIB ) { card_item } NEWLINE ;
+
+control_card = DOT_CONTROL NEWLINE { control_line } DOT_ENDC NEWLINE ;
+control_line = { card_item } NEWLINE ;
+
+unknown_directive_card = DOT ATOM { card_item } NEWLINE ;
+
+element_card = ATOM { card_item } NEWLINE ;
+
+parameter_list = LPAREN [ option_item { [ COMMA ] option_item } ] RPAREN ;
+
+option_item = assignment | card_value | waveform_call ;
+assignment  = ATOM EQUALS card_value ;
+
+function_signature = ATOM LPAREN [ ATOM { COMMA ATOM } ] RPAREN ;
+
+waveform_call = ATOM LPAREN [ card_item { [ COMMA ] card_item } ] RPAREN ;
+
+card_item = option_item
+          | parameter_list
+          | card_value
+          ;
+
+card_value = NUMBER
+           | ATOM
+           | QUOTED_STRING
+           | BRACED_EXPR
+           ;

--- a/code/grammars/spice/berkeley.tokens
+++ b/code/grammars/spice/berkeley.tokens
@@ -1,0 +1,65 @@
+# Berkeley SPICE logical-card token grammar.
+# @version 1
+# @case_insensitive true
+#
+# This grammar targets normalized Berkeley SPICE logical cards: physical deck
+# preprocessing owns title-line capture, column-1 comments, blank physical
+# lines, and leading `+` continuations. The token stream below is therefore
+# card-oriented and deliberately preserves device/model atoms for the semantic
+# lowerer instead of trying to encode all SPICE device arity in the lexer.
+
+skip:
+  WHITESPACE = /[ \t\r]+/
+
+# Quoted and braced expressions must win before the generic ATOM token.
+QUOTED_STRING = /"([^"\\\n]|\\.)*"/
+BRACED_EXPR   = /\{[^}\n]*\}/
+
+# Berkeley/SPICE-style scalar with optional engineering suffix. Semantic
+# resolution owns suffix meaning (`m` vs `meg`, temperature units, etc.).
+NUMBER = /[+-]?(?:[0-9]+(?:\.[0-9]*)?|\.[0-9]+)(?:[eE][+-]?[0-9]+)?[a-zA-Z]*/
+
+# Known dot cards for the Berkeley compatibility base plus the already-present
+# post-1970s analysis/output footholds. These appear before DOT so `.op` is not
+# tokenized as DOT + ATOM.
+DOT_END     = ".end"
+DOT_ENDS    = ".ends"
+DOT_SUBCKT  = ".subckt"
+DOT_MODEL   = ".model"
+DOT_PARAM   = ".param"
+DOT_FUNC    = ".func"
+DOT_OPTIONS = ".options"
+DOT_TEMP    = ".temp"
+DOT_IC      = ".ic"
+DOT_NODESET = ".nodeset"
+DOT_OP      = ".op"
+DOT_DC      = ".dc"
+DOT_AC      = ".ac"
+DOT_TRAN    = ".tran"
+DOT_TF      = ".tf"
+DOT_SENS    = ".sens"
+DOT_NOISE   = ".noise"
+DOT_DISTO   = ".disto"
+DOT_PZ      = ".pz"
+DOT_PRINT   = ".print"
+DOT_PLOT    = ".plot"
+DOT_SAVE    = ".save"
+DOT_PROBE   = ".probe"
+DOT_MEASURE = ".measure"
+DOT_MEAS    = ".meas"
+DOT_FOUR    = ".four"
+DOT_INCLUDE = ".include"
+DOT_LIB     = ".lib"
+DOT_CONTROL = ".control"
+DOT_ENDC    = ".endc"
+
+LPAREN = "("
+RPAREN = ")"
+COMMA  = ","
+EQUALS = "="
+DOT    = "."
+
+# Generic card atom. This is intentionally broad because SPICE node names,
+# device names, model names, vector names, and source waveform arguments vary
+# across dialects. Semantic lowering classifies atoms by card kind.
+ATOM = /[^ \t\r\n()=,"{}]+/

--- a/code/packages/rust/grammar-tools/tests/spice_grammar_validation.rs
+++ b/code/packages/rust/grammar-tools/tests/spice_grammar_validation.rs
@@ -1,0 +1,45 @@
+use std::collections::HashSet;
+
+use grammar_tools::{
+    compiler::{compile_parser_grammar, compile_token_grammar},
+    cross_validator::cross_validate,
+    parser_grammar::{parse_parser_grammar, validate_parser_grammar},
+    token_grammar::{parse_token_grammar, token_names, validate_token_grammar},
+};
+
+const TOKENS: &str = include_str!("../../../../grammars/spice/berkeley.tokens");
+const GRAMMAR: &str = include_str!("../../../../grammars/spice/berkeley.grammar");
+
+#[test]
+fn berkeley_spice_grammar_validates_and_compiles() {
+    let token_grammar = parse_token_grammar(TOKENS).expect("parse berkeley.tokens");
+    let parser_grammar = parse_parser_grammar(GRAMMAR).expect("parse berkeley.grammar");
+
+    let token_issues = validate_token_grammar(&token_grammar);
+    assert!(
+        token_issues.is_empty(),
+        "token grammar issues:\n{}",
+        token_issues.join("\n")
+    );
+
+    let token_names: HashSet<String> = token_names(&token_grammar);
+    let parser_issues = validate_parser_grammar(&parser_grammar, Some(&token_names));
+    assert!(
+        parser_issues.is_empty(),
+        "parser grammar issues:\n{}",
+        parser_issues.join("\n")
+    );
+
+    let cross_issues = cross_validate(&token_grammar, &parser_grammar);
+    assert!(
+        cross_issues.is_empty(),
+        "cross-validation issues:\n{}",
+        cross_issues.join("\n")
+    );
+
+    let compiled_tokens = compile_token_grammar(&token_grammar, "spice/berkeley.tokens");
+    assert!(compiled_tokens.contains("pub fn token_grammar() -> TokenGrammar"));
+
+    let compiled_parser = compile_parser_grammar(&parser_grammar, "spice/berkeley.grammar");
+    assert!(compiled_parser.contains("pub fn parser_grammar() -> ParserGrammar"));
+}

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -6,6 +6,19 @@ not unlimited vendor compatibility with every HSPICE, Spectre, or ngspice
 extension. The target is a documented, cross-language, production-usable SPICE
 core with predictable gaps, stable diagnostics, and native web support.
 
+The application roadmap is staged by dialect confidence:
+
+1. Berkeley SPICE / SPICE2-SPICE3 core conformance first.
+2. ngspice compatibility as an explicit open-source dialect layer.
+3. LTspice compatibility as the later vendor-dialect and product-experience
+   target.
+
+Rust is the primary app/runtime spine for Mosaic-backed user interfaces, native
+execution, and WebAssembly packaging. Python and TypeScript remain first-class
+conformance ports: parser, solver, diagnostic, and output semantics should move
+in sync unless a workstream explicitly documents a Rust-only acceleration path
+with stable cross-language results.
+
 ## Completion Bar
 
 A workstream is complete only when the Python, Rust, and TypeScript surfaces are
@@ -13,22 +26,25 @@ aligned, package tests cover the new behavior, examples or docs explain the
 user-facing entrypoint, and text or structured outputs are stable enough for
 downstream tools to compare.
 
+No backward-compatibility promise exists for pre-release parser APIs. If the
+current parser surface conflicts with Berkeley SPICE correctness, shared grammar
+contracts, source-span diagnostics, or cross-language parity, break it and fix
+the Rust, Python, and TypeScript surfaces together.
+
 ## Current PR Slice
 
-1. Device model reference-deck audit analysis summaries.
+1. Berkeley SPICE grammar foundation.
    - Status: current PR completion candidate.
-   - Python, Rust, and TypeScript now expose
-     `device_model_reference_deck_audit_analysis_summary` /
-     `deviceModelReferenceDeckAuditAnalysisSummary` helpers plus stable
-     analysis-summary table, header-keyed records, CSV, and compact JSON
-     output.
-   - The summary condenses the reference-deck audit matrix by analysis kind,
-     preserving expected model-family order, missing-kind gaps, total deck-line
-     counts, and reference labels for release dashboards and coverage reviews.
-   - Cross-language tests lock the five expected analysis summary rows,
-     CSV/JSON exports, and a negative missing `tran:NMOS` summary case so
-     downstream consumers can audit analysis coverage without scanning every
-     fixture row.
+   - Add `code/grammars/spice/berkeley.tokens` and
+     `code/grammars/spice/berkeley.grammar` as the first shared syntax contract
+     for normalized Berkeley SPICE logical cards.
+   - The grammar intentionally parses stable card shape and preserves generic
+     card atoms. Semantic passes own device arity, model legality, expression
+     resolution, include/library loading, control policies, and dialect-specific
+     behavior.
+   - Grammar-tool tests parse, validate, cross-validate, and compile the token
+     and parser grammars so future parser rewrites can break old ad hoc parsing
+     behavior against a checked source grammar instead of guessing.
 
 ## Completed Slices
 
@@ -1387,7 +1403,16 @@ downstream tools to compare.
 
 ## Backlog
 
-1. Deck compatibility follow-up.
+1. Grammar-backed parser and app facade.
+   - Route the Rust `spice-netlist-parser` through a grammar-backed Berkeley
+     syntax layer with source spans and stable diagnostics.
+   - Mirror the resulting public parser contract in Python and TypeScript, even
+     if that breaks current pre-release parser APIs.
+   - Add a Rust app facade for Mosaic-backed UI runtimes: parse deck, report
+     diagnostics, expose analysis inventory, run selected or source-order
+     analyses, and return stable table/waveform/result artifacts.
+
+2. Deck compatibility follow-up.
    - Expand deck-owned output compatibility beyond source-order analysis
      execution and stable artifact exports toward nested sweeps, raw-format
      interoperability, and remaining vendor-style output controls.
@@ -1398,7 +1423,7 @@ downstream tools to compare.
      command routing, including control flow, variables, and script execution
      policy.
 
-2. Production solver core follow-up.
+3. Production solver core follow-up.
    - Sparse real/complex matrix paths now have cross-language native coverage,
      and Python real DC solves now use an optional SciPy sparse-LU backend with
      structured native fallback metadata.
@@ -1409,14 +1434,14 @@ downstream tools to compare.
      damping, device limiting, tolerance policy, and additional convergence
      diagnostics for difficult transistor decks.
 
-3. Device model depth.
+4. Device model depth.
    - Audit diode, BJT, JFET, and MOS Level 1 behavior against reference decks.
    - Decide whether Level 2/3 MOS is in scope before BSIM; if BSIM lands, make
      Rust the first fast path and port stable semantics outward.
    - Expand temperature behavior, capacitance, noise, charge conservation, model
      card aliases, and error messages.
 
-4. Analysis completion.
+5. Analysis completion.
    - Generalize pole-zero beyond constrained fixture helpers.
    - Expand nonlinear distortion coverage.
    - Expand parsed `.FOUR` / `.MEASURE` integration across output plans and
@@ -1425,14 +1450,14 @@ downstream tools to compare.
      Carlo trials.
    - Stabilize raw, CSV, JSON, and browser-friendly result formats.
 
-5. Mixed-signal integration.
+6. Mixed-signal integration.
    - Connect SPICE transient stepping to the hardware VM scheduler.
    - Support bidirectional analog/digital thresholds, event scheduling,
      breakpoint coordination, and VCD correlation.
    - Keep mixed-signal coupling deterministic across Python, Rust, and
      TypeScript.
 
-6. Verilog-A and custom models.
+7. Verilog-A and custom models.
    - Specify the accepted model subset and residual/Jacobian hooks.
    - Add parser or compiler support with sandboxing for TypeScript/web usage.
    - Provide a Rust-native fast path for compiled models.


### PR DESCRIPTION
## Summary
- add Berkeley SPICE logical-card `.tokens` and `.grammar` sources under `code/grammars/spice/`
- validate the new grammar through grammar-tools parse, validation, cross-validation, and Rust codegen
- update the SPICE implementation plan with the Berkeley -> ngspice -> LTspice roadmap, Rust/Mosaic app spine, Python/TypeScript parity invariant, and pre-release parser breakage policy

## Validation
- `cargo test -p grammar-tools --test spice_grammar_validation`
- `cargo test -p grammar-tools`
- `git diff --check`