### PR TITLE
[codex] Track table-cell nobr repair evidence

### DIFF
--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -31282,6 +31282,48 @@ mod tests {
     }
 
     #[test]
+    fn fostered_nobr_table_cell_continuation_stays_inside_cell() {
+        let document = parse_html(
+            "<!DOCTYPE html><body><b><nobr>1<table><tr><td><nobr></b><i><nobr>2<nobr></i>3",
+        )
+        .unwrap();
+
+        let body = body(&document);
+        assert_eq!(body.children.len(), 1);
+
+        let bold = element(&body.children[0]);
+        assert_eq!(bold.name, "b");
+        let outer_nobr = element(&bold.children[0]);
+        assert_eq!(outer_nobr.name, "nobr");
+        assert_eq!(outer_nobr.children[0], Node::text("1"));
+
+        let table = element(&outer_nobr.children[1]);
+        assert_eq!(table.name, "table");
+        let table_body = element(&table.children[0]);
+        let row = element(&table_body.children[0]);
+        let cell = element(&row.children[0]);
+        assert_eq!(cell.name, "td");
+        assert_eq!(cell.children.len(), 3);
+
+        let first_nobr = element(&cell.children[0]);
+        assert_eq!(first_nobr.name, "nobr");
+        assert_eq!(element(&first_nobr.children[0]).name, "i");
+
+        let italic = element(&cell.children[1]);
+        assert_eq!(italic.name, "i");
+        let text_nobr = element(&italic.children[0]);
+        assert_eq!(text_nobr.name, "nobr");
+        assert_eq!(text_nobr.children, vec![Node::text("2")]);
+        let empty_nobr = element(&italic.children[1]);
+        assert_eq!(empty_nobr.name, "nobr");
+        assert!(empty_nobr.children.is_empty());
+
+        let trailing_nobr = element(&cell.children[2]);
+        assert_eq!(trailing_nobr.name, "nobr");
+        assert_eq!(trailing_nobr.children, vec![Node::text("3")]);
+    }
+
+    #[test]
     fn skips_fostered_anchor_reconstruction_inside_table_cells() {
         let document = parse_html(
             "<table><a href=\"blah\">aba<tr><td><a href=\"foo\">br</td></tr>x</table>aoe",

--- a/code/packages/rust/html-parser/tests/whatwg_formatting_audit_test.rs
+++ b/code/packages/rust/html-parser/tests/whatwg_formatting_audit_test.rs
@@ -6,8 +6,10 @@ use std::collections::{BTreeMap, HashMap};
 
 const TREE_CONSTRUCTION_SMOKE: &str = include_str!("fixtures/html5lib-tree-construction-smoke.dat");
 const WHATWG_FORMATTING_AUDIT: &str = include_str!("fixtures/whatwg-formatting-audit.json");
-const POST_PARSE_REPAIR_EVIDENCE: &[(&str, &str)] =
-    &[("tricky01-dat-8", "interactive-formatting-boundary")];
+const POST_PARSE_REPAIR_EVIDENCE: &[(&str, &str)] = &[
+    ("tricky01-dat-8", "interactive-formatting-boundary"),
+    ("tests26-dat-1251", "interactive-formatting-boundary"),
+];
 
 #[derive(Debug, Deserialize)]
 struct FormattingAuditSuite {


### PR DESCRIPTION
## Summary
- add a focused parser regression for the html5lib `tests26-dat-1251` table-cell `nobr` continuation shape
- extend the WHATWG formatting audit post-parse repair evidence list so the remaining table-cell fostered `nobr` repair has explicit executable coverage

## Validation
- `cargo test -p coding-adventures-html-parser fostered_nobr_table_cell_continuation_stays_inside_cell`
- `cargo test -p coding-adventures-html-parser whatwg_formatting_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_formatting_audit_cases_match_parser_dom_dump`
- `cargo test -p coding-adventures-html-parser font_newline_before_bold_stays_outside_reconstructed_font`
- `cargo test -p coding-adventures-html-parser whatwg_paragraph_audit_cases_match_parser_dom_dump`
- `cargo test -p coding-adventures-html-parser whatwg_block_boundary_audit_cases_match_parser_dom_dump`
- `cargo test -p coding-adventures-html-parser html5lib_tree_construction_smoke_cases_match_dom_dump`
- `cargo test -p coding-adventures-html-parser`
- `cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser`
- `python3 -m json.tool code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json >/dev/null`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py`
- `git diff --check`