### PR TITLE
[codex] Retire formatting newline post-parse repair

### DIFF
--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -8620,10 +8620,6 @@ fn repair_tricky_adoption_agency_in(nodes: &mut Vec<Node>) {
             repair_tricky_adoption_agency_in(&mut element.children);
         }
 
-        if repair_formatting_newline_continuation(nodes, index) {
-            index += 1;
-            continue;
-        }
         if repair_paragraph_trailing_block_continuation(nodes, index) {
             index += 1;
             continue;
@@ -8640,44 +8636,6 @@ fn repair_tricky_adoption_agency_in(nodes: &mut Vec<Node>) {
         }
         index += 1;
     }
-}
-
-fn repair_formatting_newline_continuation(nodes: &mut Vec<Node>, index: usize) -> bool {
-    let Some(Node::Element(paragraph)) = nodes.get_mut(index) else {
-        return false;
-    };
-    if paragraph.name != "p" {
-        return false;
-    }
-    let Some(Node::Element(font)) = paragraph.children.last_mut() else {
-        return false;
-    };
-    if font.name != "font" {
-        return false;
-    }
-    let font_attributes = font.attributes.clone();
-    let Some(Node::Element(inner_formatting)) = font.children.last_mut() else {
-        return false;
-    };
-    if !is_formatting_element(&inner_formatting.name) {
-        return false;
-    }
-    let inner_name = inner_formatting.name.clone();
-    let inner_attributes = inner_formatting.attributes.clone();
-    let Some(newline) = split_tail_text(&mut inner_formatting.children, "\n") else {
-        return false;
-    };
-
-    let mut continuation_inner = Node::element(inner_name, inner_attributes);
-    if let Node::Element(element) = &mut continuation_inner {
-        element.children.push(Node::text(newline));
-    }
-    let mut continuation_font = Node::element("font".to_string(), font_attributes);
-    if let Node::Element(element) = &mut continuation_font {
-        element.children.push(continuation_inner);
-    }
-    nodes.insert(index + 1, continuation_font);
-    true
 }
 
 fn repair_paragraph_trailing_block_continuation(nodes: &mut Vec<Node>, index: usize) -> bool {


### PR DESCRIPTION
## Summary
- Remove the now-redundant `repair_formatting_newline_continuation` post-parse helper from the HTML parser repair chain.
- Keep the remaining tricky adoption/table-cell repairs unchanged.

## Validation
- `cargo test -p coding-adventures-html-parser font_newline_before_bold_stays_outside_reconstructed_font`
- `cargo test -p coding-adventures-html-parser whatwg_formatting_audit_cases_match_parser_dom_dump`
- `cargo test -p coding-adventures-html-parser whatwg_formatting_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_paragraph_audit_cases_match_parser_dom_dump`
- `cargo test -p coding-adventures-html-parser whatwg_block_boundary_audit_cases_match_parser_dom_dump`
- `cargo test -p coding-adventures-html-parser html5lib_tree_construction_smoke_cases_match_dom_dump`
- `cargo test -p coding-adventures-html-parser`
- `cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser`
- `python3 -m json.tool code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json >/dev/null`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py`
- `git diff --check`