### PR TITLE
[codex] Expose ADJ engine outcomes in ladder traces

### DIFF
--- a/code/specs/data/adj-ladder/CHANGELOG.md
+++ b/code/specs/data/adj-ladder/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the ADJ-LADDER two-arm reasoning scoreboard.
 
+## [0.22.0] — 2026-06-29
+
+### Added — native engine outcome traces
+
+- Program-backed model scorecards now record `arm_b_engine_kind` and
+  `arm_b_engine_outcome`, making Arm B misses auditable as native ADJ outcomes
+  such as `solve/no_unique_solution` instead of opaque abstentions.
+- Tightened the native solve decomposition prompt so multi-variable systems ask
+  Gemma to declare every unknown and include every variable in `solve for { ... }`;
+  the harness still reads only the requested variable.
+
 ## [0.21.0] — 2026-06-29
 
 ### Added — Gemma linear-systems baseline

--- a/code/specs/data/adj-ladder/README.md
+++ b/code/specs/data/adj-ladder/README.md
@@ -209,8 +209,11 @@ python3 ladder_eval.py rung0_arithmetic --model 'cmd:ollama run <model>'
 so a cached CI run never clobbers a committed two-arm headline). Model scorecards
 also record the raw Arm B model output, the extracted ADJ decomposition, its kind
 (`formula` or `program`), and whether it passed the no-result-literals faithfulness
-gate. Those trace fields are the audit trail for the real north-star run: messy human
-input → local Gemma decomposition → native ADJ execution.
+gate. Program-backed model scorecards also record the native ADJ engine family and
+outcome (`arm_b_engine_kind` / `arm_b_engine_outcome`), so misses remain auditable as
+e.g. `solve/no_unique_solution` rather than opaque abstentions. Those trace fields are
+the audit trail for the real north-star run: messy human input → local Gemma
+decomposition → native ADJ execution.
 
 If the `adj-lang-cli` binary lives somewhere non-standard, point `ADJ_LANG_CLI` at it.
 

--- a/code/specs/data/adj-ladder/ladder_eval.py
+++ b/code/specs/data/adj-ladder/ladder_eval.py
@@ -561,6 +561,37 @@ def program_answer_to_letter(
     return None
 
 
+def program_engine_trace(doc: dict | None, answer_from: dict | None) -> tuple[str | None, str | None]:
+    """Return the native engine result family and outcome for scorecard auditing.
+
+    This does not interpret the result or pick an option. It only records the section
+    Arm B asked ADJ to execute and the engine's own outcome label, so a model-mode
+    miss can be audited as e.g. `solve/no_unique_solution` instead of an opaque
+    abstention.
+    """
+    if not doc or not answer_from:
+        return None, None
+    typ = answer_from.get("type")
+    if typ in {"solve_assignment", "solve_roots"}:
+        section = doc.get("solve")
+        kind = "solve"
+    elif typ in {"optimize_value", "optimize_assignment"}:
+        section = doc.get("optimize")
+        kind = "optimize"
+    elif typ == "check_outcome":
+        section = doc.get("check")
+        kind = "check"
+    elif typ == "decision_leader":
+        section = doc.get("decision")
+        kind = "decision"
+    else:
+        return None, None
+    if not isinstance(section, dict):
+        return kind, None
+    outcome = section.get("outcome") or section.get("type")
+    return kind, str(outcome) if outcome is not None else None
+
+
 def formula_is_faithful(
     formula: str, stem: str, *, program: bool = False, structural_weights: bool = True
 ) -> bool:
@@ -613,6 +644,8 @@ class ItemResult:
     arm_b_decomposition: str | None = None
     arm_b_decomposition_kind: str | None = None
     arm_b_decomposition_faithful: bool | None = None
+    arm_b_engine_kind: str | None = None
+    arm_b_engine_outcome: str | None = None
 
 
 def outcome(letter: str | None, gold: str) -> str:
@@ -690,6 +723,8 @@ def score_item(item: dict, gen) -> ItemResult:
     arm_b_decomposition = None
     arm_b_decomposition_kind = None
     arm_b_decomposition_faithful = None
+    arm_b_engine_kind = None
+    arm_b_engine_outcome = None
 
     # --- Arm B: decompose → engine selects ---
     if gen is None:
@@ -721,9 +756,10 @@ def score_item(item: dict, gen) -> ItemResult:
     if not faithful:
         arm_b_letter = None                                  # decompose failed → abstain
     elif program:
-        arm_b_letter = program_answer_to_letter(
-            run_program(program), item.get("answer_from"), item["options"]
-        )
+        answer_from = item.get("answer_from")
+        engine_doc = run_program(program)
+        arm_b_engine_kind, arm_b_engine_outcome = program_engine_trace(engine_doc, answer_from)
+        arm_b_letter = program_answer_to_letter(engine_doc, answer_from, item["options"])
     elif formula:
         arm_b_letter = decision_to_letter(
             run_decision(build_arm_b_program(formula, item["options"]))
@@ -746,6 +782,8 @@ def score_item(item: dict, gen) -> ItemResult:
         arm_b_decomposition,
         arm_b_decomposition_kind,
         arm_b_decomposition_faithful,
+        arm_b_engine_kind,
+        arm_b_engine_outcome,
     )
 
 
@@ -764,6 +802,9 @@ def result_to_json(r: ItemResult) -> dict:
         out["arm_b_decomposition"] = r.arm_b_decomposition
         out["arm_b_decomposition_kind"] = r.arm_b_decomposition_kind
         out["arm_b_decomposition_faithful"] = r.arm_b_decomposition_faithful
+        if r.arm_b_engine_kind is not None:
+            out["arm_b_engine_kind"] = r.arm_b_engine_kind
+            out["arm_b_engine_outcome"] = r.arm_b_engine_outcome
     return out
 
 
@@ -1001,8 +1042,11 @@ def decompose_prompt(item: dict) -> str:
         return (
             "Translate the word problem into a native ADJ solve program. Name the "
             f"requested unknown `{name}`. Use ONLY numbers that appear in the "
-            "question. Do NOT compute the answer, do NOT mention the answer choices, "
-            "and output ONLY the ADJ program.\n\n"
+            "question. For a multi-variable system, declare every named unknown and "
+            "include every variable in `solve for { ... }` even if the question asks "
+            "for only one of them; the harness will read the requested variable. Do "
+            "NOT compute the answer, do NOT mention the answer choices, and output "
+            "ONLY the ADJ program.\n\n"
             "Question: A number plus 5 is 17. What is the number?\n"
             "Program:\n"
             "symbol x : scalar\n"

--- a/code/specs/data/adj-ladder/test_ladder_eval.py
+++ b/code/specs/data/adj-ladder/test_ladder_eval.py
@@ -214,6 +214,8 @@ def test_decompose_prompt_mentions_linear_system_program():
     })
     assert "symbol y : scalar" in prompt
     assert "solve for { x, y }" in prompt
+    assert "include every variable in `solve for { ... }`" in prompt
+    assert "the harness will read the requested variable" in prompt
     assert 'constrain latex "$x + 2y = 23$"' in prompt
 
 
@@ -446,12 +448,16 @@ def test_result_json_includes_trace_for_model_result():
         "99",
         "formula",
         False,
+        "solve",
+        "no_unique_solution",
     )
     out = le.result_to_json(result)
     assert out["arm_b_model_output"] == "Formula: 99"
     assert out["arm_b_decomposition"] == "99"
     assert out["arm_b_decomposition_kind"] == "formula"
     assert out["arm_b_decomposition_faithful"] is False
+    assert out["arm_b_engine_kind"] == "solve"
+    assert out["arm_b_engine_outcome"] == "no_unique_solution"
 
 
 def test_run_limit_caps_item_count():
@@ -489,6 +495,25 @@ def test_option_expression_predicate_runs_through_engine():
         le.build_arm_b_program("1 / 10 + 2 / 10", {"A": "3 / 10", "B": "1 / 2"})
     )
     assert le.decision_to_letter(decision) == "A"
+
+
+def test_program_engine_trace_records_native_outcomes():
+    assert le.program_engine_trace(
+        {"solve": {"outcome": "no_unique_solution"}},
+        {"type": "solve_assignment", "name": "x"},
+    ) == ("solve", "no_unique_solution")
+    assert le.program_engine_trace(
+        {"optimize": {"outcome": "optimal"}},
+        {"type": "optimize_value"},
+    ) == ("optimize", "optimal")
+    assert le.program_engine_trace(
+        {"check": {"outcome": "sat"}},
+        {"type": "check_outcome"},
+    ) == ("check", "sat")
+    assert le.program_engine_trace(
+        {"decision": {"type": "determinate", "leader": "a"}},
+        {"type": "decision_leader"},
+    ) == ("decision", "determinate")
 
 
 def test_solve_assignment_program_maps_engine_value_to_option():


### PR DESCRIPTION
## Summary

- add native ADJ engine outcome trace fields (`arm_b_engine_kind` / `arm_b_engine_outcome`) to program-backed model scorecards
- tighten the native solve decomposition prompt so multi-variable systems solve for every declared variable while the harness reads the requested one
- document the scorecard trace fields in the ADJ-LADDER README/changelog

## Why

PR #6874 showed that Gemma linear-system misses can be faithful ADJ programs that still abstain after native execution. This makes those misses auditable as engine outcomes like `solve/no_unique_solution` instead of leaving them as opaque bucket-c abstentions.

## Validation

- `/Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python3 -m pytest test_ladder_eval.py -q` (`99 passed`)
- `/Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python3 ladder_eval.py rung3_linear_systems --quiet --output /tmp/adj-ladder-linear-systems-after-trace.json` (cached Arm B 20/20)
- `git diff --check`
