### PR TITLE
feat(latex): emit ± / ∓ / binomial — close L6 neutral-AST gaps (LTX01)

### DIFF
--- a/code/packages/rust/latex/CHANGELOG.md
+++ b/code/packages/rust/latex/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to the full-fidelity LaTeX parser crate.
 
+## [0.11.0] — 2026-06-28
+
+### Changed — L6 closes its two honest neutral-AST gaps (± / ∓ and binomials)
+
+The L6 capstone (0.10.0) had to return a spanned `FrontendError` for `\pm`, `\mp`, and
+`\binom`, because the `math-frontend` neutral AST could not represent them. `math-frontend`
+0.2.0 added `BinOp::PlusMinus`/`MinusPlus` and `MathExpr::Binom`; this release wires the
+`latex` adapter to **emit** them, so every LaTeX math construct the L2/L3a grammar parses now
+lowers to a faithful neutral node — no faking, no honest-error islands.
+
+- **`\pm` → `BinOp::PlusMinus`, `\mp` → `BinOp::MinusPlus`** (the ± / ∓ pair operators).
+  `lower_binop` is now total (infallible) — the two error arms are gone.
+- **`\binom{n}{k}` → `MathExpr::Binom(n, k)`** (binomial coefficient, args in source order;
+  distinct from `Frac` — no division bar). Lowered via a new `Build::Binom` work-stack step,
+  so it stays inside the iterative (stack-safe) trampoline like every other node.
+- `capabilities()` stays `Capabilities::all()` — now **honest**, since the adapter genuinely
+  emits ± / ∓ and binomials (the shared conformance harness polices this).
+- Tests: the former `neutral_gaps_error_honestly` becomes `plusminus_minusplus_and_binom_lower`
+  (asserts the three now lower to the right shapes); the conformance corpus keeps `a \pm b`
+  and `\binom{n}{k}` (now exercising emission, not error). 136 tests pass; both the default
+  build and `--no-default-features` (zero-dep L0–L5) stay green; clippy `-D warnings` clean.
+- Crate 0.10.0 → 0.11.0. **LTX01 L6 now has no honest gaps.**
+
 ## [0.10.0] — 2026-06-27
 
 ### Added — LTX01 L6: `math-frontend` adapter (the ladder's capstone)

--- a/code/packages/rust/latex/Cargo.toml
+++ b/code/packages/rust/latex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latex"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 description = "A full-fidelity LaTeX parser (documents and math): a catcode-driven, text-mode-primary tokenizer and (in later layers) a structural + math parser producing a faithful AST. Standalone and reusable; will also implement the math-frontend MathFrontend trait."
 license = "MIT"

--- a/code/packages/rust/latex/README.md
+++ b/code/packages/rust/latex/README.md
@@ -215,11 +215,12 @@ assert!(matches!(a, MathExpr::Bin(BinOp::Mul, _, _)));
 
 Lowering drops *presentation* and keeps *meaning*: fence style → `Group`, matrix delimiter →
 `Matrix`, `a^n` → `Pow`, `a_i` → `Subscript`, accents → `Call`; numbers stay **exact**
-(`MathExpr::Number`, never `f64`). Two constructs have no neutral counterpart yet — `\pm`/`\mp`
-and `\binom` — so they return a well-formed spanned error rather than being faked (extending the
-neutral AST to cover them is a future `math-frontend` change). The adapter sits behind the
-default-on **`frontend`** feature; build with `--no-default-features` for the zero-dependency
-L0–L5 parser alone.
+(`MathExpr::Number`, never `f64`). `\pm`/`\mp` lower to `BinOp::PlusMinus`/`MinusPlus` (the ± / ∓
+pair operators) and `\binom{n}{k}` to `MathExpr::Binom` — every LaTeX math construct the grammar
+parses now has a faithful neutral counterpart (the two former gaps were closed by extending the
+`math-frontend` neutral AST, not by faking them here). The adapter sits behind the default-on
+**`frontend`** feature; build with `--no-default-features` for the zero-dependency L0–L5 parser
+alone.
 
 The low-level `tokenize` is also public. Tokens and errors carry half-open byte `Span`s;
 all of `parse`, `parse_math`, and `tokenize` return spanned errors rather than panicking,

--- a/code/packages/rust/latex/src/frontend.rs
+++ b/code/packages/rust/latex/src/frontend.rs
@@ -18,16 +18,12 @@
 //! - matrix *delimiter* is dropped: `pmatrix`/`bmatrix`/`cases`/… all become [`MathExpr::Matrix`].
 //! - `base^sup` → [`BinOp::Pow`]; `base_sub` → [`MathExpr::Subscript`]; both → `Pow(Subscript(…))`.
 //! - an accent (`\hat{x}`, `\vec{v}`) is a named unary, lowered to `Call{Other(kind), arg}`.
+//! - `\pm` / `\mp` → [`BinOp::PlusMinus`] / [`BinOp::MinusPlus`] (the ± / ∓ pair operators).
+//! - `\binom{n}{k}` → [`MathExpr::Binom`] (a binomial coefficient — no division bar).
 //!
-//! ## Honest gaps (neutral AST has no representation)
-//!
-//! Two LaTeX math constructs have *no* neutral counterpart today, so rather than fake them we
-//! return a well-formed [`FrontendError`] (the parse of that island fails honestly):
-//! - `\pm` / `\mp` — the neutral [`BinOp`] has no ± / ∓;
-//! - `\binom{n}{k}` — the neutral AST has no binomial.
-//!
-//! Extending the neutral AST to cover these is a future change to the `math-frontend` crate
-//! (and its conformance harness), not a hack here. Everything else L2/L3a can parse lowers.
+//! Every LaTeX math construct L2/L3a can parse now lowers to a neutral counterpart: the two
+//! former gaps (± / ∓ and binomials) were closed by extending the `math-frontend` neutral AST
+//! and its conformance harness, then wiring them here — no faking, no hack.
 //!
 //! ## Registration
 //!
@@ -92,6 +88,7 @@ enum Build {
     Bin(BinOp),
     Unary(UnaryOp),
     Frac,
+    Binom,
     Root { has_degree: bool },
     Script { has_sub: bool, has_sup: bool },
     Call(Func),
@@ -140,17 +137,14 @@ fn lower(root: MathNode, span: (usize, usize)) -> Result<MathExpr, FrontendError
                 )?)),
                 MathNode::Sym(s) => vals.push(MathExpr::Symbol(s)),
                 MathNode::Text(s) => vals.push(MathExpr::Text(s)),
-                MathNode::Binom(_, _) => {
-                    return Err(FrontendError::new(
-                        "latex",
-                        "binomial \\binom has no neutral MathExpr representation",
-                        span,
-                    ))
+                // `\binom{n}{k}` → the neutral binomial coefficient (no division bar).
+                MathNode::Binom(x, y) => {
+                    work.push(Task::Build(Build::Binom));
+                    work.push(Task::Node(*y));
+                    work.push(Task::Node(*x));
                 }
                 MathNode::Bin(op, x, y) => {
-                    // Resolve the operator first so `\pm`/`\mp` fail before we descend.
-                    let op = lower_binop(op, span)?;
-                    work.push(Task::Build(Build::Bin(op)));
+                    work.push(Task::Build(Build::Bin(lower_binop(op))));
                     work.push(Task::Node(*y));
                     work.push(Task::Node(*x));
                 }
@@ -255,6 +249,11 @@ fn lower(root: MathNode, span: (usize, usize)) -> Result<MathExpr, FrontendError
                     let x = pop!();
                     vals.push(MathExpr::Frac(Box::new(x), Box::new(y)));
                 }
+                Build::Binom => {
+                    let k = pop!();
+                    let n = pop!();
+                    vals.push(MathExpr::Binom(Box::new(n), Box::new(k)));
+                }
                 Build::Root { has_degree } => {
                     let radicand = pop!();
                     let degree = if has_degree { Some(Box::new(pop!())) } else { None };
@@ -316,29 +315,18 @@ fn lower(root: MathNode, span: (usize, usize)) -> Result<MathExpr, FrontendError
     }
 }
 
-/// Lower a binary operator. `\pm`/`\mp` have no neutral form → spanned error.
-fn lower_binop(op: MBinOp, span: (usize, usize)) -> Result<BinOp, FrontendError> {
-    Ok(match op {
+/// Lower a binary operator (1:1 — every LaTeX math operator has a neutral form, including
+/// `\pm`/`\mp` which map to the meaning-bearing `±`/`∓`).
+fn lower_binop(op: MBinOp) -> BinOp {
+    match op {
         MBinOp::Add => BinOp::Add,
         MBinOp::Sub => BinOp::Sub,
         MBinOp::Mul => BinOp::Mul,
         MBinOp::Div => BinOp::Div,
         MBinOp::Pow => BinOp::Pow,
-        MBinOp::PlusMinus => {
-            return Err(FrontendError::new(
-                "latex",
-                "\\pm has no neutral MathExpr representation",
-                span,
-            ))
-        }
-        MBinOp::MinusPlus => {
-            return Err(FrontendError::new(
-                "latex",
-                "\\mp has no neutral MathExpr representation",
-                span,
-            ))
-        }
-    })
+        MBinOp::PlusMinus => BinOp::PlusMinus,
+        MBinOp::MinusPlus => BinOp::MinusPlus,
+    }
 }
 
 /// Map a relation operator (1:1 — both enums carry the same eight relations).
@@ -548,12 +536,17 @@ mod tests {
     }
 
     #[test]
-    fn neutral_gaps_error_honestly() {
-        // \pm / \mp / \binom have no neutral representation → well-formed spanned error.
-        for src in [r"a \pm b", r"a \mp b", r"\binom{n}{k}"] {
-            let err = LatexMath.parse(src).expect_err("should be a neutral-AST gap");
-            assert_eq!(err.frontend, "latex");
-            assert!(err.span.0 <= err.span.1 && err.span.1 <= src.len());
+    fn plusminus_minusplus_and_binom_lower() {
+        // The two former neutral-AST gaps now lower to real, meaning-bearing nodes.
+        assert!(matches!(m(r"a \pm b"), MathExpr::Bin(BinOp::PlusMinus, _, _)));
+        assert!(matches!(m(r"a \mp b"), MathExpr::Bin(BinOp::MinusPlus, _, _)));
+        // \binom{n}{k} → Binom(n, k), with the arguments in source order (not swapped).
+        match m(r"\binom{n}{k}") {
+            MathExpr::Binom(n, k) => {
+                assert_eq!(*n, MathExpr::Symbol("n".into()));
+                assert_eq!(*k, MathExpr::Symbol("k".into()));
+            }
+            other => panic!("expected Binom, got {other:?}"),
         }
     }
 
@@ -622,8 +615,8 @@ mod tests {
                 "a_i",
                 r"\hat{x}",
                 "(a+b)",
-                r"a \pm b",       // gap: must error well-formed, not panic
-                r"\binom{n}{k}",  // gap
+                r"a \pm b",       // ± → BinOp::PlusMinus
+                r"\binom{n}{k}",  // binomial → MathExpr::Binom
                 r"\frac{1}",      // parse error: span in range
                 "",               // empty
             ],

--- a/code/specs/LTX01-full-latex-parser.md
+++ b/code/specs/LTX01-full-latex-parser.md
@@ -183,10 +183,13 @@ is text-primary, which is a different mode model.)
   stays empty because that crate cannot depend on `latex` (cycle), so the wiring lives in the
   `latex` crate. Gated behind the default-on `frontend` cargo feature; `--no-default-features`
   keeps L0–L5 dependency-free. Implemented in frontend.rs + Cargo.toml.
-  **Neutral-AST gaps:** `\pm`/`\mp` and `\binom` have no `MathExpr` representation today, so they
-  lower to a well-formed spanned `FrontendError` rather than being faked; extending the neutral
-  AST (a `math-frontend`-crate change) to cover them is deferred future work. This rung
-  **completes the LTX01 ladder (L0–L6).**
+  **Neutral-AST gaps (closed in latex 0.11.0):** the L6 capstone initially had to lower `\pm`,
+  `\mp`, and `\binom` to a spanned `FrontendError`, because the neutral `MathExpr` could not
+  represent them. `math-frontend` 0.2.0 added `BinOp::PlusMinus`/`MinusPlus` and `MathExpr::Binom`
+  (plus the matching `Capabilities` flags + conformance policing), and `latex` 0.11.0 wires the
+  adapter to **emit** them (`\pm`→`PlusMinus`, `\mp`→`MinusPlus`, `\binom{n}{k}`→`Binom(n,k)`).
+  Every LaTeX math construct the grammar parses now has a faithful neutral counterpart — no
+  honest-error islands remain. This rung **completes the LTX01 ladder (L0–L6).**
 
 **Asymptote (documented in README, not built):** runtime `\catcode`, `\expandafter`/
 `\noexpand`/`\csname`, arbitrary `\if…` programming, external `\input`/`\include`. Hit →


### PR DESCRIPTION
## What

Wires the `latex` crate's `math-frontend` adapter (the L6 capstone) to **emit** the two constructs it previously had to error on, now that the neutral AST can represent them (math-frontend 0.2.0, #6764):

- `\pm` → `BinOp::PlusMinus`, `\mp` → `BinOp::MinusPlus` (the ± / ∓ pair operators)
- `\binom{n}{k}` → `MathExpr::Binom(n, k)` (binomial coefficient, args in source order; distinct from `Frac` — no division bar)

After this, **every LaTeX math construct the L2/L3a grammar parses lowers to a faithful neutral counterpart** — no faking, no honest-error islands. **LTX01 L6 now has no neutral-AST gaps.**

## How

- `lower_binop` is now **total** (infallible) — its two `Err` arms are removed; the match is exhaustive over all 7 `MBinOp` variants (compiler-enforced).
- `\binom` lowers via a new `Build::Binom` work-stack step, structurally identical to the already-reviewed `Build::Frac` arm — so it stays inside the **iterative (stack-safe) trampoline**. No recursion reintroduced; the `deep_operator_chains_do_not_overflow` (n=4000) regression test still guards the spine cases.
- `capabilities()` stays `Capabilities::all()` — now **honest**, since the adapter genuinely emits ± / ∓ and binomials (the shared `check_frontend` conformance harness polices over-claiming).

## Verification

- `cargo test -p latex` — **136 unit + 1 doc test pass**
- `cargo test -p latex --no-default-features` — green (zero-dep L0–L5 path unaffected)
- `cargo clippy -p latex -- -D warnings` (and `--no-default-features`) — clean
- Test `neutral_gaps_error_honestly` → `plusminus_minusplus_and_binom_lower` (asserts the three now lower to the right shapes); conformance corpus keeps `a \pm b` / `\binom{n}{k}` (now exercising emission).
- **/security-review PASSED** — Rust security engineer reviewed the diff (DoS/recursion-regression focus); no vulnerabilities, value stack stays balanced, no new panic/unsafe/overflow surface.

Crate `latex` 0.10.0 → 0.11.0. Updates CHANGELOG, README, and LTX01 §5 L6 (gap closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)