### PR TITLE
feat(closurec): fold static Object.entries({k:v,…}) → array of [key,value] pairs

### DIFF
--- a/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to the `coding-adventures-closure-pass-constant-fold` crate will be documented in this file.
 
+## [0.72.0] - 2026-06-27
+
+### Added — fold static `Object.entries({k: v, …})` → `[["k", v], …]`
+
+The static `Object.entries` (ECMAScript §20.1.2.5) — the inverse of
+`Object.fromEntries` — now folds a NON-empty object literal to an array of
+`[key, value]` pair literals (the empty-object case `Object.entries({})` → `[]`
+was already handled):
+
+| call                            | result                |
+|---------------------------------|-----------------------|
+| `Object.entries({a: 1, b: 2})`  | `[["a", 1], ["b", 2]]`|
+| `Object.entries({x: "hi"})`     | `[["x", "hi"]]`       |
+
+Each entry key is emitted as a string literal; the value expression is copied
+verbatim. The fold applies ONLY when every property is a plain data property
+(`k: v` — no getter, setter, method, or computed key) with a primitive-literal
+value (string / number / boolean / null). We DECLINE: a `"__proto__"` key (a
+non-computed `{__proto__: v}` is the §B.3.1 prototype setter, not an own
+property, so it is not enumerated); any canonical array-index key (`0`, `1`,
+`42`, …, which `[[OwnPropertyKeys]]` enumerates ahead of string keys, breaking
+the source order we emit); any non-literal value (including the implicit
+identifier of a shorthand `{x}`); a non-global receiver; and any arity ≠ 1.
+Duplicate keys collapse to one entry (first position, last value), mirroring the
+object the literal builds.
+
 ## [0.70.0] - 2026-06-26
 
 ### Added — fold static `Object.is(a, b)` → boolean (SameValue)

--- a/code/packages/rust/closure-pass-constant-fold/Cargo.toml
+++ b/code/packages/rust/closure-pass-constant-fold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-constant-fold"
-version = "0.70.0"
+version = "0.72.0"
 edition = "2021"
 description = "Constant-folding optimization pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Folds compile-time-evaluable expressions like `2 + 3 → 5`."
 

--- a/code/packages/rust/closure-pass-constant-fold/src/lib.rs
+++ b/code/packages/rust/closure-pass-constant-fold/src/lib.rs
@@ -96,7 +96,7 @@ use coding_adventures_javascript_ast::{
     ForStatement,
     FunctionDeclaration,
     IfStatement, LogicalExpression, LogicalOperator, MemberExpression, NullLiteral, NumericLiteral,
-    ObjectExpression, Program, ProgramItem, Property, PropertyKey, ReturnStatement, Statement,
+    ObjectExpression, Program, ProgramItem, Property, PropertyKey, PropertyKind, ReturnStatement, Statement,
     StringLiteral, UnaryExpression, UnaryOperator, UndefinedLiteral, VariableDeclaration,
     DoWhileStatement, VariableDeclarator, WhileStatement,
 };
@@ -1460,6 +1460,61 @@ fn fold_call(c: &CallExpression, st: &mut FoldState) -> Expression {
                                 cv: new_cv,
                                 elements: vec![],
                             });
+                        }
+                    }
+                }
+
+                // ---- Object.entries({k: v, …}) → [["k", v], …] ----
+                //
+                // `Object.entries` (ECMAScript §20.1.2.5) returns an array of an
+                // object's own enumerable string-keyed `[key, value]` pairs — the
+                // exact inverse of `Object.fromEntries`. For a fully-static object
+                // LITERAL we can build that array at compile time:
+                //
+                //   Object.entries({a: 1, b: 2})  → [["a", 1], ["b", 2]]
+                //   Object.entries({x: "hi"})     → [["x", "hi"]]
+                //
+                // (The EMPTY-object case `Object.entries({})` → `[]` is already
+                // handled by the block above; this block fires only for non-empty
+                // literals.) Each entry KEY is always a string, so we emit a string
+                // literal; the VALUE expression is copied verbatim.
+                //
+                // Soundness conditions — EVERY property must satisfy all of these,
+                // else we DECLINE and leave the call untouched (declining is safe):
+                //   * the property is a plain data property `k: v` — NOT a getter or
+                //     setter (`get k() {…}` runs code), NOT a method, NOT a computed
+                //     key `[expr]: v` (the key is unknown);
+                //   * the VALUE is a primitive literal (string / number / boolean /
+                //     null) — a non-literal value (including the implicit identifier
+                //     of a shorthand `{x}`) may have side effects or an unknown value;
+                //   * the key is NOT `"__proto__"` — a non-computed `{__proto__: v}`
+                //     is the §B.3.1 prototype SETTER, which creates NO own property,
+                //     so `Object.entries` would not enumerate it (folding it in would
+                //     invent an entry that does not exist);
+                //   * NO key is a canonical ARRAY INDEX (e.g. `0`, `1`, `42`):
+                //     `[[OwnPropertyKeys]]` lists integer-index keys first, in numeric
+                //     order, ahead of the source insertion order we emit, so a single
+                //     index key could reorder the result.
+                //
+                // DUPLICATE keys in the source literal collapse to one own property
+                // whose value is the LAST occurrence (kept at the FIRST occurrence's
+                // position), exactly mirroring the object the literal builds. Same
+                // bare-global-`Object` premise as the other statics — only the literal
+                // `Object.entries(...)` callee folds, never a shadowed receiver.
+                if obj.name == "Object" && prop.name == "entries" && arguments.len() == 1 {
+                    if let Some(Expression::ObjectExpression(o)) = arguments.first() {
+                        if !o.properties.is_empty() {
+                            if let Some(pairs) = fold_object_entries_pairs(&o.properties) {
+                                let parent = c.cv.clone();
+                                let before =
+                                    format!("Object.entries({{{} prop(s)}})", o.properties.len());
+                                let after = format!("[{} pair(s)]", pairs.len());
+                                let new_cv = st.fork_cv(&parent, &before, &after);
+                                return Expression::ArrayExpression(ArrayExpression {
+                                    cv: new_cv,
+                                    elements: pairs.into_iter().map(Some).collect(),
+                                });
+                            }
                         }
                     }
                 }
@@ -4245,6 +4300,92 @@ fn literal_nullish(expr: &Expression) -> Option<bool> {
         | Expression::NumericLiteral(_)
         | Expression::StringLiteral(_) => Some(false),
         _ => None,
+    }
+}
+
+/// Lower the properties of the object literal passed to `Object.entries` into a
+/// list of `[key, value]` pair array-literal expressions, honouring the spec's
+/// own-enumerable-string-key semantics. Returns `None` (decline the fold) the
+/// instant any property fails the static-shape conditions documented at the call
+/// site. On success the pairs are in source order with duplicate keys collapsed
+/// (first position, last value).
+fn fold_object_entries_pairs(properties: &[Property]) -> Option<Vec<Expression>> {
+    // Parallel vectors in first-occurrence order; `keys` finds a duplicate so its
+    // value can be overwritten in place (the object the literal builds keeps only
+    // the last value under a repeated key).
+    let mut keys: Vec<String> = Vec::new();
+    let mut pairs: Vec<Expression> = Vec::new();
+    for p in properties {
+        // Only plain data properties `k: v`. Getters/setters execute code,
+        // methods are functions, and a computed key `[expr]: v` is unknown.
+        if p.kind != PropertyKind::Init || p.method || p.computed {
+            return None;
+        }
+        let key_string = match &p.key {
+            PropertyKey::Identifier(id) => id.name.clone(),
+            PropertyKey::StringLiteral(s) => s.value.clone(),
+            PropertyKey::NumericLiteral(n) => format_js_number(n.value),
+            PropertyKey::Expression(_) => return None, // computed
+        };
+        // A non-computed `{__proto__: v}` is the §B.3.1 prototype setter, not an
+        // own property, so `Object.entries` would not enumerate it — decline.
+        if key_string == "__proto__" {
+            return None;
+        }
+        // Integer-index keys enumerate first, in numeric order, ahead of the
+        // source insertion order we emit — decline if any key is one.
+        if is_array_index(&key_string) {
+            return None;
+        }
+        // VALUE must be a primitive literal. A shorthand `{x}` has the non-literal
+        // identifier `x` as its value and is declined here.
+        let value: Expression = match &*p.value {
+            Expression::StringLiteral(_)
+            | Expression::NumericLiteral(_)
+            | Expression::BooleanLiteral(_)
+            | Expression::NullLiteral(_) => (*p.value).clone(),
+            _ => return None,
+        };
+        // An entry key is ALWAYS a string; emit a string literal.
+        let key_raw = format!(
+            "\"{}\"",
+            key_string.replace('\\', "\\\\").replace('"', "\\\"")
+        );
+        let key_expr = Expression::StringLiteral(StringLiteral {
+            cv: None,
+            value: key_string.clone(),
+            raw: key_raw,
+        });
+        let pair = Expression::ArrayExpression(ArrayExpression {
+            cv: None,
+            elements: vec![Some(key_expr), Some(value)],
+        });
+        if let Some(pos) = keys.iter().position(|k| k == &key_string) {
+            pairs[pos] = pair;
+        } else {
+            keys.push(key_string);
+            pairs.push(pair);
+        }
+    }
+    Some(pairs)
+}
+
+/// True when `s` is a canonical ECMAScript *array index*: a string for which
+/// `ToString(ToUint32(s)) === s` and whose numeric value is in `[0, 2^32 − 2]`.
+/// In the ASCII subset that means: all digits, no leading zero (except the single
+/// character `"0"`), and a value strictly below `2^32 − 1`. Such keys are
+/// enumerated ahead of ordinary string keys, so folds containing them are
+/// declined to preserve ordering.
+fn is_array_index(s: &str) -> bool {
+    if s.is_empty() || !s.bytes().all(|b| b.is_ascii_digit()) {
+        return false;
+    }
+    if s.len() > 1 && s.as_bytes()[0] == b'0' {
+        return false; // leading zero → not the canonical form
+    }
+    match s.parse::<u64>() {
+        Ok(n) => n < u32::MAX as u64, // strictly below 2^32 − 1
+        Err(_) => false,              // larger than u64 → not an index
     }
 }
 
@@ -7831,6 +7972,347 @@ mod tests {
         });
         let (out, _, changed, _) = run_pass(program_with_expr(c, true));
         assert!(!changed, "o.keys({{}}) must not fold");
+        assert!(matches!(extract_expr(&out), Expression::CallExpression(_)));
+    }
+
+    // ------------------- Object.entries (static, non-empty) ----------
+
+    /// A `{<name>: <value>}` data property with an identifier key.
+    fn entries_prop(name: &str, value: Expression) -> Property {
+        Property {
+            cv: None,
+            kind: PropertyKind::Init,
+            key: PropertyKey::Identifier(Identifier {
+                cv: None,
+                name: name.to_string(),
+            }),
+            value: Box::new(value),
+            shorthand: false,
+            computed: false,
+            method: false,
+        }
+    }
+
+    /// An object literal from a property list.
+    fn object_lit(props: Vec<Property>) -> Expression {
+        Expression::ObjectExpression(ObjectExpression {
+            cv: None,
+            properties: props,
+        })
+    }
+
+    /// Assert that `pair` is `["<key>", <expected-value-matcher>]`.
+    fn assert_pair_key(pair: &Expression, key: &str) -> Expression {
+        match pair {
+            Expression::ArrayExpression(a) => {
+                assert_eq!(a.elements.len(), 2, "each entry is a 2-element array");
+                match &a.elements[0] {
+                    Some(Expression::StringLiteral(s)) => {
+                        assert_eq!(s.value, key, "entry key string")
+                    }
+                    other => panic!("expected string key {key:?}; got {:?}", other),
+                }
+                a.elements[1].clone().expect("entry value present")
+            }
+            other => panic!("expected a [key, value] array; got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn fold_object_entries_to_pairs() {
+        // `Object.entries({a: 1, b: 2})` → `[["a", 1], ["b", 2]]`.
+        let c = object_static_call(
+            "entries",
+            object_lit(vec![
+                entries_prop("a", num(1.0, None)),
+                entries_prop("b", num(2.0, None)),
+            ]),
+        );
+        let (out, _, changed, _) = run_pass(program_with_expr(c, true));
+        assert!(changed, "Object.entries({{a:1,b:2}}) should fold");
+        match extract_expr(&out) {
+            Expression::ArrayExpression(a) => {
+                assert_eq!(a.elements.len(), 2, "two entries");
+                let v0 = assert_pair_key(a.elements[0].as_ref().unwrap(), "a");
+                assert!(matches!(v0, Expression::NumericLiteral(n) if n.value == 1.0));
+                let v1 = assert_pair_key(a.elements[1].as_ref().unwrap(), "b");
+                assert!(matches!(v1, Expression::NumericLiteral(n) if n.value == 2.0));
+            }
+            other => panic!("expected array of pairs; got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn fold_object_entries_all_primitive_value_kinds() {
+        // Values may be string / number / boolean / null literals.
+        let c = object_static_call(
+            "entries",
+            object_lit(vec![
+                entries_prop("s", string("hi", None)),
+                entries_prop("n", num(42.0, None)),
+                entries_prop("b", boolean(true, None)),
+                entries_prop("z", null(None)),
+            ]),
+        );
+        let (out, _, changed, _) = run_pass(program_with_expr(c, true));
+        assert!(changed, "all-primitive-value entries should fold");
+        match extract_expr(&out) {
+            Expression::ArrayExpression(a) => {
+                assert_eq!(a.elements.len(), 4);
+                assert!(matches!(
+                    assert_pair_key(a.elements[0].as_ref().unwrap(), "s"),
+                    Expression::StringLiteral(_)
+                ));
+                assert!(matches!(
+                    assert_pair_key(a.elements[1].as_ref().unwrap(), "n"),
+                    Expression::NumericLiteral(_)
+                ));
+                assert!(matches!(
+                    assert_pair_key(a.elements[2].as_ref().unwrap(), "b"),
+                    Expression::BooleanLiteral(_)
+                ));
+                assert!(matches!(
+                    assert_pair_key(a.elements[3].as_ref().unwrap(), "z"),
+                    Expression::NullLiteral(_)
+                ));
+            }
+            other => panic!("expected array of pairs; got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn fold_object_entries_string_and_noninteger_numeric_keys() {
+        // A string key and a non-integer-index numeric key (1.5 → "1.5", which is
+        // NOT an array index) both fold to string entry keys in source order.
+        let c = object_static_call(
+            "entries",
+            object_lit(vec![
+                Property {
+                    cv: None,
+                    kind: PropertyKind::Init,
+                    key: PropertyKey::StringLiteral(StringLiteral {
+                        cv: None,
+                        value: "a-b".to_string(),
+                        raw: "\"a-b\"".to_string(),
+                    }),
+                    value: Box::new(num(1.0, None)),
+                    shorthand: false,
+                    computed: false,
+                    method: false,
+                },
+                Property {
+                    cv: None,
+                    kind: PropertyKind::Init,
+                    key: PropertyKey::NumericLiteral(NumericLiteral {
+                        cv: None,
+                        value: 1.5,
+                        raw: "1.5".to_string(),
+                    }),
+                    value: Box::new(num(2.0, None)),
+                    shorthand: false,
+                    computed: false,
+                    method: false,
+                },
+            ]),
+        );
+        let (out, _, changed, _) = run_pass(program_with_expr(c, true));
+        assert!(changed, "string + non-index numeric keys should fold");
+        match extract_expr(&out) {
+            Expression::ArrayExpression(a) => {
+                assert_eq!(a.elements.len(), 2);
+                assert_pair_key(a.elements[0].as_ref().unwrap(), "a-b");
+                assert_pair_key(a.elements[1].as_ref().unwrap(), "1.5");
+            }
+            other => panic!("expected array of pairs; got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn fold_object_entries_duplicate_key_last_value_first_position() {
+        // `{a: 1, b: 2, a: 3}` builds `{a: 3, b: 2}`, so entries are
+        // `[["a", 3], ["b", 2]]` — key `a` keeps first position, takes last value.
+        let c = object_static_call(
+            "entries",
+            object_lit(vec![
+                entries_prop("a", num(1.0, None)),
+                entries_prop("b", num(2.0, None)),
+                entries_prop("a", num(3.0, None)),
+            ]),
+        );
+        let (out, _, changed, _) = run_pass(program_with_expr(c, true));
+        assert!(changed, "duplicate-key entries should fold");
+        match extract_expr(&out) {
+            Expression::ArrayExpression(a) => {
+                assert_eq!(a.elements.len(), 2, "deduped to two entries");
+                let v0 = assert_pair_key(a.elements[0].as_ref().unwrap(), "a");
+                assert!(
+                    matches!(v0, Expression::NumericLiteral(n) if n.value == 3.0),
+                    "a takes the LAST value (3)"
+                );
+                assert_pair_key(a.elements[1].as_ref().unwrap(), "b");
+            }
+            other => panic!("expected array of pairs; got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn object_entries_integer_index_key_does_not_fold() {
+        // Integer-index keys (0, 1, 42) enumerate before string keys, which would
+        // reorder the result — decline. Covers numeric and string index forms.
+        let cases = [
+            // {1: "x"} — numeric literal key "1" is an array index
+            object_lit(vec![Property {
+                cv: None,
+                kind: PropertyKind::Init,
+                key: PropertyKey::NumericLiteral(NumericLiteral {
+                    cv: None,
+                    value: 1.0,
+                    raw: "1".to_string(),
+                }),
+                value: Box::new(string("x", None)),
+                shorthand: false,
+                computed: false,
+                method: false,
+            }]),
+            // {"0": "x"} — string key "0" is also an array index
+            object_lit(vec![Property {
+                cv: None,
+                kind: PropertyKind::Init,
+                key: PropertyKey::StringLiteral(StringLiteral {
+                    cv: None,
+                    value: "0".to_string(),
+                    raw: "\"0\"".to_string(),
+                }),
+                value: Box::new(string("x", None)),
+                shorthand: false,
+                computed: false,
+                method: false,
+            }]),
+        ];
+        for arg in cases {
+            let c = object_static_call("entries", arg);
+            let (out, _, changed, _) = run_pass(program_with_expr(c, true));
+            assert!(!changed, "integer-index key must not fold (ordering)");
+            assert!(matches!(extract_expr(&out), Expression::CallExpression(_)));
+        }
+    }
+
+    #[test]
+    fn object_entries_proto_key_does_not_fold() {
+        // `{__proto__: v}` is the §B.3.1 prototype setter, not an own property, so
+        // Object.entries would not enumerate it — decline rather than invent one.
+        let c = object_static_call("entries", object_lit(vec![entries_prop("__proto__", num(1.0, None))]));
+        let (out, _, changed, _) = run_pass(program_with_expr(c, true));
+        assert!(!changed, "__proto__ key must not fold");
+        assert!(matches!(extract_expr(&out), Expression::CallExpression(_)));
+    }
+
+    #[test]
+    fn object_entries_non_literal_value_does_not_fold() {
+        // A non-literal value (identifier / call / nested object / array) is
+        // declined, as is a shorthand `{x}` (whose value is the identifier `x`).
+        let cases = [
+            object_lit(vec![entries_prop("a", ident("v"))]),
+            object_lit(vec![entries_prop("a", empty_object())]),
+            object_lit(vec![entries_prop(
+                "a",
+                Expression::ArrayExpression(ArrayExpression {
+                    cv: None,
+                    elements: vec![Some(num(1.0, None))],
+                }),
+            )]),
+            // shorthand { x }
+            object_lit(vec![Property {
+                cv: None,
+                kind: PropertyKind::Init,
+                key: PropertyKey::Identifier(Identifier {
+                    cv: None,
+                    name: "x".to_string(),
+                }),
+                value: Box::new(ident("x")),
+                shorthand: true,
+                computed: false,
+                method: false,
+            }]),
+        ];
+        for arg in cases {
+            let c = object_static_call("entries", arg);
+            let (out, _, changed, _) = run_pass(program_with_expr(c, true));
+            assert!(!changed, "non-literal value must not fold");
+            assert!(matches!(extract_expr(&out), Expression::CallExpression(_)));
+        }
+    }
+
+    #[test]
+    fn object_entries_getter_method_computed_do_not_fold() {
+        // Getters/setters run code, methods are functions, computed keys are
+        // unknown — each declines the whole fold.
+        let getter = object_lit(vec![Property {
+            cv: None,
+            kind: PropertyKind::Get,
+            key: PropertyKey::Identifier(Identifier {
+                cv: None,
+                name: "a".to_string(),
+            }),
+            value: Box::new(num(1.0, None)),
+            shorthand: false,
+            computed: false,
+            method: false,
+        }]);
+        let method = object_lit(vec![Property {
+            cv: None,
+            kind: PropertyKind::Init,
+            key: PropertyKey::Identifier(Identifier {
+                cv: None,
+                name: "a".to_string(),
+            }),
+            value: Box::new(num(1.0, None)),
+            shorthand: false,
+            computed: false,
+            method: true,
+        }]);
+        let computed = object_lit(vec![Property {
+            cv: None,
+            kind: PropertyKind::Init,
+            key: PropertyKey::Identifier(Identifier {
+                cv: None,
+                name: "a".to_string(),
+            }),
+            value: Box::new(num(1.0, None)),
+            shorthand: false,
+            computed: true,
+            method: false,
+        }]);
+        for arg in [getter, method, computed] {
+            let c = object_static_call("entries", arg);
+            let (out, _, changed, _) = run_pass(program_with_expr(c, true));
+            assert!(!changed, "getter/method/computed must not fold");
+            assert!(matches!(extract_expr(&out), Expression::CallExpression(_)));
+        }
+    }
+
+    #[test]
+    fn object_keys_values_nonempty_still_decline() {
+        // Only `entries` folds non-empty objects; `keys` and `values` are left
+        // for a future PR and must still decline.
+        for method in ["keys", "values"] {
+            let c = object_static_call(method, object_lit(vec![entries_prop("a", num(1.0, None))]));
+            let (out, _, changed, _) = run_pass(program_with_expr(c, true));
+            assert!(!changed, "Object.{method}({{a:1}}) must not fold yet");
+            assert!(matches!(extract_expr(&out), Expression::CallExpression(_)));
+        }
+    }
+
+    #[test]
+    fn object_entries_on_non_object_receiver_does_not_fold() {
+        // Only the bare global `Object` folds; `o.entries({a:1})` is left alone.
+        let c = Expression::CallExpression(CallExpression {
+            cv: Some("c.cv".to_string()),
+            callee: Box::new(member(ident("o"), "entries")),
+            arguments: vec![object_lit(vec![entries_prop("a", num(1.0, None))])],
+        });
+        let (out, _, changed, _) = run_pass(program_with_expr(c, true));
+        assert!(!changed, "o.entries({{a:1}}) must not fold");
         assert!(matches!(extract_expr(&out), Expression::CallExpression(_)));
     }
 

--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.221.0] - 2026-06-27
+
+### Added — SIMPLE/ADVANCED fold static `Object.entries({…})` → array of pairs
+
+At `--compilation_level SIMPLE` (and ADVANCED, which routes through the same
+pipeline) the typed constant-fold pass now collapses a static
+`Object.entries({k: v, …})` call (ECMAScript §20.1.2.5) — the inverse of
+`Object.fromEntries` — to an array of `[key, value]` pair literals when the
+argument is a non-empty object literal of plain data properties with
+primitive-literal values (string / number / boolean / null). Each entry key is
+emitted as a string literal. We decline a `"__proto__"` key (the object-literal
+form is the §B.3.1 prototype setter, not an own property), any canonical
+array-index key (`0`, `1`, `42`, … — enumerated ahead of string keys, which
+would reorder the result), any non-literal value (including a shorthand `{x}`),
+getters / setters / methods / computed keys, a non-global receiver, and arity
+≠ 1; duplicate keys collapse to one entry (first position, last value). The
+empty-object case `Object.entries({})` → `[]` was already handled. New
+end-to-end fixture `tests/diff/simple-fold-object-entries/` plus integration
+test `tests/diff_simple_fold_object_entries.rs`.
+
 ## [0.219.0] - 2026-06-26
 
 ### Added — SIMPLE/ADVANCED fold static `Object.is(a, b)` → boolean (SameValue)

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.219.0"
+version = "0.221.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.219.0",
+  "version": "0.221.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.219.0
+Version: 0.221.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff/simple-fold-object-entries/README.md
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-object-entries/README.md
@@ -1,0 +1,53 @@
+# simple-fold-object-entries
+
+End-to-end fixture for folding the static `Object.entries({k: v, …})`
+(ECMAScript §20.1.2.5) to an array of `[key, value]` pair literals at
+`--compilation_level SIMPLE`.
+
+`Object.entries` is the inverse of `Object.fromEntries`: it lists an object's
+own enumerable string-keyed entries. When the argument is a fully-static object
+literal of plain data properties with primitive-literal values, the result is
+known at compile time and the call collapses to an array literal.
+
+## What it checks
+
+| input expression               | SIMPLE output             | why                                  |
+|--------------------------------|---------------------------|--------------------------------------|
+| `Object.entries({a: 1, b: 2})` | `[["a",1],["b",2]]`       | own string entries, source order     |
+| `Object.entries({x: "hi"})`    | `[["x","hi"]]`            | single entry                         |
+| `Object.entries({})`           | `[]`                      | empty case (pre-existing fold)       |
+| `Object.entries({1: "x"})`     | `Object.entries({1:"x"})` | declined — integer-index key reorders|
+| `Object.entries({__proto__:1})`| `Object.entries(…)`       | declined — prototype setter, not own |
+| `o.entries({a: 1})`            | `o.entries({a:1})`        | declined — not the bare global       |
+
+Expected SIMPLE stdout:
+
+```text
+var a=[["a",1],["b",2]];var b=[["x","hi"]];var c=[];var d=Object.entries({1:"x"});var e=Object.entries({__proto__:1});var f=o.entries({a:1});report(a,b,c,d,e,f);
+```
+
+Each result flows into `report(...)` so it stays referenced past
+remove-unused-vars and the fold is observable.
+
+## Soundness
+
+The fold applies only when every property is a plain data property (`k: v` — no
+getter, setter, method, or computed key) with a primitive-literal value (string
+/ number / boolean / null). It declines a `"__proto__"` key (whose object-literal
+form is the §B.3.1 prototype setter, creating no own property), any canonical
+array-index key (enumerated ahead of string keys, which would reorder the
+result), any non-literal value (including a shorthand `{x}`), a non-global
+receiver, and any arity ≠ 1. Duplicate keys collapse to one entry (first
+position, last value). Declining is always safe.
+
+## How to run
+
+```bash
+cd code/programs/rust/closurec
+cargo run -- --compilation_level SIMPLE \
+  --js tests/diff/simple-fold-object-entries/input/a.js
+```
+
+The integration test `tests/diff_simple_fold_object_entries.rs` asserts the
+byte-exact stdout, the per-binding folds, and that the typed SIMPLE pipeline ran
+(not the WHITESPACE_ONLY fallback, under which all six calls would survive).

--- a/code/programs/rust/closurec/tests/diff/simple-fold-object-entries/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-object-entries/expected.stdout
@@ -1,0 +1,1 @@
+var a=[["a",1],["b",2]];var b=[["x","hi"]];var c=[];var d=Object.entries({1:"x"});var e=Object.entries({__proto__:1});var f=o.entries({a:1});report(a,b,c,d,e,f);

--- a/code/programs/rust/closurec/tests/diff/simple-fold-object-entries/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-object-entries/flags.txt
@@ -1,0 +1,4 @@
+--compilation_level
+SIMPLE
+--js
+tests/diff/simple-fold-object-entries/input/a.js

--- a/code/programs/rust/closurec/tests/diff/simple-fold-object-entries/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-object-entries/input/a.js
@@ -1,0 +1,22 @@
+// SIMPLE-level static Object.entries({k: v, …}) fold → array of [key, value]
+// pairs. Object.entries (ECMAScript §20.1.2.5) is the inverse of
+// Object.fromEntries: it lists an object's own enumerable string-keyed entries.
+// For a fully-static object literal of plain data properties with primitive
+// literal values, the result is known at compile time:
+//   * Object.entries({a: 1, b: 2}) → [["a",1],["b",2]]
+//   * Object.entries({x: "hi"})    → [["x","hi"]]
+//   * Object.entries({})           → []           (empty case)
+//   * Object.entries({1: "x"})     → declined (integer-index key reorders)
+//   * Object.entries({__proto__:1}) → declined (prototype setter, not own prop)
+//   * o.entries({a: 1})            → declined (only the bare global Object)
+//
+// Under WHITESPACE_ONLY every call survives; under SIMPLE the foldable
+// bare-global Object.entries calls collapse. Each value flows into report(...)
+// so it stays referenced past remove-unused-vars.
+var a = Object.entries({a: 1, b: 2});
+var b = Object.entries({x: "hi"});
+var c = Object.entries({});
+var d = Object.entries({1: "x"});
+var e = Object.entries({__proto__: 1});
+var f = o.entries({a: 1});
+report(a, b, c, d, e, f);

--- a/code/programs/rust/closurec/tests/diff_simple_fold_object_entries.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_fold_object_entries.rs
@@ -1,0 +1,114 @@
+//! Integration test for the `tests/diff/simple-fold-object-entries/` fixture.
+//!
+//! End-to-end oracle for static `Object.entries(...)` folding in
+//! `closure-pass-constant-fold`: `Object.entries({k: v, …})` collapses to the
+//! array of `[key, value]` pair literals `[["k", v], …]` (ECMAScript §20.1.2.5)
+//! when every property is a plain data property with a primitive-literal value.
+//! An integer-index key (`{1: "x"}`, which would reorder), a `__proto__` key
+//! (the prototype setter, not an own property), and a non-global receiver
+//! (`o.entries(...)`) are all declined.
+//!
+//! At SIMPLE the fixture optimizes to:
+//!
+//! ```text
+//! var a=[["a",1],["b",2]];var b=[["x","hi"]];var c=[];var d=Object.entries({1:"x"});var e=Object.entries({__proto__:1});var f=o.entries({a:1});report(a,b,c,d,e,f);
+//! ```
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
+
+fn read_flags() -> Vec<String> {
+    let raw = std::fs::read_to_string("tests/diff/simple-fold-object-entries/flags.txt")
+        .expect("read flags.txt");
+    raw.lines()
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[test]
+fn simple_fold_object_entries_fixture_matches_expected_stdout() {
+    let flags = read_flags();
+    let out = Command::new(BINARY)
+        .args(&flags)
+        .output()
+        .expect("run closurec");
+
+    assert!(
+        out.status.success(),
+        "exit: {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let actual = String::from_utf8_lossy(&out.stdout);
+    let expected = std::fs::read_to_string("tests/diff/simple-fold-object-entries/expected.stdout")
+        .expect("read expected.stdout");
+    assert_eq!(
+        actual.trim_end_matches('\n'),
+        expected.trim_end_matches('\n'),
+        "mismatch.\nflags: {flags:?}\nactual:\n{actual}\nexpected:\n{expected}",
+    );
+}
+
+/// Each bare-global `Object.entries({…})` of static data properties folds to the
+/// matching array of `[key, value]` pairs; the empty object is `[]`.
+#[test]
+fn simple_fold_object_entries_folds_to_pairs() {
+    let out = Command::new(BINARY)
+        .args(read_flags())
+        .output()
+        .expect("run closurec");
+    let actual = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        actual.contains(r#"a=[["a",1],["b",2]]"#),
+        "entries({{a:1,b:2}}) → [[\"a\",1],[\"b\",2]]; got:\n{actual}"
+    );
+    assert!(
+        actual.contains(r#"b=[["x","hi"]]"#),
+        "entries({{x:\"hi\"}}) → [[\"x\",\"hi\"]]; got:\n{actual}"
+    );
+    assert!(
+        actual.contains("c=[]"),
+        "entries({{}}) → [] (empty case); got:\n{actual}"
+    );
+    // Integer-index key: declined (would reorder ahead of string keys).
+    assert!(
+        actual.contains(r#"d=Object.entries({1:"x"})"#),
+        "entries({{1:\"x\"}}) must NOT fold (integer-index key); got:\n{actual}"
+    );
+    // __proto__ key: declined (prototype setter, not an own property).
+    assert!(
+        actual.contains(r#"e=Object.entries({__proto__:1})"#),
+        "entries({{__proto__:1}}) must NOT fold (prototype setter); got:\n{actual}"
+    );
+    // Non-global receiver: declined.
+    assert!(
+        actual.contains(r#"f=o.entries({a:1})"#),
+        "o.entries(...) must NOT fold (only the bare global Object); got:\n{actual}"
+    );
+}
+
+/// Regression guard: the output must be the SIMPLE typed pipeline, not the
+/// `WHITESPACE_ONLY` fallback (which would leave every call intact). Exactly
+/// three `entries(` calls survive — the two declined Object.entries (integer
+/// index and __proto__) and the non-global receiver — while the foldable calls
+/// collapse. (Under the whitespace fallback all six would remain.)
+#[test]
+fn simple_fold_object_entries_did_not_fall_back_to_whitespace_only() {
+    let out = Command::new(BINARY)
+        .args(read_flags())
+        .output()
+        .expect("run closurec");
+    let actual = String::from_utf8_lossy(&out.stdout);
+
+    assert_eq!(
+        actual.matches("entries(").count(),
+        3,
+        "exactly three entries( calls (two declined Object.entries + the \
+         non-global receiver) should remain — proving the typed SIMPLE optimizer \
+         ran, not the whitespace fallback; got:\n{actual}",
+    );
+}


### PR DESCRIPTION
## What

Adds a constant-fold rule for the static `Object.entries` (ECMAScript §20.1.2.5) — the inverse of `Object.fromEntries`. A non-empty object literal of plain data properties with primitive-literal values collapses to its array of own enumerable string-keyed `[key, value]` pair literals at `--compilation_level SIMPLE` (and ADVANCED). The empty-object case `Object.entries({})` → `[]` was already handled.

| input                          | SIMPLE output       |
|--------------------------------|---------------------|
| `Object.entries({a: 1, b: 2})` | `[["a",1],["b",2]]` |
| `Object.entries({x: "hi"})`    | `[["x","hi"]]`      |

## Soundness

Applies **only** when every property is a plain data property (`k: v` — no getter, setter, method, or computed key) with a primitive-literal value (string / number / boolean / null). Declines (declining is always safe):

- a **`"__proto__"`** key — a non-computed `{__proto__: v}` / `{"__proto__": v}` is the §B.3.1 prototype **setter**, which creates no own property, so `Object.entries` does not enumerate it;
- any **canonical array-index** key (`0`, `1`, `42`, …) — `[[OwnPropertyKeys]]` lists integer-index keys ahead of string keys, which would reorder the source order we emit;
- any **non-literal value** (including the implicit identifier of a shorthand `{x}`);
- getters / setters / methods / computed keys; a non-global receiver; arity ≠ 1.

Duplicate keys collapse to one entry (first position, last value), mirroring the object the literal builds. Each entry key is emitted as a string literal.

Inline security review (senior-Rust-engineer subagent) **passed** — verified `is_array_index` boundary correctness (`4294967294` = 2³²−2 is an index, `4294967295` = 2³²−1 is not), both `__proto__` key forms declined, computed `["__proto__"]` conservatively declined, dedup semantics, and no Rust safety issues.

## Tests

- **cf 0.72.0**: new dispatch arm + `fold_object_entries_pairs` / `is_array_index` helpers; 9 new unit tests (287 total) — folds, all primitive value kinds, string/non-index-numeric keys, duplicate last-wins, and every decline path (integer index, `__proto__`, non-literal value/shorthand, getter/method/computed, keys/values-still-decline, non-global receiver).
- **cc 0.221.0**: end-to-end fixture `tests/diff/simple-fold-object-entries/` + integration test `tests/diff_simple_fold_object_entries.rs` (byte-exact stdout, per-binding folds, WHITESPACE_ONLY regression guard). cli.spec.json + CHANGELOG bumps; help-markdown regenerated. Full `cargo test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)