### PR TITLE
feat(spreadsheet-core): column widths & row heights (engine-homed persisted layout)

### DIFF
--- a/code/packages/rust/spreadsheet-core/CHANGELOG.md
+++ b/code/packages/rust/spreadsheet-core/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## 0.16.0
+
+**Column widths & row heights — engine-homed, persisted layout.** The `Workbook`
+now stores per-sheet column widths and row heights, the engine side of resizable
+columns/rows in the demos. The engine treats the value as an **opaque `f64` in host
+units it never interprets** — it only stores, key-shifts, and serializes it; the host
+owns the unit, the default, and any min/max clamp.
+
+- `Sheet` gains `col_widths: HashMap<u32, f64>` + `row_heights: HashMap<u32, f64>`,
+  keyed by the 1-based column / row index. A column / row absent from the map uses the
+  host default, so a fresh sheet (both maps empty) is byte-identical to before.
+- API: `column_width(sheet, col) -> Option<f64>` / `row_height(sheet, row)`;
+  `column_widths_in(sheet, c0, c1)` / `row_heights_in(sheet, r0, r1)` bulk reads (only
+  the customized indices in range, sorted) so a host fetches a viewport's overrides in
+  one call; `set_column_width` / `set_row_height` (return `bool`; reject `NaN` / `±∞` /
+  `≤ 0` / index 0 so a bad host value can't poison the map or the file; setting the
+  current value is a no-op, no revision bump); `clear_column_width` / `clear_row_height`.
+- **Structural edits shift the keys.** `apply_structural_edit` slides column-width keys
+  on InsertCols / DeleteCols and row-height keys on InsertRows / DeleteRows (reusing the
+  same `insert_coord` / `delete_coord` helpers that shift cell addresses and references,
+  now `pub(crate)`), dropping a key in a deleted band — so widen column C, insert a
+  column at B, and the widened column (now D) keeps its width. The other axis is untouched.
+- **Sort-immune:** column widths are columnar and row heights positional, so a range
+  sort (which reorders row *records*) leaves them where they are (matches Excel —
+  resize is chrome, not cell data).
+- **Persisted:** `serialize` emits optional per-sheet `colWidths` / `rowHeights` arrays
+  (sorted, **only when non-empty** — the document stays `version: 1` and a workbook with
+  no custom sizes serializes byte-identically to before, exactly as `formats` was added).
+  `deserialize` reads them **tolerantly** — a missing array, a non-finite / ≤ 0 value, or
+  a 0 / out-of-`u32` index is skipped, never aborting the load.
+- Sheet management is free: the maps live inside `Sheet`, so `delete_sheet` drops them
+  and `move_sheet` carries them with no reindex (they're keyed by col/row, not `SheetId`).
+- 8 new tests (set/get/clear, reject bad values + indices, bulk-in-range, insert/delete
+  shift both axes independently, sort-immunity, two-sheet round-trip, tolerant load,
+  empty-omits-arrays). 203 tests pass; `#![forbid(unsafe_code)]` unchanged.
+
 ## 0.15.0
 
 **Sheet management + multi-sheet load fix (multi-sheet PR-4 — the last engine

--- a/code/packages/rust/spreadsheet-core/Cargo.toml
+++ b/code/packages/rust/spreadsheet-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spreadsheet-core"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 description = "Headless spreadsheet engine — cell model, formula AST, dependency DAG, recalc, dispatch to Layer-1 cores. The engine VisiCalc Modern and any other Mosaic-rendered spreadsheet sits on top of."
 

--- a/code/packages/rust/spreadsheet-core/src/edit.rs
+++ b/code/packages/rust/spreadsheet-core/src/edit.rs
@@ -82,7 +82,7 @@ pub enum StructuralEdit {
 /// Lines at or after the insertion point slide outward; earlier lines are
 /// unchanged. Saturates at `u32::MAX` rather than wrapping (a reference pushed
 /// past the end of the grid by an absurd insert is clamped, never corrupted).
-fn insert_coord(v: u32, at: u32, count: u32) -> u32 {
+pub(crate) fn insert_coord(v: u32, at: u32, count: u32) -> u32 {
     if v >= at {
         v.saturating_add(count)
     } else {
@@ -93,7 +93,7 @@ fn insert_coord(v: u32, at: u32, count: u32) -> u32 {
 /// Adjust one 1-based coordinate for a **delete** of the band `[at, at+count)`.
 /// Returns `None` if the coordinate is *inside* the deleted band (the cell it
 /// names no longer exists); coordinates after the band slide inward.
-fn delete_coord(v: u32, at: u32, count: u32) -> Option<u32> {
+pub(crate) fn delete_coord(v: u32, at: u32, count: u32) -> Option<u32> {
     let band_end = at.saturating_add(count); // exclusive
     if v < at {
         Some(v) // before the band — unchanged

--- a/code/packages/rust/spreadsheet-core/src/workbook.rs
+++ b/code/packages/rust/spreadsheet-core/src/workbook.rs
@@ -11,7 +11,7 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use crate::address::{CellAddress, CellRange, SheetId, MAX_RANGE_CELLS};
 use crate::cell::{Cell, CellContent, CellValue};
 use crate::dag::DependencyGraph;
-use crate::edit::StructuralEdit;
+use crate::edit::{delete_coord, insert_coord, StructuralEdit};
 use crate::errors::SpreadsheetError;
 use crate::parser::{parse, ParseError};
 use crate::recalc::{collect_refs, evaluate};
@@ -92,6 +92,17 @@ struct Sheet {
     ///
     /// [`get_display`]: Workbook::get_display
     formats: HashMap<CellAddress, String>,
+    /// Per-column widths and per-row heights, keyed by the 1-based column / row
+    /// index. The value is an **opaque `f64` in host units** (the engine never
+    /// computes with it — it only stores, key-shifts on structural edits, and
+    /// serializes it). A column / row *absent* from the map uses the host's
+    /// default size, so a fresh sheet (both maps empty) is byte-identical to the
+    /// pre-feature behaviour. See [`set_column_width`] / [`set_row_height`].
+    ///
+    /// [`set_column_width`]: Workbook::set_column_width
+    /// [`set_row_height`]: Workbook::set_row_height
+    col_widths: HashMap<u32, f64>,
+    row_heights: HashMap<u32, f64>,
 }
 
 impl Workbook {
@@ -117,6 +128,8 @@ impl Workbook {
             name: name.clone(),
             cells: HashMap::new(),
             formats: HashMap::new(),
+            col_widths: HashMap::new(),
+            row_heights: HashMap::new(),
         });
         self.sheet_by_name.insert(name, id);
         id
@@ -594,6 +607,140 @@ impl Workbook {
         self.apply_structural_edit(sheet, StructuralEdit::DeleteCols { at, count });
     }
 
+    // ── Column widths & row heights ──────────────────────────────────────
+    // Per-sheet presentation chrome: the engine STORES a width/height keyed by
+    // column/row index but never reads it for any computation. A host renders
+    // columns/rows at these sizes; an index with no stored size uses the host's
+    // own default. The value is an opaque `f64` in whatever unit the host picks
+    // (the demos use pixels). These survive save/load and shift with their
+    // column/row on a structural edit (see `apply_structural_edit`).
+
+    /// The stored width of a 1-based `col` on `sheet`, or `None` if the column has
+    /// no custom width (the host should use its default). `None` for an unknown
+    /// sheet or `col == 0`.
+    pub fn column_width(&self, sheet: SheetId, col: u32) -> Option<f64> {
+        self.sheets
+            .get(sheet.0 as usize)
+            .and_then(|s| s.col_widths.get(&col).copied())
+    }
+
+    /// The stored height of a 1-based `row` on `sheet`, or `None` if the row has
+    /// no custom height. `None` for an unknown sheet or `row == 0`.
+    pub fn row_height(&self, sheet: SheetId, row: u32) -> Option<f64> {
+        self.sheets
+            .get(sheet.0 as usize)
+            .and_then(|s| s.row_heights.get(&row).copied())
+    }
+
+    /// Every customized column width in the inclusive 1-based range `[col0, col1]`
+    /// on `sheet`, as `(col, width)` pairs sorted by column. Columns with no custom
+    /// width are omitted — a host fetches a viewport's overrides in one call instead
+    /// of one probe per column. Empty for an unknown sheet or an empty range.
+    pub fn column_widths_in(&self, sheet: SheetId, col0: u32, col1: u32) -> Vec<(u32, f64)> {
+        let Some(s) = self.sheets.get(sheet.0 as usize) else {
+            return Vec::new();
+        };
+        let mut out: Vec<(u32, f64)> = s
+            .col_widths
+            .iter()
+            .filter(|(c, _)| **c >= col0 && **c <= col1)
+            .map(|(c, w)| (*c, *w))
+            .collect();
+        out.sort_by_key(|(c, _)| *c);
+        out
+    }
+
+    /// Every customized row height in the inclusive 1-based range `[row0, row1]` on
+    /// `sheet`, as `(row, height)` pairs sorted by row. The row analogue of
+    /// [`column_widths_in`].
+    ///
+    /// [`column_widths_in`]: Workbook::column_widths_in
+    pub fn row_heights_in(&self, sheet: SheetId, row0: u32, row1: u32) -> Vec<(u32, f64)> {
+        let Some(s) = self.sheets.get(sheet.0 as usize) else {
+            return Vec::new();
+        };
+        let mut out: Vec<(u32, f64)> = s
+            .row_heights
+            .iter()
+            .filter(|(r, _)| **r >= row0 && **r <= row1)
+            .map(|(r, h)| (*r, *h))
+            .collect();
+        out.sort_by_key(|(r, _)| *r);
+        out
+    }
+
+    /// Set the width of a 1-based `col` on `sheet`. Returns `true` if the map
+    /// changed. Rejects (returns `false`, leaving the map untouched) a non-finite
+    /// width (`NaN` / `±∞`), a width `≤ 0`, `col == 0`, or an unknown sheet — so a
+    /// bad host value can never poison the map or the serialized file. Setting the
+    /// width a column already has is a no-op (no revision bump), matching the
+    /// engine's diff-gating convention so an unchanged resize isn't snapshotted.
+    pub fn set_column_width(&mut self, sheet: SheetId, col: u32, width: f64) -> bool {
+        if col == 0 || !width.is_finite() || width <= 0.0 {
+            return false;
+        }
+        let Some(s) = self.sheets.get_mut(sheet.0 as usize) else {
+            return false;
+        };
+        if s.col_widths.get(&col) == Some(&width) {
+            return false; // unchanged
+        }
+        s.col_widths.insert(col, width);
+        self.revision = self.revision.wrapping_add(1);
+        true
+    }
+
+    /// Set the height of a 1-based `row` on `sheet`. The row analogue of
+    /// [`set_column_width`] — same finite / `> 0` / `row ≥ 1` validation and
+    /// same-value no-op.
+    ///
+    /// [`set_column_width`]: Workbook::set_column_width
+    pub fn set_row_height(&mut self, sheet: SheetId, row: u32, height: f64) -> bool {
+        if row == 0 || !height.is_finite() || height <= 0.0 {
+            return false;
+        }
+        let Some(s) = self.sheets.get_mut(sheet.0 as usize) else {
+            return false;
+        };
+        if s.row_heights.get(&row) == Some(&height) {
+            return false; // unchanged
+        }
+        s.row_heights.insert(row, height);
+        self.revision = self.revision.wrapping_add(1);
+        true
+    }
+
+    /// Remove a column's custom width, returning it to the host default. Returns
+    /// `true` if an entry was removed (and bumps the revision); `false` if the
+    /// column had no custom width or the sheet is unknown.
+    pub fn clear_column_width(&mut self, sheet: SheetId, col: u32) -> bool {
+        let Some(s) = self.sheets.get_mut(sheet.0 as usize) else {
+            return false;
+        };
+        if s.col_widths.remove(&col).is_some() {
+            self.revision = self.revision.wrapping_add(1);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Remove a row's custom height, returning it to the host default. The row
+    /// analogue of [`clear_column_width`].
+    ///
+    /// [`clear_column_width`]: Workbook::clear_column_width
+    pub fn clear_row_height(&mut self, sheet: SheetId, row: u32) -> bool {
+        let Some(s) = self.sheets.get_mut(sheet.0 as usize) else {
+            return false;
+        };
+        if s.row_heights.remove(&row).is_some() {
+            self.revision = self.revision.wrapping_add(1);
+            true
+        } else {
+            false
+        }
+    }
+
     /// Apply a [`StructuralEdit`] to one sheet: relocate every cell, rewrite each
     /// formula's references and echo text, drop cells on deleted lines, rebuild
     /// the dependency graph, and recalculate. A no-op if `sheet` is unknown.
@@ -693,6 +840,38 @@ impl Workbook {
             }
         }
         self.sheets[sheet.0 as usize].formats = moved_formats;
+
+        // 1d. Shift the column-width / row-height keys the same way. A width is
+        //     keyed by COLUMN index, so only a column insert/delete moves it; a
+        //     height by ROW index, so only a row insert/delete. The OTHER axis is
+        //     untouched (widen column C, insert a row → column C stays wide). A key
+        //     in a deleted band is dropped (`delete_coord → None`), exactly as a
+        //     cell/format on a deleted line is. Reuses the same `insert_coord` /
+        //     `delete_coord` helpers that shift cell addresses and references, so
+        //     the chrome stays aligned with the data it decorates.
+        let s = &mut self.sheets[sheet.0 as usize];
+        match edit {
+            StructuralEdit::InsertCols { at, count } => {
+                s.col_widths = shift_axis_keys(std::mem::take(&mut s.col_widths), |c| {
+                    Some(insert_coord(c, at, count))
+                });
+            }
+            StructuralEdit::DeleteCols { at, count } => {
+                s.col_widths = shift_axis_keys(std::mem::take(&mut s.col_widths), |c| {
+                    delete_coord(c, at, count)
+                });
+            }
+            StructuralEdit::InsertRows { at, count } => {
+                s.row_heights = shift_axis_keys(std::mem::take(&mut s.row_heights), |r| {
+                    Some(insert_coord(r, at, count))
+                });
+            }
+            StructuralEdit::DeleteRows { at, count } => {
+                s.row_heights = shift_axis_keys(std::mem::take(&mut s.row_heights), |r| {
+                    delete_coord(r, at, count)
+                });
+            }
+        }
 
         // 2. Every address moved, so the old dependency edges are stale. Rebuild
         //    the graph from the rewritten ASTs, then recalc the whole workbook.
@@ -1414,12 +1593,16 @@ impl Workbook {
     /// never disagree with the engine.
     ///
     /// Shape (version 1), cells and formats sorted by (row, col) for stable
-    /// output:
+    /// output. The optional `colWidths` / `rowHeights` arrays (sorted by index)
+    /// appear only when a sheet has custom sizes, so a workbook with none is
+    /// byte-identical to the pre-feature output:
     /// ```json
     /// {"version":1,"sheets":[{"name":"Sheet1",
     ///   "cells":[{"a1":"A1","value":{"number":15.0}},
     ///            {"a1":"E1","formula":"=SUM(A1:D1)"}],
-    ///   "formats":[{"a1":"E1","code":"#,##0.00"}]}]}
+    ///   "formats":[{"a1":"E1","code":"#,##0.00"}],
+    ///   "colWidths":[{"col":3,"w":140.0}],
+    ///   "rowHeights":[{"row":2,"h":40.0}]}]}
     /// ```
     /// No I/O happens here — the caller writes the returned string wherever it
     /// likes. Round-trips through [`deserialize`].
@@ -1453,7 +1636,33 @@ impl Workbook {
                     .map(|(addr, code)| json!({ "a1": addr.to_a1(), "code": code }))
                     .collect();
 
-                json!({ "name": s.name, "cells": cells_json, "formats": fmts_json })
+                let mut sheet_obj = json!({
+                    "name": s.name, "cells": cells_json, "formats": fmts_json
+                });
+                // Column widths / row heights are additive: emit them ONLY when a
+                // sheet has custom sizes, so a workbook with none serializes
+                // byte-identically to the pre-feature output (the document stays
+                // version 1, and an old reader ignores unknown keys). Sorted by
+                // index for stable output.
+                if !s.col_widths.is_empty() {
+                    let mut ws: Vec<(&u32, &f64)> = s.col_widths.iter().collect();
+                    ws.sort_by_key(|(c, _)| **c);
+                    let ws_json: Vec<Value> = ws
+                        .iter()
+                        .map(|(c, w)| json!({ "col": *c, "w": *w }))
+                        .collect();
+                    sheet_obj["colWidths"] = Value::Array(ws_json);
+                }
+                if !s.row_heights.is_empty() {
+                    let mut hs: Vec<(&u32, &f64)> = s.row_heights.iter().collect();
+                    hs.sort_by_key(|(r, _)| **r);
+                    let hs_json: Vec<Value> = hs
+                        .iter()
+                        .map(|(r, h)| json!({ "row": *r, "h": *h }))
+                        .collect();
+                    sheet_obj["rowHeights"] = Value::Array(hs_json);
+                }
+                sheet_obj
             })
             .collect();
 
@@ -1536,6 +1745,37 @@ impl Workbook {
                     let addr = CellAddress::parse(a1)
                         .map_err(|e| format!("bad format address {a1:?}: {}", e.display()))?;
                     self.set_format(sheet, addr, code);
+                }
+            }
+
+            // Column widths / row heights are read TOLERANTLY — a missing array, a
+            // non-numeric / non-finite / ≤ 0 value, or a 0 / out-of-u32 index is
+            // skipped (never aborts the load), so a hand-edited or future file can't
+            // crash a load over presentation chrome. `set_column_width` /
+            // `set_row_height` already enforce the finite / `> 0` / index ≥ 1 rules,
+            // so a bad entry simply doesn't take.
+            if let Some(ws) = sj.get("colWidths").and_then(Value::as_array) {
+                for w in ws {
+                    if let (Some(col), Some(width)) = (
+                        w.get("col").and_then(Value::as_u64),
+                        w.get("w").and_then(Value::as_f64),
+                    ) {
+                        if let Ok(col) = u32::try_from(col) {
+                            self.set_column_width(sheet, col, width);
+                        }
+                    }
+                }
+            }
+            if let Some(hs) = sj.get("rowHeights").and_then(Value::as_array) {
+                for h in hs {
+                    if let (Some(row), Some(height)) = (
+                        h.get("row").and_then(Value::as_u64),
+                        h.get("h").and_then(Value::as_f64),
+                    ) {
+                        if let Ok(row) = u32::try_from(row) {
+                            self.set_row_height(sheet, row, height);
+                        }
+                    }
                 }
             }
         }
@@ -1687,6 +1927,20 @@ impl Default for Workbook {
 /// overflow when `row1 - row0 == u32::MAX`, wrapping to a bogus small count that
 /// slips past the cap and sends the caller's loop over the entire u32 range (an
 /// OOM DoS). `checked_mul` then rejects any product that still overflows `u64`.
+/// Re-key a column-width / row-height map under a structural edit: apply `f` to
+/// every key, keeping the entry at its new key when `f` returns `Some` and dropping
+/// it when `f` returns `None` (the index sat inside a deleted band). The value (the
+/// width / height) rides along unchanged. Used by [`Workbook::apply_structural_edit`]
+/// to slide column widths / row heights with their columns / rows.
+fn shift_axis_keys(
+    map: HashMap<u32, f64>,
+    f: impl Fn(u32) -> Option<u32>,
+) -> HashMap<u32, f64> {
+    map.into_iter()
+        .filter_map(|(k, v)| f(k).map(|nk| (nk, v)))
+        .collect()
+}
+
 /// Coerce a raw literal string (already trimmed, not a formula) to a typed value:
 /// `"TRUE"`/`"FALSE"` (any case) → boolean, a finite parseable number → number,
 /// anything else → text. The literal half of [`Workbook::set_raw`]'s policy.
@@ -3219,5 +3473,171 @@ mod tests {
         // Case-insensitive replace of "hello" → "Hi" splices over the original span.
         assert_eq!(wb.replace_all(s, "hello", "Hi", false), 1);
         assert_eq!(wb.get_value(s, cell(1, 1)), Some(CellValue::Text("Hi".into())));
+    }
+
+    // ── Column widths & row heights ──────────────────────────────────────
+
+    #[test]
+    fn column_width_and_row_height_set_get_clear() {
+        let mut wb = Workbook::new();
+        let s = wb.add_sheet("S");
+        // Absent → None (host uses its default).
+        assert_eq!(wb.column_width(s, 3), None);
+        assert_eq!(wb.row_height(s, 2), None);
+        // Set, then read back.
+        assert!(wb.set_column_width(s, 3, 140.0));
+        assert!(wb.set_row_height(s, 2, 40.0));
+        assert_eq!(wb.column_width(s, 3), Some(140.0));
+        assert_eq!(wb.row_height(s, 2), Some(40.0));
+        // Setting the SAME value is a no-op (returns false, revision unchanged).
+        let rev = wb.current_revision();
+        assert!(!wb.set_column_width(s, 3, 140.0));
+        assert!(!wb.set_row_height(s, 2, 40.0));
+        assert_eq!(wb.current_revision(), rev);
+        // A different value overwrites + bumps the revision.
+        assert!(wb.set_column_width(s, 3, 200.0));
+        assert_eq!(wb.column_width(s, 3), Some(200.0));
+        assert!(wb.current_revision() > rev);
+        // Clear → back to None; clearing an absent one returns false.
+        assert!(wb.clear_column_width(s, 3));
+        assert_eq!(wb.column_width(s, 3), None);
+        assert!(!wb.clear_column_width(s, 3));
+        assert!(wb.clear_row_height(s, 2));
+        assert_eq!(wb.row_height(s, 2), None);
+    }
+
+    #[test]
+    fn set_size_rejects_bad_values_and_indices() {
+        let mut wb = Workbook::new();
+        let s = wb.add_sheet("S");
+        for bad in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY, 0.0, -5.0] {
+            assert!(!wb.set_column_width(s, 1, bad), "width {bad} must be rejected");
+            assert!(!wb.set_row_height(s, 1, bad), "height {bad} must be rejected");
+        }
+        // Index 0 is invalid (the grid is 1-based).
+        assert!(!wb.set_column_width(s, 0, 100.0));
+        assert!(!wb.set_row_height(s, 0, 100.0));
+        // An unknown sheet is rejected, not panicked.
+        assert!(!wb.set_column_width(SheetId(9), 1, 100.0));
+        assert_eq!(wb.column_width(s, 1), None);
+    }
+
+    #[test]
+    fn widths_and_heights_in_range_are_filtered_and_sorted() {
+        let mut wb = Workbook::new();
+        let s = wb.add_sheet("S");
+        for (c, w) in [(2u32, 80.0), (5, 120.0), (3, 100.0), (9, 200.0)] {
+            wb.set_column_width(s, c, w);
+        }
+        // Only columns in [3, 6], sorted ascending.
+        assert_eq!(wb.column_widths_in(s, 3, 6), vec![(3, 100.0), (5, 120.0)]);
+        // Row analogue.
+        wb.set_row_height(s, 4, 30.0);
+        wb.set_row_height(s, 1, 20.0);
+        assert_eq!(wb.row_heights_in(s, 1, 4), vec![(1, 20.0), (4, 30.0)]);
+        // Empty range / unknown sheet → empty.
+        assert!(wb.column_widths_in(s, 100, 200).is_empty());
+        assert!(wb.column_widths_in(SheetId(9), 1, 10).is_empty());
+    }
+
+    #[test]
+    fn structural_edits_shift_width_and_height_keys() {
+        let mut wb = Workbook::new();
+        let s = wb.add_sheet("S");
+        wb.set_column_width(s, 3, 140.0); // column C
+        wb.set_row_height(s, 2, 40.0); // row 2
+
+        // Insert a column at B (col 2): C's width slides to D (col 4). Heights untouched.
+        wb.insert_cols(s, 2, 1);
+        assert_eq!(wb.column_width(s, 3), None);
+        assert_eq!(wb.column_width(s, 4), Some(140.0));
+        assert_eq!(wb.row_height(s, 2), Some(40.0)); // other axis unmoved
+
+        // Insert a row at 1: row 2's height slides to row 3. Widths untouched.
+        wb.insert_rows(s, 1, 1);
+        assert_eq!(wb.row_height(s, 2), None);
+        assert_eq!(wb.row_height(s, 3), Some(40.0));
+        assert_eq!(wb.column_width(s, 4), Some(140.0)); // width still at D
+
+        // Delete the row holding the height (now row 3): its height is dropped.
+        wb.delete_rows(s, 3, 1);
+        assert_eq!(wb.row_height(s, 3), None);
+        assert!(wb.row_heights_in(s, 1, 1000).is_empty());
+
+        // Delete a column before the widened one (col 4 → back to col 3): width slides.
+        wb.delete_cols(s, 1, 1);
+        assert_eq!(wb.column_width(s, 3), Some(140.0));
+        // Delete the widened column itself: its width is dropped.
+        wb.delete_cols(s, 3, 1);
+        assert_eq!(wb.column_width(s, 3), None);
+        assert!(wb.column_widths_in(s, 1, 1000).is_empty());
+    }
+
+    #[test]
+    fn range_sort_does_not_move_widths_or_heights() {
+        // Resize is positional chrome, not record data: sorting the VALUES of rows
+        // must leave the column widths and row heights where they are.
+        let mut wb = Workbook::new();
+        let s = wb.add_sheet("S");
+        wb.set_value(s, cell(1, 1), CellValue::Number(3.0));
+        wb.set_value(s, cell(2, 1), CellValue::Number(1.0));
+        wb.set_value(s, cell(3, 1), CellValue::Number(2.0));
+        wb.set_column_width(s, 1, 150.0); // column A wide
+        wb.set_row_height(s, 1, 50.0); // row 1 tall
+        wb.sort_range(s, CellRange::new(cell(1, 1), cell(3, 1)), 1, true);
+        // Values reordered (1,2,3) but A stays wide and row 1 stays tall.
+        assert_eq!(wb.get_value(s, cell(1, 1)), Some(CellValue::Number(1.0)));
+        assert_eq!(wb.column_width(s, 1), Some(150.0));
+        assert_eq!(wb.row_height(s, 1), Some(50.0));
+    }
+
+    #[test]
+    fn serialize_round_trips_widths_and_heights_across_two_sheets() {
+        let mut wb = Workbook::new();
+        let s1 = wb.add_sheet("Sheet1");
+        let s2 = wb.add_sheet("Summary");
+        wb.set_column_width(s1, 3, 140.0);
+        wb.set_row_height(s1, 2, 40.0);
+        wb.set_column_width(s2, 1, 90.5);
+        let doc = wb.serialize();
+        assert!(doc.contains("colWidths"));
+        assert!(doc.contains("rowHeights"));
+
+        let mut loaded = Workbook::new();
+        loaded.deserialize(&doc).expect("round-trips");
+        assert_eq!(loaded.column_width(SheetId(0), 3), Some(140.0));
+        assert_eq!(loaded.row_height(SheetId(0), 2), Some(40.0));
+        assert_eq!(loaded.column_width(SheetId(1), 1), Some(90.5));
+    }
+
+    #[test]
+    fn deserialize_is_tolerant_of_missing_and_bad_sizes() {
+        let mut wb = Workbook::new();
+        // No size arrays at all (e.g. an old file) loads fine.
+        wb.deserialize(r#"{"version":1,"sheets":[{"name":"S","cells":[],"formats":[]}]}"#)
+            .expect("old-shape file loads");
+        assert_eq!(wb.column_width(SheetId(0), 1), None);
+        // A non-finite / ≤ 0 / index-0 entry is SKIPPED, not fatal.
+        let doc = r#"{"version":1,"sheets":[{"name":"S","cells":[],"formats":[],
+            "colWidths":[{"col":2,"w":120.0},{"col":3,"w":-9.0},{"col":0,"w":50.0}],
+            "rowHeights":[{"row":1,"h":30.0}]}]}"#;
+        let mut wb2 = Workbook::new();
+        wb2.deserialize(doc).expect("tolerant load");
+        assert_eq!(wb2.column_width(SheetId(0), 2), Some(120.0)); // good one took
+        assert_eq!(wb2.column_width(SheetId(0), 3), None); // negative skipped
+        assert_eq!(wb2.column_width(SheetId(0), 0), None); // index 0 skipped
+        assert_eq!(wb2.row_height(SheetId(0), 1), Some(30.0));
+    }
+
+    #[test]
+    fn serialize_of_no_custom_sizes_omits_the_arrays() {
+        // A workbook with no resizes must serialize byte-identically to the
+        // pre-feature output (no colWidths / rowHeights keys at all).
+        let mut wb = Workbook::new();
+        let s = wb.add_sheet("S");
+        wb.set_value(s, cell(1, 1), CellValue::Number(15.0));
+        let doc = wb.serialize();
+        assert!(!doc.contains("colWidths"));
+        assert!(!doc.contains("rowHeights"));
     }
 }

--- a/code/specs/spreadsheet-core.md
+++ b/code/specs/spreadsheet-core.md
@@ -913,6 +913,43 @@ Consequences, all intentional:
   state, not document state, so it is deliberately excluded from snapshots; undo
   restores cells, not what is on the clipboard.
 
+### §16.2 Column widths & row heights
+
+A real spreadsheet lets you resize columns and rows. The width/height is pure
+**presentation chrome** — the engine never *computes* with it — but it is stored in
+the engine (not left to each host) so it **persists across save/load** and stays
+consistent across every backend, the same way per-cell display formats are.
+
+- **Storage.** Each `Sheet` holds `col_widths: HashMap<u32, f64>` and
+  `row_heights: HashMap<u32, f64>`, keyed by the 1-based column / row index. The value
+  is an **opaque `f64` in host units** — the engine stores, key-shifts, and serializes
+  it but never interprets it. A column/row **absent** from the map uses the host's
+  default, so a sheet with no resizes is byte-identical to the pre-feature behaviour.
+  The host owns the unit (the demos use pixels), the default size, and any min/max clamp.
+- **API.** `column_width(sheet, col) -> Option<f64>` / `row_height(sheet, row)`;
+  `column_widths_in` / `row_heights_in` (bulk: only the customized indices in an
+  inclusive range, sorted, for a one-call viewport fetch); `set_column_width` /
+  `set_row_height` (return `bool`; **reject `NaN` / `±∞` / `≤ 0` / index 0** so a bad
+  host value can never poison the map or the serialized file; setting the current value
+  is a no-op with no revision bump, matching the diff-gating convention);
+  `clear_column_width` / `clear_row_height`.
+- **Structural edits shift the keys.** Insert/delete columns slide the `col_widths`
+  keys (drop a key in a deleted band); insert/delete rows do the same to `row_heights`;
+  the other axis is untouched. This reuses the same `insert_coord` / `delete_coord`
+  helpers that shift cell addresses and references, so a widened column stays widened as
+  it moves: widen C, insert a column at B, and the now-D column keeps its width.
+- **Sort-immune.** Column widths are columnar and row heights positional, so a range
+  sort — which reorders the *values* of row records — leaves both where they are. Resize
+  is chrome, not cell data (matches Excel).
+- **Persistence.** `serialize` adds optional per-sheet `colWidths` / `rowHeights` arrays
+  (sorted, emitted **only when non-empty**), so the document stays `version: 1` and a
+  workbook with no custom sizes serializes byte-identically — exactly how `formats` was
+  added. `deserialize` reads them **tolerantly**: a missing array, a non-finite / `≤ 0`
+  value, or a `0` / out-of-`u32` index is skipped, never aborting the load.
+- **Out of scope:** auto-fit ("size to widest cell" needs font metrics the engine
+  doesn't have) and hidden rows/columns (`set_*` rejects `≤ 0`; hiding is a separate
+  feature). See `code/specs/visicalc-column-width-row-height.md` for the full rollout.
+
 ---
 
 ## §17 Test Vectors

--- a/code/specs/visicalc-column-width-row-height.md
+++ b/code/specs/visicalc-column-width-row-height.md
@@ -1,0 +1,246 @@
+# VisiCalc column width & row height
+
+Status: **draft** (spec-first; no implementation yet)
+Scope: the next cross-cutting feature after multi-sheet, rolled out the same way
+— engine first, then the 3 facades, then all 6 VisiCalc demos
+(web → Qt → Flutter → Compose → XAML → SwiftUI), one PR per stage/backend, each
+security-reviewed, headless-proven, and babysat to merge.
+
+## 1. Why this, and the layering decision
+
+A real spreadsheet lets you resize columns and rows: drag a column header's right
+edge to widen it, drag a row's bottom edge to make it taller. Today every VisiCalc
+demo paints a **fixed** geometry — the web/Qt/Flutter/Compose/XAML/SwiftUI infinite
+grids all hardcode `colW = 92`, `rowH = 26`. This feature makes those per-column /
+per-row, user-adjustable, and **persisted**.
+
+**The layering question.** A column's width is pure presentation — the engine never
+*computes* with it (unlike a cell value or a format code, which changes the displayed
+string). So two designs are possible:
+
+1. **Demo-only view state** — each demo keeps its own `Map<col, width>`. Simple, but
+   the size is **lost on save/load** and every demo reinvents the same map, the same
+   insert/delete-column shifting, and the same serialization. Six divergent copies.
+2. **Engine-homed, persisted layout** *(chosen)* — the `Workbook` stores per-sheet
+   `col_widths` / `row_heights`, `serialize`/`deserialize` carry them, and a
+   **structural edit shifts the keys** (insert a column → every later column's width
+   slides right; delete a column → its width is dropped). The engine treats the value
+   as an **opaque number it never interprets** — it just persists it, keyed by column
+   or row, per sheet.
+
+Design 2 matches how *formats* were added (per-cell display codes the engine stores
+but the host paints) and how *multi-sheet* layout state lives per sheet. It keeps all
+six demos consistent and makes layout survive a save/load round-trip — the same
+"one shared engine, every backend identical" philosophy as the prior six rollouts.
+The **host owns the units, the default, and the min/max clamp**; the engine owns
+**storage, key-shifting, and persistence**.
+
+This is a *smaller* campaign than multi-sheet: **one** engine PR (the container already
+has the per-sheet `Sheet` struct, `serialize`, and `insert_coord`/`delete_coord` shift
+helpers), then facades, then six demos.
+
+## 2. Engine design (`spreadsheet-core`)
+
+### 2.1 Storage — two maps per sheet
+
+`Sheet` (today `{ name, cells, formats }`) gains two maps:
+
+```rust
+struct Sheet {
+    name: String,
+    cells: HashMap<CellAddress, Cell>,
+    formats: HashMap<CellAddress, String>,
+    col_widths: HashMap<u32, f64>,   // 1-based column index → width (host units)
+    row_heights: HashMap<u32, f64>,  // 1-based row index    → height (host units)
+}
+```
+
+A column/row **absent** from the map uses the host's default size. The value is an
+**opaque `f64`** — the engine stores and persists it but never reads it for any
+computation. Keyed by the same 1-based column/row index the rest of the API uses.
+
+### 2.2 Workbook API
+
+```rust
+// Reads — None means "no custom size; the host uses its default".
+pub fn column_width(&self, sheet: SheetId, col: u32) -> Option<f64>;
+pub fn row_height(&self, sheet: SheetId, row: u32) -> Option<f64>;
+
+// Bulk reads for a viewport strip — only the columns/rows in the inclusive range
+// that HAVE a custom size, sorted ascending. Lets a host fetch a window's overrides
+// in one call instead of one-per-column. (col0/row0 ≥ 1; empty if none.)
+pub fn column_widths_in(&self, sheet: SheetId, col0: u32, col1: u32) -> Vec<(u32, f64)>;
+pub fn row_heights_in(&self, sheet: SheetId, row0: u32, row1: u32) -> Vec<(u32, f64)>;
+
+// Writes — return true if applied, false if rejected. A width must be FINITE and
+// > 0 (NaN / ±∞ / ≤ 0 rejected, so a bad host value can't poison the map or the
+// serialized file). col/row must be ≥ 1. Bumps the revision on a real change.
+pub fn set_column_width(&mut self, sheet: SheetId, col: u32, width: f64) -> bool;
+pub fn set_row_height(&mut self, sheet: SheetId, row: u32, height: f64) -> bool;
+
+// Clear — back to the host default. Returns true if an entry was removed.
+pub fn clear_column_width(&mut self, sheet: SheetId, col: u32) -> bool;
+pub fn clear_row_height(&mut self, sheet: SheetId, row: u32) -> bool;
+```
+
+`set_*` with the same value already present is a no-op (no revision bump), matching
+the engine's existing diff-gating convention (so an undo/redo snapshot isn't created
+for a non-change).
+
+### 2.3 Structural edits shift the keys
+
+This is the part that *earns* the engine home. When rows/columns are inserted or
+deleted, the width/height keys must move with their columns/rows — reusing the exact
+`insert_coord(v, at, count)` / `delete_coord(v, at, count) -> Option<u32>` helpers that
+already shift cell addresses and formula references in `edit.rs`:
+
+- **InsertCols { at, count }** — every `col_widths` key `≥ at` slides up by `count`
+  (`insert_coord`). Heights untouched.
+- **DeleteCols { at, count }** — keys in the deleted band `[at, at+count)` are
+  **dropped** (`delete_coord` → `None`); keys past the band slide down. Heights untouched.
+- **InsertRows / DeleteRows** — the same, on `row_heights`. Widths untouched.
+
+Applied inside `apply_structural_edit` (same site that already relocates cells +
+formats + rewrites references), so insert/delete keeps the visual layout aligned with
+the data: widen column C, insert a column at B, and the widened column is now D — its
+width travels with it.
+
+### 2.4 Sheet management is free
+
+Because the maps live **inside `Sheet`**, `delete_sheet` drops them with the sheet and
+`move_sheet` carries them — no extra reindex (the maps are keyed by col/row, not by
+`SheetId`). `rename_sheet` touches neither. Nothing to add there.
+
+### 2.5 Serialize / deserialize round-trip
+
+`serialize` gains two **optional** per-sheet arrays (additive — **no version bump**;
+the document stays `version: 1`, and an old file without them loads as "no custom
+sizes", exactly as `formats` was added):
+
+```json
+{"version":1,"sheets":[{"name":"Sheet1",
+  "cells":[...], "formats":[...],
+  "colWidths":[{"col":3,"w":140.0}],
+  "rowHeights":[{"row":2,"h":40.0}]}]}
+```
+
+Sorted by index for stable output. `deserialize` reads them **tolerantly** — a missing
+array, a non-finite or ≤ 0 value, or a 0 index is skipped (never aborts the load), so a
+hand-edited or future file can't crash a load. Empty maps emit empty arrays (or are
+omitted — either is fine as long as the round-trip is lossless for real data).
+
+### 2.6 Tests (engine PR)
+
+`#![forbid(unsafe_code)]` stays. New tests:
+
+- set/get/clear a width and a height; absent → `None`; same-value set is a no-op
+  (revision unchanged); a 2nd different value overwrites.
+- reject `NaN`, `+∞`, `-∞`, `0.0`, `-5.0`; reject col/row `0`.
+- `column_widths_in` / `row_heights_in` return only in-range customized indices, sorted.
+- **InsertCols** shifts a width's key up; **DeleteCols** drops the band's width and
+  slides the rest down; rows analogous; the *other* axis is untouched.
+- a width set on a column whose cells then get sorted (`sort_range`) does **not** move
+  (sort reorders row *records*, not columns — widths are columnar) — i.e. width keys are
+  immune to sort; height keys likewise stay put (sort moves values between rows but the
+  row *heights* are positional chrome, not record data — **document this choice**).
+- `serialize` → `deserialize` round-trips widths + heights across **two** sheets; a file
+  with no width/height arrays still loads; a non-finite stored value is skipped on load.
+- single-sheet / no-resize path stays **byte-identical**: every existing test passes
+  unchanged (the maps default empty; `serialize` of a workbook with no custom sizes is
+  unchanged if empty arrays are omitted — prefer omission to keep old golden strings).
+
+> **Sort interaction (decided):** column widths are **columnar** and row heights are
+> **positional** — neither participates in a range sort (which reorders the *values* of
+> row records). Widening column C and sorting A1:E4 leaves C wide; row 2 being tall and
+> sorting leaves row 2 tall. This matches Excel (resize is chrome, not cell data).
+
+## 3. Facade design (`spreadsheet-facades`)
+
+All three facades wrap `core-wasm`'s `SpreadsheetSession`, so the logic is added **once**
+in `core-wasm`, on the **active sheet** (bare ops address it, like every other
+session method):
+
+- `core-wasm` `SpreadsheetSession`:
+  `column_width(col) -> f64` (0.0 = unset/default), `row_height(row) -> f64`,
+  `set_column_width(col, w) -> bool`, `set_row_height(row, h) -> bool`,
+  `clear_column_width(col) -> bool`, `clear_row_height(row) -> bool`, and bulk
+  `column_widths(col0, col1) -> JSON [{ "col": N, "w": F }, …]` /
+  `row_heights(row0, row1) -> JSON [{ "row": N, "h": F }, …]`. The mutators go through
+  the existing `mutate` gate (so a resize is **undoable** and snapshot-tracked, like any
+  edit). 0.0 is an unambiguous "unset" sentinel because a valid width is always `> 0`.
+- `capi`: `sc_column_width(s, col) -> double`, `sc_row_height(s, row) -> double`,
+  `sc_set_column_width(s, col, w) -> int` (1/0), `sc_set_row_height(s, row, h) -> int`,
+  `sc_clear_column_width(s, col) -> int`, `sc_clear_row_height(s, row) -> int`,
+  `sc_column_widths(s, col0, col1) -> char*` (JSON, free with `sc_string_free`),
+  `sc_row_heights(s, row0, row1) -> char*` + declarations in `include/spreadsheet.h`.
+  `col`/`row` are `uint32_t`; the `double` is the host unit.
+- `wasm`: linear-mem exports (`f64` width in/out) + JS loader wrappers
+  (`columnWidth/rowHeight/setColumnWidth/setRowHeight/clearColumnWidth/clearRowHeight/
+  columnWidths/rowHeights`) + rebuilt `pkg/spreadsheet_engine.wasm` + re-bundle.
+- bump all 3 facades; `verify-infinite.mjs` gains a width/height proof (set a width,
+  read it back, save → load round-trips it, insert a column shifts it).
+
+## 4. Demo design (all six)
+
+Each demo's infinite-grid view, one PR, same shape as the prior six rollouts:
+
+- **Model passthrough**: `columnWidth(col)` / `rowHeight(row)` (fall back to the demo's
+  default `colW`/`rowH` when unset), `setColumnWidth`/`setRowHeight`/`clearColumnWidth`/
+  `clearRowHeight`, and a bulk read for the visible strip.
+- **Render** each column at its width and each row at its height (the gutter / header /
+  body must agree, since they already share the geometry constants).
+- **Resize affordance**: a thin draggable handle on the **right edge of each column
+  header** (drag to set that column's width) and the **bottom edge of each row's
+  gutter cell** (drag to set its height), clamped to a sensible `[min, max]` (e.g.
+  `[40, 600]` px for width, `[16, 240]` for height). On drag-commit, call
+  `setColumnWidth`/`setRowHeight`; the grid re-reads. Double-click the handle to clear
+  (auto-size back to default) where the toolkit makes that easy.
+- **Seed**: widen one column and tallen one row in the seed so the demo opens showing a
+  non-uniform grid (e.g. column C = 140, row 2 = 40), proving the engine path on launch.
+- **Headless proof**: set a width → reads back; survives `saveBook` → mutate → `loadBook`
+  (the loaded width is restored); `insertCol` before the widened column shifts its width
+  with it; `deleteCol` of the widened column drops it. Plus the seed's widened
+  column/tall row read back at their seeded sizes.
+- **Backend proof harness** per backend: `verify-infinite.mjs` (web), `tst_window`
+  (Qt, qmake), `flutter test` (Flutter), `scripts/verify.sh` (Compose kotlinc+FFM /
+  XAML dotnet), `swift test` (SwiftUI). `/security-review` with the diff inline before
+  every push; babysit each PR to green.
+
+Per-backend binding notes (from the prior rollouts):
+- **Flutter** `dart:ffi`: `double` ⇄ C `double` is a direct `Double` typedef; clamp
+  col/row into u32 via the existing `_u32` helper before marshalling.
+- **Compose** Java FFM: `FunctionDescriptor.of(JAVA_DOUBLE, ptr, JAVA_INT)` for the
+  getter — **include the session ptr** (the recurring WrongMethodType trap); `JAVA_DOUBLE`
+  for the width arg.
+- **XAML** P/Invoke: `[DllImport] double sc_column_width(IntPtr, uint)`; the WinUI view
+  is Windows-only, so `Engine.cs` + `test/Program.cs` carry the proof.
+- **SwiftUI**: module-map C funcs (no `DllImport`); re-sync the **tracked** header
+  `Sources/CSpreadsheetEngine/include/spreadsheet.h` from the canonical capi header;
+  links the static `.a` from `Vendor/macos`.
+- **Qt** `Q_INVOKABLE` `double columnWidth(int)` etc.; name the QByteArray locals so
+  UTF-8 outlives any C call (only the bulk-JSON getter needs strings).
+- All native demos **re-vendor** the freshly built capi (`.a`/`.dylib` + canonical
+  `spreadsheet.h`) from the **worktree** rust dir (the primary checkout is stale);
+  `nm`-verify the new symbols after re-vendor. The libs are gitignored (CI rebuilds);
+  the SwiftUI header is tracked.
+
+## 5. Out of scope
+
+- Auto-fit ("size column to widest cell") — needs text measurement the engine can't do
+  (no font metrics); a host could add it later as a demo-only convenience.
+- Hidden rows/columns (width/height = 0) — `set_*` rejects ≤ 0; hiding is a separate
+  feature with its own semantics (skip in layout, still computes).
+- Freeze panes, named ranges, 3-D refs — separate future campaigns.
+
+## 6. Rollout order (hard dependency chain)
+
+```
+spec (this doc)
+  → engine PR        (storage + get/set/clear + bulk + structural shift + serialize + tests)
+  → facades PR       (core-wasm + capi + wasm + JS + verify-infinite proof; bump 3)
+  → 6 demo PRs       web → Qt → Flutter → Compose → XAML → SwiftUI
+```
+
+Build each stage only once its dependency is **merged to main**. When all eight PRs
+(spec + engine + facades + 6 demos) are merged, column-width / row-height is complete
+across all six backends — report and check in with the user before the next feature.


### PR DESCRIPTION
**Engine stage** of the column-width / row-height rollout (spec [#6889](https://github.com/adhithyan15/coding-adventures/pull/6889), merged). spreadsheet-core **0.15.0 → 0.16.0**. The engine now stores per-sheet column widths and row heights — the foundation for resizable columns/rows in all 6 demos — as an **opaque `f64` it never computes with**: it only stores, key-shifts, and serializes. The host owns the unit, default, and clamp.

## What changed
- **`Sheet`** gains `col_widths: HashMap<u32, f64>` + `row_heights: HashMap<u32, f64>`, keyed by the 1-based column/row index. A column/row absent from the map uses the host default, so a no-resize sheet is **byte-identical** to before.
- **API:** `column_width`/`row_height` → `Option<f64>`; `column_widths_in`/`row_heights_in` bulk reads (only the customized indices in range, sorted — one-call viewport fetch); `set_column_width`/`set_row_height` → `bool` (reject `NaN`/`±∞`/`≤0`/index 0 so a bad host value can't poison the map or file; same-value set is a no-op, no revision bump); `clear_column_width`/`clear_row_height`.
- **Structural edits shift the keys** — `apply_structural_edit` slides width keys on InsertCols/DeleteCols and height keys on InsertRows/DeleteRows (reusing `insert_coord`/`delete_coord`, now `pub(crate)`), dropping a key in a deleted band. The other axis is untouched. Widen C, insert a column at B → the now-D column keeps its width.
- **Sort-immune:** widths are columnar, heights positional, so a range sort (reorders row *records*) leaves both put (matches Excel).
- **Persisted:** `serialize` adds optional per-sheet `colWidths`/`rowHeights` arrays (sorted, emitted **only when non-empty** → document stays `version: 1`, no-resize workbooks serialize byte-identically, exactly as `formats` was added). `deserialize` reads them **tolerantly** (missing array / non-finite / ≤0 / out-of-`u32` index skipped, never aborts the load).
- Sheet management is free: the maps live inside `Sheet`, so `delete_sheet` drops them and `move_sheet` carries them — no reindex (keyed by col/row, not `SheetId`).

## Verification
- **8 new tests, 203 total pass** (set/get/clear, reject bad values + indices, bulk-in-range, insert/delete shift both axes independently, sort-immunity, two-sheet round-trip, tolerant load, empty-omits-arrays). `#![forbid(unsafe_code)]` unchanged; **clippy-clean** (the one workbook.rs warning is the pre-existing `sort_range` `question_mark`, green on main).
- Both specs updated: `spreadsheet-core.md` §16.2 + `visicalc-column-width-row-height.md`.

## Security review
PASSED — no vulnerabilities. Verified: no integer overflow/underflow (`delete_coord`'s `v - count` can't underflow since setters reject index 0 ⇒ `at ≥ 1`; `u32::try_from` guards the deserialize narrowing); no panic path from public API or untrusted JSON (tolerant accessors, `.get()` not `[]`); only finite-positive floats can reach storage/serialization (single validated write path), so the file always round-trips. The width-key saturation-collapse on a column insert near `u32::MAX` is a documented, non-security, presentation-only edge case.

Next stage (after merge): facades PR (core-wasm + capi + wasm + JS + verify-infinite proof).

🤖 Generated with [Claude Code](https://claude.com/claude-code)