### PR TITLE
[codex] Add Berkeley SPICE parser app facade

### DIFF
--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- Add a Berkeley SPICE logical-card syntax facade for Rust/Mosaic app
+  substrates. The new surface exposes grammar metadata, normalized logical
+  cards, leading `+` continuation handling, source spans, grammar-token names,
+  stable syntax diagnostics, analysis inventory, and an app-deck wrapper that
+  can run source-order or selected runnable analyses through the existing
+  parser.
 - Parse `.save`, scoped or global `.probe`, and `.measure` / `.meas` cards,
   and expose `select_outputs()` / `measure_results()` helpers plus matching
   `ParsedNetlist` methods for analysis-plan results.

--- a/code/packages/rust/spice-netlist-parser/README.md
+++ b/code/packages/rust/spice-netlist-parser/README.md
@@ -17,6 +17,33 @@ C1 out 0 1u
 assert_eq!(parsed.tran_cards().len(), 1);
 ```
 
+For editor, Mosaic, and parser-generator frontends, the crate also exposes a
+Berkeley SPICE logical-card syntax facade:
+
+```rust
+use spice_netlist_parser::{parse_berkeley_app_deck, BerkeleyCardKind};
+
+let deck = parse_berkeley_app_deck(r#"
+* divider
+V1 in 0 DC 1
+R1 in out 1k
+R2 out 0 1k
+.op
+.end
+"#);
+
+assert!(!deck.has_errors());
+assert_eq!(deck.analysis_inventory()[0].analysis, "op");
+assert_eq!(deck.syntax.cards[1].kind, BerkeleyCardKind::Element);
+```
+
+The facade preserves normalized logical cards, leading `+` continuations,
+source spans, token names aligned with `code/grammars/spice/berkeley.tokens`,
+stable syntax diagnostics, analysis inventory, and source-order execution
+through the existing parser. It is the Rust app/runtime entrypoint for
+Mosaic-backed UI work while the grammar-backed parser generator and
+Python/TypeScript parity surfaces continue to mature.
+
 This parser supports `R`, `C`, `L`, `V`, `I`, `D`, `Q`, `M`, `G`, `E`, `F`, and
 `H` elements, `.model <name> D(...)` diode cards with `IS` and `VT`
 parameters, `.model <name> NPN|PNP(...)` BJT cards with `IS`, `BF` /

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -12,13 +12,23 @@ use spice_engine::{
     TransmissionLine, Vccs, Vcvs, VoltageSource, Waveform,
 };
 
+mod syntax;
+
+pub use syntax::{
+    parse_berkeley_app_deck, parse_berkeley_syntax, BerkeleyAnalysisInventoryEntry,
+    BerkeleyAppDeck, BerkeleyCardKind, BerkeleyDiagnosticSeverity, BerkeleyGrammarMetadata,
+    BerkeleyLogicalCard, BerkeleySyntaxDeck, BerkeleySyntaxDiagnostic, BerkeleySyntaxToken,
+    SourceSpan, BERKELEY_SPICE_GRAMMAR_NAME, BERKELEY_SPICE_GRAMMAR_VERSION,
+    BERKELEY_SPICE_PARSER_GRAMMAR, BERKELEY_SPICE_TOKEN_GRAMMAR,
+};
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NetlistParseError {
     message: String,
 }
 
 impl NetlistParseError {
-    fn new(message: impl Into<String>) -> Self {
+    pub(crate) fn new(message: impl Into<String>) -> Self {
         Self {
             message: message.into(),
         }

--- a/code/packages/rust/spice-netlist-parser/src/syntax.rs
+++ b/code/packages/rust/spice-netlist-parser/src/syntax.rs
@@ -1,0 +1,765 @@
+use crate::{
+    parse_netlist, AnalysisExecutionError, AnalysisExecutionResult, AnalysisKind,
+    NetlistParseError, ParsedNetlist,
+};
+
+pub const BERKELEY_SPICE_GRAMMAR_NAME: &str = "berkeley-spice-logical-card";
+pub const BERKELEY_SPICE_GRAMMAR_VERSION: u32 = 1;
+pub const BERKELEY_SPICE_TOKEN_GRAMMAR: &str =
+    include_str!("../../../../grammars/spice/berkeley.tokens");
+pub const BERKELEY_SPICE_PARSER_GRAMMAR: &str =
+    include_str!("../../../../grammars/spice/berkeley.grammar");
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct SourceSpan {
+    pub start_line: usize,
+    pub start_column: usize,
+    pub end_line: usize,
+    pub end_column: usize,
+}
+
+impl SourceSpan {
+    fn point(line: usize, column: usize) -> Self {
+        Self {
+            start_line: line,
+            start_column: column,
+            end_line: line,
+            end_column: column,
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+struct SourcePosition {
+    line: usize,
+    column: usize,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum BerkeleyDiagnosticSeverity {
+    Error,
+    Warning,
+    Note,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BerkeleySyntaxDiagnostic {
+    pub code: String,
+    pub severity: BerkeleyDiagnosticSeverity,
+    pub message: String,
+    pub span: Option<SourceSpan>,
+}
+
+impl BerkeleySyntaxDiagnostic {
+    fn new(
+        code: &str,
+        severity: BerkeleyDiagnosticSeverity,
+        message: impl Into<String>,
+        span: Option<SourceSpan>,
+    ) -> Self {
+        Self {
+            code: code.to_string(),
+            severity,
+            message: message.into(),
+            span,
+        }
+    }
+
+    fn error(code: &str, message: impl Into<String>, span: Option<SourceSpan>) -> Self {
+        Self::new(code, BerkeleyDiagnosticSeverity::Error, message, span)
+    }
+
+    pub fn is_error(&self) -> bool {
+        self.severity == BerkeleyDiagnosticSeverity::Error
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum BerkeleyCardKind {
+    Element,
+    Model,
+    SubcktStart,
+    SubcktEnd,
+    End,
+    Param,
+    Func,
+    Options,
+    Condition,
+    Analysis,
+    Output,
+    Source,
+    ControlStart,
+    ControlEnd,
+    UnknownDirective,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BerkeleySyntaxToken {
+    pub kind: String,
+    pub text: String,
+    pub span: SourceSpan,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BerkeleyLogicalCard {
+    pub kind: BerkeleyCardKind,
+    pub head: String,
+    pub text: String,
+    pub span: SourceSpan,
+    pub physical_lines: Vec<usize>,
+    pub tokens: Vec<BerkeleySyntaxToken>,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct BerkeleyGrammarMetadata {
+    pub name: &'static str,
+    pub version: u32,
+    pub token_grammar: &'static str,
+    pub parser_grammar: &'static str,
+}
+
+impl BerkeleyGrammarMetadata {
+    pub fn current() -> Self {
+        Self {
+            name: BERKELEY_SPICE_GRAMMAR_NAME,
+            version: BERKELEY_SPICE_GRAMMAR_VERSION,
+            token_grammar: BERKELEY_SPICE_TOKEN_GRAMMAR,
+            parser_grammar: BERKELEY_SPICE_PARSER_GRAMMAR,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BerkeleyAnalysisInventoryEntry {
+    pub index: usize,
+    pub directive: String,
+    pub analysis: String,
+    pub span: SourceSpan,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BerkeleySyntaxDeck {
+    pub grammar: BerkeleyGrammarMetadata,
+    pub title: Option<String>,
+    pub cards: Vec<BerkeleyLogicalCard>,
+    pub diagnostics: Vec<BerkeleySyntaxDiagnostic>,
+}
+
+impl BerkeleySyntaxDeck {
+    pub fn has_errors(&self) -> bool {
+        self.diagnostics
+            .iter()
+            .any(BerkeleySyntaxDiagnostic::is_error)
+    }
+
+    pub fn analysis_inventory(&self) -> Vec<BerkeleyAnalysisInventoryEntry> {
+        self.cards
+            .iter()
+            .enumerate()
+            .filter_map(|(index, card)| {
+                if card.kind != BerkeleyCardKind::Analysis {
+                    return None;
+                }
+                let analysis = card.head.trim_start_matches('.').to_ascii_lowercase();
+                Some(BerkeleyAnalysisInventoryEntry {
+                    index,
+                    directive: card.head.clone(),
+                    analysis,
+                    span: card.span,
+                })
+            })
+            .collect()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct BerkeleyAppDeck {
+    pub syntax: BerkeleySyntaxDeck,
+    pub parsed: Option<ParsedNetlist>,
+    pub diagnostics: Vec<BerkeleySyntaxDiagnostic>,
+}
+
+impl BerkeleyAppDeck {
+    pub fn has_errors(&self) -> bool {
+        self.diagnostics
+            .iter()
+            .any(BerkeleySyntaxDiagnostic::is_error)
+    }
+
+    pub fn analysis_inventory(&self) -> Vec<BerkeleyAnalysisInventoryEntry> {
+        self.syntax.analysis_inventory()
+    }
+
+    pub fn run_source_order(&self) -> Result<Vec<AnalysisExecutionResult>, AnalysisExecutionError> {
+        let parsed = self.parsed.as_ref().ok_or_else(|| {
+            AnalysisExecutionError::Netlist(NetlistParseError::new(self.blocking_message()))
+        })?;
+        parsed.run_analysis_plan()
+    }
+
+    pub fn run_selected_analysis(
+        &self,
+        syntax_card_index: usize,
+    ) -> Result<Option<AnalysisExecutionResult>, AnalysisExecutionError> {
+        let Some(entry) = self
+            .analysis_inventory()
+            .into_iter()
+            .find(|entry| entry.index == syntax_card_index)
+        else {
+            return Ok(None);
+        };
+        if runnable_analysis_kind(&entry.directive).is_none() {
+            return Ok(None);
+        }
+        let result_ordinal = self
+            .syntax
+            .cards
+            .iter()
+            .take(entry.index + 1)
+            .filter(|card| runnable_analysis_kind(&card.head).is_some())
+            .count()
+            - 1;
+        Ok(self.run_source_order()?.into_iter().nth(result_ordinal))
+    }
+
+    fn blocking_message(&self) -> String {
+        self.diagnostics
+            .iter()
+            .find(|diagnostic| diagnostic.is_error())
+            .map(|diagnostic| format!("Berkeley SPICE app deck: {}", diagnostic.message))
+            .unwrap_or_else(|| {
+                "Berkeley SPICE app deck did not produce a parsed netlist".to_string()
+            })
+    }
+}
+
+fn runnable_analysis_kind(directive: &str) -> Option<AnalysisKind> {
+    match directive.to_ascii_lowercase().as_str() {
+        ".op" => Some(AnalysisKind::Op),
+        ".dc" => Some(AnalysisKind::Dc),
+        ".ac" => Some(AnalysisKind::Ac),
+        ".tran" => Some(AnalysisKind::Tran),
+        _ => None,
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct LogicalCardBuilder {
+    text: String,
+    positions: Vec<SourcePosition>,
+    physical_lines: Vec<usize>,
+}
+
+impl LogicalCardBuilder {
+    fn new(line_number: usize, text: &str, start_column: usize) -> Self {
+        let positions = text
+            .chars()
+            .enumerate()
+            .map(|(offset, _)| SourcePosition {
+                line: line_number,
+                column: start_column + offset,
+            })
+            .collect();
+        Self {
+            text: text.to_string(),
+            positions,
+            physical_lines: vec![line_number],
+        }
+    }
+
+    fn append_continuation(&mut self, line_number: usize, text: &str, start_column: usize) {
+        if text.is_empty() {
+            return;
+        }
+        let join_position = self.positions.last().copied().unwrap_or(SourcePosition {
+            line: line_number,
+            column: start_column,
+        });
+        self.text.push(' ');
+        self.positions.push(join_position);
+        for (offset, ch) in text.chars().enumerate() {
+            self.text.push(ch);
+            self.positions.push(SourcePosition {
+                line: line_number,
+                column: start_column + offset,
+            });
+        }
+        self.physical_lines.push(line_number);
+    }
+
+    fn span(&self) -> SourceSpan {
+        let Some(start) = self.positions.first() else {
+            return SourceSpan::point(1, 1);
+        };
+        let Some(end) = self.positions.last() else {
+            return SourceSpan::point(start.line, start.column);
+        };
+        SourceSpan {
+            start_line: start.line,
+            start_column: start.column,
+            end_line: end.line,
+            end_column: end.column + 1,
+        }
+    }
+}
+
+pub fn parse_berkeley_syntax(text: &str) -> BerkeleySyntaxDeck {
+    let mut builders = Vec::new();
+    let mut diagnostics = Vec::new();
+    let mut pending: Option<LogicalCardBuilder> = None;
+    let mut title = None;
+    let mut saw_content = false;
+
+    for (index, raw_line) in text.lines().enumerate() {
+        let line_number = index + 1;
+        let without_comment = strip_inline_comment(raw_line);
+        let Some((trimmed, start_column)) = trimmed_with_column(without_comment) else {
+            continue;
+        };
+        if trimmed.is_empty() {
+            continue;
+        }
+        if trimmed.starts_with('*') {
+            if !saw_content && title.is_none() {
+                let candidate = trimmed[1..].trim();
+                if !candidate.is_empty() {
+                    title = Some(candidate.to_string());
+                }
+            }
+            continue;
+        }
+        if let Some(after_plus) = trimmed.strip_prefix('+') {
+            let continuation = after_plus.trim();
+            let continuation_start_column = start_column
+                + 1
+                + after_plus
+                    .len()
+                    .saturating_sub(after_plus.trim_start().len());
+            if let Some(card) = pending.as_mut() {
+                card.append_continuation(line_number, continuation, continuation_start_column);
+            } else {
+                diagnostics.push(BerkeleySyntaxDiagnostic::error(
+                    "SPICE_SYNTAX_CONTINUATION_WITHOUT_CARD",
+                    "continuation line appears before any logical SPICE card",
+                    Some(SourceSpan::point(line_number, start_column)),
+                ));
+            }
+            continue;
+        }
+        saw_content = true;
+        if let Some(card) = pending.take() {
+            builders.push(card);
+        }
+        pending = Some(LogicalCardBuilder::new(line_number, trimmed, start_column));
+    }
+
+    if let Some(card) = pending {
+        builders.push(card);
+    }
+
+    let cards = builders
+        .into_iter()
+        .map(|builder| logical_card(builder, &mut diagnostics))
+        .collect();
+
+    BerkeleySyntaxDeck {
+        grammar: BerkeleyGrammarMetadata::current(),
+        title,
+        cards,
+        diagnostics,
+    }
+}
+
+pub fn parse_berkeley_app_deck(text: &str) -> BerkeleyAppDeck {
+    let syntax = parse_berkeley_syntax(text);
+    let mut diagnostics = syntax.diagnostics.clone();
+    let parsed = if syntax.has_errors() {
+        None
+    } else {
+        match parse_netlist(text) {
+            Ok(parsed) => Some(parsed),
+            Err(error) => {
+                let message = error.to_string();
+                diagnostics.push(BerkeleySyntaxDiagnostic::error(
+                    "SPICE_BERKELEY_LOWERING_ERROR",
+                    message.clone(),
+                    parse_line_error_span(&message),
+                ));
+                None
+            }
+        }
+    };
+
+    BerkeleyAppDeck {
+        syntax,
+        parsed,
+        diagnostics,
+    }
+}
+
+fn logical_card(
+    builder: LogicalCardBuilder,
+    diagnostics: &mut Vec<BerkeleySyntaxDiagnostic>,
+) -> BerkeleyLogicalCard {
+    let tokens = tokenize_card(&builder, diagnostics);
+    let head = card_head(&tokens);
+    let kind = classify_card(&head);
+    let span = builder.span();
+    BerkeleyLogicalCard {
+        kind,
+        head,
+        text: builder.text,
+        span,
+        physical_lines: builder.physical_lines,
+        tokens,
+    }
+}
+
+fn tokenize_card(
+    builder: &LogicalCardBuilder,
+    diagnostics: &mut Vec<BerkeleySyntaxDiagnostic>,
+) -> Vec<BerkeleySyntaxToken> {
+    let chars = builder.text.chars().collect::<Vec<_>>();
+    let mut tokens = Vec::new();
+    let mut index = 0;
+    let mut paren_depth = 0_i32;
+
+    while index < chars.len() {
+        let ch = chars[index];
+        if ch.is_whitespace() {
+            index += 1;
+            continue;
+        }
+
+        if ch == '"' {
+            let start = index;
+            index += 1;
+            let mut escaped = false;
+            let mut closed = false;
+            while index < chars.len() {
+                let current = chars[index];
+                if escaped {
+                    escaped = false;
+                } else if current == '\\' {
+                    escaped = true;
+                } else if current == '"' {
+                    index += 1;
+                    closed = true;
+                    break;
+                }
+                index += 1;
+            }
+            if !closed {
+                diagnostics.push(BerkeleySyntaxDiagnostic::error(
+                    "SPICE_SYNTAX_UNCLOSED_QUOTE",
+                    "quoted string is missing its closing quote",
+                    Some(span_for_range(&builder.positions, start, index)),
+                ));
+            }
+            tokens.push(token(
+                "QUOTED_STRING",
+                &chars,
+                &builder.positions,
+                start,
+                index,
+            ));
+            continue;
+        }
+
+        if ch == '{' {
+            let start = index;
+            index += 1;
+            let mut closed = false;
+            while index < chars.len() {
+                if chars[index] == '}' {
+                    index += 1;
+                    closed = true;
+                    break;
+                }
+                index += 1;
+            }
+            if !closed {
+                diagnostics.push(BerkeleySyntaxDiagnostic::error(
+                    "SPICE_SYNTAX_UNCLOSED_BRACED_EXPR",
+                    "braced expression is missing its closing brace",
+                    Some(span_for_range(&builder.positions, start, index)),
+                ));
+            }
+            tokens.push(token(
+                "BRACED_EXPR",
+                &chars,
+                &builder.positions,
+                start,
+                index,
+            ));
+            continue;
+        }
+
+        match ch {
+            '(' => {
+                paren_depth += 1;
+                tokens.push(token(
+                    "LPAREN",
+                    &chars,
+                    &builder.positions,
+                    index,
+                    index + 1,
+                ));
+                index += 1;
+                continue;
+            }
+            ')' => {
+                if paren_depth == 0 {
+                    diagnostics.push(BerkeleySyntaxDiagnostic::error(
+                        "SPICE_SYNTAX_UNMATCHED_RPAREN",
+                        "closing parenthesis has no matching opening parenthesis",
+                        Some(span_for_range(&builder.positions, index, index + 1)),
+                    ));
+                } else {
+                    paren_depth -= 1;
+                }
+                tokens.push(token(
+                    "RPAREN",
+                    &chars,
+                    &builder.positions,
+                    index,
+                    index + 1,
+                ));
+                index += 1;
+                continue;
+            }
+            ',' => {
+                tokens.push(token("COMMA", &chars, &builder.positions, index, index + 1));
+                index += 1;
+                continue;
+            }
+            '=' => {
+                tokens.push(token(
+                    "EQUALS",
+                    &chars,
+                    &builder.positions,
+                    index,
+                    index + 1,
+                ));
+                index += 1;
+                continue;
+            }
+            _ => {}
+        }
+
+        if ch == '.' {
+            let atom_end = read_atom_end(&chars, index);
+            let raw = chars[index..atom_end].iter().collect::<String>();
+            if let Some(kind) = known_dot_token(&raw) {
+                tokens.push(token(kind, &chars, &builder.positions, index, atom_end));
+                index = atom_end;
+            } else {
+                tokens.push(token("DOT", &chars, &builder.positions, index, index + 1));
+                index += 1;
+            }
+            continue;
+        }
+
+        let start = index;
+        index = read_atom_end(&chars, index);
+        let raw = chars[start..index].iter().collect::<String>();
+        let kind = if is_number_token(&raw) {
+            "NUMBER"
+        } else {
+            "ATOM"
+        };
+        tokens.push(token(kind, &chars, &builder.positions, start, index));
+    }
+
+    if paren_depth > 0 {
+        diagnostics.push(BerkeleySyntaxDiagnostic::error(
+            "SPICE_SYNTAX_UNCLOSED_PAREN",
+            "opening parenthesis is missing its closing parenthesis",
+            Some(builder.span()),
+        ));
+    }
+
+    tokens
+}
+
+fn token(
+    kind: &str,
+    chars: &[char],
+    positions: &[SourcePosition],
+    start: usize,
+    end: usize,
+) -> BerkeleySyntaxToken {
+    BerkeleySyntaxToken {
+        kind: kind.to_string(),
+        text: chars[start..end].iter().collect(),
+        span: span_for_range(positions, start, end),
+    }
+}
+
+fn span_for_range(positions: &[SourcePosition], start: usize, end: usize) -> SourceSpan {
+    let first = positions
+        .get(start)
+        .copied()
+        .or_else(|| positions.first().copied())
+        .unwrap_or(SourcePosition { line: 1, column: 1 });
+    let last = positions
+        .get(end.saturating_sub(1))
+        .copied()
+        .unwrap_or(first);
+    SourceSpan {
+        start_line: first.line,
+        start_column: first.column,
+        end_line: last.line,
+        end_column: last.column + 1,
+    }
+}
+
+fn card_head(tokens: &[BerkeleySyntaxToken]) -> String {
+    let Some(first) = tokens.first() else {
+        return String::new();
+    };
+    if first.kind == "DOT" {
+        if let Some(second) = tokens.get(1) {
+            if second.kind == "ATOM" {
+                return format!(".{}", second.text);
+            }
+        }
+    }
+    first.text.clone()
+}
+
+fn classify_card(head: &str) -> BerkeleyCardKind {
+    match head.to_ascii_lowercase().as_str() {
+        ".model" => BerkeleyCardKind::Model,
+        ".subckt" => BerkeleyCardKind::SubcktStart,
+        ".ends" => BerkeleyCardKind::SubcktEnd,
+        ".end" => BerkeleyCardKind::End,
+        ".param" => BerkeleyCardKind::Param,
+        ".func" => BerkeleyCardKind::Func,
+        ".options" => BerkeleyCardKind::Options,
+        ".temp" | ".ic" | ".nodeset" => BerkeleyCardKind::Condition,
+        ".op" | ".dc" | ".ac" | ".tran" | ".tf" | ".sens" | ".noise" | ".disto" | ".pz" => {
+            BerkeleyCardKind::Analysis
+        }
+        ".print" | ".plot" | ".save" | ".probe" | ".measure" | ".meas" | ".four" => {
+            BerkeleyCardKind::Output
+        }
+        ".include" | ".lib" => BerkeleyCardKind::Source,
+        ".control" => BerkeleyCardKind::ControlStart,
+        ".endc" => BerkeleyCardKind::ControlEnd,
+        value if value.starts_with('.') => BerkeleyCardKind::UnknownDirective,
+        _ => BerkeleyCardKind::Element,
+    }
+}
+
+fn read_atom_end(chars: &[char], mut index: usize) -> usize {
+    while index < chars.len() {
+        let ch = chars[index];
+        if ch.is_whitespace() || matches!(ch, '(' | ')' | ',' | '=' | '"' | '{' | '}') {
+            break;
+        }
+        index += 1;
+    }
+    index
+}
+
+fn known_dot_token(raw: &str) -> Option<&'static str> {
+    match raw.to_ascii_lowercase().as_str() {
+        ".end" => Some("DOT_END"),
+        ".ends" => Some("DOT_ENDS"),
+        ".subckt" => Some("DOT_SUBCKT"),
+        ".model" => Some("DOT_MODEL"),
+        ".param" => Some("DOT_PARAM"),
+        ".func" => Some("DOT_FUNC"),
+        ".options" => Some("DOT_OPTIONS"),
+        ".temp" => Some("DOT_TEMP"),
+        ".ic" => Some("DOT_IC"),
+        ".nodeset" => Some("DOT_NODESET"),
+        ".op" => Some("DOT_OP"),
+        ".dc" => Some("DOT_DC"),
+        ".ac" => Some("DOT_AC"),
+        ".tran" => Some("DOT_TRAN"),
+        ".tf" => Some("DOT_TF"),
+        ".sens" => Some("DOT_SENS"),
+        ".noise" => Some("DOT_NOISE"),
+        ".disto" => Some("DOT_DISTO"),
+        ".pz" => Some("DOT_PZ"),
+        ".print" => Some("DOT_PRINT"),
+        ".plot" => Some("DOT_PLOT"),
+        ".save" => Some("DOT_SAVE"),
+        ".probe" => Some("DOT_PROBE"),
+        ".measure" => Some("DOT_MEASURE"),
+        ".meas" => Some("DOT_MEAS"),
+        ".four" => Some("DOT_FOUR"),
+        ".include" => Some("DOT_INCLUDE"),
+        ".lib" => Some("DOT_LIB"),
+        ".control" => Some("DOT_CONTROL"),
+        ".endc" => Some("DOT_ENDC"),
+        _ => None,
+    }
+}
+
+fn is_number_token(raw: &str) -> bool {
+    let mut chars = raw.chars().peekable();
+    if matches!(chars.peek(), Some('+') | Some('-')) {
+        chars.next();
+    }
+
+    let mut digits_before_dot = 0;
+    while matches!(chars.peek(), Some(ch) if ch.is_ascii_digit()) {
+        digits_before_dot += 1;
+        chars.next();
+    }
+
+    let mut digits_after_dot = 0;
+    if matches!(chars.peek(), Some('.')) {
+        chars.next();
+        while matches!(chars.peek(), Some(ch) if ch.is_ascii_digit()) {
+            digits_after_dot += 1;
+            chars.next();
+        }
+    }
+
+    if digits_before_dot == 0 && digits_after_dot == 0 {
+        return false;
+    }
+
+    if matches!(chars.peek(), Some('e') | Some('E')) {
+        let mut probe = chars.clone();
+        probe.next();
+        if matches!(probe.peek(), Some('+') | Some('-')) {
+            probe.next();
+        }
+        let mut exponent_digits = 0;
+        while matches!(probe.peek(), Some(ch) if ch.is_ascii_digit()) {
+            exponent_digits += 1;
+            probe.next();
+        }
+        if exponent_digits > 0 {
+            chars = probe;
+        }
+    }
+
+    chars.all(|ch| ch.is_ascii_alphabetic())
+}
+
+fn strip_inline_comment(line: &str) -> &str {
+    line.split_once(';').map_or(line, |(before, _)| before)
+}
+
+fn trimmed_with_column(line: &str) -> Option<(&str, usize)> {
+    let trimmed_end = line.trim_end();
+    if trimmed_end.is_empty() {
+        return None;
+    }
+    let trimmed = trimmed_end.trim_start();
+    let leading_columns = trimmed_end.len() - trimmed.len();
+    Some((trimmed, leading_columns + 1))
+}
+
+fn parse_line_error_span(message: &str) -> Option<SourceSpan> {
+    let after_line = message.strip_prefix("line ")?;
+    let line_text = after_line.split_once(':')?.0;
+    let line = line_text.parse::<usize>().ok()?;
+    Some(SourceSpan::point(line, 1))
+}

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -3,11 +3,13 @@ use spice_engine::{
     BjtPolarity, Element, JfetPolarity, McDistribution, McOptions, MosfetType, TransientMethod,
 };
 use spice_netlist_parser::{
-    build_analysis_plan, parse_netlist, parse_value, run_netlist, AcAnalysis, Analysis,
-    AnalysisKind, AnalysisResult, DcAnalysis, DistortionAnalysis, FourAnalysis, McAnalysis,
-    MeasureAnalysis, MeasureOperation, NetlistParseError, NoiseAnalysis, OpAnalysis, OptionValue,
-    OutputProbe, PlotAnalysis, PoleZeroAnalysis, PoleZeroKind, PrintAnalysis, ProbeAnalysis,
-    SaveAnalysis, SelectedOutputValue, SensAnalysis, TempAnalysis, TfAnalysis, TranAnalysis,
+    build_analysis_plan, parse_berkeley_app_deck, parse_berkeley_syntax, parse_netlist,
+    parse_value, run_netlist, AcAnalysis, Analysis, AnalysisKind, AnalysisResult, BerkeleyCardKind,
+    BerkeleyDiagnosticSeverity, BerkeleyGrammarMetadata, DcAnalysis, DistortionAnalysis,
+    FourAnalysis, McAnalysis, MeasureAnalysis, MeasureOperation, NetlistParseError, NoiseAnalysis,
+    OpAnalysis, OptionValue, OutputProbe, PlotAnalysis, PoleZeroAnalysis, PoleZeroKind,
+    PrintAnalysis, ProbeAnalysis, SaveAnalysis, SelectedOutputValue, SensAnalysis, TempAnalysis,
+    TfAnalysis, TranAnalysis, BERKELEY_SPICE_GRAMMAR_NAME, BERKELEY_SPICE_GRAMMAR_VERSION,
 };
 
 fn assert_close(actual: f64, expected: f64) {
@@ -1801,6 +1803,154 @@ fn rejects_unknown_subcircuit_instances() {
     assert!(err
         .to_string()
         .contains("line 1: unknown subcircuit \"missing\""));
+}
+
+#[test]
+fn berkeley_syntax_facade_preserves_logical_cards_tokens_and_spans() {
+    let syntax = parse_berkeley_syntax(
+        r#"
+* RC low pass
+V1 in 0 DC 1
+R1 in out 1k ; inline comment
++ TC=1m
+.op
+.tran 1n 2n
+.end
+"#,
+    );
+
+    assert!(!syntax.has_errors(), "{:?}", syntax.diagnostics);
+    assert_eq!(
+        syntax.grammar,
+        BerkeleyGrammarMetadata {
+            name: BERKELEY_SPICE_GRAMMAR_NAME,
+            version: BERKELEY_SPICE_GRAMMAR_VERSION,
+            token_grammar: syntax.grammar.token_grammar,
+            parser_grammar: syntax.grammar.parser_grammar,
+        }
+    );
+    assert_eq!(syntax.title.as_deref(), Some("RC low pass"));
+    assert_eq!(syntax.cards.len(), 5);
+
+    let resistor = &syntax.cards[1];
+    assert_eq!(resistor.kind, BerkeleyCardKind::Element);
+    assert_eq!(resistor.head, "R1");
+    assert_eq!(resistor.text, "R1 in out 1k TC=1m");
+    assert_eq!(resistor.physical_lines, vec![4, 5]);
+    assert_eq!(resistor.span.start_line, 4);
+    assert_eq!(resistor.span.end_line, 5);
+    assert_eq!(
+        resistor
+            .tokens
+            .iter()
+            .map(|token| (token.kind.as_str(), token.text.as_str()))
+            .collect::<Vec<_>>(),
+        vec![
+            ("ATOM", "R1"),
+            ("ATOM", "in"),
+            ("ATOM", "out"),
+            ("NUMBER", "1k"),
+            ("ATOM", "TC"),
+            ("EQUALS", "="),
+            ("NUMBER", "1m"),
+        ]
+    );
+
+    let inventory = syntax.analysis_inventory();
+    assert_eq!(
+        inventory
+            .iter()
+            .map(|entry| (entry.index, entry.analysis.as_str()))
+            .collect::<Vec<_>>(),
+        vec![(2, "op"), (3, "tran")]
+    );
+}
+
+#[test]
+fn berkeley_syntax_facade_reports_stable_diagnostics() {
+    let syntax = parse_berkeley_syntax(
+        r#"
++ orphan
+V1 in 0 PULSE(0 1
+.measure tran bad PARAM="unterminated
+"#,
+    );
+
+    assert_eq!(
+        syntax
+            .diagnostics
+            .iter()
+            .map(|diagnostic| (diagnostic.code.as_str(), diagnostic.severity))
+            .collect::<Vec<_>>(),
+        vec![
+            (
+                "SPICE_SYNTAX_CONTINUATION_WITHOUT_CARD",
+                BerkeleyDiagnosticSeverity::Error
+            ),
+            (
+                "SPICE_SYNTAX_UNCLOSED_PAREN",
+                BerkeleyDiagnosticSeverity::Error
+            ),
+            (
+                "SPICE_SYNTAX_UNCLOSED_QUOTE",
+                BerkeleyDiagnosticSeverity::Error
+            ),
+        ]
+    );
+}
+
+#[test]
+fn berkeley_app_facade_exposes_inventory_and_runs_source_order() {
+    let app = parse_berkeley_app_deck(
+        r#"
+* divider
+V1 in 0 DC 1
+R1 in out 1k
+R2 out 0 1k
+.op
+.dc V1 0 1 1
+.end
+"#,
+    );
+
+    assert!(!app.has_errors(), "{:?}", app.diagnostics);
+    assert_eq!(
+        app.analysis_inventory()
+            .iter()
+            .map(|entry| (entry.index, entry.directive.as_str()))
+            .collect::<Vec<_>>(),
+        vec![(3, ".op"), (4, ".dc")]
+    );
+
+    let results = app.run_source_order().unwrap();
+    assert_eq!(
+        results.iter().map(|result| result.kind).collect::<Vec<_>>(),
+        vec![AnalysisKind::Op, AnalysisKind::Dc]
+    );
+
+    let selected = app.run_selected_analysis(4).unwrap().unwrap();
+    assert_eq!(selected.kind, AnalysisKind::Dc);
+}
+
+#[test]
+fn berkeley_app_facade_reports_lowering_errors_without_running() {
+    let app = parse_berkeley_app_deck(
+        r#"
+* invalid semantic deck
+V1 in 0 DC 1
+Rbad in
+.op
+"#,
+    );
+
+    assert!(app.has_errors());
+    assert_eq!(app.parsed, None);
+    assert!(app
+        .diagnostics
+        .iter()
+        .any(|diagnostic| diagnostic.code == "SPICE_BERKELEY_LOWERING_ERROR"));
+    let err = app.run_source_order().unwrap_err();
+    assert!(err.to_string().contains("Berkeley SPICE app deck"));
 }
 
 fn assert_error_type(_: NetlistParseError) {}

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,18 +33,19 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Berkeley SPICE grammar foundation.
+1. Rust Berkeley SPICE parser/app facade.
    - Status: current PR completion candidate.
-   - Add `code/grammars/spice/berkeley.tokens` and
-     `code/grammars/spice/berkeley.grammar` as the first shared syntax contract
-     for normalized Berkeley SPICE logical cards.
-   - The grammar intentionally parses stable card shape and preserves generic
-     card atoms. Semantic passes own device arity, model legality, expression
-     resolution, include/library loading, control policies, and dialect-specific
-     behavior.
-   - Grammar-tool tests parse, validate, cross-validate, and compile the token
-     and parser grammars so future parser rewrites can break old ad hoc parsing
-     behavior against a checked source grammar instead of guessing.
+   - Add a Rust `spice-netlist-parser` facade for Berkeley SPICE logical-card
+     syntax that exposes grammar metadata, normalized cards, leading `+`
+     continuations, source spans, token names, stable diagnostics, and analysis
+     inventory.
+   - Add a Rust app-deck entrypoint for Mosaic-backed UI runtimes that parses
+     syntax once, reports syntax/lowering diagnostics, exposes analysis
+     inventory, and can run source-order or selected runnable analyses through
+     the existing simulator parser.
+   - This slice does not change Python/TypeScript simulator semantics. The
+     follow-up grammar-backed parser contract mirrors this facade outward once
+     the Rust/Mosaic substrate shape is reviewed.
 
 ## Completed Slices
 
@@ -1401,16 +1402,30 @@ the Rust, Python, and TypeScript surfaces together.
      exports, and a negative missing `NMOS:tran` summary case so downstream
      consumers can audit coverage without scanning every fixture row.
 
+132. Berkeley SPICE grammar foundation.
+   - Status: completed in PR 6861.
+   - `code/grammars/spice/berkeley.tokens` and
+     `code/grammars/spice/berkeley.grammar` now define the first shared syntax
+     contract for normalized Berkeley SPICE logical cards.
+   - The grammar intentionally parses stable card shape and preserves generic
+     card atoms. Semantic passes own device arity, model legality, expression
+     resolution, include/library loading, control policies, and
+     dialect-specific behavior.
+   - Grammar-tool tests parse, validate, cross-validate, and compile the token
+     and parser grammars so future parser rewrites can break old ad hoc parsing
+     behavior against a checked source grammar instead of guessing.
+
 ## Backlog
 
 1. Grammar-backed parser and app facade.
-   - Route the Rust `spice-netlist-parser` through a grammar-backed Berkeley
-     syntax layer with source spans and stable diagnostics.
+   - Route the Rust `spice-netlist-parser` semantic lowerer through the
+     Berkeley syntax facade and checked grammar contract, replacing the current
+     ad hoc line parser as the default deck parse path.
    - Mirror the resulting public parser contract in Python and TypeScript, even
      if that breaks current pre-release parser APIs.
-   - Add a Rust app facade for Mosaic-backed UI runtimes: parse deck, report
-     diagnostics, expose analysis inventory, run selected or source-order
-     analyses, and return stable table/waveform/result artifacts.
+   - Expand the Rust Mosaic app facade from analysis inventory and execution
+     entrypoints to stable table, waveform, and result artifacts backed by the
+     same public parser contract.
 
 2. Deck compatibility follow-up.
    - Expand deck-owned output compatibility beyond source-order analysis


### PR DESCRIPTION
## Summary

- add a Rust Berkeley SPICE logical-card syntax facade backed by the checked `code/grammars/spice/berkeley.*` contract
- expose grammar metadata, normalized cards, source spans, token names, stable diagnostics, analysis inventory, and a Mosaic-oriented app deck wrapper
- update the SPICE implementation plan, parser README, and changelog for the new Rust app substrate slice

## Validation

- `cargo test -p spice-netlist-parser -- --nocapture`
- `cargo test -p grammar-tools --test spice_grammar_validation -- --nocapture`
- `git diff --check HEAD~1..HEAD`

## Notes

This does not change Python or TypeScript simulator semantics. The follow-up parser-contract slice should mirror the reviewed syntax/app facade outward when the grammar-backed semantic lowerer becomes the default parser path.