### PR TITLE
feat(lang-full): BA-builtins — SQR/INT/ABS/SGN on all 7 backends

### DIFF
--- a/code/packages/rust/dartmouth-basic-iir-compiler/CHANGELOG.md
+++ b/code/packages/rust/dartmouth-basic-iir-compiler/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog — `dartmouth-basic-iir-compiler`
 
+## 0.32.0 — 2026-06-28 — BA-builtins: `SQR`, `INT`, `ABS`, `SGN` (LANG-FULL)
+
+Dartmouth BASIC's built-in math functions `SQR`, `INT`, `ABS`, and `SGN` are
+now lowered — all using existing E3/E8 IIR ops, so no new backend code was
+needed.
+
+| Function | Lowers to | All 7 backends |
+|----------|-----------|----------------|
+| `SQR(X)` | `f64_sqrt` IIR op | ✅ (hardware sqrt: WASM `f64.sqrt`, LLVM `@llvm.sqrt.f64`, JVM `Math.sqrt`, CLR `System.Math::Sqrt`, aarch64 `FSQRT`, x86_64 `SQRTSD`, VM/JIT `f64::sqrt`) |
+| `INT(X)` | `real_to_int_floor` → `int_to_real` | ✅ (E8 floor + convert back to real) |
+| `ABS(X)` | inline compare + branch (`cmp_lt`/`jmp_if_false`/`neg`) | ✅ (store-per-branch, no phi — same pattern as ALGOL `abs`) |
+| `SGN(X)` | inline 3-way conditional | ✅ (returns −1.0/0.0/1.0 as float per BA7 value model) |
+
+`SIN`, `COS`, `LOG`, `EXP`, `TAN`, `ATN`, and `RND` are rejected with a clear
+`Unsupported` error until cross-backend math helper infrastructure lands.
+
+Verified by RUNNING `PRINT SQR(49)` → `7`, `PRINT INT(3.7)` → `3`,
+`PRINT ABS(-42)` → `42`, `PRINT SGN(-5)` → `-1` on all 7 backends via
+`lang-aot/tests/lang_matrix.rs`.
+
 ## 0.31.0 — 2026-06-28 — BA4 lexical string ordering in IF branches
 
 String `IF` now lowers the standard lexical ordering relops through the shared

--- a/code/packages/rust/dartmouth-basic-iir-compiler/Cargo.toml
+++ b/code/packages/rust/dartmouth-basic-iir-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dartmouth-basic-iir-compiler"
-version = "0.31.0"
+version = "0.32.0"
 edition = "2021"
 description = "Dartmouth BASIC frontend for the LANG VM AOT chain — lowers parsed BASIC into interpreter_ir::IIRModule. v0.31.0 proves BA4 lexical string ordering in IF branches on all seven backends; v0.30.0 proved variable-variable string concat in IF equality."
 

--- a/code/packages/rust/dartmouth-basic-iir-compiler/src/lib.rs
+++ b/code/packages/rust/dartmouth-basic-iir-compiler/src/lib.rs
@@ -1477,8 +1477,8 @@ impl Compiler {
     {
         // primary = NUMBER | BUILTIN_FN(expr) | USER_FN(expr) | variable | (expr)
         //
-        // V1 supports NUMBER, `variable`, and `USER_FN(expr)` calls (BA5).
-        // Built-in maths functions (SIN/ABS/…) stay deferred until E3 (reals).
+        // V1 supports NUMBER, `variable`, `USER_FN(expr)`, and built-in functions.
+        // E3 (reals) is complete, so SQR/INT/ABS/SGN are now lowered inline.
         for c in &node.children {
             match c {
                 ASTNodeOrToken::Token(t) if t.effective_type_name() == "NUMBER" => {
@@ -1505,8 +1505,7 @@ impl Compiler {
                     return self.emit_user_fn_call(&t.value, node);
                 }
                 ASTNodeOrToken::Token(t) if t.effective_type_name() == "BUILTIN_FN" => {
-                    return Err(CompileError::Unsupported(format!(
-                        "built-in function `{}` (needs E3 reals)", t.value)));
+                    return self.emit_builtin_fn(&t.value.to_lowercase(), node);
                 }
                 ASTNodeOrToken::Node(n) if n.rule_name == "variable" => {
                     // `A(I)` reads an array element (BA3 / E5) → `array_get`.
@@ -1581,6 +1580,132 @@ impl Compiler {
         self.emit("call", Some(&dest),
             vec![Operand::Var(name.to_string()), Operand::Var(arg.slot)], "f64");
         Ok(ExprValue { slot: dest, ty: BasicScalarType::Real })
+    }
+
+    /// Lower a Dartmouth BASIC built-in math function call.
+    ///
+    /// `name` is the lower-cased `BUILTIN_FN` token value (`sqr`, `int`,
+    /// `abs`, `sgn`, …); `node` is the enclosing `primary`.  The argument is
+    /// the single `expr` child of that primary (same shape as `USER_FN`).
+    ///
+    /// Implemented now (no new backend ops needed — all reuse E3/E8 IIR ops):
+    ///
+    /// | Function | Lowers to            | Notes                              |
+    /// |----------|----------------------|------------------------------------|
+    /// | `SQR(X)` | `f64_sqrt`           | hardware sqrt on all 7 backends    |
+    /// | `INT(X)` | `real_to_int_floor` → `int_to_real` | floor, result is f64 |
+    /// | `ABS(X)` | inline if/neg/jmp    | store-per-branch, no phi          |
+    /// | `SGN(X)` | inline 3-way if/jmp  | -1.0 / 0.0 / 1.0 per BA7 model   |
+    ///
+    /// `SIN`, `COS`, `LOG`, `EXP`, `TAN`, `ATN`, `RND` need a cross-backend
+    /// math helper (libm call) and are rejected with a clear error until that
+    /// infrastructure lands.
+    fn emit_builtin_fn(&mut self, name: &str, node: &GrammarASTNode)
+        -> Result<ExprValue, CompileError>
+    {
+        let arg_node = child_nodes(node).into_iter()
+            .find(|n| n.rule_name == "expr")
+            .ok_or_else(|| CompileError::Malformed(format!(
+                "built-in function `{name}` missing argument expr")))?;
+        let arg = self.emit_expr(arg_node)?;
+        let arg = self.coerce_value(arg, BasicScalarType::Real);
+
+        match name {
+            // SQR(X) = √X — reuse the f64_sqrt IIR op added for ALGOL sqrt.
+            "sqr" => {
+                let dest = self.fresh_temp();
+                self.emit("f64_sqrt", Some(&dest),
+                    vec![Operand::Var(arg.slot)], "f64");
+                Ok(ExprValue { slot: dest, ty: BasicScalarType::Real })
+            }
+
+            // INT(X) = ⌊X⌋ — floor toward −∞, result is a real per BA7.
+            // real_to_int_floor + int_to_real: both are E8 ops present on
+            // every backend.  (BASIC INT differs from ALGOL entier only in
+            // that it returns a float, not an integer — same value.)
+            "int" => {
+                let floored = self.fresh_temp();
+                self.emit("real_to_int_floor", Some(&floored),
+                    vec![Operand::Var(arg.slot)], "i64");
+                let dest = self.fresh_temp();
+                self.emit("int_to_real", Some(&dest),
+                    vec![Operand::Var(floored)], "f64");
+                Ok(ExprValue { slot: dest, ty: BasicScalarType::Real })
+            }
+
+            // ABS(X) = |X| — inline conditional: if X < 0 then −X else X.
+            // The store-per-branch discipline (one `mov` per path, no phi)
+            // is the same pattern ALGOL abs uses (AL8).
+            "abs" => {
+                let id = self.temp_counter;
+                self.temp_counter += 1;
+                let else_lbl = format!("_abs_else_{id}");
+                let end_lbl  = format!("_abs_end_{id}");
+
+                let zero = self.fresh_temp();
+                self.emit("const", Some(&zero), vec![Operand::Float(0.0)], "f64");
+                let cond = self.fresh_temp();
+                self.emit("cmp_lt", Some(&cond),
+                    vec![Operand::Var(arg.slot.clone()), Operand::Var(zero)], "f64");
+                let dest = self.fresh_temp();
+                // then: X < 0 → negate
+                self.emit("jmp_if_false", None,
+                    vec![Operand::Var(cond), Operand::Var(else_lbl.clone())], "void");
+                let neg = self.fresh_temp();
+                self.emit("neg", Some(&neg), vec![Operand::Var(arg.slot.clone())], "f64");
+                self.emit("mov", Some(&dest), vec![Operand::Var(neg)], "f64");
+                self.emit("jmp", None, vec![Operand::Var(end_lbl.clone())], "void");
+                // else: X >= 0 → keep
+                self.emit("label", None, vec![Operand::Var(else_lbl)], "void");
+                self.emit("mov", Some(&dest), vec![Operand::Var(arg.slot)], "f64");
+                self.emit("label", None, vec![Operand::Var(end_lbl)], "void");
+                Ok(ExprValue { slot: dest, ty: BasicScalarType::Real })
+            }
+
+            // SGN(X) = sign of X: 1.0 if X > 0, −1.0 if X < 0, 0.0 if X = 0.
+            // Result is f64 (the BA7 value model has no separate integer type).
+            "sgn" => {
+                let id = self.temp_counter;
+                self.temp_counter += 1;
+                let neg_lbl  = format!("_sgn_neg_{id}");
+                let zero_lbl = format!("_sgn_zero_{id}");
+                let end_lbl  = format!("_sgn_end_{id}");
+
+                let dest = self.fresh_temp();
+                let z = self.fresh_temp();
+                self.emit("const", Some(&z), vec![Operand::Float(0.0)], "f64");
+
+                // X > 0 → 1.0
+                let gt = self.fresh_temp();
+                self.emit("cmp_gt", Some(&gt),
+                    vec![Operand::Var(arg.slot.clone()), Operand::Var(z.clone())], "f64");
+                self.emit("jmp_if_false", None,
+                    vec![Operand::Var(gt), Operand::Var(neg_lbl.clone())], "void");
+                self.emit("const", Some(&dest), vec![Operand::Float(1.0)], "f64");
+                self.emit("jmp", None, vec![Operand::Var(end_lbl.clone())], "void");
+
+                // X < 0 → −1.0
+                self.emit("label", None, vec![Operand::Var(neg_lbl)], "void");
+                let lt = self.fresh_temp();
+                self.emit("cmp_lt", Some(&lt),
+                    vec![Operand::Var(arg.slot), Operand::Var(z)], "f64");
+                self.emit("jmp_if_false", None,
+                    vec![Operand::Var(lt), Operand::Var(zero_lbl.clone())], "void");
+                self.emit("const", Some(&dest), vec![Operand::Float(-1.0)], "f64");
+                self.emit("jmp", None, vec![Operand::Var(end_lbl.clone())], "void");
+
+                // X = 0 → 0.0
+                self.emit("label", None, vec![Operand::Var(zero_lbl)], "void");
+                self.emit("const", Some(&dest), vec![Operand::Float(0.0)], "f64");
+                self.emit("label", None, vec![Operand::Var(end_lbl)], "void");
+                Ok(ExprValue { slot: dest, ty: BasicScalarType::Real })
+            }
+
+            _ => Err(CompileError::Unsupported(format!(
+                "built-in function `{}` not yet implemented \
+                 (needs cross-backend math support)",
+                name.to_uppercase())))
+        }
     }
 
     /// Pre-pass: record every `DEF FNx` name declared on `line` so a call

--- a/code/packages/rust/lang-aot/CHANGELOG.md
+++ b/code/packages/rust/lang-aot/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog — `lang-aot`
 
+## 0.153.0 — 2026-06-28 — BASIC built-in functions `SQR`/`INT`/`ABS`/`SGN` (LANG-FULL BA-builtins)
+
+Four new matrix `Prog` cells proving Dartmouth BASIC's built-in math functions
+on all 7 backends (NativeAot, Llvm, Wasm, Jvm, Clr, Vm, Jit):
+
+- `PRINT SQR(49)` → `7` (`f64_sqrt` IIR op, hardware sqrt everywhere)
+- `PRINT INT(3.7)` → `3` (`real_to_int_floor` + `int_to_real`, E8 ops)
+- `PRINT ABS(-42)` → `42` (inline conditional, store-per-branch)
+- `PRINT SGN(-5)` → `-1` (inline 3-way conditional, result is f64)
+
+818 total proven cells pass.
+
 ## 0.152.0 — 2026-06-28 — ALGOL `sqrt` on all seven backends (LANG-FULL AL8-sqrt)
 
 The matrix now proves `sqrt(49.0) = 7` — the ALGOL 60 §3.2.4 `sqrt` standard

--- a/code/packages/rust/lang-aot/Cargo.toml
+++ b/code/packages/rust/lang-aot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lang-aot"
-version = "0.152.0"
+version = "0.153.0"
 edition = "2021"
 description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, and McCarthy Lisp to native executables through the shared IIR pipeline.  v0.151.0 (LANG-FULL AL4): `tests/lang_matrix.rs` proves ALGOL string equality and ordering on native/LLVM/WASM/JVM/CLR/VM/JIT.  v0.150.0 proved BASIC lexical string ordering."
 

--- a/code/packages/rust/lang-aot/tests/lang_matrix.rs
+++ b/code/packages/rust/lang-aot/tests/lang_matrix.rs
@@ -1705,6 +1705,47 @@ const PROGRAMS: &[Prog] = &[
         expect: Expect::Stdout("876"),
         backends: &[NativeAot, Llvm, Wasm, Jvm, Clr, Vm, Jit],
     },
+    // Dartmouth BASIC — `SQR` (square root) built-in (LANG-FULL BA-builtins).
+    // SQR(X) lowers to the f64_sqrt IIR op (same hardware instruction that
+    // ALGOL sqrt uses).  SQR(49) is exactly 7.0 — a whole-valued real — so
+    // BA7's formatter prints `7` with no decimal point.
+    Prog {
+        lang: Language::DartmouthBasic,
+        ext: "bas",
+        src: "10 PRINT SQR(49)\n20 END\n",
+        expect: Expect::Stdout("7"),
+        backends: &[NativeAot, Llvm, Wasm, Jvm, Clr, Vm, Jit],
+    },
+    // Dartmouth BASIC — `INT` (floor) built-in (LANG-FULL BA-builtins).
+    // INT(X) = ⌊X⌋, returned as a real.  Lowers to real_to_int_floor +
+    // int_to_real (both E8 ops).  INT(3.7) → 3.0, printed as `3`.
+    Prog {
+        lang: Language::DartmouthBasic,
+        ext: "bas",
+        src: "10 PRINT INT(3.7)\n20 END\n",
+        expect: Expect::Stdout("3"),
+        backends: &[NativeAot, Llvm, Wasm, Jvm, Clr, Vm, Jit],
+    },
+    // Dartmouth BASIC — `ABS` (absolute value) built-in (LANG-FULL BA-builtins).
+    // ABS(X) is lowered inline: if X < 0 then −X else X (store-per-branch,
+    // same pattern as ALGOL abs).  ABS(-42) → 42.0, printed as `42`.
+    Prog {
+        lang: Language::DartmouthBasic,
+        ext: "bas",
+        src: "10 PRINT ABS(-42)\n20 END\n",
+        expect: Expect::Stdout("42"),
+        backends: &[NativeAot, Llvm, Wasm, Jvm, Clr, Vm, Jit],
+    },
+    // Dartmouth BASIC — `SGN` (signum) built-in (LANG-FULL BA-builtins).
+    // SGN(X) = 1.0 if X > 0, −1.0 if X < 0, 0.0 if X = 0.  Lowered
+    // inline as a 3-way conditional.  SGN(-5) → −1.0, printed as `-1`.
+    Prog {
+        lang: Language::DartmouthBasic,
+        ext: "bas",
+        src: "10 PRINT SGN(-5)\n20 END\n",
+        expect: Expect::Stdout("-1"),
+        backends: &[NativeAot, Llvm, Wasm, Jvm, Clr, Vm, Jit],
+    },
 ];
 
 /// Is a usable native linker present on this host? On Linux/macOS the AOT path uses

--- a/code/specs/LANG-FULL-IMPLEMENTATION.md
+++ b/code/specs/LANG-FULL-IMPLEMENTATION.md
@@ -599,7 +599,7 @@ backend immediately) come before the enabler-dependent items.
   RESTORE / READ B / PRINT A+B` ⇒ 42 (proves sequential consumption + rewind).
   BA7-3 adds the fractional proof: `DATA 3.14, 0.25 / READ A(0) / READ B / PRINT
   A(0) / PRINT B` ⇒ `3.14` and `.25` on all 7 backends.
-- ◑ **BA7** — floating-point (needs **E3**, ✅; **E8**, ✅). Design spec is
+- ✅ **BA7** — floating-point (needs **E3**, ✅; **E8**, ✅). Design spec is
   **decision-complete** ([`lang-full-ba7-floating-point.md`](lang-full-ba7-floating-point.md))
   by historical Dartmouth BASIC fidelity (no sign-off gate). **BA7-1a/1b landed**
   (`dartmouth-basic-iir-compiler` 0.11.0): decimal/exponent and integer-spelled
@@ -613,7 +613,7 @@ backend immediately) come before the enabler-dependent items.
   `dartmouth-basic-iir-compiler` 0.12.0: `DIM` arrays and `DATA` pools now store
   `f64`, with index/read-pointer boundaries left as `i64`; fractional `DATA`
   through array and scalar `READ` runs on native/LLVM/WASM/JVM/CLR/VM/JIT. BA7
-  numeric formatting completed in 0.13.0.
+  numeric formatting completed in 0.13.0. **BA7 COMPLETE.**
 - ✅ **BA-^** — integer-literal exponentiation (`dartmouth-basic-iir-compiler` 0.26.0).
   The parser already supported right-associative `^`, but the compiler rejected it pending
   a runtime math helper. The backend-neutral slice now recognizes nonnegative
@@ -621,6 +621,15 @@ backend immediately) come before the enabler-dependent items.
   `mul`, so no backend learns a new operation. Verified by RUNNING `PRINT 6 ^ 2 + 6`
   on native/LLVM/WASM/JVM/CLR/VM/JIT → stdout `42`. General variable, nested, negative,
   fractional, and large exponents still need a cross-backend runtime math helper.
+- ✅ **BA-builtins** — `SQR`, `INT`, `ABS`, `SGN` built-in functions
+  (`dartmouth-basic-iir-compiler` 0.32.0). All four reuse existing IIR ops — no new
+  backend code needed. `SQR(X)` → `f64_sqrt` (the same hardware-sqrt op ALGOL uses).
+  `INT(X)` → `real_to_int_floor` + `int_to_real` (E8 ops, floor toward −∞, result is
+  real). `ABS(X)` and `SGN(X)` lower inline via `cmp_lt`/`cmp_gt` + store-per-branch
+  conditionals (same pattern as ALGOL `abs`/`sign`). **Verified by RUNNING** on
+  native/LLVM/WASM/JVM/CLR/VM/JIT: `PRINT SQR(49)` → `7`, `PRINT INT(3.7)` → `3`,
+  `PRINT ABS(-42)` → `42`, `PRINT SGN(-5)` → `-1`. `SIN`, `COS`, `LOG`, `EXP`,
+  `TAN`, `ATN`, `RND` need a cross-backend math helper (libm/host call) — deferred.
 
 ### ALGOL 60
 - ✅ **AL1** — real arithmetic + `/` (algol-iir-compiler 0.4.0): `real` → IIR `f64`, `REAL_LIT`


### PR DESCRIPTION
## Summary

- Implements `SQR`, `INT`, `ABS`, `SGN` built-in math functions in the Dartmouth BASIC IIR compiler — all reuse existing E3/E8 IIR ops, no new backend code needed
- Fixes stale `◑` marker for BA7 (already fully implemented in 0.13.0)
- Adds 4 new matrix `Prog` cells to `lang_matrix.rs`; 818 total proven cells pass

| Function | Lowers to | All 7 backends |
|----------|-----------|----------------|
| `SQR(X)` | `f64_sqrt` IIR op | ✅ (hardware sqrt everywhere) |
| `INT(X)` | `real_to_int_floor` + `int_to_real` | ✅ (E8 floor + convert back) |
| `ABS(X)` | inline compare + branch (`cmp_lt`/`jmp_if_false`/`neg`) | ✅ (store-per-branch) |
| `SGN(X)` | inline 3-way conditional | ✅ (returns −1.0/0.0/1.0 as f64) |

`SIN`, `COS`, `LOG`, `EXP`, `TAN`, `ATN`, `RND` return a clear `Unsupported` error pending cross-backend libm infrastructure.

## Test plan

- [x] `cargo test -p lang-aot --test lang_matrix matrix_every_proven_cell_agrees` — 818 cells pass (verified locally, ~80s)
- [x] `cargo test -p lang-aot --test lang_matrix proven_columns_do_not_silently_skip` — column guard passes
- [x] Security review passed (no vulnerabilities found)
- [x] `dartmouth-basic-iir-compiler` bumped `0.31.0` → `0.32.0`
- [x] `lang-aot` bumped `0.152.0` → `0.153.0`
- [x] Both CHANGELOGs updated
- [x] `LANG-FULL-IMPLEMENTATION.md` updated: BA7 `◑` → `✅`, new `✅ BA-builtins` entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)