### PR TITLE
feat(asciimath): AsciiMath pluggable frontend (ASM01 PR-1) + iterative MathExpr Drop

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -226,6 +226,7 @@ members = [
     "logic-engine",
     "math-frontend",
     "latex",
+    "asciimath",
     "adjudication-ir",
     "llm-cache",
     "llm-gateway",

--- a/code/packages/rust/adj-lang/src/adapter.rs
+++ b/code/packages/rust/adj-lang/src/adapter.rs
@@ -514,17 +514,17 @@ fn adapt_constrain_latex(node: &GrammarASTNode) -> Result<Statement, AdapterErro
     })?;
     let source = latex_string_from_node(relation, "latex_relation")?;
     let math = parse_latex_math(&source)?;
-    let MathExpr::Rel(op, lhs, rhs) = math else {
+    let MathExpr::Rel(op, lhs, rhs) = &math else {
         return Err(AdapterError::UnsupportedLatexMath {
             source,
             detail: "expected a LaTeX relation such as x^2 = 4".into(),
         });
     };
-    let op = lower_latex_relop(op, &source)?;
+    let op = lower_latex_relop(*op, &source)?;
     Ok(Statement::Constrain {
-        lhs: latex_math_to_expr_ast(*lhs, &source)?,
+        lhs: latex_math_to_expr_ast(lhs, &source)?,
         op,
-        rhs: latex_math_to_expr_ast(*rhs, &source)?,
+        rhs: latex_math_to_expr_ast(rhs, &source)?,
     })
 }
 
@@ -836,7 +836,7 @@ fn adapt_factor(node: &GrammarASTNode) -> Result<ExprAst, AdapterError> {
     if let Some(latex) = first_named_child(node, "latex_expr") {
         let source = latex_string_from_node(latex, "latex_expr")?;
         let math = parse_latex_math(&source)?;
-        return latex_math_to_expr_ast(math, &source);
+        return latex_math_to_expr_ast(&math, &source);
     }
     if let Some(agg) = first_named_child(node, "agg") {
         return adapt_agg(agg);
@@ -907,26 +907,30 @@ fn strip_math_delimiters(source: &str) -> &str {
     }
 }
 
-fn latex_math_to_expr_ast(expr: MathExpr, source: &str) -> Result<ExprAst, AdapterError> {
+// Takes `&MathExpr` (not by value): the neutral `MathExpr` now implements `Drop` (so it is
+// safe to free at any depth), and a type with an explicit `Drop` cannot have its fields moved
+// out of a `match`. Borrowing and recursing on the references — cloning only the small leaves
+// we keep — is the idiomatic way to consume it, and avoids E0509.
+fn latex_math_to_expr_ast(expr: &MathExpr, source: &str) -> Result<ExprAst, AdapterError> {
     match expr {
-        MathExpr::Number(n) => number_to_lit(&n, source),
-        MathExpr::Symbol(name) => Ok(ExprAst::Ref(name)),
-        MathExpr::Group(inner) => latex_math_to_expr_ast(*inner, source),
-        MathExpr::Unary(UnaryOp::Pos, inner) => latex_math_to_expr_ast(*inner, source),
+        MathExpr::Number(n) => number_to_lit(n, source),
+        MathExpr::Symbol(name) => Ok(ExprAst::Ref(name.clone())),
+        MathExpr::Group(inner) => latex_math_to_expr_ast(inner, source),
+        MathExpr::Unary(UnaryOp::Pos, inner) => latex_math_to_expr_ast(inner, source),
         MathExpr::Unary(UnaryOp::Neg, inner) => Ok(ExprAst::Bin(
             ArithOp::Sub,
             Box::new(ExprAst::Lit(0.0)),
-            Box::new(latex_math_to_expr_ast(*inner, source)?),
+            Box::new(latex_math_to_expr_ast(inner, source)?),
         )),
-        MathExpr::Bin(BinOp::Add, lhs, rhs) => latex_bin(ArithOp::Add, *lhs, *rhs, source),
-        MathExpr::Bin(BinOp::Sub, lhs, rhs) => latex_bin(ArithOp::Sub, *lhs, *rhs, source),
-        MathExpr::Bin(BinOp::Mul, lhs, rhs) => latex_bin(ArithOp::Mul, *lhs, *rhs, source),
+        MathExpr::Bin(BinOp::Add, lhs, rhs) => latex_bin(ArithOp::Add, lhs, rhs, source),
+        MathExpr::Bin(BinOp::Sub, lhs, rhs) => latex_bin(ArithOp::Sub, lhs, rhs, source),
+        MathExpr::Bin(BinOp::Mul, lhs, rhs) => latex_bin(ArithOp::Mul, lhs, rhs, source),
         MathExpr::Bin(BinOp::Div, lhs, rhs) | MathExpr::Frac(lhs, rhs) => {
-            latex_bin(ArithOp::Div, *lhs, *rhs, source)
+            latex_bin(ArithOp::Div, lhs, rhs, source)
         }
         MathExpr::Bin(BinOp::Pow, base, exponent) => {
-            let n = latex_power_exponent(&exponent, source)?;
-            expand_power(*base, n, source)
+            let n = latex_power_exponent(exponent, source)?;
+            expand_power(base, n, source)
         }
         MathExpr::Rel(_, _, _) => Err(AdapterError::UnsupportedLatexMath {
             source: source.to_string(),
@@ -941,8 +945,8 @@ fn latex_math_to_expr_ast(expr: MathExpr, source: &str) -> Result<ExprAst, Adapt
 
 fn latex_bin(
     op: ArithOp,
-    lhs: MathExpr,
-    rhs: MathExpr,
+    lhs: &MathExpr,
+    rhs: &MathExpr,
     source: &str,
 ) -> Result<ExprAst, AdapterError> {
     Ok(ExprAst::Bin(
@@ -993,7 +997,7 @@ fn latex_power_exponent(expr: &MathExpr, source: &str) -> Result<usize, AdapterE
     Ok(v as usize)
 }
 
-fn expand_power(base: MathExpr, exponent: usize, source: &str) -> Result<ExprAst, AdapterError> {
+fn expand_power(base: &MathExpr, exponent: usize, source: &str) -> Result<ExprAst, AdapterError> {
     if exponent == 0 {
         return Ok(ExprAst::Lit(1.0));
     }

--- a/code/packages/rust/asciimath/BUILD
+++ b/code/packages/rust/asciimath/BUILD
@@ -1,0 +1,1 @@
+cargo test -p asciimath -- --nocapture

--- a/code/packages/rust/asciimath/BUILD_windows
+++ b/code/packages/rust/asciimath/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p asciimath -- --nocapture

--- a/code/packages/rust/asciimath/CHANGELOG.md
+++ b/code/packages/rust/asciimath/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog — asciimath
+
+All notable changes to the AsciiMath pluggable frontend.
+
+## [0.1.0] — 2026-06-28
+
+### Added — ASM01 PR-1: the AsciiMath frontend (core subset)
+
+- New standalone crate `asciimath` (added to the Rust workspace members), the **second**
+  pluggable frontend after `latex` (see ASM01 / PFE01). Depends only on `math-frontend`.
+- **`AsciiMath`** implements `math_frontend::MathFrontend`: `name() == "asciimath"`,
+  `parse(src) -> Result<MathExpr, FrontendError>`, and an honest `capabilities()`. Free
+  functions `parse` and `tokenize` are also public.
+- **Tokenizer** (`token.rs`): numbers (exact), identifiers (maximal letter runs), the
+  operators `+ - * / ^ _ = < >` and multi-char `<= >= != ~~ -= -:`, brackets `( ) [ ] { }`,
+  and `"…"` text literals; whitespace skipped. Spanned, total, panic-free.
+- **Parser** (`parser.rs`): precedence-climbing relation < add/sub < mul (incl. juxtaposition
+  and `xx`/`cdot`/`-:`) < frac (`/`) < unary < scripts (`^`/`_`), over atoms: numbers,
+  symbols, function application (`sin`, `ln`, …), `sqrt`/`root(n)(x)`, groups, and `"text"`.
+  Identifiers classify as function / known constant (`pi`, `theta`, … , `oo`→`infinity`) /
+  operator word / else a product of single-letter symbols (`xy` ⇒ `x·y`). Lowers directly to
+  the neutral `MathExpr`; `1/2` ≡ LaTeX's `\frac{1}{2}`.
+- **Total / panic-free / bounded:** every input yields `Ok` or a spanned `FrontendError`;
+  recursion is depth-guarded (`MAX_DEPTH`) and left-associative chains are built with loops,
+  so deep nesting and long chains can't overflow the parser stack.
+- **Capabilities** advertised: `fractions, roots, powers, functions, relations, implicit_mul,
+  text` (matrices / big-operators are off — PR-2). Conforms to the shared `check_frontend`
+  harness (no panics, valid spans, no capability over-claim) + notation-specific goldens.
+- Spec `code/specs/ASM01-asciimath-frontend.md`; documented PR-1 limitations + roadmap (§5).
+- No `unsafe`; `cargo clippy -- -D warnings` clean.

--- a/code/packages/rust/asciimath/Cargo.toml
+++ b/code/packages/rust/asciimath/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "asciimath"
+version = "0.1.0"
+edition = "2021"
+description = "An AsciiMath parser that implements the math-frontend MathFrontend trait: turns AsciiMath (1/2, sqrt(x), x^2+y^2=r^2) into the neutral MathExpr AST. The second pluggable frontend after LaTeX (see ASM01/PFE01). Total, panic-free, spanned errors."
+license = "MIT"
+
+[dependencies]
+# The neutral framework: MathExpr + the MathFrontend trait + the conformance harness.
+# This is a frontend, so the dependency is mandatory (not optional like latex's adapter).
+math-frontend = { path = "../math-frontend" }

--- a/code/packages/rust/asciimath/README.md
+++ b/code/packages/rust/asciimath/README.md
@@ -1,0 +1,79 @@
+# asciimath
+
+An **[AsciiMath](http://asciimath.org/) parser** that implements the
+[`math-frontend`](../math-frontend) `MathFrontend` trait — the **second** pluggable
+frontend after [`latex`](../latex). It turns terse, human-typable AsciiMath
+(`1/2`, `sqrt(x)`, `x^2 + y^2 = r^2`, `sum_(i=1)^n i`) into the **same neutral `MathExpr`**
+the LaTeX frontend produces, so every consumer (a rule engine, a CAS, a renderer) lowers
+*one* tree and gets both notations for free.
+
+Spec: [`code/specs/ASM01-asciimath-frontend.md`](../../../specs/ASM01-asciimath-frontend.md)
+(framework: [`PFE01`](../../../specs/PFE01-pluggable-parser-frontends.md)).
+
+## Why it exists
+
+```
+   LaTeX     ─┐
+ AsciiMath   ─┼─▶ MathExpr ─▶ (consumer lowers ONCE)
+   MathML    ─┘   (neutral)
+```
+
+A math-capable model or a human can write `1/2` far more readily than `\frac{1}{2}`. For an
+input→reasoning pipeline that translates a problem into a program, AsciiMath is a first-class
+input notation — and adding it is exactly "register one more frontend," with **zero** change
+to any consumer. That is the whole point of the framework; this crate is the proof with a
+second notation.
+
+## What it parses (PR-1 core)
+
+| AsciiMath | → neutral `MathExpr` |
+|-----------|----------------------|
+| `42`, `3.14`, `6.022e23` | `Number` (exact — never `f64`) |
+| `x`, `pi`, `alpha` | `Symbol` |
+| `xy` | `x · y` (implicit product of single letters, the AsciiMath rule) |
+| `a + b`, `a - b`, `a*b`, `a xx b`, `a -: b` | `Bin(Add/Sub/Mul/Div)` |
+| `a b` (juxtaposition) | `Bin(Mul)` (implicit multiplication) |
+| `1/2` | `Frac` |
+| `x^2`, `a_i`, `a_i^2` | `Bin(Pow)` / `Subscript` / `Pow(Subscript)` |
+| `sqrt(x)`, `sqrt x` | `Root { degree: None, .. }` |
+| `root(3)(x)`, `root 3 x` | `Root { degree: Some(3), .. }` |
+| `sin x`, `ln(x)` | `Call { func, arg }` |
+| `a = b`, `x <= y`, `a != b` | `Rel` |
+| `( .. )`, `[ .. ]`, `{ .. }` | `Group` |
+| `"kg"` (text literal) | `Text` |
+
+It is **total and panic-free**: every input returns `Ok(MathExpr)` or a spanned
+`FrontendError`. Recursion is depth-guarded; left-associative chains are built with loops, so
+neither deep nesting nor long chains overflow the parser. Later PRs add matrices, big
+operators (`sum`/`prod`/`int`), accents, and the full symbol table (see ASM01 §5).
+
+## Usage
+
+```rust
+use asciimath::AsciiMath;
+use math_frontend::{MathFrontend, MathExpr, BinOp};
+
+let e = AsciiMath.parse("1/2 + x^2").unwrap();
+// 1/2  →  Frac;  x^2  →  Bin(Pow);  joined by Bin(Add)
+assert!(matches!(e, MathExpr::Bin(BinOp::Add, _, _)));
+
+// Same meaning as LaTeX's \frac{1}{2}: both lower to MathExpr::Frac.
+assert_eq!(AsciiMath.parse("1/2").unwrap(), AsciiMath.parse("(1)/(2)").unwrap());
+```
+
+Registering it alongside LaTeX (a consumer concern — `math-frontend` can't depend on its own
+frontends):
+
+```rust
+use math_frontend::FrontendRegistry;
+let mut reg = FrontendRegistry::new();
+reg.register(Box::new(asciimath::AsciiMath));
+assert!(reg.parse("asciimath", "sqrt(x)").is_ok());
+```
+
+## Tests
+
+```
+cargo test -p asciimath
+cargo clippy -p asciimath -- -D warnings
+```

--- a/code/packages/rust/asciimath/required_capabilities.json
+++ b/code/packages/rust/asciimath/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/asciimath",
+  "capabilities": [],
+  "justification": "Pure computation: turns an AsciiMath string into tokens and the neutral MathExpr AST. No filesystem, network, process, or environment access."
+}

--- a/code/packages/rust/asciimath/src/lib.rs
+++ b/code/packages/rust/asciimath/src/lib.rs
@@ -1,0 +1,226 @@
+//! # asciimath — an [AsciiMath](http://asciimath.org/) frontend for [`math_frontend`]
+//!
+//! The **second** pluggable parser frontend (after `latex`). It turns terse, human-typable
+//! AsciiMath — `1/2`, `sqrt(x)`, `x^2 + y^2 = r^2`, `sin x` — into the *same* neutral
+//! [`MathExpr`] the LaTeX frontend produces. A consumer lowers that one neutral tree and
+//! gets both notations for free; adding AsciiMath required **zero** change to any consumer.
+//! That is the whole promise of [PFE01](../../../specs/PFE01-pluggable-parser-frontends.md),
+//! demonstrated here with a genuinely different notation.
+//!
+//! ## Contract
+//! [`AsciiMath`] implements [`MathFrontend`]: it is **total and panic-free** (every input is
+//! `Ok(MathExpr)` or a spanned [`FrontendError`]), **pure**, and **honest** (its
+//! [`capabilities`](MathFrontend::capabilities) match what it actually emits — enforced by
+//! the shared `check_frontend` harness).
+//!
+//! ## What it covers (PR-1)
+//! Numbers (exact), variables/constants, `+ - * / ^ _`, juxtaposition (implicit `·`),
+//! `a/b` fractions, `sqrt`/`root(n)(x)`, named functions, relations, grouping, and `"text"`.
+//! Matrices and big operators (`sum`/`prod`/`int`) are PR-2 (ASM01 §5).
+//!
+//! ```
+//! use asciimath::AsciiMath;
+//! use math_frontend::{MathFrontend, MathExpr, BinOp};
+//!
+//! let e = AsciiMath.parse("1/2 + x^2").unwrap();
+//! assert!(matches!(e, MathExpr::Bin(BinOp::Add, _, _)));
+//! // `1/2` means the same as LaTeX `\frac{1}{2}` — both are MathExpr::Frac.
+//! assert_eq!(AsciiMath.parse("1/2").unwrap(), AsciiMath.parse("(1)/(2)").unwrap());
+//! ```
+
+#![forbid(unsafe_code)]
+
+mod parser;
+mod token;
+
+pub use parser::parse;
+pub use token::{tokenize, Span, Token, TokenKind};
+
+// Re-export the neutral types so a consumer can `use asciimath::MathExpr` without also
+// naming the framework crate directly.
+pub use math_frontend::{
+    BigOp, BinOp, Capabilities, Func, FrontendError, MathExpr, MathFrontend, Number, RelOp,
+    UnaryOp,
+};
+
+/// The AsciiMath frontend. A zero-sized handle implementing [`MathFrontend`].
+#[derive(Debug, Default, Clone, Copy)]
+pub struct AsciiMath;
+
+impl MathFrontend for AsciiMath {
+    fn name(&self) -> &str {
+        "asciimath"
+    }
+
+    fn parse(&self, src: &str) -> Result<MathExpr, FrontendError> {
+        parser::parse(src)
+    }
+
+    fn capabilities(&self) -> Capabilities {
+        // Exactly the PR-1 surface. `matrices` and `big_operators` stay off until PR-2;
+        // `plusminus`/`binomials` are not part of AsciiMath's core spelling here. Declaring
+        // `implicit_mul` is a parser-behavior claim (juxtaposition ⇒ `Mul`) the goldens cover.
+        Capabilities::none()
+            .with_fractions()
+            .with_roots()
+            .with_powers()
+            .with_functions()
+            .with_relations()
+            .with_implicit_mul()
+            .with_text()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use math_frontend::check_frontend;
+
+    fn p(s: &str) -> MathExpr {
+        AsciiMath.parse(s).unwrap_or_else(|e| panic!("parse {s:?} failed: {e}"))
+    }
+    fn num(n: i64) -> MathExpr {
+        MathExpr::Number(Number::from_i64(n))
+    }
+    fn sym(s: &str) -> MathExpr {
+        MathExpr::Symbol(s.to_string())
+    }
+    fn b(op: BinOp, l: MathExpr, r: MathExpr) -> MathExpr {
+        MathExpr::Bin(op, Box::new(l), Box::new(r))
+    }
+
+    // ---- atoms -----------------------------------------------------------------
+    #[test]
+    fn number_is_exact() {
+        assert_eq!(p("42"), num(42));
+        // 1, 1.0, 01 all denote the same exact value.
+        assert_eq!(p("1.0"), p("1"));
+        assert_eq!(p("6.022e23"), p("6.022e23"));
+    }
+
+    #[test]
+    fn single_letter_is_a_symbol_multi_letter_is_a_product() {
+        assert_eq!(p("x"), sym("x"));
+        assert_eq!(p("xy"), b(BinOp::Mul, sym("x"), sym("y")));
+        assert_eq!(p("pi"), sym("pi")); // a known constant stays whole
+        assert_eq!(p("oo"), sym("infinity"));
+    }
+
+    // ---- operators & precedence ------------------------------------------------
+    #[test]
+    fn add_and_implicit_mul() {
+        assert_eq!(p("a + b"), b(BinOp::Add, sym("a"), sym("b")));
+        assert_eq!(p("2x"), b(BinOp::Mul, num(2), sym("x")));
+        assert_eq!(p("a b"), b(BinOp::Mul, sym("a"), sym("b")));
+        // explicit forms all normalize to Mul / Div
+        assert_eq!(p("a xx b"), b(BinOp::Mul, sym("a"), sym("b")));
+        assert_eq!(p("a cdot b"), b(BinOp::Mul, sym("a"), sym("b")));
+        assert_eq!(p("a -: b"), b(BinOp::Div, sym("a"), sym("b")));
+    }
+
+    #[test]
+    fn fraction_binds_tighter_than_mul() {
+        // 1/2 x  ⇒  (1/2)·x
+        assert_eq!(
+            p("1/2 x"),
+            b(BinOp::Mul, MathExpr::Frac(Box::new(num(1)), Box::new(num(2))), sym("x"))
+        );
+        // and `1/2` ≡ LaTeX `\frac{1}{2}` shape
+        assert_eq!(p("1/2"), MathExpr::Frac(Box::new(num(1)), Box::new(num(2))));
+    }
+
+    #[test]
+    fn scripts_pow_and_subscript() {
+        assert_eq!(p("x^2"), b(BinOp::Pow, sym("x"), num(2)));
+        assert_eq!(p("a_i"), MathExpr::Subscript(Box::new(sym("a")), Box::new(sym("i"))));
+        // a_i^2  ⇒  (a_i)^2
+        assert_eq!(
+            p("a_i^2"),
+            b(BinOp::Pow, MathExpr::Subscript(Box::new(sym("a")), Box::new(sym("i"))), num(2))
+        );
+    }
+
+    #[test]
+    fn roots_and_functions() {
+        let sqrt_x = MathExpr::Root { degree: None, radicand: Box::new(sym("x")) };
+        assert_eq!(p("sqrt(x)"), sqrt_x);
+        assert_eq!(p("sqrt x"), p("sqrt(x)")); // grouping normalizes away
+        assert_eq!(
+            p("root(3)(x)"),
+            MathExpr::Root { degree: Some(Box::new(num(3))), radicand: Box::new(sym("x")) }
+        );
+        assert_eq!(p("sin x"), MathExpr::Call { func: Func::Sin, arg: Box::new(sym("x")) });
+    }
+
+    #[test]
+    fn relations() {
+        assert_eq!(p("a = b"), MathExpr::Rel(RelOp::Eq, Box::new(sym("a")), Box::new(sym("b"))));
+        assert_eq!(p("a <= b"), MathExpr::Rel(RelOp::Le, Box::new(sym("a")), Box::new(sym("b"))));
+        assert_eq!(p("a != b"), MathExpr::Rel(RelOp::Ne, Box::new(sym("a")), Box::new(sym("b"))));
+    }
+
+    #[test]
+    fn grouping_normalizes_away_and_text() {
+        assert_eq!(p("(1)/(2)"), p("1/2"));
+        assert_eq!(p("(a + b)"), p("a + b"));
+        assert_eq!(p(r#""kg""#), MathExpr::Text("kg".to_string()));
+    }
+
+    #[test]
+    fn a_realistic_expression() {
+        // x^2 + y^2 = r^2
+        let lhs = b(BinOp::Add, b(BinOp::Pow, sym("x"), num(2)), b(BinOp::Pow, sym("y"), num(2)));
+        let rhs = b(BinOp::Pow, sym("r"), num(2));
+        assert_eq!(p("x^2 + y^2 = r^2"), MathExpr::Rel(RelOp::Eq, Box::new(lhs), Box::new(rhs)));
+    }
+
+    // ---- totality / errors -----------------------------------------------------
+    #[test]
+    fn errors_are_spanned_never_panic() {
+        for bad in ["", "1 +", "(x", "a ! b", "\"oops", ")"] {
+            let e = AsciiMath.parse(bad).expect_err(&format!("{bad:?} should error"));
+            assert_eq!(e.frontend, "asciimath");
+            assert!(e.span.0 <= e.span.1 && e.span.1 <= bad.len(), "bad span on {bad:?}: {:?}", e.span);
+        }
+    }
+
+    #[test]
+    fn deep_nesting_errors_not_overflows() {
+        // 5000 open-parens must return a spanned error (MAX_DEPTH), not overflow the stack.
+        let deep = "(".repeat(5000);
+        assert!(AsciiMath.parse(&deep).is_err());
+    }
+
+    // ---- name / capabilities / conformance -------------------------------------
+    #[test]
+    fn name_and_capabilities_are_honest() {
+        assert_eq!(AsciiMath.name(), "asciimath");
+        let c = AsciiMath.capabilities();
+        assert!(c.fractions && c.roots && c.powers && c.functions && c.relations && c.text && c.implicit_mul);
+        assert!(!c.matrices && !c.big_operators && !c.plusminus && !c.binomials);
+    }
+
+    #[test]
+    fn conforms_to_the_shared_harness() {
+        let report = check_frontend(
+            &AsciiMath,
+            &[
+                "1/2",
+                "x^2 + y^2 = r^2",
+                "sqrt(x)",
+                "root(3)(27)",
+                "sin x",
+                "2x + 3",
+                "a_i^2",
+                "pi",
+                r#""kg""#,
+                "a <= b",
+                "(a + b)/(c - d)",
+                "1 +",   // error: trailing operator (span in range, not a panic)
+                "(x",    // error: missing close
+                "",      // error: empty
+            ],
+        );
+        assert!(report.passed(), "conformance issues: {:?}", report.issues);
+    }
+}

--- a/code/packages/rust/asciimath/src/parser.rs
+++ b/code/packages/rust/asciimath/src/parser.rs
@@ -1,0 +1,365 @@
+//! The AsciiMath parser — tokens → the neutral [`MathExpr`].
+//!
+//! A precedence-climbing recursive-descent parser. Precedence, lowest binds loosest:
+//!
+//! ```text
+//!   relation   a = b   a <= b   a != b              (left-assoc)
+//!   add/sub    a + b   a - b
+//!   mul        a * b   a xx b   a cdot b   a -: b    and JUXTAPOSITION (a b ⇒ a·b)
+//!   frac       a / b                                 (binds the adjacent simple exprs)
+//!   unary      -a   +a                               (a sign *run* is folded with a loop)
+//!   script     a^b   a_b   a_b^c                     (operand is one atom)
+//!   atom       number | symbol | f(x) | sqrt x | root(n)(x) | (group) | "text"
+//! ```
+//!
+//! ## Two safety properties (both deliberate)
+//! * **Bounded recursion.** Only *nesting* (groups, scripts, function/root arguments)
+//!   recurses, and every such descent charges [`MAX_DEPTH`]; adversarial nesting therefore
+//!   returns a spanned error instead of overflowing the stack.
+//! * **Loops for chains.** Left-associative chains (`a+a+…`, juxtaposition, `a/a/…`) and
+//!   sign runs (`---a`) are built with `while`/`for` loops, *not* recursion — so an
+//!   arbitrarily long chain costs O(1) parser stack. (The neutral tree it builds is still
+//!   left-nested; dropping a *pathologically* deep such tree is a separate concern tracked
+//!   for the math-frontend AST, not introduced here.)
+
+use crate::token::{tokenize, Token, TokenKind};
+use math_frontend::{BinOp, Func, FrontendError, MathExpr, Number, RelOp, UnaryOp};
+
+/// Maximum *nesting* depth before we refuse with a spanned error (never overflow).
+///
+/// Each nesting level descends ~9 parser functions (`relation→…→atom→group`), so the cap is
+/// kept well below what would exhaust a 2 MiB test-thread stack — the guard must fire *before*
+/// the stack does. Real AsciiMath never nests anywhere near this deep; adversarial input that
+/// does gets a clean spanned error instead of an abort.
+const MAX_DEPTH: usize = 64;
+
+/// Parse an AsciiMath source string into the neutral [`MathExpr`]. Total and panic-free.
+pub fn parse(src: &str) -> Result<MathExpr, FrontendError> {
+    let toks = tokenize(src)?;
+    let mut p = Parser { toks: &toks, pos: 0, depth: 0 };
+    let e = p.parse_relation()?;
+    match p.peek() {
+        TokenKind::Eof => Ok(e),
+        _ => Err(p.error_here("unexpected trailing input")),
+    }
+}
+
+struct Parser<'a> {
+    toks: &'a [Token],
+    pos: usize,
+    depth: usize,
+}
+
+impl Parser<'_> {
+    fn peek(&self) -> &TokenKind {
+        // `tokenize` always appends Eof, so indexing the last token is safe; the fallback
+        // keeps this total even if that invariant were ever violated.
+        self.toks.get(self.pos).map(|t| &t.kind).unwrap_or(&TokenKind::Eof)
+    }
+
+    fn span_here(&self) -> (usize, usize) {
+        self.toks
+            .get(self.pos)
+            .or_else(|| self.toks.last())
+            .map(|t| t.span)
+            .unwrap_or((0, 0))
+    }
+
+    fn advance(&mut self) {
+        if self.pos < self.toks.len() {
+            self.pos += 1;
+        }
+    }
+
+    fn error_here(&self, msg: impl Into<String>) -> FrontendError {
+        FrontendError::new("asciimath", msg, self.span_here())
+    }
+
+    /// Enter one level of *nesting* (the recursion points). Returns an error at the cap so
+    /// deeply-nested input fails cleanly rather than overflowing the call stack.
+    fn enter(&mut self) -> Result<(), FrontendError> {
+        self.depth += 1;
+        if self.depth > MAX_DEPTH {
+            Err(self.error_here("expression nested too deeply"))
+        } else {
+            Ok(())
+        }
+    }
+    fn exit(&mut self) {
+        self.depth -= 1;
+    }
+
+    // ---- relation < add < mul < frac < unary < script < atom --------------------
+
+    fn parse_relation(&mut self) -> Result<MathExpr, FrontendError> {
+        let mut lhs = self.parse_add()?;
+        while let Some(op) = rel_of(self.peek()) {
+            self.advance();
+            let rhs = self.parse_add()?;
+            lhs = MathExpr::Rel(op, Box::new(lhs), Box::new(rhs));
+        }
+        Ok(lhs)
+    }
+
+    fn parse_add(&mut self) -> Result<MathExpr, FrontendError> {
+        let mut lhs = self.parse_mul()?;
+        loop {
+            let op = match self.peek() {
+                TokenKind::Plus => BinOp::Add,
+                TokenKind::Minus => BinOp::Sub,
+                _ => break,
+            };
+            self.advance();
+            let rhs = self.parse_mul()?;
+            lhs = MathExpr::Bin(op, Box::new(lhs), Box::new(rhs));
+        }
+        Ok(lhs)
+    }
+
+    fn parse_mul(&mut self) -> Result<MathExpr, FrontendError> {
+        let mut lhs = self.parse_frac()?;
+        loop {
+            // Explicit multiplicative operators: `*`/`**`, `xx`, `cdot`, `/`-as-`-:`, `div`.
+            let op = match self.peek() {
+                TokenKind::Star => Some(BinOp::Mul),
+                TokenKind::Div => Some(BinOp::Div),
+                TokenKind::Ident(w) if w == "xx" || w == "cdot" => Some(BinOp::Mul),
+                TokenKind::Ident(w) if w == "div" => Some(BinOp::Div),
+                _ => None,
+            };
+            if let Some(op) = op {
+                self.advance();
+                let rhs = self.parse_frac()?;
+                lhs = MathExpr::Bin(op, Box::new(lhs), Box::new(rhs));
+                continue;
+            }
+            // Implicit multiplication: a new simple expression begins with no operator.
+            if self.starts_simple() {
+                let rhs = self.parse_frac()?;
+                lhs = MathExpr::Bin(BinOp::Mul, Box::new(lhs), Box::new(rhs));
+                continue;
+            }
+            break;
+        }
+        Ok(lhs)
+    }
+
+    fn parse_frac(&mut self) -> Result<MathExpr, FrontendError> {
+        let mut lhs = self.parse_unary()?;
+        while matches!(self.peek(), TokenKind::Slash) {
+            self.advance();
+            let rhs = self.parse_unary()?;
+            lhs = MathExpr::Frac(Box::new(lhs), Box::new(rhs));
+        }
+        Ok(lhs)
+    }
+
+    fn parse_unary(&mut self) -> Result<MathExpr, FrontendError> {
+        // Collect a sign run with a loop (no recursion → `------x` can't overflow).
+        let mut signs: Vec<UnaryOp> = Vec::new();
+        loop {
+            match self.peek() {
+                TokenKind::Minus => { signs.push(UnaryOp::Neg); self.advance(); }
+                TokenKind::Plus => { signs.push(UnaryOp::Pos); self.advance(); }
+                _ => break,
+            }
+        }
+        let mut e = self.parse_script()?;
+        for op in signs.into_iter().rev() {
+            e = MathExpr::Unary(op, Box::new(e));
+        }
+        Ok(e)
+    }
+
+    fn parse_script(&mut self) -> Result<MathExpr, FrontendError> {
+        let mut base = self.parse_atom()?;
+        // AsciiMath order: subscript then superscript (`a_i^2` ⇒ (a_i)^2). Each operand is
+        // a single atom (so `x^2y` is (x^2)·y, the AsciiMath reading).
+        if matches!(self.peek(), TokenKind::Underscore) {
+            self.advance();
+            let sub = self.parse_atom()?;
+            base = MathExpr::Subscript(Box::new(base), Box::new(sub));
+        }
+        if matches!(self.peek(), TokenKind::Caret) {
+            self.advance();
+            let sup = self.parse_atom()?;
+            base = MathExpr::Bin(BinOp::Pow, Box::new(base), Box::new(sup));
+        }
+        Ok(base)
+    }
+
+    /// Does the upcoming token begin a *simple expression* (an atom)? Drives implicit
+    /// multiplication — and excludes the operator-words (`xx`/`cdot`/`div`) so they are not
+    /// mistaken for operands.
+    fn starts_simple(&self) -> bool {
+        match self.peek() {
+            TokenKind::Num(_) | TokenKind::Text(_) => true,
+            TokenKind::LParen | TokenKind::LBracket | TokenKind::LBrace => true,
+            TokenKind::Ident(w) => !matches!(w.as_str(), "xx" | "cdot" | "div"),
+            _ => false,
+        }
+    }
+
+    fn parse_atom(&mut self) -> Result<MathExpr, FrontendError> {
+        self.enter()?;
+        let result = self.parse_atom_inner();
+        self.exit();
+        result
+    }
+
+    fn parse_atom_inner(&mut self) -> Result<MathExpr, FrontendError> {
+        match self.peek().clone() {
+            TokenKind::Num(s) => {
+                self.advance();
+                match Number::parse(&s) {
+                    Some(n) => Ok(MathExpr::Number(n)),
+                    None => Err(self.error_here(format!("invalid number literal {s:?}"))),
+                }
+            }
+            TokenKind::Text(s) => {
+                self.advance();
+                Ok(MathExpr::Text(s))
+            }
+            TokenKind::LParen | TokenKind::LBracket | TokenKind::LBrace => self.parse_group(),
+            TokenKind::Ident(word) => self.parse_ident_atom(&word),
+            _ => Err(self.error_here("expected a number, symbol, or '('")),
+        }
+    }
+
+    /// A bracketed group: parentheses are *grouping only* — the delimiter style is dropped
+    /// and the inner expression is returned directly (so `sqrt(x)` ≡ `sqrt x` and
+    /// `(1)/(2)` ≡ `1/2`). Any closing bracket is accepted (AsciiMath treats them loosely).
+    fn parse_group(&mut self) -> Result<MathExpr, FrontendError> {
+        self.advance(); // opening bracket
+        let inner = self.parse_relation()?;
+        match self.peek() {
+            TokenKind::RParen | TokenKind::RBracket | TokenKind::RBrace => {
+                self.advance();
+                Ok(inner)
+            }
+            _ => Err(self.error_here("expected a closing bracket")),
+        }
+    }
+
+    fn parse_ident_atom(&mut self, word: &str) -> Result<MathExpr, FrontendError> {
+        // Function application: `sin x`, `ln(x)` — the argument is the next atom.
+        if let Some(func) = func_of(word) {
+            self.advance();
+            let arg = self.parse_atom()?;
+            return Ok(MathExpr::Call { func, arg: Box::new(arg) });
+        }
+        match word {
+            "sqrt" => {
+                self.advance();
+                let radicand = self.parse_atom()?;
+                Ok(MathExpr::Root { degree: None, radicand: Box::new(radicand) })
+            }
+            "root" => {
+                // `root(n)(x)` or `root n x`: degree then radicand, each one atom.
+                self.advance();
+                let degree = self.parse_atom()?;
+                let radicand = self.parse_atom()?;
+                Ok(MathExpr::Root { degree: Some(Box::new(degree)), radicand: Box::new(radicand) })
+            }
+            "xx" | "cdot" | "div" => {
+                // A multiplicative operator with no left operand.
+                Err(self.error_here(format!("'{word}' needs a left operand")))
+            }
+            _ => {
+                self.advance();
+                if let Some(canon) = constant_of(word) {
+                    Ok(MathExpr::Symbol(canon.to_string()))
+                } else if word.chars().count() == 1 {
+                    Ok(MathExpr::Symbol(word.to_string()))
+                } else {
+                    // A bare multi-letter run is the implicit product of its single letters
+                    // (`xy` ⇒ x·y) — the AsciiMath convention. Built left-assoc with a loop.
+                    let mut chars = word.chars();
+                    let first = chars.next().expect("identifier is non-empty");
+                    let mut e = MathExpr::Symbol(first.to_string());
+                    for ch in chars {
+                        e = MathExpr::Bin(
+                            BinOp::Mul,
+                            Box::new(e),
+                            Box::new(MathExpr::Symbol(ch.to_string())),
+                        );
+                    }
+                    Ok(e)
+                }
+            }
+        }
+    }
+}
+
+/// Relational operator for a token, if it is one (`=`, `!=`, `<`, `<=`, `>`, `>=`, `~~`, `-=`).
+fn rel_of(kind: &TokenKind) -> Option<RelOp> {
+    Some(match kind {
+        TokenKind::Eq => RelOp::Eq,
+        TokenKind::Ne => RelOp::Ne,
+        TokenKind::Lt => RelOp::Lt,
+        TokenKind::Le => RelOp::Le,
+        TokenKind::Gt => RelOp::Gt,
+        TokenKind::Ge => RelOp::Ge,
+        TokenKind::Approx => RelOp::Approx,
+        TokenKind::Equiv => RelOp::Equiv,
+        _ => return None,
+    })
+}
+
+/// Map an identifier to a named [`Func`], or `None` if it is not a known function.
+fn func_of(word: &str) -> Option<Func> {
+    Some(match word {
+        "sin" => Func::Sin,
+        "cos" => Func::Cos,
+        "tan" => Func::Tan,
+        "cot" => Func::Cot,
+        "sec" => Func::Sec,
+        "csc" => Func::Csc,
+        "arcsin" => Func::Asin,
+        "arccos" => Func::Acos,
+        "arctan" => Func::Atan,
+        "sinh" => Func::Sinh,
+        "cosh" => Func::Cosh,
+        "tanh" => Func::Tanh,
+        "ln" => Func::Ln,
+        "log" => Func::Log,
+        "exp" => Func::Exp,
+        "min" => Func::Min,
+        "max" => Func::Max,
+        "gcd" => Func::Gcd,
+        "lcm" => Func::Lcm,
+        "det" => Func::Det,
+        _ => return None,
+    })
+}
+
+/// Map an identifier to a canonical constant/symbol name, or `None` for an ordinary variable.
+/// Greek names are kept verbatim; `oo`/`infty` canonicalize to `infinity`.
+fn constant_of(word: &str) -> Option<&'static str> {
+    Some(match word {
+        "pi" => "pi",
+        "tau" => "tau",
+        "theta" => "theta",
+        "alpha" => "alpha",
+        "beta" => "beta",
+        "gamma" => "gamma",
+        "delta" => "delta",
+        "epsilon" => "epsilon",
+        "zeta" => "zeta",
+        "eta" => "eta",
+        "iota" => "iota",
+        "kappa" => "kappa",
+        "lambda" => "lambda",
+        "mu" => "mu",
+        "nu" => "nu",
+        "xi" => "xi",
+        "rho" => "rho",
+        "sigma" => "sigma",
+        "phi" => "phi",
+        "chi" => "chi",
+        "psi" => "psi",
+        "omega" => "omega",
+        "oo" | "infty" => "infinity",
+        _ => return None,
+    })
+}

--- a/code/packages/rust/asciimath/src/token.rs
+++ b/code/packages/rust/asciimath/src/token.rs
@@ -1,0 +1,269 @@
+//! The AsciiMath tokenizer — a small, total, panic-free scanner.
+//!
+//! AsciiMath is (almost entirely) ASCII, so we scan byte-by-byte and record a half-open
+//! byte `Span` for every token. The scanner recognises:
+//!
+//! * **numbers** — `42`, `3.14`, `6.022e23` (the exact text; [`Number`] validates it later);
+//! * **identifiers** — a maximal run of ASCII letters (`x`, `pi`, `sin`, `sqrt`). Whether a
+//!   run is a variable, a function, a constant, or a product of letters is the *parser's*
+//!   job (it needs grammar context), so the tokenizer just hands over the run;
+//! * **operators** — `+ - * / ^ _ = < >` and the multi-character forms `<= >= != ~~ -= -:`
+//!   (and `**` for `*`), each one token;
+//! * **brackets** — `( ) [ ] { }`;
+//! * **text literals** — `"…"` (contents become a [`crate::Token`] of kind [`TokenKind::Text`]).
+//!
+//! Whitespace is skipped. Anything else is a *returned* error (never a panic), so the
+//! tokenizer is total: every input yields `Ok(tokens)` or one `Err(FrontendError)`.
+//!
+//! Truth table for the `-` lead byte (the only genuinely ambiguous one):
+//!
+//! | next byte | token   | meaning            |
+//! |-----------|---------|--------------------|
+//! | `:`       | `Div`   | `-:` is ÷          |
+//! | `=`       | `Equiv` | `-=` is ≡          |
+//! | (other)   | `Minus` | binary/unary minus |
+
+use math_frontend::FrontendError;
+
+/// A half-open byte span `[start, end)` into the source.
+pub type Span = (usize, usize);
+
+/// The lexical categories AsciiMath PR-1 recognises.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TokenKind {
+    /// A numeric literal, exact source text (e.g. `"3.14"`).
+    Num(String),
+    /// A maximal run of ASCII letters (`"x"`, `"sin"`, `"pi"`).
+    Ident(String),
+    /// The contents of a `"…"` literal (the quotes are stripped).
+    Text(String),
+    Plus,
+    Minus,
+    /// `*` (and `**`) — multiplication.
+    Star,
+    /// `/` — built-up fraction.
+    Slash,
+    /// `^` — superscript / power.
+    Caret,
+    /// `_` — subscript.
+    Underscore,
+    /// `-:` (and the word `div`, handled in the parser) — division.
+    Div,
+    Eq,
+    Ne,
+    Lt,
+    Le,
+    Gt,
+    Ge,
+    /// `~~` — approximately equal.
+    Approx,
+    /// `-=` — identically equal.
+    Equiv,
+    LParen,
+    RParen,
+    LBracket,
+    RBracket,
+    LBrace,
+    RBrace,
+    /// End of input (always the final token; zero-width span at the end).
+    Eof,
+}
+
+/// A token plus where it came from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Token {
+    pub kind: TokenKind,
+    pub span: Span,
+}
+
+fn err(msg: impl Into<String>, span: Span) -> FrontendError {
+    FrontendError::new("asciimath", msg, span)
+}
+
+/// Is `b` the start of a numeric literal given the following byte?
+fn starts_number(b: u8, next: Option<u8>) -> bool {
+    b.is_ascii_digit() || (b == b'.' && matches!(next, Some(d) if d.is_ascii_digit()))
+}
+
+/// Scan a numeric literal beginning at `start`, returning the end offset (exclusive).
+/// Grammar: `digits? ('.' digits)? ([eE] [+-]? digits)?` with at least one mantissa digit.
+/// We only *capture* the text here; [`Number::parse`] is the authority on validity.
+fn scan_number(bytes: &[u8], start: usize) -> usize {
+    let mut i = start;
+    while i < bytes.len() && bytes[i].is_ascii_digit() {
+        i += 1;
+    }
+    if i < bytes.len() && bytes[i] == b'.' && i + 1 < bytes.len() && bytes[i + 1].is_ascii_digit() {
+        i += 1; // the dot
+        while i < bytes.len() && bytes[i].is_ascii_digit() {
+            i += 1;
+        }
+    }
+    // Optional exponent — only consumed if it is well-formed (digits follow e/E[+-]?),
+    // otherwise the `e` belongs to a following identifier (`2e` ⇒ number `2`, ident `e`).
+    if i < bytes.len() && (bytes[i] == b'e' || bytes[i] == b'E') {
+        let mut j = i + 1;
+        if j < bytes.len() && (bytes[j] == b'+' || bytes[j] == b'-') {
+            j += 1;
+        }
+        if j < bytes.len() && bytes[j].is_ascii_digit() {
+            j += 1;
+            while j < bytes.len() && bytes[j].is_ascii_digit() {
+                j += 1;
+            }
+            i = j;
+        }
+    }
+    i
+}
+
+/// Tokenize an AsciiMath source string. Total and panic-free: returns the token list
+/// (terminated by [`TokenKind::Eof`]) or a single spanned [`FrontendError`].
+pub fn tokenize(src: &str) -> Result<Vec<Token>, FrontendError> {
+    let bytes = src.as_bytes();
+    let mut toks = Vec::new();
+    let mut i = 0;
+    while i < bytes.len() {
+        let c = bytes[i];
+        if c.is_ascii_whitespace() {
+            i += 1;
+            continue;
+        }
+        let start = i;
+        let next = bytes.get(i + 1).copied();
+        let (kind, end) = match c {
+            b'+' => (TokenKind::Plus, i + 1),
+            b'-' => match next {
+                Some(b':') => (TokenKind::Div, i + 2),
+                Some(b'=') => (TokenKind::Equiv, i + 2),
+                _ => (TokenKind::Minus, i + 1),
+            },
+            b'*' => (TokenKind::Star, if next == Some(b'*') { i + 2 } else { i + 1 }),
+            b'/' => (TokenKind::Slash, i + 1),
+            b'^' => (TokenKind::Caret, i + 1),
+            b'_' => (TokenKind::Underscore, i + 1),
+            b'=' => (TokenKind::Eq, i + 1),
+            b'!' => match next {
+                Some(b'=') => (TokenKind::Ne, i + 2),
+                _ => return Err(err("unexpected '!' (did you mean '!='?)", (start, start + 1))),
+            },
+            b'<' => match next {
+                Some(b'=') => (TokenKind::Le, i + 2),
+                _ => (TokenKind::Lt, i + 1),
+            },
+            b'>' => match next {
+                Some(b'=') => (TokenKind::Ge, i + 2),
+                _ => (TokenKind::Gt, i + 1),
+            },
+            b'~' => match next {
+                Some(b'~') => (TokenKind::Approx, i + 2),
+                _ => return Err(err("unexpected '~' (did you mean '~~'?)", (start, start + 1))),
+            },
+            b'(' => (TokenKind::LParen, i + 1),
+            b')' => (TokenKind::RParen, i + 1),
+            b'[' => (TokenKind::LBracket, i + 1),
+            b']' => (TokenKind::RBracket, i + 1),
+            b'{' => (TokenKind::LBrace, i + 1),
+            b'}' => (TokenKind::RBrace, i + 1),
+            b'"' => {
+                // A text literal runs to the next double-quote.
+                let mut j = i + 1;
+                while j < bytes.len() && bytes[j] != b'"' {
+                    j += 1;
+                }
+                if j >= bytes.len() {
+                    return Err(err("unterminated string literal", (start, bytes.len())));
+                }
+                // The contents are ASCII-safe to slice on `"` boundaries; `"` is one byte.
+                (TokenKind::Text(src[i + 1..j].to_string()), j + 1)
+            }
+            _ if starts_number(c, next) => {
+                let end = scan_number(bytes, i);
+                (TokenKind::Num(src[start..end].to_string()), end)
+            }
+            _ if c.is_ascii_alphabetic() => {
+                let mut j = i;
+                while j < bytes.len() && bytes[j].is_ascii_alphabetic() {
+                    j += 1;
+                }
+                (TokenKind::Ident(src[start..j].to_string()), j)
+            }
+            _ => {
+                // Unknown byte (includes any non-ASCII lead byte). Report a one-byte span;
+                // we never slice with it, so a mid-codepoint offset cannot cause a panic.
+                return Err(err(format!("unexpected byte 0x{c:02x}"), (start, start + 1)));
+            }
+        };
+        toks.push(Token { kind, span: (start, end) });
+        i = end;
+    }
+    toks.push(Token { kind: TokenKind::Eof, span: (bytes.len(), bytes.len()) });
+    Ok(toks)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn kinds(src: &str) -> Vec<TokenKind> {
+        tokenize(src).unwrap().into_iter().map(|t| t.kind).collect()
+    }
+
+    #[test]
+    fn numbers_idents_ops() {
+        assert_eq!(
+            kinds("3.14 + x"),
+            vec![
+                TokenKind::Num("3.14".into()),
+                TokenKind::Plus,
+                TokenKind::Ident("x".into()),
+                TokenKind::Eof,
+            ]
+        );
+    }
+
+    #[test]
+    fn multi_char_operators() {
+        assert_eq!(kinds("a <= b"), vec![
+            TokenKind::Ident("a".into()), TokenKind::Le, TokenKind::Ident("b".into()), TokenKind::Eof,
+        ]);
+        assert_eq!(kinds("a != b")[1], TokenKind::Ne);
+        assert_eq!(kinds("a -: b")[1], TokenKind::Div);
+        assert_eq!(kinds("a ~~ b")[1], TokenKind::Approx);
+        assert_eq!(kinds("a -= b")[1], TokenKind::Equiv);
+        assert_eq!(kinds("a ** b")[1], TokenKind::Star);
+    }
+
+    #[test]
+    fn exponent_only_consumed_when_well_formed() {
+        assert_eq!(kinds("6.022e23")[0], TokenKind::Num("6.022e23".into()));
+        // `2e` is the number 2 then the identifier e (no exponent digits).
+        assert_eq!(kinds("2e"), vec![
+            TokenKind::Num("2".into()), TokenKind::Ident("e".into()), TokenKind::Eof,
+        ]);
+    }
+
+    #[test]
+    fn text_literal() {
+        assert_eq!(kinds(r#""kg" "#)[0], TokenKind::Text("kg".into()));
+    }
+
+    #[test]
+    fn spans_are_in_range_and_ordered() {
+        for t in tokenize("sqrt(x^2) + 1/2").unwrap() {
+            assert!(t.span.0 <= t.span.1);
+            assert!(t.span.1 <= "sqrt(x^2) + 1/2".len());
+        }
+    }
+
+    #[test]
+    fn errors_are_spanned_not_panics() {
+        let e = tokenize("a ! b").unwrap_err();
+        assert_eq!(e.frontend, "asciimath");
+        assert!(e.span.0 <= e.span.1);
+        // unterminated string
+        assert!(tokenize("\"oops").is_err());
+        // non-ascii byte
+        assert!(tokenize("×").is_err());
+    }
+}

--- a/code/packages/rust/latex/src/frontend.rs
+++ b/code/packages/rust/latex/src/frontend.rs
@@ -423,9 +423,9 @@ mod tests {
             )
         );
         // both: a_i^n → Pow(Subscript(a,i), n)
-        match m("a_i^n") {
+        match &m("a_i^n") {
             MathExpr::Bin(BinOp::Pow, base, _) => {
-                assert!(matches!(*base, MathExpr::Subscript(..)));
+                assert!(matches!(**base, MathExpr::Subscript(..)));
             }
             other => panic!("expected Pow(Subscript,..), got {other:?}"),
         }
@@ -433,8 +433,8 @@ mod tests {
 
     #[test]
     fn roots() {
-        match m(r"\sqrt[3]{x}") {
-            MathExpr::Root { degree: Some(d), .. } => assert_eq!(*d, num(3)),
+        match &m(r"\sqrt[3]{x}") {
+            MathExpr::Root { degree: Some(d), .. } => assert_eq!(**d, num(3)),
             other => panic!("expected Root with degree, got {other:?}"),
         }
         assert!(matches!(m(r"\sqrt{2}"), MathExpr::Root { degree: None, .. }));
@@ -496,8 +496,8 @@ mod tests {
         assert_eq!(m(r"\pi"), MathExpr::Symbol("pi".into()));
         assert_eq!(m(r"\text{kg}"), MathExpr::Text("kg".into()));
         // fence style dropped to Group.
-        match m("(a+b)") {
-            MathExpr::Group(inner) => assert!(matches!(*inner, MathExpr::Bin(BinOp::Add, ..))),
+        match &m("(a+b)") {
+            MathExpr::Group(inner) => assert!(matches!(**inner, MathExpr::Bin(BinOp::Add, ..))),
             other => panic!("expected Group, got {other:?}"),
         }
     }
@@ -515,7 +515,7 @@ mod tests {
 
     #[test]
     fn matrix_lowers_dropping_delimiter_style() {
-        match m(r"\begin{pmatrix} a & b \\ c & d \end{pmatrix}") {
+        match &m(r"\begin{pmatrix} a & b \\ c & d \end{pmatrix}") {
             MathExpr::Matrix(rows) => {
                 assert_eq!(rows.len(), 2);
                 assert_eq!(rows[0].len(), 2);
@@ -529,8 +529,8 @@ mod tests {
     fn numbers_stay_exact_not_f64() {
         assert_eq!(m("0.1"), MathExpr::Number(Number::parse("0.1").unwrap()));
         // and the numerator of a fraction is an exact Number, not a float.
-        match m(r"\frac{1}{3}") {
-            MathExpr::Frac(n, _) => assert_eq!(*n, num(1)),
+        match &m(r"\frac{1}{3}") {
+            MathExpr::Frac(n, _) => assert_eq!(**n, num(1)),
             other => panic!("expected Frac, got {other:?}"),
         }
     }
@@ -541,10 +541,10 @@ mod tests {
         assert!(matches!(m(r"a \pm b"), MathExpr::Bin(BinOp::PlusMinus, _, _)));
         assert!(matches!(m(r"a \mp b"), MathExpr::Bin(BinOp::MinusPlus, _, _)));
         // \binom{n}{k} → Binom(n, k), with the arguments in source order (not swapped).
-        match m(r"\binom{n}{k}") {
+        match &m(r"\binom{n}{k}") {
             MathExpr::Binom(n, k) => {
-                assert_eq!(*n, MathExpr::Symbol("n".into()));
-                assert_eq!(*k, MathExpr::Symbol("k".into()));
+                assert_eq!(**n, MathExpr::Symbol("n".into()));
+                assert_eq!(**k, MathExpr::Symbol("k".into()));
             }
             other => panic!("expected Binom, got {other:?}"),
         }

--- a/code/packages/rust/math-frontend/CHANGELOG.md
+++ b/code/packages/rust/math-frontend/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to the pluggable parser-frontend framework.
 
+## [0.3.0] — 2026-06-28
+
+### Fixed — iterative `Drop` for `MathExpr` (stack-overflow / abort on deep trees)
+
+- **`MathExpr` now drops iteratively.** A frontend can produce a very deeply-nested tree
+  from small input — a left-associative chain `a + a + a + …` (or juxtaposition, or
+  `1/1/1/…`) parses, by design, into `Bin(Add, Bin(Add, …))` nested N deep. The compiler's
+  default recursive destructor would then overflow the stack and **abort the process** when
+  that tree is dropped — an uncatchable failure reachable from every frontend's panic-free
+  `parse` on adversarial-but-tiny input (≈100 KB). The new `impl Drop for MathExpr`
+  dismantles the tree with an explicit heap worklist (moving each node's boxed children out
+  in place), so freeing is O(1) in stack depth at any tree depth.
+- Fixes the issue for **all** frontends at the source (surfaced by the `asciimath` PR-1
+  security review; `latex` and any future frontend benefit too).
+- +2 regression tests drop 300k-deep `Bin` and 100k-deep `Root`/`Matrix` trees without
+  overflow. Behaviour-only change (no API change); additive. Crate 0.2.0 → 0.3.0.
+
 ## [0.2.0] — 2026-06-27
 
 ### Added — neutral-AST coverage for ± / ∓ and binomials

--- a/code/packages/rust/math-frontend/Cargo.toml
+++ b/code/packages/rust/math-frontend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "math-frontend"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "A pluggable parser-frontend framework: a neutral math AST (MathExpr), a MathFrontend trait + registry, and a shared conformance harness. Notation parsers (LaTeX, AsciiMath, MathML, …) implement the trait so any consumer lowers ONE neutral tree."
 license = "MIT"

--- a/code/packages/rust/math-frontend/src/expr.rs
+++ b/code/packages/rust/math-frontend/src/expr.rs
@@ -259,6 +259,75 @@ pub enum MathExpr {
     Matrix(Vec<Vec<MathExpr>>),
 }
 
+/// Drop a `MathExpr` **iteratively** so freeing a deeply-nested tree cannot overflow the
+/// stack.
+///
+/// A frontend can legitimately produce a very deep tree from small input: a left-
+/// associative chain `a + a + a + …` (or juxtaposition `aaa…`, or `1/1/1/…`) parses — by
+/// design, with loops not recursion — into `Bin(Add, Bin(Add, …))` nested N deep. The
+/// compiler's *default* destructor for a recursive `Box`-owning enum is itself recursive,
+/// so dropping such a tree would recurse N frames and abort the process (an uncatchable
+/// stack overflow) on adversarial-but-tiny input. Since every frontend hands these trees
+/// back through the panic-free `MathFrontend` contract, the neutral AST must be safe to
+/// drop at any depth — so we override `Drop` to dismantle the tree with an explicit heap
+/// worklist instead of the call stack.
+///
+/// How it stays O(1) in stack depth: we move each node's boxed children onto a `Vec`
+/// worklist (replacing them in place with a cheap leaf), then pop and repeat. By the time
+/// any node is finally dropped, its children are leaves, so the compiler-generated
+/// destructor recurses at most one trivial level.
+impl Drop for MathExpr {
+    fn drop(&mut self) {
+        let mut stack: Vec<MathExpr> = Vec::new();
+        take_children(self, &mut stack);
+        while let Some(mut node) = stack.pop() {
+            take_children(&mut node, &mut stack);
+            // `node` now owns only leaf children, so dropping it here is shallow.
+        }
+    }
+}
+
+/// Move every boxed child of `e` onto `out`, leaving `e` holding cheap leaves in their place.
+/// A leaf (`Number`/`Symbol`/`Text`) contributes nothing. Used only by [`MathExpr`]'s `Drop`.
+fn take_children(e: &mut MathExpr, out: &mut Vec<MathExpr>) {
+    // Swap a boxed child out for a leaf (no allocation: `String::new()` doesn't allocate).
+    fn take(b: &mut Box<MathExpr>, out: &mut Vec<MathExpr>) {
+        out.push(std::mem::replace(b.as_mut(), MathExpr::Symbol(String::new())));
+    }
+    fn take_opt(b: &mut Option<Box<MathExpr>>, out: &mut Vec<MathExpr>) {
+        if let Some(boxed) = b.take() {
+            out.push(*boxed);
+        }
+    }
+    match e {
+        MathExpr::Number(_) | MathExpr::Symbol(_) | MathExpr::Text(_) => {}
+        MathExpr::Bin(_, a, b)
+        | MathExpr::Frac(a, b)
+        | MathExpr::Binom(a, b)
+        | MathExpr::Subscript(a, b)
+        | MathExpr::Rel(_, a, b) => {
+            take(a, out);
+            take(b, out);
+        }
+        MathExpr::Unary(_, a) | MathExpr::Group(a) => take(a, out),
+        MathExpr::Root { degree, radicand } => {
+            take_opt(degree, out);
+            take(radicand, out);
+        }
+        MathExpr::Call { arg, .. } => take(arg, out),
+        MathExpr::BigOp { lower, upper, body, .. } => {
+            take_opt(lower, out);
+            take_opt(upper, out);
+            take(body, out);
+        }
+        MathExpr::Matrix(rows) => {
+            for row in std::mem::take(rows) {
+                out.extend(row);
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -275,6 +344,35 @@ mod tests {
         let binom = MathExpr::Binom(one(), one());
         assert_eq!(binom, MathExpr::Binom(one(), one()));
         assert_ne!(binom, MathExpr::Frac(one(), one()));
+    }
+
+    #[test]
+    fn dropping_a_very_deep_tree_does_not_overflow() {
+        // A frontend can build a left-associative chain `a + a + … ` this deep from tiny
+        // input. With the default recursive destructor this drop would overflow the stack
+        // and abort the process; the iterative `Drop` impl must free it on the heap instead.
+        // 300_000 nodes is far beyond any per-frame recursive-drop budget on a 2 MiB stack.
+        let mut e = MathExpr::Number(Number::from_i64(0));
+        for _ in 0..300_000 {
+            e = MathExpr::Bin(
+                BinOp::Add,
+                Box::new(e),
+                Box::new(MathExpr::Number(Number::from_i64(1))),
+            );
+        }
+        drop(e); // must return normally, not abort with a stack overflow
+    }
+
+    #[test]
+    fn dropping_a_deep_matrix_and_options_does_not_overflow() {
+        // Exercise the Option/Vec child paths of the iterative drop (Root degree, BigOp
+        // bounds, Matrix rows) nested deeply through a Root chain.
+        let mut e = MathExpr::Symbol("x".to_string());
+        for _ in 0..100_000 {
+            e = MathExpr::Root { degree: Some(Box::new(MathExpr::Number(Number::from_i64(2)))), radicand: Box::new(e) };
+        }
+        e = MathExpr::Matrix(vec![vec![e]]);
+        drop(e);
     }
 
     #[test]

--- a/code/specs/ASM01-asciimath-frontend.md
+++ b/code/specs/ASM01-asciimath-frontend.md
@@ -1,0 +1,93 @@
+# ASM01 — AsciiMath pluggable frontend
+
+**Status:** Specs-first. The **second** frontend built against
+[PFE01](PFE01-pluggable-parser-frontends.md) (LaTeX, [LTX01](LTX01-full-latex-parser.md),
+was the first). Proves the framework's central claim — *adding a notation is "register one
+more frontend," with zero change to any consumer*.
+**Author:** architecture pass, 2026-06-28.
+
+## 1. Motivation
+
+[AsciiMath](http://asciimath.org/) is a lightweight, human-typable math notation
+(`1/2`, `sqrt(x)`, `sum_(i=1)^n i`, `x^2 + y^2 = r^2`). Math-capable models and humans
+emit it readily — it is far terser than LaTeX. For the byte-provenance input→ADJ pipeline
+([project north star]) the input LLM should be able to translate a problem written in
+AsciiMath as easily as one written in LaTeX. So AsciiMath becomes frontend **#2**: a parser
+that turns an AsciiMath string into the **same neutral `math_frontend::MathExpr`** the LaTeX
+frontend produces. Two source strings that mean the same math — `\frac{1}{2}` (LaTeX) and
+`1/2` (AsciiMath) — lower to the *same* tree, so every consumer treats them uniformly.
+
+## 2. Crate
+
+New crate `code/packages/rust/asciimath/` (workspace member, alphabetical-ish after
+`latex`). Depends only on `math-frontend` (the neutral AST + trait). Zero other deps.
+
+Public API:
+- `pub struct AsciiMath;` implementing `math_frontend::MathFrontend`
+  (`name() == "asciimath"`, `parse(src) -> Result<MathExpr, FrontendError>`, `capabilities()`).
+- `pub fn parse(src: &str) -> Result<MathExpr, FrontendError>` — free-function form.
+- `pub fn tokenize(src: &str) -> Result<Vec<Token>, FrontendError>` — the tokenizer, exposed.
+- `pub use` of the re-exported neutral types for convenience.
+
+The crate is **total and panic-free**: every input yields `Ok(MathExpr)` or a spanned
+`FrontendError`. Recursion is depth-guarded (`MAX_DEPTH`) so deeply-nested input errors
+rather than overflowing; left-associative chains (`a+a+…`, juxtaposition, `a/a/…`) are built
+with loops, not recursion, so they do not consume call-stack per term.
+
+## 3. Grammar — the PR-1 core subset
+
+PR-1 implements a faithful, useful core; later PRs add breadth (§5). Precedence, low→high:
+
+| Level | Construct | Neutral node |
+|-------|-----------|--------------|
+| relation | `= != < > <= >= ~~ -=` (and word forms `ne le ge`) | `Rel` (left-assoc) |
+| add/sub | `+ -` | `Bin(Add/Sub)` |
+| mul | `*`, `cdot`, `xx`, `-:`/`div`, **juxtaposition** (implicit) | `Bin(Mul/Div)` |
+| frac | `a/b` | `Frac` (binds simple-with-scripts on each side; left-assoc) |
+| unary | prefix `-`/`+` | `Unary(Neg/Pos)` |
+| script | `a^b`, `a_b`, `a_b^c` | `Bin(Pow)` / `Subscript` / `Pow(Subscript)` |
+| atom | number, symbol, function application, `sqrt`, `root(n)(x)`, group, `"text"` | … |
+
+Atoms:
+- **Number** — decimal numeral, kept exact (`Number`, never `f64`).
+- **Identifier** (maximal `[A-Za-z]+` run), classified:
+  - a **function** name (`sin cos tan cot sec csc sinh cosh tanh log ln exp det gcd lcm min max`)
+    → `Call{func, arg}`, applied to the following simple expression;
+  - a **known multi-letter constant** (`pi tau theta alpha beta gamma delta epsilon
+    lambda mu phi omega sigma`, and `oo`/`infty` → `infinity`) → `Symbol(canonical)`;
+  - the **unary keyword** `sqrt` → `Root{degree:None,…}`; the **binary keyword** `root`
+    → `Root{degree:Some(n), radicand}` from `root(n)(x)` or `root n x`;
+  - the **operator words** `xx cdot div`; otherwise
+  - a **bare run**: a single letter → `Symbol(c)`; a multi-letter unknown run →
+    the implicit product of its single-letter `Symbol`s (`xy` ⇒ `x·y`, the AsciiMath rule).
+- **Group** — `( … )`, `[ … ]`, `{ … }` → `Group` (delimiter style dropped; meaning kept).
+- **Text** — `"…"` → `Text`. (The `text(…)` keyword form is PR-2.)
+
+### 3.1 Deliberate PR-1 limitations (documented, widened in §5)
+Function names need a token boundary (`sin x`, `sin(x)`, not `sinx`). No matrices, big
+operators, accents, or angle brackets yet. `/` binds the adjacent *simple* expressions
+(AsciiMath's `S/S`), so `a b/c` is `a·(b/c)`; this is the AsciiMath grammar's intent and is
+documented. None of these are *wrong* outputs — they are a smaller covered surface, declared
+honestly via `Capabilities`.
+
+## 4. Capabilities & conformance
+
+`capabilities()` advertises exactly the PR-1 surface: `fractions, roots, powers, functions,
+relations, implicit_mul, text` on; `matrices, big_operators` off (PR-2). The shared
+`check_frontend` harness (PFE01 §5) verifies, over an AsciiMath sample corpus, that parsing
+never panics, errors carry valid in-range spans, and declared capabilities match what is
+actually emitted (no over-claiming). Notation-specific golden tests assert exact `MathExpr`
+shapes for representative inputs.
+
+## 5. Roadmap (later PRs)
+- **PR-2:** matrices `[[a,b],[c,d]]`; big operators `sum_(…)^(…)`, `prod`, `int`; accents
+  (`hat`, `vec`, `bar`); angle/invisible brackets `(: … :)`, `{: … :}`.
+- **PR-3:** the full AsciiMath symbol table (greek, arrows, set/logic ops), longest-match
+  tokenization (so `sinx` splits as `sin`·`x`), `stackrel`, `overset`/`underset`, and the
+  `text(…)` keyword form alongside the `"…"` literal.
+
+## 6. Non-goals
+Evaluation, simplification, rendering — none are a frontend's job (PFE01 §7). Lowering
+`MathExpr` into any engine IR is a consumer concern. Like every frontend, `asciimath` cannot
+be registered by `math-frontend` itself (that would be a dependency cycle); a consumer (or a
+future aggregating crate) registers it alongside `latex`.


### PR DESCRIPTION
## What

The **second** pluggable parser frontend after `latex` (see [ASM01](code/specs/ASM01-asciimath-frontend.md) / PFE01). New `asciimath` crate turns terse, human-typable AsciiMath — `1/2`, `sqrt(x)`, `x^2 + y^2 = r^2`, `sin x` — into the **same neutral `math_frontend::MathExpr`** the LaTeX frontend produces. A consumer lowers one tree and gets both notations, **with zero consumer changes** — the framework's central claim, now demonstrated with a genuinely different notation. It's also an input-notation for the byte-provenance input→ADJ pipeline.

## Crate (PR-1 core)

- `AsciiMath` implements `MathFrontend` (`name="asciimath"`); `parse`/`tokenize` public.
- **token.rs**: numbers (exact), identifiers, `+ - * / ^ _ = < >` and multi-char `<= >= != ~~ -= -:`, brackets, `"…"` text; spanned, total, panic-free.
- **parser.rs**: precedence-climbing relation < add/sub < mul (incl. juxtaposition, `xx`/`cdot`/`-:`) < frac (`/`) < unary < scripts (`^`/`_`) over atoms (number, symbol, function application, `sqrt`, `root(n)(x)`, group, `"text"`). Identifiers classify as function / known constant (`pi`…, `oo`→`infinity`) / operator-word / else a product of single-letter symbols (`xy` ⇒ x·y). Parens are grouping-only (normalize away), so `sqrt(x)` ≡ `sqrt x` and `(1)/(2)` ≡ `1/2` ≡ LaTeX `\frac{1}{2}`.
- Total/panic-free + bounded: `MAX_DEPTH` guards nesting (errors before overflow); chains & sign-runs built with loops, not recursion. `#![forbid(unsafe_code)]`.
- Honest capabilities: fractions/roots/powers/functions/relations/text/implicit_mul (matrices/big-ops → PR-2). Conforms to the shared `check_frontend` harness.

## Security fix folded in — iterative `Drop` for `MathExpr` (math-frontend 0.3.0)

The PR-1 security review caught a **HIGH**: a frontend can build a very deep left-associative tree from tiny input (`"a+".repeat(100k)`), and the compiler's recursive destructor overflows the stack and **aborts the process** when it's dropped — reachable from every frontend's panic-free `parse`. Fixed at the source: `impl Drop for MathExpr` dismantles the tree with a heap worklist (O(1) drop-stack depth). Benefits asciimath, latex, and all future frontends. Adding `Drop` surfaced E0509 in 6 latex *test* matches (now match by reference; production `lower()` only constructs `MathExpr`, unaffected).

## Verification

- `cargo test`: **asciimath 19 (+1 doc), latex 136, math-frontend 25** (incl. 2 new 300k/100k-deep-drop regressions) — all pass.
- `cargo clippy -- -D warnings` clean on all three; `latex --no-default-features` (zero-dep path) green.
- **/security-review: 2 rounds, PASSED** — round 1 found the deep-drop HIGH; round 2 confirmed the iterative-Drop fix is correct (complete variant coverage, no double-free/leak/panic-in-Drop, O(1) drop-stack) with no new issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)