### PR TITLE
test(closurec): differential soundness conformance harness (Stream 1)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.224.0] - 2026-06-27
+
+### Added — differential **soundness** conformance harness (`tests/conformance.rs`)
+
+A new test harness that checks the SIMPLE optimizer is **value-preserving**, not
+just byte-stable. For a corpus of source expressions it runs closurec, parses
+the optimized output with a self-contained literal evaluator, and asserts the
+folded value equals the expression's true runtime value (a canonical,
+`Object.is`-faithful golden generated offline by Node/V8 — **CI runs no JS
+engine**). Numbers reuse closurec's V8-faithful `format_js_number`, so the
+canonical form is the raw token (no float-formatting mismatch). Declined/partial
+outputs have no literal value to check and are counted as `skipped` with a loud
+end-of-test summary (no silent coverage holes).
+
+This is the soundness net that byte fixtures can't provide: it value-checks
+21/23 seed entries against the oracle and pins the two known negative-zero
+divergences (`KNOWN_DIVERGENCES`) so the day the underlying unary-minus `-0`→`0`
+flattening bug is fixed, the test tells us to promote those entries. Seed corpus
+covers numbers, string methods, `split`, `String.fromCharCode`, `Number.is*`,
+`Array.isArray`/`of`, `Object.keys`/`entries`/`fromEntries`, `Boolean`/`String`/
+`Number`, and `isNaN`/`isFinite`. Generator + docs under `tests/conformance/`.
+
 ## [0.222.0] - 2026-06-26
 
 ### Added — SIMPLE/ADVANCED fold static `Array.from("…")` → array of code-point strings

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.222.0"
+version = "0.224.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.222.0",
+  "version": "0.224.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/tests/conformance.rs
+++ b/code/programs/rust/closurec/tests/conformance.rs
@@ -1,0 +1,427 @@
+//! Differential **soundness** conformance harness for closurec's SIMPLE
+//! optimizer.
+//!
+//! ## Why this exists
+//!
+//! The `tests/diff/*` fixtures lock the optimizer's *byte output* in place, but
+//! a byte fixture can't tell you whether that output is *semantically correct* —
+//! a plausible-looking literal can still be the wrong value. The classic trap is
+//! negative zero: `Math.min(0, -0)` is `-0`, but a fold that emits the literal
+//! `0` looks fine in a byte diff while silently flipping the sign bit. Two such
+//! `-0` miscompiles were found by hand; this harness exists so the *next* one is
+//! caught automatically.
+//!
+//! ## How it works (self-contained, no runtime JS engine in CI)
+//!
+//! For each entry we know the **true runtime value** of the source expression as
+//! a canonical, `Object.is`-faithful string (the `golden` field). Those goldens
+//! were generated once, offline, by Node/V8 (see `tests/conformance/README.md`)
+//! — CI does **not** run Node. At test time we:
+//!
+//!   1. run closurec at `--compilation_level SIMPLE` on the source expression,
+//!   2. parse the optimized output with a tiny *literal* evaluator below, and
+//!   3. if the output folded all the way to a literal, assert its canonical
+//!      value equals `golden` — i.e. the optimization preserved the value.
+//!
+//! Numbers reuse closurec's own V8-faithful `format_js_number` (the emitter
+//! already prints the canonical decimal), so the canonical form is just the raw
+//! token — no float reparsing, no formatting mismatch. If the output did **not**
+//! fold to a pure literal (a declined or partial fold), there is nothing to
+//! value-check: declining is always sound, and the byte fixtures cover it, so we
+//! count it as `skipped` and move on (loudly — see the end-of-test summary, so a
+//! silently-growing skip set can't hide a coverage hole).
+//!
+//! `KNOWN_DIVERGENCES` records inputs that closurec *currently* miscompiles, with
+//! the value it wrongly produces. The test asserts the divergence is still
+//! present; the day the underlying bug is fixed, that assertion fails and tells
+//! us to promote the entry into `CORPUS`. (Today: the pre-existing unary-minus
+//! `-0` → `0` flattening, tracked separately.)
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
+
+/// `(source expression, canonical value of its true runtime result)`.
+/// Goldens generated offline by Node/V8 via `tests/conformance/gen_goldens.mjs`.
+const CORPUS: &[(&str, &str)] = &[
+    // ---- plain numeric literals ----
+    ("3", "n:3"),
+    ("1.5", "n:1.5"),
+    ("-1", "n:-1"),
+    // ---- string methods ----
+    (r#""abcd".slice(1,3)"#, "s:bc"),
+    (r#""ab".repeat(3)"#, "s:ababab"),
+    (r#""HELLO".toLowerCase()"#, "s:hello"),
+    (r#""abc".length"#, "n:3"),
+    (r#""abcabc".indexOf("c")"#, "n:2"),
+    // ---- string → array ----
+    (r#""a,b,c".split(",")"#, "[s:a,s:b,s:c]"),
+    // ---- static built-ins → primitive ----
+    ("String.fromCharCode(65,66)", "s:AB"),
+    ("Number.isInteger(5)", "b:true"),
+    ("Array.isArray([])", "b:true"),
+    ("isNaN(\"x\")", "b:true"),
+    ("isFinite(3)", "b:true"),
+    ("Boolean(0)", "b:false"),
+    ("String(42)", "s:42"),
+    ("Number(\"7\")", "n:7"),
+    // ---- static built-ins → array / object ----
+    ("Array.of(1,2,3)", "[n:1,n:2,n:3]"),
+    ("Object.keys({})", "[]"),
+    ("Object.entries({a:1,b:2})", "[[s:a,n:1],[s:b,n:2]]"),
+    (r#"Object.fromEntries([["a",1],["b",2]])"#, "{k:a=n:1,k:b=n:2}"),
+    // ---- folds that are not yet in `main` (cooking PRs) decline here and are
+    //      reported as `skipped`; once their PR merges they fold and this
+    //      harness begins value-checking them automatically ----
+    ("Math.max(1,2,3)", "n:3"),
+    ("Math.min(5,2,8)", "n:2"),
+];
+
+/// `(source, true value, value closurec WRONGLY produces today)`.
+/// The test asserts the bug is still present; when fixed, promote to `CORPUS`.
+const KNOWN_DIVERGENCES: &[(&str, &str, &str)] = &[
+    // Pre-existing unary-minus fold flattens the `-0` literal to `0` (`var x=-0`
+    // emits `var x=0`). Tracked as its own fix task, independent of any fold.
+    ("-0", "n:-0", "n:0"),
+];
+
+/// Optimize one source *expression* at SIMPLE and return the emitted output with
+/// the trailing `;`/newline stripped.
+fn optimize(src: &str) -> String {
+    let dir = std::env::temp_dir().join(format!("closurec_conf_{}", sanitize(src)));
+    std::fs::create_dir_all(&dir).expect("mk tmp dir");
+    let path = dir.join("a.js");
+    std::fs::write(&path, format!("{src};\n")).expect("write src");
+    let out = Command::new(BINARY)
+        .args([
+            "--compilation_level",
+            "SIMPLE",
+            "--js",
+            path.to_str().unwrap(),
+        ])
+        .output()
+        .expect("run closurec");
+    assert!(
+        out.status.success(),
+        "closurec failed on {src:?}: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+    String::from_utf8_lossy(&out.stdout)
+        .trim()
+        .trim_end_matches(';')
+        .trim()
+        .to_string()
+}
+
+fn sanitize(s: &str) -> String {
+    s.chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+        .take(40)
+        .collect()
+}
+
+// ------------------------------------------------------------------------
+// A tiny literal evaluator: parses the subset of JS that a fully-folded SIMPLE
+// output can be — number / string / boolean / null literals and arrays/objects
+// of those — and produces the same canonical string the Node generator emits.
+// Returns `None` the instant it meets anything non-literal (an identifier that
+// isn't true/false/null, a call, etc.) — that means the fold declined, so there
+// is no literal value to check.
+// ------------------------------------------------------------------------
+
+struct P<'a> {
+    s: &'a [u8],
+    i: usize,
+}
+
+impl<'a> P<'a> {
+    fn ws(&mut self) {
+        while self.i < self.s.len() && self.s[self.i].is_ascii_whitespace() {
+            self.i += 1;
+        }
+    }
+    fn peek(&self) -> Option<u8> {
+        self.s.get(self.i).copied()
+    }
+
+    fn value(&mut self) -> Option<String> {
+        self.ws();
+        match self.peek()? {
+            b'(' => {
+                // statement-position object literals are wrapped: `({...})`
+                self.i += 1;
+                let v = self.value()?;
+                self.ws();
+                if self.peek()? != b')' {
+                    return None;
+                }
+                self.i += 1;
+                Some(v)
+            }
+            b'"' | b'\'' => self.string(),
+            b'[' => self.array(),
+            b'{' => self.object(),
+            b'-' | b'0'..=b'9' | b'.' => self.number(),
+            _ => self.keyword(),
+        }
+    }
+
+    fn number(&mut self) -> Option<String> {
+        let start = self.i;
+        // closurec emits well-formed decimal/exponent tokens; read greedily.
+        while let Some(c) = self.peek() {
+            if c.is_ascii_digit() || matches!(c, b'-' | b'+' | b'.' | b'e' | b'E') {
+                self.i += 1;
+            } else {
+                break;
+            }
+        }
+        if self.i == start {
+            return None;
+        }
+        // The token is already V8-canonical (format_js_number); use it verbatim.
+        Some(format!("n:{}", std::str::from_utf8(&self.s[start..self.i]).ok()?))
+    }
+
+    fn string(&mut self) -> Option<String> {
+        let quote = self.s[self.i];
+        self.i += 1;
+        let mut out = String::new();
+        loop {
+            let c = self.peek()?;
+            self.i += 1;
+            match c {
+                b'\\' => {
+                    let e = self.peek()?;
+                    self.i += 1;
+                    match e {
+                        b'n' => out.push('\n'),
+                        b't' => out.push('\t'),
+                        b'r' => out.push('\r'),
+                        b'b' => out.push('\u{8}'),
+                        b'f' => out.push('\u{c}'),
+                        b'0' => out.push('\0'),
+                        b'\\' => out.push('\\'),
+                        b'"' => out.push('"'),
+                        b'\'' => out.push('\''),
+                        b'/' => out.push('/'),
+                        b'u' => {
+                            // \uXXXX (closurec does not emit \u{...} surrogate form)
+                            let hex = std::str::from_utf8(self.s.get(self.i..self.i + 4)?).ok()?;
+                            let cp = u32::from_str_radix(hex, 16).ok()?;
+                            self.i += 4;
+                            out.push(char::from_u32(cp)?);
+                        }
+                        _ => return None,
+                    }
+                }
+                _ if c == quote => break,
+                _ => {
+                    // copy a (possibly multi-byte UTF-8) char starting at c
+                    let len = utf8_len(c);
+                    out.push_str(std::str::from_utf8(&self.s[self.i - 1..self.i - 1 + len]).ok()?);
+                    self.i += len - 1;
+                }
+            }
+        }
+        Some(format!("s:{out}"))
+    }
+
+    fn array(&mut self) -> Option<String> {
+        self.i += 1; // [
+        let mut parts = Vec::new();
+        loop {
+            self.ws();
+            match self.peek()? {
+                b']' => {
+                    self.i += 1;
+                    break;
+                }
+                b',' => {
+                    // array hole, e.g. `[,1]`
+                    self.i += 1;
+                    parts.push("hole".to_string());
+                    continue;
+                }
+                _ => {}
+            }
+            parts.push(self.value()?);
+            self.ws();
+            match self.peek()? {
+                b',' => self.i += 1,
+                b']' => {
+                    self.i += 1;
+                    break;
+                }
+                _ => return None,
+            }
+        }
+        Some(format!("[{}]", parts.join(",")))
+    }
+
+    fn object(&mut self) -> Option<String> {
+        self.i += 1; // {
+        let mut parts = Vec::new();
+        loop {
+            self.ws();
+            if self.peek()? == b'}' {
+                self.i += 1;
+                break;
+            }
+            let key = self.key()?;
+            self.ws();
+            if self.peek()? != b':' {
+                return None;
+            }
+            self.i += 1;
+            let val = self.value()?;
+            parts.push(format!("k:{key}={val}"));
+            self.ws();
+            match self.peek()? {
+                b',' => self.i += 1,
+                b'}' => {
+                    self.i += 1;
+                    break;
+                }
+                _ => return None,
+            }
+        }
+        Some(format!("{{{}}}", parts.join(",")))
+    }
+
+    fn key(&mut self) -> Option<String> {
+        self.ws();
+        match self.peek()? {
+            b'"' | b'\'' => self.string().map(|s| s.trim_start_matches("s:").to_string()),
+            b'0'..=b'9' | b'-' | b'.' => self.number().map(|s| s.trim_start_matches("n:").to_string()),
+            _ => {
+                // bare identifier key
+                let start = self.i;
+                while let Some(c) = self.peek() {
+                    if c.is_ascii_alphanumeric() || matches!(c, b'_' | b'$') {
+                        self.i += 1;
+                    } else {
+                        break;
+                    }
+                }
+                if self.i == start {
+                    return None;
+                }
+                Some(std::str::from_utf8(&self.s[start..self.i]).ok()?.to_string())
+            }
+        }
+    }
+
+    fn keyword(&mut self) -> Option<String> {
+        for (kw, canon) in [("true", "b:true"), ("false", "b:false"), ("null", "null")] {
+            if self.s[self.i..].starts_with(kw.as_bytes()) {
+                self.i += kw.len();
+                return Some(canon.to_string());
+            }
+        }
+        None // an identifier / call / anything else → not a literal
+    }
+}
+
+fn utf8_len(b: u8) -> usize {
+    if b < 0x80 {
+        1
+    } else if b >> 5 == 0b110 {
+        2
+    } else if b >> 4 == 0b1110 {
+        3
+    } else {
+        4
+    }
+}
+
+/// Canonicalize an optimized output *iff* it is a single pure literal; `None`
+/// means the fold declined (no literal value to check).
+fn canonicalize(optimized: &str) -> Option<String> {
+    let mut p = P {
+        s: optimized.as_bytes(),
+        i: 0,
+    };
+    let v = p.value()?;
+    p.ws();
+    if p.i == p.s.len() {
+        Some(v)
+    } else {
+        None // trailing junk → not a single clean literal
+    }
+}
+
+#[test]
+fn conformance_optimized_values_match_oracle() {
+    let mut checked = 0usize;
+    let mut skipped: Vec<&str> = Vec::new();
+
+    for (src, golden) in CORPUS {
+        let opt = optimize(src);
+        match canonicalize(&opt) {
+            Some(canon) => {
+                assert_eq!(
+                    &canon, golden,
+                    "VALUE MISMATCH (miscompile) for {src:?}\n  optimized: {opt}\n  closurec value: {canon}\n  true value:     {golden}",
+                );
+                checked += 1;
+            }
+            None => skipped.push(src),
+        }
+    }
+
+    // Loud, non-silent accounting of coverage (per the no-silent-caps rule).
+    eprintln!(
+        "[conformance] value-checked {checked}/{} corpus entries; {} declined (no literal value to check): {:?}",
+        CORPUS.len(),
+        skipped.len(),
+        skipped,
+    );
+    assert!(checked > 0, "expected at least some entries to fold to literals");
+}
+
+#[test]
+fn conformance_known_divergences_still_diverge() {
+    for (src, golden, wrong) in KNOWN_DIVERGENCES {
+        let opt = optimize(src);
+        let canon = canonicalize(&opt);
+        assert_ne!(golden, wrong, "a KNOWN_DIVERGENCE must actually differ from the truth");
+        assert_eq!(
+            canon.as_deref(),
+            Some(*wrong),
+            "KNOWN_DIVERGENCE {src:?} no longer reproduces (optimized: {opt:?}). \
+             If the underlying bug was fixed, promote this entry into CORPUS.",
+        );
+    }
+}
+
+// ---- self-tests for the literal evaluator (so a parser bug can't mask a
+//      real miscompile by silently returning None) ----
+
+#[test]
+fn canonicalizer_self_test() {
+    assert_eq!(canonicalize("3").as_deref(), Some("n:3"));
+    assert_eq!(canonicalize("-1").as_deref(), Some("n:-1"));
+    assert_eq!(canonicalize("1.5").as_deref(), Some("n:1.5"));
+    assert_eq!(canonicalize("0").as_deref(), Some("n:0"));
+    assert_eq!(canonicalize(r#""bc""#).as_deref(), Some("s:bc"));
+    assert_eq!(canonicalize("true").as_deref(), Some("b:true"));
+    assert_eq!(canonicalize("false").as_deref(), Some("b:false"));
+    assert_eq!(canonicalize("null").as_deref(), Some("null"));
+    assert_eq!(canonicalize("[1,2,3]").as_deref(), Some("[n:1,n:2,n:3]"));
+    assert_eq!(canonicalize("[]").as_deref(), Some("[]"));
+    assert_eq!(
+        canonicalize(r#"[["a",1],["b",2]]"#).as_deref(),
+        Some("[[s:a,n:1],[s:b,n:2]]")
+    );
+    assert_eq!(
+        canonicalize("({a:1,b:2})").as_deref(),
+        Some("{k:a=n:1,k:b=n:2}")
+    );
+    assert_eq!(canonicalize(r#"{"1":"x"}"#).as_deref(), Some("{k:1=s:x}"));
+    // non-literals decline:
+    assert_eq!(canonicalize("Math.max(1,2,3)"), None);
+    assert_eq!(canonicalize("o.fromEntries([])"), None);
+    assert_eq!(canonicalize("x"), None);
+}

--- a/code/programs/rust/closurec/tests/conformance.rs
+++ b/code/programs/rust/closurec/tests/conformance.rs
@@ -88,8 +88,23 @@ const KNOWN_DIVERGENCES: &[(&str, &str, &str)] = &[
 /// Optimize one source *expression* at SIMPLE and return the emitted output with
 /// the trailing `;`/newline stripped.
 fn optimize(src: &str) -> String {
-    let dir = std::env::temp_dir().join(format!("closurec_conf_{}", sanitize(src)));
-    std::fs::create_dir_all(&dir).expect("mk tmp dir");
+    // A UNIQUE temp dir per call — never a name derived from `src`. A predictable
+    // path under the shared, world-writable system temp dir would invite a
+    // symlink/TOCTOU pre-creation attack on a multi-user host (CWE-377/367) and,
+    // more practically, would collide between parallel `cargo test` threads (two
+    // calls sharing a dir, one's cleanup yanking the other's file). pid + a
+    // monotonic counter makes the name unguessable-enough and per-invocation
+    // distinct; `create_dir` (not `_all`) fails rather than reuses if it somehow
+    // already exists.
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let dir = std::env::temp_dir().join(format!(
+        "closurec_conf_{}_{}_{}",
+        std::process::id(),
+        SEQ.fetch_add(1, Ordering::Relaxed),
+        sanitize(src),
+    ));
+    std::fs::create_dir(&dir).expect("mk tmp dir");
     let path = dir.join("a.js");
     std::fs::write(&path, format!("{src};\n")).expect("write src");
     let out = Command::new(BINARY)

--- a/code/programs/rust/closurec/tests/conformance/README.md
+++ b/code/programs/rust/closurec/tests/conformance/README.md
@@ -1,0 +1,24 @@
+# Conformance corpus — golden generation
+
+`tests/conformance.rs` checks that closurec's SIMPLE optimizer is **value-
+preserving**: each optimized output, when it folds to a literal, must have the
+same runtime value as the original source expression.
+
+The "true value" of each source is recorded as a canonical, `Object.is`-faithful
+string in the `CORPUS` table. Those golden strings are produced **offline** by
+Node/V8 — CI never runs Node. To (re)generate them:
+
+```bash
+cd code/programs/rust/closurec
+mise exec -- node tests/conformance/gen_goldens.mjs
+```
+
+Each line prints `"<source>"\t<canonical>`. Paste the canonical values into the
+`CORPUS` array in `tests/conformance.rs`. The Node `canon()` function and the
+Rust literal evaluator in `conformance.rs` must produce identical strings;
+numbers are emitted verbatim because closurec's `format_js_number` already
+matches V8's `Number.prototype.toString`.
+
+`KNOWN_DIVERGENCES` holds inputs closurec currently miscompiles (with the wrong
+value it emits). When such a bug is fixed, its `conformance_known_divergences_*`
+assertion fails — move the entry into `CORPUS` at that point.

--- a/code/programs/rust/closurec/tests/conformance/gen_goldens.mjs
+++ b/code/programs/rust/closurec/tests/conformance/gen_goldens.mjs
@@ -1,0 +1,35 @@
+// Canonical, Object.is-faithful value representation. Mirrors the Rust
+// literal evaluator in tests/conformance.rs. Numbers use V8's String() (which
+// closurec's format_js_number matches), with -0/NaN/Inf tagged explicitly.
+function canon(v){
+  if (typeof v === 'number'){
+    if (Number.isNaN(v)) return 'n:NaN';
+    if (v === 0) return Object.is(v,-0) ? 'n:-0' : 'n:0';
+    if (!Number.isFinite(v)) return v>0 ? 'n:Infinity' : 'n:-Infinity';
+    return 'n:' + String(v);
+  }
+  if (typeof v === 'string') return 's:' + v;
+  if (typeof v === 'boolean') return 'b:' + v;
+  if (v === null) return 'null';
+  if (Array.isArray(v)) return '[' + v.map(x => x===undefined ? 'hole' : canon(x)).join(',') + ']';
+  if (typeof v === 'object') return '{' + Object.entries(v).map(([k,val]) => 'k:'+k+'='+canon(val)).join(',') + '}';
+  if (v === undefined) return 'undef';
+  return '?';
+}
+const sources = [
+  "3","1.5","-1","100000000000000000000","1e21",
+  '"abcd".slice(1,3)','"ab".repeat(3)','"HELLO".toLowerCase()','"abc".length',
+  '"a,b,c".split(",")','"abcabc".indexOf("c")','"x".padStart(3,"0")',
+  'Math.max(1,2,3)','Math.min(5,2,8)','Math.max(-5,-1)',
+  'String.fromCharCode(65,66)','Number.isInteger(5)','Number.isSafeInteger(10)',
+  'Array.isArray([])','Array.of(1,2,3)','Object.keys({})',
+  'Object.entries({a:1,b:2})','Object.fromEntries([["a",1],["b",2]])',
+  'isNaN("x")','isFinite(3)','Boolean(0)','String(42)','Number("7")',
+  // edge / known-divergence:
+  "-0",
+];
+for (const s of sources){
+  let val, ok=true;
+  try { val = eval('('+s+')'); } catch(e){ ok=false; }
+  console.log(JSON.stringify(s) + "\t" + (ok ? canon(val) : 'ERR'));
+}

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.222.0
+Version: 0.224.0
 
 ## Flags
 


### PR DESCRIPTION
## What

A **value-preservation** oracle for the SIMPLE optimizer (`tests/conformance.rs`). Byte fixtures lock the optimizer's *output* in place but can't tell whether that output is semantically *correct* — a plausible literal can still be the wrong value. The textbook trap is negative zero: a fold that emits `0` for a `-0` result looks fine in a byte diff while silently flipping the sign bit. **Two such `-0` miscompiles were found by hand this session; this harness exists so the next one is caught automatically.**

## How it works (self-contained — CI runs no JS engine)

For each source expression in a corpus:
1. run closurec at `--compilation_level SIMPLE`,
2. parse the optimized output with a small **literal evaluator**, and
3. when it folds to a literal, assert its canonical, `Object.is`-faithful value equals the expression's **true runtime value**.

The "true value" goldens are generated **offline** by Node/V8 (`tests/conformance/gen_goldens.mjs`) and committed — CI has no Node dependency. Numbers reuse closurec's own V8-faithful `format_js_number` (the emitted token *is* the canonical decimal), so there's no float-formatting mismatch. Declined/partial outputs have no literal value to check and are counted as `skipped` with a **loud end-of-test summary** (no silent coverage holes). `KNOWN_DIVERGENCES` pins inputs closurec currently miscompiles, with the wrong value — so the day the bug is fixed, the test fails and tells us to promote the entry.

## Seed results

- **value-checked 21/23** corpus entries against the oracle (numbers, string methods, `split`, `String.fromCharCode`, `Number.is*`, `Array.isArray`/`of`, `Object.keys`/`entries`/`fromEntries`, `Boolean`/`String`/`Number`, `isNaN`/`isFinite`);
- 2 skipped (the `Math.max`/`min` fold is in a cooking PR — declines on `main` today, will fold and be value-checked automatically once merged);
- 1 known divergence pinned: the pre-existing unary-minus `-0`→`0` flattening (`var x=-0` emits `var x=0`), tracked separately.

Includes self-tests for the literal evaluator so a parser bug can't mask a real miscompile. Inline security review passed after fixing a predictable-temp-dir issue (now a unique per-invocation dir).

cc 0.224.0 (test-only + version/CHANGELOG/help bumps); cf untouched. Full `cargo test` green.

> This is the first of a 4-stream rotation (differential harness → tracing validation → big-pass proof on real code → constant folds) to broaden the project past the constant-fold long tail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)