### PR TITLE
[codex] Route Berkeley syntax into Rust SPICE parser

### DIFF
--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Route `parse_netlist` through the Berkeley SPICE logical-card syntax facade,
+  so the default Rust parser consumes normalized cards, supports leading `+`
+  continuations, and reports stable syntax diagnostics before semantic
+  lowering.
 - Add a Berkeley SPICE logical-card syntax facade for Rust/Mosaic app
   substrates. The new surface exposes grammar metadata, normalized logical
   cards, leading `+` continuation handling, source spans, grammar-token names,

--- a/code/packages/rust/spice-netlist-parser/README.md
+++ b/code/packages/rust/spice-netlist-parser/README.md
@@ -17,8 +17,13 @@ C1 out 0 1u
 assert_eq!(parsed.tran_cards().len(), 1);
 ```
 
-For editor, Mosaic, and parser-generator frontends, the crate also exposes a
-Berkeley SPICE logical-card syntax facade:
+`parse_netlist` lowers decks through the Berkeley SPICE logical-card syntax
+facade, so normal simulator parsing honors leading `+` continuations, strips
+inline comments from normalized cards, and reports stable syntax diagnostics
+before semantic lowering starts.
+
+For editor, Mosaic, and parser-generator frontends, the crate also exposes the
+same facade directly:
 
 ```rust
 use spice_netlist_parser::{parse_berkeley_app_deck, BerkeleyCardKind};
@@ -37,12 +42,12 @@ assert_eq!(deck.analysis_inventory()[0].analysis, "op");
 assert_eq!(deck.syntax.cards[1].kind, BerkeleyCardKind::Element);
 ```
 
-The facade preserves normalized logical cards, leading `+` continuations,
-source spans, token names aligned with `code/grammars/spice/berkeley.tokens`,
-stable syntax diagnostics, analysis inventory, and source-order execution
-through the existing parser. It is the Rust app/runtime entrypoint for
-Mosaic-backed UI work while the grammar-backed parser generator and
-Python/TypeScript parity surfaces continue to mature.
+The facade preserves normalized logical cards, source spans, token names
+aligned with `code/grammars/spice/berkeley.tokens`, stable syntax diagnostics,
+analysis inventory, and source-order execution through the existing parser. It
+is the Rust app/runtime entrypoint for Mosaic-backed UI work while the
+grammar-backed parser generator and Python/TypeScript parity surfaces continue
+to mature.
 
 This parser supports `R`, `C`, `L`, `V`, `I`, `D`, `Q`, `M`, `G`, `E`, `F`, and
 `H` elements, `.model <name> D(...)` diode cards with `IS` and `VT`

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -701,34 +701,30 @@ struct SubcktDefinition {
 }
 
 pub fn parse_netlist(text: &str) -> Result<ParsedNetlist, NetlistParseError> {
+    let syntax = syntax::parse_berkeley_syntax(text);
+    if let Some(diagnostic) = syntax
+        .diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.is_error())
+    {
+        return Err(syntax_diagnostic_error(diagnostic));
+    }
+
     let mut circuit = Circuit::new();
     let mut analyses = Vec::new();
     let mut models = HashMap::new();
     let mut statements = Vec::new();
     let mut subckts = HashMap::new();
     let mut current_subckt: Option<SubcktDefinition> = None;
-    let mut title = None;
-    let mut saw_content = false;
+    let title = syntax.title.clone();
 
-    for (index, raw_line) in text.lines().enumerate() {
-        let line_number = index + 1;
-        let stripped = raw_line.trim();
-        if stripped.is_empty() {
-            continue;
+    for card in syntax.cards {
+        let line_number = card.span.start_line;
+        if card.kind == BerkeleyCardKind::End {
+            break;
         }
-        if stripped.starts_with('*') {
-            if !saw_content && title.is_none() {
-                let candidate = stripped[1..].trim();
-                if !candidate.is_empty() {
-                    title = Some(candidate.to_string());
-                }
-            }
-            continue;
-        }
-        saw_content = true;
 
-        let fields = split_fields(strip_inline_comment(raw_line))
-            .map_err(|err| line_error(line_number, err))?;
+        let fields = split_fields(&card.text).map_err(|err| line_error(line_number, err))?;
         if fields.is_empty() {
             continue;
         }
@@ -828,6 +824,15 @@ pub fn parse_netlist(text: &str) -> Result<ParsedNetlist, NetlistParseError> {
         models,
         title,
     })
+}
+
+fn syntax_diagnostic_error(diagnostic: &BerkeleySyntaxDiagnostic) -> NetlistParseError {
+    let message = format!("{}: {}", diagnostic.code, diagnostic.message);
+    if let Some(span) = diagnostic.span {
+        line_error(span.start_line, NetlistParseError::new(message))
+    } else {
+        NetlistParseError::new(message)
+    }
 }
 
 pub fn build_analysis_plan(parsed: &ParsedNetlist) -> Vec<AnalysisPlanStep> {
@@ -2890,10 +2895,6 @@ fn split_fields(line: &str) -> Result<Vec<String>, NetlistParseError> {
         fields.push(current);
     }
     Ok(fields)
-}
-
-fn strip_inline_comment(line: &str) -> &str {
-    line.split_once(';').map_or(line, |(before, _)| before)
 }
 
 fn parse_waveform_values(inner: &str) -> Result<Vec<f64>, NetlistParseError> {

--- a/code/packages/rust/spice-netlist-parser/src/syntax.rs
+++ b/code/packages/rust/spice-netlist-parser/src/syntax.rs
@@ -574,7 +574,7 @@ fn tokenize_card(
     if paren_depth > 0 {
         diagnostics.push(BerkeleySyntaxDiagnostic::error(
             "SPICE_SYNTAX_UNCLOSED_PAREN",
-            "opening parenthesis is missing its closing parenthesis",
+            "unclosed parenthesis: opening parenthesis is missing its closing parenthesis",
             Some(builder.span()),
         ));
     }

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -1953,4 +1953,39 @@ Rbad in
     assert!(err.to_string().contains("Berkeley SPICE app deck"));
 }
 
+#[test]
+fn parse_netlist_lowers_berkeley_logical_card_continuations() {
+    let parsed = parse_netlist(
+        r#"
+* continued divider
+V1 in 0 DC 10
+R1 in mid
++ 1k
+R2 mid 0 1k
+.op
+.end
+"#,
+    )
+    .unwrap();
+
+    assert_eq!(parsed.title.as_deref(), Some("continued divider"));
+    let result = dc_op(&parsed.circuit).unwrap();
+    assert_close(result.voltage("mid").unwrap(), 5.0);
+}
+
+#[test]
+fn parse_netlist_reports_berkeley_syntax_diagnostics_before_lowering() {
+    let err = parse_netlist(
+        r#"
++ orphan
+V1 in 0 DC 1
+"#,
+    )
+    .unwrap_err();
+
+    assert!(err
+        .to_string()
+        .contains("SPICE_SYNTAX_CONTINUATION_WITHOUT_CARD"));
+}
+
 fn assert_error_type(_: NetlistParseError) {}

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,19 +33,17 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Rust Berkeley SPICE parser/app facade.
+1. Rust Berkeley syntax lowerer routing.
    - Status: current PR completion candidate.
-   - Add a Rust `spice-netlist-parser` facade for Berkeley SPICE logical-card
-     syntax that exposes grammar metadata, normalized cards, leading `+`
-     continuations, source spans, token names, stable diagnostics, and analysis
-     inventory.
-   - Add a Rust app-deck entrypoint for Mosaic-backed UI runtimes that parses
-     syntax once, reports syntax/lowering diagnostics, exposes analysis
-     inventory, and can run source-order or selected runnable analyses through
-     the existing simulator parser.
-   - This slice does not change Python/TypeScript simulator semantics. The
-     follow-up grammar-backed parser contract mirrors this facade outward once
-     the Rust/Mosaic substrate shape is reviewed.
+   - Route the Rust `spice-netlist-parser` semantic lowerer through the
+     Berkeley syntax facade by default, so normalized logical cards, leading
+     `+` continuations, source spans, and stable syntax diagnostics drive the
+     existing simulator parser.
+   - Preserve the Mosaic app facade as the Rust runtime entrypoint while
+     removing the parser's duplicate physical-line pass.
+   - This slice is a Rust/Mosaic substrate step. Python and TypeScript parser
+     parity remain the next explicit contract item once the Rust syntax-driven
+     lowering path is reviewed.
 
 ## Completed Slices
 
@@ -1415,12 +1413,20 @@ the Rust, Python, and TypeScript surfaces together.
      and parser grammars so future parser rewrites can break old ad hoc parsing
      behavior against a checked source grammar instead of guessing.
 
+133. Rust Berkeley SPICE parser/app facade.
+   - Status: completed in PR 6902.
+   - Rust `spice-netlist-parser` now exposes a Berkeley SPICE logical-card
+     syntax facade with grammar metadata, normalized cards, leading `+`
+     continuation handling, source spans, token names, stable diagnostics, and
+     analysis inventory.
+   - The Rust app-deck facade parses syntax once, reports syntax/lowering
+     diagnostics, exposes analysis inventory, and can run source-order or
+     selected runnable analyses through the simulator parser for Mosaic-backed
+     UI runtimes.
+
 ## Backlog
 
 1. Grammar-backed parser and app facade.
-   - Route the Rust `spice-netlist-parser` semantic lowerer through the
-     Berkeley syntax facade and checked grammar contract, replacing the current
-     ad hoc line parser as the default deck parse path.
    - Mirror the resulting public parser contract in Python and TypeScript, even
      if that breaks current pre-release parser APIs.
    - Expand the Rust Mosaic app facade from analysis inventory and execution


### PR DESCRIPTION
## Summary
- routes Rust parse_netlist through the Berkeley logical-card syntax facade before semantic lowering
- makes leading + continuation cards executable through the existing parser path
- updates parser docs, changelog, and the SPICE implementation plan status

## Validation
- cargo test -p spice-netlist-parser -- --nocapture
- cargo test -p grammar-tools --test spice_grammar_validation -- --nocapture
- git diff --check HEAD~1..HEAD