### PR TITLE
feat(mycin-board): wire 7 grounded recall domains into board-eval (AX3)

### DIFF
--- a/code/specs/data/mycin-2026/USMLE-DOMAIN-MAP.md
+++ b/code/specs/data/mycin-2026/USMLE-DOMAIN-MAP.md
@@ -93,6 +93,14 @@ its board items + the filename in `board_eval.EDGE_FILES`; the harness scores it
 unchanged. Adding a relation just widens the schema — the engine already binds any
 `relate(rel, args)`.
 
+> **Wiring backlog (2026-06-29):** many grounded `<domain>-edges.adj` libraries were built
+> but never added to `board_eval.EDGE_FILES`, so the board harness wasn't exercising them.
+> Now wired with board items (engine-verified, `wrong=0`): **heart-valve, cranial-nerve,
+> spinal-tract, lung-volume, acid-base, coronary-territory, nephron-transporter** (+33
+> recall items). The remaining built-but-unwired anatomy/physiology/biochem domains
+> (autonomic-receptor, ig-isotype, complement-protein, germ-layer, organelle, …) are
+> queued for the same treatment.
+
 ## Built vs. to-build matrix
 
 ### Built (grounded, scored, merged)

--- a/code/specs/data/mycin-2026/board/board-scorecard.json
+++ b/code/specs/data/mycin-2026/board/board-scorecard.json
@@ -1,7 +1,7 @@
 {
   "summary": {
-    "total": 155,
-    "correct": 148,
+    "total": 188,
+    "correct": 181,
     "abstained": 7,
     "wrong": 0,
     "by_tactic": {
@@ -16,15 +16,15 @@
         "wrong": 0
       },
       "recall": {
-        "correct": 139,
+        "correct": 172,
         "abstained": 6,
         "wrong": 0
       }
     },
     "defensibility": 1.0,
     "accuracy_on_attempted": 1.0,
-    "grounded_coverage": 0.9928,
-    "grounded_correct": 138
+    "grounded_coverage": 0.9942,
+    "grounded_correct": 171
   },
   "results": [
     {
@@ -1264,6 +1264,270 @@
       "tactic": "recall",
       "gold": "coal_workers_pneumoconiosis",
       "answer": "coal_workers_pneumoconiosis",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "hv_aortic",
+      "tactic": "recall",
+      "gold": "right_second_intercostal_space",
+      "answer": "right_second_intercostal_space",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "hv_pulmonic",
+      "tactic": "recall",
+      "gold": "left_second_intercostal_space",
+      "answer": "left_second_intercostal_space",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "hv_tricuspid",
+      "tactic": "recall",
+      "gold": "fourth_left_intercostal_space",
+      "answer": "fourth_left_intercostal_space",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "hv_mitral",
+      "tactic": "recall",
+      "gold": "fifth_intercostal_space_midclavicular_line",
+      "answer": "fifth_intercostal_space_midclavicular_line",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "cn_olfactory",
+      "tactic": "recall",
+      "gold": "smell",
+      "answer": "smell",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "cn_optic",
+      "tactic": "recall",
+      "gold": "vision",
+      "answer": "vision",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "cn_trochlear",
+      "tactic": "recall",
+      "gold": "superior_oblique_muscle",
+      "answer": "superior_oblique_muscle",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "cn_abducens",
+      "tactic": "recall",
+      "gold": "lateral_rectus_muscle",
+      "answer": "lateral_rectus_muscle",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "cn_vagus",
+      "tactic": "recall",
+      "gold": "parasympathetic_innervation_of_viscera",
+      "answer": "parasympathetic_innervation_of_viscera",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "cn_accessory",
+      "tactic": "recall",
+      "gold": "sternocleidomastoid_and_trapezius",
+      "answer": "sternocleidomastoid_and_trapezius",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "cn_hypoglossal",
+      "tactic": "recall",
+      "gold": "tongue_muscles",
+      "answer": "tongue_muscles",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "st_lateral_cst",
+      "tactic": "recall",
+      "gold": "voluntary_motor_control",
+      "answer": "voluntary_motor_control",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "st_dorsal_col",
+      "tactic": "recall",
+      "gold": "fine_touch_vibration_proprioception",
+      "answer": "fine_touch_vibration_proprioception",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "st_spinothal",
+      "tactic": "recall",
+      "gold": "pain_and_temperature",
+      "answer": "pain_and_temperature",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "st_dorsal_spino",
+      "tactic": "recall",
+      "gold": "unconscious_proprioception",
+      "answer": "unconscious_proprioception",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "st_rubrospinal",
+      "tactic": "recall",
+      "gold": "flexor_muscles",
+      "answer": "flexor_muscles",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "st_anterior_cst",
+      "tactic": "recall",
+      "gold": "axial_muscles",
+      "answer": "axial_muscles",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "lv_tidal",
+      "tactic": "recall",
+      "gold": "air_per_respiratory_cycle",
+      "answer": "air_per_respiratory_cycle",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "lv_residual",
+      "tactic": "recall",
+      "gold": "air_remaining_after_maximal_forceful_expiration",
+      "answer": "air_remaining_after_maximal_forceful_expiration",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "lv_irv",
+      "tactic": "recall",
+      "gold": "air_inhaled_after_normal_tidal",
+      "answer": "air_inhaled_after_normal_tidal",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "lv_vc",
+      "tactic": "recall",
+      "gold": "max_air_exhaled_after_max_inspiration",
+      "answer": "max_air_exhaled_after_max_inspiration",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "lv_frc",
+      "tactic": "recall",
+      "gold": "air_remaining_after_normal_passive_exhalation",
+      "answer": "air_remaining_after_normal_passive_exhalation",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "ab_met_acidosis",
+      "tactic": "recall",
+      "gold": "respiratory_compensation",
+      "answer": "respiratory_compensation",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "ab_met_alkalosis",
+      "tactic": "recall",
+      "gold": "increased_paco2_compensation",
+      "answer": "increased_paco2_compensation",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "ab_resp_acidosis",
+      "tactic": "recall",
+      "gold": "metabolic_response_increased_bicarbonate",
+      "answer": "metabolic_response_increased_bicarbonate",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "ab_resp_alkalosis",
+      "tactic": "recall",
+      "gold": "chronic_lowered_bicarbonate",
+      "answer": "chronic_lowered_bicarbonate",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "ct_lcx",
+      "tactic": "recall",
+      "gold": "lateral_wall",
+      "answer": "lateral_wall",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "ct_pda",
+      "tactic": "recall",
+      "gold": "posterior_septum",
+      "answer": "posterior_septum",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "nt_tal",
+      "tactic": "recall",
+      "gold": "nkcc2",
+      "answer": "nkcc2",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "nt_dct",
+      "tactic": "recall",
+      "gold": "ncc",
+      "answer": "ncc",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "nt_cd",
+      "tactic": "recall",
+      "gold": "aquaporin_2",
+      "answer": "aquaporin_2",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "nt_principal",
+      "tactic": "recall",
+      "gold": "enac",
+      "answer": "enac",
+      "outcome": "correct",
+      "trust": "authoritative"
+    },
+    {
+      "id": "nt_descending",
+      "tactic": "recall",
+      "gold": "water",
+      "answer": "water",
       "outcome": "correct",
       "trust": "authoritative"
     }

--- a/code/specs/data/mycin-2026/board/board_eval.py
+++ b/code/specs/data/mycin-2026/board/board_eval.py
@@ -68,7 +68,12 @@ EDGE_FILES = ["iem-edges.adj", "vitamin-edges.adj", "anemia-edges.adj", "endocri
               "coag-edges.adj", "micro-edges.adj", "pharm-edges.adj", "immuno-edges.adj",
               "genetics-edges.adj", "rheum-edges.adj", "onco-edges.adj", "histo-edges.adj",
               "cardio-edges.adj", "neuro-edges.adj", "gi-edges.adj", "derm-edges.adj",
-              "resp-edges.adj"]
+              "resp-edges.adj",
+              # Anatomy/physiology recall domains — grounded libraries that were built but
+              # not yet exercised by the board harness; wired here with board items below.
+              "heart-valve-edges.adj", "cranial-nerve-edges.adj", "spinal-tract-edges.adj",
+              "lung-volume-edges.adj", "acid-base-edges.adj", "coronary-territory-edges.adj",
+              "nephron-transporter-edges.adj"]
 
 # The native adj-lang CLI binary — the ONE engine behind every tactic (recall,
 # differential, management). If the binary is absent (e.g. a Python-only CI job that

--- a/code/specs/data/mycin-2026/board/items.json
+++ b/code/specs/data/mycin-2026/board/items.json
@@ -175,6 +175,46 @@
     {"id": "resp_asbestos_dx", "domain": "resp", "tactic": "recall", "relation": "inhalation_causes", "subject": "asbestos",    "var": "Disease", "gold": "asbestosis"},
     {"id": "resp_beryl_dx",    "domain": "resp", "tactic": "recall", "relation": "inhalation_causes", "subject": "beryllium",   "var": "Disease", "gold": "berylliosis"},
     {"id": "resp_cotton_dx",   "domain": "resp", "tactic": "recall", "relation": "inhalation_causes", "subject": "cotton_dust", "var": "Disease", "gold": "byssinosis"},
-    {"id": "resp_coal_dx",     "domain": "resp", "tactic": "recall", "relation": "inhalation_causes", "subject": "coal_dust",   "var": "Disease", "gold": "coal_workers_pneumoconiosis"}
+    {"id": "resp_coal_dx",     "domain": "resp", "tactic": "recall", "relation": "inhalation_causes", "subject": "coal_dust",   "var": "Disease", "gold": "coal_workers_pneumoconiosis"},
+
+    {"id": "hv_aortic",    "domain": "heart_valve", "tactic": "recall", "relation": "best_heard_at", "subject": "aortic_valve",    "var": "Location", "gold": "right_second_intercostal_space"},
+    {"id": "hv_pulmonic",  "domain": "heart_valve", "tactic": "recall", "relation": "best_heard_at", "subject": "pulmonic_valve",  "var": "Location", "gold": "left_second_intercostal_space"},
+    {"id": "hv_tricuspid", "domain": "heart_valve", "tactic": "recall", "relation": "best_heard_at", "subject": "tricuspid_valve", "var": "Location", "gold": "fourth_left_intercostal_space"},
+    {"id": "hv_mitral",    "domain": "heart_valve", "tactic": "recall", "relation": "best_heard_at", "subject": "mitral_valve",    "var": "Location", "gold": "fifth_intercostal_space_midclavicular_line"},
+
+    {"id": "cn_olfactory",  "domain": "cranial_nerve", "tactic": "recall", "relation": "cranial_nerve_function", "subject": "olfactory_nerve",  "var": "Function", "gold": "smell"},
+    {"id": "cn_optic",      "domain": "cranial_nerve", "tactic": "recall", "relation": "cranial_nerve_function", "subject": "optic_nerve",      "var": "Function", "gold": "vision"},
+    {"id": "cn_trochlear",  "domain": "cranial_nerve", "tactic": "recall", "relation": "cranial_nerve_function", "subject": "trochlear_nerve",  "var": "Function", "gold": "superior_oblique_muscle"},
+    {"id": "cn_abducens",   "domain": "cranial_nerve", "tactic": "recall", "relation": "cranial_nerve_function", "subject": "abducens_nerve",   "var": "Function", "gold": "lateral_rectus_muscle"},
+    {"id": "cn_vagus",      "domain": "cranial_nerve", "tactic": "recall", "relation": "cranial_nerve_function", "subject": "vagus_nerve",      "var": "Function", "gold": "parasympathetic_innervation_of_viscera"},
+    {"id": "cn_accessory",  "domain": "cranial_nerve", "tactic": "recall", "relation": "cranial_nerve_function", "subject": "accessory_nerve",  "var": "Function", "gold": "sternocleidomastoid_and_trapezius"},
+    {"id": "cn_hypoglossal","domain": "cranial_nerve", "tactic": "recall", "relation": "cranial_nerve_function", "subject": "hypoglossal_nerve","var": "Function", "gold": "tongue_muscles"},
+
+    {"id": "st_lateral_cst",  "domain": "spinal_tract", "tactic": "recall", "relation": "carries", "subject": "lateral_corticospinal_tract",   "var": "Function", "gold": "voluntary_motor_control"},
+    {"id": "st_dorsal_col",   "domain": "spinal_tract", "tactic": "recall", "relation": "carries", "subject": "dorsal_column",                 "var": "Function", "gold": "fine_touch_vibration_proprioception"},
+    {"id": "st_spinothal",    "domain": "spinal_tract", "tactic": "recall", "relation": "carries", "subject": "spinothalamic_tract",           "var": "Function", "gold": "pain_and_temperature"},
+    {"id": "st_dorsal_spino", "domain": "spinal_tract", "tactic": "recall", "relation": "carries", "subject": "dorsal_spinocerebellar_tract",  "var": "Function", "gold": "unconscious_proprioception"},
+    {"id": "st_rubrospinal",  "domain": "spinal_tract", "tactic": "recall", "relation": "carries", "subject": "rubrospinal_tract",             "var": "Function", "gold": "flexor_muscles"},
+    {"id": "st_anterior_cst", "domain": "spinal_tract", "tactic": "recall", "relation": "carries", "subject": "anterior_corticospinal_tract",  "var": "Function", "gold": "axial_muscles"},
+
+    {"id": "lv_tidal",   "domain": "lung_volume", "tactic": "recall", "relation": "is_defined_as", "subject": "tidal_volume",                 "var": "Definition", "gold": "air_per_respiratory_cycle"},
+    {"id": "lv_residual","domain": "lung_volume", "tactic": "recall", "relation": "is_defined_as", "subject": "residual_volume",              "var": "Definition", "gold": "air_remaining_after_maximal_forceful_expiration"},
+    {"id": "lv_irv",     "domain": "lung_volume", "tactic": "recall", "relation": "is_defined_as", "subject": "inspiratory_reserve_volume",   "var": "Definition", "gold": "air_inhaled_after_normal_tidal"},
+    {"id": "lv_vc",      "domain": "lung_volume", "tactic": "recall", "relation": "is_defined_as", "subject": "vital_capacity",               "var": "Definition", "gold": "max_air_exhaled_after_max_inspiration"},
+    {"id": "lv_frc",     "domain": "lung_volume", "tactic": "recall", "relation": "is_defined_as", "subject": "functional_residual_capacity", "var": "Definition", "gold": "air_remaining_after_normal_passive_exhalation"},
+
+    {"id": "ab_met_acidosis",  "domain": "acid_base", "tactic": "recall", "relation": "compensated_by", "subject": "metabolic_acidosis",    "var": "Compensation", "gold": "respiratory_compensation"},
+    {"id": "ab_met_alkalosis", "domain": "acid_base", "tactic": "recall", "relation": "compensated_by", "subject": "metabolic_alkalosis",   "var": "Compensation", "gold": "increased_paco2_compensation"},
+    {"id": "ab_resp_acidosis", "domain": "acid_base", "tactic": "recall", "relation": "compensated_by", "subject": "respiratory_acidosis",  "var": "Compensation", "gold": "metabolic_response_increased_bicarbonate"},
+    {"id": "ab_resp_alkalosis","domain": "acid_base", "tactic": "recall", "relation": "compensated_by", "subject": "respiratory_alkalosis", "var": "Compensation", "gold": "chronic_lowered_bicarbonate"},
+
+    {"id": "ct_lcx", "domain": "coronary_territory", "tactic": "recall", "relation": "coronary_artery_territory", "subject": "left_circumflex_artery",      "var": "Region", "gold": "lateral_wall"},
+    {"id": "ct_pda", "domain": "coronary_territory", "tactic": "recall", "relation": "coronary_artery_territory", "subject": "posterior_descending_artery", "var": "Region", "gold": "posterior_septum"},
+
+    {"id": "nt_tal",       "domain": "nephron_transporter", "tactic": "recall", "relation": "nephron_segment_transporter", "subject": "thick_ascending_limb",     "var": "Transporter", "gold": "nkcc2"},
+    {"id": "nt_dct",       "domain": "nephron_transporter", "tactic": "recall", "relation": "nephron_segment_transporter", "subject": "distal_convoluted_tubule", "var": "Transporter", "gold": "ncc"},
+    {"id": "nt_cd",        "domain": "nephron_transporter", "tactic": "recall", "relation": "nephron_segment_transporter", "subject": "collecting_duct",          "var": "Transporter", "gold": "aquaporin_2"},
+    {"id": "nt_principal", "domain": "nephron_transporter", "tactic": "recall", "relation": "nephron_segment_transporter", "subject": "principal_cell",           "var": "Transporter", "gold": "enac"},
+    {"id": "nt_descending","domain": "nephron_transporter", "tactic": "recall", "relation": "nephron_segment_transporter", "subject": "descending_limb",          "var": "Transporter", "gold": "water"}
   ]
 }

--- a/code/specs/data/mycin-2026/board/test_board_eval.py
+++ b/code/specs/data/mycin-2026/board/test_board_eval.py
@@ -58,8 +58,11 @@ def test_covered_items_answer_correctly_with_a_proof() -> None:
     # RHEUM/ONCO/HISTO are Tier-2 organ-system domains where a subject binds several
     # answers, so the board scores the top binding per subject (the libraries + their
     # tests cover all edges).
+    # +33 with the 7 newly-wired anatomy/physiology domains (heart-valve 4, cranial-nerve 7,
+    # spinal-tract 6, lung-volume 5, acid-base 4, coronary-territory 2, nephron-transporter 5):
+    # 139 → 172 covered recall items, all over one merged store.
     recall_correct = [r for r in card.results if r.outcome == "correct" and r.tactic == "recall"]
-    assert len(recall_correct) == 139
+    assert len(recall_correct) == 172
     assert by_id["fabry_enzyme"].outcome == "correct"               # IEM
     assert by_id["thiamine_disease"].answer == "beriberi"           # vitamin
     assert by_id["ida_mcv"].answer == "microcytic"                  # anemia
@@ -128,6 +131,15 @@ def test_covered_items_answer_correctly_with_a_proof() -> None:
     assert by_id["resp_silica_dx"].trust == "authoritative"      # ADJ-only edge, grounded inline
     assert by_id["resp_coal_dx"].answer == "coal_workers_pneumoconiosis"  # primary-source-first: no deferral
     assert by_id["resp_coal_dx"].trust == "authoritative"        # grounded from CDC/NIOSH (cdc.gov), not StatPearls
+    # Newly-wired anatomy/physiology domains (grounded libraries now exercised by the board):
+    assert by_id["hv_aortic"].answer == "right_second_intercostal_space"  # heart-valve — best_heard_at
+    assert by_id["cn_optic"].answer == "vision"                  # cranial-nerve — cranial_nerve_function
+    assert by_id["st_spinothal"].answer == "pain_and_temperature"  # spinal-tract — carries
+    assert by_id["lv_tidal"].answer == "air_per_respiratory_cycle"  # lung-volume — is_defined_as
+    assert by_id["ab_met_acidosis"].answer == "respiratory_compensation"  # acid-base — compensated_by
+    assert by_id["ct_lcx"].answer == "lateral_wall"              # coronary-territory — coronary_artery_territory
+    assert by_id["nt_tal"].answer == "nkcc2"                    # nephron-transporter — nephron_segment_transporter
+    assert by_id["hv_aortic"].trust == "authoritative"           # grounded edge, cited proof
 
 
 def test_uncovered_items_abstain_not_fabricate() -> None:
@@ -170,8 +182,11 @@ def test_grounded_coverage_is_the_live_grounding_number() -> None:
     # verbatim, so the framework declines to claim grounding it cannot defend, by design:
     # cortisol_def (endocrine, deficiency_syndrome__cortisol — the only verbatim spans frame
     # cortisol deficiency as a consequence/feature of Addison disease, not the named-syndrome identity).
-    assert s["grounded_coverage"] == round(138 / 139, 4)   # 0.9928
-    assert s["grounded_correct"] == 138
+    # +33 grounded (all [authoritative]) from the 7 newly-wired anatomy/physiology domains:
+    # grounded_correct 138 → 171, recall correct 139 → 172, so coverage 171/172 = 0.9942
+    # (the lone cortisol_def direction_only holdout is unchanged).
+    assert s["grounded_coverage"] == round(171 / 172, 4)   # 0.9942
+    assert s["grounded_correct"] == 171
     by_id = {r.item_id: r for r in card.results}
     assert by_id["tay_sachs_enzyme"].trust == "authoritative"      # IEM
     assert by_id["ida_mcv"].trust == "authoritative"               # anemia


### PR DESCRIPTION
## What

Many grounded `<domain>-edges.adj` recall libraries were **built but never added to `board_eval.EDGE_FILES`** — 63 domains exist, only 17 were exercised by the board harness. This turns **7 dormant grounded libraries into proven board coverage** — the documented next stdlib step ([USMLE-DOMAIN-MAP](code/specs/data/mycin-2026/USMLE-DOMAIN-MAP.md)), pointed at MLE, **with no new grounding** (the edges already exist and are spider-grounded).

Wired (added to `EDGE_FILES` + board items): **heart-valve, cranial-nerve, spinal-tract, lung-volume, acid-base, coronary-territory, nephron-transporter**.

+**33 recall board items** (single-answer subjects only, mirrored from each domain's `*-recall.query.adj` expected answers, so each resolves to exactly one grounded edge).

## Verification

- `python3 board_eval.py` → **188 items, correct 181 / abstained 7 / wrong 0**, defensibility **100%**, accuracy-on-attempted 100%. Every one of the 33 new items resolves **correct-with-proof** against its grounded edge (all `[authoritative]`).
- `test_board_offline.py`: **18 pass**. Regenerated `board-scorecard.json`.
- The board gate (`wrong>0` ⇒ fail) holds; nothing fabricated.
- **/security-review PASSED** — the new `EDGE_FILES` basenames and item `relation`/`subject`/`var` fields are strict identifiers/basenames interpolated into the generated ADJ query program; no injection or path traversal (confirmed across all 188 items / 24 edge files).

Spec `USMLE-DOMAIN-MAP.md` updated with a wiring-backlog note (remaining built-but-unwired domains queued).

🤖 Generated with [Claude Code](https://claude.com/claude-code)