### PR TITLE
feat(lang-full): BA-trig — Dartmouth BASIC SIN/COS/LOG/EXP on all 7 backends

### DIFF
--- a/code/packages/rust/dartmouth-basic-iir-compiler/CHANGELOG.md
+++ b/code/packages/rust/dartmouth-basic-iir-compiler/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog — `dartmouth-basic-iir-compiler`
 
+## 0.33.0 — 2026-06-29 — BA-trig: `SIN`, `COS`, `LOG`, `EXP` (LANG-FULL)
+
+Dartmouth BASIC's transcendental built-in functions `SIN`, `COS`, `LOG`, and
+`EXP` are now lowered — reusing the AL8-trig IIR ops (`f64_sin`, `f64_cos`,
+`f64_ln`, `f64_exp`) added for ALGOL 60.  No new backend code needed: the four
+ops are already mapped on all 7 backends.
+
+| Function | Lowers to | Note |
+|----------|-----------|------|
+| `SIN(X)` | `f64_sin` | sine in radians |
+| `COS(X)` | `f64_cos` | cosine in radians |
+| `LOG(X)` | `f64_ln`  | natural log (base e); Dartmouth BASIC `LOG` = ln, not log₁₀ |
+| `EXP(X)` | `f64_exp` | eˣ |
+
+Backend dispatch: WASM `env.__sin/cos/ln/exp` host imports; LLVM
+`@llvm.sin/cos/log/exp.f64` intrinsics; JVM `Math.sin/cos/log/exp`; CLR
+`System.Math.Sin/Cos/Log/Exp`; native aarch64/x86_64 `BL`/`call rel32` to
+libm; VM/JIT `f64_sin/cos/ln/exp` dispatch handlers.
+
+Verified by RUNNING `PRINT SIN(0)` → `0`, `PRINT COS(0)` → `1`,
+`PRINT LOG(1)` → `0`, `PRINT EXP(0)` → `1` on all 7 backends via
+`lang_matrix.rs` (`matrix_every_proven_cell_agrees`).
+
+`TAN`, `ATN`, and `RND` are still rejected until further infrastructure lands.
+
 ## 0.32.0 — 2026-06-28 — BA-builtins: `SQR`, `INT`, `ABS`, `SGN` (LANG-FULL)
 
 Dartmouth BASIC's built-in math functions `SQR`, `INT`, `ABS`, and `SGN` are

--- a/code/packages/rust/dartmouth-basic-iir-compiler/Cargo.toml
+++ b/code/packages/rust/dartmouth-basic-iir-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dartmouth-basic-iir-compiler"
-version = "0.32.0"
+version = "0.33.0"
 edition = "2021"
 description = "Dartmouth BASIC frontend for the LANG VM AOT chain — lowers parsed BASIC into interpreter_ir::IIRModule. v0.31.0 proves BA4 lexical string ordering in IF branches on all seven backends; v0.30.0 proved variable-variable string concat in IF equality."
 

--- a/code/packages/rust/dartmouth-basic-iir-compiler/src/lib.rs
+++ b/code/packages/rust/dartmouth-basic-iir-compiler/src/lib.rs
@@ -1596,10 +1596,16 @@ impl Compiler {
     /// | `INT(X)` | `real_to_int_floor` → `int_to_real` | floor, result is f64 |
     /// | `ABS(X)` | inline if/neg/jmp    | store-per-branch, no phi          |
     /// | `SGN(X)` | inline 3-way if/jmp  | -1.0 / 0.0 / 1.0 per BA7 model   |
+    /// | `SIN(X)` | `f64_sin`            | libm/host/LLVM/JVM/CLR sin        |
+    /// | `COS(X)` | `f64_cos`            | libm/host/LLVM/JVM/CLR cos        |
+    /// | `LOG(X)` | `f64_ln`             | natural log (BASIC `LOG` = ln)    |
+    /// | `EXP(X)` | `f64_exp`            | libm/host/LLVM/JVM/CLR exp        |
     ///
-    /// `SIN`, `COS`, `LOG`, `EXP`, `TAN`, `ATN`, `RND` need a cross-backend
-    /// math helper (libm call) and are rejected with a clear error until that
-    /// infrastructure lands.
+    /// Note: Dartmouth BASIC `LOG` is the natural logarithm (base e), not base-10.
+    /// It maps to the `f64_ln` IIR op (which ALGOL calls `ln`).
+    ///
+    /// `TAN`, `ATN`, `RND` still need a cross-backend math helper and are
+    /// rejected with a clear error until that infrastructure lands.
     fn emit_builtin_fn(&mut self, name: &str, node: &GrammarASTNode)
         -> Result<ExprValue, CompileError>
     {
@@ -1698,6 +1704,42 @@ impl Compiler {
                 self.emit("label", None, vec![Operand::Var(zero_lbl)], "void");
                 self.emit("const", Some(&dest), vec![Operand::Float(0.0)], "f64");
                 self.emit("label", None, vec![Operand::Var(end_lbl)], "void");
+                Ok(ExprValue { slot: dest, ty: BasicScalarType::Real })
+            }
+
+            // SIN(X) — sine via f64_sin IIR op (AL8-trig infrastructure).
+            // Dartmouth BASIC SIN is the standard trigonometric sine in radians.
+            "sin" => {
+                let dest = self.fresh_temp();
+                self.emit("f64_sin", Some(&dest),
+                    vec![Operand::Var(arg.slot)], "f64");
+                Ok(ExprValue { slot: dest, ty: BasicScalarType::Real })
+            }
+
+            // COS(X) — cosine via f64_cos IIR op.
+            "cos" => {
+                let dest = self.fresh_temp();
+                self.emit("f64_cos", Some(&dest),
+                    vec![Operand::Var(arg.slot)], "f64");
+                Ok(ExprValue { slot: dest, ty: BasicScalarType::Real })
+            }
+
+            // LOG(X) — natural logarithm (base e) via f64_ln IIR op.
+            // Dartmouth BASIC LOG is ln, not log₁₀.  The IIR op is named
+            // f64_ln (matching ALGOL's `ln` name); all backends map it to
+            // libm `log` / Math.log / @llvm.log.f64, which is also ln.
+            "log" => {
+                let dest = self.fresh_temp();
+                self.emit("f64_ln", Some(&dest),
+                    vec![Operand::Var(arg.slot)], "f64");
+                Ok(ExprValue { slot: dest, ty: BasicScalarType::Real })
+            }
+
+            // EXP(X) — exponential (eˣ) via f64_exp IIR op.
+            "exp" => {
+                let dest = self.fresh_temp();
+                self.emit("f64_exp", Some(&dest),
+                    vec![Operand::Var(arg.slot)], "f64");
                 Ok(ExprValue { slot: dest, ty: BasicScalarType::Real })
             }
 

--- a/code/packages/rust/lang-aot/CHANGELOG.md
+++ b/code/packages/rust/lang-aot/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog — `lang-aot`
 
+## 0.155.0 — 2026-06-29 — Dartmouth BASIC `SIN`/`COS`/`LOG`/`EXP` built-ins (LANG-FULL BA-trig)
+
+Four new matrix `Prog` cells proving Dartmouth BASIC's transcendental built-in
+functions on all 7 backends (NativeAot, Llvm, Wasm, Jvm, Clr, Vm, Jit):
+
+- `PRINT SIN(0)` → stdout `0`
+- `PRINT COS(0)` → stdout `1`
+- `PRINT LOG(1)` → stdout `0`   (Dartmouth BASIC `LOG` = natural log)
+- `PRINT EXP(0)` → stdout `1`
+
+All four use exact IEEE-754 inputs/outputs (no rounding). Each lowers to the
+same `f64_sin/cos/ln/exp` IIR ops built for ALGOL (AL8-trig) — no new backend
+code. The `BA7` formatter correctly prints whole-valued reals without a decimal
+point.
+
 ## 0.154.0 — 2026-06-28 — ALGOL 60 transcendental functions `sin`/`cos`/`ln`/`exp` (LANG-FULL AL8-trig)
 
 Four new matrix `Prog` cells proving ALGOL 60's §3.2.4 transcendental standard

--- a/code/packages/rust/lang-aot/Cargo.toml
+++ b/code/packages/rust/lang-aot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lang-aot"
-version = "0.154.0"
+version = "0.155.0"
 edition = "2021"
 description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, and McCarthy Lisp to native executables through the shared IIR pipeline.  v0.151.0 (LANG-FULL AL4): `tests/lang_matrix.rs` proves ALGOL string equality and ordering on native/LLVM/WASM/JVM/CLR/VM/JIT.  v0.150.0 proved BASIC lexical string ordering."
 

--- a/code/packages/rust/lang-aot/tests/lang_matrix.rs
+++ b/code/packages/rust/lang-aot/tests/lang_matrix.rs
@@ -1792,6 +1792,47 @@ const PROGRAMS: &[Prog] = &[
         expect: Expect::Stdout("-1"),
         backends: &[NativeAot, Llvm, Wasm, Jvm, Clr, Vm, Jit],
     },
+    // Dartmouth BASIC — `SIN` built-in (LANG-FULL BA-trig).
+    // SIN(0) = 0.0 exactly in IEEE-754 double.  BA7 formatter prints `0`.
+    // Lowers to `f64_sin` IIR op: WASM `env.__sin`, LLVM `@llvm.sin.f64`,
+    // JVM `Math.sin`, CLR `System.Math.Sin`, native `BL sin`/`call sin`,
+    // VM/JIT `f64::sin`.
+    Prog {
+        lang: Language::DartmouthBasic,
+        ext: "bas",
+        src: "10 PRINT SIN(0)\n20 END\n",
+        expect: Expect::Stdout("0"),
+        backends: &[NativeAot, Llvm, Wasm, Jvm, Clr, Vm, Jit],
+    },
+    // Dartmouth BASIC — `COS` built-in (LANG-FULL BA-trig).
+    // COS(0) = 1.0 exactly.  BA7 formatter prints `1`.
+    Prog {
+        lang: Language::DartmouthBasic,
+        ext: "bas",
+        src: "10 PRINT COS(0)\n20 END\n",
+        expect: Expect::Stdout("1"),
+        backends: &[NativeAot, Llvm, Wasm, Jvm, Clr, Vm, Jit],
+    },
+    // Dartmouth BASIC — `LOG` built-in (LANG-FULL BA-trig).
+    // Dartmouth BASIC LOG is the natural log (ln, base e), not log₁₀.
+    // LOG(1) = 0.0 exactly.  BA7 formatter prints `0`.
+    // Lowers to `f64_ln` IIR op (same op ALGOL's `ln` uses).
+    Prog {
+        lang: Language::DartmouthBasic,
+        ext: "bas",
+        src: "10 PRINT LOG(1)\n20 END\n",
+        expect: Expect::Stdout("0"),
+        backends: &[NativeAot, Llvm, Wasm, Jvm, Clr, Vm, Jit],
+    },
+    // Dartmouth BASIC — `EXP` built-in (LANG-FULL BA-trig).
+    // EXP(0) = e⁰ = 1.0 exactly.  BA7 formatter prints `1`.
+    Prog {
+        lang: Language::DartmouthBasic,
+        ext: "bas",
+        src: "10 PRINT EXP(0)\n20 END\n",
+        expect: Expect::Stdout("1"),
+        backends: &[NativeAot, Llvm, Wasm, Jvm, Clr, Vm, Jit],
+    },
 ];
 
 /// Is a usable native linker present on this host? On Linux/macOS the AOT path uses

--- a/code/specs/LANG-FULL-IMPLEMENTATION.md
+++ b/code/specs/LANG-FULL-IMPLEMENTATION.md
@@ -628,8 +628,14 @@ backend immediately) come before the enabler-dependent items.
   real). `ABS(X)` and `SGN(X)` lower inline via `cmp_lt`/`cmp_gt` + store-per-branch
   conditionals (same pattern as ALGOL `abs`/`sign`). **Verified by RUNNING** on
   native/LLVM/WASM/JVM/CLR/VM/JIT: `PRINT SQR(49)` → `7`, `PRINT INT(3.7)` → `3`,
-  `PRINT ABS(-42)` → `42`, `PRINT SGN(-5)` → `-1`. `SIN`, `COS`, `LOG`, `EXP`,
-  `TAN`, `ATN`, `RND` need a cross-backend math helper (libm/host call) — deferred.
+  `PRINT ABS(-42)` → `42`, `PRINT SGN(-5)` → `-1`.
+- ✅ **BA-trig** — `SIN`, `COS`, `LOG`, `EXP` built-in functions
+  (`dartmouth-basic-iir-compiler` 0.33.0). All four reuse the AL8-trig IIR ops
+  (`f64_sin`, `f64_cos`, `f64_ln`, `f64_exp`) — no new backend code needed.
+  Note: Dartmouth BASIC `LOG` is the natural logarithm (base e), not log₁₀;
+  it maps to `f64_ln` (same op ALGOL's `ln` uses). **Verified by RUNNING** on
+  native/LLVM/WASM/JVM/CLR/VM/JIT: `PRINT SIN(0)` → `0`, `PRINT COS(0)` → `1`,
+  `PRINT LOG(1)` → `0`, `PRINT EXP(0)` → `1`. `TAN`, `ATN`, `RND` remain.
 
 ### ALGOL 60
 - ✅ **AL1** — real arithmetic + `/` (algol-iir-compiler 0.4.0): `real` → IIR `f64`, `REAL_LIT`


### PR DESCRIPTION
## Summary

- Wires Dartmouth BASIC's `SIN`, `COS`, `LOG`, `EXP` built-ins to the AL8-trig IIR ops — no new backend code needed
- `dartmouth-basic-iir-compiler`: adds 4 arms in `emit_builtin_fn` (`sin`→`f64_sin`, `cos`→`f64_cos`, `log`→`f64_ln`, `exp`→`f64_exp`)
- Key mapping: Dartmouth BASIC `LOG` = natural log (ln), not log₁₀; maps to `f64_ln` (same as ALGOL's `ln`)
- 4 new matrix `Prog` cells with exact IEEE-754 proofs: `PRINT SIN(0)` → `0`, `PRINT COS(0)` → `1`, `PRINT LOG(1)` → `0`, `PRINT EXP(0)` → `1`
- Total proven matrix cells: **870** (was 866 after AL8-trig)
- `TAN`, `ATN`, `RND` remain rejected with a clear error

**Depends on:** feat/lang-full-al8-trig (#6910) — stacked on top; will rebase to main after that merges.

## Test plan

- [ ] `matrix_every_proven_cell_agrees` passes with 870 cells (verified locally before push)
- [ ] CI passes on ubuntu-latest, macos-latest, windows-latest
- [ ] All 4 new BASIC trig `Prog` cells run on all 7 backends

🤖 Generated with [Claude Code](https://claude.com/claude-code)