### PR TITLE
feat(lang-full): AL9 — ALGOL 60 real array + real procedure on 7 backends

### DIFF
--- a/code/packages/rust/lang-aot/CHANGELOG.md
+++ b/code/packages/rust/lang-aot/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog — `lang-aot`
 
+## 0.156.0 — 2026-06-29 — ALGOL 60 real array + real procedure on 7 backends (LANG-FULL AL9)
+
+Added two matrix proof cells for ALGOL 60 real-typed features:
+
+- **AL9-a (real array)**: `real array A[1:3]` with f64 element stores/loads;
+  `A[1]:=40.0; A[3]:=2.0; entier(A[1]+A[3])` ⇒ exit 42.  Exercises non-contiguous
+  f64 slots and ALGOL's lower-bound subtraction on array access.
+- **AL9-b (real procedure)**: `real procedure square(x); value x; real x;` with
+  a real value parameter and real return; `entier(square(6.5))` = `entier(42.25)`
+  ⇒ exit 42.  Exercises the `(f64) → f64` call/ret pathway on all 7 backends.
+
+No new IIR ops or backend changes — both cells run on the existing E5 array substrate
+(array_set/array_get with f64 type_hint) and the existing call/ret mechanism.
+
+844 total proven cells pass.
+
 ## 0.155.0 — 2026-06-29 — ALGOL 60 transcendental functions `sin`/`cos`/`ln`/`exp` (LANG-FULL AL8-trig)
 
 Four new matrix `Prog` cells proving ALGOL 60's §3.2.4 transcendental standard

--- a/code/packages/rust/lang-aot/Cargo.toml
+++ b/code/packages/rust/lang-aot/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "lang-aot"
-version = "0.155.0"
+version = "0.156.0"
 edition = "2021"
-description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, and McCarthy Lisp to native executables through the shared IIR pipeline.  v0.155.0 (LANG-FULL AL8-trig): proves ALGOL 60 sin/cos/ln/exp on all 7 backends.  v0.154.0 proved ALGOL string procedure params."
+description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, and McCarthy Lisp to native executables through the shared IIR pipeline.  v0.156.0 (LANG-FULL AL9): proves ALGOL 60 real array and real procedure on all 7 backends.  v0.155.0 proved AL8-trig."
 
 [dependencies]
 twig-aot              = { path = "../twig-aot" }

--- a/code/packages/rust/lang-aot/tests/lang_matrix.rs
+++ b/code/packages/rust/lang-aot/tests/lang_matrix.rs
@@ -1250,6 +1250,45 @@ const PROGRAMS: &[Prog] = &[
         expect: Expect::Stdout("HI"),
         backends: &[NativeAot, Llvm, Wasm, Jvm, Clr, Vm, Jit],
     },
+    // ALGOL 60 — *`real` array* (LANG-FULL AL9-a — real-typed E5 arrays).  The E5
+    // array substrate (`alloc_array`/`array_set`/`array_get`) uses the IIR
+    // type_hint to decide the element width: `f64` instead of `i64`.  BASIC's BA3
+    // cells already proved `array<f64>` reaches all 7 backends, but this is the
+    // first ALGOL 60 real-array matrix cell — exercising `real array A[lo:hi]`
+    // syntax, the ALGOL lower-bound subtraction on access, and f64-typed element
+    // stores/loads through `entier` back to an integer exit code.
+    //
+    // `A[1] := 40.0; A[3] := 2.0; result := entier(A[1] + A[3])` ⇒ `entier(42.0)`
+    // = 42 ⇒ exit 42 on all 7 backends.  Exercises a *non-contiguous* pair of
+    // f64 slots (index 1 and 3 with a gap at 2) so the element-offset arithmetic is
+    // non-trivial.
+    Prog {
+        lang: Language::Algol60,
+        ext: "alg",
+        src: "begin real array A[1:3]; integer result; \
+               A[1] := 40.0; A[3] := 2.0; result := entier(A[1] + A[3]) end",
+        expect: Expect::Exit(42),
+        backends: &[NativeAot, Llvm, Wasm, Jvm, Clr, Vm, Jit],
+    },
+    // ALGOL 60 — *`real` procedure with a real value parameter* (LANG-FULL AL9-b).
+    // Proves that the `call`/`ret` pathway carries `f64` arguments and return values
+    // correctly across all 7 backends.  The function type is `(f64) -> f64`; the
+    // call site lowers to a `call square(x_slot)` with a real (f64) argument, and
+    // the callee emits `ret square` after `square := x * x` (an f64 multiply).
+    //
+    // `square(6.5)` = 6.5 × 6.5 = 42.25; `entier(42.25)` = 42 (floor, not trunc —
+    // same direction here since 42.25 > 0) ⇒ exit 42 on all 7 backends.  The
+    // non-integer argument (6.5) and non-integer intermediate result (42.25) both
+    // exercise the f64 parameter-passing path independently of the E3 scalar
+    // arithmetic cells, which use only whole-valued reals.
+    Prog {
+        lang: Language::Algol60,
+        ext: "alg",
+        src: "begin real procedure square(x); value x; real x; square := x * x; \
+               integer result; result := entier(square(6.5)) end",
+        expect: Expect::Exit(42),
+        backends: &[NativeAot, Llvm, Wasm, Jvm, Clr, Vm, Jit],
+    },
     // Brainfuck — build 65 on the tape and `putchar` it: prints `A`.
     // `lower_brainfuck_for_aot` widens the BF cell/ptr registers to `i64` (byte width
     // survives only at the tape boundary) for every code-gen backend. On LLVM (LM-L)


### PR DESCRIPTION
## Summary

- Adds two ALGOL 60 real-typed matrix proof cells, closing a gap left by E5 (which only had an integer array ALGOL cell and a BASIC real array cell)
- No new IIR ops or backend changes — pure matrix expansion on existing E5 + E3 substrate

## New cells

| Cell | Program | Expected |
|---|---|---|
| AL9-a (real array) | `real array A[1:3]; A[1]:=40.0; A[3]:=2.0; entier(A[1]+A[3])` | Exit(42) |
| AL9-b (real procedure) | `real procedure square(x); value x; real x; square:=x*x; entier(square(6.5))` | Exit(42) |

**AL9-a** proves `array<f64>` stores/loads work through the ALGOL lower-bound subtraction on access (non-contiguous slots 1 and 3 with a gap at 2).

**AL9-b** proves the `(f64) → f64` call/ret pathway: a real value parameter passes 6.5 through, the callee multiplies 6.5×6.5=42.25, and `entier(42.25)=42`. Non-integer argument and result both exercise the f64 parameter path independently of the E3 scalar cells (which use only whole-valued reals).

## Test plan

- [x] `cargo test -p lang-aot --test lang_matrix -- matrix_every_proven_cell_agrees` passes locally (93s, all cells green including both new AL9 cells)
- [x] Security review passed (test-only change, no security surface)

🤖 Generated with [Claude Code](https://claude.com/claude-code)