### PR TITLE
feat(lexer): Token carries optional correlation-vector id (CLOC27 P1)

### DIFF
--- a/code/packages/rust/excel-lexer/src/lib.rs
+++ b/code/packages/rust/excel-lexer/src/lib.rs
@@ -30,7 +30,7 @@ fn excel_on_token(token: &Token, ctx: &mut LexerContext) {
             line: token.line,
             column: token.column,
             type_name: Some("FUNCTION_NAME".to_string()),
-            flags: None,
+            flags: None, cv: None,
         });
         return;
     }
@@ -43,7 +43,7 @@ fn excel_on_token(token: &Token, ctx: &mut LexerContext) {
             line: token.line,
             column: token.column,
             type_name: Some("TABLE_NAME".to_string()),
-            flags: None,
+            flags: None, cv: None,
         });
     }
 }

--- a/code/packages/rust/excel-parser/src/lib.rs
+++ b/code/packages/rust/excel-parser/src/lib.rs
@@ -46,7 +46,7 @@ fn normalize_excel_reference_tokens(tokens: Vec<Token>) -> Vec<Token> {
                     line: token.line,
                     column: token.column,
                     type_name: Some("COLUMN_REF".to_string()),
-                    flags: None,
+                    flags: None, cv: None,
                 };
             }
 
@@ -57,7 +57,7 @@ fn normalize_excel_reference_tokens(tokens: Vec<Token>) -> Vec<Token> {
                     line: token.line,
                     column: token.column,
                     type_name: Some("ROW_REF".to_string()),
-                    flags: None,
+                    flags: None, cv: None,
                 };
             }
 

--- a/code/packages/rust/grammar-type-checker/src/lib.rs
+++ b/code/packages/rust/grammar-type-checker/src/lib.rs
@@ -321,7 +321,7 @@ mod tests {
             line: 1,
             column: 1,
             type_name: None,
-            flags: None,
+            flags: None, cv: None,
         };
         GrammarASTNode {
             rule_name: rule.to_owned(),

--- a/code/packages/rust/grammar-wasm-support/src/lib.rs
+++ b/code/packages/rust/grammar-wasm-support/src/lib.rs
@@ -78,7 +78,7 @@ mod tests {
             line: 1,
             column: 1,
             type_name: Some("NAME".to_string()),
-            flags: None,
+            flags: None, cv: None,
         }])
         .unwrap();
 
@@ -96,7 +96,7 @@ mod tests {
                 line: 1,
                 column: 1,
                 type_name: Some("NAME".to_string()),
-                flags: None,
+                flags: None, cv: None,
             })],
             start_line: Some(1),
             start_column: Some(1),

--- a/code/packages/rust/javascript-parser/CHANGELOG.md
+++ b/code/packages/rust/javascript-parser/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the `coding-adventures-javascript-parser` crate will be documented in this file.
 
+## [0.19.1] - 2026-06-29
+
+### Changed — adapt to `lexer::Token` gaining a `cv` field (CLOC27 P1)
+
+The synthetic ASI semicolon (`asi::synthetic_semicolon`) now sets `cv: None` on
+the `Token` it builds — correct, since an ASI-inserted token corresponds to no
+source bytes and so carries no correlation-vector id. Mechanical adaptation to
+`lexer` 0.7.0; no behaviour change (all 82 tests pass unchanged).
+
 ## [0.19.0] - 2026-06-22
 
 ### Added — ASI Phase 3: restricted productions (Rule 3)

--- a/code/packages/rust/javascript-parser/Cargo.toml
+++ b/code/packages/rust/javascript-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-javascript-parser"
-version = "0.19.0"
+version = "0.19.1"
 edition = "2021"
 description = "JavaScript parser — parses JavaScript source code against any ECMAScript edition (es1 through es2025) using the grammar-driven parser. Includes correlation-vector plumbing per CLOC03 and a typed-AST bridge (GrammarASTNode → javascript_ast::Program) per CLOC12.136."
 

--- a/code/packages/rust/javascript-parser/src/asi.rs
+++ b/code/packages/rust/javascript-parser/src/asi.rs
@@ -292,6 +292,9 @@ fn synthetic_semicolon(offending: &Token) -> Token {
         column: offending.column,
         type_name: Some("SEMICOLON".to_string()),
         flags: None,
+        // Synthetic (ASI-inserted) token: it corresponds to no source bytes, so
+        // it carries no correlation-vector id.
+        cv: None,
     }
 }
 

--- a/code/packages/rust/lattice-ast-to-css/src/emitter.rs
+++ b/code/packages/rust/lattice-ast-to-css/src/emitter.rs
@@ -678,7 +678,7 @@ mod tests {
     fn make_ident_token(value: &str) -> ASTNodeOrToken {
         ASTNodeOrToken::Token(Token {
             type_: lexer::token::TokenType::Name,
-            type_name: None, flags: None,
+            type_name: None, flags: None, cv: None,
             value: value.to_string(),
             line: 0,
             column: 0,
@@ -688,7 +688,7 @@ mod tests {
     fn make_named_token(type_name: &str, value: &str) -> ASTNodeOrToken {
         ASTNodeOrToken::Token(Token {
             type_: lexer::token::TokenType::Name,
-            type_name: Some(type_name.to_string()), flags: None,
+            type_name: Some(type_name.to_string()), flags: None, cv: None,
             value: value.to_string(),
             line: 0,
             column: 0,
@@ -715,7 +715,7 @@ mod tests {
         let prop = make_token_node("property", vec![make_ident_token("color")]);
         let val_token = ASTNodeOrToken::Token(Token {
             type_: lexer::token::TokenType::Name,
-            type_name: None, flags: None,
+            type_name: None, flags: None, cv: None,
             value: "red".to_string(),
             line: 0, column: 0,
         });
@@ -740,7 +740,7 @@ mod tests {
         let prop = make_token_node("property", vec![make_ident_token("color")]);
         let val_token = ASTNodeOrToken::Token(Token {
             type_: lexer::token::TokenType::Name,
-            type_name: None, flags: None,
+            type_name: None, flags: None, cv: None,
             value: "red".to_string(),
             line: 0, column: 0,
         });
@@ -764,7 +764,7 @@ mod tests {
         // class_selector = DOT IDENT
         let dot = ASTNodeOrToken::Token(Token {
             type_: lexer::token::TokenType::Dot,
-            type_name: None, flags: None,
+            type_name: None, flags: None, cv: None,
             value: ".".to_string(),
             line: 0, column: 0,
         });
@@ -791,7 +791,7 @@ mod tests {
         // @import url("style.css");
         let at_node = ASTNodeOrToken::Token(Token {
             type_: lexer::token::TokenType::Name,
-            type_name: Some("AT_KEYWORD".to_string()), flags: None,
+            type_name: Some("AT_KEYWORD".to_string()), flags: None, cv: None,
             value: "@import".to_string(),
             line: 0, column: 0,
         });
@@ -800,7 +800,7 @@ mod tests {
         let prelude = make_token_node("at_prelude", vec![ASTNodeOrToken::Node(prelude_token)]);
         let semicolon = ASTNodeOrToken::Token(Token {
             type_: lexer::token::TokenType::Semicolon,
-            type_name: None, flags: None,
+            type_name: None, flags: None, cv: None,
             value: ";".to_string(),
             line: 0, column: 0,
         });

--- a/code/packages/rust/lattice-ast-to-css/src/transformer.rs
+++ b/code/packages/rust/lattice-ast-to-css/src/transformer.rs
@@ -932,13 +932,13 @@ impl LatticeTransformer {
                             // Add comma + new selector tokens
                             n.children.push(ASTNodeOrToken::Token(Token {
                                 type_: TokenType::Name,
-                                type_name: Some("Comma".to_string()), flags: None,
+                                type_name: Some("Comma".to_string()), flags: None, cv: None,
                                 value: ",".to_string(),
                                 line: 0, column: 0,
                             }));
                             n.children.push(ASTNodeOrToken::Token(Token {
                                 type_: TokenType::Name,
-                                type_name: None, flags: None,
+                                type_name: None, flags: None, cv: None,
                                 value: format!(" {}", sel),
                                 line: 0, column: 0,
                             }));
@@ -2352,7 +2352,7 @@ pub fn make_synthetic_token(value: &str, template: &Token) -> Token {
         value: value.to_string(),
         line: template.line,
         column: template.column,
-        flags: None,
+        flags: None, cv: None,
     }
 }
 
@@ -2361,7 +2361,7 @@ pub fn make_value_node(value: &str, _template: &GrammarASTNode) -> GrammarASTNod
     // Find a template token for position info
     let template_token = Token {
         type_: TokenType::Name,
-        type_name: None, flags: None,
+        type_name: None, flags: None, cv: None,
         value: value.to_string(),
         line: 0,
         column: 0,

--- a/code/packages/rust/lexer/CHANGELOG.md
+++ b/code/packages/rust/lexer/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.7.0] — 2026-06-29 — `Token` carries an optional correlation-vector id (CLOC27 P1)
+
+`Token` gains a `pub cv: Option<String>` field — the correlation-vector id of
+the source token, defaulting to `None`. This is the first slice of CLOC27
+(per-fold CV provenance): the CV-aware tokenizer will populate it so the id can
+ride the token through the parser into the typed AST, where the bridge stamps it
+onto leaf literals — letting an optimizer fold trace its output back to source
+bytes.
+
+No behaviour change: every construction site sets `cv: None`, so a token with no
+id behaves exactly as before, and nothing reads the field yet. The id is a plain
+`String` (not the `CvId` alias) so this low-level crate takes on no dependency on
+`correlation-vector`. All 131 lexer tests pass unchanged.
+
 ## [0.6.0] — 2026-06-21 — `GrammarLexer` sets `TOKEN_PRECEDED_BY_NEWLINE`
 
 `GrammarLexer` now sets the `TOKEN_PRECEDED_BY_NEWLINE` flag on a token when a

--- a/code/packages/rust/lexer/Cargo.toml
+++ b/code/packages/rust/lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lexer"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 description = "Two lexer implementations — a hand-written Python tokenizer and a grammar-driven universal lexer that tokenizes any language from a TokenGrammar specification"
 

--- a/code/packages/rust/lexer/src/grammar_lexer.rs
+++ b/code/packages/rust/lexer/src/grammar_lexer.rs
@@ -1168,7 +1168,7 @@ impl<'a> GrammarLexer<'a> {
 
             // --- Newlines ---
             if ch == '\n' {
-                tokens.push(Token {
+                tokens.push(Token { cv: None,
                     type_: TokenType::Newline,
                     value: "\\n".to_string(),
                     line: self.line,
@@ -1276,7 +1276,7 @@ impl<'a> GrammarLexer<'a> {
                 self.newline_before_next = false;
                 let flags = if flag_bits == 0 { None } else { Some(flag_bits) };
 
-                let token = Token {
+                let token = Token { cv: None,
                     type_: token_type,
                     value: final_value,
                     line: start_line,
@@ -1399,7 +1399,7 @@ impl<'a> GrammarLexer<'a> {
             });
         }
 
-        tokens.push(Token {
+        tokens.push(Token { cv: None,
             type_: TokenType::Eof,
             value: String::new(),
             line: self.line,
@@ -1494,7 +1494,7 @@ impl<'a> GrammarLexer<'a> {
 
                 if spaces > current_indent {
                     indent_stack.push(spaces);
-                    tokens.push(Token {
+                    tokens.push(Token { cv: None,
                         type_: TokenType::Indent,
                         value: String::new(),
                         line: indent_line,
@@ -1505,7 +1505,7 @@ impl<'a> GrammarLexer<'a> {
                     // Emit DEDENT for each level we're leaving.
                     while indent_stack.len() > 1 && *indent_stack.last().unwrap() > spaces {
                         indent_stack.pop();
-                        tokens.push(Token {
+                        tokens.push(Token { cv: None,
                             type_: TokenType::Dedent,
                             value: String::new(),
                             line: indent_line,
@@ -1543,7 +1543,7 @@ impl<'a> GrammarLexer<'a> {
             // --- Newlines ---
             if ch == '\n' {
                 if bracket_depth == 0 {
-                    tokens.push(Token {
+                    tokens.push(Token { cv: None,
                         type_: TokenType::Newline,
                         value: "\\n".to_string(),
                         line: self.line,
@@ -1598,7 +1598,7 @@ impl<'a> GrammarLexer<'a> {
                     matched.clone()
                 };
 
-                tokens.push(Token {
+                tokens.push(Token { cv: None,
                     type_: token_type,
                     value: final_value,
                     line: start_line,
@@ -1624,7 +1624,7 @@ impl<'a> GrammarLexer<'a> {
             // Emit a final NEWLINE if the last token isn't one.
             let need_newline = tokens.last().map_or(false, |t| t.type_ != TokenType::Newline);
             if need_newline {
-                tokens.push(Token {
+                tokens.push(Token { cv: None,
                     type_: TokenType::Newline,
                     value: "\\n".to_string(),
                     line: self.line,
@@ -1635,7 +1635,7 @@ impl<'a> GrammarLexer<'a> {
 
             while indent_stack.len() > 1 {
                 indent_stack.pop();
-                tokens.push(Token {
+                tokens.push(Token { cv: None,
                     type_: TokenType::Dedent,
                     value: String::new(),
                     line: self.line,
@@ -1645,7 +1645,7 @@ impl<'a> GrammarLexer<'a> {
             }
         }
 
-        tokens.push(Token {
+        tokens.push(Token { cv: None,
             type_: TokenType::Eof,
             value: String::new(),
             line: self.line,
@@ -1763,7 +1763,7 @@ impl<'a> GrammarLexer<'a> {
     }
 
     fn virtual_layout_token(&self, type_name: &str, value: &str, anchor: &Token) -> Token {
-        Token {
+        Token { cv: None,
             type_: TokenType::Name,
             value: value.to_string(),
             line: anchor.line,
@@ -2483,7 +2483,7 @@ PLUS = "+""#,
             bracket_depths: BracketDepths::default(),
             current_token_line: 1,
         };
-        let synthetic = Token {
+        let synthetic = Token { cv: None,
             type_: TokenType::Name,
             value: "!".to_string(),
             line: 1,
@@ -2746,7 +2746,7 @@ PLUS = "+""#,
         let mut lexer = GrammarLexer::new("<hello", &grammar);
         lexer.set_on_token(Some(Box::new(|token: &Token, ctx: &mut LexerContext| {
             if token.type_name.as_deref() == Some("OPEN_TAG") {
-                ctx.emit(Token {
+                ctx.emit(Token { cv: None,
                     type_: TokenType::Name,
                     value: "[start]".to_string(),
                     line: token.line,
@@ -2777,7 +2777,7 @@ PLUS = "+""#,
         lexer.set_on_token(Some(Box::new(|token: &Token, ctx: &mut LexerContext| {
             if token.type_name.as_deref() == Some("OPEN_TAG") {
                 ctx.suppress();
-                ctx.emit(Token {
+                ctx.emit(Token { cv: None,
                     type_: TokenType::Name,
                     value: "<".to_string(),
                     line: token.line,

--- a/code/packages/rust/lexer/src/token.rs
+++ b/code/packages/rust/lexer/src/token.rs
@@ -307,6 +307,20 @@ pub struct Token {
     /// let is_context_kw = token.flags.unwrap_or(0) & TOKEN_CONTEXT_KEYWORD != 0;
     /// ```
     pub flags: Option<u32>,
+
+    /// Optional correlation-vector id for this token (CLOC03 / CLOC27).
+    ///
+    /// The CV-aware tokenizer mints one `CvId` per token, recording the source
+    /// `Origin` (file, line, column). That id is stored here so it can ride the
+    /// token through the parser and into the typed AST, where the bridge stamps
+    /// it onto leaf literals — letting an optimizer fold (`"abc".length` → `3`)
+    /// trace the folded literal back to the bytes it came from.
+    ///
+    /// `None` on the non-CV path (the common, zero-overhead case): a token with
+    /// no id produces an AST leaf with no id, exactly as before. The id is a
+    /// plain `String` (the `CvId` alias) so the low-level lexer needs no
+    /// dependency on the correlation-vector crate.
+    pub cv: Option<String>,
 }
 
 impl Token {
@@ -538,7 +552,7 @@ mod tests {
 
     #[test]
     fn test_token_display() {
-        let tok = Token {
+        let tok = Token { cv: None,
             type_: TokenType::Name,
             value: "x".to_string(),
             line: 1,
@@ -549,8 +563,35 @@ mod tests {
     }
 
     #[test]
+    fn test_token_cv_defaults_none_and_carries_id() {
+        // CLOC27 P1: the `cv` field defaults to `None` (the common, zero-overhead
+        // path) and can carry a correlation-vector id when the CV-aware tokenizer
+        // sets one. It does not affect equality of two otherwise-equal tokens'
+        // observable text/position — it is pure provenance metadata.
+        let plain = Token {
+            cv: None,
+            type_: TokenType::Number,
+            value: "42".to_string(),
+            line: 1,
+            column: 1,
+            type_name: None,
+            flags: None,
+        };
+        assert_eq!(plain.cv, None, "tokens carry no cv by default");
+
+        let traced = Token {
+            cv: Some("cv-7".to_string()),
+            ..plain.clone()
+        };
+        assert_eq!(traced.cv.as_deref(), Some("cv-7"));
+        // The id rides alongside the token; the rest is identical.
+        assert_eq!(traced.value, plain.value);
+        assert_eq!((traced.line, traced.column), (plain.line, plain.column));
+    }
+
+    #[test]
     fn test_token_display_string_with_escape() {
-        let tok = Token {
+        let tok = Token { cv: None,
             type_: TokenType::String,
             value: "hello\nworld".to_string(),
             line: 3,
@@ -568,14 +609,14 @@ mod tests {
 
     #[test]
     fn test_token_equality() {
-        let a = Token {
+        let a = Token { cv: None,
             type_: TokenType::Number,
             value: "42".to_string(),
             line: 1,
             column: 1,
             type_name: None, flags: None,
         };
-        let b = Token {
+        let b = Token { cv: None,
             type_: TokenType::Number,
             value: "42".to_string(),
             line: 1,
@@ -587,14 +628,14 @@ mod tests {
 
     #[test]
     fn test_token_inequality_type() {
-        let a = Token {
+        let a = Token { cv: None,
             type_: TokenType::Number,
             value: "42".to_string(),
             line: 1,
             column: 1,
             type_name: None, flags: None,
         };
-        let b = Token {
+        let b = Token { cv: None,
             type_: TokenType::Name,
             value: "42".to_string(),
             line: 1,
@@ -639,7 +680,7 @@ mod tests {
 
     #[test]
     fn test_token_clone() {
-        let original = Token {
+        let original = Token { cv: None,
             type_: TokenType::Keyword,
             value: "if".to_string(),
             line: 10,

--- a/code/packages/rust/lexer/src/tokenizer.rs
+++ b/code/packages/rust/lexer/src/tokenizer.rs
@@ -276,7 +276,7 @@ impl<'a> Lexer<'a> {
             }
         }
 
-        Token {
+        Token { cv: None,
             type_: TokenType::Number,
             value,
             line: start_line,
@@ -318,7 +318,7 @@ impl<'a> Lexer<'a> {
             TokenType::Name
         };
 
-        Token {
+        Token { cv: None,
             type_,
             value,
             line: start_line,
@@ -411,7 +411,7 @@ impl<'a> Lexer<'a> {
             }
         }
 
-        Ok(Token {
+        Ok(Token { cv: None,
             type_: TokenType::String,
             value,
             line: start_line,
@@ -466,7 +466,7 @@ impl<'a> Lexer<'a> {
                     self.skip_whitespace();
                 }
                 "at_newline" => {
-                    let tok = Token {
+                    let tok = Token { cv: None,
                         type_: TokenType::Newline,
                         value: "\\n".to_string(),
                         line: self.line,
@@ -492,7 +492,7 @@ impl<'a> Lexer<'a> {
 
                     if self.current_char() == Some('=') {
                         self.advance();
-                        tokens.push(Token {
+                        tokens.push(Token { cv: None,
                             type_: TokenType::EqualsEquals,
                             value: "==".to_string(),
                             line: start_line,
@@ -500,7 +500,7 @@ impl<'a> Lexer<'a> {
                             type_name: None, flags: None,
                         });
                     } else {
-                        tokens.push(Token {
+                        tokens.push(Token { cv: None,
                             type_: TokenType::Equals,
                             value: "=".to_string(),
                             line: start_line,
@@ -513,7 +513,7 @@ impl<'a> Lexer<'a> {
                     let c = ch.expect("char must exist for in_operator");
                     let token_type =
                         simple_token_type(c).expect("char must be a simple token");
-                    let tok = Token {
+                    let tok = Token { cv: None,
                         type_: token_type,
                         value: c.to_string(),
                         line: self.line,
@@ -545,7 +545,7 @@ impl<'a> Lexer<'a> {
         }
 
         // Every token stream ends with EOF.
-        tokens.push(Token {
+        tokens.push(Token { cv: None,
             type_: TokenType::Eof,
             value: String::new(),
             line: self.line,

--- a/code/packages/rust/parser/CHANGELOG.md
+++ b/code/packages/rust/parser/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the `parser` crate will be documented in this file.
 
+## [0.3.1] - 2026-06-29
+
+### Changed — adapt to `lexer::Token` gaining a `cv` field (CLOC27 P1)
+
+`GrammarParser` and `Parser` internal `Token` construction (including test
+helpers) now set `cv: None`. Mechanical adaptation to `lexer` 0.7.0; no public
+API or behaviour change (all parser tests pass unchanged). Also reconciles the
+crate version with this changelog's numbering.
+
 ## [0.3.0] - 2026-04-04
 
 ### Added

--- a/code/packages/rust/parser/Cargo.toml
+++ b/code/packages/rust/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parser"
-version = "0.1.0"
+version = "0.3.1"
 edition = "2021"
 description = "Two parser implementations — a hand-written recursive descent parser for a Python subset, and a grammar-driven universal parser that parses any language from a ParserGrammar specification"
 

--- a/code/packages/rust/parser/src/grammar_parser.rs
+++ b/code/packages/rust/parser/src/grammar_parser.rs
@@ -237,8 +237,8 @@ impl GrammarParser {
     ///
     /// let grammar = parse_parser_grammar("value = NUMBER ;").unwrap();
     /// let tokens = vec![
-    ///     Token { type_: TokenType::Number, value: "42".into(), line: 1, column: 1, type_name: None, flags: None },
-    ///     Token { type_: TokenType::Eof,    value: "".into(),   line: 1, column: 3, type_name: None, flags: None },
+    ///     Token { cv: None, type_: TokenType::Number, value: "42".into(), line: 1, column: 1, type_name: None, flags: None },
+    ///     Token { cv: None, type_: TokenType::Eof,    value: "".into(),   line: 1, column: 3, type_name: None, flags: None },
     /// ];
     /// let mut parser = GrammarParser::new_with_trace(tokens, grammar, true);
     /// let result = parser.parse();
@@ -1016,7 +1016,7 @@ mod tests {
 
     /// Helper: create a token with default position.
     fn tok(type_: TokenType, value: &str) -> Token {
-        Token {
+        Token { cv: None,
             type_,
             value: value.to_string(),
             line: 1,
@@ -1027,7 +1027,7 @@ mod tests {
 
     /// Helper: create a token with a string type name.
     fn tok_named(type_: TokenType, value: &str, type_name: &str) -> Token {
-        Token {
+        Token { cv: None,
             type_,
             value: value.to_string(),
             line: 1,

--- a/code/packages/rust/parser/src/parser.rs
+++ b/code/packages/rust/parser/src/parser.rs
@@ -472,7 +472,7 @@ mod tests {
 
     /// Helper: create a token with default position (line 1, column 1).
     fn tok(type_: TokenType, value: &str) -> Token {
-        Token {
+        Token { cv: None,
             type_,
             value: value.to_string(),
             line: 1,
@@ -483,7 +483,7 @@ mod tests {
 
     /// Helper: create a token with specific position.
     fn tok_at(type_: TokenType, value: &str, line: usize, col: usize) -> Token {
-        Token {
+        Token { cv: None,
             type_,
             value: value.to_string(),
             line,

--- a/code/packages/rust/ruby-lexer/src/lib.rs
+++ b/code/packages/rust/ruby-lexer/src/lib.rs
@@ -406,7 +406,7 @@ impl RubyLexer {
                 line,
                 column,
                 type_name: None,
-                flags: None,
+                flags: None, cv: None,
             };
         }
     }
@@ -596,7 +596,7 @@ impl RubyLexer {
                     line: span_line,
                     column: span_col,
                     type_name: None,
-                    flags: None,
+                    flags: None, cv: None,
                 };
             }
             i += 1;
@@ -680,7 +680,7 @@ impl RubyLexer {
                     line: span_line,
                     column: span_col,
                     type_name: None,
-                    flags: None,
+                    flags: None, cv: None,
                 };
                 // Don't advance i — the scientific-notation suffix
                 // (if any) may follow.
@@ -724,7 +724,7 @@ impl RubyLexer {
                     line: span_line,
                     column: span_col,
                     type_name: None,
-                    flags: None,
+                    flags: None, cv: None,
                 };
                 // Don't advance — the signed-exponent step below
                 // might still match (unlikely but harmless).
@@ -794,7 +794,7 @@ impl RubyLexer {
                     line: span_line,
                     column: span_col,
                     type_name: None,
-                    flags: None,
+                    flags: None, cv: None,
                 };
             } else {
                 i += 1;
@@ -878,7 +878,7 @@ impl RubyLexer {
                         line: span_line,
                         column: span_col,
                         type_name: None,
-                        flags: None,
+                        flags: None, cv: None,
                     };
                     // Don't advance — three-`>` sequences (e.g. `a>>>b`,
                     // which is illegal in Ruby anyway) get correctly
@@ -985,7 +985,7 @@ impl RubyLexer {
                     line: span_line,
                     column: span_col,
                     type_name: None,
-                    flags: None,
+                    flags: None, cv: None,
                 };
                 // Don't advance — chained compounds are illegal but
                 // the next iteration's guard will handle it cleanly.
@@ -1128,7 +1128,7 @@ impl RubyLexer {
                     line: span_line,
                     column: span_col,
                     type_name: None,
-                    flags: None,
+                    flags: None, cv: None,
                 };
             }
             i += 1;
@@ -1169,7 +1169,7 @@ impl RubyLexer {
                     line: span_line,
                     column: span_col,
                     type_name: None,
-                    flags: None,
+                    flags: None, cv: None,
                 };
             }
             i += 1;
@@ -1202,7 +1202,7 @@ impl RubyLexer {
                     line: span_line,
                     column: span_col,
                     type_name: None,
-                    flags: None,
+                    flags: None, cv: None,
                 };
             }
             i += 1;
@@ -1297,7 +1297,7 @@ impl RubyLexer {
                     line: span_line,
                     column: span_col,
                     type_name: None,
-                    flags: None,
+                    flags: None, cv: None,
                 };
             }
             i += 1;
@@ -1353,7 +1353,7 @@ impl RubyLexer {
                     line: span_line,
                     column: span_col,
                     type_name: None,
-                    flags: None,
+                    flags: None, cv: None,
                 };
             }
             i += 1;
@@ -1740,7 +1740,7 @@ impl RubyLexer {
             line: self.token_start_line,
             column: self.token_start_column,
             type_name: None,
-            flags: None,
+            flags: None, cv: None,
         });
         self.whitespace_before_token.push(had_ws);
         // Reset start position so the next immediate-emit token


### PR DESCRIPTION
## What

First implementation slice of [CLOC27](code/specs/CLOC27-per-fold-cv-provenance.md) — per-fold CV provenance, the project's headline **tracing** differentiator. Adds `pub cv: Option<String>` to `lexer::token::Token`: the source token's correlation-vector id, defaulting to `None`.

## Why (the plumbing problem this unblocks)

The CV-aware tokenizer (CLOC03) already mints a `CvId` per token, but it's stripped before the parser, and typed-AST leaf literals carry `cv: None` — so a folded literal (e.g. `"abc".length` → `3`) can't be traced back to its source bytes (the gap pinned by #6913). Carrying the id **on the token** lets it ride through the parser into the typed AST, where a later slice (P3) stamps it onto leaf literals in the bridge — **without** threading a `CVLog` through the ~51 `convert_*` bridge functions.

## Scope — P1 only, zero behaviour change

- The field is added; **nothing reads it yet**.
- Every construction site sets `cv: None` — 45 struct-literal sites across `lexer` (token.rs / tokenizer.rs / grammar_lexer.rs) + `parser` (grammar_parser.rs / parser.rs), plus the synthetic ASI semicolon in `javascript-parser` (correctly `None` — an inserted token has no source bytes).
- The id is a plain `String` (not the `CvId` alias) so the low-level `lexer` takes on **no dependency** on `correlation-vector`.

A token with `cv: None` produces the same AST and the same emitted output as before. **Verified green with no changes to expectations:** lexer 132, parser 38, javascript-parser 82, full closurec suite. New `test_token_cv_defaults_none_and_carries_id` documents the field. Security review passed (purely additive inert metadata, no readers, no `unsafe`).

## Versions
- `lexer` 0.6.0 → 0.7.0 (new public field)
- `javascript-parser` 0.19.0 → 0.19.1 (adapt synthetic token)
- `parser` 0.1.0 → 0.3.1 (adapt ctors; also reconciles its Cargo version with its CHANGELOG numbering)

## Next (CLOC27 P2–P5)
Stop stripping the id before the parser + a CV-carrying typed parse → stamp the leaf in `convert_primary_token` → wire the run's CVLog on the SIMPLE path → golden trace test that flips #6913's gap assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)