### PR TITLE
feat(asciimath): PR-2 breadth — matrices + big operators

### DIFF
--- a/code/packages/rust/asciimath/CHANGELOG.md
+++ b/code/packages/rust/asciimath/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to the AsciiMath pluggable frontend.
 
+## [0.2.0] — 2026-06-29
+
+### Added — ASM01 PR-2: breadth (matrices + big operators)
+
+- **Matrices** `[[a,b],[c,d]]` (rows may use `[…]` or `(…)`) → `MathExpr::Matrix(rows)`, cells
+  parsed as full expressions in source order. Disambiguated from nested grouping: `((a))` and
+  `[[a]]` remain *grouping* (a 1×1 single-cell shape is not a matrix); a real matrix has ≥2 rows
+  or a row with ≥2 cells (i.e. it genuinely uses commas). Ragged rows are rejected (clean spanned
+  error, no panic). `det[[a,b],[c,d]]` binds the matrix as the function argument.
+- **Big operators** `sum`, `prod`, `int`, `oint`, `coprod`, `lim` → `MathExpr::BigOp{op,lower,upper,body}`.
+  Optional `_`/`^` bounds attach to the operator (either order, each at most once); the body is the
+  next atom (`sum_(i=1)^n i` ⇒ BigOp over `i`), the same one-atom convention used by `sqrt`/functions.
+- New `Comma` token (cell/row separator); outside a matrix it yields a clean error, never a panic.
+- `capabilities()` now declares `matrices` + `big_operators` (verified by the shared conformance
+  harness against new matrix/big-op examples). **Accents stay out** — the neutral `MathExpr` has no
+  `Accent` node yet; adding one to `math-frontend` is a prerequisite for an accents PR.
+- Safety: matrix nesting charges the parser's `MAX_DEPTH` (a 3000-deep nested matrix returns a
+  spanned error, not a stack overflow); matrix-vs-group is decided by a two-token lookahead —
+  single-pass and committed, **no backtracking** — so deep `(((…` input stays linear (no
+  exponential re-parse) and fails cleanly at the depth cap.
+- Tests: 2×2 / row-vector / paren-row matrices, `det` of a matrix, grouping-not-matrix cases,
+  ragged-row error, `sum`/`int`/`prod` with/without bounds and either bound order, comma token,
+  deep-matrix overflow guard; conformance examples extended.
+
 ## [0.1.0] — 2026-06-28
 
 ### Added — ASM01 PR-1: the AsciiMath frontend (core subset)

--- a/code/packages/rust/asciimath/Cargo.toml
+++ b/code/packages/rust/asciimath/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "asciimath"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "An AsciiMath parser that implements the math-frontend MathFrontend trait: turns AsciiMath (1/2, sqrt(x), x^2+y^2=r^2) into the neutral MathExpr AST. The second pluggable frontend after LaTeX (see ASM01/PFE01). Total, panic-free, spanned errors."
 license = "MIT"

--- a/code/packages/rust/asciimath/README.md
+++ b/code/packages/rust/asciimath/README.md
@@ -42,10 +42,24 @@ second notation.
 | `( .. )`, `[ .. ]`, `{ .. }` | `Group` |
 | `"kg"` (text literal) | `Text` |
 
+## PR-2 breadth (matrices + big operators)
+
+| AsciiMath | → neutral `MathExpr` |
+|-----------|----------------------|
+| `[[a,b],[c,d]]`, `((1,0),(0,1))` | `Matrix(rows)` (rows of full-expression cells; `[…]` or `(…)` rows) |
+| `[[a,b,c]]` | `Matrix` 1×3 (row vector) |
+| `det[[a,b],[c,d]]` | `Call { func: Det, arg: Matrix(..) }` |
+| `sum_(i=1)^n i`, `int_a^b f`, `prod x`, `lim_(x->0) f` | `BigOp { op, lower, upper, body }` |
+
+`((a))` and `[[a]]` stay **grouping**, not a 1×1 matrix — a matrix must genuinely use commas
+(≥2 rows, or a row with ≥2 cells). Big-operator bounds (`_`/`^`) attach to the operator in either
+order; the body is the next atom (same convention as `sqrt`/functions). **Accents** (`hat x`, `vec x`)
+are not yet supported: the neutral `MathExpr` has no `Accent` node, so adding one to `math-frontend`
+is a prerequisite for an accents PR (see ASM01 §5).
+
 It is **total and panic-free**: every input returns `Ok(MathExpr)` or a spanned
-`FrontendError`. Recursion is depth-guarded; left-associative chains are built with loops, so
-neither deep nesting nor long chains overflow the parser. Later PRs add matrices, big
-operators (`sum`/`prod`/`int`), accents, and the full symbol table (see ASM01 §5).
+`FrontendError`. Recursion is depth-guarded (matrix nesting included); left-associative chains are
+built with loops, so neither deep nesting nor long chains overflow the parser.
 
 ## Usage
 

--- a/code/packages/rust/asciimath/src/lib.rs
+++ b/code/packages/rust/asciimath/src/lib.rs
@@ -57,8 +57,9 @@ impl MathFrontend for AsciiMath {
     }
 
     fn capabilities(&self) -> Capabilities {
-        // Exactly the PR-1 surface. `matrices` and `big_operators` stay off until PR-2;
-        // `plusminus`/`binomials` are not part of AsciiMath's core spelling here. Declaring
+        // PR-1 surface + PR-2 breadth (`matrices`, `big_operators`). `plusminus`/`binomials`
+        // are not part of AsciiMath's core spelling here, and there is no neutral `Accent`
+        // node yet, so accents stay out until math-frontend grows one. Declaring
         // `implicit_mul` is a parser-behavior claim (juxtaposition ⇒ `Mul`) the goldens cover.
         Capabilities::none()
             .with_fractions()
@@ -68,6 +69,8 @@ impl MathFrontend for AsciiMath {
             .with_relations()
             .with_implicit_mul()
             .with_text()
+            .with_matrices()
+            .with_big_operators()
     }
 }
 
@@ -174,10 +177,95 @@ mod tests {
         assert_eq!(p("x^2 + y^2 = r^2"), MathExpr::Rel(RelOp::Eq, Box::new(lhs), Box::new(rhs)));
     }
 
+    // ---- PR-2: matrices --------------------------------------------------------
+    #[test]
+    fn matrix_two_by_two() {
+        // [[a,b],[c,d]] ⇒ Matrix rows of cells, in source order.
+        assert_eq!(
+            p("[[a,b],[c,d]]"),
+            MathExpr::Matrix(vec![vec![sym("a"), sym("b")], vec![sym("c"), sym("d")]])
+        );
+    }
+
+    #[test]
+    fn matrix_cells_are_full_expressions_and_rows_may_use_parens() {
+        // Cells parse as full expressions; `(…)` rows are accepted too.
+        assert_eq!(
+            p("((1,x^2),(a+b,0))"),
+            MathExpr::Matrix(vec![
+                vec![num(1), b(BinOp::Pow, sym("x"), num(2))],
+                vec![b(BinOp::Add, sym("a"), sym("b")), num(0)],
+            ])
+        );
+        // A single row with several cells is a 1×n matrix (row vector).
+        assert_eq!(p("[[a,b,c]]"), MathExpr::Matrix(vec![vec![sym("a"), sym("b"), sym("c")]]));
+    }
+
+    #[test]
+    fn nested_brackets_without_commas_are_grouping_not_a_matrix() {
+        // `((a))` and `[[a]]` are double grouping, NOT a 1×1 matrix.
+        assert_eq!(p("((a))"), sym("a"));
+        assert_eq!(p("[[a]]"), sym("a"));
+        // ragged rows are not a matrix → falls back to a group parse, which errors cleanly.
+        assert!(AsciiMath.parse("[[a,b],[c]]").is_err());
+    }
+
+    #[test]
+    fn det_of_a_matrix() {
+        // det binds the matrix as its argument atom.
+        assert_eq!(
+            p("det[[a,b],[c,d]]"),
+            MathExpr::Call {
+                func: Func::Det,
+                arg: Box::new(MathExpr::Matrix(vec![
+                    vec![sym("a"), sym("b")],
+                    vec![sym("c"), sym("d")],
+                ])),
+            }
+        );
+    }
+
+    // ---- PR-2: big operators ---------------------------------------------------
+    #[test]
+    fn sum_with_both_bounds() {
+        // sum_(i=1)^n i ⇒ BigOp{Sum, lower:(i=1), upper:n, body:i}
+        let lower = MathExpr::Rel(RelOp::Eq, Box::new(sym("i")), Box::new(num(1)));
+        assert_eq!(
+            p("sum_(i=1)^n i"),
+            MathExpr::BigOp {
+                op: BigOp::Sum,
+                lower: Some(Box::new(lower)),
+                upper: Some(Box::new(sym("n"))),
+                body: Box::new(sym("i")),
+            }
+        );
+    }
+
+    #[test]
+    fn integral_and_bare_and_either_order() {
+        // int_a^b f — body is the next atom.
+        assert_eq!(
+            p("int_a^b f"),
+            MathExpr::BigOp {
+                op: BigOp::Int,
+                lower: Some(Box::new(sym("a"))),
+                upper: Some(Box::new(sym("b"))),
+                body: Box::new(sym("f")),
+            }
+        );
+        // prod with no bounds.
+        assert_eq!(
+            p("prod x"),
+            MathExpr::BigOp { op: BigOp::Prod, lower: None, upper: None, body: Box::new(sym("x")) }
+        );
+        // superscript-before-subscript order is accepted and normalizes the same.
+        assert_eq!(p("sum^n_(i=1) i"), p("sum_(i=1)^n i"));
+    }
+
     // ---- totality / errors -----------------------------------------------------
     #[test]
     fn errors_are_spanned_never_panic() {
-        for bad in ["", "1 +", "(x", "a ! b", "\"oops", ")"] {
+        for bad in ["", "1 +", "(x", "a ! b", "\"oops", ")", "[[a,b],[c]]"] {
             let e = AsciiMath.parse(bad).expect_err(&format!("{bad:?} should error"));
             assert_eq!(e.frontend, "asciimath");
             assert!(e.span.0 <= e.span.1 && e.span.1 <= bad.len(), "bad span on {bad:?}: {:?}", e.span);
@@ -191,13 +279,27 @@ mod tests {
         assert!(AsciiMath.parse(&deep).is_err());
     }
 
+    #[test]
+    fn deeply_nested_matrices_error_not_overflow() {
+        // A matrix whose single cell is itself a matrix, nested thousands deep, must hit
+        // MAX_DEPTH and return a spanned error rather than overflowing the parser stack.
+        // Build [[ [[ … 1 … ]] ]]: each level wraps the prior in a 1×2 matrix (so it is a
+        // *real* matrix, not collapsed grouping) — `[[X,0]]`.
+        let mut s = String::from("1");
+        for _ in 0..3000 {
+            s = format!("[[{s},0]]");
+        }
+        assert!(AsciiMath.parse(&s).is_err());
+    }
+
     // ---- name / capabilities / conformance -------------------------------------
     #[test]
     fn name_and_capabilities_are_honest() {
         assert_eq!(AsciiMath.name(), "asciimath");
         let c = AsciiMath.capabilities();
         assert!(c.fractions && c.roots && c.powers && c.functions && c.relations && c.text && c.implicit_mul);
-        assert!(!c.matrices && !c.big_operators && !c.plusminus && !c.binomials);
+        assert!(c.matrices && c.big_operators); // PR-2 breadth
+        assert!(!c.plusminus && !c.binomials); // not part of AsciiMath's core spelling
     }
 
     #[test]
@@ -216,6 +318,9 @@ mod tests {
                 r#""kg""#,
                 "a <= b",
                 "(a + b)/(c - d)",
+                "[[a,b],[c,d]]",   // matrix
+                "sum_(i=1)^n i",   // big operator with bounds
+                "int_a^b f",       // big operator, integral
                 "1 +",   // error: trailing operator (span in range, not a panic)
                 "(x",    // error: missing close
                 "",      // error: empty

--- a/code/packages/rust/asciimath/src/parser.rs
+++ b/code/packages/rust/asciimath/src/parser.rs
@@ -23,7 +23,7 @@
 //!   for the math-frontend AST, not introduced here.)
 
 use crate::token::{tokenize, Token, TokenKind};
-use math_frontend::{BinOp, Func, FrontendError, MathExpr, Number, RelOp, UnaryOp};
+use math_frontend::{BigOp, BinOp, Func, FrontendError, MathExpr, Number, RelOp, UnaryOp};
 
 /// Maximum *nesting* depth before we refuse with a spanned error (never overflow).
 ///
@@ -55,6 +55,11 @@ impl Parser<'_> {
         // `tokenize` always appends Eof, so indexing the last token is safe; the fallback
         // keeps this total even if that invariant were ever violated.
         self.toks.get(self.pos).map(|t| &t.kind).unwrap_or(&TokenKind::Eof)
+    }
+
+    /// The token `n` positions ahead (0 == current). Used for the matrix two-token lookahead.
+    fn peek_nth(&self, n: usize) -> &TokenKind {
+        self.toks.get(self.pos + n).map(|t| &t.kind).unwrap_or(&TokenKind::Eof)
     }
 
     fn span_here(&self) -> (usize, usize) {
@@ -220,10 +225,79 @@ impl Parser<'_> {
                 self.advance();
                 Ok(MathExpr::Text(s))
             }
-            TokenKind::LParen | TokenKind::LBracket | TokenKind::LBrace => self.parse_group(),
+            TokenKind::LBracket | TokenKind::LParen => {
+                // Two-token lookahead decides matrix vs group *before* consuming anything, so
+                // the parse is single-pass (no backtracking). An outer bracket immediately
+                // followed by another opening bracket is the matrix shape `[[…` / `((…`;
+                // everything else is ordinary grouping. Committing here (rather than trying
+                // then backtracking) keeps cost linear: a deep run like `(((…` descends once,
+                // depth-charged, and fails cleanly at MAX_DEPTH instead of re-parsing
+                // exponentially.
+                if matches!(self.peek_nth(1), TokenKind::LBracket | TokenKind::LParen) {
+                    self.parse_matrix()
+                } else {
+                    self.parse_group()
+                }
+            }
+            TokenKind::LBrace => self.parse_group(),
             TokenKind::Ident(word) => self.parse_ident_atom(&word),
             _ => Err(self.error_here("expected a number, symbol, or '('")),
         }
+    }
+
+    /// Parse a matrix `[[a,b],[c,d]]` (rows may use `[…]` or `(…)`), positioned at the outer
+    /// opening bracket which is known to be followed by a row-opening bracket. Single-pass and
+    /// committed: a malformed shape returns a spanned error (never backtracks, never panics).
+    ///
+    /// Disambiguation from nested grouping: a 1×1 result (`((a))`, `[[a]]`) is *grouping* — the
+    /// single cell is returned unwrapped. A genuine matrix has ≥2 rows or a row with ≥2 cells.
+    fn parse_matrix(&mut self) -> Result<MathExpr, FrontendError> {
+        self.enter()?; // charge the matrix nesting level (paired exit below)
+        let result = self.parse_matrix_inner();
+        self.exit();
+        result
+    }
+
+    fn parse_matrix_inner(&mut self) -> Result<MathExpr, FrontendError> {
+        self.advance(); // outer opening bracket
+        let mut rows: Vec<Vec<MathExpr>> = Vec::new();
+        loop {
+            // Each outer item must itself be a bracketed row.
+            match self.peek() {
+                TokenKind::LBracket | TokenKind::LParen => self.advance(),
+                _ => return Err(self.error_here("expected a bracketed matrix row")),
+            }
+            let mut cells = vec![self.parse_relation()?];
+            while matches!(self.peek(), TokenKind::Comma) {
+                self.advance();
+                cells.push(self.parse_relation()?);
+            }
+            match self.peek() {
+                TokenKind::RBracket | TokenKind::RParen => self.advance(),
+                _ => return Err(self.error_here("expected a closing bracket for the matrix row")),
+            }
+            rows.push(cells);
+            match self.peek() {
+                TokenKind::Comma => {
+                    self.advance();
+                    continue;
+                }
+                TokenKind::RBracket | TokenKind::RParen => {
+                    self.advance(); // outer closing bracket
+                    break;
+                }
+                _ => return Err(self.error_here("expected ',' or a closing bracket in the matrix")),
+            }
+        }
+        let width = rows[0].len();
+        if rows.iter().any(|r| r.len() != width) {
+            return Err(self.error_here("matrix rows must all have the same length"));
+        }
+        if rows.len() == 1 && width == 1 {
+            // `((a))` / `[[a]]` is double grouping, not a 1×1 matrix — unwrap the single cell.
+            return Ok(rows.into_iter().next().and_then(|r| r.into_iter().next()).expect("1×1"));
+        }
+        Ok(MathExpr::Matrix(rows))
     }
 
     /// A bracketed group: parentheses are *grouping only* — the delimiter style is dropped
@@ -242,6 +316,31 @@ impl Parser<'_> {
     }
 
     fn parse_ident_atom(&mut self, word: &str) -> Result<MathExpr, FrontendError> {
+        // Big operator with optional bounds: `sum_(i=1)^n i`, `int_a^b f`, `lim_(x->0) f`.
+        // The bounds attach to the operator itself (consumed here, before parse_script sees
+        // any `_`/`^`); the body is the next single atom — the same "one atom argument"
+        // convention used by `sqrt`/functions (so `sum_(i=1)^n i + 1` is (sum … i) + 1).
+        if let Some(op) = bigop_of(word) {
+            self.advance();
+            let mut lower: Option<Box<MathExpr>> = None;
+            let mut upper: Option<Box<MathExpr>> = None;
+            // Accept `_`/`^` in either order, each at most once.
+            loop {
+                match self.peek() {
+                    TokenKind::Underscore if lower.is_none() => {
+                        self.advance();
+                        lower = Some(Box::new(self.parse_atom()?));
+                    }
+                    TokenKind::Caret if upper.is_none() => {
+                        self.advance();
+                        upper = Some(Box::new(self.parse_atom()?));
+                    }
+                    _ => break,
+                }
+            }
+            let body = self.parse_atom()?;
+            return Ok(MathExpr::BigOp { op, lower, upper, body: Box::new(body) });
+        }
         // Function application: `sin x`, `ln(x)` — the argument is the next atom.
         if let Some(func) = func_of(word) {
             self.advance();
@@ -302,6 +401,19 @@ fn rel_of(kind: &TokenKind) -> Option<RelOp> {
         TokenKind::Ge => RelOp::Ge,
         TokenKind::Approx => RelOp::Approx,
         TokenKind::Equiv => RelOp::Equiv,
+        _ => return None,
+    })
+}
+
+/// Map an identifier to a big operator, or `None`. `int`=∫, `oint`=∮, `prod`=∏, `coprod`=∐.
+fn bigop_of(word: &str) -> Option<BigOp> {
+    Some(match word {
+        "sum" => BigOp::Sum,
+        "prod" => BigOp::Prod,
+        "int" => BigOp::Int,
+        "oint" => BigOp::Oint,
+        "coprod" => BigOp::Coprod,
+        "lim" => BigOp::Lim,
         _ => return None,
     })
 }

--- a/code/packages/rust/asciimath/src/token.rs
+++ b/code/packages/rust/asciimath/src/token.rs
@@ -65,6 +65,9 @@ pub enum TokenKind {
     RBracket,
     LBrace,
     RBrace,
+    /// `,` — cell/row separator inside a matrix (`[[a,b],[c,d]]`). Outside a matrix the
+    /// parser has no use for it and reports a clean error, never a panic.
+    Comma,
     /// End of input (always the final token; zero-width span at the end).
     Eof,
 }
@@ -165,6 +168,7 @@ pub fn tokenize(src: &str) -> Result<Vec<Token>, FrontendError> {
             b']' => (TokenKind::RBracket, i + 1),
             b'{' => (TokenKind::LBrace, i + 1),
             b'}' => (TokenKind::RBrace, i + 1),
+            b',' => (TokenKind::Comma, i + 1),
             b'"' => {
                 // A text literal runs to the next double-quote.
                 let mut j = i + 1;
@@ -246,6 +250,13 @@ mod tests {
     #[test]
     fn text_literal() {
         assert_eq!(kinds(r#""kg" "#)[0], TokenKind::Text("kg".into()));
+    }
+
+    #[test]
+    fn comma_is_a_token() {
+        assert_eq!(kinds("a,b"), vec![
+            TokenKind::Ident("a".into()), TokenKind::Comma, TokenKind::Ident("b".into()), TokenKind::Eof,
+        ]);
     }
 
     #[test]

--- a/code/specs/ASM01-asciimath-frontend.md
+++ b/code/specs/ASM01-asciimath-frontend.md
@@ -80,8 +80,15 @@ actually emitted (no over-claiming). Notation-specific golden tests assert exact
 shapes for representative inputs.
 
 ## 5. Roadmap (later PRs)
-- **PR-2:** matrices `[[a,b],[c,d]]`; big operators `sum_(…)^(…)`, `prod`, `int`; accents
-  (`hat`, `vec`, `bar`); angle/invisible brackets `(: … :)`, `{: … :}`.
+- **PR-2 (shipped, v0.2.0):** matrices `[[a,b],[c,d]]` → `Matrix` (rows may use `[…]`/`(…)`;
+  `((a))`/`[[a]]` stay grouping — a matrix must use commas; ragged rows error cleanly;
+  `det[[…]]` binds the matrix); big operators `sum`/`prod`/`int`/`oint`/`coprod`/`lim` →
+  `BigOp{op,lower,upper,body}` (optional `_`/`^` bounds either order, body = next atom). A new
+  `Comma` token; `capabilities()` adds `matrices`+`big_operators`; matrix nesting is `MAX_DEPTH`-guarded.
+  **Accents deferred** — the neutral `MathExpr` has no `Accent` node; adding one to `math-frontend`
+  (with iterative-Drop + a `Capabilities::accents` flag) is the prerequisite, tracked as a follow-up.
+- **PR-2b (deferred):** accents (`hat`, `vec`, `bar`) once a neutral `Accent` node exists;
+  angle/invisible brackets `(: … :)`, `{: … :}`.
 - **PR-3:** the full AsciiMath symbol table (greek, arrows, set/logic ops), longest-match
   tokenization (so `sinx` splits as `sin`·`x`), `stackrel`, `overset`/`underset`, and the
   `text(…)` keyword form alongside the `"…"` literal.


### PR DESCRIPTION
## ASM01 PR-2 — AsciiMath breadth (pluggable frontend #2)

Extends the AsciiMath frontend from the PR-1 core to two breadth families, both lowering to **first-class neutral `MathExpr` nodes** (no shortcuts):

- **Matrices** `[[a,b],[c,d]]` (rows may use `[…]` or `(…)`) → `MathExpr::Matrix(rows)`, cells parsed as full expressions in source order; `det[[…]]` binds the matrix as its argument.
- **Big operators** `sum`/`prod`/`int`/`oint`/`coprod`/`lim` → `MathExpr::BigOp{op,lower,upper,body}`; optional `_`/`^` bounds attach to the operator (either order, each once), body = next atom (same one-atom convention as `sqrt`/functions).
- New `Comma` token (cell/row separator); outside a matrix it errors cleanly.
- `capabilities()` now declares `matrices` + `big_operators`, verified by the shared `check_frontend` conformance harness against new matrix/big-op examples.

### Disambiguation & safety
- Matrix-vs-group is decided by a **two-token lookahead — single-pass, committed, no backtracking**. `((a))`/`[[a]]` stay grouping (a 1×1 result unwraps); ragged rows error cleanly. A deep `(((…` run therefore stays **linear** and fails at `MAX_DEPTH` instead of re-parsing exponentially. *(An initial backtracking design was exponential on deep nesting — caught and replaced before merge by the 5000-paren and 3000-deep-matrix overflow-guard tests.)*
- Total / panic-free; every recursion point is depth-charged.

### Deferred (documented, not faked)
**Accents** (`hat x`, `vec x`) are out of scope: the neutral `MathExpr` has no `Accent` node. Adding one to `math-frontend` (node + iterative `Drop` + a `Capabilities::accents` flag) is the prerequisite, noted as a follow-up in ASM01 §5.

### Verification
27 unit + 1 doc test, all green in <1s; `cargo clippy -p asciimath` clean; branch synced with `origin/main` (no conflicts). Security review passed (DoS/recursion/panic/overflow classes all checked). `asciimath` 0.2.0; spec/README/CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)