### PR TITLE
Add smart home dashboard authorization principal filter

### DIFF
--- a/code/packages/rust/smart-home-platform-http/CHANGELOG.md
+++ b/code/packages/rust/smart-home-platform-http/CHANGELOG.md
@@ -71,6 +71,8 @@ All notable changes to this package will be documented in this file.
   inspecting runtime authorization boundaries.
 - Added a browser dashboard capability-grants panel with status, scope, and
   principal filters plus authorization-row links to active principal grants.
+- Added a browser dashboard authorization principal filter so decision-log
+  views can be scoped to one local API caller from the dashboard URL.
 - Added fixture-controller launch help, smoke-test URLs, and example-level tests
   to keep the local controller startup path usable.
 - Added a machine-readable local-controller smoke plan route that lists safe

--- a/code/packages/rust/smart-home-platform-http/README.md
+++ b/code/packages/rust/smart-home-platform-http/README.md
@@ -119,13 +119,13 @@ rows also link to their current state, registry detail, desired-state target,
 state history, entity-scoped runtime events, and owning bridge command-result
 audit trail. The browser shell also exposes filters for
 room, entity domain/state/control status, runtime event kind, command-result
-status, authorization outcome, capability-grant status/scope/principal, with
-server-backed room scoping across inventory, state, history, event-log, and
-command-result panels plus server-backed capability-grant scoping and local text
-search across the rendered dashboard rows. Those filter selections are mirrored
-into URL query parameters and restored on page load or browser navigation, so
-local-controller room, audit, and grant-boundary views can be shared or reopened
-directly.
+status, authorization outcome/principal, and capability-grant
+status/scope/principal, with server-backed room scoping across inventory, state,
+history, event-log, and command-result panels plus server-backed authorization
+and capability-grant scoping and local text search across the rendered dashboard
+rows. Those filter selections are mirrored into URL query parameters and
+restored on page load or browser navigation, so local-controller room, audit,
+and grant-boundary views can be shared or reopened directly.
 
 ## Dependencies
 

--- a/code/packages/rust/smart-home-platform-http/src/lib.rs
+++ b/code/packages/rust/smart-home-platform-http/src/lib.rs
@@ -405,6 +405,9 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
               <option value="denied">Denied</option>
             </select>
           </label>
+          <label>Auth Principal
+            <input id="filter-authorization-principal" data-dashboard-filter="authorization-principal" type="search" autocomplete="off">
+          </label>
           <label>Grant Status
             <select id="filter-grant-status" data-dashboard-filter="grant-status">
               <option value="">All grants</option>
@@ -559,6 +562,7 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
       entities: document.querySelector("#entities"),
       events: document.querySelector("#events"),
       filterAuthorizationOutcome: document.querySelector("#filter-authorization-outcome"),
+      filterAuthorizationPrincipal: document.querySelector("#filter-authorization-principal"),
       filterCommandStatus: document.querySelector("#filter-command-status"),
       filterControl: document.querySelector("#filter-control"),
       filterDomain: document.querySelector("#filter-domain"),
@@ -602,6 +606,7 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
       ["event_kind", els.filterEventKind],
       ["command_status", els.filterCommandStatus],
       ["authorization_outcome", els.filterAuthorizationOutcome],
+      ["authorization_principal", els.filterAuthorizationPrincipal],
       ["grant_status", els.filterGrantStatus],
       ["grant_scope", els.filterGrantScope],
       ["grant_principal", els.filterGrantPrincipal]
@@ -653,6 +658,7 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
       eventKind: els.filterEventKind.value,
       commandStatus: els.filterCommandStatus.value,
       authorizationOutcome: els.filterAuthorizationOutcome.value,
+      authorizationPrincipal: els.filterAuthorizationPrincipal.value.trim(),
       grantStatus: els.filterGrantStatus.value,
       grantScope: els.filterGrantScope.value,
       grantPrincipal: els.filterGrantPrincipal.value.trim()
@@ -1148,7 +1154,8 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
           })),
           json(queryUrl("/api/smart_home/authorization_decisions", {
             limit: 8,
-            outcome: filters.authorizationOutcome
+            outcome: filters.authorizationOutcome,
+            principal_id: filters.authorizationPrincipal
           })),
           json(queryUrl("/api/smart_home/capability_grants", {
             limit: 8,
@@ -9241,7 +9248,9 @@ mod tests {
         assert!(body.contains("data-dashboard-filter=\"grant-status\""));
         assert!(body.contains("data-dashboard-filter=\"grant-scope\""));
         assert!(body.contains("data-dashboard-filter=\"grant-principal\""));
+        assert!(body.contains("data-dashboard-filter=\"authorization-principal\""));
         assert!(body.contains("const FILTER_QUERY_PARAMS = ["));
+        assert!(body.contains("[\"authorization_principal\", els.filterAuthorizationPrincipal]"));
         assert!(body.contains("[\"grant_status\", els.filterGrantStatus]"));
         assert!(body.contains("window.addEventListener(\"popstate\""));
         assert!(body.contains("window.history.replaceState(null, \"\", nextUrl)"));
@@ -9256,6 +9265,7 @@ mod tests {
         assert!(body.contains("json(\"/api/smart_home/bridges?limit=8\")"));
         assert!(body.contains("queryUrl(\"/api/smart_home/command_results\", {"));
         assert!(body.contains("queryUrl(\"/api/smart_home/authorization_decisions\", {"));
+        assert!(body.contains("principal_id: filters.authorizationPrincipal"));
         assert!(body.contains("queryUrl(\"/api/smart_home/capability_grants\", {"));
         assert!(body.contains("id=\"detail-body\""));
         assert!(body.contains("renderDetail(label, url, response.status, response.ok, body)"));


### PR DESCRIPTION
## Summary
- add an Auth Principal dashboard filter backed by `/api/smart_home/authorization_decisions?principal_id=...`
- mirror and restore the authorization principal filter through dashboard URL query params
- document dashboard authorization principal scoping alongside capability-grant filters

## Validation
- `cargo fmt -p smart-home-platform-http`
- `cargo test -p smart-home-platform-http -- --nocapture`
- `sh BUILD` from `code/packages/rust/smart-home-platform-http`
- removed generated `code/packages/rust/Cargo.lock`
