### PR TITLE
[codex] Add Berkeley SPICE app artifacts

### DIFF
--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Add Berkeley SPICE app-deck result artifacts for Mosaic-facing Rust UI
+  substrates. `BerkeleyAppDeck::run_artifacts()` now exposes normalized source,
+  syntax-card-indexed result tables, output-plan artifacts, run-artifact
+  summaries, and rawfile / wrdata artifact metadata backed by the engine deck
+  execution layer.
 - Route `parse_netlist` through the Berkeley SPICE logical-card syntax facade,
   so the default Rust parser consumes normalized cards, supports leading `+`
   continuations, and reports stable syntax diagnostics before semantic

--- a/code/packages/rust/spice-netlist-parser/README.md
+++ b/code/packages/rust/spice-netlist-parser/README.md
@@ -40,14 +40,20 @@ R2 out 0 1k
 assert!(!deck.has_errors());
 assert_eq!(deck.analysis_inventory()[0].analysis, "op");
 assert_eq!(deck.syntax.cards[1].kind, BerkeleyCardKind::Element);
+
+let execution = deck.run_artifacts()?;
+assert_eq!(execution.analyses[0].syntax_card_index, Some(3));
+assert!(execution.analyses[0].table_columns.contains(&"Index".to_string()));
 ```
 
 The facade preserves normalized logical cards, source spans, token names
 aligned with `code/grammars/spice/berkeley.tokens`, stable syntax diagnostics,
-analysis inventory, and source-order execution through the existing parser. It
-is the Rust app/runtime entrypoint for Mosaic-backed UI work while the
-grammar-backed parser generator and Python/TypeScript parity surfaces continue
-to mature.
+analysis inventory, source-order execution through the existing parser, and
+card-indexed app artifacts with stable result tables, output-plan artifacts,
+run-artifact summaries, and rawfile / wrdata artifact metadata from the engine
+deck execution layer. It is the Rust app/runtime entrypoint for Mosaic-backed
+UI work while the grammar-backed parser generator and Python/TypeScript parity
+surfaces continue to mature.
 
 This parser supports `R`, `C`, `L`, `V`, `I`, `D`, `Q`, `M`, `G`, `E`, `F`, and
 `H` elements, `.model <name> D(...)` diode cards with `IS` and `VT`

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -16,10 +16,10 @@ mod syntax;
 
 pub use syntax::{
     parse_berkeley_app_deck, parse_berkeley_syntax, BerkeleyAnalysisInventoryEntry,
-    BerkeleyAppDeck, BerkeleyCardKind, BerkeleyDiagnosticSeverity, BerkeleyGrammarMetadata,
-    BerkeleyLogicalCard, BerkeleySyntaxDeck, BerkeleySyntaxDiagnostic, BerkeleySyntaxToken,
-    SourceSpan, BERKELEY_SPICE_GRAMMAR_NAME, BERKELEY_SPICE_GRAMMAR_VERSION,
-    BERKELEY_SPICE_PARSER_GRAMMAR, BERKELEY_SPICE_TOKEN_GRAMMAR,
+    BerkeleyAppAnalysisArtifact, BerkeleyAppDeck, BerkeleyAppExecution, BerkeleyCardKind,
+    BerkeleyDiagnosticSeverity, BerkeleyGrammarMetadata, BerkeleyLogicalCard, BerkeleySyntaxDeck,
+    BerkeleySyntaxDiagnostic, BerkeleySyntaxToken, SourceSpan, BERKELEY_SPICE_GRAMMAR_NAME,
+    BERKELEY_SPICE_GRAMMAR_VERSION, BERKELEY_SPICE_PARSER_GRAMMAR, BERKELEY_SPICE_TOKEN_GRAMMAR,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/code/packages/rust/spice-netlist-parser/src/syntax.rs
+++ b/code/packages/rust/spice-netlist-parser/src/syntax.rs
@@ -2,6 +2,10 @@ use crate::{
     parse_netlist, AnalysisExecutionError, AnalysisExecutionResult, AnalysisKind,
     NetlistParseError, ParsedNetlist,
 };
+use spice_engine::{
+    run_deck, DeckOutputPlanArtifact, DeckRawfileArtifact, DeckRunArtifact, DeckTableArtifact,
+    DeckWrdataArtifact,
+};
 
 pub const BERKELEY_SPICE_GRAMMAR_NAME: &str = "berkeley-spice-logical-card";
 pub const BERKELEY_SPICE_GRAMMAR_VERSION: u32 = 1;
@@ -175,8 +179,35 @@ impl BerkeleySyntaxDeck {
 #[derive(Debug, Clone, PartialEq)]
 pub struct BerkeleyAppDeck {
     pub syntax: BerkeleySyntaxDeck,
+    pub canonical_source: String,
     pub parsed: Option<ParsedNetlist>,
     pub diagnostics: Vec<BerkeleySyntaxDiagnostic>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct BerkeleyAppAnalysisArtifact {
+    pub syntax_card_index: Option<usize>,
+    pub directive: String,
+    pub analysis: String,
+    pub span: Option<SourceSpan>,
+    pub table: String,
+    pub table_columns: Vec<String>,
+    pub table_row_count: usize,
+    pub table_artifacts: Vec<DeckTableArtifact>,
+    pub output_plan_artifacts: Vec<DeckOutputPlanArtifact>,
+    pub run_artifacts: Vec<DeckRunArtifact>,
+    pub rawfile_artifacts: Vec<DeckRawfileArtifact>,
+    pub wrdata_artifacts: Vec<DeckWrdataArtifact>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct BerkeleyAppExecution {
+    pub canonical_source: String,
+    pub analyses: Vec<BerkeleyAppAnalysisArtifact>,
+    pub run_artifacts: Vec<DeckRunArtifact>,
+    pub run_artifact_table: String,
+    pub run_artifact_csv: String,
+    pub run_artifact_json: String,
 }
 
 impl BerkeleyAppDeck {
@@ -222,6 +253,67 @@ impl BerkeleyAppDeck {
         Ok(self.run_source_order()?.into_iter().nth(result_ordinal))
     }
 
+    pub fn run_artifacts(&self) -> Result<BerkeleyAppExecution, AnalysisExecutionError> {
+        let parsed = self.parsed.as_ref().ok_or_else(|| {
+            AnalysisExecutionError::Netlist(NetlistParseError::new(self.blocking_message()))
+        })?;
+        let deck_execution = run_deck(&parsed.circuit, &self.canonical_source)?;
+        let analysis_entries = self
+            .analysis_inventory()
+            .into_iter()
+            .filter(|entry| deck_artifact_analysis_directive(&entry.directive))
+            .collect::<Vec<_>>();
+        let mut analysis_entries = analysis_entries.into_iter();
+        let analyses = deck_execution
+            .executions
+            .into_iter()
+            .map(|execution| {
+                let entry = if execution.plan.line_number == 0 {
+                    None
+                } else {
+                    analysis_entries.next()
+                };
+                BerkeleyAppAnalysisArtifact {
+                    syntax_card_index: entry.as_ref().map(|entry| entry.index),
+                    directive: entry
+                        .as_ref()
+                        .map(|entry| entry.directive.clone())
+                        .unwrap_or_else(|| execution.plan.directive.clone()),
+                    analysis: execution.plan.analysis.clone(),
+                    span: entry.as_ref().map(|entry| entry.span),
+                    table_columns: deck_table_columns(&execution.table),
+                    table_row_count: deck_table_row_count(&execution.table),
+                    table: execution.table,
+                    table_artifacts: execution.table_artifacts,
+                    output_plan_artifacts: execution.output_plan_artifacts,
+                    run_artifacts: execution.run_artifacts,
+                    rawfile_artifacts: execution.rawfile_artifacts,
+                    wrdata_artifacts: execution.wrdata_artifacts,
+                }
+            })
+            .collect();
+
+        Ok(BerkeleyAppExecution {
+            canonical_source: self.canonical_source.clone(),
+            analyses,
+            run_artifacts: deck_execution.run_artifacts,
+            run_artifact_table: deck_execution.run_artifact_table,
+            run_artifact_csv: deck_execution.run_artifact_csv,
+            run_artifact_json: deck_execution.run_artifact_json,
+        })
+    }
+
+    pub fn run_selected_artifact(
+        &self,
+        syntax_card_index: usize,
+    ) -> Result<Option<BerkeleyAppAnalysisArtifact>, AnalysisExecutionError> {
+        Ok(self
+            .run_artifacts()?
+            .analyses
+            .into_iter()
+            .find(|artifact| artifact.syntax_card_index == Some(syntax_card_index)))
+    }
+
     fn blocking_message(&self) -> String {
         self.diagnostics
             .iter()
@@ -231,6 +323,13 @@ impl BerkeleyAppDeck {
                 "Berkeley SPICE app deck did not produce a parsed netlist".to_string()
             })
     }
+}
+
+fn deck_artifact_analysis_directive(directive: &str) -> bool {
+    matches!(
+        directive.to_ascii_lowercase().as_str(),
+        ".op" | ".dc" | ".ac" | ".tran" | ".tf" | ".sens" | ".noise"
+    )
 }
 
 fn runnable_analysis_kind(directive: &str) -> Option<AnalysisKind> {
@@ -372,6 +471,7 @@ pub fn parse_berkeley_syntax(text: &str) -> BerkeleySyntaxDeck {
 
 pub fn parse_berkeley_app_deck(text: &str) -> BerkeleyAppDeck {
     let syntax = parse_berkeley_syntax(text);
+    let canonical_source = canonical_source(&syntax);
     let mut diagnostics = syntax.diagnostics.clone();
     let parsed = if syntax.has_errors() {
         None
@@ -392,8 +492,39 @@ pub fn parse_berkeley_app_deck(text: &str) -> BerkeleyAppDeck {
 
     BerkeleyAppDeck {
         syntax,
+        canonical_source,
         parsed,
         diagnostics,
+    }
+}
+
+fn canonical_source(syntax: &BerkeleySyntaxDeck) -> String {
+    let mut lines = Vec::new();
+    if let Some(title) = &syntax.title {
+        lines.push(format!("* {title}"));
+    }
+    lines.extend(syntax.cards.iter().map(|card| card.text.clone()));
+    if lines.is_empty() {
+        String::new()
+    } else {
+        format!("{}\n", lines.join("\n"))
+    }
+}
+
+fn deck_table_columns(table: &str) -> Vec<String> {
+    table
+        .lines()
+        .next()
+        .map(|header| header.split('\t').map(str::to_string).collect())
+        .unwrap_or_default()
+}
+
+fn deck_table_row_count(table: &str) -> usize {
+    let mut lines = table.lines();
+    if lines.next().is_none() {
+        0
+    } else {
+        lines.count()
     }
 }
 

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -1933,6 +1933,56 @@ R2 out 0 1k
 }
 
 #[test]
+fn berkeley_app_facade_exports_card_indexed_result_artifacts() {
+    let app = parse_berkeley_app_deck(
+        r#"
+* transient UI
+V1 in 0 PULSE(0 1 0 1n 1n 1n 4n)
+R1 in out
++ 1k
+C1 out 0 1p
+.tran 1n 3n
+.print tran V(out)
+.end
+"#,
+    );
+
+    assert!(!app.has_errors(), "{:?}", app.diagnostics);
+    assert!(app.canonical_source.contains("R1 in out 1k\n"));
+
+    let execution = app.run_artifacts().unwrap();
+    assert_eq!(execution.analyses.len(), 1);
+    assert_eq!(execution.run_artifacts.len(), 1);
+    assert!(execution.run_artifact_table.contains("Analysis\tDirective"));
+
+    let tran = &execution.analyses[0];
+    assert_eq!(tran.syntax_card_index, Some(3));
+    assert_eq!(tran.directive, ".tran");
+    assert_eq!(tran.analysis, "tran");
+    assert_eq!(tran.span.unwrap().start_line, 7);
+    assert!(tran.table_row_count >= 1);
+    assert!(tran.table_columns.iter().any(|column| column == "Time"));
+    assert!(tran.table_columns.iter().any(|column| column == "V(out)"));
+    assert!(tran
+        .table_artifacts
+        .iter()
+        .any(|artifact| artifact.name == "result"));
+    assert!(tran
+        .table_artifacts
+        .iter()
+        .any(|artifact| artifact.name == "output-plan"));
+    assert_eq!(tran.output_plan_artifacts[0].output_probes, vec!["V(out)"]);
+    assert!(tran.run_artifacts[0]
+        .tables
+        .iter()
+        .any(|table| table == "result"));
+
+    let selected = app.run_selected_artifact(3).unwrap().unwrap();
+    assert_eq!(selected.analysis, "tran");
+    assert!(app.run_selected_artifact(4).unwrap().is_none());
+}
+
+#[test]
 fn berkeley_app_facade_reports_lowering_errors_without_running() {
     let app = parse_berkeley_app_deck(
         r#"

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,15 +33,15 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Python and TypeScript Berkeley syntax facade parity.
+1. Rust Berkeley Mosaic app artifacts.
    - Status: current PR completion candidate.
-   - Mirror the Rust Berkeley logical-card syntax facade in Python and
-     TypeScript with embedded grammar metadata, normalized cards, leading `+`
-     continuation handling, source spans, token names, stable diagnostics, and
-     analysis inventory.
-   - Keep the slice focused on parser/app-substrate metadata for Mosaic and
-     editor surfaces; richer result/table/waveform app artifacts remain in the
-     next Mosaic facade expansion.
+   - Expand the Rust `spice-netlist-parser` Berkeley app facade from analysis
+     inventory and execution entrypoints into card-indexed stable result
+     artifacts for Mosaic UI surfaces.
+   - Keep this as a Rust-only app-substrate acceleration slice over the public
+     parser contract and existing engine deck artifacts; Python and TypeScript
+     parser parity was completed separately and should remain aligned when
+     parser behavior changes.
 
 ## Completed Slices
 
@@ -1432,15 +1432,26 @@ the Rust, Python, and TypeScript surfaces together.
      semantic lowering, preserving the Mosaic app facade as the Rust runtime
      entrypoint over one shared syntax substrate.
 
+135. Python and TypeScript Berkeley syntax facade parity.
+   - Status: completed in PR 6924.
+   - Python and TypeScript `spice-engine` surfaces now mirror the Rust Berkeley
+     logical-card syntax facade with embedded grammar metadata, normalized
+     cards, leading `+` continuation handling, source spans, token names,
+     stable diagnostics, and analysis inventory.
+   - Cross-language tests lock the shared grammar metadata and representative
+     logical-card / diagnostic behavior so future parser work can keep editor
+     and app-substrate surfaces in sync.
+
 ## Backlog
 
 1. Grammar-backed parser and app facade.
    - Keep Python and TypeScript parser contract parity aligned with the Rust
      syntax facade as the grammar evolves, even if that breaks current
      pre-release parser APIs.
-   - Expand the Rust Mosaic app facade from analysis inventory and execution
-     entrypoints to stable table, waveform, and result artifacts backed by the
-     same public parser contract.
+   - Continue expanding the Rust Mosaic app facade beyond the initial
+     card-indexed result artifacts toward richer waveform inspection, app
+     session state, and editor-driven analysis controls backed by the same
+     public parser contract.
 
 2. Deck compatibility follow-up.
    - Expand deck-owned output compatibility beyond source-order analysis


### PR DESCRIPTION
## Summary
- add Berkeley app-deck artifact structs and `BerkeleyAppDeck::run_artifacts()` / `run_selected_artifact()` for Mosaic-facing Rust UI surfaces
- preserve canonical normalized source and map deck executions back to Berkeley syntax card indexes and spans
- update the SPICE implementation plan to mark PR #6924 complete and make this Rust app artifact slice current

## Validation
- `cargo fmt -p spice-netlist-parser`
- `git diff --check`
- `cargo test -p spice-netlist-parser -- --nocapture`
- `cargo test -p grammar-tools --test spice_grammar_validation -- --nocapture`