### PR TITLE
[codex] Add Berkeley SPICE waveform inspection

### DIFF
--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add Berkeley SPICE app-deck waveform inspection series for Mosaic-facing
+  Rust UI substrates. Card-indexed analysis artifacts now expose numeric
+  plot-ready series derived from stable result tables, including selected-card
+  waveform access and probe-grouped AC magnitude/phase series.
 - Add Berkeley SPICE app-deck result artifacts for Mosaic-facing Rust UI
   substrates. `BerkeleyAppDeck::run_artifacts()` now exposes normalized source,
   syntax-card-indexed result tables, output-plan artifacts, run-artifact

--- a/code/packages/rust/spice-netlist-parser/README.md
+++ b/code/packages/rust/spice-netlist-parser/README.md
@@ -44,15 +44,17 @@ assert_eq!(deck.syntax.cards[1].kind, BerkeleyCardKind::Element);
 let execution = deck.run_artifacts()?;
 assert_eq!(execution.analyses[0].syntax_card_index, Some(3));
 assert!(execution.analyses[0].table_columns.contains(&"Index".to_string()));
+assert_eq!(execution.analyses[0].waveform_series[0].x_column, "Index");
 ```
 
 The facade preserves normalized logical cards, source spans, token names
 aligned with `code/grammars/spice/berkeley.tokens`, stable syntax diagnostics,
 analysis inventory, source-order execution through the existing parser, and
 card-indexed app artifacts with stable result tables, output-plan artifacts,
-run-artifact summaries, and rawfile / wrdata artifact metadata from the engine
-deck execution layer. It is the Rust app/runtime entrypoint for Mosaic-backed
-UI work while the grammar-backed parser generator and Python/TypeScript parity
+run-artifact summaries, rawfile / wrdata artifact metadata from the engine deck
+execution layer, and numeric waveform series derived from result tables for
+Mosaic plot surfaces. It is the Rust app/runtime entrypoint for Mosaic-backed UI
+work while the grammar-backed parser generator and Python/TypeScript parity
 surfaces continue to mature.
 
 This parser supports `R`, `C`, `L`, `V`, `I`, `D`, `Q`, `M`, `G`, `E`, `F`, and

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -16,10 +16,11 @@ mod syntax;
 
 pub use syntax::{
     parse_berkeley_app_deck, parse_berkeley_syntax, BerkeleyAnalysisInventoryEntry,
-    BerkeleyAppAnalysisArtifact, BerkeleyAppDeck, BerkeleyAppExecution, BerkeleyCardKind,
-    BerkeleyDiagnosticSeverity, BerkeleyGrammarMetadata, BerkeleyLogicalCard, BerkeleySyntaxDeck,
-    BerkeleySyntaxDiagnostic, BerkeleySyntaxToken, SourceSpan, BERKELEY_SPICE_GRAMMAR_NAME,
-    BERKELEY_SPICE_GRAMMAR_VERSION, BERKELEY_SPICE_PARSER_GRAMMAR, BERKELEY_SPICE_TOKEN_GRAMMAR,
+    BerkeleyAppAnalysisArtifact, BerkeleyAppDeck, BerkeleyAppExecution, BerkeleyAppWaveformPoint,
+    BerkeleyAppWaveformSeries, BerkeleyCardKind, BerkeleyDiagnosticSeverity,
+    BerkeleyGrammarMetadata, BerkeleyLogicalCard, BerkeleySyntaxDeck, BerkeleySyntaxDiagnostic,
+    BerkeleySyntaxToken, SourceSpan, BERKELEY_SPICE_GRAMMAR_NAME, BERKELEY_SPICE_GRAMMAR_VERSION,
+    BERKELEY_SPICE_PARSER_GRAMMAR, BERKELEY_SPICE_TOKEN_GRAMMAR,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/code/packages/rust/spice-netlist-parser/src/syntax.rs
+++ b/code/packages/rust/spice-netlist-parser/src/syntax.rs
@@ -193,6 +193,8 @@ pub struct BerkeleyAppAnalysisArtifact {
     pub table: String,
     pub table_columns: Vec<String>,
     pub table_row_count: usize,
+    pub waveform_series_count: usize,
+    pub waveform_series: Vec<BerkeleyAppWaveformSeries>,
     pub table_artifacts: Vec<DeckTableArtifact>,
     pub output_plan_artifacts: Vec<DeckOutputPlanArtifact>,
     pub run_artifacts: Vec<DeckRunArtifact>,
@@ -201,9 +203,33 @@ pub struct BerkeleyAppAnalysisArtifact {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+pub struct BerkeleyAppWaveformPoint {
+    pub row_index: usize,
+    pub x: f64,
+    pub y: f64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct BerkeleyAppWaveformSeries {
+    pub syntax_card_index: Option<usize>,
+    pub directive: String,
+    pub analysis: String,
+    pub table_name: String,
+    pub name: String,
+    pub x_column: String,
+    pub y_column: String,
+    pub group_column: Option<String>,
+    pub group_value: Option<String>,
+    pub point_count: usize,
+    pub points: Vec<BerkeleyAppWaveformPoint>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub struct BerkeleyAppExecution {
     pub canonical_source: String,
     pub analyses: Vec<BerkeleyAppAnalysisArtifact>,
+    pub waveform_series_count: usize,
+    pub waveform_series: Vec<BerkeleyAppWaveformSeries>,
     pub run_artifacts: Vec<DeckRunArtifact>,
     pub run_artifact_table: String,
     pub run_artifact_csv: String,
@@ -264,6 +290,7 @@ impl BerkeleyAppDeck {
             .filter(|entry| deck_artifact_analysis_directive(&entry.directive))
             .collect::<Vec<_>>();
         let mut analysis_entries = analysis_entries.into_iter();
+        let mut execution_waveform_series = Vec::new();
         let analyses = deck_execution
             .executions
             .into_iter()
@@ -273,16 +300,28 @@ impl BerkeleyAppDeck {
                 } else {
                     analysis_entries.next()
                 };
+                let syntax_card_index = entry.as_ref().map(|entry| entry.index);
+                let directive = entry
+                    .as_ref()
+                    .map(|entry| entry.directive.clone())
+                    .unwrap_or_else(|| execution.plan.directive.clone());
+                let analysis = execution.plan.analysis.clone();
+                let waveform_series = deck_waveform_series(
+                    syntax_card_index,
+                    &directive,
+                    &analysis,
+                    &execution.table,
+                );
+                execution_waveform_series.extend(waveform_series.iter().cloned());
                 BerkeleyAppAnalysisArtifact {
-                    syntax_card_index: entry.as_ref().map(|entry| entry.index),
-                    directive: entry
-                        .as_ref()
-                        .map(|entry| entry.directive.clone())
-                        .unwrap_or_else(|| execution.plan.directive.clone()),
-                    analysis: execution.plan.analysis.clone(),
+                    syntax_card_index,
+                    directive,
+                    analysis,
                     span: entry.as_ref().map(|entry| entry.span),
                     table_columns: deck_table_columns(&execution.table),
                     table_row_count: deck_table_row_count(&execution.table),
+                    waveform_series_count: waveform_series.len(),
+                    waveform_series,
                     table: execution.table,
                     table_artifacts: execution.table_artifacts,
                     output_plan_artifacts: execution.output_plan_artifacts,
@@ -296,6 +335,8 @@ impl BerkeleyAppDeck {
         Ok(BerkeleyAppExecution {
             canonical_source: self.canonical_source.clone(),
             analyses,
+            waveform_series_count: execution_waveform_series.len(),
+            waveform_series: execution_waveform_series,
             run_artifacts: deck_execution.run_artifacts,
             run_artifact_table: deck_execution.run_artifact_table,
             run_artifact_csv: deck_execution.run_artifact_csv,
@@ -312,6 +353,15 @@ impl BerkeleyAppDeck {
             .analyses
             .into_iter()
             .find(|artifact| artifact.syntax_card_index == Some(syntax_card_index)))
+    }
+
+    pub fn run_selected_waveform_series(
+        &self,
+        syntax_card_index: usize,
+    ) -> Result<Option<Vec<BerkeleyAppWaveformSeries>>, AnalysisExecutionError> {
+        Ok(self
+            .run_selected_artifact(syntax_card_index)?
+            .map(|artifact| artifact.waveform_series))
     }
 
     fn blocking_message(&self) -> String {
@@ -526,6 +576,155 @@ fn deck_table_row_count(table: &str) -> usize {
     } else {
         lines.count()
     }
+}
+
+fn deck_waveform_series(
+    syntax_card_index: Option<usize>,
+    directive: &str,
+    analysis: &str,
+    table: &str,
+) -> Vec<BerkeleyAppWaveformSeries> {
+    let mut lines = table.lines();
+    let Some(header) = lines.next() else {
+        return Vec::new();
+    };
+    let columns = header.split('\t').map(str::to_string).collect::<Vec<_>>();
+    let Some(x_index) = deck_waveform_x_column(&columns) else {
+        return Vec::new();
+    };
+    let rows = lines
+        .map(|row| row.split('\t').map(str::to_string).collect::<Vec<_>>())
+        .collect::<Vec<_>>();
+    let group_index = deck_waveform_group_column(&columns, x_index);
+    let group_values = deck_waveform_group_values(&rows, group_index);
+    let mut series = Vec::new();
+
+    for (y_index, y_column) in columns.iter().enumerate() {
+        if y_index == x_index || Some(y_index) == group_index || !deck_waveform_y_column(y_column) {
+            continue;
+        }
+
+        if group_index.is_some() {
+            for group_value in &group_values {
+                let points =
+                    deck_waveform_points(&rows, x_index, y_index, group_index, Some(group_value));
+                if points.is_empty() {
+                    continue;
+                }
+                series.push(BerkeleyAppWaveformSeries {
+                    syntax_card_index,
+                    directive: directive.to_string(),
+                    analysis: analysis.to_string(),
+                    table_name: "result".to_string(),
+                    name: format!("{group_value}:{y_column}"),
+                    x_column: columns[x_index].clone(),
+                    y_column: y_column.clone(),
+                    group_column: group_index.map(|index| columns[index].clone()),
+                    group_value: Some(group_value.clone()),
+                    point_count: points.len(),
+                    points,
+                });
+            }
+        } else {
+            let points = deck_waveform_points(&rows, x_index, y_index, None, None);
+            if points.is_empty() {
+                continue;
+            }
+            series.push(BerkeleyAppWaveformSeries {
+                syntax_card_index,
+                directive: directive.to_string(),
+                analysis: analysis.to_string(),
+                table_name: "result".to_string(),
+                name: y_column.clone(),
+                x_column: columns[x_index].clone(),
+                y_column: y_column.clone(),
+                group_column: None,
+                group_value: None,
+                point_count: points.len(),
+                points,
+            });
+        }
+    }
+
+    series
+}
+
+fn deck_waveform_x_column(columns: &[String]) -> Option<usize> {
+    ["Time", "Frequency", "Value", "TemperatureKelvin"]
+        .into_iter()
+        .find_map(|preferred| {
+            columns
+                .iter()
+                .position(|column| column.eq_ignore_ascii_case(preferred))
+        })
+        .or_else(|| {
+            columns
+                .iter()
+                .position(|column| column.eq_ignore_ascii_case("Index"))
+        })
+}
+
+fn deck_waveform_group_column(columns: &[String], x_index: usize) -> Option<usize> {
+    ["Probe", "Source", "Corner", "Method"]
+        .into_iter()
+        .find_map(|preferred| {
+            columns.iter().enumerate().find_map(|(index, column)| {
+                if index != x_index && column.eq_ignore_ascii_case(preferred) {
+                    Some(index)
+                } else {
+                    None
+                }
+            })
+        })
+}
+
+fn deck_waveform_y_column(column: &str) -> bool {
+    !matches!(
+        column.to_ascii_lowercase().as_str(),
+        "index" | "source" | "probe" | "corner" | "method" | "converged" | "stepsrejected"
+    )
+}
+
+fn deck_waveform_group_values(rows: &[Vec<String>], group_index: Option<usize>) -> Vec<String> {
+    let Some(group_index) = group_index else {
+        return Vec::new();
+    };
+    let mut values = Vec::new();
+    for row in rows {
+        let value = row.get(group_index).cloned().unwrap_or_default();
+        if !values.iter().any(|existing| existing == &value) {
+            values.push(value);
+        }
+    }
+    values
+}
+
+fn deck_waveform_points(
+    rows: &[Vec<String>],
+    x_index: usize,
+    y_index: usize,
+    group_index: Option<usize>,
+    group_value: Option<&String>,
+) -> Vec<BerkeleyAppWaveformPoint> {
+    rows.iter()
+        .enumerate()
+        .filter_map(|(row_index, row)| {
+            if let (Some(group_index), Some(group_value)) = (group_index, group_value) {
+                if row.get(group_index) != Some(group_value) {
+                    return None;
+                }
+            }
+            let x = parse_finite_cell(row, x_index)?;
+            let y = parse_finite_cell(row, y_index)?;
+            Some(BerkeleyAppWaveformPoint { row_index, x, y })
+        })
+        .collect()
+}
+
+fn parse_finite_cell(row: &[String], index: usize) -> Option<f64> {
+    row.get(index)
+        .and_then(|value| value.parse::<f64>().ok())
+        .filter(|value| value.is_finite())
 }
 
 fn logical_card(

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -1963,6 +1963,12 @@ C1 out 0 1p
     assert!(tran.table_row_count >= 1);
     assert!(tran.table_columns.iter().any(|column| column == "Time"));
     assert!(tran.table_columns.iter().any(|column| column == "V(out)"));
+    assert_eq!(tran.waveform_series_count, 1);
+    assert_eq!(tran.waveform_series[0].name, "V(out)");
+    assert_eq!(tran.waveform_series[0].x_column, "Time");
+    assert_eq!(tran.waveform_series[0].y_column, "V(out)");
+    assert_eq!(tran.waveform_series[0].point_count, tran.table_row_count);
+    assert_eq!(tran.waveform_series[0].points[0].row_index, 0);
     assert!(tran
         .table_artifacts
         .iter()
@@ -1979,7 +1985,43 @@ C1 out 0 1p
 
     let selected = app.run_selected_artifact(3).unwrap().unwrap();
     assert_eq!(selected.analysis, "tran");
+    let selected_waveforms = app.run_selected_waveform_series(3).unwrap().unwrap();
+    assert_eq!(selected_waveforms[0].name, "V(out)");
     assert!(app.run_selected_artifact(4).unwrap().is_none());
+}
+
+#[test]
+fn berkeley_app_facade_exports_probe_grouped_waveform_series() {
+    let app = parse_berkeley_app_deck(
+        r#"
+* ac UI
+V1 in 0 DC 0 AC 1
+R1 in out 1k
+C1 out 0 1u
+.ac dec 1 1k 1k
+.print ac V(out)
+.end
+"#,
+    );
+
+    assert!(!app.has_errors(), "{:?}", app.diagnostics);
+    let execution = app.run_artifacts().unwrap();
+    let ac = &execution.analyses[0];
+
+    assert_eq!(ac.syntax_card_index, Some(3));
+    assert_eq!(ac.analysis, "ac");
+    assert!(ac
+        .waveform_series
+        .iter()
+        .any(|series| series.name == "V(out):Magnitude"
+            && series.x_column == "Frequency"
+            && series.group_column.as_deref() == Some("Probe")
+            && series.group_value.as_deref() == Some("V(out)")
+            && series.point_count == 1));
+    assert!(execution
+        .waveform_series
+        .iter()
+        .any(|series| series.name == "V(out):Phase"));
 }
 
 #[test]

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,11 +33,11 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Rust Berkeley Mosaic app artifacts.
+1. Rust Berkeley Mosaic waveform inspection.
    - Status: current PR completion candidate.
-   - Expand the Rust `spice-netlist-parser` Berkeley app facade from analysis
-     inventory and execution entrypoints into card-indexed stable result
-     artifacts for Mosaic UI surfaces.
+   - Expand the Rust `spice-netlist-parser` Berkeley app facade from
+     card-indexed stable result artifacts into plot-ready waveform inspection
+     series for Mosaic UI surfaces.
    - Keep this as a Rust-only app-substrate acceleration slice over the public
      parser contract and existing engine deck artifacts; Python and TypeScript
      parser parity was completed separately and should remain aligned when
@@ -1441,6 +1441,17 @@ the Rust, Python, and TypeScript surfaces together.
    - Cross-language tests lock the shared grammar metadata and representative
      logical-card / diagnostic behavior so future parser work can keep editor
      and app-substrate surfaces in sync.
+
+136. Rust Berkeley Mosaic app artifacts.
+   - Status: completed in PR 6934.
+   - Rust `spice-netlist-parser` now exposes Berkeley app-deck artifacts for
+     Mosaic-facing UI surfaces, including canonical normalized source,
+     syntax-card-indexed result tables, output-plan artifacts, run-artifact
+     summaries, and rawfile / wrdata artifact metadata.
+   - The slice builds on the public Berkeley parser contract and existing engine
+     deck artifacts as a Rust-only app-substrate acceleration layer while
+     Python and TypeScript parser parity remains aligned for shared syntax
+     behavior.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- add Berkeley app-deck waveform point/series structs and aggregate execution series for Mosaic plotting surfaces
- derive selected-card waveform series from stable result tables, including transient point series and probe-grouped AC magnitude/phase series
- update the Rust parser README/changelog and SPICE implementation plan after PR #6934 merged

## Validation
- `cargo fmt -p spice-netlist-parser`
- `cargo test -p spice-netlist-parser -- --nocapture`
- `cargo test -p grammar-tools --test spice_grammar_validation -- --nocapture`
- `git diff --check`