### PR TITLE
fix(latex): iterative Drop for MathNode — deep trees no longer overflow the stack

### DIFF
--- a/code/packages/rust/latex/CHANGELOG.md
+++ b/code/packages/rust/latex/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to the full-fidelity LaTeX parser crate.
 
+## [0.12.0] — 2026-06-29
+
+### Fixed — deep `MathNode` trees now drop without overflowing the stack
+
+`MathNode` is a recursive `Box`-owning enum, so the compiler-generated destructor recurses
+once per level. The parser builds **left-nested** chains via loops with no per-term depth
+charge (`parse_add`/`parse_mul`/`parse_relation`), so input like `1+1+1+…` (or a long
+juxtaposition `aaa…`) yields an O(n)-deep tree even though `MAX_DEPTH` bounds *nesting*.
+Dropping a deep-enough such tree overflowed the stack — an **uncatchable abort**, even
+though `parse_math` itself survives (it builds iteratively). This was the pre-existing
+latent hazard flagged in the L6 security review.
+
+- **`impl Drop for MathNode`** now dismantles the tree with an explicit **heap worklist**
+  instead of the call stack: each node's boxed children are moved onto a `Vec` (replaced
+  in place by a cheap `Sym("")` leaf), popped, and repeated, so the generated destructor
+  recurses at most one trivial level. O(1) stack depth regardless of tree depth. This
+  mirrors `math_frontend::MathExpr`'s `Drop` (added in `math-frontend` 0.3.0).
+- **`take_children` helper** does the per-variant child extraction (leaves contribute
+  nothing; `Matrix` rows are drained via `mem::take`).
+- Because `MathNode` now implements `Drop`, fields can no longer be moved out of an owned
+  value in a by-value `match` (E0509). The `frontend.rs` `lower()` trampoline and the
+  by-value test matches were rewritten to `match &node`/`match &n` and extract children via
+  `mem::replace`/`Option::take`/`mem::take`. No behavior change — purely how ownership is
+  threaded.
+- New regression tests: `deep_left_nested_tree_drops_without_overflow` (200k-deep `Bin`
+  spine), `deep_parsed_chain_drops_without_overflow` (50k-term `+` chain through the real
+  parser), `deep_unary_chain_drops_without_overflow` (200k-deep `Unary` spine). 139 tests
+  pass; both the default build and `--no-default-features` (zero-dep L0–L5) stay green.
+
 ## [0.11.0] — 2026-06-28
 
 ### Changed — L6 closes its two honest neutral-AST gaps (± / ∓ and binomials)

--- a/code/packages/rust/latex/Cargo.toml
+++ b/code/packages/rust/latex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latex"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 description = "A full-fidelity LaTeX parser (documents and math): a catcode-driven, text-mode-primary tokenizer and (in later layers) a structural + math parser producing a faithful AST. Standalone and reusable; will also implement the math-frontend MathFrontend trait."
 license = "MIT"

--- a/code/packages/rust/latex/README.md
+++ b/code/packages/rust/latex/README.md
@@ -226,6 +226,20 @@ The low-level `tokenize` is also public. Tokens and errors carry half-open byte 
 all of `parse`, `parse_math`, and `tokenize` return spanned errors rather than panicking,
 and recursion is depth-guarded so adversarial nesting errors instead of overflowing.
 
+### Deep-tree drop safety
+
+`MathNode` is a recursive `Box`-owning tree, so a naive (compiler-derived) destructor would
+recurse once per level. The parser's `MAX_DEPTH` bounds *nesting*, but left-associative
+chains — `1+1+1+…`, juxtaposition `aaa…` — are built in loops with no per-term depth charge,
+so they produce O(n)-deep trees that `parse_math` happily returns (it builds iteratively).
+Dropping such a tree would overflow the stack: an **uncatchable abort**. To prevent it,
+`MathNode` implements `Drop` explicitly, dismantling the tree with a **heap worklist** (each
+boxed child is moved onto a `Vec`, replaced in place by a cheap leaf, then popped) so the
+generated destructor recurses at most one trivial level — O(1) stack depth at any size. The
+neutral `math_frontend::MathExpr` does the same. (Consequence: because `MathNode: Drop`, you
+cannot move fields out of an owned `MathNode` in a by-value `match` — borrow with `match &node`
+and lift children via `mem::replace`/`Option::take`.)
+
 ## Tests
 
 ```

--- a/code/packages/rust/latex/src/frontend.rs
+++ b/code/packages/rust/latex/src/frontend.rs
@@ -104,6 +104,13 @@ enum Task {
     Build(Build),
 }
 
+/// Lift the owned `MathNode` out of a boxed child, leaving a cheap leaf (`Sym("")`) in its
+/// place. Needed because `MathNode: Drop` forbids moving a field out of an owned value (E0509);
+/// the emptied parent then drops shallowly. Mirrors the `take` helper in `MathNode`'s own `Drop`.
+fn take_box(b: &mut Box<MathNode>) -> MathNode {
+    std::mem::replace(b.as_mut(), MathNode::Sym(String::new()))
+}
+
 /// Lower one [`MathNode`] (LaTeX-shaped) into the neutral [`MathExpr`].
 ///
 /// **Iterative on purpose.** A LaTeX math tree can be *arbitrarily* deep along a left-
@@ -131,91 +138,120 @@ fn lower(root: MathNode, span: (usize, usize)) -> Result<MathExpr, FrontendError
         match task {
             // --- Decompose a node: push its assembler, then its children in REVERSE natural
             //     order so the first natural child lands on top and is processed first. ---
-            Task::Node(node) => match node {
-                MathNode::Num(s) => vals.push(MathExpr::Number(Number::parse(&s).ok_or_else(
-                    || FrontendError::new("latex", format!("invalid numeric literal {s:?}"), span),
-                )?)),
-                MathNode::Sym(s) => vals.push(MathExpr::Symbol(s)),
-                MathNode::Text(s) => vals.push(MathExpr::Text(s)),
+            // `MathNode` now implements `Drop` (iterative, see math.rs), so its fields cannot be
+            // moved out of an owned value by a by-value `match` (E0509). We instead match by
+            // `&mut` and lift each child out with `take_box` / `Option::take` / `mem::take`,
+            // leaving a cheap leaf behind; the emptied `node` then drops shallowly at arm end.
+            Task::Node(mut node) => match &mut node {
+                MathNode::Num(s) => {
+                    let s = std::mem::take(s);
+                    vals.push(MathExpr::Number(Number::parse(&s).ok_or_else(|| {
+                        FrontendError::new("latex", format!("invalid numeric literal {s:?}"), span)
+                    })?))
+                }
+                MathNode::Sym(s) => vals.push(MathExpr::Symbol(std::mem::take(s))),
+                MathNode::Text(s) => vals.push(MathExpr::Text(std::mem::take(s))),
                 // `\binom{n}{k}` → the neutral binomial coefficient (no division bar).
                 MathNode::Binom(x, y) => {
+                    let (x, y) = (take_box(x), take_box(y));
                     work.push(Task::Build(Build::Binom));
-                    work.push(Task::Node(*y));
-                    work.push(Task::Node(*x));
+                    work.push(Task::Node(y));
+                    work.push(Task::Node(x));
                 }
                 MathNode::Bin(op, x, y) => {
-                    work.push(Task::Build(Build::Bin(lower_binop(op))));
-                    work.push(Task::Node(*y));
-                    work.push(Task::Node(*x));
+                    let bop = lower_binop(*op);
+                    let (x, y) = (take_box(x), take_box(y));
+                    work.push(Task::Build(Build::Bin(bop)));
+                    work.push(Task::Node(y));
+                    work.push(Task::Node(x));
                 }
                 MathNode::Rel(op, x, y) => {
-                    work.push(Task::Build(Build::Rel(lower_relop(op))));
-                    work.push(Task::Node(*y));
-                    work.push(Task::Node(*x));
+                    let rop = lower_relop(*op);
+                    let (x, y) = (take_box(x), take_box(y));
+                    work.push(Task::Build(Build::Rel(rop)));
+                    work.push(Task::Node(y));
+                    work.push(Task::Node(x));
                 }
                 MathNode::Unary(op, x) => {
-                    let op = match op {
+                    let op = match *op {
                         MUnOp::Neg => UnaryOp::Neg,
                         MUnOp::Pos => UnaryOp::Pos,
                     };
+                    let x = take_box(x);
                     work.push(Task::Build(Build::Unary(op)));
-                    work.push(Task::Node(*x));
+                    work.push(Task::Node(x));
                 }
                 MathNode::Frac(x, y) => {
+                    let (x, y) = (take_box(x), take_box(y));
                     work.push(Task::Build(Build::Frac));
-                    work.push(Task::Node(*y));
-                    work.push(Task::Node(*x));
+                    work.push(Task::Node(y));
+                    work.push(Task::Node(x));
                 }
                 MathNode::Root { degree, radicand } => {
                     let has_degree = degree.is_some();
+                    let deg = degree.take();
+                    let rad = take_box(radicand);
                     work.push(Task::Build(Build::Root { has_degree }));
-                    work.push(Task::Node(*radicand));
-                    if let Some(d) = degree {
+                    work.push(Task::Node(rad));
+                    if let Some(d) = deg {
                         work.push(Task::Node(*d));
                     }
                 }
                 MathNode::Script { base, sub, sup } => {
                     let (has_sub, has_sup) = (sub.is_some(), sup.is_some());
+                    let sub_n = sub.take();
+                    let sup_n = sup.take();
+                    let base_n = take_box(base);
                     work.push(Task::Build(Build::Script { has_sub, has_sup }));
-                    if let Some(p) = sup {
+                    if let Some(p) = sup_n {
                         work.push(Task::Node(*p));
                     }
-                    if let Some(s) = sub {
+                    if let Some(s) = sub_n {
                         work.push(Task::Node(*s));
                     }
-                    work.push(Task::Node(*base));
+                    work.push(Task::Node(base_n));
                 }
                 MathNode::Call { func, arg } => {
+                    let func = std::mem::take(func);
+                    let arg = take_box(arg);
                     work.push(Task::Build(Build::Call(lower_func(&func))));
-                    work.push(Task::Node(*arg));
+                    work.push(Task::Node(arg));
                 }
                 // An accent is a named unary operator on its argument (`\hat{x}` ≈ hat(x)).
                 MathNode::Accent { kind, body } => {
+                    let kind = std::mem::take(kind);
+                    let body = take_box(body);
                     work.push(Task::Build(Build::Call(Func::Other(kind))));
-                    work.push(Task::Node(*body));
+                    work.push(Task::Node(body));
                 }
                 MathNode::BigOp { op, lower: lo, upper, body } => {
                     let (has_lower, has_upper) = (lo.is_some(), upper.is_some());
+                    let opname = std::mem::take(op);
+                    let lo_n = lo.take();
+                    let up_n = upper.take();
+                    let body_n = take_box(body);
                     work.push(Task::Build(Build::BigOp {
-                        op: lower_bigop(&op),
+                        op: lower_bigop(&opname),
                         has_lower,
                         has_upper,
                     }));
-                    work.push(Task::Node(*body));
-                    if let Some(u) = upper {
+                    work.push(Task::Node(body_n));
+                    if let Some(u) = up_n {
                         work.push(Task::Node(*u));
                     }
-                    if let Some(l) = lo {
+                    if let Some(l) = lo_n {
                         work.push(Task::Node(*l));
                     }
                 }
                 // Fence style is presentation; the meaning is "this is grouped".
                 MathNode::Fenced { body, .. } => {
+                    let body = take_box(body);
                     work.push(Task::Build(Build::Group));
-                    work.push(Task::Node(*body));
+                    work.push(Task::Node(body));
                 }
                 // Matrix delimiter (pmatrix/bmatrix/cases/…) is presentation; cells carry it.
                 MathNode::Matrix { rows, .. } => {
+                    let rows = std::mem::take(rows);
                     let row_lens: Vec<usize> = rows.iter().map(|r| r.len()).collect();
                     work.push(Task::Build(Build::Matrix { row_lens }));
                     // Push cells in reverse so cell (0,0) is processed first.

--- a/code/packages/rust/latex/src/math.rs
+++ b/code/packages/rust/latex/src/math.rs
@@ -133,6 +133,76 @@ pub enum MathNode {
     },
 }
 
+/// Drop a [`MathNode`] **iteratively** so freeing a deeply-nested tree cannot overflow the
+/// stack.
+///
+/// `parse_math` builds left-associative chains (`a+a+a+…`, `1/1/1/…`) and juxtaposition with
+/// *loops*, not recursion — by design — so a small input like `"1" + "+1".repeat(100_000)`
+/// parses fine into a `Bin(Add, Bin(Add, …))` tree nested 100k deep. But the compiler's
+/// default destructor for a recursive `Box`-owning enum is itself recursive: dropping such a
+/// tree would recurse 100k frames and abort the process (an uncatchable stack overflow) when
+/// the `MathNode` simply goes out of scope. Since `parse_math` is public and panic-free, the
+/// AST must be safe to drop at any depth — so we dismantle it with an explicit heap worklist
+/// instead of the call stack. (Mirrors `math_frontend::MathExpr`'s `Drop`.)
+///
+/// O(1) stack depth: move each node's boxed children onto a `Vec` worklist (replacing them in
+/// place with a cheap leaf), pop, repeat. By the time any node is finally dropped its children
+/// are leaves, so the generated destructor recurses at most one trivial level.
+impl Drop for MathNode {
+    fn drop(&mut self) {
+        let mut stack: Vec<MathNode> = Vec::new();
+        take_children(self, &mut stack);
+        while let Some(mut node) = stack.pop() {
+            take_children(&mut node, &mut stack);
+            // `node` now owns only leaf children, so dropping it here is shallow.
+        }
+    }
+}
+
+/// Move every boxed child of `n` onto `out`, leaving `n` holding cheap leaves in their place.
+/// A leaf (`Num`/`Sym`/`Text`) contributes nothing. Used only by [`MathNode`]'s `Drop`.
+fn take_children(n: &mut MathNode, out: &mut Vec<MathNode>) {
+    // Swap a boxed child out for a leaf (no allocation: `String::new()` doesn't allocate).
+    fn take(b: &mut Box<MathNode>, out: &mut Vec<MathNode>) {
+        out.push(std::mem::replace(b.as_mut(), MathNode::Sym(String::new())));
+    }
+    fn take_opt(b: &mut Option<Box<MathNode>>, out: &mut Vec<MathNode>) {
+        if let Some(boxed) = b.take() {
+            out.push(*boxed);
+        }
+    }
+    match n {
+        MathNode::Num(_) | MathNode::Sym(_) | MathNode::Text(_) => {}
+        MathNode::Bin(_, a, b) | MathNode::Frac(a, b) | MathNode::Binom(a, b) | MathNode::Rel(_, a, b) => {
+            take(a, out);
+            take(b, out);
+        }
+        MathNode::Unary(_, a) => take(a, out),
+        MathNode::Root { degree, radicand } => {
+            take_opt(degree, out);
+            take(radicand, out);
+        }
+        MathNode::Script { base, sub, sup } => {
+            take(base, out);
+            take_opt(sub, out);
+            take_opt(sup, out);
+        }
+        MathNode::Call { arg, .. } => take(arg, out),
+        MathNode::BigOp { lower, upper, body, .. } => {
+            take_opt(lower, out);
+            take_opt(upper, out);
+            take(body, out);
+        }
+        MathNode::Accent { body, .. } => take(body, out),
+        MathNode::Fenced { body, .. } => take(body, out),
+        MathNode::Matrix { rows, .. } => {
+            for row in std::mem::take(rows) {
+                out.extend(row);
+            }
+        }
+    }
+}
+
 /// Parse LaTeX math-mode source (the inner content of an island) into a [`MathNode`].
 pub fn parse_math(src: &str) -> Result<MathNode, ParseError> {
     let raw = tokenize(src)?;
@@ -1036,10 +1106,12 @@ mod tests {
     fn frac_with_nested_mul() {
         // \frac{12 \times 15}{3}
         let n = parse_math(r"\frac{12 \times 15}{3}").unwrap();
-        match n {
+        // Match by reference — `MathNode` implements `Drop`, so a by-value `match` can't
+        // move fields out (E0509). `&n` borrows; `**a` derefs &Box<MathNode> → MathNode.
+        match &n {
             MathNode::Frac(a, b) => {
-                assert!(matches!(*a, MathNode::Bin(MBinOp::Mul, ..)));
-                assert_eq!(*b, num("3"));
+                assert!(matches!(**a, MathNode::Bin(MBinOp::Mul, ..)));
+                assert_eq!(**b, num("3"));
             }
             other => panic!("expected Frac, got {other:?}"),
         }
@@ -1067,12 +1139,12 @@ mod tests {
     fn sum_with_bounds() {
         // \sum_{i=1}^{n} i
         let n = parse_math(r"\sum_{i=1}^{n} i").unwrap();
-        match n {
+        match &n {
             MathNode::BigOp { op, lower, upper, body } => {
-                assert_eq!(op, "sum");
+                assert_eq!(op.as_str(), "sum");
                 assert!(matches!(lower.as_deref(), Some(MathNode::Rel(MRelOp::Eq, ..))));
                 assert_eq!(upper.as_deref(), Some(&sym("n")));
-                assert_eq!(*body, sym("i"));
+                assert_eq!(**body, sym("i"));
             }
             other => panic!("expected BigOp, got {other:?}"),
         }
@@ -1082,9 +1154,9 @@ mod tests {
     fn left_right_fence_with_power() {
         // \left(\frac{a}{b}\right)^2
         let n = parse_math(r"\left(\frac{a}{b}\right)^2").unwrap();
-        match n {
+        match &n {
             MathNode::Script { base, sup, .. } => {
-                assert!(matches!(*base, MathNode::Fenced { .. }));
+                assert!(matches!(**base, MathNode::Fenced { .. }));
                 assert_eq!(sup.as_deref(), Some(&num("2")));
             }
             other => panic!("expected Script over Fenced, got {other:?}"),
@@ -1160,12 +1232,12 @@ mod tests {
     #[test]
     fn pmatrix_two_by_two() {
         let n = parse_math(r"\begin{pmatrix} a & b \\ c & d \end{pmatrix}").unwrap();
-        match n {
+        match &n {
             MathNode::Matrix { env, rows } => {
-                assert_eq!(env, "pmatrix");
+                assert_eq!(env.as_str(), "pmatrix");
                 assert_eq!(
                     rows,
-                    vec![
+                    &vec![
                         vec![sym("a"), sym("b")],
                         vec![sym("c"), sym("d")],
                     ]
@@ -1192,9 +1264,9 @@ mod tests {
     fn cases_with_conditions() {
         // \begin{cases} f & cond \\ g & cond \end{cases}
         let n = parse_math(r"\begin{cases} 1 & x > 0 \\ 0 & x \le 0 \end{cases}").unwrap();
-        match n {
+        match &n {
             MathNode::Matrix { env, rows } => {
-                assert_eq!(env, "cases");
+                assert_eq!(env.as_str(), "cases");
                 assert_eq!(rows.len(), 2);
                 assert_eq!(rows[0].len(), 2);
                 assert!(matches!(rows[0][1], MathNode::Rel(MRelOp::Gt, ..)));
@@ -1207,7 +1279,7 @@ mod tests {
     #[test]
     fn cells_hold_full_expressions() {
         let n = parse_math(r"\begin{matrix} \frac{a}{b} & x^2 \\ 1+1 & c \end{matrix}").unwrap();
-        match n {
+        match &n {
             MathNode::Matrix { rows, .. } => {
                 assert!(matches!(rows[0][0], MathNode::Frac(..)));
                 assert!(matches!(rows[0][1], MathNode::Script { .. }));
@@ -1220,9 +1292,9 @@ mod tests {
     #[test]
     fn single_column_multiple_rows() {
         let n = parse_math(r"\begin{matrix} a \\ b \\ c \end{matrix}").unwrap();
-        match n {
+        match &n {
             MathNode::Matrix { rows, .. } => {
-                assert_eq!(rows, vec![vec![sym("a")], vec![sym("b")], vec![sym("c")]]);
+                assert_eq!(rows, &vec![vec![sym("a")], vec![sym("b")], vec![sym("c")]]);
             }
             other => panic!("expected Matrix, got {other:?}"),
         }
@@ -1232,7 +1304,7 @@ mod tests {
     fn trailing_row_separator_is_tolerated() {
         // A trailing `\\` before `\end` does not create an empty final row.
         let n = parse_math(r"\begin{matrix} a \\ b \\ \end{matrix}").unwrap();
-        match n {
+        match &n {
             MathNode::Matrix { rows, .. } => assert_eq!(rows.len(), 2),
             other => panic!("expected Matrix, got {other:?}"),
         }
@@ -1244,7 +1316,7 @@ mod tests {
             r"\begin{pmatrix} \begin{pmatrix} a \end{pmatrix} & b \\ c & d \end{pmatrix}",
         )
         .unwrap();
-        match n {
+        match &n {
             MathNode::Matrix { rows, .. } => {
                 assert!(matches!(rows[0][0], MathNode::Matrix { .. }));
             }
@@ -1256,9 +1328,9 @@ mod tests {
     fn matrix_can_be_scripted() {
         // \begin{pmatrix}…\end{pmatrix}^2 — a matrix is an atom, so postfix scripts attach.
         let n = parse_math(r"\begin{pmatrix} a & b \\ c & d \end{pmatrix}^2").unwrap();
-        match n {
+        match &n {
             MathNode::Script { base, sup, .. } => {
-                assert!(matches!(*base, MathNode::Matrix { .. }));
+                assert!(matches!(**base, MathNode::Matrix { .. }));
                 assert_eq!(sup.as_deref(), Some(&num("2")));
             }
             other => panic!("expected Script over Matrix, got {other:?}"),
@@ -1273,5 +1345,46 @@ mod tests {
         assert!(parse_math(r"\begin{matrix} & b \end{matrix}").is_err()); // empty cell (limitation)
         assert!(parse_math(r"\end{matrix}").is_err()); // stray \end
         assert!(parse_math(r"\begin matrix").is_err()); // missing { after \begin
+    }
+
+    // ---- deep-tree Drop safety -------------------------------------------------
+    //
+    // The parser's `parse_add`/`parse_mul`/`parse_relation` build LEFT-nested chains via
+    // loops with no per-term depth charge, so a long chain like `1+1+1+…` yields an
+    // O(n)-deep `Bin` tree even though MAX_DEPTH bounds nesting. The *compiler-generated*
+    // destructor for such a tree recurses one stack frame per level → stack overflow (an
+    // uncatchable abort) on a deep-enough tree. `impl Drop for MathNode` dismantles the
+    // tree with a heap worklist instead, so these must complete without overflowing.
+
+    #[test]
+    fn deep_left_nested_tree_drops_without_overflow() {
+        // Build `((…((1+1)+1)+…)+1)` 200k levels deep directly (bypassing the parser's
+        // depth limits), then let it drop at end of scope. Pre-Drop-impl this aborted.
+        let mut node = num("1");
+        for _ in 0..200_000 {
+            node = MathNode::Bin(MBinOp::Add, Box::new(node), Box::new(num("1")));
+        }
+        // Touch it so the optimizer can't elide construction, then drop implicitly.
+        assert!(matches!(node, MathNode::Bin(MBinOp::Add, ..)));
+    }
+
+    #[test]
+    fn deep_parsed_chain_drops_without_overflow() {
+        // The same hazard but reached through the real parser: a long `+` chain parses to
+        // a deep left-nested tree. Keep it under MAX_DEPTH-per-nesting (these are loop
+        // iterations, not nesting) but long enough that a recursive Drop would overflow.
+        let src = format!("1{}", "+1".repeat(50_000));
+        let tree = parse_math(&src).expect("long additive chain parses");
+        drop(tree); // explicit: the heap-worklist Drop must not overflow
+    }
+
+    #[test]
+    fn deep_unary_chain_drops_without_overflow() {
+        // A `Unary` spine (single-child nodes) is the other deep shape; verify it too.
+        let mut node = num("1");
+        for _ in 0..200_000 {
+            node = MathNode::Unary(MUnOp::Neg, Box::new(node));
+        }
+        assert!(matches!(node, MathNode::Unary(MUnOp::Neg, _)));
     }
 }

--- a/code/specs/LTX01-full-latex-parser.md
+++ b/code/specs/LTX01-full-latex-parser.md
@@ -89,6 +89,16 @@ pub enum MathNode {
 Every node records a byte span. The parser is **total and panic-free**: malformed input
 yields a spanned `ParseError`, never a panic.
 
+**Deep-tree drop safety.** The math AST (`MathNode`) is a recursive `Box`-owning tree.
+`MAX_DEPTH` bounds *nesting*, but left-associative operator/relation chains are built in
+loops with no per-term depth charge, so well-formed input like `1+1+1+…` produces an
+O(n)-deep tree that `parse_math` returns successfully (it builds iteratively). A
+compiler-derived destructor would recurse one frame per level and overflow the stack on a
+deep-enough tree — an uncatchable abort that the spanned-error contract cannot cover. So
+`MathNode` (and the neutral `math_frontend::MathExpr`) implement `Drop` explicitly,
+dismantling the tree with a heap worklist (O(1) stack depth). Panic-freedom therefore holds
+through teardown as well as parse. (Implemented in `latex` 0.12.0 / `math-frontend` 0.3.0.)
+
 ## 4. Public API (`latex` crate)
 
 ```rust


### PR DESCRIPTION
## What

`MathNode` is a recursive `Box`-owning enum, so the compiler-derived destructor recurses once per level. The math parser builds **left-associative** chains via loops with no per-term depth charge (`parse_add`/`parse_mul`/`parse_relation`), so well-formed input like `1+1+1+…` (or a long juxtaposition `aaa…`) yields an O(n)-deep tree even though `MAX_DEPTH` bounds only *nesting*. `parse_math` itself survives (it builds iteratively), but **dropping** the returned tree overflowed the stack — an **uncatchable abort**, breaking the panic-free contract through teardown. This is the pre-existing latent hazard flagged in the L6 security review (`task_93ff511d`).

## How

- **`impl Drop for MathNode`** dismantles the tree with an explicit **heap worklist**: each boxed child is moved onto a `Vec` (replaced in place by a cheap `Sym("")` leaf), popped, and repeated, so the generated destructor recurses at most one trivial level. O(1) stack depth at any size. Mirrors `math_frontend::MathExpr`'s `Drop` (math-frontend 0.3.0).
- **`take_children` helper** does the per-variant child extraction (all 15 variants; `Matrix` rows drained via `mem::take`).
- Because `MathNode` now implements `Drop`, fields can no longer be moved out of an owned value in a by-value `match` (E0509). `frontend.rs`'s `lower()` trampoline and the by-value unit-test matches were rewritten to `match &node` / `match &mut node` and extract children via `mem::replace` / `Option::take` / `mem::take`. **No behavior change** — purely how ownership is threaded; push order and `has_*` flags preserved.

## Tests

- New regression tests: `deep_left_nested_tree_drops_without_overflow` (200k-deep `Bin` spine), `deep_parsed_chain_drops_without_overflow` (50k-term `+` chain through the real parser), `deep_unary_chain_drops_without_overflow` (200k-deep `Unary` spine).
- `cargo test -p latex` → **139 passed**; `--no-default-features` (zero-dep L0–L5) green; `cargo clippy -p latex -- -D warnings` clean.
- Downstream `cargo test -p adj-lang` (only consumer of `latex`) → **86 passed**.
- `/security-review` (Rust, diff inline): **PASSED** — variant coverage exhaustive, push order byte-for-byte equivalent, no unsafe, no new panics/double-free; confirms it fixes the unbounded-recursion stack-overflow DoS.

## Docs

CHANGELOG 0.11.0 → 0.12.0; README "Deep-tree drop safety" section; spec `LTX01` §3 gains a deep-tree-drop note (panic-freedom holds through teardown).

🤖 Generated with [Claude Code](https://claude.com/claude-code)