### PR TITLE
Add smart home dashboard activity entity filter

### DIFF
--- a/code/packages/rust/smart-home-platform-http/CHANGELOG.md
+++ b/code/packages/rust/smart-home-platform-http/CHANGELOG.md
@@ -75,6 +75,8 @@ All notable changes to this package will be documented in this file.
   views can be scoped to one local API caller from the dashboard URL.
 - Added browser dashboard command-result identity filters for command id, bridge
   id, and correlation id so audit views can be reopened from URL state.
+- Added a browser dashboard activity entity filter for scoping state history
+  and runtime event panels through existing entity-aware activity routes.
 - Added fixture-controller launch help, smoke-test URLs, and example-level tests
   to keep the local controller startup path usable.
 - Added a machine-readable local-controller smoke plan route that lists safe

--- a/code/packages/rust/smart-home-platform-http/README.md
+++ b/code/packages/rust/smart-home-platform-http/README.md
@@ -118,15 +118,15 @@ can be checked against the runtime policy boundary. Entity cards and state-gap
 rows also link to their current state, registry detail, desired-state target,
 state history, entity-scoped runtime events, and owning bridge command-result
 audit trail. The browser shell also exposes filters for
-room, entity domain/state/control status, runtime event kind, command-result
-status/id/bridge/correlation, authorization outcome/principal, and
-capability-grant status/scope/principal, with server-backed room scoping across
-inventory, state, history, event-log, and command-result panels plus
-server-backed command audit, authorization, and capability-grant scoping and
-local text search across the rendered dashboard rows. Those filter selections
-are mirrored into URL query parameters and restored on page load or browser
-navigation, so local-controller room, audit, and grant-boundary views can be
-shared or reopened directly.
+room, entity domain/state/control status, runtime event kind/activity entity,
+command-result status/id/bridge/correlation, authorization outcome/principal,
+and capability-grant status/scope/principal, with server-backed room scoping
+across inventory, state, history, event-log, and command-result panels plus
+server-backed activity, command audit, authorization, and capability-grant
+scoping and local text search across the rendered dashboard rows. Those filter
+selections are mirrored into URL query parameters and restored on page load or
+browser navigation, so local-controller room, activity, audit, and
+grant-boundary views can be shared or reopened directly.
 
 ## Dependencies
 

--- a/code/packages/rust/smart-home-platform-http/src/lib.rs
+++ b/code/packages/rust/smart-home-platform-http/src/lib.rs
@@ -389,6 +389,9 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
               <option value="supervision">Supervision</option>
             </select>
           </label>
+          <label>Activity Entity
+            <input id="filter-activity-entity" data-dashboard-filter="activity-entity" type="search" autocomplete="off">
+          </label>
           <label>Commands
             <select id="filter-command-status" data-dashboard-filter="command-status">
               <option value="">All commands</option>
@@ -570,6 +573,7 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
       devices: document.querySelector("#devices"),
       entities: document.querySelector("#entities"),
       events: document.querySelector("#events"),
+      filterActivityEntity: document.querySelector("#filter-activity-entity"),
       filterAuthorizationOutcome: document.querySelector("#filter-authorization-outcome"),
       filterAuthorizationPrincipal: document.querySelector("#filter-authorization-principal"),
       filterCommandBridge: document.querySelector("#filter-command-bridge"),
@@ -616,6 +620,7 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
       ["state", els.filterState],
       ["control", els.filterControl],
       ["event_kind", els.filterEventKind],
+      ["activity_entity", els.filterActivityEntity],
       ["command_status", els.filterCommandStatus],
       ["command_id", els.filterCommandId],
       ["command_bridge", els.filterCommandBridge],
@@ -671,6 +676,7 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
       state: els.filterState.value,
       control: els.filterControl.value,
       eventKind: els.filterEventKind.value,
+      activityEntity: els.filterActivityEntity.value.trim(),
       commandStatus: els.filterCommandStatus.value,
       commandId: els.filterCommandId.value.trim(),
       commandBridge: els.filterCommandBridge.value.trim(),
@@ -1133,6 +1139,7 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
           ? false
           : undefined;
       const roomId = filters.room || undefined;
+      const activityEntity = filters.activityEntity || undefined;
       try {
         const [
           bootstrap,
@@ -1158,13 +1165,22 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
           json(queryUrl("/api/smart_home/states", {limit: 24, room_id: roomId, stale: true})),
           json(queryUrl("/api/smart_home/scenes", {limit: 12, room_id: roomId})),
           json(queryUrl("/api/smart_home/desired_states", {limit: 12})),
-          json(queryUrl("/api/smart_home/state_history", {limit: 12, room_id: roomId})),
+          json(queryUrl("/api/smart_home/state_history", {
+            limit: 12,
+            room_id: roomId,
+            entity_id: activityEntity
+          })),
           json("/api/smart_home/services?limit=8"),
           json("/api/smart_home/api?mutating=true&authorized=true"),
           json("/api/smart_home/rooms?sort=scene_count"),
           json(queryUrl("/api/smart_home/devices", {limit: 8, room_id: roomId})),
           json("/api/smart_home/bridges?limit=8"),
-          json(queryUrl("/api/smart_home/events", {limit: 12, kind: filters.eventKind, room_id: roomId})),
+          json(queryUrl("/api/smart_home/events", {
+            limit: 12,
+            kind: filters.eventKind,
+            room_id: roomId,
+            entity_id: activityEntity
+          })),
           json(queryUrl("/api/smart_home/command_results", {
             limit: 8,
             room_id: roomId,
@@ -7915,9 +7931,11 @@ mod tests {
             assert!(body.contains("data-dashboard-filter=\"search\""));
             assert!(body.contains("data-dashboard-filter=\"room\""));
             assert!(body.contains("data-dashboard-filter=\"domain\""));
+            assert!(body.contains("data-dashboard-filter=\"activity-entity\""));
             assert!(body.contains("data-dashboard-filter=\"command-status\""));
             assert!(body.contains("const FILTER_QUERY_PARAMS = ["));
             assert!(body.contains("[\"event_kind\", els.filterEventKind]"));
+            assert!(body.contains("[\"activity_entity\", els.filterActivityEntity]"));
             assert!(body.contains("[\"command_status\", els.filterCommandStatus]"));
             assert!(body.contains("restoreFiltersFromUrl()"));
             assert!(body.contains("window.history.replaceState(null, \"\", nextUrl)"));
@@ -7931,9 +7949,10 @@ mod tests {
                 body.contains("queryUrl(\"/api/smart_home/scenes\", {limit: 12, room_id: roomId})")
             );
             assert!(body.contains("queryUrl(\"/api/smart_home/desired_states\", {limit: 12})"));
-            assert!(body.contains(
-                "queryUrl(\"/api/smart_home/state_history\", {limit: 12, room_id: roomId})"
-            ));
+            assert!(body.contains("const activityEntity = filters.activityEntity || undefined"));
+            assert!(body.contains("queryUrl(\"/api/smart_home/state_history\", {"));
+            assert!(body.contains("entity_id: activityEntity"));
+            assert!(body.matches("entity_id: activityEntity").count() >= 2);
             assert!(body.contains("json(\"/api/smart_home/services?limit=8\")"));
             assert!(body.contains("json(\"/api/smart_home/api?mutating=true&authorized=true\")"));
             assert!(body.contains("json(\"/api/smart_home/rooms?sort=scene_count\")"));
@@ -7941,9 +7960,7 @@ mod tests {
                 body.contains("queryUrl(\"/api/smart_home/devices\", {limit: 8, room_id: roomId})")
             );
             assert!(body.contains("json(\"/api/smart_home/bridges?limit=8\")"));
-            assert!(body.contains(
-                "queryUrl(\"/api/smart_home/events\", {limit: 12, kind: filters.eventKind, room_id: roomId})"
-            ));
+            assert!(body.contains("queryUrl(\"/api/smart_home/events\", {"));
             assert!(body.contains("queryUrl(\"/api/smart_home/command_results\", {"));
             assert!(body.contains("room_id: roomId"));
             assert!(body.contains("status: filters.commandStatus"));
@@ -9270,10 +9287,12 @@ mod tests {
         assert!(body.contains("data-dashboard-filter=\"grant-scope\""));
         assert!(body.contains("data-dashboard-filter=\"grant-principal\""));
         assert!(body.contains("data-dashboard-filter=\"authorization-principal\""));
+        assert!(body.contains("data-dashboard-filter=\"activity-entity\""));
         assert!(body.contains("data-dashboard-filter=\"command-id\""));
         assert!(body.contains("data-dashboard-filter=\"command-bridge\""));
         assert!(body.contains("data-dashboard-filter=\"command-correlation\""));
         assert!(body.contains("const FILTER_QUERY_PARAMS = ["));
+        assert!(body.contains("[\"activity_entity\", els.filterActivityEntity]"));
         assert!(body.contains("[\"command_id\", els.filterCommandId]"));
         assert!(body.contains("[\"command_bridge\", els.filterCommandBridge]"));
         assert!(body.contains("[\"command_correlation\", els.filterCommandCorrelation]"));
@@ -9283,8 +9302,11 @@ mod tests {
         assert!(body.contains("window.history.replaceState(null, \"\", nextUrl)"));
         assert!(body.contains("queryUrl(\"/api/smart_home/scenes\", {limit: 12, room_id: roomId})"));
         assert!(body.contains("queryUrl(\"/api/smart_home/desired_states\", {limit: 12})"));
-        assert!(body
-            .contains("queryUrl(\"/api/smart_home/state_history\", {limit: 12, room_id: roomId})"));
+        assert!(body.contains("const activityEntity = filters.activityEntity || undefined"));
+        assert!(body.contains("queryUrl(\"/api/smart_home/state_history\", {"));
+        assert!(body.contains("queryUrl(\"/api/smart_home/events\", {"));
+        assert!(body.contains("entity_id: activityEntity"));
+        assert!(body.matches("entity_id: activityEntity").count() >= 2);
         assert!(body.contains("json(\"/api/smart_home/services?limit=8\")"));
         assert!(body.contains("json(\"/api/smart_home/api?mutating=true&authorized=true\")"));
         assert!(body.contains("json(\"/api/smart_home/rooms?sort=scene_count\")"));


### PR DESCRIPTION
## Summary
- add an Activity Entity dashboard filter mirrored as the `activity_entity` URL query parameter
- pass that entity selector to the existing `/api/smart_home/state_history` and `/api/smart_home/events` entity-aware routes
- document the new server-backed activity scoping in the smart-home platform HTTP README and changelog

## Validation
- `cargo fmt -p smart-home-platform-http`
- `cargo test -p smart-home-platform-http -- --nocapture`
- `sh BUILD` from `code/packages/rust/smart-home-platform-http`
- `git diff --check`
- `test ! -e code/packages/rust/Cargo.lock`