### PR TITLE
[codex] Add Berkeley SPICE app session state

### DIFF
--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Add Berkeley SPICE app-deck session snapshots for Mosaic-facing Rust UI
+  substrates. `BerkeleyAppDeck::session_state()` and `run_session_state()` now
+  expose deterministic source fingerprints, selected-analysis state,
+  run/blocked status, diagnostics, table columns, output probes, and selected
+  waveform availability without requiring UI hosts to own simulator internals.
 - Add Berkeley SPICE app-deck waveform inspection series for Mosaic-facing
   Rust UI substrates. Card-indexed analysis artifacts now expose numeric
   plot-ready series derived from stable result tables, including selected-card

--- a/code/packages/rust/spice-netlist-parser/README.md
+++ b/code/packages/rust/spice-netlist-parser/README.md
@@ -45,6 +45,10 @@ let execution = deck.run_artifacts()?;
 assert_eq!(execution.analyses[0].syntax_card_index, Some(3));
 assert!(execution.analyses[0].table_columns.contains(&"Index".to_string()));
 assert_eq!(execution.analyses[0].waveform_series[0].x_column, "Index");
+
+let session = deck.run_session_state(Some(3))?;
+assert!(session.execution_available);
+assert_eq!(session.selected_waveform_series_count, Some(1));
 ```
 
 The facade preserves normalized logical cards, source spans, token names
@@ -53,9 +57,12 @@ analysis inventory, source-order execution through the existing parser, and
 card-indexed app artifacts with stable result tables, output-plan artifacts,
 run-artifact summaries, rawfile / wrdata artifact metadata from the engine deck
 execution layer, and numeric waveform series derived from result tables for
-Mosaic plot surfaces. It is the Rust app/runtime entrypoint for Mosaic-backed UI
-work while the grammar-backed parser generator and Python/TypeScript parity
-surfaces continue to mature.
+Mosaic plot surfaces. It also exposes app session snapshots with deterministic
+source fingerprints, selected-analysis state, run/blocked status, diagnostics,
+table columns, output probes, and selected waveform availability so Mosaic UI
+hosts can render editor controls without owning simulator internals. It is the
+Rust app/runtime entrypoint for Mosaic-backed UI work while the grammar-backed
+parser generator and Python/TypeScript parity surfaces continue to mature.
 
 This parser supports `R`, `C`, `L`, `V`, `I`, `D`, `Q`, `M`, `G`, `E`, `F`, and
 `H` elements, `.model <name> D(...)` diode cards with `IS` and `VT`

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -16,11 +16,11 @@ mod syntax;
 
 pub use syntax::{
     parse_berkeley_app_deck, parse_berkeley_syntax, BerkeleyAnalysisInventoryEntry,
-    BerkeleyAppAnalysisArtifact, BerkeleyAppDeck, BerkeleyAppExecution, BerkeleyAppWaveformPoint,
-    BerkeleyAppWaveformSeries, BerkeleyCardKind, BerkeleyDiagnosticSeverity,
-    BerkeleyGrammarMetadata, BerkeleyLogicalCard, BerkeleySyntaxDeck, BerkeleySyntaxDiagnostic,
-    BerkeleySyntaxToken, SourceSpan, BERKELEY_SPICE_GRAMMAR_NAME, BERKELEY_SPICE_GRAMMAR_VERSION,
-    BERKELEY_SPICE_PARSER_GRAMMAR, BERKELEY_SPICE_TOKEN_GRAMMAR,
+    BerkeleyAppAnalysisArtifact, BerkeleyAppDeck, BerkeleyAppExecution, BerkeleyAppSessionAnalysis,
+    BerkeleyAppSessionState, BerkeleyAppWaveformPoint, BerkeleyAppWaveformSeries, BerkeleyCardKind,
+    BerkeleyDiagnosticSeverity, BerkeleyGrammarMetadata, BerkeleyLogicalCard, BerkeleySyntaxDeck,
+    BerkeleySyntaxDiagnostic, BerkeleySyntaxToken, SourceSpan, BERKELEY_SPICE_GRAMMAR_NAME,
+    BERKELEY_SPICE_GRAMMAR_VERSION, BERKELEY_SPICE_PARSER_GRAMMAR, BERKELEY_SPICE_TOKEN_GRAMMAR,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/code/packages/rust/spice-netlist-parser/src/syntax.rs
+++ b/code/packages/rust/spice-netlist-parser/src/syntax.rs
@@ -236,6 +236,43 @@ pub struct BerkeleyAppExecution {
     pub run_artifact_json: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BerkeleyAppSessionAnalysis {
+    pub syntax_card_index: usize,
+    pub directive: String,
+    pub analysis: String,
+    pub span: SourceSpan,
+    pub runnable: bool,
+    pub artifact_supported: bool,
+    pub selected: bool,
+    pub execution_available: bool,
+    pub table_row_count: Option<usize>,
+    pub table_columns: Vec<String>,
+    pub waveform_series_count: Option<usize>,
+    pub output_probes: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BerkeleyAppSessionState {
+    pub canonical_source: String,
+    pub source_fingerprint: String,
+    pub title: Option<String>,
+    pub card_count: usize,
+    pub analysis_count: usize,
+    pub diagnostic_count: usize,
+    pub has_errors: bool,
+    pub parsed: bool,
+    pub execution_available: bool,
+    pub selected_syntax_card_index: Option<usize>,
+    pub selected_analysis: Option<BerkeleyAppSessionAnalysis>,
+    pub selected_table_columns: Vec<String>,
+    pub selected_output_probes: Vec<String>,
+    pub selected_waveform_series_count: Option<usize>,
+    pub blocking_message: Option<String>,
+    pub diagnostics: Vec<BerkeleySyntaxDiagnostic>,
+    pub analyses: Vec<BerkeleyAppSessionAnalysis>,
+}
+
 impl BerkeleyAppDeck {
     pub fn has_errors(&self) -> bool {
         self.diagnostics
@@ -245,6 +282,89 @@ impl BerkeleyAppDeck {
 
     pub fn analysis_inventory(&self) -> Vec<BerkeleyAnalysisInventoryEntry> {
         self.syntax.analysis_inventory()
+    }
+
+    pub fn session_state(
+        &self,
+        selected_syntax_card_index: Option<usize>,
+    ) -> BerkeleyAppSessionState {
+        let has_errors = self.has_errors();
+        let parsed = self.parsed.is_some();
+        let mut analyses = self
+            .analysis_inventory()
+            .into_iter()
+            .map(|entry| BerkeleyAppSessionAnalysis {
+                syntax_card_index: entry.index,
+                directive: entry.directive.clone(),
+                analysis: entry.analysis,
+                span: entry.span,
+                runnable: runnable_analysis_kind(&entry.directive).is_some(),
+                artifact_supported: deck_artifact_analysis_directive(&entry.directive),
+                selected: selected_syntax_card_index == Some(entry.index),
+                execution_available: false,
+                table_row_count: None,
+                table_columns: Vec::new(),
+                waveform_series_count: None,
+                output_probes: Vec::new(),
+            })
+            .collect::<Vec<_>>();
+        let selected_analysis = analyses.iter().find(|analysis| analysis.selected).cloned();
+
+        BerkeleyAppSessionState {
+            canonical_source: self.canonical_source.clone(),
+            source_fingerprint: stable_source_fingerprint(&self.canonical_source),
+            title: self.syntax.title.clone(),
+            card_count: self.syntax.cards.len(),
+            analysis_count: analyses.len(),
+            diagnostic_count: self.diagnostics.len(),
+            has_errors,
+            parsed,
+            execution_available: false,
+            selected_syntax_card_index,
+            selected_analysis,
+            selected_table_columns: Vec::new(),
+            selected_output_probes: Vec::new(),
+            selected_waveform_series_count: None,
+            blocking_message: if parsed {
+                None
+            } else {
+                Some(self.blocking_message())
+            },
+            diagnostics: self.diagnostics.clone(),
+            analyses: std::mem::take(&mut analyses),
+        }
+    }
+
+    pub fn run_session_state(
+        &self,
+        selected_syntax_card_index: Option<usize>,
+    ) -> Result<BerkeleyAppSessionState, AnalysisExecutionError> {
+        let mut state = self.session_state(selected_syntax_card_index);
+        if self.parsed.is_none() {
+            return Ok(state);
+        }
+
+        let execution = self.run_artifacts()?;
+        state.execution_available = true;
+        for artifact in &execution.analyses {
+            let Some(syntax_card_index) = artifact.syntax_card_index else {
+                continue;
+            };
+            let Some(analysis) = state
+                .analyses
+                .iter_mut()
+                .find(|analysis| analysis.syntax_card_index == syntax_card_index)
+            else {
+                continue;
+            };
+            analysis.execution_available = true;
+            analysis.table_row_count = Some(artifact.table_row_count);
+            analysis.table_columns = artifact.table_columns.clone();
+            analysis.waveform_series_count = Some(artifact.waveform_series_count);
+            analysis.output_probes = output_plan_probes(&artifact.output_plan_artifacts);
+        }
+        refresh_selected_session_analysis(&mut state);
+        Ok(state)
     }
 
     pub fn run_source_order(&self) -> Result<Vec<AnalysisExecutionResult>, AnalysisExecutionError> {
@@ -373,6 +493,44 @@ impl BerkeleyAppDeck {
                 "Berkeley SPICE app deck did not produce a parsed netlist".to_string()
             })
     }
+}
+
+fn refresh_selected_session_analysis(state: &mut BerkeleyAppSessionState) {
+    state.selected_analysis = state
+        .analyses
+        .iter()
+        .find(|analysis| Some(analysis.syntax_card_index) == state.selected_syntax_card_index)
+        .cloned();
+    if let Some(selected) = &state.selected_analysis {
+        state.selected_table_columns = selected.table_columns.clone();
+        state.selected_output_probes = selected.output_probes.clone();
+        state.selected_waveform_series_count = selected.waveform_series_count;
+    } else {
+        state.selected_table_columns.clear();
+        state.selected_output_probes.clear();
+        state.selected_waveform_series_count = None;
+    }
+}
+
+fn output_plan_probes(artifacts: &[DeckOutputPlanArtifact]) -> Vec<String> {
+    let mut probes = Vec::new();
+    for artifact in artifacts {
+        for probe in &artifact.output_probes {
+            if !probes.iter().any(|existing| existing == probe) {
+                probes.push(probe.clone());
+            }
+        }
+    }
+    probes
+}
+
+fn stable_source_fingerprint(source: &str) -> String {
+    let mut hash = 0xcbf2_9ce4_8422_2325_u64;
+    for byte in source.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    format!("{hash:016x}")
 }
 
 fn deck_artifact_analysis_directive(directive: &str) -> bool {

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -2025,6 +2025,92 @@ C1 out 0 1u
 }
 
 #[test]
+fn berkeley_app_facade_exports_selected_session_state() {
+    let app = parse_berkeley_app_deck(
+        r#"
+* transient session
+V1 in 0 PULSE(0 1 0 1n 1n 1n 4n)
+R1 in out 1k
+C1 out 0 1p
+.tran 1n 3n
+.print tran V(out)
+.end
+"#,
+    );
+
+    let state = app.run_session_state(Some(3)).unwrap();
+
+    assert!(state.parsed);
+    assert!(state.execution_available);
+    assert!(!state.has_errors, "{:?}", state.diagnostics);
+    assert_eq!(state.title.as_deref(), Some("transient session"));
+    assert_eq!(state.card_count, 6);
+    assert_eq!(state.analysis_count, 1);
+    assert_eq!(state.selected_syntax_card_index, Some(3));
+    assert_eq!(state.source_fingerprint.len(), 16);
+    assert!(state
+        .source_fingerprint
+        .chars()
+        .all(|ch| ch.is_ascii_hexdigit()));
+    assert_eq!(state.selected_waveform_series_count, Some(1));
+    assert_eq!(state.selected_output_probes, vec!["V(out)"]);
+    assert!(state
+        .selected_table_columns
+        .iter()
+        .any(|column| column == "Time"));
+    assert!(state
+        .selected_table_columns
+        .iter()
+        .any(|column| column == "V(out)"));
+
+    let selected = state.selected_analysis.unwrap();
+    assert!(selected.selected);
+    assert!(selected.runnable);
+    assert!(selected.artifact_supported);
+    assert!(selected.execution_available);
+    assert_eq!(selected.directive, ".tran");
+    assert_eq!(selected.analysis, "tran");
+    assert_eq!(selected.waveform_series_count, Some(1));
+    assert_eq!(selected.table_row_count, Some(3));
+    assert_eq!(selected.output_probes, vec!["V(out)"]);
+}
+
+#[test]
+fn berkeley_app_facade_session_state_reports_blocked_decks() {
+    let app = parse_berkeley_app_deck(
+        r#"
+V1 in 0 DC 1
+R1 in out
+.op
+.end
+"#,
+    );
+
+    let state = app.run_session_state(Some(2)).unwrap();
+
+    assert!(!state.parsed);
+    assert!(!state.execution_available);
+    assert!(state.has_errors);
+    assert_eq!(state.analysis_count, 1);
+    assert_eq!(state.selected_syntax_card_index, Some(2));
+    assert!(state
+        .blocking_message
+        .as_deref()
+        .unwrap()
+        .contains("Berkeley SPICE app deck:"));
+    assert_eq!(state.diagnostics[0].code, "SPICE_BERKELEY_LOWERING_ERROR");
+
+    let selected = state.selected_analysis.unwrap();
+    assert!(selected.selected);
+    assert!(selected.runnable);
+    assert!(selected.artifact_supported);
+    assert!(!selected.execution_available);
+    assert_eq!(selected.directive, ".op");
+    assert_eq!(selected.table_row_count, None);
+    assert_eq!(selected.waveform_series_count, None);
+}
+
+#[test]
 fn berkeley_app_facade_reports_lowering_errors_without_running() {
     let app = parse_berkeley_app_deck(
         r#"

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,11 +33,12 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Rust Berkeley Mosaic waveform inspection.
+1. Rust Berkeley Mosaic app session state.
    - Status: current PR completion candidate.
    - Expand the Rust `spice-netlist-parser` Berkeley app facade from
-     card-indexed stable result artifacts into plot-ready waveform inspection
-     series for Mosaic UI surfaces.
+     plot-ready waveform inspection into stable Mosaic-facing session snapshots
+     for source identity, selected analysis state, runnable/blocked status,
+     diagnostics, table/probe metadata, and waveform availability.
    - Keep this as a Rust-only app-substrate acceleration slice over the public
      parser contract and existing engine deck artifacts; Python and TypeScript
      parser parity was completed separately and should remain aligned when
@@ -1452,6 +1453,15 @@ the Rust, Python, and TypeScript surfaces together.
      deck artifacts as a Rust-only app-substrate acceleration layer while
      Python and TypeScript parser parity remains aligned for shared syntax
      behavior.
+
+137. Rust Berkeley Mosaic waveform inspection.
+   - Status: completed in PR 6936.
+   - Rust `spice-netlist-parser` Berkeley app-deck artifacts now expose numeric
+     plot-ready waveform series derived from stable result tables for Mosaic UI
+     surfaces.
+   - Selected-card waveform access covers transient series, and AC result
+     tables derive probe-grouped magnitude and phase series while preserving the
+     same public parser contract.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- add Mosaic-facing Berkeley app session snapshots with source fingerprints, selected-analysis state, run/blocked status, diagnostics, table/probe metadata, and waveform availability
- expose `BerkeleyAppSessionState` / `BerkeleyAppSessionAnalysis` plus `BerkeleyAppDeck::session_state()` and `run_session_state()` from the Rust parser facade
- update the Rust parser README/changelog and SPICE implementation plan after PR #6936 merged

## Validation
- `cargo fmt -p spice-netlist-parser`
- `cargo test -p spice-netlist-parser -- --nocapture`
- `cargo test -p grammar-tools --test spice_grammar_validation -- --nocapture`
- `git diff --check`