### PR TITLE
feat(latex): emit neutral MathExpr::Accent for diacritics (was faked as a Call)

### DIFF
--- a/code/packages/rust/latex/CHANGELOG.md
+++ b/code/packages/rust/latex/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to the full-fidelity LaTeX parser crate.
 
+## [0.13.0] — 2026-06-29
+
+### Changed — accents lower to the neutral `MathExpr::Accent` (no longer faked as a function call)
+
+The L6 adapter previously lowered a diacritical accent (`\hat{x}`, `\bar{y}`, `\vec{v}`,
+`\tilde{a}`, `\dot{x}`, …) to `MathExpr::Call { func: Func::Other(kind), arg }` — a *function
+application*, which is the wrong meaning: `\hat{x}` is a mark *over* `x`, not `hat(x)`. Now that
+`math-frontend` 0.4.0 provides a neutral **`MathExpr::Accent { accent, body }`** node, the adapter
+emits it faithfully.
+
+- `lower()`'s `MathNode::Accent { kind, body }` arm now pushes a new `Build::Accent(kind)` work step
+  (instead of `Build::Call(Func::Other(kind))`); its assembler pops the lowered body and produces
+  `MathExpr::Accent { accent: kind, body }`. Still inside the iterative trampoline — O(1) call-frame
+  depth, stack-safe on deep accent nests.
+- `capabilities()` stays `Capabilities::all()` — now **honestly** includes `accents`, which the
+  shared conformance harness (math-frontend 0.4.0) enforces (emitting an Accent requires declaring it).
+- Test `accent_is_a_named_unary` becomes `accent_lowers_to_neutral_accent_node` (asserts `\hat{x}` →
+  `Accent{accent:"hat", x}` and `\vec{v}` → `Accent{accent:"vec", v}`). Tests pass; downstream
+  `adj-lang` green (its adapter's catch-all routes an Accent to "unsupported ADJ arithmetic", since a
+  diacritic is not computable — behavior unchanged). clippy `-D warnings` clean.
+
 ## [0.12.0] — 2026-06-29
 
 ### Fixed — deep `MathNode` trees now drop without overflowing the stack

--- a/code/packages/rust/latex/Cargo.toml
+++ b/code/packages/rust/latex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latex"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "A full-fidelity LaTeX parser (documents and math): a catcode-driven, text-mode-primary tokenizer and (in later layers) a structural + math parser producing a faithful AST. Standalone and reusable; will also implement the math-frontend MathFrontend trait."
 license = "MIT"

--- a/code/packages/rust/latex/src/frontend.rs
+++ b/code/packages/rust/latex/src/frontend.rs
@@ -17,7 +17,8 @@
 //! - fence *style* is dropped: `(…)`, `[…]`, `\left(…\right)` all become [`MathExpr::Group`].
 //! - matrix *delimiter* is dropped: `pmatrix`/`bmatrix`/`cases`/… all become [`MathExpr::Matrix`].
 //! - `base^sup` → [`BinOp::Pow`]; `base_sub` → [`MathExpr::Subscript`]; both → `Pow(Subscript(…))`.
-//! - an accent (`\hat{x}`, `\vec{v}`) is a named unary, lowered to `Call{Other(kind), arg}`.
+//! - an accent (`\hat{x}`, `\vec{v}`) lowers to the neutral [`MathExpr::Accent`] (a diacritic
+//!   over its body), distinct from a named-function `Call`.
 //! - `\pm` / `\mp` → [`BinOp::PlusMinus`] / [`BinOp::MinusPlus`] (the ± / ∓ pair operators).
 //! - `\binom{n}{k}` → [`MathExpr::Binom`] (a binomial coefficient — no division bar).
 //!
@@ -92,6 +93,7 @@ enum Build {
     Root { has_degree: bool },
     Script { has_sub: bool, has_sup: bool },
     Call(Func),
+    Accent(String),
     BigOp { op: BigOp, has_lower: bool, has_upper: bool },
     Group,
     Rel(RelOp),
@@ -217,11 +219,13 @@ fn lower(root: MathNode, span: (usize, usize)) -> Result<MathExpr, FrontendError
                     work.push(Task::Build(Build::Call(lower_func(&func))));
                     work.push(Task::Node(arg));
                 }
-                // An accent is a named unary operator on its argument (`\hat{x}` ≈ hat(x)).
+                // A diacritical accent lowers to the neutral `MathExpr::Accent` (a mark over its
+                // body) — distinct from a named-function `Call`, so `\hat{x}` stays a hat *over*
+                // `x`, not the function `hat(x)`. (Needs `math-frontend` ≥ 0.4.0's Accent node.)
                 MathNode::Accent { kind, body } => {
                     let kind = std::mem::take(kind);
                     let body = take_box(body);
-                    work.push(Task::Build(Build::Call(Func::Other(kind))));
+                    work.push(Task::Build(Build::Accent(kind)));
                     work.push(Task::Node(body));
                 }
                 MathNode::BigOp { op, lower: lo, upper, body } => {
@@ -311,6 +315,10 @@ fn lower(root: MathNode, span: (usize, usize)) -> Result<MathExpr, FrontendError
                 Build::Call(func) => {
                     let arg = pop!();
                     vals.push(MathExpr::Call { func, arg: Box::new(arg) });
+                }
+                Build::Accent(accent) => {
+                    let body = pop!();
+                    vals.push(MathExpr::Accent { accent, body: Box::new(body) });
                 }
                 Build::BigOp { op, has_lower, has_upper } => {
                     let body = pop!();
@@ -539,13 +547,20 @@ mod tests {
     }
 
     #[test]
-    fn accent_is_a_named_unary() {
+    fn accent_lowers_to_neutral_accent_node() {
+        // `\hat{x}` is a diacritic OVER x — the neutral `MathExpr::Accent`, distinct from the
+        // named function `hat(x)` (which would be `\hat(x)` text / `\operatorname`).
         assert_eq!(
             m(r"\hat{x}"),
-            MathExpr::Call {
-                func: Func::Other("hat".into()),
-                arg: Box::new(MathExpr::Symbol("x".into())),
+            MathExpr::Accent {
+                accent: "hat".into(),
+                body: Box::new(MathExpr::Symbol("x".into())),
             }
+        );
+        // A different accent over a different body is distinct, and the body lowers recursively.
+        assert_eq!(
+            m(r"\vec{v}"),
+            MathExpr::Accent { accent: "vec".into(), body: Box::new(MathExpr::Symbol("v".into())) }
         );
     }
 

--- a/code/specs/LTX01-full-latex-parser.md
+++ b/code/specs/LTX01-full-latex-parser.md
@@ -187,7 +187,9 @@ is text-primary, which is a different mode model.)
 - **L6 (shipped) — `math-frontend` adapter.** `LatexMath` implements `MathFrontend` for `latex`:
   `parse` runs the L2/L3a grammar and lowers `MathNode` → neutral `MathExpr` (presentation
   dropped, meaning kept — `\times`/`\cdot`/juxtaposition → `Mul`, fence style → `Group`, matrix
-  delimiter → `Matrix`, accents → `Call{Other}`, exact numbers preserved). Declares
+  delimiter → `Matrix`, accents (`\hat{x}`/`\vec{v}`) → `Accent{accent, body}` (a diacritic over
+  its body, distinct from a function `Call`; needs `math-frontend` ≥ 0.4.0), exact numbers
+  preserved). Declares
   `Capabilities::all()` and conforms to the shared `check_frontend` harness. LaTeX is registered
   as plugin #1 via `latex::registry()` / `register_latex` — `math-frontend`'s `with_builtins()`
   stays empty because that crate cannot depend on `latex` (cycle), so the wiring lives in the


### PR DESCRIPTION
## What

With `math-frontend` 0.4.0's neutral `Accent` node now on main, the latex L6 adapter lowers a LaTeX diacritic **faithfully** instead of as a function application. Previously `\hat{x}` lowered to `MathExpr::Call { func: Func::Other("hat"), arg: x }` — semantically **wrong** (`\hat{x}` is a mark *over* `x`, not the function `hat(x)`). Now it lowers to `MathExpr::Accent { accent: "hat", body: x }`. This is the **latex half** of the accents-unblock the merged Accent node enabled.

## How

- New `Build::Accent(String)` work step. `lower()`'s `MathNode::Accent { kind, body }` arm pushes it (instead of `Build::Call(Func::Other(kind))`); its assembler pops the lowered body → `MathExpr::Accent { accent: kind, body }`. Stays inside the **iterative trampoline** — O(1) call-frame depth, stack-safe on deep accent nests (verified in review).
- `capabilities()` stays `Capabilities::all()` — now **honestly** includes `accents`, enforced by the shared conformance harness.
- Test `accent_is_a_named_unary` → `accent_lowers_to_neutral_accent_node` (asserts `\hat{x}` → `Accent{accent:"hat", x}` and `\vec{v}` → `Accent{accent:"vec", v}`); module doc updated.

## Verification

- `cargo test -p latex` → **139 pass**; `cargo clippy -p latex -- -D warnings` clean.
- Downstream `cargo test -p adj-lang` → **86 pass** (its adapter's catch-all routes an `Accent` to "unsupported ADJ arithmetic" — a diacritic isn't computable; **behavior unchanged**).
- `/security-review` (Rust, diff inline): **PASSED** — iterative O(1)-call-frame preserved, `pop!` returns a spanned error (no panic), change contained to the accent arm (general `Func::Other` function lowering unaffected), no unsafe/overflow/injection.

## Docs

Spec `LTX01` §5 L6 line updated (accents → `Accent`, not `Call{Other}`). CHANGELOG 0.12.0 → **0.13.0**.

Follow-up: asciimath accent emission (PR-2b) remains separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)