### PR TITLE
feat(asciimath): emit MathExpr::Accent for accents (PR-2b) — completes accents-unblock

### DIFF
--- a/code/packages/rust/asciimath/CHANGELOG.md
+++ b/code/packages/rust/asciimath/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to the AsciiMath pluggable frontend.
 
+## [0.3.0] — 2026-06-29
+
+### Added — accents (PR-2b), now that `math-frontend` 0.4.0 has a neutral `Accent` node
+
+AsciiMath accents were deferred at PR-2 because the neutral AST had no way to represent them.
+`math-frontend` 0.4.0 added `MathExpr::Accent { accent, body }`, so this release emits it.
+
+- **`hat x`, `bar y` / `overline y`, `vec v`, `dot x`, `ddot x`, `tilde a`, `ul x` /
+  `underline x`** now lower to `MathExpr::Accent` — a mark *over* the body, distinct from a
+  named-function `Call`. Each accent keyword takes the next single atom as its body (the same
+  "one atom argument" convention as `sqrt`/functions), so `hat(x+y)` accents the whole group.
+  Synonyms normalise to one canonical name (`bar`/`overline`→`"bar"`, `ul`/`underline`→
+  `"underline"`), so two spellings of the same mark lower equal.
+- New `accent_of()` keyword table + a parse branch in `parse_ident_atom` (after function
+  application). `capabilities()` gains `.with_accents()` — now honest, and the shared
+  conformance harness enforces it.
+- Tests: `accents_lower_to_neutral_accent_node` (per-accent + synonym + group-body + distinct);
+  `name_and_capabilities_are_honest` asserts `accents`; conformance corpus gains `hat x + vec v`
+  and `bar(x+y)`. 28 tests pass; clippy `-D warnings` clean.
+- This completes the accents-unblock across **both** frontends (latex emitted `Accent` in
+  latex 0.13.0; AsciiMath now matches).
+
 ## [0.2.0] — 2026-06-29
 
 ### Added — ASM01 PR-2: breadth (matrices + big operators)

--- a/code/packages/rust/asciimath/Cargo.toml
+++ b/code/packages/rust/asciimath/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "asciimath"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "An AsciiMath parser that implements the math-frontend MathFrontend trait: turns AsciiMath (1/2, sqrt(x), x^2+y^2=r^2) into the neutral MathExpr AST. The second pluggable frontend after LaTeX (see ASM01/PFE01). Total, panic-free, spanned errors."
 license = "MIT"

--- a/code/packages/rust/asciimath/README.md
+++ b/code/packages/rust/asciimath/README.md
@@ -53,9 +53,18 @@ second notation.
 
 `((a))` and `[[a]]` stay **grouping**, not a 1×1 matrix — a matrix must genuinely use commas
 (≥2 rows, or a row with ≥2 cells). Big-operator bounds (`_`/`^`) attach to the operator in either
-order; the body is the next atom (same convention as `sqrt`/functions). **Accents** (`hat x`, `vec x`)
-are not yet supported: the neutral `MathExpr` has no `Accent` node, so adding one to `math-frontend`
-is a prerequisite for an accents PR (see ASM01 §5).
+order; the body is the next atom (same convention as `sqrt`/functions).
+
+## PR-2b accents
+
+| AsciiMath | → neutral `MathExpr` |
+|-----------|----------------------|
+| `hat x`, `bar y` / `overline y`, `vec v`, `dot x`, `ddot x`, `tilde a`, `ul x` / `underline x` | `Accent { accent, body }` (a mark *over* the body, distinct from a function `Call`) |
+
+Each accent keyword takes the next single atom as its body (same convention as `sqrt`), so
+`hat(x+y)` accents the whole group. Synonyms normalise to one canonical name (`bar`/`overline`,
+`ul`/`underline`), so two spellings lower equal. Enabled by `math-frontend` 0.4.0's `MathExpr::Accent`
+node; `capabilities()` declares `accents` and the conformance harness enforces it.
 
 It is **total and panic-free**: every input returns `Ok(MathExpr)` or a spanned
 `FrontendError`. Recursion is depth-guarded (matrix nesting included); left-associative chains are

--- a/code/packages/rust/asciimath/src/lib.rs
+++ b/code/packages/rust/asciimath/src/lib.rs
@@ -57,10 +57,11 @@ impl MathFrontend for AsciiMath {
     }
 
     fn capabilities(&self) -> Capabilities {
-        // PR-1 surface + PR-2 breadth (`matrices`, `big_operators`). `plusminus`/`binomials`
-        // are not part of AsciiMath's core spelling here, and there is no neutral `Accent`
-        // node yet, so accents stay out until math-frontend grows one. Declaring
-        // `implicit_mul` is a parser-behavior claim (juxtaposition ⇒ `Mul`) the goldens cover.
+        // PR-1 surface + PR-2 breadth (`matrices`, `big_operators`) + PR-2b `accents`
+        // (`hat x`/`bar y`/`vec v`/`dot x`/`ddot x`/`tilde a`/`ul x`, emitted as
+        // `MathExpr::Accent` since math-frontend 0.4.0 grew the node). `plusminus`/`binomials`
+        // are not part of AsciiMath's core spelling here. Declaring `implicit_mul` is a
+        // parser-behavior claim (juxtaposition ⇒ `Mul`) the goldens cover.
         Capabilities::none()
             .with_fractions()
             .with_roots()
@@ -71,6 +72,7 @@ impl MathFrontend for AsciiMath {
             .with_text()
             .with_matrices()
             .with_big_operators()
+            .with_accents()
     }
 }
 
@@ -299,7 +301,40 @@ mod tests {
         let c = AsciiMath.capabilities();
         assert!(c.fractions && c.roots && c.powers && c.functions && c.relations && c.text && c.implicit_mul);
         assert!(c.matrices && c.big_operators); // PR-2 breadth
+        assert!(c.accents); // PR-2b: hat/bar/vec/dot/ddot/tilde/ul
         assert!(!c.plusminus && !c.binomials); // not part of AsciiMath's core spelling
+    }
+
+    // ---- accents (PR-2b) -------------------------------------------------------
+    #[test]
+    fn accents_lower_to_neutral_accent_node() {
+        // Each accent keyword takes the next single atom as its body (the `sqrt x` form) and
+        // lowers to `MathExpr::Accent` — a mark OVER the body, distinct from a function `Call`.
+        assert_eq!(
+            p("hat x"),
+            MathExpr::Accent { accent: "hat".into(), body: Box::new(sym("x")) }
+        );
+        assert_eq!(
+            p("vec v"),
+            MathExpr::Accent { accent: "vec".into(), body: Box::new(sym("v")) }
+        );
+        // Synonyms normalise to one canonical name, so two spellings lower equal.
+        assert_eq!(p("bar y"), p("overline y"));
+        assert_eq!(p("ul x"), p("underline x"));
+        assert_eq!(
+            p("bar y"),
+            MathExpr::Accent { accent: "bar".into(), body: Box::new(sym("y")) }
+        );
+        // The accented body is still a full atom: `hat(x+y)` accents the parenthesised group.
+        assert_eq!(
+            p("hat(x+y)"),
+            MathExpr::Accent {
+                accent: "hat".into(),
+                body: Box::new(b(BinOp::Add, sym("x"), sym("y"))),
+            }
+        );
+        // An accent over x is NOT the symbol x.
+        assert_ne!(p("dot x"), sym("x"));
     }
 
     #[test]
@@ -321,6 +356,8 @@ mod tests {
                 "[[a,b],[c,d]]",   // matrix
                 "sum_(i=1)^n i",   // big operator with bounds
                 "int_a^b f",       // big operator, integral
+                "hat x + vec v",   // accents (PR-2b)
+                "bar(x+y)",        // accent over a group
                 "1 +",   // error: trailing operator (span in range, not a panic)
                 "(x",    // error: missing close
                 "",      // error: empty

--- a/code/packages/rust/asciimath/src/parser.rs
+++ b/code/packages/rust/asciimath/src/parser.rs
@@ -347,6 +347,15 @@ impl Parser<'_> {
             let arg = self.parse_atom()?;
             return Ok(MathExpr::Call { func, arg: Box::new(arg) });
         }
+        // Diacritical accent: `hat x`, `bar y`, `vec v`, `dot x`, `ddot x`, `tilde a`, `ul x`.
+        // The accented thing is the next single atom (same "one atom argument" convention as
+        // `sqrt`/functions), lowered to the neutral `MathExpr::Accent` — a mark OVER the body,
+        // distinct from a function `Call`. (Needs `math-frontend` >= 0.4.0's Accent node.)
+        if let Some(accent) = accent_of(word) {
+            self.advance();
+            let body = self.parse_atom()?;
+            return Ok(MathExpr::Accent { accent: accent.to_string(), body: Box::new(body) });
+        }
         match word {
             "sqrt" => {
                 self.advance();
@@ -406,6 +415,24 @@ fn rel_of(kind: &TokenKind) -> Option<RelOp> {
 }
 
 /// Map an identifier to a big operator, or `None`. `int`=∫, `oint`=∮, `prod`=∏, `coprod`=∐.
+/// Map an AsciiMath accent keyword to its canonical neutral accent name (the `accent` field of
+/// [`MathExpr::Accent`]), or `None` if `word` is not an accent. AsciiMath spells accents as
+/// prefix words taking one argument: `hat x`, `bar y`/`overline y`, `vec v`, `dot x`, `ddot x`,
+/// `tilde a`, `ul x`/`underline x`. We normalise synonyms to one canonical name so two spellings
+/// of the same mark lower equal.
+fn accent_of(word: &str) -> Option<&'static str> {
+    Some(match word {
+        "hat" => "hat",
+        "bar" | "overline" => "bar",
+        "ul" | "underline" => "underline",
+        "vec" => "vec",
+        "dot" => "dot",
+        "ddot" => "ddot",
+        "tilde" => "tilde",
+        _ => return None,
+    })
+}
+
 fn bigop_of(word: &str) -> Option<BigOp> {
     Some(match word {
         "sum" => BigOp::Sum,

--- a/code/specs/ASM01-asciimath-frontend.md
+++ b/code/specs/ASM01-asciimath-frontend.md
@@ -85,10 +85,11 @@ shapes for representative inputs.
   `det[[…]]` binds the matrix); big operators `sum`/`prod`/`int`/`oint`/`coprod`/`lim` →
   `BigOp{op,lower,upper,body}` (optional `_`/`^` bounds either order, body = next atom). A new
   `Comma` token; `capabilities()` adds `matrices`+`big_operators`; matrix nesting is `MAX_DEPTH`-guarded.
-  **Accents deferred** — the neutral `MathExpr` has no `Accent` node; adding one to `math-frontend`
-  (with iterative-Drop + a `Capabilities::accents` flag) is the prerequisite, tracked as a follow-up.
-- **PR-2b (deferred):** accents (`hat`, `vec`, `bar`) once a neutral `Accent` node exists;
-  angle/invisible brackets `(: … :)`, `{: … :}`.
+- **PR-2b (shipped):** accents — `hat x`, `bar y`/`overline y`, `vec v`, `dot x`, `ddot x`,
+  `tilde a`, `ul x`/`underline x` → `MathExpr::Accent{accent, body}` (a mark over the body, distinct
+  from a function `Call`; body = next atom, like `sqrt`; synonyms normalise to one canonical name).
+  Enabled by `math-frontend` 0.4.0's neutral `Accent` node; `capabilities()` adds `accents` (enforced
+  by the conformance harness). Still deferred: angle/invisible brackets `(: … :)`, `{: … :}`.
 - **PR-3:** the full AsciiMath symbol table (greek, arrows, set/logic ops), longest-match
   tokenization (so `sinx` splits as `sin`·`x`), `stackrel`, `overset`/`underset`, and the
   `text(…)` keyword form alongside the `"…"` literal.


### PR DESCRIPTION
## What

AsciiMath accents were deferred at PR-2 because the neutral AST had no `Accent` node. `math-frontend` 0.4.0 added `MathExpr::Accent { accent, body }`, so this emits it — the **asciimath half** of the accents-unblock (latex emitted `Accent` in latex 0.13.0; AsciiMath now matches, so the capability is symmetric across **both** frontends).

## How

- `parser.rs`: new `accent_of()` keyword table (`hat`, `bar`/`overline`, `ul`/`underline`, `vec`, `dot`, `ddot`, `tilde` → canonical name) + a parse branch in `parse_ident_atom` (after function application). Each accent takes the **next single atom** as its body (the `sqrt x` "one atom argument" convention), so `hat(x+y)` accents the whole group. Synonyms normalise to one canonical name so two spellings lower equal. Emits `MathExpr::Accent` — a mark *over* the body, distinct from a function `Call`.
- `lib.rs`: `capabilities()` gains `.with_accents()` (now honest; the shared conformance harness enforces it).

## Verification

- New test `accents_lower_to_neutral_accent_node` (per-accent + synonym + group-body + distinct-from-symbol); `name_and_capabilities_are_honest` asserts `accents`; conformance corpus gains `hat x + vec v` and `bar(x+y)`. **28 tests pass**; `clippy -D warnings` clean.
- `/security-review` (Rust, diff inline): **PASSED** — accent recursion is bounded by the same `MAX_DEPTH` guard as `sqrt` (no new overflow vector), no panic/unwrap on adversarial input, `accent_of` is a pure inert `&str` match (no unsafe/injection), and the capability declaration is honest. Ordering note: the accent branch precedes the `sqrt`/`root` match so no keyword collision.

## Docs

Spec `ASM01` PR-2b marked **shipped**; README gains a PR-2b accents section; CHANGELOG 0.2.0 → **0.3.0**.

This completes the accents story end-to-end: neutral node (math-frontend 0.4.0) → latex emission (0.13.0) → asciimath emission (this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)