### PR TITLE
[codex] Add Berkeley SPICE app editor controls

### DIFF
--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add Berkeley SPICE app-deck editor controls for Mosaic-facing Rust UI
+  substrates. `BerkeleyAppDeck::editor_controls()` and `run_editor_controls()`
+  now expose stable per-analysis select/run/table/waveform actions, enabled
+  states, and disabled reasons derived from the app session state.
 - Add Berkeley SPICE app-deck session snapshots for Mosaic-facing Rust UI
   substrates. `BerkeleyAppDeck::session_state()` and `run_session_state()` now
   expose deterministic source fingerprints, selected-analysis state,

--- a/code/packages/rust/spice-netlist-parser/README.md
+++ b/code/packages/rust/spice-netlist-parser/README.md
@@ -49,6 +49,9 @@ assert_eq!(execution.analyses[0].waveform_series[0].x_column, "Index");
 let session = deck.run_session_state(Some(3))?;
 assert!(session.execution_available);
 assert_eq!(session.selected_waveform_series_count, Some(1));
+
+let controls = deck.run_editor_controls(Some(3))?;
+assert!(controls.selected_control.unwrap().waveform_available);
 ```
 
 The facade preserves normalized logical cards, source spans, token names
@@ -60,9 +63,11 @@ execution layer, and numeric waveform series derived from result tables for
 Mosaic plot surfaces. It also exposes app session snapshots with deterministic
 source fingerprints, selected-analysis state, run/blocked status, diagnostics,
 table columns, output probes, and selected waveform availability so Mosaic UI
-hosts can render editor controls without owning simulator internals. It is the
-Rust app/runtime entrypoint for Mosaic-backed UI work while the grammar-backed
-parser generator and Python/TypeScript parity surfaces continue to mature.
+hosts can render editor state without owning simulator internals. It also
+derives stable per-analysis editor controls for selecting, running, and
+inspecting tables or waveforms with explicit disabled reasons. It is the Rust
+app/runtime entrypoint for Mosaic-backed UI work while the grammar-backed parser
+generator and Python/TypeScript parity surfaces continue to mature.
 
 This parser supports `R`, `C`, `L`, `V`, `I`, `D`, `Q`, `M`, `G`, `E`, `F`, and
 `H` elements, `.model <name> D(...)` diode cards with `IS` and `VT`

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -16,8 +16,10 @@ mod syntax;
 
 pub use syntax::{
     parse_berkeley_app_deck, parse_berkeley_syntax, BerkeleyAnalysisInventoryEntry,
-    BerkeleyAppAnalysisArtifact, BerkeleyAppDeck, BerkeleyAppExecution, BerkeleyAppSessionAnalysis,
-    BerkeleyAppSessionState, BerkeleyAppWaveformPoint, BerkeleyAppWaveformSeries, BerkeleyCardKind,
+    BerkeleyAppAnalysisArtifact, BerkeleyAppAnalysisControl, BerkeleyAppDeck,
+    BerkeleyAppEditorAction, BerkeleyAppEditorActionKind, BerkeleyAppEditorControls,
+    BerkeleyAppExecution, BerkeleyAppSessionAnalysis, BerkeleyAppSessionState,
+    BerkeleyAppWaveformPoint, BerkeleyAppWaveformSeries, BerkeleyCardKind,
     BerkeleyDiagnosticSeverity, BerkeleyGrammarMetadata, BerkeleyLogicalCard, BerkeleySyntaxDeck,
     BerkeleySyntaxDiagnostic, BerkeleySyntaxToken, SourceSpan, BERKELEY_SPICE_GRAMMAR_NAME,
     BERKELEY_SPICE_GRAMMAR_VERSION, BERKELEY_SPICE_PARSER_GRAMMAR, BERKELEY_SPICE_TOKEN_GRAMMAR,

--- a/code/packages/rust/spice-netlist-parser/src/syntax.rs
+++ b/code/packages/rust/spice-netlist-parser/src/syntax.rs
@@ -273,6 +273,53 @@ pub struct BerkeleyAppSessionState {
     pub analyses: Vec<BerkeleyAppSessionAnalysis>,
 }
 
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum BerkeleyAppEditorActionKind {
+    SelectAnalysis,
+    RunAnalysis,
+    InspectTable,
+    InspectWaveform,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BerkeleyAppEditorAction {
+    pub kind: BerkeleyAppEditorActionKind,
+    pub label: String,
+    pub enabled: bool,
+    pub disabled_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BerkeleyAppAnalysisControl {
+    pub syntax_card_index: usize,
+    pub directive: String,
+    pub analysis: String,
+    pub span: SourceSpan,
+    pub selected: bool,
+    pub runnable: bool,
+    pub artifact_supported: bool,
+    pub execution_available: bool,
+    pub table_available: bool,
+    pub waveform_available: bool,
+    pub action_count: usize,
+    pub actions: Vec<BerkeleyAppEditorAction>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BerkeleyAppEditorControls {
+    pub canonical_source: String,
+    pub source_fingerprint: String,
+    pub title: Option<String>,
+    pub parsed: bool,
+    pub execution_available: bool,
+    pub selected_syntax_card_index: Option<usize>,
+    pub selected_control: Option<BerkeleyAppAnalysisControl>,
+    pub control_count: usize,
+    pub controls: Vec<BerkeleyAppAnalysisControl>,
+    pub blocking_message: Option<String>,
+    pub diagnostics: Vec<BerkeleySyntaxDiagnostic>,
+}
+
 impl BerkeleyAppDeck {
     pub fn has_errors(&self) -> bool {
         self.diagnostics
@@ -365,6 +412,22 @@ impl BerkeleyAppDeck {
         }
         refresh_selected_session_analysis(&mut state);
         Ok(state)
+    }
+
+    pub fn editor_controls(
+        &self,
+        selected_syntax_card_index: Option<usize>,
+    ) -> BerkeleyAppEditorControls {
+        editor_controls_from_session_state(&self.session_state(selected_syntax_card_index))
+    }
+
+    pub fn run_editor_controls(
+        &self,
+        selected_syntax_card_index: Option<usize>,
+    ) -> Result<BerkeleyAppEditorControls, AnalysisExecutionError> {
+        Ok(editor_controls_from_session_state(
+            &self.run_session_state(selected_syntax_card_index)?,
+        ))
     }
 
     pub fn run_source_order(&self) -> Result<Vec<AnalysisExecutionResult>, AnalysisExecutionError> {
@@ -492,6 +555,138 @@ impl BerkeleyAppDeck {
             .unwrap_or_else(|| {
                 "Berkeley SPICE app deck did not produce a parsed netlist".to_string()
             })
+    }
+}
+
+fn editor_controls_from_session_state(
+    state: &BerkeleyAppSessionState,
+) -> BerkeleyAppEditorControls {
+    let controls = state
+        .analyses
+        .iter()
+        .map(|analysis| analysis_control_from_session_state(state, analysis))
+        .collect::<Vec<_>>();
+    let selected_control = controls.iter().find(|control| control.selected).cloned();
+
+    BerkeleyAppEditorControls {
+        canonical_source: state.canonical_source.clone(),
+        source_fingerprint: state.source_fingerprint.clone(),
+        title: state.title.clone(),
+        parsed: state.parsed,
+        execution_available: state.execution_available,
+        selected_syntax_card_index: state.selected_syntax_card_index,
+        selected_control,
+        control_count: controls.len(),
+        controls,
+        blocking_message: state.blocking_message.clone(),
+        diagnostics: state.diagnostics.clone(),
+    }
+}
+
+fn analysis_control_from_session_state(
+    state: &BerkeleyAppSessionState,
+    analysis: &BerkeleyAppSessionAnalysis,
+) -> BerkeleyAppAnalysisControl {
+    let table_available = analysis.execution_available && analysis.table_row_count.is_some();
+    let waveform_available =
+        analysis.execution_available && analysis.waveform_series_count.unwrap_or(0) > 0;
+    let actions = vec![
+        BerkeleyAppEditorAction {
+            kind: BerkeleyAppEditorActionKind::SelectAnalysis,
+            label: format!("Select {}", analysis.directive),
+            enabled: true,
+            disabled_reason: None,
+        },
+        editor_action(
+            BerkeleyAppEditorActionKind::RunAnalysis,
+            format!("Run {}", analysis.directive),
+            state.parsed && analysis.runnable,
+            run_action_disabled_reason(state, analysis),
+        ),
+        editor_action(
+            BerkeleyAppEditorActionKind::InspectTable,
+            format!("Inspect {} table", analysis.directive),
+            table_available,
+            table_action_disabled_reason(state, analysis),
+        ),
+        editor_action(
+            BerkeleyAppEditorActionKind::InspectWaveform,
+            format!("Inspect {} waveform", analysis.directive),
+            waveform_available,
+            waveform_action_disabled_reason(state, analysis),
+        ),
+    ];
+
+    BerkeleyAppAnalysisControl {
+        syntax_card_index: analysis.syntax_card_index,
+        directive: analysis.directive.clone(),
+        analysis: analysis.analysis.clone(),
+        span: analysis.span,
+        selected: analysis.selected,
+        runnable: analysis.runnable,
+        artifact_supported: analysis.artifact_supported,
+        execution_available: analysis.execution_available,
+        table_available,
+        waveform_available,
+        action_count: actions.len(),
+        actions,
+    }
+}
+
+fn editor_action(
+    kind: BerkeleyAppEditorActionKind,
+    label: String,
+    enabled: bool,
+    disabled_reason: Option<String>,
+) -> BerkeleyAppEditorAction {
+    BerkeleyAppEditorAction {
+        kind,
+        label,
+        enabled,
+        disabled_reason: if enabled { None } else { disabled_reason },
+    }
+}
+
+fn run_action_disabled_reason(
+    state: &BerkeleyAppSessionState,
+    analysis: &BerkeleyAppSessionAnalysis,
+) -> Option<String> {
+    if !state.parsed {
+        state.blocking_message.clone()
+    } else if !analysis.runnable {
+        Some("analysis is not runnable from the app facade".to_string())
+    } else {
+        None
+    }
+}
+
+fn table_action_disabled_reason(
+    state: &BerkeleyAppSessionState,
+    analysis: &BerkeleyAppSessionAnalysis,
+) -> Option<String> {
+    if !state.parsed {
+        state.blocking_message.clone()
+    } else if !analysis.artifact_supported {
+        Some("analysis artifacts are not supported".to_string())
+    } else if !analysis.execution_available {
+        Some("run deck artifacts to populate analysis table".to_string())
+    } else {
+        Some("analysis did not produce a result table".to_string())
+    }
+}
+
+fn waveform_action_disabled_reason(
+    state: &BerkeleyAppSessionState,
+    analysis: &BerkeleyAppSessionAnalysis,
+) -> Option<String> {
+    if !state.parsed {
+        state.blocking_message.clone()
+    } else if !analysis.artifact_supported {
+        Some("analysis artifacts are not supported".to_string())
+    } else if !analysis.execution_available {
+        Some("run deck artifacts to populate waveform series".to_string())
+    } else {
+        Some("analysis has no waveform series".to_string())
     }
 }
 

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -4,12 +4,13 @@ use spice_engine::{
 };
 use spice_netlist_parser::{
     build_analysis_plan, parse_berkeley_app_deck, parse_berkeley_syntax, parse_netlist,
-    parse_value, run_netlist, AcAnalysis, Analysis, AnalysisKind, AnalysisResult, BerkeleyCardKind,
-    BerkeleyDiagnosticSeverity, BerkeleyGrammarMetadata, DcAnalysis, DistortionAnalysis,
-    FourAnalysis, McAnalysis, MeasureAnalysis, MeasureOperation, NetlistParseError, NoiseAnalysis,
-    OpAnalysis, OptionValue, OutputProbe, PlotAnalysis, PoleZeroAnalysis, PoleZeroKind,
-    PrintAnalysis, ProbeAnalysis, SaveAnalysis, SelectedOutputValue, SensAnalysis, TempAnalysis,
-    TfAnalysis, TranAnalysis, BERKELEY_SPICE_GRAMMAR_NAME, BERKELEY_SPICE_GRAMMAR_VERSION,
+    parse_value, run_netlist, AcAnalysis, Analysis, AnalysisKind, AnalysisResult,
+    BerkeleyAppEditorActionKind, BerkeleyCardKind, BerkeleyDiagnosticSeverity,
+    BerkeleyGrammarMetadata, DcAnalysis, DistortionAnalysis, FourAnalysis, McAnalysis,
+    MeasureAnalysis, MeasureOperation, NetlistParseError, NoiseAnalysis, OpAnalysis, OptionValue,
+    OutputProbe, PlotAnalysis, PoleZeroAnalysis, PoleZeroKind, PrintAnalysis, ProbeAnalysis,
+    SaveAnalysis, SelectedOutputValue, SensAnalysis, TempAnalysis, TfAnalysis, TranAnalysis,
+    BERKELEY_SPICE_GRAMMAR_NAME, BERKELEY_SPICE_GRAMMAR_VERSION,
 };
 
 fn assert_close(actual: f64, expected: f64) {
@@ -2073,6 +2074,115 @@ C1 out 0 1p
     assert_eq!(selected.waveform_series_count, Some(1));
     assert_eq!(selected.table_row_count, Some(3));
     assert_eq!(selected.output_probes, vec!["V(out)"]);
+}
+
+#[test]
+fn berkeley_app_facade_exports_editor_controls_after_execution() {
+    let app = parse_berkeley_app_deck(
+        r#"
+* transient editor controls
+V1 in 0 PULSE(0 1 0 1n 1n 1n 4n)
+R1 in out 1k
+C1 out 0 1p
+.tran 1n 3n
+.print tran V(out)
+.end
+"#,
+    );
+
+    let controls = app.run_editor_controls(Some(3)).unwrap();
+
+    assert!(controls.parsed);
+    assert!(controls.execution_available);
+    assert_eq!(controls.control_count, 1);
+    assert_eq!(controls.selected_syntax_card_index, Some(3));
+    assert_eq!(controls.source_fingerprint.len(), 16);
+
+    let selected = controls.selected_control.as_ref().unwrap();
+    assert_eq!(selected.syntax_card_index, 3);
+    assert_eq!(selected.directive, ".tran");
+    assert!(selected.selected);
+    assert!(selected.runnable);
+    assert!(selected.artifact_supported);
+    assert!(selected.execution_available);
+    assert!(selected.table_available);
+    assert!(selected.waveform_available);
+    assert_eq!(selected.action_count, 4);
+
+    let action = |kind| {
+        selected
+            .actions
+            .iter()
+            .find(|action| action.kind == kind)
+            .unwrap()
+    };
+    assert_eq!(
+        action(BerkeleyAppEditorActionKind::SelectAnalysis).label,
+        "Select .tran"
+    );
+    assert!(action(BerkeleyAppEditorActionKind::RunAnalysis).enabled);
+    assert!(action(BerkeleyAppEditorActionKind::InspectTable).enabled);
+    assert!(action(BerkeleyAppEditorActionKind::InspectWaveform).enabled);
+}
+
+#[test]
+fn berkeley_app_facade_editor_controls_explain_disabled_actions() {
+    let app = parse_berkeley_app_deck(
+        r#"
+* transient editor controls
+V1 in 0 PULSE(0 1 0 1n 1n 1n 4n)
+R1 in out 1k
+C1 out 0 1p
+.tran 1n 3n
+.print tran V(out)
+.end
+"#,
+    );
+
+    let controls = app.editor_controls(Some(3));
+    let selected = controls.selected_control.as_ref().unwrap();
+    let table = selected
+        .actions
+        .iter()
+        .find(|action| action.kind == BerkeleyAppEditorActionKind::InspectTable)
+        .unwrap();
+    let waveform = selected
+        .actions
+        .iter()
+        .find(|action| action.kind == BerkeleyAppEditorActionKind::InspectWaveform)
+        .unwrap();
+    assert!(!table.enabled);
+    assert_eq!(
+        table.disabled_reason.as_deref(),
+        Some("run deck artifacts to populate analysis table")
+    );
+    assert!(!waveform.enabled);
+    assert_eq!(
+        waveform.disabled_reason.as_deref(),
+        Some("run deck artifacts to populate waveform series")
+    );
+
+    let blocked = parse_berkeley_app_deck(
+        r#"
+V1 in 0 DC 1
+R1 in out
+.op
+.end
+"#,
+    );
+    let controls = blocked.editor_controls(Some(2));
+    let selected = controls.selected_control.as_ref().unwrap();
+    let run = selected
+        .actions
+        .iter()
+        .find(|action| action.kind == BerkeleyAppEditorActionKind::RunAnalysis)
+        .unwrap();
+    assert!(!run.enabled);
+    assert!(run
+        .disabled_reason
+        .as_deref()
+        .unwrap()
+        .contains("Berkeley SPICE app deck:"));
 }
 
 #[test]

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,12 +33,15 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Rust Berkeley Mosaic app session state.
+1. Rust Berkeley Mosaic editor controls.
    - Status: current PR completion candidate.
    - Expand the Rust `spice-netlist-parser` Berkeley app facade from
-     plot-ready waveform inspection into stable Mosaic-facing session snapshots
-     for source identity, selected analysis state, runnable/blocked status,
-     diagnostics, table/probe metadata, and waveform availability.
+     stable Mosaic-facing session snapshots into deterministic editor control
+     metadata for selecting, running, and inspecting analysis tables and
+     waveforms.
+   - Expose per-analysis actions with enabled states and stable disabled
+     reasons so Mosaic hosts can render controls without owning parser or
+     simulator internals.
    - Keep this as a Rust-only app-substrate acceleration slice over the public
      parser contract and existing engine deck artifacts; Python and TypeScript
      parser parity was completed separately and should remain aligned when
@@ -1463,6 +1466,16 @@ the Rust, Python, and TypeScript surfaces together.
      tables derive probe-grouped magnitude and phase series while preserving the
      same public parser contract.
 
+138. Rust Berkeley Mosaic app session state.
+   - Status: completed in PR 6944.
+   - Rust `spice-netlist-parser` Berkeley app-deck snapshots now expose source
+     fingerprints, selected-analysis state, runnable/blocked status,
+     diagnostics, table/probe metadata, and selected waveform availability for
+     Mosaic UI surfaces.
+   - The slice preserves the Rust app facade as a UI substrate over the public
+     Berkeley parser contract while Python and TypeScript parser parity remains
+     aligned for shared syntax behavior.
+
 ## Backlog
 
 1. Grammar-backed parser and app facade.
@@ -1470,9 +1483,9 @@ the Rust, Python, and TypeScript surfaces together.
      syntax facade as the grammar evolves, even if that breaks current
      pre-release parser APIs.
    - Continue expanding the Rust Mosaic app facade beyond the initial
-     card-indexed result artifacts toward richer waveform inspection, app
-     session state, and editor-driven analysis controls backed by the same
-     public parser contract.
+     card-indexed result artifacts toward richer editor command wiring,
+     persisted UI state, and host integration backed by the same public parser
+     contract.
 
 2. Deck compatibility follow-up.
    - Expand deck-owned output compatibility beyond source-order analysis


### PR DESCRIPTION
## Summary
- add a Rust Berkeley app editor-control surface derived from session state, with per-analysis select/run/table/waveform actions and stable disabled reasons
- expose `BerkeleyAppDeck::editor_controls()` and `run_editor_controls()` plus public control/action structs for Mosaic hosts
- update parser docs/changelog and advance the SPICE plan after PR #6944 merged

## Validation
- `cargo fmt -p spice-netlist-parser`
- `cargo test -p spice-netlist-parser -- --nocapture`
- `cargo test -p grammar-tools --test spice_grammar_validation -- --nocapture`
- `git diff --check`