### PR TITLE
feat(javascript-parser): per-token CvIds to bridge leaves (CLOC27 P2+P3)

### DIFF
--- a/code/packages/rust/javascript-parser/CHANGELOG.md
+++ b/code/packages/rust/javascript-parser/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 All notable changes to the `coding-adventures-javascript-parser` crate will be documented in this file.
 
+## [0.19.2] - 2026-06-29
+
+### Added — propagate per-token CvIds to the bridge (CLOC27 P2 + P3)
+
+Closes the gap where constant-fold provenance dead-ended at the bridge
+boundary: leaf literals in the typed AST carried `cv: None`, so a folded `3`
+from `"abc".length` derived from *nothing* and the sidecar never tied it back
+to the `"abc".length` source span. The CvIds already existed (minted per token
+by `tokenize_javascript_with_cv`) — they were simply discarded before the
+parser. This release stops discarding them and stamps them onto the leaves.
+
+- **D2 — stop stripping the CvId before the parser.** `parse_javascript_with_cv`
+  previously did `cv_tokens.into_iter().map(|t| t.token)`, dropping each token's
+  CvId; it now sets `cv: Some(t.cv)` on the token via struct-update, so the id
+  rides through the parser into the `GrammarASTNode` the bridge walks. The
+  parser does not inspect `cv`, so this is transparent to it.
+- **D3 — `parse_javascript_typed_with_cv`.** New CV-carrying twin of
+  `parse_javascript_typed`: routes through the CV tokenizer (D2) and runs the
+  identical Phase-1 ASI parse, returning a `GrammarASTNode` whose tokens carry
+  CvIds. This is the typed-AST feeder the SIMPLE `--correlation_vector` path
+  will use (CLOC27 D5/P4). The plain `parse_javascript_typed` stays the
+  zero-overhead default.
+- **D4 — stamp the leaf in `convert_primary_token`.** The bridge's sole
+  leaf-literal factory replaces its nine `cv: None` returns
+  (`NullLiteral`, `UndefinedLiteral`, `BooleanLiteral`×2, `BigIntLiteral`,
+  `NumericLiteral`, `StringLiteral`, `Identifier`×2) with `cv: t.cv.clone()`.
+  When the token carries no id (the non-CV path), this is `None` —
+  **byte-identical to today**, so every existing test passes unchanged. When CV
+  is on, the leaf now carries its source token's CvId, whose `Origin` is the
+  source span.
+
+No emitter change and no minting in the bridge: CvIds never appear in emitted
+JS, and the bridge stays a pure `GrammarASTNode → Program` transform that only
+*copies* an id that already exists. The disabled (non-CV) path is unchanged.
+
 ## [0.19.1] - 2026-06-29
 
 ### Changed — adapt to `lexer::Token` gaining a `cv` field (CLOC27 P1)

--- a/code/packages/rust/javascript-parser/Cargo.toml
+++ b/code/packages/rust/javascript-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-javascript-parser"
-version = "0.19.1"
+version = "0.19.2"
 edition = "2021"
 description = "JavaScript parser — parses JavaScript source code against any ECMAScript edition (es1 through es2025) using the grammar-driven parser. Includes correlation-vector plumbing per CLOC03 and a typed-AST bridge (GrammarASTNode → javascript_ast::Program) per CLOC12.136."
 

--- a/code/packages/rust/javascript-parser/src/bridge.rs
+++ b/code/packages/rust/javascript-parser/src/bridge.rs
@@ -1826,10 +1826,10 @@ fn convert_primary_token(t: &Token, ctx: &GrammarASTNode) -> Result<Expression, 
             rule: "ThisExpression".to_string(),
             location: loc(ctx),
         }),
-        "null" => return Ok(Expression::NullLiteral(NullLiteral { cv: None })),
-        "undefined" => return Ok(Expression::UndefinedLiteral(UndefinedLiteral { cv: None })),
-        "true" => return Ok(Expression::BooleanLiteral(BooleanLiteral { cv: None, value: true })),
-        "false" => return Ok(Expression::BooleanLiteral(BooleanLiteral { cv: None, value: false })),
+        "null" => return Ok(Expression::NullLiteral(NullLiteral { cv: t.cv.clone() })),
+        "undefined" => return Ok(Expression::UndefinedLiteral(UndefinedLiteral { cv: t.cv.clone() })),
+        "true" => return Ok(Expression::BooleanLiteral(BooleanLiteral { cv: t.cv.clone(), value: true })),
+        "false" => return Ok(Expression::BooleanLiteral(BooleanLiteral { cv: t.cv.clone(), value: false })),
         _ => {}
     }
 
@@ -1837,7 +1837,7 @@ fn convert_primary_token(t: &Token, ctx: &GrammarASTNode) -> Result<Expression, 
     if t.type_name.as_deref() == Some("BIGINT") {
         let raw = t.value.clone();
         let value = raw.trim_end_matches('n').to_string();
-        return Ok(Expression::BigIntLiteral(BigIntLiteral { cv: None, value, raw }));
+        return Ok(Expression::BigIntLiteral(BigIntLiteral { cv: t.cv.clone(), value, raw }));
     }
 
     // Standard terminal types via the type_ discriminant.
@@ -1850,7 +1850,7 @@ fn convert_primary_token(t: &Token, ctx: &GrammarASTNode) -> Result<Expression, 
                 }
             })?;
             return Ok(Expression::NumericLiteral(NumericLiteral {
-                cv: None,
+                cv: t.cv.clone(),
                 value: val,
                 raw: t.value.clone(),
             }));
@@ -1858,11 +1858,11 @@ fn convert_primary_token(t: &Token, ctx: &GrammarASTNode) -> Result<Expression, 
         TokenType::String => {
             let raw = t.value.clone();
             let value = unquote_string(&raw);
-            return Ok(Expression::StringLiteral(StringLiteral { cv: None, value, raw }));
+            return Ok(Expression::StringLiteral(StringLiteral { cv: t.cv.clone(), value, raw }));
         }
         TokenType::Name => {
             // Plain identifier (variable name or non-keyword reference).
-            return Ok(Expression::Identifier(Identifier { cv: None, name: t.value.clone() }));
+            return Ok(Expression::Identifier(Identifier { cv: t.cv.clone(), name: t.value.clone() }));
         }
         TokenType::Keyword => {
             // Context keyword used as an expression (e.g. `undefined` is not
@@ -1878,7 +1878,7 @@ fn convert_primary_token(t: &Token, ctx: &GrammarASTNode) -> Result<Expression, 
 
     // Fallback: treat as identifier (catches edge cases like regex literals
     // that look like punctuation in some grammars).
-    Ok(Expression::Identifier(Identifier { cv: None, name: t.value.clone() }))
+    Ok(Expression::Identifier(Identifier { cv: t.cv.clone(), name: t.value.clone() }))
 }
 
 // =========================================================================

--- a/code/packages/rust/javascript-parser/src/lib.rs
+++ b/code/packages/rust/javascript-parser/src/lib.rs
@@ -104,6 +104,44 @@ pub fn parse_javascript_typed(
     asi::parse_with_asi(tokens, version).map_err(|e| format!("JavaScript parse failed: {e}"))
 }
 
+/// CV-carrying twin of [`parse_javascript_typed`] (CLOC27 D3).
+///
+/// Routes through the correlation-vector tokenizer
+/// ([`tokenize_javascript_with_cv`]) so every token carries its own CvId
+/// (CLOC27 D2), then runs the identical Phase-1 ASI parse. The returned
+/// `GrammarASTNode` therefore holds tokens whose `cv` is `Some(..)`, and the
+/// bridge's leaf factory (`convert_primary_token`) stamps that id onto each
+/// leaf literal — giving the SIMPLE optimization path real per-token source
+/// provenance for its constant folds.
+///
+/// This is the entry the SIMPLE `--correlation_vector` path uses (CLOC27 D5);
+/// the plain [`parse_javascript_typed`] stays the zero-overhead default and is
+/// byte-identical to today on the non-CV path.
+///
+/// Unlike [`parse_javascript_with_cv`], this does *not* mint a program-root CV
+/// or append a "constructed" contribution: it is the typed-AST feeder for the
+/// optimizer, whose own passes (constant-fold) own the downstream CV records.
+pub fn parse_javascript_typed_with_cv(
+    source: &str,
+    source_file: &str,
+    version: EsVersion,
+    cv: &mut CVLog,
+) -> Result<GrammarASTNode, String> {
+    // Tokenize with CV plumbing, then stamp each token's CvId onto the token
+    // (CLOC27 D2) so it rides through the parser to the bridge unchanged.
+    let cv_tokens = tokenize_javascript_with_cv(source, source_file, version, cv)?;
+    let tokens: Vec<lexer::token::Token> = cv_tokens
+        .into_iter()
+        .map(|t| lexer::token::Token {
+            cv: Some(t.cv),
+            ..t.token
+        })
+        .collect();
+    // Identical Phase-1 ASI parse to `parse_javascript_typed` — only the token
+    // source differs (CV-stamped). See [`asi`].
+    asi::parse_with_asi(tokens, version).map_err(|e| format!("JavaScript parse failed: {e}"))
+}
+
 /// A parsed program paired with the correlation-vector ID assigned to its
 /// root by [`parse_javascript_with_cv`].
 ///
@@ -146,7 +184,19 @@ pub fn parse_javascript_with_cv(
     // 1. Tokenize with CV plumbing.
     let cv_tokens = tokenize_javascript_with_cv(source, source_file, version, cv)?;
     let token_cv_ids: Vec<String> = cv_tokens.iter().map(|t| t.cv.clone()).collect();
-    let tokens: Vec<lexer::token::Token> = cv_tokens.into_iter().map(|t| t.token).collect();
+    // CLOC27 D2: stamp each token's CvId onto the token itself instead of
+    // discarding it. The parser copies tokens into `GrammarASTNode` children
+    // unchanged, so the id rides through to the bridge's leaf factory
+    // (`convert_primary_token`), where it becomes the leaf literal's `cv`.
+    // Previously this stripped the id (`.map(|t| t.token)`), leaving every leaf
+    // with `cv: None` and dead-ending fold provenance at the bridge boundary.
+    let tokens: Vec<lexer::token::Token> = cv_tokens
+        .into_iter()
+        .map(|t| lexer::token::Token {
+            cv: Some(t.cv),
+            ..t.token
+        })
+        .collect();
 
     // 2. Parse via the existing GrammarParser.
     let grammar = _grammar::parser_grammar(version.as_str())


### PR DESCRIPTION
## What & why

Closes the constant-fold provenance gap at the bridge boundary (CLOC27 P2+P3, building on P1's `Token.cv` field which landed in #6928). Per-token CvIds were already minted by `tokenize_javascript_with_cv` but **discarded** before the parser, so every typed-AST leaf carried `cv: None` — a folded `3` from `"abc".length` derived from *nothing*, and the sidecar never tied it back to the `"abc".length` source span. This stops discarding them and stamps them onto the leaves.

## Changes

- **D2 — stop stripping the CvId.** `parse_javascript_with_cv` previously did `cv_tokens.into_iter().map(|t| t.token)`, dropping each token's CvId; it now sets `cv: Some(t.cv)` via struct-update so the id rides through the parser into the `GrammarASTNode` the bridge walks. The parser does not inspect `cv` — transparent to it.
- **D3 — `parse_javascript_typed_with_cv`.** New CV-carrying twin of `parse_javascript_typed`: routes through the CV tokenizer (D2), runs the identical Phase-1 ASI parse, returns a `GrammarASTNode` whose tokens carry CvIds. This is the typed-AST feeder the SIMPLE `--correlation_vector` path will use (D5/P4). `parse_javascript_typed` stays the zero-overhead default.
- **D4 — stamp the leaf in `convert_primary_token`.** The bridge's sole leaf-literal factory replaces its nine `cv: None` returns (`NullLiteral`, `UndefinedLiteral`, `BooleanLiteral`×2, `BigIntLiteral`, `NumericLiteral`, `StringLiteral`, `Identifier`×2) with `cv: t.cv.clone()`.

## Soundness — non-CV path is byte-identical

A token with `cv: None` (the default/non-CV tokenizer) yields a leaf with `cv: None`, exactly as today. No emitter change; no minting in the bridge (it only *copies* an id that already exists, staying a pure `GrammarASTNode → Program` transform).

## Tests

- `coding-adventures-javascript-parser`: **82/82** pass.
- `closurec` (downstream consumer): **877/877** pass, including `cv_fold_provenance_gap` still green — correct, since the SIMPLE path isn't wired to the CV feeder until P4/D5, so the characterization gap is intentionally unchanged here (it flips in P5).
- Security review: PASSED (pure data propagation; no unsafe/RNG/I/O/new input).

Spec: `code/specs/CLOC27-per-fold-cv-provenance.md` (PRs P2+P3 of the leaf-first breakdown). Follow-ups: P4 wires `run.rs`; P5 adds the golden trace + flips the gap test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)