### PR TITLE
feat(asciimath): symbol table — greek, blackboard sets, arrows, set/logic ops (PR-3a)

### DIFF
--- a/code/packages/rust/asciimath/CHANGELOG.md
+++ b/code/packages/rust/asciimath/CHANGELOG.md
@@ -2,6 +2,45 @@
 
 All notable changes to the AsciiMath pluggable frontend.
 
+## [0.4.0] — 2026-06-29
+
+### Added — ASM01 PR-3a: the symbol table (greek, blackboard sets, arrows, set/logic ops)
+
+The first slice of PR-3. `constant_of` grows from a 22-entry Greek-plus-infinity table into a
+proper **AsciiMath symbol table** — the fixed dictionary of multi-letter words that name *one*
+mathematical glyph rather than a product of single-letter variables (without it, `Sigma` would
+parse as `S·i·g·m·a` under the implicit-product rule). Every entry lowers to a
+`MathExpr::Symbol(canonical_name)`. Added:
+
+- **Greek** — completed the lowercase alphabet (`omicron`, `upsilon`) and the variant glyphs
+  (`varepsilon`, `vartheta`, `varpi`, `varrho`, `varsigma`, `varphi`); added the eleven
+  visually-distinct **uppercase** letters AsciiMath capitalizes (`Gamma Delta Theta Lambda Xi Pi
+  Sigma Upsilon Phi Psi Omega`).
+- **Blackboard number sets** — `NN ZZ QQ RR CC` → `naturals integers rationals reals complexes`.
+- **Arrows** (word forms) — `rarr`/`rightarrow`, `larr`/`leftarrow`, `harr`/`leftrightarrow`,
+  `uarr`/`uparrow`, `darr`/`downarrow`, plus `implies`, `iff`, `mapsto`.
+- **Set / logic** — `notin`, `subset`, `subseteq`, `supset`, `supseteq`, `cup`→`union`,
+  `cap`→`intersection`, `emptyset`, `forall`, `exists`, `aleph`.
+- **Misc. operators / decoration** — `partial`, `nabla`/`grad`, `propto`/`prop`, `perp`, `angle`,
+  `deg`→`degree`, and the dots `ldots cdots vdots ddots`.
+
+Naming convention is documented inline: lowercase Greek verbatim, uppercase Greek capitalized,
+number sets as words, arrows/set-ops as familiar TeX-ish long names — so two notations for the same
+glyph can later agree on a single `Symbol` string. **Purely additive**: symbol emission is not a
+declared `Capabilities` flag, so no consumer or conformance change; latex/adj-lang are unaffected.
+
+**Deferred to PR-3b** (documented in `constant_of` and the ASM01 spec): the bare English keyword
+spellings `in`/`and`/`or`/`not` (they need care — `in` also appears inside big-operator bounds like
+`sum_(i in S)`), AsciiMath's two-letter short forms (`sub`, `sup`, `uu`, `nn`, `AA`, `EE`),
+punctuation arrows (`->`, `=>`, tokenizer concern), longest-match identifier scan (`sinx` → `sin·x`),
+`stackrel`/`overset`/`underset`, and the `text(…)` keyword form.
+
+- Tests: `symbol_table_covers_greek_sets_arrows_and_operators` (greek lower/variant/upper, sets,
+  arrow short+long agreement, set/logic ops, alias folding, composition in a larger expression, and
+  that a deferred bare keyword like `in` still parses as a product without panic). Conformance corpus
+  gains `alpha + Omega`, `x in RR`, `a cup b`. 29 unit tests + doc-test pass; clippy `-D warnings`
+  clean. Spec ASM01 §PR-3 split into PR-3a (this) + PR-3b.
+
 ## [0.3.0] — 2026-06-29
 
 ### Added — accents (PR-2b), now that `math-frontend` 0.4.0 has a neutral `Accent` node

--- a/code/packages/rust/asciimath/Cargo.toml
+++ b/code/packages/rust/asciimath/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "asciimath"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "An AsciiMath parser that implements the math-frontend MathFrontend trait: turns AsciiMath (1/2, sqrt(x), x^2+y^2=r^2) into the neutral MathExpr AST. The second pluggable frontend after LaTeX (see ASM01/PFE01). Total, panic-free, spanned errors."
 license = "MIT"

--- a/code/packages/rust/asciimath/README.md
+++ b/code/packages/rust/asciimath/README.md
@@ -66,6 +66,26 @@ Each accent keyword takes the next single atom as its body (same convention as `
 `ul`/`underline`), so two spellings lower equal. Enabled by `math-frontend` 0.4.0's `MathExpr::Accent`
 node; `capabilities()` declares `accents` and the conformance harness enforces it.
 
+## PR-3a symbol table (greek, sets, arrows, set/logic)
+
+The **symbol table** is the fixed dictionary of multi-letter words that name *one* glyph rather than
+a product of single letters (without it `Sigma` would parse as `S·i·g·m·a`). Every entry lowers to
+`MathExpr::Symbol(canonical)`.
+
+| AsciiMath | → neutral `MathExpr` |
+|-----------|----------------------|
+| `alpha` … `omega`, `omicron`, `varepsilon`/`vartheta`/`varphi`/… | `Symbol` (lowercase Greek + variants) |
+| `Gamma Delta Theta Lambda Xi Pi Sigma Upsilon Phi Psi Omega` | `Symbol` (uppercase Greek) |
+| `NN ZZ QQ RR CC` | `Symbol("naturals" / "integers" / "rationals" / "reals" / "complexes")` |
+| `rarr`/`rightarrow`, `larr`, `harr`, `uarr`, `darr`, `implies`, `iff`, `mapsto` | `Symbol` (arrows) |
+| `notin subset subseteq supset supseteq cup cap emptyset forall exists aleph` | `Symbol` (`cup`→`union`, `cap`→`intersection`) |
+| `partial`, `nabla`/`grad`, `propto`, `perp`, `angle`, `deg`, `ldots`/`cdots`/`vdots`/`ddots`, `oo`/`infty` | `Symbol` (operators / decoration / infinity) |
+
+Symbol emission is *not* a declared capability, so this table is **purely additive** — no consumer or
+conformance change. **Deferred to PR-3b:** the bare keyword spellings `in`/`and`/`or`/`not`, the
+two-letter short forms (`sub`, `sup`, `uu`, `nn`, `AA`, `EE`), punctuation arrows (`->`, `=>`),
+longest-match identifier scan (`sinx` → `sin·x`), `stackrel`/`overset`/`underset`, and `text(…)`.
+
 It is **total and panic-free**: every input returns `Ok(MathExpr)` or a spanned
 `FrontendError`. Recursion is depth-guarded (matrix nesting included); left-associative chains are
 built with loops, so neither deep nesting nor long chains overflow the parser.

--- a/code/packages/rust/asciimath/src/lib.rs
+++ b/code/packages/rust/asciimath/src/lib.rs
@@ -111,6 +111,34 @@ mod tests {
         assert_eq!(p("oo"), sym("infinity"));
     }
 
+    #[test]
+    fn symbol_table_covers_greek_sets_arrows_and_operators() {
+        // Lowercase Greek (incl. one added in PR-3a) and a variant glyph.
+        assert_eq!(p("omicron"), sym("omicron"));
+        assert_eq!(p("varepsilon"), sym("varepsilon"));
+        // Uppercase Greek is a single symbol, NOT a product of its letters.
+        assert_eq!(p("Sigma"), sym("Sigma"));
+        assert_eq!(p("Omega"), sym("Omega"));
+        assert_ne!(p("Sigma"), b(BinOp::Mul, sym("S"), sym("i"))); // not S·i·g·m·a
+        // Blackboard number sets canonicalize to words.
+        assert_eq!(p("RR"), sym("reals"));
+        assert_eq!(p("ZZ"), sym("integers"));
+        // Arrows: the short AsciiMath spelling and the long name agree.
+        assert_eq!(p("rarr"), sym("rightarrow"));
+        assert_eq!(p("rightarrow"), sym("rightarrow"));
+        // Set / logic operators and a few misc. operators.
+        assert_eq!(p("cup"), sym("union"));
+        assert_eq!(p("cap"), sym("intersection"));
+        assert_eq!(p("subseteq"), sym("subseteq"));
+        assert_eq!(p("forall"), sym("forall"));
+        assert_eq!(p("nabla"), sym("nabla"));
+        assert_eq!(p("grad"), sym("nabla")); // alias folds to the same symbol
+        // A symbol composes in ordinary expressions: `alpha + Omega`.
+        assert_eq!(p("alpha + Omega"), b(BinOp::Add, sym("alpha"), sym("Omega")));
+        // Deferred bare keywords still parse (as a product / variable), no panic.
+        assert_eq!(p("in"), b(BinOp::Mul, sym("i"), sym("n")));
+    }
+
     // ---- operators & precedence ------------------------------------------------
     #[test]
     fn add_and_implicit_mul() {
@@ -358,6 +386,9 @@ mod tests {
                 "int_a^b f",       // big operator, integral
                 "hat x + vec v",   // accents (PR-2b)
                 "bar(x+y)",        // accent over a group
+                "alpha + Omega",   // greek symbols (PR-3a symbol table)
+                "x in RR",         // blackboard set + (deferred) bare keyword, no panic
+                "a cup b",         // set operator as a symbol
                 "1 +",   // error: trailing operator (span in range, not a panic)
                 "(x",    // error: missing close
                 "",      // error: empty

--- a/code/packages/rust/asciimath/src/parser.rs
+++ b/code/packages/rust/asciimath/src/parser.rs
@@ -473,12 +473,27 @@ fn func_of(word: &str) -> Option<Func> {
 }
 
 /// Map an identifier to a canonical constant/symbol name, or `None` for an ordinary variable.
-/// Greek names are kept verbatim; `oo`/`infty` canonicalize to `infinity`.
+///
+/// This is the AsciiMath **symbol table**: a fixed dictionary of multi-letter words that name a
+/// single mathematical glyph rather than a product of single-letter variables. (Without it, `pi`
+/// would parse as `p · i` under the implicit-product rule — see [`parse_ident_atom`].) Every entry
+/// lowers to a [`MathExpr::Symbol`] carrying the canonical name; symbol emission is *not* a
+/// declared [`Capabilities`] flag, so growing this table is purely additive — no consumer or
+/// conformance change.
+///
+/// Naming convention: lowercase Greek is kept verbatim (`alpha`); uppercase Greek is capitalized
+/// (`Sigma`); the blackboard number sets get word names (`reals`); arrows and set/logic operators
+/// use their familiar TeX-ish long names (`rightarrow`, `subseteq`, `forall`) so that two notations
+/// for the same glyph can later agree on one `Symbol` string. `oo`/`infty` canonicalize to
+/// `infinity`.
+///
+/// Deferred to PR-3b (documented in the ASM01 spec): the bare English keyword spellings `in`, `and`,
+/// `or`, `not` (they need care — e.g. `in` also appears inside big-operator bounds such as
+/// `sum_(i in S)`), AsciiMath's two-letter short forms (`sub`, `sup`, `uu`, `nn`, `AA`, `EE`), and
+/// punctuation arrows (`->`, `=>`) which are a tokenizer concern, not an identifier word.
 fn constant_of(word: &str) -> Option<&'static str> {
     Some(match word {
-        "pi" => "pi",
-        "tau" => "tau",
-        "theta" => "theta",
+        // ── Greek, lowercase ──────────────────────────────────────────────────────────────────
         "alpha" => "alpha",
         "beta" => "beta",
         "gamma" => "gamma",
@@ -486,18 +501,81 @@ fn constant_of(word: &str) -> Option<&'static str> {
         "epsilon" => "epsilon",
         "zeta" => "zeta",
         "eta" => "eta",
+        "theta" => "theta",
         "iota" => "iota",
         "kappa" => "kappa",
         "lambda" => "lambda",
         "mu" => "mu",
         "nu" => "nu",
         "xi" => "xi",
+        "omicron" => "omicron",
+        "pi" => "pi",
         "rho" => "rho",
         "sigma" => "sigma",
+        "tau" => "tau",
+        "upsilon" => "upsilon",
         "phi" => "phi",
         "chi" => "chi",
         "psi" => "psi",
         "omega" => "omega",
+        // Variant glyphs are distinct symbols, kept under their `var…` names.
+        "varepsilon" => "varepsilon",
+        "vartheta" => "vartheta",
+        "varpi" => "varpi",
+        "varrho" => "varrho",
+        "varsigma" => "varsigma",
+        "varphi" => "varphi",
+        // ── Greek, uppercase (only the visually-distinct letters AsciiMath spells capitalized) ──
+        "Gamma" => "Gamma",
+        "Delta" => "Delta",
+        "Theta" => "Theta",
+        "Lambda" => "Lambda",
+        "Xi" => "Xi",
+        "Pi" => "Pi",
+        "Sigma" => "Sigma",
+        "Upsilon" => "Upsilon",
+        "Phi" => "Phi",
+        "Psi" => "Psi",
+        "Omega" => "Omega",
+        // ── Blackboard number sets ────────────────────────────────────────────────────────────
+        "NN" => "naturals",
+        "ZZ" => "integers",
+        "QQ" => "rationals",
+        "RR" => "reals",
+        "CC" => "complexes",
+        // ── Arrows (word forms; punctuation arrows are deferred to the tokenizer) ──────────────
+        "rarr" | "rightarrow" => "rightarrow",
+        "larr" | "leftarrow" => "leftarrow",
+        "harr" | "leftrightarrow" => "leftrightarrow",
+        "uarr" | "uparrow" => "uparrow",
+        "darr" | "downarrow" => "downarrow",
+        "implies" => "implies",
+        "iff" => "iff",
+        "mapsto" => "mapsto",
+        // ── Set / logic operators (long names; bare keywords deferred to PR-3b) ────────────────
+        "notin" => "notin",
+        "subset" => "subset",
+        "subseteq" => "subseteq",
+        "supset" => "supset",
+        "supseteq" => "supseteq",
+        "cup" => "union",
+        "cap" => "intersection",
+        "emptyset" => "emptyset",
+        "forall" => "forall",
+        "exists" => "exists",
+        "aleph" => "aleph",
+        // ── Misc. operators / relations / decoration ──────────────────────────────────────────
+        "partial" => "partial",
+        "nabla" | "grad" => "nabla",
+        "propto" | "prop" => "propto",
+        "perp" => "perp",
+        "angle" => "angle",
+        "deg" => "degree",
+        "ldots" => "ldots",
+        "cdots" => "cdots",
+        "vdots" => "vdots",
+        "ddots" => "ddots",
+        // ── Infinity ──────────────────────────────────────────────────────────────────────────
         "oo" | "infty" => "infinity",
         _ => return None,
     })

--- a/code/specs/ASM01-asciimath-frontend.md
+++ b/code/specs/ASM01-asciimath-frontend.md
@@ -90,9 +90,19 @@ shapes for representative inputs.
   from a function `Call`; body = next atom, like `sqrt`; synonyms normalise to one canonical name).
   Enabled by `math-frontend` 0.4.0's neutral `Accent` node; `capabilities()` adds `accents` (enforced
   by the conformance harness). Still deferred: angle/invisible brackets `(: … :)`, `{: … :}`.
-- **PR-3:** the full AsciiMath symbol table (greek, arrows, set/logic ops), longest-match
-  tokenization (so `sinx` splits as `sin`·`x`), `stackrel`, `overset`/`underset`, and the
-  `text(…)` keyword form alongside the `"…"` literal.
+- **PR-3a (shipped, v0.4.0):** the AsciiMath **symbol table** — completed lowercase Greek + variant
+  glyphs, the visually-distinct uppercase Greek (`Gamma`…`Omega`), the blackboard number sets
+  (`NN ZZ QQ RR CC` → `naturals`…`complexes`), arrow word-forms (`rarr`/`rightarrow`, `larr`, `harr`,
+  `uarr`, `darr`, `implies`, `iff`, `mapsto`), set/logic operators (`notin`, `subset`, `subseteq`,
+  `supset`, `supseteq`, `cup`→`union`, `cap`→`intersection`, `emptyset`, `forall`, `exists`, `aleph`),
+  and misc. operators/decoration (`partial`, `nabla`/`grad`, `propto`, `perp`, `angle`, `deg`, the
+  dots). Each lowers to `MathExpr::Symbol(canonical)`; symbol emission is not a `Capabilities` flag,
+  so the table is purely additive (no consumer/conformance change).
+- **PR-3b:** the remainder — the bare English keyword spellings `in`/`and`/`or`/`not` (care needed:
+  `in` also appears inside big-operator bounds like `sum_(i in S)`), AsciiMath's two-letter short
+  forms (`sub`, `sup`, `uu`, `nn`, `AA`, `EE`), punctuation arrows (`->`, `=>`, a tokenizer concern),
+  **longest-match tokenization** (so `sinx` splits as `sin`·`x`), `stackrel`, `overset`/`underset`,
+  and the `text(…)` keyword form alongside the `"…"` literal.
 
 ## 6. Non-goals
 Evaluation, simplification, rendering — none are a frontend's job (PFE01 §7). Lowering


### PR DESCRIPTION
## What

The first slice of **ASM01 PR-3** (the LaTeX-stream alternation handoff after #6947 — asciimath accent emission — merged). Grows the asciimath parser's `constant_of` from a 22-entry Greek-plus-infinity table into a proper **symbol table**: the fixed dictionary of multi-letter words that name *one* mathematical glyph rather than a product of single-letter variables. Without it, `Sigma` parses as `S·i·g·m·a` under the implicit-product rule. Every entry lowers to `MathExpr::Symbol(canonical)`.

## Added

- **Greek** — completed the lowercase alphabet (`omicron`, `upsilon`) + variant glyphs (`varepsilon`, `vartheta`, `varpi`, `varrho`, `varsigma`, `varphi`); the eleven visually-distinct **uppercase** letters (`Gamma`…`Omega`).
- **Blackboard number sets** — `NN ZZ QQ RR CC` → `naturals integers rationals reals complexes`.
- **Arrows** (word forms) — `rarr`/`rightarrow`, `larr`, `harr`, `uarr`, `darr`, `implies`, `iff`, `mapsto`.
- **Set / logic** — `notin`, `subset`, `subseteq`, `supset`, `supseteq`, `cup`→`union`, `cap`→`intersection`, `emptyset`, `forall`, `exists`, `aleph`.
- **Misc operators / decoration** — `partial`, `nabla`/`grad`, `propto`/`prop`, `perp`, `angle`, `deg`→`degree`, `ldots`/`cdots`/`vdots`/`ddots`.

## Why this is low-risk

**Purely additive**: symbol emission is *not* a declared `Capabilities` flag, so there's no consumer or conformance change — `latex` and `adj-lang` are unaffected. The new code is a static `match` over `&str` literals returning `&'static str` (no `unsafe`, no allocation, no recursion, no overflow surface).

## Deferred to PR-3b (documented in `constant_of` + the ASM01 spec)

The bare English keyword spellings `in`/`and`/`or`/`not` (`in` also appears inside big-operator bounds like `sum_(i in S)`), the two-letter short forms (`sub`, `sup`, `uu`, `nn`, `AA`, `EE`), punctuation arrows (`->`, `=>`), **longest-match** identifier scan (`sinx` → `sin·x`), `stackrel`/`overset`/`underset`, and the `text(…)` keyword form.

## Gates

- `cargo test -p asciimath`: **29 unit tests + doc-test pass** (new `symbol_table_covers_greek_sets_arrows_and_operators`).
- `cargo clippy -p asciimath -- -D warnings`: clean.
- /security-review: **PASSED** (static match table; no unsafe / panic / overflow / ReDoS).

asciimath **0.4.0**. Spec `ASM01-asciimath-frontend.md` §PR-3 split into PR-3a (this) + PR-3b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)