### PR TITLE
[codex] Add Berkeley SPICE app editor command plans

### DIFF
--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add Berkeley SPICE app-deck editor command plans for Mosaic host wiring.
+  `BerkeleyAppDeck::editor_command_plan()` and `run_editor_command_plan()` now
+  expose stable per-analysis command IDs, action kinds, targets, enabled states,
+  and disabled reasons derived from editor controls.
 - Add Berkeley SPICE app-deck editor controls for Mosaic-facing Rust UI
   substrates. `BerkeleyAppDeck::editor_controls()` and `run_editor_controls()`
   now expose stable per-analysis select/run/table/waveform actions, enabled

--- a/code/packages/rust/spice-netlist-parser/README.md
+++ b/code/packages/rust/spice-netlist-parser/README.md
@@ -52,6 +52,12 @@ assert_eq!(session.selected_waveform_series_count, Some(1));
 
 let controls = deck.run_editor_controls(Some(3))?;
 assert!(controls.selected_control.unwrap().waveform_available);
+
+let command_plan = deck.run_editor_command_plan(Some(3))?;
+assert!(command_plan
+    .commands
+    .iter()
+    .any(|command| command.id == "analysis.3.inspect-waveform" && command.enabled));
 ```
 
 The facade preserves normalized logical cards, source spans, token names
@@ -65,9 +71,11 @@ source fingerprints, selected-analysis state, run/blocked status, diagnostics,
 table columns, output probes, and selected waveform availability so Mosaic UI
 hosts can render editor state without owning simulator internals. It also
 derives stable per-analysis editor controls for selecting, running, and
-inspecting tables or waveforms with explicit disabled reasons. It is the Rust
-app/runtime entrypoint for Mosaic-backed UI work while the grammar-backed parser
-generator and Python/TypeScript parity surfaces continue to mature.
+inspecting tables or waveforms with explicit disabled reasons, plus command
+plans with stable command IDs and target names for host menu or button wiring.
+It is the Rust app/runtime entrypoint for Mosaic-backed UI work while the
+grammar-backed parser generator and Python/TypeScript parity surfaces continue
+to mature.
 
 This parser supports `R`, `C`, `L`, `V`, `I`, `D`, `Q`, `M`, `G`, `E`, `F`, and
 `H` elements, `.model <name> D(...)` diode cards with `IS` and `VT`

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -17,12 +17,13 @@ mod syntax;
 pub use syntax::{
     parse_berkeley_app_deck, parse_berkeley_syntax, BerkeleyAnalysisInventoryEntry,
     BerkeleyAppAnalysisArtifact, BerkeleyAppAnalysisControl, BerkeleyAppDeck,
-    BerkeleyAppEditorAction, BerkeleyAppEditorActionKind, BerkeleyAppEditorControls,
-    BerkeleyAppExecution, BerkeleyAppSessionAnalysis, BerkeleyAppSessionState,
-    BerkeleyAppWaveformPoint, BerkeleyAppWaveformSeries, BerkeleyCardKind,
-    BerkeleyDiagnosticSeverity, BerkeleyGrammarMetadata, BerkeleyLogicalCard, BerkeleySyntaxDeck,
-    BerkeleySyntaxDiagnostic, BerkeleySyntaxToken, SourceSpan, BERKELEY_SPICE_GRAMMAR_NAME,
-    BERKELEY_SPICE_GRAMMAR_VERSION, BERKELEY_SPICE_PARSER_GRAMMAR, BERKELEY_SPICE_TOKEN_GRAMMAR,
+    BerkeleyAppEditorAction, BerkeleyAppEditorActionKind, BerkeleyAppEditorCommand,
+    BerkeleyAppEditorCommandPlan, BerkeleyAppEditorControls, BerkeleyAppExecution,
+    BerkeleyAppSessionAnalysis, BerkeleyAppSessionState, BerkeleyAppWaveformPoint,
+    BerkeleyAppWaveformSeries, BerkeleyCardKind, BerkeleyDiagnosticSeverity,
+    BerkeleyGrammarMetadata, BerkeleyLogicalCard, BerkeleySyntaxDeck, BerkeleySyntaxDiagnostic,
+    BerkeleySyntaxToken, SourceSpan, BERKELEY_SPICE_GRAMMAR_NAME, BERKELEY_SPICE_GRAMMAR_VERSION,
+    BERKELEY_SPICE_PARSER_GRAMMAR, BERKELEY_SPICE_TOKEN_GRAMMAR,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/code/packages/rust/spice-netlist-parser/src/syntax.rs
+++ b/code/packages/rust/spice-netlist-parser/src/syntax.rs
@@ -320,6 +320,35 @@ pub struct BerkeleyAppEditorControls {
     pub diagnostics: Vec<BerkeleySyntaxDiagnostic>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BerkeleyAppEditorCommand {
+    pub id: String,
+    pub kind: BerkeleyAppEditorActionKind,
+    pub syntax_card_index: usize,
+    pub directive: String,
+    pub analysis: String,
+    pub span: SourceSpan,
+    pub target: String,
+    pub label: String,
+    pub enabled: bool,
+    pub selected: bool,
+    pub disabled_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BerkeleyAppEditorCommandPlan {
+    pub canonical_source: String,
+    pub source_fingerprint: String,
+    pub title: Option<String>,
+    pub parsed: bool,
+    pub execution_available: bool,
+    pub selected_syntax_card_index: Option<usize>,
+    pub command_count: usize,
+    pub commands: Vec<BerkeleyAppEditorCommand>,
+    pub blocking_message: Option<String>,
+    pub diagnostics: Vec<BerkeleySyntaxDiagnostic>,
+}
+
 impl BerkeleyAppDeck {
     pub fn has_errors(&self) -> bool {
         self.diagnostics
@@ -427,6 +456,22 @@ impl BerkeleyAppDeck {
     ) -> Result<BerkeleyAppEditorControls, AnalysisExecutionError> {
         Ok(editor_controls_from_session_state(
             &self.run_session_state(selected_syntax_card_index)?,
+        ))
+    }
+
+    pub fn editor_command_plan(
+        &self,
+        selected_syntax_card_index: Option<usize>,
+    ) -> BerkeleyAppEditorCommandPlan {
+        editor_command_plan_from_controls(&self.editor_controls(selected_syntax_card_index))
+    }
+
+    pub fn run_editor_command_plan(
+        &self,
+        selected_syntax_card_index: Option<usize>,
+    ) -> Result<BerkeleyAppEditorCommandPlan, AnalysisExecutionError> {
+        Ok(editor_command_plan_from_controls(
+            &self.run_editor_controls(selected_syntax_card_index)?,
         ))
     }
 
@@ -580,6 +625,79 @@ fn editor_controls_from_session_state(
         controls,
         blocking_message: state.blocking_message.clone(),
         diagnostics: state.diagnostics.clone(),
+    }
+}
+
+fn editor_command_plan_from_controls(
+    controls: &BerkeleyAppEditorControls,
+) -> BerkeleyAppEditorCommandPlan {
+    let commands = controls
+        .controls
+        .iter()
+        .flat_map(|control| {
+            control
+                .actions
+                .iter()
+                .map(|action| editor_command_from_control(control, action))
+        })
+        .collect::<Vec<_>>();
+
+    BerkeleyAppEditorCommandPlan {
+        canonical_source: controls.canonical_source.clone(),
+        source_fingerprint: controls.source_fingerprint.clone(),
+        title: controls.title.clone(),
+        parsed: controls.parsed,
+        execution_available: controls.execution_available,
+        selected_syntax_card_index: controls.selected_syntax_card_index,
+        command_count: commands.len(),
+        commands,
+        blocking_message: controls.blocking_message.clone(),
+        diagnostics: controls.diagnostics.clone(),
+    }
+}
+
+fn editor_command_from_control(
+    control: &BerkeleyAppAnalysisControl,
+    action: &BerkeleyAppEditorAction,
+) -> BerkeleyAppEditorCommand {
+    BerkeleyAppEditorCommand {
+        id: editor_command_id(control.syntax_card_index, action.kind),
+        kind: action.kind,
+        syntax_card_index: control.syntax_card_index,
+        directive: control.directive.clone(),
+        analysis: control.analysis.clone(),
+        span: control.span,
+        target: editor_command_target(action.kind).to_string(),
+        label: action.label.clone(),
+        enabled: action.enabled,
+        selected: control.selected,
+        disabled_reason: action.disabled_reason.clone(),
+    }
+}
+
+fn editor_command_id(syntax_card_index: usize, kind: BerkeleyAppEditorActionKind) -> String {
+    format!(
+        "analysis.{}.{}",
+        syntax_card_index,
+        editor_command_slug(kind)
+    )
+}
+
+fn editor_command_slug(kind: BerkeleyAppEditorActionKind) -> &'static str {
+    match kind {
+        BerkeleyAppEditorActionKind::SelectAnalysis => "select",
+        BerkeleyAppEditorActionKind::RunAnalysis => "run",
+        BerkeleyAppEditorActionKind::InspectTable => "inspect-table",
+        BerkeleyAppEditorActionKind::InspectWaveform => "inspect-waveform",
+    }
+}
+
+fn editor_command_target(kind: BerkeleyAppEditorActionKind) -> &'static str {
+    match kind {
+        BerkeleyAppEditorActionKind::SelectAnalysis => "analysis-selection",
+        BerkeleyAppEditorActionKind::RunAnalysis => "analysis-runner",
+        BerkeleyAppEditorActionKind::InspectTable => "analysis-table",
+        BerkeleyAppEditorActionKind::InspectWaveform => "analysis-waveform",
     }
 }
 

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -2186,6 +2186,105 @@ R1 in out
 }
 
 #[test]
+fn berkeley_app_facade_exports_editor_command_plan_after_execution() {
+    let app = parse_berkeley_app_deck(
+        r#"
+* transient editor commands
+V1 in 0 PULSE(0 1 0 1n 1n 1n 4n)
+R1 in out 1k
+C1 out 0 1p
+.tran 1n 3n
+.print tran V(out)
+.end
+"#,
+    );
+
+    let plan = app.run_editor_command_plan(Some(3)).unwrap();
+
+    assert!(plan.parsed);
+    assert!(plan.execution_available);
+    assert_eq!(plan.selected_syntax_card_index, Some(3));
+    assert_eq!(plan.command_count, 4);
+    assert_eq!(
+        plan.commands
+            .iter()
+            .map(|command| command.id.as_str())
+            .collect::<Vec<_>>(),
+        vec![
+            "analysis.3.select",
+            "analysis.3.run",
+            "analysis.3.inspect-table",
+            "analysis.3.inspect-waveform",
+        ]
+    );
+
+    let waveform = plan
+        .commands
+        .iter()
+        .find(|command| command.id == "analysis.3.inspect-waveform")
+        .unwrap();
+    assert_eq!(waveform.kind, BerkeleyAppEditorActionKind::InspectWaveform);
+    assert_eq!(waveform.syntax_card_index, 3);
+    assert_eq!(waveform.directive, ".tran");
+    assert_eq!(waveform.analysis, "tran");
+    assert_eq!(waveform.target, "analysis-waveform");
+    assert_eq!(waveform.label, "Inspect .tran waveform");
+    assert!(waveform.enabled);
+    assert!(waveform.selected);
+    assert_eq!(waveform.disabled_reason, None);
+}
+
+#[test]
+fn berkeley_app_facade_editor_command_plan_preserves_disabled_reasons() {
+    let app = parse_berkeley_app_deck(
+        r#"
+* transient editor commands
+V1 in 0 PULSE(0 1 0 1n 1n 1n 4n)
+R1 in out 1k
+C1 out 0 1p
+.tran 1n 3n
+.print tran V(out)
+.end
+"#,
+    );
+
+    let plan = app.editor_command_plan(Some(3));
+    let table = plan
+        .commands
+        .iter()
+        .find(|command| command.id == "analysis.3.inspect-table")
+        .unwrap();
+    assert!(!table.enabled);
+    assert_eq!(table.target, "analysis-table");
+    assert_eq!(
+        table.disabled_reason.as_deref(),
+        Some("run deck artifacts to populate analysis table")
+    );
+
+    let blocked = parse_berkeley_app_deck(
+        r#"
+V1 in 0 DC 1
+R1 in out
+.op
+.end
+"#,
+    );
+    let plan = blocked.editor_command_plan(Some(2));
+    let run = plan
+        .commands
+        .iter()
+        .find(|command| command.id == "analysis.2.run")
+        .unwrap();
+    assert!(!run.enabled);
+    assert_eq!(run.target, "analysis-runner");
+    assert!(run
+        .disabled_reason
+        .as_deref()
+        .unwrap()
+        .contains("Berkeley SPICE app deck:"));
+}
+
+#[test]
 fn berkeley_app_facade_session_state_reports_blocked_decks() {
     let app = parse_berkeley_app_deck(
         r#"

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,15 +33,14 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Rust Berkeley Mosaic editor controls.
+1. Rust Berkeley Mosaic editor command plans.
    - Status: current PR completion candidate.
    - Expand the Rust `spice-netlist-parser` Berkeley app facade from
-     stable Mosaic-facing session snapshots into deterministic editor control
-     metadata for selecting, running, and inspecting analysis tables and
-     waveforms.
-   - Expose per-analysis actions with enabled states and stable disabled
-     reasons so Mosaic hosts can render controls without owning parser or
-     simulator internals.
+     deterministic editor controls into stable command descriptors for Mosaic
+     host menu, toolbar, and panel wiring.
+   - Expose per-analysis command IDs, action kinds, target names, enabled
+     states, and disabled reasons so hosts can dispatch select/run/table/
+     waveform actions without reinterpreting labels or parser internals.
    - Keep this as a Rust-only app-substrate acceleration slice over the public
      parser contract and existing engine deck artifacts; Python and TypeScript
      parser parity was completed separately and should remain aligned when
@@ -1476,6 +1475,15 @@ the Rust, Python, and TypeScript surfaces together.
      Berkeley parser contract while Python and TypeScript parser parity remains
      aligned for shared syntax behavior.
 
+139. Rust Berkeley Mosaic editor controls.
+   - Status: completed in PR 6948.
+   - Rust `spice-netlist-parser` Berkeley app-deck controls now expose
+     per-analysis select/run/table/waveform actions with stable enabled states
+     and disabled reasons for Mosaic UI surfaces.
+   - The slice keeps editor controls derived from app session state so UI hosts
+     can render parser and execution status without duplicating simulator
+     internals.
+
 ## Backlog
 
 1. Grammar-backed parser and app facade.
@@ -1483,9 +1491,8 @@ the Rust, Python, and TypeScript surfaces together.
      syntax facade as the grammar evolves, even if that breaks current
      pre-release parser APIs.
    - Continue expanding the Rust Mosaic app facade beyond the initial
-     card-indexed result artifacts toward richer editor command wiring,
-     persisted UI state, and host integration backed by the same public parser
-     contract.
+     card-indexed result artifacts toward persisted UI state and host
+     integration backed by the same public parser contract.
 
 2. Deck compatibility follow-up.
    - Expand deck-owned output compatibility beyond source-order analysis


### PR DESCRIPTION
## Summary
- add a Rust Berkeley app editor command-plan surface derived from editor controls, with stable command IDs, action kinds, targets, enabled states, and disabled reasons
- expose `BerkeleyAppDeck::editor_command_plan()` and `run_editor_command_plan()` plus public command structs for Mosaic host wiring
- update parser docs/changelog and advance the SPICE plan after PR #6948 merged

## Validation
- `cargo fmt -p spice-netlist-parser`
- `cargo test -p spice-netlist-parser -- --nocapture`
- `cargo test -p grammar-tools --test spice_grammar_validation -- --nocapture`
- `git diff --check`