### PR TITLE
[codex] Track formatting audit repair evidence

### DIFF
--- a/code/packages/rust/html-parser/tests/whatwg_formatting_audit_test.rs
+++ b/code/packages/rust/html-parser/tests/whatwg_formatting_audit_test.rs
@@ -7,6 +7,7 @@ use std::collections::{BTreeMap, HashMap};
 const TREE_CONSTRUCTION_SMOKE: &str = include_str!("fixtures/html5lib-tree-construction-smoke.dat");
 const WHATWG_FORMATTING_AUDIT: &str = include_str!("fixtures/whatwg-formatting-audit.json");
 const POST_PARSE_REPAIR_EVIDENCE: &[(&str, &str)] = &[
+    ("tricky01-dat-3", "adoption-agency-formatting"),
     ("tricky01-dat-8", "interactive-formatting-boundary"),
     ("tricky01-dat-9", "interactive-formatting-boundary"),
     ("tests26-dat-1251", "interactive-formatting-boundary"),


### PR DESCRIPTION
## Summary
- Track `tricky01-dat-3` as formatting audit post-parse repair evidence for `adoption-agency-formatting`.
- Keep the slice evidence-only: the parser behavior is unchanged, and the audit now records another case that depends on the existing adoption-agency repair.

## Evidence
- Negative control: temporarily no-oping `repair_tricky_adoption_agency` made `cargo test -p coding-adventures-html-parser whatwg_formatting_audit_cases_match_parser_dom_dump -- --nocapture` fail on `tricky01-dat-3` with axis `adoption-agency-formatting`.

## Validation
From `code/packages/rust`:
- `cargo test -p coding-adventures-html-parser font_newline_before_bold_stays_outside_reconstructed_font`
- `cargo test -p coding-adventures-html-parser whatwg_document_shell_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_head_body_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_form_interactive_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_legacy_element_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_paragraph_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_block_boundary_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_table_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_formatting_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_document_shell_audit_cases_match_parser_dom_dump`
- `cargo test -p coding-adventures-html-parser whatwg_head_body_audit_cases_match_parser_dom_dump`
- `cargo test -p coding-adventures-html-parser whatwg_formatting_audit_cases_match_parser_dom_dump`
- `cargo test -p coding-adventures-html-parser whatwg_paragraph_audit_cases_match_parser_dom_dump`
- `cargo test -p coding-adventures-html-parser whatwg_block_boundary_audit_cases_match_parser_dom_dump`
- `cargo test -p coding-adventures-html-parser html5lib_tree_construction_smoke_cases_match_dom_dump`
- `cargo test -p coding-adventures-html-parser`
- `cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser`

From the worktree root:
- `python3 -m json.tool code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json >/dev/null`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py`
- `git diff --check`
