### PR TITLE
feat(asciimath): symbol table PR-3b — bare keywords + two-letter short forms

### DIFF
--- a/code/packages/rust/asciimath/CHANGELOG.md
+++ b/code/packages/rust/asciimath/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to the AsciiMath pluggable frontend.
 
+## [0.5.0] — 2026-06-29
+
+### Added — ASM01 PR-3b: bare-keyword spellings + two-letter short forms
+
+The second slice of PR-3, finishing the **symbol-table** surface (the structural items —
+longest-match, `stackrel`/`overset`/`underset`, `text(…)` — remain PR-3c). All additions are more
+`constant_of` entries lowering to `MathExpr::Symbol(canonical)`, so still **purely additive** (symbol
+emission is not a `Capabilities` flag; no consumer/conformance change).
+
+- **Bare English keywords** now lower to symbols: `in`, `and`, `or`, `not`. (PR-3a deliberately
+  deferred these because `in` also appears inside big-operator bounds like `sum_(i in S)`; verified
+  that mapping it to a symbol leaves such bounds parsing cleanly — `i in S` is the harmless
+  juxtaposition `i · ∈ · S`, the same shape the previous `i·n·…` product had.) There is no
+  `In`/`And` relation in the neutral `RelOp`, so a `Symbol` standing for the glyph is the faithful
+  representation.
+- **Two-letter short forms** fold onto the same canonical names as their PR-3a long forms:
+  `sub`→`subset`, `sube`→`subseteq`, `sup`→`supset`, `supe`→`supseteq`, `uu`→`union` (= `cup`),
+  `nn`→`intersection` (= `cap`), `AA`→`forall`, `EE`→`exists`.
+- Behaviour change worth noting: `p("in")` was `i · n` in 0.4.0 and is now `Symbol("in")`; the PR-3a
+  test that asserted the product form is updated accordingly. `x in RR` now parses as the
+  three-symbol juxtaposition `x · ∈ · ℝ`.
+- Tests: new `symbol_table_pr3b_bare_keywords_and_short_forms` (each keyword + short form, short/long
+  agreement, `x in RR` juxtaposition, and that `sum_(i in S) i` still parses as a `BigOp`). 30 unit
+  tests + doc-test pass; clippy `-D warnings` clean. Spec ASM01 §PR-3 updated (3a + 3b shipped; 3c =
+  longest-match + `stackrel`/`overset`/`underset` + `text(…)`).
+
 ## [0.4.0] — 2026-06-29
 
 ### Added — ASM01 PR-3a: the symbol table (greek, blackboard sets, arrows, set/logic ops)

--- a/code/packages/rust/asciimath/Cargo.toml
+++ b/code/packages/rust/asciimath/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "asciimath"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "An AsciiMath parser that implements the math-frontend MathFrontend trait: turns AsciiMath (1/2, sqrt(x), x^2+y^2=r^2) into the neutral MathExpr AST. The second pluggable frontend after LaTeX (see ASM01/PFE01). Total, panic-free, spanned errors."
 license = "MIT"

--- a/code/packages/rust/asciimath/README.md
+++ b/code/packages/rust/asciimath/README.md
@@ -82,9 +82,14 @@ a product of single letters (without it `Sigma` would parse as `S·i·g·m·a`).
 | `partial`, `nabla`/`grad`, `propto`, `perp`, `angle`, `deg`, `ldots`/`cdots`/`vdots`/`ddots`, `oo`/`infty` | `Symbol` (operators / decoration / infinity) |
 
 Symbol emission is *not* a declared capability, so this table is **purely additive** — no consumer or
-conformance change. **Deferred to PR-3b:** the bare keyword spellings `in`/`and`/`or`/`not`, the
-two-letter short forms (`sub`, `sup`, `uu`, `nn`, `AA`, `EE`), punctuation arrows (`->`, `=>`),
-longest-match identifier scan (`sinx` → `sin·x`), `stackrel`/`overset`/`underset`, and `text(…)`.
+conformance change.
+
+**PR-3b** completes the symbol surface: the bare keyword spellings `in`/`and`/`or`/`not` (→ symbols)
+and the two-letter short forms `sub`/`sube`/`sup`/`supe` (subset family), `uu`→`union`, `nn`→`intersection`,
+`AA`→`forall`, `EE`→`exists`. (`in` is safe inside big-operator bounds — `sum_(i in S)` parses as the
+juxtaposition `i · ∈ · S`.) **Still deferred to PR-3c** (structural, not table entries): punctuation
+arrows (`->`, `=>`), longest-match identifier scan (`sinx` → `sin·x`), `stackrel`/`overset`/`underset`,
+and the `text(…)` keyword form.
 
 It is **total and panic-free**: every input returns `Ok(MathExpr)` or a spanned
 `FrontendError`. Recursion is depth-guarded (matrix nesting included); left-associative chains are

--- a/code/packages/rust/asciimath/src/lib.rs
+++ b/code/packages/rust/asciimath/src/lib.rs
@@ -135,8 +135,31 @@ mod tests {
         assert_eq!(p("grad"), sym("nabla")); // alias folds to the same symbol
         // A symbol composes in ordinary expressions: `alpha + Omega`.
         assert_eq!(p("alpha + Omega"), b(BinOp::Add, sym("alpha"), sym("Omega")));
-        // Deferred bare keywords still parse (as a product / variable), no panic.
-        assert_eq!(p("in"), b(BinOp::Mul, sym("i"), sym("n")));
+    }
+
+    #[test]
+    fn symbol_table_pr3b_bare_keywords_and_short_forms() {
+        // PR-3b: the bare English keywords are now symbols (was `i·n` etc. in PR-3a).
+        assert_eq!(p("in"), sym("in"));
+        assert_eq!(p("and"), sym("and"));
+        assert_eq!(p("or"), sym("or"));
+        assert_eq!(p("not"), sym("not"));
+        // AsciiMath two-letter short forms fold onto the same canonical names as their long forms.
+        assert_eq!(p("sub"), sym("subset"));
+        assert_eq!(p("sube"), sym("subseteq"));
+        assert_eq!(p("sup"), sym("supset"));
+        assert_eq!(p("supe"), sym("supseteq"));
+        assert_eq!(p("uu"), sym("union")); // == p("cup")
+        assert_eq!(p("nn"), sym("intersection")); // == p("cap")
+        assert_eq!(p("AA"), sym("forall"));
+        assert_eq!(p("EE"), sym("exists"));
+        // `x in RR` is now three symbols juxtaposed (x · ∈ · ℝ) — no panic, composes cleanly.
+        assert_eq!(
+            p("x in RR"),
+            b(BinOp::Mul, b(BinOp::Mul, sym("x"), sym("in")), sym("reals"))
+        );
+        // Inside a big-operator bound the keyword is harmless (no parse breakage): `sum_(i in S) i`.
+        assert!(matches!(p("sum_(i in S) i"), MathExpr::BigOp { .. }));
     }
 
     // ---- operators & precedence ------------------------------------------------

--- a/code/packages/rust/asciimath/src/parser.rs
+++ b/code/packages/rust/asciimath/src/parser.rs
@@ -564,6 +564,24 @@ fn constant_of(word: &str) -> Option<&'static str> {
         "forall" => "forall",
         "exists" => "exists",
         "aleph" => "aleph",
+        // ── PR-3b: AsciiMath two-letter short forms + bare-keyword spellings ───────────────────
+        // The compact AsciiMath spellings of the set/logic operators above, plus the four English
+        // keywords. Like every other entry these lower to `Symbol` — there is no `In`/`Subset`
+        // relation in the neutral `RelOp`, so a symbol standing for the glyph is the faithful
+        // representation (and `i in S` is then the juxtaposition `i · ∈ · S`, which is harmless
+        // inside a big-operator bound like `sum_(i in S)` — no parse breakage).
+        "in" => "in",
+        "and" => "and",
+        "or" => "or",
+        "not" => "not",
+        "sub" => "subset",     // short form of `subset`
+        "sube" => "subseteq",  // short form of `subseteq`
+        "sup" => "supset",     // short form of `supset`
+        "supe" => "supseteq",  // short form of `supseteq`
+        "uu" => "union",       // short form of `cup`
+        "nn" => "intersection", // short form of `cap`
+        "AA" => "forall",      // ∀
+        "EE" => "exists",      // ∃
         // ── Misc. operators / relations / decoration ──────────────────────────────────────────
         "partial" => "partial",
         "nabla" | "grad" => "nabla",

--- a/code/specs/ASM01-asciimath-frontend.md
+++ b/code/specs/ASM01-asciimath-frontend.md
@@ -98,11 +98,15 @@ shapes for representative inputs.
   and misc. operators/decoration (`partial`, `nabla`/`grad`, `propto`, `perp`, `angle`, `deg`, the
   dots). Each lowers to `MathExpr::Symbol(canonical)`; symbol emission is not a `Capabilities` flag,
   so the table is purely additive (no consumer/conformance change).
-- **PR-3b:** the remainder — the bare English keyword spellings `in`/`and`/`or`/`not` (care needed:
-  `in` also appears inside big-operator bounds like `sum_(i in S)`), AsciiMath's two-letter short
-  forms (`sub`, `sup`, `uu`, `nn`, `AA`, `EE`), punctuation arrows (`->`, `=>`, a tokenizer concern),
-  **longest-match tokenization** (so `sinx` splits as `sin`·`x`), `stackrel`, `overset`/`underset`,
-  and the `text(…)` keyword form alongside the `"…"` literal.
+- **PR-3b (shipped, v0.5.0):** finished the symbol-table surface — the bare English keyword spellings
+  `in`/`and`/`or`/`not` (→ `Symbol`; verified safe inside big-operator bounds: `sum_(i in S)` parses
+  as the juxtaposition `i · ∈ · S`), and AsciiMath's two-letter short forms `sub`→`subset`,
+  `sube`→`subseteq`, `sup`→`supset`, `supe`→`supseteq`, `uu`→`union`, `nn`→`intersection`,
+  `AA`→`forall`, `EE`→`exists`. Still additive (no `Capabilities`/conformance change). Behaviour note:
+  `p("in")` changed from `i·n` to `Symbol("in")`.
+- **PR-3c:** the structural remainder (not table entries) — punctuation arrows (`->`, `=>`, a tokenizer
+  concern), **longest-match tokenization** (so `sinx` splits as `sin`·`x`), `stackrel`,
+  `overset`/`underset`, and the `text(…)` keyword form alongside the `"…"` literal.
 
 ## 6. Non-goals
 Evaluation, simplification, rendering — none are a frontend's job (PFE01 §7). Lowering


### PR DESCRIPTION
## What

Second slice of **ASM01 PR-3** (LaTeX-stream handoff after #6953 / PR-3a merged), finishing the symbol-table **surface**. All additions are more `constant_of` arms lowering to `MathExpr::Symbol(canonical)` — still **purely additive** (symbol emission is not a `Capabilities` flag; no consumer/conformance change).

## Added

- **Bare English keywords** → symbols: `in`, `and`, `or`, `not`. PR-3a deliberately deferred these because `in` also appears inside big-operator bounds like `sum_(i in S)`; verified that mapping it to a symbol leaves such bounds parsing cleanly — `i in S` is the harmless juxtaposition `i · ∈ · S`. (There is no `In`/`And` relation in the neutral `RelOp`, so a `Symbol` standing for the glyph is the faithful representation.)
- **Two-letter short forms** fold onto the same canonical names as their PR-3a long forms: `sub`→`subset`, `sube`→`subseteq`, `sup`→`supset`, `supe`→`supseteq`, `uu`→`union` (= `cup`), `nn`→`intersection` (= `cap`), `AA`→`forall`, `EE`→`exists`.

## Behaviour note

`p("in")` was `i · n` in 0.4.0 and is now `Symbol("in")`; the PR-3a test that asserted the product form is updated. `x in RR` now parses as the three-symbol juxtaposition `x · ∈ · ℝ`.

## Gates

- `cargo test -p asciimath`: **30 unit tests + doc-test pass** (new `symbol_table_pr3b_bare_keywords_and_short_forms` — keywords, short/long agreement, `x in RR` juxtaposition, and that `sum_(i in S) i` still parses as a `BigOp`).
- `cargo clippy -p asciimath -- -D warnings`: clean.
- /security-review: **PASSED** (static match-table extension; no unsafe/panic/overflow/ReDoS).

asciimath **0.5.0**. Spec `ASM01-asciimath-frontend.md` §PR-3 updated: 3a + 3b shipped; **PR-3c** = punctuation arrows, longest-match (`sinx`→`sin·x`), `stackrel`/`overset`/`underset`, `text(…)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)