### PR TITLE
[codex] Add Berkeley SPICE app persisted editor state

### DIFF
--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Add Berkeley SPICE app-deck persisted editor-state snapshots for Mosaic host
+  restoration. `BerkeleyAppDeck::editor_state_snapshot()` and
+  `run_editor_state_snapshot()` now resolve saved selected-card and
+  active-command IDs against the current deck, including stale-state repair
+  flags.
 - Add Berkeley SPICE app-deck editor command plans for Mosaic host wiring.
   `BerkeleyAppDeck::editor_command_plan()` and `run_editor_command_plan()` now
   expose stable per-analysis command IDs, action kinds, targets, enabled states,

--- a/code/packages/rust/spice-netlist-parser/README.md
+++ b/code/packages/rust/spice-netlist-parser/README.md
@@ -58,6 +58,9 @@ assert!(command_plan
     .commands
     .iter()
     .any(|command| command.id == "analysis.3.inspect-waveform" && command.enabled));
+
+let view = deck.run_editor_state_snapshot(Default::default())?;
+assert_eq!(view.resolved_state.selected_syntax_card_index, Some(3));
 ```
 
 The facade preserves normalized logical cards, source spans, token names
@@ -73,9 +76,10 @@ hosts can render editor state without owning simulator internals. It also
 derives stable per-analysis editor controls for selecting, running, and
 inspecting tables or waveforms with explicit disabled reasons, plus command
 plans with stable command IDs and target names for host menu or button wiring.
-It is the Rust app/runtime entrypoint for Mosaic-backed UI work while the
-grammar-backed parser generator and Python/TypeScript parity surfaces continue
-to mature.
+Persisted editor-state snapshots resolve saved selection and active-command IDs
+against the current deck, repairing stale UI state after source edits. It is the
+Rust app/runtime entrypoint for Mosaic-backed UI work while the grammar-backed
+parser generator and Python/TypeScript parity surfaces continue to mature.
 
 This parser supports `R`, `C`, `L`, `V`, `I`, `D`, `Q`, `M`, `G`, `E`, `F`, and
 `H` elements, `.model <name> D(...)` diode cards with `IS` and `VT`

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -18,12 +18,12 @@ pub use syntax::{
     parse_berkeley_app_deck, parse_berkeley_syntax, BerkeleyAnalysisInventoryEntry,
     BerkeleyAppAnalysisArtifact, BerkeleyAppAnalysisControl, BerkeleyAppDeck,
     BerkeleyAppEditorAction, BerkeleyAppEditorActionKind, BerkeleyAppEditorCommand,
-    BerkeleyAppEditorCommandPlan, BerkeleyAppEditorControls, BerkeleyAppExecution,
-    BerkeleyAppSessionAnalysis, BerkeleyAppSessionState, BerkeleyAppWaveformPoint,
-    BerkeleyAppWaveformSeries, BerkeleyCardKind, BerkeleyDiagnosticSeverity,
-    BerkeleyGrammarMetadata, BerkeleyLogicalCard, BerkeleySyntaxDeck, BerkeleySyntaxDiagnostic,
-    BerkeleySyntaxToken, SourceSpan, BERKELEY_SPICE_GRAMMAR_NAME, BERKELEY_SPICE_GRAMMAR_VERSION,
-    BERKELEY_SPICE_PARSER_GRAMMAR, BERKELEY_SPICE_TOKEN_GRAMMAR,
+    BerkeleyAppEditorCommandPlan, BerkeleyAppEditorControls, BerkeleyAppEditorStateSnapshot,
+    BerkeleyAppExecution, BerkeleyAppPersistedEditorState, BerkeleyAppSessionAnalysis,
+    BerkeleyAppSessionState, BerkeleyAppWaveformPoint, BerkeleyAppWaveformSeries, BerkeleyCardKind,
+    BerkeleyDiagnosticSeverity, BerkeleyGrammarMetadata, BerkeleyLogicalCard, BerkeleySyntaxDeck,
+    BerkeleySyntaxDiagnostic, BerkeleySyntaxToken, SourceSpan, BERKELEY_SPICE_GRAMMAR_NAME,
+    BERKELEY_SPICE_GRAMMAR_VERSION, BERKELEY_SPICE_PARSER_GRAMMAR, BERKELEY_SPICE_TOKEN_GRAMMAR,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/code/packages/rust/spice-netlist-parser/src/syntax.rs
+++ b/code/packages/rust/spice-netlist-parser/src/syntax.rs
@@ -349,6 +349,30 @@ pub struct BerkeleyAppEditorCommandPlan {
     pub diagnostics: Vec<BerkeleySyntaxDiagnostic>,
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct BerkeleyAppPersistedEditorState {
+    pub selected_syntax_card_index: Option<usize>,
+    pub active_command_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BerkeleyAppEditorStateSnapshot {
+    pub canonical_source: String,
+    pub source_fingerprint: String,
+    pub title: Option<String>,
+    pub parsed: bool,
+    pub execution_available: bool,
+    pub requested_state: BerkeleyAppPersistedEditorState,
+    pub resolved_state: BerkeleyAppPersistedEditorState,
+    pub selection_stale: bool,
+    pub command_stale: bool,
+    pub selected_control: Option<BerkeleyAppAnalysisControl>,
+    pub active_command: Option<BerkeleyAppEditorCommand>,
+    pub command_plan: BerkeleyAppEditorCommandPlan,
+    pub blocking_message: Option<String>,
+    pub diagnostics: Vec<BerkeleySyntaxDiagnostic>,
+}
+
 impl BerkeleyAppDeck {
     pub fn has_errors(&self) -> bool {
         self.diagnostics
@@ -472,6 +496,23 @@ impl BerkeleyAppDeck {
     ) -> Result<BerkeleyAppEditorCommandPlan, AnalysisExecutionError> {
         Ok(editor_command_plan_from_controls(
             &self.run_editor_controls(selected_syntax_card_index)?,
+        ))
+    }
+
+    pub fn editor_state_snapshot(
+        &self,
+        persisted_state: BerkeleyAppPersistedEditorState,
+    ) -> BerkeleyAppEditorStateSnapshot {
+        editor_state_snapshot_from_session_state(self.session_state(None), persisted_state)
+    }
+
+    pub fn run_editor_state_snapshot(
+        &self,
+        persisted_state: BerkeleyAppPersistedEditorState,
+    ) -> Result<BerkeleyAppEditorStateSnapshot, AnalysisExecutionError> {
+        Ok(editor_state_snapshot_from_session_state(
+            self.run_session_state(None)?,
+            persisted_state,
         ))
     }
 
@@ -654,6 +695,100 @@ fn editor_command_plan_from_controls(
         blocking_message: controls.blocking_message.clone(),
         diagnostics: controls.diagnostics.clone(),
     }
+}
+
+fn editor_state_snapshot_from_session_state(
+    mut state: BerkeleyAppSessionState,
+    requested_state: BerkeleyAppPersistedEditorState,
+) -> BerkeleyAppEditorStateSnapshot {
+    let resolved_selection =
+        resolve_editor_selection(&state, requested_state.selected_syntax_card_index);
+    apply_session_selection(&mut state, resolved_selection);
+
+    let controls = editor_controls_from_session_state(&state);
+    let command_plan = editor_command_plan_from_controls(&controls);
+    let active_command = resolve_active_editor_command(
+        &command_plan,
+        resolved_selection,
+        requested_state.active_command_id.as_deref(),
+    )
+    .cloned();
+    let resolved_state = BerkeleyAppPersistedEditorState {
+        selected_syntax_card_index: resolved_selection,
+        active_command_id: active_command.as_ref().map(|command| command.id.clone()),
+    };
+    let selection_stale = requested_state.selected_syntax_card_index.is_some()
+        && requested_state.selected_syntax_card_index != resolved_state.selected_syntax_card_index;
+    let command_stale = requested_state.active_command_id.is_some()
+        && requested_state.active_command_id != resolved_state.active_command_id;
+
+    BerkeleyAppEditorStateSnapshot {
+        canonical_source: command_plan.canonical_source.clone(),
+        source_fingerprint: command_plan.source_fingerprint.clone(),
+        title: command_plan.title.clone(),
+        parsed: command_plan.parsed,
+        execution_available: command_plan.execution_available,
+        requested_state,
+        resolved_state,
+        selection_stale,
+        command_stale,
+        selected_control: controls.selected_control,
+        active_command,
+        blocking_message: command_plan.blocking_message.clone(),
+        diagnostics: command_plan.diagnostics.clone(),
+        command_plan,
+    }
+}
+
+fn resolve_editor_selection(
+    state: &BerkeleyAppSessionState,
+    requested_selection: Option<usize>,
+) -> Option<usize> {
+    if let Some(selection) = requested_selection {
+        if state
+            .analyses
+            .iter()
+            .any(|analysis| analysis.syntax_card_index == selection)
+        {
+            return Some(selection);
+        }
+    }
+    state
+        .analyses
+        .first()
+        .map(|analysis| analysis.syntax_card_index)
+}
+
+fn apply_session_selection(
+    state: &mut BerkeleyAppSessionState,
+    selected_syntax_card_index: Option<usize>,
+) {
+    state.selected_syntax_card_index = selected_syntax_card_index;
+    for analysis in &mut state.analyses {
+        analysis.selected = Some(analysis.syntax_card_index) == selected_syntax_card_index;
+    }
+    refresh_selected_session_analysis(state);
+}
+
+fn resolve_active_editor_command<'a>(
+    command_plan: &'a BerkeleyAppEditorCommandPlan,
+    selected_syntax_card_index: Option<usize>,
+    requested_command_id: Option<&str>,
+) -> Option<&'a BerkeleyAppEditorCommand> {
+    if let Some(command_id) = requested_command_id {
+        if let Some(command) = command_plan.commands.iter().find(|command| {
+            command.id == command_id
+                && Some(command.syntax_card_index) == selected_syntax_card_index
+        }) {
+            return Some(command);
+        }
+    }
+
+    let selected_syntax_card_index = selected_syntax_card_index?;
+    command_plan.commands.iter().find(|command| {
+        command.syntax_card_index == selected_syntax_card_index
+            && command.kind == BerkeleyAppEditorActionKind::SelectAnalysis
+    })
 }
 
 fn editor_command_from_control(

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -5,12 +5,12 @@ use spice_engine::{
 use spice_netlist_parser::{
     build_analysis_plan, parse_berkeley_app_deck, parse_berkeley_syntax, parse_netlist,
     parse_value, run_netlist, AcAnalysis, Analysis, AnalysisKind, AnalysisResult,
-    BerkeleyAppEditorActionKind, BerkeleyCardKind, BerkeleyDiagnosticSeverity,
-    BerkeleyGrammarMetadata, DcAnalysis, DistortionAnalysis, FourAnalysis, McAnalysis,
-    MeasureAnalysis, MeasureOperation, NetlistParseError, NoiseAnalysis, OpAnalysis, OptionValue,
-    OutputProbe, PlotAnalysis, PoleZeroAnalysis, PoleZeroKind, PrintAnalysis, ProbeAnalysis,
-    SaveAnalysis, SelectedOutputValue, SensAnalysis, TempAnalysis, TfAnalysis, TranAnalysis,
-    BERKELEY_SPICE_GRAMMAR_NAME, BERKELEY_SPICE_GRAMMAR_VERSION,
+    BerkeleyAppEditorActionKind, BerkeleyAppPersistedEditorState, BerkeleyCardKind,
+    BerkeleyDiagnosticSeverity, BerkeleyGrammarMetadata, DcAnalysis, DistortionAnalysis,
+    FourAnalysis, McAnalysis, MeasureAnalysis, MeasureOperation, NetlistParseError, NoiseAnalysis,
+    OpAnalysis, OptionValue, OutputProbe, PlotAnalysis, PoleZeroAnalysis, PoleZeroKind,
+    PrintAnalysis, ProbeAnalysis, SaveAnalysis, SelectedOutputValue, SensAnalysis, TempAnalysis,
+    TfAnalysis, TranAnalysis, BERKELEY_SPICE_GRAMMAR_NAME, BERKELEY_SPICE_GRAMMAR_VERSION,
 };
 
 fn assert_close(actual: f64, expected: f64) {
@@ -2282,6 +2282,95 @@ R1 in out
         .as_deref()
         .unwrap()
         .contains("Berkeley SPICE app deck:"));
+}
+
+#[test]
+fn berkeley_app_facade_restores_persisted_editor_state_after_execution() {
+    let app = parse_berkeley_app_deck(
+        r#"
+* transient editor state
+V1 in 0 PULSE(0 1 0 1n 1n 1n 4n)
+R1 in out 1k
+C1 out 0 1p
+.tran 1n 3n
+.print tran V(out)
+.end
+"#,
+    );
+    let requested = BerkeleyAppPersistedEditorState {
+        selected_syntax_card_index: Some(3),
+        active_command_id: Some("analysis.3.inspect-waveform".to_string()),
+    };
+
+    let snapshot = app.run_editor_state_snapshot(requested.clone()).unwrap();
+
+    assert!(snapshot.parsed);
+    assert!(snapshot.execution_available);
+    assert_eq!(snapshot.requested_state, requested);
+    assert_eq!(
+        snapshot.resolved_state,
+        BerkeleyAppPersistedEditorState {
+            selected_syntax_card_index: Some(3),
+            active_command_id: Some("analysis.3.inspect-waveform".to_string()),
+        }
+    );
+    assert!(!snapshot.selection_stale);
+    assert!(!snapshot.command_stale);
+    assert_eq!(snapshot.command_plan.command_count, 4);
+
+    let selected = snapshot.selected_control.as_ref().unwrap();
+    assert_eq!(selected.directive, ".tran");
+    assert!(selected.waveform_available);
+
+    let active = snapshot.active_command.as_ref().unwrap();
+    assert_eq!(active.id, "analysis.3.inspect-waveform");
+    assert_eq!(active.target, "analysis-waveform");
+    assert!(active.enabled);
+    assert!(active.selected);
+}
+
+#[test]
+fn berkeley_app_facade_repairs_stale_persisted_editor_state() {
+    let app = parse_berkeley_app_deck(
+        r#"
+* transient editor state
+V1 in 0 PULSE(0 1 0 1n 1n 1n 4n)
+R1 in out 1k
+C1 out 0 1p
+.tran 1n 3n
+.print tran V(out)
+.end
+"#,
+    );
+
+    let snapshot = app.editor_state_snapshot(BerkeleyAppPersistedEditorState {
+        selected_syntax_card_index: Some(99),
+        active_command_id: Some("analysis.99.run".to_string()),
+    });
+
+    assert_eq!(
+        snapshot.resolved_state,
+        BerkeleyAppPersistedEditorState {
+            selected_syntax_card_index: Some(3),
+            active_command_id: Some("analysis.3.select".to_string()),
+        }
+    );
+    assert!(snapshot.selection_stale);
+    assert!(snapshot.command_stale);
+    assert_eq!(
+        snapshot
+            .selected_control
+            .as_ref()
+            .unwrap()
+            .syntax_card_index,
+        3
+    );
+
+    let active = snapshot.active_command.as_ref().unwrap();
+    assert_eq!(active.kind, BerkeleyAppEditorActionKind::SelectAnalysis);
+    assert_eq!(active.target, "analysis-selection");
+    assert!(active.enabled);
+    assert!(active.selected);
 }
 
 #[test]

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,14 +33,14 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Rust Berkeley Mosaic editor command plans.
+1. Rust Berkeley Mosaic persisted editor state.
    - Status: current PR completion candidate.
    - Expand the Rust `spice-netlist-parser` Berkeley app facade from
-     deterministic editor controls into stable command descriptors for Mosaic
-     host menu, toolbar, and panel wiring.
-   - Expose per-analysis command IDs, action kinds, target names, enabled
-     states, and disabled reasons so hosts can dispatch select/run/table/
-     waveform actions without reinterpreting labels or parser internals.
+     stable command descriptors into persisted editor-state restoration for
+     Mosaic host UI sessions.
+   - Resolve saved selected-card and active-command IDs against the current
+     deck, including stale-state repair flags, so hosts can restore selection
+     after source edits without duplicating parser or simulator internals.
    - Keep this as a Rust-only app-substrate acceleration slice over the public
      parser contract and existing engine deck artifacts; Python and TypeScript
      parser parity was completed separately and should remain aligned when
@@ -1484,6 +1484,15 @@ the Rust, Python, and TypeScript surfaces together.
      can render parser and execution status without duplicating simulator
      internals.
 
+140. Rust Berkeley Mosaic editor command plans.
+   - Status: completed in PR 6954.
+   - Rust `spice-netlist-parser` Berkeley app-deck command plans now expose
+     per-analysis command IDs, action kinds, target names, enabled states, and
+     disabled reasons for Mosaic host menu, toolbar, and panel wiring.
+   - The slice keeps command descriptors derived from editor controls so hosts
+     can dispatch select/run/table/waveform actions without reinterpreting
+     labels or parser internals.
+
 ## Backlog
 
 1. Grammar-backed parser and app facade.
@@ -1491,8 +1500,8 @@ the Rust, Python, and TypeScript surfaces together.
      syntax facade as the grammar evolves, even if that breaks current
      pre-release parser APIs.
    - Continue expanding the Rust Mosaic app facade beyond the initial
-     card-indexed result artifacts toward persisted UI state and host
-     integration backed by the same public parser contract.
+     card-indexed result artifacts toward host integration backed by the same
+     public parser contract.
 
 2. Deck compatibility follow-up.
    - Expand deck-owned output compatibility beyond source-order analysis


### PR DESCRIPTION
## Summary
- add Rust Berkeley app persisted editor-state snapshots that resolve saved selected-card and active-command IDs against the current deck
- expose `BerkeleyAppDeck::editor_state_snapshot()` and `run_editor_state_snapshot()` plus public persisted/snapshot structs with stale-state repair flags
- update parser docs/changelog and advance the SPICE plan after PR #6954 merged

## Validation
- `cargo fmt -p spice-netlist-parser`
- `cargo test -p spice-netlist-parser -- --nocapture`
- `cargo test -p grammar-tools --test spice_grammar_validation -- --nocapture`
- `git diff --check`