### PR TITLE
feat(asciimath): punctuation arrows -> and => (PR-3c part 1)

### DIFF
--- a/code/packages/rust/asciimath/CHANGELOG.md
+++ b/code/packages/rust/asciimath/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to the AsciiMath pluggable frontend.
 
+## [0.6.0] — 2026-06-29
+
+### Added — ASM01 PR-3c (part 1): punctuation arrows `->` and `=>`
+
+- The tokenizer now recognizes the punctuation arrows **`->`** and **`=>`** and emits them as the
+  *existing* symbol-table identifiers `rightarrow` / `implies` — so they flow through the PR-3a
+  symbol table and lower to `MathExpr::Symbol("rightarrow")` / `Symbol("implies")`, agreeing exactly
+  with the word forms `rarr` / `implies`. **Zero ripple**: only `token.rs` changes (two extra
+  byte-lookahead branches, mirroring the existing `-:`/`-=`/`<=`/`!=` multi-char operators); no new
+  `TokenKind`, no parser change, no `Capabilities`/conformance change.
+- The single-character forms are untouched: `a - b` is still `Bin(Sub)`, `a = b` is still `Rel(Eq)`.
+  A right-arrow inside a limit bound parses cleanly (`lim_(x -> 0) f` is a `BigOp`) — `x -> 0` is the
+  juxtaposition `x · → · 0`, not a `-`/`>` mishmash.
+- Tests: tokenizer `multi_char_operators` gains `->`/`=>` (and asserts `-`/`=` unaffected); new parser
+  `punctuation_arrows_lower_to_symbols` (arrow lowering, punctuation==word-form agreement, sub/rel
+  still intact, limit-bound parse). Conformance corpus gains `a -> b`, `x => y`. 31 unit + doc tests
+  pass; clippy `-D warnings` clean.
+- Still **PR-3c remainder** (each its own follow-up): **longest-match** identifier scan (`sinx` →
+  `sin·x`, a deeper lexer change), `stackrel`/`overset`/`underset` (need a neutral-AST node in
+  `math-frontend` — no `Overset`/`Underset` in `MathExpr` yet), and the `text(…)` keyword form (needs
+  lexer raw-capture between the parens).
+
 ## [0.5.0] — 2026-06-29
 
 ### Added — ASM01 PR-3b: bare-keyword spellings + two-letter short forms

--- a/code/packages/rust/asciimath/Cargo.toml
+++ b/code/packages/rust/asciimath/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "asciimath"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "An AsciiMath parser that implements the math-frontend MathFrontend trait: turns AsciiMath (1/2, sqrt(x), x^2+y^2=r^2) into the neutral MathExpr AST. The second pluggable frontend after LaTeX (see ASM01/PFE01). Total, panic-free, spanned errors."
 license = "MIT"

--- a/code/packages/rust/asciimath/README.md
+++ b/code/packages/rust/asciimath/README.md
@@ -87,9 +87,14 @@ conformance change.
 **PR-3b** completes the symbol surface: the bare keyword spellings `in`/`and`/`or`/`not` (→ symbols)
 and the two-letter short forms `sub`/`sube`/`sup`/`supe` (subset family), `uu`→`union`, `nn`→`intersection`,
 `AA`→`forall`, `EE`→`exists`. (`in` is safe inside big-operator bounds — `sum_(i in S)` parses as the
-juxtaposition `i · ∈ · S`.) **Still deferred to PR-3c** (structural, not table entries): punctuation
-arrows (`->`, `=>`), longest-match identifier scan (`sinx` → `sin·x`), `stackrel`/`overset`/`underset`,
-and the `text(…)` keyword form.
+juxtaposition `i · ∈ · S`.)
+
+**PR-3c (part 1)** adds the punctuation arrows `->` → `Symbol("rightarrow")` and `=>` →
+`Symbol("implies")` — recognized in the tokenizer and routed through the PR-3a symbol table (so they
+agree with the word forms `rarr`/`implies`); `a - b` and `a = b` are unaffected. **Still to come**
+(each structural, its own PR): longest-match identifier scan (`sinx` → `sin·x`),
+`stackrel`/`overset`/`underset` (need a neutral-AST node), and the `text(…)` keyword form (needs lexer
+raw-capture).
 
 It is **total and panic-free**: every input returns `Ok(MathExpr)` or a spanned
 `FrontendError`. Recursion is depth-guarded (matrix nesting included); left-associative chains are

--- a/code/packages/rust/asciimath/src/lib.rs
+++ b/code/packages/rust/asciimath/src/lib.rs
@@ -162,6 +162,26 @@ mod tests {
         assert!(matches!(p("sum_(i in S) i"), MathExpr::BigOp { .. }));
     }
 
+    #[test]
+    fn punctuation_arrows_lower_to_symbols() {
+        // PR-3c: `->` and `=>` tokenize to the symbol-table identifiers, so they lower to the same
+        // Symbol as the word forms `rarr`/`implies` — `a -> b` is the juxtaposition `a · → · b`.
+        assert_eq!(
+            p("a -> b"),
+            b(BinOp::Mul, b(BinOp::Mul, sym("a"), sym("rightarrow")), sym("b"))
+        );
+        assert_eq!(p("a -> b"), p("a rarr b")); // punctuation and word forms agree
+        assert_eq!(
+            p("a => b"),
+            b(BinOp::Mul, b(BinOp::Mul, sym("a"), sym("implies")), sym("b"))
+        );
+        // Single-char `-` / `=` are unaffected: subtraction and relation still parse as before.
+        assert_eq!(p("a - b"), b(BinOp::Sub, sym("a"), sym("b")));
+        assert!(matches!(p("a = b"), MathExpr::Rel(RelOp::Eq, _, _)));
+        // A right-arrow inside a limit bound parses (no `-`/`>` breakage): `lim_(x -> 0) f`.
+        assert!(matches!(p("lim_(x -> 0) f"), MathExpr::BigOp { .. }));
+    }
+
     // ---- operators & precedence ------------------------------------------------
     #[test]
     fn add_and_implicit_mul() {
@@ -412,6 +432,8 @@ mod tests {
                 "alpha + Omega",   // greek symbols (PR-3a symbol table)
                 "x in RR",         // blackboard set + (deferred) bare keyword, no panic
                 "a cup b",         // set operator as a symbol
+                "a -> b",          // punctuation arrow (PR-3c)
+                "x => y",          // punctuation double-arrow
                 "1 +",   // error: trailing operator (span in range, not a panic)
                 "(x",    // error: missing close
                 "",      // error: empty

--- a/code/packages/rust/asciimath/src/token.rs
+++ b/code/packages/rust/asciimath/src/token.rs
@@ -139,13 +139,21 @@ pub fn tokenize(src: &str) -> Result<Vec<Token>, FrontendError> {
             b'-' => match next {
                 Some(b':') => (TokenKind::Div, i + 2),
                 Some(b'=') => (TokenKind::Equiv, i + 2),
+                // Punctuation arrow `->`: emit the same identifier the word form `rarr` does, so it
+                // flows through the existing symbol table (PR-3a) and lowers to `Symbol("rightarrow")`.
+                // No new token kind, no parser change. (`a->b` ⇒ `a · → · b`; `lim_(x->0)` unaffected.)
+                Some(b'>') => (TokenKind::Ident("rightarrow".to_string()), i + 2),
                 _ => (TokenKind::Minus, i + 1),
             },
             b'*' => (TokenKind::Star, if next == Some(b'*') { i + 2 } else { i + 1 }),
             b'/' => (TokenKind::Slash, i + 1),
             b'^' => (TokenKind::Caret, i + 1),
             b'_' => (TokenKind::Underscore, i + 1),
-            b'=' => (TokenKind::Eq, i + 1),
+            b'=' => match next {
+                // Punctuation double-arrow `=>` → the `implies` identifier (PR-3a symbol table).
+                Some(b'>') => (TokenKind::Ident("implies".to_string()), i + 2),
+                _ => (TokenKind::Eq, i + 1),
+            },
             b'!' => match next {
                 Some(b'=') => (TokenKind::Ne, i + 2),
                 _ => return Err(err("unexpected '!' (did you mean '!='?)", (start, start + 1))),
@@ -236,6 +244,12 @@ mod tests {
         assert_eq!(kinds("a ~~ b")[1], TokenKind::Approx);
         assert_eq!(kinds("a -= b")[1], TokenKind::Equiv);
         assert_eq!(kinds("a ** b")[1], TokenKind::Star);
+        // PR-3c: punctuation arrows tokenize as the symbol-table identifiers (not `-`/`>`/`=`).
+        assert_eq!(kinds("a -> b")[1], TokenKind::Ident("rightarrow".into()));
+        assert_eq!(kinds("a => b")[1], TokenKind::Ident("implies".into()));
+        // The single-char forms are unaffected.
+        assert_eq!(kinds("a - b")[1], TokenKind::Minus);
+        assert_eq!(kinds("a = b")[1], TokenKind::Eq);
     }
 
     #[test]

--- a/code/specs/ASM01-asciimath-frontend.md
+++ b/code/specs/ASM01-asciimath-frontend.md
@@ -104,9 +104,14 @@ shapes for representative inputs.
   `sube`→`subseteq`, `sup`→`supset`, `supe`→`supseteq`, `uu`→`union`, `nn`→`intersection`,
   `AA`→`forall`, `EE`→`exists`. Still additive (no `Capabilities`/conformance change). Behaviour note:
   `p("in")` changed from `i·n` to `Symbol("in")`.
-- **PR-3c:** the structural remainder (not table entries) — punctuation arrows (`->`, `=>`, a tokenizer
-  concern), **longest-match tokenization** (so `sinx` splits as `sin`·`x`), `stackrel`,
-  `overset`/`underset`, and the `text(…)` keyword form alongside the `"…"` literal.
+- **PR-3c part 1 (shipped, v0.6.0):** punctuation arrows `->` and `=>` — recognized in the tokenizer
+  and emitted as the existing `rightarrow`/`implies` identifiers, so they route through the PR-3a
+  symbol table and lower to `Symbol` (agreeing with the word forms). Tokenizer-only, zero ripple; the
+  single-char `-`/`=` are unaffected (`a - b` = `Bin(Sub)`, `a = b` = `Rel(Eq)`).
+- **PR-3c remainder** (each its own follow-up, structural): **longest-match tokenization** (so `sinx`
+  splits as `sin`·`x`, a deeper lexer change); `stackrel`, `overset`/`underset` (need a neutral-AST
+  node in `math-frontend` — there is no `Overset`/`Underset` in `MathExpr` yet); and the `text(…)`
+  keyword form alongside the `"…"` literal (needs lexer raw-capture between the parens).
 
 ## 6. Non-goals
 Evaluation, simplification, rendering — none are a frontend's job (PFE01 §7). Lowering


### PR DESCRIPTION
## What

The LaTeX-stream alternation handoff after #6956 (PR-3b) merged. Adds the first slice of **ASM01 PR-3c**: the tokenizer now recognizes the punctuation arrows **`->`** and **`=>`** and emits them as the *existing* symbol-table identifiers `rightarrow` / `implies` — so they flow through the PR-3a symbol table and lower to `MathExpr::Symbol`, agreeing exactly with the word forms `rarr` / `implies`.

## Why it's zero-ripple

Only `token.rs` changes — two byte-lookahead branches mirroring the existing `-:` / `-=` / `<=` / `!=` multi-char operators. **No new `TokenKind`, no parser change, no `Capabilities`/conformance change.** The single-character forms are untouched: `a - b` is still `Bin(Sub)`, `a = b` is still `Rel(Eq)`. A right-arrow inside a limit bound parses cleanly — `lim_(x -> 0) f` is a `BigOp`; `x -> 0` is the juxtaposition `x · → · 0`.

## Gates

- `cargo test -p asciimath`: **31 unit tests + doc-test pass** (new `punctuation_arrows_lower_to_symbols`; `multi_char_operators` extended).
- `cargo clippy -p asciimath -- -D warnings`: clean.
- /security-review: **PASSED** (bounded cursor arithmetic; no unsafe/panic/overflow/ReDoS).

asciimath **0.6.0**. Spec §PR-3c split: part 1 shipped; remainder = longest-match (`sinx`→`sin·x`), `stackrel`/`overset`/`underset` (needs a neutral node), `text(…)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)