### PR TITLE
[codex] Track form interactive audit repair evidence

### DIFF
--- a/code/packages/rust/html-parser/tests/whatwg_form_interactive_audit_test.rs
+++ b/code/packages/rust/html-parser/tests/whatwg_form_interactive_audit_test.rs
@@ -7,8 +7,10 @@ use std::collections::{BTreeMap, HashMap};
 const TREE_CONSTRUCTION_SMOKE: &str = include_str!("fixtures/html5lib-tree-construction-smoke.dat");
 const WHATWG_FORM_INTERACTIVE_AUDIT: &str =
     include_str!("fixtures/whatwg-form-interactive-audit.json");
-const POST_PARSE_REPAIR_EVIDENCE: &[(&str, &str)] =
-    &[("tricky01-dat-8", "interactive-formatting")];
+const POST_PARSE_REPAIR_EVIDENCE: &[(&str, &str)] = &[
+    ("tests26-dat-1251", "interactive-formatting"),
+    ("tricky01-dat-8", "interactive-formatting"),
+];
 
 #[derive(Debug, Deserialize)]
 struct FormInteractiveAuditSuite {


### PR DESCRIPTION
## Summary
- Add `tests26-dat-1251` to the form/interactive audit post-parse repair evidence list.
- Keep parser behavior unchanged; this records executable evidence for the existing `repair_table_cell_fostered_nobr_adoption` path.

## Evidence
- Negative control: temporarily no-oping `repair_table_cell_fostered_nobr_adoption` made `whatwg_form_interactive_audit_cases_match_parser_dom_dump -- --nocapture` fail on `tests26-dat-1251` with axis `interactive-formatting`.

## Validation
From `code/packages/rust`:
- `cargo test -p coding-adventures-html-parser font_newline_before_bold_stays_outside_reconstructed_font`
- `cargo test -p coding-adventures-html-parser whatwg_document_shell_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_head_body_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_form_interactive_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_legacy_element_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_paragraph_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_block_boundary_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_table_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_formatting_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_document_shell_audit_cases_match_parser_dom_dump`
- `cargo test -p coding-adventures-html-parser whatwg_head_body_audit_cases_match_parser_dom_dump`
- `cargo test -p coding-adventures-html-parser whatwg_formatting_audit_cases_match_parser_dom_dump`
- `cargo test -p coding-adventures-html-parser whatwg_paragraph_audit_cases_match_parser_dom_dump`
- `cargo test -p coding-adventures-html-parser whatwg_block_boundary_audit_cases_match_parser_dom_dump`
- `cargo test -p coding-adventures-html-parser html5lib_tree_construction_smoke_cases_match_dom_dump`
- `cargo test -p coding-adventures-html-parser`
- `cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser`

From the worktree root:
- `python3 -m json.tool code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json >/dev/null`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py`
- `git diff --check`