### PR TITLE
Add smart home state history bridge filter

### DIFF
--- a/code/packages/rust/smart-home-platform-http/CHANGELOG.md
+++ b/code/packages/rust/smart-home-platform-http/CHANGELOG.md
@@ -81,6 +81,8 @@ All notable changes to this package will be documented in this file.
   history views scoped to one device event class from URL state.
 - Added state-history time-window filters so smart-home `from_ms`/`to_ms` and
   Home Assistant period `start_time`/`end_time` requests share the same route.
+- Added state-history bridge filtering so `bridge_id` route-catalog entries are
+  enforced by the runtime history query.
 - Added fixture-controller launch help, smoke-test URLs, and example-level tests
   to keep the local controller startup path usable.
 - Added a machine-readable local-controller smoke plan route that lists safe

--- a/code/packages/rust/smart-home-platform-http/README.md
+++ b/code/packages/rust/smart-home-platform-http/README.md
@@ -130,7 +130,8 @@ room, activity, history, audit, and
 grant-boundary views can be shared or reopened directly.
 State-history routes also accept numeric observed-time windows through
 `from_ms`/`to_ms` on `/api/smart_home/state_history` and
-`start_time`/`end_time` on Home Assistant period routes.
+`start_time`/`end_time` on Home Assistant period routes, and can scope runtime
+history to a single bridge through `bridge_id`.
 
 ## Dependencies
 

--- a/code/packages/rust/smart-home-platform-http/src/lib.rs
+++ b/code/packages/rust/smart-home-platform-http/src/lib.rs
@@ -6018,6 +6018,7 @@ fn state_history_events<'a>(
     let event_type = query_string(request, "event_type")
         .map(device_event_type_from_label)
         .transpose()?;
+    let bridge_id = query_string(request, "bridge_id");
     let room_id = query_string(request, "room_id");
     let observed_at_or_after_ms = history_from_ms(request)?;
     let observed_at_or_before_ms = history_to_ms(request)?;
@@ -6032,6 +6033,7 @@ fn state_history_events<'a>(
                 .as_ref()
                 .is_none_or(|entity_id| event.entity_id.as_ref() == Some(entity_id))
         })
+        .filter(|event| bridge_id.is_none_or(|bridge_id| event.bridge_id.as_str() == bridge_id))
         .filter(|event| {
             room_id.is_none_or(|room_id| device_event_matches_room(runtime, event, room_id))
         })
@@ -9199,6 +9201,25 @@ mod tests {
             .into(),
         );
         assert!(past_window_body.contains(r#""total_events":0"#));
+
+        let bridge_body = response_body(
+            app.handle(request(
+                "GET",
+                "/api/smart_home/state_history?bridge_id=bridge-1&limit=5",
+            ))
+            .into(),
+        );
+        assert!(bridge_body.contains(r#""total_events":1"#));
+        assert!(bridge_body.contains(r#""event_id":"event-light-1-on""#));
+
+        let missing_bridge_body = response_body(
+            app.handle(request(
+                "GET",
+                "/api/smart_home/state_history?bridge_id=bridge-2&limit=5",
+            ))
+            .into(),
+        );
+        assert!(missing_bridge_body.contains(r#""total_events":0"#));
 
         let room_body = response_body(
             app.handle(request(


### PR DESCRIPTION
## Summary
- honor `bridge_id` on `/api/smart_home/state_history`
- add positive and negative bridge-scoped state-history assertions
- document that history routes can be scoped to a bridge

## Validation
- `cargo fmt -p smart-home-platform-http`
- `cargo test -p smart-home-platform-http -- --nocapture`
- `sh BUILD` from `code/packages/rust/smart-home-platform-http`
- `git diff --check`
- `test ! -e code/packages/rust/Cargo.lock`