### PR TITLE
[codex] Add Berkeley SPICE app host wire export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added — SPICE Berkeley Mosaic Host Wire Export
+- `spice-netlist-parser` now exposes schema-versioned Berkeley app host-surface
+  wire snapshots for Mosaic packaging and WebAssembly embedding.
+  `host_surface_wire()`, `run_host_surface_wire()`, and their JSON helpers
+  flatten the host panel contract into stable lower-case panel kinds,
+  diagnostics, active-panel IDs, and repaired persisted editor-state metadata.
+- The JSON helpers avoid exposing simulator internals to product shells while
+  preserving the Rust app substrate over the public Berkeley parser contract.
+
 ### Added — SPICE Berkeley Mosaic Host Surface
 - `spice-netlist-parser` now exposes Berkeley app-deck host surfaces for Mosaic
   shell integration. `host_surface()` and `run_host_surface()` derive stable

--- a/code/packages/rust/spice-netlist-parser/Cargo.toml
+++ b/code/packages/rust/spice-netlist-parser/Cargo.toml
@@ -5,4 +5,5 @@ edition = "2021"
 description = "SPICE3 netlist parser that builds coding-adventures SPICE engine circuits"
 
 [dependencies]
+serde_json = "1"
 spice-engine = { path = "../spice-engine" }

--- a/code/packages/rust/spice-netlist-parser/README.md
+++ b/code/packages/rust/spice-netlist-parser/README.md
@@ -69,6 +69,12 @@ let host = deck.run_host_surface(BerkeleyAppPersistedEditorState {
     active_command_id: Some("analysis.3.inspect-waveform".to_string()),
 })?;
 assert_eq!(host.active_panel.unwrap().id, "waveform");
+
+let host_wire_json = deck.run_host_surface_wire_json(BerkeleyAppPersistedEditorState {
+    selected_syntax_card_index: Some(3),
+    active_command_id: Some("analysis.3.inspect-waveform".to_string()),
+})?;
+assert!(host_wire_json.contains(r#""activePanelId":"waveform""#));
 ```
 
 The facade preserves normalized logical cards, source spans, token names
@@ -88,7 +94,10 @@ Persisted editor-state snapshots resolve saved selection and active-command IDs
 against the current deck, repairing stale UI state after source edits. Host
 surfaces turn those snapshots into stable source, diagnostics, analysis, table,
 and waveform panel descriptors with explicit targets, enabled states, active
-state, and disabled reasons for Mosaic shell integration. It is the
+state, and disabled reasons for Mosaic shell integration. Host-surface wire
+exports flatten the same contract into schema-versioned JSON with repaired
+selection metadata and lower-case panel / diagnostic kinds for WebAssembly and
+product-shell embedding. It is the
 Rust app/runtime entrypoint for Mosaic-backed UI work while the grammar-backed
 parser generator and Python/TypeScript parity surfaces continue to mature.
 

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -19,12 +19,15 @@ pub use syntax::{
     BerkeleyAppAnalysisArtifact, BerkeleyAppAnalysisControl, BerkeleyAppDeck,
     BerkeleyAppEditorAction, BerkeleyAppEditorActionKind, BerkeleyAppEditorCommand,
     BerkeleyAppEditorCommandPlan, BerkeleyAppEditorControls, BerkeleyAppEditorStateSnapshot,
-    BerkeleyAppExecution, BerkeleyAppHostPanel, BerkeleyAppHostPanelKind, BerkeleyAppHostSurface,
-    BerkeleyAppPersistedEditorState, BerkeleyAppSessionAnalysis, BerkeleyAppSessionState,
-    BerkeleyAppWaveformPoint, BerkeleyAppWaveformSeries, BerkeleyCardKind,
-    BerkeleyDiagnosticSeverity, BerkeleyGrammarMetadata, BerkeleyLogicalCard, BerkeleySyntaxDeck,
-    BerkeleySyntaxDiagnostic, BerkeleySyntaxToken, SourceSpan, BERKELEY_SPICE_GRAMMAR_NAME,
-    BERKELEY_SPICE_GRAMMAR_VERSION, BERKELEY_SPICE_PARSER_GRAMMAR, BERKELEY_SPICE_TOKEN_GRAMMAR,
+    BerkeleyAppExecution, BerkeleyAppHostDiagnosticWire, BerkeleyAppHostPanel,
+    BerkeleyAppHostPanelKind, BerkeleyAppHostPanelWire, BerkeleyAppHostSpanWire,
+    BerkeleyAppHostSurface, BerkeleyAppHostSurfaceWire, BerkeleyAppPersistedEditorState,
+    BerkeleyAppSessionAnalysis, BerkeleyAppSessionState, BerkeleyAppWaveformPoint,
+    BerkeleyAppWaveformSeries, BerkeleyCardKind, BerkeleyDiagnosticSeverity,
+    BerkeleyGrammarMetadata, BerkeleyLogicalCard, BerkeleySyntaxDeck, BerkeleySyntaxDiagnostic,
+    BerkeleySyntaxToken, SourceSpan, BERKELEY_APP_HOST_SURFACE_WIRE_SCHEMA_VERSION,
+    BERKELEY_SPICE_GRAMMAR_NAME, BERKELEY_SPICE_GRAMMAR_VERSION, BERKELEY_SPICE_PARSER_GRAMMAR,
+    BERKELEY_SPICE_TOKEN_GRAMMAR,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/code/packages/rust/spice-netlist-parser/src/syntax.rs
+++ b/code/packages/rust/spice-netlist-parser/src/syntax.rs
@@ -13,6 +13,7 @@ pub const BERKELEY_SPICE_TOKEN_GRAMMAR: &str =
     include_str!("../../../../grammars/spice/berkeley.tokens");
 pub const BERKELEY_SPICE_PARSER_GRAMMAR: &str =
     include_str!("../../../../grammars/spice/berkeley.grammar");
+pub const BERKELEY_APP_HOST_SURFACE_WIRE_SCHEMA_VERSION: u32 = 1;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct SourceSpan {
@@ -408,6 +409,60 @@ pub struct BerkeleyAppHostSurface {
     pub diagnostics: Vec<BerkeleySyntaxDiagnostic>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BerkeleyAppHostSpanWire {
+    pub start_line: usize,
+    pub start_column: usize,
+    pub end_line: usize,
+    pub end_column: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BerkeleyAppHostDiagnosticWire {
+    pub code: String,
+    pub severity: String,
+    pub message: String,
+    pub span: Option<BerkeleyAppHostSpanWire>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BerkeleyAppHostPanelWire {
+    pub id: String,
+    pub kind: String,
+    pub title: String,
+    pub target: String,
+    pub enabled: bool,
+    pub active: bool,
+    pub disabled_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BerkeleyAppHostSurfaceWire {
+    pub schema_version: u32,
+    pub canonical_source: String,
+    pub source_fingerprint: String,
+    pub title: Option<String>,
+    pub parsed: bool,
+    pub execution_available: bool,
+    pub requested_selected_syntax_card_index: Option<usize>,
+    pub requested_active_command_id: Option<String>,
+    pub resolved_selected_syntax_card_index: Option<usize>,
+    pub resolved_active_command_id: Option<String>,
+    pub selection_stale: bool,
+    pub command_stale: bool,
+    pub panel_count: usize,
+    pub active_panel_id: Option<String>,
+    pub panels: Vec<BerkeleyAppHostPanelWire>,
+    pub blocking_message: Option<String>,
+    pub diagnostics: Vec<BerkeleyAppHostDiagnosticWire>,
+}
+
+impl BerkeleyAppHostSurfaceWire {
+    pub fn to_json(&self) -> String {
+        host_surface_wire_json_value(self).to_string()
+    }
+}
+
 impl BerkeleyAppDeck {
     pub fn has_errors(&self) -> bool {
         self.diagnostics
@@ -565,6 +620,36 @@ impl BerkeleyAppDeck {
         Ok(host_surface_from_editor_state(
             self.run_editor_state_snapshot(persisted_state)?,
         ))
+    }
+
+    pub fn host_surface_wire(
+        &self,
+        persisted_state: BerkeleyAppPersistedEditorState,
+    ) -> BerkeleyAppHostSurfaceWire {
+        BerkeleyAppHostSurfaceWire::from(self.host_surface(persisted_state))
+    }
+
+    pub fn run_host_surface_wire(
+        &self,
+        persisted_state: BerkeleyAppPersistedEditorState,
+    ) -> Result<BerkeleyAppHostSurfaceWire, AnalysisExecutionError> {
+        Ok(BerkeleyAppHostSurfaceWire::from(
+            self.run_host_surface(persisted_state)?,
+        ))
+    }
+
+    pub fn host_surface_wire_json(
+        &self,
+        persisted_state: BerkeleyAppPersistedEditorState,
+    ) -> String {
+        self.host_surface_wire(persisted_state).to_json()
+    }
+
+    pub fn run_host_surface_wire_json(
+        &self,
+        persisted_state: BerkeleyAppPersistedEditorState,
+    ) -> Result<String, AnalysisExecutionError> {
+        Ok(self.run_host_surface_wire(persisted_state)?.to_json())
     }
 
     pub fn run_source_order(&self) -> Result<Vec<AnalysisExecutionResult>, AnalysisExecutionError> {
@@ -989,6 +1074,161 @@ fn host_panel_disabled_reason(
         })
         .and_then(|command| command.disabled_reason.clone())
         .or_else(|| Some("selected analysis does not expose this panel".to_string()))
+}
+
+impl From<BerkeleyAppHostSurface> for BerkeleyAppHostSurfaceWire {
+    fn from(surface: BerkeleyAppHostSurface) -> Self {
+        let active_panel_id = surface.active_panel.as_ref().map(|panel| panel.id.clone());
+        let requested_state = surface.editor_state.requested_state.clone();
+        let resolved_state = surface.editor_state.resolved_state.clone();
+
+        Self {
+            schema_version: BERKELEY_APP_HOST_SURFACE_WIRE_SCHEMA_VERSION,
+            canonical_source: surface.canonical_source,
+            source_fingerprint: surface.source_fingerprint,
+            title: surface.title,
+            parsed: surface.parsed,
+            execution_available: surface.execution_available,
+            requested_selected_syntax_card_index: requested_state.selected_syntax_card_index,
+            requested_active_command_id: requested_state.active_command_id,
+            resolved_selected_syntax_card_index: resolved_state.selected_syntax_card_index,
+            resolved_active_command_id: resolved_state.active_command_id,
+            selection_stale: surface.editor_state.selection_stale,
+            command_stale: surface.editor_state.command_stale,
+            panel_count: surface.panel_count,
+            active_panel_id,
+            panels: surface
+                .panels
+                .into_iter()
+                .map(BerkeleyAppHostPanelWire::from)
+                .collect(),
+            blocking_message: surface.blocking_message,
+            diagnostics: surface
+                .diagnostics
+                .into_iter()
+                .map(BerkeleyAppHostDiagnosticWire::from)
+                .collect(),
+        }
+    }
+}
+
+impl From<BerkeleyAppHostPanel> for BerkeleyAppHostPanelWire {
+    fn from(panel: BerkeleyAppHostPanel) -> Self {
+        Self {
+            id: panel.id,
+            kind: host_panel_kind_wire(panel.kind).to_string(),
+            title: panel.title,
+            target: panel.target,
+            enabled: panel.enabled,
+            active: panel.active,
+            disabled_reason: panel.disabled_reason,
+        }
+    }
+}
+
+impl From<BerkeleySyntaxDiagnostic> for BerkeleyAppHostDiagnosticWire {
+    fn from(diagnostic: BerkeleySyntaxDiagnostic) -> Self {
+        Self {
+            code: diagnostic.code,
+            severity: diagnostic_severity_wire(diagnostic.severity).to_string(),
+            message: diagnostic.message,
+            span: diagnostic.span.map(BerkeleyAppHostSpanWire::from),
+        }
+    }
+}
+
+impl From<SourceSpan> for BerkeleyAppHostSpanWire {
+    fn from(span: SourceSpan) -> Self {
+        Self {
+            start_line: span.start_line,
+            start_column: span.start_column,
+            end_line: span.end_line,
+            end_column: span.end_column,
+        }
+    }
+}
+
+fn host_panel_kind_wire(kind: BerkeleyAppHostPanelKind) -> &'static str {
+    match kind {
+        BerkeleyAppHostPanelKind::Source => "source",
+        BerkeleyAppHostPanelKind::Diagnostics => "diagnostics",
+        BerkeleyAppHostPanelKind::Analysis => "analysis",
+        BerkeleyAppHostPanelKind::Table => "table",
+        BerkeleyAppHostPanelKind::Waveform => "waveform",
+    }
+}
+
+fn diagnostic_severity_wire(severity: BerkeleyDiagnosticSeverity) -> &'static str {
+    match severity {
+        BerkeleyDiagnosticSeverity::Error => "error",
+        BerkeleyDiagnosticSeverity::Warning => "warning",
+        BerkeleyDiagnosticSeverity::Note => "note",
+    }
+}
+
+fn host_surface_wire_json_value(wire: &BerkeleyAppHostSurfaceWire) -> serde_json::Value {
+    serde_json::json!({
+        "schemaVersion": wire.schema_version,
+        "canonicalSource": &wire.canonical_source,
+        "sourceFingerprint": &wire.source_fingerprint,
+        "title": &wire.title,
+        "parsed": wire.parsed,
+        "executionAvailable": wire.execution_available,
+        "requestedSelectedSyntaxCardIndex": wire.requested_selected_syntax_card_index,
+        "requestedActiveCommandId": &wire.requested_active_command_id,
+        "resolvedSelectedSyntaxCardIndex": wire.resolved_selected_syntax_card_index,
+        "resolvedActiveCommandId": &wire.resolved_active_command_id,
+        "selectionStale": wire.selection_stale,
+        "commandStale": wire.command_stale,
+        "panelCount": wire.panel_count,
+        "activePanelId": &wire.active_panel_id,
+        "panels": wire
+            .panels
+            .iter()
+            .map(host_panel_wire_json_value)
+            .collect::<Vec<_>>(),
+        "blockingMessage": &wire.blocking_message,
+        "diagnostics": wire
+            .diagnostics
+            .iter()
+            .map(host_diagnostic_wire_json_value)
+            .collect::<Vec<_>>(),
+    })
+}
+
+fn host_panel_wire_json_value(panel: &BerkeleyAppHostPanelWire) -> serde_json::Value {
+    serde_json::json!({
+        "id": &panel.id,
+        "kind": &panel.kind,
+        "title": &panel.title,
+        "target": &panel.target,
+        "enabled": panel.enabled,
+        "active": panel.active,
+        "disabledReason": &panel.disabled_reason,
+    })
+}
+
+fn host_diagnostic_wire_json_value(
+    diagnostic: &BerkeleyAppHostDiagnosticWire,
+) -> serde_json::Value {
+    serde_json::json!({
+        "code": &diagnostic.code,
+        "severity": &diagnostic.severity,
+        "message": &diagnostic.message,
+        "span": diagnostic
+            .span
+            .as_ref()
+            .map(host_span_wire_json_value),
+    })
+}
+
+fn host_span_wire_json_value(span: &BerkeleyAppHostSpanWire) -> serde_json::Value {
+    serde_json::json!({
+        "startLine": span.start_line,
+        "startColumn": span.start_column,
+        "endLine": span.end_line,
+        "endColumn": span.end_column,
+    })
 }
 
 fn editor_command_from_control(

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -2431,6 +2431,62 @@ C1 out 0 1p
 }
 
 #[test]
+fn berkeley_app_facade_exports_host_surface_wire_json_after_execution() {
+    let app = parse_berkeley_app_deck(
+        r#"
+* transient host surface
+V1 in 0 PULSE(0 1 0 1n 1n 1n 4n)
+R1 in out 1k
+C1 out 0 1p
+.tran 1n 3n
+.print tran V(out)
+.end
+"#,
+    );
+
+    let requested_state = BerkeleyAppPersistedEditorState {
+        selected_syntax_card_index: Some(3),
+        active_command_id: Some("analysis.3.inspect-waveform".to_string()),
+    };
+    let wire = app.run_host_surface_wire(requested_state.clone()).unwrap();
+
+    assert_eq!(wire.schema_version, 1);
+    assert!(wire.parsed);
+    assert!(wire.execution_available);
+    assert_eq!(wire.requested_selected_syntax_card_index, Some(3));
+    assert_eq!(
+        wire.requested_active_command_id.as_deref(),
+        Some("analysis.3.inspect-waveform")
+    );
+    assert_eq!(wire.resolved_selected_syntax_card_index, Some(3));
+    assert_eq!(
+        wire.resolved_active_command_id.as_deref(),
+        Some("analysis.3.inspect-waveform")
+    );
+    assert!(!wire.selection_stale);
+    assert!(!wire.command_stale);
+    assert_eq!(wire.panel_count, 5);
+    assert_eq!(wire.active_panel_id.as_deref(), Some("waveform"));
+    assert_eq!(
+        wire.panels
+            .iter()
+            .map(|panel| panel.kind.as_str())
+            .collect::<Vec<_>>(),
+        vec!["source", "diagnostics", "analysis", "table", "waveform"]
+    );
+
+    let payload: serde_json::Value =
+        serde_json::from_str(&app.run_host_surface_wire_json(requested_state).unwrap()).unwrap();
+    assert_eq!(payload["schemaVersion"], 1);
+    assert_eq!(payload["activePanelId"], "waveform");
+    assert_eq!(payload["panels"][4]["kind"], "waveform");
+    assert_eq!(payload["panels"][4]["target"], "analysis-waveform");
+    assert_eq!(payload["panels"][4]["enabled"], true);
+    assert_eq!(payload["panels"][4]["active"], true);
+    assert!(payload["diagnostics"].as_array().unwrap().is_empty());
+}
+
+#[test]
 fn berkeley_app_facade_host_surface_routes_blocked_decks_to_diagnostics() {
     let app = parse_berkeley_app_deck(
         r#"
@@ -2471,6 +2527,49 @@ R1 in out
     assert!(table
         .disabled_reason
         .as_deref()
+        .unwrap()
+        .contains("Berkeley SPICE app deck:"));
+}
+
+#[test]
+fn berkeley_app_facade_host_surface_wire_json_preserves_blocked_diagnostics() {
+    let app = parse_berkeley_app_deck(
+        r#"
+V1 in 0 DC 1
+R1 in out
+.op
+.end
+"#,
+    );
+
+    let requested_state = BerkeleyAppPersistedEditorState {
+        selected_syntax_card_index: Some(2),
+        active_command_id: Some("analysis.2.run".to_string()),
+    };
+    let wire = app.host_surface_wire(requested_state.clone());
+
+    assert!(!wire.parsed);
+    assert!(!wire.execution_available);
+    assert_eq!(wire.active_panel_id.as_deref(), Some("diagnostics"));
+    assert_eq!(
+        wire.resolved_active_command_id.as_deref(),
+        Some("analysis.2.run")
+    );
+    assert_eq!(wire.diagnostics[0].severity, "error");
+    assert_eq!(wire.diagnostics[0].span.as_ref().unwrap().start_line, 3);
+    assert!(wire
+        .blocking_message
+        .as_deref()
+        .unwrap()
+        .contains("Berkeley SPICE app deck:"));
+
+    let payload: serde_json::Value =
+        serde_json::from_str(&app.host_surface_wire_json(requested_state)).unwrap();
+    assert_eq!(payload["activePanelId"], "diagnostics");
+    assert_eq!(payload["diagnostics"][0]["severity"], "error");
+    assert_eq!(payload["diagnostics"][0]["span"]["startLine"], 3);
+    assert!(payload["panels"][3]["disabledReason"]
+        .as_str()
         .unwrap()
         .contains("Berkeley SPICE app deck:"));
 }

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,15 +33,15 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Rust Berkeley Mosaic host surface.
+1. Rust Berkeley Mosaic host wire export.
    - Status: current PR completion candidate.
    - Expand the Rust `spice-netlist-parser` Berkeley app facade from
-     persisted editor-state snapshots into host-facing panel descriptors for
-     Mosaic shell integration.
-   - Expose stable source, diagnostics, analysis, table, and waveform panels
-     with panel IDs, kind tags, target names, enabled states, active state, and
-     disabled reasons so hosts can wire UI regions without duplicating parser or
-     simulator internals.
+     host-facing panel descriptors into schema-versioned wire snapshots for
+     Mosaic packaging and WebAssembly embedding.
+   - Expose stable JSON helpers with lower-case panel kinds, diagnostic
+     severities, active-panel IDs, repaired persisted editor-state metadata, and
+     the same source / diagnostics / analysis / table / waveform panel contract
+     so product shells can consume the surface without Rust struct coupling.
    - Keep this as a Rust-only app-substrate acceleration slice over the public
      parser contract and existing engine deck artifacts; Python and TypeScript
      parser parity was completed separately and should remain aligned when
@@ -1501,6 +1501,16 @@ the Rust, Python, and TypeScript surfaces together.
      stale-state repair flags for source edits.
    - The slice keeps persisted UI state derived from command descriptors and
      app session state so hosts can restore selection without duplicating parser
+     or simulator internals.
+
+142. Rust Berkeley Mosaic host surface.
+   - Status: completed in PR 6961.
+   - Rust `spice-netlist-parser` Berkeley app-deck host surfaces now expose
+     stable source, diagnostics, analysis, table, and waveform panel
+     descriptors with panel IDs, kind tags, target names, enabled states, active
+     state, and disabled reasons.
+   - The slice keeps panel routing derived from persisted editor-state
+     snapshots so Mosaic shells can wire UI regions without duplicating parser
      or simulator internals.
 
 ## Backlog


### PR DESCRIPTION
## Summary
- add schema-versioned Berkeley app host-surface wire snapshots for Mosaic packaging and WASM/product-shell embedding
- expose `host_surface_wire()`, `run_host_surface_wire()`, and JSON helpers with lower-case panel/diagnostic kinds, active panel IDs, and persisted-state repair metadata
- update parser docs/changelog and advance the SPICE plan after PR #6961 merged

## Validation
- `cargo fmt -p spice-netlist-parser`
- `cargo test -p spice-netlist-parser -- --nocapture`
- `cargo test -p grammar-tools --test spice_grammar_validation -- --nocapture`
- `git diff --check`