### PR TITLE
feat(asciimath): PR-3c part 2 — text(…) keyword form

### DIFF
--- a/code/packages/rust/asciimath/CHANGELOG.md
+++ b/code/packages/rust/asciimath/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to the AsciiMath pluggable frontend.
 
+## [0.7.0] — 2026-06-29
+
+### Added — ASM01 PR-3c (part 2): the `text(…)` keyword form
+
+- The tokenizer now recognizes **`text(…)`** — the parenthesised twin of the `"…"` literal — and
+  emits the *same* `TokenKind::Text` the quote form does. So `text(kg)` and `"kg"` lower to an
+  **identical** `MathExpr::Text("kg")`, and `5 text(kg)` == `5 "kg"`. **Zero ripple beyond the lexer**:
+  no new `TokenKind`, no parser change, no `Capabilities`/conformance change (the `text` capability
+  was already declared in PR-1).
+- Behaviour: the open paren must *immediately* follow `text` (no space). Inner parens **nest**, so
+  `text(f(x))` keeps its inner parens; an unterminated `text(` is a clean spanned error, never a panic.
+  `text` not immediately followed by `(` stays an ordinary identifier (a variable named `text`, or
+  `text (x)` with a space, is unchanged), and a longer word like `textual` is untouched. Byte-scanning
+  for the matching paren is UTF-8-safe (`(`/`)` never occur inside a multi-byte sequence), so non-ASCII
+  content slices without panicking.
+- Tests: tokenizer `text_keyword_form` (quote-equivalence, empty, nested parens, raw spaces/operators),
+  `text_without_immediate_paren_is_an_identifier`, `unterminated_text_keyword_is_an_error`; parser
+  `text_keyword_form_equals_quote_literal`. Conformance corpus gains `text(kg)`. 35 unit + doc tests
+  pass; clippy `-D warnings` clean.
+- Still **PR-3c remainder** (each its own follow-up): **longest-match** identifier scan (`sinx` →
+  `sin·x`, a deeper lexer change) and `stackrel`/`overset`/`underset` (need a neutral-AST node in
+  `math-frontend` — no `Overset`/`Underset` in `MathExpr` yet).
+
 ## [0.6.0] — 2026-06-29
 
 ### Added — ASM01 PR-3c (part 1): punctuation arrows `->` and `=>`

--- a/code/packages/rust/asciimath/Cargo.toml
+++ b/code/packages/rust/asciimath/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "asciimath"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 description = "An AsciiMath parser that implements the math-frontend MathFrontend trait: turns AsciiMath (1/2, sqrt(x), x^2+y^2=r^2) into the neutral MathExpr AST. The second pluggable frontend after LaTeX (see ASM01/PFE01). Total, panic-free, spanned errors."
 license = "MIT"

--- a/code/packages/rust/asciimath/README.md
+++ b/code/packages/rust/asciimath/README.md
@@ -91,10 +91,14 @@ juxtaposition `i · ∈ · S`.)
 
 **PR-3c (part 1)** adds the punctuation arrows `->` → `Symbol("rightarrow")` and `=>` →
 `Symbol("implies")` — recognized in the tokenizer and routed through the PR-3a symbol table (so they
-agree with the word forms `rarr`/`implies`); `a - b` and `a = b` are unaffected. **Still to come**
-(each structural, its own PR): longest-match identifier scan (`sinx` → `sin·x`),
-`stackrel`/`overset`/`underset` (need a neutral-AST node), and the `text(…)` keyword form (needs lexer
-raw-capture).
+agree with the word forms `rarr`/`implies`); `a - b` and `a = b` are unaffected.
+
+**PR-3c (part 2)** adds the **`text(…)` keyword form** — the parenthesised twin of the `"…"` literal.
+The tokenizer captures the raw bytes up to the matching close paren (parens nest) and emits the same
+`Text` token, so `text(kg)` and `"kg"` lower to an *identical* `MathExpr::Text` (no parser/capability
+change). The open paren must immediately follow `text`; otherwise `text` is an ordinary identifier.
+**Still to come** (each structural, its own PR): longest-match identifier scan (`sinx` → `sin·x`) and
+`stackrel`/`overset`/`underset` (need a neutral-AST node).
 
 It is **total and panic-free**: every input returns `Ok(MathExpr)` or a spanned
 `FrontendError`. Recursion is depth-guarded (matrix nesting included); left-associative chains are

--- a/code/packages/rust/asciimath/src/lib.rs
+++ b/code/packages/rust/asciimath/src/lib.rs
@@ -243,6 +243,15 @@ mod tests {
     }
 
     #[test]
+    fn text_keyword_form_equals_quote_literal() {
+        // PR-3c: `text(…)` is the parenthesised twin of `"…"` — they lower identically.
+        assert_eq!(p("text(kg)"), MathExpr::Text("kg".to_string()));
+        assert_eq!(p("text(kg)"), p(r#""kg""#));
+        // Used in context: `5 text(kg)` is `5 · "kg"`, same as `5 "kg"`.
+        assert_eq!(p("5 text(kg)"), p(r#"5 "kg""#));
+    }
+
+    #[test]
     fn a_realistic_expression() {
         // x^2 + y^2 = r^2
         let lhs = b(BinOp::Add, b(BinOp::Pow, sym("x"), num(2)), b(BinOp::Pow, sym("y"), num(2)));
@@ -434,6 +443,7 @@ mod tests {
                 "a cup b",         // set operator as a symbol
                 "a -> b",          // punctuation arrow (PR-3c)
                 "x => y",          // punctuation double-arrow
+                "text(kg)",        // text(…) keyword form (PR-3c) — twin of "kg"
                 "1 +",   // error: trailing operator (span in range, not a panic)
                 "(x",    // error: missing close
                 "",      // error: empty

--- a/code/packages/rust/asciimath/src/token.rs
+++ b/code/packages/rust/asciimath/src/token.rs
@@ -198,7 +198,41 @@ pub fn tokenize(src: &str) -> Result<Vec<Token>, FrontendError> {
                 while j < bytes.len() && bytes[j].is_ascii_alphabetic() {
                     j += 1;
                 }
-                (TokenKind::Ident(src[start..j].to_string()), j)
+                // PR-3c: the `text(…)` keyword form — the parenthesised twin of the `"…"`
+                // literal. When the run is exactly `text` and an open paren *immediately*
+                // follows, capture the raw bytes up to the matching close paren and emit the
+                // same [`TokenKind::Text`] the `"…"` form does, so both spellings lower to an
+                // identical `MathExpr::Text` (no parser or capability change). Parens nest, so
+                // `text(f(x))` keeps its inner parens; a missing close paren is a clean error.
+                // `text` NOT immediately followed by `(` stays an ordinary identifier (so a
+                // variable named `text`, or `text` with a space before a group, is unchanged).
+                if &src[start..j] == "text" && bytes.get(j) == Some(&b'(') {
+                    let content_start = j + 1;
+                    let mut depth = 1usize;
+                    let mut k = content_start;
+                    while k < bytes.len() {
+                        match bytes[k] {
+                            b'(' => depth += 1,
+                            b')' => {
+                                depth -= 1;
+                                if depth == 0 {
+                                    break;
+                                }
+                            }
+                            _ => {}
+                        }
+                        k += 1;
+                    }
+                    if depth != 0 {
+                        return Err(err("unterminated text(...)", (start, bytes.len())));
+                    }
+                    // `(` and `)` are one-byte ASCII and never occur inside a multi-byte
+                    // UTF-8 sequence, so `content_start` and `k` are char boundaries — the
+                    // slice is panic-free even when the content is non-ASCII.
+                    (TokenKind::Text(src[content_start..k].to_string()), k + 1)
+                } else {
+                    (TokenKind::Ident(src[start..j].to_string()), j)
+                }
             }
             _ => {
                 // Unknown byte (includes any non-ASCII lead byte). Report a one-byte span;
@@ -264,6 +298,44 @@ mod tests {
     #[test]
     fn text_literal() {
         assert_eq!(kinds(r#""kg" "#)[0], TokenKind::Text("kg".into()));
+    }
+
+    #[test]
+    fn text_keyword_form() {
+        // PR-3c: `text(…)` is the parenthesised twin of `"…"` — same Text token.
+        assert_eq!(kinds("text(kg)")[0], TokenKind::Text("kg".into()));
+        assert_eq!(kinds(r#""kg""#)[0], kinds("text(kg)")[0]);
+        // Empty content is fine.
+        assert_eq!(kinds("text()")[0], TokenKind::Text("".into()));
+        // Inner parens nest and are preserved verbatim.
+        assert_eq!(kinds("text(f(x))")[0], TokenKind::Text("f(x)".into()));
+        // Spaces and arbitrary punctuation inside are raw.
+        assert_eq!(kinds("text(a + b)")[0], TokenKind::Text("a + b".into()));
+        // The closing paren is consumed (the token after is Eof here).
+        assert_eq!(kinds("text(kg)"), vec![TokenKind::Text("kg".into()), TokenKind::Eof]);
+    }
+
+    #[test]
+    fn text_without_immediate_paren_is_an_identifier() {
+        // No paren → ordinary identifier run (parser makes it a product of letters).
+        assert_eq!(kinds("text")[0], TokenKind::Ident("text".into()));
+        // A space before `(` means `text` is an identifier and `(` opens a group.
+        assert_eq!(kinds("text (x)"), vec![
+            TokenKind::Ident("text".into()),
+            TokenKind::LParen,
+            TokenKind::Ident("x".into()),
+            TokenKind::RParen,
+            TokenKind::Eof,
+        ]);
+        // A longer word starting with `text` is untouched.
+        assert_eq!(kinds("textual")[0], TokenKind::Ident("textual".into()));
+    }
+
+    #[test]
+    fn unterminated_text_keyword_is_an_error() {
+        let e = tokenize("text(oops").unwrap_err();
+        assert_eq!(e.frontend, "asciimath");
+        assert!(e.span.0 <= e.span.1);
     }
 
     #[test]

--- a/code/specs/ASM01-asciimath-frontend.md
+++ b/code/specs/ASM01-asciimath-frontend.md
@@ -108,10 +108,16 @@ shapes for representative inputs.
   and emitted as the existing `rightarrow`/`implies` identifiers, so they route through the PR-3a
   symbol table and lower to `Symbol` (agreeing with the word forms). Tokenizer-only, zero ripple; the
   single-char `-`/`=` are unaffected (`a - b` = `Bin(Sub)`, `a = b` = `Rel(Eq)`).
+- **PR-3c part 2 (shipped, v0.7.0):** the **`text(…)` keyword form** alongside the `"…"` literal.
+  The tokenizer captures the raw bytes up to the matching close paren (parens nest) and emits the same
+  `TokenKind::Text`, so `text(kg)` and `"kg"` lower to an *identical* `MathExpr::Text` — tokenizer-only,
+  no parser/`Capabilities`/conformance change (the `text` capability shipped in PR-1). The open paren
+  must immediately follow `text`; otherwise `text` stays an ordinary identifier (a variable named
+  `text`, `text (x)` with a space, or `textual` are all unchanged). An unterminated `text(` is a clean
+  spanned error; byte-scanning for the matching paren is UTF-8-safe.
 - **PR-3c remainder** (each its own follow-up, structural): **longest-match tokenization** (so `sinx`
-  splits as `sin`·`x`, a deeper lexer change); `stackrel`, `overset`/`underset` (need a neutral-AST
-  node in `math-frontend` — there is no `Overset`/`Underset` in `MathExpr` yet); and the `text(…)`
-  keyword form alongside the `"…"` literal (needs lexer raw-capture between the parens).
+  splits as `sin`·`x`, a deeper lexer change); and `stackrel`, `overset`/`underset` (need a neutral-AST
+  node in `math-frontend` — there is no `Overset`/`Underset` in `MathExpr` yet).
 
 ## 6. Non-goals
 Evaluation, simplification, rendering — none are a frontend's job (PFE01 §7). Lowering


### PR DESCRIPTION
## What

Adds the AsciiMath **`text(…)` keyword form** — the parenthesised twin of the `"…"` literal — completing another item of the ASM01 PR-3c remainder.

## How

Tokenizer-only. When an identifier run is exactly `text` and an open paren *immediately* follows, the scanner captures the raw bytes up to the matching (nesting-aware) close paren and emits the **same** `TokenKind::Text` the `"…"` form does. So:

```
text(kg)   ≡   "kg"        →  MathExpr::Text("kg")
5 text(kg) ≡   5 "kg"      →  Bin(Mul, 5, Text("kg"))
text(f(x))                  →  Text("f(x)")   (inner parens nest, preserved)
```

**Zero ripple beyond the lexer**: no new `TokenKind`, no parser change, no `Capabilities`/conformance change (the `text` capability shipped in PR-1).

## Behaviour & safety

- The open paren must immediately follow `text` (no space). `text` not immediately followed by `(` stays an ordinary identifier — a variable named `text`, `text (x)` with a space, or `textual` are all unchanged.
- Inner parens nest; an unterminated `text(` is a clean spanned `FrontendError`, never a panic.
- Byte-scanning for the matching paren is UTF-8-safe (`(`/`)` never occur inside a multi-byte sequence), so non-ASCII content slices without panicking. `depth` cannot underflow (loop breaks the instant it reaches 0).

## Gates

- 35 unit + doc tests pass (tokenizer `text_keyword_form`, `text_without_immediate_paren_is_an_identifier`, `unterminated_text_keyword_is_an_error`; parser `text_keyword_form_equals_quote_literal`; conformance corpus gains `text(kg)`).
- `cargo clippy -p asciimath -- -D warnings` clean.
- `/security-review` **PASSED** (reviewed loop bounds, depth underflow, char-boundary slicing, unterminated path, end-offset — all safe).
- asciimath **0.7.0**. Spec `ASM01` §PR-3c part 2.

**PR-3c remainder** (each its own follow-up): longest-match identifier scan (`sinx` → `sin·x`) and `stackrel`/`overset`/`underset` (need a neutral-AST node in `math-frontend`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)