### PR TITLE
fix(closure-emitter): preserve sign of negative zero (-0) — miscompile

### DIFF
--- a/code/packages/rust/closure-emitter/CHANGELOG.md
+++ b/code/packages/rust/closure-emitter/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to the `coding-adventures-closure-emitter` crate will be documented in this file.
 
+## [0.18.1] - 2026-06-29
+
+### Fixed — negative zero (`-0`) lost its sign on emit (miscompile)
+
+`format_js_number` short-circuited every value equal to `0.0` to the string
+`"0"`. Because Rust's `-0.0 == 0.0` is `true`, negative zero took that path and
+emitted `0` — but `-0` is observably distinct from `0` in JavaScript
+(`1 / -0 === -Infinity` vs `1 / 0 === Infinity`; `Object.is(-0, 0) === false`),
+so dropping the sign is a **miscompile**. It surfaced through the constant-fold
+pass: `f(-0)`, `f(-(5-5))`, and `f(0 * -1)` all fold the argument to the
+negative-zero numeric literal `-0.0`, which the emitter then printed as `0`.
+
+The zero fast path now checks `is_sign_negative()` and emits `-0` for negative
+zero, `0` otherwise. `-0` is also the minimal correct representation. Positive
+zero and every other value are byte-identical to before — the blast radius is
+exactly negative zero. End-to-end: `f(-0);` → `f(-0);` (was `f(0);`), and
+`g(1/-0);` → `g(-Infinity);`.
+
 ## [0.18.0] - 2026-06-21
 
 ### Fixed — prefix-unary precedence and `--`/`++` token fusion

--- a/code/packages/rust/closure-emitter/Cargo.toml
+++ b/code/packages/rust/closure-emitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-emitter"
-version = "0.18.0"
+version = "0.18.1"
 edition = "2021"
 description = "JavaScript code emitter for the Closure Compiler clone. Per CLOC07's emit contract. Takes a finalized Program + sidecar and produces output JavaScript text + companion source map. Runs after every pass in the pipeline."
 

--- a/code/packages/rust/closure-emitter/src/lib.rs
+++ b/code/packages/rust/closure-emitter/src/lib.rs
@@ -1186,7 +1186,16 @@ fn format_js_number(n: f64) -> String {
         };
     }
     if n == 0.0 {
-        return "0".to_string();
+        // Negative zero must keep its sign: `-0` is observably distinct from
+        // `0` in JS (`1 / -0 === -Infinity`, `Object.is(-0, 0) === false`), so
+        // dropping the sign is a miscompile. Rust's `-0.0 == 0.0` is `true`, so
+        // we cannot rely on the equality alone — `is_sign_negative()` is what
+        // distinguishes the two zeros. `-0` is also the minimal correct form.
+        return if n.is_sign_negative() {
+            "-0".to_string()
+        } else {
+            "0".to_string()
+        };
     }
     let decimal = if n.fract() == 0.0 && n.abs() < 1e21 {
         format!("{}", n as i64)
@@ -1701,6 +1710,21 @@ mod tests {
         assert_eq!(emit_number_value(42.0), "42");
         assert_eq!(emit_number_value(100.0), "100"); // tie 3=3 → decimal
         assert_eq!(emit_number_value(-7.0), "-7");
+    }
+
+    #[test]
+    fn negative_zero_keeps_its_sign() {
+        // `-0` is observably distinct from `0` in JS (`1 / -0 === -Infinity`,
+        // `Object.is(-0, 0) === false`), so the emitter must NOT drop the sign.
+        // Rust's `-0.0 == 0.0` is `true`, which previously routed negative zero
+        // through the `== 0.0` fast path and printed `"0"` — a miscompile.
+        assert_eq!(format_js_number(-0.0), "-0");
+        assert_eq!(format_js_number(0.0), "0");
+        // Through the full emit path (synthetic NumericLiteral → emitted JS):
+        assert_eq!(emit_number_value(-0.0), "-0");
+        assert_eq!(emit_number_value(0.0), "0");
+        // `0.0 * -1.0` is negative zero in IEEE-754 / JS — also preserved.
+        assert_eq!(emit_number_value(0.0 * -1.0), "-0");
     }
 
     #[test]

--- a/code/programs/rust/closurec/tests/conformance.rs
+++ b/code/programs/rust/closurec/tests/conformance.rs
@@ -48,6 +48,11 @@ const CORPUS: &[(&str, &str)] = &[
     ("3", "n:3"),
     ("1.5", "n:1.5"),
     ("-1", "n:-1"),
+    // Negative zero: promoted from KNOWN_DIVERGENCES once the emitter stopped
+    // flattening `-0` to `0` (closure-emitter 0.18.1). `-0` is observably
+    // distinct from `0` (`1/-0 === -Infinity`, `Object.is(-0,0) === false`), so
+    // the fold must preserve the sign — closurec now value-matches the oracle.
+    ("-0", "n:-0"),
     // ---- string methods ----
     (r#""abcd".slice(1,3)"#, "s:bc"),
     (r#""ab".repeat(3)"#, "s:ababab"),
@@ -80,9 +85,10 @@ const CORPUS: &[(&str, &str)] = &[
 /// `(source, true value, value closurec WRONGLY produces today)`.
 /// The test asserts the bug is still present; when fixed, promote to `CORPUS`.
 const KNOWN_DIVERGENCES: &[(&str, &str, &str)] = &[
-    // Pre-existing unary-minus fold flattens the `-0` literal to `0` (`var x=-0`
-    // emits `var x=0`). Tracked as its own fix task, independent of any fold.
-    ("-0", "n:-0", "n:0"),
+    // (empty) — the lone entry, the unary-minus `-0` → `0` flattening, was
+    // FIXED in closure-emitter 0.18.1 (the emitter no longer drops the sign of
+    // negative zero) and PROMOTED into CORPUS above. New divergences found by
+    // the harness or by hand land here until their fix; then they too promote.
 ];
 
 /// Optimize one source *expression* at SIMPLE and return the emitted output with
@@ -420,6 +426,7 @@ fn canonicalizer_self_test() {
     assert_eq!(canonicalize("-1").as_deref(), Some("n:-1"));
     assert_eq!(canonicalize("1.5").as_deref(), Some("n:1.5"));
     assert_eq!(canonicalize("0").as_deref(), Some("n:0"));
+    assert_eq!(canonicalize("-0").as_deref(), Some("n:-0"));
     assert_eq!(canonicalize(r#""bc""#).as_deref(), Some("s:bc"));
     assert_eq!(canonicalize("true").as_deref(), Some("b:true"));
     assert_eq!(canonicalize("false").as_deref(), Some("b:false"));


### PR DESCRIPTION
## The bug (a miscompile)

`format_js_number` short-circuited **every** value equal to `0.0` to the string `"0"`:

```rust
if n == 0.0 { return "0".to_string(); }
```

Because Rust's `-0.0 == 0.0` is `true`, **negative zero took that path and emitted `0`** — but `-0` is observably distinct from `0` in JavaScript:

- `1 / -0 === -Infinity` vs `1 / 0 === Infinity`
- `Object.is(-0, 0) === false`

So dropping the sign is a **miscompile**. It surfaces through the constant-fold pass — `f(-0)`, `f(-(5-5))`, and `f(0 * -1)` all fold the argument to the negative-zero numeric literal `-0.0`, which the emitter then printed as `0`.

## The fix

The zero fast path now checks `is_sign_negative()` and emits `-0` for negative zero, `0` otherwise (`-0` is also the minimal correct representation). Positive zero and every other value are **byte-identical** to before — the blast radius is exactly negative zero.

End-to-end at SIMPLE:

| input | before | after |
|---|---|---|
| `f(-0);` | `f(0);` ❌ | `f(-0);` ✅ |
| `f(-(5-5));` | `f(0);` ❌ | `f(-0);` ✅ |
| `f(0*-1);` | `f(0);` ❌ | `f(-0);` ✅ |
| `f(0);` | `f(0);` | `f(0);` (unchanged) |
| `g(1/-0);` | — | `g(-Infinity);` ✅ |

## Tests

- **closure-emitter** 0.18.0 → 0.18.1; new unit test `negative_zero_keeps_its_sign` (direct `format_js_number` + full emit path + `0.0 * -1.0`). **113/113 pass.**
- **closurec conformance harness** (the differential soundness catalog from the cross-oracle work): `("-0", "n:-0")` is **promoted from `KNOWN_DIVERGENCES` into `CORPUS`** — the divergence is resolved, so the harness now value-checks it against the Node/V8 oracle; `canonicalize("-0") == "n:-0"` locked. **closurec 878/878 pass.**

Security review: PASSED (pure numeric string formatting; no I/O/unsafe/new input).

🤖 Generated with [Claude Code](https://claude.com/claude-code)