### PR TITLE
[codex] Add Berkeley SPICE app package manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added — SPICE Berkeley Mosaic App Package Manifest
+- `spice-netlist-parser` now exposes a schema-versioned Berkeley Mosaic app
+  package manifest plus JSON helper for WebAssembly and product-shell
+  packaging. The manifest advertises the Berkeley grammar version,
+  host-surface wire schema, source-fingerprint algorithm, panel kinds, editor
+  action kinds, command targets, runnable analysis directives, and artifact
+  capabilities before a host opens a deck.
+- The manifest keeps packaging metadata derived from the same Rust app facade
+  contract as host surfaces and host-wire exports, avoiding a separate product
+  registry while the public parser contract remains language-aligned.
+
 ### Added — SPICE Berkeley Mosaic Host Wire Export
 - `spice-netlist-parser` now exposes schema-versioned Berkeley app host-surface
   wire snapshots for Mosaic packaging and WebAssembly embedding.

--- a/code/packages/rust/spice-netlist-parser/README.md
+++ b/code/packages/rust/spice-netlist-parser/README.md
@@ -27,7 +27,8 @@ same facade directly:
 
 ```rust
 use spice_netlist_parser::{
-    parse_berkeley_app_deck, BerkeleyAppPersistedEditorState, BerkeleyCardKind,
+    berkeley_app_package_manifest_json, parse_berkeley_app_deck,
+    BerkeleyAppPersistedEditorState, BerkeleyCardKind,
 };
 
 let deck = parse_berkeley_app_deck(r#"
@@ -75,6 +76,9 @@ let host_wire_json = deck.run_host_surface_wire_json(BerkeleyAppPersistedEditorS
     active_command_id: Some("analysis.3.inspect-waveform".to_string()),
 })?;
 assert!(host_wire_json.contains(r#""activePanelId":"waveform""#));
+
+let package_manifest_json = berkeley_app_package_manifest_json();
+assert!(package_manifest_json.contains(r#""packageName":"berkeley-spice-mosaic-app""#));
 ```
 
 The facade preserves normalized logical cards, source spans, token names
@@ -97,7 +101,10 @@ and waveform panel descriptors with explicit targets, enabled states, active
 state, and disabled reasons for Mosaic shell integration. Host-surface wire
 exports flatten the same contract into schema-versioned JSON with repaired
 selection metadata and lower-case panel / diagnostic kinds for WebAssembly and
-product-shell embedding. It is the
+product-shell embedding. The static package manifest advertises the Berkeley
+grammar version, host-surface wire schema, panel kinds, command targets,
+runnable analysis directives, and artifact capabilities so Mosaic and
+WebAssembly hosts can negotiate the app package before opening a deck. It is the
 Rust app/runtime entrypoint for Mosaic-backed UI work while the grammar-backed
 parser generator and Python/TypeScript parity surfaces continue to mature.
 

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -15,19 +15,21 @@ use spice_engine::{
 mod syntax;
 
 pub use syntax::{
-    parse_berkeley_app_deck, parse_berkeley_syntax, BerkeleyAnalysisInventoryEntry,
-    BerkeleyAppAnalysisArtifact, BerkeleyAppAnalysisControl, BerkeleyAppDeck,
-    BerkeleyAppEditorAction, BerkeleyAppEditorActionKind, BerkeleyAppEditorCommand,
-    BerkeleyAppEditorCommandPlan, BerkeleyAppEditorControls, BerkeleyAppEditorStateSnapshot,
-    BerkeleyAppExecution, BerkeleyAppHostDiagnosticWire, BerkeleyAppHostPanel,
-    BerkeleyAppHostPanelKind, BerkeleyAppHostPanelWire, BerkeleyAppHostSpanWire,
-    BerkeleyAppHostSurface, BerkeleyAppHostSurfaceWire, BerkeleyAppPersistedEditorState,
+    berkeley_app_package_manifest, berkeley_app_package_manifest_json, parse_berkeley_app_deck,
+    parse_berkeley_syntax, BerkeleyAnalysisInventoryEntry, BerkeleyAppAnalysisArtifact,
+    BerkeleyAppAnalysisControl, BerkeleyAppDeck, BerkeleyAppEditorAction,
+    BerkeleyAppEditorActionKind, BerkeleyAppEditorCommand, BerkeleyAppEditorCommandPlan,
+    BerkeleyAppEditorControls, BerkeleyAppEditorStateSnapshot, BerkeleyAppExecution,
+    BerkeleyAppHostDiagnosticWire, BerkeleyAppHostPanel, BerkeleyAppHostPanelKind,
+    BerkeleyAppHostPanelWire, BerkeleyAppHostSpanWire, BerkeleyAppHostSurface,
+    BerkeleyAppHostSurfaceWire, BerkeleyAppPackageManifest, BerkeleyAppPersistedEditorState,
     BerkeleyAppSessionAnalysis, BerkeleyAppSessionState, BerkeleyAppWaveformPoint,
     BerkeleyAppWaveformSeries, BerkeleyCardKind, BerkeleyDiagnosticSeverity,
     BerkeleyGrammarMetadata, BerkeleyLogicalCard, BerkeleySyntaxDeck, BerkeleySyntaxDiagnostic,
     BerkeleySyntaxToken, SourceSpan, BERKELEY_APP_HOST_SURFACE_WIRE_SCHEMA_VERSION,
-    BERKELEY_SPICE_GRAMMAR_NAME, BERKELEY_SPICE_GRAMMAR_VERSION, BERKELEY_SPICE_PARSER_GRAMMAR,
-    BERKELEY_SPICE_TOKEN_GRAMMAR,
+    BERKELEY_APP_PACKAGE_MANIFEST_SCHEMA_VERSION, BERKELEY_APP_PACKAGE_NAME,
+    BERKELEY_APP_SOURCE_FINGERPRINT_ALGORITHM, BERKELEY_SPICE_GRAMMAR_NAME,
+    BERKELEY_SPICE_GRAMMAR_VERSION, BERKELEY_SPICE_PARSER_GRAMMAR, BERKELEY_SPICE_TOKEN_GRAMMAR,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/code/packages/rust/spice-netlist-parser/src/syntax.rs
+++ b/code/packages/rust/spice-netlist-parser/src/syntax.rs
@@ -14,6 +14,44 @@ pub const BERKELEY_SPICE_TOKEN_GRAMMAR: &str =
 pub const BERKELEY_SPICE_PARSER_GRAMMAR: &str =
     include_str!("../../../../grammars/spice/berkeley.grammar");
 pub const BERKELEY_APP_HOST_SURFACE_WIRE_SCHEMA_VERSION: u32 = 1;
+pub const BERKELEY_APP_PACKAGE_MANIFEST_SCHEMA_VERSION: u32 = 1;
+pub const BERKELEY_APP_PACKAGE_NAME: &str = "berkeley-spice-mosaic-app";
+pub const BERKELEY_APP_SOURCE_FINGERPRINT_ALGORITHM: &str = "fnv1a-64";
+
+const BERKELEY_APP_HOST_PANEL_KINDS: &[&str] =
+    &["source", "diagnostics", "analysis", "table", "waveform"];
+const BERKELEY_APP_EDITOR_ACTION_KINDS: &[&str] = &[
+    "select-analysis",
+    "run-analysis",
+    "inspect-table",
+    "inspect-waveform",
+];
+const BERKELEY_APP_COMMAND_TARGETS: &[&str] = &[
+    "analysis-selection",
+    "analysis-runner",
+    "analysis-table",
+    "analysis-waveform",
+];
+const BERKELEY_APP_RUNNABLE_ANALYSIS_DIRECTIVES: &[&str] = &[".op", ".dc", ".ac", ".tran"];
+const BERKELEY_APP_ARTIFACT_ANALYSIS_DIRECTIVES: &[&str] =
+    &[".op", ".dc", ".ac", ".tran", ".tf", ".sens", ".noise"];
+const BERKELEY_APP_ARTIFACT_CAPABILITIES: &[&str] = &[
+    "canonical-source",
+    "analysis-inventory",
+    "source-fingerprint",
+    "session-state",
+    "editor-controls",
+    "editor-command-plan",
+    "persisted-editor-state",
+    "host-surface",
+    "host-surface-wire-json",
+    "result-tables",
+    "waveform-series",
+    "run-artifacts",
+    "output-plan-artifacts",
+    "rawfile-artifacts",
+    "wrdata-artifacts",
+];
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct SourceSpan {
@@ -132,6 +170,49 @@ impl BerkeleyGrammarMetadata {
             parser_grammar: BERKELEY_SPICE_PARSER_GRAMMAR,
         }
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BerkeleyAppPackageManifest {
+    pub schema_version: u32,
+    pub package_name: String,
+    pub grammar_name: String,
+    pub grammar_version: u32,
+    pub host_surface_wire_schema_version: u32,
+    pub source_fingerprint_algorithm: String,
+    pub host_panel_kinds: Vec<String>,
+    pub editor_action_kinds: Vec<String>,
+    pub command_targets: Vec<String>,
+    pub runnable_analysis_directives: Vec<String>,
+    pub artifact_analysis_directives: Vec<String>,
+    pub artifact_capabilities: Vec<String>,
+}
+
+impl BerkeleyAppPackageManifest {
+    pub fn to_json(&self) -> String {
+        app_package_manifest_json_value(self).to_string()
+    }
+}
+
+pub fn berkeley_app_package_manifest() -> BerkeleyAppPackageManifest {
+    BerkeleyAppPackageManifest {
+        schema_version: BERKELEY_APP_PACKAGE_MANIFEST_SCHEMA_VERSION,
+        package_name: BERKELEY_APP_PACKAGE_NAME.to_string(),
+        grammar_name: BERKELEY_SPICE_GRAMMAR_NAME.to_string(),
+        grammar_version: BERKELEY_SPICE_GRAMMAR_VERSION,
+        host_surface_wire_schema_version: BERKELEY_APP_HOST_SURFACE_WIRE_SCHEMA_VERSION,
+        source_fingerprint_algorithm: BERKELEY_APP_SOURCE_FINGERPRINT_ALGORITHM.to_string(),
+        host_panel_kinds: manifest_strings(BERKELEY_APP_HOST_PANEL_KINDS),
+        editor_action_kinds: manifest_strings(BERKELEY_APP_EDITOR_ACTION_KINDS),
+        command_targets: manifest_strings(BERKELEY_APP_COMMAND_TARGETS),
+        runnable_analysis_directives: manifest_strings(BERKELEY_APP_RUNNABLE_ANALYSIS_DIRECTIVES),
+        artifact_analysis_directives: manifest_strings(BERKELEY_APP_ARTIFACT_ANALYSIS_DIRECTIVES),
+        artifact_capabilities: manifest_strings(BERKELEY_APP_ARTIFACT_CAPABILITIES),
+    }
+}
+
+pub fn berkeley_app_package_manifest_json() -> String {
+    berkeley_app_package_manifest().to_json()
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1229,6 +1310,27 @@ fn host_span_wire_json_value(span: &BerkeleyAppHostSpanWire) -> serde_json::Valu
         "endLine": span.end_line,
         "endColumn": span.end_column,
     })
+}
+
+fn app_package_manifest_json_value(manifest: &BerkeleyAppPackageManifest) -> serde_json::Value {
+    serde_json::json!({
+        "schemaVersion": manifest.schema_version,
+        "packageName": &manifest.package_name,
+        "grammarName": &manifest.grammar_name,
+        "grammarVersion": manifest.grammar_version,
+        "hostSurfaceWireSchemaVersion": manifest.host_surface_wire_schema_version,
+        "sourceFingerprintAlgorithm": &manifest.source_fingerprint_algorithm,
+        "hostPanelKinds": &manifest.host_panel_kinds,
+        "editorActionKinds": &manifest.editor_action_kinds,
+        "commandTargets": &manifest.command_targets,
+        "runnableAnalysisDirectives": &manifest.runnable_analysis_directives,
+        "artifactAnalysisDirectives": &manifest.artifact_analysis_directives,
+        "artifactCapabilities": &manifest.artifact_capabilities,
+    })
+}
+
+fn manifest_strings(values: &[&str]) -> Vec<String> {
+    values.iter().map(|value| value.to_string()).collect()
 }
 
 fn editor_command_from_control(

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -3,15 +3,18 @@ use spice_engine::{
     BjtPolarity, Element, JfetPolarity, McDistribution, McOptions, MosfetType, TransientMethod,
 };
 use spice_netlist_parser::{
-    build_analysis_plan, parse_berkeley_app_deck, parse_berkeley_syntax, parse_netlist,
-    parse_value, run_netlist, AcAnalysis, Analysis, AnalysisKind, AnalysisResult,
-    BerkeleyAppEditorActionKind, BerkeleyAppHostPanelKind, BerkeleyAppPersistedEditorState,
-    BerkeleyCardKind, BerkeleyDiagnosticSeverity, BerkeleyGrammarMetadata, DcAnalysis,
-    DistortionAnalysis, FourAnalysis, McAnalysis, MeasureAnalysis, MeasureOperation,
-    NetlistParseError, NoiseAnalysis, OpAnalysis, OptionValue, OutputProbe, PlotAnalysis,
-    PoleZeroAnalysis, PoleZeroKind, PrintAnalysis, ProbeAnalysis, SaveAnalysis,
-    SelectedOutputValue, SensAnalysis, TempAnalysis, TfAnalysis, TranAnalysis,
-    BERKELEY_SPICE_GRAMMAR_NAME, BERKELEY_SPICE_GRAMMAR_VERSION,
+    berkeley_app_package_manifest, berkeley_app_package_manifest_json, build_analysis_plan,
+    parse_berkeley_app_deck, parse_berkeley_syntax, parse_netlist, parse_value, run_netlist,
+    AcAnalysis, Analysis, AnalysisKind, AnalysisResult, BerkeleyAppEditorActionKind,
+    BerkeleyAppHostPanelKind, BerkeleyAppPersistedEditorState, BerkeleyCardKind,
+    BerkeleyDiagnosticSeverity, BerkeleyGrammarMetadata, DcAnalysis, DistortionAnalysis,
+    FourAnalysis, McAnalysis, MeasureAnalysis, MeasureOperation, NetlistParseError, NoiseAnalysis,
+    OpAnalysis, OptionValue, OutputProbe, PlotAnalysis, PoleZeroAnalysis, PoleZeroKind,
+    PrintAnalysis, ProbeAnalysis, SaveAnalysis, SelectedOutputValue, SensAnalysis, TempAnalysis,
+    TfAnalysis, TranAnalysis, BERKELEY_APP_HOST_SURFACE_WIRE_SCHEMA_VERSION,
+    BERKELEY_APP_PACKAGE_MANIFEST_SCHEMA_VERSION, BERKELEY_APP_PACKAGE_NAME,
+    BERKELEY_APP_SOURCE_FINGERPRINT_ALGORITHM, BERKELEY_SPICE_GRAMMAR_NAME,
+    BERKELEY_SPICE_GRAMMAR_VERSION,
 };
 
 fn assert_close(actual: f64, expected: f64) {
@@ -2484,6 +2487,67 @@ C1 out 0 1p
     assert_eq!(payload["panels"][4]["enabled"], true);
     assert_eq!(payload["panels"][4]["active"], true);
     assert!(payload["diagnostics"].as_array().unwrap().is_empty());
+}
+
+#[test]
+fn berkeley_app_facade_exports_package_manifest_json() {
+    let manifest = berkeley_app_package_manifest();
+
+    assert_eq!(
+        manifest.schema_version,
+        BERKELEY_APP_PACKAGE_MANIFEST_SCHEMA_VERSION
+    );
+    assert_eq!(manifest.package_name, BERKELEY_APP_PACKAGE_NAME);
+    assert_eq!(manifest.grammar_name, BERKELEY_SPICE_GRAMMAR_NAME);
+    assert_eq!(manifest.grammar_version, BERKELEY_SPICE_GRAMMAR_VERSION);
+    assert_eq!(
+        manifest.host_surface_wire_schema_version,
+        BERKELEY_APP_HOST_SURFACE_WIRE_SCHEMA_VERSION
+    );
+    assert_eq!(
+        manifest.source_fingerprint_algorithm,
+        BERKELEY_APP_SOURCE_FINGERPRINT_ALGORITHM
+    );
+    assert_eq!(
+        manifest.host_panel_kinds,
+        vec!["source", "diagnostics", "analysis", "table", "waveform"]
+    );
+    assert_eq!(
+        manifest.command_targets,
+        vec![
+            "analysis-selection",
+            "analysis-runner",
+            "analysis-table",
+            "analysis-waveform"
+        ]
+    );
+    assert_eq!(
+        manifest.runnable_analysis_directives,
+        vec![".op", ".dc", ".ac", ".tran"]
+    );
+    assert!(manifest
+        .artifact_capabilities
+        .iter()
+        .any(|capability| capability == "host-surface-wire-json"));
+
+    let payload: serde_json::Value = serde_json::from_str(&berkeley_app_package_manifest_json())
+        .expect("manifest JSON should parse");
+    assert_eq!(payload["schemaVersion"], 1);
+    assert_eq!(payload["packageName"], "berkeley-spice-mosaic-app");
+    assert_eq!(payload["grammarName"], BERKELEY_SPICE_GRAMMAR_NAME);
+    assert_eq!(
+        payload["hostSurfaceWireSchemaVersion"],
+        BERKELEY_APP_HOST_SURFACE_WIRE_SCHEMA_VERSION
+    );
+    assert_eq!(payload["hostPanelKinds"][4], "waveform");
+    assert_eq!(payload["editorActionKinds"][1], "run-analysis");
+    assert_eq!(payload["commandTargets"][3], "analysis-waveform");
+    assert_eq!(payload["artifactAnalysisDirectives"][6], ".noise");
+    assert!(payload["artifactCapabilities"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|capability| capability == "source-fingerprint"));
 }
 
 #[test]

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,18 +33,16 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Rust Berkeley Mosaic host wire export.
+1. Rust Berkeley Mosaic app package manifest.
    - Status: current PR completion candidate.
-   - Expand the Rust `spice-netlist-parser` Berkeley app facade from
-     host-facing panel descriptors into schema-versioned wire snapshots for
-     Mosaic packaging and WebAssembly embedding.
-   - Expose stable JSON helpers with lower-case panel kinds, diagnostic
-     severities, active-panel IDs, repaired persisted editor-state metadata, and
-     the same source / diagnostics / analysis / table / waveform panel contract
-     so product shells can consume the surface without Rust struct coupling.
-   - Keep this as a Rust-only app-substrate acceleration slice over the public
-     parser contract and existing engine deck artifacts; Python and TypeScript
-     parser parity was completed separately and should remain aligned when
+   - Add a Rust `spice-netlist-parser` Berkeley app package manifest for Mosaic
+     packaging, WebAssembly embedding, and product-shell capability discovery.
+   - Expose schema-versioned native and JSON helpers that advertise the Berkeley
+     grammar version, host-surface wire schema, source-fingerprint algorithm,
+     panel kinds, editor action kinds, command targets, runnable analysis
+     directives, and artifact capabilities before a host opens a deck.
+   - Keep this as a Rust-only app-substrate packaging slice over the public
+     parser contract; Python and TypeScript parser parity remains aligned when
      parser behavior changes.
 
 ## Completed Slices
@@ -1512,6 +1510,16 @@ the Rust, Python, and TypeScript surfaces together.
    - The slice keeps panel routing derived from persisted editor-state
      snapshots so Mosaic shells can wire UI regions without duplicating parser
      or simulator internals.
+
+143. Rust Berkeley Mosaic host wire export.
+   - Status: completed in PR 6965.
+   - Rust `spice-netlist-parser` Berkeley app host-surface wire snapshots now
+     expose schema-versioned native and JSON surfaces for Mosaic packaging and
+     WebAssembly embedding.
+   - The wire export flattens panel descriptors, diagnostics, active-panel IDs,
+     repaired persisted editor-state metadata, and lower-case panel /
+     diagnostic kinds so product shells can consume the app surface without
+     Rust struct coupling.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- add a schema-versioned Berkeley Mosaic app package manifest for Rust product/WASM hosts
- expose native and JSON helpers advertising grammar and host-wire schema versions, source fingerprinting, panel/action kinds, command targets, runnable analyses, and artifact capabilities
- update parser docs/changelog and advance the SPICE plan after PR #6965 merged

## Validation
- `cargo fmt -p spice-netlist-parser`
- `cargo test -p spice-netlist-parser -- --nocapture`
- `cargo test -p grammar-tools --test spice_grammar_validation -- --nocapture`
- `git diff --check HEAD~1..HEAD`