### PR TITLE
feat(math-frontend): neutral Overset/Underset nodes (unblock stacked annotations)

### DIFF
--- a/code/packages/rust/math-frontend/CHANGELOG.md
+++ b/code/packages/rust/math-frontend/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to the pluggable parser-frontend framework.
 
+## [0.5.0] — 2026-06-29
+
+### Added — neutral `Overset` / `Underset` nodes (unblock stacked annotations on every frontend)
+
+Over/under-set annotations (`\overset{a}{b}`, `\stackrel{a}{R}`, `\underset{a}{b}`; AsciiMath
+`overset`/`underset`/`stackrel`) previously had **no faithful neutral representation** — a frontend
+had to drop them or misuse `Pow`/`Subscript`. This release adds the nodes so any frontend (LaTeX,
+AsciiMath, future MathML/Unicode-math) can lower a stacked annotation honestly. **Additive**; no
+existing variant or API changed — the same shape as the `Accent` node in 0.4.0.
+
+- **`MathExpr::Overset { over: Box<MathExpr>, base: Box<MathExpr> }`** and
+  **`MathExpr::Underset { under: Box<MathExpr>, base: Box<MathExpr> }`** — generalise `Accent`: where
+  an accent's mark is a fixed named diacritic, an `Overset`'s `over` is a *full sub-expression* (an
+  arrow label, a limit annotation, a reaction condition, …). Kept **distinct from `Pow`/`Subscript`**:
+  the annotation is *centered* above/below the base, not raised/lowered, and a faithful renderer must
+  stack it.
+- `Capabilities` gains **`oversets`** (set by `all()`, with a `with_oversets()` builder) and the
+  conformance harness now polices it: a frontend that emits an `Overset`/`Underset` but does not
+  declare `oversets` is flagged, exactly as for every other node-bearing capability.
+- The iterative `impl Drop for MathExpr` (heap worklist) gains arms for both new nodes, so a deep
+  `Overset`/`Underset` spine frees in O(1) stack depth — a 300 000-deep alternating spine is dropped
+  in a test without overflow.
+- Downstream unaffected: `latex` (declares `all()`), `asciimath`, and the `adj-lang` adapter all build
+  unchanged — frontends only *construct* `MathExpr`, and the adapter routes unknown nodes through its
+  catch-all. No emitter ships in this PR; the node is the prerequisite (same staging as `Accent`),
+  consumed by a later `asciimath`/`latex` `overset`/`underset`/`stackrel` emission PR.
+
 ## [0.4.0] — 2026-06-29
 
 ### Added — neutral `Accent` node (unblocks accents on every frontend)

--- a/code/packages/rust/math-frontend/Cargo.toml
+++ b/code/packages/rust/math-frontend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "math-frontend"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "A pluggable parser-frontend framework: a neutral math AST (MathExpr), a MathFrontend trait + registry, and a shared conformance harness. Notation parsers (LaTeX, AsciiMath, MathML, …) implement the trait so any consumer lowers ONE neutral tree."
 license = "MIT"

--- a/code/packages/rust/math-frontend/README.md
+++ b/code/packages/rust/math-frontend/README.md
@@ -25,7 +25,7 @@ Adding a notation later is "register one more frontend" — zero consumer change
 
 | Piece | Role |
 |-------|------|
-| `MathExpr` (+ `Number`, `BinOp`, `Func`, `BigOp`, `RelOp`, …) | the notation-agnostic AST — includes `BinOp::PlusMinus`/`MinusPlus` (± / ∓), `MathExpr::Binom` (binomial coefficient), and `MathExpr::Accent { accent, body }` (diacritics `\hat{x}`/`\bar{y}`/`\vec{v}`, distinct from a function call) |
+| `MathExpr` (+ `Number`, `BinOp`, `Func`, `BigOp`, `RelOp`, …) | the notation-agnostic AST — includes `BinOp::PlusMinus`/`MinusPlus` (± / ∓), `MathExpr::Binom` (binomial coefficient), `MathExpr::Accent { accent, body }` (diacritics `\hat{x}`/`\bar{y}`/`\vec{v}`, distinct from a function call), and `MathExpr::Overset`/`Underset` (a full sub-expression stacked over/under a base — `\overset{a}{b}`/`\stackrel{a}{R}`/`\underset{a}{b}`, distinct from `Pow`/`Subscript`) |
 | `MathFrontend` | the contract a notation parser implements |
 | `FrontendError` / `Capabilities` | spanned errors; what a frontend can emit |
 | `FrontendRegistry` | look up a frontend by name and parse through it |

--- a/code/packages/rust/math-frontend/src/conformance.rs
+++ b/code/packages/rust/math-frontend/src/conformance.rs
@@ -94,7 +94,7 @@ pub fn check_frontend(frontend: &dyn MathFrontend, samples: &[&str]) -> Conforma
 /// Names of capabilities that `used` requires but `declared` did not advertise.
 fn over_emitted(used: Capabilities, declared: Capabilities) -> Vec<&'static str> {
     let mut v = Vec::new();
-    let pairs: [(&str, bool, bool); 12] = [
+    let pairs: [(&str, bool, bool); 13] = [
         ("fractions", used.fractions, declared.fractions),
         ("roots", used.roots, declared.roots),
         ("powers", used.powers, declared.powers),
@@ -107,6 +107,7 @@ fn over_emitted(used: Capabilities, declared: Capabilities) -> Vec<&'static str>
         ("plusminus", used.plusminus, declared.plusminus),
         ("binomials", used.binomials, declared.binomials),
         ("accents", used.accents, declared.accents),
+        ("oversets", used.oversets, declared.oversets),
     ];
     for (label, used_it, declared_it) in pairs {
         if used_it && !declared_it {
@@ -191,6 +192,11 @@ fn collect_used(e: &MathExpr, caps: &mut Capabilities) {
         MathExpr::Accent { body, .. } => {
             caps.accents = true;
             collect_used(body, caps);
+        }
+        MathExpr::Overset { over: a, base: b } | MathExpr::Underset { under: a, base: b } => {
+            caps.oversets = true;
+            collect_used(a, caps);
+            collect_used(b, caps);
         }
     }
 }
@@ -294,6 +300,45 @@ mod tests {
         let r = check_frontend(&AccentOverClaimer, &["xhat"]);
         assert!(!r.passed());
         assert!(r.issues.iter().any(|i| i.contains("accents")));
+    }
+
+    #[test]
+    fn emitting_overset_without_declaring_is_flagged() {
+        // A frontend that emits `\overset{a}{b}` (an Overset) but declares `none()` must be
+        // flagged for the `oversets` capability — the gate polices the new node too.
+        struct OversetOverClaimer;
+        impl MathFrontend for OversetOverClaimer {
+            fn name(&self) -> &str { "overset" }
+            fn parse(&self, _src: &str) -> Result<MathExpr, FrontendError> {
+                Ok(MathExpr::Overset {
+                    over: Box::new(MathExpr::Symbol("a".into())),
+                    base: Box::new(MathExpr::Symbol("b".into())),
+                })
+            }
+            fn capabilities(&self) -> Capabilities { Capabilities::none() }
+        }
+        let r = check_frontend(&OversetOverClaimer, &["aoverb"]);
+        assert!(!r.passed());
+        assert!(r.issues.iter().any(|i| i.contains("oversets")));
+    }
+
+    #[test]
+    fn declaring_oversets_admits_overset_and_underset() {
+        // Declaring `with_oversets()` makes emitting an Overset/Underset conforming.
+        struct OversetHonest;
+        impl MathFrontend for OversetHonest {
+            fn name(&self) -> &str { "overset-honest" }
+            fn parse(&self, src: &str) -> Result<MathExpr, FrontendError> {
+                let s = |n: &str| Box::new(MathExpr::Symbol(n.into()));
+                Ok(if src == "under" {
+                    MathExpr::Underset { under: s("a"), base: s("b") }
+                } else {
+                    MathExpr::Overset { over: s("a"), base: s("b") }
+                })
+            }
+            fn capabilities(&self) -> Capabilities { Capabilities::none().with_oversets() }
+        }
+        assert!(check_frontend(&OversetHonest, &["over", "under"]).passed());
     }
 
     #[test]

--- a/code/packages/rust/math-frontend/src/expr.rs
+++ b/code/packages/rust/math-frontend/src/expr.rs
@@ -264,6 +264,17 @@ pub enum MathExpr {
     /// diacritic *over* `x`, semantically unlike the named function `hat(x)`, and a faithful
     /// renderer must reproduce the mark, not a function application.
     Accent { accent: String, body: Box<MathExpr> },
+    /// An arbitrary expression set **over** a base: `\overset{a}{b}`, `\stackrel{a}{R}`
+    /// (LaTeX), `overset(a)(b)` / `stackrel a b` (AsciiMath). Generalises [`MathExpr::Accent`]:
+    /// where an accent's mark is a fixed named diacritic, an `Overset`'s `over` is a *full
+    /// sub-expression* (`\xrightarrow{f}` style labels, a limit annotation, a chemical-reaction
+    /// condition over an arrow, …). Kept DISTINCT from `Pow`: the `over` sits *centered above*
+    /// the base, not as a superscript, and a faithful renderer must stack it, not raise it.
+    Overset { over: Box<MathExpr>, base: Box<MathExpr> },
+    /// An arbitrary expression set **under** a base: `\underset{a}{b}` (LaTeX),
+    /// `underset(a)(b)` (AsciiMath). The under-the-base twin of [`MathExpr::Overset`] —
+    /// distinct from `Subscript` for the same centered-vs-lowered reason.
+    Underset { under: Box<MathExpr>, base: Box<MathExpr> },
 }
 
 /// Drop a `MathExpr` **iteratively** so freeing a deeply-nested tree cannot overflow the
@@ -323,6 +334,10 @@ fn take_children(e: &mut MathExpr, out: &mut Vec<MathExpr>) {
         }
         MathExpr::Call { arg, .. } => take(arg, out),
         MathExpr::Accent { body, .. } => take(body, out),
+        MathExpr::Overset { over: a, base: b } | MathExpr::Underset { under: a, base: b } => {
+            take(a, out);
+            take(b, out);
+        }
         MathExpr::BigOp { lower, upper, body, .. } => {
             take_opt(lower, out);
             take_opt(upper, out);
@@ -367,6 +382,32 @@ mod tests {
         let mut e = MathExpr::Symbol("x".to_string());
         for _ in 0..300_000 {
             e = MathExpr::Accent { accent: "hat".to_string(), body: Box::new(e) };
+        }
+        drop(e);
+    }
+
+    #[test]
+    fn overset_underset_are_constructible_distinct_and_drop_deep() {
+        let s = |n: &str| Box::new(MathExpr::Symbol(n.to_string()));
+        let over = MathExpr::Overset { over: s("a"), base: s("R") };
+        let under = MathExpr::Underset { under: s("a"), base: s("R") };
+        // Equal to themselves; the two directions are distinct nodes.
+        assert_eq!(over, MathExpr::Overset { over: s("a"), base: s("R") });
+        assert_eq!(under, MathExpr::Underset { under: s("a"), base: s("R") });
+        assert_ne!(over, under);
+        // Argument order matters (annotation vs base are not interchangeable).
+        assert_ne!(over, MathExpr::Overset { over: s("R"), base: s("a") });
+        // Distinct from a Pow/Subscript with the same operands (centered, not raised/lowered).
+        assert_ne!(over, MathExpr::Bin(BinOp::Pow, s("R"), s("a")));
+        assert_ne!(under, MathExpr::Subscript(s("R"), s("a")));
+        // A deep Overset/Underset spine must free via the iterative Drop, not recurse.
+        let mut e = MathExpr::Symbol("x".to_string());
+        for i in 0..300_000 {
+            e = if i % 2 == 0 {
+                MathExpr::Overset { over: s("f"), base: Box::new(e) }
+            } else {
+                MathExpr::Underset { under: s("g"), base: Box::new(e) }
+            };
         }
         drop(e);
     }

--- a/code/packages/rust/math-frontend/src/frontend.rs
+++ b/code/packages/rust/math-frontend/src/frontend.rs
@@ -66,6 +66,9 @@ pub struct Capabilities {
     pub binomials: bool,
     /// Emits diacritical accents ([`crate::MathExpr::Accent`]: `\hat{x}`, `\bar{y}`, `\vec{v}`, …).
     pub accents: bool,
+    /// Emits over/under-set annotations ([`crate::MathExpr::Overset`] / [`crate::MathExpr::Underset`]:
+    /// `\overset{a}{b}`, `\stackrel{a}{R}`, `\underset{a}{b}`).
+    pub oversets: bool,
 }
 
 impl Capabilities {
@@ -90,6 +93,7 @@ impl Capabilities {
             plusminus: true,
             binomials: true,
             accents: true,
+            oversets: true,
         }
     }
 
@@ -105,6 +109,7 @@ impl Capabilities {
     pub fn with_plusminus(mut self) -> Self { self.plusminus = true; self }
     pub fn with_binomials(mut self) -> Self { self.binomials = true; self }
     pub fn with_accents(mut self) -> Self { self.accents = true; self }
+    pub fn with_oversets(mut self) -> Self { self.oversets = true; self }
 }
 
 /// The contract every notation parser implements.

--- a/code/specs/PFE01-pluggable-parser-frontends.md
+++ b/code/specs/PFE01-pluggable-parser-frontends.md
@@ -51,6 +51,10 @@ pub enum MathExpr {
     Accent { accent: String, body: Box<MathExpr> }, // diacritic over body: \hat{x}, \bar{y},
                                                 //   \vec{v}, … (distinct from a Call: a mark,
                                                 //   not a named-function application)
+    Overset  { over:  Box<MathExpr>, base: Box<MathExpr> }, // \overset{a}{b}, \stackrel{a}{R}:
+    Underset { under: Box<MathExpr>, base: Box<MathExpr> }, //   a full expr stacked over/under a
+                                                //   base — generalises Accent; distinct from
+                                                //   Pow/Subscript (centered, not raised/lowered)
 }
 ```
 


### PR DESCRIPTION
## What

Adds two **additive** neutral-AST variants to `math-frontend` — the cross-crate **prerequisite** (same staging as the `Accent` node in 0.4.0) that lets any frontend lower **over/under-set annotations** faithfully instead of dropping them or misusing `Pow`/`Subscript`:

```rust
MathExpr::Overset  { over:  Box<MathExpr>, base: Box<MathExpr> }   // \overset{a}{b}, \stackrel{a}{R}
MathExpr::Underset { under: Box<MathExpr>, base: Box<MathExpr> }   // \underset{a}{b}
```

## Why

These **generalise `Accent`**: where an accent's mark is a fixed named diacritic, an `Overset`'s `over` is a **full sub-expression** (an arrow label like `\xrightarrow{f}`, a limit annotation, a chemical-reaction condition over an arrow, …). Kept **distinct from `Pow`/`Subscript`**: the annotation is *centered* above/below the base, not raised/lowered, and a faithful renderer must stack it.

This is the documented prerequisite for the `stackrel`/`overset`/`underset` items in the ASM01 PR-3c remainder (and the LaTeX `\overset`/`\underset` equivalents) — there was no `Overset`/`Underset` in `MathExpr` to lower into.

## Conformance & safety

- `Capabilities` gains **`oversets`** (set by `all()`, with a `with_oversets()` builder). The conformance harness now polices it (`collect_used` arm + `over_emitted` pairs array 12→13): a frontend that emits an `Overset`/`Underset` but does not declare `oversets` is flagged — enforced by new tests.
- The iterative `impl Drop for MathExpr` (heap worklist) gains arms for both nodes, so a deep spine frees in **O(1) stack depth** — a 300 000-deep alternating `Overset`/`Underset` spine drops without overflow in a test.

## Additive — downstream unaffected

`latex` (declares `all()`), `asciimath`, and the `adj-lang` adapter all **build unchanged** — frontends only *construct* `MathExpr`, and the adapter routes unknown nodes through its catch-all. **No emitter ships in this PR**; the node is the prerequisite, consumed by a later `asciimath`/`latex` `overset`/`underset`/`stackrel` emission PR.

## Gates

- math-frontend **0.5.0**; **31 tests pass** (incl. the deep-drop stress test); `cargo clippy -p math-frontend -- -D warnings` clean.
- `cargo build -p latex -p asciimath -p adj-lang` all green (no exhaustiveness breaks).
- `/security-review` **PASSED** (Drop arms, conformance recursion bound, array widening, additive `Capabilities` field — all verified safe).
- Spec `PFE01` §2 updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)