### PR TITLE
feat(asciimath): PR-3c part 3 — over/under-set emission (overset/underset/stackrel)

### DIFF
--- a/code/packages/rust/asciimath/CHANGELOG.md
+++ b/code/packages/rust/asciimath/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to the AsciiMath pluggable frontend.
 
+## [0.8.0] — 2026-06-29
+
+### Added — ASM01 PR-3c (part 3): over/under-set emission
+
+- AsciiMath now **emits** the neutral `MathExpr::Overset` / `MathExpr::Underset` nodes
+  (math-frontend 0.5.0): **`overset(a)(b)`** and its LaTeX synonym **`stackrel(a)(b)`** →
+  `Overset { over: a, base: b }`; **`underset(a)(b)`** → `Underset { under: a, base: b }`. Each
+  keyword takes **two atoms** (annotation then base, the same convention as `root(n)(x)`), so the
+  paren-free `stackrel a b` form works too and the annotation may be a full group expression
+  (`overset(a+c)(R)`). This realizes the stacked-annotation half of the PR-3c remainder, now that
+  the neutral node exists.
+- Semantics: a centered mark **over/under** the base, **distinct from `Pow`/`Subscript`** (raised /
+  lowered) — a faithful renderer must stack it. `capabilities()` adds **`oversets`**, enforced by the
+  conformance harness; the corpus gains `overset(a)(b)` and `underset(a)(b)`.
+- Tests: parser `oversets_lower_to_neutral_overset_underset_nodes` (overset/underset/stackrel,
+  paren-free form, group annotation, distinct-from-Pow). 36 unit + doc tests pass; clippy
+  `-D warnings` clean. Mirrors how accent emission (0.3.0) followed the `Accent` node.
+- Still **PR-3c remainder**: longest-match identifier scan (`sinx` → `sin·x`, a deeper lexer change).
+
 ## [0.7.0] — 2026-06-29
 
 ### Added — ASM01 PR-3c (part 2): the `text(…)` keyword form

--- a/code/packages/rust/asciimath/Cargo.toml
+++ b/code/packages/rust/asciimath/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "asciimath"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 description = "An AsciiMath parser that implements the math-frontend MathFrontend trait: turns AsciiMath (1/2, sqrt(x), x^2+y^2=r^2) into the neutral MathExpr AST. The second pluggable frontend after LaTeX (see ASM01/PFE01). Total, panic-free, spanned errors."
 license = "MIT"

--- a/code/packages/rust/asciimath/README.md
+++ b/code/packages/rust/asciimath/README.md
@@ -97,8 +97,13 @@ agree with the word forms `rarr`/`implies`); `a - b` and `a = b` are unaffected.
 The tokenizer captures the raw bytes up to the matching close paren (parens nest) and emits the same
 `Text` token, so `text(kg)` and `"kg"` lower to an *identical* `MathExpr::Text` (no parser/capability
 change). The open paren must immediately follow `text`; otherwise `text` is an ordinary identifier.
-**Still to come** (each structural, its own PR): longest-match identifier scan (`sinx` → `sin·x`) and
-`stackrel`/`overset`/`underset` (need a neutral-AST node).
+
+**PR-3c (part 3)** adds **over/under-set emission**: `overset(a)(b)` and its LaTeX synonym
+`stackrel(a)(b)` → `MathExpr::Overset { over, base }`; `underset(a)(b)` → `MathExpr::Underset
+{ under, base }` (two atoms, annotation then base, like `root(n)(x)`; the paren-free `stackrel a b`
+works too). A centered mark over/under the base, **distinct from `Pow`/`Subscript`**; enabled by
+math-frontend 0.5.0's neutral node, `capabilities()` declares `oversets`. **Still to come**: the
+longest-match identifier scan (`sinx` → `sin·x`, a deeper lexer change).
 
 It is **total and panic-free**: every input returns `Ok(MathExpr)` or a spanned
 `FrontendError`. Recursion is depth-guarded (matrix nesting included); left-associative chains are

--- a/code/packages/rust/asciimath/src/lib.rs
+++ b/code/packages/rust/asciimath/src/lib.rs
@@ -59,7 +59,9 @@ impl MathFrontend for AsciiMath {
     fn capabilities(&self) -> Capabilities {
         // PR-1 surface + PR-2 breadth (`matrices`, `big_operators`) + PR-2b `accents`
         // (`hat x`/`bar y`/`vec v`/`dot x`/`ddot x`/`tilde a`/`ul x`, emitted as
-        // `MathExpr::Accent` since math-frontend 0.4.0 grew the node). `plusminus`/`binomials`
+        // `MathExpr::Accent` since math-frontend 0.4.0 grew the node) + `oversets`
+        // (`overset(a)(b)`/`stackrel(a)(b)`/`underset(a)(b)`, emitted as
+        // `MathExpr::Overset`/`Underset` since math-frontend 0.5.0). `plusminus`/`binomials`
         // are not part of AsciiMath's core spelling here. Declaring `implicit_mul` is a
         // parser-behavior claim (juxtaposition ⇒ `Mul`) the goldens cover.
         Capabilities::none()
@@ -73,6 +75,7 @@ impl MathFrontend for AsciiMath {
             .with_matrices()
             .with_big_operators()
             .with_accents()
+            .with_oversets()
     }
 }
 
@@ -417,6 +420,40 @@ mod tests {
         assert_ne!(p("dot x"), sym("x"));
     }
 
+    // ---- over/under-sets (PR-3c emitter) ---------------------------------------
+    #[test]
+    fn oversets_lower_to_neutral_overset_underset_nodes() {
+        // `overset(a)(b)` / `stackrel(a)(b)` set an annotation OVER a base; `underset(a)(b)`
+        // sets it under. Two atoms (annotation, base) lowered to MathExpr::Overset/Underset —
+        // a centered mark, distinct from Pow/Subscript.
+        assert_eq!(
+            p("overset(a)(b)"),
+            MathExpr::Overset { over: Box::new(sym("a")), base: Box::new(sym("b")) }
+        );
+        assert_eq!(
+            p("underset(a)(b)"),
+            MathExpr::Underset { under: Box::new(sym("a")), base: Box::new(sym("b")) }
+        );
+        // `stackrel` is the LaTeX synonym for the over-set form → identical to `overset`.
+        assert_eq!(p("stackrel(a)(b)"), p("overset(a)(b)"));
+        // The paren-free `stackrel a b` form works too (two atoms).
+        assert_eq!(
+            p("stackrel a b"),
+            MathExpr::Overset { over: Box::new(sym("a")), base: Box::new(sym("b")) }
+        );
+        // Each argument is a full atom: the annotation can be a group expression.
+        assert_eq!(
+            p("overset(a+c)(R)"),
+            MathExpr::Overset {
+                over: Box::new(b(BinOp::Add, sym("a"), sym("c"))),
+                base: Box::new(sym("R")),
+            }
+        );
+        // Over and under are distinct nodes; an overset is not a Pow.
+        assert_ne!(p("overset(a)(b)"), p("underset(a)(b)"));
+        assert_ne!(p("overset(a)(b)"), p("b^a"));
+    }
+
     #[test]
     fn conforms_to_the_shared_harness() {
         let report = check_frontend(
@@ -444,6 +481,8 @@ mod tests {
                 "a -> b",          // punctuation arrow (PR-3c)
                 "x => y",          // punctuation double-arrow
                 "text(kg)",        // text(…) keyword form (PR-3c) — twin of "kg"
+                "overset(a)(b)",   // over-set annotation (PR-3c emitter) → MathExpr::Overset
+                "underset(a)(b)",  // under-set annotation → MathExpr::Underset
                 "1 +",   // error: trailing operator (span in range, not a panic)
                 "(x",    // error: missing close
                 "",      // error: empty

--- a/code/packages/rust/asciimath/src/parser.rs
+++ b/code/packages/rust/asciimath/src/parser.rs
@@ -356,6 +356,26 @@ impl Parser<'_> {
             let body = self.parse_atom()?;
             return Ok(MathExpr::Accent { accent: accent.to_string(), body: Box::new(body) });
         }
+        // Over/under-set annotations: `overset(a)(b)`/`stackrel(a)(b)` and `underset(a)(b)`
+        // (also the paren-free `stackrel a b` form). TWO atoms — the annotation then the base —
+        // lowered to the neutral `MathExpr::Overset`/`Underset` (a sub-expression centered OVER /
+        // UNDER the base, distinct from `Pow`/`Subscript`). Needs `math-frontend` >= 0.5.0.
+        // `stackrel` is LaTeX's name for the over-set form; AsciiMath accepts it as a synonym.
+        match word {
+            "overset" | "stackrel" => {
+                self.advance();
+                let over = self.parse_atom()?;
+                let base = self.parse_atom()?;
+                return Ok(MathExpr::Overset { over: Box::new(over), base: Box::new(base) });
+            }
+            "underset" => {
+                self.advance();
+                let under = self.parse_atom()?;
+                let base = self.parse_atom()?;
+                return Ok(MathExpr::Underset { under: Box::new(under), base: Box::new(base) });
+            }
+            _ => {}
+        }
         match word {
             "sqrt" => {
                 self.advance();

--- a/code/specs/ASM01-asciimath-frontend.md
+++ b/code/specs/ASM01-asciimath-frontend.md
@@ -115,9 +115,15 @@ shapes for representative inputs.
   must immediately follow `text`; otherwise `text` stays an ordinary identifier (a variable named
   `text`, `text (x)` with a space, or `textual` are all unchanged). An unterminated `text(` is a clean
   spanned error; byte-scanning for the matching paren is UTF-8-safe.
-- **PR-3c remainder** (each its own follow-up, structural): **longest-match tokenization** (so `sinx`
-  splits as `sin`·`x`, a deeper lexer change); and `stackrel`, `overset`/`underset` (need a neutral-AST
-  node in `math-frontend` — there is no `Overset`/`Underset` in `MathExpr` yet).
+- **PR-3c part 3 (shipped, v0.8.0):** over/under-set **emission** — `overset(a)(b)` and the LaTeX
+  synonym `stackrel(a)(b)` → `MathExpr::Overset{over,base}`; `underset(a)(b)` → `MathExpr::Underset
+  {under,base}`. Each keyword takes two atoms (annotation then base, the `root(n)(x)` convention; the
+  paren-free `stackrel a b` form works too). A centered mark over/under the base, distinct from
+  `Pow`/`Subscript`; enabled by `math-frontend` 0.5.0's neutral `Overset`/`Underset` node (added in the
+  prerequisite PR, the same staging as the `Accent` node → accent emission). `capabilities()` adds
+  `oversets`, enforced by the conformance harness.
+- **PR-3c remainder** (its own follow-up, structural): **longest-match tokenization** (so `sinx`
+  splits as `sin`·`x`, a deeper lexer change).
 
 ## 6. Non-goals
 Evaluation, simplification, rendering — none are a frontend's job (PFE01 §7). Lowering


### PR DESCRIPTION
## What

AsciiMath now **emits** the neutral `MathExpr::Overset` / `MathExpr::Underset` nodes (landed in math-frontend 0.5.0). This is the emitter half of the over/under-set feature — the node PR was the prerequisite, exactly like the `Accent` node → accent-emission staging.

```
overset(a)(b)  ≡  stackrel(a)(b)   →  Overset { over: a, base: b }
underset(a)(b)                     →  Underset { under: a, base: b }
stackrel a b   (paren-free)        →  Overset { over: a, base: b }
```

## How

A new branch in `parse_ident_atom` recognizes `overset`/`stackrel` and `underset`, each consuming **two atoms** (annotation then base) via the existing `parse_atom` — structurally identical to the `root(n)(x)` two-atom branch. The annotation may be a full group expression (`overset(a+c)(R)`); the paren-free `stackrel a b` form works too. `stackrel` is LaTeX's name for the over-set form, accepted as a synonym.

Semantics: a centered mark **over/under** the base, **distinct from `Pow`/`Subscript`** (raised/lowered) — a faithful renderer must stack it.

## Gates

- `capabilities()` adds **`oversets`**, enforced by the conformance harness; corpus gains `overset(a)(b)` and `underset(a)(b)`.
- New parser test `oversets_lower_to_neutral_overset_underset_nodes` (overset/underset/stackrel, paren-free form, group annotation, distinct-from-Pow). **36 unit + doc tests pass**; `cargo clippy -p asciimath -- -D warnings` clean.
- `/security-review` **PASSED** (new branch mirrors `root`'s depth-charged two-atom descent; no new recursion/index/arithmetic/unsafe; total & panic-free preserved).
- asciimath **0.8.0**. Spec `ASM01` §PR-3c part 3.

**PR-3c remainder** (the last structural item): longest-match identifier scan (`sinx` → `sin·x`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)