### PR TITLE
[codex] Track scripted head-body repair evidence

### DIFF
--- a/code/packages/rust/html-parser/tests/whatwg_head_body_audit_test.rs
+++ b/code/packages/rust/html-parser/tests/whatwg_head_body_audit_test.rs
@@ -7,6 +7,7 @@ use std::collections::{BTreeMap, HashMap};
 const TREE_CONSTRUCTION_SMOKE: &str = include_str!("fixtures/html5lib-tree-construction-smoke.dat");
 const WHATWG_HEAD_BODY_AUDIT: &str = include_str!("fixtures/whatwg-head-body-audit.json");
 const POST_PARSE_REPAIR_EVIDENCE: &[(&str, &str)] = &[
+    ("scripted-adoption01-dat-1", "head-text-mode"),
     ("tests26-dat-1251", "body-boundary"),
     ("tricky01-dat-3", "body-boundary"),
 ];


### PR DESCRIPTION
## Summary
- record `scripted-adoption01-dat-1` as head/body post-parse repair evidence on the `head-text-mode` audit axis
- keep the change scoped to the audit ledger; parser behavior is unchanged

## Evidence
- Temporarily no-oping `apply_scripted_tree_construction_side_effects` makes `whatwg_head_body_audit_cases_match_parser_dom_dump` fail for `scripted-adoption01-dat-1` on `head-text-mode` because the expected scripted `id="B"` mutation is lost.

## Validation
- `cargo test -p coding-adventures-html-parser font_newline_before_bold_stays_outside_reconstructed_font`
- `cargo test -p coding-adventures-html-parser whatwg_document_shell_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_head_body_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_form_interactive_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_legacy_element_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_paragraph_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_block_boundary_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_table_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_formatting_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_document_shell_audit_cases_match_parser_dom_dump`
- `cargo test -p coding-adventures-html-parser whatwg_head_body_audit_cases_match_parser_dom_dump`
- `cargo test -p coding-adventures-html-parser whatwg_formatting_audit_cases_match_parser_dom_dump`
- `cargo test -p coding-adventures-html-parser whatwg_paragraph_audit_cases_match_parser_dom_dump`
- `cargo test -p coding-adventures-html-parser whatwg_block_boundary_audit_cases_match_parser_dom_dump`
- `cargo test -p coding-adventures-html-parser html5lib_tree_construction_smoke_cases_match_dom_dump`
- `cargo test -p coding-adventures-html-parser`
- `cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser`
- `python3 -m json.tool code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json >/dev/null`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py`
- `git diff --check`
