### PR TITLE
fix(closure-emitter): escape U+2028/U+2029 in string literals (invalid JS)

### DIFF
--- a/code/packages/rust/closure-emitter/CHANGELOG.md
+++ b/code/packages/rust/closure-emitter/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to the `coding-adventures-closure-emitter` crate will be documented in this file.
 
+## [0.18.3] - 2026-06-29
+
+### Fixed — U+2028 / U+2029 emitted unescaped in string literals (invalid JS)
+
+The default (non-`ascii_only`) string escapers `escape_str_dq` / `escape_str_sq`
+only escaped control characters below `0x20`, so they passed U+2028 (LINE
+SEPARATOR) and U+2029 (PARAGRAPH SEPARATOR) through verbatim. Those two
+codepoints are ECMAScript **line terminators**, and before ES2019 an unescaped
+one inside a string literal is a `SyntaxError` — so a source string containing
+either character could be minified into invalid output. (The `ascii_only`
+escaper already escaped them as non-ASCII; only the default path was affected.)
+
+Both escapers now emit ` ` / ` ` explicitly. New test
+`line_and_paragraph_separators_are_escaped` covers the double-quoted,
+single-quoted, and `ascii_only` paths. Flagged during the security review of the
+property-key fix (0.18.2) as a pre-existing latent miscompile.
+
 ## [0.18.2] - 2026-06-29
 
 ### Added — sound quote-stripping for string object-property keys

--- a/code/packages/rust/closure-emitter/Cargo.toml
+++ b/code/packages/rust/closure-emitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-emitter"
-version = "0.18.2"
+version = "0.18.3"
 edition = "2021"
 description = "JavaScript code emitter for the Closure Compiler clone. Per CLOC07's emit contract. Takes a finalized Program + sidecar and produces output JavaScript text + companion source map. Runs after every pass in the pipeline."
 

--- a/code/packages/rust/closure-emitter/src/lib.rs
+++ b/code/packages/rust/closure-emitter/src/lib.rs
@@ -1568,6 +1568,13 @@ fn escape_str_sq(s: &str) -> String {
             '\n' => out.push_str("\\n"),
             '\r' => out.push_str("\\r"),
             '\t' => out.push_str("\\t"),
+            // U+2028 LINE SEPARATOR / U+2029 PARAGRAPH SEPARATOR: these are
+            // line terminators in ECMAScript, so before ES2019 an UNESCAPED one
+            // inside a string literal is a SyntaxError. They sit above 0x20, so
+            // the control-char arm below does not catch them — escape explicitly.
+            // (See `escape_ascii_only`, which already escapes them as non-ASCII.)
+            '\u{2028}' => out.push_str("\\u2028"),
+            '\u{2029}' => out.push_str("\\u2029"),
             c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04X}", c as u32)),
             c => out.push(c),
         }
@@ -1587,6 +1594,13 @@ fn escape_str_dq(s: &str) -> String {
             '\n' => out.push_str("\\n"),
             '\r' => out.push_str("\\r"),
             '\t' => out.push_str("\\t"),
+            // U+2028 LINE SEPARATOR / U+2029 PARAGRAPH SEPARATOR: line
+            // terminators in ECMAScript, so an UNESCAPED one inside a string
+            // literal is a SyntaxError before ES2019. They are above 0x20, so the
+            // control-char arm below misses them — escape explicitly. (Mirrors
+            // `escape_ascii_only`, which already escapes them as non-ASCII.)
+            '\u{2028}' => out.push_str("\\u2028"),
+            '\u{2029}' => out.push_str("\\u2029"),
             c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04X}", c as u32)),
             c => out.push(c),
         }
@@ -1737,6 +1751,34 @@ mod tests {
             raw: String::new(),
         });
         emit_default(program().with_body(vec![stmt(s)])).code
+    }
+
+    #[test]
+    fn line_and_paragraph_separators_are_escaped() {
+        // U+2028 (LINE SEPARATOR) and U+2029 (PARAGRAPH SEPARATOR) are
+        // ECMAScript line terminators. An UNESCAPED one inside a string literal
+        // is a SyntaxError before ES2019, so the emitter must escape them even in
+        // the default (non-`ascii_only`) mode. Double-quoted path:
+        assert_eq!(emit_string_value("a\u{2028}b"), "\"a\\u2028b\";");
+        assert_eq!(emit_string_value("a\u{2029}b"), "\"a\\u2029b\";");
+        // Single-quoted path (value has more `"` than `'`, so single quotes are
+        // chosen) escapes them too.
+        assert_eq!(emit_string_value("\"\u{2028}"), "'\"\\u2028';");
+        // `ascii_only` mode already escaped them (as non-ASCII) — confirm it
+        // still produces the same ` ` form, not a `\u{...}` or raw byte.
+        let s = Expression::StringLiteral(StringLiteral {
+            cv: None,
+            value: "a\u{2029}b".to_string(),
+            raw: String::new(),
+        });
+        let out = emit_with(
+            program().with_body(vec![stmt(s)]),
+            EmitOptions {
+                ascii_only: true,
+                ..Default::default()
+            },
+        );
+        assert_eq!(out.code, "\"a\\u2029b\";");
     }
 
     // ---- number shortest-form (gap-025, CLOC12.12) ---------


### PR DESCRIPTION
## Problem

The default (non-`ascii_only`) string escapers `escape_str_dq` and `escape_str_sq` only escaped control characters below `0x20`, so they emitted **U+2028** (LINE SEPARATOR) and **U+2029** (PARAGRAPH SEPARATOR) verbatim. Both are ECMAScript **line terminators** — and before ES2019, an unescaped one inside a string literal is a `SyntaxError`. So a source string containing either character could be minified into **invalid output**.

The `ascii_only` escaper already escaped them (as non-ASCII); only the default path was affected.

## Fix

Both default escapers now emit ` ` / ` ` explicitly. ` `/` ` is the correct escape inside both single- and double-quoted literals and round-trips to the same string value.

New test `line_and_paragraph_separators_are_escaped` covers the double-quoted, single-quoted, and `ascii_only` paths.

`closure-emitter` 0.18.3. Emitter suite (81 unit) + closurec downstream suites green.

## Provenance & scope

Flagged during the security review of [#6975](https://github.com/adhithyan15/coding-adventures/pull/6975) (the property-key miscompile fix) as a pre-existing, out-of-scope latent miscompile; this lands it as its own focused change.

## Security review

Inline security review **PASSED** — no vulnerabilities. Reviewer confirmed these two escapers are the only non-`ascii_only` string-literal emission paths (via `choose_quote_and_escape`), and that template/regex literals are not yet implemented in this emitter, so no other path emits these chars raw. No new `unsafe`, panics, or DoS surface (two constant-work match arms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)