### PR TITLE
feat(mle-pass): multi-hop recall harness — two-hop board reasoning, 0 model calls

### DIFF
--- a/code/specs/MLE-PASS-multihop-recall.md
+++ b/code/specs/MLE-PASS-multihop-recall.md
@@ -1,0 +1,84 @@
+# MLE-PASS — multi-hop recall (the two-hop reasoning step)
+
+**Status:** First slice shipped. Harness + worked artifact + 7-item bank, run-verified.
+**Author:** autonomous loop, 2026-06-29.
+
+## 1. Why
+
+The single-hop recall rungs answer "which gene is mutated in Huntington disease?" — one
+grounded edge, one binding query. Real board questions usually need **two hops**: you are
+given a *clinical clue*, not the disease name, and must chain
+
+```
+clue ──(hop 1)──▶ disease ──(hop 2)──▶ gene / treatment / mechanism
+```
+
+e.g. *"a child with **leukocoria** — the disease it indicates is caused by a mutation in
+which gene?"* → leukocoria → **retinoblastoma** → **RB1**. MLE-PASS is the harness that
+answers these **purely on the CPU from grounded edges, with zero model calls**, and proves
+each answer is a genuine two-hop derivation (both hops cited), not a one-edge coincidence.
+
+This is the reasoning step past the recall rungs toward board coverage
+([[project_board_exam_goal]], [[project_hle_north_star]]): the join is **CPU-bound**
+([[project_cpu_bound_reasoning_problog]]) — the engine does it, not a model.
+
+## 2. The join is a rule body (in-engine SLD), not Python
+
+adj-lang has no top-level conjunctive query (`? a, b` is a parse error), but a **rule body**
+takes comma-separated subgoals sharing variables, and the engine's SLD resolver evaluates
+them. So a two-hop question is one rule whose body joins two grounded `relate` edges on the
+shared disease, then a binding query on the rule head:
+
+```adj
+import "ophtho-edges.adj"        % hop-1 library (clue → disease)
+import "genetics-edges.adj"      % hop-2 library (disease → gene)
+rule {
+    head: clue_to_gene($X, $G)
+    when: eye_finding_indicates($X, $D), gene_defect($D, $G)   % join on $D
+}
+? clue_to_gene(leukocoria, $G)   % engine binds $G = rb1, cites BOTH spans
+```
+
+The engine returns the `$G` binding **and the citing clause of each hop** (the
+leukocoria→retinoblastoma span *and* the retinoblastoma→RB1 span). The join is done in the
+engine; Python only assembles the program and reads the binding.
+
+## 3. Nothing authored — existing grounded edges only
+
+Every chain reuses edges that already shipped through their own
+spider→byte-provenance→adversarial-gate PRs ([[feedback_nothing_human_authored]]). The first
+slice draws hop-1 from four organ-system libraries that already target genetics-library
+diseases by the same id:
+
+| hop-1 library | relation | example clue → disease | hop-2 gene |
+|---|---|---|---|
+| `ophtho-edges` | `eye_finding_indicates` | leukocoria → retinoblastoma | RB1 |
+| `ophtho-edges` | `eye_finding_indicates` | Kayser-Fleischer rings → Wilson | ATP7B |
+| `ophtho-edges` | `eye_finding_indicates` | superior lens dislocation → Marfan | FBN1 |
+| `neuro-edges` | `lesion_causes` | caudate degeneration → Huntington | HTT |
+| `collagen-defect-edges` | `defect_causes` | type I collagen defect → OI | COL1A1 |
+| `enzyme-deficiency-edges` | `enzyme_deficiency_disease` | α-galactosidase A → Fabry | GLA |
+| `enzyme-deficiency-edges` | `enzyme_deficiency_disease` | glucocerebrosidase → Gaucher | GBA1 |
+
+The bank grows as more cross-library id joins are grounded — no new harness work per chain.
+
+## 4. Harness & metrics
+
+`code/specs/data/mycin-2026/mle-pass/`:
+- `items.json` — the MCQ bank (clue, hop-1 library+relation, gene options, gold).
+- `mle_pass_eval.py` — builds each two-hop query, runs `adj-lang-cli`, reads the binding,
+  maps to the printed gene option, scores **correct / abstained / wrong**. Because imports
+  may not escape their directory, each run is assembled in a temp dir (the two `*-edges.adj`
+  copied beside the query), leaving `recall/` pristine.
+- `test_mle_pass.py` — gates: engine binds gold for every item; **every correct answer cites
+  both hops** (`multihop_coverage == 1.0`); an unknown clue **abstains** (never fabricates).
+- `recall/multihop-recall.query.adj` — the shipped worked artifact (runs in place).
+
+**`multihop_coverage`** = fraction of correct answers citing BOTH grounded hops — the
+defensibility number a future grounding PR moves, and the proof of a real two-hop derivation.
+First slice: **7/7 correct, coverage 1.0, zero model calls.**
+
+## 5. Next
+More chains as id joins are grounded (derm/histo/cardio → genetics; disease → *treatment* and
+disease → *mechanism* hops); a third hop (clue → disease → drug → contraindication); and an
+abstention bank (clues whose chain is ungrounded, which must abstain).

--- a/code/specs/data/mycin-2026/mle-pass/CHANGELOG.md
+++ b/code/specs/data/mycin-2026/mle-pass/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog — mle-pass
+
+## [0.1.0] — 2026-06-29
+
+### Added — MLE-PASS multi-hop recall harness (first slice)
+
+- New `mle-pass/` harness answering **two-hop** board questions purely on the CPU from
+  grounded edges, **zero model calls**: a clinical clue chained `clue → disease → gene` by
+  joining two grounded `relate` edges in an adj-lang **rule body** (the engine's SLD resolver
+  does the join on the shared disease), with **both hops' byte-provenance** returned.
+- `items.json` — 7-item bank over four hop-1 organ-system libraries joined to the genetics
+  library (ophtho → leukocoria/KF-rings/lens-dislocation; neuro → caudate; collagen → type-I;
+  enzyme-deficiency → α-galactosidase-A/glucocerebrosidase). Nothing authored — every edge
+  reuses an already-grounded, spider+adversarially-gated fact in `../recall/`.
+- `mle_pass_eval.py` — builds each two-hop query (in a temp dir, since adj-lang imports may
+  not escape their directory), runs `adj-lang-cli`, maps the gene binding to the printed
+  option, scores **correct / abstained / wrong** + **`multihop_coverage`** (fraction of
+  correct answers citing BOTH hops).
+- `test_mle_pass.py` — gates: engine binds gold for every item; `multihop_coverage == 1.0`
+  (every correct answer cites both hops); an unknown clue **abstains**, never fabricates.
+- `../recall/multihop-recall.query.adj` — the shipped worked artifact (runs in place).
+- First slice: **7/7 correct, coverage 1.0, zero model calls.** Spec:
+  `code/specs/MLE-PASS-multihop-recall.md`.

--- a/code/specs/data/mycin-2026/mle-pass/README.md
+++ b/code/specs/data/mycin-2026/mle-pass/README.md
@@ -1,0 +1,57 @@
+# mle-pass — multi-hop recall harness
+
+Answers **two-hop** board questions purely on the CPU from grounded edges, with **zero model
+calls**. A clinical clue is chained `clue → disease → gene` by joining two grounded `relate`
+edges in an adj-lang **rule body** (the engine's SLD resolver does the join on the shared
+disease), and the answer carries **both hops' byte-provenance**.
+
+Spec: [`code/specs/MLE-PASS-multihop-recall.md`](../../../MLE-PASS-multihop-recall.md).
+The single-hop predecessors live in [`../recall/`](../recall); this is the reasoning step
+past them, toward board coverage.
+
+```
+clue ──eye_finding_indicates──▶ disease ──gene_defect──▶ gene
+        (ophtho-edges.adj)                 (genetics-edges.adj)
+   leukocoria ───────────────▶ retinoblastoma ─────────▶ RB1
+```
+
+## Files
+
+| file | what |
+|------|------|
+| `items.json` | the MCQ bank — clue, hop-1 library+relation, 5 gene options, gold |
+| `mle_pass_eval.py` | builds each two-hop query, runs `adj-lang-cli`, scores correct/abstained/wrong + `multihop_coverage` |
+| `test_mle_pass.py` | gates: gold bound for every item, both hops cited, unknown clue abstains |
+| `gen_items.py` | regenerates `items.json` from the verified chain table |
+| `../recall/multihop-recall.query.adj` | the shipped worked artifact (runs in place) |
+
+## Run
+
+```
+# from this directory (needs adj-lang-cli built: cargo build -p adj-lang-cli)
+python3 mle_pass_eval.py
+python3 -m pytest test_mle_pass.py -q
+```
+
+## How the join works
+
+adj-lang has no top-level conjunctive query, but a rule body chains subgoals sharing a
+variable, so a two-hop question is one rule + one binding query:
+
+```adj
+import "ophtho-edges.adj"
+import "genetics-edges.adj"
+rule {
+    head: clue_to_gene($X, $G)
+    when: eye_finding_indicates($X, $D), gene_defect($D, $G)   % join on $D
+}
+? clue_to_gene(leukocoria, $G)   % → rb1, with both hops cited
+```
+
+The engine returns the gene binding **and** the citing clause of each hop. Nothing is
+authored here: every edge reuses an already-grounded, spider+adversarially-gated fact
+(`../recall/`). Because adj-lang imports may not escape their directory, the harness assembles
+each run in a temp dir (the two needed `*-edges.adj` copied beside the query), leaving the
+shipped `recall/` library untouched.
+
+First slice: **7/7 correct, `multihop_coverage` 1.0, zero model calls.**

--- a/code/specs/data/mycin-2026/mle-pass/gen_items.py
+++ b/code/specs/data/mycin-2026/mle-pass/gen_items.py
@@ -1,0 +1,93 @@
+"""Generate the MLE-PASS multi-hop recall bank (items.json).
+
+Each item is a TWO-HOP board question answered purely from grounded edges with zero
+model calls: a clinical clue → disease (hop 1, an organ-system recall library) → gene
+(hop 2, the genetics library). The engine joins the two grounded `relate` edges through
+a rule body (shared `$D`), so the answer carries BOTH hops' byte-provenance.
+
+Nothing here is authored knowledge: every chain reuses already-grounded edges that
+shipped in their own spider→provenance→adversarial-gate PRs. This generator only
+arranges existing edges into MCQs.
+"""
+import json
+
+# (id, clue, hop1_lib, hop1_rel, disease, gene, clue_phrase)
+CHAINS = [
+    ("mh-01", "leukocoria", "ophtho-edges.adj", "eye_finding_indicates",
+     "retinoblastoma", "rb1", "a white pupillary reflex (leukocoria)"),
+    ("mh-02", "kayser_fleischer_rings", "ophtho-edges.adj", "eye_finding_indicates",
+     "wilson_disease", "atp7b", "Kayser-Fleischer corneal rings"),
+    ("mh-03", "superior_lens_dislocation", "ophtho-edges.adj", "eye_finding_indicates",
+     "marfan_syndrome", "fbn1", "upward (superior) lens dislocation"),
+    ("mh-04", "caudate_nucleus", "neuro-edges.adj", "lesion_causes",
+     "huntington_disease", "htt", "degeneration of the caudate nucleus"),
+    ("mh-05", "type_i", "collagen-defect-edges.adj", "defect_causes",
+     "osteogenesis_imperfecta", "col1a1", "a defect in type I collagen"),
+    ("mh-06", "alpha_galactosidase_a", "enzyme-deficiency-edges.adj", "enzyme_deficiency_disease",
+     "fabry_disease", "gla", "deficiency of alpha-galactosidase A"),
+    ("mh-07", "glucocerebrosidase", "enzyme-deficiency-edges.adj", "enzyme_deficiency_disease",
+     "gaucher_disease", "gba1", "deficiency of glucocerebrosidase"),
+]
+
+# Distractor pool: real genes from the genetics library (so every option is a plausible gene).
+GENE_POOL = ["rb1", "atp7b", "fbn1", "htt", "col1a1", "gla", "gba1", "hexa", "cftr",
+             "dmpk", "fmr1", "pah", "hfe", "ube3a", "fxn"]
+
+
+def build():
+    items = []
+    letters = ["A", "B", "C", "D", "E"]
+    for idx, (iid, clue, lib, rel, disease, gene, phrase) in enumerate(CHAINS):
+        # five distinct gene options: the gold + four distractors from the pool.
+        distractors = [g for g in GENE_POOL if g != gene][:4]
+        opts = distractors[:]
+        pos = idx % 5
+        opts.insert(pos, gene)
+        opts = opts[:5]
+        # guarantee the gold sits at `pos` and options are distinct
+        if opts[pos] != gene:
+            opts[pos] = gene
+        assert len(set(opts)) == 5, (iid, opts)
+        options = {letters[i]: opts[i] for i in range(5)}
+        gold_letter = letters[opts.index(gene)]
+        stem = (
+            f"A patient has {phrase}. That finding points to a single disease; "
+            f"the disease is caused by a mutation in which gene?"
+        )
+        items.append({
+            "id": iid,
+            "qtype": "multi_hop_recall",
+            "stem": stem,
+            "hop1_lib": lib,
+            "hop1_relation": rel,
+            "hop2_lib": "genetics-edges.adj",
+            "hop2_relation": "gene_defect",
+            "clue": clue,
+            "expected": gene,
+            "options": options,
+            "gold_letter": gold_letter,
+        })
+    return {
+        "description": (
+            "MLE-PASS multi-hop recall bank — TWO-HOP board questions answered purely from "
+            "grounded edges with zero model calls. Each item chains a clinical clue → disease "
+            "(hop 1, an organ-system recall library: ophtho / neuro / collagen / enzyme-deficiency) "
+            "→ gene (hop 2, the genetics library) by joining two grounded `relate` edges through a "
+            "rule body (shared disease variable). The engine resolves the join (SLD) and returns the "
+            "gene binding carrying BOTH hops' byte-provenance; the harness maps the binding to the "
+            "printed gene options. Nothing is authored: every edge reuses an already-grounded, "
+            "spider+adversarially-gated fact. This is the first slice of the MLE-PASS harness — the "
+            "multi-hop reasoning step past the single-hop recall rungs, toward board coverage."
+        ),
+        "items": items,
+    }
+
+
+if __name__ == "__main__":
+    doc = build()
+    with open("items.json", "w") as f:
+        json.dump(doc, f, indent=2)
+        f.write("\n")
+    print("wrote items.json:", len(doc["items"]), "items")
+    for it in doc["items"]:
+        print(it["id"], it["clue"], "→", it["expected"], it["gold_letter"], it["options"])

--- a/code/specs/data/mycin-2026/mle-pass/items.json
+++ b/code/specs/data/mycin-2026/mle-pass/items.json
@@ -1,0 +1,138 @@
+{
+  "description": "MLE-PASS multi-hop recall bank \u2014 TWO-HOP board questions answered purely from grounded edges with zero model calls. Each item chains a clinical clue \u2192 disease (hop 1, an organ-system recall library: ophtho / neuro / collagen / enzyme-deficiency) \u2192 gene (hop 2, the genetics library) by joining two grounded `relate` edges through a rule body (shared disease variable). The engine resolves the join (SLD) and returns the gene binding carrying BOTH hops' byte-provenance; the harness maps the binding to the printed gene options. Nothing is authored: every edge reuses an already-grounded, spider+adversarially-gated fact. This is the first slice of the MLE-PASS harness \u2014 the multi-hop reasoning step past the single-hop recall rungs, toward board coverage.",
+  "items": [
+    {
+      "id": "mh-01",
+      "qtype": "multi_hop_recall",
+      "stem": "A patient has a white pupillary reflex (leukocoria). That finding points to a single disease; the disease is caused by a mutation in which gene?",
+      "hop1_lib": "ophtho-edges.adj",
+      "hop1_relation": "eye_finding_indicates",
+      "hop2_lib": "genetics-edges.adj",
+      "hop2_relation": "gene_defect",
+      "clue": "leukocoria",
+      "expected": "rb1",
+      "options": {
+        "A": "rb1",
+        "B": "atp7b",
+        "C": "fbn1",
+        "D": "htt",
+        "E": "col1a1"
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "mh-02",
+      "qtype": "multi_hop_recall",
+      "stem": "A patient has Kayser-Fleischer corneal rings. That finding points to a single disease; the disease is caused by a mutation in which gene?",
+      "hop1_lib": "ophtho-edges.adj",
+      "hop1_relation": "eye_finding_indicates",
+      "hop2_lib": "genetics-edges.adj",
+      "hop2_relation": "gene_defect",
+      "clue": "kayser_fleischer_rings",
+      "expected": "atp7b",
+      "options": {
+        "A": "rb1",
+        "B": "atp7b",
+        "C": "fbn1",
+        "D": "htt",
+        "E": "col1a1"
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "mh-03",
+      "qtype": "multi_hop_recall",
+      "stem": "A patient has upward (superior) lens dislocation. That finding points to a single disease; the disease is caused by a mutation in which gene?",
+      "hop1_lib": "ophtho-edges.adj",
+      "hop1_relation": "eye_finding_indicates",
+      "hop2_lib": "genetics-edges.adj",
+      "hop2_relation": "gene_defect",
+      "clue": "superior_lens_dislocation",
+      "expected": "fbn1",
+      "options": {
+        "A": "rb1",
+        "B": "atp7b",
+        "C": "fbn1",
+        "D": "htt",
+        "E": "col1a1"
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "mh-04",
+      "qtype": "multi_hop_recall",
+      "stem": "A patient has degeneration of the caudate nucleus. That finding points to a single disease; the disease is caused by a mutation in which gene?",
+      "hop1_lib": "neuro-edges.adj",
+      "hop1_relation": "lesion_causes",
+      "hop2_lib": "genetics-edges.adj",
+      "hop2_relation": "gene_defect",
+      "clue": "caudate_nucleus",
+      "expected": "htt",
+      "options": {
+        "A": "rb1",
+        "B": "atp7b",
+        "C": "fbn1",
+        "D": "htt",
+        "E": "col1a1"
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "mh-05",
+      "qtype": "multi_hop_recall",
+      "stem": "A patient has a defect in type I collagen. That finding points to a single disease; the disease is caused by a mutation in which gene?",
+      "hop1_lib": "collagen-defect-edges.adj",
+      "hop1_relation": "defect_causes",
+      "hop2_lib": "genetics-edges.adj",
+      "hop2_relation": "gene_defect",
+      "clue": "type_i",
+      "expected": "col1a1",
+      "options": {
+        "A": "rb1",
+        "B": "atp7b",
+        "C": "fbn1",
+        "D": "htt",
+        "E": "col1a1"
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "mh-06",
+      "qtype": "multi_hop_recall",
+      "stem": "A patient has deficiency of alpha-galactosidase A. That finding points to a single disease; the disease is caused by a mutation in which gene?",
+      "hop1_lib": "enzyme-deficiency-edges.adj",
+      "hop1_relation": "enzyme_deficiency_disease",
+      "hop2_lib": "genetics-edges.adj",
+      "hop2_relation": "gene_defect",
+      "clue": "alpha_galactosidase_a",
+      "expected": "gla",
+      "options": {
+        "A": "gla",
+        "B": "rb1",
+        "C": "atp7b",
+        "D": "fbn1",
+        "E": "htt"
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "mh-07",
+      "qtype": "multi_hop_recall",
+      "stem": "A patient has deficiency of glucocerebrosidase. That finding points to a single disease; the disease is caused by a mutation in which gene?",
+      "hop1_lib": "enzyme-deficiency-edges.adj",
+      "hop1_relation": "enzyme_deficiency_disease",
+      "hop2_lib": "genetics-edges.adj",
+      "hop2_relation": "gene_defect",
+      "clue": "glucocerebrosidase",
+      "expected": "gba1",
+      "options": {
+        "A": "rb1",
+        "B": "gba1",
+        "C": "atp7b",
+        "D": "fbn1",
+        "E": "htt"
+      },
+      "gold_letter": "B"
+    }
+  ]
+}

--- a/code/specs/data/mycin-2026/mle-pass/mle_pass_eval.py
+++ b/code/specs/data/mycin-2026/mle-pass/mle_pass_eval.py
@@ -1,0 +1,165 @@
+"""MLE-PASS multi-hop recall harness — score two-hop board questions answered purely on
+the CPU from grounded edges, with ZERO model calls.
+
+The reasoning step past single-hop recall: a board question like "leukocoria points to a
+disease caused by a mutation in which gene?" needs TWO grounded hops —
+  hop 1  clue → disease     (an organ-system recall library: ophtho / neuro / collagen / …)
+  hop 2  disease → gene     (the genetics library)
+joined on the shared disease. We express the join as an adj-lang **rule body** and let the
+engine's SLD resolver do it:
+
+    import "<hop1 library>"
+    import "genetics-edges.adj"
+    rule {
+        head: clue_to_gene($X, $G)
+        when: <hop1 relation>($X, $D), gene_defect($D, $G)
+    }
+    ? clue_to_gene(<clue>, $G)
+
+The engine returns the `$G` binding and — crucially — the citing clause of EACH hop, so a
+correct answer is defended by both spans (multi-hop byte-provenance). The harness reads the
+binding, maps it to the printed gene option, and scores correct / abstain / wrong. It never
+asks a model anything; all knowledge lives in the imported grounded libraries.
+
+Defensibility metric: `multihop_coverage` = fraction of CORRECT answers that cite BOTH hops
+(≥2 authoritative citing clauses). That is the number a future grounding PR moves, and the
+proof that the answer is a genuine two-hop derivation, not a one-edge coincidence.
+
+Import-root note: adj-lang forbids `..` in import paths (an import cannot escape its file's
+directory), so a query that imports the recall libraries must sit BESIDE them. The harness
+therefore assembles each run in a temp directory: it copies in the two needed `*-edges.adj`
+files and writes the query there with sibling imports, runs the CLI, then discards the temp
+dir — leaving the shipped recall/ library untouched.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+RECALL = HERE.parent / "recall"
+RUST = HERE.parents[3] / "packages" / "rust"
+
+
+def _find_cli() -> Path | None:
+    """Locate the adj-lang-cli binary (env override, then debug/release build dirs)."""
+    override = os.environ.get("ADJ_LANG_CLI")
+    if override and Path(override).exists():
+        return Path(override)
+    for cand in (RUST / "target" / "debug" / "adj-lang-cli",
+                 RUST / "target" / "release" / "adj-lang-cli"):
+        if cand.exists():
+            return cand
+    return None
+
+
+_CLI = _find_cli()
+
+
+def build_query(item: dict) -> str:
+    """The two-hop join program for one item: import both libraries, define the chaining
+    rule (hop1 relation × gene_defect, joined on the disease), and ask the binding query."""
+    return (
+        f'import "{item["hop1_lib"]}"\n'
+        f'import "{item["hop2_lib"]}"\n'
+        "rule {\n"
+        "    head: clue_to_gene($X, $G)\n"
+        f'    when: {item["hop1_relation"]}($X, $D), {item["hop2_relation"]}($D, $G)\n'
+        "}\n"
+        f'? clue_to_gene({item["clue"]}, $G)\n'
+    )
+
+
+@dataclass
+class RunResult:
+    binding: str | None       # the gene the engine bound (or None if it abstained)
+    citations: int            # number of citing clauses (≥2 ⇒ both hops defended)
+
+
+def run_item(item: dict, cli: Path | None = None) -> RunResult:
+    """Run one item's two-hop query through the engine in an isolated temp dir."""
+    cli = cli or _CLI
+    if cli is None:
+        raise RuntimeError("adj-lang-cli not built (cargo build -p adj-lang-cli)")
+    with tempfile.TemporaryDirectory() as td:
+        tdp = Path(td)
+        # Copy the two grounded libraries beside the query so sibling imports resolve.
+        # Each must be a BARE filename (no path separators / parent refs) — a structural
+        # guard so a library name can only ever name a file directly inside recall/, never
+        # path-traverse out of it, regardless of where items.json comes from.
+        for lib in (item["hop1_lib"], item["hop2_lib"]):
+            if "/" in lib or "\\" in lib or ".." in lib:
+                raise ValueError(f"library name must be a bare filename, got {lib!r}")
+            shutil.copy(RECALL / lib, tdp / lib)
+        query = tdp / "query.adj"
+        query.write_text(build_query(item))
+        out = subprocess.run([str(cli), str(query)], capture_output=True, text=True)
+    doc = json.loads(out.stdout)
+    recall = doc.get("recall") or []
+    if not recall or not recall[0].get("answers"):
+        return RunResult(binding=None, citations=0)
+    ans = recall[0]["answers"][0]
+    return RunResult(binding=ans["bindings"].get("G"), citations=len(ans.get("citations", [])))
+
+
+def letter_for(item: dict, gene: str | None) -> str | None:
+    """Map a bound gene to its printed option letter, or None if it is not an option."""
+    if gene is None:
+        return None
+    for letter, value in item["options"].items():
+        if value == gene:
+            return letter
+    return None
+
+
+def score(items: list[dict], cli: Path | None = None) -> dict:
+    """Run every item; return per-item outcomes and the aggregate scoreboard."""
+    results, correct, abstained, wrong, both_hops = [], 0, 0, 0, 0
+    for item in items:
+        r = run_item(item, cli=cli)
+        picked = letter_for(item, r.binding)
+        if picked is None:
+            outcome = "abstained"
+            abstained += 1
+        elif picked == item["gold_letter"]:
+            outcome = "correct"
+            correct += 1
+            if r.citations >= 2:
+                both_hops += 1
+        else:
+            outcome = "wrong"
+            wrong += 1
+        results.append({
+            "id": item["id"], "outcome": outcome, "picked": picked,
+            "binding": r.binding, "citations": r.citations,
+        })
+    total = len(items)
+    return {
+        "total": total,
+        "correct": correct,
+        "abstained": abstained,
+        "wrong": wrong,
+        # defensibility: of the correct answers, how many cite BOTH grounded hops.
+        "multihop_coverage": (both_hops / correct) if correct else 0.0,
+        "results": results,
+    }
+
+
+def load_items(path: Path | None = None) -> list[dict]:
+    path = path or (HERE / "items.json")
+    return json.loads(path.read_text())["items"]
+
+
+if __name__ == "__main__":
+    if _CLI is None:
+        raise SystemExit("adj-lang-cli not built — run: cargo build -p adj-lang-cli")
+    board = score(load_items())
+    print(json.dumps({k: v for k, v in board.items() if k != "results"}, indent=2))
+    for r in board["results"]:
+        print(f"  {r['id']}: {r['outcome']:9} picked={r['picked']} "
+              f"binding={r['binding']} hops_cited={r['citations']}")

--- a/code/specs/data/mycin-2026/mle-pass/test_mle_pass.py
+++ b/code/specs/data/mycin-2026/mle-pass/test_mle_pass.py
@@ -1,0 +1,62 @@
+"""Gates for the MLE-PASS multi-hop recall harness.
+
+These prove the two-hop reasoning is REAL and grounded: the engine binds the gold gene
+for every item, each answer cites BOTH hops (multi-hop byte-provenance), the run makes zero
+model calls, and an unknown clue abstains rather than fabricates. The CLI-backed tests skip
+cleanly when adj-lang-cli is not built (e.g. a docs-only CI shard)."""
+from pathlib import Path
+
+import pytest
+
+import mle_pass_eval as mp
+
+HERE = Path(__file__).resolve().parent
+
+
+def test_items_bank_is_well_formed():
+    items = mp.load_items()
+    assert len(items) >= 7
+    seen = set()
+    for it in items:
+        assert it["id"] not in seen, f"duplicate id {it['id']}"
+        seen.add(it["id"])
+        # five distinct options, gold present, expected gene is the gold option's value
+        assert len(it["options"]) == 5
+        assert len(set(it["options"].values())) == 5, it["id"]
+        assert it["gold_letter"] in it["options"], it["id"]
+        assert it["options"][it["gold_letter"]] == it["expected"], it["id"]
+        # query is a genuine two-hop join (rule body chains hop1 × gene_defect)
+        q = mp.build_query(it)
+        assert it["hop1_relation"] in q and "gene_defect" in q
+        assert "$D" in q  # the shared join variable
+
+
+def test_build_query_shape():
+    item = mp.load_items()[0]
+    q = mp.build_query(item)
+    assert q.count("import ") == 2          # both grounded libraries
+    assert "rule {" in q and "when:" in q   # the joining rule body
+    assert q.strip().endswith("$G)")        # the binding query
+
+
+@pytest.mark.skipif(mp._CLI is None, reason="adj-lang-cli not built")
+def test_engine_solves_every_item_with_both_hops_cited():
+    board = mp.score(mp.load_items())
+    # Every item answered correctly, none wrong, none abstained.
+    assert board["wrong"] == 0, board["results"]
+    assert board["abstained"] == 0, board["results"]
+    assert board["correct"] == board["total"]
+    # Every correct answer is defended by BOTH grounded hops (≥2 citing clauses).
+    assert board["multihop_coverage"] == 1.0, board["results"]
+    for r in board["results"]:
+        assert r["citations"] >= 2, r
+
+
+@pytest.mark.skipif(mp._CLI is None, reason="adj-lang-cli not built")
+def test_unknown_clue_abstains_not_fabricates():
+    # A clue with no grounded hop-1 edge must bind nothing — never invent a gene.
+    bogus = dict(mp.load_items()[0])
+    bogus["clue"] = "a_finding_with_no_grounded_edge"
+    r = mp.run_item(bogus)
+    assert r.binding is None
+    assert mp.letter_for(bogus, r.binding) is None

--- a/code/specs/data/mycin-2026/recall/multihop-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/multihop-recall.query.adj
@@ -1,0 +1,47 @@
+% ============================================================================
+% multihop-recall.query.adj — worked TWO-HOP recall over the grounded libraries.
+% ============================================================================
+% The shape an LLM (or a clinician) produces to ANSWER a two-step board question like
+% "a patient has leukocoria — the disease it indicates is caused by a mutation in which
+% gene?". It states no fact: it only `import`s grounded libraries and defines a chaining
+% RULE whose body joins two `relate` edges on the shared disease, then asks a binding
+% query. The native adj-lang engine resolves the join (SLD) and returns the gene binding
+% WITH the citing clause of EACH hop — so a two-hop answer is defended by two byte-stable
+% spans. All knowledge is in the imported libraries; none is here. (See MLE-PASS.md.)
+%
+% Run (from this directory so the sibling imports resolve):
+%     ../../../packages/rust/target/debug/adj-lang-cli multihop-recall.query.adj
+% ============================================================================
+
+import "ophtho-edges.adj"
+import "neuro-edges.adj"
+import "collagen-defect-edges.adj"
+import "enzyme-deficiency-edges.adj"
+import "genetics-edges.adj"
+
+% --- the chaining rules: clue -> disease -> gene, joined on the shared $D ---------------
+rule {
+    head: eye_finding_to_gene($F, $G)
+    when: eye_finding_indicates($F, $D), gene_defect($D, $G)
+}
+rule {
+    head: lesion_to_gene($S, $G)
+    when: lesion_causes($S, $D), gene_defect($D, $G)
+}
+rule {
+    head: collagen_defect_to_gene($T, $G)
+    when: defect_causes($T, $D), gene_defect($D, $G)
+}
+rule {
+    head: enzyme_deficiency_to_gene($E, $G)
+    when: enzyme_deficiency_disease($E, $D), gene_defect($D, $G)
+}
+
+% --- the two-hop binding queries (each returns the gene + both hops' provenance) --------
+? eye_finding_to_gene(leukocoria, $G)                  % expect rb1   (retinoblastoma)
+? eye_finding_to_gene(kayser_fleischer_rings, $G)      % expect atp7b (wilson_disease)
+? eye_finding_to_gene(superior_lens_dislocation, $G)   % expect fbn1  (marfan_syndrome)
+? lesion_to_gene(caudate_nucleus, $G)                  % expect htt   (huntington_disease)
+? collagen_defect_to_gene(type_i, $G)                  % expect col1a1 (osteogenesis_imperfecta)
+? enzyme_deficiency_to_gene(alpha_galactosidase_a, $G) % expect gla   (fabry_disease)
+? enzyme_deficiency_to_gene(glucocerebrosidase, $G)    % expect gba1  (gaucher_disease)


### PR DESCRIPTION
## What

First slice of the **MLE-PASS** harness — the reasoning step **past single-hop recall**. It answers **two-hop** board questions purely on the CPU from grounded edges, with **zero model calls**:

```
clue ──(hop 1)──▶ disease ──(hop 2)──▶ gene
  leukocoria ──▶ retinoblastoma ──▶ RB1
```

## The join is in-engine (rule-body SLD), not Python

adj-lang has no top-level conjunctive query, but a **rule body** takes comma-separated subgoals sharing a variable, so a two-hop question is one rule + one binding query — the engine's SLD resolver does the join on the shared disease:

```adj
import "ophtho-edges.adj"
import "genetics-edges.adj"
rule {
    head: clue_to_gene($X, $G)
    when: eye_finding_indicates($X, $D), gene_defect($D, $G)   % join on $D
}
? clue_to_gene(leukocoria, $G)   % → rb1, citing BOTH hops' spans
```

The engine returns the gene binding **and the citing clause of each hop** (the leukocoria→retinoblastoma span *and* the retinoblastoma→RB1 span) — so a correct answer is a defended two-hop derivation, not a one-edge coincidence.

## Nothing authored

Every chain reuses already-grounded, spider+adversarially-gated edges in [`../recall/`](code/specs/data/mycin-2026/recall) — this PR only arranges them into MCQs. First slice = **7 chains** over four hop-1 libraries joined to genetics: ophtho (leukocoria / Kayser-Fleischer rings / superior lens dislocation), neuro (caudate), collagen (type-I), enzyme-deficiency (α-galactosidase-A / glucocerebrosidase).

## Files (`code/specs/data/mycin-2026/mle-pass/`)

- `items.json` — the MCQ bank.
- `mle_pass_eval.py` — builds each two-hop query, runs `adj-lang-cli` (in a temp dir, since adj-lang imports may not escape their directory), maps the gene binding to the printed option, scores **correct / abstained / wrong** + **`multihop_coverage`** (fraction of correct answers citing BOTH hops). Library names guarded to bare filenames (no path traversal).
- `test_mle_pass.py` — gates: engine binds gold for every item; `multihop_coverage == 1.0`; an unknown clue **abstains**, never fabricates.
- `gen_items.py`; `../recall/multihop-recall.query.adj` (shipped worked artifact, runs in place).
- Spec: [`code/specs/MLE-PASS-multihop-recall.md`](code/specs/MLE-PASS-multihop-recall.md).

## Gates

- **7/7 correct, `multihop_coverage` 1.0, zero model calls**; 4 pytest pass; ruff clean; `/security-review` **PASSED**. mle-pass **0.1.0**.

The two-hop reasoning step toward board coverage — the join is CPU-bound (engine), the model does nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)