### PR TITLE
Add smart home audit sequence windows

### DIFF
--- a/code/packages/rust/smart-home-platform-http/CHANGELOG.md
+++ b/code/packages/rust/smart-home-platform-http/CHANGELOG.md
@@ -87,6 +87,8 @@ All notable changes to this package will be documented in this file.
   `received_at_or_before_ms`.
 - Added observed-time upper-bound filtering for state history with
   `observed_at_or_before_ms`.
+- Added sequence-window filtering for runtime event-log and command-result
+  audit routes with `to_sequence`.
 - Added fixture-controller launch help, smoke-test URLs, and example-level tests
   to keep the local controller startup path usable.
 - Added a machine-readable local-controller smoke plan route that lists safe

--- a/code/packages/rust/smart-home-platform-http/README.md
+++ b/code/packages/rust/smart-home-platform-http/README.md
@@ -135,6 +135,9 @@ State-history routes also accept numeric observed-time windows through
 period routes, and can scope runtime history to a single bridge through
 `bridge_id`. Runtime history can also be bounded by ingestion time with
 `received_at_or_after_ms` and `received_at_or_before_ms`.
+Runtime event-log and command-result audit routes accept sequence windows with
+`from_sequence` and `to_sequence`, allowing local-controller activity panels to
+reopen bounded replay slices without fetching the full audit tail.
 
 ## Dependencies
 

--- a/code/packages/rust/smart-home-platform-http/src/lib.rs
+++ b/code/packages/rust/smart-home-platform-http/src/lib.rs
@@ -2679,6 +2679,7 @@ const API_ROUTE_CATALOG: &[ApiRouteDescriptor] = &[
             "limit",
             "room_id",
             "sort",
+            "to_sequence",
         ],
     },
     ApiRouteDescriptor {
@@ -2706,6 +2707,7 @@ const API_ROUTE_CATALOG: &[ApiRouteDescriptor] = &[
             "room_id",
             "sort",
             "status",
+            "to_sequence",
         ],
     },
     ApiRouteDescriptor {
@@ -5593,6 +5595,9 @@ fn runtime_event_query(request: &WebRequest) -> Result<RuntimeEventQuery, ApiErr
             query_u64(request, "from_sequence")?.unwrap_or(0),
         ))
         .with_limit(query_limit(request, 50, 500)?);
+    if let Some(to_sequence) = query_u64(request, "to_sequence")? {
+        query = query.to_sequence(to_sequence);
+    }
 
     if query_string(request, "sort").is_some_and(|sort| sort == "desc") {
         query = query.sorted_by(RuntimeEventSort::SequenceDesc);
@@ -5622,6 +5627,9 @@ fn runtime_command_result_query(
         ))
         .sorted_by(RuntimeCommandResultSort::SequenceDesc)
         .with_limit(query_limit(request, 50, 500)?);
+    if let Some(to_sequence) = query_u64(request, "to_sequence")? {
+        query = query.to_sequence(to_sequence);
+    }
     if let Some(status) = query_string(request, "status") {
         query = query.with_status(command_status_from_label(status)?);
     }
@@ -8237,6 +8245,25 @@ mod tests {
             by_correlation_id.contains(&format!(r#""correlation_id":"{command_correlation_id}""#))
         );
 
+        let command_sequence_window = response_body(
+            app.handle(request(
+                "GET",
+                "/api/smart_home/command_results?from_sequence=0&to_sequence=0&limit=5",
+            ))
+            .into(),
+        );
+        assert!(command_sequence_window.contains(r#""total_results":1"#));
+        assert!(command_sequence_window.contains(r#""sequence":0"#));
+
+        let empty_command_sequence_window = response_body(
+            app.handle(request(
+                "GET",
+                "/api/smart_home/command_results?from_sequence=1&to_sequence=1&limit=5",
+            ))
+            .into(),
+        );
+        assert!(empty_command_sequence_window.contains(r#""total_results":0"#));
+
         let unknown_command = response_body(
             app.handle(request(
                 "GET",
@@ -8265,6 +8292,25 @@ mod tests {
         );
         assert!(events.contains(r#""command_results":1"#));
         assert!(events.contains(r#""kind":"command_result""#));
+
+        let event_sequence_window = response_body(
+            app.handle(request(
+                "GET",
+                "/api/smart_home/events?kind=commands&from_sequence=0&to_sequence=0&limit=5",
+            ))
+            .into(),
+        );
+        assert!(event_sequence_window.contains(r#""total_events":1"#));
+        assert!(event_sequence_window.contains(r#""sequence":0"#));
+
+        let empty_event_sequence_window = response_body(
+            app.handle(request(
+                "GET",
+                "/api/smart_home/events?kind=commands&from_sequence=1&to_sequence=1&limit=5",
+            ))
+            .into(),
+        );
+        assert!(empty_event_sequence_window.contains(r#""total_events":0"#));
 
         let missing_room_events = response_body(
             app.handle(request(
@@ -8575,10 +8621,10 @@ mod tests {
             r#""path":"/api/smart_home/states","category":"states","surface":"smart_home","mutates_runtime":false,"runtime_authorized":false,"query_params":["capability_id","confidence","domain","has_state","kind","limit","room_id","source","stale"]"#
         ));
         assert!(catalog.contains(
-            r#""path":"/api/smart_home/events","category":"events","surface":"smart_home","mutates_runtime":false,"runtime_authorized":false,"query_params":["entity_id","from_sequence","kind","limit","room_id","sort"]"#
+            r#""path":"/api/smart_home/events","category":"events","surface":"smart_home","mutates_runtime":false,"runtime_authorized":false,"query_params":["entity_id","from_sequence","kind","limit","room_id","sort","to_sequence"]"#
         ));
         assert!(catalog.contains(
-            r#""path":"/api/smart_home/command_results","category":"command_results","surface":"smart_home","mutates_runtime":false,"runtime_authorized":false,"query_params":["bridge_id","command_id","correlation_id","from_sequence","limit","room_id","sort","status"]"#
+            r#""path":"/api/smart_home/command_results","category":"command_results","surface":"smart_home","mutates_runtime":false,"runtime_authorized":false,"query_params":["bridge_id","command_id","correlation_id","from_sequence","limit","room_id","sort","status","to_sequence"]"#
         ));
         assert!(catalog.contains(
             r#""path":"/api/smart_home/capability_grants","category":"authorization","surface":"smart_home","mutates_runtime":false,"runtime_authorized":false,"query_params":["capability_id","entity_id","limit","principal_id","scope","sort","status"]"#

--- a/code/packages/rust/smart-home-runtime/CHANGELOG.md
+++ b/code/packages/rust/smart-home-runtime/CHANGELOG.md
@@ -18,6 +18,8 @@ All notable changes to this package will be documented in this file.
 - `RuntimeCommandResultQuery`, `RuntimeCommandResultRecord`, and
   `RuntimeCommandResultSummary` plus authorized read-tool variants for typed
   command-result audit views over runtime event history.
+- Upper sequence bounds on runtime event-log and command-result queries for
+  bounded replay/audit windows.
 - `RuntimeSubscriptionInventorySummary` plus `subscription_inventory_summary()`
   for compact event-stream filter coverage and backlog pressure checks.
 - `RuntimeEventBusHealthSummary` plus event-bus/runtime helpers for composed

--- a/code/packages/rust/smart-home-runtime/src/lib.rs
+++ b/code/packages/rust/smart-home-runtime/src/lib.rs
@@ -416,6 +416,11 @@ impl RuntimeEventBus {
             .iter()
             .enumerate()
             .skip(start)
+            .filter(|(index, _)| {
+                query
+                    .to_sequence
+                    .is_none_or(|to_sequence| *index as u64 <= to_sequence)
+            })
             .filter(|(_, event)| {
                 query
                     .filter
@@ -926,6 +931,7 @@ pub struct RuntimeCommandResultQuery {
     pub correlation_id: Option<CorrelationId>,
     pub statuses: Vec<CommandStatus>,
     pub from_checkpoint: RuntimeEventCheckpoint,
+    pub to_sequence: Option<u64>,
     pub sort: RuntimeCommandResultSort,
     pub limit: Option<usize>,
 }
@@ -960,6 +966,11 @@ impl RuntimeCommandResultQuery {
         self
     }
 
+    pub fn to_sequence(mut self, sequence: u64) -> Self {
+        self.to_sequence = Some(sequence);
+        self
+    }
+
     pub fn sorted_by(mut self, sort: RuntimeCommandResultSort) -> Self {
         self.sort = sort;
         self
@@ -979,6 +990,7 @@ impl Default for RuntimeCommandResultQuery {
             correlation_id: None,
             statuses: Vec::new(),
             from_checkpoint: RuntimeEventCheckpoint::start(),
+            to_sequence: None,
             sort: RuntimeCommandResultSort::default(),
             limit: None,
         }
@@ -1091,6 +1103,7 @@ impl RuntimeCommandResultSummary {
 pub struct RuntimeEventQuery {
     pub filter: Option<RuntimeEventFilter>,
     pub from_checkpoint: RuntimeEventCheckpoint,
+    pub to_sequence: Option<u64>,
     pub sort: RuntimeEventSort,
     pub limit: Option<usize>,
 }
@@ -1110,6 +1123,11 @@ impl RuntimeEventQuery {
         self
     }
 
+    pub fn to_sequence(mut self, sequence: u64) -> Self {
+        self.to_sequence = Some(sequence);
+        self
+    }
+
     pub fn sorted_by(mut self, sort: RuntimeEventSort) -> Self {
         self.sort = sort;
         self
@@ -1126,6 +1144,7 @@ impl Default for RuntimeEventQuery {
         Self {
             filter: None,
             from_checkpoint: RuntimeEventCheckpoint::start(),
+            to_sequence: None,
             sort: RuntimeEventSort::default(),
             limit: None,
         }
@@ -4518,9 +4537,12 @@ impl SmartHomeRuntime {
             return Vec::new();
         }
 
-        let event_query = RuntimeEventQuery::new()
+        let mut event_query = RuntimeEventQuery::new()
             .matching(RuntimeEventFilter::Commands)
             .from_checkpoint(query.from_checkpoint);
+        if let Some(sequence) = query.to_sequence {
+            event_query = event_query.to_sequence(sequence);
+        }
         let mut results = self
             .event_bus
             .query_events(&event_query)
@@ -6906,6 +6928,18 @@ mod tests {
         assert_eq!(newest_bridge_events[0].sequence, 2);
         assert_eq!(newest_bridge_events[0].next_checkpoint.next_sequence(), 3);
 
+        let early_events = bus.query_events(&RuntimeEventQuery::new().to_sequence(1));
+        assert_eq!(early_events.len(), 2);
+        assert_eq!(early_events[0].sequence, 0);
+        assert_eq!(early_events[1].sequence, 1);
+
+        let empty_window = bus.query_events(
+            &RuntimeEventQuery::new()
+                .from_checkpoint(RuntimeEventCheckpoint::from_next_sequence(2))
+                .to_sequence(1),
+        );
+        assert!(empty_window.is_empty());
+
         let backlogs = bus.query_subscriptions(
             &RuntimeSubscriptionQuery::new()
                 .matching(bridge_one)
@@ -6980,6 +7014,15 @@ mod tests {
             RuntimeEventCheckpoint::from_next_sequence(6)
         );
 
+        let early_summary = bus.event_log_summary(&RuntimeEventQuery::new().to_sequence(2));
+        assert_eq!(early_summary.total_events, 3);
+        assert_eq!(early_summary.first_sequence, Some(0));
+        assert_eq!(early_summary.latest_sequence, Some(2));
+        assert_eq!(
+            early_summary.next_checkpoint,
+            RuntimeEventCheckpoint::from_next_sequence(3)
+        );
+
         let empty = bus.event_log_summary(&RuntimeEventQuery::new().with_limit(0));
         assert_eq!(empty, RuntimeEventLogSummary::empty());
         assert!(!empty.has_events());
@@ -7022,6 +7065,22 @@ mod tests {
             newest_failure[0].result.command_id,
             CommandId::trusted("cmd-failed")
         );
+
+        let first_result =
+            runtime.query_command_results(&RuntimeCommandResultQuery::new().to_sequence(0));
+        assert_eq!(first_result.len(), 1);
+        assert_eq!(first_result[0].sequence, 0);
+        assert_eq!(
+            first_result[0].result.command_id,
+            CommandId::trusted("cmd-accepted")
+        );
+
+        let empty_window = runtime.query_command_results(
+            &RuntimeCommandResultQuery::new()
+                .from_checkpoint(RuntimeEventCheckpoint::from_next_sequence(1))
+                .to_sequence(0),
+        );
+        assert!(empty_window.is_empty());
 
         let summary = runtime.command_result_summary(
             &RuntimeCommandResultQuery::new()


### PR DESCRIPTION
## Summary
- add shared runtime upper sequence bounds for event-log and command-result queries
- expose to_sequence on /api/smart_home/events and /api/smart_home/command_results
- cover bounded and empty sequence windows in runtime and HTTP tests

## Validation
- cargo fmt -p smart-home-runtime -p smart-home-platform-http
- cargo test -p smart-home-runtime -- --nocapture
- cargo test -p smart-home-platform-http -- --nocapture
- sh BUILD (code/packages/rust/smart-home-platform-http)
- sh BUILD (code/packages/rust/smart-home-runtime)
- git diff --check
- test ! -e code/packages/rust/Cargo.lock