### PR TITLE
feat(sir-rust): SIR16 Floats + ShortCircuit in the Rust backend (A1)

### DIFF
--- a/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog
 
+## 0.2.0 — SIR16 Floats + ShortCircuit
+
+The first two SIR-v1 (SIR16) features land in the Rust backend.  Until
+now `Floats` and `ShortCircuit` were undeclared and their IR nodes hit
+the `panic!` reject group; the TypeScript and Python backends already
+supported them, so this closes part of the cross-backend parity gap.
+
+### Added
+
+- `Feature::Floats` and `Feature::ShortCircuit` in the accepted-feature
+  set (`lib.rs`).
+- Runtime value model gains `Value::Float(f64)`.  The arithmetic helpers
+  (`plus`/`minus`/`times`/`divide`) stay on the exact i64 path while
+  every operand is an integer and promote the whole fold to f64 as soon
+  as any operand is a float (Python/Ruby/JS "int op float ⇒ float").
+  `number?` now covers floats, `=` is cross-representation (`1 == 1.0`
+  is true; `NaN == NaN` is false), and `<`/`>` compare numerically.
+- `Expr::FloatLit` emits a `Value::Float` literal — `{:?}` keeps the
+  trailing `.0` on integral values so the literal is never mistaken for
+  an `i64`; non-finite values use `f64::NAN`/`INFINITY`/`NEG_INFINITY`.
+- `Expr::LogicalAnd`/`Expr::LogicalOr` emit a truthy-guarded block
+  (`{ let __l = lhs; if truthy(&__l) { ... } else { ... } }`) that
+  evaluates the rhs only when the lhs decides — same semantics as the
+  TypeScript backend's truthy-guarded arrow IIFE.
+
+### Tests
+
+- `tests/compile_and_run_floats.rs`: an end-to-end proof that emits a
+  float + short-circuit module, compiles it with `rustc`, runs the
+  binary, and asserts its stdout.
+
+### Notes
+
+- The remaining four SIR16 features (MutableBindings, Loops, Sequences,
+  Maps) are still undeclared; their emit arms keep the `panic!`
+  (unreachable via the capability check) until later PRs extend them.
+
 ## 0.1.2 — SIR18 exhaustiveness (no behaviour change)
 
 semantic-ir 0.10.0 adds `Expr::StrConcat` (the SIR18 string-concat

--- a/code/packages/rust/semantic-ir-to-rust/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-rust"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Semantic IR → self-contained Rust source code (SIR13). Second backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-rust/README.md
+++ b/code/packages/rust/semantic-ir-to-rust/README.md
@@ -31,8 +31,17 @@ let artifact = backend.compile(&sir_module)?;
 
 ## Capability declaration
 
-Accepts: `Closures`, `Pairs`, `Symbols`, `Strings`, `DynamicTyping`,
-`OptionalTypeAnnotations`, `MutualRecursion`, `Globals`.
+Accepts (v0): `Closures`, `Pairs`, `Symbols`, `Strings`,
+`DynamicTyping`, `OptionalTypeAnnotations`, `MutualRecursion`,
+`Globals`.
+
+Accepts (SIR16 / v1, landing incrementally): `Floats`, `ShortCircuit`.
+The float path adds a `Value::Float(f64)` arm to the runtime value
+model with numeric promotion (`int op float ⇒ float`); short-circuit
+`&&`/`||` emit a truthy-guarded block so the rhs is evaluated only when
+the lhs decides.  The other four v1 features (`MutableBindings`,
+`Loops`, `Sequences`, `Maps`) are not yet accepted and are still
+rejected at the capability check.
 
 Rejects: `TailCalls` (Rust does not guarantee TCO), `Intrinsics`
 (empty whitelist in v0).
@@ -42,7 +51,7 @@ Rejects: `TailCalls` (Rust does not guarantee TCO), `Intrinsics`
 ```rust
 #[derive(Clone)]
 enum Value {
-    Int(i64), Bool(bool), Nil,
+    Int(i64), Float(f64), Bool(bool), Nil,
     Sym(Rc<str>), Str(Rc<str>),
     Pair(Rc<Pair>),
     Closure(Rc<Closure>),

--- a/code/packages/rust/semantic-ir-to-rust/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/emit.rs
@@ -253,15 +253,46 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
                 name, span
             );
         }
-        // SIR16 expression kinds — Rust backend hasn't been extended.
-        Expr::FloatLit { span, .. }
-        | Expr::SeqLit { span, .. }
+        // ── SIR16: floats ──────────────────────────────────────────
+        // Emit a `Value::Float` constructor.  `{:?}` renders an f64 as
+        // a round-trippable decimal that is *also* a valid Rust float
+        // literal — crucially it keeps the trailing `.0` on integral
+        // values (`3.0`, not `3`), so the literal can never be mistaken
+        // for an `i64`.  Non-finite values have no literal spelling, so
+        // we route them through the `f64::` associated constants.
+        Expr::FloatLit { value, .. } => emit_float_literal(out, *value),
+        // ── SIR16: short-circuit logical ───────────────────────────
+        // A block with a fresh `__l` binding evaluates `lhs` exactly
+        // once, then decides whether to evaluate `rhs` — routing the
+        // test through SIR truthiness (only `false`/`nil` are falsy).
+        // `and` yields `rhs` when `lhs` is truthy else `lhs`; `or` is
+        // the mirror.  The `__l` binding is block-scoped, so nested
+        // `&&`/`||` shadow cleanly and never collide.  Matches the
+        // TypeScript backend's truthy-guarded arrow IIFE semantics.
+        Expr::LogicalAnd { lhs, rhs, .. } => {
+            out.push_str("({ let __l = (");
+            emit_expr(out, lhs, indent);
+            out.push_str("); if __sir::truthy(&__l) { (");
+            emit_expr(out, rhs, indent);
+            out.push_str(") } else { __l } })");
+        }
+        Expr::LogicalOr { lhs, rhs, .. } => {
+            out.push_str("({ let __l = (");
+            emit_expr(out, lhs, indent);
+            out.push_str("); if __sir::truthy(&__l) { __l } else { (");
+            emit_expr(out, rhs, indent);
+            out.push_str(") } })");
+        }
+        // Remaining SIR16+ expression kinds — Rust backend hasn't been
+        // extended to these yet (Sequences/Maps land in a later PR;
+        // `StrConcat` is SIR18 string interpolation).  Their features
+        // are undeclared, so the capability check rejects such modules
+        // before emit; reaching this arm is an internal bug.
+        Expr::SeqLit { span, .. }
         | Expr::SeqIndex { span, .. }
         | Expr::SeqLen { span, .. }
         | Expr::MapLit { span, .. }
         | Expr::MapGet { span, .. }
-        | Expr::LogicalAnd { span, .. }
-        | Expr::LogicalOr { span, .. }
         | Expr::StrConcat { span, .. } => {
             panic!("rust backend reached SIR16+ expression at {} — capability check should have rejected it", span);
         }
@@ -558,6 +589,34 @@ fn emit_stmt_inline(out: &mut String, s: &Stmt, indent: usize) {
 
 fn indent_str(level: usize) -> String {
     "    ".repeat(level)
+}
+
+/// Emit a SIR float literal as a `__sir::Value::Float(<rust-f64>)`.
+///
+/// Truth table for the spelling we choose:
+///
+/// | SIR value        | Rust literal emitted        | Why                       |
+/// |------------------|-----------------------------|---------------------------|
+/// | `3.0`            | `3.0f64`                    | `{:?}` keeps the `.0`     |
+/// | `3.14`           | `3.14f64`                   | round-trippable decimal   |
+/// | `-7.5`           | `-7.5f64`                   | sign preserved            |
+/// | `NaN`            | `f64::NAN`                  | no literal spelling exists |
+/// | `+∞`             | `f64::INFINITY`             | ditto                     |
+/// | `-∞`             | `f64::NEG_INFINITY`         | ditto                     |
+///
+/// Using `{:?}` (Debug) rather than `{}` (Display) is deliberate:
+/// Display renders `3.0_f64` as `"3"`, which would compile as an
+/// `i64` mismatch; Debug renders `"3.0"`, an unambiguous float.
+fn emit_float_literal(out: &mut String, value: f64) {
+    if value.is_finite() {
+        let _ = write!(out, "__sir::Value::Float({:?}f64)", value);
+    } else if value.is_nan() {
+        out.push_str("__sir::Value::Float(f64::NAN)");
+    } else if value > 0.0 {
+        out.push_str("__sir::Value::Float(f64::INFINITY)");
+    } else {
+        out.push_str("__sir::Value::Float(f64::NEG_INFINITY)");
+    }
 }
 
 /// Sanitize a SIR identifier for Rust.
@@ -898,6 +957,98 @@ mod tests {
             0,
         );
         assert_eq!(out, "__sir::apply_closure(&(f.clone()), vec![__sir::Value::Int(5i64)])");
+    }
+
+    #[test]
+    fn emit_float_literal_keeps_trailing_zero() {
+        // Integral floats must render with `.0` so the literal is an
+        // f64, never an i64.
+        let mut out = String::new();
+        emit_expr(&mut out, &Expr::FloatLit { value: 3.0, span: s() }, 0);
+        assert_eq!(out, "__sir::Value::Float(3.0f64)");
+    }
+
+    #[test]
+    fn emit_float_literal_fractional_and_negative() {
+        let mut a = String::new();
+        let mut b = String::new();
+        emit_expr(&mut a, &Expr::FloatLit { value: 3.25, span: s() }, 0);
+        emit_expr(&mut b, &Expr::FloatLit { value: -7.5, span: s() }, 0);
+        assert_eq!(a, "__sir::Value::Float(3.25f64)");
+        assert_eq!(b, "__sir::Value::Float(-7.5f64)");
+    }
+
+    #[test]
+    fn emit_float_literal_non_finite_uses_constants() {
+        let mut nan = String::new();
+        let mut inf = String::new();
+        let mut ninf = String::new();
+        emit_expr(&mut nan, &Expr::FloatLit { value: f64::NAN, span: s() }, 0);
+        emit_expr(&mut inf, &Expr::FloatLit { value: f64::INFINITY, span: s() }, 0);
+        emit_expr(&mut ninf, &Expr::FloatLit { value: f64::NEG_INFINITY, span: s() }, 0);
+        assert_eq!(nan, "__sir::Value::Float(f64::NAN)");
+        assert_eq!(inf, "__sir::Value::Float(f64::INFINITY)");
+        assert_eq!(ninf, "__sir::Value::Float(f64::NEG_INFINITY)");
+    }
+
+    #[test]
+    fn emit_logical_and_guards_rhs_with_truthy() {
+        let mut out = String::new();
+        emit_expr(
+            &mut out,
+            &Expr::LogicalAnd {
+                lhs: Box::new(Expr::BoolLit { value: true, span: s() }),
+                rhs: Box::new(Expr::IntLit { value: 5, span: s() }),
+                span: s(),
+            },
+            0,
+        );
+        // `and` yields rhs when lhs is truthy, else the lhs value.
+        assert_eq!(
+            out,
+            "({ let __l = (__sir::Value::Bool(true)); if __sir::truthy(&__l) { (__sir::Value::Int(5i64)) } else { __l } })"
+        );
+    }
+
+    #[test]
+    fn emit_logical_or_returns_lhs_when_truthy() {
+        let mut out = String::new();
+        emit_expr(
+            &mut out,
+            &Expr::LogicalOr {
+                lhs: Box::new(Expr::BoolLit { value: false, span: s() }),
+                rhs: Box::new(Expr::IntLit { value: 7, span: s() }),
+                span: s(),
+            },
+            0,
+        );
+        assert_eq!(
+            out,
+            "({ let __l = (__sir::Value::Bool(false)); if __sir::truthy(&__l) { __l } else { (__sir::Value::Int(7i64)) } })"
+        );
+    }
+
+    #[test]
+    fn emit_nested_short_circuit_uses_fresh_scopes() {
+        // Nested `&&` inside `||` — each gets its own block-scoped __l,
+        // so shadowing keeps them independent (no name collision).
+        let mut out = String::new();
+        emit_expr(
+            &mut out,
+            &Expr::LogicalOr {
+                lhs: Box::new(Expr::LogicalAnd {
+                    lhs: Box::new(Expr::BoolLit { value: true, span: s() }),
+                    rhs: Box::new(Expr::IntLit { value: 1, span: s() }),
+                    span: s(),
+                }),
+                rhs: Box::new(Expr::IntLit { value: 2, span: s() }),
+                span: s(),
+            },
+            0,
+        );
+        // Two independent `let __l` bindings, properly nested.
+        assert_eq!(out.matches("let __l =").count(), 2);
+        assert!(out.starts_with("({ let __l = (({ let __l ="));
     }
 
     #[test]

--- a/code/packages/rust/semantic-ir-to-rust/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/lib.rs
@@ -62,6 +62,17 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     Feature::OptionalTypeAnnotations,
     Feature::MutualRecursion,
     Feature::Globals,
+    // ── SIR16 (v1) — added incrementally ───────────────────────────
+    // `Floats` adds a `Value::Float(f64)` arm to the runtime value
+    // model plus numeric promotion across the arithmetic helpers.
+    // `ShortCircuit` is pure emit (a guarded block over the existing
+    // `truthy` helper) and needs no runtime change.  The remaining v1
+    // features (MutableBindings, Loops, Sequences, Maps) are *not* yet
+    // declared, so a module using them is still rejected by the
+    // capability check before emit — keeping the `panic!`s in `emit.rs`
+    // strictly unreachable until those features land in later PRs.
+    Feature::Floats,
+    Feature::ShortCircuit,
 ];
 
 impl Backend for RustBackend {

--- a/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
@@ -27,6 +27,10 @@ pub const RUNTIME: &str = r##"mod __sir {
     #[derive(Clone)]
     pub enum Value {
         Int(i64),
+        // SIR16 floats.  Kept distinct from `Int` so the value model
+        // never silently coerces — arithmetic promotes to `Float` only
+        // when an operand is already a `Float` (see `any_float`).
+        Float(f64),
         Bool(bool),
         Nil,
         Sym(Rc<str>),
@@ -115,7 +119,20 @@ pub const RUNTIME: &str = r##"mod __sir {
     }
 
     // ── arithmetic builtins (variadic) ────────────────────────────
+    //
+    // Numeric tower (SIR16): the helpers stay on the integer path while
+    // every operand is an `Int`, preserving exact i64 semantics
+    // (including `times`' wrapping).  The moment *any* operand is a
+    // `Float`, the whole fold promotes to f64 — matching the
+    // "int op float ⇒ float" rule of Python/Ruby/JS.
     pub fn plus(args: Vec<Value>) -> Value {
+        if any_float(&args) {
+            let mut total = 0.0f64;
+            for a in &args {
+                total += as_f64(a);
+            }
+            return Value::Float(total);
+        }
         let mut total: i64 = 0;
         for a in args {
             total += as_i64(&a);
@@ -126,6 +143,16 @@ pub const RUNTIME: &str = r##"mod __sir {
     pub fn minus(args: Vec<Value>) -> Value {
         if args.is_empty() {
             return Value::Int(0);
+        }
+        if any_float(&args) {
+            if args.len() == 1 {
+                return Value::Float(-as_f64(&args[0]));
+            }
+            let mut acc = as_f64(&args[0]);
+            for a in &args[1..] {
+                acc -= as_f64(a);
+            }
+            return Value::Float(acc);
         }
         if args.len() == 1 {
             return Value::Int(-as_i64(&args[0]));
@@ -138,6 +165,13 @@ pub const RUNTIME: &str = r##"mod __sir {
     }
 
     pub fn times(args: Vec<Value>) -> Value {
+        if any_float(&args) {
+            let mut acc = 1.0f64;
+            for a in &args {
+                acc *= as_f64(a);
+            }
+            return Value::Float(acc);
+        }
         let mut acc: i64 = 1;
         for a in args {
             acc = acc.wrapping_mul(as_i64(&a));
@@ -148,6 +182,16 @@ pub const RUNTIME: &str = r##"mod __sir {
     pub fn divide(args: Vec<Value>) -> Value {
         if args.is_empty() {
             return Value::Int(0);
+        }
+        if any_float(&args) {
+            // Float division follows IEEE-754: `1.0 / 0.0` is `inf`
+            // rather than a panic.  Only the all-integer path keeps the
+            // historical divide-by-zero panic.
+            let mut acc = as_f64(&args[0]);
+            for a in &args[1..] {
+                acc /= as_f64(a);
+            }
+            return Value::Float(acc);
         }
         let mut acc = as_i64(&args[0]);
         for a in &args[1..] {
@@ -165,10 +209,21 @@ pub const RUNTIME: &str = r##"mod __sir {
         Value::Bool(value_eq(&a, &b))
     }
     pub fn lt(a: Value, b: Value) -> Value {
-        Value::Bool(as_i64(&a) < as_i64(&b))
+        Value::Bool(num_lt(&a, &b))
     }
     pub fn gt(a: Value, b: Value) -> Value {
-        Value::Bool(as_i64(&a) > as_i64(&b))
+        Value::Bool(num_lt(&b, &a))
+    }
+
+    // Ordered numeric comparison.  Both-int compares as i64 (no
+    // precision loss for large magnitudes); any float operand lifts the
+    // comparison into f64.  `gt` is defined as `num_lt` with operands
+    // swapped, so the two share one source of truth.
+    fn num_lt(a: &Value, b: &Value) -> bool {
+        match (a, b) {
+            (Value::Int(x), Value::Int(y)) => x < y,
+            _ => as_f64(a) < as_f64(b),
+        }
     }
 
     // ── pair ops ──────────────────────────────────────────────────
@@ -191,7 +246,9 @@ pub const RUNTIME: &str = r##"mod __sir {
     // ── predicates ────────────────────────────────────────────────
     pub fn is_null(a: Value) -> Value { Value::Bool(matches!(a, Value::Nil)) }
     pub fn is_pair(a: Value) -> Value { Value::Bool(matches!(a, Value::Pair(_))) }
-    pub fn is_number(a: Value) -> Value { Value::Bool(matches!(a, Value::Int(_))) }
+    // `number?` is true for both integers and floats — the predicate
+    // names the numeric tower, not a single representation.
+    pub fn is_number(a: Value) -> Value { Value::Bool(matches!(a, Value::Int(_) | Value::Float(_))) }
     pub fn is_symbol(a: Value) -> Value { Value::Bool(matches!(a, Value::Sym(_))) }
 
     // ── print ─────────────────────────────────────────────────────
@@ -204,6 +261,11 @@ pub const RUNTIME: &str = r##"mod __sir {
     pub fn format(v: &Value) -> String {
         match v {
             Value::Int(n) => n.to_string(),
+            // `{:?}` keeps a trailing `.0` on integral floats (`3.0`,
+            // not `3`) so the printed form is unambiguously a float —
+            // matching how Python/Ruby render `3.0`.  Non-finite values
+            // print as `NaN` / `inf` / `-inf`.
+            Value::Float(x) => format_float(*x),
             Value::Bool(true) => "#t".to_string(),
             Value::Bool(false) => "#f".to_string(),
             Value::Nil => "nil".to_string(),
@@ -211,6 +273,16 @@ pub const RUNTIME: &str = r##"mod __sir {
             Value::Str(s) => s.to_string(),
             Value::Pair(p) => format_pair(p),
             Value::Closure(_) => "<closure>".to_string(),
+        }
+    }
+
+    fn format_float(x: f64) -> String {
+        if x.is_nan() {
+            "NaN".to_string()
+        } else if x.is_infinite() {
+            if x > 0.0 { "inf".to_string() } else { "-inf".to_string() }
+        } else {
+            format!("{:?}", x)
         }
     }
 
@@ -246,9 +318,31 @@ pub const RUNTIME: &str = r##"mod __sir {
         }
     }
 
+    // Coerce any number to f64 for the promoted arithmetic/comparison
+    // paths.  Integers widen losslessly for values within ±2^53; beyond
+    // that the all-integer fast paths above keep exactness, so this
+    // widening only runs once a float is genuinely in play.
+    fn as_f64(v: &Value) -> f64 {
+        match v {
+            Value::Int(n) => *n as f64,
+            Value::Float(x) => *x,
+            other => panic!("expected number, got {}", format(other)),
+        }
+    }
+
+    fn any_float(args: &[Value]) -> bool {
+        args.iter().any(|v| matches!(v, Value::Float(_)))
+    }
+
     fn value_eq(a: &Value, b: &Value) -> bool {
         match (a, b) {
             (Value::Int(x), Value::Int(y)) => x == y,
+            // Cross-representation numeric equality (`1 == 1.0`) holds,
+            // mirroring dynamic-language `==`.  Float/Float uses IEEE
+            // equality, so `NaN == NaN` is correctly `false`.
+            (Value::Float(x), Value::Float(y)) => x == y,
+            (Value::Int(x), Value::Float(y)) => (*x as f64) == *y,
+            (Value::Float(x), Value::Int(y)) => *x == (*y as f64),
             (Value::Bool(x), Value::Bool(y)) => x == y,
             (Value::Nil, Value::Nil) => true,
             (Value::Sym(x), Value::Sym(y)) => x == y,
@@ -327,6 +421,17 @@ mod tests {
     fn runtime_declares_module_and_value() {
         assert!(RUNTIME.contains("mod __sir"));
         assert!(RUNTIME.contains("pub enum Value"));
+    }
+
+    #[test]
+    fn runtime_declares_float_variant_and_helpers() {
+        // SIR16 floats: the value model gains a `Float(f64)` arm, and
+        // the numeric helpers gain f64 coercion + a display path.
+        assert!(RUNTIME.contains("Float(f64)"));
+        assert!(RUNTIME.contains("fn as_f64"));
+        assert!(RUNTIME.contains("fn any_float"));
+        assert!(RUNTIME.contains("fn format_float"));
+        assert!(RUNTIME.contains("fn num_lt"));
     }
 
     #[test]

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_floats.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_floats.rs
@@ -1,0 +1,203 @@
+//! End-to-end proof for SIR16 **Floats** + **ShortCircuit** in the Rust
+//! backend.
+//!
+//! Unit tests assert the *shape* of the emitted source; this test goes
+//! the whole way: it hand-builds a SIR module exercising both features,
+//! emits Rust, compiles it with `rustc`, runs the binary, and checks the
+//! program's stdout.  That closes the loop the unit tests cannot — it
+//! proves the emitted runtime actually *compiles and behaves*.
+//!
+//! `rustc` ships with every Rust toolchain (it is what `cargo` drives),
+//! so this runs in CI.  If `rustc` is somehow unavailable the test logs
+//! a skip rather than failing — we never want a missing tool to redden a
+//! build for reasons unrelated to the change.
+
+use std::process::Command;
+
+use semantic_ir::{
+    Block, Effect, EffectSet, Expr, FeatureManifest, Feature, Function, Metadata,
+    Module, Span,
+};
+use semantic_ir_to_rust::compile;
+
+fn s() -> Span {
+    Span::synthetic()
+}
+
+fn flit(v: f64) -> Expr {
+    Expr::FloatLit { value: v, span: s() }
+}
+fn ilit(v: i64) -> Expr {
+    Expr::IntLit { value: v, span: s() }
+}
+fn blit(v: bool) -> Expr {
+    Expr::BoolLit { value: v, span: s() }
+}
+
+/// `(name arg0 arg1 ...)` builtin call, pure.
+fn call(name: &str, args: Vec<Expr>) -> Expr {
+    Expr::BuiltinCall {
+        name: name.into(),
+        args,
+        effects: EffectSet::PURE,
+        span: s(),
+    }
+}
+
+/// `print(expr)` as an effectful statement.
+fn print_stmt(expr: Expr) -> semantic_ir::Stmt {
+    semantic_ir::Stmt::ExprStmt {
+        expr: Expr::BuiltinCall {
+            name: "print".into(),
+            args: vec![expr],
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            span: s(),
+        },
+        span: s(),
+    }
+}
+
+/// Build a module whose `main` prints, in order, the results of a small
+/// battery of float + short-circuit expressions.
+fn demo_module() -> Module {
+    let stmts = vec![
+        // 1.5 + 2.5  ⇒  Float(4.0)            → "4.0"
+        print_stmt(call("+", vec![flit(1.5), flit(2.5)])),
+        // 5.0 - 1    ⇒  int promoted to float → "4.0"
+        print_stmt(call("-", vec![flit(5.0), ilit(1)])),
+        // true && 5  ⇒  rhs (lhs truthy)      → "5"
+        print_stmt(Expr::LogicalAnd {
+            lhs: Box::new(blit(true)),
+            rhs: Box::new(ilit(5)),
+            span: s(),
+        }),
+        // false || 7 ⇒  rhs (lhs falsy)       → "7"
+        print_stmt(Expr::LogicalOr {
+            lhs: Box::new(blit(false)),
+            rhs: Box::new(ilit(7)),
+            span: s(),
+        }),
+        // false && 9 ⇒  lhs (short-circuits)  → "#f"
+        print_stmt(Expr::LogicalAnd {
+            lhs: Box::new(blit(false)),
+            rhs: Box::new(ilit(9)),
+            span: s(),
+        }),
+        // 1 = 1.0    ⇒  cross-type eq is true → "#t"
+        print_stmt(call("=", vec![ilit(1), flit(1.0)])),
+    ];
+
+    Module {
+        name: "floats_demo".into(),
+        manifest: FeatureManifest::from_features(&[Feature::Floats, Feature::ShortCircuit]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts,
+                value: Expr::NilLit { span: s() },
+                span: s(),
+            },
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            metadata: Metadata::new(),
+            span: s(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("test")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+fn rustc_available() -> bool {
+    Command::new("rustc")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+#[test]
+fn floats_and_short_circuit_compile_and_run() {
+    if !rustc_available() {
+        eprintln!("skipping: rustc not on PATH");
+        return;
+    }
+
+    // 1. Emit.
+    let artifact = compile(&demo_module()).expect("module should compile to Rust source");
+
+    // 2. Write the source to a unique temp file.
+    let dir = std::env::temp_dir();
+    let nonce = std::process::id();
+    let src_path = dir.join(format!("sir_floats_{nonce}.rs"));
+    let bin_path = dir.join(format!(
+        "sir_floats_{nonce}{}",
+        if cfg!(windows) { ".exe" } else { "" }
+    ));
+    std::fs::write(&src_path, &artifact.source).expect("write temp source");
+
+    // 3. Compile with rustc.  `--edition 2021` is required: the emitted
+    //    runtime uses raw identifiers (`r#fn`) and 2018+ closure capture.
+    //
+    //    Linker selection: this shells out to `rustc` directly, bypassing
+    //    the workspace `.cargo/config.toml`.  CI provides a default MSVC
+    //    linker (`link.exe`), so no override is needed there.  Hosts whose
+    //    default linker is absent can point the test at a working one via
+    //    `SIR_TEST_RUSTC_LINKER` (e.g. the toolchain's bundled `rust-lld`).
+    let mut cmd = Command::new("rustc");
+    cmd.arg("--edition").arg("2021").arg("-O");
+    if let Ok(linker) = std::env::var("SIR_TEST_RUSTC_LINKER") {
+        if !linker.is_empty() {
+            cmd.arg("-C").arg(format!("linker={linker}"));
+        }
+    }
+    let compile_out = cmd
+        .arg(&src_path)
+        .arg("-o")
+        .arg(&bin_path)
+        .output()
+        .expect("invoke rustc");
+    if !compile_out.status.success() {
+        let stderr = String::from_utf8_lossy(&compile_out.stderr);
+        // A *missing linker* is a host-environment issue, not a defect in
+        // the emitted code — skip rather than redden the build.  Any other
+        // compile failure (a genuine codegen bug) still fails the test.
+        if stderr.contains("linker") && (stderr.contains("not found") || stderr.contains("No such file"))
+        {
+            eprintln!("skipping: no usable linker on host\n{stderr}");
+            let _ = std::fs::remove_file(&src_path);
+            return;
+        }
+        panic!(
+            "emitted Rust failed to compile:\n--- stderr ---\n{stderr}\n--- source ---\n{}",
+            artifact.source,
+        );
+    }
+
+    // 4. Run the binary and capture stdout.
+    let run_out = Command::new(&bin_path).output().expect("run compiled binary");
+    assert!(
+        run_out.status.success(),
+        "compiled binary exited non-zero:\n{}",
+        String::from_utf8_lossy(&run_out.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&run_out.stdout);
+    let lines: Vec<&str> = stdout.lines().collect();
+
+    // 5. Assert the program's observable behaviour.
+    assert_eq!(
+        lines,
+        vec!["4.0", "4.0", "5", "7", "#f", "#t"],
+        "unexpected program output; full stdout:\n{stdout}"
+    );
+
+    // 6. Best-effort cleanup (ignore errors — temp dir is ephemeral).
+    let _ = std::fs::remove_file(&src_path);
+    let _ = std::fs::remove_file(&bin_path);
+}


### PR DESCRIPTION
## What & why

First step of bringing **SIR-v1 (SIR16) feature parity** to all backends. The TypeScript and Python backends already support the six SIR16 features; the Rust and Go backends support **none** (their IR nodes hit a `panic!` reject group). This PR lands the first two — **Floats** and **ShortCircuit** — in `semantic-ir-to-rust`.

Part of the autonomous "drive SIR to v1 completion" effort. Isolated to the `semantic-ir-to-rust` crate (no shared-file conflicts with parallel work).

## Changes

- **Capability**: declare `Feature::Floats` + `Feature::ShortCircuit` in `ACCEPTED_FEATURES` (`lib.rs`).
- **Runtime value model**: add `Value::Float(f64)`. Arithmetic helpers (`plus`/`minus`/`times`/`divide`) stay on the exact `i64` path while every operand is an integer, and promote the whole fold to `f64` once any operand is a float (`int op float ⇒ float`). `number?` covers floats; `=` is cross-representation (`1 == 1.0` true, `NaN == NaN` false); `<`/`>` compare numerically.
- **Emit `FloatLit`**: `{:?}` keeps the trailing `.0` on integral values (never mistaken for an `i64`); non-finite values use `f64::NAN`/`INFINITY`/`NEG_INFINITY`.
- **Emit `LogicalAnd`/`LogicalOr`**: a truthy-guarded block (`{ let __l = lhs; if truthy(&__l) { … } else { … } }`) evaluates the rhs only when the lhs decides — same semantics as the TypeScript backend's truthy-guarded arrow IIFE.

## Tests

- 43 tests pass (unit + emit-shape tests for all three new arms).
- `tests/compile_and_run_floats.rs` — end-to-end proof: emits a float + short-circuit module, compiles it with `rustc`, runs the binary, asserts stdout (`4.0, 4.0, 5, 7, #f, #t`).
- clippy clean (no new warnings); security review passed.

## Scope boundary

The remaining four SIR16 features (`MutableBindings`, `Loops`, `Sequences`, `Maps`) stay undeclared; their emit arms keep the unreachable `panic!` until follow-up PRs (A2, A3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)