### PR TITLE
[codex] Add Berkeley app startup summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added — SPICE Berkeley Mosaic App Startup Summary
+- `spice-netlist-parser` now exposes Berkeley Mosaic app startup summaries plus
+  JSON helpers. The summary derives a compact ready/blocked route from the
+  bootstrap payload, including package name, source fingerprint, repaired
+  editor-state IDs, stale-state flags, active panel, diagnostic count, and
+  blocking reason.
+- The summary helpers reuse the run and non-run bootstrap paths so product
+  shells can make startup routing decisions without walking the full host
+  panel payload or duplicating simulator internals.
+
 ### Added — SPICE Berkeley Mosaic App Bootstrap Snapshot
 - `spice-netlist-parser` now exposes schema-versioned Berkeley Mosaic app
   bootstrap snapshots plus JSON helpers. The bootstrap payload combines the

--- a/code/packages/rust/spice-netlist-parser/README.md
+++ b/code/packages/rust/spice-netlist-parser/README.md
@@ -86,6 +86,12 @@ let bootstrap_json = deck.run_app_bootstrap_json(BerkeleyAppPersistedEditorState
 })?;
 assert!(bootstrap_json.contains(r#""packageManifest":{"#));
 assert!(bootstrap_json.contains(r#""hostSurface":{"#));
+
+let startup_summary_json = deck.run_app_startup_summary_json(BerkeleyAppPersistedEditorState {
+    selected_syntax_card_index: Some(3),
+    active_command_id: Some("analysis.3.inspect-waveform".to_string()),
+})?;
+assert!(startup_summary_json.contains(r#""ready":true"#));
 ```
 
 The facade preserves normalized logical cards, source spans, token names
@@ -116,8 +122,11 @@ Rust app/runtime entrypoint for Mosaic-backed UI work. App bootstrap snapshots
 combine that manifest with the schema-versioned host-surface wire export so
 WebAssembly and product shells can load one startup payload with package
 capabilities, repaired editor-state metadata, active panels, and diagnostics
-before taking ownership of the UI. The grammar-backed parser generator and
-Python/TypeScript parity surfaces continue to mature.
+before taking ownership of the UI. Startup summaries derive a compact ready /
+blocked route from the same bootstrap payload, including source fingerprint,
+active panel, repaired editor-state IDs, stale-state flags, diagnostic count,
+and blocking reason. The grammar-backed parser generator and Python/TypeScript
+parity surfaces continue to mature.
 
 This parser supports `R`, `C`, `L`, `V`, `I`, `D`, `Q`, `M`, `G`, `E`, `F`, and
 `H` elements, `.model <name> D(...)` diode cards with `IS` and `VT`

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -24,13 +24,14 @@ pub use syntax::{
     BerkeleyAppHostPanelKind, BerkeleyAppHostPanelWire, BerkeleyAppHostSpanWire,
     BerkeleyAppHostSurface, BerkeleyAppHostSurfaceWire, BerkeleyAppPackageManifest,
     BerkeleyAppPersistedEditorState, BerkeleyAppSessionAnalysis, BerkeleyAppSessionState,
-    BerkeleyAppWaveformPoint, BerkeleyAppWaveformSeries, BerkeleyCardKind,
-    BerkeleyDiagnosticSeverity, BerkeleyGrammarMetadata, BerkeleyLogicalCard, BerkeleySyntaxDeck,
-    BerkeleySyntaxDiagnostic, BerkeleySyntaxToken, SourceSpan,
+    BerkeleyAppStartupSummary, BerkeleyAppWaveformPoint, BerkeleyAppWaveformSeries,
+    BerkeleyCardKind, BerkeleyDiagnosticSeverity, BerkeleyGrammarMetadata, BerkeleyLogicalCard,
+    BerkeleySyntaxDeck, BerkeleySyntaxDiagnostic, BerkeleySyntaxToken, SourceSpan,
     BERKELEY_APP_BOOTSTRAP_SCHEMA_VERSION, BERKELEY_APP_HOST_SURFACE_WIRE_SCHEMA_VERSION,
     BERKELEY_APP_PACKAGE_MANIFEST_SCHEMA_VERSION, BERKELEY_APP_PACKAGE_NAME,
-    BERKELEY_APP_SOURCE_FINGERPRINT_ALGORITHM, BERKELEY_SPICE_GRAMMAR_NAME,
-    BERKELEY_SPICE_GRAMMAR_VERSION, BERKELEY_SPICE_PARSER_GRAMMAR, BERKELEY_SPICE_TOKEN_GRAMMAR,
+    BERKELEY_APP_SOURCE_FINGERPRINT_ALGORITHM, BERKELEY_APP_STARTUP_SUMMARY_SCHEMA_VERSION,
+    BERKELEY_SPICE_GRAMMAR_NAME, BERKELEY_SPICE_GRAMMAR_VERSION, BERKELEY_SPICE_PARSER_GRAMMAR,
+    BERKELEY_SPICE_TOKEN_GRAMMAR,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/code/packages/rust/spice-netlist-parser/src/syntax.rs
+++ b/code/packages/rust/spice-netlist-parser/src/syntax.rs
@@ -16,6 +16,7 @@ pub const BERKELEY_SPICE_PARSER_GRAMMAR: &str =
 pub const BERKELEY_APP_HOST_SURFACE_WIRE_SCHEMA_VERSION: u32 = 1;
 pub const BERKELEY_APP_PACKAGE_MANIFEST_SCHEMA_VERSION: u32 = 1;
 pub const BERKELEY_APP_BOOTSTRAP_SCHEMA_VERSION: u32 = 1;
+pub const BERKELEY_APP_STARTUP_SUMMARY_SCHEMA_VERSION: u32 = 1;
 pub const BERKELEY_APP_PACKAGE_NAME: &str = "berkeley-spice-mosaic-app";
 pub const BERKELEY_APP_SOURCE_FINGERPRINT_ALGORITHM: &str = "fnv1a-64";
 
@@ -47,6 +48,7 @@ const BERKELEY_APP_ARTIFACT_CAPABILITIES: &[&str] = &[
     "host-surface",
     "host-surface-wire-json",
     "app-bootstrap-json",
+    "app-startup-summary-json",
     "result-tables",
     "waveform-series",
     "run-artifacts",
@@ -227,6 +229,56 @@ pub struct BerkeleyAppBootstrapSnapshot {
 impl BerkeleyAppBootstrapSnapshot {
     pub fn to_json(&self) -> String {
         app_bootstrap_snapshot_json_value(self).to_string()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BerkeleyAppStartupSummary {
+    pub schema_version: u32,
+    pub package_name: String,
+    pub source_fingerprint: String,
+    pub title: Option<String>,
+    pub parsed: bool,
+    pub execution_available: bool,
+    pub ready: bool,
+    pub requested_selected_syntax_card_index: Option<usize>,
+    pub requested_active_command_id: Option<String>,
+    pub resolved_selected_syntax_card_index: Option<usize>,
+    pub resolved_active_command_id: Option<String>,
+    pub selection_stale: bool,
+    pub command_stale: bool,
+    pub panel_count: usize,
+    pub active_panel_id: Option<String>,
+    pub diagnostic_count: usize,
+    pub blocking_message: Option<String>,
+}
+
+impl BerkeleyAppStartupSummary {
+    pub fn from_bootstrap_snapshot(snapshot: &BerkeleyAppBootstrapSnapshot) -> Self {
+        let host_surface = &snapshot.host_surface;
+        Self {
+            schema_version: BERKELEY_APP_STARTUP_SUMMARY_SCHEMA_VERSION,
+            package_name: snapshot.package_manifest.package_name.clone(),
+            source_fingerprint: host_surface.source_fingerprint.clone(),
+            title: host_surface.title.clone(),
+            parsed: host_surface.parsed,
+            execution_available: host_surface.execution_available,
+            ready: host_surface.parsed && host_surface.execution_available,
+            requested_selected_syntax_card_index: host_surface.requested_selected_syntax_card_index,
+            requested_active_command_id: host_surface.requested_active_command_id.clone(),
+            resolved_selected_syntax_card_index: host_surface.resolved_selected_syntax_card_index,
+            resolved_active_command_id: host_surface.resolved_active_command_id.clone(),
+            selection_stale: host_surface.selection_stale,
+            command_stale: host_surface.command_stale,
+            panel_count: host_surface.panel_count,
+            active_panel_id: host_surface.active_panel_id.clone(),
+            diagnostic_count: host_surface.diagnostics.len(),
+            blocking_message: host_surface.blocking_message.clone(),
+        }
+    }
+
+    pub fn to_json(&self) -> String {
+        app_startup_summary_json_value(self).to_string()
     }
 }
 
@@ -779,6 +831,38 @@ impl BerkeleyAppDeck {
         persisted_state: BerkeleyAppPersistedEditorState,
     ) -> Result<String, AnalysisExecutionError> {
         Ok(self.run_app_bootstrap_snapshot(persisted_state)?.to_json())
+    }
+
+    pub fn app_startup_summary(
+        &self,
+        persisted_state: BerkeleyAppPersistedEditorState,
+    ) -> BerkeleyAppStartupSummary {
+        BerkeleyAppStartupSummary::from_bootstrap_snapshot(
+            &self.app_bootstrap_snapshot(persisted_state),
+        )
+    }
+
+    pub fn run_app_startup_summary(
+        &self,
+        persisted_state: BerkeleyAppPersistedEditorState,
+    ) -> Result<BerkeleyAppStartupSummary, AnalysisExecutionError> {
+        Ok(BerkeleyAppStartupSummary::from_bootstrap_snapshot(
+            &self.run_app_bootstrap_snapshot(persisted_state)?,
+        ))
+    }
+
+    pub fn app_startup_summary_json(
+        &self,
+        persisted_state: BerkeleyAppPersistedEditorState,
+    ) -> String {
+        self.app_startup_summary(persisted_state).to_json()
+    }
+
+    pub fn run_app_startup_summary_json(
+        &self,
+        persisted_state: BerkeleyAppPersistedEditorState,
+    ) -> Result<String, AnalysisExecutionError> {
+        Ok(self.run_app_startup_summary(persisted_state)?.to_json())
     }
 
     pub fn run_source_order(&self) -> Result<Vec<AnalysisExecutionResult>, AnalysisExecutionError> {
@@ -1382,6 +1466,28 @@ fn app_bootstrap_snapshot_json_value(snapshot: &BerkeleyAppBootstrapSnapshot) ->
         "schemaVersion": snapshot.schema_version,
         "packageManifest": app_package_manifest_json_value(&snapshot.package_manifest),
         "hostSurface": host_surface_wire_json_value(&snapshot.host_surface),
+    })
+}
+
+fn app_startup_summary_json_value(summary: &BerkeleyAppStartupSummary) -> serde_json::Value {
+    serde_json::json!({
+        "schemaVersion": summary.schema_version,
+        "packageName": &summary.package_name,
+        "sourceFingerprint": &summary.source_fingerprint,
+        "title": &summary.title,
+        "parsed": summary.parsed,
+        "executionAvailable": summary.execution_available,
+        "ready": summary.ready,
+        "requestedSelectedSyntaxCardIndex": summary.requested_selected_syntax_card_index,
+        "requestedActiveCommandId": &summary.requested_active_command_id,
+        "resolvedSelectedSyntaxCardIndex": summary.resolved_selected_syntax_card_index,
+        "resolvedActiveCommandId": &summary.resolved_active_command_id,
+        "selectionStale": summary.selection_stale,
+        "commandStale": summary.command_stale,
+        "panelCount": summary.panel_count,
+        "activePanelId": &summary.active_panel_id,
+        "diagnosticCount": summary.diagnostic_count,
+        "blockingMessage": &summary.blocking_message,
     })
 }
 

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -14,7 +14,8 @@ use spice_netlist_parser::{
     TfAnalysis, TranAnalysis, BERKELEY_APP_BOOTSTRAP_SCHEMA_VERSION,
     BERKELEY_APP_HOST_SURFACE_WIRE_SCHEMA_VERSION, BERKELEY_APP_PACKAGE_MANIFEST_SCHEMA_VERSION,
     BERKELEY_APP_PACKAGE_NAME, BERKELEY_APP_SOURCE_FINGERPRINT_ALGORITHM,
-    BERKELEY_SPICE_GRAMMAR_NAME, BERKELEY_SPICE_GRAMMAR_VERSION,
+    BERKELEY_APP_STARTUP_SUMMARY_SCHEMA_VERSION, BERKELEY_SPICE_GRAMMAR_NAME,
+    BERKELEY_SPICE_GRAMMAR_VERSION,
 };
 
 fn assert_close(actual: f64, expected: f64) {
@@ -2553,6 +2554,11 @@ fn berkeley_app_facade_exports_package_manifest_json() {
         .unwrap()
         .iter()
         .any(|capability| capability == "app-bootstrap-json"));
+    assert!(payload["artifactCapabilities"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|capability| capability == "app-startup-summary-json"));
 }
 
 #[test]
@@ -2619,6 +2625,48 @@ C1 out 0 1p
         .unwrap()
         .iter()
         .any(|capability| capability == "app-bootstrap-json"));
+
+    let summary = app
+        .run_app_startup_summary(BerkeleyAppPersistedEditorState {
+            selected_syntax_card_index: Some(3),
+            active_command_id: Some("analysis.3.inspect-waveform".to_string()),
+        })
+        .expect("startup summary should execute");
+    assert_eq!(
+        summary.schema_version,
+        BERKELEY_APP_STARTUP_SUMMARY_SCHEMA_VERSION
+    );
+    assert_eq!(summary.package_name, BERKELEY_APP_PACKAGE_NAME);
+    assert_eq!(
+        summary.source_fingerprint,
+        snapshot.host_surface.source_fingerprint
+    );
+    assert!(summary.ready);
+    assert!(summary.parsed);
+    assert!(summary.execution_available);
+    assert_eq!(summary.active_panel_id.as_deref(), Some("waveform"));
+    assert_eq!(summary.panel_count, 5);
+    assert_eq!(summary.diagnostic_count, 0);
+    assert!(!summary.selection_stale);
+    assert!(!summary.command_stale);
+
+    let summary_payload: serde_json::Value = serde_json::from_str(
+        &app.run_app_startup_summary_json(BerkeleyAppPersistedEditorState {
+            selected_syntax_card_index: Some(3),
+            active_command_id: Some("analysis.3.inspect-waveform".to_string()),
+        })
+        .unwrap(),
+    )
+    .expect("startup summary JSON should parse");
+    assert_eq!(summary_payload["schemaVersion"], 1);
+    assert_eq!(summary_payload["packageName"], "berkeley-spice-mosaic-app");
+    assert_eq!(summary_payload["ready"], true);
+    assert_eq!(summary_payload["activePanelId"], "waveform");
+    assert_eq!(
+        summary_payload["resolvedActiveCommandId"],
+        "analysis.3.inspect-waveform"
+    );
+    assert_eq!(summary_payload["diagnosticCount"], 0);
 }
 
 #[test]
@@ -2661,6 +2709,33 @@ R1 in out
         payload["hostSurface"]["diagnostics"][0]["span"]["startLine"],
         3
     );
+
+    let summary = app.app_startup_summary(BerkeleyAppPersistedEditorState {
+        selected_syntax_card_index: Some(2),
+        active_command_id: Some("analysis.2.run".to_string()),
+    });
+    assert_eq!(
+        summary.schema_version,
+        BERKELEY_APP_STARTUP_SUMMARY_SCHEMA_VERSION
+    );
+    assert!(!summary.ready);
+    assert!(!summary.parsed);
+    assert!(!summary.execution_available);
+    assert_eq!(summary.active_panel_id.as_deref(), Some("diagnostics"));
+    assert_eq!(summary.diagnostic_count, 1);
+    assert!(summary.blocking_message.is_some());
+
+    let summary_payload: serde_json::Value = serde_json::from_str(&app.app_startup_summary_json(
+        BerkeleyAppPersistedEditorState {
+            selected_syntax_card_index: Some(2),
+            active_command_id: Some("analysis.2.run".to_string()),
+        },
+    ))
+    .expect("blocked startup summary JSON should parse");
+    assert_eq!(summary_payload["ready"], false);
+    assert_eq!(summary_payload["activePanelId"], "diagnostics");
+    assert_eq!(summary_payload["diagnosticCount"], 1);
+    assert!(summary_payload["blockingMessage"].is_string());
 }
 
 #[test]

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,14 +33,14 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Rust Berkeley Mosaic app bootstrap snapshot.
+1. Rust Berkeley Mosaic app startup summary.
    - Status: current PR completion candidate.
-   - Add schema-versioned Rust app bootstrap snapshots and JSON helpers that
-     combine the Berkeley package manifest with deck-specific host-surface wire
-     exports for Mosaic, WebAssembly, and product-shell startup.
-   - Expose run and non-run helpers that preserve blocked-deck diagnostics,
-     repaired persisted editor-state metadata, active panels, and package
-     capabilities in one startup envelope.
+   - Add schema-versioned Rust app startup summaries and JSON helpers that
+     derive a compact ready/blocked route from Berkeley app bootstrap payloads.
+   - Preserve package name, source fingerprint, repaired persisted editor-state
+     IDs, stale-state flags, active panel, diagnostic count, and blocking
+     reason so Mosaic, WebAssembly, and product shells can make startup routing
+     decisions without walking every host panel.
    - Keep this as a Rust-only app-substrate packaging slice over the public
      parser contract; Python and TypeScript parser parity remains aligned when
      parser behavior changes.
@@ -1530,6 +1530,16 @@ the Rust, Python, and TypeScript surfaces together.
      schema, source-fingerprint algorithm, panel kinds, editor action kinds,
      command targets, runnable analysis directives, and artifact capabilities
      before a host opens a deck.
+
+145. Rust Berkeley Mosaic app bootstrap snapshot.
+   - Status: completed in PR 6980.
+   - Rust `spice-netlist-parser` now exposes schema-versioned Berkeley Mosaic
+     app bootstrap snapshots plus JSON helpers that combine the static package
+     manifest with deck-specific host-surface wire exports.
+   - The bootstrap payload preserves blocked-deck diagnostics, repaired
+     persisted editor-state metadata, active panels, package capabilities, and
+     run availability in one startup envelope for Mosaic, WebAssembly, and
+     product-shell startup.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- add a schema-versioned Berkeley Mosaic app startup summary derived from the bootstrap payload
- expose run and non-run native/JSON helpers with ready state, source fingerprint, repaired editor-state IDs, stale-state flags, active panel, diagnostic count, and blocking reason
- advertise the startup-summary JSON capability and advance the SPICE implementation plan after PR #6980

## Verification
- `cargo fmt -p spice-netlist-parser`
- `cargo test -p spice-netlist-parser -- --nocapture`
- `cargo test -p grammar-tools --test spice_grammar_validation -- --nocapture`
- `git diff --check`