### PR TITLE
feat(latex): emit \overset/\underset/\stackrel → neutral Overset/Underset

### DIFF
--- a/code/packages/rust/latex/CHANGELOG.md
+++ b/code/packages/rust/latex/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to the full-fidelity LaTeX parser crate.
 
+## [0.14.0] — 2026-06-30
+
+### Added — `\overset` / `\underset` / `\stackrel` → neutral `Overset` / `Underset`
+
+- The parser recognizes **`\overset{over}{base}`**, **`\stackrel{over}{base}`** (amsmath's name
+  for the over-set form), and **`\underset{under}{base}`** — two mandatory args (annotation then
+  base, the `\frac`/`\binom` shape) — as new `MathNode::Overset` / `MathNode::Underset`, and the L6
+  lower emits the neutral **`MathExpr::Overset` / `MathExpr::Underset`** (math-frontend 0.5.0). A
+  centered annotation **over/under** the base, **distinct from `Pow`/`Subscript`** (`b^a` / `b_a`).
+  This is the LaTeX-side twin of the asciimath over/under-set emitter.
+- `to_latex` round-trips both nodes (`parse_math(node.to_latex()) == node`); the iterative
+  `take_children` (deep-Drop guard) handles their two children; both stay atoms in the precedence
+  table. The lower runs in the existing work-stack trampoline (no new recursion). `capabilities()`
+  already advertises `oversets` via `all()`, so emission is conforming with no capability change.
+- Tests: parser `overset_underset_parse_and_round_trip`, lower `overset_underset_lower_to_neutral_nodes`
+  (overset/underset/stackrel, distinct-from-Pow). 141 unit + doc tests pass; clippy `-D warnings` clean.
+
 ## [0.13.0] — 2026-06-29
 
 ### Changed — accents lower to the neutral `MathExpr::Accent` (no longer faked as a function call)

--- a/code/packages/rust/latex/Cargo.toml
+++ b/code/packages/rust/latex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latex"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 description = "A full-fidelity LaTeX parser (documents and math): a catcode-driven, text-mode-primary tokenizer and (in later layers) a structural + math parser producing a faithful AST. Standalone and reusable; will also implement the math-frontend MathFrontend trait."
 license = "MIT"

--- a/code/packages/rust/latex/src/frontend.rs
+++ b/code/packages/rust/latex/src/frontend.rs
@@ -90,6 +90,8 @@ enum Build {
     Unary(UnaryOp),
     Frac,
     Binom,
+    Overset,
+    Underset,
     Root { has_degree: bool },
     Script { has_sub: bool, has_sup: bool },
     Call(Func),
@@ -159,6 +161,21 @@ fn lower(root: MathNode, span: (usize, usize)) -> Result<MathExpr, FrontendError
                     work.push(Task::Build(Build::Binom));
                     work.push(Task::Node(y));
                     work.push(Task::Node(x));
+                }
+                // `\overset{over}{base}` / `\stackrel` → neutral Overset; `\underset` → Underset.
+                // A centered annotation over/under the base, distinct from Pow/Subscript.
+                // (Needs `math-frontend` ≥ 0.5.0's Overset/Underset nodes.)
+                MathNode::Overset { over, base } => {
+                    let (over, base) = (take_box(over), take_box(base));
+                    work.push(Task::Build(Build::Overset));
+                    work.push(Task::Node(base));
+                    work.push(Task::Node(over));
+                }
+                MathNode::Underset { under, base } => {
+                    let (under, base) = (take_box(under), take_box(base));
+                    work.push(Task::Build(Build::Underset));
+                    work.push(Task::Node(base));
+                    work.push(Task::Node(under));
                 }
                 MathNode::Bin(op, x, y) => {
                     let bop = lower_binop(*op);
@@ -293,6 +310,16 @@ fn lower(root: MathNode, span: (usize, usize)) -> Result<MathExpr, FrontendError
                     let k = pop!();
                     let n = pop!();
                     vals.push(MathExpr::Binom(Box::new(n), Box::new(k)));
+                }
+                Build::Overset => {
+                    let base = pop!();
+                    let over = pop!();
+                    vals.push(MathExpr::Overset { over: Box::new(over), base: Box::new(base) });
+                }
+                Build::Underset => {
+                    let base = pop!();
+                    let under = pop!();
+                    vals.push(MathExpr::Underset { under: Box::new(under), base: Box::new(base) });
                 }
                 Build::Root { has_degree } => {
                     let radicand = pop!();
@@ -562,6 +589,31 @@ mod tests {
             m(r"\vec{v}"),
             MathExpr::Accent { accent: "vec".into(), body: Box::new(MathExpr::Symbol("v".into())) }
         );
+    }
+
+    #[test]
+    fn overset_underset_lower_to_neutral_nodes() {
+        // `\overset{a}{b}` / `\stackrel{a}{b}` → a centered over the b; `\underset{a}{b}` under it.
+        // Distinct from Pow/Subscript (which `b^a` / `b_a` produce). Both args lower recursively.
+        assert_eq!(
+            m(r"\overset{a}{R}"),
+            MathExpr::Overset {
+                over: Box::new(MathExpr::Symbol("a".into())),
+                base: Box::new(MathExpr::Symbol("R".into())),
+            }
+        );
+        assert_eq!(
+            m(r"\underset{a}{R}"),
+            MathExpr::Underset {
+                under: Box::new(MathExpr::Symbol("a".into())),
+                base: Box::new(MathExpr::Symbol("R".into())),
+            }
+        );
+        // `\stackrel` is amsmath's name for the over-set form → identical lowering.
+        assert_eq!(m(r"\stackrel{a}{R}"), m(r"\overset{a}{R}"));
+        // Distinct from a superscript and from each other.
+        assert_ne!(m(r"\overset{a}{R}"), m(r"R^{a}"));
+        assert_ne!(m(r"\overset{a}{R}"), m(r"\underset{a}{R}"));
     }
 
     #[test]

--- a/code/packages/rust/latex/src/math.rs
+++ b/code/packages/rust/latex/src/math.rs
@@ -85,6 +85,10 @@ pub enum MathNode {
     Frac(Box<MathNode>, Box<MathNode>),
     /// `\binom{A}{B}`.
     Binom(Box<MathNode>, Box<MathNode>),
+    /// `\overset{over}{base}` / `\stackrel{over}{base}` — an annotation centered OVER the base.
+    Overset { over: Box<MathNode>, base: Box<MathNode> },
+    /// `\underset{under}{base}` — an annotation centered UNDER the base.
+    Underset { under: Box<MathNode>, base: Box<MathNode> },
     /// `\sqrt[n]{x}` (`degree` is `None` for a square root).
     Root {
         degree: Option<Box<MathNode>>,
@@ -174,6 +178,10 @@ fn take_children(n: &mut MathNode, out: &mut Vec<MathNode>) {
     match n {
         MathNode::Num(_) | MathNode::Sym(_) | MathNode::Text(_) => {}
         MathNode::Bin(_, a, b) | MathNode::Frac(a, b) | MathNode::Binom(a, b) | MathNode::Rel(_, a, b) => {
+            take(a, out);
+            take(b, out);
+        }
+        MathNode::Overset { over: a, base: b } | MathNode::Underset { under: a, base: b } => {
             take(a, out);
             take(b, out);
         }
@@ -623,6 +631,21 @@ impl<'a> MathParser<'a> {
             let b = self.read_arg()?;
             return Ok(MathNode::Binom(Box::new(a), Box::new(b)));
         }
+        // `\overset{over}{base}` / `\stackrel{over}{base}` — annotation OVER base;
+        // `\underset{under}{base}` — annotation UNDER base. Two mandatory args, the
+        // annotation first then the base (amsmath order), like `\frac`/`\binom`.
+        if name == "overset" || name == "stackrel" {
+            self.bump();
+            let over = self.read_arg()?;
+            let base = self.read_arg()?;
+            return Ok(MathNode::Overset { over: Box::new(over), base: Box::new(base) });
+        }
+        if name == "underset" {
+            self.bump();
+            let under = self.read_arg()?;
+            let base = self.read_arg()?;
+            return Ok(MathNode::Underset { under: Box::new(under), base: Box::new(base) });
+        }
         if name == "sqrt" {
             self.bump();
             let degree = if matches!(self.peek().kind, TokenKind::Char('[')) {
@@ -845,7 +868,7 @@ fn prec(n: &MathNode) -> u8 {
         MathNode::Bin(MBinOp::Mul | MBinOp::Div, ..) => 3,
         MathNode::Unary(..) => 4,
         MathNode::Bin(MBinOp::Pow, ..) | MathNode::Script { .. } => 5,
-        _ => 6, // atoms: Num, Sym, Frac, Root, Fenced, Call, BigOp, Accent, Binom, Text
+        _ => 6, // atoms: Num, Sym, Frac, Root, Fenced, Call, BigOp, Accent, Binom, Overset/Underset, Text
     }
 }
 
@@ -921,6 +944,20 @@ impl MathNode {
                 a.write(out, 0);
                 out.push_str("}{");
                 b.write(out, 0);
+                out.push('}');
+            }
+            MathNode::Overset { over, base } => {
+                out.push_str("\\overset{");
+                over.write(out, 0);
+                out.push_str("}{");
+                base.write(out, 0);
+                out.push('}');
+            }
+            MathNode::Underset { under, base } => {
+                out.push_str("\\underset{");
+                under.write(out, 0);
+                out.push_str("}{");
+                base.write(out, 0);
                 out.push('}');
             }
             MathNode::Root { degree, radicand } => {
@@ -1053,6 +1090,26 @@ mod tests {
         let r = a.to_latex();
         let b = parse_math(&r).expect("re-parse");
         assert_eq!(a, b, "round-trip: {src:?} -> {r:?}");
+    }
+
+    #[test]
+    fn overset_underset_parse_and_round_trip() {
+        // Two mandatory args (annotation then base); `\stackrel` is the over-set synonym.
+        assert!(matches!(
+            parse_math(r"\overset{a}{R}").unwrap(),
+            MathNode::Overset { .. }
+        ));
+        assert!(matches!(
+            parse_math(r"\underset{a}{R}").unwrap(),
+            MathNode::Underset { .. }
+        ));
+        assert!(matches!(
+            parse_math(r"\stackrel{a}{R}").unwrap(),
+            MathNode::Overset { .. }
+        ));
+        round_trips(r"\overset{a}{R}");
+        round_trips(r"\underset{x+1}{y}");
+        round_trips(r"a + \overset{\ast}{b}");
     }
 
     #[test]

--- a/code/specs/LTX01-full-latex-parser.md
+++ b/code/specs/LTX01-full-latex-parser.md
@@ -203,6 +203,13 @@ is text-primary, which is a different mode model.)
   Every LaTeX math construct the grammar parses now has a faithful neutral counterpart — no
   honest-error islands remain. This rung **completes the LTX01 ladder (L0–L6).**
 
+  **Over/under-set emission (latex 0.14.0):** `\overset{a}{b}`, `\stackrel{a}{b}` (amsmath's
+  over-set synonym), and `\underset{a}{b}` parse to new `MathNode::Overset`/`Underset` (two
+  mandatory args, annotation then base) and the L6 lower emits the neutral
+  `MathExpr::Overset`/`Underset` (added in `math-frontend` 0.5.0) — a centered annotation over/under
+  the base, distinct from `Pow`/`Subscript`. `to_latex` round-trips both; `capabilities()` already
+  advertises `oversets` via `all()`. The LaTeX-side twin of the asciimath over/under-set emitter.
+
 **Asymptote (documented in README, not built):** runtime `\catcode`, `\expandafter`/
 `\noexpand`/`\csname`, arbitrary `\if…` programming, external `\input`/`\include`. Hit →
 `Unsupported { construct, span }`.


### PR DESCRIPTION
## What

The **LaTeX-side twin** of the asciimath over/under-set emitter (#6981), completing the over/under-set feature end-to-end on both frontends (neutral node → asciimath → latex).

```
\overset{a}{R}   ≡  \stackrel{a}{R}   →  MathExpr::Overset { over: a, base: R }
\underset{a}{R}                       →  MathExpr::Underset { under: a, base: R }
```

## How

The math parser recognizes `\overset{over}{base}`, `\stackrel{over}{base}` (amsmath's name for the over-set form), and `\underset{under}{base}` — two mandatory args (annotation then base, the `\frac`/`\binom` shape) — as new `MathNode::Overset`/`Underset`, and the **L6 lower** emits the neutral `MathExpr::Overset`/`Underset` (math-frontend 0.5.0).

Semantics: a centered annotation **over/under** the base, **distinct from `Pow`/`Subscript`** (`b^a` / `b_a`).

## Plumbing & safety

- `to_latex` round-trips both nodes (`parse_math(node.to_latex()) == node`).
- The iterative `take_children` (deep-Drop guard) handles their two children; both stay atoms in the precedence table; the lower runs in the existing work-stack trampoline (**no new recursion**).
- `capabilities()` already advertises `oversets` via `all()`, so emission is conforming with **no capability change**.

## Gates

- Parser test `overset_underset_parse_and_round_trip` + lower test `overset_underset_lower_to_neutral_nodes` (overset/underset/stackrel, distinct-from-Pow). **141 unit + doc tests pass**; `cargo clippy -p latex -- -D warnings` clean.
- `/security-review` **PASSED** (parse branch mirrors `\frac`/`\binom` depth-charged two-arg read; no new recursion/indexing/arithmetic/unsafe).
- latex **0.14.0**. Spec `LTX01` §5 (L6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)