### PR TITLE
fix(closurec): array elisions (holes) dropped — miscompile

### DIFF
--- a/code/packages/rust/closure-emitter/CHANGELOG.md
+++ b/code/packages/rust/closure-emitter/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to the `coding-adventures-closure-emitter` crate will be documented in this file.
 
+## [0.18.4] - 2026-06-30
+
+### Fixed — trailing array hole lost its comma (miscompile)
+
+`emit_array` wrote one separating comma *between* elements, so an array whose
+last element is a hole printed one comma short: `[Some(1), None]` became `[1,]`
+(length 1) instead of `[1,,]` (length 2). A trailing hole is semantically real
+(`[1,,].length === 2`), so the shortened output is a miscompile. The emitter now
+appends one extra comma when the last element is a hole, fixing `[1,,]`, `[,,]`
+(from `[None, None]`), `[,]` (from `[None]`), etc.; arrays ending in a real
+element are unchanged. Pairs with the bridge elision fix in `javascript-parser`
+0.19.4. New test `array_trailing_and_leading_holes_round_trip`.
+
 ## [0.18.3] - 2026-06-29
 
 ### Fixed — U+2028 / U+2029 emitted unescaped in string literals (invalid JS)

--- a/code/packages/rust/closure-emitter/Cargo.toml
+++ b/code/packages/rust/closure-emitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-emitter"
-version = "0.18.3"
+version = "0.18.4"
 edition = "2021"
 description = "JavaScript code emitter for the Closure Compiler clone. Per CLOC07's emit contract. Takes a finalized Program + sidecar and produces output JavaScript text + companion source map. Runs after every pass in the pipeline."
 

--- a/code/packages/rust/closure-emitter/src/lib.rs
+++ b/code/packages/rust/closure-emitter/src/lib.rs
@@ -1080,6 +1080,15 @@ impl<'a> Emitter<'a> {
                 }
             }
         }
+        // A TRAILING hole needs an extra comma. The loop writes one separating
+        // comma *between* elements, so `[Some(1), None]` would print as `[1,]` —
+        // but `[1,]` has length 1, whereas the source `[1,,]` has length 2 (a
+        // trailing hole). Emitting one more comma when the last element is a hole
+        // restores the count: `[1,,]`, `[,,]` (from `[None, None]`), etc. A
+        // trailing *element* (e.g. `[1,2]`) is unaffected.
+        if matches!(a.elements.last(), Some(None)) {
+            self.write_str(",");
+        }
         self.write_str("]");
     }
 
@@ -2307,6 +2316,38 @@ mod tests {
         let prog = program().with_body(vec![stmt(a)]);
         let out = emit_default(prog);
         assert_eq!(out.code, "[1,,3];");
+    }
+
+    /// Emit an ArrayExpression built from a hole-pattern (`'e'` = element `n`,
+    /// `'_'` = hole) and return the code without the trailing `;`.
+    fn emit_holes(pattern: &str) -> String {
+        let elements = pattern
+            .chars()
+            .map(|c| if c == 'e' { Some(num(1.0)) } else { None })
+            .collect();
+        let a = Expression::ArrayExpression(ArrayExpression { cv: None, elements });
+        emit_default(program().with_body(vec![stmt(a)]))
+            .code
+            .trim_end_matches(';')
+            .to_string()
+    }
+
+    #[test]
+    fn array_trailing_and_leading_holes_round_trip() {
+        // A TRAILING hole needs an extra comma: `[Some(1), None]` must print as
+        // `[1,,]` (length 2), NOT `[1,]` (length 1). Before the fix the emitter
+        // wrote only the separating comma and silently shortened the array.
+        assert_eq!(emit_holes("e_"), "[1,,]"); // trailing hole, length 2
+        assert_eq!(emit_holes("__"), "[,,]"); // two holes, length 2
+        assert_eq!(emit_holes("_"), "[,]"); // single hole, length 1
+        assert_eq!(emit_holes("_e"), "[,1]"); // leading hole, length 2
+        // Internal hole is unchanged by the trailing-hole fix (every element here
+        // is the literal `1`): `[1,,1]`, length 3.
+        assert_eq!(emit_holes("e_e"), "[1,,1]");
+        // No trailing hole → no extra comma.
+        assert_eq!(emit_holes("ee"), "[1,1]");
+        assert_eq!(emit_holes("e"), "[1]");
+        assert_eq!(emit_holes(""), "[]");
     }
 
     #[test]

--- a/code/packages/rust/javascript-parser/CHANGELOG.md
+++ b/code/packages/rust/javascript-parser/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to the `coding-adventures-javascript-parser` crate will be documented in this file.
 
+## [0.19.4] - 2026-06-30
+
+### Fixed — array elisions (holes) silently dropped (miscompile)
+
+`convert_array_literal` iterated `node_children(element_list)`, but
+`node_children` strips Token children — so the COMMA tokens that delimit array
+holes were invisible and every elision was dropped. `[1,,3]` (a length-3 array
+with a hole at index 1) became the length-2 dense array `[1,3]`. That is
+observable: `[1,,3].length === 3` and `1 in [1,,3] === false`, versus
+`[1,3].length === 2` and `1 in [1,3] === true`.
+
+The function now walks the RAW children of `element_list` and applies the
+standard elision rule: a comma seen while still "expecting an element" (at the
+start, or right after another comma) pushes a `None` hole; a single trailing
+comma after an element is not a hole (`[1,2,]` stays length 2). Spread elements
+(`[...x]`) still return `UnsupportedSyntax`. New test
+`array_elisions_become_holes_not_dropped` covers internal / leading / trailing /
+multiple / single-hole and trailing-comma shapes.
+
 ## [0.19.3] - 2026-06-29
 
 ### Fixed — object property keys parsed as bare identifiers (miscompile)

--- a/code/packages/rust/javascript-parser/Cargo.toml
+++ b/code/packages/rust/javascript-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-javascript-parser"
-version = "0.19.3"
+version = "0.19.4"
 edition = "2021"
 description = "JavaScript parser — parses JavaScript source code against any ECMAScript edition (es1 through es2025) using the grammar-driven parser. Includes correlation-vector plumbing per CLOC03 and a typed-AST bridge (GrammarASTNode → javascript_ast::Program) per CLOC12.136."
 

--- a/code/packages/rust/javascript-parser/src/bridge.rs
+++ b/code/packages/rust/javascript-parser/src/bridge.rs
@@ -1887,24 +1887,65 @@ fn convert_primary_token(t: &Token, ctx: &GrammarASTNode) -> Result<Expression, 
 
 fn convert_array_literal(node: &GrammarASTNode) -> Result<Expression, BridgeError> {
     // array_literal = LBRACKET [ element_list ] RBRACKET ;
-    // element_list = [ ELLIPSIS ] assignment_expression { COMMA [ ELLIPSIS ] assignment_expression }
-    let nodes = node_children(node);
-    let mut elements = Vec::new();
-    for n in nodes {
+    // element_list  = [ ELLIPSIS ] assignment_expression
+    //                 { COMMA [ ELLIPSIS ] assignment_expression } [ COMMA ] ;
+    //
+    // ELISIONS (array holes). A comma that is NOT preceded by an element since
+    // the previous comma (or the start) marks a HOLE: `[1,,3]` is `[1, <hole>, 3]`
+    // of length 3, NOT `[1, 3]` of length 2. The distinction is observable —
+    // `[1,,3].length === 3` and `1 in [1,,3] === false`, whereas `[1,3].length
+    // === 2` and `1 in [1,3] === true` — so dropping a hole is a miscompile.
+    //
+    // The grammar keeps every comma as a Token child of `element_list`, but
+    // `node_children` strips Token children, so the previous implementation
+    // (which iterated `node_children`) never saw the commas and silently dropped
+    // every hole. We therefore walk the RAW children of `element_list` here.
+    //
+    // `expect_element` is true at the start and immediately after each comma. A
+    // comma seen while it is still true means the slot before that comma was
+    // empty → push a hole. A lone *trailing* comma after an element is NOT a hole
+    // (`[1,2,]` is length 2): the loop simply ends with `expect_element == true`
+    // and pushes nothing more.
+    let mut elements: Vec<Option<Expression>> = Vec::new();
+    for n in node_children(node) {
         match n.rule_name.as_str() {
             "element_list" => {
-                for elem_n in node_children(n) {
-                    if has_token(elem_n, "...") {
-                        return Err(BridgeError::UnsupportedSyntax {
-                            rule: "SpreadElement".to_string(),
-                            location: loc(elem_n),
-                        });
+                let mut expect_element = true;
+                for c in &n.children {
+                    match c {
+                        ASTNodeOrToken::Token(t) if t.value == "," => {
+                            if expect_element {
+                                elements.push(None);
+                            }
+                            expect_element = true;
+                        }
+                        // A spread `[...x]` is not supported (Phase 2); the
+                        // ELLIPSIS may appear either as a sibling token here or
+                        // nested inside the element node (handled below).
+                        ASTNodeOrToken::Token(t) if t.value == "..." => {
+                            return Err(BridgeError::UnsupportedSyntax {
+                                rule: "SpreadElement".to_string(),
+                                location: loc(n),
+                            });
+                        }
+                        ASTNodeOrToken::Token(_) => { /* stray token: ignore */ }
+                        ASTNodeOrToken::Node(elem) => {
+                            if has_token(elem, "...") {
+                                return Err(BridgeError::UnsupportedSyntax {
+                                    rule: "SpreadElement".to_string(),
+                                    location: loc(elem),
+                                });
+                            }
+                            let child =
+                                node_children(elem).into_iter().next().unwrap_or(elem);
+                            elements.push(Some(convert_expression(child)?));
+                            expect_element = false;
+                        }
                     }
-                    let child = node_children(elem_n).into_iter().next()
-                        .unwrap_or(elem_n);
-                    elements.push(Some(convert_expression(child)?));
                 }
             }
+            // Single-element array with no `element_list` wrapper — no commas, so
+            // no holes are possible.
             r if r.contains("expression") => {
                 elements.push(Some(convert_expression(n)?));
             }
@@ -2167,6 +2208,7 @@ mod tests {
     fn bridge_ok(src: &str) -> Program {
         bridge(src).unwrap_or_else(|e| panic!("bridge failed for {:?}: {e}", src))
     }
+
 
     // -----------------------------------------------------------------------
     // Empty program
@@ -2860,6 +2902,37 @@ mod tests {
             Expression::ObjectExpression(o) => o.properties[0].key.clone(),
             other => panic!("expected ObjectExpression, got {other:?}"),
         }
+    }
+
+    /// The array-literal expression's elements rendered as a compact
+    /// hole-pattern string: `e` for a present element, `_` for a hole.
+    fn array_hole_pattern(src: &str) -> String {
+        match first_expr(&bridge_ok(src)) {
+            Expression::ArrayExpression(a) => a
+                .elements
+                .iter()
+                .map(|e| if e.is_some() { 'e' } else { '_' })
+                .collect(),
+            other => panic!("expected ArrayExpression, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn array_elisions_become_holes_not_dropped() {
+        // Regression: `convert_array_literal` iterated `node_children`, which
+        // strips the COMMA tokens, so every elision (hole) was silently dropped —
+        // `[1,,3]` became a length-2 dense array. Holes must survive as `None`.
+        assert_eq!(array_hole_pattern("[1,,3];"), "e_e"); // length 3, hole at 1
+        assert_eq!(array_hole_pattern("[,,];"), "__"); // two leading holes, length 2
+        assert_eq!(array_hole_pattern("[1,,];"), "e_"); // trailing hole, length 2
+        assert_eq!(array_hole_pattern("[,1];"), "_e"); // leading hole, length 2
+        assert_eq!(array_hole_pattern("[1,,,2];"), "e__e"); // two holes, length 4
+        assert_eq!(array_hole_pattern("[,];"), "_"); // single hole, length 1
+        // A *trailing comma* after an element is not a hole.
+        assert_eq!(array_hole_pattern("[1,2,3,];"), "eee"); // length 3
+        assert_eq!(array_hole_pattern("[1,2,3];"), "eee");
+        assert_eq!(array_hole_pattern("[1];"), "e");
+        assert_eq!(array_hole_pattern("[];"), "");
     }
 
     #[test]

--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.230.0] - 2026-06-30
+
+### Fixed — array elisions (holes) dropped at SIMPLE/ADVANCED (miscompile)
+
+Sparse array literals lost their holes, changing the array's length and index
+membership:
+
+| input         | was        | now (correct) |
+|---------------|------------|---------------|
+| `f([1,,3])`   | `f([1,3])` | `f([1,,3])`   |
+| `f([,,])`     | `f([])`    | `f([,,])`     |
+| `f([1,,])`    | `f([1])`   | `f([1,,])`    |
+| `f([,1])`     | `f([1])`   | `f([,1])`     |
+| `f([1,,,2])`  | `f([1,2])` | `f([1,,,2])`  |
+| `f([1,2,3,])` | `f([1,2,3])` | `f([1,2,3])` (trailing comma, no hole) |
+
+Two-part fix: the bridge (`javascript-parser` 0.19.4) now walks the raw
+`element_list` children so the elision commas are visible and produces a `None`
+per hole; the emitter (`closure-emitter` 0.18.4) appends the extra comma a
+trailing hole needs. New end-to-end test `simple_array_elisions_preserved`.
+
 ## [0.229.0] - 2026-06-29
 
 ### Fixed — quoted object property keys miscompiled at SIMPLE/ADVANCED

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.229.0"
+version = "0.230.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.229.0",
+  "version": "0.230.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/run.rs
+++ b/code/programs/rust/closurec/src/run.rs
@@ -6187,6 +6187,30 @@ mod tests {
     }
 
     #[test]
+    fn simple_array_elisions_preserved() {
+        // End-to-end regression: array holes used to be dropped at the bridge,
+        // changing the array's length and index membership (a miscompile). They
+        // must survive SIMPLE minification byte-for-byte.
+        let cfg = CompilerConfig {
+            compilation: crate::config::CompilationConfig {
+                level: crate::config::CompilationLevel::Simple,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let simple = |src: &str| transform_source(src, &cfg).expect("ok");
+
+        assert_eq!(simple("f([1,,3]);"), "f([1,,3]);"); // internal hole, len 3
+        assert_eq!(simple("f([,,]);"), "f([,,]);"); // two holes, len 2
+        assert_eq!(simple("f([1,,]);"), "f([1,,]);"); // trailing hole, len 2
+        assert_eq!(simple("f([,1]);"), "f([,1]);"); // leading hole, len 2
+        assert_eq!(simple("f([1,,,2]);"), "f([1,,,2]);"); // two holes, len 4
+        // A trailing comma after an element is NOT a hole — it is dropped.
+        assert_eq!(simple("f([1,2,3,]);"), "f([1,2,3]);");
+        assert_eq!(simple("f([1,2,3]);"), "f([1,2,3]);");
+    }
+
+    #[test]
     fn simple_object_string_keys_quote_handling() {
         // End-to-end regression for the property-key miscompile: the bridge used
         // to emit EVERY quoted object key as a bare identifier from un-decoded

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.229.0
+Version: 0.230.0
 
 ## Flags
 


### PR DESCRIPTION
## Problem

Sparse array literals lost their holes at SIMPLE/ADVANCED, changing the array's **length** and **index membership** — a soundness miscompile:

| input         | was        | now (correct) |
|---------------|------------|---------------|
| `f([1,,3])`   | `f([1,3])` | `f([1,,3])`   |
| `f([,,])`     | `f([])`    | `f([,,])`     |
| `f([1,,])`    | `f([1])`   | `f([1,,])`    |
| `f([,1])`     | `f([1])`   | `f([,1])`     |
| `f([1,,,2])`  | `f([1,2])` | `f([1,,,2])`  |
| `f([1,2,3,])` | `f([1,2,3])` | `f([1,2,3])` (trailing comma — correctly **not** a hole) |

`[1,,3]` is a length-3 array with a hole at index 1; the old `[1,3]` is length 2 (`[1,,3].length === 3` & `1 in [1,,3] === false`, vs `[1,3].length === 2` & `1 in [1,3] === true`).

## Two coupled causes, both fixed

- **`javascript-parser` 0.19.4** — `convert_array_literal` iterated `node_children`, which strips Token children, so the COMMA delimiters were invisible and every elision was dropped. It now walks the **raw** `element_list` children and applies the standard elision rule: a comma seen while still "expecting an element" (start, or right after another comma) pushes a `None` hole; a lone trailing comma after an element is not a hole. Spread (`[...x]`) still returns `UnsupportedSyntax` (incl. nested, via `convert_expression` recursion).
- **`closure-emitter` 0.18.4** — `emit_array` wrote only the separating comma between elements, so a trailing hole printed one comma short (`[Some(1), None]` → `[1,]`, length 1, instead of `[1,,]`, length 2). It now appends one extra comma when the last element is a hole.

## Tests

Bridge hole-pattern assertions (internal/leading/trailing/multiple/single + trailing-comma), emitter trailing/leading/all-hole round-trip, and end-to-end `simple_array_elisions_preserved`. Suites green: javascript-parser (86), closure-emitter (83), closurec (681 + integration). `closurec` 0.230.0 (+`cli.spec.json`, help-markdown fixture).

## Security review

Inline security review **PASSED** — reviewer traced the full edge-case matrix (trailing-comma vs trailing-hole, nested spread, empty/all-hole arrays), confirming no panics, no DoS/unbounded allocation, spread still rejected three ways, and `matches!(None, Some(None))` correctly leaves `[]` as `[]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)