### PR TITLE
feat(mle-pass): slice 2 — more chains, inheritance second hop, abstention sub-bank

### DIFF
--- a/code/specs/MLE-PASS-multihop-recall.md
+++ b/code/specs/MLE-PASS-multihop-recall.md
@@ -78,7 +78,16 @@ The bank grows as more cross-library id joins are grounded — no new harness wo
 defensibility number a future grounding PR moves, and the proof of a real two-hop derivation.
 First slice: **7/7 correct, coverage 1.0, zero model calls.**
 
-## 5. Next
-More chains as id joins are grounded (derm/histo/cardio → genetics; disease → *treatment* and
-disease → *mechanism* hops); a third hop (clue → disease → drug → contraindication); and an
-abstention bank (clues whose chain is ungrounded, which must abstain).
+## 5. Slice 2 (shipped)
+The bank grew **7 → 15**: more `gene_defect` chains (derm `ash_leaf_spots → tuberous_sclerosis →
+TSC1/TSC2`; Niemann-Pick → SMPD1; Pompe → GAA — 10 gene chains over 5 hop-1 libraries); a **second
+hop-2 relation, `inheritance`** (clue → disease → inheritance pattern), proving the harness is generic
+over the second relation, not gene-specific; and an **abstention sub-bank** whose clue has no grounded
+hop-1 edge — the engine binds nothing and the scorer counts abstaining as correct, a binding as a
+fabrication. `score()` reports `abstained_correctly`; `multihop_coverage` is over correct *answerable*
+items. Run-verified: 15/15 correct (13 answerable, coverage 1.0; 2 abstained), zero model calls.
+
+## 6. Next
+More chains as id joins are grounded (histo/cardio → genetics; disease → *treatment* and
+disease → *mechanism* hops); a third hop (clue → disease → drug → contraindication); a `decision`-style
+multi-hop where the engine ranks among several reachable answers.

--- a/code/specs/data/mycin-2026/mle-pass/CHANGELOG.md
+++ b/code/specs/data/mycin-2026/mle-pass/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog — mle-pass
 
+## [0.2.0] — 2026-06-30
+
+### Added — slice 2: more chains, a second hop-2 relation, and an abstention sub-bank
+
+- Bank grows **7 → 15** items, in three groups:
+  - **More clue→disease→gene chains** (hop 2 = `gene_defect`): derm `ash_leaf_spots →
+    tuberous_sclerosis → TSC1/TSC2`, and two more enzyme deficiencies (`sphingomyelinase →
+    Niemann-Pick → SMPD1`, `acid α-glucosidase → Pompe → GAA`). Now 10 gene chains over 5 hop-1
+    libraries (ophtho, neuro, collagen, enzyme-deficiency, derm).
+  - **A different second hop — `inheritance`** (clue→disease→inheritance pattern): caudate→Huntington
+    →autosomal_dominant; KF-rings→Wilson→autosomal_recessive; lens-dislocation→Marfan→autosomal_dominant.
+    Proves the harness and rule-body join are **generic over the second relation**, not gene-specific
+    (the query builder already parameterizes `hop2_relation`).
+  - **An abstention sub-bank**: items whose clue has **no grounded hop-1 edge**. The engine binds
+    nothing, so the only correct, non-fabricating answer is to **abstain** — the scorer counts a
+    binding here as *wrong* (a fabrication).
+- `mle_pass_eval.score()` now handles `expect_abstain` items (abstain = correct; any binding = wrong)
+  and reports `abstained_correctly`; `multihop_coverage` is measured over the correct **answerable**
+  items only. The worked artifact `../recall/multihop-recall.query.adj` gains the new gene + inheritance
+  rules/queries (13 in-place queries, all bound, both hops cited).
+- Tests: `test_bank_exercises_multiple_hop2_relations_and_abstention`; the engine gate now asserts
+  every abstention item binds nothing and every answerable correct item cites both hops. Run-verified:
+  **15/15 correct** (13 answerable, coverage 1.0; 2 abstained correctly), zero model calls. 5 pytest
+  pass; ruff clean.
+
 ## [0.1.0] — 2026-06-29
 
 ### Added — MLE-PASS multi-hop recall harness (first slice)

--- a/code/specs/data/mycin-2026/mle-pass/README.md
+++ b/code/specs/data/mycin-2026/mle-pass/README.md
@@ -54,4 +54,7 @@ authored here: every edge reuses an already-grounded, spider+adversarially-gated
 each run in a temp dir (the two needed `*-edges.adj` copied beside the query), leaving the
 shipped `recall/` library untouched.
 
-First slice: **7/7 correct, `multihop_coverage` 1.0, zero model calls.**
+Slice 2: **15/15 correct, zero model calls** — 10 clue→disease→gene chains + 3 clue→disease→**inheritance**
+chains (proving the harness is generic over the second hop) + 2 **abstention** items (ungrounded clue ⇒
+must abstain). `multihop_coverage` 1.0 over the 13 answerable items; the scorer reports
+`abstained_correctly` and counts any binding on an abstention item as a fabrication (wrong).

--- a/code/specs/data/mycin-2026/mle-pass/gen_items.py
+++ b/code/specs/data/mycin-2026/mle-pass/gen_items.py
@@ -1,83 +1,134 @@
 """Generate the MLE-PASS multi-hop recall bank (items.json).
 
 Each item is a TWO-HOP board question answered purely from grounded edges with zero
-model calls: a clinical clue → disease (hop 1, an organ-system recall library) → gene
-(hop 2, the genetics library). The engine joins the two grounded `relate` edges through
-a rule body (shared `$D`), so the answer carries BOTH hops' byte-provenance.
+model calls: a clinical clue → disease (hop 1, an organ-system recall library) → answer
+(hop 2). The engine joins the two grounded `relate` edges through a rule body (shared
+`$D`), so the answer carries BOTH hops' byte-provenance.
 
-Nothing here is authored knowledge: every chain reuses already-grounded edges that
-shipped in their own spider→provenance→adversarial-gate PRs. This generator only
-arranges existing edges into MCQs.
+Three groups (slice 2):
+  • GENE_CHAINS  — hop 2 = `gene_defect` (clue → disease → gene).
+  • INH_CHAINS   — hop 2 = `inheritance` (clue → disease → inheritance pattern): proves the
+                   harness is generic over the second relation, not gene-specific.
+  • ABSTAIN      — a real rule shape whose clue has NO grounded hop-1 edge: the engine binds
+                   nothing and the item MUST abstain (never fabricate).
+
+Nothing here is authored knowledge: every chain reuses already-grounded edges that shipped
+in their own spider→provenance→adversarial-gate PRs. This generator only arranges them.
 """
 import json
 
-# (id, clue, hop1_lib, hop1_rel, disease, gene, clue_phrase)
-CHAINS = [
+# (id, clue, hop1_lib, hop1_rel, disease, answer, clue_phrase, question_tail)
+GENE_CHAINS = [
     ("mh-01", "leukocoria", "ophtho-edges.adj", "eye_finding_indicates",
-     "retinoblastoma", "rb1", "a white pupillary reflex (leukocoria)"),
+     "retinoblastoma", "rb1", "a white pupillary reflex (leukocoria)", "a mutation in which gene"),
     ("mh-02", "kayser_fleischer_rings", "ophtho-edges.adj", "eye_finding_indicates",
-     "wilson_disease", "atp7b", "Kayser-Fleischer corneal rings"),
+     "wilson_disease", "atp7b", "Kayser-Fleischer corneal rings", "a mutation in which gene"),
     ("mh-03", "superior_lens_dislocation", "ophtho-edges.adj", "eye_finding_indicates",
-     "marfan_syndrome", "fbn1", "upward (superior) lens dislocation"),
+     "marfan_syndrome", "fbn1", "upward (superior) lens dislocation", "a mutation in which gene"),
     ("mh-04", "caudate_nucleus", "neuro-edges.adj", "lesion_causes",
-     "huntington_disease", "htt", "degeneration of the caudate nucleus"),
+     "huntington_disease", "htt", "degeneration of the caudate nucleus", "a mutation in which gene"),
     ("mh-05", "type_i", "collagen-defect-edges.adj", "defect_causes",
-     "osteogenesis_imperfecta", "col1a1", "a defect in type I collagen"),
+     "osteogenesis_imperfecta", "col1a1", "a defect in type I collagen", "a mutation in which gene"),
     ("mh-06", "alpha_galactosidase_a", "enzyme-deficiency-edges.adj", "enzyme_deficiency_disease",
-     "fabry_disease", "gla", "deficiency of alpha-galactosidase A"),
+     "fabry_disease", "gla", "deficiency of alpha-galactosidase A", "a mutation in which gene"),
     ("mh-07", "glucocerebrosidase", "enzyme-deficiency-edges.adj", "enzyme_deficiency_disease",
-     "gaucher_disease", "gba1", "deficiency of glucocerebrosidase"),
+     "gaucher_disease", "gba1", "deficiency of glucocerebrosidase", "a mutation in which gene"),
+    # slice 2 — new gene chains over derm + two more enzyme deficiencies
+    ("mh-08", "ash_leaf_spots", "derm-edges.adj", "skin_finding_in",
+     "tuberous_sclerosis", "tsc1_tsc2", "ash-leaf (hypopigmented) macules", "a mutation in which gene"),
+    ("mh-09", "sphingomyelinase", "enzyme-deficiency-edges.adj", "enzyme_deficiency_disease",
+     "niemann_pick_disease", "smpd1", "deficiency of sphingomyelinase", "a mutation in which gene"),
+    ("mh-10", "acid_alpha_glucosidase", "enzyme-deficiency-edges.adj", "enzyme_deficiency_disease",
+     "pompe_disease", "gaa", "deficiency of acid alpha-glucosidase", "a mutation in which gene"),
+]
+GENE_POOL = ["rb1", "atp7b", "fbn1", "htt", "col1a1", "gla", "gba1", "hexa", "cftr",
+             "dmpk", "fmr1", "pah", "hfe", "ube3a", "fxn", "tsc1_tsc2", "smpd1", "gaa"]
+
+# hop 2 = inheritance (a different second relation; answer is a transmission pattern)
+INH_CHAINS = [
+    ("mh-11", "caudate_nucleus", "neuro-edges.adj", "lesion_causes",
+     "huntington_disease", "autosomal_dominant", "degeneration of the caudate nucleus"),
+    ("mh-12", "kayser_fleischer_rings", "ophtho-edges.adj", "eye_finding_indicates",
+     "wilson_disease", "autosomal_recessive", "Kayser-Fleischer corneal rings"),
+    ("mh-13", "superior_lens_dislocation", "ophtho-edges.adj", "eye_finding_indicates",
+     "marfan_syndrome", "autosomal_dominant", "upward (superior) lens dislocation"),
+]
+INH_POOL = ["autosomal_dominant", "autosomal_recessive", "x_linked_recessive",
+            "x_linked_dominant", "mitochondrial"]
+
+# abstention — real rule shape, ungrounded clue: the engine binds nothing → MUST abstain.
+ABSTAIN = [
+    ("mh-14", "a_clue_with_no_grounded_eye_edge", "ophtho-edges.adj", "eye_finding_indicates",
+     "gene_defect", "genetics-edges.adj", GENE_POOL, "an eye finding not in the grounded library"),
+    ("mh-15", "a_lesion_with_no_grounded_edge", "neuro-edges.adj", "lesion_causes",
+     "gene_defect", "genetics-edges.adj", GENE_POOL, "a neuro lesion not in the grounded library"),
 ]
 
-# Distractor pool: real genes from the genetics library (so every option is a plausible gene).
-GENE_POOL = ["rb1", "atp7b", "fbn1", "htt", "col1a1", "gla", "gba1", "hexa", "cftr",
-             "dmpk", "fmr1", "pah", "hfe", "ube3a", "fxn"]
+LETTERS = ["A", "B", "C", "D", "E"]
+
+
+def options_for(answer, pool, idx):
+    distractors = [g for g in pool if g != answer][:4]
+    opts = distractors[:]
+    pos = idx % 5
+    opts.insert(pos, answer)
+    opts = opts[:5]
+    if opts[pos] != answer:
+        opts[pos] = answer
+    assert len(set(opts)) == 5, (answer, opts)
+    return {LETTERS[i]: opts[i] for i in range(5)}, LETTERS[pos]
 
 
 def build():
     items = []
-    letters = ["A", "B", "C", "D", "E"]
-    for idx, (iid, clue, lib, rel, disease, gene, phrase) in enumerate(CHAINS):
-        # five distinct gene options: the gold + four distractors from the pool.
-        distractors = [g for g in GENE_POOL if g != gene][:4]
-        opts = distractors[:]
-        pos = idx % 5
-        opts.insert(pos, gene)
-        opts = opts[:5]
-        # guarantee the gold sits at `pos` and options are distinct
-        if opts[pos] != gene:
-            opts[pos] = gene
-        assert len(set(opts)) == 5, (iid, opts)
-        options = {letters[i]: opts[i] for i in range(5)}
-        gold_letter = letters[opts.index(gene)]
-        stem = (
-            f"A patient has {phrase}. That finding points to a single disease; "
-            f"the disease is caused by a mutation in which gene?"
-        )
+    # --- gene chains (hop2 = gene_defect) ---
+    for idx, (iid, clue, lib, rel, disease, gene, phrase, tail) in enumerate(GENE_CHAINS):
+        options, gold = options_for(gene, GENE_POOL, idx)
         items.append({
-            "id": iid,
-            "qtype": "multi_hop_recall",
-            "stem": stem,
-            "hop1_lib": lib,
-            "hop1_relation": rel,
-            "hop2_lib": "genetics-edges.adj",
-            "hop2_relation": "gene_defect",
-            "clue": clue,
-            "expected": gene,
-            "options": options,
-            "gold_letter": gold_letter,
+            "id": iid, "qtype": "multi_hop_recall",
+            "stem": f"A patient has {phrase}. That finding points to a single disease; "
+                    f"the disease is caused by {tail}?",
+            "hop1_lib": lib, "hop1_relation": rel,
+            "hop2_lib": "genetics-edges.adj", "hop2_relation": "gene_defect",
+            "clue": clue, "expected": gene, "options": options, "gold_letter": gold,
+        })
+    # --- inheritance chains (hop2 = inheritance) ---
+    for idx, (iid, clue, lib, rel, disease, patt, phrase) in enumerate(INH_CHAINS):
+        options, gold = options_for(patt, INH_POOL, idx)
+        items.append({
+            "id": iid, "qtype": "multi_hop_recall",
+            "stem": f"A patient has {phrase}. That finding points to a single disease; "
+                    f"that disease is inherited in which pattern?",
+            "hop1_lib": lib, "hop1_relation": rel,
+            "hop2_lib": "genetics-edges.adj", "hop2_relation": "inheritance",
+            "clue": clue, "expected": patt, "options": options, "gold_letter": gold,
+        })
+    # --- abstention (ungrounded clue: MUST abstain) ---
+    for (iid, clue, lib, rel, hop2_rel, hop2_lib, pool, phrase) in ABSTAIN:
+        # plausible distractors, but NO correct answer is reachable (the chain is ungrounded).
+        options = {LETTERS[i]: pool[i] for i in range(5)}
+        items.append({
+            "id": iid, "qtype": "multi_hop_recall",
+            "stem": f"A patient has {phrase}. The disease it indicates is caused by a mutation "
+                    f"in which gene? (If the chain is not grounded, abstain.)",
+            "hop1_lib": lib, "hop1_relation": rel,
+            "hop2_lib": hop2_lib, "hop2_relation": hop2_rel,
+            "clue": clue, "expected": None, "expect_abstain": True, "options": options,
         })
     return {
         "description": (
             "MLE-PASS multi-hop recall bank — TWO-HOP board questions answered purely from "
-            "grounded edges with zero model calls. Each item chains a clinical clue → disease "
-            "(hop 1, an organ-system recall library: ophtho / neuro / collagen / enzyme-deficiency) "
-            "→ gene (hop 2, the genetics library) by joining two grounded `relate` edges through a "
-            "rule body (shared disease variable). The engine resolves the join (SLD) and returns the "
-            "gene binding carrying BOTH hops' byte-provenance; the harness maps the binding to the "
-            "printed gene options. Nothing is authored: every edge reuses an already-grounded, "
-            "spider+adversarially-gated fact. This is the first slice of the MLE-PASS harness — the "
-            "multi-hop reasoning step past the single-hop recall rungs, toward board coverage."
+            "grounded edges with zero model calls. A clinical clue → disease (hop 1, an "
+            "organ-system recall library) → answer (hop 2) is joined on the shared disease "
+            "through an adj-lang rule body; the engine's SLD resolver returns the binding with "
+            "BOTH hops' byte-provenance, and the harness maps it to the printed options. "
+            "Slice 2 adds: more clue→disease→gene chains (derm, niemann-pick, pompe); a second "
+            "relation as hop 2 — inheritance (clue→disease→inheritance pattern), proving the "
+            "harness is generic over the second hop, not gene-specific; and an ABSTENTION "
+            "sub-bank whose clue has no grounded hop-1 edge, which MUST abstain (never "
+            "fabricate). Nothing authored: every edge reuses an already-grounded, "
+            "spider+adversarially-gated fact. Engine: every answerable item correct with both "
+            "hops cited; every abstention item abstains; zero model calls."
         ),
         "items": items,
     }
@@ -90,4 +141,5 @@ if __name__ == "__main__":
         f.write("\n")
     print("wrote items.json:", len(doc["items"]), "items")
     for it in doc["items"]:
-        print(it["id"], it["clue"], "→", it["expected"], it["gold_letter"], it["options"])
+        tag = "ABSTAIN" if it.get("expect_abstain") else f"{it['expected']} ({it['gold_letter']})"
+        print(it["id"], it["hop2_relation"], it["clue"], "→", tag)

--- a/code/specs/data/mycin-2026/mle-pass/items.json
+++ b/code/specs/data/mycin-2026/mle-pass/items.json
@@ -1,5 +1,5 @@
 {
-  "description": "MLE-PASS multi-hop recall bank \u2014 TWO-HOP board questions answered purely from grounded edges with zero model calls. Each item chains a clinical clue \u2192 disease (hop 1, an organ-system recall library: ophtho / neuro / collagen / enzyme-deficiency) \u2192 gene (hop 2, the genetics library) by joining two grounded `relate` edges through a rule body (shared disease variable). The engine resolves the join (SLD) and returns the gene binding carrying BOTH hops' byte-provenance; the harness maps the binding to the printed gene options. Nothing is authored: every edge reuses an already-grounded, spider+adversarially-gated fact. This is the first slice of the MLE-PASS harness \u2014 the multi-hop reasoning step past the single-hop recall rungs, toward board coverage.",
+  "description": "MLE-PASS multi-hop recall bank \u2014 TWO-HOP board questions answered purely from grounded edges with zero model calls. A clinical clue \u2192 disease (hop 1, an organ-system recall library) \u2192 answer (hop 2) is joined on the shared disease through an adj-lang rule body; the engine's SLD resolver returns the binding with BOTH hops' byte-provenance, and the harness maps it to the printed options. Slice 2 adds: more clue\u2192disease\u2192gene chains (derm, niemann-pick, pompe); a second relation as hop 2 \u2014 inheritance (clue\u2192disease\u2192inheritance pattern), proving the harness is generic over the second hop, not gene-specific; and an ABSTENTION sub-bank whose clue has no grounded hop-1 edge, which MUST abstain (never fabricate). Nothing authored: every edge reuses an already-grounded, spider+adversarially-gated fact. Engine: every answerable item correct with both hops cited; every abstention item abstains; zero model calls.",
   "items": [
     {
       "id": "mh-01",
@@ -133,6 +133,158 @@
         "E": "htt"
       },
       "gold_letter": "B"
+    },
+    {
+      "id": "mh-08",
+      "qtype": "multi_hop_recall",
+      "stem": "A patient has ash-leaf (hypopigmented) macules. That finding points to a single disease; the disease is caused by a mutation in which gene?",
+      "hop1_lib": "derm-edges.adj",
+      "hop1_relation": "skin_finding_in",
+      "hop2_lib": "genetics-edges.adj",
+      "hop2_relation": "gene_defect",
+      "clue": "ash_leaf_spots",
+      "expected": "tsc1_tsc2",
+      "options": {
+        "A": "rb1",
+        "B": "atp7b",
+        "C": "tsc1_tsc2",
+        "D": "fbn1",
+        "E": "htt"
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "mh-09",
+      "qtype": "multi_hop_recall",
+      "stem": "A patient has deficiency of sphingomyelinase. That finding points to a single disease; the disease is caused by a mutation in which gene?",
+      "hop1_lib": "enzyme-deficiency-edges.adj",
+      "hop1_relation": "enzyme_deficiency_disease",
+      "hop2_lib": "genetics-edges.adj",
+      "hop2_relation": "gene_defect",
+      "clue": "sphingomyelinase",
+      "expected": "smpd1",
+      "options": {
+        "A": "rb1",
+        "B": "atp7b",
+        "C": "fbn1",
+        "D": "smpd1",
+        "E": "htt"
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "mh-10",
+      "qtype": "multi_hop_recall",
+      "stem": "A patient has deficiency of acid alpha-glucosidase. That finding points to a single disease; the disease is caused by a mutation in which gene?",
+      "hop1_lib": "enzyme-deficiency-edges.adj",
+      "hop1_relation": "enzyme_deficiency_disease",
+      "hop2_lib": "genetics-edges.adj",
+      "hop2_relation": "gene_defect",
+      "clue": "acid_alpha_glucosidase",
+      "expected": "gaa",
+      "options": {
+        "A": "rb1",
+        "B": "atp7b",
+        "C": "fbn1",
+        "D": "htt",
+        "E": "gaa"
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "mh-11",
+      "qtype": "multi_hop_recall",
+      "stem": "A patient has degeneration of the caudate nucleus. That finding points to a single disease; that disease is inherited in which pattern?",
+      "hop1_lib": "neuro-edges.adj",
+      "hop1_relation": "lesion_causes",
+      "hop2_lib": "genetics-edges.adj",
+      "hop2_relation": "inheritance",
+      "clue": "caudate_nucleus",
+      "expected": "autosomal_dominant",
+      "options": {
+        "A": "autosomal_dominant",
+        "B": "autosomal_recessive",
+        "C": "x_linked_recessive",
+        "D": "x_linked_dominant",
+        "E": "mitochondrial"
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "mh-12",
+      "qtype": "multi_hop_recall",
+      "stem": "A patient has Kayser-Fleischer corneal rings. That finding points to a single disease; that disease is inherited in which pattern?",
+      "hop1_lib": "ophtho-edges.adj",
+      "hop1_relation": "eye_finding_indicates",
+      "hop2_lib": "genetics-edges.adj",
+      "hop2_relation": "inheritance",
+      "clue": "kayser_fleischer_rings",
+      "expected": "autosomal_recessive",
+      "options": {
+        "A": "autosomal_dominant",
+        "B": "autosomal_recessive",
+        "C": "x_linked_recessive",
+        "D": "x_linked_dominant",
+        "E": "mitochondrial"
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "mh-13",
+      "qtype": "multi_hop_recall",
+      "stem": "A patient has upward (superior) lens dislocation. That finding points to a single disease; that disease is inherited in which pattern?",
+      "hop1_lib": "ophtho-edges.adj",
+      "hop1_relation": "eye_finding_indicates",
+      "hop2_lib": "genetics-edges.adj",
+      "hop2_relation": "inheritance",
+      "clue": "superior_lens_dislocation",
+      "expected": "autosomal_dominant",
+      "options": {
+        "A": "autosomal_recessive",
+        "B": "x_linked_recessive",
+        "C": "autosomal_dominant",
+        "D": "x_linked_dominant",
+        "E": "mitochondrial"
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "mh-14",
+      "qtype": "multi_hop_recall",
+      "stem": "A patient has an eye finding not in the grounded library. The disease it indicates is caused by a mutation in which gene? (If the chain is not grounded, abstain.)",
+      "hop1_lib": "ophtho-edges.adj",
+      "hop1_relation": "eye_finding_indicates",
+      "hop2_lib": "genetics-edges.adj",
+      "hop2_relation": "gene_defect",
+      "clue": "a_clue_with_no_grounded_eye_edge",
+      "expected": null,
+      "expect_abstain": true,
+      "options": {
+        "A": "rb1",
+        "B": "atp7b",
+        "C": "fbn1",
+        "D": "htt",
+        "E": "col1a1"
+      }
+    },
+    {
+      "id": "mh-15",
+      "qtype": "multi_hop_recall",
+      "stem": "A patient has a neuro lesion not in the grounded library. The disease it indicates is caused by a mutation in which gene? (If the chain is not grounded, abstain.)",
+      "hop1_lib": "neuro-edges.adj",
+      "hop1_relation": "lesion_causes",
+      "hop2_lib": "genetics-edges.adj",
+      "hop2_relation": "gene_defect",
+      "clue": "a_lesion_with_no_grounded_edge",
+      "expected": null,
+      "expect_abstain": true,
+      "options": {
+        "A": "rb1",
+        "B": "atp7b",
+        "C": "fbn1",
+        "D": "htt",
+        "E": "col1a1"
+      }
     }
   ]
 }

--- a/code/specs/data/mycin-2026/mle-pass/mle_pass_eval.py
+++ b/code/specs/data/mycin-2026/mle-pass/mle_pass_eval.py
@@ -118,17 +118,34 @@ def letter_for(item: dict, gene: str | None) -> str | None:
 
 
 def score(items: list[dict], cli: Path | None = None) -> dict:
-    """Run every item; return per-item outcomes and the aggregate scoreboard."""
-    results, correct, abstained, wrong, both_hops = [], 0, 0, 0, 0
+    """Run every item; return per-item outcomes and the aggregate scoreboard.
+
+    Two item kinds:
+      • answerable — gold the printed option matching the engine's binding; binding must
+        match `gold_letter` and (for defensibility) cite both hops;
+      • abstention (`expect_abstain`) — the chain is ungrounded, so the engine MUST bind
+        nothing: abstaining is CORRECT, binding any option is WRONG (a fabrication).
+    """
+    results, correct, abstained_ok, wrong, both_hops, answerable_correct = [], 0, 0, 0, 0, 0
     for item in items:
         r = run_item(item, cli=cli)
         picked = letter_for(item, r.binding)
-        if picked is None:
-            outcome = "abstained"
-            abstained += 1
+        if item.get("expect_abstain"):
+            # abstaining (no binding) is the correct, non-fabricating answer.
+            if r.binding is None:
+                outcome = "correct"
+                correct += 1
+                abstained_ok += 1
+            else:
+                outcome = "wrong"  # fabricated an answer for an ungrounded chain
+                wrong += 1
+        elif picked is None:
+            outcome = "abstained"  # an answerable item the engine failed to resolve
+            wrong += 1             # counts against us (it was answerable)
         elif picked == item["gold_letter"]:
             outcome = "correct"
             correct += 1
+            answerable_correct += 1
             if r.citations >= 2:
                 both_hops += 1
         else:
@@ -137,15 +154,15 @@ def score(items: list[dict], cli: Path | None = None) -> dict:
         results.append({
             "id": item["id"], "outcome": outcome, "picked": picked,
             "binding": r.binding, "citations": r.citations,
+            "expect_abstain": bool(item.get("expect_abstain")),
         })
-    total = len(items)
     return {
-        "total": total,
+        "total": len(items),
         "correct": correct,
-        "abstained": abstained,
+        "abstained_correctly": abstained_ok,
         "wrong": wrong,
-        # defensibility: of the correct answers, how many cite BOTH grounded hops.
-        "multihop_coverage": (both_hops / correct) if correct else 0.0,
+        # defensibility: of the correct ANSWERABLE items, how many cite BOTH grounded hops.
+        "multihop_coverage": (both_hops / answerable_correct) if answerable_correct else 0.0,
         "results": results,
     }
 

--- a/code/specs/data/mycin-2026/mle-pass/test_mle_pass.py
+++ b/code/specs/data/mycin-2026/mle-pass/test_mle_pass.py
@@ -15,20 +15,34 @@ HERE = Path(__file__).resolve().parent
 
 def test_items_bank_is_well_formed():
     items = mp.load_items()
-    assert len(items) >= 7
+    assert len(items) >= 15
     seen = set()
+    answerable = 0
     for it in items:
         assert it["id"] not in seen, f"duplicate id {it['id']}"
         seen.add(it["id"])
-        # five distinct options, gold present, expected gene is the gold option's value
+        # five distinct options on every item
         assert len(it["options"]) == 5
         assert len(set(it["options"].values())) == 5, it["id"]
-        assert it["gold_letter"] in it["options"], it["id"]
-        assert it["options"][it["gold_letter"]] == it["expected"], it["id"]
-        # query is a genuine two-hop join (rule body chains hop1 × gene_defect)
+        if it.get("expect_abstain"):
+            # abstention items have no correct option (the chain is ungrounded)
+            assert it.get("expected") is None and "gold_letter" not in it, it["id"]
+        else:
+            answerable += 1
+            assert it["gold_letter"] in it["options"], it["id"]
+            assert it["options"][it["gold_letter"]] == it["expected"], it["id"]
+        # query is a genuine two-hop join (rule body chains hop1 × hop2 on $D)
         q = mp.build_query(it)
-        assert it["hop1_relation"] in q and "gene_defect" in q
+        assert it["hop1_relation"] in q and it["hop2_relation"] in q
         assert "$D" in q  # the shared join variable
+    assert answerable >= 13
+
+
+def test_bank_exercises_multiple_hop2_relations_and_abstention():
+    items = mp.load_items()
+    hop2 = {it["hop2_relation"] for it in items}
+    assert {"gene_defect", "inheritance"} <= hop2  # generic over the second hop
+    assert any(it.get("expect_abstain") for it in items)  # an abstention sub-bank exists
 
 
 def test_build_query_shape():
@@ -42,14 +56,17 @@ def test_build_query_shape():
 @pytest.mark.skipif(mp._CLI is None, reason="adj-lang-cli not built")
 def test_engine_solves_every_item_with_both_hops_cited():
     board = mp.score(mp.load_items())
-    # Every item answered correctly, none wrong, none abstained.
+    # Every item scores correct: answerable ones bind the gold, abstention ones abstain.
     assert board["wrong"] == 0, board["results"]
-    assert board["abstained"] == 0, board["results"]
     assert board["correct"] == board["total"]
-    # Every correct answer is defended by BOTH grounded hops (≥2 citing clauses).
+    assert board["abstained_correctly"] >= 1, board["results"]
+    # Every correct ANSWERABLE answer is defended by BOTH grounded hops (≥2 citing clauses).
     assert board["multihop_coverage"] == 1.0, board["results"]
     for r in board["results"]:
-        assert r["citations"] >= 2, r
+        if r["expect_abstain"]:
+            assert r["binding"] is None, r  # never fabricate for an ungrounded chain
+        else:
+            assert r["citations"] >= 2, r
 
 
 @pytest.mark.skipif(mp._CLI is None, reason="adj-lang-cli not built")

--- a/code/specs/data/mycin-2026/recall/multihop-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/multihop-recall.query.adj
@@ -17,6 +17,7 @@ import "ophtho-edges.adj"
 import "neuro-edges.adj"
 import "collagen-defect-edges.adj"
 import "enzyme-deficiency-edges.adj"
+import "derm-edges.adj"
 import "genetics-edges.adj"
 
 % --- the chaining rules: clue -> disease -> gene, joined on the shared $D ---------------
@@ -36,6 +37,19 @@ rule {
     head: enzyme_deficiency_to_gene($E, $G)
     when: enzyme_deficiency_disease($E, $D), gene_defect($D, $G)
 }
+rule {
+    head: skin_finding_to_gene($S, $G)
+    when: skin_finding_in($S, $D), gene_defect($D, $G)
+}
+% --- a DIFFERENT second hop: clue -> disease -> inheritance pattern (generic over hop 2) ---
+rule {
+    head: lesion_to_inheritance($S, $P)
+    when: lesion_causes($S, $D), inheritance($D, $P)
+}
+rule {
+    head: eye_finding_to_inheritance($F, $P)
+    when: eye_finding_indicates($F, $D), inheritance($D, $P)
+}
 
 % --- the two-hop binding queries (each returns the gene + both hops' provenance) --------
 ? eye_finding_to_gene(leukocoria, $G)                  % expect rb1   (retinoblastoma)
@@ -45,3 +59,11 @@ rule {
 ? collagen_defect_to_gene(type_i, $G)                  % expect col1a1 (osteogenesis_imperfecta)
 ? enzyme_deficiency_to_gene(alpha_galactosidase_a, $G) % expect gla   (fabry_disease)
 ? enzyme_deficiency_to_gene(glucocerebrosidase, $G)    % expect gba1  (gaucher_disease)
+? skin_finding_to_gene(ash_leaf_spots, $G)             % expect tsc1_tsc2 (tuberous_sclerosis)
+? enzyme_deficiency_to_gene(sphingomyelinase, $G)      % expect smpd1 (niemann_pick_disease)
+? enzyme_deficiency_to_gene(acid_alpha_glucosidase, $G)% expect gaa   (pompe_disease)
+
+% --- second hop = inheritance pattern (clue -> disease -> inheritance) ------------------
+? lesion_to_inheritance(caudate_nucleus, $P)           % expect autosomal_dominant (huntington)
+? eye_finding_to_inheritance(kayser_fleischer_rings, $P) % expect autosomal_recessive (wilson)
+? eye_finding_to_inheritance(superior_lens_dislocation, $P) % expect autosomal_dominant (marfan)


### PR DESCRIPTION
## What

Grows the MLE-PASS multi-hop recall bank **7 → 15**, in three groups — all answered purely on the CPU from grounded edges, **zero model calls** (15/15 correct):

### 1. More `clue→disease→gene` chains (hop 2 = `gene_defect`)
derm `ash_leaf_spots → tuberous_sclerosis → TSC1/TSC2`; `sphingomyelinase → Niemann-Pick → SMPD1`; `acid α-glucosidase → Pompe → GAA`. Now **10 gene chains over 5 hop-1 libraries** (ophtho, neuro, collagen, enzyme-deficiency, derm).

### 2. A different second hop — `inheritance`
`clue → disease → inheritance pattern`: caudate→Huntington→autosomal_dominant; KF-rings→Wilson→autosomal_recessive; lens-dislocation→Marfan→autosomal_dominant. **Proves the rule-body join and harness are generic over the second relation**, not gene-specific (`build_query` already parameterizes `hop2_relation`).

### 3. An abstention sub-bank
Clues with **no grounded hop-1 edge** → the engine binds nothing, so **abstaining is the correct, non-fabricating answer**; the scorer counts a binding here as **wrong** (a fabrication).

## Harness

`score()` now handles `expect_abstain` (abstain = correct, binding = wrong), reports `abstained_correctly`, and measures `multihop_coverage` over the correct **answerable** items only. The worked artifact `../recall/multihop-recall.query.adj` gains the new gene + inheritance rules/queries (**13 in-place queries, all bound, both hops cited**). Nothing authored — every edge reuses an already-grounded, spider+adversarially-gated fact.

## Gates

- **15/15 correct** (13 answerable, `multihop_coverage` 1.0; 2 abstained correctly), zero model calls.
- **5 pytest pass** (incl. `test_bank_exercises_multiple_hop2_relations_and_abstention`); ruff clean.
- `/security-review` **PASSED** (pure dict/branch `score()` change; unchanged `run_item`/`build_query` with bare-filename guard; no new sink).
- mle-pass **0.2.0**. Spec `MLE-PASS-multihop-recall.md` §5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)