### PR TITLE
Fix Engram Mosaic demo generation

### DIFF
--- a/code/packages/rust/mosaic-emit-react/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-react/src/pipeline.rs
@@ -431,9 +431,7 @@ fn build_fallback_props_object(slots: &[SlotDecl]) -> String {
 
 fn sample_ts_value_for_slot(slot: &SlotDecl) -> String {
     match &slot.default {
-        Some(SlotDefault::Text(value)) => {
-            format!("\"{}\"", escape_for_jsx_double_quoted(value))
-        }
+        Some(SlotDefault::Text(value)) => js_string_literal(value),
         Some(SlotDefault::Number(value)) if value.is_finite() => format!("{value}"),
         Some(SlotDefault::Number(_)) => "0".to_string(),
         Some(SlotDefault::Bool(value)) => value.to_string(),
@@ -1566,13 +1564,10 @@ fn emit_input_jsx(
     }
 
     // placeholder="text"  — string-literal moslayout prop (post-PR-H).
-    // Escaping: JSX double-quoted attributes require `\` and `"` escaped;
-    // newlines/tabs pass through as their literal characters.
+    // Escaping: simple strings stay as JSX quoted attributes; strings that
+    // need JavaScript escaping use JSX expression form.
     if let Some(s) = find_string_prop(node, "placeholder") {
-        attrs.push_str(&format!(
-            " placeholder=\"{}\"",
-            escape_for_jsx_double_quoted(s)
-        ));
+        attrs.push_str(&jsx_string_attr("placeholder", s));
     }
 
     // maxLength={N}
@@ -1704,10 +1699,7 @@ fn emit_host_input_jsx(
 
     // placeholder="text" — string-literal moslayout prop.
     if let Some(s) = find_string_prop(node, "placeholder") {
-        attrs.push_str(&format!(
-            " placeholder=\"{}\"",
-            escape_for_jsx_double_quoted(s)
-        ));
+        attrs.push_str(&jsx_string_attr("placeholder", s));
     }
 
     // onChange={e => dispatch({ type: "...", value: e.target.value })}
@@ -1867,7 +1859,7 @@ fn host_button_label_body(node: &LayoutNode) -> Result<String, PipelineEmitError
             // context (rare, but possible if the host wants Unicode).  We
             // reuse the double-quoted escaper for `\` and `"`, then wrap the
             // result as a string expression so HTML entities don't escape us.
-            Ok(format!("{{\"{}\"}}", escape_for_jsx_double_quoted(s)))
+            Ok(jsx_string_expr(s))
         }
         LayoutPropValue::SlotRef(slot) => {
             let camel = to_camel_case_first_lower(slot);
@@ -2329,7 +2321,7 @@ fn emit_host_checkbox_jsx(
     // to generate stable unique IDs and is the idiomatic React shape for
     // a single-line checkbox-with-text.
     let label_body: Option<String> = if let Some(s) = find_string_prop(node, "label") {
-        Some(format!("{{\"{}\"}}", escape_for_jsx_double_quoted(s)))
+        Some(jsx_string_expr(s))
     } else if let Some(slot) = find_slot_ref_prop(node, "label") {
         let camel = to_camel_case_first_lower(slot);
         validate_slot_or_field_name(&camel).map_err(PipelineEmitError::UnsafeSlotName)?;
@@ -2399,7 +2391,7 @@ fn emit_host_radio_jsx(
 
     // `name="group"` (string literal) or `name={group}` (slot ref).
     if let Some(g) = find_string_prop(node, "group") {
-        attrs.push_str(&format!(" name=\"{}\"", escape_for_jsx_double_quoted(g)));
+        attrs.push_str(&jsx_string_attr("name", g));
     } else if let Some(slot) = find_slot_ref_prop(node, "group") {
         let camel = to_camel_case_first_lower(slot);
         validate_slot_or_field_name(&camel).map_err(PipelineEmitError::UnsafeSlotName)?;
@@ -2408,7 +2400,7 @@ fn emit_host_radio_jsx(
 
     // `value="v"` (string literal) or `value={v}` (slot ref).
     if let Some(v) = find_string_prop(node, "value") {
-        attrs.push_str(&format!(" value=\"{}\"", escape_for_jsx_double_quoted(v)));
+        attrs.push_str(&jsx_string_attr("value", v));
     } else if let Some(slot) = find_slot_ref_prop(node, "value") {
         let camel = to_camel_case_first_lower(slot);
         validate_slot_or_field_name(&camel).map_err(PipelineEmitError::UnsafeSlotName)?;
@@ -2439,7 +2431,7 @@ fn emit_host_radio_jsx(
 
     // Optional `<label>` wrapping — same idiom as HostCheckbox.
     let label_body: Option<String> = if let Some(s) = find_string_prop(node, "label") {
-        Some(format!("{{\"{}\"}}", escape_for_jsx_double_quoted(s)))
+        Some(jsx_string_expr(s))
     } else if let Some(slot) = find_slot_ref_prop(node, "label") {
         let camel = to_camel_case_first_lower(slot);
         validate_slot_or_field_name(&camel).map_err(PipelineEmitError::UnsafeSlotName)?;
@@ -2505,8 +2497,8 @@ fn emit_host_link_jsx(
 
     // href= — string literal or slot ref.
     let href_expr: String = if let Some(s) = find_string_prop(node, "href") {
-        attrs.push_str(&format!(" href=\"{}\"", escape_for_jsx_double_quoted(s)));
-        format!("\"{}\"", escape_for_jsx_double_quoted(s))
+        attrs.push_str(&jsx_string_attr("href", s));
+        js_string_literal(s)
     } else if let Some(slot) = find_slot_ref_prop(node, "href") {
         let camel = to_camel_case_first_lower(slot);
         validate_slot_or_field_name(&camel).map_err(PipelineEmitError::UnsafeSlotName)?;
@@ -2549,7 +2541,7 @@ fn emit_host_link_jsx(
 
     // Body: label (string or slot) OR children.
     let label_body: Option<String> = if let Some(s) = find_string_prop(node, "label") {
-        Some(format!("{{\"{}\"}}", escape_for_jsx_double_quoted(s)))
+        Some(jsx_string_expr(s))
     } else if let Some(slot) = find_slot_ref_prop(node, "label") {
         let camel = to_camel_case_first_lower(slot);
         validate_slot_or_field_name(&camel).map_err(PipelineEmitError::UnsafeSlotName)?;
@@ -2663,7 +2655,7 @@ fn emit_host_tooltip_jsx(
 
     // title= — string literal or slot ref.
     if let Some(s) = find_string_prop(node, "text") {
-        attrs.push_str(&format!(" title=\"{}\"", escape_for_jsx_double_quoted(s)));
+        attrs.push_str(&jsx_string_attr("title", s));
     } else if let Some(slot) = find_slot_ref_prop(node, "text") {
         let camel = to_camel_case_first_lower(slot);
         validate_slot_or_field_name(&camel).map_err(PipelineEmitError::UnsafeSlotName)?;
@@ -2749,10 +2741,7 @@ fn emit_host_number_input_jsx(
 
     // placeholder.
     if let Some(s) = find_string_prop(node, "placeholder") {
-        attrs.push_str(&format!(
-            " placeholder=\"{}\"",
-            escape_for_jsx_double_quoted(s)
-        ));
+        attrs.push_str(&jsx_string_attr("placeholder", s));
     }
 
     // disabled.
@@ -3679,17 +3668,40 @@ fn find_string_prop<'a>(node: &'a LayoutNode, prop_name: &str) -> Option<&'a str
     })
 }
 
-/// Escape a Rust `&str` for embedding inside a JSX double-quoted string
-/// attribute value. The only characters JSX requires escaped inside a
-/// `"..."` attribute are `"` (close the literal) and `\` (the escape
-/// character itself). Newlines / tabs are preserved as their literal
-/// characters because JSX double-quoted attributes accept them.
-fn escape_for_jsx_double_quoted(s: &str) -> String {
+fn jsx_string_attr(name: &str, value: &str) -> String {
+    if can_use_jsx_quoted_attr(value) {
+        format!(" {name}=\"{value}\"")
+    } else {
+        format!(" {name}={}", jsx_string_expr(value))
+    }
+}
+
+fn jsx_string_expr(value: &str) -> String {
+    format!("{{{}}}", js_string_literal(value))
+}
+
+fn js_string_literal(value: &str) -> String {
+    format!("\"{}\"", escape_for_js_string_literal(value))
+}
+
+fn can_use_jsx_quoted_attr(value: &str) -> bool {
+    value
+        .chars()
+        .all(|c| !matches!(c, '"' | '\\' | '\n' | '\r' | '\t'))
+}
+
+/// Escape a Rust `&str` for embedding inside a JavaScript double-quoted
+/// string literal. JSX expression attributes use this form for values that
+/// quoted JSX attributes cannot represent safely, such as embedded quotes.
+fn escape_for_js_string_literal(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
     for c in s.chars() {
         match c {
             '\\' => out.push_str("\\\\"),
             '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
             other => out.push(other),
         }
     }
@@ -5161,8 +5173,9 @@ mod tests {
         );
     }
 
-    /// Double quotes and backslashes inside the placeholder string get
-    /// escaped so the generated JSX attribute stays well-formed.
+    /// Double quotes and backslashes inside the placeholder string switch
+    /// the generated JSX attribute to expression form so the TSX parser sees
+    /// a normal JavaScript string literal.
     #[test]
     fn input_placeholder_escapes_quotes_and_backslashes() {
         let m = component("X", vec![], vec![]);
@@ -5174,8 +5187,8 @@ mod tests {
         assert!(
             result
                 .output
-                .contains(r#"placeholder="say \"hi\" \\ then more""#),
-            "expected escaped placeholder attr, got:\n{}",
+                .contains(r#"placeholder={"say \"hi\" \\ then more"}"#),
+            "expected expression-form placeholder attr, got:\n{}",
             result.output
         );
     }
@@ -5725,6 +5738,23 @@ mod tests {
         assert!(
             result.output.contains("placeholder=\"Type a formula\""),
             "expected placeholder attr, got:\n{}",
+            result.output
+        );
+    }
+
+    #[test]
+    fn host_input_placeholder_with_quotes_uses_expression_attr() {
+        let m = component("X", vec![], vec![]);
+        let l = host_input_layout(vec![LayoutProp {
+            name: "placeholder".to_string(),
+            value: LayoutPropValue::String(r#"preset:"Default" -is:suspended"#.to_string()),
+        }]);
+        let result = from_pipeline(&m, &l, &empty_style("X")).unwrap();
+        assert!(
+            result
+                .output
+                .contains(r#"placeholder={"preset:\"Default\" -is:suspended"}"#),
+            "expected expression-form placeholder attr, got:\n{}",
             result.output
         );
     }

--- a/code/packages/rust/mosaic-package-resolver/src/lib.rs
+++ b/code/packages/rust/mosaic-package-resolver/src/lib.rs
@@ -761,9 +761,13 @@ fn read_component_source(pkg: &str, comp: &str, path: &Path) -> Result<String, L
 }
 
 fn build_binding_map(call_props: &[LayoutProp]) -> HashMap<String, LayoutPropValue> {
-    let mut bindings = HashMap::with_capacity(call_props.len());
+    let mut bindings = HashMap::with_capacity(call_props.len() * 2);
     for prop in call_props {
         bindings.insert(prop.name.clone(), prop.value.clone());
+        let camel = to_camel_case_first_lower(&prop.name);
+        if camel != prop.name {
+            bindings.insert(camel, prop.value.clone());
+        }
     }
     bindings
 }
@@ -781,12 +785,138 @@ fn rewrite_bindings(node: &mut LayoutNode, bindings: &HashMap<String, LayoutProp
                     prop.value = value.clone();
                 }
             }
+            LayoutPropValue::Expr(text) => {
+                let rewritten = rewrite_expression_bindings(text, bindings);
+                if rewritten != *text {
+                    prop.value = LayoutPropValue::Expr(rewritten);
+                }
+            }
             _ => {}
         }
     }
     for child in &mut node.children {
         rewrite_bindings(child, bindings);
     }
+}
+
+fn rewrite_expression_bindings(expr: &str, bindings: &HashMap<String, LayoutPropValue>) -> String {
+    let mut out = String::with_capacity(expr.len());
+    let bytes = expr.as_bytes();
+    let mut i = 0;
+    let mut prev_non_ws: Option<u8> = None;
+
+    while i < bytes.len() {
+        let b = bytes[i];
+        if b == b'"' {
+            let start = i;
+            i += 1;
+            let mut escaped = false;
+            while i < bytes.len() {
+                let c = bytes[i];
+                i += 1;
+                if escaped {
+                    escaped = false;
+                    continue;
+                }
+                if c == b'\\' {
+                    escaped = true;
+                    continue;
+                }
+                if c == b'"' {
+                    break;
+                }
+            }
+            out.push_str(&expr[start..i]);
+            prev_non_ws = Some(b'"');
+            continue;
+        }
+
+        if is_identifier_start(b) {
+            let start = i;
+            i += 1;
+            while i < bytes.len() && is_identifier_continue(bytes[i]) {
+                i += 1;
+            }
+            let ident = &expr[start..i];
+            if prev_non_ws != Some(b'.') {
+                if let Some(value) = bindings.get(ident) {
+                    out.push_str(&layout_prop_value_as_expression(value));
+                } else {
+                    out.push_str(ident);
+                }
+            } else {
+                out.push_str(ident);
+            }
+            prev_non_ws = Some(bytes[i - 1]);
+            continue;
+        }
+
+        out.push(b as char);
+        if !b.is_ascii_whitespace() {
+            prev_non_ws = Some(b);
+        }
+        i += 1;
+    }
+
+    out
+}
+
+fn layout_prop_value_as_expression(value: &LayoutPropValue) -> String {
+    match value {
+        LayoutPropValue::SlotRef(name) => to_camel_case_first_lower(name),
+        LayoutPropValue::EmitRef(name) => to_camel_case_first_lower(name),
+        LayoutPropValue::Keyword(name) => to_camel_case_first_lower(name),
+        LayoutPropValue::Number(n) => n.to_string(),
+        LayoutPropValue::String(s) => js_string_literal(s),
+        LayoutPropValue::Expr(text) => format!("( {text} )"),
+    }
+}
+
+fn js_string_literal(value: &str) -> String {
+    let mut out = String::with_capacity(value.len() + 2);
+    out.push('"');
+    for ch in value.chars() {
+        match ch {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            _ => out.push(ch),
+        }
+    }
+    out.push('"');
+    out
+}
+
+fn is_identifier_start(b: u8) -> bool {
+    b == b'_' || b.is_ascii_alphabetic()
+}
+
+fn is_identifier_continue(b: u8) -> bool {
+    is_identifier_start(b) || b.is_ascii_digit()
+}
+
+fn to_camel_case_first_lower(s: &str) -> String {
+    let mut out = String::new();
+    let mut cap_next = false;
+    let mut first = true;
+    for ch in s.chars() {
+        if ch == '-' {
+            cap_next = true;
+            continue;
+        }
+        if first {
+            out.push(ch.to_ascii_lowercase());
+            first = false;
+        } else if cap_next {
+            out.push(ch.to_ascii_uppercase());
+            cap_next = false;
+        } else {
+            out.push(ch);
+        }
+    }
+    out
 }
 
 fn qualify_local_refs(node: &mut LayoutNode, pkg: &str, pkg_exports: &[String]) {
@@ -1308,6 +1438,78 @@ version = "1"
                     && prop.value == LayoutPropValue::EmitRef("outer-click".to_string())
             }),
             "emit binding should be rewritten to the consumer emit"
+        );
+    }
+
+    #[test]
+    fn layout_inliner_rewrites_expression_binding_identifiers() {
+        let tmp = TempDir::new().unwrap();
+        let pkgs = tmp.path().join("packages");
+        fs::create_dir_all(&pkgs).unwrap();
+        let mini = make_pkg(
+            &pkgs,
+            "mosaic-pkg-selector",
+            "mosaic-pkg-selector",
+            &["Selector"],
+        );
+        write_component(
+            &mini,
+            "Selector",
+            r#"component Selector {
+  slot selected-index : number ;
+  slot label : text ;
+}"#,
+            r#"layout Selector {
+  If ( when: selectedIndex == 0 ) {
+    Text [ selected-label ] ( slot: label )
+  }
+}"#,
+        );
+
+        let resolver = LayoutPackageResolver::new(vec![pkgs]);
+        let mut layout = consumer_layout(
+            r#"layout Demo {
+  pkg::mosaic-pkg-selector::Selector (
+    selected-index : slot: browser-selected-index ,
+    label : slot: outer-label
+  )
+}"#,
+        );
+
+        resolver.resolve(&mut layout).expect("layout resolves");
+
+        assert_eq!(layout.root.tag, "If");
+        assert!(
+            layout.root.props.iter().any(|prop| {
+                prop.name == "when"
+                    && prop.value == LayoutPropValue::Expr("browserSelectedIndex == 0".to_string())
+            }),
+            "expression binding should be rewritten to the consumer slot: {:#?}",
+            layout.root.props
+        );
+        assert!(
+            layout.root.children[0].props.iter().any(|prop| {
+                prop.name == "slot"
+                    && prop.value == LayoutPropValue::SlotRef("outer-label".to_string())
+            }),
+            "nested direct slot binding should still be rewritten"
+        );
+    }
+
+    #[test]
+    fn expression_binding_rewrite_skips_member_names_and_strings() {
+        let mut bindings = HashMap::new();
+        bindings.insert(
+            "selectedIndex".to_string(),
+            LayoutPropValue::SlotRef("browser-selected-index".to_string()),
+        );
+
+        assert_eq!(
+            rewrite_expression_bindings(
+                r#"i == selectedIndex && item.selectedIndex != "selectedIndex""#,
+                &bindings
+            ),
+            r#"i == browserSelectedIndex && item.selectedIndex != "selectedIndex""#
         );
     }
 


### PR DESCRIPTION
## Summary
- emit JSX string attributes as expression literals when values contain quotes/backslashes so generated React/Electron TSX parses cleanly
- rewrite inlined dependency expression identifiers across Mosaic package boundaries so child predicates like ListGroup.selectedIndex bind to parent slots such as browserSelectedIndex
- regenerate Engram Mosaic shells from the clean main base and verify React/Electron builds

## Verification
- cargo test --manifest-path code/packages/rust/mosaic-package-resolver/Cargo.toml
- cargo test --manifest-path code/packages/rust/mosaic-emit-react/Cargo.toml
- cargo test --manifest-path code/programs/mosaic/engram-app/Cargo.toml
- powershell -ExecutionPolicy Bypass -File code/programs/mosaic/engram-app/scripts/build-all.ps1
- npm run build (react shell)
- npm run build (electron shell)
- live previews served locally: React 5173, HTML 5174, WebComponent 5175