### PR TITLE
feat(js-sir): javascript-to-semantic-ir crate skeleton + literals (C1)

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -510,6 +510,7 @@ members = [
     "repl",
     "ruby-bridge",
     "ruby-to-semantic-ir",
+    "javascript-to-semantic-ir",
     "scytale-cipher",
     "sha256",
     "sha512",

--- a/code/packages/rust/javascript-to-semantic-ir/BUILD
+++ b/code/packages/rust/javascript-to-semantic-ir/BUILD
@@ -1,0 +1,1 @@
+cargo test -p javascript-to-semantic-ir -- --nocapture

--- a/code/packages/rust/javascript-to-semantic-ir/BUILD_windows
+++ b/code/packages/rust/javascript-to-semantic-ir/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p javascript-to-semantic-ir -- --nocapture

--- a/code/packages/rust/javascript-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/javascript-to-semantic-ir/CHANGELOG.md
@@ -1,0 +1,69 @@
+# Changelog
+
+All notable changes to `javascript-to-semantic-ir` are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/),
+and this project adheres to [Semantic Versioning](https://semver.org/).
+
+## 0.1.0
+
+First release — SIR19 milestone **M1 (crate skeleton + literal
+lowering)**.
+
+### Added
+
+- Crate skeleton: `Cargo.toml` (path deps on `semantic-ir`,
+  `coding-adventures-javascript-parser`, `parser`, `lexer`), `BUILD` /
+  `BUILD_windows`, `README.md`, and this changelog.
+- Public API:
+  - `compile(tree: &GrammarASTNode, module_name: &str) -> Result<Module, JsLowerError>`
+    — lower an already-parsed JavaScript CST.
+  - `compile_source(source: &str, module_name: &str) -> Result<Module, JsLowerError>`
+    — parse (with the `es2020` grammar) then lower, surfacing parse
+    failures as `JsLowerError`s with a best-effort `line:column`.
+  - `JsLowerError { message, line, column }`
+    (`Debug`/`Clone`/`PartialEq`/`Eq`, plus `Display` + `std::error::Error`).
+- Literal lowering from the **generic** `GrammarASTNode`:
+  - integer-shaped number literal → `IntLit`;
+  - decimal / exponent number literal → `FloatLit`;
+  - `true` / `false` → `BoolLit`;
+  - `null` **and** `undefined` → `NilLit` (the JS distinction is
+    intentionally lost in v0);
+  - string literal (single- or double-quoted) → `StrLit`.
+- Synthesises an exported `main` function whose body's tail value is the
+  final top-level literal (or `NilLit` for empty source).
+- Stamps `metadata.source_language = "javascript"` and
+  `metadata.sir_version = CURRENT_SIR_VERSION`, and emits a feature
+  manifest declaring exactly the observed features (`Strings`,
+  `Floats`), so every produced module passes `semantic_ir::validate`.
+- 17 unit tests: one per literal kind, `compile_source` structural
+  checks, a validate round-trip, and error paths (operator expression,
+  bare identifier, parse failure, position extractor).
+
+### Deferred
+
+The following are explicitly **out of scope for M1** and currently
+return a clear `JsLowerError`. They are scheduled for later milestones,
+tracked against the SIR19 spec
+(`code/specs/SIR19-javascript-to-semantic-ir.md`):
+
+- **M2 — variables & operators:** variable references (`VarRef`),
+  `let`/`const`/`var` (`LetBinding`), re-assignment (`Assign`),
+  arithmetic / comparison / logical operators, unary `!`/`-`, loose vs.
+  strict equality normalisation.
+- **M3 — control flow:** `if`/`else`, `while`, `for` (`ForRange`),
+  `for-of` (`ForEach`).
+- **M4 — functions & closures:** `function` declarations, arrow
+  functions (`MakeClosure`), `return`, calls (`DirectCall` /
+  `IndirectCall`), `console.log` → `BuiltinCall("print", …)`.
+- **M5 — collections:** array literals (`SeqLit`), indexing
+  (`SeqIndex`), `.length` (`SeqLen`), object literals (`MapLit`),
+  member/`[]` access (`MapGet`).
+- **Template literals** (backtick strings, e.g. `` `a ${x} b` ``):
+  deferred — these are a distinct token/rule from plain strings and will
+  desugar to `+`-concatenation in a later milestone.
+- **Non-decimal numeric forms:** hex (`0x…`), octal (`0o…`), binary
+  (`0b…`), and `BigInt` (`10n`) literals are rejected in M1.
+- Everything in the SIR19 spec "Out of scope (deferred)" section:
+  classes, exceptions, generators, `async`/`await`, destructuring,
+  spread/rest, default parameters, ES modules, `eval`, regex.

--- a/code/packages/rust/javascript-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/javascript-to-semantic-ir/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "javascript-to-semantic-ir"
+version = "0.1.0"
+edition = "2021"
+description = "JavaScript (GrammarASTNode CST) → narrow-waist Semantic IR. SIR19 frontend, milestone M1 (literals)."
+
+[dependencies]
+coding-adventures-javascript-parser = { path = "../javascript-parser" }
+lexer = { path = "../lexer" }
+parser = { path = "../parser" }
+semantic-ir = { path = "../semantic-ir" }

--- a/code/packages/rust/javascript-to-semantic-ir/README.md
+++ b/code/packages/rust/javascript-to-semantic-ir/README.md
@@ -1,0 +1,114 @@
+# javascript-to-semantic-ir
+
+JavaScript → narrow-waist [Semantic IR](../semantic-ir/) frontend (SIR19).
+
+This crate is the JavaScript entry point into the Semantic IR (SIR)
+pipeline, joining the existing Twig (SIR11), Python (SIR17), and Ruby
+frontends. It consumes the **generic concrete syntax tree**
+(`parser::grammar_parser::GrammarASTNode`) emitted by the
+[`javascript-parser`](../javascript-parser/) crate and produces a
+`semantic_ir::Module` that any SIR backend (`semantic-ir-to-rust`,
+`-typescript`, `-go`, `-python`) can consume.
+
+```text
+JavaScript source
+   │
+   ▼  javascript_parser::parse_javascript(source, "es2020")
+parser::grammar_parser::GrammarASTNode   (generic CST)
+   │
+   ▼  javascript_to_semantic_ir::compile_source     ← THIS CRATE
+semantic_ir::Module
+   │
+   ▼  semantic-ir-to-{rust, typescript, go, python}
+target source
+```
+
+We lower from the *generic* `GrammarASTNode`, **not** from the parser's
+typed-AST bridge (`javascript-parser/src/bridge.rs`). That is the
+contract SIR19 sets, matching how the Ruby and Twig frontends work.
+
+## Milestone status — M1 (literals)
+
+This is the first slice of SIR19. It implements **literal lowering
+only**. The supported subset:
+
+| JavaScript source        | SIR lowering                                  |
+|--------------------------|-----------------------------------------------|
+| `42`, `0`, `-`-free ints | `IntLit { value }`                            |
+| `3.25`, `1e3`, `1.5e-3`  | `FloatLit { value }`                          |
+| `true`, `false`          | `BoolLit { value }`                           |
+| `null`                   | `NilLit`                                       |
+| `undefined`              | `NilLit` (distinction from `null` is lost)    |
+| `"hi"`, `'hi'`           | `StrLit { value }`                            |
+
+### Number classification
+
+JavaScript has a single numeric type (an IEEE-754 double). We split it
+on the literal's *textual shape*: a literal with no `.` and no exponent
+marker (`e`/`E`) that fits in an `i64` becomes an `IntLit`; everything
+else becomes a `FloatLit`. This lets integer-heavy code round-trip
+cleanly through backends that distinguish integers from floats. Hex /
+octal / binary integer forms (`0x…`, `0o…`, `0b…`) and `BigInt` (`10n`)
+are rejected in M1 (deferred).
+
+### `null` vs `undefined`
+
+Both lower to `NilLit`. The IR has a single "absence" value, so the JS
+distinction is intentionally lost in v0. Note `undefined` is an
+*identifier* in JS (not a keyword), so the lowerer special-cases that
+exact spelling; any other bare identifier is a variable reference, which
+is out of M1 scope.
+
+## Public API
+
+```rust
+use javascript_to_semantic_ir::{compile, compile_source, JsLowerError};
+
+// Parse + lower in one call:
+let module = compile_source("42;", "demo")?;
+
+// Or lower an already-parsed CST:
+// let module = compile(&tree, "demo")?;
+```
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct JsLowerError {
+    pub message: String,
+    pub line:    usize,   // 1-based; 0 when unknown
+    pub column:  usize,   // 1-based; 0 when unknown
+}
+```
+
+Every produced `Module`:
+
+- wraps the top-level statements in a synthetic, exported `main`
+  function whose body's tail value is the final literal expression (or
+  `NilLit` for empty input);
+- carries `metadata.source_language = "javascript"` and
+  `metadata.sir_version = semantic_ir::CURRENT_SIR_VERSION`;
+- declares **exactly** the features its literals use (`Strings` for any
+  string literal, `Floats` for any float literal) so it passes
+  `semantic_ir::validate` with no used-but-undeclared errors and no
+  declared-but-unused warnings.
+
+## Out of scope for M1 (deferred)
+
+Variables, operators, control flow, functions, collections, and
+template literals all currently return a `JsLowerError` describing what
+was rejected, with the offending node's position. The error sites are
+structured so later milestones slot their handling in at exactly the
+right place. See `CHANGELOG.md` for the milestone roadmap and the full
+SIR19 spec at [`code/specs/SIR19-javascript-to-semantic-ir.md`](../../../specs/SIR19-javascript-to-semantic-ir.md).
+
+## Testing
+
+```sh
+cargo test -p javascript-to-semantic-ir
+```
+
+On Windows, prefix with the LLD linker:
+
+```sh
+CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER=rust-lld cargo test -p javascript-to-semantic-ir
+```

--- a/code/packages/rust/javascript-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/javascript-to-semantic-ir/src/lib.rs
@@ -1,0 +1,308 @@
+//! # javascript-to-semantic-ir
+//!
+//! JavaScript CST → narrow-waist [Semantic IR](semantic_ir).
+//!
+//! The SIR19 JavaScript frontend (after Twig in SIR11, Python in SIR17,
+//! and Ruby).  It consumes the generic
+//! [`GrammarASTNode`](parser::grammar_parser::GrammarASTNode) produced by
+//! the [`javascript-parser`](coding_adventures_javascript_parser) crate
+//! and emits a [`semantic_ir::Module`] suitable for any SIR backend.
+//!
+//! ## Pipeline
+//!
+//! ```text
+//! JavaScript source
+//!    │
+//!    ▼  javascript_parser::parse_javascript(source, "es2020")
+//! parser::grammar_parser::GrammarASTNode  (generic CST)
+//!    │
+//!    ▼  javascript_to_semantic_ir::compile_source     ← THIS CRATE
+//! semantic_ir::Module
+//!    │
+//!    ▼  semantic-ir-to-{rust, typescript, go, python}
+//! target source
+//! ```
+//!
+//! We deliberately lower from the **generic** `GrammarASTNode` (the CST),
+//! not from the parser's typed-AST bridge — that's the contract SIR19
+//! sets, mirroring the Ruby and Twig frontends.
+//!
+//! ## Milestone status — M1 (literals)
+//!
+//! This build implements **literal lowering only**:
+//!
+//! - JS number → [`IntLit`](semantic_ir::Expr::IntLit) when the literal
+//!   text is an integer (no `.`/exponent), else
+//!   [`FloatLit`](semantic_ir::Expr::FloatLit).
+//! - `true`/`false` → [`BoolLit`](semantic_ir::Expr::BoolLit).
+//! - `null` **and** `undefined` → [`NilLit`](semantic_ir::Expr::NilLit)
+//!   (the JS distinction is intentionally lost in v0).
+//! - string → [`StrLit`](semantic_ir::Expr::StrLit).
+//!
+//! All other syntax (variables, operators, control flow, functions,
+//! collections, template literals) is **deferred** to later milestones
+//! and currently produces a clear [`JsLowerError`].  See the crate
+//! `CHANGELOG.md` "Deferred" section for the roadmap.
+//!
+//! ## Public API
+//!
+//! ```ignore
+//! use javascript_to_semantic_ir::{compile_source, JsLowerError};
+//!
+//! let module = compile_source("42;", "demo")?;
+//! // `module` is a `semantic_ir::Module` with a `main` whose body
+//! // value is `IntLit { value: 42 }`.
+//! ```
+
+use coding_adventures_javascript_parser::parse_javascript;
+
+mod lower;
+
+pub use lower::{compile, JsLowerError};
+
+/// The ECMAScript edition we parse against.  `es2020` is broad enough to
+/// admit modern syntax (arrow functions, `let`/`const`, template
+/// literals); the frontend then rejects the parts it doesn't yet lower.
+const JS_VERSION: &str = "es2020";
+
+/// Parse JavaScript source and lower it to SIR in a single call.
+///
+/// Wraps [`parse_javascript`] (with the [`JS_VERSION`] grammar) followed
+/// by [`compile`].  A parse failure is surfaced as a [`JsLowerError`]
+/// with the parser's reported position when available, so callers get a
+/// single uniform error type for both phases.
+pub fn compile_source(
+    source: &str,
+    module_name: &str,
+) -> Result<semantic_ir::Module, JsLowerError> {
+    let tree = parse_javascript(source, JS_VERSION).map_err(|e| parse_error_to_lower(&e))?;
+    compile(&tree, module_name)
+}
+
+/// Translate the parser's free-form error string into a [`JsLowerError`].
+///
+/// The parser reports errors as `"… at L:C: …"`; we best-effort extract
+/// the `L:C` so the error carries a usable position.  When extraction
+/// fails we fall back to `0:0` — the message is still preserved.
+fn parse_error_to_lower(msg: &str) -> JsLowerError {
+    let (line, column) = extract_line_col(msg).unwrap_or((0, 0));
+    JsLowerError {
+        message: msg.to_string(),
+        line,
+        column,
+    }
+}
+
+/// Pull the first `"<line>:<col>"` pair out of a parser error message.
+fn extract_line_col(msg: &str) -> Option<(usize, usize)> {
+    // Look for the " at " marker the parser uses, then parse "L:C".
+    let after = msg.split(" at ").nth(1)?;
+    let coords = after.split(':');
+    let parts: Vec<&str> = coords.take(2).collect();
+    if parts.len() == 2 {
+        let line = parts[0].trim().parse().ok()?;
+        let col = parts[1].trim().parse().ok()?;
+        Some((line, col))
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use semantic_ir::{Expr, Feature, FeatureManifest};
+
+    /// Lower `src`, asserting success, and return the module.
+    fn lower(src: &str) -> semantic_ir::Module {
+        compile_source(src, "test").expect("lowering succeeded")
+    }
+
+    /// Fetch the `main` function's body block.
+    fn main_value(m: &semantic_ir::Module) -> &Expr {
+        let f = m
+            .functions
+            .iter()
+            .find(|f| f.name == "main")
+            .expect("main function present");
+        &f.body.value
+    }
+
+    /// Helper: a module must always pass the SIR validator.
+    fn assert_valid(m: &semantic_ir::Module) {
+        let r = semantic_ir::validate(m);
+        assert!(r.is_ok(), "validation failed: {:?}", r.issues);
+    }
+
+    // ── one positive test per literal kind ─────────────────────────
+
+    #[test]
+    fn integer_number_becomes_int_lit() {
+        let m = lower("42;");
+        assert!(matches!(main_value(&m), Expr::IntLit { value: 42, .. }));
+        assert_valid(&m);
+        // No string/float features ⇒ an empty manifest.
+        assert_eq!(m.manifest, FeatureManifest::new());
+    }
+
+    #[test]
+    fn decimal_number_becomes_float_lit() {
+        let m = lower("3.25;");
+        match main_value(&m) {
+            Expr::FloatLit { value, .. } => assert!((value - 3.25).abs() < 1e-12),
+            other => panic!("expected FloatLit, got {other:?}"),
+        }
+        assert!(m.manifest.contains(Feature::Floats));
+        assert_valid(&m);
+    }
+
+    #[test]
+    fn exponent_number_becomes_float_lit() {
+        // `1e3` has an exponent marker ⇒ float, even with no decimal pt.
+        let m = lower("1e3;");
+        match main_value(&m) {
+            Expr::FloatLit { value, .. } => assert!((value - 1000.0).abs() < 1e-9),
+            other => panic!("expected FloatLit, got {other:?}"),
+        }
+        assert_valid(&m);
+    }
+
+    #[test]
+    fn true_becomes_bool_lit() {
+        let m = lower("true;");
+        assert!(matches!(main_value(&m), Expr::BoolLit { value: true, .. }));
+        assert_valid(&m);
+    }
+
+    #[test]
+    fn false_becomes_bool_lit() {
+        let m = lower("false;");
+        assert!(matches!(
+            main_value(&m),
+            Expr::BoolLit { value: false, .. }
+        ));
+        assert_valid(&m);
+    }
+
+    #[test]
+    fn null_becomes_nil_lit() {
+        let m = lower("null;");
+        assert!(matches!(main_value(&m), Expr::NilLit { .. }));
+        assert_valid(&m);
+    }
+
+    #[test]
+    fn undefined_also_becomes_nil_lit() {
+        // JS-specific: `undefined` is an identifier, but we collapse it
+        // to the same NilLit as `null`. The distinction is lost in v0.
+        let m = lower("undefined;");
+        assert!(matches!(main_value(&m), Expr::NilLit { .. }));
+        assert_valid(&m);
+    }
+
+    #[test]
+    fn double_quoted_string_becomes_str_lit() {
+        let m = lower("\"hello\";");
+        match main_value(&m) {
+            Expr::StrLit { value, .. } => assert_eq!(value, "hello"),
+            other => panic!("expected StrLit, got {other:?}"),
+        }
+        assert!(m.manifest.contains(Feature::Strings));
+        assert_valid(&m);
+    }
+
+    #[test]
+    fn single_quoted_string_becomes_str_lit() {
+        let m = lower("'world';");
+        match main_value(&m) {
+            Expr::StrLit { value, .. } => assert_eq!(value, "world"),
+            other => panic!("expected StrLit, got {other:?}"),
+        }
+        assert_valid(&m);
+    }
+
+    // ── compile_source / structural tests ──────────────────────────
+
+    #[test]
+    fn empty_program_compiles_to_nil_main() {
+        // `compile_source` on empty input must still produce a valid
+        // module with a nil-valued `main`.
+        let m = lower("");
+        assert_eq!(m.name, "test");
+        assert!(matches!(main_value(&m), Expr::NilLit { .. }));
+        // Exactly one function (`main`) and it is exported.
+        assert_eq!(m.functions.len(), 1);
+        assert!(m.exports.iter().any(|e| e.name == "main"));
+        assert_valid(&m);
+    }
+
+    #[test]
+    fn metadata_records_source_language_and_sir_version() {
+        let m = lower("1;");
+        assert_eq!(m.metadata.source_language.as_deref(), Some("javascript"));
+        assert_eq!(
+            m.metadata.sir_version.as_deref(),
+            Some(semantic_ir::CURRENT_SIR_VERSION)
+        );
+    }
+
+    #[test]
+    fn last_literal_is_the_block_value() {
+        // Multiple top-level literal statements: the final one is the
+        // block's tail value (earlier pure literals are unobservable).
+        let m = lower("1;\n2;\n3;\n");
+        assert!(matches!(main_value(&m), Expr::IntLit { value: 3, .. }));
+        assert_valid(&m);
+    }
+
+    #[test]
+    fn validate_round_trip_on_mixed_literals() {
+        // A string literal forces the `Strings` feature; the module must
+        // still validate (used-but-undeclared would otherwise error).
+        let m = lower("\"abc\";");
+        assert_valid(&m);
+        // And declaring exactly the observed feature: no extra warnings.
+        let r = semantic_ir::validate(&m);
+        assert!(r.warnings().next().is_none(), "unexpected warnings");
+    }
+
+    // ── error paths ────────────────────────────────────────────────
+
+    #[test]
+    fn operator_expression_is_rejected_in_m1() {
+        // `1 + 2` is a non-literal expression ⇒ out of M1 scope.
+        let err = compile_source("1 + 2;", "test").expect_err("should reject operators");
+        assert!(
+            err.message.contains("out of scope") || err.message.contains("M1"),
+            "unexpected message: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn bare_identifier_reference_is_rejected_in_m1() {
+        // A variable reference (not `undefined`) is deferred to M2.
+        let err = compile_source("x;", "test").expect_err("should reject var refs");
+        assert!(
+            err.message.contains("variable reference") || err.message.contains("out of scope"),
+            "unexpected message: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn parse_failure_surfaces_as_lower_error_with_position() {
+        // `@` is not valid JS ⇒ the parser errors; we must surface it as
+        // a `JsLowerError` (not panic) with a best-effort position.
+        let err = compile_source("@;", "test").expect_err("should fail to parse");
+        assert!(!err.message.is_empty());
+    }
+
+    #[test]
+    fn extract_line_col_parses_parser_message() {
+        // Unit-test the position extractor directly.
+        let got = extract_line_col("Parse error at 3:7: something");
+        assert_eq!(got, Some((3, 7)));
+        assert_eq!(extract_line_col("no position here"), None);
+    }
+}

--- a/code/packages/rust/javascript-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/javascript-to-semantic-ir/src/lower.rs
@@ -1,0 +1,457 @@
+//! JavaScript `GrammarASTNode` (CST) → `semantic_ir::Module` lowering.
+//!
+//! # What this file does (milestone M1)
+//!
+//! The [`javascript-parser`](coding_adventures_javascript_parser) crate
+//! hands us a *concrete syntax tree* (CST): a [`GrammarASTNode`] whose
+//! shape mirrors the ECMAScript grammar one-for-one.  Even a bare
+//! literal like `42;` produces a deep spine of single-child wrapper
+//! nodes — `program → source_element → statement →
+//! expression_statement → expression → assignment_expression → … →
+//! primary_expression → <token>`.  Twenty-odd rule layers, all of which
+//! exist only to encode operator precedence, and *none* of which carry
+//! information once you've reached the leaf.
+//!
+//! M1 lowers **literals only**.  The strategy is therefore deliberately
+//! blunt: walk a statement down to its single leaf token, classify the
+//! token, and emit the matching SIR literal.  Anything that *isn't* a
+//! single-leaf literal statement (an operator, a name reference, a
+//! declaration, a call) is **out of scope** and rejected with a clear
+//! [`JsLowerError`] so later milestones can slot their handling in at
+//! exactly the right place.
+//!
+//! ## The literal truth table (learned by probing the real parser)
+//!
+//! | JS source     | leaf token                                  | SIR node            |
+//! |---------------|---------------------------------------------|---------------------|
+//! | `42`          | `Number` value `"42"`  (no `.`/`e`)         | `IntLit { 42 }`     |
+//! | `3.25`        | `Number` value `"3.25"` (has `.`)           | `FloatLit { 3.25 }` |
+//! | `1e3`         | `Number` value `"1e3"` (has `e`)            | `FloatLit { 1000 }` |
+//! | `true`        | `Keyword` value `"true"`                    | `BoolLit { true }`  |
+//! | `false`       | `Keyword` value `"false"`                   | `BoolLit { false }` |
+//! | `null`        | `Keyword` value `"null"`                    | `NilLit`            |
+//! | `undefined`   | `Name`   value `"undefined"` (an ident!)    | `NilLit`            |
+//! | `"hi"`/`'hi'` | `String` value `hi` (already unescaped)     | `StrLit { "hi" }`   |
+//!
+//! Note two JS-specific lossy mappings, both spec-sanctioned for v0:
+//!   * `null` **and** `undefined` collapse to `NilLit` — the IR has one
+//!     "absence" value, so the JS distinction is lost.
+//!   * an integer-shaped number becomes `IntLit`, everything else
+//!     `FloatLit`.  JS has a single `number` type (an IEEE-754 double);
+//!     splitting it lets integer-heavy code round-trip through SIR
+//!     backends that *do* distinguish.
+
+use lexer::token::{Token, TokenType};
+use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode};
+use semantic_ir::{
+    Block, EffectSet, ExportName, Expr, Feature, FeatureManifest, Function, Metadata, Module, Span,
+    CURRENT_SIR_VERSION,
+};
+
+/// A failure encountered during JavaScript → SIR lowering.
+///
+/// Carries 1-based `line`/`column` so callers can produce IDE-friendly
+/// diagnostics.  When the position is unknown (the AST node had no
+/// recorded span), the fields are zero.  Mirrors the error shape used by
+/// the sibling [`ruby-to-semantic-ir`](https://example.invalid) and
+/// [`twig-to-semantic-ir`] frontends.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct JsLowerError {
+    pub message: String,
+    pub line: usize,
+    pub column: usize,
+}
+
+impl std::fmt::Display for JsLowerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "JsLowerError at {}:{}: {}",
+            self.line, self.column, self.message
+        )
+    }
+}
+
+impl std::error::Error for JsLowerError {}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+/// Lower a parsed JavaScript program into a [`semantic_ir::Module`].
+///
+/// The root node must be a `program` rule node — that's what
+/// [`coding_adventures_javascript_parser::parse_javascript`] always
+/// emits.  The `module_name` becomes the SIR module identifier
+/// (typically the source file's stem).
+///
+/// In M1 the body may contain only literal expression statements; any
+/// other statement shape produces a [`JsLowerError`] (see module docs).
+pub fn compile(program: &GrammarASTNode, module_name: &str) -> Result<Module, JsLowerError> {
+    if program.rule_name != "program" {
+        return Err(JsLowerError {
+            message: format!("expected root rule `program`, got `{}`", program.rule_name),
+            line: program.start_line.unwrap_or(0),
+            column: program.start_column.unwrap_or(0),
+        });
+    }
+
+    let mut lw = Lowerer {
+        file_name: module_name.to_string(),
+        features_used: FeatureManifest::new(),
+    };
+
+    let block = lw.lower_program(program)?;
+
+    // Every JS source becomes a synthetic `main` whose body is the
+    // top-level statement sequence — matching SIR17 (Python) and the
+    // Ruby frontend.  `main` has no params, so it never triggers the
+    // validator's `DynamicTyping` observation; we only declare features
+    // that the literals themselves use (`Strings`, `Floats`).
+    let main = Function {
+        name: "main".to_string(),
+        params: Vec::new(),
+        return_type: None,
+        captures: Vec::new(),
+        body: block,
+        effects: EffectSet::PURE,
+        metadata: Metadata::new(),
+        span: lw.span_of(program),
+    };
+
+    // Materialise the manifest in a stable order.  The SIR validator
+    // requires the manifest to *exactly* match what the body uses:
+    // used-but-undeclared is an error, declared-but-unused a warning.
+    // We tallied features while lowering, so we just hand the
+    // accumulator over.
+    let manifest = lw.features_used.clone();
+
+    let metadata = Metadata::new()
+        .with_source_language("javascript")
+        .with_sir_version(CURRENT_SIR_VERSION);
+
+    Ok(Module {
+        name: module_name.to_string(),
+        manifest,
+        imports: Vec::new(),
+        // `main` is the conventional entry point — exporting it lets SIR
+        // backends recognise it as such.
+        exports: vec![ExportName {
+            name: "main".to_string(),
+            span: Span::synthetic(),
+        }],
+        functions: vec![main],
+        globals: Vec::new(),
+        metadata,
+        span: lw.span_of(program),
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Lowerer — the small amount of mutable state M1 needs
+// ---------------------------------------------------------------------------
+
+struct Lowerer {
+    /// Logical filename stamped into every [`Span`].  We use the module
+    /// name because the parser CST doesn't carry the original path.
+    file_name: String,
+    /// Features accumulated as we lower.  `FeatureManifest::add` is
+    /// idempotent, so repeated `StrLit`s add `Strings` exactly once.
+    features_used: FeatureManifest,
+}
+
+impl Lowerer {
+    /// Build a [`Span`] from a node's recorded 1-based position.  Falls
+    /// back to a zero point when the parser left positions unset.
+    fn span_of(&self, node: &GrammarASTNode) -> Span {
+        Span::new(
+            self.file_name.clone(),
+            node.start_line.unwrap_or(0),
+            node.start_column.unwrap_or(0),
+            node.end_line.unwrap_or_else(|| node.start_line.unwrap_or(0)),
+            node.end_column.unwrap_or_else(|| node.start_column.unwrap_or(0)),
+        )
+    }
+
+    /// Build a [`Span`] from a leaf [`Token`]'s 1-based position.  The
+    /// width is one column (zero-width point), which is good enough for
+    /// literal diagnostics.
+    fn span_of_token(&self, tok: &Token) -> Span {
+        Span::point(self.file_name.clone(), tok.line, tok.column)
+    }
+
+    // -----------------------------------------------------------------------
+    // program → Block
+    // -----------------------------------------------------------------------
+
+    /// Lower the whole program into a single [`Block`].
+    ///
+    /// SIR `Block`s are "statements then a tail value": `Block.value` is
+    /// the program's result.  Following SIR17/Ruby, the **final**
+    /// top-level expression becomes the tail `value`; everything before
+    /// it would become `stmts`.  In M1 the only statement kind is a
+    /// literal expression statement, and a bare literal has no side
+    /// effect, so any *non-final* literal statement is simply dropped (it
+    /// can't be observed).  We therefore keep `stmts` empty and route the
+    /// last literal — if any — into `value`.  An empty program yields a
+    /// `NilLit` value, exactly like `ruby-to-semantic-ir` on `""`.
+    fn lower_program(&mut self, program: &GrammarASTNode) -> Result<Block, JsLowerError> {
+        // `program`'s children are `source_element` nodes (one per
+        // top-level statement).  We collect the lowered expression for
+        // each so the last becomes the block's tail value.
+        let mut exprs: Vec<Expr> = Vec::new();
+        for child in &program.children {
+            match child {
+                ASTNodeOrToken::Node(n) => {
+                    // A `source_element` wraps a `statement`; descend.
+                    let expr = self.lower_source_element(n)?;
+                    exprs.push(expr);
+                }
+                // Stray tokens directly under `program` (there should be
+                // none for well-formed input) are ignored.
+                ASTNodeOrToken::Token(_) => {}
+            }
+        }
+
+        let value = exprs.pop().unwrap_or(Expr::NilLit {
+            span: self.span_of(program),
+        });
+
+        Ok(Block {
+            // M1 produces no statements: literals are pure, so only the
+            // tail value is observable.  Later milestones (let-bindings,
+            // assignments, calls) will populate this.
+            stmts: Vec::new(),
+            value,
+            span: self.span_of(program),
+        })
+    }
+
+    /// Lower one `source_element` (top-level item) to an [`Expr`].
+    fn lower_source_element(&mut self, node: &GrammarASTNode) -> Result<Expr, JsLowerError> {
+        // `source_element` → `statement` → `expression_statement`.
+        // Descend through the single-child wrappers until we reach a
+        // statement we recognise.  In M1 only `expression_statement` is
+        // supported; a `function_declaration`, `variable_statement`,
+        // `if_statement`, etc. reaches us here and is rejected.
+        let stmt = single_child_node(node).unwrap_or(node);
+        match stmt.rule_name.as_str() {
+            "statement" => {
+                let inner = single_child_node(stmt).unwrap_or(stmt);
+                self.lower_statement_inner(inner)
+            }
+            "expression_statement" => self.lower_expression_statement(stmt),
+            other => Err(self.unsupported(stmt, other)),
+        }
+    }
+
+    /// Lower the node *inside* a `statement` wrapper.
+    fn lower_statement_inner(&mut self, node: &GrammarASTNode) -> Result<Expr, JsLowerError> {
+        match node.rule_name.as_str() {
+            "expression_statement" => self.lower_expression_statement(node),
+            // deferred to M2+: variable_statement, if_statement,
+            // iteration_statement, function_declaration, return_statement…
+            other => Err(self.unsupported(node, other)),
+        }
+    }
+
+    /// Lower an `expression_statement` (`<expression> ;`) to an [`Expr`].
+    fn lower_expression_statement(
+        &mut self,
+        node: &GrammarASTNode,
+    ) -> Result<Expr, JsLowerError> {
+        // Children are the `expression` node followed by a `Semicolon`
+        // token.  Find the first child node (the expression) and lower
+        // it; the trailing semicolon carries no value.
+        let expr_node = node
+            .children
+            .iter()
+            .find_map(|c| match c {
+                ASTNodeOrToken::Node(n) => Some(n),
+                ASTNodeOrToken::Token(_) => None,
+            })
+            .ok_or_else(|| JsLowerError {
+                message: "empty expression statement".to_string(),
+                line: node.start_line.unwrap_or(0),
+                column: node.start_column.unwrap_or(0),
+            })?;
+        self.lower_expression(expr_node)
+    }
+
+    // -----------------------------------------------------------------------
+    // expression → Expr (M1: literals only)
+    // -----------------------------------------------------------------------
+
+    /// Lower a JS `expression` to a SIR [`Expr`].
+    ///
+    /// The CST spine from `expression` down to the leaf is a chain of
+    /// single-child precedence wrappers (see module docs).  We walk that
+    /// spine to its bottom.  If the bottom is a single leaf token, it's a
+    /// literal we can lower.  If instead we hit a node that *branches*
+    /// (more than one meaningful child — i.e. an actual operator,
+    /// arguments list, member access, …), that's a non-literal
+    /// expression and out of M1 scope.
+    fn lower_expression(&mut self, expr: &GrammarASTNode) -> Result<Expr, JsLowerError> {
+        // Descend through single-child wrapper nodes.
+        let mut cur = expr;
+        loop {
+            // A leaf node (exactly one child, and that child is a token)
+            // is a literal — classify and emit.
+            if let Some(tok) = cur.token() {
+                return self.lower_literal_token(tok);
+            }
+            // Otherwise, if there's exactly one *node* child and no other
+            // meaningful children, keep descending.
+            match single_child_node(cur) {
+                Some(next) => cur = next,
+                None => {
+                    // We reached a branching node (an operator, call,
+                    // member access, …).  Not a literal → out of M1.
+                    return Err(self.unsupported(cur, &cur.rule_name));
+                }
+            }
+        }
+    }
+
+    /// Classify a leaf literal token and build the matching SIR literal.
+    ///
+    /// See the truth table in the module docs for the full mapping.
+    fn lower_literal_token(&mut self, tok: &Token) -> Result<Expr, JsLowerError> {
+        let span = self.span_of_token(tok);
+        match tok.type_ {
+            // ── number ──────────────────────────────────────────────
+            // JS has a single numeric type.  We split on textual shape:
+            // a literal with no `.` and no exponent marker is an
+            // integer; anything else is a float.  This lets integer code
+            // round-trip cleanly through backends that distinguish.
+            TokenType::Number => self.lower_number(&tok.value, span),
+
+            // ── keyword literals: true / false / null ───────────────
+            TokenType::Keyword => match tok.value.as_str() {
+                "true" => Ok(Expr::BoolLit { value: true, span }),
+                "false" => Ok(Expr::BoolLit { value: false, span }),
+                // `null` → the IR's single absence value.
+                "null" => Ok(Expr::NilLit { span }),
+                other => Err(JsLowerError {
+                    message: format!("unsupported keyword literal `{other}` (M1 supports only true/false/null)"),
+                    line: tok.line,
+                    column: tok.column,
+                }),
+            },
+
+            // ── string ──────────────────────────────────────────────
+            // The lexer already resolved escape sequences, so `tok.value`
+            // is the final string content.  NOTE: template literals
+            // (backtick strings) are a *different* token/rule and are
+            // deferred to a later milestone (see CHANGELOG "Deferred").
+            TokenType::String => {
+                self.features_used.add(Feature::Strings);
+                Ok(Expr::StrLit {
+                    value: tok.value.clone(),
+                    span,
+                })
+            }
+
+            // ── `undefined` ─────────────────────────────────────────
+            // `undefined` is not a keyword in JS — it's a global
+            // identifier, so it arrives as a `Name` token.  We special-
+            // case that exact spelling to `NilLit` (the JS null/undefined
+            // distinction is intentionally lost in v0).  Any *other*
+            // identifier is a variable reference, which is out of M1
+            // scope (deferred to M2).
+            TokenType::Name if tok.value == "undefined" => Ok(Expr::NilLit { span }),
+            TokenType::Name => Err(JsLowerError {
+                message: format!(
+                    "variable reference `{}` is out of scope for M1 (literals only)",
+                    tok.value
+                ),
+                line: tok.line,
+                column: tok.column,
+            }),
+
+            other => Err(JsLowerError {
+                message: format!("unsupported literal token {other:?} (M1 supports literals only)"),
+                line: tok.line,
+                column: tok.column,
+            }),
+        }
+    }
+
+    /// Lower a numeric literal's *text* into `IntLit` or `FloatLit`.
+    ///
+    /// A literal is treated as an integer iff it parses as an `i64` and
+    /// its text contains neither a decimal point nor an exponent marker
+    /// (`e`/`E`).  Otherwise it's a float.  Hex/octal/binary integer
+    /// forms (`0x…`, `0o…`, `0b…`) and `BigInt` (`10n`) are deferred to a
+    /// later milestone.
+    fn lower_number(&mut self, text: &str, span: Span) -> Result<Expr, JsLowerError> {
+        let looks_float = text.contains('.') || text.contains('e') || text.contains('E');
+        // Reject the non-decimal integer forms in M1: their `i64` parse
+        // would fail, and silently falling through to a `FloatLit` would
+        // be wrong.  Detecting them explicitly yields a clear error.
+        let non_decimal = text.len() > 1
+            && text.starts_with('0')
+            && matches!(text.as_bytes()[1], b'x' | b'X' | b'o' | b'O' | b'b' | b'B');
+        if non_decimal || text.ends_with('n') {
+            return Err(JsLowerError {
+                message: format!(
+                    "numeric literal `{text}` form (hex/octal/binary/BigInt) is deferred past M1"
+                ),
+                line: span.start_line,
+                column: span.start_col,
+            });
+        }
+
+        if !looks_float {
+            if let Ok(value) = text.parse::<i64>() {
+                return Ok(Expr::IntLit { value, span });
+            }
+            // Integer-shaped but doesn't fit i64 (e.g. very large).  Fall
+            // through to float so we don't lose the program; JS would
+            // hold it as a double anyway.
+        }
+
+        match text.parse::<f64>() {
+            Ok(value) => {
+                self.features_used.add(Feature::Floats);
+                Ok(Expr::FloatLit { value, span })
+            }
+            Err(_) => Err(JsLowerError {
+                message: format!("could not parse numeric literal `{text}`"),
+                line: span.start_line,
+                column: span.start_col,
+            }),
+        }
+    }
+
+    /// Build the standard "out of M1 scope" error for a node.
+    fn unsupported(&self, node: &GrammarASTNode, what: &str) -> JsLowerError {
+        JsLowerError {
+            message: format!(
+                "`{what}` is out of scope for M1 (literals only); deferred to a later milestone"
+            ),
+            line: node.start_line.unwrap_or(0),
+            column: node.start_column.unwrap_or(0),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Free helpers
+// ---------------------------------------------------------------------------
+
+/// If `node` has exactly one child and that child is a nested node,
+/// return it.  This is the workhorse for descending the CST's precedence
+/// spine: each precedence layer that wasn't "used" appears as a wrapper
+/// with a single node child.  Returns `None` when the node branches
+/// (multiple children) or when its single child is a token (a leaf).
+fn single_child_node(node: &GrammarASTNode) -> Option<&GrammarASTNode> {
+    if node.children.len() == 1 {
+        match &node.children[0] {
+            ASTNodeOrToken::Node(n) => Some(n),
+            ASTNodeOrToken::Token(_) => None,
+        }
+    } else {
+        None
+    }
+}


### PR DESCRIPTION
New **SIR19 JavaScript→Semantic-IR frontend**, milestone M1. Walks the `javascript-parser` generic `GrammarASTNode` CST and lowers literals (number→Int/Float by textual shape, true/false→Bool, null & undefined→Nil, string→Str). The single-child peel is an iterative loop (no recursion DoS). Everything else returns a positioned `JsLowerError`.

**Tests:** 17 (per-literal + compile_source + validate round-trip + error paths); clippy clean; security review passed.

Adds the crate to the rust workspace `members` list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)