### PR TITLE
feat(mle-pass): slice 3 — microbiology organism-ID chain, run in reverse

### DIFF
--- a/code/specs/MLE-PASS-multihop-recall.md
+++ b/code/specs/MLE-PASS-multihop-recall.md
@@ -1,6 +1,7 @@
 # MLE-PASS — multi-hop recall (the two-hop reasoning step)
 
-**Status:** First slice shipped. Harness + worked artifact + 7-item bank, run-verified.
+**Status:** Slices 1–3 shipped. Harness + worked artifact + 30-item bank, run-verified
+(gene / inheritance / microbiology-trait hops + abstention; forward and reverse hop 1).
 **Author:** autonomous loop, 2026-06-29.
 
 ## 1. Why
@@ -87,7 +88,35 @@ hop-1 edge — the engine binds nothing and the scorer counts abstaining as corr
 fabrication. `score()` reports `abstained_correctly`; `multihop_coverage` is over correct *answerable*
 items. Run-verified: 15/15 correct (13 answerable, coverage 1.0; 2 abstained), zero model calls.
 
-## 6. Next
+## 6. Slice 3 (shipped) — the microbiology organism-ID chain, run in reverse
+The bank grew **15 → 30**, adding the original **MYCIN** reasoning chain: from a *disease*,
+find the **causative organism**, then read that organism's **Gram stain** or **microscopic
+morphology**. The twist is direction. The grounded edge is `causes(organism, disease)`, so the
+clue (the disease) is its **second** argument and the organism is the middle entity. The harness
+gained a generic **`hop1_reverse`** flag: hop 1's subgoal is emitted as `rel1($D, $X)` (join var
+first, clue second) instead of `rel1($X, $D)`, and the engine's SLD resolver joins on `$D`
+regardless of argument order — relations are bidirectional. Both hops live in one library
+(`micro-edges.adj`), so imports are de-duplicated.
+
+```adj
+import "micro-edges.adj"
+rule {
+    head: clue_to_answer($X, $A)
+    when: causes($D, $X), gram_stain($D, $A)   % $X = disease (clue), $D = organism (join)
+}
+? clue_to_answer(cholera, $A)   % engine binds $A = gram_negative, cites BOTH hops
+```
+
+14 answerable micro chains (8 Gram stain, 6 morphology) plus a micro abstention item whose disease
+has no grounded causative organism. The answer variable is now `$A` (it is a gene, an inheritance
+pattern, a Gram stain, …, depending on hop 2). Run-verified: **30/30 correct** (27 answerable,
+`multihop_coverage` 1.0; 3 abstained correctly), zero model calls. The worked artifact gains
+`disease_to_gram` / `disease_to_morphology` rules (19 in-place queries, all bound, both hops cited).
+
+## 7. Next
 More chains as id joins are grounded (histo/cardio → genetics; disease → *treatment* and
-disease → *mechanism* hops); a third hop (clue → disease → drug → contraindication); a `decision`-style
-multi-hop where the engine ranks among several reachable answers.
+disease → *mechanism* hops). A genuine **three-relation** forward chain (`A→B→C→D`) awaits a
+grounded relation that *chains off* a hop-2 answer (today no edge starts from a gene, substrate,
+or trait), or an id-consistency pass (e.g. the enzyme-deficiency disease ids `gaucher_disease`
+do not yet match the lysosomal `accumulates` ids `gaucher`). A `decision`-style multi-hop where
+the engine ranks among several reachable answers.

--- a/code/specs/data/mycin-2026/mle-pass/CHANGELOG.md
+++ b/code/specs/data/mycin-2026/mle-pass/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog — mle-pass
 
+## [0.3.0] — 2026-06-30
+
+### Added — slice 3: the microbiology organism-ID chain, run in reverse
+
+- Bank grows **15 → 30** items, adding the original **MYCIN** reasoning chain: from a *disease*,
+  bind the **causative organism**, then read that organism's **Gram stain** or **microscopic
+  morphology** (`disease → organism → trait`). 14 answerable micro chains (8 Gram stain, 6
+  morphology) + a micro abstention item whose disease has no grounded causative organism.
+- New generic harness capability **`hop1_reverse`**: the grounded edge is `causes(organism,
+  disease)`, so the clue (disease) is its *second* argument. When `hop1_reverse` is set, hop 1's
+  subgoal is emitted as `rel1($D, $X)` (join var first, clue second) instead of `rel1($X, $D)`;
+  the engine's SLD resolver joins on `$D` regardless of argument order — **relations are
+  bidirectional**, so a two-hop chain need not run left-to-right through the edges.
+- `build_query` now **de-duplicates imports** (micro's `causes` and `gram_stain`/`morphology`
+  share `micro-edges.adj`, imported once) and the answer variable is generalised `$G` → `$A`
+  (it may be a gene, inheritance pattern, Gram stain, or morphology depending on hop 2);
+  `run_item` reads the `A` binding. No new model calls, no new sink.
+- Worked artifact gains `disease_to_gram` / `disease_to_morphology` reverse-join rules (now 19
+  in-place queries, all bound, both hops cited). Tests: `test_reverse_hop1_and_import_dedup`;
+  `test_bank_exercises_multiple_hop2_relations_and_abstention` now also requires `gram_stain`,
+  `morphology`, and a reverse-hop1 item. Run-verified: **30/30 correct** (27 answerable, coverage
+  1.0; 3 abstained correctly), zero model calls. 6 pytest pass; ruff clean.
+- Nothing authored: every edge reuses an already-grounded, spider+adversarially-gated micro fact.
+
 ## [0.2.0] — 2026-06-30
 
 ### Added — slice 2: more chains, a second hop-2 relation, and an abstention sub-bank

--- a/code/specs/data/mycin-2026/mle-pass/README.md
+++ b/code/specs/data/mycin-2026/mle-pass/README.md
@@ -42,19 +42,38 @@ variable, so a two-hop question is one rule + one binding query:
 import "ophtho-edges.adj"
 import "genetics-edges.adj"
 rule {
-    head: clue_to_gene($X, $G)
-    when: eye_finding_indicates($X, $D), gene_defect($D, $G)   % join on $D
+    head: clue_to_answer($X, $A)
+    when: eye_finding_indicates($X, $D), gene_defect($D, $A)   % join on $D
 }
-? clue_to_gene(leukocoria, $G)   % → rb1, with both hops cited
+? clue_to_answer(leukocoria, $A)   % → rb1, with both hops cited
 ```
 
-The engine returns the gene binding **and** the citing clause of each hop. Nothing is
+The engine returns the binding **and** the citing clause of each hop. Nothing is
 authored here: every edge reuses an already-grounded, spider+adversarially-gated fact
 (`../recall/`). Because adj-lang imports may not escape their directory, the harness assembles
-each run in a temp dir (the two needed `*-edges.adj` copied beside the query), leaving the
-shipped `recall/` library untouched.
+each run in a temp dir (the needed `*-edges.adj` copied beside the query, de-duplicated),
+leaving the shipped `recall/` library untouched.
 
-Slice 2: **15/15 correct, zero model calls** — 10 clue→disease→gene chains + 3 clue→disease→**inheritance**
-chains (proving the harness is generic over the second hop) + 2 **abstention** items (ungrounded clue ⇒
-must abstain). `multihop_coverage` 1.0 over the 13 answerable items; the scorer reports
+### Hop 1 can run in reverse
+
+Some chains run "backwards". The grounded edge is `causes(organism, disease)`, so to answer
+"disease X — what is its causative organism's Gram stain?" the clue is the *second* argument
+and the organism is the middle entity. Setting `"hop1_reverse": true` emits the hop-1 subgoal
+as `rel1($D, $X)` (join var first), and the engine's SLD resolver joins on `$D` either way —
+relations are bidirectional, so a two-hop chain need not run left-to-right:
+
+```adj
+import "micro-edges.adj"          % both hops live here → imported once
+rule {
+    head: clue_to_answer($X, $A)
+    when: causes($D, $X), gram_stain($D, $A)   % $X = disease (clue), $D = organism (join)
+}
+? clue_to_answer(cholera, $A)     % → gram_negative (vibrio_cholerae), both hops cited
+```
+
+Slice 3: **30/30 correct, zero model calls** — slice-2's 13 gene/inheritance chains + 14
+microbiology organism-ID chains (8 `disease → organism → Gram stain`, 6 `→ morphology`, run in
+reverse — the original MYCIN domain) + 3 **abstention** items (ungrounded clue/disease ⇒ must
+abstain). `multihop_coverage` 1.0 over the 27 answerable items; the scorer reports
 `abstained_correctly` and counts any binding on an abstention item as a fabrication (wrong).
+The answer variable is `$A` (gene / inheritance pattern / Gram stain / morphology, per hop 2).

--- a/code/specs/data/mycin-2026/mle-pass/gen_items.py
+++ b/code/specs/data/mycin-2026/mle-pass/gen_items.py
@@ -56,6 +56,43 @@ INH_CHAINS = [
 INH_POOL = ["autosomal_dominant", "autosomal_recessive", "x_linked_recessive",
             "x_linked_dominant", "mitochondrial"]
 
+# slice 3 — microbiology organism-ID chain (the original MYCIN domain), run in REVERSE:
+# the clue is a *disease*, hop 1 is `causes(organism, disease)` traversed backwards to bind the
+# causative organism (the middle entity), and hop 2 reads that organism's Gram stain or
+# microscopic morphology. Both relations live in micro-edges.adj (imports de-dupe). This
+# exercises the harness's `hop1_reverse` capability — a relation joined on its FIRST argument —
+# and proves a two-hop chain need not run "left to right" through the edges.
+# (id, disease, hop2_relation, answer | None for abstain, clue_phrase)
+MICRO_CHAINS = [
+    # disease → causative organism → Gram stain
+    ("mh-16", "cholera", "gram_stain", "gram_negative", "cholera"),
+    ("mh-17", "gonorrhea", "gram_stain", "gram_negative", "gonorrhea"),
+    ("mh-18", "pertussis", "gram_stain", "gram_negative", "whooping cough (pertussis)"),
+    ("mh-19", "anthrax", "gram_stain", "gram_positive", "anthrax"),
+    ("mh-20", "listeriosis", "gram_stain", "gram_positive", "listeriosis"),
+    ("mh-21", "pseudomembranous_colitis", "gram_stain", "gram_positive", "pseudomembranous colitis"),
+    ("mh-22", "tetanus", "gram_stain", "gram_positive", "tetanus"),
+    ("mh-23", "legionnaires_disease", "gram_stain", "gram_negative", "Legionnaires disease"),
+    # disease → causative organism → microscopic morphology
+    ("mh-24", "cholera", "morphology", "comma_shaped", "rice-water diarrhea of cholera"),
+    ("mh-25", "peptic_ulcer_disease", "morphology", "spiral", "Helicobacter peptic ulcer disease"),
+    ("mh-26", "gonorrhea", "morphology", "diplococci", "gonorrhea"),
+    ("mh-27", "syphilis", "morphology", "spirochete", "syphilis"),
+    ("mh-28", "meningitis", "morphology", "diplococci", "meningococcal meningitis"),
+    ("mh-29", "pertussis", "morphology", "coccobacilli", "whooping cough (pertussis)"),
+    # abstention — a disease whose causative organism is NOT grounded: MUST abstain.
+    ("mh-30", "a_syndrome_with_no_grounded_organism", "gram_stain", None,
+     "a syndrome whose causative organism is not in the grounded library"),
+]
+GRAM_POOL = ["gram_positive", "gram_negative", "acid_fast", "gram_variable", "poorly_staining"]
+MORPH_POOL = ["cocci", "diplococci", "bacilli", "comma_shaped", "spiral", "spirochete",
+              "coccobacilli"]
+MICRO_POOLS = {"gram_stain": GRAM_POOL, "morphology": MORPH_POOL}
+MICRO_TAIL = {
+    "gram_stain": "shows which Gram-stain reaction on microscopy",
+    "morphology": "has which microscopic morphology",
+}
+
 # abstention — real rule shape, ungrounded clue: the engine binds nothing → MUST abstain.
 ABSTAIN = [
     ("mh-14", "a_clue_with_no_grounded_eye_edge", "ophtho-edges.adj", "eye_finding_indicates",
@@ -103,6 +140,31 @@ def build():
             "hop2_lib": "genetics-edges.adj", "hop2_relation": "inheritance",
             "clue": clue, "expected": patt, "options": options, "gold_letter": gold,
         })
+    # --- microbiology organism-ID chain (slice 3): reverse hop1 + Gram stain / morphology ---
+    for idx, (iid, disease, hop2_rel, answer, phrase) in enumerate(MICRO_CHAINS):
+        pool = MICRO_POOLS[hop2_rel]
+        item = {
+            "id": iid, "qtype": "multi_hop_recall",
+            "hop1_lib": "micro-edges.adj", "hop1_relation": "causes", "hop1_reverse": True,
+            "hop2_lib": "micro-edges.adj", "hop2_relation": hop2_rel,
+            "clue": disease,
+        }
+        if answer is None:
+            # ungrounded disease — no causative organism is grounded, so the chain MUST abstain.
+            item.update({
+                "stem": f"A patient has {phrase}. The organism that causes it {MICRO_TAIL[hop2_rel]}? "
+                        f"(If the causative organism is not grounded, abstain.)",
+                "expected": None, "expect_abstain": True,
+                "options": {LETTERS[i]: pool[i] for i in range(5)},
+            })
+        else:
+            options, gold = options_for(answer, pool, idx)
+            item.update({
+                "stem": f"A patient is diagnosed with {phrase}. The organism that causes it "
+                        f"{MICRO_TAIL[hop2_rel]}?",
+                "expected": answer, "options": options, "gold_letter": gold,
+            })
+        items.append(item)
     # --- abstention (ungrounded clue: MUST abstain) ---
     for (iid, clue, lib, rel, hop2_rel, hop2_lib, pool, phrase) in ABSTAIN:
         # plausible distractors, but NO correct answer is reachable (the chain is ungrounded).
@@ -126,9 +188,14 @@ def build():
             "relation as hop 2 — inheritance (clue→disease→inheritance pattern), proving the "
             "harness is generic over the second hop, not gene-specific; and an ABSTENTION "
             "sub-bank whose clue has no grounded hop-1 edge, which MUST abstain (never "
-            "fabricate). Nothing authored: every edge reuses an already-grounded, "
-            "spider+adversarially-gated fact. Engine: every answerable item correct with both "
-            "hops cited; every abstention item abstains; zero model calls."
+            "fabricate). Slice 3 adds the microbiology organism-ID chain (the original MYCIN "
+            "domain) run in REVERSE: the clue is a disease, hop 1 is causes(organism, disease) "
+            "traversed backwards to bind the causative organism, and hop 2 reads that organism's "
+            "Gram stain or microscopic morphology — proving a two-hop chain need not run left to "
+            "right through the edges, and that both hops can share one library. Nothing authored: "
+            "every edge reuses an already-grounded, spider+adversarially-gated fact. Engine: every "
+            "answerable item correct with both hops cited; every abstention item abstains; zero "
+            "model calls."
         ),
         "items": items,
     }

--- a/code/specs/data/mycin-2026/mle-pass/items.json
+++ b/code/specs/data/mycin-2026/mle-pass/items.json
@@ -1,5 +1,5 @@
 {
-  "description": "MLE-PASS multi-hop recall bank \u2014 TWO-HOP board questions answered purely from grounded edges with zero model calls. A clinical clue \u2192 disease (hop 1, an organ-system recall library) \u2192 answer (hop 2) is joined on the shared disease through an adj-lang rule body; the engine's SLD resolver returns the binding with BOTH hops' byte-provenance, and the harness maps it to the printed options. Slice 2 adds: more clue\u2192disease\u2192gene chains (derm, niemann-pick, pompe); a second relation as hop 2 \u2014 inheritance (clue\u2192disease\u2192inheritance pattern), proving the harness is generic over the second hop, not gene-specific; and an ABSTENTION sub-bank whose clue has no grounded hop-1 edge, which MUST abstain (never fabricate). Nothing authored: every edge reuses an already-grounded, spider+adversarially-gated fact. Engine: every answerable item correct with both hops cited; every abstention item abstains; zero model calls.",
+  "description": "MLE-PASS multi-hop recall bank \u2014 TWO-HOP board questions answered purely from grounded edges with zero model calls. A clinical clue \u2192 disease (hop 1, an organ-system recall library) \u2192 answer (hop 2) is joined on the shared disease through an adj-lang rule body; the engine's SLD resolver returns the binding with BOTH hops' byte-provenance, and the harness maps it to the printed options. Slice 2 adds: more clue\u2192disease\u2192gene chains (derm, niemann-pick, pompe); a second relation as hop 2 \u2014 inheritance (clue\u2192disease\u2192inheritance pattern), proving the harness is generic over the second hop, not gene-specific; and an ABSTENTION sub-bank whose clue has no grounded hop-1 edge, which MUST abstain (never fabricate). Slice 3 adds the microbiology organism-ID chain (the original MYCIN domain) run in REVERSE: the clue is a disease, hop 1 is causes(organism, disease) traversed backwards to bind the causative organism, and hop 2 reads that organism's Gram stain or microscopic morphology \u2014 proving a two-hop chain need not run left to right through the edges, and that both hops can share one library. Nothing authored: every edge reuses an already-grounded, spider+adversarially-gated fact. Engine: every answerable item correct with both hops cited; every abstention item abstains; zero model calls.",
   "items": [
     {
       "id": "mh-01",
@@ -247,6 +247,306 @@
         "E": "mitochondrial"
       },
       "gold_letter": "C"
+    },
+    {
+      "id": "mh-16",
+      "qtype": "multi_hop_recall",
+      "hop1_lib": "micro-edges.adj",
+      "hop1_relation": "causes",
+      "hop1_reverse": true,
+      "hop2_lib": "micro-edges.adj",
+      "hop2_relation": "gram_stain",
+      "clue": "cholera",
+      "stem": "A patient is diagnosed with cholera. The organism that causes it shows which Gram-stain reaction on microscopy?",
+      "expected": "gram_negative",
+      "options": {
+        "A": "gram_negative",
+        "B": "gram_positive",
+        "C": "acid_fast",
+        "D": "gram_variable",
+        "E": "poorly_staining"
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "mh-17",
+      "qtype": "multi_hop_recall",
+      "hop1_lib": "micro-edges.adj",
+      "hop1_relation": "causes",
+      "hop1_reverse": true,
+      "hop2_lib": "micro-edges.adj",
+      "hop2_relation": "gram_stain",
+      "clue": "gonorrhea",
+      "stem": "A patient is diagnosed with gonorrhea. The organism that causes it shows which Gram-stain reaction on microscopy?",
+      "expected": "gram_negative",
+      "options": {
+        "A": "gram_positive",
+        "B": "gram_negative",
+        "C": "acid_fast",
+        "D": "gram_variable",
+        "E": "poorly_staining"
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "mh-18",
+      "qtype": "multi_hop_recall",
+      "hop1_lib": "micro-edges.adj",
+      "hop1_relation": "causes",
+      "hop1_reverse": true,
+      "hop2_lib": "micro-edges.adj",
+      "hop2_relation": "gram_stain",
+      "clue": "pertussis",
+      "stem": "A patient is diagnosed with whooping cough (pertussis). The organism that causes it shows which Gram-stain reaction on microscopy?",
+      "expected": "gram_negative",
+      "options": {
+        "A": "gram_positive",
+        "B": "acid_fast",
+        "C": "gram_negative",
+        "D": "gram_variable",
+        "E": "poorly_staining"
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "mh-19",
+      "qtype": "multi_hop_recall",
+      "hop1_lib": "micro-edges.adj",
+      "hop1_relation": "causes",
+      "hop1_reverse": true,
+      "hop2_lib": "micro-edges.adj",
+      "hop2_relation": "gram_stain",
+      "clue": "anthrax",
+      "stem": "A patient is diagnosed with anthrax. The organism that causes it shows which Gram-stain reaction on microscopy?",
+      "expected": "gram_positive",
+      "options": {
+        "A": "gram_negative",
+        "B": "acid_fast",
+        "C": "gram_variable",
+        "D": "gram_positive",
+        "E": "poorly_staining"
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "mh-20",
+      "qtype": "multi_hop_recall",
+      "hop1_lib": "micro-edges.adj",
+      "hop1_relation": "causes",
+      "hop1_reverse": true,
+      "hop2_lib": "micro-edges.adj",
+      "hop2_relation": "gram_stain",
+      "clue": "listeriosis",
+      "stem": "A patient is diagnosed with listeriosis. The organism that causes it shows which Gram-stain reaction on microscopy?",
+      "expected": "gram_positive",
+      "options": {
+        "A": "gram_negative",
+        "B": "acid_fast",
+        "C": "gram_variable",
+        "D": "poorly_staining",
+        "E": "gram_positive"
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "mh-21",
+      "qtype": "multi_hop_recall",
+      "hop1_lib": "micro-edges.adj",
+      "hop1_relation": "causes",
+      "hop1_reverse": true,
+      "hop2_lib": "micro-edges.adj",
+      "hop2_relation": "gram_stain",
+      "clue": "pseudomembranous_colitis",
+      "stem": "A patient is diagnosed with pseudomembranous colitis. The organism that causes it shows which Gram-stain reaction on microscopy?",
+      "expected": "gram_positive",
+      "options": {
+        "A": "gram_positive",
+        "B": "gram_negative",
+        "C": "acid_fast",
+        "D": "gram_variable",
+        "E": "poorly_staining"
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "mh-22",
+      "qtype": "multi_hop_recall",
+      "hop1_lib": "micro-edges.adj",
+      "hop1_relation": "causes",
+      "hop1_reverse": true,
+      "hop2_lib": "micro-edges.adj",
+      "hop2_relation": "gram_stain",
+      "clue": "tetanus",
+      "stem": "A patient is diagnosed with tetanus. The organism that causes it shows which Gram-stain reaction on microscopy?",
+      "expected": "gram_positive",
+      "options": {
+        "A": "gram_negative",
+        "B": "gram_positive",
+        "C": "acid_fast",
+        "D": "gram_variable",
+        "E": "poorly_staining"
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "mh-23",
+      "qtype": "multi_hop_recall",
+      "hop1_lib": "micro-edges.adj",
+      "hop1_relation": "causes",
+      "hop1_reverse": true,
+      "hop2_lib": "micro-edges.adj",
+      "hop2_relation": "gram_stain",
+      "clue": "legionnaires_disease",
+      "stem": "A patient is diagnosed with Legionnaires disease. The organism that causes it shows which Gram-stain reaction on microscopy?",
+      "expected": "gram_negative",
+      "options": {
+        "A": "gram_positive",
+        "B": "acid_fast",
+        "C": "gram_negative",
+        "D": "gram_variable",
+        "E": "poorly_staining"
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "mh-24",
+      "qtype": "multi_hop_recall",
+      "hop1_lib": "micro-edges.adj",
+      "hop1_relation": "causes",
+      "hop1_reverse": true,
+      "hop2_lib": "micro-edges.adj",
+      "hop2_relation": "morphology",
+      "clue": "cholera",
+      "stem": "A patient is diagnosed with rice-water diarrhea of cholera. The organism that causes it has which microscopic morphology?",
+      "expected": "comma_shaped",
+      "options": {
+        "A": "cocci",
+        "B": "diplococci",
+        "C": "bacilli",
+        "D": "comma_shaped",
+        "E": "spiral"
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "mh-25",
+      "qtype": "multi_hop_recall",
+      "hop1_lib": "micro-edges.adj",
+      "hop1_relation": "causes",
+      "hop1_reverse": true,
+      "hop2_lib": "micro-edges.adj",
+      "hop2_relation": "morphology",
+      "clue": "peptic_ulcer_disease",
+      "stem": "A patient is diagnosed with Helicobacter peptic ulcer disease. The organism that causes it has which microscopic morphology?",
+      "expected": "spiral",
+      "options": {
+        "A": "cocci",
+        "B": "diplococci",
+        "C": "bacilli",
+        "D": "comma_shaped",
+        "E": "spiral"
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "mh-26",
+      "qtype": "multi_hop_recall",
+      "hop1_lib": "micro-edges.adj",
+      "hop1_relation": "causes",
+      "hop1_reverse": true,
+      "hop2_lib": "micro-edges.adj",
+      "hop2_relation": "morphology",
+      "clue": "gonorrhea",
+      "stem": "A patient is diagnosed with gonorrhea. The organism that causes it has which microscopic morphology?",
+      "expected": "diplococci",
+      "options": {
+        "A": "diplococci",
+        "B": "cocci",
+        "C": "bacilli",
+        "D": "comma_shaped",
+        "E": "spiral"
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "mh-27",
+      "qtype": "multi_hop_recall",
+      "hop1_lib": "micro-edges.adj",
+      "hop1_relation": "causes",
+      "hop1_reverse": true,
+      "hop2_lib": "micro-edges.adj",
+      "hop2_relation": "morphology",
+      "clue": "syphilis",
+      "stem": "A patient is diagnosed with syphilis. The organism that causes it has which microscopic morphology?",
+      "expected": "spirochete",
+      "options": {
+        "A": "cocci",
+        "B": "spirochete",
+        "C": "diplococci",
+        "D": "bacilli",
+        "E": "comma_shaped"
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "mh-28",
+      "qtype": "multi_hop_recall",
+      "hop1_lib": "micro-edges.adj",
+      "hop1_relation": "causes",
+      "hop1_reverse": true,
+      "hop2_lib": "micro-edges.adj",
+      "hop2_relation": "morphology",
+      "clue": "meningitis",
+      "stem": "A patient is diagnosed with meningococcal meningitis. The organism that causes it has which microscopic morphology?",
+      "expected": "diplococci",
+      "options": {
+        "A": "cocci",
+        "B": "bacilli",
+        "C": "diplococci",
+        "D": "comma_shaped",
+        "E": "spiral"
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "mh-29",
+      "qtype": "multi_hop_recall",
+      "hop1_lib": "micro-edges.adj",
+      "hop1_relation": "causes",
+      "hop1_reverse": true,
+      "hop2_lib": "micro-edges.adj",
+      "hop2_relation": "morphology",
+      "clue": "pertussis",
+      "stem": "A patient is diagnosed with whooping cough (pertussis). The organism that causes it has which microscopic morphology?",
+      "expected": "coccobacilli",
+      "options": {
+        "A": "cocci",
+        "B": "diplococci",
+        "C": "bacilli",
+        "D": "coccobacilli",
+        "E": "comma_shaped"
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "mh-30",
+      "qtype": "multi_hop_recall",
+      "hop1_lib": "micro-edges.adj",
+      "hop1_relation": "causes",
+      "hop1_reverse": true,
+      "hop2_lib": "micro-edges.adj",
+      "hop2_relation": "gram_stain",
+      "clue": "a_syndrome_with_no_grounded_organism",
+      "stem": "A patient has a syndrome whose causative organism is not in the grounded library. The organism that causes it shows which Gram-stain reaction on microscopy? (If the causative organism is not grounded, abstain.)",
+      "expected": null,
+      "expect_abstain": true,
+      "options": {
+        "A": "gram_positive",
+        "B": "gram_negative",
+        "C": "acid_fast",
+        "D": "gram_variable",
+        "E": "poorly_staining"
+      }
     },
     {
       "id": "mh-14",

--- a/code/specs/data/mycin-2026/mle-pass/mle_pass_eval.py
+++ b/code/specs/data/mycin-2026/mle-pass/mle_pass_eval.py
@@ -3,23 +3,26 @@ the CPU from grounded edges, with ZERO model calls.
 
 The reasoning step past single-hop recall: a board question like "leukocoria points to a
 disease caused by a mutation in which gene?" needs TWO grounded hops —
-  hop 1  clue → disease     (an organ-system recall library: ophtho / neuro / collagen / …)
-  hop 2  disease → gene     (the genetics library)
-joined on the shared disease. We express the join as an adj-lang **rule body** and let the
-engine's SLD resolver do it:
+  hop 1  clue → middle entity   (an organ-system recall library: ophtho / neuro / micro / …)
+  hop 2  middle entity → answer (gene / inheritance pattern / Gram stain / morphology / …)
+joined on the shared middle entity. We express the join as an adj-lang **rule body** and let
+the engine's SLD resolver do it:
 
     import "<hop1 library>"
-    import "genetics-edges.adj"
+    import "<hop2 library>"
     rule {
-        head: clue_to_gene($X, $G)
-        when: <hop1 relation>($X, $D), gene_defect($D, $G)
+        head: clue_to_answer($X, $A)
+        when: <hop1 relation>($X, $D), <hop2 relation>($D, $A)
     }
-    ? clue_to_gene(<clue>, $G)
+    ? clue_to_answer(<clue>, $A)
 
-The engine returns the `$G` binding and — crucially — the citing clause of EACH hop, so a
+The engine returns the `$A` binding and — crucially — the citing clause of EACH hop, so a
 correct answer is defended by both spans (multi-hop byte-provenance). The harness reads the
-binding, maps it to the printed gene option, and scores correct / abstain / wrong. It never
-asks a model anything; all knowledge lives in the imported grounded libraries.
+binding, maps it to the printed option, and scores correct / abstain / wrong. It never asks a
+model anything; all knowledge lives in the imported grounded libraries. Hop 1 may run in
+reverse (`"hop1_reverse"`) when the clue is the relation's second argument — e.g. microbiology
+`causes(organism, disease)`, where the *disease* is the clue and the *organism* is the middle
+entity whose Gram stain / morphology is the answer (the original MYCIN organism-ID chain).
 
 Defensibility metric: `multihop_coverage` = fraction of CORRECT answers that cite BOTH hops
 (≥2 authoritative citing clauses). That is the number a future grounding PR moves, and the
@@ -63,15 +66,34 @@ _CLI = _find_cli()
 
 def build_query(item: dict) -> str:
     """The two-hop join program for one item: import both libraries, define the chaining
-    rule (hop1 relation × gene_defect, joined on the disease), and ask the binding query."""
+    rule (hop1 relation joined to hop2 relation on the shared middle entity `$D`), and ask the
+    binding query. The answer variable is `$A` (it may be a gene, an inheritance pattern, a
+    Gram stain, …, depending on the hop2 relation).
+
+    Hop-1 direction. By default the clue is hop1's FIRST argument and the middle entity its
+    second: `rel1($X, $D)` (e.g. `eye_finding_indicates(clue, disease)`). Some chains run the
+    other way: the clue is hop1's SECOND argument and the middle entity its first — e.g.
+    `causes(organism, disease)`, where the clue is the *disease* and the middle entity is the
+    *organism* to be found. Setting `"hop1_reverse": true` emits `rel1($D, $X)` for that case.
+    Either way the join variable `$D` is what hop2 consumes (`rel2($D, $A)`), so the engine's
+    SLD resolver does the join regardless of argument order — relations are bidirectional.
+
+    Imports are de-duplicated: when both hops draw on the same library (e.g. microbiology's
+    `causes` and `gram_stain` both live in `micro-edges.adj`) it is imported once.
+    """
+    libs = [item["hop1_lib"]]
+    if item["hop2_lib"] not in libs:
+        libs.append(item["hop2_lib"])
+    imports = "".join(f'import "{lib}"\n' for lib in libs)
+    hop1 = (f'{item["hop1_relation"]}($D, $X)' if item.get("hop1_reverse")
+            else f'{item["hop1_relation"]}($X, $D)')
     return (
-        f'import "{item["hop1_lib"]}"\n'
-        f'import "{item["hop2_lib"]}"\n'
-        "rule {\n"
-        "    head: clue_to_gene($X, $G)\n"
-        f'    when: {item["hop1_relation"]}($X, $D), {item["hop2_relation"]}($D, $G)\n'
+        imports
+        + "rule {\n"
+        "    head: clue_to_answer($X, $A)\n"
+        f'    when: {hop1}, {item["hop2_relation"]}($D, $A)\n'
         "}\n"
-        f'? clue_to_gene({item["clue"]}, $G)\n'
+        f'? clue_to_answer({item["clue"]}, $A)\n'
     )
 
 
@@ -88,11 +110,12 @@ def run_item(item: dict, cli: Path | None = None) -> RunResult:
         raise RuntimeError("adj-lang-cli not built (cargo build -p adj-lang-cli)")
     with tempfile.TemporaryDirectory() as td:
         tdp = Path(td)
-        # Copy the two grounded libraries beside the query so sibling imports resolve.
-        # Each must be a BARE filename (no path separators / parent refs) — a structural
-        # guard so a library name can only ever name a file directly inside recall/, never
-        # path-traverse out of it, regardless of where items.json comes from.
-        for lib in (item["hop1_lib"], item["hop2_lib"]):
+        # Copy the grounded libraries beside the query so sibling imports resolve (deduped —
+        # a chain whose two hops share one library copies it once). Each must be a BARE
+        # filename (no path separators / parent refs) — a structural guard so a library name
+        # can only ever name a file directly inside recall/, never path-traverse out of it,
+        # regardless of where items.json comes from.
+        for lib in dict.fromkeys((item["hop1_lib"], item["hop2_lib"])):
             if "/" in lib or "\\" in lib or ".." in lib:
                 raise ValueError(f"library name must be a bare filename, got {lib!r}")
             shutil.copy(RECALL / lib, tdp / lib)
@@ -104,7 +127,7 @@ def run_item(item: dict, cli: Path | None = None) -> RunResult:
     if not recall or not recall[0].get("answers"):
         return RunResult(binding=None, citations=0)
     ans = recall[0]["answers"][0]
-    return RunResult(binding=ans["bindings"].get("G"), citations=len(ans.get("citations", [])))
+    return RunResult(binding=ans["bindings"].get("A"), citations=len(ans.get("citations", [])))
 
 
 def letter_for(item: dict, gene: str | None) -> str | None:

--- a/code/specs/data/mycin-2026/mle-pass/test_mle_pass.py
+++ b/code/specs/data/mycin-2026/mle-pass/test_mle_pass.py
@@ -15,7 +15,7 @@ HERE = Path(__file__).resolve().parent
 
 def test_items_bank_is_well_formed():
     items = mp.load_items()
-    assert len(items) >= 15
+    assert len(items) >= 30
     seen = set()
     answerable = 0
     for it in items:
@@ -41,16 +41,33 @@ def test_items_bank_is_well_formed():
 def test_bank_exercises_multiple_hop2_relations_and_abstention():
     items = mp.load_items()
     hop2 = {it["hop2_relation"] for it in items}
-    assert {"gene_defect", "inheritance"} <= hop2  # generic over the second hop
-    assert any(it.get("expect_abstain") for it in items)  # an abstention sub-bank exists
+    # generic over the second hop: genes, inheritance, and microbiology traits all appear.
+    assert {"gene_defect", "inheritance", "gram_stain", "morphology"} <= hop2
+    assert any(it.get("expect_abstain") for it in items)   # an abstention sub-bank exists
+    assert any(it.get("hop1_reverse") for it in items)     # a reverse-hop1 chain exists
 
 
 def test_build_query_shape():
     item = mp.load_items()[0]
     q = mp.build_query(item)
-    assert q.count("import ") == 2          # both grounded libraries
+    assert q.count("import ") == 2          # two distinct grounded libraries
     assert "rule {" in q and "when:" in q   # the joining rule body
-    assert q.strip().endswith("$G)")        # the binding query
+    assert q.strip().endswith("$A)")        # the binding query (answer variable)
+
+
+def test_reverse_hop1_and_import_dedup():
+    # A reverse-hop1 micro item: clue is the relation's SECOND arg, and both hops share one
+    # library, so it is imported exactly once and the hop1 subgoal binds the join var first.
+    micro = next(it for it in mp.load_items() if it.get("hop1_reverse"))
+    assert micro["hop1_lib"] == micro["hop2_lib"]
+    q = mp.build_query(micro)
+    assert q.count("import ") == 1                                 # de-duplicated
+    assert f'{micro["hop1_relation"]}($D, $X)' in q                # reverse: join var first
+    assert f'{micro["hop2_relation"]}($D, $A)' in q                # hop2 consumes the join var
+    # A forward item still places the clue first.
+    fwd = next(it for it in mp.load_items() if not it.get("hop1_reverse")
+               and not it.get("expect_abstain"))
+    assert f'{fwd["hop1_relation"]}($X, $D)' in mp.build_query(fwd)
 
 
 @pytest.mark.skipif(mp._CLI is None, reason="adj-lang-cli not built")

--- a/code/specs/data/mycin-2026/recall/multihop-recall.query.adj
+++ b/code/specs/data/mycin-2026/recall/multihop-recall.query.adj
@@ -19,6 +19,7 @@ import "collagen-defect-edges.adj"
 import "enzyme-deficiency-edges.adj"
 import "derm-edges.adj"
 import "genetics-edges.adj"
+import "micro-edges.adj"
 
 % --- the chaining rules: clue -> disease -> gene, joined on the shared $D ---------------
 rule {
@@ -50,6 +51,19 @@ rule {
     head: eye_finding_to_inheritance($F, $P)
     when: eye_finding_indicates($F, $D), inheritance($D, $P)
 }
+% --- a REVERSE first hop: disease -> (causative organism) -> trait. `causes(organism, disease)`
+%     is traversed backwards (the disease is the clue, bound to the SECOND argument; the organism
+%     $O is the shared join), then the organism's Gram stain / morphology is read. The engine's
+%     SLD resolver joins on $O regardless of argument order — relations are bidirectional. This is
+%     the original MYCIN organism-identification chain, and both hops live in one library.
+rule {
+    head: disease_to_gram($Dis, $Stain)
+    when: causes($O, $Dis), gram_stain($O, $Stain)
+}
+rule {
+    head: disease_to_morphology($Dis, $Shape)
+    when: causes($O, $Dis), morphology($O, $Shape)
+}
 
 % --- the two-hop binding queries (each returns the gene + both hops' provenance) --------
 ? eye_finding_to_gene(leukocoria, $G)                  % expect rb1   (retinoblastoma)
@@ -67,3 +81,11 @@ rule {
 ? lesion_to_inheritance(caudate_nucleus, $P)           % expect autosomal_dominant (huntington)
 ? eye_finding_to_inheritance(kayser_fleischer_rings, $P) % expect autosomal_recessive (wilson)
 ? eye_finding_to_inheritance(superior_lens_dislocation, $P) % expect autosomal_dominant (marfan)
+
+% --- reverse first hop: disease -> causative organism -> Gram stain / morphology ------------
+? disease_to_gram(cholera, $Stain)                     % expect gram_negative (vibrio_cholerae)
+? disease_to_gram(anthrax, $Stain)                     % expect gram_positive (bacillus_anthracis)
+? disease_to_morphology(cholera, $Shape)               % expect comma_shaped (vibrio_cholerae)
+? disease_to_morphology(peptic_ulcer_disease, $Shape)  % expect spiral (helicobacter_pylori)
+? disease_to_morphology(gonorrhea, $Shape)             % expect diplococci (neisseria_gonorrhoeae)
+? disease_to_morphology(syphilis, $Shape)              % expect spirochete (treponema_pallidum)


### PR DESCRIPTION
## What

Grows the MLE-PASS multi-hop bank **15 → 30** by adding the original **MYCIN** reasoning chain: from a **disease**, bind the **causative organism**, then read that organism's **Gram stain** or microscopic **morphology** (`disease → organism → trait`). All answered purely on the CPU from grounded edges — **zero model calls** (30/30 correct).

## The twist: hop 1 runs in reverse

The grounded edge is `causes(organism, disease)`, so the clue (the disease) is its **second** argument and the organism is the middle entity. A new generic harness flag **`hop1_reverse`** emits hop 1's subgoal as `rel1($D, $X)` (join var first, clue second) instead of `rel1($X, $D)`; the engine's SLD resolver joins on `$D` **regardless of argument order** — relations are bidirectional, so a two-hop chain need not run left-to-right through the edges.

```adj
import "micro-edges.adj"          % both hops live here → imported once
rule {
    head: clue_to_answer($X, $A)
    when: causes($D, $X), gram_stain($D, $A)   % $X = disease (clue), $D = organism (join)
}
? clue_to_answer(cholera, $A)     % → gram_negative (vibrio_cholerae), both hops cited
```

## Harness

- **`hop1_reverse`** (generic, defaults false → slices 1–2 unaffected).
- `build_query` **de-duplicates imports** (micro's `causes` + `gram_stain`/`morphology` share one library) and the answer variable is generalised `$G → $A` (gene / inheritance pattern / Gram stain / morphology, per hop 2); `run_item` reads the `A` binding.
- 14 answerable micro chains (8 Gram stain, 6 morphology) + a micro abstention item whose disease has no grounded causative organism. Nothing authored — every edge reuses an already-grounded, spider+adversarially-gated micro fact.

## Honesty note

The spec records why a genuine **three-relation forward chain** is not groundable yet (no grounded edge chains off a gene/substrate/trait; the enzyme-deficiency disease ids `gaucher_disease` don't match the lysosomal `accumulates` ids `gaucher`) — rather than authoring edges to force it.

## Gates

- **30/30 correct** (27 answerable, `multihop_coverage` 1.0; 3 abstained correctly), zero model calls.
- **6 pytest** pass (new `test_reverse_hop1_and_import_dedup`); ruff clean. Worked artifact extended (19 in-place queries, all bound, both hops cited).
- `/security-review` **PASSED** (only template token-order + dedup over trusted JSON; bare-filename guard intact; `json.loads` + list-form `shell=False`; no new sink).
- mle-pass **0.3.0**. Spec `MLE-PASS-multihop-recall.md` §6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)