### PR TITLE
fix(mini-sqlite/ts): cut v0.1.1 — release ReDoS fix

### DIFF
--- a/code/packages/typescript/mini-sqlite/CHANGELOG.md
+++ b/code/packages/typescript/mini-sqlite/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog - @coding-adventures/mini-sqlite
 
-## Unreleased
+## [0.1.1] - 2026-06-30
 
 ### Fixed
 - Removed `\s*;?\s*$` trailer from five DDL/DML parsing regexes; trailing

--- a/code/packages/typescript/mini-sqlite/package.json
+++ b/code/packages/typescript/mini-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/mini-sqlite",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Mini-SQLite facade for TypeScript backed by the SQL execution engine",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
## Summary

- Formally releases the ReDoS regression fix that was already in the codebase as `v0.1.1`.
- `package.json` version: `0.1.0` → `0.1.1`
- `CHANGELOG.md`: `## Unreleased` → `## [0.1.1] - 2026-06-30`

The fix itself (replacing `\s*;?\s*$` regex trailer with imperative `stripStatementTerminator`) landed in the initial 0.1.0 commit; this just gives it a versioned release so downstream consumers can pin the patch.

## Test plan
- [ ] CI TypeScript build passes (no code changes, only metadata)
- [ ] `package.json` version field is `0.1.1`
- [ ] CHANGELOG has `[0.1.1]` with today's date

🤖 Generated with [Claude Code](https://claude.com/claude-code)