### PR TITLE
fix(mini-sqlite/ruby): cut v0.1.1 — release ReDoS fix

### DIFF
--- a/code/packages/ruby/mini_sqlite/CHANGELOG.md
+++ b/code/packages/ruby/mini_sqlite/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog - coding_adventures_mini_sqlite
 
-## Unreleased
+## [0.1.1] - 2026-06-30
 
 ### Fixed
 - Removed `\s*;?\s*\z` trailer from four DDL/DML parsing regexes; trailing

--- a/code/packages/ruby/mini_sqlite/lib/coding_adventures/mini_sqlite/version.rb
+++ b/code/packages/ruby/mini_sqlite/lib/coding_adventures/mini_sqlite/version.rb
@@ -2,6 +2,6 @@
 
 module CodingAdventures
   module MiniSqlite
-    VERSION = "0.1.0"
+    VERSION = "0.1.1"
   end
 end


### PR DESCRIPTION
## Summary

- Formally releases the ReDoS regression fix that was already in the codebase as `v0.1.1`.
- `version.rb` VERSION: `0.1.0` → `0.1.1`
- `CHANGELOG.md`: `## Unreleased` → `## [0.1.1] - 2026-06-30`

The fix itself (replacing `\s*;?\s*\z` regex trailer with imperative `strip_terminator`) landed in the initial 0.1.0 commit; this just gives it a versioned release so downstream consumers can pin the patch.

## Test plan
- [ ] CI Ruby build passes (no code changes, only metadata)
- [ ] `VERSION` constant is `0.1.1`
- [ ] CHANGELOG has `[0.1.1]` with today's date

🤖 Generated with [Claude Code](https://claude.com/claude-code)