### PR TITLE
[codex] Add Berkeley app readiness report

### DIFF
--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Add Berkeley SPICE app-deck readiness reports for Mosaic product-shell
+  telemetry and startup gates. `BerkeleyAppDeck::app_readiness_report()`,
+  `run_app_readiness_report()`, and their JSON helpers summarize launch route,
+  panel/action availability, diagnostic severity counts, repaired state, and
+  blocking reasons from bootstrap snapshots.
 - Add Berkeley SPICE app-deck launch plans for Mosaic product-shell startup
   routing. `BerkeleyAppDeck::app_launch_plan()`, `run_app_launch_plan()`, and
   their JSON helpers derive ready/blocked entry panels, route targets, and panel

--- a/code/packages/rust/spice-netlist-parser/README.md
+++ b/code/packages/rust/spice-netlist-parser/README.md
@@ -99,6 +99,12 @@ let launch_plan_json = deck.run_app_launch_plan_json(BerkeleyAppPersistedEditorS
 })?;
 assert!(launch_plan_json.contains(r#""startupRoute":"ready""#));
 assert!(launch_plan_json.contains(r#""entryPanelId":"waveform""#));
+
+let readiness_report_json = deck.run_app_readiness_report_json(BerkeleyAppPersistedEditorState {
+    selected_syntax_card_index: Some(3),
+    active_command_id: Some("analysis.3.inspect-waveform".to_string()),
+})?;
+assert!(readiness_report_json.contains(r#""errorCount":0"#));
 ```
 
 The facade preserves normalized logical cards, source spans, token names
@@ -135,8 +141,11 @@ active panel, repaired editor-state IDs, stale-state flags, diagnostic count,
 and blocking reason. Launch plans derive product-shell entry actions from the
 bootstrap payload, including a primary entry panel, target, route status, and
 panel action descriptors so hosts can start on the right Mosaic surface without
-walking the full host-surface export. The grammar-backed parser generator and
-Python/TypeScript parity surfaces continue to mature.
+walking the full host-surface export. Readiness reports summarize the same
+startup path with panel/action availability counts, diagnostic severity counts,
+repaired-state flags, and blocking reasons for product-shell telemetry and
+readiness gates. The grammar-backed parser generator and Python/TypeScript
+parity surfaces continue to mature.
 
 This parser supports `R`, `C`, `L`, `V`, `I`, `D`, `Q`, `M`, `G`, `E`, `F`, and
 `H` elements, `.model <name> D(...)` diode cards with `IS` and `VT`

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -24,15 +24,16 @@ pub use syntax::{
     BerkeleyAppHostPanelKind, BerkeleyAppHostPanelWire, BerkeleyAppHostSpanWire,
     BerkeleyAppHostSurface, BerkeleyAppHostSurfaceWire, BerkeleyAppLaunchAction,
     BerkeleyAppLaunchPlan, BerkeleyAppPackageManifest, BerkeleyAppPersistedEditorState,
-    BerkeleyAppSessionAnalysis, BerkeleyAppSessionState, BerkeleyAppStartupSummary,
-    BerkeleyAppWaveformPoint, BerkeleyAppWaveformSeries, BerkeleyCardKind,
-    BerkeleyDiagnosticSeverity, BerkeleyGrammarMetadata, BerkeleyLogicalCard, BerkeleySyntaxDeck,
-    BerkeleySyntaxDiagnostic, BerkeleySyntaxToken, SourceSpan,
+    BerkeleyAppReadinessReport, BerkeleyAppSessionAnalysis, BerkeleyAppSessionState,
+    BerkeleyAppStartupSummary, BerkeleyAppWaveformPoint, BerkeleyAppWaveformSeries,
+    BerkeleyCardKind, BerkeleyDiagnosticSeverity, BerkeleyGrammarMetadata, BerkeleyLogicalCard,
+    BerkeleySyntaxDeck, BerkeleySyntaxDiagnostic, BerkeleySyntaxToken, SourceSpan,
     BERKELEY_APP_BOOTSTRAP_SCHEMA_VERSION, BERKELEY_APP_HOST_SURFACE_WIRE_SCHEMA_VERSION,
     BERKELEY_APP_LAUNCH_PLAN_SCHEMA_VERSION, BERKELEY_APP_PACKAGE_MANIFEST_SCHEMA_VERSION,
-    BERKELEY_APP_PACKAGE_NAME, BERKELEY_APP_SOURCE_FINGERPRINT_ALGORITHM,
-    BERKELEY_APP_STARTUP_SUMMARY_SCHEMA_VERSION, BERKELEY_SPICE_GRAMMAR_NAME,
-    BERKELEY_SPICE_GRAMMAR_VERSION, BERKELEY_SPICE_PARSER_GRAMMAR, BERKELEY_SPICE_TOKEN_GRAMMAR,
+    BERKELEY_APP_PACKAGE_NAME, BERKELEY_APP_READINESS_REPORT_SCHEMA_VERSION,
+    BERKELEY_APP_SOURCE_FINGERPRINT_ALGORITHM, BERKELEY_APP_STARTUP_SUMMARY_SCHEMA_VERSION,
+    BERKELEY_SPICE_GRAMMAR_NAME, BERKELEY_SPICE_GRAMMAR_VERSION, BERKELEY_SPICE_PARSER_GRAMMAR,
+    BERKELEY_SPICE_TOKEN_GRAMMAR,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/code/packages/rust/spice-netlist-parser/src/syntax.rs
+++ b/code/packages/rust/spice-netlist-parser/src/syntax.rs
@@ -18,6 +18,7 @@ pub const BERKELEY_APP_PACKAGE_MANIFEST_SCHEMA_VERSION: u32 = 1;
 pub const BERKELEY_APP_BOOTSTRAP_SCHEMA_VERSION: u32 = 1;
 pub const BERKELEY_APP_STARTUP_SUMMARY_SCHEMA_VERSION: u32 = 1;
 pub const BERKELEY_APP_LAUNCH_PLAN_SCHEMA_VERSION: u32 = 1;
+pub const BERKELEY_APP_READINESS_REPORT_SCHEMA_VERSION: u32 = 1;
 pub const BERKELEY_APP_PACKAGE_NAME: &str = "berkeley-spice-mosaic-app";
 pub const BERKELEY_APP_SOURCE_FINGERPRINT_ALGORITHM: &str = "fnv1a-64";
 
@@ -51,6 +52,7 @@ const BERKELEY_APP_ARTIFACT_CAPABILITIES: &[&str] = &[
     "app-bootstrap-json",
     "app-startup-summary-json",
     "app-launch-plan-json",
+    "app-readiness-report-json",
     "result-tables",
     "waveform-series",
     "run-artifacts",
@@ -359,6 +361,107 @@ impl BerkeleyAppLaunchPlan {
 
     pub fn to_json(&self) -> String {
         app_launch_plan_json_value(self).to_string()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BerkeleyAppReadinessReport {
+    pub schema_version: u32,
+    pub package_name: String,
+    pub source_fingerprint: String,
+    pub title: Option<String>,
+    pub startup_route: String,
+    pub ready: bool,
+    pub parsed: bool,
+    pub execution_available: bool,
+    pub entry_panel_id: Option<String>,
+    pub entry_target: Option<String>,
+    pub primary_action_id: Option<String>,
+    pub primary_action_enabled: bool,
+    pub panel_count: usize,
+    pub enabled_panel_count: usize,
+    pub disabled_panel_count: usize,
+    pub action_count: usize,
+    pub enabled_action_count: usize,
+    pub disabled_action_count: usize,
+    pub diagnostic_count: usize,
+    pub error_count: usize,
+    pub warning_count: usize,
+    pub note_count: usize,
+    pub selection_stale: bool,
+    pub command_stale: bool,
+    pub repaired_state: bool,
+    pub blocking_message: Option<String>,
+}
+
+impl BerkeleyAppReadinessReport {
+    pub fn from_bootstrap_snapshot(snapshot: &BerkeleyAppBootstrapSnapshot) -> Self {
+        let host_surface = &snapshot.host_surface;
+        let launch_plan = BerkeleyAppLaunchPlan::from_bootstrap_snapshot(snapshot);
+        let enabled_panel_count = host_surface
+            .panels
+            .iter()
+            .filter(|panel| panel.enabled)
+            .count();
+        let primary_action = launch_plan.actions.iter().find(|action| action.primary);
+        let primary_action_id = primary_action.map(|action| action.id.clone());
+        let primary_action_enabled = primary_action.is_some_and(|action| action.enabled);
+        let enabled_action_count = launch_plan
+            .actions
+            .iter()
+            .filter(|action| action.enabled)
+            .count();
+        let error_count = host_surface
+            .diagnostics
+            .iter()
+            .filter(|diagnostic| diagnostic.severity == "error")
+            .count();
+        let warning_count = host_surface
+            .diagnostics
+            .iter()
+            .filter(|diagnostic| diagnostic.severity == "warning")
+            .count();
+        let note_count = host_surface
+            .diagnostics
+            .iter()
+            .filter(|diagnostic| diagnostic.severity == "note")
+            .count();
+        let repaired_state = launch_plan.selection_stale || launch_plan.command_stale;
+
+        Self {
+            schema_version: BERKELEY_APP_READINESS_REPORT_SCHEMA_VERSION,
+            package_name: launch_plan.package_name,
+            source_fingerprint: launch_plan.source_fingerprint,
+            title: launch_plan.title,
+            startup_route: launch_plan.startup_route,
+            ready: launch_plan.ready,
+            parsed: host_surface.parsed,
+            execution_available: host_surface.execution_available,
+            entry_panel_id: launch_plan.entry_panel_id,
+            entry_target: launch_plan.entry_target,
+            primary_action_id,
+            primary_action_enabled,
+            panel_count: host_surface.panel_count,
+            enabled_panel_count,
+            disabled_panel_count: host_surface.panel_count.saturating_sub(enabled_panel_count),
+            action_count: launch_plan.action_count,
+            enabled_action_count,
+            disabled_action_count: launch_plan
+                .action_count
+                .saturating_sub(enabled_action_count),
+            diagnostic_count: host_surface.diagnostics.len(),
+            error_count,
+            warning_count,
+            note_count,
+            selection_stale: launch_plan.selection_stale,
+            command_stale: launch_plan.command_stale,
+            repaired_state,
+            blocking_message: launch_plan.blocking_message,
+        }
+    }
+
+    pub fn to_json(&self) -> String {
+        app_readiness_report_json_value(self).to_string()
     }
 }
 
@@ -972,6 +1075,38 @@ impl BerkeleyAppDeck {
         persisted_state: BerkeleyAppPersistedEditorState,
     ) -> Result<String, AnalysisExecutionError> {
         Ok(self.run_app_launch_plan(persisted_state)?.to_json())
+    }
+
+    pub fn app_readiness_report(
+        &self,
+        persisted_state: BerkeleyAppPersistedEditorState,
+    ) -> BerkeleyAppReadinessReport {
+        BerkeleyAppReadinessReport::from_bootstrap_snapshot(
+            &self.app_bootstrap_snapshot(persisted_state),
+        )
+    }
+
+    pub fn run_app_readiness_report(
+        &self,
+        persisted_state: BerkeleyAppPersistedEditorState,
+    ) -> Result<BerkeleyAppReadinessReport, AnalysisExecutionError> {
+        Ok(BerkeleyAppReadinessReport::from_bootstrap_snapshot(
+            &self.run_app_bootstrap_snapshot(persisted_state)?,
+        ))
+    }
+
+    pub fn app_readiness_report_json(
+        &self,
+        persisted_state: BerkeleyAppPersistedEditorState,
+    ) -> String {
+        self.app_readiness_report(persisted_state).to_json()
+    }
+
+    pub fn run_app_readiness_report_json(
+        &self,
+        persisted_state: BerkeleyAppPersistedEditorState,
+    ) -> Result<String, AnalysisExecutionError> {
+        Ok(self.run_app_readiness_report(persisted_state)?.to_json())
     }
 
     pub fn run_source_order(&self) -> Result<Vec<AnalysisExecutionResult>, AnalysisExecutionError> {
@@ -1677,6 +1812,37 @@ fn app_launch_action_json_value(action: &BerkeleyAppLaunchAction) -> serde_json:
         "enabled": action.enabled,
         "primary": action.primary,
         "disabledReason": &action.disabled_reason,
+    })
+}
+
+fn app_readiness_report_json_value(report: &BerkeleyAppReadinessReport) -> serde_json::Value {
+    serde_json::json!({
+        "schemaVersion": report.schema_version,
+        "packageName": &report.package_name,
+        "sourceFingerprint": &report.source_fingerprint,
+        "title": &report.title,
+        "startupRoute": &report.startup_route,
+        "ready": report.ready,
+        "parsed": report.parsed,
+        "executionAvailable": report.execution_available,
+        "entryPanelId": &report.entry_panel_id,
+        "entryTarget": &report.entry_target,
+        "primaryActionId": &report.primary_action_id,
+        "primaryActionEnabled": report.primary_action_enabled,
+        "panelCount": report.panel_count,
+        "enabledPanelCount": report.enabled_panel_count,
+        "disabledPanelCount": report.disabled_panel_count,
+        "actionCount": report.action_count,
+        "enabledActionCount": report.enabled_action_count,
+        "disabledActionCount": report.disabled_action_count,
+        "diagnosticCount": report.diagnostic_count,
+        "errorCount": report.error_count,
+        "warningCount": report.warning_count,
+        "noteCount": report.note_count,
+        "selectionStale": report.selection_stale,
+        "commandStale": report.command_stale,
+        "repairedState": report.repaired_state,
+        "blockingMessage": &report.blocking_message,
     })
 }
 

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -14,8 +14,9 @@ use spice_netlist_parser::{
     TfAnalysis, TranAnalysis, BERKELEY_APP_BOOTSTRAP_SCHEMA_VERSION,
     BERKELEY_APP_HOST_SURFACE_WIRE_SCHEMA_VERSION, BERKELEY_APP_LAUNCH_PLAN_SCHEMA_VERSION,
     BERKELEY_APP_PACKAGE_MANIFEST_SCHEMA_VERSION, BERKELEY_APP_PACKAGE_NAME,
-    BERKELEY_APP_SOURCE_FINGERPRINT_ALGORITHM, BERKELEY_APP_STARTUP_SUMMARY_SCHEMA_VERSION,
-    BERKELEY_SPICE_GRAMMAR_NAME, BERKELEY_SPICE_GRAMMAR_VERSION,
+    BERKELEY_APP_READINESS_REPORT_SCHEMA_VERSION, BERKELEY_APP_SOURCE_FINGERPRINT_ALGORITHM,
+    BERKELEY_APP_STARTUP_SUMMARY_SCHEMA_VERSION, BERKELEY_SPICE_GRAMMAR_NAME,
+    BERKELEY_SPICE_GRAMMAR_VERSION,
 };
 
 fn assert_close(actual: f64, expected: f64) {
@@ -2564,6 +2565,11 @@ fn berkeley_app_facade_exports_package_manifest_json() {
         .unwrap()
         .iter()
         .any(|capability| capability == "app-launch-plan-json"));
+    assert!(payload["artifactCapabilities"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|capability| capability == "app-readiness-report-json"));
 }
 
 #[test]
@@ -2724,6 +2730,57 @@ C1 out 0 1p
     assert_eq!(launch_payload["actions"][4]["id"], "launch.waveform");
     assert_eq!(launch_payload["actions"][4]["primary"], true);
     assert_eq!(launch_payload["actions"][4]["enabled"], true);
+
+    let readiness_report = app
+        .run_app_readiness_report(BerkeleyAppPersistedEditorState {
+            selected_syntax_card_index: Some(3),
+            active_command_id: Some("analysis.3.inspect-waveform".to_string()),
+        })
+        .expect("readiness report should execute");
+    assert_eq!(
+        readiness_report.schema_version,
+        BERKELEY_APP_READINESS_REPORT_SCHEMA_VERSION
+    );
+    assert_eq!(readiness_report.package_name, BERKELEY_APP_PACKAGE_NAME);
+    assert_eq!(readiness_report.startup_route, "ready");
+    assert!(readiness_report.ready);
+    assert!(readiness_report.parsed);
+    assert!(readiness_report.execution_available);
+    assert_eq!(readiness_report.entry_panel_id.as_deref(), Some("waveform"));
+    assert_eq!(
+        readiness_report.primary_action_id.as_deref(),
+        Some("launch.waveform")
+    );
+    assert!(readiness_report.primary_action_enabled);
+    assert_eq!(readiness_report.panel_count, 5);
+    assert_eq!(readiness_report.enabled_panel_count, 4);
+    assert_eq!(readiness_report.disabled_panel_count, 1);
+    assert_eq!(readiness_report.action_count, 5);
+    assert_eq!(readiness_report.enabled_action_count, 4);
+    assert_eq!(readiness_report.disabled_action_count, 1);
+    assert_eq!(readiness_report.diagnostic_count, 0);
+    assert_eq!(readiness_report.error_count, 0);
+    assert_eq!(readiness_report.warning_count, 0);
+    assert_eq!(readiness_report.note_count, 0);
+    assert!(!readiness_report.repaired_state);
+
+    let readiness_payload: serde_json::Value = serde_json::from_str(
+        &app.run_app_readiness_report_json(BerkeleyAppPersistedEditorState {
+            selected_syntax_card_index: Some(3),
+            active_command_id: Some("analysis.3.inspect-waveform".to_string()),
+        })
+        .unwrap(),
+    )
+    .expect("readiness report JSON should parse");
+    assert_eq!(readiness_payload["schemaVersion"], 1);
+    assert_eq!(readiness_payload["startupRoute"], "ready");
+    assert_eq!(readiness_payload["entryPanelId"], "waveform");
+    assert_eq!(readiness_payload["primaryActionId"], "launch.waveform");
+    assert_eq!(readiness_payload["enabledPanelCount"], 4);
+    assert_eq!(readiness_payload["disabledPanelCount"], 1);
+    assert_eq!(readiness_payload["enabledActionCount"], 4);
+    assert_eq!(readiness_payload["errorCount"], 0);
+    assert_eq!(readiness_payload["repairedState"], false);
 }
 
 #[test]
@@ -2830,6 +2887,55 @@ R1 in out
     assert_eq!(launch_payload["actions"][1]["id"], "launch.diagnostics");
     assert_eq!(launch_payload["actions"][1]["primary"], true);
     assert_eq!(launch_payload["diagnosticCount"], 1);
+
+    let readiness_report = app.app_readiness_report(BerkeleyAppPersistedEditorState {
+        selected_syntax_card_index: Some(2),
+        active_command_id: Some("analysis.2.run".to_string()),
+    });
+    assert_eq!(
+        readiness_report.schema_version,
+        BERKELEY_APP_READINESS_REPORT_SCHEMA_VERSION
+    );
+    assert_eq!(readiness_report.startup_route, "blocked");
+    assert!(!readiness_report.ready);
+    assert!(!readiness_report.parsed);
+    assert!(!readiness_report.execution_available);
+    assert_eq!(
+        readiness_report.entry_panel_id.as_deref(),
+        Some("diagnostics")
+    );
+    assert_eq!(
+        readiness_report.primary_action_id.as_deref(),
+        Some("launch.diagnostics")
+    );
+    assert!(readiness_report.primary_action_enabled);
+    assert_eq!(readiness_report.panel_count, 5);
+    assert_eq!(readiness_report.enabled_panel_count, 3);
+    assert_eq!(readiness_report.disabled_panel_count, 2);
+    assert_eq!(readiness_report.action_count, 5);
+    assert_eq!(readiness_report.enabled_action_count, 3);
+    assert_eq!(readiness_report.disabled_action_count, 2);
+    assert_eq!(readiness_report.diagnostic_count, 1);
+    assert_eq!(readiness_report.error_count, 1);
+    assert_eq!(readiness_report.warning_count, 0);
+    assert_eq!(readiness_report.note_count, 0);
+    assert!(readiness_report.blocking_message.is_some());
+
+    let readiness_payload: serde_json::Value = serde_json::from_str(
+        &app.app_readiness_report_json(BerkeleyAppPersistedEditorState {
+            selected_syntax_card_index: Some(2),
+            active_command_id: Some("analysis.2.run".to_string()),
+        }),
+    )
+    .expect("blocked readiness report JSON should parse");
+    assert_eq!(readiness_payload["startupRoute"], "blocked");
+    assert_eq!(readiness_payload["entryPanelId"], "diagnostics");
+    assert_eq!(readiness_payload["primaryActionId"], "launch.diagnostics");
+    assert_eq!(readiness_payload["enabledPanelCount"], 3);
+    assert_eq!(readiness_payload["disabledPanelCount"], 2);
+    assert_eq!(readiness_payload["enabledActionCount"], 3);
+    assert_eq!(readiness_payload["errorCount"], 1);
+    assert!(readiness_payload["blockingMessage"].is_string());
 }
 
 #[test]

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,16 +33,15 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Rust Berkeley Mosaic app launch plan.
+1. Rust Berkeley Mosaic app readiness report.
    - Status: current PR completion candidate.
-   - Add schema-versioned Rust app launch plans and JSON helpers that derive
-     ready/blocked product-shell entry actions from Berkeley app bootstrap
-     payloads.
-   - Preserve package name, source fingerprint, startup route, primary entry
-     panel, entry target, repaired persisted editor-state IDs, stale-state
-     flags, panel action descriptors, diagnostic count, and blocking reason so
-     Mosaic, WebAssembly, and product shells can launch the correct surface
-     without walking every host panel.
+   - Add schema-versioned Rust app readiness reports and JSON helpers that
+     summarize startup route health from Berkeley app bootstrap payloads.
+   - Preserve package name, source fingerprint, startup route, parsed/execution
+     availability, entry panel/action, panel/action availability counts,
+     diagnostic severity counts, repaired persisted editor-state flags, and
+     blocking reason so Mosaic, WebAssembly, and product shells can gate startup
+     and telemetry without walking every host panel.
    - Keep this as a Rust-only app-substrate packaging slice over the public
      parser contract; Python and TypeScript parser parity remains aligned when
      parser behavior changes.
@@ -1552,6 +1551,17 @@ the Rust, Python, and TypeScript surfaces together.
      persisted editor-state IDs, stale-state flags, active panel, diagnostic
      count, and blocking reason so Mosaic, WebAssembly, and product shells can
      make startup routing decisions without walking every host panel.
+
+147. Rust Berkeley Mosaic app launch plan.
+   - Status: completed in PR 6995.
+   - Rust `spice-netlist-parser` now exposes schema-versioned Berkeley Mosaic
+     app launch plans plus JSON helpers that derive ready/blocked product-shell
+     entry actions from bootstrap payloads.
+   - The launch plan preserves package name, source fingerprint, startup route,
+     primary entry panel, entry target, repaired persisted editor-state IDs,
+     stale-state flags, panel action descriptors, diagnostic count, and blocking
+     reason so Mosaic, WebAssembly, and product shells can launch the correct
+     surface without walking every host panel.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary

- Add schema-versioned Berkeley Mosaic app readiness reports and JSON helpers derived from app bootstrap snapshots.
- Advertise `app-readiness-report-json` in the package manifest and export the native readiness report type plus schema version.
- Cover ready and blocked readiness reports in Rust tests, and update README, changelog, and the SPICE implementation plan to mark PR #6995 complete.

## Verification

- `cargo fmt -p spice-netlist-parser`
- `cargo test -p spice-netlist-parser -- --nocapture`
- `cargo test -p grammar-tools --test spice_grammar_validation -- --nocapture`
- `git diff --check`

Python and TypeScript were not changed because this is a Rust-only Mosaic app-substrate surface derived from the existing Rust bootstrap/launch payloads; parser behavior is unchanged.