### PR TITLE
feat(sir-go): SIR16 Floats + ShortCircuit in the Go backend (A4)

### DIFF
--- a/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
@@ -1,5 +1,62 @@
 # Changelog
 
+## 0.2.0 — SIR16 Floats + ShortCircuit (A4)
+
+First two SIR16 (v1) features land in the Go backend, mirroring the
+just-merged Rust backend equivalent.  Before this release the Go backend
+declared *none* of the six SIR16 features, so every SIR16 IR node hit a
+`panic!` reject arm.  This release wires up two of them end-to-end.
+
+### Added
+
+- `Feature::Floats` and `Feature::ShortCircuit` join the backend's
+  `ACCEPTED_FEATURES`, so a module declaring them is no longer rejected
+  by the capability check.
+- **Floats** — the inlined Go runtime's `Value` (`interface{}`) now
+  accepts a `float64` arm:
+  - New helpers `_sir_as_float`, `_sir_any_float`, `_sir_is_number_val`,
+    and `_sir_format_float`.
+  - Arithmetic (`+ - * /`) keeps the exact int64 fast-path while every
+    operand is an integer, and promotes the whole fold to `float64` the
+    moment any operand is a float ("int op float ⇒ float").  Integer
+    division keeps its divide-by-zero panic; float division follows
+    IEEE-754 (`1.0/0.0 ⇒ +Inf`).
+  - `=` is cross-type for numbers (`1 == 1.0` is true) and uses IEEE
+    equality for floats (`NaN != NaN`).  `<` / `>` compare numerically,
+    staying on the int path when both operands are int64.
+  - `number?` is true for both integers and floats.
+  - `FloatLit` emits `Value(float64(<lit>))`; integral values spell out
+    `3.0` (never `3`) so the runtime type-switch hits the float arm.
+    Non-finite values route through `math.NaN()` / `math.Inf(±1)` since
+    Go has no float literal for them.
+  - Display: `_sir_format_float` prints integral floats with a trailing
+    `.0` (`3.0`, not Go's default `%v`-style `3`), fractional values via
+    `strconv.FormatFloat(x, 'g', -1, 64)`, and non-finite values as
+    `NaN` / `inf` / `-inf` — matching the Rust backend's intent.
+- **ShortCircuit** — `LogicalAnd` / `LogicalOr` emit a truthy-guarded
+  immediately-invoked func literal:
+  `func() Value { __l := <lhs>; if _sir_truthy(__l) { return <rhs> } else { return __l } }()`
+  (and the mirror for `or`).  The operand value is returned (not a
+  coerced bool), `lhs` is evaluated exactly once, and each IIFE scopes
+  its own `__l` so nesting never collides.  Pure emit — no runtime
+  change.
+- The emitter now imports `"math"` (alongside `"fmt"` and `"strconv"`);
+  the runtime always references it via the float `NaN`/`Inf` checks, so
+  Go's unused-import rule stays satisfied.
+- Integration test `tests/compile_and_run_floats.rs`: hand-builds a SIR
+  module exercising floats, short-circuit, and cross-type equality;
+  emits Go, runs it with `go run`, and asserts stdout
+  (`4.0 / 4.0 / 5 / 7 / #f / #t`).  Gated on `go version` — skips with a
+  log line if the Go toolchain is absent.
+
+### Notes
+
+- The remaining four SIR16 features (MutableBindings, Loops, Sequences,
+  Maps) are still **not** declared, so the corresponding emit arms
+  (`SeqLit`, `MapLit`, `Assign`, `While`, …) remain reachable only as
+  internal-bug `panic!`s — the capability check rejects such modules
+  before emit.  They land in later Go PRs.
+
 ## 0.1.2 — SIR18 exhaustiveness (no behaviour change)
 
 semantic-ir 0.10.0 adds `Expr::StrConcat` (the SIR18 string-concat

--- a/code/packages/rust/semantic-ir-to-go/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-go/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-go"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Semantic IR → self-contained Go source code (SIR15). Fourth backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-go/README.md
+++ b/code/packages/rust/semantic-ir-to-go/README.md
@@ -24,6 +24,23 @@ let artifact = backend.compile(&sir_module)?;
 Accepts the full v0 feature set minus `TailCalls` (Go has no TCO) and
 `Intrinsics` (empty whitelist in v0).
 
+### SIR16 (v1) — added incrementally
+
+- **`Floats`** — the runtime `Value` gains a `float64` arm.  Arithmetic
+  stays on the exact int64 path while every operand is an integer and
+  promotes to `float64` once any operand is a float ("int op float ⇒
+  float").  `number?` covers floats; `=` is cross-type for numbers
+  (`1 == 1.0` is true, `NaN != NaN`); `<` / `>` compare numerically.
+  Float display keeps a trailing `.0` on integral floats (`3.0`, not
+  `3`) and prints non-finite values as `NaN` / `inf` / `-inf`.
+- **`ShortCircuit`** — `and` / `or` lower to a truthy-guarded
+  immediately-invoked func literal that returns the operand value
+  (`a and b ⇒ b` if `a` is truthy else `a`), evaluating the left side
+  exactly once.
+
+The remaining four SIR16 features (`MutableBindings`, `Loops`,
+`Sequences`, `Maps`) are not yet declared and land in later PRs.
+
 ## Value model
 
 ```go

--- a/code/packages/rust/semantic-ir-to-go/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/emit.rs
@@ -36,7 +36,7 @@ pub fn emit_module(m: &Module) -> String {
     let mut out = String::new();
     emit_banner(&mut out, m);
     out.push_str("package main\n\n");
-    out.push_str("import (\n\t\"fmt\"\n\t\"strconv\"\n)\n\n");
+    out.push_str("import (\n\t\"fmt\"\n\t\"math\"\n\t\"strconv\"\n)\n\n");
     // Suppress unused-import linter complaints if a tiny module
     // happens not to reference them (the runtime always does, so
     // we're fine — but blank-import the packages defensively in
@@ -312,15 +312,46 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
                 name, span
             );
         }
-        // SIR16 expression kinds — Go backend hasn't been extended.
-        Expr::FloatLit { span, .. }
-        | Expr::SeqLit { span, .. }
+        // ── SIR16: floats ──────────────────────────────────────────
+        // Emit a Go `float64` literal wrapped as a `Value`.  Integral
+        // values must spell out `3.0` (not `3`) so the runtime's type
+        // switches hit the `float64` arm rather than the int one.
+        // Non-finite values have no Go float literal, so we route them
+        // through `math.NaN()` / `math.Inf(±1)`.
+        Expr::FloatLit { value, .. } => emit_float_literal(out, *value),
+        // ── SIR16: short-circuit logical ───────────────────────────
+        // Go has no expression-position `&&`/`||` over arbitrary
+        // `Value`s, so we lift to an immediately-invoked func literal
+        // with a fresh `__l` binding: evaluate `lhs` exactly once, then
+        // decide whether to evaluate `rhs`, routing the test through SIR
+        // truthiness (`_sir_truthy`: only `false`/`nil` are falsy).
+        // `and` yields `rhs` when `lhs` is truthy else `lhs`; `or` is
+        // the mirror.  Each IIFE has its own scope, so nested `and`/`or`
+        // never collide on `__l`.
+        Expr::LogicalAnd { lhs, rhs, .. } => {
+            out.push_str("func() Value { __l := ");
+            emit_expr(out, lhs, indent);
+            out.push_str("; if _sir_truthy(__l) { return ");
+            emit_expr(out, rhs, indent);
+            out.push_str(" } else { return __l } }()");
+        }
+        Expr::LogicalOr { lhs, rhs, .. } => {
+            out.push_str("func() Value { __l := ");
+            emit_expr(out, lhs, indent);
+            out.push_str("; if _sir_truthy(__l) { return __l } else { return ");
+            emit_expr(out, rhs, indent);
+            out.push_str(" } }()");
+        }
+        // Remaining SIR16+ expression kinds — Go backend hasn't been
+        // extended to these yet (Sequences/Maps land in a later PR;
+        // `StrConcat` is SIR18 string interpolation).  Their features
+        // are undeclared, so the capability check rejects such modules
+        // before emit; reaching this arm is an internal bug.
+        Expr::SeqLit { span, .. }
         | Expr::SeqIndex { span, .. }
         | Expr::SeqLen { span, .. }
         | Expr::MapLit { span, .. }
         | Expr::MapGet { span, .. }
-        | Expr::LogicalAnd { span, .. }
-        | Expr::LogicalOr { span, .. }
         | Expr::StrConcat { span, .. } => {
             panic!("go backend reached SIR16+ expression at {} — capability check should have rejected it", span);
         }
@@ -453,6 +484,35 @@ thread_local! {
 
 fn indent_str(level: usize) -> String {
     "\t".repeat(level)
+}
+
+/// Emit a SIR float literal as a Go `Value(float64(<lit>))`.
+///
+/// Truth table for the spelling we choose:
+///
+/// | SIR value | Go expression emitted          | Why                        |
+/// |-----------|--------------------------------|----------------------------|
+/// | `3.0`     | `Value(float64(3.0))`          | `{:?}` keeps the `.0`      |
+/// | `3.25`    | `Value(float64(3.25))`         | round-trippable decimal    |
+/// | `-7.5`    | `Value(float64(-7.5))`         | sign preserved             |
+/// | `NaN`     | `Value(math.NaN())`            | no Go float literal exists |
+/// | `+∞`      | `Value(math.Inf(1))`           | ditto                      |
+/// | `-∞`      | `Value(math.Inf(-1))`          | ditto                      |
+///
+/// Rust's `{:?}` (Debug) is used for the finite literal body because it
+/// renders an integral f64 as `"3.0"` (keeping the `.0`), whereas `{}`
+/// (Display) would render `"3"` — which Go would parse as an `int`,
+/// landing in the wrong runtime type-switch arm.
+fn emit_float_literal(out: &mut String, value: f64) {
+    if value.is_finite() {
+        let _ = write!(out, "Value(float64({:?}))", value);
+    } else if value.is_nan() {
+        out.push_str("Value(math.NaN())");
+    } else if value > 0.0 {
+        out.push_str("Value(math.Inf(1))");
+    } else {
+        out.push_str("Value(math.Inf(-1))");
+    }
 }
 
 /// Sanitize a SIR identifier for Go.
@@ -626,6 +686,97 @@ mod tests {
     }
 
     #[test]
+    fn emit_float_literal_keeps_trailing_zero() {
+        // Integral floats must render with `.0` so the Go literal is a
+        // float64, never an int.
+        let mut out = String::new();
+        emit_expr(&mut out, &Expr::FloatLit { value: 3.0, span: s() }, 0);
+        assert_eq!(out, "Value(float64(3.0))");
+    }
+
+    #[test]
+    fn emit_float_literal_fractional_and_negative() {
+        let mut a = String::new();
+        let mut b = String::new();
+        emit_expr(&mut a, &Expr::FloatLit { value: 3.25, span: s() }, 0);
+        emit_expr(&mut b, &Expr::FloatLit { value: -7.5, span: s() }, 0);
+        assert_eq!(a, "Value(float64(3.25))");
+        assert_eq!(b, "Value(float64(-7.5))");
+    }
+
+    #[test]
+    fn emit_float_literal_non_finite_uses_math() {
+        let mut nan = String::new();
+        let mut inf = String::new();
+        let mut ninf = String::new();
+        emit_expr(&mut nan, &Expr::FloatLit { value: f64::NAN, span: s() }, 0);
+        emit_expr(&mut inf, &Expr::FloatLit { value: f64::INFINITY, span: s() }, 0);
+        emit_expr(&mut ninf, &Expr::FloatLit { value: f64::NEG_INFINITY, span: s() }, 0);
+        assert_eq!(nan, "Value(math.NaN())");
+        assert_eq!(inf, "Value(math.Inf(1))");
+        assert_eq!(ninf, "Value(math.Inf(-1))");
+    }
+
+    #[test]
+    fn emit_logical_and_guards_rhs_with_truthy() {
+        let mut out = String::new();
+        emit_expr(
+            &mut out,
+            &Expr::LogicalAnd {
+                lhs: Box::new(Expr::BoolLit { value: true, span: s() }),
+                rhs: Box::new(Expr::IntLit { value: 5, span: s() }),
+                span: s(),
+            },
+            0,
+        );
+        // `and` yields rhs when lhs is truthy, else the lhs value.
+        assert_eq!(
+            out,
+            "func() Value { __l := Value(true); if _sir_truthy(__l) { return Value(int64(5)) } else { return __l } }()"
+        );
+    }
+
+    #[test]
+    fn emit_logical_or_returns_lhs_when_truthy() {
+        let mut out = String::new();
+        emit_expr(
+            &mut out,
+            &Expr::LogicalOr {
+                lhs: Box::new(Expr::BoolLit { value: false, span: s() }),
+                rhs: Box::new(Expr::IntLit { value: 7, span: s() }),
+                span: s(),
+            },
+            0,
+        );
+        assert_eq!(
+            out,
+            "func() Value { __l := Value(false); if _sir_truthy(__l) { return __l } else { return Value(int64(7)) } }()"
+        );
+    }
+
+    #[test]
+    fn emit_nested_short_circuit_uses_fresh_scopes() {
+        // Nested `and` inside `or` — each IIFE gets its own `__l`, so
+        // the inner func literal shadows cleanly (no name collision).
+        let mut out = String::new();
+        emit_expr(
+            &mut out,
+            &Expr::LogicalOr {
+                lhs: Box::new(Expr::LogicalAnd {
+                    lhs: Box::new(Expr::BoolLit { value: true, span: s() }),
+                    rhs: Box::new(Expr::IntLit { value: 1, span: s() }),
+                    span: s(),
+                }),
+                rhs: Box::new(Expr::IntLit { value: 2, span: s() }),
+                span: s(),
+            },
+            0,
+        );
+        assert_eq!(out.matches("__l :=").count(), 2);
+        assert!(out.starts_with("func() Value { __l := func() Value { __l :="));
+    }
+
+    #[test]
     fn emit_simple_function() {
         let body = Block {
             stmts: vec![],
@@ -683,6 +834,7 @@ mod tests {
         assert!(out.contains("package main"));
         assert!(out.contains("import ("));
         assert!(out.contains("\"fmt\""));
+        assert!(out.contains("\"math\""));
         assert!(out.contains("\"strconv\""));
         assert!(out.contains("func _sir_user_main() Value"));
         assert!(out.contains("func main()"));

--- a/code/packages/rust/semantic-ir-to-go/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/lib.rs
@@ -43,6 +43,17 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     Feature::OptionalTypeAnnotations,
     Feature::MutualRecursion,
     Feature::Globals,
+    // ── SIR16 (v1) — added incrementally ───────────────────────────
+    // `Floats` adds a `float64` arm to the Go runtime's `Value` plus
+    // numeric promotion across the arithmetic/comparison helpers.
+    // `ShortCircuit` is pure emit (a truthy-guarded IIFE over the
+    // existing `_sir_truthy` helper) and needs no runtime change.  The
+    // remaining v1 features (MutableBindings, Loops, Sequences, Maps)
+    // are *not* yet declared, so a module using them is still rejected
+    // by the capability check before emit — keeping the `panic!`s in
+    // `emit.rs` for those nodes strictly unreachable until later PRs.
+    Feature::Floats,
+    Feature::ShortCircuit,
 ];
 
 impl Backend for GoBackend {

--- a/code/packages/rust/semantic-ir-to-go/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/runtime.rs
@@ -1,8 +1,9 @@
 //! Inlined Go runtime helpers — pasted verbatim into every artifact.
 //!
-//! Imports of `fmt` and `strconv` are required by the runtime; the
-//! emitter always emits them in the file header.  They are always
-//! used (the runtime block as a whole references both), so the Go
+//! Imports of `fmt`, `math`, and `strconv` are required by the runtime;
+//! the emitter always emits them in the file header.  They are always
+//! used (the runtime block as a whole references all three — `math` via
+//! the SIR16 float `NaN`/`Inf` checks in `_sir_format_float`), so the Go
 //! "unused import" rule is satisfied for every generated file.
 
 pub const RUNTIME: &str = r##"// ── inlined SIR runtime ────────────────────────────────────────
@@ -106,7 +107,52 @@ func _sir_as_int(v Value) int64 {
 	panic("expected int")
 }
 
+// ── numeric tower (SIR16 floats) ───────────────────────────────
+//
+// `Value` gains a `float64` arm.  Arithmetic stays on the integer
+// fast-path while EVERY operand is an integer (preserving exact int64
+// semantics, including the `*` wrapping below).  The moment ANY operand
+// is a float the whole fold promotes to float64 — matching the
+// "int op float ⇒ float" rule of Python/Ruby/JS.
+
+func _sir_is_float_val(v Value) bool {
+	_, ok := v.(float64)
+	return ok
+}
+
+func _sir_any_float(args []Value) bool {
+	for _, a := range args {
+		if _sir_is_float_val(a) {
+			return true
+		}
+	}
+	return false
+}
+
+// Coerce any number to float64 for the promoted arithmetic/comparison
+// paths.  Integers widen losslessly for magnitudes within ±2^53; beyond
+// that the all-integer fast paths keep exactness, so this widening only
+// runs once a float is genuinely in play.
+func _sir_as_float(v Value) float64 {
+	switch n := v.(type) {
+	case float64:
+		return n
+	case int64:
+		return float64(n)
+	case int:
+		return float64(n)
+	}
+	panic("expected number")
+}
+
 func _sir_plus(args []Value) Value {
+	if _sir_any_float(args) {
+		var total float64
+		for _, a := range args {
+			total += _sir_as_float(a)
+		}
+		return total
+	}
 	var total int64
 	for _, a := range args {
 		total += _sir_as_int(a)
@@ -117,6 +163,16 @@ func _sir_plus(args []Value) Value {
 func _sir_minus(args []Value) Value {
 	if len(args) == 0 {
 		return int64(0)
+	}
+	if _sir_any_float(args) {
+		if len(args) == 1 {
+			return -_sir_as_float(args[0])
+		}
+		acc := _sir_as_float(args[0])
+		for _, a := range args[1:] {
+			acc -= _sir_as_float(a)
+		}
+		return acc
 	}
 	if len(args) == 1 {
 		return -_sir_as_int(args[0])
@@ -129,6 +185,13 @@ func _sir_minus(args []Value) Value {
 }
 
 func _sir_times(args []Value) Value {
+	if _sir_any_float(args) {
+		acc := 1.0
+		for _, a := range args {
+			acc *= _sir_as_float(a)
+		}
+		return acc
+	}
 	var acc int64 = 1
 	for _, a := range args {
 		acc *= _sir_as_int(a)
@@ -139,6 +202,16 @@ func _sir_times(args []Value) Value {
 func _sir_divide(args []Value) Value {
 	if len(args) == 0 {
 		return int64(0)
+	}
+	if _sir_any_float(args) {
+		// Float division follows IEEE-754: `1.0 / 0.0` is `+Inf`
+		// rather than a panic.  Only the all-integer path keeps the
+		// historical divide-by-zero panic.
+		acc := _sir_as_float(args[0])
+		for _, a := range args[1:] {
+			acc /= _sir_as_float(a)
+		}
+		return acc
 	}
 	acc := _sir_as_int(args[0])
 	for _, a := range args[1:] {
@@ -162,15 +235,41 @@ func _sir_eq(args []Value) Value {
 			return as.Name == bs.Name
 		}
 	}
+	// Cross-representation numeric equality (`1 == 1.0`) holds,
+	// mirroring dynamic-language `==`.  Float/Float uses IEEE
+	// equality, so `NaN == NaN` is correctly `false`.  We route ANY
+	// number pair through float64 comparison; non-numbers fall back to
+	// Go's `==`.
+	if _sir_is_number_val(a) && _sir_is_number_val(b) {
+		return _sir_as_float(a) == _sir_as_float(b)
+	}
 	return a == b
 }
 
+func _sir_is_number_val(v Value) bool {
+	switch v.(type) {
+	case int64, int, float64:
+		return true
+	}
+	return false
+}
+
 func _sir_lt(args []Value) Value {
-	return _sir_as_int(args[0]) < _sir_as_int(args[1])
+	if ai, aok := args[0].(int64); aok {
+		if bi, bok := args[1].(int64); bok {
+			return ai < bi
+		}
+	}
+	return _sir_as_float(args[0]) < _sir_as_float(args[1])
 }
 
 func _sir_gt(args []Value) Value {
-	return _sir_as_int(args[0]) > _sir_as_int(args[1])
+	if ai, aok := args[0].(int64); aok {
+		if bi, bok := args[1].(int64); bok {
+			return ai > bi
+		}
+	}
+	return _sir_as_float(args[0]) > _sir_as_float(args[1])
 }
 
 func _sir_cons(args []Value) Value {
@@ -199,8 +298,10 @@ func _sir_is_pair(args []Value) Value {
 }
 
 func _sir_is_number(args []Value) Value {
+	// `number?` names the whole numeric tower — true for integers AND
+	// floats, not a single representation.
 	switch args[0].(type) {
-	case int64, int:
+	case int64, int, float64:
 		return true
 	}
 	return false
@@ -232,6 +333,9 @@ func _sir_format(v Value) string {
 	if n, ok := v.(int); ok {
 		return strconv.FormatInt(int64(n), 10)
 	}
+	if x, ok := v.(float64); ok {
+		return _sir_format_float(x)
+	}
 	if s, ok := v.(string); ok {
 		return s
 	}
@@ -245,6 +349,43 @@ func _sir_format(v Value) string {
 		return "<closure>"
 	}
 	return fmt.Sprintf("%v", v)
+}
+
+// Render a float so integral values keep a trailing `.0` (`3.0`, not
+// `3`) — making the printed form unambiguously a float, matching how
+// Python/Ruby and the Rust backend's `{:?}` render `3.0`.  Non-finite
+// values print as `NaN` / `inf` / `-inf` (mirroring the Rust backend).
+//
+//   | value | output |
+//   |-------|--------|
+//   | 3.0   | "3.0"  |  ← FormatFloat gives "3"; we append ".0"
+//   | 3.25  | "3.25" |  ← already has a "."
+//   | -7.5  | "-7.5" |
+//   | 1e20  | "1e+20"|  ← exponent form already unambiguous
+//   | NaN   | "NaN"  |
+//   | +Inf  | "inf"  |
+//   | -Inf  | "-inf" |
+func _sir_format_float(x float64) string {
+	if math.IsNaN(x) {
+		return "NaN"
+	}
+	if math.IsInf(x, 1) {
+		return "inf"
+	}
+	if math.IsInf(x, -1) {
+		return "-inf"
+	}
+	s := strconv.FormatFloat(x, 'g', -1, 64)
+	// If the shortest representation has no decimal point and no
+	// exponent, it looks like an integer — append ".0" to keep the
+	// float identity visible.
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '.' || c == 'e' || c == 'E' {
+			return s
+		}
+	}
+	return s + ".0"
 }
 
 func _sir_format_pair(p *Pair) string {
@@ -325,12 +466,25 @@ mod tests {
 
     #[test]
     fn runtime_uses_fmt_and_strconv() {
-        // The emitter always emits `import ("fmt"; "strconv")` so
-        // both must be referenced in the runtime to satisfy Go's
-        // unused-import rule.
+        // The emitter always emits `import ("fmt"; "math"; "strconv")`
+        // so all three must be referenced in the runtime to satisfy
+        // Go's unused-import rule.
         assert!(RUNTIME.contains("fmt.Println"));
         assert!(RUNTIME.contains("fmt.Sprintf"));
         assert!(RUNTIME.contains("strconv.FormatInt"));
+        assert!(RUNTIME.contains("strconv.FormatFloat"));
+        assert!(RUNTIME.contains("math.IsNaN"));
+        assert!(RUNTIME.contains("math.IsInf"));
+    }
+
+    #[test]
+    fn runtime_declares_float_helpers() {
+        // SIR16 floats: the value model accepts a `float64` arm, and
+        // the numeric helpers gain float coercion + a display path.
+        assert!(RUNTIME.contains("_sir_as_float"));
+        assert!(RUNTIME.contains("_sir_any_float"));
+        assert!(RUNTIME.contains("_sir_format_float"));
+        assert!(RUNTIME.contains("_sir_is_number_val"));
     }
 
     #[test]

--- a/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_floats.rs
+++ b/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_floats.rs
@@ -1,0 +1,170 @@
+//! End-to-end proof for SIR16 **Floats** + **ShortCircuit** in the Go
+//! backend.
+//!
+//! Unit tests assert the *shape* of the emitted source; this test goes
+//! the whole way: it hand-builds a SIR module exercising both features,
+//! emits Go, writes it to a temp `.go` file, runs it with `go run`, and
+//! checks the program's stdout.  That closes the loop the unit tests
+//! cannot — it proves the emitted runtime actually *compiles and
+//! behaves* under a real Go toolchain.
+//!
+//! The test gates on `go` being available (`go version`).  If the Go
+//! toolchain is absent the test logs a skip rather than failing — we
+//! never want a missing tool to redden a build for reasons unrelated to
+//! the change (mirrors how the Rust backend's equivalent test gates on
+//! `rustc`).
+
+use std::process::Command;
+
+use semantic_ir::{
+    Block, Effect, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, Span,
+};
+use semantic_ir_to_go::compile;
+
+fn s() -> Span {
+    Span::synthetic()
+}
+
+fn flit(v: f64) -> Expr {
+    Expr::FloatLit { value: v, span: s() }
+}
+fn ilit(v: i64) -> Expr {
+    Expr::IntLit { value: v, span: s() }
+}
+fn blit(v: bool) -> Expr {
+    Expr::BoolLit { value: v, span: s() }
+}
+
+/// `(name arg0 arg1 ...)` builtin call, pure.
+fn call(name: &str, args: Vec<Expr>) -> Expr {
+    Expr::BuiltinCall {
+        name: name.into(),
+        args,
+        effects: EffectSet::PURE,
+        span: s(),
+    }
+}
+
+/// `print(expr)` as an effectful statement.
+fn print_stmt(expr: Expr) -> semantic_ir::Stmt {
+    semantic_ir::Stmt::ExprStmt {
+        expr: Expr::BuiltinCall {
+            name: "print".into(),
+            args: vec![expr],
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            span: s(),
+        },
+        span: s(),
+    }
+}
+
+/// Build a module whose `main` prints, in order, the results of a small
+/// battery of float + short-circuit expressions.
+fn demo_module() -> Module {
+    let stmts = vec![
+        // 1.5 + 2.5  ⇒  float(4.0)             → "4.0"
+        print_stmt(call("+", vec![flit(1.5), flit(2.5)])),
+        // 5.0 - 1    ⇒  int promoted to float  → "4.0"
+        print_stmt(call("-", vec![flit(5.0), ilit(1)])),
+        // true and 5 ⇒  rhs (lhs truthy)       → "5"
+        print_stmt(Expr::LogicalAnd {
+            lhs: Box::new(blit(true)),
+            rhs: Box::new(ilit(5)),
+            span: s(),
+        }),
+        // false or 7 ⇒  rhs (lhs falsy)        → "7"
+        print_stmt(Expr::LogicalOr {
+            lhs: Box::new(blit(false)),
+            rhs: Box::new(ilit(7)),
+            span: s(),
+        }),
+        // false and 9 ⇒ lhs (short-circuits)   → "#f"
+        print_stmt(Expr::LogicalAnd {
+            lhs: Box::new(blit(false)),
+            rhs: Box::new(ilit(9)),
+            span: s(),
+        }),
+        // 1 = 1.0    ⇒  cross-type eq is true  → "#t"
+        print_stmt(call("=", vec![ilit(1), flit(1.0)])),
+    ];
+
+    Module {
+        name: "floats_demo".into(),
+        manifest: FeatureManifest::from_features(&[Feature::Floats, Feature::ShortCircuit]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts,
+                value: Expr::NilLit { span: s() },
+                span: s(),
+            },
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            metadata: Metadata::new(),
+            span: s(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("test")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+fn go_available() -> bool {
+    Command::new("go")
+        .arg("version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+#[test]
+fn floats_and_short_circuit_compile_and_run() {
+    if !go_available() {
+        eprintln!("skipping: go not on PATH");
+        return;
+    }
+
+    // 1. Emit.
+    let artifact = compile(&demo_module()).expect("module should compile to Go source");
+
+    // 2. Write the source to a unique temp file.  `go run` requires a
+    //    `.go` extension.
+    let dir = std::env::temp_dir();
+    let nonce = std::process::id();
+    let src_path = dir.join(format!("sir_go_floats_{nonce}.go"));
+    std::fs::write(&src_path, &artifact.source).expect("write temp source");
+
+    // 3. Compile + run with `go run` (arg vector — no shell).
+    let run_out = Command::new("go")
+        .arg("run")
+        .arg(&src_path)
+        .output()
+        .expect("invoke go run");
+
+    if !run_out.status.success() {
+        let stderr = String::from_utf8_lossy(&run_out.stderr);
+        let _ = std::fs::remove_file(&src_path);
+        panic!(
+            "emitted Go failed to compile/run:\n--- stderr ---\n{stderr}\n--- source ---\n{}",
+            artifact.source,
+        );
+    }
+
+    // 4. Assert the program's observable behaviour.
+    let stdout = String::from_utf8_lossy(&run_out.stdout);
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert_eq!(
+        lines,
+        vec!["4.0", "4.0", "5", "7", "#f", "#t"],
+        "unexpected program output; full stdout:\n{stdout}"
+    );
+
+    // 5. Best-effort cleanup (ignore errors — temp dir is ephemeral).
+    let _ = std::fs::remove_file(&src_path);
+}


### PR DESCRIPTION
Brings SIR-v1 parity to the **Go** backend (mirrors the merged Rust A1). The Go backend previously declared none of the 6 SIR16 features; this lands the first two.

- Declares `Feature::Floats` + `Feature::ShortCircuit`.
- Emitted Go runtime gains a Float `Value` case; arithmetic promotes int→float when any operand is a float; `number?` covers floats; `=` is cross-type (`1 == 1.0`); `</>` numeric. Integral floats display with a trailing `.0` (matches the Rust backend); non-finite → `math.NaN()/Inf`.
- `FloatLit` emits a Go float64 literal; `LogicalAnd`/`LogicalOr` emit a short-circuiting func literal routing truthiness through the runtime.

**Tests:** 27 unit + a `go run` compile-and-run proof (executes emitted Go, asserts `4.0/4.0/5/7/#f/#t`); clippy clean; security review passed. Seq/Maps/MutableBindings/Loops remain deferred (later Go PRs). Isolated to `semantic-ir-to-go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)