### PR TITLE
feat(unicode-math): PFE01 frontend #3 — a Unicode plain-math reader

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -228,6 +228,7 @@ members = [
     "math-frontend",
     "latex",
     "asciimath",
+    "unicode-math",
     "adjudication-ir",
     "llm-cache",
     "llm-gateway",

--- a/code/packages/rust/unicode-math/BUILD
+++ b/code/packages/rust/unicode-math/BUILD
@@ -1,0 +1,1 @@
+cargo test -p unicode-math -- --nocapture

--- a/code/packages/rust/unicode-math/BUILD_windows
+++ b/code/packages/rust/unicode-math/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p unicode-math -- --nocapture

--- a/code/packages/rust/unicode-math/CHANGELOG.md
+++ b/code/packages/rust/unicode-math/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog — unicode-math
+
+All notable changes to the unicode-math pluggable frontend.
+
+## [0.1.0] — 2026-06-30
+
+### Added — PFE01 frontend #3: a Unicode plain-math reader
+
+- New `unicode-math` crate: the **third** pluggable `MathFrontend` (after `latex` and
+  `asciimath`). It reads the math people and models actually type with real glyphs and produces
+  the **same** neutral `MathExpr`, so every existing consumer gains the notation with **zero**
+  change — PFE01 pluggability now demonstrated across three genuinely different notations.
+- **Tokenizer** (`token.rs`) — a total, panic-free **codepoint** scanner recording byte spans:
+  numbers; single-letter variables; Greek / constant glyphs (`π`→`pi`, `Σ`→`Sigma`, `∞`→`infinity`,
+  canonicalized to match the AsciiMath table); Unicode superscript runs (`x²`, `x⁻¹`, `x¹⁰`) and
+  subscript runs (`a₁`); vulgar-fraction glyphs (`½ ⅓ ¼ ⅔ …`); operators `+ − × ⋅ ÷ ± ∓` and roots
+  `√ ∛ ∜`; relations `= ≠ < ≤ > ≥ ≈ ≡`; brackets. An out-of-scope glyph (e.g. `∑`) is a clean
+  spanned error, never a panic.
+- **Parser** (`parser.rs`) — precedence-climbing recursive descent (relation < add < mul < frac <
+  unary < script < atom), mirroring the AsciiMath frontend: implicit multiplication by
+  juxtaposition (`2x`, `πα`), `MAX_DEPTH` nesting guard, and loop-built left-assoc chains so
+  adversarial input fails cleanly instead of overflowing the stack.
+- `capabilities()` advertises exactly the PR-1 surface — `fractions` (both `a/b` and vulgar
+  glyphs), `roots`, `powers`, `relations`, `implicit_mul`, `plusminus` — and declares
+  `functions`/`big_operators`/`matrices`/`text` **off** (PR-2), enforced by the shared
+  `check_frontend` conformance harness.
+- 23 unit + 1 doc test pass (incl. the conformance corpus); clippy `-D warnings` clean;
+  `#![forbid(unsafe_code)]`. Spec: `PFE01-pluggable-parser-frontends.md`.
+- **Out of scope (PR-2):** big operators (`∑ ∏ ∫`), named functions, matrices, embedded `\text`.

--- a/code/packages/rust/unicode-math/Cargo.toml
+++ b/code/packages/rust/unicode-math/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "unicode-math"
+version = "0.1.0"
+edition = "2021"
+description = "A Unicode plain-math parser that implements the math-frontend MathFrontend trait: turns the math people and models actually type (x² + y² = r², √x, ½, π·α, a ≤ b) into the neutral MathExpr AST. The third pluggable frontend after LaTeX and AsciiMath (see PFE01). Total, panic-free, spanned errors."
+license = "MIT"
+
+[dependencies]
+# The neutral framework: MathExpr + the MathFrontend trait + the conformance harness.
+# This is a frontend, so the dependency is mandatory.
+math-frontend = { path = "../math-frontend" }

--- a/code/packages/rust/unicode-math/README.md
+++ b/code/packages/rust/unicode-math/README.md
@@ -1,0 +1,57 @@
+# unicode-math — a Unicode plain-math frontend for `math-frontend`
+
+The **third** pluggable parser frontend (after [`latex`](../latex) and [`asciimath`](../asciimath)).
+It reads the math people and language models actually *type* with real glyphs —
+`x² + y² = r²`, `√x`, `½`, `π·α`, `a ≤ b`, `2 ∓ 1` — and produces the **same** neutral
+[`MathExpr`](../math-frontend) the other two frontends do. A consumer that already lowers
+`MathExpr` gains this notation for **free**: adding it required **zero** change to any consumer.
+That is the whole promise of [PFE01](../../../specs/PFE01-pluggable-parser-frontends.md), now
+demonstrated across three genuinely different notations — a macro language (LaTeX), a terse
+ASCII syntax (AsciiMath), and raw Unicode.
+
+## What it parses (PR-1)
+
+| Unicode math | → neutral `MathExpr` |
+|--------------|----------------------|
+| `42`, `3.14`, `6.022e23` | `Number` (exact — never `f64`) |
+| `x`, `π`, `Σ`, `∞` | `Symbol` (`π`→`pi`, `Σ`→`Sigma`, `∞`→`infinity`) |
+| `xy`, `2x`, `πα` | `Bin(Mul)` (juxtaposition ⇒ implicit `·`) |
+| `x²`, `x⁻¹`, `x¹⁰` | `Bin(Pow)` (Unicode superscripts) |
+| `a₁`, `a₁²` | `Subscript` / `Pow(Subscript)` |
+| `1/2`, `½`, `⅔` | `Frac` (built-up **and** vulgar-fraction glyphs) |
+| `√x`, `∛x`, `∜x` | `Root { degree, radicand }` |
+| `a + b`, `a − b`, `a × b`, `a ⋅ b`, `a ÷ b` | `Bin(Add/Sub/Mul/Div)` |
+| `a ± b`, `a ∓ b` | `Bin(PlusMinus/MinusPlus)` |
+| `a = b`, `a ≤ b`, `a ≠ b`, `a ≥ b`, `a ≈ b`, `a ≡ b` | `Rel` |
+| `( … )`, `[ … ]`, `{ … }` | grouping (delimiter style dropped; meaning kept) |
+
+`−` (U+2212 minus) and the ASCII `-` are both accepted, as are `×`/`⋅`/`*` for multiplication.
+Greek and constant glyphs canonicalize to the **same** `Symbol` names the AsciiMath frontend
+uses (`π` and `pi` both → `"pi"`), so the two notations agree on one neutral string.
+
+## Example
+
+```rust
+use unicode_math::UnicodeMath;
+use math_frontend::{MathFrontend, MathExpr, BinOp, RelOp};
+
+let e = UnicodeMath.parse("x² + y² = r²").unwrap();
+assert!(matches!(e, MathExpr::Rel(RelOp::Eq, _, _)));
+// `x²` means the same as LaTeX `x^{2}` and AsciiMath `x^2` — all MathExpr::Bin(Pow, …).
+assert_eq!(UnicodeMath.parse("½").unwrap(), UnicodeMath.parse("1/2").unwrap());
+```
+
+## Contract
+
+It is **total and panic-free** — every input returns `Ok(MathExpr)` or a spanned
+`FrontendError` (byte span into the original Unicode source), **pure** (no I/O), and **honest**:
+`capabilities()` advertises exactly what it emits, enforced by the shared `check_frontend`
+harness. Like every frontend it cannot be registered by `math-frontend` itself (that would be a
+dependency cycle); a consumer registers it.
+
+## Scope
+
+PR-1 covers the surface in the table above. **Out of scope** (a clean spanned error, never a
+panic — tracked for PR-2): big operators (`∑ ∏ ∫`), named functions (`sin`, `log`), matrices,
+and embedded `\text`. As in AsciiMath there are no multi-letter variables: a letter run like
+`xy` is the product `x·y` (write distinct symbols, or use Greek/constant glyphs).

--- a/code/packages/rust/unicode-math/required_capabilities.json
+++ b/code/packages/rust/unicode-math/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/unicode-math",
+  "capabilities": [],
+  "justification": "Pure computation: turns a Unicode plain-math string into tokens and the neutral MathExpr AST. No filesystem, network, process, or environment access."
+}

--- a/code/packages/rust/unicode-math/src/lib.rs
+++ b/code/packages/rust/unicode-math/src/lib.rs
@@ -1,0 +1,245 @@
+//! # unicode-math — a Unicode plain-math frontend for [`math_frontend`]
+//!
+//! The **third** pluggable parser frontend (after `latex` and `asciimath`). It reads the math
+//! people and language models actually *type* with real glyphs — `x² + y² = r²`, `√x`, `½`,
+//! `π·α`, `a ≤ b`, `2 ∓ 1` — and produces the *same* neutral [`MathExpr`] the other two do. A
+//! consumer that already lowers `MathExpr` gets this notation **for free**; adding it required
+//! **zero** change to any consumer. That is the whole promise of
+//! [PFE01](../../../specs/PFE01-pluggable-parser-frontends.md), now demonstrated across three
+//! genuinely different notations (a macro language, a terse ASCII syntax, and raw Unicode).
+//!
+//! ## Contract
+//! [`UnicodeMath`] implements [`MathFrontend`]: **total and panic-free** (every input is
+//! `Ok(MathExpr)` or a spanned [`FrontendError`]), **pure**, and **honest** (its
+//! [`capabilities`](MathFrontend::capabilities) match what it emits — enforced by the shared
+//! `check_frontend` harness).
+//!
+//! ## What it covers (PR-1)
+//! Numbers (exact); single-letter variables and Greek/constant glyphs (`π`→`pi`, `Σ`→`Sigma`,
+//! `∞`→`infinity`); `+ − × ⋅ ÷ ±  ∓` and juxtaposition (implicit `·`); built-up `a/b` and the
+//! vulgar fractions `½ ⅓ ¼ …`; the roots `√`, `∛`, `∜`; Unicode super/subscripts (`x²`, `a₁`,
+//! `x⁻¹`); and the relations `= ≠ < ≤ > ≥ ≈ ≡`. Out of scope for PR-1 (a clean spanned error,
+//! never a panic), tracked for PR-2: big operators (`∑ ∏ ∫`), named functions, matrices, `\text`.
+//!
+//! ```
+//! use unicode_math::UnicodeMath;
+//! use math_frontend::{MathFrontend, MathExpr, BinOp};
+//!
+//! let e = UnicodeMath.parse("x² + 1").unwrap();
+//! assert!(matches!(e, MathExpr::Bin(BinOp::Add, _, _)));
+//! // `x²` means the same as LaTeX `x^{2}` and AsciiMath `x^2` — all MathExpr::Bin(Pow, …).
+//! ```
+
+#![forbid(unsafe_code)]
+
+mod parser;
+mod token;
+
+pub use parser::parse;
+pub use token::{tokenize, Span, Token, TokenKind};
+
+// Re-export the neutral types so a consumer can `use unicode_math::MathExpr` without also
+// naming the framework crate directly.
+pub use math_frontend::{
+    BigOp, BinOp, Capabilities, Func, FrontendError, MathExpr, MathFrontend, Number, RelOp,
+    UnaryOp,
+};
+
+/// The unicode-math frontend. A zero-sized handle implementing [`MathFrontend`].
+#[derive(Debug, Default, Clone, Copy)]
+pub struct UnicodeMath;
+
+impl MathFrontend for UnicodeMath {
+    fn name(&self) -> &str {
+        "unicode-math"
+    }
+
+    fn parse(&self, src: &str) -> Result<MathExpr, FrontendError> {
+        parser::parse(src)
+    }
+
+    fn capabilities(&self) -> Capabilities {
+        // PR-1 surface. `fractions` covers both `a/b` and the vulgar-fraction glyphs; `powers`
+        // covers Unicode superscripts; `plusminus` covers `±`/`∓`. `functions`, `big_operators`,
+        // `matrices`, and `text` are PR-2 — declared OFF so the conformance harness holds us
+        // honest. (Subscripts need no flag: `Subscript` is not a gated capability.)
+        Capabilities::none()
+            .with_fractions()
+            .with_roots()
+            .with_powers()
+            .with_relations()
+            .with_implicit_mul()
+            .with_plusminus()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use math_frontend::check_frontend;
+
+    fn p(s: &str) -> MathExpr {
+        UnicodeMath.parse(s).unwrap_or_else(|e| panic!("parse {s:?} failed: {e}"))
+    }
+    fn num(n: i64) -> MathExpr {
+        MathExpr::Number(Number::from_i64(n))
+    }
+    fn sym(s: &str) -> MathExpr {
+        MathExpr::Symbol(s.to_string())
+    }
+    fn b(op: BinOp, l: MathExpr, r: MathExpr) -> MathExpr {
+        MathExpr::Bin(op, Box::new(l), Box::new(r))
+    }
+
+    // ---- atoms -----------------------------------------------------------------
+    #[test]
+    fn numbers_and_symbols() {
+        assert_eq!(p("42"), num(42));
+        assert_eq!(p("x"), sym("x"));
+        assert_eq!(p("xy"), b(BinOp::Mul, sym("x"), sym("y"))); // juxtaposition
+        assert_eq!(p("π"), sym("pi")); // a Greek glyph is a single symbol
+        assert_eq!(p("∞"), sym("infinity"));
+    }
+
+    #[test]
+    fn greek_composes_in_expressions() {
+        // π·α as written with no operator is the product π·α.
+        assert_eq!(p("πα"), b(BinOp::Mul, sym("pi"), sym("alpha")));
+        assert_eq!(p("α + Ω"), b(BinOp::Add, sym("alpha"), sym("Omega")));
+    }
+
+    // ---- powers / scripts / fractions / roots ----------------------------------
+    #[test]
+    fn unicode_superscript_is_a_power() {
+        assert_eq!(p("x²"), b(BinOp::Pow, sym("x"), num(2)));
+        assert_eq!(p("x⁻¹"), b(BinOp::Pow, sym("x"), num(-1)));
+        // multi-digit superscript: x¹⁰ ⇒ x^10
+        assert_eq!(p("x¹⁰"), b(BinOp::Pow, sym("x"), num(10)));
+    }
+
+    #[test]
+    fn unicode_subscript_is_a_subscript() {
+        assert_eq!(p("a₁"), MathExpr::Subscript(Box::new(sym("a")), Box::new(num(1))));
+        // subscript then superscript: a₁² ⇒ (a₁)²
+        assert_eq!(
+            p("a₁²"),
+            b(BinOp::Pow, MathExpr::Subscript(Box::new(sym("a")), Box::new(num(1))), num(2))
+        );
+    }
+
+    #[test]
+    fn built_up_and_vulgar_fractions() {
+        assert_eq!(p("1/2"), MathExpr::Frac(Box::new(num(1)), Box::new(num(2))));
+        assert_eq!(p("½"), MathExpr::Frac(Box::new(num(1)), Box::new(num(2))));
+        // ½ and 1/2 lower identically — the whole point of the neutral AST.
+        assert_eq!(p("½"), p("1/2"));
+        assert_eq!(p("⅔"), MathExpr::Frac(Box::new(num(2)), Box::new(num(3))));
+    }
+
+    #[test]
+    fn roots() {
+        assert_eq!(p("√x"), MathExpr::Root { degree: None, radicand: Box::new(sym("x")) });
+        assert_eq!(p("√x"), p("√(x)")); // grouping normalizes away
+        assert_eq!(
+            p("∛x"),
+            MathExpr::Root { degree: Some(Box::new(num(3))), radicand: Box::new(sym("x")) }
+        );
+    }
+
+    // ---- operators / precedence / relations ------------------------------------
+    #[test]
+    fn unicode_multiplication_and_division() {
+        assert_eq!(p("a × b"), b(BinOp::Mul, sym("a"), sym("b")));
+        assert_eq!(p("a ⋅ b"), b(BinOp::Mul, sym("a"), sym("b")));
+        assert_eq!(p("a ÷ b"), b(BinOp::Div, sym("a"), sym("b")));
+        assert_eq!(p("2x"), b(BinOp::Mul, num(2), sym("x")));
+    }
+
+    #[test]
+    fn plus_minus_operators() {
+        assert_eq!(p("a ± b"), b(BinOp::PlusMinus, sym("a"), sym("b")));
+        assert_eq!(p("a ∓ b"), b(BinOp::MinusPlus, sym("a"), sym("b")));
+        // unary minus uses U+2212 too: −x ⇒ Unary(Neg, x)
+        assert_eq!(p("−x"), MathExpr::Unary(UnaryOp::Neg, Box::new(sym("x"))));
+    }
+
+    #[test]
+    fn relations() {
+        assert_eq!(p("a ≤ b"), MathExpr::Rel(RelOp::Le, Box::new(sym("a")), Box::new(sym("b"))));
+        assert_eq!(p("a ≠ b"), MathExpr::Rel(RelOp::Ne, Box::new(sym("a")), Box::new(sym("b"))));
+        assert_eq!(p("a ≥ b"), MathExpr::Rel(RelOp::Ge, Box::new(sym("a")), Box::new(sym("b"))));
+    }
+
+    #[test]
+    fn a_realistic_expression() {
+        // x² + y² = r²
+        let lhs = b(BinOp::Add, b(BinOp::Pow, sym("x"), num(2)), b(BinOp::Pow, sym("y"), num(2)));
+        let rhs = b(BinOp::Pow, sym("r"), num(2));
+        assert_eq!(p("x² + y² = r²"), MathExpr::Rel(RelOp::Eq, Box::new(lhs), Box::new(rhs)));
+    }
+
+    #[test]
+    fn fraction_binds_tighter_than_mul() {
+        // 1/2 x ⇒ (1/2)·x
+        assert_eq!(
+            p("1/2 x"),
+            b(BinOp::Mul, MathExpr::Frac(Box::new(num(1)), Box::new(num(2))), sym("x"))
+        );
+    }
+
+    // ---- totality / errors -----------------------------------------------------
+    #[test]
+    fn errors_are_spanned_never_panic() {
+        for bad in ["", "1 +", "(x", ")", "x²₁∑", "∑"] {
+            let e = UnicodeMath.parse(bad).expect_err(&format!("{bad:?} should error"));
+            assert_eq!(e.frontend, "unicode-math");
+            assert!(e.span.0 <= e.span.1 && e.span.1 <= bad.len(), "bad span on {bad:?}: {:?}", e.span);
+        }
+    }
+
+    #[test]
+    fn deep_nesting_errors_not_overflows() {
+        // 5000 open-parens must return a spanned error (MAX_DEPTH), not overflow the stack.
+        let deep = "(".repeat(5000);
+        assert!(UnicodeMath.parse(&deep).is_err());
+    }
+
+    // ---- name / capabilities / conformance -------------------------------------
+    #[test]
+    fn name_and_capabilities_are_honest() {
+        assert_eq!(UnicodeMath.name(), "unicode-math");
+        let c = UnicodeMath.capabilities();
+        assert!(c.fractions && c.roots && c.powers && c.relations && c.implicit_mul && c.plusminus);
+        // PR-1 does NOT do these yet — declared off so the harness holds us honest.
+        assert!(!c.functions && !c.big_operators && !c.matrices && !c.text);
+        assert!(!c.binomials && !c.accents && !c.oversets);
+    }
+
+    #[test]
+    fn conforms_to_the_shared_harness() {
+        let report = check_frontend(
+            &UnicodeMath,
+            &[
+                "x² + y² = r²",
+                "1/2",
+                "½",
+                "√x",
+                "∛27",
+                "2x + 3",
+                "a₁²",
+                "π",
+                "α + Ω",
+                "a ≤ b",
+                "a ± b",
+                "a ∓ b",
+                "(a + b)/(c − d)",
+                "x⁻¹",
+                "1 +",   // error: trailing operator
+                "(x",    // error: missing close
+                "∑",     // error: out-of-scope glyph (PR-2)
+                "",      // error: empty
+            ],
+        );
+        assert!(report.passed(), "conformance issues: {:?}", report.issues);
+    }
+}

--- a/code/packages/rust/unicode-math/src/parser.rs
+++ b/code/packages/rust/unicode-math/src/parser.rs
@@ -1,0 +1,266 @@
+//! The unicode-math parser — tokens → the neutral [`MathExpr`].
+//!
+//! A precedence-climbing recursive-descent parser, the same shape as the AsciiMath one.
+//! Precedence, lowest binds loosest:
+//!
+//! ```text
+//!   relation   a = b   a ≤ b   a ≠ b                 (left-assoc)
+//!   add/sub    a + b   a − b   a ± b   a ∓ b
+//!   mul        a × b   a ⋅ b   a ÷ b   and JUXTAPOSITION (2x, xy ⇒ ·)
+//!   frac       a / b                                 (built-up fraction)
+//!   unary      −a   +a                               (a sign run, folded with a loop)
+//!   script     a²   a₁   a₁²                         (super/subscript on one atom)
+//!   atom       number | symbol | ½ | √x | ∛x | (group)
+//! ```
+//!
+//! ## Two safety properties (both deliberate, mirroring the AsciiMath frontend)
+//! * **Bounded recursion** — only *nesting* (groups, roots, scripts) recurses, and every such
+//!   descent charges [`MAX_DEPTH`], so adversarial nesting returns a spanned error rather than
+//!   overflowing the stack.
+//! * **Loops for chains** — left-associative chains (`a+a+…`, juxtaposition) and sign runs
+//!   (`−−−a`) are built with loops, not recursion, so an arbitrarily long chain costs O(1)
+//!   parser stack.
+
+use crate::token::{tokenize, Token, TokenKind};
+use math_frontend::{BinOp, FrontendError, MathExpr, Number, RelOp, UnaryOp};
+
+/// Maximum *nesting* depth before refusing with a spanned error (never overflow). Kept well
+/// below what would exhaust a test-thread stack so the guard fires before the stack does.
+const MAX_DEPTH: usize = 64;
+
+/// Parse a unicode-math source string into the neutral [`MathExpr`]. Total and panic-free.
+pub fn parse(src: &str) -> Result<MathExpr, FrontendError> {
+    let toks = tokenize(src)?;
+    let mut p = Parser { toks: &toks, pos: 0, depth: 0 };
+    let e = p.parse_relation()?;
+    match p.peek() {
+        TokenKind::Eof => Ok(e),
+        _ => Err(p.error_here("unexpected trailing input")),
+    }
+}
+
+struct Parser<'a> {
+    toks: &'a [Token],
+    pos: usize,
+    depth: usize,
+}
+
+impl Parser<'_> {
+    fn peek(&self) -> &TokenKind {
+        self.toks.get(self.pos).map(|t| &t.kind).unwrap_or(&TokenKind::Eof)
+    }
+
+    fn span_here(&self) -> (usize, usize) {
+        self.toks.get(self.pos).or_else(|| self.toks.last()).map(|t| t.span).unwrap_or((0, 0))
+    }
+
+    fn advance(&mut self) {
+        if self.pos < self.toks.len() {
+            self.pos += 1;
+        }
+    }
+
+    fn error_here(&self, msg: impl Into<String>) -> FrontendError {
+        FrontendError::new("unicode-math", msg, self.span_here())
+    }
+
+    /// Enter one level of *nesting* (the recursion points). Returns an error at the cap.
+    fn enter(&mut self) -> Result<(), FrontendError> {
+        self.depth += 1;
+        if self.depth > MAX_DEPTH {
+            Err(self.error_here("expression nested too deeply"))
+        } else {
+            Ok(())
+        }
+    }
+    fn exit(&mut self) {
+        self.depth -= 1;
+    }
+
+    // ---- relation < add < mul < frac < unary < script < atom --------------------
+
+    fn parse_relation(&mut self) -> Result<MathExpr, FrontendError> {
+        let mut lhs = self.parse_add()?;
+        while let Some(op) = rel_of(self.peek()) {
+            self.advance();
+            let rhs = self.parse_add()?;
+            lhs = MathExpr::Rel(op, Box::new(lhs), Box::new(rhs));
+        }
+        Ok(lhs)
+    }
+
+    fn parse_add(&mut self) -> Result<MathExpr, FrontendError> {
+        let mut lhs = self.parse_mul()?;
+        loop {
+            let op = match self.peek() {
+                TokenKind::Plus => BinOp::Add,
+                TokenKind::Minus => BinOp::Sub,
+                TokenKind::PlusMinus => BinOp::PlusMinus,
+                TokenKind::MinusPlus => BinOp::MinusPlus,
+                _ => break,
+            };
+            self.advance();
+            let rhs = self.parse_mul()?;
+            lhs = MathExpr::Bin(op, Box::new(lhs), Box::new(rhs));
+        }
+        Ok(lhs)
+    }
+
+    fn parse_mul(&mut self) -> Result<MathExpr, FrontendError> {
+        let mut lhs = self.parse_frac()?;
+        loop {
+            // explicit multiplicative operators
+            let op = match self.peek() {
+                TokenKind::Times => Some(BinOp::Mul),
+                TokenKind::Div => Some(BinOp::Div),
+                _ => None,
+            };
+            if let Some(op) = op {
+                self.advance();
+                let rhs = self.parse_frac()?;
+                lhs = MathExpr::Bin(op, Box::new(lhs), Box::new(rhs));
+                continue;
+            }
+            // implicit multiplication: a new simple expression begins with no operator.
+            if self.starts_simple() {
+                let rhs = self.parse_frac()?;
+                lhs = MathExpr::Bin(BinOp::Mul, Box::new(lhs), Box::new(rhs));
+                continue;
+            }
+            break;
+        }
+        Ok(lhs)
+    }
+
+    fn parse_frac(&mut self) -> Result<MathExpr, FrontendError> {
+        let mut lhs = self.parse_unary()?;
+        while matches!(self.peek(), TokenKind::Slash) {
+            self.advance();
+            let rhs = self.parse_unary()?;
+            lhs = MathExpr::Frac(Box::new(lhs), Box::new(rhs));
+        }
+        Ok(lhs)
+    }
+
+    fn parse_unary(&mut self) -> Result<MathExpr, FrontendError> {
+        // collect a sign run with a loop (no recursion → `−−−x` can't overflow)
+        let mut signs: Vec<UnaryOp> = Vec::new();
+        loop {
+            match self.peek() {
+                TokenKind::Minus => { signs.push(UnaryOp::Neg); self.advance(); }
+                TokenKind::Plus => { signs.push(UnaryOp::Pos); self.advance(); }
+                _ => break,
+            }
+        }
+        let mut e = self.parse_script()?;
+        for op in signs.into_iter().rev() {
+            e = MathExpr::Unary(op, Box::new(e));
+        }
+        Ok(e)
+    }
+
+    fn parse_script(&mut self) -> Result<MathExpr, FrontendError> {
+        let mut base = self.parse_atom()?;
+        // subscript then superscript (`a₁²` ⇒ (a₁)²), each at most once — the natural reading.
+        if let TokenKind::Sub(s) = self.peek().clone() {
+            self.advance();
+            base = MathExpr::Subscript(Box::new(base), Box::new(self.numeral(&s)?));
+        }
+        if let TokenKind::Super(s) = self.peek().clone() {
+            self.advance();
+            base = MathExpr::Bin(BinOp::Pow, Box::new(base), Box::new(self.numeral(&s)?));
+        }
+        Ok(base)
+    }
+
+    /// Build a [`MathExpr::Number`] from a normalised super/subscript numeral string, or a
+    /// spanned error if it is not a well-formed numeral (e.g. a lone `⁻`).
+    fn numeral(&self, s: &str) -> Result<MathExpr, FrontendError> {
+        Number::parse(s)
+            .map(MathExpr::Number)
+            .ok_or_else(|| self.error_here(format!("invalid script numeral {s:?}")))
+    }
+
+    /// Does the upcoming token begin a *simple expression* (an atom)? Drives implicit mul.
+    fn starts_simple(&self) -> bool {
+        matches!(
+            self.peek(),
+            TokenKind::Num(_)
+                | TokenKind::Sym(_)
+                | TokenKind::VulgarFrac(_, _)
+                | TokenKind::Sqrt
+                | TokenKind::RootN(_)
+                | TokenKind::LParen
+                | TokenKind::LBracket
+                | TokenKind::LBrace
+        )
+    }
+
+    fn parse_atom(&mut self) -> Result<MathExpr, FrontendError> {
+        self.enter()?;
+        let result = self.parse_atom_inner();
+        self.exit();
+        result
+    }
+
+    fn parse_atom_inner(&mut self) -> Result<MathExpr, FrontendError> {
+        match self.peek().clone() {
+            TokenKind::Num(s) => {
+                self.advance();
+                Number::parse(&s)
+                    .map(MathExpr::Number)
+                    .ok_or_else(|| self.error_here(format!("invalid number literal {s:?}")))
+            }
+            TokenKind::Sym(s) => {
+                self.advance();
+                Ok(MathExpr::Symbol(s))
+            }
+            TokenKind::VulgarFrac(n, d) => {
+                self.advance();
+                Ok(MathExpr::Frac(Box::new(self.numeral(&n)?), Box::new(self.numeral(&d)?)))
+            }
+            TokenKind::Sqrt => {
+                self.advance();
+                Ok(MathExpr::Root { degree: None, radicand: Box::new(self.parse_atom()?) })
+            }
+            TokenKind::RootN(n) => {
+                self.advance();
+                Ok(MathExpr::Root {
+                    degree: Some(Box::new(MathExpr::Number(Number::from_i64(n as i64)))),
+                    radicand: Box::new(self.parse_atom()?),
+                })
+            }
+            TokenKind::LParen | TokenKind::LBracket | TokenKind::LBrace => self.parse_group(),
+            _ => Err(self.error_here("expected a number, symbol, root, or '('")),
+        }
+    }
+
+    /// A bracketed group: the delimiter style is dropped and the inner expression returned
+    /// directly (so `(a + b)` and `[a + b]` mean the same). Any closing bracket is accepted.
+    fn parse_group(&mut self) -> Result<MathExpr, FrontendError> {
+        self.advance(); // opening bracket
+        let inner = self.parse_relation()?;
+        match self.peek() {
+            TokenKind::RParen | TokenKind::RBracket | TokenKind::RBrace => {
+                self.advance();
+                Ok(inner)
+            }
+            _ => Err(self.error_here("expected a closing bracket")),
+        }
+    }
+}
+
+/// Relational operator for a token, if it is one.
+fn rel_of(kind: &TokenKind) -> Option<RelOp> {
+    Some(match kind {
+        TokenKind::Eq => RelOp::Eq,
+        TokenKind::Ne => RelOp::Ne,
+        TokenKind::Lt => RelOp::Lt,
+        TokenKind::Le => RelOp::Le,
+        TokenKind::Gt => RelOp::Gt,
+        TokenKind::Ge => RelOp::Ge,
+        TokenKind::Approx => RelOp::Approx,
+        TokenKind::Equiv => RelOp::Equiv,
+        _ => return None,
+    })
+}

--- a/code/packages/rust/unicode-math/src/token.rs
+++ b/code/packages/rust/unicode-math/src/token.rs
@@ -1,0 +1,354 @@
+//! The unicode-math tokenizer — a small, total, panic-free scanner over **Unicode** math text.
+//!
+//! Unlike the ASCII-only AsciiMath scanner, this frontend reads the math people and models
+//! actually type with real glyphs — `x² + y² = r²`, `√x`, `½`, `π·α`, `a ≤ b`, `2∓1` — so we
+//! scan by **codepoint** (not byte), recording a half-open *byte* `Span` for every token (so a
+//! caller can still slice the original `&str` to underline an error). The scanner recognises:
+//!
+//! * **numbers** — `42`, `3.14`, `6.022e23` (ASCII digits; [`Number`] validates the text);
+//! * **symbols** — a single ASCII letter (`x`) or a Greek / constant glyph (`π`→`pi`, `Σ`→`Sigma`,
+//!   `∞`→`infinity`). Each is ONE token; a run like `xy` is two tokens the parser multiplies,
+//!   mirroring the AsciiMath convention (there are no multi-letter variables here);
+//! * **superscripts** — a maximal run of `⁰¹²³⁴⁵⁶⁷⁸⁹⁺⁻` normalised to a plain numeral string
+//!   (`x²`→`Super("2")`, `x⁻¹`→`Super("-1")`); the parser turns it into a power;
+//! * **subscripts** — a maximal run of `₀₁₂₃₄₅₆₇₈₉₊₋` (`a₁`→`Sub("1")`) → a subscript;
+//! * **vulgar fractions** — `½ ⅓ ¼ ¾ ⅔ …` → a ready-built `VulgarFrac("1","2")`;
+//! * **operators** — `+`, `-`/`−`(U+2212), `×`/`⋅`/`*`(→×), `÷`(→÷), `/`(built-up fraction),
+//!   `±`, `∓`, and the roots `√`/`∛`/`∜`;
+//! * **relations** — `=`, `≠`, `<`, `≤`, `>`, `≥`, `≈`, `≡`;
+//! * **brackets** — `( ) [ ] { }`.
+//!
+//! Whitespace is skipped. Anything else (including an out-of-scope glyph such as `∑`) is a
+//! *returned* spanned error, never a panic, so the tokenizer is total: every input yields
+//! `Ok(tokens)` or one `Err(FrontendError)`.
+
+use math_frontend::FrontendError;
+
+/// A half-open byte span `[start, end)` into the source.
+pub type Span = (usize, usize);
+
+/// The lexical categories the unicode-math frontend recognises.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TokenKind {
+    /// A numeric literal, exact source text (e.g. `"3.14"`).
+    Num(String),
+    /// A single variable letter, or the canonical name of a constant/Greek glyph (`"pi"`).
+    Sym(String),
+    /// A superscript run normalised to a plain numeral (`"2"`, `"-1"`) — becomes a power.
+    Super(String),
+    /// A subscript run normalised to a plain numeral (`"1"`) — becomes a subscript.
+    Sub(String),
+    /// A vulgar-fraction glyph already split into `(numerator, denominator)` numerals.
+    VulgarFrac(String, String),
+    Plus,
+    /// `-` or `−` (U+2212) — binary/unary minus.
+    Minus,
+    /// `×` / `⋅` / `*` — multiplication.
+    Times,
+    /// `÷` — division.
+    Div,
+    /// `/` — built-up fraction.
+    Slash,
+    /// `±` — plus-or-minus (the pair {a+b, a−b}).
+    PlusMinus,
+    /// `∓` — minus-or-plus (the opposite pairing).
+    MinusPlus,
+    /// `√` — square root (degree-less).
+    Sqrt,
+    /// `∛`/`∜` — nth root with the given fixed degree (3 or 4).
+    RootN(u32),
+    Eq,
+    Ne,
+    Lt,
+    Le,
+    Gt,
+    Ge,
+    /// `≈` — approximately equal.
+    Approx,
+    /// `≡` — identically equal.
+    Equiv,
+    LParen,
+    RParen,
+    LBracket,
+    RBracket,
+    LBrace,
+    RBrace,
+    /// End of input (always the final token; zero-width span at the end).
+    Eof,
+}
+
+/// A token plus where it came from (a byte span into the original source).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Token {
+    pub kind: TokenKind,
+    pub span: Span,
+}
+
+fn err(msg: impl Into<String>, span: Span) -> FrontendError {
+    FrontendError::new("unicode-math", msg, span)
+}
+
+/// Map a Greek letter or math constant glyph to its canonical neutral [`MathExpr::Symbol`] name,
+/// or `None` if `c` is not such a glyph. Names match the AsciiMath frontend's table so the two
+/// notations agree on one `Symbol` string (`π` and `pi` both → `"pi"`), the whole point of a
+/// shared neutral AST.
+fn constant_glyph(c: char) -> Option<&'static str> {
+    Some(match c {
+        // lowercase Greek
+        'α' => "alpha", 'β' => "beta", 'γ' => "gamma", 'δ' => "delta", 'ε' => "epsilon",
+        'ζ' => "zeta", 'η' => "eta", 'θ' => "theta", 'ι' => "iota", 'κ' => "kappa",
+        'λ' => "lambda", 'μ' => "mu", 'ν' => "nu", 'ξ' => "xi", 'ο' => "omicron",
+        'π' => "pi", 'ρ' => "rho", 'σ' => "sigma", 'τ' => "tau", 'υ' => "upsilon",
+        'φ' => "phi", 'χ' => "chi", 'ψ' => "psi", 'ω' => "omega",
+        // uppercase Greek (the visually distinct ones)
+        'Γ' => "Gamma", 'Δ' => "Delta", 'Θ' => "Theta", 'Λ' => "Lambda", 'Ξ' => "Xi",
+        'Π' => "Pi", 'Σ' => "Sigma", 'Υ' => "Upsilon", 'Φ' => "Phi", 'Ψ' => "Psi", 'Ω' => "Omega",
+        // constants / sets
+        '∞' => "infinity", 'ℝ' => "reals", 'ℕ' => "naturals", 'ℤ' => "integers",
+        'ℚ' => "rationals", 'ℂ' => "complexes", '∅' => "emptyset", '∂' => "partial", '∇' => "nabla",
+        _ => return None,
+    })
+}
+
+/// Map a superscript codepoint to the plain character it stands for, or `None`.
+fn superscript_char(c: char) -> Option<char> {
+    Some(match c {
+        '⁰' => '0', '¹' => '1', '²' => '2', '³' => '3', '⁴' => '4',
+        '⁵' => '5', '⁶' => '6', '⁷' => '7', '⁸' => '8', '⁹' => '9',
+        '⁺' => '+', '⁻' => '-',
+        _ => return None,
+    })
+}
+
+/// Map a subscript codepoint to the plain character it stands for, or `None`.
+fn subscript_char(c: char) -> Option<char> {
+    Some(match c {
+        '₀' => '0', '₁' => '1', '₂' => '2', '₃' => '3', '₄' => '4',
+        '₅' => '5', '₆' => '6', '₇' => '7', '₈' => '8', '₉' => '9',
+        '₊' => '+', '₋' => '-',
+        _ => return None,
+    })
+}
+
+/// Map a vulgar-fraction glyph to `(numerator, denominator)`, or `None`.
+fn vulgar_fraction(c: char) -> Option<(&'static str, &'static str)> {
+    Some(match c {
+        '½' => ("1", "2"), '⅓' => ("1", "3"), '⅔' => ("2", "3"),
+        '¼' => ("1", "4"), '¾' => ("3", "4"),
+        '⅕' => ("1", "5"), '⅖' => ("2", "5"), '⅗' => ("3", "5"), '⅘' => ("4", "5"),
+        '⅙' => ("1", "6"), '⅚' => ("5", "6"),
+        '⅛' => ("1", "8"), '⅜' => ("3", "8"), '⅝' => ("5", "8"), '⅞' => ("7", "8"),
+        '⅐' => ("1", "7"), '⅑' => ("1", "9"), '⅒' => ("1", "10"),
+        _ => return None,
+    })
+}
+
+/// Tokenize a unicode-math source string. Total and panic-free: returns the token list
+/// (terminated by [`TokenKind::Eof`]) or a single spanned [`FrontendError`].
+pub fn tokenize(src: &str) -> Result<Vec<Token>, FrontendError> {
+    // Materialise (byte_offset, char) pairs so we can look ahead within runs while still
+    // recording true byte spans. All slicing uses these byte offsets, so it is panic-free
+    // even though the input is full Unicode.
+    let chars: Vec<(usize, char)> = src.char_indices().collect();
+    let len = src.len();
+    let end_of = |i: usize| chars.get(i).map(|&(b, _)| b).unwrap_or(len);
+
+    let mut toks = Vec::new();
+    let mut i = 0;
+    while i < chars.len() {
+        let (start, c) = chars[i];
+        if c.is_whitespace() {
+            i += 1;
+            continue;
+        }
+        // ── numbers ────────────────────────────────────────────────────────────────────────
+        if c.is_ascii_digit() || (c == '.' && matches!(chars.get(i + 1), Some(&(_, d)) if d.is_ascii_digit())) {
+            let j = scan_number(&chars, i);
+            toks.push(Token { kind: TokenKind::Num(src[start..end_of(j)].to_string()), span: (start, end_of(j)) });
+            i = j;
+            continue;
+        }
+        // ── superscript run → a power exponent ───────────────────────────────────────────────
+        if superscript_char(c).is_some() {
+            let mut s = String::new();
+            let mut j = i;
+            while let Some(&(_, ch)) = chars.get(j) {
+                match superscript_char(ch) {
+                    Some(p) => { s.push(p); j += 1; }
+                    None => break,
+                }
+            }
+            toks.push(Token { kind: TokenKind::Super(s), span: (start, end_of(j)) });
+            i = j;
+            continue;
+        }
+        // ── subscript run → a subscript index ────────────────────────────────────────────────
+        if subscript_char(c).is_some() {
+            let mut s = String::new();
+            let mut j = i;
+            while let Some(&(_, ch)) = chars.get(j) {
+                match subscript_char(ch) {
+                    Some(p) => { s.push(p); j += 1; }
+                    None => break,
+                }
+            }
+            toks.push(Token { kind: TokenKind::Sub(s), span: (start, end_of(j)) });
+            i = j;
+            continue;
+        }
+        // ── single-codepoint tokens ──────────────────────────────────────────────────────────
+        let one = (start, end_of(i + 1));
+        if let Some((n, d)) = vulgar_fraction(c) {
+            toks.push(Token { kind: TokenKind::VulgarFrac(n.into(), d.into()), span: one });
+            i += 1;
+            continue;
+        }
+        if let Some(name) = constant_glyph(c) {
+            toks.push(Token { kind: TokenKind::Sym(name.into()), span: one });
+            i += 1;
+            continue;
+        }
+        let kind = match c {
+            'a'..='z' | 'A'..='Z' => TokenKind::Sym(c.to_string()),
+            '+' => TokenKind::Plus,
+            '-' | '−' => TokenKind::Minus,
+            '×' | '⋅' | '*' => TokenKind::Times,
+            '÷' => TokenKind::Div,
+            '/' => TokenKind::Slash,
+            '±' => TokenKind::PlusMinus,
+            '∓' => TokenKind::MinusPlus,
+            '√' => TokenKind::Sqrt,
+            '∛' => TokenKind::RootN(3),
+            '∜' => TokenKind::RootN(4),
+            '=' => TokenKind::Eq,
+            '≠' => TokenKind::Ne,
+            '<' => TokenKind::Lt,
+            '≤' => TokenKind::Le,
+            '>' => TokenKind::Gt,
+            '≥' => TokenKind::Ge,
+            '≈' => TokenKind::Approx,
+            '≡' => TokenKind::Equiv,
+            '(' => TokenKind::LParen,
+            ')' => TokenKind::RParen,
+            '[' => TokenKind::LBracket,
+            ']' => TokenKind::RBracket,
+            '{' => TokenKind::LBrace,
+            '}' => TokenKind::RBrace,
+            _ => return Err(err(format!("unexpected character {c:?}"), one)),
+        };
+        toks.push(Token { kind, span: one });
+        i += 1;
+    }
+    toks.push(Token { kind: TokenKind::Eof, span: (len, len) });
+    Ok(toks)
+}
+
+/// Scan a numeric literal beginning at char-index `start`, returning the end char-index
+/// (exclusive). Grammar mirrors AsciiMath/[`Number::parse`]: `digits? ('.' digits)? ([eE][+-]?
+/// digits)?`, with the exponent consumed only when well-formed (so `2e` is `2` then `e`).
+fn scan_number(chars: &[(usize, char)], start: usize) -> usize {
+    let at = |k: usize| chars.get(k).map(|&(_, c)| c);
+    let mut i = start;
+    while matches!(at(i), Some(d) if d.is_ascii_digit()) {
+        i += 1;
+    }
+    if at(i) == Some('.') && matches!(at(i + 1), Some(d) if d.is_ascii_digit()) {
+        i += 1;
+        while matches!(at(i), Some(d) if d.is_ascii_digit()) {
+            i += 1;
+        }
+    }
+    if matches!(at(i), Some('e') | Some('E')) {
+        let mut j = i + 1;
+        if matches!(at(j), Some('+') | Some('-')) {
+            j += 1;
+        }
+        if matches!(at(j), Some(d) if d.is_ascii_digit()) {
+            j += 1;
+            while matches!(at(j), Some(d) if d.is_ascii_digit()) {
+                j += 1;
+            }
+            i = j;
+        }
+    }
+    i
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn kinds(src: &str) -> Vec<TokenKind> {
+        tokenize(src).unwrap().into_iter().map(|t| t.kind).collect()
+    }
+
+    #[test]
+    fn numbers_symbols_operators() {
+        assert_eq!(kinds("3.14 + x"), vec![
+            TokenKind::Num("3.14".into()), TokenKind::Plus, TokenKind::Sym("x".into()), TokenKind::Eof,
+        ]);
+    }
+
+    #[test]
+    fn greek_and_constants_map_to_canonical_names() {
+        assert_eq!(kinds("π")[0], TokenKind::Sym("pi".into()));
+        assert_eq!(kinds("Σ")[0], TokenKind::Sym("Sigma".into()));
+        assert_eq!(kinds("∞")[0], TokenKind::Sym("infinity".into()));
+    }
+
+    #[test]
+    fn superscript_and_subscript_runs_normalise() {
+        assert_eq!(kinds("x²")[1], TokenKind::Super("2".into()));
+        assert_eq!(kinds("x⁻¹")[1], TokenKind::Super("-1".into()));
+        assert_eq!(kinds("a₁")[1], TokenKind::Sub("1".into()));
+    }
+
+    #[test]
+    fn vulgar_fractions_split() {
+        assert_eq!(kinds("½")[0], TokenKind::VulgarFrac("1".into(), "2".into()));
+        assert_eq!(kinds("⅔")[0], TokenKind::VulgarFrac("2".into(), "3".into()));
+    }
+
+    #[test]
+    fn unicode_operators_and_relations() {
+        assert_eq!(kinds("a × b")[1], TokenKind::Times);
+        assert_eq!(kinds("a ⋅ b")[1], TokenKind::Times);
+        assert_eq!(kinds("a ÷ b")[1], TokenKind::Div);
+        assert_eq!(kinds("a − b")[1], TokenKind::Minus); // U+2212
+        assert_eq!(kinds("a ± b")[1], TokenKind::PlusMinus);
+        assert_eq!(kinds("a ∓ b")[1], TokenKind::MinusPlus);
+        assert_eq!(kinds("a ≤ b")[1], TokenKind::Le);
+        assert_eq!(kinds("a ≥ b")[1], TokenKind::Ge);
+        assert_eq!(kinds("a ≠ b")[1], TokenKind::Ne);
+        assert_eq!(kinds("a ≈ b")[1], TokenKind::Approx);
+        assert_eq!(kinds("√x")[0], TokenKind::Sqrt);
+        assert_eq!(kinds("∛x")[0], TokenKind::RootN(3));
+    }
+
+    #[test]
+    fn exponent_only_consumed_when_well_formed() {
+        assert_eq!(kinds("6.022e23")[0], TokenKind::Num("6.022e23".into()));
+        assert_eq!(kinds("2e"), vec![
+            TokenKind::Num("2".into()), TokenKind::Sym("e".into()), TokenKind::Eof,
+        ]);
+    }
+
+    #[test]
+    fn spans_are_byte_offsets_into_unicode_source() {
+        // `π` is two bytes; the `²` after `x` starts at byte 1.
+        let t = tokenize("x²").unwrap();
+        assert_eq!(t[0].span, (0, 1)); // x
+        assert_eq!(t[1].span, (1, 3)); // ² (3 bytes)
+        for tok in tokenize("π² ≤ ∞").unwrap() {
+            assert!(tok.span.0 <= tok.span.1 && tok.span.1 <= "π² ≤ ∞".len());
+        }
+    }
+
+    #[test]
+    fn errors_are_spanned_not_panics() {
+        // An out-of-scope glyph (∑ is PR-2) is a clean spanned error, never a panic.
+        let e = tokenize("∑").unwrap_err();
+        assert_eq!(e.frontend, "unicode-math");
+        assert!(e.span.0 <= e.span.1 && e.span.1 <= "∑".len());
+    }
+}

--- a/code/specs/PFE01-pluggable-parser-frontends.md
+++ b/code/specs/PFE01-pluggable-parser-frontends.md
@@ -143,8 +143,16 @@ frontend additionally ships notation-specific golden tests.
 - `latex` — the first frontend (full LaTeX; see [LTX01](LTX01-full-latex-parser.md)). It is
   a standalone full-LaTeX parser in its own right and *also* implements `MathFrontend` via a
   thin adapter (math nodes of its document AST → `MathExpr`).
-- Future: `asciimath`, `mathml`, `unicode-math`, … each a small crate implementing the
-  trait. None require changes to consumers.
+- `asciimath` — the second frontend (terse ASCII math; see [ASM01](ASM01-asciimath-frontend.md)).
+- `unicode-math` — the **third** frontend: Unicode plain math as people and models type it
+  (`x² + y² = r²`, `√x`, `½`, `π·α`, `a ≤ b`). A small crate implementing the trait; its Greek /
+  constant glyphs canonicalize to the same `Symbol` names as AsciiMath, so the notations agree on
+  one neutral string. PR-1 covers numbers/symbols/super-&-subscripts/fractions/roots/relations
+  /implicit-mul/±∓; big operators, named functions, matrices, and `\text` are PR-2.
+- Future: `mathml`, MathJSON, content-MathML, spreadsheet formulae, … each a small crate
+  implementing the trait. None require changes to consumers. **Three frontends now in (LaTeX,
+  AsciiMath, Unicode), all feeding one neutral AST with zero consumer change** — the pluggability
+  claim is demonstrated, not just asserted.
 
 ## 7. Non-goals
 


### PR DESCRIPTION
## What

Adds the **third** pluggable `MathFrontend` (after [`latex`](code/packages/rust/latex) and [`asciimath`](code/packages/rust/asciimath)): a parser for the math people and language models actually *type* with real glyphs — `x² + y² = r²`, `√x`, `½`, `π·α`, `a ≤ b`, `2 ∓ 1` — producing the **same** neutral `MathExpr` the other two frontends do. Every existing consumer gains the notation with **zero** change.

> PFE01 pluggability is now **demonstrated, not just asserted**, across three genuinely different notations: a macro language (LaTeX), a terse ASCII syntax (AsciiMath), and raw Unicode.

## token.rs — a total, panic-free **codepoint** scanner (byte spans)

- numbers; single-letter variables; **Greek / constant glyphs** canonicalised to the same `Symbol` names as AsciiMath (`π`→`pi`, `Σ`→`Sigma`, `∞`→`infinity`) so the notations agree on one neutral string;
- Unicode **superscript** runs (`x²`, `x⁻¹`, `x¹⁰`) → powers; **subscript** runs (`a₁`);
- **vulgar-fraction** glyphs (`½ ⅓ ¼ ⅔ …`) → `Frac`;
- operators `+ − × ⋅ ÷ ± ∓`, roots `√ ∛ ∜`, relations `= ≠ < ≤ > ≥ ≈ ≡`, brackets.

All slicing uses `char_indices` byte offsets, so multi-byte input never panics; an out-of-scope glyph (e.g. `∑`) is a clean spanned error.

## parser.rs — precedence-climbing recursive descent

Mirrors the AsciiMath frontend (relation < add < mul < frac < unary < script < atom): implicit multiplication by juxtaposition, a `MAX_DEPTH=64` nesting guard, and loop-built left-assoc chains so adversarial input fails cleanly instead of overflowing the stack.

## Scope & honesty

`capabilities()` advertises exactly the PR-1 surface (`fractions`, `roots`, `powers`, `relations`, `implicit_mul`, `plusminus`) and declares `functions`/`big_operators`/`matrices`/`text` **off** (PR-2), enforced by the shared `check_frontend` harness.

## Gates

- **23 unit + 1 doc test** pass (incl. the conformance corpus); `cargo build --workspace` wires the new member; clippy `-D warnings` clean; `#![forbid(unsafe_code)]`.
- `/security-review` **PASSED** (codepoint slicing is char-boundary-safe; `MAX_DEPTH` caps recursion; loops for chains; `Number::parse` is the only numeric conversion with no `unwrap` on input; no unsafe/eval/IO; no over-range or inverted spans).
- unicode-math **0.1.0**. Spec `PFE01-pluggable-parser-frontends.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)