### PR TITLE
[codex] Fix Engram web demo rendering

### DIFF
--- a/code/packages/rust/mosaic-emit-html/src/lib.rs
+++ b/code/packages/rust/mosaic-emit-html/src/lib.rs
@@ -47,8 +47,8 @@
 //! </html>
 //! ```
 
-use mosaic_vm::{EmitResult, MosaicRenderer, ResolvedProperty, ResolvedValue};
 use mosaic_analyzer::{MosaicSlot, MosaicType};
+use mosaic_vm::{EmitResult, MosaicRenderer, ResolvedProperty, ResolvedValue};
 
 // =====================================================================
 // New three-file pipeline entry point.
@@ -180,10 +180,7 @@ impl HtmlRenderer {
     ///
     /// - `fixtures` — a JSON object mapping slot names to values.
     /// - `css` — optional CSS string to inline in `<style>`.
-    pub fn new(
-        fixtures: serde_json::Map<String, serde_json::Value>,
-        css: Option<String>,
-    ) -> Self {
+    pub fn new(fixtures: serde_json::Map<String, serde_json::Value>, css: Option<String>) -> Self {
         Self {
             component_name: String::new(),
             slots: Vec::new(),
@@ -295,7 +292,14 @@ impl HtmlRenderer {
     /// `red" onmouseover="alert(1)` from breaking out of the attribute and
     /// injecting event handlers.
     fn build_style(&self, props: &[ResolvedProperty]) -> String {
-        let skip = ["content", "source", "a11y-label", "a11y-role", "a11y-hidden", "style"];
+        let skip = [
+            "content",
+            "source",
+            "a11y-label",
+            "a11y-role",
+            "a11y-hidden",
+            "style",
+        ];
         let entries: Vec<String> = props
             .iter()
             .filter(|p| !skip.contains(&p.name.as_str()))
@@ -434,14 +438,22 @@ impl HtmlRenderer {
                     .fixtures
                     .get(&headers_slot)
                     .and_then(|v| v.as_array())
-                    .map(|arr| arr.iter().map(|h| html_escape(&json_to_string(h))).collect())
+                    .map(|arr| {
+                        arr.iter()
+                            .map(|h| html_escape(&json_to_string(h)))
+                            .collect()
+                    })
                     .unwrap_or_else(|| vec![format!("[{headers_slot}]")]);
 
                 let rows: Vec<String> = self
                     .fixtures
                     .get(&rows_slot)
                     .and_then(|v| v.as_array())
-                    .map(|arr| arr.iter().map(|r| html_escape(&json_to_string(r))).collect())
+                    .map(|arr| {
+                        arr.iter()
+                            .map(|r| html_escape(&json_to_string(r)))
+                            .collect()
+                    })
                     .unwrap_or_else(|| vec![format!("[{rows_slot}]")]);
 
                 let style_attr = if extra_style.is_empty() {
@@ -450,10 +462,8 @@ impl HtmlRenderer {
                     format!(" style=\"{extra_style}\"")
                 };
 
-                let header_cells: String = headers
-                    .iter()
-                    .map(|h| format!("<th>{h}</th>"))
-                    .collect();
+                let header_cells: String =
+                    headers.iter().map(|h| format!("<th>{h}</th>")).collect();
                 let row_cells: String = rows
                     .iter()
                     .map(|r| format!("<tr><td>{r}</td></tr>"))
@@ -611,22 +621,24 @@ impl HtmlRenderer {
     /// - `item_name` — the loop variable name to bind during this pass.
     /// - `item` — the JSON value for this iteration's fixture item.
     /// - `events` — the recorded event log (cloned from recording state).
-    fn replay_events(
-        &mut self,
-        item_name: &str,
-        item: serde_json::Value,
-        events: &[EachEvent],
-    ) {
+    fn replay_events(&mut self, item_name: &str, item: serde_json::Value, events: &[EachEvent]) {
         self.loop_bindings.push((item_name.to_string(), Some(item)));
         for event in events {
             match event {
-                EachEvent::BeginNode { tag, is_primitive, props } => {
+                EachEvent::BeginNode {
+                    tag,
+                    is_primitive,
+                    props,
+                } => {
                     self.begin_node_inner(tag, *is_primitive, props);
                 }
                 EachEvent::EndNode { tag } => {
                     self.end_node_inner(tag);
                 }
-                EachEvent::RenderSlotChild { slot_name, slot_type } => {
+                EachEvent::RenderSlotChild {
+                    slot_name,
+                    slot_type,
+                } => {
                     self.render_slot_child_inner(slot_name, slot_type);
                 }
                 EachEvent::BeginWhen { slot_name } => {
@@ -635,7 +647,11 @@ impl HtmlRenderer {
                 EachEvent::EndWhen => {
                     self.end_when_inner();
                 }
-                EachEvent::BeginEach { slot_name, item_name: nested_name, element_type } => {
+                EachEvent::BeginEach {
+                    slot_name,
+                    item_name: nested_name,
+                    element_type,
+                } => {
                     // Nested each during replay: expand first item only (v1).
                     self.begin_each_inner(slot_name, nested_name, element_type);
                 }
@@ -946,8 +962,8 @@ fn format_div(style: &str, class: &str, props: &[ResolvedProperty]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use mosaic_vm::MosaicVM;
     use mosaic_analyzer::analyze;
+    use mosaic_vm::MosaicVM;
     use serde_json::json;
 
     /// Build an `HtmlRenderer` with the given fixture JSON, run it on `src`.
@@ -971,7 +987,10 @@ mod tests {
     #[test]
     fn test_html_document_structure() {
         let out = emit(r#"component X { Box { } }"#);
-        assert!(out.starts_with("<!DOCTYPE html>"), "Expected DOCTYPE: {out}");
+        assert!(
+            out.starts_with("<!DOCTYPE html>"),
+            "Expected DOCTYPE: {out}"
+        );
         assert!(out.contains("<html lang=\"en\">"), "Expected <html>: {out}");
         assert!(out.contains("<head>"), "Expected <head>: {out}");
         assert!(out.contains("<body>"), "Expected <body>: {out}");
@@ -985,7 +1004,10 @@ mod tests {
     #[test]
     fn test_component_title() {
         let out = emit(r#"component ProfileCard { Box { } }"#);
-        assert!(out.contains("<title>Profile Card</title>"), "Expected title: {out}");
+        assert!(
+            out.contains("<title>Profile Card</title>"),
+            "Expected title: {out}"
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -1045,10 +1067,7 @@ mod tests {
     #[test]
     fn test_text_content_placeholder() {
         let out = emit(r#"component Card { slot title: text; Text { content: @title; } }"#);
-        assert!(
-            out.contains("[slot: title]"),
-            "Expected placeholder: {out}"
-        );
+        assert!(out.contains("[slot: title]"), "Expected placeholder: {out}");
     }
 
     // -----------------------------------------------------------------------
@@ -1069,7 +1088,10 @@ mod tests {
             json!({"show": true}),
             None,
         );
-        assert!(out.contains("Visible"), "Expected body when show=true: {out}");
+        assert!(
+            out.contains("Visible"),
+            "Expected body when show=true: {out}"
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -1090,7 +1112,10 @@ mod tests {
             json!({"show": false}),
             None,
         );
-        assert!(!out.contains("Hidden"), "Expected body suppressed when show=false: {out}");
+        assert!(
+            !out.contains("Hidden"),
+            "Expected body suppressed when show=false: {out}"
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -1133,9 +1158,18 @@ mod tests {
             json!({"items": ["FirstItem", "SecondItem", "ThirdItem"]}),
             None,
         );
-        assert!(out.contains("FirstItem"), "Expected first fixture item: {out}");
-        assert!(out.contains("SecondItem"), "Expected second fixture item: {out}");
-        assert!(out.contains("ThirdItem"), "Expected third fixture item: {out}");
+        assert!(
+            out.contains("FirstItem"),
+            "Expected first fixture item: {out}"
+        );
+        assert!(
+            out.contains("SecondItem"),
+            "Expected second fixture item: {out}"
+        );
+        assert!(
+            out.contains("ThirdItem"),
+            "Expected third fixture item: {out}"
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -1155,7 +1189,10 @@ mod tests {
             }"#,
         );
         // Without fixture, loop var resolves to [item] placeholder.
-        assert!(out.contains("[item]"), "Expected placeholder for loop var: {out}");
+        assert!(
+            out.contains("[item]"),
+            "Expected placeholder for loop var: {out}"
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -1210,7 +1247,10 @@ mod tests {
     #[test]
     fn test_minimal_reset_emitted() {
         let out = emit(r#"component X { Box { } }"#);
-        assert!(out.contains("box-sizing: border-box"), "Expected reset CSS: {out}");
+        assert!(
+            out.contains("box-sizing: border-box"),
+            "Expected reset CSS: {out}"
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/code/packages/rust/mosaic-emit-html/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-html/src/pipeline.rs
@@ -2628,10 +2628,133 @@ fn build_inline_css_fragment(props: &[StyleProp]) -> String {
         // that to `background-color` so the resulting HTML attribute is
         // canonical CSS, not mixed-case.
         let key = camel_to_kebab(&p.name);
-        let value = escape_html_attr(&p.value);
+        let value = normalize_css_value(&key, &p.value);
+        let value = escape_html_attr(&value);
         parts.push(format!("{key}: {value}"));
     }
     parts.join("; ")
+}
+
+fn normalize_css_value(property: &str, value: &str) -> String {
+    let trimmed = value.trim();
+    if is_plain_number(trimmed) && !is_zero(trimmed) && css_property_needs_px(property) {
+        format!("{trimmed}px")
+    } else {
+        value.to_string()
+    }
+}
+
+fn is_plain_number(value: &str) -> bool {
+    !value.is_empty()
+        && value
+            .chars()
+            .all(|c| c.is_ascii_digit() || matches!(c, '+' | '-' | '.'))
+        && value.parse::<f64>().is_ok()
+}
+
+fn is_zero(value: &str) -> bool {
+    value.parse::<f64>() == Ok(0.0)
+}
+
+fn css_property_needs_px(property: &str) -> bool {
+    matches!(
+        property,
+        "block-size"
+            | "border-block-end-width"
+            | "border-block-start-width"
+            | "border-bottom-left-radius"
+            | "border-bottom-right-radius"
+            | "border-bottom-width"
+            | "border-end-end-radius"
+            | "border-end-start-radius"
+            | "border-inline-end-width"
+            | "border-inline-start-width"
+            | "border-left-width"
+            | "border-radius"
+            | "border-right-width"
+            | "border-start-end-radius"
+            | "border-start-start-radius"
+            | "border-top-left-radius"
+            | "border-top-right-radius"
+            | "border-top-width"
+            | "border-width"
+            | "bottom"
+            | "column-gap"
+            | "column-width"
+            | "flex-basis"
+            | "font-size"
+            | "gap"
+            | "height"
+            | "inline-size"
+            | "inset"
+            | "inset-block"
+            | "inset-block-end"
+            | "inset-block-start"
+            | "inset-inline"
+            | "inset-inline-end"
+            | "inset-inline-start"
+            | "left"
+            | "letter-spacing"
+            | "margin"
+            | "margin-block"
+            | "margin-block-end"
+            | "margin-block-start"
+            | "margin-bottom"
+            | "margin-inline"
+            | "margin-inline-end"
+            | "margin-inline-start"
+            | "margin-left"
+            | "margin-right"
+            | "margin-top"
+            | "max-block-size"
+            | "max-height"
+            | "max-inline-size"
+            | "max-width"
+            | "min-block-size"
+            | "min-height"
+            | "min-inline-size"
+            | "min-width"
+            | "outline-offset"
+            | "outline-width"
+            | "padding"
+            | "padding-block"
+            | "padding-block-end"
+            | "padding-block-start"
+            | "padding-bottom"
+            | "padding-inline"
+            | "padding-inline-end"
+            | "padding-inline-start"
+            | "padding-left"
+            | "padding-right"
+            | "padding-top"
+            | "right"
+            | "row-gap"
+            | "scroll-margin"
+            | "scroll-margin-block"
+            | "scroll-margin-block-end"
+            | "scroll-margin-block-start"
+            | "scroll-margin-bottom"
+            | "scroll-margin-inline"
+            | "scroll-margin-inline-end"
+            | "scroll-margin-inline-start"
+            | "scroll-margin-left"
+            | "scroll-margin-right"
+            | "scroll-margin-top"
+            | "scroll-padding"
+            | "scroll-padding-block"
+            | "scroll-padding-block-end"
+            | "scroll-padding-block-start"
+            | "scroll-padding-bottom"
+            | "scroll-padding-inline"
+            | "scroll-padding-inline-end"
+            | "scroll-padding-inline-start"
+            | "scroll-padding-left"
+            | "scroll-padding-right"
+            | "scroll-padding-top"
+            | "top"
+            | "width"
+            | "word-spacing"
+    )
 }
 
 /// Concatenate two CSS declaration lists, semicolon-separated, dropping
@@ -3117,6 +3240,76 @@ mod tests {
     // 7. Kebab → CSS mapping: camelCase author input becomes kebab-case
     //    CSS, plain kebab-case input passes through unchanged.
     // ---------------------------------------------------------------
+    #[test]
+    fn unitless_mosstyle_numbers_gain_css_units_when_required() {
+        let style = StyleDef {
+            component_name: "Card".to_string(),
+            parts: vec![PartStyle {
+                name: "root".to_string(),
+                base: vec![
+                    StyleProp {
+                        name: "padding".to_string(),
+                        value: "8".to_string(),
+                    },
+                    StyleProp {
+                        name: "font-size".to_string(),
+                        value: "14".to_string(),
+                    },
+                    StyleProp {
+                        name: "font-weight".to_string(),
+                        value: "700".to_string(),
+                    },
+                    StyleProp {
+                        name: "opacity".to_string(),
+                        value: "0.75".to_string(),
+                    },
+                    StyleProp {
+                        name: "line-height".to_string(),
+                        value: "1.4".to_string(),
+                    },
+                    StyleProp {
+                        name: "border-radius".to_string(),
+                        value: "6".to_string(),
+                    },
+                    StyleProp {
+                        name: "padding-bottom".to_string(),
+                        value: "0".to_string(),
+                    },
+                ],
+                states: Vec::new(),
+            }],
+        };
+        let l = layout("Card", node_with_part("Box", "root"));
+        let result = from_pipeline(&component("Card", vec![]), &l, &style).expect("emit ok");
+        let out = result.output;
+
+        assert!(out.contains("padding: 8px"), "expected padding px:\n{out}");
+        assert!(
+            out.contains("font-size: 14px"),
+            "expected font-size px:\n{out}"
+        );
+        assert!(
+            out.contains("font-weight: 700"),
+            "font-weight must stay unitless:\n{out}"
+        );
+        assert!(
+            out.contains("opacity: 0.75"),
+            "opacity must stay unitless:\n{out}"
+        );
+        assert!(
+            out.contains("line-height: 1.4"),
+            "line-height must stay unitless:\n{out}"
+        );
+        assert!(
+            out.contains("border-radius: 6px"),
+            "expected border-radius px:\n{out}"
+        );
+        assert!(
+            out.contains("padding-bottom: 0"),
+            "zero lengths should remain valid unitless zero:\n{out}"
+        );
+    }
+
     #[test]
     fn camel_case_style_keys_normalise_to_kebab() {
         let style = StyleDef {

--- a/code/packages/rust/mosaic-emit-react/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-react/src/pipeline.rs
@@ -3895,13 +3895,31 @@ fn build_inline_style_fragment(props: &[StyleProp]) -> String {
     let mut parts: Vec<String> = Vec::with_capacity(props.len());
     for p in props {
         let key = css_property_to_camel(&p.name);
+        parts.push(format!("{key}: {}", react_style_value_literal(&p.value)));
+    }
+    parts.join(", ")
+}
+
+/// Render a mosstyle value as a React inline-style literal.
+fn react_style_value_literal(value: &str) -> String {
+    let trimmed = value.trim();
+    if is_plain_number(trimmed) {
+        trimmed.to_string()
+    } else {
         // Escape any embedded double quotes in the value to keep the JSX
         // string literal well-formed. Real mosstyle values shouldn't
         // contain `"` but defensive coding here costs essentially nothing.
-        let escaped = p.value.replace('\\', "\\\\").replace('"', "\\\"");
-        parts.push(format!("{key}: \"{escaped}\""));
+        let escaped = value.replace('\\', "\\\\").replace('"', "\\\"");
+        format!("\"{escaped}\"")
     }
-    parts.join(", ")
+}
+
+fn is_plain_number(value: &str) -> bool {
+    !value.is_empty()
+        && value
+            .chars()
+            .all(|c| c.is_ascii_digit() || matches!(c, '+' | '-' | '.'))
+        && value.parse::<f64>().is_ok()
 }
 
 /// Convert a kebab-case CSS property name to its camelCase JS form.
@@ -4810,6 +4828,29 @@ mod tests {
         assert!(
             result.output.contains("fontSize: \"13px\""),
             "got:\n{}",
+            result.output
+        );
+    }
+
+    #[test]
+    fn unitless_mosstyle_numbers_emit_numeric_react_values() {
+        let m = component("X", vec![], vec![]);
+        let s = style_with_part(
+            "X",
+            "panel",
+            &[
+                ("padding", "8"),
+                ("font-size", "14"),
+                ("font-weight", "700"),
+                ("opacity", "0.75"),
+            ],
+        );
+        let l = box_root(Some("panel"));
+        let result = from_pipeline(&m, &l, &s).unwrap();
+        let expected = "style={{ padding: 8, fontSize: 14, fontWeight: 700, opacity: 0.75 }}";
+        assert!(
+            result.output.contains(expected),
+            "numeric mosstyle values should be emitted as React numbers, got:\n{}",
             result.output
         );
     }

--- a/code/packages/rust/mosaic-emit-webcomponent/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-webcomponent/src/pipeline.rs
@@ -2695,10 +2695,133 @@ fn build_inline_css_fragment(props: &[StyleProp]) -> String {
     let mut parts: Vec<String> = Vec::with_capacity(props.len());
     for p in props {
         let key = camel_to_kebab(&p.name);
-        let value = escape_html_attribute(&p.value);
+        let value = normalize_css_value(&key, &p.value);
+        let value = escape_html_attribute(&value);
         parts.push(format!("{key}: {value}"));
     }
     parts.join("; ")
+}
+
+fn normalize_css_value(property: &str, value: &str) -> String {
+    let trimmed = value.trim();
+    if is_plain_number(trimmed) && !is_zero(trimmed) && css_property_needs_px(property) {
+        format!("{trimmed}px")
+    } else {
+        value.to_string()
+    }
+}
+
+fn is_plain_number(value: &str) -> bool {
+    !value.is_empty()
+        && value
+            .chars()
+            .all(|c| c.is_ascii_digit() || matches!(c, '+' | '-' | '.'))
+        && value.parse::<f64>().is_ok()
+}
+
+fn is_zero(value: &str) -> bool {
+    value.parse::<f64>() == Ok(0.0)
+}
+
+fn css_property_needs_px(property: &str) -> bool {
+    matches!(
+        property,
+        "block-size"
+            | "border-block-end-width"
+            | "border-block-start-width"
+            | "border-bottom-left-radius"
+            | "border-bottom-right-radius"
+            | "border-bottom-width"
+            | "border-end-end-radius"
+            | "border-end-start-radius"
+            | "border-inline-end-width"
+            | "border-inline-start-width"
+            | "border-left-width"
+            | "border-radius"
+            | "border-right-width"
+            | "border-start-end-radius"
+            | "border-start-start-radius"
+            | "border-top-left-radius"
+            | "border-top-right-radius"
+            | "border-top-width"
+            | "border-width"
+            | "bottom"
+            | "column-gap"
+            | "column-width"
+            | "flex-basis"
+            | "font-size"
+            | "gap"
+            | "height"
+            | "inline-size"
+            | "inset"
+            | "inset-block"
+            | "inset-block-end"
+            | "inset-block-start"
+            | "inset-inline"
+            | "inset-inline-end"
+            | "inset-inline-start"
+            | "left"
+            | "letter-spacing"
+            | "margin"
+            | "margin-block"
+            | "margin-block-end"
+            | "margin-block-start"
+            | "margin-bottom"
+            | "margin-inline"
+            | "margin-inline-end"
+            | "margin-inline-start"
+            | "margin-left"
+            | "margin-right"
+            | "margin-top"
+            | "max-block-size"
+            | "max-height"
+            | "max-inline-size"
+            | "max-width"
+            | "min-block-size"
+            | "min-height"
+            | "min-inline-size"
+            | "min-width"
+            | "outline-offset"
+            | "outline-width"
+            | "padding"
+            | "padding-block"
+            | "padding-block-end"
+            | "padding-block-start"
+            | "padding-bottom"
+            | "padding-inline"
+            | "padding-inline-end"
+            | "padding-inline-start"
+            | "padding-left"
+            | "padding-right"
+            | "padding-top"
+            | "right"
+            | "row-gap"
+            | "scroll-margin"
+            | "scroll-margin-block"
+            | "scroll-margin-block-end"
+            | "scroll-margin-block-start"
+            | "scroll-margin-bottom"
+            | "scroll-margin-inline"
+            | "scroll-margin-inline-end"
+            | "scroll-margin-inline-start"
+            | "scroll-margin-left"
+            | "scroll-margin-right"
+            | "scroll-margin-top"
+            | "scroll-padding"
+            | "scroll-padding-block"
+            | "scroll-padding-block-end"
+            | "scroll-padding-block-start"
+            | "scroll-padding-bottom"
+            | "scroll-padding-inline"
+            | "scroll-padding-inline-end"
+            | "scroll-padding-inline-start"
+            | "scroll-padding-left"
+            | "scroll-padding-right"
+            | "scroll-padding-top"
+            | "top"
+            | "width"
+            | "word-spacing"
+    )
 }
 
 /// Concatenate two CSS declaration lists, semicolon-separated, dropping
@@ -3898,8 +4021,9 @@ mod tests {
         );
         let r = from_pipeline(&m, &l, &s).unwrap();
         assert!(
-            r.output
-                .contains(r#"<button style="background: #f87171; border-radius: 6">Save</button>"#),
+            r.output.contains(
+                r#"<button style="background: #f87171; border-radius: 6px">Save</button>"#
+            ),
             "HostButton part style missing from special-path output:\n{}",
             r.output
         );
@@ -6171,6 +6295,60 @@ mod tests {
         assert_eq!(
             map.get("cell:selected").map(String::as_str),
             Some("background: blue")
+        );
+    }
+
+    #[test]
+    fn unitless_mosstyle_numbers_gain_css_units_when_required() {
+        let s = style_with_parts(
+            "X",
+            vec![part(
+                "panel",
+                vec![
+                    prop("padding", "8"),
+                    prop("font-size", "14"),
+                    prop("font-weight", "700"),
+                    prop("opacity", "0.75"),
+                    prop("line-height", "1.4"),
+                    prop("border-radius", "6"),
+                    prop("padding-bottom", "0"),
+                ],
+                vec![StateStyle {
+                    state: "selected".to_string(),
+                    props: vec![prop("border-width", "1")],
+                }],
+            )],
+        );
+        let map = build_part_style_map(&s);
+        let base = map.get("panel").map(String::as_str).unwrap_or("");
+        assert!(base.contains("padding: 8px"), "expected padding px: {base}");
+        assert!(
+            base.contains("font-size: 14px"),
+            "expected font-size px: {base}"
+        );
+        assert!(
+            base.contains("font-weight: 700"),
+            "font-weight must stay unitless: {base}"
+        );
+        assert!(
+            base.contains("opacity: 0.75"),
+            "opacity must stay unitless: {base}"
+        );
+        assert!(
+            base.contains("line-height: 1.4"),
+            "line-height must stay unitless: {base}"
+        );
+        assert!(
+            base.contains("border-radius: 6px"),
+            "expected border-radius px: {base}"
+        );
+        assert!(
+            base.contains("padding-bottom: 0"),
+            "zero lengths should remain valid unitless zero: {base}"
+        );
+        assert_eq!(
+            map.get("panel:selected").map(String::as_str),
+            Some("border-width: 1px")
         );
     }
 }

--- a/code/programs/mosaic/engram-app/host/web/engram-host.mjs
+++ b/code/programs/mosaic/engram-app/host/web/engram-host.mjs
@@ -3,12 +3,14 @@ import { installEngramMosaicHost } from "./engram-mosaic-host-wasm.mjs";
 const WASM_URL = "./engram_engine.wasm";
 const DECK_ID_STORAGE_KEY = "engram.deckId";
 const HOST_INTENT_EVENT = "engram-host-intent";
+const HOST_READY_EVENT = "mosaic-host-ready";
 
 async function installEngramHost() {
   if (
     typeof window.mosaicHost?.getProps === "function" &&
     typeof window.mosaicHost?.handleEvent === "function"
   ) {
+    announceHostReady();
     return;
   }
 
@@ -28,10 +30,15 @@ async function installEngramHost() {
       );
     },
   });
+  announceHostReady();
 }
 
 function selectedDeckId() {
   return window.localStorage.getItem(DECK_ID_STORAGE_KEY) ?? "";
+}
+
+function announceHostReady() {
+  window.dispatchEvent(new CustomEvent(HOST_READY_EVENT));
 }
 
 void installEngramHost().catch(error => {

--- a/code/programs/mosaic/engram-app/host/web/engram-host.ts
+++ b/code/programs/mosaic/engram-app/host/web/engram-host.ts
@@ -12,6 +12,7 @@ type HostedWindow = Window & {
 const WASM_URL = "/engram_engine.wasm";
 const DECK_ID_STORAGE_KEY = "engram.deckId";
 const HOST_INTENT_EVENT = "engram-host-intent";
+const HOST_READY_EVENT = "mosaic-host-ready";
 
 async function installEngramHost(): Promise<void> {
   const target = window as HostedWindow;
@@ -20,6 +21,7 @@ async function installEngramHost(): Promise<void> {
     typeof existing?.getProps === "function" &&
     typeof existing?.handleEvent === "function"
   ) {
+    announceHostReady();
     return;
   }
 
@@ -39,10 +41,15 @@ async function installEngramHost(): Promise<void> {
       );
     },
   });
+  announceHostReady();
 }
 
 function selectedDeckId(): string {
   return window.localStorage.getItem(DECK_ID_STORAGE_KEY) ?? "";
+}
+
+function announceHostReady(): void {
+  window.dispatchEvent(new CustomEvent(HOST_READY_EVENT));
 }
 
 void installEngramHost().catch((error: unknown) => {

--- a/code/programs/mosaic/engram-app/src/EngramApp.dark.msl
+++ b/code/programs/mosaic/engram-app/src/EngramApp.dark.msl
@@ -2,8 +2,10 @@
 
 style EngramApp {
   part app-shell {
-    background : "#101827" ;
-    padding    : 24 ;
+    background  : "#101827" ;
+    color       : "#f8fafc" ;
+    font-family : "system-ui, sans-serif" ;
+    padding     : 24 ;
   }
 
   part app-title {

--- a/code/programs/mosaic/engram-app/tests/package_compiles.rs
+++ b/code/programs/mosaic/engram-app/tests/package_compiles.rs
@@ -666,6 +666,14 @@ fn native_project_shells_expose_engram_host_contract() {
     let html_host =
         fs::read_to_string(tmp.path().join("html").join("engram-host.mjs")).expect("html host");
     assert_contains(&html_host, "engram_engine.wasm");
+    assert_contains(
+        &html_host,
+        "const HOST_READY_EVENT = \"mosaic-host-ready\";",
+    );
+    assert_contains(
+        &html_host,
+        "window.dispatchEvent(new CustomEvent(HOST_READY_EVENT));",
+    );
 
     let webcomponent_index = fs::read_to_string(tmp.path().join("webcomponent").join("index.html"))
         .expect("webcomponent/index.html");
@@ -740,6 +748,14 @@ fn native_project_shells_expose_engram_host_contract() {
         fs::read_to_string(tmp.path().join("webcomponent").join("engram-host.mjs"))
             .expect("webcomponent host");
     assert_contains(&webcomponent_host, "engram_engine.wasm");
+    assert_contains(
+        &webcomponent_host,
+        "const HOST_READY_EVENT = \"mosaic-host-ready\";",
+    );
+    assert_contains(
+        &webcomponent_host,
+        "window.dispatchEvent(new CustomEvent(HOST_READY_EVENT));",
+    );
 
     let react_app = fs::read_to_string(tmp.path().join("react").join("src").join("main.tsx"))
         .expect("react/src/main.tsx");
@@ -835,6 +851,14 @@ fn native_project_shells_expose_engram_host_contract() {
             .expect("react host");
     assert_contains(&react_host, "installEngramMosaicHost");
     assert_contains(&react_host, "engram_engine.wasm");
+    assert_contains(
+        &react_host,
+        "const HOST_READY_EVENT = \"mosaic-host-ready\";",
+    );
+    assert_contains(
+        &react_host,
+        "window.dispatchEvent(new CustomEvent(HOST_READY_EVENT));",
+    );
     assert!(
         tmp.path()
             .join("react")


### PR DESCRIPTION
## Summary

- normalize unitless mosstyle numeric values so HTML/WebComponent CSS emits `px` for browser length properties while React inline styles emit real numeric literals
- dispatch `mosaic-host-ready` from the Engram web hosts so the React demo refreshes from the WASM Mosaic host instead of staying on fallback sample props
- give the Engram app shell inherited foreground color and a system font so generated web demos are readable on the dark theme

## Root cause

The generated demos were mostly structurally present, but several style values were invalid for their target runtime. HTML/WebComponent output contained declarations such as `padding: 24`, which browsers ignore for length-valued CSS properties, while React output quoted numeric inline-style values such as `padding: "24"`, which React treats as unitless strings. The React shell also waited for a `mosaic-host-ready` event that the Engram host never fired, so it could remain stuck on generated sample data.

## Validation

- `cargo test -p mosaic-emit-react -p mosaic-emit-html -p mosaic-emit-webcomponent`
- `cargo test` in `code/programs/mosaic/engram-app`
- `code/programs/mosaic/engram-app/scripts/build-all.ps1`
- `npm run build` in generated React app
- `npm run build` in generated Electron app
- served and checked generated React, HTML, and WebComponent demos locally on ports 5173, 5174, and 5175
- captured Edge screenshots for React, HTML, and WebComponent demos