### PR TITLE
[codex] Track nested document.write repair evidence

### DIFF
--- a/code/packages/rust/html-parser/tests/whatwg_head_body_audit_test.rs
+++ b/code/packages/rust/html-parser/tests/whatwg_head_body_audit_test.rs
@@ -9,6 +9,7 @@ const WHATWG_HEAD_BODY_AUDIT: &str = include_str!("fixtures/whatwg-head-body-aud
 const POST_PARSE_REPAIR_EVIDENCE: &[(&str, &str)] = &[
     ("scripted-adoption01-dat-1", "head-text-mode"),
     ("scripted-webkit01-dat-1", "head-text-mode"),
+    ("scripted-webkit01-dat-2", "head-text-mode"),
     ("tests26-dat-1251", "body-boundary"),
     ("tricky01-dat-3", "body-boundary"),
 ];


### PR DESCRIPTION
## Summary
- add `scripted-webkit01-dat-2` to the head/body post-parse repair evidence set
- keep the case tied to the `head-text-mode` audit axis so nested scripted document.write replay stays executable

## Evidence
- Negative control: temporarily disabled only the nested `scripted_document_write_nodes` match arm for `document.write(\"<script>document.write('2')</scr\"+ ...)`.
- Result: `cargo test -p coding-adventures-html-parser whatwg_head_body_audit_cases_match_parser_dom_dump` failed on `scripted-webkit01-dat-2`; the inserted `script` nodes plus `\"2\"` and `\"34\"` text disappeared from the DOM dump.
- Restored the parser hook before final validation; final diff is the single evidence-list addition.

## Validation
- `cargo test -p coding-adventures-html-parser font_newline_before_bold_stays_outside_reconstructed_font`
- `cargo test -p coding-adventures-html-parser whatwg_document_shell_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_head_body_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_form_interactive_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_legacy_element_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_paragraph_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_block_boundary_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_table_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_formatting_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_document_shell_audit_cases_match_parser_dom_dump`
- `cargo test -p coding-adventures-html-parser whatwg_head_body_audit_cases_match_parser_dom_dump`
- `cargo test -p coding-adventures-html-parser whatwg_formatting_audit_cases_match_parser_dom_dump`
- `cargo test -p coding-adventures-html-parser whatwg_paragraph_audit_cases_match_parser_dom_dump`
- `cargo test -p coding-adventures-html-parser whatwg_block_boundary_audit_cases_match_parser_dom_dump`
- `cargo test -p coding-adventures-html-parser html5lib_tree_construction_smoke_cases_match_dom_dump`
- `cargo test -p coding-adventures-html-parser`
- `cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser`
- `python3 -m json.tool code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json >/dev/null`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py`
- `git diff --check`