### PR TITLE
feat(unicode-math): PR-2 — big operators + explicit ASCII scripts

### DIFF
--- a/code/packages/rust/unicode-math/CHANGELOG.md
+++ b/code/packages/rust/unicode-math/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to the unicode-math pluggable frontend.
 
+## [0.2.0] — 2026-06-30
+
+### Added — PR-2: big operators + explicit ASCII scripts
+
+- **Big operators** `∑ ∏ ∫ ∮ ∐` → `MathExpr::BigOp { op, lower, upper, body }`, with optional
+  lower/upper bounds and a one-atom body (the same "one atom argument" rule as roots, so `∑ x + 1`
+  is `(∑ x) + 1`). `capabilities()` now declares `big_operators` (enforced by the conformance harness).
+- **Explicit ASCII script operators** `^` and `_` — the twins of the Unicode superscript/subscript
+  glyphs, so `x^2` ≡ `x²` and `a_i` parses as a subscript. These also express big-operator bounds:
+  `∑_(i=1)^n i` → `BigOp{Sum, lower:(i=1), upper:n, body:i}`, `∫_a^b f`. Bounds may equally be written
+  with a Unicode sub/superscript glyph (a numeral). A big operator with no body is a clean spanned
+  error (never a panic), exactly as before.
+- Tokenizer gains the five big-operator glyphs (carrying their canonical `BigOp` name) plus `Caret`
+  /`Underscore` tokens; the parser maps them via `bigop_of` and extends `parse_script` + the
+  big-operator atom with the bound loop (mirroring the AsciiMath frontend). `MAX_DEPTH`, the
+  loop-built chains, and `#![forbid(unsafe_code)]` are unchanged.
+- 26 unit + 1 doc test pass (new `big_operators_and_explicit_scripts`, `big_operators_with_bounds`,
+  `ascii_scripts_match_unicode_glyphs`; conformance corpus gains `∑_(i=1)^n i`, `∫_a^b f`, `∏ x`,
+  `x^2`); clippy `-D warnings` clean. **Out of scope (PR-3):** named functions, matrices, `\text`.
+
 ## [0.1.0] — 2026-06-30
 
 ### Added — PFE01 frontend #3: a Unicode plain-math reader

--- a/code/packages/rust/unicode-math/Cargo.toml
+++ b/code/packages/rust/unicode-math/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unicode-math"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "A Unicode plain-math parser that implements the math-frontend MathFrontend trait: turns the math people and models actually type (x² + y² = r², √x, ½, π·α, a ≤ b) into the neutral MathExpr AST. The third pluggable frontend after LaTeX and AsciiMath (see PFE01). Total, panic-free, spanned errors."
 license = "MIT"

--- a/code/packages/rust/unicode-math/README.md
+++ b/code/packages/rust/unicode-math/README.md
@@ -16,8 +16,9 @@ ASCII syntax (AsciiMath), and raw Unicode.
 | `42`, `3.14`, `6.022e23` | `Number` (exact — never `f64`) |
 | `x`, `π`, `Σ`, `∞` | `Symbol` (`π`→`pi`, `Σ`→`Sigma`, `∞`→`infinity`) |
 | `xy`, `2x`, `πα` | `Bin(Mul)` (juxtaposition ⇒ implicit `·`) |
-| `x²`, `x⁻¹`, `x¹⁰` | `Bin(Pow)` (Unicode superscripts) |
-| `a₁`, `a₁²` | `Subscript` / `Pow(Subscript)` |
+| `x²`, `x⁻¹`, `x¹⁰`, `x^2` | `Bin(Pow)` (Unicode superscripts **or** the ASCII `^` operator) |
+| `a₁`, `a₁²`, `a_i` | `Subscript` / `Pow(Subscript)` (Unicode glyph **or** ASCII `_`) |
+| `∑_(i=1)^n i`, `∫_a^b f`, `∏ x` | `BigOp { op, lower, upper, body }` (`∑ ∏ ∫ ∮ ∐`) |
 | `1/2`, `½`, `⅔` | `Frac` (built-up **and** vulgar-fraction glyphs) |
 | `√x`, `∛x`, `∜x` | `Root { degree, radicand }` |
 | `a + b`, `a − b`, `a × b`, `a ⋅ b`, `a ÷ b` | `Bin(Add/Sub/Mul/Div)` |
@@ -51,7 +52,8 @@ dependency cycle); a consumer registers it.
 
 ## Scope
 
-PR-1 covers the surface in the table above. **Out of scope** (a clean spanned error, never a
-panic — tracked for PR-2): big operators (`∑ ∏ ∫`), named functions (`sin`, `log`), matrices,
-and embedded `\text`. As in AsciiMath there are no multi-letter variables: a letter run like
-`xy` is the product `x·y` (write distinct symbols, or use Greek/constant glyphs).
+PR-1 covered numbers/symbols/scripts/fractions/roots/relations/±∓; **PR-2** adds the big operators
+`∑ ∏ ∫ ∮ ∐` (with optional bounds) and the explicit ASCII script operators `^`/`_`. **Out of scope**
+(a clean spanned error, never a panic — tracked for PR-3): named functions (`sin`, `log`), matrices,
+and embedded `\text`. As in AsciiMath there are no multi-letter variables: a letter run like `xy`
+is the product `x·y` (write distinct symbols, or use Greek/constant glyphs).

--- a/code/packages/rust/unicode-math/src/lib.rs
+++ b/code/packages/rust/unicode-math/src/lib.rs
@@ -14,12 +14,14 @@
 //! [`capabilities`](MathFrontend::capabilities) match what it emits — enforced by the shared
 //! `check_frontend` harness).
 //!
-//! ## What it covers (PR-1)
+//! ## What it covers
 //! Numbers (exact); single-letter variables and Greek/constant glyphs (`π`→`pi`, `Σ`→`Sigma`,
 //! `∞`→`infinity`); `+ − × ⋅ ÷ ±  ∓` and juxtaposition (implicit `·`); built-up `a/b` and the
-//! vulgar fractions `½ ⅓ ¼ …`; the roots `√`, `∛`, `∜`; Unicode super/subscripts (`x²`, `a₁`,
-//! `x⁻¹`); and the relations `= ≠ < ≤ > ≥ ≈ ≡`. Out of scope for PR-1 (a clean spanned error,
-//! never a panic), tracked for PR-2: big operators (`∑ ∏ ∫`), named functions, matrices, `\text`.
+//! vulgar fractions `½ ⅓ ¼ …`; the roots `√`, `∛`, `∜`; super/subscripts written either as
+//! Unicode glyphs (`x²`, `a₁`, `x⁻¹`) or with the explicit ASCII operators `^`/`_` (`x^2` ≡ `x²`);
+//! the **big operators** `∑ ∏ ∫ ∮ ∐` with optional lower/upper bounds (PR-2, e.g. `∑_(i=1)^n i`);
+//! and the relations `= ≠ < ≤ > ≥ ≈ ≡`. Out of scope (a clean spanned error, never a panic),
+//! tracked for PR-3: named functions (`sin`, `log`), matrices, `\text`.
 //!
 //! ```
 //! use unicode_math::UnicodeMath;
@@ -59,10 +61,11 @@ impl MathFrontend for UnicodeMath {
     }
 
     fn capabilities(&self) -> Capabilities {
-        // PR-1 surface. `fractions` covers both `a/b` and the vulgar-fraction glyphs; `powers`
-        // covers Unicode superscripts; `plusminus` covers `±`/`∓`. `functions`, `big_operators`,
-        // `matrices`, and `text` are PR-2 — declared OFF so the conformance harness holds us
-        // honest. (Subscripts need no flag: `Subscript` is not a gated capability.)
+        // `fractions` covers both `a/b` and the vulgar-fraction glyphs; `powers` covers Unicode
+        // superscripts and the ASCII `^` operator; `plusminus` covers `±`/`∓`; `big_operators`
+        // covers `∑ ∏ ∫ ∮ ∐` (PR-2). `functions`, `matrices`, and `text` are PR-3 — declared OFF
+        // so the conformance harness holds us honest. (Subscripts need no flag: `Subscript` is
+        // not a gated capability.)
         Capabilities::none()
             .with_fractions()
             .with_roots()
@@ -70,6 +73,7 @@ impl MathFrontend for UnicodeMath {
             .with_relations()
             .with_implicit_mul()
             .with_plusminus()
+            .with_big_operators()
     }
 }
 
@@ -170,6 +174,46 @@ mod tests {
         assert_eq!(p("a ≥ b"), MathExpr::Rel(RelOp::Ge, Box::new(sym("a")), Box::new(sym("b"))));
     }
 
+    // ---- big operators + explicit scripts (PR-2) -------------------------------
+    #[test]
+    fn big_operators_with_bounds() {
+        use math_frontend::BigOp;
+        // ∑_(i=1)^n i ⇒ BigOp{Sum, lower:(i=1), upper:n, body:i}
+        let lower = MathExpr::Rel(RelOp::Eq, Box::new(sym("i")), Box::new(num(1)));
+        assert_eq!(
+            p("∑_(i=1)^n i"),
+            MathExpr::BigOp {
+                op: BigOp::Sum,
+                lower: Some(Box::new(lower)),
+                upper: Some(Box::new(sym("n"))),
+                body: Box::new(sym("i")),
+            }
+        );
+        // ∫_a^b f — integral with both bounds.
+        assert_eq!(
+            p("∫_a^b f"),
+            MathExpr::BigOp {
+                op: BigOp::Int,
+                lower: Some(Box::new(sym("a"))),
+                upper: Some(Box::new(sym("b"))),
+                body: Box::new(sym("f")),
+            }
+        );
+        // ∏ x — bare body, no bounds.
+        assert_eq!(
+            p("∏ x"),
+            MathExpr::BigOp { op: BigOp::Prod, lower: None, upper: None, body: Box::new(sym("x")) }
+        );
+    }
+
+    #[test]
+    fn ascii_scripts_match_unicode_glyphs() {
+        // The explicit ASCII `^`/`_` operators are twins of the Unicode super/subscript glyphs.
+        assert_eq!(p("x^2"), p("x²"));
+        assert_eq!(p("x^2"), b(BinOp::Pow, sym("x"), num(2)));
+        assert_eq!(p("a_i"), MathExpr::Subscript(Box::new(sym("a")), Box::new(sym("i"))));
+    }
+
     #[test]
     fn a_realistic_expression() {
         // x² + y² = r²
@@ -210,8 +254,9 @@ mod tests {
         assert_eq!(UnicodeMath.name(), "unicode-math");
         let c = UnicodeMath.capabilities();
         assert!(c.fractions && c.roots && c.powers && c.relations && c.implicit_mul && c.plusminus);
-        // PR-1 does NOT do these yet — declared off so the harness holds us honest.
-        assert!(!c.functions && !c.big_operators && !c.matrices && !c.text);
+        assert!(c.big_operators); // PR-2: ∑ ∏ ∫ ∮ ∐
+        // PR-3 still to come — declared off so the harness holds us honest.
+        assert!(!c.functions && !c.matrices && !c.text);
         assert!(!c.binomials && !c.accents && !c.oversets);
     }
 
@@ -234,9 +279,13 @@ mod tests {
                 "a ∓ b",
                 "(a + b)/(c − d)",
                 "x⁻¹",
+                "∑_(i=1)^n i",  // big operator with ASCII-script bounds (PR-2)
+                "∫_a^b f",      // integral with bounds
+                "∏ x",          // big operator, bare body
+                "x^2",          // ASCII `^` ≡ Unicode `x²`
                 "1 +",   // error: trailing operator
                 "(x",    // error: missing close
-                "∑",     // error: out-of-scope glyph (PR-2)
+                "∑",     // error: big operator with no body
                 "",      // error: empty
             ],
         );

--- a/code/packages/rust/unicode-math/src/parser.rs
+++ b/code/packages/rust/unicode-math/src/parser.rs
@@ -22,7 +22,7 @@
 //!   parser stack.
 
 use crate::token::{tokenize, Token, TokenKind};
-use math_frontend::{BinOp, FrontendError, MathExpr, Number, RelOp, UnaryOp};
+use math_frontend::{BigOp, BinOp, FrontendError, MathExpr, Number, RelOp, UnaryOp};
 
 /// Maximum *nesting* depth before refusing with a spanned error (never overflow). Kept well
 /// below what would exhaust a test-thread stack so the guard fires before the stack does.
@@ -161,14 +161,30 @@ impl Parser<'_> {
 
     fn parse_script(&mut self) -> Result<MathExpr, FrontendError> {
         let mut base = self.parse_atom()?;
-        // subscript then superscript (`a₁²` ⇒ (a₁)²), each at most once — the natural reading.
-        if let TokenKind::Sub(s) = self.peek().clone() {
-            self.advance();
-            base = MathExpr::Subscript(Box::new(base), Box::new(self.numeral(&s)?));
+        // Subscript then superscript (`a₁²` ⇒ (a₁)²), each at most once — the natural reading.
+        // Either form is accepted: a Unicode glyph run (a numeral, e.g. `₁`/`²`) or the explicit
+        // ASCII operator (`_`/`^`) whose operand is the next single atom (`a_i`, `x^2` ≡ `x²`).
+        match self.peek().clone() {
+            TokenKind::Sub(s) => {
+                self.advance();
+                base = MathExpr::Subscript(Box::new(base), Box::new(self.numeral(&s)?));
+            }
+            TokenKind::Underscore => {
+                self.advance();
+                base = MathExpr::Subscript(Box::new(base), Box::new(self.parse_atom()?));
+            }
+            _ => {}
         }
-        if let TokenKind::Super(s) = self.peek().clone() {
-            self.advance();
-            base = MathExpr::Bin(BinOp::Pow, Box::new(base), Box::new(self.numeral(&s)?));
+        match self.peek().clone() {
+            TokenKind::Super(s) => {
+                self.advance();
+                base = MathExpr::Bin(BinOp::Pow, Box::new(base), Box::new(self.numeral(&s)?));
+            }
+            TokenKind::Caret => {
+                self.advance();
+                base = MathExpr::Bin(BinOp::Pow, Box::new(base), Box::new(self.parse_atom()?));
+            }
+            _ => {}
         }
         Ok(base)
     }
@@ -190,6 +206,7 @@ impl Parser<'_> {
                 | TokenKind::VulgarFrac(_, _)
                 | TokenKind::Sqrt
                 | TokenKind::RootN(_)
+                | TokenKind::Big(_)
                 | TokenKind::LParen
                 | TokenKind::LBracket
                 | TokenKind::LBrace
@@ -230,8 +247,43 @@ impl Parser<'_> {
                     radicand: Box::new(self.parse_atom()?),
                 })
             }
+            TokenKind::Big(name) => {
+                // A big operator (`∑ ∏ ∫ ∮ ∐`) with optional lower/upper bounds and a body.
+                // Bounds attach to the operator itself (consumed here, before parse_script sees
+                // any script), written either with ASCII `_`/`^` (a full atom each, so
+                // `∑_(i=1)^n`) or with a Unicode sub/superscript glyph (a numeral). The body is
+                // the next single atom — the same "one atom argument" rule used by roots, so
+                // `∑ x + 1` is `(∑ x) + 1`.
+                self.advance();
+                let op = bigop_of(&name);
+                let mut lower: Option<Box<MathExpr>> = None;
+                let mut upper: Option<Box<MathExpr>> = None;
+                loop {
+                    match self.peek().clone() {
+                        TokenKind::Underscore if lower.is_none() => {
+                            self.advance();
+                            lower = Some(Box::new(self.parse_atom()?));
+                        }
+                        TokenKind::Sub(s) if lower.is_none() => {
+                            self.advance();
+                            lower = Some(Box::new(self.numeral(&s)?));
+                        }
+                        TokenKind::Caret if upper.is_none() => {
+                            self.advance();
+                            upper = Some(Box::new(self.parse_atom()?));
+                        }
+                        TokenKind::Super(s) if upper.is_none() => {
+                            self.advance();
+                            upper = Some(Box::new(self.numeral(&s)?));
+                        }
+                        _ => break,
+                    }
+                }
+                let body = self.parse_atom()?;
+                Ok(MathExpr::BigOp { op, lower, upper, body: Box::new(body) })
+            }
             TokenKind::LParen | TokenKind::LBracket | TokenKind::LBrace => self.parse_group(),
-            _ => Err(self.error_here("expected a number, symbol, root, or '('")),
+            _ => Err(self.error_here("expected a number, symbol, root, big operator, or '('")),
         }
     }
 
@@ -247,6 +299,19 @@ impl Parser<'_> {
             }
             _ => Err(self.error_here("expected a closing bracket")),
         }
+    }
+}
+
+/// The neutral [`BigOp`] for a big-operator glyph's canonical name. The tokenizer only ever
+/// emits the five known names, so `Other` is a defensive fallback (never reached in practice).
+fn bigop_of(name: &str) -> BigOp {
+    match name {
+        "sum" => BigOp::Sum,
+        "prod" => BigOp::Prod,
+        "int" => BigOp::Int,
+        "oint" => BigOp::Oint,
+        "coprod" => BigOp::Coprod,
+        _ => BigOp::Other(name.to_string()),
     }
 }
 

--- a/code/packages/rust/unicode-math/src/token.rs
+++ b/code/packages/rust/unicode-math/src/token.rs
@@ -67,6 +67,14 @@ pub enum TokenKind {
     Approx,
     /// `≡` — identically equal.
     Equiv,
+    /// `^` — explicit superscript / power operator (the ASCII twin of the Unicode superscript
+    /// glyphs, so `x^2` ≡ `x²`; needed for big-operator upper bounds like `∑_(i=1)^n`).
+    Caret,
+    /// `_` — explicit subscript operator (`a_i`; big-operator lower bounds).
+    Underscore,
+    /// A big operator glyph — `∑ ∏ ∫ ∮ ∐` — carrying its canonical [`BigOp`] name
+    /// (`"sum"`, `"prod"`, `"int"`, `"oint"`, `"coprod"`).
+    Big(String),
     LParen,
     RParen,
     LBracket,
@@ -220,6 +228,13 @@ pub fn tokenize(src: &str) -> Result<Vec<Token>, FrontendError> {
             '√' => TokenKind::Sqrt,
             '∛' => TokenKind::RootN(3),
             '∜' => TokenKind::RootN(4),
+            '^' => TokenKind::Caret,
+            '_' => TokenKind::Underscore,
+            '∑' => TokenKind::Big("sum".into()),
+            '∏' => TokenKind::Big("prod".into()),
+            '∫' => TokenKind::Big("int".into()),
+            '∮' => TokenKind::Big("oint".into()),
+            '∐' => TokenKind::Big("coprod".into()),
             '=' => TokenKind::Eq,
             '≠' => TokenKind::Ne,
             '<' => TokenKind::Lt,
@@ -345,10 +360,23 @@ mod tests {
     }
 
     #[test]
+    fn big_operators_and_explicit_scripts() {
+        // PR-2: big-operator glyphs carry their canonical BigOp name.
+        assert_eq!(kinds("∑")[0], TokenKind::Big("sum".into()));
+        assert_eq!(kinds("∏")[0], TokenKind::Big("prod".into()));
+        assert_eq!(kinds("∫")[0], TokenKind::Big("int".into()));
+        // ASCII `^`/`_` are explicit script operators (twins of the Unicode glyphs).
+        assert_eq!(kinds("x^2"), vec![
+            TokenKind::Sym("x".into()), TokenKind::Caret, TokenKind::Num("2".into()), TokenKind::Eof,
+        ]);
+        assert_eq!(kinds("a_i")[1], TokenKind::Underscore);
+    }
+
+    #[test]
     fn errors_are_spanned_not_panics() {
-        // An out-of-scope glyph (∑ is PR-2) is a clean spanned error, never a panic.
-        let e = tokenize("∑").unwrap_err();
+        // An out-of-scope glyph (⊗ is not handled) is a clean spanned error, never a panic.
+        let e = tokenize("⊗").unwrap_err();
         assert_eq!(e.frontend, "unicode-math");
-        assert!(e.span.0 <= e.span.1 && e.span.1 <= "∑".len());
+        assert!(e.span.0 <= e.span.1 && e.span.1 <= "⊗".len());
     }
 }

--- a/code/specs/PFE01-pluggable-parser-frontends.md
+++ b/code/specs/PFE01-pluggable-parser-frontends.md
@@ -147,8 +147,9 @@ frontend additionally ships notation-specific golden tests.
 - `unicode-math` — the **third** frontend: Unicode plain math as people and models type it
   (`x² + y² = r²`, `√x`, `½`, `π·α`, `a ≤ b`). A small crate implementing the trait; its Greek /
   constant glyphs canonicalize to the same `Symbol` names as AsciiMath, so the notations agree on
-  one neutral string. PR-1 covers numbers/symbols/super-&-subscripts/fractions/roots/relations
-  /implicit-mul/±∓; big operators, named functions, matrices, and `\text` are PR-2.
+  one neutral string. Covers numbers/symbols/super-&-subscripts (Unicode glyphs *and* ASCII
+  `^`/`_`)/fractions/roots/relations/implicit-mul/±∓ and the big operators `∑ ∏ ∫ ∮ ∐` (PR-2);
+  named functions, matrices, and `\text` are PR-3.
 - Future: `mathml`, MathJSON, content-MathML, spreadsheet formulae, … each a small crate
   implementing the trait. None require changes to consumers. **Three frontends now in (LaTeX,
   AsciiMath, Unicode), all feeding one neutral AST with zero consumer change** — the pluggability


### PR DESCRIPTION
## What

Extends the Unicode plain-math frontend ([shipped PR-1, #7008](https://github.com/adhithyan15/coding-adventures/pull/7008)) toward parity:

- **Big operators** `∑ ∏ ∫ ∮ ∐` → `MathExpr::BigOp { op, lower, upper, body }`, with optional bounds and a one-atom body (same rule as roots, so `∑ x + 1` is `(∑ x) + 1`). `capabilities()` now declares `big_operators`.
- **Explicit ASCII script operators** `^` and `_` — twins of the Unicode super/subscript glyphs, so `x^2` ≡ `x²` and `a_i` is a subscript. These express big-operator bounds: `∑_(i=1)^n i` → `BigOp{Sum, lower:(i=1), upper:n, body:i}`, `∫_a^b f`. A bound may equally be a Unicode sub/superscript glyph (numeral).

## How

The tokenizer gains the five big-op glyphs (carrying their canonical `BigOp` name) plus `Caret`/`Underscore` tokens; the parser maps them via `bigop_of` and extends `parse_script` + a `Big` atom with a bounded bound-loop, **mirroring the AsciiMath frontend**. A big operator with no body is a clean spanned error (never a panic). `MAX_DEPTH`, the loop-built chains, and `#![forbid(unsafe_code)]` are unchanged.

## Gates

- **26 unit + 1 doc test** pass (new `big_operators_and_explicit_scripts`, `big_operators_with_bounds`, `ascii_scripts_match_unicode_glyphs`; conformance corpus gains `∑_(i=1)^n i`, `∫_a^b f`, `∏ x`, `x^2`); clippy `-D warnings` clean; `#![forbid(unsafe_code)]`.
- `/security-review` **PASSED** (bound loop provably terminates — each iteration consumes a token or breaks; all bounds/body recursion is `MAX_DEPTH`-charged; char-boundary-safe spans on the multi-byte glyphs; no new arithmetic on input lengths).
- unicode-math **0.2.0**. Spec `PFE01-pluggable-parser-frontends.md` updated. **PR-3** = named functions / matrices / `\text`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)