### PR TITLE
feat(sir-js): SIR16 v1 parity for the JavaScript backend (D4)

### DIFF
--- a/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
@@ -5,6 +5,66 @@ All notable changes to `semantic-ir-to-javascript` are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.0 — D4 (completes SIR16 / v1 parity for the JS backend)
+
+Brings the JavaScript backend to **full SIR16 / v1 parity**: the six
+SIR16 features it previously deferred are now emitted and accepted.
+JavaScript supports all of them natively, so each lowering is direct.
+
+### Added
+
+- `accepts_features()` now declares the v0 surface **plus all of SIR16**:
+  `Floats`, `ShortCircuit`, `Sequences`, `Maps`, `MutableBindings`,
+  `Loops`. (`accepts_intrinsics()` stays empty.)
+- Emit arms for every SIR16 node:
+  - `Floats` — `FloatLit` emits a native `number` literal (already wired
+    in D1; the `Floats` capability is now accepted). `NaN`/`Infinity`/
+    `-Infinity` spelled out; integer-valued floats keep an explicit `.0`.
+  - `ShortCircuit` — `LogicalAnd`/`LogicalOr` emit a truthy-guarded arrow
+    IIFE (`((__l) => __Sir.truthy(__l) ? (rhs) : __l)(lhs)` for And, the
+    mirror for Or) so the rhs runs only when the lhs decides, routing the
+    test through `__Sir.truthy` (only `false`/`nil` are falsy).
+  - `Sequences` — `SeqLit` → `[…]`, `SeqIndex` → `(arr)[i]`, `SeqLen` →
+    `(arr).length`, `SeqSet` → `(arr)[i] = v;` (native arrays).
+  - `Maps` — `MapLit` → `new Map([[k, v], …])`, `MapGet` →
+    `((m).get(k) ?? null)` (missing key reads as nil), `MapSet` →
+    `(m).set(k, v);` (native `Map`, matching the TypeScript backend's
+    representation).
+  - `MutableBindings` — `Assign` (Local/Param/Capture/Global) → a plain
+    `name = value;` reassignment. `let` (never `const`) is already the
+    keyword for every binding, so no const→let pre-pass is needed (unlike
+    the Rust/TypeScript backends).
+  - `Loops` — `While` → `while (__Sir.truthy(cond)) { … }`; `ForRange` →
+    a direction-aware C-style `for` with `stop`/`step` evaluated once into
+    block-scoped `__sir_stop_N`/`__sir_step_N` temporaries (a per-module
+    monotonic counter keeps them deterministic); `ForEach` → `for (let x
+    of iter) { … }`.
+- `emit_block_as_stmts` helper for loop bodies (trailing value discarded;
+  a bare `nil` value is dropped).
+- Unit tests for every new emit arm (floats incl. specials, short-circuit
+  And/Or, seq build/index/len, map lit/get, assign, seq-set, map-set,
+  while, for-range incl. distinct nested temporaries, for-each).
+- Integration tests (`tests/run_with_node.rs`) that hand-build SIR16
+  modules, emit JavaScript, **run it under `node`**, and assert stdout:
+  float arithmetic promotion (`3.5`), short-circuit (rhs not evaluated),
+  `or` first-truthy (`7`), sequence build/index/len/set, map
+  build/get/set (incl. missing-key → nil), a `while` counter, a
+  for-range accumulator (and a descending step), for-each over a
+  sequence, and mutable reassignment (`42`).
+
+### Still deferred (rejected at the capability check)
+
+- String interpolation — `StrConcat` (`StringInterpolation`).
+- OOP & exceptions — `ClassDef`/`ModuleDef`/`SingletonClassDef`,
+  `TryCatch`, and the `Instance`/`ClassVar`/`Const` scopes (`Classes`,
+  `Modules`, `InstanceVars`, `ClassVars`, `Constants`, `Exceptions`).
+- `TailCalls` (V8 has no reliable TCO) and `Intrinsics` (empty
+  whitelist).
+
+The remaining `panic!` arms in `emit` cover only these unaccepted nodes,
+so they are defence-in-depth (unreachable for a capability-checked
+module), never reachable for an accepted feature.
+
 ## 0.1.0 — D1 (initial runnable core)
 
 The first slice of the SIR18 JavaScript backend: the v0 expression /

--- a/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-javascript"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Semantic IR → self-contained JavaScript source code (SIR18). Fifth backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-javascript/README.md
+++ b/code/packages/rust/semantic-ir-to-javascript/README.md
@@ -60,24 +60,48 @@ let artifact = semantic_ir_to_javascript::JavaScriptBackend::new().compile(&modu
 
 ## Capability declaration
 
-This first milestone accepts exactly the **v0 feature set** — the
-surface that the emitter knows how to lower today:
+This backend accepts the **v0 feature set plus all of SIR16 / v1** — the
+surface the emitter lowers today. JavaScript supports every SIR16 feature
+natively (arrays, `Map`, `while`/`for`, reassignable `let`), so each
+lowering is direct.
 
-| Accepted (v0)              | Rejected (deferred / unsupported)            |
+| Accepted (v0 + SIR16)      | Rejected (deferred / unsupported)            |
 |----------------------------|----------------------------------------------|
-| `Closures`                 | `Floats`, `Sequences`, `Maps` (SIR16)        |
-| `Pairs`                    | `MutableBindings`, `Loops`, `ShortCircuit`   |
-| `Symbols`                  | `Classes`, `Modules`, `InstanceVars`, …      |
-| `Strings`                  | `Exceptions`, `StringInterpolation`          |
-| `DynamicTyping`            | `TailCalls` (V8 has no reliable TCO)         |
-| `OptionalTypeAnnotations`  | `Intrinsics` (empty whitelist)               |
+| `Closures`                 | `Classes`, `Modules`, `InstanceVars` (SIR17) |
+| `Pairs`                    | `ClassVars`, `Constants`, `Exceptions`       |
+| `Symbols`                  | `StringInterpolation` (`StrConcat`, SIR18)   |
+| `Strings`                  | `TailCalls` (V8 has no reliable TCO)         |
+| `DynamicTyping`            | `Intrinsics` (empty whitelist)               |
+| `OptionalTypeAnnotations`  |                                              |
 | `MutualRecursion`          |                                              |
 | `Globals`                  |                                              |
+| `Floats` (SIR16)           |                                              |
+| `ShortCircuit` (SIR16)     |                                              |
+| `Sequences` (SIR16)        |                                              |
+| `Maps` (SIR16)             |                                              |
+| `MutableBindings` (SIR16)  |                                              |
+| `Loops` (SIR16)            |                                              |
 
 `accepts_intrinsics()` is empty. The accept-set is deliberately matched
 to what `emit` handles, so a module using a deferred node is turned away
-*before* lowering rather than mis-compiled. Later milestones widen the
-set as the matching emit arms land.
+*before* lowering rather than mis-compiled — and every accepted feature
+has a real emit arm (the residual `panic!` guards cover only the
+rejected SIR17/18 nodes).
+
+### SIR16 lowering at a glance
+
+| SIR16 node                       | JavaScript emitted                              |
+|----------------------------------|-------------------------------------------------|
+| `FloatLit`                       | native `number` (`NaN`/`Infinity` spelled out)  |
+| `LogicalAnd` / `LogicalOr`       | `((__l) => __Sir.truthy(__l) ? … : …)(lhs)`     |
+| `SeqLit` / `SeqIndex` / `SeqLen` | `[…]` / `(a)[i]` / `(a).length`                 |
+| `SeqSet`                         | `(a)[i] = v;`                                    |
+| `MapLit` / `MapGet`              | `new Map([[k, v]])` / `((m).get(k) ?? null)`    |
+| `MapSet`                         | `(m).set(k, v);`                                |
+| `Assign`                         | `name = value;` (`let` bindings are mutable)    |
+| `While`                          | `while (__Sir.truthy(cond)) { … }`              |
+| `ForRange`                       | direction-aware C-style `for` (bounds once)     |
+| `ForEach`                        | `for (let x of iter) { … }`                     |
 
 ## Runtime shape (inlined `__Sir`)
 
@@ -172,8 +196,12 @@ cargo test -p semantic-ir-to-javascript
 - Unit tests for `sanitize_ident`, string quoting, float formatting, and
   every emit arm.
 - A determinism test (two compilations are byte-identical).
-- An end-to-end integration test (`tests/run_with_node.rs`) that lowers a
-  Twig program via `twig-to-semantic-ir`, emits JavaScript to a unique
-  temp file, **runs it with `node`**, and asserts stdout (add → `3`,
-  factorial → `120`, closure-adder → `8`). When `node` is not on PATH the
-  execution is skipped and the syntactic checks still run.
+- End-to-end integration tests (`tests/run_with_node.rs`) that emit
+  JavaScript to a unique temp file, **run it with `node`**, and assert
+  stdout. Twig-lowered programs cover the v0 core (add → `3`, factorial →
+  `120`, closure-adder → `8`); hand-built SIR16 modules cover float
+  arithmetic promotion (`3.5`), short-circuit (rhs not evaluated), seq
+  build/index/len/set, map build/get/set (missing key → nil), a `while`
+  counter, a for-range accumulator (and a descending step), for-each, and
+  mutable reassignment (`42`). When `node` is not on PATH the execution is
+  skipped and the syntactic checks still run.

--- a/code/packages/rust/semantic-ir-to-javascript/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/emit.rs
@@ -25,28 +25,65 @@
 //! - `MakeClosure` becomes `new __Sir.Closure((..._a) => fn(caps…, ..._a))`,
 //!   prepending the captured values ahead of the call's runtime args.
 //!
-//! ## Deferred nodes (this milestone)
+//! ## SIR16 nodes (this milestone, D4)
 //!
-//! Collections (`SeqLit`/`MapLit`/index/get/len), loops (`While`/
-//! `ForRange`/`ForEach`), indexed mutation (`SeqSet`/`MapSet`), mutable
-//! `Assign`, short-circuit (`LogicalAnd`/`LogicalOr`), string
-//! interpolation (`StrConcat`), and the OOP/exception scopes are **not
-//! emitted yet**.  Their `Feature`s are absent from the backend's
+//! As of D4 the emitter covers the **full SIR16 / v1 surface**, all of
+//! which JavaScript supports natively:
+//!
+//! - Floats (`FloatLit`) — native `number` (`NaN`/`Infinity` spelled out).
+//! - Short-circuit (`LogicalAnd`/`LogicalOr`) — a truthy-guarded arrow
+//!   IIFE so the rhs runs only when the lhs decides, routing the test
+//!   through `__Sir.truthy` (only `false`/`nil` are falsy).
+//! - Sequences (`SeqLit`/`SeqIndex`/`SeqLen`, `SeqSet`) — native arrays
+//!   (`[…]`, `a[i]`, `a.length`, `a[i] = v`).
+//! - Maps (`MapLit`/`MapGet`, `MapSet`) — native `Map` (`new Map([[k, v]])`,
+//!   `.get(k) ?? null`, `.set(k, v)`).
+//! - Mutable bindings (`Assign`) — a plain reassignment; `let` (not
+//!   `const`) is already the keyword for every binding, so no pre-pass is
+//!   needed (unlike the Rust/TypeScript backends).
+//! - Loops (`While`/`ForRange`/`ForEach`) — native `while`/`for`/
+//!   `for…of`, with the `while`/`for-range` tests routed through
+//!   `__Sir.truthy` and a direction-aware, once-evaluated `for-range`.
+//!
+//! ## Deferred nodes (still rejected at the capability check)
+//!
+//! String interpolation (`StrConcat`) and the SIR17/18 OOP/exception
+//! scopes (`ClassDef`/`ModuleDef`/`SingletonClassDef`, `TryCatch`, the
+//! `Instance`/`ClassVar`/`Const` scopes) and `Intrinsic` are **not
+//! emitted**.  Their `Feature`s are absent from the backend's
 //! `accepts_features()` list, so a module that uses them is rejected at
 //! the capability check *before* lowering — the `panic!` arms below are
 //! defence-in-depth that fire only on a backend bug (the accept-set
 //! drifting out of sync with what `emit` handles), never on user input.
 
+use std::cell::Cell;
 use std::fmt::Write;
 
 use semantic_ir::{Block, Expr, Function, Global, Module, ParamKind, Scope, Stmt};
 
 use crate::runtime::RUNTIME;
 
+thread_local! {
+    /// Monotonic counter for synthesised loop temporaries (the
+    /// once-evaluated `__sir_stop`/`__sir_step` bounds of a `ForRange`).
+    /// Reset at the start of every `emit_module` so output stays
+    /// deterministic regardless of how many modules a process compiles.
+    static LOOP_COUNTER: Cell<usize> = const { Cell::new(0) };
+}
+
+fn fresh_loop_id() -> usize {
+    LOOP_COUNTER.with(|c| {
+        let n = c.get();
+        c.set(n + 1);
+        n
+    })
+}
+
 /// Emit a SIR module as JavaScript source.  The caller is responsible
 /// for prior validation and capability checks; this function assumes
 /// the module is valid and uses only accepted features.
 pub fn emit_module(m: &Module) -> String {
+    LOOP_COUNTER.with(|c| c.set(0));
     let mut out = String::new();
     emit_banner(&mut out, m);
     // Strict mode goes first (after the banner comment) so the whole
@@ -163,9 +200,10 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
         // `let <name> = <value>;`.  Both `let` and `let*` bindings emit
         // a JS `let` — the lowerer already ordered `let*`'s sequential
         // dependencies, so a top-down emission is faithful.  We use
-        // `let` (not `const`) uniformly: this milestone does not accept
-        // mutable bindings, but a future `Assign` over a `let`-bound
-        // name must still type-check, and `let` is the safe default.
+        // `let` (not `const`) uniformly so a later `Assign` over the same
+        // name reassigns a mutable binding (the `MutableBindings` feature)
+        // without any const→let pre-pass — JS `let` is reassignable, so
+        // unlike the Rust/TypeScript backends this backend needs none.
         Stmt::LetBinding { name, value, .. } | Stmt::LetStarBinding { name, value, .. } => {
             let _ = write!(out, "{}let {} = ", pad, sanitize_ident(name));
             emit_expr(out, value, indent);
@@ -184,29 +222,107 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
                 out.push_str(";\n");
             }
         }
+        // ── SIR16: mutation (MutableBindings) ───────────────────────
+        // `Assign` re-binds an already-declared name.  Local/Param/
+        // Capture/Global all resolve to a bare identifier in JS (globals
+        // are module-level `let`s), so a plain reassignment is faithful.
+        // The Instance/ClassVar/Const scopes are SIR17 features this
+        // backend does not accept, so they fall through to the panic guard.
+        Stmt::Assign {
+            name,
+            scope: Scope::Local | Scope::Param | Scope::Capture | Scope::Global,
+            value,
+            ..
+        } => {
+            let _ = write!(out, "{}{} = ", pad, sanitize_ident(name));
+            emit_expr(out, value, indent);
+            out.push_str(";\n");
+        }
+        Stmt::Assign { scope, span, .. } => {
+            panic!(
+                "javascript backend reached a deferred `Assign` scope `{}` at {span} — not accepted yet",
+                scope.name()
+            );
+        }
+        // ── SIR16: loops (Loops) ────────────────────────────────────
+        // `while (truthy(cond)) { body }` — the test routes through SIR
+        // truthiness (only `false`/`nil` are falsy), never JS truthiness.
+        Stmt::While { cond, body, .. } => {
+            out.push_str(&pad);
+            out.push_str("while (__Sir.truthy(");
+            emit_expr(out, cond, indent);
+            out.push_str(")) {\n");
+            emit_block_as_stmts(out, body, indent + 2);
+            let _ = writeln!(out, "{pad}}}");
+        }
+        // `for (var = start; …; var += step) { body }` — half-open
+        // (`stop` exclusive).  `stop`/`step` are evaluated ONCE into
+        // block-scoped temporaries (matching Python's `range`), and the
+        // loop condition is direction-aware so a negative `step` counts
+        // down correctly.  JS has one numeric type, so no casts are
+        // needed (unlike the TypeScript backend's `as number`).
+        Stmt::ForRange { var, start, stop, step, body, .. } => {
+            let id = fresh_loop_id();
+            let v = sanitize_ident(var);
+            let inner = indent + 2;
+            let inner_pad = " ".repeat(inner);
+            // Open a block so the temporaries don't leak.
+            let _ = writeln!(out, "{pad}{{");
+            let _ = write!(out, "{inner_pad}let {v} = ");
+            emit_expr(out, start, inner);
+            out.push_str(";\n");
+            let _ = write!(out, "{inner_pad}const __sir_stop_{id} = ");
+            emit_expr(out, stop, inner);
+            out.push_str(";\n");
+            let _ = write!(out, "{inner_pad}const __sir_step_{id} = ");
+            emit_expr(out, step, inner);
+            out.push_str(";\n");
+            let _ = writeln!(
+                out,
+                "{inner_pad}while (__sir_step_{id} >= 0 ? {v} < __sir_stop_{id} : {v} > __sir_stop_{id}) {{"
+            );
+            emit_block_as_stmts(out, body, inner + 2);
+            let _ = writeln!(out, "{}{v} = {v} + __sir_step_{id};", " ".repeat(inner + 2));
+            let _ = writeln!(out, "{inner_pad}}}");
+            let _ = writeln!(out, "{pad}}}");
+        }
+        // `for (const var of iter) { body }` — iterate a Seq.  `let` is
+        // used so a body that reassigns the loop variable still works.
+        Stmt::ForEach { var, iter, body, .. } => {
+            let _ = write!(out, "{}for (let {} of ", pad, sanitize_ident(var));
+            emit_expr(out, iter, indent);
+            out.push_str(") {\n");
+            emit_block_as_stmts(out, body, indent + 2);
+            let _ = writeln!(out, "{pad}}}");
+        }
+        // ── SIR16: indexed assignment (Sequences / Maps) ────────────
+        // `seq[index] = value;` — native array element write.
+        Stmt::SeqSet { seq, index, value, .. } => {
+            out.push_str(&pad);
+            out.push('(');
+            emit_expr(out, seq, indent);
+            out.push_str(")[");
+            emit_expr(out, index, indent);
+            out.push_str("] = ");
+            emit_expr(out, value, indent);
+            out.push_str(";\n");
+        }
+        // `map.set(key, value);` — native `Map.set`.
+        Stmt::MapSet { map, key, value, .. } => {
+            out.push_str(&pad);
+            out.push('(');
+            emit_expr(out, map, indent);
+            out.push_str(").set(");
+            emit_expr(out, key, indent);
+            out.push_str(", ");
+            emit_expr(out, value, indent);
+            out.push_str(");\n");
+        }
         // ── Deferred (rejected at the capability check) ────────────
-        // The following statement kinds belong to SIR16/17 features this
-        // backend does not yet accept.  Reaching them means the
-        // accept-set drifted out of sync with `emit`; fail loudly rather
-        // than emit silently-wrong code.
-        Stmt::Assign { span, .. } => {
-            panic!("javascript backend reached a deferred `Assign` at {span} — not accepted yet");
-        }
-        Stmt::While { span, .. } => {
-            panic!("javascript backend reached a deferred `While` at {span} — not accepted yet");
-        }
-        Stmt::ForRange { span, .. } => {
-            panic!("javascript backend reached a deferred `ForRange` at {span} — not accepted yet");
-        }
-        Stmt::ForEach { span, .. } => {
-            panic!("javascript backend reached a deferred `ForEach` at {span} — not accepted yet");
-        }
-        Stmt::SeqSet { span, .. } => {
-            panic!("javascript backend reached a deferred `SeqSet` at {span} — not accepted yet");
-        }
-        Stmt::MapSet { span, .. } => {
-            panic!("javascript backend reached a deferred `MapSet` at {span} — not accepted yet");
-        }
+        // The following statement kinds belong to SIR17/18 features this
+        // backend does not accept.  Reaching them means the accept-set
+        // drifted out of sync with `emit`; fail loudly rather than emit
+        // silently-wrong code.
         Stmt::ClassDef { span, .. }
         | Stmt::ModuleDef { span, .. }
         | Stmt::SingletonClassDef { span, .. } => {
@@ -293,16 +409,71 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
             }
             out.push_str("..._a))");
         }
+        // ── SIR16: sequences (Sequences) — native arrays ──────────────
+        Expr::SeqLit { items, .. } => {
+            out.push('[');
+            emit_args(out, items, indent);
+            out.push(']');
+        }
+        Expr::SeqIndex { seq, index, .. } => {
+            out.push('(');
+            emit_expr(out, seq, indent);
+            out.push_str(")[");
+            emit_expr(out, index, indent);
+            out.push(']');
+        }
+        Expr::SeqLen { seq, .. } => {
+            out.push('(');
+            emit_expr(out, seq, indent);
+            out.push_str(").length");
+        }
+        // ── SIR16: maps (Maps) — native `Map` ─────────────────────────
+        Expr::MapLit { entries, .. } => {
+            out.push_str("new Map([");
+            for (i, entry) in entries.iter().enumerate() {
+                if i > 0 {
+                    out.push_str(", ");
+                }
+                out.push('[');
+                emit_expr(out, &entry.key, indent);
+                out.push_str(", ");
+                emit_expr(out, &entry.value, indent);
+                out.push(']');
+            }
+            out.push_str("])");
+        }
+        // `map.get(key) ?? null` — a missing key reads as nil (`null`),
+        // matching the spec's target-defined miss behaviour.
+        Expr::MapGet { map, key, .. } => {
+            out.push_str("((");
+            emit_expr(out, map, indent);
+            out.push_str(").get(");
+            emit_expr(out, key, indent);
+            out.push_str(") ?? null)");
+        }
+        // ── SIR16: short-circuit (ShortCircuit) ───────────────────────
+        // An arrow IIFE keeps the rhs unevaluated until the lhs decides,
+        // routing the test through SIR truthiness (only `false`/`nil` are
+        // falsy — not `0`/`""`).  The param `__l` gives each occurrence
+        // its own scope, so nested `&&`/`||` never collide.
+        Expr::LogicalAnd { lhs, rhs, .. } => {
+            out.push_str("((__l) => __Sir.truthy(__l) ? (");
+            emit_expr(out, rhs, indent);
+            out.push_str(") : __l)(");
+            emit_expr(out, lhs, indent);
+            out.push(')');
+        }
+        Expr::LogicalOr { lhs, rhs, .. } => {
+            out.push_str("((__l) => __Sir.truthy(__l) ? __l : (");
+            emit_expr(out, rhs, indent);
+            out.push_str("))(");
+            emit_expr(out, lhs, indent);
+            out.push(')');
+        }
         // ── Deferred expression kinds (rejected at capability check) ──
-        Expr::SeqLit { span, .. }
-        | Expr::SeqIndex { span, .. }
-        | Expr::SeqLen { span, .. }
-        | Expr::MapLit { span, .. }
-        | Expr::MapGet { span, .. }
-        | Expr::LogicalAnd { span, .. }
-        | Expr::LogicalOr { span, .. }
-        | Expr::StrConcat { span, .. } => {
-            panic!("javascript backend reached a deferred expression at {span} — not accepted yet");
+        // `StrConcat` (SIR18 string interpolation) is not accepted yet.
+        Expr::StrConcat { span, .. } => {
+            panic!("javascript backend reached a deferred `StrConcat` at {span} — not accepted yet");
         }
         Expr::Intrinsic { name, span, .. } => {
             // The v0 backend accepts no intrinsics; `check_module`
@@ -463,6 +634,24 @@ fn emit_block_as_expr(out: &mut String, b: &Block, indent: usize) {
     out.push_str(";\n");
     let opad = " ".repeat(indent);
     let _ = write!(out, "{opad}}})()");
+}
+
+/// Emit a block in **statement context** — used for loop bodies, whose
+/// trailing value is discarded rather than returned.  Each statement is
+/// emitted in order; the block's trailing `value` is emitted as an
+/// expression statement so any side effect still fires, except a bare
+/// `nil` (the common "this block yields nothing" marker), which is
+/// dropped to keep the output clean.
+fn emit_block_as_stmts(out: &mut String, b: &Block, indent: usize) {
+    for s in &b.stmts {
+        emit_stmt(out, s, indent);
+    }
+    if !matches!(b.value, Expr::NilLit { .. }) {
+        let pad = " ".repeat(indent);
+        out.push_str(&pad);
+        emit_expr(out, &b.value, indent);
+        out.push_str(";\n");
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -923,6 +1112,249 @@ mod tests {
         assert!(out.contains("let x = 1;"));
         assert!(out.contains("return x;"));
         assert!(out.trim_end().ends_with("})()"));
+    }
+
+    // ── SIR16 expressions ─────────────────────────────────────────
+
+    fn var(name: &str) -> Expr {
+        Expr::VarRef { name: name.into(), scope: Scope::Local, span: s() }
+    }
+
+    fn int(v: i64) -> Expr {
+        Expr::IntLit { value: v, span: s() }
+    }
+
+    #[test]
+    fn emit_float_lit_decimal_and_specials() {
+        assert_eq!(emit_e(&Expr::FloatLit { value: 3.0, span: s() }), "3.0");
+        assert_eq!(emit_e(&Expr::FloatLit { value: 2.5, span: s() }), "2.5");
+        assert_eq!(emit_e(&Expr::FloatLit { value: f64::INFINITY, span: s() }), "Infinity");
+        assert_eq!(
+            emit_e(&Expr::FloatLit { value: f64::NEG_INFINITY, span: s() }),
+            "-Infinity"
+        );
+        assert_eq!(emit_e(&Expr::FloatLit { value: f64::NAN, span: s() }), "NaN");
+    }
+
+    #[test]
+    fn emit_seq_lit_is_native_array() {
+        let seq = Expr::SeqLit { items: vec![int(1), int(2), int(3)], span: s() };
+        assert_eq!(emit_e(&seq), "[1, 2, 3]");
+        let empty = Expr::SeqLit { items: vec![], span: s() };
+        assert_eq!(emit_e(&empty), "[]");
+    }
+
+    #[test]
+    fn emit_seq_index_is_native_subscript() {
+        let e = Expr::SeqIndex {
+            seq: Box::new(var("xs")),
+            index: Box::new(int(0)),
+            span: s(),
+        };
+        assert_eq!(emit_e(&e), "(xs)[0]");
+    }
+
+    #[test]
+    fn emit_seq_len_is_native_length() {
+        let e = Expr::SeqLen { seq: Box::new(var("xs")), span: s() };
+        assert_eq!(emit_e(&e), "(xs).length");
+    }
+
+    #[test]
+    fn emit_map_lit_is_native_map() {
+        let e = Expr::MapLit {
+            entries: vec![
+                semantic_ir::nodes::MapEntry {
+                    key: Expr::StrLit { value: "a".into(), span: s() },
+                    value: int(1),
+                },
+                semantic_ir::nodes::MapEntry {
+                    key: Expr::StrLit { value: "b".into(), span: s() },
+                    value: int(2),
+                },
+            ],
+            span: s(),
+        };
+        assert_eq!(emit_e(&e), r#"new Map([["a", 1], ["b", 2]])"#);
+        let empty = Expr::MapLit { entries: vec![], span: s() };
+        assert_eq!(emit_e(&empty), "new Map([])");
+    }
+
+    #[test]
+    fn emit_map_get_uses_get_with_nil_default() {
+        let e = Expr::MapGet {
+            map: Box::new(var("d")),
+            key: Box::new(Expr::StrLit { value: "k".into(), span: s() }),
+            span: s(),
+        };
+        assert_eq!(emit_e(&e), r#"((d).get("k") ?? null)"#);
+    }
+
+    #[test]
+    fn emit_logical_and_short_circuits_via_truthy() {
+        let e = Expr::LogicalAnd {
+            lhs: Box::new(var("a")),
+            rhs: Box::new(var("b")),
+            span: s(),
+        };
+        assert_eq!(emit_e(&e), "((__l) => __Sir.truthy(__l) ? (b) : __l)(a)");
+    }
+
+    #[test]
+    fn emit_logical_or_short_circuits_via_truthy() {
+        let e = Expr::LogicalOr {
+            lhs: Box::new(var("a")),
+            rhs: Box::new(var("b")),
+            span: s(),
+        };
+        assert_eq!(emit_e(&e), "((__l) => __Sir.truthy(__l) ? __l : (b))(a)");
+    }
+
+    // ── SIR16 statements ──────────────────────────────────────────
+
+    fn emit_s(st: &Stmt) -> String {
+        let mut out = String::new();
+        emit_stmt(&mut out, st, 0);
+        out
+    }
+
+    #[test]
+    fn emit_assign_is_bare_reassignment() {
+        for scope in [Scope::Local, Scope::Param, Scope::Capture, Scope::Global] {
+            let st = Stmt::Assign {
+                name: "x".into(),
+                scope,
+                value: int(7),
+                span: s(),
+            };
+            assert_eq!(emit_s(&st), "x = 7;\n");
+        }
+    }
+
+    #[test]
+    fn emit_seq_set_is_native_element_write() {
+        let st = Stmt::SeqSet {
+            seq: var("xs"),
+            index: int(0),
+            value: int(9),
+            span: s(),
+        };
+        assert_eq!(emit_s(&st), "(xs)[0] = 9;\n");
+    }
+
+    #[test]
+    fn emit_map_set_is_native_map_set() {
+        let st = Stmt::MapSet {
+            map: var("d"),
+            key: Expr::StrLit { value: "k".into(), span: s() },
+            value: int(1),
+            span: s(),
+        };
+        assert_eq!(emit_s(&st), r#"(d).set("k", 1);"#.to_string() + "\n");
+    }
+
+    #[test]
+    fn emit_while_routes_cond_through_truthy() {
+        let st = Stmt::While {
+            cond: Expr::BuiltinCall {
+                name: "<".into(),
+                args: vec![var("i"), int(3)],
+                effects: EffectSet::PURE,
+                span: s(),
+            },
+            body: Block {
+                stmts: vec![Stmt::Assign {
+                    name: "i".into(),
+                    scope: Scope::Local,
+                    value: Expr::BuiltinCall {
+                        name: "+".into(),
+                        args: vec![var("i"), int(1)],
+                        effects: EffectSet::PURE,
+                        span: s(),
+                    },
+                    span: s(),
+                }],
+                value: Expr::NilLit { span: s() },
+                span: s(),
+            },
+            span: s(),
+        };
+        let out = emit_s(&st);
+        assert!(out.starts_with("while (__Sir.truthy((i < 3))) {\n"), "got {out}");
+        assert!(out.contains("i = (i + 1);"));
+        // The trailing nil body value is dropped.
+        assert!(!out.contains("null;"), "got {out}");
+        assert!(out.trim_end().ends_with('}'));
+    }
+
+    #[test]
+    fn emit_for_range_is_direction_aware_c_style() {
+        // Reset the counter so the temporary names are predictable.
+        LOOP_COUNTER.with(|c| c.set(0));
+        let st = Stmt::ForRange {
+            var: "i".into(),
+            start: int(0),
+            stop: int(5),
+            step: int(1),
+            body: Block {
+                stmts: vec![Stmt::ExprStmt {
+                    expr: bc("print", vec![var("i")]),
+                    span: s(),
+                }],
+                value: Expr::NilLit { span: s() },
+                span: s(),
+            },
+            span: s(),
+        };
+        let out = emit_s(&st);
+        assert!(out.contains("let i = 0;"), "got {out}");
+        assert!(out.contains("const __sir_stop_0 = 5;"), "got {out}");
+        assert!(out.contains("const __sir_step_0 = 1;"), "got {out}");
+        assert!(
+            out.contains("while (__sir_step_0 >= 0 ? i < __sir_stop_0 : i > __sir_stop_0) {"),
+            "got {out}"
+        );
+        assert!(out.contains("__Sir.print(i);"), "got {out}");
+        assert!(out.contains("i = i + __sir_step_0;"), "got {out}");
+    }
+
+    #[test]
+    fn emit_for_each_is_for_of() {
+        let st = Stmt::ForEach {
+            var: "x".into(),
+            iter: var("xs"),
+            body: Block {
+                stmts: vec![Stmt::ExprStmt {
+                    expr: bc("print", vec![var("x")]),
+                    span: s(),
+                }],
+                value: Expr::NilLit { span: s() },
+                span: s(),
+            },
+            span: s(),
+        };
+        let out = emit_s(&st);
+        assert!(out.starts_with("for (let x of xs) {\n"), "got {out}");
+        assert!(out.contains("__Sir.print(x);"), "got {out}");
+    }
+
+    #[test]
+    fn emit_nested_loop_temporaries_are_distinct() {
+        // Two for-ranges in one module must get distinct temp ids so the
+        // emitted code is well-formed (no shadow collision).
+        LOOP_COUNTER.with(|c| c.set(0));
+        let mk = || Stmt::ForRange {
+            var: "i".into(),
+            start: int(0),
+            stop: int(2),
+            step: int(1),
+            body: Block { stmts: vec![], value: Expr::NilLit { span: s() }, span: s() },
+            span: s(),
+        };
+        let a = emit_s(&mk());
+        let b = emit_s(&mk());
+        assert!(a.contains("__sir_stop_0"), "got {a}");
+        assert!(b.contains("__sir_stop_1"), "got {b}");
     }
 
     // ── statements ────────────────────────────────────────────────

--- a/code/packages/rust/semantic-ir-to-javascript/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/lib.rs
@@ -31,21 +31,22 @@
 //! Both paths return [`semantic_ir::Artifact`] with `filename`,
 //! `source` (the generated `.js`), and metadata.
 //!
-//! ## Capability declaration (this milestone)
+//! ## Capability declaration (this milestone, D4)
 //!
-//! This first slice accepts the **v0 feature set** and nothing more:
+//! This milestone accepts the **v0 feature set plus all of SIR16 / v1**:
 //!
-//! - `Closures`, `Pairs`, `Symbols`, `Strings`, `DynamicTyping`,
+//! - v0: `Closures`, `Pairs`, `Symbols`, `Strings`, `DynamicTyping`,
 //!   `OptionalTypeAnnotations`, `MutualRecursion`, `Globals`.
+//! - SIR16: `Floats`, `ShortCircuit`, `Sequences`, `Maps`,
+//!   `MutableBindings`, `Loops` — JavaScript supports all six natively,
+//!   so emit is direct (arrays, `Map`, `while`/`for`, reassignable `let`).
 //!
-//! It **rejects** everything else at the capability check — including
-//! the SIR16 collection/loop/short-circuit features, the SIR17 OOP and
-//! exception features, `TailCalls` (V8 does not reliably tail-call
-//! optimise), and `Intrinsics` (empty whitelist).  The accept-set is
-//! deliberately matched to exactly what [`emit`](crate::emit) lowers, so
-//! a module that uses a deferred node is turned away *before* lowering
-//! rather than producing wrong code.  Later milestones widen the set as
-//! the corresponding emit arms land.
+//! It **rejects** everything else at the capability check — the SIR17/18
+//! OOP, exception, and string-interpolation features, `TailCalls` (V8
+//! does not reliably tail-call optimise), and `Intrinsics` (empty
+//! whitelist).  The accept-set is deliberately matched to exactly what
+//! [`emit`](crate::emit) lowers, so a module that uses a deferred node is
+//! turned away *before* lowering rather than producing wrong code.
 //!
 //! See [SIR18](../../../specs/SIR18-semantic-ir-to-javascript.md) for the
 //! full per-node lowering rules.
@@ -80,16 +81,17 @@ impl Default for JavaScriptBackend {
     }
 }
 
-/// Features the JavaScript backend accepts in this milestone: exactly
-/// the v0 surface that [`emit`](crate::emit) knows how to lower.
+/// Features the JavaScript backend accepts in this milestone: the v0
+/// surface plus all of SIR16 / v1 — exactly what [`emit`](crate::emit)
+/// knows how to lower.
 ///
 /// `TailCalls` and `Intrinsics` are excluded deliberately (the former is
 /// fundamentally unsupported on V8; the latter has an empty whitelist).
-/// The SIR16 collection/loop/short-circuit features and the SIR17/18
-/// OOP/exception/interpolation features are excluded because their emit
-/// arms are deferred to a later milestone — a module that declares one
-/// is rejected here, never silently mis-compiled.
+/// The SIR17/18 OOP / exception / string-interpolation features are
+/// excluded because their emit arms are deferred — a module that declares
+/// one is rejected here, never silently mis-compiled.
 const ACCEPTED_FEATURES: &[Feature] = &[
+    // v0 surface.
     Feature::Closures,
     Feature::Pairs,
     Feature::Symbols,
@@ -98,6 +100,13 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     Feature::OptionalTypeAnnotations,
     Feature::MutualRecursion,
     Feature::Globals,
+    // SIR16 / v1 surface (all native in JavaScript).
+    Feature::Floats,
+    Feature::ShortCircuit,
+    Feature::Sequences,
+    Feature::Maps,
+    Feature::MutableBindings,
+    Feature::Loops,
 ];
 
 impl Backend for JavaScriptBackend {
@@ -235,11 +244,36 @@ mod tests {
     }
 
     #[test]
-    fn rejects_sir16_loops_feature() {
-        // A deferred feature must be turned away at the capability check.
+    fn accepts_sir16_loops_feature() {
+        // Loops are now part of the accepted SIR16 surface, so a module
+        // that merely declares the feature compiles.
         let mut m = minimal_module();
         m.manifest = FeatureManifest::from_features(&[Feature::Loops]);
-        let err = compile(&m).expect_err("loops rejected");
+        compile(&m).expect("loops accepted");
+    }
+
+    #[test]
+    fn accepts_all_sir16_features() {
+        // Every SIR16 / v1 feature is accepted as of D4.
+        let mut m = minimal_module();
+        m.manifest = FeatureManifest::from_features(&[
+            Feature::Floats,
+            Feature::ShortCircuit,
+            Feature::Sequences,
+            Feature::Maps,
+            Feature::MutableBindings,
+            Feature::Loops,
+        ]);
+        compile(&m).expect("all SIR16 features accepted");
+    }
+
+    #[test]
+    fn rejects_sir17_exceptions_feature() {
+        // A still-deferred SIR17 feature must be turned away at the
+        // capability check.
+        let mut m = minimal_module();
+        m.manifest = FeatureManifest::from_features(&[Feature::Exceptions]);
+        let err = compile(&m).expect_err("exceptions rejected");
         assert_eq!(err.kind, BackendErrorKind::UnsupportedFeature);
     }
 

--- a/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
@@ -14,6 +14,10 @@
 use std::path::PathBuf;
 use std::process::Command;
 
+use semantic_ir::nodes::MapEntry;
+use semantic_ir::{
+    Block, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, Scope, Span, Stmt,
+};
 use semantic_ir_to_javascript::compile;
 
 /// Is a working `node` on PATH?
@@ -23,6 +27,91 @@ fn node_available() -> bool {
         .output()
         .map(|o| o.status.success())
         .unwrap_or(false)
+}
+
+// ── hand-built SIR helpers ─────────────────────────────────────────────
+//
+// The Twig frontend is a Lisp dialect and does not yet produce the SIR16
+// nodes (sequences, maps, loops, mutation, short-circuit), so the SIR16
+// behaviour tests construct SIR modules directly.  Each helper keeps the
+// call sites in the tests terse.
+
+fn sp() -> Span {
+    Span::synthetic()
+}
+
+fn int(v: i64) -> Expr {
+    Expr::IntLit { value: v, span: sp() }
+}
+
+fn float(v: f64) -> Expr {
+    Expr::FloatLit { value: v, span: sp() }
+}
+
+fn local(name: &str) -> Expr {
+    Expr::VarRef { name: name.into(), scope: Scope::Local, span: sp() }
+}
+
+fn bc(name: &str, args: Vec<Expr>) -> Expr {
+    Expr::BuiltinCall { name: name.into(), args, effects: EffectSet::PURE, span: sp() }
+}
+
+fn print(arg: Expr) -> Stmt {
+    Stmt::ExprStmt { expr: bc("print", vec![arg]), span: sp() }
+}
+
+fn let_(name: &str, value: Expr) -> Stmt {
+    Stmt::LetBinding { name: name.into(), sir_type: None, value, span: sp() }
+}
+
+/// Wrap a `main` function (the `stmts` run for effect, `value` is its
+/// return) into a complete, SIR16-flagged module ready for `compile`.
+fn module_with_main(stmts: Vec<Stmt>, value: Expr, features: &[Feature]) -> Module {
+    Module {
+        name: "sir16".into(),
+        manifest: FeatureManifest::from_features(features),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block { stmts, value, span: sp() },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: sp(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("handbuilt")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: sp(),
+    }
+}
+
+/// Compile a hand-built module, run it under `node`, and return stdout
+/// (trailing newlines trimmed).  Returns `None` when Node is unavailable.
+fn run_module(module: &Module, tag: &str) -> Option<String> {
+    let artifact = compile(module).expect("compile to javascript");
+    if !node_available() {
+        eprintln!("note: `node` unavailable — skipping execution for `{tag}`");
+        return None;
+    }
+    let mut path: PathBuf = std::env::temp_dir();
+    path.push(format!("sir_js_{}_{}.js", tag, std::process::id()));
+    std::fs::write(&path, &artifact.source).expect("write temp js");
+    let output = Command::new("node").arg(&path).output().expect("spawn node");
+    let _ = std::fs::remove_file(&path);
+    assert!(
+        output.status.success(),
+        "node exited non-zero for `{tag}`:\nstdout: {}\nstderr: {}\nsource:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+        artifact.source,
+    );
+    let stdout = String::from_utf8(output.stdout).expect("utf8 stdout");
+    Some(stdout.trim_end_matches(['\n', '\r']).to_string())
 }
 
 /// Compile Twig `src` to a `.js` file in a unique temp path, run it with
@@ -89,5 +178,265 @@ fn closure_adder_program_prints_eight() {
     let out = emit_and_run(src, "closprog", "closure");
     if let Some(stdout) = out {
         assert_eq!(stdout, "8", "expected add5(3) = 8");
+    }
+}
+
+// ── SIR16 behaviour tests (hand-built modules) ─────────────────────────
+
+#[test]
+fn floats_arithmetic_promotion_prints_3_5() {
+    // print(1 + 2.5) → 3.5 (int/float mix promotes to float natively).
+    let module = module_with_main(
+        vec![print(bc("+", vec![int(1), float(2.5)]))],
+        Expr::NilLit { span: sp() },
+        &[Feature::Floats],
+    );
+    if let Some(stdout) = run_module(&module, "floats") {
+        assert_eq!(stdout, "3.5");
+    }
+}
+
+#[test]
+fn short_circuit_does_not_evaluate_rhs() {
+    // (false && <print "boom">) must NOT print "boom"; the whole
+    // expression prints #f.  Routing through truthy keeps `false` falsy.
+    let and = Expr::LogicalAnd {
+        lhs: Box::new(Expr::BoolLit { value: false, span: sp() }),
+        rhs: Box::new(Expr::Block(Box::new(Block {
+            stmts: vec![print(Expr::StrLit { value: "boom".into(), span: sp() })],
+            value: int(99),
+            span: sp(),
+        }))),
+        span: sp(),
+    };
+    let module = module_with_main(
+        vec![print(and)],
+        Expr::NilLit { span: sp() },
+        &[Feature::ShortCircuit, Feature::Strings],
+    );
+    if let Some(stdout) = run_module(&module, "shortcircuit") {
+        // Only `#f` printed — the rhs block (which would print "boom")
+        // never ran.
+        assert_eq!(stdout, "#f", "rhs must not be evaluated");
+    }
+}
+
+#[test]
+fn short_circuit_or_returns_first_truthy() {
+    // (false || 7) → 7.
+    let or = Expr::LogicalOr {
+        lhs: Box::new(Expr::BoolLit { value: false, span: sp() }),
+        rhs: Box::new(int(7)),
+        span: sp(),
+    };
+    let module = module_with_main(
+        vec![print(or)],
+        Expr::NilLit { span: sp() },
+        &[Feature::ShortCircuit],
+    );
+    if let Some(stdout) = run_module(&module, "or") {
+        assert_eq!(stdout, "7");
+    }
+}
+
+#[test]
+fn sequence_build_index_len_set() {
+    // let xs = [10, 20, 30];
+    // xs[1] = 99;
+    // print(xs[1]); print(len(xs));   → 99 then 3
+    let stmts = vec![
+        let_("xs", Expr::SeqLit { items: vec![int(10), int(20), int(30)], span: sp() }),
+        Stmt::SeqSet { seq: local("xs"), index: int(1), value: int(99), span: sp() },
+        print(Expr::SeqIndex {
+            seq: Box::new(local("xs")),
+            index: Box::new(int(1)),
+            span: sp(),
+        }),
+        print(Expr::SeqLen { seq: Box::new(local("xs")), span: sp() }),
+    ];
+    let module = module_with_main(stmts, Expr::NilLit { span: sp() }, &[Feature::Sequences]);
+    if let Some(stdout) = run_module(&module, "sequence") {
+        assert_eq!(stdout, "99\n3");
+    }
+}
+
+#[test]
+fn map_build_get_set() {
+    // let m = {"a": 1};
+    // m["b"] = 2;
+    // print(m["a"]); print(m["b"]); print(m["missing"]);  → 1, 2, nil
+    let stmts = vec![
+        let_(
+            "m",
+            Expr::MapLit {
+                entries: vec![MapEntry {
+                    key: Expr::StrLit { value: "a".into(), span: sp() },
+                    value: int(1),
+                }],
+                span: sp(),
+            },
+        ),
+        Stmt::MapSet {
+            map: local("m"),
+            key: Expr::StrLit { value: "b".into(), span: sp() },
+            value: int(2),
+            span: sp(),
+        },
+        print(Expr::MapGet {
+            map: Box::new(local("m")),
+            key: Box::new(Expr::StrLit { value: "a".into(), span: sp() }),
+            span: sp(),
+        }),
+        print(Expr::MapGet {
+            map: Box::new(local("m")),
+            key: Box::new(Expr::StrLit { value: "b".into(), span: sp() }),
+            span: sp(),
+        }),
+        print(Expr::MapGet {
+            map: Box::new(local("m")),
+            key: Box::new(Expr::StrLit { value: "missing".into(), span: sp() }),
+            span: sp(),
+        }),
+    ];
+    let module =
+        module_with_main(stmts, Expr::NilLit { span: sp() }, &[Feature::Maps, Feature::Strings]);
+    if let Some(stdout) = run_module(&module, "map") {
+        // A missing key reads as nil (`null` → "nil" via format).
+        assert_eq!(stdout, "1\n2\nnil");
+    }
+}
+
+#[test]
+fn while_loop_counts_to_three() {
+    // let i = 0; while (i < 3) { print(i); i = i + 1; }  → 0,1,2
+    let stmts = vec![
+        let_("i", int(0)),
+        Stmt::While {
+            cond: bc("<", vec![local("i"), int(3)]),
+            body: Block {
+                stmts: vec![
+                    print(local("i")),
+                    Stmt::Assign {
+                        name: "i".into(),
+                        scope: Scope::Local,
+                        value: bc("+", vec![local("i"), int(1)]),
+                        span: sp(),
+                    },
+                ],
+                value: Expr::NilLit { span: sp() },
+                span: sp(),
+            },
+            span: sp(),
+        },
+    ];
+    let module = module_with_main(
+        stmts,
+        Expr::NilLit { span: sp() },
+        &[Feature::Loops, Feature::MutableBindings],
+    );
+    if let Some(stdout) = run_module(&module, "while") {
+        assert_eq!(stdout, "0\n1\n2");
+    }
+}
+
+#[test]
+fn for_range_accumulator_sums_to_ten() {
+    // let sum = 0; for i in range(0, 5, 1) { sum = sum + i; }  print(sum) → 10
+    let stmts = vec![
+        let_("sum", int(0)),
+        Stmt::ForRange {
+            var: "i".into(),
+            start: int(0),
+            stop: int(5),
+            step: int(1),
+            body: Block {
+                stmts: vec![Stmt::Assign {
+                    name: "sum".into(),
+                    scope: Scope::Local,
+                    value: bc("+", vec![local("sum"), local("i")]),
+                    span: sp(),
+                }],
+                value: Expr::NilLit { span: sp() },
+                span: sp(),
+            },
+            span: sp(),
+        },
+        print(local("sum")),
+    ];
+    let module = module_with_main(
+        stmts,
+        Expr::NilLit { span: sp() },
+        &[Feature::Loops, Feature::MutableBindings],
+    );
+    if let Some(stdout) = run_module(&module, "forrange") {
+        assert_eq!(stdout, "10");
+    }
+}
+
+#[test]
+fn for_range_descending_step_counts_down() {
+    // for i in range(3, 0, -1) { print(i); }  → 3,2,1
+    let stmts = vec![Stmt::ForRange {
+        var: "i".into(),
+        start: int(3),
+        stop: int(0),
+        step: int(-1),
+        body: Block {
+            stmts: vec![print(local("i"))],
+            value: Expr::NilLit { span: sp() },
+            span: sp(),
+        },
+        span: sp(),
+    }];
+    let module = module_with_main(stmts, Expr::NilLit { span: sp() }, &[Feature::Loops]);
+    if let Some(stdout) = run_module(&module, "forrangedown") {
+        assert_eq!(stdout, "3\n2\n1");
+    }
+}
+
+#[test]
+fn for_each_over_sequence() {
+    // for x in [4, 5, 6] { print(x); }  → 4,5,6
+    let stmts = vec![Stmt::ForEach {
+        var: "x".into(),
+        iter: Expr::SeqLit { items: vec![int(4), int(5), int(6)], span: sp() },
+        body: Block {
+            stmts: vec![print(local("x"))],
+            value: Expr::NilLit { span: sp() },
+            span: sp(),
+        },
+        span: sp(),
+    }];
+    let module = module_with_main(
+        stmts,
+        Expr::NilLit { span: sp() },
+        &[Feature::Loops, Feature::Sequences],
+    );
+    if let Some(stdout) = run_module(&module, "foreach") {
+        assert_eq!(stdout, "4\n5\n6");
+    }
+}
+
+#[test]
+fn mutable_reassignment_updates_binding() {
+    // let x = 1; x = 2; x = x + 40; print(x);  → 42
+    let stmts = vec![
+        let_("x", int(1)),
+        Stmt::Assign { name: "x".into(), scope: Scope::Local, value: int(2), span: sp() },
+        Stmt::Assign {
+            name: "x".into(),
+            scope: Scope::Local,
+            value: bc("+", vec![local("x"), int(40)]),
+            span: sp(),
+        },
+        print(local("x")),
+    ];
+    let module = module_with_main(
+        stmts,
+        Expr::NilLit { span: sp() },
+        &[Feature::MutableBindings],
+    );
+    if let Some(stdout) = run_module(&module, "mutable") {
+        assert_eq!(stdout, "42");
     }
 }


### PR DESCRIPTION
Brings `semantic-ir-to-javascript` to **full SIR-v1 parity** — it now accepts and emits all six SIR16 features (Floats, ShortCircuit, Sequences, Maps, MutableBindings, Loops), where the initial v0 backend (D1) deferred them. JavaScript's native semantics make the emit direct; mirrors the TypeScript backend.

- Short-circuit via truthy-guarded arrow IIFE; sequences→arrays; maps→native `Map` (`MapGet` missing key → null); `Assign` reassignment; `While`/`ForRange`/`ForEach` (for…of); floats incl. NaN/Infinity.
- `accepts_features()` now declares v0 + all 6 SIR16; no reachable panic for accepted features.

**Tests:** 60 unit + 13 integration tests that **run emitted JS under node** (10 new SIR16 programs); clippy clean; security review passed (all new sinks route through `sanitize_ident`/`quote_js_string`). Isolated to `semantic-ir-to-javascript`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)