### PR TITLE
feat(sir-rust): SIR16 Sequences + Maps — completes Rust v1 parity (A3)

### DIFF
--- a/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
@@ -1,5 +1,77 @@
 # Changelog
 
+## 0.4.0 — SIR16 Sequences + Maps (completes SIR16 / v1 parity)
+
+The final two SIR-v1 (SIR16) features land in the Rust backend.  With
+`Sequences` and `Maps` now accepted, the Rust backend supports **all six**
+SIR16 / SIR-v1 features — `Floats`, `ShortCircuit`, `MutableBindings`,
+`Loops`, `Sequences`, `Maps` — reaching full v1 parity with the
+TypeScript backend.  Every SIR16 IR node now has a real emit arm; the
+only remaining `panic!`s cover SIR17/18 nodes (classes, modules,
+singleton classes, try/catch, string interpolation, instance/class/const
+vars, intrinsics) whose features stay unaccepted, so they are unreachable
+for any validated module.
+
+### Added
+
+- `Feature::Sequences` and `Feature::Maps` in the accepted-feature set
+  (`lib.rs`).
+- **Runtime value model** — two new shared, mutable `Value` arms:
+  - `Value::Seq(Rc<RefCell<Vec<Value>>>)` — a growable vector.  The
+    `Rc<RefCell<…>>` is essential: `SeqSet` (`xs[i] = v`) must mutate the
+    sequence the caller holds, and aliasing bindings must observe each
+    other's writes — the reference semantics of a Python list / JS array.
+  - `Value::Map(Rc<RefCell<Vec<(Value, Value)>>>)` — an insertion-ordered
+    association list.  Keys compare with the runtime's own `value_eq`
+    (linear scan) rather than a `HashMap`, because `Value` is neither
+    `Hash` nor `Eq` (floats, closures, nested seqs/maps).  This gives
+    correct lookup semantics for *any* key type and preserves insertion
+    order for deterministic iteration and printing.
+- **Sequences** — `SeqLit`/`SeqIndex`/`SeqLen` expressions lower to the
+  `seq_lit`/`seq_index`/`seq_len` helpers; the `SeqSet` statement mutates
+  the backing vector through `seq_set`.  Out-of-range index reads/writes
+  panic (strict, like `car`/`cdr` on a non-pair).
+- **Maps** — `MapLit`/`MapGet` expressions lower to `map_lit`/`map_get`;
+  the `MapSet` statement mutates via `map_set`.  A missing-key `MapGet`
+  returns `Nil` (mirroring the TypeScript backend's `?? null`).  Literal
+  and `map_set` writes are last-write-wins on an existing key while
+  preserving first-seen insertion order.
+- **`format`** renders sequences as `[1, 2, 3]` and maps as `{a: 1, b: 2}`
+  (insertion order); **`value_eq`** compares seqs/maps structurally
+  (element-wise, with an `Rc::ptr_eq` fast path).
+
+### Changed (ForEach reconciliation)
+
+- A2 introduced `Stmt::ForEach` with a `seq_iter` helper that walked a
+  cons-list (there was no `Seq` value yet).  Now that a real
+  `Value::Seq` exists, `seq_iter` was reconciled to **snapshot a
+  `Value::Seq`** as well as walk the legacy cons-list, so a
+  `for x in [1, 2, 3]` (a `SeqLit`) iterates end to end while the
+  cons-list path keeps working unchanged.
+- Fixed a latent `ForEach` emit bug surfaced by the new end-to-end test:
+  the loop emitted `for <var>: __sir::Value in …`, but a type annotation
+  on a `for` pattern is not valid Rust.  Dropped the annotation
+  (`for <var> in …`); the element type is already `Value` from
+  `seq_iter`'s return.  This path had no prior compile-and-run coverage
+  (the loops test exercised only `while`/`for-range`).
+- The mutable-binding pre-pass (`collect_assigned_locals`) now recurses
+  into Seq/Map statements and expressions, so an `Assign` nested inside a
+  `SeqSet`/`MapSet` value (or a `SeqLit`/`MapLit` sub-expression) is
+  still discovered and its binding declared `let mut`.
+
+### Tests
+
+- `tests/compile_and_run_seq_maps.rs`: an end-to-end proof that emits a
+  module using a sequence (literal, index, len, set), a map (literal,
+  get with a present *and* a missing key, set), and a `for v in <SeqLit>`
+  `ForEach` accumulation, compiles it with `rustc`, runs the binary, and
+  asserts its stdout (`20`, `3`, `99`, `2`, `nil`, `7`, `10`).
+- Unit tests for every new emit arm (seq/map literal, index, len, get,
+  and the seq/map set statements in both the block and inline paths),
+  for `ForEach`-over-`SeqLit` composition, and for the mutable-name
+  pre-pass recursing into a `SeqSet` value; runtime tests for the new
+  value arms and helpers.
+
 ## 0.3.0 — SIR16 MutableBindings + Loops
 
 The next two SIR-v1 (SIR16) features land in the Rust backend, matching

--- a/code/packages/rust/semantic-ir-to-rust/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-rust"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "Semantic IR → self-contained Rust source code (SIR13). Second backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-rust/README.md
+++ b/code/packages/rust/semantic-ir-to-rust/README.md
@@ -35,8 +35,8 @@ Accepts (v0): `Closures`, `Pairs`, `Symbols`, `Strings`,
 `DynamicTyping`, `OptionalTypeAnnotations`, `MutualRecursion`,
 `Globals`.
 
-Accepts (SIR16 / v1, landing incrementally): `Floats`, `ShortCircuit`,
-`MutableBindings`, `Loops`.
+Accepts (SIR16 / v1 — **all six** features, full v1 parity): `Floats`,
+`ShortCircuit`, `MutableBindings`, `Loops`, `Sequences`, `Maps`.
 
 - `Floats` adds a `Value::Float(f64)` arm to the runtime value model with
   numeric promotion (`int op float ⇒ float`).
@@ -48,14 +48,25 @@ Accepts (SIR16 / v1, landing incrementally): `Floats`, `ShortCircuit`,
   (Local/Param/Capture) or a runtime `global_set` (Global).
 - `Loops` covers `while`, `for-range`, and `for-each`.  `while` and
   `for-range` route through SIR truthiness / cached `i64` bounds;
-  `for-each` iterates a cons-list (`Pair`-chain) via the runtime
-  `seq_iter` helper, so it needs no dedicated `Sequences` value yet.
+  `for-each` iterates via the runtime `seq_iter` helper, which now
+  snapshots a real `Value::Seq` **and** still walks the legacy cons-list
+  (`Pair`-chain) — so `for x in [1, 2, 3]` works end to end.
+- `Sequences` adds a shared, mutable `Value::Seq(Rc<RefCell<Vec<Value>>>)`.
+  `SeqLit`/`SeqIndex`/`SeqLen` lower to `seq_lit`/`seq_index`/`seq_len`;
+  the `SeqSet` statement mutates the backing vector via `seq_set`.
+- `Maps` adds a shared, mutable, insertion-ordered
+  `Value::Map(Rc<RefCell<Vec<(Value, Value)>>>)`.  `MapLit`/`MapGet`
+  lower to `map_lit`/`map_get`; `MapSet` mutates via `map_set`.  Keys
+  compare with the runtime's `value_eq` (so any value type is a key), and
+  a missing-key `MapGet` returns `Nil`.
 
-The other two v1 features (`Sequences`, `Maps`) are not yet accepted and
-are still rejected at the capability check.
+With all six SIR16 features accepted, every SIR16 IR node has a real emit
+arm — no reachable `panic!` remains for v1.  The remaining emit panics
+cover SIR17/18 nodes (classes, modules, try/catch, string interpolation,
+instance/class/const vars) whose features stay unaccepted.
 
 Rejects: `TailCalls` (Rust does not guarantee TCO), `Intrinsics`
-(empty whitelist in v0).
+(empty whitelist in v0), and the SIR17/18 features above.
 
 ## Value model
 
@@ -66,6 +77,8 @@ enum Value {
     Sym(Rc<str>), Str(Rc<str>),
     Pair(Rc<Pair>),
     Closure(Rc<Closure>),
+    Seq(Rc<RefCell<Vec<Value>>>),            // SIR16 Sequences
+    Map(Rc<RefCell<Vec<(Value, Value)>>>),   // SIR16 Maps (insertion-ordered)
 }
 ```
 
@@ -73,6 +86,9 @@ enum Value {
 - Closures wrap a `Box<dyn Fn(Vec<Value>) -> Value>` inside an `Rc`.
 - Symbols and strings are interned `Rc<str>` for cheap clones.
 - Globals live in a `thread_local!` `HashMap<String, Value>`.
+- Sequences and maps are `Rc<RefCell<…>>` so `SeqSet`/`MapSet` mutate the
+  shared value in place; maps key by `value_eq` (linear lookup) and keep
+  insertion order.
 
 ## `main` collision
 

--- a/code/packages/rust/semantic-ir-to-rust/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/emit.rs
@@ -197,11 +197,22 @@ fn collect_stmt_assigned(s: &Stmt, out: &mut HashSet<String>) {
             collect_expr_assigned(iter, out);
             collect_assigned_locals(body, out);
         }
-        // Sequences/Maps and SIR17 nodes are rejected at the capability
-        // check for this backend; nothing reachable to collect.
-        Stmt::SeqSet { .. }
-        | Stmt::MapSet { .. }
-        | Stmt::ClassDef { .. }
+        // SIR16 Seq/Map indexed assignment: the target, index/key, and
+        // value sub-expressions can each hold a nested `Assign` (e.g.
+        // `xs[i] = (foo := 1)`), so recurse into all three.
+        Stmt::SeqSet { seq, index, value, .. } => {
+            collect_expr_assigned(seq, out);
+            collect_expr_assigned(index, out);
+            collect_expr_assigned(value, out);
+        }
+        Stmt::MapSet { map, key, value, .. } => {
+            collect_expr_assigned(map, out);
+            collect_expr_assigned(key, out);
+            collect_expr_assigned(value, out);
+        }
+        // SIR17 nodes are rejected at the capability check for this
+        // backend; nothing reachable to collect.
+        Stmt::ClassDef { .. }
         | Stmt::ModuleDef { .. }
         | Stmt::SingletonClassDef { .. }
         | Stmt::TryCatch { .. } => {}
@@ -236,8 +247,30 @@ fn collect_expr_assigned(e: &Expr, out: &mut HashSet<String>) {
             collect_expr_assigned(lhs, out);
             collect_expr_assigned(rhs, out);
         }
-        // Leaves, and SIR16+ Seq/Map/StrConcat nodes (rejected before
-        // emit) — nothing nested that could hold a reachable `Assign`.
+        // SIR16 Seq/Map expressions: recurse into their sub-expressions,
+        // any of which could nest an `Assign`.
+        Expr::SeqLit { items, .. } => {
+            for item in items {
+                collect_expr_assigned(item, out);
+            }
+        }
+        Expr::SeqIndex { seq, index, .. } => {
+            collect_expr_assigned(seq, out);
+            collect_expr_assigned(index, out);
+        }
+        Expr::SeqLen { seq, .. } => collect_expr_assigned(seq, out),
+        Expr::MapLit { entries, .. } => {
+            for entry in entries {
+                collect_expr_assigned(&entry.key, out);
+                collect_expr_assigned(&entry.value, out);
+            }
+        }
+        Expr::MapGet { map, key, .. } => {
+            collect_expr_assigned(map, out);
+            collect_expr_assigned(key, out);
+        }
+        // Leaves, and the SIR18 `StrConcat` node (rejected before emit) —
+        // nothing nested that could hold a reachable `Assign`.
         Expr::IntLit { .. }
         | Expr::FloatLit { .. }
         | Expr::BoolLit { .. }
@@ -246,11 +279,6 @@ fn collect_expr_assigned(e: &Expr, out: &mut HashSet<String>) {
         | Expr::StrLit { .. }
         | Expr::VarRef { .. }
         | Expr::Intrinsic { .. }
-        | Expr::SeqLit { .. }
-        | Expr::SeqIndex { .. }
-        | Expr::SeqLen { .. }
-        | Expr::MapLit { .. }
-        | Expr::MapGet { .. }
         | Expr::StrConcat { .. } => {}
     }
 }
@@ -335,11 +363,26 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
             emit_for_each(out, var, iter, body, indent)
         }
         // ── SIR16 indexed assignment (Sequences/Maps) ───────────────
-        // `Feature::Sequences`/`Feature::Maps` are not accepted by this
-        // backend, so a module using `SeqSet`/`MapSet` is rejected at the
-        // capability check before emit.  Reaching these arms is a bug.
-        Stmt::SeqSet { span, .. } | Stmt::MapSet { span, .. } => {
-            panic!("rust backend reached SIR16 Seq/Map statement at {} — capability check should have rejected it", span);
+        // `seq[index] = value` mutates the shared backing vector in place
+        // via `seq_set`; the returned value is discarded (`let _ = …`).
+        Stmt::SeqSet { seq, index, value, .. } => {
+            let _ = write!(out, "{}let _ = __sir::seq_set(&(", pad);
+            emit_expr(out, seq, indent);
+            out.push_str("), &(");
+            emit_expr(out, index, indent);
+            out.push_str("), ");
+            emit_expr(out, value, indent);
+            out.push_str(");\n");
+        }
+        // `map[key] = value` inserts/overwrites via `map_set`.
+        Stmt::MapSet { map, key, value, .. } => {
+            let _ = write!(out, "{}let _ = __sir::map_set(&(", pad);
+            emit_expr(out, map, indent);
+            out.push_str("), ");
+            emit_expr(out, key, indent);
+            out.push_str(", ");
+            emit_expr(out, value, indent);
+            out.push_str(");\n");
         }
         // An `Assign` to an Instance/ClassVar/Const/Builtin scope: those
         // scopes belong to SIR17 features this backend does not accept
@@ -451,18 +494,58 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
             emit_expr(out, rhs, indent);
             out.push_str(") } })");
         }
-        // Remaining SIR16+ expression kinds — Rust backend hasn't been
-        // extended to these yet (Sequences/Maps land in a later PR;
-        // `StrConcat` is SIR18 string interpolation).  Their features
-        // are undeclared, so the capability check rejects such modules
-        // before emit; reaching this arm is an internal bug.
-        Expr::SeqLit { span, .. }
-        | Expr::SeqIndex { span, .. }
-        | Expr::SeqLen { span, .. }
-        | Expr::MapLit { span, .. }
-        | Expr::MapGet { span, .. }
-        | Expr::StrConcat { span, .. } => {
-            panic!("rust backend reached SIR16+ expression at {} — capability check should have rejected it", span);
+        // ── SIR16: sequences ───────────────────────────────────────
+        // `SeqLit` builds a fresh shared sequence from its items via the
+        // runtime `seq_lit` helper; `SeqIndex`/`SeqLen` read through
+        // `seq_index`/`seq_len`.  All keep the `Value` model — the seq is
+        // boxed, so a `VarRef` to it clones the shared `Rc` handle.
+        Expr::SeqLit { items, .. } => {
+            out.push_str("__sir::seq_lit(vec![");
+            emit_args(out, items, indent);
+            out.push_str("])");
+        }
+        Expr::SeqIndex { seq, index, .. } => {
+            out.push_str("__sir::seq_index(&(");
+            emit_expr(out, seq, indent);
+            out.push_str("), &(");
+            emit_expr(out, index, indent);
+            out.push_str("))");
+        }
+        Expr::SeqLen { seq, .. } => {
+            out.push_str("__sir::seq_len(&(");
+            emit_expr(out, seq, indent);
+            out.push_str("))");
+        }
+        // ── SIR16: maps ────────────────────────────────────────────
+        // `MapLit` builds an insertion-ordered map from `(key, value)`
+        // pairs; `MapGet` reads through `map_get` (missing key ⇒ `Nil`).
+        Expr::MapLit { entries, .. } => {
+            out.push_str("__sir::map_lit(vec![");
+            for (i, entry) in entries.iter().enumerate() {
+                if i > 0 {
+                    out.push_str(", ");
+                }
+                out.push('(');
+                emit_expr(out, &entry.key, indent);
+                out.push_str(", ");
+                emit_expr(out, &entry.value, indent);
+                out.push(')');
+            }
+            out.push_str("])");
+        }
+        Expr::MapGet { map, key, .. } => {
+            out.push_str("__sir::map_get(&(");
+            emit_expr(out, map, indent);
+            out.push_str("), &(");
+            emit_expr(out, key, indent);
+            out.push_str("))");
+        }
+        // The only remaining unsupported expression is `StrConcat`
+        // (SIR18 string interpolation).  Its feature is undeclared, so
+        // the capability check rejects such modules before emit; reaching
+        // this arm is an internal bug.
+        Expr::StrConcat { span, .. } => {
+            panic!("rust backend reached SIR18 str-concat expression at {} — capability check should have rejected it", span);
         }
     }
 }
@@ -835,7 +918,11 @@ fn emit_for_range(
 fn emit_for_each(out: &mut String, var: &str, iter: &Expr, body: &Block, indent: usize) {
     let pad = indent_str(indent);
     let v = sanitize_ident(var);
-    let _ = write!(out, "{}for {}: __sir::Value in __sir::seq_iter(&(", pad, v);
+    // No type annotation on the loop pattern: `for <pat>: T in ...` is not
+    // valid Rust (type ascription on a `for` binding is rejected).  The
+    // element type is already `__sir::Value` because `seq_iter` returns a
+    // `Vec<Value>`, so a plain `for <var> in ...` binds it correctly.
+    let _ = write!(out, "{}for {} in __sir::seq_iter(&(", pad, v);
     emit_expr(out, iter, indent);
     out.push_str(")) {\n");
     emit_block_as_stmts(out, body, indent + 1);
@@ -883,10 +970,27 @@ fn emit_stmt_inline(out: &mut String, s: &Stmt, indent: usize) {
         Stmt::ForEach { var, iter, body, .. } => {
             emit_for_each(out, var, iter, body, indent)
         }
-        // SIR16 Seq/Map indexed assignment — unaccepted features,
-        // rejected before emit.
-        Stmt::SeqSet { span, .. } | Stmt::MapSet { span, .. } => {
-            panic!("rust backend (inline) reached SIR16 Seq/Map statement at {} — capability check should have rejected it", span);
+        // SIR16 Seq/Map indexed assignment — compact (inline) rendering
+        // for a block-as-expression context.  Same `seq_set`/`map_set`
+        // helpers as the statement path, with a trailing space instead of
+        // a newline.
+        Stmt::SeqSet { seq, index, value, .. } => {
+            out.push_str("let _ = __sir::seq_set(&(");
+            emit_expr(out, seq, indent);
+            out.push_str("), &(");
+            emit_expr(out, index, indent);
+            out.push_str("), ");
+            emit_expr(out, value, indent);
+            out.push_str("); ");
+        }
+        Stmt::MapSet { map, key, value, .. } => {
+            out.push_str("let _ = __sir::map_set(&(");
+            emit_expr(out, map, indent);
+            out.push_str("), ");
+            emit_expr(out, key, indent);
+            out.push_str(", ");
+            emit_expr(out, value, indent);
+            out.push_str("); ");
         }
         Stmt::Assign { span, .. } => {
             panic!("rust backend (inline) reached an Assign to an unsupported scope at {} — capability check should have rejected it", span);
@@ -1664,7 +1768,7 @@ mod tests {
             },
             1,
         );
-        assert!(out.contains("for x: __sir::Value in __sir::seq_iter(&(xs.clone()))"), "got: {out}");
+        assert!(out.contains("for x in __sir::seq_iter(&(xs.clone()))"), "got: {out}");
     }
 
     #[test]
@@ -1684,5 +1788,222 @@ mod tests {
             1,
         );
         assert!(out.contains("let _ = i.clone();"), "got: {out}");
+    }
+
+    // ── SIR16 Sequences + Maps ─────────────────────────────────────
+
+    #[test]
+    fn emit_seq_lit_builds_via_seq_lit_helper() {
+        let mut out = String::new();
+        emit_expr(
+            &mut out,
+            &Expr::SeqLit { items: vec![int(1), int(2), int(3)], span: s() },
+            0,
+        );
+        assert_eq!(
+            out,
+            "__sir::seq_lit(vec![__sir::Value::Int(1i64), __sir::Value::Int(2i64), __sir::Value::Int(3i64)])"
+        );
+    }
+
+    #[test]
+    fn emit_seq_index_reads_through_seq_index() {
+        let mut out = String::new();
+        emit_expr(
+            &mut out,
+            &Expr::SeqIndex {
+                seq: Box::new(local("xs")),
+                index: Box::new(int(0)),
+                span: s(),
+            },
+            0,
+        );
+        assert_eq!(out, "__sir::seq_index(&(xs.clone()), &(__sir::Value::Int(0i64)))");
+    }
+
+    #[test]
+    fn emit_seq_len_reads_through_seq_len() {
+        let mut out = String::new();
+        emit_expr(
+            &mut out,
+            &Expr::SeqLen { seq: Box::new(local("xs")), span: s() },
+            0,
+        );
+        assert_eq!(out, "__sir::seq_len(&(xs.clone()))");
+    }
+
+    #[test]
+    fn emit_map_lit_builds_via_map_lit_helper() {
+        use semantic_ir::nodes::MapEntry;
+        let mut out = String::new();
+        emit_expr(
+            &mut out,
+            &Expr::MapLit {
+                entries: vec![
+                    MapEntry {
+                        key: Expr::StrLit { value: "a".into(), span: s() },
+                        value: int(1),
+                    },
+                    MapEntry {
+                        key: Expr::StrLit { value: "b".into(), span: s() },
+                        value: int(2),
+                    },
+                ],
+                span: s(),
+            },
+            0,
+        );
+        assert!(out.starts_with("__sir::map_lit(vec!["), "got: {out}");
+        assert!(out.contains("(__sir::Value::Str(::std::rc::Rc::from(\"a\")), __sir::Value::Int(1i64))"), "got: {out}");
+        assert!(out.contains("(__sir::Value::Str(::std::rc::Rc::from(\"b\")), __sir::Value::Int(2i64))"), "got: {out}");
+    }
+
+    #[test]
+    fn emit_map_get_reads_through_map_get() {
+        let mut out = String::new();
+        emit_expr(
+            &mut out,
+            &Expr::MapGet {
+                map: Box::new(local("d")),
+                key: Box::new(Expr::StrLit { value: "k".into(), span: s() }),
+                span: s(),
+            },
+            0,
+        );
+        assert_eq!(
+            out,
+            "__sir::map_get(&(d.clone()), &(__sir::Value::Str(::std::rc::Rc::from(\"k\"))))"
+        );
+    }
+
+    #[test]
+    fn emit_seq_set_mutates_via_seq_set() {
+        let mut out = String::new();
+        emit_stmt(
+            &mut out,
+            &Stmt::SeqSet {
+                seq: local("xs"),
+                index: int(1),
+                value: int(9),
+                span: s(),
+            },
+            1,
+        );
+        assert_eq!(
+            out,
+            "    let _ = __sir::seq_set(&(xs.clone()), &(__sir::Value::Int(1i64)), __sir::Value::Int(9i64));\n"
+        );
+    }
+
+    #[test]
+    fn emit_map_set_mutates_via_map_set() {
+        let mut out = String::new();
+        emit_stmt(
+            &mut out,
+            &Stmt::MapSet {
+                map: local("d"),
+                key: Expr::StrLit { value: "k".into(), span: s() },
+                value: int(7),
+                span: s(),
+            },
+            1,
+        );
+        assert_eq!(
+            out,
+            "    let _ = __sir::map_set(&(d.clone()), __sir::Value::Str(::std::rc::Rc::from(\"k\")), __sir::Value::Int(7i64));\n"
+        );
+    }
+
+    #[test]
+    fn emit_seq_set_inline_uses_trailing_space() {
+        // The block-as-expression (inline) path renders the same helper
+        // with a trailing space rather than a newline.
+        let mut out = String::new();
+        emit_stmt_inline(
+            &mut out,
+            &Stmt::SeqSet {
+                seq: local("xs"),
+                index: int(0),
+                value: int(1),
+                span: s(),
+            },
+            1,
+        );
+        assert_eq!(
+            out,
+            "let _ = __sir::seq_set(&(xs.clone()), &(__sir::Value::Int(0i64)), __sir::Value::Int(1i64)); "
+        );
+    }
+
+    #[test]
+    fn emit_map_set_inline_uses_trailing_space() {
+        let mut out = String::new();
+        emit_stmt_inline(
+            &mut out,
+            &Stmt::MapSet {
+                map: local("d"),
+                key: Expr::StrLit { value: "k".into(), span: s() },
+                value: int(2),
+                span: s(),
+            },
+            1,
+        );
+        assert_eq!(
+            out,
+            "let _ = __sir::map_set(&(d.clone()), __sir::Value::Str(::std::rc::Rc::from(\"k\")), __sir::Value::Int(2i64)); "
+        );
+    }
+
+    #[test]
+    fn for_each_over_seq_lit_uses_seq_iter() {
+        // ForEach reconciliation: a `for x in [1, 2, 3]` (SeqLit) lowers
+        // to `seq_iter` over the emitted `seq_lit(…)`, proving the two
+        // SIR16 features compose.
+        let mut out = String::new();
+        emit_stmt(
+            &mut out,
+            &Stmt::ForEach {
+                var: "x".into(),
+                iter: Expr::SeqLit { items: vec![int(1), int(2), int(3)], span: s() },
+                body: block(vec![], nil()),
+                span: s(),
+            },
+            1,
+        );
+        assert!(out.contains("for x in __sir::seq_iter(&(__sir::seq_lit(vec!["), "got: {out}");
+    }
+
+    #[test]
+    fn seq_set_value_marks_nested_assign_target_mutable() {
+        // A `LetBinding` reassigned inside a `SeqSet` value sub-expression
+        // must still be discovered by the mutable-name pre-pass.
+        let f = Function {
+            name: "f".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: block(
+                vec![
+                    Stmt::LetBinding { name: "acc".into(), sir_type: None, value: int(0), span: s() },
+                    Stmt::LetBinding { name: "xs".into(), sir_type: None, value: Expr::SeqLit { items: vec![int(0)], span: s() }, span: s() },
+                    Stmt::SeqSet {
+                        seq: local("xs"),
+                        index: int(0),
+                        value: Expr::Block(Box::new(block(
+                            vec![Stmt::Assign { name: "acc".into(), scope: Scope::Local, value: int(1), span: s() }],
+                            local("acc"),
+                        ))),
+                        span: s(),
+                    },
+                ],
+                nil(),
+            ),
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        };
+        let mut out = String::new();
+        emit_function(&mut out, &f);
+        assert!(out.contains("let mut acc: __sir::Value = __sir::Value::Int(0i64);"), "got: {out}");
     }
 }

--- a/code/packages/rust/semantic-ir-to-rust/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/lib.rs
@@ -82,11 +82,28 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     // statement now emits without panic, accepting `Loops` keeps the
     // capability check and emit coverage consistent.
     Feature::Loops,
-    // The remaining two v1 features (Sequences, Maps) are *not* yet
-    // declared, so a module using a `SeqLit`/`MapLit` (etc.) is still
-    // rejected by the capability check before emit — keeping the
-    // `SeqSet`/`MapSet` and Seq/Map expression `panic!`s in `emit.rs`
-    // strictly unreachable until those features land in a later PR.
+    // `Sequences` adds a shared, mutable `Value::Seq(Rc<RefCell<Vec<…>>>)`
+    // to the runtime value model.  `SeqLit`/`SeqIndex`/`SeqLen` lower to
+    // the `seq_lit`/`seq_index`/`seq_len` helpers; the `SeqSet` statement
+    // mutates the backing vector through `seq_set`.  Because `Seq` is a
+    // real value now, the A2 `ForEach`/`seq_iter` path was reconciled to
+    // iterate it (snapshotting the elements) in addition to the legacy
+    // cons-list — `for x in [1, 2, 3]` works end to end.
+    Feature::Sequences,
+    // `Maps` adds a shared, mutable, insertion-ordered
+    // `Value::Map(Rc<RefCell<Vec<(Value, Value)>>>)`.  `MapLit`/`MapGet`
+    // lower to `map_lit`/`map_get`; the `MapSet` statement mutates via
+    // `map_set`.  Keys compare with the runtime's `value_eq` (linear
+    // lookup), so any value type is a usable key and a missing-key
+    // `MapGet` returns `Nil`.
+    Feature::Maps,
+    // With Sequences + Maps declared, all SIX SIR16 (v1) features —
+    // Floats, ShortCircuit, MutableBindings, Loops, Sequences, Maps —
+    // are accepted, and every SIR16 IR node now has a real emit arm.
+    // The only remaining `panic!`s in `emit.rs` cover SIR17/18 nodes
+    // (classes, modules, try/catch, str-concat, instance/class/const
+    // vars, intrinsics) whose features stay unaccepted, so those arms
+    // remain unreachable for any validated module.
 ];
 
 impl Backend for RustBackend {

--- a/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
@@ -37,6 +37,25 @@ pub const RUNTIME: &str = r##"mod __sir {
         Str(Rc<str>),
         Pair(Rc<Pair>),
         Closure(Rc<Closure>),
+        // ── SIR16 sequences ───────────────────────────────────────
+        // A growable, *mutably shared* vector.  `Rc<RefCell<…>>` is the
+        // crux: `SeqSet` (`xs[i] = v`) must mutate the very sequence the
+        // caller holds, and two bindings that alias the same literal must
+        // see each other's writes — exactly the reference semantics of a
+        // Python list or JS array.  Cloning a `Value::Seq` clones the
+        // `Rc` (a shared handle), not the backing `Vec`.
+        Seq(Rc<RefCell<Vec<Value>>>),
+        // ── SIR16 maps ────────────────────────────────────────────
+        // An *insertion-ordered* association list.  We key by `Value`
+        // using the runtime's own `value_eq` (linear scan) rather than a
+        // `HashMap`, because our `Value` is neither `Hash` nor `Eq`
+        // (floats, closures, nested seqs/maps).  `value_eq` already
+        // defines structural equality across the whole tower, so a
+        // `Vec<(Value, Value)>` gives correct `MapGet`/`MapSet` semantics
+        // — including missing-key ⇒ `Nil` — for *any* key type, and
+        // preserves insertion order for deterministic iteration/printing.
+        // Shared + mutable via `Rc<RefCell<…>>`, same as `Seq`.
+        Map(Rc<RefCell<Vec<(Value, Value)>>>),
     }
 
     pub struct Pair {
@@ -273,7 +292,40 @@ pub const RUNTIME: &str = r##"mod __sir {
             Value::Str(s) => s.to_string(),
             Value::Pair(p) => format_pair(p),
             Value::Closure(_) => "<closure>".to_string(),
+            // Sequences print like a bracketed list: `[1, 2, 3]`.
+            Value::Seq(items) => format_seq(&items.borrow()),
+            // Maps print like a brace-wrapped entry list in insertion
+            // order: `{a: 1, b: 2}`.
+            Value::Map(entries) => format_map(&entries.borrow()),
         }
+    }
+
+    fn format_seq(items: &[Value]) -> String {
+        let mut out = String::new();
+        out.push('[');
+        for (i, item) in items.iter().enumerate() {
+            if i > 0 {
+                out.push_str(", ");
+            }
+            out.push_str(&format(item));
+        }
+        out.push(']');
+        out
+    }
+
+    fn format_map(entries: &[(Value, Value)]) -> String {
+        let mut out = String::new();
+        out.push('{');
+        for (i, (k, v)) in entries.iter().enumerate() {
+            if i > 0 {
+                out.push_str(", ");
+            }
+            out.push_str(&format(k));
+            out.push_str(": ");
+            out.push_str(&format(v));
+        }
+        out.push('}');
+        out
     }
 
     fn format_float(x: f64) -> String {
@@ -322,12 +374,25 @@ pub const RUNTIME: &str = r##"mod __sir {
     }
 
     // `seq_iter` flattens a sequence value into a `Vec<Value>` for a
-    // `ForEach` loop.  This backend has no dedicated `Seq` value yet, so
-    // a "sequence" is the classic cons-list: a `Pair`-chain whose final
-    // `cdr` is `Nil`.  `Nil` itself is the empty sequence.  An improper
-    // list (a non-`Nil`, non-`Pair` tail) is a programming error and
-    // panics, matching the strictness of `car`/`cdr` on a non-pair.
+    // `ForEach` loop.  SIR16 introduced two distinct "sequence" shapes
+    // this backend must iterate uniformly:
+    //
+    //   * `Value::Seq(vec)` — the real `Sequences` value (a `SeqLit`,
+    //     `[1, 2, 3]`).  Cloned element-wise so the loop body sees stable
+    //     snapshots even if it mutates the underlying sequence.
+    //   * the classic cons-list — a `Pair`-chain ending in `Nil` (what
+    //     `cons`/`car`/`cdr` build).  `Nil` itself is the empty sequence.
+    //
+    // Keeping both keeps A2's `ForEach`-over-cons-list working while
+    // making `for x in [1, 2, 3]` (a `SeqLit`) iterate end to end.  An
+    // improper list (a non-`Nil`, non-`Pair` tail) is a programming error
+    // and panics, matching the strictness of `car`/`cdr` on a non-pair.
     pub fn seq_iter(v: &Value) -> Vec<Value> {
+        // A real sequence: snapshot its current elements.
+        if let Value::Seq(items) = v {
+            return items.borrow().clone();
+        }
+        // Otherwise treat it as a cons-list.
         let mut out = Vec::new();
         let mut cur = v.clone();
         loop {
@@ -341,6 +406,119 @@ pub const RUNTIME: &str = r##"mod __sir {
             }
         }
         out
+    }
+
+    // ── sequence ops (SIR16 Sequences) ────────────────────────────
+    //
+    // A `Value::Seq` wraps a shared, mutable `Vec<Value>`.  These helpers
+    // are the lowering targets for `SeqLit`/`SeqIndex`/`SeqLen`/`SeqSet`.
+
+    // `seq_lit([a, b, ...])` constructs a fresh sequence from its items.
+    pub fn seq_lit(items: Vec<Value>) -> Value {
+        Value::Seq(Rc::new(RefCell::new(items)))
+    }
+
+    // `seq_index(seq, i)` reads `seq[i]`.  The index is taken as an
+    // integer; a negative or out-of-range index panics (sequences are
+    // strict, like `car`/`cdr`), matching SIR's "0-indexed, bounds are
+    // target-defined" — we choose to define out-of-bounds as a panic.
+    pub fn seq_index(seq: &Value, index: &Value) -> Value {
+        match seq {
+            Value::Seq(items) => {
+                let i = as_i64(index);
+                let items = items.borrow();
+                if i < 0 || (i as usize) >= items.len() {
+                    panic!("sequence index out of range: {} (len {})", i, items.len());
+                }
+                items[i as usize].clone()
+            }
+            other => panic!("seq-index on non-sequence: {}", format(other)),
+        }
+    }
+
+    // `seq_len(seq)` returns the element count as an `Int`.
+    pub fn seq_len(seq: &Value) -> Value {
+        match seq {
+            Value::Seq(items) => Value::Int(items.borrow().len() as i64),
+            other => panic!("seq-len on non-sequence: {}", format(other)),
+        }
+    }
+
+    // `seq_set(seq, i, value)` writes `seq[i] = value`, mutating the
+    // shared backing vector in place.  Out-of-range writes panic (we do
+    // not auto-grow, matching the index read's strictness).
+    pub fn seq_set(seq: &Value, index: &Value, value: Value) -> Value {
+        match seq {
+            Value::Seq(items) => {
+                let i = as_i64(index);
+                let mut items = items.borrow_mut();
+                if i < 0 || (i as usize) >= items.len() {
+                    panic!("sequence index out of range: {} (len {})", i, items.len());
+                }
+                items[i as usize] = value.clone();
+                value
+            }
+            other => panic!("seq-set on non-sequence: {}", format(other)),
+        }
+    }
+
+    // ── map ops (SIR16 Maps) ──────────────────────────────────────
+    //
+    // A `Value::Map` wraps a shared, mutable, insertion-ordered
+    // `Vec<(Value, Value)>`.  Lookups use `value_eq` for key comparison,
+    // so any value type (including a float, string, or symbol) can be a
+    // key with the same structural-equality semantics as `=`.
+
+    // `map_lit([(k0, v0), (k1, v1), ...])` builds a fresh map.  Later
+    // entries with a key equal to an earlier one overwrite in place, so
+    // the literal `{a: 1, a: 2}` yields `{a: 2}` (last-write-wins,
+    // mirroring object/dict literal semantics) while keeping first-seen
+    // insertion order.
+    pub fn map_lit(entries: Vec<(Value, Value)>) -> Value {
+        let mut store: Vec<(Value, Value)> = Vec::with_capacity(entries.len());
+        for (k, v) in entries {
+            if let Some(slot) = store.iter_mut().find(|(ek, _)| value_eq(ek, &k)) {
+                slot.1 = v;
+            } else {
+                store.push((k, v));
+            }
+        }
+        Value::Map(Rc::new(RefCell::new(store)))
+    }
+
+    // `map_get(map, key)` reads `map[key]`, returning the associated
+    // value or `Nil` when the key is absent (SIR's target-defined
+    // missing-key behaviour — we choose `Nil`, mirroring the TypeScript
+    // backend's `?? null`).
+    pub fn map_get(map: &Value, key: &Value) -> Value {
+        match map {
+            Value::Map(entries) => entries
+                .borrow()
+                .iter()
+                .find(|(k, _)| value_eq(k, key))
+                .map(|(_, v)| v.clone())
+                .unwrap_or(Value::Nil),
+            other => panic!("map-get on non-map: {}", format(other)),
+        }
+    }
+
+    // `map_set(map, key, value)` inserts or overwrites `map[key]`,
+    // mutating the shared backing store.  A new key appends (preserving
+    // insertion order); an existing key (by `value_eq`) overwrites in
+    // place without disturbing order.
+    pub fn map_set(map: &Value, key: Value, value: Value) -> Value {
+        match map {
+            Value::Map(entries) => {
+                let mut entries = entries.borrow_mut();
+                if let Some(slot) = entries.iter_mut().find(|(k, _)| value_eq(k, &key)) {
+                    slot.1 = value.clone();
+                } else {
+                    entries.push((key, value.clone()));
+                }
+                value
+            }
+            other => panic!("map-set on non-map: {}", format(other)),
+        }
     }
 
     // ── helpers ───────────────────────────────────────────────────
@@ -382,6 +560,30 @@ pub const RUNTIME: &str = r##"mod __sir {
             (Value::Str(x), Value::Str(y)) => **x == **y,
             (Value::Pair(x), Value::Pair(y)) => {
                 value_eq(&x.car, &y.car) && value_eq(&x.cdr, &y.cdr)
+            }
+            // Sequences and maps compare *structurally* (element-wise),
+            // matching how `Pair` compares — `[1, 2] = [1, 2]` is true,
+            // and two maps are equal when they hold equal entries in the
+            // same insertion order.  Identical `Rc` handles short-circuit
+            // to `true` without a deep walk.  Comparing two maps element-
+            // wise (rather than as unordered sets) is sufficient here
+            // because `map_lit`/`map_set` keep a canonical first-seen
+            // order, so equal maps built the same way share that order.
+            (Value::Seq(x), Value::Seq(y)) => {
+                Rc::ptr_eq(x, y) || {
+                    let (xb, yb) = (x.borrow(), y.borrow());
+                    xb.len() == yb.len()
+                        && xb.iter().zip(yb.iter()).all(|(a, b)| value_eq(a, b))
+                }
+            }
+            (Value::Map(x), Value::Map(y)) => {
+                Rc::ptr_eq(x, y) || {
+                    let (xb, yb) = (x.borrow(), y.borrow());
+                    xb.len() == yb.len()
+                        && xb.iter().zip(yb.iter()).all(|((ak, av), (bk, bv))| {
+                            value_eq(ak, bk) && value_eq(av, bv)
+                        })
+                }
             }
             _ => false,
         }
@@ -493,5 +695,27 @@ mod tests {
         // (`as_int`), ForEach needs cons-list iteration (`seq_iter`).
         assert!(RUNTIME.contains("pub fn as_int"));
         assert!(RUNTIME.contains("pub fn seq_iter"));
+    }
+
+    #[test]
+    fn runtime_declares_seq_and_map_value_and_helpers() {
+        // SIR16 Sequences + Maps: the value model gains shared, mutable
+        // `Seq`/`Map` arms and the lowering helpers for each IR node.
+        assert!(RUNTIME.contains("Seq(Rc<RefCell<Vec<Value>>>)"));
+        assert!(RUNTIME.contains("Map(Rc<RefCell<Vec<(Value, Value)>>>)"));
+        for helper in &[
+            "pub fn seq_lit", "pub fn seq_index", "pub fn seq_len",
+            "pub fn seq_set", "pub fn map_lit", "pub fn map_get",
+            "pub fn map_set",
+        ] {
+            assert!(RUNTIME.contains(helper), "runtime missing `{}`", helper);
+        }
+    }
+
+    #[test]
+    fn runtime_seq_iter_handles_real_seq() {
+        // ForEach reconciliation: `seq_iter` must snapshot a `Value::Seq`
+        // (the new real sequence) as well as walk a cons-list.
+        assert!(RUNTIME.contains("if let Value::Seq(items) = v"));
     }
 }

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_seq_maps.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_seq_maps.rs
@@ -1,0 +1,279 @@
+//! End-to-end proof for SIR16 **Sequences** + **Maps** in the Rust
+//! backend — the final two v1 features.
+//!
+//! Unit tests assert the *shape* of the emitted source; this test goes
+//! the whole way.  It hand-builds a SIR module that exercises every new
+//! IR node:
+//!
+//!   * sequence literal (`SeqLit`), index read (`SeqIndex`), length
+//!     (`SeqLen`), and indexed write (`SeqSet`);
+//!   * map literal (`MapLit`), key read (`MapGet`), and key write
+//!     (`MapSet`), including a missing-key read that must yield `nil`;
+//!   * a `for x in <SeqLit>` (`ForEach`) accumulation — the integration
+//!     point where the new `Value::Seq` had to be reconciled with A2's
+//!     `seq_iter`.
+//!
+//! It then emits Rust, compiles it with `rustc`, runs the binary, and
+//! checks stdout.  That closes the loop the unit tests cannot — it
+//! proves the emitted runtime actually *compiles and behaves*.
+//!
+//! `rustc` ships with every Rust toolchain (it is what `cargo` drives),
+//! so this runs in CI.  If `rustc` (or a usable linker) is unavailable
+//! the test logs a skip rather than failing — a missing host tool must
+//! never redden a build for reasons unrelated to the change.
+
+use std::process::Command;
+
+use semantic_ir::nodes::MapEntry;
+use semantic_ir::{
+    Block, Effect, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata,
+    Module, Scope, Span, Stmt,
+};
+use semantic_ir_to_rust::compile;
+
+fn s() -> Span {
+    Span::synthetic()
+}
+
+fn ilit(v: i64) -> Expr {
+    Expr::IntLit { value: v, span: s() }
+}
+
+fn slit(v: &str) -> Expr {
+    Expr::StrLit { value: v.into(), span: s() }
+}
+
+fn local(name: &str) -> Expr {
+    Expr::VarRef { name: name.into(), scope: Scope::Local, span: s() }
+}
+
+/// `(name arg0 arg1 ...)` builtin call, pure.
+fn call(name: &str, args: Vec<Expr>) -> Expr {
+    Expr::BuiltinCall {
+        name: name.into(),
+        args,
+        effects: EffectSet::PURE,
+        span: s(),
+    }
+}
+
+/// `print(expr)` as an effectful statement.
+fn print_stmt(expr: Expr) -> Stmt {
+    Stmt::ExprStmt {
+        expr: Expr::BuiltinCall {
+            name: "print".into(),
+            args: vec![expr],
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            span: s(),
+        },
+        span: s(),
+    }
+}
+
+fn let_local(name: &str, value: Expr) -> Stmt {
+    Stmt::LetBinding { name: name.into(), sir_type: None, value, span: s() }
+}
+
+fn assign_local(name: &str, value: Expr) -> Stmt {
+    Stmt::Assign { name: name.into(), scope: Scope::Local, value, span: s() }
+}
+
+fn block(stmts: Vec<Stmt>, value: Expr) -> Block {
+    Block { stmts, value, span: s() }
+}
+
+fn seq(items: Vec<Expr>) -> Expr {
+    Expr::SeqLit { items, span: s() }
+}
+
+fn seq_index(s_expr: Expr, i: Expr) -> Expr {
+    Expr::SeqIndex { seq: Box::new(s_expr), index: Box::new(i), span: s() }
+}
+
+fn seq_len(s_expr: Expr) -> Expr {
+    Expr::SeqLen { seq: Box::new(s_expr), span: s() }
+}
+
+fn map_lit(entries: Vec<(Expr, Expr)>) -> Expr {
+    Expr::MapLit {
+        entries: entries
+            .into_iter()
+            .map(|(key, value)| MapEntry { key, value })
+            .collect(),
+        span: s(),
+    }
+}
+
+fn map_get(m: Expr, k: Expr) -> Expr {
+    Expr::MapGet { map: Box::new(m), key: Box::new(k), span: s() }
+}
+
+/// Build a module whose `main` exercises sequences, maps, and a
+/// `ForEach` over a sequence literal, printing observable results:
+///
+///  1. `xs = [10, 20, 30]`; print `xs[1]`              → "20"
+///  2. print `len(xs)`                                  → "3"
+///  3. `xs[0] = 99`; print `xs[0]`  (SeqSet mutation)   → "99"
+///  4. `d = {"a": 1, "b": 2}`; print `d["b"]`          → "2"
+///  5. print `d["missing"]`  (missing key ⇒ nil)        → "nil"
+///  6. `d["c"] = 7`; print `d["c"]`  (MapSet)           → "7"
+///  7. `total = 0; for v in [1, 2, 3, 4] { total += v }`; print total
+///     (ForEach over a *real* SeqLit, the reconciliation point) → "10"
+fn demo_module() -> Module {
+    let stmts = vec![
+        // 1. xs = [10, 20, 30]; print xs[1]
+        let_local("xs", seq(vec![ilit(10), ilit(20), ilit(30)])),
+        print_stmt(seq_index(local("xs"), ilit(1))),
+        // 2. print len(xs)
+        print_stmt(seq_len(local("xs"))),
+        // 3. xs[0] = 99; print xs[0]
+        Stmt::SeqSet {
+            seq: local("xs"),
+            index: ilit(0),
+            value: ilit(99),
+            span: s(),
+        },
+        print_stmt(seq_index(local("xs"), ilit(0))),
+        // 4. d = {"a": 1, "b": 2}; print d["b"]
+        let_local(
+            "d",
+            map_lit(vec![(slit("a"), ilit(1)), (slit("b"), ilit(2))]),
+        ),
+        print_stmt(map_get(local("d"), slit("b"))),
+        // 5. print d["missing"]  -> nil
+        print_stmt(map_get(local("d"), slit("missing"))),
+        // 6. d["c"] = 7; print d["c"]
+        Stmt::MapSet {
+            map: local("d"),
+            key: slit("c"),
+            value: ilit(7),
+            span: s(),
+        },
+        print_stmt(map_get(local("d"), slit("c"))),
+        // 7. total = 0; for v in [1, 2, 3, 4] { total = total + v }; print total
+        let_local("total", ilit(0)),
+        Stmt::ForEach {
+            var: "v".into(),
+            iter: seq(vec![ilit(1), ilit(2), ilit(3), ilit(4)]),
+            body: block(
+                vec![assign_local("total", call("+", vec![local("total"), local("v")]))],
+                Expr::NilLit { span: s() },
+            ),
+            span: s(),
+        },
+        print_stmt(local("total")),
+    ];
+
+    Module {
+        name: "seq_maps_demo".into(),
+        manifest: FeatureManifest::from_features(&[
+            Feature::Sequences,
+            Feature::Maps,
+            Feature::Loops,
+            Feature::MutableBindings,
+            // String literals are used as map keys.
+            Feature::Strings,
+        ]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: block(stmts, Expr::NilLit { span: s() }),
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            metadata: Metadata::new(),
+            span: s(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("test")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+fn rustc_available() -> bool {
+    Command::new("rustc")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+#[test]
+fn sequences_and_maps_compile_and_run() {
+    if !rustc_available() {
+        eprintln!("skipping: rustc not on PATH");
+        return;
+    }
+
+    // 1. Emit.
+    let artifact = compile(&demo_module()).expect("module should compile to Rust source");
+
+    // 2. Write the source to a unique temp file.
+    let dir = std::env::temp_dir();
+    let nonce = std::process::id();
+    let src_path = dir.join(format!("sir_seq_maps_{nonce}.rs"));
+    let bin_path = dir.join(format!(
+        "sir_seq_maps_{nonce}{}",
+        if cfg!(windows) { ".exe" } else { "" }
+    ));
+    std::fs::write(&src_path, &artifact.source).expect("write temp source");
+
+    // 3. Compile with rustc.  `--edition 2021` is required (raw idents +
+    //    2018+ closure capture).  A host whose default linker is absent
+    //    can point the test at a working one via `SIR_TEST_RUSTC_LINKER`
+    //    (e.g. the toolchain's bundled `rust-lld`).
+    let mut cmd = Command::new("rustc");
+    cmd.arg("--edition").arg("2021").arg("-O");
+    if let Ok(linker) = std::env::var("SIR_TEST_RUSTC_LINKER") {
+        if !linker.is_empty() {
+            cmd.arg("-C").arg(format!("linker={linker}"));
+        }
+    }
+    let compile_out = cmd
+        .arg(&src_path)
+        .arg("-o")
+        .arg(&bin_path)
+        .output()
+        .expect("invoke rustc");
+    if !compile_out.status.success() {
+        let stderr = String::from_utf8_lossy(&compile_out.stderr);
+        // A *missing linker* is a host-environment issue, not a defect in
+        // the emitted code — skip rather than redden the build.  Any other
+        // compile failure (a genuine codegen bug) still fails the test.
+        if stderr.contains("linker") && (stderr.contains("not found") || stderr.contains("No such file"))
+        {
+            eprintln!("skipping: no usable linker on host\n{stderr}");
+            let _ = std::fs::remove_file(&src_path);
+            return;
+        }
+        panic!(
+            "emitted Rust failed to compile:\n--- stderr ---\n{stderr}\n--- source ---\n{}",
+            artifact.source,
+        );
+    }
+
+    // 4. Run the binary and capture stdout.
+    let run_out = Command::new(&bin_path).output().expect("run compiled binary");
+    assert!(
+        run_out.status.success(),
+        "compiled binary exited non-zero:\n{}",
+        String::from_utf8_lossy(&run_out.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&run_out.stdout);
+    let lines: Vec<&str> = stdout.lines().collect();
+
+    // 5. Assert the program's observable behaviour.
+    assert_eq!(
+        lines,
+        vec!["20", "3", "99", "2", "nil", "7", "10"],
+        "unexpected program output; full stdout:\n{stdout}"
+    );
+
+    // 6. Best-effort cleanup (ignore errors — temp dir is ephemeral).
+    let _ = std::fs::remove_file(&src_path);
+    let _ = std::fs::remove_file(&bin_path);
+}


### PR DESCRIPTION
The final two SIR16 features land in `semantic-ir-to-rust`, so the **Rust backend now supports all six SIR-v1 features** (Floats, ShortCircuit, MutableBindings, Loops, Sequences, Maps).

- Runtime gains `Value::Seq(Rc<RefCell<Vec>>)` (mutable, reference-semantics) and `Value::Map(Rc<RefCell<Vec<(Value,Value)>>>)` (insertion-ordered assoc list keyed by `value_eq` — chosen because `Value` isn't `Hash`/`Eq`; missing key → Nil).
- Emit arms for SeqLit/SeqIndex/SeqLen/MapLit/MapGet + SeqSet/MapSet stmts. All 6 SIR16 features now accepted; no reachable panic.
- **Also fixes a latent bug in A2's merged `ForEach`**: it emitted `for <var>: __sir::Value in …` (invalid Rust — type annotation on a for-pattern); that path had no prior compile-and-run coverage. `seq_iter` now iterates the new `Value::Seq` and still handles cons-lists.

**Tests:** 65 unit + 3 rustc compile-and-run integration tests (floats, loops, seq_maps — the new one asserts `20,3,99,2,nil,7,10`); clippy clean; security review passed (one LOW/INFO note: cyclic Seq/Map could overflow in the *emitted* program — tracked as a follow-up, out of threat model). Isolated to `semantic-ir-to-rust`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)