### PR TITLE
feat(js-sir): M2 variables, assignment, operators (C2)

### DIFF
--- a/code/packages/rust/javascript-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/javascript-to-semantic-ir/CHANGELOG.md
@@ -5,6 +5,95 @@ All notable changes to `javascript-to-semantic-ir` are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## 0.2.0
+
+SIR19 milestone **M2 (variables, assignment, operators)** — builds on
+M1's literal lowering.
+
+### Added
+
+- **Variable references.**  A bare identifier resolves to
+  `Expr::VarRef { name, scope }`.  M2 has a single flat scope (everything
+  lives in the synthetic `main`), so a declared name resolves to
+  `Scope::Local`.  `undefined` continues to collapse to `NilLit`; any
+  other *undeclared* identifier is a positioned
+  `JsLowerError { message: "unresolved name reference `…`" }`.
+- **Bindings.**  `let x = e;`, `const x = e;`, and `var x = e;` all lower
+  to a binding statement.  We emit **`Stmt::LetStarBinding`** (sequential
+  `let*`), not `Stmt::LetBinding`: the validator treats a run of
+  consecutive `LetBinding`s as a *parallel* group whose RHSs cannot see
+  one another, but JS `let`/`const` are sequentially scoped, so a
+  perfectly ordinary `let x = 1; const y = x + 1;` must validate.  `let*`
+  matches JS exactly.  `const`/`let`/`var` are not distinguished in v0
+  (the IR models no immutability constraint); `var` hoisting is not
+  modelled (binding emitted at its source position).
+- **Re-assignment.**  `x = e;` to an already-declared name lowers to
+  `Stmt::Assign { scope: Local }` (declares `Feature::MutableBindings`).
+  A first bare `x = e;` with no prior declarator still binds (JS
+  implicitly creates the binding), matching the resolution model.
+- **Binary operators** (flat left-associative chains fold left into
+  nested `BuiltinCall`s):
+  - arithmetic `+ - * / %` → `BuiltinCall("+"/"-"/"*"/"/"/"%")`;
+  - comparison `< > <= >=` → `BuiltinCall("<"/">"/"<="/">=")`.
+- **Equality normalisation.**  Both `==` *and* `===` → `BuiltinCall("=")`,
+  and both `!=` *and* `!==` → `BuiltinCall("!=")`.  This is a **deliberate
+  semantic change**: the IR has only the strict-shaped comparison, so the
+  loose-equality coercion cases (e.g. `null == undefined`, `true` in JS)
+  become `false`.  Spec-sanctioned for v0 (SIR19 "Equality
+  normalisation").
+- **Logical operators.**  `&&` → `Expr::LogicalAnd`, `||` →
+  `Expr::LogicalOr` — short-circuit nodes (declares
+  `Feature::ShortCircuit`), **not** builtins (a builtin would eagerly
+  evaluate both operands).
+- **Unary operators.**  `!x` → `BuiltinCall("not", [x])`; `-x` →
+  `BuiltinCall("neg", [x])`.  `-<numeric literal>` is **constant-folded**
+  into a negative literal (`-5` → `IntLit(-5)`, `-3.25` →
+  `FloatLit(-3.25)`), keeping the spec's `-7 → IntLit` row exact.
+- **Bounded operand recursion.**  The precedence-spine peel stays
+  iterative; only genuine operand descent recurses, capped at
+  `MAX_EXPR_DEPTH = 256` so an adversarial deeply-nested expression
+  yields an ordinary positioned error rather than a stack-overflow abort.
+- 17 new unit tests (34 total): variable resolution incl. let-then-
+  reassign and first-bare-assignment, unresolved-name error, every
+  arithmetic/comparison operator, equality strict-normalisation,
+  left-associativity and precedence, `&&`/`||` short-circuit nodes (and a
+  guard that they are *not* builtins), unary `!`/`-`/`-literal` fold, a
+  cross-referencing-bindings validation test (the parallel-`let` trap),
+  and mixed-program validate round-trips.
+
+### Changed
+
+- Minor version bump `0.1.0 → 0.2.0` (additive, backward-compatible).
+- The two M1 error-path tests that asserted operators and bare
+  identifiers were *rejected* now assert they lower correctly.
+
+### Deferred
+
+Still **out of scope after M2** and returning a clear positioned
+`JsLowerError`, tracked against the SIR19 spec:
+
+- **M3 — control flow:** `if`/`else`, `while`, `for` (`ForRange`),
+  `for-of` (`ForEach`).
+- **M4 — functions & closures:** `function` declarations, arrow
+  functions (`MakeClosure`), `return`, calls (`DirectCall` /
+  `IndirectCall`), `console.log` → `BuiltinCall("print", …)`.
+- **M5 — collections:** array literals (`SeqLit`), indexing
+  (`SeqIndex`), `.length` (`SeqLen`), object literals (`MapLit`),
+  member/`[]` access (`MapGet`).
+- **Operator/assignment gaps within M2's families:** compound assignment
+  (`+=`, `-=`, …), assignment to a member/index target (`obj.x = …`,
+  `xs[i] = …`), multi-binding declarations (`let a = 1, b = 2;`),
+  uninitialised bindings (`let x;`), bitwise / shift / exponentiation /
+  nullish-coalescing operators, and other prefix unaries (`+`, `~`,
+  `typeof`, `void`, `delete`).
+- **Template literals** (backtick strings) — distinct token/rule; will
+  desugar to concatenation in a later milestone.
+- **Non-decimal numeric forms:** hex (`0x…`), octal (`0o…`), binary
+  (`0b…`), and `BigInt` (`10n`) literals remain rejected.
+- Everything in the SIR19 spec "Out of scope (deferred)" section:
+  classes, exceptions, generators, `async`/`await`, destructuring,
+  spread/rest, default parameters, ES modules, `eval`, regex.
+
 ## 0.1.0
 
 First release — SIR19 milestone **M1 (crate skeleton + literal

--- a/code/packages/rust/javascript-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/javascript-to-semantic-ir/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "javascript-to-semantic-ir"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
-description = "JavaScript (GrammarASTNode CST) → narrow-waist Semantic IR. SIR19 frontend, milestone M1 (literals)."
+description = "JavaScript (GrammarASTNode CST) → narrow-waist Semantic IR. SIR19 frontend, milestone M2 (variables, assignment, operators)."
 
 [dependencies]
 coding-adventures-javascript-parser = { path = "../javascript-parser" }

--- a/code/packages/rust/javascript-to-semantic-ir/README.md
+++ b/code/packages/rust/javascript-to-semantic-ir/README.md
@@ -27,19 +27,60 @@ We lower from the *generic* `GrammarASTNode`, **not** from the parser's
 typed-AST bridge (`javascript-parser/src/bridge.rs`). That is the
 contract SIR19 sets, matching how the Ruby and Twig frontends work.
 
-## Milestone status — M1 (literals)
+## Milestone status — M2 (variables, assignment, operators)
 
-This is the first slice of SIR19. It implements **literal lowering
-only**. The supported subset:
+This is the second slice of SIR19. It implements literals (M1) **plus**
+variable references, bindings/assignment, and unary/binary operators.
+The supported subset:
 
-| JavaScript source        | SIR lowering                                  |
-|--------------------------|-----------------------------------------------|
-| `42`, `0`, `-`-free ints | `IntLit { value }`                            |
-| `3.25`, `1e3`, `1.5e-3`  | `FloatLit { value }`                          |
-| `true`, `false`          | `BoolLit { value }`                           |
-| `null`                   | `NilLit`                                       |
-| `undefined`              | `NilLit` (distinction from `null` is lost)    |
-| `"hi"`, `'hi'`           | `StrLit { value }`                            |
+| JavaScript source           | SIR lowering                                  |
+|-----------------------------|-----------------------------------------------|
+| `42`, `0`, `-`-free ints    | `IntLit { value }`                            |
+| `3.25`, `1e3`, `1.5e-3`     | `FloatLit { value }`                          |
+| `-5`, `-3.25`               | constant-folded `IntLit(-5)` / `FloatLit(-3.25)` |
+| `true`, `false`             | `BoolLit { value }`                           |
+| `null`                      | `NilLit`                                       |
+| `undefined`                 | `NilLit` (distinction from `null` is lost)    |
+| `"hi"`, `'hi'`              | `StrLit { value }`                            |
+| `name` (declared reference) | `VarRef { name, scope: Local }`               |
+| `let`/`const`/`var x = e;`  | `LetStarBinding` (see "Bindings" below)       |
+| `x = e;` (re-assignment)    | `Assign { scope: Local }`                     |
+| `a + b`, `a - b`, `a * b`, `a / b`, `a % b` | `BuiltinCall("+"/"-"/"*"/"/"/"%")` |
+| `a < b`, `a > b`, `a <= b`, `a >= b` | `BuiltinCall("<"/">"/"<="/">=")`     |
+| `a == b`, `a === b`         | `BuiltinCall("=")` (strict-normalised)        |
+| `a != b`, `a !== b`         | `BuiltinCall("!=")` (strict-normalised)       |
+| `a && b`                    | `LogicalAnd` (short-circuit)                  |
+| `a \|\| b`                  | `LogicalOr` (short-circuit)                   |
+| `!a`                        | `BuiltinCall("not", [a])`                     |
+| `-a` (non-literal `a`)      | `BuiltinCall("neg", [a])`                     |
+
+### Variables and scope
+
+M2 has a single flat scope: everything lives inside the synthetic
+`main`, so a declared name resolves to `Scope::Local`. The lowerer
+tracks declared names in source order — the first sighting of `x`
+(`let`/`const`/`var x = …`, or a bare `x = …` with no prior binding)
+emits a binding; a subsequent `x = …` emits an `Assign`
+(`Feature::MutableBindings`). A reference to a name that was never
+declared is a positioned "unresolved name reference" error.
+
+### Bindings: `LetStarBinding`, not `LetBinding`
+
+`let`/`const`/`var` all lower to **`Stmt::LetStarBinding`** (sequential
+`let*` semantics). The SIR validator treats a run of consecutive
+`LetBinding`s as a *parallel* group whose right-hand sides cannot
+reference one another, but JS declarations are sequentially scoped —
+`let x = 1; const y = x + 1;` must validate — so `let*` is the correct
+fit. `const`/`let`/`var` are not otherwise distinguished in v0 (the IR
+models no immutability constraint), and `var` hoisting is not modelled.
+
+### Equality is normalised to strict
+
+JS has loose (`==`/`!=`, coercing) and strict (`===`/`!==`) equality;
+the IR has only the strict-shaped `=`/`!=`. Both JS families map to the
+strict IR comparison, **changing semantics** for the coercion cases
+(`null == undefined` is `true` in JS but `false` here). This loss is
+spec-sanctioned for v0.
 
 ### Number classification
 
@@ -92,13 +133,16 @@ Every produced `Module`:
   `semantic_ir::validate` with no used-but-undeclared errors and no
   declared-but-unused warnings.
 
-## Out of scope for M1 (deferred)
+## Out of scope for M2 (deferred)
 
-Variables, operators, control flow, functions, collections, and
-template literals all currently return a `JsLowerError` describing what
-was rejected, with the offending node's position. The error sites are
-structured so later milestones slot their handling in at exactly the
-right place. See `CHANGELOG.md` for the milestone roadmap and the full
+Control flow, functions, collections, member access, and template
+literals all currently return a `JsLowerError` describing what was
+rejected, with the offending node's position — as do the gaps within
+M2's own families (compound assignment, assignment to a member/index,
+multi-binding declarations, uninitialised bindings, bitwise/shift/
+exponentiation/nullish operators). The error sites are structured so
+later milestones slot their handling in at exactly the right place. See
+`CHANGELOG.md` for the milestone roadmap and the full
 SIR19 spec at [`code/specs/SIR19-javascript-to-semantic-ir.md`](../../../specs/SIR19-javascript-to-semantic-ir.md).
 
 ## Testing

--- a/code/packages/rust/javascript-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/javascript-to-semantic-ir/src/lib.rs
@@ -27,9 +27,9 @@
 //! not from the parser's typed-AST bridge — that's the contract SIR19
 //! sets, mirroring the Ruby and Twig frontends.
 //!
-//! ## Milestone status — M1 (literals)
+//! ## Milestone status — M2 (variables, assignment, operators)
 //!
-//! This build implements **literal lowering only**:
+//! This build implements literals (M1) **plus**:
 //!
 //! - JS number → [`IntLit`](semantic_ir::Expr::IntLit) when the literal
 //!   text is an integer (no `.`/exponent), else
@@ -38,10 +38,22 @@
 //! - `null` **and** `undefined` → [`NilLit`](semantic_ir::Expr::NilLit)
 //!   (the JS distinction is intentionally lost in v0).
 //! - string → [`StrLit`](semantic_ir::Expr::StrLit).
+//! - variable reference → [`VarRef`](semantic_ir::Expr::VarRef) with a
+//!   resolved [`Scope`](semantic_ir::Scope) (M2 has one flat scope, so
+//!   `Scope::Local`); an undeclared name is a positioned error.
+//! - `let`/`const`/`var x = e;` → a sequential binding statement
+//!   ([`Stmt::LetStarBinding`](semantic_ir::Stmt::LetStarBinding));
+//!   re-assignment `x = e;` → [`Stmt::Assign`](semantic_ir::Stmt::Assign).
+//! - arithmetic / comparison operators → `BuiltinCall`; `&&`/`||` →
+//!   short-circuit [`LogicalAnd`](semantic_ir::Expr::LogicalAnd) /
+//!   [`LogicalOr`](semantic_ir::Expr::LogicalOr); unary `!`→`not`,
+//!   `-`→`neg`; both `==`/`===` → `BuiltinCall("=")` and both `!=`/`!==`
+//!   → `BuiltinCall("!=")` (strict normalisation — a documented semantic
+//!   change for the loose-equality coercion cases).
 //!
-//! All other syntax (variables, operators, control flow, functions,
-//! collections, template literals) is **deferred** to later milestones
-//! and currently produces a clear [`JsLowerError`].  See the crate
+//! All other syntax (control flow, functions, collections, member
+//! access, template literals) is **deferred** to later milestones and
+//! currently produces a clear [`JsLowerError`].  See the crate
 //! `CHANGELOG.md` "Deferred" section for the roadmap.
 //!
 //! ## Public API
@@ -266,28 +278,254 @@ mod tests {
         assert!(r.warnings().next().is_none(), "unexpected warnings");
     }
 
-    // ── error paths ────────────────────────────────────────────────
+    // ── M2: variables, binding, assignment ─────────────────────────
+
+    use semantic_ir::{Scope, Stmt};
+
+    /// Fetch the `main` function's body block.
+    fn main_block(m: &semantic_ir::Module) -> &semantic_ir::Block {
+        &m.functions
+            .iter()
+            .find(|f| f.name == "main")
+            .expect("main function present")
+            .body
+    }
 
     #[test]
-    fn operator_expression_is_rejected_in_m1() {
-        // `1 + 2` is a non-literal expression ⇒ out of M1 scope.
-        let err = compile_source("1 + 2;", "test").expect_err("should reject operators");
+    fn let_binding_emits_let_star_and_resolves_reference() {
+        // `let x = 1; x;` → one binding stmt, tail value a local var-ref.
+        let m = lower("let x = 1; x;");
+        let b = main_block(&m);
+        assert_eq!(b.stmts.len(), 1);
+        match &b.stmts[0] {
+            Stmt::LetStarBinding { name, value, .. } => {
+                assert_eq!(name, "x");
+                assert!(matches!(value, Expr::IntLit { value: 1, .. }));
+            }
+            other => panic!("expected LetStarBinding, got {other:?}"),
+        }
+        match &b.value {
+            Expr::VarRef { name, scope: Scope::Local, .. } => assert_eq!(name, "x"),
+            other => panic!("expected local VarRef, got {other:?}"),
+        }
+        assert_valid(&m);
+    }
+
+    #[test]
+    fn const_and_var_both_lower_to_bindings() {
+        let m = lower("const a = 1; var b = 2;");
+        let b = main_block(&m);
+        assert_eq!(b.stmts.len(), 2);
+        assert!(matches!(&b.stmts[0], Stmt::LetStarBinding { name, .. } if name == "a"));
+        assert!(matches!(&b.stmts[1], Stmt::LetStarBinding { name, .. } if name == "b"));
+        assert_valid(&m);
+    }
+
+    #[test]
+    fn cross_referencing_consecutive_bindings_validate() {
+        // The parallel-`let` trap: `const y = x + 1` references the prior
+        // `x`.  Sequential `let*` makes this validate.
+        let m = lower("let x = 1; const y = x + 1; y;");
+        assert_valid(&m);
+        assert!(matches!(main_block(&m).value, Expr::VarRef { .. }));
+    }
+
+    #[test]
+    fn reassignment_emits_assign_after_binding() {
+        // `let x = 1; x = 2;` — second is a re-assignment, not a binding.
+        let m = lower("let x = 1; x = 2;");
+        let b = main_block(&m);
+        assert_eq!(b.stmts.len(), 2);
+        assert!(matches!(&b.stmts[0], Stmt::LetStarBinding { .. }));
+        match &b.stmts[1] {
+            Stmt::Assign { name, scope: Scope::Local, value, .. } => {
+                assert_eq!(name, "x");
+                assert!(matches!(value, Expr::IntLit { value: 2, .. }));
+            }
+            other => panic!("expected Assign, got {other:?}"),
+        }
+        assert!(m.manifest.contains(Feature::MutableBindings));
+        assert_valid(&m);
+    }
+
+    #[test]
+    fn first_bare_assignment_creates_a_binding() {
+        // `x = 5; x;` — no declarator, first sighting still binds (JS
+        // implicitly creates the global); the reference then resolves.
+        let m = lower("x = 5; x;");
+        let b = main_block(&m);
+        assert!(matches!(&b.stmts[0], Stmt::LetStarBinding { name, .. } if name == "x"));
+        assert!(matches!(&b.value, Expr::VarRef { .. }));
+        assert_valid(&m);
+    }
+
+    #[test]
+    fn unresolved_name_is_a_positioned_error() {
+        let err = compile_source("nope;", "test").expect_err("should reject unknown name");
         assert!(
-            err.message.contains("out of scope") || err.message.contains("M1"),
+            err.message.contains("unresolved name"),
             "unexpected message: {}",
             err.message
         );
     }
 
+    // ── M2: binary operators → BuiltinCall ─────────────────────────
+
+    /// Lower `let a = 1; let b = 2; <op>;` and return the tail-value
+    /// `BuiltinCall` name, asserting the module validates.
+    fn binop_name(src_op: &str) -> String {
+        let m = lower(&format!("let a = 1; let b = 2; {src_op};"));
+        assert_valid(&m);
+        match &main_block(&m).value {
+            Expr::BuiltinCall { name, args, .. } => {
+                assert_eq!(args.len(), 2, "binary op must have 2 args");
+                name.clone()
+            }
+            other => panic!("expected BuiltinCall for `{src_op}`, got {other:?}"),
+        }
+    }
+
     #[test]
-    fn bare_identifier_reference_is_rejected_in_m1() {
-        // A variable reference (not `undefined`) is deferred to M2.
-        let err = compile_source("x;", "test").expect_err("should reject var refs");
-        assert!(
-            err.message.contains("variable reference") || err.message.contains("out of scope"),
-            "unexpected message: {}",
-            err.message
-        );
+    fn arithmetic_operators_lower_to_builtins() {
+        assert_eq!(binop_name("a + b"), "+");
+        assert_eq!(binop_name("a - b"), "-");
+        assert_eq!(binop_name("a * b"), "*");
+        assert_eq!(binop_name("a / b"), "/");
+        assert_eq!(binop_name("a % b"), "%");
+    }
+
+    #[test]
+    fn comparison_operators_lower_to_builtins() {
+        assert_eq!(binop_name("a < b"), "<");
+        assert_eq!(binop_name("a > b"), ">");
+        assert_eq!(binop_name("a <= b"), "<=");
+        assert_eq!(binop_name("a >= b"), ">=");
+    }
+
+    #[test]
+    fn equality_is_normalised_to_strict() {
+        // Both loose and strict equality collapse to the SIR `=`/`!=`.
+        assert_eq!(binop_name("a == b"), "=");
+        assert_eq!(binop_name("a === b"), "=");
+        assert_eq!(binop_name("a != b"), "!=");
+        assert_eq!(binop_name("a !== b"), "!=");
+    }
+
+    #[test]
+    fn left_associative_chain_folds_left() {
+        // `a + b + a` → BuiltinCall("+", [BuiltinCall("+", [a, b]), a]).
+        let m = lower("let a = 1; let b = 2; a + b + a;");
+        assert_valid(&m);
+        match &main_block(&m).value {
+            Expr::BuiltinCall { name, args, .. } => {
+                assert_eq!(name, "+");
+                assert!(matches!(&args[0], Expr::BuiltinCall { name, .. } if name == "+"));
+                assert!(matches!(&args[1], Expr::VarRef { .. }));
+            }
+            other => panic!("expected nested BuiltinCall, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn precedence_is_preserved_by_the_cst() {
+        // `a + b * a` must nest the `*` inside the `+`'s second arg.
+        let m = lower("let a = 1; let b = 2; a + b * a;");
+        assert_valid(&m);
+        match &main_block(&m).value {
+            Expr::BuiltinCall { name, args, .. } => {
+                assert_eq!(name, "+");
+                assert!(matches!(&args[1], Expr::BuiltinCall { name, .. } if name == "*"));
+            }
+            other => panic!("expected `+` at root, got {other:?}"),
+        }
+    }
+
+    // ── M2: logical short-circuit ──────────────────────────────────
+
+    #[test]
+    fn logical_and_is_a_short_circuit_node() {
+        let m = lower("let a = 1; let b = 2; a && b;");
+        assert!(matches!(main_block(&m).value, Expr::LogicalAnd { .. }));
+        assert!(m.manifest.contains(Feature::ShortCircuit));
+        assert_valid(&m);
+    }
+
+    #[test]
+    fn logical_or_is_a_short_circuit_node() {
+        let m = lower("let a = 1; let b = 2; a || b;");
+        assert!(matches!(main_block(&m).value, Expr::LogicalOr { .. }));
+        assert!(m.manifest.contains(Feature::ShortCircuit));
+        assert_valid(&m);
+    }
+
+    #[test]
+    fn logical_operators_are_not_builtins() {
+        // Guard against a regression that lowers `&&` to BuiltinCall.
+        let m = lower("let a = 1; let b = 2; a && b;");
+        assert!(!matches!(main_block(&m).value, Expr::BuiltinCall { .. }));
+    }
+
+    // ── M2: unary operators ────────────────────────────────────────
+
+    #[test]
+    fn unary_not_lowers_to_builtin_not() {
+        let m = lower("let c = true; !c;");
+        match &main_block(&m).value {
+            Expr::BuiltinCall { name, args, .. } => {
+                assert_eq!(name, "not");
+                assert_eq!(args.len(), 1);
+            }
+            other => panic!("expected BuiltinCall(not), got {other:?}"),
+        }
+        assert_valid(&m);
+    }
+
+    #[test]
+    fn unary_minus_on_variable_lowers_to_neg() {
+        let m = lower("let d = 1; -d;");
+        match &main_block(&m).value {
+            Expr::BuiltinCall { name, args, .. } => {
+                assert_eq!(name, "neg");
+                assert!(matches!(&args[0], Expr::VarRef { .. }));
+            }
+            other => panic!("expected BuiltinCall(neg), got {other:?}"),
+        }
+        assert_valid(&m);
+    }
+
+    #[test]
+    fn unary_minus_on_literal_is_constant_folded() {
+        // `-5` folds to IntLit(-5); `-3.25` to FloatLit(-3.25).
+        let m = lower("-5;");
+        assert!(matches!(main_value(&m), Expr::IntLit { value: -5, .. }));
+        assert_valid(&m);
+
+        let m = lower("-3.25;");
+        match main_value(&m) {
+            Expr::FloatLit { value, .. } => assert!((value + 3.25).abs() < 1e-12),
+            other => panic!("expected FloatLit(-3.25), got {other:?}"),
+        }
+    }
+
+    // ── M2: structural / round-trip ────────────────────────────────
+
+    #[test]
+    fn operators_add_no_features_but_validate() {
+        // A pure arithmetic program declares no Strings/Floats/etc.
+        let m = lower("let a = 1; let b = 2; a + b;");
+        assert!(!m.manifest.contains(Feature::ShortCircuit));
+        assert!(!m.manifest.contains(Feature::MutableBindings));
+        assert_valid(&m);
+        let r = semantic_ir::validate(&m);
+        assert!(r.warnings().next().is_none(), "unexpected warnings");
+    }
+
+    #[test]
+    fn mixed_program_validates_round_trip() {
+        let m = lower("let x = 10; let y = x * 2; x = y + 1; x >= y && y != 0;");
+        assert_valid(&m);
+        assert!(m.manifest.contains(Feature::ShortCircuit));
+        assert!(m.manifest.contains(Feature::MutableBindings));
     }
 
     #[test]

--- a/code/packages/rust/javascript-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/javascript-to-semantic-ir/src/lower.rs
@@ -1,6 +1,6 @@
 //! JavaScript `GrammarASTNode` (CST) → `semantic_ir::Module` lowering.
 //!
-//! # What this file does (milestone M1)
+//! # What this file does (milestones M1 + M2)
 //!
 //! The [`javascript-parser`](coding_adventures_javascript_parser) crate
 //! hands us a *concrete syntax tree* (CST): a [`GrammarASTNode`] whose
@@ -10,15 +10,22 @@
 //! expression_statement → expression → assignment_expression → … →
 //! primary_expression → <token>`.  Twenty-odd rule layers, all of which
 //! exist only to encode operator precedence, and *none* of which carry
-//! information once you've reached the leaf.
+//! information until one of them *branches* (an operator with two
+//! operands, an assignment with a target and value, …).
 //!
-//! M1 lowers **literals only**.  The strategy is therefore deliberately
-//! blunt: walk a statement down to its single leaf token, classify the
-//! token, and emit the matching SIR literal.  Anything that *isn't* a
-//! single-leaf literal statement (an operator, a name reference, a
-//! declaration, a call) is **out of scope** and rejected with a clear
-//! [`JsLowerError`] so later milestones can slot their handling in at
-//! exactly the right place.
+//! ## Milestone history
+//!
+//! - **M1** lowered **literals only**: walk a statement down to its
+//!   single leaf token, classify the token, emit the matching SIR
+//!   literal.  Anything non-literal was rejected.
+//! - **M2** (this build) adds **variables and operators**.  The
+//!   single-child *peel* in [`Lowerer::lower_expression`] is still the
+//!   entry point: when it stops at a *branching* node it now dispatches
+//!   on the rule name (`additive_expression`, `relational_expression`,
+//!   `logical_and_expression`, `unary_expression`, …) instead of
+//!   rejecting.  And `program` now threads a per-scope set of declared
+//!   names so a bare identifier resolves to a [`VarRef`] and a
+//!   `let`/`const`/`var` becomes a binding statement.
 //!
 //! ## The literal truth table (learned by probing the real parser)
 //!
@@ -33,20 +40,85 @@
 //! | `undefined`   | `Name`   value `"undefined"` (an ident!)    | `NilLit`            |
 //! | `"hi"`/`'hi'` | `String` value `hi` (already unescaped)     | `StrLit { "hi" }`   |
 //!
-//! Note two JS-specific lossy mappings, both spec-sanctioned for v0:
-//!   * `null` **and** `undefined` collapse to `NilLit` — the IR has one
-//!     "absence" value, so the JS distinction is lost.
-//!   * an integer-shaped number becomes `IntLit`, everything else
-//!     `FloatLit`.  JS has a single `number` type (an IEEE-754 double);
-//!     splitting it lets integer-heavy code round-trip through SIR
-//!     backends that *do* distinguish.
+//! ## The operator truth table (M2 — learned by probing the parser)
+//!
+//! Each row's *rule node* is where the precedence spine **branches**:
+//! the children are `[lhs, op_token, rhs, op_token, rhs, …]` (binary
+//! rules are flat, left-associative chains), or `[op_token, operand]`
+//! for a prefix `unary_expression`.  The middle/first token's *value*
+//! (not its `TokenType`, which varies) carries the operator spelling.
+//!
+//! | JS source     | branching rule              | op value | SIR node                       |
+//! |---------------|-----------------------------|----------|--------------------------------|
+//! | `a + b`       | `additive_expression`       | `+`      | `BuiltinCall("+", [a, b])`     |
+//! | `a - b`       | `additive_expression`       | `-`      | `BuiltinCall("-", [a, b])`     |
+//! | `a * b`       | `multiplicative_expression` | `*`      | `BuiltinCall("*", [a, b])`     |
+//! | `a / b`       | `multiplicative_expression` | `/`      | `BuiltinCall("/", [a, b])`     |
+//! | `a % b`       | `multiplicative_expression` | `%`      | `BuiltinCall("%", [a, b])`     |
+//! | `a < b`       | `relational_expression`     | `<`      | `BuiltinCall("<", [a, b])`     |
+//! | `a > b`       | `relational_expression`     | `>`      | `BuiltinCall(">", [a, b])`     |
+//! | `a <= b`      | `relational_expression`     | `<=`     | `BuiltinCall("<=", [a, b])`    |
+//! | `a >= b`      | `relational_expression`     | `>=`     | `BuiltinCall(">=", [a, b])`    |
+//! | `a == b`      | `equality_expression`       | `==`     | `BuiltinCall("=", [a, b])`     |
+//! | `a === b`     | `equality_expression`       | `===`    | `BuiltinCall("=", [a, b])`     |
+//! | `a != b`      | `equality_expression`       | `!=`     | `BuiltinCall("!=", [a, b])`    |
+//! | `a !== b`     | `equality_expression`       | `!==`    | `BuiltinCall("!=", [a, b])`    |
+//! | `a && b`      | `logical_and_expression`    | `&&`     | `LogicalAnd { a, b }`          |
+//! | `a \|\| b`    | `logical_or_expression`     | `\|\|`   | `LogicalOr { a, b }`           |
+//! | `!a`          | `unary_expression`          | `!`      | `BuiltinCall("not", [a])`      |
+//! | `-a`          | `unary_expression`          | `-`      | `BuiltinCall("neg", [a])`      |
+//!
+//! ### Equality normalisation (a deliberate semantic change)
+//!
+//! JS has *two* equality families: loose (`==`/`!=`, with coercion) and
+//! strict (`===`/`!==`, no coercion).  The IR has a single `=` /`!=`.
+//! We map **both** JS families to the strict-shaped IR comparison
+//! (`BuiltinCall("=")` / `BuiltinCall("!=")`).  This *changes semantics*
+//! for the coercion cases — `null == undefined` is `true` in JS but
+//! `false` under strict comparison.  This loss is spec-sanctioned for v0
+//! (see SIR19 "Equality normalisation"); programs relying on loose
+//! coercion are out of scope.
+//!
+//! ### Unary `-` on a numeric literal (constant fold)
+//!
+//! `-5` parses as a prefix `unary_expression` whose operand is the
+//! literal `5`.  Rather than emit `BuiltinCall("neg", [IntLit(5)])` we
+//! *constant-fold* it to `IntLit(-5)` (and `-3.25` to `FloatLit(-3.25)`).
+//! This keeps the spec's `-7 → IntLit` row exact.  Unary `-` on any
+//! *non-literal* operand (e.g. `-x`) stays `BuiltinCall("neg", [x])`.
+//!
+//! ## Variable model (M2)
+//!
+//! Everything lives inside the synthetic top-level `main`, so every
+//! top-level binding is a *local* of `main` (`Scope::Local`).  We track a
+//! `declared_locals` set as we lower statements in source order:
+//!
+//! - First sighting of a name as `let`/`const`/`var x = …` (or a bare
+//!   `x = …` that has no prior binding) emits a binding statement and
+//!   records the name.
+//! - A subsequent `x = …` to an already-declared name emits
+//!   `Stmt::Assign` (`Feature::MutableBindings`).
+//! - A bare identifier reference resolves to `VarRef { scope: Local }`
+//!   if it is declared, to `NilLit` for the exact spelling `undefined`,
+//!   and otherwise to a positioned "unresolved name" [`JsLowerError`].
+//!
+//! Bindings lower to [`Stmt::LetStarBinding`] (sequential `let*`), **not**
+//! [`Stmt::LetBinding`].  The SIR validator treats a run of consecutive
+//! `LetBinding`s as a *parallel* group whose right-hand sides may not see
+//! one another; JS `let`/`const` are sequentially scoped, so a perfectly
+//! ordinary `let x = 1; const y = x + 1;` must validate.  `let*`'s
+//! sequential semantics match JS exactly.  (The SIR19 spec coverage table
+//! writes "LetBinding" generically for both kinds; this divergence is
+//! noted there.)  `const` vs `let` vs `var` are not distinguished in v0
+//! (the IR models no immutability constraint).
 
 use lexer::token::{Token, TokenType};
 use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode};
 use semantic_ir::{
-    Block, EffectSet, ExportName, Expr, Feature, FeatureManifest, Function, Metadata, Module, Span,
-    CURRENT_SIR_VERSION,
+    Block, EffectSet, ExportName, Expr, Feature, FeatureManifest, Function, Metadata, Module,
+    Scope, Span, Stmt, CURRENT_SIR_VERSION,
 };
+use std::collections::HashSet;
 
 /// A failure encountered during JavaScript → SIR lowering.
 ///
@@ -74,6 +146,21 @@ impl std::fmt::Display for JsLowerError {
 
 impl std::error::Error for JsLowerError {}
 
+/// Hard ceiling on operator-expression recursion depth.
+///
+/// `lower_expression` descends the precedence spine iteratively, but each
+/// operand of a branching node is lowered by a *recursive* call back into
+/// `lower_expression`.  A pathological input — thousands of nested
+/// parenthesised operators — could otherwise drive that recursion deep
+/// enough to overflow the thread stack (an uncatchable abort, i.e. a DoS
+/// for any host compiling untrusted source).  We cap the depth and turn
+/// an over-deep tree into an ordinary positioned error.  The limit is
+/// generous: real JavaScript almost never nests operators past a handful
+/// of levels, and the CST's ~20 fixed precedence-wrapper layers per
+/// "real" level are peeled iteratively (they do **not** count against
+/// this budget — only genuine operand recursion does).
+const MAX_EXPR_DEPTH: usize = 256;
+
 // ---------------------------------------------------------------------------
 // Entry point
 // ---------------------------------------------------------------------------
@@ -85,8 +172,10 @@ impl std::error::Error for JsLowerError {}
 /// emits.  The `module_name` becomes the SIR module identifier
 /// (typically the source file's stem).
 ///
-/// In M1 the body may contain only literal expression statements; any
-/// other statement shape produces a [`JsLowerError`] (see module docs).
+/// M2 admits literal expression statements, `let`/`const`/`var`
+/// bindings, re-assignments, variable references, and unary/binary
+/// operators.  Any other statement or expression shape produces a
+/// [`JsLowerError`] (see module docs).
 pub fn compile(program: &GrammarASTNode, module_name: &str) -> Result<Module, JsLowerError> {
     if program.rule_name != "program" {
         return Err(JsLowerError {
@@ -99,6 +188,7 @@ pub fn compile(program: &GrammarASTNode, module_name: &str) -> Result<Module, Js
     let mut lw = Lowerer {
         file_name: module_name.to_string(),
         features_used: FeatureManifest::new(),
+        declared_locals: HashSet::new(),
     };
 
     let block = lw.lower_program(program)?;
@@ -107,7 +197,7 @@ pub fn compile(program: &GrammarASTNode, module_name: &str) -> Result<Module, Js
     // top-level statement sequence — matching SIR17 (Python) and the
     // Ruby frontend.  `main` has no params, so it never triggers the
     // validator's `DynamicTyping` observation; we only declare features
-    // that the literals themselves use (`Strings`, `Floats`).
+    // the body actually uses.
     let main = Function {
         name: "main".to_string(),
         params: Vec::new(),
@@ -148,7 +238,7 @@ pub fn compile(program: &GrammarASTNode, module_name: &str) -> Result<Module, Js
 }
 
 // ---------------------------------------------------------------------------
-// Lowerer — the small amount of mutable state M1 needs
+// Lowerer — the small amount of mutable state M2 needs
 // ---------------------------------------------------------------------------
 
 struct Lowerer {
@@ -158,6 +248,12 @@ struct Lowerer {
     /// Features accumulated as we lower.  `FeatureManifest::add` is
     /// idempotent, so repeated `StrLit`s add `Strings` exactly once.
     features_used: FeatureManifest,
+    /// Names already bound in `main`'s top-level scope.  Drives the
+    /// binding-vs-assignment choice (first sighting binds, later
+    /// sightings re-assign) and lets a bare identifier resolve to a
+    /// `Scope::Local` `VarRef`.  M2 has a single flat scope (no nested
+    /// functions yet), so one set suffices.
+    declared_locals: HashSet<String>,
 }
 
 impl Lowerer {
@@ -187,25 +283,41 @@ impl Lowerer {
     /// Lower the whole program into a single [`Block`].
     ///
     /// SIR `Block`s are "statements then a tail value": `Block.value` is
-    /// the program's result.  Following SIR17/Ruby, the **final**
-    /// top-level expression becomes the tail `value`; everything before
-    /// it would become `stmts`.  In M1 the only statement kind is a
-    /// literal expression statement, and a bare literal has no side
-    /// effect, so any *non-final* literal statement is simply dropped (it
-    /// can't be observed).  We therefore keep `stmts` empty and route the
-    /// last literal — if any — into `value`.  An empty program yields a
-    /// `NilLit` value, exactly like `ruby-to-semantic-ir` on `""`.
+    /// the program's result.  Following SIR17/Ruby, binding and
+    /// assignment statements accumulate in `stmts`, and the **final**
+    /// top-level *expression* statement becomes the tail `value`.
+    /// Earlier bare expression statements are pure (M2 has no calls yet),
+    /// hence unobservable, so we drop them.  An empty program yields a
+    /// `NilLit` value.
     fn lower_program(&mut self, program: &GrammarASTNode) -> Result<Block, JsLowerError> {
-        // `program`'s children are `source_element` nodes (one per
-        // top-level statement).  We collect the lowered expression for
-        // each so the last becomes the block's tail value.
-        let mut exprs: Vec<Expr> = Vec::new();
+        let mut stmts: Vec<Stmt> = Vec::new();
+        // The most recent bare-expression value seen.  Whatever it holds
+        // at the end becomes the block's tail value.
+        let mut tail: Option<Expr> = None;
+
         for child in &program.children {
             match child {
                 ASTNodeOrToken::Node(n) => {
                     // A `source_element` wraps a `statement`; descend.
-                    let expr = self.lower_source_element(n)?;
-                    exprs.push(expr);
+                    match self.lower_source_element(n)? {
+                        Lowered::Stmt(s) => {
+                            // A statement makes any pending tail
+                            // expression unobservable as a *value*, but it
+                            // may have a side effect — keep it as an
+                            // `ExprStmt` so evaluation order is preserved.
+                            if let Some(prev) = tail.take() {
+                                let span = prev.span().clone();
+                                stmts.push(Stmt::ExprStmt { expr: prev, span });
+                            }
+                            stmts.push(*s);
+                        }
+                        Lowered::Expr(e) => {
+                            // A new bare expression supersedes the prior
+                            // one as the candidate tail value; the prior
+                            // one, being pure, is dropped.
+                            tail = Some(e);
+                        }
+                    }
                 }
                 // Stray tokens directly under `program` (there should be
                 // none for well-formed input) are ignored.
@@ -213,27 +325,22 @@ impl Lowerer {
             }
         }
 
-        let value = exprs.pop().unwrap_or(Expr::NilLit {
+        let value = tail.unwrap_or(Expr::NilLit {
             span: self.span_of(program),
         });
 
         Ok(Block {
-            // M1 produces no statements: literals are pure, so only the
-            // tail value is observable.  Later milestones (let-bindings,
-            // assignments, calls) will populate this.
-            stmts: Vec::new(),
+            stmts,
             value,
             span: self.span_of(program),
         })
     }
 
-    /// Lower one `source_element` (top-level item) to an [`Expr`].
-    fn lower_source_element(&mut self, node: &GrammarASTNode) -> Result<Expr, JsLowerError> {
-        // `source_element` → `statement` → `expression_statement`.
+    /// Lower one `source_element` (top-level item) to a [`Lowered`].
+    fn lower_source_element(&mut self, node: &GrammarASTNode) -> Result<Lowered, JsLowerError> {
+        // `source_element` → `statement` → `<concrete statement>`.
         // Descend through the single-child wrappers until we reach a
-        // statement we recognise.  In M1 only `expression_statement` is
-        // supported; a `function_declaration`, `variable_statement`,
-        // `if_statement`, etc. reaches us here and is rejected.
+        // statement we recognise.
         let stmt = single_child_node(node).unwrap_or(node);
         match stmt.rule_name.as_str() {
             "statement" => {
@@ -241,28 +348,158 @@ impl Lowerer {
                 self.lower_statement_inner(inner)
             }
             "expression_statement" => self.lower_expression_statement(stmt),
+            "lexical_declaration" => self.lower_lexical_declaration(stmt).map(|s| Lowered::Stmt(Box::new(s))),
+            "variable_statement" => self.lower_variable_statement(stmt).map(|s| Lowered::Stmt(Box::new(s))),
             other => Err(self.unsupported(stmt, other)),
         }
     }
 
     /// Lower the node *inside* a `statement` wrapper.
-    fn lower_statement_inner(&mut self, node: &GrammarASTNode) -> Result<Expr, JsLowerError> {
+    fn lower_statement_inner(&mut self, node: &GrammarASTNode) -> Result<Lowered, JsLowerError> {
         match node.rule_name.as_str() {
             "expression_statement" => self.lower_expression_statement(node),
-            // deferred to M2+: variable_statement, if_statement,
-            // iteration_statement, function_declaration, return_statement…
+            "lexical_declaration" => self.lower_lexical_declaration(node).map(|s| Lowered::Stmt(Box::new(s))),
+            "variable_statement" => self.lower_variable_statement(node).map(|s| Lowered::Stmt(Box::new(s))),
+            // deferred to M3+: if_statement, iteration_statement,
+            // function_declaration, return_statement, block, …
             other => Err(self.unsupported(node, other)),
         }
     }
 
-    /// Lower an `expression_statement` (`<expression> ;`) to an [`Expr`].
+    // -----------------------------------------------------------------------
+    // Declarations: let / const / var  →  binding or assignment statement
+    // -----------------------------------------------------------------------
+
+    /// Lower a `lexical_declaration` (`let`/`const` form).
+    ///
+    /// Shape (from the probe):
+    /// `lexical_declaration[ Keyword(let|const), binding_list, Semicolon ]`
+    /// where `binding_list` holds one or more `lexical_binding`s, each
+    /// `lexical_binding[ Name, Equals, assignment_expression ]`.
+    ///
+    /// M2 supports the common single-binding case; a comma-separated
+    /// multi-binding list (`let a = 1, b = 2;`) is rejected (deferred) so
+    /// the lossy behaviour is explicit rather than silent.
+    fn lower_lexical_declaration(
+        &mut self,
+        node: &GrammarASTNode,
+    ) -> Result<Stmt, JsLowerError> {
+        let list = child_node_named(node, "binding_list")
+            .ok_or_else(|| self.unsupported(node, "lexical_declaration (no binding_list)"))?;
+        let bindings = children_nodes_named(list, "lexical_binding");
+        self.lower_single_binding(node, &bindings, "lexical_binding")
+    }
+
+    /// Lower a `variable_statement` (`var` form).
+    ///
+    /// Shape: `variable_statement[ Keyword(var), variable_declaration_list,
+    /// Semicolon ]`, the list holding `variable_declaration`s each shaped
+    /// `[ Name, Equals, assignment_expression ]`.  `var` hoisting is NOT
+    /// modelled (SIR19 spec "`var` hoisting"): we emit the binding at its
+    /// source position, exactly like `let`.
+    fn lower_variable_statement(
+        &mut self,
+        node: &GrammarASTNode,
+    ) -> Result<Stmt, JsLowerError> {
+        let list = child_node_named(node, "variable_declaration_list")
+            .ok_or_else(|| self.unsupported(node, "variable_statement (no declaration list)"))?;
+        let decls = children_nodes_named(list, "variable_declaration");
+        self.lower_single_binding(node, &decls, "variable_declaration")
+    }
+
+    /// Shared core for `let`/`const`/`var`: lower exactly one binding of
+    /// the form `[ Name, Equals, <init expr> ]`.
+    fn lower_single_binding(
+        &mut self,
+        decl_node: &GrammarASTNode,
+        bindings: &[&GrammarASTNode],
+        what: &str,
+    ) -> Result<Stmt, JsLowerError> {
+        if bindings.len() != 1 {
+            return Err(JsLowerError {
+                message: format!(
+                    "multi-binding `{what}` (`let a = 1, b = 2;`) is deferred past M2"
+                ),
+                line: decl_node.start_line.unwrap_or(0),
+                column: decl_node.start_column.unwrap_or(0),
+            });
+        }
+        let binding = bindings[0];
+
+        // The binding name is the first `Name` token child.
+        let name_tok = binding
+            .children
+            .iter()
+            .find_map(|c| match c {
+                ASTNodeOrToken::Token(t) if matches!(t.type_, TokenType::Name) => Some(t),
+                _ => None,
+            })
+            .ok_or_else(|| {
+                self.unsupported(binding, &format!("{what} (destructuring/no name)"))
+            })?;
+        let name = name_tok.value.clone();
+        let span = self.span_of(decl_node);
+
+        // The initialiser is the single expression-shaped child node.
+        // A declaration with no initialiser (`let x;`) is deferred — the
+        // IR has no "uninitialised binding" and inventing a `NilLit`
+        // would mask the source's intent.
+        let init_node = binding
+            .children
+            .iter()
+            .find_map(|c| match c {
+                ASTNodeOrToken::Node(n) => Some(n),
+                ASTNodeOrToken::Token(_) => None,
+            })
+            .ok_or_else(|| JsLowerError {
+                message: format!(
+                    "uninitialised binding `{name}` (`{what}` with no `= …`) is deferred past M2"
+                ),
+                line: span.start_line,
+                column: span.start_col,
+            })?;
+        let value = self.lower_expression(init_node, 0)?;
+
+        // First sighting → `let*` binding; a re-declaration of an
+        // already-declared name (legal for `var`, a redeclare error for
+        // `let`/`const` in real JS but we don't enforce that) becomes an
+        // `Assign` to keep validation honest.
+        if self.declared_locals.contains(&name) {
+            self.features_used.add(Feature::MutableBindings);
+            Ok(Stmt::Assign {
+                name,
+                scope: Scope::Local,
+                value,
+                span,
+            })
+        } else {
+            self.declared_locals.insert(name.clone());
+            // Sequential `let*` (not parallel `let`): see module docs.
+            Ok(Stmt::LetStarBinding {
+                name,
+                sir_type: None,
+                value,
+                span,
+            })
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // expression_statement  →  bare expression OR re-assignment statement
+    // -----------------------------------------------------------------------
+
+    /// Lower an `expression_statement` (`<expression> ;`).
+    ///
+    /// Two cases distinguished by the inner expression's shape:
+    ///   * a top-level `assignment_expression` with an `=` operator
+    ///     (`x = …`) becomes a binding/assignment **statement**;
+    ///   * anything else is a value-producing expression returned as
+    ///     [`Lowered::Expr`].
     fn lower_expression_statement(
         &mut self,
         node: &GrammarASTNode,
-    ) -> Result<Expr, JsLowerError> {
-        // Children are the `expression` node followed by a `Semicolon`
-        // token.  Find the first child node (the expression) and lower
-        // it; the trailing semicolon carries no value.
+    ) -> Result<Lowered, JsLowerError> {
+        // Children are the `expression` node followed by a `Semicolon`.
         let expr_node = node
             .children
             .iter()
@@ -275,75 +512,383 @@ impl Lowerer {
                 line: node.start_line.unwrap_or(0),
                 column: node.start_column.unwrap_or(0),
             })?;
-        self.lower_expression(expr_node)
+
+        // Peek for a top-level assignment: descend the single-child
+        // spine until something branches; if that something is an
+        // `assignment_expression` with three children (`lhs op rhs`),
+        // it's a statement-level assignment.
+        let branch = peel_to_branch(expr_node);
+        if branch.rule_name == "assignment_expression" && branch.children.len() == 3 {
+            return self.lower_assignment(branch).map(|s| Lowered::Stmt(Box::new(s)));
+        }
+        self.lower_expression(expr_node, 0).map(Lowered::Expr)
+    }
+
+    /// Lower a statement-level `assignment_expression` (`x = expr`).
+    ///
+    /// Shape: `assignment_expression[ left_hand_side_expression,
+    /// assignment_operator, assignment_expression ]`.  M2 supports only
+    /// the plain `=` operator on a bare identifier target; compound
+    /// assignment (`+=`, …) and assignment to a member/index
+    /// (`obj.x = …`, `xs[i] = …`) are deferred.
+    fn lower_assignment(&mut self, node: &GrammarASTNode) -> Result<Stmt, JsLowerError> {
+        let span = self.span_of(node);
+
+        // children[0] = LHS target, children[1] = assignment_operator,
+        // children[2] = RHS value.
+        let lhs = match &node.children[0] {
+            ASTNodeOrToken::Node(n) => n,
+            ASTNodeOrToken::Token(_) => {
+                return Err(self.unsupported(node, "assignment (token LHS)"))
+            }
+        };
+        let op = &node.children[1];
+        // Only the plain `=` operator is supported.
+        let op_is_plain_eq = match op {
+            ASTNodeOrToken::Node(n) => single_leaf_token(n)
+                .map(|t| t.value == "=")
+                .unwrap_or(false),
+            ASTNodeOrToken::Token(t) => t.value == "=",
+        };
+        if !op_is_plain_eq {
+            return Err(JsLowerError {
+                message: "compound assignment (`+=`, `-=`, …) is deferred past M2".to_string(),
+                line: span.start_line,
+                column: span.start_col,
+            });
+        }
+
+        // The target must be a bare identifier.  Peel the LHS spine to
+        // its leaf token; anything that branches (member access, index)
+        // is deferred.
+        let target_tok = single_leaf_token(peel_to_branch(lhs)).ok_or_else(|| JsLowerError {
+            message: "assignment to a non-identifier target (member/index) is deferred past M2"
+                .to_string(),
+            line: span.start_line,
+            column: span.start_col,
+        })?;
+        if !matches!(target_tok.type_, TokenType::Name) {
+            return Err(self.unsupported(lhs, "assignment target (not a name)"));
+        }
+        let name = target_tok.value.clone();
+
+        let rhs = match &node.children[2] {
+            ASTNodeOrToken::Node(n) => n,
+            ASTNodeOrToken::Token(_) => {
+                return Err(self.unsupported(node, "assignment (token RHS)"))
+            }
+        };
+        let value = self.lower_expression(rhs, 0)?;
+
+        // First sighting of a never-declared name via bare `x = …`
+        // creates a top-level binding (JS implicitly creates a global on
+        // assignment without a declarator).  A subsequent `x = …`
+        // re-assigns.
+        if self.declared_locals.contains(&name) {
+            self.features_used.add(Feature::MutableBindings);
+            Ok(Stmt::Assign {
+                name,
+                scope: Scope::Local,
+                value,
+                span,
+            })
+        } else {
+            self.declared_locals.insert(name.clone());
+            Ok(Stmt::LetStarBinding {
+                name,
+                sir_type: None,
+                value,
+                span,
+            })
+        }
     }
 
     // -----------------------------------------------------------------------
-    // expression → Expr (M1: literals only)
+    // expression → Expr  (M2: literals, var refs, unary/binary operators)
     // -----------------------------------------------------------------------
 
     /// Lower a JS `expression` to a SIR [`Expr`].
     ///
     /// The CST spine from `expression` down to the leaf is a chain of
     /// single-child precedence wrappers (see module docs).  We walk that
-    /// spine to its bottom.  If the bottom is a single leaf token, it's a
-    /// literal we can lower.  If instead we hit a node that *branches*
-    /// (more than one meaningful child — i.e. an actual operator,
-    /// arguments list, member access, …), that's a non-literal
-    /// expression and out of M1 scope.
-    fn lower_expression(&mut self, expr: &GrammarASTNode) -> Result<Expr, JsLowerError> {
+    /// spine to its bottom iteratively.  Two outcomes:
+    ///   * the bottom is a single leaf token → a literal or variable
+    ///     reference;
+    ///   * we hit a node that *branches* (an operator with operands) →
+    ///     dispatch on the rule name to build the matching SIR node.
+    ///
+    /// `depth` bounds the *operand* recursion (each branch lowers its
+    /// children with `depth + 1`); the iterative spine-peel itself does
+    /// not consume the budget.
+    fn lower_expression(
+        &mut self,
+        expr: &GrammarASTNode,
+        depth: usize,
+    ) -> Result<Expr, JsLowerError> {
+        if depth > MAX_EXPR_DEPTH {
+            return Err(JsLowerError {
+                message: format!(
+                    "expression nests deeper than the supported limit ({MAX_EXPR_DEPTH})"
+                ),
+                line: expr.start_line.unwrap_or(0),
+                column: expr.start_column.unwrap_or(0),
+            });
+        }
+
         // Descend through single-child wrapper nodes.
         let mut cur = expr;
         loop {
-            // A leaf node (exactly one child, and that child is a token)
-            // is a literal — classify and emit.
+            // A leaf node (exactly one child, a token) is a literal or a
+            // variable reference — classify and emit.
             if let Some(tok) = cur.token() {
-                return self.lower_literal_token(tok);
+                return self.lower_leaf_token(tok);
             }
-            // Otherwise, if there's exactly one *node* child and no other
-            // meaningful children, keep descending.
             match single_child_node(cur) {
                 Some(next) => cur = next,
                 None => {
-                    // We reached a branching node (an operator, call,
-                    // member access, …).  Not a literal → out of M1.
-                    return Err(self.unsupported(cur, &cur.rule_name));
+                    // A branching node — an operator (or, in M2's
+                    // still-unsupported set, a call/member access).
+                    return self.lower_branch(cur, depth);
                 }
             }
         }
     }
 
-    /// Classify a leaf literal token and build the matching SIR literal.
+    /// Dispatch a *branching* precedence node to its operator handler.
+    fn lower_branch(
+        &mut self,
+        node: &GrammarASTNode,
+        depth: usize,
+    ) -> Result<Expr, JsLowerError> {
+        match node.rule_name.as_str() {
+            // ── flat left-associative binary chains ─────────────────
+            // children = [lhs, op, rhs, op, rhs, …]
+            "additive_expression"
+            | "multiplicative_expression"
+            | "relational_expression"
+            | "equality_expression" => self.lower_binary_chain(node, depth),
+
+            // ── short-circuit logical chains ────────────────────────
+            "logical_and_expression" => self.lower_logical_chain(node, depth, true),
+            "logical_or_expression" => self.lower_logical_chain(node, depth, false),
+
+            // ── prefix unary ────────────────────────────────────────
+            // children = [op_token, operand]
+            "unary_expression" => self.lower_unary(node, depth),
+
+            // ── still unsupported in M2 (calls, member access, …) ───
+            other => Err(self.unsupported(node, other)),
+        }
+    }
+
+    /// Lower a flat, left-associative binary chain to nested
+    /// `BuiltinCall`s.  `a + b - c` (one `additive_expression` with
+    /// children `[a, +, b, -, c]`) folds left into
+    /// `BuiltinCall("-", [BuiltinCall("+", [a, b]), c])`.
+    fn lower_binary_chain(
+        &mut self,
+        node: &GrammarASTNode,
+        depth: usize,
+    ) -> Result<Expr, JsLowerError> {
+        // Split children into operand nodes and operator tokens.  The
+        // grammar guarantees the alternating shape `[n, t, n, t, n, …]`.
+        let mut acc: Option<Expr> = None;
+        let mut pending_op: Option<&Token> = None;
+
+        for child in &node.children {
+            match child {
+                ASTNodeOrToken::Node(n) => {
+                    let operand = self.lower_expression(n, depth + 1)?;
+                    match (acc.take(), pending_op.take()) {
+                        (None, _) => acc = Some(operand),
+                        (Some(lhs), Some(op)) => {
+                            acc = Some(self.build_binary_op(op, lhs, operand)?);
+                        }
+                        (Some(_), None) => {
+                            // Two operands with no operator between —
+                            // shouldn't happen for a well-formed CST.
+                            return Err(self.unsupported(node, &node.rule_name));
+                        }
+                    }
+                }
+                ASTNodeOrToken::Token(t) => pending_op = Some(t),
+            }
+        }
+
+        acc.ok_or_else(|| self.unsupported(node, &node.rule_name))
+    }
+
+    /// Build one binary `BuiltinCall` from an operator token and its two
+    /// already-lowered operands, applying equality normalisation.
+    fn build_binary_op(
+        &mut self,
+        op: &Token,
+        lhs: Expr,
+        rhs: Expr,
+    ) -> Result<Expr, JsLowerError> {
+        // Normalise the operator spelling to the IR builtin name.  Both
+        // loose and strict equality collapse to the strict-shaped IR
+        // comparison — a deliberate semantic change (see module docs).
+        let builtin = match op.value.as_str() {
+            "+" | "-" | "*" | "/" | "%" | "<" | ">" | "<=" | ">=" => op.value.as_str(),
+            "==" | "===" => "=",
+            "!=" | "!==" => "!=",
+            other => {
+                return Err(JsLowerError {
+                    message: format!("unsupported binary operator `{other}`"),
+                    line: op.line,
+                    column: op.column,
+                })
+            }
+        };
+        let span = self.span_of_token(op);
+        Ok(Expr::BuiltinCall {
+            name: builtin.to_string(),
+            args: vec![lhs, rhs],
+            // Arithmetic/comparison builtins are pure.
+            effects: EffectSet::PURE,
+            span,
+        })
+    }
+
+    /// Lower a logical chain (`&&` / `||`) to nested short-circuit nodes.
+    /// `a && b && c` folds left into `And(And(a, b), c)`.  These are
+    /// **not** builtins: `LogicalAnd`/`LogicalOr` carry short-circuit
+    /// semantics the validator records as `Feature::ShortCircuit`.
+    fn lower_logical_chain(
+        &mut self,
+        node: &GrammarASTNode,
+        depth: usize,
+        is_and: bool,
+    ) -> Result<Expr, JsLowerError> {
+        // Short-circuit nodes are observed by the validator as
+        // `Feature::ShortCircuit`; declare it so the manifest matches.
+        self.features_used.add(Feature::ShortCircuit);
+        let mut acc: Option<Expr> = None;
+        for child in &node.children {
+            match child {
+                ASTNodeOrToken::Node(n) => {
+                    let operand = self.lower_expression(n, depth + 1)?;
+                    acc = Some(match acc.take() {
+                        None => operand,
+                        Some(lhs) => {
+                            let span = lhs.span().clone();
+                            if is_and {
+                                Expr::LogicalAnd {
+                                    lhs: Box::new(lhs),
+                                    rhs: Box::new(operand),
+                                    span,
+                                }
+                            } else {
+                                Expr::LogicalOr {
+                                    lhs: Box::new(lhs),
+                                    rhs: Box::new(operand),
+                                    span,
+                                }
+                            }
+                        }
+                    });
+                }
+                // The `&&` / `||` operator token carries no operand.
+                ASTNodeOrToken::Token(_) => {}
+            }
+        }
+        acc.ok_or_else(|| self.unsupported(node, &node.rule_name))
+    }
+
+    /// Lower a prefix `unary_expression` (`!x`, `-x`).
     ///
-    /// See the truth table in the module docs for the full mapping.
-    fn lower_literal_token(&mut self, tok: &Token) -> Result<Expr, JsLowerError> {
+    /// Children are `[op_token, operand]`.  `!` → `BuiltinCall("not")`,
+    /// `-` → `BuiltinCall("neg")` — except `-<numeric literal>` is
+    /// constant-folded into a negative literal (see module docs).  Other
+    /// prefix operators (`+`, `~`, `typeof`, `void`, `delete`) are
+    /// deferred.
+    fn lower_unary(
+        &mut self,
+        node: &GrammarASTNode,
+        depth: usize,
+    ) -> Result<Expr, JsLowerError> {
+        // The operator is the leading token; the operand is the node.
+        let op = node
+            .children
+            .iter()
+            .find_map(|c| match c {
+                ASTNodeOrToken::Token(t) => Some(t),
+                ASTNodeOrToken::Node(_) => None,
+            })
+            .ok_or_else(|| self.unsupported(node, "unary_expression (no operator)"))?;
+        let operand_node = node
+            .children
+            .iter()
+            .find_map(|c| match c {
+                ASTNodeOrToken::Node(n) => Some(n),
+                ASTNodeOrToken::Token(_) => None,
+            })
+            .ok_or_else(|| self.unsupported(node, "unary_expression (no operand)"))?;
+
+        match op.value.as_str() {
+            "!" => {
+                let operand = self.lower_expression(operand_node, depth + 1)?;
+                Ok(Expr::BuiltinCall {
+                    name: "not".to_string(),
+                    args: vec![operand],
+                    effects: EffectSet::PURE,
+                    span: self.span_of_token(op),
+                })
+            }
+            "-" => {
+                // Constant-fold `-<numeric literal>`: peel the operand
+                // spine; if it bottoms out at a single Number token, emit
+                // a negative literal directly (keeps the spec's `-7 →
+                // IntLit` row exact).
+                if let Some(tok) = single_leaf_token(peel_to_branch(operand_node)) {
+                    if matches!(tok.type_, TokenType::Number) {
+                        return self.lower_number(&format!("-{}", tok.value), self.span_of_token(op));
+                    }
+                }
+                let operand = self.lower_expression(operand_node, depth + 1)?;
+                Ok(Expr::BuiltinCall {
+                    name: "neg".to_string(),
+                    args: vec![operand],
+                    effects: EffectSet::PURE,
+                    span: self.span_of_token(op),
+                })
+            }
+            other => Err(JsLowerError {
+                message: format!(
+                    "unary operator `{other}` is deferred past M2 (only `!` and `-` supported)"
+                ),
+                line: op.line,
+                column: op.column,
+            }),
+        }
+    }
+
+    /// Classify a leaf token and build the matching SIR atom.
+    ///
+    /// Covers M1 literals plus M2 variable references.  See the truth
+    /// tables in the module docs.
+    fn lower_leaf_token(&mut self, tok: &Token) -> Result<Expr, JsLowerError> {
         let span = self.span_of_token(tok);
         match tok.type_ {
             // ── number ──────────────────────────────────────────────
-            // JS has a single numeric type.  We split on textual shape:
-            // a literal with no `.` and no exponent marker is an
-            // integer; anything else is a float.  This lets integer code
-            // round-trip cleanly through backends that distinguish.
             TokenType::Number => self.lower_number(&tok.value, span),
 
             // ── keyword literals: true / false / null ───────────────
             TokenType::Keyword => match tok.value.as_str() {
                 "true" => Ok(Expr::BoolLit { value: true, span }),
                 "false" => Ok(Expr::BoolLit { value: false, span }),
-                // `null` → the IR's single absence value.
                 "null" => Ok(Expr::NilLit { span }),
                 other => Err(JsLowerError {
-                    message: format!("unsupported keyword literal `{other}` (M1 supports only true/false/null)"),
+                    message: format!(
+                        "keyword `{other}` is not a value expression supported in M2"
+                    ),
                     line: tok.line,
                     column: tok.column,
                 }),
             },
 
             // ── string ──────────────────────────────────────────────
-            // The lexer already resolved escape sequences, so `tok.value`
-            // is the final string content.  NOTE: template literals
-            // (backtick strings) are a *different* token/rule and are
-            // deferred to a later milestone (see CHANGELOG "Deferred").
             TokenType::String => {
                 self.features_used.add(Feature::Strings);
                 Ok(Expr::StrLit {
@@ -352,25 +897,32 @@ impl Lowerer {
                 })
             }
 
-            // ── `undefined` ─────────────────────────────────────────
-            // `undefined` is not a keyword in JS — it's a global
-            // identifier, so it arrives as a `Name` token.  We special-
-            // case that exact spelling to `NilLit` (the JS null/undefined
-            // distinction is intentionally lost in v0).  Any *other*
-            // identifier is a variable reference, which is out of M1
-            // scope (deferred to M2).
+            // ── identifier: undefined / variable reference ──────────
+            // `undefined` is a global identifier, not a keyword, so it
+            // arrives as a `Name` token; collapse it to `NilLit` (the
+            // JS null/undefined distinction is intentionally lost in v0).
             TokenType::Name if tok.value == "undefined" => Ok(Expr::NilLit { span }),
-            TokenType::Name => Err(JsLowerError {
-                message: format!(
-                    "variable reference `{}` is out of scope for M1 (literals only)",
-                    tok.value
-                ),
-                line: tok.line,
-                column: tok.column,
-            }),
+            // Any other identifier is a variable reference.  Resolve it
+            // against the declared-locals set; an undeclared name is a
+            // positioned "unresolved name" error (SIR19 "Error model").
+            TokenType::Name => {
+                if self.declared_locals.contains(&tok.value) {
+                    Ok(Expr::VarRef {
+                        name: tok.value.clone(),
+                        scope: Scope::Local,
+                        span,
+                    })
+                } else {
+                    Err(JsLowerError {
+                        message: format!("unresolved name reference `{}`", tok.value),
+                        line: tok.line,
+                        column: tok.column,
+                    })
+                }
+            }
 
             other => Err(JsLowerError {
-                message: format!("unsupported literal token {other:?} (M1 supports literals only)"),
+                message: format!("unsupported token {other:?} in expression position"),
                 line: tok.line,
                 column: tok.column,
             }),
@@ -382,20 +934,21 @@ impl Lowerer {
     /// A literal is treated as an integer iff it parses as an `i64` and
     /// its text contains neither a decimal point nor an exponent marker
     /// (`e`/`E`).  Otherwise it's a float.  Hex/octal/binary integer
-    /// forms (`0x…`, `0o…`, `0b…`) and `BigInt` (`10n`) are deferred to a
-    /// later milestone.
+    /// forms (`0x…`, `0o…`, `0b…`) and `BigInt` (`10n`) are deferred.
+    ///
+    /// A leading `-` (from a constant-folded unary minus) is permitted
+    /// and parsed as part of the literal.
     fn lower_number(&mut self, text: &str, span: Span) -> Result<Expr, JsLowerError> {
         let looks_float = text.contains('.') || text.contains('e') || text.contains('E');
-        // Reject the non-decimal integer forms in M1: their `i64` parse
-        // would fail, and silently falling through to a `FloatLit` would
-        // be wrong.  Detecting them explicitly yields a clear error.
-        let non_decimal = text.len() > 1
-            && text.starts_with('0')
-            && matches!(text.as_bytes()[1], b'x' | b'X' | b'o' | b'O' | b'b' | b'B');
+        // Detect the non-decimal integer forms after any leading sign.
+        let digits = text.strip_prefix('-').unwrap_or(text);
+        let non_decimal = digits.len() > 1
+            && digits.starts_with('0')
+            && matches!(digits.as_bytes()[1], b'x' | b'X' | b'o' | b'O' | b'b' | b'B');
         if non_decimal || text.ends_with('n') {
             return Err(JsLowerError {
                 message: format!(
-                    "numeric literal `{text}` form (hex/octal/binary/BigInt) is deferred past M1"
+                    "numeric literal `{text}` form (hex/octal/binary/BigInt) is deferred past M2"
                 ),
                 line: span.start_line,
                 column: span.start_col,
@@ -406,9 +959,8 @@ impl Lowerer {
             if let Ok(value) = text.parse::<i64>() {
                 return Ok(Expr::IntLit { value, span });
             }
-            // Integer-shaped but doesn't fit i64 (e.g. very large).  Fall
-            // through to float so we don't lose the program; JS would
-            // hold it as a double anyway.
+            // Integer-shaped but doesn't fit i64.  Fall through to float
+            // so we don't lose the program; JS holds it as a double.
         }
 
         match text.parse::<f64>() {
@@ -424,16 +976,36 @@ impl Lowerer {
         }
     }
 
-    /// Build the standard "out of M1 scope" error for a node.
+    /// Build the standard "out of scope" error for a node.
     fn unsupported(&self, node: &GrammarASTNode, what: &str) -> JsLowerError {
         JsLowerError {
             message: format!(
-                "`{what}` is out of scope for M1 (literals only); deferred to a later milestone"
+                "`{what}` is out of scope for M2; deferred to a later milestone"
             ),
             line: node.start_line.unwrap_or(0),
             column: node.start_column.unwrap_or(0),
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// Lowered — a top-level item is either a statement or a tail expression
+// ---------------------------------------------------------------------------
+
+/// The result of lowering one top-level `source_element`.
+///
+/// Bindings and assignments are [`Stmt`]s that accumulate in the block;
+/// a bare expression is a candidate tail value.  Keeping the distinction
+/// explicit (rather than always wrapping in `ExprStmt`) lets
+/// [`Lowerer::lower_program`] route the final expression into the block's
+/// `value` slot, matching the SIR "statements then a value" block shape.
+///
+/// `Stmt` is boxed: it is substantially larger than `Expr` (it embeds
+/// loop/class/try variants), so an unboxed enum would size every
+/// `Lowered` to the largest variant — clippy's `large_enum_variant`.
+enum Lowered {
+    Stmt(Box<Stmt>),
+    Expr(Expr),
 }
 
 // ---------------------------------------------------------------------------
@@ -454,4 +1026,46 @@ fn single_child_node(node: &GrammarASTNode) -> Option<&GrammarASTNode> {
     } else {
         None
     }
+}
+
+/// Peel a node's single-child precedence spine down to the first node
+/// that *branches* (more than one child) or is a leaf (single token
+/// child).  Returns that node.  Unlike [`single_child_node`] this keeps
+/// descending; it's used to classify an expression's "real" shape
+/// without lowering it (e.g. is the LHS of an `expression_statement` an
+/// assignment?).
+fn peel_to_branch(node: &GrammarASTNode) -> &GrammarASTNode {
+    let mut cur = node;
+    while let Some(next) = single_child_node(cur) {
+        cur = next;
+    }
+    cur
+}
+
+/// If `node` is a leaf wrapper bottoming out at a single token, return
+/// that token.  Peels the precedence spine first, so
+/// `single_leaf_token(primary_expression-wrapping-`x`)` yields the `x`
+/// token.  Returns `None` if the bottom node branches.
+fn single_leaf_token(node: &GrammarASTNode) -> Option<&Token> {
+    peel_to_branch(node).token()
+}
+
+/// Return the first direct child node of `node` whose `rule_name` is
+/// `name`, if any.
+fn child_node_named<'a>(node: &'a GrammarASTNode, name: &str) -> Option<&'a GrammarASTNode> {
+    node.children.iter().find_map(|c| match c {
+        ASTNodeOrToken::Node(n) if n.rule_name == name => Some(n),
+        _ => None,
+    })
+}
+
+/// Return every direct child node of `node` whose `rule_name` is `name`.
+fn children_nodes_named<'a>(node: &'a GrammarASTNode, name: &str) -> Vec<&'a GrammarASTNode> {
+    node.children
+        .iter()
+        .filter_map(|c| match c {
+            ASTNodeOrToken::Node(n) if n.rule_name == name => Some(n),
+            _ => None,
+        })
+        .collect()
 }

--- a/code/specs/SIR19-javascript-to-semantic-ir.md
+++ b/code/specs/SIR19-javascript-to-semantic-ir.md
@@ -87,8 +87,19 @@ scope; the spread parts of the language we then reject at lowering).
 
 ## let / const / var
 
-All three become `LetBinding`.  The frontend doesn't preserve the
-distinction in v0 — the IR doesn't model immutability constraints, and
+All three become a binding statement.  **Implementation note (M2):** the
+frontend emits `Stmt::LetStarBinding` (sequential `let*`), **not**
+`Stmt::LetBinding`.  The coverage table above writes "LetBinding"
+generically, but the SIR validator treats a run of consecutive
+`LetBinding`s as a *parallel* group whose right-hand sides may not see
+one another, whereas JS `let`/`const`/`var` are sequentially scoped — a
+plain `let x = 1; const y = x + 1;` must validate.  `let*`'s sequential
+semantics match JS exactly, so it is the correct lowering for ordered
+top-level declarations.
+
+The frontend doesn't preserve the
+`let`/`const`/`var` distinction in v0 — the IR doesn't model immutability
+constraints, and
 JS's runtime treats `const` as advisory anyway.  A subsequent
 re-assignment to a `const`-declared name in source is **silently
 accepted** by the frontend (no error); the round-tripped Python or


### PR DESCRIPTION
Milestone M2 for the `javascript-to-semantic-ir` SIR19 frontend (builds on the merged M1 literals).

- **Variables + scope resolution:** bare identifiers → `VarRef`; `undefined` → nil; unresolved → positioned error.
- **Binding/assignment:** first occurrence of `let`/`const`/`var x = …` (or bare `x = …`) → binding; later `x = …` → `Assign`. Uses `LetStarBinding` (sequential `let*`) rather than `LetBinding` — the validator rejects parallel-let for JS's sequential scoping (`let x=1; let y=x+1;`); documented divergence from the spec table.
- **Operators:** arithmetic/comparison via `BuiltinCall`; `!`→not, unary `-`→neg (keeps M1 numeric constant-fold); `&&`/`||` → short-circuit `LogicalAnd`/`LogicalOr`; equality normalized (`==` and `===` → `=`; `!=`/`!==` → `!=`) — documented semantic change.

Operand recursion stays bounded by `MAX_EXPR_DEPTH` (256); the precedence-spine peel is iterative. Everything else (control flow, functions, calls, collections, compound assignment, member targets) returns a positioned `JsLowerError`.

**Tests:** 34 (17 new M2 + 17 M1 still green); clippy clean; security review passed. Isolated to `javascript-to-semantic-ir`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)