### PR TITLE
feat(sir-go): SIR16 MutableBindings + Loops in the Go backend (A5)

### DIFF
--- a/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
@@ -1,5 +1,61 @@
 # Changelog
 
+## 0.3.0 — SIR16 MutableBindings + Loops (A5)
+
+The next two SIR16 (v1) features land in the Go backend, mirroring the
+merged Rust backend equivalent.  Before this release the Go backend
+accepted only `Floats` + `ShortCircuit`, so every `Assign` / `While` /
+`ForRange` / `ForEach` IR node hit a `panic!` reject arm.  This release
+wires up mutation and the three loop forms end-to-end onto Go's native
+`for`.
+
+### Added
+
+- `Feature::MutableBindings` and `Feature::Loops` join the backend's
+  `ACCEPTED_FEATURES`, so a module declaring them is no longer rejected
+  by the capability check.
+- **MutableBindings** — `Stmt::Assign` to a Local/Param/Capture emits a
+  plain `<name> = <value>`.  Go has no const/mut distinction, so unlike
+  the Rust backend (which needs a `let mut` pre-pass) reassignment just
+  works against the name already declared by the matching `LetBinding`
+  (`:=`) or parameter.  A `Global` assignment writes through the runtime
+  global store (`_sir_globals[<key>] = <value>`).
+- **Loops** — `Stmt::While` / `ForRange` / `ForEach` map onto Go's
+  native `for`:
+  - `While` → `for _sir_truthy(<cond>) { <body> }` (Go's `for` is its
+    `while`; the test routes through SIR truthiness, never Go `bool`).
+  - `ForRange` → a native three-clause `for` whose `stop`/`step` bounds
+    are cached **once** into `int64` temporaries (re-evaluating Python's
+    `range` bounds each turn would be wrong).  A direction-aware
+    continue test (`_sir_range_cont`) lets a negative `step` count down.
+    The loop variable is re-bound each turn as a fresh `Value(int64(…))`
+    and guarded with `_ = <var>` so an unused loop var still compiles.
+  - `ForEach` → `for _, <var> := range _sir_seq_iter(<iter>)`.  The new
+    runtime `_sir_seq_iter` flattens a cons-list (`Pair`-chain ending in
+    `nil`) into a `[]Value` (Sequences land in a later PR, so a
+    "sequence" is still the classic cons-list).
+- Loop bodies emit in statement context: a body's trailing non-`nil`
+  value becomes `_ = <value>` (so side effects fire), and introduced
+  loop variables get a `_ = <var>` guard — satisfying Go's strict
+  unused-variable rule even when the body ignores them.
+- New runtime helpers `_sir_range_cont` and `_sir_seq_iter`.  (`ForRange`
+  reuses the existing `_sir_as_int` from the Floats release for its
+  bound extraction.)
+- New integration test `tests/compile_and_run_loops.rs` — hand-builds a
+  module using a mutable accumulator, a `for`-range, and a `while`
+  countdown, emits Go, `go run`s it (gated on `go` availability), and
+  asserts stdout (`sum 0..5 = 10`, countdown to `0`, reassign to `99`).
+  This is the only check that catches Go's `:=`-vs-`=` and
+  unused-variable strictness.
+
+### Notes
+
+- Only two SIR16 features remain undeclared (`Sequences`, `Maps`); their
+  `SeqLit` / `MapLit` / `SeqSet` / `MapSet` nodes still hit `panic!`
+  reject arms, kept strictly unreachable by the capability check until a
+  later PR.  `accepts_features` stays in lockstep with emit: every
+  declared feature has a real (non-panicking) emit path.
+
 ## 0.2.0 — SIR16 Floats + ShortCircuit (A4)
 
 First two SIR16 (v1) features land in the Go backend, mirroring the

--- a/code/packages/rust/semantic-ir-to-go/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-go/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-go"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Semantic IR → self-contained Go source code (SIR15). Fourth backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-go/README.md
+++ b/code/packages/rust/semantic-ir-to-go/README.md
@@ -37,9 +37,32 @@ Accepts the full v0 feature set minus `TailCalls` (Go has no TCO) and
   immediately-invoked func literal that returns the operand value
   (`a and b ⇒ b` if `a` is truthy else `a`), evaluating the left side
   exactly once.
+- **`MutableBindings`** — `Assign` re-binds an already-declared name.
+  Go has no const/mut distinction, so a Local/Param/Capture reassignment
+  is just `<name> = <value>` (the matching `LetBinding`/param already
+  declared the name with `:=`).  No `let mut` pre-pass is needed the way
+  the Rust backend needs one.  A `Global` assignment writes through the
+  runtime global store.
+- **`Loops`** — maps SIR's three loop forms onto Go's native `for`:
+  - `While { cond, body }` → `for _sir_truthy(<cond>) { <body> }`
+    (Go's `for` is its `while`; the test routes through SIR truthiness).
+  - `ForRange { var, start, stop, step, body }` → a native three-clause
+    `for`.  `stop`/`step` are cached **once** into `int64` temporaries
+    (re-evaluating Python's `range` bounds each turn would be wrong);
+    the continue test is direction-aware via `_sir_range_cont`, so a
+    negative `step` counts down.  `var` is re-bound each iteration as a
+    fresh `Value(int64(...))`.
+  - `ForEach { var, iter, body }` → `for _, <var> := range _sir_seq_iter(<iter>)`.
+    The runtime `_sir_seq_iter` flattens a cons-list (a `Pair`-chain
+    ending in `nil`) into a `[]Value` (Sequences land in a later PR, so
+    a "sequence" is still the classic cons-list).
+  Loop bodies emit in statement context: a body's trailing non-`nil`
+  value becomes `_ = <value>` so side effects still fire, and every
+  introduced loop variable gets a `_ = <var>` guard so Go's strict
+  unused-variable rule never rejects a body that ignores it.
 
-The remaining four SIR16 features (`MutableBindings`, `Loops`,
-`Sequences`, `Maps`) are not yet declared and land in later PRs.
+The remaining two SIR16 features (`Sequences`, `Maps`) are not yet
+declared and land in a later PR.
 
 ## Value model
 

--- a/code/packages/rust/semantic-ir-to-go/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/emit.rs
@@ -32,6 +32,9 @@ pub fn emit_module(m: &Module) -> String {
             t.insert(f.name.clone(), f.params.len());
         }
     });
+    // Reset the loop-id counter so emission is deterministic across
+    // repeated `emit_module` calls (the determinism test relies on this).
+    LOOP_ID.with(|c| *c.borrow_mut() = 0);
 
     let mut out = String::new();
     emit_banner(&mut out, m);
@@ -176,14 +179,53 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
                 out.push('\n');
             }
         }
-        // SIR16 statement kinds — Go backend hasn't been extended.
-        Stmt::Assign { span, .. }
-        | Stmt::While { span, .. }
-        | Stmt::ForRange { span, .. }
-        | Stmt::ForEach { span, .. }
-        | Stmt::SeqSet { span, .. }
-        | Stmt::MapSet { span, .. } => {
-            panic!("go backend reached SIR16 statement at {} — capability check should have rejected it", span);
+        // ── SIR16 mutation (MutableBindings) ────────────────────────
+        // `Assign` re-binds an already-declared name.  Go has no
+        // const/mut distinction, so a Local/Param/Capture reassignment
+        // is just `<name> = <value>` (the matching `LetBinding`/param
+        // already declared the name with `:=` / as a parameter — no
+        // `let mut` pre-pass is needed the way the Rust backend needs
+        // one).  `Global` writes through the runtime global store.
+        // Instance/ClassVar/Const/Builtin scopes belong to SIR17
+        // features this backend does not accept, so they fall through to
+        // the panic guard below.
+        Stmt::Assign {
+            name,
+            scope: Scope::Local | Scope::Param | Scope::Capture,
+            value,
+            ..
+        } => {
+            let _ = write!(out, "{}{} = ", pad, sanitize_ident(name));
+            emit_expr(out, value, indent);
+            out.push('\n');
+        }
+        Stmt::Assign { name, scope: Scope::Global, value, .. } => {
+            let _ = write!(out, "{}_sir_globals[{}] = ", pad, quote_go_string(name));
+            emit_expr(out, value, indent);
+            out.push('\n');
+        }
+        // ── SIR16 loops (Loops) ─────────────────────────────────────
+        Stmt::While { cond, body, .. } => emit_while(out, cond, body, indent),
+        Stmt::ForRange { var, start, stop, step, body, .. } => {
+            emit_for_range(out, var, start, stop, step, body, indent)
+        }
+        Stmt::ForEach { var, iter, body, .. } => {
+            emit_for_each(out, var, iter, body, indent)
+        }
+        // ── SIR16 indexed assignment (Sequences/Maps) ───────────────
+        // `Feature::Sequences`/`Feature::Maps` are not accepted by this
+        // backend, so a module using `SeqSet`/`MapSet` is rejected at
+        // the capability check before emit.  Reaching these arms is a
+        // bug.
+        Stmt::SeqSet { span, .. } | Stmt::MapSet { span, .. } => {
+            panic!("go backend reached SIR16 Seq/Map statement at {} — capability check should have rejected it", span);
+        }
+        // An `Assign` to an Instance/ClassVar/Const/Builtin scope: those
+        // scopes belong to SIR17 features this backend does not accept
+        // (or, for Builtin, are never produced by any frontend), so a
+        // validated module never reaches here.
+        Stmt::Assign { span, .. } => {
+            panic!("go backend reached an Assign to an unsupported scope at {} — capability check should have rejected it", span);
         }
         // SIR17 (classes) — `Feature::Classes` is not accepted by
         // this backend, so a class-using module is rejected by the
@@ -471,11 +513,147 @@ fn emit_block_as_expr(out: &mut String, b: &Block, indent: usize) {
 }
 
 // ---------------------------------------------------------------------------
-// TLS arity table
+// SIR16 loops (Loops)
+// ---------------------------------------------------------------------------
+
+/// Emit a block in **statement context** — used for loop bodies, whose
+/// trailing value is discarded rather than returned.  Each statement is
+/// emitted in order; the block's trailing `value` is emitted as an
+/// expression statement (`_ = <value>`) so any side effect still fires,
+/// except a bare `nil` (the common "this block yields nothing" marker),
+/// which is dropped to keep the output clean and avoid a useless
+/// `_ = nil`.  Mirrors the Rust backend's `emit_block_as_stmts`.
+fn emit_block_as_stmts(out: &mut String, b: &Block, indent: usize) {
+    let pad = indent_str(indent);
+    for s in &b.stmts {
+        emit_stmt(out, s, indent);
+    }
+    if !matches!(b.value, Expr::NilLit { .. }) {
+        let _ = write!(out, "{}_ = ", pad);
+        emit_expr(out, &b.value, indent);
+        out.push('\n');
+    }
+}
+
+/// `for _sir_truthy(<cond>) { <body> }`.  Go uses `for` as its `while`;
+/// the test routes through SIR truthiness (only `false`/`nil` are falsy)
+/// — never Go's `bool` directly, since `cond` is a `Value`.
+fn emit_while(out: &mut String, cond: &Expr, body: &Block, indent: usize) {
+    let pad = indent_str(indent);
+    let _ = write!(out, "{}for _sir_truthy(", pad);
+    emit_expr(out, cond, indent);
+    out.push_str(") {\n");
+    emit_block_as_stmts(out, body, indent + 1);
+    let _ = writeln!(out, "{}}}", pad);
+}
+
+/// `for var in range(start, stop, step)` — half-open (`stop` exclusive).
+///
+/// `stop`/`step` are evaluated **once** into block-scoped `int64`
+/// temporaries (matching Python's `range`, where re-evaluating the bound
+/// each turn would be wrong), and the loop condition is direction-aware
+/// so a negative `step` counts down correctly.  The loop variable `var`
+/// is re-bound each iteration as a fresh `Value(int64(<n>))` so the body
+/// sees it through the normal `Value` model.  A defensive `_ = <var>`
+/// guard silences Go's strict unused-variable check when the body never
+/// references the loop variable.  Mirrors the Rust backend's bound
+/// caching, expressed with Go's native three-clause `for`:
+///
+/// ```text
+/// {
+///     __sir_stop_<id> := _sir_as_int(<stop>)
+///     __sir_step_<id> := _sir_as_int(<step>)
+///     for __sir_i_<id> := _sir_as_int(<start>); _sir_range_cont(__sir_i_<id>, __sir_stop_<id>, __sir_step_<id>); __sir_i_<id> += __sir_step_<id> {
+///         <var> := Value(int64(__sir_i_<id>))
+///         _ = <var>
+///         <body>
+///     }
+/// }
+/// ```
+fn emit_for_range(
+    out: &mut String,
+    var: &str,
+    start: &Expr,
+    stop: &Expr,
+    step: &Expr,
+    body: &Block,
+    indent: usize,
+) {
+    let id = fresh_loop_id();
+    let v = sanitize_ident(var);
+    let pad = indent_str(indent);
+    let inner = indent + 1;
+    let inner_pad = indent_str(inner);
+    let body_pad = indent_str(inner + 1);
+
+    // Open a block so the loop temporaries don't leak.
+    let _ = writeln!(out, "{}{{", pad);
+
+    let _ = write!(out, "{}__sir_stop_{} := _sir_as_int(", inner_pad, id);
+    emit_expr(out, stop, inner);
+    out.push_str(")\n");
+    let _ = write!(out, "{}__sir_step_{} := _sir_as_int(", inner_pad, id);
+    emit_expr(out, step, inner);
+    out.push_str(")\n");
+
+    let _ = write!(out, "{}for __sir_i_{} := _sir_as_int(", inner_pad, id);
+    emit_expr(out, start, inner);
+    out.push(')');
+    // Direction-aware continue condition: count up while step >= 0, down
+    // otherwise.  Routed through a tiny runtime helper so the emitted
+    // `for` header stays readable.
+    let _ = writeln!(
+        out,
+        "; _sir_range_cont(__sir_i_{id}, __sir_stop_{id}, __sir_step_{id}); __sir_i_{id} += __sir_step_{id} {{",
+        id = id
+    );
+    let _ = writeln!(out, "{}{} := Value(int64(__sir_i_{}))", body_pad, v, id);
+    let _ = writeln!(out, "{}_ = {}", body_pad, v);
+    emit_block_as_stmts(out, body, inner + 1);
+    let _ = writeln!(out, "{}}}", inner_pad);
+    let _ = writeln!(out, "{}}}", pad);
+}
+
+/// `for var in iter` — iterate a sequence value.  This backend has no
+/// dedicated `Seq` value yet (Sequences land in a later PR), so a
+/// sequence is the classic cons-list (a `Pair`-chain terminated by
+/// `nil`).  The runtime `_sir_seq_iter` helper flattens that chain into
+/// a `[]Value`; the loop binds each element to `var`.  A `_ = <var>`
+/// guard silences Go's unused-variable check when the body ignores the
+/// element.  Mirrors the Rust backend's `seq_iter` approach.
+fn emit_for_each(out: &mut String, var: &str, iter: &Expr, body: &Block, indent: usize) {
+    let pad = indent_str(indent);
+    let v = sanitize_ident(var);
+    let inner = indent + 1;
+    let inner_pad = indent_str(inner);
+    let _ = write!(out, "{}for _, {} := range _sir_seq_iter(", pad, v);
+    emit_expr(out, iter, indent);
+    out.push_str(") {\n");
+    let _ = writeln!(out, "{}_ = {}", inner_pad, v);
+    emit_block_as_stmts(out, body, inner);
+    let _ = writeln!(out, "{}}}", pad);
+}
+
+// ---------------------------------------------------------------------------
+// TLS arity table + loop counter
 // ---------------------------------------------------------------------------
 
 thread_local! {
     static FN_ARITY: RefCell<HashMap<String, usize>> = RefCell::new(HashMap::new());
+    /// Monotonic per-module loop counter — gives each emitted `ForRange`
+    /// a unique suffix so its `__sir_i_`/`__sir_stop_`/`__sir_step_`
+    /// temporaries never collide with a sibling or nested loop's.
+    static LOOP_ID: RefCell<u64> = const { RefCell::new(0) };
+}
+
+/// Allocate a fresh, module-unique loop id.
+fn fresh_loop_id() -> u64 {
+    LOOP_ID.with(|c| {
+        let mut c = c.borrow_mut();
+        let id = *c;
+        *c += 1;
+        id
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -774,6 +952,150 @@ mod tests {
         );
         assert_eq!(out.matches("__l :=").count(), 2);
         assert!(out.starts_with("func() Value { __l := func() Value { __l :="));
+    }
+
+    // ── SIR16 MutableBindings + Loops ──────────────────────────────
+
+    fn ilit(v: i64) -> Expr {
+        Expr::IntLit { value: v, span: s() }
+    }
+
+    fn nil_block() -> Block {
+        Block { stmts: vec![], value: Expr::NilLit { span: s() }, span: s() }
+    }
+
+    #[test]
+    fn emit_assign_local_uses_plain_equals() {
+        // A reassignment of an already-declared local emits `=`, not
+        // `:=` — Go has no const/mut distinction so no pre-pass needed.
+        let mut out = String::new();
+        emit_stmt(
+            &mut out,
+            &Stmt::Assign {
+                name: "x".into(),
+                scope: Scope::Local,
+                value: ilit(7),
+                span: s(),
+            },
+            1,
+        );
+        assert_eq!(out, "\tx = Value(int64(7))\n");
+    }
+
+    #[test]
+    fn emit_assign_global_writes_store() {
+        let mut out = String::new();
+        emit_stmt(
+            &mut out,
+            &Stmt::Assign {
+                name: "g".into(),
+                scope: Scope::Global,
+                value: ilit(3),
+                span: s(),
+            },
+            1,
+        );
+        assert_eq!(out, "\t_sir_globals[\"g\"] = Value(int64(3))\n");
+    }
+
+    #[test]
+    fn emit_while_uses_for_with_truthy() {
+        let mut out = String::new();
+        emit_stmt(
+            &mut out,
+            &Stmt::While {
+                cond: Expr::BoolLit { value: true, span: s() },
+                body: nil_block(),
+                span: s(),
+            },
+            1,
+        );
+        assert!(out.starts_with("\tfor _sir_truthy(Value(true)) {\n"), "got: {out}");
+        // A nil block value emits no dangling `_ = nil`.
+        assert!(!out.contains("_ = Value(nil)"), "got: {out}");
+        assert!(out.trim_end().ends_with('}'));
+    }
+
+    #[test]
+    fn emit_for_range_caches_bounds_and_guards_var() {
+        // Reset the counter so the suffix is predictable in isolation.
+        LOOP_ID.with(|c| *c.borrow_mut() = 0);
+        let mut out = String::new();
+        emit_stmt(
+            &mut out,
+            &Stmt::ForRange {
+                var: "i".into(),
+                start: ilit(0),
+                stop: ilit(5),
+                step: ilit(1),
+                body: nil_block(),
+                span: s(),
+            },
+            1,
+        );
+        // Bounds cached into temps once.
+        assert!(out.contains("__sir_stop_0 := _sir_as_int(Value(int64(5)))"), "got: {out}");
+        assert!(out.contains("__sir_step_0 := _sir_as_int(Value(int64(1)))"), "got: {out}");
+        // Native three-clause for with direction-aware continue test.
+        assert!(
+            out.contains("for __sir_i_0 := _sir_as_int(Value(int64(0))); _sir_range_cont(__sir_i_0, __sir_stop_0, __sir_step_0); __sir_i_0 += __sir_step_0 {"),
+            "got: {out}"
+        );
+        // Loop var bound as a Value(int) and guarded against unused.
+        assert!(out.contains("i := Value(int64(__sir_i_0))"), "got: {out}");
+        assert!(out.contains("_ = i"), "got: {out}");
+    }
+
+    #[test]
+    fn emit_for_range_unique_ids_for_sibling_loops() {
+        LOOP_ID.with(|c| *c.borrow_mut() = 0);
+        let mk = || Stmt::ForRange {
+            var: "i".into(),
+            start: ilit(0),
+            stop: ilit(2),
+            step: ilit(1),
+            body: nil_block(),
+            span: s(),
+        };
+        let mut out = String::new();
+        emit_stmt(&mut out, &mk(), 1);
+        emit_stmt(&mut out, &mk(), 1);
+        assert!(out.contains("__sir_i_0"), "got: {out}");
+        assert!(out.contains("__sir_i_1"), "got: {out}");
+    }
+
+    #[test]
+    fn emit_for_each_iterates_via_seq_iter() {
+        let mut out = String::new();
+        emit_stmt(
+            &mut out,
+            &Stmt::ForEach {
+                var: "x".into(),
+                iter: Expr::NilLit { span: s() },
+                body: nil_block(),
+                span: s(),
+            },
+            1,
+        );
+        assert!(out.contains("for _, x := range _sir_seq_iter(Value(nil)) {"), "got: {out}");
+        assert!(out.contains("_ = x"), "got: {out}");
+    }
+
+    #[test]
+    fn emit_loop_body_keeps_non_nil_value_as_stmt() {
+        // A loop body whose trailing value is non-nil emits `_ = <value>`
+        // so the side effect still fires in statement context.
+        let mut out = String::new();
+        emit_stmt(
+            &mut out,
+            &Stmt::While {
+                cond: Expr::BoolLit { value: false, span: s() },
+                body: Block { stmts: vec![], value: ilit(9), span: s() },
+                span: s(),
+            },
+            1,
+        );
+        assert!(out.contains("_ = Value(int64(9))"), "got: {out}");
     }
 
     #[test]

--- a/code/packages/rust/semantic-ir-to-go/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/lib.rs
@@ -47,13 +47,20 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     // `Floats` adds a `float64` arm to the Go runtime's `Value` plus
     // numeric promotion across the arithmetic/comparison helpers.
     // `ShortCircuit` is pure emit (a truthy-guarded IIFE over the
-    // existing `_sir_truthy` helper) and needs no runtime change.  The
-    // remaining v1 features (MutableBindings, Loops, Sequences, Maps)
-    // are *not* yet declared, so a module using them is still rejected
-    // by the capability check before emit — keeping the `panic!`s in
-    // `emit.rs` for those nodes strictly unreachable until later PRs.
+    // existing `_sir_truthy` helper) and needs no runtime change.
     Feature::Floats,
     Feature::ShortCircuit,
+    // `MutableBindings` is pure emit — Go has native reassignment, so a
+    // re-bound name just emits `<name> = <value>` (the matching
+    // `LetBinding` already declared it with `:=`).  `Loops` maps `While`
+    // / `ForRange` / `ForEach` onto Go's native `for`; `ForEach` adds a
+    // `_sir_seq_iter` cons-list flattener to the runtime.  The two
+    // remaining v1 features (Sequences, Maps) stay *undeclared*, so a
+    // module using `SeqLit`/`MapLit`/`SeqSet`/`MapSet` is still rejected
+    // by the capability check before emit — keeping the `panic!`s in
+    // `emit.rs` for those nodes strictly unreachable until a later PR.
+    Feature::MutableBindings,
+    Feature::Loops,
 ];
 
 impl Backend for GoBackend {

--- a/code/packages/rust/semantic-ir-to-go/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/runtime.rs
@@ -406,6 +406,46 @@ func _sir_format_pair(p *Pair) string {
 	return out + ")"
 }
 
+// ── SIR16 loops: ForRange continue test ────────────────────────
+//
+// Direction-aware half-open bound check for a `ForRange` counter.  With
+// a non-negative `step` the loop runs while `i < stop` (counting up);
+// with a negative `step` it runs while `i > stop` (counting down).  This
+// keeps the emitted three-clause `for` header readable while preserving
+// Python's `range` semantics for negative steps.
+func _sir_range_cont(i int64, stop int64, step int64) bool {
+	if step >= 0 {
+		return i < stop
+	}
+	return i > stop
+}
+
+// ── SIR16 loops: cons-list iteration (ForEach) ─────────────────
+//
+// `ForEach` iterates a "sequence" value.  This backend has no dedicated
+// `Seq` value yet (Sequences land in a later PR), so a sequence is the
+// classic cons-list: a `Pair`-chain whose final `cdr` is `nil`.  `nil`
+// itself is the empty sequence.  `_sir_seq_iter` flattens that chain
+// into a `[]Value` the `for ... range` loop can walk.  An improper list
+// (a non-`nil`, non-`Pair` tail) is a programming error and panics,
+// matching the strictness of `car`/`cdr` on a non-pair.
+func _sir_seq_iter(v Value) []Value {
+	out := []Value{}
+	cur := v
+	for {
+		if cur == nil {
+			break
+		}
+		if p, ok := cur.(*Pair); ok {
+			out = append(out, p.Car)
+			cur = p.Cdr
+			continue
+		}
+		panic("cannot iterate non-sequence: " + _sir_format(cur))
+	}
+	return out
+}
+
 func _sir_builtin_closure(name string) Value {
 	return &Closure{Fn: func(args []Value) Value {
 		return _sir_call_builtin_by_name(name, args)
@@ -485,6 +525,16 @@ mod tests {
         assert!(RUNTIME.contains("_sir_any_float"));
         assert!(RUNTIME.contains("_sir_format_float"));
         assert!(RUNTIME.contains("_sir_is_number_val"));
+    }
+
+    #[test]
+    fn runtime_declares_loop_helpers() {
+        // SIR16 Loops: ForRange needs `_sir_as_int` (already present for
+        // floats) + the direction-aware `_sir_range_cont`; ForEach needs
+        // the cons-list flattener `_sir_seq_iter`.
+        assert!(RUNTIME.contains("func _sir_range_cont(i int64, stop int64, step int64) bool"));
+        assert!(RUNTIME.contains("func _sir_seq_iter(v Value) []Value"));
+        assert!(RUNTIME.contains("_sir_as_int"));
     }
 
     #[test]

--- a/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_loops.rs
+++ b/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_loops.rs
@@ -1,0 +1,211 @@
+//! End-to-end proof for SIR16 **MutableBindings** + **Loops** in the Go
+//! backend (A5).
+//!
+//! Unit tests assert the *shape* of the emitted source; this test goes
+//! the whole way: it hand-builds a SIR module that uses a mutable local,
+//! a `while` loop, and a `for`-range accumulator, emits Go, writes it to
+//! a temp `.go` file, runs it with `go run`, and checks stdout.  That
+//! closes the loop the unit tests cannot — it proves the emitted Go
+//! actually *compiles and behaves* under a real Go toolchain, which is
+//! the only way to catch Go's strict unused-variable / `:=`-vs-`=`
+//! rules (the whole reason this feature is delicate).
+//!
+//! The test gates on `go` being available (`go version`).  If the Go
+//! toolchain is absent it logs a skip rather than failing — a missing
+//! tool should never redden a build for reasons unrelated to the change
+//! (mirrors `compile_and_run_floats.rs`).
+
+use std::process::Command;
+
+use semantic_ir::{
+    Block, Effect, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, Scope,
+    Span, Stmt,
+};
+use semantic_ir_to_go::compile;
+
+fn s() -> Span {
+    Span::synthetic()
+}
+
+fn ilit(v: i64) -> Expr {
+    Expr::IntLit { value: v, span: s() }
+}
+
+fn var_local(name: &str) -> Expr {
+    Expr::VarRef { name: name.into(), scope: Scope::Local, span: s() }
+}
+
+/// `(name arg0 arg1 ...)` builtin call, pure.
+fn call(name: &str, args: Vec<Expr>) -> Expr {
+    Expr::BuiltinCall {
+        name: name.into(),
+        args,
+        effects: EffectSet::PURE,
+        span: s(),
+    }
+}
+
+/// `<name> := <value>` — first-occurrence local binding.
+fn let_local(name: &str, value: Expr) -> Stmt {
+    Stmt::LetBinding {
+        name: name.into(),
+        value,
+        sir_type: None,
+        span: s(),
+    }
+}
+
+/// `<name> = <value>` — reassignment of an already-declared local.
+fn assign_local(name: &str, value: Expr) -> Stmt {
+    Stmt::Assign {
+        name: name.into(),
+        scope: Scope::Local,
+        value,
+        span: s(),
+    }
+}
+
+/// `print(expr)` as an effectful statement.
+fn print_stmt(expr: Expr) -> Stmt {
+    Stmt::ExprStmt {
+        expr: Expr::BuiltinCall {
+            name: "print".into(),
+            args: vec![expr],
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            span: s(),
+        },
+        span: s(),
+    }
+}
+
+/// Build a module whose `main`:
+///   1. seeds a mutable `sum := 0`,
+///   2. accumulates `0+1+2+3+4` with a `for i in range(0,5,1): sum = sum + i`,
+///   3. prints `sum`                         → "10"
+///   4. seeds `n := 3`, counts it down to 0 with a `while n > 0: n = n - 1`,
+///   5. prints `n`                           → "0"
+///   6. reassigns `sum = 99` (plain MutableBindings) and prints it → "99"
+fn demo_module() -> Module {
+    let for_range = Stmt::ForRange {
+        var: "i".into(),
+        start: ilit(0),
+        stop: ilit(5),
+        step: ilit(1),
+        body: Block {
+            stmts: vec![assign_local("sum", call("+", vec![var_local("sum"), var_local("i")]))],
+            value: Expr::NilLit { span: s() },
+            span: s(),
+        },
+        span: s(),
+    };
+
+    let while_loop = Stmt::While {
+        cond: call(">", vec![var_local("n"), ilit(0)]),
+        body: Block {
+            stmts: vec![assign_local("n", call("-", vec![var_local("n"), ilit(1)]))],
+            value: Expr::NilLit { span: s() },
+            span: s(),
+        },
+        span: s(),
+    };
+
+    let stmts = vec![
+        // 1. mutable accumulator seeded at 0.
+        let_local("sum", ilit(0)),
+        // 2. for-range accumulate.
+        for_range,
+        // 3. print sum → 10.
+        print_stmt(var_local("sum")),
+        // 4. while countdown.
+        let_local("n", ilit(3)),
+        while_loop,
+        // 5. print n → 0.
+        print_stmt(var_local("n")),
+        // 6. plain reassignment, then print → 99.
+        assign_local("sum", ilit(99)),
+        print_stmt(var_local("sum")),
+    ];
+
+    Module {
+        name: "loops_demo".into(),
+        manifest: FeatureManifest::from_features(&[
+            Feature::MutableBindings,
+            Feature::Loops,
+        ]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts,
+                value: Expr::NilLit { span: s() },
+                span: s(),
+            },
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            metadata: Metadata::new(),
+            span: s(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("test")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+fn go_available() -> bool {
+    Command::new("go")
+        .arg("version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+#[test]
+fn loops_and_mutable_bindings_compile_and_run() {
+    if !go_available() {
+        eprintln!("skipping: go not on PATH");
+        return;
+    }
+
+    // 1. Emit.
+    let artifact = compile(&demo_module()).expect("module should compile to Go source");
+
+    // 2. Write the source to a unique temp file.  `go run` requires a
+    //    `.go` extension.
+    let dir = std::env::temp_dir();
+    let nonce = std::process::id();
+    let src_path = dir.join(format!("sir_go_loops_{nonce}.go"));
+    std::fs::write(&src_path, &artifact.source).expect("write temp source");
+
+    // 3. Compile + run with `go run` (arg vector — no shell).
+    let run_out = Command::new("go")
+        .arg("run")
+        .arg(&src_path)
+        .output()
+        .expect("invoke go run");
+
+    if !run_out.status.success() {
+        let stderr = String::from_utf8_lossy(&run_out.stderr);
+        let _ = std::fs::remove_file(&src_path);
+        panic!(
+            "emitted Go failed to compile/run:\n--- stderr ---\n{stderr}\n--- source ---\n{}",
+            artifact.source,
+        );
+    }
+
+    // 4. Assert the program's observable behaviour.
+    let stdout = String::from_utf8_lossy(&run_out.stdout);
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert_eq!(
+        lines,
+        vec!["10", "0", "99"],
+        "unexpected program output; full stdout:\n{stdout}"
+    );
+
+    // 5. Best-effort cleanup (ignore errors — temp dir is ephemeral).
+    let _ = std::fs::remove_file(&src_path);
+}


### PR DESCRIPTION
Continues SIR-v1 parity for the **Go** backend (after A4's Floats + ShortCircuit). Declares `Feature::MutableBindings` + `Feature::Loops` and implements their emit:
- `Stmt::Assign`: plain `<name> = <value>` (Go `LetBinding` already uses `:=`; no const/mut distinction so no pre-pass needed). Global assign → `_sir_globals[<key>] = <value>`.
- `While` → Go `for _sir_truthy(<cond>) {…}`; `ForRange` caches stop/step into int64 temps with a direction-aware `_sir_range_cont` (handles negative steps); `ForEach` → `for _, v := range _sir_seq_iter(<iter>)` (new runtime helper flattens a cons-list).
- Handles Go's strictness: `_ = <var>` guards for loop vars, statement-context loop bodies, package-level runtime helpers.

**Tests:** 35 unit + a `go run` compile-and-run loops proof (mutable accumulator + for-range + while → `10,0,99`); clippy clean; security review passed. Seq/Maps remain deferred (A6 finishes the Go backend). Isolated to `semantic-ir-to-go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)