### PR TITLE
[codex] Track paragraph font repair evidence

### DIFF
--- a/code/packages/rust/html-parser/tests/whatwg_paragraph_audit_test.rs
+++ b/code/packages/rust/html-parser/tests/whatwg_paragraph_audit_test.rs
@@ -8,6 +8,7 @@ const TREE_CONSTRUCTION_SMOKE: &str = include_str!("fixtures/html5lib-tree-const
 const WHATWG_PARAGRAPH_AUDIT: &str = include_str!("fixtures/whatwg-paragraph-audit.json");
 const POST_PARSE_REPAIR_EVIDENCE: &[(&str, &str)] = &[
     ("scripted-adoption01-dat-1", "paragraph-text-mode-boundary"),
+    ("scripted-ark-dat-1", "paragraph-text-mode-boundary"),
     ("tricky01-dat-3", "paragraph-formatting-boundary"),
     ("tricky01-dat-8", "paragraph-table-boundary"),
 ];


### PR DESCRIPTION
## Summary
- add `scripted-ark-dat-1` to the paragraph post-parse repair evidence set
- keep the case tied to the `paragraph-text-mode-boundary` audit axis so scripted font mutation remains checked in paragraph recovery coverage

## Evidence
- Negative control: temporarily disabled only `apply_scripted_font_attribute_mutation`.
- Result: `cargo test -p coding-adventures-html-parser whatwg_paragraph_audit_cases_match_parser_dom_dump` failed on `scripted-ark-dat-1`; the third nested `font` stayed `size=\"4\"` instead of the expected repaired `size=\"5\"`.
- Restored the repair hook before final validation; final diff is the single evidence-list addition.

## Validation
- `cargo test -p coding-adventures-html-parser font_newline_before_bold_stays_outside_reconstructed_font`
- `cargo test -p coding-adventures-html-parser whatwg_document_shell_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_head_body_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_form_interactive_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_legacy_element_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_paragraph_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_block_boundary_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_table_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_formatting_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_document_shell_audit_cases_match_parser_dom_dump`
- `cargo test -p coding-adventures-html-parser whatwg_head_body_audit_cases_match_parser_dom_dump`
- `cargo test -p coding-adventures-html-parser whatwg_formatting_audit_cases_match_parser_dom_dump`
- `cargo test -p coding-adventures-html-parser whatwg_paragraph_audit_cases_match_parser_dom_dump`
- `cargo test -p coding-adventures-html-parser whatwg_block_boundary_audit_cases_match_parser_dom_dump`
- `cargo test -p coding-adventures-html-parser html5lib_tree_construction_smoke_cases_match_dom_dump`
- `cargo test -p coding-adventures-html-parser`
- `cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser`
- `python3 -m json.tool code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json >/dev/null`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py`
- `git diff --check`