### PR TITLE
feat(python-sir): M2 variables, assignment, operators (B2)

### DIFF
--- a/code/packages/rust/python-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/python-to-semantic-ir/CHANGELOG.md
@@ -5,6 +5,83 @@ All notable changes to `python-to-semantic-ir` are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to semantic versioning.
 
+## 0.2.0 — 2026-06-30
+
+Milestone **M2**: variable references, assignment, and unary/binary
+operators (SIR17 Python → Semantic IR frontend, B2).
+
+### Added
+
+- **Variable references.**  A bare `Name` atom (`x`) lowers to a
+  `VarRef { name, scope }`.  Scope resolution follows the SIR17 model:
+  a name bound earlier in the current (module / `main`) scope resolves
+  to `Scope::Local`; an unbound name raises a positioned
+  `PythonLowerError("unresolved name `x`")` (no builtins are wired up
+  until calls arrive in a later milestone).
+- **Assignment with first-occurrence detection.**  `x = expr` tracks
+  declared names per scope: the **first** assignment to a name declares
+  it (emits `Stmt::LetStarBinding`), and a **subsequent** assignment to
+  an already-declared name re-binds it (emits `Stmt::Assign`, declaring
+  `Feature::MutableBindings`).  `LetStarBinding` (sequential `let*`) is
+  used rather than `LetBinding` so a later RHS can see an earlier
+  binding — the SIR validator treats consecutive `LetBinding`s as a
+  *parallel* group whose RHS cannot see one another, which would break
+  Python's top-to-bottom execution (`x = 1` then `y = x + 1`).  The RHS
+  is lowered before the name is declared, so `x = x` correctly reports
+  `x` as unresolved.
+- **Operators**, recognised by turning each precedence rule into a
+  small operator matcher (still bounded by the M1 `MAX_EXPR_DEPTH`
+  depth-tracked peel — every recursive descent increments `depth`, so
+  pathologically deep input yields a clean error, never a stack
+  overflow):
+  - arithmetic `+ - * / %` (rules `arith` / `term`) →
+    `BuiltinCall("+"/"-"/"*"/"/"/"%", [lhs, rhs])`, left-associative;
+  - comparison `== != < > <= >=` (rule `comparison` / `comp_op`) →
+    `BuiltinCall(op, [lhs, rhs])`, mapping `==`→`"="` and `!=`→`"!="`
+    per SIR17, the rest keeping their literal spelling;
+  - unary `not x` (rule `not_expr`) → `BuiltinCall("not", [x])`;
+  - unary `-x` (rule `factor`) → `BuiltinCall("neg", [x])`, with
+    `-<numeric literal>` still constant-folded to a negative literal
+    (carried from M1); unary `+x` is the identity (operand returned
+    unchanged);
+  - `x and y` / `x or y` (rules `and_expr` / `or_expr`) →
+    `LogicalAnd` / `LogicalOr` short-circuit nodes (left-nested for
+    chains), declaring `Feature::ShortCircuit`.
+- **Manifest** now also declares `Feature::ShortCircuit` (any `and`/`or`)
+  and `Feature::MutableBindings` (any re-assignment) in addition to M1's
+  `Floats` / `Strings`, keeping the declared manifest exactly matched to
+  what the module emits.  Every lowered module still round-trips through
+  `semantic_ir::validate`.
+- 16 new unit tests (35 total): operator lowering (each arithmetic /
+  comparison / unary / logical form), left-associativity and
+  precedence, variable resolution, let-then-reference, let-vs-reassign
+  first-occurrence, unresolved-name and self-reference errors,
+  short-circuit-node shape, and an extended validator round-trip set.
+
+### Changed
+
+- `compile` / `compile_source` now accept the M2 constructs above; the
+  M1 "unsupported in M1" errors for assignment, variable references, and
+  operators are replaced by real lowering.  Remaining unsupported forms
+  return `PythonLowerError("unsupported: <rule> (deferred …)")`.
+
+### Deferred
+
+Still out of scope after M2; each returns a clear
+`PythonLowerError("unsupported: <rule> (deferred …)")` at the exact
+site a later milestone will handle it:
+
+- **M3+** — control flow (`if` / `elif` / `else`, `while`, `for` /
+  `range`), `def` functions, `lambda` / closures, calls
+  (`f(...)`, `print` / `len` / `range` builtins).
+- **M4+** — sequences, maps, indexing and indexed assignment.
+- Multi-target / tuple / chained assignment (`a, b = …`, `a = b = …`),
+  attribute / subscript assignment targets, the bitwise operators
+  (`& | ^ << >> ~`), and the power operator (`**`).
+- Full SIR17 "out of scope" set: classes, exceptions, generators,
+  comprehensions, decorators, slicing, default/keyword args, string
+  methods, `with`, imports, `async`, `global` / `nonlocal`, f-strings.
+
 ## 0.1.0 — 2026-06-30
 
 Milestone **M1**: crate skeleton + literal lowering (SIR17 Python →

--- a/code/packages/rust/python-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/python-to-semantic-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "python-to-semantic-ir"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Python CST → narrow-waist Semantic IR (SIR17). Second frontend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/python-to-semantic-ir/README.md
+++ b/code/packages/rust/python-to-semantic-ir/README.md
@@ -52,12 +52,15 @@ pub struct PythonLowerError {
 `compile_source` parses then lowers; both parse and lower failures are
 surfaced as `PythonLowerError`.
 
-## Milestone status — M1 (literals)
+## Milestone status — M2 (variables, assignment, operators)
 
-M1 is the crate skeleton plus **literal lowering**.  The whole program
-is wrapped in a synthesised `main` function whose block value is the
-program's final top-level expression (or `NilLit` for an empty
-program); earlier top-level expressions become `ExprStmt`s.
+The whole program is wrapped in a synthesised `main` function whose
+block value is the program's final top-level expression (or `NilLit`
+for an empty program, or when the last statement is an assignment);
+earlier top-level statements become `ExprStmt`s (bare expressions) or
+binding / `Assign` statements.
+
+### Literals (M1, still supported)
 
 | Python source        | SIR lowering            | Feature declared |
 |----------------------|-------------------------|------------------|
@@ -68,29 +71,66 @@ program); earlier top-level expressions become `ExprStmt`s.
 | `"hi"`, `'world'`    | `StrLit { value }`      | `Strings`        |
 
 `-7` / `-2.5` are constant-folded: a `factor( "-", numeric-literal )`
-becomes a negative literal.  Unary minus on a *non*-literal is
-deferred.
+becomes a negative literal.
 
-The manifest declares **exactly** the features observed (`Floats` only
-when a float literal appears, `Strings` only when a string appears), so
-a minimal int-only program declares no extra features.  Module metadata
-records `source_language = "python"` and
+### Variables & assignment (M2)
+
+| Python source                | SIR lowering                              | Feature declared   |
+|------------------------------|-------------------------------------------|--------------------|
+| `x` (bound earlier)          | `VarRef { name, scope: Local }`           | —                  |
+| `x` (not bound)              | error: `unresolved name `x``              | —                  |
+| `x = 1` (first occurrence)   | `LetStarBinding { name, value }`          | —                  |
+| `x = 2` (already declared)   | `Assign { name, scope: Local, value }`    | `MutableBindings`  |
+
+Assignment uses **first-occurrence detection** (per scope): the first
+`x = …` declares the name, later ones re-bind it.  The frontend emits
+`LetStarBinding` (sequential `let*`) for the declaration so a later
+RHS can see an earlier binding — `x = 1` then `y = x + 1` resolves `x`
+correctly.  The RHS is lowered before the name is declared, so `x = x`
+reports `x` as unresolved (matching Python's `NameError`).
+
+### Operators (M2)
+
+| Python source                | SIR lowering                              | Feature declared   |
+|------------------------------|-------------------------------------------|--------------------|
+| `a + b`, `a - b`             | `BuiltinCall("+" / "-", [a, b])`          | —                  |
+| `a * b`, `a / b`, `a % b`    | `BuiltinCall("*" / "/" / "%", [a, b])`    | —                  |
+| `a == b`, `a != b`           | `BuiltinCall("=" / "!=", [a, b])`         | —                  |
+| `a < b`, `>`, `<=`, `>=`     | `BuiltinCall("<" / ">" / "<=" / ">=", …)` | —                  |
+| `not x`                      | `BuiltinCall("not", [x])`                 | —                  |
+| `-x` (non-literal)           | `BuiltinCall("neg", [x])`                 | —                  |
+| `+x`                         | identity (operand returned unchanged)     | —                  |
+| `a and b`                    | `LogicalAnd { lhs, rhs }`                 | `ShortCircuit`     |
+| `a or b`                     | `LogicalOr { lhs, rhs }`                  | `ShortCircuit`     |
+
+Binary operators are left-associative and respect Python precedence
+(`a + b * c` → `a + (b * c)`).  `and` / `or` use the dedicated
+short-circuit nodes rather than `BuiltinCall`, so the right operand is
+not eagerly evaluated.  Operator lowering reuses M1's depth-tracked
+peel (`MAX_EXPR_DEPTH`): every recursive descent increments the depth
+counter, so pathologically deep input yields a clean `PythonLowerError`
+instead of a native stack overflow.
+
+The manifest declares **exactly** the features observed.  Module
+metadata records `source_language = "python"` and
 `sir_version = semantic_ir::CURRENT_SIR_VERSION`.  Every lowered module
 passes `semantic_ir::validate`.
 
 ### Deferred (later milestones)
 
-Everything past literals returns a clear `PythonLowerError`
-(`"unsupported in M1: <rule>"`) so later milestones slot in where the
-error is raised today:
+Everything past M2 returns a clear `PythonLowerError`
+(`"unsupported: <rule> (deferred …)"`) so later milestones slot in
+where the error is raised today:
 
-- variable references (`x`) and assignment (`x = 1`) — M2
-- arithmetic / comparison / boolean operators — M3
 - control flow (`if` / `while` / `for`) — M3
-- functions (`def`), lambdas, calls — M4
-- sequences, maps, indexing — M5
+- functions (`def`), lambdas, calls (`f(...)`, `print` / `len` /
+  `range`) — M3/M4
+- sequences, maps, indexing — M4/M5
+- multi-target / chained assignment, attribute / subscript targets,
+  bitwise operators, the power operator (`**`)
 - and the full SIR17 "out of scope" list (classes, exceptions,
-  generators, comprehensions, decorators, `with`, `async`, imports).
+  generators, comprehensions, decorators, `with`, `async`, imports,
+  `global` / `nonlocal`, f-strings).
 
 ## Testing & coverage
 
@@ -98,10 +138,12 @@ error is raised today:
 cargo test -p python-to-semantic-ir
 ```
 
-The suite has one positive test per literal kind (int, negative int,
-float, negative float, `True`, `False`, `None`, double- and
-single-quoted strings), top-level structure tests (empty program,
-multi-statement `ExprStmt` + value split, metadata, minimal manifest),
-a `validate` round-trip across every literal shape, and error-path
-tests (assignment, bare name, operator, parse error, error position).
-This exercises ≥ 90% of the M1 surface.
+The suite (35 tests) covers: one positive test per literal kind; the
+M2 operators (each arithmetic, comparison, unary, and logical form),
+left-associativity and precedence; variable resolution,
+let-then-reference, and let-vs-reassign first-occurrence; the
+short-circuit-node shape; top-level structure (empty program,
+`ExprStmt` + value split, metadata, minimal manifest); a `validate`
+round-trip across every literal and M2 construct; and error paths
+(unresolved name, self-reference, `global`, parse error, error
+position).  This exercises ≥ 90% of the M2 surface.

--- a/code/packages/rust/python-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/python-to-semantic-ir/src/lib.rs
@@ -1,6 +1,6 @@
 //! # python-to-semantic-ir
 //!
-//! Python CST → narrow-waist Semantic IR (SIR17), **milestone M1**.
+//! Python CST → narrow-waist Semantic IR (SIR17), **milestone M2**.
 //!
 //! This is the second frontend for the SIR10 narrow-waist IR (after
 //! [`twig-to-semantic-ir`]).  It consumes the generic
@@ -28,13 +28,24 @@
 //! assert!(module.functions.iter().any(|f| f.name == "main"));
 //! ```
 //!
-//! ## M1 scope
+//! ## M2 scope
 //!
-//! M1 lowers **literals only** — int, float, `True`/`False`, `None`,
-//! and strings — wrapped in a synthesised `main` function.  Variable
-//! references, assignment, operators, control flow, functions, and
-//! collections are deferred to later milestones; unhandled forms
-//! return a clear `PythonLowerError` (`"unsupported in M1: …"`).
+//! M1 lowered **literals only**.  M2 adds, still wrapped in a
+//! synthesised `main` function:
+//!
+//! - **variable references** — a bare `x` becomes a `VarRef` whose
+//!   `scope` is resolved (`Local` when bound, error otherwise);
+//! - **assignment** — `x = expr` is *first-occurrence* detected: the
+//!   first binding of a name declares it (`LetStarBinding`), a later
+//!   assignment re-binds it (`Assign`);
+//! - **operators** — arithmetic (`+ - * / %`) and comparison
+//!   (`== != < > <= >=`) lower to `BuiltinCall`; unary `not`/`-` to
+//!   `BuiltinCall("not"/"neg")` (with `-<literal>` constant-folded);
+//!   `and`/`or` to the short-circuit `LogicalAnd`/`LogicalOr` nodes.
+//!
+//! Control flow, functions/`def`/`lambda`, calls, and collections are
+//! deferred to later milestones; unhandled forms return a clear
+//! `PythonLowerError`.
 //!
 //! See `code/specs/SIR17-python-to-semantic-ir.md` for the full
 //! lowering table and the deferred-form roadmap.
@@ -67,7 +78,7 @@ pub fn compile_source(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use semantic_ir::{Expr, Feature, Stmt};
+    use semantic_ir::{Expr, Feature, Scope, Stmt};
 
     /// Lower a snippet, asserting success, and return the module.
     fn lower(src: &str) -> semantic_ir::Module {
@@ -82,6 +93,16 @@ mod tests {
             .expect("main exists")
             .body
             .value
+    }
+
+    /// Fetch `main`'s block statements.
+    fn main_stmts(m: &semantic_ir::Module) -> &[Stmt] {
+        &m.functions
+            .iter()
+            .find(|f| f.name == "main")
+            .expect("main exists")
+            .body
+            .stmts
     }
 
     // ── one positive test per literal kind ────────────────────────────
@@ -225,35 +246,282 @@ mod tests {
 
     #[test]
     fn lowered_modules_pass_the_validator() {
-        for src in ["", "42\n", "3.25\n", "True\n", "None\n", "\"hi\"\n", "-7\n", "1\n2\n"] {
+        for src in [
+            "",
+            "42\n",
+            "3.25\n",
+            "True\n",
+            "None\n",
+            "\"hi\"\n",
+            "-7\n",
+            "1\n2\n",
+            // M2 constructs:
+            "x = 1\n",
+            "x = 1\nx = 2\n",
+            "x = 1\ny = x + 1\n",
+            "x = 5\ny = x * 2 + 3\n",
+            "a = 1\nb = 2\nc = a < b\n",
+            "p = True\nq = False\nr = p and q\n",
+            "m = 1\nn = not m\n",
+            "x = 10\ny = -x\n",
+            "a = 1\nb = a == a\n",
+            "a = 1\nb = a % 2\n",
+        ] {
             let m = lower(src);
             let r = semantic_ir::validate(&m);
             assert!(r.is_ok(), "module for {src:?} failed validation: {:?}", r.issues);
         }
     }
 
-    // ── error paths ──────────────────────────────────────────────────
+    // ── M2: variable references + assignment ──────────────────────────
 
     #[test]
-    fn assignment_is_unsupported_in_m1() {
-        let err = compile_source("x = 1\n", "t").expect_err("assignment rejected");
+    fn first_assignment_is_let_star_binding() {
+        let m = lower("x = 1\n");
+        match &main_stmts(&m)[0] {
+            Stmt::LetStarBinding { name, value, .. } => {
+                assert_eq!(name, "x");
+                assert!(matches!(value, Expr::IntLit { value: 1, .. }));
+            }
+            other => panic!("expected LetStarBinding, got {other:?}"),
+        }
+        // A trailing assignment yields a NilLit block value.
+        assert!(matches!(main_value(&m), Expr::NilLit { .. }));
+    }
+
+    #[test]
+    fn reassignment_becomes_assign_and_sets_mutable_feature() {
+        let m = lower("x = 1\nx = 2\n");
+        let stmts = main_stmts(&m);
+        assert!(matches!(stmts[0], Stmt::LetStarBinding { .. }));
+        match &stmts[1] {
+            Stmt::Assign { name, scope, value, .. } => {
+                assert_eq!(name, "x");
+                assert_eq!(*scope, Scope::Local);
+                assert!(matches!(value, Expr::IntLit { value: 2, .. }));
+            }
+            other => panic!("expected Assign, got {other:?}"),
+        }
         assert!(
-            err.message.contains("unsupported in M1"),
+            m.manifest.contains(Feature::MutableBindings),
+            "reassignment must declare MutableBindings"
+        );
+    }
+
+    #[test]
+    fn variable_reference_resolves_to_local() {
+        // `x` is bound, then referenced as the trailing value.
+        let m = lower("x = 1\nx\n");
+        match main_value(&m) {
+            Expr::VarRef { name, scope, .. } => {
+                assert_eq!(name, "x");
+                assert_eq!(*scope, Scope::Local);
+            }
+            other => panic!("expected VarRef, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn let_then_reference_in_rhs_resolves() {
+        // `y = x + 1` must see the prior `x` binding (sequential let*).
+        let m = lower("x = 2\ny = x + 1\n");
+        match &main_stmts(&m)[1] {
+            Stmt::LetStarBinding { name, value, .. } => {
+                assert_eq!(name, "y");
+                match value {
+                    Expr::BuiltinCall { name, args, .. } => {
+                        assert_eq!(name, "+");
+                        assert!(matches!(args[0], Expr::VarRef { scope: Scope::Local, .. }));
+                        assert!(matches!(args[1], Expr::IntLit { value: 1, .. }));
+                    }
+                    other => panic!("expected BuiltinCall(+), got {other:?}"),
+                }
+            }
+            other => panic!("expected LetStarBinding, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unresolved_name_is_an_error() {
+        let err = compile_source("x\n", "t").expect_err("unresolved name rejected");
+        assert!(
+            err.message.contains("unresolved name `x`"),
             "got: {}",
             err.message
         );
     }
 
     #[test]
-    fn bare_name_reference_is_unsupported_in_m1() {
-        let err = compile_source("x\n", "t").expect_err("name ref rejected");
-        assert!(err.message.contains("unsupported in M1"), "got: {}", err.message);
+    fn self_reference_first_binding_is_unresolved() {
+        // `x = x` — the RHS `x` is not yet bound, so it's unresolved.
+        let err = compile_source("x = x\n", "t").expect_err("self-ref rejected");
+        assert!(err.message.contains("unresolved name"), "got: {}", err.message);
+    }
+
+    // ── M2: binary arithmetic operators ───────────────────────────────
+
+    #[test]
+    fn arithmetic_operators_lower_to_builtin_calls() {
+        for (src, op) in [
+            ("a = 1\na + 1\n", "+"),
+            ("a = 1\na - 1\n", "-"),
+            ("a = 1\na * 2\n", "*"),
+            ("a = 1\na / 2\n", "/"),
+            ("a = 1\na % 2\n", "%"),
+        ] {
+            let m = lower(src);
+            match main_value(&m) {
+                Expr::BuiltinCall { name, args, .. } => {
+                    assert_eq!(name, op, "for {src:?}");
+                    assert_eq!(args.len(), 2);
+                }
+                other => panic!("expected BuiltinCall({op}) for {src:?}, got {other:?}"),
+            }
+        }
     }
 
     #[test]
-    fn operator_expression_is_unsupported_in_m1() {
-        let err = compile_source("1 + 2\n", "t").expect_err("operator rejected");
-        assert!(err.message.contains("unsupported in M1"), "got: {}", err.message);
+    fn arithmetic_is_left_associative() {
+        // `a - b - c` → ((a - b) - c).
+        let m = lower("a = 1\nb = 1\nc = 1\na - b - c\n");
+        match main_value(&m) {
+            Expr::BuiltinCall { name, args, .. } => {
+                assert_eq!(name, "-");
+                // lhs is itself a (a - b) call; rhs is c.
+                assert!(matches!(&args[0], Expr::BuiltinCall { name, .. } if name == "-"));
+                assert!(matches!(&args[1], Expr::VarRef { name, .. } if name == "c"));
+            }
+            other => panic!("expected nested BuiltinCall(-), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn precedence_multiply_binds_tighter_than_add() {
+        // `a + b * c` → a + (b * c).
+        let m = lower("a = 1\nb = 1\nc = 1\na + b * c\n");
+        match main_value(&m) {
+            Expr::BuiltinCall { name, args, .. } => {
+                assert_eq!(name, "+");
+                assert!(matches!(&args[0], Expr::VarRef { name, .. } if name == "a"));
+                assert!(matches!(&args[1], Expr::BuiltinCall { name, .. } if name == "*"));
+            }
+            other => panic!("expected BuiltinCall(+), got {other:?}"),
+        }
+    }
+
+    // ── M2: comparison operators ──────────────────────────────────────
+
+    #[test]
+    fn comparison_operators_lower_to_builtin_calls() {
+        for (src, op) in [
+            ("a = 1\na < 1\n", "<"),
+            ("a = 1\na > 1\n", ">"),
+            ("a = 1\na <= 1\n", "<="),
+            ("a = 1\na >= 1\n", ">="),
+            ("a = 1\na == 1\n", "="),  // == maps to "="
+            ("a = 1\na != 1\n", "!="),
+        ] {
+            let m = lower(src);
+            match main_value(&m) {
+                Expr::BuiltinCall { name, args, .. } => {
+                    assert_eq!(name, op, "for {src:?}");
+                    assert_eq!(args.len(), 2);
+                }
+                other => panic!("expected BuiltinCall({op}) for {src:?}, got {other:?}"),
+            }
+        }
+    }
+
+    // ── M2: unary operators ───────────────────────────────────────────
+
+    #[test]
+    fn unary_not_lowers_to_builtin_not() {
+        let m = lower("c = True\nnot c\n");
+        match main_value(&m) {
+            Expr::BuiltinCall { name, args, .. } => {
+                assert_eq!(name, "not");
+                assert_eq!(args.len(), 1);
+                assert!(matches!(args[0], Expr::VarRef { .. }));
+            }
+            other => panic!("expected BuiltinCall(not), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unary_minus_on_variable_lowers_to_neg() {
+        let m = lower("d = 1\n-d\n");
+        match main_value(&m) {
+            Expr::BuiltinCall { name, args, .. } => {
+                assert_eq!(name, "neg");
+                assert_eq!(args.len(), 1);
+                assert!(matches!(args[0], Expr::VarRef { .. }));
+            }
+            other => panic!("expected BuiltinCall(neg), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unary_minus_on_literal_still_constant_folds() {
+        // Carried from M1: `-7` folds to IntLit(-7), not BuiltinCall(neg).
+        let m = lower("-7\n");
+        assert!(matches!(main_value(&m), Expr::IntLit { value: -7, .. }));
+    }
+
+    #[test]
+    fn unary_plus_is_identity() {
+        let m = lower("e = 1\n+e\n");
+        // `+e` returns the operand unchanged — a VarRef, no builtin.
+        assert!(matches!(main_value(&m), Expr::VarRef { name, .. } if name == "e"));
+    }
+
+    // ── M2: short-circuit logical operators ───────────────────────────
+
+    #[test]
+    fn logical_and_lowers_to_short_circuit_node() {
+        let m = lower("a = True\nb = False\na and b\n");
+        match main_value(&m) {
+            Expr::LogicalAnd { lhs, rhs, .. } => {
+                assert!(matches!(**lhs, Expr::VarRef { .. }));
+                assert!(matches!(**rhs, Expr::VarRef { .. }));
+            }
+            other => panic!("expected LogicalAnd, got {other:?}"),
+        }
+        assert!(m.manifest.contains(Feature::ShortCircuit));
+    }
+
+    #[test]
+    fn logical_or_lowers_to_short_circuit_node() {
+        let m = lower("a = True\nb = False\na or b\n");
+        assert!(matches!(main_value(&m), Expr::LogicalOr { .. }));
+        assert!(m.manifest.contains(Feature::ShortCircuit));
+    }
+
+    #[test]
+    fn logical_and_is_left_nested() {
+        // `a and b and c` → (a and b) and c.
+        let m = lower("a = True\nb = True\nc = True\na and b and c\n");
+        match main_value(&m) {
+            Expr::LogicalAnd { lhs, rhs, .. } => {
+                assert!(matches!(**lhs, Expr::LogicalAnd { .. }));
+                assert!(matches!(&**rhs, Expr::VarRef { name, .. } if name == "c"));
+            }
+            other => panic!("expected nested LogicalAnd, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn no_operator_program_declares_no_short_circuit() {
+        let m = lower("x = 1\nx + 1\n");
+        assert!(!m.manifest.contains(Feature::ShortCircuit));
+        assert!(!m.manifest.contains(Feature::MutableBindings));
+    }
+
+    // ── error paths ──────────────────────────────────────────────────
+
+    #[test]
+    fn global_statement_is_unsupported() {
+        let err = compile_source("global x\n", "t").expect_err("global rejected");
+        assert!(err.message.contains("unsupported"), "got: {}", err.message);
     }
 
     #[test]
@@ -264,10 +532,9 @@ mod tests {
 
     #[test]
     fn error_carries_position() {
-        // The error position is taken from the offending node; just
-        // assert it is populated (1-based) rather than a fixed value.
-        let err = compile_source("x = 1\n", "t").unwrap_err();
-        assert!(err.line >= 1);
+        // A reference on line 2 should report line 2.
+        let err = compile_source("x = 1\nzzz\n", "t").unwrap_err();
+        assert_eq!(err.line, 2, "got {}:{}", err.line, err.column);
         assert!(err.column >= 1);
     }
 }

--- a/code/packages/rust/python-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/python-to-semantic-ir/src/lower.rs
@@ -1,11 +1,11 @@
 //! The lowering pass from `python_parser`'s generic
-//! [`GrammarASTNode`] CST → [`semantic_ir::Module`], **milestone M1**.
+//! [`GrammarASTNode`] CST → [`semantic_ir::Module`], **milestone M2**.
 //!
-//! # What M1 covers
+//! # What M1 covered (still supported)
 //!
 //! Only *literals* at the top level.  The Python parser emits a deeply
 //! nested generic CST (every precedence level of the expression
-//! grammar is its own rule), so the bulk of M1's work is *peeling*
+//! grammar is its own rule), so the bulk of M1's work was *peeling*
 //! that onion down to the single `atom` token that carries a literal.
 //!
 //! ```text
@@ -16,50 +16,97 @@
 //!         assign_stmt
 //!           expression_list
 //!             expression
-//!               walrus_expr → or_expr → … → power → await_expr
-//!                 → primary → atom
-//!                   TOKEN type_name="INT"  value="42"     ⇒ IntLit
-//!                   TOKEN type_name="FLOAT" value="3.25"  ⇒ FloatLit
-//!                   TOKEN Keyword "True"/"False"          ⇒ BoolLit
-//!                   TOKEN Keyword "None"                  ⇒ NilLit
-//!                   TOKEN String  "hi"                    ⇒ StrLit
+//!               walrus_expr → or_expr → and_expr → not_expr
+//!                 → comparison → bitwise_or → … → arith → term
+//!                   → factor → power → await_expr → primary → atom
+//!                     TOKEN type_name="INT"  value="42"     ⇒ IntLit
+//!                     TOKEN type_name="FLOAT" value="3.25"  ⇒ FloatLit
+//!                     TOKEN Keyword "True"/"False"          ⇒ BoolLit
+//!                     TOKEN Keyword "None"                  ⇒ NilLit
+//!                     TOKEN String  "hi"                    ⇒ StrLit
+//!                     TOKEN Name    "x"                     ⇒ VarRef (M2)
 //! ```
 //!
-//! Every rule between `expression` and `atom` is a *single-child
-//! wrapper* when the source is a bare literal, so we collapse the
-//! chain generically (`unwrap_single_node`) rather than naming all
-//! ~20 levels.
+//! When the source is a *bare* literal, every rule between `expression`
+//! and `atom` is a single-child wrapper, so we collapse the chain
+//! generically rather than naming all ~20 levels.
 //!
-//! ## Unary minus
+//! # What M2 adds
 //!
-//! `-7` parses as `factor( Minus, factor(…INT 7…) )`.  When `factor`
-//! has the shape `[Token("-"), Node]` and the inner node lowers to an
-//! `IntLit`/`FloatLit`, we negate it in place — a trivial constant
-//! fold, kept because the spec lists `-7 ⇒ IntLit { value }`.
+//! M2 turns the precedence-rule onion from a pure *peel* into a small
+//! *operator recogniser*.  Each precedence rule, when it actually
+//! *branches* (more than one child node, with operator tokens between),
+//! is lowered to the matching SIR node:
 //!
-//! ## Everything else is deferred
+//! | rule           | branching shape                       | SIR node                  |
+//! |----------------|---------------------------------------|---------------------------|
+//! | `or_expr`      | `a or b or …`                         | `LogicalOr` (left-nested) |
+//! | `and_expr`     | `a and b and …`                       | `LogicalAnd` (left-nested)|
+//! | `not_expr`     | `not x`                               | `BuiltinCall("not", [x])` |
+//! | `comparison`   | `a < b`, `a == b`, …                  | `BuiltinCall("<"/"="/…)`  |
+//! | `arith`        | `a + b`, `a - b`                      | `BuiltinCall("+"/"-")`    |
+//! | `term`         | `a * b`, `a / b`, `a % b`             | `BuiltinCall("*"/"/"/"%") |
+//! | `factor`       | `-x`, `+x`                            | `BuiltinCall("neg")` / id |
 //!
-//! - variable references (`x`)                 → deferred to M2
-//! - assignment (`x = 1`, `assign_suffix`)     → deferred to M2
-//! - operators / calls / collections / control → deferred to M3+
+//! Comparison maps `==`→`"="` and `!=`→`"!="` per SIR17; the rest use
+//! their literal spelling.  `and`/`or` become the dedicated
+//! short-circuit nodes (`LogicalAnd`/`LogicalOr`) rather than
+//! `BuiltinCall`, because the latter would eagerly evaluate both sides.
 //!
-//! Unhandled rules produce a clear `PythonLowerError`
-//! (`"unsupported in M1: <rule>"`) rather than silently dropping
-//! source, so later milestones can slot their extractors in exactly
-//! where the M1 error is raised today.
+//! M2 also adds **variable references** and **assignment**:
+//!
+//! - a bare `Name` token (`x`) becomes a `VarRef` whose `scope` is
+//!   resolved against the names bound so far in the current (module/
+//!   `main`) scope — `Scope::Local` when bound, otherwise a positioned
+//!   "unresolved name" error.
+//! - `x = expr` performs *first-occurrence detection*: the first time a
+//!   name is assigned in a scope it is *declared* (we emit a
+//!   `LetStarBinding`); a later assignment to an already-declared name
+//!   *mutates* it (we emit an `Assign`).  Python has no `let`/`var`
+//!   keyword, so this mirrors how the JS and Ruby sibling frontends
+//!   decide bind-vs-reassign.
+//!
+//! Why `LetStarBinding` and not `LetBinding`?  The SIR validator treats
+//! a *run* of consecutive `LetBinding`s as a **parallel**-let group:
+//! every RHS is checked in the scope *before* the group, so a later
+//! binding cannot see an earlier one (`x = 1` then `y = x + 1` would
+//! fail to resolve `x`).  `LetStarBinding` has **sequential** semantics
+//! — each RHS sees the prior bindings — which is exactly Python's
+//! top-to-bottom execution model.
+//!
+//! ## Constant-folded unary minus (carried from M1)
+//!
+//! `-7` parses as `factor( Minus, factor(…INT 7…) )`.  When the operand
+//! is a numeric *literal* we still fold the negation in place
+//! (`IntLit{-7}`), because the spec lists `-7 ⇒ IntLit { value }`.  For a
+//! non-literal operand (`-x`) we now emit `BuiltinCall("neg", [x])`
+//! instead of erroring.
+//!
+//! ## Still deferred (later milestones)
+//!
+//! - calls / functions / `def` / `lambda`                → M3+
+//! - control flow (`if` / `while` / `for`)               → M3+
+//! - collections (lists / dicts / indexing)              → M3+
+//! - `global` / `nonlocal`, multi-target assignment      → deferred
+//!
+//! Unhandled rules produce a clear `PythonLowerError` rather than
+//! silently dropping source, so later milestones can slot their
+//! extractors in exactly where the error is raised today.
 
 use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode};
 use semantic_ir::{
-    Block, Expr, Feature, FeatureManifest, Function, Metadata, Module, Span, Stmt,
+    Block, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, Scope, Span, Stmt,
 };
+use std::collections::HashSet;
 
 /// Maximum expression-nesting depth the lowerer will descend before
 /// bailing with an error.  The expression-precedence chain is ~20 levels
-/// deep for a *bare* literal, and explicit grouping/unary-minus add a
-/// level each, so a healthy human-written literal sits far below this.
+/// deep for a *bare* literal, and explicit grouping/unary operators add a
+/// level each, so a healthy human-written expression sits far below this.
 /// The cap exists purely to turn pathologically deep (but parseable)
-/// input — `((((…42…))))`, `------…42` — into a clean `PythonLowerError`
-/// instead of a native stack overflow (which aborts unrecoverably).
+/// input — `((((…42…))))`, `------…42`, `a and a and a and …` — into a
+/// clean `PythonLowerError` instead of a native stack overflow (which
+/// aborts unrecoverably and cannot be caught in Rust).
 const MAX_EXPR_DEPTH: usize = 256;
 
 // ---------------------------------------------------------------------------
@@ -97,7 +144,8 @@ impl std::error::Error for PythonLowerError {}
 /// original path).
 const FILE: &str = "<python>";
 
-/// Lower a parsed Python CST into a SIR module (M1: literals only).
+/// Lower a parsed Python CST into a SIR module (M2: literals, variable
+/// references, assignment, unary/binary operators).
 pub fn compile(tree: &GrammarASTNode, module_name: &str) -> Result<Module, PythonLowerError> {
     Lowerer::new(module_name).lower_file(tree)
 }
@@ -106,11 +154,27 @@ pub fn compile(tree: &GrammarASTNode, module_name: &str) -> Result<Module, Pytho
 // The lowerer
 // ---------------------------------------------------------------------------
 
+/// One lowered top-level statement: either a `Stmt` (an assignment) or a
+/// bare expression (an expression statement / the final value).
+///
+/// `Stmt` is boxed because it is by far the largest variant (it holds a
+/// full `Stmt`, which transitively contains `Block`s); boxing keeps the
+/// enum small and silences `clippy::large_enum_variant`.
+enum Lowered {
+    Stmt(Box<Stmt>),
+    Expr(Expr),
+}
+
 struct Lowerer {
     module_name: String,
     /// Features observed while lowering, used to build the manifest so
     /// it declares *exactly* what the module emits.
     observed: FeatureManifest,
+    /// Names already bound in the current (module / `main`) scope.  Drives
+    /// first-occurrence detection: the first `x = …` declares (`LetStar`),
+    /// later `x = …` re-assign (`Assign`), and a `VarRef` to a name in
+    /// this set resolves as `Scope::Local`.
+    declared: HashSet<String>,
 }
 
 impl Lowerer {
@@ -118,6 +182,7 @@ impl Lowerer {
         Self {
             module_name: module_name.to_string(),
             observed: FeatureManifest::new(),
+            declared: HashSet::new(),
         }
     }
 
@@ -128,11 +193,15 @@ impl Lowerer {
     /// The CST root is a `file` rule whose children are top-level
     /// `statement` nodes interleaved with stray `Newline` tokens.
     ///
-    /// In M1 every statement must be a bare literal expression.  We
-    /// lower each to an `Expr`; the *last* one becomes `main`'s block
-    /// value (Python's "last expression's value" REPL semantics), and
-    /// any earlier ones become `ExprStmt`s so they are still evaluated.
-    /// An empty program yields `main` returning `NilLit`.
+    /// Each statement lowers to either an *assignment* statement
+    /// (`LetStarBinding` / `Assign`) or a bare *expression*.  Python's
+    /// REPL "last expression is the value" rule means the trailing item,
+    /// **if it is a bare expression**, becomes `main`'s block value;
+    /// everything before it becomes a `Stmt` (assignments stay as-is,
+    /// bare expressions become `ExprStmt`s so side effects still run).
+    /// A program whose last statement is an assignment has block value
+    /// `NilLit` (assignment yields no value in Python).  An empty program
+    /// yields `main` returning `NilLit`.
     fn lower_file(&mut self, file: &GrammarASTNode) -> Result<Module, PythonLowerError> {
         if file.rule_name != "file" {
             return Err(self.err_at(
@@ -141,28 +210,36 @@ impl Lowerer {
             ));
         }
 
-        // Collect the lowered expression for each top-level statement.
-        let mut exprs: Vec<Expr> = Vec::new();
+        // Collect the lowered form of each top-level statement, in order.
+        let mut items: Vec<Lowered> = Vec::new();
         for child in &file.children {
             if let ASTNodeOrToken::Node(stmt) = child {
-                // Skip purely structural empty `statement` wrappers that
-                // carry no expression (defensive — none observed in M1).
-                if let Some(expr) = self.lower_statement(stmt)? {
-                    exprs.push(expr);
-                }
+                items.push(self.lower_statement(stmt)?);
             }
             // Token children at file level are stray NEWLINEs — ignore.
         }
 
         let span = Span::point(FILE, 1, 1);
 
-        // Split into leading ExprStmts + final value expression.
-        let value = exprs.pop().unwrap_or(Expr::NilLit { span: span.clone() });
-        let stmts: Vec<Stmt> = exprs
+        // The block value is the *last* item iff it is a bare expression;
+        // otherwise (assignment last, or empty) the value is `NilLit` and
+        // every item becomes a statement.
+        let value = match items.last() {
+            Some(Lowered::Expr(_)) => match items.pop() {
+                Some(Lowered::Expr(e)) => e,
+                _ => unreachable!("just matched Expr"),
+            },
+            _ => Expr::NilLit { span: span.clone() },
+        };
+
+        let stmts: Vec<Stmt> = items
             .into_iter()
-            .map(|expr| {
-                let s = expr.span().clone();
-                Stmt::ExprStmt { expr, span: s }
+            .map(|item| match item {
+                Lowered::Stmt(s) => *s,
+                Lowered::Expr(expr) => {
+                    let s = expr.span().clone();
+                    Stmt::ExprStmt { expr, span: s }
+                }
             })
             .collect();
 
@@ -176,7 +253,7 @@ impl Lowerer {
                 value,
                 span: span.clone(),
             },
-            effects: semantic_ir::EffectSet::PURE,
+            effects: EffectSet::PURE,
             metadata: Metadata::new(),
             span: span.clone(),
         };
@@ -198,75 +275,149 @@ impl Lowerer {
     }
 
     // -------------------------------------------------------------------
-    // statement → expression
+    // statement → assignment or expression
     // -------------------------------------------------------------------
 
-    /// Lower a top-level `statement`.  In M1 the only supported shape
-    /// is an *expression statement* (a bare literal).  Assignments,
-    /// `def`/`class`, imports, control flow, etc. are rejected with a
-    /// clear `unsupported in M1` error.
-    fn lower_statement(&mut self, stmt: &GrammarASTNode) -> Result<Option<Expr>, PythonLowerError> {
-        // Descend through the statement wrappers:
+    /// Lower a top-level `statement`.
+    ///
+    /// The supported shapes are an *assignment* (`x = expr`) and a bare
+    /// *expression statement*.  Compound statements (`if`/`def`/`for`),
+    /// `global`/`nonlocal`, imports, etc. take a different `small_stmt`
+    /// branch (e.g. `global_stmt`) and are rejected with a clear
+    /// "unsupported" error.
+    fn lower_statement(&mut self, stmt: &GrammarASTNode) -> Result<Lowered, PythonLowerError> {
+        // Descend the fixed statement spine:
         //   statement → simple_stmt → small_stmt → assign_stmt
-        // (compound statements like `if`/`def`/`for` take a different
-        // branch and are unsupported in M1.)
         let simple = self.expect_single_named(stmt, "statement", &["simple_stmt"])?;
         let small = self.expect_single_named(simple, "simple_stmt", &["small_stmt"])?;
         let assign = self.expect_single_named(small, "small_stmt", &["assign_stmt"])?;
 
-        // `assign_stmt` carries an `expression_list` and, *only for real
-        // assignments*, an `assign_suffix` (`= rhs`).  An `assign_suffix`
-        // means `x = ...`, which is deferred to M2.
-        let node_children: Vec<&GrammarASTNode> = assign
-            .children
+        // `assign_stmt` is `expression_list (assign_suffix)?`.  When an
+        // `assign_suffix` (`= rhs`) is present it's a real assignment;
+        // otherwise it's a bare expression statement.
+        let node_children: Vec<&GrammarASTNode> = child_nodes(assign);
+        let suffix = node_children
             .iter()
-            .filter_map(|c| match c {
-                ASTNodeOrToken::Node(n) => Some(n),
-                ASTNodeOrToken::Token(_) => None,
-            })
-            .collect();
-        if node_children.iter().any(|n| n.rule_name == "assign_suffix") {
-            return Err(self.err_at(
-                assign,
-                "unsupported in M1: assignment (deferred to M2)".to_string(),
-            ));
-        }
+            .find(|n| n.rule_name == "assign_suffix")
+            .copied();
 
-        let expr_list = self.expect_single_named(assign, "assign_stmt", &["expression_list"])?;
-        // An `expression_list` of one element is a single expression;
-        // multi-element (tuple / multi-target) lists are deferred.
-        let expr_nodes: Vec<&GrammarASTNode> = expr_list
-            .children
-            .iter()
-            .filter_map(|c| match c {
-                ASTNodeOrToken::Node(n) => Some(n),
-                ASTNodeOrToken::Token(_) => None,
-            })
-            .collect();
-        if expr_nodes.len() != 1 {
-            return Err(self.err_at(
-                expr_list,
-                "unsupported in M1: multi-element expression list (deferred)".to_string(),
-            ));
-        }
+        // The first `expression_list` is the assignment *target* (LHS) for
+        // an assignment, or the whole expression for a bare statement.
+        let lhs_list = self.expect_single_kind(assign, "expression_list")?;
 
-        let expr = self.lower_expr(expr_nodes[0])?;
-        Ok(Some(expr))
+        match suffix {
+            None => {
+                // Bare expression statement.
+                let expr = self.lower_expr(self.single_expr(lhs_list)?)?;
+                Ok(Lowered::Expr(expr))
+            }
+            Some(suffix) => self.lower_assignment(assign, lhs_list, suffix),
+        }
+    }
+
+    /// Lower `target = rhs` from its `assign_stmt`, target `expression_list`,
+    /// and `assign_suffix` (`= <expression_list>`).
+    ///
+    /// First-occurrence detection: the first assignment to a name emits a
+    /// `LetStarBinding` (declares it); a later assignment to an
+    /// already-declared name emits an `Assign` (re-binds, sets
+    /// `Feature::MutableBindings` via the validator).
+    fn lower_assignment(
+        &mut self,
+        assign: &GrammarASTNode,
+        lhs_list: &GrammarASTNode,
+        suffix: &GrammarASTNode,
+    ) -> Result<Lowered, PythonLowerError> {
+        // The RHS lives in the suffix's `expression_list`.
+        let rhs_list = self.expect_single_kind(suffix, "expression_list")?;
+
+        // M2 supports exactly one target = one value.  Tuple/chained
+        // assignment (`a, b = …`, `a = b = …`) is deferred.
+        let target_node = self.single_expr(lhs_list)?;
+        let rhs_node = self.single_expr(rhs_list)?;
+
+        // The target must be a bare name (`x`).  Attribute/subscript
+        // targets (`obj.x = …`, `xs[i] = …`) are deferred.
+        let name = match self.target_name(target_node)? {
+            Some(name) => name,
+            None => {
+                return Err(self.err_at(
+                    target_node,
+                    "unsupported: assignment target is not a bare name (deferred)".to_string(),
+                ))
+            }
+        };
+
+        // Lower the RHS *before* declaring the name so a self-referential
+        // first binding (`x = x`) correctly sees `x` as still-unbound and
+        // raises an unresolved-name error (Python's behaviour).
+        let value = self.lower_expr(rhs_node)?;
+        let span = self.span_of(assign);
+
+        if self.declared.contains(&name) {
+            // Re-assignment to an already-declared local.  Emitting an
+            // `Assign` means the module mutates a binding, so declare the
+            // feature (the validator also observes it; declaring it here
+            // keeps the manifest comparison balanced).
+            self.observed.add(Feature::MutableBindings);
+            Ok(Lowered::Stmt(Box::new(Stmt::Assign {
+                name,
+                scope: Scope::Local,
+                value,
+                span,
+            })))
+        } else {
+            // First occurrence: declare via sequential `let*` so later
+            // statements (and later RHS) can see it.
+            self.declared.insert(name.clone());
+            Ok(Lowered::Stmt(Box::new(Stmt::LetStarBinding {
+                name,
+                sir_type: None,
+                value,
+                span,
+            })))
+        }
+    }
+
+    /// If `node` is an expression that is *just* a bare `Name` atom,
+    /// return that name.  Used to recognise an assignment target.  Returns
+    /// `Ok(None)` for any non-trivial expression (an operator, literal,
+    /// call, …), which the caller reports as an unsupported target.
+    fn target_name(&self, node: &GrammarASTNode) -> Result<Option<String>, PythonLowerError> {
+        // Peel single-child wrappers down to the leaf, exactly like the
+        // expression peeler but without lowering — we only want to know if
+        // the bottom is a single `Name` token.
+        let mut cur = node;
+        let mut depth = 0usize;
+        loop {
+            if depth > MAX_EXPR_DEPTH {
+                return Err(self.err_at(node, "assignment target nesting too deep".to_string()));
+            }
+            if let Some(tok) = cur.token() {
+                if matches!(tok.type_, lexer::token::TokenType::Name)
+                    && tok.type_name.is_none()
+                {
+                    return Ok(Some(tok.value.clone()));
+                }
+                return Ok(None);
+            }
+            let kids = child_nodes(cur);
+            match kids.as_slice() {
+                [only] if cur.children.len() == 1 => {
+                    cur = only;
+                    depth += 1;
+                }
+                _ => return Ok(None),
+            }
+        }
     }
 
     // -------------------------------------------------------------------
-    // expression → literal
+    // expression → Expr
     // -------------------------------------------------------------------
 
-    /// Lower an expression node by peeling the precedence-rule onion
-    /// down to the literal `atom`.
-    ///
-    /// Two structural cases are handled before the generic peel:
-    ///
-    /// 1. `factor( "-", factor(...) )` — unary minus on a numeric
-    ///    literal, constant-folded into a negative `IntLit`/`FloatLit`.
-    /// 2. any other multi-child node — unsupported in M1 (it would be
-    ///    an operator, call, subscript, etc.).
+    /// Lower an expression node, recognising operators and peeling the
+    /// precedence-rule onion down to literals / variable references.
     fn lower_expr(&mut self, node: &GrammarASTNode) -> Result<Expr, PythonLowerError> {
         self.lower_expr_d(node, 0)
     }
@@ -274,16 +425,23 @@ impl Lowerer {
     /// Depth-tracked core of [`Self::lower_expr`].
     ///
     /// Python's precedence grammar wraps every expression in a deep
-    /// single-child chain (`expression → … → atom`, ~20 levels), and
-    /// source can nest arbitrarily (`((((42))))`, `------42`).  The
-    /// generic peel below and `try_unary_minus` both recurse, so the
-    /// recursion depth tracks the *input* nesting depth.  Without a cap,
-    /// pathologically deep (but parseable) input would exhaust the native
-    /// stack — an unrecoverable abort, since a Rust stack overflow cannot
-    /// be caught.  `compile` is a public entry point taking an arbitrary
-    /// CST, so we must bound this ourselves: past `MAX_EXPR_DEPTH` we
-    /// return a positioned error instead of recursing further.
-    fn lower_expr_d(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Expr, PythonLowerError> {
+    /// single-child chain, and operators / grouping / source nesting all
+    /// add depth.  Every recursive call below increments `depth`, so the
+    /// recursion depth tracks the *input* nesting depth.  `compile` is a
+    /// public entry point taking an arbitrary CST, so we bound this
+    /// ourselves: past `MAX_EXPR_DEPTH` we return a positioned error
+    /// instead of recursing further (a Rust stack overflow cannot be
+    /// caught, so this is the only way to keep `compile` total).
+    ///
+    /// The recursion is structural — each call descends into a strictly
+    /// smaller sub-tree of the (finite) CST — so it always terminates; the
+    /// depth cap only guards against the *native stack* on pathologically
+    /// deep input, never against non-termination.
+    fn lower_expr_d(
+        &mut self,
+        node: &GrammarASTNode,
+        depth: usize,
+    ) -> Result<Expr, PythonLowerError> {
         if depth > MAX_EXPR_DEPTH {
             return Err(self.err_at(
                 node,
@@ -291,93 +449,362 @@ impl Lowerer {
             ));
         }
 
-        // Case 1: unary-minus literal.  `factor` with [Minus, factor].
-        if node.rule_name == "factor" {
-            if let Some(folded) = self.try_unary_minus(node, depth)? {
-                return Ok(folded);
+        // Operator rules: handle each *branching* precedence level.  Each
+        // returns `Ok(Some(expr))` when it matched the operator shape, or
+        // `Ok(None)` to fall through to the generic peel (the rule was a
+        // single-child wrapper this time).
+        match node.rule_name.as_str() {
+            "or_expr" => {
+                if let Some(e) = self.try_logical(node, depth, "or")? {
+                    return Ok(e);
+                }
             }
+            "and_expr" => {
+                if let Some(e) = self.try_logical(node, depth, "and")? {
+                    return Ok(e);
+                }
+            }
+            "not_expr" => {
+                if let Some(e) = self.try_not(node, depth)? {
+                    return Ok(e);
+                }
+            }
+            "comparison" => {
+                if let Some(e) = self.try_comparison(node, depth)? {
+                    return Ok(e);
+                }
+            }
+            "arith" | "term" => {
+                if let Some(e) = self.try_binary_arith(node, depth)? {
+                    return Ok(e);
+                }
+            }
+            "factor" => {
+                if let Some(e) = self.try_unary_factor(node, depth)? {
+                    return Ok(e);
+                }
+            }
+            _ => {}
         }
 
-        // Case 2: a `leaf` node — exactly one child that is a Token.
-        // This is where every literal bottoms out (`atom` is a leaf).
+        // A `leaf` node — exactly one child that is a Token.  This is
+        // where every literal and bare name bottoms out.
         if let Some(tok) = node.token() {
-            return self.lower_literal_token(node, tok);
+            return self.lower_leaf_token(node, tok);
         }
 
         // Generic peel: a single Node child → recurse.  Any other shape
         // (zero children, or >1 node children, or a Token sibling) is a
-        // non-literal construct we do not handle in M1.
-        let node_children: Vec<&GrammarASTNode> = node
-            .children
-            .iter()
-            .filter_map(|c| match c {
-                ASTNodeOrToken::Node(n) => Some(n),
-                ASTNodeOrToken::Token(_) => None,
-            })
-            .collect();
-
-        match node_children.as_slice() {
+        // construct M2 does not handle (call, subscript, attribute, …).
+        let kids = child_nodes(node);
+        match kids.as_slice() {
             [only] if node.children.len() == 1 => self.lower_expr_d(only, depth + 1),
             _ => Err(self.err_at(
                 node,
-                format!("unsupported in M1: {} (only literals are lowered)", node.rule_name),
+                format!("unsupported: {} (deferred to a later milestone)", node.rule_name),
             )),
         }
     }
 
-    /// Recognise `factor( Token("-"), Node )` and constant-fold the
-    /// negation when the inner node is a numeric literal.  Returns
-    /// `Ok(None)` if `node` is not a unary-minus factor, letting the
-    /// caller fall through to the generic peel.
-    fn try_unary_minus(
+    /// `or_expr` / `and_expr`: `a (op b)+` where `op` is the keyword
+    /// `or`/`and`.  Lowers to left-nested `LogicalOr`/`LogicalAnd`
+    /// short-circuit nodes (so `a and b and c` is `(a and b) and c`).
+    /// Returns `Ok(None)` when the node is a single-child wrapper (no
+    /// operator present at this level).
+    fn try_logical(
+        &mut self,
+        node: &GrammarASTNode,
+        depth: usize,
+        keyword: &str,
+    ) -> Result<Option<Expr>, PythonLowerError> {
+        // Operands are the node children; operators are the `keyword`
+        // tokens between them.  A bare wrapper has one node child and no
+        // operator token → fall through.
+        let operands = child_nodes(node);
+        let has_kw = node.children.iter().any(|c| {
+            matches!(c, ASTNodeOrToken::Token(t)
+                if t.type_ == lexer::token::TokenType::Keyword && t.value == keyword)
+        });
+        if !has_kw {
+            return Ok(None);
+        }
+        if operands.len() < 2 {
+            // A keyword token but fewer than two operands is malformed.
+            return Err(self.err_at(node, format!("malformed `{keyword}` expression")));
+        }
+
+        // Fold left: ((o0 op o1) op o2) …  Each operand is one precedence
+        // level lower, so descend with depth+1.
+        let mut acc = self.lower_expr_d(operands[0], depth + 1)?;
+        for operand in &operands[1..] {
+            let rhs = self.lower_expr_d(operand, depth + 1)?;
+            let span = acc.span().clone();
+            acc = if keyword == "and" {
+                Expr::LogicalAnd {
+                    lhs: Box::new(acc),
+                    rhs: Box::new(rhs),
+                    span,
+                }
+            } else {
+                Expr::LogicalOr {
+                    lhs: Box::new(acc),
+                    rhs: Box::new(rhs),
+                    span,
+                }
+            };
+        }
+        self.observed.add(Feature::ShortCircuit);
+        Ok(Some(acc))
+    }
+
+    /// `not_expr`: `not <not_expr>` → `BuiltinCall("not", [operand])`.
+    /// Returns `Ok(None)` when there is no leading `not` keyword (the rule
+    /// was a single-child wrapper around a `comparison`).
+    fn try_not(
         &mut self,
         node: &GrammarASTNode,
         depth: usize,
     ) -> Result<Option<Expr>, PythonLowerError> {
-        // Exactly two children: a leading Token and an inner Node.
+        let leads_with_not = matches!(
+            node.children.first(),
+            Some(ASTNodeOrToken::Token(t))
+                if t.type_ == lexer::token::TokenType::Keyword && t.value == "not"
+        );
+        if !leads_with_not {
+            return Ok(None);
+        }
+        // The operand is the single node child after the keyword.
+        let operand_node = child_nodes(node).into_iter().next().ok_or_else(|| {
+            self.err_at(node, "malformed `not` expression (missing operand)".to_string())
+        })?;
+        let operand = self.lower_expr_d(operand_node, depth + 1)?;
+        let span = self.span_of(node);
+        Ok(Some(Expr::BuiltinCall {
+            name: "not".to_string(),
+            args: vec![operand],
+            effects: EffectSet::PURE,
+            span,
+        }))
+    }
+
+    /// `comparison`: `a comp_op b (comp_op c)…` → left-nested
+    /// `BuiltinCall(op, [lhs, rhs])`.  Each `comp_op` wraps the operator
+    /// token; we map `==`→`"="`, `!=`→`"!="`, and the ordering ops to
+    /// their literal spelling.  Returns `Ok(None)` for a bare wrapper.
+    fn try_comparison(
+        &mut self,
+        node: &GrammarASTNode,
+        depth: usize,
+    ) -> Result<Option<Expr>, PythonLowerError> {
+        // children: operand, comp_op, operand, comp_op, operand, …
+        // We need at least one `comp_op` to be an actual comparison.
+        let has_comp_op = node
+            .children
+            .iter()
+            .any(|c| matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "comp_op"));
+        if !has_comp_op {
+            return Ok(None);
+        }
+
+        // Walk the children left to right, alternating operand / comp_op.
+        let mut acc: Option<Expr> = None;
+        let mut pending_op: Option<String> = None;
+        for child in &node.children {
+            match child {
+                ASTNodeOrToken::Node(n) if n.rule_name == "comp_op" => {
+                    pending_op = Some(self.comp_op_name(n)?);
+                }
+                ASTNodeOrToken::Node(n) => {
+                    let operand = self.lower_expr_d(n, depth + 1)?;
+                    acc = Some(match (acc.take(), pending_op.take()) {
+                        // First operand: nothing to combine yet.
+                        (None, _) => operand,
+                        // lhs op operand → builtin compare.
+                        (Some(lhs), Some(op)) => {
+                            let span = lhs.span().clone();
+                            Expr::BuiltinCall {
+                                name: op,
+                                args: vec![lhs, operand],
+                                effects: EffectSet::PURE,
+                                span,
+                            }
+                        }
+                        // operand with no preceding comp_op — malformed.
+                        (Some(_), None) => {
+                            return Err(self.err_at(node, "malformed comparison".to_string()))
+                        }
+                    });
+                }
+                ASTNodeOrToken::Token(_) => {
+                    // No bare operator tokens directly under `comparison`
+                    // (they live inside `comp_op`); ignore defensively.
+                }
+            }
+        }
+        match acc {
+            Some(e) => Ok(Some(e)),
+            None => Err(self.err_at(node, "empty comparison".to_string())),
+        }
+    }
+
+    /// Map a `comp_op` node's inner operator token to its SIR builtin
+    /// name.  `==`→`"="` and `!=`→`"!="`; the ordering operators keep
+    /// their literal spelling.
+    fn comp_op_name(&self, comp_op: &GrammarASTNode) -> Result<String, PythonLowerError> {
+        let tok = comp_op.children.iter().find_map(|c| match c {
+            ASTNodeOrToken::Token(t) => Some(t),
+            ASTNodeOrToken::Node(_) => None,
+        });
+        let tok = tok.ok_or_else(|| {
+            self.err_at(comp_op, "comparison operator missing token".to_string())
+        })?;
+        let name = match tok.value.as_str() {
+            "==" => "=",
+            "!=" => "!=",
+            "<" => "<",
+            ">" => ">",
+            "<=" => "<=",
+            ">=" => ">=",
+            other => {
+                return Err(self.err_at(
+                    comp_op,
+                    format!("unsupported comparison operator `{other}` (deferred)"),
+                ))
+            }
+        };
+        Ok(name.to_string())
+    }
+
+    /// `arith` (`+`/`-`) and `term` (`*`/`/`/`%`): a left-associative run
+    /// of binary operators with operator tokens between operands.  Lowers
+    /// to left-nested `BuiltinCall(op, [lhs, rhs])`.  Returns `Ok(None)`
+    /// for a bare single-operand wrapper.
+    fn try_binary_arith(
+        &mut self,
+        node: &GrammarASTNode,
+        depth: usize,
+    ) -> Result<Option<Expr>, PythonLowerError> {
+        // Need at least one operator token to be a real binary op.
+        let has_op = node
+            .children
+            .iter()
+            .any(|c| matches!(c, ASTNodeOrToken::Token(t) if is_arith_op(&t.value)));
+        if !has_op {
+            return Ok(None);
+        }
+
+        let mut acc: Option<Expr> = None;
+        let mut pending_op: Option<String> = None;
+        for child in &node.children {
+            match child {
+                ASTNodeOrToken::Token(t) if is_arith_op(&t.value) => {
+                    pending_op = Some(t.value.clone());
+                }
+                ASTNodeOrToken::Node(n) => {
+                    let operand = self.lower_expr_d(n, depth + 1)?;
+                    acc = Some(match (acc.take(), pending_op.take()) {
+                        (None, _) => operand,
+                        (Some(lhs), Some(op)) => {
+                            let span = lhs.span().clone();
+                            Expr::BuiltinCall {
+                                name: op,
+                                args: vec![lhs, operand],
+                                effects: EffectSet::PURE,
+                                span,
+                            }
+                        }
+                        (Some(_), None) => {
+                            return Err(self.err_at(node, "malformed arithmetic expression".to_string()))
+                        }
+                    });
+                }
+                ASTNodeOrToken::Token(_) => {
+                    // A non-operator token under arith/term is unexpected.
+                }
+            }
+        }
+        match acc {
+            Some(e) => Ok(Some(e)),
+            None => Err(self.err_at(node, "empty arithmetic expression".to_string())),
+        }
+    }
+
+    /// `factor`: `(- | + | ~) <factor>`.  We handle unary `-` and `+`:
+    ///
+    /// - `-<numeric literal>` constant-folds to a negative literal
+    ///   (carried from M1, because the spec lists `-7 ⇒ IntLit`).
+    /// - `-<non-literal>` → `BuiltinCall("neg", [operand])`.
+    /// - `+<operand>` is the identity — we drop it and return the operand
+    ///   unchanged (no SIR node for unary plus).
+    /// - `~<operand>` (bitwise NOT) is deferred.
+    ///
+    /// Returns `Ok(None)` for a bare single-child `factor` (no unary op).
+    fn try_unary_factor(
+        &mut self,
+        node: &GrammarASTNode,
+        depth: usize,
+    ) -> Result<Option<Expr>, PythonLowerError> {
+        // Unary shape is exactly `[Token(op), Node(inner)]`.
         if node.children.len() != 2 {
             return Ok(None);
         }
         let (lead, inner) = (&node.children[0], &node.children[1]);
-        let is_minus = matches!(lead, ASTNodeOrToken::Token(t) if t.value == "-");
+        let op = match lead {
+            ASTNodeOrToken::Token(t) => t.value.as_str(),
+            ASTNodeOrToken::Node(_) => return Ok(None),
+        };
         let inner = match inner {
-            ASTNodeOrToken::Node(n) if is_minus => n,
-            _ => return Ok(None),
+            ASTNodeOrToken::Node(n) => n,
+            ASTNodeOrToken::Token(_) => return Ok(None),
         };
 
-        // Lower the operand, then negate iff it is numeric.  Carry the
-        // depth forward (+1) so a chain of unary minuses (`----42`) is
-        // bounded by the same `MAX_EXPR_DEPTH` budget as the peel.
         let operand = self.lower_expr_d(inner, depth + 1)?;
-        match operand {
-            Expr::IntLit { value, span } => Ok(Some(Expr::IntLit {
-                value: value.wrapping_neg(),
-                span,
-            })),
-            Expr::FloatLit { value, span } => Ok(Some(Expr::FloatLit {
-                value: -value,
-                span,
-            })),
-            // `-x`, `-True`, etc. are real unary operators → deferred.
-            _ => Err(self.err_at(
+        match op {
+            "-" => match operand {
+                // Constant-fold negation of numeric literals.
+                Expr::IntLit { value, span } => Ok(Some(Expr::IntLit {
+                    value: value.wrapping_neg(),
+                    span,
+                })),
+                Expr::FloatLit { value, span } => Ok(Some(Expr::FloatLit {
+                    value: -value,
+                    span,
+                })),
+                // `-x` on a non-literal → builtin negate.
+                other => {
+                    let span = other.span().clone();
+                    Ok(Some(Expr::BuiltinCall {
+                        name: "neg".to_string(),
+                        args: vec![other],
+                        effects: EffectSet::PURE,
+                        span,
+                    }))
+                }
+            },
+            // Unary plus is the identity in SIR — return the operand as-is.
+            "+" => Ok(Some(operand)),
+            // `~` (bitwise NOT) and any other unary token are deferred.
+            other => Err(self.err_at(
                 node,
-                "unsupported in M1: unary minus on non-literal (deferred)".to_string(),
+                format!("unsupported unary operator `{other}` (deferred)"),
             )),
         }
     }
 
-    /// Turn a leaf `atom`/literal token into the matching SIR literal.
+    /// Turn a leaf token into the matching SIR expression — a literal, or
+    /// (M2) a variable reference for a bare `Name`.
     ///
     /// Token classification (learned by inspecting real parses):
     ///
-    /// | token                                   | SIR node            |
-    /// |-----------------------------------------|---------------------|
-    /// | `type_name == "INT"`                    | `IntLit`            |
-    /// | `type_name == "FLOAT"`                  | `FloatLit` (+Floats)|
-    /// | Keyword `True` / `False`                | `BoolLit`           |
-    /// | Keyword `None`                          | `NilLit`            |
-    /// | String token                            | `StrLit` (+Strings) |
-    fn lower_literal_token(
+    /// | token                                   | SIR node               |
+    /// |-----------------------------------------|------------------------|
+    /// | `type_name == "INT"`                    | `IntLit`               |
+    /// | `type_name == "FLOAT"`                  | `FloatLit` (+Floats)   |
+    /// | Keyword `True` / `False`                | `BoolLit`              |
+    /// | Keyword `None`                          | `NilLit`               |
+    /// | String token                            | `StrLit` (+Strings)    |
+    /// | `Name` (no `type_name`)                 | `VarRef` (scope rslv)  |
+    fn lower_leaf_token(
         &mut self,
         node: &GrammarASTNode,
         tok: &lexer::token::Token,
@@ -387,15 +814,15 @@ impl Lowerer {
 
         match (type_name, tok.type_, tok.value.as_str()) {
             (Some("INT"), _, text) => {
-                let value: i64 = text.parse().map_err(|_| {
-                    self.err_at(node, format!("invalid integer literal `{text}`"))
-                })?;
+                let value: i64 = text
+                    .parse()
+                    .map_err(|_| self.err_at(node, format!("invalid integer literal `{text}`")))?;
                 Ok(Expr::IntLit { value, span })
             }
             (Some("FLOAT"), _, text) => {
-                let value: f64 = text.parse().map_err(|_| {
-                    self.err_at(node, format!("invalid float literal `{text}`"))
-                })?;
+                let value: f64 = text
+                    .parse()
+                    .map_err(|_| self.err_at(node, format!("invalid float literal `{text}`")))?;
                 self.observed.add(Feature::Floats);
                 Ok(Expr::FloatLit { value, span })
             }
@@ -415,15 +842,39 @@ impl Lowerer {
                     span,
                 })
             }
-            // A bare `Name` token (e.g. `x`) is a variable reference,
-            // deferred to M2; anything else is genuinely unsupported.
+            // A bare `Name` token is a variable reference.  Resolve its
+            // scope against the names bound so far in this scope.
+            (None, lexer::token::TokenType::Name, name) => self.resolve_var(node, name, span),
+            // Anything else is genuinely unsupported.
             _ => Err(self.err_at(
                 node,
-                format!(
-                    "unsupported in M1: token `{}` (only int/float/bool/None/string literals)",
-                    tok.value
-                ),
+                format!("unsupported token `{}` (deferred to a later milestone)", tok.value),
             )),
+        }
+    }
+
+    /// Resolve a bare name reference to a scoped `VarRef`.
+    ///
+    /// M2 scope model (per SIR17): the only binding form so far is a
+    /// top-level assignment, which becomes a *local* of `main`.  So a name
+    /// bound earlier resolves as `Scope::Local`; an unbound name is an
+    /// error (Python raises `NameError` at runtime, and we have no
+    /// builtins wired up in M2 — `print`/`len`/`range` arrive with calls
+    /// in M3).
+    fn resolve_var(
+        &mut self,
+        node: &GrammarASTNode,
+        name: &str,
+        span: Span,
+    ) -> Result<Expr, PythonLowerError> {
+        if self.declared.contains(name) {
+            Ok(Expr::VarRef {
+                name: name.to_string(),
+                scope: Scope::Local,
+                span,
+            })
+        } else {
+            Err(self.err_at(node, format!("unresolved name `{name}`")))
         }
     }
 
@@ -434,8 +885,8 @@ impl Lowerer {
     /// Assert `node.rule_name == expected` and that it has exactly one
     /// child *node* whose rule name is in `allowed`; return that child.
     /// Used to walk the fixed `statement → … → assign_stmt` spine while
-    /// emitting precise errors when an unexpected (compound-statement)
-    /// shape shows up.
+    /// emitting precise errors when an unexpected (compound-statement /
+    /// `global`/`nonlocal`) shape shows up.
     fn expect_single_named<'a>(
         &self,
         node: &'a GrammarASTNode,
@@ -448,23 +899,47 @@ impl Lowerer {
                 format!("expected `{}`, got `{}`", expected, node.rule_name),
             ));
         }
-        let node_children: Vec<&GrammarASTNode> = node
-            .children
-            .iter()
-            .filter_map(|c| match c {
-                ASTNodeOrToken::Node(n) => Some(n),
-                ASTNodeOrToken::Token(_) => None,
-            })
-            .collect();
-        match node_children.as_slice() {
+        let kids = child_nodes(node);
+        match kids.as_slice() {
             [child] if allowed.contains(&child.rule_name.as_str()) => Ok(child),
             [child] => Err(self.err_at(
                 child,
-                format!("unsupported in M1: {} (deferred)", child.rule_name),
+                format!("unsupported: {} (deferred to a later milestone)", child.rule_name),
             )),
             _ => Err(self.err_at(
                 node,
-                format!("unsupported in M1: {} with multiple parts (deferred)", expected),
+                format!("unsupported: {} with multiple parts (deferred)", expected),
+            )),
+        }
+    }
+
+    /// Find the single child node of `node` whose `rule_name == kind`.
+    /// Errors if absent.  (`assign_stmt` and `assign_suffix` both carry an
+    /// `expression_list` child this way.)
+    fn expect_single_kind<'a>(
+        &self,
+        node: &'a GrammarASTNode,
+        kind: &str,
+    ) -> Result<&'a GrammarASTNode, PythonLowerError> {
+        child_nodes(node)
+            .into_iter()
+            .find(|n| n.rule_name == kind)
+            .ok_or_else(|| self.err_at(node, format!("expected a `{kind}` child")))
+    }
+
+    /// An `expression_list` of exactly one element yields that single
+    /// `expression`; multi-element lists (tuples / multi-target) are
+    /// deferred.
+    fn single_expr<'a>(
+        &self,
+        list: &'a GrammarASTNode,
+    ) -> Result<&'a GrammarASTNode, PythonLowerError> {
+        let exprs = child_nodes(list);
+        match exprs.as_slice() {
+            [only] => Ok(only),
+            _ => Err(self.err_at(
+                list,
+                "unsupported: multi-element expression list (deferred)".to_string(),
             )),
         }
     }
@@ -487,4 +962,25 @@ impl Lowerer {
             column: node.start_column.unwrap_or(1),
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// Free helpers
+// ---------------------------------------------------------------------------
+
+/// Collect the *node* children of `node` (dropping tokens).
+fn child_nodes(node: &GrammarASTNode) -> Vec<&GrammarASTNode> {
+    node.children
+        .iter()
+        .filter_map(|c| match c {
+            ASTNodeOrToken::Node(n) => Some(n),
+            ASTNodeOrToken::Token(_) => None,
+        })
+        .collect()
+}
+
+/// Is `value` one of the binary arithmetic operator spellings the lowerer
+/// recognises under `arith` (`+`/`-`) and `term` (`*`/`/`/`%`)?
+fn is_arith_op(value: &str) -> bool {
+    matches!(value, "+" | "-" | "*" | "/" | "%")
 }

--- a/code/specs/SIR17-python-to-semantic-ir.md
+++ b/code/specs/SIR17-python-to-semantic-ir.md
@@ -60,7 +60,7 @@ versions of this frontend may accept a version parameter.
 | `None`                                 | `NilLit`                                                    |
 | `"hello"`, `'world'`                   | `StrLit { value }`                                          |
 | `name` (reference)                     | `VarRef { name, scope }` with resolved scope                |
-| `x = 1`                                | `LetBinding` (first time) or `Assign` (subsequent)          |
+| `x = 1`                                | `LetStarBinding` (first time) or `Assign` (subsequent)      |
 | `x + y`, `x - y`, `x * y`, `x / y`     | `BuiltinCall("+" / "-" / "*" / "/", [...])`                 |
 | `x % y`                                | `BuiltinCall("%", [x, y])`                                  |
 | `-x`                                   | `BuiltinCall("neg", [x])`                                   |
@@ -117,8 +117,19 @@ Same model as Twig (SIR11):
 Python lacks an explicit declaration syntax for locals — `x = 1`
 creates a local if `x` isn't already defined elsewhere in scope.
 The frontend implements first-occurrence detection: the first
-`assign(x, value)` in a function emits `LetBinding`, subsequent ones
-emit `Assign`.  The same rule applies inside loops.
+`assign(x, value)` in a function declares it, subsequent ones emit
+`Assign`.  The same rule applies inside loops.
+
+**Implementation note (M2):** the first-occurrence *declaration* emits
+a `LetStarBinding` (sequential `let*`), **not** a `LetBinding`.  The
+SIR validator treats a run of consecutive `LetBinding`s as a *parallel*
+group whose right-hand sides are all evaluated in the scope *before*
+the group, so a later binding cannot reference an earlier one
+(`x = 1` then `y = x + 1` would fail to resolve `x`).  `let*` has the
+sequential semantics Python's top-to-bottom execution requires.  The
+RHS is lowered before the name is added to the declared set, so a
+self-referential first binding (`x = x`) correctly reports `x` as
+unresolved.
 
 `global x` and `nonlocal x` declarations are **out of scope** in v0
 — the frontend rejects them.


### PR DESCRIPTION
Milestone M2 for the `python-to-semantic-ir` SIR17 frontend (builds on merged M1 literals).

- **Variables + scope resolution:** bare names → `VarRef`; unresolved → positioned error.
- **Assignment:** first `x = …` → binding + record name; later `x = …` → `Assign`. Uses `LetStarBinding` (sequential `let*`) not `LetBinding` — the validator treats consecutive LetBindings as a *parallel* group (so `x=1; y=x+1` wouldn't resolve `x`); `let*` matches Python's top-to-bottom execution. Spec's assignment/scope sections synced. (Same fix as the JS frontend M2.)
- **Operators:** arithmetic/comparison via `BuiltinCall`; `not`→not, unary `-`→neg (keeps M1 fold); `and`/`or` → short-circuit `LogicalAnd`/`LogicalOr`.

All operator descents thread `depth+1` through M1's `MAX_EXPR_DEPTH` (256) cap; flat left-assoc chains iterate (no per-operand recursion). Control flow / functions / collections / chained-assignment remain deferred (positioned errors).

**Tests:** 35 (16 new M2 + M1 still green); clippy clean; security review passed. Isolated to `python-to-semantic-ir`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)