### PR TITLE
feat(unicode-math): PR-3 — named functions (sin/cos/log/… → Call)

### DIFF
--- a/code/packages/rust/unicode-math/CHANGELOG.md
+++ b/code/packages/rust/unicode-math/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to the unicode-math pluggable frontend.
 
+## [0.3.0] — 2026-06-30
+
+### Added — PR-3: named functions
+
+- **Named functions** in ASCII letter runs → `MathExpr::Call { func, arg }`: `sin cos tan cot sec
+  csc arcsin arccos arctan sinh cosh tanh ln log exp min max gcd lcm det`, applied to the next
+  single atom (`sin x`, `log(x)`, `arcsin x`; `sin x + 1` is `(sin x) + 1`). `capabilities()` now
+  declares `functions` (enforced by the conformance harness). The function set mirrors the
+  AsciiMath frontend's `func_of`, so the two notations name the same functions.
+- The tokenizer now scans a **maximal ASCII-letter run** and carves it by **greedy longest-match**
+  against the function table (`token::function_prefix_len`): a recognised name becomes one `Func`
+  token, any other leading letter a single `Sym` — so `sinx` ⇒ `sin`·`x`, `arcsin` is one function
+  (not `arc`·…), and a non-function run like `xy` is still the product `x·y` (single-letter
+  variables, unchanged). Runs are pure ASCII (Greek/constant glyphs are multi-byte, handled
+  separately), so the byte-offset spans stay char-boundary-safe.
+- 28 unit + 1 doc test pass (new `function_runs_split_longest_match`, `named_functions`; conformance
+  corpus gains `sin x`, `log(x) + 1`, `arcsin x`); clippy `-D warnings` clean;
+  `#![forbid(unsafe_code)]`. **Out of scope (PR-4):** matrices, `\text`.
+
 ## [0.2.0] — 2026-06-30
 
 ### Added — PR-2: big operators + explicit ASCII scripts

--- a/code/packages/rust/unicode-math/Cargo.toml
+++ b/code/packages/rust/unicode-math/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unicode-math"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "A Unicode plain-math parser that implements the math-frontend MathFrontend trait: turns the math people and models actually type (x² + y² = r², √x, ½, π·α, a ≤ b) into the neutral MathExpr AST. The third pluggable frontend after LaTeX and AsciiMath (see PFE01). Total, panic-free, spanned errors."
 license = "MIT"

--- a/code/packages/rust/unicode-math/README.md
+++ b/code/packages/rust/unicode-math/README.md
@@ -19,6 +19,7 @@ ASCII syntax (AsciiMath), and raw Unicode.
 | `x²`, `x⁻¹`, `x¹⁰`, `x^2` | `Bin(Pow)` (Unicode superscripts **or** the ASCII `^` operator) |
 | `a₁`, `a₁²`, `a_i` | `Subscript` / `Pow(Subscript)` (Unicode glyph **or** ASCII `_`) |
 | `∑_(i=1)^n i`, `∫_a^b f`, `∏ x` | `BigOp { op, lower, upper, body }` (`∑ ∏ ∫ ∮ ∐`) |
+| `sin x`, `log(x)`, `arcsin x` | `Call { func, arg }` (named functions; longest-match, so `sinx` ⇒ `sin·x`) |
 | `1/2`, `½`, `⅔` | `Frac` (built-up **and** vulgar-fraction glyphs) |
 | `√x`, `∛x`, `∜x` | `Root { degree, radicand }` |
 | `a + b`, `a − b`, `a × b`, `a ⋅ b`, `a ÷ b` | `Bin(Add/Sub/Mul/Div)` |
@@ -53,7 +54,8 @@ dependency cycle); a consumer registers it.
 ## Scope
 
 PR-1 covered numbers/symbols/scripts/fractions/roots/relations/±∓; **PR-2** adds the big operators
-`∑ ∏ ∫ ∮ ∐` (with optional bounds) and the explicit ASCII script operators `^`/`_`. **Out of scope**
-(a clean spanned error, never a panic — tracked for PR-3): named functions (`sin`, `log`), matrices,
-and embedded `\text`. As in AsciiMath there are no multi-letter variables: a letter run like `xy`
-is the product `x·y` (write distinct symbols, or use Greek/constant glyphs).
+`∑ ∏ ∫ ∮ ∐` (with optional bounds) and the explicit ASCII script operators `^`/`_`; **PR-3** adds
+**named functions** (`sin cos tan … ln log exp`, longest-match so `sinx` ⇒ `sin·x`). **Out of scope**
+(a clean spanned error, never a panic — tracked for PR-4): matrices and embedded `\text`. As in
+AsciiMath there are no multi-letter variables: a non-function letter run like `xy` is the product
+`x·y` (write distinct symbols, or use Greek/constant glyphs).

--- a/code/packages/rust/unicode-math/src/lib.rs
+++ b/code/packages/rust/unicode-math/src/lib.rs
@@ -20,8 +20,9 @@
 //! vulgar fractions `½ ⅓ ¼ …`; the roots `√`, `∛`, `∜`; super/subscripts written either as
 //! Unicode glyphs (`x²`, `a₁`, `x⁻¹`) or with the explicit ASCII operators `^`/`_` (`x^2` ≡ `x²`);
 //! the **big operators** `∑ ∏ ∫ ∮ ∐` with optional lower/upper bounds (PR-2, e.g. `∑_(i=1)^n i`);
-//! and the relations `= ≠ < ≤ > ≥ ≈ ≡`. Out of scope (a clean spanned error, never a panic),
-//! tracked for PR-3: named functions (`sin`, `log`), matrices, `\text`.
+//! **named functions** `sin cos tan … ln log exp` applied to the next atom (PR-3, `sin x`, `log(x)`,
+//! `arcsin x` — longest-match, so `sinx` ⇒ `sin·x`); and the relations `= ≠ < ≤ > ≥ ≈ ≡`. Out of
+//! scope (a clean spanned error, never a panic), tracked for PR-4: matrices and `\text`.
 //!
 //! ```
 //! use unicode_math::UnicodeMath;
@@ -74,6 +75,7 @@ impl MathFrontend for UnicodeMath {
             .with_implicit_mul()
             .with_plusminus()
             .with_big_operators()
+            .with_functions()
     }
 }
 
@@ -214,6 +216,27 @@ mod tests {
         assert_eq!(p("a_i"), MathExpr::Subscript(Box::new(sym("a")), Box::new(sym("i"))));
     }
 
+    // ---- named functions (PR-3) ------------------------------------------------
+    #[test]
+    fn named_functions() {
+        use math_frontend::Func;
+        // `sin x` — a function applied to the next atom.
+        assert_eq!(p("sin x"), MathExpr::Call { func: Func::Sin, arg: Box::new(sym("x")) });
+        // glued: `sinx` ⇒ sin·x splits to `sin` then `x` (longest-match), like AsciiMath.
+        assert_eq!(p("sinx"), p("sin x"));
+        // `log(x)` — grouped argument.
+        assert_eq!(p("log(x)"), MathExpr::Call { func: Func::Log, arg: Box::new(sym("x")) });
+        // longest-match: `arcsin` is one function, not `arc`·s·i·n.
+        assert_eq!(p("arcsin x"), MathExpr::Call { func: Func::Asin, arg: Box::new(sym("x")) });
+        // `sin x + 1` is `(sin x) + 1` (one-atom argument).
+        assert_eq!(
+            p("sin x + 1"),
+            b(BinOp::Add, MathExpr::Call { func: Func::Sin, arg: Box::new(sym("x")) }, num(1))
+        );
+        // a non-function letter run is still the product of single letters.
+        assert_eq!(p("xy"), b(BinOp::Mul, sym("x"), sym("y")));
+    }
+
     #[test]
     fn a_realistic_expression() {
         // x² + y² = r²
@@ -255,8 +278,9 @@ mod tests {
         let c = UnicodeMath.capabilities();
         assert!(c.fractions && c.roots && c.powers && c.relations && c.implicit_mul && c.plusminus);
         assert!(c.big_operators); // PR-2: ∑ ∏ ∫ ∮ ∐
-        // PR-3 still to come — declared off so the harness holds us honest.
-        assert!(!c.functions && !c.matrices && !c.text);
+        assert!(c.functions);     // PR-3: sin/cos/log/… → Call
+        // Still to come — declared off so the harness holds us honest.
+        assert!(!c.matrices && !c.text);
         assert!(!c.binomials && !c.accents && !c.oversets);
     }
 
@@ -283,6 +307,9 @@ mod tests {
                 "∫_a^b f",      // integral with bounds
                 "∏ x",          // big operator, bare body
                 "x^2",          // ASCII `^` ≡ Unicode `x²`
+                "sin x",        // named function (PR-3)
+                "log(x) + 1",   // function with a grouped argument
+                "arcsin x",     // longest-match function name
                 "1 +",   // error: trailing operator
                 "(x",    // error: missing close
                 "∑",     // error: big operator with no body

--- a/code/packages/rust/unicode-math/src/parser.rs
+++ b/code/packages/rust/unicode-math/src/parser.rs
@@ -22,7 +22,7 @@
 //!   parser stack.
 
 use crate::token::{tokenize, Token, TokenKind};
-use math_frontend::{BigOp, BinOp, FrontendError, MathExpr, Number, RelOp, UnaryOp};
+use math_frontend::{BigOp, BinOp, Func, FrontendError, MathExpr, Number, RelOp, UnaryOp};
 
 /// Maximum *nesting* depth before refusing with a spanned error (never overflow). Kept well
 /// below what would exhaust a test-thread stack so the guard fires before the stack does.
@@ -203,6 +203,7 @@ impl Parser<'_> {
             self.peek(),
             TokenKind::Num(_)
                 | TokenKind::Sym(_)
+                | TokenKind::Func(_)
                 | TokenKind::VulgarFrac(_, _)
                 | TokenKind::Sqrt
                 | TokenKind::RootN(_)
@@ -231,6 +232,12 @@ impl Parser<'_> {
             TokenKind::Sym(s) => {
                 self.advance();
                 Ok(MathExpr::Symbol(s))
+            }
+            TokenKind::Func(name) => {
+                // A named function applied to the next single atom (`sin x`, `log(x)`), the same
+                // "one atom argument" convention as roots — so `sin x + 1` is `(sin x) + 1`.
+                self.advance();
+                Ok(MathExpr::Call { func: func_of(&name), arg: Box::new(self.parse_atom()?) })
             }
             TokenKind::VulgarFrac(n, d) => {
                 self.advance();
@@ -299,6 +306,35 @@ impl Parser<'_> {
             }
             _ => Err(self.error_here("expected a closing bracket")),
         }
+    }
+}
+
+/// The neutral [`Func`] for a recognised function name. The tokenizer only emits names that
+/// [`crate::token`]'s `is_function` accepted, so `Other` is a defensive fallback (the closed
+/// variants below cover the whole accepted set, matching the AsciiMath frontend's `func_of`).
+fn func_of(name: &str) -> Func {
+    match name {
+        "sin" => Func::Sin,
+        "cos" => Func::Cos,
+        "tan" => Func::Tan,
+        "cot" => Func::Cot,
+        "sec" => Func::Sec,
+        "csc" => Func::Csc,
+        "arcsin" => Func::Asin,
+        "arccos" => Func::Acos,
+        "arctan" => Func::Atan,
+        "sinh" => Func::Sinh,
+        "cosh" => Func::Cosh,
+        "tanh" => Func::Tanh,
+        "ln" => Func::Ln,
+        "log" => Func::Log,
+        "exp" => Func::Exp,
+        "min" => Func::Min,
+        "max" => Func::Max,
+        "gcd" => Func::Gcd,
+        "lcm" => Func::Lcm,
+        "det" => Func::Det,
+        _ => Func::Other(name.to_string()),
     }
 }
 

--- a/code/packages/rust/unicode-math/src/token.rs
+++ b/code/packages/rust/unicode-math/src/token.rs
@@ -34,6 +34,9 @@ pub enum TokenKind {
     Num(String),
     /// A single variable letter, or the canonical name of a constant/Greek glyph (`"pi"`).
     Sym(String),
+    /// A named function recognised in an ASCII letter run — `"sin"`, `"log"`, `"exp"`, … The
+    /// parser maps it to [`math_frontend::Func`] and applies it to the following atom.
+    Func(String),
     /// A superscript run normalised to a plain numeral (`"2"`, `"-1"`) — becomes a power.
     Super(String),
     /// A subscript run normalised to a plain numeral (`"1"`) — becomes a subscript.
@@ -151,6 +154,35 @@ fn vulgar_fraction(c: char) -> Option<(&'static str, &'static str)> {
     })
 }
 
+/// Is `name` a recognised named function? The set mirrors the AsciiMath frontend's `func_of`
+/// table so the two notations name the same functions; the parser maps each to
+/// [`math_frontend::Func`]. (Single letters are never functions, so the shortest entry is `ln`.)
+fn is_function(name: &str) -> bool {
+    matches!(
+        name,
+        "sin" | "cos" | "tan" | "cot" | "sec" | "csc"
+            | "arcsin" | "arccos" | "arctan"
+            | "sinh" | "cosh" | "tanh"
+            | "ln" | "log" | "exp"
+            | "min" | "max" | "gcd" | "lcm" | "det"
+    )
+}
+
+/// The longest function name (in codepoints) that is a prefix of `chars[k..run_end]`, or `None`.
+/// Greedy longest-match (so `arcsin` wins over `arc`-then-letters, and `sin` is taken whole). The
+/// run is pure ASCII, so a codepoint count equals a byte count and the candidate slice is safe.
+fn function_prefix_len(chars: &[(usize, char)], k: usize, run_end: usize) -> Option<usize> {
+    const MAX_FN_LEN: usize = 6; // "arcsin" / "arccos" / "arctan"
+    let hi = (run_end - k).min(MAX_FN_LEN);
+    for len in (2..=hi).rev() {
+        let cand: String = chars[k..k + len].iter().map(|&(_, ch)| ch).collect();
+        if is_function(&cand) {
+            return Some(len);
+        }
+    }
+    None
+}
+
 /// Tokenize a unicode-math source string. Total and panic-free: returns the token list
 /// (terminated by [`TokenKind::Eof`]) or a single spanned [`FrontendError`].
 pub fn tokenize(src: &str) -> Result<Vec<Token>, FrontendError> {
@@ -204,6 +236,33 @@ pub fn tokenize(src: &str) -> Result<Vec<Token>, FrontendError> {
             i = j;
             continue;
         }
+        // ── ASCII letter runs → functions (longest-match) + single-letter variables ──────────
+        // A run of ASCII letters is scanned and carved by greedy longest-match against the
+        // function-name table: a recognised name (`sin`, `arcsin`, `log`, …) becomes one `Func`
+        // token; any other leading letter becomes a single `Sym` (so `xy` ⇒ `x·y`, the same
+        // single-letter-variable convention as before, and `sinx` ⇒ `sin`·`x`). Greek/constant
+        // glyphs are multi-byte and handled below, so a run here is pure ASCII — byte offsets
+        // from `char_indices` are char boundaries and slicing is panic-free.
+        if c.is_ascii_alphabetic() {
+            let mut run_end = i;
+            while matches!(chars.get(run_end), Some(&(_, ch)) if ch.is_ascii_alphabetic()) {
+                run_end += 1;
+            }
+            let mut k = i;
+            while k < run_end {
+                let s = chars[k].0;
+                if let Some(flen) = function_prefix_len(&chars, k, run_end) {
+                    let name: String = chars[k..k + flen].iter().map(|&(_, ch)| ch).collect();
+                    toks.push(Token { kind: TokenKind::Func(name), span: (s, end_of(k + flen)) });
+                    k += flen;
+                } else {
+                    toks.push(Token { kind: TokenKind::Sym(chars[k].1.to_string()), span: (s, end_of(k + 1)) });
+                    k += 1;
+                }
+            }
+            i = run_end;
+            continue;
+        }
         // ── single-codepoint tokens ──────────────────────────────────────────────────────────
         let one = (start, end_of(i + 1));
         if let Some((n, d)) = vulgar_fraction(c) {
@@ -217,7 +276,6 @@ pub fn tokenize(src: &str) -> Result<Vec<Token>, FrontendError> {
             continue;
         }
         let kind = match c {
-            'a'..='z' | 'A'..='Z' => TokenKind::Sym(c.to_string()),
             '+' => TokenKind::Plus,
             '-' | '−' => TokenKind::Minus,
             '×' | '⋅' | '*' => TokenKind::Times,
@@ -370,6 +428,24 @@ mod tests {
             TokenKind::Sym("x".into()), TokenKind::Caret, TokenKind::Num("2".into()), TokenKind::Eof,
         ]);
         assert_eq!(kinds("a_i")[1], TokenKind::Underscore);
+    }
+
+    #[test]
+    fn function_runs_split_longest_match() {
+        // PR-3: an ASCII letter run carves into functions + single-letter variables.
+        assert_eq!(kinds("sin"), vec![TokenKind::Func("sin".into()), TokenKind::Eof]);
+        assert_eq!(kinds("sinx"), vec![
+            TokenKind::Func("sin".into()), TokenKind::Sym("x".into()), TokenKind::Eof,
+        ]);
+        assert_eq!(kinds("arcsin")[0], TokenKind::Func("arcsin".into())); // longest wins
+        // a non-function run is single-letter variables (so `xy` ⇒ x·y, unchanged).
+        assert_eq!(kinds("xy"), vec![
+            TokenKind::Sym("x".into()), TokenKind::Sym("y".into()), TokenKind::Eof,
+        ]);
+        // sub-token spans are correct.
+        let t = tokenize("sinx").unwrap();
+        assert_eq!(t[0].span, (0, 3));
+        assert_eq!(t[1].span, (3, 4));
     }
 
     #[test]

--- a/code/specs/PFE01-pluggable-parser-frontends.md
+++ b/code/specs/PFE01-pluggable-parser-frontends.md
@@ -148,8 +148,8 @@ frontend additionally ships notation-specific golden tests.
   (`x² + y² = r²`, `√x`, `½`, `π·α`, `a ≤ b`). A small crate implementing the trait; its Greek /
   constant glyphs canonicalize to the same `Symbol` names as AsciiMath, so the notations agree on
   one neutral string. Covers numbers/symbols/super-&-subscripts (Unicode glyphs *and* ASCII
-  `^`/`_`)/fractions/roots/relations/implicit-mul/±∓ and the big operators `∑ ∏ ∫ ∮ ∐` (PR-2);
-  named functions, matrices, and `\text` are PR-3.
+  `^`/`_`)/fractions/roots/relations/implicit-mul/±∓, the big operators `∑ ∏ ∫ ∮ ∐` (PR-2), and
+  named functions `sin cos … ln log exp` (PR-3, longest-match); matrices and `\text` are PR-4.
 - Future: `mathml`, MathJSON, content-MathML, spreadsheet formulae, … each a small crate
   implementing the trait. None require changes to consumers. **Three frontends now in (LaTeX,
   AsciiMath, Unicode), all feeding one neutral AST with zero consumer change** — the pluggability


### PR DESCRIPTION
## What

Drives the Unicode plain-math frontend toward parity with the LaTeX/AsciiMath frontends: **named functions** applied to the next atom.

| input | → |
|---|---|
| `sin x` | `Call(Sin, x)` |
| `log(x)` | `Call(Log, x)` (grouped argument) |
| `arcsin x` | `Call(Asin, x)` (longest-match: one function, not `arc·s·i·n`) |
| `sinx` | `sin·x` (greedy split, like AsciiMath) |
| `sin x + 1` | `(sin x) + 1` (one-atom argument) |

Set: `sin cos tan cot sec csc arcsin arccos arctan sinh cosh tanh ln log exp min max gcd lcm det` — mirrors the AsciiMath frontend's `func_of`, so the two notations name the same functions. `capabilities()` now declares `functions`.

## How

The tokenizer scans a **maximal ASCII-letter run** and carves it by **greedy longest-match** against the function table (`token::function_prefix_len`): a recognised name → one `Func` token, any other leading letter → a single `Sym`. A non-function run like `xy` is still the product `x·y` (single-letter variables, unchanged). Runs are pure ASCII (Greek/constant glyphs are multi-byte, handled separately), so the byte-offset spans stay char-boundary-safe. The parser maps `Func` → `Call` via `func_of`.

## Gates

- **28 unit + 1 doc test** pass (new `function_runs_split_longest_match`, `named_functions`; conformance corpus gains `sin x`, `log(x) + 1`, `arcsin x`); clippy `-D warnings` clean; `#![forbid(unsafe_code)]`.
- `/security-review` **PASSED** (the carve loop's `k` strictly advances; all indices in-bounds; pure-ASCII runs keep spans char-boundary-safe; `Func` arg recursion is `MAX_DEPTH`-charged; `func_of` total with `Other` fallback).
- unicode-math **0.3.0**. Spec `PFE01-pluggable-parser-frontends.md` updated. **PR-4** = matrices / `\text` (last gap toward parity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)