### PR TITLE
feat(unicode-math): PR-4 — matrices (full parity with AsciiMath)

### DIFF
--- a/code/packages/rust/unicode-math/CHANGELOG.md
+++ b/code/packages/rust/unicode-math/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to the unicode-math pluggable frontend.
 
+## [0.4.0] — 2026-06-30
+
+### Added — PR-4: matrices (full parity with AsciiMath)
+
+- **Matrices** `[[a,b],[c,d]]` → `MathExpr::Matrix` (rows of cells, in source order); rows may use
+  `[…]` or `(…)`, cells are full expressions, and a 1×n single row is a row vector. A `Comma` token
+  is added; the parser uses a two-token lookahead (an outer bracket immediately followed by another
+  opening bracket ⇒ matrix, else a group), so `((a))` / `[[a]]` stay double *grouping* (unwrapped),
+  a genuine matrix needs ≥2 rows or a row with ≥2 cells, and ragged rows are a clean spanned error.
+  Mirrors the AsciiMath frontend's `parse_matrix` exactly (the matrix nesting level is `MAX_DEPTH`
+  -charged, so adversarial `[[[[…` fails cleanly, never overflows). `capabilities()` declares `matrices`.
+- This brings unicode-math to **full parity with the AsciiMath frontend** (the only remaining
+  AsciiMath construct, embedded `\text`, has no Unicode plain-math equivalent and is intentionally
+  out of scope).
+- 29 unit + 1 doc test pass (new `matrices`; conformance corpus gains `[[a,b],[c,d]]` and the ragged
+  `[[a,b],[c]]` error case); clippy `-D warnings` clean; `#![forbid(unsafe_code)]`.
+
 ## [0.3.0] — 2026-06-30
 
 ### Added — PR-3: named functions

--- a/code/packages/rust/unicode-math/Cargo.toml
+++ b/code/packages/rust/unicode-math/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unicode-math"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "A Unicode plain-math parser that implements the math-frontend MathFrontend trait: turns the math people and models actually type (x² + y² = r², √x, ½, π·α, a ≤ b) into the neutral MathExpr AST. The third pluggable frontend after LaTeX and AsciiMath (see PFE01). Total, panic-free, spanned errors."
 license = "MIT"

--- a/code/packages/rust/unicode-math/README.md
+++ b/code/packages/rust/unicode-math/README.md
@@ -20,6 +20,7 @@ ASCII syntax (AsciiMath), and raw Unicode.
 | `a₁`, `a₁²`, `a_i` | `Subscript` / `Pow(Subscript)` (Unicode glyph **or** ASCII `_`) |
 | `∑_(i=1)^n i`, `∫_a^b f`, `∏ x` | `BigOp { op, lower, upper, body }` (`∑ ∏ ∫ ∮ ∐`) |
 | `sin x`, `log(x)`, `arcsin x` | `Call { func, arg }` (named functions; longest-match, so `sinx` ⇒ `sin·x`) |
+| `[[a,b],[c,d]]` | `Matrix` (rows in `[…]` or `(…)`; `((a))` stays grouping) |
 | `1/2`, `½`, `⅔` | `Frac` (built-up **and** vulgar-fraction glyphs) |
 | `√x`, `∛x`, `∜x` | `Root { degree, radicand }` |
 | `a + b`, `a − b`, `a × b`, `a ⋅ b`, `a ÷ b` | `Bin(Add/Sub/Mul/Div)` |
@@ -55,7 +56,8 @@ dependency cycle); a consumer registers it.
 
 PR-1 covered numbers/symbols/scripts/fractions/roots/relations/±∓; **PR-2** adds the big operators
 `∑ ∏ ∫ ∮ ∐` (with optional bounds) and the explicit ASCII script operators `^`/`_`; **PR-3** adds
-**named functions** (`sin cos tan … ln log exp`, longest-match so `sinx` ⇒ `sin·x`). **Out of scope**
-(a clean spanned error, never a panic — tracked for PR-4): matrices and embedded `\text`. As in
-AsciiMath there are no multi-letter variables: a non-function letter run like `xy` is the product
-`x·y` (write distinct symbols, or use Greek/constant glyphs).
+**named functions** (`sin cos tan … ln log exp`, longest-match so `sinx` ⇒ `sin·x`); **PR-4** adds **matrices**
+`[[a,b],[c,d]]` — reaching **full parity with the AsciiMath frontend**. The only remaining
+AsciiMath construct, embedded `\text`, has no Unicode plain-math equivalent and is out of scope (a
+clean spanned error, never a panic). As in AsciiMath there are no multi-letter variables: a
+non-function letter run like `xy` is the product `x·y` (write distinct symbols, or use glyphs).

--- a/code/packages/rust/unicode-math/src/lib.rs
+++ b/code/packages/rust/unicode-math/src/lib.rs
@@ -21,8 +21,10 @@
 //! Unicode glyphs (`x²`, `a₁`, `x⁻¹`) or with the explicit ASCII operators `^`/`_` (`x^2` ≡ `x²`);
 //! the **big operators** `∑ ∏ ∫ ∮ ∐` with optional lower/upper bounds (PR-2, e.g. `∑_(i=1)^n i`);
 //! **named functions** `sin cos tan … ln log exp` applied to the next atom (PR-3, `sin x`, `log(x)`,
-//! `arcsin x` — longest-match, so `sinx` ⇒ `sin·x`); and the relations `= ≠ < ≤ > ≥ ≈ ≡`. Out of
-//! scope (a clean spanned error, never a panic), tracked for PR-4: matrices and `\text`.
+//! `arcsin x` — longest-match, so `sinx` ⇒ `sin·x`); the relations `= ≠ < ≤ > ≥ ≈ ≡`; and
+//! **matrices** `[[a,b],[c,d]]` (PR-4, rows in `[…]` or `(…)`). The only remaining gap vs the
+//! AsciiMath frontend is embedded `\text` (no Unicode equivalent) — an out-of-scope input is a
+//! clean spanned error, never a panic.
 //!
 //! ```
 //! use unicode_math::UnicodeMath;
@@ -76,6 +78,7 @@ impl MathFrontend for UnicodeMath {
             .with_plusminus()
             .with_big_operators()
             .with_functions()
+            .with_matrices()
     }
 }
 
@@ -237,6 +240,31 @@ mod tests {
         assert_eq!(p("xy"), b(BinOp::Mul, sym("x"), sym("y")));
     }
 
+    // ---- matrices (PR-4) -------------------------------------------------------
+    #[test]
+    fn matrices() {
+        // [[a,b],[c,d]] ⇒ Matrix of rows of cells, in source order.
+        assert_eq!(
+            p("[[a,b],[c,d]]"),
+            MathExpr::Matrix(vec![vec![sym("a"), sym("b")], vec![sym("c"), sym("d")]])
+        );
+        // cells are full expressions; `(…)` rows are accepted too.
+        assert_eq!(
+            p("((1,x²),(a+b,0))"),
+            MathExpr::Matrix(vec![
+                vec![num(1), b(BinOp::Pow, sym("x"), num(2))],
+                vec![b(BinOp::Add, sym("a"), sym("b")), num(0)],
+            ])
+        );
+        // a single row with several cells is a 1×n row vector.
+        assert_eq!(p("[[a,b,c]]"), MathExpr::Matrix(vec![vec![sym("a"), sym("b"), sym("c")]]));
+        // `((a))` / `[[a]]` are double grouping, NOT a 1×1 matrix.
+        assert_eq!(p("((a))"), sym("a"));
+        assert_eq!(p("[[a]]"), sym("a"));
+        // ragged rows are not a matrix → clean error, never a panic.
+        assert!(UnicodeMath.parse("[[a,b],[c]]").is_err());
+    }
+
     #[test]
     fn a_realistic_expression() {
         // x² + y² = r²
@@ -279,9 +307,9 @@ mod tests {
         assert!(c.fractions && c.roots && c.powers && c.relations && c.implicit_mul && c.plusminus);
         assert!(c.big_operators); // PR-2: ∑ ∏ ∫ ∮ ∐
         assert!(c.functions);     // PR-3: sin/cos/log/… → Call
-        // Still to come — declared off so the harness holds us honest.
-        assert!(!c.matrices && !c.text);
-        assert!(!c.binomials && !c.accents && !c.oversets);
+        assert!(c.matrices);      // PR-4: [[a,b],[c,d]]
+        // `text` is the last remaining gap (no Unicode equivalent); the rest are not AsciiMath's.
+        assert!(!c.text && !c.binomials && !c.accents && !c.oversets);
     }
 
     #[test]
@@ -310,6 +338,8 @@ mod tests {
                 "sin x",        // named function (PR-3)
                 "log(x) + 1",   // function with a grouped argument
                 "arcsin x",     // longest-match function name
+                "[[a,b],[c,d]]", // matrix (PR-4)
+                "[[a,b],[c]]",   // error: ragged matrix rows
                 "1 +",   // error: trailing operator
                 "(x",    // error: missing close
                 "∑",     // error: big operator with no body

--- a/code/packages/rust/unicode-math/src/parser.rs
+++ b/code/packages/rust/unicode-math/src/parser.rs
@@ -50,6 +50,11 @@ impl Parser<'_> {
         self.toks.get(self.pos).map(|t| &t.kind).unwrap_or(&TokenKind::Eof)
     }
 
+    /// The token `n` positions ahead (0 == current). Used for the matrix two-token lookahead.
+    fn peek_nth(&self, n: usize) -> &TokenKind {
+        self.toks.get(self.pos + n).map(|t| &t.kind).unwrap_or(&TokenKind::Eof)
+    }
+
     fn span_here(&self) -> (usize, usize) {
         self.toks.get(self.pos).or_else(|| self.toks.last()).map(|t| t.span).unwrap_or((0, 0))
     }
@@ -289,7 +294,18 @@ impl Parser<'_> {
                 let body = self.parse_atom()?;
                 Ok(MathExpr::BigOp { op, lower, upper, body: Box::new(body) })
             }
-            TokenKind::LParen | TokenKind::LBracket | TokenKind::LBrace => self.parse_group(),
+            TokenKind::LBracket | TokenKind::LParen => {
+                // Two-token lookahead decides matrix vs group before consuming anything (so the
+                // parse is single-pass, no backtracking): an outer bracket immediately followed by
+                // another opening bracket is the matrix shape `[[…` / `((…`; everything else is
+                // ordinary grouping. (Same rule as the AsciiMath frontend.)
+                if matches!(self.peek_nth(1), TokenKind::LBracket | TokenKind::LParen) {
+                    self.parse_matrix()
+                } else {
+                    self.parse_group()
+                }
+            }
+            TokenKind::LBrace => self.parse_group(),
             _ => Err(self.error_here("expected a number, symbol, root, big operator, or '('")),
         }
     }
@@ -306,6 +322,59 @@ impl Parser<'_> {
             }
             _ => Err(self.error_here("expected a closing bracket")),
         }
+    }
+
+    /// A matrix `[[a,b],[c,d]]` (rows may use `[…]` or `(…)`), positioned at the outer opening
+    /// bracket which is known to be followed by a row-opening bracket. Single-pass and committed:
+    /// a malformed shape returns a spanned error (never backtracks, never panics). A 1×1 result
+    /// (`((a))`, `[[a]]`) is *grouping* — the single cell is returned unwrapped; a genuine matrix
+    /// has ≥2 rows or a row with ≥2 cells. (Mirrors the AsciiMath frontend.)
+    fn parse_matrix(&mut self) -> Result<MathExpr, FrontendError> {
+        self.enter()?; // charge the matrix nesting level (paired exit below)
+        let result = self.parse_matrix_inner();
+        self.exit();
+        result
+    }
+
+    fn parse_matrix_inner(&mut self) -> Result<MathExpr, FrontendError> {
+        self.advance(); // outer opening bracket
+        let mut rows: Vec<Vec<MathExpr>> = Vec::new();
+        loop {
+            match self.peek() {
+                TokenKind::LBracket | TokenKind::LParen => self.advance(),
+                _ => return Err(self.error_here("expected a bracketed matrix row")),
+            }
+            let mut cells = vec![self.parse_relation()?];
+            while matches!(self.peek(), TokenKind::Comma) {
+                self.advance();
+                cells.push(self.parse_relation()?);
+            }
+            match self.peek() {
+                TokenKind::RBracket | TokenKind::RParen => self.advance(),
+                _ => return Err(self.error_here("expected a closing bracket for the matrix row")),
+            }
+            rows.push(cells);
+            match self.peek() {
+                TokenKind::Comma => {
+                    self.advance();
+                    continue;
+                }
+                TokenKind::RBracket | TokenKind::RParen => {
+                    self.advance(); // outer closing bracket
+                    break;
+                }
+                _ => return Err(self.error_here("expected ',' or a closing bracket in the matrix")),
+            }
+        }
+        let width = rows[0].len();
+        if rows.iter().any(|r| r.len() != width) {
+            return Err(self.error_here("matrix rows must all have the same length"));
+        }
+        if rows.len() == 1 && width == 1 {
+            // `((a))` / `[[a]]` is double grouping, not a 1×1 matrix — unwrap the single cell.
+            return Ok(rows.into_iter().next().and_then(|r| r.into_iter().next()).expect("1×1"));
+        }
+        Ok(MathExpr::Matrix(rows))
     }
 }
 

--- a/code/packages/rust/unicode-math/src/token.rs
+++ b/code/packages/rust/unicode-math/src/token.rs
@@ -80,6 +80,9 @@ pub enum TokenKind {
     Big(String),
     LParen,
     RParen,
+    /// `,` — cell/row separator inside a matrix (`[[a,b],[c,d]]`). Outside a matrix the parser
+    /// has no use for it and reports a clean error, never a panic.
+    Comma,
     LBracket,
     RBracket,
     LBrace,
@@ -303,6 +306,7 @@ pub fn tokenize(src: &str) -> Result<Vec<Token>, FrontendError> {
             '≡' => TokenKind::Equiv,
             '(' => TokenKind::LParen,
             ')' => TokenKind::RParen,
+            ',' => TokenKind::Comma,
             '[' => TokenKind::LBracket,
             ']' => TokenKind::RBracket,
             '{' => TokenKind::LBrace,

--- a/code/specs/PFE01-pluggable-parser-frontends.md
+++ b/code/specs/PFE01-pluggable-parser-frontends.md
@@ -149,7 +149,9 @@ frontend additionally ships notation-specific golden tests.
   constant glyphs canonicalize to the same `Symbol` names as AsciiMath, so the notations agree on
   one neutral string. Covers numbers/symbols/super-&-subscripts (Unicode glyphs *and* ASCII
   `^`/`_`)/fractions/roots/relations/implicit-mul/±∓, the big operators `∑ ∏ ∫ ∮ ∐` (PR-2), and
-  named functions `sin cos … ln log exp` (PR-3, longest-match); matrices and `\text` are PR-4.
+  named functions `sin cos … ln log exp` (PR-3, longest-match), and matrices `[[a,b],[c,d]]`
+  (PR-4) — **full parity with AsciiMath** (only embedded `\text`, which has no Unicode equivalent,
+  is out of scope).
 - Future: `mathml`, MathJSON, content-MathML, spreadsheet formulae, … each a small crate
   implementing the trait. None require changes to consumers. **Three frontends now in (LaTeX,
   AsciiMath, Unicode), all feeding one neutral AST with zero consumer change** — the pluggability


### PR DESCRIPTION
## What

Adds **matrices** to the Unicode plain-math frontend:

```
[[a,b],[c,d]]  →  MathExpr::Matrix   (rows of cells, source order)
```

Rows may use `[…]` or `(…)`; cells are full expressions; a 1×n single row is a row vector.

## How

A `Comma` token is added; the parser uses a **two-token lookahead** (an outer bracket immediately followed by another opening bracket ⇒ matrix, else a group), so `((a))` / `[[a]]` stay double **grouping** (unwrapped), a genuine matrix needs ≥2 rows or a row with ≥2 cells, and ragged rows are a clean spanned error. **Mirrors the AsciiMath frontend's `parse_matrix` exactly** (the matrix nesting level is `MAX_DEPTH`-charged, so adversarial `[[[[…` fails cleanly, never overflows). `capabilities()` declares `matrices`.

## Milestone

This brings unicode-math to **full parity with the AsciiMath frontend** — the only remaining AsciiMath construct, embedded `\text`, has no Unicode plain-math equivalent and is intentionally out of scope. PFE01's third frontend is now feature-complete.

## Gates

- **29 unit + 1 doc test** pass (new `matrices`; conformance corpus gains `[[a,b],[c,d]]` + ragged `[[a,b],[c]]` error); clippy `-D warnings` clean; `#![forbid(unsafe_code)]`.
- `/security-review` **PASSED** (matrix loop consumes ≥1 token per pass → terminates; `rows` non-empty before `rows[0]`; `.expect("1×1")` provably unreachable as a panic; nesting `MAX_DEPTH`-charged; `peek_nth` OOB-safe; no input-controlled arithmetic).
- unicode-math **0.4.0**. Spec `PFE01-pluggable-parser-frontends.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)