### PR TITLE
feat(sir-go): SIR16 Sequences + Maps — completes Go v1 parity (A6)

### DIFF
--- a/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
@@ -1,5 +1,76 @@
 # Changelog
 
+## 0.4.0 — SIR16 Sequences + Maps — completes Go v1 parity (A6)
+
+The final two SIR16 (v1) features land in the Go backend.  With them the
+Go backend accepts **all six** SIR16 features (Floats, ShortCircuit,
+MutableBindings, Loops, Sequences, Maps) — reaching **full SIR-v1
+parity**.  Go is the **fifth and last backend to reach v1**, completing
+the backend fleet (joining TypeScript, Rust, Python, and the others).
+Before this release a module using `SeqLit` / `SeqIndex` / `SeqLen` /
+`MapLit` / `MapGet` / `SeqSet` / `MapSet` was rejected at the capability
+check and those emit arms were unreachable `panic!`s; this release wires
+them up end-to-end.
+
+### Added
+
+- `Feature::Sequences` and `Feature::Maps` join the backend's
+  `ACCEPTED_FEATURES`, so a module declaring them is no longer rejected
+  by the capability check.
+- **Sequences** — the inlined Go runtime gains a `*Seq` value (a struct
+  `Seq{ Items []Value }` held by pointer).  The pointer is the crux: a
+  `SeqSet` (`xs[i] = v`) mutates the very sequence the caller holds, and
+  two bindings that alias the same literal observe each other's writes —
+  the reference semantics of a Python list / JS array.  Copying a `Value`
+  that holds a `*Seq` copies the handle, not the backing slice.
+  - `SeqLit` → `_sir_seq_lit([]Value{...})` builds a fresh shared seq.
+  - `SeqIndex` → `_sir_seq_index(seq, i)` (strict bounds; out-of-range
+    panics, like `car`/`cdr`).
+  - `SeqLen` → `_sir_seq_len(seq)` returns the element count as `int64`.
+  - `SeqSet` → `_ = _sir_seq_set(seq, i, v)` mutates in place (no
+    auto-grow; out-of-range panics).
+- **Maps** — the runtime gains a `*Map` value (a struct
+  `Map{ Entries []MapEntry }`, an *insertion-ordered* association list).
+  Go's native `map` can't key on an arbitrary `Value` (floats, closures,
+  nested seqs/maps aren't usable keys), so — mirroring the Rust backend —
+  keys are compared with the runtime's structural value-equality
+  (`_sir_value_eq`, a linear scan).  A missing key reads as `nil`.
+  - `MapLit` → `_sir_map_lit([]Value{keys...}, []Value{vals...})` (keys
+    and values emitted as two parallel slices since Go has no tuple
+    literal); last-write-wins on duplicate keys, first-seen order kept.
+  - `MapGet` → `_sir_map_get(map, key)` (missing key ⇒ `nil`).
+  - `MapSet` → `_ = _sir_map_set(map, key, v)` inserts (appends, order-
+    preserving) or overwrites in place.
+- **Structural value-equality** — `_sir_eq` now routes through a new
+  `_sir_value_eq` that handles the whole value tower (numbers cross-type,
+  symbols, pairs, and now seqs/maps element-wise / entry-wise, with
+  identical-handle short-circuit).  This is the single source of truth
+  shared by `=` and map-key lookup.
+- **ForEach reconciliation** — `_sir_seq_iter` (the A5 cons-list
+  flattener used by `ForEach`) now *also* snapshots a real `*Seq`, so
+  `for x in [1, 2, 3]` (a `SeqLit`) iterates end to end while
+  `ForEach`-over-cons-list keeps working.  A `*Seq` is copied element-wise
+  into a fresh `[]Value` so the loop body sees a stable view even if it
+  mutates the underlying sequence.
+- **Display** — `_sir_format` renders a seq as a bracketed list
+  (`[1, 2, 3]`) and a map as a brace-wrapped, insertion-ordered entry
+  list (`{a: 1, b: 2}`).
+- New integration test `tests/compile_and_run_seq_maps.rs` — hand-builds
+  a module that exercises a sequence (lit/index/len/set + aliasing), a
+  map (lit/get/set + missing-key ⇒ nil), and a `for x in [10,20,30]`
+  ForEach accumulation; emits Go, `go run`s it (gated on `go`
+  availability), and asserts stdout (`99 / 3 / 99 / 2 / 3 / nil / 60`).
+  This is the only check that catches Go's `:=`-vs-`=` and
+  unused-variable strictness.
+
+### Notes
+
+- `accepts_features` is now in lockstep with emit for **all six** SIR16
+  features: every declared feature has a real (non-panicking) emit path.
+  The only remaining `panic!` reject arms cover SIR17/18 nodes
+  (classes / module-defs / exceptions / `StrConcat`) whose features stay
+  unaccepted, so they remain strictly unreachable.
+
 ## 0.3.0 — SIR16 MutableBindings + Loops (A5)
 
 The next two SIR16 (v1) features land in the Go backend, mirroring the

--- a/code/packages/rust/semantic-ir-to-go/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-go/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-go"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "Semantic IR → self-contained Go source code (SIR15). Fourth backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-go/README.md
+++ b/code/packages/rust/semantic-ir-to-go/README.md
@@ -24,7 +24,11 @@ let artifact = backend.compile(&sir_module)?;
 Accepts the full v0 feature set minus `TailCalls` (Go has no TCO) and
 `Intrinsics` (empty whitelist in v0).
 
-### SIR16 (v1) — added incrementally
+### SIR16 (v1) — complete
+
+The Go backend accepts **all six** SIR16 features below, reaching **full
+SIR-v1 parity**.  Go is the fifth and last backend to reach v1.
+
 
 - **`Floats`** — the runtime `Value` gains a `float64` arm.  Arithmetic
   stays on the exact int64 path while every operand is an integer and
@@ -60,20 +64,42 @@ Accepts the full v0 feature set minus `TailCalls` (Go has no TCO) and
   value becomes `_ = <value>` so side effects still fire, and every
   introduced loop variable gets a `_ = <var>` guard so Go's strict
   unused-variable rule never rejects a body that ignores it.
+- **`Sequences`** — the runtime gains a pointer-backed `*Seq`
+  (`Seq{ Items []Value }`) with **shared mutable** semantics: a `SeqSet`
+  (`xs[i] = v`) mutates the very sequence the caller holds, and aliasing
+  bindings observe the write (Python-list / JS-array reference
+  semantics).  `SeqLit` → `_sir_seq_lit`, `SeqIndex` → `_sir_seq_index`,
+  `SeqLen` → `_sir_seq_len`, `SeqSet` → `_sir_seq_set`.  Indexing is
+  strict — out-of-range reads/writes panic.  `ForEach` over a `SeqLit`
+  works end-to-end: `_sir_seq_iter` now snapshots a `*Seq` as well as
+  walking a cons-list.  Display: `[1, 2, 3]`.
+- **`Maps`** — the runtime gains a pointer-backed `*Map`
+  (`Map{ Entries []MapEntry }`), an *insertion-ordered* association list.
+  Go's native `map` can't key on an arbitrary `Value`, so keys are
+  compared with the runtime's structural equality (`_sir_value_eq`, a
+  linear scan — shared by `=`).  A missing key reads as `nil`.
+  `MapLit` → `_sir_map_lit` (keys/values emitted as two parallel slices),
+  `MapGet` → `_sir_map_get`, `MapSet` → `_sir_map_set` (insert appends in
+  order; existing key overwrites in place).  Display: `{a: 1, b: 2}`.
 
-The remaining two SIR16 features (`Sequences`, `Maps`) are not yet
-declared and land in a later PR.
+With all six SIR16 features wired up, `accepts_features` is in lockstep
+with emit — every declared feature has a real (non-panicking) emit path.
 
 ## Value model
 
 ```go
 type Value interface{}
-type Symbol  struct { Name string }
-type Pair    struct { Car, Cdr Value }
-type Closure struct { Fn func(args []Value) Value }
+type Symbol   struct { Name string }
+type Pair     struct { Car, Cdr Value }
+type Closure  struct { Fn func(args []Value) Value }
+type Seq      struct { Items []Value }              // held by *Seq (shared, mutable)
+type MapEntry struct { Key, Val Value }
+type Map      struct { Entries []MapEntry }         // held by *Map (insertion-ordered assoc list)
 ```
 
 Single-threaded; symbol interning + globals in module-level maps.
+`*Seq` / `*Map` give sequences and maps reference (shared-mutable)
+semantics; maps key on structural value-equality (`_sir_value_eq`).
 
 ## Block-as-expression
 

--- a/code/packages/rust/semantic-ir-to-go/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/emit.rs
@@ -213,12 +213,26 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
             emit_for_each(out, var, iter, body, indent)
         }
         // ── SIR16 indexed assignment (Sequences/Maps) ───────────────
-        // `Feature::Sequences`/`Feature::Maps` are not accepted by this
-        // backend, so a module using `SeqSet`/`MapSet` is rejected at
-        // the capability check before emit.  Reaching these arms is a
-        // bug.
-        Stmt::SeqSet { span, .. } | Stmt::MapSet { span, .. } => {
-            panic!("go backend reached SIR16 Seq/Map statement at {} — capability check should have rejected it", span);
+        // `seq[index] = value` mutates the shared backing slice in place
+        // via `_sir_seq_set`; the returned value is discarded (`_ = …`).
+        Stmt::SeqSet { seq, index, value, .. } => {
+            let _ = write!(out, "{}_ = _sir_seq_set(", pad);
+            emit_expr(out, seq, indent);
+            out.push_str(", ");
+            emit_expr(out, index, indent);
+            out.push_str(", ");
+            emit_expr(out, value, indent);
+            out.push_str(")\n");
+        }
+        // `map[key] = value` inserts/overwrites via `_sir_map_set`.
+        Stmt::MapSet { map, key, value, .. } => {
+            let _ = write!(out, "{}_ = _sir_map_set(", pad);
+            emit_expr(out, map, indent);
+            out.push_str(", ");
+            emit_expr(out, key, indent);
+            out.push_str(", ");
+            emit_expr(out, value, indent);
+            out.push_str(")\n");
         }
         // An `Assign` to an Instance/ClassVar/Const/Builtin scope: those
         // scopes belong to SIR17 features this backend does not accept
@@ -384,18 +398,65 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
             emit_expr(out, rhs, indent);
             out.push_str(" } }()");
         }
-        // Remaining SIR16+ expression kinds — Go backend hasn't been
-        // extended to these yet (Sequences/Maps land in a later PR;
-        // `StrConcat` is SIR18 string interpolation).  Their features
-        // are undeclared, so the capability check rejects such modules
-        // before emit; reaching this arm is an internal bug.
-        Expr::SeqLit { span, .. }
-        | Expr::SeqIndex { span, .. }
-        | Expr::SeqLen { span, .. }
-        | Expr::MapLit { span, .. }
-        | Expr::MapGet { span, .. }
-        | Expr::StrConcat { span, .. } => {
-            panic!("go backend reached SIR16+ expression at {} — capability check should have rejected it", span);
+        // ── SIR16: sequences ───────────────────────────────────────
+        // `SeqLit` builds a fresh shared sequence from its items via the
+        // runtime `_sir_seq_lit` helper; `SeqIndex`/`SeqLen` read through
+        // `_sir_seq_index`/`_sir_seq_len`.  All keep the `Value` model —
+        // the seq is pointer-backed, so a `VarRef` to it copies the shared
+        // handle (and observes later `SeqSet` mutations).
+        Expr::SeqLit { items, .. } => {
+            out.push_str("_sir_seq_lit([]Value{");
+            emit_args(out, items, indent);
+            out.push_str("})");
+        }
+        Expr::SeqIndex { seq, index, .. } => {
+            out.push_str("_sir_seq_index(");
+            emit_expr(out, seq, indent);
+            out.push_str(", ");
+            emit_expr(out, index, indent);
+            out.push(')');
+        }
+        Expr::SeqLen { seq, .. } => {
+            out.push_str("_sir_seq_len(");
+            emit_expr(out, seq, indent);
+            out.push(')');
+        }
+        // ── SIR16: maps ────────────────────────────────────────────
+        // `MapLit` builds an insertion-ordered map from its `(key, value)`
+        // entries; the keys and values are emitted as two parallel
+        // `[]Value` slices so the runtime `_sir_map_lit` can zip them
+        // (Go has no tuple literal).  `MapGet` reads through `_sir_map_get`
+        // (missing key ⇒ `nil`).
+        Expr::MapLit { entries, .. } => {
+            out.push_str("_sir_map_lit([]Value{");
+            for (i, entry) in entries.iter().enumerate() {
+                if i > 0 {
+                    out.push_str(", ");
+                }
+                emit_expr(out, &entry.key, indent);
+            }
+            out.push_str("}, []Value{");
+            for (i, entry) in entries.iter().enumerate() {
+                if i > 0 {
+                    out.push_str(", ");
+                }
+                emit_expr(out, &entry.value, indent);
+            }
+            out.push_str("})");
+        }
+        Expr::MapGet { map, key, .. } => {
+            out.push_str("_sir_map_get(");
+            emit_expr(out, map, indent);
+            out.push_str(", ");
+            emit_expr(out, key, indent);
+            out.push(')');
+        }
+        // The only remaining unsupported expression is `StrConcat` (SIR18
+        // string interpolation).  Its feature is undeclared, so the
+        // capability check rejects such modules before emit; reaching this
+        // arm is an internal bug.
+        Expr::StrConcat { span, .. } => {
+            panic!("go backend reached SIR18 str-concat expression at {} — capability check should have rejected it", span);
         }
     }
 }
@@ -614,13 +675,14 @@ fn emit_for_range(
     let _ = writeln!(out, "{}}}", pad);
 }
 
-/// `for var in iter` — iterate a sequence value.  This backend has no
-/// dedicated `Seq` value yet (Sequences land in a later PR), so a
-/// sequence is the classic cons-list (a `Pair`-chain terminated by
-/// `nil`).  The runtime `_sir_seq_iter` helper flattens that chain into
-/// a `[]Value`; the loop binds each element to `var`.  A `_ = <var>`
-/// guard silences Go's unused-variable check when the body ignores the
-/// element.  Mirrors the Rust backend's `seq_iter` approach.
+/// `for var in iter` — iterate a sequence value.  The runtime
+/// `_sir_seq_iter` helper flattens the iterable into a `[]Value`,
+/// handling **both** sequence shapes uniformly: a real `*Seq`
+/// (`Feature::Sequences`, e.g. `for x in [1,2,3]`) is snapshotted
+/// element-wise, while the classic cons-list (a `Pair`-chain terminated
+/// by `nil`) is walked car-by-car.  The loop binds each element to `var`;
+/// a `_ = <var>` guard silences Go's unused-variable check when the body
+/// ignores the element.  Mirrors the Rust backend's `seq_iter` approach.
 fn emit_for_each(out: &mut String, var: &str, iter: &Expr, body: &Block, indent: usize) {
     let pad = indent_str(indent);
     let v = sanitize_ident(var);
@@ -1096,6 +1158,141 @@ mod tests {
             1,
         );
         assert!(out.contains("_ = Value(int64(9))"), "got: {out}");
+    }
+
+    // ── SIR16 Sequences + Maps ─────────────────────────────────────
+
+    #[test]
+    fn emit_seq_lit_builds_value_slice() {
+        let mut out = String::new();
+        emit_expr(
+            &mut out,
+            &Expr::SeqLit { items: vec![ilit(1), ilit(2), ilit(3)], span: s() },
+            0,
+        );
+        assert_eq!(
+            out,
+            "_sir_seq_lit([]Value{Value(int64(1)), Value(int64(2)), Value(int64(3))})"
+        );
+    }
+
+    #[test]
+    fn emit_empty_seq_lit() {
+        let mut out = String::new();
+        emit_expr(&mut out, &Expr::SeqLit { items: vec![], span: s() }, 0);
+        assert_eq!(out, "_sir_seq_lit([]Value{})");
+    }
+
+    #[test]
+    fn emit_seq_index_reads_element() {
+        let mut out = String::new();
+        emit_expr(
+            &mut out,
+            &Expr::SeqIndex {
+                seq: Box::new(var_local("xs")),
+                index: Box::new(ilit(0)),
+                span: s(),
+            },
+            0,
+        );
+        assert_eq!(out, "_sir_seq_index(xs, Value(int64(0)))");
+    }
+
+    #[test]
+    fn emit_seq_len_reads_length() {
+        let mut out = String::new();
+        emit_expr(
+            &mut out,
+            &Expr::SeqLen { seq: Box::new(var_local("xs")), span: s() },
+            0,
+        );
+        assert_eq!(out, "_sir_seq_len(xs)");
+    }
+
+    #[test]
+    fn emit_map_lit_splits_keys_and_values() {
+        // Keys and values are emitted as two parallel `[]Value` slices so
+        // the runtime can zip them (Go has no tuple literal).
+        let mut out = String::new();
+        emit_expr(
+            &mut out,
+            &Expr::MapLit {
+                entries: vec![
+                    semantic_ir::nodes::MapEntry {
+                        key: Expr::StrLit { value: "a".into(), span: s() },
+                        value: ilit(1),
+                    },
+                    semantic_ir::nodes::MapEntry {
+                        key: Expr::StrLit { value: "b".into(), span: s() },
+                        value: ilit(2),
+                    },
+                ],
+                span: s(),
+            },
+            0,
+        );
+        assert_eq!(
+            out,
+            "_sir_map_lit([]Value{Value(\"a\"), Value(\"b\")}, []Value{Value(int64(1)), Value(int64(2))})"
+        );
+    }
+
+    #[test]
+    fn emit_empty_map_lit() {
+        let mut out = String::new();
+        emit_expr(&mut out, &Expr::MapLit { entries: vec![], span: s() }, 0);
+        assert_eq!(out, "_sir_map_lit([]Value{}, []Value{})");
+    }
+
+    #[test]
+    fn emit_map_get_reads_value() {
+        let mut out = String::new();
+        emit_expr(
+            &mut out,
+            &Expr::MapGet {
+                map: Box::new(var_local("d")),
+                key: Box::new(Expr::StrLit { value: "k".into(), span: s() }),
+                span: s(),
+            },
+            0,
+        );
+        assert_eq!(out, "_sir_map_get(d, Value(\"k\"))");
+    }
+
+    #[test]
+    fn emit_seq_set_mutates_in_place() {
+        let mut out = String::new();
+        emit_stmt(
+            &mut out,
+            &Stmt::SeqSet {
+                seq: var_local("xs"),
+                index: ilit(0),
+                value: ilit(9),
+                span: s(),
+            },
+            1,
+        );
+        assert_eq!(out, "\t_ = _sir_seq_set(xs, Value(int64(0)), Value(int64(9)))\n");
+    }
+
+    #[test]
+    fn emit_map_set_inserts_or_overwrites() {
+        let mut out = String::new();
+        emit_stmt(
+            &mut out,
+            &Stmt::MapSet {
+                map: var_local("d"),
+                key: Expr::StrLit { value: "k".into(), span: s() },
+                value: ilit(1),
+                span: s(),
+            },
+            1,
+        );
+        assert_eq!(out, "\t_ = _sir_map_set(d, Value(\"k\"), Value(int64(1)))\n");
+    }
+
+    fn var_local(name: &str) -> Expr {
+        Expr::VarRef { name: name.into(), scope: Scope::Local, span: s() }
     }
 
     #[test]

--- a/code/packages/rust/semantic-ir-to-go/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/lib.rs
@@ -54,13 +54,22 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     // re-bound name just emits `<name> = <value>` (the matching
     // `LetBinding` already declared it with `:=`).  `Loops` maps `While`
     // / `ForRange` / `ForEach` onto Go's native `for`; `ForEach` adds a
-    // `_sir_seq_iter` cons-list flattener to the runtime.  The two
-    // remaining v1 features (Sequences, Maps) stay *undeclared*, so a
-    // module using `SeqLit`/`MapLit`/`SeqSet`/`MapSet` is still rejected
-    // by the capability check before emit — keeping the `panic!`s in
-    // `emit.rs` for those nodes strictly unreachable until a later PR.
+    // `_sir_seq_iter` cons-list flattener to the runtime.
     Feature::MutableBindings,
     Feature::Loops,
+    // `Sequences` and `Maps` are the final two SIR16 (v1) features — with
+    // them the Go backend reaches **full SIR-v1 parity** (the fifth and
+    // last backend to do so).  Both add a shared-mutable value to the Go
+    // runtime: a `Seq` (pointer-backed `*[]Value`, so `SeqSet` mutates the
+    // very sequence the caller holds and aliasing bindings observe the
+    // write) and a `Map` (insertion-ordered assoc list keyed by the
+    // runtime's structural value-equality; missing key ⇒ `nil`).  With all
+    // six SIR16 features now declared, every SIR16 IR node has a real
+    // (non-panicking) emit path — the only remaining `panic!`s cover
+    // SIR17/18 nodes (classes/exceptions/str-concat) whose features stay
+    // unaccepted, so they remain strictly unreachable.
+    Feature::Sequences,
+    Feature::Maps,
 ];
 
 impl Backend for GoBackend {

--- a/code/packages/rust/semantic-ir-to-go/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/runtime.rs
@@ -22,6 +22,41 @@ type Closure struct {
 	Fn func(args []Value) Value
 }
 
+// ── SIR16 sequences ────────────────────────────────────────────
+//
+// A `Seq` is a growable, *mutably shared* vector.  The pointer is the
+// crux: a `Value` holds a `*Seq` (a shared handle), so `SeqSet`
+// (`xs[i] = v`) mutates the very sequence the caller holds, and two
+// bindings that alias the same literal see each other's writes — exactly
+// the reference semantics of a Python list or JS array.  Wrapping the
+// `[]Value` in a struct (rather than a bare `*[]Value`) keeps field
+// access readable and lets a future PR hang metadata off the sequence.
+// Copying a `Value` that holds a `*Seq` copies the pointer, not the
+// backing slice.
+type Seq struct {
+	Items []Value
+}
+
+// ── SIR16 maps ─────────────────────────────────────────────────
+//
+// A `Map` is an *insertion-ordered* association list.  Go's native `map`
+// can't key on an arbitrary `Value` (floats, closures, nested seqs/maps
+// are not comparable / hashable the way we need), so — mirroring the
+// Rust backend's choice — we key by `Value` using the runtime's own
+// structural equality (`_sir_value_eq`, a linear scan) over a
+// `[]MapEntry`.  This gives correct `MapGet`/`MapSet` semantics
+// (including missing-key ⇒ `nil`) for *any* key type and preserves
+// insertion order for deterministic iteration/printing.  Shared + mutable
+// via a `*Map` pointer, same as `Seq`.
+type MapEntry struct {
+	Key Value
+	Val Value
+}
+
+type Map struct {
+	Entries []MapEntry
+}
+
 var _sir_symbol_table = make(map[string]*Symbol)
 var _sir_globals = make(map[string]Value)
 
@@ -228,20 +263,82 @@ func _sir_eq(args []Value) Value {
 	if len(args) < 2 {
 		return true
 	}
-	a := args[0]
-	b := args[1]
+	return _sir_value_eq(args[0], args[1])
+}
+
+// Structural value-equality across the whole value tower.  This is the
+// single source of truth for `=` (via `_sir_eq`) AND for map key lookup
+// (`_sir_map_get`/`_sir_map_set`), so a float, string, symbol, or even a
+// nested seq/map can be a map key with the same semantics as `=`.
+//
+//   | a, b              | rule                                        |
+//   |-------------------|---------------------------------------------|
+//   | both numbers      | compare as float64 (`1 == 1.0`; `NaN != NaN`)|
+//   | both symbols      | intern-name equality                        |
+//   | both pairs        | structural (car & cdr recursively)          |
+//   | both seqs         | same handle, or element-wise equal          |
+//   | both maps         | same handle, or entry-wise equal (in order) |
+//   | otherwise         | Go `==` (bool/nil/string/closure identity)  |
+func _sir_value_eq(a Value, b Value) bool {
 	if as, ok := a.(*Symbol); ok {
 		if bs, ok := b.(*Symbol); ok {
 			return as.Name == bs.Name
 		}
+		return false
 	}
 	// Cross-representation numeric equality (`1 == 1.0`) holds,
 	// mirroring dynamic-language `==`.  Float/Float uses IEEE
-	// equality, so `NaN == NaN` is correctly `false`.  We route ANY
-	// number pair through float64 comparison; non-numbers fall back to
-	// Go's `==`.
+	// equality, so `NaN == NaN` is correctly `false`.
 	if _sir_is_number_val(a) && _sir_is_number_val(b) {
 		return _sir_as_float(a) == _sir_as_float(b)
+	}
+	if ap, ok := a.(*Pair); ok {
+		if bp, ok := b.(*Pair); ok {
+			return _sir_value_eq(ap.Car, bp.Car) && _sir_value_eq(ap.Cdr, bp.Cdr)
+		}
+		return false
+	}
+	// Sequences and maps compare *structurally* (element-wise / entry-
+	// wise), matching how pairs compare.  Identical handles short-circuit
+	// without a deep walk.  Maps compare in insertion order, which is
+	// sufficient because `_sir_map_lit`/`_sir_map_set` keep a canonical
+	// first-seen order — equal maps built the same way share it.
+	if as, ok := a.(*Seq); ok {
+		bs, ok := b.(*Seq)
+		if !ok {
+			return false
+		}
+		if as == bs {
+			return true
+		}
+		if len(as.Items) != len(bs.Items) {
+			return false
+		}
+		for i := range as.Items {
+			if !_sir_value_eq(as.Items[i], bs.Items[i]) {
+				return false
+			}
+		}
+		return true
+	}
+	if am, ok := a.(*Map); ok {
+		bm, ok := b.(*Map)
+		if !ok {
+			return false
+		}
+		if am == bm {
+			return true
+		}
+		if len(am.Entries) != len(bm.Entries) {
+			return false
+		}
+		for i := range am.Entries {
+			if !_sir_value_eq(am.Entries[i].Key, bm.Entries[i].Key) ||
+				!_sir_value_eq(am.Entries[i].Val, bm.Entries[i].Val) {
+				return false
+			}
+		}
+		return true
 	}
 	return a == b
 }
@@ -345,10 +442,41 @@ func _sir_format(v Value) string {
 	if p, ok := v.(*Pair); ok {
 		return _sir_format_pair(p)
 	}
+	if s, ok := v.(*Seq); ok {
+		return _sir_format_seq(s)
+	}
+	if m, ok := v.(*Map); ok {
+		return _sir_format_map(m)
+	}
 	if _, ok := v.(*Closure); ok {
 		return "<closure>"
 	}
 	return fmt.Sprintf("%v", v)
+}
+
+// Sequences print like a bracketed list: `[1, 2, 3]`.
+func _sir_format_seq(s *Seq) string {
+	out := "["
+	for i, item := range s.Items {
+		if i > 0 {
+			out += ", "
+		}
+		out += _sir_format(item)
+	}
+	return out + "]"
+}
+
+// Maps print like a brace-wrapped entry list in insertion order:
+// `{a: 1, b: 2}`.
+func _sir_format_map(m *Map) string {
+	out := "{"
+	for i, e := range m.Entries {
+		if i > 0 {
+			out += ", "
+		}
+		out += _sir_format(e.Key) + ": " + _sir_format(e.Val)
+	}
+	return out + "}"
 }
 
 // Render a float so integral values keep a trailing `.0` (`3.0`, not
@@ -420,16 +548,30 @@ func _sir_range_cont(i int64, stop int64, step int64) bool {
 	return i > stop
 }
 
-// ── SIR16 loops: cons-list iteration (ForEach) ─────────────────
+// ── SIR16 loops: sequence iteration (ForEach) ──────────────────
 //
-// `ForEach` iterates a "sequence" value.  This backend has no dedicated
-// `Seq` value yet (Sequences land in a later PR), so a sequence is the
-// classic cons-list: a `Pair`-chain whose final `cdr` is `nil`.  `nil`
-// itself is the empty sequence.  `_sir_seq_iter` flattens that chain
-// into a `[]Value` the `for ... range` loop can walk.  An improper list
+// `ForEach` iterates a "sequence" value.  SIR16 introduced two distinct
+// "sequence" shapes this backend must iterate uniformly:
+//
+//   * `*Seq` — the real `Sequences` value (a `SeqLit`, `[1, 2, 3]`).  We
+//     snapshot its current elements into a fresh `[]Value` so the loop
+//     body sees a stable view even if it mutates the underlying sequence.
+//   * the classic cons-list — a `Pair`-chain whose final `cdr` is `nil`
+//     (what `cons`/`car`/`cdr` build).  `nil` itself is the empty
+//     sequence.
+//
+// Keeping both keeps the A5 `ForEach`-over-cons-list working while making
+// `for x in [1, 2, 3]` (a `SeqLit`) iterate end to end.  An improper list
 // (a non-`nil`, non-`Pair` tail) is a programming error and panics,
 // matching the strictness of `car`/`cdr` on a non-pair.
 func _sir_seq_iter(v Value) []Value {
+	// A real sequence: snapshot its current elements.
+	if s, ok := v.(*Seq); ok {
+		out := make([]Value, len(s.Items))
+		copy(out, s.Items)
+		return out
+	}
+	// Otherwise treat it as a cons-list.
 	out := []Value{}
 	cur := v
 	for {
@@ -444,6 +586,116 @@ func _sir_seq_iter(v Value) []Value {
 		panic("cannot iterate non-sequence: " + _sir_format(cur))
 	}
 	return out
+}
+
+// ── SIR16 sequence ops (Sequences) ─────────────────────────────
+//
+// A `*Seq` wraps a shared, mutable `[]Value`.  These helpers are the
+// lowering targets for `SeqLit`/`SeqIndex`/`SeqLen`/`SeqSet`.
+
+// `_sir_seq_lit([a, b, ...])` constructs a fresh sequence from its items.
+func _sir_seq_lit(items []Value) Value {
+	return &Seq{Items: items}
+}
+
+// `_sir_seq_index(seq, i)` reads `seq[i]`.  The index is taken as an
+// integer; a negative or out-of-range index panics (sequences are
+// strict, like `car`/`cdr`) — we define out-of-bounds as a panic.
+func _sir_seq_index(seq Value, index Value) Value {
+	s, ok := seq.(*Seq)
+	if !ok {
+		panic("seq-index on non-sequence: " + _sir_format(seq))
+	}
+	i := _sir_as_int(index)
+	if i < 0 || int(i) >= len(s.Items) {
+		panic("sequence index out of range: " + strconv.FormatInt(i, 10))
+	}
+	return s.Items[i]
+}
+
+// `_sir_seq_len(seq)` returns the element count as an `int64`.
+func _sir_seq_len(seq Value) Value {
+	s, ok := seq.(*Seq)
+	if !ok {
+		panic("seq-len on non-sequence: " + _sir_format(seq))
+	}
+	return int64(len(s.Items))
+}
+
+// `_sir_seq_set(seq, i, value)` writes `seq[i] = value`, mutating the
+// shared backing slice in place.  Out-of-range writes panic (we do not
+// auto-grow, matching the index read's strictness).  Returns the written
+// value so the emitter can use it in expression position if needed.
+func _sir_seq_set(seq Value, index Value, value Value) Value {
+	s, ok := seq.(*Seq)
+	if !ok {
+		panic("seq-set on non-sequence: " + _sir_format(seq))
+	}
+	i := _sir_as_int(index)
+	if i < 0 || int(i) >= len(s.Items) {
+		panic("sequence index out of range: " + strconv.FormatInt(i, 10))
+	}
+	s.Items[i] = value
+	return value
+}
+
+// ── SIR16 map ops (Maps) ───────────────────────────────────────
+//
+// A `*Map` wraps a shared, mutable, insertion-ordered `[]MapEntry`.
+// Lookups use `_sir_value_eq` for key comparison, so any value type
+// (including a float, string, or symbol) can be a key with the same
+// structural-equality semantics as `=`.
+
+// `_sir_map_lit([(k0, v0), ...])` builds a fresh map.  A later entry with
+// a key equal to an earlier one overwrites in place, so the literal
+// `{a: 1, a: 2}` yields `{a: 2}` (last-write-wins) while keeping
+// first-seen insertion order.
+func _sir_map_lit(keys []Value, vals []Value) Value {
+	m := &Map{Entries: make([]MapEntry, 0, len(keys))}
+	for i := range keys {
+		_sir_map_put(m, keys[i], vals[i])
+	}
+	return m
+}
+
+// `_sir_map_get(map, key)` reads `map[key]`, returning the associated
+// value or `nil` when the key is absent (we choose `nil` for the
+// target-defined missing-key behaviour, mirroring the other backends).
+func _sir_map_get(mp Value, key Value) Value {
+	m, ok := mp.(*Map)
+	if !ok {
+		panic("map-get on non-map: " + _sir_format(mp))
+	}
+	for i := range m.Entries {
+		if _sir_value_eq(m.Entries[i].Key, key) {
+			return m.Entries[i].Val
+		}
+	}
+	return nil
+}
+
+// `_sir_map_set(map, key, value)` inserts or overwrites `map[key]`,
+// mutating the shared backing store.  Returns the written value.
+func _sir_map_set(mp Value, key Value, value Value) Value {
+	m, ok := mp.(*Map)
+	if !ok {
+		panic("map-set on non-map: " + _sir_format(mp))
+	}
+	_sir_map_put(m, key, value)
+	return value
+}
+
+// Shared insert-or-overwrite for `_sir_map_lit`/`_sir_map_set`: a new key
+// appends (preserving insertion order); an existing key (by
+// `_sir_value_eq`) overwrites in place without disturbing order.
+func _sir_map_put(m *Map, key Value, value Value) {
+	for i := range m.Entries {
+		if _sir_value_eq(m.Entries[i].Key, key) {
+			m.Entries[i].Val = value
+			return
+		}
+	}
+	m.Entries = append(m.Entries, MapEntry{Key: key, Val: value})
 }
 
 func _sir_builtin_closure(name string) Value {
@@ -543,6 +795,44 @@ mod tests {
         assert!(RUNTIME.contains("type Symbol struct"));
         assert!(RUNTIME.contains("type Pair struct"));
         assert!(RUNTIME.contains("type Closure struct"));
+    }
+
+    #[test]
+    fn runtime_declares_seq_and_map_types_and_helpers() {
+        // SIR16 Sequences + Maps: the value model gains shared, mutable
+        // `*Seq`/`*Map` arms and the lowering helpers for each IR node.
+        assert!(RUNTIME.contains("type Seq struct"));
+        assert!(RUNTIME.contains("Items []Value"));
+        assert!(RUNTIME.contains("type Map struct"));
+        assert!(RUNTIME.contains("type MapEntry struct"));
+        for helper in &[
+            "func _sir_seq_lit", "func _sir_seq_index", "func _sir_seq_len",
+            "func _sir_seq_set", "func _sir_map_lit", "func _sir_map_get",
+            "func _sir_map_set",
+        ] {
+            assert!(RUNTIME.contains(helper), "runtime missing `{}`", helper);
+        }
+    }
+
+    #[test]
+    fn runtime_declares_structural_value_eq() {
+        // `=` and map-key lookup share one structural-equality function
+        // that covers seqs and maps.
+        assert!(RUNTIME.contains("func _sir_value_eq"));
+        assert!(RUNTIME.contains("_sir_eq"));
+    }
+
+    #[test]
+    fn runtime_seq_iter_handles_real_seq() {
+        // ForEach reconciliation: `_sir_seq_iter` must snapshot a `*Seq`
+        // (the new real sequence) as well as walk a cons-list.
+        assert!(RUNTIME.contains("if s, ok := v.(*Seq); ok"));
+    }
+
+    #[test]
+    fn runtime_formats_seq_and_map() {
+        assert!(RUNTIME.contains("func _sir_format_seq"));
+        assert!(RUNTIME.contains("func _sir_format_map"));
     }
 
     #[test]

--- a/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_seq_maps.rs
+++ b/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_seq_maps.rs
@@ -1,0 +1,222 @@
+//! End-to-end proof for SIR16 **Sequences** + **Maps** in the Go backend
+//! (A6) — the final two v1 features, which complete the Go backend's
+//! SIR-v1 parity (the fifth and last backend to reach v1).
+//!
+//! Unit tests assert the *shape* of the emitted source; this test goes
+//! the whole way: it hand-builds a SIR module that builds a sequence
+//! (lit/index/len/set), a map (lit/get/set), and a `for x in [10,20,30]`
+//! ForEach accumulator, emits Go, writes it to a temp `.go` file, runs it
+//! with `go run`, and checks stdout.  That closes the loop the unit tests
+//! cannot — it proves the emitted Go actually *compiles and behaves*
+//! under a real Go toolchain (Go's strict unused-variable / `:=`-vs-`=`
+//! rules make codegen delicate).
+//!
+//! The test gates on `go` being available (`go version`).  If the Go
+//! toolchain is absent it logs a skip rather than failing — a missing
+//! tool should never redden a build for reasons unrelated to the change
+//! (mirrors `compile_and_run_loops.rs`).
+
+use std::process::Command;
+
+use semantic_ir::nodes::MapEntry;
+use semantic_ir::{
+    Block, Effect, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, Scope,
+    Span, Stmt,
+};
+use semantic_ir_to_go::compile;
+
+fn s() -> Span {
+    Span::synthetic()
+}
+
+fn ilit(v: i64) -> Expr {
+    Expr::IntLit { value: v, span: s() }
+}
+
+fn slit(v: &str) -> Expr {
+    Expr::StrLit { value: v.into(), span: s() }
+}
+
+fn var_local(name: &str) -> Expr {
+    Expr::VarRef { name: name.into(), scope: Scope::Local, span: s() }
+}
+
+fn call(name: &str, args: Vec<Expr>) -> Expr {
+    Expr::BuiltinCall { name: name.into(), args, effects: EffectSet::PURE, span: s() }
+}
+
+fn let_local(name: &str, value: Expr) -> Stmt {
+    Stmt::LetBinding { name: name.into(), value, sir_type: None, span: s() }
+}
+
+fn assign_local(name: &str, value: Expr) -> Stmt {
+    Stmt::Assign { name: name.into(), scope: Scope::Local, value, span: s() }
+}
+
+fn print_stmt(expr: Expr) -> Stmt {
+    Stmt::ExprStmt {
+        expr: Expr::BuiltinCall {
+            name: "print".into(),
+            args: vec![expr],
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            span: s(),
+        },
+        span: s(),
+    }
+}
+
+/// Build a module whose `main`:
+///   1. `xs := [1, 2, 3]`            (SeqLit)
+///   2. `xs[0] = 99`                 (SeqSet — mutate shared seq)
+///   3. print `xs[0]`                (SeqIndex)               → "99"
+///   4. print `len(xs)`              (SeqLen)                 → "3"
+///   5. alias `ys := xs`; print `ys[0]` — aliasing observes the
+///      earlier SeqSet through the shared handle               → "99"
+///   6. `d := {a: 1, b: 2}`          (MapLit)
+///   7. `d[c] = 3`                   (MapSet — insert)
+///   8. print `d[b]`, `d[c]`, `d[zzz]` (MapGet; missing ⇒ nil) → "2", "3", "nil"
+///   9. `for x in [10, 20, 30]: total = total + x`; print total → "60"
+fn demo_module() -> Module {
+    let map_lit = Expr::MapLit {
+        entries: vec![
+            MapEntry { key: slit("a"), value: ilit(1) },
+            MapEntry { key: slit("b"), value: ilit(2) },
+        ],
+        span: s(),
+    };
+
+    let for_each = Stmt::ForEach {
+        var: "x".into(),
+        iter: Expr::SeqLit { items: vec![ilit(10), ilit(20), ilit(30)], span: s() },
+        body: Block {
+            stmts: vec![assign_local("total", call("+", vec![var_local("total"), var_local("x")]))],
+            value: Expr::NilLit { span: s() },
+            span: s(),
+        },
+        span: s(),
+    };
+
+    let stmts = vec![
+        // Sequences.
+        let_local("xs", Expr::SeqLit { items: vec![ilit(1), ilit(2), ilit(3)], span: s() }),
+        Stmt::SeqSet { seq: var_local("xs"), index: ilit(0), value: ilit(99), span: s() },
+        print_stmt(Expr::SeqIndex {
+            seq: Box::new(var_local("xs")),
+            index: Box::new(ilit(0)),
+            span: s(),
+        }),
+        print_stmt(Expr::SeqLen { seq: Box::new(var_local("xs")), span: s() }),
+        // Aliasing: ys shares the same backing slice as xs.
+        let_local("ys", var_local("xs")),
+        print_stmt(Expr::SeqIndex {
+            seq: Box::new(var_local("ys")),
+            index: Box::new(ilit(0)),
+            span: s(),
+        }),
+        // Maps.
+        let_local("d", map_lit),
+        Stmt::MapSet { map: var_local("d"), key: slit("c"), value: ilit(3), span: s() },
+        print_stmt(Expr::MapGet {
+            map: Box::new(var_local("d")),
+            key: Box::new(slit("b")),
+            span: s(),
+        }),
+        print_stmt(Expr::MapGet {
+            map: Box::new(var_local("d")),
+            key: Box::new(slit("c")),
+            span: s(),
+        }),
+        // Missing key ⇒ nil (printed as "nil").
+        print_stmt(Expr::MapGet {
+            map: Box::new(var_local("d")),
+            key: Box::new(slit("zzz")),
+            span: s(),
+        }),
+        // ForEach over a real SeqLit.
+        let_local("total", ilit(0)),
+        for_each,
+        print_stmt(var_local("total")),
+    ];
+
+    Module {
+        name: "seq_maps_demo".into(),
+        manifest: FeatureManifest::from_features(&[
+            Feature::MutableBindings,
+            Feature::Loops,
+            Feature::Sequences,
+            Feature::Maps,
+            Feature::Strings,
+        ]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block { stmts, value: Expr::NilLit { span: s() }, span: s() },
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            metadata: Metadata::new(),
+            span: s(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("test")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+fn go_available() -> bool {
+    Command::new("go")
+        .arg("version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+#[test]
+fn sequences_and_maps_compile_and_run() {
+    if !go_available() {
+        eprintln!("skipping: go not on PATH");
+        return;
+    }
+
+    // 1. Emit.
+    let artifact = compile(&demo_module()).expect("module should compile to Go source");
+
+    // 2. Write the source to a unique temp file.  `go run` requires a
+    //    `.go` extension.
+    let dir = std::env::temp_dir();
+    let nonce = std::process::id();
+    let src_path = dir.join(format!("sir_go_seq_maps_{nonce}.go"));
+    std::fs::write(&src_path, &artifact.source).expect("write temp source");
+
+    // 3. Compile + run with `go run` (arg vector — no shell).
+    let run_out = Command::new("go")
+        .arg("run")
+        .arg(&src_path)
+        .output()
+        .expect("invoke go run");
+
+    if !run_out.status.success() {
+        let stderr = String::from_utf8_lossy(&run_out.stderr);
+        let _ = std::fs::remove_file(&src_path);
+        panic!(
+            "emitted Go failed to compile/run:\n--- stderr ---\n{stderr}\n--- source ---\n{}",
+            artifact.source,
+        );
+    }
+
+    // 4. Assert the program's observable behaviour.
+    let stdout = String::from_utf8_lossy(&run_out.stdout);
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert_eq!(
+        lines,
+        vec!["99", "3", "99", "2", "3", "nil", "60"],
+        "unexpected program output; full stdout:\n{stdout}"
+    );
+
+    // 5. Best-effort cleanup (ignore errors — temp dir is ephemeral).
+    let _ = std::fs::remove_file(&src_path);
+}


### PR DESCRIPTION
The final two SIR16 features land in `semantic-ir-to-go`, so the **Go backend now supports all six SIR-v1 features** — making it the **fifth and last backend to reach full v1 parity** (TS, Python, Rust, JS, Go all complete).

- Emitted Go runtime gains `Seq` (`*struct{Items []Value}` — pointer-backed for shared-mutable reference semantics; `SeqSet` mutates in place, aliasing bindings observe writes) and `Map` (`*struct`, insertion-ordered assoc list keyed by a new structural `_sir_value_eq` — Go maps can't key on arbitrary Value; missing key → nil). `MapLit` emits parallel keys/vals slices zipped at runtime (length-equal by construction).
- Emit arms for SeqLit/SeqIndex/SeqLen/MapLit/MapGet + SeqSet/MapSet. All 6 SIR16 features accepted; no reachable panic.
- **Reconciles A5's `ForEach`**: `_sir_seq_iter` now snapshots a `*Seq`'s elements (and still walks cons-lists), so `for x in [1,2,3]` and `for x in <cons-list>` both work.

**Tests:** 48 unit + 3 `go run` compile-and-run proofs (the new one asserts `99,3,99,2,3,nil,60` across seq lit/index/len/set + aliasing, map lit/get/set + missing-key, and ForEach over a seq literal); clippy clean; security review passed (one LOW/INFO: cyclic Seq/Map could overflow in the *emitted* program — same as the Rust backend, tracked as a follow-up). Isolated to `semantic-ir-to-go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)