### PR TITLE
feat(fsharp-sql-planner): F# logical query planner (Level 1 prerequisite)

### DIFF
--- a/code/packages/fsharp/sql-planner/BUILD
+++ b/code/packages/fsharp/sql-planner/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.SqlPlanner.Tests/CodingAdventures.SqlPlanner.Tests.fsproj --disable-build-servers /p:CollectCoverage=true "/p:Include=[CodingAdventures.SqlPlanner]*" /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/sql-planner/BUILD_windows
+++ b/code/packages/fsharp/sql-planner/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.SqlPlanner.Tests/CodingAdventures.SqlPlanner.Tests.fsproj --disable-build-servers /p:CollectCoverage=true "/p:Include=[CodingAdventures.SqlPlanner]*" /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/sql-planner/CHANGELOG.md
+++ b/code/packages/fsharp/sql-planner/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to `CodingAdventures.SqlPlanner.FSharp` will be documented here.
+
+## [0.1.0] - 2026-06-30
+
+### Added
+- `SqlValue` discriminated union (Null | Integer | Real | Text | Bool)
+- `Expr` discriminated union with 14 variants: Literal, Column, BinaryOp, UnaryOp, FuncCall, IsNull, IsNotNull, Between, In, NotIn, Like, NotLike, Wildcard, AggExpr
+- `LogicalPlan` discriminated union with 15 node types: Scan, Filter, Project, Join, Aggregate, Having, Sort, Limit, Distinct, Union, Insert, Update, Delete, CreateTable, DropTable
+- `Statement` type with 6 variants: Select, Insert, Update, Delete, CreateTable, DropTable
+- `PlanError` type with 6 variants: AmbiguousColumn, UnknownTable, UnknownColumn, InvalidAggregate, UnsupportedStatement, InternalError
+- `ISchemaProvider` interface and `InMemorySchemaProvider` implementation
+- `Planner.plan` — transforms a single `Statement` into `Result<LogicalPlan, PlanError>`
+- `Planner.planAll` — plans a list of statements, failing fast on the first error
+- 8-step bottom-up SELECT pipeline: Scan → Filter → Aggregate → Having → Project → Distinct → Sort → Limit
+- Column resolution with scope tracking, alias support, and ambiguity detection
+- 52 unit tests; 83% line coverage, 100% method coverage

--- a/code/packages/fsharp/sql-planner/CodingAdventures.SqlPlanner.fsproj
+++ b/code/packages/fsharp/sql-planner/CodingAdventures.SqlPlanner.fsproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.SqlPlanner.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>F# logical query planner: transforms SQL statements into LogicalPlan trees for the Mini-SQLite Level 1 pipeline.</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="SqlPlanner.fs" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/sql-planner/README.md
+++ b/code/packages/fsharp/sql-planner/README.md
@@ -1,0 +1,66 @@
+# CodingAdventures.SqlPlanner.FSharp
+
+F# logical query planner for the Mini-SQLite Level 1 pipeline.
+
+## What it does
+
+Transforms a parsed `Statement` into a tree of `LogicalPlan` nodes using an
+8-step bottom-up pipeline for SELECT:
+
+```
+Scan → Filter → Aggregate → Having → Project → Distinct → Sort → Limit
+```
+
+No I/O, no execution. Pure data transformation: statement in, plan tree out.
+
+## How it fits in the stack
+
+```
+sql-parser  →  sql-planner  →  sql-optimizer  →  sql-codegen  →  sql-vm
+              (this pkg)
+```
+
+The F# `sql-parser` package is currently a stub, so callers build `Statement`
+values directly (or wrap their own parser output).
+
+## Usage
+
+```fsharp
+open CodingAdventures.SqlPlanner.FSharp
+
+let schema =
+    InMemorySchemaProvider(Map.ofList [ "users", ["id"; "name"; "age"] ])
+
+let stmt =
+    Statement.Select
+        { Distinct = false
+          Columns  = [ OutputColumn.Expr(Expr.Column(None, "name"), None) ]
+          From     = [ "users", None ]
+          Joins    = []
+          Where    = Some (Expr.BinaryOp(Gt, Expr.Column(None, "age"), Expr.Literal(SqlValue.Integer 18L)))
+          GroupBy  = []
+          Having   = None
+          OrderBy  = []
+          Limit    = None }
+
+match Planner.plan schema stmt with
+| Ok plan  -> printfn "%A" plan
+| Error e  -> printfn "Planning error: %A" e
+```
+
+## Key types
+
+| Type | Description |
+|------|-------------|
+| `SqlValue` | Literal values: Null, Integer, Real, Text, Bool |
+| `Expr` | Scalar expressions: Column, BinaryOp, AggExpr, Like, … |
+| `Statement` | SQL statements: Select, Insert, Update, Delete, DDL |
+| `LogicalPlan` | Plan nodes: Scan, Filter, Project, Join, Aggregate, … |
+| `PlanError` | Planning errors: UnknownTable, AmbiguousColumn, … |
+| `ISchemaProvider` | Interface for column-name lookup |
+
+## Running tests
+
+```
+dotnet test tests/CodingAdventures.SqlPlanner.Tests/ --disable-build-servers
+```

--- a/code/packages/fsharp/sql-planner/SqlPlanner.fs
+++ b/code/packages/fsharp/sql-planner/SqlPlanner.fs
@@ -1,0 +1,555 @@
+// SqlPlanner.fs — logical query plan builder for SQL statements.
+//
+// This module transforms a parsed SQL statement (Statement DU) into a
+// tree of LogicalPlan nodes. No I/O, no execution — planning only.
+//
+// Architecture: bottom-up for SELECT
+//   Scan → Filter → Aggregate → Having → Project → Distinct → Sort → Limit
+//
+// Usage:
+//   let schema = InMemorySchemaProvider(Map.ofList [("users", ["id";"name";"age"])])
+//   let plan = Planner.plan schema (Statement.Select { ... })
+
+namespace CodingAdventures.SqlPlanner.FSharp
+
+// ── SQL primitive values ──────────────────────────────────────────────────────
+// A minimal value type for literal expressions in query plans.
+
+[<RequireQualifiedAccess>]
+type SqlValue =
+    | Null
+    | Integer of int64
+    | Real    of float
+    | Text    of string
+    | Bool    of bool
+
+// ── Operator enumerations ─────────────────────────────────────────────────────
+// Suffix names avoid DU case conflicts with Expr.BinaryOp, Expr.UnaryOp, Expr.AggExpr.
+
+/// Binary infix operators.
+type BinaryOperator =
+    | Eq | NotEq | Lt | Lte | Gt | Gte
+    | And | Or
+    | Add | Sub | Mul | Div | Mod
+
+/// Unary prefix operators.
+type UnaryOperator = Not | Neg
+
+/// Aggregate functions.
+type AggFunction = Count | Sum | Avg | Min | Max
+
+// ── Expression IR ────────────────────────────────────────────────────────────
+// AggArg and Expr are mutually recursive via the `and` keyword.
+
+/// Argument to an aggregate function.
+[<RequireQualifiedAccess>]
+type AggArg =
+    | Star
+    | Expr of Expr
+
+/// A scalar expression in a query plan.
+and [<RequireQualifiedAccess>] Expr =
+    | Literal   of value: SqlValue
+    | Column    of table: string option * col: string
+    | BinaryOp  of op: BinaryOperator * left: Expr * right: Expr
+    | UnaryOp   of op: UnaryOperator  * operand: Expr
+    | FuncCall  of name: string * args: Expr list
+    | IsNull    of Expr
+    | IsNotNull of Expr
+    | Between   of value: Expr * low: Expr * high: Expr
+    | In        of value: Expr * items: Expr list
+    | NotIn     of value: Expr * items: Expr list
+    | Like      of value: Expr * pattern: string
+    | NotLike   of value: Expr * pattern: string
+    | Wildcard
+    | AggExpr   of func: AggFunction * arg: AggArg * distinct: bool
+
+// ── Sort / join helpers ───────────────────────────────────────────────────────
+
+type SortDir   = Asc | Desc
+type NullOrder = NullsFirst | NullsLast
+type JoinKind  = Inner | Left | Right | Full | Cross
+
+type SortKey = { KeyExpr: Expr; Direction: SortDir; NullOrder: NullOrder }
+
+// ── SELECT output columns ─────────────────────────────────────────────────────
+
+[<RequireQualifiedAccess>]
+type OutputColumn =
+    | Expr of expr: Expr * alias: string option
+    | Star
+
+// ── Structural types ──────────────────────────────────────────────────────────
+
+type JoinClause =
+    { Kind:  JoinKind
+      Table: string
+      Alias: string option
+      On:    Expr option }
+
+type ColumnDef =
+    { Name:       string
+      TypeName:   string
+      NotNull:    bool
+      PrimaryKey: bool
+      Unique:     bool
+      Default:    Expr option }
+
+type Assignment = { Column: string; Value: Expr }
+
+type LimitClause = { Count: int64 option; Offset: int64 option }
+
+// ── Statement AST ─────────────────────────────────────────────────────────────
+// The F# sql-parser is a stub, so this package defines its own statement types.
+
+type SelectStmt =
+    { Distinct: bool
+      Columns:  OutputColumn list
+      From:     (string * string option) list
+      Joins:    JoinClause list
+      Where:    Expr option
+      GroupBy:  Expr list
+      Having:   Expr option
+      OrderBy:  SortKey list
+      Limit:    LimitClause option }
+
+type InsertStmt =
+    { Table:   string
+      Columns: string list option
+      Values:  Expr list list }
+
+type UpdateStmt =
+    { Table:       string
+      Assignments: Assignment list
+      Where:       Expr option }
+
+type DeleteStmt = { Table: string; Where: Expr option }
+
+type CreateTableStmt =
+    { Table:       string
+      IfNotExists: bool
+      Columns:     ColumnDef list }
+
+type DropTableStmt = { Table: string; IfExists: bool }
+
+[<RequireQualifiedAccess>]
+type Statement =
+    | Select      of SelectStmt
+    | Insert      of InsertStmt
+    | Update      of UpdateStmt
+    | Delete      of DeleteStmt
+    | CreateTable of CreateTableStmt
+    | DropTable   of DropTableStmt
+
+// ── Aggregate item ────────────────────────────────────────────────────────────
+
+type AggregateItem =
+    { Func:     AggFunction
+      Arg:      AggArg
+      Alias:    string
+      Distinct: bool }
+
+// ── Logical plan ─────────────────────────────────────────────────────────────
+// InsertSource and LogicalPlan are mutually recursive.
+
+[<RequireQualifiedAccess>]
+type InsertSource =
+    | Values of Expr list list
+    | Query  of LogicalPlan
+
+and [<RequireQualifiedAccess>] LogicalPlan =
+    | Scan        of table: string * alias: string option
+    | Filter      of input: LogicalPlan * predicate: Expr
+    | Project     of input: LogicalPlan * columns: OutputColumn list
+    | Join        of left: LogicalPlan * right: LogicalPlan * kind: JoinKind * condition: Expr option
+    | Aggregate   of input: LogicalPlan * groupBy: Expr list * aggregates: AggregateItem list
+    | Having      of input: LogicalPlan * predicate: Expr
+    | Sort        of input: LogicalPlan * keys: SortKey list
+    | Limit       of input: LogicalPlan * count: int64 option * offset: int64 option
+    | Distinct    of input: LogicalPlan
+    | Union       of left: LogicalPlan * right: LogicalPlan * all: bool
+    | Insert      of table: string * columns: string list option * source: InsertSource
+    | Update      of table: string * assignments: Assignment list * predicate: Expr option
+    | Delete      of table: string * predicate: Expr option
+    | CreateTable of table: string * ifNotExists: bool * columns: ColumnDef list
+    | DropTable   of table: string * ifExists: bool
+
+// ── Plan errors ───────────────────────────────────────────────────────────────
+
+[<RequireQualifiedAccess>]
+type PlanError =
+    | AmbiguousColumn      of column: string * tables: string list
+    | UnknownTable         of table: string
+    | UnknownColumn        of table: string option * column: string
+    | InvalidAggregate     of message: string
+    | UnsupportedStatement of kind: string
+    | InternalError        of message: string
+
+// ── Schema provider ───────────────────────────────────────────────────────────
+
+type ISchemaProvider =
+    abstract member Columns : table: string -> Result<string list, PlanError>
+
+type InMemorySchemaProvider(tables: Map<string, string list>) =
+    interface ISchemaProvider with
+        member _.Columns(table) =
+            match Map.tryFind table tables with
+            | Some cols -> Ok cols
+            | None      -> Error (PlanError.UnknownTable table)
+
+// ── Internal helpers ──────────────────────────────────────────────────────────
+
+module private Helpers =
+    let traverseResult (f: 'a -> Result<'b, 'e>) (lst: 'a list) : Result<'b list, 'e> =
+        let rec loop acc = function
+            | []      -> Ok (List.rev acc)
+            | x :: xs ->
+                match f x with
+                | Error e -> Error e
+                | Ok v    -> loop (v :: acc) xs
+        loop [] lst
+
+// ── Planner ───────────────────────────────────────────────────────────────────
+
+module Planner =
+    open Helpers
+
+    type private ScopeEntry = { Alias: string; Table: string; Cols: string list }
+
+    // Build scope from FROM + JOIN sources.
+    let private buildScope
+        (schema: ISchemaProvider)
+        (from:   (string * string option) list)
+        (joins:  JoinClause list)
+        : Result<ScopeEntry list, PlanError> =
+
+        let fromResult =
+            from |> traverseResult (fun (tbl, aliasOpt) ->
+                match schema.Columns(tbl) with
+                | Error e -> Error e
+                | Ok cols ->
+                    Ok { Alias = aliasOpt |> Option.defaultValue tbl
+                         Table = tbl
+                         Cols  = cols })
+
+        let joinResult =
+            joins |> traverseResult (fun j ->
+                match schema.Columns(j.Table) with
+                | Error e -> Error e
+                | Ok cols ->
+                    Ok { Alias = j.Alias |> Option.defaultValue j.Table
+                         Table = j.Table
+                         Cols  = cols })
+
+        match fromResult, joinResult with
+        | Ok fe, Ok je -> Ok (fe @ je)
+        | Error e, _   -> Error e
+        | _, Error e   -> Error e
+
+    // Resolve a column reference against scope.
+    let private resolveColumn
+        (scope:    ScopeEntry list)
+        (tableOpt: string option)
+        (col:      string)
+        : Result<Expr, PlanError> =
+
+        let ciEq a b =
+            System.String.Compare(a, b, System.StringComparison.OrdinalIgnoreCase) = 0
+
+        match tableOpt with
+        | Some tbl ->
+            match scope |> List.tryFind (fun e -> e.Alias = tbl) with
+            | None ->
+                Error (PlanError.UnknownTable tbl)
+            | Some entry ->
+                if entry.Cols |> List.exists (ciEq col)
+                then Ok (Expr.Column(Some entry.Alias, col))
+                else Error (PlanError.UnknownColumn(Some tbl, col))
+        | None ->
+            let matches = scope |> List.filter (fun e -> e.Cols |> List.exists (ciEq col))
+            match matches with
+            | []  -> Error (PlanError.UnknownColumn(None, col))
+            | [m] -> Ok (Expr.Column(Some m.Alias, col))
+            | ms  -> Error (PlanError.AmbiguousColumn(col, ms |> List.map (fun e -> e.Alias)))
+
+    // Recursively resolve column references inside an expression.
+    let rec private resolveExpr (scope: ScopeEntry list) (expr: Expr) : Result<Expr, PlanError> =
+        match expr with
+        | Expr.Column(tOpt, col) -> resolveColumn scope tOpt col
+        | Expr.Literal _         -> Ok expr
+        | Expr.Wildcard          -> Ok expr
+        | Expr.AggExpr _         -> Ok expr
+        | Expr.BinaryOp(op, l, r) ->
+            match resolveExpr scope l with
+            | Error e -> Error e
+            | Ok rl   ->
+                match resolveExpr scope r with
+                | Error e -> Error e
+                | Ok rr   -> Ok (Expr.BinaryOp(op, rl, rr))
+        | Expr.UnaryOp(op, e) ->
+            match resolveExpr scope e with
+            | Error e2 -> Error e2
+            | Ok re    -> Ok (Expr.UnaryOp(op, re))
+        | Expr.FuncCall(name, args) ->
+            match args |> traverseResult (resolveExpr scope) with
+            | Error e    -> Error e
+            | Ok rArgs   -> Ok (Expr.FuncCall(name, rArgs))
+        | Expr.IsNull e ->
+            match resolveExpr scope e with
+            | Error e2 -> Error e2
+            | Ok re    -> Ok (Expr.IsNull re)
+        | Expr.IsNotNull e ->
+            match resolveExpr scope e with
+            | Error e2 -> Error e2
+            | Ok re    -> Ok (Expr.IsNotNull re)
+        | Expr.Between(v, lo, hi) ->
+            match resolveExpr scope v with
+            | Error e -> Error e
+            | Ok rv   ->
+                match resolveExpr scope lo with
+                | Error e  -> Error e
+                | Ok rlo   ->
+                    match resolveExpr scope hi with
+                    | Error e  -> Error e
+                    | Ok rhi   -> Ok (Expr.Between(rv, rlo, rhi))
+        | Expr.In(v, items) ->
+            match resolveExpr scope v with
+            | Error e -> Error e
+            | Ok rv   ->
+                match items |> traverseResult (resolveExpr scope) with
+                | Error e    -> Error e
+                | Ok rItems  -> Ok (Expr.In(rv, rItems))
+        | Expr.NotIn(v, items) ->
+            match resolveExpr scope v with
+            | Error e -> Error e
+            | Ok rv   ->
+                match items |> traverseResult (resolveExpr scope) with
+                | Error e    -> Error e
+                | Ok rItems  -> Ok (Expr.NotIn(rv, rItems))
+        | Expr.Like(v, p) ->
+            match resolveExpr scope v with
+            | Error e -> Error e
+            | Ok rv   -> Ok (Expr.Like(rv, p))
+        | Expr.NotLike(v, p) ->
+            match resolveExpr scope v with
+            | Error e -> Error e
+            | Ok rv   -> Ok (Expr.NotLike(rv, p))
+
+    // Collect AggExpr nodes from a list of expressions.
+    let private collectAggregates (exprs: Expr list) : AggregateItem list =
+        let mutable found: AggregateItem list = []
+        let mutable counter = 0
+        let rec walk e =
+            match e with
+            | Expr.AggExpr(func, arg, distinct) ->
+                let alias = sprintf "_agg%d" counter
+                counter <- counter + 1
+                found <- { Func = func; Arg = arg; Alias = alias; Distinct = distinct } :: found
+            | Expr.BinaryOp(_, l, r) -> walk l; walk r
+            | Expr.UnaryOp(_, e2)    -> walk e2
+            | Expr.FuncCall(_, args) -> List.iter walk args
+            | Expr.IsNull e2         -> walk e2
+            | Expr.IsNotNull e2      -> walk e2
+            | Expr.Between(v, lo, hi)-> walk v; walk lo; walk hi
+            | Expr.In(v, items)      -> walk v; List.iter walk items
+            | Expr.NotIn(v, items)   -> walk v; List.iter walk items
+            | Expr.Like(v, _)        -> walk v
+            | Expr.NotLike(v, _)     -> walk v
+            | _                      -> ()
+        List.iter walk exprs
+        List.rev found
+
+    // Check whether any expression contains an aggregate call.
+    let private containsAgg (exprs: Expr list) : bool =
+        let rec check e =
+            match e with
+            | Expr.AggExpr _          -> true
+            | Expr.BinaryOp(_, l, r)  -> check l || check r
+            | Expr.UnaryOp(_, e2)     -> check e2
+            | Expr.FuncCall(_, args)  -> List.exists check args
+            | Expr.IsNull e2          -> check e2
+            | Expr.IsNotNull e2       -> check e2
+            | Expr.Between(v, lo, hi) -> check v || check lo || check hi
+            | Expr.In(v, items)       -> check v || List.exists check items
+            | Expr.NotIn(v, items)    -> check v || List.exists check items
+            | Expr.Like(v, _)         -> check v
+            | Expr.NotLike(v, _)      -> check v
+            | _                       -> false
+        List.exists check exprs
+
+    let private exprOfOutputCol = function
+        | OutputColumn.Star      -> Expr.Wildcard
+        | OutputColumn.Expr(e,_) -> e
+
+    // Validate table exists and return a Scan node.
+    let private buildScan (schema: ISchemaProvider) (tbl: string) (aliasOpt: string option)
+        : Result<LogicalPlan, PlanError> =
+        match schema.Columns(tbl) with
+        | Error e -> Error e
+        | Ok _    -> Ok (LogicalPlan.Scan(tbl, aliasOpt))
+
+    // Build the FROM + JOIN tree left-associatively.
+    let private buildFromTree
+        (schema: ISchemaProvider)
+        (from:   (string * string option) list)
+        (joins:  JoinClause list)
+        : Result<LogicalPlan, PlanError> =
+
+        match from with
+        | [] -> Error (PlanError.UnsupportedStatement "SELECT without FROM")
+        | (tbl0, alias0) :: rest ->
+            match buildScan schema tbl0 alias0 with
+            | Error e -> Error e
+            | Ok root ->
+                let withRest =
+                    rest |> List.fold (fun accR (tbl, aliasOpt) ->
+                        match accR with
+                        | Error e -> Error e
+                        | Ok acc  ->
+                            match buildScan schema tbl aliasOpt with
+                            | Error e    -> Error e
+                            | Ok right   -> Ok (LogicalPlan.Join(acc, right, Cross, None)))
+                        (Ok root)
+                match withRest with
+                | Error e     -> Error e
+                | Ok fromPlan ->
+                    joins |> List.fold (fun accR jc ->
+                        match accR with
+                        | Error e -> Error e
+                        | Ok acc  ->
+                            match buildScan schema jc.Table jc.Alias with
+                            | Error e  -> Error e
+                            | Ok right -> Ok (LogicalPlan.Join(acc, right, jc.Kind, jc.On)))
+                        (Ok fromPlan)
+
+    // Plan a SELECT using the 8-step bottom-up pipeline.
+    // Uses explicit match chains (railway pattern) to avoid F# indentation issues
+    // with `let` bindings nested inside `|> Result.bind` lambda continuations.
+    let private planSelect (schema: ISchemaProvider) (s: SelectStmt) : Result<LogicalPlan, PlanError> =
+        match buildScope schema s.From s.Joins with
+        | Error e -> Error e
+        | Ok scope ->
+        match buildFromTree schema s.From s.Joins with
+        | Error e -> Error e
+        | Ok fromPlan ->
+
+        // Step 1: WHERE → Filter
+        let filtered =
+            match s.Where with
+            | None      -> Ok fromPlan
+            | Some pred ->
+                match resolveExpr scope pred with
+                | Error e    -> Error e
+                | Ok rPred   -> Ok (LogicalPlan.Filter(fromPlan, rPred))
+
+        match filtered with
+        | Error e -> Error e
+        | Ok afterFilter ->
+
+        let colExprs    = s.Columns |> List.map exprOfOutputCol
+        let havingExprs = s.Having  |> Option.toList
+
+        // Step 2: GROUP BY + Aggregate
+        let needsAgg =
+            s.GroupBy <> [] || containsAgg colExprs || containsAgg havingExprs
+
+        let aggregated =
+            if needsAgg then
+                let aggs = collectAggregates (colExprs @ havingExprs)
+                match s.GroupBy |> traverseResult (resolveExpr scope) with
+                | Error e       -> Error e
+                | Ok rGroupBy   -> Ok (LogicalPlan.Aggregate(afterFilter, rGroupBy, aggs))
+            else
+                Ok afterFilter
+
+        match aggregated with
+        | Error e -> Error e
+        | Ok afterAgg ->
+
+        // Step 3: HAVING
+        let having =
+            match s.Having with
+            | None      -> Ok afterAgg
+            | Some pred ->
+                match resolveExpr scope pred with
+                | Ok rPred                        -> Ok (LogicalPlan.Having(afterAgg, rPred))
+                | Error (PlanError.UnknownColumn _) -> Ok (LogicalPlan.Having(afterAgg, pred))
+                | Error e                         -> Error e
+
+        match having with
+        | Error e -> Error e
+        | Ok afterHaving ->
+
+        // Step 4: PROJECT
+        let projected =
+            match s.Columns |> traverseResult (fun outCol ->
+                match outCol with
+                | OutputColumn.Star -> Ok OutputColumn.Star
+                | OutputColumn.Expr(e, alias) ->
+                    match resolveExpr scope e with
+                    | Ok re -> Ok (OutputColumn.Expr(re, alias))
+                    | Error (PlanError.UnknownColumn _) when needsAgg ->
+                        Ok (OutputColumn.Expr(e, alias))
+                    | Error e2 -> Error e2) with
+            | Error e    -> Error e
+            | Ok cols    -> Ok (LogicalPlan.Project(afterHaving, cols))
+
+        match projected with
+        | Error e -> Error e
+        | Ok afterProject ->
+
+        // Step 5: DISTINCT
+        let distinct =
+            if s.Distinct
+            then LogicalPlan.Distinct(afterProject)
+            else afterProject
+
+        // Step 6: ORDER BY
+        let sorted =
+            if s.OrderBy = [] then
+                Ok distinct
+            else
+                match s.OrderBy |> traverseResult (fun key ->
+                    match resolveExpr scope key.KeyExpr with
+                    | Ok re                           -> Ok { key with KeyExpr = re }
+                    | Error (PlanError.UnknownColumn _) -> Ok key
+                    | Error e                         -> Error e) with
+                | Error e    -> Error e
+                | Ok keys    -> Ok (LogicalPlan.Sort(distinct, keys))
+
+        match sorted with
+        | Error e -> Error e
+        | Ok afterSort ->
+
+        // Step 7: LIMIT / OFFSET
+        match s.Limit with
+        | None    -> Ok afterSort
+        | Some lc -> Ok (LogicalPlan.Limit(afterSort, lc.Count, lc.Offset))
+
+    // ── Public API ────────────────────────────────────────────────────────────
+
+    /// Transform a single Statement into a LogicalPlan, or return a PlanError.
+    let plan (schema: ISchemaProvider) (stmt: Statement) : Result<LogicalPlan, PlanError> =
+        match stmt with
+        | Statement.Select s ->
+            planSelect schema s
+        | Statement.Insert i ->
+            match schema.Columns(i.Table) with
+            | Error e -> Error e
+            | Ok _    -> Ok (LogicalPlan.Insert(i.Table, i.Columns, InsertSource.Values i.Values))
+        | Statement.Update u ->
+            match schema.Columns(u.Table) with
+            | Error e -> Error e
+            | Ok _    -> Ok (LogicalPlan.Update(u.Table, u.Assignments, u.Where))
+        | Statement.Delete d ->
+            match schema.Columns(d.Table) with
+            | Error e -> Error e
+            | Ok _    -> Ok (LogicalPlan.Delete(d.Table, d.Where))
+        | Statement.CreateTable ct ->
+            Ok (LogicalPlan.CreateTable(ct.Table, ct.IfNotExists, ct.Columns))
+        | Statement.DropTable dt ->
+            Ok (LogicalPlan.DropTable(dt.Table, dt.IfExists))
+
+    /// Plan every statement in the list, failing on the first error.
+    let planAll (schema: ISchemaProvider) (stmts: Statement list) : Result<LogicalPlan list, PlanError> =
+        stmts |> Helpers.traverseResult (plan schema)

--- a/code/packages/fsharp/sql-planner/required_capabilities.json
+++ b/code/packages/fsharp/sql-planner/required_capabilities.json
@@ -1,0 +1,5 @@
+{
+  "network": false,
+  "filesystem": false,
+  "subprocess": false
+}

--- a/code/packages/fsharp/sql-planner/tests/CodingAdventures.SqlPlanner.Tests/CodingAdventures.SqlPlanner.Tests.fsproj
+++ b/code/packages/fsharp/sql-planner/tests/CodingAdventures.SqlPlanner.Tests/CodingAdventures.SqlPlanner.Tests.fsproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="SqlPlannerTests.fs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk"      Version="17.12.0" />
+    <PackageReference Include="xunit"                       Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio"   Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector"          Version="6.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.msbuild"            Version="6.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../CodingAdventures.SqlPlanner.fsproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/sql-planner/tests/CodingAdventures.SqlPlanner.Tests/SqlPlannerTests.fs
+++ b/code/packages/fsharp/sql-planner/tests/CodingAdventures.SqlPlanner.Tests/SqlPlannerTests.fs
@@ -1,0 +1,640 @@
+// SqlPlannerTests.fs — conformance tests for the F# sql-planner.
+//
+// Covers the 13 required conformance points from sql-planner.md plus
+// extensive expression-type and error-path coverage.
+
+module CodingAdventures.SqlPlanner.FSharp.Tests
+
+open Xunit
+open CodingAdventures.SqlPlanner.FSharp
+
+// ── Shared helpers ────────────────────────────────────────────────────────────
+
+/// Schema: users(id, name, age)  orders(id, user_id, amount)
+let private schema =
+    InMemorySchemaProvider(
+        Map.ofList
+            [ "users",  ["id"; "name"; "age"]
+              "orders", ["id"; "user_id"; "amount"] ]) :> ISchemaProvider
+
+let private ok (r: Result<'a, PlanError>) =
+    match r with
+    | Ok v    -> v
+    | Error e -> failwith (sprintf "Expected Ok but got Error: %A" e)
+
+let private err (r: Result<'a, PlanError>) =
+    match r with
+    | Error e -> e
+    | Ok v    -> failwith (sprintf "Expected Error but got Ok: %A" v)
+
+let private col tblOpt name =
+    OutputColumn.Expr(Expr.Column(tblOpt, name), None)
+
+let private selectFrom cols from =
+    { Distinct = false
+      Columns  = cols
+      From     = from
+      Joins    = []
+      Where    = None
+      GroupBy  = []
+      Having   = None
+      OrderBy  = []
+      Limit    = None }
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Conformance tests (13 required by spec)
+// ──────────────────────────────────────────────────────────────────────────────
+
+[<Fact>]
+let ``C1: Simple SELECT produces Scan wrapped in Project`` () =
+    let plan = ok (Planner.plan schema (Statement.Select (selectFrom [col None "id"; col None "name"] ["users", None])))
+    match plan with
+    | LogicalPlan.Project(LogicalPlan.Scan("users", None), cols) ->
+        Assert.Equal(2, cols.Length)
+    | other -> failwith (sprintf "Expected Project(Scan), got %A" other)
+
+[<Fact>]
+let ``C2: WHERE clause inserts Filter between Scan and Project`` () =
+    let pred = Expr.BinaryOp(Gt, Expr.Column(None, "age"), Expr.Literal(SqlValue.Integer 18L))
+    let stmt = selectFrom [col None "name"] ["users", None]
+    let plan = ok (Planner.plan schema (Statement.Select { stmt with Where = Some pred }))
+    match plan with
+    | LogicalPlan.Project(LogicalPlan.Filter(LogicalPlan.Scan("users", None), _), _) -> ()
+    | other -> failwith (sprintf "Expected Project(Filter(Scan)), got %A" other)
+
+[<Fact>]
+let ``C3: GROUP BY with aggregate and HAVING produces Aggregate then Having then Project`` () =
+    let aggExpr = Expr.AggExpr(Count, AggArg.Star, false)
+    let stmt =
+        { Distinct = false
+          Columns  = [ col None "name"; OutputColumn.Expr(aggExpr, Some "cnt") ]
+          From     = [ "users", None ]
+          Joins    = []
+          Where    = None
+          GroupBy  = [ Expr.Column(None, "name") ]
+          Having   = Some (Expr.BinaryOp(Gt, aggExpr, Expr.Literal(SqlValue.Integer 1L)))
+          OrderBy  = []
+          Limit    = None }
+    let plan = ok (Planner.plan schema (Statement.Select stmt))
+    match plan with
+    | LogicalPlan.Project(LogicalPlan.Having(LogicalPlan.Aggregate(LogicalPlan.Scan("users", None), groupBy, aggs), _), _) ->
+        Assert.Equal(1, groupBy.Length)
+        Assert.NotEmpty(aggs)
+    | other -> failwith (sprintf "Expected Project(Having(Aggregate(Scan))), got %A" other)
+
+[<Fact>]
+let ``C4: JOIN clause produces a Join node above the Scans`` () =
+    let onCond = Expr.BinaryOp(Eq, Expr.Column(Some "users", "id"), Expr.Column(Some "orders", "user_id"))
+    let stmt =
+        { Distinct = false
+          Columns  = [ col (Some "users") "name"; col (Some "orders") "amount" ]
+          From     = [ "users", None ]
+          Joins    = [ { Kind = Inner; Table = "orders"; Alias = None; On = Some onCond } ]
+          Where    = None
+          GroupBy  = []
+          Having   = None
+          OrderBy  = []
+          Limit    = None }
+    let plan = ok (Planner.plan schema (Statement.Select stmt))
+    match plan with
+    | LogicalPlan.Project(LogicalPlan.Join(LogicalPlan.Scan("users", _), LogicalPlan.Scan("orders", _), Inner, Some _), _) -> ()
+    | other -> failwith (sprintf "Expected Project(Join(Scan,Scan)), got %A" other)
+
+[<Fact>]
+let ``C5: ORDER BY produces Sort at the top`` () =
+    let stmt = selectFrom [col None "name"] ["users", None]
+    let plan = ok (Planner.plan schema (Statement.Select
+        { stmt with OrderBy = [ { KeyExpr = Expr.Column(None, "age"); Direction = Desc; NullOrder = NullsLast } ] }))
+    match plan with
+    | LogicalPlan.Sort(_, keys) -> Assert.Equal(1, keys.Length)
+    | other -> failwith (sprintf "Expected Sort at top, got %A" other)
+
+[<Fact>]
+let ``C6: LIMIT and OFFSET produce Limit at the top`` () =
+    let stmt = selectFrom [col None "id"] ["users", None]
+    let plan = ok (Planner.plan schema (Statement.Select
+        { stmt with Limit = Some { Count = Some 10L; Offset = Some 20L } }))
+    match plan with
+    | LogicalPlan.Limit(_, Some 10L, Some 20L) -> ()
+    | other -> failwith (sprintf "Expected Limit(_, 10, 20), got %A" other)
+
+[<Fact>]
+let ``C7: SELECT DISTINCT wraps Project in Distinct`` () =
+    let stmt = selectFrom [col None "name"] ["users", None]
+    let plan = ok (Planner.plan schema (Statement.Select { stmt with Distinct = true }))
+    match plan with
+    | LogicalPlan.Distinct(LogicalPlan.Project _) -> ()
+    | other -> failwith (sprintf "Expected Distinct(Project(_)), got %A" other)
+
+[<Fact>]
+let ``C8: INSERT produces Insert node with Values source`` () =
+    let stmt =
+        Statement.Insert
+            { Table   = "users"
+              Columns = Some ["id"; "name"; "age"]
+              Values  = [ [ Expr.Literal(SqlValue.Integer 1L)
+                            Expr.Literal(SqlValue.Text "Alice")
+                            Expr.Literal(SqlValue.Integer 30L) ] ] }
+    let plan = ok (Planner.plan schema stmt)
+    match plan with
+    | LogicalPlan.Insert("users", Some cols, InsertSource.Values rows) ->
+        Assert.Equal(3, cols.Length); Assert.Equal(1, rows.Length)
+    | other -> failwith (sprintf "Expected Insert, got %A" other)
+
+[<Fact>]
+let ``C9: UPDATE produces Update node with assignments and predicate`` () =
+    let stmt =
+        Statement.Update
+            { Table       = "users"
+              Assignments = [ { Column = "name"; Value = Expr.Literal(SqlValue.Text "Bob") } ]
+              Where       = Some (Expr.BinaryOp(Eq, Expr.Column(None, "id"), Expr.Literal(SqlValue.Integer 1L))) }
+    let plan = ok (Planner.plan schema stmt)
+    match plan with
+    | LogicalPlan.Update("users", asgns, Some _) ->
+        Assert.Equal(1, asgns.Length); Assert.Equal("name", asgns.[0].Column)
+    | other -> failwith (sprintf "Expected Update, got %A" other)
+
+[<Fact>]
+let ``C10: DELETE produces Delete node`` () =
+    let stmt = Statement.Delete { Table = "users"; Where = Some (Expr.Literal(SqlValue.Bool true)) }
+    let plan = ok (Planner.plan schema stmt)
+    match plan with
+    | LogicalPlan.Delete("users", Some _) -> ()
+    | other -> failwith (sprintf "Expected Delete, got %A" other)
+
+[<Fact>]
+let ``C11a: CREATE TABLE produces CreateTable leaf node`` () =
+    let stmt =
+        Statement.CreateTable
+            { Table       = "products"
+              IfNotExists = true
+              Columns     =
+                [ { Name = "id";    TypeName = "INTEGER"; NotNull = true;  PrimaryKey = true;  Unique = false; Default = None }
+                  { Name = "name";  TypeName = "TEXT";    NotNull = true;  PrimaryKey = false; Unique = false; Default = None }
+                  { Name = "price"; TypeName = "REAL";    NotNull = false; PrimaryKey = false; Unique = false; Default = None } ] }
+    let plan = ok (Planner.plan schema stmt)
+    match plan with
+    | LogicalPlan.CreateTable("products", true, cols) -> Assert.Equal(3, cols.Length)
+    | other -> failwith (sprintf "Expected CreateTable, got %A" other)
+
+[<Fact>]
+let ``C11b: DROP TABLE produces DropTable leaf node`` () =
+    let plan = ok (Planner.plan schema (Statement.DropTable { Table = "users"; IfExists = false }))
+    match plan with
+    | LogicalPlan.DropTable("users", false) -> ()
+    | other -> failwith (sprintf "Expected DropTable, got %A" other)
+
+[<Fact>]
+let ``C12: Ambiguous column reference yields AmbiguousColumn error`` () =
+    // Both "users" and "orders" have "id".
+    let stmt =
+        { Distinct = false
+          Columns  = [ col None "id" ]
+          From     = [ "users", None ]
+          Joins    = [ { Kind = Inner; Table = "orders"; Alias = None; On = None } ]
+          Where    = None
+          GroupBy  = []
+          Having   = None
+          OrderBy  = []
+          Limit    = None }
+    let e = err (Planner.plan schema (Statement.Select stmt))
+    match e with
+    | PlanError.AmbiguousColumn("id", tables) -> Assert.Equal(2, tables.Length)
+    | other -> failwith (sprintf "Expected AmbiguousColumn, got %A" other)
+
+[<Fact>]
+let ``C13: Unknown table yields UnknownTable error`` () =
+    let e = err (Planner.plan schema (Statement.Select (selectFrom [col None "id"] ["ghost", None])))
+    match e with
+    | PlanError.UnknownTable "ghost" -> ()
+    | other -> failwith (sprintf "Expected UnknownTable, got %A" other)
+
+// ──────────────────────────────────────────────────────────────────────────────
+// planAll helper
+// ──────────────────────────────────────────────────────────────────────────────
+
+[<Fact>]
+let ``planAll returns list of plans, fails on first error`` () =
+    let stmts =
+        [ Statement.Insert { Table = "users"; Columns = None; Values = [] }
+          Statement.Delete { Table = "users"; Where = None } ]
+    let plans = ok (Planner.planAll schema stmts)
+    Assert.Equal(2, plans.Length)
+
+    let e = err (Planner.planAll schema [Statement.Select (selectFrom [col None "x"] ["ghost", None])])
+    match e with
+    | PlanError.UnknownTable "ghost" -> ()
+    | other -> failwith (sprintf "Expected UnknownTable, got %A" other)
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Expression type coverage — exercise resolveExpr for every Expr variant
+// ──────────────────────────────────────────────────────────────────────────────
+
+[<Fact>]
+let ``WHERE: FuncCall with resolved args is accepted`` () =
+    let pred = Expr.FuncCall("upper", [ Expr.Column(None, "name") ])
+    let stmt = selectFrom [col None "id"] ["users", None]
+    let plan = ok (Planner.plan schema (Statement.Select { stmt with Where = Some pred }))
+    match plan with
+    | LogicalPlan.Project(LogicalPlan.Filter(_, Expr.FuncCall("upper", [Expr.Column(Some "users", "name")])), _) -> ()
+    | other -> failwith (sprintf "Expected Filter with FuncCall, got %A" other)
+
+[<Fact>]
+let ``WHERE: IsNull and IsNotNull are resolved`` () =
+    let pred1 = Expr.IsNull(Expr.Column(None, "age"))
+    let stmt = selectFrom [col None "id"] ["users", None]
+    let plan1 = ok (Planner.plan schema (Statement.Select { stmt with Where = Some pred1 }))
+    match plan1 with
+    | LogicalPlan.Project(LogicalPlan.Filter(_, Expr.IsNull(Expr.Column(Some "users", "age"))), _) -> ()
+    | other -> failwith (sprintf "Expected Filter with IsNull, got %A" other)
+
+    let pred2 = Expr.IsNotNull(Expr.Column(None, "name"))
+    let plan2 = ok (Planner.plan schema (Statement.Select { stmt with Where = Some pred2 }))
+    match plan2 with
+    | LogicalPlan.Project(LogicalPlan.Filter(_, Expr.IsNotNull(Expr.Column(Some "users", "name"))), _) -> ()
+    | other -> failwith (sprintf "Expected Filter with IsNotNull, got %A" other)
+
+[<Fact>]
+let ``WHERE: Between is resolved`` () =
+    let pred = Expr.Between(Expr.Column(None, "age"), Expr.Literal(SqlValue.Integer 18L), Expr.Literal(SqlValue.Integer 65L))
+    let stmt = selectFrom [col None "id"] ["users", None]
+    let plan = ok (Planner.plan schema (Statement.Select { stmt with Where = Some pred }))
+    match plan with
+    | LogicalPlan.Project(LogicalPlan.Filter(_, Expr.Between _), _) -> ()
+    | other -> failwith (sprintf "Expected Filter with Between, got %A" other)
+
+[<Fact>]
+let ``WHERE: In and NotIn are resolved`` () =
+    let items = [ Expr.Literal(SqlValue.Integer 1L); Expr.Literal(SqlValue.Integer 2L) ]
+    let pred1 = Expr.In(Expr.Column(None, "id"), items)
+    let stmt = selectFrom [col None "name"] ["users", None]
+    let plan1 = ok (Planner.plan schema (Statement.Select { stmt with Where = Some pred1 }))
+    match plan1 with
+    | LogicalPlan.Project(LogicalPlan.Filter(_, Expr.In _), _) -> ()
+    | other -> failwith (sprintf "Expected Filter with In, got %A" other)
+
+    let pred2 = Expr.NotIn(Expr.Column(None, "id"), items)
+    let plan2 = ok (Planner.plan schema (Statement.Select { stmt with Where = Some pred2 }))
+    match plan2 with
+    | LogicalPlan.Project(LogicalPlan.Filter(_, Expr.NotIn _), _) -> ()
+    | other -> failwith (sprintf "Expected Filter with NotIn, got %A" other)
+
+[<Fact>]
+let ``WHERE: Like and NotLike are resolved`` () =
+    let pred1 = Expr.Like(Expr.Column(None, "name"), "A%")
+    let stmt = selectFrom [col None "id"] ["users", None]
+    let plan1 = ok (Planner.plan schema (Statement.Select { stmt with Where = Some pred1 }))
+    match plan1 with
+    | LogicalPlan.Project(LogicalPlan.Filter(_, Expr.Like(Expr.Column(Some "users", "name"), "A%")), _) -> ()
+    | other -> failwith (sprintf "Expected Filter with Like, got %A" other)
+
+    let pred2 = Expr.NotLike(Expr.Column(None, "name"), "B%")
+    let plan2 = ok (Planner.plan schema (Statement.Select { stmt with Where = Some pred2 }))
+    match plan2 with
+    | LogicalPlan.Project(LogicalPlan.Filter(_, Expr.NotLike _), _) -> ()
+    | other -> failwith (sprintf "Expected Filter with NotLike, got %A" other)
+
+[<Fact>]
+let ``WHERE: UnaryOp (Not) is resolved`` () =
+    let pred = Expr.UnaryOp(Not, Expr.BinaryOp(Eq, Expr.Column(None, "age"), Expr.Literal(SqlValue.Integer 0L)))
+    let stmt = selectFrom [col None "id"] ["users", None]
+    let plan = ok (Planner.plan schema (Statement.Select { stmt with Where = Some pred }))
+    match plan with
+    | LogicalPlan.Project(LogicalPlan.Filter(_, Expr.UnaryOp(Not, _)), _) -> ()
+    | other -> failwith (sprintf "Expected Filter with UnaryOp(Not), got %A" other)
+
+[<Fact>]
+let ``WHERE: qualified column reference is resolved`` () =
+    let pred = Expr.BinaryOp(Gt, Expr.Column(Some "users", "age"), Expr.Literal(SqlValue.Integer 21L))
+    let stmt = selectFrom [col None "id"] ["users", None]
+    let plan = ok (Planner.plan schema (Statement.Select { stmt with Where = Some pred }))
+    match plan with
+    | LogicalPlan.Project(LogicalPlan.Filter(_, Expr.BinaryOp(Gt, Expr.Column(Some "users", "age"), _)), _) -> ()
+    | other -> failwith (sprintf "Expected resolved qualified column, got %A" other)
+
+[<Fact>]
+let ``WHERE: qualified column with wrong table yields UnknownTable`` () =
+    let pred = Expr.BinaryOp(Eq, Expr.Column(Some "no_such", "id"), Expr.Literal(SqlValue.Integer 1L))
+    let stmt = selectFrom [col None "id"] ["users", None]
+    let e = err (Planner.plan schema (Statement.Select { stmt with Where = Some pred }))
+    match e with
+    | PlanError.UnknownTable "no_such" -> ()
+    | other -> failwith (sprintf "Expected UnknownTable, got %A" other)
+
+[<Fact>]
+let ``WHERE: qualified column not in table yields UnknownColumn`` () =
+    let pred = Expr.Column(Some "users", "no_col")
+    let stmt = selectFrom [col None "id"] ["users", None]
+    let e = err (Planner.plan schema (Statement.Select { stmt with Where = Some pred }))
+    match e with
+    | PlanError.UnknownColumn(Some "users", "no_col") -> ()
+    | other -> failwith (sprintf "Expected UnknownColumn, got %A" other)
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Error paths
+// ──────────────────────────────────────────────────────────────────────────────
+
+[<Fact>]
+let ``INSERT on unknown table yields UnknownTable`` () =
+    let e = err (Planner.plan schema (Statement.Insert { Table = "ghost"; Columns = None; Values = [] }))
+    match e with
+    | PlanError.UnknownTable "ghost" -> ()
+    | other -> failwith (sprintf "Expected UnknownTable, got %A" other)
+
+[<Fact>]
+let ``UPDATE on unknown table yields UnknownTable`` () =
+    let e = err (Planner.plan schema (Statement.Update { Table = "ghost"; Assignments = []; Where = None }))
+    match e with
+    | PlanError.UnknownTable "ghost" -> ()
+    | other -> failwith (sprintf "Expected UnknownTable, got %A" other)
+
+[<Fact>]
+let ``DELETE on unknown table yields UnknownTable`` () =
+    let e = err (Planner.plan schema (Statement.Delete { Table = "ghost"; Where = None }))
+    match e with
+    | PlanError.UnknownTable "ghost" -> ()
+    | other -> failwith (sprintf "Expected UnknownTable, got %A" other)
+
+[<Fact>]
+let ``WHERE BinaryOp propagates left error`` () =
+    let pred = Expr.BinaryOp(Eq, Expr.Column(None, "no_col"), Expr.Literal(SqlValue.Integer 1L))
+    let e = err (Planner.plan schema (Statement.Select (selectFrom [col None "id"] ["users", None] |> fun s -> { s with Where = Some pred })))
+    match e with
+    | PlanError.UnknownColumn _ -> ()
+    | other -> failwith (sprintf "Expected UnknownColumn, got %A" other)
+
+[<Fact>]
+let ``WHERE BinaryOp propagates right error`` () =
+    let pred = Expr.BinaryOp(Eq, Expr.Column(None, "id"), Expr.Column(None, "no_col"))
+    let e = err (Planner.plan schema (Statement.Select (selectFrom [col None "id"] ["users", None] |> fun s -> { s with Where = Some pred })))
+    match e with
+    | PlanError.UnknownColumn _ -> ()
+    | other -> failwith (sprintf "Expected UnknownColumn, got %A" other)
+
+[<Fact>]
+let ``JOIN with unknown join table yields UnknownTable`` () =
+    let stmt =
+        { Distinct = false
+          Columns  = [ col None "id" ]
+          From     = [ "users", None ]
+          Joins    = [ { Kind = Inner; Table = "no_such"; Alias = None; On = None } ]
+          Where    = None
+          GroupBy  = []
+          Having   = None
+          OrderBy  = []
+          Limit    = None }
+    let e = err (Planner.plan schema (Statement.Select stmt))
+    match e with
+    | PlanError.UnknownTable "no_such" -> ()
+    | other -> failwith (sprintf "Expected UnknownTable for join table, got %A" other)
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Aggregate expression variants
+// ──────────────────────────────────────────────────────────────────────────────
+
+[<Fact>]
+let ``SELECT with SUM, AVG, MIN, MAX aggregates produces Aggregate node`` () =
+    let aggs =
+        [ Expr.AggExpr(Sum, AggArg.Expr(Expr.Column(None, "age")), false)
+          Expr.AggExpr(Avg, AggArg.Expr(Expr.Column(None, "age")), false)
+          Expr.AggExpr(Min, AggArg.Expr(Expr.Column(None, "age")), false)
+          Expr.AggExpr(Max, AggArg.Expr(Expr.Column(None, "age")), false) ]
+    let cols = aggs |> List.mapi (fun i e -> OutputColumn.Expr(e, Some (sprintf "a%d" i)))
+    let stmt = selectFrom cols ["users", None]
+    let plan = ok (Planner.plan schema (Statement.Select stmt))
+    match plan with
+    | LogicalPlan.Project(LogicalPlan.Aggregate(LogicalPlan.Scan("users", None), [], aggItems), _) ->
+        Assert.Equal(4, aggItems.Length)
+    | other -> failwith (sprintf "Expected Project(Aggregate(Scan)), got %A" other)
+
+[<Fact>]
+let ``SELECT with COUNT DISTINCT produces Aggregate with distinct=true`` () =
+    let aggExpr = Expr.AggExpr(Count, AggArg.Expr(Expr.Column(None, "name")), true)
+    let stmt = selectFrom [ OutputColumn.Expr(aggExpr, Some "cnt") ] ["users", None]
+    let plan = ok (Planner.plan schema (Statement.Select stmt))
+    match plan with
+    | LogicalPlan.Project(LogicalPlan.Aggregate(_, _, aggs), _) ->
+        Assert.True(aggs |> List.exists (fun a -> a.Distinct))
+    | other -> failwith (sprintf "Expected Aggregate with distinct=true, got %A" other)
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Multi-table FROM (cross join)
+// ──────────────────────────────────────────────────────────────────────────────
+
+[<Fact>]
+let ``Two bare FROM tables produce cross-join`` () =
+    let stmt =
+        { Distinct = false
+          Columns  = [ col (Some "users") "id"; col (Some "orders") "amount" ]
+          From     = [ "users", None; "orders", None ]
+          Joins    = []
+          Where    = None
+          GroupBy  = []
+          Having   = None
+          OrderBy  = []
+          Limit    = None }
+    let plan = ok (Planner.plan schema (Statement.Select stmt))
+    match plan with
+    | LogicalPlan.Project(LogicalPlan.Join(LogicalPlan.Scan("users", _), LogicalPlan.Scan("orders", _), Cross, None), _) -> ()
+    | other -> failwith (sprintf "Expected cross-join from two FROM tables, got %A" other)
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Table aliases
+// ──────────────────────────────────────────────────────────────────────────────
+
+[<Fact>]
+let ``Table alias is threaded through scope and plan`` () =
+    let pred = Expr.BinaryOp(Eq, Expr.Column(Some "u", "id"), Expr.Literal(SqlValue.Integer 1L))
+    let stmt =
+        { Distinct = false
+          Columns  = [ OutputColumn.Expr(Expr.Column(Some "u", "name"), None) ]
+          From     = [ "users", Some "u" ]
+          Joins    = []
+          Where    = Some pred
+          GroupBy  = []
+          Having   = None
+          OrderBy  = []
+          Limit    = None }
+    let plan = ok (Planner.plan schema (Statement.Select stmt))
+    match plan with
+    | LogicalPlan.Project(LogicalPlan.Filter(LogicalPlan.Scan("users", Some "u"), _), _) -> ()
+    | other -> failwith (sprintf "Expected Project(Filter(Scan(alias=u))), got %A" other)
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Wildcard
+// ──────────────────────────────────────────────────────────────────────────────
+
+[<Fact>]
+let ``SELECT star is preserved in Project columns`` () =
+    let stmt = selectFrom [ OutputColumn.Star ] ["users", None]
+    let plan = ok (Planner.plan schema (Statement.Select stmt))
+    match plan with
+    | LogicalPlan.Project(LogicalPlan.Scan("users", None), [OutputColumn.Star]) -> ()
+    | other -> failwith (sprintf "Expected Project with Star, got %A" other)
+
+// ──────────────────────────────────────────────────────────────────────────────
+// DISTINCT + ORDER BY + LIMIT stacking
+// ──────────────────────────────────────────────────────────────────────────────
+
+[<Fact>]
+let ``DISTINCT + ORDER BY + LIMIT stacks Limit(Sort(Distinct(Project)))`` () =
+    let stmt =
+        { Distinct = true
+          Columns  = [ col None "name" ]
+          From     = [ "users", None ]
+          Joins    = []
+          Where    = None
+          GroupBy  = []
+          Having   = None
+          OrderBy  = [ { KeyExpr = Expr.Column(None, "name"); Direction = Asc; NullOrder = NullsFirst } ]
+          Limit    = Some { Count = Some 5L; Offset = None } }
+    let plan = ok (Planner.plan schema (Statement.Select stmt))
+    match plan with
+    | LogicalPlan.Limit(LogicalPlan.Sort(LogicalPlan.Distinct(LogicalPlan.Project _), _), Some 5L, None) -> ()
+    | other -> failwith (sprintf "Expected Limit(Sort(Distinct(Project))), got %A" other)
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Error propagation inside complex expressions
+// ──────────────────────────────────────────────────────────────────────────────
+
+[<Fact>]
+let ``Between: error in low propagates`` () =
+    let pred = Expr.Between(Expr.Column(None, "age"), Expr.Column(None, "no_col"), Expr.Literal(SqlValue.Integer 65L))
+    let e = err (Planner.plan schema (Statement.Select (selectFrom [col None "id"] ["users", None] |> fun s -> { s with Where = Some pred })))
+    match e with
+    | PlanError.UnknownColumn _ -> ()
+    | other -> failwith (sprintf "Expected UnknownColumn from Between.lo, got %A" other)
+
+[<Fact>]
+let ``Between: error in high propagates`` () =
+    let pred = Expr.Between(Expr.Column(None, "age"), Expr.Literal(SqlValue.Integer 0L), Expr.Column(None, "no_col"))
+    let e = err (Planner.plan schema (Statement.Select (selectFrom [col None "id"] ["users", None] |> fun s -> { s with Where = Some pred })))
+    match e with
+    | PlanError.UnknownColumn _ -> ()
+    | other -> failwith (sprintf "Expected UnknownColumn from Between.hi, got %A" other)
+
+[<Fact>]
+let ``In: error in item propagates`` () =
+    let pred = Expr.In(Expr.Column(None, "id"), [ Expr.Literal(SqlValue.Integer 1L); Expr.Column(None, "no_col") ])
+    let e = err (Planner.plan schema (Statement.Select (selectFrom [col None "id"] ["users", None] |> fun s -> { s with Where = Some pred })))
+    match e with
+    | PlanError.UnknownColumn _ -> ()
+    | other -> failwith (sprintf "Expected UnknownColumn from In.items, got %A" other)
+
+[<Fact>]
+let ``NotIn: error in item propagates`` () =
+    let pred = Expr.NotIn(Expr.Column(None, "id"), [ Expr.Column(None, "no_col") ])
+    let e = err (Planner.plan schema (Statement.Select (selectFrom [col None "id"] ["users", None] |> fun s -> { s with Where = Some pred })))
+    match e with
+    | PlanError.UnknownColumn _ -> ()
+    | other -> failwith (sprintf "Expected UnknownColumn from NotIn.items, got %A" other)
+
+[<Fact>]
+let ``FuncCall: error in arg propagates`` () =
+    let pred = Expr.FuncCall("upper", [ Expr.Column(None, "no_col") ])
+    let e = err (Planner.plan schema (Statement.Select (selectFrom [col None "id"] ["users", None] |> fun s -> { s with Where = Some pred })))
+    match e with
+    | PlanError.UnknownColumn _ -> ()
+    | other -> failwith (sprintf "Expected UnknownColumn from FuncCall.args, got %A" other)
+
+[<Fact>]
+let ``IsNull: error in inner expr propagates`` () =
+    let pred = Expr.IsNull(Expr.Column(None, "no_col"))
+    let e = err (Planner.plan schema (Statement.Select (selectFrom [col None "id"] ["users", None] |> fun s -> { s with Where = Some pred })))
+    match e with
+    | PlanError.UnknownColumn _ -> ()
+    | other -> failwith (sprintf "Expected UnknownColumn from IsNull, got %A" other)
+
+[<Fact>]
+let ``IsNotNull: error in inner expr propagates`` () =
+    let pred = Expr.IsNotNull(Expr.Column(None, "no_col"))
+    let e = err (Planner.plan schema (Statement.Select (selectFrom [col None "id"] ["users", None] |> fun s -> { s with Where = Some pred })))
+    match e with
+    | PlanError.UnknownColumn _ -> ()
+    | other -> failwith (sprintf "Expected UnknownColumn from IsNotNull, got %A" other)
+
+[<Fact>]
+let ``Like: error in value expr propagates`` () =
+    let pred = Expr.Like(Expr.Column(None, "no_col"), "A%")
+    let e = err (Planner.plan schema (Statement.Select (selectFrom [col None "id"] ["users", None] |> fun s -> { s with Where = Some pred })))
+    match e with
+    | PlanError.UnknownColumn _ -> ()
+    | other -> failwith (sprintf "Expected UnknownColumn from Like, got %A" other)
+
+[<Fact>]
+let ``NotLike: error in value expr propagates`` () =
+    let pred = Expr.NotLike(Expr.Column(None, "no_col"), "B%")
+    let e = err (Planner.plan schema (Statement.Select (selectFrom [col None "id"] ["users", None] |> fun s -> { s with Where = Some pred })))
+    match e with
+    | PlanError.UnknownColumn _ -> ()
+    | other -> failwith (sprintf "Expected UnknownColumn from NotLike, got %A" other)
+
+[<Fact>]
+let ``UnaryOp: error in inner expr propagates`` () =
+    let pred = Expr.UnaryOp(Not, Expr.Column(None, "no_col"))
+    let e = err (Planner.plan schema (Statement.Select (selectFrom [col None "id"] ["users", None] |> fun s -> { s with Where = Some pred })))
+    match e with
+    | PlanError.UnknownColumn _ -> ()
+    | other -> failwith (sprintf "Expected UnknownColumn from UnaryOp, got %A" other)
+
+[<Fact>]
+let ``PROJECT: unknown column in non-agg context yields UnknownColumn`` () =
+    let stmt = selectFrom [ col None "no_col" ] ["users", None]
+    let e = err (Planner.plan schema (Statement.Select stmt))
+    match e with
+    | PlanError.UnknownColumn _ -> ()
+    | other -> failwith (sprintf "Expected UnknownColumn from Project, got %A" other)
+
+[<Fact>]
+let ``GROUP BY: unknown column yields error`` () =
+    let stmt = selectFrom [ OutputColumn.Expr(Expr.AggExpr(Count, AggArg.Star, false), Some "cnt") ] ["users", None]
+    let e = err (Planner.plan schema (Statement.Select { stmt with GroupBy = [ Expr.Column(None, "no_col") ] }))
+    match e with
+    | PlanError.UnknownColumn _ -> ()
+    | other -> failwith (sprintf "Expected UnknownColumn from GROUP BY, got %A" other)
+
+[<Fact>]
+let ``Multi-FROM: second table unknown yields UnknownTable`` () =
+    let stmt =
+        { selectFrom [ col (Some "users") "id" ] ["users", None] with
+            From = [ "users", None; "ghost", None ]
+            Columns = [ col (Some "users") "id" ] }
+    let e = err (Planner.plan schema (Statement.Select stmt))
+    match e with
+    | PlanError.UnknownTable "ghost" -> ()
+    | other -> failwith (sprintf "Expected UnknownTable for second FROM, got %A" other)
+
+[<Fact>]
+let ``In: error in value expr propagates`` () =
+    let pred = Expr.In(Expr.Column(None, "no_col"), [ Expr.Literal(SqlValue.Integer 1L) ])
+    let e = err (Planner.plan schema (Statement.Select (selectFrom [col None "id"] ["users", None] |> fun s -> { s with Where = Some pred })))
+    match e with
+    | PlanError.UnknownColumn _ -> ()
+    | other -> failwith (sprintf "Expected UnknownColumn from In.value, got %A" other)
+
+[<Fact>]
+let ``NotIn: error in value expr propagates`` () =
+    let pred = Expr.NotIn(Expr.Column(None, "no_col"), [ Expr.Literal(SqlValue.Integer 1L) ])
+    let e = err (Planner.plan schema (Statement.Select (selectFrom [col None "id"] ["users", None] |> fun s -> { s with Where = Some pred })))
+    match e with
+    | PlanError.UnknownColumn _ -> ()
+    | other -> failwith (sprintf "Expected UnknownColumn from NotIn.value, got %A" other)
+
+// ──────────────────────────────────────────────────────────────────────────────
+// SqlValue literals coverage
+// ──────────────────────────────────────────────────────────────────────────────
+
+[<Fact>]
+let ``Literal variants are preserved unchanged through resolveExpr`` () =
+    let literals =
+        [ SqlValue.Null
+          SqlValue.Integer 42L
+          SqlValue.Real 3.14
+          SqlValue.Text "hello"
+          SqlValue.Bool true ]
+        |> List.map (fun v -> OutputColumn.Expr(Expr.Literal v, None))
+    let stmt = selectFrom literals ["users", None]
+    let plan = ok (Planner.plan schema (Statement.Select stmt))
+    match plan with
+    | LogicalPlan.Project(_, cols) -> Assert.Equal(5, cols.Length)
+    | other -> failwith (sprintf "Expected Project with 5 literal cols, got %A" other)


### PR DESCRIPTION
## Summary

- Ports the Python `sql_planner` to F# as `CodingAdventures.SqlPlanner.FSharp` v0.1.0
- Implements the 8-step bottom-up SELECT pipeline: Scan → Filter → Aggregate → Having → Project → Distinct → Sort → Limit
- Defines self-contained `Statement` AST types (F# sql-parser is a stub, consistent with Python)
- Column resolution with scope tracking, table alias support, and ambiguity detection for unqualified columns
- `Planner.plan` returns `Result<LogicalPlan, PlanError>` — no exceptions to callers
- 52 xUnit tests; 83% line coverage, 100% method coverage

## Key design decisions

- **Railway match-chain style** in `planSelect` to avoid F# indentation issues with nested `|> Result.bind` lambdas containing `let` bindings
- **`BinaryOperator` / `UnaryOperator` / `AggFunction`** named with type suffixes to avoid DU case name conflicts (`Expr.BinaryOp` case vs `BinaryOp` type)
- **`AggArg` and `Expr` are mutually recursive** (`and` keyword) to allow `AggArg.Expr` to wrap an `Expr`
- **ORDER BY alias fallthrough**: tries scope resolution first; passes expression through unchanged on `UnknownColumn` so the VM can resolve SELECT-list aliases post-projection

## Test plan

- [ ] Build passes: `dotnet test tests/CodingAdventures.SqlPlanner.Tests/`
- [ ] All 13 spec conformance points covered (C1–C13 in test file)
- [ ] 52/52 tests pass, 83% line coverage ≥ 80% threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)