### PR TITLE
feat(js-sir): M3 control flow — if/while/for (C3)

### DIFF
--- a/code/packages/rust/javascript-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/javascript-to-semantic-ir/CHANGELOG.md
@@ -5,6 +5,98 @@ All notable changes to `javascript-to-semantic-ir` are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## 0.3.0
+
+SIR19 milestone **M3 (control flow)** — builds on M2's variables and
+operators.  Adds `if`/`else`, `while`, the canonical counting C-style
+`for`, `for … of`, and bare `{ … }` blocks.
+
+### Added
+
+- **`if`/`else` → `Expr::If`.**  A JS `if` *statement* lowers to a
+  `Stmt::ExprStmt` wrapping an `Expr::If` (the IR's conditional is an
+  expression; there is no statement-level `if`).  The `then`/`else`
+  branches are `Block`s — either a `{ … }` block or a single unbraced
+  statement (`if (c) x = 1;`).  A missing `else` becomes a synthetic
+  empty nil-valued `Block`.  **Else-if chains** (`else if (…)`) fall out
+  of the grammar for free: the parser nests another `if_statement` inside
+  the `else` statement, so it recurses into a *nested* `Expr::If` living
+  in the outer `else_branch`'s tail value.  `Expr::If` is *not* gated by
+  any `Feature` in SIR v0 (the validator observes none), so no manifest
+  entry is added for conditionals.
+- **`while (c) { body }` → `Stmt::While`.**  Lowers the condition
+  expression and the body block.
+- **C-style `for` → `Stmt::ForRange`** — accepted **only** for the
+  canonical half-open counting shape, from which `var`/`start`/`stop`/
+  `step` are extracted:
+
+  - **init** must be `let i = <start>` (a single `let`/`const`/`var`
+    binding of one variable);
+  - **cond** must be `i < <stop>` or `i <= <stop>` on the *same* `i`
+    (`<=` is rewritten half-open by bumping `stop` to
+    `BuiltinCall("+", [stop, IntLit(1)])`);
+  - **update** must increment `i` by a constant `step` in one of
+    `i = i + <step>`, `i += <step>`, or `i++` (step `IntLit(1)`).
+
+  Any **non-canonical** loop — a different variable across clauses, a
+  decrement (`i--`), a multiplicative step (`i = i * 2`), a missing
+  clause, or a multi-variable init — is rejected with a positioned
+  `JsLowerError` (deferred) rather than silently mangled.
+- **`for (const x of xs) { body }` → `Stmt::ForEach { var: x, iter: xs }`.**
+  Only the single-identifier binding is supported; destructuring
+  (`for (const [a, b] of …)`) is deferred.
+- **Bare `{ … }` blocks** lower to `Expr::Block`; their statements run
+  for effect.
+- **Block-scoped names.**  Names bound inside any control-flow body or a
+  bare block are block-scoped: `declared_locals` is snapshotted before a
+  body and restored after, so an inner `let` does not leak outward.  This
+  mirrors the SIR validator, which marks/rewinds its `LocalEnv` around
+  each `Block`.  The **loop variable** is bound into the loop body scope
+  *only* (visible in the body, unresolved after the loop) — again
+  matching the validator.
+- **Manifest.**  `while`/`for`/`for-of` declare `Feature::Loops` (the
+  feature the validator observes for every loop statement); `if` declares
+  nothing.
+- **Bounded statement-block nesting.**  Control-flow bodies recurse with
+  `depth + 1`, capped at `MAX_STMT_DEPTH = 256` (the statement-side twin
+  of `MAX_EXPR_DEPTH`), so adversarial deep nesting yields an ordinary
+  positioned error rather than a stack-overflow abort.
+- 21 new unit tests (55 total): if/else with both branches, missing-else
+  synthetic block, else-if nesting, single-statement if body, comparison
+  conditions, `while`, all three C-`for` update forms (`i = i + s`,
+  `i++`, `i += s`), `<=` half-open stop bump, literal stop, three
+  non-canonical-`for` rejections (decrement, wrong cond variable,
+  multiplicative step), `for-of`, loop-var and for-of-var
+  non-leakage, block-scoped `let` non-leakage, bare block lowering,
+  nested control flow, and an all-forms validate round-trip.
+
+### Changed
+
+- Minor version bump `0.2.0 → 0.3.0` (additive, backward-compatible).
+- `lower_program` now delegates to a shared `lower_stmt_seq` routine that
+  also lowers `{ … }` block / control-flow bodies, threading a
+  statement-nesting `depth`.
+
+### Deferred
+
+Still **out of scope after M3** and returning a clear positioned
+`JsLowerError`:
+
+- **M4 — functions & closures:** `function` declarations, arrow
+  functions (`MakeClosure`), `return`, calls (`DirectCall` /
+  `IndirectCall`), `console.log` → `BuiltinCall("print", …)`.
+- **M5 — collections:** array literals (`SeqLit`), indexing
+  (`SeqIndex`), `.length` (`SeqLen`), object literals (`MapLit`),
+  member/`[]` access (`MapGet`).
+- **Other control-flow constructs:** `switch`, `try`/`catch`, `do … while`,
+  labeled statements, and `break`/`continue` (the IR has no early-exit
+  node) — all positioned `JsLowerError`.
+- **Within-M2 operator/assignment gaps** (compound assignment outside the
+  loop-update position, member/index assignment targets, multi-binding
+  declarations, uninitialised bindings, bitwise/shift/exponentiation/
+  nullish operators, other prefix unaries) and template literals,
+  non-decimal numeric forms — unchanged from M2.
+
 ## 0.2.0
 
 SIR19 milestone **M2 (variables, assignment, operators)** — builds on

--- a/code/packages/rust/javascript-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/javascript-to-semantic-ir/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "javascript-to-semantic-ir"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
-description = "JavaScript (GrammarASTNode CST) → narrow-waist Semantic IR. SIR19 frontend, milestone M2 (variables, assignment, operators)."
+description = "JavaScript (GrammarASTNode CST) → narrow-waist Semantic IR. SIR19 frontend, milestone M3 (control flow: if/while/for/for-of)."
 
 [dependencies]
 coding-adventures-javascript-parser = { path = "../javascript-parser" }

--- a/code/packages/rust/javascript-to-semantic-ir/README.md
+++ b/code/packages/rust/javascript-to-semantic-ir/README.md
@@ -27,11 +27,12 @@ We lower from the *generic* `GrammarASTNode`, **not** from the parser's
 typed-AST bridge (`javascript-parser/src/bridge.rs`). That is the
 contract SIR19 sets, matching how the Ruby and Twig frontends work.
 
-## Milestone status — M2 (variables, assignment, operators)
+## Milestone status — M3 (control flow)
 
-This is the second slice of SIR19. It implements literals (M1) **plus**
-variable references, bindings/assignment, and unary/binary operators.
-The supported subset:
+This is the third slice of SIR19. It implements literals (M1) and
+variables/operators (M2) **plus** control flow: `if`/`else`, `while`,
+the canonical counting C-style `for`, `for … of`, and bare `{ … }`
+blocks. The supported subset (M1 + M2 + M3):
 
 | JavaScript source           | SIR lowering                                  |
 |-----------------------------|-----------------------------------------------|
@@ -53,6 +54,38 @@ The supported subset:
 | `a \|\| b`                  | `LogicalOr` (short-circuit)                   |
 | `!a`                        | `BuiltinCall("not", [a])`                     |
 | `-a` (non-literal `a`)      | `BuiltinCall("neg", [a])`                     |
+| `if (c) { … } else { … }`   | `Expr::If { cond, then_branch, else_branch }` |
+| `if (c) {} else if (d) {}`  | nested `Expr::If` in the else branch          |
+| `while (c) { … }`           | `Stmt::While { cond, body }`                  |
+| `for (let i=0; i<n; i++) {…}` | `Stmt::ForRange { var, start, stop, step, body }` |
+| `for (const x of xs) { … }` | `Stmt::ForEach { var, iter, body }`           |
+| `{ … }` (bare block)        | `Expr::Block`                                 |
+
+### Control flow
+
+- **`if`/`else`** lowers to an `Expr::If` (the IR's conditional is an
+  expression, so a JS `if` *statement* is wrapped in an `ExprStmt`).
+  Branch bodies are `Block`s — a `{ … }` block or a single unbraced
+  statement. A missing `else` becomes a synthetic empty nil-valued block.
+  **Else-if chains** nest naturally: the parser puts another `if` inside
+  the `else`, producing a nested `Expr::If` in the outer else branch's
+  tail value.
+- **`while`** maps directly to `Stmt::While`.
+- **C-style `for`** maps to the half-open counting `Stmt::ForRange`
+  **only** when it matches the canonical shape: init `let i = <start>`,
+  condition `i < <stop>` or `i <= <stop>` (the latter rewritten half-open
+  to `<stop> + 1`), and update `i = i + <step>`, `i += <step>`, or `i++`.
+  Anything else (a different variable across clauses, a decrement, a
+  multiplicative step, a multi-variable init) is rejected with a
+  positioned "non-canonical `for`" error — never silently mangled.
+- **`for … of`** maps to `Stmt::ForEach` (single-identifier binding only;
+  destructuring is deferred).
+- **Scoping** matches the SIR validator: the loop variable is visible in
+  the loop body but unresolved after the loop, and a `let` bound inside
+  any control-flow body or bare block does not leak to the enclosing
+  scope. Statement-block nesting is bounded by `MAX_STMT_DEPTH = 256` so
+  deeply nested control flow yields an ordinary error, not a stack
+  overflow.
 
 ### Variables and scope
 
@@ -133,17 +166,20 @@ Every produced `Module`:
   `semantic_ir::validate` with no used-but-undeclared errors and no
   declared-but-unused warnings.
 
-## Out of scope for M2 (deferred)
+## Out of scope for M3 (deferred)
 
-Control flow, functions, collections, member access, and template
+Functions/closures (M4), collections and member access (M5), and template
 literals all currently return a `JsLowerError` describing what was
-rejected, with the offending node's position — as do the gaps within
-M2's own families (compound assignment, assignment to a member/index,
-multi-binding declarations, uninitialised bindings, bitwise/shift/
-exponentiation/nullish operators). The error sites are structured so
-later milestones slot their handling in at exactly the right place. See
-`CHANGELOG.md` for the milestone roadmap and the full
-SIR19 spec at [`code/specs/SIR19-javascript-to-semantic-ir.md`](../../../specs/SIR19-javascript-to-semantic-ir.md).
+rejected, with the offending node's position. So do the remaining
+control-flow constructs — `switch`, `try`/`catch`, `do … while`, labeled
+statements, and `break`/`continue` (the IR has no early-exit node) — and
+the gaps within M2's own families (compound assignment outside the
+loop-update position, assignment to a member/index, multi-binding
+declarations, uninitialised bindings, bitwise/shift/exponentiation/
+nullish operators). The error sites are structured so later milestones
+slot their handling in at exactly the right place. See `CHANGELOG.md` for
+the milestone roadmap and the full SIR19 spec at
+[`code/specs/SIR19-javascript-to-semantic-ir.md`](../../../specs/SIR19-javascript-to-semantic-ir.md).
 
 ## Testing
 

--- a/code/packages/rust/javascript-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/javascript-to-semantic-ir/src/lib.rs
@@ -27,9 +27,19 @@
 //! not from the parser's typed-AST bridge — that's the contract SIR19
 //! sets, mirroring the Ruby and Twig frontends.
 //!
-//! ## Milestone status — M2 (variables, assignment, operators)
+//! ## Milestone status — M3 (control flow)
 //!
-//! This build implements literals (M1) **plus**:
+//! This build implements literals (M1) and variables/operators (M2)
+//! **plus** control flow (M3): `if`/`else` → [`Expr::If`] (nested in the
+//! else branch for else-if chains), `while` → [`Stmt::While`], the
+//! canonical counting C-style `for` → [`Stmt::ForRange`], `for … of` →
+//! [`Stmt::ForEach`], and bare `{ … }` blocks → [`Expr::Block`].  Loop
+//! variables are scoped into the body only; statement-block nesting is
+//! depth-bounded.  Non-canonical `for` loops, and all other control-flow
+//! constructs (`switch`/`try`/`do-while`/labeled/`break`/`continue`), are
+//! positioned errors (deferred).
+//!
+//! The M1 + M2 lowerings, unchanged, are:
 //!
 //! - JS number → [`IntLit`](semantic_ir::Expr::IntLit) when the literal
 //!   text is an integer (no `.`/exponent), else
@@ -51,10 +61,12 @@
 //!   → `BuiltinCall("!=")` (strict normalisation — a documented semantic
 //!   change for the loose-equality coercion cases).
 //!
-//! All other syntax (control flow, functions, collections, member
-//! access, template literals) is **deferred** to later milestones and
-//! currently produces a clear [`JsLowerError`].  See the crate
-//! `CHANGELOG.md` "Deferred" section for the roadmap.
+//! All other syntax (functions, collections, member access, template
+//! literals, plus non-canonical `for` and the remaining control-flow
+//! constructs `switch`/`try`/`do-while`/labeled/`break`/`continue`) is
+//! **deferred** to later milestones and currently produces a clear
+//! [`JsLowerError`].  See the crate `CHANGELOG.md` "Deferred" section for
+//! the roadmap.
 //!
 //! ## Public API
 //!
@@ -542,5 +554,378 @@ mod tests {
         let got = extract_line_col("Parse error at 3:7: something");
         assert_eq!(got, Some((3, 7)));
         assert_eq!(extract_line_col("no position here"), None);
+    }
+
+    // ── M3: control flow — if / while / for / for-of ───────────────
+
+    use semantic_ir::Block;
+
+    /// Find the single `Expr::If` that a top-level `if` statement lowers to.
+    /// An `if` statement becomes a `Stmt::ExprStmt { expr: Expr::If, .. }`
+    /// in `main`'s body (it produces no observable tail value at the top
+    /// level), so we dig it out of the first statement.
+    fn first_if(m: &semantic_ir::Module) -> &Expr {
+        let b = main_block(m);
+        match b.stmts.first() {
+            Some(Stmt::ExprStmt { expr: e @ Expr::If { .. }, .. }) => e,
+            // Or, when `if` is the *only* item, it may be the tail value.
+            _ => match &b.value {
+                e @ Expr::If { .. } => e,
+                other => panic!("expected Expr::If, got stmts={:?} value={other:?}", b.stmts),
+            },
+        }
+    }
+
+    /// Pull a block's only `ExprStmt`-wrapped assignment target name, used
+    /// to sanity-check which branch body we are looking at.
+    fn block_only_assign_name(b: &Block) -> Option<&str> {
+        b.stmts.iter().find_map(|s| match s {
+            Stmt::Assign { name, .. } | Stmt::LetStarBinding { name, .. } => Some(name.as_str()),
+            _ => None,
+        })
+    }
+
+    #[test]
+    fn if_else_lowers_to_expr_if_with_both_branches() {
+        let m = lower("let c = true; let x = 0; if (c) { x = 1; } else { x = 2; }");
+        assert_valid(&m);
+        match first_if(&m) {
+            Expr::If { cond, then_branch, else_branch, .. } => {
+                assert!(matches!(**cond, Expr::VarRef { .. }));
+                // then-branch assigns x = 1
+                assert!(matches!(
+                    then_branch.stmts.first(),
+                    Some(Stmt::Assign { .. })
+                ));
+                assert!(matches!(
+                    else_branch.stmts.first(),
+                    Some(Stmt::Assign { .. })
+                ));
+            }
+            other => panic!("expected If, got {other:?}"),
+        }
+        // NB: `Expr::If` is not gated by any `Feature` in SIR v0 — the
+        // validator observes no feature for a conditional — so we
+        // deliberately do *not* assert a manifest entry here.
+    }
+
+    #[test]
+    fn if_without_else_gets_empty_nil_else_branch() {
+        let m = lower("let c = true; let x = 0; if (c) { x = 1; }");
+        assert_valid(&m);
+        match first_if(&m) {
+            Expr::If { then_branch, else_branch, .. } => {
+                assert!(matches!(then_branch.stmts.first(), Some(Stmt::Assign { .. })));
+                // Synthetic empty else: no stmts, nil value.
+                assert!(else_branch.stmts.is_empty());
+                assert!(matches!(else_branch.value, Expr::NilLit { .. }));
+            }
+            other => panic!("expected If, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn else_if_chain_nests_if_in_else_branch() {
+        // `if (a) {} else if (b) {} else {}` → outer If whose else_branch's
+        // tail value is a nested If.
+        let m = lower(
+            "let a = true; let b = false; let x = 0; \
+             if (a) { x = 1; } else if (b) { x = 2; } else { x = 3; }",
+        );
+        assert_valid(&m);
+        match first_if(&m) {
+            Expr::If { else_branch, .. } => {
+                // The else branch holds the nested `if` as its tail value.
+                match &else_branch.value {
+                    Expr::If { then_branch, else_branch: inner_else, .. } => {
+                        assert_eq!(block_only_assign_name(then_branch), Some("x"));
+                        // Final `else { x = 3; }`.
+                        assert!(matches!(
+                            inner_else.stmts.first(),
+                            Some(Stmt::Assign { .. })
+                        ));
+                    }
+                    other => panic!("expected nested If in else, got {other:?}"),
+                }
+            }
+            other => panic!("expected If, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn single_statement_if_body_needs_no_braces() {
+        // `if (c) x = 1;` — an unbraced single-statement body.
+        let m = lower("let c = true; let x = 0; if (c) x = 1;");
+        assert_valid(&m);
+        match first_if(&m) {
+            Expr::If { then_branch, .. } => {
+                assert!(matches!(then_branch.stmts.first(), Some(Stmt::Assign { .. })));
+            }
+            other => panic!("expected If, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn while_loop_lowers_to_stmt_while() {
+        let m = lower("let c = true; let x = 0; while (c) { x = 1; }");
+        assert_valid(&m);
+        let b = main_block(&m);
+        let w = b.stmts.iter().find(|s| matches!(s, Stmt::While { .. }))
+            .expect("a While statement");
+        match w {
+            Stmt::While { cond, body, .. } => {
+                assert!(matches!(cond, Expr::VarRef { .. }));
+                assert!(matches!(body.stmts.first(), Some(Stmt::Assign { .. })));
+            }
+            _ => unreachable!(),
+        }
+        assert!(m.manifest.contains(Feature::Loops));
+    }
+
+    /// Locate the single `ForRange` in `main`.
+    fn first_for_range(m: &semantic_ir::Module) -> &Stmt {
+        main_block(m)
+            .stmts
+            .iter()
+            .find(|s| matches!(s, Stmt::ForRange { .. }))
+            .expect("a ForRange statement")
+    }
+
+    #[test]
+    fn c_for_with_explicit_assign_update_lowers_to_for_range() {
+        // `for (let i = 0; i < n; i = i + 1)` → ForRange(i, 0, n, 1).
+        let m = lower("let n = 10; let s = 0; for (let i = 0; i < n; i = i + 1) { s = s + i; }");
+        assert_valid(&m);
+        match first_for_range(&m) {
+            Stmt::ForRange { var, start, stop, step, body, .. } => {
+                assert_eq!(var, "i");
+                assert!(matches!(start, Expr::IntLit { value: 0, .. }));
+                assert!(matches!(stop, Expr::VarRef { name, .. } if name == "n"));
+                assert!(matches!(step, Expr::IntLit { value: 1, .. }));
+                // Body references both `s` (outer) and `i` (loop var).
+                assert!(matches!(body.stmts.first(), Some(Stmt::Assign { .. })));
+            }
+            _ => unreachable!(),
+        }
+        assert!(m.manifest.contains(Feature::Loops));
+    }
+
+    #[test]
+    fn c_for_with_postfix_increment_update() {
+        // `i++` update → step IntLit(1).
+        let m = lower("let n = 5; let s = 0; for (let i = 0; i < n; i++) { s = s + i; }");
+        assert_valid(&m);
+        match first_for_range(&m) {
+            Stmt::ForRange { var, step, .. } => {
+                assert_eq!(var, "i");
+                assert!(matches!(step, Expr::IntLit { value: 1, .. }));
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    #[test]
+    fn c_for_with_compound_plus_assign_step() {
+        // `i += 2` update → step IntLit(2).
+        let m = lower("let n = 9; let s = 0; for (let i = 0; i < n; i += 2) { s = s + i; }");
+        assert_valid(&m);
+        match first_for_range(&m) {
+            Stmt::ForRange { step, .. } => {
+                assert!(matches!(step, Expr::IntLit { value: 2, .. }));
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    #[test]
+    fn c_for_with_le_condition_bumps_stop_half_open() {
+        // `i <= n` ⇒ half-open `n + 1`.
+        let m = lower("let n = 4; let s = 0; for (let i = 0; i <= n; i++) { s = s + i; }");
+        assert_valid(&m);
+        match first_for_range(&m) {
+            Stmt::ForRange { stop, .. } => match stop {
+                Expr::BuiltinCall { name, args, .. } => {
+                    assert_eq!(name, "+");
+                    assert!(matches!(&args[0], Expr::VarRef { name, .. } if name == "n"));
+                    assert!(matches!(&args[1], Expr::IntLit { value: 1, .. }));
+                }
+                other => panic!("expected n+1 stop, got {other:?}"),
+            },
+            _ => unreachable!(),
+        }
+    }
+
+    #[test]
+    fn c_for_with_literal_stop() {
+        // `for (let i = 0; i < 10; i++)` — stop is a literal.
+        let m = lower("let s = 0; for (let i = 0; i < 10; i++) { s = s + i; }");
+        assert_valid(&m);
+        match first_for_range(&m) {
+            Stmt::ForRange { start, stop, step, .. } => {
+                assert!(matches!(start, Expr::IntLit { value: 0, .. }));
+                assert!(matches!(stop, Expr::IntLit { value: 10, .. }));
+                assert!(matches!(step, Expr::IntLit { value: 1, .. }));
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    #[test]
+    fn non_canonical_for_decrement_is_rejected() {
+        // `i--` is a decrement; we can't represent it as a half-open
+        // counting ForRange, so it's a positioned deferral error.
+        let err = compile_source(
+            "let n = 5; for (let i = n; i > 0; i--) { n = n; }",
+            "test",
+        )
+        .expect_err("decrementing for must be rejected");
+        assert!(
+            err.message.contains("non-canonical"),
+            "unexpected message: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn non_canonical_for_wrong_cond_variable_is_rejected() {
+        // Condition references a different variable than the loop var.
+        let err = compile_source(
+            "let n = 5; let j = 0; for (let i = 0; j < n; i++) { n = n; }",
+            "test",
+        )
+        .expect_err("mismatched condition variable must be rejected");
+        assert!(err.message.contains("non-canonical"), "got: {}", err.message);
+    }
+
+    #[test]
+    fn non_canonical_for_multiplicative_step_is_rejected() {
+        // `i = i * 2` is not an additive increment.
+        let err = compile_source(
+            "let n = 64; for (let i = 1; i < n; i = i * 2) { n = n; }",
+            "test",
+        )
+        .expect_err("multiplicative step must be rejected");
+        assert!(err.message.contains("non-canonical"), "got: {}", err.message);
+    }
+
+    #[test]
+    fn for_of_lowers_to_for_each() {
+        // `for (const x of xs) { p = x; }` → ForEach { var: x, iter: xs }.
+        // NB: collection literals are deferred past M3, so the iterable
+        // `xs` is bound to a placeholder scalar.  The lowering is
+        // structural — it does not typecheck the iterable — so `for-of`
+        // over a `VarRef` lowers regardless of the bound value's shape.
+        let m = lower("let xs = 0; let p = 0; for (const x of xs) { p = x; }");
+        assert_valid(&m);
+        let fe = main_block(&m).stmts.iter()
+            .find(|s| matches!(s, Stmt::ForEach { .. }))
+            .expect("a ForEach statement");
+        match fe {
+            Stmt::ForEach { var, iter, body, .. } => {
+                assert_eq!(var, "x");
+                assert!(matches!(iter, Expr::VarRef { name, .. } if name == "xs"));
+                // Body assigns p = x (x resolves to the loop var).
+                assert!(matches!(body.stmts.first(), Some(Stmt::Assign { .. })));
+            }
+            _ => unreachable!(),
+        }
+        assert!(m.manifest.contains(Feature::Loops));
+    }
+
+    #[test]
+    fn loop_variable_is_not_visible_after_the_loop() {
+        // `i` is in scope inside the for body but unresolved afterwards.
+        let err = compile_source(
+            "let n = 3; let s = 0; for (let i = 0; i < n; i++) { s = s + i; } i;",
+            "test",
+        )
+        .expect_err("loop var must not leak past the loop");
+        assert!(
+            err.message.contains("unresolved name"),
+            "unexpected message: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn for_of_variable_is_not_visible_after_the_loop() {
+        let err = compile_source(
+            "let xs = 0; let p = 0; for (const x of xs) { p = x; } x;",
+            "test",
+        )
+        .expect_err("for-of var must not leak");
+        assert!(err.message.contains("unresolved name"), "got: {}", err.message);
+    }
+
+    #[test]
+    fn block_scoped_let_does_not_leak_to_outer_scope() {
+        // A `let` inside an if-body is block-scoped: referencing it after
+        // the `if` is an unresolved-name error.
+        let err = compile_source(
+            "let c = true; if (c) { let inner = 1; inner; } inner;",
+            "test",
+        )
+        .expect_err("block-scoped let must not leak");
+        assert!(err.message.contains("unresolved name"), "got: {}", err.message);
+    }
+
+    #[test]
+    fn bare_block_statement_lowers_and_scopes() {
+        // A bare `{ … }` block runs its statements; an inner binding is
+        // scoped to the block.
+        let m = lower("let x = 0; { x = 1; }");
+        assert_valid(&m);
+        // The block's inner `x = 1` is an Assign to the outer x.
+        let has_block = main_block(&m).stmts.iter().any(|s| {
+            matches!(s, Stmt::ExprStmt { expr: Expr::Block(_), .. })
+        }) || matches!(&main_block(&m).value, Expr::Block(_));
+        assert!(has_block, "expected an Expr::Block somewhere in main");
+    }
+
+    #[test]
+    fn nested_control_flow_validates() {
+        // while containing an if containing a for — exercise nesting and
+        // the shared body/scoping machinery end to end.
+        let m = lower(
+            "let n = 5; let s = 0; let go = true; \
+             while (go) { \
+               if (s < n) { for (let i = 0; i < n; i++) { s = s + i; } } else { go = false; } \
+             }",
+        );
+        assert_valid(&m);
+        assert!(m.manifest.contains(Feature::Loops));
+        // The outer statement is a While.
+        assert!(main_block(&m).stmts.iter().any(|s| matches!(s, Stmt::While { .. })));
+    }
+
+    #[test]
+    fn if_condition_can_be_a_comparison() {
+        // The condition is a relational BuiltinCall, not just a var-ref.
+        let m = lower("let a = 1; let b = 2; let x = 0; if (a < b) { x = 1; }");
+        assert_valid(&m);
+        match first_if(&m) {
+            Expr::If { cond, .. } => {
+                assert!(matches!(**cond, Expr::BuiltinCall { .. }));
+            }
+            other => panic!("expected If, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn control_flow_round_trips_through_validation() {
+        // A small program mixing all four control-flow forms validates and
+        // declares exactly the observed features (no spurious warnings).
+        // Collection literals are deferred, so `xs` is a placeholder scalar.
+        let m = lower(
+            "let xs = 0; let total = 0; \
+             for (const x of xs) { total = total + x; } \
+             let i = 0; while (i < 3) { i = i + 1; } \
+             for (let k = 0; k < 3; k++) { total = total + k; } \
+             if (total > 0) { total = total; } else { total = 0; }",
+        );
+        assert_valid(&m);
+        let r = semantic_ir::validate(&m);
+        assert!(r.warnings().next().is_none(), "unexpected warnings");
+        assert!(m.manifest.contains(Feature::Loops));
     }
 }

--- a/code/packages/rust/javascript-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/javascript-to-semantic-ir/src/lower.rs
@@ -1,6 +1,6 @@
 //! JavaScript `GrammarASTNode` (CST) → `semantic_ir::Module` lowering.
 //!
-//! # What this file does (milestones M1 + M2)
+//! # What this file does (milestones M1 + M2 + M3)
 //!
 //! The [`javascript-parser`](coding_adventures_javascript_parser) crate
 //! hands us a *concrete syntax tree* (CST): a [`GrammarASTNode`] whose
@@ -111,6 +111,76 @@
 //! writes "LetBinding" generically for both kinds; this divergence is
 //! noted there.)  `const` vs `let` vs `var` are not distinguished in v0
 //! (the IR models no immutability constraint).
+//!
+//! ## Control flow (M3 — learned by probing the parser)
+//!
+//! M3 adds the four counting/branching control-flow shapes.  The CST
+//! rule names and child layouts (precedence-wrapper layers elided):
+//!
+//! | JS source                                   | CST rule           | children                                                                     |
+//! |---------------------------------------------|--------------------|------------------------------------------------------------------------------|
+//! | `if (c) S`                                  | `if_statement`     | `[Kw("if"), (, expression, ), statement]`                                    |
+//! | `if (c) S else T`                           | `if_statement`     | `[…, statement, Kw("else"), statement]`                                      |
+//! | `while (c) S`                               | `while_statement`  | `[Kw("while"), (, expression, ), statement]`                                 |
+//! | `for (let i=0; c; u) S`                     | `for_statement`    | `[Kw("for"), (, Kw("let"), binding_list, ;, expr(cond), ;, expr(update), ), statement]` |
+//! | `for (const x of xs) S`                     | `for_of_statement` | `[Kw("for"), (, Kw("const"), binding_element, Name("of"), assignment_expression, ), statement]` |
+//! | `{ S1; S2; }`                               | `block`            | `[{, statement*, }]`                                                          |
+//!
+//! ### `if` → [`Expr::If`]
+//!
+//! The IR's conditional is an *expression* ([`Expr::If`]) with `then_branch`
+//! and `else_branch` [`Block`]s — there is no statement-level `if`.  So a JS
+//! `if` *statement* lowers to a `Stmt::ExprStmt` wrapping an `Expr::If`.  A
+//! missing `else` becomes a synthetic nil-valued empty `Block`.  An
+//! **else-if chain** (`else if (…)`) is just the grammar nesting another
+//! `if_statement` inside the `else` `statement`, so it recurses naturally
+//! into a *nested* `Expr::If` living in the outer `else_branch`'s tail value.
+//!
+//! ### `while` → [`Stmt::While`]
+//!
+//! Direct: lower the condition expression and the body block.
+//!
+//! ### C-style `for` → [`Stmt::ForRange`] (canonical counting loops only)
+//!
+//! The IR has no general three-clause `for`; it has a half-open counting
+//! [`Stmt::ForRange`] (`for var in range(start, stop, step)`).  We accept a
+//! C-style `for` **only** when it matches the canonical counting shape and
+//! extract `var`/`start`/`stop`/`step`:
+//!
+//! - **init** must be `let i = <start>` (a single `lexical_binding`/`var`
+//!   declaration binding `i` to the start expression).
+//! - **cond** must be `i < <stop>` or `i <= <stop>` on the *same* `i`.
+//!   `<=` is rewritten to a half-open `<` by bumping the stop to
+//!   `<stop> + 1` (`BuiltinCall("+", [stop, IntLit(1)])`).
+//! - **update** must increment `i` by a constant `step` in one of:
+//!   `i = i + <step>`, `i += <step>`, or `i++` (step = 1).
+//!
+//! Anything else — a different loop variable across clauses, a decrementing
+//! or multiplicative update, a missing clause, a multi-binding init — is a
+//! *non-canonical* loop we cannot faithfully represent as a `ForRange`, so
+//! it is a positioned [`JsLowerError`] (deferred), never silently mangled.
+//!
+//! ### `for … of` → [`Stmt::ForEach`]
+//!
+//! `for (const x of xs)` binds `x` over the iterable `xs`.  Only the
+//! single-identifier binding form is supported (destructuring is deferred).
+//!
+//! ### Block scoping
+//!
+//! A `{ … }` block and every control-flow body lower to a [`Block`].  Names
+//! bound *inside* a body are block-scoped: we snapshot `declared_locals`
+//! before lowering a body and restore it afterwards, so an inner `let` does
+//! not leak to the enclosing scope.  This mirrors the SIR validator, which
+//! marks/rewinds its `LocalEnv` around each `Block` and around a loop's
+//! body (with the loop variable added only for that body).  The loop
+//! variable is likewise bound into the body scope only.
+//!
+//! ### Recursion bound
+//!
+//! Statement-block nesting is bounded by [`MAX_STMT_DEPTH`] exactly as
+//! operator recursion is bounded by [`MAX_EXPR_DEPTH`]: each nested body is
+//! lowered with `depth + 1`, and an over-deep nest becomes an ordinary
+//! positioned error rather than a stack overflow.
 
 use lexer::token::{Token, TokenType};
 use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode};
@@ -161,6 +231,19 @@ impl std::error::Error for JsLowerError {}
 /// this budget — only genuine operand recursion does).
 const MAX_EXPR_DEPTH: usize = 256;
 
+/// Hard ceiling on *statement-block* nesting depth (M3).
+///
+/// Each control-flow body (`if`/`while`/`for` body, or a bare `{ … }`
+/// block) is lowered by a recursive call that descends with `depth + 1`.
+/// Deeply nested control flow — thousands of `if (c) { if (c) { … } }` —
+/// could otherwise drive that recursion deep enough to overflow the thread
+/// stack (an uncatchable abort, i.e. a DoS for any host compiling untrusted
+/// source).  We cap the nesting and turn an over-deep tree into an ordinary
+/// positioned error.  The limit is generous: real JavaScript almost never
+/// nests blocks past a handful of levels.  This is the statement-side twin
+/// of [`MAX_EXPR_DEPTH`].
+const MAX_STMT_DEPTH: usize = 256;
+
 // ---------------------------------------------------------------------------
 // Entry point
 // ---------------------------------------------------------------------------
@@ -174,8 +257,10 @@ const MAX_EXPR_DEPTH: usize = 256;
 ///
 /// M2 admits literal expression statements, `let`/`const`/`var`
 /// bindings, re-assignments, variable references, and unary/binary
-/// operators.  Any other statement or expression shape produces a
-/// [`JsLowerError`] (see module docs).
+/// operators.  M3 adds control flow: `if`/`else`, `while`, the canonical
+/// counting C-style `for`, `for … of`, and bare `{ … }` blocks.  Any
+/// other statement or expression shape produces a [`JsLowerError`] (see
+/// module docs).
 pub fn compile(program: &GrammarASTNode, module_name: &str) -> Result<Module, JsLowerError> {
     if program.rule_name != "program" {
         return Err(JsLowerError {
@@ -290,16 +375,44 @@ impl Lowerer {
     /// hence unobservable, so we drop them.  An empty program yields a
     /// `NilLit` value.
     fn lower_program(&mut self, program: &GrammarASTNode) -> Result<Block, JsLowerError> {
+        // The top-level statement sequence is `program`'s children, each a
+        // `source_element` wrapping one `statement`.  Lowering it is exactly
+        // lowering a statement list — the same routine used for `{ … }`
+        // block bodies — at depth 0.
+        self.lower_stmt_seq(&program.children, self.span_of(program), 0)
+    }
+
+    /// Lower a slice of CST children that are statement-bearing nodes into a
+    /// single [`Block`] (statements then a tail value).
+    ///
+    /// This is the shared workhorse for the top-level program body and every
+    /// `{ … }` block / control-flow body.  Each child is lowered to a
+    /// [`Lowered`]:
+    ///
+    /// - a [`Lowered::Stmt`] is pushed onto `stmts` (flushing any pending
+    ///   bare-expression value as an `ExprStmt` first, so evaluation order
+    ///   and side effects are preserved);
+    /// - a [`Lowered::Expr`] becomes the *candidate* tail value, superseding
+    ///   any earlier pure bare-expression value.
+    ///
+    /// The final candidate tail value becomes `Block.value`; an empty
+    /// sequence yields a `NilLit` tail (matching SIR's "every block produces
+    /// a value" rule).  `block_span` stamps the resulting `Block`.
+    fn lower_stmt_seq(
+        &mut self,
+        children: &[ASTNodeOrToken],
+        block_span: Span,
+        depth: usize,
+    ) -> Result<Block, JsLowerError> {
         let mut stmts: Vec<Stmt> = Vec::new();
         // The most recent bare-expression value seen.  Whatever it holds
         // at the end becomes the block's tail value.
         let mut tail: Option<Expr> = None;
 
-        for child in &program.children {
+        for child in children {
             match child {
                 ASTNodeOrToken::Node(n) => {
-                    // A `source_element` wraps a `statement`; descend.
-                    match self.lower_source_element(n)? {
+                    match self.lower_source_element(n, depth)? {
                         Lowered::Stmt(s) => {
                             // A statement makes any pending tail
                             // expression unobservable as a *value*, but it
@@ -319,51 +432,546 @@ impl Lowerer {
                         }
                     }
                 }
-                // Stray tokens directly under `program` (there should be
-                // none for well-formed input) are ignored.
+                // Stray tokens (the `{`/`}` of a block, the `source_element`
+                // separators, etc.) carry no statement; skip them.
                 ASTNodeOrToken::Token(_) => {}
             }
         }
 
         let value = tail.unwrap_or(Expr::NilLit {
-            span: self.span_of(program),
+            span: block_span.clone(),
         });
 
         Ok(Block {
             stmts,
             value,
-            span: self.span_of(program),
+            span: block_span,
         })
     }
 
-    /// Lower one `source_element` (top-level item) to a [`Lowered`].
-    fn lower_source_element(&mut self, node: &GrammarASTNode) -> Result<Lowered, JsLowerError> {
+    /// Lower one statement-bearing item (a `source_element`, a `statement`
+    /// wrapper, or a concrete statement node) to a [`Lowered`].
+    ///
+    /// `depth` bounds control-flow body nesting (see [`MAX_STMT_DEPTH`]); a
+    /// nested body recurses with `depth + 1`.
+    fn lower_source_element(
+        &mut self,
+        node: &GrammarASTNode,
+        depth: usize,
+    ) -> Result<Lowered, JsLowerError> {
         // `source_element` → `statement` → `<concrete statement>`.
         // Descend through the single-child wrappers until we reach a
         // statement we recognise.
-        let stmt = single_child_node(node).unwrap_or(node);
-        match stmt.rule_name.as_str() {
-            "statement" => {
-                let inner = single_child_node(stmt).unwrap_or(stmt);
-                self.lower_statement_inner(inner)
-            }
-            "expression_statement" => self.lower_expression_statement(stmt),
-            "lexical_declaration" => self.lower_lexical_declaration(stmt).map(|s| Lowered::Stmt(Box::new(s))),
-            "variable_statement" => self.lower_variable_statement(stmt).map(|s| Lowered::Stmt(Box::new(s))),
-            other => Err(self.unsupported(stmt, other)),
+        let inner = single_child_node(node).unwrap_or(node);
+        match inner.rule_name.as_str() {
+            // `source_element` and `statement` are both single-child
+            // wrappers; recurse through them to the concrete statement.
+            "statement" => self.lower_source_element(inner, depth),
+            other => self.lower_statement_inner(inner, other, depth),
         }
     }
 
-    /// Lower the node *inside* a `statement` wrapper.
-    fn lower_statement_inner(&mut self, node: &GrammarASTNode) -> Result<Lowered, JsLowerError> {
-        match node.rule_name.as_str() {
+    /// Lower a concrete statement node, dispatching on its `rule_name`.
+    fn lower_statement_inner(
+        &mut self,
+        node: &GrammarASTNode,
+        rule_name: &str,
+        depth: usize,
+    ) -> Result<Lowered, JsLowerError> {
+        match rule_name {
             "expression_statement" => self.lower_expression_statement(node),
-            "lexical_declaration" => self.lower_lexical_declaration(node).map(|s| Lowered::Stmt(Box::new(s))),
-            "variable_statement" => self.lower_variable_statement(node).map(|s| Lowered::Stmt(Box::new(s))),
-            // deferred to M3+: if_statement, iteration_statement,
-            // function_declaration, return_statement, block, …
+            "lexical_declaration" => self
+                .lower_lexical_declaration(node)
+                .map(|s| Lowered::Stmt(Box::new(s))),
+            "variable_statement" => self
+                .lower_variable_statement(node)
+                .map(|s| Lowered::Stmt(Box::new(s))),
+            // ── M3: control flow ────────────────────────────────────
+            "if_statement" => self.lower_if(node, depth).map(Lowered::Expr),
+            "while_statement" => self
+                .lower_while(node, depth)
+                .map(|s| Lowered::Stmt(Box::new(s))),
+            "for_statement" => self
+                .lower_for(node, depth)
+                .map(|s| Lowered::Stmt(Box::new(s))),
+            "for_of_statement" => self
+                .lower_for_of(node, depth)
+                .map(|s| Lowered::Stmt(Box::new(s))),
+            "block" => self.lower_block(node, depth).map(|b| {
+                // A bare `{ … }` block is a value-producing expression in
+                // SIR (`Expr::Block`); at statement position its tail value
+                // is unobservable but its statements run for effect.
+                Lowered::Expr(Expr::Block(Box::new(b)))
+            }),
+            // deferred to a later milestone: function_declaration,
+            // return_statement, switch, try, do-while, labeled, …
             other => Err(self.unsupported(node, other)),
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // M3: control-flow lowering
+    // -----------------------------------------------------------------------
+
+    /// Lower an `if_statement` to an [`Expr::If`].
+    ///
+    /// CST (probed): `[Kw("if"), (, expression, ), statement]` with no else,
+    /// or `[…, statement, Kw("else"), statement]` with one.  The `then`/
+    /// `else` `statement`s are each a block body (a `{ … }` block or a
+    /// single statement).  A missing `else` becomes a synthetic empty
+    /// nil-valued [`Block`].  An `else if` chain is the grammar nesting
+    /// another `if_statement` inside the else `statement`, so it recurses
+    /// into a nested `Expr::If` automatically.
+    fn lower_if(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Expr, JsLowerError> {
+        self.check_stmt_depth(node, depth)?;
+        let span = self.span_of(node);
+
+        // Collect the direct child *nodes* in order: [cond_expr, then_stmt]
+        // or [cond_expr, then_stmt, else_stmt].  The `if`/`else` keywords,
+        // parens, etc. are tokens we skip.
+        let nodes = child_nodes(node);
+        let cond_node = nodes.first().ok_or_else(|| self.unsupported(node, "if (no condition)"))?;
+        let then_node = nodes.get(1).ok_or_else(|| self.unsupported(node, "if (no then branch)"))?;
+
+        let cond = self.lower_expression(cond_node, 0)?;
+        let then_branch = self.lower_body(then_node, depth)?;
+        let else_branch = match nodes.get(2) {
+            Some(else_node) => self.lower_body(else_node, depth)?,
+            // No `else`: an empty, nil-valued block.
+            None => Block {
+                stmts: Vec::new(),
+                value: Expr::NilLit { span: span.clone() },
+                span: span.clone(),
+            },
+        };
+
+        Ok(Expr::If {
+            cond: Box::new(cond),
+            then_branch: Box::new(then_branch),
+            else_branch: Box::new(else_branch),
+            span,
+        })
+    }
+
+    /// Lower a `while_statement` to a [`Stmt::While`].
+    ///
+    /// CST: `[Kw("while"), (, expression, ), statement]`.
+    fn lower_while(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Stmt, JsLowerError> {
+        self.check_stmt_depth(node, depth)?;
+        let span = self.span_of(node);
+        let nodes = child_nodes(node);
+        let cond_node = nodes.first().ok_or_else(|| self.unsupported(node, "while (no condition)"))?;
+        let body_node = nodes.get(1).ok_or_else(|| self.unsupported(node, "while (no body)"))?;
+
+        let cond = self.lower_expression(cond_node, 0)?;
+        let body = self.lower_body(body_node, depth)?;
+        // The validator observes `Feature::Loops` for every loop statement;
+        // declare it so the manifest matches the body exactly.
+        self.features_used.add(Feature::Loops);
+        Ok(Stmt::While { cond, body, span })
+    }
+
+    /// Lower a `for_of_statement` to a [`Stmt::ForEach`].
+    ///
+    /// CST: `[Kw("for"), (, Kw("let|const|var"), binding_element,
+    /// Name("of"), assignment_expression(iter), ), statement]`.  Only the
+    /// single-identifier binding (`for (const x of xs)`) is supported;
+    /// destructuring (`for (const [a, b] of …)`) is deferred.  The loop
+    /// variable `x` is bound into the body scope only.
+    fn lower_for_of(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Stmt, JsLowerError> {
+        self.check_stmt_depth(node, depth)?;
+        let span = self.span_of(node);
+
+        // The binding name lives in the `binding_element`'s single Name
+        // token.  Anything else (a destructuring pattern) is deferred.
+        let binding = child_node_named(node, "binding_element")
+            .ok_or_else(|| self.unsupported(node, "for-of (no binding_element)"))?;
+        let var_tok = single_leaf_token(binding)
+            .filter(|t| matches!(t.type_, TokenType::Name))
+            .ok_or_else(|| JsLowerError {
+                message: "for-of destructuring binding is deferred (only `for (const x of …)`)"
+                    .to_string(),
+                line: span.start_line,
+                column: span.start_col,
+            })?;
+        let var = var_tok.value.clone();
+
+        // The iterable is the `assignment_expression` child — the only
+        // expression-shaped node (the `binding_element` is the binding).
+        let iter_node = child_node_named(node, "assignment_expression")
+            .ok_or_else(|| self.unsupported(node, "for-of (no iterable)"))?;
+        let iter = self.lower_expression(iter_node, 0)?;
+
+        let body = self.lower_loop_body_scoped(&var, node, depth)?;
+        self.features_used.add(Feature::Loops);
+        Ok(Stmt::ForEach { var, iter, body, span })
+    }
+
+    /// Lower a canonical C-style `for_statement` to a [`Stmt::ForRange`].
+    ///
+    /// CST: `[Kw("for"), (, Kw("let"), binding_list, ;, expr(cond), ;,
+    /// expr(update), ), statement]`.  We accept **only** the canonical
+    /// counting shape (see module docs):
+    ///
+    ///   * init `let i = <start>` (single binding of `i`),
+    ///   * cond `i < <stop>` or `i <= <stop>` on the same `i`,
+    ///   * update `i = i + <step>`, `i += <step>`, or `i++` (step 1).
+    ///
+    /// `<=` is rewritten half-open by bumping `stop` to `stop + 1`.  Any
+    /// non-canonical shape is a positioned [`JsLowerError`] (deferred).
+    fn lower_for(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Stmt, JsLowerError> {
+        self.check_stmt_depth(node, depth)?;
+        let span = self.span_of(node);
+
+        // The non-canonical bail-out, factored so every rejection carries
+        // the loop's position and a uniform "deferred" message.
+        let reject = |why: &str| JsLowerError {
+            message: format!(
+                "non-canonical C-style `for` ({why}) is deferred; only the counting form \
+                 `for (let i = <start>; i < <stop>; i++/i += <step>)` is supported"
+            ),
+            line: span.start_line,
+            column: span.start_col,
+        };
+
+        // ── init: `let i = <start>` ─────────────────────────────────────
+        // The init clause is a `binding_list` (for `let`/`const`) sitting
+        // directly under the `for_statement` (the probe shows it is *not*
+        // wrapped in a `lexical_declaration` here — the `let` keyword and
+        // `binding_list` are direct children).  `var` would surface a
+        // `variable_declaration_list` instead; we accept either.
+        let (loop_var, start) = self.extract_for_init(node).ok_or_else(|| {
+            reject("init is not a single `let i = <start>` binding")
+        })?;
+
+        // ── cond: `i < <stop>` / `i <= <stop>` ──────────────────────────
+        // The condition is the first `expression` child after the init's
+        // terminating `;`.  We need the *branching* relational node.
+        let cond_expr = self
+            .for_clause_expr(node, 0)
+            .ok_or_else(|| reject("missing condition clause"))?;
+        let stop = self.extract_for_cond(cond_expr, &loop_var).ok_or_else(|| {
+            reject("condition is not `i < <stop>` or `i <= <stop>` on the loop variable")
+        })?;
+
+        // ── update: `i = i + <step>` / `i += <step>` / `i++` ────────────
+        let update_expr = self
+            .for_clause_expr(node, 1)
+            .ok_or_else(|| reject("missing update clause"))?;
+        let step = self.extract_for_step(update_expr, &loop_var).ok_or_else(|| {
+            reject("update is not an increment of the loop variable by a constant step")
+        })?;
+
+        // ── body (loop variable scoped into it) ─────────────────────────
+        let body = self.lower_loop_body_scoped(&loop_var, node, depth)?;
+
+        self.features_used.add(Feature::Loops);
+        Ok(Stmt::ForRange {
+            var: loop_var,
+            start,
+            stop,
+            step,
+            body,
+            span,
+        })
+    }
+
+    /// Extract `(var, start_expr)` from a C-`for` init clause, or `None` if
+    /// it is not a single `let|const|var i = <start>` binding.
+    fn extract_for_init(&mut self, for_node: &GrammarASTNode) -> Option<(String, Expr)> {
+        // `let`/`const` → `binding_list[ lexical_binding[ Name, =, init ] ]`.
+        // `var`         → `variable_declaration_list[ variable_declaration ]`.
+        let (list_name, binding_name) =
+            if child_node_named(for_node, "binding_list").is_some() {
+                ("binding_list", "lexical_binding")
+            } else {
+                ("variable_declaration_list", "variable_declaration")
+            };
+        let list = child_node_named(for_node, list_name)?;
+        let bindings = children_nodes_named(list, binding_name);
+        if bindings.len() != 1 {
+            return None; // multi-variable init is non-canonical.
+        }
+        let binding = bindings[0];
+        let name_tok = binding.children.iter().find_map(|c| match c {
+            ASTNodeOrToken::Token(t) if matches!(t.type_, TokenType::Name) => Some(t),
+            _ => None,
+        })?;
+        let init_node = binding.children.iter().find_map(|c| match c {
+            ASTNodeOrToken::Node(n) => Some(n),
+            ASTNodeOrToken::Token(_) => None,
+        })?;
+        let start = self.lower_expression(init_node, 0).ok()?;
+        Some((name_tok.value.clone(), start))
+    }
+
+    /// Return the `n`-th `expression` clause node under a `for_statement`
+    /// (cond = 0, update = 1).  These are the `expression` rule nodes that
+    /// sit between the clause-separating `;`/`)` tokens.
+    fn for_clause_expr<'a>(
+        &self,
+        for_node: &'a GrammarASTNode,
+        n: usize,
+    ) -> Option<&'a GrammarASTNode> {
+        for_node
+            .children
+            .iter()
+            .filter_map(|c| match c {
+                ASTNodeOrToken::Node(node) if node.rule_name == "expression" => Some(node),
+                _ => None,
+            })
+            .nth(n)
+    }
+
+    /// Extract the `stop` expression from a canonical loop condition.
+    ///
+    /// Accepts `i < S` (→ `S`) and `i <= S` (→ half-open `S + 1`), where the
+    /// left operand is exactly the loop variable `var`.  Returns `None` for
+    /// any other comparison (wrong variable, `>`/`>=`, RHS-anchored, …).
+    fn extract_for_cond(
+        &mut self,
+        cond_node: &GrammarASTNode,
+        var: &str,
+    ) -> Option<Expr> {
+        // Peel to the branching `relational_expression`: `[lhs, op, rhs]`.
+        let branch = peel_to_branch(cond_node);
+        if branch.rule_name != "relational_expression" || branch.children.len() != 3 {
+            return None;
+        }
+        // children = [lhs_node, op_token, rhs_node].
+        let lhs = match &branch.children[0] {
+            ASTNodeOrToken::Node(n) => n,
+            _ => return None,
+        };
+        let op = match &branch.children[1] {
+            ASTNodeOrToken::Token(t) => t.value.as_str(),
+            _ => return None,
+        };
+        let rhs = match &branch.children[2] {
+            ASTNodeOrToken::Node(n) => n,
+            _ => return None,
+        };
+        // LHS must be exactly the loop variable.
+        let lhs_tok = single_leaf_token(lhs)?;
+        if !matches!(lhs_tok.type_, TokenType::Name) || lhs_tok.value != var {
+            return None;
+        }
+        let stop = self.lower_expression(rhs, 0).ok()?;
+        match op {
+            "<" => Some(stop),
+            "<=" => {
+                // Half-open rewrite: `i <= S` ⇔ `i < S + 1`.
+                let span = stop.span().clone();
+                Some(Expr::BuiltinCall {
+                    name: "+".to_string(),
+                    args: vec![stop, Expr::IntLit { value: 1, span: span.clone() }],
+                    effects: EffectSet::PURE,
+                    span,
+                })
+            }
+            _ => None,
+        }
+    }
+
+    /// Extract the `step` expression from a canonical loop update clause.
+    ///
+    /// Accepts (on the loop variable `var`):
+    ///
+    ///   * `i++`           → `IntLit(1)` (postfix increment),
+    ///   * `i += <step>`   → `<step>`,
+    ///   * `i = i + <step>`→ `<step>`.
+    ///
+    /// Returns `None` for decrements, `*=`, a different variable, etc.
+    fn extract_for_step(
+        &mut self,
+        update_node: &GrammarASTNode,
+        var: &str,
+    ) -> Option<Expr> {
+        let branch = peel_to_branch(update_node);
+        match branch.rule_name.as_str() {
+            // ── `i++` : postfix_expression[ lhs, Name("++") ] ───────────
+            "postfix_expression" => {
+                let nodes = child_nodes(branch);
+                let target = nodes.first()?;
+                let t = single_leaf_token(target)?;
+                if !matches!(t.type_, TokenType::Name) || t.value != var {
+                    return None;
+                }
+                // The operator token must be `++` (reject `i--`).
+                let op_ok = branch.children.iter().any(|c| {
+                    matches!(c, ASTNodeOrToken::Token(tok) if tok.value == "++")
+                });
+                if !op_ok {
+                    return None;
+                }
+                Some(Expr::IntLit { value: 1, span: self.span_of(branch) })
+            }
+            // ── `i += s` or `i = i + s` :
+            //    assignment_expression[ lhs, op, rhs ] ─────────────────
+            "assignment_expression" if branch.children.len() == 3 => {
+                let lhs = match &branch.children[0] {
+                    ASTNodeOrToken::Node(n) => n,
+                    _ => return None,
+                };
+                let lhs_tok = single_leaf_token(lhs)?;
+                if !matches!(lhs_tok.type_, TokenType::Name) || lhs_tok.value != var {
+                    return None;
+                }
+                // The assignment operator value (`=`, `+=`, …).
+                let op = match &branch.children[1] {
+                    ASTNodeOrToken::Node(n) => single_leaf_token(n)?.value.clone(),
+                    ASTNodeOrToken::Token(t) => t.value.clone(),
+                };
+                let rhs = match &branch.children[2] {
+                    ASTNodeOrToken::Node(n) => n,
+                    _ => return None,
+                };
+                match op.as_str() {
+                    // `i += s` → step is `s`.
+                    "+=" => self.lower_expression(rhs, 0).ok(),
+                    // `i = i + s` → the RHS must be `i + s`; step is `s`.
+                    "=" => self.extract_plus_step(rhs, var),
+                    _ => None,
+                }
+            }
+            _ => None,
+        }
+    }
+
+    /// From an RHS shaped `i + <step>` (an `additive_expression` whose left
+    /// operand is the loop variable and whose single operator is `+`),
+    /// extract `<step>`.  Returns `None` for anything else (e.g. `i - 1`,
+    /// `i * 2`, `s + i`).
+    fn extract_plus_step(&mut self, rhs: &GrammarASTNode, var: &str) -> Option<Expr> {
+        let branch = peel_to_branch(rhs);
+        // `i + s` is one `additive_expression` with children
+        // `[i_node, Plus, s_node]`.
+        if branch.rule_name != "additive_expression" || branch.children.len() != 3 {
+            return None;
+        }
+        let lhs = match &branch.children[0] {
+            ASTNodeOrToken::Node(n) => n,
+            _ => return None,
+        };
+        let op = match &branch.children[1] {
+            ASTNodeOrToken::Token(t) => t.value.as_str(),
+            _ => return None,
+        };
+        if op != "+" {
+            return None;
+        }
+        let lhs_tok = single_leaf_token(lhs)?;
+        if !matches!(lhs_tok.type_, TokenType::Name) || lhs_tok.value != var {
+            return None;
+        }
+        let step_node = match &branch.children[2] {
+            ASTNodeOrToken::Node(n) => n,
+            _ => return None,
+        };
+        self.lower_expression(step_node, 0).ok()
+    }
+
+    // -----------------------------------------------------------------------
+    // M3: shared body / block helpers
+    // -----------------------------------------------------------------------
+
+    /// Lower a control-flow *body* `statement` (an `if`/`while` branch or a
+    /// `for` body) into a [`Block`].
+    ///
+    /// The body is either a `{ … }` block (→ its statement sequence) or a
+    /// single statement (→ a one-item block).  Either way names bound inside
+    /// it are block-scoped: we snapshot `declared_locals` before lowering
+    /// and restore it after, so an inner `let` does not leak outward.
+    fn lower_body(
+        &mut self,
+        body_stmt: &GrammarASTNode,
+        depth: usize,
+    ) -> Result<Block, JsLowerError> {
+        let saved = self.declared_locals.clone();
+        let result = self.lower_body_inner(body_stmt, depth);
+        // Restore the outer scope regardless of success so a partially
+        // mutated set never leaks (defensive; on `Err` we abort anyway).
+        self.declared_locals = saved;
+        result
+    }
+
+    /// Lower a loop body with `loop_var` bound into the body scope only.
+    ///
+    /// Mirrors the validator, which adds the loop variable to its `LocalEnv`
+    /// for the body and rewinds afterwards.  The variable must resolve to a
+    /// `Scope::Local` `VarRef` inside the body but be invisible after the
+    /// loop.  We add it to `declared_locals` over the body and then restore
+    /// the snapshot (which excludes it).
+    fn lower_loop_body_scoped(
+        &mut self,
+        loop_var: &str,
+        for_node: &GrammarASTNode,
+        depth: usize,
+    ) -> Result<Block, JsLowerError> {
+        let body_stmt = self
+            .loop_body_node(for_node)
+            .ok_or_else(|| self.unsupported(for_node, "loop (no body)"))?;
+        let saved = self.declared_locals.clone();
+        self.declared_locals.insert(loop_var.to_string());
+        let result = self.lower_body_inner(body_stmt, depth);
+        self.declared_locals = saved;
+        result
+    }
+
+    /// The body `statement` of a loop is its **last** direct child node
+    /// (after the header tokens / clause expressions).
+    fn loop_body_node<'a>(&self, for_node: &'a GrammarASTNode) -> Option<&'a GrammarASTNode> {
+        child_nodes(for_node).into_iter().next_back()
+    }
+
+    /// Inner body-lowering shared by [`lower_body`] and
+    /// [`lower_loop_body_scoped`] (which own the scope save/restore).
+    fn lower_body_inner(
+        &mut self,
+        body_stmt: &GrammarASTNode,
+        depth: usize,
+    ) -> Result<Block, JsLowerError> {
+        // Descend the `statement` wrapper to the concrete body node.
+        let inner = single_child_node(body_stmt).unwrap_or(body_stmt);
+        if inner.rule_name == "block" {
+            return self.lower_block(inner, depth);
+        }
+        // A single (unbraced) statement body, e.g. `if (c) x = 1;`.  Lower
+        // the one statement and fold it into a one-element `Block`, reusing
+        // the same Stmt/Expr → (stmts, tail) routing as a block.
+        let span = self.span_of(body_stmt);
+        let mut stmts: Vec<Stmt> = Vec::new();
+        let value = match self.lower_source_element(body_stmt, depth + 1)? {
+            Lowered::Stmt(s) => {
+                stmts.push(*s);
+                Expr::NilLit { span: span.clone() }
+            }
+            Lowered::Expr(e) => e,
+        };
+        Ok(Block { stmts, value, span })
+    }
+
+    /// Lower a `block` (`{ stmt* }`) into a [`Block`].  The `{`/`}` tokens
+    /// are skipped by [`lower_stmt_seq`].  Recurses with `depth + 1` so the
+    /// nesting guard catches pathological depth.
+    fn lower_block(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Block, JsLowerError> {
+        self.check_stmt_depth(node, depth)?;
+        let span = self.span_of(node);
+        self.lower_stmt_seq(&node.children, span, depth + 1)
+    }
+
+    /// Enforce the [`MAX_STMT_DEPTH`] nesting bound; error if exceeded.
+    fn check_stmt_depth(&self, node: &GrammarASTNode, depth: usize) -> Result<(), JsLowerError> {
+        if depth > MAX_STMT_DEPTH {
+            return Err(JsLowerError {
+                message: format!(
+                    "control-flow nests deeper than the supported limit ({MAX_STMT_DEPTH})"
+                ),
+                line: node.start_line.unwrap_or(0),
+                column: node.start_column.unwrap_or(0),
+            });
+        }
+        Ok(())
     }
 
     // -----------------------------------------------------------------------
@@ -980,7 +1588,7 @@ impl Lowerer {
     fn unsupported(&self, node: &GrammarASTNode, what: &str) -> JsLowerError {
         JsLowerError {
             message: format!(
-                "`{what}` is out of scope for M2; deferred to a later milestone"
+                "`{what}` is out of scope for this milestone; deferred to a later one"
             ),
             line: node.start_line.unwrap_or(0),
             column: node.start_column.unwrap_or(0),
@@ -1048,6 +1656,21 @@ fn peel_to_branch(node: &GrammarASTNode) -> &GrammarASTNode {
 /// token.  Returns `None` if the bottom node branches.
 fn single_leaf_token(node: &GrammarASTNode) -> Option<&Token> {
     peel_to_branch(node).token()
+}
+
+/// Return every direct child of `node` that is a *node* (dropping the
+/// interleaved tokens), in source order.  Used by the control-flow lowerers
+/// to read a statement's operand nodes positionally — e.g. an
+/// `if_statement`'s `[cond, then, else]` or a loop's trailing body node —
+/// without having to thread past the keyword/paren tokens.
+fn child_nodes(node: &GrammarASTNode) -> Vec<&GrammarASTNode> {
+    node.children
+        .iter()
+        .filter_map(|c| match c {
+            ASTNodeOrToken::Node(n) => Some(n),
+            ASTNodeOrToken::Token(_) => None,
+        })
+        .collect()
 }
 
 /// Return the first direct child node of `node` whose `rule_name` is

--- a/code/specs/SIR19-javascript-to-semantic-ir.md
+++ b/code/specs/SIR19-javascript-to-semantic-ir.md
@@ -85,6 +85,43 @@ scope; the spread parts of the language we then reject at lowering).
 | `d[k]` / `d.k`                               | `MapGet { map: d, key: k }`                             |
 | `d[k] = v;` / `d.k = v;`                     | `MapSet`                                                |
 
+## Control flow (M3)
+
+**Implementation note (M3).**  `if`/`else`, `while`, the C-style `for`,
+and `for … of` are implemented as of crate `0.3.0`, along with bare
+`{ … }` blocks.  Details and the two deliberate divergences from a naive
+reading of the table above:
+
+- **`if` is an expression.**  The IR has no statement-level `if`; an `if`
+  *statement* lowers to `Stmt::ExprStmt` wrapping an `Expr::If`.  A
+  missing `else` gets a synthetic empty nil-valued `Block`.  Else-if
+  chains nest a further `Expr::If` in the outer `else_branch`'s tail
+  value.  `Expr::If` is **not** gated by any `Feature` (the validator
+  observes none), so a conditional adds nothing to the manifest.
+- **C-style `for` is accepted only for the canonical counting shape.**
+  Init `let i = <start>`, cond `i < <stop>` or `i <= <stop>` on the same
+  `i`, update `i = i + <step>` / `i += <step>` / `i++`.  `i <= <stop>` is
+  rewritten to the half-open `i < <stop> + 1` (the IR `ForRange` is
+  half-open, `stop` exclusive).  **Non-canonical** loops — a different
+  loop variable across clauses, a decrement (`i--`), a multiplicative
+  step (`i = i * 2`), a missing clause, or a multi-variable init — are
+  rejected with a positioned `JsLowerError` (deferred) rather than
+  mis-lowered.  This is a tightening of the bare table rows above: only
+  the counting form is in scope for v0.
+- **`for … of`** supports the single-identifier binding only;
+  destructuring is deferred.
+- **Scoping.**  The loop variable is bound into the loop body scope only
+  (visible inside, unresolved after); names bound inside any control-flow
+  body or bare block are block-scoped and do not leak outward — matching
+  the SIR validator's `LocalEnv` mark/rewind around each `Block` and each
+  loop body.
+- **Recursion bound.**  Statement-block nesting is capped at
+  `MAX_STMT_DEPTH = 256` (the twin of the M2 `MAX_EXPR_DEPTH`), so deeply
+  nested control flow yields a positioned error, not a stack overflow.
+
+Still deferred after M3: `switch`, `try`/`catch`, `do … while`, labeled
+statements, and `break`/`continue` (the IR has no early-exit node).
+
 ## let / const / var
 
 All three become a binding statement.  **Implementation note (M2):** the


### PR DESCRIPTION
Milestone M3 for the `javascript-to-semantic-ir` SIR19 frontend — **control flow** (builds on merged M1 literals + M2 variables/operators).

- **if/else** → `Expr::If`; else-if falls out of the grammar (the else statement nests another if).
- **while** → `Stmt::While`.
- **C-style for** → `Stmt::ForRange` via canonical-shape extraction: init `let i = <start>`, cond `i < S` / `i <= S` (half-open rewrite `S+1`), update `i++` / `i += s` / `i = i + s`. Non-canonical loops (wrong var, `i--`, `i = i*2`, multi-var, missing clause) → positioned error.
- **for-of** → `Stmt::ForEach`.
- Loop-var/body scoping via snapshot/restore of `declared_locals` (matches the validator's LocalEnv). New `MAX_STMT_DEPTH` (256) guards every nested body; expressions still bounded by `MAX_EXPR_DEPTH`.

Deferred (positioned errors): non-canonical for, switch, try/catch, do-while, labeled/break/continue; functions/closures (M4), collections (M5), template literals.

**Tests:** 55 (21 new M3 + M1/M2 still green); clippy clean; security review passed. Isolated to `javascript-to-semantic-ir`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)