### PR TITLE
fix(closure-emitter): ** exponentiation operand precedence (invalid-JS miscompile)

### DIFF
--- a/code/packages/rust/closure-emitter/CHANGELOG.md
+++ b/code/packages/rust/closure-emitter/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to the `coding-adventures-closure-emitter` crate will be documented in this file.
 
+## [0.18.7] - 2026-06-30
+
+### Fixed — `**` exponentiation operand precedence (invalid-JS miscompile)
+
+`emit_binary` emitted every operator's left child at `my_prec` and right child
+at `my_prec + 1` — correct for the left-associative operators, but wrong for
+`**`, which is right-associative AND whose grammar base is an `UpdateExpression`
+(it binds tighter than unary). Two bugs resulted:
+
+- **Invalid output.** A unary base printed without parentheses: `(-a)**2` became
+  `-a**2`, which is a `SyntaxError` in JavaScript (a unary operator may not be
+  the base of `**` without parens). Same for `(~a)**2`, `(!a)**2`.
+- **Over-parenthesisation.** Right-associativity was not modelled, so
+  `a**b**c` (which natively *is* `a**(b**c)`) printed as `a**(b**c)`.
+
+`**` now emits its left at `PREC_UNARY + 1` (parenthesising a unary/lower base —
+`(-a)**2`, `(a**b)**c`) and its right at `my_prec` (a same-precedence right needs
+no parens — `a**b**c`; a unary right is still legal bare — `a**-b`). All other
+operators are unchanged. New test `exponentiation_base_and_right_precedence`.
+
 ## [0.18.6] - 2026-06-30
 
 ### Fixed — member object / call callee lost its parentheses (miscompile)

--- a/code/packages/rust/closure-emitter/Cargo.toml
+++ b/code/packages/rust/closure-emitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-emitter"
-version = "0.18.6"
+version = "0.18.7"
 edition = "2021"
 description = "JavaScript code emitter for the Closure Compiler clone. Per CLOC07's emit contract. Takes a finalized Program + sidecar and produces output JavaScript text + companion source map. Runs after every pass in the pipeline."
 

--- a/code/packages/rust/closure-emitter/src/lib.rs
+++ b/code/packages/rust/closure-emitter/src/lib.rs
@@ -950,7 +950,25 @@ impl<'a> Emitter<'a> {
         // `emit_expression_inner`.
         self.maybe_map(&b.cv);
         let my_prec = binary_prec(b.operator);
-        self.emit_expression_inner(&b.left, my_prec);
+        // Operand precedences. Almost every binary operator is LEFT-associative,
+        // so the left child accepts the same precedence (no parens for
+        // `a+b+c`) and the right child must be strictly higher (`a-(b-c)`).
+        //
+        // `**` (exponentiation) is the exception on BOTH counts:
+        //   • It is RIGHT-associative, so `a**b**c` is `a**(b**c)`: the RIGHT
+        //     child accepts the same precedence (no parens) and it is the LEFT
+        //     child that must be strictly higher.
+        //   • Its grammar base is an `UpdateExpression`, NOT a `UnaryExpression`
+        //     — `-a**2`, `~a**2`, `!a**2` are SYNTAX ERRORS. The base must
+        //     therefore bind tighter than unary, so we require `PREC_UNARY + 1`
+        //     on the left, which parenthesises a unary (or lower) base:
+        //     `(-a)**2`.
+        let (left_prec, right_prec) = if matches!(b.operator, BinaryOperator::Exp) {
+            (PREC_UNARY + 1, my_prec)
+        } else {
+            (my_prec, my_prec + 1)
+        };
+        self.emit_expression_inner(&b.left, left_prec);
         let op = binary_op_str(b.operator);
 
         // Word-shaped operators MUST keep a space on both sides or they fuse
@@ -960,7 +978,7 @@ impl<'a> Emitter<'a> {
             self.required_ws();
             self.write_str(op);
             self.required_ws();
-            self.emit_expression_inner(&b.right, my_prec + 1);
+            self.emit_expression_inner(&b.right, right_prec);
             return;
         }
 
@@ -991,7 +1009,7 @@ impl<'a> Emitter<'a> {
         if right_needs_space {
             self.write_str(" ");
         }
-        self.emit_expression_inner(&b.right, my_prec + 1);
+        self.emit_expression_inner(&b.right, right_prec);
     }
 
     fn emit_logical(&mut self, l: &LogicalExpression) {
@@ -1749,6 +1767,24 @@ mod tests {
             property: Box::new(ident(prop)),
             computed,
         })
+    }
+
+    #[test]
+    fn exponentiation_base_and_right_precedence() {
+        use BinaryOperator::*;
+        // `(-a)**2` — a unary base of `**` MUST be parenthesised; `-a**2` is a
+        // SyntaxError (the grammar base binds tighter than unary).
+        let neg_a = unary(UnaryOperator::Negate, ident("a"));
+        assert_eq!(emit_expr(binary(Exp, neg_a, num(2.0))), "(-a)**2;");
+        // `**` is right-associative: a `**` on the RIGHT needs no parens.
+        let b_pow_c = binary(Exp, ident("b"), ident("c"));
+        assert_eq!(emit_expr(binary(Exp, ident("a"), b_pow_c)), "a**b**c;");
+        // A `**` on the LEFT (left-grouped AST) DOES need parens.
+        let a_pow_b = binary(Exp, ident("a"), ident("b"));
+        assert_eq!(emit_expr(binary(Exp, a_pow_b, ident("c"))), "(a**b)**c;");
+        // A unary RIGHT operand is legal without parens (`a**-b`).
+        let neg_b = unary(UnaryOperator::Negate, ident("b"));
+        assert_eq!(emit_expr(binary(Exp, ident("a"), neg_b)), "a**-b;");
     }
 
     #[test]

--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.233.0] - 2026-06-30
+
+### Fixed — `**` operand precedence emitted invalid JS (miscompile)
+
+A unary base of `**` was emitted without its required parentheses — `(-a)**2`
+became `-a**2`, a `SyntaxError` (also `(~a)**2`, `(!a)**2`). And right-associativity
+was not modelled, so `a**b**c` was over-parenthesised to `a**(b**c)`. The emitter
+now parenthesises a unary/lower-precedence `**` base and leaves a same-precedence
+right operand bare (see `closure-emitter` 0.18.7). New end-to-end test
+`simple_exponentiation_operand_precedence`.
+
 ## [0.232.0] - 2026-06-30
 
 ### Fixed — member object / call callee lost required parens (miscompile)

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.232.0"
+version = "0.233.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.232.0",
+  "version": "0.233.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/run.rs
+++ b/code/programs/rust/closurec/src/run.rs
@@ -6240,6 +6240,36 @@ mod tests {
     }
 
     #[test]
+    fn simple_exponentiation_operand_precedence() {
+        // `**` is right-associative and its base must bind tighter than unary
+        // (the grammar base is an UpdateExpression). A unary base therefore needs
+        // parens — `-a**2` is a SyntaxError; the correct form is `(-a)**2`. The
+        // emitter previously emitted the invalid `-a**2`. The right operand, by
+        // contrast, accepts the same precedence, so `a**b**c` needs no parens.
+        let cfg = CompilerConfig {
+            compilation: crate::config::CompilationConfig {
+                level: crate::config::CompilationLevel::Simple,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let simple = |src: &str| transform_source(src, &cfg).expect("ok");
+
+        // Unary base MUST be parenthesised (else invalid JS).
+        assert_eq!(simple("x=(-a)**2;"), "x=(-a)**2;");
+        assert_eq!(simple("x=(~a)**2;"), "x=(~a)**2;");
+        assert_eq!(simple("x=(!a)**2;"), "x=(!a)**2;");
+        // Lower-precedence base stays parenthesised.
+        assert_eq!(simple("x=(a||b)**2;"), "x=(a||b)**2;");
+        // Right-associative: same-precedence right needs NO parens (was
+        // over-parenthesised as `a**(b**c)`).
+        assert_eq!(simple("x=a**b**c;"), "x=a**b**c;");
+        // A unary RIGHT operand is legal without parens.
+        assert_eq!(simple("x=a**-b;"), "x=a**-b;");
+        assert_eq!(simple("x=a**b;"), "x=a**b;");
+    }
+
+    #[test]
     fn simple_member_and_call_object_keeps_required_parens() {
         // Regression: the emitter wrote a member-expression's object (and a
         // call's callee) at parent precedence 0, dropping the parentheses that

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.232.0
+Version: 0.233.0
 
 ## Flags
 


### PR DESCRIPTION
## Problem

`emit_binary` emitted every operator's left child at `my_prec` and right child at `my_prec + 1` — correct for left-associative operators, but wrong for `**`, which is **right-associative** and whose grammar base is an `UpdateExpression` (binds tighter than unary). Two bugs:

| input      | was         | now (correct) |
|------------|-------------|---------------|
| `(-a)**2`  | `-a**2` — **SyntaxError** | `(-a)**2` |
| `(~a)**2`  | `~a**2` — SyntaxError | `(~a)**2` |
| `(!a)**2`  | `!a**2` — SyntaxError | `(!a)**2` |
| `a**b**c`  | `a**(b**c)` — over-parenthesised | `a**b**c` |

A unary operator may not be the base of `**` without parentheses, so `-a**2` is invalid JavaScript.

## Fix

For `**` only, emit the **left** at `PREC_UNARY + 1` (so a unary or lower-precedence base is wrapped: `(-a)**2`, `(a**b)**c`) and the **right** at `my_prec` (right-associative, so a same-precedence right needs no parens — `a**b**c`; a unary right is still legal bare — `a**-b`). Every other operator keeps its exact prior behaviour (`my_prec`, `my_prec + 1`).

## Tests

Emitter unit `exponentiation_base_and_right_precedence` + closurec e2e `simple_exponentiation_operand_precedence`. `closure-emitter` 0.18.7, `closurec` 0.233.0. Green: closure-emitter + all six downstream consumers + closurec (685 + integration).

## Security review

Inline security review **PASSED** — verified soundness on every operand shape (unary/`**`/primary base; `**`/unary/lower right), correct scoping to `**` (the `else` branch is byte-identical to prior behaviour), and no interaction with the `+`/`-` sign-merge spacing or `in`/`instanceof` word-operator branches. No panic/DoS/unsafe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)