### PR TITLE
feat(latex): array/subarray math environments with column-spec — LTX01 L3a

### DIFF
--- a/code/packages/rust/latex/CHANGELOG.md
+++ b/code/packages/rust/latex/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to the full-fidelity LaTeX parser crate.
 
+## [0.15.0] — 2026-06-30
+
+### Added — the `array` / `subarray` grids (mandatory column-spec)
+
+- The parser now accepts the general **`\begin{array}{cols} … \end{array}`** grid and its
+  big-operator-limit cousin **`\begin{subarray}{c} … \end{subarray}`** — the math environments that
+  carry a **mandatory column-alignment argument**. This was the documented gap in the matrix family
+  (`pmatrix`/`bmatrix`/`cases`/`aligned`/…, all of which take *no* argument): the comment on
+  `is_math_env` explicitly parked `array` for "a later layer" because it "need[s] an extra field on
+  the node." That field is now here.
+- New optional field **`MathNode::Matrix { col_spec: Option<String>, … }`**: the column spec is
+  captured **verbatim** (`"cc"`, `"l|cr"`, `"p{3cm}"`, `*{3}{c}`, `>{…}`/`<{…}`/`@{…}` inserts), so
+  the node **round-trips** exactly — `to_latex` re-emits `\begin{array}{<spec>}`. It is `None` for
+  every environment that takes no argument (a `pmatrix` is unchanged).
+- The neutral **lowering drops `col_spec`** (alignment is presentation, PFE01 §2.2): an `array` and
+  the equivalent `pmatrix` lower to the **same** `MathExpr::Matrix`. So consumers gain `array` for
+  free — no consumer change, no new neutral node, no capability change.
+- `read_col_spec` reads the `{…}` argument with a **flat `depth` counter, not recursion**, so it is
+  brace-nesting-aware (captures `p{3cm}` whole) yet an adversarial `{{{{…` cannot overflow the
+  stack (bounded by input length, like the rest of the tokenizer output). A missing or unterminated
+  col-spec is a clean **spanned error**, never a panic.
+- Tests (9 new): `array_captures_column_spec_and_cells`, `…_keeps_rules_and_alignment_letters`,
+  `…_handles_braced_groups`, `subarray_takes_a_column_spec_too`, `array_round_trips_through_to_latex`,
+  `matrix_family_still_has_no_column_spec`, `array_without_column_spec_is_a_spanned_error`,
+  `deep_column_spec_braces_do_not_overflow`, and frontend `array_lowers_dropping_column_spec`
+  (array ≡ pmatrix after lowering). 150 unit + doc tests pass; clippy `-D warnings` clean;
+  downstream `adj-lang` (the only consumer) 86 green.
+
 ## [0.14.0] — 2026-06-30
 
 ### Added — `\overset` / `\underset` / `\stackrel` → neutral `Overset` / `Underset`

--- a/code/packages/rust/latex/Cargo.toml
+++ b/code/packages/rust/latex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latex"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 description = "A full-fidelity LaTeX parser (documents and math): a catcode-driven, text-mode-primary tokenizer and (in later layers) a structural + math parser producing a faithful AST. Standalone and reusable; will also implement the math-frontend MathFrontend trait."
 license = "MIT"

--- a/code/packages/rust/latex/README.md
+++ b/code/packages/rust/latex/README.md
@@ -33,7 +33,7 @@ with a **text-mode-primary** mode stack (LaTeX starts in text mode; math is ente
 | **L0 tokenizer** | catcode state machine → flat `Token` stream w/ byte spans | ✅ |
 | **L1 structural** | groups, `\cmd[opt]{arg}`, `\begin{env}…\end{env}`, text runs, raw math islands, `to_latex()` round-trip | ✅ |
 | **L2 math** | math AST (frac, binom, roots, scripts, big ops, functions, accents, `\left\right` fences, relations), precedence-climbing parser, `to_latex()` round-trip | ✅ |
-| **L3 environments** | math env family — `matrix`/`pmatrix`/`bmatrix`/`vmatrix`/`cases`/`aligned`/`align` split on `&` and `\\` → `MathNode::Matrix`, round-trip; nesting + scripts | ✅ |
+| **L3 environments** | math env family — `matrix`/`pmatrix`/`bmatrix`/`vmatrix`/`cases`/`aligned`/`align` plus `array`/`subarray` (mandatory `{col-spec}`) split on `&` and `\\` → `MathNode::Matrix`, round-trip; nesting + scripts | ✅ |
 | **L4 macros** | `\newcommand`/`\renewcommand`/`\providecommand` with positional `#1`..`#9`; bounded recursive expansion via `expand()` (L4a) | ✅ |
 | **L5 text breadth** | `\verb`/`verbatim` raw (L5a/b) + text accents `\'e`/`\c{c}` via `recognize_accents` (L5c) + sectioning/refs/preamble/font via `recognize_structure` (L5d) | ✅ |
 | **L6 frontend** | `LatexMath` implements `math-frontend::MathFrontend` — lifts `MathNode` → neutral `MathExpr`; LaTeX is plugin #1 via `registry()` (default-on `frontend` feature) | ✅ |
@@ -76,25 +76,31 @@ assert!(matches!(area, MathNode::Bin(..)));   // π · r²  (implicit multiplica
 
 ### Environments (L3)
 
-The math environment family parses into `MathNode::Matrix { env, rows }` — `&` splits
-columns, `\\` splits rows. Supported: `matrix`/`pmatrix`/`bmatrix`/`Bmatrix`/`vmatrix`/
-`Vmatrix`/`smallmatrix`, `cases`, and the alignment environments (`aligned`/`align`/…).
-Cells hold arbitrary math, environments nest, and a matrix is an atom (so `…^2` attaches):
+The math environment family parses into `MathNode::Matrix { env, col_spec, rows }` — `&`
+splits columns, `\\` splits rows. Supported: `matrix`/`pmatrix`/`bmatrix`/`Bmatrix`/`vmatrix`/
+`Vmatrix`/`smallmatrix`, `cases`, the alignment environments (`aligned`/`align`/…), and the
+general `array`/`subarray` grids. Cells hold arbitrary math, environments nest, and a matrix
+is an atom (so `…^2` attaches):
 
 ```rust
 use latex::{parse_math, MathNode};
 
 let m = parse_math(r"\begin{pmatrix} a & b \\ c & d \end{pmatrix}").unwrap();
-if let MathNode::Matrix { env, rows } = &m {
+if let MathNode::Matrix { env, col_spec, rows } = &m {
     assert_eq!(env, "pmatrix");
+    assert_eq!(*col_spec, None);        // pmatrix takes no column-spec argument
     assert_eq!(rows.len(), 2);          // two rows
     assert_eq!(rows[0].len(), 2);       // two columns
 }
 assert_eq!(parse_math(&m.to_latex()).unwrap(), m);   // round-trips
 ```
 
-`array`/`tabular` (which take a column-spec argument) and document-mode list environments
-are a later layer; an unknown `\begin{…}` is rejected with a spanned error, never mis-parsed.
+`array` and `subarray` carry a **mandatory column-spec argument** — `\begin{array}{l|cr}` —
+captured verbatim on `col_spec` (`Some("l|cr")`) so the node round-trips. Alignment is
+presentation, so the neutral `MathExpr` lowering **drops** `col_spec`: an `array` and the
+equivalent `pmatrix` lower to the same `MathExpr::Matrix`. The text-mode `tabular` family and
+document-mode list environments are a later layer; an unknown `\begin{…}` (or an `array`
+missing its column-spec) is rejected with a spanned error, never mis-parsed.
 
 ### Macros (L4a)
 

--- a/code/packages/rust/latex/src/frontend.rs
+++ b/code/packages/rust/latex/src/frontend.rs
@@ -629,6 +629,23 @@ mod tests {
     }
 
     #[test]
+    fn array_lowers_dropping_column_spec() {
+        // The `{cc}` alignment argument is presentation (PFE01 §2.2) — the neutral lowering
+        // drops it, so an `array` lowers to the SAME MathExpr::Matrix as the equivalent
+        // pmatrix. Two source strings that mean the same math produce the same MathExpr.
+        let from_array = m(r"\begin{array}{cc} a & b \\ c & d \end{array}");
+        let from_pmatrix = m(r"\begin{pmatrix} a & b \\ c & d \end{pmatrix}");
+        assert_eq!(from_array, from_pmatrix);
+        match &from_array {
+            MathExpr::Matrix(rows) => {
+                assert_eq!(rows.len(), 2);
+                assert_eq!(rows[1][1], MathExpr::Symbol("d".into()));
+            }
+            other => panic!("expected Matrix, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn numbers_stay_exact_not_f64() {
         assert_eq!(m("0.1"), MathExpr::Number(Number::parse("0.1").unwrap()));
         // and the numerator of a fraction is an exact Number, not a float.

--- a/code/packages/rust/latex/src/math.rs
+++ b/code/packages/rust/latex/src/math.rs
@@ -122,17 +122,28 @@ pub enum MathNode {
     /// A relation: `a = b`, `x \le y`.
     Rel(MRelOp, Box<MathNode>, Box<MathNode>),
     /// A math environment with row/column structure (L3): the `matrix` family
-    /// (`matrix`/`pmatrix`/`bmatrix`/`vmatrix`/…), `cases`, and the alignment environments
-    /// (`aligned`/`align`). `rows` is a list of rows; each row is a list of cells, split on
-    /// `&` (columns) and `\\` (rows). `env` is the environment name verbatim (case-sensitive,
-    /// so `bmatrix` ≠ `Bmatrix`), which also fixes the delimiters when rendered.
+    /// (`matrix`/`pmatrix`/`bmatrix`/`vmatrix`/…), `cases`, the alignment environments
+    /// (`aligned`/`align`), and the general `array`/`subarray` grids. `rows` is a list of
+    /// rows; each row is a list of cells, split on `&` (columns) and `\\` (rows). `env` is the
+    /// environment name verbatim (case-sensitive, so `bmatrix` ≠ `Bmatrix`), which also fixes
+    /// the delimiters when rendered.
+    ///
+    /// `col_spec` is the **mandatory column-alignment argument** of `\begin{array}{…}` /
+    /// `\begin{subarray}{…}` — e.g. `"ccc"`, `"l|r"`, `"p{3cm}"` — captured verbatim so the
+    /// node round-trips (`to_latex` re-emits it). It is `None` for every other environment
+    /// (which take no such argument). Alignment is *presentation*: the neutral `MathExpr`
+    /// lowering drops `col_spec` entirely (an `array` and a `pmatrix` with the same cells lower
+    /// to the same `MathExpr::Matrix`), per PFE01 §2.2.
     ///
     /// ```text
     ///   \begin{pmatrix} a & b \\ c & d \end{pmatrix}
-    ///   → Matrix { env: "pmatrix", rows: [[a, b], [c, d]] }
+    ///   → Matrix { env: "pmatrix", col_spec: None,        rows: [[a, b], [c, d]] }
+    ///   \begin{array}{cc} a & b \\ c & d \end{array}
+    ///   → Matrix { env: "array",   col_spec: Some("cc"),  rows: [[a, b], [c, d]] }
     /// ```
     Matrix {
         env: String,
+        col_spec: Option<String>,
         rows: Vec<Vec<MathNode>>,
     },
 }
@@ -285,10 +296,11 @@ fn is_text(name: &str) -> bool {
     )
 }
 /// Math environments with `&`/`\\` row/column structure (L3). Case-sensitive — `bmatrix`
-/// (square brackets) and `Bmatrix` (braces) are different environments. The `array`/`tabular`
-/// family (which take a mandatory column-spec argument) and document-mode list environments
-/// are deliberately **not** here — they need an extra field on the node and arrive in a
-/// later layer; an unknown `\begin{…}` is rejected with a spanned error, never mis-parsed.
+/// (square brackets) and `Bmatrix` (braces) are different environments. The `array`/`subarray`
+/// grids take a **mandatory** column-spec argument (`\begin{array}{cc}`) — see
+/// [`env_takes_col_spec`]; it is stored on [`MathNode::Matrix::col_spec`]. The text-mode
+/// `tabular` family and document-mode list environments are deliberately **not** here; an
+/// unknown `\begin{…}` is rejected with a spanned error, never mis-parsed.
 fn is_math_env(name: &str) -> bool {
     matches!(
         name,
@@ -306,7 +318,16 @@ fn is_math_env(name: &str) -> bool {
             | "align"
             | "align*"
             | "split"
+            | "array"
+            | "subarray"
     )
+}
+
+/// Which math environments require the mandatory `{column-spec}` argument right after
+/// `\begin{…}`. `array` (`\begin{array}{l|cr} …`) and `subarray` (`\begin{subarray}{c} …`,
+/// used inside big-operator limits) do; every matrix/cases/alignment environment does not.
+fn env_takes_col_spec(name: &str) -> bool {
+    matches!(name, "array" | "subarray")
 }
 
 /// The `_lower` and `^upper` bound scripts captured for a big operator.
@@ -784,8 +805,74 @@ impl<'a> MathParser<'a> {
         if !is_math_env(&env) {
             return self.err(format!("unsupported environment: {env}"));
         }
+        // `array`/`subarray` carry a mandatory `{column-spec}` argument before the grid body.
+        let col_spec = if env_takes_col_spec(&env) {
+            Some(self.read_col_spec(&env)?)
+        } else {
+            None
+        };
         let rows = self.parse_env_rows(&env)?;
-        Ok(MathNode::Matrix { env, rows })
+        Ok(MathNode::Matrix { env, col_spec, rows })
+    }
+
+    /// Read the mandatory `{column-spec}` argument of `\begin{array}{…}` (and `subarray`).
+    /// The spec is captured as its literal text — column letters (`l`/`c`/`r`), `|` rules,
+    /// `p{3cm}` paragraph columns, `*{n}{…}` repeats, `@{…}`/`>{…}`/`<{…}` inserts — so the
+    /// node round-trips exactly; the neutral lowering drops it (alignment is presentation).
+    ///
+    /// Brace-nesting aware (so `p{3cm}` is captured whole) and **iterative**: a `depth`
+    /// counter over a flat loop, never recursion, so an adversarial `{{{{…` cannot overflow
+    /// the stack — it is bounded by the input length, like the rest of the tokenizer output.
+    fn read_col_spec(&mut self, env: &str) -> Result<String, ParseError> {
+        if !matches!(self.peek().kind, TokenKind::BeginGroup) {
+            return self.err(format!("expected '{{column-spec}}' after \\begin{{{env}}}"));
+        }
+        self.bump(); // opening {
+        let mut spec = String::new();
+        let mut depth = 1usize;
+        loop {
+            match self.peek().kind.clone() {
+                TokenKind::BeginGroup => {
+                    depth += 1;
+                    spec.push('{');
+                    self.bump();
+                }
+                TokenKind::EndGroup => {
+                    self.bump();
+                    depth -= 1;
+                    if depth == 0 {
+                        return Ok(spec);
+                    }
+                    spec.push('}');
+                }
+                TokenKind::Char(c) => {
+                    spec.push(c);
+                    self.bump();
+                }
+                TokenKind::Space => {
+                    spec.push(' ');
+                    self.bump();
+                }
+                // `>{\centering}` etc. embed control sequences in the spec; keep them verbatim.
+                TokenKind::ControlWord(w) => {
+                    spec.push('\\');
+                    spec.push_str(&w);
+                    spec.push(' '); // a control word needs a trailing space so it re-lexes whole
+                    self.bump();
+                }
+                TokenKind::ControlSymbol(c) => {
+                    spec.push('\\');
+                    spec.push(c);
+                    self.bump();
+                }
+                TokenKind::Eof => {
+                    return self.err(format!("unterminated column-spec in \\begin{{{env}}}"));
+                }
+                other => {
+                    return self.err(format!("unexpected token in column-spec: {other:?}"));
+                }
+            }
+        }
     }
 
     /// Read an environment name from the `{…}` after `\begin`/`\end`. Names are letters with
@@ -1051,10 +1138,16 @@ impl MathNode {
                 out.push_str(opstr);
                 Self::write_child(b, out, 2);
             }
-            MathNode::Matrix { env, rows } => {
+            MathNode::Matrix { env, col_spec, rows } => {
                 out.push_str("\\begin{");
                 out.push_str(env);
                 out.push('}');
+                // `array`/`subarray` re-emit their mandatory `{column-spec}` argument.
+                if let Some(spec) = col_spec {
+                    out.push('{');
+                    out.push_str(spec);
+                    out.push('}');
+                }
                 for (ri, row) in rows.iter().enumerate() {
                     if ri > 0 {
                         out.push_str(" \\\\ ");
@@ -1290,7 +1383,7 @@ mod tests {
     fn pmatrix_two_by_two() {
         let n = parse_math(r"\begin{pmatrix} a & b \\ c & d \end{pmatrix}").unwrap();
         match &n {
-            MathNode::Matrix { env, rows } => {
+            MathNode::Matrix { env, rows, .. } => {
                 assert_eq!(env.as_str(), "pmatrix");
                 assert_eq!(
                     rows,
@@ -1322,7 +1415,7 @@ mod tests {
         // \begin{cases} f & cond \\ g & cond \end{cases}
         let n = parse_math(r"\begin{cases} 1 & x > 0 \\ 0 & x \le 0 \end{cases}").unwrap();
         match &n {
-            MathNode::Matrix { env, rows } => {
+            MathNode::Matrix { env, rows, .. } => {
                 assert_eq!(env.as_str(), "cases");
                 assert_eq!(rows.len(), 2);
                 assert_eq!(rows[0].len(), 2);
@@ -1402,6 +1495,104 @@ mod tests {
         assert!(parse_math(r"\begin{matrix} & b \end{matrix}").is_err()); // empty cell (limitation)
         assert!(parse_math(r"\end{matrix}").is_err()); // stray \end
         assert!(parse_math(r"\begin matrix").is_err()); // missing { after \begin
+    }
+
+    // ---- L3: the `array` / `subarray` grids (mandatory column-spec) -------------
+
+    #[test]
+    fn array_captures_column_spec_and_cells() {
+        // \begin{array}{cc} a & b \\ c & d \end{array} — the {cc} is the alignment argument,
+        // captured on col_spec; the grid is the same shape as a pmatrix.
+        let n = parse_math(r"\begin{array}{cc} a & b \\ c & d \end{array}").unwrap();
+        match &n {
+            MathNode::Matrix { env, col_spec, rows } => {
+                assert_eq!(env.as_str(), "array");
+                assert_eq!(col_spec.as_deref(), Some("cc"));
+                assert_eq!(
+                    rows,
+                    &vec![vec![sym("a"), sym("b")], vec![sym("c"), sym("d")]]
+                );
+            }
+            other => panic!("expected Matrix, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn array_column_spec_keeps_rules_and_alignment_letters() {
+        // Vertical rules (`|`) and l/c/r letters are part of the spec and captured verbatim.
+        let n = parse_math(r"\begin{array}{l|cr} 1 & 2 & 3 \end{array}").unwrap();
+        match &n {
+            MathNode::Matrix { col_spec, rows, .. } => {
+                assert_eq!(col_spec.as_deref(), Some("l|cr"));
+                assert_eq!(rows, &vec![vec![num("1"), num("2"), num("3")]]);
+            }
+            other => panic!("expected Matrix, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn array_column_spec_handles_braced_groups() {
+        // `p{3cm}` is a paragraph column whose own `{…}` must be captured whole (nesting-aware).
+        let n = parse_math(r"\begin{array}{p{3cm}c} a & b \end{array}").unwrap();
+        match &n {
+            MathNode::Matrix { col_spec, .. } => {
+                assert_eq!(col_spec.as_deref(), Some("p{3cm}c"));
+            }
+            other => panic!("expected Matrix, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn subarray_takes_a_column_spec_too() {
+        // \begin{subarray}{c} … \end{subarray} (used inside big-operator limits).
+        let n = parse_math(r"\begin{subarray}{c} i \\ j \end{subarray}").unwrap();
+        match &n {
+            MathNode::Matrix { env, col_spec, rows } => {
+                assert_eq!(env.as_str(), "subarray");
+                assert_eq!(col_spec.as_deref(), Some("c"));
+                assert_eq!(rows, &vec![vec![sym("i")], vec![sym("j")]]);
+            }
+            other => panic!("expected Matrix, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn array_round_trips_through_to_latex() {
+        // parse → to_latex → parse must be a fixed point, col-spec and all.
+        for src in [
+            r"\begin{array}{cc} a & b \\ c & d \end{array}",
+            r"\begin{array}{l|cr} 1 & 2 & 3 \end{array}",
+            r"\begin{array}{p{3cm}c} a & b \end{array}",
+            r"\begin{subarray}{c} i \\ j \end{subarray}",
+        ] {
+            let once = parse_math(src).unwrap();
+            let twice = parse_math(&once.to_latex()).unwrap();
+            assert_eq!(once, twice, "round-trip changed the tree for {src:?}");
+        }
+    }
+
+    #[test]
+    fn matrix_family_still_has_no_column_spec() {
+        // Environments that take no alignment argument keep col_spec == None.
+        let n = parse_math(r"\begin{pmatrix} a \end{pmatrix}").unwrap();
+        assert!(matches!(n, MathNode::Matrix { col_spec: None, .. }));
+    }
+
+    #[test]
+    fn array_without_column_spec_is_a_spanned_error() {
+        // The `{col-spec}` argument is mandatory — its absence is a clean error, not a panic.
+        assert!(parse_math(r"\begin{array} a & b \end{array}").is_err());
+        assert!(parse_math(r"\begin{array}{cc} a & b").is_err()); // unterminated body
+        assert!(parse_math(r"\begin{array}{cc a \end{array}").is_err()); // unterminated col-spec
+    }
+
+    #[test]
+    fn deep_column_spec_braces_do_not_overflow() {
+        // An adversarial `{{{{…}}}}` inside the col-spec is captured by a flat depth counter,
+        // never recursion, so it cannot overflow the stack.
+        let spec = format!("{}{}", "{".repeat(20_000), "}".repeat(20_000));
+        let src = format!(r"\begin{{array}}{{{spec}}} a \end{{array}}");
+        assert!(parse_math(&src).is_ok());
     }
 
     // ---- deep-tree Drop safety -------------------------------------------------

--- a/code/specs/LTX01-full-latex-parser.md
+++ b/code/specs/LTX01-full-latex-parser.md
@@ -82,7 +82,7 @@ pub enum MathNode {
     Fenced { left: Delim, body: Box<MathNode>, right: Delim },   // \left( … \right)
     Group(Box<MathNode>), Text(String),
     Rel(RelOp, Box<MathNode>, Box<MathNode>),
-    Matrix { env: String, rows: Vec<Vec<MathNode>> },
+    Matrix { env: String, col_spec: Option<String>, rows: Vec<Vec<MathNode>> },
 }
 ```
 
@@ -132,14 +132,18 @@ is text-primary, which is a different mode model.)
 - **L3 — environment semantics.** Split into two sub-rungs:
   - **L3a (shipped) — math environment family.** The matrix family
     (`matrix`/`pmatrix`/`bmatrix`/`Bmatrix`/`vmatrix`/`Vmatrix`/`smallmatrix`), `cases`,
-    and the alignment environments (`aligned`/`gathered`/`align`/`align*`/`split`) parsed
-    inside math islands via `&` (columns) and `\\` (rows) → `MathNode::Matrix { env, rows }`,
-    with `to_latex` round-trip, nesting, and postfix scripts. Empty cells are a documented
-    limitation (spanned error). Implemented in the `latex` crate (math.rs).
-  - **L3b (later) — document-mode tables & lists.** Row/column structure for `tabular`/`array`
-    (which take a mandatory column-spec argument) and list environments
-    (`itemize`/`enumerate`/`description`) with `\item`, operating on the document `Node` tree.
-    Deferred because they need an extra column-spec field on the node; an unknown
+    the alignment environments (`aligned`/`gathered`/`align`/`align*`/`split`), and the general
+    **`array`/`subarray` grids** parsed inside math islands via `&` (columns) and `\\` (rows) →
+    `MathNode::Matrix { env, col_spec, rows }`, with `to_latex` round-trip, nesting, and postfix
+    scripts. `array`/`subarray` carry a **mandatory `{column-spec}` argument** (`\begin{array}{l|cr}`)
+    captured verbatim on `col_spec` (`None` for every other environment); the neutral lowering drops
+    it (alignment is presentation, PFE01 §2.2), so `array` ≡ `pmatrix` as `MathExpr::Matrix`. The
+    col-spec reader is brace-nesting-aware yet iterative (no stack-overflow on adversarial `{{{…`).
+    Empty cells, a missing col-spec, and an unterminated env are documented spanned errors.
+    Implemented in the `latex` crate (math.rs).
+  - **L3b (later) — document-mode tables & lists.** Row/column structure for the text-mode
+    `tabular` family and list environments (`itemize`/`enumerate`/`description`) with `\item`,
+    operating on the document `Node` tree. (Math-mode `array`/`subarray` shipped in L3a.) An unknown
     `\begin{…}` is rejected with a spanned error in the meantime, never mis-parsed.
 - **L4 — macros.** Split into sub-rungs:
   - **L4a (shipped) — positional macros.** `\newcommand`/`\renewcommand`/`\providecommand`


### PR DESCRIPTION
## `latex` L3a — the `array` / `subarray` math environments

The matrix family (`pmatrix`/`bmatrix`/`cases`/`aligned`/…) was already parsed, but the general **`array`** grid was the documented gap. The comment on `is_math_env` explicitly parked it for "a later layer" because it "need[s] an extra field on the node" — its mandatory `{column-spec}` argument. **That field is now here.**

### What's added
- **`\begin{array}{cols} … \end{array}`** and its big-operator-limit cousin **`\begin{subarray}{c} …`** — the two math environments that take a mandatory column-alignment argument.
- New optional field **`MathNode::Matrix { col_spec: Option<String>, … }`**: the spec is captured **verbatim** (`"cc"`, `"l|cr"`, `"p{3cm}"`, `*{n}{…}`, `>{…}`/`<{…}`/`@{…}` inserts), so the node **round-trips** — `to_latex` re-emits `\begin{array}{<spec>}`. `None` for every environment that takes no argument (a `pmatrix` is unchanged).
- The neutral **lowering drops `col_spec`** (alignment is presentation, PFE01 §2.2): an `array` and the equivalent `pmatrix` lower to the **same** `MathExpr::Matrix`. Consumers gain `array` for free — no consumer change, no new neutral node, no capability change.

### Safety
`read_col_spec` reads the `{…}` argument with a **flat `depth` counter, not recursion** — brace-nesting-aware (captures `p{3cm}` whole) yet an adversarial `{{{{…` cannot overflow the stack (bounded by input length). A missing or unterminated col-spec is a clean **spanned error**, never a panic. `#![forbid(unsafe_code)]` preserved.

### Verification
- **9 new tests** (cells+spec, rules/alignment letters, braced groups, subarray, round-trip, matrix-family-still-`None`, missing-spec error, 20k-deep-brace no-overflow, frontend `array ≡ pmatrix`).
- **150** `latex` unit + doc tests pass; **clippy `-D warnings`** clean.
- Downstream **`adj-lang`** (the only consumer) **86** green; affected frontend family (`math-frontend`/`asciimath`/`unicode-math`) builds clean.
- `/security-review` (parser DoS/panic/overflow focus, diff inline) → **PASSED** (verified `depth` underflow-safety, termination, no-overflow, no-panic on the real code).
- Spec `LTX01-full-latex-parser.md` §L3 updated (array/subarray now in L3a; L3b narrowed to text-mode `tabular` + lists). latex **0.15.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)