### PR TITLE
fix(sir-rust): guard emitted runtime against cyclic Seq/Map (format/value_eq)

### DIFF
--- a/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
@@ -1,5 +1,54 @@
 # Changelog
 
+## 0.4.1 — harden emitted runtime against cyclic Seq/Map
+
+`Value::Seq`/`Value::Map` are shared, *mutable* handles, so an emitted
+program can build a cyclic structure (`xs = []; xs[0] = xs`).  Before this
+release the emitted runtime walked such values structurally with no cycle
+protection, so a cyclic value could:
+
+- **`format`** — recurse forever and overflow the stack while printing.
+- **`value_eq`** — recurse forever when comparing two *distinct* cyclic
+  structures (a self-cycle was already short-circuited by the `Rc::ptr_eq`
+  fast path, but distinct cyclic operands were not).
+- **`map_get`/`map_set`/`map_lit`** — hit a `RefCell` "already mutably
+  borrowed" panic when a self-referential key was compared while the map's
+  entries were `borrow_mut`'d.
+
+This is a robustness fix only — the public runtime API and the printed
+form of every *non-cyclic* value are byte-identical (all existing tests
+pass unchanged).
+
+### Fixed
+
+- **`format` / `format_seq` / `format_map`** now thread a visited-pointer
+  set (`HashSet<usize>` of each Seq/Map `Rc` handle address).  A handle is
+  inserted on entry and removed on exit, so it is only "seen" along the
+  *current* path: a true cycle re-entering a handle within its own subtree
+  prints a placeholder (`[...]` for a seq, `{...}` for a map) and returns
+  instead of recursing, while a value reached twice by sibling
+  (non-cyclic) paths still prints in full.  `format_pair` threads the set
+  too (a pair can hold a cyclic seq/map).
+- **`value_eq`** keeps the `Rc::ptr_eq` identity fast path and adds a
+  co-inductive `pending` set of handle-pairs currently being compared:
+  re-encountering a pair already in flight (a cycle matched in lock-step)
+  is treated as equal, bounding the deep comparison of two distinct cyclic
+  operands so it always terminates.
+- **`map_get` / `map_set` / `map_lit`** no longer call `value_eq` while
+  holding a borrow on the same map's entries: each snapshots/collects the
+  comparison inputs and resolves to an *index* before taking the borrow it
+  needs for the read/write, so a self-referential key can no longer trigger
+  an "already borrowed" panic.
+
+### Tests
+
+- New `tests/compile_and_run_cyclic.rs` integration test: hand-builds a
+  module that constructs a cyclic seq (`xs = [0]; xs[0] = xs; print(xs)`),
+  emits Rust, compiles it with `rustc`, runs it, and asserts the program
+  *terminates* and prints the `[...]` placeholder.  It also checks that
+  `value_eq` terminates on both a self-cyclic operand (via `ptr_eq`) and
+  two *distinct* cyclic structures (via the co-inductive guard).
+
 ## 0.4.0 — SIR16 Sequences + Maps (completes SIR16 / v1 parity)
 
 The final two SIR-v1 (SIR16) features land in the Rust backend.  With

--- a/code/packages/rust/semantic-ir-to-rust/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-rust"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 description = "Semantic IR → self-contained Rust source code (SIR13). Second backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
@@ -277,7 +277,37 @@ pub const RUNTIME: &str = r##"mod __sir {
     }
 
     // ── format ────────────────────────────────────────────────────
+    //
+    // Cycle safety.  `Value::Seq`/`Value::Map` are *shared, mutable*
+    // handles, so an emitted program can build a cyclic structure
+    // (`xs = []; xs[0] = xs`).  A naive structural walk would recurse
+    // forever and blow the stack.  We guard the recursion with a
+    // `visited` set of the `Rc` handle addresses *currently on the
+    // active path*: a handle is inserted on entry and removed on exit.
+    //
+    // Removing on exit (rather than leaving it set for the whole walk)
+    // is deliberate — it means a value reached twice by two *sibling*
+    // (non-cyclic) paths still prints in full both times; only a handle
+    // that re-appears *within its own subtree* (a true cycle) is
+    // short-circuited to a placeholder (`[...]` for a seq, `{...}` for a
+    // map).  See `handle_id` for how a stable per-handle key is derived.
     pub fn format(v: &Value) -> String {
+        let mut visited: std::collections::HashSet<usize> = std::collections::HashSet::new();
+        format_d(v, &mut visited)
+    }
+
+    // A stable identity for a shared handle: the address of the
+    // `RefCell` the `Rc` points at, narrowed to a plain `usize`.  Two
+    // `Value`s alias the same backing store iff their `handle_id`s match.
+    fn seq_handle_id(items: &Rc<RefCell<Vec<Value>>>) -> usize {
+        Rc::as_ptr(items) as *const () as usize
+    }
+
+    fn map_handle_id(entries: &Rc<RefCell<Vec<(Value, Value)>>>) -> usize {
+        Rc::as_ptr(entries) as *const () as usize
+    }
+
+    fn format_d(v: &Value, visited: &mut std::collections::HashSet<usize>) -> String {
         match v {
             Value::Int(n) => n.to_string(),
             // `{:?}` keeps a trailing `.0` on integral floats (`3.0`,
@@ -290,39 +320,60 @@ pub const RUNTIME: &str = r##"mod __sir {
             Value::Nil => "nil".to_string(),
             Value::Sym(s) => s.to_string(),
             Value::Str(s) => s.to_string(),
-            Value::Pair(p) => format_pair(p),
+            Value::Pair(p) => format_pair_d(p, visited),
             Value::Closure(_) => "<closure>".to_string(),
             // Sequences print like a bracketed list: `[1, 2, 3]`.
-            Value::Seq(items) => format_seq(&items.borrow()),
+            Value::Seq(items) => {
+                let id = seq_handle_id(items);
+                if !visited.insert(id) {
+                    // Already on the active path ⇒ cycle.  Print a
+                    // placeholder instead of recursing forever.
+                    return "[...]".to_string();
+                }
+                let out = format_seq_d(&items.borrow(), visited);
+                visited.remove(&id);
+                out
+            }
             // Maps print like a brace-wrapped entry list in insertion
             // order: `{a: 1, b: 2}`.
-            Value::Map(entries) => format_map(&entries.borrow()),
+            Value::Map(entries) => {
+                let id = map_handle_id(entries);
+                if !visited.insert(id) {
+                    return "{...}".to_string();
+                }
+                let out = format_map_d(&entries.borrow(), visited);
+                visited.remove(&id);
+                out
+            }
         }
     }
 
-    fn format_seq(items: &[Value]) -> String {
+    fn format_seq_d(items: &[Value], visited: &mut std::collections::HashSet<usize>) -> String {
         let mut out = String::new();
         out.push('[');
         for (i, item) in items.iter().enumerate() {
             if i > 0 {
                 out.push_str(", ");
             }
-            out.push_str(&format(item));
+            out.push_str(&format_d(item, visited));
         }
         out.push(']');
         out
     }
 
-    fn format_map(entries: &[(Value, Value)]) -> String {
+    fn format_map_d(
+        entries: &[(Value, Value)],
+        visited: &mut std::collections::HashSet<usize>,
+    ) -> String {
         let mut out = String::new();
         out.push('{');
         for (i, (k, v)) in entries.iter().enumerate() {
             if i > 0 {
                 out.push_str(", ");
             }
-            out.push_str(&format(k));
+            out.push_str(&format_d(k, visited));
             out.push_str(": ");
-            out.push_str(&format(v));
+            out.push_str(&format_d(v, visited));
         }
         out.push('}');
         out
@@ -338,22 +389,26 @@ pub const RUNTIME: &str = r##"mod __sir {
         }
     }
 
-    fn format_pair(p: &Pair) -> String {
+    // `Pair`s are immutable (no shared `RefCell`), so a pair-chain can
+    // never form a cycle on its own.  It can, however, *contain* a
+    // cyclic seq/map in a `car`/`cdr`, so we still thread `visited`
+    // through to the element formatters.
+    fn format_pair_d(p: &Pair, visited: &mut std::collections::HashSet<usize>) -> String {
         let mut out = String::new();
         out.push('(');
-        out.push_str(&format(&p.car));
+        out.push_str(&format_d(&p.car, visited));
         let mut rest = p.cdr.clone();
         loop {
             match rest {
                 Value::Pair(inner) => {
                     out.push(' ');
-                    out.push_str(&format(&inner.car));
+                    out.push_str(&format_d(&inner.car, visited));
                     rest = inner.cdr.clone();
                 }
                 Value::Nil => break,
                 other => {
                     out.push_str(" . ");
-                    out.push_str(&format(&other));
+                    out.push_str(&format_d(&other, visited));
                     break;
                 }
             }
@@ -475,12 +530,19 @@ pub const RUNTIME: &str = r##"mod __sir {
     // mirroring object/dict literal semantics) while keeping first-seen
     // insertion order.
     pub fn map_lit(entries: Vec<(Value, Value)>) -> Value {
+        // `store` is a plain local `Vec` (not yet wrapped in the shared
+        // `Rc<RefCell<…>>`), so the `value_eq` key comparisons below
+        // cannot collide with a borrow of the map under construction —
+        // even for a self-referential key, which can only be an *already
+        // built* map handle, never this not-yet-published `store`.
         let mut store: Vec<(Value, Value)> = Vec::with_capacity(entries.len());
         for (k, v) in entries {
-            if let Some(slot) = store.iter_mut().find(|(ek, _)| value_eq(ek, &k)) {
-                slot.1 = v;
-            } else {
-                store.push((k, v));
+            // Resolve the slot index without holding any iterator borrow
+            // across the (recursive) `value_eq` call.
+            let found = store.iter().position(|(ek, _)| value_eq(ek, &k));
+            match found {
+                Some(i) => store[i].1 = v,
+                None => store.push((k, v)),
             }
         }
         Value::Map(Rc::new(RefCell::new(store)))
@@ -492,12 +554,22 @@ pub const RUNTIME: &str = r##"mod __sir {
     // backend's `?? null`).
     pub fn map_get(map: &Value, key: &Value) -> Value {
         match map {
-            Value::Map(entries) => entries
-                .borrow()
-                .iter()
-                .find(|(k, _)| value_eq(k, key))
-                .map(|(_, v)| v.clone())
-                .unwrap_or(Value::Nil),
+            Value::Map(entries) => {
+                // Snapshot the entries (a shallow `Rc`-handle clone per
+                // value) and drop the borrow *before* running `value_eq`.
+                // A self-referential key would otherwise re-enter this
+                // same cell while it's still borrowed; `value_eq` on a
+                // cyclic value can deep-walk, so we must not hold a borrow
+                // across it.  (A shared borrow would tolerate a nested
+                // shared re-borrow, but scoping it is clearer and keeps
+                // `map_get`/`map_set`/`map_lit` uniform.)
+                let snapshot = entries.borrow().clone();
+                snapshot
+                    .iter()
+                    .find(|(k, _)| value_eq(k, key))
+                    .map(|(_, v)| v.clone())
+                    .unwrap_or(Value::Nil)
+            }
             other => panic!("map-get on non-map: {}", format(other)),
         }
     }
@@ -509,11 +581,22 @@ pub const RUNTIME: &str = r##"mod __sir {
     pub fn map_set(map: &Value, key: Value, value: Value) -> Value {
         match map {
             Value::Map(entries) => {
+                // Find the matching slot *without* holding a `borrow_mut`
+                // across `value_eq`: take a short shared borrow, snapshot
+                // the keys, drop it, then compare.  A self-referential key
+                // (`d["self"] = d` then looking it up) would otherwise
+                // re-borrow this very cell inside `value_eq` and panic with
+                // "already mutably borrowed".  Resolving to an *index*
+                // first lets us re-borrow mutably only for the write.
+                let index = {
+                    let keys: Vec<Value> =
+                        entries.borrow().iter().map(|(k, _)| k.clone()).collect();
+                    keys.iter().position(|k| value_eq(k, &key))
+                };
                 let mut entries = entries.borrow_mut();
-                if let Some(slot) = entries.iter_mut().find(|(k, _)| value_eq(k, &key)) {
-                    slot.1 = value.clone();
-                } else {
-                    entries.push((key, value.clone()));
+                match index {
+                    Some(i) => entries[i].1 = value.clone(),
+                    None => entries.push((key, value.clone())),
                 }
                 value
             }
@@ -545,7 +628,26 @@ pub const RUNTIME: &str = r##"mod __sir {
         args.iter().any(|v| matches!(v, Value::Float(_)))
     }
 
+    // Public structural equality.  Cycle safety: two *distinct* cyclic
+    // structures (e.g. `xs[0]=xs` and `ys[0]=ys`, separate handles) would
+    // make a naive deep walk recurse forever, because the `Rc::ptr_eq`
+    // fast path only catches a value compared against *itself*.  We bound
+    // the walk co-inductively with a `pending` set of handle-pairs
+    // currently being compared: re-encountering a pair already in flight
+    // means we've closed a cycle in lock-step, so we treat that pair as
+    // equal (the standard co-inductive definition of bisimulation
+    // equality).  This terminates for *any* pair of finite-handle graphs.
     fn value_eq(a: &Value, b: &Value) -> bool {
+        let mut pending: std::collections::HashSet<(usize, usize)> =
+            std::collections::HashSet::new();
+        value_eq_d(a, b, &mut pending)
+    }
+
+    fn value_eq_d(
+        a: &Value,
+        b: &Value,
+        pending: &mut std::collections::HashSet<(usize, usize)>,
+    ) -> bool {
         match (a, b) {
             (Value::Int(x), Value::Int(y)) => x == y,
             // Cross-representation numeric equality (`1 == 1.0`) holds,
@@ -559,7 +661,7 @@ pub const RUNTIME: &str = r##"mod __sir {
             (Value::Sym(x), Value::Sym(y)) => x == y,
             (Value::Str(x), Value::Str(y)) => **x == **y,
             (Value::Pair(x), Value::Pair(y)) => {
-                value_eq(&x.car, &y.car) && value_eq(&x.cdr, &y.cdr)
+                value_eq_d(&x.car, &y.car, pending) && value_eq_d(&x.cdr, &y.cdr, pending)
             }
             // Sequences and maps compare *structurally* (element-wise),
             // matching how `Pair` compares — `[1, 2] = [1, 2]` is true,
@@ -570,20 +672,44 @@ pub const RUNTIME: &str = r##"mod __sir {
             // because `map_lit`/`map_set` keep a canonical first-seen
             // order, so equal maps built the same way share that order.
             (Value::Seq(x), Value::Seq(y)) => {
-                Rc::ptr_eq(x, y) || {
-                    let (xb, yb) = (x.borrow(), y.borrow());
-                    xb.len() == yb.len()
-                        && xb.iter().zip(yb.iter()).all(|(a, b)| value_eq(a, b))
+                if Rc::ptr_eq(x, y) {
+                    return true;
                 }
+                let pair = (seq_handle_id(x), seq_handle_id(y));
+                // Already comparing this exact handle-pair higher up the
+                // stack ⇒ we've matched in lock-step around a cycle.
+                // Assume equal; if the structures genuinely differ it will
+                // be caught on a *non-cyclic* element elsewhere.
+                if !pending.insert(pair) {
+                    return true;
+                }
+                // Snapshot the operands before recursing so we never hold
+                // a `RefCell` borrow across the recursive `value_eq_d`
+                // calls (a self-referential element would otherwise try to
+                // re-borrow the same cell and panic).
+                let xs = x.borrow().clone();
+                let ys = y.borrow().clone();
+                let result = xs.len() == ys.len()
+                    && xs.iter().zip(ys.iter()).all(|(a, b)| value_eq_d(a, b, pending));
+                pending.remove(&pair);
+                result
             }
             (Value::Map(x), Value::Map(y)) => {
-                Rc::ptr_eq(x, y) || {
-                    let (xb, yb) = (x.borrow(), y.borrow());
-                    xb.len() == yb.len()
-                        && xb.iter().zip(yb.iter()).all(|((ak, av), (bk, bv))| {
-                            value_eq(ak, bk) && value_eq(av, bv)
-                        })
+                if Rc::ptr_eq(x, y) {
+                    return true;
                 }
+                let pair = (map_handle_id(x), map_handle_id(y));
+                if !pending.insert(pair) {
+                    return true;
+                }
+                let xs = x.borrow().clone();
+                let ys = y.borrow().clone();
+                let result = xs.len() == ys.len()
+                    && xs.iter().zip(ys.iter()).all(|((ak, av), (bk, bv))| {
+                        value_eq_d(ak, bk, pending) && value_eq_d(av, bv, pending)
+                    });
+                pending.remove(&pair);
+                result
             }
             _ => false,
         }

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_cyclic.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_cyclic.rs
@@ -1,0 +1,244 @@
+//! Robustness proof: an emitted program that builds a **cyclic**
+//! Seq/Map structure must *terminate gracefully* instead of stack-
+//! overflowing (in `format`) or RefCell-panicking (in the map ops).
+//!
+//! `Value::Seq`/`Value::Map` are shared, *mutable* handles, so a
+//! generated program can tie a knot:
+//!
+//!   ```text
+//!   xs = [0]
+//!   xs[0] = xs        # SeqSet whose value aliases the seq itself
+//!   print(xs)         # would recurse forever without a cycle guard
+//!   ```
+//!
+//! The hardened runtime threads a visited-pointer set through
+//! `format`/`format_seq`/`format_map`, printing a `[...]` placeholder on
+//! re-entry of a handle already on the active path.  This test hand-
+//! builds exactly that module, emits Rust, compiles it with `rustc`,
+//! runs it, and asserts the binary **terminates** and prints the
+//! placeholder rather than crashing or looping.
+//!
+//! Mirrors `compile_and_run_seq_maps.rs` for the toolchain plumbing
+//! (rustc/linker discovery, host-tool skips).  A missing host tool logs
+//! a skip rather than reddening the build.
+
+use std::process::Command;
+
+use semantic_ir::{
+    Block, Effect, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata,
+    Module, Scope, Span, Stmt,
+};
+use semantic_ir_to_rust::compile;
+
+fn s() -> Span {
+    Span::synthetic()
+}
+
+fn ilit(v: i64) -> Expr {
+    Expr::IntLit { value: v, span: s() }
+}
+
+fn local(name: &str) -> Expr {
+    Expr::VarRef { name: name.into(), scope: Scope::Local, span: s() }
+}
+
+fn print_stmt(expr: Expr) -> Stmt {
+    Stmt::ExprStmt {
+        expr: Expr::BuiltinCall {
+            name: "print".into(),
+            args: vec![expr],
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            span: s(),
+        },
+        span: s(),
+    }
+}
+
+fn let_local(name: &str, value: Expr) -> Stmt {
+    Stmt::LetBinding { name: name.into(), sir_type: None, value, span: s() }
+}
+
+fn block(stmts: Vec<Stmt>, value: Expr) -> Block {
+    Block { stmts, value, span: s() }
+}
+
+fn seq(items: Vec<Expr>) -> Expr {
+    Expr::SeqLit { items, span: s() }
+}
+
+/// Build a module whose `main` constructs a self-referential sequence
+/// and prints it:
+///
+///   1. `xs = [0]`
+///   2. `xs[0] = xs`        (SeqSet whose value aliases `xs` ⇒ a cycle)
+///   3. `print(xs)`          → must print `[[...]]` (placeholder) and
+///      terminate — `xs == [xs]`, so the inner self-reference becomes
+///      the `[...]` placeholder.
+///   4. `print(xs[0] == xs)` → identity short-circuit ⇒ `#t`,
+///      proving `value_eq` on a *self*-cyclic operand terminates.
+///   5. `ys = [0]; ys[0] = ys; print(xs == ys)` → two **distinct**
+///      cyclic structures (separate handles, so the `Rc::ptr_eq` fast
+///      path does *not* fire).  The co-inductive visited-pair guard must
+///      still terminate; structurally these are the same shape ⇒ `#t`.
+fn cyclic_module() -> Module {
+    let eq_expr = |a: Expr, b: Expr| Expr::BuiltinCall {
+        name: "=".into(),
+        args: vec![a, b],
+        effects: EffectSet::PURE,
+        span: s(),
+    };
+    let stmts = vec![
+        // 1. xs = [0]
+        let_local("xs", seq(vec![ilit(0)])),
+        // 2. xs[0] = xs   (the knot)
+        Stmt::SeqSet {
+            seq: local("xs"),
+            index: ilit(0),
+            value: local("xs"),
+            span: s(),
+        },
+        // 3. print(xs)  -> "[...]"
+        print_stmt(local("xs")),
+        // 4. print(xs[0] == xs) -> "#t"  (value_eq, self-cycle, ptr_eq)
+        print_stmt(eq_expr(
+            Expr::SeqIndex {
+                seq: Box::new(local("xs")),
+                index: Box::new(ilit(0)),
+                span: s(),
+            },
+            local("xs"),
+        )),
+        // 5. ys = [0]; ys[0] = ys; print(xs == ys) -> "#t"
+        //    Distinct handles ⇒ exercises the co-inductive deep walk.
+        let_local("ys", seq(vec![ilit(0)])),
+        Stmt::SeqSet {
+            seq: local("ys"),
+            index: ilit(0),
+            value: local("ys"),
+            span: s(),
+        },
+        print_stmt(eq_expr(local("xs"), local("ys"))),
+    ];
+
+    Module {
+        name: "cyclic_demo".into(),
+        manifest: FeatureManifest::from_features(&[
+            Feature::Sequences,
+            Feature::MutableBindings,
+        ]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: block(stmts, Expr::NilLit { span: s() }),
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            metadata: Metadata::new(),
+            span: s(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("test")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+fn rustc_available() -> bool {
+    Command::new("rustc")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+#[test]
+fn cyclic_seq_compiles_runs_and_terminates() {
+    if !rustc_available() {
+        eprintln!("skipping: rustc not on PATH");
+        return;
+    }
+
+    // 1. Emit.
+    let artifact = compile(&cyclic_module()).expect("module should compile to Rust source");
+
+    // 2. Write the source to a unique temp file.
+    let dir = std::env::temp_dir();
+    let nonce = std::process::id();
+    let src_path = dir.join(format!("sir_cyclic_{nonce}.rs"));
+    let bin_path = dir.join(format!(
+        "sir_cyclic_{nonce}{}",
+        if cfg!(windows) { ".exe" } else { "" }
+    ));
+    std::fs::write(&src_path, &artifact.source).expect("write temp source");
+
+    // 3. Compile with rustc.
+    let mut cmd = Command::new("rustc");
+    cmd.arg("--edition").arg("2021").arg("-O");
+    if let Ok(linker) = std::env::var("SIR_TEST_RUSTC_LINKER") {
+        if !linker.is_empty() {
+            cmd.arg("-C").arg(format!("linker={linker}"));
+        }
+    }
+    let compile_out = cmd
+        .arg(&src_path)
+        .arg("-o")
+        .arg(&bin_path)
+        .output()
+        .expect("invoke rustc");
+    if !compile_out.status.success() {
+        let stderr = String::from_utf8_lossy(&compile_out.stderr);
+        if stderr.contains("linker") && (stderr.contains("not found") || stderr.contains("No such file"))
+        {
+            eprintln!("skipping: no usable linker on host\n{stderr}");
+            let _ = std::fs::remove_file(&src_path);
+            return;
+        }
+        panic!(
+            "emitted Rust failed to compile:\n--- stderr ---\n{stderr}\n--- source ---\n{}",
+            artifact.source,
+        );
+    }
+
+    // 4. Run the binary.  The whole point of the guard: this must
+    //    *terminate*.  A stack-overflow or RefCell panic would surface as
+    //    a non-success exit status (or, for an infinite loop, the test
+    //    harness would hang) — so a clean exit is itself the assertion.
+    let run_out = Command::new(&bin_path).output().expect("run compiled binary");
+    assert!(
+        run_out.status.success(),
+        "compiled binary exited non-zero (cycle guard failed to keep it alive):\n{}",
+        String::from_utf8_lossy(&run_out.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&run_out.stdout);
+    let lines: Vec<&str> = stdout.lines().collect();
+
+    // 5. Assert the observable behaviour.
+    //
+    //    `xs == [xs]`, so printing the outer seq opens `[`, then meets
+    //    `xs` again (now on the active path) and emits the `[...]`
+    //    placeholder, then closes `]` — i.e. `[[...]]`.  The key property
+    //    is that it *terminates* and *contains* the placeholder rather
+    //    than recursing forever.
+    assert_eq!(
+        lines.len(),
+        3,
+        "expected three printed lines; full stdout:\n{stdout}"
+    );
+    assert_eq!(lines[0], "[[...]]", "cyclic seq should print with a [...] placeholder");
+    assert!(
+        lines[0].contains("[...]"),
+        "cyclic seq output must contain the [...] placeholder; got {:?}",
+        lines[0],
+    );
+    // Both equality checks (self-cycle via ptr_eq; distinct cycles via
+    // the co-inductive visited-pair guard) must terminate as `#t`.
+    assert_eq!(lines[1], "#t", "self-cyclic value_eq should be #t and terminate");
+    assert_eq!(lines[2], "#t", "distinct-cycle value_eq should be #t and terminate");
+
+    // 6. Best-effort cleanup.
+    let _ = std::fs::remove_file(&src_path);
+    let _ = std::fs::remove_file(&bin_path);
+}


### PR DESCRIPTION
Hardens the `semantic-ir-to-rust` **emitted runtime** so a generated program that builds a cyclic Seq/Map structure (e.g. `xs = [0]; xs[0] = xs`) terminates gracefully instead of stack-overflowing or RefCell-panicking. Addresses the LOW/INFO robustness finding from the Seq/Maps PR (A3).

- **`format`** — cycle detection via a path-scoped visited-pointer set (`HashSet<usize>` of `Rc::as_ptr` addresses, added on enter / removed on exit). A true subtree cycle prints `[...]`/`{...}`; sibling non-cyclic repeats still print in full.
- **`value_eq`** — keeps the `Rc::ptr_eq` fast path; adds a co-inductive pending-pair set so comparing two *distinct* cyclic structures terminates (lock-step cycle ⇒ equal) without false-positives on acyclic values.
- **Map borrow fix** — `map_get`/`map_set`/`map_lit` no longer call `value_eq` while holding a `RefCell` borrow on the same map's entries (snapshot/collect-keys/resolve-index-then-mutate), removing the 'already mutably borrowed' panic path for a self-referential key.

**Non-cyclic output is byte-identical** — only private `_d` helper signatures changed; the public `print`/`format` behavior is unchanged (existing exact-stdout tests pass).

**Tests:** 65 unit + 4 rustc compile-and-run integration tests — the new `compile_and_run_cyclic` builds a cyclic seq, runs it, asserts it terminates printing `[[...]]`, and checks `value_eq` terminates on self-cyclic and two distinct cyclic operands; clippy clean; security review passed. Isolated to `semantic-ir-to-rust`. (Go backend has the same hand-rolled runtime — a matching guard will follow once A6 merges.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)