### PR TITLE
feat(kotlin-sql-planner): Kotlin logical query planner (Level 1 prerequisite)

### DIFF
--- a/.claude/mini-sqlite-loop-state.json
+++ b/.claude/mini-sqlite-loop-state.json
@@ -1,0 +1,313 @@
+{
+  "job": "mini-sqlite-completion",
+  "cron_job_id": "d39be3bf",
+  "started": "2026-06-30",
+  "items": [
+    {
+      "id": "ts-v011",
+      "title": "TypeScript mini-sqlite v0.1.1 (cut ReDoS fix release)",
+      "status": "merged",
+      "depends_on": [],
+      "branch": "mini-sqlite/ts-v011",
+      "pr_number": 7003,
+      "notes": "Merged 2026-06-30."
+    },
+    {
+      "id": "ruby-v011",
+      "title": "Ruby mini-sqlite v0.1.1 (cut ReDoS fix release)",
+      "status": "merged",
+      "depends_on": [],
+      "branch": "mini-sqlite/ruby-v011",
+      "pr_number": 7004,
+      "notes": "Merged 2026-06-30."
+    },
+    {
+      "id": "conformance-fixtures",
+      "title": "Shared conformance test fixtures for Level 0 mini-sqlite ports",
+      "status": "merged",
+      "depends_on": [],
+      "branch": "mini-sqlite/conformance-fixtures",
+      "pr_number": 7006,
+      "notes": "Merged 2026-06-30. 16 JSON fixtures in code/specs/mini-sqlite-conformance/."
+    },
+    {
+      "id": "wasm-mini-sqlite",
+      "title": "Wasm mini-sqlite Level 0 facade",
+      "status": "merged",
+      "depends_on": [],
+      "branch": "mini-sqlite/wasm-mini-sqlite",
+      "pr_number": 7016,
+      "notes": "Merged 2026-06-30. Wraps coding-adventures-mini-sqlite with wasm-bindgen. 14 native tests pass."
+    },
+    {
+      "id": "csharp-level1-sql-backend",
+      "title": "C# sql-backend (Level 1 prerequisite)",
+      "status": "merged",
+      "depends_on": [],
+      "branch": "mini-sqlite/csharp-level1-sql-backend",
+      "pr_number": 7027,
+      "notes": "Merged 2026-06-30. InMemoryBackend + SqlValue discriminated union + coverlet."
+    },
+    {
+      "id": "fsharp-level1-sql-backend",
+      "title": "F# sql-backend (Level 1 prerequisite)",
+      "status": "merged",
+      "depends_on": [],
+      "branch": null,
+      "pr_number": 1942,
+      "notes": "Already on main (PR #1942). Full InMemoryBackend in SqlBackend.fs."
+    },
+    {
+      "id": "java-level1-sql-backend",
+      "title": "Java sql-backend (Level 1 prerequisite)",
+      "status": "merged",
+      "depends_on": [],
+      "branch": null,
+      "pr_number": 1943,
+      "notes": "Already on main (PR #1943)."
+    },
+    {
+      "id": "kotlin-level1-sql-backend",
+      "title": "Kotlin sql-backend (Level 1 prerequisite)",
+      "status": "merged",
+      "depends_on": [],
+      "branch": null,
+      "pr_number": 1958,
+      "notes": "Already on main (PR #1958)."
+    },
+    {
+      "id": "haskell-level1-sql-backend",
+      "title": "Haskell sql-backend (Level 1 prerequisite)",
+      "status": "merged",
+      "depends_on": [],
+      "branch": null,
+      "pr_number": 1962,
+      "notes": "Already on main (PR #1962)."
+    },
+    {
+      "id": "fsharp-level1-sql-planner",
+      "title": "F# sql-planner",
+      "status": "in-review",
+      "depends_on": ["fsharp-level1-sql-backend"],
+      "branch": "mini-sqlite/fsharp-level1-sql-planner",
+      "pr_number": 7036,
+      "notes": "PR open 2026-06-30. 52 tests, 83% coverage. Awaiting CI + merge."
+    },
+    {
+      "id": "fsharp-level1-sql-optimizer",
+      "title": "F# sql-optimizer",
+      "status": "pending",
+      "depends_on": ["fsharp-level1-sql-planner"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Port Python sql_optimizer to F#."
+    },
+    {
+      "id": "fsharp-level1-sql-codegen",
+      "title": "F# sql-codegen",
+      "status": "pending",
+      "depends_on": ["fsharp-level1-sql-optimizer"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Port Python sql_codegen to F#."
+    },
+    {
+      "id": "fsharp-level1-sql-vm",
+      "title": "F# sql-vm",
+      "status": "pending",
+      "depends_on": ["fsharp-level1-sql-codegen"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Port Python sql_vm to F#."
+    },
+    {
+      "id": "fsharp-level1-graduate",
+      "title": "Graduate F# mini-sqlite to Level 1",
+      "status": "pending",
+      "depends_on": ["fsharp-level1-sql-vm"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Wire F# mini-sqlite to use the full sql-backend/planner/optimizer/codegen/vm pipeline."
+    },
+    {
+      "id": "java-level1-sql-planner",
+      "title": "Java sql-planner",
+      "status": "pending",
+      "depends_on": ["java-level1-sql-backend"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Port Python sql_planner to Java."
+    },
+    {
+      "id": "java-level1-sql-optimizer",
+      "title": "Java sql-optimizer",
+      "status": "pending",
+      "depends_on": ["java-level1-sql-planner"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Port Python sql_optimizer to Java."
+    },
+    {
+      "id": "java-level1-sql-codegen",
+      "title": "Java sql-codegen",
+      "status": "pending",
+      "depends_on": ["java-level1-sql-optimizer"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Port Python sql_codegen to Java."
+    },
+    {
+      "id": "java-level1-sql-vm",
+      "title": "Java sql-vm",
+      "status": "pending",
+      "depends_on": ["java-level1-sql-codegen"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Port Python sql_vm to Java."
+    },
+    {
+      "id": "java-level1-graduate",
+      "title": "Graduate Java mini-sqlite to Level 1",
+      "status": "pending",
+      "depends_on": ["java-level1-sql-vm"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Wire Java mini-sqlite to use the full pipeline."
+    },
+    {
+      "id": "kotlin-level1-sql-planner",
+      "title": "Kotlin sql-planner",
+      "status": "pending",
+      "depends_on": ["kotlin-level1-sql-backend"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Port Python sql_planner to Kotlin."
+    },
+    {
+      "id": "kotlin-level1-sql-optimizer",
+      "title": "Kotlin sql-optimizer",
+      "status": "pending",
+      "depends_on": ["kotlin-level1-sql-planner"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Port Python sql_optimizer to Kotlin."
+    },
+    {
+      "id": "kotlin-level1-sql-codegen",
+      "title": "Kotlin sql-codegen",
+      "status": "pending",
+      "depends_on": ["kotlin-level1-sql-optimizer"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Port Python sql_codegen to Kotlin."
+    },
+    {
+      "id": "kotlin-level1-sql-vm",
+      "title": "Kotlin sql-vm",
+      "status": "pending",
+      "depends_on": ["kotlin-level1-sql-codegen"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Port Python sql_vm to Kotlin."
+    },
+    {
+      "id": "kotlin-level1-graduate",
+      "title": "Graduate Kotlin mini-sqlite to Level 1",
+      "status": "pending",
+      "depends_on": ["kotlin-level1-sql-vm"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Wire Kotlin mini-sqlite to use the full pipeline."
+    },
+    {
+      "id": "haskell-level1-sql-planner",
+      "title": "Haskell sql-planner",
+      "status": "pending",
+      "depends_on": ["haskell-level1-sql-backend"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Port Python sql_planner to Haskell."
+    },
+    {
+      "id": "haskell-level1-sql-optimizer",
+      "title": "Haskell sql-optimizer",
+      "status": "pending",
+      "depends_on": ["haskell-level1-sql-planner"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Port Python sql_optimizer to Haskell."
+    },
+    {
+      "id": "haskell-level1-sql-codegen",
+      "title": "Haskell sql-codegen",
+      "status": "pending",
+      "depends_on": ["haskell-level1-sql-optimizer"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Port Python sql_codegen to Haskell."
+    },
+    {
+      "id": "haskell-level1-sql-vm",
+      "title": "Haskell sql-vm",
+      "status": "pending",
+      "depends_on": ["haskell-level1-sql-codegen"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Port Python sql_vm to Haskell."
+    },
+    {
+      "id": "haskell-level1-graduate",
+      "title": "Graduate Haskell mini-sqlite to Level 1",
+      "status": "pending",
+      "depends_on": ["haskell-level1-sql-vm"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Wire Haskell mini-sqlite to use the full pipeline."
+    },
+    {
+      "id": "csharp-level1-sql-planner",
+      "title": "C# sql-planner (Level 1 prerequisite)",
+      "status": "in-review",
+      "depends_on": ["csharp-level1-sql-backend"],
+      "branch": "mini-sqlite/csharp-level1-sql-planner",
+      "pr_number": 7041,
+      "notes": "PR open 2026-06-30. 40 tests, 89% coverage. Awaiting CI + merge."
+    },
+    {
+      "id": "csharp-level1-sql-optimizer",
+      "title": "C# sql-optimizer (Level 1 prerequisite)",
+      "status": "pending",
+      "depends_on": ["csharp-level1-sql-planner"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Port Python sql_optimizer to C#."
+    },
+    {
+      "id": "csharp-level1-sql-codegen",
+      "title": "C# sql-codegen (Level 1 prerequisite)",
+      "status": "pending",
+      "depends_on": ["csharp-level1-sql-optimizer"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Port Python sql_codegen to C#."
+    },
+    {
+      "id": "csharp-level1-sql-vm",
+      "title": "C# sql-vm (Level 1 prerequisite)",
+      "status": "pending",
+      "depends_on": ["csharp-level1-sql-codegen"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Port Python sql_vm to C#."
+    },
+    {
+      "id": "csharp-level1-graduate",
+      "title": "Graduate C# mini-sqlite to Level 1",
+      "status": "pending",
+      "depends_on": ["csharp-level1-sql-vm"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Wire C# mini-sqlite to use the full sql-backend/planner/optimizer/codegen/vm pipeline."
+    }
+  ]
+}

--- a/.claude/mini-sqlite-loop-state.json
+++ b/.claude/mini-sqlite-loop-state.json
@@ -91,7 +91,7 @@
       "depends_on": ["fsharp-level1-sql-backend"],
       "branch": "mini-sqlite/fsharp-level1-sql-planner",
       "pr_number": 7036,
-      "notes": "PR open 2026-06-30. 52 tests, 83% coverage. Awaiting CI + merge."
+      "notes": "PR open 2026-06-30. 52 tests, 83% coverage. CI all green (ubuntu/macos/windows). Awaiting merge."
     },
     {
       "id": "fsharp-level1-sql-optimizer",
@@ -132,11 +132,11 @@
     {
       "id": "java-level1-sql-planner",
       "title": "Java sql-planner",
-      "status": "pending",
+      "status": "in-review",
       "depends_on": ["java-level1-sql-backend"],
-      "branch": null,
-      "pr_number": null,
-      "notes": "Port Python sql_planner to Java."
+      "branch": "mini-sqlite/java-level1-sql-planner",
+      "pr_number": 7045,
+      "notes": "PR open 2026-06-30. 50 tests (JaCoCo ≥80%). Java 21 sealed interfaces + records. Awaiting CI + merge."
     },
     {
       "id": "java-level1-sql-optimizer",
@@ -271,7 +271,7 @@
       "depends_on": ["csharp-level1-sql-backend"],
       "branch": "mini-sqlite/csharp-level1-sql-planner",
       "pr_number": 7041,
-      "notes": "PR open 2026-06-30. 40 tests, 89% coverage. Awaiting CI + merge."
+      "notes": "PR open 2026-06-30. 40 tests, 89% coverage. CI all green (ubuntu/macos/windows). Awaiting merge."
     },
     {
       "id": "csharp-level1-sql-optimizer",

--- a/code/packages/kotlin/sql-planner/BUILD
+++ b/code/packages/kotlin/sql-planner/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/sql-planner/BUILD_windows
+++ b/code/packages/kotlin/sql-planner/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/sql-planner/CHANGELOG.md
+++ b/code/packages/kotlin/sql-planner/CHANGELOG.md
@@ -12,6 +12,6 @@ All notable changes to `coding-adventures-sql-planner` (Kotlin) will be document
 - `SchemaProvider` interface and `InMemorySchemaProvider` implementation
 - `SqlPlanner.plan(Statement)` — transforms a single statement, throws on error
 - `SqlPlanner.planAll(List<Statement>)` — plans a list, failing on first error
-- 8-step bottom-up SELECT pipeline: Scan → Filter → Aggregate → Having → Project → Distinct → Sort → Limit
+- 8-step bottom-up SELECT pipeline: Scan → Filter → Aggregate → Having → Distinct → Sort → Limit → Project
 - Column resolution with scope tracking, alias support, and ambiguity detection
 - 50 unit tests; ≥80% line coverage (JaCoCo)

--- a/code/packages/kotlin/sql-planner/CHANGELOG.md
+++ b/code/packages/kotlin/sql-planner/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to `coding-adventures-sql-planner` (Kotlin) will be documented here.
+
+## [0.1.0] - 2026-06-30
+
+### Added
+- `SqlExpr` sealed class with 14 subclasses: Literal, Column, BinaryOp, UnaryOp, FuncCall, IsNull, IsNotNull, Between, In, NotIn, Like, NotLike, Wildcard, AggExpr
+- `LogicalPlan` sealed class with 15 subclasses: Scan, Filter, Project, Join, Aggregate, Having, Sort, Limit, Distinct, Union, Insert, Update, Delete, CreateTable, DropTable
+- `Statement` sealed class with 6 subclasses: Select, Insert, Update, Delete, CreateTable, DropTable
+- `PlanException` base class with 5 subtypes: AmbiguousColumnException, UnknownTableException, UnknownColumnException, InvalidAggregateException, UnsupportedStatementException
+- `SchemaProvider` interface and `InMemorySchemaProvider` implementation
+- `SqlPlanner.plan(Statement)` — transforms a single statement, throws on error
+- `SqlPlanner.planAll(List<Statement>)` — plans a list, failing on first error
+- 8-step bottom-up SELECT pipeline: Scan → Filter → Aggregate → Having → Project → Distinct → Sort → Limit
+- Column resolution with scope tracking, alias support, and ambiguity detection
+- 50 unit tests; ≥80% line coverage (JaCoCo)

--- a/code/packages/kotlin/sql-planner/README.md
+++ b/code/packages/kotlin/sql-planner/README.md
@@ -1,0 +1,65 @@
+# coding-adventures-sql-planner (Kotlin)
+
+Kotlin logical query planner for the Mini-SQLite Level 1 pipeline.
+
+## What it does
+
+Transforms a `Statement` into a tree of `LogicalPlan` nodes using an
+8-step bottom-up pipeline for SELECT:
+
+```
+Scan → Filter → Aggregate → Having → Project → Distinct → Sort → Limit
+```
+
+No I/O, no database connections — pure in-memory data transformation.
+Errors are reported as `PlanException` subclasses (consistent with the Kotlin
+`sql-backend` style).
+
+## How it fits in the stack
+
+```
+sql-parser  →  sql-planner  →  sql-optimizer  →  sql-codegen  →  sql-vm
+               (this pkg)
+```
+
+## Usage
+
+```kotlin
+val schema = InMemorySchemaProvider(mapOf(
+    "users" to listOf("id", "name", "age", "email")
+))
+
+val planner = SqlPlanner(schema)
+
+val stmt = Statement.Select(
+    distinct = false,
+    columns  = listOf(OutputColumn.Star),
+    from     = listOf(TableRef("users", null)),
+    joins    = emptyList(),
+    where    = SqlExpr.BinaryOp(BinaryOperator.GT, SqlExpr.Column(null, "age"), SqlExpr.Literal(18L)),
+    groupBy  = emptyList(),
+    having   = null,
+    orderBy  = emptyList(),
+    limit    = null)
+
+val plan: LogicalPlan = planner.plan(stmt)   // throws PlanException on error
+```
+
+## Key types
+
+| Type | Description |
+|------|-------------|
+| `SqlExpr` | Sealed class for scalar expressions (14 subclasses) |
+| `LogicalPlan` | Sealed class for plan nodes (15 subclasses) |
+| `Statement` | Sealed class for SQL statements (6 subclasses) |
+| `PlanException` | Base class for planning errors |
+| `SchemaProvider` | Interface for column-name lookup |
+| `InMemorySchemaProvider` | Map-backed schema provider |
+
+## Running tests
+
+```
+gradle test
+```
+
+Coverage threshold: 80% line coverage (enforced by JaCoCo).

--- a/code/packages/kotlin/sql-planner/build.gradle.kts
+++ b/code/packages/kotlin/sql-planner/build.gradle.kts
@@ -1,0 +1,66 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    kotlin("jvm") version "2.1.20"
+    `java-library`
+    jacoco
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+    }
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    testImplementation(kotlin("test"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+    finalizedBy(tasks.jacocoTestReport)
+}
+
+jacoco {
+    toolVersion = "0.8.12"
+}
+
+tasks.jacocoTestReport {
+    dependsOn(tasks.test)
+    reports {
+        xml.required.set(true)
+        html.required.set(true)
+    }
+}
+
+tasks.jacocoTestCoverageVerification {
+    dependsOn(tasks.jacocoTestReport)
+    violationRules {
+        rule {
+            limit {
+                counter = "LINE"
+                value = "COVEREDRATIO"
+                minimum = "0.80".toBigDecimal()
+            }
+        }
+    }
+}
+
+tasks.named("check") {
+    dependsOn(tasks.jacocoTestCoverageVerification)
+}

--- a/code/packages/kotlin/sql-planner/required_capabilities.json
+++ b/code/packages/kotlin/sql-planner/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "kotlin/sql-planner",
+  "capabilities": [],
+  "justification": "Pure in-memory library and tests. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/kotlin/sql-planner/settings.gradle.kts
+++ b/code/packages/kotlin/sql-planner/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "coding-adventures-sql-planner"

--- a/code/packages/kotlin/sql-planner/src/main/kotlin/com/codingadventures/sqlplanner/SqlPlanner.kt
+++ b/code/packages/kotlin/sql-planner/src/main/kotlin/com/codingadventures/sqlplanner/SqlPlanner.kt
@@ -1,0 +1,342 @@
+package com.codingadventures.sqlplanner
+
+// SqlPlanner.kt — logical query plan builder for SQL statements.
+//
+// Transforms a Statement into a LogicalPlan tree using an 8-step bottom-up
+// SELECT pipeline:
+//
+//   Scan → Filter → Aggregate → Having → Project → Distinct → Sort → Limit
+//
+// No I/O, no database connections — pure in-memory data transformation.
+// Errors are reported as PlanException subclasses (consistent with the
+// Kotlin sql-backend's exception-based error style).
+//
+// Usage:
+//   val schema = InMemorySchemaProvider(mapOf("users" to listOf("id", "name", "age")))
+//   val planner = SqlPlanner(schema)
+//   val plan: LogicalPlan = planner.plan(stmt)   // throws PlanException on error
+
+// ── Enumerations ──────────────────────────────────────────────────────────────
+
+enum class BinaryOperator { EQ, NOT_EQ, LT, LTE, GT, GTE, AND, OR, ADD, SUB, MUL, DIV, MOD }
+enum class UnaryOperator  { NOT, NEG }
+enum class AggFunction    { COUNT, SUM, AVG, MIN, MAX }
+enum class SortDir        { ASC, DESC }
+enum class NullOrder      { NULLS_FIRST, NULLS_LAST }
+enum class JoinKind       { INNER, LEFT, RIGHT, FULL, CROSS }
+
+// ── Aggregate argument ────────────────────────────────────────────────────────
+
+sealed class AggArg {
+    object Star : AggArg()
+    data class Expr(val expression: SqlExpr) : AggArg()
+}
+
+// ── Scalar expressions ────────────────────────────────────────────────────────
+
+sealed class SqlExpr {
+    data class Literal(val value: Any?) : SqlExpr()
+    data class Column(val table: String?, val column: String) : SqlExpr()
+    data class BinaryOp(val op: BinaryOperator, val left: SqlExpr, val right: SqlExpr) : SqlExpr()
+    data class UnaryOp(val op: UnaryOperator, val operand: SqlExpr) : SqlExpr()
+    data class FuncCall(val name: String, val args: List<SqlExpr>) : SqlExpr()
+    data class IsNull(val operand: SqlExpr) : SqlExpr()
+    data class IsNotNull(val operand: SqlExpr) : SqlExpr()
+    data class Between(val value: SqlExpr, val low: SqlExpr, val high: SqlExpr) : SqlExpr()
+    data class In(val value: SqlExpr, val items: List<SqlExpr>) : SqlExpr()
+    data class NotIn(val value: SqlExpr, val items: List<SqlExpr>) : SqlExpr()
+    data class Like(val value: SqlExpr, val pattern: String) : SqlExpr()
+    data class NotLike(val value: SqlExpr, val pattern: String) : SqlExpr()
+    object Wildcard : SqlExpr()
+    data class AggExpr(val func: AggFunction, val arg: AggArg, val distinct: Boolean) : SqlExpr()
+}
+
+// ── Output column ─────────────────────────────────────────────────────────────
+
+sealed class OutputColumn {
+    object Star : OutputColumn()
+    data class Expr(val expression: SqlExpr, val alias: String?) : OutputColumn()
+}
+
+// ── Structural types ──────────────────────────────────────────────────────────
+
+data class JoinClause(val kind: JoinKind, val table: String, val alias: String?, val on: SqlExpr?)
+data class ColumnDef(val name: String, val typeName: String, val notNull: Boolean, val primaryKey: Boolean, val unique: Boolean, val default: SqlExpr?)
+data class Assignment(val column: String, val value: SqlExpr)
+data class LimitClause(val count: Long?, val offset: Long?)
+data class SortKey(val keyExpr: SqlExpr, val direction: SortDir, val nullOrder: NullOrder)
+data class AggregateItem(val func: AggFunction, val arg: AggArg, val alias: String, val distinct: Boolean)
+data class TableRef(val table: String, val alias: String?)
+
+// ── Statement AST ─────────────────────────────────────────────────────────────
+
+sealed class Statement {
+    data class Select(
+        val distinct: Boolean,
+        val columns: List<OutputColumn>,
+        val from: List<TableRef>,
+        val joins: List<JoinClause>,
+        val where: SqlExpr?,
+        val groupBy: List<SqlExpr>,
+        val having: SqlExpr?,
+        val orderBy: List<SortKey>,
+        val limit: LimitClause?
+    ) : Statement()
+
+    data class Insert(
+        val table: String,
+        val columns: List<String>,
+        val values: List<List<SqlExpr>>
+    ) : Statement()
+
+    data class Update(
+        val table: String,
+        val assignments: List<Assignment>,
+        val where: SqlExpr?
+    ) : Statement()
+
+    data class Delete(val table: String, val where: SqlExpr?) : Statement()
+
+    data class CreateTable(
+        val table: String,
+        val ifNotExists: Boolean,
+        val columns: List<ColumnDef>
+    ) : Statement()
+
+    data class DropTable(val table: String, val ifExists: Boolean) : Statement()
+}
+
+// ── Logical plan nodes ────────────────────────────────────────────────────────
+
+sealed class LogicalPlan {
+    data class Scan(val table: String, val alias: String?) : LogicalPlan()
+    data class Filter(val input: LogicalPlan, val predicate: SqlExpr) : LogicalPlan()
+    data class Project(val input: LogicalPlan, val columns: List<OutputColumn>) : LogicalPlan()
+    data class Join(val left: LogicalPlan, val right: LogicalPlan, val kind: JoinKind, val condition: SqlExpr?) : LogicalPlan()
+    data class Aggregate(val input: LogicalPlan, val groupBy: List<SqlExpr>, val aggregates: List<AggregateItem>) : LogicalPlan()
+    data class Having(val input: LogicalPlan, val predicate: SqlExpr) : LogicalPlan()
+    data class Sort(val input: LogicalPlan, val keys: List<SortKey>) : LogicalPlan()
+    data class Limit(val input: LogicalPlan, val count: Long?, val offset: Long?) : LogicalPlan()
+    data class Distinct(val input: LogicalPlan) : LogicalPlan()
+    data class Union(val left: LogicalPlan, val right: LogicalPlan, val all: Boolean) : LogicalPlan()
+    data class Insert(val table: String, val columns: List<String>, val values: List<List<SqlExpr>>) : LogicalPlan()
+    data class Update(val table: String, val assignments: List<Assignment>, val predicate: SqlExpr?) : LogicalPlan()
+    data class Delete(val table: String, val predicate: SqlExpr?) : LogicalPlan()
+    data class CreateTable(val table: String, val ifNotExists: Boolean, val columns: List<ColumnDef>) : LogicalPlan()
+    data class DropTable(val table: String, val ifExists: Boolean) : LogicalPlan()
+}
+
+// ── Plan exceptions ───────────────────────────────────────────────────────────
+
+abstract class PlanException(message: String) : RuntimeException(message)
+
+class AmbiguousColumnException(val column: String, val tables: List<String>) :
+    PlanException("Ambiguous column '$column' — found in: ${tables.joinToString(", ")}")
+
+class UnknownTableException(val table: String) :
+    PlanException("Unknown table '$table'")
+
+class UnknownColumnException(val qualifyingTable: String?, val column: String) :
+    PlanException(if (qualifyingTable != null) "Unknown column '$qualifyingTable.$column'" else "Unknown column '$column'")
+
+class InvalidAggregateException(message: String) : PlanException(message)
+
+class UnsupportedStatementException(kind: String) : PlanException("Unsupported statement: $kind")
+
+// ── Schema provider ───────────────────────────────────────────────────────────
+
+interface SchemaProvider {
+    /** Returns column names for [table], or throws [UnknownTableException]. */
+    fun columns(table: String): List<String>
+}
+
+class InMemorySchemaProvider(private val tables: Map<String, List<String>>) : SchemaProvider {
+    override fun columns(table: String): List<String> =
+        tables[table] ?: throw UnknownTableException(table)
+}
+
+// ── Planner ───────────────────────────────────────────────────────────────────
+
+class SqlPlanner(private val schema: SchemaProvider) {
+
+    // Scope entry: one source in FROM/JOIN with its resolved alias and columns.
+    private data class ScopeEntry(val alias: String, val table: String, val cols: List<String>)
+
+    private fun buildScope(from: List<TableRef>, joins: List<JoinClause>): List<ScopeEntry> {
+        val scope = mutableListOf<ScopeEntry>()
+        for (ref in from) {
+            val cols = schema.columns(ref.table)    // throws UnknownTableException
+            scope.add(ScopeEntry(ref.alias ?: ref.table, ref.table, cols))
+        }
+        for (j in joins) {
+            val cols = schema.columns(j.table)      // throws UnknownTableException
+            scope.add(ScopeEntry(j.alias ?: j.table, j.table, cols))
+        }
+        return scope
+    }
+
+    private fun resolveColumn(scope: List<ScopeEntry>, tableOpt: String?, col: String): SqlExpr {
+        if (tableOpt != null) {
+            val entry = scope.find { it.alias == tableOpt }
+                ?: throw UnknownTableException(tableOpt)
+            if (!entry.cols.any { it.equals(col, ignoreCase = true) })
+                throw UnknownColumnException(tableOpt, col)
+            return SqlExpr.Column(entry.alias, col)
+        } else {
+            val matches = scope.filter { e -> e.cols.any { it.equals(col, ignoreCase = true) } }
+            if (matches.isEmpty()) throw UnknownColumnException(null, col)
+            if (matches.size > 1)  throw AmbiguousColumnException(col, matches.map { it.alias })
+            return SqlExpr.Column(matches[0].alias, col)
+        }
+    }
+
+    private fun resolveExpr(scope: List<ScopeEntry>, expr: SqlExpr): SqlExpr = when (expr) {
+        is SqlExpr.Column    -> resolveColumn(scope, expr.table, expr.column)
+        is SqlExpr.Literal   -> expr
+        is SqlExpr.Wildcard  -> expr
+        is SqlExpr.AggExpr   -> expr
+        is SqlExpr.BinaryOp  -> SqlExpr.BinaryOp(expr.op, resolveExpr(scope, expr.left), resolveExpr(scope, expr.right))
+        is SqlExpr.UnaryOp   -> SqlExpr.UnaryOp(expr.op, resolveExpr(scope, expr.operand))
+        is SqlExpr.FuncCall  -> SqlExpr.FuncCall(expr.name, expr.args.map { resolveExpr(scope, it) })
+        is SqlExpr.IsNull    -> SqlExpr.IsNull(resolveExpr(scope, expr.operand))
+        is SqlExpr.IsNotNull -> SqlExpr.IsNotNull(resolveExpr(scope, expr.operand))
+        is SqlExpr.Between   -> SqlExpr.Between(resolveExpr(scope, expr.value), resolveExpr(scope, expr.low), resolveExpr(scope, expr.high))
+        is SqlExpr.In        -> SqlExpr.In(resolveExpr(scope, expr.value), expr.items.map { resolveExpr(scope, it) })
+        is SqlExpr.NotIn     -> SqlExpr.NotIn(resolveExpr(scope, expr.value), expr.items.map { resolveExpr(scope, it) })
+        is SqlExpr.Like      -> SqlExpr.Like(resolveExpr(scope, expr.value), expr.pattern)
+        is SqlExpr.NotLike   -> SqlExpr.NotLike(resolveExpr(scope, expr.value), expr.pattern)
+    }
+
+    private fun tryResolveExpr(scope: List<ScopeEntry>, expr: SqlExpr): SqlExpr? =
+        try { resolveExpr(scope, expr) }
+        catch (_: UnknownColumnException) { null }
+
+    private fun containsAggExpr(e: SqlExpr): Boolean = when (e) {
+        is SqlExpr.AggExpr   -> true
+        is SqlExpr.BinaryOp  -> containsAggExpr(e.left) || containsAggExpr(e.right)
+        is SqlExpr.UnaryOp   -> containsAggExpr(e.operand)
+        is SqlExpr.FuncCall  -> e.args.any { containsAggExpr(it) }
+        is SqlExpr.IsNull    -> containsAggExpr(e.operand)
+        is SqlExpr.IsNotNull -> containsAggExpr(e.operand)
+        is SqlExpr.Between   -> containsAggExpr(e.value) || containsAggExpr(e.low) || containsAggExpr(e.high)
+        is SqlExpr.In        -> containsAggExpr(e.value) || e.items.any { containsAggExpr(it) }
+        is SqlExpr.NotIn     -> containsAggExpr(e.value) || e.items.any { containsAggExpr(it) }
+        is SqlExpr.Like      -> containsAggExpr(e.value)
+        is SqlExpr.NotLike   -> containsAggExpr(e.value)
+        else                 -> false
+    }
+
+    private fun collectAggregates(exprs: List<SqlExpr>): List<AggregateItem> {
+        val found   = mutableListOf<AggregateItem>()
+        var counter = 0
+        fun walk(e: SqlExpr) {
+            when (e) {
+                is SqlExpr.AggExpr   -> { found.add(AggregateItem(e.func, e.arg, "_agg${counter++}", e.distinct)) }
+                is SqlExpr.BinaryOp  -> { walk(e.left); walk(e.right) }
+                is SqlExpr.UnaryOp   -> walk(e.operand)
+                is SqlExpr.FuncCall  -> e.args.forEach { walk(it) }
+                is SqlExpr.IsNull    -> walk(e.operand)
+                is SqlExpr.IsNotNull -> walk(e.operand)
+                is SqlExpr.Between   -> { walk(e.value); walk(e.low); walk(e.high) }
+                is SqlExpr.In        -> { walk(e.value); e.items.forEach { walk(it) } }
+                is SqlExpr.NotIn     -> { walk(e.value); e.items.forEach { walk(it) } }
+                is SqlExpr.Like      -> walk(e.value)
+                is SqlExpr.NotLike   -> walk(e.value)
+                else                 -> {}
+            }
+        }
+        exprs.forEach { walk(it) }
+        return found
+    }
+
+    private fun buildFromTree(from: List<TableRef>, joins: List<JoinClause>): LogicalPlan {
+        if (from.isEmpty()) throw UnsupportedStatementException("SELECT without FROM")
+        schema.columns(from[0].table)   // validate
+        var plan: LogicalPlan = LogicalPlan.Scan(from[0].table, from[0].alias)
+        for (i in 1 until from.size) {
+            schema.columns(from[i].table)  // validate
+            plan = LogicalPlan.Join(plan, LogicalPlan.Scan(from[i].table, from[i].alias), JoinKind.CROSS, null)
+        }
+        for (j in joins) {
+            schema.columns(j.table)  // validate
+            plan = LogicalPlan.Join(plan, LogicalPlan.Scan(j.table, j.alias), j.kind, j.on)
+        }
+        return plan
+    }
+
+    private fun planSelect(s: Statement.Select): LogicalPlan {
+        val scope    = buildScope(s.from, s.joins)
+        val fromPlan = buildFromTree(s.from, s.joins)
+
+        // Step 1: WHERE → Filter
+        var plan: LogicalPlan = if (s.where != null)
+            LogicalPlan.Filter(fromPlan, resolveExpr(scope, s.where))
+        else fromPlan
+
+        // Determine whether aggregation is required.
+        val colExprs    = s.columns.map { if (it is OutputColumn.Expr) it.expression else SqlExpr.Wildcard }
+        val havingExprs = listOfNotNull(s.having)
+        val needsAgg    = s.groupBy.isNotEmpty() ||
+            colExprs.any    { containsAggExpr(it) } ||
+            havingExprs.any { containsAggExpr(it) }
+
+        // Step 2: GROUP BY + Aggregate
+        if (needsAgg) {
+            val aggs    = collectAggregates(colExprs + havingExprs)
+            val groupBy = s.groupBy.map { resolveExpr(scope, it) }
+            plan = LogicalPlan.Aggregate(plan, groupBy, aggs)
+        }
+
+        // Step 3: HAVING
+        if (s.having != null) {
+            val rHaving = tryResolveExpr(scope, s.having) ?: s.having
+            plan = LogicalPlan.Having(plan, rHaving)
+        }
+
+        // Step 4: PROJECT
+        val projCols = s.columns.map { col ->
+            when (col) {
+                is OutputColumn.Star -> OutputColumn.Star
+                is OutputColumn.Expr -> {
+                    val resolved = if (needsAgg)
+                        (tryResolveExpr(scope, col.expression) ?: col.expression)
+                    else resolveExpr(scope, col.expression)
+                    OutputColumn.Expr(resolved, col.alias)
+                }
+            }
+        }
+        plan = LogicalPlan.Project(plan, projCols)
+
+        // Step 5: DISTINCT
+        if (s.distinct) plan = LogicalPlan.Distinct(plan)
+
+        // Step 6: ORDER BY
+        if (s.orderBy.isNotEmpty()) {
+            val keys = s.orderBy.map { key ->
+                val r = tryResolveExpr(scope, key.keyExpr)
+                SortKey(r ?: key.keyExpr, key.direction, key.nullOrder)
+            }
+            plan = LogicalPlan.Sort(plan, keys)
+        }
+
+        // Step 7: LIMIT / OFFSET
+        if (s.limit != null) {
+            plan = LogicalPlan.Limit(plan, s.limit.count, s.limit.offset)
+        }
+
+        return plan
+    }
+
+    /** Transform a single statement into a logical plan. Throws [PlanException] on error. */
+    fun plan(stmt: Statement): LogicalPlan = when (stmt) {
+        is Statement.Select      -> planSelect(stmt)
+        is Statement.Insert      -> { schema.columns(stmt.table); LogicalPlan.Insert(stmt.table, stmt.columns, stmt.values) }
+        is Statement.Update      -> { schema.columns(stmt.table); LogicalPlan.Update(stmt.table, stmt.assignments, stmt.where) }
+        is Statement.Delete      -> { schema.columns(stmt.table); LogicalPlan.Delete(stmt.table, stmt.where) }
+        is Statement.CreateTable -> LogicalPlan.CreateTable(stmt.table, stmt.ifNotExists, stmt.columns)
+        is Statement.DropTable   -> LogicalPlan.DropTable(stmt.table, stmt.ifExists)
+    }
+
+    /** Plan every statement in the list; throws on the first error. */
+    fun planAll(stmts: List<Statement>): List<LogicalPlan> = stmts.map { plan(it) }
+}

--- a/code/packages/kotlin/sql-planner/src/main/kotlin/com/codingadventures/sqlplanner/SqlPlanner.kt
+++ b/code/packages/kotlin/sql-planner/src/main/kotlin/com/codingadventures/sqlplanner/SqlPlanner.kt
@@ -293,7 +293,24 @@ class SqlPlanner(private val schema: SchemaProvider) {
             plan = LogicalPlan.Having(plan, rHaving)
         }
 
-        // Step 4: PROJECT
+        // Step 4: DISTINCT
+        if (s.distinct) plan = LogicalPlan.Distinct(plan)
+
+        // Step 5: ORDER BY
+        if (s.orderBy.isNotEmpty()) {
+            val keys = s.orderBy.map { key ->
+                val r = tryResolveExpr(scope, key.keyExpr)
+                SortKey(r ?: key.keyExpr, key.direction, key.nullOrder)
+            }
+            plan = LogicalPlan.Sort(plan, keys)
+        }
+
+        // Step 6: LIMIT / OFFSET
+        if (s.limit != null) {
+            plan = LogicalPlan.Limit(plan, s.limit.count, s.limit.offset)
+        }
+
+        // Step 7: PROJECT (outermost — applied last so ORDER BY / LIMIT can see raw column refs)
         val projCols = s.columns.map { col ->
             when (col) {
                 is OutputColumn.Star -> OutputColumn.Star
@@ -306,23 +323,6 @@ class SqlPlanner(private val schema: SchemaProvider) {
             }
         }
         plan = LogicalPlan.Project(plan, projCols)
-
-        // Step 5: DISTINCT
-        if (s.distinct) plan = LogicalPlan.Distinct(plan)
-
-        // Step 6: ORDER BY
-        if (s.orderBy.isNotEmpty()) {
-            val keys = s.orderBy.map { key ->
-                val r = tryResolveExpr(scope, key.keyExpr)
-                SortKey(r ?: key.keyExpr, key.direction, key.nullOrder)
-            }
-            plan = LogicalPlan.Sort(plan, keys)
-        }
-
-        // Step 7: LIMIT / OFFSET
-        if (s.limit != null) {
-            plan = LogicalPlan.Limit(plan, s.limit.count, s.limit.offset)
-        }
 
         return plan
     }

--- a/code/packages/kotlin/sql-planner/src/test/kotlin/com/codingadventures/sqlplanner/SqlPlannerTest.kt
+++ b/code/packages/kotlin/sql-planner/src/test/kotlin/com/codingadventures/sqlplanner/SqlPlannerTest.kt
@@ -1,0 +1,571 @@
+package com.codingadventures.sqlplanner
+
+// SqlPlannerTest.kt — conformance and unit tests for the Kotlin sql-planner.
+//
+// Test organisation mirrors the Java and C# suites:
+//   C1–C13  Conformance tests
+//   Struct   Structural tests (JOIN, aliases, DISTINCT/SORT/LIMIT stacking)
+//   Error    Error-path tests (unknown table, unknown column, ambiguous column)
+//   Expr     Expression-type tests
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.DisplayName
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.test.assertFalse
+
+class SqlPlannerTest {
+
+    // ── Schema fixture ────────────────────────────────────────────────────────
+
+    private val schema = InMemorySchemaProvider(mapOf(
+        "users"    to listOf("id", "name", "age", "email"),
+        "orders"   to listOf("id", "user_id", "amount", "status"),
+        "products" to listOf("id", "name", "price", "category")
+    ))
+
+    private fun planner() = SqlPlanner(schema)
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private fun selectStar(table: String) = Statement.Select(
+        distinct = false,
+        columns  = listOf(OutputColumn.Star),
+        from     = listOf(TableRef(table, null)),
+        joins    = emptyList(),
+        where    = null, groupBy = emptyList(), having = null,
+        orderBy  = emptyList(), limit = null)
+
+    private fun selectStarWhere(table: String, where: SqlExpr) = Statement.Select(
+        distinct = false,
+        columns  = listOf(OutputColumn.Star),
+        from     = listOf(TableRef(table, null)),
+        joins    = emptyList(),
+        where    = where, groupBy = emptyList(), having = null,
+        orderBy  = emptyList(), limit = null)
+
+    private fun col(column: String)              = OutputColumn.Expr(SqlExpr.Column(null, column), null)
+    private fun colAs(column: String, alias: String) = OutputColumn.Expr(SqlExpr.Column(null, column), alias)
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // C1 — SELECT * FROM users
+    // ═══════════════════════════════════════════════════════════════════════════
+    @Test @DisplayName("C1: SELECT * FROM users")
+    fun c1_selectStarFromUsers() {
+        val plan = planner().plan(selectStar("users"))
+        val proj = assertIs<LogicalPlan.Project>(plan)
+        assertEquals(1, proj.columns.size)
+        assertIs<OutputColumn.Star>(proj.columns[0])
+        val scan = assertIs<LogicalPlan.Scan>(proj.input)
+        assertEquals("users", scan.table)
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // C2 — SELECT * FROM users WHERE age > 18
+    // ═══════════════════════════════════════════════════════════════════════════
+    @Test @DisplayName("C2: SELECT * FROM users WHERE age > 18")
+    fun c2_selectStarWhereAge() {
+        val where = SqlExpr.BinaryOp(BinaryOperator.GT, SqlExpr.Column(null, "age"), SqlExpr.Literal(18L))
+        val plan  = planner().plan(selectStarWhere("users", where))
+        val proj  = assertIs<LogicalPlan.Project>(plan)
+        val filt  = assertIs<LogicalPlan.Filter>(proj.input)
+        val pred  = assertIs<SqlExpr.BinaryOp>(filt.predicate)
+        assertEquals(BinaryOperator.GT, pred.op)
+        val col   = assertIs<SqlExpr.Column>(pred.left)
+        assertEquals("age", col.column)
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // C3 — SELECT id, name FROM users
+    // ═══════════════════════════════════════════════════════════════════════════
+    @Test @DisplayName("C3: SELECT id, name FROM users")
+    fun c3_selectColumns() {
+        val stmt = Statement.Select(false, listOf(col("id"), col("name")),
+            listOf(TableRef("users", null)), emptyList(), null, emptyList(), null, emptyList(), null)
+        val plan = planner().plan(stmt)
+        val proj = assertIs<LogicalPlan.Project>(plan)
+        assertEquals(2, proj.columns.size)
+        val c0 = assertIs<OutputColumn.Expr>(proj.columns[0])
+        val c1 = assertIs<OutputColumn.Expr>(proj.columns[1])
+        assertEquals("id",   (c0.expression as SqlExpr.Column).column)
+        assertEquals("name", (c1.expression as SqlExpr.Column).column)
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // C4 — SELECT name AS n FROM users
+    // ═══════════════════════════════════════════════════════════════════════════
+    @Test @DisplayName("C4: SELECT name AS n FROM users")
+    fun c4_selectAlias() {
+        val stmt = Statement.Select(false, listOf(colAs("name", "n")),
+            listOf(TableRef("users", null)), emptyList(), null, emptyList(), null, emptyList(), null)
+        val plan = planner().plan(stmt)
+        val proj = assertIs<LogicalPlan.Project>(plan)
+        val c0   = assertIs<OutputColumn.Expr>(proj.columns[0])
+        assertEquals("n", c0.alias)
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // C5 — SELECT * FROM users ORDER BY name ASC
+    // ═══════════════════════════════════════════════════════════════════════════
+    @Test @DisplayName("C5: SELECT * FROM users ORDER BY name ASC")
+    fun c5_orderBy() {
+        val stmt = Statement.Select(false, listOf(OutputColumn.Star),
+            listOf(TableRef("users", null)), emptyList(), null, emptyList(), null,
+            listOf(SortKey(SqlExpr.Column(null, "name"), SortDir.ASC, NullOrder.NULLS_LAST)), null)
+        val plan = planner().plan(stmt)
+        val proj = assertIs<LogicalPlan.Project>(plan)
+        val sort = assertIs<LogicalPlan.Sort>(proj.input)
+        assertEquals(1, sort.keys.size)
+        assertEquals(SortDir.ASC, sort.keys[0].direction)
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // C6 — SELECT * FROM users LIMIT 10
+    // ═══════════════════════════════════════════════════════════════════════════
+    @Test @DisplayName("C6: SELECT * FROM users LIMIT 10")
+    fun c6_limit() {
+        val stmt = Statement.Select(false, listOf(OutputColumn.Star),
+            listOf(TableRef("users", null)), emptyList(), null, emptyList(), null, emptyList(),
+            LimitClause(10L, null))
+        val plan  = planner().plan(stmt)
+        val proj  = assertIs<LogicalPlan.Project>(plan)
+        val limit = assertIs<LogicalPlan.Limit>(proj.input)
+        assertEquals(10L, limit.count)
+        assertNull(limit.offset)
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // C7 — SELECT DISTINCT name FROM users
+    // ═══════════════════════════════════════════════════════════════════════════
+    @Test @DisplayName("C7: SELECT DISTINCT name FROM users")
+    fun c7_distinct() {
+        val stmt = Statement.Select(true, listOf(col("name")),
+            listOf(TableRef("users", null)), emptyList(), null, emptyList(), null, emptyList(), null)
+        val plan = planner().plan(stmt)
+        val proj = assertIs<LogicalPlan.Project>(plan)
+        val dist = assertIs<LogicalPlan.Distinct>(proj.input)
+        assertIs<LogicalPlan.Scan>(dist.input)
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // C8 — SELECT COUNT(*) FROM users GROUP BY age
+    // ═══════════════════════════════════════════════════════════════════════════
+    @Test @DisplayName("C8: SELECT COUNT(*) FROM users GROUP BY age")
+    fun c8_aggregate() {
+        val countStar = SqlExpr.AggExpr(AggFunction.COUNT, AggArg.Star, false)
+        val stmt = Statement.Select(
+            false, listOf(OutputColumn.Expr(countStar, null)),
+            listOf(TableRef("users", null)), emptyList(), null,
+            listOf(SqlExpr.Column(null, "age")), null, emptyList(), null)
+        val plan = planner().plan(stmt)
+        val proj = assertIs<LogicalPlan.Project>(plan)
+        val agg  = assertIs<LogicalPlan.Aggregate>(proj.input)
+        assertEquals(1, agg.groupBy.size)
+        assertTrue(agg.aggregates.isNotEmpty())
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // C9 — HAVING generates Having node
+    // ═══════════════════════════════════════════════════════════════════════════
+    @Test @DisplayName("C9: HAVING clause generates Having node")
+    fun c9_having() {
+        val countStar = SqlExpr.AggExpr(AggFunction.COUNT, AggArg.Star, false)
+        val having    = SqlExpr.BinaryOp(BinaryOperator.GT, countStar, SqlExpr.Literal(5L))
+        val stmt = Statement.Select(
+            false, listOf(col("age")),
+            listOf(TableRef("users", null)), emptyList(), null,
+            listOf(SqlExpr.Column(null, "age")), having, emptyList(), null)
+        val plan = planner().plan(stmt)
+        val proj = assertIs<LogicalPlan.Project>(plan)
+        val hav  = assertIs<LogicalPlan.Having>(proj.input)
+        assertIs<LogicalPlan.Aggregate>(hav.input)
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // C10 — INSERT
+    // ═══════════════════════════════════════════════════════════════════════════
+    @Test @DisplayName("C10: INSERT into known table produces Insert plan")
+    fun c10_insert() {
+        val stmt = Statement.Insert("users", listOf("id", "name", "age", "email"),
+            listOf(listOf(SqlExpr.Literal(1L), SqlExpr.Literal("Alice"), SqlExpr.Literal(30L), SqlExpr.Literal("alice@example.com"))))
+        val plan = planner().plan(stmt)
+        val ins  = assertIs<LogicalPlan.Insert>(plan)
+        assertEquals("users", ins.table)
+        assertEquals(4, ins.columns.size)
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // C11 — UPDATE
+    // ═══════════════════════════════════════════════════════════════════════════
+    @Test @DisplayName("C11: UPDATE produces Update plan")
+    fun c11_update() {
+        val stmt = Statement.Update("users",
+            listOf(Assignment("age", SqlExpr.Literal(31L))),
+            SqlExpr.BinaryOp(BinaryOperator.EQ, SqlExpr.Column(null, "id"), SqlExpr.Literal(1L)))
+        val plan = planner().plan(stmt)
+        val upd  = assertIs<LogicalPlan.Update>(plan)
+        assertEquals("users", upd.table)
+        assertEquals(1, upd.assignments.size)
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // C12 — DELETE
+    // ═══════════════════════════════════════════════════════════════════════════
+    @Test @DisplayName("C12: DELETE produces Delete plan")
+    fun c12_delete() {
+        val stmt = Statement.Delete("users",
+            SqlExpr.BinaryOp(BinaryOperator.EQ, SqlExpr.Column(null, "id"), SqlExpr.Literal(1L)))
+        val plan = planner().plan(stmt)
+        val del  = assertIs<LogicalPlan.Delete>(plan)
+        assertEquals("users", del.table)
+        assertNotNull(del.predicate)
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // C13 — CREATE TABLE + DROP TABLE
+    // ═══════════════════════════════════════════════════════════════════════════
+    @Test @DisplayName("C13a: CREATE TABLE produces CreateTable plan")
+    fun c13a_createTable() {
+        val stmt = Statement.CreateTable("logs", false,
+            listOf(ColumnDef("id", "INTEGER", notNull = true, primaryKey = true, unique = false, default = null)))
+        val plan = planner().plan(stmt)
+        val ct   = assertIs<LogicalPlan.CreateTable>(plan)
+        assertEquals("logs", ct.table)
+        assertFalse(ct.ifNotExists)
+    }
+
+    @Test @DisplayName("C13b: DROP TABLE produces DropTable plan")
+    fun c13b_dropTable() {
+        val stmt = Statement.DropTable("logs", true)
+        val plan = planner().plan(stmt)
+        val dt   = assertIs<LogicalPlan.DropTable>(plan)
+        assertEquals("logs", dt.table)
+        assertTrue(dt.ifExists)
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Structural tests
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    @Test @DisplayName("Struct: multi-FROM cross join")
+    fun struct_multiFromCrossJoin() {
+        val stmt = Statement.Select(false, listOf(OutputColumn.Star),
+            listOf(TableRef("users", null), TableRef("orders", null)),
+            emptyList(), null, emptyList(), null, emptyList(), null)
+        val plan = planner().plan(stmt)
+        val proj = assertIs<LogicalPlan.Project>(plan)
+        val join = assertIs<LogicalPlan.Join>(proj.input)
+        assertEquals(JoinKind.CROSS, join.kind)
+    }
+
+    @Test @DisplayName("Struct: INNER JOIN on condition")
+    fun struct_innerJoin() {
+        val on  = SqlExpr.BinaryOp(BinaryOperator.EQ,
+            SqlExpr.Column("users", "id"), SqlExpr.Column("orders", "user_id"))
+        val jc  = JoinClause(JoinKind.INNER, "orders", null, on)
+        val stmt = Statement.Select(false, listOf(OutputColumn.Star),
+            listOf(TableRef("users", null)), listOf(jc),
+            null, emptyList(), null, emptyList(), null)
+        val plan = planner().plan(stmt)
+        val proj = assertIs<LogicalPlan.Project>(plan)
+        val join = assertIs<LogicalPlan.Join>(proj.input)
+        assertEquals(JoinKind.INNER, join.kind)
+    }
+
+    @Test @DisplayName("Struct: table alias resolves correctly")
+    fun struct_tableAlias() {
+        val stmt = Statement.Select(false,
+            listOf(OutputColumn.Expr(SqlExpr.Column("u", "name"), null)),
+            listOf(TableRef("users", "u")),
+            emptyList(), null, emptyList(), null, emptyList(), null)
+        val plan = planner().plan(stmt)
+        val proj = assertIs<LogicalPlan.Project>(plan)
+        val c0   = assertIs<OutputColumn.Expr>(proj.columns[0])
+        val col  = assertIs<SqlExpr.Column>(c0.expression)
+        assertEquals("u",    col.table)
+        assertEquals("name", col.column)
+    }
+
+    @Test @DisplayName("Struct: DISTINCT + ORDER BY + LIMIT stacking")
+    fun struct_distinctSortLimit() {
+        val stmt = Statement.Select(
+            true, listOf(col("name")),
+            listOf(TableRef("users", null)), emptyList(), null, emptyList(), null,
+            listOf(SortKey(SqlExpr.Column(null, "name"), SortDir.DESC, NullOrder.NULLS_LAST)),
+            LimitClause(5L, 2L))
+        val plan  = planner().plan(stmt)
+        val proj  = assertIs<LogicalPlan.Project>(plan)
+        val limit = assertIs<LogicalPlan.Limit>(proj.input)
+        val sort  = assertIs<LogicalPlan.Sort>(limit.input)
+        val dist  = assertIs<LogicalPlan.Distinct>(sort.input)
+        assertIs<LogicalPlan.Scan>(dist.input)
+        assertEquals(5L, limit.count)
+        assertEquals(2L, limit.offset)
+    }
+
+    @Test @DisplayName("Struct: planAll returns one plan per statement")
+    fun struct_planAll() {
+        val stmts = listOf<Statement>(selectStar("users"), Statement.DropTable("nope", true))
+        val plans = planner().planAll(stmts)
+        assertEquals(2, plans.size)
+        assertIs<LogicalPlan.Project>(plans[0])
+        assertIs<LogicalPlan.DropTable>(plans[1])
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Error tests
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    @Test @DisplayName("Error: unknown table in FROM throws UnknownTableException")
+    fun error_unknownTable() {
+        val ex = assertThrows<UnknownTableException> { planner().plan(selectStar("ghost")) }
+        assertEquals("ghost", ex.table)
+    }
+
+    @Test @DisplayName("Error: unknown column in WHERE throws UnknownColumnException")
+    fun error_unknownColumn() {
+        val where = SqlExpr.BinaryOp(BinaryOperator.EQ, SqlExpr.Column(null, "no_such_col"), SqlExpr.Literal(1L))
+        assertThrows<UnknownColumnException> { planner().plan(selectStarWhere("users", where)) }
+    }
+
+    @Test @DisplayName("Error: ambiguous unqualified column throws AmbiguousColumnException")
+    fun error_ambiguousColumn() {
+        val stmt = Statement.Select(false,
+            listOf(OutputColumn.Expr(SqlExpr.Column(null, "id"), null)),
+            listOf(TableRef("users", null), TableRef("orders", null)),
+            emptyList(), null, emptyList(), null, emptyList(), null)
+        val ex = assertThrows<AmbiguousColumnException> { planner().plan(stmt) }
+        assertEquals("id", ex.column)
+        assertTrue(ex.tables.size >= 2)
+    }
+
+    @Test @DisplayName("Error: qualified column against unknown alias throws UnknownTableException")
+    fun error_unknownAlias() {
+        val stmt = Statement.Select(false,
+            listOf(OutputColumn.Expr(SqlExpr.Column("x", "id"), null)),
+            listOf(TableRef("users", null)),
+            emptyList(), null, emptyList(), null, emptyList(), null)
+        assertThrows<UnknownTableException> { planner().plan(stmt) }
+    }
+
+    @Test @DisplayName("Error: INSERT into unknown table throws UnknownTableException")
+    fun error_insertUnknownTable() {
+        assertThrows<UnknownTableException> {
+            planner().plan(Statement.Insert("nope", listOf("id"), listOf(listOf(SqlExpr.Literal(1L)))))
+        }
+    }
+
+    @Test @DisplayName("Error: UPDATE on unknown table throws UnknownTableException")
+    fun error_updateUnknownTable() {
+        assertThrows<UnknownTableException> {
+            planner().plan(Statement.Update("nope", listOf(Assignment("id", SqlExpr.Literal(1L))), null))
+        }
+    }
+
+    @Test @DisplayName("Error: DELETE from unknown table throws UnknownTableException")
+    fun error_deleteUnknownTable() {
+        assertThrows<UnknownTableException> {
+            planner().plan(Statement.Delete("nope", null))
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Expression-type tests
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    @Test @DisplayName("Expr: IS NULL predicate resolves inner column")
+    fun expr_isNull() {
+        val plan  = planner().plan(selectStarWhere("users", SqlExpr.IsNull(SqlExpr.Column(null, "email"))))
+        val proj  = assertIs<LogicalPlan.Project>(plan)
+        val filt  = assertIs<LogicalPlan.Filter>(proj.input)
+        val isNull = assertIs<SqlExpr.IsNull>(filt.predicate)
+        assertEquals("email", (isNull.operand as SqlExpr.Column).column)
+    }
+
+    @Test @DisplayName("Expr: IS NOT NULL predicate resolves inner column")
+    fun expr_isNotNull() {
+        val plan  = planner().plan(selectStarWhere("users", SqlExpr.IsNotNull(SqlExpr.Column(null, "email"))))
+        val proj  = assertIs<LogicalPlan.Project>(plan)
+        val filt  = assertIs<LogicalPlan.Filter>(proj.input)
+        assertIs<SqlExpr.IsNotNull>(filt.predicate)
+    }
+
+    @Test @DisplayName("Expr: BETWEEN resolves value, lo, hi columns")
+    fun expr_between() {
+        val plan  = planner().plan(selectStarWhere("users",
+            SqlExpr.Between(SqlExpr.Column(null, "age"), SqlExpr.Literal(18L), SqlExpr.Literal(65L))))
+        val proj  = assertIs<LogicalPlan.Project>(plan)
+        val filt  = assertIs<LogicalPlan.Filter>(proj.input)
+        val bet   = assertIs<SqlExpr.Between>(filt.predicate)
+        assertEquals("age", (bet.value as SqlExpr.Column).column)
+    }
+
+    @Test @DisplayName("Expr: IN resolves value and items")
+    fun expr_in() {
+        val plan  = planner().plan(selectStarWhere("users",
+            SqlExpr.In(SqlExpr.Column(null, "age"), listOf(SqlExpr.Literal(20L), SqlExpr.Literal(30L)))))
+        val proj  = assertIs<LogicalPlan.Project>(plan)
+        val filt  = assertIs<LogicalPlan.Filter>(proj.input)
+        val inExpr = assertIs<SqlExpr.In>(filt.predicate)
+        assertEquals(2, inExpr.items.size)
+    }
+
+    @Test @DisplayName("Expr: NOT IN resolves value and items")
+    fun expr_notIn() {
+        val plan  = planner().plan(selectStarWhere("users",
+            SqlExpr.NotIn(SqlExpr.Column(null, "age"), listOf(SqlExpr.Literal(0L)))))
+        val proj  = assertIs<LogicalPlan.Project>(plan)
+        val filt  = assertIs<LogicalPlan.Filter>(proj.input)
+        assertIs<SqlExpr.NotIn>(filt.predicate)
+    }
+
+    @Test @DisplayName("Expr: LIKE resolves value column")
+    fun expr_like() {
+        val plan  = planner().plan(selectStarWhere("users", SqlExpr.Like(SqlExpr.Column(null, "name"), "%Alice%")))
+        val proj  = assertIs<LogicalPlan.Project>(plan)
+        val filt  = assertIs<LogicalPlan.Filter>(proj.input)
+        val like  = assertIs<SqlExpr.Like>(filt.predicate)
+        assertEquals("%Alice%", like.pattern)
+    }
+
+    @Test @DisplayName("Expr: NOT LIKE resolves value column")
+    fun expr_notLike() {
+        val plan  = planner().plan(selectStarWhere("users", SqlExpr.NotLike(SqlExpr.Column(null, "name"), "%Bob%")))
+        val proj  = assertIs<LogicalPlan.Project>(plan)
+        val filt  = assertIs<LogicalPlan.Filter>(proj.input)
+        assertIs<SqlExpr.NotLike>(filt.predicate)
+    }
+
+    @Test @DisplayName("Expr: Unary NOT resolves operand column")
+    fun expr_unaryNot() {
+        val where = SqlExpr.UnaryOp(UnaryOperator.NOT,
+            SqlExpr.BinaryOp(BinaryOperator.EQ, SqlExpr.Column(null, "age"), SqlExpr.Literal(0L)))
+        val plan  = planner().plan(selectStarWhere("users", where))
+        val proj  = assertIs<LogicalPlan.Project>(plan)
+        val filt  = assertIs<LogicalPlan.Filter>(proj.input)
+        assertIs<SqlExpr.UnaryOp>(filt.predicate)
+    }
+
+    @Test @DisplayName("Expr: FuncCall resolves argument columns")
+    fun expr_funcCall() {
+        val where = SqlExpr.BinaryOp(BinaryOperator.GT,
+            SqlExpr.FuncCall("LENGTH", listOf(SqlExpr.Column(null, "name"))),
+            SqlExpr.Literal(3L))
+        val plan  = planner().plan(selectStarWhere("users", where))
+        val proj  = assertIs<LogicalPlan.Project>(plan)
+        val filt  = assertIs<LogicalPlan.Filter>(proj.input)
+        val bop   = assertIs<SqlExpr.BinaryOp>(filt.predicate)
+        val fn    = assertIs<SqlExpr.FuncCall>(bop.left)
+        assertEquals("LENGTH", fn.name)
+    }
+
+    // ─── Error propagation inside expressions ─────────────────────────────────
+
+    @Test @DisplayName("Expr error: BETWEEN bad value column throws")
+    fun exprErr_betweenValue() {
+        assertThrows<UnknownColumnException> {
+            planner().plan(selectStarWhere("users",
+                SqlExpr.Between(SqlExpr.Column(null, "ghost"), SqlExpr.Literal(1L), SqlExpr.Literal(10L))))
+        }
+    }
+
+    @Test @DisplayName("Expr error: BETWEEN bad lo column throws")
+    fun exprErr_betweenLo() {
+        assertThrows<UnknownColumnException> {
+            planner().plan(selectStarWhere("users",
+                SqlExpr.Between(SqlExpr.Column(null, "age"), SqlExpr.Column(null, "ghost_lo"), SqlExpr.Literal(10L))))
+        }
+    }
+
+    @Test @DisplayName("Expr error: BETWEEN bad hi column throws")
+    fun exprErr_betweenHi() {
+        assertThrows<UnknownColumnException> {
+            planner().plan(selectStarWhere("users",
+                SqlExpr.Between(SqlExpr.Column(null, "age"), SqlExpr.Literal(1L), SqlExpr.Column(null, "ghost_hi"))))
+        }
+    }
+
+    @Test @DisplayName("Expr error: IN bad item column throws")
+    fun exprErr_inItem() {
+        assertThrows<UnknownColumnException> {
+            planner().plan(selectStarWhere("users",
+                SqlExpr.In(SqlExpr.Column(null, "age"), listOf(SqlExpr.Column(null, "ghost_col")))))
+        }
+    }
+
+    @Test @DisplayName("Expr error: NOT IN bad item column throws")
+    fun exprErr_notInItem() {
+        assertThrows<UnknownColumnException> {
+            planner().plan(selectStarWhere("users",
+                SqlExpr.NotIn(SqlExpr.Column(null, "age"), listOf(SqlExpr.Column(null, "ghost_col")))))
+        }
+    }
+
+    @Test @DisplayName("Expr error: FuncCall bad arg column throws")
+    fun exprErr_funcCallArg() {
+        assertThrows<UnknownColumnException> {
+            planner().plan(selectStarWhere("users",
+                SqlExpr.BinaryOp(BinaryOperator.GT,
+                    SqlExpr.FuncCall("LENGTH", listOf(SqlExpr.Column(null, "ghost_col"))),
+                    SqlExpr.Literal(3L))))
+        }
+    }
+
+    @Test @DisplayName("Expr error: IS NULL bad inner column throws")
+    fun exprErr_isNullBadCol() {
+        assertThrows<UnknownColumnException> {
+            planner().plan(selectStarWhere("users", SqlExpr.IsNull(SqlExpr.Column(null, "ghost_col"))))
+        }
+    }
+
+    @Test @DisplayName("Expr error: IS NOT NULL bad inner column throws")
+    fun exprErr_isNotNullBadCol() {
+        assertThrows<UnknownColumnException> {
+            planner().plan(selectStarWhere("users", SqlExpr.IsNotNull(SqlExpr.Column(null, "ghost_col"))))
+        }
+    }
+
+    @Test @DisplayName("Expr error: LIKE bad value column throws")
+    fun exprErr_likeBadCol() {
+        assertThrows<UnknownColumnException> {
+            planner().plan(selectStarWhere("users", SqlExpr.Like(SqlExpr.Column(null, "ghost_col"), "%x%")))
+        }
+    }
+
+    @Test @DisplayName("Expr error: NOT LIKE bad value column throws")
+    fun exprErr_notLikeBadCol() {
+        assertThrows<UnknownColumnException> {
+            planner().plan(selectStarWhere("users", SqlExpr.NotLike(SqlExpr.Column(null, "ghost_col"), "%x%")))
+        }
+    }
+
+    @Test @DisplayName("Expr: Literal null value preserved")
+    fun expr_literalNull() {
+        planner().plan(selectStarWhere("users", SqlExpr.IsNull(SqlExpr.Literal(null))))
+    }
+
+    @Test @DisplayName("Aggregate: SUM with no GROUP BY produces Aggregate node")
+    fun agg_sumNoGroupBy() {
+        val sum  = SqlExpr.AggExpr(AggFunction.SUM, AggArg.Expr(SqlExpr.Column(null, "amount")), false)
+        val stmt = Statement.Select(false, listOf(OutputColumn.Expr(sum, null)),
+            listOf(TableRef("orders", null)), emptyList(), null, emptyList(), null, emptyList(), null)
+        val plan = planner().plan(stmt)
+        val proj = assertIs<LogicalPlan.Project>(plan)
+        assertIs<LogicalPlan.Aggregate>(proj.input)
+    }
+
+    @Test @DisplayName("Aggregate: COUNT DISTINCT")
+    fun agg_countDistinct() {
+        val cd   = SqlExpr.AggExpr(AggFunction.COUNT, AggArg.Expr(SqlExpr.Column(null, "name")), true)
+        val stmt = Statement.Select(false, listOf(OutputColumn.Expr(cd, null)),
+            listOf(TableRef("users", null)), emptyList(), null, emptyList(), null, emptyList(), null)
+        val plan = planner().plan(stmt)
+        val proj = assertIs<LogicalPlan.Project>(plan)
+        val agg  = assertIs<LogicalPlan.Aggregate>(proj.input)
+        assertTrue(agg.aggregates[0].distinct)
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `code/packages/kotlin/sql-planner` — a pure in-memory logical query planner for the Mini-SQLite Level 1 pipeline
- Kotlin sealed classes + data classes for `SqlExpr` (14 subclasses), `LogicalPlan` (15 subclasses), and `Statement` (6 subclasses) — exhaustive `when` expressions enforced at compile time
- 8-step bottom-up SELECT pipeline: Scan → Filter → Aggregate → Having → Project → Distinct → Sort → Limit
- `PlanException` hierarchy (5 subtypes) consistent with Kotlin `sql-backend` style
- 50 JUnit 5 tests: C1–C13 conformance battery, structural tests (JOIN, aliases, DISTINCT/SORT/LIMIT stacking), error-path tests, expression-type tests, error propagation through nested expressions
- JaCoCo ≥80% line coverage enforced in `check`

## Test plan

- [ ] CI passes on ubuntu, macos, windows
- [ ] `gradle test` compiles and runs all 50 tests green
- [ ] JaCoCo coverage check passes (≥80% line)
- [ ] Column resolution: qualified refs, unqualified refs, ambiguity detection, alias threading
- [ ] Error paths: UnknownTable, UnknownColumn, AmbiguousColumn propagate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
