### PR TITLE
fix(javascript-parser): bridge chained calls f()() instead of erroring

### DIFF
--- a/code/packages/rust/javascript-parser/CHANGELOG.md
+++ b/code/packages/rust/javascript-parser/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 All notable changes to the `coding-adventures-javascript-parser` crate will be documented in this file.
 
+## [0.19.6] - 2026-06-30
+
+### Fixed — chained calls `f()()` raised a bridge internal error
+
+A chained call such as `f()()` or `f(1)(2)(3)` raised
+`bridge internal error: arguments: unknown expression rule 'arguments'`,
+so any program containing one failed to compile.
+
+The grammar models calls with left recursion
+(`call_expression = call_expression arguments`), and the parser flattens a
+chain of call sites into a **single** `call_expression` node whose children
+are the base followed by one `arguments` node per call site:
+
+```
+f()()   →  call_expression[ member_expression(f), arguments(()), arguments(()) ]
+```
+
+`convert_call_expression` derived the callee of the outer call by converting
+the *second-to-last* child directly — for a 3-child chain that child is the
+inner `arguments` node, not an expression, so `convert_expression` fell through
+to its catch-all and reported the rule name `arguments`.
+
+The callee is now rebuilt by folding the leading `arguments` nodes
+left-to-right into nested `CallExpression`s
+(`f` → `f()` → `f()()`), with the final `arguments` node forming the outer
+call. A guard keeps this sound: because `node_children` strips `Token`
+children, a `.`/`[` member access appearing between calls would be invisible
+to the fold, so when such a token is present at this level we fall through to
+the existing unsupported-syntax path (an error) rather than risk silently
+turning `f().x()` into `f()()`. Pure call chains carry no such tokens and now
+round-trip correctly; interleaved member/call forms continue to nest into
+their own sub-nodes and are unaffected.
+
+Regression tests: `chained_call_expression`, `triple_chained_call_with_args`.
+
 ## [0.19.5] - 2026-06-30
 
 ### Fixed — prefix `++` / `--` silently dropped (miscompile)

--- a/code/packages/rust/javascript-parser/Cargo.toml
+++ b/code/packages/rust/javascript-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-javascript-parser"
-version = "0.19.5"
+version = "0.19.6"
 edition = "2021"
 description = "JavaScript parser — parses JavaScript source code against any ECMAScript edition (es1 through es2025) using the grammar-driven parser. Includes correlation-vector plumbing per CLOC03 and a typed-AST bridge (GrammarASTNode → javascript_ast::Program) per CLOC12.136."
 

--- a/code/packages/rust/javascript-parser/src/bridge.rs
+++ b/code/packages/rust/javascript-parser/src/bridge.rs
@@ -1572,13 +1572,51 @@ fn convert_call_expression(node: &GrammarASTNode) -> Result<Expression, BridgeEr
     let last = nodes.last().unwrap();
     match last.rule_name.as_str() {
         "arguments" => {
-            // f(args) — callee is everything before arguments
-            let callee = if nodes.len() == 2 {
-                convert_expression(nodes[0])?
-            } else {
-                // Recursive: re-interpret all but last as call_expression
-                convert_expression(nodes[nodes.len() - 2])?
-            };
+            // A trailing `arguments` node means this is a call: `<callee>(args)`.
+            //
+            // For a simple call `f(x)` the grammar yields exactly two children:
+            //   [member_expression(f), arguments(x)]
+            // and the callee is just `nodes[0]`.
+            //
+            // For a CHAINED call like `f()()` or `f(1)(2)(3)` the parser
+            // flattens the left-recursion into a single call_expression node
+            // whose children are the base followed by ONE `arguments` node per
+            // call site:
+            //   [member_expression(f), arguments(()), arguments(())]
+            // The callee of the outermost call is therefore the call formed by
+            // the base plus every `arguments` node except the last. We rebuild
+            // that by folding left-to-right:
+            //   f            (base)
+            //   f()          (after first arguments)
+            //   f()()        (outer call, built from `last` below)
+            //
+            // GUARD: `node_children` strips Token children, so a `.`/`[` that
+            // appears between calls (e.g. `f().x()`) would be silently dropped,
+            // turning `f().x()` into `f()()` — a miscompile. We only fold when
+            // no member-access tokens are present at this level; otherwise we
+            // fall through to the unsupported path (sound: an error, never a
+            // wrong program). Pure call chains carry no such tokens.
+            //
+            // A well-formed call always has a callee, so there are at least two
+            // children (`<callee>` then `arguments`). Reject anything shorter
+            // with a clean error rather than indexing `nodes[0]` / slicing
+            // `nodes[1..len-1]` (which would underflow to `1..0` and panic) on a
+            // malformed node from untrusted source.
+            if nodes.len() < 2 {
+                return Err(internal(node, "call_expression: arguments without a callee"));
+            }
+            let mut callee = convert_expression(nodes[0])?;
+            for mid in &nodes[1..nodes.len() - 1] {
+                if mid.rule_name != "arguments" || has_token(node, ".") || has_token(node, "[") {
+                    return Err(unsupported(node));
+                }
+                let mid_args = convert_arguments(mid)?;
+                callee = Expression::CallExpression(CallExpression {
+                    cv: None,
+                    callee: Box::new(callee),
+                    arguments: mid_args,
+                });
+            }
             let args = convert_arguments(last)?;
             Ok(Expression::CallExpression(CallExpression {
                 cv: None,
@@ -2785,6 +2823,49 @@ mod tests {
             }
             _ => panic!("expected call expression"),
         }
+    }
+
+    #[test]
+    fn chained_call_expression() {
+        // `f()()` — the callee of the OUTER call is itself the call `f()`.
+        // Regression: the parser flattens chained left-recursive calls into a
+        // single call_expression node `[member_expression(f), arguments, arguments]`,
+        // and the bridge previously tried to convert the inner `arguments` node
+        // as an expression, raising "unknown expression rule 'arguments'".
+        let outer = match first_expr(&bridge_ok("f()();")) {
+            Expression::CallExpression(c) => c.clone(),
+            other => panic!("expected CallExpression, got {other:?}"),
+        };
+        assert_eq!(outer.arguments.len(), 0);
+        match &*outer.callee {
+            Expression::CallExpression(inner) => {
+                assert_eq!(inner.arguments.len(), 0);
+                assert!(matches!(&*inner.callee, Expression::Identifier(id) if id.name == "f"));
+            }
+            other => panic!("expected inner CallExpression, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn triple_chained_call_with_args() {
+        // `f(1)(2)(3)` folds left-to-right: ((f(1))(2))(3). Verify the nesting
+        // and that each call site keeps its own single argument.
+        let c3 = match first_expr(&bridge_ok("f(1)(2)(3);")) {
+            Expression::CallExpression(c) => c.clone(),
+            other => panic!("expected CallExpression, got {other:?}"),
+        };
+        assert_eq!(c3.arguments.len(), 1); // (3)
+        let c2 = match &*c3.callee {
+            Expression::CallExpression(c) => c.clone(),
+            other => panic!("expected CallExpression, got {other:?}"),
+        };
+        assert_eq!(c2.arguments.len(), 1); // (2)
+        let c1 = match &*c2.callee {
+            Expression::CallExpression(c) => c.clone(),
+            other => panic!("expected CallExpression, got {other:?}"),
+        };
+        assert_eq!(c1.arguments.len(), 1); // (1)
+        assert!(matches!(&*c1.callee, Expression::Identifier(id) if id.name == "f"));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

A chained call such as `f()()` or `f(1)(2)(3)` raised
`bridge internal error: arguments: unknown expression rule 'arguments'`,
so **any** JS program containing one failed to compile at SIMPLE/ADVANCED.

Reproduced before the fix:
```
$ closurec --js <(echo 'var x = f()();') --compilation_level SIMPLE
bridge internal error: arguments: unknown expression rule 'arguments'
```

## Root cause

The grammar models calls with left recursion
(`call_expression = call_expression arguments`). The parser flattens a chain
of call sites into a **single** `call_expression` node whose children are the
base followed by one `arguments` node per call site:

```
f()()  →  call_expression[ member_expression(f), arguments(()), arguments(()) ]
```

`convert_call_expression` derived the outer callee from the *second-to-last*
child directly — for a 3+ child chain that child is an inner `arguments` node,
not an expression, so `convert_expression` hit its catch-all and reported the
rule name `arguments`.

## Fix

Rebuild the callee by folding the leading `arguments` nodes left-to-right into
nested `CallExpression`s (`f` → `f()` → `f()()`), the final `arguments` node
forming the outer call.

**Soundness guard:** `node_children` strips `Token` children, so a `.`/`[`
member access appearing *between* calls would be invisible to the fold and
could silently turn `f().x()` into `f()()` (a miscompile). When such a token is
present at this level we fall through to the existing unsupported-syntax path
(an **error**, never a wrong program). Pure call chains carry no such tokens
and round-trip correctly; interleaved member/call forms nest into their own
sub-nodes and are unaffected. A `len < 2` check returns a clean error instead
of risking a `1..0` slice panic on a malformed node.

## Verification

- New bridge regression tests: `chained_call_expression`, `triple_chained_call_with_args`.
- `javascript-parser`: 89 tests green.
- All 5 downstream `javascript-parser` consumers green: closure-pass-inline, -inline-variables, -rename, -rename-globals, -rename-properties.
- `closurec`: 685 tests green; e2e via the binary confirms `f()()`→`f()()`, `f(1)(2)(3)`→`f(1)(2)(3)`, `g(a)(b)`→`g(a)(b)`, and `f().x()`→`f().x()` (member access preserved, no collapse).
- Scoped to `javascript-parser` only (closurec picks up the fix via its path dependency) — no version-line churn.
- Inline security review: **PASSED** (verified `len==1` unreachable, iterative fold = no new DoS, guard is fail-closed).

`javascript-parser` 0.19.5 → 0.19.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)