### PR TITLE
Add smart home dashboard service catalog controls

### DIFF
--- a/code/packages/rust/smart-home-platform-http/CHANGELOG.md
+++ b/code/packages/rust/smart-home-platform-http/CHANGELOG.md
@@ -34,6 +34,8 @@ All notable changes to this package will be documented in this file.
   service path.
 - Added browser dashboard service and authorized API catalog panels backed by
   the native local-controller discovery routes.
+- Added URL-backed browser dashboard service-catalog controls for service name,
+  capability, target entity, and target scene filters.
 - Added browser dashboard desired-state target controls for light on/off and
   brightness so the local controller can supervise intended state through the
   existing runtime-authorized native API.

--- a/code/packages/rust/smart-home-platform-http/README.md
+++ b/code/packages/rust/smart-home-platform-http/README.md
@@ -118,18 +118,20 @@ can be checked against the runtime policy boundary. Entity cards and state-gap
 rows also link to their current state, registry detail, desired-state target,
 state history, entity-scoped runtime events, and owning bridge command-result
 audit trail. The browser shell also exposes filters for
-room, entity domain/state/control status, API catalog
+room, entity domain/state/control status, service catalog
+service/capability/target-entity/target-scene, API catalog
 surface/method/category/mutation/authorization, runtime event
 kind/activity entity, history event type, history bridge and observed/received
 time windows, command-result status/id/bridge/correlation, runtime event-log
 sequence windows, command-result sequence windows, authorization
 outcome/principal, and capability-grant status/scope/principal,
 with server-backed room scoping across inventory, state, history, event-log,
-and command-result panels plus server-backed activity/history, command audit,
-authorization, and capability-grant scoping and local text search across the
-rendered dashboard rows. Those filter selections are mirrored into URL query
+and command-result panels plus server-backed service catalog,
+activity/history, command audit, authorization, and capability-grant scoping and
+local text search across the rendered dashboard rows. Those filter selections
+are mirrored into URL query
 parameters and restored on page load or browser navigation, so local-controller
-room, activity, history, audit, and
+room, service, activity, history, audit, and
 grant-boundary views can be shared or reopened directly.
 State-history routes also accept numeric observed-time windows through
 `from_ms`/`to_ms` or
@@ -188,6 +190,8 @@ curl 'http://127.0.0.1:8123/api/smart_home/states?domain=light&stale=true'
 curl 'http://127.0.0.1:8123/api/smart_home/states?room_id=kitchen&stale=true'
 curl 'http://127.0.0.1:8123/api/smart_home/states/light.entity_light_1'
 curl 'http://127.0.0.1:8123/api/smart_home/services?domain=light'
+curl 'http://127.0.0.1:8123/api/smart_home/services?domain=light&service=turn_on&entity_id=light.entity_light_1'
+curl 'http://127.0.0.1:8123/api/smart_home/services?capability_id=light.on_off'
 curl 'http://127.0.0.1:8123/api/smart_home/services/light/turn_on'
 curl 'http://127.0.0.1:8123/api/smart_home/entities?domain=light&commandable=true'
 curl 'http://127.0.0.1:8123/api/smart_home/entities?room_id=kitchen'

--- a/code/packages/rust/smart-home-platform-http/src/lib.rs
+++ b/code/packages/rust/smart-home-platform-http/src/lib.rs
@@ -382,6 +382,18 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
               <option value="readonly">Read-only</option>
             </select>
           </label>
+          <label>Service Name
+            <input id="filter-service-name" data-dashboard-filter="service-name" type="search" autocomplete="off">
+          </label>
+          <label>Service Capability
+            <input id="filter-service-capability" data-dashboard-filter="service-capability" type="search" autocomplete="off">
+          </label>
+          <label>Service Entity
+            <input id="filter-service-entity" data-dashboard-filter="service-entity" type="search" autocomplete="off">
+          </label>
+          <label>Service Scene
+            <input id="filter-service-scene" data-dashboard-filter="service-scene" type="search" autocomplete="off">
+          </label>
           <label>API Surface
             <select id="filter-api-surface" data-dashboard-filter="api-surface">
               <option value="">All surfaces</option>
@@ -674,6 +686,10 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
       filterHistoryType: document.querySelector("#filter-history-type"),
       filterRoom: document.querySelector("#filter-room"),
       filterSearch: document.querySelector("#filter-search"),
+      filterServiceCapability: document.querySelector("#filter-service-capability"),
+      filterServiceEntity: document.querySelector("#filter-service-entity"),
+      filterServiceName: document.querySelector("#filter-service-name"),
+      filterServiceScene: document.querySelector("#filter-service-scene"),
       filterState: document.querySelector("#filter-state"),
       gaps: document.querySelector("#gaps"),
       history: document.querySelector("#history"),
@@ -705,6 +721,10 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
       ["domain", els.filterDomain],
       ["state", els.filterState],
       ["control", els.filterControl],
+      ["service_name", els.filterServiceName],
+      ["service_capability", els.filterServiceCapability],
+      ["service_entity", els.filterServiceEntity],
+      ["service_scene", els.filterServiceScene],
       ["api_surface", els.filterApiSurface],
       ["api_method", els.filterApiMethod],
       ["api_category", els.filterApiCategory],
@@ -776,6 +796,10 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
       domain: els.filterDomain.value,
       state: els.filterState.value,
       control: els.filterControl.value,
+      serviceName: els.filterServiceName.value.trim(),
+      serviceCapability: els.filterServiceCapability.value.trim(),
+      serviceEntity: els.filterServiceEntity.value.trim(),
+      serviceScene: els.filterServiceScene.value.trim(),
       apiSurface: els.filterApiSurface.value,
       apiMethod: els.filterApiMethod.value,
       apiCategory: els.filterApiCategory.value.trim(),
@@ -1293,7 +1317,14 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
             received_at_or_after_ms: filters.historyReceivedFromMs,
             received_at_or_before_ms: filters.historyReceivedToMs
           })),
-          json("/api/smart_home/services?limit=8"),
+          json(queryUrl("/api/smart_home/services", {
+            limit: 8,
+            domain: filters.domain,
+            service: filters.serviceName,
+            capability_id: filters.serviceCapability,
+            entity_id: filters.serviceEntity,
+            scene_id: filters.serviceScene
+          })),
           json(queryUrl("/api/smart_home/api", {
             surface: filters.apiSurface,
             method: filters.apiMethod,
@@ -8114,6 +8145,10 @@ mod tests {
             assert!(body.contains("data-dashboard-filter=\"search\""));
             assert!(body.contains("data-dashboard-filter=\"room\""));
             assert!(body.contains("data-dashboard-filter=\"domain\""));
+            assert!(body.contains("data-dashboard-filter=\"service-name\""));
+            assert!(body.contains("data-dashboard-filter=\"service-capability\""));
+            assert!(body.contains("data-dashboard-filter=\"service-entity\""));
+            assert!(body.contains("data-dashboard-filter=\"service-scene\""));
             assert!(body.contains("data-dashboard-filter=\"api-surface\""));
             assert!(body.contains("data-dashboard-filter=\"api-method\""));
             assert!(body.contains("data-dashboard-filter=\"api-category\""));
@@ -8137,6 +8172,10 @@ mod tests {
             assert!(body.contains("[\"api_category\", els.filterApiCategory]"));
             assert!(body.contains("[\"api_mutating\", els.filterApiMutating]"));
             assert!(body.contains("[\"api_authorized\", els.filterApiAuthorized]"));
+            assert!(body.contains("[\"service_name\", els.filterServiceName]"));
+            assert!(body.contains("[\"service_capability\", els.filterServiceCapability]"));
+            assert!(body.contains("[\"service_entity\", els.filterServiceEntity]"));
+            assert!(body.contains("[\"service_scene\", els.filterServiceScene]"));
             assert!(body.contains("[\"event_kind\", els.filterEventKind]"));
             assert!(body.contains("[\"event_from_sequence\", els.filterEventFromSequence]"));
             assert!(body.contains("[\"event_to_sequence\", els.filterEventToSequence]"));
@@ -8181,7 +8220,11 @@ mod tests {
             assert!(body.contains("received_at_or_after_ms: filters.historyReceivedFromMs"));
             assert!(body.contains("received_at_or_before_ms: filters.historyReceivedToMs"));
             assert!(body.matches("entity_id: activityEntity").count() >= 2);
-            assert!(body.contains("json(\"/api/smart_home/services?limit=8\")"));
+            assert!(body.contains("queryUrl(\"/api/smart_home/services\", {"));
+            assert!(body.contains("service: filters.serviceName"));
+            assert!(body.contains("capability_id: filters.serviceCapability"));
+            assert!(body.contains("entity_id: filters.serviceEntity"));
+            assert!(body.contains("scene_id: filters.serviceScene"));
             assert!(body.contains("json(\"/api/smart_home/rooms?sort=scene_count\")"));
             assert!(
                 body.contains("queryUrl(\"/api/smart_home/devices\", {limit: 8, room_id: roomId})")
@@ -9664,6 +9707,10 @@ mod tests {
         assert!(body.contains("json(\"/api/smart_home/bootstrap\")"));
         assert!(body.contains("data-dashboard-filter=\"search\""));
         assert!(body.contains("data-dashboard-filter=\"room\""));
+        assert!(body.contains("data-dashboard-filter=\"service-name\""));
+        assert!(body.contains("data-dashboard-filter=\"service-capability\""));
+        assert!(body.contains("data-dashboard-filter=\"service-entity\""));
+        assert!(body.contains("data-dashboard-filter=\"service-scene\""));
         assert!(body.contains("data-dashboard-filter=\"api-surface\""));
         assert!(body.contains("data-dashboard-filter=\"api-method\""));
         assert!(body.contains("data-dashboard-filter=\"api-category\""));
@@ -9693,6 +9740,10 @@ mod tests {
         assert!(body.contains("[\"api_category\", els.filterApiCategory]"));
         assert!(body.contains("[\"api_mutating\", els.filterApiMutating]"));
         assert!(body.contains("[\"api_authorized\", els.filterApiAuthorized]"));
+        assert!(body.contains("[\"service_name\", els.filterServiceName]"));
+        assert!(body.contains("[\"service_capability\", els.filterServiceCapability]"));
+        assert!(body.contains("[\"service_entity\", els.filterServiceEntity]"));
+        assert!(body.contains("[\"service_scene\", els.filterServiceScene]"));
         assert!(body.contains("[\"event_from_sequence\", els.filterEventFromSequence]"));
         assert!(body.contains("[\"event_to_sequence\", els.filterEventToSequence]"));
         assert!(body.contains("[\"activity_entity\", els.filterActivityEntity]"));
@@ -9733,7 +9784,11 @@ mod tests {
         assert!(body.contains("received_at_or_after_ms: filters.historyReceivedFromMs"));
         assert!(body.contains("received_at_or_before_ms: filters.historyReceivedToMs"));
         assert!(body.matches("entity_id: activityEntity").count() >= 2);
-        assert!(body.contains("json(\"/api/smart_home/services?limit=8\")"));
+        assert!(body.contains("queryUrl(\"/api/smart_home/services\", {"));
+        assert!(body.contains("service: filters.serviceName"));
+        assert!(body.contains("capability_id: filters.serviceCapability"));
+        assert!(body.contains("entity_id: filters.serviceEntity"));
+        assert!(body.contains("scene_id: filters.serviceScene"));
         assert!(body.contains("json(\"/api/smart_home/rooms?sort=scene_count\")"));
         assert!(body.contains("queryUrl(\"/api/smart_home/devices\", {limit: 8, room_id: roomId})"));
         assert!(body.contains("json(\"/api/smart_home/bridges?limit=8\")"));


### PR DESCRIPTION
## Summary
- add URL-backed dashboard controls for service name, capability, target entity, and target scene
- wire the browser services panel through the native /api/smart_home/services query filters
- document service-catalog filter usage and update the package changelog

## Validation
- cargo fmt -p smart-home-platform-http
- cargo test -p smart-home-platform-http -- --nocapture
- sh BUILD
- git diff --check
- test ! -e code/packages/rust/Cargo.lock