### PR TITLE
[codex] Track form interactive tricky repair evidence

### DIFF
--- a/code/packages/rust/html-parser/tests/whatwg_form_interactive_audit_test.rs
+++ b/code/packages/rust/html-parser/tests/whatwg_form_interactive_audit_test.rs
@@ -10,6 +10,7 @@ const WHATWG_FORM_INTERACTIVE_AUDIT: &str =
 const POST_PARSE_REPAIR_EVIDENCE: &[(&str, &str)] = &[
     ("tests26-dat-1251", "interactive-formatting"),
     ("tricky01-dat-8", "interactive-formatting"),
+    ("tricky01-dat-9", "interactive-formatting"),
 ];
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
## Summary
- add `tricky01-dat-9` to the form/interactive post-parse repair evidence list
- lock another existing `interactive-formatting` WHATWG audit case under the repair-evidence assertion
- leave parser behavior and fixtures unchanged

## Validation
- `cargo test -p coding-adventures-html-parser whatwg_form_interactive_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser`
- `cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser`
- `python3 -m json.tool code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json >/dev/null`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py`
- `git diff --check`
