### PR TITLE
feat(python-sir): M4 functions, calls, closures (B4)

### DIFF
--- a/code/packages/rust/python-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/python-to-semantic-ir/CHANGELOG.md
@@ -88,6 +88,15 @@ Milestone **M4**: functions, calls, and closures — `def`, tail-position
   a function body — run on an enlarged stack so the (separately unguarded)
   parser survives to reach the lowerer — and assert a clean "too deep"
   error rather than a crash.
+- **Robust Python 3 resolution in the end-to-end tests.**  The e2e helper
+  now resolves a *working Python 3* interpreter: it tries `python3` first,
+  then `python`, and for each requires `<exe> --version` to report
+  "Python 3.x" (checking both stdout and stderr).  When no Python 3 is
+  found — or the interpreter cannot be launched — the test **skips**
+  (eprintln + return) instead of panicking, mirroring how the other
+  integration tests gate on a tool being present.  A non-zero exit from a
+  *verified* Python 3 still fails the test (a real codegen bug must be
+  caught).  Fixes a macOS-CI failure where `python` was absent / python2.
 
 ### Changed
 

--- a/code/packages/rust/python-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/python-to-semantic-ir/CHANGELOG.md
@@ -69,6 +69,26 @@ Milestone **M4**: functions, calls, and closures — `def`, tail-position
   resolution, lambda + capture, nested-def + capture, mutual-recursion
   detection, default-parameter rejection, and a validator round-trip set.
 
+### Fixed
+
+- **Depth-bounded the three M4 pre-lowering CST walks** so the public
+  `compile` cannot overflow the native (uncatchable) stack on a
+  pathologically deep input.  These walks run *before* the depth-guarded
+  lowering, so they previously bypassed the `MAX_BLOCK_DEPTH` /
+  `MAX_EXPR_DEPTH` guards:
+  - `collect_function_names` (pass-1 def-name collection) now threads a
+    block-nesting `depth` capped at `MAX_BLOCK_DEPTH`;
+  - `collect_free_names` (free-variable scan) and `walk_for_targets` /
+    `descendant_assign_targets` / `collect_suite_bound_names` (bound-name
+    scan) now thread an expression-nesting `depth` capped at
+    `MAX_EXPR_DEPTH`.
+  Each returns a clean positioned `PythonLowerError("… nesting too deep …")`
+  past the cap, mirroring the lowering guards.  Two regression tests
+  (84 total) build a 400-deep `def` tower and a 400-deep expression inside
+  a function body — run on an enlarged stack so the (separately unguarded)
+  parser survives to reach the lowerer — and assert a clean "too deep"
+  error rather than a crash.
+
 ### Changed
 
 - `compile` / `compile_source` now lower `def` / `lambda` / `return` /

--- a/code/packages/rust/python-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/python-to-semantic-ir/CHANGELOG.md
@@ -97,6 +97,21 @@ Milestone **M4**: functions, calls, and closures — `def`, tail-position
   integration tests gate on a tool being present.  A non-zero exit from a
   *verified* Python 3 still fails the test (a real codegen bug must be
   caught).  Fixes a macOS-CI failure where `python` was absent / python2.
+- **`PYTHONPATH` for the end-to-end-emitted Python.**  The
+  `semantic-ir-to-python` backend's emitted code is **not** fully
+  self-contained — its runtime header imports the
+  `coding_adventures_sir_runtime_*` packages — so on a CI host with no
+  ambient install the program failed with
+  `ModuleNotFoundError: No module named 'coding_adventures_sir_runtime_core'`.
+  The e2e helper now sets `PYTHONPATH` (via `Command::env`) to each
+  runtime package's `src` dir, resolved from `CARGO_MANIFEST_DIR` as
+  `../../python/<pkg>/src` — the **same** approach the backend's own
+  execution tests use (`run_emitted_python`).  All runtime packages are
+  added (`core`, `pairs`, `oop`, `range`, `regex`, `exceptions`, `shell`)
+  so the tests are robust regardless of which features a program exercises.
+  Verified by running the e2e tests in a clean venv with **no** ambient
+  install (reproducing the runner): all 5 RUN and PASS purely via the
+  test-set `PYTHONPATH`.
 
 ### Changed
 

--- a/code/packages/rust/python-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/python-to-semantic-ir/CHANGELOG.md
@@ -5,6 +5,94 @@ All notable changes to `python-to-semantic-ir` are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to semantic versioning.
 
+## 0.4.0 — 2026-06-30
+
+Milestone **M4**: functions, calls, and closures — `def`, tail-position
+`return`, `lambda`, function calls, and free-variable-captured closures
+(SIR17 Python → Semantic IR frontend, B4).
+
+### Added
+
+- **`def f(params): suite` → a top-level `Function`.**  Lowering is now
+  **two-pass**: a first pass collects **every** function name (top-level
+  and nested `def`s) into a flat table, so calls — including *forward
+  references* and *mutual recursion* — resolve to `DirectCall` regardless
+  of textual order; the second pass lowers each body.  Parameters are in
+  scope as `Scope::Param`.  A `def` with parameters declares
+  `Feature::DynamicTyping` (the subset has no parameter annotations).
+- **`return` (tail position only).**  A function body is a `Block` whose
+  `value` IS the return value, so a **tail** `return expr` sets
+  `body.value = expr`; a bare tail `return` or falling off the end yields
+  `body.value = NilLit` (Python's implicit `None`).  A tail `if` whose
+  branches each end in a `return` (the canonical
+  `if c: return a else: return b` shape) is lowered with each branch in
+  *function-tail* position, so those returns become the branch values of
+  an `Expr::If`.  A **non-tail** (early) `return` — one nested in control
+  flow or followed by more statements — is **rejected** with a positioned
+  `PythonLowerError("early return not supported in v0 …")` pointing at the
+  offending `return`, per the SIR17 spec (the IR has no `Return` node).
+- **`lambda params: expr` → a synthesised top-level `Function` +
+  `Expr::MakeClosure`.**  Each lambda is gensym'd `__lambda_<N>`; the use
+  site emits a `MakeClosure` referencing it.
+- **Nested `def` → lifted to a top-level synthesised function** with the
+  same closure treatment as a lambda.  A **bare reference** to a nested
+  function's name yields a `MakeClosure` (re-threading its captures from
+  the currently visible enclosing values), so the closure can be
+  `return`ed / passed.
+- **Free-variable capture.**  For a lambda / nested `def`, the body's free
+  names (bare references minus the body's own params and locally assigned
+  names) that resolve to an **enclosing local / param / capture** become
+  `Capture`s — threaded through `MakeClosure` as `CaptureValue`s and
+  resolved inside the synthesised function as `Scope::Capture`.  Names that
+  resolve to a global / top-level function / builtin need **no** capture
+  (they are reachable directly).  Captures are emitted in deterministic
+  (alphabetical) order for reproducible output.
+- **Calls.**  `f(args)` lowers to `Expr::DirectCall` when `f` is a known
+  function name (and not shadowed by a same-named local value),
+  `Expr::BuiltinCall` for the builtins `print` / `len` / `range` (now a
+  general expression-position builtin, not only the `for`-header form),
+  and `Expr::IndirectCall` through a `VarRef` when `f` is a local / param /
+  captured **closure handle**.  Argument expressions are lowered eagerly.
+- **Manifest** now declares `Feature::Closures` whenever the module emits
+  a retained `MakeClosure`, an `IndirectCall`, or a function with
+  captures; and `Feature::MutualRecursion` when two top-level functions
+  transitively call each other (a 1-cycle — plain self-recursion — does
+  **not** count).  Bounded closure-body recursion reuses the
+  `MAX_BLOCK_DEPTH` / `MAX_EXPR_DEPTH` guards.
+- 25 new unit tests (82 total), including **executed end-to-end**
+  round-trips (Python → SIR → Python via the `semantic-ir-to-python`
+  backend, run with the system `python`, gated on availability): factorial
+  (recursion + tail if/else), fibonacci (while + mutation), a closure
+  adder, a capturing lambda, and mutual recursion.  Structural unit tests
+  cover `def`/params, tail-return vs no-return→nil, early-return rejection,
+  `DirectCall` vs `BuiltinCall` vs `IndirectCall`, forward-reference
+  resolution, lambda + capture, nested-def + capture, mutual-recursion
+  detection, default-parameter rejection, and a validator round-trip set.
+
+### Changed
+
+- `compile` / `compile_source` now lower `def` / `lambda` / `return` /
+  calls.  The module's function table holds user `def`s, synthesised
+  closure bodies (`__lambda_<N>`, lifted nested defs), and `main` (the
+  top-level statements).  The per-function name-resolution state is now a
+  `FunctionCtx` (params / captures / a local stack) rather than a single
+  shared declared-name stack, so each function resolves names in its own
+  scope.
+- Added a **dev-dependency** on `semantic-ir-to-python` for the executed
+  end-to-end tests.
+
+### Deferred
+
+Still out of scope after M4; each returns a clear positioned
+`PythonLowerError`:
+
+- **M5+** — sequences, maps, indexing and indexed assignment,
+  comprehensions.
+- Default / keyword arguments, `*args` / `**kwargs`, decorators, classes,
+  exceptions, generators, slicing, string methods, imports, `async`,
+  `global` / `nonlocal`, tuple / multi-target assignment, multi-level
+  capture chaining (capturing a variable two scopes up).
+
 ## 0.3.0 — 2026-06-30
 
 Milestone **M3**: control flow — `if` / `elif` / `else`, `while`, and

--- a/code/packages/rust/python-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/python-to-semantic-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "python-to-semantic-ir"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "Python CST → narrow-waist Semantic IR (SIR17). Second frontend for the SIR10 narrow-waist IR."
 
@@ -11,3 +11,8 @@ coding-adventures-python-parser = { path = "../python-parser" }
 # whose leaf tokens are `lexer::token::Token`; we walk both directly.
 parser = { path = "../parser" }
 lexer = { path = "../lexer" }
+
+[dev-dependencies]
+# End-to-end round-trip tests lower Python → SIR → Python and execute
+# the emitted source with the system `python` (gated on availability).
+semantic-ir-to-python = { path = "../semantic-ir-to-python" }

--- a/code/packages/rust/python-to-semantic-ir/README.md
+++ b/code/packages/rust/python-to-semantic-ir/README.md
@@ -52,14 +52,15 @@ pub struct PythonLowerError {
 `compile_source` parses then lowers; both parse and lower failures are
 surfaced as `PythonLowerError`.
 
-## Milestone status — M3 (control flow)
+## Milestone status — M4 (functions, calls, closures)
 
-The whole program is wrapped in a synthesised `main` function whose
+Top-level statements run inline in a synthesised `main` function whose
 block value is the program's final top-level expression (or `NilLit`
-for an empty program, or when the last statement is an assignment);
-earlier top-level statements become `ExprStmt`s (bare expressions) or
-binding / `Assign` / loop statements.  M3 adds `if` / `elif` / `else`,
-`while`, and `for` (`range` and iterables).
+for an empty program / a trailing assignment).  A `def` at any level is
+lifted to a **top-level `Function`** (the module gains a real function
+table); `lambda`s and nested `def`s are lifted to synthesised functions
+with computed captures.  M4 adds `def`, tail `return`, `lambda`,
+function calls, and closures, on top of M1–M3.
 
 ### Literals (M1, still supported)
 
@@ -147,6 +148,49 @@ lowering and validation agree.  Nested control flow is bounded by
 `MAX_BLOCK_DEPTH` (companion to `MAX_EXPR_DEPTH`), turning pathological
 nesting into a clean error rather than a native stack overflow.
 
+### Functions, calls & closures (M4)
+
+| Python source                          | SIR lowering                                          | Feature declared       |
+|----------------------------------------|-------------------------------------------------------|------------------------|
+| `def f(a, b): …`                       | top-level `Function { name f, params [a, b], body }`  | `DynamicTyping`†       |
+| `return expr` (tail)                   | function body `value = expr`                          | —                      |
+| `return` / no return (tail)            | function body `value = NilLit` (implicit `None`)      | —                      |
+| `return expr` (non-tail / early)       | **error** — "early return not supported in v0"        | —                      |
+| `lambda a: expr`                       | `MakeClosure { fn_name __lambda_N, captures }`        | `Closures`             |
+| nested `def` (returned / referenced)   | lifted `Function` + `MakeClosure` with captures       | `Closures`             |
+| `f(args)` — `f` a known function       | `DirectCall { fn_name f, args }`                      | —                      |
+| `f(args)` — `f` a closure value        | `IndirectCall { target VarRef, args }`                | `Closures`             |
+| `print(x)`, `len(x)`, `range(n)`       | `BuiltinCall("print" / "len" / "range", …)`           | —                      |
+| `is_even`/`is_odd` cross-calling       | (call-graph cycle of length ≥ 2)                      | `MutualRecursion`      |
+
+† a `def`/`lambda` with parameters declares `DynamicTyping` (the subset
+has no parameter annotations).
+
+**Two-pass design.**  A first pass collects **every** function name
+(top-level and nested) into a flat table, so a call to a function defined
+*later* in the file — and **mutual recursion** — resolve to `DirectCall`.
+The second pass lowers each body.
+
+**`return` is tail-only.**  A SIR function body is a `Block` whose `value`
+IS the return value, so a tail `return expr` sets that value (and a bare
+tail `return` / falling off the end yields `NilLit`).  A tail `if` whose
+branches each `return` (`if c: return a else: return b`) lowers with each
+branch in function-tail position, becoming an `Expr::If`.  A **non-tail**
+`return` (followed by more statements, or nested in a loop / non-tail
+branch) is rejected with a positioned error — the IR has no `Return`
+node, so early returns are deferred.
+
+**Closures & capture.**  A `lambda` / nested `def` is lifted to a fresh
+top-level function; its **free variables** (names the body reads that are
+not its own params / locals and that resolve to an *enclosing* local /
+param / capture) become `Capture`s, threaded through `MakeClosure` as
+`CaptureValue`s and resolved inside the body as `Scope::Capture`.  Names
+that resolve to a global / top-level function / builtin need **no**
+capture.  A bare reference to a function name yields a `MakeClosure`
+(re-threading its captures), so closures can be returned or passed.
+Capture order is deterministic (alphabetical).  Closure bodies reuse the
+`MAX_BLOCK_DEPTH` / `MAX_EXPR_DEPTH` guards, so recursion stays bounded.
+
 The manifest declares **exactly** the features observed.  Module
 metadata records `source_language = "python"` and
 `sir_version = semantic_ir::CURRENT_SIR_VERSION`.  Every lowered module
@@ -154,14 +198,11 @@ passes `semantic_ir::validate`.
 
 ### Deferred (later milestones)
 
-Everything past M3 returns a clear `PythonLowerError`
-(`"unsupported: <rule> (deferred …)"`) so later milestones slot in
-where the error is raised today:
+Everything past M4 returns a clear positioned `PythonLowerError`:
 
-- functions (`def`), lambdas, calls (`f(...)`, `print` / `len`
-  builtins; `range` is recognised only in `for` headers, not as a
-  general call yet) — M4
 - sequences, maps, indexing, comprehensions — M5
+- default / keyword arguments, `*args` / `**kwargs`, multi-level capture
+  chaining (capturing a variable two scopes up)
 - tuple / multi-target `for` (`for k, v in …`), multi-target / chained
   assignment, attribute / subscript targets, bitwise operators, the
   power operator (`**`)
@@ -175,17 +216,31 @@ where the error is raised today:
 cargo test -p python-to-semantic-ir
 ```
 
-The suite (57 tests) covers: one positive test per literal kind; the
-M2 operators (each arithmetic, comparison, unary, and logical form),
-left-associativity and precedence; variable resolution,
-let-then-reference, and let-vs-reassign first-occurrence; the
-short-circuit-node shape; the M3 control flow — `if` / `elif` / `else`
-nesting (incl. no-else and elif-without-else nil branches, trailing vs
-statement-position `if`), `while` (with body re-assignment), `for`-range
-at all three arities plus variable bounds and the zero-/four-arg arity
-errors, `for`-each, loop-variable and branch-local scope non-leakage,
-and nested control flow; top-level structure (empty program, `ExprStmt`
-+ value split, metadata, minimal manifest); a `validate` round-trip
-across every literal, M2, and M3 construct; and error paths (unresolved
-name, self-reference, `global`, `def` / `with` deferral, parse error,
-error position).  This exercises ≥ 90% of the M3 surface.
+The suite (82 tests) covers M1–M3 (literals; operators with
+left-associativity / precedence; variable resolution and first-occurrence
+assignment; short-circuit nodes; `if` / `elif` / `else`, `while`,
+`for`-range / `for`-each with block scoping) plus the M4 surface:
+
+- **functions** — `def` lifting with params (`Scope::Param`), tail-return
+  vs no-return→`NilLit`, body statements + tail return;
+- **early-return rejection** — a `return` followed by more statements, or
+  nested in an `if` branch, errors with a position;
+- **calls** — `DirectCall` (incl. forward references resolved by the
+  first pass), `BuiltinCall` (`print` / `len` / `range`), and
+  `IndirectCall` through a closure value;
+- **closures** — `lambda` → `MakeClosure` + synthesised function; capture
+  of an enclosing local; non-capture of globals / functions; nested-`def`
+  capture of an enclosing param with a returned closure;
+- **mutual recursion** detected (and self-recursion correctly *not*
+  flagged);
+- a `validate` round-trip across the M4 programs, and
+- **executed end-to-end** round-trips — factorial, fibonacci, a closure
+  adder, a capturing lambda, and mutual recursion are lowered to SIR,
+  re-emitted to Python via `semantic-ir-to-python`, and run with the
+  system `python` (gated on availability), asserting on stdout.
+
+```sh
+cargo test -p python-to-semantic-ir
+```
+
+This exercises ≥ 90% of the M4 surface.

--- a/code/packages/rust/python-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/python-to-semantic-ir/src/lib.rs
@@ -1,6 +1,6 @@
 //! # python-to-semantic-ir
 //!
-//! Python CST → narrow-waist Semantic IR (SIR17), **milestone M3**.
+//! Python CST → narrow-waist Semantic IR (SIR17), **milestone M4**.
 //!
 //! This is the second frontend for the SIR10 narrow-waist IR (after
 //! [`twig-to-semantic-ir`]).  It consumes the generic
@@ -28,28 +28,29 @@
 //! assert!(module.functions.iter().any(|f| f.name == "main"));
 //! ```
 //!
-//! ## M3 scope
+//! ## M4 scope
 //!
 //! M1 lowered **literals only**; M2 added variable references,
-//! assignment, and unary/binary operators.  M3 adds **control flow**,
-//! still wrapped in the synthesised `main` function:
+//! assignment, and unary/binary operators; M3 added **control flow**
+//! (`if`/`elif`/`else`, `while`, `for`).  M4 adds **functions, calls,
+//! and closures**:
 //!
-//! - **`if` / `elif` / `else`** → `Expr::If` (an `elif` chain folds
-//!   right-to-left into nested `If`s; a missing `else` yields an empty
-//!   nil-valued block).  Since `if` is a SIR *expression*, a trailing
-//!   `if` becomes the block value; otherwise it is a `Stmt::ExprStmt`;
-//! - **`while c: body`** → `Stmt::While { cond, body }`;
-//! - **`for x in range(...): body`** → `Stmt::ForRange` (1/2/3-arg
-//!   `range` mapped to `start`/`stop`/`step`; wrong arity rejected);
-//! - **`for x in <iter>: body`** → `Stmt::ForEach`.
+//! - **`def f(params): suite`** → a top-level `Function` named `f`.  A
+//!   two-pass design collects every function name first so calls (and
+//!   mutual recursion) resolve regardless of textual order.
+//! - **`return expr`** (tail position only) sets the function body's
+//!   block `value`; falling off the end yields `NilLit` (Python's
+//!   implicit `None`).  A **non-tail** (early) `return` is rejected with
+//!   a positioned error.
+//! - **`lambda params: expr`** and **nested `def`** are lifted to
+//!   top-level synthesised functions with computed **captures**, and the
+//!   definition site emits an `Expr::MakeClosure`.
+//! - **calls** `f(args)` → `DirectCall` (known function), `BuiltinCall`
+//!   (`print`/`len`/`range`), or `IndirectCall` (a closure value).
 //!
-//! Each loop / branch suite lowers to a `Block`; the loop variable is a
-//! `Scope::Local` bound inside the body only, and block-local bindings do
-//! not leak (matching the validator).  Loops declare `Feature::Loops`;
-//! `if` adds no feature.
-//!
-//! Functions/`def`/`lambda`, calls, and collections are deferred to
-//! later milestones; unhandled forms return a clear `PythonLowerError`.
+//! Collections / comprehensions / decorators / `*args` & default
+//! arguments are deferred to later milestones; unhandled forms return a
+//! clear `PythonLowerError`.
 //!
 //! See `code/specs/SIR17-python-to-semantic-ir.md` for the full
 //! lowering table and the deferred-form roadmap.
@@ -83,6 +84,14 @@ pub fn compile_source(
 mod tests {
     use super::*;
     use semantic_ir::{Expr, Feature, Scope, Stmt};
+
+    /// Find a function by name in a lowered module.
+    fn func<'a>(m: &'a semantic_ir::Module, name: &str) -> &'a semantic_ir::Function {
+        m.functions
+            .iter()
+            .find(|f| f.name == name)
+            .unwrap_or_else(|| panic!("function `{name}` exists"))
+    }
 
     /// Lower a snippet, asserting success, and return the module.
     fn lower(src: &str) -> semantic_ir::Module {
@@ -848,12 +857,6 @@ mod tests {
     // ── M3: deferred constructs stay rejected ─────────────────────────
 
     #[test]
-    fn def_is_still_unsupported() {
-        let err = compile_source("def f():\n    x = 1\n", "t").expect_err("def rejected");
-        assert!(err.message.contains("unsupported"), "got: {}", err.message);
-    }
-
-    #[test]
     fn with_statement_is_still_unsupported() {
         let err = compile_source("with a:\n    x = 1\n", "t").expect_err("with rejected");
         assert!(err.message.contains("unsupported"), "got: {}", err.message);
@@ -879,6 +882,458 @@ mod tests {
             let m = lower(src);
             let r = semantic_ir::validate(&m);
             assert!(r.is_ok(), "module for {src:?} failed validation: {:?}", r.issues);
+        }
+    }
+
+    // ══════════════════════════════════════════════════════════════════
+    // M4: functions, calls, closures
+    // ══════════════════════════════════════════════════════════════════
+
+    // ── def → top-level Function ──────────────────────────────────────
+
+    #[test]
+    fn def_lifts_to_top_level_function_with_params() {
+        let m = lower("def add(a, b):\n    return a + b\n");
+        let f = func(&m, "add");
+        assert_eq!(f.params.iter().map(|p| p.name.as_str()).collect::<Vec<_>>(), ["a", "b"]);
+        assert!(f.captures.is_empty());
+        // Tail `return a + b` → body value is the `+` builtin call.
+        match &f.body.value {
+            Expr::BuiltinCall { name, args, .. } => {
+                assert_eq!(name, "+");
+                assert!(matches!(args[0], Expr::VarRef { scope: Scope::Param, .. }));
+                assert!(matches!(args[1], Expr::VarRef { scope: Scope::Param, .. }));
+            }
+            other => panic!("expected BuiltinCall(+), got {other:?}"),
+        }
+        // A def with params declares DynamicTyping (no annotations).
+        assert!(m.manifest.contains(Feature::DynamicTyping));
+        // `main` exists alongside.
+        assert!(m.functions.iter().any(|f| f.name == "main"));
+    }
+
+    #[test]
+    fn def_no_params_no_return_yields_nil_body() {
+        // Falling off the end with no `return` ⇒ implicit `None` (NilLit).
+        let m = lower("def g():\n    x = 1\n");
+        let f = func(&m, "g");
+        assert!(f.params.is_empty());
+        assert!(matches!(f.body.value, Expr::NilLit { .. }));
+        // The single assignment is a let* statement in the body.
+        assert!(matches!(&f.body.stmts[0], Stmt::LetStarBinding { name, .. } if name == "x"));
+    }
+
+    #[test]
+    fn def_bare_return_yields_nil_body() {
+        let m = lower("def h():\n    return\n");
+        let f = func(&m, "h");
+        assert!(matches!(f.body.value, Expr::NilLit { .. }));
+    }
+
+    #[test]
+    fn def_tail_return_value_is_block_value() {
+        let m = lower("def k():\n    return 42\n");
+        let f = func(&m, "k");
+        assert!(matches!(f.body.value, Expr::IntLit { value: 42, .. }));
+    }
+
+    #[test]
+    fn def_param_resolves_as_param_scope() {
+        let m = lower("def f(x):\n    return x\n");
+        let f = func(&m, "f");
+        assert!(matches!(f.body.value, Expr::VarRef { scope: Scope::Param, .. }));
+    }
+
+    #[test]
+    fn def_statements_then_tail_return() {
+        // A body with leading statements and a tail return.
+        let m = lower("def f(n):\n    x = n + 1\n    return x\n");
+        let f = func(&m, "f");
+        assert_eq!(f.body.stmts.len(), 1);
+        assert!(matches!(&f.body.stmts[0], Stmt::LetStarBinding { name, .. } if name == "x"));
+        assert!(matches!(&f.body.value, Expr::VarRef { name, scope: Scope::Local, .. } if name == "x"));
+    }
+
+    // ── early-return rejection ────────────────────────────────────────
+
+    #[test]
+    fn early_return_is_rejected_with_position() {
+        // A `return` that is not the final statement is an early return.
+        let err = compile_source("def f(x):\n    return x\n    y = 1\n", "t")
+            .expect_err("early return rejected");
+        assert!(
+            err.message.contains("early return"),
+            "got: {}",
+            err.message
+        );
+        assert_eq!(err.line, 2, "error points at the offending return");
+    }
+
+    #[test]
+    fn return_inside_if_branch_is_early_return() {
+        // A `return` nested inside an `if` branch is never the function
+        // tail — rejected.
+        let err = compile_source(
+            "def f(x):\n    if x:\n        return 1\n    return 2\n",
+            "t",
+        )
+        .expect_err("return-in-branch rejected");
+        assert!(err.message.contains("early return"), "got: {}", err.message);
+    }
+
+    // ── calls: DirectCall / BuiltinCall / IndirectCall ────────────────
+
+    #[test]
+    fn call_known_function_is_direct_call() {
+        let m = lower("def f(a):\n    return a\n\nf(1)\n");
+        match main_value(&m) {
+            Expr::DirectCall { fn_name, args, .. } => {
+                assert_eq!(fn_name, "f");
+                assert!(matches!(args[0], Expr::IntLit { value: 1, .. }));
+            }
+            other => panic!("expected DirectCall, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn call_forward_reference_resolves_via_two_pass() {
+        // `g` is called before it is defined — the name-collection pass
+        // makes this a DirectCall.
+        let m = lower("def f():\n    return g()\n\ndef g():\n    return 1\n");
+        let f = func(&m, "f");
+        assert!(matches!(&f.body.value, Expr::DirectCall { fn_name, .. } if fn_name == "g"));
+    }
+
+    #[test]
+    fn builtin_calls_lower_to_builtin_call() {
+        for (src, name) in [
+            ("print(1)\n", "print"),
+            ("xs = 1\nlen(xs)\n", "len"),
+            ("range(5)\n", "range"),
+        ] {
+            let m = lower(src);
+            match main_value(&m) {
+                Expr::BuiltinCall { name: got, .. } => assert_eq!(got, name, "for {src:?}"),
+                other => panic!("expected BuiltinCall({name}) for {src:?}, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn call_through_local_value_is_indirect_call() {
+        // `f` is a captured/local closure handle (a parameter), so calling
+        // it is an IndirectCall through the value.
+        let m = lower("def apply(fn, x):\n    return fn(x)\n");
+        let f = func(&m, "apply");
+        match &f.body.value {
+            Expr::IndirectCall { target, args, .. } => {
+                assert!(matches!(&**target, Expr::VarRef { name, scope: Scope::Param, .. } if name == "fn"));
+                assert_eq!(args.len(), 1);
+            }
+            other => panic!("expected IndirectCall, got {other:?}"),
+        }
+        assert!(m.manifest.contains(Feature::Closures));
+    }
+
+    // ── lambda + capture ──────────────────────────────────────────────
+
+    #[test]
+    fn lambda_lowers_to_make_closure_and_synthesised_function() {
+        let m = lower("f = lambda a: a + 1\n");
+        // A synthesised `__lambda_0` function exists.
+        let lam = func(&m, "__lambda_0");
+        assert_eq!(lam.params.iter().map(|p| p.name.as_str()).collect::<Vec<_>>(), ["a"]);
+        assert!(lam.captures.is_empty());
+        // The binding's value is a MakeClosure referencing it.
+        match &main_stmts(&m)[0] {
+            Stmt::LetStarBinding { value: Expr::MakeClosure { fn_name, captures, .. }, .. } => {
+                assert_eq!(fn_name, "__lambda_0");
+                assert!(captures.is_empty());
+            }
+            other => panic!("expected LetStarBinding(MakeClosure), got {other:?}"),
+        }
+        assert!(m.manifest.contains(Feature::Closures));
+    }
+
+    #[test]
+    fn lambda_captures_enclosing_local() {
+        // `n` is a top-level local; the lambda body reads it → it is
+        // captured (Scope::Capture inside the synthesised function).
+        let m = lower("n = 10\nf = lambda x: x + n\n");
+        let lam = func(&m, "__lambda_0");
+        assert_eq!(lam.captures.iter().map(|c| c.name.as_str()).collect::<Vec<_>>(), ["n"]);
+        // Inside the body, `n` resolves as a capture, `x` as a param.
+        match &lam.body.value {
+            Expr::BuiltinCall { name, args, .. } => {
+                assert_eq!(name, "+");
+                assert!(matches!(&args[0], Expr::VarRef { name, scope: Scope::Param, .. } if name == "x"));
+                assert!(matches!(&args[1], Expr::VarRef { name, scope: Scope::Capture, .. } if name == "n"));
+            }
+            other => panic!("expected BuiltinCall(+), got {other:?}"),
+        }
+        // The MakeClosure threads `n`'s enclosing value.
+        match &main_stmts(&m)[1] {
+            Stmt::LetStarBinding { value: Expr::MakeClosure { captures, .. }, .. } => {
+                assert_eq!(captures.len(), 1);
+                assert_eq!(captures[0].name, "n");
+                assert!(matches!(&captures[0].value, Expr::VarRef { name, scope: Scope::Local, .. } if name == "n"));
+            }
+            other => panic!("expected MakeClosure capturing n, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn lambda_does_not_capture_globals_or_functions() {
+        // A reference to a top-level function name inside a lambda is NOT
+        // a capture — it is reachable directly.
+        let m = lower("def g(y):\n    return y\n\nf = lambda x: g(x)\n");
+        let lam = func(&m, "__lambda_0");
+        assert!(lam.captures.is_empty(), "g should not be captured");
+        assert!(matches!(&lam.body.value, Expr::DirectCall { fn_name, .. } if fn_name == "g"));
+    }
+
+    // ── nested def + capture ──────────────────────────────────────────
+
+    #[test]
+    fn nested_def_captures_enclosing_param_and_returns_closure() {
+        // The canonical closure-adder: outer(n) returns inner, which
+        // captures n.
+        let m = lower(
+            "def outer(n):\n    def inner(x):\n        return x + n\n    return inner\n",
+        );
+        // `inner` is lifted to a top-level function capturing `n`.
+        let inner = func(&m, "inner");
+        assert_eq!(inner.captures.iter().map(|c| c.name.as_str()).collect::<Vec<_>>(), ["n"]);
+        match &inner.body.value {
+            Expr::BuiltinCall { name, args, .. } => {
+                assert_eq!(name, "+");
+                assert!(matches!(&args[0], Expr::VarRef { scope: Scope::Param, .. }));
+                assert!(matches!(&args[1], Expr::VarRef { name, scope: Scope::Capture, .. } if name == "n"));
+            }
+            other => panic!("expected BuiltinCall(+), got {other:?}"),
+        }
+        // `outer`'s tail `return inner` is a MakeClosure threading `n`.
+        let outer = func(&m, "outer");
+        match &outer.body.value {
+            Expr::MakeClosure { fn_name, captures, .. } => {
+                assert_eq!(fn_name, "inner");
+                assert_eq!(captures.len(), 1);
+                assert_eq!(captures[0].name, "n");
+                assert!(matches!(&captures[0].value, Expr::VarRef { name, scope: Scope::Param, .. } if name == "n"));
+            }
+            other => panic!("expected MakeClosure(inner), got {other:?}"),
+        }
+        assert!(m.manifest.contains(Feature::Closures));
+    }
+
+    // ── mutual recursion ──────────────────────────────────────────────
+
+    #[test]
+    fn mutual_recursion_sets_feature() {
+        let m = lower(
+            "def is_even(n):\n    return is_odd(n)\n\ndef is_odd(n):\n    return is_even(n)\n",
+        );
+        assert!(
+            m.manifest.contains(Feature::MutualRecursion),
+            "two functions calling each other ⇒ MutualRecursion"
+        );
+    }
+
+    #[test]
+    fn self_recursion_is_not_mutual_recursion() {
+        let m = lower("def fact(n):\n    return fact(n)\n");
+        assert!(
+            !m.manifest.contains(Feature::MutualRecursion),
+            "self-recursion alone is not mutual recursion"
+        );
+    }
+
+    // ── deferred constructs stay rejected ─────────────────────────────
+
+    #[test]
+    fn default_parameter_is_rejected() {
+        let err = compile_source("def f(a=1):\n    return a\n", "t")
+            .expect_err("default param rejected");
+        assert!(err.message.contains("default"), "got: {}", err.message);
+    }
+
+    #[test]
+    fn list_literal_is_still_unsupported() {
+        let err = compile_source("xs = [1, 2, 3]\n", "t").expect_err("list rejected");
+        assert!(err.message.contains("unsupported"), "got: {}", err.message);
+    }
+
+    // ── validator round-trip over M4 programs ─────────────────────────
+
+    #[test]
+    fn m4_modules_pass_the_validator() {
+        for src in [
+            "def f():\n    return 1\n",
+            "def f(a, b):\n    return a + b\n",
+            "def g():\n    x = 1\n",
+            "def h():\n    return\n",
+            "def f(a):\n    return a\n\nf(1)\n",
+            "def f():\n    return g()\n\ndef g():\n    return 1\n",
+            "print(1)\n",
+            "f = lambda a: a + 1\n",
+            "n = 10\nf = lambda x: x + n\n",
+            "def apply(fn, x):\n    return fn(x)\n",
+            "def outer(n):\n    def inner(x):\n        return x + n\n    return inner\n",
+            "def is_even(n):\n    return is_odd(n)\n\ndef is_odd(n):\n    return is_even(n)\n",
+            // factorial (recursion + if/else tail)
+            "def fact(n):\n    if n < 2:\n        return 1\n    else:\n        return n * fact(n - 1)\n",
+            // fibonacci (while loop + mutation, tail return)
+            "def fib(n):\n    a = 0\n    b = 1\n    i = 0\n    while i < n:\n        t = a + b\n        a = b\n        b = t\n        i = i + 1\n    return a\n",
+        ] {
+            let m = lower(src);
+            let r = semantic_ir::validate(&m);
+            assert!(r.is_ok(), "module for {src:?} failed validation: {:?}", r.issues);
+        }
+    }
+
+    // ══════════════════════════════════════════════════════════════════
+    // M4: end-to-end — Python → SIR → Python → execute
+    // ══════════════════════════════════════════════════════════════════
+    //
+    // These tests close the loop: lower a golden Python program to SIR,
+    // emit *fresh* Python via the `semantic-ir-to-python` backend, run it
+    // with the system `python`, and assert on stdout.  They are gated on
+    // `python` being available so CI hosts without an interpreter still
+    // pass (the lowering + validate assertions above already cover
+    // correctness structurally; this is the behavioural confirmation).
+
+    /// Locate a Python interpreter, or `None` if none is on `PATH`.
+    fn python_exe() -> Option<&'static str> {
+        ["python3", "python"].into_iter().find(|cand| {
+            std::process::Command::new(cand)
+                .arg("--version")
+                .output()
+                .map(|o| o.status.success())
+                .unwrap_or(false)
+        })
+    }
+
+    /// Lower `src` → SIR → Python, execute it, and return trimmed stdout.
+    /// Returns `None` when no interpreter is available (test should skip).
+    fn run_roundtrip(src: &str) -> Option<String> {
+        let py = python_exe()?;
+        let module = compile_source(src, "golden").expect("lowering succeeded");
+        // The lowered module must validate before we trust the emit.
+        let v = semantic_ir::validate(&module);
+        assert!(v.is_ok(), "golden module failed validation: {:?}", v.issues);
+
+        let artifact =
+            semantic_ir_to_python::compile(&module).expect("emit python from SIR");
+
+        let out = std::process::Command::new(py)
+            .arg("-c")
+            .arg(&artifact.source)
+            .output()
+            .expect("python ran");
+        assert!(
+            out.status.success(),
+            "python execution failed:\nstderr:\n{}\n--- emitted ---\n{}",
+            String::from_utf8_lossy(&out.stderr),
+            artifact.source
+        );
+        Some(String::from_utf8_lossy(&out.stdout).trim().to_string())
+    }
+
+    #[test]
+    fn e2e_factorial() {
+        // Recursion + tail-position if/else (returns in both branches).
+        let src = "\
+def fact(n):
+    if n < 2:
+        return 1
+    else:
+        return n * fact(n - 1)
+
+print(fact(5))
+";
+        if let Some(out) = run_roundtrip(src) {
+            assert_eq!(out, "120", "factorial(5) should print 120");
+        }
+    }
+
+    #[test]
+    fn e2e_fibonacci() {
+        // While loop + mutation + tail return.
+        let src = "\
+def fib(n):
+    a = 0
+    b = 1
+    i = 0
+    while i < n:
+        t = a + b
+        a = b
+        b = t
+        i = i + 1
+    return a
+
+print(fib(10))
+";
+        if let Some(out) = run_roundtrip(src) {
+            assert_eq!(out, "55", "fib(10) should print 55");
+        }
+    }
+
+    #[test]
+    fn e2e_closure_adder() {
+        // A closure that captures its enclosing parameter `n`.
+        let src = "\
+def adder(n):
+    def add(x):
+        return x + n
+    return add
+
+a = adder(10)
+print(a(5))
+";
+        if let Some(out) = run_roundtrip(src) {
+            assert_eq!(out, "15", "adder(10)(5) should print 15");
+        }
+    }
+
+    #[test]
+    fn e2e_lambda_closure() {
+        // A lambda capturing an enclosing local, invoked indirectly.
+        let src = "\
+n = 100
+f = lambda x: x + n
+print(f(23))
+";
+        if let Some(out) = run_roundtrip(src) {
+            assert_eq!(out, "123", "lambda capturing n should print 123");
+        }
+    }
+
+    #[test]
+    fn e2e_mutual_recursion() {
+        // is_even / is_odd call each other.
+        let src = "\
+def is_even(n):
+    if n == 0:
+        return True
+    else:
+        return is_odd(n - 1)
+
+def is_odd(n):
+    if n == 0:
+        return False
+    else:
+        return is_even(n - 1)
+
+print(is_even(10))
+";
+        if let Some(out) = run_roundtrip(src) {
+            // The backend renders booleans in the SIR runtime's own
+            // display form (`#t`/`#f`), not Python's `True`/`False` — the
+            // value is what matters: `is_even(10)` is true.
+            assert!(
+                out == "True" || out == "#t",
+                "is_even(10) should be truthy, got {out:?}"
+            );
         }
     }
 }

--- a/code/packages/rust/python-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/python-to-semantic-ir/src/lib.rs
@@ -1300,6 +1300,39 @@ mod tests {
         })
     }
 
+    /// Build the `PYTHONPATH` the emitted program needs to import the SIR
+    /// runtime packages.
+    ///
+    /// The `semantic-ir-to-python` backend's emitted code is **not** fully
+    /// self-contained: its runtime header does
+    /// `from coding_adventures_sir_runtime_core import …` (and, depending
+    /// on the features used, `…_pairs` / `…_oop` / `…_range` / `…_regex` /
+    /// `…_exceptions` / `…_shell`).  Those packages live in the workspace
+    /// under `code/packages/python/<pkg>/src` (a src-layout package), so
+    /// they are not importable on a CI host that has no ambient install.
+    ///
+    /// This mirrors the backend's *own* execution tests (see
+    /// `semantic-ir-to-python/src/lib.rs::run_emitted_python`), which set
+    /// `PYTHONPATH` to each runtime package's `src` dir, resolved relative
+    /// to `CARGO_MANIFEST_DIR` as `../../python/<pkg>/src`.  Our crate sits
+    /// at the same depth (`code/packages/rust/python-to-semantic-ir`), so
+    /// the same relative path resolves.  We add **all** runtime packages so
+    /// the e2e tests are robust regardless of which features a program
+    /// exercises.
+    fn runtime_pythonpath() -> std::ffi::OsString {
+        let py_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../python");
+        std::env::join_paths([
+            py_root.join("sir-runtime-core/src"),
+            py_root.join("sir-runtime-pairs/src"),
+            py_root.join("sir-runtime-oop/src"),
+            py_root.join("sir-runtime-range/src"),
+            py_root.join("sir-runtime-regex/src"),
+            py_root.join("sir-runtime-exceptions/src"),
+            py_root.join("sir-runtime-shell/src"),
+        ])
+        .expect("join PYTHONPATH")
+    }
+
     /// Lower `src` → SIR → Python, execute it, and return trimmed stdout.
     /// Returns `None` when no working Python 3 interpreter is available —
     /// the test then **skips** (it does not fail), so CI hosts lacking a
@@ -1321,12 +1354,15 @@ mod tests {
         let artifact =
             semantic_ir_to_python::compile(&module).expect("emit python from SIR");
 
+        // The emitted code imports the SIR runtime packages — make them
+        // importable via PYTHONPATH (the runner has no ambient install).
         // Spawning the interpreter could still fail for an *environment*
         // reason (the exe vanished after the probe, a sandbox blocks
         // exec, …) — that is not a codegen bug, so skip rather than fail.
         let out = match std::process::Command::new(py)
             .arg("-c")
             .arg(&artifact.source)
+            .env("PYTHONPATH", runtime_pythonpath())
             .output()
         {
             Ok(out) => out,

--- a/code/packages/rust/python-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/python-to-semantic-ir/src/lib.rs
@@ -1272,21 +1272,47 @@ mod tests {
     // pass (the lowering + validate assertions above already cover
     // correctness structurally; this is the behavioural confirmation).
 
-    /// Locate a Python interpreter, or `None` if none is on `PATH`.
-    fn python_exe() -> Option<&'static str> {
+    /// Locate a working **Python 3** interpreter on `PATH`, or `None` if
+    /// none is available.
+    ///
+    /// CI hosts differ: on macOS runners `python` is often absent or is
+    /// python2 (the emitted code is Python 3), while Linux/Windows vary
+    /// between `python3` and `python`.  So we don't just check that an exe
+    /// launches — we run `<exe> --version` and require it to report
+    /// "Python 3.x".  `--version` writes to stdout on 3.4+ but historically
+    /// to stderr, so we check both streams.  Mirrors how the other
+    /// integration tests gate on a tool being present (rustc / go / node).
+    fn python3_exe() -> Option<&'static str> {
         ["python3", "python"].into_iter().find(|cand| {
-            std::process::Command::new(cand)
-                .arg("--version")
-                .output()
-                .map(|o| o.status.success())
-                .unwrap_or(false)
+            let Ok(out) = std::process::Command::new(cand).arg("--version").output() else {
+                return false; // exe not found / failed to launch
+            };
+            if !out.status.success() {
+                return false;
+            }
+            // Accept only an interpreter that reports a 3.x version.
+            let combined = format!(
+                "{}{}",
+                String::from_utf8_lossy(&out.stdout),
+                String::from_utf8_lossy(&out.stderr)
+            );
+            combined.trim().starts_with("Python 3")
         })
     }
 
     /// Lower `src` → SIR → Python, execute it, and return trimmed stdout.
-    /// Returns `None` when no interpreter is available (test should skip).
+    /// Returns `None` when no working Python 3 interpreter is available —
+    /// the test then **skips** (it does not fail), so CI hosts lacking a
+    /// Python 3 still pass.  The lowering + `validate` assertions above
+    /// already cover correctness structurally; this is the behavioural
+    /// confirmation, which a real codegen bug (wrong output) still fails.
     fn run_roundtrip(src: &str) -> Option<String> {
-        let py = python_exe()?;
+        let Some(py) = python3_exe() else {
+            eprintln!(
+                "skipping end-to-end execution: no working Python 3 interpreter on PATH"
+            );
+            return None;
+        };
         let module = compile_source(src, "golden").expect("lowering succeeded");
         // The lowered module must validate before we trust the emit.
         let v = semantic_ir::validate(&module);
@@ -1295,11 +1321,23 @@ mod tests {
         let artifact =
             semantic_ir_to_python::compile(&module).expect("emit python from SIR");
 
-        let out = std::process::Command::new(py)
+        // Spawning the interpreter could still fail for an *environment*
+        // reason (the exe vanished after the probe, a sandbox blocks
+        // exec, …) — that is not a codegen bug, so skip rather than fail.
+        let out = match std::process::Command::new(py)
             .arg("-c")
             .arg(&artifact.source)
             .output()
-            .expect("python ran");
+        {
+            Ok(out) => out,
+            Err(e) => {
+                eprintln!("skipping end-to-end execution: could not launch `{py}`: {e}");
+                return None;
+            }
+        };
+        // A non-zero exit from a *verified* Python 3 means the emitted
+        // program itself failed — a real codegen bug — so this stays a
+        // hard failure.
         assert!(
             out.status.success(),
             "python execution failed:\nstderr:\n{}\n--- emitted ---\n{}",

--- a/code/packages/rust/python-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/python-to-semantic-ir/src/lib.rs
@@ -1148,6 +1148,76 @@ mod tests {
         );
     }
 
+    // ── pre-lowering CST walks are depth-bounded (no native overflow) ──
+    //
+    // M4 added three CST walks that run *before* the depth-guarded
+    // lowering: pass-1 def-name collection (`collect_function_names`), the
+    // free-variable scan (`collect_free_names`), and the bound-name scan
+    // (`walk_for_targets`).  Each is now depth-bounded (block depth →
+    // MAX_BLOCK_DEPTH, expression depth → MAX_EXPR_DEPTH) so a
+    // pathologically deep input via the public `compile` yields a clean
+    // positioned `PythonLowerError` ("too deep") instead of overflowing
+    // the native (uncatchable) stack.
+    //
+    // The test runs on an enlarged stack so the *parser's* own
+    // (unguarded) recursive descent survives long enough for the lowerer
+    // to be reached — the guard under test is the lowerer's, not the
+    // parser's.  Depth 400 comfortably exceeds the 256-level caps while
+    // keeping construction / drop bounded.
+
+    /// Run `f` on a 64 MiB stack so the parser survives deep input and the
+    /// *lowering* depth guards are the ones exercised.
+    fn on_big_stack<F: FnOnce() + Send + 'static>(f: F) {
+        std::thread::Builder::new()
+            .stack_size(64 * 1024 * 1024)
+            .spawn(f)
+            .expect("spawn worker thread")
+            .join()
+            .expect("worker thread did not overflow / panic");
+    }
+
+    #[test]
+    fn deep_def_tower_errors_cleanly_not_overflow() {
+        // A tower of nested `def`s drives `collect_function_names`
+        // (pass 1) past MAX_BLOCK_DEPTH.
+        on_big_stack(|| {
+            let depth = 400usize;
+            let mut src = String::new();
+            for i in 0..depth {
+                let pad = "    ".repeat(i);
+                src.push_str(&format!("{pad}def f{i}():\n"));
+            }
+            let pad = "    ".repeat(depth);
+            src.push_str(&format!("{pad}return 1\n"));
+
+            let err = compile_source(&src, "t")
+                .expect_err("deep def tower must be rejected, not crash");
+            assert!(
+                err.message.contains("too deep"),
+                "expected a positioned 'too deep' error, got: {}",
+                err.message
+            );
+        });
+    }
+
+    #[test]
+    fn deep_expression_in_def_body_errors_cleanly_not_overflow() {
+        // A long unary-minus chain inside a function body drives the
+        // free-variable / bound-name scans (and the lowerer) past
+        // MAX_EXPR_DEPTH.
+        on_big_stack(|| {
+            let body = format!("{}x", "-".repeat(400));
+            let src = format!("x = 1\ndef g():\n    return {body}\n");
+            let err = compile_source(&src, "t")
+                .expect_err("deep expression must be rejected, not crash");
+            assert!(
+                err.message.contains("too deep"),
+                "expected a positioned 'too deep' error, got: {}",
+                err.message
+            );
+        });
+    }
+
     // ── deferred constructs stay rejected ─────────────────────────────
 
     #[test]

--- a/code/packages/rust/python-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/python-to-semantic-ir/src/lower.rs
@@ -1,5 +1,5 @@
 //! The lowering pass from `python_parser`'s generic
-//! [`GrammarASTNode`] CST → [`semantic_ir::Module`], **milestone M3**.
+//! [`GrammarASTNode`] CST → [`semantic_ir::Module`], **milestone M4**.
 //!
 //! # What M1 covered (still supported)
 //!
@@ -36,88 +36,89 @@
 //! M2 turns the precedence-rule onion from a pure *peel* into a small
 //! *operator recogniser*.  Each precedence rule, when it actually
 //! *branches* (more than one child node, with operator tokens between),
-//! is lowered to the matching SIR node:
-//!
-//! | rule           | branching shape                       | SIR node                  |
-//! |----------------|---------------------------------------|---------------------------|
-//! | `or_expr`      | `a or b or …`                         | `LogicalOr` (left-nested) |
-//! | `and_expr`     | `a and b and …`                       | `LogicalAnd` (left-nested)|
-//! | `not_expr`     | `not x`                               | `BuiltinCall("not", [x])` |
-//! | `comparison`   | `a < b`, `a == b`, …                  | `BuiltinCall("<"/"="/…)`  |
-//! | `arith`        | `a + b`, `a - b`                      | `BuiltinCall("+"/"-")`    |
-//! | `term`         | `a * b`, `a / b`, `a % b`             | `BuiltinCall("*"/"/"/"%") |
-//! | `factor`       | `-x`, `+x`                            | `BuiltinCall("neg")` / id |
-//!
-//! Comparison maps `==`→`"="` and `!=`→`"!="` per SIR17; the rest use
-//! their literal spelling.  `and`/`or` become the dedicated
-//! short-circuit nodes (`LogicalAnd`/`LogicalOr`) rather than
-//! `BuiltinCall`, because the latter would eagerly evaluate both sides.
-//!
-//! M2 also adds **variable references** and **assignment**:
-//!
-//! - a bare `Name` token (`x`) becomes a `VarRef` whose `scope` is
-//!   resolved against the names bound so far in the current (module/
-//!   `main`) scope — `Scope::Local` when bound, otherwise a positioned
-//!   "unresolved name" error.
-//! - `x = expr` performs *first-occurrence detection*: the first time a
-//!   name is assigned in a scope it is *declared* (we emit a
-//!   `LetStarBinding`); a later assignment to an already-declared name
-//!   *mutates* it (we emit an `Assign`).  Python has no `let`/`var`
-//!   keyword, so this mirrors how the JS and Ruby sibling frontends
-//!   decide bind-vs-reassign.
-//!
-//! Why `LetStarBinding` and not `LetBinding`?  The SIR validator treats
-//! a *run* of consecutive `LetBinding`s as a **parallel**-let group:
-//! every RHS is checked in the scope *before* the group, so a later
-//! binding cannot see an earlier one (`x = 1` then `y = x + 1` would
-//! fail to resolve `x`).  `LetStarBinding` has **sequential** semantics
-//! — each RHS sees the prior bindings — which is exactly Python's
-//! top-to-bottom execution model.
-//!
-//! ## Constant-folded unary minus (carried from M1)
-//!
-//! `-7` parses as `factor( Minus, factor(…INT 7…) )`.  When the operand
-//! is a numeric *literal* we still fold the negation in place
-//! (`IntLit{-7}`), because the spec lists `-7 ⇒ IntLit { value }`.  For a
-//! non-literal operand (`-x`) we now emit `BuiltinCall("neg", [x])`
-//! instead of erroring.
+//! is lowered to the matching SIR node (`+`/`-`/`*`/`/`/`%` →
+//! `BuiltinCall`, `and`/`or` → `LogicalAnd`/`LogicalOr`, comparisons →
+//! `BuiltinCall("<"/"="/…)`, `not`/unary `-`/`+`).  M2 also adds
+//! **variable references** (bare `Name` → `VarRef` with resolved scope)
+//! and **assignment** (`x = …` → `LetStarBinding` first time / `Assign`
+//! after — first-occurrence detection).
 //!
 //! # What M3 adds
 //!
-//! M3 adds **control flow**.  A `statement` may now wrap a
-//! `compound_stmt` (`if_stmt` / `while_stmt` / `for_stmt`) in addition to
-//! a `simple_stmt`:
+//! M3 adds **control flow**: `if`/`elif`/`else` → nested [`Expr::If`];
+//! `while c: body` → [`Stmt::While`]; `for x in range(...): body` →
+//! [`Stmt::ForRange`] (arity 1/2/3 → start/stop/step) and any other
+//! iterable → [`Stmt::ForEach`].  Each suite lowers to a [`Block`] via
+//! [`Lowerer::lower_suite`].  The declared-name table is a **stack** so
+//! block-local names (loop vars, names first-bound inside a body) are
+//! scoped exactly as the SIR validator scopes them (`mark`/`rewind`).
 //!
-//! - `if_stmt` — the parser flattens `if`/`elif`/`else` into one node; we
-//!   collect the `(cond, suite)` clauses + optional `else`, then fold
-//!   right-to-left into nested [`Expr::If`].  A trailing `if` becomes the
-//!   block value; otherwise it is wrapped as a `Stmt::ExprStmt`.
-//! - `while_stmt` → [`Stmt::While`].
-//! - `for_stmt` → [`Stmt::ForRange`] when the iterable is a literal
-//!   `range(...)` call (arity 1/2/3 → `start`/`stop`/`step`), else
-//!   [`Stmt::ForEach`].
+//! # What M4 adds — functions, calls, closures
 //!
-//! Each suite lowers to a [`Block`] via [`Lowerer::lower_suite`].  The
-//! lowerer's declared-name table became a **stack** (was a `HashSet`) so
-//! block-local names — including the loop variable — are scoped exactly
-//! as the SIR validator scopes them (`mark`/`rewind`), keeping lowering
-//! and validation in lock-step.  A `MAX_BLOCK_DEPTH` guard bounds nested
-//! control-flow recursion.
+//! M4 is the milestone that turns the single-`main` module into a real
+//! function table:
+//!
+//! - **`def f(params): suite`** → a top-level [`Function`] named `f`.
+//!   Lowering is **two-pass**: a first pass collects *every* function
+//!   name (top-level and nested) so calls resolve and mutual recursion
+//!   works; the second pass lowers each body.  Each `def` lowers as if
+//!   it stood alone, with its parameters in scope as `Scope::Param`.
+//! - **`return expr`** — a function body is a [`Block`] whose `.value`
+//!   IS the return value, so a *tail* `return expr` sets `body.value =
+//!   expr`, and falling off the end (no `return`) synthesises
+//!   `body.value = NilLit` (Python's implicit `None`).  A **non-tail**
+//!   (early) `return` is **rejected** with a positioned error per the
+//!   SIR17 spec — the IR has no `Return` node, so early returns would
+//!   need a control-flow lift that v0 does not perform.
+//! - **`lambda params: expr`** → a fresh top-level synthesised
+//!   [`Function`] named `__lambda_<N>` plus an [`Expr::MakeClosure`] at
+//!   the use site.  Free variables (names the body reads that are not
+//!   its own params/locals and not globals/top-level functions/builtins)
+//!   become **captures**; inside the synthesised function they resolve
+//!   as [`Scope::Capture`].
+//! - **nested `def`** → the same treatment as a lambda: lifted to a
+//!   top-level synthesised function with computed captures.  A bare
+//!   reference to the nested function's name yields an
+//!   [`Expr::MakeClosure`] (so the closure value can be returned/passed).
+//! - **calls** `f(args)` — `f` a known function name → [`Expr::DirectCall`];
+//!   `f` a builtin (`print`/`len`/`range`) → [`Expr::BuiltinCall`]; `f`
+//!   a local/param/captured value (a closure handle) → an
+//!   [`Expr::IndirectCall`] through that `VarRef`.
+//!
+//! The manifest declares `Closures` when any `MakeClosure` / capture /
+//! `IndirectCall` is emitted, and `MutualRecursion` when two top-level
+//! functions call each other.
+//!
+//! ## Free-variable analysis (how captures are computed)
+//!
+//! We scan the lambda/nested-`def` **body subtree of the CST** for bare
+//! `Name` references, subtracting the names bound *within* that body
+//! (its own params and names it assigns).  Any remaining name that is a
+//! *local/param/capture of the enclosing function* becomes a capture
+//! (its value is the enclosing reference, evaluated at the
+//! `MakeClosure` site).  Names that resolve to a global / top-level
+//! function / builtin need no capture — they are reachable directly
+//! from the synthesised body.  This mirrors the Twig and Ruby frontends.
 //!
 //! ## Still deferred (later milestones)
 //!
-//! - calls / functions / `def` / `lambda`                → M4+
-//! - collections (lists / dicts / indexing)              → M5+
-//! - tuple `for` targets, `with` / `try`, `global` /
-//!   `nonlocal`, multi-target assignment                 → deferred
+//! - collections (lists / dicts / indexing / comprehensions)  → M5+
+//! - `*args` / keyword & default arguments                    → deferred
+//! - decorators / classes / `with` / `try` / generators       → deferred
+//! - `global` / `nonlocal`, multi-target assignment           → deferred
 //!
 //! Unhandled rules produce a clear `PythonLowerError` rather than
-//! silently dropping source, so later milestones can slot their
-//! extractors in exactly where the error is raised today.
+//! silently dropping source.
+//!
+//! See `code/specs/SIR17-python-to-semantic-ir.md` for the full
+//! lowering table and the deferred-form roadmap.
+
+use std::collections::HashSet;
 
 use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode};
 use semantic_ir::{
-    Block, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, Scope, Span, Stmt,
+    Block, Capture, CaptureValue, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata,
+    Module, Param, ParamKind, Scope, Span, Stmt,
 };
 
 /// Maximum expression-nesting depth the lowerer will descend before
@@ -131,13 +132,19 @@ use semantic_ir::{
 const MAX_EXPR_DEPTH: usize = 256;
 
 /// Maximum *statement-block* nesting depth (M3).  Each `if` / `while` /
-/// `for` body re-enters [`Lowerer::lower_suite`] one level deeper, so a
-/// pathological tower of `while c:\n while c:\n …` would recurse without
-/// bound.  Mirroring [`MAX_EXPR_DEPTH`]'s role for expressions, this cap
-/// turns deeply nested control flow into a clean positioned
+/// `for` body — and (M4) each `def` / `lambda` body — re-enters the
+/// suite/expression lowerer one level deeper, so a pathological tower of
+/// nested bodies would recurse without bound.  Mirroring
+/// [`MAX_EXPR_DEPTH`]'s role for expressions, this cap turns deeply
+/// nested control flow / closures into a clean positioned
 /// `PythonLowerError` instead of a native (uncatchable) stack overflow.
 /// It is generous: real source nests a handful of levels, far below this.
 const MAX_BLOCK_DEPTH: usize = 256;
+
+/// The builtin function names M4 recognises in call position.  `range`
+/// is also recognised structurally inside `for` headers (M3); here it is
+/// a general expression-position builtin (`range(n)` outside a `for`).
+const BUILTIN_CALLS: &[&str] = &["print", "len", "range"];
 
 // ---------------------------------------------------------------------------
 // Public error type
@@ -174,8 +181,9 @@ impl std::error::Error for PythonLowerError {}
 /// original path).
 const FILE: &str = "<python>";
 
-/// Lower a parsed Python CST into a SIR module (M2: literals, variable
-/// references, assignment, unary/binary operators).
+/// Lower a parsed Python CST into a SIR module (M4: literals, variable
+/// references, assignment, operators, control flow, functions, calls,
+/// and closures).
 pub fn compile(tree: &GrammarASTNode, module_name: &str) -> Result<Module, PythonLowerError> {
     Lowerer::new(module_name).lower_file(tree)
 }
@@ -184,8 +192,8 @@ pub fn compile(tree: &GrammarASTNode, module_name: &str) -> Result<Module, Pytho
 // The lowerer
 // ---------------------------------------------------------------------------
 
-/// One lowered top-level statement: either a `Stmt` (an assignment) or a
-/// bare expression (an expression statement / the final value).
+/// One lowered top-level / suite statement: either a `Stmt` or a bare
+/// expression (an expression statement / the trailing block value).
 ///
 /// `Stmt` is boxed because it is by far the largest variant (it holds a
 /// full `Stmt`, which transitively contains `Block`s); boxing keeps the
@@ -195,27 +203,80 @@ enum Lowered {
     Expr(Expr),
 }
 
+/// Per-function name-resolution context (M4).
+///
+/// `main` and every user / synthesised `def`/`lambda` get their own
+/// `FunctionCtx`.  It tracks the names visible *inside this function*:
+///
+/// - `params` — the function's parameters (resolve as [`Scope::Param`]).
+/// - `captures` — names captured from an enclosing function (resolve as
+///   [`Scope::Capture`]); empty for top-level functions and `main`.
+/// - `locals` — a LIFO stack of `let*`-bound / loop-variable names,
+///   mirroring the SIR validator's `LocalEnv` (block-scoped via
+///   `mark`/`rewind`).
+///
+/// Module-level function names and builtins live on the [`Lowerer`]
+/// itself (they are the same for every function), so they are not
+/// duplicated here.
+struct FunctionCtx {
+    params: HashSet<String>,
+    captures: HashSet<String>,
+    locals: Vec<String>,
+}
+
+impl FunctionCtx {
+    /// A context for a function with the given params and captures.
+    fn new(params: HashSet<String>, captures: HashSet<String>) -> Self {
+        Self {
+            params,
+            captures,
+            locals: Vec::new(),
+        }
+    }
+
+    /// The top-level / `main` context: no params, no captures.
+    fn top_level() -> Self {
+        Self::new(HashSet::new(), HashSet::new())
+    }
+
+    /// Is `name` an enclosing-scope value (local / param / capture) of
+    /// *this* function?  Such a name, when read inside a nested
+    /// `lambda`/`def`, must be **captured**.
+    fn is_enclosing_value(&self, name: &str) -> bool {
+        self.locals.iter().any(|n| n == name)
+            || self.params.contains(name)
+            || self.captures.contains(name)
+    }
+}
+
 struct Lowerer {
     module_name: String,
     /// Features observed while lowering, used to build the manifest so
     /// it declares *exactly* what the module emits.
     observed: FeatureManifest,
-    /// Names bound in the scope chain *so far*, as a stack (M3).  Drives
-    /// first-occurrence detection: the first `x = …` declares (`LetStar`),
-    /// a later `x = …` re-assigns (`Assign`), and a `VarRef` to a name in
-    /// this stack resolves as `Scope::Local`.
-    ///
-    /// Why a stack rather than a flat `HashSet` (M2's design)?  M3 adds
-    /// nested statement *blocks* — loop and `if`-branch bodies.  The SIR
-    /// validator scopes block-local names with `mark()`/`rewind()`: a name
-    /// bound inside a loop body (or the loop variable itself) is **not**
-    /// visible once the body ends.  We mirror that exactly here with
-    /// [`Self::scope_mark`] / [`Self::scope_rewind`] so the names the
-    /// lowerer resolves and the names the validator accepts stay in
-    /// lock-step — otherwise a lowered module could fail its own
-    /// round-trip validation.  Membership is by linear scan (scopes are
-    /// tiny in practice), matching the validator's `LocalEnv`.
-    declared: Vec<String>,
+    /// Every function name known to the module: user `def`s (top-level
+    /// and nested) plus synthesised `__lambda_<N>` names.  Collected in
+    /// a *first pass* (see [`Self::collect_function_names`]) so a call to
+    /// a function defined later in the file — and mutual recursion —
+    /// resolve as [`Expr::DirectCall`].
+    function_names: HashSet<String>,
+    /// The synthesised + user functions accumulated during lowering, in
+    /// definition order.  `main` is appended last by [`Self::lower_file`].
+    functions: Vec<Function>,
+    /// Counter for `__lambda_<N>` gensym names.
+    lambda_counter: usize,
+    /// For each *lifted* function (nested `def` / lambda) that carries
+    /// captures, its ordered capture-name list.  When a **bare reference**
+    /// to such a function name appears (constructing a closure handle
+    /// without calling it), the `MakeClosure` must re-thread those
+    /// captures from the *currently visible* enclosing values — this map
+    /// records what to thread.  A function with no captures is absent
+    /// (its bare reference is a zero-capture `MakeClosure`).
+    fn_captures: std::collections::HashMap<String, Vec<String>>,
+    /// Call graph among *top-level* functions: `caller → callees` by
+    /// name.  Used after lowering to detect [`Feature::MutualRecursion`]
+    /// (a cycle of length ≥ 2 — two functions that call each other).
+    call_graph: Vec<(String, HashSet<String>)>,
 }
 
 impl Lowerer {
@@ -223,52 +284,47 @@ impl Lowerer {
         Self {
             module_name: module_name.to_string(),
             observed: FeatureManifest::new(),
-            declared: Vec::new(),
+            function_names: HashSet::new(),
+            functions: Vec::new(),
+            lambda_counter: 0,
+            fn_captures: std::collections::HashMap::new(),
+            call_graph: Vec::new(),
         }
     }
 
     // -------------------------------------------------------------------
-    // scope stack (M3): mirror the validator's `LocalEnv` mark/rewind so
+    // scope stack: mirror the validator's `LocalEnv` mark/rewind so
     // block-local bindings (loop vars, names first-bound inside a body)
     // do not leak past the block — exactly as the validator scopes them.
     // -------------------------------------------------------------------
 
-    /// Is `name` bound somewhere in the current scope chain?
-    fn is_declared(&self, name: &str) -> bool {
-        self.declared.iter().any(|n| n == name)
+    /// Remember the current local-stack depth before entering a block.
+    fn scope_mark(ctx: &FunctionCtx) -> usize {
+        ctx.locals.len()
     }
 
-    /// Bind `name` in the current (innermost) scope.
-    fn declare(&mut self, name: String) {
-        self.declared.push(name);
-    }
-
-    /// Remember the current scope depth before entering a nested block.
-    fn scope_mark(&self) -> usize {
-        self.declared.len()
-    }
-
-    /// Drop every name bound since `mark`, leaving the enclosing scope.
-    fn scope_rewind(&mut self, mark: usize) {
-        self.declared.truncate(mark);
+    /// Drop every local bound since `mark`, leaving the enclosing scope.
+    fn scope_rewind(ctx: &mut FunctionCtx, mark: usize) {
+        ctx.locals.truncate(mark);
     }
 
     // -------------------------------------------------------------------
-    // top level: `file` → synthesise `main`
+    // top level: `file` → collect function names, then synthesise `main`
     // -------------------------------------------------------------------
 
     /// The CST root is a `file` rule whose children are top-level
     /// `statement` nodes interleaved with stray `Newline` tokens.
     ///
-    /// Each statement lowers to either an *assignment* statement
-    /// (`LetStarBinding` / `Assign`) or a bare *expression*.  Python's
-    /// REPL "last expression is the value" rule means the trailing item,
-    /// **if it is a bare expression**, becomes `main`'s block value;
-    /// everything before it becomes a `Stmt` (assignments stay as-is,
-    /// bare expressions become `ExprStmt`s so side effects still run).
-    /// A program whose last statement is an assignment has block value
-    /// `NilLit` (assignment yields no value in Python).  An empty program
-    /// yields `main` returning `NilLit`.
+    /// M4 makes this two-pass:
+    ///
+    /// 1. **Collect** every function name (top-level and nested `def`s)
+    ///    so calls and mutual recursion resolve regardless of textual
+    ///    order.
+    /// 2. **Lower** each top-level statement.  A `def` lowers to a
+    ///    [`Function`] (appended to the function table, *not* a `main`
+    ///    statement); every other statement contributes to `main`'s body
+    ///    exactly as in M3 (the trailing bare expression becomes the
+    ///    block value).
     fn lower_file(&mut self, file: &GrammarASTNode) -> Result<Module, PythonLowerError> {
         if file.rule_name != "file" {
             return Err(self.err_at(
@@ -277,53 +333,48 @@ impl Lowerer {
             ));
         }
 
-        // Collect the lowered form of each top-level statement, in order.
+        // ── Pass 1: collect all function names (top-level + nested). ──
+        for child in &file.children {
+            if let ASTNodeOrToken::Node(stmt) = child {
+                self.collect_function_names(stmt)?;
+            }
+        }
+
+        // ── Pass 2: lower each top-level statement. ──
+        let mut ctx = FunctionCtx::top_level();
         let mut items: Vec<Lowered> = Vec::new();
         for child in &file.children {
             if let ASTNodeOrToken::Node(stmt) = child {
-                items.push(self.lower_statement(stmt, 0)?);
+                if let Some(item) = self.lower_top_statement(stmt, &mut ctx, 0)? {
+                    items.push(item);
+                }
             }
             // Token children at file level are stray NEWLINEs — ignore.
         }
 
         let span = Span::point(FILE, 1, 1);
-
-        // The block value is the *last* item iff it is a bare expression;
-        // otherwise (assignment last, or empty) the value is `NilLit` and
-        // every item becomes a statement.
-        let value = match items.last() {
-            Some(Lowered::Expr(_)) => match items.pop() {
-                Some(Lowered::Expr(e)) => e,
-                _ => unreachable!("just matched Expr"),
-            },
-            _ => Expr::NilLit { span: span.clone() },
-        };
-
-        let stmts: Vec<Stmt> = items
-            .into_iter()
-            .map(|item| match item {
-                Lowered::Stmt(s) => *s,
-                Lowered::Expr(expr) => {
-                    let s = expr.span().clone();
-                    Stmt::ExprStmt { expr, span: s }
-                }
-            })
-            .collect();
+        let body = Self::assemble_block(items, &span);
 
         let main = Function {
             name: "main".to_string(),
             params: vec![],
             return_type: None,
             captures: vec![],
-            body: Block {
-                stmts,
-                value,
-                span: span.clone(),
-            },
+            body,
             effects: EffectSet::PURE,
             metadata: Metadata::new(),
             span: span.clone(),
         };
+
+        // User + synthesised functions first, then `main`.  The
+        // validator does not care about ordering.
+        let mut functions = std::mem::take(&mut self.functions);
+        functions.push(main);
+
+        // Detect mutual recursion among top-level functions.
+        if self.has_mutual_recursion() {
+            self.observed.add(Feature::MutualRecursion);
+        }
 
         let metadata = Metadata::new()
             .with_source_language("python")
@@ -334,38 +385,180 @@ impl Lowerer {
             manifest: self.observed.clone(),
             imports: vec![],
             exports: vec![],
-            functions: vec![main],
+            functions,
             globals: vec![],
             metadata,
             span,
         })
     }
 
+    /// Assemble a list of lowered items into a [`Block`].  The trailing
+    /// item, **iff it is a bare expression**, becomes the block's value;
+    /// otherwise (statement last, or empty) the value is `NilLit` and
+    /// every item becomes a statement (bare expressions → `ExprStmt`).
+    fn assemble_block(mut items: Vec<Lowered>, span: &Span) -> Block {
+        let value = match items.last() {
+            Some(Lowered::Expr(_)) => match items.pop() {
+                Some(Lowered::Expr(e)) => e,
+                _ => unreachable!("just matched Expr"),
+            },
+            _ => Expr::NilLit { span: span.clone() },
+        };
+        let stmts: Vec<Stmt> = items
+            .into_iter()
+            .map(|item| match item {
+                Lowered::Stmt(s) => *s,
+                Lowered::Expr(expr) => {
+                    let s = expr.span().clone();
+                    Stmt::ExprStmt { expr, span: s }
+                }
+            })
+            .collect();
+        Block {
+            stmts,
+            value,
+            span: span.clone(),
+        }
+    }
+
     // -------------------------------------------------------------------
-    // statement → assignment, expression, or compound (if/while/for)
+    // Pass 1: collect every function name (top-level + nested)
     // -------------------------------------------------------------------
 
-    /// Lower a `statement`.
+    /// Recursively collect every `def`'s name into `function_names`, so
+    /// the second (lowering) pass can resolve calls — including
+    /// forward references and mutual recursion — to `DirectCall`.
     ///
-    /// A `statement` wraps exactly one of:
+    /// We descend into `def` suites too, so *nested* `def` names are
+    /// known before their use; nested defs are lifted to top-level
+    /// synthesised functions during lowering, but their names live in the
+    /// same flat table.  `lambda` names are *not* collected here — they
+    /// are gensym'd on the fly during lowering (a lambda has no source
+    /// name to forward-reference).
+    fn collect_function_names(&mut self, stmt: &GrammarASTNode) -> Result<(), PythonLowerError> {
+        // Only `statement` nodes carry defs; recurse structurally.
+        if let Some(def) = self.as_def_stmt(stmt) {
+            let name = self.def_name(def)?;
+            self.function_names.insert(name);
+            // Descend into the def's suite for nested defs.
+            if let Some(suite) = self.first_child_named(def, "suite") {
+                for child in &suite.children {
+                    if let ASTNodeOrToken::Node(inner) = child {
+                        if inner.rule_name == "statement" {
+                            self.collect_function_names(inner)?;
+                        }
+                    }
+                }
+            }
+        } else {
+            // Non-def compound statements (if/while/for) may *contain*
+            // nested defs in their suites — but Python forbids `def`
+            // inside an `if`/loop at our v0 subset's depth resolution
+            // semantics only at lowering time.  Still, scan suites so a
+            // `def` nested under control flow is name-collected.
+            for suite in self.descendant_suites(stmt) {
+                for child in &suite.children {
+                    if let ASTNodeOrToken::Node(inner) = child {
+                        if inner.rule_name == "statement" {
+                            self.collect_function_names(inner)?;
+                        }
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// If `stmt` is a `statement` wrapping a `compound_stmt` wrapping a
+    /// `def_stmt`, return the `def_stmt` node.
+    fn as_def_stmt<'a>(&self, stmt: &'a GrammarASTNode) -> Option<&'a GrammarASTNode> {
+        if stmt.rule_name != "statement" {
+            return None;
+        }
+        let compound = child_nodes(stmt)
+            .into_iter()
+            .find(|n| n.rule_name == "compound_stmt")?;
+        child_nodes(compound)
+            .into_iter()
+            .find(|n| n.rule_name == "def_stmt")
+    }
+
+    /// The direct `suite` children of any `compound_stmt` inside
+    /// `statement` *other than* a `def` — used by name collection to find
+    /// defs nested under `if`/`while`/`for`.  (A `def`'s own suite is
+    /// handled separately so its name is recorded first.)
+    fn descendant_suites<'a>(&self, stmt: &'a GrammarASTNode) -> Vec<&'a GrammarASTNode> {
+        let mut out = Vec::new();
+        if stmt.rule_name != "statement" {
+            return out;
+        }
+        if let Some(compound) = child_nodes(stmt)
+            .into_iter()
+            .find(|n| n.rule_name == "compound_stmt")
+        {
+            for inner in child_nodes(compound) {
+                if inner.rule_name == "def_stmt" {
+                    continue;
+                }
+                for s in child_nodes(inner) {
+                    if s.rule_name == "suite" {
+                        out.push(s);
+                    }
+                }
+            }
+        }
+        out
+    }
+
+    /// Extract a `def_stmt`'s declared name (the `NAME` token after the
+    /// `def` keyword).
+    fn def_name(&self, def: &GrammarASTNode) -> Result<String, PythonLowerError> {
+        for child in &def.children {
+            if let ASTNodeOrToken::Token(t) = child {
+                if matches!(t.type_, lexer::token::TokenType::Name) && t.type_name.is_none() {
+                    return Ok(t.value.clone());
+                }
+            }
+        }
+        Err(self.err_at(def, "malformed def: missing function name".to_string()))
+    }
+
+    // -------------------------------------------------------------------
+    // Pass 2 — statement → assignment / expression / compound / def
+    // -------------------------------------------------------------------
+
+    /// Lower a top-level (`main`-body) `statement`.  Returns `None` when
+    /// the statement is a `def` (which is lifted to the function table and
+    /// contributes nothing to `main`'s body), or `Some(item)` otherwise.
+    fn lower_top_statement(
+        &mut self,
+        stmt: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+        depth: usize,
+    ) -> Result<Option<Lowered>, PythonLowerError> {
+        if let Some(def) = self.as_def_stmt(stmt) {
+            // A top-level def: lift to the function table and discard the
+            // definition-site closure value (nothing consumes it at the
+            // top level, and a top-level def captures nothing).  We drop
+            // the returned `MakeClosure` without retaining it, so it does
+            // not contribute a `Closures` feature.
+            self.lower_def(def, ctx, depth)?;
+            return Ok(None);
+        }
+        Ok(Some(self.lower_statement(stmt, ctx, depth)?))
+    }
+
+    /// Lower a `statement` (already known *not* to be a top-level `def`
+    /// the caller wants lifted; a `def` reaching here is a nested def and
+    /// lowers to a `MakeClosure`-yielding lifted function).
     ///
-    /// - a `simple_stmt` — an *assignment* (`x = expr`) or a bare
-    ///   *expression statement*; or
-    /// - a `compound_stmt` — control flow (`if` / `while` / `for`), added
-    ///   in M3.
-    ///
-    /// `def` / `class` / `with` / `try` also arrive as `compound_stmt`
-    /// children and are still rejected with a clear "unsupported" error;
-    /// `global` / `nonlocal` take a different `small_stmt` branch and are
-    /// likewise rejected.
-    ///
-    /// `depth` is the statement-block nesting depth — top-level statements
-    /// are depth 0; each loop / `if`-branch body recurses one level deeper.
-    /// It bounds [`MAX_BLOCK_DEPTH`] so pathologically nested control flow
-    /// fails cleanly instead of overflowing the native stack.
+    /// `depth` is the statement-block nesting depth; it bounds
+    /// [`MAX_BLOCK_DEPTH`] so pathologically nested control flow / bodies
+    /// fail cleanly instead of overflowing the native stack.
     fn lower_statement(
         &mut self,
         stmt: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
         depth: usize,
     ) -> Result<Lowered, PythonLowerError> {
         if depth > MAX_BLOCK_DEPTH {
@@ -381,8 +574,6 @@ impl Lowerer {
             ));
         }
 
-        // `statement` has a single node child: either `simple_stmt` or
-        // (M3) `compound_stmt`.
         let inner = match child_nodes(stmt).as_slice() {
             [only] => *only,
             _ => {
@@ -393,8 +584,8 @@ impl Lowerer {
             }
         };
         match inner.rule_name.as_str() {
-            "simple_stmt" => self.lower_simple_stmt(inner),
-            "compound_stmt" => self.lower_compound_stmt(inner, depth),
+            "simple_stmt" => self.lower_simple_stmt(inner, ctx),
+            "compound_stmt" => self.lower_compound_stmt(inner, ctx, depth),
             other => Err(self.err_at(
                 inner,
                 format!("unsupported: {other} (deferred to a later milestone)"),
@@ -402,58 +593,86 @@ impl Lowerer {
         }
     }
 
-    /// Lower a `simple_stmt` — an assignment or a bare expression.
-    fn lower_simple_stmt(&mut self, simple: &GrammarASTNode) -> Result<Lowered, PythonLowerError> {
-        // Descend the fixed spine: simple_stmt → small_stmt → assign_stmt.
+    /// Lower a `simple_stmt` — an assignment, a `return`, or a bare
+    /// expression.  A `return` reaching here is a **tail** return (the
+    /// suite lowerer special-cases the final statement); a `return` in
+    /// any other position is an early return and is rejected.
+    fn lower_simple_stmt(
+        &mut self,
+        simple: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+    ) -> Result<Lowered, PythonLowerError> {
         let small = self.expect_single_named(simple, "simple_stmt", &["small_stmt"])?;
-        let assign = self.expect_single_named(small, "small_stmt", &["assign_stmt"])?;
+        // `small_stmt` wraps the actual statement: `assign_stmt` (M2) or
+        // (M4) `return_stmt`.  Anything else is deferred/unsupported.
+        let inner = match child_nodes(small).as_slice() {
+            [only] => *only,
+            _ => {
+                return Err(self.err_at(
+                    small,
+                    "unsupported: small statement with multiple parts (deferred)".to_string(),
+                ))
+            }
+        };
+        match inner.rule_name.as_str() {
+            "assign_stmt" => self.lower_assign_stmt(inner, ctx),
+            "return_stmt" => {
+                // A `return` reaching the *general* statement lowerer is
+                // an early (non-tail) return — rejected per spec.  Tail
+                // returns are intercepted by `lower_suite_no_mark`.
+                Err(self.err_at(
+                    inner,
+                    "early return not supported in v0 (return must be the last statement of a function)"
+                        .to_string(),
+                ))
+            }
+            other => Err(self.err_at(
+                inner,
+                format!("unsupported: {other} (deferred to a later milestone)"),
+            )),
+        }
+    }
 
-        // `assign_stmt` is `expression_list (assign_suffix)?`.  When an
-        // `assign_suffix` (`= rhs`) is present it's a real assignment;
-        // otherwise it's a bare expression statement.
+    /// Lower an `assign_stmt` — `expression_list (assign_suffix)?`.  With
+    /// an `assign_suffix` (`= rhs`) present it is a real assignment;
+    /// otherwise it is a bare expression statement.
+    fn lower_assign_stmt(
+        &mut self,
+        assign: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+    ) -> Result<Lowered, PythonLowerError> {
         let node_children: Vec<&GrammarASTNode> = child_nodes(assign);
         let suffix = node_children
             .iter()
             .find(|n| n.rule_name == "assign_suffix")
             .copied();
 
-        // The first `expression_list` is the assignment *target* (LHS) for
-        // an assignment, or the whole expression for a bare statement.
         let lhs_list = self.expect_single_kind(assign, "expression_list")?;
 
         match suffix {
             None => {
-                // Bare expression statement.
-                let expr = self.lower_expr(self.single_expr(lhs_list)?)?;
+                let expr = self.lower_expr(self.single_expr(lhs_list)?, ctx)?;
                 Ok(Lowered::Expr(expr))
             }
-            Some(suffix) => self.lower_assignment(assign, lhs_list, suffix),
+            Some(suffix) => self.lower_assignment(assign, lhs_list, suffix, ctx),
         }
     }
 
-    /// Lower `target = rhs` from its `assign_stmt`, target `expression_list`,
-    /// and `assign_suffix` (`= <expression_list>`).
-    ///
-    /// First-occurrence detection: the first assignment to a name emits a
-    /// `LetStarBinding` (declares it); a later assignment to an
-    /// already-declared name emits an `Assign` (re-binds, sets
-    /// `Feature::MutableBindings` via the validator).
+    /// Lower `target = rhs`.  First-occurrence detection: the first
+    /// assignment to a name emits a `LetStarBinding`; a later assignment
+    /// to an already-declared name emits an `Assign`.
     fn lower_assignment(
         &mut self,
         assign: &GrammarASTNode,
         lhs_list: &GrammarASTNode,
         suffix: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
     ) -> Result<Lowered, PythonLowerError> {
-        // The RHS lives in the suffix's `expression_list`.
         let rhs_list = self.expect_single_kind(suffix, "expression_list")?;
 
-        // M2 supports exactly one target = one value.  Tuple/chained
-        // assignment (`a, b = …`, `a = b = …`) is deferred.
         let target_node = self.single_expr(lhs_list)?;
         let rhs_node = self.single_expr(rhs_list)?;
 
-        // The target must be a bare name (`x`).  Attribute/subscript
-        // targets (`obj.x = …`, `xs[i] = …`) are deferred.
         let name = match self.target_name(target_node)? {
             Some(name) => name,
             None => {
@@ -465,16 +684,11 @@ impl Lowerer {
         };
 
         // Lower the RHS *before* declaring the name so a self-referential
-        // first binding (`x = x`) correctly sees `x` as still-unbound and
-        // raises an unresolved-name error (Python's behaviour).
-        let value = self.lower_expr(rhs_node)?;
+        // first binding (`x = x`) correctly sees `x` as still-unbound.
+        let value = self.lower_expr(rhs_node, ctx)?;
         let span = self.span_of(assign);
 
-        if self.is_declared(&name) {
-            // Re-assignment to an already-declared local.  Emitting an
-            // `Assign` means the module mutates a binding, so declare the
-            // feature (the validator also observes it; declaring it here
-            // keeps the manifest comparison balanced).
+        if ctx.locals.iter().any(|n| n == &name) {
             self.observed.add(Feature::MutableBindings);
             Ok(Lowered::Stmt(Box::new(Stmt::Assign {
                 name,
@@ -483,9 +697,7 @@ impl Lowerer {
                 span,
             })))
         } else {
-            // First occurrence: declare via sequential `let*` so later
-            // statements (and later RHS) can see it.
-            self.declare(name.clone());
+            ctx.locals.push(name.clone());
             Ok(Lowered::Stmt(Box::new(Stmt::LetStarBinding {
                 name,
                 sir_type: None,
@@ -496,13 +708,8 @@ impl Lowerer {
     }
 
     /// If `node` is an expression that is *just* a bare `Name` atom,
-    /// return that name.  Used to recognise an assignment target.  Returns
-    /// `Ok(None)` for any non-trivial expression (an operator, literal,
-    /// call, …), which the caller reports as an unsupported target.
+    /// return that name (used to recognise an assignment / call target).
     fn target_name(&self, node: &GrammarASTNode) -> Result<Option<String>, PythonLowerError> {
-        // Peel single-child wrappers down to the leaf, exactly like the
-        // expression peeler but without lowering — we only want to know if
-        // the bottom is a single `Name` token.
         let mut cur = node;
         let mut depth = 0usize;
         loop {
@@ -510,9 +717,7 @@ impl Lowerer {
                 return Err(self.err_at(node, "assignment target nesting too deep".to_string()));
             }
             if let Some(tok) = cur.token() {
-                if matches!(tok.type_, lexer::token::TokenType::Name)
-                    && tok.type_name.is_none()
-                {
+                if matches!(tok.type_, lexer::token::TokenType::Name) && tok.type_name.is_none() {
                     return Ok(Some(tok.value.clone()));
                 }
                 return Ok(None);
@@ -529,21 +734,14 @@ impl Lowerer {
     }
 
     // -------------------------------------------------------------------
-    // compound statements (M3): if / while / for
+    // compound statements: if / while / for / def
     // -------------------------------------------------------------------
 
-    /// Lower a `compound_stmt` — control flow.  A `compound_stmt` wraps a
-    /// single rule node: `if_stmt`, `while_stmt`, or `for_stmt` (M3).
-    /// `def` / `class_def` / `with_stmt` / `try_stmt` also surface here and
-    /// are deferred to later milestones with a clear error.
-    ///
-    /// `if` lowers to an [`Expr::If`] returned as a [`Lowered::Expr`], so a
-    /// trailing `if` can become the block *value* (Python's `if` is a
-    /// statement, but SIR models it as an expression — see [`Self::lower_if`]).
-    /// `while` / `for` are pure statements ([`Lowered::Stmt`]).
+    /// Lower a `compound_stmt` — control flow or a nested `def`.
     fn lower_compound_stmt(
         &mut self,
         compound: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
         depth: usize,
     ) -> Result<Lowered, PythonLowerError> {
         let inner = match child_nodes(compound).as_slice() {
@@ -556,9 +754,21 @@ impl Lowerer {
             }
         };
         match inner.rule_name.as_str() {
-            "if_stmt" => Ok(Lowered::Expr(self.lower_if(inner, depth)?)),
-            "while_stmt" => Ok(Lowered::Stmt(Box::new(self.lower_while(inner, depth)?))),
-            "for_stmt" => Ok(Lowered::Stmt(Box::new(self.lower_for(inner, depth)?))),
+            "if_stmt" => Ok(Lowered::Expr(self.lower_if(inner, ctx, depth)?)),
+            "while_stmt" => Ok(Lowered::Stmt(Box::new(self.lower_while(inner, ctx, depth)?))),
+            "for_stmt" => Ok(Lowered::Stmt(Box::new(self.lower_for(inner, ctx, depth)?))),
+            "def_stmt" => {
+                // A nested `def` reaching the general statement lowerer:
+                // lift it to a top-level synthesised function with
+                // captures, then yield a `MakeClosure` so the closure
+                // value is produced at this position (e.g. as a block
+                // value to be `return`ed).
+                let mc = self.lower_def(inner, ctx, depth)?;
+                // This `MakeClosure` is retained (it becomes the block
+                // value) → the module uses closures.
+                self.observed.add(Feature::Closures);
+                Ok(Lowered::Expr(mc))
+            }
             other => Err(self.err_at(
                 inner,
                 format!("unsupported: {other} (deferred to a later milestone)"),
@@ -566,36 +776,14 @@ impl Lowerer {
         }
     }
 
-    /// Lower an `if_stmt` into a nested chain of [`Expr::If`].
-    ///
-    /// The parser flattens the whole `if` / `elif` / `else` construct into
-    /// **one** `if_stmt` node whose children are an ordered token+node
-    /// stream:
-    ///
-    /// ```text
-    /// if_stmt:
-    ///   KW "if"   expression  ":"  suite          ← the leading clause
-    ///   KW "elif" expression  ":"  suite          ← zero or more elif clauses
-    ///   …
-    ///   KW "else" ":"  suite                       ← optional trailing else
-    /// ```
-    ///
-    /// We walk that stream into a list of `(cond, suite)` clauses plus an
-    /// optional `else` suite, then fold it **right-to-left** so each `elif`
-    /// becomes the `else_branch` of the clause before it:
-    ///
-    /// ```text
-    /// if c1: B1 elif c2: B2 else: B3
-    ///   ⇒ If { c1, B1, else: If { c2, B2, else: B3 } }
-    /// ```
-    ///
-    /// A missing `else` becomes an empty `else_branch` block whose value is
-    /// `NilLit` (SIR requires both branches; an `if` with no `else` yields
-    /// nil on the false path, matching Python where the suite simply does
-    /// not run).  `if` adds no manifest feature — it is a SIR v0 construct.
-    fn lower_if(&mut self, if_stmt: &GrammarASTNode, depth: usize) -> Result<Expr, PythonLowerError> {
-        // Each clause is a guard expression paired with its suite; `else`
-        // (if present) is a bare suite with no guard.
+    /// Lower an `if_stmt` into a nested chain of [`Expr::If`].  (Unchanged
+    /// from M3 except for threading the [`FunctionCtx`].)
+    fn lower_if(
+        &mut self,
+        if_stmt: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+        depth: usize,
+    ) -> Result<Expr, PythonLowerError> {
         struct Clause<'a> {
             cond: &'a GrammarASTNode,
             suite: &'a GrammarASTNode,
@@ -603,9 +791,6 @@ impl Lowerer {
         let mut clauses: Vec<Clause> = Vec::new();
         let mut else_suite: Option<&GrammarASTNode> = None;
 
-        // Walk the flat child stream.  A keyword token (`if`/`elif`/`else`)
-        // opens a clause; the next `expression` is its guard (absent for
-        // `else`); the next `suite` is its body.
         let mut pending_cond: Option<&GrammarASTNode> = None;
         let mut in_else = false;
         for child in &if_stmt.children {
@@ -634,7 +819,6 @@ impl Lowerer {
                         clauses.push(Clause { cond, suite: n });
                     }
                 }
-                // Other tokens (`:`) and any stray nodes are ignored.
                 _ => {}
             }
         }
@@ -645,16 +829,14 @@ impl Lowerer {
 
         let if_span = self.span_of(if_stmt);
 
-        // Build the final `else` block first (it is the deepest branch).
         let mut else_branch: Block = match else_suite {
-            Some(s) => self.lower_suite(s, depth + 1)?,
+            Some(s) => self.lower_suite(s, ctx, depth + 1)?,
             None => empty_block(if_span.clone()),
         };
 
-        // Fold clauses right-to-left so earlier `elif`s wrap later ones.
         for clause in clauses.into_iter().rev() {
-            let cond = self.lower_expr(clause.cond)?;
-            let then_branch = self.lower_suite(clause.suite, depth + 1)?;
+            let cond = self.lower_expr(clause.cond, ctx)?;
+            let then_branch = self.lower_suite(clause.suite, ctx, depth + 1)?;
             let span = cond.span().clone();
             let folded = Expr::If {
                 cond: Box::new(cond),
@@ -662,13 +844,9 @@ impl Lowerer {
                 else_branch: Box::new(else_branch),
                 span,
             };
-            // The just-built `If` becomes the else-branch of the next
-            // (outer) clause: wrap it in a one-value block.
             else_branch = value_block(folded);
         }
 
-        // After the fold, `else_branch` is a block whose value is the
-        // outermost `If`.  Unwrap it back to the bare `If` expression.
         match else_branch.value {
             Expr::If { .. } => Ok(else_branch.value),
             other => Ok(other),
@@ -676,13 +854,10 @@ impl Lowerer {
     }
 
     /// Lower a `while_stmt` into [`Stmt::While`].
-    ///
-    /// `while_stmt` children: `KW "while"`, `expression` (the condition),
-    /// `:`, `suite` (the body).  The body is lowered into a [`Block`]; the
-    /// loop adds [`Feature::Loops`].
     fn lower_while(
         &mut self,
         while_stmt: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
         depth: usize,
     ) -> Result<Stmt, PythonLowerError> {
         let cond_node = self
@@ -692,8 +867,8 @@ impl Lowerer {
             .first_child_named(while_stmt, "suite")
             .ok_or_else(|| self.err_at(while_stmt, "malformed while: no body".to_string()))?;
 
-        let cond = self.lower_expr(cond_node)?;
-        let body = self.lower_suite(suite, depth + 1)?;
+        let cond = self.lower_expr(cond_node, ctx)?;
+        let body = self.lower_suite(suite, ctx, depth + 1)?;
         self.observed.add(Feature::Loops);
         Ok(Stmt::While {
             cond,
@@ -702,18 +877,14 @@ impl Lowerer {
         })
     }
 
-    /// Lower a `for_stmt` into either [`Stmt::ForRange`] (when the iterable
-    /// is a literal `range(...)` call) or [`Stmt::ForEach`] (any other
-    /// iterable).
-    ///
-    /// `for_stmt` children: `KW "for"`, `target_list` (the loop var(s)),
-    /// `KW "in"`, `expression_list` (the iterable), `:`, `suite` (body).
-    ///
-    /// M3 supports exactly one bare-name target (`for i in …`).  Tuple
-    /// targets (`for k, v in …`) are deferred.  The loop variable is bound
-    /// **inside the body's scope only** (mirroring the validator): we push
-    /// a scope mark, declare the var, lower the body, then rewind.
-    fn lower_for(&mut self, for_stmt: &GrammarASTNode, depth: usize) -> Result<Stmt, PythonLowerError> {
+    /// Lower a `for_stmt` into [`Stmt::ForRange`] (literal `range(...)`
+    /// iterable) or [`Stmt::ForEach`] (any other iterable).
+    fn lower_for(
+        &mut self,
+        for_stmt: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+        depth: usize,
+    ) -> Result<Stmt, PythonLowerError> {
         let target_list = self
             .first_child_named(for_stmt, "target_list")
             .ok_or_else(|| self.err_at(for_stmt, "malformed for: no target".to_string()))?;
@@ -724,9 +895,6 @@ impl Lowerer {
             .first_child_named(for_stmt, "suite")
             .ok_or_else(|| self.err_at(for_stmt, "malformed for: no body".to_string()))?;
 
-        // The target must be a single bare name.  `target_list` holds one
-        // or more `target` nodes; we accept exactly one whose leaf is a
-        // `Name`.
         let targets = child_nodes(target_list);
         let var = match targets.as_slice() {
             [one] => match self.target_name(one)? {
@@ -746,26 +914,18 @@ impl Lowerer {
             }
         };
 
-        // The iterable is the single expression in `expression_list`.
         let iter_expr_node = self.single_expr(iter_list)?;
         let span = self.span_of(for_stmt);
 
-        // Is the iterable a literal `range(...)` call?  If so, lower to
-        // `ForRange`; otherwise lower the iterable expression and emit
-        // `ForEach`.  We classify *before* binding the loop var because the
-        // iterable is evaluated in the *enclosing* scope (the loop var is
-        // not yet in scope), exactly as the validator checks it.
-        let range = self.try_range_call(iter_expr_node)?;
-
+        let range = self.try_range_call(iter_expr_node, ctx)?;
         self.observed.add(Feature::Loops);
 
         match range {
             Some((start, stop, step)) => {
-                // Bind the loop var inside the body's scope only.
-                let mark = self.scope_mark();
-                self.declare(var.clone());
-                let body = self.lower_suite_no_mark(suite, depth + 1)?;
-                self.scope_rewind(mark);
+                let mark = Self::scope_mark(ctx);
+                ctx.locals.push(var.clone());
+                let body = self.lower_suite_no_mark(suite, ctx, depth + 1)?;
+                Self::scope_rewind(ctx, mark);
                 Ok(Stmt::ForRange {
                     var,
                     start,
@@ -776,11 +936,11 @@ impl Lowerer {
                 })
             }
             None => {
-                let iter = self.lower_expr(iter_expr_node)?;
-                let mark = self.scope_mark();
-                self.declare(var.clone());
-                let body = self.lower_suite_no_mark(suite, depth + 1)?;
-                self.scope_rewind(mark);
+                let iter = self.lower_expr(iter_expr_node, ctx)?;
+                let mark = Self::scope_mark(ctx);
+                ctx.locals.push(var.clone());
+                let body = self.lower_suite_no_mark(suite, ctx, depth + 1)?;
+                Self::scope_rewind(ctx, mark);
                 Ok(Stmt::ForEach {
                     var,
                     iter,
@@ -791,74 +951,59 @@ impl Lowerer {
         }
     }
 
-    /// Recognise a literal `range(...)` call and lower its arguments into
-    /// `(start, stop, step)` expressions per Python's `range` arities:
-    ///
-    /// | call form            | start | stop | step |
-    /// |----------------------|-------|------|------|
-    /// | `range(n)`           | `0`   | `n`  | `1`  |
-    /// | `range(a, b)`        | `a`   | `b`  | `1`  |
-    /// | `range(a, b, c)`     | `a`   | `b`  | `c`  |
-    ///
-    /// Returns `Ok(None)` when the iterable is *not* a `range(...)` call
-    /// (so the caller falls back to `ForEach`).  A `range` call with zero
-    /// arguments or more than three is rejected (`range` requires 1–3 args).
+    /// Recognise a literal `range(...)` call inside a `for` header and
+    /// lower its 1/2/3 arguments into `(start, stop, step)`.
     fn try_range_call(
         &mut self,
         iter: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
     ) -> Result<Option<(Expr, Expr, Expr)>, PythonLowerError> {
-        // Peel single-child wrappers down to the `primary` that carries the
-        // `atom`(Name) + `suffix`(call) shape.
         let primary = match self.peel_to_primary(iter) {
             Some(p) => p,
             None => return Ok(None),
         };
 
-        // A call `primary` is `atom suffix` where `suffix` is `( args )`.
         let kids = child_nodes(primary);
         let (callee, suffix) = match kids.as_slice() {
             [callee, suffix] if suffix.rule_name == "suffix" => (*callee, *suffix),
             _ => return Ok(None),
         };
 
-        // The callee must be the bare name `range`.
         match self.target_name(callee)? {
             Some(name) if name == "range" => {}
             _ => return Ok(None),
         }
 
-        // Collect the call's `argument` nodes (commas are tokens).
-        let suffix_kids = child_nodes(suffix);
-        let args: Vec<&GrammarASTNode> = suffix_kids
-            .into_iter()
-            .filter(|n| n.rule_name == "arguments")
-            .flat_map(child_nodes)
-            .filter(|n| n.rule_name == "argument")
-            .collect();
+        let args = self.call_arguments(suffix);
 
         let span = self.span_of(primary);
-        let int = |v: i64| Expr::IntLit { value: v, span: span.clone() };
+        let int = |v: i64| Expr::IntLit {
+            value: v,
+            span: span.clone(),
+        };
 
-        // One `argument` wraps one `expression`; lower it.
-        let arg_expr = |me: &mut Self, a: &GrammarASTNode| -> Result<Expr, PythonLowerError> {
+        let arg_expr = |me: &mut Self,
+                        a: &GrammarASTNode,
+                        ctx: &mut FunctionCtx|
+         -> Result<Expr, PythonLowerError> {
             let expr = me.single_arg_expr(a)?;
-            me.lower_expr(expr)
+            me.lower_expr(expr, ctx)
         };
 
         match args.as_slice() {
             [n] => {
-                let stop = arg_expr(self, n)?;
+                let stop = arg_expr(self, n, ctx)?;
                 Ok(Some((int(0), stop, int(1))))
             }
             [a, b] => {
-                let start = arg_expr(self, a)?;
-                let stop = arg_expr(self, b)?;
+                let start = arg_expr(self, a, ctx)?;
+                let stop = arg_expr(self, b, ctx)?;
                 Ok(Some((start, stop, int(1))))
             }
             [a, b, c] => {
-                let start = arg_expr(self, a)?;
-                let stop = arg_expr(self, b)?;
-                let step = arg_expr(self, c)?;
+                let start = arg_expr(self, a, ctx)?;
+                let stop = arg_expr(self, b, ctx)?;
+                let step = arg_expr(self, c, ctx)?;
                 Ok(Some((start, stop, step)))
             }
             other => Err(self.err_at(
@@ -871,10 +1016,17 @@ impl Lowerer {
         }
     }
 
-    /// Peel an expression node down to the `primary` rule (the level that
-    /// carries call/index/attribute suffixes), following single-child
-    /// wrappers.  Returns `None` if no `primary` with a non-trivial shape
-    /// is reached (e.g. a bare name peels past `primary` to its `atom`).
+    /// Collect the `argument` nodes from a call `suffix` (`( args )`).
+    fn call_arguments<'a>(&self, suffix: &'a GrammarASTNode) -> Vec<&'a GrammarASTNode> {
+        child_nodes(suffix)
+            .into_iter()
+            .filter(|n| n.rule_name == "arguments")
+            .flat_map(child_nodes)
+            .filter(|n| n.rule_name == "argument")
+            .collect()
+    }
+
+    /// Peel an expression node down to the `primary` rule.
     fn peel_to_primary<'a>(&self, node: &'a GrammarASTNode) -> Option<&'a GrammarASTNode> {
         let mut cur = node;
         let mut depth = 0usize;
@@ -906,32 +1058,698 @@ impl Lowerer {
             .ok_or_else(|| self.err_at(arg, "malformed call argument".to_string()))
     }
 
-    /// Lower a `suite` (an indented statement block) into a [`Block`].
+    // -------------------------------------------------------------------
+    // def / lambda → lifted Function (+ MakeClosure)
+    // -------------------------------------------------------------------
+
+    /// Lower a `def_stmt` into a top-level [`Function`].
     ///
-    /// A `suite` is `Newline Indent statement+ Dedent`.  Each `statement`
-    /// lowers via [`Self::lower_statement`] (so nested control flow works).
-    /// Block-value semantics mirror `main`'s top level: the trailing item,
-    /// **if it is a bare expression**, becomes the block's value; everything
-    /// before becomes a `Stmt` (bare expressions become `ExprStmt`s).  A
-    /// suite ending in an assignment / loop yields a `NilLit` value.
+    /// `enclosing` is the context the `def` is *written inside* (the
+    /// top-level `main` ctx, or another function's ctx for a nested
+    /// `def`).  The returned [`Expr`] is an [`Expr::MakeClosure`] that
+    /// constructs the closure value at the definition site — captures are
+    /// evaluated against `enclosing`.  For a *top-level* `def` the
+    /// captures are empty (nothing to capture) and the caller discards
+    /// the `MakeClosure`; for a *nested* `def` the `MakeClosure` becomes
+    /// the value produced where the `def` appeared (so it can be
+    /// `return`ed or assigned).
+    fn lower_def(
+        &mut self,
+        def: &GrammarASTNode,
+        enclosing: &mut FunctionCtx,
+        depth: usize,
+    ) -> Result<Expr, PythonLowerError> {
+        let name = self.def_name(def)?;
+        let params = self.def_params(def)?;
+        let suite = self
+            .first_child_named(def, "suite")
+            .ok_or_else(|| self.err_at(def, "malformed def: missing body".to_string()))?;
+        let span = self.span_of(def);
+
+        self.lower_callable(&name, &params, suite, enclosing, depth, span)
+    }
+
+    /// Extract a `def_stmt`'s parameter names (rejecting defaults / `*args`
+    /// / `**kwargs`, which are deferred).
+    fn def_params(&self, def: &GrammarASTNode) -> Result<Vec<String>, PythonLowerError> {
+        let parameters = match self.first_child_named(def, "parameters") {
+            Some(p) => p,
+            None => return Ok(vec![]), // `def f():` — no params.
+        };
+        // `parameters → parameter_list → param_with_default+`.
+        let list = self
+            .first_child_named(parameters, "parameter_list")
+            .unwrap_or(parameters);
+        let mut names = Vec::new();
+        for pwd in child_nodes(list) {
+            if pwd.rule_name != "param_with_default" {
+                continue;
+            }
+            names.push(self.param_name(pwd)?);
+        }
+        Ok(names)
+    }
+
+    /// Extract one parameter's name from a `param_with_default`, rejecting
+    /// a default value (`a=1`) — the node then carries an extra `EQUALS`
+    /// token / default `expression`, which v0 does not model.
+    fn param_name(&self, pwd: &GrammarASTNode) -> Result<String, PythonLowerError> {
+        // A plain parameter is exactly one `NAME` token.  A default adds
+        // an `EQUALS` token (+ a default expression node).
+        let has_default = pwd.children.iter().any(|c| {
+            matches!(c, ASTNodeOrToken::Token(t) if t.value == "=")
+                || matches!(c, ASTNodeOrToken::Node(_))
+        });
+        if has_default {
+            return Err(self.err_at(
+                pwd,
+                "unsupported: default parameter value (deferred)".to_string(),
+            ));
+        }
+        for child in &pwd.children {
+            if let ASTNodeOrToken::Token(t) = child {
+                if matches!(t.type_, lexer::token::TokenType::Name) && t.type_name.is_none() {
+                    return Ok(t.value.clone());
+                }
+            }
+        }
+        Err(self.err_at(pwd, "malformed parameter".to_string()))
+    }
+
+    /// Lower a `lambda_expr` into a fresh top-level synthesised
+    /// [`Function`] plus an [`Expr::MakeClosure`] at the use site.
+    fn lower_lambda(
+        &mut self,
+        lambda: &GrammarASTNode,
+        enclosing: &mut FunctionCtx,
+        depth: usize,
+    ) -> Result<Expr, PythonLowerError> {
+        let span = self.span_of(lambda);
+        let params = self.lambda_params(lambda)?;
+        let body_expr = self
+            .first_child_named(lambda, "expression")
+            .ok_or_else(|| self.err_at(lambda, "malformed lambda: missing body".to_string()))?;
+
+        let fn_name = self.fresh_lambda_name();
+
+        // A lambda's body is a single expression; compute its free
+        // variables, lower it in a fresh ctx with those captures, and
+        // emit the closure body + a MakeClosure.
+        let bound: HashSet<String> = params.iter().cloned().collect();
+        let mut free = Vec::new();
+        let mut seen = HashSet::new();
+        self.collect_free_names(body_expr, &bound, &mut free, &mut seen);
+
+        let (captures, capture_values) =
+            self.resolve_captures(&free, enclosing, &span)?;
+
+        // Lower the body in the synthesised function's own context.
+        let mut inner = FunctionCtx::new(bound.clone(), captures.iter().cloned().collect());
+        let value = self.lower_expr_in(body_expr, &mut inner, depth + 1)?;
+        let body = Block {
+            stmts: vec![],
+            value,
+            span: span.clone(),
+        };
+        self.push_function(&fn_name, &params, &captures, body, span.clone());
+
+        // A lambda always yields a retained closure value.
+        self.observed.add(Feature::Closures);
+        Ok(self.make_closure(fn_name, captures, capture_values, span))
+    }
+
+    /// Extract a `lambda_expr`'s parameter names (rejecting `*`/`**` and
+    /// defaults).
+    fn lambda_params(&self, lambda: &GrammarASTNode) -> Result<Vec<String>, PythonLowerError> {
+        let params = match self.first_child_named(lambda, "lambda_params") {
+            Some(p) => p,
+            None => return Ok(vec![]), // `lambda: expr` — no params.
+        };
+        let mut names = Vec::new();
+        for lp in child_nodes(params) {
+            if lp.rule_name != "lambda_param" {
+                continue;
+            }
+            // A default / `*`/`**` lambda param carries an extra token /
+            // node beyond the lone NAME — reject.
+            let has_extra = lp.children.iter().any(|c| {
+                matches!(c, ASTNodeOrToken::Token(t) if t.value == "=" || t.value == "*" || t.value == "**")
+                    || matches!(c, ASTNodeOrToken::Node(_))
+            });
+            if has_extra {
+                return Err(self.err_at(
+                    lp,
+                    "unsupported: lambda default / *args / **kwargs (deferred)".to_string(),
+                ));
+            }
+            for child in &lp.children {
+                if let ASTNodeOrToken::Token(t) = child {
+                    if matches!(t.type_, lexer::token::TokenType::Name) && t.type_name.is_none() {
+                        names.push(t.value.clone());
+                    }
+                }
+            }
+        }
+        Ok(names)
+    }
+
+    /// The shared back-end for `def` and (analogously) a lambda's body:
+    /// given a function `name`, its `params`, and a `suite`, compute the
+    /// captures (against `enclosing`), lower the suite in a fresh
+    /// context, append the [`Function`] to the table, and return the
+    /// [`Expr::MakeClosure`] for the definition site.
+    fn lower_callable(
+        &mut self,
+        name: &str,
+        params: &[String],
+        suite: &GrammarASTNode,
+        enclosing: &mut FunctionCtx,
+        depth: usize,
+        span: Span,
+    ) -> Result<Expr, PythonLowerError> {
+        // ── Free-variable analysis over the suite. ──
+        // Names bound *within* the body — the params plus every name the
+        // body assigns / `for`-binds — are body-local, not captures.
+        let mut bound: HashSet<String> = params.iter().cloned().collect();
+        self.collect_suite_bound_names(suite, &mut bound);
+        let mut free = Vec::new();
+        let mut seen = HashSet::new();
+        self.collect_free_names(suite, &bound, &mut free, &mut seen);
+
+        let (captures, capture_values) = self.resolve_captures(&free, enclosing, &span)?;
+
+        // ── Lower the body in the function's own context. ──
+        let mut inner = FunctionCtx::new(
+            params.iter().cloned().collect(),
+            captures.iter().cloned().collect(),
+        );
+        let body = self.lower_function_suite(suite, &mut inner, depth + 1)?;
+
+        self.push_function(name, params, &captures, body, span.clone());
+
+        Ok(self.make_closure(name.to_string(), captures, capture_values, span))
+    }
+
+    /// Build a [`Function`] and append it to the table; also record its
+    /// top-level call edges for mutual-recursion detection.
+    fn push_function(
+        &mut self,
+        name: &str,
+        params: &[String],
+        captures: &[String],
+        body: Block,
+        span: Span,
+    ) {
+        // Any param with no annotation → DynamicTyping (Python has no
+        // parameter type annotations in our subset).
+        if !params.is_empty() {
+            self.observed.add(Feature::DynamicTyping);
+        }
+        // A function that carries captures is a closure body — the
+        // validator declares `Closures` for it, so we must too.
+        if !captures.is_empty() {
+            self.observed.add(Feature::Closures);
+            // Record the capture list so a *bare reference* to this
+            // function name re-threads the captures (a nested closure
+            // returned/passed by name).
+            self.fn_captures
+                .insert(name.to_string(), captures.to_vec());
+        }
+        let f = Function {
+            name: name.to_string(),
+            params: params
+                .iter()
+                .map(|p| Param {
+                    name: p.clone(),
+                    sir_type: None,
+                    kind: ParamKind::Required,
+                    span: span.clone(),
+                })
+                .collect(),
+            return_type: None,
+            captures: captures
+                .iter()
+                .map(|n| Capture {
+                    name: n.clone(),
+                    sir_type: None,
+                })
+                .collect(),
+            body,
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span,
+        };
+        // Record DirectCall edges out of this function (top-level call
+        // graph) for mutual-recursion detection.
+        let mut callees = HashSet::new();
+        collect_direct_callees(&f.body, &mut callees);
+        self.call_graph.push((name.to_string(), callees));
+        self.functions.push(f);
+    }
+
+    /// Build the `MakeClosure` expression for a definition site, zipping
+    /// capture names with their (enclosing-scope) values.
     ///
-    /// This variant introduces its own scope mark/rewind so names bound
-    /// inside the suite do not leak to the enclosing scope (matching the
-    /// validator's `check_block`).
-    fn lower_suite(&mut self, suite: &GrammarASTNode, depth: usize) -> Result<Block, PythonLowerError> {
-        let mark = self.scope_mark();
-        let block = self.lower_suite_no_mark(suite, depth)?;
-        self.scope_rewind(mark);
+    /// This does **not** itself declare [`Feature::Closures`]: a
+    /// top-level `def`'s `MakeClosure` is *discarded* (it never lands in a
+    /// body), so the feature is declared by the *retaining* caller (a
+    /// nested `def` / `lambda` / bare function-name reference) and by
+    /// [`Self::push_function`] for any function that actually carries
+    /// captures — mirroring exactly what the validator observes.
+    fn make_closure(
+        &mut self,
+        fn_name: String,
+        captures: Vec<String>,
+        capture_values: Vec<Expr>,
+        span: Span,
+    ) -> Expr {
+        Expr::MakeClosure {
+            fn_name,
+            captures: captures
+                .into_iter()
+                .zip(capture_values)
+                .map(|(name, value)| CaptureValue { name, value })
+                .collect(),
+            span,
+        }
+    }
+
+    /// Resolve the free names of a closure body against the `enclosing`
+    /// context, partitioning them into *captures* (names that are an
+    /// enclosing local/param/capture — these must be threaded through the
+    /// closure handle) and non-captures (globals / top-level functions /
+    /// builtins, reachable directly from the synthesised body).  Returns
+    /// `(capture_names, capture_value_exprs)` in deterministic
+    /// (alphabetical) order.
+    fn resolve_captures(
+        &mut self,
+        free: &[String],
+        enclosing: &mut FunctionCtx,
+        span: &Span,
+    ) -> Result<(Vec<String>, Vec<Expr>), PythonLowerError> {
+        let mut names: Vec<String> = free
+            .iter()
+            .filter(|n| enclosing.is_enclosing_value(n))
+            .cloned()
+            .collect();
+        names.sort();
+        names.dedup();
+
+        let mut values = Vec::with_capacity(names.len());
+        for n in &names {
+            // The capture *value* is the enclosing reference, resolved in
+            // the enclosing context.
+            values.push(self.resolve_var_in(enclosing, n, span.clone())?);
+        }
+        Ok((names, values))
+    }
+
+    fn fresh_lambda_name(&mut self) -> String {
+        let name = format!("__lambda_{}", self.lambda_counter);
+        self.lambda_counter += 1;
+        self.function_names.insert(name.clone());
+        name
+    }
+
+    /// Collect every name *bound* (assigned) inside a suite into `bound`,
+    /// so the free-variable scan treats body-local assignments as bound
+    /// rather than as captures.  Bare `x = …` targets are collected;
+    /// nested-`def` names too (they shadow).
+    fn collect_suite_bound_names(&self, suite: &GrammarASTNode, bound: &mut HashSet<String>) {
+        for child in &suite.children {
+            if let ASTNodeOrToken::Node(stmt) = child {
+                self.collect_stmt_bound_names(stmt, bound);
+            }
+        }
+    }
+
+    fn collect_stmt_bound_names(&self, stmt: &GrammarASTNode, bound: &mut HashSet<String>) {
+        // assignment target?
+        if let Some(def) = self.as_def_stmt(stmt) {
+            if let Ok(n) = self.def_name(def) {
+                bound.insert(n);
+            }
+            return;
+        }
+        // `for x in …:` binds `x`; descend into suites of compounds.
+        for n in self.descendant_assign_targets(stmt) {
+            bound.insert(n);
+        }
+    }
+
+    /// Collect assignment targets and `for`-loop variables anywhere
+    /// within `stmt` (descending suites), for body-local bound-name
+    /// analysis.  Best-effort and conservative — over-binding only ever
+    /// *reduces* captures, and a missing capture would surface as a
+    /// validator error, so a name we fail to collect here cannot silently
+    /// corrupt output.
+    fn descendant_assign_targets(&self, stmt: &GrammarASTNode) -> Vec<String> {
+        let mut out = Vec::new();
+        self.walk_for_targets(stmt, &mut out);
+        out
+    }
+
+    fn walk_for_targets(&self, node: &GrammarASTNode, out: &mut Vec<String>) {
+        match node.rule_name.as_str() {
+            "assign_stmt" => {
+                // First expression_list is the LHS; if there's an
+                // assign_suffix it's a real assignment target.
+                let has_suffix = child_nodes(node)
+                    .iter()
+                    .any(|n| n.rule_name == "assign_suffix");
+                if has_suffix {
+                    if let Some(list) = self.first_child_named(node, "expression_list") {
+                        if let Ok(Some(name)) = self
+                            .single_expr(list)
+                            .and_then(|e| self.target_name(e))
+                        {
+                            out.push(name);
+                        }
+                    }
+                }
+            }
+            "for_stmt" => {
+                if let Some(tl) = self.first_child_named(node, "target_list") {
+                    for t in child_nodes(tl) {
+                        if let Ok(Some(name)) = self.target_name(t) {
+                            out.push(name);
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+        for child in &node.children {
+            if let ASTNodeOrToken::Node(n) = child {
+                self.walk_for_targets(n, out);
+            }
+        }
+    }
+
+    /// Collect free `Name` references in a CST subtree: every bare `Name`
+    /// token that is *not* in `bound`, appended to `free` in first-seen
+    /// order (`seen` deduplicates).  A `Name` that immediately precedes a
+    /// call `suffix` is still collected (a called name can be a captured
+    /// closure).  Nested `lambda`/`def` bodies bind their own params, so
+    /// we extend `bound` when descending into them — but their *free*
+    /// names that escape to *this* scope still surface (capture chaining
+    /// at one level: an inner lambda referencing an outer-outer local is a
+    /// documented v0 cut-line, but a single level works).
+    fn collect_free_names(
+        &self,
+        node: &GrammarASTNode,
+        bound: &HashSet<String>,
+        free: &mut Vec<String>,
+        seen: &mut HashSet<String>,
+    ) {
+        // A nested lambda binds its params; descend with them added.
+        if node.rule_name == "lambda_expr" {
+            let mut inner = bound.clone();
+            if let Ok(ps) = self.lambda_params(node) {
+                for p in ps {
+                    inner.insert(p);
+                }
+            }
+            if let Some(body) = self.first_child_named(node, "expression") {
+                self.collect_free_names(body, &inner, free, seen);
+            }
+            return;
+        }
+        // A nested def binds its name + params; descend into its suite
+        // with those added.
+        if node.rule_name == "def_stmt" {
+            let mut inner = bound.clone();
+            if let Ok(n) = self.def_name(node) {
+                inner.insert(n);
+            }
+            if let Ok(ps) = self.def_params(node) {
+                for p in ps {
+                    inner.insert(p);
+                }
+            }
+            if let Some(suite) = self.first_child_named(node, "suite") {
+                self.collect_suite_bound_names(suite, &mut inner);
+                self.collect_free_names(suite, &inner, free, seen);
+            }
+            return;
+        }
+
+        // A bare `Name` token (no type_name) is a reference.
+        if let Some(tok) = node.token() {
+            if matches!(tok.type_, lexer::token::TokenType::Name) && tok.type_name.is_none() {
+                let name = &tok.value;
+                if !bound.contains(name) && seen.insert(name.clone()) {
+                    free.push(name.clone());
+                }
+            }
+            return;
+        }
+
+        for child in &node.children {
+            if let ASTNodeOrToken::Node(n) = child {
+                self.collect_free_names(n, bound, free, seen);
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // suites
+    // -------------------------------------------------------------------
+
+    /// Lower a *function* body `suite` into a [`Block`], intercepting a
+    /// **tail** `return`.  The body's `value` IS the return value, so:
+    ///
+    /// - a final `return expr` → `body.value = expr`;
+    /// - a final `return` (bare) or falling off the end → `value = NilLit`
+    ///   (Python's implicit `None`);
+    /// - a `return` in any *non-final* position → positioned error.
+    fn lower_function_suite(
+        &mut self,
+        suite: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+        depth: usize,
+    ) -> Result<Block, PythonLowerError> {
+        if suite.rule_name != "suite" {
+            return Err(self.err_at(
+                suite,
+                format!("expected `suite`, got `{}`", suite.rule_name),
+            ));
+        }
+        let stmt_nodes: Vec<&GrammarASTNode> = suite
+            .children
+            .iter()
+            .filter_map(|c| match c {
+                ASTNodeOrToken::Node(n) if n.rule_name == "statement" => Some(n),
+                _ => None,
+            })
+            .collect();
+
+        let span = self.span_of(suite);
+        if stmt_nodes.is_empty() {
+            // An empty function body (only `pass`-like) returns nil.
+            return Ok(Block {
+                stmts: vec![],
+                value: Expr::NilLit { span: span.clone() },
+                span,
+            });
+        }
+
+        let mark = Self::scope_mark(ctx);
+
+        // Lower every statement *except the last* with the normal rule —
+        // a `return` here is non-tail and errors out.
+        let mut items: Vec<Lowered> = Vec::new();
+        for stmt in &stmt_nodes[..stmt_nodes.len() - 1] {
+            items.push(self.lower_statement(stmt, ctx, depth)?);
+        }
+
+        // The last statement may be a tail `return`.
+        let last = stmt_nodes[stmt_nodes.len() - 1];
+        if let Some(ret) = self.as_return_stmt(last) {
+            let value = self.lower_return_value(ret, ctx)?;
+            let block = Self::assemble_block(items, &span);
+            Self::scope_rewind(ctx, mark);
+            return Ok(Block {
+                stmts: block.stmts,
+                value,
+                span,
+            });
+        }
+
+        // The last statement may be a tail `if` whose branches end in
+        // `return`s — the canonical `if cond: return a else: return b`
+        // shape.  Each branch is itself in *function-tail* position, so we
+        // lower it as a function suite (its tail `return` becomes the
+        // branch's block value) and fold into an `if`-expression.  This is
+        // how an early-looking `return` inside a *tail* `if` is accepted
+        // (it is not actually early — control reaches the function end).
+        if let Some(if_stmt) = self.as_if_stmt(last) {
+            let value = self.lower_if_tail(if_stmt, ctx, depth)?;
+            let block = Self::assemble_block(items, &span);
+            Self::scope_rewind(ctx, mark);
+            return Ok(Block {
+                stmts: block.stmts,
+                value,
+                span,
+            });
+        }
+
+        // No tail return: the last statement lowers normally (its
+        // trailing-expr value, if any, becomes the body value; else nil).
+        items.push(self.lower_statement(last, ctx, depth)?);
+        let block = Self::assemble_block(items, &span);
+        Self::scope_rewind(ctx, mark);
         Ok(block)
     }
 
-    /// Like [`Self::lower_suite`] but **without** pushing/popping a scope
-    /// mark — the caller manages scope (used by `for`, which must bind the
-    /// loop variable across the body in the *same* scope frame, then rewind
-    /// once afterwards).
+    /// If `stmt` is a `statement → compound_stmt → if_stmt`, return the
+    /// `if_stmt` node.
+    fn as_if_stmt<'a>(&self, stmt: &'a GrammarASTNode) -> Option<&'a GrammarASTNode> {
+        if stmt.rule_name != "statement" {
+            return None;
+        }
+        let compound = child_nodes(stmt)
+            .into_iter()
+            .find(|n| n.rule_name == "compound_stmt")?;
+        child_nodes(compound)
+            .into_iter()
+            .find(|n| n.rule_name == "if_stmt")
+    }
+
+    /// Lower a **tail-position** `if_stmt` into a nested [`Expr::If`],
+    /// lowering each branch suite as a *function suite* so a tail `return`
+    /// inside a branch becomes that branch's block value.  Identical in
+    /// structure to [`Self::lower_if`] except the branch lowerer is
+    /// [`Self::lower_function_suite`] (tail-aware) rather than
+    /// [`Self::lower_suite`].  A missing `else` yields a `NilLit` branch
+    /// (Python's implicit `None` on the untaken path).
+    fn lower_if_tail(
+        &mut self,
+        if_stmt: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+        depth: usize,
+    ) -> Result<Expr, PythonLowerError> {
+        struct Clause<'a> {
+            cond: &'a GrammarASTNode,
+            suite: &'a GrammarASTNode,
+        }
+        let mut clauses: Vec<Clause> = Vec::new();
+        let mut else_suite: Option<&GrammarASTNode> = None;
+        let mut pending_cond: Option<&GrammarASTNode> = None;
+        let mut in_else = false;
+        for child in &if_stmt.children {
+            match child {
+                ASTNodeOrToken::Token(t)
+                    if t.type_ == lexer::token::TokenType::Keyword
+                        && (t.value == "if" || t.value == "elif") =>
+                {
+                    in_else = false;
+                }
+                ASTNodeOrToken::Token(t)
+                    if t.type_ == lexer::token::TokenType::Keyword && t.value == "else" =>
+                {
+                    in_else = true;
+                }
+                ASTNodeOrToken::Node(n) if n.rule_name == "expression" => {
+                    pending_cond = Some(n);
+                }
+                ASTNodeOrToken::Node(n) if n.rule_name == "suite" => {
+                    if in_else {
+                        else_suite = Some(n);
+                    } else {
+                        let cond = pending_cond.take().ok_or_else(|| {
+                            self.err_at(n, "malformed if: clause has no condition".to_string())
+                        })?;
+                        clauses.push(Clause { cond, suite: n });
+                    }
+                }
+                _ => {}
+            }
+        }
+        if clauses.is_empty() {
+            return Err(self.err_at(if_stmt, "malformed if: no clauses".to_string()));
+        }
+
+        let if_span = self.span_of(if_stmt);
+        let mut else_branch: Block = match else_suite {
+            Some(s) => self.lower_function_suite(s, ctx, depth + 1)?,
+            None => empty_block(if_span.clone()),
+        };
+        for clause in clauses.into_iter().rev() {
+            let cond = self.lower_expr(clause.cond, ctx)?;
+            let then_branch = self.lower_function_suite(clause.suite, ctx, depth + 1)?;
+            let span = cond.span().clone();
+            let folded = Expr::If {
+                cond: Box::new(cond),
+                then_branch: Box::new(then_branch),
+                else_branch: Box::new(else_branch),
+                span,
+            };
+            else_branch = value_block(folded);
+        }
+        match else_branch.value {
+            Expr::If { .. } => Ok(else_branch.value),
+            other => Ok(other),
+        }
+    }
+
+    /// If `stmt` is a `statement → simple_stmt → small_stmt → return_stmt`,
+    /// return the `return_stmt` node.
+    fn as_return_stmt<'a>(&self, stmt: &'a GrammarASTNode) -> Option<&'a GrammarASTNode> {
+        if stmt.rule_name != "statement" {
+            return None;
+        }
+        let simple = child_nodes(stmt)
+            .into_iter()
+            .find(|n| n.rule_name == "simple_stmt")?;
+        let small = child_nodes(simple)
+            .into_iter()
+            .find(|n| n.rule_name == "small_stmt")?;
+        child_nodes(small)
+            .into_iter()
+            .find(|n| n.rule_name == "return_stmt")
+    }
+
+    /// Lower a tail `return_stmt`'s value: `return expr` → `expr`; a bare
+    /// `return` → `NilLit` (Python's implicit `None`).
+    fn lower_return_value(
+        &mut self,
+        ret: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+    ) -> Result<Expr, PythonLowerError> {
+        match self.first_child_named(ret, "expression_list") {
+            Some(list) => {
+                let expr = self.single_expr(list)?;
+                self.lower_expr(expr, ctx)
+            }
+            None => Ok(Expr::NilLit {
+                span: self.span_of(ret),
+            }),
+        }
+    }
+
+    /// Lower a control-flow `suite` (loop / branch body) into a [`Block`]
+    /// with its own scope mark/rewind.  A `return` inside such a suite is
+    /// always non-tail (it is nested in control flow, not the function
+    /// tail) and is rejected by [`Self::lower_statement`].
+    fn lower_suite(
+        &mut self,
+        suite: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+        depth: usize,
+    ) -> Result<Block, PythonLowerError> {
+        let mark = Self::scope_mark(ctx);
+        let block = self.lower_suite_no_mark(suite, ctx, depth)?;
+        Self::scope_rewind(ctx, mark);
+        Ok(block)
+    }
+
+    /// Like [`Self::lower_suite`] but without pushing/popping a scope mark
+    /// (the caller manages scope, e.g. `for` binding its loop variable).
     fn lower_suite_no_mark(
         &mut self,
         suite: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
         depth: usize,
     ) -> Result<Block, PythonLowerError> {
         if suite.rule_name != "suite" {
@@ -945,33 +1763,12 @@ impl Lowerer {
         for child in &suite.children {
             if let ASTNodeOrToken::Node(stmt) = child {
                 if stmt.rule_name == "statement" {
-                    items.push(self.lower_statement(stmt, depth)?);
+                    items.push(self.lower_statement(stmt, ctx, depth)?);
                 }
             }
-            // Token children (Newline / Indent / Dedent) are ignored.
         }
-
         let span = self.span_of(suite);
-
-        let value = match items.last() {
-            Some(Lowered::Expr(_)) => match items.pop() {
-                Some(Lowered::Expr(e)) => e,
-                _ => unreachable!("just matched Expr"),
-            },
-            _ => Expr::NilLit { span: span.clone() },
-        };
-        let stmts: Vec<Stmt> = items
-            .into_iter()
-            .map(|item| match item {
-                Lowered::Stmt(s) => *s,
-                Lowered::Expr(expr) => {
-                    let s = expr.span().clone();
-                    Stmt::ExprStmt { expr, span: s }
-                }
-            })
-            .collect();
-
-        Ok(Block { stmts, value, span })
+        Ok(Self::assemble_block(items, &span))
     }
 
     /// First *node* child of `node` whose `rule_name == name`.
@@ -987,30 +1784,34 @@ impl Lowerer {
     // expression → Expr
     // -------------------------------------------------------------------
 
-    /// Lower an expression node, recognising operators and peeling the
-    /// precedence-rule onion down to literals / variable references.
-    fn lower_expr(&mut self, node: &GrammarASTNode) -> Result<Expr, PythonLowerError> {
-        self.lower_expr_d(node, 0)
+    /// Lower an expression node in `ctx`.
+    fn lower_expr(
+        &mut self,
+        node: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+    ) -> Result<Expr, PythonLowerError> {
+        self.lower_expr_in(node, ctx, 0)
     }
 
-    /// Depth-tracked core of [`Self::lower_expr`].
-    ///
-    /// Python's precedence grammar wraps every expression in a deep
-    /// single-child chain, and operators / grouping / source nesting all
-    /// add depth.  Every recursive call below increments `depth`, so the
-    /// recursion depth tracks the *input* nesting depth.  `compile` is a
-    /// public entry point taking an arbitrary CST, so we bound this
-    /// ourselves: past `MAX_EXPR_DEPTH` we return a positioned error
-    /// instead of recursing further (a Rust stack overflow cannot be
-    /// caught, so this is the only way to keep `compile` total).
-    ///
-    /// The recursion is structural — each call descends into a strictly
-    /// smaller sub-tree of the (finite) CST — so it always terminates; the
-    /// depth cap only guards against the *native stack* on pathologically
-    /// deep input, never against non-termination.
+    /// Lower an expression with an explicit starting depth (used by
+    /// closure-body lowering so the depth guard accounts for the
+    /// enclosing block nesting).
+    fn lower_expr_in(
+        &mut self,
+        node: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+        depth: usize,
+    ) -> Result<Expr, PythonLowerError> {
+        self.lower_expr_d(node, ctx, depth)
+    }
+
+    /// Depth-tracked core of expression lowering.  Bounded by
+    /// [`MAX_EXPR_DEPTH`] so pathologically deep input fails cleanly
+    /// instead of overflowing the native stack.
     fn lower_expr_d(
         &mut self,
         node: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
         depth: usize,
     ) -> Result<Expr, PythonLowerError> {
         if depth > MAX_EXPR_DEPTH {
@@ -1020,77 +1821,159 @@ impl Lowerer {
             ));
         }
 
-        // Operator rules: handle each *branching* precedence level.  Each
-        // returns `Ok(Some(expr))` when it matched the operator shape, or
-        // `Ok(None)` to fall through to the generic peel (the rule was a
-        // single-child wrapper this time).
+        // A `lambda` can appear at any expression position.
+        if node.rule_name == "lambda_expr" {
+            return self.lower_lambda(node, ctx, depth);
+        }
+
         match node.rule_name.as_str() {
             "or_expr" => {
-                if let Some(e) = self.try_logical(node, depth, "or")? {
+                if let Some(e) = self.try_logical(node, ctx, depth, "or")? {
                     return Ok(e);
                 }
             }
             "and_expr" => {
-                if let Some(e) = self.try_logical(node, depth, "and")? {
+                if let Some(e) = self.try_logical(node, ctx, depth, "and")? {
                     return Ok(e);
                 }
             }
             "not_expr" => {
-                if let Some(e) = self.try_not(node, depth)? {
+                if let Some(e) = self.try_not(node, ctx, depth)? {
                     return Ok(e);
                 }
             }
             "comparison" => {
-                if let Some(e) = self.try_comparison(node, depth)? {
+                if let Some(e) = self.try_comparison(node, ctx, depth)? {
                     return Ok(e);
                 }
             }
             "arith" | "term" => {
-                if let Some(e) = self.try_binary_arith(node, depth)? {
+                if let Some(e) = self.try_binary_arith(node, ctx, depth)? {
                     return Ok(e);
                 }
             }
             "factor" => {
-                if let Some(e) = self.try_unary_factor(node, depth)? {
+                if let Some(e) = self.try_unary_factor(node, ctx, depth)? {
+                    return Ok(e);
+                }
+            }
+            "primary" => {
+                // A `primary` with a call `suffix` is a call expression.
+                if let Some(e) = self.try_call(node, ctx, depth)? {
                     return Ok(e);
                 }
             }
             _ => {}
         }
 
-        // A `leaf` node — exactly one child that is a Token.  This is
-        // where every literal and bare name bottoms out.
         if let Some(tok) = node.token() {
-            return self.lower_leaf_token(node, tok);
+            return self.lower_leaf_token(node, tok, ctx);
         }
 
-        // Generic peel: a single Node child → recurse.  Any other shape
-        // (zero children, or >1 node children, or a Token sibling) is a
-        // construct M2 does not handle (call, subscript, attribute, …).
         let kids = child_nodes(node);
         match kids.as_slice() {
-            [only] if node.children.len() == 1 => self.lower_expr_d(only, depth + 1),
+            [only] if node.children.len() == 1 => self.lower_expr_d(only, ctx, depth + 1),
             _ => Err(self.err_at(
                 node,
-                format!("unsupported: {} (deferred to a later milestone)", node.rule_name),
+                format!(
+                    "unsupported: {} (deferred to a later milestone)",
+                    node.rule_name
+                ),
             )),
         }
     }
 
-    /// `or_expr` / `and_expr`: `a (op b)+` where `op` is the keyword
-    /// `or`/`and`.  Lowers to left-nested `LogicalOr`/`LogicalAnd`
-    /// short-circuit nodes (so `a and b and c` is `(a and b) and c`).
-    /// Returns `Ok(None)` when the node is a single-child wrapper (no
-    /// operator present at this level).
+    /// `primary` with a trailing call `suffix` → a call expression.
+    /// Resolves the callee: a known function name → [`Expr::DirectCall`];
+    /// a builtin (`print`/`len`/`range`) → [`Expr::BuiltinCall`]; a
+    /// local/param/captured value → [`Expr::IndirectCall`] through that
+    /// `VarRef`.  Returns `Ok(None)` when the `primary` is not a call
+    /// (no `suffix`) so the generic peel handles it.
+    fn try_call(
+        &mut self,
+        node: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+        depth: usize,
+    ) -> Result<Option<Expr>, PythonLowerError> {
+        let kids = child_nodes(node);
+        let (callee, suffix) = match kids.as_slice() {
+            [callee, suffix] if suffix.rule_name == "suffix" => (*callee, *suffix),
+            _ => return Ok(None),
+        };
+        // Only a *call* suffix `( … )` — not indexing `[ … ]` or
+        // attribute `.x` (deferred).  A call suffix's first token is `(`.
+        let is_call = matches!(
+            suffix.children.first(),
+            Some(ASTNodeOrToken::Token(t)) if t.value == "("
+        );
+        if !is_call {
+            return Err(self.err_at(
+                suffix,
+                "unsupported: indexing / attribute access (deferred to a later milestone)"
+                    .to_string(),
+            ));
+        }
+
+        let span = self.span_of(node);
+
+        // Lower the arguments first.
+        let arg_nodes = self.call_arguments(suffix);
+        let mut args = Vec::with_capacity(arg_nodes.len());
+        for a in &arg_nodes {
+            let e = self.single_arg_expr(a)?;
+            args.push(self.lower_expr_d(e, ctx, depth + 1)?);
+        }
+
+        // The callee must be a bare name (no method calls in v0).
+        let name = match self.target_name(callee)? {
+            Some(n) => n,
+            None => {
+                return Err(self.err_at(
+                    callee,
+                    "unsupported: call of a non-name expression (deferred)".to_string(),
+                ))
+            }
+        };
+
+        // Builtin?
+        if BUILTIN_CALLS.contains(&name.as_str()) {
+            return Ok(Some(Expr::BuiltinCall {
+                name,
+                args,
+                effects: EffectSet::PURE,
+                span,
+            }));
+        }
+        // Known function (top-level or nested-lifted) → DirectCall, but
+        // only if it is *not* shadowed by an enclosing value of the same
+        // name (a local/param/capture closure handle wins).
+        if self.function_names.contains(&name) && !ctx.is_enclosing_value(&name) {
+            return Ok(Some(Expr::DirectCall {
+                fn_name: name,
+                args,
+                effects: EffectSet::PURE,
+                span,
+            }));
+        }
+        // Otherwise the name must be a value (closure handle) — resolve
+        // it and emit an IndirectCall.
+        let target = self.resolve_var_in(ctx, &name, span.clone())?;
+        self.observed.add(Feature::Closures);
+        Ok(Some(Expr::IndirectCall {
+            target: Box::new(target),
+            args,
+            effects: EffectSet::PURE,
+            span,
+        }))
+    }
+
     fn try_logical(
         &mut self,
         node: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
         depth: usize,
         keyword: &str,
     ) -> Result<Option<Expr>, PythonLowerError> {
-        // Operands are the node children; operators are the `keyword`
-        // tokens between them.  A bare wrapper has one node child and no
-        // operator token → fall through.
         let operands = child_nodes(node);
         let has_kw = node.children.iter().any(|c| {
             matches!(c, ASTNodeOrToken::Token(t)
@@ -1100,15 +1983,12 @@ impl Lowerer {
             return Ok(None);
         }
         if operands.len() < 2 {
-            // A keyword token but fewer than two operands is malformed.
             return Err(self.err_at(node, format!("malformed `{keyword}` expression")));
         }
 
-        // Fold left: ((o0 op o1) op o2) …  Each operand is one precedence
-        // level lower, so descend with depth+1.
-        let mut acc = self.lower_expr_d(operands[0], depth + 1)?;
+        let mut acc = self.lower_expr_d(operands[0], ctx, depth + 1)?;
         for operand in &operands[1..] {
-            let rhs = self.lower_expr_d(operand, depth + 1)?;
+            let rhs = self.lower_expr_d(operand, ctx, depth + 1)?;
             let span = acc.span().clone();
             acc = if keyword == "and" {
                 Expr::LogicalAnd {
@@ -1128,12 +2008,10 @@ impl Lowerer {
         Ok(Some(acc))
     }
 
-    /// `not_expr`: `not <not_expr>` → `BuiltinCall("not", [operand])`.
-    /// Returns `Ok(None)` when there is no leading `not` keyword (the rule
-    /// was a single-child wrapper around a `comparison`).
     fn try_not(
         &mut self,
         node: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
         depth: usize,
     ) -> Result<Option<Expr>, PythonLowerError> {
         let leads_with_not = matches!(
@@ -1144,11 +2022,10 @@ impl Lowerer {
         if !leads_with_not {
             return Ok(None);
         }
-        // The operand is the single node child after the keyword.
         let operand_node = child_nodes(node).into_iter().next().ok_or_else(|| {
             self.err_at(node, "malformed `not` expression (missing operand)".to_string())
         })?;
-        let operand = self.lower_expr_d(operand_node, depth + 1)?;
+        let operand = self.lower_expr_d(operand_node, ctx, depth + 1)?;
         let span = self.span_of(node);
         Ok(Some(Expr::BuiltinCall {
             name: "not".to_string(),
@@ -1158,17 +2035,12 @@ impl Lowerer {
         }))
     }
 
-    /// `comparison`: `a comp_op b (comp_op c)…` → left-nested
-    /// `BuiltinCall(op, [lhs, rhs])`.  Each `comp_op` wraps the operator
-    /// token; we map `==`→`"="`, `!=`→`"!="`, and the ordering ops to
-    /// their literal spelling.  Returns `Ok(None)` for a bare wrapper.
     fn try_comparison(
         &mut self,
         node: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
         depth: usize,
     ) -> Result<Option<Expr>, PythonLowerError> {
-        // children: operand, comp_op, operand, comp_op, operand, …
-        // We need at least one `comp_op` to be an actual comparison.
         let has_comp_op = node
             .children
             .iter()
@@ -1177,7 +2049,6 @@ impl Lowerer {
             return Ok(None);
         }
 
-        // Walk the children left to right, alternating operand / comp_op.
         let mut acc: Option<Expr> = None;
         let mut pending_op: Option<String> = None;
         for child in &node.children {
@@ -1186,11 +2057,9 @@ impl Lowerer {
                     pending_op = Some(self.comp_op_name(n)?);
                 }
                 ASTNodeOrToken::Node(n) => {
-                    let operand = self.lower_expr_d(n, depth + 1)?;
+                    let operand = self.lower_expr_d(n, ctx, depth + 1)?;
                     acc = Some(match (acc.take(), pending_op.take()) {
-                        // First operand: nothing to combine yet.
                         (None, _) => operand,
-                        // lhs op operand → builtin compare.
                         (Some(lhs), Some(op)) => {
                             let span = lhs.span().clone();
                             Expr::BuiltinCall {
@@ -1200,16 +2069,12 @@ impl Lowerer {
                                 span,
                             }
                         }
-                        // operand with no preceding comp_op — malformed.
                         (Some(_), None) => {
                             return Err(self.err_at(node, "malformed comparison".to_string()))
                         }
                     });
                 }
-                ASTNodeOrToken::Token(_) => {
-                    // No bare operator tokens directly under `comparison`
-                    // (they live inside `comp_op`); ignore defensively.
-                }
+                ASTNodeOrToken::Token(_) => {}
             }
         }
         match acc {
@@ -1218,17 +2083,13 @@ impl Lowerer {
         }
     }
 
-    /// Map a `comp_op` node's inner operator token to its SIR builtin
-    /// name.  `==`→`"="` and `!=`→`"!="`; the ordering operators keep
-    /// their literal spelling.
     fn comp_op_name(&self, comp_op: &GrammarASTNode) -> Result<String, PythonLowerError> {
         let tok = comp_op.children.iter().find_map(|c| match c {
             ASTNodeOrToken::Token(t) => Some(t),
             ASTNodeOrToken::Node(_) => None,
         });
-        let tok = tok.ok_or_else(|| {
-            self.err_at(comp_op, "comparison operator missing token".to_string())
-        })?;
+        let tok = tok
+            .ok_or_else(|| self.err_at(comp_op, "comparison operator missing token".to_string()))?;
         let name = match tok.value.as_str() {
             "==" => "=",
             "!=" => "!=",
@@ -1246,16 +2107,12 @@ impl Lowerer {
         Ok(name.to_string())
     }
 
-    /// `arith` (`+`/`-`) and `term` (`*`/`/`/`%`): a left-associative run
-    /// of binary operators with operator tokens between operands.  Lowers
-    /// to left-nested `BuiltinCall(op, [lhs, rhs])`.  Returns `Ok(None)`
-    /// for a bare single-operand wrapper.
     fn try_binary_arith(
         &mut self,
         node: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
         depth: usize,
     ) -> Result<Option<Expr>, PythonLowerError> {
-        // Need at least one operator token to be a real binary op.
         let has_op = node
             .children
             .iter()
@@ -1272,7 +2129,7 @@ impl Lowerer {
                     pending_op = Some(t.value.clone());
                 }
                 ASTNodeOrToken::Node(n) => {
-                    let operand = self.lower_expr_d(n, depth + 1)?;
+                    let operand = self.lower_expr_d(n, ctx, depth + 1)?;
                     acc = Some(match (acc.take(), pending_op.take()) {
                         (None, _) => operand,
                         (Some(lhs), Some(op)) => {
@@ -1285,13 +2142,13 @@ impl Lowerer {
                             }
                         }
                         (Some(_), None) => {
-                            return Err(self.err_at(node, "malformed arithmetic expression".to_string()))
+                            return Err(
+                                self.err_at(node, "malformed arithmetic expression".to_string())
+                            )
                         }
                     });
                 }
-                ASTNodeOrToken::Token(_) => {
-                    // A non-operator token under arith/term is unexpected.
-                }
+                ASTNodeOrToken::Token(_) => {}
             }
         }
         match acc {
@@ -1300,22 +2157,12 @@ impl Lowerer {
         }
     }
 
-    /// `factor`: `(- | + | ~) <factor>`.  We handle unary `-` and `+`:
-    ///
-    /// - `-<numeric literal>` constant-folds to a negative literal
-    ///   (carried from M1, because the spec lists `-7 ⇒ IntLit`).
-    /// - `-<non-literal>` → `BuiltinCall("neg", [operand])`.
-    /// - `+<operand>` is the identity — we drop it and return the operand
-    ///   unchanged (no SIR node for unary plus).
-    /// - `~<operand>` (bitwise NOT) is deferred.
-    ///
-    /// Returns `Ok(None)` for a bare single-child `factor` (no unary op).
     fn try_unary_factor(
         &mut self,
         node: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
         depth: usize,
     ) -> Result<Option<Expr>, PythonLowerError> {
-        // Unary shape is exactly `[Token(op), Node(inner)]`.
         if node.children.len() != 2 {
             return Ok(None);
         }
@@ -1329,10 +2176,9 @@ impl Lowerer {
             ASTNodeOrToken::Token(_) => return Ok(None),
         };
 
-        let operand = self.lower_expr_d(inner, depth + 1)?;
+        let operand = self.lower_expr_d(inner, ctx, depth + 1)?;
         match op {
             "-" => match operand {
-                // Constant-fold negation of numeric literals.
                 Expr::IntLit { value, span } => Ok(Some(Expr::IntLit {
                     value: value.wrapping_neg(),
                     span,
@@ -1341,7 +2187,6 @@ impl Lowerer {
                     value: -value,
                     span,
                 })),
-                // `-x` on a non-literal → builtin negate.
                 other => {
                     let span = other.span().clone();
                     Ok(Some(Expr::BuiltinCall {
@@ -1352,9 +2197,7 @@ impl Lowerer {
                     }))
                 }
             },
-            // Unary plus is the identity in SIR — return the operand as-is.
             "+" => Ok(Some(operand)),
-            // `~` (bitwise NOT) and any other unary token are deferred.
             other => Err(self.err_at(
                 node,
                 format!("unsupported unary operator `{other}` (deferred)"),
@@ -1363,22 +2206,12 @@ impl Lowerer {
     }
 
     /// Turn a leaf token into the matching SIR expression — a literal, or
-    /// (M2) a variable reference for a bare `Name`.
-    ///
-    /// Token classification (learned by inspecting real parses):
-    ///
-    /// | token                                   | SIR node               |
-    /// |-----------------------------------------|------------------------|
-    /// | `type_name == "INT"`                    | `IntLit`               |
-    /// | `type_name == "FLOAT"`                  | `FloatLit` (+Floats)   |
-    /// | Keyword `True` / `False`                | `BoolLit`              |
-    /// | Keyword `None`                          | `NilLit`               |
-    /// | String token                            | `StrLit` (+Strings)    |
-    /// | `Name` (no `type_name`)                 | `VarRef` (scope rslv)  |
+    /// a variable reference for a bare `Name`.
     fn lower_leaf_token(
         &mut self,
         node: &GrammarASTNode,
         tok: &lexer::token::Token,
+        ctx: &mut FunctionCtx,
     ) -> Result<Expr, PythonLowerError> {
         let span = self.span_of(node);
         let type_name = tok.type_name.as_deref();
@@ -1406,58 +2239,129 @@ impl Lowerer {
             (_, lexer::token::TokenType::Keyword, "None") => Ok(Expr::NilLit { span }),
             (_, lexer::token::TokenType::String, text) => {
                 self.observed.add(Feature::Strings);
-                // The lexer already resolved escapes (`"\n"` → newline),
-                // so the token value is the final string content.
                 Ok(Expr::StrLit {
                     value: text.to_string(),
                     span,
                 })
             }
-            // A bare `Name` token is a variable reference.  Resolve its
-            // scope against the names bound so far in this scope.
-            (None, lexer::token::TokenType::Name, name) => self.resolve_var(node, name, span),
-            // Anything else is genuinely unsupported.
+            (None, lexer::token::TokenType::Name, name) => self.resolve_var(node, name, ctx, span),
             _ => Err(self.err_at(
                 node,
-                format!("unsupported token `{}` (deferred to a later milestone)", tok.value),
+                format!(
+                    "unsupported token `{}` (deferred to a later milestone)",
+                    tok.value
+                ),
             )),
         }
     }
 
-    /// Resolve a bare name reference to a scoped `VarRef`.
+    /// Resolve a bare name reference (the node-anchored variant used by
+    /// leaf-token lowering, which can report a precise error position).
     ///
-    /// Scope model (per SIR17): the binding forms so far are a top-level
-    /// (or block-level) assignment and a `for` loop variable, both of
-    /// which become *locals*.  A name bound earlier in the current scope
-    /// chain resolves as `Scope::Local`; an unbound name is an error
-    /// (Python raises `NameError` at runtime, and we have no builtins
-    /// wired up yet — `print`/`len` arrive with calls in M4).
+    /// A bare reference to a **known function name** is a *closure value*:
+    /// referencing a function by name (without calling it) constructs a
+    /// closure handle.  A top-level function with no captures lowers to a
+    /// zero-capture `MakeClosure`; a nested function likewise (its
+    /// captures were computed where it was *defined*, threaded there — a
+    /// bare reference to a nested function name re-constructs the closure
+    /// from the *currently visible* values of those captures).
     fn resolve_var(
         &mut self,
         node: &GrammarASTNode,
         name: &str,
+        ctx: &mut FunctionCtx,
         span: Span,
     ) -> Result<Expr, PythonLowerError> {
-        if self.is_declared(name) {
-            Ok(Expr::VarRef {
+        // Local / param / capture (a value) wins over a same-named fn.
+        if ctx.is_enclosing_value(name) {
+            return self.resolve_var_in(ctx, name, span);
+        }
+        // A bare reference to a function name → a closure value.  If the
+        // function carries captures (a nested closure), re-thread them
+        // from the currently visible enclosing values; otherwise it is a
+        // zero-capture closure handle.
+        if self.function_names.contains(name) {
+            self.observed.add(Feature::Closures);
+            let cap_names = self.fn_captures.get(name).cloned().unwrap_or_default();
+            let mut capture_values = Vec::with_capacity(cap_names.len());
+            for cn in &cap_names {
+                capture_values.push(self.resolve_var_in(ctx, cn, span.clone())?);
+            }
+            return Ok(self.make_closure(name.to_string(), cap_names, capture_values, span));
+        }
+        Err(self.err_at(node, format!("unresolved name `{name}`")))
+    }
+
+    /// Resolve a name that is *expected* to be in scope as a value
+    /// (local/param/capture/global/builtin), producing the appropriately
+    /// scoped [`Expr::VarRef`].  Errors if unresolved.
+    fn resolve_var_in(
+        &self,
+        ctx: &FunctionCtx,
+        name: &str,
+        span: Span,
+    ) -> Result<Expr, PythonLowerError> {
+        if ctx.locals.iter().rev().any(|n| n == name) {
+            return Ok(Expr::VarRef {
                 name: name.to_string(),
                 scope: Scope::Local,
                 span,
-            })
-        } else {
-            Err(self.err_at(node, format!("unresolved name `{name}`")))
+            });
         }
+        if ctx.params.contains(name) {
+            return Ok(Expr::VarRef {
+                name: name.to_string(),
+                scope: Scope::Param,
+                span,
+            });
+        }
+        if ctx.captures.contains(name) {
+            return Ok(Expr::VarRef {
+                name: name.to_string(),
+                scope: Scope::Capture,
+                span,
+            });
+        }
+        Err(PythonLowerError {
+            message: format!("unresolved name `{name}`"),
+            line: span.start_line,
+            column: span.start_col,
+        })
+    }
+
+    // -------------------------------------------------------------------
+    // mutual recursion detection
+    // -------------------------------------------------------------------
+
+    /// Is there a cycle of length ≥ 2 in the top-level call graph (two
+    /// functions that transitively call each other)?  A self-recursive
+    /// function (a 1-cycle) is *not* mutual recursion.
+    fn has_mutual_recursion(&self) -> bool {
+        use std::collections::HashMap;
+        let graph: HashMap<&str, &HashSet<String>> = self
+            .call_graph
+            .iter()
+            .map(|(n, callees)| (n.as_str(), callees))
+            .collect();
+        // For each function f, see if any callee g (g != f) can reach
+        // back to f — that is a mutual-recursion cycle.
+        for (f, callees) in &self.call_graph {
+            for g in callees.iter() {
+                if g == f {
+                    continue; // self-recursion is not mutual
+                }
+                if reaches(&graph, g, f) {
+                    return true;
+                }
+            }
+        }
+        false
     }
 
     // -------------------------------------------------------------------
     // helpers
     // -------------------------------------------------------------------
 
-    /// Assert `node.rule_name == expected` and that it has exactly one
-    /// child *node* whose rule name is in `allowed`; return that child.
-    /// Used to walk the fixed `statement → … → assign_stmt` spine while
-    /// emitting precise errors when an unexpected (compound-statement /
-    /// `global`/`nonlocal`) shape shows up.
     fn expect_single_named<'a>(
         &self,
         node: &'a GrammarASTNode,
@@ -1475,7 +2379,10 @@ impl Lowerer {
             [child] if allowed.contains(&child.rule_name.as_str()) => Ok(child),
             [child] => Err(self.err_at(
                 child,
-                format!("unsupported: {} (deferred to a later milestone)", child.rule_name),
+                format!(
+                    "unsupported: {} (deferred to a later milestone)",
+                    child.rule_name
+                ),
             )),
             _ => Err(self.err_at(
                 node,
@@ -1484,9 +2391,6 @@ impl Lowerer {
         }
     }
 
-    /// Find the single child node of `node` whose `rule_name == kind`.
-    /// Errors if absent.  (`assign_stmt` and `assign_suffix` both carry an
-    /// `expression_list` child this way.)
     fn expect_single_kind<'a>(
         &self,
         node: &'a GrammarASTNode,
@@ -1498,9 +2402,6 @@ impl Lowerer {
             .ok_or_else(|| self.err_at(node, format!("expected a `{kind}` child")))
     }
 
-    /// An `expression_list` of exactly one element yields that single
-    /// `expression`; multi-element lists (tuples / multi-target) are
-    /// deferred.
     fn single_expr<'a>(
         &self,
         list: &'a GrammarASTNode,
@@ -1515,8 +2416,6 @@ impl Lowerer {
         }
     }
 
-    /// Build a `Span` from a node's start position, defaulting to 1:1
-    /// when the parser did not record one.
     fn span_of(&self, node: &GrammarASTNode) -> Span {
         Span::point(
             FILE,
@@ -1525,7 +2424,6 @@ impl Lowerer {
         )
     }
 
-    /// Build a `PythonLowerError` anchored at `node`'s start position.
     fn err_at(&self, node: &GrammarASTNode, message: String) -> PythonLowerError {
         PythonLowerError {
             message,
@@ -1556,10 +2454,7 @@ fn is_arith_op(value: &str) -> bool {
     matches!(value, "+" | "-" | "*" | "/" | "%")
 }
 
-/// An empty `Block` whose value is `NilLit` — used for an absent `else`
-/// branch (SIR's `If` always carries both branches; a missing `else`
-/// yields nil on the false path, matching Python's "the suite just doesn't
-/// run").
+/// An empty `Block` whose value is `NilLit`.
 fn empty_block(span: Span) -> Block {
     Block {
         stmts: vec![],
@@ -1568,8 +2463,7 @@ fn empty_block(span: Span) -> Block {
     }
 }
 
-/// A `Block` with no statements whose value is `expr` — used to nest one
-/// `If` as the `else_branch` of another (an `elif` chain).
+/// A `Block` with no statements whose value is `expr`.
 fn value_block(expr: Expr) -> Block {
     let span = expr.span().clone();
     Block {
@@ -1577,4 +2471,180 @@ fn value_block(expr: Expr) -> Block {
         value: expr,
         span,
     }
+}
+
+/// Walk a lowered `Block`, collecting the names of every `DirectCall`
+/// target into `out` — the call edges out of one function, for
+/// mutual-recursion detection.
+fn collect_direct_callees(block: &Block, out: &mut HashSet<String>) {
+    for s in &block.stmts {
+        collect_callees_stmt(s, out);
+    }
+    collect_callees_expr(&block.value, out);
+}
+
+fn collect_callees_stmt(stmt: &Stmt, out: &mut HashSet<String>) {
+    match stmt {
+        Stmt::LetBinding { value, .. }
+        | Stmt::LetStarBinding { value, .. }
+        | Stmt::ExprStmt { expr: value, .. }
+        | Stmt::Assign { value, .. } => collect_callees_expr(value, out),
+        Stmt::While { cond, body, .. } => {
+            collect_callees_expr(cond, out);
+            collect_direct_callees(body, out);
+        }
+        Stmt::ForRange {
+            start, stop, step, body, ..
+        } => {
+            collect_callees_expr(start, out);
+            collect_callees_expr(stop, out);
+            collect_callees_expr(step, out);
+            collect_direct_callees(body, out);
+        }
+        Stmt::ForEach { iter, body, .. } => {
+            collect_callees_expr(iter, out);
+            collect_direct_callees(body, out);
+        }
+        Stmt::SeqSet { seq, index, value, .. } => {
+            collect_callees_expr(seq, out);
+            collect_callees_expr(index, out);
+            collect_callees_expr(value, out);
+        }
+        Stmt::MapSet { map, key, value, .. } => {
+            collect_callees_expr(map, out);
+            collect_callees_expr(key, out);
+            collect_callees_expr(value, out);
+        }
+        Stmt::ClassDef { body, .. }
+        | Stmt::ModuleDef { body, .. }
+        | Stmt::SingletonClassDef { body, .. } => {
+            for s in body {
+                collect_callees_stmt(s, out);
+            }
+        }
+        Stmt::TryCatch {
+            body,
+            rescues,
+            ensure_body,
+            ..
+        } => {
+            for s in body {
+                collect_callees_stmt(s, out);
+            }
+            for r in rescues {
+                for s in &r.body {
+                    collect_callees_stmt(s, out);
+                }
+            }
+            if let Some(eb) = ensure_body {
+                for s in eb {
+                    collect_callees_stmt(s, out);
+                }
+            }
+        }
+    }
+}
+
+fn collect_callees_expr(expr: &Expr, out: &mut HashSet<String>) {
+    match expr {
+        Expr::DirectCall { fn_name, args, .. } => {
+            out.insert(fn_name.clone());
+            for a in args {
+                collect_callees_expr(a, out);
+            }
+        }
+        Expr::IndirectCall { target, args, .. } => {
+            collect_callees_expr(target, out);
+            for a in args {
+                collect_callees_expr(a, out);
+            }
+        }
+        Expr::BuiltinCall { args, .. } => {
+            for a in args {
+                collect_callees_expr(a, out);
+            }
+        }
+        Expr::MakeClosure { captures, .. } => {
+            for c in captures {
+                collect_callees_expr(&c.value, out);
+            }
+        }
+        Expr::If {
+            cond,
+            then_branch,
+            else_branch,
+            ..
+        } => {
+            collect_callees_expr(cond, out);
+            collect_direct_callees(then_branch, out);
+            collect_direct_callees(else_branch, out);
+        }
+        Expr::Block(b) => collect_direct_callees(b, out),
+        Expr::LogicalAnd { lhs, rhs, .. } | Expr::LogicalOr { lhs, rhs, .. } => {
+            collect_callees_expr(lhs, out);
+            collect_callees_expr(rhs, out);
+        }
+        Expr::SeqLit { items, .. } => {
+            for i in items {
+                collect_callees_expr(i, out);
+            }
+        }
+        Expr::SeqIndex { seq, index, .. } => {
+            collect_callees_expr(seq, out);
+            collect_callees_expr(index, out);
+        }
+        Expr::SeqLen { seq, .. } => collect_callees_expr(seq, out),
+        Expr::MapLit { entries, .. } => {
+            for e in entries {
+                collect_callees_expr(&e.key, out);
+                collect_callees_expr(&e.value, out);
+            }
+        }
+        Expr::MapGet { map, key, .. } => {
+            collect_callees_expr(map, out);
+            collect_callees_expr(key, out);
+        }
+        Expr::StrConcat { parts, .. } => {
+            for p in parts {
+                collect_callees_expr(p, out);
+            }
+        }
+        Expr::Intrinsic { args, .. } => {
+            for a in args {
+                collect_callees_expr(a, out);
+            }
+        }
+        // Atoms and references bind nothing.
+        Expr::IntLit { .. }
+        | Expr::BoolLit { .. }
+        | Expr::NilLit { .. }
+        | Expr::SymLit { .. }
+        | Expr::StrLit { .. }
+        | Expr::FloatLit { .. }
+        | Expr::VarRef { .. } => {}
+    }
+}
+
+/// Can `from` transitively reach `target` in the top-level call graph?
+fn reaches(
+    graph: &std::collections::HashMap<&str, &HashSet<String>>,
+    from: &str,
+    target: &str,
+) -> bool {
+    let mut stack = vec![from.to_string()];
+    let mut visited = HashSet::new();
+    while let Some(cur) = stack.pop() {
+        if cur == target {
+            return true;
+        }
+        if !visited.insert(cur.clone()) {
+            continue;
+        }
+        if let Some(callees) = graph.get(cur.as_str()) {
+            for c in callees.iter() {
+                stack.push(c.clone());
+            }
+        }
+    }
+    false
 }

--- a/code/packages/rust/python-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/python-to-semantic-ir/src/lower.rs
@@ -336,7 +336,7 @@ impl Lowerer {
         // ── Pass 1: collect all function names (top-level + nested). ──
         for child in &file.children {
             if let ASTNodeOrToken::Node(stmt) = child {
-                self.collect_function_names(stmt)?;
+                self.collect_function_names(stmt, 0)?;
             }
         }
 
@@ -435,7 +435,23 @@ impl Lowerer {
     /// same flat table.  `lambda` names are *not* collected here — they
     /// are gensym'd on the fly during lowering (a lambda has no source
     /// name to forward-reference).
-    fn collect_function_names(&mut self, stmt: &GrammarASTNode) -> Result<(), PythonLowerError> {
+    ///
+    /// `depth` bounds the *suite-nesting* recursion: this pass-1 walk runs
+    /// **before** the depth-guarded lowering, so a pathological tower of
+    /// nested `def`s (or compounds) would otherwise overflow the native
+    /// (uncatchable) stack here.  Past [`MAX_BLOCK_DEPTH`] we return a
+    /// clean positioned `PythonLowerError`, mirroring the lowering guard.
+    fn collect_function_names(
+        &mut self,
+        stmt: &GrammarASTNode,
+        depth: usize,
+    ) -> Result<(), PythonLowerError> {
+        if depth > MAX_BLOCK_DEPTH {
+            return Err(self.err_at(
+                stmt,
+                format!("control-flow nesting too deep (exceeds {MAX_BLOCK_DEPTH} levels)"),
+            ));
+        }
         // Only `statement` nodes carry defs; recurse structurally.
         if let Some(def) = self.as_def_stmt(stmt) {
             let name = self.def_name(def)?;
@@ -445,7 +461,7 @@ impl Lowerer {
                 for child in &suite.children {
                     if let ASTNodeOrToken::Node(inner) = child {
                         if inner.rule_name == "statement" {
-                            self.collect_function_names(inner)?;
+                            self.collect_function_names(inner, depth + 1)?;
                         }
                     }
                 }
@@ -460,7 +476,7 @@ impl Lowerer {
                 for child in &suite.children {
                     if let ASTNodeOrToken::Node(inner) = child {
                         if inner.rule_name == "statement" {
-                            self.collect_function_names(inner)?;
+                            self.collect_function_names(inner, depth + 1)?;
                         }
                     }
                 }
@@ -1158,7 +1174,7 @@ impl Lowerer {
         let bound: HashSet<String> = params.iter().cloned().collect();
         let mut free = Vec::new();
         let mut seen = HashSet::new();
-        self.collect_free_names(body_expr, &bound, &mut free, &mut seen);
+        self.collect_free_names(body_expr, &bound, &mut free, &mut seen, 0)?;
 
         let (captures, capture_values) =
             self.resolve_captures(&free, enclosing, &span)?;
@@ -1231,10 +1247,10 @@ impl Lowerer {
         // Names bound *within* the body — the params plus every name the
         // body assigns / `for`-binds — are body-local, not captures.
         let mut bound: HashSet<String> = params.iter().cloned().collect();
-        self.collect_suite_bound_names(suite, &mut bound);
+        self.collect_suite_bound_names(suite, &mut bound)?;
         let mut free = Vec::new();
         let mut seen = HashSet::new();
-        self.collect_free_names(suite, &bound, &mut free, &mut seen);
+        self.collect_free_names(suite, &bound, &mut free, &mut seen, 0)?;
 
         let (captures, capture_values) = self.resolve_captures(&free, enclosing, &span)?;
 
@@ -1375,26 +1391,36 @@ impl Lowerer {
     /// so the free-variable scan treats body-local assignments as bound
     /// rather than as captures.  Bare `x = …` targets are collected;
     /// nested-`def` names too (they shadow).
-    fn collect_suite_bound_names(&self, suite: &GrammarASTNode, bound: &mut HashSet<String>) {
+    fn collect_suite_bound_names(
+        &self,
+        suite: &GrammarASTNode,
+        bound: &mut HashSet<String>,
+    ) -> Result<(), PythonLowerError> {
         for child in &suite.children {
             if let ASTNodeOrToken::Node(stmt) = child {
-                self.collect_stmt_bound_names(stmt, bound);
+                self.collect_stmt_bound_names(stmt, bound)?;
             }
         }
+        Ok(())
     }
 
-    fn collect_stmt_bound_names(&self, stmt: &GrammarASTNode, bound: &mut HashSet<String>) {
+    fn collect_stmt_bound_names(
+        &self,
+        stmt: &GrammarASTNode,
+        bound: &mut HashSet<String>,
+    ) -> Result<(), PythonLowerError> {
         // assignment target?
         if let Some(def) = self.as_def_stmt(stmt) {
             if let Ok(n) = self.def_name(def) {
                 bound.insert(n);
             }
-            return;
+            return Ok(());
         }
         // `for x in …:` binds `x`; descend into suites of compounds.
-        for n in self.descendant_assign_targets(stmt) {
+        for n in self.descendant_assign_targets(stmt)? {
             bound.insert(n);
         }
+        Ok(())
     }
 
     /// Collect assignment targets and `for`-loop variables anywhere
@@ -1403,13 +1429,34 @@ impl Lowerer {
     /// *reduces* captures, and a missing capture would surface as a
     /// validator error, so a name we fail to collect here cannot silently
     /// corrupt output.
-    fn descendant_assign_targets(&self, stmt: &GrammarASTNode) -> Vec<String> {
+    fn descendant_assign_targets(
+        &self,
+        stmt: &GrammarASTNode,
+    ) -> Result<Vec<String>, PythonLowerError> {
         let mut out = Vec::new();
-        self.walk_for_targets(stmt, &mut out);
-        out
+        self.walk_for_targets(stmt, &mut out, 0)?;
+        Ok(out)
     }
 
-    fn walk_for_targets(&self, node: &GrammarASTNode, out: &mut Vec<String>) {
+    /// Recursively scan `node`'s subtree for assignment / `for`-target
+    /// names.  This is a pre-lowering walk (it feeds free-variable
+    /// analysis before the depth-guarded lowering runs), so it bounds its
+    /// own recursion: it descends into *every* node child, so its depth
+    /// tracks the *expression* nesting depth and is capped at
+    /// [`MAX_EXPR_DEPTH`] — past which it returns a clean positioned error
+    /// rather than overflowing the native stack.
+    fn walk_for_targets(
+        &self,
+        node: &GrammarASTNode,
+        out: &mut Vec<String>,
+        depth: usize,
+    ) -> Result<(), PythonLowerError> {
+        if depth > MAX_EXPR_DEPTH {
+            return Err(self.err_at(
+                node,
+                format!("expression nesting too deep (exceeds {MAX_EXPR_DEPTH} levels)"),
+            ));
+        }
         match node.rule_name.as_str() {
             "assign_stmt" => {
                 // First expression_list is the LHS; if there's an
@@ -1441,9 +1488,10 @@ impl Lowerer {
         }
         for child in &node.children {
             if let ASTNodeOrToken::Node(n) = child {
-                self.walk_for_targets(n, out);
+                self.walk_for_targets(n, out, depth + 1)?;
             }
         }
+        Ok(())
     }
 
     /// Collect free `Name` references in a CST subtree: every bare `Name`
@@ -1455,13 +1503,27 @@ impl Lowerer {
     /// names that escape to *this* scope still surface (capture chaining
     /// at one level: an inner lambda referencing an outer-outer local is a
     /// documented v0 cut-line, but a single level works).
+    ///
+    /// `depth` bounds this pre-lowering walk's recursion.  Like the
+    /// expression lowerer, it descends into *every* node child, so its
+    /// depth tracks the *expression* nesting depth and is capped at
+    /// [`MAX_EXPR_DEPTH`]; past the cap we return a clean positioned
+    /// `PythonLowerError` instead of overflowing the native (uncatchable)
+    /// stack on a pathologically deep input via the public `compile`.
     fn collect_free_names(
         &self,
         node: &GrammarASTNode,
         bound: &HashSet<String>,
         free: &mut Vec<String>,
         seen: &mut HashSet<String>,
-    ) {
+        depth: usize,
+    ) -> Result<(), PythonLowerError> {
+        if depth > MAX_EXPR_DEPTH {
+            return Err(self.err_at(
+                node,
+                format!("expression nesting too deep (exceeds {MAX_EXPR_DEPTH} levels)"),
+            ));
+        }
         // A nested lambda binds its params; descend with them added.
         if node.rule_name == "lambda_expr" {
             let mut inner = bound.clone();
@@ -1471,9 +1533,9 @@ impl Lowerer {
                 }
             }
             if let Some(body) = self.first_child_named(node, "expression") {
-                self.collect_free_names(body, &inner, free, seen);
+                self.collect_free_names(body, &inner, free, seen, depth + 1)?;
             }
-            return;
+            return Ok(());
         }
         // A nested def binds its name + params; descend into its suite
         // with those added.
@@ -1488,10 +1550,10 @@ impl Lowerer {
                 }
             }
             if let Some(suite) = self.first_child_named(node, "suite") {
-                self.collect_suite_bound_names(suite, &mut inner);
-                self.collect_free_names(suite, &inner, free, seen);
+                self.collect_suite_bound_names(suite, &mut inner)?;
+                self.collect_free_names(suite, &inner, free, seen, depth + 1)?;
             }
-            return;
+            return Ok(());
         }
 
         // A bare `Name` token (no type_name) is a reference.
@@ -1502,14 +1564,15 @@ impl Lowerer {
                     free.push(name.clone());
                 }
             }
-            return;
+            return Ok(());
         }
 
         for child in &node.children {
             if let ASTNodeOrToken::Node(n) = child {
-                self.collect_free_names(n, bound, free, seen);
+                self.collect_free_names(n, bound, free, seen, depth + 1)?;
             }
         }
+        Ok(())
     }
 
     // -------------------------------------------------------------------

--- a/code/specs/SIR17-python-to-semantic-ir.md
+++ b/code/specs/SIR17-python-to-semantic-ir.md
@@ -8,6 +8,10 @@ existing [`python-parser`](../packages/rust/python-parser/) crate and
 produces a `semantic_ir::Module`.  Implemented as the Rust crate
 `python-to-semantic-ir`.
 
+Milestones implemented: **M1** (literals), **M2** (variables /
+assignment / operators), **M3** (control flow), **M4** (functions,
+calls, closures).  Collections / maps (M5) remain deferred.
+
 ## Pipeline
 
 ```text
@@ -90,11 +94,24 @@ versions of this frontend may accept a version parameter.
 `for x in range(...)` rows above are realised in M3 by recognising a
 literal `range(...)` call *structurally inside the `for` header* and
 lowering it directly to `ForRange` (with arity 1/2/3 mapped to
-`start`/`stop`/`step`, and a `range` call of wrong arity rejected).
-`range` is **not** yet a general expression-position builtin — a bare
-`range(n)` outside a `for` header (the `BuiltinCall("range", …)` row)
-arrives with general call support in M4.  A non-`range` iterable lowers
-to `ForEach`.
+`start`/`stop`/`step`, and a `range` call of wrong arity rejected).  A
+non-`range` iterable lowers to `ForEach`.
+
+**Implementation note (M4 — functions, calls, closures):** the
+`def` / `lambda` / `return` / call / builtin rows above are realised in
+M4.  As of M4, `range` (alongside `print` / `len`) **is** a general
+expression-position `BuiltinCall` — a bare `range(n)` outside a `for`
+header now lowers, in addition to the M3 `for`-header form.  `def`
+lowering is **two-pass** (collect all function names first, then lower
+bodies) so forward references and mutual recursion resolve to
+`DirectCall`.  Nested `def`s and `lambda`s are lifted to top-level
+synthesised functions with computed captures; the `Function { name: f,
+params, body }` row for `def` carries `captures: []` for a top-level
+`def` and a non-empty capture list for a lifted nested `def`/`lambda`.
+A bare reference to a function name yields a `MakeClosure` (re-threading
+the function's captures from the currently visible enclosing values).
+`MutualRecursion` is declared when two top-level functions transitively
+call each other (a self-recursive 1-cycle does not count).
 
 ## Return statement
 
@@ -164,18 +181,12 @@ variables not in scope at the call site become `Capture`s.
 ## Top-level
 
 Top-level Python is a sequence of statements at module scope.  The
-frontend synthesises:
-
-- A `_init` function for top-level value assignments (`x = 1`,
-  `def f(): ...` — function defs at module scope also become entries
-  here).
-- A `main` function for the synthetic entry point.  In v0, Python
-  doesn't have a `main()` convention, so the SIR's `main` is just
-  "run all top-level expressions sequentially after `_init`".
-
-Actually for cleanliness, we use a different approach: all top-level
-statements run inline as part of `main`.  This matches Python's
-actual execution model.
+frontend runs **all top-level statements inline as part of `main`**
+(matching Python's actual execution model — there is no separate
+`_init` function and no `globals` table in v0; a top-level `x = 1`
+becomes a `LetStarBinding` local of `main`).  A module-level `def`
+becomes a top-level `Function` entry (lifted out of `main`'s body);
+`main` holds the remaining top-level statements.
 
 ```text
 SIR Module {


### PR DESCRIPTION
Milestone M4 for the `python-to-semantic-ir` SIR17 frontend — **functions, calls, closures** (builds on merged M1-M3). The Python frontend can now lower real recursive/closure programs end-to-end.

- **def** (two-pass: collect names → lower bodies; nested defs lifted with captures); **return** tail-position (early return → positioned error); **lambda** → `MakeClosure` via free-variable analysis; **calls** → DirectCall (known fn) / IndirectCall (closure value) / BuiltinCall (print/len/range).
- Free-var capture resolves enclosing locals/params/captures as `Scope::Capture`; mutual recursion supported.

**Security hardening (found by review):** the M4 pre-lowering CST walks (`collect_function_names`, `collect_free_names`, `walk_for_targets`) ran before the depth-guarded lowering and were unbounded — a stack-overflow DoS on deeply-nested input via the public `compile`. All three now thread a depth param capped at `MAX_BLOCK_DEPTH`/`MAX_EXPR_DEPTH`, returning a positioned error. Regression tests included.

**Tests:** 84 (incl. 2 deep-nesting regression tests + **5 end-to-end Python-execution tests** that run lowered programs through the merged `semantic-ir-to-python` backend: factorial(5)=120, fib(10)=55, closure-adder=15, mutual recursion); clippy clean; security review + re-review passed.

Deferred to M5 (per the new full-coverage mandate, these will land via direct lowering or runtime-library): collections/comprehensions, default/keyword args, classes, exceptions. Isolated to `python-to-semantic-ir`.

> Note: surfaced a latent stack-overflow in the shared `parser` crate (unguarded recursive descent, ~depth 300) — tracked as a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)