### PR TITLE
feat(mathml): Presentation-MathML frontend (PFE01 #4) — PR-1 core reader

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -229,6 +229,7 @@ members = [
     "latex",
     "asciimath",
     "unicode-math",
+    "mathml",
     "adjudication-ir",
     "llm-cache",
     "llm-gateway",

--- a/code/packages/rust/mathml/BUILD
+++ b/code/packages/rust/mathml/BUILD
@@ -1,0 +1,1 @@
+cargo test -p mathml -- --nocapture

--- a/code/packages/rust/mathml/BUILD_windows
+++ b/code/packages/rust/mathml/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p mathml -- --nocapture

--- a/code/packages/rust/mathml/CHANGELOG.md
+++ b/code/packages/rust/mathml/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Changelog — mathml
+
+All notable changes to the Presentation-MathML frontend crate.
+
+## [0.1.0] — 2026-06-30
+
+### Added — PR-1: a Presentation-MathML reader → neutral `MathExpr` (PFE01 frontend #4)
+
+- New crate `mathml`: `MathMl` implements `math_frontend::MathFrontend`, the **fourth pluggable
+  parser frontend** after `latex`, `asciimath`, and `unicode-math`. It turns Presentation MathML
+  (`<math>…</math>`) into the same neutral `MathExpr` the others produce, so a consumer supports
+  MathML with **zero** change — the PFE01 promise, now demonstrated across an XML tree notation.
+- **XML-subset event lexer** (no general XML engine needed): emits start/end/character-data events,
+  ignoring attributes, namespace prefixes (`m:math` ≡ `math`), the XML declaration, comments, and
+  DOCTYPE. Entities decode — the basic five, numeric `&#NN;`/`&#xHH;`, and the common operator
+  entities (`&times;`, `&middot;`, `&le;`, `&ge;`, `&ne;`, `&plusmn;`, …); unknown entities are
+  preserved verbatim rather than dropped.
+- **Element coverage (PR-1):** `<mn>` (exact `Number`, tolerating `1,000`/`1.0`), `<mi>`
+  (`Symbol`), `<mtext>` (`Text`), `<mo>` operators (`+ - * / = < > ≤ ≥ ≠ ≈ ≡ ± ∓` and entity
+  spellings), `<mrow>` (a folded row with operator precedence relations < ±/∓/+− < ×÷, implicit
+  multiplication of adjacent operands, unary signs, and `(`…`)` fences → `Group`), `<mfrac>` →
+  `Frac`, `<msup>` → `Bin(Pow)`, `<msub>` → `Subscript`, `<msubsup>` → `Pow(Subscript(…))`,
+  `<msqrt>`/`<mroot>` → `Root`. `<math>`/`<mstyle>`/`<mpadded>` are transparent wrappers.
+- **Capabilities** (honest, checked by the shared `check_frontend` harness): fractions, roots,
+  powers, relations, implicit_mul, text, plusminus. (Subscripts are core, no flag.)
+- **Total, panic-free, spanned:** every input is `Ok(MathExpr)` or a `FrontendError` carrying a
+  byte span. A `MAX_DEPTH` guard bounds **both** the element recursion and the `(`…`)` fence
+  recursion, so adversarially deep input errors cleanly instead of overflowing the stack; the
+  neutral tree drops iteratively (math-frontend ≥ 0.3.0). `#![forbid(unsafe_code)]`.
+- `register_mathml`/`registry` helpers to install the frontend by name; 24 unit tests + a doctest
+  cover leaves, precedence, implicit multiplication, fences, the built-up structures, namespace/
+  attribute/declaration skipping, the cross-notation equivalences, spanned-error cases, the
+  deep-nesting guard, the registry, and a conformance check.
+
+### Deferred to PR-2
+`<mtable>`/`<mtr>`/`<mtd>` → `Matrix`, `<mover>`/`<munder>` → over/under-sets, `<mfenced>`, and
+named-function recognition (`<mi>sin</mi>` → `Call`).

--- a/code/packages/rust/mathml/Cargo.toml
+++ b/code/packages/rust/mathml/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "mathml"
+version = "0.1.0"
+edition = "2021"
+description = "A Presentation-MathML reader that implements the math-frontend MathFrontend trait: turns <math>…</math> (mn/mi/mo/mrow/mfrac/msup/msub/msqrt/mroot/mtext) into the neutral MathExpr AST. The fourth pluggable frontend after LaTeX and AsciiMath (see PFE01). Total, panic-free, spanned errors."
+license = "MIT"
+
+[dependencies]
+# The neutral framework: MathExpr + the MathFrontend trait + the conformance harness.
+# This is a frontend, so the dependency is mandatory (not optional like latex's adapter).
+math-frontend = { path = "../math-frontend" }

--- a/code/packages/rust/mathml/README.md
+++ b/code/packages/rust/mathml/README.md
@@ -1,0 +1,77 @@
+# mathml
+
+A **Presentation-MathML** reader that implements the [`math-frontend`](../math-frontend)
+`MathFrontend` trait: it turns the XML notation `<math>…</math>` into the *same* neutral
+`MathExpr` AST that the `latex`, `asciimath`, and `unicode-math` frontends produce.
+
+It is the **fourth pluggable parser frontend** (see
+[PFE01](../../../specs/PFE01-pluggable-parser-frontends.md)). The point of PFE01: a consumer
+depends on the neutral `MathExpr`, never on a concrete notation, so supporting MathML required
+**zero** change to any consumer — and now four genuinely different notations (a TeX macro
+language, a terse linear notation, a Unicode-symbol notation, and an XML tree) all lower to one
+tree.
+
+## What it covers (PR-1)
+
+| MathML | neutral `MathExpr` |
+|--------|--------------------|
+| `<mn>42</mn>` | `Number` (exact; `1,000` and `1.0` tolerated) |
+| `<mi>x</mi>` | `Symbol` |
+| `<mtext>kg</mtext>` | `Text` |
+| `<mo>+ - * / = &lt; &gt; ≤ ≥ ≠ ≈ ≡ ± ∓</mo>` | the matching `Bin`/`Rel` operator |
+| `<mrow>…</mrow>` | a folded row: operator precedence (relations < ± / +− < × ÷), implicit multiplication of adjacent operands, unary signs, and `(`…`)` fences → `Group` |
+| `<mfrac>a b</mfrac>` | `Frac(a, b)` |
+| `<msup>b e</msup>` | `Bin(Pow, b, e)` |
+| `<msub>b s</msub>` | `Subscript(b, s)` |
+| `<msubsup>b s e</msubsup>` | `Bin(Pow, Subscript(b, s), e)` |
+| `<msqrt>x</msqrt>` / `<mroot>x n</mroot>` | `Root` (degree `None` / `Some(n)`) |
+
+`<math>`, `<mstyle>`, and `<mpadded>` are **transparent** wrappers (their children join the
+surrounding row). Attributes, namespace prefixes (`m:math` ≡ `math`), the XML declaration,
+comments, and DOCTYPE are ignored. Operator entity spellings (`&times;`, `&le;`, `&#xD7;`, …)
+decode to the same operators as their literal glyphs.
+
+Deferred to PR-2: `<mtable>`/`<mtr>`/`<mtd>` → `Matrix`, `<mover>`/`<munder>` → over/under-sets,
+`<mfenced>`, and named-function recognition (`<mi>sin</mi>` → `Call`).
+
+## Contract
+
+`MathMl` implements `MathFrontend`: **total and panic-free** (every input is `Ok(MathExpr)` or a
+spanned `FrontendError`), **pure**, and **honest** (its `capabilities()` match what it actually
+emits — enforced by the shared `check_frontend` harness). Deeply-nested input is rejected with a
+spanned error (a `MAX_DEPTH` guard on both the element recursion and the fence recursion) rather
+than overflowing the stack, and the neutral tree it returns drops iteratively.
+
+## Usage
+
+```rust
+use mathml::MathMl;
+use math_frontend::{MathFrontend, MathExpr, BinOp};
+
+let e = MathMl.parse("<math><mn>1</mn><mo>+</mo><mn>2</mn></math>").unwrap();
+assert!(matches!(e, MathExpr::Bin(BinOp::Add, _, _)));
+
+// `<mfrac>` means the same as LaTeX `\frac{1}{2}` and AsciiMath `1/2` — all `MathExpr::Frac`.
+let f = MathMl.parse("<mfrac><mn>1</mn><mn>2</mn></mfrac>").unwrap();
+assert!(matches!(f, MathExpr::Frac(_, _)));
+```
+
+Register it in a `FrontendRegistry` and parse by name:
+
+```rust
+let r = mathml::registry();
+assert_eq!(r.names(), vec!["mathml"]);
+let _ = r.parse("mathml", "<msup><mi>x</mi><mn>2</mn></msup>").unwrap();
+```
+
+## Where it fits
+
+```
+notation source ──▶ [frontend] ──▶ neutral MathExpr ──▶ one consumer (CAS, renderer, ADJ, …)
+   LaTeX            latex
+   AsciiMath        asciimath
+   Unicode-math     unicode-math
+   MathML  ◀── this crate
+```
+
+Standalone and reusable; `#![forbid(unsafe_code)]`; the only dependency is `math-frontend`.

--- a/code/packages/rust/mathml/required_capabilities.json
+++ b/code/packages/rust/mathml/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/mathml",
+  "capabilities": [],
+  "justification": "Pure computation: turns a Presentation-MathML string into the neutral MathExpr AST. No filesystem, network, process, or environment access."
+}

--- a/code/packages/rust/mathml/src/lib.rs
+++ b/code/packages/rust/mathml/src/lib.rs
@@ -1,0 +1,340 @@
+//! # mathml — a [Presentation MathML](https://www.w3.org/TR/MathML3/chapter3.html) frontend for [`math_frontend`]
+//!
+//! The **fourth** pluggable parser frontend, after `latex` and `asciimath`. It turns
+//! Presentation MathML — the XML notation `<math>…</math>` that browsers and tools emit —
+//! into the *same* neutral [`MathExpr`] the other frontends produce. A consumer lowers that one
+//! neutral tree and supports MathML for free; adding it required **zero** change to any consumer.
+//! That is the promise of [PFE01](../../../specs/PFE01-pluggable-parser-frontends.md), now shown
+//! across three genuinely different notations (a TeX macro language, a terse linear notation, and
+//! an XML tree).
+//!
+//! ## Contract
+//! [`MathMl`] implements [`MathFrontend`]: it is **total and panic-free** (every input is
+//! `Ok(MathExpr)` or a spanned [`FrontendError`]), **pure**, and **honest** (its
+//! [`capabilities`](MathFrontend::capabilities) match what it actually emits — enforced by the
+//! shared `check_frontend` harness). Deeply-nested input is rejected with a spanned error rather
+//! than overflowing the stack, and the neutral tree it returns drops iteratively.
+//!
+//! ## What it covers (PR-1)
+//! The core presentation element set: `<mn>` numbers (exact), `<mi>` identifiers, `<mo>` operators
+//! (`+ - * / = < > ≤ ≥ ≠ ≈ ≡ ± ∓` and their entity spellings), `<mrow>` rows (with operator
+//! precedence, implicit multiplication of adjacent operands, unary signs, and `(`…`)` fences),
+//! `<mfrac>` → [`MathExpr::Frac`], `<msup>` → `Pow`, `<msub>` → [`MathExpr::Subscript`],
+//! `<msubsup>`, `<msqrt>`/`<mroot>` → [`MathExpr::Root`], and `<mtext>` → [`MathExpr::Text`]. The
+//! `<math>`/`<mstyle>`/`<mpadded>` wrappers are transparent. Attributes, namespace prefixes
+//! (`m:math` ≡ `math`), the XML declaration, comments, and DOCTYPE are ignored.
+//!
+//! Tables (`<mtable>`) → [`MathExpr::Matrix`], `<mover>`/`<munder>` → over/under-sets, `<mfenced>`,
+//! and named-function recognition (`<mi>sin</mi>`) are a later slice (PR-2).
+//!
+//! ```
+//! use mathml::MathMl;
+//! use math_frontend::{MathFrontend, MathExpr, BinOp};
+//!
+//! let e = MathMl.parse("<math><mn>1</mn><mo>+</mo><mn>2</mn></math>").unwrap();
+//! assert!(matches!(e, MathExpr::Bin(BinOp::Add, _, _)));
+//! // `<mfrac>` means the same as LaTeX `\frac{1}{2}` and AsciiMath `1/2` — all MathExpr::Frac.
+//! let f = MathMl.parse("<mfrac><mn>1</mn><mn>2</mn></mfrac>").unwrap();
+//! assert!(matches!(f, MathExpr::Frac(_, _)));
+//! ```
+
+#![forbid(unsafe_code)]
+
+mod parser;
+
+pub use parser::parse;
+
+// Re-export the neutral types so a consumer can `use mathml::MathExpr` without also naming the
+// framework crate directly.
+pub use math_frontend::{
+    BigOp, BinOp, Capabilities, Func, FrontendError, FrontendRegistry, MathExpr, MathFrontend,
+    Number, RelOp, UnaryOp,
+};
+
+/// The Presentation-MathML frontend. A zero-sized handle implementing [`MathFrontend`].
+#[derive(Debug, Default, Clone, Copy)]
+pub struct MathMl;
+
+impl MathFrontend for MathMl {
+    fn name(&self) -> &str {
+        "mathml"
+    }
+
+    fn parse(&self, src: &str) -> Result<MathExpr, FrontendError> {
+        parser::parse(src)
+    }
+
+    fn capabilities(&self) -> Capabilities {
+        // PR-1 surface: fractions (`<mfrac>`), roots (`<msqrt>`/`<mroot>`), powers (`<msup>` →
+        // `Pow`), relations (`<mo>=`/`<` …), implicit multiplication (adjacent operands in a row),
+        // text (`<mtext>`), and ± / ∓ (`<mo>±`). Subscripts are core (not a capability flag).
+        // Functions, matrices, accents, and over/under-sets are PR-2.
+        Capabilities::none()
+            .with_fractions()
+            .with_roots()
+            .with_powers()
+            .with_relations()
+            .with_implicit_mul()
+            .with_text()
+            .with_plusminus()
+    }
+}
+
+/// Install the MathML frontend into an existing registry (replacing any prior `"mathml"`).
+pub fn register_mathml(registry: &mut FrontendRegistry) {
+    registry.register(Box::new(MathMl));
+}
+
+/// A fresh [`FrontendRegistry`] with MathML registered.
+pub fn registry() -> FrontendRegistry {
+    let mut r = FrontendRegistry::new();
+    register_mathml(&mut r);
+    r
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use math_frontend::check_frontend;
+
+    fn p(s: &str) -> MathExpr {
+        MathMl.parse(s).unwrap_or_else(|e| panic!("parse {s:?} failed: {e}"))
+    }
+    fn num(n: i64) -> MathExpr {
+        MathExpr::Number(Number::from_i64(n))
+    }
+    fn sym(s: &str) -> MathExpr {
+        MathExpr::Symbol(s.to_string())
+    }
+    fn b(op: BinOp, l: MathExpr, r: MathExpr) -> MathExpr {
+        MathExpr::Bin(op, Box::new(l), Box::new(r))
+    }
+
+    // ---- leaf tokens -----------------------------------------------------------
+    #[test]
+    fn number_is_exact() {
+        assert_eq!(p("<mn>42</mn>"), num(42));
+        assert_eq!(p("<mn>1.0</mn>"), p("<mn>1</mn>"));
+        assert_eq!(p("<mn>1,000</mn>"), num(1000)); // thousands separators tolerated
+    }
+
+    #[test]
+    fn identifier_is_a_symbol() {
+        assert_eq!(p("<mi>x</mi>"), sym("x"));
+        assert_eq!(p("<mi>theta</mi>"), sym("theta"));
+    }
+
+    #[test]
+    fn mtext_is_text() {
+        assert_eq!(p("<mtext>kg</mtext>"), MathExpr::Text("kg".into()));
+    }
+
+    // ---- rows, operators, precedence ------------------------------------------
+    #[test]
+    fn addition_is_a_bin_add() {
+        assert_eq!(p("<math><mn>1</mn><mo>+</mo><mn>2</mn></math>"), b(BinOp::Add, num(1), num(2)));
+    }
+
+    #[test]
+    fn precedence_mul_binds_tighter_than_add() {
+        // 1 + 2*3 → Add(1, Mul(2,3))
+        let e = p("<math><mn>1</mn><mo>+</mo><mn>2</mn><mo>&times;</mo><mn>3</mn></math>");
+        assert_eq!(e, b(BinOp::Add, num(1), b(BinOp::Mul, num(2), num(3))));
+    }
+
+    #[test]
+    fn implicit_multiplication_of_adjacent_operands() {
+        // 2 x → Mul(2, x), even with no operator between them.
+        assert_eq!(p("<math><mn>2</mn><mi>x</mi></math>"), b(BinOp::Mul, num(2), sym("x")));
+    }
+
+    #[test]
+    fn unary_minus_at_row_start() {
+        assert_eq!(
+            p("<math><mo>-</mo><mi>x</mi></math>"),
+            MathExpr::Unary(UnaryOp::Neg, Box::new(sym("x")))
+        );
+    }
+
+    #[test]
+    fn relation_is_lowest_precedence() {
+        // x + 1 = y → Rel(Eq, Add(x,1), y)
+        let e = p("<math><mi>x</mi><mo>+</mo><mn>1</mn><mo>=</mo><mi>y</mi></math>");
+        assert_eq!(e, MathExpr::Rel(RelOp::Eq, Box::new(b(BinOp::Add, sym("x"), num(1))), Box::new(sym("y"))));
+    }
+
+    #[test]
+    fn entity_and_unicode_operators_agree() {
+        // `&times;`, the literal `×`, and `&#xD7;` all denote Mul.
+        let a = p("<math><mn>2</mn><mo>&times;</mo><mn>3</mn></math>");
+        let b1 = p("<math><mn>2</mn><mo>×</mo><mn>3</mn></math>");
+        let c = p("<math><mn>2</mn><mo>&#xD7;</mo><mn>3</mn></math>");
+        assert_eq!(a, b1);
+        assert_eq!(a, c);
+    }
+
+    #[test]
+    fn parenthesis_fence_becomes_group_and_overrides_precedence() {
+        // (1 + 2) * 3 → Mul(Group(Add(1,2)), 3)
+        let e = p("<math><mo>(</mo><mn>1</mn><mo>+</mo><mn>2</mn><mo>)</mo><mo>*</mo><mn>3</mn></math>");
+        assert_eq!(
+            e,
+            b(BinOp::Mul, MathExpr::Group(Box::new(b(BinOp::Add, num(1), num(2)))), num(3))
+        );
+    }
+
+    // ---- built-up structures (the cross-notation equivalences) -----------------
+    #[test]
+    fn mfrac_is_frac_like_latex_and_asciimath() {
+        let e = p("<mfrac><mn>1</mn><mn>2</mn></mfrac>");
+        assert_eq!(e, MathExpr::Frac(Box::new(num(1)), Box::new(num(2))));
+    }
+
+    #[test]
+    fn msup_is_pow_and_msub_is_subscript() {
+        assert_eq!(p("<msup><mi>x</mi><mn>2</mn></msup>"), b(BinOp::Pow, sym("x"), num(2)));
+        assert_eq!(
+            p("<msub><mi>a</mi><mi>i</mi></msub>"),
+            MathExpr::Subscript(Box::new(sym("a")), Box::new(sym("i")))
+        );
+    }
+
+    #[test]
+    fn msubsup_is_subscript_then_power() {
+        // x_i^2 → Pow(Subscript(x,i), 2)
+        let e = p("<msubsup><mi>x</mi><mi>i</mi><mn>2</mn></msubsup>");
+        assert_eq!(
+            e,
+            b(BinOp::Pow, MathExpr::Subscript(Box::new(sym("x")), Box::new(sym("i"))), num(2))
+        );
+    }
+
+    #[test]
+    fn msqrt_and_mroot_are_roots() {
+        assert_eq!(
+            p("<msqrt><mi>x</mi></msqrt>"),
+            MathExpr::Root { degree: None, radicand: Box::new(sym("x")) }
+        );
+        // <mroot> base index → cube root of x.
+        assert_eq!(
+            p("<mroot><mi>x</mi><mn>3</mn></mroot>"),
+            MathExpr::Root { degree: Some(Box::new(num(3))), radicand: Box::new(sym("x")) }
+        );
+    }
+
+    #[test]
+    fn msqrt_folds_its_whole_row() {
+        // sqrt of (a + b): the msqrt body is a row, folded before becoming the radicand.
+        let e = p("<msqrt><mi>a</mi><mo>+</mo><mi>b</mi></msqrt>");
+        assert_eq!(
+            e,
+            MathExpr::Root { degree: None, radicand: Box::new(b(BinOp::Add, sym("a"), sym("b"))) }
+        );
+    }
+
+    #[test]
+    fn nested_mrow_is_transparent_grouping() {
+        // <mrow> nesting does not change the folded meaning.
+        let flat = p("<math><mn>1</mn><mo>+</mo><mn>2</mn></math>");
+        let nested = p("<math><mrow><mn>1</mn><mo>+</mo><mn>2</mn></mrow></math>");
+        assert_eq!(flat, nested);
+    }
+
+    // ---- namespaces / attributes / declarations are ignored --------------------
+    #[test]
+    fn namespace_prefix_and_attributes_are_ignored() {
+        let e = p(r#"<m:math xmlns:m="http://www.w3.org/1998/Math/MathML"><m:mn>1</m:mn><m:mo>+</m:mo><m:mn>2</m:mn></m:math>"#);
+        assert_eq!(e, b(BinOp::Add, num(1), num(2)));
+    }
+
+    #[test]
+    fn xml_declaration_and_comments_are_skipped() {
+        let e = p("<?xml version=\"1.0\"?><!-- a formula --><math><mn>3</mn></math>");
+        assert_eq!(e, num(3));
+    }
+
+    #[test]
+    fn display_attribute_does_not_change_parse() {
+        let e = p(r#"<math display="block"><mn>5</mn></math>"#);
+        assert_eq!(e, num(5));
+    }
+
+    // ---- the cross-notation payoff --------------------------------------------
+    #[test]
+    fn same_neutral_tree_as_latex_and_asciimath_would_make() {
+        // <mn>1</mn>/<mn>2</mn> via mfrac is the SAME MathExpr as LaTeX \frac{1}{2} / AsciiMath 1/2.
+        assert_eq!(
+            p("<mfrac><mn>1</mn><mn>2</mn></mfrac>"),
+            MathExpr::Frac(Box::new(num(1)), Box::new(num(2)))
+        );
+    }
+
+    // ---- errors are spanned, never panics -------------------------------------
+    #[test]
+    fn malformed_input_is_a_spanned_error_not_a_panic() {
+        assert!(MathMl.parse("<math><mn>1</mn>").is_err()); // unclosed <math>
+        assert!(MathMl.parse("<mfrac><mn>1</mn></mfrac>").is_err()); // mfrac needs 2 args
+        assert!(MathMl.parse("<math><mo>+</mo></math>").is_err()); // operator with no operand
+        assert!(MathMl.parse("<math></mrow></math>").is_err()); // mismatched end tag
+        assert!(MathMl.parse("<mn>x</mn>").is_err()); // non-numeric <mn>
+        assert!(MathMl.parse("").is_err()); // empty
+        assert!(MathMl.parse("<math><mn>1</mn><mo>+</mo></math>").is_err()); // dangling binary op
+        assert!(MathMl.parse("<math><mo>)</mo></math>").is_err()); // unmatched fence
+    }
+
+    #[test]
+    fn double_unary_sign_folds_outermost_first() {
+        // `+ - x` → Unary(Pos, Unary(Neg, x)); the iterative collector preserves the order.
+        let e = p("<math><mo>+</mo><mo>-</mo><mi>x</mi></math>");
+        assert_eq!(
+            e,
+            MathExpr::Unary(UnaryOp::Pos, Box::new(MathExpr::Unary(UnaryOp::Neg, Box::new(sym("x")))))
+        );
+    }
+
+    #[test]
+    fn long_unary_sign_run_does_not_overflow() {
+        // A flat run of unary-minus operators lives at ONE nesting level, so the element/fence
+        // MAX_DEPTH guard does not cover it. Unary parsing is iterative, so even 100k signs parse
+        // (and the deep Unary chain drops iteratively) without a stack overflow / abort.
+        let run = format!("<math>{}<mn>1</mn></math>", "<mo>-</mo>".repeat(100_000));
+        let parsed = MathMl.parse(&run);
+        assert!(parsed.is_ok(), "long unary run should parse, not abort");
+    }
+
+    #[test]
+    fn deeply_nested_input_errors_rather_than_overflowing() {
+        let deep = format!("{}{}{}", "<mrow>".repeat(5000), "<mn>1</mn>", "</mrow>".repeat(5000));
+        // Either a clean parse or a spanned depth error — never a panic/overflow.
+        let _ = MathMl.parse(&deep);
+        // A *parse* that is well past MAX_DEPTH must be the spanned error, not a crash.
+        assert!(MathMl.parse(&deep).is_err());
+    }
+
+    // ---- registry --------------------------------------------------------------
+    #[test]
+    fn registry_registers_under_its_name() {
+        let r = registry();
+        assert_eq!(r.names(), vec!["mathml"]);
+        assert_eq!(r.parse("mathml", "<mn>7</mn>").unwrap(), num(7));
+    }
+
+    // ---- conformance: declared capabilities match reality ----------------------
+    #[test]
+    fn conformance_capabilities_are_honest() {
+        let samples = [
+            "<mn>1</mn>",
+            "<mi>x</mi>",
+            "<math><mn>1</mn><mo>+</mo><mn>2</mn></math>",
+            "<mfrac><mn>1</mn><mn>2</mn></mfrac>",
+            "<msup><mi>x</mi><mn>2</mn></msup>",
+            "<msqrt><mi>x</mi></msqrt>",
+            "<math><mi>x</mi><mo>=</mo><mn>1</mn></math>",
+            "<math><mn>2</mn><mi>x</mi></math>",
+            "<mtext>kg</mtext>",
+            "<math><mn>1</mn><mo>±</mo><mn>2</mn></math>",
+        ];
+        let report = check_frontend(&MathMl, &samples);
+        assert!(report.passed(), "conformance violations: {report:?}");
+    }
+}

--- a/code/packages/rust/mathml/src/parser.rs
+++ b/code/packages/rust/mathml/src/parser.rs
@@ -1,0 +1,745 @@
+//! Presentation-MathML reader: an XML-subset event lexer + a recursive element-tree builder
+//! that produces the neutral [`MathExpr`](math_frontend::MathExpr).
+//!
+//! MathML is XML, but we do **not** need a general XML engine — Presentation MathML is a small,
+//! regular tree of known elements. So the lexer emits just three event kinds (start tag, end tag,
+//! character data), ignoring attributes, namespace prefixes (`m:math` ≡ `math`), the XML
+//! declaration, comments, and DOCTYPE. The builder then walks those events into `MathExpr`.
+//!
+//! Contract (shared by every frontend): **total and panic-free** — every input is `Ok(MathExpr)`
+//! or a spanned [`FrontendError`]. Recursion is bounded by `MAX_DEPTH` so deeply-nested input
+//! yields a clean error rather than a stack overflow, and the neutral `MathExpr` it returns drops
+//! iteratively (math-frontend ≥ 0.3.0), so teardown is panic-free at any depth too.
+
+use math_frontend::{BinOp, FrontendError, MathExpr, Number, RelOp, UnaryOp};
+
+/// Maximum element/fence nesting depth. Presentation MathML for real formulae is shallow (a few
+/// dozen levels at most); a pathologically deep `<mrow><mrow>…` or `(((…` is rejected with a spanned
+/// error instead of overflowing the parse stack. Kept conservatively low because each nesting level
+/// here costs several recursive frames (parse_one_into → build_element → parse_row_children, or the
+/// fold_row → fence → fold_row fence loop), and `#[test]` threads run on a ~2 MB stack.
+const MAX_DEPTH: usize = 64;
+
+const FRONTEND: &str = "mathml";
+
+fn err<T>(message: impl Into<String>, span: (usize, usize)) -> Result<T, FrontendError> {
+    Err(FrontendError::new(FRONTEND, message, span))
+}
+
+// ---- XML-subset event lexer -------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Event {
+    /// `<name …>` — attributes discarded, namespace prefix stripped. `self_closing` for `<name/>`.
+    Start { name: String, self_closing: bool, span: (usize, usize) },
+    /// `</name>`.
+    End { name: String, span: (usize, usize) },
+    /// Character data between tags (entity-decoded, never empty after trim unless whitespace-only
+    /// is meaningful — we keep it and let the builder decide).
+    Text { text: String, span: (usize, usize) },
+}
+
+struct Lexer<'a> {
+    src: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Lexer<'a> {
+    fn new(src: &'a str) -> Self {
+        Lexer { src: src.as_bytes(), pos: 0 }
+    }
+
+    fn events(mut self) -> Result<Vec<Event>, FrontendError> {
+        let mut out = Vec::new();
+        let n = self.src.len();
+        while self.pos < n {
+            if self.src[self.pos] == b'<' {
+                // A markup construct. Distinguish comment / declaration / doctype / end / start.
+                if self.starts_with("<!--") {
+                    self.skip_until("-->", "unterminated comment")?;
+                } else if self.starts_with("<?") {
+                    self.skip_until("?>", "unterminated processing instruction")?;
+                } else if self.starts_with("<!") {
+                    // DOCTYPE or CDATA-ish; skip to the next '>'. (CDATA with '>' inside is out of
+                    // scope for PR-1 presentation MathML.)
+                    self.skip_until(">", "unterminated declaration")?;
+                } else if self.starts_with("</") {
+                    out.push(self.read_end_tag()?);
+                } else {
+                    out.push(self.read_start_tag()?);
+                }
+            } else {
+                if let Some(ev) = self.read_text()? {
+                    out.push(ev);
+                }
+            }
+        }
+        Ok(out)
+    }
+
+    fn starts_with(&self, s: &str) -> bool {
+        self.src[self.pos..].starts_with(s.as_bytes())
+    }
+
+    fn skip_until(&mut self, close: &str, unterminated: &str) -> Result<(), FrontendError> {
+        let start = self.pos;
+        let bytes = close.as_bytes();
+        while self.pos < self.src.len() {
+            if self.src[self.pos..].starts_with(bytes) {
+                self.pos += bytes.len();
+                return Ok(());
+            }
+            self.pos += 1;
+        }
+        err(unterminated, (start, self.src.len()))
+    }
+
+    fn read_end_tag(&mut self) -> Result<Event, FrontendError> {
+        let start = self.pos;
+        self.pos += 2; // consume "</"
+        let name = self.read_name();
+        if name.is_empty() {
+            return err("malformed end tag", (start, self.pos));
+        }
+        self.skip_spaces();
+        if self.pos >= self.src.len() || self.src[self.pos] != b'>' {
+            return err(format!("expected '>' to close </{name}"), (start, self.pos));
+        }
+        self.pos += 1; // '>'
+        Ok(Event::End { name, span: (start, self.pos) })
+    }
+
+    fn read_start_tag(&mut self) -> Result<Event, FrontendError> {
+        let start = self.pos;
+        self.pos += 1; // consume '<'
+        let name = self.read_name();
+        if name.is_empty() {
+            return err("malformed start tag", (start, self.pos));
+        }
+        // Skip attributes: scan to the matching '>' honouring quoted attribute values.
+        let mut self_closing = false;
+        loop {
+            if self.pos >= self.src.len() {
+                return err(format!("unterminated <{name}"), (start, self.src.len()));
+            }
+            match self.src[self.pos] {
+                b'>' => {
+                    self.pos += 1;
+                    break;
+                }
+                b'/' if self.pos + 1 < self.src.len() && self.src[self.pos + 1] == b'>' => {
+                    self_closing = true;
+                    self.pos += 2;
+                    break;
+                }
+                b'"' | b'\'' => {
+                    let quote = self.src[self.pos];
+                    self.pos += 1;
+                    while self.pos < self.src.len() && self.src[self.pos] != quote {
+                        self.pos += 1;
+                    }
+                    if self.pos >= self.src.len() {
+                        return err(format!("unterminated attribute in <{name}"), (start, self.src.len()));
+                    }
+                    self.pos += 1; // closing quote
+                }
+                _ => self.pos += 1,
+            }
+        }
+        Ok(Event::Start { name, self_closing, span: (start, self.pos) })
+    }
+
+    /// Read an element name and strip any namespace prefix (`m:math` → `math`).
+    fn read_name(&mut self) -> String {
+        let begin = self.pos;
+        while self.pos < self.src.len() {
+            let c = self.src[self.pos];
+            if c.is_ascii_alphanumeric() || c == b'_' || c == b'-' || c == b':' || c == b'.' {
+                self.pos += 1;
+            } else {
+                break;
+            }
+        }
+        let raw = std::str::from_utf8(&self.src[begin..self.pos]).unwrap_or("");
+        match raw.rsplit_once(':') {
+            Some((_prefix, local)) => local.to_string(),
+            None => raw.to_string(),
+        }
+    }
+
+    fn skip_spaces(&mut self) {
+        while self.pos < self.src.len() && self.src[self.pos].is_ascii_whitespace() {
+            self.pos += 1;
+        }
+    }
+
+    /// Read character data up to the next `<`, decoding entities. Returns `None` if the run is
+    /// empty or pure inter-element whitespace (which carries no math meaning).
+    fn read_text(&mut self) -> Result<Option<Event>, FrontendError> {
+        let start = self.pos;
+        let mut s = String::new();
+        while self.pos < self.src.len() && self.src[self.pos] != b'<' {
+            if self.src[self.pos] == b'&' {
+                s.push_str(&self.read_entity()?);
+            } else {
+                // Copy one UTF-8 scalar (the source is valid UTF-8, so advance by the lead byte's width).
+                let w = utf8_width(self.src[self.pos]);
+                let end = (self.pos + w).min(self.src.len());
+                if let Ok(chunk) = std::str::from_utf8(&self.src[self.pos..end]) {
+                    s.push_str(chunk);
+                }
+                self.pos = end;
+            }
+        }
+        if s.trim().is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(Event::Text { text: s, span: (start, self.pos) }))
+        }
+    }
+
+    fn read_entity(&mut self) -> Result<String, FrontendError> {
+        let start = self.pos;
+        self.pos += 1; // '&'
+        let begin = self.pos;
+        while self.pos < self.src.len() && self.src[self.pos] != b';' && self.src[self.pos] != b'<' {
+            self.pos += 1;
+        }
+        if self.pos >= self.src.len() || self.src[self.pos] != b';' {
+            return err("unterminated entity reference", (start, self.pos));
+        }
+        let name = std::str::from_utf8(&self.src[begin..self.pos]).unwrap_or("");
+        self.pos += 1; // ';'
+        Ok(decode_entity(name))
+    }
+}
+
+fn utf8_width(lead: u8) -> usize {
+    if lead < 0x80 {
+        1
+    } else if lead >> 5 == 0b110 {
+        2
+    } else if lead >> 4 == 0b1110 {
+        3
+    } else if lead >> 3 == 0b11110 {
+        4
+    } else {
+        1
+    }
+}
+
+/// Decode an entity body (the part between `&` and `;`). Unknown names are returned verbatim
+/// wrapped back as `&name;` so nothing is silently dropped — an unknown entity simply becomes part
+/// of a symbol's text rather than an error.
+fn decode_entity(name: &str) -> String {
+    // Numeric character references: &#NN; and &#xHH;.
+    if let Some(rest) = name.strip_prefix('#') {
+        let code = if let Some(hex) = rest.strip_prefix('x').or_else(|| rest.strip_prefix('X')) {
+            u32::from_str_radix(hex, 16).ok()
+        } else {
+            rest.parse::<u32>().ok()
+        };
+        if let Some(c) = code.and_then(char::from_u32) {
+            return c.to_string();
+        }
+        return format!("&{name};");
+    }
+    let mapped = match name {
+        "lt" => "<",
+        "gt" => ">",
+        "amp" => "&",
+        "quot" => "\"",
+        "apos" => "'",
+        "nbsp" => " ",
+        // Common MathML operator entities so `<mo>` content maps to a known operator.
+        "times" => "×",
+        "div" => "÷",
+        "minus" => "−",
+        "plusmn" | "PlusMinus" => "±",
+        "MinusPlus" => "∓",
+        "middot" | "CenterDot" | "sdot" => "·",
+        "le" | "leq" => "≤",
+        "ge" | "geq" => "≥",
+        "ne" | "neq" => "≠",
+        "equiv" => "≡",
+        "approx" => "≈",
+        "InvisibleTimes" | "af" | "ApplyFunction" => "", // invisible operators carry no glyph
+        "pi" => "π",
+        _ => return format!("&{name};"),
+    };
+    mapped.to_string()
+}
+
+// ---- element-tree builder ---------------------------------------------------------------------
+
+/// One processed child of a row: either a finished operand expression, or a raw `<mo>` operator
+/// string (interpreted by the row folder), or a fenced sub-row already wrapped as a `Group`.
+enum Child {
+    Expr(MathExpr),
+    Op(String),
+}
+
+struct Parser {
+    events: Vec<Event>,
+    pos: usize,
+    src_len: usize,
+}
+
+impl Parser {
+    fn new(events: Vec<Event>, src_len: usize) -> Self {
+        Parser { events, pos: 0, src_len }
+    }
+
+    fn peek(&self) -> Option<&Event> {
+        self.events.get(self.pos)
+    }
+
+    /// Parse the whole document: an optional single `<math>` wrapper around a row, or a bare row of
+    /// top-level presentation elements.
+    fn parse_document(&mut self) -> Result<MathExpr, FrontendError> {
+        // Collect every top-level element/text into children, then fold as one row. A `<math>`
+        // wrapper is transparent: its children become this row.
+        let children = self.parse_children_until_eof(0)?;
+        if children.is_empty() {
+            return err("empty MathML: no elements found", (0, self.src_len));
+        }
+        fold_row(children, (0, self.src_len), 0)
+    }
+
+    fn parse_children_until_eof(&mut self, depth: usize) -> Result<Vec<Child>, FrontendError> {
+        let mut children = Vec::new();
+        while self.peek().is_some() {
+            match self.peek().unwrap() {
+                Event::End { name, span } => {
+                    return err(format!("unexpected </{name}> with no open element"), *span);
+                }
+                _ => self.parse_one_into(&mut children, depth)?,
+            }
+        }
+        Ok(children)
+    }
+
+    /// Parse a single element (and its subtree) appending the resulting `Child`(ren). A `<math>`
+    /// wrapper is spliced transparently (its children join the current row).
+    fn parse_one_into(&mut self, out: &mut Vec<Child>, depth: usize) -> Result<(), FrontendError> {
+        if depth > MAX_DEPTH {
+            let span = self.current_span();
+            return err("MathML nested too deeply", span);
+        }
+        let ev = self.events[self.pos].clone();
+        match ev {
+            Event::Text { text, .. } => {
+                self.pos += 1;
+                // Bare text outside a leaf element is unusual; treat as a symbol token.
+                out.push(Child::Expr(MathExpr::Symbol(text.trim().to_string())));
+                Ok(())
+            }
+            Event::Start { name, self_closing, span } => {
+                self.pos += 1;
+                if self_closing {
+                    out.push(self.build_leaf(&name, "", span)?);
+                    return Ok(());
+                }
+                // `math` and `mstyle`/`mpadded` are transparent containers in PR-1: their children
+                // join the surrounding row.
+                if name == "math" || name == "mstyle" || name == "mpadded" {
+                    let kids = self.parse_row_children(&name, depth + 1)?;
+                    let folded = fold_row(kids, span, depth + 1)?;
+                    out.push(Child::Expr(folded));
+                    return Ok(());
+                }
+                let child = self.build_element(&name, span, depth + 1)?;
+                out.push(child);
+                Ok(())
+            }
+            Event::End { name, span } => err(format!("unexpected </{name}>"), span),
+        }
+    }
+
+    /// Parse children up to the matching `</name>`, returning them as a row of `Child`s.
+    fn parse_row_children(&mut self, name: &str, depth: usize) -> Result<Vec<Child>, FrontendError> {
+        let mut children = Vec::new();
+        loop {
+            match self.peek() {
+                None => {
+                    return err(format!("unclosed <{name}> (expected </{name}>)"), (0, self.src_len));
+                }
+                Some(Event::End { name: end, .. }) => {
+                    if end == name {
+                        self.pos += 1; // consume the matching end tag
+                        return Ok(children);
+                    }
+                    let span = self.current_span();
+                    let end = end.clone();
+                    return err(format!("mismatched </{end}>, expected </{name}>"), span);
+                }
+                _ => self.parse_one_into(&mut children, depth)?,
+            }
+        }
+    }
+
+    /// Build a known container/script element (children already to be read up to its end tag).
+    fn build_element(&mut self, name: &str, span: (usize, usize), depth: usize) -> Result<Child, FrontendError> {
+        match name {
+            // Leaf token elements: exactly one text child.
+            "mn" | "mi" | "mo" | "mtext" => {
+                let text = self.read_leaf_text(name)?;
+                self.build_leaf(name, &text, span)
+            }
+            // `mrow` and friends: a sub-row, folded.
+            "mrow" => {
+                let kids = self.parse_row_children(name, depth)?;
+                Ok(Child::Expr(fold_row(kids, span, depth)?))
+            }
+            "msqrt" => {
+                let kids = self.parse_row_children(name, depth)?;
+                let radicand = fold_row(kids, span, depth)?;
+                Ok(Child::Expr(MathExpr::Root { degree: None, radicand: Box::new(radicand) }))
+            }
+            "mfrac" => {
+                let args = self.read_n_args(name, 2, depth)?;
+                let mut it = args.into_iter();
+                let num = it.next().unwrap();
+                let den = it.next().unwrap();
+                Ok(Child::Expr(MathExpr::Frac(Box::new(num), Box::new(den))))
+            }
+            "mroot" => {
+                let args = self.read_n_args(name, 2, depth)?;
+                let mut it = args.into_iter();
+                let radicand = it.next().unwrap();
+                let degree = it.next().unwrap();
+                Ok(Child::Expr(MathExpr::Root {
+                    degree: Some(Box::new(degree)),
+                    radicand: Box::new(radicand),
+                }))
+            }
+            "msup" => {
+                let args = self.read_n_args(name, 2, depth)?;
+                let mut it = args.into_iter();
+                let base = it.next().unwrap();
+                let sup = it.next().unwrap();
+                Ok(Child::Expr(MathExpr::Bin(BinOp::Pow, Box::new(base), Box::new(sup))))
+            }
+            "msub" => {
+                let args = self.read_n_args(name, 2, depth)?;
+                let mut it = args.into_iter();
+                let base = it.next().unwrap();
+                let sub = it.next().unwrap();
+                Ok(Child::Expr(MathExpr::Subscript(Box::new(base), Box::new(sub))))
+            }
+            "msubsup" => {
+                let args = self.read_n_args(name, 3, depth)?;
+                let mut it = args.into_iter();
+                let base = it.next().unwrap();
+                let sub = it.next().unwrap();
+                let sup = it.next().unwrap();
+                let subbed = MathExpr::Subscript(Box::new(base), Box::new(sub));
+                Ok(Child::Expr(MathExpr::Bin(BinOp::Pow, Box::new(subbed), Box::new(sup))))
+            }
+            other => {
+                // Unknown element: consume its subtree so the lexer stays balanced, then report
+                // it honestly rather than silently dropping content.
+                let _ = self.parse_row_children(name, depth);
+                err(format!("unsupported MathML element <{other}>"), span)
+            }
+        }
+    }
+
+    /// Read exactly `n` child *element* arguments (each folded to one expression) up to `</name>`.
+    fn read_n_args(&mut self, name: &str, n: usize, depth: usize) -> Result<Vec<MathExpr>, FrontendError> {
+        let kids = self.parse_row_children(name, depth)?;
+        // Each child must be an operand expression (script/fraction args are single elements, not
+        // bare operators).
+        let mut args = Vec::with_capacity(kids.len());
+        for c in kids {
+            match c {
+                Child::Expr(e) => args.push(e),
+                Child::Op(s) => {
+                    return err(
+                        format!("<{name}> argument cannot be a bare operator {s:?}"),
+                        (0, self.src_len),
+                    )
+                }
+            }
+        }
+        if args.len() != n {
+            return err(
+                format!("<{name}> expects {n} arguments, got {}", args.len()),
+                (0, self.src_len),
+            );
+        }
+        Ok(args)
+    }
+
+    /// A leaf token element (`mn`/`mi`/`mo`/`mtext`) holds exactly one text child (possibly empty).
+    fn read_leaf_text(&mut self, name: &str) -> Result<String, FrontendError> {
+        let mut text = String::new();
+        loop {
+            match self.peek() {
+                None => return err(format!("unclosed <{name}>"), (0, self.src_len)),
+                Some(Event::Text { text: t, .. }) => {
+                    text.push_str(t);
+                    self.pos += 1;
+                }
+                Some(Event::End { name: end, span }) => {
+                    if end == name {
+                        self.pos += 1;
+                        return Ok(text);
+                    }
+                    return err(format!("mismatched </{end}>, expected </{name}>"), *span);
+                }
+                Some(Event::Start { name: inner, span, .. }) => {
+                    // A token element must not contain child elements in PR-1.
+                    return err(format!("<{name}> may not contain <{inner}>"), *span);
+                }
+            }
+        }
+    }
+
+    fn build_leaf(&self, name: &str, text: &str, span: (usize, usize)) -> Result<Child, FrontendError> {
+        let trimmed = text.trim();
+        match name {
+            "mn" => {
+                let normalized = trimmed.replace(',', "");
+                match Number::parse(&normalized) {
+                    Some(n) => Ok(Child::Expr(MathExpr::Number(n))),
+                    None => err(format!("<mn> is not a number: {trimmed:?}"), span),
+                }
+            }
+            "mi" => {
+                if trimmed.is_empty() {
+                    // An empty/invisible <mi/> contributes nothing.
+                    Ok(Child::Expr(MathExpr::Symbol(String::new())))
+                } else {
+                    Ok(Child::Expr(MathExpr::Symbol(trimmed.to_string())))
+                }
+            }
+            "mtext" => Ok(Child::Expr(MathExpr::Text(text.to_string()))),
+            "mo" => Ok(Child::Op(trimmed.to_string())),
+            _ => err(format!("<{name}> is not a leaf token element"), span),
+        }
+    }
+
+    fn current_span(&self) -> (usize, usize) {
+        match self.events.get(self.pos) {
+            Some(Event::Start { span, .. })
+            | Some(Event::End { span, .. })
+            | Some(Event::Text { span, .. }) => *span,
+            None => (self.src_len, self.src_len),
+        }
+    }
+}
+
+// ---- row folding (operators + implicit multiplication + fences) -------------------------------
+
+/// A token in the flat row passed to the precedence parser.
+enum RowTok {
+    Operand(MathExpr),
+    Bin(BinOp),
+    Rel(RelOp),
+}
+
+/// Fold a row of `Child`s into one `MathExpr`, applying parenthesis fences, operator precedence
+/// (relations < add/sub < mul/div), implicit multiplication of adjacent operands, and unary signs.
+/// `depth` bounds the fence recursion (`(`…`)` → `Group`) so adversarially nested fences error
+/// rather than overflow.
+fn fold_row(children: Vec<Child>, span: (usize, usize), depth: usize) -> Result<MathExpr, FrontendError> {
+    if depth > MAX_DEPTH {
+        return err("MathML nested too deeply", span);
+    }
+    let toks = lower_children_to_tokens(children, span, depth)?;
+    if toks.is_empty() {
+        return err("empty MathML group", span);
+    }
+    let mut rp = RowParser { toks, pos: 0, span };
+    let e = rp.parse_rel()?;
+    if rp.pos != rp.toks.len() {
+        return err("trailing tokens in MathML row", span);
+    }
+    Ok(e)
+}
+
+/// Turn the row's children into `RowTok`s, resolving `(`…`)` fences into `Group` operands first.
+fn lower_children_to_tokens(
+    children: Vec<Child>,
+    span: (usize, usize),
+    depth: usize,
+) -> Result<Vec<RowTok>, FrontendError> {
+    let mut toks = Vec::new();
+    let mut iter = children.into_iter().peekable();
+    while let Some(child) = iter.next() {
+        match child {
+            Child::Expr(e) => toks.push(RowTok::Operand(e)),
+            Child::Op(s) => {
+                if s == "(" || s == "[" {
+                    // Collect up to the matching close fence (depth-counted), recurse, wrap Group.
+                    let mut inner: Vec<Child> = Vec::new();
+                    let mut fence_depth = 1usize;
+                    for next in iter.by_ref() {
+                        if let Child::Op(o) = &next {
+                            if o == "(" || o == "[" {
+                                fence_depth += 1;
+                            } else if o == ")" || o == "]" {
+                                fence_depth -= 1;
+                                if fence_depth == 0 {
+                                    break;
+                                }
+                            }
+                        }
+                        inner.push(next);
+                    }
+                    if fence_depth != 0 {
+                        return err("unbalanced fence in MathML row", span);
+                    }
+                    let grouped = fold_row(inner, span, depth + 1)?;
+                    toks.push(RowTok::Operand(MathExpr::Group(Box::new(grouped))));
+                } else if s == ")" || s == "]" {
+                    return err("unmatched closing fence in MathML row", span);
+                } else if let Some(op) = operator_token(&s) {
+                    toks.push(op);
+                } else if s.is_empty() {
+                    // An invisible operator (InvisibleTimes / ApplyFunction): contributes nothing;
+                    // adjacency will become implicit multiplication.
+                } else {
+                    // An unrecognised operator glyph is preserved as a symbol operand so meaning is
+                    // not silently lost (e.g. a stray punctuation mark).
+                    toks.push(RowTok::Operand(MathExpr::Symbol(s)));
+                }
+            }
+        }
+    }
+    Ok(toks)
+}
+
+/// Map a `<mo>` glyph to a binary/relational operator, or `None` if it is not one we model.
+fn operator_token(s: &str) -> Option<RowTok> {
+    // One spelling per glyph: ASCII plus the Unicode math glyphs MathML commonly uses. `\u{2062}`
+    // is INVISIBLE TIMES (a literal U+2062 in `<mo>` content), distinct from the entity we already
+    // decode to "".
+    Some(match s {
+        "+" => RowTok::Bin(BinOp::Add),
+        "-" | "−" => RowTok::Bin(BinOp::Sub), // ASCII hyphen-minus, U+2212 MINUS SIGN
+        "*" | "×" | "·" | "⋅" | "\u{2062}" => RowTok::Bin(BinOp::Mul), // *, MULTIPLICATION, MIDDLE DOT, DOT OPERATOR, INVISIBLE TIMES
+        "/" | "÷" => RowTok::Bin(BinOp::Div),
+        "±" => RowTok::Bin(BinOp::PlusMinus),
+        "∓" => RowTok::Bin(BinOp::MinusPlus),
+        "=" => RowTok::Rel(RelOp::Eq),
+        "≠" => RowTok::Rel(RelOp::Ne),
+        "<" => RowTok::Rel(RelOp::Lt),
+        ">" => RowTok::Rel(RelOp::Gt),
+        "≤" => RowTok::Rel(RelOp::Le),
+        "≥" => RowTok::Rel(RelOp::Ge),
+        "≈" => RowTok::Rel(RelOp::Approx),
+        "≡" => RowTok::Rel(RelOp::Equiv),
+        _ => return None,
+    })
+}
+
+struct RowParser {
+    toks: Vec<RowTok>,
+    pos: usize,
+    span: (usize, usize),
+}
+
+impl RowParser {
+    fn parse_rel(&mut self) -> Result<MathExpr, FrontendError> {
+        let mut left = self.parse_add()?;
+        while let Some(RowTok::Rel(op)) = self.toks.get(self.pos) {
+            let op = *op;
+            self.pos += 1;
+            let right = self.parse_add()?;
+            left = MathExpr::Rel(op, Box::new(left), Box::new(right));
+        }
+        Ok(left)
+    }
+
+    fn parse_add(&mut self) -> Result<MathExpr, FrontendError> {
+        let mut left = self.parse_mul()?;
+        while let Some(RowTok::Bin(op @ (BinOp::Add | BinOp::Sub | BinOp::PlusMinus | BinOp::MinusPlus))) =
+            self.toks.get(self.pos)
+        {
+            let op = *op;
+            self.pos += 1;
+            let right = self.parse_mul()?;
+            left = MathExpr::Bin(op, Box::new(left), Box::new(right));
+        }
+        Ok(left)
+    }
+
+    fn parse_mul(&mut self) -> Result<MathExpr, FrontendError> {
+        let mut left = self.parse_unary()?;
+        loop {
+            match self.toks.get(self.pos) {
+                Some(RowTok::Bin(op @ (BinOp::Mul | BinOp::Div))) => {
+                    let op = *op;
+                    self.pos += 1;
+                    let right = self.parse_unary()?;
+                    left = MathExpr::Bin(op, Box::new(left), Box::new(right));
+                }
+                // Implicit multiplication: two operands adjacent with no operator between.
+                Some(RowTok::Operand(_)) => {
+                    let right = self.parse_unary()?;
+                    left = MathExpr::Bin(BinOp::Mul, Box::new(left), Box::new(right));
+                }
+                _ => break,
+            }
+        }
+        Ok(left)
+    }
+
+    fn parse_unary(&mut self) -> Result<MathExpr, FrontendError> {
+        // Collect a run of leading unary signs ITERATIVELY, then fold them back onto one atom.
+        // This must not recurse per sign: the signs of a row live in one flat token list at a
+        // single nesting level, so a recursive `parse_unary` would grow the call stack linearly
+        // with the operator count and a long run of `<mo>-</mo>` would overflow the stack (an
+        // uncatchable abort, defeating the panic-free contract). The loop keeps it O(1) in stack
+        // depth; the resulting (possibly deep) `Unary` chain is built and dropped iteratively.
+        let mut signs: Vec<UnaryOp> = Vec::new();
+        loop {
+            match self.toks.get(self.pos) {
+                Some(RowTok::Bin(BinOp::Add)) => {
+                    self.pos += 1;
+                    signs.push(UnaryOp::Pos);
+                }
+                Some(RowTok::Bin(BinOp::Sub)) => {
+                    self.pos += 1;
+                    signs.push(UnaryOp::Neg);
+                }
+                _ => break,
+            }
+        }
+        let mut e = self.parse_atom()?;
+        // Fold innermost-first so `+ - x` becomes `Unary(Pos, Unary(Neg, x))` (outermost = the
+        // first sign read).
+        for op in signs.into_iter().rev() {
+            e = MathExpr::Unary(op, Box::new(e));
+        }
+        Ok(e)
+    }
+
+    fn parse_atom(&mut self) -> Result<MathExpr, FrontendError> {
+        match self.toks.get(self.pos) {
+            Some(RowTok::Operand(_)) => {
+                // Take ownership of the operand by swapping in a placeholder.
+                let RowTok::Operand(e) =
+                    std::mem::replace(&mut self.toks[self.pos], RowTok::Operand(MathExpr::Symbol(String::new())))
+                else {
+                    unreachable!()
+                };
+                self.pos += 1;
+                Ok(e)
+            }
+            Some(RowTok::Bin(_)) | Some(RowTok::Rel(_)) => {
+                err("expected an operand in MathML row", self.span)
+            }
+            None => err("unexpected end of MathML row", self.span),
+        }
+    }
+}
+
+/// The crate entry point: parse a Presentation-MathML string into the neutral [`MathExpr`].
+pub fn parse(src: &str) -> Result<MathExpr, FrontendError> {
+    let events = Lexer::new(src).events()?;
+    let mut parser = Parser::new(events, src.len());
+    parser.parse_document()
+}

--- a/code/specs/PFE01-pluggable-parser-frontends.md
+++ b/code/specs/PFE01-pluggable-parser-frontends.md
@@ -152,10 +152,16 @@ frontend additionally ships notation-specific golden tests.
   named functions `sin cos … ln log exp` (PR-3, longest-match), and matrices `[[a,b],[c,d]]`
   (PR-4) — **full parity with AsciiMath** (only embedded `\text`, which has no Unicode equivalent,
   is out of scope).
-- Future: `mathml`, MathJSON, content-MathML, spreadsheet formulae, … each a small crate
-  implementing the trait. None require changes to consumers. **Three frontends now in (LaTeX,
-  AsciiMath, Unicode), all feeding one neutral AST with zero consumer change** — the pluggability
-  claim is demonstrated, not just asserted.
+- `mathml` — the **fourth** frontend: Presentation MathML, the XML notation (`<math>…</math>`)
+  that browsers and tools emit. A small crate with an XML-subset event lexer (attributes,
+  namespace prefixes, the XML declaration, comments, and DOCTYPE all ignored) and an element-tree
+  builder. PR-1 covers `<mn>`/`<mi>`/`<mtext>`/`<mo>`, `<mrow>` (operator precedence + implicit
+  multiplication + `(`…`)` fences), `<mfrac>`/`<msup>`/`<msub>`/`<msubsup>`/`<msqrt>`/`<mroot>`;
+  `<mtable>`, `<mover>`/`<munder>`, `<mfenced>`, and named-function recognition are PR-2.
+- Future: MathJSON, content-MathML, spreadsheet formulae, … each a small crate implementing the
+  trait. None require changes to consumers. **Four frontends now in (LaTeX, AsciiMath, Unicode,
+  MathML), all feeding one neutral AST with zero consumer change** — the pluggability claim is
+  demonstrated, not just asserted.
 
 ## 7. Non-goals
 


### PR DESCRIPTION
## PFE01 frontend #4 — Presentation MathML

A new crate `mathml`: `MathMl` implements `math_frontend::MathFrontend`, the **fourth pluggable parser frontend** after `latex`, `asciimath`, and `unicode-math`. It turns Presentation MathML (the XML notation `<math>…</math>` that browsers and tools emit) into the *same* neutral `MathExpr` AST the others produce — so a consumer supports MathML with **zero** change. PFE01's pluggability claim is now demonstrated across four genuinely different notations (a TeX macro language, a terse linear notation, a Unicode-symbol notation, and an XML tree).

### XML-subset event lexer
No general XML engine needed — Presentation MathML is a small regular tree. The lexer emits start/end/character-data events, **ignoring** attributes, namespace prefixes (`m:math` ≡ `math`), the XML declaration, comments, and DOCTYPE. Entities decode: the basic five, numeric `&#NN;`/`&#xHH;`, and common operator entities (`&times;`, `&middot;`, `&le;`, `&ge;`, `&ne;`, `&plusmn;`, …); unknown entities are preserved verbatim rather than dropped.

### Element coverage (PR-1)
| MathML | neutral `MathExpr` |
|---|---|
| `<mn>` / `<mi>` / `<mtext>` | `Number` (exact) / `Symbol` / `Text` |
| `<mo>` `+ - * / = < > ≤ ≥ ≠ ≈ ≡ ± ∓` (+ entity spellings) | the matching `Bin`/`Rel` |
| `<mrow>` | folded row: precedence (relations < ±∓+− < ×÷), implicit multiplication of adjacent operands, unary signs, `(`…`)` fences → `Group` |
| `<mfrac>` / `<msup>` / `<msub>` / `<msubsup>` | `Frac` / `Bin(Pow)` / `Subscript` / `Pow(Subscript)` |
| `<msqrt>` / `<mroot>` | `Root` (degree `None` / `Some`) |

`<math>`/`<mstyle>`/`<mpadded>` are transparent wrappers. **Deferred to PR-2:** `<mtable>` → `Matrix`, `<mover>`/`<munder>` → over/under-sets, `<mfenced>`, named-function recognition (`<mi>sin</mi>` → `Call`).

### Contract & robustness
- **Total, panic-free, spanned** (`#![forbid(unsafe_code)]`). A `MAX_DEPTH` guard bounds the element recursion **and** the `(`…`)` fence recursion; **unary-sign parsing is fully iterative** (collect signs in a loop, fold back) so even a flat run of 100k `<mo>-</mo>` parses without a stack overflow. The neutral tree drops iteratively.
- **Honest capabilities** (conformance-checked): fractions, roots, powers, relations, implicit_mul, text, plusminus.

### Verification
- `cargo test -p mathml` — **26 tests + doctest** green (leaves, precedence, implicit mul, fences, built-up structures, namespace/attribute/declaration skipping, cross-notation equivalences, spanned-error cases, the deep-nesting guard, the **100k-unary-run** regression, registry, conformance).
- `cargo clippy -p mathml -- -D warnings` — clean.
- `/security-review` — **PASSED** (two rounds): the reviewer found and reproduced a HIGH (unbounded recursion in unary parsing → stack-overflow abort on a flat sign run); fixed by making unary parsing iterative + added the regression test; re-review confirmed the whole precedence descent is non-cyclic (constant 5-frame depth) with no other unguarded recursion.

Workspace member added; `PFE01-pluggable-parser-frontends.md` updated (four frontends now in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)