### PR TITLE
feat(java-sql-optimizer): Java logical query optimizer (Level 1 prerequisite)

### DIFF
--- a/.claude/mini-sqlite-loop-state.json
+++ b/.claude/mini-sqlite-loop-state.json
@@ -141,11 +141,11 @@
     {
       "id": "java-level1-sql-optimizer",
       "title": "Java sql-optimizer",
-      "status": "pending",
+      "status": "in-review",
       "depends_on": ["java-level1-sql-planner"],
-      "branch": null,
+      "branch": "mini-sqlite/java-level1-sql-optimizer",
       "pr_number": null,
-      "notes": "Port Python sql_optimizer to Java."
+      "notes": "PR open 2026-06-30. 124 tests (JaCoCo ≥80%). 5 passes: ConstantFolding, PredicatePushdown, ProjectionPruning, DeadCodeElimination, LimitPushdown. Java 21 sealed interfaces + records."
     },
     {
       "id": "java-level1-sql-codegen",

--- a/.claude/mini-sqlite-loop-state.json
+++ b/.claude/mini-sqlite-loop-state.json
@@ -144,7 +144,7 @@
       "status": "in-review",
       "depends_on": ["java-level1-sql-planner"],
       "branch": "mini-sqlite/java-level1-sql-optimizer",
-      "pr_number": null,
+      "pr_number": 7073,
       "notes": "PR open 2026-06-30. 124 tests (JaCoCo ≥80%). 5 passes: ConstantFolding, PredicatePushdown, ProjectionPruning, DeadCodeElimination, LimitPushdown. Java 21 sealed interfaces + records."
     },
     {

--- a/code/packages/java/sql-optimizer/BUILD
+++ b/code/packages/java/sql-optimizer/BUILD
@@ -1,0 +1,2 @@
+(cd ../sql-planner && gradle jar --quiet)
+gradle test

--- a/code/packages/java/sql-optimizer/BUILD_windows
+++ b/code/packages/java/sql-optimizer/BUILD_windows
@@ -1,0 +1,2 @@
+(cd ../sql-planner && gradle jar --quiet)
+gradle test

--- a/code/packages/java/sql-optimizer/CHANGELOG.md
+++ b/code/packages/java/sql-optimizer/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog — coding-adventures-sql-optimizer (Java)
+
+All notable changes to this package are documented here.
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [0.1.0] — 2026-06-30
+
+### Added
+
+- `SqlOptimizer` — top-level class with static `optimize`, `optimizeWithPasses`,
+  `defaultPasses`, and `lift` API methods.
+- `SqlOptimizer.OptimizedPlan` sealed interface mirroring `SqlPlanner.LogicalPlan`
+  with all 15 variants plus:
+  - `EmptyResult` — a new leaf node for provably-empty subtrees.
+  - `Scan` extended with `requiredColumns` (nullable `List<String>`) and
+    `scanLimit` (nullable `Long`) annotations set by later passes.
+- `SqlOptimizer.Pass` interface — `name()` + `apply()` for composable transformations.
+- **Five default optimization passes** (in pipeline order):
+  1. `ConstantFolding` — arithmetic, comparison, Boolean short-circuit, NULL
+     propagation, IS NULL/IS NOT NULL on literals.
+  2. `PredicatePushdown` — AND-split + route conjuncts through Sort, Distinct,
+     Project, and INNER/CROSS Join sides; outer-join safety guards.
+  3. `ProjectionPruning` — top-down `(table, column)` required-set tracking;
+     annotates Scan nodes with the minimal column list.
+  4. `DeadCodeElimination` — converts `Filter(false)`, `Filter(null)`, `Limit(0)`,
+     and cascading EmptyResult into `EmptyResult`; removes `Filter(true)`.
+     Intentionally does NOT collapse `Aggregate(EmptyResult)`.
+  5. `LimitPushdown` — propagates `LIMIT N` (with no offset) through Project and
+     Filter to annotate Scan nodes with an early-stop row count.
+- 45 JUnit 5 tests; JaCoCo line coverage ≥ 80 %.

--- a/code/packages/java/sql-optimizer/README.md
+++ b/code/packages/java/sql-optimizer/README.md
@@ -1,0 +1,90 @@
+# coding-adventures-sql-optimizer (Java)
+
+A pure in-memory SQL logical query optimizer written in Java 21.
+
+## What it does
+
+`SqlOptimizer` transforms a `SqlPlanner.LogicalPlan` (from the
+`coding-adventures-sql-planner` package) into an `OptimizedPlan` by running a
+configurable pipeline of optimization passes.
+
+The five default passes are:
+
+| # | Pass                  | What it does                                                               |
+|---|-----------------------|----------------------------------------------------------------------------|
+| 1 | ConstantFolding       | Evaluates literal arithmetic, comparisons, Boolean logic, and NULL rules.  |
+| 2 | PredicatePushdown     | Moves Filter nodes closer to Scans; splits AND conjuncts for joins.        |
+| 3 | ProjectionPruning     | Annotates Scan nodes with only the columns they need to emit.              |
+| 4 | DeadCodeElimination   | Replaces provably-empty subtrees with `EmptyResult`; removes trivial TRUE filters. |
+| 5 | LimitPushdown         | Propagates `LIMIT N` to Scan nodes as an early-stop row count.             |
+
+## How it fits in the stack
+
+```
+sql-lexer → sql-parser → sql-planner → sql-optimizer → sql-codegen → sql-vm
+                                           ↑ this package
+```
+
+## Usage
+
+```java
+import com.codingadventures.sqlplanner.SqlPlanner;
+import com.codingadventures.sqloptimizer.SqlOptimizer;
+
+var schema  = new SqlPlanner.InMemorySchemaProvider(Map.of("users", List.of("id", "name", "age")));
+var planner = new SqlPlanner(schema);
+var logical = planner.plan(stmt);            // LogicalPlan
+var opt     = SqlOptimizer.optimize(logical); // OptimizedPlan
+```
+
+### Custom pass pipeline
+
+```java
+var opt = SqlOptimizer.optimizeWithPasses(logical, List.of(
+    new SqlOptimizer.ConstantFolding(),
+    new SqlOptimizer.DeadCodeElimination()
+));
+```
+
+### Implementing your own pass
+
+```java
+public class MyPass implements SqlOptimizer.Pass {
+    @Override public String name() { return "MyPass"; }
+    @Override public SqlOptimizer.OptimizedPlan apply(SqlOptimizer.OptimizedPlan plan) {
+        // ... transform and return
+        return plan;
+    }
+}
+```
+
+## OptimizedPlan extensions
+
+`OptimizedPlan` is a sealed interface mirroring `LogicalPlan`, with two additions:
+
+- **`EmptyResult`** — a leaf node meaning "zero rows will ever be produced".
+  Introduced by `DeadCodeElimination`; propagates upward through Filter, Sort,
+  Project, INNER/CROSS Join, etc.  Intentionally does *not* collapse
+  `Aggregate(EmptyResult)` because `SELECT COUNT(*) FROM empty` must return one row.
+
+- **`Scan` annotations** — `Scan` gains two nullable fields:
+  - `requiredColumns` — set by `ProjectionPruning`; the storage layer can read
+    only these columns.
+  - `scanLimit` — set by `LimitPushdown`; the storage layer can stop reading
+    after this many rows (only valid when there is no ORDER BY above).
+
+## Building & testing
+
+```bash
+# Build the sql-planner JAR first (dependency)
+cd ../sql-planner && gradle jar
+
+# Run tests + coverage check
+cd ../sql-optimizer
+gradle test           # runs 45+ tests; JaCoCo ≥80% line coverage required
+```
+
+## Requirements
+
+- Java 21 (sealed interfaces + records + pattern matching)
+- `coding-adventures-sql-planner` JAR on the classpath (built locally via Gradle)

--- a/code/packages/java/sql-optimizer/build.gradle.kts
+++ b/code/packages/java/sql-optimizer/build.gradle.kts
@@ -1,0 +1,60 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    java
+    `java-library`
+    jacoco
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    implementation(files("../sql-planner/gradle-build/libs/coding-adventures-sql-planner-0.1.0.jar"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+    finalizedBy(tasks.jacocoTestReport)
+}
+
+jacoco {
+    toolVersion = "0.8.12"
+}
+
+tasks.jacocoTestReport {
+    dependsOn(tasks.test)
+    reports {
+        xml.required.set(true)
+        html.required.set(true)
+    }
+}
+
+tasks.jacocoTestCoverageVerification {
+    dependsOn(tasks.jacocoTestReport)
+    violationRules {
+        rule {
+            limit {
+                counter = "LINE"
+                value = "COVEREDRATIO"
+                minimum = "0.80".toBigDecimal()
+            }
+        }
+    }
+}
+
+tasks.named("check") {
+    dependsOn(tasks.jacocoTestCoverageVerification)
+}

--- a/code/packages/java/sql-optimizer/required_capabilities.json
+++ b/code/packages/java/sql-optimizer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "java/sql-optimizer",
+  "capabilities": [],
+  "justification": "Pure in-memory optimizer library. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/java/sql-optimizer/settings.gradle.kts
+++ b/code/packages/java/sql-optimizer/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "coding-adventures-sql-optimizer"

--- a/code/packages/java/sql-optimizer/settings.gradle.kts
+++ b/code/packages/java/sql-optimizer/settings.gradle.kts
@@ -1,1 +1,7 @@
 rootProject.name = "coding-adventures-sql-optimizer"
+
+// Declare the local build dependency on sql-planner so the monorepo build tool
+// can construct the correct dependency graph edge (java/sql-optimizer →
+// java/sql-planner) and satisfy the BUILD file validator that checks all
+// relative path references in BUILD commands are declared predecessors.
+includeBuild("../sql-planner")

--- a/code/packages/java/sql-optimizer/src/main/java/com/codingadventures/sqloptimizer/SqlOptimizer.java
+++ b/code/packages/java/sql-optimizer/src/main/java/com/codingadventures/sqloptimizer/SqlOptimizer.java
@@ -503,8 +503,18 @@ public final class SqlOptimizer {
         private static int compareValues(Object a, Object b) {
             if (a instanceof Number na && b instanceof Number nb)
                 return Double.compare(na.doubleValue(), nb.doubleValue());
-            if (a instanceof Comparable ca)
+            if (a instanceof Comparable ca) {
+                // Guard against mixed-type comparison (e.g. String vs Long): the
+                // unchecked cast inside compareTo would throw ClassCastException
+                // with an opaque message.  We detect the mismatch early and
+                // report it clearly.
+                if (!a.getClass().isInstance(b))
+                    throw new IllegalArgumentException(
+                        "Cannot compare values of different types: "
+                        + a.getClass().getSimpleName() + " vs "
+                        + b.getClass().getSimpleName());
                 return ca.compareTo(b);
+            }
             throw new IllegalArgumentException("Cannot compare " + a + " with " + b);
         }
 

--- a/code/packages/java/sql-optimizer/src/main/java/com/codingadventures/sqloptimizer/SqlOptimizer.java
+++ b/code/packages/java/sql-optimizer/src/main/java/com/codingadventures/sqloptimizer/SqlOptimizer.java
@@ -1,0 +1,1261 @@
+package com.codingadventures.sqloptimizer;
+
+import com.codingadventures.sqlplanner.SqlPlanner;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+// SqlOptimizer.java — logical query plan optimizer for SQL.
+//
+// The optimizer transforms a LogicalPlan (produced by SqlPlanner) into an
+// OptimizedPlan by running a fixed sequence of analysis passes.  Each pass
+// is a pure function: it takes an OptimizedPlan and returns a new (possibly
+// smaller, flatter, or annotated) OptimizedPlan.
+//
+// The five default passes, in order:
+//
+//   1. ConstantFolding      — evaluate compile-time constants, propagate NULL
+//   2. PredicatePushdown    — move filters closer to the data they filter
+//   3. ProjectionPruning    — annotate Scans with only the columns they need
+//   4. DeadCodeElimination  — replace provably-empty subtrees with EmptyResult
+//   5. LimitPushdown        — annotate Scans with an early-stop row count
+//
+// All passes compose cleanly: the output of one is the input of the next.
+// Passes are idempotent: running them twice produces the same result as once.
+//
+// Usage:
+//   OptimizedPlan opt = SqlOptimizer.optimize(planner.plan(stmt));
+
+public final class SqlOptimizer {
+
+    // Private constructor: this class is a static-method namespace only.
+    private SqlOptimizer() {}
+
+    // ── OptimizedPlan sealed interface ────────────────────────────────────────
+    //
+    // OptimizedPlan mirrors LogicalPlan but:
+    //   • Scan gains two nullable annotations set by the optimizer passes:
+    //       - requiredColumns: column names this scan must actually emit
+    //       - scanLimit:       the optimizer has proven the caller needs at
+    //                          most this many rows
+    //   • EmptyResult is a new leaf indicating zero rows will ever be produced.
+    //     Dead-code elimination introduces it wherever a predicate is statically
+    //     false or a LIMIT 0 is encountered.
+
+    public sealed interface OptimizedPlan
+        permits OptimizedPlan.Scan, OptimizedPlan.Filter, OptimizedPlan.Project,
+                OptimizedPlan.Join, OptimizedPlan.Aggregate, OptimizedPlan.Having,
+                OptimizedPlan.Sort, OptimizedPlan.Limit, OptimizedPlan.Distinct,
+                OptimizedPlan.Union, OptimizedPlan.Insert, OptimizedPlan.Update,
+                OptimizedPlan.Delete, OptimizedPlan.CreateTable, OptimizedPlan.DropTable,
+                OptimizedPlan.EmptyResult {
+
+        /**
+         * A base table scan.
+         * <p>
+         * {@code requiredColumns} — when non-null, only these column names need to
+         * be read from storage.  Null means "all columns" (SELECT *).
+         * <p>
+         * {@code scanLimit} — when non-null, the engine may stop reading after this
+         * many rows.  Only correct when there is no ordering requirement above.
+         */
+        record Scan(String table, String alias,
+                    List<String> requiredColumns, Long scanLimit)
+            implements OptimizedPlan {
+
+            // Convenience constructor used by lift() and tests.
+            public Scan(String table, String alias) {
+                this(table, alias, null, null);
+            }
+        }
+
+        record Filter(OptimizedPlan input, SqlPlanner.SqlExpr predicate)
+            implements OptimizedPlan {}
+
+        record Project(OptimizedPlan input, List<SqlPlanner.OutputColumn> columns)
+            implements OptimizedPlan {}
+
+        record Join(OptimizedPlan left, OptimizedPlan right,
+                    SqlPlanner.JoinKind kind, SqlPlanner.SqlExpr condition)
+            implements OptimizedPlan {}
+
+        record Aggregate(OptimizedPlan input,
+                         List<SqlPlanner.SqlExpr> groupBy,
+                         List<SqlPlanner.AggregateItem> aggregates)
+            implements OptimizedPlan {}
+
+        record Having(OptimizedPlan input, SqlPlanner.SqlExpr predicate)
+            implements OptimizedPlan {}
+
+        record Sort(OptimizedPlan input, List<SqlPlanner.SortKey> keys)
+            implements OptimizedPlan {}
+
+        record Limit(OptimizedPlan input, Long count, Long offset)
+            implements OptimizedPlan {}
+
+        record Distinct(OptimizedPlan input) implements OptimizedPlan {}
+
+        record Union(OptimizedPlan left, OptimizedPlan right, boolean all)
+            implements OptimizedPlan {}
+
+        record Insert(String table, List<String> columns,
+                      List<List<SqlPlanner.SqlExpr>> values)
+            implements OptimizedPlan {}
+
+        record Update(String table, List<SqlPlanner.Assignment> assignments,
+                      SqlPlanner.SqlExpr predicate)
+            implements OptimizedPlan {}
+
+        record Delete(String table, SqlPlanner.SqlExpr predicate)
+            implements OptimizedPlan {}
+
+        record CreateTable(String table, boolean ifNotExists,
+                           List<SqlPlanner.ColumnDef> columns)
+            implements OptimizedPlan {}
+
+        record DropTable(String table, boolean ifExists)
+            implements OptimizedPlan {}
+
+        /**
+         * A sentinel node meaning "this subtree produces zero rows".
+         * Introduced by DeadCodeElimination; propagated upward through operators
+         * that cannot manufacture rows from nothing (Filter, Sort, Project, etc.).
+         */
+        record EmptyResult() implements OptimizedPlan {}
+    }
+
+    // ── Pass interface ────────────────────────────────────────────────────────
+    //
+    // A Pass is any tree transformation.  Passes are composable and named so
+    // that a pipeline can be described in log output.
+
+    public interface Pass {
+        /** A short human-readable label for this pass, e.g. "ConstantFolding". */
+        String name();
+
+        /**
+         * Transform {@code plan} into a (possibly new) OptimizedPlan.
+         * Must not modify the input; must return a structurally equal plan
+         * if no transformation applies.
+         */
+        OptimizedPlan apply(OptimizedPlan plan);
+    }
+
+    // ── Public API ─────────────────────────────────────────────────────────────
+
+    /**
+     * Convert a LogicalPlan to an OptimizedPlan and run all five default passes.
+     * This is the primary entry point for callers.
+     */
+    public static OptimizedPlan optimize(SqlPlanner.LogicalPlan plan) {
+        return optimizeWithPasses(plan, defaultPasses());
+    }
+
+    /**
+     * Convert a LogicalPlan to an OptimizedPlan and run the supplied passes
+     * in order.  An empty list is valid (returns the lifted plan unchanged).
+     */
+    public static OptimizedPlan optimizeWithPasses(SqlPlanner.LogicalPlan plan,
+                                                    List<Pass> passes) {
+        OptimizedPlan current = lift(plan);
+        for (var pass : passes) {
+            current = pass.apply(current);
+        }
+        return current;
+    }
+
+    /**
+     * Returns the five default optimization passes in their canonical order:
+     *   ConstantFolding → PredicatePushdown → ProjectionPruning →
+     *   DeadCodeElimination → LimitPushdown
+     */
+    public static List<Pass> defaultPasses() {
+        return List.of(
+            new ConstantFolding(),
+            new PredicatePushdown(),
+            new ProjectionPruning(),
+            new DeadCodeElimination(),
+            new LimitPushdown()
+        );
+    }
+
+    /**
+     * Convert a LogicalPlan tree to an OptimizedPlan tree without running any
+     * optimization passes.  Scan nodes are annotated with (null, null) for
+     * requiredColumns and scanLimit.
+     */
+    public static OptimizedPlan lift(SqlPlanner.LogicalPlan plan) {
+        return switch (plan) {
+            case SqlPlanner.LogicalPlan.Scan(var t, var a) ->
+                new OptimizedPlan.Scan(t, a, null, null);
+
+            case SqlPlanner.LogicalPlan.Filter(var input, var pred) ->
+                new OptimizedPlan.Filter(lift(input), pred);
+
+            case SqlPlanner.LogicalPlan.Project(var input, var cols) ->
+                new OptimizedPlan.Project(lift(input), cols);
+
+            case SqlPlanner.LogicalPlan.Join(var l, var r, var kind, var cond) ->
+                new OptimizedPlan.Join(lift(l), lift(r), kind, cond);
+
+            case SqlPlanner.LogicalPlan.Aggregate(var input, var gb, var aggs) ->
+                new OptimizedPlan.Aggregate(lift(input), gb, aggs);
+
+            case SqlPlanner.LogicalPlan.Having(var input, var pred) ->
+                new OptimizedPlan.Having(lift(input), pred);
+
+            case SqlPlanner.LogicalPlan.Sort(var input, var keys) ->
+                new OptimizedPlan.Sort(lift(input), keys);
+
+            case SqlPlanner.LogicalPlan.Limit(var input, var count, var offset) ->
+                new OptimizedPlan.Limit(lift(input), count, offset);
+
+            case SqlPlanner.LogicalPlan.Distinct(var input) ->
+                new OptimizedPlan.Distinct(lift(input));
+
+            case SqlPlanner.LogicalPlan.Union(var l, var r, var all) ->
+                new OptimizedPlan.Union(lift(l), lift(r), all);
+
+            case SqlPlanner.LogicalPlan.Insert(var tbl, var cols, var vals) ->
+                new OptimizedPlan.Insert(tbl, cols, vals);
+
+            case SqlPlanner.LogicalPlan.Update(var tbl, var asgns, var pred) ->
+                new OptimizedPlan.Update(tbl, asgns, pred);
+
+            case SqlPlanner.LogicalPlan.Delete(var tbl, var pred) ->
+                new OptimizedPlan.Delete(tbl, pred);
+
+            case SqlPlanner.LogicalPlan.CreateTable(var tbl, var ine, var colDefs) ->
+                new OptimizedPlan.CreateTable(tbl, ine, colDefs);
+
+            case SqlPlanner.LogicalPlan.DropTable(var tbl, var ie) ->
+                new OptimizedPlan.DropTable(tbl, ie);
+        };
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Pass 1 — Constant Folding
+    // ═══════════════════════════════════════════════════════════════════════════
+    //
+    // Evaluates expressions that can be resolved at compile time:
+    //
+    //   • Arithmetic on two literal numbers    (1 + 2 → 3)
+    //   • Comparison of two literal values     (1 < 2 → true)
+    //   • Short-circuit Boolean logic          (x AND false → false)
+    //   • NULL propagation                     (NULL + 5 → NULL)
+    //   • Unary NOT / NEG on literals          (NOT true → false)
+    //   • IS NULL / IS NOT NULL on literals    (IS NULL(null) → true)
+    //
+    // The pass is bottom-up: children are folded before parents, so folded
+    // sub-expressions become available for further folding above them.
+
+    public static final class ConstantFolding implements Pass {
+        @Override public String name() { return "ConstantFolding"; }
+
+        @Override
+        public OptimizedPlan apply(OptimizedPlan plan) {
+            return transformPlan(plan);
+        }
+
+        // ── Plan-level traversal ─────────────────────────────────────────────
+
+        private OptimizedPlan transformPlan(OptimizedPlan plan) {
+            return switch (plan) {
+                case OptimizedPlan.Filter(var input, var pred) ->
+                    new OptimizedPlan.Filter(transformPlan(input), foldExpr(pred));
+
+                case OptimizedPlan.Project(var input, var cols) ->
+                    new OptimizedPlan.Project(transformPlan(input), foldOutputCols(cols));
+
+                case OptimizedPlan.Join(var l, var r, var kind, var cond) ->
+                    new OptimizedPlan.Join(transformPlan(l), transformPlan(r), kind,
+                                           cond != null ? foldExpr(cond) : null);
+
+                case OptimizedPlan.Aggregate(var input, var gb, var aggs) ->
+                    new OptimizedPlan.Aggregate(transformPlan(input),
+                                                gb.stream().map(this::foldExpr).toList(),
+                                                aggs);
+
+                case OptimizedPlan.Having(var input, var pred) ->
+                    new OptimizedPlan.Having(transformPlan(input), foldExpr(pred));
+
+                case OptimizedPlan.Sort(var input, var keys) ->
+                    new OptimizedPlan.Sort(transformPlan(input),
+                                           keys.stream().map(k ->
+                                               new SqlPlanner.SortKey(foldExpr(k.keyExpr()),
+                                                                       k.direction(),
+                                                                       k.nullOrder())).toList());
+
+                case OptimizedPlan.Limit(var input, var count, var offset) ->
+                    new OptimizedPlan.Limit(transformPlan(input), count, offset);
+
+                case OptimizedPlan.Distinct(var input) ->
+                    new OptimizedPlan.Distinct(transformPlan(input));
+
+                case OptimizedPlan.Union(var l, var r, var all) ->
+                    new OptimizedPlan.Union(transformPlan(l), transformPlan(r), all);
+
+                // Leaf nodes and DML — no scalar expressions in their "body"
+                // that benefit from folding (INSERT values could be folded but
+                // it is not required for optimizer correctness).
+                default -> plan;
+            };
+        }
+
+        private List<SqlPlanner.OutputColumn> foldOutputCols(List<SqlPlanner.OutputColumn> cols) {
+            var out = new ArrayList<SqlPlanner.OutputColumn>(cols.size());
+            for (var c : cols) {
+                out.add(switch (c) {
+                    case SqlPlanner.OutputColumn.Star s -> s;
+                    case SqlPlanner.OutputColumn.Expr(var expr, var alias) ->
+                        new SqlPlanner.OutputColumn.Expr(foldExpr(expr), alias);
+                });
+            }
+            return out;
+        }
+
+        // ── Expression folding (bottom-up) ───────────────────────────────────
+
+        SqlPlanner.SqlExpr foldExpr(SqlPlanner.SqlExpr expr) {
+            return switch (expr) {
+                // ── Recurse and then try to fold the result ──────────────────
+                case SqlPlanner.SqlExpr.BinaryOp(var op, var l, var r) -> {
+                    var fl = foldExpr(l);
+                    var fr = foldExpr(r);
+                    yield foldBinary(op, fl, fr);
+                }
+
+                case SqlPlanner.SqlExpr.UnaryOp(var op, var operand) -> {
+                    var fo = foldExpr(operand);
+                    yield foldUnary(op, fo);
+                }
+
+                case SqlPlanner.SqlExpr.IsNull(var operand) -> {
+                    var fo = foldExpr(operand);
+                    if (fo instanceof SqlPlanner.SqlExpr.Literal(var v))
+                        yield new SqlPlanner.SqlExpr.Literal(v == null);
+                    yield new SqlPlanner.SqlExpr.IsNull(fo);
+                }
+
+                case SqlPlanner.SqlExpr.IsNotNull(var operand) -> {
+                    var fo = foldExpr(operand);
+                    if (fo instanceof SqlPlanner.SqlExpr.Literal(var v))
+                        yield new SqlPlanner.SqlExpr.Literal(v != null);
+                    yield new SqlPlanner.SqlExpr.IsNotNull(fo);
+                }
+
+                case SqlPlanner.SqlExpr.FuncCall(var name, var args) ->
+                    new SqlPlanner.SqlExpr.FuncCall(name, args.stream().map(this::foldExpr).toList());
+
+                case SqlPlanner.SqlExpr.Between(var v, var lo, var hi) ->
+                    new SqlPlanner.SqlExpr.Between(foldExpr(v), foldExpr(lo), foldExpr(hi));
+
+                case SqlPlanner.SqlExpr.In(var v, var items) ->
+                    new SqlPlanner.SqlExpr.In(foldExpr(v), items.stream().map(this::foldExpr).toList());
+
+                case SqlPlanner.SqlExpr.NotIn(var v, var items) ->
+                    new SqlPlanner.SqlExpr.NotIn(foldExpr(v), items.stream().map(this::foldExpr).toList());
+
+                // Leaves — nothing to fold.
+                default -> expr;
+            };
+        }
+
+        // ── Binary folding ───────────────────────────────────────────────────
+
+        private SqlPlanner.SqlExpr foldBinary(SqlPlanner.BinaryOperator op,
+                                               SqlPlanner.SqlExpr fl,
+                                               SqlPlanner.SqlExpr fr) {
+            // Short-circuit Boolean rules that don't require BOTH sides to be literals.
+            //
+            //   TRUE  AND x  → x        FALSE AND x → FALSE
+            //   TRUE  OR  x  → TRUE     FALSE OR  x → x
+            //   x     AND TRUE → x      x     AND FALSE → FALSE
+            //   x     OR  TRUE → TRUE   x     OR  FALSE → x
+
+            if (op == SqlPlanner.BinaryOperator.AND) {
+                if (isLiteral(fl, Boolean.FALSE)) return lit(false);
+                if (isLiteral(fr, Boolean.FALSE)) return lit(false);
+                if (isLiteral(fl, Boolean.TRUE))  return fr;
+                if (isLiteral(fr, Boolean.TRUE))  return fl;
+            }
+
+            if (op == SqlPlanner.BinaryOperator.OR) {
+                if (isLiteral(fl, Boolean.TRUE))  return lit(true);
+                if (isLiteral(fr, Boolean.TRUE))  return lit(true);
+                if (isLiteral(fl, Boolean.FALSE)) return fr;
+                if (isLiteral(fr, Boolean.FALSE)) return fl;
+            }
+
+            // NULL propagation — anything op NULL → NULL
+            // (after AND/OR short-circuit checks above so that TRUE OR NULL → TRUE).
+            if (isNull(fl) || isNull(fr)) return lit(null);
+
+            // From here both sides must be non-null literals for folding to apply.
+            if (!(fl instanceof SqlPlanner.SqlExpr.Literal(var lv)) ||
+                !(fr instanceof SqlPlanner.SqlExpr.Literal(var rv))) {
+                return new SqlPlanner.SqlExpr.BinaryOp(op, fl, fr);
+            }
+
+            return switch (op) {
+                case ADD  -> numericOp(lv, rv, (a, b) -> a + b, (a, b) -> a + b);
+                case SUB  -> numericOp(lv, rv, (a, b) -> a - b, (a, b) -> a - b);
+                case MUL  -> numericOp(lv, rv, (a, b) -> a * b, (a, b) -> a * b);
+                case DIV  -> {
+                    // Division by zero is left for the VM to handle at runtime.
+                    if ((rv instanceof Long && (Long) rv == 0L) ||
+                        (rv instanceof Double && (Double) rv == 0.0))
+                        yield new SqlPlanner.SqlExpr.BinaryOp(op, fl, fr);
+                    yield numericOp(lv, rv,
+                        (a, b) -> a / b,
+                        (a, b) -> a / b);
+                }
+                case MOD  -> {
+                    if ((rv instanceof Long && (Long) rv == 0L) ||
+                        (rv instanceof Double && (Double) rv == 0.0))
+                        yield new SqlPlanner.SqlExpr.BinaryOp(op, fl, fr);
+                    yield numericOp(lv, rv,
+                        (a, b) -> a % b,
+                        (a, b) -> a % b);
+                }
+                case EQ    -> lit(compareValues(lv, rv) == 0);
+                case NOT_EQ -> lit(compareValues(lv, rv) != 0);
+                case LT    -> lit(compareValues(lv, rv) < 0);
+                case LTE   -> lit(compareValues(lv, rv) <= 0);
+                case GT    -> lit(compareValues(lv, rv) > 0);
+                case GTE   -> lit(compareValues(lv, rv) >= 0);
+                // AND / OR with two non-null, non-boolean literals shouldn't
+                // reach here after the short-circuit guard above, but be safe.
+                case AND   -> {
+                    if (lv instanceof Boolean lb && rv instanceof Boolean rb)
+                        yield lit(lb && rb);
+                    yield new SqlPlanner.SqlExpr.BinaryOp(op, fl, fr);
+                }
+                case OR    -> {
+                    if (lv instanceof Boolean lb && rv instanceof Boolean rb)
+                        yield lit(lb || rb);
+                    yield new SqlPlanner.SqlExpr.BinaryOp(op, fl, fr);
+                }
+            };
+        }
+
+        // ── Unary folding ────────────────────────────────────────────────────
+
+        private SqlPlanner.SqlExpr foldUnary(SqlPlanner.UnaryOperator op,
+                                              SqlPlanner.SqlExpr fo) {
+            if (!(fo instanceof SqlPlanner.SqlExpr.Literal(var v)))
+                return new SqlPlanner.SqlExpr.UnaryOp(op, fo);
+
+            if (v == null) return lit(null);    // NULL propagation
+
+            return switch (op) {
+                case NOT -> {
+                    if (v instanceof Boolean b) yield lit(!b);
+                    yield new SqlPlanner.SqlExpr.UnaryOp(op, fo);
+                }
+                case NEG -> {
+                    if (v instanceof Long l) yield lit(-l);
+                    if (v instanceof Double d) yield lit(-d);
+                    if (v instanceof Integer i) yield lit((long) -i);
+                    yield new SqlPlanner.SqlExpr.UnaryOp(op, fo);
+                }
+            };
+        }
+
+        // ── Arithmetic helpers ────────────────────────────────────────────────
+
+        @FunctionalInterface interface LongBinaryOp  { long  apply(long  a, long  b); }
+        @FunctionalInterface interface DoubleBinaryOp { double apply(double a, double b); }
+
+        private SqlPlanner.SqlExpr numericOp(Object lv, Object rv,
+                                              LongBinaryOp longOp,
+                                              DoubleBinaryOp doubleOp) {
+            if (lv instanceof Long l && rv instanceof Long r)
+                return lit(longOp.apply(l, r));
+            if (lv instanceof Integer li && rv instanceof Integer ri)
+                return lit(longOp.apply(li.longValue(), ri.longValue()));
+            if (lv instanceof Integer li && rv instanceof Long r)
+                return lit(longOp.apply(li.longValue(), r));
+            if (lv instanceof Long l && rv instanceof Integer ri)
+                return lit(longOp.apply(l, ri.longValue()));
+
+            double dl = toDouble(lv), dr = toDouble(rv);
+            return lit(doubleOp.apply(dl, dr));
+        }
+
+        private static double toDouble(Object v) {
+            if (v instanceof Double d) return d;
+            if (v instanceof Float f)  return f.doubleValue();
+            if (v instanceof Long l)   return l.doubleValue();
+            if (v instanceof Integer i) return i.doubleValue();
+            throw new IllegalArgumentException("Not a number: " + v);
+        }
+
+        // ── Comparison helper ─────────────────────────────────────────────────
+        //
+        // Compares two non-null literal values.  Numbers are compared by
+        // promoting both to double so that comparing Long and Double works.
+
+        @SuppressWarnings("unchecked")
+        private static int compareValues(Object a, Object b) {
+            if (a instanceof Number na && b instanceof Number nb)
+                return Double.compare(na.doubleValue(), nb.doubleValue());
+            if (a instanceof Comparable ca)
+                return ca.compareTo(b);
+            throw new IllegalArgumentException("Cannot compare " + a + " with " + b);
+        }
+
+        // ── Convenience constructors ─────────────────────────────────────────
+
+        private static SqlPlanner.SqlExpr lit(Object v) {
+            return new SqlPlanner.SqlExpr.Literal(v);
+        }
+
+        private static boolean isLiteral(SqlPlanner.SqlExpr e, Object expected) {
+            return e instanceof SqlPlanner.SqlExpr.Literal(var v) && expected.equals(v);
+        }
+
+        private static boolean isNull(SqlPlanner.SqlExpr e) {
+            return e instanceof SqlPlanner.SqlExpr.Literal(var v) && v == null;
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Pass 2 — Predicate Pushdown
+    // ═══════════════════════════════════════════════════════════════════════════
+    //
+    // Moves Filter nodes downward (closer to the Scan they filter).
+    // A filter pushed closer to its data source reduces the number of rows that
+    // flow upward through the rest of the plan.
+    //
+    // The pass splits AND conjuncts and tries to place each one as low as
+    // possible.  The routing rules are:
+    //
+    //   • Filter → Sort or Distinct   : always safe; push through
+    //   • Filter → Project            : push through (conservative: only when the
+    //                                   predicate can be resolved against the
+    //                                   scan aliases below the project)
+    //   • Filter → Join               : push conjunct to whichever side owns all
+    //                                   of the referenced column aliases:
+    //                                     LEFT  JOIN  : only push to left side
+    //                                     RIGHT JOIN  : only push to right side
+    //                                     FULL  JOIN  : keep above (push neither)
+    //                                     INNER/CROSS : push to either/both
+    //   • Filter → Aggregate, Limit,
+    //              Union, Having      : do NOT push (semantics change or it's wrong)
+
+    public static final class PredicatePushdown implements Pass {
+        @Override public String name() { return "PredicatePushdown"; }
+
+        @Override
+        public OptimizedPlan apply(OptimizedPlan plan) {
+            return transformPlan(plan);
+        }
+
+        // ── Plan traversal ───────────────────────────────────────────────────
+
+        private OptimizedPlan transformPlan(OptimizedPlan plan) {
+            return switch (plan) {
+                // The interesting case: try to push the filter downward.
+                case OptimizedPlan.Filter(var input, var pred) -> {
+                    var pushedInput = transformPlan(input);   // recurse first
+                    yield pushFilter(pushedInput, pred);
+                }
+
+                // Non-filter nodes: just recurse into their children.
+                case OptimizedPlan.Project(var input, var cols) ->
+                    new OptimizedPlan.Project(transformPlan(input), cols);
+
+                case OptimizedPlan.Join(var l, var r, var kind, var cond) ->
+                    new OptimizedPlan.Join(transformPlan(l), transformPlan(r), kind, cond);
+
+                case OptimizedPlan.Aggregate(var input, var gb, var aggs) ->
+                    new OptimizedPlan.Aggregate(transformPlan(input), gb, aggs);
+
+                case OptimizedPlan.Having(var input, var pred) ->
+                    new OptimizedPlan.Having(transformPlan(input), pred);
+
+                case OptimizedPlan.Sort(var input, var keys) ->
+                    new OptimizedPlan.Sort(transformPlan(input), keys);
+
+                case OptimizedPlan.Limit(var input, var count, var offset) ->
+                    new OptimizedPlan.Limit(transformPlan(input), count, offset);
+
+                case OptimizedPlan.Distinct(var input) ->
+                    new OptimizedPlan.Distinct(transformPlan(input));
+
+                case OptimizedPlan.Union(var l, var r, var all) ->
+                    new OptimizedPlan.Union(transformPlan(l), transformPlan(r), all);
+
+                default -> plan;
+            };
+        }
+
+        // ── Core pushdown logic ───────────────────────────────────────────────
+
+        /**
+         * Attempt to push {@code pred} through {@code input}.
+         * If it cannot be pushed, wraps it in a new Filter node.
+         */
+        private OptimizedPlan pushFilter(OptimizedPlan input, SqlPlanner.SqlExpr pred) {
+            // Split the predicate into AND conjuncts; each is pushed independently.
+            var conjuncts = splitAnd(pred);
+            return pushConjuncts(input, conjuncts);
+        }
+
+        private OptimizedPlan pushConjuncts(OptimizedPlan input,
+                                             List<SqlPlanner.SqlExpr> conjuncts) {
+            return switch (input) {
+                // Push through Sort: Sort(Filter(x)) = Filter(Sort(x)) because
+                // ordering does not depend on row count.
+                case OptimizedPlan.Sort(var child, var keys) -> {
+                    var pushed = pushConjuncts(child, conjuncts);
+                    yield new OptimizedPlan.Sort(pushed, keys);
+                }
+
+                // Push through Distinct: same reasoning — predicate doesn't affect
+                // which distinct values exist, only how many rows we keep.
+                case OptimizedPlan.Distinct(var child) -> {
+                    var pushed = pushConjuncts(child, conjuncts);
+                    yield new OptimizedPlan.Distinct(pushed);
+                }
+
+                // Push through Project conservatively: push only if the predicate's
+                // column references can be satisfied by the aliases visible below
+                // the project.
+                case OptimizedPlan.Project(var child, var cols) -> {
+                    var belowAliases = collectAliases(child);
+                    var canPush  = new ArrayList<SqlPlanner.SqlExpr>();
+                    var mustKeep = new ArrayList<SqlPlanner.SqlExpr>();
+                    for (var c : conjuncts) {
+                        var refs = columnAliases(c);
+                        // If all referenced aliases exist below the project, push.
+                        if (refs.isEmpty() || belowAliases.containsAll(refs))
+                            canPush.add(c);
+                        else
+                            mustKeep.add(c);
+                    }
+                    OptimizedPlan result = new OptimizedPlan.Project(
+                        pushConjuncts(child, canPush), cols);
+                    result = wrapFilters(result, mustKeep);
+                    yield result;
+                }
+
+                // Push through Join — conjuncts are routed by alias ownership.
+                case OptimizedPlan.Join(var left, var right, var kind, var cond) -> {
+                    var leftAliases  = collectAliases(left);
+                    var rightAliases = collectAliases(right);
+
+                    var toLeft   = new ArrayList<SqlPlanner.SqlExpr>();
+                    var toRight  = new ArrayList<SqlPlanner.SqlExpr>();
+                    var keepHere = new ArrayList<SqlPlanner.SqlExpr>();
+
+                    for (var c : conjuncts) {
+                        var refs = columnAliases(c);
+                        boolean refsLeft  = !Collections.disjoint(refs, leftAliases)  || (refs.isEmpty());
+                        boolean refsRight = !Collections.disjoint(refs, rightAliases) || (refs.isEmpty());
+
+                        // A conjunct that references no columns (e.g. literal) can go
+                        // to either side; we route it left by convention.
+                        if (refs.isEmpty()) { toLeft.add(c); continue; }
+
+                        boolean onlyLeft  = leftAliases.containsAll(refs);
+                        boolean onlyRight = rightAliases.containsAll(refs);
+                        boolean bothSides = refsLeft && refsRight && !onlyLeft && !onlyRight;
+
+                        if (bothSides) {
+                            keepHere.add(c);
+                        } else if (onlyLeft) {
+                            // Outer join safety: don't push to left of RIGHT JOIN or either of FULL.
+                            if (kind == SqlPlanner.JoinKind.RIGHT || kind == SqlPlanner.JoinKind.FULL)
+                                keepHere.add(c);
+                            else
+                                toLeft.add(c);
+                        } else if (onlyRight) {
+                            // Don't push to right of LEFT JOIN or either of FULL.
+                            if (kind == SqlPlanner.JoinKind.LEFT || kind == SqlPlanner.JoinKind.FULL)
+                                keepHere.add(c);
+                            else
+                                toRight.add(c);
+                        } else {
+                            keepHere.add(c);
+                        }
+                    }
+
+                    var newLeft  = pushConjuncts(left,  toLeft);
+                    var newRight = pushConjuncts(right, toRight);
+                    OptimizedPlan result = new OptimizedPlan.Join(newLeft, newRight, kind, cond);
+                    result = wrapFilters(result, keepHere);
+                    yield result;
+                }
+
+                // Cannot push through Aggregate, Limit, Having, Union, or leaf nodes.
+                default -> wrapFilters(input, conjuncts);
+            };
+        }
+
+        // ── Helpers ──────────────────────────────────────────────────────────
+
+        /** Wrap {@code plan} in Filter nodes for each conjunct in order. */
+        private static OptimizedPlan wrapFilters(OptimizedPlan plan,
+                                                  List<SqlPlanner.SqlExpr> conjuncts) {
+            var result = plan;
+            for (var c : conjuncts)
+                result = new OptimizedPlan.Filter(result, c);
+            return result;
+        }
+
+        /** Split an expression on AND into its top-level conjuncts. */
+        static List<SqlPlanner.SqlExpr> splitAnd(SqlPlanner.SqlExpr expr) {
+            var parts = new ArrayList<SqlPlanner.SqlExpr>();
+            splitAndInto(expr, parts);
+            return parts;
+        }
+
+        private static void splitAndInto(SqlPlanner.SqlExpr expr,
+                                          List<SqlPlanner.SqlExpr> acc) {
+            if (expr instanceof SqlPlanner.SqlExpr.BinaryOp(var op, var l, var r)
+                && op == SqlPlanner.BinaryOperator.AND) {
+                splitAndInto(l, acc);
+                splitAndInto(r, acc);
+            } else {
+                acc.add(expr);
+            }
+        }
+
+        /**
+         * Collect all table-alias names that appear in Scan nodes under {@code plan}.
+         * These are the aliases that predicates can reference to be pushed below.
+         */
+        static Set<String> collectAliases(OptimizedPlan plan) {
+            var aliases = new HashSet<String>();
+            collectAliasesInto(plan, aliases);
+            return aliases;
+        }
+
+        private static void collectAliasesInto(OptimizedPlan plan, Set<String> acc) {
+            switch (plan) {
+                case OptimizedPlan.Scan(var t, var a, var rc, var sl) -> {
+                    acc.add(a != null ? a : t);
+                }
+                case OptimizedPlan.Filter(var input, var p) -> collectAliasesInto(input, acc);
+                case OptimizedPlan.Project(var input, var c) -> collectAliasesInto(input, acc);
+                case OptimizedPlan.Join(var l, var r, var k, var c) -> {
+                    collectAliasesInto(l, acc);
+                    collectAliasesInto(r, acc);
+                }
+                case OptimizedPlan.Aggregate(var input, var g, var ag) -> collectAliasesInto(input, acc);
+                case OptimizedPlan.Having(var input, var p) -> collectAliasesInto(input, acc);
+                case OptimizedPlan.Sort(var input, var k) -> collectAliasesInto(input, acc);
+                case OptimizedPlan.Limit(var input, var c, var o) -> collectAliasesInto(input, acc);
+                case OptimizedPlan.Distinct(var input) -> collectAliasesInto(input, acc);
+                case OptimizedPlan.Union(var l, var r, var al) -> {
+                    collectAliasesInto(l, acc);
+                    collectAliasesInto(r, acc);
+                }
+                default -> {} // leaf DML nodes
+            }
+        }
+
+        /**
+         * Return the set of table qualifiers (the "table" field of Column nodes)
+         * used anywhere in {@code expr}.  An empty set means the expression has
+         * no Column references at all.
+         */
+        static Set<String> columnAliases(SqlPlanner.SqlExpr expr) {
+            var refs = new HashSet<String>();
+            collectColumnAliasesInto(expr, refs);
+            return refs;
+        }
+
+        private static void collectColumnAliasesInto(SqlPlanner.SqlExpr expr,
+                                                       Set<String> acc) {
+            switch (expr) {
+                case SqlPlanner.SqlExpr.Column(var t, var c) -> { if (t != null) acc.add(t); }
+                case SqlPlanner.SqlExpr.BinaryOp(var op, var l, var r) -> {
+                    collectColumnAliasesInto(l, acc);
+                    collectColumnAliasesInto(r, acc);
+                }
+                case SqlPlanner.SqlExpr.UnaryOp(var op, var o) -> collectColumnAliasesInto(o, acc);
+                case SqlPlanner.SqlExpr.FuncCall(var n, var args) ->
+                    args.forEach(a -> collectColumnAliasesInto(a, acc));
+                case SqlPlanner.SqlExpr.IsNull(var o)    -> collectColumnAliasesInto(o, acc);
+                case SqlPlanner.SqlExpr.IsNotNull(var o) -> collectColumnAliasesInto(o, acc);
+                case SqlPlanner.SqlExpr.Between(var v, var lo, var hi) -> {
+                    collectColumnAliasesInto(v, acc);
+                    collectColumnAliasesInto(lo, acc);
+                    collectColumnAliasesInto(hi, acc);
+                }
+                case SqlPlanner.SqlExpr.In(var v, var items) -> {
+                    collectColumnAliasesInto(v, acc);
+                    items.forEach(i -> collectColumnAliasesInto(i, acc));
+                }
+                case SqlPlanner.SqlExpr.NotIn(var v, var items) -> {
+                    collectColumnAliasesInto(v, acc);
+                    items.forEach(i -> collectColumnAliasesInto(i, acc));
+                }
+                case SqlPlanner.SqlExpr.Like(var v, var p) -> collectColumnAliasesInto(v, acc);
+                case SqlPlanner.SqlExpr.NotLike(var v, var p) -> collectColumnAliasesInto(v, acc);
+                default -> {} // Literal, Wildcard, AggExpr — no column refs
+            }
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Pass 3 — Projection Pruning
+    // ═══════════════════════════════════════════════════════════════════════════
+    //
+    // Determines which columns each Scan actually needs to produce.  Columns
+    // that are never referenced above a Scan can be dropped from storage reads.
+    //
+    // The pass is top-down: it threads a "required" set of (table, column) pairs
+    // downward.  At each Project it recomputes required = union of all column refs
+    // in the project expressions; at each Filter / Sort / Join it adds the column
+    // refs in the predicate / sort keys / join condition to the required set.
+    //
+    // A null required set means "all columns needed" (SELECT *, or we have no
+    // information).  A Wildcard() anywhere in the project list also disables
+    // pruning.
+
+    public static final class ProjectionPruning implements Pass {
+
+        // A simple pair record to track (table-alias, column-name) requirements.
+        record ColRef(String table, String column) {}
+
+        @Override public String name() { return "ProjectionPruning"; }
+
+        @Override
+        public OptimizedPlan apply(OptimizedPlan plan) {
+            // null required → "all columns needed"
+            return transformPlan(plan, null);
+        }
+
+        private OptimizedPlan transformPlan(OptimizedPlan plan, Set<ColRef> required) {
+            return switch (plan) {
+                // At a Project: compute required from the project expressions
+                // (everything the project references from below).
+                case OptimizedPlan.Project(var input, var cols) -> {
+                    if (hasWildcard(cols)) {
+                        // SELECT * — we can't prune anything.
+                        yield new OptimizedPlan.Project(transformPlan(input, null), cols);
+                    }
+                    var newRequired = new HashSet<ColRef>();
+                    for (var c : cols) {
+                        if (c instanceof SqlPlanner.OutputColumn.Expr(var expr, var alias))
+                            collectColRefs(expr, newRequired);
+                    }
+                    // Union with any required passed down from above.
+                    if (required != null) newRequired.addAll(required);
+                    yield new OptimizedPlan.Project(transformPlan(input, newRequired), cols);
+                }
+
+                // At a Filter: add predicate column refs to required.
+                case OptimizedPlan.Filter(var input, var pred) -> {
+                    var newRequired = required == null ? null : new HashSet<>(required);
+                    if (newRequired != null) collectColRefs(pred, newRequired);
+                    yield new OptimizedPlan.Filter(transformPlan(input, newRequired), pred);
+                }
+
+                // At a Sort: add sort-key column refs to required.
+                case OptimizedPlan.Sort(var input, var keys) -> {
+                    var newRequired = required == null ? null : new HashSet<>(required);
+                    if (newRequired != null)
+                        for (var k : keys) collectColRefs(k.keyExpr(), newRequired);
+                    yield new OptimizedPlan.Sort(transformPlan(input, newRequired), keys);
+                }
+
+                // At a Join: add condition column refs, then split required by alias.
+                case OptimizedPlan.Join(var left, var right, var kind, var cond) -> {
+                    var newRequired = required == null ? null : new HashSet<>(required);
+                    if (newRequired != null && cond != null)
+                        collectColRefs(cond, newRequired);
+
+                    var leftAliases  = collectAliasSet(left);
+                    var rightAliases = collectAliasSet(right);
+
+                    Set<ColRef> leftReq  = splitRequired(newRequired, leftAliases);
+                    Set<ColRef> rightReq = splitRequired(newRequired, rightAliases);
+
+                    yield new OptimizedPlan.Join(
+                        transformPlan(left,  leftReq),
+                        transformPlan(right, rightReq),
+                        kind, cond);
+                }
+
+                // At an Aggregate: required = GROUP BY refs + aggregate arg refs.
+                case OptimizedPlan.Aggregate(var input, var gb, var aggs) -> {
+                    var newRequired = required == null ? null : new HashSet<ColRef>();
+                    if (newRequired != null) {
+                        for (var e : gb) collectColRefs(e, newRequired);
+                        for (var agg : aggs) {
+                            if (agg.arg() instanceof SqlPlanner.AggArg.Expr(var expr))
+                                collectColRefs(expr, newRequired);
+                        }
+                    }
+                    yield new OptimizedPlan.Aggregate(transformPlan(input, newRequired), gb, aggs);
+                }
+
+                // At Having, Limit, Distinct: pass through unchanged.
+                case OptimizedPlan.Having(var input, var pred) -> {
+                    var newRequired = required == null ? null : new HashSet<>(required);
+                    if (newRequired != null) collectColRefs(pred, newRequired);
+                    yield new OptimizedPlan.Having(transformPlan(input, newRequired), pred);
+                }
+
+                case OptimizedPlan.Limit(var input, var count, var offset) ->
+                    new OptimizedPlan.Limit(transformPlan(input, required), count, offset);
+
+                case OptimizedPlan.Distinct(var input) ->
+                    new OptimizedPlan.Distinct(transformPlan(input, required));
+
+                case OptimizedPlan.Union(var l, var r, var all) ->
+                    new OptimizedPlan.Union(transformPlan(l, required), transformPlan(r, required), all);
+
+                // At a Scan: annotate with the columns required by this scan's alias.
+                case OptimizedPlan.Scan(var tbl, var alias, var existingRC, var sl) -> {
+                    if (required == null) {
+                        yield new OptimizedPlan.Scan(tbl, alias, null, sl);
+                    }
+                    var scanAlias = alias != null ? alias : tbl;
+                    var cols = new ArrayList<String>();
+                    for (var cr : required) {
+                        if (scanAlias.equals(cr.table()))
+                            cols.add(cr.column());
+                    }
+                    if (cols.isEmpty()) {
+                        // No specific columns needed → might be a COUNT(*) situation;
+                        // keep null to avoid confusing the engine.
+                        yield new OptimizedPlan.Scan(tbl, alias, null, sl);
+                    }
+                    Collections.sort(cols);
+                    yield new OptimizedPlan.Scan(tbl, alias, cols, sl);
+                }
+
+                default -> plan;
+            };
+        }
+
+        // ── Helpers ──────────────────────────────────────────────────────────
+
+        private static boolean hasWildcard(List<SqlPlanner.OutputColumn> cols) {
+            for (var c : cols)
+                if (c instanceof SqlPlanner.OutputColumn.Star) return true;
+            return false;
+        }
+
+        static void collectColRefs(SqlPlanner.SqlExpr expr, Set<ColRef> acc) {
+            switch (expr) {
+                case SqlPlanner.SqlExpr.Column(var t, var c) -> {
+                    if (t != null) acc.add(new ColRef(t, c));
+                }
+                case SqlPlanner.SqlExpr.BinaryOp(var op, var l, var r) -> {
+                    collectColRefs(l, acc);
+                    collectColRefs(r, acc);
+                }
+                case SqlPlanner.SqlExpr.UnaryOp(var op, var o) -> collectColRefs(o, acc);
+                case SqlPlanner.SqlExpr.FuncCall(var n, var args) ->
+                    args.forEach(a -> collectColRefs(a, acc));
+                case SqlPlanner.SqlExpr.IsNull(var o)    -> collectColRefs(o, acc);
+                case SqlPlanner.SqlExpr.IsNotNull(var o) -> collectColRefs(o, acc);
+                case SqlPlanner.SqlExpr.Between(var v, var lo, var hi) -> {
+                    collectColRefs(v, acc);
+                    collectColRefs(lo, acc);
+                    collectColRefs(hi, acc);
+                }
+                case SqlPlanner.SqlExpr.In(var v, var items) -> {
+                    collectColRefs(v, acc);
+                    items.forEach(i -> collectColRefs(i, acc));
+                }
+                case SqlPlanner.SqlExpr.NotIn(var v, var items) -> {
+                    collectColRefs(v, acc);
+                    items.forEach(i -> collectColRefs(i, acc));
+                }
+                case SqlPlanner.SqlExpr.Like(var v, var p) -> collectColRefs(v, acc);
+                case SqlPlanner.SqlExpr.NotLike(var v, var p) -> collectColRefs(v, acc);
+                default -> {} // Literal, Wildcard, AggExpr.Star — no col refs
+            }
+        }
+
+        private static Set<String> collectAliasSet(OptimizedPlan plan) {
+            var aliases = new HashSet<String>();
+            collectAliasSetInto(plan, aliases);
+            return aliases;
+        }
+
+        private static void collectAliasSetInto(OptimizedPlan plan, Set<String> acc) {
+            switch (plan) {
+                case OptimizedPlan.Scan(var t, var a, var rc, var sl) ->
+                    acc.add(a != null ? a : t);
+                case OptimizedPlan.Filter(var input, var p) -> collectAliasSetInto(input, acc);
+                case OptimizedPlan.Project(var input, var c) -> collectAliasSetInto(input, acc);
+                case OptimizedPlan.Join(var l, var r, var k, var c) -> {
+                    collectAliasSetInto(l, acc);
+                    collectAliasSetInto(r, acc);
+                }
+                case OptimizedPlan.Aggregate(var input, var g, var ag) ->
+                    collectAliasSetInto(input, acc);
+                case OptimizedPlan.Having(var input, var p) -> collectAliasSetInto(input, acc);
+                case OptimizedPlan.Sort(var input, var k) -> collectAliasSetInto(input, acc);
+                case OptimizedPlan.Limit(var input, var c, var o) -> collectAliasSetInto(input, acc);
+                case OptimizedPlan.Distinct(var input) -> collectAliasSetInto(input, acc);
+                case OptimizedPlan.Union(var l, var r, var al) -> {
+                    collectAliasSetInto(l, acc);
+                    collectAliasSetInto(r, acc);
+                }
+                default -> {}
+            }
+        }
+
+        private static Set<ColRef> splitRequired(Set<ColRef> required, Set<String> aliases) {
+            if (required == null) return null;
+            var out = new HashSet<ColRef>();
+            for (var cr : required)
+                if (aliases.contains(cr.table()))
+                    out.add(cr);
+            return out;
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Pass 4 — Dead Code Elimination
+    // ═══════════════════════════════════════════════════════════════════════════
+    //
+    // Replaces subtrees that provably produce zero rows with EmptyResult,
+    // then propagates EmptyResult upward through operators that cannot conjure
+    // rows from nothing.
+    //
+    // Rules (bottom-up):
+    //
+    //   Filter(EmptyResult, _)          → EmptyResult
+    //   Filter(child, Literal(false))   → EmptyResult
+    //   Filter(child, Literal(null))    → EmptyResult
+    //   Filter(child, Literal(true))    → child          (remove useless filter)
+    //   Limit(child, count=0, _)        → EmptyResult
+    //   Project(EmptyResult, _)         → EmptyResult
+    //   Sort(EmptyResult, _)            → EmptyResult
+    //   Limit(EmptyResult, _, _)        → EmptyResult
+    //   Distinct(EmptyResult)           → EmptyResult
+    //   Having(EmptyResult, _)          → EmptyResult
+    //   Join(EmptyResult, _, INNER/CROSS) → EmptyResult
+    //   Join(_, EmptyResult, INNER/CROSS) → EmptyResult
+    //   Union(EmptyResult, right)       → right
+    //   Union(left, EmptyResult)        → left
+    //
+    // NOTE: Aggregate(EmptyResult) is intentionally NOT collapsed.
+    // "SELECT COUNT(*) FROM empty_table" must return one row with count 0.
+
+    public static final class DeadCodeElimination implements Pass {
+        @Override public String name() { return "DeadCodeElimination"; }
+
+        @Override
+        public OptimizedPlan apply(OptimizedPlan plan) {
+            return transformPlan(plan);
+        }
+
+        private OptimizedPlan transformPlan(OptimizedPlan plan) {
+            return switch (plan) {
+                case OptimizedPlan.Filter(var input, var pred) -> {
+                    var child = transformPlan(input);
+
+                    // If the child is already empty, propagate.
+                    if (child instanceof OptimizedPlan.EmptyResult) yield child;
+
+                    // If the predicate is statically false or null, no rows pass.
+                    if (isFalsy(pred)) yield new OptimizedPlan.EmptyResult();
+
+                    // If the predicate is statically true, the filter is a no-op.
+                    if (isTrue(pred)) yield child;
+
+                    yield new OptimizedPlan.Filter(child, pred);
+                }
+
+                case OptimizedPlan.Project(var input, var cols) -> {
+                    var child = transformPlan(input);
+                    if (child instanceof OptimizedPlan.EmptyResult) yield child;
+                    yield new OptimizedPlan.Project(child, cols);
+                }
+
+                case OptimizedPlan.Sort(var input, var keys) -> {
+                    var child = transformPlan(input);
+                    if (child instanceof OptimizedPlan.EmptyResult) yield child;
+                    yield new OptimizedPlan.Sort(child, keys);
+                }
+
+                case OptimizedPlan.Limit(var input, var count, var offset) -> {
+                    var child = transformPlan(input);
+                    if (child instanceof OptimizedPlan.EmptyResult) yield child;
+                    // LIMIT 0 → no rows will ever be produced.
+                    if (count != null && count == 0L) yield new OptimizedPlan.EmptyResult();
+                    yield new OptimizedPlan.Limit(child, count, offset);
+                }
+
+                case OptimizedPlan.Distinct(var input) -> {
+                    var child = transformPlan(input);
+                    if (child instanceof OptimizedPlan.EmptyResult) yield child;
+                    yield new OptimizedPlan.Distinct(child);
+                }
+
+                case OptimizedPlan.Having(var input, var pred) -> {
+                    var child = transformPlan(input);
+                    if (child instanceof OptimizedPlan.EmptyResult) yield child;
+                    yield new OptimizedPlan.Having(child, pred);
+                }
+
+                case OptimizedPlan.Join(var left, var right, var kind, var cond) -> {
+                    var lc = transformPlan(left);
+                    var rc = transformPlan(right);
+                    // INNER and CROSS joins produce no rows when either side is empty.
+                    boolean innerLike = kind == SqlPlanner.JoinKind.INNER
+                                     || kind == SqlPlanner.JoinKind.CROSS;
+                    if (innerLike &&
+                        (lc instanceof OptimizedPlan.EmptyResult ||
+                         rc instanceof OptimizedPlan.EmptyResult))
+                        yield new OptimizedPlan.EmptyResult();
+
+                    yield new OptimizedPlan.Join(lc, rc, kind, cond);
+                }
+
+                case OptimizedPlan.Union(var left, var right, var all) -> {
+                    var lc = transformPlan(left);
+                    var rc = transformPlan(right);
+                    // Union with one empty side collapses to the other side.
+                    if (lc instanceof OptimizedPlan.EmptyResult) yield rc;
+                    if (rc instanceof OptimizedPlan.EmptyResult) yield lc;
+                    yield new OptimizedPlan.Union(lc, rc, all);
+                }
+
+                // Aggregate(EmptyResult) is NOT collapsed — see class-level note.
+                case OptimizedPlan.Aggregate(var input, var gb, var aggs) -> {
+                    var child = transformPlan(input);
+                    yield new OptimizedPlan.Aggregate(child, gb, aggs);
+                }
+
+                case OptimizedPlan.Scan s -> s;
+                case OptimizedPlan.EmptyResult e -> e;
+                default -> plan;
+            };
+        }
+
+        // ── Predicate helpers ─────────────────────────────────────────────────
+
+        /** Returns true if the expression is statically false or null. */
+        private static boolean isFalsy(SqlPlanner.SqlExpr expr) {
+            if (expr instanceof SqlPlanner.SqlExpr.Literal(var v))
+                return Boolean.FALSE.equals(v) || v == null;
+            return false;
+        }
+
+        /** Returns true if the expression is statically true. */
+        private static boolean isTrue(SqlPlanner.SqlExpr expr) {
+            if (expr instanceof SqlPlanner.SqlExpr.Literal(var v))
+                return Boolean.TRUE.equals(v);
+            return false;
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Pass 5 — Limit Pushdown
+    // ═══════════════════════════════════════════════════════════════════════════
+    //
+    // Propagates LIMIT counts down to Scan nodes so the storage layer can
+    // short-circuit after reading enough rows.
+    //
+    // A LIMIT N with no offset (or offset == 0) tells us the plan needs at most
+    // N rows from its source.  We push N downward through Project and Filter
+    // until we reach a Scan.  On the way we set Scan.scanLimit = min(N, existing).
+    //
+    // We must NOT push through:
+    //   • Sort      — needs all rows to determine the first N
+    //   • Aggregate — GROUP BY changes cardinality
+    //   • Join      — cartesian product may expand rows
+    //   • Distinct  — duplicates may collapse rows
+    //   • Union     — row counts come from two sources
+    //
+    // When offset > 0 the effective early-stop is count + offset rows, but
+    // pushing that is more complex and we simply skip the push to be safe.
+
+    public static final class LimitPushdown implements Pass {
+        @Override public String name() { return "LimitPushdown"; }
+
+        @Override
+        public OptimizedPlan apply(OptimizedPlan plan) {
+            return transformPlan(plan, null);
+        }
+
+        /**
+         * @param plan    the node to transform
+         * @param limit   the maximum row count to propagate (null = no limit known)
+         */
+        private OptimizedPlan transformPlan(OptimizedPlan plan, Long limit) {
+            return switch (plan) {
+                // When we encounter a Limit node, extract its count (if offset == 0)
+                // and propagate downward.
+                case OptimizedPlan.Limit(var input, var count, var offset) -> {
+                    // Only push when there is no offset (offset = null or 0).
+                    boolean noOffset = offset == null || offset == 0L;
+                    Long childLimit;
+                    if (noOffset && count != null) {
+                        // Avoid mixing Long/long in ternary (auto-unboxing NPE).
+                        if (limit == null) {
+                            childLimit = count;
+                        } else {
+                            childLimit = Math.min(limit, count);  // both non-null
+                        }
+                    } else {
+                        childLimit = null;
+                    }
+                    yield new OptimizedPlan.Limit(transformPlan(input, childLimit),
+                                                   count, offset);
+                }
+
+                // Project and Filter are transparent to row count — pass limit through.
+                case OptimizedPlan.Project(var input, var cols) ->
+                    new OptimizedPlan.Project(transformPlan(input, limit), cols);
+
+                case OptimizedPlan.Filter(var input, var pred) ->
+                    new OptimizedPlan.Filter(transformPlan(input, limit), pred);
+
+                // At a Scan: apply the limit annotation.
+                // Care: avoid mixing Long and long in ternaries (auto-unboxing NPE).
+                case OptimizedPlan.Scan(var tbl, var alias, var rc, var existingSL) -> {
+                    Long newSL;
+                    if (existingSL == null) {
+                        newSL = limit;                                   // may be null
+                    } else if (limit == null) {
+                        newSL = existingSL;
+                    } else {
+                        newSL = Math.min(existingSL, limit);             // both non-null
+                    }
+                    yield new OptimizedPlan.Scan(tbl, alias, rc, newSL);
+                }
+
+                // Barriers: recurse but reset limit to null so children are not
+                // contaminated by an outer limit that doesn't apply to them.
+                case OptimizedPlan.Sort(var input, var keys) ->
+                    new OptimizedPlan.Sort(transformPlan(input, null), keys);
+
+                case OptimizedPlan.Aggregate(var input, var gb, var aggs) ->
+                    new OptimizedPlan.Aggregate(transformPlan(input, null), gb, aggs);
+
+                case OptimizedPlan.Having(var input, var pred) ->
+                    new OptimizedPlan.Having(transformPlan(input, null), pred);
+
+                case OptimizedPlan.Distinct(var input) ->
+                    new OptimizedPlan.Distinct(transformPlan(input, null));
+
+                case OptimizedPlan.Join(var l, var r, var kind, var cond) ->
+                    new OptimizedPlan.Join(transformPlan(l, null), transformPlan(r, null),
+                                           kind, cond);
+
+                case OptimizedPlan.Union(var l, var r, var all) ->
+                    new OptimizedPlan.Union(transformPlan(l, null), transformPlan(r, null), all);
+
+                // Leaf nodes / DML — nothing to propagate into.
+                default -> plan;
+            };
+        }
+    }
+}

--- a/code/packages/java/sql-optimizer/src/test/java/com/codingadventures/sqloptimizer/SqlOptimizerTest.java
+++ b/code/packages/java/sql-optimizer/src/test/java/com/codingadventures/sqloptimizer/SqlOptimizerTest.java
@@ -1,0 +1,1577 @@
+package com.codingadventures.sqloptimizer;
+
+import com.codingadventures.sqlplanner.SqlPlanner;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * SqlOptimizerTest — comprehensive JUnit 5 test suite for the SQL optimizer.
+ *
+ * The tests are grouped by pass for clarity:
+ *   • ConstantFoldingTests
+ *   • PredicatePushdownTests
+ *   • ProjectionPruningTests
+ *   • DeadCodeEliminationTests
+ *   • LimitPushdownTests
+ *   • CombinedTests (multi-pass and API surface)
+ *
+ * Every test uses direct plan construction (no real schema required) so tests
+ * are self-contained and fast.
+ */
+class SqlOptimizerTest {
+
+    // ── Convenience factories ─────────────────────────────────────────────────
+
+    static SqlPlanner.SqlExpr lit(Object v) {
+        return new SqlPlanner.SqlExpr.Literal(v);
+    }
+    static SqlPlanner.SqlExpr col(String table, String column) {
+        return new SqlPlanner.SqlExpr.Column(table, column);
+    }
+    static SqlPlanner.SqlExpr binOp(SqlPlanner.BinaryOperator op,
+                                     SqlPlanner.SqlExpr l, SqlPlanner.SqlExpr r) {
+        return new SqlPlanner.SqlExpr.BinaryOp(op, l, r);
+    }
+    static SqlPlanner.SqlExpr add(SqlPlanner.SqlExpr l, SqlPlanner.SqlExpr r) {
+        return binOp(SqlPlanner.BinaryOperator.ADD, l, r);
+    }
+    static SqlPlanner.SqlExpr sub(SqlPlanner.SqlExpr l, SqlPlanner.SqlExpr r) {
+        return binOp(SqlPlanner.BinaryOperator.SUB, l, r);
+    }
+    static SqlPlanner.SqlExpr mul(SqlPlanner.SqlExpr l, SqlPlanner.SqlExpr r) {
+        return binOp(SqlPlanner.BinaryOperator.MUL, l, r);
+    }
+    static SqlPlanner.SqlExpr div(SqlPlanner.SqlExpr l, SqlPlanner.SqlExpr r) {
+        return binOp(SqlPlanner.BinaryOperator.DIV, l, r);
+    }
+    static SqlPlanner.SqlExpr and(SqlPlanner.SqlExpr l, SqlPlanner.SqlExpr r) {
+        return binOp(SqlPlanner.BinaryOperator.AND, l, r);
+    }
+    static SqlPlanner.SqlExpr or(SqlPlanner.SqlExpr l, SqlPlanner.SqlExpr r) {
+        return binOp(SqlPlanner.BinaryOperator.OR, l, r);
+    }
+    static SqlPlanner.SqlExpr eq(SqlPlanner.SqlExpr l, SqlPlanner.SqlExpr r) {
+        return binOp(SqlPlanner.BinaryOperator.EQ, l, r);
+    }
+    static SqlPlanner.SqlExpr lt(SqlPlanner.SqlExpr l, SqlPlanner.SqlExpr r) {
+        return binOp(SqlPlanner.BinaryOperator.LT, l, r);
+    }
+    static SqlPlanner.SqlExpr not(SqlPlanner.SqlExpr e) {
+        return new SqlPlanner.SqlExpr.UnaryOp(SqlPlanner.UnaryOperator.NOT, e);
+    }
+    static SqlPlanner.SqlExpr neg(SqlPlanner.SqlExpr e) {
+        return new SqlPlanner.SqlExpr.UnaryOp(SqlPlanner.UnaryOperator.NEG, e);
+    }
+    static SqlPlanner.SqlExpr isNull(SqlPlanner.SqlExpr e) {
+        return new SqlPlanner.SqlExpr.IsNull(e);
+    }
+    static SqlPlanner.SqlExpr isNotNull(SqlPlanner.SqlExpr e) {
+        return new SqlPlanner.SqlExpr.IsNotNull(e);
+    }
+
+    static SqlOptimizer.OptimizedPlan scan(String table, String alias) {
+        return new SqlOptimizer.OptimizedPlan.Scan(table, alias);
+    }
+    static SqlOptimizer.OptimizedPlan filter(SqlOptimizer.OptimizedPlan input,
+                                              SqlPlanner.SqlExpr pred) {
+        return new SqlOptimizer.OptimizedPlan.Filter(input, pred);
+    }
+    static SqlOptimizer.OptimizedPlan project(SqlOptimizer.OptimizedPlan input,
+                                               List<SqlPlanner.OutputColumn> cols) {
+        return new SqlOptimizer.OptimizedPlan.Project(input, cols);
+    }
+    static SqlOptimizer.OptimizedPlan limit(SqlOptimizer.OptimizedPlan input,
+                                             Long count, Long offset) {
+        return new SqlOptimizer.OptimizedPlan.Limit(input, count, offset);
+    }
+    static SqlOptimizer.OptimizedPlan sort(SqlOptimizer.OptimizedPlan input,
+                                            List<SqlPlanner.SortKey> keys) {
+        return new SqlOptimizer.OptimizedPlan.Sort(input, keys);
+    }
+    static SqlOptimizer.OptimizedPlan distinct(SqlOptimizer.OptimizedPlan input) {
+        return new SqlOptimizer.OptimizedPlan.Distinct(input);
+    }
+    static SqlOptimizer.OptimizedPlan join(SqlOptimizer.OptimizedPlan l,
+                                            SqlOptimizer.OptimizedPlan r,
+                                            SqlPlanner.JoinKind kind,
+                                            SqlPlanner.SqlExpr cond) {
+        return new SqlOptimizer.OptimizedPlan.Join(l, r, kind, cond);
+    }
+    static SqlOptimizer.OptimizedPlan agg(SqlOptimizer.OptimizedPlan input,
+                                           List<SqlPlanner.SqlExpr> gb,
+                                           List<SqlPlanner.AggregateItem> aggs) {
+        return new SqlOptimizer.OptimizedPlan.Aggregate(input, gb, aggs);
+    }
+
+    static SqlPlanner.OutputColumn exprCol(SqlPlanner.SqlExpr expr, String alias) {
+        return new SqlPlanner.OutputColumn.Expr(expr, alias);
+    }
+    static SqlPlanner.OutputColumn starCol() { return new SqlPlanner.OutputColumn.Star(); }
+
+    static SqlPlanner.SortKey asc(SqlPlanner.SqlExpr expr) {
+        return new SqlPlanner.SortKey(expr, SqlPlanner.SortDir.ASC, SqlPlanner.NullOrder.NULLS_LAST);
+    }
+
+    // Fold a single expression via ConstantFolding.
+    static SqlPlanner.SqlExpr fold(SqlPlanner.SqlExpr expr) {
+        return new SqlOptimizer.ConstantFolding().foldExpr(expr);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // API surface
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Test @DisplayName("defaultPasses() returns 5 passes in correct order")
+    void defaultPassesOrderAndCount() {
+        var passes = SqlOptimizer.defaultPasses();
+        assertEquals(5, passes.size());
+        assertEquals("ConstantFolding",     passes.get(0).name());
+        assertEquals("PredicatePushdown",   passes.get(1).name());
+        assertEquals("ProjectionPruning",   passes.get(2).name());
+        assertEquals("DeadCodeElimination", passes.get(3).name());
+        assertEquals("LimitPushdown",       passes.get(4).name());
+    }
+
+    @Test @DisplayName("Pass.name() returns correct string for each pass")
+    void passNames() {
+        assertEquals("ConstantFolding",     new SqlOptimizer.ConstantFolding().name());
+        assertEquals("PredicatePushdown",   new SqlOptimizer.PredicatePushdown().name());
+        assertEquals("ProjectionPruning",   new SqlOptimizer.ProjectionPruning().name());
+        assertEquals("DeadCodeElimination", new SqlOptimizer.DeadCodeElimination().name());
+        assertEquals("LimitPushdown",       new SqlOptimizer.LimitPushdown().name());
+    }
+
+    @Test @DisplayName("optimizeWithPasses with custom single pass")
+    void customSinglePass() {
+        // A no-op pass that returns the plan unchanged.
+        SqlOptimizer.Pass noOp = new SqlOptimizer.Pass() {
+            @Override public String name() { return "NoOp"; }
+            @Override public SqlOptimizer.OptimizedPlan apply(SqlOptimizer.OptimizedPlan p) { return p; }
+        };
+
+        var logical = new SqlPlanner.LogicalPlan.Scan("users", "u");
+        var result = SqlOptimizer.optimizeWithPasses(logical, List.of(noOp));
+        assertInstanceOf(SqlOptimizer.OptimizedPlan.Scan.class, result);
+    }
+
+    @Test @DisplayName("optimize returns same structure if no optimizations apply")
+    void optimizeNoOp() {
+        // A simple scan with a non-constant predicate — nothing can be optimized.
+        var logical = new SqlPlanner.LogicalPlan.Filter(
+            new SqlPlanner.LogicalPlan.Scan("users", "u"),
+            col("u", "age")   // non-constant; cannot fold or eliminate
+        );
+        var result = SqlOptimizer.optimize(logical);
+        // The result should still be a Filter(Scan) shape.
+        assertInstanceOf(SqlOptimizer.OptimizedPlan.Filter.class, result);
+        var f = (SqlOptimizer.OptimizedPlan.Filter) result;
+        assertInstanceOf(SqlOptimizer.OptimizedPlan.Scan.class, f.input());
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // lift()
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Test @DisplayName("lift() correctly converts Scan")
+    void liftScan() {
+        var plan = new SqlPlanner.LogicalPlan.Scan("t", "a");
+        var opt  = SqlOptimizer.lift(plan);
+        assertInstanceOf(SqlOptimizer.OptimizedPlan.Scan.class, opt);
+        var s = (SqlOptimizer.OptimizedPlan.Scan) opt;
+        assertEquals("t", s.table());
+        assertEquals("a", s.alias());
+        assertNull(s.requiredColumns());
+        assertNull(s.scanLimit());
+    }
+
+    @Test @DisplayName("lift() correctly converts all LogicalPlan variants")
+    void liftAllVariants() {
+        var scan   = new SqlPlanner.LogicalPlan.Scan("t", "t");
+        var filter = new SqlPlanner.LogicalPlan.Filter(scan, lit(true));
+        var project = new SqlPlanner.LogicalPlan.Project(filter, List.of(starCol()));
+        var sort   = new SqlPlanner.LogicalPlan.Sort(project,
+            List.of(asc(col("t", "id"))));
+        var lim    = new SqlPlanner.LogicalPlan.Limit(sort, 10L, 0L);
+        var dist   = new SqlPlanner.LogicalPlan.Distinct(lim);
+        var union  = new SqlPlanner.LogicalPlan.Union(dist, scan, false);
+
+        var opt = SqlOptimizer.lift(union);
+        assertInstanceOf(SqlOptimizer.OptimizedPlan.Union.class, opt);
+
+        // CreateTable
+        var ct = new SqlPlanner.LogicalPlan.CreateTable("t2", false, List.of());
+        assertInstanceOf(SqlOptimizer.OptimizedPlan.CreateTable.class, SqlOptimizer.lift(ct));
+
+        // DropTable
+        var dt = new SqlPlanner.LogicalPlan.DropTable("t2", true);
+        assertInstanceOf(SqlOptimizer.OptimizedPlan.DropTable.class, SqlOptimizer.lift(dt));
+
+        // Insert
+        var ins = new SqlPlanner.LogicalPlan.Insert("t", List.of("id"), List.of(List.of(lit(1L))));
+        assertInstanceOf(SqlOptimizer.OptimizedPlan.Insert.class, SqlOptimizer.lift(ins));
+
+        // Update
+        var upd = new SqlPlanner.LogicalPlan.Update("t",
+            List.of(new SqlPlanner.Assignment("id", lit(1L))), lit(true));
+        assertInstanceOf(SqlOptimizer.OptimizedPlan.Update.class, SqlOptimizer.lift(upd));
+
+        // Delete
+        var del = new SqlPlanner.LogicalPlan.Delete("t", lit(true));
+        assertInstanceOf(SqlOptimizer.OptimizedPlan.Delete.class, SqlOptimizer.lift(del));
+
+        // Aggregate
+        var aggPlan = new SqlPlanner.LogicalPlan.Aggregate(scan, List.of(), List.of());
+        assertInstanceOf(SqlOptimizer.OptimizedPlan.Aggregate.class, SqlOptimizer.lift(aggPlan));
+
+        // Having
+        var having = new SqlPlanner.LogicalPlan.Having(scan, lit(true));
+        assertInstanceOf(SqlOptimizer.OptimizedPlan.Having.class, SqlOptimizer.lift(having));
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // ConstantFolding
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Nested @DisplayName("ConstantFolding")
+    class ConstantFoldingTests {
+
+        @Test @DisplayName("1 + 2 → Literal(3)")
+        void addTwoInts() {
+            var result = fold(add(lit(1L), lit(2L)));
+            assertEquals(new SqlPlanner.SqlExpr.Literal(3L), result);
+        }
+
+        @Test @DisplayName("TRUE AND FALSE → Literal(false)")
+        void andTrueAndFalse() {
+            var result = fold(and(lit(true), lit(false)));
+            assertEquals(new SqlPlanner.SqlExpr.Literal(false), result);
+        }
+
+        @Test @DisplayName("NULL + 5 → Literal(null)")
+        void nullPropagationAdd() {
+            var result = fold(add(lit(null), lit(5L)));
+            assertEquals(new SqlPlanner.SqlExpr.Literal(null), result);
+        }
+
+        @Test @DisplayName("NOT TRUE → Literal(false)")
+        void notTrue() {
+            var result = fold(not(lit(true)));
+            assertEquals(new SqlPlanner.SqlExpr.Literal(false), result);
+        }
+
+        @Test @DisplayName("x AND TRUE → x (identity simplification)")
+        void andTrueIsIdentity() {
+            var x = col("u", "active");
+            var result = fold(and(x, lit(true)));
+            assertEquals(x, result);
+        }
+
+        @Test @DisplayName("TRUE OR unknown → TRUE (short circuit)")
+        void orTrueShortCircuits() {
+            var result = fold(or(lit(true), col("u", "x")));
+            assertEquals(new SqlPlanner.SqlExpr.Literal(true), result);
+        }
+
+        @Test @DisplayName("NULL OR TRUE → TRUE (short circuit before null propagation)")
+        void nullOrTrueIsTrue() {
+            var result = fold(or(lit(null), lit(true)));
+            // TRUE short circuits: TRUE OR _ → TRUE, so order matters.
+            // Here left is NULL and right is TRUE; the rule TRUE OR x → TRUE fires when
+            // right is TRUE, so result is TRUE.
+            assertEquals(new SqlPlanner.SqlExpr.Literal(true), result);
+        }
+
+        @Test @DisplayName("IsNull(Literal(null)) → Literal(true)")
+        void isNullOfNull() {
+            var result = fold(isNull(lit(null)));
+            assertEquals(new SqlPlanner.SqlExpr.Literal(true), result);
+        }
+
+        @Test @DisplayName("IsNotNull(Literal(42)) → Literal(true)")
+        void isNotNullOfNonNull() {
+            var result = fold(isNotNull(lit(42L)));
+            assertEquals(new SqlPlanner.SqlExpr.Literal(true), result);
+        }
+
+        @Test @DisplayName("Division by zero not folded")
+        void divisionByZeroNotFolded() {
+            var expr   = div(lit(10L), lit(0L));
+            var result = fold(expr);
+            // Should remain as BinaryOp, not throw.
+            assertInstanceOf(SqlPlanner.SqlExpr.BinaryOp.class, result);
+        }
+
+        @Test @DisplayName("SUB, MUL arithmetic fold")
+        void arithmeticSubAndMul() {
+            assertEquals(new SqlPlanner.SqlExpr.Literal(3L),  fold(sub(lit(5L), lit(2L))));
+            assertEquals(new SqlPlanner.SqlExpr.Literal(6L),  fold(mul(lit(2L), lit(3L))));
+        }
+
+        @Test @DisplayName("1 < 2 → Literal(true)")
+        void comparisonLessThan() {
+            var result = fold(lt(lit(1L), lit(2L)));
+            assertEquals(new SqlPlanner.SqlExpr.Literal(true), result);
+        }
+
+        @Test @DisplayName("NEG on literal: NEG(-5) → Literal(5)")
+        void negOnLiteral() {
+            var result = fold(neg(lit(-5L)));
+            assertEquals(new SqlPlanner.SqlExpr.Literal(5L), result);
+        }
+
+        @Test @DisplayName("FALSE AND x → FALSE (short circuit with non-literal x)")
+        void falseAndXIsAlwaysFalse() {
+            var result = fold(and(lit(false), col("u", "x")));
+            assertEquals(new SqlPlanner.SqlExpr.Literal(false), result);
+        }
+
+        @Test @DisplayName("Constant folding propagates through plan nodes")
+        void foldingPropagatesThroughPlan() {
+            // Filter(Scan, 1+2=3) — the predicate 1+2 should be folded to 3.
+            var plan = filter(scan("t", "t"),
+                add(lit(1L), lit(2L)));
+            var cf = new SqlOptimizer.ConstantFolding();
+            var result = cf.apply(plan);
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.Filter.class, result);
+            var f = (SqlOptimizer.OptimizedPlan.Filter) result;
+            assertEquals(new SqlPlanner.SqlExpr.Literal(3L), f.predicate());
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // PredicatePushdown
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Nested @DisplayName("PredicatePushdown")
+    class PredicatePushdownTests {
+
+        @Test @DisplayName("Filter above Project pushed below Project")
+        void filterPushedThroughProject() {
+            // Filter(Project(Scan("u","u"), [u.name]), u.id = 1)
+            // predicate references alias "u" which exists below Project → push down
+            var pred    = eq(col("u", "id"), lit(1L));
+            var scanU   = scan("users", "u");
+            var proj    = project(scanU, List.of(exprCol(col("u", "name"), "name")));
+            var filtered = filter(proj, pred);
+
+            var pp = new SqlOptimizer.PredicatePushdown();
+            var result = pp.apply(filtered);
+
+            // The filter should now be below the project.
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.Project.class, result);
+            var p = (SqlOptimizer.OptimizedPlan.Project) result;
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.Filter.class, p.input());
+        }
+
+        @Test @DisplayName("AND predicate splits — each half pushed to correct join side")
+        void andSplitsAndPushesToBothSides() {
+            // Filter(Join(Scan(u), Scan(o)), u.id=1 AND o.user_id=2)
+            // Left conjunct (u.id=1) goes to left side; right conjunct to right.
+            var predLeft  = eq(col("u", "id"), lit(1L));
+            var predRight = eq(col("o", "user_id"), lit(2L));
+            var combined  = and(predLeft, predRight);
+
+            var scanU = scan("users", "u");
+            var scanO = scan("orders", "o");
+            var joined = join(scanU, scanO, SqlPlanner.JoinKind.INNER, null);
+            var filtered = filter(joined, combined);
+
+            var pp = new SqlOptimizer.PredicatePushdown();
+            var result = pp.apply(filtered);
+
+            // The join itself should have no wrapping filter; each predicate
+            // should be below.
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.Join.class, result);
+            var j = (SqlOptimizer.OptimizedPlan.Join) result;
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.Filter.class, j.left());
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.Filter.class, j.right());
+        }
+
+        @Test @DisplayName("HAVING filter is not pushed below Aggregate")
+        void havingNotPushedBelowAggregate() {
+            // Filter(Aggregate(Scan), count > 5)
+            // Aggregate is a barrier — the filter must stay above.
+            var pred    = binOp(SqlPlanner.BinaryOperator.GT, col("g", "cnt"), lit(5L));
+            var scanG   = scan("grp", "g");
+            var aggPlan = agg(scanG, List.of(), List.of());
+            var filtered = filter(aggPlan, pred);
+
+            var pp = new SqlOptimizer.PredicatePushdown();
+            var result = pp.apply(filtered);
+
+            // Filter must remain above Aggregate (not pushed through).
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.Filter.class, result);
+            var f = (SqlOptimizer.OptimizedPlan.Filter) result;
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.Aggregate.class, f.input());
+        }
+
+        @Test @DisplayName("Filter pushed through Sort")
+        void filterPushedThroughSort() {
+            var pred = eq(col("u", "id"), lit(1L));
+            var s    = sort(scan("u", "u"), List.of(asc(col("u", "name"))));
+            var f    = filter(s, pred);
+
+            var result = new SqlOptimizer.PredicatePushdown().apply(f);
+
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.Sort.class, result);
+            var sortResult = (SqlOptimizer.OptimizedPlan.Sort) result;
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.Filter.class, sortResult.input());
+        }
+
+        @Test @DisplayName("Filter pushed through Distinct")
+        void filterPushedThroughDistinct() {
+            var pred = eq(col("u", "id"), lit(1L));
+            var d    = distinct(scan("u", "u"));
+            var f    = filter(d, pred);
+
+            var result = new SqlOptimizer.PredicatePushdown().apply(f);
+
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.Distinct.class, result);
+            var distResult = (SqlOptimizer.OptimizedPlan.Distinct) result;
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.Filter.class, distResult.input());
+        }
+
+        @Test @DisplayName("LEFT JOIN: right-side predicate NOT pushed to right")
+        void leftJoinRightNotPushed() {
+            var predRight = eq(col("o", "user_id"), lit(2L));
+            var scanU = scan("users", "u");
+            var scanO = scan("orders", "o");
+            var joined = join(scanU, scanO, SqlPlanner.JoinKind.LEFT, null);
+            var filtered = filter(joined, predRight);
+
+            var result = new SqlOptimizer.PredicatePushdown().apply(filtered);
+
+            // The filter should stay above the join (not pushed to right side
+            // of a LEFT JOIN — that would change outer-join semantics).
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.Filter.class, result);
+        }
+
+        @Test @DisplayName("Predicate referencing both join sides stays above join")
+        void predicateSpanningBothSidesStaysAbove() {
+            // u.id = o.user_id references both sides — cannot push to either.
+            var pred    = eq(col("u", "id"), col("o", "user_id"));
+            var scanU   = scan("users", "u");
+            var scanO   = scan("orders", "o");
+            var joined  = join(scanU, scanO, SqlPlanner.JoinKind.INNER, null);
+            var filtered = filter(joined, pred);
+
+            var result = new SqlOptimizer.PredicatePushdown().apply(filtered);
+
+            // Should remain as Filter(Join(...))
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.Filter.class, result);
+            var f = (SqlOptimizer.OptimizedPlan.Filter) result;
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.Join.class, f.input());
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // ProjectionPruning
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Nested @DisplayName("ProjectionPruning")
+    class ProjectionPruningTests {
+
+        @Test @DisplayName("Scan gains requiredColumns from Project above it")
+        void scanGetsRequiredColumns() {
+            // Project(Scan("users", "u"), [u.name])
+            var scanU = scan("users", "u");
+            var proj  = project(scanU, List.of(exprCol(col("u", "name"), "name")));
+
+            var result = new SqlOptimizer.ProjectionPruning().apply(proj);
+
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.Project.class, result);
+            var p = (SqlOptimizer.OptimizedPlan.Project) result;
+            var s = (SqlOptimizer.OptimizedPlan.Scan) p.input();
+            assertNotNull(s.requiredColumns());
+            assertTrue(s.requiredColumns().contains("name"));
+        }
+
+        @Test @DisplayName("SELECT * disables projection pruning (requiredColumns stays null)")
+        void selectStarDisablesPruning() {
+            var scanU = scan("users", "u");
+            var proj  = project(scanU, List.of(starCol()));
+
+            var result = new SqlOptimizer.ProjectionPruning().apply(proj);
+
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.Project.class, result);
+            var p = (SqlOptimizer.OptimizedPlan.Project) result;
+            var s = (SqlOptimizer.OptimizedPlan.Scan) p.input();
+            // Wildcard in project disables pruning.
+            assertNull(s.requiredColumns());
+        }
+
+        @Test @DisplayName("ProjectionPruning with join condition adds its cols")
+        void pruningWithJoinCondition() {
+            var scanU  = scan("users", "u");
+            var scanO  = scan("orders", "o");
+            var j      = join(scanU, scanO, SqlPlanner.JoinKind.INNER,
+                              eq(col("u", "id"), col("o", "user_id")));
+            var proj   = project(j, List.of(exprCol(col("u", "name"), "name")));
+
+            var result = new SqlOptimizer.ProjectionPruning().apply(proj);
+
+            var p = (SqlOptimizer.OptimizedPlan.Project) result;
+            var joinResult = (SqlOptimizer.OptimizedPlan.Join) p.input();
+            var scanUResult = (SqlOptimizer.OptimizedPlan.Scan) joinResult.left();
+            var scanOResult = (SqlOptimizer.OptimizedPlan.Scan) joinResult.right();
+
+            // u needs name (from project) and id (from join condition).
+            assertNotNull(scanUResult.requiredColumns());
+            assertTrue(scanUResult.requiredColumns().contains("id"));
+            assertTrue(scanUResult.requiredColumns().contains("name"));
+
+            // o needs user_id (from join condition).
+            assertNotNull(scanOResult.requiredColumns());
+            assertTrue(scanOResult.requiredColumns().contains("user_id"));
+        }
+
+        @Test @DisplayName("ProjectionPruning with sort key adds sort columns")
+        void pruningWithSortKey() {
+            var scanU  = scan("users", "u");
+            var sortP  = sort(scanU, List.of(asc(col("u", "age"))));
+            var proj   = project(sortP, List.of(exprCol(col("u", "name"), "name")));
+
+            var result = new SqlOptimizer.ProjectionPruning().apply(proj);
+
+            var p       = (SqlOptimizer.OptimizedPlan.Project) result;
+            var sortR   = (SqlOptimizer.OptimizedPlan.Sort) p.input();
+            var scanR   = (SqlOptimizer.OptimizedPlan.Scan) sortR.input();
+
+            assertNotNull(scanR.requiredColumns());
+            // Both name (from project) and age (from sort key) are required.
+            assertTrue(scanR.requiredColumns().contains("name"));
+            assertTrue(scanR.requiredColumns().contains("age"));
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // DeadCodeElimination
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Nested @DisplayName("DeadCodeElimination")
+    class DeadCodeEliminationTests {
+
+        final SqlOptimizer.DeadCodeElimination dce = new SqlOptimizer.DeadCodeElimination();
+
+        @Test @DisplayName("Filter(child, Literal(false)) → EmptyResult")
+        void filterFalseBecomesEmpty() {
+            var plan = filter(scan("t", "t"), lit(false));
+            var result = dce.apply(plan);
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.EmptyResult.class, result);
+        }
+
+        @Test @DisplayName("Filter(child, Literal(null)) → EmptyResult")
+        void filterNullBecomesEmpty() {
+            var plan = filter(scan("t", "t"), lit(null));
+            var result = dce.apply(plan);
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.EmptyResult.class, result);
+        }
+
+        @Test @DisplayName("Filter(child, Literal(true)) → child (filter removed)")
+        void filterTrueRemoved() {
+            var scanT  = scan("t", "t");
+            var plan   = filter(scanT, lit(true));
+            var result = dce.apply(plan);
+            // The filter should be gone; scan remains.
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.Scan.class, result);
+        }
+
+        @Test @DisplayName("Limit(child, count=0, offset=null) → EmptyResult")
+        void limitZeroBecomesEmpty() {
+            var plan   = limit(scan("t", "t"), 0L, null);
+            var result = dce.apply(plan);
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.EmptyResult.class, result);
+        }
+
+        @Test @DisplayName("Union(EmptyResult, scan) → scan")
+        void unionWithEmptyLeft() {
+            var scanT = scan("t", "t");
+            var plan  = new SqlOptimizer.OptimizedPlan.Union(
+                new SqlOptimizer.OptimizedPlan.EmptyResult(), scanT, false);
+            var result = dce.apply(plan);
+            // The EmptyResult side disappears; scan remains.
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.Scan.class, result);
+        }
+
+        @Test @DisplayName("Inner Join with EmptyResult → EmptyResult")
+        void innerJoinEmptyResultCollapses() {
+            var plan = join(
+                new SqlOptimizer.OptimizedPlan.EmptyResult(),
+                scan("t", "t"),
+                SqlPlanner.JoinKind.INNER, null);
+            var result = dce.apply(plan);
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.EmptyResult.class, result);
+        }
+
+        @Test @DisplayName("Aggregate(EmptyResult) NOT collapsed — COUNT(*) from empty")
+        void aggregateEmptyNotCollapsed() {
+            var plan = agg(
+                new SqlOptimizer.OptimizedPlan.EmptyResult(),
+                List.of(), List.of());
+            var result = dce.apply(plan);
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.Aggregate.class, result);
+        }
+
+        @Test @DisplayName("Filter(FALSE) under Sort → EmptyResult propagates up")
+        void emptyPropagatesUpThroughSort() {
+            var falseScan = filter(scan("t", "t"), lit(false));
+            var plan = sort(falseScan, List.of(asc(col("t", "id"))));
+            var result = dce.apply(plan);
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.EmptyResult.class, result);
+        }
+
+        @Test @DisplayName("Project(EmptyResult) → EmptyResult")
+        void projectEmptyResult() {
+            var plan = project(new SqlOptimizer.OptimizedPlan.EmptyResult(),
+                               List.of(exprCol(col("t", "id"), "id")));
+            var result = dce.apply(plan);
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.EmptyResult.class, result);
+        }
+
+        @Test @DisplayName("CROSS Join with EmptyResult right side → EmptyResult")
+        void crossJoinEmptyRightCollapses() {
+            var plan = join(
+                scan("t", "t"),
+                new SqlOptimizer.OptimizedPlan.EmptyResult(),
+                SqlPlanner.JoinKind.CROSS, null);
+            var result = dce.apply(plan);
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.EmptyResult.class, result);
+        }
+
+        @Test @DisplayName("Distinct(EmptyResult) → EmptyResult")
+        void distinctEmpty() {
+            var plan = distinct(new SqlOptimizer.OptimizedPlan.EmptyResult());
+            var result = dce.apply(plan);
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.EmptyResult.class, result);
+        }
+
+        @Test @DisplayName("Sort(EmptyResult) → EmptyResult")
+        void sortEmpty() {
+            var plan = sort(new SqlOptimizer.OptimizedPlan.EmptyResult(),
+                            List.of(asc(col("t", "id"))));
+            var result = dce.apply(plan);
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.EmptyResult.class, result);
+        }
+
+        @Test @DisplayName("Limit(EmptyResult) → EmptyResult")
+        void limitEmpty() {
+            var plan = limit(new SqlOptimizer.OptimizedPlan.EmptyResult(), 10L, null);
+            var result = dce.apply(plan);
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.EmptyResult.class, result);
+        }
+
+        @Test @DisplayName("Having(EmptyResult) → EmptyResult")
+        void havingEmpty() {
+            var plan = new SqlOptimizer.OptimizedPlan.Having(
+                new SqlOptimizer.OptimizedPlan.EmptyResult(), lit(true));
+            var result = dce.apply(plan);
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.EmptyResult.class, result);
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // LimitPushdown
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Nested @DisplayName("LimitPushdown")
+    class LimitPushdownTests {
+
+        final SqlOptimizer.LimitPushdown lp = new SqlOptimizer.LimitPushdown();
+
+        @Test @DisplayName("Limit annotates Scan with scanLimit through Project")
+        void limitPropagatesThroughProject() {
+            var scanU = scan("users", "u");
+            var proj  = project(scanU, List.of(starCol()));
+            var lim   = limit(proj, 10L, null);
+
+            var result = lp.apply(lim);
+
+            var limResult  = (SqlOptimizer.OptimizedPlan.Limit) result;
+            var projResult = (SqlOptimizer.OptimizedPlan.Project) limResult.input();
+            var scanResult = (SqlOptimizer.OptimizedPlan.Scan) projResult.input();
+            assertEquals(10L, scanResult.scanLimit());
+        }
+
+        @Test @DisplayName("Limit does NOT push through Sort")
+        void limitDoesNotPushThroughSort() {
+            var scanU = scan("users", "u");
+            var sortP = sort(scanU, List.of(asc(col("u", "name"))));
+            var lim   = limit(sortP, 10L, null);
+
+            var result = lp.apply(lim);
+
+            var limResult  = (SqlOptimizer.OptimizedPlan.Limit) result;
+            var sortResult = (SqlOptimizer.OptimizedPlan.Sort) limResult.input();
+            var scanResult = (SqlOptimizer.OptimizedPlan.Scan) sortResult.input();
+            // scanLimit must NOT be set — Sort is a barrier.
+            assertNull(scanResult.scanLimit());
+        }
+
+        @Test @DisplayName("Limit pushes through Filter")
+        void limitPropagatesThroughFilter() {
+            var scanU   = scan("users", "u");
+            var filtP   = filter(scanU, col("u", "active"));
+            var lim     = limit(filtP, 5L, null);
+
+            var result = lp.apply(lim);
+
+            var limResult  = (SqlOptimizer.OptimizedPlan.Limit) result;
+            var filtResult = (SqlOptimizer.OptimizedPlan.Filter) limResult.input();
+            var scanResult = (SqlOptimizer.OptimizedPlan.Scan) filtResult.input();
+            assertEquals(5L, scanResult.scanLimit());
+        }
+
+        @Test @DisplayName("Limit with offset > 0 is NOT pushed to Scan")
+        void limitWithOffsetNotPushed() {
+            var scanU = scan("users", "u");
+            var lim   = limit(scanU, 10L, 5L);   // LIMIT 10 OFFSET 5
+
+            var result = lp.apply(lim);
+
+            var limResult  = (SqlOptimizer.OptimizedPlan.Limit) result;
+            var scanResult = (SqlOptimizer.OptimizedPlan.Scan) limResult.input();
+            // No scanLimit because offset > 0.
+            assertNull(scanResult.scanLimit());
+        }
+
+        @Test @DisplayName("Limit with offset=0 IS pushed")
+        void limitWithZeroOffsetIsPushed() {
+            var scanU = scan("users", "u");
+            var lim   = limit(scanU, 10L, 0L);   // LIMIT 10 OFFSET 0
+
+            var result = lp.apply(lim);
+
+            var limResult  = (SqlOptimizer.OptimizedPlan.Limit) result;
+            var scanResult = (SqlOptimizer.OptimizedPlan.Scan) limResult.input();
+            assertEquals(10L, scanResult.scanLimit());
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Combined / integration
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Nested @DisplayName("Combined")
+    class CombinedTests {
+
+        @Test @DisplayName("All five passes applied in sequence")
+        void allFivePassesTogether() {
+            // SELECT u.name FROM users u WHERE 1=1 LIMIT 10
+            // After optimize():
+            //   - ConstantFolding folds 1=1 → true
+            //   - DCE removes the Filter(true, ...) → bare Scan
+            //   - ProjectionPruning annotates Scan with requiredColumns=[name]
+            //   - LimitPushdown annotates Scan with scanLimit=10
+
+            var logical = new SqlPlanner.LogicalPlan.Limit(
+                new SqlPlanner.LogicalPlan.Project(
+                    new SqlPlanner.LogicalPlan.Filter(
+                        new SqlPlanner.LogicalPlan.Scan("users", "u"),
+                        eq(lit(1L), lit(1L))   // 1=1 → constant true
+                    ),
+                    List.of(exprCol(col("u", "name"), "name"))
+                ),
+                10L, null
+            );
+
+            var result = SqlOptimizer.optimize(logical);
+
+            // Result should be: Limit(Project(Scan(...)))
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.Limit.class, result);
+            var lim  = (SqlOptimizer.OptimizedPlan.Limit) result;
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.Project.class, lim.input());
+            var proj = (SqlOptimizer.OptimizedPlan.Project) lim.input();
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.Scan.class, proj.input());
+            var scan = (SqlOptimizer.OptimizedPlan.Scan) proj.input();
+
+            // Projection pruning annotated the scan.
+            assertNotNull(scan.requiredColumns());
+            assertTrue(scan.requiredColumns().contains("name"));
+
+            // Limit pushdown annotated the scan.
+            assertEquals(10L, scan.scanLimit());
+        }
+
+        @Test @DisplayName("Filter(FALSE) under aggregate → DCE does not collapse aggregate")
+        void falseFilterUnderAggregate() {
+            // SELECT COUNT(*) FROM t WHERE 1=2
+            // The DCE should make Filter(Scan, false) → EmptyResult,
+            // but Aggregate(EmptyResult) should NOT be collapsed.
+            var logical = new SqlPlanner.LogicalPlan.Aggregate(
+                new SqlPlanner.LogicalPlan.Filter(
+                    new SqlPlanner.LogicalPlan.Scan("t", "t"),
+                    eq(lit(1L), lit(2L))   // 1=2 → false after ConstantFolding
+                ),
+                List.of(),
+                List.of(new SqlPlanner.AggregateItem(
+                    SqlPlanner.AggFunction.COUNT,
+                    new SqlPlanner.AggArg.Star(),
+                    "cnt", false))
+            );
+
+            var result = SqlOptimizer.optimize(logical);
+
+            // After passes: Aggregate should survive (COUNT(*) over empty = 1 row).
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.Aggregate.class, result);
+            var agg = (SqlOptimizer.OptimizedPlan.Aggregate) result;
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.EmptyResult.class, agg.input());
+        }
+
+        @Test @DisplayName("ConstantFolding + DCE: NULL in predicate → EmptyResult")
+        void nullPredicateBecomesEmpty() {
+            // Filter(Scan, NULL) → after CF stays null lit, DCE removes the scan.
+            var plan = new SqlPlanner.LogicalPlan.Filter(
+                new SqlPlanner.LogicalPlan.Scan("t", "t"),
+                lit(null)
+            );
+            var result = SqlOptimizer.optimize(plan);
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.EmptyResult.class, result);
+        }
+
+        @Test @DisplayName("PredicatePushdown + Limit: push both down through Project")
+        void predPushdownAndLimitTogether() {
+            // SELECT u.name FROM users u WHERE u.id = 1 LIMIT 5
+            var logical = new SqlPlanner.LogicalPlan.Limit(
+                new SqlPlanner.LogicalPlan.Project(
+                    new SqlPlanner.LogicalPlan.Filter(
+                        new SqlPlanner.LogicalPlan.Scan("users", "u"),
+                        eq(col("u", "id"), lit(1L))
+                    ),
+                    List.of(exprCol(col("u", "name"), "name"))
+                ),
+                5L, null
+            );
+
+            var result = SqlOptimizer.optimize(logical);
+
+            // After predicate pushdown, the filter should already be below the project.
+            // After limit pushdown, scanLimit = 5.
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.Limit.class, result);
+            var lim = (SqlOptimizer.OptimizedPlan.Limit) result;
+            assertEquals(5L, lim.count());
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Extended ConstantFolding coverage
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Nested @DisplayName("ConstantFolding Extended")
+    class ConstantFoldingExtendedTests {
+
+        @Test @DisplayName("MOD: 10 mod 3 → 1")
+        void modFolding() {
+            var expr = binOp(SqlPlanner.BinaryOperator.MOD, lit(10L), lit(3L));
+            assertEquals(new SqlPlanner.SqlExpr.Literal(1L), fold(expr));
+        }
+
+        @Test @DisplayName("MOD by zero not folded")
+        void modByZeroNotFolded() {
+            var expr = binOp(SqlPlanner.BinaryOperator.MOD, lit(10L), lit(0L));
+            assertInstanceOf(SqlPlanner.SqlExpr.BinaryOp.class, fold(expr));
+        }
+
+        @Test @DisplayName("EQ on literals: 5 = 5 → true")
+        void eqLiterals() {
+            assertEquals(new SqlPlanner.SqlExpr.Literal(true), fold(eq(lit(5L), lit(5L))));
+        }
+
+        @Test @DisplayName("NOT_EQ on literals: 3 != 5 → true")
+        void notEqLiterals() {
+            var expr = binOp(SqlPlanner.BinaryOperator.NOT_EQ, lit(3L), lit(5L));
+            assertEquals(new SqlPlanner.SqlExpr.Literal(true), fold(expr));
+        }
+
+        @Test @DisplayName("GT: 5 > 3 → true")
+        void gtLiterals() {
+            var expr = binOp(SqlPlanner.BinaryOperator.GT, lit(5L), lit(3L));
+            assertEquals(new SqlPlanner.SqlExpr.Literal(true), fold(expr));
+        }
+
+        @Test @DisplayName("GTE: 5 >= 5 → true")
+        void gteLiterals() {
+            var expr = binOp(SqlPlanner.BinaryOperator.GTE, lit(5L), lit(5L));
+            assertEquals(new SqlPlanner.SqlExpr.Literal(true), fold(expr));
+        }
+
+        @Test @DisplayName("LTE: 3 <= 5 → true")
+        void lteLiterals() {
+            var expr = binOp(SqlPlanner.BinaryOperator.LTE, lit(3L), lit(5L));
+            assertEquals(new SqlPlanner.SqlExpr.Literal(true), fold(expr));
+        }
+
+        @Test @DisplayName("AND of two Boolean literals: true AND true → true")
+        void andBothTrue() {
+            assertEquals(new SqlPlanner.SqlExpr.Literal(true), fold(and(lit(true), lit(true))));
+        }
+
+        @Test @DisplayName("OR of two Boolean literals: false OR false → false")
+        void orBothFalse() {
+            assertEquals(new SqlPlanner.SqlExpr.Literal(false), fold(or(lit(false), lit(false))));
+        }
+
+        @Test @DisplayName("FALSE OR x → x (short circuit)")
+        void falseOrXIsX() {
+            var x = col("u", "flag");
+            var result = fold(or(lit(false), x));
+            assertEquals(x, result);
+        }
+
+        @Test @DisplayName("x AND FALSE → FALSE (right-side short circuit)")
+        void xAndFalseIsFalse() {
+            var x = col("u", "flag");
+            assertEquals(new SqlPlanner.SqlExpr.Literal(false), fold(and(x, lit(false))));
+        }
+
+        @Test @DisplayName("x OR FALSE → x (right-side identity)")
+        void xOrFalseIsX() {
+            var x = col("u", "flag");
+            assertEquals(x, fold(or(x, lit(false))));
+        }
+
+        @Test @DisplayName("TRUE AND x → x (left-side identity)")
+        void trueAndXIsX() {
+            var x = col("u", "flag");
+            assertEquals(x, fold(and(lit(true), x)));
+        }
+
+        @Test @DisplayName("DIV of longs: 10 / 3 → 3 (integer division)")
+        void divLongs() {
+            assertEquals(new SqlPlanner.SqlExpr.Literal(3L), fold(div(lit(10L), lit(3L))));
+        }
+
+        @Test @DisplayName("NULL AND FALSE → FALSE (AND short-circuit before null prop)")
+        void nullAndFalseIsFalse() {
+            // FALSE short-circuits AND before null propagation applies.
+            assertEquals(new SqlPlanner.SqlExpr.Literal(false), fold(and(lit(null), lit(false))));
+        }
+
+        @Test @DisplayName("IsNull(Literal(42)) → false")
+        void isNullOfNonNull() {
+            assertEquals(new SqlPlanner.SqlExpr.Literal(false), fold(isNull(lit(42L))));
+        }
+
+        @Test @DisplayName("IsNotNull(Literal(null)) → false")
+        void isNotNullOfNull() {
+            assertEquals(new SqlPlanner.SqlExpr.Literal(false), fold(isNotNull(lit(null))));
+        }
+
+        @Test @DisplayName("NOT(non-Boolean literal) not folded")
+        void notNonBooleanNotFolded() {
+            var result = fold(not(lit(42L)));
+            assertInstanceOf(SqlPlanner.SqlExpr.UnaryOp.class, result);
+        }
+
+        @Test @DisplayName("NEG(null) → null (null propagation)")
+        void negNull() {
+            assertEquals(new SqlPlanner.SqlExpr.Literal(null), fold(neg(lit(null))));
+        }
+
+        @Test @DisplayName("FuncCall args are folded")
+        void funcCallArgsFolded() {
+            var expr = new SqlPlanner.SqlExpr.FuncCall("ABS", List.of(add(lit(1L), lit(2L))));
+            var result = fold(expr);
+            assertInstanceOf(SqlPlanner.SqlExpr.FuncCall.class, result);
+            var fc = (SqlPlanner.SqlExpr.FuncCall) result;
+            assertEquals(new SqlPlanner.SqlExpr.Literal(3L), fc.args().get(0));
+        }
+
+        @Test @DisplayName("Between children are folded")
+        void betweenFolded() {
+            var expr = new SqlPlanner.SqlExpr.Between(
+                add(lit(1L), lit(1L)),
+                lit(0L), lit(5L));
+            var result = fold(expr);
+            assertInstanceOf(SqlPlanner.SqlExpr.Between.class, result);
+            var b = (SqlPlanner.SqlExpr.Between) result;
+            assertEquals(new SqlPlanner.SqlExpr.Literal(2L), b.value());
+        }
+
+        @Test @DisplayName("In items are folded")
+        void inFolded() {
+            var expr = new SqlPlanner.SqlExpr.In(
+                col("u", "x"),
+                List.of(add(lit(1L), lit(1L)), lit(5L)));
+            var result = fold(expr);
+            assertInstanceOf(SqlPlanner.SqlExpr.In.class, result);
+            var in = (SqlPlanner.SqlExpr.In) result;
+            assertEquals(new SqlPlanner.SqlExpr.Literal(2L), in.items().get(0));
+        }
+
+        @Test @DisplayName("NotIn items are folded")
+        void notInFolded() {
+            var expr = new SqlPlanner.SqlExpr.NotIn(
+                col("u", "x"),
+                List.of(add(lit(2L), lit(3L))));
+            var result = fold(expr);
+            assertInstanceOf(SqlPlanner.SqlExpr.NotIn.class, result);
+            var nin = (SqlPlanner.SqlExpr.NotIn) result;
+            assertEquals(new SqlPlanner.SqlExpr.Literal(5L), nin.items().get(0));
+        }
+
+        @Test @DisplayName("Double arithmetic: 1.5 + 2.5 → 4.0")
+        void doubleArithmetic() {
+            var result = fold(add(lit(1.5), lit(2.5)));
+            assertInstanceOf(SqlPlanner.SqlExpr.Literal.class, result);
+            var lit = (SqlPlanner.SqlExpr.Literal) result;
+            assertEquals(4.0, (Double) lit.value(), 1e-9);
+        }
+
+        @Test @DisplayName("NULL + NULL → NULL")
+        void nullPlusNull() {
+            assertEquals(new SqlPlanner.SqlExpr.Literal(null), fold(add(lit(null), lit(null))));
+        }
+
+        @Test @DisplayName("String comparison: 'a' < 'b' → true")
+        void stringComparison() {
+            var result = fold(lt(lit("a"), lit("b")));
+            assertEquals(new SqlPlanner.SqlExpr.Literal(true), result);
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Extended ProjectionPruning coverage
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Nested @DisplayName("ProjectionPruning Extended")
+    class ProjectionPruningExtendedTests {
+
+        @Test @DisplayName("ProjectionPruning with AggArg.Star: no column refs, scan stays null")
+        void aggStarDoesNotPruneColumns() {
+            // Aggregate(Scan, [], [COUNT(*)])
+            var scanT = scan("t", "t");
+            var aggPlan = agg(scanT, List.of(),
+                List.of(new SqlPlanner.AggregateItem(
+                    SqlPlanner.AggFunction.COUNT,
+                    new SqlPlanner.AggArg.Star(),
+                    "cnt", false)));
+
+            var result = new SqlOptimizer.ProjectionPruning().apply(aggPlan);
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.Aggregate.class, result);
+            var a = (SqlOptimizer.OptimizedPlan.Aggregate) result;
+            // COUNT(*) has no column refs; scan's requiredColumns should stay null.
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.Scan.class, a.input());
+            var s = (SqlOptimizer.OptimizedPlan.Scan) a.input();
+            assertNull(s.requiredColumns());
+        }
+
+        @Test @DisplayName("ProjectionPruning with Having: having predicate columns added")
+        void havingPredicateAddsColumns() {
+            // Having(Scan, col(t, cnt) > 5) with Scan("t", "t")
+            var scanT = scan("t", "t");
+            var havingPlan = new SqlOptimizer.OptimizedPlan.Having(
+                scanT,
+                binOp(SqlPlanner.BinaryOperator.GT, col("t", "cnt"), lit(5L)));
+
+            var result = new SqlOptimizer.ProjectionPruning().apply(havingPlan);
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.Having.class, result);
+            var h = (SqlOptimizer.OptimizedPlan.Having) result;
+            // No project above, so required is null; scan stays null.
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.Scan.class, h.input());
+        }
+
+        @Test @DisplayName("ProjectionPruning passes through Distinct")
+        void pruningPassesThroughDistinct() {
+            var scanU = scan("u", "u");
+            var proj  = project(distinct(scanU), List.of(exprCol(col("u", "name"), "n")));
+
+            var result = new SqlOptimizer.ProjectionPruning().apply(proj);
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.Project.class, result);
+            var p = (SqlOptimizer.OptimizedPlan.Project) result;
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.Distinct.class, p.input());
+            var d = (SqlOptimizer.OptimizedPlan.Distinct) p.input();
+            var s = (SqlOptimizer.OptimizedPlan.Scan) d.input();
+            assertNotNull(s.requiredColumns());
+            assertTrue(s.requiredColumns().contains("name"));
+        }
+
+        @Test @DisplayName("ProjectionPruning passes through Limit")
+        void pruningPassesThroughLimit() {
+            var scanU = scan("u", "u");
+            var lim   = limit(scanU, 10L, null);
+            var proj  = project(lim, List.of(exprCol(col("u", "name"), "n")));
+
+            var result = new SqlOptimizer.ProjectionPruning().apply(proj);
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.Project.class, result);
+            var p = (SqlOptimizer.OptimizedPlan.Project) result;
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.Limit.class, p.input());
+            var limResult = (SqlOptimizer.OptimizedPlan.Limit) p.input();
+            var s = (SqlOptimizer.OptimizedPlan.Scan) limResult.input();
+            assertNotNull(s.requiredColumns());
+        }
+
+        @Test @DisplayName("ProjectionPruning with Union passes required to both sides")
+        void pruningWithUnion() {
+            var scanA = scan("a", "a");
+            var scanB = scan("b", "b");
+            var u     = new SqlOptimizer.OptimizedPlan.Union(scanA, scanB, false);
+            // No project; required is null → both scans stay null.
+            var result = new SqlOptimizer.ProjectionPruning().apply(u);
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.Union.class, result);
+            var un = (SqlOptimizer.OptimizedPlan.Union) result;
+            assertNull(((SqlOptimizer.OptimizedPlan.Scan) un.left()).requiredColumns());
+            assertNull(((SqlOptimizer.OptimizedPlan.Scan) un.right()).requiredColumns());
+        }
+
+        @Test @DisplayName("ProjectionPruning collectColRefs handles AggArg.Expr path")
+        void aggExprColRefPath() {
+            // Project(Aggregate(Scan("t","t"), [], [SUM(t.amount)]), [t.amount])
+            // The project feeds required = {t:amount} to aggregate.
+            // The aggregate resets required and adds AggArg.Expr(col("t","amount"))
+            // → newRequired = {t:amount}.
+            // The scan receives required = {t:amount} → requiredColumns = ["amount"].
+            var scanT = scan("t", "t");
+            var aggPlan = agg(scanT, List.of(),
+                List.of(new SqlPlanner.AggregateItem(
+                    SqlPlanner.AggFunction.SUM,
+                    new SqlPlanner.AggArg.Expr(col("t", "amount")),
+                    "total", false)));
+            var proj = project(aggPlan, List.of(exprCol(col("t", "amount"), "amt")));
+
+            var result = new SqlOptimizer.ProjectionPruning().apply(proj);
+            var p = (SqlOptimizer.OptimizedPlan.Project) result;
+            var a = (SqlOptimizer.OptimizedPlan.Aggregate) p.input();
+            var s = (SqlOptimizer.OptimizedPlan.Scan) a.input();
+            assertNotNull(s.requiredColumns());
+            assertTrue(s.requiredColumns().contains("amount"));
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Extended PredicatePushdown coverage
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Nested @DisplayName("PredicatePushdown Extended")
+    class PredicatePushdownExtendedTests {
+
+        @Test @DisplayName("RIGHT JOIN: left-side predicate NOT pushed")
+        void rightJoinLeftNotPushed() {
+            var predLeft = eq(col("u", "id"), lit(1L));
+            var scanU = scan("users", "u");
+            var scanO = scan("orders", "o");
+            var joined = join(scanU, scanO, SqlPlanner.JoinKind.RIGHT, null);
+            var filtered = filter(joined, predLeft);
+
+            var result = new SqlOptimizer.PredicatePushdown().apply(filtered);
+
+            // LEFT side pred not pushed through RIGHT JOIN.
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.Filter.class, result);
+        }
+
+        @Test @DisplayName("FULL JOIN: no predicate pushed")
+        void fullJoinNothingPushed() {
+            var pred = eq(col("u", "id"), lit(1L));
+            var scanU = scan("users", "u");
+            var scanO = scan("orders", "o");
+            var joined = join(scanU, scanO, SqlPlanner.JoinKind.FULL, null);
+            var filtered = filter(joined, pred);
+
+            var result = new SqlOptimizer.PredicatePushdown().apply(filtered);
+
+            // FULL JOIN: nothing pushed.
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.Filter.class, result);
+            var f = (SqlOptimizer.OptimizedPlan.Filter) result;
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.Join.class, f.input());
+            var j = (SqlOptimizer.OptimizedPlan.Join) f.input();
+            // Neither side should have a Filter added.
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.Scan.class, j.left());
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.Scan.class, j.right());
+        }
+
+        @Test @DisplayName("INNER JOIN: right-side predicate IS pushed to right")
+        void innerJoinRightPushed() {
+            var predRight = eq(col("o", "status"), lit("active"));
+            var scanU = scan("users", "u");
+            var scanO = scan("orders", "o");
+            var joined = join(scanU, scanO, SqlPlanner.JoinKind.INNER,
+                eq(col("u", "id"), col("o", "user_id")));
+            var filtered = filter(joined, predRight);
+
+            var result = new SqlOptimizer.PredicatePushdown().apply(filtered);
+
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.Join.class, result);
+            var j = (SqlOptimizer.OptimizedPlan.Join) result;
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.Filter.class, j.right());
+        }
+
+        @Test @DisplayName("Predicate with no column refs pushed to left by convention")
+        void noColRefPredicatePushedLeft() {
+            var pred = lit(true);   // no column references
+            var scanU = scan("users", "u");
+            var scanO = scan("orders", "o");
+            var joined = join(scanU, scanO, SqlPlanner.JoinKind.INNER, null);
+            var filtered = filter(joined, pred);
+
+            var result = new SqlOptimizer.PredicatePushdown().apply(filtered);
+
+            // No-column predicate goes to left by convention.
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.Join.class, result);
+        }
+
+        @Test @DisplayName("Filter through Project: predicate referencing non-scan alias stays above")
+        void filterThroughProjectNonMatchingAlias() {
+            // Project(Scan("t","t"), ...) filtered by col("x", "y")
+            // "x" is not a scan alias below the project → stays above.
+            var pred = eq(col("x", "y"), lit(1L));
+            var proj = project(scan("t", "t"), List.of(exprCol(col("t", "id"), "id")));
+            var filtered = filter(proj, pred);
+
+            var result = new SqlOptimizer.PredicatePushdown().apply(filtered);
+
+            // Filter should stay above project.
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.Filter.class, result);
+            var f = (SqlOptimizer.OptimizedPlan.Filter) result;
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.Project.class, f.input());
+        }
+
+        @Test @DisplayName("splitAnd correctly splits 3-way AND")
+        void splitAndThreeWay() {
+            var a = col("u", "a");
+            var b = col("u", "b");
+            var c = col("u", "c");
+            var expr = and(and(a, b), c);
+            var parts = SqlOptimizer.PredicatePushdown.splitAnd(expr);
+            assertEquals(3, parts.size());
+        }
+
+        @Test @DisplayName("columnAliases returns correct alias set")
+        void columnAliasesHelper() {
+            var expr = and(col("u", "id"), col("o", "uid"));
+            var aliases = SqlOptimizer.PredicatePushdown.columnAliases(expr);
+            assertTrue(aliases.contains("u"));
+            assertTrue(aliases.contains("o"));
+        }
+
+        @Test @DisplayName("Filter not pushed through Limit (barrier)")
+        void filterNotPushedThroughLimit() {
+            var pred = eq(col("t", "id"), lit(1L));
+            var lim  = limit(scan("t", "t"), 10L, null);
+            var f    = filter(lim, pred);
+
+            var result = new SqlOptimizer.PredicatePushdown().apply(f);
+
+            // Filter stays above Limit.
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.Filter.class, result);
+            var fr = (SqlOptimizer.OptimizedPlan.Filter) result;
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.Limit.class, fr.input());
+        }
+
+        @Test @DisplayName("collectAliases includes aliases from nested Join")
+        void collectAliasesNestedJoin() {
+            var j = join(scan("u","u"), scan("o","o"), SqlPlanner.JoinKind.INNER, null);
+            var aliases = SqlOptimizer.PredicatePushdown.collectAliases(j);
+            assertTrue(aliases.contains("u"));
+            assertTrue(aliases.contains("o"));
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Extended LimitPushdown coverage
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Nested @DisplayName("LimitPushdown Extended")
+    class LimitPushdownExtendedTests {
+
+        @Test @DisplayName("LimitPushdown does not push through Aggregate (barrier)")
+        void limitDoesNotPushThroughAggregate() {
+            var scanT = scan("t", "t");
+            var aggP  = agg(scanT, List.of(), List.of());
+            var lim   = limit(aggP, 5L, null);
+
+            var result = new SqlOptimizer.LimitPushdown().apply(lim);
+            var limResult = (SqlOptimizer.OptimizedPlan.Limit) result;
+            var aggResult = (SqlOptimizer.OptimizedPlan.Aggregate) limResult.input();
+            var scanResult = (SqlOptimizer.OptimizedPlan.Scan) aggResult.input();
+            assertNull(scanResult.scanLimit());
+        }
+
+        @Test @DisplayName("LimitPushdown does not push through Distinct (barrier)")
+        void limitDoesNotPushThroughDistinct() {
+            var scanT = scan("t", "t");
+            var distP = distinct(scanT);
+            var lim   = limit(distP, 5L, null);
+
+            var result = new SqlOptimizer.LimitPushdown().apply(lim);
+            var limResult = (SqlOptimizer.OptimizedPlan.Limit) result;
+            var distResult = (SqlOptimizer.OptimizedPlan.Distinct) limResult.input();
+            var scanResult = (SqlOptimizer.OptimizedPlan.Scan) distResult.input();
+            assertNull(scanResult.scanLimit());
+        }
+
+        @Test @DisplayName("Multiple nested limits: min(5, 10) = 5 pushed to scan")
+        void nestedLimitsTakeMin() {
+            var scanT = scan("t", "t");
+            var inner = limit(scanT, 10L, null);
+            var outer = limit(inner, 5L, null);
+
+            var result = new SqlOptimizer.LimitPushdown().apply(outer);
+            var outerLim = (SqlOptimizer.OptimizedPlan.Limit) result;
+            var innerLim = (SqlOptimizer.OptimizedPlan.Limit) outerLim.input();
+            var scanResult = (SqlOptimizer.OptimizedPlan.Scan) innerLim.input();
+            assertEquals(5L, scanResult.scanLimit());
+        }
+
+        @Test @DisplayName("LimitPushdown does not push through Join (barrier)")
+        void limitDoesNotPushThroughJoin() {
+            var j   = join(scan("u","u"), scan("o","o"), SqlPlanner.JoinKind.INNER, null);
+            var lim = limit(j, 5L, null);
+
+            var result = new SqlOptimizer.LimitPushdown().apply(lim);
+            var limResult = (SqlOptimizer.OptimizedPlan.Limit) result;
+            var jResult = (SqlOptimizer.OptimizedPlan.Join) limResult.input();
+            assertNull(((SqlOptimizer.OptimizedPlan.Scan) jResult.left()).scanLimit());
+        }
+
+        @Test @DisplayName("LimitPushdown does not push through Union (barrier)")
+        void limitDoesNotPushThroughUnion() {
+            var u   = new SqlOptimizer.OptimizedPlan.Union(scan("a","a"), scan("b","b"), false);
+            var lim = limit(u, 5L, null);
+
+            var result = new SqlOptimizer.LimitPushdown().apply(lim);
+            var limResult = (SqlOptimizer.OptimizedPlan.Limit) result;
+            var uResult = (SqlOptimizer.OptimizedPlan.Union) limResult.input();
+            assertNull(((SqlOptimizer.OptimizedPlan.Scan) uResult.left()).scanLimit());
+        }
+
+        @Test @DisplayName("LimitPushdown: null count does not annotate scan")
+        void nullCountDoesNotAnnotateScan() {
+            // Limit(Scan, null, null) — no count to push
+            var scanT = scan("t", "t");
+            var lim   = limit(scanT, null, null);
+
+            var result = new SqlOptimizer.LimitPushdown().apply(lim);
+            var limResult = (SqlOptimizer.OptimizedPlan.Limit) result;
+            var scanResult = (SqlOptimizer.OptimizedPlan.Scan) limResult.input();
+            assertNull(scanResult.scanLimit());
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // ConstantFolding plan-level traversal coverage
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Nested @DisplayName("ConstantFolding Plan Traversal")
+    class ConstantFoldingPlanTraversalTests {
+
+        private final SqlOptimizer.ConstantFolding cf = new SqlOptimizer.ConstantFolding();
+
+        @Test @DisplayName("CF folds expression in Sort key")
+        void foldSortKey() {
+            // Sort by add(1,2) — should fold the key expression.
+            var plan = sort(scan("t","t"), List.of(
+                new SqlPlanner.SortKey(add(lit(1L), lit(2L)),
+                    SqlPlanner.SortDir.ASC, SqlPlanner.NullOrder.NULLS_LAST)));
+            var result = cf.apply(plan);
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.Sort.class, result);
+            var s = (SqlOptimizer.OptimizedPlan.Sort) result;
+            assertEquals(new SqlPlanner.SqlExpr.Literal(3L), s.keys().get(0).keyExpr());
+        }
+
+        @Test @DisplayName("CF traverses Limit node")
+        void foldLimit() {
+            // Filter(Scan, 1+2) under Limit
+            var plan = limit(filter(scan("t","t"), add(lit(1L), lit(2L))), 5L, null);
+            var result = cf.apply(plan);
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.Limit.class, result);
+            var l = (SqlOptimizer.OptimizedPlan.Limit) result;
+            var f = (SqlOptimizer.OptimizedPlan.Filter) l.input();
+            assertEquals(new SqlPlanner.SqlExpr.Literal(3L), f.predicate());
+        }
+
+        @Test @DisplayName("CF traverses Distinct node")
+        void foldDistinct() {
+            var plan = distinct(filter(scan("t","t"), add(lit(1L), lit(1L))));
+            var result = cf.apply(plan);
+            var d = (SqlOptimizer.OptimizedPlan.Distinct) result;
+            var f = (SqlOptimizer.OptimizedPlan.Filter) d.input();
+            assertEquals(new SqlPlanner.SqlExpr.Literal(2L), f.predicate());
+        }
+
+        @Test @DisplayName("CF traverses Union node")
+        void foldUnion() {
+            var leftF  = filter(scan("a","a"), add(lit(1L), lit(1L)));
+            var rightF = filter(scan("b","b"), add(lit(2L), lit(2L)));
+            var plan   = new SqlOptimizer.OptimizedPlan.Union(leftF, rightF, false);
+            var result = cf.apply(plan);
+            var u = (SqlOptimizer.OptimizedPlan.Union) result;
+            assertEquals(new SqlPlanner.SqlExpr.Literal(2L),
+                ((SqlOptimizer.OptimizedPlan.Filter) u.left()).predicate());
+            assertEquals(new SqlPlanner.SqlExpr.Literal(4L),
+                ((SqlOptimizer.OptimizedPlan.Filter) u.right()).predicate());
+        }
+
+        @Test @DisplayName("CF traverses Having node")
+        void foldHaving() {
+            var plan = new SqlOptimizer.OptimizedPlan.Having(
+                scan("t","t"), add(lit(3L), lit(4L)));
+            var result = cf.apply(plan);
+            var h = (SqlOptimizer.OptimizedPlan.Having) result;
+            assertEquals(new SqlPlanner.SqlExpr.Literal(7L), h.predicate());
+        }
+
+        @Test @DisplayName("CF traverses Aggregate groupBy expressions")
+        void foldAggGroupBy() {
+            var plan = agg(scan("t","t"),
+                List.of(add(lit(1L), lit(1L))),
+                List.of());
+            var result = cf.apply(plan);
+            var a = (SqlOptimizer.OptimizedPlan.Aggregate) result;
+            assertEquals(new SqlPlanner.SqlExpr.Literal(2L), a.groupBy().get(0));
+        }
+
+        @Test @DisplayName("CF traverses Join: folds condition and recurses into children")
+        void foldJoin() {
+            var lf = filter(scan("u","u"), add(lit(1L), lit(2L)));
+            var rf = filter(scan("o","o"), add(lit(3L), lit(4L)));
+            var plan = join(lf, rf, SqlPlanner.JoinKind.INNER, add(lit(5L), lit(5L)));
+            var result = cf.apply(plan);
+            var j = (SqlOptimizer.OptimizedPlan.Join) result;
+            assertEquals(new SqlPlanner.SqlExpr.Literal(10L), j.condition());
+            assertEquals(new SqlPlanner.SqlExpr.Literal(3L),
+                ((SqlOptimizer.OptimizedPlan.Filter) j.left()).predicate());
+            assertEquals(new SqlPlanner.SqlExpr.Literal(7L),
+                ((SqlOptimizer.OptimizedPlan.Filter) j.right()).predicate());
+        }
+
+        @Test @DisplayName("CF traverses Join with null condition")
+        void foldJoinNullCondition() {
+            var plan = join(scan("u","u"), scan("o","o"), SqlPlanner.JoinKind.CROSS, null);
+            var result = cf.apply(plan);
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.Join.class, result);
+            assertNull(((SqlOptimizer.OptimizedPlan.Join) result).condition());
+        }
+
+        @Test @DisplayName("CF: NEG on Double literal")
+        void negDouble() {
+            assertEquals(new SqlPlanner.SqlExpr.Literal(-3.14), fold(neg(lit(-(-3.14)))));
+            var r = fold(neg(lit(2.5)));
+            assertEquals(new SqlPlanner.SqlExpr.Literal(-2.5), r);
+        }
+
+        @Test @DisplayName("CF: AND with two non-boolean non-null literals stays as BinaryOp")
+        void andNonBooleanLiterals() {
+            // AND(42, 99) — both non-null, non-boolean → returns BinaryOp unchanged.
+            var expr = and(lit(42L), lit(99L));
+            var result = fold(expr);
+            assertInstanceOf(SqlPlanner.SqlExpr.BinaryOp.class, result);
+        }
+
+        @Test @DisplayName("CF: OR with two non-boolean non-null literals stays as BinaryOp")
+        void orNonBooleanLiterals() {
+            var expr = or(lit(42L), lit(99L));
+            var result = fold(expr);
+            assertInstanceOf(SqlPlanner.SqlExpr.BinaryOp.class, result);
+        }
+
+        @Test @DisplayName("CF: DIV zero-check for Double 0.0")
+        void divByDoubleZeroNotFolded() {
+            var expr = div(lit(10.0), lit(0.0));
+            assertInstanceOf(SqlPlanner.SqlExpr.BinaryOp.class, fold(expr));
+        }
+
+        @Test @DisplayName("CF: MOD zero-check for Double 0.0")
+        void modByDoubleZeroNotFolded() {
+            var expr = binOp(SqlPlanner.BinaryOperator.MOD, lit(10.0), lit(0.0));
+            assertInstanceOf(SqlPlanner.SqlExpr.BinaryOp.class, fold(expr));
+        }
+
+        @Test @DisplayName("CF: Integer + Long → Long")
+        void intPlusLong() {
+            // Box as Integer (not Long) for the Integer+Long branch.
+            var result = fold(add(
+                new SqlPlanner.SqlExpr.Literal(Integer.valueOf(3)),
+                lit(4L)));
+            assertEquals(new SqlPlanner.SqlExpr.Literal(7L), result);
+        }
+
+        @Test @DisplayName("CF: Long + Integer → Long")
+        void longPlusInt() {
+            var result = fold(add(
+                lit(10L),
+                new SqlPlanner.SqlExpr.Literal(Integer.valueOf(5))));
+            assertEquals(new SqlPlanner.SqlExpr.Literal(15L), result);
+        }
+
+        @Test @DisplayName("CF: Integer + Integer → Long")
+        void intPlusInt() {
+            var result = fold(add(
+                new SqlPlanner.SqlExpr.Literal(Integer.valueOf(2)),
+                new SqlPlanner.SqlExpr.Literal(Integer.valueOf(3))));
+            assertEquals(new SqlPlanner.SqlExpr.Literal(5L), result);
+        }
+
+        @Test @DisplayName("CF: OutputColumn.Star passthrough in Project")
+        void projectStarPassthrough() {
+            var plan = project(scan("t","t"), List.of(starCol()));
+            var result = cf.apply(plan);
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.Project.class, result);
+            var p = (SqlOptimizer.OptimizedPlan.Project) result;
+            assertInstanceOf(SqlPlanner.OutputColumn.Star.class, p.columns().get(0));
+        }
+
+        @Test @DisplayName("CF: default branch returns DML nodes unchanged")
+        void defaultBranchDml() {
+            var ins = new SqlOptimizer.OptimizedPlan.Insert("t",
+                List.of("id"), List.of(List.of(lit(1L))));
+            var result = cf.apply(ins);
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.Insert.class, result);
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Extended DeadCodeElimination coverage
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Nested @DisplayName("DeadCodeElimination Extended")
+    class DeadCodeEliminationExtendedTests {
+
+        @Test @DisplayName("Union(left, EmptyResult) → left")
+        void unionWithEmptyRight() {
+            var scanT = scan("t", "t");
+            var u = new SqlOptimizer.OptimizedPlan.Union(
+                scanT,
+                new SqlOptimizer.OptimizedPlan.EmptyResult(),
+                false);
+            var result = new SqlOptimizer.DeadCodeElimination().apply(u);
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.Scan.class, result);
+        }
+
+        @Test @DisplayName("LEFT JOIN with EmptyResult left — NOT collapsed (left outer join)")
+        void leftJoinEmptyLeftNotCollapsed() {
+            // LEFT JOIN: even when left side is empty, we don't collapse
+            // (outer joins can still produce rows via null padding from right side
+            // — actually LEFT JOIN returns right rows? No — LEFT JOIN returns all
+            // left rows. If left is empty, LEFT JOIN is empty too, but we're
+            // conservative here and only collapse INNER/CROSS.)
+            var leftEmpty = new SqlOptimizer.OptimizedPlan.EmptyResult();
+            var scanO = scan("o", "o");
+            var plan = join(leftEmpty, scanO, SqlPlanner.JoinKind.LEFT, null);
+
+            var result = new SqlOptimizer.DeadCodeElimination().apply(plan);
+            // LEFT JOIN(EmptyResult, ...) is actually also empty, but our DCE
+            // conservatively only collapses INNER and CROSS — so the join stays.
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.Join.class, result);
+        }
+
+        @Test @DisplayName("Limit(EmptyResult) → EmptyResult even with non-zero count")
+        void limitNonZeroCountWithEmptyInput() {
+            var plan = limit(new SqlOptimizer.OptimizedPlan.EmptyResult(), 10L, null);
+            var result = new SqlOptimizer.DeadCodeElimination().apply(plan);
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.EmptyResult.class, result);
+        }
+
+        @Test @DisplayName("DCE recurses: Filter(Filter(Scan, false), pred) → EmptyResult")
+        void dceRecursesIntoFilter() {
+            var innerFalse = filter(scan("t","t"), lit(false));
+            var outer = filter(innerFalse, col("t","x"));
+            var result = new SqlOptimizer.DeadCodeElimination().apply(outer);
+            // Inner becomes EmptyResult, outer filter of EmptyResult → EmptyResult.
+            assertInstanceOf(SqlOptimizer.OptimizedPlan.EmptyResult.class, result);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Ports `sql-optimizer` to Java 21 using sealed interfaces + records
- 5 optimization passes: ConstantFolding, PredicatePushdown, ProjectionPruning, DeadCodeElimination, LimitPushdown
- `OptimizedPlan` sealed interface extends planner's `LogicalPlan` shape with `EmptyResult` node and scan annotations (`requiredColumns`, `scanLimit`)
- 124 JUnit 5 tests; ≥80% line coverage (JaCoCo enforced by `gradle check`)
- Pre-push security review: PASS (fixed one LOW finding — mixed-type ClassCastException in `compareValues`)

## Architecture
`SqlOptimizer` is a self-contained class that imports from `sql-planner`. The five default passes run in order:

1. **ConstantFolding** — folds arithmetic, comparisons, Boolean short-circuit, NULL propagation, IS NULL/IS NOT NULL on Literal nodes (bottom-up)
2. **PredicatePushdown** — splits AND conjuncts; pushes filters through Sort, Distinct, Project; routes to correct INNER/CROSS Join sides; respects LEFT/RIGHT/FULL outer-join safety guards
3. **ProjectionPruning** — top-down (table, column) required-set tracking; annotates Scan nodes with minimal column subset
4. **DeadCodeElimination** — Filter(false/null)→EmptyResult; Filter(true)→child; Limit(0)→EmptyResult; propagates EmptyResult upward; intentionally does NOT collapse Aggregate(EmptyResult) (COUNT(*) semantics)
5. **LimitPushdown** — propagates LIMIT N (no offset) through Project/Filter down to Scan.scanLimit

## Test plan
- [ ] All 124 tests pass (`gradle test`)
- [ ] `gradle check` passes (includes JaCoCo ≥80% line coverage verification)
- [ ] CI green on ubuntu / macos / windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)