### PR TITLE
feat(mle-pass): slice 5 — two more multi-hop chains via cross-library id-joins

### DIFF
--- a/code/specs/MLE-PASS-multihop-recall.md
+++ b/code/specs/MLE-PASS-multihop-recall.md
@@ -138,6 +138,25 @@ disease→organism→trait reasoning. Today only this disease bridges a finding 
 so more land for free as cross-library id-joins are grounded (§7). Run-verified: **34/34 correct**
 (31 answerable, `multihop_coverage` 1.0, the 3-hop citing 3 spans; 3 abstained), zero model calls.
 
+## 6c. Slice 5 (shipped) — two more chains from cross-library id-joins
+The bank grew **34 → 38**: two diseases now chain end-to-end *only* because a finding-library disease
+id already equals a `genetics-edges` disease id — nothing was grounded, renamed, or authored, exactly
+the "land for free" mechanism §7 anticipated.
+
+```
+cafe_au_lait_macules ──skin_finding_in──▶ neurofibromatosis_type_1 ──gene_defect──▶ nf1   (derm + genetics)
+                                              └──────────────────── inheritance ──▶ autosomal_dominant
+heinz_bodies ──seen_in──▶ g6pd_deficiency ──gene_defect──▶ g6pd                          (histo + genetics)
+                              └──────────── inheritance ──▶ x_linked
+```
+
+`heinz_bodies` also has a grounded edge to `methemoglobinemia`, but only `g6pd_deficiency` carries a
+`gene_defect`/`inheritance` edge, so the conjunctive join binds a **single** answer — the second hop
+disambiguates a multi-disease hop-1 finding, rather than the harness guessing. These add two new
+hop-1 libraries to the gene/inheritance chains (dermatology, histopathology), two genes (`nf1`,
+`g6pd`), and the `x_linked` pattern. Run-verified: **38/38 correct** (35 answerable, both hops cited,
+`multihop_coverage` 1.0; 3 abstained), zero model calls.
+
 ## 7. Next
 The **three-hop harness now exists** (slice 4); the limit is grounded id-joins, not the engine.
 More 3-hops land for free once: (a) more finding→disease edges reach micro `causes` diseases

--- a/code/specs/data/mycin-2026/mle-pass/CHANGELOG.md
+++ b/code/specs/data/mycin-2026/mle-pass/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog — mle-pass
 
+## [0.5.0] — 2026-06-30
+
+### Added — slice 5: two more clue→disease→{gene, inheritance} chains via cross-library id-joins
+
+- Bank grows **34 → 38**: two new diseases now chain end-to-end purely because a **finding-library
+  disease id already matches a `genetics-edges` disease id** — no edge was grounded, renamed, or
+  authored for this PR; the generator only arranges already-grounded, spider+adversarially-gated
+  facts (per the no-human-authored rule).
+  - **`cafe_au_lait_macules → neurofibromatosis_type_1 → nf1`** (gene, `mh-35`) and **→
+    `autosomal_dominant`** (inheritance, `mh-37`): hop 1 is `derm-edges.adj skin_finding_in`, joined
+    on the shared disease to `genetics-edges.adj`.
+  - **`heinz_bodies → g6pd_deficiency → g6pd`** (gene, `mh-36`) and **→ `x_linked`** (inheritance,
+    `mh-38`): hop 1 is `histo-edges.adj seen_in`. Note `heinz_bodies` also has a grounded edge to
+    `methemoglobinemia`, but only `g6pd_deficiency` has a `gene_defect`/`inheritance` edge, so the
+    conjunctive join disambiguates to a single answer — a demonstration that a multi-disease hop-1
+    finding is resolved by the second hop, not by guessing.
+- These reach **two new genes** (`nf1`, `g6pd`, added to `GENE_POOL`) and the **`x_linked`**
+  inheritance pattern (added to `INH_POOL`), and exercise **two new hop-1 libraries for the gene/
+  inheritance chains** (derm, histopathology) — widening the proof that the harness is generic over
+  the source library.
+- Eval: **38/38 correct, 0 wrong, 3 correct abstentions, multihop_coverage 1.0** — every answerable
+  item cites BOTH hops' byte-provenance, zero model calls.
+
 ## [0.4.0] — 2026-06-30
 
 ### Added — slice 4: a genuine THREE-relation chain (N-hop harness)

--- a/code/specs/data/mycin-2026/mle-pass/README.md
+++ b/code/specs/data/mycin-2026/mle-pass/README.md
@@ -98,3 +98,11 @@ first genuine **three-relation** chain (`pseudomembranes → pseudomembranous_co
 gram_positive`), joined on two shared interior entities, the answer citing all three hops. The bank
 ships one 3-hop today (only that disease bridges a finding library to a micro `causes` disease), but
 the harness supports any N-hop — more land for free as cross-library id-joins are grounded.
+
+Slice 5: **38/38 correct, zero model calls** — slice-4 plus four more clue→disease→{gene,
+inheritance} chains landed PURELY by cross-library id-joins that are already grounded:
+`cafe_au_lait_macules → neurofibromatosis_type_1 → nf1 / autosomal_dominant` (hop 1 = `derm-edges`)
+and `heinz_bodies → g6pd_deficiency → g6pd / x_linked` (hop 1 = `histo-edges`). Nothing was grounded,
+renamed, or authored — exactly the "land for free" the spec anticipated. (`heinz_bodies` also maps to
+`methemoglobinemia`, but only `g6pd_deficiency` carries the gene/inheritance edge, so the join binds a
+single answer — the second hop disambiguates.) `multihop_coverage` 1.0 over the 35 answerable items.

--- a/code/specs/data/mycin-2026/mle-pass/gen_items.py
+++ b/code/specs/data/mycin-2026/mle-pass/gen_items.py
@@ -40,9 +40,17 @@ GENE_CHAINS = [
      "niemann_pick_disease", "smpd1", "deficiency of sphingomyelinase", "a mutation in which gene"),
     ("mh-10", "acid_alpha_glucosidase", "enzyme-deficiency-edges.adj", "enzyme_deficiency_disease",
      "pompe_disease", "gaa", "deficiency of acid alpha-glucosidase", "a mutation in which gene"),
+    # slice 5 — two more clue→disease→gene chains landed PURELY by cross-library id-joins that are
+    # already grounded: a derm skin-finding and a histopathology smear finding, each whose disease
+    # id already matches a genetics `gene_defect` disease id. Nothing new was grounded.
+    ("mh-35", "cafe_au_lait_macules", "derm-edges.adj", "skin_finding_in",
+     "neurofibromatosis_type_1", "nf1", "café-au-lait macules", "a mutation in which gene"),
+    ("mh-36", "heinz_bodies", "histo-edges.adj", "seen_in",
+     "g6pd_deficiency", "g6pd", "Heinz bodies on the peripheral blood smear", "a mutation in which gene"),
 ]
 GENE_POOL = ["rb1", "atp7b", "fbn1", "htt", "col1a1", "gla", "gba1", "hexa", "cftr",
-             "dmpk", "fmr1", "pah", "hfe", "ube3a", "fxn", "tsc1_tsc2", "smpd1", "gaa"]
+             "dmpk", "fmr1", "pah", "hfe", "ube3a", "fxn", "tsc1_tsc2", "smpd1", "gaa",
+             "nf1", "g6pd"]
 
 # hop 2 = inheritance (a different second relation; answer is a transmission pattern)
 INH_CHAINS = [
@@ -52,9 +60,15 @@ INH_CHAINS = [
      "wilson_disease", "autosomal_recessive", "Kayser-Fleischer corneal rings"),
     ("mh-13", "superior_lens_dislocation", "ophtho-edges.adj", "eye_finding_indicates",
      "marfan_syndrome", "autosomal_dominant", "upward (superior) lens dislocation"),
+    # slice 5 — the same two new cross-library joins, this time with hop 2 = inheritance, proving
+    # one finding library feeds BOTH second relations off the shared disease id.
+    ("mh-37", "cafe_au_lait_macules", "derm-edges.adj", "skin_finding_in",
+     "neurofibromatosis_type_1", "autosomal_dominant", "café-au-lait macules"),
+    ("mh-38", "heinz_bodies", "histo-edges.adj", "seen_in",
+     "g6pd_deficiency", "x_linked", "Heinz bodies on the peripheral blood smear"),
 ]
 INH_POOL = ["autosomal_dominant", "autosomal_recessive", "x_linked_recessive",
-            "x_linked_dominant", "mitochondrial"]
+            "x_linked_dominant", "x_linked", "mitochondrial"]
 
 # slice 3 — microbiology organism-ID chain (the original MYCIN domain), run in REVERSE:
 # the clue is a *disease*, hop 1 is `causes(organism, disease)` traversed backwards to bind the

--- a/code/specs/data/mycin-2026/mle-pass/items.json
+++ b/code/specs/data/mycin-2026/mle-pass/items.json
@@ -192,6 +192,44 @@
       "gold_letter": "E"
     },
     {
+      "id": "mh-35",
+      "qtype": "multi_hop_recall",
+      "stem": "A patient has caf\u00e9-au-lait macules. That finding points to a single disease; the disease is caused by a mutation in which gene?",
+      "hop1_lib": "derm-edges.adj",
+      "hop1_relation": "skin_finding_in",
+      "hop2_lib": "genetics-edges.adj",
+      "hop2_relation": "gene_defect",
+      "clue": "cafe_au_lait_macules",
+      "expected": "nf1",
+      "options": {
+        "A": "nf1",
+        "B": "rb1",
+        "C": "atp7b",
+        "D": "fbn1",
+        "E": "htt"
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "mh-36",
+      "qtype": "multi_hop_recall",
+      "stem": "A patient has Heinz bodies on the peripheral blood smear. That finding points to a single disease; the disease is caused by a mutation in which gene?",
+      "hop1_lib": "histo-edges.adj",
+      "hop1_relation": "seen_in",
+      "hop2_lib": "genetics-edges.adj",
+      "hop2_relation": "gene_defect",
+      "clue": "heinz_bodies",
+      "expected": "g6pd",
+      "options": {
+        "A": "rb1",
+        "B": "g6pd",
+        "C": "atp7b",
+        "D": "fbn1",
+        "E": "htt"
+      },
+      "gold_letter": "B"
+    },
+    {
       "id": "mh-11",
       "qtype": "multi_hop_recall",
       "stem": "A patient has degeneration of the caudate nucleus. That finding points to a single disease; that disease is inherited in which pattern?",
@@ -206,7 +244,7 @@
         "B": "autosomal_recessive",
         "C": "x_linked_recessive",
         "D": "x_linked_dominant",
-        "E": "mitochondrial"
+        "E": "x_linked"
       },
       "gold_letter": "A"
     },
@@ -225,7 +263,7 @@
         "B": "autosomal_recessive",
         "C": "x_linked_recessive",
         "D": "x_linked_dominant",
-        "E": "mitochondrial"
+        "E": "x_linked"
       },
       "gold_letter": "B"
     },
@@ -244,9 +282,47 @@
         "B": "x_linked_recessive",
         "C": "autosomal_dominant",
         "D": "x_linked_dominant",
-        "E": "mitochondrial"
+        "E": "x_linked"
       },
       "gold_letter": "C"
+    },
+    {
+      "id": "mh-37",
+      "qtype": "multi_hop_recall",
+      "stem": "A patient has caf\u00e9-au-lait macules. That finding points to a single disease; that disease is inherited in which pattern?",
+      "hop1_lib": "derm-edges.adj",
+      "hop1_relation": "skin_finding_in",
+      "hop2_lib": "genetics-edges.adj",
+      "hop2_relation": "inheritance",
+      "clue": "cafe_au_lait_macules",
+      "expected": "autosomal_dominant",
+      "options": {
+        "A": "autosomal_recessive",
+        "B": "x_linked_recessive",
+        "C": "x_linked_dominant",
+        "D": "autosomal_dominant",
+        "E": "x_linked"
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "mh-38",
+      "qtype": "multi_hop_recall",
+      "stem": "A patient has Heinz bodies on the peripheral blood smear. That finding points to a single disease; that disease is inherited in which pattern?",
+      "hop1_lib": "histo-edges.adj",
+      "hop1_relation": "seen_in",
+      "hop2_lib": "genetics-edges.adj",
+      "hop2_relation": "inheritance",
+      "clue": "heinz_bodies",
+      "expected": "x_linked",
+      "options": {
+        "A": "autosomal_dominant",
+        "B": "autosomal_recessive",
+        "C": "x_linked_recessive",
+        "D": "x_linked_dominant",
+        "E": "x_linked"
+      },
+      "gold_letter": "E"
     },
     {
       "id": "mh-16",


### PR DESCRIPTION
## MLE-PASS slice 5 — advancing the multi-hop reasoning spine

The MLE-PASS bank answers **two-hop board questions purely on the CPU from grounded edges, zero model calls**: a clinical clue → disease (hop 1, an organ-system recall library) → answer (hop 2), joined on the shared disease through an adj-lang rule body; the engine's SLD resolver returns the binding with **both hops' byte-provenance**.

This slice grows the bank **34 → 38** with four new chains that land **purely because a finding-library disease id already equals a `genetics-edges` disease id** — nothing was grounded, renamed, or authored (the no-human-authored rule). The generator only *arranges* already-grounded, spider+adversarially-gated facts. This is exactly the "more land for free as cross-library id-joins are grounded" the spec anticipated.

```
cafe_au_lait_macules ──skin_finding_in──▶ neurofibromatosis_type_1 ──gene_defect──▶ nf1   (derm + genetics)
                                              └──────────────────── inheritance ──▶ autosomal_dominant
heinz_bodies ──seen_in──▶ g6pd_deficiency ──gene_defect──▶ g6pd                          (histo + genetics)
                              └──────────── inheritance ──▶ x_linked
```

- `mh-35` / `mh-37` — café-au-lait macules → NF1 → `nf1` (gene) / `autosomal_dominant` (inheritance); **hop-1 lib = `derm-edges.adj`**.
- `mh-36` / `mh-38` — Heinz bodies → G6PD deficiency → `g6pd` (gene) / `x_linked` (inheritance); **hop-1 lib = `histo-edges.adj`**.

**Disambiguation by the second hop:** `heinz_bodies` also has a grounded edge to `methemoglobinemia`, but only `g6pd_deficiency` carries a `gene_defect`/`inheritance` edge, so the conjunctive join binds a *single* answer — the second hop resolves a multi-disease hop-1 finding rather than the harness guessing.

These reach **two new genes** (`nf1`, `g6pd`), the **`x_linked`** inheritance pattern, and **two new hop-1 libraries** for the gene/inheritance chains (dermatology, histopathology) — widening the proof that the harness is generic over the source library.

### Verification
- `mle_pass_eval.py` — **38/38 correct, 0 wrong, 3 correct abstentions, multihop_coverage 1.0**; every answerable item cites BOTH hops' byte-provenance; **zero model calls**.
- `pytest test_mle_pass.py` — 8/8 green.
- `/security-review` — PASSED (pure data appends to the generator's constant lists; no executable/eval/IO surface).

mle-pass `0.4.0` → `0.5.0`; `MLE-PASS-multihop-recall.md` §6c + README + CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)