### PR TITLE
feat(closure-emitter): minify boolean literals to !0 / !1 (Closure-style)

### DIFF
--- a/code/packages/rust/closure-emitter/CHANGELOG.md
+++ b/code/packages/rust/closure-emitter/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to the `coding-adventures-closure-emitter` crate will be documented in this file.
 
+## [0.18.9] - 2026-06-30
+
+### Added — Closure-style boolean shorthand: `true` → `!0`, `false` → `!1`
+
+Boolean literals now minify to their negation-of-digit form, matching the
+Closure Compiler: `true` (4 chars) → `!0` (2), `false` (5) → `!1` (2).
+`!0 === true` and `!1 === false` in every context (`!` coerces to boolean and
+negates), so the rewrite is value-exact.
+
+**Precedence (soundness).** `!0` / `!1` are `UnaryExpression`s, which bind
+*looser* than member access, call, `new`, and tagged templates — so a naive
+`true.x` → `!0.x` would reparse as `!(0.x)`, a miscompile. To prevent that,
+`expr_prec` now tags `BooleanLiteral` at `PREC_UNARY` (exactly as the `void 0`
+`UndefinedLiteral` is already handled), so the existing precedence wrapper in
+`emit_expression_inner` inserts parentheses automatically where required:
+
+```
+true.toString()  →  (!0).toString()
+true()           →  (!0)()
+x = true         →  x=!0           (no parens needed)
+[true, false]    →  [!0,!1]
+a && true        →  a&&!0
+true == 1        →  !0==1          (unary binds tighter than ==)
+```
+
+Tests: `boolean_literals_minify_to_bang_zero_and_bang_one`,
+`boolean_as_member_object_is_parenthesized`, `boolean_in_binary_needs_no_parens`
+(and `unary_not_no_space` updated: `!true` → `!!0`).
+
 ## [0.18.8] - 2026-06-30
 
 ### Fixed — large integer literals saturated to `i64::MAX`/`MIN` (miscompile)

--- a/code/packages/rust/closure-emitter/Cargo.toml
+++ b/code/packages/rust/closure-emitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-emitter"
-version = "0.18.8"
+version = "0.18.9"
 edition = "2021"
 description = "JavaScript code emitter for the Closure Compiler clone. Per CLOC07's emit contract. Takes a finalized Program + sidecar and produces output JavaScript text + companion source map. Runs after every pass in the pipeline."
 

--- a/code/packages/rust/closure-emitter/src/lib.rs
+++ b/code/packages/rust/closure-emitter/src/lib.rs
@@ -902,7 +902,21 @@ impl<'a> Emitter<'a> {
 
     fn emit_boolean(&mut self, b: &BooleanLiteral) {
         self.maybe_map(&b.cv);
-        self.write_str(if b.value { "true" } else { "false" });
+        // Closure-style minification: `true` (4 chars) → `!0` (2), `false`
+        // (5) → `!1` (2). `!0` evaluates to `true` and `!1` to `false` in
+        // every context (`!` coerces its operand to a boolean and negates;
+        // `!0 === true`, `!1 === false`), so the substitution is value-exact.
+        //
+        // PRECEDENCE: `!0` / `!1` are UnaryExpressions, NOT primaries, so they
+        // bind LOOSER than member access, call, `new`, and tagged templates.
+        // Emitting `true.x` naively as `!0.x` would reparse as `!(0.x)` — a
+        // miscompile. We avoid this WITHOUT any local paren logic here:
+        // `expr_prec` tags `BooleanLiteral` at `PREC_UNARY` (exactly like the
+        // `void 0` UndefinedLiteral case), so `emit_expression_inner` inserts
+        // the needed parens automatically in higher-precedence parents —
+        // `(!0).x`, `(!0)()`, `new (!1)` — while leaving the common cases
+        // (`x=!0`, `[!0]`, `f(!0)`, `a&&!0`, `return!0`) paren-free.
+        self.write_str(if b.value { "!0" } else { "!1" });
     }
 
     fn emit_null(&mut self, n: &NullLiteral) {
@@ -1447,7 +1461,6 @@ fn expr_prec(e: &Expression) -> u8 {
         Expression::Identifier(_)
         | Expression::NumericLiteral(_)
         | Expression::StringLiteral(_)
-        | Expression::BooleanLiteral(_)
         | Expression::NullLiteral(_)
         | Expression::BigIntLiteral(_)
         | Expression::ArrayExpression(_)
@@ -1456,6 +1469,13 @@ fn expr_prec(e: &Expression) -> u8 {
         | Expression::MemberExpression(_) => PREC_PRIMARY,
 
         Expression::UnaryExpression(_) => PREC_UNARY,
+        // `true`/`false` are emitted as `!0`/`!1` (see `emit_boolean`), which
+        // are UnaryExpressions — precedence `PREC_UNARY`, NOT primary. Tagging
+        // them here is what makes `emit_expression_inner` parenthesise them in
+        // member/call/new parents (`(!0).x`, `(!0)()`), exactly as it does for
+        // the `void 0` UndefinedLiteral below. Without this they would emit as
+        // `!0.x` (parsed `!(0.x)`) — a miscompile.
+        Expression::BooleanLiteral(_) => PREC_UNARY,
         // `void 0` is a UnaryExpression in disguise (CLOC12.16):
         // its precedence is unary, not primary, so that contexts
         // like `(void 0).x` and `(void 0)()` insert the necessary
@@ -2166,7 +2186,38 @@ mod tests {
         });
         let prog = program().with_body(vec![stmt(e)]);
         let out = emit_default(prog);
-        assert_eq!(out.code, "!true;");
+        // The `true` operand is itself minified to `!0` (see `emit_boolean`),
+        // so `!true` emits as `!!0` — still demonstrating that the prefix `!`
+        // abuts its operand with no space. `!!0 === !true === false`.
+        assert_eq!(out.code, "!!0;");
+    }
+
+    #[test]
+    fn boolean_literals_minify_to_bang_zero_and_bang_one() {
+        // Closure-style: `true` → `!0`, `false` → `!1` (value-exact, shorter).
+        let t = emit_default(program().with_body(vec![stmt(boolean(true))]));
+        assert_eq!(t.code, "!0;");
+        let f = emit_default(program().with_body(vec![stmt(boolean(false))]));
+        assert_eq!(f.code, "!1;");
+    }
+
+    #[test]
+    fn boolean_as_member_object_is_parenthesized() {
+        // `true.x` must NOT emit as `!0.x` (which reparses as `!(0.x)`); the
+        // boolean is precedence `PREC_UNARY`, so the member-object emit wraps
+        // it: `(!0).x`. This is the soundness guard for the `!0`/`!1` rewrite.
+        let e = member(boolean(true), "x", false);
+        let out = emit_default(program().with_body(vec![stmt(e)]));
+        assert_eq!(out.code, "(!0).x;");
+    }
+
+    #[test]
+    fn boolean_in_binary_needs_no_parens() {
+        // Unary precedence (14) is higher than equality (`==`), so `true==1`
+        // emits as `!0==1` with no parens — `!0==1` parses as `(!0)==1`.
+        let e = binary(BinaryOperator::Eq, boolean(true), ident("a"));
+        let out = emit_default(program().with_body(vec![stmt(e)]));
+        assert_eq!(out.code, "!0==a;");
     }
 
     #[test]

--- a/code/packages/rust/closure-emitter/tests/upstream/code_printer_declarations_test.rs
+++ b/code/packages/rust/closure-emitter/tests/upstream/code_printer_declarations_test.rs
@@ -203,13 +203,13 @@ fn var_with_null_init() {
 
 /// Upstream `assertPrintSame("var x = true;")`.
 ///
-/// Boolean init. Pins that booleans emit as the keyword form (not
-/// `1`/`0`).
+/// Boolean init. Pins the Closure-style boolean shorthand: `true` emits as
+/// `!0` (value-exact, 2 chars vs 4). See `emit_boolean`.
 #[test]
 fn var_with_boolean_init() {
     assert_var_emits(
         var_decl_single(VarKind::Var, "x", Some(boolean(true))),
-        "var x=true;",
+        "var x=!0;",
     );
 }
 

--- a/code/packages/rust/closure-emitter/tests/upstream/code_printer_test.rs
+++ b/code/packages/rust/closure-emitter/tests/upstream/code_printer_test.rs
@@ -189,12 +189,14 @@ fn test_unary_not_emits_without_space() {
 }
 
 /// Upstream `assertPrintSame("true")` — boolean literal at statement
-/// position. Our emitter produces `true;` — bare boolean literal, no
-/// parens.
+/// position. Our emitter applies the Closure-style boolean shorthand,
+/// printing `true` as `!0` and `false` as `!1` (value-exact: `!0 === true`,
+/// `!1 === false`). `!0` / `!1` start with `!`, so there is no
+/// expression-statement / ASI pitfall at statement position.
 #[test]
 fn test_boolean_literal_at_statement_position() {
-    assert_emits(boolean(true), "true;");
-    assert_emits(boolean(false), "false;");
+    assert_emits(boolean(true), "!0;");
+    assert_emits(boolean(false), "!1;");
 }
 
 /// Upstream `assertPrintSame("0")`, `assertPrintSame("42")`, etc. —

--- a/code/packages/rust/closure-pass-inline-variables/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-inline-variables/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the `coding-adventures-closure-pass-inline-variables` crate will be documented in this file.
 
+## [0.6.1] - 2026-06-30
+
+### Changed — test sync for closure-emitter boolean shorthand
+
+`closure-emitter` 0.18.9 now minifies `true`/`false` to `!0`/`!1`. The
+`propagates_boolean_and_null_literals` golden-output test was updated to
+expect the new rendering (`const ON=!0;const NONE=null;f(!0,null);`). No
+behavior change in this crate — the propagation logic is unchanged.
+
 ## [0.6.0] - 2026-06-20
 
 ### Added — CLOC23: variable inlining inside `for`-`of`

--- a/code/packages/rust/closure-pass-inline-variables/Cargo.toml
+++ b/code/packages/rust/closure-pass-inline-variables/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-inline-variables"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "Constant-propagation pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Replaces references to a top-level `const` bound to a literal with the literal itself, so the binding becomes unused and remove-unused-vars deletes it."
 

--- a/code/packages/rust/closure-pass-inline-variables/src/lib.rs
+++ b/code/packages/rust/closure-pass-inline-variables/src/lib.rs
@@ -1126,9 +1126,13 @@ mod tests {
 
     #[test]
     fn propagates_boolean_and_null_literals() {
+        // Booleans render via closure-emitter's Closure-style shorthand
+        // (`true` → `!0`); `null` is unchanged. The propagation itself — both
+        // the declaration and the propagated use carrying the literal — is
+        // what this test exercises.
         assert_eq!(
             propagate_source("const ON = true; const NONE = null; f(ON, NONE);"),
-            "const ON=true;const NONE=null;f(true,null);"
+            "const ON=!0;const NONE=null;f(!0,null);"
         );
     }
 

--- a/code/programs/rust/closurec/tests/diff/simple-fold-array-isarray/README.md
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-array-isarray/README.md
@@ -31,10 +31,12 @@ runtime.
 - `flags.txt` — CLI flags (`--compilation_level SIMPLE --js input/a.js`).
 - `input/a.js` — six `var` bindings flowing into `report(...)` so each stays
   referenced past remove-unused-vars and the fold is observable.
-- `expected.stdout` — the byte-exact SIMPLE output:
+- `expected.stdout` — the byte-exact SIMPLE output. The fold produces boolean
+  `true`/`false`, which the emitter prints in its Closure-style shorthand as
+  `!0`/`!1` (value-exact: `!0 === true`, `!1 === false`):
 
   ```text
-  var a=true;var b=false;var c=false;var d=false;var e=false;var f=Array.isArray([1,2]);report(a,b,c,d,e,f);
+  var a=!0;var b=!1;var c=!1;var d=!1;var e=!1;var f=Array.isArray([1,2]);report(a,b,c,d,e,f);
   ```
 
 The integration test `tests/diff_simple_fold_array_isarray.rs` runs the binary

--- a/code/programs/rust/closurec/tests/diff/simple-fold-array-isarray/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-array-isarray/expected.stdout
@@ -1,1 +1,1 @@
-var a=true;var b=false;var c=false;var d=false;var e=false;var f=Array.isArray([1,2]);report(a,b,c,d,e,f);
+var a=!0;var b=!1;var c=!1;var d=!1;var e=!1;var f=Array.isArray([1,2]);report(a,b,c,d,e,f);

--- a/code/programs/rust/closurec/tests/diff/simple-fold-boolean/README.md
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-boolean/README.md
@@ -25,7 +25,7 @@ boolean literal:
 So the folded `expected.stdout` is:
 
 ```js
-var a=false;var b=true;var c=true;var d=false;var e=true;var f=Boolean(z);report(a,b,c,d,e,f);
+var a=!1;var b=!0;var c=!0;var d=!1;var e=!0;var f=Boolean(z);report(a,b,c,d,e,f);
 ```
 
 Only the **bare global identifier** folds — a member access like

--- a/code/programs/rust/closurec/tests/diff/simple-fold-boolean/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-boolean/expected.stdout
@@ -1,1 +1,1 @@
-var a=false;var b=true;var c=true;var d=false;var e=true;var f=Boolean(z);report(a,b,c,d,e,f);
+var a=!1;var b=!0;var c=!0;var d=!1;var e=!0;var f=Boolean(z);report(a,b,c,d,e,f);

--- a/code/programs/rust/closurec/tests/diff/simple-fold-isnan/README.md
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-isnan/README.md
@@ -40,7 +40,7 @@ compiler's canonical literal form (`true` / `false`).
 - `expected.stdout` — the byte-exact SIMPLE output:
 
   ```text
-  var a=true;var b=false;var c=false;var d=true;var e=false;var f=false;var g=true;report(a,b,c,d,e,f,g);
+  var a=!0;var b=!1;var c=!1;var d=!0;var e=!1;var f=!1;var g=!0;report(a,b,c,d,e,f,g);
   ```
 
 The integration test `tests/diff_simple_fold_isnan.rs` runs the binary against

--- a/code/programs/rust/closurec/tests/diff/simple-fold-isnan/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-isnan/expected.stdout
@@ -1,1 +1,1 @@
-var a=true;var b=false;var c=false;var d=true;var e=false;var f=false;var g=true;report(a,b,c,d,e,f,g);
+var a=!0;var b=!1;var c=!1;var d=!0;var e=!1;var f=!1;var g=!0;report(a,b,c,d,e,f,g);

--- a/code/programs/rust/closurec/tests/diff/simple-fold-number-issafeinteger/README.md
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-number-issafeinteger/README.md
@@ -33,7 +33,7 @@ shadowable free identifier).
 - `expected.stdout` — the byte-exact SIMPLE output:
 
   ```text
-  var a=true;var b=false;var c=true;var d=false;var e=Number.isSafeInteger(x);report(a,b,c,d,e);
+  var a=!0;var b=!1;var c=!0;var d=!1;var e=Number.isSafeInteger(x);report(a,b,c,d,e);
   ```
 
 The integration test `tests/diff_simple_fold_number_issafeinteger.rs` runs the

--- a/code/programs/rust/closurec/tests/diff/simple-fold-number-issafeinteger/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-number-issafeinteger/expected.stdout
@@ -1,1 +1,1 @@
-var a=true;var b=false;var c=true;var d=false;var e=Number.isSafeInteger(x);report(a,b,c,d,e);
+var a=!0;var b=!1;var c=!0;var d=!1;var e=Number.isSafeInteger(x);report(a,b,c,d,e);

--- a/code/programs/rust/closurec/tests/diff/simple-fold-number-static/README.md
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-number-static/README.md
@@ -38,7 +38,7 @@ type at compile time and is left for the runtime.
 - `expected.stdout` — the byte-exact SIMPLE output:
 
   ```text
-  var a=true;var b=false;var c=true;var d=true;var e=false;var f=false;var g=false;report(a,b,c,d,e,f,g);
+  var a=!0;var b=!1;var c=!0;var d=!0;var e=!1;var f=!1;var g=!1;report(a,b,c,d,e,f,g);
   ```
 
 The integration test `tests/diff_simple_fold_number_static.rs` runs the binary

--- a/code/programs/rust/closurec/tests/diff/simple-fold-number-static/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-number-static/expected.stdout
@@ -1,1 +1,1 @@
-var a=true;var b=false;var c=true;var d=true;var e=false;var f=false;var g=false;report(a,b,c,d,e,f,g);
+var a=!0;var b=!1;var c=!0;var d=!0;var e=!1;var f=!1;var g=!1;report(a,b,c,d,e,f,g);

--- a/code/programs/rust/closurec/tests/diff/simple-fold-object-is/README.md
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-object-is/README.md
@@ -41,7 +41,7 @@ correctly yields `false`.
 - `expected.stdout` — the byte-exact SIMPLE output:
 
   ```text
-  var a=true;var b=false;var c=true;var d=false;var e=Object.is(NaN,NaN);report(a,b,c,d,e);
+  var a=!0;var b=!1;var c=!0;var d=!1;var e=Object.is(NaN,NaN);report(a,b,c,d,e);
   ```
 
 The integration test `tests/diff_simple_fold_object_is.rs` runs the binary

--- a/code/programs/rust/closurec/tests/diff/simple-fold-object-is/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-object-is/expected.stdout
@@ -1,1 +1,1 @@
-var a=true;var b=false;var c=true;var d=false;var e=Object.is(NaN,NaN);report(a,b,c,d,e);
+var a=!0;var b=!1;var c=!0;var d=!1;var e=Object.is(NaN,NaN);report(a,b,c,d,e);

--- a/code/programs/rust/closurec/tests/diff/simple-fold-strpred/README.md
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-strpred/README.md
@@ -7,7 +7,7 @@ End-to-end oracle for string-literal substring-**predicate** folding at
 |------|------|
 | `flags.txt` | CLI args: `--compilation_level SIMPLE --js input/a.js` |
 | `input/a.js` | three calls: `"hello".startsWith("he")`, `.endsWith("xo")`, `.includes("ell")` |
-| `expected.stdout` | The folded output: `var a=true;var b=false;var c=true;report(a,b,c);` |
+| `expected.stdout` | The folded output: `var a=!0;var b=!1;var c=!0;report(a,b,c);` |
 
 The SIMPLE level runs the typed-AST optimization pipeline, whose `constant-fold`
 pass folds the single-argument `String#startsWith` / `endsWith` / `includes`

--- a/code/programs/rust/closurec/tests/diff/simple-fold-strpred/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-strpred/expected.stdout
@@ -1,1 +1,1 @@
-var a=true;var b=false;var c=true;report(a,b,c);
+var a=!0;var b=!1;var c=!0;report(a,b,c);

--- a/code/programs/rust/closurec/tests/diff_simple_fold_array_isarray.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_fold_array_isarray.rs
@@ -9,8 +9,11 @@
 //! At SIMPLE the fixture optimizes to:
 //!
 //! ```text
-//! var a=true;var b=false;var c=false;var d=false;var e=false;var f=Array.isArray([1,2]);report(a,b,c,d,e,f);
+//! var a=!0;var b=!1;var c=!1;var d=!1;var e=!1;var f=Array.isArray([1,2]);report(a,b,c,d,e,f);
 //! ```
+//!
+//! (booleans render via the emitter's Closure-style shorthand: the fold still
+//! produces `true`/`false`, which the emitter prints as `!0`/`!1`.)
 
 use std::process::Command;
 
@@ -61,11 +64,13 @@ fn simple_fold_array_isarray_folds_to_booleans() {
         .expect("run closurec");
     let actual = String::from_utf8_lossy(&out.stdout);
 
-    assert!(actual.contains("a=true"), "Array.isArray([]) → true; got:\n{actual}");
-    assert!(actual.contains("b=false"), "Array.isArray({{}}) → false; got:\n{actual}");
-    assert!(actual.contains("c=false"), "Array.isArray(\"x\") → false; got:\n{actual}");
-    assert!(actual.contains("d=false"), "Array.isArray(42) → false; got:\n{actual}");
-    assert!(actual.contains("e=false"), "Array.isArray(null) → false; got:\n{actual}");
+    // Folded booleans render via the emitter's Closure-style shorthand:
+    // `true`→`!0`, `false`→`!1` (value-exact).
+    assert!(actual.contains("a=!0"), "Array.isArray([]) → true (!0); got:\n{actual}");
+    assert!(actual.contains("b=!1"), "Array.isArray({{}}) → false (!1); got:\n{actual}");
+    assert!(actual.contains("c=!1"), "Array.isArray(\"x\") → false (!1); got:\n{actual}");
+    assert!(actual.contains("d=!1"), "Array.isArray(42) → false (!1); got:\n{actual}");
+    assert!(actual.contains("e=!1"), "Array.isArray(null) → false (!1); got:\n{actual}");
     // The non-empty array literal is NOT folded — the call must remain.
     assert!(
         actual.contains("f=Array.isArray([1,2])"),

--- a/code/programs/rust/closurec/tests/diff_simple_fold_boolean.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_fold_boolean.rs
@@ -9,7 +9,7 @@
 //! At SIMPLE the fixture optimizes to:
 //!
 //! ```text
-//! var a=false;var b=true;var c=true;var d=false;var e=true;var f=Boolean(z);report(a,b,c,d,e,f);
+//! var a=!1;var b=!0;var c=!0;var d=!1;var e=!0;var f=Boolean(z);report(a,b,c,d,e,f);
 //! ```
 
 use std::process::Command;
@@ -61,11 +61,11 @@ fn simple_fold_boolean_folds_to_boolean_literals() {
         .expect("run closurec");
     let actual = String::from_utf8_lossy(&out.stdout);
 
-    assert!(actual.contains("a=false"), "Boolean(\"\") → false; got:\n{actual}");
-    assert!(actual.contains("b=true"), "Boolean(\"x\") → true; got:\n{actual}");
-    assert!(actual.contains("c=true"), "Boolean(\"0\") → true (non-empty); got:\n{actual}");
-    assert!(actual.contains("d=false"), "Boolean(0) → false; got:\n{actual}");
-    assert!(actual.contains("e=true"), "Boolean(1) → true; got:\n{actual}");
+    assert!(actual.contains("a=!1"), "Boolean(\"\") → false; got:\n{actual}");
+    assert!(actual.contains("b=!0"), "Boolean(\"x\") → true; got:\n{actual}");
+    assert!(actual.contains("c=!0"), "Boolean(\"0\") → true (non-empty); got:\n{actual}");
+    assert!(actual.contains("d=!1"), "Boolean(0) → false; got:\n{actual}");
+    assert!(actual.contains("e=!0"), "Boolean(1) → true; got:\n{actual}");
     // `Boolean(z)` needs the runtime value of `z` — the call must survive.
     assert!(
         actual.contains("f=Boolean(z)"),

--- a/code/programs/rust/closurec/tests/diff_simple_fold_isnan.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_fold_isnan.rs
@@ -10,7 +10,7 @@
 //! At SIMPLE the fixture optimizes to:
 //!
 //! ```text
-//! var a=true;var b=false;var c=false;var d=true;var e=false;var f=false;var g=true;report(a,b,c,d,e,f,g);
+//! var a=!0;var b=!1;var c=!1;var d=!0;var e=!1;var f=!1;var g=!0;report(a,b,c,d,e,f,g);
 //! ```
 
 use std::process::Command;
@@ -62,13 +62,13 @@ fn simple_fold_isnan_folds_to_booleans() {
         .expect("run closurec");
     let actual = String::from_utf8_lossy(&out.stdout);
 
-    assert!(actual.contains("a=true"), "isNaN(\"abc\") → true; got:\n{actual}");
-    assert!(actual.contains("b=false"), "isNaN(\"42\") → false; got:\n{actual}");
-    assert!(actual.contains("c=false"), "isNaN(\" \") → false (ToNumber(\" \")=+0); got:\n{actual}");
-    assert!(actual.contains("d=true"), "isFinite(\"1e3\") → true; got:\n{actual}");
-    assert!(actual.contains("e=false"), "isFinite(\"Infinity\") → false; got:\n{actual}");
-    assert!(actual.contains("f=false"), "isFinite(\"abc\") → false; got:\n{actual}");
-    assert!(actual.contains("g=true"), "isFinite(0) → true; got:\n{actual}");
+    assert!(actual.contains("a=!0"), "isNaN(\"abc\") → true; got:\n{actual}");
+    assert!(actual.contains("b=!1"), "isNaN(\"42\") → false; got:\n{actual}");
+    assert!(actual.contains("c=!1"), "isNaN(\" \") → false (ToNumber(\" \")=+0); got:\n{actual}");
+    assert!(actual.contains("d=!0"), "isFinite(\"1e3\") → true; got:\n{actual}");
+    assert!(actual.contains("e=!1"), "isFinite(\"Infinity\") → false; got:\n{actual}");
+    assert!(actual.contains("f=!1"), "isFinite(\"abc\") → false; got:\n{actual}");
+    assert!(actual.contains("g=!0"), "isFinite(0) → true; got:\n{actual}");
 }
 
 /// Regression guard: the output must be the SIMPLE typed pipeline, not the

--- a/code/programs/rust/closurec/tests/diff_simple_fold_number_issafeinteger.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_fold_number_issafeinteger.rs
@@ -9,7 +9,7 @@
 //! At SIMPLE the fixture optimizes to:
 //!
 //! ```text
-//! var a=true;var b=false;var c=true;var d=false;var e=Number.isSafeInteger(x);report(a,b,c,d,e);
+//! var a=!0;var b=!1;var c=!0;var d=!1;var e=Number.isSafeInteger(x);report(a,b,c,d,e);
 //! ```
 
 use std::process::Command;
@@ -56,14 +56,14 @@ fn simple_fold_number_issafeinteger_classifies_literals() {
     let out = Command::new(BINARY).args(read_flags()).output().expect("run closurec");
     let actual = String::from_utf8_lossy(&out.stdout);
 
-    assert!(actual.contains("a=true"), "isSafeInteger(7) → true; got:\n{actual}");
-    assert!(actual.contains("b=false"), "isSafeInteger(3.5) → false; got:\n{actual}");
+    assert!(actual.contains("a=!0"), "isSafeInteger(7) → true; got:\n{actual}");
+    assert!(actual.contains("b=!1"), "isSafeInteger(3.5) → false; got:\n{actual}");
     assert!(
-        actual.contains("c=true"),
+        actual.contains("c=!0"),
         "isSafeInteger(9007199254740991) → true (MAX_SAFE_INTEGER); got:\n{actual}"
     );
     assert!(
-        actual.contains("d=false"),
+        actual.contains("d=!1"),
         "isSafeInteger(9007199254740992) → false (2^53, past safe range); got:\n{actual}"
     );
     // The identifier argument is NOT folded — the call must remain.

--- a/code/programs/rust/closurec/tests/diff_simple_fold_number_static.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_fold_number_static.rs
@@ -9,7 +9,7 @@
 //! At SIMPLE the fixture optimizes to:
 //!
 //! ```text
-//! var a=true;var b=false;var c=true;var d=true;var e=false;var f=false;var g=false;report(a,b,c,d,e,f,g);
+//! var a=!0;var b=!1;var c=!0;var d=!0;var e=!1;var f=!1;var g=!1;report(a,b,c,d,e,f,g);
 //! ```
 
 use std::process::Command;
@@ -61,13 +61,13 @@ fn simple_fold_number_static_folds_to_booleans() {
         .expect("run closurec");
     let actual = String::from_utf8_lossy(&out.stdout);
 
-    assert!(actual.contains("a=true"), "Number.isInteger(42) → true; got:\n{actual}");
-    assert!(actual.contains("b=false"), "Number.isInteger(3.5) → false; got:\n{actual}");
-    assert!(actual.contains("c=true"), "Number.isInteger(1e21) → true (integer-valued); got:\n{actual}");
-    assert!(actual.contains("d=true"), "Number.isFinite(42) → true; got:\n{actual}");
-    assert!(actual.contains("e=false"), "Number.isNaN(42) → false; got:\n{actual}");
-    assert!(actual.contains("f=false"), "Number.isInteger(\"42\") → false (no coercion); got:\n{actual}");
-    assert!(actual.contains("g=false"), "Number.isFinite(null) → false; got:\n{actual}");
+    assert!(actual.contains("a=!0"), "Number.isInteger(42) → true; got:\n{actual}");
+    assert!(actual.contains("b=!1"), "Number.isInteger(3.5) → false; got:\n{actual}");
+    assert!(actual.contains("c=!0"), "Number.isInteger(1e21) → true (integer-valued); got:\n{actual}");
+    assert!(actual.contains("d=!0"), "Number.isFinite(42) → true; got:\n{actual}");
+    assert!(actual.contains("e=!1"), "Number.isNaN(42) → false; got:\n{actual}");
+    assert!(actual.contains("f=!1"), "Number.isInteger(\"42\") → false (no coercion); got:\n{actual}");
+    assert!(actual.contains("g=!1"), "Number.isFinite(null) → false; got:\n{actual}");
 }
 
 /// Regression guard: the output must be the SIMPLE typed pipeline, not the

--- a/code/programs/rust/closurec/tests/diff_simple_fold_object_is.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_fold_object_is.rs
@@ -11,7 +11,7 @@
 //! At SIMPLE the fixture optimizes to:
 //!
 //! ```text
-//! var a=true;var b=false;var c=true;var d=false;var e=Object.is(NaN,NaN);report(a,b,c,d,e);
+//! var a=!0;var b=!1;var c=!0;var d=!1;var e=Object.is(NaN,NaN);report(a,b,c,d,e);
 //! ```
 
 use std::process::Command;
@@ -56,14 +56,14 @@ fn simple_fold_object_is_folds_same_value() {
     let out = Command::new(BINARY).args(read_flags()).output().expect("run closurec");
     let actual = String::from_utf8_lossy(&out.stdout);
 
-    assert!(actual.contains("a=true"), "Object.is(1,1) → true; got:\n{actual}");
+    assert!(actual.contains("a=!0"), "Object.is(1,1) → true; got:\n{actual}");
     assert!(
-        actual.contains("b=false"),
+        actual.contains("b=!1"),
         "Object.is(0,-0) → false (±0 SameValue, NOT ===); got:\n{actual}"
     );
-    assert!(actual.contains("c=true"), "Object.is(\"x\",\"x\") → true; got:\n{actual}");
+    assert!(actual.contains("c=!0"), "Object.is(\"x\",\"x\") → true; got:\n{actual}");
     assert!(
-        actual.contains("d=false"),
+        actual.contains("d=!1"),
         "Object.is(1,\"1\") → false (different Type); got:\n{actual}"
     );
     // `NaN` is the global identifier, not a literal — conservatively declined.

--- a/code/programs/rust/closurec/tests/diff_simple_fold_strpred.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_fold_strpred.rs
@@ -8,7 +8,7 @@
 //! At SIMPLE the fixture optimizes to:
 //!
 //! ```text
-//! var a=true;var b=false;var c=true;report(a,b,c);
+//! var a=!0;var b=!1;var c=!0;report(a,b,c);
 //! ```
 
 use std::process::Command;
@@ -59,9 +59,9 @@ fn simple_fold_strpred_folds_to_boolean_literals() {
         .expect("run closurec");
     let actual = String::from_utf8_lossy(&out.stdout);
 
-    assert!(actual.contains("a=true"), "startsWith should fold to true; got:\n{actual}");
-    assert!(actual.contains("b=false"), "endsWith should fold to false; got:\n{actual}");
-    assert!(actual.contains("c=true"), "includes should fold to true; got:\n{actual}");
+    assert!(actual.contains("a=!0"), "startsWith should fold to true; got:\n{actual}");
+    assert!(actual.contains("b=!1"), "endsWith should fold to false; got:\n{actual}");
+    assert!(actual.contains("c=!0"), "includes should fold to true; got:\n{actual}");
     for method in ["startsWith", "endsWith", "includes"] {
         assert!(
             !actual.contains(method),


### PR DESCRIPTION
## What

Boolean literals now minify to their negation-of-digit shorthand, matching the Closure Compiler: `true` (4 chars) → `!0` (2), `false` (5) → `!1` (2). `!0 === true` and `!1 === false` in every JS context, so the rewrite is **value-exact**.

## Soundness (precedence)

`!0` / `!1` are `UnaryExpression`s — they bind **looser** than member access, call, `new`, and tagged templates. A naive `true.x` → `!0.x` would reparse as `!(0.x)`, a miscompile. The fix tags `BooleanLiteral` at `PREC_UNARY` in `expr_prec` (exactly as the existing `void 0` `UndefinedLiteral` is handled), so the existing `emit_expression_inner` precedence wrapper inserts parens automatically:

```
true.toString()  →  (!0).toString()
true()           →  (!0)()
x = true         →  x=!0           (no parens needed)
[true, false]    →  [!0,!1]
a && true        →  a&&!0
true == 1        →  !0==1          (unary binds tighter than ==)
```

Inline security review passed a full JS-semantics audit (value-exactness, precedence completeness — the AST has only Call/Member as tighter-binding nodes, both routed through `PREC_PRIMARY`; ASI/token-pasting `return!0`/`typeof!0`; `case`/object-key/`in`/`instanceof` contexts).

## Scope note

Only the **SIMPLE/ADVANCED** AST emit path applies the shorthand. `WHITESPACE_ONLY` passes booleans through as raw tokens, and `--define X=false` splices the value directly — both correctly keep `true`/`false` (verified end-to-end).

## Verification

- New emitter tests: `boolean_literals_minify_to_bang_zero_and_bang_one`, `boolean_as_member_object_is_parenthesized`, `boolean_in_binary_needs_no_parens`; updated `unary_not_no_space` (`!true`→`!!0`) and upstream `code_printer` integration tests.
- **Full `cargo test`** (incl. integration + fixture diff tests) green across closure-emitter (129) and all 7 consumers — closure-pass-inline/-inline-variables/-rename/-rename-globals/-rename-properties, closure-source-map, closurec (883).
- Downstream golden-output syncs: closure-pass-inline-variables; closurec SIMPLE fixtures `simple-fold-{array-isarray,boolean,isnan,number-static,number-issafeinteger,object-is,strpred}` (expected.stdout + inline assertions + docs). `define` / `minify_boolean_literals` fixtures are WHITESPACE_ONLY and correctly unchanged.
- Versions: closure-emitter `0.18.8`→`0.18.9`; closure-pass-inline-variables `0.6.0`→`0.6.1` (test-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)