### PR TITLE
docs(lessons): Gradle optimizer packages need includeBuild for dep graph

### DIFF
--- a/lessons.md
+++ b/lessons.md
@@ -935,3 +935,20 @@ emits cross-function `call`s, use a backend whose `compile` returns `None`
 (defer-to-interpreter) so nothing is stubbed. When a JIT test passes locally but
 fails on CI with missing output, suspect eager-compilation of FullyTyped
 functions to no-op binaries.
+
+## Gradle / JVM
+
+### Gradle optimizer packages need `includeBuild` for the build-tool's dep graph
+
+When a Gradle package (Java or Kotlin) depends on a sibling package via a file-based JAR
+(`implementation(files("../sql-planner/gradle-build/libs/..."))`), the build tool's
+`parseGradleDeps` function reads `includeBuild(...)` lines from `settings.gradle.kts` to
+construct the dependency graph. Without this, the validator raises:
+
+  `<lang>/sql-optimizer (BUILD): undeclared local package refs: <lang>/sql-planner`
+
+Fix: Add `includeBuild("../sql-planner")` to the optimizer's `settings.gradle.kts` BEFORE
+the `rootProject.name` line. This applies to Java and Kotlin optimizer packages (and
+any future Gradle packages that depend on siblings via file deps).
+
+Discovered: 2026-06-30 during Java sql-optimizer CI (PR #7073 fix commit d31296a48).


### PR DESCRIPTION
## Summary

- Adds a new `## Gradle / JVM` section to `lessons.md`
- Documents that Gradle packages depending on siblings via file-based JARs must declare `includeBuild(../sibling)` in `settings.gradle.kts` so the build-tool's `parseGradleDeps` can resolve the dependency graph
- Without this the validator raises: `<lang>/sql-optimizer (BUILD): undeclared local package refs: <lang>/sql-planner`
- Discovered during Java sql-optimizer CI (PR #7073 fix commit d31296a48)

## Test plan

- [ ] Verify `lessons.md` has the new `## Gradle / JVM` section at the end of the file
- [ ] No code changes — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)