### PR TITLE
feat(mathml): tables, over/under-sets, fences — PFE01 frontend #4 PR-2

### DIFF
--- a/code/packages/rust/mathml/CHANGELOG.md
+++ b/code/packages/rust/mathml/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to the Presentation-MathML frontend crate.
 
+## [0.2.0] — 2026-06-30
+
+### Added — PR-2: tables, over/under-sets, and fences (structural breadth)
+
+- **`<mtable>`/`<mtr>`/`<mtd>` → `MathExpr::Matrix`.** A dedicated structural parser walks the rows
+  and cells directly (a table's children are rows, a row's are cells — neither is an operand), so a
+  2×2 `<mtable>` becomes `Matrix([[1,2],[3,4]])`. Each `<mtd>` cell folds a full expression (not
+  just an atom). Stray non-`<mtr>` content in a table, or non-`<mtd>` content in a row, is a spanned
+  error; an empty cell becomes an empty `Symbol`.
+- **`<mover>`/`<munder>`/`<munderover>` → `Overset`/`Underset`.** MathML's base-first order maps to
+  `Overset { over, base }` / `Underset { under, base }`; `<munderover>` nests under-most outside
+  (`Underset { under, base: Overset { over, base } }`). Because an over/under annotation is commonly
+  an operator *glyph* (a hat `^`, bar `‾`, arrow `→`, brace `⏞`), these read their arguments with a
+  script-args reader that accepts a lone `<mo>` as an annotation **symbol** rather than rejecting it
+  as a bare infix operator.
+- **`<mfenced>` → `Group`.** A parenthesised group folds its contents to one row wrapped in `Group`
+  (its `open`/`close`/`separators` attributes are presentation, dropped like all attributes; a
+  comma-separated list folds as one row — separators are not yet modelled).
+- **Capabilities** grow to add `matrices` and `oversets`, kept honest by `check_frontend` (the
+  conformance sample corpus now includes a table, an over/under-set, and a fenced group).
+- **Stack-safety regression** per the unary-overflow lesson: a *flat* 50 000-row `<mtable>` parses
+  (and the `Matrix` drops) without a stack overflow, since the structural table/row parsing is
+  iterative, not recursive-per-row.
+- 35 unit tests + a doctest (was 24): adds tables, table-cell folding, table well-formedness errors,
+  over/under/under-over sets, mover arity, fenced groups, and the wide-table stack-safety test.
+
+### Deferred to PR-3
+Named-function recognition (`<mi>sin</mi>` → `Call`), and `<mfenced>` separator modelling.
+
 ## [0.1.0] — 2026-06-30
 
 ### Added — PR-1: a Presentation-MathML reader → neutral `MathExpr` (PFE01 frontend #4)

--- a/code/packages/rust/mathml/Cargo.toml
+++ b/code/packages/rust/mathml/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "mathml"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
-description = "A Presentation-MathML reader that implements the math-frontend MathFrontend trait: turns <math>…</math> (mn/mi/mo/mrow/mfrac/msup/msub/msqrt/mroot/mtext) into the neutral MathExpr AST. The fourth pluggable frontend after LaTeX and AsciiMath (see PFE01). Total, panic-free, spanned errors."
+description = "A Presentation-MathML reader that implements the math-frontend MathFrontend trait: turns <math>…</math> (mn/mi/mo/mrow/mfrac/msup/msub/msqrt/mroot/mtext/mtable/mover/munder/mfenced) into the neutral MathExpr AST. The fourth pluggable frontend after LaTeX and AsciiMath (see PFE01). Total, panic-free, spanned errors."
 license = "MIT"
 
 [dependencies]

--- a/code/packages/rust/mathml/README.md
+++ b/code/packages/rust/mathml/README.md
@@ -11,7 +11,7 @@ depends on the neutral `MathExpr`, never on a concrete notation, so supporting M
 language, a terse linear notation, a Unicode-symbol notation, and an XML tree) all lower to one
 tree.
 
-## What it covers (PR-1)
+## What it covers
 
 | MathML | neutral `MathExpr` |
 |--------|--------------------|
@@ -25,14 +25,20 @@ tree.
 | `<msub>b s</msub>` | `Subscript(b, s)` |
 | `<msubsup>b s e</msubsup>` | `Bin(Pow, Subscript(b, s), e)` |
 | `<msqrt>x</msqrt>` / `<mroot>x n</mroot>` | `Root` (degree `None` / `Some(n)`) |
+| `<mover>b a</mover>` / `<munder>b a</munder>` | `Overset { over: a, base: b }` / `Underset { under: a, base: b }` (PR-2) |
+| `<munderover>b u o</munderover>` | `Underset { under: u, base: Overset { over: o, base: b } }` (PR-2) |
+| `<mfenced>…</mfenced>` | `Group` over the folded contents (PR-2) |
+| `<mtable><mtr><mtd>…</mtd></mtr></mtable>` | `Matrix(rows × cells)` (PR-2) |
 
 `<math>`, `<mstyle>`, and `<mpadded>` are **transparent** wrappers (their children join the
 surrounding row). Attributes, namespace prefixes (`m:math` ≡ `math`), the XML declaration,
 comments, and DOCTYPE are ignored. Operator entity spellings (`&times;`, `&le;`, `&#xD7;`, …)
-decode to the same operators as their literal glyphs.
+decode to the same operators as their literal glyphs. In `<mover>`/`<munder>` position an operator
+glyph (`<mo>^</mo>`, `<mo>‾</mo>`, `<mo>→</mo>`) is read as an **annotation symbol**, not an infix
+operator — so `<mover><mi>x</mi><mo>^</mo></mover>` is "x with a hat".
 
-Deferred to PR-2: `<mtable>`/`<mtr>`/`<mtd>` → `Matrix`, `<mover>`/`<munder>` → over/under-sets,
-`<mfenced>`, and named-function recognition (`<mi>sin</mi>` → `Call`).
+Deferred to PR-3: named-function recognition (`<mi>sin</mi>` → `Call`) and `<mfenced>` separator
+modelling (today a fence's contents fold as one row).
 
 ## Contract
 

--- a/code/packages/rust/mathml/src/lib.rs
+++ b/code/packages/rust/mathml/src/lib.rs
@@ -68,7 +68,8 @@ impl MathFrontend for MathMl {
         // PR-1 surface: fractions (`<mfrac>`), roots (`<msqrt>`/`<mroot>`), powers (`<msup>` →
         // `Pow`), relations (`<mo>=`/`<` …), implicit multiplication (adjacent operands in a row),
         // text (`<mtext>`), and ± / ∓ (`<mo>±`). Subscripts are core (not a capability flag).
-        // Functions, matrices, accents, and over/under-sets are PR-2.
+        // PR-2 adds matrices (`<mtable>`) and over/under-sets (`<mover>`/`<munder>`/`<munderover>`);
+        // `<mfenced>` lowers to `Group` (core). Named functions (`<mi>sin</mi>` → Call) are PR-3.
         Capabilities::none()
             .with_fractions()
             .with_roots()
@@ -77,6 +78,8 @@ impl MathFrontend for MathMl {
             .with_implicit_mul()
             .with_text()
             .with_plusminus()
+            .with_matrices()
+            .with_oversets()
     }
 }
 
@@ -311,6 +314,86 @@ mod tests {
         assert!(MathMl.parse(&deep).is_err());
     }
 
+    // ---- PR-2: over/under-sets, fences, tables --------------------------------
+    fn overset(over: MathExpr, base: MathExpr) -> MathExpr {
+        MathExpr::Overset { over: Box::new(over), base: Box::new(base) }
+    }
+    fn underset(under: MathExpr, base: MathExpr) -> MathExpr {
+        MathExpr::Underset { under: Box::new(under), base: Box::new(base) }
+    }
+
+    #[test]
+    fn mover_stacks_annotation_over_base() {
+        // <mover>x ^</mover> → Overset{ over: ^, base: x }  (base first in MathML order). The hat
+        // glyph arrives as an <mo>; in over-position it is an annotation symbol, not an infix op.
+        assert_eq!(p("<mover><mi>x</mi><mo>^</mo></mover>"), overset(sym("^"), sym("x")));
+    }
+
+    #[test]
+    fn munder_stacks_annotation_under_base() {
+        // <munder>lim 0</munder> with a symbolic annotation.
+        assert_eq!(p("<munder><mi>lim</mi><mi>n</mi></munder>"), underset(sym("n"), sym("lim")));
+    }
+
+    #[test]
+    fn munderover_nests_under_outside_over() {
+        // <munderover>base under over</munderover> → Underset{ under, base: Overset{ over, base } }.
+        let e = p("<munderover><mi>S</mi><mi>a</mi><mi>b</mi></munderover>");
+        assert_eq!(e, underset(sym("a"), overset(sym("b"), sym("S"))));
+    }
+
+    #[test]
+    fn mfenced_lowers_to_group() {
+        // <mfenced><mrow>x + 1</mrow></mfenced> → Group(Add(x,1)).
+        let e = p("<mfenced><mrow><mi>x</mi><mo>+</mo><mn>1</mn></mrow></mfenced>");
+        assert_eq!(e, MathExpr::Group(Box::new(b(BinOp::Add, sym("x"), num(1)))));
+    }
+
+    #[test]
+    fn mtable_is_a_matrix_of_rows_and_cells() {
+        // 2×2 table → Matrix([[1,2],[3,4]]).
+        let e = p(concat!(
+            "<mtable>",
+            "<mtr><mtd><mn>1</mn></mtd><mtd><mn>2</mn></mtd></mtr>",
+            "<mtr><mtd><mn>3</mn></mtd><mtd><mn>4</mn></mtd></mtr>",
+            "</mtable>"
+        ));
+        assert_eq!(e, MathExpr::Matrix(vec![vec![num(1), num(2)], vec![num(3), num(4)]]));
+    }
+
+    #[test]
+    fn mtable_cell_folds_a_full_expression() {
+        // A cell may hold a whole expression, not just an atom.
+        let e = p("<mtable><mtr><mtd><mn>1</mn><mo>+</mo><mn>2</mn></mtd></mtr></mtable>");
+        assert_eq!(e, MathExpr::Matrix(vec![vec![b(BinOp::Add, num(1), num(2))]]));
+    }
+
+    #[test]
+    fn mtable_rejects_non_mtr_children() {
+        // Only <mtr> may appear directly inside <mtable>; a stray cell is a spanned error.
+        assert!(MathMl.parse("<mtable><mtd><mn>1</mn></mtd></mtable>").is_err());
+        // and inside a row, only <mtd>.
+        assert!(MathMl.parse("<mtable><mtr><mn>1</mn></mtr></mtable>").is_err());
+        // unclosed table / row are spanned errors, not panics.
+        assert!(MathMl.parse("<mtable><mtr><mtd><mn>1</mn></mtd></mtr>").is_err());
+    }
+
+    #[test]
+    fn mover_arity_is_enforced() {
+        // <mover> needs exactly two children.
+        assert!(MathMl.parse("<mover><mi>x</mi></mover>").is_err());
+        assert!(MathMl.parse("<munderover><mi>x</mi><mi>a</mi></munderover>").is_err());
+    }
+
+    #[test]
+    fn wide_table_does_not_overflow() {
+        // A FLAT run of many rows/cells lives at shallow nesting; structural parsing is iterative,
+        // so a 50k-row table parses (and the Matrix drops) without a stack overflow / abort.
+        let row = "<mtr><mtd><mn>1</mn></mtd></mtr>";
+        let wide = format!("<mtable>{}</mtable>", row.repeat(50_000));
+        assert!(MathMl.parse(&wide).is_ok(), "wide table should parse, not abort");
+    }
+
     // ---- registry --------------------------------------------------------------
     #[test]
     fn registry_registers_under_its_name() {
@@ -333,6 +416,10 @@ mod tests {
             "<math><mn>2</mn><mi>x</mi></math>",
             "<mtext>kg</mtext>",
             "<math><mn>1</mn><mo>±</mo><mn>2</mn></math>",
+            "<mover><mi>x</mi><mo>^</mo></mover>",
+            "<munder><mi>lim</mi><mi>n</mi></munder>",
+            "<mtable><mtr><mtd><mn>1</mn></mtd><mtd><mn>2</mn></mtd></mtr></mtable>",
+            "<mfenced><mrow><mi>x</mi><mo>+</mo><mn>1</mn></mrow></mfenced>",
         ];
         let report = check_frontend(&MathMl, &samples);
         assert!(report.passed(), "conformance violations: {report:?}");

--- a/code/packages/rust/mathml/src/parser.rs
+++ b/code/packages/rust/mathml/src/parser.rs
@@ -436,11 +436,110 @@ impl Parser {
                 let subbed = MathExpr::Subscript(Box::new(base), Box::new(sub));
                 Ok(Child::Expr(MathExpr::Bin(BinOp::Pow, Box::new(subbed), Box::new(sup))))
             }
+            // `<mover>base over</mover>` → annotation stacked over the base (drops the `accent`
+            // attribute, which we ignore — a generic Overset). `<munder>base under</munder>` →
+            // Underset. `<munderover>base under over</munderover>` → both, under-most outside.
+            "mover" => {
+                let args = self.read_n_script_args(name, 2, depth)?;
+                let mut it = args.into_iter();
+                let base = it.next().unwrap();
+                let over = it.next().unwrap();
+                Ok(Child::Expr(MathExpr::Overset { over: Box::new(over), base: Box::new(base) }))
+            }
+            "munder" => {
+                let args = self.read_n_script_args(name, 2, depth)?;
+                let mut it = args.into_iter();
+                let base = it.next().unwrap();
+                let under = it.next().unwrap();
+                Ok(Child::Expr(MathExpr::Underset { under: Box::new(under), base: Box::new(base) }))
+            }
+            "munderover" => {
+                let args = self.read_n_script_args(name, 3, depth)?;
+                let mut it = args.into_iter();
+                let base = it.next().unwrap();
+                let under = it.next().unwrap();
+                let over = it.next().unwrap();
+                let overset = MathExpr::Overset { over: Box::new(over), base: Box::new(base) };
+                Ok(Child::Expr(MathExpr::Underset { under: Box::new(under), base: Box::new(overset) }))
+            }
+            // `<mfenced>…</mfenced>` — a parenthesised group. We model the fence as a `Group` over
+            // the folded contents (its `open`/`close`/`separators` attributes are presentation,
+            // dropped like all attributes); a comma-separated list folds as one row (PR-2 limit).
+            "mfenced" => {
+                let kids = self.parse_row_children(name, depth)?;
+                let inner = fold_row(kids, span, depth)?;
+                Ok(Child::Expr(MathExpr::Group(Box::new(inner))))
+            }
+            // `<mtable>` of `<mtr>` rows of `<mtd>` cells → MathExpr::Matrix (delimiter style is
+            // not part of MathML's mtable, so nothing to drop). Parsed structurally below.
+            "mtable" => self.build_mtable(depth),
             other => {
                 // Unknown element: consume its subtree so the lexer stays balanced, then report
                 // it honestly rather than silently dropping content.
                 let _ = self.parse_row_children(name, depth);
                 err(format!("unsupported MathML element <{other}>"), span)
+            }
+        }
+    }
+
+    /// Parse a `<mtable>` body: a sequence of `<mtr>` rows, each a sequence of `<mtd>` cells, into
+    /// `MathExpr::Matrix`. Stray non-`mtr` content (or non-`mtd` inside a row) is a spanned error.
+    fn build_mtable(&mut self, depth: usize) -> Result<Child, FrontendError> {
+        if depth > MAX_DEPTH {
+            return err("MathML nested too deeply", self.current_span());
+        }
+        let mut rows: Vec<Vec<MathExpr>> = Vec::new();
+        loop {
+            match self.peek() {
+                None => return err("unclosed <mtable> (expected </mtable>)", (0, self.src_len)),
+                Some(Event::End { name, .. }) if name == "mtable" => {
+                    self.pos += 1;
+                    break;
+                }
+                Some(Event::Start { name, self_closing, .. }) if name == "mtr" => {
+                    let self_closing = *self_closing;
+                    self.pos += 1;
+                    let cells = if self_closing { Vec::new() } else { self.build_mtr_cells(depth + 1)? };
+                    rows.push(cells);
+                }
+                _ => {
+                    let span = self.current_span();
+                    return err("<mtable> may contain only <mtr> rows", span);
+                }
+            }
+        }
+        Ok(Child::Expr(MathExpr::Matrix(rows)))
+    }
+
+    /// Parse one `<mtr>` row: its `<mtd>` cells (each a folded row), up to `</mtr>`.
+    fn build_mtr_cells(&mut self, depth: usize) -> Result<Vec<MathExpr>, FrontendError> {
+        let mut cells: Vec<MathExpr> = Vec::new();
+        loop {
+            match self.peek() {
+                None => return err("unclosed <mtr> (expected </mtr>)", (0, self.src_len)),
+                Some(Event::End { name, .. }) if name == "mtr" => {
+                    self.pos += 1;
+                    return Ok(cells);
+                }
+                Some(Event::Start { name, self_closing, span }) if name == "mtd" => {
+                    let self_closing = *self_closing;
+                    let span = *span;
+                    self.pos += 1;
+                    if self_closing {
+                        cells.push(MathExpr::Symbol(String::new())); // an empty cell
+                    } else {
+                        let kids = self.parse_row_children("mtd", depth + 1)?;
+                        if kids.is_empty() {
+                            cells.push(MathExpr::Symbol(String::new()));
+                        } else {
+                            cells.push(fold_row(kids, span, depth + 1)?);
+                        }
+                    }
+                }
+                _ => {
+                    let span = self.current_span();
+                    return err("<mtr> may contain only <mtd> cells", span);
+                }
             }
         }
     }
@@ -460,6 +559,29 @@ impl Parser {
                         (0, self.src_len),
                     )
                 }
+            }
+        }
+        if args.len() != n {
+            return err(
+                format!("<{name}> expects {n} arguments, got {}", args.len()),
+                (0, self.src_len),
+            );
+        }
+        Ok(args)
+    }
+
+    /// Like [`read_n_args`](Self::read_n_args), but an operator-glyph child (`<mo>^</mo>`,
+    /// `<mo>‾</mo>`, `<mo>→</mo>`, `<mo>⏞</mo>`) is accepted as an annotation *symbol* rather than
+    /// rejected. In over/under-script position a glyph is a mark stacked on the base, not an infix
+    /// operator — so `<mover><mi>x</mi><mo>^</mo></mover>` is a legitimate "x with a hat". Used by
+    /// `<mover>`/`<munder>`/`<munderover>`.
+    fn read_n_script_args(&mut self, name: &str, n: usize, depth: usize) -> Result<Vec<MathExpr>, FrontendError> {
+        let kids = self.parse_row_children(name, depth)?;
+        let mut args = Vec::with_capacity(kids.len());
+        for c in kids {
+            match c {
+                Child::Expr(e) => args.push(e),
+                Child::Op(s) => args.push(MathExpr::Symbol(s)),
             }
         }
         if args.len() != n {

--- a/code/specs/PFE01-pluggable-parser-frontends.md
+++ b/code/specs/PFE01-pluggable-parser-frontends.md
@@ -156,8 +156,11 @@ frontend additionally ships notation-specific golden tests.
   that browsers and tools emit. A small crate with an XML-subset event lexer (attributes,
   namespace prefixes, the XML declaration, comments, and DOCTYPE all ignored) and an element-tree
   builder. PR-1 covers `<mn>`/`<mi>`/`<mtext>`/`<mo>`, `<mrow>` (operator precedence + implicit
-  multiplication + `(`…`)` fences), `<mfrac>`/`<msup>`/`<msub>`/`<msubsup>`/`<msqrt>`/`<mroot>`;
-  `<mtable>`, `<mover>`/`<munder>`, `<mfenced>`, and named-function recognition are PR-2.
+  multiplication + `(`…`)` fences), `<mfrac>`/`<msup>`/`<msub>`/`<msubsup>`/`<msqrt>`/`<mroot>`.
+  PR-2 adds `<mtable>`/`<mtr>`/`<mtd>` → `Matrix`, `<mover>`/`<munder>`/`<munderover>` →
+  `Overset`/`Underset` (an `<mo>` annotation in over/under position is read as a mark symbol), and
+  `<mfenced>` → `Group`. Named-function recognition (`<mi>sin</mi>` → `Call`) and `<mfenced>`
+  separator modelling are PR-3.
 - Future: MathJSON, content-MathML, spreadsheet formulae, … each a small crate implementing the
   trait. None require changes to consumers. **Four frontends now in (LaTeX, AsciiMath, Unicode,
   MathML), all feeding one neutral AST with zero consumer change** — the pluggability claim is


### PR DESCRIPTION
## What

PR-2 of the **MathML** frontend (the fourth pluggable [PFE01](code/specs/PFE01-pluggable-parser-frontends.md) frontend). Adds structural breadth — all lowering to the **same neutral `MathExpr` AST** the `latex`, `asciimath`, and `unicode-math` frontends produce, so consumers gain MathML matrices/over-sets with **zero** change.

| MathML | neutral `MathExpr` |
|--------|--------------------|
| `<mtable><mtr><mtd>…</mtd></mtr></mtable>` | `Matrix(rows × cells)` |
| `<mover>b a</mover>` / `<munder>b a</munder>` | `Overset { over: a, base: b }` / `Underset { under: a, base: b }` |
| `<munderover>b u o</munderover>` | `Underset { under: u, base: Overset { over: o, base: b } }` |
| `<mfenced>…</mfenced>` | `Group` over the folded contents |

### Design notes
- **`<mtable>` needs dedicated structural parsing.** A table's children are `<mtr>` rows and a row's are `<mtd>` cells — neither is an operand, so they can't go through the operand readers. `build_mtable`/`build_mtr_cells` walk the events directly. Each cell folds a full expression; stray non-`<mtr>`/non-`<mtd>` content and unclosed table/row are spanned errors; an empty cell becomes an empty `Symbol`.
- **Over/under annotations are often operator glyphs** (a hat `^`, bar `‾`, arrow `→`, brace `⏞`). `read_n_script_args` accepts a lone `<mo>` as an annotation **symbol** rather than rejecting it as a bare infix operator — so `<mover><mi>x</mi><mo>^</mo></mover>` is "x with a hat".
- **Capabilities** grow `matrices` + `oversets`, kept honest by the shared `check_frontend` conformance harness (its sample corpus now includes a table, an over/under-set, and a fenced group).

## Safety
Both new functions are **iterative loops, not recursion-per-row**; the only nesting cycle (a nested `<mtable>` inside an `<mtd>`) goes back through the `MAX_DEPTH`-guarded `parse_one_into`. A **flat 50 000-row table** stack-safety regression test guards against reintroducing the prior unary flat-run overflow. The `.unwrap()`s in the over/under arms are guarded by `read_n_script_args`'s exact length check (same pattern as `read_n_args`). `#![forbid(unsafe_code)]` holds; the neutral tree drops iteratively.

## Tests / gates
- **35 unit tests + doctest** (was 24): tables, table-cell folding, table well-formedness errors, over/under/under-over sets, mover arity, fenced groups, the wide-table stack-safety test, and an extended conformance check.
- `cargo test -p mathml` green; `cargo clippy -p mathml -- -D warnings` clean.
- **Security review passed** (Rust-focused: recursion/DoS, panics, integer overflow) — no findings.

## Deferred to PR-3
Named-function recognition (`<mi>sin</mi>` → `Call`) and `<mfenced>` separator modelling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)