### PR TITLE
fix(javascript-parser): decline destructuring declarations instead of aborting

### DIFF
--- a/code/packages/rust/javascript-parser/CHANGELOG.md
+++ b/code/packages/rust/javascript-parser/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable changes to the `coding-adventures-javascript-parser` crate will be documented in this file.
 
+## [0.19.9] - 2026-06-30
+
+### Fixed — destructuring declarations aborted the compile instead of declining
+
+A `var` / `let` / `const` declaration with a destructuring binding pattern
+made the bridge raise an `Internal` error, which the CLI treats as a hard
+failure (`exit 2`, error text on stdout, no JS output):
+
+```
+var [a, b] = c;   →  bridge internal error: variable declarator: missing name
+let {p, q} = o;   →  bridge internal error: lexical_binding: ... missing name
+```
+
+Destructuring is a Phase 2 feature the typed bridge doesn't represent yet —
+but, like spread / optional chaining / `new`, it should DECLINE gracefully so
+the CLI falls back to WHITESPACE_ONLY and still emits valid (if less
+optimized) JavaScript, never abort.
+
+**Cause.** `convert_variable_declarator` searched the declarator's direct
+children for a NAME token and unwrapped it with
+`ok_or_else(|| internal(node, "missing name"))` BEFORE checking for a
+`binding_pattern` node. A destructuring target is a `binding_pattern` node
+with no NAME token at that level, so the unwrap fired the `Internal` error
+first and the later binding-pattern→`UnsupportedSyntax` check was dead code.
+
+**Fix.** The `binding_pattern` → `UnsupportedSyntax` decline now runs first,
+so `var [a,b]=c;` / `let {p,q}=o;` / `const [x]=y;` round-trip through the
+WHITESPACE_ONLY fallback (`exit 0`) instead of aborting. Plain (identifier)
+declarations are unaffected.
+
+Regression test: `destructuring_declarations_decline_gracefully_not_hard_error`.
+
 ## [0.19.8] - 2026-06-30
 
 ### Fixed — assignment expression as a call argument / array element was dropped (miscompile)

--- a/code/packages/rust/javascript-parser/Cargo.toml
+++ b/code/packages/rust/javascript-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-javascript-parser"
-version = "0.19.8"
+version = "0.19.9"
 edition = "2021"
 description = "JavaScript parser — parses JavaScript source code against any ECMAScript edition (es1 through es2025) using the grammar-driven parser. Includes correlation-vector plumbing per CLOC03 and a typed-AST bridge (GrammarASTNode → javascript_ast::Program) per CLOC12.136."
 

--- a/code/packages/rust/javascript-parser/src/bridge.rs
+++ b/code/packages/rust/javascript-parser/src/bridge.rs
@@ -827,14 +827,19 @@ fn convert_variable_declarator(node: &GrammarASTNode) -> Result<VariableDeclarat
     // In both cases: first token or node is the binding name; optional
     // second node is the initializer expression.
 
-    // Find the NAME token (the binding identifier).
-    let id_name = node.children.iter().find_map(|c| match c {
-        ASTNodeOrToken::Token(t) if t.value != "=" => Some(t.value.clone()),
-        _ => None,
-    });
-    let id_name = id_name.ok_or_else(|| internal(node, "variable declarator: missing name"))?;
-
-    // Check for binding_pattern (destructuring) — not in Phase 1.
+    // Destructuring binding patterns (`var [a, b] = c`, `let {p, q} = o`,
+    // `const [x] = y`) are not yet supported by the typed bridge (Phase 2).
+    // DECLINE GRACEFULLY here — return `unsupported` so the CLI falls back to
+    // WHITESPACE_ONLY and still emits valid output (the same way spread,
+    // optional chaining, `new`, etc. are declined).
+    //
+    // This check MUST come before the NAME lookup below. A binding pattern is
+    // a `binding_pattern` *node* with no NAME *token* among the declarator's
+    // direct children, so the `find_map` yields `None` and the
+    // `ok_or_else(internal(...))` would abort the WHOLE compile with a hard
+    // error (`exit 2`) instead of declining. Previously this check sat AFTER
+    // that unwrap and was dead code for the destructuring case, so
+    // `var [a,b]=c;` / `let {p,q}=o;` failed to compile at SIMPLE/ADVANCED.
     for c in &node.children {
         if let ASTNodeOrToken::Node(n) = c {
             if n.rule_name == "binding_pattern" {
@@ -842,6 +847,13 @@ fn convert_variable_declarator(node: &GrammarASTNode) -> Result<VariableDeclarat
             }
         }
     }
+
+    // Find the NAME token (the binding identifier).
+    let id_name = node.children.iter().find_map(|c| match c {
+        ASTNodeOrToken::Token(t) if t.value != "=" => Some(t.value.clone()),
+        _ => None,
+    });
+    let id_name = id_name.ok_or_else(|| internal(node, "variable declarator: missing name"))?;
 
     // Find the initializer: the expression node child.
     let init = node_children(node).into_iter().next();
@@ -2790,6 +2802,23 @@ mod tests {
                 continue; // parse declined — sound fallback
             };
             let _ = grammar_to_program(&node, DEFAULT_ES_VERSION); // must not panic
+        }
+    }
+
+    #[test]
+    fn destructuring_declarations_decline_gracefully_not_hard_error() {
+        // `var [a,b]=c;`, `let {p,q}=o;`, `const [x]=y;` — destructuring binding
+        // patterns are Phase 2. The bridge must decline with `UnsupportedSyntax`
+        // (so the CLI falls back to WHITESPACE_ONLY and still emits valid JS),
+        // NOT raise an `Internal` error — which the CLI treats as a hard failure
+        // (`exit 2`, no output). Regression: the binding-pattern check sat after
+        // the NAME-token unwrap, so the unwrap fired `internal("missing name")`
+        // first and `var [a,b]=c;` failed to compile at SIMPLE/ADVANCED.
+        for src in ["var [a,b]=c;", "let {p,q}=o;", "const [x]=y;"] {
+            match bridge(src) {
+                Err(BridgeError::UnsupportedSyntax { .. }) => {} // graceful decline
+                other => panic!("expected UnsupportedSyntax for {src:?}, got {other:?}"),
+            }
         }
     }
 


### PR DESCRIPTION
## Problem

A `var` / `let` / `const` declaration with a **destructuring binding pattern** made the bridge raise an `Internal` error, which the CLI treats as a **hard failure** (`exit 2`, error text on stdout, no JS output):

```
var [a, b] = c;   →  bridge internal error: ... missing name   (exit 2)
let {p, q} = o;   →  bridge internal error: ... missing name   (exit 2)
```

Destructuring is valid ES syntax and a Phase 2 feature the typed bridge doesn't represent yet — but, like spread / optional chaining / `new`, it should **decline gracefully** so the CLI falls back to WHITESPACE_ONLY and still emits valid (if less optimized) JavaScript, never abort the whole compile.

## Cause

`convert_variable_declarator` searched the declarator's direct children for a NAME token and unwrapped it with `ok_or_else(|| internal(node, "missing name"))` **before** checking for a `binding_pattern` node. A destructuring target is a `binding_pattern` node with **no NAME token** at that level, so the unwrap fired the `Internal` error first — and the later `binding_pattern` → `UnsupportedSyntax` decline was **dead code**.

## Fix

Run the `binding_pattern` → `UnsupportedSyntax` decline **first**, before the NAME lookup. Now:

```
var [a,b]=c;   →  var [a,b]=c;   (exit 0, WHITESPACE_ONLY passthrough)
let {p,q}=o;   →  let {p,q}=o;   (exit 0)
const [x]=y;   →  const [x]=y;   (exit 0)
```

Plain (identifier) declarations are completely unaffected. The change only makes *more* inputs decline gracefully — it never lowers a binding pattern into a (wrong) AST.

## Verification

- Reproduced the `exit 2` hard failure and confirmed `exit 0` + valid passthrough after the fix.
- New regression test: `destructuring_declarations_decline_gracefully_not_hard_error` (asserts `UnsupportedSyntax`, not `Internal`).
- **96** parser tests green; full `cargo test` green across all consumers — closure-pass-inline/-inline-variables/-rename/-rename-globals/-rename-properties, closurec (883). No fixture changes (this is a decline fix, not an output change).
- Inline security review passed (non-destructuring path unaffected, declining is sound not a drop, no new panic/mis-conversion surface).
- Version `0.19.8` → `0.19.9`; CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)