### PR TITLE
feat(js-sir): M5 collections — arrays & objects (C5)

### DIFF
--- a/code/packages/rust/javascript-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/javascript-to-semantic-ir/CHANGELOG.md
@@ -5,6 +5,85 @@ All notable changes to `javascript-to-semantic-ir` are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## 0.5.0
+
+SIR19 milestone **M5 (collections: arrays & objects)** — builds on M4's
+functions/closures.  Adds array literals, object literals, member / dot /
+subscript access (reads), and indexed / property assignment (writes).
+This is the last big data-manipulation milestone for the JS frontend.
+
+### Added
+
+- **Array literals → `SeqLit`.**  `[e0, e1, …]` (CST `array_literal[
+  LBracket, element_list, RBracket ]`) lowers each element through the
+  depth-bounded expression lowerer.  `[]` is an empty `SeqLit`.  Observes
+  `Feature::Sequences`.
+- **Object literals → `MapLit`.**  `{ a: 1, "k": v }` (CST `object_literal`
+  with `property_definition[ property_name, Colon, value ]` children) lowers
+  to a `MapLit`.  Identifier keys (`a:`) and quoted keys (`"k":`) **both**
+  become string map keys — the JS quoting distinction is syntactic.  `{}` is
+  an empty `MapLit`.  Observes `Feature::Maps`.  A parenthesised grouping
+  (`primary_expression[ (, expression, ) ]`) is now peeled, so `({a:1})` at
+  statement start lowers (the `{`-as-block ambiguity is resolved by the
+  source parens).
+- **Member / subscript reads.**  `xs.length` → `SeqLen`; every other
+  `obj.prop` (dot) → `MapGet` with a string key; `xs[i]` → `SeqIndex`;
+  `obj["k"]` (string-literal subscript) → `MapGet`.  Member chains are
+  **flat** in the CST (`grid[0][1]` is one `member_expression` with the
+  accesses as a trailing token/node sequence), so we **fold the accesses
+  left iteratively** — no per-segment CST recursion.
+- **Indexed / property assignment (writes).**  `xs[i] = v` → `SeqSet`;
+  `obj.prop = v` / `obj["k"] = v` → `MapSet`; chained `grid[0][1] = v`
+  builds the receiver (`grid[0]`) via the read path then emits the `SeqSet`.
+
+### The bracket-vs-dot disambiguation
+
+The IR has both sequences and maps; JS `x[i]` is structurally ambiguous and
+the IR is untyped at this layer.  Following the SIR19 collections table
+(the authority), we resolve it **by access shape and key kind**, not by
+value-type inference:
+
+- dot `.prop` → `MapGet` (string key), with the single special case
+  `.length` → `SeqLen`;
+- bracket with a **string-literal** key (`obj["k"]`) → `MapGet` (a quoted
+  subscript reads exactly like the equivalent dotted access);
+- bracket with **any other** key (`xs[0]`, `xs[i]`, `xs[i+1]`) → `SeqIndex`.
+
+Assignment targets mirror this exactly.  This default is spec-sanctioned
+and documented in both the module docs and the spec's collections section.
+
+### Recursion safety (CWE-674)
+
+Every new CST walk is depth-bounded.  Array elements, object-property
+values, member-chain receivers, and bracket indices are all lowered through
+`lower_expression` at `depth + 1`, capped by `MAX_EXPR_DEPTH = 256`; the
+element/property/access *iteration* is strictly non-recursive.  A
+pathological `[[[[…]]]]`, `{a:{b:{c:…}}}`, or `p.p.p…` tower yields a
+positioned `JsLowerError`, never a native stack overflow.  A regression test
+(`deeply_nested_member_chain_is_rejected_without_crashing`) feeds a
+600-deep member tower straight into `compile` and asserts a clean error.
+
+### Deferred past M5
+
+Spread (`[...xs]` / `{...o}`), array elisions (`[1, , 3]`), object shorthand
+(`{x}`), computed keys (`{[e]: v}`), numeric keys, object methods /
+getters / setters, `.length` *assignment* (a resize with no IR node), and
+array methods (`.map`/`.push`/… — these need runtime-library support per the
+project mandate), plus the existing M4 deferrals (classes, `this`/`new`,
+generators, `async`, destructuring, default/rest params, template literals).
+
+### Tests
+
+- Per-form lowering tests (array/object literals incl. empty + nested, the
+  SeqLen/SeqIndex/MapGet disambiguation, string-vs-numeric subscripts, dot
+  chains, all four write forms, chained writes), each with a
+  `semantic_ir::validate` round-trip.
+- The CWE-674 deep-member-chain regression test.
+- Two new `node` end-to-end goldens (gated on `node` availability):
+  `array_sum` (build/index/mutate/sum an array via a counting `for` over
+  `xs.length`) → `19`; `object_get_set` (build an object, get/set
+  properties) → `155`.
+
 ## 0.4.0
 
 SIR19 milestone **M4 (functions, calls, closures)** — builds on M3's

--- a/code/packages/rust/javascript-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/javascript-to-semantic-ir/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "javascript-to-semantic-ir"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
-description = "JavaScript (GrammarASTNode CST) → narrow-waist Semantic IR. SIR19 frontend, milestone M4 (functions, calls, closures)."
+description = "JavaScript (GrammarASTNode CST) → narrow-waist Semantic IR. SIR19 frontend, milestone M5 (collections: arrays & objects)."
 
 [dependencies]
 coding-adventures-javascript-parser = { path = "../javascript-parser" }

--- a/code/packages/rust/javascript-to-semantic-ir/README.md
+++ b/code/packages/rust/javascript-to-semantic-ir/README.md
@@ -27,13 +27,13 @@ We lower from the *generic* `GrammarASTNode`, **not** from the parser's
 typed-AST bridge (`javascript-parser/src/bridge.rs`). That is the
 contract SIR19 sets, matching how the Ruby and Twig frontends work.
 
-## Milestone status — M4 (functions, calls, closures)
+## Milestone status — M5 (collections: arrays & objects)
 
-This is the fourth slice of SIR19. It implements literals (M1),
-variables/operators (M2), and control flow (M3) **plus** functions:
-`function` declarations, arrow functions, tail-position `return`,
-function calls, and closures (`MakeClosure` + free-variable capture). The
-supported subset (M1 + M2 + M3 + M4):
+This is the fifth slice of SIR19. It implements literals (M1),
+variables/operators (M2), control flow (M3), and functions/closures (M4)
+**plus** collections: array literals, object literals, member / dot /
+subscript access (reads), and indexed / property assignment (writes). The
+supported subset (M1 + M2 + M3 + M4 + M5):
 
 | JavaScript source           | SIR lowering                                  |
 |-----------------------------|-----------------------------------------------|
@@ -69,6 +69,39 @@ supported subset (M1 + M2 + M3 + M4):
 | `f(1, 2)` (known function)  | `DirectCall { fn_name, args }`                |
 | `g(3)` (closure value)      | `IndirectCall { target, args }`               |
 | `console.log(x)`            | `BuiltinCall("print", [x])`                   |
+| `[1, 2, 3]`, `[]`           | `SeqLit { items }`                            |
+| `{ a: 1, "k": v }`, `{}`    | `MapLit { entries }` (id/string keys → string) |
+| `xs.length`                 | `SeqLen { seq }`                              |
+| `xs[i]` (non-string index)  | `SeqIndex { seq, index }`                     |
+| `obj.prop`, `obj["k"]`      | `MapGet { map, key }` (string key)            |
+| `xs[i] = v;`                | `Stmt::SeqSet { seq, index, value }`          |
+| `obj.prop = v;`, `obj["k"] = v;` | `Stmt::MapSet { map, key, value }`       |
+
+### Collections (M5)
+
+- **Array / object literals** become `SeqLit` / `MapLit`. Object keys —
+  identifier (`a:`) or quoted (`"k":`) — both lower to **string** map keys
+  (the JS quoting distinction is purely syntactic). A parenthesised
+  grouping is peeled, so `({a: 1})` lowers at statement start.
+- **The bracket-vs-dot disambiguation.** The IR has both sequences and
+  maps and is untyped here, so `x[i]` is structurally ambiguous. Per the
+  SIR19 collections table we resolve **by access shape and key kind**:
+  `.length` → `SeqLen`; every other `.prop` → `MapGet` (string key);
+  `obj["k"]` (string-literal subscript) → `MapGet`; `xs[i]` (any other
+  index) → `SeqIndex`. Assignment targets mirror this exactly.
+- **Flat member chains.** `grid[0][1]` / `a.b.c` parse as a *single*
+  `member_expression` with the accesses as a trailing token/node sequence;
+  we **fold them left iteratively** (no per-segment CST recursion). A
+  chained write `grid[0][1] = v` builds the receiver `grid[0]` via the read
+  path, then emits the final `SeqSet`/`MapSet`.
+- **Recursion safety (CWE-674).** Every element, property value, chain
+  receiver, and bracket index is lowered through the depth-bounded
+  `lower_expression` (`MAX_EXPR_DEPTH = 256`), so a deep `[[[[…]]]]`,
+  `{a:{b:…}}`, or `p.p.p…` tower is a positioned error, not a stack
+  overflow. The element/property/access iteration is non-recursive.
+- **Deferred:** spread, elisions, object shorthand, computed/numeric keys,
+  methods/getters/setters, `.length` assignment (a resize), and array
+  methods (`.map`/`.push`/… — need runtime-library support).
 
 ### Functions, calls, and closures
 
@@ -204,19 +237,21 @@ Every produced `Module`:
   `semantic_ir::validate` with no used-but-undeclared errors and no
   declared-but-unused warnings.
 
-## Out of scope for M4 (deferred)
+## Out of scope for M5 (deferred)
 
-Collections and member access (M5 — array/object literals, indexing,
-`.length`, member/`[]` access, and method calls other than
-`console.log`), classes / `this` / `new`, generators, `async`/`await`,
-default / rest parameters, destructuring, spread, and template literals
-all currently return a `JsLowerError` describing what was rejected, with
-the offending node's position. So do **early `return`** (non-tail), the
-remaining control-flow constructs (`switch`, `try`/`catch`, `do … while`,
-labeled statements, `break`/`continue`), and the gaps within the M2/M3
-operator/assignment families (compound assignment outside the loop-update
-position, member/index assignment targets, multi-binding declarations,
-uninitialised bindings, bitwise/shift/exponentiation/nullish operators).
+Method calls other than `console.log` and array methods (`.map`/`.push`/…,
+which need runtime-library support), spread (`[...xs]` / `{...o}`), array
+elisions, object shorthand / computed / numeric keys / methods / getters /
+setters, `.length` *assignment* (a resize with no IR node), classes /
+`this` / `new`, generators, `async`/`await`, default / rest parameters,
+destructuring, and template literals all currently return a `JsLowerError`
+describing what was rejected, with the offending node's position. So do
+**early `return`** (non-tail), the remaining control-flow constructs
+(`switch`, `try`/`catch`, `do … while`, labeled statements,
+`break`/`continue`), and the gaps within the M2/M3 operator/assignment
+families (compound assignment outside the loop-update position,
+multi-binding declarations, uninitialised bindings,
+bitwise/shift/exponentiation/nullish operators).
 The error sites are structured so later milestones slot their handling in
 at exactly the right place. See `CHANGELOG.md` for the milestone roadmap
 and the full SIR19 spec at

--- a/code/packages/rust/javascript-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/javascript-to-semantic-ir/src/lib.rs
@@ -27,10 +27,21 @@
 //! not from the parser's typed-AST bridge — that's the contract SIR19
 //! sets, mirroring the Ruby and Twig frontends.
 //!
-//! ## Milestone status — M4 (functions, calls, closures)
+//! ## Milestone status — M5 (collections: arrays & objects)
 //!
-//! This build implements literals (M1), variables/operators (M2), and
-//! control flow (M3) **plus** functions (M4): `function` declarations →
+//! This build implements literals (M1), variables/operators (M2), control
+//! flow (M3), and functions/closures (M4) **plus** collections (M5):
+//! array literals → [`Expr::SeqLit`], object literals → [`Expr::MapLit`]
+//! (identifier and `"string"` keys both → string map keys), `xs.length`
+//! → [`Expr::SeqLen`], `obj.prop`/`obj["k"]` → [`Expr::MapGet`], `xs[i]`
+//! → [`Expr::SeqIndex`], and the matching write forms
+//! [`Stmt::SeqSet`]/[`Stmt::MapSet`].  The bracket-vs-dot disambiguation
+//! (`x[<string-literal>]`→map, `x[<other>]`→sequence, `.length`→`SeqLen`,
+//! other `.prop`→map) follows the SIR19 collections table; flat member
+//! chains (`grid[0][1]`) fold left iteratively.  See [`lower`] for the
+//! full collections design and the CWE-674 depth bounds.
+//!
+//! M4, unchanged: functions (M4): `function` declarations →
 //! top-level [`Function`](semantic_ir::Function)s, arrow functions and
 //! nested `function`s → [`Expr::MakeClosure`] over synthesised functions
 //! with free-variable [`Capture`](semantic_ir::Capture)s, tail-position
@@ -46,9 +57,8 @@
 //! C-style `for` → [`Stmt::ForRange`], `for … of` → [`Stmt::ForEach`], and
 //! bare `{ … }` blocks → [`Expr::Block`].  Non-canonical `for` loops, the
 //! remaining control-flow constructs
-//! (`switch`/`try`/`do-while`/labeled/`break`/`continue`), and collections
-//! / member access / classes / `this` (M5+) are positioned errors
-//! (deferred).
+//! (`switch`/`try`/`do-while`/labeled/`break`/`continue`), and classes /
+//! `this` / `new` (M6+) are positioned errors (deferred).
 //!
 //! The M1 + M2 lowerings, unchanged, are:
 //!
@@ -72,9 +82,10 @@
 //!   → `BuiltinCall("!=")` (strict normalisation — a documented semantic
 //!   change for the loose-equality coercion cases).
 //!
-//! All other syntax (collections, member access, methods beyond
-//! `console.log`, template literals, classes/`this`/`new`,
-//! generators/`async`, default/rest params, destructuring/spread, plus
+//! All other syntax (methods beyond `console.log`, array methods like
+//! `.map`/`.push`, spread/elisions, object shorthand/computed/numeric keys,
+//! `.length` assignment, template literals, classes/`this`/`new`,
+//! generators/`async`, default/rest params, destructuring, plus
 //! non-canonical `for`, early `return`, and the remaining control-flow
 //! constructs `switch`/`try`/`do-while`/labeled/`break`/`continue`) is
 //! **deferred** to later milestones and currently produces a clear
@@ -1349,6 +1360,345 @@ mod tests {
             cur = node("block", vec![ASTNodeOrToken::Node(cur)]);
         }
         cur
+    }
+
+    // ── M5: collections — arrays, objects, member/subscript access ─
+
+    /// Lower `src` whose tail value is a collection expression, returning it.
+    fn coll_value(src: &str) -> Expr {
+        let m = lower(src);
+        let r = semantic_ir::validate(&m);
+        assert!(r.is_ok(), "validation failed: {:?}", r.issues);
+        main_value(&m).clone()
+    }
+
+    #[test]
+    fn array_literal_lowers_to_seq_lit() {
+        let m = lower("[1, 2, 3];");
+        match main_value(&m) {
+            Expr::SeqLit { items, .. } => {
+                assert_eq!(items.len(), 3);
+                assert!(matches!(items[0], Expr::IntLit { value: 1, .. }));
+                assert!(matches!(items[2], Expr::IntLit { value: 3, .. }));
+            }
+            other => panic!("expected SeqLit, got {other:?}"),
+        }
+        assert!(m.manifest.contains(Feature::Sequences));
+        assert_valid(&m);
+    }
+
+    #[test]
+    fn empty_array_is_empty_seq_lit() {
+        match coll_value("[];") {
+            Expr::SeqLit { items, .. } => assert!(items.is_empty()),
+            other => panic!("expected empty SeqLit, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn nested_array_literals() {
+        // `[[1], [2, 3]]` → SeqLit of two SeqLits.
+        match coll_value("[[1], [2, 3]];") {
+            Expr::SeqLit { items, .. } => {
+                assert_eq!(items.len(), 2);
+                assert!(matches!(&items[0], Expr::SeqLit { items, .. } if items.len() == 1));
+                assert!(matches!(&items[1], Expr::SeqLit { items, .. } if items.len() == 2));
+            }
+            other => panic!("expected nested SeqLit, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn object_literal_with_identifier_keys_lowers_to_map_lit() {
+        // Parenthesised so `{` is not read as a block at statement start.
+        let m = lower("({a: 1, b: 2});");
+        match main_value(&m) {
+            Expr::MapLit { entries, .. } => {
+                assert_eq!(entries.len(), 2);
+                assert!(matches!(&entries[0].key, Expr::StrLit { value, .. } if value == "a"));
+                assert!(matches!(&entries[0].value, Expr::IntLit { value: 1, .. }));
+                assert!(matches!(&entries[1].key, Expr::StrLit { value, .. } if value == "b"));
+            }
+            other => panic!("expected MapLit, got {other:?}"),
+        }
+        assert!(m.manifest.contains(Feature::Maps));
+        assert_valid(&m);
+    }
+
+    #[test]
+    fn object_literal_in_binding_needs_no_parens() {
+        // In value position (not statement start) `{` is unambiguous.
+        let m = lower("let o = {a: 1}; o;");
+        let b = main_block(&m);
+        assert!(matches!(
+            &b.stmts[0],
+            Stmt::LetStarBinding { value: Expr::MapLit { .. }, .. }
+        ));
+        assert_valid(&m);
+    }
+
+    #[test]
+    fn object_literal_with_string_keys() {
+        match coll_value("let v = 0; ({\"k\": v});") {
+            Expr::MapLit { entries, .. } => {
+                assert!(matches!(&entries[0].key, Expr::StrLit { value, .. } if value == "k"));
+                assert!(matches!(&entries[0].value, Expr::VarRef { .. }));
+            }
+            other => panic!("expected MapLit, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn empty_object_is_empty_map_lit() {
+        match coll_value("({});") {
+            Expr::MapLit { entries, .. } => assert!(entries.is_empty()),
+            other => panic!("expected empty MapLit, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn array_length_lowers_to_seq_len() {
+        // `xs.length` → SeqLen (the one dotted property that is a sequence op).
+        match coll_value("let xs = [1, 2]; xs.length;") {
+            Expr::SeqLen { seq, .. } => {
+                assert!(matches!(&*seq, Expr::VarRef { name, .. } if name == "xs"));
+            }
+            other => panic!("expected SeqLen, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn numeric_subscript_lowers_to_seq_index() {
+        // `xs[0]` → SeqIndex (non-string index → sequence).
+        match coll_value("let xs = [9]; xs[0];") {
+            Expr::SeqIndex { seq, index, .. } => {
+                assert!(matches!(&*seq, Expr::VarRef { name, .. } if name == "xs"));
+                assert!(matches!(&*index, Expr::IntLit { value: 0, .. }));
+            }
+            other => panic!("expected SeqIndex, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn variable_subscript_lowers_to_seq_index() {
+        // `xs[i]` with a variable index is also a SeqIndex (not a string key).
+        match coll_value("let xs = [9]; let i = 0; xs[i];") {
+            Expr::SeqIndex { index, .. } => {
+                assert!(matches!(&*index, Expr::VarRef { name, .. } if name == "i"));
+            }
+            other => panic!("expected SeqIndex, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn dot_member_lowers_to_map_get() {
+        // `obj.prop` → MapGet with string key "prop".
+        match coll_value("let obj = {p: 1}; obj.p;") {
+            Expr::MapGet { map, key, .. } => {
+                assert!(matches!(&*map, Expr::VarRef { name, .. } if name == "obj"));
+                assert!(matches!(&*key, Expr::StrLit { value, .. } if value == "p"));
+            }
+            other => panic!("expected MapGet, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn string_subscript_lowers_to_map_get() {
+        // `obj["k"]` — a string-literal key → MapGet (mirrors `obj.k`).
+        match coll_value("let obj = {k: 1}; obj[\"k\"];") {
+            Expr::MapGet { map, key, .. } => {
+                assert!(matches!(&*map, Expr::VarRef { name, .. } if name == "obj"));
+                assert!(matches!(&*key, Expr::StrLit { value, .. } if value == "k"));
+            }
+            other => panic!("expected MapGet, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn seq_index_assignment_lowers_to_seq_set() {
+        // `xs[0] = 9;` → SeqSet.
+        let m = lower("let xs = [1]; xs[0] = 9;");
+        let b = main_block(&m);
+        let set = b.stmts.iter().find(|s| matches!(s, Stmt::SeqSet { .. }))
+            .expect("a SeqSet statement");
+        match set {
+            Stmt::SeqSet { seq, index, value, .. } => {
+                assert!(matches!(seq, Expr::VarRef { name, .. } if name == "xs"));
+                assert!(matches!(index, Expr::IntLit { value: 0, .. }));
+                assert!(matches!(value, Expr::IntLit { value: 9, .. }));
+            }
+            _ => unreachable!(),
+        }
+        assert!(m.manifest.contains(Feature::Sequences));
+        assert_valid(&m);
+    }
+
+    #[test]
+    fn dot_assignment_lowers_to_map_set() {
+        // `obj.prop = 5;` → MapSet with string key.
+        let m = lower("let obj = {p: 0}; obj.p = 5;");
+        let set = main_block(&m).stmts.iter().find(|s| matches!(s, Stmt::MapSet { .. }))
+            .expect("a MapSet statement");
+        match set {
+            Stmt::MapSet { map, key, value, .. } => {
+                assert!(matches!(map, Expr::VarRef { name, .. } if name == "obj"));
+                assert!(matches!(key, Expr::StrLit { value, .. } if value == "p"));
+                assert!(matches!(value, Expr::IntLit { value: 5, .. }));
+            }
+            _ => unreachable!(),
+        }
+        assert!(m.manifest.contains(Feature::Maps));
+        assert_valid(&m);
+    }
+
+    #[test]
+    fn string_subscript_assignment_lowers_to_map_set() {
+        // `obj["k"] = 5;` → MapSet.
+        let m = lower("let obj = {k: 0}; obj[\"k\"] = 5;");
+        assert!(main_block(&m).stmts.iter().any(|s| matches!(
+            s,
+            Stmt::MapSet { key: Expr::StrLit { value, .. }, .. } if value == "k"
+        )));
+        assert_valid(&m);
+    }
+
+    #[test]
+    fn numeric_subscript_assignment_is_seq_set_not_map_set() {
+        // Guard the disambiguation on the *assignment* side: `xs[i] = v`
+        // must be a SeqSet, never a MapSet.
+        let m = lower("let xs = [0]; let i = 0; xs[i] = 7;");
+        assert!(main_block(&m).stmts.iter().any(|s| matches!(s, Stmt::SeqSet { .. })));
+        assert!(!main_block(&m).stmts.iter().any(|s| matches!(s, Stmt::MapSet { .. })));
+        assert_valid(&m);
+    }
+
+    #[test]
+    fn nested_map_in_seq_validates() {
+        // A sequence of maps — exercise the manifest declaring both features.
+        let m = lower("let data = [{id: 1}, {id: 2}]; data[0];");
+        assert_valid(&m);
+        assert!(m.manifest.contains(Feature::Sequences));
+        assert!(m.manifest.contains(Feature::Maps));
+        let r = semantic_ir::validate(&m);
+        assert!(r.warnings().next().is_none(), "unexpected warnings");
+    }
+
+    #[test]
+    fn chained_subscript_left_associates() {
+        // `grid[0][1]` → SeqIndex(SeqIndex(grid, 0), 1).
+        match coll_value("let grid = [[1, 2]]; grid[0][1];") {
+            Expr::SeqIndex { seq, index, .. } => {
+                assert!(matches!(&*index, Expr::IntLit { value: 1, .. }));
+                assert!(matches!(&*seq, Expr::SeqIndex { .. }));
+            }
+            other => panic!("expected nested SeqIndex, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn chained_subscript_assignment_sets_innermost() {
+        // `grid[0][1] = 9;` → SeqSet whose seq is SeqIndex(grid, 0).
+        let m = lower("let grid = [[0, 0]]; grid[0][1] = 9;");
+        let set = main_block(&m).stmts.iter().find(|s| matches!(s, Stmt::SeqSet { .. }))
+            .expect("a SeqSet statement");
+        match set {
+            Stmt::SeqSet { seq, index, value, .. } => {
+                assert!(matches!(seq, Expr::SeqIndex { .. }));
+                assert!(matches!(index, Expr::IntLit { value: 1, .. }));
+                assert!(matches!(value, Expr::IntLit { value: 9, .. }));
+            }
+            _ => unreachable!(),
+        }
+        assert_valid(&m);
+    }
+
+    #[test]
+    fn dot_chain_lowers_to_nested_map_get() {
+        // `a.b.c` → MapGet(MapGet(a, "b"), "c").
+        match coll_value("let a = {b: {c: 1}}; a.b.c;") {
+            Expr::MapGet { map, key, .. } => {
+                assert!(matches!(&*key, Expr::StrLit { value, .. } if value == "c"));
+                assert!(matches!(&*map, Expr::MapGet { .. }));
+            }
+            other => panic!("expected nested MapGet, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn array_spread_is_deferred() {
+        let err = compile_source("let xs = [1]; [...xs];", "test")
+            .expect_err("array spread deferred");
+        assert!(err.message.contains("deferred"), "got: {}", err.message);
+    }
+
+    #[test]
+    fn length_assignment_is_deferred() {
+        let err = compile_source("let xs = [1]; xs.length = 0;", "test")
+            .expect_err("length assignment deferred");
+        assert!(err.message.contains("deferred"), "got: {}", err.message);
+    }
+
+    #[test]
+    fn computed_object_key_is_deferred() {
+        let err = compile_source("let k = \"x\"; ({[k]: 1});", "test")
+            .expect_err("computed key deferred");
+        assert!(err.message.contains("deferred"), "got: {}", err.message);
+    }
+
+    /// Build a `member_expression` dot-chain nested `n` levels deep
+    /// (`p.p.p…`) so the **expression** depth guard trips while lowering it.
+    fn nest_member(n: usize) -> GrammarASTNode {
+        use lexer::token::{Token, TokenType};
+        let tok = |type_: TokenType, value: &str| Token {
+            type_,
+            value: value.to_string(),
+            line: 1,
+            column: 1,
+            type_name: None,
+            flags: None,
+            cv: None,
+        };
+        // Each layer: member_expression[ inner, Dot, Name("p") ].
+        let mut cur = node(
+            "primary_expression",
+            vec![ASTNodeOrToken::Token(tok(TokenType::Name, "p"))],
+        );
+        for _ in 0..n {
+            cur = node(
+                "member_expression",
+                vec![
+                    ASTNodeOrToken::Node(cur),
+                    ASTNodeOrToken::Token(tok(TokenType::Dot, ".")),
+                    ASTNodeOrToken::Token(tok(TokenType::Name, "p")),
+                ],
+            );
+        }
+        cur
+    }
+
+    #[test]
+    fn deeply_nested_member_chain_is_rejected_without_crashing() {
+        // A `p.p.p…` chain far deeper than MAX_EXPR_DEPTH (256) must turn
+        // into a positioned error, not overflow the native stack (CWE-674).
+        // We build the member tower directly and lower it as the program's
+        // single expression statement via the public `compile`.
+        let expr = node("expression", vec![ASTNodeOrToken::Node(nest_member(600))]);
+        let stmt = node(
+            "expression_statement",
+            vec![ASTNodeOrToken::Node(expr)],
+        );
+        let body = node(
+            "source_element",
+            vec![ASTNodeOrToken::Node(node("statement", vec![ASTNodeOrToken::Node(stmt)]))],
+        );
+        let program = node("program", vec![ASTNodeOrToken::Node(body)]);
+        let err = compile(&program, "deep")
+            .expect_err("a 600-deep member chain must be rejected, not crash");
+        assert!(
+            err.message.contains("deeper than the supported limit"),
+            "unexpected message: {}",
+            err.message
+        );
     }
 
     #[test]

--- a/code/packages/rust/javascript-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/javascript-to-semantic-ir/src/lower.rs
@@ -261,11 +261,64 @@
 //! nest of functions or calls becomes a positioned error, not a stack
 //! overflow.
 //!
-//! ### Deferred past M4
+//! ## Collections (M5 — learned by probing the parser)
 //!
-//! Collections / member-access / methods (M5), classes, `this`/`new`,
-//! generators / `async`/`await`, default / rest params, destructuring,
-//! spread, and template literals remain positioned errors.
+//! M5 adds **arrays** and **objects** plus member / subscript access.  The
+//! CST rule names and child layouts (precedence-wrapper layers elided):
+//!
+//! | JS source        | CST rule              | children                                                    |
+//! |------------------|-----------------------|-------------------------------------------------------------|
+//! | `[1, 2, 3]`      | `array_literal`       | `[LBracket, element_list, RBracket]`                        |
+//! | `[]`             | `array_literal`       | `[LBracket, element_list(empty), RBracket]`                 |
+//! | `{a: 1, "k": v}` | `object_literal`      | `[LBrace, property_definition*, (Comma), RBrace]`           |
+//! | `{}`             | `object_literal`      | `[LBrace, RBrace]`                                          |
+//! | `a:`/`"k":`      | `property_definition` | `[property_name(Name|String), Colon, assignment_expression]`|
+//! | `obj.prop`       | `member_expression`   | `[receiver, Dot, Name(prop)]`                               |
+//! | `xs[i]`/`obj["k"]`| `member_expression`  | `[receiver, LBracket, expression, RBracket]`                |
+//! | `({…})`          | `primary_expression`  | `[LParen, expression, RParen]` (grouping)                   |
+//!
+//! ### The bracket-vs-dot disambiguation (the M5 design decision)
+//!
+//! The IR has *both* sequences (`SeqLit`/`SeqIndex`/`SeqLen`/`SeqSet`) and
+//! maps (`MapLit`/`MapGet`/`MapSet`).  JS `x[i]` is structurally ambiguous —
+//! it could index either — and `x.prop` is unambiguously object access.  The
+//! IR is untyped at this layer, so we cannot infer the receiver's kind.  We
+//! follow the SIR19 collections table, which fixes:
+//!
+//! - `[…]` → `SeqLit`, `{…}` → `MapLit` (identifier and `"string"` keys both
+//!   lower to a **string** map key — the JS quoting distinction is syntactic);
+//! - `xs.length` → `SeqLen`; **every other** `.prop` (dot) → `MapGet` with a
+//!   string key;
+//! - `xs[i]` → `SeqIndex`, `d[k]`/`d.k` → `MapGet`.
+//!
+//! The only genuinely ambiguous *source* form is `x[<expr>]`.  We resolve it
+//! **by the index expression's kind**: a **string-literal** key
+//! (`obj["k"]`) → `MapGet` (treating a quoted subscript exactly like the
+//! equivalent dotted access `obj.k`); **any other** index (`xs[0]`, `xs[i]`,
+//! `xs[i + 1]`) → `SeqIndex`.  Assignment targets mirror this exactly:
+//! `obj.prop = v` / `obj["k"] = v` → `MapSet`, `xs[i] = v` → `SeqSet`.  This
+//! default is spec-sanctioned (the table is the authority); it is documented
+//! here and in the spec's collections section.
+//!
+//! ### Recursion bound
+//!
+//! Every M5 CST walk is depth-bounded.  Array elements, object-property
+//! values, member-chain receivers, and bracket indices are all lowered
+//! through [`lower_expression`](Lowerer::lower_expression) at `depth + 1`, so
+//! a pathological `[[[[…]]]]`, `{a:{b:{c:…}}}`, or `a.b.c.d…` tower past
+//! [`MAX_EXPR_DEPTH`] becomes a positioned [`JsLowerError`], never a native
+//! stack overflow (CWE-674).  The object-property and array-element *iteration*
+//! is strictly non-recursive (a `for` over direct children).
+//!
+//! ### Deferred past M5
+//!
+//! Spread (`[...xs]` / `{...o}`), array elisions (`[1, , 3]`), object
+//! shorthand (`{x}`), computed keys (`{[e]: v}`), numeric keys (`{0: v}`),
+//! object methods / getters / setters, `.length` *assignment* (a resize, with
+//! no IR node), array methods (`.map`/`.push`/… — these would need
+//! runtime-library support, per the project mandate), classes, `this`/`new`,
+//! generators / `async`/`await`, default / rest params, destructuring, and
+//! template literals all remain positioned errors.
 
 use lexer::token::{Token, TokenType};
 use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode};
@@ -2135,13 +2188,15 @@ impl Lowerer {
         self.lower_expression(expr_node, 0).map(Lowered::Expr)
     }
 
-    /// Lower a statement-level `assignment_expression` (`x = expr`).
+    /// Lower a statement-level `assignment_expression` (`x = expr`,
+    /// `xs[i] = expr`, `obj.prop = expr`).
     ///
     /// Shape: `assignment_expression[ left_hand_side_expression,
-    /// assignment_operator, assignment_expression ]`.  M2 supports only
-    /// the plain `=` operator on a bare identifier target; compound
-    /// assignment (`+=`, …) and assignment to a member/index
-    /// (`obj.x = …`, `xs[i] = …`) are deferred.
+    /// assignment_operator, assignment_expression ]`.  Only the plain `=`
+    /// operator is supported; compound assignment (`+=`, …) is deferred.  The
+    /// target may be a bare identifier (→ `Assign`) **or** (M5) a member /
+    /// subscript access (→ `SeqSet` / `MapSet`), disambiguated exactly as the
+    /// read side ([`lower_member_expression`](Self::lower_member_expression)).
     fn lower_assignment(&mut self, node: &GrammarASTNode) -> Result<Stmt, JsLowerError> {
         let span = self.span_of(node);
 
@@ -2169,12 +2224,19 @@ impl Lowerer {
             });
         }
 
+        // ── M5: member / subscript target → SeqSet / MapSet ─────────────
+        // Peel the LHS spine; a *branching* `member_expression` is an
+        // indexed/member assignment target (`xs[i] = v`, `obj.prop = v`).
+        let lhs_branch = peel_to_branch(lhs);
+        if lhs_branch.rule_name == "member_expression" {
+            return self.lower_member_assignment(lhs_branch, node, span);
+        }
+
         // The target must be a bare identifier.  Peel the LHS spine to
-        // its leaf token; anything that branches (member access, index)
-        // is deferred.
-        let target_tok = single_leaf_token(peel_to_branch(lhs)).ok_or_else(|| JsLowerError {
-            message: "assignment to a non-identifier target (member/index) is deferred past M2"
-                .to_string(),
+        // its leaf token; anything that branches (and isn't a member
+        // access, handled above) is deferred.
+        let target_tok = single_leaf_token(lhs_branch).ok_or_else(|| JsLowerError {
+            message: "assignment to a non-identifier target is deferred".to_string(),
             line: span.start_line,
             column: span.start_col,
         })?;
@@ -2214,6 +2276,140 @@ impl Lowerer {
                 value,
                 span,
             })
+        }
+    }
+
+    /// Lower an indexed / member assignment target (`xs[i] = v`,
+    /// `obj.prop = v`, `obj["k"] = v`, and chained `grid[0][1] = v`) to a
+    /// [`Stmt::SeqSet`] / [`Stmt::MapSet`].
+    ///
+    /// `member` is the branching `member_expression` LHS;
+    /// `assign_node.children[2]` is the RHS value.  Like the read side, the
+    /// chain is **flat** in the CST (`[receiver, access, access, …]`).  The
+    /// *final* access is the assignment site; every access *before* it builds
+    /// the receiver expression.  We split the children at the last access,
+    /// lower the receiver prefix as an ordinary `member_expression` read (so
+    /// `grid[0][1] = v` indexes `grid[0]` first), then emit the matching Set.
+    ///
+    /// The SeqSet-vs-MapSet choice mirrors the read side exactly: a dotted
+    /// target is always a map key (`.length` is read-only — assignment is a
+    /// resize the IR can't express, so it is deferred); a bracket target with
+    /// a string-literal key is a map key, any other bracket key a sequence
+    /// index.
+    fn lower_member_assignment(
+        &mut self,
+        member: &GrammarASTNode,
+        assign_node: &GrammarASTNode,
+        span: Span,
+    ) -> Result<Stmt, JsLowerError> {
+        // The RHS value (children[2] of the assignment).
+        let rhs = match &assign_node.children[2] {
+            ASTNodeOrToken::Node(n) => n,
+            ASTNodeOrToken::Token(_) => {
+                return Err(self.unsupported(assign_node, "assignment (token RHS)"))
+            }
+        };
+        let value = self.lower_expression(rhs, 0)?;
+
+        // Find where the *final* access starts (a `.` or `[` token).  Earlier
+        // children form the receiver prefix; the final access is the target.
+        let last_access = member
+            .children
+            .iter()
+            .rposition(|c| matches!(c, ASTNodeOrToken::Token(t) if t.value == "." || t.value == "["))
+            .ok_or_else(|| self.unsupported(member, "assignment target (no access)"))?;
+
+        // The receiver is the member_expression truncated to everything
+        // before the final access; if that is a single node, lower it
+        // directly, otherwise re-wrap it as a `member_expression` and lower
+        // the prefix chain through the read path.
+        let recv = self.lower_member_prefix(member, last_access, &span)?;
+
+        match &member.children[last_access] {
+            // ── final `.name` access → MapSet (string key) ─────────────
+            ASTNodeOrToken::Token(t) if t.value == "." => {
+                let prop = match member.children.get(last_access + 1) {
+                    Some(ASTNodeOrToken::Token(p)) if matches!(p.type_, TokenType::Name) => {
+                        p.value.clone()
+                    }
+                    _ => return Err(self.unsupported(member, "assignment to non-name property")),
+                };
+                if prop == "length" {
+                    return Err(JsLowerError {
+                        message: "assignment to `.length` is deferred past M5 (no resize node)"
+                            .to_string(),
+                        line: span.start_line,
+                        column: span.start_col,
+                    });
+                }
+                self.features_used.add(Feature::Maps);
+                self.features_used.add(Feature::Strings);
+                Ok(Stmt::MapSet {
+                    map: recv,
+                    key: Expr::StrLit { value: prop, span: span.clone() },
+                    value,
+                    span,
+                })
+            }
+            // ── final `[index]` access → SeqSet / MapSet ───────────────
+            ASTNodeOrToken::Token(t) if t.value == "[" => {
+                let index_node = match member.children.get(last_access + 1) {
+                    Some(ASTNodeOrToken::Node(n)) => n,
+                    _ => return Err(self.unsupported(member, "subscript target (no index)")),
+                };
+                let index = self.lower_expression(index_node, 0)?;
+                if matches!(index, Expr::StrLit { .. }) {
+                    self.features_used.add(Feature::Maps);
+                    Ok(Stmt::MapSet { map: recv, key: index, value, span })
+                } else {
+                    self.features_used.add(Feature::Sequences);
+                    Ok(Stmt::SeqSet { seq: recv, index, value, span })
+                }
+            }
+            _ => Err(self.unsupported(member, "assignment target (unsupported access form)")),
+        }
+    }
+
+    /// Lower the *receiver prefix* of a flat `member_expression` assignment
+    /// target: everything before the access at `last_access`.  If the prefix
+    /// is just the bare receiver node (a simple `xs[i] = v` / `obj.p = v`),
+    /// lower that node directly; otherwise (a chained `grid[0][1] = v`)
+    /// re-wrap the prefix children as a `member_expression` and lower it
+    /// through the read path so the inner accesses fold correctly.
+    fn lower_member_prefix(
+        &mut self,
+        member: &GrammarASTNode,
+        last_access: usize,
+        _span: &Span,
+    ) -> Result<Expr, JsLowerError> {
+        let prefix = &member.children[..last_access];
+        // Count access tokens in the prefix; zero means the prefix is the
+        // bare receiver node (the common, single-access case).
+        let prefix_accesses = prefix
+            .iter()
+            .filter(|c| matches!(c, ASTNodeOrToken::Token(t) if t.value == "." || t.value == "["))
+            .count();
+        let recv_node = prefix
+            .iter()
+            .find_map(|c| match c {
+                ASTNodeOrToken::Node(n) => Some(n),
+                ASTNodeOrToken::Token(_) => None,
+            })
+            .ok_or_else(|| self.unsupported(member, "assignment target (no receiver)"))?;
+        if prefix_accesses == 0 {
+            self.lower_expression(recv_node, 0)
+        } else {
+            // Re-wrap the prefix as its own member_expression and lower it as
+            // a read (folds the inner `grid[0]` of `grid[0][1] = v`).
+            let inner = GrammarASTNode {
+                rule_name: "member_expression".to_string(),
+                children: prefix.to_vec(),
+                start_line: member.start_line,
+                start_column: member.start_column,
+                end_line: member.end_line,
+                end_column: member.end_column,
+            };
+            self.lower_member_expression(&inner, 0)
         }
     }
 
@@ -2305,9 +2501,289 @@ impl Lowerer {
             "arrow_function" => self.lower_arrow_function(node, depth),
             "call_expression" => self.lower_call_expression(node, depth),
 
-            // ── still unsupported (member access, collections, …) ───
+            // ── M5: collections ─────────────────────────────────────
+            // Array / object literals and member / subscript access.
+            "array_literal" => self.lower_array_literal(node, depth),
+            "object_literal" => self.lower_object_literal(node, depth),
+            "member_expression" => self.lower_member_expression(node, depth),
+
+            // ── M5: parenthesised expression ────────────────────────
+            // `( expr )` — the parser wraps a grouping in a branching
+            // `primary_expression[ (, expression, ) ]`.  This is how an
+            // object literal reaches value position at statement start
+            // (`({a: 1})`), and grouping in general.  Peel to the inner
+            // expression and lower it.
+            "primary_expression" if is_parenthesised(node) => {
+                let inner = child_node_named(node, "expression")
+                    .ok_or_else(|| self.unsupported(node, "parenthesised (no inner expr)"))?;
+                self.lower_expression(inner, depth + 1)
+            }
+
+            // ── still unsupported (classes, `this`, `new`, …) ───────
             other => Err(self.unsupported(node, other)),
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // M5: collections — array / object literals, member / subscript access
+    // -----------------------------------------------------------------------
+
+    /// Lower an `array_literal` (`[ e0, e1, … ]`) to an [`Expr::SeqLit`].
+    ///
+    /// CST: `array_literal[ LBracket, element_list, RBracket ]`, where
+    /// `element_list` holds `assignment_expression` element nodes separated
+    /// by `Comma` tokens (empty for `[]`).  Each element is lowered with the
+    /// depth-bounded expression lowerer, so a nested `[[[…]]]` tower past
+    /// [`MAX_EXPR_DEPTH`] is a positioned error, not a stack overflow.
+    ///
+    /// Spread elements (`[...xs]`) and elisions (`[1, , 3]`) are deferred:
+    /// the former adds a `spread_element` child we don't model, the latter
+    /// a hole we'd have to invent a value for.
+    fn lower_array_literal(
+        &mut self,
+        node: &GrammarASTNode,
+        depth: usize,
+    ) -> Result<Expr, JsLowerError> {
+        let span = self.span_of(node);
+        let mut items = Vec::new();
+        // The element nodes live under the `element_list` child (absent for
+        // some grammars when empty; the probe shows an empty `element_list`).
+        if let Some(list) = child_node_named(node, "element_list") {
+            for child in &list.children {
+                match child {
+                    ASTNodeOrToken::Node(n) => {
+                        // A `spread_element` (`...xs`) is the one element node
+                        // we cannot model as a plain item; reject it.
+                        if peel_to_branch(n).rule_name == "spread_element" {
+                            return Err(JsLowerError {
+                                message: "array spread (`[...xs]`) is deferred past M5"
+                                    .to_string(),
+                                line: span.start_line,
+                                column: span.start_col,
+                            });
+                        }
+                        items.push(self.lower_expression(n, depth + 1)?);
+                    }
+                    // Comma separators carry no element.
+                    ASTNodeOrToken::Token(_) => {}
+                }
+            }
+        }
+        self.features_used.add(Feature::Sequences);
+        Ok(Expr::SeqLit { items, span })
+    }
+
+    /// Lower an `object_literal` (`{ k0: v0, k1: v1, … }`) to an
+    /// [`Expr::MapLit`].
+    ///
+    /// CST: `object_literal[ LBrace, property_definition*, (Comma), RBrace ]`,
+    /// each `property_definition[ property_name, Colon, assignment_expression ]`
+    /// where `property_name` wraps a single `Name` token (identifier key
+    /// `a:`) or a `String` token (string key `"k":`).  Both lower to a
+    /// **string** map key (`StrLit`); the JS distinction between an
+    /// identifier and a quoted key is purely syntactic.
+    ///
+    /// Computed keys (`{ [e]: v }`), shorthand (`{ x }`), methods
+    /// (`{ f() {} }`), getters/setters, and spread (`{ ...o }`) are deferred —
+    /// each surfaces a `property_definition` shape we don't model.  Values are
+    /// lowered with the depth-bounded expression lowerer, so a nested
+    /// `{a:{b:{…}}}` tower past [`MAX_EXPR_DEPTH`] is a positioned error.
+    fn lower_object_literal(
+        &mut self,
+        node: &GrammarASTNode,
+        depth: usize,
+    ) -> Result<Expr, JsLowerError> {
+        let span = self.span_of(node);
+        let mut entries = Vec::new();
+        for prop in children_nodes_named(node, "property_definition") {
+            // A simple `key: value` property has exactly a `property_name`,
+            // a `Colon`, and one expression value node.  Anything else
+            // (shorthand `{x}`, method `{f(){}}`, spread `{...o}`, computed
+            // `{[e]:v}`) is deferred.
+            let key = self.object_key(prop, &span)?;
+            let value_node = prop
+                .children
+                .iter()
+                .rev()
+                .find_map(|c| match c {
+                    ASTNodeOrToken::Node(n) => Some(n),
+                    ASTNodeOrToken::Token(_) => None,
+                })
+                .ok_or_else(|| JsLowerError {
+                    message: "object property without a value (shorthand / method) \
+                              is deferred past M5"
+                        .to_string(),
+                    line: span.start_line,
+                    column: span.start_col,
+                })?;
+            let value = self.lower_expression(value_node, depth + 1)?;
+            entries.push(semantic_ir::nodes::MapEntry { key, value });
+        }
+        self.features_used.add(Feature::Maps);
+        Ok(Expr::MapLit { entries, span })
+    }
+
+    /// Extract the string key of a `property_definition`, rejecting the
+    /// deferred key forms (computed `[e]`, shorthand, method, numeric).
+    fn object_key(
+        &mut self,
+        prop: &GrammarASTNode,
+        span: &Span,
+    ) -> Result<Expr, JsLowerError> {
+        let name_node = child_node_named(prop, "property_name").ok_or_else(|| JsLowerError {
+            message: "object property key form (computed / shorthand / method) \
+                      is deferred past M5"
+                .to_string(),
+            line: span.start_line,
+            column: span.start_col,
+        })?;
+        let tok = single_leaf_token(name_node).ok_or_else(|| JsLowerError {
+            message: "computed object key (`{ [e]: v }`) is deferred past M5".to_string(),
+            line: span.start_line,
+            column: span.start_col,
+        })?;
+        match tok.type_ {
+            // Identifier key `a:` and quoted key `"k":` both become a string
+            // key — the JS-level distinction is syntactic only.
+            TokenType::Name | TokenType::String => {
+                self.features_used.add(Feature::Strings);
+                Ok(Expr::StrLit {
+                    value: tok.value.clone(),
+                    span: self.span_of_token(tok),
+                })
+            }
+            // Numeric keys (`{ 0: v }`) would need integer-keyed maps we
+            // don't model in v0.
+            other => Err(JsLowerError {
+                message: format!(
+                    "object key token {other:?} is deferred past M5 (string / identifier keys only)"
+                ),
+                line: tok.line,
+                column: tok.column,
+            }),
+        }
+    }
+
+    /// Lower a *branching* `member_expression` — a dot member or a bracket
+    /// subscript — to the spec's collection node.
+    ///
+    /// The disambiguation (SIR19 collections table) is **by access shape and
+    /// key kind**, not by any value-type inference (the IR is untyped here):
+    ///
+    /// | JS access      | CST shape                                  | SIR node                         |
+    /// |----------------|--------------------------------------------|----------------------------------|
+    /// | `xs.length`    | `[obj, Dot, Name("length")]`               | `SeqLen { seq: obj }`            |
+    /// | `obj.prop`     | `[obj, Dot, Name(prop)]`                   | `MapGet { map: obj, key: "prop"}`|
+    /// | `obj["k"]`     | `[obj, LBracket, expr(String), RBracket]`  | `MapGet { map: obj, key: "k" }`  |
+    /// | `xs[i]`        | `[obj, LBracket, expr(non-string), RBracket]` | `SeqIndex { seq: obj, index: i}` |
+    ///
+    /// So: **dot access → `MapGet`** (string key), with the single special
+    /// case `.length` → `SeqLen`; **bracket access with a string-literal key
+    /// → `MapGet`** (mirroring dot's string key), and **bracket access with
+    /// any other key → `SeqIndex`**.  This default is spec-sanctioned (the
+    /// table fixes `xs[i]`→`SeqIndex`, `d[k]`/`d.k`→`MapGet`,
+    /// `xs.length`→`SeqLen`); the only genuinely ambiguous source form,
+    /// `x[<string-literal>]`, is routed to `MapGet` by treating a quoted key
+    /// the same as a dotted one.
+    ///
+    /// A multi-segment chain (`a.b.c`, `grid[0][1]`) is **left-associative**
+    /// and, crucially, **flat in the CST**: the parser emits a *single*
+    /// `member_expression` whose children are `[receiver, access, access, …]`
+    /// — e.g. `grid[0][1]` → `[grid, [, 0, ], [, 1, ]]` (7 children) and
+    /// `a.b.c` → `[a, ., b, ., c]` (5 children).  We therefore fold the
+    /// accesses left over the child sequence (no CST recursion), lowering only
+    /// the receiver and each index through the depth-bounded expression
+    /// lowerer.  The *fold* is iterative, so a long chain costs no native
+    /// stack; each lowered index/receiver still consumes the `MAX_EXPR_DEPTH`
+    /// budget, so a `a[b[c[…]]]` index tower is a positioned error.
+    fn lower_member_expression(
+        &mut self,
+        node: &GrammarASTNode,
+        depth: usize,
+    ) -> Result<Expr, JsLowerError> {
+        let span = self.span_of(node);
+        // The receiver is the first child *node*; the trailing children are
+        // a flat sequence of `.name` or `[index]` accesses applied left to
+        // right.  We walk the children with a small cursor so both access
+        // shapes (and chains of them) fold uniformly.
+        let children = &node.children;
+        let first_idx = children
+            .iter()
+            .position(|c| matches!(c, ASTNodeOrToken::Node(_)))
+            .ok_or_else(|| self.unsupported(node, "member_expression (no receiver)"))?;
+        let recv_node = match &children[first_idx] {
+            ASTNodeOrToken::Node(n) => n,
+            ASTNodeOrToken::Token(_) => unreachable!("position found a Node"),
+        };
+        let mut acc = self.lower_expression(recv_node, depth + 1)?;
+
+        let mut i = first_idx + 1;
+        while i < children.len() {
+            match &children[i] {
+                // ── `.name` dot access ──────────────────────────────────
+                ASTNodeOrToken::Token(t) if t.value == "." => {
+                    // The next child is the property `Name` token.
+                    let prop = match children.get(i + 1) {
+                        Some(ASTNodeOrToken::Token(p)) if matches!(p.type_, TokenType::Name) => {
+                            p.value.clone()
+                        }
+                        _ => {
+                            return Err(self.unsupported(node, "member access (non-name property)"))
+                        }
+                    };
+                    i += 2;
+                    acc = if prop == "length" {
+                        // The one dotted property that is a sequence op.
+                        self.features_used.add(Feature::Sequences);
+                        Expr::SeqLen { seq: Box::new(acc), span: span.clone() }
+                    } else {
+                        self.features_used.add(Feature::Maps);
+                        self.features_used.add(Feature::Strings);
+                        Expr::MapGet {
+                            map: Box::new(acc),
+                            key: Box::new(Expr::StrLit {
+                                value: prop,
+                                span: span.clone(),
+                            }),
+                            span: span.clone(),
+                        }
+                    };
+                }
+                // ── `[index]` bracket access ────────────────────────────
+                ASTNodeOrToken::Token(t) if t.value == "[" => {
+                    // The next child is the index node (an `expression` for a
+                    // standalone subscript, or a bare precedence node in a
+                    // flat chain); the child after that is the `]` token.
+                    let index_node = match children.get(i + 1) {
+                        Some(ASTNodeOrToken::Node(n)) => n,
+                        _ => return Err(self.unsupported(node, "subscript (no index)")),
+                    };
+                    let index = self.lower_expression(index_node, depth + 1)?;
+                    i += 3; // skip `[`, index, `]`.
+                    // A *string-literal* key reads like object access → MapGet
+                    // (mirrors `obj.prop`); any other index → sequence index.
+                    acc = if matches!(index, Expr::StrLit { .. }) {
+                        self.features_used.add(Feature::Maps);
+                        Expr::MapGet {
+                            map: Box::new(acc),
+                            key: Box::new(index),
+                            span: span.clone(),
+                        }
+                    } else {
+                        self.features_used.add(Feature::Sequences);
+                        Expr::SeqIndex {
+                            seq: Box::new(acc),
+                            index: Box::new(index),
+                            span: span.clone(),
+                        }
+                    };
+                }
+                // Optional chaining `?.`, tagged templates, etc. are deferred.
+                _ => return Err(self.unsupported(node, "member_expression (unsupported access)")),
+            }
+        }
+
+        Ok(acc)
     }
 
     /// Lower a flat, left-associative binary chain to nested
@@ -2681,6 +3157,19 @@ fn child_nodes(node: &GrammarASTNode) -> Vec<&GrammarASTNode> {
             ASTNodeOrToken::Token(_) => None,
         })
         .collect()
+}
+
+/// Is `node` a parenthesised grouping `( expression )` — the branching
+/// `primary_expression[ LParen, expression, RParen ]` the parser emits for
+/// `(e)`?  Used (M5) to peel a grouping that brought an object literal into
+/// value position at statement start (`({a: 1})`).
+fn is_parenthesised(node: &GrammarASTNode) -> bool {
+    node.rule_name == "primary_expression"
+        && node
+            .children
+            .first()
+            .map(|c| matches!(c, ASTNodeOrToken::Token(t) if t.value == "("))
+            .unwrap_or(false)
 }
 
 /// Return the first direct child node of `node` whose `rule_name` is

--- a/code/packages/rust/javascript-to-semantic-ir/tests/e2e_node.rs
+++ b/code/packages/rust/javascript-to-semantic-ir/tests/e2e_node.rs
@@ -101,6 +101,48 @@ fn closure_adder_runs_in_node() {
 }
 
 #[test]
+fn array_sum_runs_in_node() {
+    if !node_available() {
+        eprintln!("skipping array_sum_runs_in_node: `node` not available");
+        return;
+    }
+    // M5 golden: build an array, index it, mutate an element, sum it with a
+    // counting `for` over `xs.length`.  Exercises SeqLit / SeqIndex / SeqLen
+    // / SeqSet end to end.
+    let out = run_via_node(
+        "array_sum",
+        "let xs = [1, 2, 3, 4]; \
+         xs[0] = 10; \
+         let total = 0; \
+         for (let i = 0; i < xs.length; i++) { total = total + xs[i]; } \
+         console.log(total);",
+    );
+    // [10, 2, 3, 4] sums to 19.
+    assert_eq!(out, "19");
+}
+
+#[test]
+fn object_get_set_runs_in_node() {
+    if !node_available() {
+        eprintln!("skipping object_get_set_runs_in_node: `node` not available");
+        return;
+    }
+    // M5 golden: build an object, read a property, set a property, read the
+    // updated value.  Exercises MapLit / MapGet / MapSet end to end.  Note
+    // we print individual values, not the Map itself (which `console.log`
+    // would render as `Map { … }`).
+    let out = run_via_node(
+        "object_get_set",
+        "let acct = {balance: 100, owner: \"ada\"}; \
+         acct.balance = acct.balance + 50; \
+         acct[\"bonus\"] = 5; \
+         console.log(acct.balance + acct[\"bonus\"]);",
+    );
+    // 100 + 50 + 5 = 155.
+    assert_eq!(out, "155");
+}
+
+#[test]
 fn mutual_recursion_runs_in_node() {
     if !node_available() {
         eprintln!("skipping mutual_recursion_runs_in_node: `node` not available");

--- a/code/specs/SIR19-javascript-to-semantic-ir.md
+++ b/code/specs/SIR19-javascript-to-semantic-ir.md
@@ -197,6 +197,60 @@ and `value = r`.
 declarations are not preserved.  v0 doesn't support `this` at all —
 no class support means no `this` cases worth modelling.
 
+## Collections (M5)
+
+**Implementation note (M5).**  Arrays, objects, member / dot / subscript
+access (reads), and indexed / property assignment (writes) are implemented
+as of crate `0.5.0`.  Details and the central design decision:
+
+- **Array literals → `SeqLit`** (`Feature::Sequences`); **object literals →
+  `MapLit`** (`Feature::Maps`).  Object keys are strings: an identifier key
+  (`a:`) and a quoted key (`"k":`) both lower to a `StrLit` map key — the JS
+  quoting distinction is purely syntactic.  Empty `[]`/`{}` lower to empty
+  `SeqLit`/`MapLit`.  A parenthesised grouping (`primary_expression[ (,
+  expression, ) ]`) is peeled, so `({a: 1})` lowers at statement start (the
+  source parens resolve the `{`-as-block ambiguity).
+
+- **The bracket-vs-dot disambiguation (the M5 decision).**  The IR has *both*
+  sequences and maps; JS `x[i]` is structurally ambiguous and the IR is
+  untyped at this layer, so the receiver's kind cannot be inferred.  The
+  coverage table above is the authority and fixes:
+  - `xs.length` → `SeqLen`; **every other** `.prop` (dot) → `MapGet` with a
+    string key;
+  - `xs[i]` → `SeqIndex`; `d[k]` / `d.k` → `MapGet`.
+
+  The only genuinely ambiguous *source* form is `x[<expr>]`.  The frontend
+  resolves it **by the index expression's kind**: a **string-literal** key
+  (`obj["k"]`) → `MapGet` (a quoted subscript reads exactly like the
+  equivalent dotted access `obj.k`); **any other** index (`xs[0]`, `xs[i]`,
+  `xs[i + 1]`) → `SeqIndex`.  Assignment targets mirror this exactly:
+  `obj.prop = v` / `obj["k"] = v` → `MapSet`, `xs[i] = v` → `SeqSet`.  This
+  default is spec-sanctioned (it is the only reading consistent with the
+  table's `xs[i]`→`SeqIndex` and `d[k]`→`MapGet` rows) and is documented in
+  the frontend's module docs.
+
+- **Flat member chains.**  The parser emits a *single* `member_expression`
+  whose children are the receiver followed by a flat token/node sequence of
+  accesses (`grid[0][1]` → `[grid, [, 0, ], [, 1, ]]`; `a.b.c` → `[a, ., b,
+  ., c]`).  The frontend folds the accesses **left, iteratively** — no
+  per-segment CST recursion — so `grid[0][1]` is `SeqIndex(SeqIndex(grid, 0),
+  1)` and `a.b.c` is `MapGet(MapGet(a, "b"), "c")`.  A chained write
+  `grid[0][1] = v` builds the receiver `grid[0]` through the read path, then
+  emits the final `SeqSet`/`MapSet`.
+
+- **Recursion bound (CWE-674).**  Every M5 CST walk is depth-bounded: array
+  elements, object-property values, member-chain receivers, and bracket
+  indices are all lowered through the depth-bounded expression lowerer
+  (`MAX_EXPR_DEPTH = 256`), and the element/property/access iteration is
+  strictly non-recursive.  A pathological `[[[[…]]]]`, `{a:{b:{c:…}}}`, or
+  `p.p.p…` tower yields a positioned `JsLowerError`, not a stack overflow.
+
+Deferred after M5: spread (`[...xs]` / `{...o}`), array elisions
+(`[1, , 3]`), object shorthand (`{x}`), computed keys (`{[e]: v}`), numeric
+keys, object methods / getters / setters, `.length` *assignment* (a resize
+with no IR node), and array methods (`.map`/`.push`/… — these would need
+runtime-library support per the project mandate).
+
 ## `var` hoisting
 
 JavaScript hoists `var` declarations to function scope.  In v0, the


### PR DESCRIPTION
Milestone M5 for the `javascript-to-semantic-ir` SIR19 frontend — **collections** (builds on merged M1-M4). The JS frontend can now lower real data-manipulating programs.

- Array literal → `SeqLit`; subscript `xs[i]` → `SeqIndex`; `xs.length` → `SeqLen`; `xs[i]=v` → `SeqSet`.
- Object literal → `MapLit` (identifier/string keys); member/subscript access → `MapGet`; property assignment → `MapSet`.
- **Bracket-vs-dot disambiguation** (spec-mandated): `.prop`→MapGet, `.length`→SeqLen, `x[<string-literal>]`→MapGet, `x[<other>]`→SeqIndex; assignment targets mirror this. Member chains are folded **iteratively** (parser emits flat chains).

**Recursion guards (the recurring class — handled up front):** every new CST walk is iterative or depth-bounded via `MAX_EXPR_DEPTH`; a 600-deep member/array/object tower returns a positioned error, not a crash (regression test included). Security review confirmed all walks bounded.

**Tests:** 110 lib + **6 node e2e** (array_sum→19, object_get_set→155, executed under node v24); clippy clean; security review passed.

Deferred (per the full-coverage mandate, via direct-lowering or runtime-library): spread/destructuring, computed/shorthand keys, array methods (.map/.push → need runtime-library), classes. Isolated to `javascript-to-semantic-ir`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)