### PR TITLE
[codex] Track tricky formatting repair evidence

### DIFF
--- a/code/packages/rust/html-parser/tests/whatwg_formatting_audit_test.rs
+++ b/code/packages/rust/html-parser/tests/whatwg_formatting_audit_test.rs
@@ -9,6 +9,7 @@ const WHATWG_FORMATTING_AUDIT: &str = include_str!("fixtures/whatwg-formatting-a
 const POST_PARSE_REPAIR_EVIDENCE: &[(&str, &str)] = &[
     ("scripted-adoption01-dat-1", "adoption-agency-formatting"),
     ("scripted-ark-dat-1", "adoption-agency-formatting"),
+    ("tricky01-dat-1", "adoption-agency-formatting"),
     ("tricky01-dat-3", "adoption-agency-formatting"),
     ("tricky01-dat-8", "interactive-formatting-boundary"),
     ("tricky01-dat-9", "interactive-formatting-boundary"),


### PR DESCRIPTION
## Summary
- add `tricky01-dat-1` to the formatting audit post-parse repair evidence guard
- pin the case to the `adoption-agency-formatting` axis while continuing to compare it against the html5lib/WHATWG DOM dump

## Validation
- cargo test -p coding-adventures-html-parser <monitor targeted tests>
- cargo test -p coding-adventures-html-parser
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser
- python3 -m json.tool code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json >/dev/null
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py
- git diff --check

After rebasing onto latest origin/main, the new main commits did not touch html-parser/html-lexer/state-machine-tokenizer/Rust workspace files; reran `cargo test -p coding-adventures-html-parser whatwg_formatting_audit_tracks_post_parse_repair_evidence`, `python3 -m json.tool ...html-browser-readiness.json >/dev/null`, and `git diff --check` on the final base.