### PR TITLE
feat(mle-pass): slice 6 — third hop-2 relation per disease + three-hop abstention

### DIFF
--- a/code/specs/MLE-PASS-multihop-recall.md
+++ b/code/specs/MLE-PASS-multihop-recall.md
@@ -157,6 +157,31 @@ hop-1 libraries to the gene/inheritance chains (dermatology, histopathology), tw
 `g6pd`), and the `x_linked` pattern. Run-verified: **38/38 correct** (35 answerable, both hops cited,
 `multihop_coverage` 1.0; 3 abstained), zero model calls.
 
+## 6d. Slice 6 (shipped) — a third hop-2 relation per disease, and three-hop abstention
+The bank grew **38 → 40** with two distinct spine advances, both arranging only already-grounded facts.
+
+```
+heinz_bodies ──seen_in──▶ g6pd_deficiency ──classic_finding──▶ bite_cells          (histo + anemia)
+   g6pd_deficiency now answers THREE hop-2 relations across THREE libraries:
+   gene_defect→g6pd (genetics, mh-36) · inheritance→x_linked (genetics, mh-38) · classic_finding→bite_cells (anemia, mh-39)
+
+leukocoria ──eye_finding_indicates──▶ retinoblastoma ──causes?──▶ ⊥ ──gram_stain──▶ (abstain)   (mh-40)
+   ends grounded, interior join ungrounded (no causative organism) → engine MUST abstain
+```
+
+- **`mh-39` (write-once-use-many at the hop-2 level).** A systematic join-scan shows `g6pd_deficiency`
+  is the one disease id appearing both as a finding-library object and a knowledge-library subject; it
+  now answers a *third* second relation (hematology `classic_finding`) from a different hop-1 finding
+  (`heinz_bodies`, histo) into a third hop-2 library (`anemia-edges`). One grounded id, three relations,
+  three libraries — the strongest single-disease evidence the second hop is fully generic.
+- **`mh-40` (three-hop abstention).** The deepest negative test: a 3-hop whose ends are grounded but
+  whose interior join (`causes(organism, retinoblastoma)`) binds nothing, so the engine abstains rather
+  than fabricate a Gram stain. A partially-grounded multi-hop is still an abstention — never-fabricate
+  extended to the deepest chain.
+
+Run-verified: **40/40 correct** (36 answerable, every answerable item cites all its hops — the 3-hop
+`mh-34` cites 3, `mh-39` cites 2; `multihop_coverage` 1.0; 4 abstained), zero model calls.
+
 ## 7. Next
 The **three-hop harness now exists** (slice 4); the limit is grounded id-joins, not the engine.
 More 3-hops land for free once: (a) more finding→disease edges reach micro `causes` diseases

--- a/code/specs/data/mycin-2026/mle-pass/CHANGELOG.md
+++ b/code/specs/data/mycin-2026/mle-pass/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog — mle-pass
 
+## [0.6.0] — 2026-06-30
+
+### Added — slice 6: a third hop-2 relation per disease, and three-hop abstention
+
+- Bank grows **38 → 40**, advancing the multi-hop spine in two distinct ways, both purely by
+  arranging already-grounded, spider+adversarially-gated facts (no edge grounded, renamed, or
+  authored — the no-human-authored rule):
+  - **`mh-39` — write-once-use-many at the hop-2 level.** `g6pd_deficiency` already answers
+    `gene_defect` (`mh-36`) and `inheritance` (`mh-38`); it now also answers a hematology
+    **`classic_finding`**: `heinz_bodies → g6pd_deficiency → bite_cells`, with hop 1 =
+    `histo-edges.adj seen_in` and hop 2 = a **third hop-2 library** (`anemia-edges.adj`). One
+    grounded disease id now feeds three distinct second relations across three libraries from two
+    different hop-1 findings — the strongest single-disease demonstration that the second hop is
+    fully generic over the relation/library.
+  - **`mh-40` — three-hop abstention.** A 3-hop question whose *ends* are grounded
+    (`leukocoria → retinoblastoma` is a real ophtho edge; `gram_stain` is a real relation) but whose
+    **interior join is ungrounded**: retinoblastoma is a tumour with no grounded causative organism,
+    so `causes(organism, retinoblastoma)` binds nothing and the chain cannot complete. The engine
+    MUST abstain rather than fabricate a Gram stain — extending the never-fabricate discipline to the
+    deepest chain (a partially-grounded multi-hop is still an abstention, not a guess).
+- Join-finder note: a systematic scan confirms `g6pd_deficiency` is today the **only** disease whose
+  id appears both as a finding-library object and as a knowledge-library subject, and that
+  `pseudomembranous_colitis` (slice 4, `mh-34`) remains the only finding→disease→organism bridge — so
+  the answerable cross-library surface is currently saturated; more lands for free as new ids are
+  grounded (spec §7).
+- Eval: **40/40 correct, 0 wrong, 4 correct abstentions, multihop_coverage 1.0** — every answerable
+  item cites all its hops' byte-provenance (`mh-39` cites 2, the 3-hop `mh-34` cites 3), zero model
+  calls.
+
 ## [0.5.0] — 2026-06-30
 
 ### Added — slice 5: two more clue→disease→{gene, inheritance} chains via cross-library id-joins

--- a/code/specs/data/mycin-2026/mle-pass/README.md
+++ b/code/specs/data/mycin-2026/mle-pass/README.md
@@ -106,3 +106,14 @@ and `heinz_bodies → g6pd_deficiency → g6pd / x_linked` (hop 1 = `histo-edges
 renamed, or authored — exactly the "land for free" the spec anticipated. (`heinz_bodies` also maps to
 `methemoglobinemia`, but only `g6pd_deficiency` carries the gene/inheritance edge, so the join binds a
 single answer — the second hop disambiguates.) `multihop_coverage` 1.0 over the 35 answerable items.
+
+Slice 6: **40/40 correct, zero model calls** — slice-5 plus two distinct spine advances, again with
+nothing grounded, renamed, or authored. (1) **A third hop-2 relation off one disease** (`mh-39`):
+`g6pd_deficiency` already answers gene and inheritance; it now also answers a hematology
+`classic_finding` — `heinz_bodies → g6pd_deficiency → bite_cells` (hop 2 = `anemia-edges`), so one
+grounded disease feeds three different second relations across three libraries (write-once-use-many at
+the hop-2 level). (2) **A three-hop abstention** (`mh-40`): `leukocoria → retinoblastoma → ? →
+gram_stain` — the ends are grounded but retinoblastoma has no grounded causative organism, so the
+interior join binds nothing and the engine MUST abstain rather than fabricate a Gram stain. A
+partially-grounded multi-hop is still an abstention, not a guess — the never-fabricate discipline at
+the deepest chain. `multihop_coverage` 1.0 over the 36 answerable items.

--- a/code/specs/data/mycin-2026/mle-pass/gen_items.py
+++ b/code/specs/data/mycin-2026/mle-pass/gen_items.py
@@ -111,12 +111,39 @@ MICRO_TAIL = {
     "morphology": "has which microscopic morphology",
 }
 
+# slice 6 — a THIRD second-relation off an already-chained disease, proving write-once-use-many at
+# the hop-2 level: g6pd_deficiency already answers `gene_defect` (mh-36) and `inheritance` (mh-38);
+# here the SAME middle disease answers a hematology `classic_finding` (the peripheral-smear sign),
+# joined from a DIFFERENT hop-1 finding (Heinz bodies, histo) into a DIFFERENT hop-2 library
+# (anemia). One grounded disease id, now feeding three distinct second relations across three
+# libraries — nothing newly grounded. (id, clue, hop1_lib, hop1_rel, disease, hop2_lib, hop2_rel,
+# answer, pool, clue_phrase, tail)
+SMEAR_POOL = ["bite_cells", "koilonychia", "ringed_sideroblasts", "spherocytes", "target_cells"]
+SMEAR_CHAINS = [
+    ("mh-39", "heinz_bodies", "histo-edges.adj", "seen_in", "g6pd_deficiency",
+     "anemia-edges.adj", "classic_finding", "bite_cells", SMEAR_POOL,
+     "Heinz bodies on the peripheral blood smear",
+     "has which other classic peripheral-smear finding"),
+]
+
 # abstention — real rule shape, ungrounded clue: the engine binds nothing → MUST abstain.
 ABSTAIN = [
     ("mh-14", "a_clue_with_no_grounded_eye_edge", "ophtho-edges.adj", "eye_finding_indicates",
      "gene_defect", "genetics-edges.adj", GENE_POOL, "an eye finding not in the grounded library"),
     ("mh-15", "a_lesion_with_no_grounded_edge", "neuro-edges.adj", "lesion_causes",
      "gene_defect", "genetics-edges.adj", GENE_POOL, "a neuro lesion not in the grounded library"),
+]
+
+# slice 6 — a THREE-hop ABSTENTION: hops 1 AND 3 are grounded shapes, but the chain BREAKS at the
+# interior join (hop 2). The clue → disease edge is real (leukocoria → retinoblastoma, ophtho), and
+# `gram_stain` is a real relation, but retinoblastoma is a tumour with NO grounded causative
+# organism — so `causes(organism, retinoblastoma)` binds nothing and the 3-hop derivation cannot
+# complete. The engine MUST abstain rather than fabricate a Gram stain. This extends the
+# never-fabricate discipline to the deepest chain: a partially-grounded multi-hop is still an
+# abstention. (id, clue, hop1_lib, hop1_rel, clue_phrase)
+THREE_HOP_ABSTAIN = [
+    ("mh-40", "leukocoria", "ophtho-edges.adj", "eye_finding_indicates",
+     "a white pupillary reflex (leukocoria)"),
 ]
 
 LETTERS = ["A", "B", "C", "D", "E"]
@@ -199,6 +226,30 @@ def build():
         "clue": "pseudomembranes", "expected": "gram_positive",
         **dict(zip(("options", "gold_letter"), options_for("gram_positive", GRAM_POOL, 1))),
     })
+    # --- smear chains (slice 6): a third hop-2 relation off an already-chained disease ---------
+    for idx, (iid, clue, lib, rel, disease, hop2_lib, hop2_rel, answer, pool, phrase, tail) \
+            in enumerate(SMEAR_CHAINS):
+        options, gold = options_for(answer, pool, idx)
+        items.append({
+            "id": iid, "qtype": "multi_hop_recall",
+            "stem": f"A patient has {phrase}. That finding points to a single disease; "
+                    f"that disease {tail}?",
+            "hop1_lib": lib, "hop1_relation": rel,
+            "hop2_lib": hop2_lib, "hop2_relation": hop2_rel,
+            "clue": clue, "expected": answer, "options": options, "gold_letter": gold,
+        })
+    # --- three-hop abstention (slice 6): grounded ends, ungrounded interior join → MUST abstain --
+    for (iid, clue, lib, rel, phrase) in THREE_HOP_ABSTAIN:
+        items.append({
+            "id": iid, "qtype": "multi_hop_recall",
+            "stem": f"A patient has {phrase}. The disease it indicates is caused by an organism "
+                    f"with which Gram-stain reaction? (If no causative organism is grounded, abstain.)",
+            "hop1_lib": lib, "hop1_relation": rel,
+            "hop2_lib": "micro-edges.adj", "hop2_relation": "causes", "hop2_reverse": True,
+            "hop3_lib": "micro-edges.adj", "hop3_relation": "gram_stain",
+            "clue": clue, "expected": None, "expect_abstain": True,
+            "options": {LETTERS[i]: GRAM_POOL[i] for i in range(5)},
+        })
     # --- abstention (ungrounded clue: MUST abstain) ---
     for (iid, clue, lib, rel, hop2_rel, hop2_lib, pool, phrase) in ABSTAIN:
         # plausible distractors, but NO correct answer is reachable (the chain is ungrounded).
@@ -226,7 +277,13 @@ def build():
             "domain) run in REVERSE: the clue is a disease, hop 1 is causes(organism, disease) "
             "traversed backwards to bind the causative organism, and hop 2 reads that organism's "
             "Gram stain or microscopic morphology — proving a two-hop chain need not run left to "
-            "right through the edges, and that both hops can share one library. Nothing authored: "
+            "right through the edges, and that both hops can share one library. Slice 4 adds the "
+            "first THREE-hop chain (finding → disease → organism → Gram stain). Slice 6 adds a "
+            "third hop-2 relation off an already-chained disease (g6pd_deficiency now answers gene, "
+            "inheritance, AND a hematology smear finding — write-once-use-many at the hop-2 level), "
+            "and a THREE-hop abstention whose interior join is ungrounded (grounded ends, no "
+            "causative organism) and so MUST abstain — the never-fabricate discipline extended to "
+            "the deepest chain. Nothing authored: "
             "every edge reuses an already-grounded, spider+adversarially-gated fact. Engine: every "
             "answerable item correct with both hops cited; every abstention item abstains; zero "
             "model calls."

--- a/code/specs/data/mycin-2026/mle-pass/items.json
+++ b/code/specs/data/mycin-2026/mle-pass/items.json
@@ -1,5 +1,5 @@
 {
-  "description": "MLE-PASS multi-hop recall bank \u2014 TWO-HOP board questions answered purely from grounded edges with zero model calls. A clinical clue \u2192 disease (hop 1, an organ-system recall library) \u2192 answer (hop 2) is joined on the shared disease through an adj-lang rule body; the engine's SLD resolver returns the binding with BOTH hops' byte-provenance, and the harness maps it to the printed options. Slice 2 adds: more clue\u2192disease\u2192gene chains (derm, niemann-pick, pompe); a second relation as hop 2 \u2014 inheritance (clue\u2192disease\u2192inheritance pattern), proving the harness is generic over the second hop, not gene-specific; and an ABSTENTION sub-bank whose clue has no grounded hop-1 edge, which MUST abstain (never fabricate). Slice 3 adds the microbiology organism-ID chain (the original MYCIN domain) run in REVERSE: the clue is a disease, hop 1 is causes(organism, disease) traversed backwards to bind the causative organism, and hop 2 reads that organism's Gram stain or microscopic morphology \u2014 proving a two-hop chain need not run left to right through the edges, and that both hops can share one library. Nothing authored: every edge reuses an already-grounded, spider+adversarially-gated fact. Engine: every answerable item correct with both hops cited; every abstention item abstains; zero model calls.",
+  "description": "MLE-PASS multi-hop recall bank \u2014 TWO-HOP board questions answered purely from grounded edges with zero model calls. A clinical clue \u2192 disease (hop 1, an organ-system recall library) \u2192 answer (hop 2) is joined on the shared disease through an adj-lang rule body; the engine's SLD resolver returns the binding with BOTH hops' byte-provenance, and the harness maps it to the printed options. Slice 2 adds: more clue\u2192disease\u2192gene chains (derm, niemann-pick, pompe); a second relation as hop 2 \u2014 inheritance (clue\u2192disease\u2192inheritance pattern), proving the harness is generic over the second hop, not gene-specific; and an ABSTENTION sub-bank whose clue has no grounded hop-1 edge, which MUST abstain (never fabricate). Slice 3 adds the microbiology organism-ID chain (the original MYCIN domain) run in REVERSE: the clue is a disease, hop 1 is causes(organism, disease) traversed backwards to bind the causative organism, and hop 2 reads that organism's Gram stain or microscopic morphology \u2014 proving a two-hop chain need not run left to right through the edges, and that both hops can share one library. Slice 4 adds the first THREE-hop chain (finding \u2192 disease \u2192 organism \u2192 Gram stain). Slice 6 adds a third hop-2 relation off an already-chained disease (g6pd_deficiency now answers gene, inheritance, AND a hematology smear finding \u2014 write-once-use-many at the hop-2 level), and a THREE-hop abstention whose interior join is ungrounded (grounded ends, no causative organism) and so MUST abstain \u2014 the never-fabricate discipline extended to the deepest chain. Nothing authored: every edge reuses an already-grounded, spider+adversarially-gated fact. Engine: every answerable item correct with both hops cited; every abstention item abstains; zero model calls.",
   "items": [
     {
       "id": "mh-01",
@@ -705,6 +705,47 @@
         "E": "poorly_staining"
       },
       "gold_letter": "B"
+    },
+    {
+      "id": "mh-39",
+      "qtype": "multi_hop_recall",
+      "stem": "A patient has Heinz bodies on the peripheral blood smear. That finding points to a single disease; that disease has which other classic peripheral-smear finding?",
+      "hop1_lib": "histo-edges.adj",
+      "hop1_relation": "seen_in",
+      "hop2_lib": "anemia-edges.adj",
+      "hop2_relation": "classic_finding",
+      "clue": "heinz_bodies",
+      "expected": "bite_cells",
+      "options": {
+        "A": "bite_cells",
+        "B": "koilonychia",
+        "C": "ringed_sideroblasts",
+        "D": "spherocytes",
+        "E": "target_cells"
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "mh-40",
+      "qtype": "multi_hop_recall",
+      "stem": "A patient has a white pupillary reflex (leukocoria). The disease it indicates is caused by an organism with which Gram-stain reaction? (If no causative organism is grounded, abstain.)",
+      "hop1_lib": "ophtho-edges.adj",
+      "hop1_relation": "eye_finding_indicates",
+      "hop2_lib": "micro-edges.adj",
+      "hop2_relation": "causes",
+      "hop2_reverse": true,
+      "hop3_lib": "micro-edges.adj",
+      "hop3_relation": "gram_stain",
+      "clue": "leukocoria",
+      "expected": null,
+      "expect_abstain": true,
+      "options": {
+        "A": "gram_positive",
+        "B": "gram_negative",
+        "C": "acid_fast",
+        "D": "gram_variable",
+        "E": "poorly_staining"
+      }
     },
     {
       "id": "mh-14",


### PR DESCRIPTION
## What

Slice 6 of the **MLE-PASS multi-hop recall** bank — two board questions answered purely on the CPU from grounded edges, **zero model calls**. Both advance the multi-hop spine by arranging only **already-grounded** facts (no edge grounded, renamed, or authored — the no-human-authored rule).

A systematic join-finder confirms the *answerable* cross-library surface is currently **saturated**: `g6pd_deficiency` is the only disease id appearing both as a finding-library object and a knowledge-library subject, and `pseudomembranous_colitis` (slice 4, `mh-34`) remains the only finding→disease→organism bridge. So slice 6 **deepens** rather than widens:

| item | chain | what it proves |
|------|-------|----------------|
| **mh-39** | `heinz_bodies` →(histo `seen_in`)→ `g6pd_deficiency` →(anemia `classic_finding`)→ `bite_cells` | **write-once-use-many at the hop-2 level** — g6pd_deficiency now answers gene (`mh-36`), inheritance (`mh-38`), AND a hematology smear finding, across three libraries from two different hop-1 findings |
| **mh-40** | `leukocoria` →(ophtho)→ `retinoblastoma` →(micro `causes` ⊥)→ … →(`gram_stain`)→ **abstain** | **three-hop abstention** — ends grounded, interior join ungrounded (no causative organism) → engine MUST abstain, never fabricate a Gram stain |

`mh-40` is the deepest negative test in the bank: a *partially*-grounded multi-hop is still an abstention, not a guess — never-fabricate extended to the 3-hop chain.

## Verification
- `gen_items.py` → **40 items** (was 38).
- `mle_pass_eval.py`: **40/40 correct, 0 wrong, 4 correct abstentions, `multihop_coverage` 1.0** — every answerable item cites all its hops' byte-provenance (the 3-hop `mh-34` cites 3, `mh-39` cites 2).
- `pytest test_mle_pass.py` — **8/8 pass**.
- **Security review passed** (Python: injection / path traversal / deserialization / DoS) — no findings; the diff is static data literals + doc updates only.

Spec `MLE-PASS-multihop-recall.md` §6d + README + CHANGELOG (0.6.0) updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)