### PR TITLE
feat(mathml): named-function recognition — PFE01 frontend #4 PR-3

### DIFF
--- a/code/packages/rust/mathml/CHANGELOG.md
+++ b/code/packages/rust/mathml/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to the Presentation-MathML frontend crate.
 
+## [0.3.0] — 2026-06-30
+
+### Added — PR-3: named-function recognition (`<mi>sin</mi>` → `Call`)
+
+- **Applied named functions → `MathExpr::Call`.** A function name arrives as a `<mi>` identifier
+  (e.g. `<mi>sin</mi>`), usually with an invisible `<mo>&ApplyFunction;</mo>` before its argument
+  that lowering already drops — so the function symbol sits directly adjacent to its argument. The
+  row folder now recognises `sin x`, `cos(θ)`, `ln 2`, `log(x)`, … → `Call { func, arg }`, with the
+  same recognised set (sin/cos/tan/cot/sec/csc, arc*, *h, ln/log/exp, min/max/gcd/lcm/det) and
+  neutral `Func` values as the `unicode-math` and `asciimath` frontends — so all four notations agree
+  on one tree.
+- **Semantics:** the function takes ONE atom as its argument, then ordinary precedence resumes —
+  `sin x y` → `(sin x)·y`. Nested names fold right — `sin cos x` → `Call(sin, Call(cos, x))`. A
+  function name NOT followed by an operand is a plain `Symbol` (`sin` alone is the symbol `sin`,
+  never an empty application); a one-letter variable is never a function.
+- **Capabilities** add `functions`, kept honest by `check_frontend` (the conformance corpus now
+  includes `sin x`).
+- **Stack-safety regression** per the iterative-collection lesson: the leading run of function names
+  is collected then folded (not recursed per name), so a *flat* 100 000-`<mi>sin</mi>` run parses
+  (and the deep `Call` chain drops) without a stack overflow.
+- 41 unit tests + doctest (was 35): applied function (with and without `&ApplyFunction;`), one-atom
+  argument + implicit-mul, nested folding, bare-name-as-symbol, one-letter-not-a-function, and the
+  long-run stack-safety test.
+
+### Deferred to PR-4
+`<mfenced>` separator modelling (a comma-separated `(a, b)` list) — needs a neutral *list* node the
+AST does not yet have; today a fence's contents fold as one row.
+
 ## [0.2.0] — 2026-06-30
 
 ### Added — PR-2: tables, over/under-sets, and fences (structural breadth)

--- a/code/packages/rust/mathml/Cargo.toml
+++ b/code/packages/rust/mathml/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "mathml"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
-description = "A Presentation-MathML reader that implements the math-frontend MathFrontend trait: turns <math>…</math> (mn/mi/mo/mrow/mfrac/msup/msub/msqrt/mroot/mtext/mtable/mover/munder/mfenced) into the neutral MathExpr AST. The fourth pluggable frontend after LaTeX and AsciiMath (see PFE01). Total, panic-free, spanned errors."
+description = "A Presentation-MathML reader that implements the math-frontend MathFrontend trait: turns <math>…</math> (mn/mi/mo/mrow/mfrac/msup/msub/msqrt/mroot/mtext/mtable/mover/munder/mfenced + named functions) into the neutral MathExpr AST. The fourth pluggable frontend after LaTeX and AsciiMath (see PFE01). Total, panic-free, spanned errors."
 license = "MIT"
 
 [dependencies]

--- a/code/packages/rust/mathml/README.md
+++ b/code/packages/rust/mathml/README.md
@@ -29,16 +29,19 @@ tree.
 | `<munderover>b u o</munderover>` | `Underset { under: u, base: Overset { over: o, base: b } }` (PR-2) |
 | `<mfenced>…</mfenced>` | `Group` over the folded contents (PR-2) |
 | `<mtable><mtr><mtd>…</mtd></mtr></mtable>` | `Matrix(rows × cells)` (PR-2) |
+| `<mi>sin</mi> … x` (applied) | `Call { func: Sin, arg: x }` (PR-3) |
 
 `<math>`, `<mstyle>`, and `<mpadded>` are **transparent** wrappers (their children join the
 surrounding row). Attributes, namespace prefixes (`m:math` ≡ `math`), the XML declaration,
 comments, and DOCTYPE are ignored. Operator entity spellings (`&times;`, `&le;`, `&#xD7;`, …)
 decode to the same operators as their literal glyphs. In `<mover>`/`<munder>` position an operator
 glyph (`<mo>^</mo>`, `<mo>‾</mo>`, `<mo>→</mo>`) is read as an **annotation symbol**, not an infix
-operator — so `<mover><mi>x</mi><mo>^</mo></mover>` is "x with a hat".
+operator — so `<mover><mi>x</mi><mo>^</mo></mover>` is "x with a hat". An `<mi>` whose name is a known
+function (sin, cos, ln, …) **applied to an argument** becomes a `Call`; the same name with no argument
+stays a plain `Symbol`.
 
-Deferred to PR-3: named-function recognition (`<mi>sin</mi>` → `Call`) and `<mfenced>` separator
-modelling (today a fence's contents fold as one row).
+Deferred to PR-4: `<mfenced>` separator modelling (a comma-separated `(a, b)` list) — needs a neutral
+*list* node the AST does not yet have; today a fence's contents fold as one row.
 
 ## Contract
 

--- a/code/packages/rust/mathml/src/lib.rs
+++ b/code/packages/rust/mathml/src/lib.rs
@@ -69,7 +69,8 @@ impl MathFrontend for MathMl {
         // `Pow`), relations (`<mo>=`/`<` …), implicit multiplication (adjacent operands in a row),
         // text (`<mtext>`), and ± / ∓ (`<mo>±`). Subscripts are core (not a capability flag).
         // PR-2 adds matrices (`<mtable>`) and over/under-sets (`<mover>`/`<munder>`/`<munderover>`);
-        // `<mfenced>` lowers to `Group` (core). Named functions (`<mi>sin</mi>` → Call) are PR-3.
+        // `<mfenced>` lowers to `Group` (core). PR-3 adds named-function recognition (`<mi>sin</mi>`
+        // applied to an argument → `Call`).
         Capabilities::none()
             .with_fractions()
             .with_roots()
@@ -80,6 +81,7 @@ impl MathFrontend for MathMl {
             .with_plusminus()
             .with_matrices()
             .with_oversets()
+            .with_functions()
     }
 }
 
@@ -394,6 +396,65 @@ mod tests {
         assert!(MathMl.parse(&wide).is_ok(), "wide table should parse, not abort");
     }
 
+    // ---- PR-3: named-function recognition -------------------------------------
+    fn call(f: Func, arg: MathExpr) -> MathExpr {
+        MathExpr::Call { func: f, arg: Box::new(arg) }
+    }
+
+    #[test]
+    fn applied_function_becomes_a_call() {
+        // <mi>sin</mi> applied (invisible ApplyFunction dropped) to x → Call(Sin, x).
+        assert_eq!(
+            p("<math><mi>sin</mi><mo>&ApplyFunction;</mo><mi>x</mi></math>"),
+            call(Func::Sin, sym("x"))
+        );
+        // Bare juxtaposition (no ApplyFunction) works too — same neutral tree.
+        assert_eq!(p("<math><mi>cos</mi><mi>x</mi></math>"), call(Func::Cos, sym("x")));
+        // ln of a number; log of a fenced group.
+        assert_eq!(p("<math><mi>ln</mi><mn>2</mn></math>"), call(Func::Ln, num(2)));
+        assert_eq!(
+            p("<math><mi>log</mi><mo>(</mo><mi>x</mi><mo>)</mo></math>"),
+            call(Func::Log, MathExpr::Group(Box::new(sym("x"))))
+        );
+    }
+
+    #[test]
+    fn function_argument_is_one_atom_then_implicit_mul() {
+        // sin x y → (sin x) · y : the function takes ONE atom, then juxtaposition multiplies.
+        let e = p("<math><mi>sin</mi><mi>x</mi><mi>y</mi></math>");
+        assert_eq!(e, b(BinOp::Mul, call(Func::Sin, sym("x")), sym("y")));
+    }
+
+    #[test]
+    fn nested_functions_fold_right() {
+        // sin cos x → Call(Sin, Call(Cos, x)).
+        let e = p("<math><mi>sin</mi><mi>cos</mi><mi>x</mi></math>");
+        assert_eq!(e, call(Func::Sin, call(Func::Cos, sym("x"))));
+    }
+
+    #[test]
+    fn function_name_alone_is_a_plain_symbol() {
+        // No argument → `sin` is just a symbol, not an empty application.
+        assert_eq!(p("<mi>sin</mi>"), sym("sin"));
+        // and at the end of a row.
+        assert_eq!(p("<math><mn>2</mn><mi>sin</mi></math>"), b(BinOp::Mul, num(2), sym("sin")));
+    }
+
+    #[test]
+    fn one_letter_variable_is_never_a_function() {
+        // A single-letter identifier that happens to start a function name stays a symbol.
+        assert_eq!(p("<math><mi>s</mi><mi>x</mi></math>"), b(BinOp::Mul, sym("s"), sym("x")));
+    }
+
+    #[test]
+    fn long_function_run_does_not_overflow() {
+        // A flat run of applied function names lives at ONE nesting level; the function folder is
+        // iterative (collect-then-fold, like the unary collector), so even 100k `<mi>sin</mi>`
+        // followed by an argument parses (and the deep Call chain drops) without a stack overflow.
+        let run = format!("<math>{}<mn>1</mn></math>", "<mi>sin</mi>".repeat(100_000));
+        assert!(MathMl.parse(&run).is_ok(), "long function run should parse, not abort");
+    }
+
     // ---- registry --------------------------------------------------------------
     #[test]
     fn registry_registers_under_its_name() {
@@ -420,6 +481,7 @@ mod tests {
             "<munder><mi>lim</mi><mi>n</mi></munder>",
             "<mtable><mtr><mtd><mn>1</mn></mtd><mtd><mn>2</mn></mtd></mtr></mtable>",
             "<mfenced><mrow><mi>x</mi><mo>+</mo><mn>1</mn></mrow></mfenced>",
+            "<math><mi>sin</mi><mi>x</mi></math>",
         ];
         let report = check_frontend(&MathMl, &samples);
         assert!(report.passed(), "conformance violations: {report:?}");

--- a/code/packages/rust/mathml/src/parser.rs
+++ b/code/packages/rust/mathml/src/parser.rs
@@ -11,7 +11,7 @@
 //! yields a clean error rather than a stack overflow, and the neutral `MathExpr` it returns drops
 //! iteratively (math-frontend ≥ 0.3.0), so teardown is panic-free at any depth too.
 
-use math_frontend::{BinOp, FrontendError, MathExpr, Number, RelOp, UnaryOp};
+use math_frontend::{BinOp, Func, FrontendError, MathExpr, Number, RelOp, UnaryOp};
 
 /// Maximum element/fence nesting depth. Presentation MathML for real formulae is shallow (a few
 /// dozen levels at most); a pathologically deep `<mrow><mrow>…` or `(((…` is rejected with a spanned
@@ -840,6 +840,36 @@ impl RowParser {
     }
 
     fn parse_atom(&mut self) -> Result<MathExpr, FrontendError> {
+        // Named-function application. A function name arrives as a `<mi>` → `Symbol` operand (e.g.
+        // `<mi>sin</mi>`), typically with an invisible `<mo>&ApplyFunction;</mo>` before its argument
+        // that lowering already dropped — so the function symbol sits directly adjacent to its
+        // argument. We recognise `sin x`, `cos(θ)`, `ln 2`, … → `Call { func, arg }`.
+        //
+        // The run of leading function names is collected ITERATIVELY, then folded onto the base atom
+        // right-to-left, so `sin cos x` → `Call(sin, Call(cos, x))`. This deliberately does NOT
+        // recurse per function: a flat run of N `<mi>sin</mi>` lives at one nesting level, and a
+        // recursive folder would grow the stack with N and overflow on a long run (the same hazard
+        // the iterative unary collector avoids). A function name NOT followed by an operand is a
+        // plain symbol (`sin` alone is the variable/symbol `sin`, not an empty application).
+        let mut funcs: Vec<Func> = Vec::new();
+        while let Some(RowTok::Operand(MathExpr::Symbol(name))) = self.toks.get(self.pos) {
+            if func_of(name).is_some() && matches!(self.toks.get(self.pos + 1), Some(RowTok::Operand(_))) {
+                let f = func_of(name).unwrap();
+                self.pos += 1;
+                funcs.push(f);
+            } else {
+                break;
+            }
+        }
+        let mut atom = self.take_operand()?;
+        for f in funcs.into_iter().rev() {
+            atom = MathExpr::Call { func: f, arg: Box::new(atom) };
+        }
+        Ok(atom)
+    }
+
+    /// Extract the operand at the cursor (the base of an atom), erroring on an operator or end.
+    fn take_operand(&mut self) -> Result<MathExpr, FrontendError> {
         match self.toks.get(self.pos) {
             Some(RowTok::Operand(_)) => {
                 // Take ownership of the operand by swapping in a placeholder.
@@ -857,6 +887,36 @@ impl RowParser {
             None => err("unexpected end of MathML row", self.span),
         }
     }
+}
+
+/// Map a `<mi>` identifier to a known mathematical function, or `None` if it is an ordinary symbol.
+/// The recognised set matches the other frontends (`unicode-math`, `asciimath`) so the four
+/// notations agree on one neutral `Func`. Only these exact spellings are functions — a one-letter
+/// variable like `s` stays a `Symbol`, never a function.
+fn func_of(name: &str) -> Option<Func> {
+    Some(match name {
+        "sin" => Func::Sin,
+        "cos" => Func::Cos,
+        "tan" => Func::Tan,
+        "cot" => Func::Cot,
+        "sec" => Func::Sec,
+        "csc" => Func::Csc,
+        "arcsin" => Func::Asin,
+        "arccos" => Func::Acos,
+        "arctan" => Func::Atan,
+        "sinh" => Func::Sinh,
+        "cosh" => Func::Cosh,
+        "tanh" => Func::Tanh,
+        "ln" => Func::Ln,
+        "log" => Func::Log,
+        "exp" => Func::Exp,
+        "min" => Func::Min,
+        "max" => Func::Max,
+        "gcd" => Func::Gcd,
+        "lcm" => Func::Lcm,
+        "det" => Func::Det,
+        _ => return None,
+    })
 }
 
 /// The crate entry point: parse a Presentation-MathML string into the neutral [`MathExpr`].

--- a/code/specs/PFE01-pluggable-parser-frontends.md
+++ b/code/specs/PFE01-pluggable-parser-frontends.md
@@ -159,8 +159,9 @@ frontend additionally ships notation-specific golden tests.
   multiplication + `(`…`)` fences), `<mfrac>`/`<msup>`/`<msub>`/`<msubsup>`/`<msqrt>`/`<mroot>`.
   PR-2 adds `<mtable>`/`<mtr>`/`<mtd>` → `Matrix`, `<mover>`/`<munder>`/`<munderover>` →
   `Overset`/`Underset` (an `<mo>` annotation in over/under position is read as a mark symbol), and
-  `<mfenced>` → `Group`. Named-function recognition (`<mi>sin</mi>` → `Call`) and `<mfenced>`
-  separator modelling are PR-3.
+  `<mfenced>` → `Group`. PR-3 adds named-function recognition: an `<mi>` whose name is a known
+  function (sin/cos/ln/…) applied to an argument → `Call`, matching the other frontends' `Func` set.
+  `<mfenced>` separator modelling (a `(a, b)` list) is PR-4 — it needs a neutral list node.
 - Future: MathJSON, content-MathML, spreadsheet formulae, … each a small crate implementing the
   trait. None require changes to consumers. **Four frontends now in (LaTeX, AsciiMath, Unicode,
   MathML), all feeding one neutral AST with zero consumer change** — the pluggability claim is


### PR DESCRIPTION
## What

PR-3 of the **MathML** frontend (the fourth pluggable [PFE01](code/specs/PFE01-pluggable-parser-frontends.md) frontend). Recognises **applied named functions**, lowering them to the same neutral `MathExpr::Call` the `latex`, `asciimath`, and `unicode-math` frontends produce.

A function name arrives as an `<mi>` identifier (e.g. `<mi>sin</mi>`), usually with an invisible `<mo>&ApplyFunction;</mo>` before its argument that lowering already drops — so the function symbol sits directly adjacent to its argument:

| MathML | neutral `MathExpr` |
|--------|--------------------|
| `<mi>sin</mi><mo>&ApplyFunction;</mo><mi>x</mi>` | `Call { func: Sin, arg: x }` |
| `<mi>cos</mi><mi>x</mi>` (bare juxtaposition) | `Call { func: Cos, arg: x }` |
| `<mi>log</mi><mo>(</mo><mi>x</mi><mo>)</mo>` | `Call { func: Log, arg: Group(x) }` |

Recognised set matches the other frontends (sin/cos/tan/cot/sec/csc, arcsin/arccos/arctan, sinh/cosh/tanh, ln/log/exp, min/max/gcd/lcm/det) with the same neutral `Func` values, so all four notations agree on one tree.

### Semantics
- The function takes **one atom** as its argument, then ordinary precedence resumes — `sin x y` → `(sin x)·y`.
- Nested names **fold right** — `sin cos x` → `Call(sin, Call(cos, x))`.
- A function name **not** followed by an operand is a plain `Symbol` (`sin` alone is the symbol `sin`, never an empty application); a one-letter variable is never a function.

## Safety
The leading run of function names is **collected then folded** (a `while` loop into a `Vec`, then a `for` fold), **not recursed per name** — a flat run of N `<mi>sin</mi>` would otherwise overflow the stack, the same hazard the iterative unary-sign collector avoids. A regression test parses a flat **100 000-`<mi>sin</mi>`** run safely; the deep `Call` chain drops iteratively. The `func_of(name).unwrap()` is short-circuit-guarded by `func_of(name).is_some()`. `#![forbid(unsafe_code)]` holds.

## Tests / gates
- **41 unit tests + doctest** (was 35): applied function (with/without `&ApplyFunction;`), one-atom-argument + implicit-mul, nested folding, bare-name-as-symbol, one-letter-not-a-function, and the long-run stack-safety test; conformance corpus gains `sin x`.
- `cargo test -p mathml` green; `cargo clippy -p mathml -- -D warnings` clean.
- **Security review passed** (Rust: recursion/DoS, panics, integer overflow, forward progress) — no findings.

## Deferred to PR-4
`<mfenced>` separator modelling (a comma-separated `(a, b)` list) — needs a neutral *list* node the AST does not yet have; today a fence's contents fold as one row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)