### PR TITLE
[codex] Track script rawtext repair evidence

### DIFF
--- a/code/packages/rust/html-parser/tests/whatwg_text_control_audit_test.rs
+++ b/code/packages/rust/html-parser/tests/whatwg_text_control_audit_test.rs
@@ -7,8 +7,10 @@ use std::collections::{BTreeMap, HashMap};
 const TREE_CONSTRUCTION_SMOKE: &str = include_str!("fixtures/html5lib-tree-construction-smoke.dat");
 const WHATWG_TEXT_CONTROL_AUDIT: &str =
     include_str!("fixtures/whatwg-text-control-audit.json");
-const POST_PARSE_REPAIR_EVIDENCE: &[(&str, &str)] =
-    &[("scripted-webkit01-dat-2", "script-rawtext")];
+const POST_PARSE_REPAIR_EVIDENCE: &[(&str, &str)] = &[
+    ("scripted-ark-dat-1", "script-rawtext"),
+    ("scripted-webkit01-dat-2", "script-rawtext"),
+];
 
 #[derive(Debug, Deserialize)]
 struct TextControlAuditSuite {


### PR DESCRIPTION
## Summary
- add `scripted-ark-dat-1` to the text-control post-parse repair evidence guard
- pin the generated WHATWG/html5lib audit axis as `script-rawtext` while keeping the parser DOM dump executable check

## Validation
- `cargo test -p coding-adventures-html-parser font_newline_before_bold_stays_outside_reconstructed_font`
- `cargo test -p coding-adventures-html-parser whatwg_document_shell_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_head_body_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_form_interactive_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_legacy_element_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_paragraph_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_block_boundary_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_table_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_formatting_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_text_control_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_document_shell_audit_cases_match_parser_dom_dump`
- `cargo test -p coding-adventures-html-parser whatwg_head_body_audit_cases_match_parser_dom_dump`
- `cargo test -p coding-adventures-html-parser whatwg_form_interactive_audit_cases_match_parser_dom_dump`
- `cargo test -p coding-adventures-html-parser whatwg_table_audit_cases_match_parser_dom_dump`
- `cargo test -p coding-adventures-html-parser whatwg_formatting_audit_cases_match_parser_dom_dump`
- `cargo test -p coding-adventures-html-parser whatwg_paragraph_audit_cases_match_parser_dom_dump`
- `cargo test -p coding-adventures-html-parser whatwg_text_control_audit_cases_match_parser_dom_dump`
- `cargo test -p coding-adventures-html-parser whatwg_block_boundary_audit_cases_match_parser_dom_dump`
- `cargo test -p coding-adventures-html-parser html5lib_tree_construction_smoke_cases_match_dom_dump`
- `cargo test -p coding-adventures-html-parser`
- `cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser`
- `python3 -m json.tool code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json >/dev/null`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py`
- `git diff --check`

After rebasing over unrelated latest `origin/main` commits, reran:
- `cargo test -p coding-adventures-html-parser whatwg_text_control_audit_tracks_post_parse_repair_evidence`
- `python3 -m json.tool code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json >/dev/null`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py`
- `git diff --check`