### PR TITLE
fix(javascript-parser): decline function expressions instead of aborting the compile

### DIFF
--- a/code/packages/rust/javascript-parser/CHANGELOG.md
+++ b/code/packages/rust/javascript-parser/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to the `coding-adventures-javascript-parser` crate will be documented in this file.
 
+## [0.19.10] - 2026-06-30
+
+### Fixed — function expressions (IIFEs etc.) aborted the compile
+
+A `function` expression in value position made the bridge raise an `Internal`
+error, which the CLI treats as a hard failure (`exit 2`, no JS output):
+
+```
+(function(){})();     →  bridge internal error: unknown expression rule 'function_expression'
+x = function(){};     →  (same)
+f(function(){ … });   →  (same)
+```
+
+IIFEs, assigned function expressions, and function callbacks are extremely
+common, valid JavaScript. Like arrow functions, generator/async function
+expressions, and class expressions — all of which already decline gracefully —
+a plain function expression is a Phase 2 feature that should DECLINE with
+`UnsupportedSyntax` (so the CLI falls back to WHITESPACE_ONLY and still emits
+valid output), never abort.
+
+**Cause.** `convert_expression`'s "ES2015+ unsupported" arm listed
+`generator_expression`, `async_function_expression`, `arrow_function`,
+`class_expression`, … but **omitted** the plain `function_expression`, so it
+fell through to the `InternalError` catch-all.
+
+**Fix.** Added `"function_expression"` to that decline list, alongside its
+siblings. `(function(){})();` / `x=function(){}` / `f(function(){})` now
+round-trip through the WHITESPACE_ONLY fallback (`exit 0`) instead of aborting.
+
+Regression test: `function_expressions_decline_gracefully_not_hard_error`.
+
 ## [0.19.9] - 2026-06-30
 
 ### Fixed — destructuring declarations aborted the compile instead of declining

--- a/code/packages/rust/javascript-parser/Cargo.toml
+++ b/code/packages/rust/javascript-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-javascript-parser"
-version = "0.19.9"
+version = "0.19.10"
 edition = "2021"
 description = "JavaScript parser — parses JavaScript source code against any ECMAScript edition (es1 through es2025) using the grammar-driven parser. Includes correlation-vector plumbing per CLOC03 and a typed-AST bridge (GrammarASTNode → javascript_ast::Program) per CLOC12.136."
 

--- a/code/packages/rust/javascript-parser/src/bridge.rs
+++ b/code/packages/rust/javascript-parser/src/bridge.rs
@@ -1057,12 +1057,30 @@ fn convert_expression(node: &GrammarASTNode) -> Result<Expression, BridgeError> 
         "array_literal" => convert_array_literal(node),
         "object_literal" => convert_object_literal(node),
 
-        // ES2015+ unsupported in Phase 1
-        "arrow_function" | "async_arrow_function" | "yield_expression"
-        | "await_expression" | "generator_expression" | "async_function_expression"
-        | "async_generator_expression" | "class_expression"
-        | "template_literal" | "tagged_template_expression"
-        | "new_target_expression" | "import_meta_expression" => Err(unsupported(node)),
+        // Function-valued and ES2015+ expression forms the typed bridge does
+        // not yet represent (Phase 2). DECLINE GRACEFULLY (`UnsupportedSyntax`
+        // → the CLI falls back to WHITESPACE_ONLY and still emits valid JS).
+        //
+        // `function_expression` MUST be here alongside its siblings
+        // (`generator_expression`, `async_function_expression`, …): a plain
+        // function expression in value position — an IIFE `(function(){})()`,
+        // an assigned function `x = function(){}`, a callback
+        // `f(function(){})` — is extremely common, and without this entry it
+        // fell through to the `InternalError` arm below, aborting the whole
+        // compile (`exit 2`, no output) on valid input.
+        "function_expression"
+        | "arrow_function"
+        | "async_arrow_function"
+        | "yield_expression"
+        | "await_expression"
+        | "generator_expression"
+        | "async_function_expression"
+        | "async_generator_expression"
+        | "class_expression"
+        | "template_literal"
+        | "tagged_template_expression"
+        | "new_target_expression"
+        | "import_meta_expression" => Err(unsupported(node)),
 
         other => Err(BridgeError::InternalError {
             msg: format!("unknown expression rule '{other}'"),
@@ -2815,6 +2833,28 @@ mod tests {
         // the NAME-token unwrap, so the unwrap fired `internal("missing name")`
         // first and `var [a,b]=c;` failed to compile at SIMPLE/ADVANCED.
         for src in ["var [a,b]=c;", "let {p,q}=o;", "const [x]=y;"] {
+            match bridge(src) {
+                Err(BridgeError::UnsupportedSyntax { .. }) => {} // graceful decline
+                other => panic!("expected UnsupportedSyntax for {src:?}, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn function_expressions_decline_gracefully_not_hard_error() {
+        // A `function` expression in value position — an IIFE, an assigned
+        // function, a callback argument — is Phase 2. It must decline with
+        // `UnsupportedSyntax` (→ WHITESPACE_ONLY fallback, valid output), NOT
+        // raise an `Internal` error (a hard `exit 2` compile abort).
+        // Regression: `function_expression` was missing from the unsupported
+        // list in `convert_expression`, so it fell through to the
+        // `InternalError` catch-all and `(function(){})();` failed to compile.
+        for src in [
+            "(function(){})();",
+            "x=function(){};",
+            "f(function(){});",
+            "var g=function h(){};",
+        ] {
             match bridge(src) {
                 Err(BridgeError::UnsupportedSyntax { .. }) => {} // graceful decline
                 other => panic!("expected UnsupportedSyntax for {src:?}, got {other:?}"),


### PR DESCRIPTION
## Problem

A `function` expression in value position made the bridge raise an `Internal` error, which the CLI treats as a **hard failure** (`exit 2`, no JS output):

```
(function(){})();     →  bridge internal error: unknown expression rule 'function_expression'   (exit 2)
x = function(){};     →  (same)
f(function(){ … });   →  (same)
```

IIFEs, assigned function expressions, and function callbacks are extremely common, valid JavaScript. Like arrow functions, generator/async function expressions, and class expressions — all of which already decline gracefully — a plain function expression is a Phase 2 feature that should **decline** with `UnsupportedSyntax` (so the CLI falls back to WHITESPACE_ONLY and still emits valid output), never abort.

## Cause

`convert_expression`'s "ES2015+ unsupported" arm listed `generator_expression`, `async_function_expression`, `arrow_function`, `class_expression`, … but **omitted the plain `function_expression`**, so it fell through to the `InternalError` catch-all.

## Fix

Added `"function_expression"` to that decline list, alongside its siblings. Now:

```
(function(){})();   →  (function(){})();   (exit 0, WHITESPACE_ONLY passthrough)
x = function(){};   →  x=function(){};     (exit 0)
f(function(){…});   →  f(function(){…});   (exit 0)
```

Statement-level function **declarations**, object methods, and getters/setters are separate grammar rules handled elsewhere and are unaffected.

## Verification

- Reproduced the `exit 2` crash and confirmed `exit 0` + valid passthrough after the fix.
- New regression test: `function_expressions_decline_gracefully_not_hard_error`.
- **97** parser tests green; full `cargo test` green across all consumers — closure-pass-inline/-inline-variables/-rename/-rename-globals/-rename-properties, closurec (883). No fixture changes (decline fix, not an output change).
- Inline security review passed (exact-string match, no shadowing of declarations/methods, no prior correct path, catch-all preserved for malformed input).
- Version `0.19.9` → `0.19.10`; CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)