### PR TITLE
feat(python-sir): M5 collections — lists & dicts (B5)

### DIFF
--- a/code/packages/rust/python-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/python-to-semantic-ir/CHANGELOG.md
@@ -5,6 +5,91 @@ All notable changes to `python-to-semantic-ir` are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to semantic versioning.
 
+## 0.5.0 — 2026-06-30
+
+Milestone **M5**: collections — list & dict literals, indexing, `len`, and
+subscript assignment (SIR17 Python → Semantic IR frontend, B5).  This is
+the last big milestone for the Python frontend — it lowers real data
+programs.
+
+### Added
+
+- **List display `[a, b, c]` → `Expr::SeqLit`** (parser rule
+  `atom → list_expr [ "[", list_body?, "]" ]`; `list_body` is a
+  comma-separated run of `expression`s).  `[]` → an empty `SeqLit`.
+  Elements are lowered depth-bounded, so a deep `[[[…]]]` tower yields a
+  positioned error, never a stack overflow.
+- **Dict display `{k: v, ...}` → `Expr::MapLit`** over `MapEntry`s
+  (parser: `atom → dict_or_set_expr [ "{", dict_or_set_body?, "}" ]`,
+  `dict_or_set_body → dict_body` of `dict_entry [ key, ":", value ]`).
+  `{}` → an empty `MapLit`.
+- **Subscription `x[i]` → `Expr::SeqIndex` / `Expr::MapGet`.**  The parser
+  models a subscript as a trailing `suffix` on a `primary`
+  (`primary → atom suffix*`, subscript suffix `[ "[", subscript, "]" ]`).
+  Suffixes are folded **left-to-right**, so chained `xs[i][j]`, `g()[0]`,
+  and mixed call/subscript chains lower correctly.
+- **`len(xs)` → the dedicated `Expr::SeqLen` node** (SIR17 prefers it over
+  `BuiltinCall("len")` so backends can emit native length access).  Arity
+  must be exactly 1; a local/param named `len` shadows the builtin.
+- **Subscript assignment `x[i] = v` → `Stmt::SeqSet` / `Stmt::MapSet`**,
+  mirroring the read-side disambiguation.  Chained `m[a][b] = v` is
+  supported (the base `m[a]` lowers as a value, `[b]` is the assigned
+  index).
+- **Manifest** declares `Feature::Sequences` for any
+  `SeqLit`/`SeqIndex`/`SeqLen`/`SeqSet`, and `Feature::Maps` for any
+  `MapLit`/`MapGet`/`MapSet`.
+- **`MapEntry` is now re-exported** from the `semantic-ir` crate root
+  (`semantic_ir::MapEntry`) for use by frontends/backends.
+
+### Subscript disambiguation
+
+Python overloads `[]` for both list indexing and dict lookup, and the
+frontend has no type information.  The SIR17 spec lists `xs[i] → SeqIndex`
+and `d[k] → MapGet` but leaves the *syntactic* rule open.  M5 uses a
+purely syntactic heuristic (mirroring the JS sibling's cut-line): **a
+string-literal index → `MapGet`/`MapSet` (a map key); any other index →
+`SeqIndex`/`SeqSet` (a sequence index).**  The canonical idioms (`xs[0]`,
+`d["name"]`) lower correctly; the choice only affects the manifest feature
+(`Sequences` vs `Maps`), not runtime behaviour — the SIR runtime's
+duck-typed `[]` executes both via `__getitem__`/`__setitem__`.
+
+### Deferred (rejected with a positioned error)
+
+- List/dict **comprehensions** (`[x for x in xs]`, `{k: v for …}`).
+- **Slicing** (`xs[a:b]`) — also rejected by the parser, with the
+  lowerer's `has_colon_token` guard as defence-in-depth.
+- **Tuple** (`(1, 2)`) and **set** (`{1, 2}`) literals.
+- List/dict **methods** (`.append` / `.keys` / `.get` …) — these require
+  the SIR runtime-library per the project mandate.
+- **Unpacking** (`a, b = xs`).
+
+### Tests
+
+- A positive unit test per collection form (list/dict literal, empty,
+  nested), both subscript disambiguation directions, `len`→`SeqLen` (plus
+  wrong-arity and shadowing), and subscript assignment (`SeqSet`/`MapSet`,
+  chained).
+- Negative tests for every deferred form (set, comprehension, slice,
+  tuple).
+- **Deep-nesting regression tests** — a `[[[…]]]` list tower, an
+  `xs[xs[xs[…]]]` index tower, and a `{"a": {"a": …}}` dict tower each
+  exceed `MAX_EXPR_DEPTH` and must return a clean positioned error
+  (verified on a 64 MiB worker stack so the *lowerer's* guard, not the
+  parser's, is exercised).
+- `validate` round-trip over the M5 collection programs.
+- **End-to-end goldens** (Python → SIR → `semantic-ir-to-python` →
+  executed): build/index/sum a list, list subscript assignment, dict
+  get/set, and a for-each list sum.  These run through the existing
+  PYTHONPATH-aware helper (resolving a real Python 3 and pointing
+  `PYTHONPATH` at the SIR runtime package `src` dirs), and skip cleanly
+  when no interpreter is present.
+
+### Fixed
+
+- Updated the `Param` construction for the new `semantic_ir::Param.default`
+  field (added upstream), so the crate builds against the current
+  `semantic-ir`.
+
 ## 0.4.0 — 2026-06-30
 
 Milestone **M4**: functions, calls, and closures — `def`, tail-position

--- a/code/packages/rust/python-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/python-to-semantic-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "python-to-semantic-ir"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "Python CST → narrow-waist Semantic IR (SIR17). Second frontend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/python-to-semantic-ir/README.md
+++ b/code/packages/rust/python-to-semantic-ir/README.md
@@ -52,15 +52,16 @@ pub struct PythonLowerError {
 `compile_source` parses then lowers; both parse and lower failures are
 surfaced as `PythonLowerError`.
 
-## Milestone status — M4 (functions, calls, closures)
+## Milestone status — M5 (collections)
 
 Top-level statements run inline in a synthesised `main` function whose
 block value is the program's final top-level expression (or `NilLit`
 for an empty program / a trailing assignment).  A `def` at any level is
 lifted to a **top-level `Function`** (the module gains a real function
 table); `lambda`s and nested `def`s are lifted to synthesised functions
-with computed captures.  M4 adds `def`, tail `return`, `lambda`,
-function calls, and closures, on top of M1–M3.
+with computed captures.  M5 adds **collections** — list & dict literals,
+indexing (`x[i]`), `len`, and subscript assignment — on top of M1–M4
+(`def`, tail `return`, `lambda`, calls, closures).
 
 ### Literals (M1, still supported)
 
@@ -191,6 +192,38 @@ capture.  A bare reference to a function name yields a `MakeClosure`
 Capture order is deterministic (alphabetical).  Closure bodies reuse the
 `MAX_BLOCK_DEPTH` / `MAX_EXPR_DEPTH` guards, so recursion stays bounded.
 
+### Collections (M5)
+
+| Python source              | SIR lowering                                  | Feature declared |
+|----------------------------|-----------------------------------------------|------------------|
+| `[a, b, c]`, `[]`          | `SeqLit { items }`                            | `Sequences`      |
+| `xs[i]` (non-string index) | `SeqIndex { seq, index }`                     | `Sequences`      |
+| `xs[i] = v`                | `SeqSet { seq, index, value }`                | `Sequences`      |
+| `len(xs)`                  | `SeqLen { seq }`†                             | `Sequences`      |
+| `{"a": 1, "b": 2}`, `{}`   | `MapLit { entries }`                          | `Maps`           |
+| `d["k"]` (string index)    | `MapGet { map, key }`                         | `Maps`           |
+| `d["k"] = v`               | `MapSet { map, key, value }`                  | `Maps`           |
+
+† `len` lowers to the dedicated `SeqLen` node (preferred over
+`BuiltinCall("len")` so backends can emit native length access); arity
+must be exactly 1, and a local/param named `len` shadows the builtin.
+
+**Subscript disambiguation.**  Python overloads `[]` for both list
+indexing and dict lookup, and the frontend has no types.  The rule is
+purely syntactic: a **string-literal** index is a *map key*
+(`MapGet` / `MapSet`); any other index is a *sequence index*
+(`SeqIndex` / `SeqSet`).  So `xs[0]` and `d["name"]` lower as expected,
+while `d[k]` / `counts[n]` (a variable / integer key) lower as a sequence
+index.  The choice only affects the manifest feature (`Sequences` vs
+`Maps`) — the SIR runtime's duck-typed `[]` executes both identically.
+
+**Suffix folding.**  A `primary` is `atom suffix*`; trailing call /
+subscript suffixes fold **left-to-right**, so `xs[i][j]`, `g()[0]`, and
+mixed chains lower correctly.  Every element / index / key is lowered
+depth-bounded (`MAX_EXPR_DEPTH`), so a deep `[[[…]]]` / `{a:{b:…}}` /
+`xs[xs[xs[…]]]` tower returns a clean positioned error rather than
+overflowing the stack.
+
 The manifest declares **exactly** the features observed.  Module
 metadata records `source_language = "python"` and
 `sir_version = semantic_ir::CURRENT_SIR_VERSION`.  Every lowered module
@@ -198,14 +231,16 @@ passes `semantic_ir::validate`.
 
 ### Deferred (later milestones)
 
-Everything past M4 returns a clear positioned `PythonLowerError`:
+Everything past M5 returns a clear positioned `PythonLowerError`:
 
-- sequences, maps, indexing, comprehensions — M5
+- list / dict **comprehensions**, **slicing** (`xs[a:b]`), **tuple** /
+  **set** literals, and list/dict **methods** (`.append` / `.keys` /
+  `.get` — these need the SIR runtime-library)
 - default / keyword arguments, `*args` / `**kwargs`, multi-level capture
   chaining (capturing a variable two scopes up)
 - tuple / multi-target `for` (`for k, v in …`), multi-target / chained
-  assignment, attribute / subscript targets, bitwise operators, the
-  power operator (`**`)
+  assignment, attribute targets, bitwise operators, the power operator
+  (`**`)
 - and the full SIR17 "out of scope" list (classes, exceptions,
   generators, decorators, `with` / `try`, `async`, imports,
   `global` / `nonlocal`, f-strings).

--- a/code/packages/rust/python-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/python-to-semantic-ir/src/lib.rs
@@ -1006,11 +1006,9 @@ mod tests {
 
     #[test]
     fn builtin_calls_lower_to_builtin_call() {
-        for (src, name) in [
-            ("print(1)\n", "print"),
-            ("xs = 1\nlen(xs)\n", "len"),
-            ("range(5)\n", "range"),
-        ] {
+        // `len` is *not* here: as of M5 it lowers to the dedicated
+        // `SeqLen` node (see `len_lowers_to_seq_len`), not `BuiltinCall`.
+        for (src, name) in [("print(1)\n", "print"), ("range(5)\n", "range")] {
             let m = lower(src);
             match main_value(&m) {
                 Expr::BuiltinCall { name: got, .. } => assert_eq!(got, name, "for {src:?}"),
@@ -1227,10 +1225,337 @@ mod tests {
         assert!(err.message.contains("default"), "got: {}", err.message);
     }
 
+    // ══════════════════════════════════════════════════════════════════
+    // M5: collections — list & dict literals, subscript, len, set
+    // ══════════════════════════════════════════════════════════════════
+
+    // ── list literals → SeqLit ────────────────────────────────────────
+
     #[test]
-    fn list_literal_is_still_unsupported() {
-        let err = compile_source("xs = [1, 2, 3]\n", "t").expect_err("list rejected");
+    fn list_literal_lowers_to_seq_lit_and_sets_sequences_feature() {
+        let m = lower("[1, 2, 3]\n");
+        match main_value(&m) {
+            Expr::SeqLit { items, .. } => {
+                assert_eq!(items.len(), 3);
+                assert!(matches!(items[0], Expr::IntLit { value: 1, .. }));
+                assert!(matches!(items[2], Expr::IntLit { value: 3, .. }));
+            }
+            other => panic!("expected SeqLit, got {other:?}"),
+        }
+        assert!(m.manifest.contains(Feature::Sequences));
+    }
+
+    #[test]
+    fn empty_list_lowers_to_empty_seq_lit() {
+        let m = lower("[]\n");
+        match main_value(&m) {
+            Expr::SeqLit { items, .. } => assert!(items.is_empty()),
+            other => panic!("expected empty SeqLit, got {other:?}"),
+        }
+        assert!(m.manifest.contains(Feature::Sequences));
+    }
+
+    #[test]
+    fn nested_list_literal_lowers_recursively() {
+        let m = lower("[[1, 2], [3]]\n");
+        match main_value(&m) {
+            Expr::SeqLit { items, .. } => {
+                assert_eq!(items.len(), 2);
+                assert!(matches!(&items[0], Expr::SeqLit { items, .. } if items.len() == 2));
+                assert!(matches!(&items[1], Expr::SeqLit { items, .. } if items.len() == 1));
+            }
+            other => panic!("expected nested SeqLit, got {other:?}"),
+        }
+    }
+
+    // ── subscript: list index vs dict key disambiguation ──────────────
+
+    #[test]
+    fn integer_subscript_lowers_to_seq_index() {
+        let m = lower("xs = [1, 2]\nxs[0]\n");
+        match main_value(&m) {
+            Expr::SeqIndex { seq, index, .. } => {
+                assert!(matches!(**seq, Expr::VarRef { .. }));
+                assert!(matches!(**index, Expr::IntLit { value: 0, .. }));
+            }
+            other => panic!("expected SeqIndex, got {other:?}"),
+        }
+        assert!(m.manifest.contains(Feature::Sequences));
+    }
+
+    #[test]
+    fn variable_subscript_lowers_to_seq_index() {
+        // A non-string-literal index (a variable) → SeqIndex by the
+        // disambiguation rule.
+        let m = lower("xs = [1, 2]\ni = 0\nxs[i]\n");
+        assert!(matches!(main_value(&m), Expr::SeqIndex { .. }));
+    }
+
+    #[test]
+    fn string_literal_subscript_lowers_to_map_get() {
+        let m = lower("d = {\"a\": 1}\nd[\"a\"]\n");
+        match main_value(&m) {
+            Expr::MapGet { map, key, .. } => {
+                assert!(matches!(**map, Expr::VarRef { .. }));
+                assert!(matches!(&**key, Expr::StrLit { value, .. } if value == "a"));
+            }
+            other => panic!("expected MapGet, got {other:?}"),
+        }
+        assert!(m.manifest.contains(Feature::Maps));
+    }
+
+    #[test]
+    fn chained_subscript_folds_left_to_right() {
+        // `m[a][b]` — the inner `m[a]` is the base of the outer index.
+        // Both indices are variables → both SeqIndex.
+        let m = lower("m = [[1]]\na = 0\nb = 0\nm[a][b]\n");
+        match main_value(&m) {
+            Expr::SeqIndex { seq, .. } => {
+                assert!(matches!(**seq, Expr::SeqIndex { .. }), "outer wraps inner index");
+            }
+            other => panic!("expected nested SeqIndex, got {other:?}"),
+        }
+    }
+
+    // ── len(xs) → SeqLen ──────────────────────────────────────────────
+
+    #[test]
+    fn len_lowers_to_seq_len() {
+        let m = lower("xs = [1, 2, 3]\nlen(xs)\n");
+        match main_value(&m) {
+            Expr::SeqLen { seq, .. } => assert!(matches!(**seq, Expr::VarRef { .. })),
+            other => panic!("expected SeqLen, got {other:?}"),
+        }
+        assert!(m.manifest.contains(Feature::Sequences));
+    }
+
+    #[test]
+    fn len_with_wrong_arity_is_rejected() {
+        let err =
+            compile_source("xs = [1]\nlen(xs, 2)\n", "t").expect_err("len arity rejected");
+        assert!(err.message.contains("len()"), "got: {}", err.message);
+    }
+
+    #[test]
+    fn len_shadowed_by_local_is_an_indirect_call() {
+        // A local named `len` shadows the builtin → not SeqLen.
+        let m = lower("def f(len, xs):\n    return len(xs)\n");
+        let f = func(&m, "f");
+        assert!(
+            matches!(&f.body.value, Expr::IndirectCall { .. }),
+            "shadowed len should be an indirect call, got {:?}",
+            f.body.value
+        );
+    }
+
+    // ── dict literals → MapLit ────────────────────────────────────────
+
+    #[test]
+    fn dict_literal_lowers_to_map_lit_and_sets_maps_feature() {
+        let m = lower("{\"a\": 1, \"b\": 2}\n");
+        match main_value(&m) {
+            Expr::MapLit { entries, .. } => {
+                assert_eq!(entries.len(), 2);
+                assert!(matches!(&entries[0].key, Expr::StrLit { value, .. } if value == "a"));
+                assert!(matches!(entries[0].value, Expr::IntLit { value: 1, .. }));
+            }
+            other => panic!("expected MapLit, got {other:?}"),
+        }
+        assert!(m.manifest.contains(Feature::Maps));
+    }
+
+    #[test]
+    fn empty_dict_lowers_to_empty_map_lit() {
+        let m = lower("{}\n");
+        match main_value(&m) {
+            Expr::MapLit { entries, .. } => assert!(entries.is_empty()),
+            other => panic!("expected empty MapLit, got {other:?}"),
+        }
+        assert!(m.manifest.contains(Feature::Maps));
+    }
+
+    #[test]
+    fn nested_dict_literal_lowers_recursively() {
+        let m = lower("{\"a\": {\"b\": 1}}\n");
+        match main_value(&m) {
+            Expr::MapLit { entries, .. } => {
+                assert_eq!(entries.len(), 1);
+                assert!(matches!(&entries[0].value, Expr::MapLit { entries, .. } if entries.len() == 1));
+            }
+            other => panic!("expected nested MapLit, got {other:?}"),
+        }
+    }
+
+    // ── subscript assignment → SeqSet / MapSet ────────────────────────
+
+    #[test]
+    fn list_subscript_assignment_lowers_to_seq_set() {
+        let m = lower("xs = [1, 2]\nxs[0] = 9\n");
+        match &main_stmts(&m)[1] {
+            Stmt::SeqSet { seq, index, value, .. } => {
+                assert!(matches!(seq, Expr::VarRef { .. }));
+                assert!(matches!(index, Expr::IntLit { value: 0, .. }));
+                assert!(matches!(value, Expr::IntLit { value: 9, .. }));
+            }
+            other => panic!("expected SeqSet, got {other:?}"),
+        }
+        assert!(m.manifest.contains(Feature::Sequences));
+    }
+
+    #[test]
+    fn dict_subscript_assignment_lowers_to_map_set() {
+        let m = lower("d = {}\nd[\"k\"] = 5\n");
+        match &main_stmts(&m)[1] {
+            Stmt::MapSet { map, key, value, .. } => {
+                assert!(matches!(map, Expr::VarRef { .. }));
+                assert!(matches!(key, Expr::StrLit { value, .. } if value == "k"));
+                assert!(matches!(value, Expr::IntLit { value: 5, .. }));
+            }
+            other => panic!("expected MapSet, got {other:?}"),
+        }
+        assert!(m.manifest.contains(Feature::Maps));
+    }
+
+    #[test]
+    fn chained_subscript_assignment_uses_index_base() {
+        // `m[a][b] = v` — the assigned target is `[b]`; the base is `m[a]`.
+        let m = lower("m = [[0]]\na = 0\nb = 0\nm[a][b] = 7\n");
+        match main_stmts(&m).last().expect("a stmt") {
+            Stmt::SeqSet { seq, value, .. } => {
+                assert!(matches!(seq, Expr::SeqIndex { .. }), "base is the inner index");
+                assert!(matches!(value, Expr::IntLit { value: 7, .. }));
+            }
+            other => panic!("expected SeqSet with SeqIndex base, got {other:?}"),
+        }
+    }
+
+    // ── deferred collection forms stay rejected ───────────────────────
+
+    #[test]
+    fn set_literal_is_rejected() {
+        let err = compile_source("{1, 2, 3}\n", "t").expect_err("set rejected");
+        assert!(err.message.contains("set literal"), "got: {}", err.message);
+    }
+
+    #[test]
+    fn list_comprehension_is_rejected() {
+        let err = compile_source("[x for x in xs]\n", "t").expect_err("comprehension rejected");
+        assert!(
+            err.message.contains("comprehension") || err.message.contains("unresolved"),
+            "got: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn slice_subscript_is_rejected() {
+        // The Python parser has no slice grammar, so `xs[0:2]` is rejected
+        // at *parse* time (before lowering).  The lowerer's own `slicing`
+        // guard (`has_colon_token`) is defence-in-depth for any future
+        // grammar that admits the colon; either way the program is
+        // rejected, never mis-lowered.
+        let err = compile_source("xs = [1, 2, 3]\nxs[0:2]\n", "t").expect_err("slice rejected");
+        assert!(
+            err.message.contains("slicing") || err.message.contains("parse error"),
+            "got: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn tuple_literal_is_still_unsupported() {
+        // A parenthesised tuple `(1, 2)` is a multi-element expression list
+        // — not an M5 collection — and stays deferred.
+        let err = compile_source("(1, 2)\n", "t").expect_err("tuple rejected");
         assert!(err.message.contains("unsupported"), "got: {}", err.message);
+    }
+
+    // ── deep-nesting regression: clean error, never overflow ──────────
+
+    #[test]
+    fn deep_list_tower_errors_cleanly_not_overflow() {
+        // `[[[…1…]]]` past MAX_EXPR_DEPTH must yield a positioned error,
+        // not a native stack overflow.
+        on_big_stack(|| {
+            let depth = 400usize;
+            let src = format!("{}1{}\n", "[".repeat(depth), "]".repeat(depth));
+            let err = compile_source(&src, "t")
+                .expect_err("deep list tower must be rejected, not crash");
+            assert!(
+                err.message.contains("too deep"),
+                "expected a positioned 'too deep' error, got: {}",
+                err.message
+            );
+        });
+    }
+
+    #[test]
+    fn deep_subscript_index_tower_errors_cleanly_not_overflow() {
+        // `xs[xs[xs[…]]]` — a tower of *index* expressions past
+        // MAX_EXPR_DEPTH must error cleanly.  Depth 300 just clears the
+        // 256 cap; the parser's cost on this backtracking-heavy form grows
+        // fast, so we stay close to the cap rather than 400.
+        on_big_stack(|| {
+            let depth = 300usize;
+            let mut src = String::from("xs = [0]\n");
+            src.push_str(&"xs[".repeat(depth));
+            src.push('0');
+            src.push_str(&"]".repeat(depth));
+            src.push('\n');
+            let err = compile_source(&src, "t")
+                .expect_err("deep subscript tower must be rejected, not crash");
+            assert!(
+                err.message.contains("too deep"),
+                "expected a positioned 'too deep' error, got: {}",
+                err.message
+            );
+        });
+    }
+
+    #[test]
+    fn deep_dict_value_tower_errors_cleanly_not_overflow() {
+        // `{"a": {"a": {…}}}` past MAX_EXPR_DEPTH must error cleanly.
+        // Depth 300 just clears the 256 cap (the parser's cost on this
+        // form grows fast, so we stay close to the cap rather than 400).
+        on_big_stack(|| {
+            let depth = 300usize;
+            let mut src = String::new();
+            src.push_str(&"{\"a\": ".repeat(depth));
+            src.push('1');
+            src.push_str(&"}".repeat(depth));
+            src.push('\n');
+            let err = compile_source(&src, "t")
+                .expect_err("deep dict tower must be rejected, not crash");
+            assert!(
+                err.message.contains("too deep"),
+                "expected a positioned 'too deep' error, got: {}",
+                err.message
+            );
+        });
+    }
+
+    // ── validator round-trip over M5 collection programs ──────────────
+
+    #[test]
+    fn m5_modules_pass_the_validator() {
+        for src in [
+            "xs = [1, 2, 3]\n",
+            "[]\n",
+            "{}\n",
+            "xs = [1, 2, 3]\nlen(xs)\n",
+            "xs = [10, 20]\nxs[0]\n",
+            "xs = [1, 2]\nxs[0] = 9\n",
+            "d = {\"a\": 1, \"b\": 2}\nd[\"a\"]\n",
+            "d = {}\nd[\"k\"] = 5\n",
+            "xs = [[1], [2]]\n",
+            "d = {\"x\": [1, 2], \"y\": [3]}\n",
+            // build, index, sum a list
+            "xs = [1, 2, 3]\ntotal = xs[0] + xs[1] + xs[2]\nprint(total)\n",
+        ] {
+            let m = lower(src);
+            let r = semantic_ir::validate(&m);
+            assert!(r.is_ok(), "module for {src:?} failed validation: {:?}", r.issues);
+        }
     }
 
     // ── validator round-trip over M4 programs ─────────────────────────
@@ -1380,7 +1705,14 @@ mod tests {
             String::from_utf8_lossy(&out.stderr),
             artifact.source
         );
-        Some(String::from_utf8_lossy(&out.stdout).trim().to_string())
+        // Normalise CRLF → LF so multi-line goldens are the same on
+        // Windows (where the interpreter writes `\r\n`) and Unix.
+        Some(
+            String::from_utf8_lossy(&out.stdout)
+                .replace("\r\n", "\n")
+                .trim()
+                .to_string(),
+        )
     }
 
     #[test]
@@ -1478,6 +1810,70 @@ print(is_even(10))
                 out == "True" || out == "#t",
                 "is_even(10) should be truthy, got {out:?}"
             );
+        }
+    }
+
+    // ══════════════════════════════════════════════════════════════════
+    // M5: end-to-end — collections lowered → SIR → Python → execute
+    // ══════════════════════════════════════════════════════════════════
+    //
+    // Same PYTHONPATH-aware runner as M4 (`run_roundtrip` resolves a real
+    // Python 3 and sets PYTHONPATH to the SIR runtime package `src` dirs,
+    // skipping cleanly when no interpreter is present).
+
+    #[test]
+    fn e2e_list_build_index_sum() {
+        // Build a list, index its elements, sum them, print the total.
+        let src = "\
+xs = [10, 20, 30]
+total = xs[0] + xs[1] + xs[2]
+print(total)
+print(len(xs))
+";
+        if let Some(out) = run_roundtrip(src) {
+            assert_eq!(out, "60\n3", "sum should be 60 and len 3");
+        }
+    }
+
+    #[test]
+    fn e2e_list_subscript_assignment() {
+        // Mutate a list element in place, then read it back.
+        let src = "\
+xs = [1, 2, 3]
+xs[1] = 99
+print(xs[1])
+";
+        if let Some(out) = run_roundtrip(src) {
+            assert_eq!(out, "99", "mutated element should be 99");
+        }
+    }
+
+    #[test]
+    fn e2e_dict_get_and_set() {
+        // Build a dict, read a key, set another key, read it back.
+        let src = "\
+d = {\"a\": 1, \"b\": 2}
+print(d[\"a\"])
+d[\"c\"] = 7
+print(d[\"c\"])
+";
+        if let Some(out) = run_roundtrip(src) {
+            assert_eq!(out, "1\n7", "dict get/set should print 1 then 7");
+        }
+    }
+
+    #[test]
+    fn e2e_list_sum_loop() {
+        // for-each over a list literal, accumulating a running total.
+        let src = "\
+total = 0
+for x in [1, 2, 3, 4]:
+    total = total + x
+
+print(total)
+";
+        if let Some(out) = run_roundtrip(src) {
+            assert_eq!(out, "10", "1+2+3+4 should print 10");
         }
     }
 }

--- a/code/packages/rust/python-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/python-to-semantic-ir/src/lower.rs
@@ -1,5 +1,5 @@
 //! The lowering pass from `python_parser`'s generic
-//! [`GrammarASTNode`] CST → [`semantic_ir::Module`], **milestone M4**.
+//! [`GrammarASTNode`] CST → [`semantic_ir::Module`], **milestone M5**.
 //!
 //! # What M1 covered (still supported)
 //!
@@ -89,6 +89,59 @@
 //! `IndirectCall` is emitted, and `MutualRecursion` when two top-level
 //! functions call each other.
 //!
+//! # What M5 adds — collections (lists & dicts)
+//!
+//! M5 is the last big Python-frontend milestone — it turns the
+//! single-scalar IR into one that lowers real data programs:
+//!
+//! - **list display `[a, b, c]`** → [`Expr::SeqLit`] (the parser names
+//!   this `atom → list_expr [ "[", list_body?, "]" ]`; `list_body` is a
+//!   comma-separated run of `expression`s).  `[]` → an empty `SeqLit`.
+//! - **dict display `{k: v, ...}`** → [`Expr::MapLit`] over
+//!   [`semantic_ir::MapEntry`]s (parser: `atom → dict_or_set_expr [ "{",
+//!   dict_or_set_body?, "}" ]`, where `dict_or_set_body → dict_body` is a
+//!   comma-separated run of `dict_entry [ key, ":", value ]`).  `{}` → an
+//!   empty `MapLit`.  A **set** display (`{1, 2}`) parses to a
+//!   `dict_or_set_body` with *no* `dict_body` child — rejected (deferred).
+//! - **subscription `x[i]`** → either [`Expr::SeqIndex`] or
+//!   [`Expr::MapGet`], disambiguated by the index (see below).  The parser
+//!   names a subscript a *trailing `suffix`* on a `primary`:
+//!   `primary → atom suffix*`, where a subscript suffix is
+//!   `[ "[", subscript, "]" ]` (a call suffix is `[ "(", arguments?, ")" ]`).
+//!   Chained subscripts (`xs[i][j]`) are multiple suffixes, applied
+//!   left-to-right.
+//! - **`len(xs)`** → [`Expr::SeqLen`] (the SIR17 spec prefers the
+//!   dedicated `SeqLen` node over `BuiltinCall("len")` so backends can
+//!   emit native length access).  `len` with arity ≠ 1 is rejected.
+//! - **subscript assignment `x[i] = v`** → [`Stmt::SeqSet`] /
+//!   [`Stmt::MapSet`], mirroring the read-side disambiguation.
+//!
+//! ## Subscript disambiguation (list index vs dict key)
+//!
+//! Python uses one `[]` syntax for both list indexing and dict lookup; the
+//! SIR17 spec lists `xs[i] → SeqIndex` and `d[k] → MapGet` but leaves the
+//! *syntactic* rule that tells them apart open (the frontend has no type
+//! information).  Mirroring the JS sibling's cut-line, M5 uses a purely
+//! syntactic heuristic: **a string-literal index → `MapGet` / `MapSet`
+//! (a map key); any other index → `SeqIndex` / `SeqSet` (a list index).**
+//! This makes the canonical idioms (`xs[0]`, `d["name"]`) lower correctly;
+//! a dict keyed by a computed/integer key (`d[k]`, `counts[n]`) lowers as
+//! a sequence index, which the SIR runtime's duck-typed `[]` still
+//! executes correctly (both route through `__getitem__`/`__setitem__`).
+//! The choice only affects the manifest feature (`Sequences` vs `Maps`),
+//! not runtime behaviour.
+//!
+//! ## Still deferred (later milestones / runtime-library work)
+//!
+//! - list/dict **comprehensions** (`[x for x in xs]`)            → deferred
+//! - **slicing** (`xs[a:b]`, `xs[::2]`)                          → deferred
+//! - **tuple** / **set** literals (`(1, 2)`, `{1, 2}`)           → deferred
+//! - list/dict **methods** (`.append` / `.keys` / `.get` …) — these need
+//!   the SIR runtime-library per the project mandate                → deferred
+//! - **unpacking** (`a, b = xs`, `*rest`)                        → deferred
+//!
+//! Each deferred form yields a positioned [`PythonLowerError`].
+//!
 //! ## Free-variable analysis (how captures are computed)
 //!
 //! We scan the lambda/nested-`def` **body subtree of the CST** for bare
@@ -102,7 +155,8 @@
 //!
 //! ## Still deferred (later milestones)
 //!
-//! - collections (lists / dicts / indexing / comprehensions)  → M5+
+//! - collection *comprehensions* / *slicing* / *methods*      → deferred
+//!   (list & dict literals / index / `len` / subscript-assign land in M5)
 //! - `*args` / keyword & default arguments                    → deferred
 //! - decorators / classes / `with` / `try` / generators       → deferred
 //! - `global` / `nonlocal`, multi-target assignment           → deferred
@@ -117,8 +171,8 @@ use std::collections::HashSet;
 
 use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode};
 use semantic_ir::{
-    Block, Capture, CaptureValue, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata,
-    Module, Param, ParamKind, Scope, Span, Stmt,
+    Block, Capture, CaptureValue, EffectSet, Expr, Feature, FeatureManifest, Function, MapEntry,
+    Metadata, Module, Param, ParamKind, Scope, Span, Stmt,
 };
 
 /// Maximum expression-nesting depth the lowerer will descend before
@@ -201,6 +255,14 @@ pub fn compile(tree: &GrammarASTNode, module_name: &str) -> Result<Module, Pytho
 enum Lowered {
     Stmt(Box<Stmt>),
     Expr(Expr),
+}
+
+/// What a trailing `primary` `suffix` denotes (M5).  A `suffix` is one of
+/// a *call* (`( … )`), a *subscript* (`[ … ]`), or a deferred attribute
+/// access (`.x`) — classified by [`Lowerer::suffix_kind`].
+enum SuffixKind {
+    Call,
+    Subscript,
 }
 
 /// Per-function name-resolution context (M4).
@@ -692,10 +754,15 @@ impl Lowerer {
         let name = match self.target_name(target_node)? {
             Some(name) => name,
             None => {
+                // M5: a *subscript* target (`xs[i] = v` / `d[k] = v`)?
+                // Everything else (attribute, tuple-unpack, …) is deferred.
+                if let Some(stmt) = self.try_subscript_assign(assign, target_node, rhs_node, ctx)? {
+                    return Ok(Lowered::Stmt(Box::new(stmt)));
+                }
                 return Err(self.err_at(
                     target_node,
                     "unsupported: assignment target is not a bare name (deferred)".to_string(),
-                ))
+                ));
             }
         };
 
@@ -720,6 +787,81 @@ impl Lowerer {
                 value,
                 span,
             })))
+        }
+    }
+
+    /// M5: lower a **subscript assignment** `base[index] = rhs` into
+    /// [`Stmt::SeqSet`] (list) or [`Stmt::MapSet`] (map), mirroring the
+    /// read-side disambiguation (string-literal index → map).  Returns
+    /// `Ok(None)` when the LHS is *not* a subscript target (so the caller
+    /// reports the generic "not a bare name" deferral).
+    ///
+    /// The `base` is everything left of the final subscript: for
+    /// `xs[i] = v` it is `xs`; for a chained `m[a][b] = v` it is `m[a]`
+    /// (itself lowered as a `SeqIndex`/`MapGet` value).  The base is
+    /// lowered as an ordinary expression (it must resolve to a value in
+    /// scope), the final index/key and the RHS likewise.
+    fn try_subscript_assign(
+        &mut self,
+        assign: &GrammarASTNode,
+        target_node: &GrammarASTNode,
+        rhs_node: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+    ) -> Result<Option<Stmt>, PythonLowerError> {
+        // Peel the target expression to its `primary` (the rule that
+        // carries `atom suffix*`); a non-subscript target peels to a bare
+        // atom (no suffix) and is not ours.
+        let primary = match self.peel_to_primary(target_node) {
+            Some(p) => p,
+            None => return Ok(None),
+        };
+        let kids = child_nodes(primary);
+        let (atom, suffixes) = match kids.split_first() {
+            Some((atom, rest)) if !rest.is_empty() && rest[0].rule_name == "suffix" => {
+                (*atom, rest)
+            }
+            _ => return Ok(None),
+        };
+        // The *final* suffix must be the subscript being assigned.  Earlier
+        // suffixes (if any) form the base value `m[a]` / `g()`.
+        let (last, leading) = suffixes.split_last().expect("split_first left ≥ 1 suffix");
+        if !matches!(self.suffix_kind(last)?, SuffixKind::Subscript) {
+            // `f(x) = v` is not a valid assignment target.
+            return Err(self.err_at(
+                primary,
+                "unsupported: assignment to a call result (deferred)".to_string(),
+            ));
+        }
+
+        // Build the base value: the atom, with every leading suffix
+        // applied (calls / subscripts).  No leading suffix → the base is
+        // just the atom (`xs`).
+        let span = self.span_of(assign);
+        let mut base = self.lower_expr(atom, ctx)?;
+        for suffix in leading {
+            base = self.apply_value_suffix(base, suffix, ctx, 0, &span)?;
+        }
+
+        let index_node = self.subscript_index(last)?;
+        let index = self.lower_expr(index_node, ctx)?;
+        let value = self.lower_expr(rhs_node, ctx)?;
+
+        if is_str_lit(&index) {
+            self.observed.add(Feature::Maps);
+            Ok(Some(Stmt::MapSet {
+                map: base,
+                key: index,
+                value,
+                span,
+            }))
+        } else {
+            self.observed.add(Feature::Sequences);
+            Ok(Some(Stmt::SeqSet {
+                seq: base,
+                index,
+                value,
+                span,
+            }))
         }
     }
 
@@ -1922,11 +2064,17 @@ impl Lowerer {
                 }
             }
             "primary" => {
-                // A `primary` with a call `suffix` is a call expression.
-                if let Some(e) = self.try_call(node, ctx, depth)? {
+                // A `primary` with trailing `suffix`es is a call and/or
+                // subscript chain (`f(x)`, `xs[i]`, `xs[i][j]`, `g()[0]`).
+                if let Some(e) = self.try_primary_suffixes(node, ctx, depth)? {
                     return Ok(e);
                 }
             }
+            // M5: list display `[a, b, c]` → SeqLit.
+            "list_expr" => return self.lower_list_expr(node, ctx, depth),
+            // M5: dict display `{k: v, ...}` → MapLit (a set display is
+            // rejected inside this handler).
+            "dict_or_set_expr" => return self.lower_dict_or_set_expr(node, ctx, depth),
             _ => {}
         }
 
@@ -1947,46 +2095,127 @@ impl Lowerer {
         }
     }
 
-    /// `primary` with a trailing call `suffix` → a call expression.
-    /// Resolves the callee: a known function name → [`Expr::DirectCall`];
-    /// a builtin (`print`/`len`/`range`) → [`Expr::BuiltinCall`]; a
-    /// local/param/captured value → [`Expr::IndirectCall`] through that
-    /// `VarRef`.  Returns `Ok(None)` when the `primary` is not a call
-    /// (no `suffix`) so the generic peel handles it.
-    fn try_call(
+    /// `primary` with trailing `suffix`es → a call / subscript chain
+    /// (`f(x)`, `xs[i]`, `xs[i][j]`, `g()[0]`).  Returns `Ok(None)` when
+    /// the `primary` has no suffix (a bare atom) so the generic peel
+    /// handles it.
+    ///
+    /// The suffixes are applied **left to right** as a fold over an
+    /// accumulated [`Expr`].  The *first* suffix is special-cased because
+    /// the base is a bare `atom` (a name): a **call** there resolves with
+    /// the full name semantics (builtin / `DirectCall` / `IndirectCall`),
+    /// and a **`len(...)`** call is intercepted as [`Expr::SeqLen`].  Once
+    /// the accumulator is a *computed value*, a further call suffix is an
+    /// [`Expr::IndirectCall`] and a subscript suffix a `SeqIndex`/`MapGet`.
+    ///
+    /// Each suffix application is depth-bounded (it lowers the suffix's
+    /// argument/index expressions at `depth + 1`), so a pathological
+    /// subscript tower `xs[xs[xs[...]]]` (deep *index* expressions) fails
+    /// cleanly via [`MAX_EXPR_DEPTH`].
+    fn try_primary_suffixes(
         &mut self,
         node: &GrammarASTNode,
         ctx: &mut FunctionCtx,
         depth: usize,
     ) -> Result<Option<Expr>, PythonLowerError> {
         let kids = child_nodes(node);
-        let (callee, suffix) = match kids.as_slice() {
-            [callee, suffix] if suffix.rule_name == "suffix" => (*callee, *suffix),
+        // `primary → atom suffix*`.  No suffix → not our shape.
+        let (atom, suffixes) = match kids.split_first() {
+            Some((atom, rest)) if !rest.is_empty() && rest[0].rule_name == "suffix" => {
+                (*atom, rest)
+            }
             _ => return Ok(None),
         };
-        // Only a *call* suffix `( … )` — not indexing `[ … ]` or
-        // attribute `.x` (deferred).  A call suffix's first token is `(`.
-        let is_call = matches!(
-            suffix.children.first(),
-            Some(ASTNodeOrToken::Token(t)) if t.value == "("
-        );
-        if !is_call {
-            return Err(self.err_at(
-                suffix,
-                "unsupported: indexing / attribute access (deferred to a later milestone)"
-                    .to_string(),
-            ));
-        }
 
         let span = self.span_of(node);
 
-        // Lower the arguments first.
-        let arg_nodes = self.call_arguments(suffix);
-        let mut args = Vec::with_capacity(arg_nodes.len());
-        for a in &arg_nodes {
-            let e = self.single_arg_expr(a)?;
-            args.push(self.lower_expr_d(e, ctx, depth + 1)?);
+        // Apply the first suffix against the bare-name atom (call name
+        // semantics live here), then fold the rest over the result.
+        let mut acc = self.apply_first_suffix(atom, suffixes[0], ctx, depth, &span)?;
+        for suffix in &suffixes[1..] {
+            acc = self.apply_value_suffix(acc, suffix, ctx, depth, &span)?;
         }
+        Ok(Some(acc))
+    }
+
+    /// Apply the **first** trailing `suffix` to the bare-name `atom`.  A
+    /// call suffix resolves the callee with full name semantics
+    /// (builtin / `len`→`SeqLen` / `DirectCall` / `IndirectCall`); a
+    /// subscript suffix lowers the atom as a value first, then indexes it.
+    fn apply_first_suffix(
+        &mut self,
+        atom: &GrammarASTNode,
+        suffix: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+        depth: usize,
+        span: &Span,
+    ) -> Result<Expr, PythonLowerError> {
+        match self.suffix_kind(suffix)? {
+            SuffixKind::Call => self.lower_call_suffix(atom, suffix, ctx, depth, span),
+            SuffixKind::Subscript => {
+                let base = self.lower_expr_d(atom, ctx, depth + 1)?;
+                self.lower_subscript_suffix(base, suffix, ctx, depth, span)
+            }
+        }
+    }
+
+    /// Apply a trailing `suffix` to an already-computed value (a chained
+    /// suffix: `g()[0]`, `xs[i][j]`, `f(x)(y)`).  A call here is always an
+    /// [`Expr::IndirectCall`] (the value is a closure handle); a subscript
+    /// is a `SeqIndex`/`MapGet`.
+    fn apply_value_suffix(
+        &mut self,
+        base: Expr,
+        suffix: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+        depth: usize,
+        span: &Span,
+    ) -> Result<Expr, PythonLowerError> {
+        match self.suffix_kind(suffix)? {
+            SuffixKind::Call => {
+                let args = self.lower_call_args(suffix, ctx, depth)?;
+                self.observed.add(Feature::Closures);
+                Ok(Expr::IndirectCall {
+                    target: Box::new(base),
+                    args,
+                    effects: EffectSet::PURE,
+                    span: span.clone(),
+                })
+            }
+            SuffixKind::Subscript => {
+                self.lower_subscript_suffix(base, suffix, ctx, depth, span)
+            }
+        }
+    }
+
+    /// Classify a `suffix`: a call `( … )`, a subscript `[ … ]`, or a
+    /// deferred attribute access `.x`.
+    fn suffix_kind(&self, suffix: &GrammarASTNode) -> Result<SuffixKind, PythonLowerError> {
+        match suffix.children.first() {
+            Some(ASTNodeOrToken::Token(t)) if t.value == "(" => Ok(SuffixKind::Call),
+            Some(ASTNodeOrToken::Token(t)) if t.value == "[" => Ok(SuffixKind::Subscript),
+            _ => Err(self.err_at(
+                suffix,
+                "unsupported: attribute access / method call (deferred to a later milestone)"
+                    .to_string(),
+            )),
+        }
+    }
+
+    /// Lower a call `suffix` applied to a bare-name `callee` atom, with
+    /// full name semantics: a builtin (`print`/`range`) → `BuiltinCall`;
+    /// `len(x)` → the dedicated [`Expr::SeqLen`] node (SIR17 prefers it
+    /// over `BuiltinCall("len")`); a known function → `DirectCall`; a
+    /// local/param/capture value → `IndirectCall`.
+    fn lower_call_suffix(
+        &mut self,
+        callee: &GrammarASTNode,
+        suffix: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+        depth: usize,
+        span: &Span,
+    ) -> Result<Expr, PythonLowerError> {
+        let args = self.lower_call_args(suffix, ctx, depth)?;
 
         // The callee must be a bare name (no method calls in v0).
         let name = match self.target_name(callee)? {
@@ -1999,36 +2228,267 @@ impl Lowerer {
             }
         };
 
-        // Builtin?
-        if BUILTIN_CALLS.contains(&name.as_str()) {
-            return Ok(Some(Expr::BuiltinCall {
+        // `len(x)` → SeqLen (preferred over BuiltinCall("len")).  Arity
+        // must be exactly 1; a value of the same name in scope shadows the
+        // builtin (then it is an ordinary indirect call).
+        if name == "len" && !ctx.is_enclosing_value(&name) {
+            if args.len() != 1 {
+                return Err(self.err_at(
+                    suffix,
+                    format!("len() takes exactly 1 argument, got {}", args.len()),
+                ));
+            }
+            self.observed.add(Feature::Sequences);
+            return Ok(Expr::SeqLen {
+                seq: Box::new(args.into_iter().next().expect("arity checked == 1")),
+                span: span.clone(),
+            });
+        }
+
+        // Other builtins (`print` / `range`).
+        if BUILTIN_CALLS.contains(&name.as_str()) && !ctx.is_enclosing_value(&name) {
+            return Ok(Expr::BuiltinCall {
                 name,
                 args,
                 effects: EffectSet::PURE,
-                span,
-            }));
+                span: span.clone(),
+            });
         }
         // Known function (top-level or nested-lifted) → DirectCall, but
         // only if it is *not* shadowed by an enclosing value of the same
         // name (a local/param/capture closure handle wins).
         if self.function_names.contains(&name) && !ctx.is_enclosing_value(&name) {
-            return Ok(Some(Expr::DirectCall {
+            return Ok(Expr::DirectCall {
                 fn_name: name,
                 args,
                 effects: EffectSet::PURE,
-                span,
-            }));
+                span: span.clone(),
+            });
         }
         // Otherwise the name must be a value (closure handle) — resolve
         // it and emit an IndirectCall.
         let target = self.resolve_var_in(ctx, &name, span.clone())?;
         self.observed.add(Feature::Closures);
-        Ok(Some(Expr::IndirectCall {
+        Ok(Expr::IndirectCall {
             target: Box::new(target),
             args,
             effects: EffectSet::PURE,
+            span: span.clone(),
+        })
+    }
+
+    /// Lower the argument expressions of a call `suffix` (`( a, b, … )`).
+    fn lower_call_args(
+        &mut self,
+        suffix: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+        depth: usize,
+    ) -> Result<Vec<Expr>, PythonLowerError> {
+        let arg_nodes = self.call_arguments(suffix);
+        let mut args = Vec::with_capacity(arg_nodes.len());
+        for a in &arg_nodes {
+            let e = self.single_arg_expr(a)?;
+            args.push(self.lower_expr_d(e, ctx, depth + 1)?);
+        }
+        Ok(args)
+    }
+
+    /// Lower a subscript `suffix` (`[ index ]`) applied to `base`,
+    /// disambiguating list-index ([`Expr::SeqIndex`]) from dict-lookup
+    /// ([`Expr::MapGet`]) by the index: a **string-literal** index is a
+    /// map key; anything else is a sequence index (see the module-level
+    /// "Subscript disambiguation" note).  Slicing (`a:b`) is rejected.
+    fn lower_subscript_suffix(
+        &mut self,
+        base: Expr,
+        suffix: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+        depth: usize,
+        span: &Span,
+    ) -> Result<Expr, PythonLowerError> {
+        let index_node = self.subscript_index(suffix)?;
+        let index = self.lower_expr_d(index_node, ctx, depth + 1)?;
+        if is_str_lit(&index) {
+            self.observed.add(Feature::Maps);
+            Ok(Expr::MapGet {
+                map: Box::new(base),
+                key: Box::new(index),
+                span: span.clone(),
+            })
+        } else {
+            self.observed.add(Feature::Sequences);
+            Ok(Expr::SeqIndex {
+                seq: Box::new(base),
+                index: Box::new(index),
+                span: span.clone(),
+            })
+        }
+    }
+
+    /// Extract the single index `expression` from a subscript `suffix`
+    /// (`suffix → "[" subscript "]"`, `subscript → subscript_item →
+    /// expression`).  A *slice* (`a:b`, with a `Colon`) or multi-item
+    /// subscript is rejected (deferred).
+    fn subscript_index<'a>(
+        &self,
+        suffix: &'a GrammarASTNode,
+    ) -> Result<&'a GrammarASTNode, PythonLowerError> {
+        let subscript = self
+            .first_child_named(suffix, "subscript")
+            .ok_or_else(|| self.err_at(suffix, "malformed subscript".to_string()))?;
+        // A slice surfaces as a `Colon` token somewhere in the subscript
+        // (e.g. `xs[a:b]`); reject it explicitly as deferred.
+        if has_colon_token(subscript) {
+            return Err(self.err_at(
+                subscript,
+                "unsupported: slicing (deferred to a later milestone)".to_string(),
+            ));
+        }
+        let items: Vec<&GrammarASTNode> = child_nodes(subscript)
+            .into_iter()
+            .filter(|n| n.rule_name == "subscript_item")
+            .collect();
+        let item = match items.as_slice() {
+            [only] => *only,
+            _ => {
+                return Err(self.err_at(
+                    subscript,
+                    "unsupported: multi-element subscript (deferred)".to_string(),
+                ))
+            }
+        };
+        self.first_child_named(item, "expression").ok_or_else(|| {
+            self.err_at(item, "unsupported: non-expression subscript (deferred)".to_string())
+        })
+    }
+
+    /// Lower a list display `list_expr → "[" list_body? "]"` into
+    /// [`Expr::SeqLit`].  The elements live in `list_body` as a
+    /// comma-separated run of `expression`s; an empty list (`[]`) has no
+    /// `list_body` child.  A comprehension (`[x for x in xs]`) carries a
+    /// `for`/`comp_for` node instead — rejected as deferred.  Each element
+    /// is lowered at `depth + 1`, so a deep `[[[…]]]` tower fails cleanly.
+    fn lower_list_expr(
+        &mut self,
+        node: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+        depth: usize,
+    ) -> Result<Expr, PythonLowerError> {
+        let span = self.span_of(node);
+        let mut items = Vec::new();
+        if let Some(body) = self.first_child_named(node, "list_body") {
+            // A comprehension body carries a `comp_for` / `for`-bearing
+            // node rather than a plain expression run — reject it.
+            if self.is_comprehension_body(body) {
+                return Err(self.err_at(
+                    body,
+                    "unsupported: list comprehension (deferred to a later milestone)".to_string(),
+                ));
+            }
+            for el in child_nodes(body) {
+                if el.rule_name == "expression" {
+                    items.push(self.lower_expr_d(el, ctx, depth + 1)?);
+                } else {
+                    return Err(self.err_at(
+                        el,
+                        format!("unsupported list element `{}` (deferred)", el.rule_name),
+                    ));
+                }
+            }
+        }
+        self.observed.add(Feature::Sequences);
+        Ok(Expr::SeqLit { items, span })
+    }
+
+    /// Lower a dict display `dict_or_set_expr → "{" dict_or_set_body? "}"`
+    /// into [`Expr::MapLit`].  The body wraps a `dict_body` whose children
+    /// are `dict_entry [ key, ":", value ]` nodes (comma-separated).  An
+    /// empty `{}` has no body.  A **set** display (`{1, 2}`) parses to a
+    /// `dict_or_set_body` with no `dict_body` (a bare expression run) and is
+    /// rejected; a comprehension likewise.  Each key/value is lowered at
+    /// `depth + 1` so a deep `{a: {b: …}}` tower fails cleanly.
+    fn lower_dict_or_set_expr(
+        &mut self,
+        node: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+        depth: usize,
+    ) -> Result<Expr, PythonLowerError> {
+        let span = self.span_of(node);
+        let body = match self.first_child_named(node, "dict_or_set_body") {
+            // Empty `{}` is an empty map.
+            None => return Ok(self.empty_map(span)),
+            Some(b) => b,
+        };
+        let dict_body = match self.first_child_named(body, "dict_body") {
+            Some(db) => db,
+            // No `dict_body` ⇒ a *set* display (or set comprehension) —
+            // deferred (sets are not an SIR17 collection in v0).
+            None => {
+                return Err(self.err_at(
+                    body,
+                    "unsupported: set literal / comprehension (deferred to a later milestone)"
+                        .to_string(),
+                ))
+            }
+        };
+        if self.is_comprehension_body(dict_body) {
+            return Err(self.err_at(
+                dict_body,
+                "unsupported: dict comprehension (deferred to a later milestone)".to_string(),
+            ));
+        }
+        let mut entries = Vec::new();
+        for entry in child_nodes(dict_body) {
+            if entry.rule_name != "dict_entry" {
+                return Err(self.err_at(
+                    entry,
+                    format!("unsupported dict element `{}` (deferred)", entry.rule_name),
+                ));
+            }
+            // `dict_entry → key_expression ":" value_expression`.  A `**d`
+            // spread entry has no plain `[key, value]` expression pair.
+            let exprs: Vec<&GrammarASTNode> = child_nodes(entry)
+                .into_iter()
+                .filter(|n| n.rule_name == "expression")
+                .collect();
+            let (k, v) = match exprs.as_slice() {
+                [k, v] => (*k, *v),
+                _ => {
+                    return Err(self.err_at(
+                        entry,
+                        "unsupported: dict spread / non key-value entry (deferred)".to_string(),
+                    ))
+                }
+            };
+            let key = self.lower_expr_d(k, ctx, depth + 1)?;
+            let value = self.lower_expr_d(v, ctx, depth + 1)?;
+            entries.push(MapEntry { key, value });
+        }
+        self.observed.add(Feature::Maps);
+        Ok(Expr::MapLit { entries, span })
+    }
+
+    /// An empty [`Expr::MapLit`] (the lowering of `{}`).  Declares `Maps`.
+    fn empty_map(&mut self, span: Span) -> Expr {
+        self.observed.add(Feature::Maps);
+        Expr::MapLit {
+            entries: vec![],
             span,
-        }))
+        }
+    }
+
+    /// Does a list/dict body carry a comprehension (`for`/`comp_for`)
+    /// rather than a plain element run?  Best-effort: a comprehension's
+    /// CST contains a `comp_for` node or a `for` keyword token.
+    fn is_comprehension_body(&self, body: &GrammarASTNode) -> bool {
+        body.children.iter().any(|c| match c {
+            ASTNodeOrToken::Node(n) => {
+                n.rule_name == "comp_for" || n.rule_name.contains("comprehension")
+            }
+            ASTNodeOrToken::Token(t) => {
+                t.type_ == lexer::token::TokenType::Keyword && t.value == "for"
+            }
+        })
     }
 
     fn try_logical(
@@ -2516,6 +2976,24 @@ fn child_nodes(node: &GrammarASTNode) -> Vec<&GrammarASTNode> {
 /// recognises under `arith` (`+`/`-`) and `term` (`*`/`/`/`%`)?
 fn is_arith_op(value: &str) -> bool {
     matches!(value, "+" | "-" | "*" | "/" | "%")
+}
+
+/// Is a lowered index expression a string literal?  This is the M5
+/// subscript-disambiguation predicate: a string-literal subscript index is
+/// treated as a **map key** (`MapGet`/`MapSet`); any other index is a
+/// **sequence index** (`SeqIndex`/`SeqSet`).  See the module-level
+/// "Subscript disambiguation" note for the rationale and its limits.
+fn is_str_lit(expr: &Expr) -> bool {
+    matches!(expr, Expr::StrLit { .. })
+}
+
+/// Does `node` carry a `Colon` token among its *direct* children?  Used to
+/// detect a slice subscript (`xs[a:b]`), which surfaces as a `Colon` token
+/// inside the `subscript` node and is rejected (deferred) in M5.
+fn has_colon_token(node: &GrammarASTNode) -> bool {
+    node.children.iter().any(|c| {
+        matches!(c, ASTNodeOrToken::Token(t) if t.type_ == lexer::token::TokenType::Colon)
+    })
 }
 
 /// An empty `Block` whose value is `NilLit`.

--- a/code/packages/rust/semantic-ir/src/lib.rs
+++ b/code/packages/rust/semantic-ir/src/lib.rs
@@ -65,8 +65,8 @@ pub use limits::MAX_IR_DEPTH;
 pub use manifest::{Feature, FeatureManifest};
 pub use metadata::{Metadata, CURRENT_SIR_VERSION};
 pub use nodes::{
-    Block, Capture, CaptureValue, ExportName, Expr, Function, Global, Import, ImportName, Module,
-    Param, ParamKind, RescueClause, Scope, Stmt,
+    Block, Capture, CaptureValue, ExportName, Expr, Function, Global, Import, ImportName, MapEntry,
+    Module, Param, ParamKind, RescueClause, Scope, Stmt,
 };
 pub use span::Span;
 pub use text::{print_block, print_expr, print_function, print_module};

--- a/code/specs/SIR17-python-to-semantic-ir.md
+++ b/code/specs/SIR17-python-to-semantic-ir.md
@@ -113,6 +113,32 @@ the function's captures from the currently visible enclosing values).
 `MutualRecursion` is declared when two top-level functions transitively
 call each other (a self-recursive 1-cycle does not count).
 
+**Implementation note (M5 — collections):** the `[...]` / `xs[i]` /
+`xs[i] = v` / `{k: v}` / `d[k]` / `d[k] = v` rows above are realised in
+M5, and `len(x)` is **refined**: it lowers to the dedicated `SeqLen` node
+(not `BuiltinCall("len")`) so backends can emit native length access, per
+the `SeqLen` node's own documentation (`len` arity must be exactly 1, and
+a local/param named `len` shadows the builtin → an indirect call).  The
+parser models a list display as `atom → list_expr`, a dict display as
+`atom → dict_or_set_expr → dict_or_set_body → dict_body` (a set display
+has *no* `dict_body` and is rejected), and a subscript as a trailing
+`suffix` on a `primary` (`primary → atom suffix*`); chained suffixes
+(`xs[i][j]`, `g()[0]`) fold left-to-right.
+
+*Subscript disambiguation.*  Python overloads `[]` for list indexing and
+dict lookup and the frontend has no type information, so this spec's
+`xs[i] → SeqIndex` / `d[k] → MapGet` rows are realised by a purely
+**syntactic** heuristic (matching the JS sibling): a **string-literal**
+index lowers to `MapGet` / `MapSet` (a map key); **any other** index
+lowers to `SeqIndex` / `SeqSet` (a sequence index).  This makes the
+canonical idioms (`xs[0]`, `d["name"]`) correct; a dict keyed by a
+variable / integer (`d[k]`, `counts[n]`) lowers as a sequence index,
+which the SIR runtime's duck-typed `[]` still executes correctly (both
+route through `__getitem__` / `__setitem__`).  The choice affects only the
+manifest feature (`Sequences` vs `Maps`), never runtime behaviour.
+Comprehensions, slicing (`xs[a:b]`), tuple / set literals, list/dict
+methods, and unpacking remain deferred (positioned errors).
+
 ## Return statement
 
 Python's `return` is a statement in the AST.  The SIR doesn't have a


### PR DESCRIPTION
Milestone M5 for the `python-to-semantic-ir` SIR17 frontend — **collections** (builds on merged M1-M4). The Python frontend now lowers real data programs — completing its v0 surface (M1-M5).

- List `[...]` → `SeqLit`; subscript `xs[i]` → `SeqIndex`; `len(xs)` → `SeqLen` (spec-preferred over `BuiltinCall("len")`; arity-checked; a local named `len` shadows it → indirect call); `xs[i]=v` → `SeqSet`.
- Dict `{k: v}` → `MapLit`; `d[k]` → `MapGet`; `d[k]=v` → `MapSet`. (Set displays rejected.)
- **Subscript disambiguation** (spec left open): string-literal index → MapGet/MapSet, else SeqIndex/SeqSet; documented.
- Adds a `MapEntry` re-export at the semantic-ir crate root (additive, non-breaking — needed to construct `MapLit` entries).

**Recursion guards (the recurring class — handled up front):** every new CST walk is iterative or depth-bounded via `MAX_EXPR_DEPTH`/`MAX_BLOCK_DEPTH`; `[[[...]]]`, `xs[xs[xs[...]]]`, `{"a":{"a":...}}` towers return positioned errors (regression tests). Security review confirmed.

**Tests:** 111 (incl. deep-nesting regressions + **Python e2e** goldens run via the PYTHONPATH-aware helper — build/index/sum a list, get/set a dict); clippy clean; security review passed.

Deferred (per the full-coverage mandate — direct-lowering or runtime-library): comprehensions, slicing, tuples/sets, list/dict methods (.append/.keys → runtime-library), unpacking. Isolated to `python-to-semantic-ir` (+ the small semantic-ir re-export).

🤖 Generated with [Claude Code](https://claude.com/claude-code)