### PR TITLE
feat(latex): \overbrace / \underbrace horizontal braces — LTX01 L2

### DIFF
--- a/code/packages/rust/latex/CHANGELOG.md
+++ b/code/packages/rust/latex/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to the full-fidelity LaTeX parser crate.
 
+## [0.17.0] — 2026-06-30
+
+### Added — horizontal braces (`\overbrace` / `\underbrace`)
+
+- The parser now accepts `\overbrace{body}` and `\underbrace{body}` — a horizontal brace drawn over
+  or under the body, optionally labelled by a trailing `^{label}` (overbrace) / `_{label}`
+  (underbrace) that sits over/under the brace. As with the extensible arrows, there is **no new AST
+  node**: a brace is exactly an annotation stacked on the body, so it lowers onto the existing
+  `Overset`/`Underset` nodes over the Unicode brace glyph (`⏞` U+23DE / `⏟` U+23DF):
+  - `\overbrace{a+b}` → `Overset { over: ⏞, base: a+b }`
+  - `\overbrace{x+y}^{n}` → `Overset { over: n, base: Overset { over: ⏞, base: x+y } }` (label over
+    brace over body); `\underbrace{a}_{k}` is the under-side twin.
+- The optional label is consumed inside the brace parse (peeking for `^`/`_`) so it stacks centered
+  on the brace, mirroring how the xarrows consume their `[below]`/`{above}` labels — rather than
+  being attached as an ordinary raised/lowered script by the postfix mechanism.
+- Reuses the existing `Overset`/`Underset` `to_latex` and neutral-frontend lowering, so **no
+  frontend change**: `\overbrace`/`\underbrace` reach the neutral `MathExpr::Overset`/`Underset` for
+  free. Round-trips through `to_latex` (the surface normalises to `\overset`/`\underset`, which
+  re-parse to the identical tree). 7 new tests (parse, labelled, in-context, round-trip, missing-body
+  error); the `{body}` is mandatory and its absence is a clean spanned error, never a panic.
+- `latex` 0.16.0 → 0.17.0.
+
 ## [0.16.0] — 2026-06-30
 
 ### Added — extensible / labelled arrows (`\xrightarrow` & friends)

--- a/code/packages/rust/latex/Cargo.toml
+++ b/code/packages/rust/latex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latex"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 description = "A full-fidelity LaTeX parser (documents and math): a catcode-driven, text-mode-primary tokenizer and (in later layers) a structural + math parser producing a faithful AST. Standalone and reusable; will also implement the math-frontend MathFrontend trait."
 license = "MIT"

--- a/code/packages/rust/latex/README.md
+++ b/code/packages/rust/latex/README.md
@@ -32,7 +32,7 @@ with a **text-mode-primary** mode stack (LaTeX starts in text mode; math is ente
 |-------|----------|--------|
 | **L0 tokenizer** | catcode state machine → flat `Token` stream w/ byte spans | ✅ |
 | **L1 structural** | groups, `\cmd[opt]{arg}`, `\begin{env}…\end{env}`, text runs, raw math islands, `to_latex()` round-trip | ✅ |
-| **L2 math** | math AST (frac, binom, roots, scripts, big ops, functions, accents, `\left\right` fences, relations, `\overset`/`\underset`/`\stackrel` stacking and `\xrightarrow`-family extensible labelled arrows), precedence-climbing parser, `to_latex()` round-trip | ✅ |
+| **L2 math** | math AST (frac, binom, roots, scripts, big ops, functions, accents, `\left\right` fences, relations, `\overset`/`\underset`/`\stackrel` stacking, `\xrightarrow`-family extensible labelled arrows, and `\overbrace`/`\underbrace` horizontal braces), precedence-climbing parser, `to_latex()` round-trip | ✅ |
 | **L3 environments** | math env family — `matrix`/`pmatrix`/`bmatrix`/`vmatrix`/`cases`/`aligned`/`align` plus `array`/`subarray` (mandatory `{col-spec}`) split on `&` and `\\` → `MathNode::Matrix`, round-trip; nesting + scripts | ✅ |
 | **L4 macros** | `\newcommand`/`\renewcommand`/`\providecommand` with positional `#1`..`#9`; bounded recursive expansion via `expand()` (L4a) | ✅ |
 | **L5 text breadth** | `\verb`/`verbatim` raw (L5a/b) + text accents `\'e`/`\c{c}` via `recognize_accents` (L5c) + sectioning/refs/preamble/font via `recognize_structure` (L5d) | ✅ |

--- a/code/packages/rust/latex/src/math.rs
+++ b/code/packages/rust/latex/src/math.rs
@@ -318,6 +318,13 @@ fn xarrow_base(name: &str) -> Option<&'static str> {
         _ => return None,
     })
 }
+/// The horizontal-brace glyphs `\overbrace` / `\underbrace` lower onto (U+23DE TOP CURLY BRACKET /
+/// U+23DF BOTTOM CURLY BRACKET) — the standard Unicode over/under-brace, carried as a plain `Sym`
+/// so the existing `Overset`/`Underset` machinery (and its `to_latex`/frontend lowering) needs no
+/// change. See the `\overbrace`/`\underbrace` branch in [`Parser::parse_command`].
+const OVERBRACE: &str = "\u{23DE}";
+const UNDERBRACE: &str = "\u{23DF}";
+
 /// Math environments with `&`/`\\` row/column structure (L3). Case-sensitive — `bmatrix`
 /// (square brackets) and `Bmatrix` (braces) are different environments. The `array`/`subarray`
 /// grids take a **mandatory** column-spec argument (`\begin{array}{cc}`) — see
@@ -689,6 +696,40 @@ impl<'a> MathParser<'a> {
             let under = self.read_arg()?;
             let base = self.read_arg()?;
             return Ok(MathNode::Underset { under: Box::new(under), base: Box::new(base) });
+        }
+        // `\overbrace{body}` / `\underbrace{body}` — a horizontal brace drawn over/under the body,
+        // optionally labelled by a trailing `^{label}` (overbrace) / `_{label}` (underbrace) that
+        // sits over/under the brace. We lower to the existing Overset/Underset nodes on the brace
+        // glyph (⏞ U+23DE / ⏟ U+23DF), reusing the same machinery as `\overset` and the xarrows, so
+        // the neutral frontend lowering needs no change. `\overbrace{x}` → `Overset{⏞, x}`;
+        // `\overbrace{x}^{n}` → `Overset{n, Overset{⏞, x}}` (label over brace over body).
+        if name == "overbrace" {
+            self.bump();
+            let body = self.read_arg()?;
+            let braced = MathNode::Overset {
+                over: Box::new(MathNode::Sym(OVERBRACE.to_string())),
+                base: Box::new(body),
+            };
+            if matches!(self.peek().kind, TokenKind::Superscript) {
+                self.bump();
+                let label = self.parse_script_arg()?;
+                return Ok(MathNode::Overset { over: Box::new(label), base: Box::new(braced) });
+            }
+            return Ok(braced);
+        }
+        if name == "underbrace" {
+            self.bump();
+            let body = self.read_arg()?;
+            let braced = MathNode::Underset {
+                under: Box::new(MathNode::Sym(UNDERBRACE.to_string())),
+                base: Box::new(body),
+            };
+            if matches!(self.peek().kind, TokenKind::Subscript) {
+                self.bump();
+                let label = self.parse_script_arg()?;
+                return Ok(MathNode::Underset { under: Box::new(label), base: Box::new(braced) });
+            }
+            return Ok(braced);
         }
         // `\xrightarrow[below]{above}` and friends — an extensible/labelled arrow. The optional
         // `[below]` group sits under the arrow, the mandatory `{above}` group over it. We lower to
@@ -1729,6 +1770,97 @@ mod tests {
         assert!(parse_math(r"\xrightarrow").is_err());
         assert!(parse_math(r"\xrightarrow[n]").is_err()); // optional present, mandatory missing
         assert!(parse_math(r"\xrightarrow[n{f}").is_err()); // unterminated optional label
+    }
+
+    // ---- horizontal braces (\overbrace / \underbrace) --------------------------
+
+    #[test]
+    fn overbrace_is_the_brace_glyph_set_over_the_body() {
+        // `\overbrace{a+b}` ≡ the over-brace glyph set OVER the body.
+        let n = parse_math(r"\overbrace{a+b}").unwrap();
+        match &n {
+            MathNode::Overset { over, base } => {
+                assert_eq!(**over, sym(OVERBRACE));
+                assert!(matches!(**base, MathNode::Bin(MBinOp::Add, ..)));
+            }
+            other => panic!("expected Overset, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn underbrace_is_the_brace_glyph_set_under_the_body() {
+        let n = parse_math(r"\underbrace{x}").unwrap();
+        assert_eq!(
+            n,
+            MathNode::Underset {
+                under: Box::new(sym(UNDERBRACE)),
+                base: Box::new(sym("x")),
+            }
+        );
+    }
+
+    #[test]
+    fn overbrace_label_stacks_over_the_brace() {
+        // `\overbrace{x+y}^{n}` → the label `n` sits over the brace, which sits over the body:
+        // Overset { over: n, base: Overset { over: ⏞, base: x+y } }.
+        let n = parse_math(r"\overbrace{x+y}^{n}").unwrap();
+        match &n {
+            MathNode::Overset { over, base } => {
+                assert_eq!(**over, sym("n"));
+                match &**base {
+                    MathNode::Overset { over: brace, base: body } => {
+                        assert_eq!(**brace, sym(OVERBRACE));
+                        assert!(matches!(**body, MathNode::Bin(MBinOp::Add, ..)));
+                    }
+                    other => panic!("expected inner Overset on the brace, got {other:?}"),
+                }
+            }
+            other => panic!("expected Overset, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn underbrace_label_stacks_under_the_brace() {
+        // `\underbrace{a}_{k}` → Underset { under: k, base: Underset { under: ⏟, base: a } }.
+        let n = parse_math(r"\underbrace{a}_{k}").unwrap();
+        match &n {
+            MathNode::Underset { under, base } => {
+                assert_eq!(**under, sym("k"));
+                assert!(matches!(**base, MathNode::Underset { .. }));
+            }
+            other => panic!("expected Underset, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn brace_in_context_chains_with_neighbours() {
+        // A brace group is an atom, so it sits inline: `1 + \underbrace{x+y}_{s}`.
+        let n = parse_math(r"1 + \underbrace{x+y}_{s}").unwrap();
+        assert!(matches!(n, MathNode::Bin(MBinOp::Add, ..)));
+        assert!(n.to_latex().contains(r"\underset"));
+    }
+
+    #[test]
+    fn brace_round_trips_through_to_latex() {
+        // parse → to_latex → parse is a fixed point (the surface normalises to \overset/\underset).
+        for src in [
+            r"\overbrace{a+b}",
+            r"\underbrace{x}",
+            r"\overbrace{x+y}^{n}",
+            r"\underbrace{a+b+c}_{k}",
+        ] {
+            let once = parse_math(src).unwrap();
+            let twice = parse_math(&once.to_latex()).unwrap();
+            assert_eq!(once, twice, "round-trip changed the tree for {src:?}");
+        }
+    }
+
+    #[test]
+    fn brace_missing_mandatory_body_is_a_spanned_error() {
+        // The `{body}` group is mandatory (LaTeX would take the next atom); a trailing command with
+        // no argument is a clean error, never a panic.
+        assert!(parse_math(r"\overbrace").is_err());
+        assert!(parse_math(r"\underbrace").is_err());
     }
 
     // ---- deep-tree Drop safety -------------------------------------------------

--- a/code/specs/LTX01-full-latex-parser.md
+++ b/code/specs/LTX01-full-latex-parser.md
@@ -225,6 +225,16 @@ is text-primary, which is a different mode model.)
   `to_latex` normalises to the `\overset`/`\underset` form (a round-trip fixed point); a missing
   mandatory label is a spanned error, never a panic.
 
+  **Horizontal braces (latex 0.17.0):** `\overbrace{body}` / `\underbrace{body}` — a brace drawn
+  over/under the body, optionally labelled by a trailing `^{label}` (overbrace) / `_{label}`
+  (underbrace) that sits over/under the brace. Same desugaring as the arrows — **no new node**: a
+  brace is an annotation stacked on the body, lowering onto the existing `Overset`/`Underset` nodes
+  over the Unicode brace glyph (`⏞` U+23DE / `⏟` U+23DF). `\overbrace{a+b}` → `Overset { over: ⏞,
+  base: a+b }`; `\overbrace{x+y}^{n}` → `Overset { over: n, base: Overset { over: ⏞, base: x+y } }`
+  (the optional label is consumed inside the brace parse so it stacks centered on the brace, not as a
+  postfix raised script). The L6 lowering and `to_latex` therefore need **zero change**; round-trips
+  through `to_latex`, and a missing mandatory body is a spanned error, never a panic.
+
 **Asymptote (documented in README, not built):** runtime `\catcode`, `\expandafter`/
 `\noexpand`/`\csname`, arbitrary `\if…` programming, external `\input`/`\include`. Hit →
 `Unsupported { construct, span }`.


### PR DESCRIPTION
## What

Adds `\overbrace{body}` and `\underbrace{body}` to the `latex` crate's math parser (LTX01 L2) — a horizontal brace drawn over/under the body, optionally labelled by a trailing `^{label}` (overbrace) / `_{label}` (underbrace) that sits over/under the brace.

As with the extensible arrows (`\xrightarrow` &c.), there is **no new AST node**: a brace is exactly an annotation stacked on the body, so it lowers onto the existing `Overset`/`Underset` nodes over the Unicode brace glyph (`⏞` U+23DE / `⏟` U+23DF):

| LaTeX | AST |
|-------|-----|
| `\overbrace{a+b}` | `Overset { over: ⏞, base: a+b }` |
| `\overbrace{x+y}^{n}` | `Overset { over: n, base: Overset { over: ⏞, base: x+y } }` (label over brace over body) |
| `\underbrace{a}_{k}` | `Underset { under: k, base: Underset { under: ⏟, base: a } }` |

The optional label is consumed inside the brace parse (peeking for `^`/`_`) so it stacks centered on the brace — mirroring how the xarrows consume their `[below]`/`{above}` labels — rather than being attached as an ordinary postfix raised/lowered script.

## Why it's clean
- **No new node, no frontend change.** Reuses the existing `Overset`/`Underset` `to_latex` and neutral-frontend lowering, so `\overbrace`/`\underbrace` reach the neutral `MathExpr::Overset`/`Underset` for free (the same way `\xrightarrow` does).
- **Round-trips** through `to_latex` (the surface normalises to `\overset`/`\underset`, which re-parse to the identical tree — an AST fixed point).
- The `{body}` is **mandatory**; its absence is a clean spanned `ParseError`, never a panic.

## Tests / gates
- **165 tests + doctest** (7 new): brace-over/under-body, labelled (`^{n}`/`_{k}`), in-context chaining, round-trip, and missing-mandatory-body error.
- `cargo test -p latex` green; `cargo clippy -p latex -- -D warnings` clean.
- **Security review passed** (Rust: recursion/DoS, panics, forward progress, overflow) — no findings; the new branches add no unguarded recursion (they descend through the existing `MAX_DEPTH`-guarded expression parser) and no indexing/unwrap.

Spec `LTX01-full-latex-parser.md` + crate README/CHANGELOG updated; `latex` 0.16.0 → 0.17.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)