### PR TITLE
fix(sir-go): guard emitted runtime against cyclic Seq/Map (format/value_eq)

### DIFF
--- a/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
@@ -1,5 +1,61 @@
 # Changelog
 
+## 0.4.1 — harden emitted Go runtime against cyclic Seq/Map
+
+`*Seq`/`*Map` are shared, *mutable* handles, so an emitted Go program can
+build a cyclic structure (`xs = [0]; xs[0] = xs`).  Before this release the
+emitted runtime walked such values structurally with no cycle protection,
+so a cyclic value would make **`_sir_format`** recurse forever and overflow
+the stack while printing, and make **`_sir_value_eq`** recurse forever when
+comparing two *distinct* cyclic structures (a self-cycle was already short-
+circuited by the same-pointer fast path, but distinct cyclic operands were
+not).  This mirrors the Rust backend's `0.4.1` cyclic-guard.
+
+This is a robustness fix only — the public runtime API and the printed form
+of every *non-cyclic* value are byte-identical (all existing tests pass
+unchanged).
+
+### Fixed
+
+- **`_sir_format` / `_sir_format_seq` / `_sir_format_map`** now thread a
+  visited-pointer set through a new `_sir_format_d(v, visited)` variant.
+  The set is a `map[Value]bool` keyed on the Seq/Map **pointer** — a
+  `*Seq`/`*Map` boxed in the `Value` (`interface{}`) compares by pointer
+  identity, the idiomatic Go way to key on handle identity.  A handle is
+  inserted on entry and removed on exit, so it is only "seen" along the
+  *current* path: a true cycle re-entering a handle within its own subtree
+  prints a placeholder (`[...]` for a seq, `{...}` for a map) and returns
+  instead of recursing, while a value reached twice by sibling (non-cyclic)
+  paths still prints in full.  `_sir_format_pair` threads the set too (a
+  pair can hold a cyclic seq/map).  The public `_sir_format(Value) string`
+  signature is unchanged — it allocates a fresh visited set and delegates.
+- **`_sir_value_eq`** keeps the same-pointer (`as == bs`) identity fast
+  path and adds a co-inductive `pending` set of handle-pairs currently
+  being compared (a `map[[2]Value]bool` keyed on the two boxed pointers)
+  via a new `_sir_value_eq_d(a, b, pending)` variant: re-encountering a
+  pair already in flight (a cycle matched in lock-step) is treated as
+  equal, bounding the deep comparison of two distinct cyclic operands so it
+  always terminates.
+- **`_sir_map_get` / `_sir_map_set` / `_sir_map_put`** need no
+  restructuring: Go has no `RefCell`-style aliasing-borrow check (the Rust
+  backend's "already mutably borrowed" panic on a self-referential key has
+  no Go analogue), and the remaining hazard — a cyclic key making
+  `_sir_value_eq` recurse forever — is now handled by that function's
+  co-inductive guard.  A comment on `_sir_map_put` records this.
+
+### Tests
+
+- New `tests/compile_and_run_cyclic.rs` integration test: hand-builds a
+  module that constructs a cyclic seq (`xs = [0]; xs[0] = xs; print(xs)`),
+  emits Go, `go run`s it (gated on `go` availability), and asserts the
+  program *terminates* and prints the `[[...]]` placeholder.  It also
+  checks that `_sir_value_eq` terminates on both a self-cyclic operand (via
+  the same-pointer fast path) and two *distinct* cyclic structures (via the
+  co-inductive guard), both `#t`.
+- Two new runtime unit tests assert the cycle-guard plumbing is present in
+  the emitted runtime string (`_sir_format_d` / `_sir_value_eq_d` and the
+  placeholder literals).
+
 ## 0.4.0 — SIR16 Sequences + Maps — completes Go v1 parity (A6)
 
 The final two SIR16 (v1) features land in the Go backend.  With them the

--- a/code/packages/rust/semantic-ir-to-go/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-go/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-go"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 description = "Semantic IR → self-contained Go source code (SIR15). Fourth backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-go/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/runtime.rs
@@ -280,6 +280,20 @@ func _sir_eq(args []Value) Value {
 //   | both maps         | same handle, or entry-wise equal (in order) |
 //   | otherwise         | Go `==` (bool/nil/string/closure identity)  |
 func _sir_value_eq(a Value, b Value) bool {
+	// Cycle safety: two *distinct* cyclic structures (e.g. `xs[0]=xs`
+	// and `ys[0]=ys`, separate handles) would make a naive deep walk
+	// recurse forever — the same-pointer fast path only catches a value
+	// compared against *itself*.  We bound the walk co-inductively with a
+	// `pending` set of handle-pairs currently being compared: re-
+	// encountering a pair already in flight means we've closed a cycle in
+	// lock-step, so we treat that pair as equal (the standard co-inductive
+	// definition of bisimulation equality).  This terminates for *any*
+	// pair of finite-handle graphs.  The public signature is unchanged: it
+	// allocates a fresh `pending` set and delegates to the `_d` variant.
+	return _sir_value_eq_d(a, b, make(map[[2]Value]bool))
+}
+
+func _sir_value_eq_d(a Value, b Value, pending map[[2]Value]bool) bool {
 	if as, ok := a.(*Symbol); ok {
 		if bs, ok := b.(*Symbol); ok {
 			return as.Name == bs.Name
@@ -294,7 +308,7 @@ func _sir_value_eq(a Value, b Value) bool {
 	}
 	if ap, ok := a.(*Pair); ok {
 		if bp, ok := b.(*Pair); ok {
-			return _sir_value_eq(ap.Car, bp.Car) && _sir_value_eq(ap.Cdr, bp.Cdr)
+			return _sir_value_eq_d(ap.Car, bp.Car, pending) && _sir_value_eq_d(ap.Cdr, bp.Cdr, pending)
 		}
 		return false
 	}
@@ -311,15 +325,28 @@ func _sir_value_eq(a Value, b Value) bool {
 		if as == bs {
 			return true
 		}
+		// Already comparing this exact handle-pair higher up the stack ⇒
+		// we've matched in lock-step around a cycle.  Assume equal; a
+		// genuine difference is caught on a *non-cyclic* element
+		// elsewhere.  Key the pair on the boxed `Value`s so the two
+		// pointers compare by identity.
+		key := [2]Value{a, b}
+		if pending[key] {
+			return true
+		}
 		if len(as.Items) != len(bs.Items) {
 			return false
 		}
+		pending[key] = true
+		result := true
 		for i := range as.Items {
-			if !_sir_value_eq(as.Items[i], bs.Items[i]) {
-				return false
+			if !_sir_value_eq_d(as.Items[i], bs.Items[i], pending) {
+				result = false
+				break
 			}
 		}
-		return true
+		delete(pending, key)
+		return result
 	}
 	if am, ok := a.(*Map); ok {
 		bm, ok := b.(*Map)
@@ -329,16 +356,24 @@ func _sir_value_eq(a Value, b Value) bool {
 		if am == bm {
 			return true
 		}
+		key := [2]Value{a, b}
+		if pending[key] {
+			return true
+		}
 		if len(am.Entries) != len(bm.Entries) {
 			return false
 		}
+		pending[key] = true
+		result := true
 		for i := range am.Entries {
-			if !_sir_value_eq(am.Entries[i].Key, bm.Entries[i].Key) ||
-				!_sir_value_eq(am.Entries[i].Val, bm.Entries[i].Val) {
-				return false
+			if !_sir_value_eq_d(am.Entries[i].Key, bm.Entries[i].Key, pending) ||
+				!_sir_value_eq_d(am.Entries[i].Val, bm.Entries[i].Val, pending) {
+				result = false
+				break
 			}
 		}
-		return true
+		delete(pending, key)
+		return result
 	}
 	return a == b
 }
@@ -414,7 +449,34 @@ func _sir_print(args []Value) Value {
 	return nil
 }
 
+// ── format (cycle-safe) ────────────────────────────────────────
+//
+// `*Seq`/`*Map` are *shared, mutable* handles, so an emitted program
+// can build a cyclic structure (`xs = []; xs[0] = xs`).  A naive
+// structural walk would recurse forever and overflow the stack.  We
+// guard the recursion with a `visited` set of the Seq/Map *pointers*
+// currently on the active path: a handle is inserted on entry and
+// removed on exit.
+//
+// Keying on the pointer is idiomatic in Go — a `*Seq`/`*Map` boxed in
+// the `Value` (`interface{}`) compares by pointer identity, so it can be
+// used directly as a `map[Value]bool` key.  Two `Value`s alias the same
+// backing store iff they are the equal interface value (same dynamic
+// type + same pointer).
+//
+// Removing on exit (rather than leaving it set for the whole walk) is
+// deliberate — it means a value reached twice by two *sibling*
+// (non-cyclic) paths still prints in full both times; only a handle that
+// re-appears *within its own subtree* (a true cycle) is short-circuited
+// to a placeholder (`[...]` for a seq, `{...}` for a map).
+//
+// `_sir_format(Value) string` keeps its public signature: it allocates a
+// fresh visited set and delegates to the `_d` variant.
 func _sir_format(v Value) string {
+	return _sir_format_d(v, make(map[Value]bool))
+}
+
+func _sir_format_d(v Value, visited map[Value]bool) string {
 	if v == nil {
 		return "nil"
 	}
@@ -440,13 +502,27 @@ func _sir_format(v Value) string {
 		return s.Name
 	}
 	if p, ok := v.(*Pair); ok {
-		return _sir_format_pair(p)
+		return _sir_format_pair(p, visited)
 	}
 	if s, ok := v.(*Seq); ok {
-		return _sir_format_seq(s)
+		// Already on the active path ⇒ cycle.  Print a placeholder
+		// instead of recursing forever.
+		if visited[v] {
+			return "[...]"
+		}
+		visited[v] = true
+		out := _sir_format_seq(s, visited)
+		delete(visited, v)
+		return out
 	}
 	if m, ok := v.(*Map); ok {
-		return _sir_format_map(m)
+		if visited[v] {
+			return "{...}"
+		}
+		visited[v] = true
+		out := _sir_format_map(m, visited)
+		delete(visited, v)
+		return out
 	}
 	if _, ok := v.(*Closure); ok {
 		return "<closure>"
@@ -455,26 +531,26 @@ func _sir_format(v Value) string {
 }
 
 // Sequences print like a bracketed list: `[1, 2, 3]`.
-func _sir_format_seq(s *Seq) string {
+func _sir_format_seq(s *Seq, visited map[Value]bool) string {
 	out := "["
 	for i, item := range s.Items {
 		if i > 0 {
 			out += ", "
 		}
-		out += _sir_format(item)
+		out += _sir_format_d(item, visited)
 	}
 	return out + "]"
 }
 
 // Maps print like a brace-wrapped entry list in insertion order:
 // `{a: 1, b: 2}`.
-func _sir_format_map(m *Map) string {
+func _sir_format_map(m *Map, visited map[Value]bool) string {
 	out := "{"
 	for i, e := range m.Entries {
 		if i > 0 {
 			out += ", "
 		}
-		out += _sir_format(e.Key) + ": " + _sir_format(e.Val)
+		out += _sir_format_d(e.Key, visited) + ": " + _sir_format_d(e.Val, visited)
 	}
 	return out + "}"
 }
@@ -516,19 +592,23 @@ func _sir_format_float(x float64) string {
 	return s + ".0"
 }
 
-func _sir_format_pair(p *Pair) string {
-	out := "(" + _sir_format(p.Car)
+// `Pair`s are immutable (no shared mutable handle), so a pair-chain can
+// never form a cycle on its own.  It can, however, *contain* a cyclic
+// seq/map in a `car`/`cdr`, so we still thread `visited` through to the
+// element formatters.
+func _sir_format_pair(p *Pair, visited map[Value]bool) string {
+	out := "(" + _sir_format_d(p.Car, visited)
 	rest := p.Cdr
 	for {
 		if next, ok := rest.(*Pair); ok {
-			out += " " + _sir_format(next.Car)
+			out += " " + _sir_format_d(next.Car, visited)
 			rest = next.Cdr
 			continue
 		}
 		if rest == nil {
 			break
 		}
-		out += " . " + _sir_format(rest)
+		out += " . " + _sir_format_d(rest, visited)
 		break
 	}
 	return out + ")"
@@ -688,6 +768,14 @@ func _sir_map_set(mp Value, key Value, value Value) Value {
 // Shared insert-or-overwrite for `_sir_map_lit`/`_sir_map_set`: a new key
 // appends (preserving insertion order); an existing key (by
 // `_sir_value_eq`) overwrites in place without disturbing order.
+//
+// Cycle safety: unlike the Rust backend (whose `RefCell` would panic with
+// "already mutably borrowed" if `value_eq` re-entered the map being
+// mutated), Go has no aliasing-borrow check, so comparing a self-
+// referential key here is sound on its own.  The remaining hazard — a
+// cyclic key making `_sir_value_eq` recurse forever — is handled by that
+// function's co-inductive `pending` guard, so a self-referential key
+// (`d["self"] = d`) terminates.  No restructuring is needed here.
 func _sir_map_put(m *Map, key Value, value Value) {
 	for i := range m.Entries {
 		if _sir_value_eq(m.Entries[i].Key, key) {
@@ -833,6 +921,30 @@ mod tests {
     fn runtime_formats_seq_and_map() {
         assert!(RUNTIME.contains("func _sir_format_seq"));
         assert!(RUNTIME.contains("func _sir_format_map"));
+    }
+
+    #[test]
+    fn runtime_format_is_cycle_safe() {
+        // The public `_sir_format(Value) string` delegates to a
+        // visited-set variant that threads a `map[Value]bool` of the
+        // Seq/Map pointers currently on the active path, emitting a
+        // placeholder on re-entry (a true cycle) so a cyclic value
+        // terminates instead of overflowing the stack.
+        assert!(RUNTIME.contains("func _sir_format_d(v Value, visited map[Value]bool) string"));
+        assert!(RUNTIME.contains("return _sir_format_d(v, make(map[Value]bool))"));
+        assert!(RUNTIME.contains("\"[...]\""));
+        assert!(RUNTIME.contains("\"{...}\""));
+    }
+
+    #[test]
+    fn runtime_value_eq_is_cycle_safe() {
+        // `_sir_value_eq` keeps the same-pointer fast path and adds a
+        // co-inductive `pending` set of handle-pairs (`map[[2]Value]bool`)
+        // currently being compared, so two *distinct* cyclic structures
+        // terminate (lock-step cycle ⇒ equal).
+        assert!(RUNTIME.contains("func _sir_value_eq_d(a Value, b Value, pending map[[2]Value]bool) bool"));
+        assert!(RUNTIME.contains("return _sir_value_eq_d(a, b, make(map[[2]Value]bool))"));
+        assert!(RUNTIME.contains("key := [2]Value{a, b}"));
     }
 
     #[test]

--- a/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_cyclic.rs
+++ b/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_cyclic.rs
@@ -1,0 +1,204 @@
+//! Robustness proof: an emitted Go program that builds a **cyclic**
+//! Seq structure must *terminate gracefully* instead of stack-overflowing
+//! in `_sir_format` (and `_sir_value_eq` must terminate on cyclic
+//! operands too).
+//!
+//! `*Seq`/`*Map` are shared, *mutable* handles, so a generated program
+//! can tie a knot:
+//!
+//!   ```text
+//!   xs = [0]
+//!   xs[0] = xs        # SeqSet whose value aliases the seq itself
+//!   print(xs)         # would recurse forever without a cycle guard
+//!   ```
+//!
+//! The hardened runtime threads a visited-pointer set (`map[Value]bool`
+//! keyed on the Seq/Map pointer) through
+//! `_sir_format`/`_sir_format_seq`/`_sir_format_map`, printing a `[...]`
+//! placeholder on re-entry of a handle already on the active path.  This
+//! test hand-builds exactly that module, emits Go, runs it with `go run`,
+//! and asserts the program **terminates** and prints the placeholder
+//! rather than crashing or looping.
+//!
+//! Mirrors `compile_and_run_seq_maps.rs` for the toolchain plumbing (Go
+//! discovery, host-tool skips).  A missing `go` toolchain logs a skip
+//! rather than reddening the build.
+
+use std::process::Command;
+
+use semantic_ir::{
+    Block, Effect, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, Scope,
+    Span, Stmt,
+};
+use semantic_ir_to_go::compile;
+
+fn s() -> Span {
+    Span::synthetic()
+}
+
+fn ilit(v: i64) -> Expr {
+    Expr::IntLit { value: v, span: s() }
+}
+
+fn local(name: &str) -> Expr {
+    Expr::VarRef { name: name.into(), scope: Scope::Local, span: s() }
+}
+
+fn print_stmt(expr: Expr) -> Stmt {
+    Stmt::ExprStmt {
+        expr: Expr::BuiltinCall {
+            name: "print".into(),
+            args: vec![expr],
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            span: s(),
+        },
+        span: s(),
+    }
+}
+
+fn let_local(name: &str, value: Expr) -> Stmt {
+    Stmt::LetBinding { name: name.into(), sir_type: None, value, span: s() }
+}
+
+fn seq(items: Vec<Expr>) -> Expr {
+    Expr::SeqLit { items, span: s() }
+}
+
+/// Build a module whose `main` constructs a self-referential sequence
+/// and prints it:
+///
+///   1. `xs = [0]`
+///   2. `xs[0] = xs`        (SeqSet whose value aliases `xs` ⇒ a cycle)
+///   3. `print(xs)`          → must print `[[...]]` (placeholder) and
+///      terminate — `xs == [xs]`, so the inner self-reference becomes
+///      the `[...]` placeholder.
+///   4. `print(xs[0] == xs)` → identity short-circuit ⇒ `#t`,
+///      proving `value_eq` on a *self*-cyclic operand terminates.
+///   5. `ys = [0]; ys[0] = ys; print(xs == ys)` → two **distinct**
+///      cyclic structures (separate handles, so the same-pointer fast
+///      path does *not* fire).  The co-inductive visited-pair guard must
+///      still terminate; structurally these are the same shape ⇒ `#t`.
+fn cyclic_module() -> Module {
+    let eq_expr = |a: Expr, b: Expr| Expr::BuiltinCall {
+        name: "=".into(),
+        args: vec![a, b],
+        effects: EffectSet::PURE,
+        span: s(),
+    };
+    let stmts = vec![
+        // 1. xs = [0]
+        let_local("xs", seq(vec![ilit(0)])),
+        // 2. xs[0] = xs   (the knot)
+        Stmt::SeqSet { seq: local("xs"), index: ilit(0), value: local("xs"), span: s() },
+        // 3. print(xs)  -> "[[...]]"
+        print_stmt(local("xs")),
+        // 4. print(xs[0] == xs) -> "#t"  (value_eq, self-cycle, same ptr)
+        print_stmt(eq_expr(
+            Expr::SeqIndex {
+                seq: Box::new(local("xs")),
+                index: Box::new(ilit(0)),
+                span: s(),
+            },
+            local("xs"),
+        )),
+        // 5. ys = [0]; ys[0] = ys; print(xs == ys) -> "#t"
+        //    Distinct handles ⇒ exercises the co-inductive deep walk.
+        let_local("ys", seq(vec![ilit(0)])),
+        Stmt::SeqSet { seq: local("ys"), index: ilit(0), value: local("ys"), span: s() },
+        print_stmt(eq_expr(local("xs"), local("ys"))),
+    ];
+
+    Module {
+        name: "cyclic_demo".into(),
+        manifest: FeatureManifest::from_features(&[
+            Feature::Sequences,
+            Feature::MutableBindings,
+        ]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block { stmts, value: Expr::NilLit { span: s() }, span: s() },
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            metadata: Metadata::new(),
+            span: s(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("test")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+fn go_available() -> bool {
+    Command::new("go")
+        .arg("version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+#[test]
+fn cyclic_seq_compiles_runs_and_terminates() {
+    if !go_available() {
+        eprintln!("skipping: go not on PATH");
+        return;
+    }
+
+    // 1. Emit.
+    let artifact = compile(&cyclic_module()).expect("module should compile to Go source");
+
+    // 2. Write the source to a unique temp file.  `go run` requires a
+    //    `.go` extension.
+    let dir = std::env::temp_dir();
+    let nonce = std::process::id();
+    let src_path = dir.join(format!("sir_go_cyclic_{nonce}.go"));
+    std::fs::write(&src_path, &artifact.source).expect("write temp source");
+
+    // 3. Compile + run with `go run`.  The whole point of the guard: this
+    //    must *terminate*.  A stack-overflow would surface as a non-success
+    //    exit status (or, for an infinite loop, the harness would hang) —
+    //    so a clean exit is itself the assertion.
+    let run_out = Command::new("go")
+        .arg("run")
+        .arg(&src_path)
+        .output()
+        .expect("invoke go run");
+
+    if !run_out.status.success() {
+        let stderr = String::from_utf8_lossy(&run_out.stderr);
+        let _ = std::fs::remove_file(&src_path);
+        panic!(
+            "emitted Go failed to compile/run (cycle guard failed to keep it alive):\n--- stderr ---\n{stderr}\n--- source ---\n{}",
+            artifact.source,
+        );
+    }
+
+    // 4. Assert the observable behaviour.
+    let stdout = String::from_utf8_lossy(&run_out.stdout);
+    let lines: Vec<&str> = stdout.lines().collect();
+
+    assert_eq!(lines.len(), 3, "expected three printed lines; full stdout:\n{stdout}");
+    // `xs == [xs]`, so printing the outer seq opens `[`, then meets `xs`
+    // again (now on the active path) and emits the `[...]` placeholder,
+    // then closes `]` — i.e. `[[...]]`.  The key property is that it
+    // *terminates* and *contains* the placeholder rather than looping.
+    assert_eq!(lines[0], "[[...]]", "cyclic seq should print with a [...] placeholder");
+    assert!(
+        lines[0].contains("[...]"),
+        "cyclic seq output must contain the [...] placeholder; got {:?}",
+        lines[0],
+    );
+    // Both equality checks (self-cycle via same-pointer fast path; distinct
+    // cycles via the co-inductive visited-pair guard) must terminate as
+    // `#t`.
+    assert_eq!(lines[1], "#t", "self-cyclic value_eq should be #t and terminate");
+    assert_eq!(lines[2], "#t", "distinct-cycle value_eq should be #t and terminate");
+
+    // 5. Best-effort cleanup (ignore errors — temp dir is ephemeral).
+    let _ = std::fs::remove_file(&src_path);
+}


### PR DESCRIPTION
Go counterpart of the merged Rust cyclic-guard (#7046). The Go backend's emitted runtime has the same hand-rolled recursive `_sir_format`/`_sir_value_eq` over `*Seq`/`*Map`, so a generated Go program that builds a cyclic structure (`xs[0] = xs`) would stack-overflow. Completes the cyclic-robustness follow-up (TS/Python backends use native runtime cycle handling, so need no change).

- `_sir_format`/`_sir_format_seq`/`_sir_format_map`/`_sir_format_pair`: path-scoped visited-pointer set (`map[Value]bool` keyed on the `*Seq`/`*Map` pointer; added on enter / deleted on exit). A true subtree cycle prints `[...]`/`{...}`; non-cyclic sibling repeats still print in full.
- `_sir_value_eq`: co-inductive `pending` set keyed on `[2]Value{a,b}` so two distinct cyclic structures terminate (bisimulation); same-pointer fast path kept; length/leaf mismatches still surface.
- Map ops need no restructuring (Go has no RefCell borrow hazard; the cyclic-key case is covered by the co-inductive guard).

**Non-cyclic output byte-identical** — public `_sir_format`/`_sir_value_eq` signatures unchanged (fresh set + delegate); acyclic input never triggers the short-circuits.

**Tests:** 50 unit + 4 `go run` integration (new `cyclic_seq_compiles_runs_and_terminates`: emits a cyclic seq, runs it, asserts it prints `[[...]]` and value_eq on self- and distinct-cycles both terminate; the existing exact-stdout test still passes); clippy clean; security review passed. Isolated to `semantic-ir-to-go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)