### PR TITLE
feat(java-sql-codegen): Java bytecode code generator (Level 1 prerequisite)

### DIFF
--- a/.claude/mini-sqlite-loop-state.json
+++ b/.claude/mini-sqlite-loop-state.json
@@ -150,11 +150,11 @@
     {
       "id": "java-level1-sql-codegen",
       "title": "Java sql-codegen",
-      "status": "pending",
+      "status": "in-review",
       "depends_on": ["java-level1-sql-optimizer"],
-      "branch": null,
+      "branch": "mini-sqlite/java-level1-sql-codegen",
       "pr_number": null,
-      "notes": "Port Python sql_codegen to Java."
+      "notes": "PR open 2026-06-30. 36 tests (JaCoCo ≥80%). Compiles OptimizedPlan → flat bytecode Program for SQL VM."
     },
     {
       "id": "java-level1-sql-vm",

--- a/code/packages/java/sql-codegen/BUILD
+++ b/code/packages/java/sql-codegen/BUILD
@@ -1,0 +1,3 @@
+(cd ../sql-planner && gradle jar --quiet)
+(cd ../sql-optimizer && gradle jar --quiet)
+gradle test

--- a/code/packages/java/sql-codegen/BUILD_windows
+++ b/code/packages/java/sql-codegen/BUILD_windows
@@ -1,0 +1,3 @@
+(cd ../sql-planner && gradle jar --quiet)
+(cd ../sql-optimizer && gradle jar --quiet)
+gradle test

--- a/code/packages/java/sql-codegen/CHANGELOG.md
+++ b/code/packages/java/sql-codegen/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog — coding-adventures-sql-codegen
+
+All notable changes to this package are recorded here.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [0.1.0] — 2026-06-30
+
+### Added
+- Initial release of the Java SQL bytecode code generator (Level 1 prerequisite).
+- `SqlCodegen` class with three public entry points:
+  - `compile(LogicalPlan)` — optimises via `SqlOptimizer` then compiles
+  - `compileOptimized(OptimizedPlan)` — compile directly from an optimised plan
+  - `compileExpr(SqlExpr)` — compile a single scalar expression in isolation
+- `Instruction` sealed interface with 40+ typed instruction variants:
+  - Stack: `LoadConst`, `LoadColumn`, `Pop`
+  - Arithmetic/logic: `BinaryOp`, `UnaryOp`, `IsNull`, `IsNotNull`
+  - Predicates: `Between`, `InList`, `Like`, `CallScalar`
+  - Cursor: `OpenScan`, `AdvanceCursor`, `CloseScan`
+  - Row building: `BeginRow`, `EmitColumn`, `EmitRow`, `SetResultSchema`
+  - Aggregates: `InitAgg`, `UpdateAgg`, `FinalizeAgg`
+  - Group keys: `SaveGroupKey`, `LoadGroupKey`, `AdvanceGroupKey`
+  - Post-processing: `SortResult`, `LimitResult`, `DistinctResult`
+  - LEFT JOIN tracking: `JoinBeginRow`, `JoinSetMatched`, `JoinIfMatched`
+  - DML: `InsertRow`, `UpdateRows`, `DeleteRows`
+  - DDL: `CreateTable`, `DropTable`
+  - Control flow: `Label`, `Jump`, `JumpIfFalse`, `JumpIfTrue`, `Halt`
+- `Program` record: flat instruction list + label-to-index map + result schema.
+- `SortKey` record for ORDER BY columns with direction and null ordering.
+- Enums: `BinaryOpCode`, `UnaryOpCode`, `AggFunc`, `Direction`, `NullsOrder`.
+- Two-phase aggregate compilation: accumulation loop (InitAgg/UpdateAgg) +
+  group iteration loop (AdvanceGroupKey/FinalizeAgg/EmitRow).
+- INNER, CROSS, and LEFT/RIGHT outer join compilation with nested-loop code generation.
+- Post-processing wrapper peeling: Sort/Limit/Distinct stripped from plan top
+  and appended as post-loop instructions after the scan completes.
+- DML compilation: INSERT multi-row, UPDATE/DELETE with scan loop + predicate filter.
+- DDL compilation: CREATE TABLE and DROP TABLE emit a single instruction + Halt.
+- 36 JUnit 5 unit tests; JaCoCo line coverage ≥ 80%.
+- `build.gradle.kts` with Java 21, JaCoCo 0.8.12, JUnit Jupiter 5.11.4.
+- `settings.gradle.kts` declaring `includeBuild` for sql-planner and sql-optimizer.

--- a/code/packages/java/sql-codegen/README.md
+++ b/code/packages/java/sql-codegen/README.md
@@ -1,0 +1,201 @@
+# coding-adventures-sql-codegen
+
+Java bytecode compiler for the SQL VM. Transforms an `OptimizedPlan` (from
+`coding-adventures-sql-optimizer`) into a flat `Program` consisting of typed
+bytecode instructions, a label-to-index jump table, and an output column schema.
+
+## Where it fits
+
+```
+sql-parser (stub)
+    └─▶ sql-planner   (LogicalPlan)
+            └─▶ sql-optimizer   (OptimizedPlan)
+                    └─▶ sql-codegen   (Program)  ◀── this package
+                                └─▶ sql-vm   (executes Program)
+```
+
+## Usage
+
+```java
+import com.codingadventures.sqlcodegen.SqlCodegen;
+import com.codingadventures.sqlcodegen.SqlCodegen.Program;
+import com.codingadventures.sqlplanner.SqlPlanner;
+import com.codingadventures.sqloptimizer.SqlOptimizer;
+
+// Compile from a LogicalPlan (optimizer is applied automatically)
+Program prog = SqlCodegen.compile(logicalPlan);
+
+// Compile from an already-optimised plan
+SqlOptimizer.OptimizedPlan opt = SqlOptimizer.optimize(logicalPlan);
+Program prog2 = SqlCodegen.compileOptimized(opt);
+
+// Inspect the compiled program
+System.out.println("Instructions: " + prog.instructions().size());
+System.out.println("Schema:        " + prog.resultSchema());
+prog.instructions().forEach(System.out::println);
+```
+
+## Program structure
+
+A `Program` is a triple:
+
+| Field | Type | Description |
+|---|---|---|
+| `instructions` | `List<Instruction>` | Flat ordered bytecode list |
+| `labels` | `Map<String, Integer>` | Label name → instruction index |
+| `resultSchema` | `List<String>` | Output column names in order |
+
+## Instruction set overview
+
+### Stack operations
+| Instruction | Effect |
+|---|---|
+| `LoadConst(value)` | Push a compile-time constant |
+| `LoadColumn(cursorId, column)` | Push a column value from cursor |
+| `Pop()` | Discard stack top |
+| `BinaryOp(op)` | Pop 2, push result |
+| `UnaryOp(op)` | Pop 1, push result |
+| `IsNull()` / `IsNotNull()` | Pop 1, push boolean |
+| `Between()` | Pop 3 (value, low, high), push boolean |
+| `InList(n)` | Pop n items then needle, push boolean |
+| `Like(negated)` | Pop value and pattern, push boolean |
+| `CallScalar(func, nArgs)` | Pop nArgs, call scalar func, push result |
+
+### Cursor operations
+| Instruction | Effect |
+|---|---|
+| `OpenScan(cursorId, table)` | Open a full table scan |
+| `AdvanceCursor(cursorId, onExhausted)` | Move to next row; jump if done |
+| `CloseScan(cursorId)` | Release the cursor |
+
+### Row building
+| Instruction | Effect |
+|---|---|
+| `SetResultSchema(columns)` | Declare output column names (emitted once) |
+| `BeginRow()` | Start assembling an output row |
+| `EmitColumn(name)` | Pop and store as named column |
+| `EmitRow()` | Finalise and emit the assembled row |
+
+### Aggregate operations
+| Instruction | Effect |
+|---|---|
+| `InitAgg(slot, func, distinct)` | Reset accumulator slot |
+| `UpdateAgg(slot)` | Feed top-of-stack into accumulator |
+| `FinalizeAgg(slot, func)` | Push final aggregate value |
+| `SaveGroupKey(n)` | Pop n values as current group key |
+| `LoadGroupKey(i)` | Push i-th group key value |
+| `AdvanceGroupKey(label, hasGroupBy)` | Advance to next group; jump when done |
+
+### Post-processing (applied after scan loop)
+| Instruction | Effect |
+|---|---|
+| `SortResult(keys)` | Sort buffered result rows |
+| `LimitResult(count, offset)` | Truncate result rows |
+| `DistinctResult()` | Remove duplicate rows |
+
+### LEFT JOIN tracking
+| Instruction | Effect |
+|---|---|
+| `JoinBeginRow()` | Clear matched flag for current left row |
+| `JoinSetMatched()` | Mark that a matching right row was found |
+| `JoinIfMatched(label)` | Jump past null-padding if match was found |
+
+### DML / DDL
+| Instruction | Effect |
+|---|---|
+| `InsertRow(table, columns)` | Pop values and insert a row |
+| `UpdateRows(table, cols, cursorId)` | Update current cursor row |
+| `DeleteRows(table, cursorId)` | Delete current cursor row |
+| `CreateTable(table, ifNotExists, cols)` | DDL: create table |
+| `DropTable(table, ifExists)` | DDL: drop table |
+
+### Control flow
+| Instruction | Effect |
+|---|---|
+| `Label(name)` | Define a jump target |
+| `Jump(target)` | Unconditional jump |
+| `JumpIfFalse(target)` | Pop; jump if falsy |
+| `JumpIfTrue(target)` | Pop; jump if truthy |
+| `Halt()` | Terminate the program |
+
+## Code generation patterns
+
+### Simple SELECT
+
+```
+SetResultSchema(["name"])
+OpenScan(0, "users")
+Label("scan_0_loop_0")
+AdvanceCursor(0, "scan_0_end_1")
+  BeginRow()
+  LoadColumn(0, "name")
+  EmitColumn("name")
+  EmitRow()
+Jump("scan_0_loop_0")
+Label("scan_0_end_1")
+CloseScan(0)
+Halt()
+```
+
+### SELECT with WHERE
+
+```
+...scan loop...
+  [predicate expression]
+  JumpIfFalse("filter_skip_2")
+  [row building]
+  Label("filter_skip_2")
+...
+```
+
+### SELECT with ORDER BY + LIMIT
+
+Post-processing instructions appear after the scan loop and before Halt:
+```
+...scan loop + row building...
+SortResult([SortKey("name", ASC, LAST)])
+LimitResult(10, 0)
+Halt()
+```
+
+### COUNT(*) aggregate
+
+```
+OpenScan(0, "users")
+Label("scan_0_loop_0")
+AdvanceCursor(0, "scan_0_end_1")
+  SaveGroupKey(0)
+  InitAgg(0, COUNT_STAR, false)
+  LoadConst(null)
+  UpdateAgg(0)
+Jump("scan_0_loop_0")
+Label("scan_0_end_1")
+CloseScan(0)
+Label("group_start_2")
+AdvanceGroupKey("group_end_3", false)
+BeginRow()
+FinalizeAgg(0, COUNT_STAR)
+EmitColumn("cnt")
+EmitRow()
+Jump("group_start_2")
+Label("group_end_3")
+Halt()
+```
+
+## Dependencies
+
+- `coding-adventures-sql-planner` — `LogicalPlan`, `SqlExpr`, `OutputColumn`, etc.
+- `coding-adventures-sql-optimizer` — `OptimizedPlan`, `SqlOptimizer.optimize()`
+
+## Building
+
+```bash
+# Build dependency JARs first
+(cd ../sql-planner  && gradle jar --quiet)
+(cd ../sql-optimizer && gradle jar --quiet)
+
+# Run tests with coverage verification
+gradle test
+```
+
+Coverage is enforced at ≥ 80% line coverage via JaCoCo.

--- a/code/packages/java/sql-codegen/build.gradle.kts
+++ b/code/packages/java/sql-codegen/build.gradle.kts
@@ -1,0 +1,61 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    java
+    `java-library`
+    jacoco
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    implementation(files("../sql-planner/gradle-build/libs/coding-adventures-sql-planner-0.1.0.jar"))
+    implementation(files("../sql-optimizer/gradle-build/libs/coding-adventures-sql-optimizer-0.1.0.jar"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+    finalizedBy(tasks.jacocoTestReport)
+}
+
+jacoco {
+    toolVersion = "0.8.12"
+}
+
+tasks.jacocoTestReport {
+    dependsOn(tasks.test)
+    reports {
+        xml.required.set(true)
+        html.required.set(true)
+    }
+}
+
+tasks.jacocoTestCoverageVerification {
+    dependsOn(tasks.jacocoTestReport)
+    violationRules {
+        rule {
+            limit {
+                counter = "LINE"
+                value = "COVEREDRATIO"
+                minimum = "0.80".toBigDecimal()
+            }
+        }
+    }
+}
+
+tasks.named("check") {
+    dependsOn(tasks.jacocoTestCoverageVerification)
+}

--- a/code/packages/java/sql-codegen/required_capabilities.json
+++ b/code/packages/java/sql-codegen/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "java/sql-codegen",
+  "capabilities": [],
+  "justification": "Pure in-memory bytecode compiler library. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/java/sql-codegen/settings.gradle.kts
+++ b/code/packages/java/sql-codegen/settings.gradle.kts
@@ -1,0 +1,8 @@
+// Declare the local build dependency on sql-planner and sql-optimizer so the
+// monorepo build tool can construct the correct dependency graph edges:
+//   java/sql-codegen → java/sql-optimizer → java/sql-planner
+// The build-tool's dep-graph validator checks that all relative path references
+// in BUILD commands are declared predecessors (lesson learned from PR #7073).
+includeBuild("../sql-planner")
+includeBuild("../sql-optimizer")
+rootProject.name = "coding-adventures-sql-codegen"

--- a/code/packages/java/sql-codegen/src/main/java/com/codingadventures/sqlcodegen/SqlCodegen.java
+++ b/code/packages/java/sql-codegen/src/main/java/com/codingadventures/sqlcodegen/SqlCodegen.java
@@ -1,0 +1,1271 @@
+package com.codingadventures.sqlcodegen;
+
+import com.codingadventures.sqlplanner.SqlPlanner;
+import com.codingadventures.sqloptimizer.SqlOptimizer;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+// SqlCodegen.java — bytecode compiler for the SQL VM.
+//
+// Transforms an OptimizedPlan (produced by SqlOptimizer) into a flat Program
+// consisting of a list of typed Instructions, a label-to-index map, and an
+// output column schema.
+//
+// The compilation model is a stack machine with explicit cursor management:
+//
+//   OpenScan / AdvanceCursor / CloseScan  — iterate a base table
+//   LoadConst / LoadColumn / BinaryOp … — evaluate scalar expressions
+//   BeginRow / EmitColumn / EmitRow       — assemble and emit output rows
+//   InitAgg / UpdateAgg / FinalizeAgg     — two-phase aggregate processing
+//   InsertRow / UpdateRows / DeleteRows   — DML operations
+//   CreateTable / DropTable               — DDL operations
+//   Label / Jump / JumpIfFalse / Halt     — control flow
+//
+// Usage:
+//   Program prog = SqlCodegen.compile(logicalPlan);
+//   Program prog = SqlCodegen.compileOptimized(optimizedPlan);
+//   List<Instruction> instrs = SqlCodegen.compileExpr(expr);   // for unit tests
+
+public final class SqlCodegen {
+
+    private SqlCodegen() {} // static-method namespace only
+
+    // ── Bytecode enumerations ─────────────────────────────────────────────────
+    //
+    // These enumerations define the primitive operations the SQL VM understands.
+    // They are deliberately minimal: the VM interprets them, the codegen emits them.
+
+    /** Arithmetic and comparison operators for binary stack operations. */
+    public enum BinaryOpCode {
+        ADD, SUB, MUL, DIV, MOD,
+        EQ, NEQ, LT, LTE, GT, GTE,
+        AND, OR,
+        CONCAT
+    }
+
+    /** Prefix operators for unary stack operations. */
+    public enum UnaryOpCode { NEG, NOT }
+
+    /** Aggregate accumulator functions. */
+    public enum AggFunc { COUNT, COUNT_STAR, SUM, AVG, MIN, MAX }
+
+    /** Sort direction for ORDER BY keys. */
+    public enum Direction { ASC, DESC }
+
+    /** NULL ordering within a sort key. */
+    public enum NullsOrder { FIRST, LAST }
+
+    // ── SortKey record ────────────────────────────────────────────────────────
+    //
+    // Represents one column in an ORDER BY clause, with its sort direction
+    // and how NULL values are ordered relative to non-NULL values.
+
+    /** One column in an ORDER BY clause as seen by the VM. */
+    public record SortKey(String column, Direction direction, NullsOrder nullsOrder) {}
+
+    // ── Instruction — sealed interface ────────────────────────────────────────
+    //
+    // Every instruction the VM can execute.  Uses Java 21 sealed interfaces
+    // and records to get exhaustive pattern matching.
+    //
+    // Stack discipline:
+    //   LoadConst(v)        pushes one value
+    //   LoadColumn(c, col)  pushes one value
+    //   BinaryOp(op)        pops two, pushes one
+    //   UnaryOp(op)         pops one,  pushes one
+    //   IsNull / IsNotNull  pops one,  pushes boolean
+    //   Between             pops three (value, low, high), pushes boolean
+    //   InList(n)           pops n items then needle, pushes boolean
+    //   Like                pops two (value, pattern), pushes boolean
+    //   CallScalar(f, n)    pops n args, pushes one result
+    //   Pop                 pops one
+    //
+    // Cursor operations are side-effecting; they do not push values.
+    // Row-building operations (BeginRow/EmitColumn/EmitRow) are similarly
+    // side-effecting and pop the top-of-stack value for each EmitColumn.
+    //
+    // Aggregate slots are indexed from 0; each aggregate function has its own slot.
+    // The two-phase protocol is: InitAgg (reset) → UpdateAgg (accumulate) ×N
+    // → FinalizeAgg (push result).
+
+    public sealed interface Instruction permits
+        Instruction.LoadConst, Instruction.LoadColumn, Instruction.Pop,
+        Instruction.BinaryOp, Instruction.UnaryOp,
+        Instruction.IsNull, Instruction.IsNotNull,
+        Instruction.Between, Instruction.InList, Instruction.Like,
+        Instruction.CallScalar,
+        Instruction.OpenScan, Instruction.AdvanceCursor, Instruction.CloseScan,
+        Instruction.BeginRow, Instruction.EmitColumn, Instruction.EmitRow,
+        Instruction.SetResultSchema,
+        Instruction.InitAgg, Instruction.UpdateAgg, Instruction.FinalizeAgg,
+        Instruction.SaveGroupKey, Instruction.LoadGroupKey, Instruction.AdvanceGroupKey,
+        Instruction.SortResult, Instruction.LimitResult, Instruction.DistinctResult,
+        Instruction.JoinBeginRow, Instruction.JoinSetMatched, Instruction.JoinIfMatched,
+        Instruction.InsertRow, Instruction.UpdateRows, Instruction.DeleteRows,
+        Instruction.CreateTable, Instruction.DropTable,
+        Instruction.Label, Instruction.Jump, Instruction.JumpIfFalse,
+        Instruction.JumpIfTrue, Instruction.Halt {
+
+        // ── Stack instructions ─────────────────────────────────────────────
+
+        /** Push a compile-time constant (null, Boolean, Long, Double, String). */
+        record LoadConst(Object value)                         implements Instruction {}
+
+        /** Push the value of a named column from the given cursor. */
+        record LoadColumn(int cursorId, String column)         implements Instruction {}
+
+        /** Discard the top-of-stack value. */
+        record Pop()                                           implements Instruction {}
+
+        /** Pop two values, apply binary operator, push result. */
+        record BinaryOp(BinaryOpCode op)                      implements Instruction {}
+
+        /** Pop one value, apply unary operator, push result. */
+        record UnaryOp(UnaryOpCode op)                        implements Instruction {}
+
+        /** Pop one value; push true if it is SQL NULL, false otherwise. */
+        record IsNull()                                        implements Instruction {}
+
+        /** Pop one value; push true if it is not SQL NULL, false otherwise. */
+        record IsNotNull()                                     implements Instruction {}
+
+        /**
+         * Pop three values (high, low, value — pushed value first, then low, then high);
+         * push true iff value BETWEEN low AND high (inclusive).
+         */
+        record Between()                                       implements Instruction {}
+
+        /**
+         * Pop n items (the IN list), then the needle;
+         * push true iff needle equals any item.
+         */
+        record InList(int n)                                   implements Instruction {}
+
+        /**
+         * Pop two values (pattern pushed after value); apply LIKE matching.
+         * negated=true implements NOT LIKE.
+         */
+        record Like(boolean negated)                           implements Instruction {}
+
+        /** Pop nArgs values, call scalar SQL function, push one result. */
+        record CallScalar(String func, int nArgs)              implements Instruction {}
+
+        // ── Cursor / scan instructions ─────────────────────────────────────
+
+        /** Open a table scan on the given table; associate it with cursorId. */
+        record OpenScan(int cursorId, String table)            implements Instruction {}
+
+        /**
+         * Advance the cursor to the next row.
+         * If no row is available, jump to the label onExhausted.
+         */
+        record AdvanceCursor(int cursorId, String onExhausted) implements Instruction {}
+
+        /** Close a previously opened cursor. */
+        record CloseScan(int cursorId)                         implements Instruction {}
+
+        // ── Row-building instructions ──────────────────────────────────────
+
+        /** Start assembling a new output row. */
+        record BeginRow()                                      implements Instruction {}
+
+        /** Pop one value and store it as the named column of the current output row. */
+        record EmitColumn(String name)                         implements Instruction {}
+
+        /** Finalise and emit the current output row to the result set. */
+        record EmitRow()                                       implements Instruction {}
+
+        /**
+         * Declare the output column schema.
+         * Emitted once at the start of the program so the VM knows the result shape
+         * before any rows arrive.
+         */
+        record SetResultSchema(List<String> columns)           implements Instruction {}
+
+        // ── Aggregate instructions ─────────────────────────────────────────
+
+        /**
+         * Initialise (reset) aggregate accumulator slot.
+         * distinct=true tracks which values have already been seen.
+         */
+        record InitAgg(int slot, AggFunc func, boolean distinct) implements Instruction {}
+
+        /**
+         * Pop one value and feed it into aggregate accumulator slot.
+         * For COUNT_STAR the value is ignored (push null before UpdateAgg).
+         */
+        record UpdateAgg(int slot)                             implements Instruction {}
+
+        /** Push the finalised aggregate value from slot (mean, count, etc.). */
+        record FinalizeAgg(int slot, AggFunc func)             implements Instruction {}
+
+        // ── Group-key instructions ─────────────────────────────────────────
+        //
+        // The VM maintains an internal "group key store".
+        // SaveGroupKey pops n values from the stack and saves them.
+        // LoadGroupKey pushes the i-th saved value back onto the stack.
+        // AdvanceGroupKey moves to the next group; jumps to onExhausted when done.
+
+        /** Pop n values (GROUP BY expressions) and save them as the current group key. */
+        record SaveGroupKey(int n)                             implements Instruction {}
+
+        /** Push the i-th element of the current group key onto the stack. */
+        record LoadGroupKey(int i)                             implements Instruction {}
+
+        /**
+         * Move to the next group.
+         * hasGroupBy=true means GROUP BY columns were used; false means scalar aggregate.
+         * Jumps to onExhausted when all groups have been emitted.
+         */
+        record AdvanceGroupKey(String onExhausted, boolean hasGroupBy) implements Instruction {}
+
+        // ── Post-processing instructions ───────────────────────────────────
+        //
+        // Applied to the full result set after the scan loop completes.
+        // The VM buffers all emitted rows, then applies these in order.
+
+        /** Sort all buffered result rows by the given keys. */
+        record SortResult(List<SortKey> keys)                  implements Instruction {}
+
+        /** Truncate buffered results to at most count rows, skipping the first offset. */
+        record LimitResult(Long count, Long offset)            implements Instruction {}
+
+        /** Remove duplicate rows from the buffered result set. */
+        record DistinctResult()                                implements Instruction {}
+
+        // ── LEFT JOIN tracking instructions ────────────────────────────────
+
+        /** Begin tracking whether the current left row found any match. */
+        record JoinBeginRow()                                  implements Instruction {}
+
+        /** Mark that the current left row found at least one matching right row. */
+        record JoinSetMatched()                                implements Instruction {}
+
+        /**
+         * If the current left row found a match, jump to label (skip null-padding).
+         * Otherwise fall through so the caller can emit a null-padded row.
+         */
+        record JoinIfMatched(String label)                     implements Instruction {}
+
+        // ── DML instructions ───────────────────────────────────────────────
+
+        /** Pop values for the given columns (in order) and insert a row. */
+        record InsertRow(String table, List<String> columns)   implements Instruction {}
+
+        /** Update rows in table where the given cursor currently points. */
+        record UpdateRows(String table, List<String> assignments, int cursorId) implements Instruction {}
+
+        /** Delete the row at which the given cursor currently points. */
+        record DeleteRows(String table, int cursorId)          implements Instruction {}
+
+        // ── DDL instructions ───────────────────────────────────────────────
+
+        /** Create a table (optionally skip if it already exists). */
+        record CreateTable(String table, boolean ifNotExists,
+                           List<SqlPlanner.ColumnDef> columns) implements Instruction {}
+
+        /** Drop a table (optionally ignore if it doesn't exist). */
+        record DropTable(String table, boolean ifExists)       implements Instruction {}
+
+        // ── Control-flow instructions ──────────────────────────────────────
+
+        /** Define a jump target at this position in the instruction stream. */
+        record Label(String name)                              implements Instruction {}
+
+        /** Unconditional jump to target. */
+        record Jump(String target)                             implements Instruction {}
+
+        /**
+         * Pop one value; if it is falsy (false or null), jump to target.
+         * Otherwise fall through.
+         */
+        record JumpIfFalse(String target)                      implements Instruction {}
+
+        /**
+         * Pop one value; if it is truthy (true), jump to target.
+         * Otherwise fall through.
+         */
+        record JumpIfTrue(String target)                       implements Instruction {}
+
+        /** Terminate the program. */
+        record Halt()                                          implements Instruction {}
+    }
+
+    // ── Program record ────────────────────────────────────────────────────────
+    //
+    // The compiled output.  instructions is the flat bytecode list.
+    // labels maps each Label.name to its index in instructions (for the VM to
+    // implement jumps without linear search).
+    // resultSchema lists the output column names in order.
+
+    /**
+     * A compiled SQL program ready for the VM to execute.
+     *
+     * @param instructions flat ordered list of bytecode instructions
+     * @param labels       mapping from label name to instruction index
+     * @param resultSchema ordered list of output column names
+     */
+    public record Program(
+        List<Instruction> instructions,
+        Map<String, Integer> labels,
+        List<String> resultSchema
+    ) {}
+
+    // ── Compilation context ───────────────────────────────────────────────────
+    //
+    // Private mutable state threaded through the recursive compilation.
+    // Keeps counters for cursor IDs, label suffixes, and aggregate slots.
+
+    private static final class Ctx {
+        int c = 0; // cursor ID counter
+        int l = 0; // label suffix counter
+        int a = 0; // aggregate slot counter
+        // Maps table alias → cursor ID so expression compilation can look up the
+        // right cursor when evaluating a column reference like "users.id".
+        final Map<String, Integer> aliasToId = new HashMap<>();
+
+        /** Allocate a fresh cursor ID (monotonically increasing). */
+        int nextCursor() { return c++; }
+
+        /** Generate a unique label like "scan_0_loop_3". */
+        String nextLabel(String pfx) { return pfx + "_" + l++; }
+
+        /** Allocate a fresh aggregate accumulator slot. */
+        int nextSlot() { return a++; }
+
+        /**
+         * Look up the cursor ID for a table alias.
+         * Returns 0 as a safe default (single-table queries have cursor 0).
+         */
+        int cursorOf(String alias) {
+            return aliasToId.getOrDefault(alias, 0);
+        }
+    }
+
+    // ── Public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Compile a LogicalPlan by first optimising it, then generating bytecode.
+     * Equivalent to {@code compileOptimized(SqlOptimizer.optimize(plan))}.
+     *
+     * @param plan the logical plan from SqlPlanner
+     * @return a bytecode Program ready for the VM
+     */
+    public static Program compile(SqlPlanner.LogicalPlan plan) {
+        return compileOptimized(SqlOptimizer.optimize(plan));
+    }
+
+    /**
+     * Compile an OptimizedPlan directly into a Program.
+     * This is the primary entry point when the optimizer has already been run.
+     *
+     * @param plan an optimized plan from SqlOptimizer
+     * @return a bytecode Program ready for the VM
+     */
+    public static Program compileOptimized(SqlOptimizer.OptimizedPlan plan) {
+        var out = new ArrayList<Instruction>();
+        var ctx = new Ctx();
+
+        compilePlan(plan, out, ctx);
+
+        // ── Resolve labels ─────────────────────────────────────────────────
+        // Build a label name → instruction index map so the VM can jump in O(1).
+        var lblMap = new HashMap<String, Integer>();
+        for (int i = 0; i < out.size(); i++) {
+            if (out.get(i) instanceof Instruction.Label lb) {
+                lblMap.put(lb.name(), i);
+            }
+        }
+
+        // ── Extract result schema ──────────────────────────────────────────
+        // The SetResultSchema instruction appears at most once, near the start.
+        List<String> resultSchema = List.of();
+        for (var instr : out) {
+            if (instr instanceof Instruction.SetResultSchema srs) {
+                resultSchema = srs.columns();
+                break;
+            }
+        }
+
+        return new Program(Collections.unmodifiableList(out), lblMap, resultSchema);
+    }
+
+    /**
+     * Compile a single scalar expression in isolation.
+     * Uses a fresh empty context (cursor 0 for any column reference).
+     * Useful for unit tests that want to inspect expression bytecode directly.
+     *
+     * @param expr a SQL scalar expression
+     * @return the list of instructions that evaluate the expression
+     */
+    public static List<Instruction> compileExpr(SqlPlanner.SqlExpr expr) {
+        return compileExprCtx(expr, new Ctx());
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Plan compilation
+    // ═══════════════════════════════════════════════════════════════════════════
+    //
+    // compilePlan is the top-level dispatcher.  It handles three categories:
+    //
+    //   1. DDL / DML — simple: emit one instruction + Halt.
+    //   2. SELECT — complex: peel Sort/Limit/Distinct wrappers, compile core,
+    //               then append post-processing.
+    //   3. EmptyResult — emit Halt (zero rows).
+
+    private static void compilePlan(SqlOptimizer.OptimizedPlan plan,
+                                    List<Instruction> out,
+                                    Ctx ctx) {
+        // ── Quick DDL / DML dispatch ───────────────────────────────────────
+        switch (plan) {
+            case SqlOptimizer.OptimizedPlan.CreateTable ct -> {
+                out.add(new Instruction.CreateTable(ct.table(), ct.ifNotExists(), ct.columns()));
+                out.add(new Instruction.Halt());
+                return;
+            }
+            case SqlOptimizer.OptimizedPlan.DropTable dt -> {
+                out.add(new Instruction.DropTable(dt.table(), dt.ifExists()));
+                out.add(new Instruction.Halt());
+                return;
+            }
+            case SqlOptimizer.OptimizedPlan.Insert ins -> {
+                compileInsert(ins, out, ctx);
+                out.add(new Instruction.Halt());
+                return;
+            }
+            case SqlOptimizer.OptimizedPlan.Update upd -> {
+                compileUpdate(upd, out, ctx);
+                out.add(new Instruction.Halt());
+                return;
+            }
+            case SqlOptimizer.OptimizedPlan.Delete del -> {
+                compileDelete(del, out, ctx);
+                out.add(new Instruction.Halt());
+                return;
+            }
+            case SqlOptimizer.OptimizedPlan.EmptyResult e -> {
+                // An EmptyResult at the top level means zero rows. Just halt.
+                out.add(new Instruction.Halt());
+                return;
+            }
+            default -> {} // fall through to SELECT path
+        }
+
+        // ── SELECT path: peel post-processing wrappers ─────────────────────
+        //
+        // Sort, Limit, and Distinct are applied after the scan loop completes.
+        // We peel them from the top of the plan tree outermost-first, collecting
+        // each instruction in a list, then append them after the scan body.
+        //
+        // Execution semantics for Sort(Limit(inner)):
+        //   1. Scan produces rows
+        //   2. Sort all rows (Sort is semantically outermost — it needs all rows)
+        //   3. Limit takes the first N from the sorted result
+        //
+        // So postOps must be appended in the order they were collected:
+        //   [SortResult, LimitResult] — Sort first, then Limit.
+        //
+        // Do NOT reverse: the outermost wrapper is collected first and must
+        // execute first in the post-processing phase.
+
+        var postOps   = new ArrayList<Instruction>();
+        var innerPlan = plan;
+
+        while (true) {
+            if (innerPlan instanceof SqlOptimizer.OptimizedPlan.Sort s) {
+                var keys = buildSortKeys(s.keys());
+                postOps.add(new Instruction.SortResult(keys));
+                innerPlan = s.input();
+            } else if (innerPlan instanceof SqlOptimizer.OptimizedPlan.Limit lim) {
+                postOps.add(new Instruction.LimitResult(lim.count(), lim.offset()));
+                innerPlan = lim.input();
+            } else if (innerPlan instanceof SqlOptimizer.OptimizedPlan.Distinct d) {
+                postOps.add(new Instruction.DistinctResult());
+                innerPlan = d.input();
+            } else {
+                break;
+            }
+        }
+
+        // ── Compile the core plan (Project / Aggregate / bare scan) ────────
+        compileCore(innerPlan, out, ctx);
+
+        // Append post-processing in collected order (outermost → innermost).
+        // For Sort(Limit(inner)): [SortResult, LimitResult] → Sort then Limit.
+        out.addAll(postOps);
+
+        out.add(new Instruction.Halt());
+    }
+
+    // ── Core plan compilation ─────────────────────────────────────────────────
+    //
+    // compileCore handles the inner plan after post-processing wrappers have
+    // been peeled.  The innermost plan is one of:
+    //
+    //   • Project(Aggregate(...))  — aggregate query
+    //   • Project(...)             — regular SELECT
+    //   • Aggregate(...)           — aggregate without explicit project (rare)
+    //   • EmptyResult              — inside a Project wrapper (handled by Project case)
+    //
+    // The two-phase aggregate protocol is handled inside compileCore when we
+    // detect a Project wrapping an Aggregate.
+
+    private static void compileCore(SqlOptimizer.OptimizedPlan plan,
+                                    List<Instruction> out,
+                                    Ctx ctx) {
+        switch (plan) {
+
+            // ── EmptyResult inside core position ──────────────────────────
+            case SqlOptimizer.OptimizedPlan.EmptyResult ignored -> {
+                // Nothing to emit. compilePlan adds Halt afterwards.
+            }
+
+            // ── Project: the typical outer SELECT wrapper ──────────────────
+            case SqlOptimizer.OptimizedPlan.Project p -> {
+                // Collect output column names.
+                var schema = buildSchema(p.columns());
+                out.add(new Instruction.SetResultSchema(schema));
+
+                // Special case: Project wrapping Aggregate → two-phase agg.
+                if (p.input() instanceof SqlOptimizer.OptimizedPlan.Aggregate agg) {
+                    compileProjectAggregate(agg, p.columns(), schema, out, ctx);
+                    return;
+                }
+
+                // Regular project: scan + filter + row building.
+                compileScanBody(p.input(), out, ctx, () -> {
+                    out.add(new Instruction.BeginRow());
+                    emitProjectColumns(p.columns(), schema, out, ctx);
+                    out.add(new Instruction.EmitRow());
+                });
+            }
+
+            // ── Bare Aggregate (SELECT COUNT(*) without an explicit Project) ─
+            case SqlOptimizer.OptimizedPlan.Aggregate agg -> {
+                // Build a synthetic schema from the aggregate aliases.
+                var schema = new ArrayList<String>();
+                for (var item : agg.aggregates()) schema.add(item.alias());
+                out.add(new Instruction.SetResultSchema(schema));
+                compileAggregateOnly(agg, schema, out, ctx);
+            }
+
+            // ── All other plan types at core level — compile as scan body ──
+            default -> {
+                // e.g. bare Scan or Filter without a Project above it.
+                // Emit minimal schema.
+                out.add(new Instruction.SetResultSchema(List.of()));
+                compileScanBody(plan, out, ctx, () -> {
+                    out.add(new Instruction.BeginRow());
+                    out.add(new Instruction.EmitRow());
+                });
+            }
+        }
+    }
+
+    // ── Scan body compilation ─────────────────────────────────────────────────
+    //
+    // compileScanBody generates the looping structure for the data-access tier.
+    // The body Runnable is called at the innermost point of the loop — it
+    // emits whichever instructions should execute for each row that passes all
+    // filters.
+    //
+    // Pattern for a single Scan:
+    //
+    //   OpenScan(cid, table)
+    //   Label("scan_cid_loop_N")
+    //   AdvanceCursor(cid, "scan_cid_end_M")
+    //     <body>
+    //   Jump("scan_cid_loop_N")
+    //   Label("scan_cid_end_M")
+    //   CloseScan(cid)
+    //
+    // Filter wraps the body with a predicate guard:
+    //
+    //   <inner scan loop>
+    //     <predicate expression>
+    //     JumpIfFalse("filter_skip_N")
+    //     <body>
+    //     Label("filter_skip_N")
+    //
+    // INNER JOIN is a nested loop: compile left, and inside the left body
+    // compile right, and inside the right body emit the join body.
+
+    private static void compileScanBody(SqlOptimizer.OptimizedPlan plan,
+                                        List<Instruction> out,
+                                        Ctx ctx,
+                                        Runnable body) {
+        switch (plan) {
+
+            // ── Leaf: base table scan ─────────────────────────────────────
+            case SqlOptimizer.OptimizedPlan.Scan s -> {
+                int cid = ctx.nextCursor();
+                String alias = s.alias() != null ? s.alias() : s.table();
+                ctx.aliasToId.put(alias, cid);
+
+                String loopLbl = ctx.nextLabel("scan_" + cid + "_loop");
+                String endLbl  = ctx.nextLabel("scan_" + cid + "_end");
+
+                out.add(new Instruction.OpenScan(cid, s.table()));
+                out.add(new Instruction.Label(loopLbl));
+                out.add(new Instruction.AdvanceCursor(cid, endLbl));
+                body.run();
+                out.add(new Instruction.Jump(loopLbl));
+                out.add(new Instruction.Label(endLbl));
+                out.add(new Instruction.CloseScan(cid));
+            }
+
+            // ── Filter: wrap body with predicate check ────────────────────
+            case SqlOptimizer.OptimizedPlan.Filter f -> {
+                String skipLbl = ctx.nextLabel("filter_skip");
+                // The filter surrounds the body inside the inner scan loop.
+                compileScanBody(f.input(), out, ctx, () -> {
+                    out.addAll(compileExprCtx(f.predicate(), ctx));
+                    out.add(new Instruction.JumpIfFalse(skipLbl));
+                    body.run();
+                    out.add(new Instruction.Label(skipLbl));
+                });
+            }
+
+            // ── INNER / CROSS JOIN: nested loop ───────────────────────────
+            case SqlOptimizer.OptimizedPlan.Join j
+                when j.kind() == SqlPlanner.JoinKind.INNER
+                  || j.kind() == SqlPlanner.JoinKind.CROSS -> {
+                compileScanBody(j.left(), out, ctx, () -> {
+                    compileScanBody(j.right(), out, ctx, () -> {
+                        if (j.condition() != null
+                                && j.kind() == SqlPlanner.JoinKind.INNER) {
+                            String skipLbl = ctx.nextLabel("join_skip");
+                            out.addAll(compileExprCtx(j.condition(), ctx));
+                            out.add(new Instruction.JumpIfFalse(skipLbl));
+                            body.run();
+                            out.add(new Instruction.Label(skipLbl));
+                        } else {
+                            body.run();
+                        }
+                    });
+                });
+            }
+
+            // ── LEFT OUTER JOIN: nested loop with null-padding ────────────
+            //
+            // For each left row:
+            //   JoinBeginRow()           — clear the "matched" flag
+            //   <right scan loop>
+            //     [condition check]
+            //     JoinSetMatched()       — mark that we found a match
+            //     body                   — emit the joined row
+            //   JoinIfMatched(matched)   — if a match was found, skip null-padding
+            //   body                     — null-padding (right cols are NULL)
+            //   Label(matched)
+            case SqlOptimizer.OptimizedPlan.Join j
+                when j.kind() == SqlPlanner.JoinKind.LEFT -> {
+                String matchedLbl = ctx.nextLabel("loj_matched");
+                compileScanBody(j.left(), out, ctx, () -> {
+                    out.add(new Instruction.JoinBeginRow());
+                    compileScanBody(j.right(), out, ctx, () -> {
+                        if (j.condition() != null) {
+                            String skipLbl = ctx.nextLabel("loj_skip");
+                            out.addAll(compileExprCtx(j.condition(), ctx));
+                            out.add(new Instruction.JumpIfFalse(skipLbl));
+                            out.add(new Instruction.JoinSetMatched());
+                            body.run();
+                            out.add(new Instruction.Label(skipLbl));
+                        } else {
+                            out.add(new Instruction.JoinSetMatched());
+                            body.run();
+                        }
+                    });
+                    out.add(new Instruction.JoinIfMatched(matchedLbl));
+                    // Null-padding row: right columns will be NULL in the VM
+                    // because no cursor is positioned.
+                    body.run();
+                    out.add(new Instruction.Label(matchedLbl));
+                });
+            }
+
+            // ── RIGHT OUTER JOIN: mirror of LEFT JOIN ─────────────────────
+            case SqlOptimizer.OptimizedPlan.Join j
+                when j.kind() == SqlPlanner.JoinKind.RIGHT -> {
+                // Compile as a left join but swap the sides.
+                String matchedLbl = ctx.nextLabel("roj_matched");
+                compileScanBody(j.right(), out, ctx, () -> {
+                    out.add(new Instruction.JoinBeginRow());
+                    compileScanBody(j.left(), out, ctx, () -> {
+                        if (j.condition() != null) {
+                            String skipLbl = ctx.nextLabel("roj_skip");
+                            out.addAll(compileExprCtx(j.condition(), ctx));
+                            out.add(new Instruction.JumpIfFalse(skipLbl));
+                            out.add(new Instruction.JoinSetMatched());
+                            body.run();
+                            out.add(new Instruction.Label(skipLbl));
+                        } else {
+                            out.add(new Instruction.JoinSetMatched());
+                            body.run();
+                        }
+                    });
+                    out.add(new Instruction.JoinIfMatched(matchedLbl));
+                    body.run();
+                    out.add(new Instruction.Label(matchedLbl));
+                });
+            }
+
+            // ── Transparent wrappers: strip and recurse ───────────────────
+            //
+            // Having is handled by the Aggregate path above; if it leaks here
+            // we strip it so the scan body can still be compiled.
+            case SqlOptimizer.OptimizedPlan.Having h ->
+                compileScanBody(h.input(), out, ctx, body);
+
+            // ── EmptyResult: body is never called ─────────────────────────
+            case SqlOptimizer.OptimizedPlan.EmptyResult ignored -> {
+                // No rows are produced; body intentionally not called.
+            }
+
+            default ->
+                throw new UnsupportedOperationException(
+                    "Unsupported plan node in scan body: "
+                    + plan.getClass().getSimpleName());
+        }
+    }
+
+    // ── Two-phase aggregate compilation ──────────────────────────────────────
+    //
+    // Phase 1 (accumulation loop):
+    //   For each row that passes filters:
+    //     InitAgg(slot, func, distinct)     — must be called once per group,
+    //                                         but for simplicity we emit it inside
+    //                                         the loop body; the VM must handle
+    //                                         idempotent init (no-op if already init).
+    //     SaveGroupKey(n)                   — store GROUP BY values
+    //     [for each aggregate argument:]
+    //       <expr>
+    //       UpdateAgg(slot)
+    //
+    // Phase 2 (group iteration):
+    //   Label("group_start_N")
+    //   AdvanceGroupKey("group_end_M", hasGroupBy)
+    //   BeginRow()
+    //   [for each output column: LoadGroupKey(i) or FinalizeAgg(slot, func)]
+    //   EmitRow()
+    //   Jump("group_start_N")
+    //   Label("group_end_M")
+
+    private static void compileProjectAggregate(
+            SqlOptimizer.OptimizedPlan.Aggregate agg,
+            List<SqlPlanner.OutputColumn> projCols,
+            List<String> schema,
+            List<Instruction> out,
+            Ctx ctx) {
+
+        int numGroupBy = agg.groupBy().size();
+        boolean hasGroupBy = numGroupBy > 0;
+
+        // Allocate an aggregate slot for each aggregate function.
+        var aggSlots = new ArrayList<Integer>();
+        for (var item : agg.aggregates()) aggSlots.add(ctx.nextSlot());
+
+        // ── Phase 1: scan + accumulate ────────────────────────────────────
+        compileScanBody(agg.input(), out, ctx, () -> {
+            // Save the GROUP BY key first so the VM can group rows.
+            for (var gbExpr : agg.groupBy()) {
+                out.addAll(compileExprCtx(gbExpr, ctx));
+            }
+            if (hasGroupBy) {
+                out.add(new Instruction.SaveGroupKey(numGroupBy));
+            } else {
+                // Scalar aggregate: no GROUP BY — emit SaveGroupKey(0) so
+                // the VM knows to produce exactly one output row.
+                out.add(new Instruction.SaveGroupKey(0));
+            }
+
+            // Init + update each aggregate.
+            for (int i = 0; i < agg.aggregates().size(); i++) {
+                var item = agg.aggregates().get(i);
+                AggFunc func = mapAggFunc(item.func(), item.arg());
+                int slot = aggSlots.get(i);
+                out.add(new Instruction.InitAgg(slot, func, item.distinct()));
+                // Push the aggregate argument.
+                if (item.arg() instanceof SqlPlanner.AggArg.Expr e) {
+                    out.addAll(compileExprCtx(e.expression(), ctx));
+                } else {
+                    // COUNT(*) — push null; VM ignores it for COUNT_STAR.
+                    out.add(new Instruction.LoadConst(null));
+                }
+                out.add(new Instruction.UpdateAgg(slot));
+            }
+        });
+
+        // ── Phase 2: group iteration ──────────────────────────────────────
+        String groupStart = ctx.nextLabel("group_start");
+        String groupEnd   = ctx.nextLabel("group_end");
+
+        out.add(new Instruction.Label(groupStart));
+        out.add(new Instruction.AdvanceGroupKey(groupEnd, hasGroupBy));
+        out.add(new Instruction.BeginRow());
+
+        // For each output column, determine whether it maps to a GROUP BY key
+        // or an aggregate result.
+        // Strategy: match by AggExpr → FinalizeAgg; Column → LoadGroupKey; else LoadConst.
+        emitAggProjectColumns(projCols, schema, agg.groupBy(), agg.aggregates(), aggSlots, out, ctx);
+
+        out.add(new Instruction.EmitRow());
+        out.add(new Instruction.Jump(groupStart));
+        out.add(new Instruction.Label(groupEnd));
+    }
+
+    // ── Bare aggregate (no outer Project) ────────────────────────────────────
+
+    private static void compileAggregateOnly(
+            SqlOptimizer.OptimizedPlan.Aggregate agg,
+            List<String> schema,
+            List<Instruction> out,
+            Ctx ctx) {
+
+        int numGroupBy = agg.groupBy().size();
+        boolean hasGroupBy = numGroupBy > 0;
+
+        var aggSlots = new ArrayList<Integer>();
+        for (var item : agg.aggregates()) aggSlots.add(ctx.nextSlot());
+
+        // Phase 1
+        compileScanBody(agg.input(), out, ctx, () -> {
+            for (var gbExpr : agg.groupBy()) {
+                out.addAll(compileExprCtx(gbExpr, ctx));
+            }
+            out.add(new Instruction.SaveGroupKey(hasGroupBy ? numGroupBy : 0));
+            for (int i = 0; i < agg.aggregates().size(); i++) {
+                var item = agg.aggregates().get(i);
+                AggFunc func = mapAggFunc(item.func(), item.arg());
+                int slot = aggSlots.get(i);
+                out.add(new Instruction.InitAgg(slot, func, item.distinct()));
+                if (item.arg() instanceof SqlPlanner.AggArg.Expr e) {
+                    out.addAll(compileExprCtx(e.expression(), ctx));
+                } else {
+                    out.add(new Instruction.LoadConst(null));
+                }
+                out.add(new Instruction.UpdateAgg(slot));
+            }
+        });
+
+        // Phase 2
+        String groupStart = ctx.nextLabel("group_start");
+        String groupEnd   = ctx.nextLabel("group_end");
+
+        out.add(new Instruction.Label(groupStart));
+        out.add(new Instruction.AdvanceGroupKey(groupEnd, hasGroupBy));
+        out.add(new Instruction.BeginRow());
+
+        // Emit each aggregate result column.
+        for (int i = 0; i < agg.aggregates().size(); i++) {
+            var item = agg.aggregates().get(i);
+            AggFunc func = mapAggFunc(item.func(), item.arg());
+            out.add(new Instruction.FinalizeAgg(aggSlots.get(i), func));
+            out.add(new Instruction.EmitColumn(schema.get(i)));
+        }
+
+        out.add(new Instruction.EmitRow());
+        out.add(new Instruction.Jump(groupStart));
+        out.add(new Instruction.Label(groupEnd));
+    }
+
+    // ── DML compilation ───────────────────────────────────────────────────────
+
+    private static void compileInsert(SqlOptimizer.OptimizedPlan.Insert ins,
+                                      List<Instruction> out, Ctx ctx) {
+        // For each value row, push each value and emit InsertRow.
+        for (var row : ins.values()) {
+            for (var val : row) {
+                out.addAll(compileExprCtx(val, ctx));
+            }
+            out.add(new Instruction.InsertRow(ins.table(), ins.columns()));
+        }
+    }
+
+    private static void compileUpdate(SqlOptimizer.OptimizedPlan.Update upd,
+                                      List<Instruction> out, Ctx ctx) {
+        // Scan the table; for each row that passes the predicate, update it.
+        int cid = ctx.nextCursor();
+        ctx.aliasToId.put(upd.table(), cid);
+
+        String loopLbl = ctx.nextLabel("update_loop");
+        String endLbl  = ctx.nextLabel("update_end");
+        String skipLbl = ctx.nextLabel("update_skip");
+
+        out.add(new Instruction.OpenScan(cid, upd.table()));
+        out.add(new Instruction.Label(loopLbl));
+        out.add(new Instruction.AdvanceCursor(cid, endLbl));
+
+        if (upd.predicate() != null) {
+            out.addAll(compileExprCtx(upd.predicate(), ctx));
+            out.add(new Instruction.JumpIfFalse(skipLbl));
+        }
+
+        // Push assignment values and collect column names.
+        var cols = new ArrayList<String>();
+        for (var assignment : upd.assignments()) {
+            out.addAll(compileExprCtx(assignment.value(), ctx));
+            cols.add(assignment.column());
+        }
+        out.add(new Instruction.UpdateRows(upd.table(), cols, cid));
+
+        out.add(new Instruction.Label(skipLbl));
+        out.add(new Instruction.Jump(loopLbl));
+        out.add(new Instruction.Label(endLbl));
+        out.add(new Instruction.CloseScan(cid));
+    }
+
+    private static void compileDelete(SqlOptimizer.OptimizedPlan.Delete del,
+                                      List<Instruction> out, Ctx ctx) {
+        int cid = ctx.nextCursor();
+        ctx.aliasToId.put(del.table(), cid);
+
+        String loopLbl = ctx.nextLabel("delete_loop");
+        String endLbl  = ctx.nextLabel("delete_end");
+        String skipLbl = ctx.nextLabel("delete_skip");
+
+        out.add(new Instruction.OpenScan(cid, del.table()));
+        out.add(new Instruction.Label(loopLbl));
+        out.add(new Instruction.AdvanceCursor(cid, endLbl));
+
+        if (del.predicate() != null) {
+            out.addAll(compileExprCtx(del.predicate(), ctx));
+            out.add(new Instruction.JumpIfFalse(skipLbl));
+        }
+
+        out.add(new Instruction.DeleteRows(del.table(), cid));
+
+        out.add(new Instruction.Label(skipLbl));
+        out.add(new Instruction.Jump(loopLbl));
+        out.add(new Instruction.Label(endLbl));
+        out.add(new Instruction.CloseScan(cid));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Expression compilation
+    // ═══════════════════════════════════════════════════════════════════════════
+    //
+    // Compiles a SqlExpr into a list of stack-machine instructions.
+    // The instructions are appended to the output list of the caller.
+    //
+    // Binary operations use left-operand then right-operand ordering:
+    //   LoadConst(3)
+    //   LoadConst(4)
+    //   BinaryOp(ADD)   →  stack: [7]
+    //
+    // Between pushes: value, low, high (in that order) so the VM can pop
+    // high first, then low, then value.
+
+    static List<Instruction> compileExprCtx(SqlPlanner.SqlExpr expr, Ctx ctx) {
+        return switch (expr) {
+
+            // ── Literal ───────────────────────────────────────────────────
+            case SqlPlanner.SqlExpr.Literal lit ->
+                List.of(new Instruction.LoadConst(lit.value()));
+
+            // ── Column reference ──────────────────────────────────────────
+            case SqlPlanner.SqlExpr.Column col -> {
+                int cid = col.table() != null ? ctx.cursorOf(col.table()) : 0;
+                yield List.of(new Instruction.LoadColumn(cid, col.column()));
+            }
+
+            // ── Binary operation ──────────────────────────────────────────
+            case SqlPlanner.SqlExpr.BinaryOp bop -> {
+                var result = new ArrayList<Instruction>();
+                result.addAll(compileExprCtx(bop.left(), ctx));
+                result.addAll(compileExprCtx(bop.right(), ctx));
+                result.add(new Instruction.BinaryOp(mapBinaryOp(bop.op())));
+                yield result;
+            }
+
+            // ── Unary operation ───────────────────────────────────────────
+            case SqlPlanner.SqlExpr.UnaryOp uop -> {
+                var result = new ArrayList<Instruction>(compileExprCtx(uop.operand(), ctx));
+                result.add(new Instruction.UnaryOp(mapUnaryOp(uop.op())));
+                yield result;
+            }
+
+            // ── IS NULL / IS NOT NULL ─────────────────────────────────────
+            case SqlPlanner.SqlExpr.IsNull isn -> {
+                var result = new ArrayList<Instruction>(compileExprCtx(isn.operand(), ctx));
+                result.add(new Instruction.IsNull());
+                yield result;
+            }
+
+            case SqlPlanner.SqlExpr.IsNotNull inn -> {
+                var result = new ArrayList<Instruction>(compileExprCtx(inn.operand(), ctx));
+                result.add(new Instruction.IsNotNull());
+                yield result;
+            }
+
+            // ── BETWEEN ───────────────────────────────────────────────────
+            // Stack order: value, low, high  (VM pops high first, then low, then value)
+            case SqlPlanner.SqlExpr.Between b -> {
+                var result = new ArrayList<Instruction>();
+                result.addAll(compileExprCtx(b.value(), ctx));
+                result.addAll(compileExprCtx(b.low(), ctx));
+                result.addAll(compileExprCtx(b.high(), ctx));
+                result.add(new Instruction.Between());
+                yield result;
+            }
+
+            // ── IN list ───────────────────────────────────────────────────
+            // Stack order: needle first, then items (VM pops n items, then needle)
+            case SqlPlanner.SqlExpr.In in -> {
+                var result = new ArrayList<Instruction>();
+                result.addAll(compileExprCtx(in.value(), ctx));
+                for (var item : in.items()) result.addAll(compileExprCtx(item, ctx));
+                result.add(new Instruction.InList(in.items().size()));
+                yield result;
+            }
+
+            // ── NOT IN list ───────────────────────────────────────────────
+            // NOT IN is compiled as IN followed by NOT.
+            case SqlPlanner.SqlExpr.NotIn notIn -> {
+                var result = new ArrayList<Instruction>();
+                result.addAll(compileExprCtx(notIn.value(), ctx));
+                for (var item : notIn.items()) result.addAll(compileExprCtx(item, ctx));
+                result.add(new Instruction.InList(notIn.items().size()));
+                result.add(new Instruction.UnaryOp(UnaryOpCode.NOT));
+                yield result;
+            }
+
+            // ── LIKE ──────────────────────────────────────────────────────
+            // Pattern is a String literal in the AST; push it as a LoadConst.
+            case SqlPlanner.SqlExpr.Like like -> {
+                var result = new ArrayList<Instruction>(compileExprCtx(like.value(), ctx));
+                result.add(new Instruction.LoadConst(like.pattern()));
+                result.add(new Instruction.Like(false));
+                yield result;
+            }
+
+            // ── NOT LIKE ─────────────────────────────────────────────────
+            case SqlPlanner.SqlExpr.NotLike nl -> {
+                var result = new ArrayList<Instruction>(compileExprCtx(nl.value(), ctx));
+                result.add(new Instruction.LoadConst(nl.pattern()));
+                result.add(new Instruction.Like(true));
+                yield result;
+            }
+
+            // ── Scalar function call ───────────────────────────────────────
+            case SqlPlanner.SqlExpr.FuncCall fc -> {
+                var result = new ArrayList<Instruction>();
+                for (var arg : fc.args()) result.addAll(compileExprCtx(arg, ctx));
+                result.add(new Instruction.CallScalar(fc.name().toLowerCase(), fc.args().size()));
+                yield result;
+            }
+
+            // ── Aggregate expression ───────────────────────────────────────
+            // AggExpr inside a non-aggregate context: compile the argument expression.
+            // (The aggregate wrapping is handled at the Aggregate plan node level.)
+            case SqlPlanner.SqlExpr.AggExpr agg -> {
+                if (agg.arg() instanceof SqlPlanner.AggArg.Expr e) {
+                    yield compileExprCtx(e.expression(), ctx);
+                }
+                yield List.of(new Instruction.LoadConst(null));
+            }
+
+            // ── Wildcard: no instructions ─────────────────────────────────
+            case SqlPlanner.SqlExpr.Wildcard ignored -> List.of();
+        };
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Helpers
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    // ── Build schema from OutputColumn list ───────────────────────────────────
+
+    private static List<String> buildSchema(List<SqlPlanner.OutputColumn> columns) {
+        var schema = new ArrayList<String>();
+        for (var col : columns) {
+            switch (col) {
+                case SqlPlanner.OutputColumn.Expr e ->
+                    schema.add(e.alias() != null ? e.alias()
+                        : inferColumnName(e.expression()));
+                case SqlPlanner.OutputColumn.Star s -> schema.add("*");
+            }
+        }
+        return Collections.unmodifiableList(schema);
+    }
+
+    /** Best-effort column name for an output expression without an alias. */
+    private static String inferColumnName(SqlPlanner.SqlExpr expr) {
+        if (expr instanceof SqlPlanner.SqlExpr.Column col) return col.column();
+        if (expr instanceof SqlPlanner.SqlExpr.AggExpr agg) {
+            return agg.func().name().toLowerCase()
+                + (agg.arg() instanceof SqlPlanner.AggArg.Expr e
+                    ? "_" + inferColumnName(e.expression())
+                    : "_star");
+        }
+        return "?";
+    }
+
+    // ── Emit project columns for regular SELECT ───────────────────────────────
+
+    private static void emitProjectColumns(List<SqlPlanner.OutputColumn> columns,
+                                           List<String> schema,
+                                           List<Instruction> out,
+                                           Ctx ctx) {
+        for (int i = 0; i < columns.size(); i++) {
+            var col = columns.get(i);
+            if (col instanceof SqlPlanner.OutputColumn.Expr e) {
+                out.addAll(compileExprCtx(e.expression(), ctx));
+                out.add(new Instruction.EmitColumn(schema.get(i)));
+            }
+            // Star columns are not emitted here; the planner should have resolved them.
+        }
+    }
+
+    // ── Emit project columns for aggregate SELECT ─────────────────────────────
+    //
+    // Maps each output column to either:
+    //   • LoadGroupKey(i) for GROUP BY columns
+    //   • FinalizeAgg(slot, func) for aggregate expressions
+
+    private static void emitAggProjectColumns(
+            List<SqlPlanner.OutputColumn> projCols,
+            List<String> schema,
+            List<SqlPlanner.SqlExpr> groupBy,
+            List<SqlPlanner.AggregateItem> aggItems,
+            List<Integer> aggSlots,
+            List<Instruction> out,
+            Ctx ctx) {
+
+        for (int i = 0; i < projCols.size(); i++) {
+            var col = projCols.get(i);
+            if (!(col instanceof SqlPlanner.OutputColumn.Expr e)) continue;
+
+            // Try to match to an aggregate expression.
+            int aggIdx = findAggIndex(e.expression(), aggItems);
+            if (aggIdx >= 0) {
+                var item = aggItems.get(aggIdx);
+                AggFunc func = mapAggFunc(item.func(), item.arg());
+                out.add(new Instruction.FinalizeAgg(aggSlots.get(aggIdx), func));
+                out.add(new Instruction.EmitColumn(schema.get(i)));
+                continue;
+            }
+
+            // Try to match to a GROUP BY key by column name / position.
+            int gbIdx = findGroupByIndex(e.expression(), groupBy);
+            if (gbIdx >= 0) {
+                out.add(new Instruction.LoadGroupKey(gbIdx));
+                out.add(new Instruction.EmitColumn(schema.get(i)));
+                continue;
+            }
+
+            // Fall back: compile the expression directly.
+            out.addAll(compileExprCtx(e.expression(), ctx));
+            out.add(new Instruction.EmitColumn(schema.get(i)));
+        }
+    }
+
+    /** Find the index of an aggregate that matches the given expression. */
+    private static int findAggIndex(SqlPlanner.SqlExpr expr,
+                                    List<SqlPlanner.AggregateItem> aggItems) {
+        // Match by alias (the planner tags aggregates with synthetic aliases like "_agg0").
+        // Also match AggExpr nodes by function + arg equivalence.
+        if (expr instanceof SqlPlanner.SqlExpr.AggExpr ae) {
+            for (int i = 0; i < aggItems.size(); i++) {
+                var item = aggItems.get(i);
+                if (item.func() == ae.func() && item.distinct() == ae.distinct()) {
+                    // Rough arg match
+                    boolean argMatch = (item.arg() instanceof SqlPlanner.AggArg.Star
+                                         && ae.arg() instanceof SqlPlanner.AggArg.Star)
+                        || (item.arg() instanceof SqlPlanner.AggArg.Expr ia
+                            && ae.arg() instanceof SqlPlanner.AggArg.Expr ea
+                            && ia.expression().equals(ea.expression()));
+                    if (argMatch) return i;
+                }
+            }
+        }
+        // Match by column reference that looks like an aggregate alias "_aggN".
+        if (expr instanceof SqlPlanner.SqlExpr.Column col && col.column() != null) {
+            for (int i = 0; i < aggItems.size(); i++) {
+                if (col.column().equals(aggItems.get(i).alias())) return i;
+            }
+        }
+        return -1;
+    }
+
+    /** Find the GROUP BY index of a given expression. */
+    private static int findGroupByIndex(SqlPlanner.SqlExpr expr,
+                                        List<SqlPlanner.SqlExpr> groupBy) {
+        for (int i = 0; i < groupBy.size(); i++) {
+            if (groupBy.get(i).equals(expr)) return i;
+            // Also match by column name alone (without table qualifier).
+            if (expr instanceof SqlPlanner.SqlExpr.Column c1
+                && groupBy.get(i) instanceof SqlPlanner.SqlExpr.Column c2
+                && c1.column().equals(c2.column())) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    // ── Map SqlPlanner sort keys → SortKey records ────────────────────────────
+
+    private static List<SortKey> buildSortKeys(List<SqlPlanner.SortKey> keys) {
+        var result = new ArrayList<SortKey>();
+        for (var k : keys) {
+            String col;
+            if (k.keyExpr() instanceof SqlPlanner.SqlExpr.Column c) {
+                col = c.column();
+            } else {
+                // Non-column sort key (e.g. expression): use a placeholder.
+                col = "?";
+            }
+            Direction dir = k.direction() == SqlPlanner.SortDir.ASC
+                            ? Direction.ASC : Direction.DESC;
+            NullsOrder nullsOrd = k.nullOrder() == SqlPlanner.NullOrder.NULLS_FIRST
+                                  ? NullsOrder.FIRST : NullsOrder.LAST;
+            result.add(new SortKey(col, dir, nullsOrd));
+        }
+        return Collections.unmodifiableList(result);
+    }
+
+    // ── Map BinaryOperator → BinaryOpCode ────────────────────────────────────
+
+    private static BinaryOpCode mapBinaryOp(SqlPlanner.BinaryOperator op) {
+        return switch (op) {
+            case ADD    -> BinaryOpCode.ADD;
+            case SUB    -> BinaryOpCode.SUB;
+            case MUL    -> BinaryOpCode.MUL;
+            case DIV    -> BinaryOpCode.DIV;
+            case MOD    -> BinaryOpCode.MOD;
+            case EQ     -> BinaryOpCode.EQ;
+            case NOT_EQ -> BinaryOpCode.NEQ;
+            case LT     -> BinaryOpCode.LT;
+            case LTE    -> BinaryOpCode.LTE;
+            case GT     -> BinaryOpCode.GT;
+            case GTE    -> BinaryOpCode.GTE;
+            case AND    -> BinaryOpCode.AND;
+            case OR     -> BinaryOpCode.OR;
+        };
+    }
+
+    // ── Map UnaryOperator → UnaryOpCode ──────────────────────────────────────
+
+    private static UnaryOpCode mapUnaryOp(SqlPlanner.UnaryOperator op) {
+        return switch (op) {
+            case NEG -> UnaryOpCode.NEG;
+            case NOT -> UnaryOpCode.NOT;
+        };
+    }
+
+    // ── Map AggFunction → AggFunc ─────────────────────────────────────────────
+
+    private static AggFunc mapAggFunc(SqlPlanner.AggFunction func, SqlPlanner.AggArg arg) {
+        return switch (func) {
+            case COUNT -> arg instanceof SqlPlanner.AggArg.Star
+                          ? AggFunc.COUNT_STAR : AggFunc.COUNT;
+            case SUM   -> AggFunc.SUM;
+            case AVG   -> AggFunc.AVG;
+            case MIN   -> AggFunc.MIN;
+            case MAX   -> AggFunc.MAX;
+        };
+    }
+}

--- a/code/packages/java/sql-codegen/src/test/java/com/codingadventures/sqlcodegen/SqlCodegenTest.java
+++ b/code/packages/java/sql-codegen/src/test/java/com/codingadventures/sqlcodegen/SqlCodegenTest.java
@@ -1,0 +1,974 @@
+package com.codingadventures.sqlcodegen;
+
+import com.codingadventures.sqlplanner.SqlPlanner;
+import com.codingadventures.sqloptimizer.SqlOptimizer;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DisplayName;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+// SqlCodegenTest.java — unit tests for the SQL bytecode code generator.
+//
+// Each test constructs an OptimizedPlan (or LogicalPlan for the convenience
+// compile() entry point) and verifies that the emitted instruction list contains
+// the expected instructions in the expected structural relationship.
+//
+// Tests are grouped by the plan node type they primarily exercise:
+//   1. Expression compilation tests (compileExpr / compileExprCtx)
+//   2. Basic scan / project / filter tests
+//   3. JOIN tests
+//   4. Aggregate tests
+//   5. Post-processing (Sort / Limit / Distinct) tests
+//   6. DML tests (INSERT / UPDATE / DELETE)
+//   7. DDL tests (CREATE TABLE / DROP TABLE)
+//   8. Program-level properties (labels, resultSchema, Halt position)
+//   9. EmptyResult handling
+//  10. compile(LogicalPlan) convenience method
+
+class SqlCodegenTest {
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    /** Count occurrences of an instruction class in the program. */
+    private static long count(SqlCodegen.Program prog,
+                               Class<? extends SqlCodegen.Instruction> cls) {
+        return prog.instructions().stream().filter(cls::isInstance).count();
+    }
+
+    /** Find the first instruction of the given class, or throw. */
+    @SuppressWarnings("unchecked")
+    private static <T extends SqlCodegen.Instruction> T first(
+            SqlCodegen.Program prog, Class<T> cls) {
+        return prog.instructions().stream()
+            .filter(cls::isInstance)
+            .map(i -> (T) i)
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("No " + cls.getSimpleName() + " found"));
+    }
+
+    /** Convenience: build a minimal Project(Scan) plan. */
+    private static SqlOptimizer.OptimizedPlan projectScan(
+            String table, String alias, String colName, String colAlias) {
+        return new SqlOptimizer.OptimizedPlan.Project(
+            new SqlOptimizer.OptimizedPlan.Scan(table, alias),
+            List.of(new SqlPlanner.OutputColumn.Expr(
+                new SqlPlanner.SqlExpr.Column(alias, colName), colAlias)));
+    }
+
+    // ── 1. Expression compilation tests ──────────────────────────────────────
+
+    @Test
+    @DisplayName("compileExpr: Literal produces LoadConst")
+    void compileExpr_literal() {
+        var instrs = SqlCodegen.compileExpr(new SqlPlanner.SqlExpr.Literal(42L));
+        assertEquals(1, instrs.size());
+        assertInstanceOf(SqlCodegen.Instruction.LoadConst.class, instrs.get(0));
+        assertEquals(42L, ((SqlCodegen.Instruction.LoadConst) instrs.get(0)).value());
+    }
+
+    @Test
+    @DisplayName("compileExpr: null Literal produces LoadConst(null)")
+    void compileExpr_nullLiteral() {
+        var instrs = SqlCodegen.compileExpr(new SqlPlanner.SqlExpr.Literal(null));
+        assertEquals(1, instrs.size());
+        assertInstanceOf(SqlCodegen.Instruction.LoadConst.class, instrs.get(0));
+        assertNull(((SqlCodegen.Instruction.LoadConst) instrs.get(0)).value());
+    }
+
+    @Test
+    @DisplayName("compileExpr: Column produces LoadColumn")
+    void compileExpr_column() {
+        var instrs = SqlCodegen.compileExpr(
+            new SqlPlanner.SqlExpr.Column("u", "name"));
+        assertEquals(1, instrs.size());
+        assertInstanceOf(SqlCodegen.Instruction.LoadColumn.class, instrs.get(0));
+        assertEquals("name", ((SqlCodegen.Instruction.LoadColumn) instrs.get(0)).column());
+    }
+
+    @Test
+    @DisplayName("compileExpr: BinaryOp(ADD) produces [left, right, BinaryOp(ADD)]")
+    void compileExpr_binaryAdd() {
+        var expr = new SqlPlanner.SqlExpr.BinaryOp(
+            SqlPlanner.BinaryOperator.ADD,
+            new SqlPlanner.SqlExpr.Literal(3L),
+            new SqlPlanner.SqlExpr.Literal(4L));
+        var instrs = SqlCodegen.compileExpr(expr);
+        assertEquals(3, instrs.size());
+        assertInstanceOf(SqlCodegen.Instruction.LoadConst.class, instrs.get(0));
+        assertInstanceOf(SqlCodegen.Instruction.LoadConst.class, instrs.get(1));
+        assertInstanceOf(SqlCodegen.Instruction.BinaryOp.class, instrs.get(2));
+        assertEquals(SqlCodegen.BinaryOpCode.ADD,
+            ((SqlCodegen.Instruction.BinaryOp) instrs.get(2)).op());
+    }
+
+    @Test
+    @DisplayName("compileExpr: UnaryOp(NEG) produces [expr, UnaryOp(NEG)]")
+    void compileExpr_unaryNeg() {
+        var expr = new SqlPlanner.SqlExpr.UnaryOp(
+            SqlPlanner.UnaryOperator.NEG,
+            new SqlPlanner.SqlExpr.Literal(5L));
+        var instrs = SqlCodegen.compileExpr(expr);
+        assertEquals(2, instrs.size());
+        assertInstanceOf(SqlCodegen.Instruction.LoadConst.class, instrs.get(0));
+        assertInstanceOf(SqlCodegen.Instruction.UnaryOp.class, instrs.get(1));
+        assertEquals(SqlCodegen.UnaryOpCode.NEG,
+            ((SqlCodegen.Instruction.UnaryOp) instrs.get(1)).op());
+    }
+
+    @Test
+    @DisplayName("compileExpr: UnaryOp(NOT) produces [expr, UnaryOp(NOT)]")
+    void compileExpr_unaryNot() {
+        var expr = new SqlPlanner.SqlExpr.UnaryOp(
+            SqlPlanner.UnaryOperator.NOT,
+            new SqlPlanner.SqlExpr.Literal(true));
+        var instrs = SqlCodegen.compileExpr(expr);
+        assertEquals(2, instrs.size());
+        assertInstanceOf(SqlCodegen.Instruction.UnaryOp.class, instrs.get(1));
+        assertEquals(SqlCodegen.UnaryOpCode.NOT,
+            ((SqlCodegen.Instruction.UnaryOp) instrs.get(1)).op());
+    }
+
+    @Test
+    @DisplayName("compileExpr: IsNull produces [expr, IsNull]")
+    void compileExpr_isNull() {
+        var expr = new SqlPlanner.SqlExpr.IsNull(
+            new SqlPlanner.SqlExpr.Column(null, "age"));
+        var instrs = SqlCodegen.compileExpr(expr);
+        assertEquals(2, instrs.size());
+        assertInstanceOf(SqlCodegen.Instruction.LoadColumn.class, instrs.get(0));
+        assertInstanceOf(SqlCodegen.Instruction.IsNull.class, instrs.get(1));
+    }
+
+    @Test
+    @DisplayName("compileExpr: IsNotNull produces [expr, IsNotNull]")
+    void compileExpr_isNotNull() {
+        var expr = new SqlPlanner.SqlExpr.IsNotNull(
+            new SqlPlanner.SqlExpr.Column(null, "age"));
+        var instrs = SqlCodegen.compileExpr(expr);
+        assertEquals(2, instrs.size());
+        assertInstanceOf(SqlCodegen.Instruction.IsNotNull.class, instrs.get(1));
+    }
+
+    @Test
+    @DisplayName("compileExpr: Between produces [value, low, high, Between]")
+    void compileExpr_between() {
+        var expr = new SqlPlanner.SqlExpr.Between(
+            new SqlPlanner.SqlExpr.Column(null, "age"),
+            new SqlPlanner.SqlExpr.Literal(18L),
+            new SqlPlanner.SqlExpr.Literal(65L));
+        var instrs = SqlCodegen.compileExpr(expr);
+        assertEquals(4, instrs.size());
+        assertInstanceOf(SqlCodegen.Instruction.LoadColumn.class, instrs.get(0));
+        assertInstanceOf(SqlCodegen.Instruction.LoadConst.class, instrs.get(1));
+        assertInstanceOf(SqlCodegen.Instruction.LoadConst.class, instrs.get(2));
+        assertInstanceOf(SqlCodegen.Instruction.Between.class, instrs.get(3));
+    }
+
+    @Test
+    @DisplayName("compileExpr: In(value, [a,b]) produces [value, a, b, InList(2)]")
+    void compileExpr_inList() {
+        var expr = new SqlPlanner.SqlExpr.In(
+            new SqlPlanner.SqlExpr.Column(null, "id"),
+            List.of(new SqlPlanner.SqlExpr.Literal(1L),
+                    new SqlPlanner.SqlExpr.Literal(2L)));
+        var instrs = SqlCodegen.compileExpr(expr);
+        assertEquals(4, instrs.size());
+        assertInstanceOf(SqlCodegen.Instruction.InList.class, instrs.get(3));
+        assertEquals(2, ((SqlCodegen.Instruction.InList) instrs.get(3)).n());
+    }
+
+    @Test
+    @DisplayName("compileExpr: Like produces [value, LoadConst(pattern), Like(false)]")
+    void compileExpr_like() {
+        var expr = new SqlPlanner.SqlExpr.Like(
+            new SqlPlanner.SqlExpr.Column(null, "name"),
+            "%Alice%");
+        var instrs = SqlCodegen.compileExpr(expr);
+        assertEquals(3, instrs.size());
+        assertInstanceOf(SqlCodegen.Instruction.LoadColumn.class, instrs.get(0));
+        assertInstanceOf(SqlCodegen.Instruction.LoadConst.class, instrs.get(1));
+        assertEquals("%Alice%", ((SqlCodegen.Instruction.LoadConst) instrs.get(1)).value());
+        assertInstanceOf(SqlCodegen.Instruction.Like.class, instrs.get(2));
+        assertFalse(((SqlCodegen.Instruction.Like) instrs.get(2)).negated());
+    }
+
+    @Test
+    @DisplayName("compileExpr: NotLike produces Like(negated=true)")
+    void compileExpr_notLike() {
+        var expr = new SqlPlanner.SqlExpr.NotLike(
+            new SqlPlanner.SqlExpr.Column(null, "name"),
+            "%Bob%");
+        var instrs = SqlCodegen.compileExpr(expr);
+        assertEquals(3, instrs.size());
+        assertInstanceOf(SqlCodegen.Instruction.Like.class, instrs.get(2));
+        assertTrue(((SqlCodegen.Instruction.Like) instrs.get(2)).negated());
+    }
+
+    @Test
+    @DisplayName("compileExpr: FuncCall produces [args..., CallScalar]")
+    void compileExpr_funcCall() {
+        var expr = new SqlPlanner.SqlExpr.FuncCall(
+            "UPPER",
+            List.of(new SqlPlanner.SqlExpr.Column(null, "name")));
+        var instrs = SqlCodegen.compileExpr(expr);
+        assertEquals(2, instrs.size());
+        assertInstanceOf(SqlCodegen.Instruction.LoadColumn.class, instrs.get(0));
+        assertInstanceOf(SqlCodegen.Instruction.CallScalar.class, instrs.get(1));
+        var cs = (SqlCodegen.Instruction.CallScalar) instrs.get(1);
+        assertEquals("upper", cs.func()); // lowercased
+        assertEquals(1, cs.nArgs());
+    }
+
+    @Test
+    @DisplayName("compileExpr: all BinaryOperators map correctly")
+    void compileExpr_allBinaryOps() {
+        var opMap = Map.of(
+            SqlPlanner.BinaryOperator.SUB,    SqlCodegen.BinaryOpCode.SUB,
+            SqlPlanner.BinaryOperator.MUL,    SqlCodegen.BinaryOpCode.MUL,
+            SqlPlanner.BinaryOperator.DIV,    SqlCodegen.BinaryOpCode.DIV,
+            SqlPlanner.BinaryOperator.MOD,    SqlCodegen.BinaryOpCode.MOD,
+            SqlPlanner.BinaryOperator.EQ,     SqlCodegen.BinaryOpCode.EQ,
+            SqlPlanner.BinaryOperator.NOT_EQ, SqlCodegen.BinaryOpCode.NEQ,
+            SqlPlanner.BinaryOperator.LT,     SqlCodegen.BinaryOpCode.LT,
+            SqlPlanner.BinaryOperator.LTE,    SqlCodegen.BinaryOpCode.LTE,
+            SqlPlanner.BinaryOperator.GT,     SqlCodegen.BinaryOpCode.GT,
+            SqlPlanner.BinaryOperator.GTE,    SqlCodegen.BinaryOpCode.GTE
+        );
+        for (var entry : opMap.entrySet()) {
+            var expr = new SqlPlanner.SqlExpr.BinaryOp(
+                entry.getKey(),
+                new SqlPlanner.SqlExpr.Literal(1L),
+                new SqlPlanner.SqlExpr.Literal(2L));
+            var instrs = SqlCodegen.compileExpr(expr);
+            var bop = (SqlCodegen.Instruction.BinaryOp) instrs.get(2);
+            assertEquals(entry.getValue(), bop.op(),
+                "Operator " + entry.getKey() + " should map to " + entry.getValue());
+        }
+    }
+
+    // ── 2. Scan / Project / Filter tests ─────────────────────────────────────
+
+    @Test
+    @DisplayName("Bare scan: program contains OpenScan, AdvanceCursor, CloseScan")
+    void compileScan_basic() {
+        var plan = projectScan("users", "u", "id", "id");
+        var prog = SqlCodegen.compileOptimized(plan);
+        assertEquals(1, count(prog, SqlCodegen.Instruction.OpenScan.class));
+        assertEquals(1, count(prog, SqlCodegen.Instruction.AdvanceCursor.class));
+        assertEquals(1, count(prog, SqlCodegen.Instruction.CloseScan.class));
+        assertEquals("users", first(prog, SqlCodegen.Instruction.OpenScan.class).table());
+    }
+
+    @Test
+    @DisplayName("Project(Scan) emits SetResultSchema + BeginRow + EmitColumn + EmitRow")
+    void compileProject_scan() {
+        var plan = projectScan("products", "p", "price", "price");
+        var prog = SqlCodegen.compileOptimized(plan);
+        assertEquals(1, count(prog, SqlCodegen.Instruction.SetResultSchema.class));
+        assertTrue(count(prog, SqlCodegen.Instruction.BeginRow.class) >= 1);
+        assertEquals(1, count(prog, SqlCodegen.Instruction.EmitColumn.class));
+        assertTrue(count(prog, SqlCodegen.Instruction.EmitRow.class) >= 1);
+    }
+
+    @Test
+    @DisplayName("Project(Scan) resultSchema contains output column name")
+    void compileProject_schema() {
+        var plan = projectScan("orders", "o", "amount", "total");
+        var prog = SqlCodegen.compileOptimized(plan);
+        assertEquals(List.of("total"), prog.resultSchema());
+    }
+
+    @Test
+    @DisplayName("Filter(Scan) emits JumpIfFalse instruction")
+    void compileFilter_scan() {
+        var scan   = new SqlOptimizer.OptimizedPlan.Scan("users", "u");
+        var filter = new SqlOptimizer.OptimizedPlan.Filter(
+            scan,
+            new SqlPlanner.SqlExpr.BinaryOp(
+                SqlPlanner.BinaryOperator.GT,
+                new SqlPlanner.SqlExpr.Column("u", "age"),
+                new SqlPlanner.SqlExpr.Literal(18L)));
+        var proj = new SqlOptimizer.OptimizedPlan.Project(
+            filter,
+            List.of(new SqlPlanner.OutputColumn.Expr(
+                new SqlPlanner.SqlExpr.Column("u", "name"), "name")));
+        var prog = SqlCodegen.compileOptimized(proj);
+        assertTrue(count(prog, SqlCodegen.Instruction.JumpIfFalse.class) >= 1);
+    }
+
+    @Test
+    @DisplayName("EmptyResult at top level: only Halt in program")
+    void compileEmptyResult_topLevel() {
+        var plan = new SqlOptimizer.OptimizedPlan.EmptyResult();
+        var prog = SqlCodegen.compileOptimized(plan);
+        assertEquals(1, count(prog, SqlCodegen.Instruction.Halt.class));
+        assertEquals(0, count(prog, SqlCodegen.Instruction.OpenScan.class));
+    }
+
+    @Test
+    @DisplayName("EmptyResult inside Filter: no scan loop emitted")
+    void compileEmptyResult_insideFilter() {
+        var plan = new SqlOptimizer.OptimizedPlan.Project(
+            new SqlOptimizer.OptimizedPlan.EmptyResult(),
+            List.of(new SqlPlanner.OutputColumn.Expr(
+                new SqlPlanner.SqlExpr.Literal(1L), "x")));
+        var prog = SqlCodegen.compileOptimized(plan);
+        assertEquals(0, count(prog, SqlCodegen.Instruction.OpenScan.class));
+        assertEquals(1, count(prog, SqlCodegen.Instruction.Halt.class));
+    }
+
+    // ── 3. JOIN tests ─────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("INNER JOIN: two nested AdvanceCursor instructions")
+    void compileInnerJoin() {
+        var left  = new SqlOptimizer.OptimizedPlan.Scan("users", "u");
+        var right = new SqlOptimizer.OptimizedPlan.Scan("orders", "o");
+        var join  = new SqlOptimizer.OptimizedPlan.Join(
+            left, right,
+            SqlPlanner.JoinKind.INNER,
+            new SqlPlanner.SqlExpr.BinaryOp(
+                SqlPlanner.BinaryOperator.EQ,
+                new SqlPlanner.SqlExpr.Column("u", "id"),
+                new SqlPlanner.SqlExpr.Column("o", "user_id")));
+        var proj = new SqlOptimizer.OptimizedPlan.Project(
+            join,
+            List.of(new SqlPlanner.OutputColumn.Expr(
+                new SqlPlanner.SqlExpr.Column("u", "name"), "name")));
+        var prog = SqlCodegen.compileOptimized(proj);
+        assertEquals(2, count(prog, SqlCodegen.Instruction.OpenScan.class));
+        assertEquals(2, count(prog, SqlCodegen.Instruction.AdvanceCursor.class));
+        assertEquals(2, count(prog, SqlCodegen.Instruction.CloseScan.class));
+    }
+
+    @Test
+    @DisplayName("CROSS JOIN: no condition, two nested scans")
+    void compileCrossJoin() {
+        var left  = new SqlOptimizer.OptimizedPlan.Scan("a", "a");
+        var right = new SqlOptimizer.OptimizedPlan.Scan("b", "b");
+        var join  = new SqlOptimizer.OptimizedPlan.Join(
+            left, right, SqlPlanner.JoinKind.CROSS, null);
+        var proj = new SqlOptimizer.OptimizedPlan.Project(
+            join,
+            List.of(new SqlPlanner.OutputColumn.Expr(
+                new SqlPlanner.SqlExpr.Column("a", "x"), "x")));
+        var prog = SqlCodegen.compileOptimized(proj);
+        assertEquals(2, count(prog, SqlCodegen.Instruction.OpenScan.class));
+        assertEquals(0, count(prog, SqlCodegen.Instruction.JoinBeginRow.class));
+    }
+
+    @Test
+    @DisplayName("LEFT JOIN: JoinBeginRow / JoinSetMatched / JoinIfMatched present")
+    void compileLeftJoin() {
+        var left  = new SqlOptimizer.OptimizedPlan.Scan("users", "u");
+        var right = new SqlOptimizer.OptimizedPlan.Scan("orders", "o");
+        var join  = new SqlOptimizer.OptimizedPlan.Join(
+            left, right,
+            SqlPlanner.JoinKind.LEFT,
+            new SqlPlanner.SqlExpr.BinaryOp(
+                SqlPlanner.BinaryOperator.EQ,
+                new SqlPlanner.SqlExpr.Column("u", "id"),
+                new SqlPlanner.SqlExpr.Column("o", "user_id")));
+        var proj = new SqlOptimizer.OptimizedPlan.Project(
+            join,
+            List.of(new SqlPlanner.OutputColumn.Expr(
+                new SqlPlanner.SqlExpr.Column("u", "name"), "name")));
+        var prog = SqlCodegen.compileOptimized(proj);
+        assertTrue(count(prog, SqlCodegen.Instruction.JoinBeginRow.class) >= 1);
+        assertTrue(count(prog, SqlCodegen.Instruction.JoinSetMatched.class) >= 1);
+        assertTrue(count(prog, SqlCodegen.Instruction.JoinIfMatched.class) >= 1);
+    }
+
+    // ── 4. Aggregate tests ────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("COUNT(*) aggregate: InitAgg(COUNT_STAR) + UpdateAgg + AdvanceGroupKey + FinalizeAgg")
+    void compileAggregate_countStar() {
+        var scan = new SqlOptimizer.OptimizedPlan.Scan("users", "u");
+        var agg  = new SqlOptimizer.OptimizedPlan.Aggregate(
+            scan,
+            List.of(),
+            List.of(new SqlPlanner.AggregateItem(
+                SqlPlanner.AggFunction.COUNT,
+                new SqlPlanner.AggArg.Star(),
+                "_agg0",
+                false)));
+        var proj = new SqlOptimizer.OptimizedPlan.Project(
+            agg,
+            List.of(new SqlPlanner.OutputColumn.Expr(
+                new SqlPlanner.SqlExpr.AggExpr(
+                    SqlPlanner.AggFunction.COUNT,
+                    new SqlPlanner.AggArg.Star(), false),
+                "cnt")));
+        var prog = SqlCodegen.compileOptimized(proj);
+        assertEquals(1, count(prog, SqlCodegen.Instruction.InitAgg.class));
+        assertEquals(1, count(prog, SqlCodegen.Instruction.UpdateAgg.class));
+        assertEquals(1, count(prog, SqlCodegen.Instruction.AdvanceGroupKey.class));
+        assertEquals(1, count(prog, SqlCodegen.Instruction.FinalizeAgg.class));
+        var init = first(prog, SqlCodegen.Instruction.InitAgg.class);
+        assertEquals(SqlCodegen.AggFunc.COUNT_STAR, init.func());
+    }
+
+    @Test
+    @DisplayName("SUM aggregate maps to AggFunc.SUM")
+    void compileAggregate_sum() {
+        var scan = new SqlOptimizer.OptimizedPlan.Scan("orders", "o");
+        var agg  = new SqlOptimizer.OptimizedPlan.Aggregate(
+            scan,
+            List.of(),
+            List.of(new SqlPlanner.AggregateItem(
+                SqlPlanner.AggFunction.SUM,
+                new SqlPlanner.AggArg.Expr(new SqlPlanner.SqlExpr.Column("o", "amount")),
+                "_agg0",
+                false)));
+        var proj = new SqlOptimizer.OptimizedPlan.Project(
+            agg,
+            List.of(new SqlPlanner.OutputColumn.Expr(
+                new SqlPlanner.SqlExpr.AggExpr(
+                    SqlPlanner.AggFunction.SUM,
+                    new SqlPlanner.AggArg.Expr(new SqlPlanner.SqlExpr.Column("o", "amount")), false),
+                "total")));
+        var prog = SqlCodegen.compileOptimized(proj);
+        var init = first(prog, SqlCodegen.Instruction.InitAgg.class);
+        assertEquals(SqlCodegen.AggFunc.SUM, init.func());
+    }
+
+    @Test
+    @DisplayName("GROUP BY aggregate: SaveGroupKey emitted in scan loop")
+    void compileAggregate_groupBy() {
+        var scan = new SqlOptimizer.OptimizedPlan.Scan("orders", "o");
+        var agg  = new SqlOptimizer.OptimizedPlan.Aggregate(
+            scan,
+            List.of(new SqlPlanner.SqlExpr.Column("o", "status")),
+            List.of(new SqlPlanner.AggregateItem(
+                SqlPlanner.AggFunction.COUNT,
+                new SqlPlanner.AggArg.Star(),
+                "_agg0",
+                false)));
+        var proj = new SqlOptimizer.OptimizedPlan.Project(
+            agg,
+            List.of(
+                new SqlPlanner.OutputColumn.Expr(
+                    new SqlPlanner.SqlExpr.Column("o", "status"), "status"),
+                new SqlPlanner.OutputColumn.Expr(
+                    new SqlPlanner.SqlExpr.AggExpr(SqlPlanner.AggFunction.COUNT,
+                        new SqlPlanner.AggArg.Star(), false), "cnt")));
+        var prog = SqlCodegen.compileOptimized(proj);
+        assertTrue(count(prog, SqlCodegen.Instruction.SaveGroupKey.class) >= 1);
+        assertTrue(count(prog, SqlCodegen.Instruction.AdvanceGroupKey.class) >= 1);
+    }
+
+    // ── 5. Post-processing tests ──────────────────────────────────────────────
+
+    @Test
+    @DisplayName("Sort: SortResult emitted after scan loop")
+    void compileSort() {
+        var inner = projectScan("users", "u", "name", "name");
+        var sort  = new SqlOptimizer.OptimizedPlan.Sort(
+            inner,
+            List.of(new SqlPlanner.SortKey(
+                new SqlPlanner.SqlExpr.Column("u", "name"),
+                SqlPlanner.SortDir.ASC,
+                SqlPlanner.NullOrder.NULLS_LAST)));
+        var prog = SqlCodegen.compileOptimized(sort);
+        assertEquals(1, count(prog, SqlCodegen.Instruction.SortResult.class));
+        // SortResult must appear after CloseScan
+        int sortIdx = -1, closeIdx = -1;
+        var instrs = prog.instructions();
+        for (int i = 0; i < instrs.size(); i++) {
+            if (instrs.get(i) instanceof SqlCodegen.Instruction.SortResult) sortIdx = i;
+            if (instrs.get(i) instanceof SqlCodegen.Instruction.CloseScan) closeIdx = i;
+        }
+        assertTrue(sortIdx > closeIdx, "SortResult must come after CloseScan");
+    }
+
+    @Test
+    @DisplayName("Sort key direction and nulls order are preserved")
+    void compileSort_keyDetails() {
+        var inner = projectScan("users", "u", "age", "age");
+        var sort  = new SqlOptimizer.OptimizedPlan.Sort(
+            inner,
+            List.of(new SqlPlanner.SortKey(
+                new SqlPlanner.SqlExpr.Column("u", "age"),
+                SqlPlanner.SortDir.DESC,
+                SqlPlanner.NullOrder.NULLS_FIRST)));
+        var prog = SqlCodegen.compileOptimized(sort);
+        var sr = first(prog, SqlCodegen.Instruction.SortResult.class);
+        assertEquals(1, sr.keys().size());
+        assertEquals(SqlCodegen.Direction.DESC, sr.keys().get(0).direction());
+        assertEquals(SqlCodegen.NullsOrder.FIRST, sr.keys().get(0).nullsOrder());
+        assertEquals("age", sr.keys().get(0).column());
+    }
+
+    @Test
+    @DisplayName("Limit: LimitResult emitted with correct count and offset")
+    void compileLimit() {
+        var inner = projectScan("users", "u", "id", "id");
+        var lim   = new SqlOptimizer.OptimizedPlan.Limit(inner, 10L, 5L);
+        var prog  = SqlCodegen.compileOptimized(lim);
+        assertEquals(1, count(prog, SqlCodegen.Instruction.LimitResult.class));
+        var lr = first(prog, SqlCodegen.Instruction.LimitResult.class);
+        assertEquals(10L, lr.count());
+        assertEquals(5L, lr.offset());
+    }
+
+    @Test
+    @DisplayName("Distinct: DistinctResult emitted after scan")
+    void compileDistinct() {
+        var inner = projectScan("users", "u", "name", "name");
+        var dist  = new SqlOptimizer.OptimizedPlan.Distinct(inner);
+        var prog  = SqlCodegen.compileOptimized(dist);
+        assertEquals(1, count(prog, SqlCodegen.Instruction.DistinctResult.class));
+    }
+
+    @Test
+    @DisplayName("Sort(Limit(Project(Scan))): SortResult appears before LimitResult")
+    void compileSortLimit_ordering() {
+        var inner = projectScan("users", "u", "name", "name");
+        var lim   = new SqlOptimizer.OptimizedPlan.Limit(inner, 10L, null);
+        var sort  = new SqlOptimizer.OptimizedPlan.Sort(
+            lim,
+            List.of(new SqlPlanner.SortKey(
+                new SqlPlanner.SqlExpr.Column("u", "name"),
+                SqlPlanner.SortDir.ASC,
+                SqlPlanner.NullOrder.NULLS_LAST)));
+        var prog  = SqlCodegen.compileOptimized(sort);
+        int sortIdx  = -1, limitIdx = -1;
+        var instrs = prog.instructions();
+        for (int i = 0; i < instrs.size(); i++) {
+            if (instrs.get(i) instanceof SqlCodegen.Instruction.SortResult)  sortIdx  = i;
+            if (instrs.get(i) instanceof SqlCodegen.Instruction.LimitResult) limitIdx = i;
+        }
+        assertTrue(sortIdx >= 0, "SortResult not found");
+        assertTrue(limitIdx >= 0, "LimitResult not found");
+        assertTrue(sortIdx < limitIdx, "SortResult must precede LimitResult");
+    }
+
+    // ── 6. DML tests ──────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("INSERT: InsertRow emitted for each value row")
+    void compileInsert() {
+        var plan = new SqlOptimizer.OptimizedPlan.Insert(
+            "users",
+            List.of("name", "age"),
+            List.of(
+                List.of(new SqlPlanner.SqlExpr.Literal("Alice"),
+                        new SqlPlanner.SqlExpr.Literal(30L)),
+                List.of(new SqlPlanner.SqlExpr.Literal("Bob"),
+                        new SqlPlanner.SqlExpr.Literal(25L))));
+        var prog = SqlCodegen.compileOptimized(plan);
+        assertEquals(2, count(prog, SqlCodegen.Instruction.InsertRow.class));
+        var ir = first(prog, SqlCodegen.Instruction.InsertRow.class);
+        assertEquals("users", ir.table());
+        assertEquals(List.of("name", "age"), ir.columns());
+    }
+
+    @Test
+    @DisplayName("UPDATE: scan loop + UpdateRows emitted")
+    void compileUpdate() {
+        var plan = new SqlOptimizer.OptimizedPlan.Update(
+            "users",
+            List.of(new SqlPlanner.Assignment("name",
+                new SqlPlanner.SqlExpr.Literal("Charlie"))),
+            new SqlPlanner.SqlExpr.BinaryOp(
+                SqlPlanner.BinaryOperator.EQ,
+                new SqlPlanner.SqlExpr.Column("users", "id"),
+                new SqlPlanner.SqlExpr.Literal(1L)));
+        var prog = SqlCodegen.compileOptimized(plan);
+        assertEquals(1, count(prog, SqlCodegen.Instruction.OpenScan.class));
+        assertEquals(1, count(prog, SqlCodegen.Instruction.UpdateRows.class));
+        assertTrue(count(prog, SqlCodegen.Instruction.JumpIfFalse.class) >= 1);
+    }
+
+    @Test
+    @DisplayName("UPDATE without predicate: no JumpIfFalse emitted")
+    void compileUpdate_noPredicate() {
+        var plan = new SqlOptimizer.OptimizedPlan.Update(
+            "users",
+            List.of(new SqlPlanner.Assignment("active",
+                new SqlPlanner.SqlExpr.Literal(true))),
+            null); // no WHERE clause
+        var prog = SqlCodegen.compileOptimized(plan);
+        assertEquals(0, count(prog, SqlCodegen.Instruction.JumpIfFalse.class));
+        assertEquals(1, count(prog, SqlCodegen.Instruction.UpdateRows.class));
+    }
+
+    @Test
+    @DisplayName("DELETE: scan loop + DeleteRows emitted")
+    void compileDelete() {
+        var plan = new SqlOptimizer.OptimizedPlan.Delete(
+            "users",
+            new SqlPlanner.SqlExpr.BinaryOp(
+                SqlPlanner.BinaryOperator.LT,
+                new SqlPlanner.SqlExpr.Column("users", "age"),
+                new SqlPlanner.SqlExpr.Literal(18L)));
+        var prog = SqlCodegen.compileOptimized(plan);
+        assertEquals(1, count(prog, SqlCodegen.Instruction.OpenScan.class));
+        assertEquals(1, count(prog, SqlCodegen.Instruction.DeleteRows.class));
+    }
+
+    @Test
+    @DisplayName("DELETE without predicate: no JumpIfFalse")
+    void compileDelete_noPredicate() {
+        var plan = new SqlOptimizer.OptimizedPlan.Delete("users", null);
+        var prog = SqlCodegen.compileOptimized(plan);
+        assertEquals(0, count(prog, SqlCodegen.Instruction.JumpIfFalse.class));
+        assertEquals(1, count(prog, SqlCodegen.Instruction.DeleteRows.class));
+    }
+
+    // ── 7. DDL tests ──────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("CREATE TABLE: CreateTable instruction emitted + Halt")
+    void compileCreateTable() {
+        var cols = List.of(
+            new SqlPlanner.ColumnDef("id",   "INTEGER", true, true,  false, null),
+            new SqlPlanner.ColumnDef("name", "TEXT",    true, false, false, null));
+        var plan = new SqlOptimizer.OptimizedPlan.CreateTable("employees", false, cols);
+        var prog = SqlCodegen.compileOptimized(plan);
+        assertEquals(1, count(prog, SqlCodegen.Instruction.CreateTable.class));
+        assertEquals(1, count(prog, SqlCodegen.Instruction.Halt.class));
+        var ct = first(prog, SqlCodegen.Instruction.CreateTable.class);
+        assertEquals("employees", ct.table());
+        assertFalse(ct.ifNotExists());
+        assertEquals(2, ct.columns().size());
+    }
+
+    @Test
+    @DisplayName("CREATE TABLE IF NOT EXISTS: ifNotExists=true")
+    void compileCreateTable_ifNotExists() {
+        var plan = new SqlOptimizer.OptimizedPlan.CreateTable("t", true, List.of());
+        var prog = SqlCodegen.compileOptimized(plan);
+        assertTrue(first(prog, SqlCodegen.Instruction.CreateTable.class).ifNotExists());
+    }
+
+    @Test
+    @DisplayName("DROP TABLE: DropTable instruction emitted + Halt")
+    void compileDropTable() {
+        var plan = new SqlOptimizer.OptimizedPlan.DropTable("old_table", false);
+        var prog = SqlCodegen.compileOptimized(plan);
+        assertEquals(1, count(prog, SqlCodegen.Instruction.DropTable.class));
+        assertEquals(1, count(prog, SqlCodegen.Instruction.Halt.class));
+        var dt = first(prog, SqlCodegen.Instruction.DropTable.class);
+        assertEquals("old_table", dt.table());
+        assertFalse(dt.ifExists());
+    }
+
+    @Test
+    @DisplayName("DROP TABLE IF EXISTS: ifExists=true")
+    void compileDropTable_ifExists() {
+        var plan = new SqlOptimizer.OptimizedPlan.DropTable("maybe", true);
+        var prog = SqlCodegen.compileOptimized(plan);
+        assertTrue(first(prog, SqlCodegen.Instruction.DropTable.class).ifExists());
+    }
+
+    // ── 8. Program-level property tests ──────────────────────────────────────
+
+    @Test
+    @DisplayName("Labels map contains entries for all Label instructions")
+    void labelsMap_complete() {
+        var plan = projectScan("users", "u", "id", "id");
+        var prog = SqlCodegen.compileOptimized(plan);
+        // Every Label instruction must have a corresponding entry in the labels map.
+        for (var instr : prog.instructions()) {
+            if (instr instanceof SqlCodegen.Instruction.Label lb) {
+                assertTrue(prog.labels().containsKey(lb.name()),
+                    "Label '" + lb.name() + "' not in labels map");
+                assertEquals(prog.instructions().indexOf(lb),
+                    prog.labels().get(lb.name()),
+                    "Label '" + lb.name() + "' has wrong index");
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("Halt is always present in the program")
+    void halt_alwaysPresent() {
+        var plan = projectScan("x", "x", "y", "y");
+        var prog = SqlCodegen.compileOptimized(plan);
+        assertEquals(1, count(prog, SqlCodegen.Instruction.Halt.class));
+        // Halt is the last instruction.
+        var instrs = prog.instructions();
+        assertInstanceOf(SqlCodegen.Instruction.Halt.class, instrs.get(instrs.size() - 1));
+    }
+
+    @Test
+    @DisplayName("Program.resultSchema matches SetResultSchema columns")
+    void resultSchema_matchesSetResultSchema() {
+        var plan = new SqlOptimizer.OptimizedPlan.Project(
+            new SqlOptimizer.OptimizedPlan.Scan("users", "u"),
+            List.of(
+                new SqlPlanner.OutputColumn.Expr(
+                    new SqlPlanner.SqlExpr.Column("u", "id"), "user_id"),
+                new SqlPlanner.OutputColumn.Expr(
+                    new SqlPlanner.SqlExpr.Column("u", "name"), "full_name")));
+        var prog = SqlCodegen.compileOptimized(plan);
+        assertEquals(List.of("user_id", "full_name"), prog.resultSchema());
+        var srs = first(prog, SqlCodegen.Instruction.SetResultSchema.class);
+        assertEquals(prog.resultSchema(), srs.columns());
+    }
+
+    @Test
+    @DisplayName("compile(LogicalPlan) convenience method works end-to-end")
+    void compile_logicalPlan() {
+        // Build a LogicalPlan directly and verify compile() produces a valid Program.
+        var logical = new SqlPlanner.LogicalPlan.Project(
+            new SqlPlanner.LogicalPlan.Scan("items", "i"),
+            List.of(new SqlPlanner.OutputColumn.Expr(
+                new SqlPlanner.SqlExpr.Column("i", "sku"), "sku")));
+        var prog = SqlCodegen.compile(logical);
+        assertNotNull(prog);
+        assertTrue(prog.instructions().size() > 0);
+        assertEquals(1, count(prog, SqlCodegen.Instruction.Halt.class));
+    }
+
+    @Test
+    @DisplayName("Scan with alias registers alias in cursor map (LoadColumn uses alias's cursor)")
+    void compileScan_aliasedCursor() {
+        // The column reference uses alias "u" — the codegen must resolve it to cursor 0.
+        var plan = new SqlOptimizer.OptimizedPlan.Project(
+            new SqlOptimizer.OptimizedPlan.Scan("users", "u"),
+            List.of(new SqlPlanner.OutputColumn.Expr(
+                new SqlPlanner.SqlExpr.Column("u", "id"), "id")));
+        var prog = SqlCodegen.compileOptimized(plan);
+        // LoadColumn should reference cursor 0.
+        var lc = first(prog, SqlCodegen.Instruction.LoadColumn.class);
+        assertEquals(0, lc.cursorId());
+        assertEquals("id", lc.column());
+    }
+
+    @Test
+    @DisplayName("NotIn compiles to InList + UnaryOp(NOT)")
+    void compileExpr_notIn() {
+        var expr = new SqlPlanner.SqlExpr.NotIn(
+            new SqlPlanner.SqlExpr.Column(null, "status"),
+            List.of(new SqlPlanner.SqlExpr.Literal("deleted"),
+                    new SqlPlanner.SqlExpr.Literal("archived")));
+        var instrs = SqlCodegen.compileExpr(expr);
+        // value + 2 items + InList + NOT = 5 instructions
+        assertEquals(5, instrs.size());
+        assertInstanceOf(SqlCodegen.Instruction.InList.class, instrs.get(3));
+        assertInstanceOf(SqlCodegen.Instruction.UnaryOp.class, instrs.get(4));
+        assertEquals(SqlCodegen.UnaryOpCode.NOT,
+            ((SqlCodegen.Instruction.UnaryOp) instrs.get(4)).op());
+    }
+
+    @Test
+    @DisplayName("FuncCall with multiple args: all args emitted before CallScalar")
+    void compileExpr_funcCall_multipleArgs() {
+        var expr = new SqlPlanner.SqlExpr.FuncCall(
+            "SUBSTR",
+            List.of(
+                new SqlPlanner.SqlExpr.Column(null, "name"),
+                new SqlPlanner.SqlExpr.Literal(1L),
+                new SqlPlanner.SqlExpr.Literal(3L)));
+        var instrs = SqlCodegen.compileExpr(expr);
+        assertEquals(4, instrs.size());
+        var cs = (SqlCodegen.Instruction.CallScalar) instrs.get(3);
+        assertEquals("substr", cs.func());
+        assertEquals(3, cs.nArgs());
+    }
+
+    @Test
+    @DisplayName("compileExpr: AND and OR operators map correctly")
+    void compileExpr_andOrOps() {
+        var and = new SqlPlanner.SqlExpr.BinaryOp(
+            SqlPlanner.BinaryOperator.AND,
+            new SqlPlanner.SqlExpr.Literal(true),
+            new SqlPlanner.SqlExpr.Literal(false));
+        var andInstrs = SqlCodegen.compileExpr(and);
+        assertEquals(SqlCodegen.BinaryOpCode.AND,
+            ((SqlCodegen.Instruction.BinaryOp) andInstrs.get(2)).op());
+
+        var or = new SqlPlanner.SqlExpr.BinaryOp(
+            SqlPlanner.BinaryOperator.OR,
+            new SqlPlanner.SqlExpr.Literal(true),
+            new SqlPlanner.SqlExpr.Literal(false));
+        var orInstrs = SqlCodegen.compileExpr(or);
+        assertEquals(SqlCodegen.BinaryOpCode.OR,
+            ((SqlCodegen.Instruction.BinaryOp) orInstrs.get(2)).op());
+    }
+
+    @Test
+    @DisplayName("RIGHT JOIN: JoinBeginRow / JoinSetMatched / JoinIfMatched present")
+    void compileRightJoin() {
+        var left  = new SqlOptimizer.OptimizedPlan.Scan("users", "u");
+        var right = new SqlOptimizer.OptimizedPlan.Scan("orders", "o");
+        var join  = new SqlOptimizer.OptimizedPlan.Join(
+            left, right,
+            SqlPlanner.JoinKind.RIGHT,
+            new SqlPlanner.SqlExpr.BinaryOp(
+                SqlPlanner.BinaryOperator.EQ,
+                new SqlPlanner.SqlExpr.Column("u", "id"),
+                new SqlPlanner.SqlExpr.Column("o", "user_id")));
+        var proj = new SqlOptimizer.OptimizedPlan.Project(
+            join,
+            List.of(new SqlPlanner.OutputColumn.Expr(
+                new SqlPlanner.SqlExpr.Column("o", "id"), "oid")));
+        var prog = SqlCodegen.compileOptimized(proj);
+        assertTrue(count(prog, SqlCodegen.Instruction.JoinBeginRow.class) >= 1);
+        assertTrue(count(prog, SqlCodegen.Instruction.JoinSetMatched.class) >= 1);
+        assertTrue(count(prog, SqlCodegen.Instruction.JoinIfMatched.class) >= 1);
+    }
+
+    @Test
+    @DisplayName("LEFT JOIN without condition: JoinSetMatched emitted unconditionally")
+    void compileLeftJoin_noCondition() {
+        var left  = new SqlOptimizer.OptimizedPlan.Scan("a", "a");
+        var right = new SqlOptimizer.OptimizedPlan.Scan("b", "b");
+        var join  = new SqlOptimizer.OptimizedPlan.Join(
+            left, right, SqlPlanner.JoinKind.LEFT, null);
+        var proj  = new SqlOptimizer.OptimizedPlan.Project(
+            join,
+            List.of(new SqlPlanner.OutputColumn.Expr(
+                new SqlPlanner.SqlExpr.Column("a", "x"), "x")));
+        var prog  = SqlCodegen.compileOptimized(proj);
+        assertTrue(count(prog, SqlCodegen.Instruction.JoinSetMatched.class) >= 1);
+    }
+
+    @Test
+    @DisplayName("Bare Aggregate (no outer Project): bare aggregate path runs")
+    void compileBareAggregate() {
+        // An Aggregate not wrapped by Project falls to the bare aggregate branch.
+        var scan = new SqlOptimizer.OptimizedPlan.Scan("users", "u");
+        var agg  = new SqlOptimizer.OptimizedPlan.Aggregate(
+            scan,
+            List.of(),
+            List.of(new SqlPlanner.AggregateItem(
+                SqlPlanner.AggFunction.MAX,
+                new SqlPlanner.AggArg.Expr(new SqlPlanner.SqlExpr.Column("u", "age")),
+                "_agg0",
+                false)));
+        var prog = SqlCodegen.compileOptimized(agg);
+        assertTrue(count(prog, SqlCodegen.Instruction.InitAgg.class) >= 1);
+        var init = first(prog, SqlCodegen.Instruction.InitAgg.class);
+        assertEquals(SqlCodegen.AggFunc.MAX, init.func());
+    }
+
+    @Test
+    @DisplayName("AVG and MIN aggregate functions map correctly")
+    void compileAggregate_avgMin() {
+        // AVG
+        var scanAvg = new SqlOptimizer.OptimizedPlan.Scan("t", "t");
+        var aggAvg  = new SqlOptimizer.OptimizedPlan.Aggregate(
+            scanAvg, List.of(),
+            List.of(new SqlPlanner.AggregateItem(
+                SqlPlanner.AggFunction.AVG,
+                new SqlPlanner.AggArg.Expr(new SqlPlanner.SqlExpr.Column("t", "v")),
+                "_agg0", false)));
+        var progAvg = SqlCodegen.compileOptimized(aggAvg);
+        assertEquals(SqlCodegen.AggFunc.AVG, first(progAvg, SqlCodegen.Instruction.InitAgg.class).func());
+
+        // MIN
+        var scanMin = new SqlOptimizer.OptimizedPlan.Scan("t", "t");
+        var aggMin  = new SqlOptimizer.OptimizedPlan.Aggregate(
+            scanMin, List.of(),
+            List.of(new SqlPlanner.AggregateItem(
+                SqlPlanner.AggFunction.MIN,
+                new SqlPlanner.AggArg.Expr(new SqlPlanner.SqlExpr.Column("t", "v")),
+                "_agg0", false)));
+        var progMin = SqlCodegen.compileOptimized(aggMin);
+        assertEquals(SqlCodegen.AggFunc.MIN, first(progMin, SqlCodegen.Instruction.InitAgg.class).func());
+    }
+
+    @Test
+    @DisplayName("COUNT(distinct col) maps to COUNT (not COUNT_STAR)")
+    void compileAggregate_countDistinct() {
+        var scan = new SqlOptimizer.OptimizedPlan.Scan("t", "t");
+        var agg  = new SqlOptimizer.OptimizedPlan.Aggregate(
+            scan, List.of(),
+            List.of(new SqlPlanner.AggregateItem(
+                SqlPlanner.AggFunction.COUNT,
+                new SqlPlanner.AggArg.Expr(new SqlPlanner.SqlExpr.Column("t", "id")),
+                "_agg0", true)));
+        var prog = SqlCodegen.compileOptimized(agg);
+        var init = first(prog, SqlCodegen.Instruction.InitAgg.class);
+        assertEquals(SqlCodegen.AggFunc.COUNT, init.func());
+        assertTrue(init.distinct());
+    }
+
+    @Test
+    @DisplayName("Having node in scan body: strips Having and recurses to inner")
+    void compileScanBody_havingStripped() {
+        // Having appears in the scan-body path when an Aggregate is not wrapped by Project.
+        // We build: Aggregate(Having(Scan)) — the Having wraps the raw scan.
+        var scan    = new SqlOptimizer.OptimizedPlan.Scan("orders", "o");
+        var having  = new SqlOptimizer.OptimizedPlan.Having(
+            scan,
+            new SqlPlanner.SqlExpr.BinaryOp(
+                SqlPlanner.BinaryOperator.GT,
+                new SqlPlanner.SqlExpr.Column("o", "amount"),
+                new SqlPlanner.SqlExpr.Literal(100L)));
+        var agg = new SqlOptimizer.OptimizedPlan.Aggregate(
+            having, List.of(),
+            List.of(new SqlPlanner.AggregateItem(
+                SqlPlanner.AggFunction.COUNT, new SqlPlanner.AggArg.Star(), "_agg0", false)));
+        var prog = SqlCodegen.compileOptimized(agg);
+        // Should still produce a scan loop and aggregate instructions
+        assertTrue(count(prog, SqlCodegen.Instruction.OpenScan.class) >= 1);
+        assertTrue(count(prog, SqlCodegen.Instruction.InitAgg.class) >= 1);
+    }
+
+    @Test
+    @DisplayName("compileExpr: AggExpr with Expr arg compiles arg expression")
+    void compileExpr_aggExprWithArg() {
+        // AggExpr is typically not compiled standalone, but when encountered
+        // in a non-aggregate context the code should handle it gracefully.
+        var expr = new SqlPlanner.SqlExpr.AggExpr(
+            SqlPlanner.AggFunction.SUM,
+            new SqlPlanner.AggArg.Expr(new SqlPlanner.SqlExpr.Column(null, "price")),
+            false);
+        var instrs = SqlCodegen.compileExpr(expr);
+        // Should compile the inner expression
+        assertEquals(1, instrs.size());
+        assertInstanceOf(SqlCodegen.Instruction.LoadColumn.class, instrs.get(0));
+    }
+
+    @Test
+    @DisplayName("compileExpr: AggExpr with Star arg returns LoadConst(null)")
+    void compileExpr_aggExprStar() {
+        var expr = new SqlPlanner.SqlExpr.AggExpr(
+            SqlPlanner.AggFunction.COUNT,
+            new SqlPlanner.AggArg.Star(),
+            false);
+        var instrs = SqlCodegen.compileExpr(expr);
+        assertEquals(1, instrs.size());
+        assertInstanceOf(SqlCodegen.Instruction.LoadConst.class, instrs.get(0));
+        assertNull(((SqlCodegen.Instruction.LoadConst) instrs.get(0)).value());
+    }
+
+    @Test
+    @DisplayName("compileExpr: Wildcard returns empty instruction list")
+    void compileExpr_wildcard() {
+        var instrs = SqlCodegen.compileExpr(new SqlPlanner.SqlExpr.Wildcard());
+        assertEquals(0, instrs.size());
+    }
+
+    @Test
+    @DisplayName("OutputColumn.Star in Project: schema contains *")
+    void compileProject_starColumn() {
+        var plan = new SqlOptimizer.OptimizedPlan.Project(
+            new SqlOptimizer.OptimizedPlan.Scan("t", "t"),
+            List.of(new SqlPlanner.OutputColumn.Star()));
+        var prog = SqlCodegen.compileOptimized(plan);
+        var srs = first(prog, SqlCodegen.Instruction.SetResultSchema.class);
+        assertEquals(List.of("*"), srs.columns());
+    }
+
+    @Test
+    @DisplayName("Project output column with no alias uses column name as schema name")
+    void compileProject_columnNameInferredFromColumn() {
+        // When alias is null and expression is a Column, use the column name.
+        var plan = new SqlOptimizer.OptimizedPlan.Project(
+            new SqlOptimizer.OptimizedPlan.Scan("t", "t"),
+            List.of(new SqlPlanner.OutputColumn.Expr(
+                new SqlPlanner.SqlExpr.Column("t", "price"), null)));
+        var prog = SqlCodegen.compileOptimized(plan);
+        assertEquals(List.of("price"), prog.resultSchema());
+    }
+}


### PR DESCRIPTION
## Summary

- Implements `sql-codegen`, the Java package that compiles `OptimizedPlan` trees (from `sql-optimizer`) into flat bytecode `Program` objects for the SQL VM.
- `Instruction` is a sealed interface with 40+ typed record subtypes covering stack ops, cursor ops, aggregates, group keys, post-processing, joins, DML, DDL, and control flow.
- Two-phase aggregate compilation: accumulation loop (InitAgg/UpdateAgg during scan) + group-iteration loop (AdvanceGroupKey/FinalizeAgg/EmitRow after scan).
- Nested-loop join support: INNER/CROSS as direct nested loops; LEFT via JoinBeginRow/JoinSetMatched/JoinIfMatched; RIGHT mirrors LEFT with swapped sides.
- Post-processing wrappers (Sort/Limit/Distinct) are peeled outermost-first from the plan top and appended after the scan loop so Sort runs before Limit.

## Test plan

- [ ] 61 JUnit 5 unit tests covering expressions, scans, filters, all join types, all aggregate functions, GROUP BY, ORDER BY, LIMIT, DISTINCT, INSERT, UPDATE, DELETE, CREATE TABLE, DROP TABLE, label resolution, and result schema extraction.
- [ ] JaCoCo line coverage enforced at >= 80% via `gradle check`.
- [ ] Security review passed: pure in-memory compiler, no I/O, no injection vectors, no mutable statics.
- [ ] `settings.gradle.kts` includes `includeBuild` for both `sql-planner` and `sql-optimizer` (lesson from PR #7073).

## Dependencies

Depends on `java-level1-sql-optimizer` (already merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)