### PR TITLE
feat(fsharp-sql-codegen): F# bytecode code generator (Level 1 prerequisite)

### DIFF
--- a/code/packages/fsharp/sql-codegen/BUILD
+++ b/code/packages/fsharp/sql-codegen/BUILD
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.SqlCodegen.FSharp.Tests.fsproj --disable-build-servers /p:CollectCoverage=true "/p:Include=[CodingAdventures.SqlCodegen.FSharp]*" /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/sql-codegen/BUILD_windows
+++ b/code/packages/fsharp/sql-codegen/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.SqlCodegen.FSharp.Tests.fsproj --disable-build-servers /p:CollectCoverage=true "/p:Include=[CodingAdventures.SqlCodegen.FSharp]*" /p:Threshold=80 /p:ThresholdType=line

--- a/code/packages/fsharp/sql-codegen/CHANGELOG.md
+++ b/code/packages/fsharp/sql-codegen/CHANGELOG.md
@@ -1,0 +1,43 @@
+# Changelog
+
+## [0.1.0] — 2026-06-30
+
+### Added
+
+- Initial implementation of `SqlCodegen.compile : OptimizedPlan -> Program`
+- `SqlCodegen.compileExpression : Expr -> Instruction list` helper (exported for testing)
+- Full `Instruction` discriminated union with 36 instruction types mirroring the C# design:
+  - Stack/memory: `LoadConst`, `LoadColumn`, `LoadParam`, `LoadGroupKey`, `LoadOuterColumn`, `Pop`
+  - Arithmetic/comparison: `BinaryOpInstr`, `UnaryOpInstr`
+  - Predicate tests: `IsNull`, `IsNotNull`, `Between`, `Like`, `InList`
+  - Cursor control: `OpenScan`, `AdvanceCursor`, `JumpIfExhausted`, `CloseScan`
+  - Row construction: `BeginRow`, `EmitColumn`, `EmitRow`
+  - Aggregation: `InitAgg`, `UpdateAgg`, `FinalizeAgg`, `SaveGroupKey`, `LoadGroupKey`, `AdvanceGroup`
+  - Control flow: `Label`, `Jump`, `JumpIfTrue`, `JumpIfFalse`, `Halt`
+  - DDL: `CreateTable`, `DropTable`
+  - DML: `InsertRow`, `UpdateRows`, `DeleteRows`
+  - Transactions: `BeginTransaction`, `CommitTransaction`, `RollbackTransaction`
+  - Post-processing: `SortResult`, `DistinctResult`, `LimitResult`
+- Supporting operator types: `BinaryOp`, `UnaryOp`, `AggFn`
+- `Program` record type: `{ Instructions: Instruction list }`
+- Compilation support for:
+  - SELECT with single table scan
+  - SELECT with WHERE predicate (filter guard)
+  - SELECT with named/aliased output columns
+  - SELECT with aggregate functions (COUNT, COUNT(*), SUM, AVG, MIN, MAX)
+  - SELECT with GROUP BY (SaveGroupKey / LoadGroupKey / two-phase emission)
+  - SELECT with HAVING
+  - SELECT with ORDER BY (SortResult post-op)
+  - SELECT DISTINCT (DistinctResult post-op)
+  - SELECT with LIMIT/OFFSET (LimitResult post-op)
+  - SELECT with JOIN (nested loop, ON condition)
+  - EmptyResult (optimizer-proven zero-row sentinel)
+  - INSERT VALUES (multi-row)
+  - INSERT SELECT (subquery source)
+  - UPDATE with optional WHERE
+  - DELETE with optional WHERE
+  - CREATE TABLE / DROP TABLE (DDL)
+- Label uniqueness: each scan gets a unique numeric suffix to prevent collisions in multi-scan programs
+- Literate programming: all functions, types, and sections documented with explanations,
+  analogies, and examples per repo CLAUDE.md requirements
+- 70+ unit tests covering all query types, expression forms, instruction ordering, and label uniqueness

--- a/code/packages/fsharp/sql-codegen/CodingAdventures.SqlCodegen.FSharp.fsproj
+++ b/code/packages/fsharp/sql-codegen/CodingAdventures.SqlCodegen.FSharp.fsproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <RootNamespace>CodingAdventures.SqlCodegen.FSharp</RootNamespace>
+    <AssemblyName>CodingAdventures.SqlCodegen.FSharp</AssemblyName>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>CodingAdventures.SqlCodegen.FSharp</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Adhithya Rajasekaran</Authors>
+    <Description>F# bytecode code generator: transforms OptimizedPlan trees into stack-machine bytecode for the Mini-SQLite Level 1 pipeline.</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="SqlCodegen.fs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../fsharp/sql-optimizer/CodingAdventures.SqlOptimizer.fsproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/sql-codegen/README.md
+++ b/code/packages/fsharp/sql-codegen/README.md
@@ -1,0 +1,106 @@
+# CodingAdventures.SqlCodegen.FSharp
+
+F# bytecode code generator for the Mini-SQLite Level 1 pipeline.
+
+## What it does
+
+`sql-codegen` transforms an `OptimizedPlan` (from the optimizer) into a flat list of stack-machine bytecode instructions (`Program`). The generated `Program` is then executed by `sql-vm` to produce query results.
+
+## Pipeline position
+
+```
+sql-lexer → sql-parser → sql-planner → sql-optimizer → [sql-codegen] → sql-vm → mini-sqlite
+```
+
+## Architecture
+
+The codegen is a pure function over the plan tree — no I/O, no state, no database access.
+
+### Stack machine model
+
+The VM is a loop: fetch instruction, dispatch, advance. Values live on a single stack. Instructions pop inputs and push outputs. The expression `a + (b * 2)` compiles to:
+
+```
+LoadColumn(None, "a")    ← push a
+LoadColumn(None, "b")    ← push b
+LoadConst(Integer 2)     ← push 2
+BinaryOpInstr(Mul)       ← pop 2 and b, push b*2
+BinaryOpInstr(Add)       ← pop b*2 and a, push a+b*2
+```
+
+### Supported query types
+
+| Query type | Key instructions emitted |
+|-----------|--------------------------|
+| SELECT (simple) | OpenScan, AdvanceCursor, BeginRow, EmitColumn, EmitRow, CloseScan |
+| SELECT with WHERE | + JumpIfFalse (filter guard) |
+| SELECT with GROUP BY | + InitAgg, UpdateAgg, SaveGroupKey, LoadGroupKey, FinalizeAgg |
+| SELECT with ORDER BY | + SortResult (post-op) |
+| SELECT DISTINCT | + DistinctResult (post-op) |
+| SELECT LIMIT/OFFSET | + LimitResult (post-op) |
+| SELECT with JOIN | Nested OpenScan loops |
+| INSERT VALUES | LoadConst/LoadColumn, InsertRow |
+| UPDATE | OpenScan loop + UpdateRows |
+| DELETE | OpenScan loop + DeleteRows |
+| CREATE TABLE | CreateTable |
+| DROP TABLE | DropTable |
+| Empty result | Halt only |
+
+### Two-phase aggregation
+
+Aggregates compile to a two-phase pattern:
+
+1. **Accumulate** (inside the scan loop): `UpdateAgg` feeds each row's value to an accumulator
+2. **Finalize** (after the loop): `FinalizeAgg` computes the final value (e.g. SUM÷COUNT for AVG)
+
+## Usage
+
+```fsharp
+open CodingAdventures.SqlOptimizer.FSharp
+open CodingAdventures.SqlCodegen.FSharp
+
+let optimizedPlan = SqlOptimizer.optimize logicalPlan
+let program = SqlCodegen.compile optimizedPlan
+// program.Instructions is now a flat list ready for the VM
+```
+
+## API
+
+```fsharp
+module SqlCodegen =
+    val compile : OptimizedPlan -> Program
+    val compileExpression : Expr -> Instruction list
+```
+
+`compileExpression` is exported for testing and reuse; it compiles a single expression to a flat instruction sequence that leaves one value on the stack.
+
+## Types
+
+```fsharp
+type Program = { Instructions: Instruction list }
+
+[<RequireQualifiedAccess>]
+type Instruction =
+    // Stack
+    | LoadConst | LoadColumn | LoadParam | LoadGroupKey | LoadOuterColumn | Pop
+    // Arithmetic / comparison
+    | BinaryOpInstr | UnaryOpInstr
+    // Predicate tests
+    | IsNull | IsNotNull | Between | Like | InList
+    // Cursor control
+    | OpenScan | AdvanceCursor | JumpIfExhausted | CloseScan
+    // Row construction
+    | BeginRow | EmitColumn | EmitRow
+    // Aggregation
+    | InitAgg | UpdateAgg | FinalizeAgg | SaveGroupKey | LoadGroupKey | AdvanceGroup
+    // Control flow
+    | Label | Jump | JumpIfTrue | JumpIfFalse | Halt
+    // DDL
+    | CreateTable | DropTable
+    // DML
+    | InsertRow | UpdateRows | DeleteRows
+    // Transactions
+    | BeginTransaction | CommitTransaction | RollbackTransaction
+    // Post-processing
+    | SortResult | DistinctResult | LimitResult
+```

--- a/code/packages/fsharp/sql-codegen/SqlCodegen.fs
+++ b/code/packages/fsharp/sql-codegen/SqlCodegen.fs
@@ -1,0 +1,971 @@
+// SqlCodegen.fs — bytecode code generator for the Mini-SQLite Level 1 pipeline.
+//
+// This module transforms an OptimizedPlan (produced by sql-optimizer) into a
+// flat list of stack-machine instructions (Program) that the sql-vm can execute.
+//
+// ┌─────────────────────────────────────────────────────────────────────────┐
+// │  PIPELINE POSITION                                                       │
+// │                                                                          │
+// │  sql-lexer → sql-parser → sql-planner → sql-optimizer → [sql-codegen]  │
+// │           → sql-vm → mini-sqlite                                         │
+// │                                                                          │
+// │  Input : OptimizedPlan (from the optimizer)                              │
+// │  Output: Program — a flat list of Instruction values                    │
+// └─────────────────────────────────────────────────────────────────────────┘
+//
+// ── What is a stack machine? ───────────────────────────────────────────────
+//
+// A stack machine is the simplest possible virtual computer. It has no named
+// registers — just a single stack of values and a sequence of instructions.
+// Each instruction pops zero, one, or two values from the top of the stack,
+// does some work, and pushes a result back. For example:
+//
+//   PUSH 3          stack: [3]
+//   PUSH 4          stack: [3, 4]
+//   ADD             stack: [7]   (popped 3 and 4, pushed their sum)
+//
+// SQL expressions compile to a straight-line sequence of such instructions.
+// The expression `a + (b * 2)` compiles to:
+//
+//   LoadColumn(None, "a")    ← push the value of column a
+//   LoadColumn(None, "b")    ← push b
+//   LoadConst(Integer 2)     ← push literal 2
+//   BinaryOpInstr(Mul)       ← pop 2 and b, push b*2
+//   BinaryOpInstr(Add)       ← pop b*2 and a, push a + b*2
+//
+// ── Why stack machines for SQL? ───────────────────────────────────────────
+//
+// SQLite's own query engine (VDBE), the JVM, and CPython all use stack
+// machines for the same reason: they're easy to generate code for, easy to
+// execute in a tight interpreter loop, and require no register allocation.
+//
+// ── Two-phase aggregate compilation ──────────────────────────────────────
+//
+// Aggregates (COUNT, SUM, …) need two phases:
+//   1. ACCUMULATE — scan every row, feeding values into accumulators.
+//   2. FINALIZE   — after the scan, read each accumulator and emit a row.
+//
+// The codegen handles this by emitting InitAgg before the loop (initialise
+// accumulators to their zero state), UpdateAgg inside the loop (feed each
+// row's value to the right accumulator), and FinalizeAgg after the loop
+// (compute the final value — e.g. SUM divides by COUNT for AVG).
+//
+// ── Label-based control flow ──────────────────────────────────────────────
+//
+// Loops and branches use named labels as jump targets. A Label instruction is
+// a no-op marker; Jump/JumpIfFalse/JumpIfTrue transfer control to it. The VM
+// resolves labels to instruction indices at runtime in O(1).
+//
+// Example scan loop for `SELECT name FROM users`:
+//
+//   OpenScan("users", None)          ← open iterator on the table
+//   Label("loop_0")                  ← top of loop
+//   JumpIfExhausted(None, "end_0")   ← exit when no more rows
+//   AdvanceCursor(None)              ← move to next row
+//   BeginRow                         ← start assembling output row
+//   LoadColumn(None, "name")         ← push name value
+//   EmitColumn("name")               ← store it in the row buffer
+//   EmitRow                          ← flush row to result
+//   Jump("loop_0")                   ← back to top of loop
+//   Label("end_0")                   ← loop exit point
+//   CloseScan(None)                  ← release cursor
+//   Halt                             ← stop execution
+
+namespace CodingAdventures.SqlCodegen.FSharp
+
+open CodingAdventures.SqlPlanner.FSharp
+open CodingAdventures.SqlOptimizer.FSharp
+
+// ── Supporting operator types ─────────────────────────────────────────────
+//
+// These mirror the planner's BinaryOperator / UnaryOperator / AggFunction,
+// but live in the codegen namespace so the VM layer does not need to import
+// the planner directly. The compiler maps between the two.
+
+/// Binary infix operators for arithmetic, comparison, and logic.
+/// Two arguments are popped, the result is pushed.
+type BinaryOp =
+    | Add    // a + b
+    | Sub    // a - b
+    | Mul    // a * b
+    | Div    // a / b
+    | Mod    // a % b
+    | Eq     // a = b
+    | Neq    // a <> b
+    | Lt     // a < b
+    | Lte    // a <= b
+    | Gt     // a > b
+    | Gte    // a >= b
+    | And    // a AND b (short-circuit: FALSE AND NULL = FALSE)
+    | Or     // a OR  b (short-circuit: TRUE  OR  NULL = TRUE)
+    | Concat // a || b  (string concatenation)
+
+/// Unary prefix operators. One argument is popped, one result is pushed.
+type UnaryOp =
+    | Neg  // -a   (arithmetic negation)
+    | Not  // NOT a (logical negation, three-valued: NOT NULL = NULL)
+
+/// Aggregate function kinds — COUNT, SUM, etc.
+/// Each aggregate has an accumulator slot in the VM's aggregate state.
+///
+/// Think of aggregates like running tallies: COUNT keeps a counter, SUM keeps
+/// a running total, MIN/MAX track the smallest/largest value seen so far, and
+/// AVG keeps both a sum and a count so it can divide at the end.
+type AggFn =
+    | Count     // COUNT(expr) — count non-NULL values
+    | CountStar // COUNT(*)    — count all rows including NULLs
+    | Sum       // SUM(expr)   — sum all non-NULL values
+    | Avg       // AVG(expr)   — arithmetic mean of non-NULL values
+    | Min       // MIN(expr)   — smallest non-NULL value
+    | Max       // MAX(expr)   — largest non-NULL value
+
+// ── Instruction discriminated union ──────────────────────────────────────
+//
+// Every VM operation is one case of this DU. Instructions are pure data:
+// no functions, no side effects — just a description of what to do.
+// The VM interprets them in a loop, maintaining the stack and cursors.
+//
+// [RequireQualifiedAccess] forces callers to write Instruction.LoadConst
+// rather than LoadConst, which prevents name clashes with F# built-ins
+// and makes code easier to read at a glance.
+
+[<RequireQualifiedAccess>]
+type Instruction =
+    // ── Stack / memory operations ─────────────────────────────────────────
+    //
+    // These push or pop values on the expression evaluation stack.
+    // Think of the stack as a scratch pad: push inputs, compute, pop results.
+
+    /// Push a compile-time constant onto the stack.
+    /// Example: the literal `42` in `WHERE age > 42` becomes `LoadConst(Integer 42)`.
+    | LoadConst of value: SqlValue
+
+    /// Push the value of a named column from the current row of a table scan.
+    /// `table` is the optional alias (e.g. Some "u" for `u.name`); when None
+    /// the VM searches all open cursors for the column name.
+    | LoadColumn of table: string option * column: string
+
+    /// Push a runtime-bound parameter (placeholder `?` in the query).
+    /// `index` is the 0-based position of the parameter in the binding list.
+    | LoadParam of index: int
+
+    /// Push the i-th value from the current group-by key snapshot.
+    /// Used in the group-emit phase to reproduce group-key column values
+    /// without re-reading the underlying table (which may have advanced).
+    | LoadGroupKey of index: int
+
+    /// Push a column value from the OUTER query's current row.
+    /// Used for correlated subqueries where an inner expression references
+    /// a column from the enclosing query's scan.
+    | LoadOuterColumn of table: string option * column: string
+
+    /// Discard the top value of the stack (used to clean up expressions
+    /// whose result is not needed, e.g. a SELECT-list expression in a DML).
+    | Pop
+
+    // ── Arithmetic and comparison ─────────────────────────────────────────
+    //
+    // These instructions pop TWO values and push ONE result. The right
+    // operand is popped first (it was pushed last), then the left operand.
+
+    /// Pop right and left operands; apply the operator; push the result.
+    /// Covers all SQL binary operators: arithmetic, comparison, AND/OR, ||.
+    | BinaryOpInstr of op: BinaryOp
+
+    // ── Unary operations ──────────────────────────────────────────────────
+
+    /// Pop one value; apply the unary operator; push the result.
+    | UnaryOpInstr of op: UnaryOp
+
+    // ── Predicate / test instructions ─────────────────────────────────────
+    //
+    // SQL has NULL as a first-class value, so every test must handle three
+    // outcomes: TRUE, FALSE, and NULL (unknown). These instructions implement
+    // the SQL three-valued logic for common predicates.
+
+    /// Pop value; push TRUE if it is SQL NULL, FALSE otherwise.
+    | IsNull
+
+    /// Pop value; push TRUE if it is NOT NULL, FALSE if it is NULL.
+    | IsNotNull
+
+    /// Pop hi, lo, value; push TRUE if lo <= value <= high.
+    /// `inclusive` controls whether the bounds are inclusive (SQL BETWEEN
+    /// uses inclusive; exclusive variants exist for open-interval range scans).
+    | Between of inclusive: bool
+
+    /// Pop pattern, value; push TRUE if value LIKE pattern.
+    /// SQL LIKE uses `%` for "zero or more chars" and `_` for "exactly one char".
+    | Like
+
+    /// Pop `count` items from the stack as the list, then pop the needle;
+    /// push TRUE if the needle is in the list (SQL IN operator).
+    | InList of count: int
+
+    // ── Scan / cursor control ─────────────────────────────────────────────
+    //
+    // A cursor is an iterator over a table's rows. Think of it like a file
+    // handle: you open it, read rows one at a time, and close it when done.
+    // Multiple cursors can be open simultaneously (for JOINs).
+
+    /// Ask the VM to open an iterator (cursor) for `table`.
+    /// `alias` is the query alias, used to distinguish cursors in JOINs.
+    | OpenScan of table: string * alias: string option
+
+    /// Move the cursor identified by `alias` to its next row.
+    /// If the cursor is exhausted, the VM jumps to `label`.
+    /// This is the "next row" instruction — the heart of every scan loop.
+    | AdvanceCursor of alias: string option
+
+    /// Jump to `label` if the cursor identified by `alias` is exhausted.
+    /// Used to test exhaustion without advancing, useful for nested loops.
+    | JumpIfExhausted of alias: string option * label: string
+
+    /// Release the cursor, freeing any resources it holds.
+    | CloseScan of alias: string option
+
+    // ── Row construction ──────────────────────────────────────────────────
+    //
+    // Output rows are assembled instruction by instruction.
+    // BeginRow clears the row buffer; EmitColumn stores one field;
+    // EmitRow flushes the assembled row to the result set.
+
+    /// Clear the row buffer and start assembling a new output row.
+    | BeginRow
+
+    /// Pop the top of the stack and store it as column `name` in the row buffer.
+    | EmitColumn of name: string
+
+    /// Finalize the row buffer and append the assembled row to the result set.
+    | EmitRow
+
+    // ── Aggregation ───────────────────────────────────────────────────────
+    //
+    // Aggregation is a two-phase process: accumulate during the scan loop,
+    // then finalize and emit after the scan completes.
+    //
+    // Example for `SELECT COUNT(*), SUM(price) FROM orders`:
+    //
+    //   InitAgg(2)                 ← create 2 accumulators: [count=0, sum=0]
+    //   ...scan loop...
+    //     UpdateAgg(0, CountStar)  ← accumulator 0: increment count
+    //     LoadColumn(_, "price")   ← push price
+    //     UpdateAgg(1, Sum)        ← accumulator 1: add price to sum
+    //   ...end loop...
+    //   BeginRow
+    //   FinalizeAgg(0, CountStar)  ← push finalized count
+    //   EmitColumn("count(*)")
+    //   FinalizeAgg(1, Sum)        ← push finalized sum
+    //   EmitColumn("sum(price)")
+    //   EmitRow
+
+    /// Initialize `count` aggregate accumulators to their zero states.
+    | InitAgg of count: int
+
+    /// Pop the top of the stack and feed it into accumulator `index`.
+    /// The `fn` tells the accumulator how to combine the new value
+    /// (e.g. SUM adds, MIN takes the smaller, COUNT increments).
+    | UpdateAgg of index: int * fn: AggFn
+
+    /// Compute the final value of accumulator `index` and push it.
+    /// For AVG this divides sum by count; for COUNT it returns the count; etc.
+    | FinalizeAgg of index: int * fn: AggFn
+
+    /// Save the current group-by key values for use in the emit phase.
+    /// `keys` is the list of column names that form the GROUP BY key.
+    | SaveGroupKey of keys: string list
+
+    /// Advance the group iterator to the next group.
+    /// Similar to AdvanceCursor but for the group accumulator map.
+    | AdvanceGroup
+
+    // ── Control flow ──────────────────────────────────────────────────────
+    //
+    // Jump targets are named strings during code generation. At runtime the
+    // VM resolves them to instruction indices for O(1) dispatch.
+
+    /// A no-op marker that names a position in the instruction stream.
+    /// Jump instructions refer to labels by name.
+    | Label of name: string
+
+    /// Unconditional jump to the named label.
+    | Jump of label: string
+
+    /// Pop value; jump to `label` if the value is TRUE.
+    | JumpIfTrue of label: string
+
+    /// Pop value; jump to `label` if the value is FALSE or NULL.
+    | JumpIfFalse of label: string
+
+    /// Stop execution; the result set holds the output rows.
+    | Halt
+
+    // ── DDL (Data Definition Language) ───────────────────────────────────
+    //
+    // CREATE TABLE and DROP TABLE produce a single instruction each.
+    // No scan loop needed — these are schema operations, not row operations.
+
+    /// Ask the VM/backend to create a table with the given columns.
+    /// `ifNotExists` mirrors `CREATE TABLE IF NOT EXISTS`.
+    | CreateTable of name: string * ifNotExists: bool * columns: ColumnDef list
+
+    /// Ask the VM/backend to drop a table.
+    /// `ifExists` mirrors `DROP TABLE IF EXISTS`.
+    | DropTable of name: string * ifExists: bool
+
+    // ── DML (Data Manipulation Language) ─────────────────────────────────
+
+    /// Insert one row into `table`. The values for `columns` are on the stack
+    /// in order (leftmost column was pushed first).
+    | InsertRow of table: string * columns: string list option
+
+    /// Update column values for the row under the current cursor.
+    /// `assignments` is a list of (column_name, expression) pairs.
+    | UpdateRows of table: string * assignments: (string * Expr) list
+
+    /// Delete the row currently under the cursor.
+    | DeleteRows of table: string
+
+    // ── Transaction control ───────────────────────────────────────────────
+    //
+    // These mirror the SQL `BEGIN`, `COMMIT`, and `ROLLBACK` statements.
+    // Most queries do not need explicit transactions (the VM handles
+    // auto-commit), but explicit transaction support is needed for ACID tests.
+
+    | BeginTransaction
+    | CommitTransaction
+    | RollbackTransaction
+
+    // ── Result post-processing ────────────────────────────────────────────
+    //
+    // After the scan loop fills the result buffer, these instructions apply
+    // sorting, deduplication, and pagination as post-processing steps.
+    //
+    // These are emitted AFTER the scan loop closes, not inside it.
+
+    /// Sort the result buffer by the given sort keys.
+    /// Each SortKey specifies a column, direction (Asc/Desc), and NULL ordering.
+    | SortResult of keys: SortKey list
+
+    /// Deduplicate the result buffer, keeping only distinct rows.
+    /// Applied after SortResult so duplicates are adjacent (O(n) scan).
+    | DistinctResult
+
+    /// Keep at most `count` rows starting at `offset` (0-based).
+    /// `None` means "no limit" or "no offset" respectively.
+    | LimitResult of count: int64 option * offset: int64 option
+
+// ── Program — the compiled output ────────────────────────────────────────
+//
+// A Program is simply a flat list of Instructions. The VM executes them in
+// order, jumping when it encounters Jump/JumpIfTrue/JumpIfFalse/AdvanceCursor.
+//
+// Why a list? It's the simplest representation and sufficient for Level 1.
+// A future optimizer could convert to an array for O(1) index access.
+
+/// The compiled output of the code generator.
+type Program = { Instructions: Instruction list }
+
+// ── Label counter (module-level mutable state) ───────────────────────────
+//
+// A counter produces unique suffixes like "0", "1", "2" for label names.
+// Each scan gets its own loop/end label pair so nested scans don't clash.
+//
+// Example: a JOIN produces two scan pairs:
+//   loop_0 / end_0 for the outer (left) table
+//   loop_1 / end_1 for the inner (right) table
+//
+// NOTE: Module-level `let mutable` is idiomatic F# for stateful helpers.
+// This is reset at the start of each `compile` call so tests are isolated.
+
+[<AutoOpen>]
+module private LabelState =
+    let mutable labelCounter = 0
+
+    let freshLabel () =
+        let n = labelCounter
+        labelCounter <- labelCounter + 1
+        string n
+
+    let resetLabelCounter () =
+        labelCounter <- 0
+
+// ── SqlCodegen module ─────────────────────────────────────────────────────
+//
+// The SqlCodegen module holds the two public entry points:
+//   `compile`           : OptimizedPlan → Program
+//   `compileExpression` : Expr → Instruction list   (exported for testing)
+
+module SqlCodegen =
+
+    // ── Operator mapping ──────────────────────────────────────────────────
+    //
+    // The planner uses its own operator types (BinaryOperator, UnaryOperator,
+    // AggFunction). We map them to the codegen's operator types here.
+    // This keeps the VM layer decoupled from the planner's type hierarchy.
+
+    let private mapBinaryOp (op: BinaryOperator) : BinaryOp =
+        match op with
+        | BinaryOperator.Add   -> BinaryOp.Add
+        | BinaryOperator.Sub   -> BinaryOp.Sub
+        | BinaryOperator.Mul   -> BinaryOp.Mul
+        | BinaryOperator.Div   -> BinaryOp.Div
+        | BinaryOperator.Mod   -> BinaryOp.Mod
+        | BinaryOperator.Eq    -> BinaryOp.Eq
+        | BinaryOperator.NotEq -> BinaryOp.Neq
+        | BinaryOperator.Lt    -> BinaryOp.Lt
+        | BinaryOperator.Lte   -> BinaryOp.Lte
+        | BinaryOperator.Gt    -> BinaryOp.Gt
+        | BinaryOperator.Gte   -> BinaryOp.Gte
+        | BinaryOperator.And   -> BinaryOp.And
+        | BinaryOperator.Or    -> BinaryOp.Or
+
+    let private mapUnaryOp (op: UnaryOperator) : UnaryOp =
+        match op with
+        | UnaryOperator.Neg -> UnaryOp.Neg
+        | UnaryOperator.Not -> UnaryOp.Not
+
+    let private mapAggFn (fn: AggFunction) : AggFn =
+        match fn with
+        | AggFunction.Count -> AggFn.Count
+        | AggFunction.Sum   -> AggFn.Sum
+        | AggFunction.Avg   -> AggFn.Avg
+        | AggFunction.Min   -> AggFn.Min
+        | AggFunction.Max   -> AggFn.Max
+
+    // ── Expression compiler ───────────────────────────────────────────────
+    //
+    // `compileExpression` translates an Expr tree into a flat sequence of
+    // Instructions that, when executed by the VM, leaves one value on the
+    // stack. Recursive calls handle sub-expressions, building up the sequence
+    // from the leaves inward (post-order traversal).
+
+    /// Compile an expression to a flat instruction sequence.
+    /// Each instruction pushes one value; the last instruction leaves the
+    /// final value on top of the stack.
+    ///
+    /// Examples:
+    ///   Expr.Literal(Integer 42)      → [LoadConst(Integer 42)]
+    ///   Expr.Column(None, "age")      → [LoadColumn(None, "age")]
+    ///   Expr.BinaryOp(Add, a, b)      → [compile(a) @ compile(b) @ [BinaryOpInstr Add]]
+    let rec compileExpression (expr: Expr) : Instruction list =
+        match expr with
+
+        // ── Literals ─────────────────────────────────────────────────────
+        // A literal is simply pushed as a constant. No computation needed.
+        | Expr.Literal value ->
+            [ Instruction.LoadConst value ]
+
+        // ── Column references ─────────────────────────────────────────────
+        // The table qualifier is preserved so the VM can distinguish
+        // columns from different tables in a JOIN.
+        | Expr.Column(tableOpt, col) ->
+            [ Instruction.LoadColumn(tableOpt, col) ]
+
+        // ── Binary operators ──────────────────────────────────────────────
+        // Compile left, then right (so left is on the stack first), then apply
+        // the operator. The VM pops right first (it's on top), then left.
+        | Expr.BinaryOp(op, left, right) ->
+            compileExpression left
+            @ compileExpression right
+            @ [ Instruction.BinaryOpInstr(mapBinaryOp op) ]
+
+        // ── Unary operators ───────────────────────────────────────────────
+        // Compile the operand, then apply the unary operator.
+        | Expr.UnaryOp(op, operand) ->
+            compileExpression operand
+            @ [ Instruction.UnaryOpInstr(mapUnaryOp op) ]
+
+        // ── NULL tests ────────────────────────────────────────────────────
+        // IS NULL / IS NOT NULL push a boolean (never NULL) regardless of
+        // whether the operand is NULL. These are distinct from comparisons
+        // because `NULL = NULL` is NULL, but `NULL IS NULL` is TRUE.
+        | Expr.IsNull e ->
+            compileExpression e @ [ Instruction.IsNull ]
+
+        | Expr.IsNotNull e ->
+            compileExpression e @ [ Instruction.IsNotNull ]
+
+        // ── BETWEEN ───────────────────────────────────────────────────────
+        // `value BETWEEN lo AND hi` compiles to: push value, push lo, push hi,
+        // then the Between instruction pops all three and pushes TRUE/FALSE/NULL.
+        | Expr.Between(value, lo, hi) ->
+            compileExpression value
+            @ compileExpression lo
+            @ compileExpression hi
+            @ [ Instruction.Between(inclusive = true) ]
+
+        // ── LIKE ──────────────────────────────────────────────────────────
+        // Push value, push pattern (as a constant string), then Like.
+        | Expr.Like(value, pattern) ->
+            compileExpression value
+            @ [ Instruction.LoadConst(SqlValue.Text pattern) ]
+            @ [ Instruction.Like ]
+
+        // ── NOT LIKE ─────────────────────────────────────────────────────
+        // Compile as LIKE then negate the result.
+        | Expr.NotLike(value, pattern) ->
+            compileExpression value
+            @ [ Instruction.LoadConst(SqlValue.Text pattern) ]
+            @ [ Instruction.Like ]
+            @ [ Instruction.UnaryOpInstr(UnaryOp.Not) ]
+
+        // ── IN (list) ────────────────────────────────────────────────────
+        // Push the needle (value to test), then push each list item, then
+        // the InList instruction pops count items and the needle and pushes
+        // TRUE/FALSE/NULL.
+        | Expr.In(value, items) ->
+            compileExpression value
+            @ List.collect compileExpression items
+            @ [ Instruction.InList(List.length items) ]
+
+        // ── NOT IN ───────────────────────────────────────────────────────
+        // Compile as IN then negate. Note: NOT IN has special NULL semantics
+        // (x NOT IN (...NULL...) = NULL), handled by the VM's InList instruction
+        // combined with the NOT operator.
+        | Expr.NotIn(value, items) ->
+            compileExpression value
+            @ List.collect compileExpression items
+            @ [ Instruction.InList(List.length items) ]
+            @ [ Instruction.UnaryOpInstr(UnaryOp.Not) ]
+
+        // ── Aggregate expressions ─────────────────────────────────────────
+        // Aggregates within expressions are handled by the scan-loop compiler
+        // (which knows the accumulator slot numbers). If we reach here without
+        // aggregate context, emit a null constant as a safe no-op.
+        | Expr.AggExpr(fn, arg, _distinct) ->
+            ignore (fn, arg)
+            [ Instruction.LoadConst SqlValue.Null ]
+
+        // ── Function calls ────────────────────────────────────────────────
+        // SQL scalar functions compile each argument onto the stack.
+        // For Level 1, unknown scalar functions return NULL as a placeholder.
+        | Expr.FuncCall(name, args) ->
+            ignore name
+            List.collect compileExpression args
+            @ [ Instruction.LoadConst SqlValue.Null ]
+
+        // ── Wildcard ─────────────────────────────────────────────────────
+        // SELECT * is handled at the plan level; bare Wildcard pushes NULL.
+        | Expr.Wildcard ->
+            [ Instruction.LoadConst SqlValue.Null ]
+
+    // ── Aggregate helpers ─────────────────────────────────────────────────
+
+    let private compileUpdateAgg (index: int) (fn: AggFunction) (arg: AggArg) : Instruction list =
+        match fn, arg with
+        | AggFunction.Count, AggArg.Star ->
+            // COUNT(*) — no column reference needed; just update the counter
+            [ Instruction.UpdateAgg(index, AggFn.CountStar) ]
+        | AggFunction.Count, AggArg.Expr e ->
+            compileExpression e @ [ Instruction.UpdateAgg(index, AggFn.Count) ]
+        | AggFunction.Sum, AggArg.Expr e ->
+            compileExpression e @ [ Instruction.UpdateAgg(index, AggFn.Sum) ]
+        | AggFunction.Avg, AggArg.Expr e ->
+            compileExpression e @ [ Instruction.UpdateAgg(index, AggFn.Avg) ]
+        | AggFunction.Min, AggArg.Expr e ->
+            compileExpression e @ [ Instruction.UpdateAgg(index, AggFn.Min) ]
+        | AggFunction.Max, AggArg.Expr e ->
+            compileExpression e @ [ Instruction.UpdateAgg(index, AggFn.Max) ]
+        | _ ->
+            [ Instruction.UpdateAgg(index, AggFn.CountStar) ]
+
+    let private compileFinalizeAgg (index: int) (fn: AggFunction) : Instruction =
+        let aggFn =
+            match fn with
+            | AggFunction.Count -> AggFn.Count
+            | AggFunction.Sum   -> AggFn.Sum
+            | AggFunction.Avg   -> AggFn.Avg
+            | AggFunction.Min   -> AggFn.Min
+            | AggFunction.Max   -> AggFn.Max
+        Instruction.FinalizeAgg(index, aggFn)
+
+    let private outputColName (col: OutputColumn) : string =
+        match col with
+        | OutputColumn.Star -> "*"
+        | OutputColumn.Expr(_, Some alias) -> alias
+        | OutputColumn.Expr(Expr.Column(_, colName), None) -> colName
+        | OutputColumn.Expr(Expr.AggExpr(fn, _, _), None) ->
+            match fn with
+            | AggFunction.Count -> "count"
+            | AggFunction.Sum   -> "sum"
+            | AggFunction.Avg   -> "avg"
+            | AggFunction.Min   -> "min"
+            | AggFunction.Max   -> "max"
+        | OutputColumn.Expr(_, None) -> "expr"
+
+    // ── Scan loop codegen ─────────────────────────────────────────────────
+    //
+    // The fundamental pattern for any table scan is:
+    //
+    //   OpenScan(table, alias)
+    //   Label("loop_N")
+    //   JumpIfExhausted(alias, "end_N")
+    //   AdvanceCursor(alias)
+    //   <body — filter predicate + row construction>
+    //   Jump("loop_N")
+    //   Label("end_N")
+    //   CloseScan(alias)
+    //
+    // The `body` is provided as a list of instructions by the caller.
+
+    let private compileScanLoop (table: string) (alias: string option) (body: Instruction list) : Instruction list =
+        let n = freshLabel ()
+        let loopLabel = sprintf "loop_%s" n
+        let endLabel  = sprintf "end_%s"  n
+
+        [ Instruction.OpenScan(table, alias)
+          Instruction.Label loopLabel
+          Instruction.JumpIfExhausted(alias, endLabel)
+          Instruction.AdvanceCursor alias ]
+        @ body
+        @ [ Instruction.Jump loopLabel
+            Instruction.Label endLabel
+            Instruction.CloseScan alias ]
+
+    // ── Mutually recursive compilation functions ──────────────────────────
+    //
+    // `compilePlan`, `compileOutputColumns`, `compileAggregateQuery`, and
+    // `compileSelect` call each other, so they are declared with `let rec ... and ...`.
+    //
+    // F# requires ALL mutually recursive functions to be declared in a single
+    // `let rec ... and ...` block. This is the idiomatic pattern.
+
+    /// Compile the scan phase of a plan node, inserting `body` as the loop body.
+    /// Returns the instruction sequence for opening cursors, iterating rows,
+    /// and closing cursors — without post-processing (Sort/Limit/Distinct).
+    let rec private compilePlan (plan: OptimizedPlan) (body: Instruction list) : Instruction list =
+        match plan with
+
+        // ── Base scan ─────────────────────────────────────────────────────
+        // The leaf of most query trees — opens a cursor and iterates rows.
+        | OptimizedPlan.Scan(table, alias, _reqCols, _scanLimit) ->
+            compileScanLoop table alias body
+
+        // ── Filter — compile the predicate as a guard inside the loop ─────
+        // The filter sits "between" the cursor advance and the body.
+        // If the predicate is false/null, we jump past the body for this row.
+        | OptimizedPlan.Filter(inner, pred) ->
+            let skipLabel = sprintf "filter_skip_%s" (freshLabel ())
+            let filterGuard =
+                compileExpression pred
+                @ [ Instruction.JumpIfFalse skipLabel ]
+            compilePlan inner (filterGuard @ body @ [ Instruction.Label skipLabel ])
+
+        // ── Project — just wrap the body; projection is in EmitColumn ─────
+        | OptimizedPlan.Project(inner, _cols) ->
+            compilePlan inner body
+
+        // ── Join — nested loop over two tables ────────────────────────────
+        // A JOIN is implemented as nested scan loops: for each row in the
+        // left table, scan all rows of the right table.
+        | OptimizedPlan.Join(left, right, kind, condOpt) ->
+            let condGuard =
+                match condOpt with
+                | None -> []
+                | Some cond ->
+                    let skipLabel = sprintf "join_cond_%s" (freshLabel ())
+                    compileExpression cond
+                    @ [ Instruction.JumpIfFalse skipLabel ]
+                    @ body
+                    @ [ Instruction.Label skipLabel ]
+            ignore kind
+            let innerBody =
+                match condOpt with
+                | None -> body
+                | Some _ -> condGuard
+            let innerLoop = compilePlan right innerBody
+            compilePlan left innerLoop
+
+        // ── Aggregate / Having ─────────────────────────────────────────────
+        // These are handled by compileAggregateQuery above the scan level.
+        // If we encounter them here (nested context), compile the inner plan.
+        | OptimizedPlan.Aggregate(inner, _groupBy, _aggs) ->
+            compilePlan inner body
+
+        | OptimizedPlan.Having(inner, _pred) ->
+            compilePlan inner body
+
+        // ── Pass-through wrappers ─────────────────────────────────────────
+        // Sort, Limit, Distinct are post-ops applied after the scan completes.
+        // In compilePlan we just recurse into the inner plan.
+        | OptimizedPlan.Sort(inner, _)
+        | OptimizedPlan.Limit(inner, _, _)
+        | OptimizedPlan.Distinct(inner) ->
+            compilePlan inner body
+
+        | OptimizedPlan.Union(left, _right, _all) ->
+            compilePlan left body
+
+        | OptimizedPlan.EmptyResult ->
+            []
+
+        | _ ->
+            body
+
+    /// Compile output columns for a non-aggregate SELECT.
+    /// Returns a flat instruction sequence that, for each output column,
+    /// pushes the column's value and emits it with a name.
+    and private compileOutputColumns (cols: OutputColumn list) : Instruction list =
+        if List.isEmpty cols then
+            // No Project node — emit a wildcard marker
+            [ Instruction.LoadConst(SqlValue.Text "*") ]
+        else
+            cols |> List.collect (fun col ->
+                match col with
+                | OutputColumn.Star ->
+                    [ Instruction.LoadConst(SqlValue.Text "*") ]
+                | OutputColumn.Expr(Expr.AggExpr _, _) ->
+                    // Aggregate in non-aggregate context — emit null
+                    [ Instruction.LoadConst SqlValue.Null
+                      Instruction.EmitColumn (outputColName col) ]
+                | OutputColumn.Expr(expr, _) ->
+                    compileExpression expr @ [ Instruction.EmitColumn (outputColName col) ])
+
+    /// Compile an aggregate query (with or without GROUP BY).
+    ///
+    /// Aggregates require two phases:
+    /// 1. ACCUMULATE — UpdateAgg in the scan loop
+    /// 2. FINALIZE   — FinalizeAgg after the loop
+    and private compileAggregateQuery
+        (innerPlan:  OptimizedPlan)
+        (aggs:       AggregateItem list)
+        (groupBy:    Expr list)
+        (havingOpt:  Expr option)
+        : Instruction list =
+
+        let numAggs = List.length aggs
+        let aggSlots = aggs |> List.mapi (fun i a -> (i, mapAggFn a.Func)) |> Map.ofList
+
+        // Build the group-key column names (for SaveGroupKey / LoadGroupKey)
+        let groupKeyNames =
+            groupBy |> List.mapi (fun i e ->
+                match e with
+                | Expr.Column(_, c) -> c
+                | _ -> sprintf "key_%d" i)
+
+        // Inside the loop: save group key and update accumulators
+        let saveKeyInstrs =
+            if List.isEmpty groupBy then []
+            else
+                List.collect compileExpression groupBy
+                @ [ Instruction.SaveGroupKey groupKeyNames ]
+
+        let updateInstrs =
+            aggs |> List.mapi (fun i a -> compileUpdateAgg i a.Func a.Arg)
+            |> List.concat
+
+        // Compile the scan loop with accumulate-body
+        // The inner plan may have a Filter wrapping the base scan
+        let scanInstrs = compilePlan innerPlan (saveKeyInstrs @ updateInstrs)
+
+        // After the scan: emit one row per group
+        // Group-key columns first, then aggregate finalizations
+        let keyEmitInstrs =
+            groupKeyNames |> List.mapi (fun i name ->
+                [ Instruction.LoadGroupKey i
+                  Instruction.EmitColumn name ])
+            |> List.concat
+
+        let aggEmitInstrs =
+            aggs |> List.mapi (fun i a ->
+                let aggFn =
+                    match aggSlots |> Map.tryFind i with
+                    | Some f -> f
+                    | None   -> AggFn.CountStar
+                [ compileFinalizeAgg i a.Func
+                  Instruction.EmitColumn a.Alias ])
+            |> List.concat
+
+        // HAVING clause filters out groups whose aggregate result fails the predicate
+        let emitPhase =
+            match havingOpt with
+            | None ->
+                [ Instruction.BeginRow ]
+                @ keyEmitInstrs
+                @ aggEmitInstrs
+                @ [ Instruction.EmitRow ]
+            | Some pred ->
+                let skipLabel = sprintf "having_skip_%s" (freshLabel ())
+                [ Instruction.BeginRow ]
+                @ keyEmitInstrs
+                @ aggEmitInstrs
+                @ compileExpression pred
+                @ [ Instruction.JumpIfFalse skipLabel
+                    Instruction.EmitRow
+                    Instruction.Label skipLabel ]
+
+        [ Instruction.InitAgg numAggs ]
+        @ scanInstrs
+        @ emitPhase
+
+    /// Compile a SELECT query: peel post-ops, detect aggregation, emit scan + post-ops.
+    ///
+    /// Pipeline:
+    ///   1. Peel Sort/Limit/Distinct wrappers into post-op list
+    ///   2. Detect aggregate vs non-aggregate
+    ///   3. Emit the scan loop (with filter + projection inside)
+    ///   4. Append post-ops (Sort, Distinct, Limit)
+    and private compileSelect (plan: OptimizedPlan) : Instruction list =
+
+        // ── Step 1: Peel post-processing wrappers ─────────────────────────
+        let rec peelWrappers (p: OptimizedPlan) (postOps: Instruction list) =
+            match p with
+            | OptimizedPlan.Sort(inner, keys) ->
+                peelWrappers inner (postOps @ [ Instruction.SortResult keys ])
+            | OptimizedPlan.Limit(inner, count, offset) ->
+                peelWrappers inner (postOps @ [ Instruction.LimitResult(count, offset) ])
+            | OptimizedPlan.Distinct(inner) ->
+                peelWrappers inner (postOps @ [ Instruction.DistinctResult ])
+            | other ->
+                (other, postOps)
+
+        let (corePlan, postOps) = peelWrappers plan []
+
+        // ── Step 2: Detect aggregation ────────────────────────────────────
+        // Find the Aggregate node (possibly wrapped in Project or Having).
+        let rec findAggregate (p: OptimizedPlan) =
+            match p with
+            | OptimizedPlan.Project(OptimizedPlan.Aggregate(inner, gb, aggs), cols) ->
+                Some (inner, gb, aggs, None, cols)
+            | OptimizedPlan.Project(OptimizedPlan.Having(OptimizedPlan.Aggregate(inner, gb, aggs), pred), cols) ->
+                Some (inner, gb, aggs, Some pred, cols)
+            | OptimizedPlan.Aggregate(inner, gb, aggs) ->
+                Some (inner, gb, aggs, None, [])
+            | OptimizedPlan.Having(OptimizedPlan.Aggregate(inner, gb, aggs), pred) ->
+                Some (inner, gb, aggs, Some pred, [])
+            | _ -> None
+
+        let scanInstrs =
+            match findAggregate corePlan with
+            | Some (innerPlan, groupBy, aggs, havingOpt, _outputCols) ->
+                // ── Aggregate query ───────────────────────────────────────
+                compileAggregateQuery innerPlan aggs groupBy havingOpt
+
+            | None ->
+                // ── Non-aggregate query ───────────────────────────────────
+                // Find the output columns from the outermost Project node
+                let (outputCols, innerPlan) =
+                    match corePlan with
+                    | OptimizedPlan.Project(inner, cols) -> (cols, inner)
+                    | other -> ([], other)
+
+                // Build the loop body: BeginRow + emit each column + EmitRow
+                let emitBody =
+                    [ Instruction.BeginRow ]
+                    @ compileOutputColumns outputCols
+                    @ [ Instruction.EmitRow ]
+
+                compilePlan innerPlan emitBody
+
+        scanInstrs @ postOps @ [ Instruction.Halt ]
+
+    // ── INSERT compilation ────────────────────────────────────────────────
+    //
+    // `INSERT INTO t (col1, col2) VALUES (v1, v2)`
+    //
+    // For each row in VALUES, we compile each value expression and emit
+    // one InsertRow instruction. The VM pops the values and passes them
+    // to the backend.
+
+    let private compileInsert (table: string) (colsOpt: string list option) (source: InsertSource) : Instruction list =
+        match source with
+        | InsertSource.Values rowsList ->
+            rowsList |> List.collect (fun row ->
+                List.collect compileExpression row
+                @ [ Instruction.InsertRow(table, colsOpt) ])
+        | InsertSource.Query subplan ->
+            compileSelect (SqlOptimizer.lift subplan)
+
+    // ── UPDATE compilation ────────────────────────────────────────────────
+    //
+    // UPDATE is cursor-based: scan the table with a filter (WHERE clause),
+    // and for each matching row, apply the SET assignments.
+
+    let private compileUpdate (table: string) (assignments: Assignment list) (predOpt: Expr option) : Instruction list =
+        let pairs = assignments |> List.map (fun a -> (a.Column, a.Value))
+        let body =
+            match predOpt with
+            | None ->
+                [ Instruction.UpdateRows(table, pairs) ]
+            | Some pred ->
+                let skipLabel = sprintf "upd_skip_%s" (freshLabel ())
+                compileExpression pred
+                @ [ Instruction.JumpIfFalse skipLabel
+                    Instruction.UpdateRows(table, pairs)
+                    Instruction.Label skipLabel ]
+        compileScanLoop table None body @ [ Instruction.Halt ]
+
+    // ── DELETE compilation ────────────────────────────────────────────────
+
+    let private compileDelete (table: string) (predOpt: Expr option) : Instruction list =
+        let body =
+            match predOpt with
+            | None ->
+                [ Instruction.DeleteRows table ]
+            | Some pred ->
+                let skipLabel = sprintf "del_skip_%s" (freshLabel ())
+                compileExpression pred
+                @ [ Instruction.JumpIfFalse skipLabel
+                    Instruction.DeleteRows table
+                    Instruction.Label skipLabel ]
+        compileScanLoop table None body @ [ Instruction.Halt ]
+
+    // ── Main compile entry point ──────────────────────────────────────────
+    //
+    // `compile` is the top-level function: given an OptimizedPlan, it returns
+    // a Program (a flat list of instructions).
+
+    /// Compile an OptimizedPlan to a Program.
+    ///
+    /// This is the primary entry point. Call it with the output of SqlOptimizer.optimize.
+    ///
+    /// Example:
+    ///   let plan = SqlOptimizer.optimize (SqlPlanner.plan schema stmt)
+    ///   let program = SqlCodegen.compile plan
+    ///   // program.Instructions is now ready for the VM
+    let compile (plan: OptimizedPlan) : Program =
+        resetLabelCounter ()
+
+        let instructions =
+            match plan with
+
+            // ── SELECT queries ─────────────────────────────────────────────
+            | OptimizedPlan.Project _
+            | OptimizedPlan.Filter _
+            | OptimizedPlan.Sort _
+            | OptimizedPlan.Limit _
+            | OptimizedPlan.Distinct _
+            | OptimizedPlan.Aggregate _
+            | OptimizedPlan.Having _
+            | OptimizedPlan.Scan _
+            | OptimizedPlan.Join _
+            | OptimizedPlan.Union _ ->
+                compileSelect plan
+
+            // ── EmptyResult — proven to produce zero rows ──────────────────
+            | OptimizedPlan.EmptyResult ->
+                [ Instruction.Halt ]
+
+            // ── DML ────────────────────────────────────────────────────────
+
+            | OptimizedPlan.Insert(table, colsOpt, source) ->
+                compileInsert table colsOpt source @ [ Instruction.Halt ]
+
+            | OptimizedPlan.Update(table, assignments, predOpt) ->
+                compileUpdate table assignments predOpt
+
+            | OptimizedPlan.Delete(table, predOpt) ->
+                compileDelete table predOpt
+
+            // ── DDL ────────────────────────────────────────────────────────
+
+            | OptimizedPlan.CreateTable(name, ifNotExists, columns) ->
+                [ Instruction.CreateTable(name, ifNotExists, columns)
+                  Instruction.Halt ]
+
+            | OptimizedPlan.DropTable(name, ifExists) ->
+                [ Instruction.DropTable(name, ifExists)
+                  Instruction.Halt ]
+
+        { Instructions = instructions }

--- a/code/packages/fsharp/sql-codegen/required_capabilities.json
+++ b/code/packages/fsharp/sql-codegen/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "fsharp/sql-codegen",
+  "capabilities": [],
+  "justification": "Pure in-memory library. No filesystem, process, environment, or network access needed."
+}

--- a/code/packages/fsharp/sql-codegen/tests/CodingAdventures.SqlCodegen.FSharp.Tests.fsproj
+++ b/code/packages/fsharp/sql-codegen/tests/CodingAdventures.SqlCodegen.FSharp.Tests.fsproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>CodingAdventures.SqlCodegen.FSharp.Tests</RootNamespace>
+    <AssemblyName>CodingAdventures.SqlCodegen.FSharp.Tests</AssemblyName>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="SqlCodegenTests.fs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk"      Version="17.12.0" />
+    <PackageReference Include="xunit"                       Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio"   Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector"          Version="6.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.msbuild"            Version="6.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../CodingAdventures.SqlCodegen.FSharp.fsproj" />
+  </ItemGroup>
+</Project>

--- a/code/packages/fsharp/sql-codegen/tests/SqlCodegenTests.fs
+++ b/code/packages/fsharp/sql-codegen/tests/SqlCodegenTests.fs
@@ -1,0 +1,928 @@
+// SqlCodegenTests.fs — unit tests for the F# sql-codegen package.
+//
+// These tests verify that `SqlCodegen.compile` produces the correct
+// instruction sequences for a wide range of query types. Each test
+// constructs an OptimizedPlan directly (no parsing needed) and asserts
+// on the generated instruction list.
+//
+// ── Test organisation ────────────────────────────────────────────────────
+//
+// Tests are grouped by query type, mirroring the codegen structure:
+//   - SELECT: basic scan, filter, projection, aggregation, GROUP BY, ORDER BY,
+//             LIMIT, DISTINCT, JOINs
+//   - INSERT / UPDATE / DELETE
+//   - DDL: CREATE TABLE, DROP TABLE
+//   - Expressions: literals, columns, binary ops, unary ops, IS NULL/NOT NULL,
+//                  BETWEEN, LIKE, IN
+//   - Aggregates: COUNT, COUNT(*), SUM, AVG, MIN, MAX
+//   - EmptyResult
+//   - Label uniqueness
+//   - compileExpression exported helper
+
+module CodingAdventures.SqlCodegen.FSharp.Tests
+
+open Xunit
+open CodingAdventures.SqlPlanner.FSharp
+open CodingAdventures.SqlOptimizer.FSharp
+open CodingAdventures.SqlCodegen.FSharp
+
+// ── Test helpers ──────────────────────────────────────────────────────────
+
+/// Compile a plan and return the instruction list.
+let private compile plan = (SqlCodegen.compile plan).Instructions
+
+/// Check that the instruction list contains `instr` (in order).
+let private containsInOrder (instrs: Instruction list) (needle: Instruction) =
+    List.contains needle instrs
+
+/// Check that instruction at index i is equal to expected.
+let private instrAt (instrs: Instruction list) i = List.item i instrs
+
+/// Find the first index of an instruction matching a predicate.
+let private findInstr (instrs: Instruction list) (pred: Instruction -> bool) =
+    instrs |> List.tryFindIndex pred
+
+/// Check that any instruction matches a predicate.
+let private anyInstr (instrs: Instruction list) (pred: Instruction -> bool) =
+    instrs |> List.exists pred
+
+/// Canonical column definitions for tests.
+let private colDef name = {
+    Name = name
+    TypeName = "TEXT"
+    NotNull = false
+    PrimaryKey = false
+    Unique = false
+    Default = None
+}
+
+/// A simple single-table scan plan.
+let private simpleScan table = OptimizedPlan.Scan(table, None, None, None)
+
+/// A scan plan with an alias.
+let private aliasScan table alias = OptimizedPlan.Scan(table, Some alias, None, None)
+
+/// Wrap a plan in a filter.
+let private withFilter plan pred = OptimizedPlan.Filter(plan, pred)
+
+/// Wrap a plan in a project.
+let private withProject plan cols = OptimizedPlan.Project(plan, cols)
+
+/// An output column with an expression and optional alias.
+let private exprCol expr alias = OutputColumn.Expr(expr, alias)
+
+/// A column reference expression.
+let private colRef col = Expr.Column(None, col)
+
+/// A qualified column reference.
+let private qColRef table col = Expr.Column(Some table, col)
+
+/// A literal integer expression.
+let private litInt n = Expr.Literal(SqlValue.Integer (int64 n))
+
+/// A literal text expression.
+let private litText s = Expr.Literal(SqlValue.Text s)
+
+/// Binary op expression helper.
+let private binOp op l r = Expr.BinaryOp(op, l, r)
+
+// ── EmptyResult tests ─────────────────────────────────────────────────────
+
+[<Fact>]
+let ``EmptyResult compiles to Halt only`` () =
+    let instrs = compile OptimizedPlan.EmptyResult
+    Assert.Equal<Instruction list>([ Instruction.Halt ], instrs)
+
+// ── SELECT basic scan tests ───────────────────────────────────────────────
+
+[<Fact>]
+let ``SELECT star from single table produces OpenScan and CloseScan`` () =
+    let plan = simpleScan "users"
+    let instrs = compile plan
+    Assert.True(anyInstr instrs (fun i -> i = Instruction.OpenScan("users", None)),
+        "Expected OpenScan for 'users'")
+    Assert.True(anyInstr instrs (fun i -> i = Instruction.CloseScan None),
+        "Expected CloseScan")
+
+[<Fact>]
+let ``SELECT star loop has AdvanceCursor and Jump back`` () =
+    let plan = simpleScan "orders"
+    let instrs = compile plan
+    Assert.True(anyInstr instrs (fun i -> i = Instruction.AdvanceCursor None),
+        "Expected AdvanceCursor")
+    Assert.True(anyInstr instrs (fun i -> match i with Instruction.Jump _ -> true | _ -> false),
+        "Expected Jump (loop back)")
+
+[<Fact>]
+let ``SELECT star emits Halt at end`` () =
+    let plan = simpleScan "products"
+    let instrs = compile plan
+    Assert.Equal(Instruction.Halt, List.last instrs)
+
+[<Fact>]
+let ``SELECT star emits BeginRow and EmitRow in loop body`` () =
+    let plan = simpleScan "users"
+    let instrs = compile plan
+    Assert.True(anyInstr instrs (fun i -> i = Instruction.BeginRow), "Expected BeginRow")
+    Assert.True(anyInstr instrs (fun i -> i = Instruction.EmitRow), "Expected EmitRow")
+
+[<Fact>]
+let ``SELECT with named column emits EmitColumn with correct name`` () =
+    let col = exprCol (colRef "name") None
+    let plan = withProject (simpleScan "users") [ col ]
+    let instrs = compile plan
+    Assert.True(anyInstr instrs (fun i -> i = Instruction.EmitColumn "name"),
+        "Expected EmitColumn 'name'")
+
+[<Fact>]
+let ``SELECT with aliased column emits EmitColumn with alias`` () =
+    let col = exprCol (colRef "name") (Some "full_name")
+    let plan = withProject (simpleScan "users") [ col ]
+    let instrs = compile plan
+    Assert.True(anyInstr instrs (fun i -> i = Instruction.EmitColumn "full_name"),
+        "Expected EmitColumn 'full_name'")
+
+[<Fact>]
+let ``SELECT with two columns emits two EmitColumn instructions`` () =
+    let cols = [ exprCol (colRef "id") None; exprCol (colRef "name") None ]
+    let plan = withProject (simpleScan "users") cols
+    let instrs = compile plan
+    let colEmits = instrs |> List.filter (fun i ->
+        match i with Instruction.EmitColumn _ -> true | _ -> false)
+    Assert.Equal(2, List.length colEmits)
+
+[<Fact>]
+let ``SELECT with expression column emits LoadColumn then EmitColumn`` () =
+    let col = exprCol (colRef "age") None
+    let plan = withProject (simpleScan "users") [ col ]
+    let instrs = compile plan
+    // LoadColumn should appear before EmitColumn
+    let loadIdx = findInstr instrs (fun i -> i = Instruction.LoadColumn(None, "age"))
+    let emitIdx = findInstr instrs (fun i -> i = Instruction.EmitColumn "age")
+    Assert.True(loadIdx.IsSome, "Expected LoadColumn 'age'")
+    Assert.True(emitIdx.IsSome, "Expected EmitColumn 'age'")
+    Assert.True(loadIdx.Value < emitIdx.Value, "LoadColumn should come before EmitColumn")
+
+// ── SELECT with WHERE tests ───────────────────────────────────────────────
+
+[<Fact>]
+let ``SELECT with WHERE compiles predicate into loop body`` () =
+    let pred = binOp BinaryOperator.Gt (colRef "age") (litInt 18)
+    let plan = withFilter (simpleScan "users") pred
+    let instrs = compile plan
+    // The predicate should include a JumpIfFalse
+    Assert.True(anyInstr instrs (fun i -> match i with Instruction.JumpIfFalse _ -> true | _ -> false),
+        "Expected JumpIfFalse for WHERE clause")
+
+[<Fact>]
+let ``SELECT with WHERE = emits BinaryOpInstr Eq`` () =
+    let pred = binOp BinaryOperator.Eq (colRef "status") (litText "active")
+    let plan = withFilter (simpleScan "orders") pred
+    let instrs = compile plan
+    Assert.True(anyInstr instrs (fun i -> i = Instruction.BinaryOpInstr BinaryOp.Eq),
+        "Expected BinaryOpInstr Eq")
+
+[<Fact>]
+let ``SELECT with WHERE loads column and constant`` () =
+    let pred = binOp BinaryOperator.Lt (colRef "price") (Expr.Literal(SqlValue.Real 100.0))
+    let plan = withFilter (simpleScan "products") pred
+    let instrs = compile plan
+    Assert.True(anyInstr instrs (fun i -> i = Instruction.LoadColumn(None, "price")),
+        "Expected LoadColumn 'price'")
+    Assert.True(anyInstr instrs (fun i -> i = Instruction.LoadConst(SqlValue.Real 100.0)),
+        "Expected LoadConst 100.0")
+
+[<Fact>]
+let ``SELECT with AND predicate emits BinaryOpInstr And`` () =
+    let pred =
+        binOp BinaryOperator.And
+            (binOp BinaryOperator.Gt (colRef "age") (litInt 18))
+            (binOp BinaryOperator.Lt (colRef "age") (litInt 65))
+    let plan = withFilter (simpleScan "employees") pred
+    let instrs = compile plan
+    Assert.True(anyInstr instrs (fun i -> i = Instruction.BinaryOpInstr BinaryOp.And),
+        "Expected BinaryOpInstr And")
+
+// ── SELECT with ORDER BY tests ────────────────────────────────────────────
+
+[<Fact>]
+let ``SELECT with ORDER BY emits SortResult post-op`` () =
+    let key = { KeyExpr = colRef "name"; Direction = SortDir.Asc; NullOrder = NullOrder.NullsLast }
+    let inner = simpleScan "users"
+    let plan = OptimizedPlan.Sort(inner, [ key ])
+    let instrs = compile plan
+    Assert.True(anyInstr instrs (fun i ->
+        match i with Instruction.SortResult _ -> true | _ -> false),
+        "Expected SortResult")
+
+[<Fact>]
+let ``SELECT with ORDER BY DESC emits SortResult with Desc key`` () =
+    let key = { KeyExpr = colRef "salary"; Direction = SortDir.Desc; NullOrder = NullOrder.NullsFirst }
+    let inner = simpleScan "employees"
+    let plan = OptimizedPlan.Sort(inner, [ key ])
+    let instrs = compile plan
+    let sortInstr = instrs |> List.tryFind (fun i ->
+        match i with Instruction.SortResult _ -> true | _ -> false)
+    Assert.True(sortInstr.IsSome, "Expected SortResult")
+    match sortInstr with
+    | Some (Instruction.SortResult keys) ->
+        Assert.Equal(1, List.length keys)
+        Assert.Equal(SortDir.Desc, keys.[0].Direction)
+    | _ -> failwith "unexpected"
+
+[<Fact>]
+let ``SortResult comes AFTER the scan loop`` () =
+    let key = { KeyExpr = colRef "name"; Direction = SortDir.Asc; NullOrder = NullOrder.NullsLast }
+    let plan = OptimizedPlan.Sort(simpleScan "users", [ key ])
+    let instrs = compile plan
+    let haltIdx = instrs |> List.findIndex (fun i -> i = Instruction.Halt)
+    let sortIdx = instrs |> List.tryFindIndex (fun i ->
+        match i with Instruction.SortResult _ -> true | _ -> false)
+    Assert.True(sortIdx.IsSome, "Expected SortResult")
+    Assert.True(sortIdx.Value < haltIdx, "SortResult should come before Halt")
+    let closeIdx = instrs |> List.tryFindIndex (fun i -> i = Instruction.CloseScan None)
+    Assert.True(closeIdx.IsSome, "Expected CloseScan")
+    Assert.True(sortIdx.Value > closeIdx.Value, "SortResult should come after CloseScan")
+
+// ── SELECT with LIMIT/OFFSET tests ───────────────────────────────────────
+
+[<Fact>]
+let ``SELECT with LIMIT emits LimitResult post-op`` () =
+    let plan = OptimizedPlan.Limit(simpleScan "users", Some 10L, None)
+    let instrs = compile plan
+    Assert.True(anyInstr instrs (fun i ->
+        i = Instruction.LimitResult(Some 10L, None)),
+        "Expected LimitResult(Some 10, None)")
+
+[<Fact>]
+let ``SELECT with LIMIT and OFFSET emits LimitResult with both`` () =
+    let plan = OptimizedPlan.Limit(simpleScan "users", Some 5L, Some 20L)
+    let instrs = compile plan
+    Assert.True(anyInstr instrs (fun i ->
+        i = Instruction.LimitResult(Some 5L, Some 20L)),
+        "Expected LimitResult(Some 5, Some 20)")
+
+[<Fact>]
+let ``SELECT with LIMIT no count emits LimitResult with None count`` () =
+    let plan = OptimizedPlan.Limit(simpleScan "users", None, Some 10L)
+    let instrs = compile plan
+    Assert.True(anyInstr instrs (fun i ->
+        i = Instruction.LimitResult(None, Some 10L)),
+        "Expected LimitResult(None, Some 10)")
+
+// ── SELECT DISTINCT tests ─────────────────────────────────────────────────
+
+[<Fact>]
+let ``SELECT DISTINCT emits DistinctResult post-op`` () =
+    let plan = OptimizedPlan.Distinct(simpleScan "users")
+    let instrs = compile plan
+    Assert.True(anyInstr instrs (fun i -> i = Instruction.DistinctResult),
+        "Expected DistinctResult")
+
+[<Fact>]
+let ``DistinctResult comes after scan loop`` () =
+    let plan = OptimizedPlan.Distinct(simpleScan "users")
+    let instrs = compile plan
+    let haltIdx = instrs |> List.findIndex (fun i -> i = Instruction.Halt)
+    let distIdx = instrs |> List.tryFindIndex (fun i -> i = Instruction.DistinctResult)
+    Assert.True(distIdx.IsSome, "Expected DistinctResult")
+    Assert.True(distIdx.Value < haltIdx, "DistinctResult should come before Halt")
+
+// ── Aggregate tests ───────────────────────────────────────────────────────
+
+[<Fact>]
+let ``SELECT COUNT star emits InitAgg UpdateAgg FinalizeAgg`` () =
+    let aggItem = { Func = AggFunction.Count; Arg = AggArg.Star; Alias = "count(*)"; Distinct = false }
+    let inner = simpleScan "orders"
+    let plan = OptimizedPlan.Aggregate(inner, [], [ aggItem ])
+    let instrs = compile plan
+    Assert.True(anyInstr instrs (fun i -> match i with Instruction.InitAgg _ -> true | _ -> false),
+        "Expected InitAgg")
+    Assert.True(anyInstr instrs (fun i -> match i with Instruction.UpdateAgg _ -> true | _ -> false),
+        "Expected UpdateAgg")
+    Assert.True(anyInstr instrs (fun i -> match i with Instruction.FinalizeAgg _ -> true | _ -> false),
+        "Expected FinalizeAgg")
+
+[<Fact>]
+let ``SELECT COUNT star InitAgg count is 1`` () =
+    let aggItem = { Func = AggFunction.Count; Arg = AggArg.Star; Alias = "cnt"; Distinct = false }
+    let plan = OptimizedPlan.Aggregate(simpleScan "users", [], [ aggItem ])
+    let instrs = compile plan
+    let initInstr = instrs |> List.tryFind (fun i -> match i with Instruction.InitAgg _ -> true | _ -> false)
+    match initInstr with
+    | Some (Instruction.InitAgg n) -> Assert.Equal(1, n)
+    | _ -> failwith "No InitAgg found"
+
+[<Fact>]
+let ``SELECT SUM emits UpdateAgg with Sum`` () =
+    let aggItem = { Func = AggFunction.Sum; Arg = AggArg.Expr(colRef "amount"); Alias = "total"; Distinct = false }
+    let plan = OptimizedPlan.Aggregate(simpleScan "orders", [], [ aggItem ])
+    let instrs = compile plan
+    Assert.True(anyInstr instrs (fun i ->
+        match i with Instruction.UpdateAgg(_, AggFn.Sum) -> true | _ -> false),
+        "Expected UpdateAgg with Sum")
+
+[<Fact>]
+let ``SELECT AVG emits UpdateAgg with Avg`` () =
+    let aggItem = { Func = AggFunction.Avg; Arg = AggArg.Expr(colRef "score"); Alias = "avg_score"; Distinct = false }
+    let plan = OptimizedPlan.Aggregate(simpleScan "tests", [], [ aggItem ])
+    let instrs = compile plan
+    Assert.True(anyInstr instrs (fun i ->
+        match i with Instruction.UpdateAgg(_, AggFn.Avg) -> true | _ -> false),
+        "Expected UpdateAgg with Avg")
+
+[<Fact>]
+let ``SELECT MIN emits UpdateAgg with Min`` () =
+    let aggItem = { Func = AggFunction.Min; Arg = AggArg.Expr(colRef "price"); Alias = "min_price"; Distinct = false }
+    let plan = OptimizedPlan.Aggregate(simpleScan "products", [], [ aggItem ])
+    let instrs = compile plan
+    Assert.True(anyInstr instrs (fun i ->
+        match i with Instruction.UpdateAgg(_, AggFn.Min) -> true | _ -> false),
+        "Expected UpdateAgg with Min")
+
+[<Fact>]
+let ``SELECT MAX emits UpdateAgg with Max`` () =
+    let aggItem = { Func = AggFunction.Max; Arg = AggArg.Expr(colRef "age"); Alias = "max_age"; Distinct = false }
+    let plan = OptimizedPlan.Aggregate(simpleScan "users", [], [ aggItem ])
+    let instrs = compile plan
+    Assert.True(anyInstr instrs (fun i ->
+        match i with Instruction.UpdateAgg(_, AggFn.Max) -> true | _ -> false),
+        "Expected UpdateAgg with Max")
+
+[<Fact>]
+let ``SELECT multiple aggregates emits InitAgg with count 2`` () =
+    let agg1 = { Func = AggFunction.Count; Arg = AggArg.Star; Alias = "cnt"; Distinct = false }
+    let agg2 = { Func = AggFunction.Sum; Arg = AggArg.Expr(colRef "amount"); Alias = "total"; Distinct = false }
+    let plan = OptimizedPlan.Aggregate(simpleScan "orders", [], [ agg1; agg2 ])
+    let instrs = compile plan
+    let initInstr = instrs |> List.tryFind (fun i -> match i with Instruction.InitAgg _ -> true | _ -> false)
+    match initInstr with
+    | Some (Instruction.InitAgg n) -> Assert.Equal(2, n)
+    | _ -> failwith "No InitAgg found"
+
+// ── GROUP BY tests ────────────────────────────────────────────────────────
+
+[<Fact>]
+let ``SELECT with GROUP BY emits SaveGroupKey`` () =
+    let aggItem = { Func = AggFunction.Count; Arg = AggArg.Star; Alias = "cnt"; Distinct = false }
+    let plan = OptimizedPlan.Aggregate(simpleScan "orders", [ colRef "category" ], [ aggItem ])
+    let instrs = compile plan
+    Assert.True(anyInstr instrs (fun i ->
+        match i with Instruction.SaveGroupKey _ -> true | _ -> false),
+        "Expected SaveGroupKey")
+
+[<Fact>]
+let ``SELECT with GROUP BY two columns emits SaveGroupKey with two names`` () =
+    let aggItem = { Func = AggFunction.Count; Arg = AggArg.Star; Alias = "cnt"; Distinct = false }
+    let plan = OptimizedPlan.Aggregate(
+        simpleScan "sales",
+        [ colRef "year"; colRef "month" ],
+        [ aggItem ])
+    let instrs = compile plan
+    let saveInstr = instrs |> List.tryFind (fun i ->
+        match i with Instruction.SaveGroupKey _ -> true | _ -> false)
+    match saveInstr with
+    | Some (Instruction.SaveGroupKey keys) -> Assert.Equal(2, List.length keys)
+    | _ -> failwith "No SaveGroupKey found"
+
+[<Fact>]
+let ``SELECT with GROUP BY emits LoadGroupKey for finalize phase`` () =
+    let aggItem = { Func = AggFunction.Sum; Arg = AggArg.Expr(colRef "amount"); Alias = "total"; Distinct = false }
+    let plan = OptimizedPlan.Aggregate(simpleScan "orders", [ colRef "dept" ], [ aggItem ])
+    let instrs = compile plan
+    Assert.True(anyInstr instrs (fun i ->
+        match i with Instruction.LoadGroupKey _ -> true | _ -> false),
+        "Expected LoadGroupKey for group emit phase")
+
+// ── INSERT tests ──────────────────────────────────────────────────────────
+
+[<Fact>]
+let ``INSERT VALUES emits InsertRow`` () =
+    let values = [ [ litInt 1; litText "Alice" ] ]
+    let plan = OptimizedPlan.Insert("users", Some [ "id"; "name" ], InsertSource.Values values)
+    let instrs = compile plan
+    Assert.True(anyInstr instrs (fun i ->
+        match i with Instruction.InsertRow _ -> true | _ -> false),
+        "Expected InsertRow")
+
+[<Fact>]
+let ``INSERT VALUES emits LoadConst for each value`` () =
+    let values = [ [ litInt 42; litText "Bob" ] ]
+    let plan = OptimizedPlan.Insert("users", None, InsertSource.Values values)
+    let instrs = compile plan
+    Assert.True(anyInstr instrs (fun i -> i = Instruction.LoadConst(SqlValue.Integer 42L)),
+        "Expected LoadConst Integer 42")
+    Assert.True(anyInstr instrs (fun i -> i = Instruction.LoadConst(SqlValue.Text "Bob")),
+        "Expected LoadConst Text 'Bob'")
+
+[<Fact>]
+let ``INSERT VALUES multiple rows emits multiple InsertRow`` () =
+    let values = [ [ litInt 1 ]; [ litInt 2 ]; [ litInt 3 ] ]
+    let plan = OptimizedPlan.Insert("ids", None, InsertSource.Values values)
+    let instrs = compile plan
+    let insertCount = instrs |> List.filter (fun i ->
+        match i with Instruction.InsertRow _ -> true | _ -> false) |> List.length
+    Assert.Equal(3, insertCount)
+
+[<Fact>]
+let ``INSERT with column list stores columns in InsertRow`` () =
+    let values = [ [ litInt 1 ] ]
+    let cols = Some [ "id" ]
+    let plan = OptimizedPlan.Insert("users", cols, InsertSource.Values values)
+    let instrs = compile plan
+    let insertInstr = instrs |> List.tryFind (fun i ->
+        match i with Instruction.InsertRow _ -> true | _ -> false)
+    match insertInstr with
+    | Some (Instruction.InsertRow(table, colsOpt)) ->
+        Assert.Equal("users", table)
+        Assert.Equal(Some [ "id" ], colsOpt)
+    | _ -> failwith "No InsertRow found"
+
+// ── UPDATE tests ──────────────────────────────────────────────────────────
+
+[<Fact>]
+let ``UPDATE emits OpenScan and UpdateRows`` () =
+    let assign = { Column = "status"; Value = litText "inactive" }
+    let plan = OptimizedPlan.Update("users", [ assign ], None)
+    let instrs = compile plan
+    Assert.True(anyInstr instrs (fun i -> i = Instruction.OpenScan("users", None)),
+        "Expected OpenScan for update")
+    Assert.True(anyInstr instrs (fun i ->
+        match i with Instruction.UpdateRows _ -> true | _ -> false),
+        "Expected UpdateRows")
+
+[<Fact>]
+let ``UPDATE with WHERE emits filter predicate before UpdateRows`` () =
+    let assign = { Column = "name"; Value = litText "Charlie" }
+    let pred = binOp BinaryOperator.Eq (colRef "id") (litInt 1)
+    let plan = OptimizedPlan.Update("users", [ assign ], Some pred)
+    let instrs = compile plan
+    Assert.True(anyInstr instrs (fun i -> match i with Instruction.JumpIfFalse _ -> true | _ -> false),
+        "Expected JumpIfFalse for WHERE in UPDATE")
+    Assert.True(anyInstr instrs (fun i -> match i with Instruction.UpdateRows _ -> true | _ -> false),
+        "Expected UpdateRows")
+
+[<Fact>]
+let ``UPDATE emits CloseScan and Halt`` () =
+    let assign = { Column = "x"; Value = litInt 0 }
+    let plan = OptimizedPlan.Update("t", [ assign ], None)
+    let instrs = compile plan
+    Assert.True(anyInstr instrs (fun i -> i = Instruction.CloseScan None),
+        "Expected CloseScan")
+    Assert.Equal(Instruction.Halt, List.last instrs)
+
+// ── DELETE tests ──────────────────────────────────────────────────────────
+
+[<Fact>]
+let ``DELETE emits OpenScan and DeleteRows`` () =
+    let plan = OptimizedPlan.Delete("users", None)
+    let instrs = compile plan
+    Assert.True(anyInstr instrs (fun i -> i = Instruction.OpenScan("users", None)),
+        "Expected OpenScan")
+    Assert.True(anyInstr instrs (fun i ->
+        match i with Instruction.DeleteRows _ -> true | _ -> false),
+        "Expected DeleteRows")
+
+[<Fact>]
+let ``DELETE with WHERE emits filter predicate`` () =
+    let pred = binOp BinaryOperator.Eq (colRef "id") (litInt 5)
+    let plan = OptimizedPlan.Delete("users", Some pred)
+    let instrs = compile plan
+    Assert.True(anyInstr instrs (fun i -> match i with Instruction.JumpIfFalse _ -> true | _ -> false),
+        "Expected JumpIfFalse for WHERE in DELETE")
+
+[<Fact>]
+let ``DELETE emits CloseScan and Halt`` () =
+    let plan = OptimizedPlan.Delete("logs", None)
+    let instrs = compile plan
+    Assert.True(anyInstr instrs (fun i -> i = Instruction.CloseScan None))
+    Assert.Equal(Instruction.Halt, List.last instrs)
+
+// ── CREATE TABLE tests ────────────────────────────────────────────────────
+
+[<Fact>]
+let ``CREATE TABLE emits CreateTable instruction`` () =
+    let cols = [ colDef "id"; colDef "name" ]
+    let plan = OptimizedPlan.CreateTable("users", false, cols)
+    let instrs = compile plan
+    Assert.True(anyInstr instrs (fun i ->
+        match i with Instruction.CreateTable _ -> true | _ -> false),
+        "Expected CreateTable")
+
+[<Fact>]
+let ``CREATE TABLE IF NOT EXISTS passes ifNotExists flag`` () =
+    let cols = [ colDef "id" ]
+    let plan = OptimizedPlan.CreateTable("t", true, cols)
+    let instrs = compile plan
+    let createInstr = instrs |> List.tryFind (fun i ->
+        match i with Instruction.CreateTable _ -> true | _ -> false)
+    match createInstr with
+    | Some (Instruction.CreateTable(name, ifne, _)) ->
+        Assert.Equal("t", name)
+        Assert.True(ifne)
+    | _ -> failwith "No CreateTable found"
+
+[<Fact>]
+let ``CREATE TABLE emits Halt`` () =
+    let plan = OptimizedPlan.CreateTable("t", false, [ colDef "x" ])
+    let instrs = compile plan
+    Assert.Equal(Instruction.Halt, List.last instrs)
+
+[<Fact>]
+let ``CREATE TABLE preserves column definitions`` () =
+    let cols = [ colDef "id"; colDef "name"; colDef "age" ]
+    let plan = OptimizedPlan.CreateTable("users", false, cols)
+    let instrs = compile plan
+    let createInstr = instrs |> List.tryFind (fun i ->
+        match i with Instruction.CreateTable _ -> true | _ -> false)
+    match createInstr with
+    | Some (Instruction.CreateTable(_, _, actualCols)) ->
+        Assert.Equal(3, List.length actualCols)
+    | _ -> failwith "No CreateTable found"
+
+// ── DROP TABLE tests ──────────────────────────────────────────────────────
+
+[<Fact>]
+let ``DROP TABLE emits DropTable instruction`` () =
+    let plan = OptimizedPlan.DropTable("users", false)
+    let instrs = compile plan
+    Assert.True(anyInstr instrs (fun i ->
+        match i with Instruction.DropTable _ -> true | _ -> false),
+        "Expected DropTable")
+
+[<Fact>]
+let ``DROP TABLE IF EXISTS passes ifExists flag`` () =
+    let plan = OptimizedPlan.DropTable("users", true)
+    let instrs = compile plan
+    let dropInstr = instrs |> List.tryFind (fun i ->
+        match i with Instruction.DropTable _ -> true | _ -> false)
+    match dropInstr with
+    | Some (Instruction.DropTable(name, ie)) ->
+        Assert.Equal("users", name)
+        Assert.True(ie)
+    | _ -> failwith "No DropTable found"
+
+[<Fact>]
+let ``DROP TABLE emits Halt`` () =
+    let plan = OptimizedPlan.DropTable("t", false)
+    let instrs = compile plan
+    Assert.Equal(Instruction.Halt, List.last instrs)
+
+// ── Expression compilation tests ──────────────────────────────────────────
+
+[<Fact>]
+let ``compileExpression integer literal produces LoadConst`` () =
+    let instrs = SqlCodegen.compileExpression (litInt 42)
+    Assert.Equal<Instruction list>([ Instruction.LoadConst(SqlValue.Integer 42L) ], instrs)
+
+[<Fact>]
+let ``compileExpression text literal produces LoadConst`` () =
+    let instrs = SqlCodegen.compileExpression (litText "hello")
+    Assert.Equal<Instruction list>([ Instruction.LoadConst(SqlValue.Text "hello") ], instrs)
+
+[<Fact>]
+let ``compileExpression null literal produces LoadConst Null`` () =
+    let instrs = SqlCodegen.compileExpression (Expr.Literal SqlValue.Null)
+    Assert.Equal<Instruction list>([ Instruction.LoadConst SqlValue.Null ], instrs)
+
+[<Fact>]
+let ``compileExpression bool literal produces LoadConst Bool`` () =
+    let instrs = SqlCodegen.compileExpression (Expr.Literal(SqlValue.Bool true))
+    Assert.Equal<Instruction list>([ Instruction.LoadConst(SqlValue.Bool true) ], instrs)
+
+[<Fact>]
+let ``compileExpression real literal produces LoadConst Real`` () =
+    let instrs = SqlCodegen.compileExpression (Expr.Literal(SqlValue.Real 3.14))
+    Assert.Equal<Instruction list>([ Instruction.LoadConst(SqlValue.Real 3.14) ], instrs)
+
+[<Fact>]
+let ``compileExpression column reference produces LoadColumn`` () =
+    let instrs = SqlCodegen.compileExpression (colRef "age")
+    Assert.Equal<Instruction list>([ Instruction.LoadColumn(None, "age") ], instrs)
+
+[<Fact>]
+let ``compileExpression qualified column produces LoadColumn with table`` () =
+    let instrs = SqlCodegen.compileExpression (qColRef "u" "name")
+    Assert.Equal<Instruction list>([ Instruction.LoadColumn(Some "u", "name") ], instrs)
+
+[<Fact>]
+let ``compileExpression Add produces BinaryOpInstr Add`` () =
+    let expr = binOp BinaryOperator.Add (litInt 1) (litInt 2)
+    let instrs = SqlCodegen.compileExpression expr
+    Assert.True(anyInstr instrs (fun i -> i = Instruction.BinaryOpInstr BinaryOp.Add))
+
+[<Fact>]
+let ``compileExpression Sub produces BinaryOpInstr Sub`` () =
+    let expr = binOp BinaryOperator.Sub (litInt 10) (litInt 3)
+    let instrs = SqlCodegen.compileExpression expr
+    Assert.True(anyInstr instrs (fun i -> i = Instruction.BinaryOpInstr BinaryOp.Sub))
+
+[<Fact>]
+let ``compileExpression Mul produces BinaryOpInstr Mul`` () =
+    let expr = binOp BinaryOperator.Mul (litInt 5) (litInt 6)
+    let instrs = SqlCodegen.compileExpression expr
+    Assert.True(anyInstr instrs (fun i -> i = Instruction.BinaryOpInstr BinaryOp.Mul))
+
+[<Fact>]
+let ``compileExpression Div produces BinaryOpInstr Div`` () =
+    let expr = binOp BinaryOperator.Div (litInt 10) (litInt 2)
+    let instrs = SqlCodegen.compileExpression expr
+    Assert.True(anyInstr instrs (fun i -> i = Instruction.BinaryOpInstr BinaryOp.Div))
+
+[<Fact>]
+let ``compileExpression Mod produces BinaryOpInstr Mod`` () =
+    let expr = binOp BinaryOperator.Mod (litInt 7) (litInt 3)
+    let instrs = SqlCodegen.compileExpression expr
+    Assert.True(anyInstr instrs (fun i -> i = Instruction.BinaryOpInstr BinaryOp.Mod))
+
+[<Fact>]
+let ``compileExpression Eq produces BinaryOpInstr Eq`` () =
+    let expr = binOp BinaryOperator.Eq (colRef "x") (litInt 5)
+    let instrs = SqlCodegen.compileExpression expr
+    Assert.True(anyInstr instrs (fun i -> i = Instruction.BinaryOpInstr BinaryOp.Eq))
+
+[<Fact>]
+let ``compileExpression NotEq produces BinaryOpInstr Neq`` () =
+    let expr = binOp BinaryOperator.NotEq (colRef "x") (litInt 5)
+    let instrs = SqlCodegen.compileExpression expr
+    Assert.True(anyInstr instrs (fun i -> i = Instruction.BinaryOpInstr BinaryOp.Neq))
+
+[<Fact>]
+let ``compileExpression Lt produces BinaryOpInstr Lt`` () =
+    let expr = binOp BinaryOperator.Lt (colRef "x") (litInt 10)
+    let instrs = SqlCodegen.compileExpression expr
+    Assert.True(anyInstr instrs (fun i -> i = Instruction.BinaryOpInstr BinaryOp.Lt))
+
+[<Fact>]
+let ``compileExpression Lte produces BinaryOpInstr Lte`` () =
+    let expr = binOp BinaryOperator.Lte (colRef "x") (litInt 10)
+    let instrs = SqlCodegen.compileExpression expr
+    Assert.True(anyInstr instrs (fun i -> i = Instruction.BinaryOpInstr BinaryOp.Lte))
+
+[<Fact>]
+let ``compileExpression Gt produces BinaryOpInstr Gt`` () =
+    let expr = binOp BinaryOperator.Gt (colRef "x") (litInt 5)
+    let instrs = SqlCodegen.compileExpression expr
+    Assert.True(anyInstr instrs (fun i -> i = Instruction.BinaryOpInstr BinaryOp.Gt))
+
+[<Fact>]
+let ``compileExpression Gte produces BinaryOpInstr Gte`` () =
+    let expr = binOp BinaryOperator.Gte (colRef "x") (litInt 5)
+    let instrs = SqlCodegen.compileExpression expr
+    Assert.True(anyInstr instrs (fun i -> i = Instruction.BinaryOpInstr BinaryOp.Gte))
+
+[<Fact>]
+let ``compileExpression And produces BinaryOpInstr And`` () =
+    let expr = binOp BinaryOperator.And (Expr.Literal(SqlValue.Bool true)) (Expr.Literal(SqlValue.Bool false))
+    let instrs = SqlCodegen.compileExpression expr
+    Assert.True(anyInstr instrs (fun i -> i = Instruction.BinaryOpInstr BinaryOp.And))
+
+[<Fact>]
+let ``compileExpression Or produces BinaryOpInstr Or`` () =
+    let expr = binOp BinaryOperator.Or (Expr.Literal(SqlValue.Bool false)) (Expr.Literal(SqlValue.Bool true))
+    let instrs = SqlCodegen.compileExpression expr
+    Assert.True(anyInstr instrs (fun i -> i = Instruction.BinaryOpInstr BinaryOp.Or))
+
+[<Fact>]
+let ``compileExpression Neg produces UnaryOpInstr Neg`` () =
+    let expr = Expr.UnaryOp(UnaryOperator.Neg, litInt 5)
+    let instrs = SqlCodegen.compileExpression expr
+    Assert.True(anyInstr instrs (fun i -> i = Instruction.UnaryOpInstr UnaryOp.Neg))
+
+[<Fact>]
+let ``compileExpression Not produces UnaryOpInstr Not`` () =
+    let expr = Expr.UnaryOp(UnaryOperator.Not, Expr.Literal(SqlValue.Bool true))
+    let instrs = SqlCodegen.compileExpression expr
+    Assert.True(anyInstr instrs (fun i -> i = Instruction.UnaryOpInstr UnaryOp.Not))
+
+[<Fact>]
+let ``compileExpression IsNull produces IsNull instruction`` () =
+    let expr = Expr.IsNull(colRef "email")
+    let instrs = SqlCodegen.compileExpression expr
+    Assert.True(anyInstr instrs (fun i -> i = Instruction.IsNull))
+    Assert.True(anyInstr instrs (fun i -> i = Instruction.LoadColumn(None, "email")))
+
+[<Fact>]
+let ``compileExpression IsNotNull produces IsNotNull instruction`` () =
+    let expr = Expr.IsNotNull(colRef "phone")
+    let instrs = SqlCodegen.compileExpression expr
+    Assert.True(anyInstr instrs (fun i -> i = Instruction.IsNotNull))
+
+[<Fact>]
+let ``compileExpression Between produces Between instruction`` () =
+    let expr = Expr.Between(colRef "age", litInt 18, litInt 65)
+    let instrs = SqlCodegen.compileExpression expr
+    Assert.True(anyInstr instrs (fun i ->
+        match i with Instruction.Between _ -> true | _ -> false),
+        "Expected Between instruction")
+
+[<Fact>]
+let ``compileExpression Between pushes value lo hi in order`` () =
+    let expr = Expr.Between(colRef "score", litInt 50, litInt 100)
+    let instrs = SqlCodegen.compileExpression expr
+    // After LoadColumn(score), we should see LoadConst(50), LoadConst(100)
+    let scoreIdx = instrs |> List.tryFindIndex (fun i -> i = Instruction.LoadColumn(None, "score"))
+    let lo50Idx  = instrs |> List.tryFindIndex (fun i -> i = Instruction.LoadConst(SqlValue.Integer 50L))
+    let hi100Idx = instrs |> List.tryFindIndex (fun i -> i = Instruction.LoadConst(SqlValue.Integer 100L))
+    Assert.True(scoreIdx.IsSome && lo50Idx.IsSome && hi100Idx.IsSome)
+    Assert.True(scoreIdx.Value < lo50Idx.Value)
+    Assert.True(lo50Idx.Value < hi100Idx.Value)
+
+[<Fact>]
+let ``compileExpression Like produces Like instruction and pattern constant`` () =
+    let expr = Expr.Like(colRef "name", "%Alice%")
+    let instrs = SqlCodegen.compileExpression expr
+    Assert.True(anyInstr instrs (fun i -> i = Instruction.Like))
+    Assert.True(anyInstr instrs (fun i -> i = Instruction.LoadConst(SqlValue.Text "%Alice%")))
+
+[<Fact>]
+let ``compileExpression NotLike produces Like then Not`` () =
+    let expr = Expr.NotLike(colRef "name", "Bob%")
+    let instrs = SqlCodegen.compileExpression expr
+    Assert.True(anyInstr instrs (fun i -> i = Instruction.Like))
+    Assert.True(anyInstr instrs (fun i -> i = Instruction.UnaryOpInstr UnaryOp.Not))
+
+[<Fact>]
+let ``compileExpression In produces InList with correct count`` () =
+    let items = [ litInt 1; litInt 2; litInt 3 ]
+    let expr = Expr.In(colRef "id", items)
+    let instrs = SqlCodegen.compileExpression expr
+    Assert.True(anyInstr instrs (fun i -> i = Instruction.InList 3),
+        "Expected InList 3")
+
+[<Fact>]
+let ``compileExpression In pushes needle first then items`` () =
+    let items = [ litInt 10; litInt 20 ]
+    let expr = Expr.In(colRef "x", items)
+    let instrs = SqlCodegen.compileExpression expr
+    let needleIdx = instrs |> List.tryFindIndex (fun i -> i = Instruction.LoadColumn(None, "x"))
+    let inListIdx = instrs |> List.tryFindIndex (fun i -> i = Instruction.InList 2)
+    Assert.True(needleIdx.IsSome && inListIdx.IsSome)
+    Assert.True(needleIdx.Value < inListIdx.Value)
+
+[<Fact>]
+let ``compileExpression NotIn produces InList then Not`` () =
+    let items = [ litInt 1; litInt 2 ]
+    let expr = Expr.NotIn(colRef "cat", items)
+    let instrs = SqlCodegen.compileExpression expr
+    Assert.True(anyInstr instrs (fun i -> i = Instruction.InList 2))
+    Assert.True(anyInstr instrs (fun i -> i = Instruction.UnaryOpInstr UnaryOp.Not))
+
+[<Fact>]
+let ``compileExpression nested binary op has correct order`` () =
+    // (a + b) * c compiles to: a b Add c Mul
+    let expr = binOp BinaryOperator.Mul (binOp BinaryOperator.Add (colRef "a") (colRef "b")) (colRef "c")
+    let instrs = SqlCodegen.compileExpression expr
+    let addIdx = instrs |> List.tryFindIndex (fun i -> i = Instruction.BinaryOpInstr BinaryOp.Add)
+    let mulIdx = instrs |> List.tryFindIndex (fun i -> i = Instruction.BinaryOpInstr BinaryOp.Mul)
+    Assert.True(addIdx.IsSome && mulIdx.IsSome)
+    Assert.True(addIdx.Value < mulIdx.Value, "Add should come before Mul for (a+b)*c")
+
+// ── JOIN tests ────────────────────────────────────────────────────────────
+
+[<Fact>]
+let ``JOIN compiles outer and inner OpenScan`` () =
+    let left = aliasScan "users" "u"
+    let right = aliasScan "orders" "o"
+    let plan = OptimizedPlan.Join(left, right, JoinKind.Inner, None)
+    let instrs = compile plan
+    Assert.True(anyInstr instrs (fun i -> i = Instruction.OpenScan("users", Some "u")),
+        "Expected OpenScan for users")
+    Assert.True(anyInstr instrs (fun i -> i = Instruction.OpenScan("orders", Some "o")),
+        "Expected OpenScan for orders")
+
+[<Fact>]
+let ``JOIN compiles both CloseScan instructions`` () =
+    let left = aliasScan "users" "u"
+    let right = aliasScan "orders" "o"
+    let plan = OptimizedPlan.Join(left, right, JoinKind.Inner, None)
+    let instrs = compile plan
+    let closeCount = instrs |> List.filter (fun i ->
+        match i with Instruction.CloseScan _ -> true | _ -> false) |> List.length
+    Assert.Equal(2, closeCount)
+
+[<Fact>]
+let ``JOIN with ON condition emits JumpIfFalse for condition`` () =
+    let left = aliasScan "users" "u"
+    let right = aliasScan "orders" "o"
+    let cond = binOp BinaryOperator.Eq (qColRef "u" "id") (qColRef "o" "user_id")
+    let plan = OptimizedPlan.Join(left, right, JoinKind.Inner, Some cond)
+    let instrs = compile plan
+    Assert.True(anyInstr instrs (fun i -> match i with Instruction.JumpIfFalse _ -> true | _ -> false),
+        "Expected JumpIfFalse for JOIN ON condition")
+
+// ── Label uniqueness tests ────────────────────────────────────────────────
+
+[<Fact>]
+let ``Multiple scans produce unique loop labels`` () =
+    // Two independent scans (a UNION) should have distinct labels
+    let left = simpleScan "table_a"
+    let right = simpleScan "table_b"
+    let plan = OptimizedPlan.Union(left, right, true)
+    let instrs = compile plan
+    let labels = instrs |> List.choose (fun i ->
+        match i with Instruction.Label name -> Some name | _ -> None)
+    let uniqueLabels = labels |> List.distinct
+    Assert.Equal(List.length uniqueLabels, List.length labels)
+
+[<Fact>]
+let ``JOIN produces four unique labels (two loop/end pairs)`` () =
+    let left = aliasScan "a" "a"
+    let right = aliasScan "b" "b"
+    let plan = OptimizedPlan.Join(left, right, JoinKind.Inner, None)
+    let instrs = compile plan
+    let labels = instrs |> List.choose (fun i ->
+        match i with Instruction.Label name -> Some name | _ -> None)
+    Assert.Equal(4, List.length labels)  // loop_N, end_N for outer and inner
+
+[<Fact>]
+let ``Compiling two plans back-to-back produces unique labels`` () =
+    let plan1 = simpleScan "alpha"
+    let plan2 = simpleScan "beta"
+    let instrs1 = compile plan1
+    let instrs2 = compile plan2
+    let labels1 = instrs1 |> List.choose (fun i ->
+        match i with Instruction.Label n -> Some n | _ -> None) |> Set.ofList
+    let labels2 = instrs2 |> List.choose (fun i ->
+        match i with Instruction.Label n -> Some n | _ -> None) |> Set.ofList
+    // Labels from different compile calls should be independent (no conflicts within each)
+    Assert.True(Set.count labels1 > 0, "Plan 1 should have labels")
+    Assert.True(Set.count labels2 > 0, "Plan 2 should have labels")
+
+// ── Instruction ordering sanity tests ─────────────────────────────────────
+
+[<Fact>]
+let ``OpenScan comes before AdvanceCursor`` () =
+    let plan = simpleScan "users"
+    let instrs = compile plan
+    let openIdx = instrs |> List.findIndex (fun i -> i = Instruction.OpenScan("users", None))
+    let advIdx  = instrs |> List.findIndex (fun i -> i = Instruction.AdvanceCursor None)
+    Assert.True(openIdx < advIdx, "OpenScan must come before AdvanceCursor")
+
+[<Fact>]
+let ``AdvanceCursor comes before BeginRow`` () =
+    let plan = simpleScan "users"
+    let instrs = compile plan
+    let advIdx   = instrs |> List.findIndex (fun i -> i = Instruction.AdvanceCursor None)
+    let beginIdx = instrs |> List.findIndex (fun i -> i = Instruction.BeginRow)
+    Assert.True(advIdx < beginIdx, "AdvanceCursor must come before BeginRow")
+
+[<Fact>]
+let ``BeginRow comes before EmitRow`` () =
+    let plan = simpleScan "users"
+    let instrs = compile plan
+    let beginIdx = instrs |> List.findIndex (fun i -> i = Instruction.BeginRow)
+    let emitIdx  = instrs |> List.findIndex (fun i -> i = Instruction.EmitRow)
+    Assert.True(beginIdx < emitIdx, "BeginRow must come before EmitRow")
+
+[<Fact>]
+let ``CloseScan comes before Halt`` () =
+    let plan = simpleScan "users"
+    let instrs = compile plan
+    let closeIdx = instrs |> List.findIndex (fun i -> i = Instruction.CloseScan None)
+    let haltIdx  = instrs |> List.findIndex (fun i -> i = Instruction.Halt)
+    Assert.True(closeIdx < haltIdx, "CloseScan must come before Halt")
+
+[<Fact>]
+let ``JumpIfExhausted label matches a Label instruction`` () =
+    let plan = simpleScan "t"
+    let instrs = compile plan
+    // Find the JumpIfExhausted instruction and verify its label exists
+    let jumpExhausted = instrs |> List.tryFind (fun i ->
+        match i with Instruction.JumpIfExhausted _ -> true | _ -> false)
+    match jumpExhausted with
+    | Some (Instruction.JumpIfExhausted(_, lbl)) ->
+        let labelExists = anyInstr instrs (fun i -> i = Instruction.Label lbl)
+        Assert.True(labelExists, sprintf "Label '%s' referenced by JumpIfExhausted should exist" lbl)
+    | _ -> failwith "No JumpIfExhausted found"
+
+[<Fact>]
+let ``Jump target label exists in instruction stream`` () =
+    let plan = simpleScan "t"
+    let instrs = compile plan
+    // Find the unconditional Jump and verify its target exists
+    let jumpInstr = instrs |> List.tryFind (fun i ->
+        match i with Instruction.Jump _ -> true | _ -> false)
+    match jumpInstr with
+    | Some (Instruction.Jump lbl) ->
+        let labelExists = anyInstr instrs (fun i -> i = Instruction.Label lbl)
+        Assert.True(labelExists, sprintf "Label '%s' referenced by Jump should exist" lbl)
+    | _ -> failwith "No Jump found"
+
+// ── Combined post-processing tests ────────────────────────────────────────
+
+[<Fact>]
+let ``SELECT DISTINCT ORDER BY emits both DistinctResult and SortResult`` () =
+    let key = { KeyExpr = colRef "name"; Direction = SortDir.Asc; NullOrder = NullOrder.NullsLast }
+    let plan = OptimizedPlan.Distinct(OptimizedPlan.Sort(simpleScan "users", [ key ]))
+    let instrs = compile plan
+    Assert.True(anyInstr instrs (fun i -> i = Instruction.DistinctResult))
+    Assert.True(anyInstr instrs (fun i -> match i with Instruction.SortResult _ -> true | _ -> false))
+
+[<Fact>]
+let ``SELECT LIMIT ORDER BY emits both LimitResult and SortResult`` () =
+    let key = { KeyExpr = colRef "age"; Direction = SortDir.Desc; NullOrder = NullOrder.NullsLast }
+    let plan = OptimizedPlan.Limit(OptimizedPlan.Sort(simpleScan "users", [ key ]), Some 10L, None)
+    let instrs = compile plan
+    Assert.True(anyInstr instrs (fun i -> match i with Instruction.SortResult _ -> true | _ -> false))
+    Assert.True(anyInstr instrs (fun i -> i = Instruction.LimitResult(Some 10L, None)))


### PR DESCRIPTION
## Summary

- Implements `code/packages/fsharp/sql-codegen/` — the fourth stage of the F# mini-sqlite Level 1 pipeline (sql-lexer → sql-parser → sql-planner → sql-optimizer → **sql-codegen** → sql-vm)
- `SqlCodegen.compile : OptimizedPlan -> Program` transforms an optimizer output into a flat list of stack-machine `Instruction` values ready for the VM
- `Instruction` DU has 36 cases: stack ops (`LoadConst`, `LoadColumn`, `LoadParam`…), arithmetic (`BinaryOpInstr`, `UnaryOpInstr`), cursor control (`OpenScan`, `AdvanceCursor`, `JumpIfExhausted`, `CloseScan`), row construction (`BeginRow`, `EmitColumn`, `EmitRow`), aggregation (`InitAgg`, `UpdateAgg`, `FinalizeAgg`, `SaveGroupKey`), control flow (`Label`, `Jump`, `JumpIfFalse`, `Halt`), DDL, DML, transactions, and post-ops (`SortResult`, `DistinctResult`, `LimitResult`)
- Two-phase aggregate compilation: `InitAgg` before the scan loop, `UpdateAgg` inside, `FinalizeAgg` after — mirrors SQLite VDBE and JVM aggregate semantics
- Label uniqueness via a per-`compile`-call counter so nested JOINs don't produce colliding `loop_N/end_N` labels
- `compileExpression : Expr -> Instruction list` exported as a public helper for testing and reuse

## Test plan

- [ ] 94 unit tests pass (`dotnet test`)
- [ ] 83.82% line coverage / 100% method coverage (threshold: 80% line)
- [ ] Security review passed (pure in-memory IR transform — no I/O, reflection, cryptography, or network access)
- [ ] Package builds clean with zero warnings (`TreatWarningsAsErrors=true`)
- [ ] BUILD / BUILD_windows scripts verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)