### PR TITLE
feat(latex): \overrightarrow / \overleftarrow stretchy over-arrow accents — LTX01 L2

### DIFF
--- a/code/packages/rust/latex/CHANGELOG.md
+++ b/code/packages/rust/latex/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to the full-fidelity LaTeX parser crate.
 
+## [0.18.0] — 2026-06-30
+
+### Added — stretchy over-arrow accents (`\overrightarrow` & friends)
+
+- The parser now accepts the stretchy over-arrow accents `\overrightarrow`, `\overleftarrow`,
+  `\overleftrightarrow`, `\overrightharpoonup`, `\overleftharpoonup` — an arrow drawn **over** a
+  (possibly multi-token) body, e.g. `\overrightarrow{AB}`. Distinct from `\vec` (a fixed
+  single-glyph accent over one symbol). As with `\overbrace` and the xarrows, there is **no new AST
+  node**: an over-arrow is an annotation stacked on the body, so it lowers onto the existing
+  `Overset` node over the plain arrow symbol — `\overrightarrow{AB}` → `Overset { over: →, base: AB }`,
+  identical to `\overset{\rightarrow}{AB}`.
+- Reuses the existing `Overset` `to_latex` and neutral-frontend lowering, so **no frontend change**;
+  round-trips through `to_latex` (surface normalises to `\overset`). 5 new tests (parse, per-arrow
+  base, in-context, round-trip, missing-body error); the `{body}` is mandatory and its absence is a
+  clean spanned error, never a panic.
+- `latex` 0.17.0 → 0.18.0.
+
 ## [0.17.0] — 2026-06-30
 
 ### Added — horizontal braces (`\overbrace` / `\underbrace`)

--- a/code/packages/rust/latex/Cargo.toml
+++ b/code/packages/rust/latex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latex"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 description = "A full-fidelity LaTeX parser (documents and math): a catcode-driven, text-mode-primary tokenizer and (in later layers) a structural + math parser producing a faithful AST. Standalone and reusable; will also implement the math-frontend MathFrontend trait."
 license = "MIT"

--- a/code/packages/rust/latex/README.md
+++ b/code/packages/rust/latex/README.md
@@ -32,7 +32,7 @@ with a **text-mode-primary** mode stack (LaTeX starts in text mode; math is ente
 |-------|----------|--------|
 | **L0 tokenizer** | catcode state machine → flat `Token` stream w/ byte spans | ✅ |
 | **L1 structural** | groups, `\cmd[opt]{arg}`, `\begin{env}…\end{env}`, text runs, raw math islands, `to_latex()` round-trip | ✅ |
-| **L2 math** | math AST (frac, binom, roots, scripts, big ops, functions, accents, `\left\right` fences, relations, `\overset`/`\underset`/`\stackrel` stacking, `\xrightarrow`-family extensible labelled arrows, and `\overbrace`/`\underbrace` horizontal braces), precedence-climbing parser, `to_latex()` round-trip | ✅ |
+| **L2 math** | math AST (frac, binom, roots, scripts, big ops, functions, accents, `\left\right` fences, relations, `\overset`/`\underset`/`\stackrel` stacking, `\xrightarrow`-family extensible labelled arrows, `\overbrace`/`\underbrace` horizontal braces, and `\overrightarrow`-family stretchy over-arrow accents), precedence-climbing parser, `to_latex()` round-trip | ✅ |
 | **L3 environments** | math env family — `matrix`/`pmatrix`/`bmatrix`/`vmatrix`/`cases`/`aligned`/`align` plus `array`/`subarray` (mandatory `{col-spec}`) split on `&` and `\\` → `MathNode::Matrix`, round-trip; nesting + scripts | ✅ |
 | **L4 macros** | `\newcommand`/`\renewcommand`/`\providecommand` with positional `#1`..`#9`; bounded recursive expansion via `expand()` (L4a) | ✅ |
 | **L5 text breadth** | `\verb`/`verbatim` raw (L5a/b) + text accents `\'e`/`\c{c}` via `recognize_accents` (L5c) + sectioning/refs/preamble/font via `recognize_structure` (L5d) | ✅ |

--- a/code/packages/rust/latex/src/math.rs
+++ b/code/packages/rust/latex/src/math.rs
@@ -325,6 +325,23 @@ fn xarrow_base(name: &str) -> Option<&'static str> {
 const OVERBRACE: &str = "\u{23DE}";
 const UNDERBRACE: &str = "\u{23DF}";
 
+/// The stretchy over-arrow accents `\overrightarrow` / `\overleftarrow` / `\overleftrightarrow`
+/// (and harpoon variants) draw an arrow OVER their argument — exactly an annotation stacked on the
+/// body, so they lower onto the existing `Overset` node over the plain arrow symbol, like the
+/// xarrows and `\overbrace`. Distinct from `\vec` (a fixed single-glyph accent): these stretch over
+/// a multi-token body, e.g. `\overrightarrow{AB}`. Returns the base arrow's control-word name (so
+/// `overrightarrow` → `rightarrow`, round-tripping through `to_latex` as `\rightarrow`).
+fn over_arrow_base(name: &str) -> Option<&'static str> {
+    Some(match name {
+        "overrightarrow" => "rightarrow",
+        "overleftarrow" => "leftarrow",
+        "overleftrightarrow" => "leftrightarrow",
+        "overrightharpoonup" => "rightharpoonup",
+        "overleftharpoonup" => "leftharpoonup",
+        _ => return None,
+    })
+}
+
 /// Math environments with `&`/`\\` row/column structure (L3). Case-sensitive — `bmatrix`
 /// (square brackets) and `Bmatrix` (braces) are different environments. The `array`/`subarray`
 /// grids take a **mandatory** column-spec argument (`\begin{array}{cc}`) — see
@@ -730,6 +747,19 @@ impl<'a> MathParser<'a> {
                 return Ok(MathNode::Underset { under: Box::new(label), base: Box::new(braced) });
             }
             return Ok(braced);
+        }
+        // `\overrightarrow{body}` / `\overleftarrow{body}` / … — a stretchy arrow drawn OVER the
+        // body. One mandatory `{body}` group; we lower to `Overset { over: <arrow>, base: body }`,
+        // reusing the same machinery as `\overbrace` (see `over_arrow_base`), so the neutral frontend
+        // lowering needs no change: `\overrightarrow{AB}` lowers identically to
+        // `\overset{\rightarrow}{AB}`.
+        if let Some(arrow) = over_arrow_base(name) {
+            self.bump();
+            let body = self.read_arg()?;
+            return Ok(MathNode::Overset {
+                over: Box::new(MathNode::Sym(arrow.to_string())),
+                base: Box::new(body),
+            });
         }
         // `\xrightarrow[below]{above}` and friends — an extensible/labelled arrow. The optional
         // `[below]` group sits under the arrow, the mandatory `{above}` group over it. We lower to
@@ -1861,6 +1891,62 @@ mod tests {
         // no argument is a clean error, never a panic.
         assert!(parse_math(r"\overbrace").is_err());
         assert!(parse_math(r"\underbrace").is_err());
+    }
+
+    // ---- stretchy over-arrow accents (\overrightarrow & friends) ----------------
+
+    #[test]
+    fn overrightarrow_is_the_arrow_set_over_the_body() {
+        // `\overrightarrow{AB}` ≡ a `\rightarrow` set OVER the body `AB`.
+        let n = parse_math(r"\overrightarrow{AB}").unwrap();
+        match &n {
+            MathNode::Overset { over, base } => {
+                assert_eq!(**over, sym("rightarrow"));
+                // `AB` is implicit multiplication A·B
+                assert!(matches!(**base, MathNode::Bin(MBinOp::Mul, ..)));
+            }
+            other => panic!("expected Overset, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn over_arrows_use_their_own_base_arrow() {
+        // Each command maps to its own base arrow symbol.
+        for (src, arrow) in [
+            (r"\overleftarrow{v}", "leftarrow"),
+            (r"\overleftrightarrow{w}", "leftrightarrow"),
+            (r"\overrightharpoonup{p}", "rightharpoonup"),
+        ] {
+            match &parse_math(src).unwrap() {
+                MathNode::Overset { over, .. } => assert_eq!(**over, sym(arrow), "{src}"),
+                other => panic!("expected Overset for {src}, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn over_arrow_in_context_chains_with_neighbours() {
+        // An over-arrow group is an atom, so it sits inline: `\overrightarrow{F} = m a`.
+        let n = parse_math(r"\overrightarrow{F} = m a").unwrap();
+        assert!(matches!(n, MathNode::Rel(..)));
+        assert!(n.to_latex().contains(r"\overset"));
+        assert!(n.to_latex().contains(r"\rightarrow"));
+    }
+
+    #[test]
+    fn over_arrow_round_trips_through_to_latex() {
+        // parse → to_latex → parse is a fixed point (surface normalises to \overset).
+        for src in [r"\overrightarrow{AB}", r"\overleftarrow{x}", r"\overleftrightarrow{PQ}"] {
+            let once = parse_math(src).unwrap();
+            let twice = parse_math(&once.to_latex()).unwrap();
+            assert_eq!(once, twice, "round-trip changed the tree for {src:?}");
+        }
+    }
+
+    #[test]
+    fn over_arrow_missing_mandatory_body_is_a_spanned_error() {
+        // The `{body}` is mandatory; a trailing command with no argument is a clean error.
+        assert!(parse_math(r"\overrightarrow").is_err());
     }
 
     // ---- deep-tree Drop safety -------------------------------------------------

--- a/code/specs/LTX01-full-latex-parser.md
+++ b/code/specs/LTX01-full-latex-parser.md
@@ -235,6 +235,14 @@ is text-primary, which is a different mode model.)
   postfix raised script). The L6 lowering and `to_latex` therefore need **zero change**; round-trips
   through `to_latex`, and a missing mandatory body is a spanned error, never a panic.
 
+  **Stretchy over-arrow accents (latex 0.18.0):** `\overrightarrow{body}` / `\overleftarrow{body}` /
+  `\overleftrightarrow{body}` / `\overrightharpoonup` / `\overleftharpoonup` — an arrow drawn over a
+  (possibly multi-token) body, e.g. `\overrightarrow{AB}`; distinct from `\vec` (a fixed single-glyph
+  accent). Same desugaring as the over-brace — **no new node**: it lowers onto the existing `Overset`
+  node over the plain arrow symbol, so `\overrightarrow{AB}` ≡ `\overset{\rightarrow}{AB}` and the L6
+  lowering needs zero change. Round-trips through `to_latex`; a missing mandatory body is a spanned
+  error, never a panic.
+
 **Asymptote (documented in README, not built):** runtime `\catcode`, `\expandafter`/
 `\noexpand`/`\csname`, arbitrary `\if…` programming, external `\input`/`\include`. Hit →
 `Unsupported { construct, span }`.


### PR DESCRIPTION
## What

Adds the stretchy **over-arrow accents** to the `latex` crate's math parser (LTX01 L2): `\overrightarrow`, `\overleftarrow`, `\overleftrightarrow`, `\overrightharpoonup`, `\overleftharpoonup` — an arrow drawn **over** a (possibly multi-token) body, e.g. `\overrightarrow{AB}`. Distinct from `\vec` (a fixed single-glyph accent over one symbol).

As with `\overbrace` and the xarrows, there is **no new AST node** — an over-arrow is an annotation stacked on the body, so it lowers onto the existing `Overset` node over the plain arrow symbol (`over_arrow_base` maps each command to its base arrow control-word):

| LaTeX | AST |
|-------|-----|
| `\overrightarrow{AB}` | `Overset { over: \rightarrow, base: AB }` — identical to `\overset{\rightarrow}{AB}` |
| `\overleftarrow{v}` | `Overset { over: \leftarrow, base: v }` |
| `\overleftrightarrow{PQ}` | `Overset { over: \leftrightarrow, base: PQ }` |

## Why it's clean
- **No new node, no frontend change.** Reuses the existing `Overset` `to_latex` and neutral-frontend lowering, so over-arrows reach the neutral `MathExpr::Overset` for free.
- **Round-trips** through `to_latex` (surface normalises to `\overset`, an AST fixed point).
- The `{body}` is **mandatory**; its absence is a clean spanned `ParseError`, never a panic.

## Tests / gates
- **170 tests + doctest** (5 new): arrow-over-body, per-arrow base symbol, in-context chaining, round-trip, missing-body error.
- `cargo test -p latex` green; `cargo clippy -p latex -- -D warnings` clean.
- **Security review passed** (Rust: recursion/DoS via the `MAX_DEPTH`-guarded `read_arg`, panics, forward progress, overflow) — no findings; structurally identical to the merged `\overbrace` handling.

Spec `LTX01-full-latex-parser.md` + crate README/CHANGELOG updated; `latex` 0.17.0 → 0.18.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)