### PR TITLE
feat(sir-js): default-parameter emission (P2d)

### DIFF
--- a/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
@@ -5,6 +5,39 @@ All notable changes to `semantic-ir-to-javascript` are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.0 — P2d (default-parameter emission)
+
+Adds **default parameters** to the JavaScript backend.  JavaScript's
+native default-parameter feature has *exactly* SIR's semantics — the
+default expression is evaluated **at call time**, only when the argument
+is omitted, in **param scope** (so a later default may reference an
+earlier parameter by name).  The lowering is therefore a direct native
+inline: no runtime helper, no call-site padding.
+
+### Added
+
+- `accepts_features()` now declares `DefaultParams`.
+- Emit: a `Param { default: Some(expr) }` lowers to a native JS default
+  parameter `name = <emitted default>`.  The default expression is
+  emitted with the ordinary `emit_expr`, so a default that references an
+  earlier parameter (`VarRef { scope: Param }`) becomes a bare name —
+  valid JavaScript, since earlier params are in scope left-to-right.
+  `Rest`/`KwRest` params are unchanged; `IndirectCall` and closure
+  defaults are unchanged / deferred.
+- `DirectCall` documented and confirmed to emit **only the args present**
+  — the SIR validator allows omitting trailing defaulted args (arity ≥
+  `required_param_count`), and native JS defaults fill the omitted
+  trailing params at call time.  No padding is inserted.
+- Unit tests: `f(a, b = a + 1)` emits `function f(a, b = (a + 1)) {`; a
+  short `DirectCall` (`f(5)`) is not padded.
+- Integration test (`tests/run_with_node.rs`,
+  `default_param_is_call_time_and_param_scoped`): hand-builds a module
+  with `f(a, b = a + 1)` returning `b` and a `main` that calls
+  `print(f(5))` then `print(f(5, 10))`, emits JavaScript, **runs it under
+  `node`**, and asserts stdout `6` then `10` — proving the default is
+  evaluated at call time (depends on the actual `a = 5`) and in param
+  scope (references the earlier param `a`).
+
 ## 0.2.0 — D4 (completes SIR16 / v1 parity for the JS backend)
 
 Brings the JavaScript backend to **full SIR16 / v1 parity**: the six

--- a/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-javascript"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Semantic IR → self-contained JavaScript source code (SIR18). Fifth backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-javascript/README.md
+++ b/code/packages/rust/semantic-ir-to-javascript/README.md
@@ -81,6 +81,7 @@ lowering is direct.
 | `Maps` (SIR16)             |                                              |
 | `MutableBindings` (SIR16)  |                                              |
 | `Loops` (SIR16)            |                                              |
+| `DefaultParams` (P2d)      |                                              |
 
 `accepts_intrinsics()` is empty. The accept-set is deliberately matched
 to what `emit` handles, so a module using a deferred node is turned away
@@ -102,6 +103,26 @@ rejected SIR17/18 nodes).
 | `While`                          | `while (__Sir.truthy(cond)) { … }`              |
 | `ForRange`                       | direction-aware C-style `for` (bounds once)     |
 | `ForEach`                        | `for (let x of iter) { … }`                     |
+
+### Default parameters (P2d)
+
+A `Param` carrying `default: Some(expr)` lowers to a **native JS default
+parameter** — `function f(a, b = <expr>) { … }` — because JavaScript's
+default-parameter semantics are exactly SIR's:
+
+- **Call-time**: the default runs each call, only when the argument is
+  omitted (not a compile-time constant baked in once).
+- **Param scope**: a later default may reference an earlier parameter by
+  name. SIR emits such a reference as `VarRef { scope: Param }` → a bare
+  identifier, which is in scope left-to-right in a JS parameter list.
+
+There is no call-site padding: the SIR validator allows a caller to omit
+trailing defaulted args (arity ≥ `required_param_count`), so a
+`DirectCall` emits **only the args present** and the native defaults fill
+the omitted trailing params. For example, `f(a, b = a + 1)` emits
+`function f(a, b = (a + 1)) { … }`; `f(5)` calls it with one arg and
+`b` binds to `6` at call time. (`IndirectCall` / closure defaults are
+unchanged / deferred.)
 
 ## Runtime shape (inlined `__Sir`)
 

--- a/code/packages/rust/semantic-ir-to-javascript/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/emit.rs
@@ -169,6 +169,20 @@ fn emit_function(out: &mut String, f: &Function) {
             // yet, so in practice only `Required` is reached here.
             ParamKind::Required | ParamKind::KwRest => {
                 out.push_str(&sanitize_ident(&p.name));
+                // P2d: a defaulted param (`Param { default: Some(e) }`)
+                // becomes a native JS default parameter `name = <e>`.
+                //
+                // JavaScript's default-parameter semantics are *exactly*
+                // SIR's: the default expression is evaluated **at call
+                // time**, only when the argument is omitted, in **param
+                // scope** — so a later param's default may reference an
+                // earlier param by its bare name (valid JS, since earlier
+                // params are already in scope left-to-right).  No runtime
+                // helper is needed; the strategy is a direct native inline.
+                if let Some(default) = &p.default {
+                    out.push_str(" = ");
+                    emit_expr(out, default, 2);
+                }
             }
         }
     }
@@ -384,6 +398,12 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
             out.push_str("))");
         }
         Expr::Block(b) => emit_block_as_expr(out, b, indent),
+        // A statically-known call.  P2d: the validator allows a caller to
+        // omit trailing defaulted args (arity ≥ `required_param_count`), so
+        // we emit ONLY the args that are present and do NOT pad — native JS
+        // default parameters (emitted on the callee in `emit_function`)
+        // fill the omitted trailing params at call time.  IndirectCall and
+        // closure defaults are unchanged / deferred.
         Expr::DirectCall { fn_name, args, .. } => {
             let _ = write!(out, "{}(", sanitize_ident(fn_name));
             emit_args(out, args, indent);
@@ -1445,6 +1465,54 @@ mod tests {
         let mut out = String::new();
         emit_function(&mut out, &f);
         assert!(out.contains("function f(...rest) {"), "got {out}");
+    }
+
+    #[test]
+    fn emit_defaulted_param_is_native_js_default() {
+        // P2d: `f(a, b = a + 1)` emits `function f(a, b = (a + 1)) {`.
+        // The default is a native JS default param referencing the earlier
+        // param `a` by name (legal — earlier params are in scope).
+        let default = bc(
+            "+",
+            vec![
+                Expr::VarRef { name: "a".into(), scope: Scope::Param, span: s() },
+                int(1),
+            ],
+        );
+        let f = fun(
+            "f",
+            vec![
+                Param { name: "a".into(), sir_type: None, kind: ParamKind::Required, default: None, span: s() },
+                Param {
+                    name: "b".into(),
+                    sir_type: None,
+                    kind: ParamKind::Required,
+                    default: Some(Box::new(default)),
+                    span: s(),
+                },
+            ],
+            Block {
+                stmts: vec![],
+                value: Expr::VarRef { name: "b".into(), scope: Scope::Param, span: s() },
+                span: s(),
+            },
+        );
+        let mut out = String::new();
+        emit_function(&mut out, &f);
+        assert!(out.contains("function f(a, b = (a + 1)) {"), "got {out}");
+    }
+
+    #[test]
+    fn emit_direct_call_omitting_defaulted_arg_does_not_pad() {
+        // P2d: a DirectCall that supplies fewer args than params emits ONLY
+        // the present args — native JS defaults fill the rest, no padding.
+        let dc = Expr::DirectCall {
+            fn_name: "f".into(),
+            args: vec![int(5)],
+            effects: EffectSet::PURE,
+            span: s(),
+        };
+        assert_eq!(emit_e(&dc), "f(5)");
     }
 
     #[test]

--- a/code/packages/rust/semantic-ir-to-javascript/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/lib.rs
@@ -107,6 +107,12 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     Feature::Maps,
     Feature::MutableBindings,
     Feature::Loops,
+    // P2d: default parameters — JavaScript native default params have
+    // exactly SIR's call-time, param-scope semantics, so `emit` lowers a
+    // `Param { default: Some(_) }` to a native `name = <default>` and a
+    // short DirectCall to the bare args (defaults fill omitted trailing
+    // params).  See `emit_function` / `emit_expr`'s `DirectCall` arm.
+    Feature::DefaultParams,
 ];
 
 impl Backend for JavaScriptBackend {

--- a/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
@@ -417,6 +417,130 @@ fn for_each_over_sequence() {
     }
 }
 
+// ── P2d: default parameters (hand-built module) ────────────────────────
+
+#[test]
+fn default_param_is_call_time_and_param_scoped() {
+    // The discriminating test for P2d.  Build a module with:
+    //
+    //   function f(a, b = a + 1) { return a + b; }
+    //   function main() { print(f(5)); print(f(5, 10)); }
+    //
+    // and run it under node.  `f(5)` omits `b`, so the native JS default
+    // fires: `b = a + 1 = 6`, and `f` returns `a + b = 5 + 6 = 11`?  No —
+    // the test prints `b` itself, not `a + b`: the body returns `b` so the
+    // call's *value* is the bound `b`.  We use that to read the default
+    // directly:
+    //
+    //   f(5)      → b defaults to a + 1 = 6   → prints 6
+    //   f(5, 10)  → b is supplied as 10       → prints 10
+    //
+    // Printing 6 then 10 proves the default is (a) evaluated at call time
+    // — it depends on the actual argument `a = 5`, not on a compile-time
+    // constant — AND (b) evaluated in param scope, since it references the
+    // earlier param `a` by name.
+    use semantic_ir::Param;
+
+    fn param(name: &str) -> Param {
+        Param {
+            name: name.into(),
+            sir_type: None,
+            kind: semantic_ir::ParamKind::Required,
+            default: None,
+            span: sp(),
+        }
+    }
+
+    fn param_ref(name: &str) -> Expr {
+        Expr::VarRef { name: name.into(), scope: Scope::Param, span: sp() }
+    }
+
+    // b's default = (a + 1), referencing the earlier param `a`.
+    let b_default = bc("+", vec![param_ref("a"), int(1)]);
+
+    let f = Function {
+        name: "f".into(),
+        params: vec![
+            param("a"),
+            Param {
+                name: "b".into(),
+                sir_type: None,
+                kind: semantic_ir::ParamKind::Required,
+                default: Some(Box::new(b_default)),
+                span: sp(),
+            },
+        ],
+        return_type: None,
+        captures: vec![],
+        // Body returns `b` so the printed value IS the (possibly defaulted)
+        // second parameter.
+        body: Block { stmts: vec![], value: param_ref("b"), span: sp() },
+        effects: EffectSet::PURE,
+        metadata: Metadata::new(),
+        span: sp(),
+    };
+
+    let call_one_arg = Expr::DirectCall {
+        fn_name: "f".into(),
+        args: vec![int(5)],
+        effects: EffectSet::PURE,
+        span: sp(),
+    };
+    let call_two_args = Expr::DirectCall {
+        fn_name: "f".into(),
+        args: vec![int(5), int(10)],
+        effects: EffectSet::PURE,
+        span: sp(),
+    };
+
+    let main = Function {
+        name: "main".into(),
+        params: vec![],
+        return_type: None,
+        captures: vec![],
+        body: Block {
+            stmts: vec![print(call_one_arg), print(call_two_args)],
+            value: Expr::NilLit { span: sp() },
+            span: sp(),
+        },
+        effects: EffectSet::PURE,
+        metadata: Metadata::new(),
+        span: sp(),
+    };
+
+    let module = Module {
+        name: "defaultparams".into(),
+        manifest: FeatureManifest::from_features(&[
+            Feature::DefaultParams,
+            Feature::DynamicTyping,
+        ]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![f, main],
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("handbuilt")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: sp(),
+    };
+
+    // Shape check first (runs even without node): the emitted callee carries
+    // a native JS default referencing the earlier param, and the one-arg
+    // call is NOT padded.
+    let artifact = compile(&module).expect("compile to javascript");
+    assert!(
+        artifact.source.contains("function f(a, b = (a + 1)) {"),
+        "expected native JS default param, got:\n{}",
+        artifact.source
+    );
+    assert!(artifact.source.contains("__Sir.print(f(5))"), "got:\n{}", artifact.source);
+    assert!(artifact.source.contains("__Sir.print(f(5, 10))"), "got:\n{}", artifact.source);
+
+    if let Some(stdout) = run_module(&module, "defaultparams") {
+        assert_eq!(stdout, "6\n10", "f(5) must default b to a+1=6; f(5,10) must use 10");
+    }
+}
+
 #[test]
 fn mutable_reassignment_updates_binding() {
     // let x = 1; x = 2; x = x + 40; print(x);  → 42


### PR DESCRIPTION
Backend default-param emission for `semantic-ir-to-javascript` (after the core P1 + semantics P2a). **Direct native lowering** — JS's native default params match the IR's call-time, param-scope semantics exactly.

- Accepts `Feature::DefaultParams`.
- A `Param{default: Some(expr)}` emits native `name = <default expr>` (via the normal `emit_expr`, so a default referencing an earlier param becomes a bare name — valid JS). Non-default params unchanged.
- `DirectCall` emits only the args present (the validator now allows omitting trailing defaulted args); native JS defaults fill the rest — no padding.

**Tests:** 62 unit + 14 node e2e. The discriminating test `default_param_is_call_time_and_param_scoped` hand-builds `f(a, b=a+1)`, runs the emitted JS under node, and asserts `print(f(5))`→`6`, `print(f(5,10))`→`10` — proving call-time evaluation and param-scope reference. clippy clean; security review passed (default expr + names route through the vetted emit/sanitize paths). Isolated to `semantic-ir-to-javascript`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)