### PR TITLE
feat(sir-py): default-parameter emission via sentinel+prologue (P2c)

### DIFF
--- a/code/packages/rust/semantic-ir-to-python/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-python/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog
 
+## 0.2.0 — default-parameter emission via sentinel + body prologue (P2c)
+
+The backend now accepts `Feature::DefaultParams` and lowers default parameters.
+
+SIR defaults are **call-time** and may reference **earlier params** (e.g. a
+default of `a + 1`), which Python's native def-time defaults cannot express —
+`def f(a, b=a)` raises `NameError`, and even a constant default would evaluate
+once at definition time, not per call. So native default syntax is wrong for
+this model. Instead:
+
+- **Sentinel.** The core runtime header now defines a module-level
+  `_SIR_MISSING = object()` — a unique value distinct from every real argument
+  (including `None`).
+- **Signature.** A defaulted param emits `name=_SIR_MISSING` (its native Python
+  default is the sentinel), so callers may omit the trailing argument.
+- **Resolve-prologue.** The function body opens with, in **param order**, one
+  guard per defaulted param:
+
+  ```python
+  if name is _SIR_MISSING:
+      name = <default expr>
+  ```
+
+  The default expression is emitted through the ordinary expr path and runs in
+  the body, where earlier params are already bound — giving call-time,
+  param-scoped semantics correctly. Param order guarantees an earlier defaulted
+  param is resolved before a later default that references it.
+- **Calls.** `DirectCall` is unchanged: it emits only the arguments present (no
+  padding). An omitted trailing defaulted argument leaves the param bound to the
+  sentinel, which the prologue then resolves. `IndirectCall`/closure defaults
+  are deferred.
+
+Execution-proof (via the PYTHONPATH-aware `run_emitted_python` harness):
+`def f(a, b)` with `b`'s default `a + 1`, returning `b`; `print(f(5))` prints
+`6` (default resolved against the earlier param) and `print(f(5, 10))` prints
+`10` (supplied argument suppresses the default).
+
 ## 0.1.23 — case-equality `case_eq` emission (M5)
 
 A `case_eq` builtin (emitted by a `when` clause for range/regex/literal

--- a/code/packages/rust/semantic-ir-to-python/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-python"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Semantic IR → self-contained Python 3 source code (SIR14). Third backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-python/README.md
+++ b/code/packages/rust/semantic-ir-to-python/README.md
@@ -36,10 +36,34 @@ This evaluates the bindings left-to-right and returns the tuple's
 last element (the block's value).  Tested deterministically — no
 codegen variance across runs.
 
+## Default parameters
+
+SIR default parameters are **call-time** and a default may reference an
+**earlier param** (e.g. `def f(a, b = a + 1)`).  Python's *native* default
+args are def-time and cannot reference other params (`def f(a, b=a)` raises
+`NameError`), so native syntax is wrong for this model.  The emitter instead
+uses a **sentinel + body-prologue** strategy:
+
+- The runtime header defines `_SIR_MISSING = object()`.
+- A defaulted param emits `name=_SIR_MISSING`, so callers may omit it.
+- The function body opens with a resolve-prologue, in param order:
+
+  ```python
+  if name is _SIR_MISSING:
+      name = <default expr>
+  ```
+
+  The default runs in the body, where earlier params are in scope — giving
+  correct call-time, param-referencing semantics.  Calls emit only the
+  arguments present (no padding); an omitted trailing default binds the
+  sentinel, which the prologue resolves.  `IndirectCall`/closure defaults are
+  deferred.
+
 ## Capability declaration
 
 Accepts: `Closures`, `Pairs`, `Symbols`, `Strings`, `DynamicTyping`,
-`OptionalTypeAnnotations`, `MutualRecursion`, `Globals`.
+`OptionalTypeAnnotations`, `MutualRecursion`, `Globals`, `DefaultParams`
+(and the SIR16/17 expression, mutation, loop, OOP and exception features).
 
 Rejects: `TailCalls` (CPython has no TCO), `Intrinsics` (empty
 whitelist).

--- a/code/packages/rust/semantic-ir-to-python/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-python/src/emit.rs
@@ -321,6 +321,16 @@ fn emit_function(out: &mut String, f: &Function) {
             ParamKind::Required => {}
         }
         out.push_str(&sanitize_ident(&p.name));
+        // P2c default parameters.  A defaulted param gets the *sentinel* as its
+        // native Python default — `name=_SIR_MISSING` — so callers may omit the
+        // trailing argument.  We deliberately do NOT emit `name=<expr>`: SIR
+        // defaults are call-time and may reference earlier params, which
+        // Python's def-time defaults cannot express (`def f(a, b=a)` is a
+        // NameError).  The real default is resolved in the body prologue below.
+        // (Only `Required` params carry a default; `*rest`/`**opts` never do.)
+        if p.kind == ParamKind::Required && p.default.is_some() {
+            out.push_str("=_SIR_MISSING");
+        }
     }
     out.push_str("):\n");
 
@@ -336,6 +346,32 @@ fn emit_function(out: &mut String, f: &Function) {
             let name = sanitize_ident(&p.name);
             let _ = writeln!(out, "{pad}{name} = list({name})");
         }
+    }
+
+    // P2c default-parameter resolve-prologue.  Emitted in *param order* so an
+    // earlier defaulted param is already resolved before a later default that
+    // references it.  Each defaulted param is `_SIR_MISSING` exactly when the
+    // caller omitted it; we then rebind it to its default expression, which is
+    // emitted through the ordinary expr path and runs *here in the body*, where
+    // earlier params are in scope — giving call-time, param-scoped semantics:
+    //
+    //     if <name> is _SIR_MISSING:
+    //         <name> = <default expr>
+    //
+    // A default expr may itself hoist nested defs (see `flush_hoist`), so each
+    // prologue entry is rendered into a scratch buffer, its hoists flushed
+    // before it, then appended — matching every other statement-emitting path.
+    let inner_pad = indent_str(2);
+    for p in &f.params {
+        let Some(default) = &p.default else { continue };
+        let name = sanitize_ident(&p.name);
+        let mut tmp = String::new();
+        let _ = writeln!(tmp, "{pad}if {name} is _SIR_MISSING:");
+        let _ = write!(tmp, "{inner_pad}{name} = ");
+        emit_expr(&mut tmp, default, 1);
+        tmp.push('\n');
+        flush_hoist(out);
+        out.push_str(&tmp);
     }
 
     emit_function_body(out, &f.body, 1);
@@ -1561,6 +1597,69 @@ mod tests {
         let mut out = String::new();
         emit_function(&mut out, &f);
         assert!(out.contains("def f(a, *rest, **opts):"), "got: {out}");
+    }
+
+    #[test]
+    fn emit_default_param_uses_sentinel_and_prologue() {
+        // P2c: `def f(a, b = a + 1); a + b; end`.  `b` is defaulted, so the
+        // signature must bind it to the sentinel (`b=_SIR_MISSING`) and the body
+        // must open with the resolve-prologue that rewrites a still-sentinel `b`
+        // to `a + 1` — emitted in the body, where the earlier param `a` is in
+        // scope (call-time, param-referencing default semantics).
+        let default_b = Expr::BuiltinCall {
+            name: "+".into(),
+            args: vec![
+                Expr::VarRef { name: "a".into(), scope: Scope::Param, span: s() },
+                Expr::IntLit { value: 1, span: s() },
+            ],
+            effects: EffectSet::PURE,
+            span: s(),
+        };
+        let body = Block {
+            stmts: vec![],
+            value: Expr::BuiltinCall {
+                name: "+".into(),
+                args: vec![
+                    Expr::VarRef { name: "a".into(), scope: Scope::Param, span: s() },
+                    Expr::VarRef { name: "b".into(), scope: Scope::Param, span: s() },
+                ],
+                effects: EffectSet::PURE,
+                span: s(),
+            },
+            span: s(),
+        };
+        let f = Function {
+            name: "f".into(),
+            params: vec![
+                Param { name: "a".into(), sir_type: None, kind: ParamKind::Required, default: None, span: s() },
+                Param {
+                    name: "b".into(),
+                    sir_type: None,
+                    kind: ParamKind::Required,
+                    default: Some(Box::new(default_b)),
+                    span: s(),
+                },
+            ],
+            return_type: None,
+            captures: vec![],
+            body,
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        };
+        let mut out = String::new();
+        emit_function(&mut out, &f);
+        // Signature: `a` plain, `b` defaulted to the sentinel.
+        assert!(out.contains("def f(a, b=_SIR_MISSING):"), "got:\n{out}");
+        // Prologue: sentinel check + rebind to the param-referencing default.
+        assert!(out.contains("    if b is _SIR_MISSING:"), "got:\n{out}");
+        assert!(out.contains("        b = _sir_plus(a, 1)"), "got:\n{out}");
+        // The prologue precedes the body's `return`.
+        let prologue_at = out.find("if b is _SIR_MISSING:").unwrap();
+        let return_at = out.find("return ").unwrap();
+        assert!(prologue_at < return_at, "prologue must precede return; got:\n{out}");
+        // A param with no default must NOT gain a sentinel default.
+        assert!(!out.contains("a=_SIR_MISSING"), "got:\n{out}");
     }
 
     #[test]

--- a/code/packages/rust/semantic-ir-to-python/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-python/src/lib.rs
@@ -49,6 +49,13 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     Feature::OptionalTypeAnnotations,
     Feature::MutualRecursion,
     Feature::Globals,
+    // P2c default parameters — emitted via the sentinel + body-prologue
+    // strategy (NOT Python's native def-time defaults, which cannot reference
+    // earlier params).  A defaulted param emits `name=_SIR_MISSING`; the
+    // function body opens with a resolve-prologue that, in param order,
+    // rewrites each still-sentinel param to its (call-time, param-scoped)
+    // default expression.  See `emit_function`.
+    Feature::DefaultParams,
     // SIR16 expression features — emitted natively (sequences → list,
     // maps → dict, short-circuit → truthy-guarded lambda, interpolation →
     // display-joined), per code/specs/sir-runtime.md.
@@ -282,6 +289,116 @@ mod tests {
         assert!(a.source.contains("a = list(a)"), "rest param must normalize to list; got:\n{}", a.source);
         if let Some(stdout) = run_emitted_python(&a.source) {
             assert_eq!(stdout, "3\n", "emitted python printed unexpected output");
+        }
+    }
+
+    #[test]
+    fn end_to_end_default_param_resolves_at_call_time_executes_py() {
+        // P2c discriminating execution-proof.  `def f(a, b)` where `b`'s default
+        // is `a + 1` — a *param-referencing* default that Python's native
+        // def-time defaults cannot express.  Two calls:
+        //   • `f(5)`     omits `b` → prologue resolves `b = a + 1 = 6`
+        //   • `f(5, 10)` passes `b` → prologue is skipped, `b = 10`
+        // so stdout must be `6` then `10`.  This proves the sentinel binds on
+        // omission, the prologue runs in body scope (sees `a`), and a supplied
+        // argument suppresses the default.
+        use semantic_ir::{Param, ParamKind, Scope, Stmt};
+
+        let default_b = Expr::BuiltinCall {
+            name: "+".into(),
+            args: vec![
+                Expr::VarRef { name: "a".into(), scope: Scope::Param, span: s() },
+                Expr::IntLit { value: 1, span: s() },
+            ],
+            effects: EffectSet::PURE,
+            span: s(),
+        };
+        let f = Function {
+            name: "f".into(),
+            params: vec![
+                Param { name: "a".into(), sir_type: None, kind: ParamKind::Required, default: None, span: s() },
+                Param {
+                    name: "b".into(),
+                    sir_type: None,
+                    kind: ParamKind::Required,
+                    default: Some(Box::new(default_b)),
+                    span: s(),
+                },
+            ],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts: vec![],
+                // return b — so the printed value *is* the resolved default:
+                // f(5) → b defaults to a+1 = 6; f(5, 10) → b = 10.
+                value: Expr::VarRef { name: "b".into(), scope: Scope::Param, span: s() },
+                span: s(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        };
+        // main: print(f(5)); print(f(5, 10))
+        let call_f = |args: Vec<Expr>| Expr::DirectCall {
+            fn_name: "f".into(),
+            args,
+            effects: EffectSet::PURE,
+            span: s(),
+        };
+        let print_call = |inner: Expr| Stmt::ExprStmt {
+            expr: Expr::BuiltinCall {
+                name: "print".into(),
+                args: vec![inner],
+                effects: EffectSet::PURE,
+                span: s(),
+            },
+            span: s(),
+        };
+        let main = Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts: vec![
+                    print_call(call_f(vec![Expr::IntLit { value: 5, span: s() }])),
+                    print_call(call_f(vec![
+                        Expr::IntLit { value: 5, span: s() },
+                        Expr::IntLit { value: 10, span: s() },
+                    ])),
+                ],
+                value: Expr::NilLit { span: s() },
+                span: s(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        };
+        let m = Module {
+            name: "demo".into(),
+            manifest: FeatureManifest::from_features(&[
+                Feature::DefaultParams,
+                Feature::DynamicTyping,
+            ]),
+            imports: vec![],
+            exports: vec![],
+            functions: vec![f, main],
+            globals: vec![],
+            metadata: Metadata::new()
+                .with_source_language("test")
+                .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+            span: s(),
+        };
+        let a = compile(&m).expect("compile to python");
+        // Sentinel default + body prologue (the call-time, param-scoped shape).
+        assert!(a.source.contains("def f(a, b=_SIR_MISSING):"), "got:\n{}", a.source);
+        assert!(a.source.contains("    if b is _SIR_MISSING:"), "got:\n{}", a.source);
+        assert!(a.source.contains("        b = _sir_plus(a, 1)"), "got:\n{}", a.source);
+        // The omitting call passes only the present arg (no padding).
+        assert!(a.source.contains("f(5)"), "got:\n{}", a.source);
+        // Execution-proof via the PYTHONPATH-aware harness: 6 then 10.
+        if let Some(stdout) = run_emitted_python(&a.source) {
+            assert_eq!(stdout, "6\n10\n", "call-time default produced wrong output");
         }
     }
 

--- a/code/packages/rust/semantic-ir-to-python/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-python/src/runtime.rs
@@ -107,6 +107,16 @@ from coding_adventures_sir_runtime_core import (
     sir_print as _sir_print,
     to_display as _sir_to_display,
 )
+
+# Default-parameter sentinel (P2c).  SIR defaults are *call-time* and may
+# reference *earlier* params, so Python's native def-time defaults are wrong
+# for our model.  Instead a defaulted param's native default is this unique
+# sentinel object: callers may omit the argument (it then binds the sentinel),
+# and the function body's resolve-prologue replaces any still-sentinel param
+# with its default expression — evaluated in the body, where earlier params
+# are already in scope.  A fresh `object()` is distinct from every real value
+# (including `None`), so it can never collide with a legitimate argument.
+_SIR_MISSING = object()
 "##;
 
 #[cfg(test)]


### PR DESCRIPTION
Backend default-param emission for `semantic-ir-to-python`. **Python's native defaults are def-time and can't reference other params**, so a direct native lowering would be *wrong* for the IR's call-time, param-scope model. Strategy = **sentinel + body-prologue**:

- Runtime emits a module-level `_SIR_MISSING = object()` sentinel.
- A defaulted param emits `name=_SIR_MISSING` (so callers may omit it natively).
- A body prologue (in param order) resolves each: `if name is _SIR_MISSING: name = <default expr>` — running at call time, in the body where earlier params are bound. The `is` identity check against a fresh `object()` is unforgeable.
- Accepts `Feature::DefaultParams`. DirectCall unchanged (omitted trailing args bind the sentinel → prologue resolves).

Emitted shape:
```python
def f(a, b=_SIR_MISSING):
    if b is _SIR_MISSING:
        b = _sir_plus(a, 1)
    return b
```

**Tests:** 70 (incl. shape assertions + a Python execution test via the PYTHONPATH-aware harness): `print(f(5))`→`6`, `print(f(5,10))`→`10` — call-time + param-scope confirmed. clippy clean; security review passed. Isolated to `semantic-ir-to-python`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)