### PR TITLE
feat(sir-ts): default-parameter emission (P2b)

### DIFF
--- a/code/packages/rust/semantic-ir-to-typescript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-typescript/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## 0.2.0 — default-parameter emission (P2b)
+
+Default parameters now lower to TypeScript-native defaults. A `Param` whose new
+SIR `default` field is `Some(expr)` emits `name: __Sir.Val = <default>`, where
+`<default>` is the default expression run through the ordinary expression
+emitter. So `def f(a, b = a + 1); b; end` emits
+`function f(a: __Sir.Val, b: __Sir.Val = __Sir.add(a, 1)): __Sir.Val`.
+
+- **Why native is exact.** A SIR default is conceptually evaluated per call in
+  the callee's *parameter scope* and may reference *earlier* parameters.
+  TypeScript's own default-value parameters have precisely these semantics
+  (later defaults see earlier params; defaults run at call time when the
+  argument is omitted), so the lowering is a direct inline — no runtime helper,
+  no desugaring.
+- **No call-site padding.** The core validator now lets a `DirectCall` omit
+  trailing defaulted arguments. The emitter simply emits the arguments present
+  (`f(5)` stays one argument); TS native defaults fill the omitted trailing
+  parameters. `f(5, 10)` still passes both. `IndirectCall` is unchanged
+  (closures-with-defaults deferred).
+- **Capability.** `Feature::DefaultParams` is added to `ACCEPTED_FEATURES`, so a
+  default-using module passes the backend's feature check.
+- **Scope of `default`.** Only a `Required` parameter emits a default; a `Rest`
+  (`...rest`) parameter has none, and a `KwRest` (`**opts`) keeps its v0 object
+  fallback with no default surface form.
+- **Version.** Minor bump `0.1.x → 0.2.0` (Cargo manifest); the changelog
+  realigns onto the manifest version here.
+
 ## 0.1.22 — case-equality `case_eq` emission (M5)
 
 A `case_eq` builtin (emitted by a `when` clause for range/regex/literal

--- a/code/packages/rust/semantic-ir-to-typescript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-typescript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-typescript"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Semantic IR → self-contained TypeScript source code (SIR12). First backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-typescript/README.md
+++ b/code/packages/rust/semantic-ir-to-typescript/README.md
@@ -46,6 +46,14 @@ The TypeScript backend accepts these SIR features:
   `__Sir.Val`; type-narrowing in generated code is a future change.
 - `MutualRecursion` — JS hoisting handles this naturally.
 - `Globals` — module-level `let` + a `_init()` invocation.
+- `DefaultParams` (P2b) — a parameter's default lowers to a TypeScript-native
+  default: `name: __Sir.Val = <default>`. The SIR semantics (evaluated per call
+  in the callee's parameter scope, free to reference *earlier* params) match TS
+  native defaults exactly, so it is a direct inline. A `DirectCall` may omit
+  trailing defaulted arguments; the emitter emits only the args present (no
+  padding) and the native default fills the rest. So `def f(a, b = a + 1)`
+  emits `function f(a: __Sir.Val, b: __Sir.Val = __Sir.add(a, 1))`, and `f(5)`
+  emits `f(5)`.
 
 It **rejects**:
 

--- a/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
@@ -319,6 +319,26 @@ fn emit_function(out: &mut String, f: &Function) {
             }
             ParamKind::Required | ParamKind::KwRest => {
                 let _ = write!(out, "{}: __Sir.Val", sanitize_ident(&p.name));
+                // P2b default parameters.  A SIR default is evaluated
+                // per-call in the callee's parameter scope and may reference
+                // EARLIER params — exactly TypeScript's native default-value
+                // semantics.  So we emit the default expression verbatim
+                // through the ordinary expression emitter (which renders an
+                // earlier param's `VarRef` as a plain identifier, valid in
+                // TS):  `name: __Sir.Val = <default>`.  The call side never
+                // pads omitted trailing args (the validator allows omitting
+                // them), so these native defaults are what fill them in.
+                //
+                // Only `Required` params carry a meaningful default: a `Rest`
+                // param matched the arm above, and a `KwRest` (`**opts`) has
+                // no default surface form, so its `default` (if any) is
+                // ignored here — consistent with the v0 object fallback.
+                if p.kind == ParamKind::Required {
+                    if let Some(default) = &p.default {
+                        out.push_str(" = ");
+                        emit_expr(out, default, 2);
+                    }
+                }
             }
         }
     }
@@ -1727,6 +1747,53 @@ mod tests {
         emit_function(&mut out, &f);
         assert!(out.contains("function id(x: __Sir.Val): __Sir.Val"));
         assert!(out.contains("return x;"));
+    }
+
+    #[test]
+    fn emit_default_param_referencing_earlier_param() {
+        // P2b: `def f(a, b = a + 1); b; end` → TS
+        // `function f(a: __Sir.Val, b: __Sir.Val = __Sir.add(a, 1)): __Sir.Val`.
+        // The default is inlined natively and references the EARLIER param
+        // `a` (valid TS), so omitted trailing args are filled at call time.
+        let default_b = Expr::BuiltinCall {
+            name: "+".into(),
+            args: vec![
+                Expr::VarRef { name: "a".into(), scope: Scope::Param, span: s() },
+                Expr::IntLit { value: 1, span: s() },
+            ],
+            effects: EffectSet::PURE,
+            span: s(),
+        };
+        let f = Function {
+            name: "f".into(),
+            params: vec![
+                Param { name: "a".into(), sir_type: None, kind: ParamKind::Required, default: None, span: s() },
+                Param {
+                    name: "b".into(),
+                    sir_type: None,
+                    kind: ParamKind::Required,
+                    default: Some(Box::new(default_b)),
+                    span: s(),
+                },
+            ],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts: vec![],
+                value: Expr::VarRef { name: "b".into(), scope: Scope::Param, span: s() },
+                span: s(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        };
+        let mut out = String::new();
+        emit_function(&mut out, &f);
+        assert!(
+            out.contains("function f(a: __Sir.Val, b: __Sir.Val = __Sir.add(a, 1)): __Sir.Val"),
+            "got:\n{}",
+            out
+        );
     }
 
     #[test]

--- a/code/packages/rust/semantic-ir-to-typescript/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-typescript/src/lib.rs
@@ -106,6 +106,14 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     // object, `raise`, and ordered rescue-clause class matching come from
     // `@coding-adventures/sir-runtime-exceptions`.  Per code/specs/sir-runtime.md.
     Feature::Exceptions,
+    // P2b default parameters — a param with `default = Some(expr)`.  Emitted
+    // as a TypeScript-native default (`name: __Sir.Val = <expr>`).  The
+    // call-time / param-scope semantics of a SIR default — evaluated per call
+    // in the callee's parameter scope, free to reference EARLIER params —
+    // line up exactly with TS native defaults, so the lowering is a direct
+    // inline (no runtime helper, no call-site padding).  Per
+    // code/specs/sir-runtime.md.
+    Feature::DefaultParams,
 ];
 
 impl Backend for TypeScriptBackend {
@@ -1198,6 +1206,148 @@ mod tests {
         assert!(a.source.contains("\"method\""), "got:\n{}", a.source);
         assert!(!a.source.contains("__method__"), "operand was rendered; got:\n{}", a.source);
         assert!(!a.source.contains("\"foo\""), "operand was rendered; got:\n{}", a.source);
+    }
+
+    // ─── P2b default parameters → TS-native defaults ────────────────────────
+
+    /// Build a module exercising default parameters end-to-end:
+    ///
+    /// ```text
+    /// def f(a, b = a + 1)   # b's default REFERENCES the earlier param a
+    ///   b
+    /// end
+    /// def main
+    ///   f(5)        # omits b → native default fills it (b = a + 1 = 6)
+    ///   f(5, 10)    # passes b explicitly
+    /// end
+    /// ```
+    ///
+    /// The default expression is the canonical "references an earlier param"
+    /// form: `BuiltinCall("+", [VarRef{a, Param}, IntLit 1])`, which the TS
+    /// backend renders through its ordinary builtin lowering as
+    /// `__Sir.add(a, 1)`.
+    fn default_params_module() -> Module {
+        use semantic_ir::{Param, ParamKind, Scope};
+        let default_b = Expr::BuiltinCall {
+            name: "+".into(),
+            args: vec![
+                Expr::VarRef { name: "a".into(), scope: Scope::Param, span: s() },
+                Expr::IntLit { value: 1, span: s() },
+            ],
+            effects: EffectSet::PURE,
+            span: s(),
+        };
+        let f = Function {
+            name: "f".into(),
+            params: vec![
+                Param { name: "a".into(), sir_type: None, kind: ParamKind::Required, default: None, span: s() },
+                Param {
+                    name: "b".into(),
+                    sir_type: None,
+                    kind: ParamKind::Required,
+                    default: Some(Box::new(default_b)),
+                    span: s(),
+                },
+            ],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts: vec![],
+                value: Expr::VarRef { name: "b".into(), scope: Scope::Param, span: s() },
+                span: s(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        };
+        // main calls f(5) (b omitted) and f(5, 10) (b supplied).
+        let call_one = Expr::DirectCall {
+            fn_name: "f".into(),
+            args: vec![Expr::IntLit { value: 5, span: s() }],
+            effects: EffectSet::PURE,
+            span: s(),
+        };
+        let call_two = Expr::DirectCall {
+            fn_name: "f".into(),
+            args: vec![
+                Expr::IntLit { value: 5, span: s() },
+                Expr::IntLit { value: 10, span: s() },
+            ],
+            effects: EffectSet::PURE,
+            span: s(),
+        };
+        let main = Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts: vec![semantic_ir::Stmt::ExprStmt { expr: call_one, span: s() }],
+                value: call_two,
+                span: s(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        };
+        Module {
+            name: "demo".into(),
+            manifest: FeatureManifest::from_features(&[
+                Feature::DefaultParams,
+                Feature::DynamicTyping,
+            ]),
+            imports: vec![],
+            exports: vec![],
+            functions: vec![f, main],
+            globals: vec![],
+            metadata: Metadata::new()
+                .with_source_language("test")
+                .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+            span: s(),
+        }
+    }
+
+    #[test]
+    fn default_param_referencing_earlier_param_emits_native_ts_default() {
+        // Capability: the module declares DefaultParams, so it must pass the
+        // backend's feature check rather than be rejected.
+        let m = default_params_module();
+        let a = compile(&m).expect("default-using module must compile");
+        let src = &a.source;
+        // The param `b` carries a TS-native default in the param position,
+        // and that default references the EARLIER param `a` by name —
+        // exactly the call-time / param-scope semantics SIR specifies.
+        assert!(
+            src.contains("function f(a: __Sir.Val, b: __Sir.Val = __Sir.add(a, 1)): __Sir.Val"),
+            "expected a native default referencing the earlier param; got:\n{}",
+            src
+        );
+        // The param `a` (no default) is unchanged — no `= ` after it.
+        assert!(
+            src.contains("function f(a: __Sir.Val, b"),
+            "param without a default must be unchanged; got:\n{}",
+            src
+        );
+    }
+
+    #[test]
+    fn default_param_partial_and_full_calls_emit_present_args_only() {
+        // The 1-arg call `f(5)` omits the trailing defaulted `b`; TS native
+        // defaults fill it.  No padding, no placeholder for the omitted arg.
+        // The 2-arg call `f(5, 10)` passes both.
+        let m = default_params_module();
+        let a = compile(&m).expect("compile");
+        let src = &a.source;
+        assert!(
+            src.contains("f(5)"),
+            "partial call must emit one arg (omitting the defaulted trailing param); got:\n{}",
+            src
+        );
+        assert!(
+            src.contains("f(5, 10)"),
+            "full call must emit both args; got:\n{}",
+            src
+        );
     }
 
     #[test]


### PR DESCRIPTION
Backend default-param emission for `semantic-ir-to-typescript`. **Direct native lowering** — TS native default params match the IR's call-time, param-scope semantics.

- Accepts `Feature::DefaultParams`.
- A `Param{default: Some(expr)}` emits native `name: __Sir.Val = <default expr>` (via the normal `emit_expr` — an earlier-param reference renders as a bare identifier). Non-default/Rest/KwRest params unchanged.
- `DirectCall` unchanged (emits only present args; the validator now allows omitting trailing defaulted ones; native TS defaults fill the rest).

Emitted shape: `function f(a: __Sir.Val, b: __Sir.Val = __Sir.add(a, 1))`; partial call `f(5)` → `f(5)` (no padding).

**Tests:** 82 (source-shape assertions — this crate has no tsc+node execution harness because emitted `.ts` carries type annotations; the JS backend lane #7112 proves execution of identical semantics: f(5)→6, f(5,10)→10). clippy clean; security review passed. (Realigned Cargo.toml 0.1.0→0.2.0 with the CHANGELOG.) Isolated to `semantic-ir-to-typescript`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)