### PR TITLE
feat(sir-go): default-parameter emission via missing-sentinel runtime-mimic (P2f)

### DIFF
--- a/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
@@ -1,5 +1,66 @@
 # Changelog
 
+## 0.5.0 — SIR19 default parameters (P2f) via missing-sentinel runtime-mimic
+
+Adds `Feature::DefaultParams` to the Go backend's accepted set.  Go has no
+native optional/default parameters and emitted functions are *fixed-arity*
+over `Value`, so the backend uses a **runtime-mimic** strategy: a unique
+package-level MISSING sentinel flows through the ordinary `Value` channel.
+
+Semantics are **call-time, param-scope**: a default expression is evaluated
+each call, in the callee, where the *earlier* parameters are already bound
+(so a later default may reference an earlier param — `def f(a, b = a + 1)`).
+
+### Added
+
+- **Runtime MISSING sentinel.**  A distinct, otherwise-empty `_missingMarker`
+  struct type plus the single shared instance `var _sir_missing Value =
+  &_missingMarker{}`.  A program can never construct one itself (no IR node
+  lowers to it), so pointer identity makes the new
+  `func _sir_is_missing(v Value) bool` predicate exact and total.
+- **Caller-side padding.**  A `DirectCall` that omits trailing defaulted
+  arguments pads the call up to the callee's full (fixed) param count with
+  `_sir_missing`, e.g. `f(5)` for `f(a, b = …)` emits
+  `f(Value(int64(5)), _sir_missing)`.  The full param count comes from the
+  module's function table (`FN_ARITY`, populated by `emit_module` before any
+  body is walked).
+- **Callee body prologue.**  Each defaulted parameter gets a guard at the top
+  of the function body, in declaration order:
+  `if _sir_is_missing(<name>) { <name> = <emitted default expr> }`.  Ordering
+  is what makes a later default see an earlier param's already-resolved
+  value.  Reassigning a parameter is ordinary Go (parameters are mutable
+  locals) and the guard itself "uses" the param, so Go's strict
+  unused-variable rule is satisfied even when the body never reads it.
+
+### Changed
+
+- **`_sir_format` / `_sir_value_eq`** defensively handle the sentinel — it
+  never reaches a print or `=` path in a well-formed program (a defaulted
+  param is always replaced before use), but `_sir_format` renders a stray
+  sentinel as `<missing>` and `_sir_value_eq` treats two sentinels as equal
+  and a sentinel as equal to nothing else, so it can never masquerade as a
+  user value.
+
+### Tested
+
+- Unit tests assert the emitted shape: the body prologue (`if
+  _sir_is_missing(b) { b = _sir_plus([]Value{a, Value(int64(1))}) }`), that a
+  required param emits no guard, and that `DirectCall` padding appends the
+  right number of sentinels.  Runtime tests assert the sentinel type, the
+  `_sir_is_missing` helper, and the defensive format/eq guards.
+- New `go run` integration test (`compile_and_run_default_params.rs`):
+  module `f(a, b = a + 1)` returning `b`, `main` prints `f(5)` then
+  `f(5, 10)`; the emitted Go is compiled and run under the real Go toolchain
+  and stdout is asserted to be `6` then `10` (the default ran and saw
+  `a = 5`; a supplied argument suppressed it).  The four existing `go run`
+  tests (floats / loops / seq+maps / cyclic) still pass.
+
+### Housekeeping
+
+- Fixed three pre-existing `clippy` lints in `emit.rs` (a `write!`-with-
+  trailing-newline, a needless lifetime on `pick_global_set`, and a
+  `len() >= 1`) so the crate is clippy-clean under `--all-targets`.
+
 ## 0.4.1 — harden emitted Go runtime against cyclic Seq/Map
 
 `*Seq`/`*Map` are shared, *mutable* handles, so an emitted Go program can

--- a/code/packages/rust/semantic-ir-to-go/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-go/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-go"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 description = "Semantic IR → self-contained Go source code (SIR15). Fourth backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-go/README.md
+++ b/code/packages/rust/semantic-ir-to-go/README.md
@@ -85,6 +85,29 @@ SIR-v1 parity**.  Go is the fifth and last backend to reach v1.
 With all six SIR16 features wired up, `accepts_features` is in lockstep
 with emit — every declared feature has a real (non-panicking) emit path.
 
+### SIR19 — default parameters (`DefaultParams`)
+
+Go has no native optional/default parameters and emitted functions are
+*fixed-arity* over `Value`, so default parameters use a **runtime-mimic**
+strategy built on a unique MISSING sentinel:
+
+- **Runtime sentinel.** A distinct `_missingMarker` struct and a single
+  shared `var _sir_missing Value = &_missingMarker{}`, with an exact
+  `_sir_is_missing(v Value) bool` (pointer-identity) predicate.  A program
+  cannot construct one (no IR node lowers to it).  `_sir_format` /
+  `_sir_value_eq` guard it defensively (a stray sentinel prints as
+  `<missing>`), so it never masquerades as a user value.
+- **Caller padding.** A `DirectCall` that omits trailing defaulted arguments
+  pads up to the callee's full param count (read from the module's function
+  table) with `_sir_missing` — `f(5)` for `f(a, b = …)` emits
+  `f(Value(int64(5)), _sir_missing)`.
+- **Callee prologue.** At the body top, each defaulted param gets a guard in
+  declaration order: `if _sir_is_missing(b) { b = <default expr> }`.  The
+  default runs **call-time, in param-scope** — a later default sees the
+  *earlier* params already bound (`def f(a, b = a + 1)` ⇒ `f(5)` yields
+  `b == 6`).  Reassigning a parameter is ordinary mutable-local Go, and the
+  guard "uses" the param, so Go's strict unused-variable rule is satisfied.
+
 ## Value model
 
 ```go

--- a/code/packages/rust/semantic-ir-to-go/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/emit.rs
@@ -124,9 +124,50 @@ fn emit_function(out: &mut String, f: &Function) {
     }
     out.push_str(") Value {\n");
 
+    emit_default_prologue(out, f, 1);
     emit_function_body(out, &f.body, 1);
 
     out.push_str("}\n");
+}
+
+/// Emit the **default-parameter prologue** (SIR19 default params).
+///
+/// Emitted Go functions are fixed-arity over `Value`, so a caller that
+/// omits a trailing defaulted argument pads the call with the `_sir_missing`
+/// sentinel (see `emit_args`/`emit_call_padding`).  At the *top* of the
+/// body, each defaulted parameter gets a guard — in declaration order, so a
+/// later default may reference an *earlier* param whose own default has
+/// already run (call-time + param-scope semantics):
+///
+/// ```text
+///   if _sir_is_missing(<name>) {
+///       <name> = <emitted default expr>
+///   }
+/// ```
+///
+/// The default expression is emitted exactly like any other expression and
+/// sees the parameter names as plain Go identifiers (a default's
+/// `VarRef{scope: Param}` lowers to the bare name — the same binding the Go
+/// signature introduced).  Reassigning a parameter is legal Go (parameters
+/// are ordinary mutable locals), so no `:=`/`_ =` dance is needed: the param
+/// is always "used" by the guard itself, so Go's unused-variable rule is
+/// satisfied even when the body never reads it.
+///
+/// Only params carrying a `default` emit a guard; a required param (or a
+/// `Rest`/`KwRest` variadic, which this backend does not accept) emits
+/// nothing.  Captures are never defaulted, so they are skipped entirely.
+fn emit_default_prologue(out: &mut String, f: &Function, indent: usize) {
+    let pad = indent_str(indent);
+    let body_pad = indent_str(indent + 1);
+    for p in &f.params {
+        let Some(default) = &p.default else { continue };
+        let name = sanitize_ident(&p.name);
+        let _ = writeln!(out, "{}if _sir_is_missing({}) {{", pad, name);
+        let _ = write!(out, "{}{} = ", body_pad, name);
+        emit_expr(out, default, indent + 1);
+        out.push('\n');
+        let _ = writeln!(out, "{}}}", pad);
+    }
 }
 
 fn function_emit_name(name: &str) -> String {
@@ -262,7 +303,7 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
     }
 }
 
-fn pick_global_set<'a>(e: &'a Expr) -> Option<(&'a str, &'a Expr)> {
+fn pick_global_set(e: &Expr) -> Option<(&str, &Expr)> {
     if let Expr::BuiltinCall { name, args, .. } = e {
         if name == "global_set" && args.len() == 2 {
             if let Expr::SymLit { name: gn, .. } = &args[0] {
@@ -310,7 +351,7 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
             let _ = write!(out, "{}return ", pad2);
             emit_block_as_expr(out, then_branch, indent + 2);
             out.push('\n');
-            let _ = write!(out, "{}}}\n", pad);
+            let _ = writeln!(out, "{}}}", pad);
             let _ = write!(out, "{}return ", pad);
             emit_block_as_expr(out, else_branch, indent + 1);
             out.push('\n');
@@ -318,8 +359,27 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
         }
         Expr::Block(b) => emit_block_as_expr(out, b, indent),
         Expr::DirectCall { fn_name, args, .. } => {
+            // ── SIR19 default params: caller-side padding ───────────────
+            // Emitted Go functions are fixed-arity, so a call that omits
+            // trailing defaulted arguments must PAD up to the callee's full
+            // param count with the `_sir_missing` sentinel.  The callee's
+            // body prologue (see `emit_default_prologue`) then swaps each
+            // sentinel for that param's default.  The full param count comes
+            // from the module's function table (`FN_ARITY`), which
+            // `emit_module` populated with every function's `params.len()`
+            // before walking bodies.  A validated module never *over*-
+            // supplies, so `pad` is the non-negative shortfall; an unknown
+            // callee (not in the table) pads nothing.
+            let full_arity = FN_ARITY.with(|t| t.borrow().get(fn_name).copied());
+            let pad = full_arity.map_or(0, |n| n.saturating_sub(args.len()));
             let _ = write!(out, "{}(", function_emit_name(fn_name));
             emit_args(out, args, indent);
+            for i in 0..pad {
+                if i > 0 || !args.is_empty() {
+                    out.push_str(", ");
+                }
+                out.push_str("_sir_missing");
+            }
             out.push(')');
         }
         Expr::IndirectCall { target, args, .. } => {
@@ -523,7 +583,7 @@ fn emit_builtin_call(out: &mut String, name: &str, args: &[Expr], indent: usize)
         "global_set" => {
             // Two args, special signature.
             out.push_str("_sir_global_set(");
-            if args.len() >= 1 {
+            if !args.is_empty() {
                 emit_expr(out, &args[0], indent);
             }
             out.push_str(", ");
@@ -1320,6 +1380,120 @@ mod tests {
         emit_function(&mut out, &f);
         assert!(out.contains("func id(x Value) Value"));
         assert!(out.contains("return x"));
+    }
+
+    // ── SIR19 default parameters ───────────────────────────────────
+
+    /// `b = (+ a 1)` — a default that references the *earlier* param `a`,
+    /// exercising param-scope evaluation.
+    fn defaulted_fn() -> Function {
+        let plus = Expr::BuiltinCall {
+            name: "+".into(),
+            args: vec![
+                Expr::VarRef { name: "a".into(), scope: Scope::Param, span: s() },
+                Expr::IntLit { value: 1, span: s() },
+            ],
+            effects: EffectSet::PURE,
+            span: s(),
+        };
+        Function {
+            name: "f".into(),
+            params: vec![
+                Param { name: "a".into(), kind: ParamKind::Required, sir_type: None, default: None, span: s() },
+                Param { name: "b".into(), kind: ParamKind::Required, sir_type: None, default: Some(Box::new(plus)), span: s() },
+            ],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts: vec![],
+                value: Expr::BuiltinCall {
+                    name: "+".into(),
+                    args: vec![
+                        Expr::VarRef { name: "a".into(), scope: Scope::Param, span: s() },
+                        Expr::VarRef { name: "b".into(), scope: Scope::Param, span: s() },
+                    ],
+                    effects: EffectSet::PURE,
+                    span: s(),
+                },
+                span: s(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        }
+    }
+
+    #[test]
+    fn emit_function_emits_default_prologue() {
+        // The defaulted param gets a `if _sir_is_missing(...) { ... }` guard
+        // at the body top; the required param does not.  The default
+        // expression sees `a` as a plain Go identifier (param-scope).
+        let mut out = String::new();
+        emit_function(&mut out, &defaulted_fn());
+        assert!(out.contains("func f(a Value, b Value) Value"), "got: {out}");
+        assert!(out.contains("if _sir_is_missing(b) {"), "got: {out}");
+        assert!(out.contains("b = _sir_plus([]Value{a, Value(int64(1))})"), "got: {out}");
+        // `a` is required — no guard for it.
+        assert!(!out.contains("_sir_is_missing(a)"), "got: {out}");
+    }
+
+    #[test]
+    fn emit_direct_call_pads_omitted_defaults_with_sentinel() {
+        // A full-arity module: `f(a, b=a+1)` plus a `main` that calls
+        // `f(5)` (one arg omitted) and `f(5, 10)` (full).  Padding relies on
+        // the module's function table, so we go through `emit_module`.
+        let main = Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts: vec![
+                    Stmt::ExprStmt {
+                        expr: Expr::DirectCall {
+                            fn_name: "f".into(),
+                            args: vec![ilit(5)],
+                            effects: EffectSet::PURE,
+                            span: s(),
+                        },
+                        span: s(),
+                    },
+                    Stmt::ExprStmt {
+                        expr: Expr::DirectCall {
+                            fn_name: "f".into(),
+                            args: vec![ilit(5), ilit(10)],
+                            effects: EffectSet::PURE,
+                            span: s(),
+                        },
+                        span: s(),
+                    },
+                ],
+                value: Expr::NilLit { span: s() },
+                span: s(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        };
+        let m = Module {
+            name: "demo".into(),
+            manifest: FeatureManifest::from_features(&[
+                semantic_ir::Feature::DefaultParams,
+            ]),
+            imports: vec![],
+            exports: vec![],
+            functions: vec![defaulted_fn(), main],
+            globals: vec![],
+            metadata: Metadata::new()
+                .with_source_language("test")
+                .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+            span: s(),
+        };
+        let out = emit_module(&m);
+        // `f(5)` pads the one omitted trailing arg with the sentinel.
+        assert!(out.contains("f(Value(int64(5)), _sir_missing)"), "got: {out}");
+        // `f(5, 10)` is full-arity — no padding.
+        assert!(out.contains("f(Value(int64(5)), Value(int64(10)))"), "got: {out}");
     }
 
     #[test]

--- a/code/packages/rust/semantic-ir-to-go/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/lib.rs
@@ -70,6 +70,19 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     // unaccepted, so they remain strictly unreachable.
     Feature::Sequences,
     Feature::Maps,
+    // ── SIR19 (P2f) — default parameters ───────────────────────────
+    // `DefaultParams` is a hybrid emit + runtime feature.  Go has no
+    // native optional/default parameters, so we use a RUNTIME-MIMIC
+    // strategy: a package-level MISSING sentinel (`_sir_missing`, a
+    // distinct `*_missingMarker`) flows through the ordinary `Value`
+    // channel.  A `DirectCall` that omits trailing defaulted arguments
+    // pads up to the callee's full (fixed) arity with the sentinel; the
+    // callee's body prologue replaces each sentinel with that param's
+    // default expression, evaluated where earlier params are already
+    // bound (call-time + param-scope).  `_sir_is_missing` tests the
+    // sentinel by pointer identity; `_sir_format`/`_sir_value_eq` handle
+    // it defensively so it never reaches user-visible output.
+    Feature::DefaultParams,
 ];
 
 impl Backend for GoBackend {

--- a/code/packages/rust/semantic-ir-to-go/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/runtime.rs
@@ -57,6 +57,35 @@ type Map struct {
 	Entries []MapEntry
 }
 
+// ── SIR19 default parameters: the MISSING sentinel ─────────────
+//
+// Emitted Go functions are *fixed-arity* over `Value` — Go has no native
+// optional/default parameters.  To mimic call-time defaults we route an
+// "argument not supplied" marker through the ordinary `Value` channel: a
+// unique, package-level sentinel value.  A caller that omits a trailing
+// defaulted argument PADS the call with `_sir_missing`; the callee's body
+// prologue tests each defaulted param with `_sir_is_missing` and, when it
+// finds the sentinel, evaluates that param's default expression in place
+// (where earlier params are already bound — call-time, param-scope
+// semantics).
+//
+// `_missingMarker` is a distinct, otherwise-empty struct type so the
+// sentinel can never be confused with any user value: a program cannot
+// construct a `*_missingMarker` itself (no IR node lowers to one), and
+// pointer identity makes the `_sir_is_missing` check exact.  `_sir_missing`
+// is the single shared instance boxed in a `Value`.
+type _missingMarker struct{}
+
+var _sir_missing Value = &_missingMarker{}
+
+// True iff `v` is the missing-argument sentinel.  Compared by pointer
+// identity (interface equality of the boxed `*_missingMarker`), so it is
+// exact and total — no user value matches.
+func _sir_is_missing(v Value) bool {
+	_, ok := v.(*_missingMarker)
+	return ok
+}
+
 var _sir_symbol_table = make(map[string]*Symbol)
 var _sir_globals = make(map[string]Value)
 
@@ -294,6 +323,14 @@ func _sir_value_eq(a Value, b Value) bool {
 }
 
 func _sir_value_eq_d(a Value, b Value, pending map[[2]Value]bool) bool {
+	// Defensive: the MISSING sentinel (SIR19 default params) never reaches
+	// `=` in a well-formed program (a defaulted param is replaced by its
+	// default before use).  Should one slip through, two sentinels are
+	// equal and a sentinel equals nothing else — handled here before the
+	// numeric/structural arms so it can never be mistaken for a value.
+	if _sir_is_missing(a) || _sir_is_missing(b) {
+		return _sir_is_missing(a) && _sir_is_missing(b)
+	}
 	if as, ok := a.(*Symbol); ok {
 		if bs, ok := b.(*Symbol); ok {
 			return as.Name == bs.Name
@@ -479,6 +516,14 @@ func _sir_format(v Value) string {
 func _sir_format_d(v Value, visited map[Value]bool) string {
 	if v == nil {
 		return "nil"
+	}
+	// Defensive: the MISSING sentinel (SIR19 default params) should never
+	// reach a print path — a defaulted param is always replaced by its
+	// default in the body prologue before any use.  Render it as a
+	// distinctive marker rather than the bare `&{}` Go would otherwise
+	// print, so a stray sentinel is obvious in output.
+	if _sir_is_missing(v) {
+		return "<missing>"
 	}
 	if b, ok := v.(bool); ok {
 		if b {
@@ -945,6 +990,25 @@ mod tests {
         assert!(RUNTIME.contains("func _sir_value_eq_d(a Value, b Value, pending map[[2]Value]bool) bool"));
         assert!(RUNTIME.contains("return _sir_value_eq_d(a, b, make(map[[2]Value]bool))"));
         assert!(RUNTIME.contains("key := [2]Value{a, b}"));
+    }
+
+    #[test]
+    fn runtime_declares_missing_sentinel_and_helper() {
+        // SIR19 default params: the runtime must carry a unique MISSING
+        // sentinel (a distinct `*_missingMarker` boxed in a `Value`) and an
+        // exact `_sir_is_missing` predicate.
+        assert!(RUNTIME.contains("type _missingMarker struct{}"));
+        assert!(RUNTIME.contains("var _sir_missing Value = &_missingMarker{}"));
+        assert!(RUNTIME.contains("func _sir_is_missing(v Value) bool"));
+    }
+
+    #[test]
+    fn runtime_handles_missing_in_format_and_eq() {
+        // The sentinel never normally prints or compares, but both paths
+        // guard it defensively so a stray sentinel can't masquerade as a
+        // user value.
+        assert!(RUNTIME.contains("\"<missing>\""));
+        assert!(RUNTIME.contains("if _sir_is_missing(a) || _sir_is_missing(b)"));
     }
 
     #[test]

--- a/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_default_params.rs
+++ b/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_default_params.rs
@@ -1,0 +1,200 @@
+//! End-to-end proof for SIR19 **DefaultParams** in the Go backend (P2f).
+//!
+//! Go has no native optional/default parameters, so the backend uses a
+//! RUNTIME-MIMIC strategy: a package-level MISSING sentinel
+//! (`_sir_missing`) flows through the ordinary `Value` channel.  A
+//! `DirectCall` that omits trailing defaulted arguments pads up to the
+//! callee's full (fixed) arity with the sentinel; the callee's body
+//! prologue swaps each sentinel for that param's default expression,
+//! evaluated where the *earlier* params are already bound (call-time +
+//! param-scope).
+//!
+//! Unit tests assert the emitted *shape*; this test goes the whole way:
+//! it hand-builds the discriminating module, emits Go, writes it to a temp
+//! `.go` file, runs it with `go run`, and checks stdout.  Only a real Go
+//! toolchain can confirm the emitted source compiles under Go's strict
+//! unused-var / unused-import rules and behaves — which is the entire
+//! reason this feature is delicate.
+//!
+//! DISCRIMINATING MODULE: `f(a, b)` where `b`'s default is `(+ a 1)` (it
+//! references the *earlier* param `a`).  `main` prints `f(5)` then
+//! `f(5, 10)`.  Expected stdout: `6` then `10`.  The first call proves the
+//! default ran *and* saw the supplied `a = 5` (param-scope, call-time); the
+//! second proves a supplied argument suppresses the default.
+//!
+//! The test gates on `go` being available (`go version`); a missing
+//! toolchain logs a skip rather than reddening an unrelated build (mirrors
+//! `compile_and_run_loops.rs`).
+
+use std::process::Command;
+
+use semantic_ir::{
+    Block, Effect, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, Param,
+    ParamKind, Scope, Span, Stmt,
+};
+use semantic_ir_to_go::compile;
+
+fn s() -> Span {
+    Span::synthetic()
+}
+
+fn ilit(v: i64) -> Expr {
+    Expr::IntLit { value: v, span: s() }
+}
+
+fn param_ref(name: &str) -> Expr {
+    Expr::VarRef { name: name.into(), scope: Scope::Param, span: s() }
+}
+
+fn call(name: &str, args: Vec<Expr>) -> Expr {
+    Expr::BuiltinCall {
+        name: name.into(),
+        args,
+        effects: EffectSet::PURE,
+        span: s(),
+    }
+}
+
+/// `print(expr)` as an effectful statement.
+fn print_stmt(expr: Expr) -> Stmt {
+    Stmt::ExprStmt {
+        expr: Expr::BuiltinCall {
+            name: "print".into(),
+            args: vec![expr],
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            span: s(),
+        },
+        span: s(),
+    }
+}
+
+/// `f(a, b = (+ a 1))` returning `(+ a b)` … no, simpler: returns `b`.
+///
+/// We make `f` return `b` so the printed value isolates exactly what the
+/// default mechanism produced:
+///   * `f(5)`     → `b` defaulted to `5 + 1` = `6`
+///   * `f(5, 10)` → `b` supplied as `10`
+fn defaulted_fn() -> Function {
+    Function {
+        name: "f".into(),
+        params: vec![
+            Param { name: "a".into(), kind: ParamKind::Required, sir_type: None, default: None, span: s() },
+            Param {
+                name: "b".into(),
+                kind: ParamKind::Required,
+                sir_type: None,
+                default: Some(Box::new(call("+", vec![param_ref("a"), ilit(1)]))),
+                span: s(),
+            },
+        ],
+        return_type: None,
+        captures: vec![],
+        body: Block { stmts: vec![], value: param_ref("b"), span: s() },
+        effects: EffectSet::PURE,
+        metadata: Metadata::new(),
+        span: s(),
+    }
+}
+
+/// `main`: print `f(5)` (→ 6), then print `f(5, 10)` (→ 10).
+fn demo_module() -> Module {
+    let main = Function {
+        name: "main".into(),
+        params: vec![],
+        return_type: None,
+        captures: vec![],
+        body: Block {
+            stmts: vec![
+                print_stmt(Expr::DirectCall {
+                    fn_name: "f".into(),
+                    args: vec![ilit(5)],
+                    effects: EffectSet::PURE,
+                    span: s(),
+                }),
+                print_stmt(Expr::DirectCall {
+                    fn_name: "f".into(),
+                    args: vec![ilit(5), ilit(10)],
+                    effects: EffectSet::PURE,
+                    span: s(),
+                }),
+            ],
+            value: Expr::NilLit { span: s() },
+            span: s(),
+        },
+        effects: EffectSet::PURE.with(Effect::MayPrint),
+        metadata: Metadata::new(),
+        span: s(),
+    };
+
+    Module {
+        name: "default_params_demo".into(),
+        manifest: FeatureManifest::from_features(&[
+            Feature::DefaultParams,
+            // Untyped params observe `DynamicTyping`; the validator requires
+            // every observed feature to be declared.
+            Feature::DynamicTyping,
+        ]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![defaulted_fn(), main],
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("test")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+fn go_available() -> bool {
+    Command::new("go")
+        .arg("version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+#[test]
+fn default_params_compile_and_run() {
+    if !go_available() {
+        eprintln!("skipping: go not on PATH");
+        return;
+    }
+
+    // 1. Emit.
+    let artifact = compile(&demo_module()).expect("module should compile to Go source");
+
+    // 2. Write to a unique temp file (`go run` requires a `.go` extension).
+    let dir = std::env::temp_dir();
+    let nonce = std::process::id();
+    let src_path = dir.join(format!("sir_go_default_params_{nonce}.go"));
+    std::fs::write(&src_path, &artifact.source).expect("write temp source");
+
+    // 3. Compile + run with `go run` (arg vector — no shell).
+    let run_out = Command::new("go")
+        .arg("run")
+        .arg(&src_path)
+        .output()
+        .expect("invoke go run");
+
+    if !run_out.status.success() {
+        let stderr = String::from_utf8_lossy(&run_out.stderr);
+        let _ = std::fs::remove_file(&src_path);
+        panic!(
+            "emitted Go failed to compile/run:\n--- stderr ---\n{stderr}\n--- source ---\n{}",
+            artifact.source,
+        );
+    }
+
+    // 4. Assert observable behaviour: the default ran and saw `a = 5`
+    //    (→ 6); a supplied argument suppressed it (→ 10).
+    let stdout = String::from_utf8_lossy(&run_out.stdout);
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert_eq!(
+        lines,
+        vec!["6", "10"],
+        "unexpected program output; full stdout:\n{stdout}"
+    );
+
+    // 5. Best-effort cleanup.
+    let _ = std::fs::remove_file(&src_path);
+}


### PR DESCRIPTION
Backend default-param emission for `semantic-ir-to-go`. Go has no native default params, so **runtime-mimic** per the full-syntax mandate:

- Emitted runtime gains a `_missingMarker` sentinel type + `var _sir_missing Value` + `_sir_is_missing(v) bool` (pointer/type-identity — unforgeable; no IR node lowers to it).
- Functions take all params (fixed arity); a body **prologue** resolves each defaulted param: `if _sir_is_missing(b) { b = <default expr> }` — at call time, in param scope (earlier params bound).
- `DirectCall` **pads** omitted trailing positions with `_sir_missing` (pad count = full arity − args, from the emitter's FN_ARITY table; `saturating_sub`, DirectCall-to-known-function only). IndirectCall unchanged.
- `_sir_format` renders a stray sentinel `<missing>`; `_sir_value_eq` treats sentinels by identity.

Emitted shape:
```go
func f(a Value, b Value) Value { if _sir_is_missing(b) { b = _sir_plus([]Value{a, Value(int64(1))}) }; return b }
// f(5): f(Value(int64(5)), _sir_missing)
```

**Tests:** 54 unit + 5 `go run` integration (new `compile_and_run_default_params` asserts `f(5)`→`6`, `f(5,10)`→`10` — call-time + param-scope; existing cyclic/floats/loops/seq_maps still green). clippy clean (also fixed 3 pre-existing lints); security review passed. Isolated to `semantic-ir-to-go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)