### PR TITLE
feat(sir-rust): default-parameter emission via missing-sentinel runtime-mimic (P2e)

### DIFF
--- a/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
@@ -1,5 +1,53 @@
 # Changelog
 
+## 0.5.0 — default-parameter emission (P2e)
+
+Adds `Feature::DefaultParams` support: a `Param` may now carry a
+`default` expression that runs when the caller omits that trailing
+argument.  Rust functions are fixed-arity over `__sir::Value` with no
+native default parameters, so the backend uses a **runtime-mimic**
+strategy built around a `Missing` sentinel — preserving the language's
+**call-time, param-scope** default semantics (a default expression is
+evaluated on each call that omits the argument, in body scope where
+*earlier* parameters are already bound, so `b = a + 1` resolves `a`).
+
+### Added
+
+- **`__sir::Value::Missing`** — a new sentinel variant marking an
+  *omitted* positional argument, plus **`__sir::missing()`** (constructor)
+  and **`__sir::is_missing(&Value)`** (predicate).  `Missing` is internal:
+  it is created only at call sites that drop a trailing argument and is
+  consumed by the callee's prologue before any value flows on.
+- **Defensive runtime arms** — `format` renders a stray `Missing` as
+  `<missing>` and `value_eq` treats `Missing` as equal only to another
+  `Missing` (never to `Nil` or a real value).  These should be
+  unreachable in well-formed programs but degrade gracefully instead of
+  panicking.
+- **Function-body default-param prologue** — for each defaulted param, in
+  declaration order, the emitter now writes
+  `let <name> = if __sir::is_missing(&<name>) { <default> } else { <name> };`
+  at the top of the function body.  Emitting the default *inside the body*
+  is what gives call-time + param-scope semantics.
+- **`DirectCall` caller padding** — a call that omits trailing defaulted
+  arguments now pads the omitted positions with `__sir::missing()` so the
+  emitted Rust call is full-arity.  The callee's full parameter count is
+  read from the existing `FN_ARITY` thread-local arity table (the same
+  table `MakeClosure` consults), keyed by the callee's SIR name.
+- **`Feature::DefaultParams`** added to `ACCEPTED_FEATURES`.
+
+### Tests
+
+- Unit tests for the emitted shape: the sentinel-guarded prologue (with a
+  default that references an earlier param), the padded full-arity call,
+  and the no-padding case for a fully-supplied call.
+- A `rustc` compile-and-run integration test
+  (`tests/compile_and_run_default_params.rs`): hand-builds
+  `f(a, b = a + 1) -> b`, prints `f(5)` then `f(5, 10)`, compiles the
+  emitted Rust with `rustc`, runs it, and asserts stdout `6` then `10`.
+
+Non-default behaviour is byte-for-byte unchanged — every existing test
+(floats, loops, seq/maps, cyclic) passes untouched.
+
 ## 0.4.1 — harden emitted runtime against cyclic Seq/Map
 
 `Value::Seq`/`Value::Map` are shared, *mutable* handles, so an emitted

--- a/code/packages/rust/semantic-ir-to-rust/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-rust"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 description = "Semantic IR → self-contained Rust source code (SIR13). Second backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-rust/README.md
+++ b/code/packages/rust/semantic-ir-to-rust/README.md
@@ -65,6 +65,28 @@ arm — no reachable `panic!` remains for v1.  The remaining emit panics
 cover SIR17/18 nodes (classes, modules, try/catch, string interpolation,
 instance/class/const vars) whose features stay unaccepted.
 
+Accepts (P2e): `DefaultParams` — a `Param` may carry a `default`
+expression that runs when the caller omits that trailing argument.  Rust
+functions are fixed-arity over `__sir::Value` with no native defaults, so
+the backend uses a **runtime-mimic** strategy that preserves the
+language's **call-time, param-scope** semantics:
+
+- A `Value::Missing` sentinel marks an *omitted* positional argument,
+  with `__sir::missing()` (constructor) and `__sir::is_missing(&Value)`
+  (predicate) helpers.  `format` renders a stray `Missing` as `<missing>`
+  and `value_eq` treats it as equal only to another `Missing`.
+- Each defaulted param gets a **body-top prologue**
+  `let p = if __sir::is_missing(&p) { <default> } else { p };`.  Emitting
+  the default *inside the body* — in declaration order — is what gives the
+  call-time + param-scope rule: an earlier parameter is already bound, so
+  a default like `b = a + 1` resolves `a`.
+- A `DirectCall` that omits trailing defaulted arguments **pads** the
+  omitted positions with `__sir::missing()` so the emitted Rust call is
+  full-arity.  The callee's parameter count comes from the same
+  `FN_ARITY` table the closure emitter uses.
+
+Non-default behaviour is byte-for-byte unchanged.
+
 Rejects: `TailCalls` (Rust does not guarantee TCO), `Intrinsics`
 (empty whitelist in v0), and the SIR17/18 features above.
 
@@ -74,6 +96,7 @@ Rejects: `TailCalls` (Rust does not guarantee TCO), `Intrinsics`
 #[derive(Clone)]
 enum Value {
     Int(i64), Float(f64), Bool(bool), Nil,
+    Missing,                                 // P2e DefaultParams sentinel
     Sym(Rc<str>), Str(Rc<str>),
     Pair(Rc<Pair>),
     Closure(Rc<Closure>),

--- a/code/packages/rust/semantic-ir-to-rust/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/emit.rs
@@ -146,6 +146,32 @@ fn emit_function(out: &mut String, f: &Function) {
     }
     out.push_str(") -> __sir::Value {\n");
 
+    // ── DefaultParams (P2e) prologue ───────────────────────────────
+    //
+    // Rust fns are fixed-arity, so every defaulted param is still a
+    // real parameter of type `__sir::Value`.  A caller that omits a
+    // trailing defaulted argument passes the `__sir::missing()`
+    // sentinel for it (see the `DirectCall` emitter).  We rebind each
+    // defaulted param at the very top of the body:
+    //
+    //   let <name> = if __sir::is_missing(&<name>) { <default> }
+    //                else { <name> };
+    //
+    // Emitting the default *here* — inside the body, in declaration
+    // order — is what gives the language-level semantics:
+    //   • call-time: the default expression evaluates on each call that
+    //     omits the argument, not once at definition time; and
+    //   • param-scope: an earlier param is already bound (as a plain
+    //     Rust binding) by the time a later param's default runs, so a
+    //     default like `b = a + 1` resolves `a` correctly.
+    //
+    // The `else { <name> }` branch moves the already-bound param value
+    // through unchanged (no clone needed — we shadow the binding).  A
+    // param with no default is left exactly as the fn signature bound
+    // it.  We emit prologue lines only for params that carry a default,
+    // so non-default functions are byte-for-byte unchanged.
+    emit_default_param_prologue(out, f, 1);
+
     // Pre-pass: any local that is later reassigned must bind with
     // `let mut`.  Scope is per-function — clear, populate, emit, clear.
     MUTABLE_NAMES.with(|m| {
@@ -158,6 +184,32 @@ fn emit_function(out: &mut String, f: &Function) {
 
     MUTABLE_NAMES.with(|m| m.borrow_mut().clear());
     out.push_str("}\n");
+}
+
+/// Emit the body-top prologue that resolves each defaulted parameter.
+///
+/// For every param carrying a `default`, in declaration order, emit:
+///
+/// ```text
+///     let <name> = if __sir::is_missing(&<name>) { <default> } else { <name> };
+/// ```
+///
+/// Params without a default emit nothing, so a function with no
+/// defaulted params produces byte-for-byte identical output to before
+/// this feature existed.  The default expression is lowered through the
+/// ordinary `emit_expr` path, so it sees the same scope resolution as
+/// any body expression — in particular a `VarRef` with `Param` scope to
+/// an *earlier* parameter resolves to that parameter's already-bound
+/// Rust identifier (`a.clone()`), which is exactly the param-scope rule.
+fn emit_default_param_prologue(out: &mut String, f: &Function, indent: usize) {
+    let pad = indent_str(indent);
+    for p in &f.params {
+        let Some(default) = &p.default else { continue };
+        let name = sanitize_ident(&p.name);
+        let _ = write!(out, "{}let {} = if __sir::is_missing(&{}) {{ ", pad, name, name);
+        emit_expr(out, default, indent);
+        let _ = writeln!(out, " }} else {{ {} }};", name);
+    }
 }
 
 /// Walk a block (recursing through nested blocks, loop bodies, and
@@ -442,6 +494,31 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
         Expr::DirectCall { fn_name, args, .. } => {
             let _ = write!(out, "{}(", function_emit_name(fn_name));
             emit_args(out, args, indent);
+            // ── DefaultParams (P2e) caller padding ─────────────────
+            //
+            // The IR call may carry FEWER args than the callee declares
+            // (the validator allows omitting trailing defaulted params).
+            // Rust fns are fixed-arity, so we PAD the omitted trailing
+            // positions with the `__sir::missing()` sentinel — the
+            // callee's prologue then swaps each sentinel for that param's
+            // default.  The callee's full param count comes from the same
+            // `FN_ARITY` table that `MakeClosure` already consults; it is
+            // keyed by the function's SIR name (`fn_name`), not its
+            // emitted name.  A callee absent from the table (e.g. a
+            // builtin reached via DirectCall) yields `0`, so `saturating_
+            // sub` pads nothing and the call is emitted unchanged.
+            let arity = FN_ARITY.with(|t| t.borrow().get(fn_name).copied().unwrap_or(0));
+            let pad_count = arity.saturating_sub(args.len());
+            for i in 0..pad_count {
+                // A comma precedes every sentinel that is not the very
+                // first emitted argument: either real args were emitted
+                // (so the first sentinel still needs a separator), or a
+                // prior sentinel was emitted.
+                if !args.is_empty() || i > 0 {
+                    out.push_str(", ");
+                }
+                out.push_str("__sir::missing()");
+            }
             out.push(')');
         }
         Expr::IndirectCall { target, args, .. } => {
@@ -1506,6 +1583,184 @@ mod tests {
         emit_function(&mut out, &f);
         assert!(out.contains("fn id(x: __sir::Value) -> __sir::Value"));
         assert!(out.contains("x.clone()"));
+    }
+
+    // ── DefaultParams (P2e) ────────────────────────────────────────
+
+    /// A defaulted param emits a body-top prologue that tests the
+    /// `is_missing` sentinel and substitutes the default expression.
+    /// The default here references an *earlier* param (`b = a + 1`),
+    /// proving the prologue runs in body scope where `a` is bound.
+    #[test]
+    fn emit_default_param_prologue_shape() {
+        // f(a, b = a + 1) -> a + b
+        let body = Block {
+            stmts: vec![],
+            value: Expr::BuiltinCall {
+                name: "+".into(),
+                args: vec![
+                    Expr::VarRef { name: "a".into(), scope: Scope::Param, span: s() },
+                    Expr::VarRef { name: "b".into(), scope: Scope::Param, span: s() },
+                ],
+                effects: EffectSet::PURE,
+                span: s(),
+            },
+            span: s(),
+        };
+        let default_b = Expr::BuiltinCall {
+            name: "+".into(),
+            args: vec![
+                Expr::VarRef { name: "a".into(), scope: Scope::Param, span: s() },
+                Expr::IntLit { value: 1, span: s() },
+            ],
+            effects: EffectSet::PURE,
+            span: s(),
+        };
+        let f = Function {
+            name: "f".into(),
+            params: vec![
+                Param { name: "a".into(), kind: ParamKind::Required, sir_type: None, default: None, span: s() },
+                Param { name: "b".into(), kind: ParamKind::Required, sir_type: None, default: Some(Box::new(default_b)), span: s() },
+            ],
+            return_type: None,
+            captures: vec![],
+            body,
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        };
+        let mut out = String::new();
+        emit_function(&mut out, &f);
+        // Fixed-arity signature: BOTH params are still real parameters.
+        assert!(out.contains("fn f(a: __sir::Value, b: __sir::Value) -> __sir::Value"));
+        // `a` has no default → no prologue line for it.
+        assert!(!out.contains("is_missing(&a)"));
+        // `b` gets the sentinel-guarded prologue, with its default
+        // (`a + 1`) lowered in body scope.
+        assert!(
+            out.contains("let b = if __sir::is_missing(&b) { __sir::plus(vec![a.clone(), __sir::Value::Int(1i64)]) } else { b };"),
+            "missing/garbled default-param prologue; got:\n{out}"
+        );
+    }
+
+    /// A `DirectCall` that omits a trailing defaulted argument pads the
+    /// omitted slot with `__sir::missing()` so the emitted Rust call is
+    /// full-arity.  Padding count comes from the callee's `FN_ARITY`.
+    #[test]
+    fn emit_direct_call_pads_omitted_defaults() {
+        // Build a module with f(a, b = ...) so FN_ARITY[f] == 2, then a
+        // `main` whose body is `f(5)` — one arg short.
+        let default_b = Expr::IntLit { value: 99, span: s() };
+        let f = Function {
+            name: "f".into(),
+            params: vec![
+                Param { name: "a".into(), kind: ParamKind::Required, sir_type: None, default: None, span: s() },
+                Param { name: "b".into(), kind: ParamKind::Required, sir_type: None, default: Some(Box::new(default_b)), span: s() },
+            ],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts: vec![],
+                value: Expr::VarRef { name: "a".into(), scope: Scope::Param, span: s() },
+                span: s(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        };
+        let main = Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts: vec![],
+                value: Expr::DirectCall {
+                    fn_name: "f".into(),
+                    args: vec![Expr::IntLit { value: 5, span: s() }],
+                    effects: EffectSet::PURE,
+                    span: s(),
+                },
+                span: s(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        };
+        let m = Module {
+            name: "demo".into(),
+            manifest: FeatureManifest::new(),
+            imports: vec![],
+            exports: vec![],
+            functions: vec![f, main],
+            globals: vec![],
+            metadata: Metadata::new()
+                .with_source_language("test")
+                .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+            span: s(),
+        };
+        let out = emit_module_with_arity_table(&m);
+        // One real arg + one padded sentinel → full-arity 2-arg call.
+        assert!(
+            out.contains("f(__sir::Value::Int(5i64), __sir::missing())"),
+            "expected padded full-arity call; got:\n{out}"
+        );
+    }
+
+    /// A fully-supplied `DirectCall` (no omitted args) pads nothing —
+    /// non-default call sites are byte-for-byte unchanged.
+    #[test]
+    fn emit_direct_call_no_padding_when_full() {
+        let f = Function {
+            name: "g".into(),
+            params: vec![
+                Param { name: "a".into(), kind: ParamKind::Required, sir_type: None, default: None, span: s() },
+                Param { name: "b".into(), kind: ParamKind::Required, sir_type: None, default: None, span: s() },
+            ],
+            return_type: None,
+            captures: vec![],
+            body: Block { stmts: vec![], value: Expr::VarRef { name: "a".into(), scope: Scope::Param, span: s() }, span: s() },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        };
+        let main = Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts: vec![],
+                value: Expr::DirectCall {
+                    fn_name: "g".into(),
+                    args: vec![
+                        Expr::IntLit { value: 1, span: s() },
+                        Expr::IntLit { value: 2, span: s() },
+                    ],
+                    effects: EffectSet::PURE,
+                    span: s(),
+                },
+                span: s(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        };
+        let m = Module {
+            name: "demo".into(),
+            manifest: FeatureManifest::new(),
+            imports: vec![],
+            exports: vec![],
+            functions: vec![f, main],
+            globals: vec![],
+            metadata: Metadata::new()
+                .with_source_language("test")
+                .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+            span: s(),
+        };
+        let out = emit_module_with_arity_table(&m);
+        assert!(out.contains("g(__sir::Value::Int(1i64), __sir::Value::Int(2i64))"));
+        assert!(!out.contains("__sir::missing()"));
     }
 
     #[test]

--- a/code/packages/rust/semantic-ir-to-rust/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/lib.rs
@@ -104,6 +104,20 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     // (classes, modules, try/catch, str-concat, instance/class/const
     // vars, intrinsics) whose features stay unaccepted, so those arms
     // remain unreachable for any validated module.
+    //
+    // `DefaultParams` (P2e) lets a `Param` carry a `default` expression
+    // that runs when the caller omits that trailing argument.  Rust fns
+    // are fixed-arity over `__sir::Value` with no native defaults, so the
+    // backend uses a RUNTIME-MIMIC strategy: a `Value::Missing` sentinel
+    // marks an omitted argument, every defaulted param gets a body-top
+    // prologue (`let p = if is_missing(&p) { <default> } else { p };`)
+    // that evaluates the default *in the body* — where earlier params are
+    // already bound, giving call-time, param-scope semantics — and each
+    // `DirectCall` pads its omitted trailing positions with
+    // `__sir::missing()` so the emitted call is full-arity.  This needs no
+    // validator change (the core validator already permits omitting
+    // trailing defaulted args in a `DirectCall`).
+    Feature::DefaultParams,
 ];
 
 impl Backend for RustBackend {

--- a/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
@@ -33,6 +33,19 @@ pub const RUNTIME: &str = r##"mod __sir {
         Float(f64),
         Bool(bool),
         Nil,
+        // ── DefaultParams (P2e) sentinel ──────────────────────────
+        // `Missing` marks an *omitted* positional argument at a call
+        // site (the `DirectCall` emitter pads omitted trailing slots
+        // with `missing()`).  A defaulted param's body-top prologue
+        // tests for it via `is_missing` and substitutes the param's
+        // default expression.  It is an internal sentinel — it should
+        // never be printed or compared by ordinary user code, because
+        // by the time a function body runs past its prologue every
+        // `Missing` has been replaced.  We still give it safe,
+        // defensive arms in `format`/`value_eq` so a leaked sentinel
+        // degrades gracefully instead of panicking (`<missing>`; equal
+        // only to another `Missing`).
+        Missing,
         Sym(Rc<str>),
         Str(Rc<str>),
         Pair(Rc<Pair>),
@@ -83,6 +96,23 @@ pub const RUNTIME: &str = r##"mod __sir {
             t.insert(name.to_string(), s.clone());
             Value::Sym(s)
         })
+    }
+
+    // ── DefaultParams (P2e) sentinel helpers ──────────────────────
+    //
+    // `missing()` constructs the omitted-argument sentinel; the
+    // `DirectCall` emitter appends one per trailing param the caller
+    // left off, so the emitted call is always full-arity.  `is_missing`
+    // is the predicate a defaulted param's prologue uses to decide
+    // whether to evaluate its default.  Both are trivial, but exposing
+    // them as named helpers keeps the emitter's output readable and the
+    // sentinel representation in one place.
+    pub fn missing() -> Value {
+        Value::Missing
+    }
+
+    pub fn is_missing(v: &Value) -> bool {
+        matches!(v, Value::Missing)
     }
 
     // ── global storage ────────────────────────────────────────────
@@ -318,6 +348,11 @@ pub const RUNTIME: &str = r##"mod __sir {
             Value::Bool(true) => "#t".to_string(),
             Value::Bool(false) => "#f".to_string(),
             Value::Nil => "nil".to_string(),
+            // Defensive: a `Missing` sentinel should be consumed by a
+            // defaulted param's prologue before any value is printed, so
+            // this arm is normally unreachable.  Render a visible
+            // placeholder rather than panicking if one ever leaks.
+            Value::Missing => "<missing>".to_string(),
             Value::Sym(s) => s.to_string(),
             Value::Str(s) => s.to_string(),
             Value::Pair(p) => format_pair_d(p, visited),
@@ -658,6 +693,12 @@ pub const RUNTIME: &str = r##"mod __sir {
             (Value::Float(x), Value::Int(y)) => *x == (*y as f64),
             (Value::Bool(x), Value::Bool(y)) => x == y,
             (Value::Nil, Value::Nil) => true,
+            // Defensive: the `Missing` sentinel is internal and should
+            // never reach a user-level comparison (a defaulted param's
+            // prologue replaces it before the body runs).  Give it a
+            // safe arm anyway: a `Missing` is equal only to another
+            // `Missing`, never to `Nil` or any real value.
+            (Value::Missing, Value::Missing) => true,
             (Value::Sym(x), Value::Sym(y)) => x == y,
             (Value::Str(x), Value::Str(y)) => **x == **y,
             (Value::Pair(x), Value::Pair(y)) => {

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_default_params.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_default_params.rs
@@ -1,0 +1,236 @@
+//! End-to-end proof for **DefaultParams** (P2e) in the Rust backend.
+//!
+//! Unit tests assert the *shape* of the emitted source (the body-top
+//! prologue + the padded full-arity call); this test closes the loop:
+//! it hand-builds a SIR module that exercises a default referencing an
+//! *earlier* parameter, emits Rust, compiles it with `rustc`, runs the
+//! binary, and checks stdout.  That proves the missing-sentinel
+//! runtime-mimic strategy actually compiles and behaves with call-time,
+//! param-scope semantics.
+//!
+//! Discriminating program (`f` returns `b`, so the printed value is the
+//! resolved parameter — exposing whether the default actually ran):
+//!
+//! ```text
+//!   f(a, b = a + 1) -> b
+//!   print(f(5))        // b omitted ⇒ default a + 1 = 6   → "6"
+//!   print(f(5, 10))    // b supplied = 10                 → "10"
+//! ```
+//!
+//! `rustc` ships with every Rust toolchain, so this runs in CI.  A
+//! missing `rustc` or linker logs a skip rather than reddening the
+//! build (matching the sibling `compile_and_run_*` tests).
+
+use std::process::Command;
+
+use semantic_ir::{
+    Block, Effect, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module,
+    Param, ParamKind, Scope, Span,
+};
+use semantic_ir_to_rust::compile;
+
+fn s() -> Span {
+    Span::synthetic()
+}
+
+fn ilit(v: i64) -> Expr {
+    Expr::IntLit { value: v, span: s() }
+}
+
+fn param_ref(name: &str) -> Expr {
+    Expr::VarRef { name: name.into(), scope: Scope::Param, span: s() }
+}
+
+/// `(name arg0 arg1 ...)` builtin call, pure.
+fn call(name: &str, args: Vec<Expr>) -> Expr {
+    Expr::BuiltinCall {
+        name: name.into(),
+        args,
+        effects: EffectSet::PURE,
+        span: s(),
+    }
+}
+
+/// `(f arg0 arg1 ...)` direct call.
+fn direct(fn_name: &str, args: Vec<Expr>) -> Expr {
+    Expr::DirectCall {
+        fn_name: fn_name.into(),
+        args,
+        effects: EffectSet::PURE,
+        span: s(),
+    }
+}
+
+/// `print(expr)` as an effectful statement.
+fn print_stmt(expr: Expr) -> semantic_ir::Stmt {
+    semantic_ir::Stmt::ExprStmt {
+        expr: Expr::BuiltinCall {
+            name: "print".into(),
+            args: vec![expr],
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            span: s(),
+        },
+        span: s(),
+    }
+}
+
+/// Build the discriminating module:
+///   f(a, b = a + 1) -> b
+///   main: print(f(5)); print(f(5, 10))
+fn demo_module() -> Module {
+    // b's default = (+ a 1), referencing the EARLIER param `a`.
+    let default_b = call("+", vec![param_ref("a"), ilit(1)]);
+
+    let f = Function {
+        name: "f".into(),
+        params: vec![
+            Param { name: "a".into(), kind: ParamKind::Required, sir_type: None, default: None, span: s() },
+            Param {
+                name: "b".into(),
+                kind: ParamKind::Required,
+                sir_type: None,
+                default: Some(Box::new(default_b)),
+                span: s(),
+            },
+        ],
+        return_type: None,
+        captures: vec![],
+        // f returns b — so the printed value IS the resolved default.
+        body: Block { stmts: vec![], value: param_ref("b"), span: s() },
+        effects: EffectSet::PURE,
+        metadata: Metadata::new(),
+        span: s(),
+    };
+
+    let main = Function {
+        name: "main".into(),
+        params: vec![],
+        return_type: None,
+        captures: vec![],
+        body: Block {
+            stmts: vec![
+                // f(5)      → b defaulted to a + 1 = 6   → "6"
+                print_stmt(direct("f", vec![ilit(5)])),
+                // f(5, 10)  → b supplied = 10            → "10"
+                print_stmt(direct("f", vec![ilit(5), ilit(10)])),
+            ],
+            value: Expr::NilLit { span: s() },
+            span: s(),
+        },
+        effects: EffectSet::PURE.with(Effect::MayPrint),
+        metadata: Metadata::new(),
+        span: s(),
+    };
+
+    Module {
+        name: "default_params_demo".into(),
+        manifest: FeatureManifest::from_features(&[
+            Feature::DynamicTyping,
+            Feature::DefaultParams,
+        ]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![f, main],
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("test")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+fn rustc_available() -> bool {
+    Command::new("rustc")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+#[test]
+fn default_params_compile_and_run() {
+    if !rustc_available() {
+        eprintln!("skipping: rustc not on PATH");
+        return;
+    }
+
+    // 1. Emit.
+    let artifact = compile(&demo_module()).expect("module should compile to Rust source");
+
+    // Sanity: the emitted source carries the prologue + padded call.
+    assert!(
+        artifact.source.contains("let b = if __sir::is_missing(&b)"),
+        "expected default-param prologue in emitted source:\n{}",
+        artifact.source
+    );
+    assert!(
+        artifact.source.contains("f(__sir::Value::Int(5i64), __sir::missing())"),
+        "expected padded full-arity call in emitted source:\n{}",
+        artifact.source
+    );
+
+    // 2. Write the source to a unique temp file.
+    let dir = std::env::temp_dir();
+    let nonce = std::process::id();
+    let src_path = dir.join(format!("sir_defparams_{nonce}.rs"));
+    let bin_path = dir.join(format!(
+        "sir_defparams_{nonce}{}",
+        if cfg!(windows) { ".exe" } else { "" }
+    ));
+    std::fs::write(&src_path, &artifact.source).expect("write temp source");
+
+    // 3. Compile with rustc.  `--edition 2021` is required (raw idents +
+    //    2018+ closure capture).  An absent default linker can be pointed
+    //    at a working one via `SIR_TEST_RUSTC_LINKER` (e.g. `rust-lld`).
+    let mut cmd = Command::new("rustc");
+    cmd.arg("--edition").arg("2021").arg("-O");
+    if let Ok(linker) = std::env::var("SIR_TEST_RUSTC_LINKER") {
+        if !linker.is_empty() {
+            cmd.arg("-C").arg(format!("linker={linker}"));
+        }
+    }
+    let compile_out = cmd
+        .arg(&src_path)
+        .arg("-o")
+        .arg(&bin_path)
+        .output()
+        .expect("invoke rustc");
+    if !compile_out.status.success() {
+        let stderr = String::from_utf8_lossy(&compile_out.stderr);
+        // A missing linker is a host issue, not a codegen defect — skip.
+        if stderr.contains("linker")
+            && (stderr.contains("not found") || stderr.contains("No such file"))
+        {
+            eprintln!("skipping: no usable linker on host\n{stderr}");
+            let _ = std::fs::remove_file(&src_path);
+            return;
+        }
+        panic!(
+            "emitted Rust failed to compile:\n--- stderr ---\n{stderr}\n--- source ---\n{}",
+            artifact.source,
+        );
+    }
+
+    // 4. Run the binary and capture stdout.
+    let run_out = Command::new(&bin_path).output().expect("run compiled binary");
+    assert!(
+        run_out.status.success(),
+        "compiled binary exited non-zero:\n{}",
+        String::from_utf8_lossy(&run_out.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&run_out.stdout);
+    let lines: Vec<&str> = stdout.lines().collect();
+
+    // 5. Assert the program's observable behaviour:
+    //    f(5)     → default b = a + 1 = 6
+    //    f(5, 10) → supplied b = 10
+    assert_eq!(
+        lines,
+        vec!["6", "10"],
+        "unexpected program output; full stdout:\n{stdout}"
+    );
+
+    // 6. Best-effort cleanup.
+    let _ = std::fs::remove_file(&src_path);
+    let _ = std::fs::remove_file(&bin_path);
+}


### PR DESCRIPTION
Backend default-param emission for `semantic-ir-to-rust` — the **last of the 5 backends**, completing default-param support across the whole stack. Rust has no native default params, so **runtime-mimic** per the full-syntax mandate:

- Runtime value model gains `Value::Missing` + `__sir::missing()` + `__sir::is_missing(&Value)`. Defensive arms: `format`→`<missing>`, `value_eq`→Missing-equals-only-Missing; a leaked Missing in arithmetic fails fast (`as_i64`/`as_f64` panic) rather than producing wrong output.
- Functions take all params (fixed arity); a body **prologue** resolves each defaulted param at call time in param scope: `let b = if __sir::is_missing(&b) { <default expr> } else { b };`.
- `DirectCall` **pads** omitted trailing positions with `__sir::missing()` (pad count from the existing FN_ARITY table, `saturating_sub`; DirectCall-to-known-function only). IndirectCall unchanged.

Emitted shape:
```rust
let b = if __sir::is_missing(&b) { __sir::plus(vec![a.clone(), __sir::Value::Int(1i64)]) } else { b };
// f(5): f(__sir::Value::Int(5i64), __sir::missing())
```

**Tests:** 68 unit + 5 rustc compile-and-run integration (new `compile_and_run_default_params` executed real emitted Rust → `f(5)`→`6`, `f(5,10)`→`10`; existing cyclic/floats/loops/seq_maps byte-identical). clippy clean; security review passed (Value::Missing keeps matches exhaustive; no silent-wrong-result; padding correct). Isolated to `semantic-ir-to-rust`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)