### PR TITLE
Add smart home dashboard scene filters

### DIFF
--- a/code/packages/rust/smart-home-platform-http/CHANGELOG.md
+++ b/code/packages/rust/smart-home-platform-http/CHANGELOG.md
@@ -40,6 +40,8 @@ All notable changes to this package will be documented in this file.
   embedded dashboard shell is served over the repo TCP stack as it grows.
 - Added URL-backed browser dashboard service-catalog controls for service name,
   capability, target entity, and target scene filters.
+- Added URL-backed browser dashboard scene-catalog controls for scene scope and
+  target entity filters.
 - Added browser dashboard desired-state target controls for light on/off and
   brightness so the local controller can supervise intended state through the
   existing runtime-authorized native API.

--- a/code/packages/rust/smart-home-platform-http/README.md
+++ b/code/packages/rust/smart-home-platform-http/README.md
@@ -121,7 +121,7 @@ owning bridge command-result audit trail. The browser shell also exposes
 filters for room, entity domain/state/control status, device
 bridge/manufacturer/health, bridge integration/transport/health, capability
 catalog capability/commandability/observability, desired-state
-entity/requester/capability, service catalog
+entity/requester/capability, scene catalog scope/entity, service catalog
 service/capability/target-entity/target-scene, API catalog
 surface/method/category/mutation/authorization, runtime event kind/activity
 entity, history event type, history bridge and observed/received time windows,
@@ -130,12 +130,13 @@ windows, command-result sequence windows, authorization outcome/principal, and
 capability-grant status/scope/principal,
 with server-backed room and topology scoping across inventory, state, history,
 event-log, and command-result panels plus server-backed capability catalog,
-desired-state supervision, service catalog, activity/history, command audit,
-authorization, and capability-grant scoping and local text search across the
-rendered dashboard rows. Those filter selections are mirrored into URL query
-parameters and restored on page load or browser navigation, so local-controller
-room, topology, capability, desired-state, service, activity, history, audit, and
-grant-boundary views can be shared or reopened directly.
+desired-state supervision, scene catalog, service catalog, activity/history,
+command audit, authorization, and capability-grant scoping and local text
+search across the rendered dashboard rows. Those filter selections are mirrored
+into URL query parameters and restored on page load or browser navigation, so
+local-controller room, topology, capability, desired-state, scene, service,
+activity, history, audit, and grant-boundary views can be shared or reopened
+directly.
 State-history routes also accept numeric observed-time windows through
 `from_ms`/`to_ms` or
 `observed_at_or_after_ms`/`observed_at_or_before_ms` on

--- a/code/packages/rust/smart-home-platform-http/src/lib.rs
+++ b/code/packages/rust/smart-home-platform-http/src/lib.rs
@@ -453,6 +453,19 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
               <option value="unknown">Unknown</option>
             </select>
           </label>
+          <label>Scene Scope
+            <select id="filter-scene-scope" data-dashboard-filter="scene-scope">
+              <option value="">All scene scopes</option>
+              <option value="room">Room</option>
+              <option value="zone">Zone</option>
+              <option value="home">Home</option>
+              <option value="bridge">Bridge</option>
+              <option value="custom">Custom</option>
+            </select>
+          </label>
+          <label>Scene Entity
+            <input id="filter-scene-entity" data-dashboard-filter="scene-entity" type="search" autocomplete="off">
+          </label>
           <label>Service Name
             <input id="filter-service-name" data-dashboard-filter="service-name" type="search" autocomplete="off">
           </label>
@@ -776,6 +789,8 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
       filterHistoryToMs: document.querySelector("#filter-history-to-ms"),
       filterHistoryType: document.querySelector("#filter-history-type"),
       filterRoom: document.querySelector("#filter-room"),
+      filterSceneEntity: document.querySelector("#filter-scene-entity"),
+      filterSceneScope: document.querySelector("#filter-scene-scope"),
       filterSearch: document.querySelector("#filter-search"),
       filterServiceCapability: document.querySelector("#filter-service-capability"),
       filterServiceEntity: document.querySelector("#filter-service-entity"),
@@ -823,6 +838,8 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
       ["bridge_integration", els.filterBridgeIntegration],
       ["bridge_transport", els.filterBridgeTransport],
       ["bridge_health", els.filterBridgeHealth],
+      ["scene_scope", els.filterSceneScope],
+      ["scene_entity", els.filterSceneEntity],
       ["service_name", els.filterServiceName],
       ["service_capability", els.filterServiceCapability],
       ["service_entity", els.filterServiceEntity],
@@ -909,6 +926,8 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
       bridgeIntegration: els.filterBridgeIntegration.value.trim(),
       bridgeTransport: els.filterBridgeTransport.value,
       bridgeHealth: els.filterBridgeHealth.value,
+      sceneScope: els.filterSceneScope.value,
+      sceneEntity: els.filterSceneEntity.value.trim(),
       serviceName: els.filterServiceName.value.trim(),
       serviceCapability: els.filterServiceCapability.value.trim(),
       serviceEntity: els.filterServiceEntity.value.trim(),
@@ -1462,7 +1481,12 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
           json("/api/smart_home/readiness"),
           json(queryUrl("/api/smart_home/states", {limit: 24, domain: filters.domain, room_id: roomId, stale, capability_id: capabilityId})),
           json(queryUrl("/api/smart_home/states", {limit: 24, room_id: roomId, stale: true, capability_id: capabilityId})),
-          json(queryUrl("/api/smart_home/scenes", {limit: 12, room_id: roomId})),
+          json(queryUrl("/api/smart_home/scenes", {
+            limit: 12,
+            room_id: roomId,
+            scope: filters.sceneScope,
+            entity_id: filters.sceneEntity
+          })),
           json(queryUrl("/api/smart_home/desired_states", {
             limit: 12,
             entity_id: filters.desiredEntity,
@@ -8337,6 +8361,8 @@ mod tests {
             assert!(body.contains("data-dashboard-filter=\"bridge-integration\""));
             assert!(body.contains("data-dashboard-filter=\"bridge-transport\""));
             assert!(body.contains("data-dashboard-filter=\"bridge-health\""));
+            assert!(body.contains("data-dashboard-filter=\"scene-scope\""));
+            assert!(body.contains("data-dashboard-filter=\"scene-entity\""));
             assert!(body.contains("data-dashboard-filter=\"service-name\""));
             assert!(body.contains("data-dashboard-filter=\"service-capability\""));
             assert!(body.contains("data-dashboard-filter=\"service-entity\""));
@@ -8375,6 +8401,8 @@ mod tests {
             assert!(body.contains("[\"bridge_integration\", els.filterBridgeIntegration]"));
             assert!(body.contains("[\"bridge_transport\", els.filterBridgeTransport]"));
             assert!(body.contains("[\"bridge_health\", els.filterBridgeHealth]"));
+            assert!(body.contains("[\"scene_scope\", els.filterSceneScope]"));
+            assert!(body.contains("[\"scene_entity\", els.filterSceneEntity]"));
             assert!(body.contains("[\"service_name\", els.filterServiceName]"));
             assert!(body.contains("[\"service_capability\", els.filterServiceCapability]"));
             assert!(body.contains("[\"service_entity\", els.filterServiceEntity]"));
@@ -8402,9 +8430,10 @@ mod tests {
             assert!(body.contains(
                 "queryUrl(\"/api/smart_home/states\", {limit: 24, room_id: roomId, stale: true, capability_id: capabilityId})"
             ));
-            assert!(
-                body.contains("queryUrl(\"/api/smart_home/scenes\", {limit: 12, room_id: roomId})")
-            );
+            assert!(body.contains("queryUrl(\"/api/smart_home/scenes\", {"));
+            assert!(body.contains("room_id: roomId"));
+            assert!(body.contains("scope: filters.sceneScope"));
+            assert!(body.contains("entity_id: filters.sceneEntity"));
             assert!(body.contains("queryUrl(\"/api/smart_home/desired_states\", {"));
             assert!(body.contains("entity_id: filters.desiredEntity"));
             assert!(body.contains("capability_id: capabilityId"));
@@ -9937,6 +9966,8 @@ mod tests {
         assert!(body.contains("data-dashboard-filter=\"bridge-integration\""));
         assert!(body.contains("data-dashboard-filter=\"bridge-transport\""));
         assert!(body.contains("data-dashboard-filter=\"bridge-health\""));
+        assert!(body.contains("data-dashboard-filter=\"scene-scope\""));
+        assert!(body.contains("data-dashboard-filter=\"scene-entity\""));
         assert!(body.contains("data-dashboard-filter=\"service-name\""));
         assert!(body.contains("data-dashboard-filter=\"service-capability\""));
         assert!(body.contains("data-dashboard-filter=\"service-entity\""));
@@ -9981,6 +10012,8 @@ mod tests {
         assert!(body.contains("[\"bridge_integration\", els.filterBridgeIntegration]"));
         assert!(body.contains("[\"bridge_transport\", els.filterBridgeTransport]"));
         assert!(body.contains("[\"bridge_health\", els.filterBridgeHealth]"));
+        assert!(body.contains("[\"scene_scope\", els.filterSceneScope]"));
+        assert!(body.contains("[\"scene_entity\", els.filterSceneEntity]"));
         assert!(body.contains("[\"service_name\", els.filterServiceName]"));
         assert!(body.contains("[\"service_capability\", els.filterServiceCapability]"));
         assert!(body.contains("[\"service_entity\", els.filterServiceEntity]"));
@@ -10003,7 +10036,10 @@ mod tests {
         assert!(body.contains("[\"grant_status\", els.filterGrantStatus]"));
         assert!(body.contains("window.addEventListener(\"popstate\""));
         assert!(body.contains("window.history.replaceState(null, \"\", nextUrl)"));
-        assert!(body.contains("queryUrl(\"/api/smart_home/scenes\", {limit: 12, room_id: roomId})"));
+        assert!(body.contains("queryUrl(\"/api/smart_home/scenes\", {"));
+        assert!(body.contains("room_id: roomId"));
+        assert!(body.contains("scope: filters.sceneScope"));
+        assert!(body.contains("entity_id: filters.sceneEntity"));
         assert!(body.contains("queryUrl(\"/api/smart_home/desired_states\", {"));
         assert!(body.contains("entity_id: filters.desiredEntity"));
         assert!(body.contains("capability_id: capabilityId"));


### PR DESCRIPTION
## Summary
- add URL-backed Scene Scope and Scene Entity dashboard controls
- scope the scene panel through /api/smart_home/scenes using room_id, scope, and entity_id
- update dashboard smoke assertions plus README/CHANGELOG documentation

## Validation
- cargo fmt -p smart-home-platform-http
- cargo test -p smart-home-platform-http -- --nocapture
- sh BUILD
- git diff --check
- confirmed code/packages/rust/Cargo.lock is absent