### PR TITLE
[codex] Track tricky formatting repair evidence

### DIFF
--- a/code/packages/rust/html-parser/tests/whatwg_formatting_audit_test.rs
+++ b/code/packages/rust/html-parser/tests/whatwg_formatting_audit_test.rs
@@ -11,6 +11,7 @@ const POST_PARSE_REPAIR_EVIDENCE: &[(&str, &str)] = &[
     ("scripted-ark-dat-1", "adoption-agency-formatting"),
     ("tricky01-dat-1", "adoption-agency-formatting"),
     ("tricky01-dat-3", "adoption-agency-formatting"),
+    ("tricky01-dat-7", "interactive-formatting-boundary"),
     ("tricky01-dat-8", "interactive-formatting-boundary"),
     ("tricky01-dat-9", "interactive-formatting-boundary"),
     ("tests26-dat-1251", "interactive-formatting-boundary"),


### PR DESCRIPTION
## Summary
- add `tricky01-dat-7` to the WHATWG formatting post-parse repair evidence list
- pin it to the existing `interactive-formatting-boundary` audit axis so the parser DOM dump remains executable evidence

## Validation
- cargo test -p coding-adventures-html-parser font_newline_before_bold_stays_outside_reconstructed_font
- cargo test -p coding-adventures-html-parser whatwg_*_audit_tracks_post_parse_repair_evidence filters listed in the monitor
- cargo test -p coding-adventures-html-parser whatwg_*_audit_cases_match_parser_dom_dump filters listed in the monitor
- cargo test -p coding-adventures-html-parser html5lib_tree_construction_smoke_cases_match_dom_dump
- cargo test -p coding-adventures-html-parser
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser
- python3 -m json.tool code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json >/dev/null
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py
- git diff --check