### PR TITLE
feat(math-frontend,mathml): neutral Sequence node + <mfenced> comma lists

### DIFF
--- a/code/packages/rust/math-frontend/CHANGELOG.md
+++ b/code/packages/rust/math-frontend/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to the pluggable parser-frontend framework.
 
+## [0.6.0] — 2026-06-30
+
+### Added — neutral `Sequence` node (comma-separated lists in fences)
+
+Comma-separated sequences in fence contexts (`(a, b, c)` — MathML `<mfenced>` with
+separators, coordinate tuples, argument lists) previously had **no faithful neutral
+representation**: a frontend had to drop the commas or model the list as implicit
+multiplication. This release adds the node so any frontend can lower a list honestly.
+**Additive**; no existing variant or API changed — the same shape as the `Overset` node in
+0.5.0.
+
+- **`MathExpr::Sequence(Vec<MathExpr>)`** — an ordered list of expressions separated by
+  commas. The items are preserved in source order; a faithful renderer shows them as a
+  delimited list, not a product. Kept **distinct from nested `Bin(Mul, …)`**: juxtaposition
+  is implicit multiplication, while a sequence is a deliberate list structure. An empty
+  sequence is not representable (a fence with no items is not a list).
+- `Capabilities` gains **`sequences`** (set by `all()`, with a `with_sequences()` builder)
+  and the conformance harness now polices it: a frontend that emits a `Sequence` but does
+  not declare `sequences` is flagged, exactly as for every other node-bearing capability.
+- The iterative `impl Drop for MathExpr` (heap worklist) gains an arm for the new node, so a
+  deep `Sequence` spine frees in O(1) stack depth — a 300 000-deep nesting drops in a test
+  without overflow.
+- Downstream unaffected: `latex`, `asciimath`, and the `adj-lang` adapter all build unchanged
+  (frontends only *construct* `MathExpr`). The `mathml` crate consumes the node in the same
+  release to emit comma-separated `<mfenced>` lists.
+
 ## [0.5.0] — 2026-06-29
 
 ### Added — neutral `Overset` / `Underset` nodes (unblock stacked annotations on every frontend)

--- a/code/packages/rust/math-frontend/Cargo.toml
+++ b/code/packages/rust/math-frontend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "math-frontend"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "A pluggable parser-frontend framework: a neutral math AST (MathExpr), a MathFrontend trait + registry, and a shared conformance harness. Notation parsers (LaTeX, AsciiMath, MathML, …) implement the trait so any consumer lowers ONE neutral tree."
 license = "MIT"

--- a/code/packages/rust/math-frontend/src/conformance.rs
+++ b/code/packages/rust/math-frontend/src/conformance.rs
@@ -94,7 +94,7 @@ pub fn check_frontend(frontend: &dyn MathFrontend, samples: &[&str]) -> Conforma
 /// Names of capabilities that `used` requires but `declared` did not advertise.
 fn over_emitted(used: Capabilities, declared: Capabilities) -> Vec<&'static str> {
     let mut v = Vec::new();
-    let pairs: [(&str, bool, bool); 13] = [
+    let pairs: [(&str, bool, bool); 14] = [
         ("fractions", used.fractions, declared.fractions),
         ("roots", used.roots, declared.roots),
         ("powers", used.powers, declared.powers),
@@ -108,6 +108,7 @@ fn over_emitted(used: Capabilities, declared: Capabilities) -> Vec<&'static str>
         ("binomials", used.binomials, declared.binomials),
         ("accents", used.accents, declared.accents),
         ("oversets", used.oversets, declared.oversets),
+        ("sequences", used.sequences, declared.sequences),
     ];
     for (label, used_it, declared_it) in pairs {
         if used_it && !declared_it {
@@ -197,6 +198,12 @@ fn collect_used(e: &MathExpr, caps: &mut Capabilities) {
             caps.oversets = true;
             collect_used(a, caps);
             collect_used(b, caps);
+        }
+        MathExpr::Sequence(items) => {
+            caps.sequences = true;
+            for item in items {
+                collect_used(item, caps);
+            }
         }
     }
 }
@@ -339,6 +346,44 @@ mod tests {
             fn capabilities(&self) -> Capabilities { Capabilities::none().with_oversets() }
         }
         assert!(check_frontend(&OversetHonest, &["over", "under"]).passed());
+    }
+
+    #[test]
+    fn emitting_sequence_without_declaring_is_flagged() {
+        // A frontend that emits a `Sequence` but declares `none()` must be flagged for the
+        // `sequences` capability — the gate polices the new node too.
+        struct SequenceOverClaimer;
+        impl MathFrontend for SequenceOverClaimer {
+            fn name(&self) -> &str { "sequence" }
+            fn parse(&self, _src: &str) -> Result<MathExpr, FrontendError> {
+                Ok(MathExpr::Sequence(vec![
+                    MathExpr::Symbol("a".into()),
+                    MathExpr::Symbol("b".into()),
+                ]))
+            }
+            fn capabilities(&self) -> Capabilities { Capabilities::none() }
+        }
+        let r = check_frontend(&SequenceOverClaimer, &["a,b"]);
+        assert!(!r.passed());
+        assert!(r.issues.iter().any(|i| i.contains("sequences")));
+    }
+
+    #[test]
+    fn declaring_sequences_admits_sequence() {
+        // Declaring `with_sequences()` makes emitting a Sequence conforming.
+        struct SequenceHonest;
+        impl MathFrontend for SequenceHonest {
+            fn name(&self) -> &str { "sequence-honest" }
+            fn parse(&self, _src: &str) -> Result<MathExpr, FrontendError> {
+                Ok(MathExpr::Sequence(vec![
+                    MathExpr::Symbol("a".into()),
+                    MathExpr::Symbol("b".into()),
+                    MathExpr::Symbol("c".into()),
+                ]))
+            }
+            fn capabilities(&self) -> Capabilities { Capabilities::none().with_sequences() }
+        }
+        assert!(check_frontend(&SequenceHonest, &["a,b,c"]).passed());
     }
 
     #[test]

--- a/code/packages/rust/math-frontend/src/expr.rs
+++ b/code/packages/rust/math-frontend/src/expr.rs
@@ -275,6 +275,13 @@ pub enum MathExpr {
     /// `underset(a)(b)` (AsciiMath). The under-the-base twin of [`MathExpr::Overset`] —
     /// distinct from `Subscript` for the same centered-vs-lowered reason.
     Underset { under: Box<MathExpr>, base: Box<MathExpr> },
+    /// An ordered, comma-separated sequence of expressions: the items of a fenced list
+    /// `(a, b, c)` (MathML `<mfenced>` with separators), a coordinate tuple, a function's
+    /// argument list. Kept DISTINCT from nested `Bin(Mul, …)` (implicit multiplication):
+    /// the commas are *list separators*, not an operation, so a faithful renderer must show
+    /// the items as a delimited list, not a product. The items appear in source order; an
+    /// empty sequence is not representable (a fence with no items is not a list).
+    Sequence(Vec<MathExpr>),
 }
 
 /// Drop a `MathExpr` **iteratively** so freeing a deeply-nested tree cannot overflow the
@@ -348,6 +355,9 @@ fn take_children(e: &mut MathExpr, out: &mut Vec<MathExpr>) {
                 out.extend(row);
             }
         }
+        MathExpr::Sequence(items) => {
+            out.extend(std::mem::take(items));
+        }
     }
 }
 
@@ -408,6 +418,27 @@ mod tests {
             } else {
                 MathExpr::Underset { under: s("g"), base: Box::new(e) }
             };
+        }
+        drop(e);
+    }
+
+    #[test]
+    fn sequence_is_constructible_distinct_and_drops_deep() {
+        let s = |n: &str| MathExpr::Symbol(n.to_string());
+        let seq = MathExpr::Sequence(vec![s("a"), s("b"), s("c")]);
+        // Equal to itself; it is an ORDERED list, so order and length both matter.
+        assert_eq!(seq, MathExpr::Sequence(vec![s("a"), s("b"), s("c")]));
+        assert_ne!(seq, MathExpr::Sequence(vec![s("a"), s("b")]));
+        assert_ne!(seq, MathExpr::Sequence(vec![s("c"), s("b"), s("a")]));
+        // Distinct from implicit-mul juxtaposition of the same operands (commas ≠ product).
+        assert_ne!(
+            MathExpr::Sequence(vec![s("a"), s("b")]),
+            MathExpr::Bin(BinOp::Mul, Box::new(s("a")), Box::new(s("b")))
+        );
+        // A deep Sequence spine must free via the iterative Drop, not recurse.
+        let mut e = MathExpr::Symbol("x".to_string());
+        for _ in 0..300_000 {
+            e = MathExpr::Sequence(vec![e, MathExpr::Symbol("y".to_string())]);
         }
         drop(e);
     }

--- a/code/packages/rust/math-frontend/src/frontend.rs
+++ b/code/packages/rust/math-frontend/src/frontend.rs
@@ -69,6 +69,8 @@ pub struct Capabilities {
     /// Emits over/under-set annotations ([`crate::MathExpr::Overset`] / [`crate::MathExpr::Underset`]:
     /// `\overset{a}{b}`, `\stackrel{a}{R}`, `\underset{a}{b}`).
     pub oversets: bool,
+    /// Emits comma-separated sequences ([`crate::MathExpr::Sequence`]: fenced lists `(a, b, c)`).
+    pub sequences: bool,
 }
 
 impl Capabilities {
@@ -94,6 +96,7 @@ impl Capabilities {
             binomials: true,
             accents: true,
             oversets: true,
+            sequences: true,
         }
     }
 
@@ -110,6 +113,7 @@ impl Capabilities {
     pub fn with_binomials(mut self) -> Self { self.binomials = true; self }
     pub fn with_accents(mut self) -> Self { self.accents = true; self }
     pub fn with_oversets(mut self) -> Self { self.oversets = true; self }
+    pub fn with_sequences(mut self) -> Self { self.sequences = true; self }
 }
 
 /// The contract every notation parser implements.

--- a/code/packages/rust/mathml/CHANGELOG.md
+++ b/code/packages/rust/mathml/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to the Presentation-MathML frontend crate.
 
+## [0.4.0] — 2026-06-30
+
+### Added — PR-4: comma-separated `<mfenced>` lists lower to `Sequence`
+
+- **`<mfenced>` with comma separators → `MathExpr::Sequence`.** A fence containing one or
+  more top-level `<mo>,</mo>` separators (e.g. `(a, b, c)`) now emits `Sequence([a, b, c])`,
+  preserving the list structure instead of folding the commas into a single row. Each
+  segment between commas is itself folded to one expression (so an item may be compound, e.g.
+  `(x+1, 2)`). The fence's `open`/`close`/`separators` attributes remain presentation and are
+  dropped, as before.
+- **A fence with NO commas is unchanged** — it still lowers to `Group` (an ordinary
+  parenthesised sub-expression). An empty segment (leading/trailing/doubled comma) is
+  malformed and reported as `empty MathML group`, so no list item is silently dropped.
+- **Capabilities** add `sequences` (requires `math-frontend` 0.6.0), kept honest by
+  `check_frontend` — the conformance corpus now includes a comma-separated `<mfenced>`.
+- Tests: comma-separated sequence, compound items in a sequence, two-item pair, plus the
+  retained no-comma → `Group` case.
+
+### Deferred to a later PR
+Semicolon separators and surfacing the fence's `open`/`close` delimiters as data.
+
 ## [0.3.0] — 2026-06-30
 
 ### Added — PR-3: named-function recognition (`<mi>sin</mi>` → `Call`)

--- a/code/packages/rust/mathml/Cargo.toml
+++ b/code/packages/rust/mathml/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mathml"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "A Presentation-MathML reader that implements the math-frontend MathFrontend trait: turns <math>…</math> (mn/mi/mo/mrow/mfrac/msup/msub/msqrt/mroot/mtext/mtable/mover/munder/mfenced + named functions) into the neutral MathExpr AST. The fourth pluggable frontend after LaTeX and AsciiMath (see PFE01). Total, panic-free, spanned errors."
 license = "MIT"

--- a/code/packages/rust/mathml/src/lib.rs
+++ b/code/packages/rust/mathml/src/lib.rs
@@ -69,8 +69,9 @@ impl MathFrontend for MathMl {
         // `Pow`), relations (`<mo>=`/`<` …), implicit multiplication (adjacent operands in a row),
         // text (`<mtext>`), and ± / ∓ (`<mo>±`). Subscripts are core (not a capability flag).
         // PR-2 adds matrices (`<mtable>`) and over/under-sets (`<mover>`/`<munder>`/`<munderover>`);
-        // `<mfenced>` lowers to `Group` (core). PR-3 adds named-function recognition (`<mi>sin</mi>`
-        // applied to an argument → `Call`).
+        // a plain `<mfenced>` lowers to `Group` (core). PR-3 adds named-function recognition
+        // (`<mi>sin</mi>` applied to an argument → `Call`). PR-4 adds sequences: an `<mfenced>` with
+        // comma separators (`(a, b, c)`) lowers to `Sequence` instead of folding the commas away.
         Capabilities::none()
             .with_fractions()
             .with_roots()
@@ -82,6 +83,7 @@ impl MathFrontend for MathMl {
             .with_matrices()
             .with_oversets()
             .with_functions()
+            .with_sequences()
     }
 }
 
@@ -345,10 +347,35 @@ mod tests {
     }
 
     #[test]
-    fn mfenced_lowers_to_group() {
+    fn mfenced_without_commas_lowers_to_group() {
+        // A fence with no comma separators is an ordinary parenthesised sub-expression:
         // <mfenced><mrow>x + 1</mrow></mfenced> → Group(Add(x,1)).
         let e = p("<mfenced><mrow><mi>x</mi><mo>+</mo><mn>1</mn></mrow></mfenced>");
         assert_eq!(e, MathExpr::Group(Box::new(b(BinOp::Add, sym("x"), num(1)))));
+    }
+
+    #[test]
+    fn mfenced_comma_separated_becomes_sequence() {
+        // A fence with comma separators is a LIST: <mfenced>a, b, c</mfenced> → Sequence([a,b,c]).
+        let e = p("<mfenced><mi>a</mi><mo>,</mo><mi>b</mi><mo>,</mo><mi>c</mi></mfenced>");
+        assert_eq!(e, MathExpr::Sequence(vec![sym("a"), sym("b"), sym("c")]));
+    }
+
+    #[test]
+    fn mfenced_sequence_items_are_each_folded() {
+        // Each item between commas is itself folded to one expression, not just a leaf.
+        let e = p("<mfenced><mrow><mi>x</mi><mo>+</mo><mn>1</mn></mrow><mo>,</mo><mn>2</mn></mfenced>");
+        assert_eq!(
+            e,
+            MathExpr::Sequence(vec![b(BinOp::Add, sym("x"), num(1)), num(2)])
+        );
+    }
+
+    #[test]
+    fn mfenced_pair_is_a_two_item_sequence() {
+        // The common coordinate-pair case `(a, b)` → Sequence([a, b]).
+        let e = p("<mfenced><mi>a</mi><mo>,</mo><mi>b</mi></mfenced>");
+        assert_eq!(e, MathExpr::Sequence(vec![sym("a"), sym("b")]));
     }
 
     #[test]
@@ -481,6 +508,7 @@ mod tests {
             "<munder><mi>lim</mi><mi>n</mi></munder>",
             "<mtable><mtr><mtd><mn>1</mn></mtd><mtd><mn>2</mn></mtd></mtr></mtable>",
             "<mfenced><mrow><mi>x</mi><mo>+</mo><mn>1</mn></mrow></mfenced>",
+            "<mfenced><mi>a</mi><mo>,</mo><mi>b</mi></mfenced>",
             "<math><mi>sin</mi><mi>x</mi></math>",
         ];
         let report = check_frontend(&MathMl, &samples);

--- a/code/packages/rust/mathml/src/parser.rs
+++ b/code/packages/rust/mathml/src/parser.rs
@@ -462,13 +462,35 @@ impl Parser {
                 let overset = MathExpr::Overset { over: Box::new(over), base: Box::new(base) };
                 Ok(Child::Expr(MathExpr::Underset { under: Box::new(under), base: Box::new(overset) }))
             }
-            // `<mfenced>…</mfenced>` — a parenthesised group. We model the fence as a `Group` over
-            // the folded contents (its `open`/`close`/`separators` attributes are presentation,
-            // dropped like all attributes); a comma-separated list folds as one row (PR-2 limit).
+            // `<mfenced>…</mfenced>` — a fence. With NO comma separators it is an ordinary
+            // parenthesised group (a sub-expression) and folds to a `Group`, as before. With one
+            // or more top-level `<mo>,</mo>` separators it is a LIST — `(a, b, c)` → `Sequence([a,
+            // b, c])` — so the commas are preserved as list structure rather than folded into the
+            // row (the previous PR-2 limit). Each segment between commas is itself folded to one
+            // expression. The fence's `open`/`close`/`separators` attributes are presentation,
+            // dropped like all attributes.
             "mfenced" => {
                 let kids = self.parse_row_children(name, depth)?;
-                let inner = fold_row(kids, span, depth)?;
-                Ok(Child::Expr(MathExpr::Group(Box::new(inner))))
+                let has_comma = kids.iter().any(|c| matches!(c, Child::Op(s) if s == ","));
+                if !has_comma {
+                    let inner = fold_row(kids, span, depth)?;
+                    return Ok(Child::Expr(MathExpr::Group(Box::new(inner))));
+                }
+                let mut items: Vec<MathExpr> = Vec::new();
+                let mut current: Vec<Child> = Vec::new();
+                for child in kids {
+                    match child {
+                        Child::Op(ref s) if s == "," => {
+                            // End of one list item: fold the accumulated children. An empty
+                            // segment (a leading/trailing/doubled comma) is malformed — fold_row
+                            // reports "empty MathML group", so no item is silently dropped.
+                            items.push(fold_row(std::mem::take(&mut current), span, depth)?);
+                        }
+                        _ => current.push(child),
+                    }
+                }
+                items.push(fold_row(current, span, depth)?);
+                Ok(Child::Expr(MathExpr::Sequence(items)))
             }
             // `<mtable>` of `<mtr>` rows of `<mtd>` cells → MathExpr::Matrix (delimiter style is
             // not part of MathML's mtable, so nothing to drop). Parsed structurally below.

--- a/code/specs/PFE01-pluggable-parser-frontends.md
+++ b/code/specs/PFE01-pluggable-parser-frontends.md
@@ -55,6 +55,9 @@ pub enum MathExpr {
     Underset { under: Box<MathExpr>, base: Box<MathExpr> }, //   a full expr stacked over/under a
                                                 //   base — generalises Accent; distinct from
                                                 //   Pow/Subscript (centered, not raised/lowered)
+    Sequence(Vec<MathExpr>),                    // (a, b, c): an ordered comma-separated list —
+                                                //   <mfenced> separators, tuples, arg lists;
+                                                //   distinct from Bin(Mul,…) (commas ≠ product)
 }
 ```
 
@@ -161,7 +164,9 @@ frontend additionally ships notation-specific golden tests.
   `Overset`/`Underset` (an `<mo>` annotation in over/under position is read as a mark symbol), and
   `<mfenced>` → `Group`. PR-3 adds named-function recognition: an `<mi>` whose name is a known
   function (sin/cos/ln/…) applied to an argument → `Call`, matching the other frontends' `Func` set.
-  `<mfenced>` separator modelling (a `(a, b)` list) is PR-4 — it needs a neutral list node.
+  PR-4 adds `<mfenced>` separator modelling: a fence with comma separators (`(a, b, c)`) lowers to
+  the new neutral `Sequence` list node (math-frontend 0.6.0), while a comma-free fence still lowers
+  to `Group`. Semicolon separators and surfacing the `open`/`close` delimiters as data are deferred.
 - Future: MathJSON, content-MathML, spreadsheet formulae, … each a small crate implementing the
   trait. None require changes to consumers. **Four frontends now in (LaTeX, AsciiMath, Unicode,
   MathML), all feeding one neutral AST with zero consumer change** — the pluggability claim is


### PR DESCRIPTION
## Summary

Adds a neutral **`MathExpr::Sequence(Vec<MathExpr>)`** node to `math-frontend` (0.6.0) and wires the `mathml` frontend (0.4.0) to emit it for **comma-separated `<mfenced>` lists** — `(a, b, c)` → `Sequence([a, b, c])`. This completes the MathML frontend's fenced-list handling (PFE01 PR-4).

It mirrors the additive `Overset`-node addition (#6974) exactly: **node + iterative-Drop arm + Capabilities flag + builder + conformance arm**. No existing variant or API changed; **no consumer change**.

## Why a neutral list node

A comma-separated fence is a *list*, not a product. Before this, a frontend had to drop the commas or model the list as implicit multiplication — neither faithful. `Sequence` lets any frontend lower a list honestly, kept **distinct from nested `Bin(Mul, …)`**.

## math-frontend (0.5.0 → 0.6.0)
- **`MathExpr::Sequence(Vec<MathExpr>)`** — an ordered comma-separated list. Items preserved in source order; an empty sequence is not representable.
- `Capabilities` gains **`sequences`** (set by `all()`, `with_sequences()` builder); the conformance harness polices it — emitting a `Sequence` without declaring it is flagged.
- The iterative (heap-worklist) `impl Drop for MathExpr` gains a `Sequence` arm, so a deep spine frees in O(1) stack depth — a **300 000-deep** nesting drops in a test without overflow.

## mathml (0.3.0 → 0.4.0)
- **`<mfenced>` with comma `<mo>,</mo>` separators → `Sequence`** (each segment between commas is itself folded to one expression, so an item may be compound like `x+1`).
- **A comma-free fence is unchanged** — still lowers to `Group` (an ordinary parenthesised sub-expression). An empty segment (leading/trailing/doubled comma) is a spanned `empty MathML group` error, so **no list item is silently dropped**.
- `.with_sequences()` capability; 4 tests + a conformance-corpus sample.

## Verification
- `cargo test -p math-frontend` (34) and `-p mathml` (44) green; `cargo clippy` clean on both with `-D warnings`.
- All math-frontend consumers — **latex, asciimath, unicode-math, adj-lang** — build & test unchanged (additive variant, no exhaustive-match breakage).
- PFE01 spec + both CHANGELOGs updated.
- `/security-review` **PASSED** (diff reviewed inline; focus on the comma-splitting loop's panic/DoS surface, the new Drop arm's stack-safety, and unwrap/index hazards — none found).

🤖 Generated with [Claude Code](https://claude.com/claude-code)