### PR TITLE
feat(python-sir): produce default parameters — def f(a=1) (P8)

### DIFF
--- a/code/packages/rust/python-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/python-to-semantic-ir/CHANGELOG.md
@@ -5,6 +5,58 @@ All notable changes to `python-to-semantic-ir` are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to semantic versioning.
 
+## 0.6.0 — 2026-06-30
+
+**P8**: produce **default parameters** — `def f(a=1)` now lowers to
+`Param { default: Some(<lowered default expr>) }`.  The core IR and all
+five backends gained `Param.default` support on `main`; this wires the
+Python frontend through to emit it.
+
+### Added
+
+- **Positional default parameters** `def f(a, b=10)` → the defaulted
+  parameter's `param_with_default` CST node (`[NAME, EQUALS, expression]`)
+  has its `expression` lowered into `Param { default: Some(Box::new(..)) }`.
+  Plain parameters keep `default: None`.  The default is lowered via the
+  existing `MAX_EXPR_DEPTH`-bounded expression walk, so a pathologically
+  deep default fails with a clean positioned error rather than overflowing
+  the stack.
+- **`Feature::DefaultParams`** is declared in the manifest whenever a
+  lowered function carries at least one defaulted parameter — matching what
+  the validator observes from `Param.default = Some(_)`.
+- **Partial calls** — a call that omits a defaulted argument, e.g.
+  `f(5)`, lowers to a *partial* `DirectCall` carrying only the arguments
+  actually present (the frontend never pads in defaults).  The validator
+  permits this because the omitted parameters have defaults.
+- Free-variable analysis now visits default expressions against the
+  **enclosing** scope, so an enclosing-referencing default
+  (`x = 1; def f(a=x): ...`) is captured correctly.
+
+### Changed
+
+- **M4 no longer rejects default parameters.**  The former positioned error
+  `"unsupported: default parameter value (deferred)"` is gone; `def_params`
+  was reworked into `def_param_specs` (returning `(name, optional default
+  CST node)` pairs), and `lower_callable` / `push_function` now thread
+  `(name, Option<Expr>)` pairs so defaults reach `Param.default`.  The unit
+  test `default_parameter_is_rejected` was replaced by positive tests
+  (`default_parameter_lowers_to_param_default`,
+  `call_omitting_defaulted_arg_lowers_to_partial_directcall`,
+  `default_parameter_module_validates`) plus an e2e
+  (`e2e_default_parameter`).
+
+### Semantics note (def-time vs. call-time)
+
+Python evaluates a default **once, at `def` time, in the enclosing scope**,
+and a default cannot reference another parameter (`def f(a, b=a)` is a
+`NameError` — not supported here, Python forbids it anyway).  The IR's
+`Param.default` is a *call-time*, param-scope model (a superset).  For the
+constant / enclosing-reference defaults Python permits, the two coincide,
+so the lowering is faithful.  The one observable divergence is a **mutable
+default** (`def f(x=[])`): Python shares a single list across calls; under
+the IR it is re-evaluated per call.  That is a deliberate, documented v0
+choice.
+
 ## 0.5.0 — 2026-06-30
 
 Milestone **M5**: collections — list & dict literals, indexing, `len`, and

--- a/code/packages/rust/python-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/python-to-semantic-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "python-to-semantic-ir"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "Python CST → narrow-waist Semantic IR (SIR17). Second frontend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/python-to-semantic-ir/README.md
+++ b/code/packages/rust/python-to-semantic-ir/README.md
@@ -154,6 +154,8 @@ nesting into a clean error rather than a native stack overflow.
 | Python source                          | SIR lowering                                          | Feature declared       |
 |----------------------------------------|-------------------------------------------------------|------------------------|
 | `def f(a, b): …`                       | top-level `Function { name f, params [a, b], body }`  | `DynamicTyping`†       |
+| `def f(a, b=10): …`                     | `Param { name b, default: Some(IntLit 10) }` (P8)     | `DefaultParams`        |
+| `f(5)` (omitting a defaulted arg)       | *partial* `DirectCall { args [IntLit 5] }`            | `DefaultParams`        |
 | `return expr` (tail)                   | function body `value = expr`                          | —                      |
 | `return` / no return (tail)            | function body `value = NilLit` (implicit `None`)      | —                      |
 | `return expr` (non-tail / early)       | **error** — "early return not supported in v0"        | —                      |
@@ -191,6 +193,27 @@ capture.  A bare reference to a function name yields a `MakeClosure`
 (re-threading its captures), so closures can be returned or passed.
 Capture order is deterministic (alphabetical).  Closure bodies reuse the
 `MAX_BLOCK_DEPTH` / `MAX_EXPR_DEPTH` guards, so recursion stays bounded.
+
+**Default parameters (P8).**  A positional default `def f(a, b=10)` lowers
+the `param_with_default` node's `= <expr>` into `Param.default = Some(expr)`
+(plain params keep `None`); the default is lowered with the same
+`MAX_EXPR_DEPTH`-bounded expression walk, so a deep default fails cleanly.
+A function with any defaulted parameter declares `Feature::DefaultParams`.
+A call that **omits** a defaulted argument — `f(5)` — lowers to a *partial*
+`DirectCall` carrying only the arguments present (the frontend never pads
+in defaults); the validator permits this because the missing parameters
+have defaults.
+
+> **Def-time vs. call-time semantics.**  Python evaluates a default
+> **once, at `def` time, in the enclosing scope**, and a default cannot
+> reference another parameter (`def f(a, b=a)` is a `NameError` — not
+> supported, Python forbids it).  The IR's `Param.default` is a
+> *call-time*, param-scope model (a superset).  For the constant /
+> enclosing-reference defaults Python permits the two coincide, so the
+> lowering is faithful.  The one observable divergence is a **mutable
+> default** (`def f(x=[])`): Python shares one list across calls, whereas
+> under the IR it is re-evaluated per call.  That is a deliberate,
+> documented v0 choice.
 
 ### Collections (M5)
 
@@ -236,8 +259,10 @@ Everything past M5 returns a clear positioned `PythonLowerError`:
 - list / dict **comprehensions**, **slicing** (`xs[a:b]`), **tuple** /
   **set** literals, and list/dict **methods** (`.append` / `.keys` /
   `.get` — these need the SIR runtime-library)
-- default / keyword arguments, `*args` / `**kwargs`, multi-level capture
-  chaining (capturing a variable two scopes up)
+- keyword arguments, `*args` / `**kwargs`, keyword-only parameters,
+  multi-level capture chaining (capturing a variable two scopes up)
+  — note **positional default parameters** (`def f(a=1)`) are now
+  supported (P8); only the keyword/variadic forms remain deferred
 - tuple / multi-target `for` (`for k, v in …`), multi-target / chained
   assignment, attribute targets, bitwise operators, the power operator
   (`**`)

--- a/code/packages/rust/python-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/python-to-semantic-ir/src/lib.rs
@@ -46,9 +46,17 @@
 //!   top-level synthesised functions with computed **captures**, and the
 //!   definition site emits an `Expr::MakeClosure`.
 //! - **calls** `f(args)` → `DirectCall` (known function), `BuiltinCall`
-//!   (`print`/`len`/`range`), or `IndirectCall` (a closure value).
+//!   (`print`/`len`/`range`), or `IndirectCall` (a closure value).  A call
+//!   that omits a defaulted argument lowers to a *partial* `DirectCall`.
+//! - **positional default parameters** (P8) — `def f(a, b=10)` lowers the
+//!   default expression into `Param.default = Some(..)` (declaring
+//!   `Feature::DefaultParams`).  Python evaluates defaults at *def time* in
+//!   the enclosing scope; the IR's `Param.default` is a call-time superset,
+//!   so a *mutable* default (`def f(x=[])`) is re-evaluated per call — a
+//!   documented v0 choice.  A default referencing another parameter is a
+//!   Python `NameError` and is not supported.
 //!
-//! Collections / comprehensions / decorators / `*args` & default
+//! Collections / comprehensions / decorators / `*args` & **keyword**
 //! arguments are deferred to later milestones; unhandled forms return a
 //! clear `PythonLowerError`.
 //!
@@ -1216,13 +1224,72 @@ mod tests {
         });
     }
 
-    // ── deferred constructs stay rejected ─────────────────────────────
+    // ── default parameters (P8) ───────────────────────────────────────
+    //
+    // NOTE: this block replaces the former `default_parameter_is_rejected`
+    // test.  M4 originally *rejected* a default value with a positioned
+    // "unsupported: default parameter value (deferred)" error; the core IR
+    // and all five backends now model `Param.default`, so the frontend
+    // **produces** it.  See the crate README for the def-time-vs-call-time
+    // semantic note (mutable defaults become call-time-evaluated under the
+    // IR model — a documented v0 choice).
 
     #[test]
-    fn default_parameter_is_rejected() {
-        let err = compile_source("def f(a=1):\n    return a\n", "t")
-            .expect_err("default param rejected");
-        assert!(err.message.contains("default"), "got: {}", err.message);
+    fn default_parameter_lowers_to_param_default() {
+        // `b = 10` must produce `Param { default: Some(IntLit 10) }`; the
+        // plain `a` keeps `default: None`.
+        let m = lower("def f(a, b=10):\n    return a + b\n");
+        let f = func(&m, "f");
+        assert_eq!(f.params.len(), 2);
+        assert_eq!(f.params[0].name, "a");
+        assert!(f.params[0].default.is_none(), "plain param keeps None");
+        assert_eq!(f.params[1].name, "b");
+        match f.params[1].default.as_deref() {
+            Some(Expr::IntLit { value, .. }) => assert_eq!(*value, 10),
+            other => panic!("expected b's default = IntLit(10), got {other:?}"),
+        }
+        // A default declares the DefaultParams feature in the manifest.
+        assert!(
+            m.manifest.contains(Feature::DefaultParams),
+            "a default parameter must declare DefaultParams"
+        );
+    }
+
+    #[test]
+    fn default_parameter_module_validates() {
+        // The lowered module (defaulted callee + a full call) round-trips
+        // through the validator.
+        let m = lower("def f(a, b=10):\n    return a + b\n\nf(5, 100)\n");
+        let v = semantic_ir::validate(&m);
+        assert!(v.is_ok(), "module with default param must validate: {:?}", v.issues);
+    }
+
+    #[test]
+    fn call_omitting_defaulted_arg_lowers_to_partial_directcall() {
+        // `f(5)` omits the defaulted `b`; the frontend lowers only the args
+        // *present* — a partial `DirectCall` with a single argument (the
+        // validator permits this because `b` has a default).
+        let m = lower("def f(a, b=10):\n    return a + b\n\nf(5)\n");
+        // Find the `f(5)` call in main's statements/value.
+        let call = main_value(&m);
+        match call {
+            Expr::DirectCall { fn_name, args, .. } => {
+                assert_eq!(fn_name, "f");
+                assert_eq!(args.len(), 1, "only the present arg is lowered");
+                assert!(matches!(args[0], Expr::IntLit { value: 5, .. }));
+            }
+            // `f(5)` as an expression-statement may sit in stmts; fall back.
+            _ => {
+                let found = main_stmts(&m).iter().any(|s| matches!(
+                    s,
+                    Stmt::ExprStmt { expr: Expr::DirectCall { fn_name, args, .. }, .. }
+                        if fn_name == "f" && args.len() == 1
+                ));
+                assert!(found, "expected a partial f(5) DirectCall, got {call:?}");
+            }
+        }
+        let v = semantic_ir::validate(&m);
+        assert!(v.is_ok(), "partial call must validate: {:?}", v.issues);
     }
 
     // ══════════════════════════════════════════════════════════════════
@@ -1768,6 +1835,24 @@ print(a(5))
 ";
         if let Some(out) = run_roundtrip(src) {
             assert_eq!(out, "15", "adder(10)(5) should print 15");
+        }
+    }
+
+    #[test]
+    fn e2e_default_parameter() {
+        // A defaulted parameter exercised both ways: `f(5)` omits the
+        // default (b ← 10 → 15) and `f(5, 100)` overrides it (→ 105).
+        // This is the P8 acceptance check — lower → SIR → emit Python →
+        // run → assert stdout, via the PYTHONPATH-aware harness.
+        let src = "\
+def f(a, b=10):
+    return a + b
+
+print(f(5))
+print(f(5, 100))
+";
+        if let Some(out) = run_roundtrip(src) {
+            assert_eq!(out, "15\n105", "f(5)=15 then f(5,100)=105");
         }
     }
 

--- a/code/packages/rust/python-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/python-to-semantic-ir/src/lower.rs
@@ -1238,7 +1238,30 @@ impl Lowerer {
         depth: usize,
     ) -> Result<Expr, PythonLowerError> {
         let name = self.def_name(def)?;
-        let params = self.def_params(def)?;
+        // Resolve `(name, optional default-CST)` for each parameter, then
+        // lower every default **in the enclosing scope** (Python evaluates
+        // defaults at `def` time in the scope the `def` is written inside).
+        // The bounded `lower_expr_in` reuses the `MAX_EXPR_DEPTH`-capped
+        // expression walk, so a pathologically deep default fails cleanly.
+        let specs = self.def_param_specs(def)?;
+        let mut params: Vec<(String, Option<Expr>)> = Vec::with_capacity(specs.len());
+        let mut any_default = false;
+        for (pname, default_node) in specs {
+            let default = match default_node {
+                Some(node) => {
+                    any_default = true;
+                    Some(self.lower_expr_in(node, enclosing, depth + 1)?)
+                }
+                None => None,
+            };
+            params.push((pname, default));
+        }
+        if any_default {
+            // A `Param.default = Some(_)` is exactly what the validator
+            // observes as `DefaultParams`; declare it here so the manifest
+            // matches.
+            self.observed.add(Feature::DefaultParams);
+        }
         let suite = self
             .first_child_named(def, "suite")
             .ok_or_else(|| self.err_at(def, "malformed def: missing body".to_string()))?;
@@ -1247,9 +1270,31 @@ impl Lowerer {
         self.lower_callable(&name, &params, suite, enclosing, depth, span)
     }
 
-    /// Extract a `def_stmt`'s parameter names (rejecting defaults / `*args`
-    /// / `**kwargs`, which are deferred).
-    fn def_params(&self, def: &GrammarASTNode) -> Result<Vec<String>, PythonLowerError> {
+    /// Extract a `def_stmt`'s parameters as `(name, optional default-value
+    /// CST node)` pairs.
+    ///
+    /// A *plain* positional parameter (`a`) yields `(name, None)`.  A
+    /// *defaulted* one (`b = 10`) yields `(name, Some(<expression node>))`
+    /// — the `param_with_default` node carries an extra `=` token and an
+    /// `expression` child, which the caller lowers (in the **enclosing**
+    /// scope) into the IR's `Param.default`.
+    ///
+    /// ## Python def-time semantics vs. the IR's call-time model
+    ///
+    /// Python evaluates a default **once, at `def` time, in the enclosing
+    /// scope** — so a default cannot reference another parameter
+    /// (`def f(a, b=a)` is a `NameError`).  The IR's `Param.default` is a
+    /// *call-time*, param-scope model (a superset).  For the constant /
+    /// enclosing-reference defaults Python actually permits, the two
+    /// coincide, so lowering the Python default straight into
+    /// `Param.default` is faithful.  The one observable divergence is a
+    /// *mutable* default (`def f(x=[])`): Python shares one list across
+    /// calls; under the IR it is re-evaluated per call.  That is a
+    /// deliberate, documented v0 choice (see the crate README).
+    fn def_param_specs<'a>(
+        &self,
+        def: &'a GrammarASTNode,
+    ) -> Result<Vec<(String, Option<&'a GrammarASTNode>)>, PythonLowerError> {
         let parameters = match self.first_child_named(def, "parameters") {
             Some(p) => p,
             None => return Ok(vec![]), // `def f():` — no params.
@@ -1258,40 +1303,54 @@ impl Lowerer {
         let list = self
             .first_child_named(parameters, "parameter_list")
             .unwrap_or(parameters);
-        let mut names = Vec::new();
+        let mut specs = Vec::new();
         for pwd in child_nodes(list) {
             if pwd.rule_name != "param_with_default" {
                 continue;
             }
-            names.push(self.param_name(pwd)?);
+            specs.push(self.param_spec(pwd)?);
         }
-        Ok(names)
+        Ok(specs)
     }
 
-    /// Extract one parameter's name from a `param_with_default`, rejecting
-    /// a default value (`a=1`) — the node then carries an extra `EQUALS`
-    /// token / default `expression`, which v0 does not model.
-    fn param_name(&self, pwd: &GrammarASTNode) -> Result<String, PythonLowerError> {
-        // A plain parameter is exactly one `NAME` token.  A default adds
-        // an `EQUALS` token (+ a default expression node).
-        let has_default = pwd.children.iter().any(|c| {
-            matches!(c, ASTNodeOrToken::Token(t) if t.value == "=")
-                || matches!(c, ASTNodeOrToken::Node(_))
-        });
-        if has_default {
-            return Err(self.err_at(
-                pwd,
-                "unsupported: default parameter value (deferred)".to_string(),
-            ));
-        }
+    /// Extract one parameter's `(name, optional default node)` from a
+    /// `param_with_default`.
+    ///
+    /// The CST shapes are:
+    ///   - plain `a`     → `[NAME]`                       → `(name, None)`
+    ///   - default `b=1` → `[NAME, EQUALS, expression]`   → `(name, Some(expr))`
+    ///
+    /// Only positional defaults are modelled here; keyword-only markers and
+    /// `*args` / `**kwargs` never reach this rule in the M5 subset.
+    fn param_spec<'a>(
+        &self,
+        pwd: &'a GrammarASTNode,
+    ) -> Result<(String, Option<&'a GrammarASTNode>), PythonLowerError> {
+        let mut name: Option<String> = None;
+        let mut default: Option<&GrammarASTNode> = None;
         for child in &pwd.children {
-            if let ASTNodeOrToken::Token(t) = child {
-                if matches!(t.type_, lexer::token::TokenType::Name) && t.type_name.is_none() {
-                    return Ok(t.value.clone());
+            match child {
+                ASTNodeOrToken::Token(t) => {
+                    if matches!(t.type_, lexer::token::TokenType::Name)
+                        && t.type_name.is_none()
+                        && name.is_none()
+                    {
+                        name = Some(t.value.clone());
+                    }
+                    // The `=` token is the marker only; the value that
+                    // follows is the `expression` node captured below.
+                }
+                // The default-value `expression` node (present only for a
+                // `name = expr` parameter).
+                ASTNodeOrToken::Node(n) => {
+                    default = Some(n);
                 }
             }
         }
-        Err(self.err_at(pwd, "malformed parameter".to_string()))
+        match name {
+            Some(name) => Ok((name, default)),
+            None => Err(self.err_at(pwd, "malformed parameter".to_string())),
+        }
     }
 
     /// Lower a `lambda_expr` into a fresh top-level synthesised
@@ -1329,7 +1388,11 @@ impl Lowerer {
             value,
             span: span.clone(),
         };
-        self.push_function(&fn_name, &params, &captures, body, span.clone());
+        // Lambdas in the M5 subset never carry defaults (rejected in
+        // `lambda_params`), so every param maps to `(name, None)`.
+        let lambda_params: Vec<(String, Option<Expr>)> =
+            params.iter().map(|n| (n.clone(), None)).collect();
+        self.push_function(&fn_name, &lambda_params, &captures, body, span.clone());
 
         // A lambda always yields a retained closure value.
         self.observed.add(Feature::Closures);
@@ -1379,7 +1442,7 @@ impl Lowerer {
     fn lower_callable(
         &mut self,
         name: &str,
-        params: &[String],
+        params: &[(String, Option<Expr>)],
         suite: &GrammarASTNode,
         enclosing: &mut FunctionCtx,
         depth: usize,
@@ -1387,8 +1450,11 @@ impl Lowerer {
     ) -> Result<Expr, PythonLowerError> {
         // ── Free-variable analysis over the suite. ──
         // Names bound *within* the body — the params plus every name the
-        // body assigns / `for`-binds — are body-local, not captures.
-        let mut bound: HashSet<String> = params.iter().cloned().collect();
+        // body assigns / `for`-binds — are body-local, not captures.  Note
+        // a default expression sees the *enclosing* scope (it was already
+        // lowered there by the caller), so it never contributes to the
+        // body's free/bound sets here.
+        let mut bound: HashSet<String> = params.iter().map(|(n, _)| n.clone()).collect();
         self.collect_suite_bound_names(suite, &mut bound)?;
         let mut free = Vec::new();
         let mut seen = HashSet::new();
@@ -1398,7 +1464,7 @@ impl Lowerer {
 
         // ── Lower the body in the function's own context. ──
         let mut inner = FunctionCtx::new(
-            params.iter().cloned().collect(),
+            params.iter().map(|(n, _)| n.clone()).collect(),
             captures.iter().cloned().collect(),
         );
         let body = self.lower_function_suite(suite, &mut inner, depth + 1)?;
@@ -1413,7 +1479,7 @@ impl Lowerer {
     fn push_function(
         &mut self,
         name: &str,
-        params: &[String],
+        params: &[(String, Option<Expr>)],
         captures: &[String],
         body: Block,
         span: Span,
@@ -1437,11 +1503,15 @@ impl Lowerer {
             name: name.to_string(),
             params: params
                 .iter()
-                .map(|p| Param {
-                    name: p.clone(),
+                .map(|(pname, default)| Param {
+                    name: pname.clone(),
                     sir_type: None,
+                    // A defaulted positional param keeps `Required` kind —
+                    // `ParamKind` distinguishes only `Required`/`Rest`/
+                    // `KwRest`; the presence of a default lives in
+                    // `default`, not the kind.
                     kind: ParamKind::Required,
-                    default: None,
+                    default: default.clone().map(Box::new),
                     span: span.clone(),
                 })
                 .collect(),
@@ -1687,9 +1757,17 @@ impl Lowerer {
             if let Ok(n) = self.def_name(node) {
                 inner.insert(n);
             }
-            if let Ok(ps) = self.def_params(node) {
-                for p in ps {
-                    inner.insert(p);
+            if let Ok(specs) = self.def_param_specs(node) {
+                for (pname, default_node) in specs {
+                    // A *default expression* is evaluated in the **enclosing**
+                    // scope (Python def-time semantics), so any name it
+                    // references is free against the *outer* `bound` set — not
+                    // shadowed by the params.  Collect those before adding the
+                    // param itself to `inner`.
+                    if let Some(default) = default_node {
+                        self.collect_free_names(default, bound, free, seen, depth + 1)?;
+                    }
+                    inner.insert(pname);
                 }
             }
             if let Some(suite) = self.first_child_named(node, "suite") {

--- a/code/specs/SIR17-python-to-semantic-ir.md
+++ b/code/specs/SIR17-python-to-semantic-ir.md
@@ -10,7 +10,8 @@ produces a `semantic_ir::Module`.  Implemented as the Rust crate
 
 Milestones implemented: **M1** (literals), **M2** (variables /
 assignment / operators), **M3** (control flow), **M4** (functions,
-calls, closures).  Collections / maps (M5) remain deferred.
+calls, closures), **M5** (collections / maps), and **P8** (positional
+default parameters — `def f(a=1)`).
 
 ## Pipeline
 
@@ -138,6 +139,33 @@ route through `__getitem__` / `__setitem__`).  The choice affects only the
 manifest feature (`Sequences` vs `Maps`), never runtime behaviour.
 Comprehensions, slicing (`xs[a:b]`), tuple / set literals, list/dict
 methods, and unpacking remain deferred (positioned errors).
+
+**Implementation note (P8 — positional default parameters):** a
+`def f(a, b=10)` parameter is represented by the parser as a
+`param_with_default` node; a *defaulted* one carries `[NAME, EQUALS,
+expression]`, a *plain* one just `[NAME]`.  M4 originally **rejected** the
+defaulted form (`"unsupported: default parameter value (deferred)"`); P8
+removes that rejection and lowers the default `expression` — **in the
+enclosing scope** — into the IR's `Param.default = Some(Box::new(expr))`
+via the existing `MAX_EXPR_DEPTH`-bounded expression walk.  A function with
+any defaulted parameter declares `Feature::DefaultParams`.  A call that
+omits a defaulted argument (`f(5)`) lowers to a *partial* `DirectCall`
+carrying only the arguments present — the frontend never pads in defaults;
+the validator accepts the shortfall because the omitted parameters have
+defaults.
+
+*Def-time vs. call-time semantics.*  Python evaluates a default **once, at
+`def` time, in the enclosing scope**, and a default **cannot** reference
+another parameter (`def f(a, b=a)` is a `NameError`) — so we never need to
+resolve a default against the param scope, and that unsupported form is
+forbidden by Python anyway.  The IR's `Param.default` is a *call-time*,
+param-scope model (a strict superset).  For the constant / enclosing-
+reference defaults Python permits, the two coincide and the lowering is
+faithful.  The single observable divergence is a **mutable default**
+(`def f(x=[])`): Python shares one list object across calls; under the IR
+the default is re-evaluated per call.  This is a deliberate, documented v0
+choice.  Keyword-only parameters, `*args` / `**kwargs`, and keyword
+arguments at call sites remain deferred.
 
 ## Return statement
 
@@ -290,7 +318,8 @@ Coverage target ≥ 90%.
 - Decorators
 - Multi-target assignment / unpacking
 - Slicing
-- Default + keyword arguments
+- Keyword arguments, keyword-only parameters, `*args` / `**kwargs`
+  (positional default parameters `def f(a=1)` ARE supported — P8)
 - String methods
 - `with` / context managers
 - Module-level `import`


### PR DESCRIPTION
The `python-to-semantic-ir` frontend now **produces** default parameters (M4 previously rejected them with a positioned error). Completes the Python side of the default-param cascade (core P1 + semantics P2a + 5 backends all merged).

- A `param_with_default` (`name = <expr>`) lowers the default via the existing `MAX_EXPR_DEPTH`-bounded expr lowering → `Param{default: Some(...)}`. Plain params keep `None`. `Feature::DefaultParams` observed when any default is present; free-var analysis extended to walk the default against the enclosing bound set.
- Partial calls: `f(5)` omitting a defaulted arg lowers to a partial `DirectCall` (the validator now permits the shortfall) — no padding in the frontend.

**Semantics (documented):** Python evaluates defaults at def-time in the enclosing scope and forbids `def f(a, b=a)` (NameError). The IR's `Param.default` is a call-time, param-scope superset; constant/enclosing-ref defaults lower faithfully. A mutable default (`def f(x=[])`) becomes call-time-evaluated — a deliberate, documented v0 choice.

**Tests:** 114 (incl. lowering + partial-call + validate round-trip; replaced the old default-rejection test) + a Python **e2e** via the PYTHONPATH harness: `def f(a, b=10): return a + b` → `print(f(5))`→`15`, `print(f(5,100))`→`105`. clippy clean; security review passed. Isolated to `python-to-semantic-ir`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)