### PR TITLE
feat(js-sir): produce default parameters — function f(a=1) (P9)

### DIFF
--- a/code/packages/rust/javascript-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/javascript-to-semantic-ir/CHANGELOG.md
@@ -5,6 +5,65 @@ All notable changes to `javascript-to-semantic-ir` are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## 0.6.0
+
+**Default parameters (P9).**  The frontend now *produces* default
+parameters: a defaulted formal `name = <expr>` lowers to a
+`Param { default: Some(<lowered expr>) }`.  Previously M4 deferred any
+parameter with an initializer; this wires defaults all the way through, for
+both `function` declarations and arrow functions.  The core IR and all five
+backends already supported `Param.default`; this completes the JavaScript
+front of that work.
+
+### Added
+
+- **Default-parameter lowering.**  A `formal_parameter` with the CST shape
+  `[Name, "=", <assignment_expression>]` lowers to a `Param` whose `default`
+  is the lowered initializer.  A plain `[Name]` keeps `default: None`.  This
+  applies to `function f(a = 1) { … }` and to arrow functions
+  `(a = 1) => …`.  Observes `Feature::DefaultParams` (and any feature the
+  default expression itself uses, e.g. `Strings` for `a = "x"`).
+- **Call-time, param-scope semantics.**  JS defaults are evaluated at the
+  call site and may reference *earlier* parameters
+  (`function f(a, b = a + 1)`).  We lower each default **inside the function
+  frame** (after the param scope is pushed), so a reference to an earlier
+  param resolves as a `Scope::Param` `VarRef` — exactly the SIR
+  `Param.default` model the validator and every backend already assume.
+- **Partial calls.**  A call that omits a defaulted argument (`f(5)` against
+  `function f(a, b = a + 1)`) lowers to a `DirectCall` carrying *only the
+  present arguments*; the omitted parameter is filled by its default at the
+  call site.  The SIR validator permits such partial calls when the trailing
+  params have defaults.
+- **e2e (node).**  New `default_params_run_in_node` test lowers
+  `function f(a, b = a + 1) { … } console.log(f(5)); console.log(f(5, 10));`
+  → SIR → JavaScript (via the `semantic-ir-to-javascript` dev-dep) → `node`,
+  asserting `6` then `10` — proving call-time evaluation and param-scope
+  resolution end to end.
+
+### Changed
+
+- **Block builder keeps effectful superseded tail expressions.**  When a
+  bare-expression statement is superseded as a block's tail value by a later
+  expression, it is now flushed as an `ExprStmt` **iff it may have a side
+  effect** (a `print`, a call, …) rather than always being dropped as pure.
+  This fixes a latent bug where two consecutive `console.log(...)`
+  statements at the same block level lost all but the last.  A new
+  conservative `expr_may_have_effects` helper drives the decision (literals,
+  var-refs, and pure operators over pure operands are still dropped).
+
+### Rejected (still deferred)
+
+- Rest `...args` and destructuring (`{a}` / `[a]`) parameters remain
+  deferred — defaults are the only previously-deferred param form now
+  supported.  The deferral message was updated accordingly.
+
+### Safety
+
+- The default initializer is an ordinary expression, lowered through the
+  existing `MAX_EXPR_DEPTH`-bounded `lower_expression`, so a pathologically
+  deep default becomes a positioned error rather than a native stack
+  overflow (CWE-674).  No new unbounded CST walk was introduced.
+
 ## 0.5.0
 
 SIR19 milestone **M5 (collections: arrays & objects)** — builds on M4's

--- a/code/packages/rust/javascript-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/javascript-to-semantic-ir/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "javascript-to-semantic-ir"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
-description = "JavaScript (GrammarASTNode CST) → narrow-waist Semantic IR. SIR19 frontend, milestone M5 (collections: arrays & objects)."
+description = "JavaScript (GrammarASTNode CST) → narrow-waist Semantic IR. SIR19 frontend, milestone M5 (collections) + default parameters."
 
 [dependencies]
 coding-adventures-javascript-parser = { path = "../javascript-parser" }

--- a/code/packages/rust/javascript-to-semantic-ir/README.md
+++ b/code/packages/rust/javascript-to-semantic-ir/README.md
@@ -123,9 +123,21 @@ supported subset (M1 + M2 + M3 + M4 + M5):
   Captures thread transitively through nested closures.
 - **Calls** dispatch on the callee: a known module `function` →
   `DirectCall`; `console.log(x)` → `BuiltinCall("print", …)`; any other
-  identifier resolving to a closure value → `IndirectCall`.
+  identifier resolving to a closure value → `IndirectCall`. A call may omit
+  trailing defaulted arguments (`f(5)` against `function f(a, b = a + 1)`):
+  it lowers to a **partial** `DirectCall` carrying only the present args,
+  with the default filled at the call site (the validator permits this).
+- **Default parameters.** A defaulted formal `name = <expr>` (both in
+  `function` declarations and arrow functions) lowers to
+  `Param { default: Some(<lowered expr>) }`. JS defaults are *call-time* and
+  may reference *earlier* params (`function f(a, b = a + 1)`), so each
+  default is lowered **inside the function frame** — a reference to an
+  earlier param resolves as `Scope::Param`, matching the SIR `Param.default`
+  model exactly. Declares `Feature::DefaultParams` (plus any feature the
+  default expression uses). Rest `...args` and destructuring stay deferred.
 - **Manifest.** Closures declare `Feature::Closures`; untyped params
-  declare `Feature::DynamicTyping`; a genuine call-graph cycle declares
+  declare `Feature::DynamicTyping`; a defaulted param declares
+  `Feature::DefaultParams`; a genuine call-graph cycle declares
   `Feature::MutualRecursion` (self-recursion alone does not).
 
 ### Control flow
@@ -243,8 +255,9 @@ Method calls other than `console.log` and array methods (`.map`/`.push`/…,
 which need runtime-library support), spread (`[...xs]` / `{...o}`), array
 elisions, object shorthand / computed / numeric keys / methods / getters /
 setters, `.length` *assignment* (a resize with no IR node), classes /
-`this` / `new`, generators, `async`/`await`, default / rest parameters,
-destructuring, and template literals all currently return a `JsLowerError`
+`this` / `new`, generators, `async`/`await`, **rest** parameters
+(`...args`), destructuring, and template literals all currently return a
+`JsLowerError`
 describing what was rejected, with the offending node's position. So do
 **early `return`** (non-tail), the remaining control-flow constructs
 (`switch`, `try`/`catch`, `do … while`, labeled statements,

--- a/code/packages/rust/javascript-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/javascript-to-semantic-ir/src/lib.rs
@@ -1302,14 +1302,106 @@ mod tests {
     }
 
     #[test]
-    fn default_parameter_is_deferred() {
-        let err = compile_source("function f(a = 1) { return a; }", "test")
-            .expect_err("default params deferred");
+    fn default_parameter_literal_lowers_to_param_default() {
+        // `function f(a = 1)` → a single `Param` whose `default` is the
+        // lowered initializer `IntLit 1`.  Observes `Feature::DefaultParams`.
+        let m = lower("function f(a = 1) { return a; }");
+        assert_valid(&m);
+        let f = func(&m, "f");
+        assert_eq!(f.params.len(), 1);
+        let p = &f.params[0];
+        assert_eq!(p.name, "a");
         assert!(
-            err.message.contains("deferred") || err.message.contains("default"),
-            "got: {}",
-            err.message
+            matches!(p.default.as_deref(), Some(Expr::IntLit { value: 1, .. })),
+            "expected default IntLit 1, got {:?}",
+            p.default
         );
+        assert!(m.manifest.contains(Feature::DefaultParams));
+    }
+
+    #[test]
+    fn plain_parameter_has_no_default() {
+        // A parameter with no initializer keeps `default: None`, and a
+        // function with only plain params does *not* declare DefaultParams.
+        let m = lower("function f(a) { return a; }");
+        assert_valid(&m);
+        assert!(func(&m, "f").params[0].default.is_none());
+        assert!(!m.manifest.contains(Feature::DefaultParams));
+    }
+
+    #[test]
+    fn default_parameter_may_reference_earlier_param() {
+        // `function f(a, b = a + 1)` — the default for `b` is lowered in
+        // param scope, so it references `a` as a `Scope::Param` VarRef.
+        // This is the JS call-time / param-scope rule, which matches the SIR
+        // `Param.default` model exactly.
+        let m = lower("function f(a, b = a + 1) { return b; }");
+        assert_valid(&m);
+        let f = func(&m, "f");
+        assert_eq!(f.params.len(), 2);
+        assert!(f.params[0].default.is_none(), "`a` has no default");
+        // `b`'s default is `a + 1` → BuiltinCall("+", [VarRef(a, Param), IntLit 1]).
+        match f.params[1].default.as_deref() {
+            Some(Expr::BuiltinCall { name, args, .. }) if name == "+" => {
+                assert!(
+                    matches!(&args[0], Expr::VarRef { scope: Scope::Param, name, .. } if name == "a"),
+                    "default must reference earlier param `a`, got {:?}",
+                    args[0]
+                );
+                assert!(matches!(&args[1], Expr::IntLit { value: 1, .. }));
+            }
+            other => panic!("expected `a + 1` default, got {other:?}"),
+        }
+        assert!(m.manifest.contains(Feature::DefaultParams));
+    }
+
+    #[test]
+    fn arrow_default_parameter_lowers_to_param_default() {
+        // Arrow functions take defaults too: `(a = 1) => a`.
+        let m = lower("let g = (a = 1) => a; g();");
+        assert_valid(&m);
+        let lambda = func(&m, "__lambda_0");
+        assert!(
+            matches!(lambda.params[0].default.as_deref(), Some(Expr::IntLit { value: 1, .. })),
+            "expected arrow default IntLit 1, got {:?}",
+            lambda.params[0].default
+        );
+        assert!(m.manifest.contains(Feature::DefaultParams));
+    }
+
+    #[test]
+    fn partial_call_omitting_defaulted_arg_lowers_present_args_only() {
+        // `f(5)` against `function f(a, b = a + 1)` is a *partial* call: the
+        // `DirectCall` carries only the present argument (`5`); the omitted
+        // `b` is filled by its default at the call site.  The validator
+        // permits a partial call when the trailing params have defaults.
+        let m = lower("function f(a, b = a + 1) { return b; } console.log(f(5));");
+        assert_valid(&m);
+        // The top-level `console.log(f(5))` wraps a DirectCall with one arg.
+        fn find_direct_call(e: &Expr) -> Option<&Expr> {
+            match e {
+                Expr::BuiltinCall { args, .. } => args.iter().find_map(find_direct_call),
+                Expr::DirectCall { .. } => Some(e),
+                _ => None,
+            }
+        }
+        let call = find_direct_call(main_value(&m)).expect("a DirectCall to `f`");
+        match call {
+            Expr::DirectCall { fn_name, args, .. } => {
+                assert_eq!(fn_name, "f");
+                assert_eq!(args.len(), 1, "only the present arg is lowered (partial call)");
+                assert!(matches!(&args[0], Expr::IntLit { value: 5, .. }));
+            }
+            other => panic!("expected DirectCall, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rest_parameter_still_deferred() {
+        // Defaults are now supported, but rest `...args` stays deferred.
+        let err = compile_source("function f(...args) { return args; }", "test")
+            .expect_err("rest params still deferred");
+        assert!(err.message.contains("deferred"), "got: {}", err.message);
     }
 
     #[test]

--- a/code/packages/rust/javascript-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/javascript-to-semantic-ir/src/lower.rs
@@ -317,8 +317,20 @@
 //! object methods / getters / setters, `.length` *assignment* (a resize, with
 //! no IR node), array methods (`.map`/`.push`/… — these would need
 //! runtime-library support, per the project mandate), classes, `this`/`new`,
-//! generators / `async`/`await`, default / rest params, destructuring, and
-//! template literals all remain positioned errors.
+//! generators / `async`/`await`, **rest** params (`...args`),
+//! destructuring, and template literals all remain positioned errors.
+//!
+//! ### Default parameters (P9, post-M5)
+//!
+//! A defaulted formal `name = <expr>` (in both `function` declarations and
+//! arrow functions) lowers to `Param { default: Some(<lowered expr>) }`.
+//! JS defaults are **call-time** and may reference **earlier** params
+//! (`function f(a, b = a + 1)`), so the initializer is lowered *inside* the
+//! function frame (after the params are in scope) — a reference to an
+//! earlier param resolves as `Scope::Param`, which is exactly the SIR
+//! `Param.default` model.  A call omitting a defaulted argument (`f(5)`)
+//! lowers to a **partial** `DirectCall` carrying only the present args.
+//! Observes `Feature::DefaultParams`.  Rest and destructuring stay deferred.
 
 use lexer::token::{Token, TokenType};
 use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode};
@@ -527,6 +539,16 @@ pub fn compile(program: &GrammarASTNode, module_name: &str) -> Result<Module, Js
 /// (`resolve_name`) walks the stack top-down: the current frame's
 /// `locals`/`params`, then `captures`, then — for a name found in an
 /// *enclosing* frame — a capture is recorded on the current closure.
+/// A single formal parameter extracted from the CST, before it is lowered
+/// into a [`Param`].  `default` borrows the initializer expression node (the
+/// `assignment_expression` after `=`) so it can be lowered **inside** the
+/// function frame — JS defaults are call-time and may reference earlier
+/// params, so they must be lowered with the params in scope.
+struct FormalParamSpec<'a> {
+    name: String,
+    default: Option<&'a GrammarASTNode>,
+}
+
 struct FnScope {
     /// Parameter names of this function (empty for `main`).
     params: HashSet<String>,
@@ -835,9 +857,22 @@ impl Lowerer {
                             stmts.push(*s);
                         }
                         Lowered::Expr(e) => {
-                            // A new bare expression supersedes the prior
-                            // one as the candidate tail value; the prior
-                            // one, being pure, is dropped.
+                            // A new bare expression supersedes the prior one
+                            // as the candidate tail value.  The prior one is
+                            // no longer observable *as a value*, but if it may
+                            // have a side effect (e.g. `console.log(...)` →
+                            // an effectful `print`, or a call) it must still
+                            // run — flush it as an `ExprStmt`.  A provably
+                            // pure prior (a literal, a var-ref, arithmetic on
+                            // pure operands) is simply dropped.  Without this,
+                            // two consecutive `console.log(...)` statements
+                            // would lose all but the last.
+                            if let Some(prev) = tail.take() {
+                                if expr_may_have_effects(&prev) {
+                                    let span = prev.span().clone();
+                                    stmts.push(Stmt::ExprStmt { expr: prev, span });
+                                }
+                            }
                             tail = Some(e);
                         }
                     }
@@ -1424,7 +1459,7 @@ impl Lowerer {
         self.check_stmt_depth(node, depth)?;
         let name = function_decl_name(node)
             .ok_or_else(|| self.unsupported(node, "function_declaration (no name)"))?;
-        let params = self.formal_param_names(node)?;
+        let params = self.formal_param_specs(node)?;
         let body_node = child_node_named(node, "function_body");
 
         // A *nested* declaration (we're inside a function frame deeper than
@@ -1480,7 +1515,7 @@ impl Lowerer {
     ) -> Result<Expr, JsLowerError> {
         self.check_stmt_depth(node, depth)?;
         let span = self.span_of(node);
-        let params = self.arrow_param_names(node)?;
+        let params = self.arrow_param_specs(node)?;
         let concise = child_node_named(node, "concise_body")
             .ok_or_else(|| self.unsupported(node, "arrow_function (no body)"))?;
 
@@ -1609,15 +1644,22 @@ impl Lowerer {
     fn lower_callable_body(
         &mut self,
         name: &str,
-        params: &[String],
+        params: &[FormalParamSpec],
         body_node: Option<&GrammarASTNode>,
         decl_node: &GrammarASTNode,
         depth: usize,
         is_closure: bool,
     ) -> Result<(Function, Vec<CaptureValue>), JsLowerError> {
         let span = self.span_of(decl_node);
-        self.scopes
-            .push(FnScope::new(params.iter().cloned().collect(), is_closure));
+        self.scopes.push(FnScope::new(
+            params.iter().map(|p| p.name.clone()).collect(),
+            is_closure,
+        ));
+
+        // Lower the default initializers **inside** the freshly pushed frame
+        // (so a default may reference earlier params), then the body.  We do
+        // defaults before the body, but both see the same param frame.
+        let params_result = self.lower_param_specs(params, depth, &span);
 
         // Lower the function body's statement sequence with the tail-return
         // rule.  An absent / empty body yields a nil-valued block.
@@ -1626,20 +1668,12 @@ impl Lowerer {
         let body_result = self.lower_function_body(body_children, span.clone(), depth + 1);
 
         let frame = self.scopes.pop().expect("pushed a frame");
+        let lowered_params = params_result?;
         let body = body_result?;
 
         let function = Function {
             name: name.to_string(),
-            params: params
-                .iter()
-                .map(|p| Param {
-                    name: p.clone(),
-                    sir_type: None,
-                    kind: ParamKind::Required,
-                    default: None,
-                    span: span.clone(),
-                })
-                .collect(),
+            params: lowered_params,
             return_type: None,
             captures: frame
                 .captures
@@ -1670,14 +1704,20 @@ impl Lowerer {
     fn lower_arrow_callable(
         &mut self,
         name: &str,
-        params: &[String],
+        params: &[FormalParamSpec],
         concise: &GrammarASTNode,
         arrow_node: &GrammarASTNode,
         depth: usize,
     ) -> Result<(Function, Vec<CaptureValue>), JsLowerError> {
         let span = self.span_of(arrow_node);
-        self.scopes
-            .push(FnScope::new(params.iter().cloned().collect(), true));
+        self.scopes.push(FnScope::new(
+            params.iter().map(|p| p.name.clone()).collect(),
+            true,
+        ));
+
+        // Lower default initializers inside the frame (may reference earlier
+        // params), then the concise body.
+        let params_result = self.lower_param_specs(params, depth, &span);
 
         // Expression body: `concise_body` has a single expression child and
         // no `{`.  Block body: it wraps a `function_body` between braces.
@@ -1702,20 +1742,12 @@ impl Lowerer {
         })();
 
         let frame = self.scopes.pop().expect("pushed a frame");
+        let lowered_params = params_result?;
         let body = result?;
 
         let function = Function {
             name: name.to_string(),
-            params: params
-                .iter()
-                .map(|p| Param {
-                    name: p.clone(),
-                    sir_type: None,
-                    kind: ParamKind::Required,
-                    default: None,
-                    span: span.clone(),
-                })
-                .collect(),
+            params: lowered_params,
             return_type: None,
             captures: frame
                 .captures
@@ -1729,6 +1761,55 @@ impl Lowerer {
         };
         self.features_used.add(Feature::Closures);
         Ok((function, frame.capture_values))
+    }
+
+    /// Lower a run of [`FormalParamSpec`]s into [`Param`]s, lowering each
+    /// default initializer with the function frame already on the scope
+    /// stack.
+    ///
+    /// **Call-time & param-scope semantics.** In JavaScript a default is
+    /// evaluated at call time and may read *earlier* parameters
+    /// (`function f(a, b = a + 1)`).  Because the whole param frame is
+    /// already pushed by the caller before this runs, lowering the default
+    /// as an ordinary expression makes a reference to `a` resolve as a
+    /// `Scope::Param` `VarRef` — exactly the SIR model (the IR validator and
+    /// every backend treat `Param.default` as evaluated in param scope).
+    ///
+    /// **Depth bound.** The initializer is an ordinary expression node, so
+    /// it is lowered through [`lower_expression`], which is bounded by
+    /// [`MAX_EXPR_DEPTH`] (a pathologically deep default becomes a positioned
+    /// error, never a native stack overflow — CWE-674).  We start it at
+    /// `depth + 1` so a default nested inside a deep function still counts
+    /// against the same budget.
+    ///
+    /// A parameter that carries a default makes the module observe
+    /// [`Feature::DefaultParams`]; the validator independently observes the
+    /// same feature off the `default = Some(_)` slot, so the declared and
+    /// observed manifests agree.
+    fn lower_param_specs(
+        &mut self,
+        params: &[FormalParamSpec],
+        depth: usize,
+        span: &Span,
+    ) -> Result<Vec<Param>, JsLowerError> {
+        let mut out = Vec::with_capacity(params.len());
+        for spec in params {
+            let default = match spec.default {
+                None => None,
+                Some(expr_node) => {
+                    self.features_used.add(Feature::DefaultParams);
+                    Some(Box::new(self.lower_expression(expr_node, depth + 1)?))
+                }
+            };
+            out.push(Param {
+                name: spec.name.clone(),
+                sir_type: None,
+                kind: ParamKind::Required,
+                default,
+                span: span.clone(),
+            });
+        }
+        Ok(out)
     }
 
     /// Lower a function/closure body's statement sequence into a [`Block`],
@@ -1943,78 +2024,98 @@ impl Lowerer {
         }
     }
 
-    /// Extract a `function_declaration`'s formal parameter names, rejecting
-    /// the deferred parameter forms (default / rest / destructuring).
-    fn formal_param_names(
+    /// Extract a `function_declaration`'s formal parameters as
+    /// [`FormalParamSpec`]s (name + optional default-initialiser CST node).
+    /// Rest `...r` / destructuring `{a}`/`[a]` stay deferred.
+    fn formal_param_specs<'a>(
         &self,
-        decl_node: &GrammarASTNode,
-    ) -> Result<Vec<String>, JsLowerError> {
+        decl_node: &'a GrammarASTNode,
+    ) -> Result<Vec<FormalParamSpec<'a>>, JsLowerError> {
         match child_node_named(decl_node, "formal_parameters") {
             None => Ok(Vec::new()), // zero-parameter function.
-            Some(fp) => self.simple_param_names(fp, decl_node),
+            Some(fp) => self.param_specs(fp, decl_node),
         }
     }
 
-    /// Extract an `arrow_function`'s parameter names.  The `arrow_parameters`
-    /// node is either `[(, formal_parameters?, )]` or a bare `[Name]` (for
-    /// `a => …`).
-    fn arrow_param_names(
+    /// Extract an `arrow_function`'s parameters as [`FormalParamSpec`]s.  The
+    /// `arrow_parameters` node is either `[(, formal_parameters?, )]` or a
+    /// bare `[Name]` (for `a => …`, which can carry no default).
+    fn arrow_param_specs<'a>(
         &self,
-        arrow_node: &GrammarASTNode,
-    ) -> Result<Vec<String>, JsLowerError> {
+        arrow_node: &'a GrammarASTNode,
+    ) -> Result<Vec<FormalParamSpec<'a>>, JsLowerError> {
         let ap = child_node_named(arrow_node, "arrow_parameters")
             .ok_or_else(|| self.unsupported(arrow_node, "arrow_function (no parameters)"))?;
-        // Bare single-identifier form: `a => …`.
+        // Bare single-identifier form: `a => …` (no parens, no default).
         if let Some(tok) = ap.token() {
             if matches!(tok.type_, TokenType::Name) {
-                return Ok(vec![tok.value.clone()]);
+                return Ok(vec![FormalParamSpec { name: tok.value.clone(), default: None }]);
             }
         }
         match child_node_named(ap, "formal_parameters") {
             None => Ok(Vec::new()), // `() => …`.
-            Some(fp) => self.simple_param_names(fp, arrow_node),
+            Some(fp) => self.param_specs(fp, arrow_node),
         }
     }
 
-    /// Extract simple positional parameter names from a `formal_parameters`
-    /// node, rejecting any non-trivial `formal_parameter` (a default value,
-    /// rest `...`, or a destructuring pattern) as deferred.
-    fn simple_param_names(
+    /// Extract positional parameter specs from a `formal_parameters` node.
+    ///
+    /// Two `formal_parameter` shapes are accepted (see the probed CST in the
+    /// module header):
+    ///
+    /// - `[Name]` — a plain positional parameter; `default: None`.
+    /// - `[Name, "=", <assignment_expression>]` — a **default** parameter;
+    ///   `default: Some(<expr node>)`.  The initializer is an ordinary
+    ///   expression node, lowered later **inside the function frame** (so it
+    ///   may reference earlier params, matching JS call-time semantics) by
+    ///   the depth-bounded [`lower_expression`].
+    ///
+    /// Any other shape — rest `...r`, a destructuring pattern `{a}`/`[a]`
+    /// (which introduces a child *node* in the binding position rather than a
+    /// leading `Name` token) — stays deferred.
+    fn param_specs<'a>(
         &self,
-        fp: &GrammarASTNode,
+        fp: &'a GrammarASTNode,
         ctx_node: &GrammarASTNode,
-    ) -> Result<Vec<String>, JsLowerError> {
-        let mut names = Vec::new();
+    ) -> Result<Vec<FormalParamSpec<'a>>, JsLowerError> {
+        let mut specs = Vec::new();
         for param in children_nodes_named(fp, "formal_parameter") {
-            // A simple parameter is exactly one `Name` token; anything else
-            // (default `= v`, rest `...r`, destructuring `{a}`/`[a]`) means
-            // extra children we don't model in v0.
-            let toks: Vec<&Token> = param
-                .children
-                .iter()
-                .filter_map(|c| match c {
-                    ASTNodeOrToken::Token(t) => Some(t),
-                    ASTNodeOrToken::Node(_) => None,
-                })
-                .collect();
-            let has_node_child =
-                param.children.iter().any(|c| matches!(c, ASTNodeOrToken::Node(_)));
-            match (toks.as_slice(), has_node_child) {
-                ([only], false) if matches!(only.type_, TokenType::Name) => {
-                    names.push(only.value.clone());
+            // The binding must be a *single leading `Name` token* (rejecting
+            // destructuring, whose binding is a node, and rest, whose first
+            // token is `...`).
+            let name = match param.children.first() {
+                Some(ASTNodeOrToken::Token(t)) if matches!(t.type_, TokenType::Name) => {
+                    t.value.clone()
                 }
-                _ => {
-                    return Err(JsLowerError {
-                        message: "default / rest / destructuring parameters are deferred \
-                                  past M4 (only simple positional params supported)"
-                            .to_string(),
-                        line: ctx_node.start_line.unwrap_or(0),
-                        column: ctx_node.start_column.unwrap_or(0),
-                    });
+                _ => return Err(self.deferred_param(ctx_node)),
+            };
+            // Classify the remaining children:
+            //   - none                      → plain param (`a`)
+            //   - [Equals, <expr-node>]     → default param (`a = expr`)
+            //   - anything else             → deferred
+            let default = match &param.children[1..] {
+                [] => None,
+                [ASTNodeOrToken::Token(eq), ASTNodeOrToken::Node(expr)]
+                    if eq.value == "=" =>
+                {
+                    Some(expr)
                 }
-            }
+                _ => return Err(self.deferred_param(ctx_node)),
+            };
+            specs.push(FormalParamSpec { name, default });
         }
-        Ok(names)
+        Ok(specs)
+    }
+
+    /// The positioned "deferred parameter form" error (rest / destructuring).
+    fn deferred_param(&self, ctx_node: &GrammarASTNode) -> JsLowerError {
+        JsLowerError {
+            message: "rest / destructuring parameters are deferred past M4 \
+                      (simple positional and default params supported)"
+                .to_string(),
+            line: ctx_node.start_line.unwrap_or(0),
+            column: ctx_node.start_column.unwrap_or(0),
+        }
     }
 
     /// A fresh synthesised arrow-function name (`__lambda_<N>`).
@@ -3105,6 +3206,73 @@ enum Lowered {
 // ---------------------------------------------------------------------------
 // Free helpers
 // ---------------------------------------------------------------------------
+
+/// Conservatively decide whether evaluating `expr` may have an observable
+/// side effect (printing, mutation, allocation, or *any* call whose callee
+/// could).  Used by the block builder to decide whether a bare-expression
+/// statement that is *superseded* as a tail value must still be flushed as
+/// an `ExprStmt` (it may run for effect) or can be dropped (it's pure).
+///
+/// This is deliberately **conservative**: when in doubt we answer `true`
+/// (keep the statement).  Dropping a side-effecting expression is a
+/// correctness bug; keeping a pure one is at most a harmless dead `ExprStmt`
+/// that later passes can elide.
+///
+/// Pure (droppable) forms are the literals, a variable reference, and the
+/// pure operators over pure operands.  Everything that *calls* (a
+/// `DirectCall` / `IndirectCall` / `BuiltinCall` such as `print`) or builds
+/// a closure is treated as potentially effectful.
+fn expr_may_have_effects(expr: &Expr) -> bool {
+    match expr {
+        // Provably pure leaves.
+        Expr::IntLit { .. }
+        | Expr::FloatLit { .. }
+        | Expr::BoolLit { .. }
+        | Expr::NilLit { .. }
+        | Expr::SymLit { .. }
+        | Expr::StrLit { .. }
+        | Expr::VarRef { .. } => false,
+
+        // Pure iff every operand is pure.
+        Expr::StrConcat { parts, .. } => parts.iter().any(expr_may_have_effects),
+        Expr::SeqLit { items, .. } => items.iter().any(expr_may_have_effects),
+        Expr::SeqLen { seq, .. } => expr_may_have_effects(seq),
+        Expr::SeqIndex { seq, index, .. } => {
+            expr_may_have_effects(seq) || expr_may_have_effects(index)
+        }
+        Expr::MapGet { map, key, .. } => {
+            expr_may_have_effects(map) || expr_may_have_effects(key)
+        }
+        Expr::MapLit { entries, .. } => entries
+            .iter()
+            .any(|e| expr_may_have_effects(&e.key) || expr_may_have_effects(&e.value)),
+        Expr::LogicalAnd { lhs, rhs, .. } | Expr::LogicalOr { lhs, rhs, .. } => {
+            expr_may_have_effects(lhs) || expr_may_have_effects(rhs)
+        }
+        Expr::If { cond, then_branch, else_branch, .. } => {
+            expr_may_have_effects(cond)
+                || block_may_have_effects(then_branch)
+                || block_may_have_effects(else_branch)
+        }
+        Expr::Block(b) => block_may_have_effects(b),
+
+        // Calls, closures, and intrinsics may do anything → keep.
+        Expr::DirectCall { .. }
+        | Expr::IndirectCall { .. }
+        | Expr::BuiltinCall { .. }
+        | Expr::MakeClosure { .. }
+        | Expr::Intrinsic { .. } => true,
+    }
+}
+
+/// A block may have an effect if any of its statements does, or if its tail
+/// value expression does.  Any statement at all (`let*`, `assign`, an
+/// `ExprStmt` we only keep *because* it had an effect, a loop, …) is treated
+/// as effectful — the block builder never emits a statement for a provably
+/// pure dropped value.
+fn block_may_have_effects(block: &Block) -> bool {
+    !block.stmts.is_empty() || expr_may_have_effects(&block.value)
+}
 
 /// If `node` has exactly one child and that child is a nested node,
 /// return it.  This is the workhorse for descending the CST's precedence

--- a/code/packages/rust/javascript-to-semantic-ir/tests/e2e_node.rs
+++ b/code/packages/rust/javascript-to-semantic-ir/tests/e2e_node.rs
@@ -143,6 +143,26 @@ fn object_get_set_runs_in_node() {
 }
 
 #[test]
+fn default_params_run_in_node() {
+    if !node_available() {
+        eprintln!("skipping default_params_run_in_node: `node` not available");
+        return;
+    }
+    // A default that references an earlier param (`b = a + 1`), exercised
+    // both by a *partial* call that omits `b` (`f(5)` → default → 6) and a
+    // full call that supplies it (`f(5, 10)` → 10).  Running this under node
+    // proves the call-time + param-scope semantics end to end: the default
+    // is evaluated at the call site against the actual `a`.
+    let out = run_via_node(
+        "default_params",
+        "function f(a, b = a + 1) { return b; }\n\
+         console.log(f(5));\n\
+         console.log(f(5, 10));",
+    );
+    assert_eq!(out, "6\n10");
+}
+
+#[test]
 fn mutual_recursion_runs_in_node() {
     if !node_available() {
         eprintln!("skipping mutual_recursion_runs_in_node: `node` not available");

--- a/code/specs/SIR19-javascript-to-semantic-ir.md
+++ b/code/specs/SIR19-javascript-to-semantic-ir.md
@@ -197,6 +197,32 @@ and `value = r`.
 declarations are not preserved.  v0 doesn't support `this` at all —
 no class support means no `this` cases worth modelling.
 
+## Default parameters (P9)
+
+A formal parameter with an initializer — the CST shape
+`formal_parameter[ Name, "=", assignment_expression ]` — lowers to
+`Param { default: Some(<lowered initializer>) }`.  A plain `formal_parameter`
+(`[Name]`) keeps `default: None`.  This applies uniformly to `function`
+declarations and arrow functions.
+
+JavaScript defaults are **call-time** and may reference **earlier**
+parameters (`function f(a, b = a + 1)`), which is exactly the SIR
+`Param.default` model.  We honour this by lowering each default initializer
+*inside the function frame* (after the param scope is pushed): a reference to
+an earlier param then resolves as a `Scope::Param` `VarRef`.  The initializer
+is an ordinary expression, lowered through the `MAX_EXPR_DEPTH`-bounded
+expression lowerer (no new unbounded CST walk).
+
+A call that omits a trailing defaulted argument (`f(5)` against
+`function f(a, b = a + 1)`) lowers to a **partial** `DirectCall` carrying only
+the present arguments; the omitted parameter is filled by its default at the
+call site.  The SIR validator permits such partial calls when the trailing
+params have defaults.
+
+A defaulted parameter makes the module observe `Feature::DefaultParams` (plus
+any feature the default expression itself uses).  Rest `...args` and
+destructuring parameters remain deferred.
+
 ## Collections (M5)
 
 **Implementation note (M5).**  Arrays, objects, member / dot / subscript
@@ -314,8 +340,10 @@ Errors:
 - Early `return` mid-function
 - Reassignment to a `const` — actually NOT an error in v0; permitted.
 - Unsupported syntax: `class`, `try`/`catch`, `throw`, `async`/`await`,
-  generators, destructuring, spread, default parameters, rest parameters,
+  generators, destructuring, spread, rest parameters (`...args`),
   `with`, `eval`, `new`, `this` outside permitted contexts.
+  (Default parameters are now **supported** — see "Default parameters
+  (P9)".)
 - `import` / `export` (multi-module is out of scope)
 
 ## Tests
@@ -339,8 +367,7 @@ Coverage target ≥ 90%.
 - Generators / `yield`
 - `async function` / `await`
 - Destructuring (`const { a, b } = obj;`)
-- Spread / rest (`...args`)
-- Default parameters
+- Spread / rest parameters (`...args`)
 - Tagged template literals
 - ES module `import` / `export`
 - `eval` / `Function()` constructor


### PR DESCRIPTION
The `javascript-to-semantic-ir` frontend now **produces** default parameters for `function` decls and arrow functions (M4 deferred them). Completes the JS side of the default-param cascade.

- A defaulted formal param `name = <expr>` lowers the initializer via the existing `MAX_EXPR_DEPTH`-bounded `lower_expression`, **inside the pushed function frame**, so `function f(a, b = a + 1)` lowers b's default to `BuiltinCall("+", [VarRef{a,Param}, IntLit 1])` → call-time, param-scope. Plain params keep `None`; rest/destructuring still deferred. `Feature::DefaultParams` observed.
- Partial calls: `f(5)` omitting a defaulted arg → partial `DirectCall` (validator permits).

**Also fixes an in-scope bug:** two consecutive `console.log(...)` statements silently dropped the first — the top-level block builder discarded a *superseded* tail expression as if always pure. Added a sound, conservative `expr_may_have_effects` (exhaustive over Expr, no wildcard; effectful→flush as ExprStmt, only provably-pure dropped). The e2e (two prints) exercises this.

**Tests:** 115 lib + 7 node e2e (replaced the default-deferred test with literal/plain/earlier-param-ref/arrow/partial-call cases; `function f(a, b=a+1)` → `console.log(f(5))`→`6`, `f(5,10)`→`10` under node). clippy clean; security review passed (effects helper confirmed sound — won't drop side-effecting expressions). Isolated to `javascript-to-semantic-ir`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)