### PR TITLE
feat(ruby-sir): produce default parameters — def f(a=1) (P7, closes the Ruby 1.0 gap)

### DIFF
--- a/code/grammars/ruby.grammar
+++ b/code/grammars/ruby.grammar
@@ -265,7 +265,19 @@ super_args = LPAREN [ call_arg { COMMA call_arg } ] RPAREN
 # child, not a `param` node); the call-side `n(...)` marker carries the
 # forwarding semantics.
 params       = "..." | param { COMMA param } ;
-param        = [ "*" | "**" ] NAME ;
+# Phase P7 (Ruby 1.0) — optional/default parameters `name = expr`.
+#
+# A `param` may now carry a trailing `= expression` default value, e.g.
+# `def f(a = 1)` or `def f(a, b = a + 1)`.  The default is an ordinary
+# `expression`, which the PEG parser stops at the next COMMA / RPAREN
+# (the default `a + 1` does not greedily swallow a following `, c`
+# because `expression` itself never matches a bare comma list).  Ruby
+# defaults are evaluated at call time and may reference EARLIER params
+# (`def f(a, b = a)` is legal Ruby), so the SIR lowerer evaluates the
+# default subtree in the param scope.  Splat (`*rest`) and double-splat
+# (`**kwrest`) params never carry a default; the grammar is permissive
+# here and the lowerer attaches `Param.default` only to ordinary params.
+param        = [ "*" | "**" ] NAME [ EQUALS expression ] ;
 if_statement = "if" expression { !"else" !"elsif" !"end" statement } { elsif_clause } [ else_clause ] "end" ;
 elsif_clause = "elsif" expression { !"else" !"elsif" !"end" statement } ;
 else_clause  = "else" { !"end" statement } ;

--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.80.0] - 2026-06-30
+
+### Added (P7 — default / optional parameters in `param`)
+
+- The `param` rule now accepts an optional default value:
+  `param = [ "*" | "**" ] NAME [ EQUALS expression ] ;`. This makes
+  `def f(a = 1)`, `def f(a, b = a + 1)`, and `->(a = 1) { … }` parse — they
+  previously parse-panicked at the `=` because `param` had no default branch.
+  The default is an ordinary `expression`, which the PEG parser stops at the
+  next `COMMA` / `RPAREN`, so `def f(a, b = a + 1, c)` does not greedily
+  swallow `c`. Updated both `code/grammars/ruby.grammar` and the embedded
+  `src/_grammar.rs` (regenerated via `grammar-tools
+  generate-rust-compiled-grammars ruby-parser`). The `ruby-to-semantic-ir`
+  frontend lowers the default subtree into `Param.default`.
+- Cargo crate version bumped `0.1.0` → `0.2.0`.
+
 ## [0.79.0] - 2026-06-19
 
 ### Added (RB1 — trailing block on receiver/dotted method calls)

--- a/code/packages/rust/ruby-parser/Cargo.toml
+++ b/code/packages/rust/ruby-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-ruby-parser"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Ruby parser — parses Ruby source code into an AST using the grammar-driven parser and the ruby.grammar file"
 

--- a/code/packages/rust/ruby-parser/src/_grammar.rs
+++ b/code/packages/rust/ruby-parser/src/_grammar.rs
@@ -393,8 +393,12 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::Literal { value: r#"**"#.to_string() },
                     ] }) },
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"EQUALS"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"expression"#.to_string() },
+                    ] }) },
             ] },
-            line_number: 268,
+            line_number: 280,
         },
         GrammarRule {
             name: r#"if_statement"#.to_string(),
@@ -411,7 +415,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"else_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 269,
+            line_number: 281,
         },
         GrammarRule {
             name: r#"elsif_clause"#.to_string(),
@@ -425,7 +429,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 270,
+            line_number: 282,
         },
         GrammarRule {
             name: r#"else_clause"#.to_string(),
@@ -436,7 +440,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 271,
+            line_number: 283,
         },
         GrammarRule {
             name: r#"unless_statement"#.to_string(),
@@ -451,7 +455,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"else_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 272,
+            line_number: 284,
         },
         GrammarRule {
             name: r#"while_statement"#.to_string(),
@@ -464,7 +468,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 273,
+            line_number: 285,
         },
         GrammarRule {
             name: r#"until_statement"#.to_string(),
@@ -477,7 +481,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 274,
+            line_number: 286,
         },
         GrammarRule {
             name: r#"case_statement"#.to_string(),
@@ -491,7 +495,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"else_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 297,
+            line_number: 309,
         },
         GrammarRule {
             name: r#"when_clause"#.to_string(),
@@ -510,7 +514,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 298,
+            line_number: 310,
         },
         GrammarRule {
             name: r#"in_clause"#.to_string(),
@@ -525,7 +529,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 320,
+            line_number: 332,
         },
         GrammarRule {
             name: r#"pattern"#.to_string(),
@@ -537,7 +541,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"literal_pattern"#.to_string() },
                 GrammarElement::RuleReference { name: r#"binding_pattern"#.to_string() },
             ] },
-            line_number: 321,
+            line_number: 333,
         },
         GrammarRule {
             name: r#"literal_pattern"#.to_string(),
@@ -547,12 +551,12 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"symbol_literal"#.to_string() },
                 GrammarElement::TokenReference { name: r#"KEYWORD"#.to_string() },
             ] },
-            line_number: 322,
+            line_number: 334,
         },
         GrammarRule {
             name: r#"binding_pattern"#.to_string(),
             body: GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
-            line_number: 323,
+            line_number: 335,
         },
         GrammarRule {
             name: r#"array_pattern"#.to_string(),
@@ -573,7 +577,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
             ] },
-            line_number: 324,
+            line_number: 336,
         },
         GrammarRule {
             name: r#"hash_pattern"#.to_string(),
@@ -588,7 +592,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 325,
+            line_number: 337,
         },
         GrammarRule {
             name: r#"hash_pattern_pair"#.to_string(),
@@ -597,7 +601,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"pattern"#.to_string() }) },
             ] },
-            line_number: 326,
+            line_number: 338,
         },
         GrammarRule {
             name: r#"splat_pattern"#.to_string(),
@@ -605,7 +609,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"*"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::TokenReference { name: r#"NAME"#.to_string() }) },
             ] },
-            line_number: 333,
+            line_number: 345,
         },
         GrammarRule {
             name: r#"pin_pattern"#.to_string(),
@@ -613,7 +617,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"^"#.to_string() },
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
             ] },
-            line_number: 338,
+            line_number: 350,
         },
         GrammarRule {
             name: r#"class_pattern"#.to_string(),
@@ -629,7 +633,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
             ] },
-            line_number: 344,
+            line_number: 356,
         },
         GrammarRule {
             name: r#"begin_statement"#.to_string(),
@@ -645,7 +649,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"ensure_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 365,
+            line_number: 377,
         },
         GrammarRule {
             name: r#"rescue_clause"#.to_string(),
@@ -663,7 +667,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 374,
+            line_number: 386,
         },
         GrammarRule {
             name: r#"exception_list"#.to_string(),
@@ -674,7 +678,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
                     ] }) },
             ] },
-            line_number: 375,
+            line_number: 387,
         },
         GrammarRule {
             name: r#"ensure_clause"#.to_string(),
@@ -685,7 +689,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 376,
+            line_number: 388,
         },
         GrammarRule {
             name: r#"assignment"#.to_string(),
@@ -709,7 +713,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"expression"#.to_string() },
             ] },
-            line_number: 396,
+            line_number: 408,
         },
         GrammarRule {
             name: r#"rightward_assignment"#.to_string(),
@@ -718,7 +722,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"=>"#.to_string() },
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
             ] },
-            line_number: 415,
+            line_number: 427,
         },
         GrammarRule {
             name: r#"method_call"#.to_string(),
@@ -738,7 +742,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"dot_call"#.to_string() }) },
             ] },
-            line_number: 426,
+            line_number: 438,
         },
         GrammarRule {
             name: r#"dot_call"#.to_string(),
@@ -761,7 +765,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"block"#.to_string() }) },
             ] },
-            line_number: 427,
+            line_number: 439,
         },
         GrammarRule {
             name: r#"scope_resolution"#.to_string(),
@@ -772,7 +776,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"KEYWORD"#.to_string() },
                     ] }) },
             ] },
-            line_number: 435,
+            line_number: 447,
         },
         GrammarRule {
             name: r#"call_arg"#.to_string(),
@@ -784,7 +788,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"expression"#.to_string() },
             ] },
-            line_number: 465,
+            line_number: 477,
         },
         GrammarRule {
             name: r#"method_call_no_paren"#.to_string(),
@@ -799,17 +803,17 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                     ] }) },
             ] },
-            line_number: 479,
+            line_number: 491,
         },
         GrammarRule {
             name: r#"expression_stmt"#.to_string(),
             body: GrammarElement::RuleReference { name: r#"expression"#.to_string() },
-            line_number: 480,
+            line_number: 492,
         },
         GrammarRule {
             name: r#"expression"#.to_string(),
             body: GrammarElement::RuleReference { name: r#"ternary"#.to_string() },
-            line_number: 587,
+            line_number: 599,
         },
         GrammarRule {
             name: r#"ternary"#.to_string(),
@@ -822,7 +826,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                     ] }) },
             ] },
-            line_number: 588,
+            line_number: 600,
         },
         GrammarRule {
             name: r#"range"#.to_string(),
@@ -845,7 +849,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) },
                 ] },
             ] },
-            line_number: 589,
+            line_number: 601,
         },
         GrammarRule {
             name: r#"logical_or"#.to_string(),
@@ -859,7 +863,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_and"#.to_string() },
                     ] }) },
             ] },
-            line_number: 590,
+            line_number: 602,
         },
         GrammarRule {
             name: r#"logical_and"#.to_string(),
@@ -873,7 +877,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_not"#.to_string() },
                     ] }) },
             ] },
-            line_number: 591,
+            line_number: 603,
         },
         GrammarRule {
             name: r#"logical_not"#.to_string(),
@@ -884,7 +888,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) }) },
                 GrammarElement::RuleReference { name: r#"comparison"#.to_string() },
             ] },
-            line_number: 598,
+            line_number: 610,
         },
         GrammarRule {
             name: r#"comparison"#.to_string(),
@@ -902,7 +906,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"sum"#.to_string() },
                     ] }) },
             ] },
-            line_number: 599,
+            line_number: 611,
         },
         GrammarRule {
             name: r#"sum"#.to_string(),
@@ -916,7 +920,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"term"#.to_string() },
                     ] }) },
             ] },
-            line_number: 600,
+            line_number: 612,
         },
         GrammarRule {
             name: r#"term"#.to_string(),
@@ -930,7 +934,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"factor"#.to_string() },
                     ] }) },
             ] },
-            line_number: 601,
+            line_number: 613,
         },
         GrammarRule {
             name: r#"factor"#.to_string(),
@@ -958,7 +962,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"scope_resolution"#.to_string() },
                     ] }) },
             ] },
-            line_number: 611,
+            line_number: 623,
         },
         GrammarRule {
             name: r#"lambda_literal"#.to_string(),
@@ -971,7 +975,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"block"#.to_string() },
             ] },
-            line_number: 630,
+            line_number: 642,
         },
         GrammarRule {
             name: r#"unary_minus"#.to_string(),
@@ -979,7 +983,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"MINUS"#.to_string() },
                 GrammarElement::RuleReference { name: r#"factor"#.to_string() },
             ] },
-            line_number: 631,
+            line_number: 643,
         },
         GrammarRule {
             name: r#"defined_expression"#.to_string(),
@@ -987,7 +991,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"defined?"#.to_string() },
                 GrammarElement::RuleReference { name: r#"factor"#.to_string() },
             ] },
-            line_number: 642,
+            line_number: 654,
         },
         GrammarRule {
             name: r#"symbol_literal"#.to_string(),
@@ -999,7 +1003,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
                     ] }) },
             ] },
-            line_number: 649,
+            line_number: 661,
         },
         GrammarRule {
             name: r#"array_literal"#.to_string(),
@@ -1014,7 +1018,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
             ] },
-            line_number: 650,
+            line_number: 662,
         },
         GrammarRule {
             name: r#"hash_literal"#.to_string(),
@@ -1029,7 +1033,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 651,
+            line_number: 663,
         },
         GrammarRule {
             name: r#"hash_entry"#.to_string(),
@@ -1049,7 +1053,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                 ] },
             ] },
-            line_number: 652,
+            line_number: 664,
         },
     ],
         version: 1,

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,57 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.99.0] - 2026-06-30
+
+### Added (P7 — default / optional parameters, Ruby-1.0 gap closed)
+
+- `def f(a = 1)` now PRODUCES a default parameter. The frontend used to extract
+  the param name but *silently drop* the `= <default>` subtree; worse, the
+  grammar `param` rule (`[ "*" | "**" ] NAME`) had **no default-value branch at
+  all**, so `def f(a = 1)` did not even parse. Both gaps are now closed:
+  - **Grammar.** `param` is extended to `param = [ "*" | "**" ] NAME [ EQUALS
+    expression ]` in both `code/grammars/ruby.grammar` and the embedded
+    `ruby-parser/src/_grammar.rs` (kept in sync per the grammar-tools rule).
+  - **Lowering.** A new `Lowerer::extract_params` helper centralises the
+    parameter walk for all three call sites (`def_statement`,
+    `endless_def_statement`, `lambda_literal`). When a param carries a default
+    `expression` child, it is lowered through the normal bounded
+    `lower_expression` path into `Param { default: Some(Box::new(expr)), .. }`.
+    Required / rest (`*r`) / kwrest (`**o`) params keep `default: None`.
+  - **Call-time, param-scoped.** Ruby defaults evaluate at call time and may
+    reference EARLIER params (`def f(a, b = a)` is legal Ruby). `extract_params`
+    lowers each default with every prior param already visible as a
+    `Scope::Param`, matching the SIR validator's model exactly. The temporary
+    scope visibility is snapshotted and restored so it does not leak into the
+    method body scope.
+  - **Feature manifest.** A defaulted param now observes `Feature::DefaultParams`
+    and the manifest materialiser emits it, so the SIR validator accepts the
+    used feature.
+  - **Partial calls.** A call that omits a defaulted arg (`f(5)` for
+    `def f(a, b = 1)`) lowers to a call with FEWER args — the frontend lowers the
+    args present and does not pad. The SIR validator (and the Python/JS backends)
+    now permit omitting trailing defaulted args.
+
+### Tests
+
+- Six new unit tests: `def f(a = 1)` → `Param.default = Some(IntLit 1)`;
+  `def f(a, b = a + 1)` → default referencing param `a` resolves to
+  `Scope::Param` and the module validates; required/rest params keep no default;
+  the DefaultParams feature is observed only when a default is present; and a
+  partial call lowers without padding the omitted default.
+- End-to-end execution proof lives in `semantic-ir-to-python` (which already
+  depends on this crate as a dev-dependency):
+  `def f(a, b = a + 1)\n  b + 0\nend\nprint f(5)\nprint f(5, 10)` → Ruby SIR →
+  Python source → CPython prints `6` then `10`, proving the default is genuinely
+  call-time and param-scoped through the whole pipeline.
+
+### Notes
+
+- A pre-existing parser quirk (a method body that is a single *bare* identifier,
+  e.g. `def f(a)\n  a\nend`, mis-parses as a no-paren call) is unrelated to this
+  change; the new tests use honest expression bodies (`a + 0`).
+- Cargo crate version bumped `0.1.0` → `0.2.0`.
+
 ## [0.98.0] - 2026-06-26
 
 ### Changed (M5 — `when` uses case-equality `===`, not `==`)

--- a/code/packages/rust/ruby-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/ruby-to-semantic-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruby-to-semantic-ir"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Ruby AST → narrow-waist Semantic IR. Phase 5 of the Ruby parser project — first frontend for the ruby-parser → SIR pipeline."
 

--- a/code/packages/rust/ruby-to-semantic-ir/README.md
+++ b/code/packages/rust/ruby-to-semantic-ir/README.md
@@ -45,6 +45,14 @@ parses (see [ruby-parser/src/_grammar.rs](../ruby-parser/src/_grammar.rs)):
   is the sequence of lowered statements.  If the final source-level
   statement is a bare expression, it becomes the block's *value*;
   otherwise the value is `NilLit`.
+- **Parameters** — positional, splat (`*rest`), and double-splat
+  (`**kwrest`), plus **default / optional parameters** (P7, Ruby-1.0):
+  `def f(a = 1)` lowers `a`'s default to `Param.default = Some(IntLit 1)`.
+  Ruby defaults are call-time and may reference earlier params
+  (`def f(a, b = a + 1)`), so the default expression is lowered in the
+  parameter scope and resolves earlier params as `Scope::Param`.  A
+  defaulted param observes `Feature::DefaultParams`; a call that omits a
+  defaulted arg (`f(5)`) lowers to a call with fewer args (no padding).
 
 ## Usage
 

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -76,6 +76,158 @@ mod tests {
         &f.body
     }
 
+    // -----------------------------------------------------------------
+    // Phase P7 (Ruby 1.0) — default / optional parameters.
+    //
+    // Before P7 the grammar `param` rule was `[ "*" | "**" ] NAME`, with
+    // no default-value branch — so `def f(a = 1)` did not even PARSE.  P7
+    // extends the grammar to `param = [ "*" | "**" ] NAME [ EQUALS
+    // expression ]` and the lowerer (`extract_params`) carries the
+    // default subtree into `Param.default`.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn def_default_param_lowers_to_param_default_intlit() {
+        // `def f(a = 1)` → the single Param carries `default: Some(IntLit 1)`.
+        let m = lower("def f(a = 1)\n  a + 0\nend\n");
+        let f = m.functions.iter().find(|f| f.name == "f").expect("fn f");
+        assert_eq!(f.params.len(), 1);
+        assert_eq!(f.params[0].name, "a");
+        assert_eq!(f.params[0].kind, ParamKind::Required);
+        match &f.params[0].default {
+            Some(boxed) => assert!(
+                matches!(**boxed, Expr::IntLit { value: 1, .. }),
+                "expected default IntLit(1), got {:?}",
+                boxed
+            ),
+            None => panic!("expected a default value, got None"),
+        }
+    }
+
+    #[test]
+    fn def_default_param_observes_default_params_feature() {
+        // A defaulted param must make the manifest declare `DefaultParams`
+        // (otherwise the validator rejects the used-but-undeclared feature).
+        let m = lower("def f(a = 1)\n  a + 0\nend\n");
+        assert!(
+            m.manifest.contains(semantic_ir::Feature::DefaultParams),
+            "manifest should declare DefaultParams; declared = {:?}",
+            m.manifest
+        );
+    }
+
+    #[test]
+    fn def_default_param_can_reference_earlier_param() {
+        // `def f(a, b = a + 1)` — Ruby defaults are call-time and may
+        // reference EARLIER params.  `a` inside the default for `b` must
+        // resolve to `Scope::Param`, not an unbound local.
+        let m = lower("def f(a, b = a + 1)\n  b + 0\nend\n");
+        let f = m.functions.iter().find(|f| f.name == "f").expect("fn f");
+        assert_eq!(f.params.len(), 2);
+        assert_eq!(f.params[0].name, "a");
+        assert!(f.params[0].default.is_none(), "first param has no default");
+        assert_eq!(f.params[1].name, "b");
+        let default = f.params[1]
+            .default
+            .as_ref()
+            .expect("second param has a default");
+        // The default is `a + 1` → BuiltinCall("+", [VarRef(a, Param), IntLit 1]).
+        match &**default {
+            Expr::BuiltinCall { name, args, .. } => {
+                assert_eq!(name, "+");
+                match &args[0] {
+                    Expr::VarRef { name, scope, .. } => {
+                        assert_eq!(name, "a");
+                        assert_eq!(*scope, Scope::Param);
+                    }
+                    other => panic!("expected VarRef(a, Param), got {:?}", other),
+                }
+                assert!(matches!(args[1], Expr::IntLit { value: 1, .. }));
+            }
+            other => panic!("expected BuiltinCall(+), got {:?}", other),
+        }
+        // And the module validates (the default checks in param scope).
+        assert!(
+            semantic_ir::validate(&m).is_ok(),
+            "module with param-scoped default should validate: {:?}",
+            semantic_ir::validate(&m).issues
+        );
+    }
+
+    #[test]
+    fn def_required_param_keeps_no_default() {
+        // Regression: an ordinary positional param keeps `default: None`
+        // and does NOT trip the DefaultParams feature.
+        let m = lower("def k(a)\nend\n");
+        let k = m.functions.iter().find(|f| f.name == "k").expect("fn k");
+        assert!(k.params[0].default.is_none());
+        assert!(!m.manifest.contains(semantic_ir::Feature::DefaultParams));
+    }
+
+    #[test]
+    fn def_rest_param_never_carries_default() {
+        // Splat params keep `default: None` even though the grammar is
+        // permissive — `extract_params` attaches defaults only to ordinary
+        // params.
+        let m = lower("def f(a = 1, *r)\nend\n");
+        let f = m.functions.iter().find(|f| f.name == "f").expect("fn f");
+        assert_eq!(f.params.len(), 2);
+        assert!(f.params[0].default.is_some());
+        assert_eq!(f.params[1].kind, ParamKind::Rest);
+        assert!(f.params[1].default.is_none());
+    }
+
+    #[test]
+    fn call_omitting_default_lowers_to_partial_arg_list() {
+        // A call that omits the defaulted arg must lower with FEWER args —
+        // the frontend lowers the args present and does NOT pad.  The SIR
+        // validator now permits a DirectCall/BuiltinCall that omits trailing
+        // defaulted params.
+        let m = lower("def f(a, b = 1)\n  a + b\nend\nf(5)\n");
+        // The whole module (def with default + partial call) validates.
+        assert!(
+            semantic_ir::validate(&m).is_ok(),
+            "module with partial call should validate: {:?}",
+            semantic_ir::validate(&m).issues
+        );
+        // Locate the call in main's body and confirm it carries a single arg.
+        let body = main_body(&m);
+        // The defaulted-arg value `1` must NOT appear in the call's lowered
+        // args — i.e. the call carries exactly one arg (the literal `5`),
+        // proving the frontend does not pad omitted defaults.
+        let mut found_int5 = false;
+        let mut found_int1_as_arg = false;
+        for s in &body.stmts {
+            if let Stmt::ExprStmt { expr, .. } = s {
+                scan_call_args(expr, &mut found_int5, &mut found_int1_as_arg);
+            }
+        }
+        scan_call_args(&body.value, &mut found_int5, &mut found_int1_as_arg);
+        assert!(found_int5, "expected the literal arg 5 in the call to f");
+        assert!(
+            !found_int1_as_arg,
+            "frontend must NOT pad the omitted default (no synthesised arg 1)"
+        );
+    }
+
+    /// Walk an expression; for every call node record whether its arg list
+    /// contains an `IntLit 5` and whether it contains an `IntLit 1`.  Used
+    /// to prove `f(5)` lowers to a single-arg call (the `b = 1` default is
+    /// NOT padded in by the frontend).
+    fn scan_call_args(e: &Expr, found5: &mut bool, found1: &mut bool) {
+        if let Expr::DirectCall { args, .. } | Expr::BuiltinCall { args, .. } = e {
+            for a in args {
+                if matches!(a, Expr::IntLit { value: 5, .. }) {
+                    *found5 = true;
+                }
+                if matches!(a, Expr::IntLit { value: 1, .. }) {
+                    *found1 = true;
+                }
+                scan_call_args(a, found5, found1);
+            }
+        }
+    }
+
     #[test]
     fn empty_program_compiles_to_nil_main() {
         let m = lower("");

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -175,6 +175,10 @@ pub fn compile(program: &GrammarASTNode, module_name: &str) -> Result<Module, Ru
         // or nested element ANDs its checks via `Expr::LogicalAnd`, which
         // triggers the `ShortCircuit` feature.
         Feature::ShortCircuit,
+        // Phase P7 (Ruby 1.0) — a parameter with a `name = expr` default
+        // lowers to `Param.default = Some(_)` and triggers the
+        // `DefaultParams` feature (`extract_params`).
+        Feature::DefaultParams,
     ] {
         if lw.features_used.contains(&f) {
             manifest.add(f);
@@ -3968,43 +3972,13 @@ impl Lowerer {
         // Reuse the same extraction (find each `param` subnode, detect the
         // `*`/`**` splat prefix → ParamKind, take the identifier Name).  See
         // the matching code in `lower_def_statement` (M3).
+        // Phase P7: extract params with `name = expr` defaults (see
+        // `extract_params`).  Endless defs share the `params` rule shape.
         let params_node = node.children.iter().find_map(|c| match c {
             ASTNodeOrToken::Node(n) if n.rule_name == "params" => Some(n),
             _ => None,
         });
-        let params: Vec<Param> = if let Some(pn) = params_node {
-            pn.children
-                .iter()
-                .filter_map(|c| match c {
-                    ASTNodeOrToken::Node(param_node) if param_node.rule_name == "param" => {
-                        let kind = param_node.children.iter().find_map(|cc| match cc {
-                            ASTNodeOrToken::Token(t) if t.value == "**" => Some(ParamKind::KwRest),
-                            ASTNodeOrToken::Token(t) if t.value == "*" => Some(ParamKind::Rest),
-                            _ => None,
-                        });
-                        param_node.children.iter().find_map(|cc| match cc {
-                            ASTNodeOrToken::Token(t)
-                                if matches!(t.type_, TokenType::Name)
-                                    && t.value != "*"
-                                    && t.value != "**" =>
-                            {
-                                Some(Param {
-                                    name: t.value.clone(),
-                                    sir_type: None,
-                                    kind: kind.unwrap_or(ParamKind::Required),
-                                    default: None,
-                                    span: self.span_of_token(t),
-                                })
-                            }
-                            _ => None,
-                        })
-                    }
-                    _ => None,
-                })
-                .collect()
-        } else {
-            Vec::new()
-        };
+        let params: Vec<Param> = self.extract_params(params_node)?;
 
         if !params.is_empty() {
             self.features_used.insert(Feature::DynamicTyping);
@@ -4105,49 +4079,14 @@ impl Lowerer {
         // `ParamKind::Required` — so the backends can emit faithful
         // `*args`/`**kwargs` (Python) / `...rest` (TypeScript).  See
         // `code/specs/sir-variadic-params.md`.
+        // Phase P7: extract params, lowering `name = expr` defaults into
+        // `Param.default` (param-scoped, so later defaults may reference
+        // earlier params).  See `extract_params`.
         let params_node = node.children.iter().find_map(|c| match c {
             ASTNodeOrToken::Node(n) if n.rule_name == "params" => Some(n),
             _ => None,
         });
-        let params: Vec<Param> = if let Some(pn) = params_node {
-            pn.children
-                .iter()
-                .filter_map(|c| match c {
-                    ASTNodeOrToken::Node(param_node) if param_node.rule_name == "param" => {
-                        // Detect the leading `*`/`**` splat prefix (the
-                        // 1.8-baseline state machine coalesces `**` into one
-                        // Name token with value `"**"`; `*` is a Star token,
-                        // but a defensive value match covers either spelling).
-                        let kind = param_node.children.iter().find_map(|cc| match cc {
-                            ASTNodeOrToken::Token(t) if t.value == "**" => Some(ParamKind::KwRest),
-                            ASTNodeOrToken::Token(t) if t.value == "*" => Some(ParamKind::Rest),
-                            _ => None,
-                        });
-                        // The parameter Name token is the one that is not the
-                        // `*`/`**` prefix.
-                        param_node.children.iter().find_map(|cc| match cc {
-                            ASTNodeOrToken::Token(t)
-                                if matches!(t.type_, TokenType::Name)
-                                    && t.value != "*"
-                                    && t.value != "**" =>
-                            {
-                                Some(Param {
-                                    name: t.value.clone(),
-                                    sir_type: None,
-                                    kind: kind.unwrap_or(ParamKind::Required),
-                                    default: None,
-                                    span: self.span_of_token(t),
-                                })
-                            }
-                            _ => None,
-                        })
-                    }
-                    _ => None,
-                })
-                .collect()
-        } else {
-            Vec::new()
-        };
+        let params: Vec<Param> = self.extract_params(params_node)?;
 
         // Phase 6b: any non-empty parameter list means we'll emit
         // untyped Params (sir_type=None), which the SIR validator
@@ -6097,44 +6036,11 @@ impl Lowerer {
 
         // 2. Extract arrow-lambda params from the optional `params`
         //    subnode (Phase 6s: param = [ "*"|"**" ] NAME).
+        // Phase P7: extract arrow-lambda params with `name = expr`
+        // defaults (see `extract_params`).  `->(a = 1) { ... }` is valid
+        // Ruby; the parens-list IS the param list here.
         let params_node = self.find_node_child(node, "params");
-        let params: Vec<Param> = if let Some(pn) = params_node {
-            pn.children
-                .iter()
-                .filter_map(|c| match c {
-                    ASTNodeOrToken::Node(param_node)
-                        if param_node.rule_name == "param" =>
-                    {
-                        // M3: detect the `*`/`**` splat prefix → ParamKind,
-                        // then pick the bare NAME token.
-                        let kind = param_node.children.iter().find_map(|cc| match cc {
-                            ASTNodeOrToken::Token(t) if t.value == "**" => Some(ParamKind::KwRest),
-                            ASTNodeOrToken::Token(t) if t.value == "*" => Some(ParamKind::Rest),
-                            _ => None,
-                        });
-                        param_node.children.iter().find_map(|cc| match cc {
-                            ASTNodeOrToken::Token(t)
-                                if matches!(t.type_, TokenType::Name)
-                                    && t.value != "*"
-                                    && t.value != "**" =>
-                            {
-                                Some(Param {
-                                    name: t.value.clone(),
-                                    sir_type: None,
-                                    kind: kind.unwrap_or(ParamKind::Required),
-                                    default: None,
-                                    span: self.span_of_token(t),
-                                })
-                            }
-                            _ => None,
-                        })
-                    }
-                    _ => None,
-                })
-                .collect()
-        } else {
-            Vec::new()
-        };
+        let params: Vec<Param> = self.extract_params(params_node)?;
         if !params.is_empty() {
             self.features_used.insert(Feature::DynamicTyping);
         }
@@ -6267,6 +6173,137 @@ impl Lowerer {
         });
 
         Ok(fn_name)
+    }
+
+    // -------------------------------------------------------------------
+    // parameters
+    // -------------------------------------------------------------------
+
+    /// Phase P7 (Ruby 1.0) — extract a `def`/lambda parameter list from a
+    /// `params` CST node, lowering any `name = expr` default value into
+    /// `Param.default`.
+    ///
+    /// ## Why this is its own helper
+    ///
+    /// Three call sites (`def_statement`, `endless_def_statement`,
+    /// `lambda_literal`) used to inline the same `filter_map` that pulled
+    /// the param Name and the splat kind but *silently dropped* the
+    /// `= <default>` subtree.  Now that the grammar parses the default
+    /// (`param = [ "*" | "**" ] NAME [ EQUALS expression ]`), the default
+    /// must be lowered through the normal expression path.  Centralising
+    /// it here keeps the three sites in lock-step.
+    ///
+    /// ## CST shape
+    ///
+    /// A `param` node has one of these child layouts:
+    ///
+    /// ```text
+    /// param ::= NAME                         # required:   default = None
+    ///        |  ("*"|"**") NAME              # rest/kwrest: default = None
+    ///        |  NAME EQUALS expression       # optional:   default = Some(expr)
+    /// ```
+    ///
+    /// ## Param-scoped, call-time defaults
+    ///
+    /// Ruby defaults are evaluated at CALL time and may reference EARLIER
+    /// parameters — `def f(a, b = a)` is legal and binds `b` to `a`'s
+    /// runtime value.  This matches the SIR model exactly (the validator
+    /// checks each default in a scope holding the params declared so far).
+    /// To honour that, we lower each default with every *prior* param name
+    /// already visible as a `Scope::Param`, so a `VarRef` to an earlier
+    /// param resolves correctly.  We snapshot and restore the caller's
+    /// `current_params` / `declared_locals` so this temporary visibility
+    /// does not leak — the caller re-establishes the full param scope for
+    /// the body afterwards.
+    ///
+    /// Splat (`*rest`) and double-splat (`**kwrest`) params never carry a
+    /// default; the grammar is permissive but we attach `default` only to
+    /// ordinary params.
+    ///
+    /// The walk is depth-bounded: it reuses the existing bounded
+    /// `lower_expression` for the default subtree and introduces no new
+    /// recursion over the CST.
+    fn extract_params(
+        &mut self,
+        params_node: Option<&GrammarASTNode>,
+    ) -> Result<Vec<Param>, RubyLowerError> {
+        let Some(pn) = params_node else {
+            return Ok(Vec::new());
+        };
+
+        // Snapshot the caller's scope so the incremental "earlier params
+        // are visible" trick below is fully reverted on return.
+        let saved_params = self.current_params.clone();
+        let saved_locals = self.declared_locals.clone();
+
+        let mut params: Vec<Param> = Vec::new();
+        for c in &pn.children {
+            let ASTNodeOrToken::Node(param_node) = c else {
+                continue;
+            };
+            if param_node.rule_name != "param" {
+                continue;
+            }
+
+            // Splat prefix → ParamKind (same detection as before).
+            let kind = param_node.children.iter().find_map(|cc| match cc {
+                ASTNodeOrToken::Token(t) if t.value == "**" => Some(ParamKind::KwRest),
+                ASTNodeOrToken::Token(t) if t.value == "*" => Some(ParamKind::Rest),
+                _ => None,
+            });
+
+            // The parameter Name token is the one that is not the
+            // `*`/`**` prefix.
+            let name_tok = param_node.children.iter().find_map(|cc| match cc {
+                ASTNodeOrToken::Token(t)
+                    if matches!(t.type_, TokenType::Name)
+                        && t.value != "*"
+                        && t.value != "**" =>
+                {
+                    Some(t)
+                }
+                _ => None,
+            });
+            let Some(name_tok) = name_tok else {
+                continue;
+            };
+
+            // Optional default — the trailing `expression` child (present
+            // only when the source wrote `name = expr`).  Rest/kwrest
+            // params keep `default: None`.
+            let default_node = param_node.children.iter().find_map(|cc| match cc {
+                ASTNodeOrToken::Node(n) if n.rule_name == "expression" => Some(n),
+                _ => None,
+            });
+            let default = match (kind, default_node) {
+                (None, Some(expr_node)) => {
+                    let lowered = self.lower_expression(expr_node)?;
+                    self.features_used.insert(Feature::DefaultParams);
+                    Some(Box::new(lowered))
+                }
+                _ => None,
+            };
+
+            // Make THIS param visible to LATER params' defaults
+            // (`def f(a, b = a)`), then record it.
+            self.current_params.insert(name_tok.value.clone());
+            self.declared_locals.insert(name_tok.value.clone());
+
+            params.push(Param {
+                name: name_tok.value.clone(),
+                sir_type: None,
+                kind: kind.unwrap_or(ParamKind::Required),
+                default,
+                span: self.span_of_token(name_tok),
+            });
+        }
+
+        // Revert the temporary scope visibility — the caller owns the
+        // real body scope.
+        self.current_params = saved_params;
+        self.declared_locals = saved_locals;
+
+        Ok(params)
     }
 
     // -------------------------------------------------------------------

--- a/code/packages/rust/semantic-ir-to-python/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-python/src/lib.rs
@@ -293,6 +293,61 @@ mod tests {
     }
 
     #[test]
+    fn end_to_end_ruby_default_param_resolves_at_call_time_executes_py() {
+        // Ruby-1.0 (P7) full-pipeline execution-proof: Ruby SOURCE with a
+        // call-time, param-referencing default → ruby-to-semantic-ir →
+        // semantic-ir-to-python → CPython.  `def f(a, b = a + 1)` is legal
+        // Ruby (the default sees the EARLIER param `a`).  Two calls:
+        //   • `f(5)`     omits `b` → default resolves `b = a + 1 = 6`
+        //   • `f(5, 10)` passes `b` → default suppressed, `b = 10`
+        // so stdout must be `6` then `10`.  This is the discriminating proof
+        // that the Ruby frontend now PRODUCES `Param.default` (it previously
+        // dropped the `= <expr>` subtree) AND that the default is genuinely
+        // call-time and param-scoped end to end — not Python def-time
+        // semantics (which could not reference `a`).
+        // NB: the def body is `b + 0` rather than a bare `b` — the Ruby
+        // parser currently mis-parses a method body that is a single bare
+        // identifier as a no-paren call (a pre-existing quirk unrelated to
+        // defaults); `b + 0` is an honest expression that evaluates to `b`.
+        let src = "def f(a, b = a + 1)\n  b + 0\nend\nprint f(5)\nprint f(5, 10)\n";
+        let module = ruby_to_semantic_ir::compile_source(src, "demo").expect("lower ruby");
+
+        // Frontend must have produced the default and declared the feature.
+        assert!(
+            module.manifest.contains(Feature::DefaultParams),
+            "ruby frontend must declare DefaultParams; manifest = {:?}",
+            module.manifest
+        );
+        let f = module
+            .functions
+            .iter()
+            .find(|f| f.name == "f")
+            .expect("fn f");
+        assert!(
+            f.params[1].default.is_some(),
+            "b must carry a lowered default"
+        );
+
+        let a = compile(&module).expect("compile to python");
+        // Sentinel-default + body-prologue shape (call-time, param-scoped).
+        assert!(
+            a.source.contains("def f(a, b=_SIR_MISSING):"),
+            "got:\n{}",
+            a.source
+        );
+        assert!(a.source.contains("    if b is _SIR_MISSING:"), "got:\n{}", a.source);
+        // The omitting call passes only the present arg (no frontend padding).
+        assert!(a.source.contains("f(5)"), "got:\n{}", a.source);
+
+        if let Some(stdout) = run_emitted_python(&a.source) {
+            assert_eq!(
+                stdout, "6\n10\n",
+                "Ruby call-time param-scoped default produced wrong output"
+            );
+        }
+    }
+
+    #[test]
     fn end_to_end_default_param_resolves_at_call_time_executes_py() {
         // P2c discriminating execution-proof.  `def f(a, b)` where `b`'s default
         // is `a + 1` — a *param-referencing* default that Python's native

--- a/code/specs/ruby-version-evolution.md
+++ b/code/specs/ruby-version-evolution.md
@@ -39,6 +39,14 @@ recent era at or before their release.
 
 Establishes the bulk of Ruby's syntax:
 - `def` / `end`, `class` / `end`, `module` / `end`
+  - **Default / optional parameters** (`def f(a = 1)`, `def f(a, b = a + 1)`)
+    are part of the 1.0 baseline. They are evaluated at CALL time and may
+    reference EARLIER parameters. As of `ruby-to-semantic-ir` 0.2.0 (changelog
+    0.99.0), the grammar `param` rule is `[ "*" | "**" ] NAME [ EQUALS
+    expression ]` and the frontend lowers the default into `Param.default`
+    (param-scoped, observing `Feature::DefaultParams`) — closing the original
+    Ruby-1.0 gap where the `= <default>` subtree was dropped and, in fact,
+    did not even parse. See the `ruby-to-semantic-ir` CHANGELOG.
 - `if` / `elsif` / `else` / `end`, `unless`, `while`, `until`, `for`
 - `case` / `when` / `else` / `end`  (no `in` patterns yet)
 - `begin` / `rescue` / `ensure` / `end`


### PR DESCRIPTION
The `ruby-to-semantic-ir` frontend now **produces** default parameters — closing the **original Ruby-1.0 gap** the E1 audit found (defaults were silently dropped). The fix was deeper than a lowering tweak:

- **Grammar:** the `param` rule had NO default branch (`def f(a=1)` literally didn't parse — the parser panicked at `=`). Extended `code/grammars/ruby.grammar` to `[ "*"|"**" ] NAME [ EQUALS expression ]` and regenerated the compiled grammar (`ruby-parser/src/_grammar.rs`) via the canonical grammar-tools (keeping .grammar + embedded Rust in sync per lessons.md). Strictly additive optional suffix — no parse regression (268 ruby-parser tests green).
- **Lowering:** new `extract_params` lowers each default via the existing bounded `lower_expression` into `Param{default: Some(...)}`, with earlier params visible as `Scope::Param` (so `def f(a, b = a + 1)` resolves `a`) and scope restored after. `Feature::DefaultParams` observed. Ruby defaults are call-time + can reference earlier params — matching the IR model exactly.
- Partial calls: `f(5)` omitting a defaulted arg → partial DirectCall (no padding).

**Tests:** 381 (6 new) + a Ruby **e2e** (added in semantic-ir-to-python's tests to avoid a dep cycle): `def f(a, b = a + 1); b + 0; end; print f(5); print f(5, 10)` → Ruby→SIR→Python→CPython 3.13 → `6` then `10`. clippy clean (zero new warnings); security review passed (grammar additive, recursion bounded, no panics). Touches `ruby-parser` + `ruby-to-semantic-ir` (+ a test in `semantic-ir-to-python`).

> **Ruby 1.0:** with defaults landed, the def-parameter surface is essentially complete (positional/`*rest`/`**kwrest`/defaults/`...` forwarding). Remaining for strict 1.0 fidelity: a pre-existing bare-identifier-method-body parse quirk (tracked separately). Keyword args are a 2.0+ feature, out of 1.0 scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)