### PR TITLE
feat(asciimath): comma-separated fences lower to neutral Sequence

### DIFF
--- a/code/packages/rust/asciimath/CHANGELOG.md
+++ b/code/packages/rust/asciimath/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to the AsciiMath pluggable frontend.
 
+## [0.10.0] — 2026-06-30
+
+### Added — comma-separated fences lower to `Sequence`
+
+- **`(a, b, c)` → `MathExpr::Sequence([a, b, c])`.** A single fence containing top-level
+  commas is now a LIST (a coordinate tuple, an argument list) instead of a parse error: each
+  item is parsed as a full relation and collected, mirroring the matrix row's cell loop (a
+  bounded loop, never recursion, so a wide list cannot overflow the stack). This is the
+  second frontend to emit the neutral `Sequence` node added in `math-frontend` 0.6.0 (after
+  `mathml`) — write-once-use-many across notations.
+- **A comma-free fence is unchanged** — `(x+1)` / `(a)` still lower to plain grouping (the
+  delimiters dropped, the inner expression returned). The matrix shape `((a,b),(c,d))`
+  (an outer bracket immediately followed by another opening bracket) is unaffected — it is
+  still handled by `parse_matrix` before this path. A trailing/doubled comma leaves a
+  non-atom before the next item and yields a clean spanned error (no panic).
+- **Capabilities** gain `sequences`, kept honest by the shared `check_frontend` harness (the
+  conformance corpus now includes `(a,b,c)`). Requires `math-frontend` >= 0.6.0.
+- 3 new tests (comma list, compound items, retained comma-free grouping) + a conformance
+  sample; the capability-honesty test asserts `sequences`.
+
 ## [0.9.0] — 2026-06-30
 
 ### Added — ASM01 PR-3c (the last remainder): greedy longest-match identifier scan

--- a/code/packages/rust/asciimath/Cargo.toml
+++ b/code/packages/rust/asciimath/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "asciimath"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 description = "An AsciiMath parser that implements the math-frontend MathFrontend trait: turns AsciiMath (1/2, sqrt(x), x^2+y^2=r^2) into the neutral MathExpr AST. The second pluggable frontend after LaTeX (see ASM01/PFE01). Total, panic-free, spanned errors."
 license = "MIT"

--- a/code/packages/rust/asciimath/src/lib.rs
+++ b/code/packages/rust/asciimath/src/lib.rs
@@ -61,9 +61,11 @@ impl MathFrontend for AsciiMath {
         // (`hat x`/`bar y`/`vec v`/`dot x`/`ddot x`/`tilde a`/`ul x`, emitted as
         // `MathExpr::Accent` since math-frontend 0.4.0 grew the node) + `oversets`
         // (`overset(a)(b)`/`stackrel(a)(b)`/`underset(a)(b)`, emitted as
-        // `MathExpr::Overset`/`Underset` since math-frontend 0.5.0). `plusminus`/`binomials`
-        // are not part of AsciiMath's core spelling here. Declaring `implicit_mul` is a
-        // parser-behavior claim (juxtaposition ⇒ `Mul`) the goldens cover.
+        // `MathExpr::Overset`/`Underset` since math-frontend 0.5.0) + `sequences`
+        // (a comma-separated fence `(a, b, c)` → `MathExpr::Sequence` since math-frontend
+        // 0.6.0). `plusminus`/`binomials` are not part of AsciiMath's core spelling here.
+        // Declaring `implicit_mul` is a parser-behavior claim (juxtaposition ⇒ `Mul`) the
+        // goldens cover.
         Capabilities::none()
             .with_fractions()
             .with_roots()
@@ -76,6 +78,7 @@ impl MathFrontend for AsciiMath {
             .with_big_operators()
             .with_accents()
             .with_oversets()
+            .with_sequences()
     }
 }
 
@@ -315,6 +318,30 @@ mod tests {
     }
 
     #[test]
+    fn comma_separated_fence_is_a_sequence() {
+        // A single fence with commas is a LIST: `(a, b, c)` → Sequence([a, b, c]).
+        assert_eq!(p("(a,b,c)"), MathExpr::Sequence(vec![sym("a"), sym("b"), sym("c")]));
+        // The common coordinate-pair case.
+        assert_eq!(p("(x,y)"), MathExpr::Sequence(vec![sym("x"), sym("y")]));
+    }
+
+    #[test]
+    fn sequence_items_are_full_expressions() {
+        // Each item between commas is a full relation, not just a leaf.
+        assert_eq!(
+            p("(x+1,2)"),
+            MathExpr::Sequence(vec![b(BinOp::Add, sym("x"), num(1)), num(2)])
+        );
+    }
+
+    #[test]
+    fn comma_free_fence_is_still_plain_grouping() {
+        // No comma → ordinary grouping, unchanged (delimiters dropped, inner returned).
+        assert_eq!(p("(x+1)"), b(BinOp::Add, sym("x"), num(1)));
+        assert_eq!(p("(a)"), sym("a"));
+    }
+
+    #[test]
     fn det_of_a_matrix() {
         // det binds the matrix as its argument atom.
         assert_eq!(
@@ -404,6 +431,7 @@ mod tests {
         assert!(c.fractions && c.roots && c.powers && c.functions && c.relations && c.text && c.implicit_mul);
         assert!(c.matrices && c.big_operators); // PR-2 breadth
         assert!(c.accents); // PR-2b: hat/bar/vec/dot/ddot/tilde/ul
+        assert!(c.oversets && c.sequences); // overset/underset + comma-separated fence → Sequence
         assert!(!c.plusminus && !c.binomials); // not part of AsciiMath's core spelling
     }
 
@@ -502,6 +530,7 @@ mod tests {
                 "text(kg)",        // text(…) keyword form (PR-3c) — twin of "kg"
                 "overset(a)(b)",   // over-set annotation (PR-3c emitter) → MathExpr::Overset
                 "underset(a)(b)",  // under-set annotation → MathExpr::Underset
+                "(a,b,c)",         // comma-separated fence → MathExpr::Sequence
                 "1 +",   // error: trailing operator (span in range, not a panic)
                 "(x",    // error: missing close
                 "",      // error: empty

--- a/code/packages/rust/asciimath/src/parser.rs
+++ b/code/packages/rust/asciimath/src/parser.rs
@@ -300,16 +300,35 @@ impl Parser<'_> {
         Ok(MathExpr::Matrix(rows))
     }
 
-    /// A bracketed group: parentheses are *grouping only* — the delimiter style is dropped
-    /// and the inner expression is returned directly (so `sqrt(x)` ≡ `sqrt x` and
-    /// `(1)/(2)` ≡ `1/2`). Any closing bracket is accepted (AsciiMath treats them loosely).
+    /// A bracketed group. With NO commas, parentheses are *grouping only* — the delimiter style
+    /// is dropped and the inner expression is returned directly (so `sqrt(x)` ≡ `sqrt x` and
+    /// `(1)/(2)` ≡ `1/2`). With one or more top-level commas, the fence is a LIST — `(a, b, c)`
+    /// → `MathExpr::Sequence([a, b, c])` — so the commas are preserved as list structure (a
+    /// coordinate tuple, an argument list) rather than rejected. Each item is a full relation.
+    /// Any closing bracket is accepted (AsciiMath treats them loosely). Note the matrix shape
+    /// `((a,b),(c,d))` is handled earlier by `parse_matrix` (an outer bracket immediately
+    /// followed by another opening bracket); this path sees only single-fence groups/lists.
     fn parse_group(&mut self) -> Result<MathExpr, FrontendError> {
         self.advance(); // opening bracket
-        let inner = self.parse_relation()?;
+        let first = self.parse_relation()?;
+        let expr = if matches!(self.peek(), TokenKind::Comma) {
+            // Comma-separated list → Sequence. Mirrors the matrix row's cell loop: a bounded
+            // loop over `parse_relation` (each item already depth-charged), never recursion, so
+            // a wide `(a, b, …, z)` cannot overflow the stack. A trailing/doubled comma leaves a
+            // non-atom before the next `parse_relation`, which returns a clean spanned error.
+            let mut items = vec![first];
+            while matches!(self.peek(), TokenKind::Comma) {
+                self.advance();
+                items.push(self.parse_relation()?);
+            }
+            MathExpr::Sequence(items)
+        } else {
+            first
+        };
         match self.peek() {
             TokenKind::RParen | TokenKind::RBracket | TokenKind::RBrace => {
                 self.advance();
-                Ok(inner)
+                Ok(expr)
             }
             _ => Err(self.error_here("expected a closing bracket")),
         }

--- a/code/specs/ASM01-asciimath-frontend.md
+++ b/code/specs/ASM01-asciimath-frontend.md
@@ -133,6 +133,13 @@ shapes for representative inputs.
   own lookup tables (one `is_keyword`, no drift). The operator words `xx`/`cdot`/`div` are part of
   that set so they are taken whole (else `cdot` would mis-split on the accent `dot`). Like real
   AsciiMath, a multi-letter *variable* that collides with a keyword must be quoted or spaced.
+- **PR-4 (shipped, v0.10.0):** **comma-separated fences → `Sequence`.** A single fence with
+  top-level commas — `(a, b, c)` — lowers to `MathExpr::Sequence([a, b, c])` (a coordinate
+  tuple / argument list) instead of a parse error; each item is a full relation, collected by a
+  bounded loop (never recursion). A comma-free fence is unchanged (plain grouping), and the
+  matrix shape `((a,b),(c,d))` is still handled first by `parse_matrix`. Enabled by
+  `math-frontend` 0.6.0's neutral `Sequence` node (first emitted by `mathml`); `capabilities()`
+  adds `sequences`, enforced by the conformance harness. The second frontend on the shared node.
 
 ## 6. Non-goals
 Evaluation, simplification, rendering — none are a frontend's job (PFE01 §7). Lowering


### PR DESCRIPTION
## Summary

Makes **`asciimath`** the second frontend to emit the neutral **`MathExpr::Sequence`** node (added to `math-frontend` 0.6.0 and first used by `mathml` in the previous PR): a single AsciiMath fence with top-level commas — `(a, b, c)` — now lowers to `Sequence([a, b, c])` (a coordinate tuple / argument list) instead of returning a parse error. **Write-once-use-many across notations.**

## How it works

`parse_group`: after the first item, a comma turns the fence into a list — each subsequent item is parsed as a full relation and collected in a bounded loop (mirroring the matrix row's cell loop — **never recursion**, so a wide list can't overflow the stack).

| input | before | after |
|---|---|---|
| `(a,b,c)` | parse error | `Sequence([a,b,c])` |
| `(x+1,2)` | parse error | `Sequence([x+1, 2])` |
| `(x+1)` / `(a)` | grouping | grouping (**unchanged**) |
| `((a,b),(c,d))` | Matrix | Matrix (**unchanged** — handled by `parse_matrix` first) |

A trailing/doubled/leading comma leaves a non-atom before the next item and yields a clean spanned error (no panic).

## Verification
- `cargo test -p asciimath` — **43 pass** (3 new: comma list, compound items, retained comma-free grouping); `cargo clippy` clean with `-D warnings`.
- **No shared-crate edit** — only this leaf frontend changed (the `Sequence` node, its iterative-Drop arm, and the `sequences` capability all already landed in `math-frontend` 0.6.0), so no downstream ripple.
- `capabilities()` gains `sequences`, kept honest by the shared `check_frontend` harness (conformance corpus gains `(a,b,c)`); the capability-honesty test asserts it.
- ASM01 spec §5 (PR-4) + CHANGELOG 0.10.0.
- `/security-review` **PASSED** (diff reviewed inline; comma-loop termination + panic/DoS surface verified — all adversarial inputs resolve to a bounded `Sequence` or a clean spanned error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)