### PR TITLE
feat(semantic-ir): keyword parameters & arguments — core IR (KW1)

### DIFF
--- a/code/packages/rust/javascript-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/javascript-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to `javascript-to-semantic-ir` are documented here.
 
+## Unreleased
+
+### Changed
+
+- Compile-compat stub arm for the new core `semantic-ir` variant
+  `Expr::KeywordArg` (KW1) — the effect-inference pass recurses into the
+  keyword arg's inner `value` so purity analysis stays
+  conservative-correct. Real keyword-argument lowering is pending KW2–KW8.
+
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 

--- a/code/packages/rust/javascript-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/javascript-to-semantic-ir/src/lower.rs
@@ -3256,6 +3256,12 @@ fn expr_may_have_effects(expr: &Expr) -> bool {
         }
         Expr::Block(b) => block_may_have_effects(b),
 
+        // KW1 compile-compat stub: a `KeywordArg`'s effect is exactly its
+        // inner `value`'s effect (the `name` is a static label) — recurse
+        // faithfully so effect inference stays conservative-correct.  Real
+        // support pending KW2–KW8.
+        Expr::KeywordArg { value, .. } => expr_may_have_effects(value),
+
         // Calls, closures, and intrinsics may do anything → keep.
         Expr::DirectCall { .. }
         | Expr::IndirectCall { .. }

--- a/code/packages/rust/python-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/python-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to `python-to-semantic-ir` are documented here.
 
+## Unreleased
+
+### Changed
+
+- Compile-compat stub arm for the new core `semantic-ir` variant
+  `Expr::KeywordArg` (KW1) — the callee-collection pass recurses into the
+  keyword arg's inner `value`. Real keyword-argument lowering is pending
+  KW2–KW8.
+
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to semantic versioning.
 

--- a/code/packages/rust/python-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/python-to-semantic-ir/src/lower.rs
@@ -3234,6 +3234,10 @@ fn collect_callees_expr(expr: &Expr, out: &mut HashSet<String>) {
                 collect_callees_expr(a, out);
             }
         }
+        // KW1 compile-compat stub: recurse into the `KeywordArg`'s inner
+        // `value` (its runtime meaning) so callees nested in a keyword
+        // argument are still collected.  Real support pending KW2–KW8.
+        Expr::KeywordArg { value, .. } => collect_callees_expr(value, out),
         // Atoms and references bind nothing.
         Expr::IntLit { .. }
         | Expr::BoolLit { .. }

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## Unreleased
+
+### Changed
+
+- Compile-compat stub arms for the new core `semantic-ir` variant
+  `Expr::KeywordArg` (KW1). Every affected pass — the swap-safety reference
+  check, the `yield`-rewrite and call-normalization `&mut` visitors, and the
+  bound-name collector — recurses faithfully into the keyword arg's inner
+  `value`. Real keyword-argument lowering is pending KW2–KW8.
+
 ## [0.99.1] - 2026-06-30
 
 ### Fixed (bare-identifier method bodies now lower)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -275,6 +275,12 @@ fn expr_references_any_name(expr: &Expr, names: &HashSet<String>) -> bool {
         Expr::StrConcat { parts, .. } => {
             parts.iter().any(|p| expr_references_any_name(p, names))
         }
+
+        // KW1 compile-compat stub: a `KeywordArg` is a single-child wrapper
+        // whose runtime meaning is its inner `value` (the `name` is a static
+        // label carrying no `VarRef`).  Recurse into `value` so the swap-safety
+        // reference check stays faithful.  Real support pending KW2–KW8.
+        Expr::KeywordArg { value, .. } => expr_references_any_name(value, names),
     }
 }
 
@@ -3246,6 +3252,13 @@ impl Lowerer {
                 }
                 found
             }
+            // KW1 compile-compat stub: recurse into the `KeywordArg`'s inner
+            // `value` (its runtime meaning) so a `yield` nested inside a
+            // keyword argument is still rewritten.  Real support pending
+            // KW2–KW8.
+            Expr::KeywordArg { value, .. } => {
+                Self::rewrite_yields_in_expr(value, block_scope)
+            }
             // Phase Q10b — `block_given?` reaches the lowerer as a bare
             // `VarRef` named "block_given?" (it is parenless, so the
             // method-call parser treats it as a name).  Inside a method
@@ -3775,6 +3788,12 @@ impl Lowerer {
                     Self::normalize_calls_in_expr(p, ctx);
                 }
             }
+            // KW1 compile-compat stub: recurse into the `KeywordArg`'s inner
+            // `value` so a parenless block-method call nested in a keyword
+            // argument is still normalized.  Real support pending KW2–KW8.
+            Expr::KeywordArg { value, .. } => {
+                Self::normalize_calls_in_expr(value, ctx);
+            }
             // Atomic literals and a non-rewritten VarRef carry no
             // sub-expressions.
             Expr::IntLit { .. }
@@ -3918,6 +3937,10 @@ impl Lowerer {
                     Self::collect_bound_names_expr(p, out);
                 }
             }
+            // KW1 compile-compat stub: recurse into the `KeywordArg`'s inner
+            // `value` so a name bound inside a keyword argument is still
+            // collected.  Real support pending KW2–KW8.
+            Expr::KeywordArg { value, .. } => Self::collect_bound_names_expr(value, out),
             Expr::IntLit { .. }
             | Expr::BoolLit { .. }
             | Expr::NilLit { .. }

--- a/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- Compile-compat stub arm for the new core `semantic-ir` variant
+  `Expr::KeywordArg` (KW1) — `emit_expr` follows this crate's existing
+  unsupported-node convention (positioned panic that the capability check
+  should already have rejected). Real keyword-argument support is pending
+  KW2–KW8.
+
 ## 0.5.0 — SIR19 default parameters (P2f) via missing-sentinel runtime-mimic
 
 Adds `Feature::DefaultParams` to the Go backend's accepted set.  Go has no

--- a/code/packages/rust/semantic-ir-to-go/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/emit.rs
@@ -518,6 +518,15 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
         Expr::StrConcat { span, .. } => {
             panic!("go backend reached SIR18 str-concat expression at {} — capability check should have rejected it", span);
         }
+        // KW1 compile-compat stub: keyword arguments (`f(a: 1)`) are gated
+        // behind `Feature::KeywordParams`, which the validator rejects until
+        // real support lands in KW2–KW6.  `emit_expr` is infallible, so we
+        // follow this crate's established convention for an unsupported node
+        // (see `StrConcat` above): a positioned panic documenting the
+        // internal-bug-only reachability.  No real emission yet.
+        Expr::KeywordArg { span, .. } => {
+            panic!("go backend reached KW1 keyword-arg expression at {} — capability check should have rejected it (real support pending KW2–KW6)", span);
+        }
     }
 }
 

--- a/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to `semantic-ir-to-javascript` are documented here.
 
+## Unreleased
+
+### Changed
+
+- Compile-compat stub arms for the new core `semantic-ir` variants
+  `ParamKind::Keyword` / `Expr::KeywordArg` (KW1). A single `Keyword` param
+  emits as a best-effort trailing positional (combined with `KwRest`);
+  `emit_expr` follows the crate's deferred-node convention (positioned
+  panic). Real keyword-parameter support is pending KW2–KW8.
+
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 

--- a/code/packages/rust/semantic-ir-to-javascript/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/emit.rs
@@ -167,7 +167,13 @@ fn emit_function(out: &mut String, f: &Function) {
             // v0 binds it as a trailing ordinary parameter — but this
             // backend does not accept the features that produce KwRest
             // yet, so in practice only `Required` is reached here.
-            ParamKind::Required | ParamKind::KwRest => {
+            // KW1 compile-compat stub: a single `Keyword` param has no native
+            // JS form (JS has no keyword-argument call), so mirror the
+            // `KwRest` best-effort — emit it as a trailing ordinary parameter.
+            // Real keyword-param support lands in KW2–KW6; the validator
+            // rejects `Feature::KeywordParams` until then, so this arm is
+            // unreachable today.
+            ParamKind::Required | ParamKind::KwRest | ParamKind::Keyword => {
                 out.push_str(&sanitize_ident(&p.name));
                 // P2d: a defaulted param (`Param { default: Some(e) }`)
                 // becomes a native JS default parameter `name = <e>`.
@@ -502,6 +508,14 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
             panic!(
                 "emit reached an Intrinsic `{name}` at {span} — backend should have rejected it"
             );
+        }
+        // KW1 compile-compat stub: keyword arguments (`f(a: 1)`) are gated
+        // behind `Feature::KeywordParams`, rejected at the capability check
+        // until real support lands in KW2–KW6.  Follow this crate's deferred
+        // -node convention (see `StrConcat` above): a positioned panic
+        // covering backend bugs only.  No real emission yet.
+        Expr::KeywordArg { span, .. } => {
+            panic!("javascript backend reached a deferred `KeywordArg` at {span} — not accepted yet (real support pending KW2–KW6)");
         }
     }
 }

--- a/code/packages/rust/semantic-ir-to-python/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-python/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- Compile-compat stub arms for the new core `semantic-ir` variants
+  `ParamKind::Keyword` / `Expr::KeywordArg` (KW1). The builtin-usage scan
+  recurses into the keyword arg's inner `value`; a single `Keyword` param
+  emits as a best-effort plain positional (combined with `Required`);
+  `emit_expr` follows the crate's unsupported-node convention. Real
+  keyword-parameter support is pending KW2–KW8.
+
 ## 0.2.0 — default-parameter emission via sentinel + body prologue (P2c)
 
 The backend now accepts `Feature::DefaultParams` and lowers default parameters.

--- a/code/packages/rust/semantic-ir-to-python/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-python/src/emit.rs
@@ -166,6 +166,10 @@ fn expr_uses_builtin(e: &Expr, name: &str) -> bool {
         }
         Expr::StrConcat { parts, .. } => parts.iter().any(|p| expr_uses_builtin(p, name)),
         Expr::Intrinsic { args, .. } => args.iter().any(|a| expr_uses_builtin(a, name)),
+        // KW1 compile-compat stub: a `KeywordArg` is a single-child wrapper
+        // whose runtime meaning is its inner `value`; recurse into it so this
+        // builtin-usage scan stays faithful.  Real support pending KW2–KW6.
+        Expr::KeywordArg { value, .. } => expr_uses_builtin(value, name),
         Expr::IntLit { .. }
         | Expr::FloatLit { .. }
         | Expr::BoolLit { .. }
@@ -318,7 +322,15 @@ fn emit_function(out: &mut String, f: &Function) {
         match p.kind {
             ParamKind::Rest => out.push('*'),
             ParamKind::KwRest => out.push_str("**"),
-            ParamKind::Required => {}
+            // KW1 compile-compat stub: a single keyword param (`Keyword`) is
+            // NOT the `**opts` collector, so it takes no prefix here — the
+            // shared `push_str(name)` below emits its name, giving a
+            // best-effort plain positional.  Real keyword-param syntax (order
+            // after `*`, name-only binding) lands in KW2–KW6; the validator
+            // rejects `Feature::KeywordParams` until then, so this arm is
+            // unreachable today.  Combined with `Required` as both emit no
+            // prefix.
+            ParamKind::Required | ParamKind::Keyword => {}
         }
         out.push_str(&sanitize_ident(&p.name));
         // P2c default parameters.  A defaulted param gets the *sentinel* as its
@@ -802,6 +814,18 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
                 out.push(')');
             }
             out.push(')');
+        }
+        // KW1 compile-compat stub: keyword arguments (`f(a: 1)`) are gated
+        // behind `Feature::KeywordParams`, which the validator rejects until
+        // real support lands in KW2–KW6.  Follow this crate's convention for
+        // an unsupported codegen node the capability check should have
+        // rejected (see the `Intrinsic` panic above): a positioned panic
+        // covering internal bugs only.  No real emission yet.
+        Expr::KeywordArg { span, .. } => {
+            panic!(
+                "python backend reached KW1 keyword-arg expression at {} — backend should have rejected it (real support pending KW2–KW6)",
+                span
+            );
         }
     }
 }

--- a/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- Compile-compat stub arms for the new core `semantic-ir` variants
+  `ParamKind::Keyword` / `Expr::KeywordArg` (KW1). Analysis passes recurse
+  into the keyword arg's inner `value`; codegen follows the crate's existing
+  unsupported-node convention. Real keyword-parameter support is pending
+  KW2–KW8.
+
 ## 0.5.0 — default-parameter emission (P2e)
 
 Adds `Feature::DefaultParams` support: a `Param` may now carry a

--- a/code/packages/rust/semantic-ir-to-rust/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/emit.rs
@@ -321,6 +321,13 @@ fn collect_expr_assigned(e: &Expr, out: &mut HashSet<String>) {
             collect_expr_assigned(map, out);
             collect_expr_assigned(key, out);
         }
+        // KW1 compile-compat stub: a `KeywordArg` is a single-child wrapper
+        // whose runtime meaning is its inner `value` (the `name` is a static
+        // label).  This is a pure traversal collecting assigned locals, so we
+        // recurse faithfully into `value`.  Real keyword-arg emission lands in
+        // KW2–KW6; modules using `Feature::KeywordParams` are rejected by the
+        // validator until then, so this arm is effectively unreachable today.
+        Expr::KeywordArg { value, .. } => collect_expr_assigned(value, out),
         // Leaves, and the SIR18 `StrConcat` node (rejected before emit) —
         // nothing nested that could hold a reachable `Assign`.
         Expr::IntLit { .. }
@@ -623,6 +630,16 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
         // this arm is an internal bug.
         Expr::StrConcat { span, .. } => {
             panic!("rust backend reached SIR18 str-concat expression at {} — capability check should have rejected it", span);
+        }
+        // KW1 compile-compat stub: keyword arguments (`f(a: 1)`) are gated
+        // behind `Feature::KeywordParams`, which the validator rejects until
+        // real support lands in KW2–KW6.  `emit_expr` is infallible, so we
+        // follow this crate's established convention for an unsupported node
+        // whose feature the capability check should already have rejected
+        // (see `StrConcat`/`Intrinsic` above): a positioned panic documenting
+        // the internal-bug-only reachability.  No real emission yet.
+        Expr::KeywordArg { span, .. } => {
+            panic!("rust backend reached KW1 keyword-arg expression at {} — capability check should have rejected it (real support pending KW2–KW6)", span);
         }
     }
 }

--- a/code/packages/rust/semantic-ir-to-typescript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-typescript/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- Compile-compat stub arms for the new core `semantic-ir` variants
+  `ParamKind::Keyword` / `Expr::KeywordArg` (KW1). Analysis passes
+  (builtin-usage scan, assigned-local collection) recurse into the keyword
+  arg's inner `value`; a single `Keyword` param emits as a best-effort typed
+  positional (combined with `KwRest`); `emit_expr` follows the crate's
+  unsupported-node convention. Real keyword-parameter support is pending
+  KW2–KW8.
+
 ## 0.2.0 — default-parameter emission (P2b)
 
 Default parameters now lower to TypeScript-native defaults. A `Param` whose new

--- a/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
@@ -174,6 +174,10 @@ fn expr_uses_builtin(e: &Expr, name: &str) -> bool {
         }
         Expr::StrConcat { parts, .. } => parts.iter().any(|p| expr_uses_builtin(p, name)),
         Expr::Intrinsic { args, .. } => args.iter().any(|a| expr_uses_builtin(a, name)),
+        // KW1 compile-compat stub: recurse into a `KeywordArg`'s inner `value`
+        // (its runtime meaning) so this builtin-usage scan stays faithful.
+        // Real support pending KW2–KW6.
+        Expr::KeywordArg { value, .. } => expr_uses_builtin(value, name),
         Expr::IntLit { .. }
         | Expr::FloatLit { .. }
         | Expr::BoolLit { .. }
@@ -317,7 +321,15 @@ fn emit_function(out: &mut String, f: &Function) {
             ParamKind::Rest => {
                 let _ = write!(out, "...{}: __Sir.Val[]", sanitize_ident(&p.name));
             }
-            ParamKind::Required | ParamKind::KwRest => {
+            // KW1 compile-compat stub: a single `Keyword` param has no
+            // faithful native JS/TS declaration (JS has no keyword-call form),
+            // so mirror the `KwRest` best-effort — emit it as an ordinary
+            // trailing typed parameter (`name: __Sir.Val`).  The inner
+            // `Required`-only guard below withholds a default, matching the
+            // KwRest treatment.  Real keyword-param support lands in KW2–KW6;
+            // the validator rejects `Feature::KeywordParams` until then, so
+            // this arm is unreachable today.
+            ParamKind::Required | ParamKind::KwRest | ParamKind::Keyword => {
                 let _ = write!(out, "{}: __Sir.Val", sanitize_ident(&p.name));
                 // P2b default parameters.  A SIR default is evaluated
                 // per-call in the callee's parameter scope and may reference
@@ -478,6 +490,10 @@ fn collect_expr_assigned(e: &Expr, out: &mut HashSet<String>) {
                 collect_expr_assigned(p, out);
             }
         }
+        // KW1 compile-compat stub: recurse into a `KeywordArg`'s inner `value`
+        // — its runtime meaning — so assigned-local collection stays faithful.
+        // Real support pending KW2–KW6.
+        Expr::KeywordArg { value, .. } => collect_expr_assigned(value, out),
         // Leaves with no nested blocks/exprs that could hold an Assign.
         Expr::IntLit { .. }
         | Expr::FloatLit { .. }
@@ -909,6 +925,18 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
                 out.push(')');
             }
             out.push(')');
+        }
+        // KW1 compile-compat stub: keyword arguments (`f(a: 1)`) are gated
+        // behind `Feature::KeywordParams`, which the validator rejects until
+        // real support lands in KW2–KW6.  Follow this crate's convention for
+        // an unsupported codegen node the capability check should have
+        // rejected (see the `Intrinsic` panic): a positioned panic covering
+        // internal bugs only.  No real emission yet.
+        Expr::KeywordArg { span, .. } => {
+            panic!(
+                "typescript backend reached KW1 keyword-arg expression at {} — backend should have rejected it (real support pending KW2–KW6)",
+                span
+            );
         }
     }
 }

--- a/code/packages/rust/semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir/CHANGELOG.md
@@ -2,6 +2,95 @@
 
 All notable changes to the `semantic-ir` crate are documented here.
 
+## 0.14.0 — Keyword parameters & arguments (KW1; core IR)
+
+Adds **named keyword parameters** (`def f(x:)` / `def f(x: 1)`) and
+**keyword arguments** (`f(x: 1)`, Python `f(x=1)`) to the core IR. This is
+**milestone KW1 of the keyword-params cascade**: it lands the
+representation, validation, walker, and printer support only. No frontend
+lowers to keyword params yet and no backend accepts the new
+`Feature::KeywordParams`, so a keyword-using module is correctly rejected by
+the capability check until each backend gains support — **all existing
+behavior is unchanged**.
+
+### Model — required vs. optional rides on `Param.default`
+
+A keyword parameter is a `Param` with `kind == ParamKind::Keyword`. Whether
+it is *required* or *optional* is carried by the **existing** `default`
+field, exactly as a positional optional already works — there is no separate
+"is-required" flag:
+
+| `kind`    | `default` | meaning                          | source        |
+|-----------|-----------|----------------------------------|---------------|
+| `Keyword` | `None`    | **required** keyword parameter   | `def f(x:)`   |
+| `Keyword` | `Some(e)` | **optional** keyword parameter   | `def f(x: 1)` |
+
+`ParamKind` remains `Copy` with `#[default] = Required`, so no existing
+`Param { .. }` construction changes.
+
+A keyword argument at a call site is the new `Expr::KeywordArg { name,
+value, span }`. It lives **inside the existing `args` vec** of a call, after
+all positional args (`f(1, a: 2)` → `args: [IntLit(1), KeywordArg{…}]`),
+rather than a parallel `kwargs` field on every call node — keeping the
+walker/printer/backend surface area unchanged for positional callers.
+
+### Added
+
+- `ParamKind::Keyword` — a named keyword parameter variant.
+- `Expr::KeywordArg { name, value, span }` — a call-site keyword argument;
+  covered by `Expr::span()` and `Expr::kind_name()` (`"keyword-arg"`).
+- `Feature::KeywordParams` (name string `"keyword-params"`) — observed when
+  a `Keyword` param or a `KeywordArg` appears; wired into `Feature::ALL`,
+  `name`/`from_name`, and `Display`.
+- `Function::keyword_params(&self) -> Vec<&Param>` — the params with
+  `kind == Keyword`.
+- `Function::missing_keywords(&self, supplied: &[&str]) -> Vec<&Param>` —
+  the keyword params a caller omitted. For a validator-accepted call every
+  returned param carries a `default` (required keywords can never be
+  omitted), so a backend may emit each default unconditionally.
+- Validator rules:
+  - **Def-side ordering** — the canonical param list is
+    `Required* Rest? Keyword* KwRest?`. A `Keyword` before a positional/rest,
+    or after the `KwRest`, is rejected (and a positional/rest after a
+    `Keyword` symmetrically).
+  - **Call-side ordering** — every `KeywordArg` must follow all positional
+    args; a positional after a keyword is rejected.
+  - **No duplicate keyword names** within one call's args.
+  - **Known-callee name resolution** (DirectCall only) — each keyword must
+    match a `Keyword` param OR the callee declares a `**kwrest`; every
+    **required** keyword param must be supplied. IndirectCall/closure calls
+    skip resolution (signature not statically known) but still enforce
+    ordering + duplicates.
+  - **KeywordArg only in call position** — a `KeywordArg` anywhere other
+    than directly inside a call's `args` vec is rejected.
+  - **Feature gating** — using a `Keyword` param or a `KeywordArg` requires
+    the manifest to declare `Feature::KeywordParams` (same contract as
+    `DefaultParams`). A keyword param's default triggers `KeywordParams`,
+    not `DefaultParams` (that feature is specifically *positional* trailing
+    defaults).
+- Walker: `walk_expr_default` and the backend intrinsic walker recurse into
+  `KeywordArg.value` (depth-bounded like every other child).
+- Printer: a `Keyword` param renders `(x: any)` (required) /
+  `(x: any (default (int 1)))` (optional); a `KeywordArg` renders
+  `(keyword-arg name <value>)` inline in a call's arg list.
+- Unit tests (28): ParamKind::Keyword required/optional distinction;
+  `Expr::KeywordArg` span/kind-name; the two `Function` helpers; feature
+  name/round-trip; def-side ordering (valid + each rejection); call-side
+  ordering + duplicate rejection; known-callee name resolution (unknown
+  keyword with/without kwrest, missing/optional/supplied required keyword);
+  indirect-call skips resolution but keeps ordering; KeywordArg-out-of-call
+  rejection (block value, builtin arg, nested in a keyword value); keyword
+  value expression is validated; printer output; walker traversal.
+
+### Deferred / scoped
+
+- **Backends** do not yet accept `Feature::KeywordParams`; a keyword-using
+  module is rejected at the capability check until per-backend emission
+  lands (later milestones).
+- **Frontends** do not yet lower to keyword params/args (later milestones).
+- **IndirectCall / closure** keyword-name resolution stays deferred (the
+  target signature is not known statically).
+
 ## 0.13.0 — Default-param call-arity semantics (P2a; behavior-neutral)
 
 Defines the **call-arity rule for default parameters** so a `DirectCall`

--- a/code/packages/rust/semantic-ir/Cargo.toml
+++ b/code/packages/rust/semantic-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "Narrow-waist Semantic IR (SIR10): a language-neutral intermediate representation between frontends and backends."
 

--- a/code/packages/rust/semantic-ir/src/backend.rs
+++ b/code/packages/rust/semantic-ir/src/backend.rs
@@ -350,6 +350,10 @@ where
                 walk_intrinsics_in_expr(p, f, depth + 1);
             }
         }
+        // ── KW1: keyword argument ──────────────────────────────────
+        Expr::KeywordArg { value, .. } => {
+            walk_intrinsics_in_expr(value, f, depth + 1);
+        }
     }
 }
 

--- a/code/packages/rust/semantic-ir/src/manifest.rs
+++ b/code/packages/rust/semantic-ir/src/manifest.rs
@@ -27,6 +27,7 @@ use std::fmt;
 /// | `Intrinsics`               | any `Intrinsic` node                  |
 /// | `StringInterpolation`      | an `Expr::StrConcat` node             |
 /// | `DefaultParams`            | a param with `default = Some(_)`      |
+/// | `KeywordParams`            | a `Keyword` param or `KeywordArg`     |
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Feature {
     Closures,
@@ -97,6 +98,21 @@ pub enum Feature {
     /// check until each backend gains support.  Emission (backends) and
     /// lowering (frontends) land in follow-up PRs.
     DefaultParams,
+    // ── KW1 (keyword parameters & arguments) ─────────────────────────
+    /// The module uses **named keyword parameters** (a `Param` with
+    /// `kind == ParamKind::Keyword`, e.g. Ruby `def f(x:)` / `def f(x: 1)`)
+    /// and/or **keyword arguments** at a call site (an `Expr::KeywordArg`,
+    /// e.g. Ruby `f(x: 1)` / Python `f(x=1)`).  Distinct from
+    /// `DefaultParams`: a keyword param is matched by *name*, not position,
+    /// and its default (when present) marks it *optional* rather than
+    /// *required* — a different axis from a positional trailing default.
+    /// Like `DefaultParams`, this is the core-IR representation only: it is
+    /// observed by the validator when a keyword param or argument appears
+    /// and is NOT yet accepted by any backend, so a keyword-using module is
+    /// correctly rejected by the capability check until each backend gains
+    /// support.  Emission (backends) and lowering (frontends) land in
+    /// follow-up PRs.
+    KeywordParams,
 }
 
 impl Feature {
@@ -126,6 +142,7 @@ impl Feature {
         Feature::Exceptions,
         Feature::StringInterpolation,
         Feature::DefaultParams,
+        Feature::KeywordParams,
     ];
 
     /// Kebab-case name for the SIR text format.
@@ -155,6 +172,7 @@ impl Feature {
             Feature::Exceptions => "exceptions",
             Feature::StringInterpolation => "string-interpolation",
             Feature::DefaultParams => "default-params",
+            Feature::KeywordParams => "keyword-params",
         }
     }
 
@@ -256,6 +274,17 @@ mod tests {
         for f in Feature::ALL {
             assert_eq!(Feature::from_name(f.name()), Some(*f));
         }
+    }
+
+    #[test]
+    fn keyword_params_feature_name_and_round_trip() {
+        assert_eq!(Feature::KeywordParams.name(), "keyword-params");
+        assert_eq!(
+            Feature::from_name("keyword-params"),
+            Some(Feature::KeywordParams)
+        );
+        assert_eq!(format!("{}", Feature::KeywordParams), "keyword-params");
+        assert!(Feature::ALL.contains(&Feature::KeywordParams));
     }
 
     #[test]

--- a/code/packages/rust/semantic-ir/src/nodes.rs
+++ b/code/packages/rust/semantic-ir/src/nodes.rs
@@ -185,6 +185,48 @@ impl Function {
         let n = n_args.min(self.params.len());
         &self.params[n..]
     }
+
+    /// The callee's *keyword* parameters — those with `kind == Keyword`
+    /// (KW1).  Unlike positionals, a keyword param is matched by **name**
+    /// at the call site, so the validator's call-side resolution consults
+    /// this list (rather than a positional index) to decide whether a
+    /// `KeywordArg` is accepted and which required keywords were supplied.
+    ///
+    /// ```text
+    ///   def f(a, x:, y: 1, **rest)   →  keyword_params() == [x, y]
+    /// ```
+    ///
+    /// (`a` is positional, `**rest` is `KwRest` — neither is a `Keyword`.)
+    pub fn keyword_params(&self) -> Vec<&Param> {
+        self.params
+            .iter()
+            .filter(|p| p.kind == ParamKind::Keyword)
+            .collect()
+    }
+
+    /// The `Keyword` params whose name is **not** in `supplied` — i.e. the
+    /// keyword parameters a caller left out (KW1).
+    ///
+    /// Backends use this the way [`Self::missing_defaults`] is used for
+    /// trailing positionals: for a call the validator has **accepted**,
+    /// every returned param is guaranteed to carry a `default`.  That is
+    /// precisely the required-keyword rule: a *required* keyword (kind
+    /// `Keyword`, `default == None`) that the caller omits is a validation
+    /// error, so it can never survive into this list.  A backend may
+    /// therefore emit each returned param's default unconditionally.
+    ///
+    /// ```text
+    ///   def f(x:, y: 1, z: 2)
+    ///   f.missing_keywords(&["x", "y"])  →  [z]        // z omitted, has default
+    ///   f.missing_keywords(&["x"])       →  [y, z]     // y, z omitted, both have defaults
+    /// ```
+    pub fn missing_keywords(&self, supplied: &[&str]) -> Vec<&Param> {
+        self.params
+            .iter()
+            .filter(|p| p.kind == ParamKind::Keyword)
+            .filter(|p| !supplied.contains(&p.name.as_str()))
+            .collect()
+    }
 }
 
 /// How a parameter binds its arguments (M3 — see
@@ -198,6 +240,29 @@ pub enum ParamKind {
     /// A rest parameter (`*rest`) — collects trailing positional arguments
     /// into a sequence.
     Rest,
+    /// A named keyword parameter (`x:` / `x: 1` in Ruby, `x` / `x=1` after
+    /// `*` in Python) — bound by *name* at the call site, never by
+    /// position (KW1 — see `code/specs/sir-keyword-params.md`).
+    ///
+    /// Required-vs-optional rides on the **existing** `Param.default`
+    /// field, exactly as a positional optional does — there is no separate
+    /// "is-required" flag:
+    ///
+    /// ```text
+    ///   Param { kind: Keyword, default: None    }  →  REQUIRED keyword: `def f(x:)`
+    ///   Param { kind: Keyword, default: Some(e) }  →  OPTIONAL keyword: `def f(x: 1)`
+    /// ```
+    ///
+    /// Why reuse `default` rather than add a flag?  Because the two axes
+    /// (how the argument is *matched* — position vs. name — and whether it
+    /// may be *omitted*) are orthogonal.  `ParamKind` already answers the
+    /// first for the positional/`Rest`/`KwRest` cases; `default` already
+    /// answers the second for positionals.  A `Keyword` param simply
+    /// combines the name-matched axis with the same omissibility rule, so
+    /// no new field (and, because `ParamKind` is `Copy` with
+    /// `#[default] = Required`, no existing `Param { .. }` construction)
+    /// changes.
+    Keyword,
     /// A keyword-rest parameter (`**opts`) — collects trailing keyword
     /// arguments into a map.
     KwRest,
@@ -666,6 +731,27 @@ pub enum Expr {
     /// degenerate — frontends emit a bare `StrLit` (empty string) or the
     /// single part directly rather than wrapping it.
     StrConcat { parts: Vec<Expr>, span: Span },
+
+    // ── KW1: keyword arguments ─────────────────────────────────────
+    /// A keyword argument at a call site: `name: value` (Ruby `f(a: 1)`,
+    /// Python `f(a=1)`).  Appears ONLY inside a call's `args` vec, and only
+    /// AFTER all positional arguments.  The validator enforces both rules.
+    ///
+    /// Design note — why a `KeywordArg` *inside* `args` rather than a
+    /// separate `kwargs` field on each call node?  Three call nodes
+    /// (`DirectCall`, `IndirectCall`, `MakeClosure`) all take arguments;
+    /// threading a parallel `kwargs: Vec<(String, Expr)>` through every one
+    /// (plus the walker, printer, and every backend `match`) would triple
+    /// the surface area.  Instead a keyword argument is just another
+    /// `Expr` variant that may sit in the *existing* `args` vec, so
+    /// `f(1, a: 2)` lowers to `args: [IntLit(1), KeywordArg { name: "a",
+    /// value: IntLit(2) }]`.  Positional args stay bare; the validator
+    /// guarantees every `KeywordArg` trails all positionals, so a backend
+    /// can split `args` at the first `KeywordArg` without ambiguity.
+    ///
+    /// `value` is boxed for the same fixed-size reason as the other
+    /// single-child expression variants (`SeqLen`, `MapGet`, …).
+    KeywordArg { name: String, value: Box<Expr>, span: Span },
 }
 
 /// A single capture provided to `MakeClosure`.  The `name` matches a
@@ -710,6 +796,7 @@ impl Expr {
             Expr::LogicalAnd { span, .. } => span,
             Expr::LogicalOr { span, .. } => span,
             Expr::StrConcat { span, .. } => span,
+            Expr::KeywordArg { span, .. } => span,
         }
     }
 
@@ -739,6 +826,7 @@ impl Expr {
             Expr::LogicalAnd { .. } => "and",
             Expr::LogicalOr { .. } => "or",
             Expr::StrConcat { .. } => "str-concat",
+            Expr::KeywordArg { .. } => "keyword-arg",
         }
     }
 }
@@ -916,6 +1004,105 @@ mod tests {
         let c = Expr::FloatLit { value: 3.14, span: s() };
         let d = Expr::FloatLit { value: 3.14, span: s() };
         assert_eq!(c, d);
+    }
+
+    // ── KW1: keyword parameters & arguments ────────────────────────
+
+    #[test]
+    fn keyword_arg_span_and_kind_name() {
+        let e = Expr::KeywordArg {
+            name: "a".into(),
+            value: Box::new(Expr::IntLit { value: 1, span: s() }),
+            span: s(),
+        };
+        assert_eq!(e.span(), &s());
+        assert_eq!(e.kind_name(), "keyword-arg");
+    }
+
+    /// A `Keyword` param with `default == None` is REQUIRED; with
+    /// `default == Some(_)` it is OPTIONAL.  This test pins the truth table
+    /// documented on `ParamKind::Keyword`.
+    #[test]
+    fn keyword_param_required_vs_optional_via_default() {
+        let required = Param {
+            name: "x".into(),
+            sir_type: None,
+            kind: ParamKind::Keyword,
+            default: None,
+            span: s(),
+        };
+        let optional = Param {
+            name: "y".into(),
+            sir_type: None,
+            kind: ParamKind::Keyword,
+            default: Some(Box::new(Expr::IntLit { value: 1, span: s() })),
+            span: s(),
+        };
+        assert_eq!(required.kind, ParamKind::Keyword);
+        assert!(required.default.is_none(), "kw with no default = required");
+        assert!(optional.default.is_some(), "kw with default = optional");
+    }
+
+    fn kw_param(name: &str, default: Option<i64>) -> Param {
+        Param {
+            name: name.into(),
+            sir_type: None,
+            kind: ParamKind::Keyword,
+            default: default.map(|v| Box::new(Expr::IntLit { value: v, span: s() })),
+            span: s(),
+        }
+    }
+
+    fn fn_with_params(params: Vec<Param>) -> Function {
+        Function {
+            name: "f".into(),
+            params,
+            return_type: None,
+            captures: vec![],
+            body: Block { stmts: vec![], value: Expr::NilLit { span: s() }, span: s() },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        }
+    }
+
+    #[test]
+    fn keyword_params_helper_selects_only_keyword_kind() {
+        // def f(a, x:, y: 1, **rest) → keyword_params() == [x, y].
+        let f = fn_with_params(vec![
+            Param { name: "a".into(), sir_type: None, kind: ParamKind::Required, default: None, span: s() },
+            kw_param("x", None),
+            kw_param("y", Some(1)),
+            Param { name: "rest".into(), sir_type: None, kind: ParamKind::KwRest, default: None, span: s() },
+        ]);
+        let kws: Vec<&str> = f.keyword_params().iter().map(|p| p.name.as_str()).collect();
+        assert_eq!(kws, vec!["x", "y"]);
+    }
+
+    #[test]
+    fn missing_keywords_returns_unsupplied_keyword_params() {
+        // def f(x:, y: 1, z: 2)
+        let f = fn_with_params(vec![
+            kw_param("x", None),
+            kw_param("y", Some(1)),
+            kw_param("z", Some(2)),
+        ]);
+        // Supplying x and y leaves z omitted.
+        let missing: Vec<&str> = f
+            .missing_keywords(&["x", "y"])
+            .iter()
+            .map(|p| p.name.as_str())
+            .collect();
+        assert_eq!(missing, vec!["z"]);
+        // Supplying only x leaves y and z omitted (both carry defaults).
+        let missing2: Vec<&str> = f
+            .missing_keywords(&["x"])
+            .iter()
+            .map(|p| p.name.as_str())
+            .collect();
+        assert_eq!(missing2, vec!["y", "z"]);
+        // Supplying all leaves nothing.
+        assert!(f.missing_keywords(&["x", "y", "z"]).is_empty());
     }
 
     #[test]

--- a/code/packages/rust/semantic-ir/src/text/printer.rs
+++ b/code/packages/rust/semantic-ir/src/text/printer.rs
@@ -100,25 +100,34 @@ fn print_function_indented(out: &mut String, f: &Function, indent: usize) {
         if i > 0 {
             out.push(' ');
         }
-        // Variadic kinds render with a Ruby-faithful prefix so a
-        // round-tripped module preserves splat-ness: `*rest` for a Rest
-        // param, `**opts` for a KwRest param, plain `name` otherwise.
-        let prefix = match p.kind {
-            ParamKind::Required => "",
-            ParamKind::Rest => "*",
-            ParamKind::KwRest => "**",
+        // Kinds render with a Ruby-faithful sigil so a round-tripped
+        // module preserves the parameter's binding form:
+        //   - `Rest`    → `*name`   prefix (slurps positionals)
+        //   - `KwRest`  → `**name`  prefix (slurps keywords)
+        //   - `Keyword` → `name:`   *suffix* (a named keyword param — the
+        //     trailing colon mirrors Ruby `def f(x:)` / `def f(x: 1)`)
+        //   - `Required`→ plain `name`
+        // A keyword param uses a suffix (not a prefix) so its printed form
+        // reads exactly like the Ruby source that produced it.
+        let (prefix, suffix) = match p.kind {
+            ParamKind::Required => ("", ""),
+            ParamKind::Rest => ("*", ""),
+            ParamKind::Keyword => ("", ":"),
+            ParamKind::KwRest => ("**", ""),
         };
-        // A parameter with a default-value expression (SIR19) renders an
-        // extra `(default <expr>)` clause inside the param form, e.g.
+        // A parameter with a default-value expression renders an extra
+        // `(default <expr>)` clause inside the param form, e.g.
         // `(a any (default (int 1)))`.  Params with no default keep the
         // original `(name type)` shape, so existing modules round-trip
-        // unchanged.
+        // unchanged.  For a keyword param the same clause distinguishes an
+        // OPTIONAL keyword (`(x: any (default (int 1)))`, Ruby `x: 1`) from
+        // a REQUIRED one (`(x: any)`, Ruby `x:`).
         if let Some(default) = &p.default {
-            let _ = write!(out, "({}{} {} (default ", prefix, p.name, type_or_any(p.sir_type.as_ref()));
+            let _ = write!(out, "({}{}{} {} (default ", prefix, p.name, suffix, type_or_any(p.sir_type.as_ref()));
             print_expr_inline_depth(out, default, 0);
             out.push_str("))");
         } else {
-            let _ = write!(out, "({}{} {})", prefix, p.name, type_or_any(p.sir_type.as_ref()));
+            let _ = write!(out, "({}{}{} {})", prefix, p.name, suffix, type_or_any(p.sir_type.as_ref()));
         }
     }
     let _ = write!(out, ") {}", type_or_any(f.return_type.as_ref()));
@@ -452,6 +461,17 @@ fn print_expr_inline_depth(out: &mut String, e: &Expr, depth: usize) {
         Expr::StrConcat { parts, .. } => {
             let _ = write!(out, "(str-concat");
             print_args(out, parts, depth);
+            out.push(')');
+        }
+        // ── KW1: keyword argument ──────────────────────────────────
+        // `(keyword-arg name <value>)` — the head keyword names the
+        // concept, then the keyword's name (bare, like a `var-ref`'s name),
+        // then the value expression.  It appears inline in a call's arg
+        // list, so `f(1, a: 2)` prints as
+        // `(direct-call f (effects …) (int 1) (keyword-arg a (int 2)))`.
+        Expr::KeywordArg { name, value, .. } => {
+            let _ = write!(out, "(keyword-arg {} ", name);
+            print_expr_inline_depth(out, value, depth + 1);
             out.push(')');
         }
     }
@@ -796,6 +816,65 @@ mod tests {
         assert!(
             text.contains("(function f ((a any (default (int 1))) (b any)) any"),
             "got: {text}"
+        );
+    }
+
+    #[test]
+    fn print_keyword_params_render_colon_suffix() {
+        // KW1: `def f(x:, y: 1)` → a REQUIRED keyword `x` renders `(x: any)`
+        // and an OPTIONAL keyword `y` renders `(y: any (default (int 1)))`.
+        let body = Block { stmts: vec![], value: Expr::NilLit { span: s() }, span: s() };
+        let f = Function {
+            name: "f".into(),
+            params: vec![
+                Param { name: "x".into(), sir_type: None, kind: ParamKind::Keyword, default: None, span: s() },
+                Param {
+                    name: "y".into(),
+                    sir_type: None,
+                    kind: ParamKind::Keyword,
+                    default: Some(Box::new(Expr::IntLit { value: 1, span: s() })),
+                    span: s(),
+                },
+            ],
+            return_type: None,
+            captures: vec![],
+            body,
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        };
+        let m = module_with(
+            vec![f],
+            FeatureManifest::from_features(&[Feature::DynamicTyping, Feature::KeywordParams]),
+        );
+        let text = print_module(&m);
+        assert!(
+            text.contains("(function f ((x: any) (y: any (default (int 1)))) any"),
+            "got: {text}"
+        );
+    }
+
+    #[test]
+    fn print_keyword_arg_renders_head_name_value() {
+        // KW1: `f(1, a: 2)` → a keyword argument prints as
+        // `(keyword-arg a (int 2))`, inline in the call's arg list after
+        // the positional `(int 1)`.
+        let e = Expr::DirectCall {
+            fn_name: "f".into(),
+            args: vec![
+                Expr::IntLit { value: 1, span: s() },
+                Expr::KeywordArg {
+                    name: "a".into(),
+                    value: Box::new(Expr::IntLit { value: 2, span: s() }),
+                    span: s(),
+                },
+            ],
+            effects: EffectSet::PURE,
+            span: s(),
+        };
+        assert_eq!(
+            print_expr(&e),
+            "(direct-call f (effects pure) (int 1) (keyword-arg a (int 2)))"
         );
     }
 

--- a/code/packages/rust/semantic-ir/src/validator.rs
+++ b/code/packages/rust/semantic-ir/src/validator.rs
@@ -153,6 +153,15 @@ struct ValidatorState<'m> {
     /// `true` once a depth-overflow error has been recorded for
     /// this module.  Suppresses duplicate spam.
     depth_overflow_reported: bool,
+    /// `true` while checking the *immediate* arguments of a call node
+    /// (DirectCall / IndirectCall / MakeClosure).  A `KeywordArg` is only
+    /// well-placed as such an immediate argument; the flag lets the
+    /// `check_expr` `KeywordArg` arm distinguish a legitimate call-position
+    /// keyword from a misplaced one (e.g. `(+ (kw a 1))` or a keyword arg
+    /// nested inside another expression).  It is set true just around the
+    /// per-arg walk of a call and reset to false before recursing into any
+    /// argument's sub-expressions.
+    in_call_args: bool,
 }
 
 impl<'m> ValidatorState<'m> {
@@ -165,6 +174,7 @@ impl<'m> ValidatorState<'m> {
             fn_arity: HashMap::new(),
             global_names: HashSet::new(),
             depth_overflow_reported: false,
+            in_call_args: false,
         }
     }
 
@@ -301,29 +311,59 @@ impl<'m> ValidatorState<'m> {
             } else {
                 self.observed.add(Feature::DynamicTyping);
             }
+            // Keyword parameter (KW1): observe the feature.  A `Keyword`
+            // param is matched by name, not position; whether it is
+            // REQUIRED (`default == None`) or OPTIONAL (`default == Some`)
+            // rides on the same `default` field checked just below, so we
+            // do not special-case the default handling here — a keyword
+            // default is validated exactly like a positional default.
+            if p.kind == ParamKind::Keyword {
+                self.observed.add(Feature::KeywordParams);
+            }
             // Default-value expression (SIR19): observe the feature and
             // validate the expression as if it appeared in the function's
             // parameter scope with the params declared so far in view.
+            //
+            // A default on a `Keyword` param means "optional keyword"; it
+            // triggers `KeywordParams` (above), NOT `DefaultParams` —
+            // `DefaultParams` is specifically the *positional* trailing
+            // default feature.  Only observe `DefaultParams` for a
+            // non-keyword default.
             if let Some(default) = &p.default {
-                self.observed.add(Feature::DefaultParams);
+                if p.kind != ParamKind::Keyword {
+                    self.observed.add(Feature::DefaultParams);
+                }
                 let mut env = LocalEnv::new(&scope_so_far, &no_captures);
                 self.check_expr(default, &mut env, 0);
             }
             scope_so_far.insert(p.name.clone());
         }
 
-        // Variadic-parameter well-formedness (M3). A Ruby-faithful, v0-light
-        // rule set over `kind`:
+        // Variadic/keyword-parameter well-formedness (M3 + KW1). A
+        // Ruby-faithful, v0-light rule set over `kind`:
         //   - at most one `Rest` (`*rest`) parameter;
         //   - at most one `KwRest` (`**opts`) parameter;
-        //   - ordering: required positionals come first, then the lone Rest,
-        //     then the lone KwRest. A Required after a Rest, or anything after
-        //     a KwRest, is a structural error (not a panic).
-        // Truth table for the offending transitions we reject:
-        //   prev\cur | Required | Rest     | KwRest
-        //   Rest     | ERROR    | (dup)    | ok
-        //   KwRest   | ERROR    | ERROR    | (dup)
+        //   - ordering: positional `Required` first, then the lone `Rest`,
+        //     then any number of `Keyword` params, then the lone `KwRest`.
+        //     Anything out of that order is a structural error (not a panic).
+        //
+        // The canonical param list is therefore:
+        //     Required*  Rest?  Keyword*  KwRest?
+        //
+        // Truth table for the offending transitions we reject (prev seen ⇒
+        // current kind is illegal):
+        //   prev seen \ cur | Required | Rest  | Keyword | KwRest
+        //   Rest            | ERROR    | (dup) | ok      | ok
+        //   Keyword         | ERROR    | ERROR | ok      | ok
+        //   KwRest          | ERROR    | ERROR | ERROR   | (dup)
+        //
+        // Rationale for `Keyword` sitting *after* `Rest` but *before*
+        // `KwRest`: a `*rest` slurps trailing *positional* args, so it must
+        // close the positional run before any name-matched keyword params;
+        // a `**opts` slurps *unmatched* keywords, so it must come after the
+        // explicitly-named keyword params it would otherwise shadow.
         let mut rest_seen = false;
+        let mut keyword_seen = false;
         let mut kwrest_seen = false;
         for p in &f.params {
             match p.kind {
@@ -334,6 +374,12 @@ impl<'m> ValidatorState<'m> {
                             &p.span,
                         );
                     }
+                    if keyword_seen {
+                        self.error(
+                            format!("rest parameter `*{}` must precede keyword parameters", p.name),
+                            &p.span,
+                        );
+                    }
                     if kwrest_seen {
                         self.error(
                             format!("rest parameter `*{}` must precede the keyword-rest parameter", p.name),
@@ -341,6 +387,17 @@ impl<'m> ValidatorState<'m> {
                         );
                     }
                     rest_seen = true;
+                }
+                ParamKind::Keyword => {
+                    // A keyword param must precede the lone `**opts`; it may
+                    // follow positionals, the `*rest`, and other keywords.
+                    if kwrest_seen {
+                        self.error(
+                            format!("keyword parameter `{}` must precede the keyword-rest parameter", p.name),
+                            &p.span,
+                        );
+                    }
+                    keyword_seen = true;
                 }
                 ParamKind::KwRest => {
                     if kwrest_seen {
@@ -354,13 +411,19 @@ impl<'m> ValidatorState<'m> {
                 ParamKind::Required => {
                     // The reserved trailing block parameter (Q9e) is always
                     // Required and always appended last — after any variadic
-                    // params — so it is exempt from the ordering rule.
+                    // or keyword params — so it is exempt from the ordering
+                    // rule.
                     if p.name == "__sir_block__" {
                         continue;
                     }
                     if kwrest_seen {
                         self.error(
                             format!("required parameter `{}` must precede the keyword-rest parameter", p.name),
+                            &p.span,
+                        );
+                    } else if keyword_seen {
+                        self.error(
+                            format!("required parameter `{}` must precede keyword parameters", p.name),
                             &p.span,
                         );
                     } else if rest_seen {
@@ -657,6 +720,10 @@ impl<'m> ValidatorState<'m> {
             }
             Expr::Block(b) => self.check_block(b, env, depth + 1),
             Expr::DirectCall { fn_name, args, .. } => {
+                // Call-side keyword-argument checks (ordering, duplicates,
+                // name resolution against the known callee) run first, then
+                // arity, then the recursive arg walk.
+                self.check_call_kwargs(fn_name, args, e.span());
                 if let Some(arity) = self.fn_arity.get(fn_name).copied() {
                     // SIR10 default-param call-arity rule.  Let R be the
                     // callee's required (leading no-default) param count and
@@ -687,7 +754,18 @@ impl<'m> ValidatorState<'m> {
                     // for every existing frontend lowering, which relied on the
                     // validator never checking DirectCall arity at all.
                     if !arity.variadic && args_are_plain(args) {
-                        let n = args.len();
+                        // Only *positional* args count against the R/M
+                        // bounds; any `KeywordArg` is matched by name, not
+                        // position, so it is excluded here (its validity is
+                        // handled by `check_call_kwargs`).  A plain
+                        // positional callee that receives a stray keyword
+                        // still gets the precise "unknown keyword" diagnostic
+                        // from name resolution rather than a misleading
+                        // arity-count error.
+                        let n = args
+                            .iter()
+                            .filter(|a| !matches!(a, Expr::KeywordArg { .. }))
+                            .count();
                         if n < arity.min {
                             self.error(
                                 format!(
@@ -712,16 +790,15 @@ impl<'m> ValidatorState<'m> {
                         e.span(),
                     );
                 }
-                for a in args {
-                    self.check_expr(a, env, depth + 1);
-                }
+                self.check_args(args, env, depth);
             }
             Expr::IndirectCall { target, args, .. } => {
                 self.observed.add(Feature::Closures);
+                // Ordering + duplicate keyword checks apply, but the callee
+                // signature is not statically known, so no name resolution.
+                self.check_kwargs_common(None, args, e.span());
                 self.check_expr(target, env, depth + 1);
-                for a in args {
-                    self.check_expr(a, env, depth + 1);
-                }
+                self.check_args(args, env, depth);
             }
             Expr::BuiltinCall { name, args, .. } => {
                 match name.as_str() {
@@ -808,6 +885,155 @@ impl<'m> ValidatorState<'m> {
                 for p in parts {
                     self.check_expr(p, env, depth + 1);
                 }
+            }
+            // ── KW1: keyword argument ──────────────────────────────
+            Expr::KeywordArg { value, span, .. } => {
+                // Using a keyword argument at all requires the feature.
+                self.observed.add(Feature::KeywordParams);
+                // A `KeywordArg` is only well-formed as an *immediate*
+                // argument of a call.  `in_call_args` is true exactly when
+                // we are walking such immediate arguments (see
+                // `check_args`); anywhere else — nested inside another
+                // expression, as a `BuiltinCall`/`Intrinsic` argument, as a
+                // block value, a let RHS, a default expr, etc. — it is
+                // misplaced and rejected.
+                if !self.in_call_args {
+                    self.error(
+                        "keyword argument may only appear directly in a call's argument list"
+                            .to_string(),
+                        span,
+                    );
+                }
+                // Recurse into the value with the call-args flag cleared:
+                // the value itself is an ordinary expression position (a
+                // nested `KeywordArg` inside it would be misplaced).
+                let prev = self.in_call_args;
+                self.in_call_args = false;
+                self.check_expr(value, env, depth + 1);
+                self.in_call_args = prev;
+            }
+        }
+    }
+
+    /// Walk the arguments of a call node (DirectCall / IndirectCall /
+    /// BuiltinCall / MakeClosure), permitting a top-level `KeywordArg`.
+    ///
+    /// A `KeywordArg` is only well-placed as a *direct* argument of a call,
+    /// so we set `in_call_args = true` around this loop; the `KeywordArg`
+    /// arm of [`Self::check_expr`] reads the flag to allow the keyword here
+    /// and to *reject* it anywhere else (it clears the flag before
+    /// recursing into the keyword's value).  We save and restore the prior
+    /// flag value so nested calls compose correctly.
+    fn check_args(&mut self, args: &[Expr], env: &mut LocalEnv, depth: usize) {
+        let prev = self.in_call_args;
+        self.in_call_args = true;
+        for a in args {
+            self.check_expr(a, env, depth + 1);
+        }
+        self.in_call_args = prev;
+    }
+
+    /// Call-side keyword-argument validation for a call whose args vec is
+    /// `args` (KW1).  Enforces, independent of the callee's identity:
+    ///
+    ///   1. **Ordering** — every `KeywordArg` must follow all positional
+    ///      (non-`KeywordArg`) arguments.  `f(1, a: 2)` is fine; a
+    ///      positional after a keyword (`f(a: 2, 1)`) is rejected.
+    ///   2. **No duplicate keyword names** within one call's args.
+    ///
+    /// When `known_callee` is `Some(name)` and that name resolves to a
+    /// function in this module, it additionally performs
+    ///   3. **Name resolution** — each `KeywordArg.name` must match a
+    ///      `Keyword` param of the callee OR the callee declares a
+    ///      `KwRest`; and every REQUIRED keyword param (Keyword, default
+    ///      None) must be supplied.
+    ///
+    /// IndirectCall / closure calls pass `None`: the signature is not
+    /// statically known, so only ordering + duplicate checks apply.
+    fn check_call_kwargs(&mut self, callee: &str, args: &[Expr], call_span: &Span) {
+        self.check_kwargs_common(Some(callee), args, call_span);
+    }
+
+    /// Ordering + duplicate checks (and optional name resolution) shared by
+    /// every call kind.  `callee` is `Some` only for a `DirectCall`, whose
+    /// target may be a known module function.
+    fn check_kwargs_common(&mut self, callee: Option<&str>, args: &[Expr], call_span: &Span) {
+        let mut seen_keyword = false;
+        let mut names: HashSet<&str> = HashSet::new();
+        let mut supplied: Vec<&str> = Vec::new();
+        for a in args {
+            match a {
+                Expr::KeywordArg { name, span, .. } => {
+                    seen_keyword = true;
+                    if !names.insert(name.as_str()) {
+                        self.error(
+                            format!("duplicate keyword argument `{}` in call", name),
+                            span,
+                        );
+                    }
+                    supplied.push(name.as_str());
+                }
+                _ => {
+                    // A positional argument.  Once a keyword has appeared,
+                    // positionals are illegal — keyword args must trail all
+                    // positionals so a backend can split `args` at the first
+                    // keyword unambiguously.
+                    if seen_keyword {
+                        self.error(
+                            "positional argument may not follow a keyword argument"
+                                .to_string(),
+                            a.span(),
+                        );
+                    }
+                }
+            }
+        }
+
+        // Name resolution against a *known* callee only.
+        let Some(callee) = callee else { return };
+        // Clone out the callee's keyword-param facts we need, to avoid
+        // holding a borrow of `self.module` across the `self.error` calls.
+        let Some(f) = self.module.functions.iter().find(|f| f.name == callee) else {
+            return;
+        };
+        let kw_names: HashSet<String> =
+            f.keyword_params().iter().map(|p| p.name.clone()).collect();
+        let has_kwrest = f.params.iter().any(|p| p.kind == ParamKind::KwRest);
+        let required_kw: Vec<String> = f
+            .params
+            .iter()
+            .filter(|p| p.kind == ParamKind::Keyword && p.default.is_none())
+            .map(|p| p.name.clone())
+            .collect();
+
+        // Every supplied keyword must name a declared keyword param, unless
+        // the callee slurps extras via `**kwrest`.
+        if !has_kwrest {
+            for a in args {
+                if let Expr::KeywordArg { name, span, .. } = a {
+                    if !kw_names.contains(name) {
+                        self.error(
+                            format!(
+                                "call to `{}` passes unknown keyword `{}` (callee declares no such keyword parameter and no `**` keyword-rest)",
+                                callee, name
+                            ),
+                            span,
+                        );
+                    }
+                }
+            }
+        }
+
+        // Every required keyword param must be supplied.
+        for req in &required_kw {
+            if !supplied.contains(&req.as_str()) {
+                self.error(
+                    format!(
+                        "call to `{}` is missing required keyword `{}`",
+                        callee, req
+                    ),
+                    call_span,
+                );
             }
         }
     }
@@ -2671,5 +2897,532 @@ mod tests {
         });
         let r = validate(&m);
         assert!(!r.is_ok(), "expected `e` out-of-scope error in ensure body");
+    }
+
+    // ── KW1: keyword parameters & arguments ────────────────────────────
+
+    /// A keyword param `name:` (required) or `name: 1` (optional).
+    fn kw(name: &str, default: Option<i64>) -> Param {
+        Param {
+            name: name.into(),
+            sir_type: None,
+            kind: ParamKind::Keyword,
+            default: default.map(|v| Box::new(Expr::IntLit { value: v, span: s() })),
+            span: s(),
+        }
+    }
+
+    /// A keyword argument `name: <int>` for a call's args vec.
+    fn kwarg(name: &str, v: i64) -> Expr {
+        Expr::KeywordArg {
+            name: name.into(),
+            value: Box::new(Expr::IntLit { value: v, span: s() }),
+            span: s(),
+        }
+    }
+
+    /// Build a two-function module: callee `f` with `callee_params` and a
+    /// caller `g` whose body is a `DirectCall` to `f` with `call_args`.
+    /// The manifest declares KeywordParams so keyword-using modules pass
+    /// the manifest check; extra features can be appended by the caller
+    /// via `extra`.
+    fn module_kw_call(
+        callee_params: Vec<Param>,
+        call_args: Vec<Expr>,
+        extra: &[Feature],
+    ) -> Module {
+        let mut feats = vec![Feature::DynamicTyping, Feature::KeywordParams];
+        feats.extend_from_slice(extra);
+        let mut m = empty_module(FeatureManifest::from_features(&feats));
+        m.functions.push(Function {
+            name: "f".into(),
+            params: callee_params,
+            return_type: None,
+            captures: vec![],
+            body: Block { stmts: vec![], value: Expr::NilLit { span: s() }, span: s() },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        });
+        m.functions.push(Function {
+            name: "g".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts: vec![],
+                value: Expr::DirectCall {
+                    fn_name: "f".into(),
+                    args: call_args,
+                    effects: EffectSet::PURE,
+                    span: s(),
+                },
+                span: s(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        });
+        m
+    }
+
+    #[test]
+    fn keyword_param_observes_feature_and_gating() {
+        // def f(x:) with the feature declared → ok; without it → error.
+        let ok = module_with_params(vec![kw("x", Some(1))]);
+        // module_with_params only declares DynamicTyping, so the keyword
+        // param is undeclared → error.
+        assert!(
+            !validate(&ok).is_ok(),
+            "keyword param without KeywordParams declared must error"
+        );
+        // Now declare it.
+        let mut m = empty_module(FeatureManifest::from_features(&[
+            Feature::DynamicTyping,
+            Feature::KeywordParams,
+        ]));
+        m.functions.push(Function {
+            name: "f".into(),
+            params: vec![kw("x", Some(1))],
+            return_type: None,
+            captures: vec![],
+            body: Block { stmts: vec![], value: Expr::NilLit { span: s() }, span: s() },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        });
+        let r = validate(&m);
+        assert!(r.is_ok(), "expected ok, got {:?}", r.issues);
+    }
+
+    #[test]
+    fn keyword_arg_requires_feature() {
+        // f(a: 1) where the manifest omits KeywordParams → error, even
+        // though the callee accepts `a` (feature gating is independent of
+        // name resolution).
+        let mut m = empty_module(FeatureManifest::from_features(&[Feature::DynamicTyping]));
+        m.functions.push(Function {
+            name: "f".into(),
+            params: vec![kw("a", Some(0))],
+            return_type: None,
+            captures: vec![],
+            body: Block { stmts: vec![], value: Expr::NilLit { span: s() }, span: s() },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        });
+        m.functions.push(Function {
+            name: "g".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts: vec![],
+                value: Expr::DirectCall {
+                    fn_name: "f".into(),
+                    args: vec![kwarg("a", 1)],
+                    effects: EffectSet::PURE,
+                    span: s(),
+                },
+                span: s(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        });
+        let r = validate(&m);
+        assert!(!r.is_ok(), "keyword arg without the feature must error");
+        assert!(r.errors().any(|i| i.message.contains("keyword-params")));
+    }
+
+    // ── def-side ordering ──────────────────────────────────────────────
+
+    #[test]
+    fn keyword_params_canonical_order_is_valid() {
+        // def f(a, *rest, x:, y: 1, **opts) — required, rest, keywords, kwrest.
+        let m = module_with_params_kw(vec![
+            p("a", ParamKind::Required),
+            p("rest", ParamKind::Rest),
+            kw("x", None),
+            kw("y", Some(1)),
+            p("opts", ParamKind::KwRest),
+        ]);
+        let r = validate(&m);
+        assert!(r.is_ok(), "expected ok, got {:?}", r.issues);
+    }
+
+    /// module_with_params but declaring KeywordParams too.
+    fn module_with_params_kw(params: Vec<Param>) -> Module {
+        let mut m = empty_module(FeatureManifest::from_features(&[
+            Feature::DynamicTyping,
+            Feature::KeywordParams,
+        ]));
+        m.functions.push(Function {
+            name: "f".into(),
+            params,
+            return_type: None,
+            captures: vec![],
+            body: Block { stmts: vec![], value: Expr::NilLit { span: s() }, span: s() },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        });
+        m
+    }
+
+    #[test]
+    fn keyword_param_before_positional_is_error() {
+        // def f(x:, a) — a required positional after a keyword param.
+        let m = module_with_params_kw(vec![kw("x", None), p("a", ParamKind::Required)]);
+        let r = validate(&m);
+        assert!(!r.is_ok());
+        assert!(
+            r.errors().any(|i| i.message.contains("must precede keyword parameters")),
+            "got {:?}",
+            r.issues
+        );
+    }
+
+    #[test]
+    fn keyword_param_after_kwrest_is_error() {
+        // def f(**opts, x:) — a keyword param after the keyword-rest.
+        let m = module_with_params_kw(vec![p("opts", ParamKind::KwRest), kw("x", None)]);
+        let r = validate(&m);
+        assert!(!r.is_ok());
+        assert!(
+            r.errors()
+                .any(|i| i.message.contains("must precede the keyword-rest")),
+            "got {:?}",
+            r.issues
+        );
+    }
+
+    #[test]
+    fn rest_after_keyword_is_error() {
+        // def f(x:, *rest) — the rest param must precede keyword params.
+        let m = module_with_params_kw(vec![kw("x", None), p("rest", ParamKind::Rest)]);
+        let r = validate(&m);
+        assert!(!r.is_ok());
+        assert!(
+            r.errors()
+                .any(|i| i.message.contains("must precede keyword parameters")),
+            "got {:?}",
+            r.issues
+        );
+    }
+
+    // ── call-side ordering / duplicates ────────────────────────────────
+
+    #[test]
+    fn keyword_arg_after_positional_is_valid() {
+        // def f(a, x:); f(1, x: 2) — one positional then one keyword.
+        let m = module_kw_call(
+            vec![p("a", ParamKind::Required), kw("x", None)],
+            vec![Expr::IntLit { value: 1, span: s() }, kwarg("x", 2)],
+            &[],
+        );
+        let r = validate(&m);
+        assert!(r.is_ok(), "expected ok, got {:?}", r.issues);
+    }
+
+    #[test]
+    fn positional_after_keyword_arg_is_error() {
+        // f(x: 2, 1) — a positional after a keyword argument.
+        let m = module_kw_call(
+            vec![kw("x", Some(0)), p("a", ParamKind::Required)],
+            vec![kwarg("x", 2), Expr::IntLit { value: 1, span: s() }],
+            &[],
+        );
+        let r = validate(&m);
+        assert!(!r.is_ok());
+        assert!(
+            r.errors()
+                .any(|i| i.message.contains("positional argument may not follow a keyword")),
+            "got {:?}",
+            r.issues
+        );
+    }
+
+    #[test]
+    fn duplicate_keyword_arg_is_error() {
+        // f(x: 1, x: 2) — the same keyword twice in one call.
+        let m = module_kw_call(
+            vec![kw("x", Some(0))],
+            vec![kwarg("x", 1), kwarg("x", 2)],
+            &[],
+        );
+        let r = validate(&m);
+        assert!(!r.is_ok());
+        assert!(
+            r.errors().any(|i| i.message.contains("duplicate keyword argument")),
+            "got {:?}",
+            r.issues
+        );
+    }
+
+    // ── name resolution against a known callee ─────────────────────────
+
+    #[test]
+    fn unknown_keyword_without_kwrest_is_error() {
+        // def f(x:); f(y: 1) — `y` is not a declared keyword and there is
+        // no **kwrest to absorb it.
+        let m = module_kw_call(vec![kw("x", None)], vec![kwarg("y", 1)], &[]);
+        let r = validate(&m);
+        assert!(!r.is_ok());
+        assert!(
+            r.errors().any(|i| i.message.contains("unknown keyword `y`")),
+            "got {:?}",
+            r.issues
+        );
+    }
+
+    #[test]
+    fn unknown_keyword_with_kwrest_is_accepted() {
+        // def f(**opts); f(y: 1) — the **opts absorbs the unmatched keyword,
+        // so an otherwise-unknown keyword name is accepted.
+        let m = module_kw_call(
+            vec![p("opts", ParamKind::KwRest)],
+            vec![kwarg("y", 1)],
+            &[],
+        );
+        let r = validate(&m);
+        assert!(r.is_ok(), "expected ok with **kwrest, got {:?}", r.issues);
+    }
+
+    #[test]
+    fn missing_required_keyword_is_error() {
+        // def f(x:); f() — the required keyword `x` is not supplied.
+        let m = module_kw_call(vec![kw("x", None)], vec![], &[]);
+        let r = validate(&m);
+        assert!(!r.is_ok());
+        assert!(
+            r.errors().any(|i| i.message.contains("missing required keyword `x`")),
+            "got {:?}",
+            r.issues
+        );
+    }
+
+    #[test]
+    fn optional_keyword_may_be_omitted() {
+        // def f(x: 1); f() — the keyword `x` is optional (has a default),
+        // so omitting it is fine.
+        let m = module_kw_call(vec![kw("x", Some(1))], vec![], &[]);
+        let r = validate(&m);
+        assert!(r.is_ok(), "expected ok, got {:?}", r.issues);
+    }
+
+    #[test]
+    fn supplying_required_keyword_is_valid() {
+        // def f(x:); f(x: 5) — the required keyword is supplied.
+        let m = module_kw_call(vec![kw("x", None)], vec![kwarg("x", 5)], &[]);
+        let r = validate(&m);
+        assert!(r.is_ok(), "expected ok, got {:?}", r.issues);
+    }
+
+    #[test]
+    fn indirect_call_skips_keyword_name_resolution() {
+        // A closure/indirect call has no statically known signature, so
+        // ordering + dup checks apply but NOT name resolution: an "unknown"
+        // keyword against a closure is accepted.  Ordering violations still
+        // fail (checked separately); here we prove a lone keyword arg is ok.
+        let mut m = empty_module(FeatureManifest::from_features(&[
+            Feature::DynamicTyping,
+            Feature::KeywordParams,
+            Feature::Closures,
+        ]));
+        m.functions.push(Function {
+            name: "g".into(),
+            params: vec![p("cb", ParamKind::Required)],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts: vec![],
+                value: Expr::IndirectCall {
+                    target: Box::new(Expr::VarRef {
+                        name: "cb".into(),
+                        scope: Scope::Param,
+                        span: s(),
+                    }),
+                    args: vec![kwarg("anything", 1)],
+                    effects: EffectSet::PURE,
+                    span: s(),
+                },
+                span: s(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        });
+        let r = validate(&m);
+        assert!(r.is_ok(), "indirect keyword call must skip resolution, got {:?}", r.issues);
+    }
+
+    #[test]
+    fn indirect_call_still_enforces_keyword_ordering() {
+        // Even without name resolution, a positional after a keyword in an
+        // indirect call is rejected.
+        let mut m = empty_module(FeatureManifest::from_features(&[
+            Feature::DynamicTyping,
+            Feature::KeywordParams,
+            Feature::Closures,
+        ]));
+        m.functions.push(Function {
+            name: "g".into(),
+            params: vec![p("cb", ParamKind::Required)],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts: vec![],
+                value: Expr::IndirectCall {
+                    target: Box::new(Expr::VarRef {
+                        name: "cb".into(),
+                        scope: Scope::Param,
+                        span: s(),
+                    }),
+                    args: vec![kwarg("x", 1), Expr::IntLit { value: 2, span: s() }],
+                    effects: EffectSet::PURE,
+                    span: s(),
+                },
+                span: s(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        });
+        let r = validate(&m);
+        assert!(!r.is_ok());
+        assert!(
+            r.errors()
+                .any(|i| i.message.contains("positional argument may not follow a keyword")),
+            "got {:?}",
+            r.issues
+        );
+    }
+
+    // ── KeywordArg only in call position ───────────────────────────────
+
+    #[test]
+    fn keyword_arg_outside_call_is_error() {
+        // A KeywordArg used as a block value (not a call argument) is
+        // misplaced.  `def g() = (a: 1)` — invalid.
+        let mut m = empty_module(FeatureManifest::from_features(&[
+            Feature::DynamicTyping,
+            Feature::KeywordParams,
+        ]));
+        m.functions.push(Function {
+            name: "g".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts: vec![],
+                value: kwarg("a", 1),
+                span: s(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        });
+        let r = validate(&m);
+        assert!(!r.is_ok());
+        assert!(
+            r.errors()
+                .any(|i| i.message.contains("may only appear directly in a call")),
+            "got {:?}",
+            r.issues
+        );
+    }
+
+    #[test]
+    fn keyword_arg_nested_in_builtin_call_is_error() {
+        // A KeywordArg buried in a BuiltinCall's args (not a keyword-taking
+        // call position) is misplaced.  `(+ (a: 1))` — invalid.
+        let mut m = empty_module(FeatureManifest::from_features(&[
+            Feature::DynamicTyping,
+            Feature::KeywordParams,
+        ]));
+        m.functions.push(Function {
+            name: "g".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts: vec![],
+                value: Expr::BuiltinCall {
+                    name: "+".into(),
+                    args: vec![kwarg("a", 1)],
+                    effects: EffectSet::PURE,
+                    span: s(),
+                },
+                span: s(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        });
+        let r = validate(&m);
+        assert!(!r.is_ok());
+        assert!(
+            r.errors()
+                .any(|i| i.message.contains("may only appear directly in a call")),
+            "got {:?}",
+            r.issues
+        );
+    }
+
+    #[test]
+    fn keyword_arg_value_may_not_nest_a_keyword_arg() {
+        // The *value* of a keyword arg is an ordinary expression position,
+        // so a keyword arg nested inside it is misplaced.
+        // f(a: (b: 1)) — the inner `(b: 1)` is invalid.
+        let inner = Expr::KeywordArg {
+            name: "b".into(),
+            value: Box::new(Expr::IntLit { value: 1, span: s() }),
+            span: s(),
+        };
+        let outer = Expr::KeywordArg {
+            name: "a".into(),
+            value: Box::new(inner),
+            span: s(),
+        };
+        let m = module_kw_call(
+            vec![p("opts", ParamKind::KwRest)],
+            vec![outer],
+            &[],
+        );
+        let r = validate(&m);
+        assert!(!r.is_ok());
+        assert!(
+            r.errors()
+                .any(|i| i.message.contains("may only appear directly in a call")),
+            "got {:?}",
+            r.issues
+        );
+    }
+
+    #[test]
+    fn keyword_arg_value_expression_is_validated() {
+        // The keyword arg's value is recursed into: a bad var-ref inside it
+        // is caught.  f(**opts); f(x: <unknown local>) — scope error.
+        let m = module_kw_call(
+            vec![p("opts", ParamKind::KwRest)],
+            vec![Expr::KeywordArg {
+                name: "x".into(),
+                value: Box::new(Expr::VarRef {
+                    name: "ghost".into(),
+                    scope: Scope::Local,
+                    span: s(),
+                }),
+                span: s(),
+            }],
+            &[],
+        );
+        let r = validate(&m);
+        assert!(!r.is_ok());
+        assert!(
+            r.errors().any(|i| i.message.contains("unknown name `ghost`")),
+            "got {:?}",
+            r.issues
+        );
     }
 }

--- a/code/packages/rust/semantic-ir/src/walker.rs
+++ b/code/packages/rust/semantic-ir/src/walker.rs
@@ -258,6 +258,15 @@ pub fn walk_expr_default<V: Visitor>(v: &mut V, e: &Expr) {
                 v.visit_expr(p);
             }
         }
+        // ── KW1: keyword argument ──────────────────────────────────
+        // A keyword argument has exactly one child, its `value`.  We
+        // recurse into it so a visitor sees the argument expression (e.g.
+        // the `1` in `f(a: 1)`).  The recursion is depth-bounded like the
+        // rest of the walk: the same `visit_expr` dispatch that guards
+        // every other child applies here — we add no bypass.
+        Expr::KeywordArg { value, .. } => {
+            v.visit_expr(value);
+        }
     }
 }
 
@@ -415,6 +424,49 @@ mod tests {
         let mut c = Counter { builtins: 0, ints: 0 };
         c.visit_module(&m);
         assert_eq!(c.ints, 1, "walker should visit the default-value expression");
+    }
+
+    #[test]
+    fn visitor_visits_keyword_arg_value() {
+        // KW1: the walker must recurse into a KeywordArg's value, so the
+        // IntLit `2` inside `f(a: 2)` is counted.
+        let body = Block {
+            stmts: vec![],
+            value: Expr::DirectCall {
+                fn_name: "f".into(),
+                args: vec![Expr::KeywordArg {
+                    name: "a".into(),
+                    value: Box::new(Expr::IntLit { value: 2, span: s() }),
+                    span: s(),
+                }],
+                effects: EffectSet::PURE,
+                span: s(),
+            },
+            span: s(),
+        };
+        let f = Function {
+            name: "g".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body,
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        };
+        let m = Module {
+            name: "m".into(),
+            manifest: FeatureManifest::new(),
+            imports: vec![],
+            exports: vec![],
+            functions: vec![f],
+            globals: vec![],
+            metadata: Metadata::new(),
+            span: s(),
+        };
+        let mut c = Counter { builtins: 0, ints: 0 };
+        c.visit_module(&m);
+        assert_eq!(c.ints, 1, "walker should visit the keyword-arg value");
     }
 
     #[test]


### PR DESCRIPTION
## What

**KW1** of the keyword-params cascade (design: [#7133](https://github.com/adhithyan15/coding-adventures/pull/7133) / `code/specs/sir-keyword-params.md`). Adds named keyword params (`def f(x:)` / `def f(x: 1)`) and keyword args (`f(x: 1)`) to the `semantic-ir` **core** — the change every backend/frontend milestone rebases on top of.

## Core additions

- **`ParamKind::Keyword`** — required-vs-optional rides on the **existing** `Param.default` field (None = required kw, Some = optional kw). No new flag; no existing `Param` construction changes (Copy enum, `#[default]` = Required).
- **`Expr::KeywordArg { name, value: Box<Expr>, span }`** — lives inside the existing call `args: Vec<Expr>` (positionals stay bare). Chosen over a parallel `kwargs` field on every call struct to minimize cross-PR construction-site churn.
- **`Feature::KeywordParams`** — observed when any `Keyword` param or any `KeywordArg` is present; the pre-existing manifest capability check rejects keyword-using modules that don't declare it (so they can't silently reach a backend that doesn't yet accept them).
- **Validator rules:** def-side ordering (`Required* Rest? Keyword* KwRest?`), call-side ordering (keywords trail positionals), duplicate-keyword rejection, known-callee (DirectCall) unknown-keyword + required-keyword enforcement, and "`KeywordArg` only in a call's arg list" (via a saved/restored `in_call_args` flag).
- **Walker / printer / backend-walker** arms for `KeywordArg` (all depth-bounded); helpers `Function::keyword_params()` / `missing_keywords()`.

## Verification

- `cargo test -p semantic-ir` — **163 passed** (+28 new) + 2 doc-tests, 0 failed.
- Clippy: no new warnings on touched files (the `approx_constant` errors are pre-existing test floats, line-shifted only; KW1 introduces no such literals).
- **Security review passed**: recursion into `KeywordArg.value` is under the same `MAX_IR_DEPTH` guard as every other variant (no stack-overflow bypass); no panics/unwraps/unsafe on untrusted modules; feature-gating closes the exhaustiveness gap.

## Sequencing

Per the spec + the cross-PR struct-field lesson: **this core PR merges first**, then KW2–KW6 (Python/TS/JS/Rust/Go backends) and KW7–KW8 (Ruby/Python frontends) rebase on top as disjoint parallel lanes. I'll hold those until this lands.

Design note carried into code: a *keyword* param's default triggers `KeywordParams` (not `DefaultParams` — that's specifically the positional trailing-default axis).

🤖 Generated with [Claude Code](https://claude.com/claude-code)