### PR TITLE
feat(mathml): semicolon-separated <mfenced> lowers to rows — PR-5

### DIFF
--- a/code/packages/rust/mathml/CHANGELOG.md
+++ b/code/packages/rust/mathml/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to the Presentation-MathML frontend crate.
 
+## [0.5.0] — 2026-06-30
+
+### Added — PR-5: semicolon-separated `<mfenced>` lowers to rows
+
+- An `<mfenced>` whose top-level children include a `<mo>;</mo>` separator is now read as **rows**:
+  semicolons are the row separator and commas the within-row (column) separator, the classic
+  fenced-matrix notation. `(a, b; c, d)` → `Sequence([Sequence([a, b]), Sequence([c, d])])` — an
+  outer sequence of rows, each row an inner sequence of columns. This is the natural extension of
+  the PR-4 comma list (which stays a flat `Sequence`) and keeps `<mfenced>` distinct from
+  `<mtable>` → `Matrix` (a fenced list of tuples vs a true table).
+- Degenerate shapes are handled predictably: a **semicolon-only** fence `(a; b; c)` — a column
+  vector with no second column in any row — collapses to the same flat `Sequence([a, b, c])` as a
+  comma list, so there is no spurious one-element nesting; a **ragged** fence `(a; b, c)` is kept
+  faithfully as `Sequence([a, Sequence([b, c])])`. Each cell is still folded to one expression
+  (operator precedence, implicit multiplication), so `(x + 1, 2; y)` nests the folded `x+1`.
+- A leading/trailing/doubled `;` (or `,`) leaves an empty segment, which `fold_row` rejects as
+  "empty MathML group" — a malformed fence is a clean spanned error, **never a silently-dropped
+  row**. Only *literal* `<mo>,</mo>`/`<mo>;</mo>` children are separators; the `separators`
+  attribute (like all attributes) remains dropped, matching how the comma list already worked.
+- Implemented with a shared `split_fence_children` helper (one bounded pass, no recursion); no new
+  AST node, no shared-crate change (reuses the neutral `MathExpr::Sequence` from `math-frontend`
+  0.6.0), so no downstream ripple. 5 new tests (nested rows, semicolon-only flat, ragged, folded
+  cells, trailing-separator error). `mathml` 0.4.0 → 0.5.0.
+
 ## [0.4.0] — 2026-06-30
 
 ### Added — PR-4: comma-separated `<mfenced>` lists lower to `Sequence`

--- a/code/packages/rust/mathml/Cargo.toml
+++ b/code/packages/rust/mathml/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mathml"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "A Presentation-MathML reader that implements the math-frontend MathFrontend trait: turns <math>…</math> (mn/mi/mo/mrow/mfrac/msup/msub/msqrt/mroot/mtext/mtable/mover/munder/mfenced + named functions) into the neutral MathExpr AST. The fourth pluggable frontend after LaTeX and AsciiMath (see PFE01). Total, panic-free, spanned errors."
 license = "MIT"

--- a/code/packages/rust/mathml/src/lib.rs
+++ b/code/packages/rust/mathml/src/lib.rs
@@ -379,6 +379,69 @@ mod tests {
     }
 
     #[test]
+    fn mfenced_semicolon_rows_of_comma_columns_nest() {
+        // Semicolons are the ROW separator, commas the column separator — the fenced-matrix
+        // reading `(a, b; c, d)` → Sequence([Sequence([a, b]), Sequence([c, d])]).
+        let e = p(concat!(
+            "<mfenced>",
+            "<mi>a</mi><mo>,</mo><mi>b</mi><mo>;</mo><mi>c</mi><mo>,</mo><mi>d</mi>",
+            "</mfenced>"
+        ));
+        assert_eq!(
+            e,
+            MathExpr::Sequence(vec![
+                MathExpr::Sequence(vec![sym("a"), sym("b")]),
+                MathExpr::Sequence(vec![sym("c"), sym("d")]),
+            ])
+        );
+    }
+
+    #[test]
+    fn mfenced_semicolon_only_is_a_flat_sequence() {
+        // A column vector `(a; b; c)` has no second column in any row, so it collapses to the same
+        // flat Sequence([a, b, c]) as a comma list — no spurious one-element nesting.
+        let e = p("<mfenced><mi>a</mi><mo>;</mo><mi>b</mi><mo>;</mo><mi>c</mi></mfenced>");
+        assert_eq!(e, MathExpr::Sequence(vec![sym("a"), sym("b"), sym("c")]));
+    }
+
+    #[test]
+    fn mfenced_ragged_semicolon_rows_are_faithful() {
+        // A ragged fence `(a; b, c)` keeps its shape: row 1 is a single expr, row 2 is a pair.
+        let e = p("<mfenced><mi>a</mi><mo>;</mo><mi>b</mi><mo>,</mo><mi>c</mi></mfenced>");
+        assert_eq!(
+            e,
+            MathExpr::Sequence(vec![sym("a"), MathExpr::Sequence(vec![sym("b"), sym("c")])])
+        );
+    }
+
+    #[test]
+    fn mfenced_semicolon_rows_fold_each_cell() {
+        // Each cell is folded to one expression, not just a leaf: `(x + 1, 2; y)`.
+        let e = p(concat!(
+            "<mfenced>",
+            "<mrow><mi>x</mi><mo>+</mo><mn>1</mn></mrow><mo>,</mo><mn>2</mn>",
+            "<mo>;</mo><mi>y</mi>",
+            "</mfenced>"
+        ));
+        assert_eq!(
+            e,
+            MathExpr::Sequence(vec![
+                MathExpr::Sequence(vec![b(BinOp::Add, sym("x"), num(1)), num(2)]),
+                sym("y"),
+            ])
+        );
+    }
+
+    #[test]
+    fn mfenced_trailing_semicolon_is_an_error_not_a_dropped_row() {
+        // A trailing separator leaves an empty final row → "empty MathML group", never silently
+        // dropped (same guarantee as the comma list).
+        assert!(MathMl
+            .parse("<mfenced><mi>a</mi><mo>,</mo><mi>b</mi><mo>;</mo></mfenced>")
+            .is_err());
+    }
+
+    #[test]
     fn mtable_is_a_matrix_of_rows_and_cells() {
         // 2×2 table → Matrix([[1,2],[3,4]]).
         let e = p(concat!(

--- a/code/packages/rust/mathml/src/parser.rs
+++ b/code/packages/rust/mathml/src/parser.rs
@@ -462,35 +462,53 @@ impl Parser {
                 let overset = MathExpr::Overset { over: Box::new(over), base: Box::new(base) };
                 Ok(Child::Expr(MathExpr::Underset { under: Box::new(under), base: Box::new(overset) }))
             }
-            // `<mfenced>…</mfenced>` — a fence. With NO comma separators it is an ordinary
-            // parenthesised group (a sub-expression) and folds to a `Group`, as before. With one
-            // or more top-level `<mo>,</mo>` separators it is a LIST — `(a, b, c)` → `Sequence([a,
-            // b, c])` — so the commas are preserved as list structure rather than folded into the
-            // row (the previous PR-2 limit). Each segment between commas is itself folded to one
-            // expression. The fence's `open`/`close`/`separators` attributes are presentation,
-            // dropped like all attributes.
+            // `<mfenced>…</mfenced>` — a fence. Three shapes, decided by the top-level separators:
+            //
+            //   * NO separator            → an ordinary parenthesised group `(a b)` → `Group`.
+            //   * `<mo>,</mo>` only       → a flat LIST `(a, b, c)` → `Sequence([a, b, c])`.
+            //   * any `<mo>;</mo>`        → ROWS. Semicolons are the row separator and commas the
+            //                               within-row (column) separator — the classic fenced-matrix
+            //                               reading `(a, b; c, d)` → `Sequence([Sequence([a, b]),
+            //                               Sequence([c, d])])`. A row with no comma is a single
+            //                               expression, so a semicolon-only fence `(a; b; c)` — a
+            //                               column vector — collapses to the same flat
+            //                               `Sequence([a, b, c])` as a comma list (no row has a
+            //                               second column). A ragged fence `(a; b, c)` is faithful:
+            //                               `Sequence([a, Sequence([b, c])])`.
+            //
+            // The delimiters and the `open`/`close`/`separators` *attributes* are presentation and
+            // dropped like all attributes — only *literal* `<mo>,</mo>`/`<mo>;</mo>` children are
+            // read as separators, matching how the comma list already worked.
             "mfenced" => {
                 let kids = self.parse_row_children(name, depth)?;
                 let has_comma = kids.iter().any(|c| matches!(c, Child::Op(s) if s == ","));
-                if !has_comma {
+                let has_semicolon = kids.iter().any(|c| matches!(c, Child::Op(s) if s == ";"));
+                if !has_comma && !has_semicolon {
                     let inner = fold_row(kids, span, depth)?;
                     return Ok(Child::Expr(MathExpr::Group(Box::new(inner))));
                 }
-                let mut items: Vec<MathExpr> = Vec::new();
-                let mut current: Vec<Child> = Vec::new();
-                for child in kids {
-                    match child {
-                        Child::Op(ref s) if s == "," => {
-                            // End of one list item: fold the accumulated children. An empty
-                            // segment (a leading/trailing/doubled comma) is malformed — fold_row
-                            // reports "empty MathML group", so no item is silently dropped.
-                            items.push(fold_row(std::mem::take(&mut current), span, depth)?);
-                        }
-                        _ => current.push(child),
+                if !has_semicolon {
+                    // Comma-only: a flat list. Each comma-delimited segment folds to one expression.
+                    let items = split_fence_children(kids, ",")
+                        .into_iter()
+                        .map(|seg| fold_row(seg, span, depth))
+                        .collect::<Result<Vec<_>, _>>()?;
+                    return Ok(Child::Expr(MathExpr::Sequence(items)));
+                }
+                // Semicolon present: split into rows first, then columns within each row.
+                let mut rows: Vec<MathExpr> = Vec::new();
+                for row in split_fence_children(kids, ";") {
+                    if row.iter().any(|c| matches!(c, Child::Op(s) if s == ",")) {
+                        let cols = split_fence_children(row, ",")
+                            .into_iter()
+                            .map(|seg| fold_row(seg, span, depth))
+                            .collect::<Result<Vec<_>, _>>()?;
+                        rows.push(MathExpr::Sequence(cols));
+                    } else {
+                        rows.push(fold_row(row, span, depth)?);
                     }
                 }
-                items.push(fold_row(current, span, depth)?);
-                Ok(Child::Expr(MathExpr::Sequence(items)))
+                Ok(Child::Expr(MathExpr::Sequence(rows)))
             }
             // `<mtable>` of `<mtr>` rows of `<mtd>` cells → MathExpr::Matrix (delimiter style is
             // not part of MathML's mtable, so nothing to drop). Parsed structurally below.
@@ -681,6 +699,25 @@ enum RowTok {
     Operand(MathExpr),
     Bin(BinOp),
     Rel(RelOp),
+}
+
+/// Split a fence's children into the maximal segments separated by a top-level `sep` operator
+/// (e.g. `,` or `;`). A leading, trailing, or doubled separator yields an *empty* segment, which
+/// `fold_row` later rejects as "empty MathML group" — so a malformed list is a clean spanned error,
+/// never a silently-dropped item. Only *literal* `<mo>sep</mo>` children are separators; nested
+/// elements keep their own inner separators (this looks at the top level only). A single bounded
+/// pass over `children`, no recursion.
+fn split_fence_children(children: Vec<Child>, sep: &str) -> Vec<Vec<Child>> {
+    let mut segments: Vec<Vec<Child>> = Vec::new();
+    let mut current: Vec<Child> = Vec::new();
+    for child in children {
+        match &child {
+            Child::Op(s) if s == sep => segments.push(std::mem::take(&mut current)),
+            _ => current.push(child),
+        }
+    }
+    segments.push(current);
+    segments
 }
 
 /// Fold a row of `Child`s into one `MathExpr`, applying parenthesis fences, operator precedence

--- a/code/specs/PFE01-pluggable-parser-frontends.md
+++ b/code/specs/PFE01-pluggable-parser-frontends.md
@@ -170,7 +170,13 @@ frontend additionally ships notation-specific golden tests.
   function (sin/cos/ln/…) applied to an argument → `Call`, matching the other frontends' `Func` set.
   PR-4 adds `<mfenced>` separator modelling: a fence with comma separators (`(a, b, c)`) lowers to
   the new neutral `Sequence` list node (math-frontend 0.6.0), while a comma-free fence still lowers
-  to `Group`. Semicolon separators and surfacing the `open`/`close` delimiters as data are deferred.
+  to `Group`. PR-5 adds semicolon separators as **rows**: a `<mfenced>` containing a `<mo>;</mo>`
+  reads semicolons as the row separator and commas as the within-row column separator (the classic
+  fenced-matrix notation), so `(a, b; c, d)` → `Sequence([Sequence([a, b]), Sequence([c, d])])`. A
+  semicolon-only fence `(a; b; c)` collapses to the same flat `Sequence` as a comma list (no row has
+  a second column); a ragged fence `(a; b, c)` keeps its shape faithfully. Surfacing the
+  `open`/`close` delimiters as data remains deferred (they are presentation, dropped like all
+  attributes).
 - Future: MathJSON, content-MathML, spreadsheet formulae, … each a small crate implementing the
   trait. None require changes to consumers. **Four frontends now in (LaTeX, AsciiMath, Unicode,
   MathML), all feeding one neutral AST with zero consumer change** — the pluggability claim is


### PR DESCRIPTION
## What

Extends the `mathml` `<mfenced>` handler so a fence containing a `<mo>;</mo>` separator is read as **rows** — semicolons are the row separator and commas the within-row (column) separator, the classic fenced-matrix notation:

- `(a, b; c, d)` → `Sequence([Sequence([a, b]), Sequence([c, d])])` (rows of columns)
- comma-only `(a, b, c)` → flat `Sequence([a, b, c])` (unchanged, PR-4)
- no separator `(a b)` → `Group` (unchanged)

This is the natural next increment on the neutral `MathExpr::Sequence` node, and keeps `<mfenced>` distinct from `<mtable>` → `Matrix` (a fenced list of tuples vs a true table).

## How

A shared `split_fence_children(children, sep)` helper splits the fence's **top-level** children on a literal separator operator in one bounded pass (no recursion). The `<mfenced>` arm now decides on `has_comma`/`has_semicolon`:

- semicolon present → split into rows, then split each row on commas (a row with commas → inner `Sequence`; a row without → a single folded expression).

Degenerate shapes are predictable: a **semicolon-only** fence `(a; b; c)` collapses to the same flat `Sequence([a, b, c])` as a comma list (no row has a second column); a **ragged** fence `(a; b, c)` is kept faithfully as `Sequence([a, Sequence([b, c])])`. Each cell is still folded to one expression (precedence, implicit multiplication).

**No new AST node, no shared-crate change** — reuses `MathExpr::Sequence` from `math-frontend` 0.6.0, so no downstream ripple (`mathml` is a leaf frontend).

## Robustness

A leading/trailing/doubled `;` or `,` leaves an empty segment, which `fold_row` rejects as `"empty MathML group"` — a malformed fence is a clean spanned error, **never a silently-dropped row**. Only *literal* `<mo>,</mo>`/`<mo>;</mo>` children are separators; the `separators` attribute (like all attributes) remains dropped.

## Tests

5 new tests: nested rows-of-columns, semicolon-only flat, ragged, folded cells, trailing-separator error. **`cargo test -p mathml` = 49 passed**; `clippy -D warnings` clean. Spec `PFE01` updated (mathml PR-5). `mathml` **0.4.0 → 0.5.0**.

## Security

`/security-review` **passed** — parser stays total and panic-free: the split is O(n) non-recursive, `depth` is preserved and bounded by `MAX_DEPTH`, an empty segment is a clean error, and there is no `unwrap`/panic on the untrusted MathML input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)