### PR TITLE
fix(closure-emitter,constant-fold): deep operator chains no longer overflow the stack

### DIFF
--- a/code/packages/rust/closure-emitter/CHANGELOG.md
+++ b/code/packages/rust/closure-emitter/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to the `coding-adventures-closure-emitter` crate will be documented in this file.
 
+## [0.18.11] - 2026-06-30
+
+### Fixed — deep operator chains no longer overflow the native stack (DoS)
+
+`emit_binary`/`emit_logical` recurse on the left operand once per operator, so
+a deeply left-nested chain — the shape the bridge builds for flat source like
+`1+1+…+1` (tens of thousands of terms) — recursed once per operator and, past a
+few thousand levels, overflowed the caller's ordinary ~2 MiB stack. That is an
+*uncatchable* abort, and closurec feeds this emitter *untrusted* JS, so it must
+not be crashable by pathological input.
+
+`emit` now runs the recursive emission on a 64 MiB worker thread
+(`EMIT_STACK_SIZE`) via `std::thread::scope` (borrows the program without
+`'static`; the shallow source-map serialisation finishes on the caller thread).
+Emission is **byte-identical** to before — only the stack size differs — so
+every existing fixture is unchanged. Regression test builds a 20 000-deep `+`
+chain and asserts it emits `1+1+…+1;` without crashing.
+
+(Very deep ASTs can still stress *other* recursive stages — notably the AST's
+own recursive `Drop` — which closurec absorbs on its 8 MiB main thread for the
+inputs seen here; full pipeline-level hardening is tracked separately.)
+
 ## [0.18.10] - 2026-06-30
 
 ### Changed — drop needless parens around assignments in conditional branches

--- a/code/packages/rust/closure-emitter/Cargo.toml
+++ b/code/packages/rust/closure-emitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-emitter"
-version = "0.18.10"
+version = "0.18.11"
 edition = "2021"
 description = "JavaScript code emitter for the Closure Compiler clone. Per CLOC07's emit contract. Takes a finalized Program + sidecar and produces output JavaScript text + companion source map. Runs after every pass in the pipeline."
 

--- a/code/packages/rust/closure-emitter/src/lib.rs
+++ b/code/packages/rust/closure-emitter/src/lib.rs
@@ -138,26 +138,61 @@ impl std::error::Error for EmitError {}
 /// `_sidecar` and the typing on `cv` (mutable so the future
 /// source-map encoder can consult it) are kept in the signature
 /// for forward-compat with the source-map v2 work.
+/// Stack size for the emitter worker thread (see [`emit`]).
+///
+/// The emitter is a recursive-descent tree walk: `emit_expression_inner`
+/// → `emit_binary`/`emit_logical` → `emit_expression_inner` on the left
+/// operand, once per operator. A deeply left-nested operator chain — the
+/// shape the bridge builds for flat source like `1+1+…+1` (thousands of
+/// terms) — therefore recurses once per operator. Past a few thousand
+/// levels this overflows the caller's ordinary ~2 MiB stack, which is an
+/// **uncatchable** `SIGSEGV`/abort: it kills the whole process, so a
+/// `Result`-returning API cannot report it. closurec feeds *untrusted* JS
+/// here, so it must not be crashable by pathological input.
+///
+/// 64 MiB holds well over 100 000 levels of this light per-operator frame —
+/// far beyond any hand-written expression, and beyond the ~20 000-deep
+/// adversarial inputs that motivated this — while costing nothing for real
+/// code (the thread reserves address space lazily; only touched pages fault
+/// in). Emission is otherwise **byte-identical** to running on the caller's
+/// stack; only the stack size differs.
+const EMIT_STACK_SIZE: usize = 64 * 1024 * 1024;
+
 pub fn emit(
     program: &Program,
     _sidecar: &Sidecar,
     cv: &mut CVLog,
     opts: &EmitOptions,
 ) -> Result<EmitOutput, EmitError> {
-    let mut emitter = Emitter::new(opts);
-    emitter.emit_program(program);
+    // Run the recursive emission on a large-stack worker so deep (but valid)
+    // ASTs emit without overflowing the native stack. `std::thread::scope`
+    // lets the worker borrow `program`/`opts` without `'static`; we hand back
+    // the owned `out` string and source-map builder and finish the (shallow)
+    // source-map serialisation on the caller thread, where `cv` lives.
+    let (out, source_map_builder) = std::thread::scope(|scope| {
+        std::thread::Builder::new()
+            .stack_size(EMIT_STACK_SIZE)
+            .spawn_scoped(scope, || {
+                let mut emitter = Emitter::new(opts);
+                emitter.emit_program(program);
+                (emitter.out, emitter.source_map)
+            })
+            .expect("failed to spawn emitter worker thread")
+            .join()
+            .expect("emitter worker thread panicked")
+    });
 
     let source_map = if opts.source_map {
         // Build the source map. Even when no mappings were
         // accumulated (untraced input), this produces a valid
         // v3 blob with empty mappings.
-        Some(emitter.source_map.build(cv).to_json())
+        Some(source_map_builder.build(cv).to_json())
     } else {
         None
     };
 
     Ok(EmitOutput {
-        code: emitter.out,
+        code: out,
         source_map,
         contributions: Vec::new(),
     })
@@ -3133,6 +3168,47 @@ mod tests {
 
     fn emit_expr(e: Expression) -> String {
         emit_default(program().with_body(vec![stmt(e)])).code
+    }
+
+    /// A very deep left-nested operator chain — the shape the bridge builds for
+    /// flat source like `1+1+…+1` (tens of thousands of terms) — must emit
+    /// without overflowing the native stack. `emit_binary` recurses on `b.left`
+    /// once per operator; on the caller's ordinary ~2 MiB stack this used to
+    /// overflow (an uncatchable abort). Emission now runs on a large-stack
+    /// worker (`EMIT_STACK_SIZE`), so arbitrarily deep valid ASTs emit fine —
+    /// output is byte-identical to shallow emission, just with headroom.
+    #[test]
+    fn deeply_nested_binary_chain_emits_without_stack_overflow() {
+        const N: usize = 20_000;
+        let mut e = num(1.0);
+        for _ in 0..N {
+            e = Expression::BinaryExpression(BinaryExpression {
+                cv: None,
+                operator: BinaryOperator::Add,
+                left: Box::new(e),
+                right: Box::new(num(1.0)),
+            });
+        }
+        let prog = program().with_body(vec![stmt(e)]);
+        // `emit` runs its recursion on the 64 MiB `EMIT_STACK_SIZE` worker, so
+        // this depth emits fine even though the test itself runs on cargo's
+        // ~2 MiB thread. Two caveats make this a *precise* regression test:
+        //   • Without the worker, `emit_binary`'s per-operator recursion
+        //     overflows here — so a regression re-breaks this test.
+        //   • The 20 000-deep AST's own recursive `Drop` (walking the Box
+        //     spine) would ALSO overflow this small thread — an orthogonal
+        //     concern, out of scope here — so we `forget` it rather than let
+        //     Drop mask the emit result. The process exits right after.
+        let sidecar = Sidecar::new();
+        let mut cv = CVLog::new(true);
+        let out = emit(&prog, &sidecar, &mut cv, &EmitOptions::default())
+            .expect("emit should succeed")
+            .code;
+        // `1+1+…+1;` — N `+` operators joining N+1 ones, terminated by `;`.
+        assert_eq!(out.matches('+').count(), N, "one `+` per operator");
+        assert!(out.starts_with("1+1+1"), "left-to-right compact emit");
+        assert!(out.ends_with(';'));
+        std::mem::forget(prog);
     }
 
     #[test]

--- a/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to the `coding-adventures-closure-pass-constant-fold` crate will be documented in this file.
 
+## [0.77.0] - 2026-06-30
+
+### Fixed — deep operator chains no longer overflow the native stack (DoS)
+
+`fold_binary` folds `b.left`/`b.right` bottom-up, recursing once per operator.
+A deeply left-nested chain — the shape the bridge builds for flat source like
+`1+1+…+1` (tens of thousands of terms) — recursed once per operator and, past a
+few thousand levels, overflowed the caller's ordinary ~2 MiB stack: an
+*uncatchable* abort on *untrusted* input. This is the stage that overflowed
+*first* on the SIMPLE pipeline (before the emitter).
+
+`ConstantFoldPass::run` now runs `fold_program` on a 64 MiB worker thread
+(`FOLD_STACK_SIZE`) via `std::thread::scope` (borrows the program without
+`'static`). Output is **identical** to before — deep chains still collapse
+fully (`1+1+…+1` → a single number); only the stack size differs — so every
+existing fold is unchanged. Regression test folds a 20 000-deep `+` chain to a
+single `NumericLiteral` without crashing. Mirrors the emitter's
+`EMIT_STACK_SIZE` hardening (`coding-adventures-closure-emitter` 0.18.11).
+
 ## [0.76.0] - 2026-06-29
 
 ### Changed — `Object.keys` now folds escaped string keys (bridge decode)

--- a/code/packages/rust/closure-pass-constant-fold/Cargo.toml
+++ b/code/packages/rust/closure-pass-constant-fold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-constant-fold"
-version = "0.76.0"
+version = "0.77.0"
 edition = "2021"
 description = "Constant-folding optimization pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Folds compile-time-evaluable expressions like `2 + 3 → 5`."
 

--- a/code/packages/rust/closure-pass-constant-fold/src/lib.rs
+++ b/code/packages/rust/closure-pass-constant-fold/src/lib.rs
@@ -134,26 +134,62 @@ impl Pass for ConstantFoldPass {
     }
 
     fn run(&self, ctx: PassContext<'_>) -> Result<PassOutput, PassError> {
-        let mut state = FoldState {
-            cv: ctx.cv,
-            contributions: Vec::new(),
-            changed: false,
-            nodes_touched: 0,
-        };
-
-        let new_program = fold_program(ctx.program, &mut state);
+        // `fold_program` is a recursive bottom-up tree walk: `fold_binary`
+        // folds `b.left`/`b.right`, each of which may be another binary node,
+        // once per operator. A deeply left-nested operator chain — the shape
+        // the bridge builds for flat source like `1+1+…+1` (thousands of
+        // terms) — therefore recurses once per operator and, past a few
+        // thousand levels, overflows the caller's ordinary ~2 MiB stack. That
+        // is an *uncatchable* abort, and closurec runs this pass over
+        // *untrusted* JS, so it must not be crashable by pathological input.
+        //
+        // Run the recursive fold on a large-stack worker (mirrors the emitter,
+        // `coding-adventures-closure-emitter`). Output is *identical* to the
+        // caller-thread fold — deep chains still collapse fully (`1+1+…` → one
+        // number); only the stack size differs. `std::thread::scope` lets the
+        // worker borrow `ctx.program`/`ctx.cv` without `'static`.
+        let program = ctx.program;
+        let cv = ctx.cv;
+        let (new_program, contributions, changed, nodes_touched) = std::thread::scope(|scope| {
+            std::thread::Builder::new()
+                .stack_size(FOLD_STACK_SIZE)
+                .spawn_scoped(scope, move || {
+                    let mut state = FoldState {
+                        cv,
+                        contributions: Vec::new(),
+                        changed: false,
+                        nodes_touched: 0,
+                    };
+                    let new_program = fold_program(program, &mut state);
+                    (
+                        new_program,
+                        state.contributions,
+                        state.changed,
+                        state.nodes_touched,
+                    )
+                })
+                .expect("failed to spawn constant-fold worker thread")
+                .join()
+                .expect("constant-fold worker thread panicked")
+        });
 
         Ok(PassOutput {
             program: new_program,
-            contributions: state.contributions,
-            changed: state.changed,
+            contributions,
+            changed,
             diagnostics: Vec::new(),
-            stats: PassStats {
-                nodes_touched: state.nodes_touched,
-            },
+            stats: PassStats { nodes_touched },
         })
     }
 }
+
+/// Stack size for the constant-fold worker thread (see [`ConstantFoldPass::run`]).
+///
+/// 64 MiB holds well over 100 000 levels of the light per-operator fold frame —
+/// far beyond any real expression, and beyond the ~20 000-deep adversarial
+/// inputs that motivated this — while costing nothing for real code (pages
+/// fault in lazily). Matches the emitter's `EMIT_STACK_SIZE`.
+const FOLD_STACK_SIZE: usize = 64 * 1024 * 1024;
 
 // =====================================================================
 // FoldState — mutable bookkeeping threaded through the recursive walk
@@ -5026,6 +5062,53 @@ mod tests {
             panic!("expected a single expression statement, got {:?}", item);
         };
         &es.expression
+    }
+
+    // ------------------- deep-chain DoS regression -------------------
+
+    /// A very deep left-nested operator chain — the shape the bridge builds
+    /// for flat source like `1+1+…+1` (tens of thousands of terms) — must fold
+    /// without overflowing the native stack. The bottom-up `fold_binary` walk
+    /// recurses once per operator; on the caller's ordinary ~2 MiB stack this
+    /// used to overflow (an uncatchable abort). The large-stack worker
+    /// (`FOLD_STACK_SIZE`) absorbs the recursion and still folds the whole
+    /// chain to a single number.
+    #[test]
+    fn deeply_nested_binary_chain_folds_without_stack_overflow() {
+        const N: usize = 20_000;
+        let mut expr = num(1.0, None);
+        for _ in 0..N {
+            expr = Expression::BinaryExpression(BinaryExpression {
+                cv: None,
+                operator: BinaryOperator::Add,
+                left: Box::new(expr),
+                right: Box::new(num(1.0, None)),
+            });
+        }
+        let prog = program_with_expr(expr, false);
+        // `fold_program` runs its recursion on the 64 MiB `FOLD_STACK_SIZE`
+        // worker, so this depth folds fine even though the test runs on cargo's
+        // ~2 MiB thread. Without the worker, `fold_binary`'s per-operator
+        // recursion overflows here — so a regression re-breaks this test. The
+        // 20 000-deep *input* AST's own recursive `Drop` would ALSO overflow
+        // this small thread (orthogonal), so we run the pass by reference and
+        // `forget` the input; the shallow folded output drops fine.
+        let pass = ConstantFoldPass::new();
+        let sidecar = Sidecar::new();
+        let mut cv = CVLog::new(true);
+        let out = pass
+            .run(PassContext {
+                program: &prog,
+                sidecar: &sidecar,
+                cv: &mut cv,
+            })
+            .expect("pass should succeed");
+        assert!(out.changed, "the deep chain must fold");
+        match extract_expr(&out.program) {
+            Expression::NumericLiteral(n) => assert_eq!(n.value, (N + 1) as f64),
+            other => panic!("expected a single folded number, got {other:?}"),
+        }
+        std::mem::forget(prog);
     }
 
     // ------------------- metadata + identity tests -------------------


### PR DESCRIPTION
## Problem
closurec aborts (uncatchable stack overflow, exit 134) at `--compilation_level SIMPLE`/`ADVANCED` on a very deep **flat** expression like `x=1+1+…+1;` (~20 000 terms).

This is **distinct** from the parser recursive-descent DoS (`feat/parser-depth-guard`, #7105): the parser *survives* this input (`--print_tree` prints the tree). The bridge builds it iteratively into a ~20 000-deep **left-nested** `BinaryExpression`, which the constant-fold pass (`fold_binary`) and the emitter (`emit_binary`) then walk **recursively**, once per operator — overflowing the caller's ~2 MiB stack.

## Fix
Run each recursive pass on a 64 MiB worker thread via `std::thread::scope` + `spawn_scoped` (borrows the program without `'static`):
- `closure-pass-constant-fold` 0.76.0 → 0.77.0: `ConstantFoldPass::run` runs `fold_program` on a `FOLD_STACK_SIZE` worker (this stage overflows *first* on SIMPLE).
- `closure-emitter` 0.18.10 → 0.18.11: `emit` runs `emit_program` on an `EMIT_STACK_SIZE` worker; shallow source-map serialisation stays on the caller thread.

Output is **byte/value-identical** to before — deep chains still fold to one number and emit as `1+1+…+1`; only the stack size differs — so every existing fixture and fold is unchanged.

## Verification
- closurec SIMPLE on the 20 000-deep `1+1+…+1`: now exits **0** with `x=20001;` (was 134).
- `1+2*3` → 7, `5&3` → 1 — unchanged.
- Regression tests in both crates build a 20 000-deep chain and assert it folds/emits without crashing (deep input leaked via `mem::forget` so its orthogonal recursive `Drop` doesn't overflow cargo's 2 MiB test thread). All existing tests green (fold 326, emitter unchanged).
- Inline security review: PASSED (correct scoped-borrow lifetimes, no data race, no unsafe, preserved failure semantics).

## Scope / follow-up
Neither crate is touched by #7105, so this lands independently. Very deep ASTs can still stress *other* recursive stages (notably the AST's own recursive `Drop`, which closurec absorbs on its 8 MiB main thread for the inputs seen here); full pipeline-level hardening is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)