### PR TITLE
feat(latex): semicolon-separated fences lower to rows (matches MathML PR-5)

### DIFF
--- a/code/packages/rust/latex/CHANGELOG.md
+++ b/code/packages/rust/latex/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to the full-fidelity LaTeX parser crate.
 
+## [0.20.0] — 2026-06-30
+
+### Added — semicolon-separated fences lower to rows (matches MathML `<mfenced>` PR-5)
+
+- A fence whose body contains a top-level semicolon — `(a, b; c, d)`, `\left(a, b; c, d\right)` — is
+  now read as **rows**: semicolons are the row separator and commas the within-row (column)
+  separator, the classic fenced-matrix notation. `(a, b; c, d)` parses to
+  `Sequence([Sequence([a, b]), Sequence([c, d])])` and lowers to the same nested
+  `MathExpr::Sequence`. This mirrors the `mathml` crate's PR-5 exactly, extending the write-once
+  Sequence node to a second structural frontend's row shape.
+- Degenerate shapes are predictable, identical to MathML: a **semicolon-only** fence `(a; b; c)` — a
+  column vector with no second column in any row — collapses to the same flat `Sequence([a, b, c])`
+  as a comma list; a **ragged** fence `(a; b, c)` stays faithful as
+  `Sequence([a, Sequence([b, c])])`. Each cell is still folded to a full relation, so `(x + 1, 2; y)`
+  nests the folded `x + 1`. A comma-only fence is unchanged (flat `Sequence`), and a comma/semicolon-
+  free fence is still a plain grouped expression.
+- **Round-trips** through `to_latex`: a rows `Sequence` (detectable because a comma-list item is
+  always a relation, never a *bare* `Sequence`, so a bare-`Sequence` child can only be a row)
+  semicolon-joins its rows and comma-joins each row's columns, so `parse_math(n.to_latex()) == n`
+  holds for `(a, b; c, d)` and friends. `read_fence_body` records the separator after each relation
+  in a bounded loop (never recursion), so a wide grid cannot overflow the stack; a
+  leading/trailing/doubled `;` or `,` is a clean spanned error, never a dropped row.
+- No new AST node, no shared-crate change (reuses `MathExpr::Sequence`; the neutral node already
+  nests, and the frontend lowering already recurses). 10 new tests (rows, semicolon-only flat,
+  ragged, folded cells, trailing-`;` error, 4 round-trip corpus entries, frontend nested-lowering).
+  `latex` 0.19.0 → 0.20.0.
+
 ## [0.19.0] — 2026-06-30
 
 ### Added — comma-separated fences lower to the neutral `Sequence` node (third frontend)

--- a/code/packages/rust/latex/Cargo.toml
+++ b/code/packages/rust/latex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latex"
-version = "0.19.0"
+version = "0.20.0"
 edition = "2021"
 description = "A full-fidelity LaTeX parser (documents and math): a catcode-driven, text-mode-primary tokenizer and (in later layers) a structural + math parser producing a faithful AST. Standalone and reusable; will also implement the math-frontend MathFrontend trait."
 license = "MIT"

--- a/code/packages/rust/latex/src/frontend.rs
+++ b/code/packages/rust/latex/src/frontend.rs
@@ -624,6 +624,35 @@ mod tests {
     }
 
     #[test]
+    fn semicolon_fence_lowers_to_nested_sequence() {
+        // A semicolon fence is ROWS of columns → a nested MathExpr::Sequence (matching MathML
+        // `<mfenced>` semicolon rows). `(a, b; c, d)` → Sequence([Sequence([a,b]), Sequence([c,d])]).
+        let sym = |s: &str| MathExpr::Symbol(s.into());
+        assert_eq!(
+            m("(a, b; c, d)"),
+            MathExpr::Sequence(vec![
+                MathExpr::Sequence(vec![sym("a"), sym("b")]),
+                MathExpr::Sequence(vec![sym("c"), sym("d")]),
+            ])
+        );
+        // `\left(…;…\right)` lowers the same way.
+        assert_eq!(
+            m(r"\left(a, b; c, d\right)"),
+            MathExpr::Sequence(vec![
+                MathExpr::Sequence(vec![sym("a"), sym("b")]),
+                MathExpr::Sequence(vec![sym("c"), sym("d")]),
+            ])
+        );
+        // A semicolon-only fence collapses to a flat Sequence (no row has a second column).
+        assert_eq!(m("(a; b; c)"), MathExpr::Sequence(vec![sym("a"), sym("b"), sym("c")]));
+        // A ragged fence keeps its shape.
+        assert_eq!(
+            m("(a; b, c)"),
+            MathExpr::Sequence(vec![sym("a"), MathExpr::Sequence(vec![sym("b"), sym("c")])])
+        );
+    }
+
+    #[test]
     fn accent_lowers_to_neutral_accent_node() {
         // `\hat{x}` is a diacritic OVER x — the neutral `MathExpr::Accent`, distinct from the
         // named function `hat(x)` (which would be `\hat(x)` text / `\operatorname`).

--- a/code/packages/rust/latex/src/math.rs
+++ b/code/packages/rust/latex/src/math.rs
@@ -645,22 +645,55 @@ impl<'a> MathParser<'a> {
         MathNode::Num(s)
     }
 
-    /// Read a fenced body: one relation, or — when a top-level comma follows — a comma-separated
-    /// [`MathNode::Sequence`] of relations (`a, b, c`). The caller consumes the delimiters. A
-    /// bounded loop over `parse_relation` (never recursion), so a wide list cannot overflow the
-    /// stack; a trailing/leading/doubled comma leaves a non-atom before the next `parse_relation`,
-    /// which returns a clean spanned error.
+    /// Read a fenced body. Three shapes, decided by the top-level separators:
+    ///
+    ///   * no separator      → one relation, returned as-is (`a + b`).
+    ///   * `,` only          → a flat [`MathNode::Sequence`] list (`a, b, c`).
+    ///   * any `;`           → ROWS. Semicolons are the row separator and commas the within-row
+    ///     (column) separator — the classic fenced-matrix reading `(a, b; c, d)` →
+    ///     `Sequence([Sequence([a, b]), Sequence([c, d])])`. A row with no comma is a single
+    ///     relation, so a semicolon-only fence `(a; b; c)` — a column vector — collapses to the same
+    ///     flat `Sequence([a, b, c])` as a comma list (no row has a second column); a ragged fence
+    ///     `(a; b, c)` stays faithful as `Sequence([a, Sequence([b, c])])`. Mirrors the MathML
+    ///     `<mfenced>` reading exactly.
+    ///
+    /// The caller consumes the delimiters. A bounded loop over `parse_relation` (never recursion),
+    /// so a wide list cannot overflow the stack; a trailing/leading/doubled separator leaves a
+    /// non-atom before the next `parse_relation`, which returns a clean spanned error.
     fn read_fence_body(&mut self) -> Result<MathNode, ParseError> {
-        let first = self.parse_relation()?;
-        if !matches!(self.peek().kind, TokenKind::Char(',')) {
-            return Ok(first);
-        }
-        let mut items = vec![first];
-        while matches!(self.peek().kind, TokenKind::Char(',')) {
-            self.bump(); // consume the comma
+        let mut items = vec![self.parse_relation()?];
+        // `seps[i]` is the separator that follows `items[i]` (so `seps.len() == items.len() - 1`).
+        let mut seps: Vec<char> = Vec::new();
+        while let TokenKind::Char(sep @ (',' | ';')) = self.peek().kind {
+            self.bump(); // consume the separator
+            seps.push(sep);
             items.push(self.parse_relation()?);
         }
-        Ok(MathNode::Sequence(items))
+        if seps.is_empty() {
+            // Exactly one relation, no separator.
+            return Ok(items.pop().expect("one item"));
+        }
+        if !seps.contains(&';') {
+            // Comma-only: a flat list.
+            return Ok(MathNode::Sequence(items));
+        }
+        // Semicolons present: split into rows at each `;`, and fold each row's comma-separated
+        // columns into an inner Sequence (a single-column row folds to that one relation).
+        let mut rows: Vec<MathNode> = Vec::new();
+        let mut current: Vec<MathNode> = Vec::new();
+        for (i, item) in items.into_iter().enumerate() {
+            current.push(item);
+            let ends_row = i >= seps.len() || seps[i] == ';';
+            if ends_row {
+                if current.len() == 1 {
+                    rows.push(current.pop().expect("one column"));
+                } else {
+                    rows.push(MathNode::Sequence(std::mem::take(&mut current)));
+                }
+                current.clear();
+            }
+        }
+        Ok(MathNode::Sequence(rows))
     }
 
     /// Read `( … )` / `[ … ]` up to the matching `close` char.
@@ -1265,13 +1298,29 @@ impl MathNode {
                 }
             }
             MathNode::Sequence(items) => {
-                // Comma-join the items; the enclosing Fenced supplies the delimiters, so
-                // `Fenced { body: Sequence([a, b, c]) }` round-trips to `(a, b, c)`.
+                // The enclosing Fenced supplies the delimiters. A flat list comma-joins its items;
+                // a ROWS sequence (one built from `;` — detectable because a comma-list item is
+                // always a relation, never a bare `Sequence`, so a bare `Sequence` child can only be
+                // a row) semicolon-joins its rows, each row comma-joining its own columns. Thus
+                // `Fenced { body: Sequence([a, b, c]) }` → `(a, b, c)` and
+                // `Fenced { body: Sequence([Sequence([a, b]), Sequence([c, d])]) }` → `(a, b; c, d)`.
+                let is_rows = items.iter().any(|it| matches!(it, MathNode::Sequence(_)));
+                let sep = if is_rows { "; " } else { ", " };
                 for (i, item) in items.iter().enumerate() {
                     if i > 0 {
-                        out.push_str(", ");
+                        out.push_str(sep);
                     }
-                    item.write(out, 0);
+                    match item {
+                        MathNode::Sequence(cols) => {
+                            for (j, col) in cols.iter().enumerate() {
+                                if j > 0 {
+                                    out.push_str(", ");
+                                }
+                                col.write(out, 0);
+                            }
+                        }
+                        other => other.write(out, 0),
+                    }
                 }
             }
             MathNode::Text(t) => {
@@ -1532,9 +1581,63 @@ mod tests {
             "[x, y, z]",
             "\\left(p, q\\right)",
             "(x + 1, 2)",
+            "(a, b; c, d)",
+            "\\left(a, b; c, d\\right)",
+            "(a; b, c)",
+            "(x + 1, 2; y, z)",
         ] {
             round_trips(s);
         }
+    }
+
+    #[test]
+    fn semicolon_fence_is_rows_of_columns() {
+        // (a, b; c, d) → Fenced { body: Sequence([Sequence([a, b]), Sequence([c, d])]) }.
+        let n = parse_math("(a, b; c, d)").expect("parse");
+        let MathNode::Fenced { body, .. } = &n else { panic!("expected Fenced, got {n:?}") };
+        let MathNode::Sequence(rows) = &**body else { panic!("expected Sequence, got {body:?}") };
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0], MathNode::Sequence(vec![sym("a"), sym("b")]));
+        assert_eq!(rows[1], MathNode::Sequence(vec![sym("c"), sym("d")]));
+    }
+
+    #[test]
+    fn semicolon_only_fence_is_a_flat_sequence() {
+        // A column vector (a; b; c) has no second column in any row, so it collapses to the same
+        // flat Sequence([a, b, c]) as a comma list — no spurious one-element nesting.
+        let n = parse_math("(a; b; c)").expect("parse");
+        let MathNode::Fenced { body, .. } = &n else { panic!("expected Fenced, got {n:?}") };
+        assert_eq!(**body, MathNode::Sequence(vec![sym("a"), sym("b"), sym("c")]));
+    }
+
+    #[test]
+    fn ragged_semicolon_fence_is_faithful() {
+        // (a; b, c) keeps its shape: row 1 is a single relation, row 2 is a pair.
+        let n = parse_math("(a; b, c)").expect("parse");
+        let MathNode::Fenced { body, .. } = &n else { panic!("expected Fenced, got {n:?}") };
+        assert_eq!(
+            **body,
+            MathNode::Sequence(vec![sym("a"), MathNode::Sequence(vec![sym("b"), sym("c")])])
+        );
+    }
+
+    #[test]
+    fn semicolon_rows_fold_each_cell() {
+        // Each cell is a full relation, not just a leaf: (x + 1, 2; y).
+        let n = parse_math("(x + 1, 2; y)").expect("parse");
+        let MathNode::Fenced { body, .. } = &n else { panic!("expected Fenced, got {n:?}") };
+        let MathNode::Sequence(rows) = &**body else { panic!("expected Sequence, got {body:?}") };
+        assert_eq!(rows.len(), 2);
+        let MathNode::Sequence(cols) = &rows[0] else { panic!("expected row Sequence, got {:?}", rows[0]) };
+        assert!(matches!(cols[0], MathNode::Bin(MBinOp::Add, ..)));
+        assert_eq!(cols[1], num("2"));
+        assert_eq!(rows[1], sym("y")); // single-column row folds to the bare relation
+    }
+
+    #[test]
+    fn trailing_semicolon_is_an_error_not_a_dropped_row() {
+        // A trailing separator leaves a non-atom before the next parse_relation → clean error.
+        assert!(parse_math("(a, b;)").is_err());
     }
 
     #[test]

--- a/code/specs/LTX01-full-latex-parser.md
+++ b/code/specs/LTX01-full-latex-parser.md
@@ -81,7 +81,7 @@ pub enum MathNode {
     Accent { kind: String, body: Box<MathNode> },   // \hat \bar \vec …
     Fenced { left: Delim, body: Box<MathNode>, right: Delim },   // \left( … \right)
     Group(Box<MathNode>), Text(String),
-    Sequence(Vec<MathNode>),                        // (a, b, c): comma-separated fence → ordered list
+    Sequence(Vec<MathNode>),                        // (a, b, c) list; (a, b; c, d) → rows of columns (nested)
     Rel(RelOp, Box<MathNode>, Box<MathNode>),
     Matrix { env: String, col_spec: Option<String>, rows: Vec<Vec<MathNode>> },
 }

--- a/code/specs/PFE01-pluggable-parser-frontends.md
+++ b/code/specs/PFE01-pluggable-parser-frontends.md
@@ -150,6 +150,11 @@ frontend additionally ships notation-specific golden tests.
   `[x, y, z]`, `\left(p, q\right)` — parses to a `Sequence` in its own document AST (round-tripping
   through `to_latex`) and lowers to `MathExpr::Sequence` (delimiters dropped), exactly matching
   MathML `<mfenced>` comma rows and AsciiMath `(a,b,c)`. A comma-free fence still lowers to `Group`.
+  Since 0.20.0 it also mirrors MathML's **semicolon rows**: a fence with a top-level `;` —
+  `(a, b; c, d)` — reads semicolons as the row separator and commas as the column separator →
+  `Sequence([Sequence([a, b]), Sequence([c, d])])`, with the same degenerate handling (semicolon-only
+  collapses to a flat `Sequence`, ragged stays faithful). Both structural frontends (LaTeX, MathML)
+  now agree on the neutral rows shape.
 - `asciimath` — the second frontend (terse ASCII math; see [ASM01](ASM01-asciimath-frontend.md)).
 - `unicode-math` — the **third** frontend: Unicode plain math as people and models type it
   (`x² + y² = r²`, `√x`, `½`, `π·α`, `a ≤ b`). A small crate implementing the trait; its Greek /


### PR DESCRIPTION
## What

Extends the **`latex`** crate so a fence with a top-level semicolon — `(a, b; c, d)`, `\left(a, b; c, d\right)` — is read as **rows**: semicolons are the row separator and commas the within-row (column) separator, the classic fenced-matrix notation.

- `(a, b; c, d)` → `Sequence([Sequence([a, b]), Sequence([c, d])])` (rows of columns)
- comma-only `(a, b, c)` → flat `Sequence` (unchanged)
- separator-free `(a b)` → plain grouped expression (unchanged)

This mirrors the **`mathml`** crate's PR-5 exactly, so both structural frontends (LaTeX + MathML) now agree on the neutral rows shape — extending write-once-use-many on `MathExpr::Sequence` to a second frontend's row form.

## How

`read_fence_body` now records the separator after each parsed relation in a bounded `while let` loop (no recursion), then groups items into rows at each `;`. Degenerate shapes match MathML: a **semicolon-only** fence `(a; b; c)` collapses to the same flat `Sequence([a, b, c])` (no row has a second column); a **ragged** fence `(a; b, c)` stays faithful as `Sequence([a, Sequence([b, c])])`. Each cell folds to a full relation.

The `to_latex` writer is made row-aware — a bare `Sequence` child can only be a row (comma-list items are always relations, never a bare `Sequence`), so `(a, b; c, d)` round-trips (`parse_math(n.to_latex()) == n`).

**No new AST node, no shared-crate change** — reuses `MathExpr::Sequence` (the neutral node already nests and the frontend lowering already recurses), so no downstream ripple; `adj-lang` (the only consumer) builds.

## Robustness

A leading/trailing/doubled `;` or `,` leaves a non-atom before the next `parse_relation` → a clean spanned error, never a dropped row or panic. The loop is flat; nesting depth stays bounded by the existing `MAX_DEPTH`.

## Tests

10 new tests: rows-of-columns, semicolon-only flat, ragged, folded cells, trailing-`;` error, 4 round-trip corpus entries, and a `frontend.rs` nested-lowering test asserting `(a, b; c, d)` → nested `MathExpr::Sequence`. **`cargo test -p latex` = 181 passed**; `clippy -D warnings` clean. Specs `LTX01` + `PFE01` updated. `latex` **0.19.0 → 0.20.0**.

## Security

`/security-review` **passed** — the new loop is bounded and non-recursive, the `expect()`s hold structurally and are unreachable from untrusted input, a malformed separator errors cleanly, and `to_latex` recursion stays within `MAX_DEPTH`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)