### PR TITLE
feat(kotlin-sql-vm): Kotlin stack-machine bytecode VM (Level 1 prerequisite)

### DIFF
--- a/code/packages/kotlin/sql-backend/src/main/kotlin/com/codingadventures/sqlbackend/SqlBackend.kt
+++ b/code/packages/kotlin/sql-backend/src/main/kotlin/com/codingadventures/sqlbackend/SqlBackend.kt
@@ -233,6 +233,37 @@ fun backendAsSchemaProvider(backend: Backend): SchemaProvider =
         override fun listIndexes(table: String): List<IndexDef> = backend.listIndexes(table)
     }
 
+// ── CursorBackend ─────────────────────────────────────────────────────────────
+//
+// Optional mixin interface for [Backend] implementations that support positioned
+// cursors — i.e., a cursor that can also UPDATE or DELETE the row at its current
+// position.
+//
+// Declaring the interface here (in sql-backend, alongside [Backend] and [Cursor])
+// keeps it in the same package so [InMemoryBackend] can implement it without any
+// circular dependency.  Consumers (e.g. sql-vm) check `backend is CursorBackend`
+// rather than using reflection to find an `openCursor` method by name, which
+// eliminates a ReDoS-class risk and survives obfuscation.
+
+/**
+ * Mixin interface for [Backend] implementations that expose positioned cursors.
+ *
+ * Implement this interface alongside [Backend] when your backend supports
+ * row-level UPDATE / DELETE via a [Cursor].  Consumers use a Kotlin `is`-check
+ * (`if (backend is CursorBackend) backend.openCursor(table)`) instead of
+ * reflection to discover this capability.
+ */
+interface CursorBackend {
+    /**
+     * Open a [Cursor] over [table] that supports positioned UPDATE / DELETE.
+     *
+     * The returned [Cursor] must implement [RowIterator] so callers can iterate
+     * over rows with [RowIterator.next] while optionally mutating the current
+     * row via the [Backend.update] / [Backend.delete] API.
+     */
+    fun openCursor(table: String): Cursor
+}
+
 private data class StoredRow(val rowid: Int, var row: Row)
 private data class TableState(
     val name: String,
@@ -261,7 +292,7 @@ private data class Snapshot(
 private data class Savepoint(val name: String, val snapshot: Snapshot)
 private data class KeyedRow(val key: List<Any?>, val rowid: Int)
 
-class InMemoryBackend : Backend() {
+class InMemoryBackend : Backend(), CursorBackend {
     private val tablesByKey = linkedMapOf<String, TableState>()
     private val indexesByKey = linkedMapOf<String, IndexDef>()
     private val triggersByKey = linkedMapOf<String, TriggerDef>()
@@ -282,7 +313,7 @@ class InMemoryBackend : Backend() {
     override fun scan(table: String): RowIterator =
         ListRowIterator(tableState(table).rows.map { it.row })
 
-    fun openCursor(table: String): Cursor {
+    override fun openCursor(table: String): Cursor {
         val key = normalizeName(table)
         return TableCursor(key, tableState(table))
     }

--- a/code/packages/kotlin/sql-vm/BUILD
+++ b/code/packages/kotlin/sql-vm/BUILD
@@ -1,0 +1,5 @@
+(cd ../sql-backend && gradle jar --quiet) || true
+(cd ../sql-planner && gradle jar --quiet)
+(cd ../sql-optimizer && gradle jar --quiet)
+(cd ../sql-codegen && gradle jar --quiet)
+gradle test jacocoTestReport jacocoTestCoverageVerification

--- a/code/packages/kotlin/sql-vm/BUILD_windows
+++ b/code/packages/kotlin/sql-vm/BUILD_windows
@@ -1,0 +1,5 @@
+(cd ../sql-backend && gradle jar --quiet) || true
+(cd ../sql-planner && gradle jar --quiet)
+(cd ../sql-optimizer && gradle jar --quiet)
+(cd ../sql-codegen && gradle jar --quiet)
+gradle test jacocoTestReport jacocoTestCoverageVerification

--- a/code/packages/kotlin/sql-vm/CHANGELOG.md
+++ b/code/packages/kotlin/sql-vm/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog — sql-vm (Kotlin)
+
+All notable changes to this package are documented here.
+
+## [0.1.0] — 2026-06-30
+
+### Added
+
+- Initial implementation of `SqlVm.execute(program, backend)` — the dispatch-loop
+  stack-machine VM for the mini-sqlite Level 1 pipeline.
+- `QueryResult` data class with `columns`, `rows`, and `rowsAffected` fields.
+- Complete `Instruction` dispatch covering:
+  - Stack ops: `LoadConst`, `LoadColumn`, `LoadParam`, `LoadGroupKey`, `Pop`
+  - Arithmetic binary ops: `ADD`, `SUB`, `MUL`, `DIV`, `MOD`, `CONCAT`
+  - Comparison binary ops: `EQ`, `NEQ`, `LT`, `LTE`, `GT`, `GTE`
+  - Logic binary ops: `AND`, `OR` (three-valued / SQL semantics)
+  - Unary ops: `NEG`, `NOT`
+  - Predicate tests: `IsNull`, `IsNotNull`, `Between`, `Like`, `InList`
+  - Scan lifecycle: `OpenScan`, `AdvanceCursor`, `JumpIfExhausted`, `CloseScan`
+  - Row emission: `BeginRow`, `EmitColumn`, `EmitRow`
+  - Aggregation: `InitAgg`, `UpdateAgg`, `FinalizeAgg`, `SaveGroupKey`,
+    `LoadGroupKey`, `AdvanceGroup`
+  - Control flow: `Label` (no-op), `Jump`, `JumpIfTrue`, `JumpIfFalse`, `Halt`
+  - DDL: `CreateTableInstr`, `DropTableInstr`
+  - DML: `InsertRow`, `UpdateRows`, `DeleteRows`
+  - Transactions: `BeginTransaction`, `CommitTransaction`, `RollbackTransaction`
+  - Post-processing: `SortResult`, `DistinctResult`, `LimitResult`
+- SQL three-valued logic (NULL propagation) for all binary and unary operators.
+- SQL LIKE matching via regex conversion (`%` → `.*`, `_` → `.`), case-insensitive.
+- GROUP BY aggregation with per-group accumulator tables.
+- Stable sort for `ORDER BY` (preserves insertion order for equal keys).
+- NULLS FIRST / NULLS LAST placement in `SortResult`.
+- 45+ JUnit 5 tests covering all instruction variants, NULL semantics, aggregates,
+  ORDER BY, DISTINCT, LIMIT/OFFSET, DML, DDL, and transaction behaviour.
+- JaCoCo coverage configured at ≥80% line coverage.
+- Knuth-style literate comments throughout `SqlVm.kt`.
+- `BUILD` / `BUILD_windows` scripts that pre-build all four sibling JARs in
+  leaf-to-root order before running tests.
+- `required_capabilities.json` documenting the package's capability requirements.

--- a/code/packages/kotlin/sql-vm/README.md
+++ b/code/packages/kotlin/sql-vm/README.md
@@ -1,0 +1,124 @@
+# sql-vm (Kotlin)
+
+The Kotlin stack-machine VM that executes bytecode `Program` objects produced by `sql-codegen`.
+
+## What is this?
+
+`sql-vm` is the execution engine of the mini-sqlite Level 1 pipeline:
+
+```
+SQL text
+  │  sql-lexer / sql-parser
+  ▼
+AST
+  │  sql-planner
+  ▼
+LogicalPlan
+  │  sql-optimizer
+  ▼
+OptimizedPlan
+  │  sql-codegen
+  ▼
+Program (flat instruction list)
+  │  sql-vm  ← THIS PACKAGE
+  ▼
+QueryResult
+```
+
+## How does it work?
+
+The VM is a simple dispatch loop — a `while (pc < instructions.size)` that reads one `Instruction` at a time, executes it, and advances the program counter. Control-flow instructions (`Jump`, `JumpIfFalse`, `JumpIfTrue`) rewrite the program counter directly.
+
+### Value representation
+
+All SQL values flow through the `SqlValue` sealed class from `sql-codegen`:
+
+| Kotlin type          | SQL type       |
+|----------------------|----------------|
+| `SqlValue.Null`      | NULL           |
+| `SqlValue.IntVal`    | INTEGER (Long) |
+| `SqlValue.FloatVal`  | REAL (Double)  |
+| `SqlValue.TextVal`   | TEXT           |
+| `SqlValue.BoolVal`   | BOOLEAN        |
+
+### Stack machine
+
+The VM is register-free. All intermediate values live on an `ArrayDeque<SqlValue>` stack:
+- `push(v)` → `stack.addLast(v)`
+- `pop()` → `stack.removeLast()`
+
+### Cursors
+
+Table scans are backed by the `Backend` interface from `sql-backend`. Each `OpenScan` instruction opens a cursor; `AdvanceCursor` moves it to the next row (or jumps to an end label if exhausted); `CloseScan` releases the cursor.
+
+### Aggregation
+
+Two-phase:
+1. **Accumulate** (inside the scan loop): `InitAgg` / `UpdateAgg` feed each row's value into a running accumulator keyed by the current GROUP BY key.
+2. **Finalize** (after the scan): `AdvanceGroup` / `FinalizeAgg` iterate over accumulated groups and emit one result row per group.
+
+## Public API
+
+```kotlin
+object SqlVm {
+    fun execute(program: Program, backend: Backend): QueryResult
+}
+
+data class QueryResult(
+    val columns: List<String>,
+    val rows: List<List<SqlValue>>,
+    val rowsAffected: Int,
+)
+```
+
+## Usage
+
+```kotlin
+val backend = InMemoryBackend()
+val program: Program = SqlCodegen.compile(SqlOptimizer.optimize(SqlPlanner.plan(ast)))
+val result: QueryResult = SqlVm.execute(program, backend)
+
+println(result.columns)        // ["id", "name"]
+result.rows.forEach { println(it) }
+```
+
+## Three-valued logic
+
+SQL uses three-valued logic for NULL:
+
+| Expression     | Result |
+|----------------|--------|
+| `NULL AND TRUE`  | NULL   |
+| `NULL AND FALSE` | FALSE  |
+| `NULL OR TRUE`   | TRUE   |
+| `NULL OR FALSE`  | NULL   |
+| `NULL = anything`| NULL   |
+| `NULL IS NULL`   | TRUE   |
+
+The VM implements these semantics in `evalBinary` / `evalAnd` / `evalOr`.
+
+## Package stack
+
+| Package        | Role                          |
+|----------------|-------------------------------|
+| `sql-backend`  | Storage interface + in-memory implementation |
+| `sql-planner`  | AST → logical plan            |
+| `sql-optimizer`| Logical plan → optimized plan |
+| `sql-codegen`  | Optimized plan → bytecode     |
+| **`sql-vm`**   | **Bytecode → QueryResult**    |
+
+## Building
+
+```bash
+# Pre-build all dependencies (leaf-to-root order):
+(cd ../sql-backend  && gradle jar --quiet)
+(cd ../sql-planner  && gradle jar --quiet)
+(cd ../sql-optimizer && gradle jar --quiet)
+(cd ../sql-codegen  && gradle jar --quiet)
+
+# Build and test:
+gradle test jacocoTestReport jacocoTestCoverageVerification
+```
+
+The build output goes to `gradle-build/` (NOT `build/`) to avoid a
+case-insensitive filesystem collision with the `BUILD` script file on macOS and Windows.

--- a/code/packages/kotlin/sql-vm/build.gradle.kts
+++ b/code/packages/kotlin/sql-vm/build.gradle.kts
@@ -1,0 +1,93 @@
+// build.gradle.kts — Gradle build script for the Kotlin sql-vm package.
+//
+// CRITICAL: layout.buildDirectory MUST be redirected away from "build/" to
+// avoid a collision with the "BUILD" script file on case-insensitive
+// filesystems (macOS HFS+, Windows NTFS).  "gradle-build/" is the repo-wide
+// convention for all Java/Kotlin packages.  (lessons.md §BUILD files, lesson #48.)
+//
+// Dependency strategy: we consume pre-built JARs from sibling packages rather
+// than using Gradle's project() dependencies.  The BUILD script pre-compiles all
+// sibling JARs before running this package's tests, so the files exist at their
+// declared paths when Gradle resolves them.
+
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    kotlin("jvm") version "2.1.20"
+    `java-library`
+    jacoco
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+// Pin the JVM target to match the CI runner's actions/setup-java configuration.
+// We deliberately do NOT use java { toolchain { languageVersion } } — that would
+// ask Gradle to download a JDK, which fails on restricted CI runners.  Letting
+// Gradle use the running JDK (provided by setup-java) is the correct approach.
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+    }
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    // Four sibling JARs, pre-built by the BUILD script in leaf-to-root order.
+    // These paths are relative to this package's directory.
+    // Note: sql-backend's rootProject.name is "sql-backend" (no "coding-adventures-" prefix);
+    // the other three packages include the prefix.
+    implementation(files("../sql-backend/gradle-build/libs/sql-backend-0.1.0.jar"))
+    implementation(files("../sql-planner/gradle-build/libs/coding-adventures-sql-planner-0.1.0.jar"))
+    implementation(files("../sql-optimizer/gradle-build/libs/coding-adventures-sql-optimizer-0.1.0.jar"))
+    implementation(files("../sql-codegen/gradle-build/libs/coding-adventures-sql-codegen-0.1.0.jar"))
+
+    testImplementation(kotlin("test"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+    finalizedBy(tasks.jacocoTestReport)
+}
+
+// JaCoCo coverage configuration.
+// Minimum coverage threshold is 80% line coverage (lessons.md §Repo Standards).
+jacoco {
+    toolVersion = "0.8.12"
+}
+
+tasks.jacocoTestReport {
+    dependsOn(tasks.test)
+    reports {
+        xml.required.set(true)
+        html.required.set(true)
+    }
+}
+
+tasks.jacocoTestCoverageVerification {
+    dependsOn(tasks.jacocoTestReport)
+    violationRules {
+        rule {
+            limit {
+                counter = "LINE"
+                value = "COVEREDRATIO"
+                minimum = "0.80".toBigDecimal()
+            }
+        }
+    }
+}
+
+tasks.named("check") {
+    dependsOn(tasks.jacocoTestCoverageVerification)
+}

--- a/code/packages/kotlin/sql-vm/required_capabilities.json
+++ b/code/packages/kotlin/sql-vm/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "kotlin/sql-vm",
+  "capabilities": [],
+  "justification": "Pure in-memory stack-machine VM. Executes a Program (flat instruction list) against an in-memory Backend. No filesystem, process, environment, or network access needed — all I/O is mediated through the Backend interface."
+}

--- a/code/packages/kotlin/sql-vm/settings.gradle.kts
+++ b/code/packages/kotlin/sql-vm/settings.gradle.kts
@@ -11,6 +11,7 @@
 // CRITICAL: all four packages must be listed.  Missing one causes an
 // "unresolved reference" at compile time on a fresh CI runner.
 
+includeBuild("../sql-backend")
 includeBuild("../sql-planner")
 includeBuild("../sql-optimizer")
 includeBuild("../sql-codegen")

--- a/code/packages/kotlin/sql-vm/settings.gradle.kts
+++ b/code/packages/kotlin/sql-vm/settings.gradle.kts
@@ -1,0 +1,18 @@
+// settings.gradle.kts — Gradle composite build settings for sql-vm.
+//
+// We declare all four upstream sibling packages as "included builds".  This
+// lets Gradle resolve their types (SqlValue, Instruction, Program, Backend …)
+// at compile time without requiring the JARs to be published to Maven Central.
+//
+// Composite builds are Gradle's monorepo story: each includeBuild declares
+// "this project lives locally at this relative path, please treat it as part
+// of the build graph rather than fetching it from a remote repository."
+//
+// CRITICAL: all four packages must be listed.  Missing one causes an
+// "unresolved reference" at compile time on a fresh CI runner.
+
+includeBuild("../sql-planner")
+includeBuild("../sql-optimizer")
+includeBuild("../sql-codegen")
+
+rootProject.name = "coding-adventures-sql-vm"

--- a/code/packages/kotlin/sql-vm/src/main/kotlin/com/codingadventures/sqlvm/SqlVm.kt
+++ b/code/packages/kotlin/sql-vm/src/main/kotlin/com/codingadventures/sqlvm/SqlVm.kt
@@ -1,0 +1,1522 @@
+package com.codingadventures.sqlvm
+
+// SqlVm.kt — Kotlin stack-machine bytecode VM for the mini-sqlite Level 1 pipeline.
+//
+// This is the *execution engine* of the pipeline:
+//
+//   SQL text
+//     │  sql-lexer / sql-parser
+//     ▼
+//   AST
+//     │  sql-planner
+//     ▼
+//   LogicalPlan
+//     │  sql-optimizer
+//     ▼
+//   OptimizedPlan
+//     │  sql-codegen
+//     ▼
+//   Program (flat instruction list)   ← we receive this
+//     │  sql-vm  (THIS FILE)
+//     ▼
+//   QueryResult
+//
+// Architecture — the dispatch loop
+// ─────────────────────────────────
+// The VM is a simple while-loop over a flat array of instructions, exactly like
+// CPython's ceval.c or SQLite's VDBE.  No tree recursion — every "complex"
+// operation is decomposed into a sequence of simple stack steps by the codegen.
+//
+//   while (pc < instructions.size) {
+//       dispatch(instructions[pc])
+//       pc++
+//   }
+//
+// The stack holds SqlValue instances (the sealed class from sql-codegen).  Most
+// instructions pop one or two values, do something, and push a result.
+//
+// Value representation
+// ────────────────────
+// Inside the VM we use the `SqlValue` sealed class from sql-codegen as the
+// single currency for all values:
+//
+//   SqlValue.Null       — SQL NULL
+//   SqlValue.IntVal     — 64-bit integer
+//   SqlValue.FloatVal   — IEEE-754 double
+//   SqlValue.TextVal    — Unicode string
+//   SqlValue.BoolVal    — boolean
+//
+// Key lesson from lessons.md:
+//   • layout.buildDirectory = file("gradle-build") — mandatory to avoid
+//     case-insensitive collision with the BUILD script on macOS/Windows.
+//   • Kotlin when-guard patterns ("is Type when cond") are NOT supported;
+//     use nested if inside an "is Type ->" branch.
+//   • ArrayDeque is the idiomatic Kotlin stack (addLast / removeLast).
+//   • Test method names in backticks must NOT contain "--", ":", etc.
+
+import com.codingadventures.sqlbackend.Backend
+import com.codingadventures.sqlbackend.ColumnDef
+import com.codingadventures.sqlbackend.Cursor
+import com.codingadventures.sqlbackend.CursorBackend
+import com.codingadventures.sqlplanner.ColumnDef as PlannerColumnDef
+import com.codingadventures.sqlplanner.SqlExpr as PlannerSqlExpr
+import com.codingadventures.sqlbackend.IndexDef
+import com.codingadventures.sqlbackend.Row
+import com.codingadventures.sqlbackend.RowIterator
+import com.codingadventures.sqlbackend.TriggerDef
+import com.codingadventures.sqlcodegen.AggFn
+import com.codingadventures.sqlcodegen.BinaryOp
+import com.codingadventures.sqlcodegen.Instruction
+import com.codingadventures.sqlcodegen.Program
+import com.codingadventures.sqlcodegen.SqlValue
+import com.codingadventures.sqlcodegen.UnaryOp
+
+// ── QueryResult ───────────────────────────────────────────────────────────────
+//
+// The final product of executing a Program.  For SELECT queries, `columns` and
+// `rows` carry the result set.  For DML (INSERT / UPDATE / DELETE), `rows` is
+// empty and `rowsAffected` is the number of rows changed.
+
+/**
+ * The result of executing a [Program].
+ *
+ * For SELECT queries:
+ *   - [columns] — ordered list of output column names (matches row width)
+ *   - [rows]    — each row is a positional list of [SqlValue]s; order matches [columns]
+ *   - [rowsAffected] — 0 (SELECTs don't mutate data)
+ *
+ * For DML (INSERT / UPDATE / DELETE):
+ *   - [columns] — empty
+ *   - [rows]    — empty
+ *   - [rowsAffected] — count of rows inserted/updated/deleted
+ *
+ * For DDL (CREATE TABLE / DROP TABLE):
+ *   - All fields are empty/zero (DDL produces no rows)
+ */
+data class QueryResult(
+    val columns: List<String>,
+    val rows: List<List<SqlValue>>,
+    val rowsAffected: Int,
+)
+
+// ── Aggregate state ───────────────────────────────────────────────────────────
+//
+// SQL aggregates (COUNT, SUM, AVG, MIN, MAX) must track running state per
+// group.  We maintain a flat array of AggAccumulator objects indexed by slot
+// number.  Within a GROUP BY query there are multiple groups; each group maps
+// to its own array of accumulators.
+
+/**
+ * Mutable accumulator for a single aggregate slot within a single group.
+ *
+ * For AVG, both [sum] and [count] are used.  For SUM/MIN/MAX, only [sum] is
+ * used (max starts at null, updated via comparison).  For COUNT/COUNT_STAR,
+ * only [count] is used.
+ */
+private data class AggAccumulator(
+    val fn: AggFn,
+    var count: Long = 0L,
+    var sum: SqlValue = SqlValue.Null,     // also serves as min/max accumulator
+)
+
+// ── In-memory subquery cursor ─────────────────────────────────────────────────
+//
+// When the codegen produces a Union (two sequential scan loops writing to the
+// same result buffer) or other multi-source scans, intermediate results are
+// sometimes materialised.  For Level 1 we don't implement full subqueries, but
+// we DO need a general RowIterator over a pre-collected list of rows.
+
+/**
+ * A simple [RowIterator] backed by a pre-materialised list of [Row] objects.
+ *
+ * Used internally by the VM when it needs to iterate a snapshot.
+ */
+private class ListCursorInternal(private val rows: List<Row>) : RowIterator {
+    private var idx = -1
+    override fun next(): Row? {
+        idx += 1
+        return rows.getOrNull(idx)
+    }
+    override fun close() {}
+}
+
+// ── VM state ──────────────────────────────────────────────────────────────────
+//
+// All mutable execution state for one execute() call is bundled here so the
+// public API (SqlVm.execute) is side-effect-free from the caller's perspective.
+
+/**
+ * Encapsulates all mutable state for a single [SqlVm.execute] invocation.
+ *
+ * Keeping state in a dedicated object (rather than as loose local variables)
+ * makes helper functions easy to write: every helper receives `state` and can
+ * read/write any field without threading every variable through the call chain.
+ */
+private class VmState(
+    val instructions: List<Instruction>,
+    val backend: Backend,
+    val labelIndex: Map<String, Int>,
+) {
+    // Program counter — index into `instructions`.
+    var pc: Int = 0
+
+    // The operand stack.  We use ArrayDeque as a stack: addLast to push,
+    // removeLast to pop.  (Kotlin's ArrayDeque is a resizable array; O(1)
+    // at both ends, no boxing overhead for object references.)
+    val stack: ArrayDeque<SqlValue> = ArrayDeque()
+
+    // Open cursors, keyed by alias (null = default/anonymous cursor).
+    // Each cursor is the RowIterator returned by backend.scan() or openCursor().
+    val cursors: MutableMap<String?, RowIterator> = mutableMapOf()
+
+    // Current row for each open cursor, keyed by alias.
+    // Updated on every AdvanceCursor; cleared on CloseScan.
+    val currentRow: MutableMap<String?, Row> = mutableMapOf()
+
+    // Output row buffer — columns are accumulated here between BeginRow and EmitRow.
+    val rowBuffer: MutableList<Pair<String, SqlValue>> = mutableListOf()
+
+    // Final result buffer — rows committed by EmitRow.
+    val resultRows: MutableList<List<Pair<String, SqlValue>>> = mutableListOf()
+
+    // Number of rows affected by DML (INSERT / UPDATE / DELETE).
+    var rowsAffected: Int = 0
+
+    // ── Aggregate state ────────────────────────────────────────────────────────
+    //
+    // For GROUP BY queries the VM tracks a separate accumulator array per group.
+    // The group key is the tuple of GROUP BY column values, serialised as a list.
+    //
+    // For non-GROUP BY aggregates, we use an empty-list key (the single implicit
+    // group that covers all rows).
+
+    // Current group key (values pushed by SaveGroupKey).
+    var groupKey: List<SqlValue> = emptyList()
+
+    // Accumulator table: group key → slot array.
+    val aggTable: MutableMap<List<SqlValue>, MutableList<AggAccumulator>> = linkedMapOf()
+
+    // Group ordering (insertion order — so AdvanceGroup is deterministic).
+    val groupOrder: MutableList<List<SqlValue>> = mutableListOf()
+
+    // Iterator position for the finalize phase (AdvanceGroup increments this).
+    var groupIter: Int = -1
+
+    // ── Transaction state ──────────────────────────────────────────────────────
+    var transactionHandle: com.codingadventures.sqlbackend.TransactionHandle? = null
+
+    // ── Stack helpers ──────────────────────────────────────────────────────────
+
+    /** Push a value onto the operand stack. */
+    fun push(v: SqlValue) { stack.addLast(v) }
+
+    /**
+     * Pop and return the top of the operand stack.
+     *
+     * Throws [IllegalStateException] if the stack is empty — this indicates
+     * a codegen bug, not a user error.
+     */
+    fun pop(): SqlValue {
+        check(stack.isNotEmpty()) { "operand stack underflow" }
+        return stack.removeLast()
+    }
+
+    /**
+     * Pop [n] values and return them in push order (oldest first).
+     *
+     * Example: if the stack top-to-bottom is [C, B, A] and we popN(3), we
+     * return [A, B, C] — the order in which they were pushed.
+     *
+     * This is important for IN lists and multi-argument aggregate functions
+     * where argument order matters.
+     */
+    fun popN(n: Int): List<SqlValue> {
+        if (n == 0) return emptyList()
+        check(stack.size >= n) { "operand stack underflow: need $n, have ${stack.size}" }
+        val result: MutableList<SqlValue> = MutableList(n) { SqlValue.Null }
+        for (i in n - 1 downTo 0) result[i] = stack.removeLast()
+        return result
+    }
+}
+
+// ── SqlVm ─────────────────────────────────────────────────────────────────────
+//
+// The public entry point.  `execute` is a standalone function that creates a
+// fresh VmState, runs the dispatch loop, and returns the QueryResult.
+
+/**
+ * Stack-machine VM that executes [Program] bytecode against a [Backend].
+ *
+ * The VM is a simple dispatch loop — it reads each [Instruction] in sequence,
+ * executes it (modifying the [VmState]), and advances the program counter.
+ * Control-flow instructions (Jump, JumpIfFalse, JumpIfTrue) rewrite the
+ * program counter directly.
+ *
+ * # Thread safety
+ * [execute] creates a fresh [VmState] on each call and does not share mutable
+ * state between invocations.  Concurrent calls are safe as long as the
+ * [Backend] implementation is itself thread-safe.
+ */
+object SqlVm {
+
+    /**
+     * Execute [program] against [backend] and return the query result.
+     *
+     * For SELECT queries, the returned [QueryResult] has a non-empty [columns]
+     * list and zero or more [rows].  For DML, [rowsAffected] is non-zero and
+     * [rows] is empty.  For DDL, all fields are zero/empty.
+     */
+    fun execute(program: Program, backend: Backend): QueryResult {
+        // ── Label resolution ──────────────────────────────────────────────────
+        //
+        // Before execution, we build a Map<labelName, instructionIndex> by
+        // scanning the instruction list once.  This makes all jump targets O(1)
+        // to resolve during execution instead of O(n) linear scan per jump.
+        val labelIndex = buildLabelIndex(program.instructions)
+
+        val state = VmState(
+            instructions = program.instructions,
+            backend      = backend,
+            labelIndex   = labelIndex,
+        )
+
+        // ── Main dispatch loop ────────────────────────────────────────────────
+        //
+        // We increment `pc` at the top of the loop so that jump instructions can
+        // set `pc` to the target index and the loop will execute that instruction
+        // next.  Note: Halt breaks the loop, so it does not need to set pc.
+        while (state.pc < state.instructions.size) {
+            val instr = state.instructions[state.pc]
+            state.pc++
+
+            when (instr) {
+                // ─ Stack / constants ─────────────────────────────────────────
+                is Instruction.LoadConst -> state.push(instr.value)
+
+                is Instruction.LoadColumn -> doLoadColumn(instr, state)
+
+                is Instruction.LoadParam -> {
+                    // Reserved for parameterised queries; Level 1 inlines all
+                    // literals, so this instruction should not appear in practice.
+                    // Push NULL as a safe placeholder.
+                    state.push(SqlValue.Null)
+                }
+
+                is Instruction.LoadGroupKey -> {
+                    // Push the i-th component of the current group key.
+                    // During the finalize phase, groupKey holds the values for
+                    // the group currently being emitted.
+                    val v = state.groupKey.getOrNull(instr.index) ?: SqlValue.Null
+                    state.push(v)
+                }
+
+                is Instruction.Pop -> state.pop()
+
+                // ─ Binary / unary operators ──────────────────────────────────
+                is Instruction.BinaryOpInstr -> {
+                    val right = state.pop()
+                    val left  = state.pop()
+                    state.push(evalBinary(instr.op, left, right))
+                }
+
+                is Instruction.UnaryOpInstr -> {
+                    val operand = state.pop()
+                    state.push(evalUnary(instr.op, operand))
+                }
+
+                // ─ Predicate tests ───────────────────────────────────────────
+                is Instruction.IsNull -> {
+                    val v = state.pop()
+                    state.push(SqlValue.BoolVal(v is SqlValue.Null))
+                }
+
+                is Instruction.IsNotNull -> {
+                    val v = state.pop()
+                    state.push(SqlValue.BoolVal(v !is SqlValue.Null))
+                }
+
+                is Instruction.Between -> doInstrBetween(instr, state)
+
+                is Instruction.Like -> doLike(state)
+
+                is Instruction.InList -> doInList(instr, state)
+
+                // ─ Scans ─────────────────────────────────────────────────────
+                is Instruction.OpenScan -> {
+                    // Ask the backend for a cursor over the named table.
+                    // We prefer openCursor() (which supports positioned UPDATE /
+                    // DELETE) over scan() (read-only iterator).
+                    val iter = openCursorOrScan(backend, instr.table)
+                    state.cursors[instr.alias] = iter
+                }
+
+                is Instruction.AdvanceCursor -> doAdvanceCursor(instr, state)
+
+                is Instruction.JumpIfExhausted -> doJumpIfExhausted(instr, state)
+
+                is Instruction.CloseScan -> {
+                    val iter = state.cursors.remove(instr.alias)
+                    iter?.close()
+                    state.currentRow.remove(instr.alias)
+                }
+
+                // ─ Row emission ───────────────────────────────────────────────
+                is Instruction.BeginRow -> state.rowBuffer.clear()
+
+                is Instruction.EmitColumn -> {
+                    val value = state.pop()
+                    state.rowBuffer.add(instr.name to value)
+                }
+
+                is Instruction.EmitRow -> {
+                    state.resultRows.add(state.rowBuffer.toList())
+                    state.rowBuffer.clear()
+                }
+
+                // ─ Aggregation ────────────────────────────────────────────────
+                is Instruction.InitAgg   -> doInitAgg(instr, state)
+                is Instruction.UpdateAgg -> doUpdateAgg(instr, state)
+                is Instruction.FinalizeAgg -> doFinalizeAgg(instr, state)
+
+                is Instruction.SaveGroupKey -> {
+                    // Pop `keys.size` values from the stack (oldest first) and
+                    // store them as the current group key.
+                    val n = instr.keys.size
+                    val values = state.popN(n)
+                    state.groupKey = values
+                }
+
+                is Instruction.AdvanceGroup -> doAdvanceGroup(instr, state)
+
+                // ─ Control flow ────────────────────────────────────────────────
+                is Instruction.Label -> { /* runtime no-op; used only for pre-scan */ }
+
+                is Instruction.Jump -> {
+                    state.pc = resolveLabel(instr.label, state)
+                }
+
+                is Instruction.JumpIfTrue -> {
+                    val v = state.pop()
+                    if (isTruthy(v)) {
+                        state.pc = resolveLabel(instr.label, state)
+                    }
+                }
+
+                is Instruction.JumpIfFalse -> {
+                    val v = state.pop()
+                    if (!isTruthy(v)) {
+                        state.pc = resolveLabel(instr.label, state)
+                    }
+                }
+
+                is Instruction.Halt -> break
+
+                // ─ DDL ─────────────────────────────────────────────────────────
+                is Instruction.CreateTableInstr -> {
+                    // instr.columns is List<com.codingadventures.sqlplanner.ColumnDef>;
+                    // backend.createTable expects List<com.codingadventures.sqlbackend.ColumnDef>.
+                    // We convert each one via convertColumnDef().
+                    backend.createTable(instr.name, instr.columns.map { convertColumnDef(it) }, instr.ifNotExists)
+                }
+
+                is Instruction.DropTableInstr -> {
+                    backend.dropTable(instr.name, instr.ifExists)
+                }
+
+                // ─ DML ─────────────────────────────────────────────────────────
+                is Instruction.InsertRow  -> doInsert(instr, state)
+                is Instruction.UpdateRows -> doUpdate(instr, state)
+                is Instruction.DeleteRows -> doDelete(instr, state)
+
+                // ─ Transactions ────────────────────────────────────────────────
+                is Instruction.BeginTransaction -> {
+                    if (state.transactionHandle == null) {
+                        state.transactionHandle = backend.beginTransaction()
+                    }
+                }
+
+                is Instruction.CommitTransaction -> {
+                    val handle = state.transactionHandle
+                    if (handle != null) {
+                        backend.commit(handle)
+                        state.transactionHandle = null
+                    }
+                }
+
+                is Instruction.RollbackTransaction -> {
+                    val handle = state.transactionHandle
+                    if (handle != null) {
+                        backend.rollback(handle)
+                        state.transactionHandle = null
+                    }
+                }
+
+                // ─ Post-operation instructions ─────────────────────────────────
+                is Instruction.SortResult     -> doSortResult(instr, state)
+                is Instruction.DistinctResult -> doDistinctResult(state)
+                is Instruction.LimitResult    -> doLimitResult(instr, state)
+            }
+        }
+
+        return buildResult(state)
+    }
+
+    // ── Label resolution ──────────────────────────────────────────────────────
+
+    /**
+     * Build a map from label name to instruction index by scanning [instructions] once.
+     *
+     * Labels are [Instruction.Label] objects that act as no-ops at runtime.
+     * Pre-scanning them means every jump is O(1) during execution.
+     */
+    private fun buildLabelIndex(instructions: List<Instruction>): Map<String, Int> {
+        val map = HashMap<String, Int>(instructions.size)
+        for ((idx, instr) in instructions.withIndex()) {
+            if (instr is Instruction.Label) {
+                map[instr.name] = idx
+            }
+        }
+        return map
+    }
+
+    /**
+     * Resolve a label name to its instruction index.
+     *
+     * Throws [IllegalArgumentException] if the label is unknown — this would
+     * indicate a codegen bug, not a user error.
+     */
+    private fun resolveLabel(label: String, state: VmState): Int =
+        state.labelIndex[label]
+            ?: error("unknown label: '$label'")
+
+    // ── Backend cursor helpers ────────────────────────────────────────────────
+
+    /**
+     * Open a cursor over [table].
+     *
+     * Prefers [CursorBackend.openCursor] (which returns a positioned [Cursor]
+     * supporting UPDATE / DELETE) over the read-only [Backend.scan].  The
+     * dispatch uses a Kotlin `is`-check instead of reflection, which is
+     * type-safe, obfuscation-friendly, and throws no [ReflectiveOperationException].
+     */
+    private fun openCursorOrScan(backend: Backend, table: String): RowIterator =
+        if (backend is CursorBackend) backend.openCursor(table)
+        else backend.scan(table)
+
+    // ── Column load ───────────────────────────────────────────────────────────
+
+    /**
+     * Load a column value from the current row of the named cursor.
+     *
+     * The cursor alias (or null for the default cursor) identifies which
+     * open scan to read from.  If the cursor has no current row (e.g., the
+     * cursor was already closed) we push NULL.
+     */
+    private fun doLoadColumn(instr: Instruction.LoadColumn, state: VmState) {
+        val row = state.currentRow[instr.table]
+        if (row == null) {
+            state.push(SqlValue.Null)
+            return
+        }
+        // Column lookup is case-insensitive (SQL standard).
+        val rawValue = row.entries
+            .find { it.key.equals(instr.column, ignoreCase = true) }
+            ?.value
+        state.push(backendValueToSqlValue(rawValue))
+    }
+
+    /**
+     * Convert a backend [Any?] value to an [SqlValue].
+     *
+     * The backend stores values as untyped [Any?] (null, Long, Double, String,
+     * Boolean, Blob).  We box them into the SqlValue sealed class hierarchy.
+     */
+    private fun backendValueToSqlValue(v: Any?): SqlValue = when (v) {
+        null       -> SqlValue.Null
+        is Boolean -> SqlValue.BoolVal(v)
+        is Long    -> SqlValue.IntVal(v)
+        is Int     -> SqlValue.IntVal(v.toLong())
+        is Short   -> SqlValue.IntVal(v.toLong())
+        is Byte    -> SqlValue.IntVal(v.toLong())
+        is Double  -> SqlValue.FloatVal(v)
+        is Float   -> SqlValue.FloatVal(v.toDouble())
+        is String  -> SqlValue.TextVal(v)
+        else       -> SqlValue.TextVal(v.toString())
+    }
+
+    /**
+     * Convert an [SqlValue] to the native type that the [Backend] expects.
+     *
+     * The backend accepts null, Long, Double, String, or Boolean.
+     */
+    private fun sqlValueToBackend(v: SqlValue): Any? = when (v) {
+        is SqlValue.Null    -> null
+        is SqlValue.IntVal  -> v.v
+        is SqlValue.FloatVal -> v.v
+        is SqlValue.TextVal -> v.v
+        is SqlValue.BoolVal -> v.v
+    }
+
+    // ── Cursor advance ────────────────────────────────────────────────────────
+
+    /**
+     * Advance the named cursor to the next row.
+     *
+     * If the cursor is exhausted (no more rows), jump to [instr.label].
+     * Otherwise, update [VmState.currentRow] and fall through to the loop body.
+     */
+    private fun doAdvanceCursor(instr: Instruction.AdvanceCursor, state: VmState) {
+        val cursor = state.cursors[instr.alias]
+            ?: error("AdvanceCursor: no open cursor for alias '${instr.alias}'")
+        val row = cursor.next()
+        if (row == null) {
+            // Cursor exhausted — jump to end label.
+            state.currentRow.remove(instr.alias)
+            state.pc = resolveLabel(instr.label, state)
+        } else {
+            state.currentRow[instr.alias] = row
+        }
+    }
+
+    /**
+     * Jump to [instr.label] if the named cursor is exhausted.
+     *
+     * This is a variant of [doAdvanceCursor] used in patterns where the advance
+     * and the exhaustion check are separate steps.
+     */
+    private fun doJumpIfExhausted(instr: Instruction.JumpIfExhausted, state: VmState) {
+        val cursor = state.cursors[instr.alias]
+        if (cursor == null || state.currentRow[instr.alias] == null) {
+            state.pc = resolveLabel(instr.label, state)
+        }
+    }
+
+    // ── Binary operators ──────────────────────────────────────────────────────
+    //
+    // SQL's three-valued logic: any operation with a NULL input propagates NULL
+    // as the output (except for AND/OR which have special truth tables).
+    //
+    // AND truth table:                 OR truth table:
+    //   TRUE  AND TRUE  = TRUE           TRUE  OR FALSE = TRUE
+    //   TRUE  AND FALSE = FALSE          TRUE  OR NULL  = TRUE
+    //   TRUE  AND NULL  = NULL           FALSE OR FALSE = FALSE
+    //   FALSE AND FALSE = FALSE          FALSE OR NULL  = NULL
+    //   FALSE AND NULL  = FALSE          NULL  OR NULL  = NULL
+    //   NULL  AND NULL  = NULL
+    //
+    // (Ref: SQL-92 §8.16.  Same semantics as SQLite.)
+
+    /**
+     * Evaluate a binary operation on two [SqlValue] operands.
+     *
+     * For arithmetic / comparison operations, NULL in → NULL out.
+     * For AND / OR, SQL three-valued logic applies.
+     * For CONCAT, NULL in → NULL out.
+     */
+    private fun evalBinary(op: BinaryOp, left: SqlValue, right: SqlValue): SqlValue {
+        // AND and OR have special NULL handling — check them first.
+        if (op == BinaryOp.AND) {
+            return evalAnd(left, right)
+        }
+        if (op == BinaryOp.OR) {
+            return evalOr(left, right)
+        }
+
+        // All other ops propagate NULL.
+        if (left is SqlValue.Null || right is SqlValue.Null) return SqlValue.Null
+
+        return when (op) {
+            BinaryOp.ADD    -> evalArith(left, right, { a, b -> a + b }, { a, b -> a + b })
+            BinaryOp.SUB    -> evalArith(left, right, { a, b -> a - b }, { a, b -> a - b })
+            BinaryOp.MUL    -> evalArith(left, right, { a, b -> a * b }, { a, b -> a * b })
+            BinaryOp.DIV    -> evalDiv(left, right)
+            BinaryOp.MOD    -> evalMod(left, right)
+            BinaryOp.EQ     -> SqlValue.BoolVal(sqlEquals(left, right))
+            BinaryOp.NEQ    -> SqlValue.BoolVal(!sqlEquals(left, right))
+            BinaryOp.LT     -> SqlValue.BoolVal(sqlCompare(left, right) < 0)
+            BinaryOp.LTE    -> SqlValue.BoolVal(sqlCompare(left, right) <= 0)
+            BinaryOp.GT     -> SqlValue.BoolVal(sqlCompare(left, right) > 0)
+            BinaryOp.GTE    -> SqlValue.BoolVal(sqlCompare(left, right) >= 0)
+            BinaryOp.CONCAT -> evalConcat(left, right)
+            // AND / OR handled above — unreachable here.
+            BinaryOp.AND, BinaryOp.OR -> SqlValue.Null
+        }
+    }
+
+    /** SQL AND with three-valued logic. */
+    private fun evalAnd(left: SqlValue, right: SqlValue): SqlValue {
+        val l = toBoolOrNull(left)
+        val r = toBoolOrNull(right)
+        // FALSE AND anything = FALSE
+        if (l == false || r == false) return SqlValue.BoolVal(false)
+        // NULL AND TRUE = NULL; NULL AND NULL = NULL
+        if (l == null || r == null) return SqlValue.Null
+        return SqlValue.BoolVal(true)
+    }
+
+    /** SQL OR with three-valued logic. */
+    private fun evalOr(left: SqlValue, right: SqlValue): SqlValue {
+        val l = toBoolOrNull(left)
+        val r = toBoolOrNull(right)
+        // TRUE OR anything = TRUE
+        if (l == true || r == true) return SqlValue.BoolVal(true)
+        // NULL OR FALSE = NULL; NULL OR NULL = NULL
+        if (l == null || r == null) return SqlValue.Null
+        return SqlValue.BoolVal(false)
+    }
+
+    /**
+     * Convert [SqlValue] to [Boolean?] for three-valued logic.
+     *
+     * NULL → null; FALSE/0/0.0 → false; everything else → true.
+     */
+    private fun toBoolOrNull(v: SqlValue): Boolean? = when (v) {
+        is SqlValue.Null    -> null
+        is SqlValue.BoolVal -> v.v
+        is SqlValue.IntVal  -> v.v != 0L
+        is SqlValue.FloatVal -> v.v != 0.0
+        is SqlValue.TextVal -> v.v.isNotEmpty()
+    }
+
+    /**
+     * Evaluate [v] as a truthy SQL value for JumpIfTrue / JumpIfFalse.
+     *
+     * NULL is falsy (jump is NOT taken for JumpIfTrue; IS taken for JumpIfFalse).
+     * False, 0, and 0.0 are also falsy.
+     */
+    private fun isTruthy(v: SqlValue): Boolean = when (v) {
+        is SqlValue.Null    -> false
+        is SqlValue.BoolVal -> v.v
+        is SqlValue.IntVal  -> v.v != 0L
+        is SqlValue.FloatVal -> v.v != 0.0
+        is SqlValue.TextVal -> v.v.isNotEmpty()
+    }
+
+    /**
+     * Evaluate an arithmetic operation.
+     *
+     * If both operands are integers, the result is an integer (preserving SQL's
+     * integer arithmetic for exact precision).  If either is a float, the result
+     * is a float.
+     *
+     * The two lambdas [intOp] and [floatOp] provide the type-specific operation.
+     */
+    private inline fun evalArith(
+        left: SqlValue,
+        right: SqlValue,
+        intOp: (Long, Long) -> Long,
+        floatOp: (Double, Double) -> Double,
+    ): SqlValue {
+        val lNum = toNumber(left)
+        val rNum = toNumber(right)
+        if (lNum == null || rNum == null) return SqlValue.Null
+
+        return if (left is SqlValue.FloatVal || right is SqlValue.FloatVal) {
+            SqlValue.FloatVal(floatOp(lNum.toDouble(), rNum.toDouble()))
+        } else {
+            SqlValue.IntVal(intOp(lNum.toLong(), rNum.toLong()))
+        }
+    }
+
+    /**
+     * Integer or floating-point division.
+     *
+     * SQL: integer / integer = integer (truncated toward zero); divide-by-zero
+     * returns NULL (SQLite behaviour — does not throw an exception).
+     */
+    private fun evalDiv(left: SqlValue, right: SqlValue): SqlValue {
+        val lNum = toNumber(left) ?: return SqlValue.Null
+        val rNum = toNumber(right) ?: return SqlValue.Null
+        return if (left is SqlValue.FloatVal || right is SqlValue.FloatVal) {
+            val d = rNum.toDouble()
+            if (d == 0.0) SqlValue.Null else SqlValue.FloatVal(lNum.toDouble() / d)
+        } else {
+            val r = rNum.toLong()
+            if (r == 0L) SqlValue.Null else SqlValue.IntVal(lNum.toLong() / r)
+        }
+    }
+
+    /** Integer modulo; divide-by-zero returns NULL. */
+    private fun evalMod(left: SqlValue, right: SqlValue): SqlValue {
+        val lNum = toNumber(left) ?: return SqlValue.Null
+        val rNum = toNumber(right) ?: return SqlValue.Null
+        return if (left is SqlValue.FloatVal || right is SqlValue.FloatVal) {
+            val d = rNum.toDouble()
+            if (d == 0.0) SqlValue.Null else SqlValue.FloatVal(lNum.toDouble() % d)
+        } else {
+            val r = rNum.toLong()
+            if (r == 0L) SqlValue.Null else SqlValue.IntVal(lNum.toLong() % r)
+        }
+    }
+
+    /** String concatenation (SQL `||`). */
+    private fun evalConcat(left: SqlValue, right: SqlValue): SqlValue {
+        val l = sqlToString(left)
+        val r = sqlToString(right)
+        return SqlValue.TextVal(l + r)
+    }
+
+    /**
+     * Convert [SqlValue] to a [Number] for arithmetic, or null if not numeric.
+     *
+     * Strings that represent numbers are coerced (SQLite does this too — e.g.
+     * `'3' + 4` evaluates to 7).  Non-numeric strings yield null (which becomes
+     * a NULL output via NULL propagation).
+     */
+    private fun toNumber(v: SqlValue): Number? = when (v) {
+        is SqlValue.IntVal  -> v.v
+        is SqlValue.FloatVal -> v.v
+        is SqlValue.BoolVal -> if (v.v) 1L else 0L
+        is SqlValue.TextVal -> v.v.toLongOrNull() ?: v.v.toDoubleOrNull()
+        is SqlValue.Null    -> null
+    }
+
+    /**
+     * SQL equality test — returns a Boolean (not an SqlValue) for use in
+     * comparison operators.
+     *
+     * NULL == NULL is true for DISTINCT deduplication but false for regular
+     * SQL comparison.  Here we implement regular equality: NULL is not equal
+     * to anything (callers handle the NULL case before reaching this function).
+     */
+    private fun sqlEquals(left: SqlValue, right: SqlValue): Boolean {
+        if (left is SqlValue.Null || right is SqlValue.Null) return false
+        // Numeric cross-type comparison: IntVal == FloatVal when values are equal.
+        val lNum = toNumber(left)
+        val rNum = toNumber(right)
+        if (lNum != null && rNum != null) {
+            return lNum.toDouble() == rNum.toDouble()
+        }
+        return left == right
+    }
+
+    /**
+     * SQL ordering comparison.
+     *
+     * Type ordering (SQLite affinity order): NULL < BOOL < INTEGER/REAL < TEXT.
+     * Within integers and reals, numeric comparison.  Within text, lexicographic.
+     */
+    private fun sqlCompare(left: SqlValue, right: SqlValue): Int {
+        // NULL sorts before everything.
+        if (left is SqlValue.Null && right is SqlValue.Null) return 0
+        if (left is SqlValue.Null) return -1
+        if (right is SqlValue.Null) return 1
+
+        val lNum = toNumber(left)
+        val rNum = toNumber(right)
+        if (lNum != null && rNum != null) {
+            return lNum.toDouble().compareTo(rNum.toDouble())
+        }
+        // Fall back to string comparison (TEXT > numeric in SQLite affinity).
+        return sqlToString(left).compareTo(sqlToString(right))
+    }
+
+    /** Convert any [SqlValue] to its SQL string representation. */
+    private fun sqlToString(v: SqlValue): String = when (v) {
+        is SqlValue.Null    -> ""
+        is SqlValue.IntVal  -> v.v.toString()
+        is SqlValue.FloatVal -> {
+            // Match SQLite's float rendering: omit trailing ".0" for whole numbers.
+            if (v.v == v.v.toLong().toDouble() && !v.v.isInfinite() && !v.v.isNaN()) {
+                v.v.toLong().toString()
+            } else {
+                v.v.toString()
+            }
+        }
+        is SqlValue.TextVal -> v.v
+        is SqlValue.BoolVal -> if (v.v) "1" else "0"
+    }
+
+    // ── Unary operators ───────────────────────────────────────────────────────
+
+    /**
+     * Evaluate a unary operation.
+     *
+     * NEG: arithmetic negation.  -(NULL) = NULL.
+     * NOT: boolean NOT.  NOT NULL = NULL; NOT TRUE = FALSE; NOT FALSE = TRUE.
+     *      Note: NOT 0 = TRUE; NOT 1 = FALSE (SQLite integer truthiness).
+     */
+    private fun evalUnary(op: UnaryOp, operand: SqlValue): SqlValue = when (op) {
+        UnaryOp.NEG -> {
+            when (operand) {
+                is SqlValue.Null    -> SqlValue.Null
+                is SqlValue.IntVal  -> SqlValue.IntVal(-operand.v)
+                is SqlValue.FloatVal -> SqlValue.FloatVal(-operand.v)
+                is SqlValue.BoolVal -> SqlValue.IntVal(if (operand.v) -1L else 0L)
+                is SqlValue.TextVal -> {
+                    val n = toNumber(operand)
+                    if (n == null) SqlValue.Null
+                    else if (n is Long) SqlValue.IntVal(-n)
+                    else SqlValue.FloatVal(-n.toDouble())
+                }
+            }
+        }
+        UnaryOp.NOT -> {
+            when (operand) {
+                is SqlValue.Null    -> SqlValue.Null
+                is SqlValue.BoolVal -> SqlValue.BoolVal(!operand.v)
+                is SqlValue.IntVal  -> SqlValue.BoolVal(operand.v == 0L)
+                is SqlValue.FloatVal -> SqlValue.BoolVal(operand.v == 0.0)
+                is SqlValue.TextVal -> {
+                    // NOT '0' = TRUE; NOT '' = TRUE; NOT '1' = FALSE
+                    val n = toNumber(operand) ?: return SqlValue.Null
+                    SqlValue.BoolVal(n.toDouble() == 0.0)
+                }
+            }
+        }
+    }
+
+    // ── BETWEEN ───────────────────────────────────────────────────────────────
+
+    /**
+     * Evaluate SQL BETWEEN: push TRUE if `low <= value <= high`.
+     *
+     * Stack layout when this instruction executes (top is last pushed):
+     *   ... value  low  high
+     *
+     * We pop high first, then low, then value.
+     *
+     * Three-valued logic: any NULL input yields NULL.
+     */
+    private fun doInstrBetween(@Suppress("UNUSED_PARAMETER") instr: Instruction.Between, state: VmState) {
+        val high  = state.pop()
+        val low   = state.pop()
+        val value = state.pop()
+
+        if (value is SqlValue.Null || low is SqlValue.Null || high is SqlValue.Null) {
+            state.push(SqlValue.Null)
+            return
+        }
+        val ge = sqlCompare(value, low)  >= 0
+        val le = sqlCompare(value, high) <= 0
+        state.push(SqlValue.BoolVal(ge && le))
+    }
+
+    // ── LIKE ─────────────────────────────────────────────────────────────────
+    //
+    // SQL LIKE uses two wildcards:
+    //   %   — matches any sequence of zero or more characters
+    //   _   — matches any single character
+    //
+    // Escape character: not supported in Level 1 (the codegen's Like instruction
+    // does not carry an escape character field).
+    //
+    // The algorithm uses a linear-time iterative matcher (classic two-pointer
+    // backtracking approach) instead of converting to a regex.  This avoids
+    // ReDoS vulnerabilities: a crafted pattern like `%a%a%a%a%a%a%a%b` with a
+    // long non-matching text could cause exponential backtracking in a
+    // regex-based implementation.
+    //
+    // The algorithm maintains:
+    //   ti     — current position in text
+    //   pi     — current position in pattern
+    //   starPi — position of the last '%' wildcard in pattern (-1 = none)
+    //   starTi — text position where we started trying to match after the last '%'
+    //
+    // When a mismatch occurs and we have a saved '%' position, we backtrack by
+    // advancing starTi one character and replaying from starPi+1.  This is O(n*m)
+    // worst-case (n = text length, m = pattern length) but avoids catastrophic
+    // exponential blowup.
+
+    /**
+     * LIKE predicate.  Stack (top-to-bottom when this executes): pattern, value.
+     *
+     * We pop pattern first, then value.
+     * NULL in → NULL out.
+     */
+    private fun doLike(state: VmState) {
+        val pattern = state.pop()
+        val value   = state.pop()
+
+        if (value is SqlValue.Null || pattern is SqlValue.Null) {
+            state.push(SqlValue.Null)
+            return
+        }
+
+        val patStr = sqlToString(pattern)
+        val valStr = sqlToString(value)
+
+        state.push(SqlValue.BoolVal(likeMatch(valStr, patStr)))
+    }
+
+    /**
+     * Match [text] against a SQL LIKE [pattern] using a linear-time iterative
+     * matcher.
+     *
+     * Wildcards:
+     *   `%` — matches any sequence of zero or more characters
+     *   `_` — matches any single character
+     *
+     * All other characters match themselves case-insensitively (SQLite NOCASE
+     * for ASCII compatibility).
+     *
+     * This avoids the ReDoS vulnerability inherent in converting `%` to `.*` and
+     * delegating to [Regex]: a pattern with many `%` wildcards and a long
+     * non-matching text could trigger exponential backtracking in the regex engine.
+     */
+    internal fun likeMatch(text: String, pattern: String): Boolean {
+        var ti = 0      // current index into text
+        var pi = 0      // current index into pattern
+        var starPi = -1 // index of the most recent '%' in pattern; -1 = none seen
+        var starTi = -1 // text index where we began the match attempt after '%'
+
+        while (ti < text.length) {
+            val pc = pattern.getOrNull(pi)
+            when {
+                // '%' matches zero or more characters — save this position and
+                // advance the pattern pointer (consuming zero chars of text now).
+                pc == '%' -> { starPi = pi++; starTi = ti }
+
+                // '_' matches exactly one character; plain chars match
+                // case-insensitively.
+                pc == '_' || (pc != null && pc.equals(text[ti], ignoreCase = true)) -> {
+                    ti++; pi++
+                }
+
+                // Mismatch — but we have a saved '%': backtrack by letting '%'
+                // consume one more character of text and replay from starPi+1.
+                starPi >= 0 -> { pi = starPi + 1; ti = ++starTi }
+
+                // No '%' to backtrack to — no match.
+                else -> return false
+            }
+        }
+
+        // Consume any trailing '%' wildcards (they match the empty suffix).
+        while (pi < pattern.length && pattern[pi] == '%') pi++
+
+        // A match requires the pattern to be fully consumed.
+        return pi == pattern.length
+    }
+
+    // ── IN list ───────────────────────────────────────────────────────────────
+    //
+    // Stack layout for `x IN (v1, v2, v3)` with count=3 when this executes:
+    //   ... x  v1  v2  v3       (v3 is on top)
+    //
+    // We pop `count` list items first (they were pushed in order v1..vN so
+    // popN returns them in push order), then pop the needle.
+    //
+    // NULL semantics (SQL standard):
+    //   needle IS NULL → push NULL
+    //   needle found in non-NULL items → push TRUE
+    //   needle not found; no NULL in list → push FALSE
+    //   needle not found; a NULL is in the list → push NULL
+
+    /** SQL IN (v1, v2, …) predicate. */
+    private fun doInList(instr: Instruction.InList, state: VmState) {
+        val items  = state.popN(instr.count)
+        val needle = state.pop()
+
+        if (instr.count == 0) {
+            state.push(SqlValue.BoolVal(false))
+            return
+        }
+
+        if (needle is SqlValue.Null) {
+            state.push(SqlValue.Null)
+            return
+        }
+
+        var foundNull = false
+        for (item in items) {
+            if (item is SqlValue.Null) {
+                foundNull = true
+                continue
+            }
+            if (sqlEquals(needle, item)) {
+                state.push(SqlValue.BoolVal(true))
+                return
+            }
+        }
+        state.push(if (foundNull) SqlValue.Null else SqlValue.BoolVal(false))
+    }
+
+    // ── Aggregation ───────────────────────────────────────────────────────────
+    //
+    // Two-phase aggregate computation:
+    //   Phase 1 (scan loop): InitAgg → UpdateAgg  (per input row)
+    //   Phase 2 (finalize):  AdvanceGroup → FinalizeAgg → EmitRow  (per group)
+    //
+    // The `aggTable` maps group keys to arrays of AggAccumulator.
+    // The slot index (from InitAgg/UpdateAgg/FinalizeAgg) selects which aggregate
+    // within the group we're updating.
+
+    /** Ensure a slot exists for the current group key.  Idempotent. */
+    private fun ensureGroup(state: VmState): MutableList<AggAccumulator> {
+        return state.aggTable.getOrPut(state.groupKey) {
+            state.groupOrder.add(state.groupKey)
+            mutableListOf()
+        }
+    }
+
+    /**
+     * InitAgg: ensure aggregate slot [instr.index] exists for the current group.
+     *
+     * This instruction is emitted once per input row by the codegen (idempotent —
+     * if the slot already exists we leave it unchanged so partial sums aren't reset).
+     */
+    private fun doInitAgg(instr: Instruction.InitAgg, state: VmState) {
+        val slots = ensureGroup(state)
+        while (slots.size <= instr.index) {
+            slots.add(AggAccumulator(fn = instr.fn))
+        }
+    }
+
+    /**
+     * UpdateAgg: pop one value and feed it into aggregate slot [instr.index].
+     *
+     * NULL values are ignored by all aggregate functions except COUNT(*).
+     */
+    private fun doUpdateAgg(instr: Instruction.UpdateAgg, state: VmState) {
+        val value = state.pop()
+        val slots = ensureGroup(state)
+        while (slots.size <= instr.index) {
+            slots.add(AggAccumulator(fn = instr.fn))
+        }
+        val acc = slots[instr.index]
+
+        when (acc.fn) {
+            AggFn.COUNT_STAR -> acc.count++
+
+            AggFn.COUNT -> {
+                if (value !is SqlValue.Null) acc.count++
+            }
+
+            AggFn.SUM -> {
+                if (value !is SqlValue.Null) {
+                    acc.sum = if (acc.sum is SqlValue.Null) value else addSqlValues(acc.sum, value)
+                }
+            }
+
+            AggFn.AVG -> {
+                if (value !is SqlValue.Null) {
+                    acc.sum = if (acc.sum is SqlValue.Null) value else addSqlValues(acc.sum, value)
+                    acc.count++
+                }
+            }
+
+            AggFn.MIN -> {
+                if (value !is SqlValue.Null) {
+                    if (acc.sum is SqlValue.Null || sqlCompare(value, acc.sum) < 0) {
+                        acc.sum = value
+                    }
+                }
+            }
+
+            AggFn.MAX -> {
+                if (value !is SqlValue.Null) {
+                    if (acc.sum is SqlValue.Null || sqlCompare(value, acc.sum) > 0) {
+                        acc.sum = value
+                    }
+                }
+            }
+        }
+    }
+
+    /** Add two non-null SQL numeric values (used by SUM / AVG accumulation). */
+    private fun addSqlValues(a: SqlValue, b: SqlValue): SqlValue {
+        val aNum = toNumber(a) ?: return b
+        val bNum = toNumber(b) ?: return a
+        return if (a is SqlValue.FloatVal || b is SqlValue.FloatVal) {
+            SqlValue.FloatVal(aNum.toDouble() + bNum.toDouble())
+        } else {
+            SqlValue.IntVal(aNum.toLong() + bNum.toLong())
+        }
+    }
+
+    /**
+     * FinalizeAgg: compute the final aggregate value and push it.
+     *
+     * Called during the finalize (group-emit) phase.  The current group key
+     * is already set by [doAdvanceGroup].
+     */
+    private fun doFinalizeAgg(instr: Instruction.FinalizeAgg, state: VmState) {
+        // Auto-grow: if InitAgg was never called for this group (happens when
+        // the table is empty and GROUP BY emits one implicit group), create a
+        // default-zeroed accumulator.
+        val slots = ensureGroup(state)
+        while (slots.size <= instr.index) {
+            slots.add(AggAccumulator(fn = instr.fn))
+        }
+        val acc = slots[instr.index]
+
+        val result: SqlValue = when (acc.fn) {
+            AggFn.COUNT, AggFn.COUNT_STAR -> SqlValue.IntVal(acc.count)
+            AggFn.SUM   -> acc.sum                  // NULL if no non-null inputs
+            AggFn.AVG   -> {
+                if (acc.count == 0L) SqlValue.Null
+                else {
+                    val s = toNumber(acc.sum)?.toDouble() ?: 0.0
+                    SqlValue.FloatVal(s / acc.count.toDouble())
+                }
+            }
+            AggFn.MIN, AggFn.MAX -> acc.sum         // NULL if no non-null inputs
+        }
+        state.push(result)
+    }
+
+    /**
+     * AdvanceGroup: move to the next accumulated group for the finalize phase.
+     *
+     * Increments the group iterator.  If all groups have been emitted, this
+     * instruction must jump to a "done" label — but the codegen doesn't embed
+     * the label in [Instruction.AdvanceGroup].  Instead, the codegen structure is:
+     *
+     *   Label("agg_N_finalize")
+     *   AdvanceGroup          ← we increment groupIter here
+     *   BeginRow
+     *   LoadGroupKey(0) ... FinalizeAgg ... EmitRow
+     *   Jump("agg_N_finalize")
+     *   Label("agg_N_done")
+     *
+     * The exhaustion check is handled by the pattern: after AdvanceGroup the VM
+     * sets groupKey to the next group's key.  If there are no more groups, we
+     * need to jump past the finalize loop.
+     *
+     * To accomplish this without a label in the AdvanceGroup instruction, we
+     * scan ahead to find the matching Jump-back instruction and skip past it
+     * (jumping to the label after the finalize loop).
+     *
+     * Simpler alternative: look at the instruction stream and find the Label
+     * that follows the finalize loop's closing Jump.  This is deterministic
+     * because the codegen always emits:
+     *
+     *   Label("agg_N_finalize")   ← labelIndex maps this to some index I
+     *   AdvanceGroup              ← current pc-1
+     *   BeginRow
+     *   ...
+     *   EmitRow
+     *   Jump("agg_N_finalize")    ← jumps back to I
+     *   Label("agg_N_done")       ← THIS is where we jump on exhaustion
+     *
+     * We find "agg_N_done" by scanning forward from pc for the first Label
+     * instruction after a Jump that targets the finalize label.
+     */
+    private fun doAdvanceGroup(instr: Instruction.AdvanceGroup, state: VmState) {
+        @Suppress("UNUSED_PARAMETER") val _unused = instr
+        state.groupIter++
+
+        // SQL standard: a global aggregate (no GROUP BY) over an empty table
+        // must emit exactly one row of NULL/zero values.  Detect this by
+        // checking whether the implicit empty-key group was ever added.
+        if (state.groupIter == 0 && state.groupOrder.isEmpty()) {
+            // Synthesise the implicit single-group with no accumulated rows.
+            state.groupOrder.add(emptyList())
+            state.aggTable[emptyList()] = mutableListOf()
+        }
+
+        if (state.groupIter >= state.groupOrder.size) {
+            // All groups emitted — jump past the finalize loop.
+            // Find the Label instruction that comes after the next backward Jump.
+            val targetPc = findGroupDoneLabel(state)
+            state.pc = targetPc
+        } else {
+            state.groupKey = state.groupOrder[state.groupIter]
+        }
+    }
+
+    /**
+     * Scan forward from the current [VmState.pc] to find the instruction index
+     * that the finalize loop should jump to on exhaustion.
+     *
+     * The codegen emits:
+     *   AdvanceGroup         ← state.pc - 1 (we've already incremented)
+     *   ...body...
+     *   Jump("agg_N_finalize")
+     *   Label("agg_N_done") ← this is the target
+     *
+     * We look for the first Jump instruction followed immediately by a Label.
+     */
+    private fun findGroupDoneLabel(state: VmState): Int {
+        val instrs = state.instructions
+        var i = state.pc
+        while (i < instrs.size) {
+            val curr = instrs[i]
+            if (curr is Instruction.Jump) {
+                // Found the closing Jump.  The instruction after it is the done label.
+                val next = i + 1
+                if (next < instrs.size && instrs[next] is Instruction.Label) {
+                    return next + 1  // skip the Label itself (it's a no-op)
+                }
+                // No Label follows — jump to end.
+                return instrs.size
+            }
+            i++
+        }
+        return instrs.size
+    }
+
+    // ── DML ───────────────────────────────────────────────────────────────────
+
+    /**
+     * InsertRow: pop values for each column and insert a row into the backend.
+     *
+     * If [instr.columns] is non-null, values are mapped positionally to column
+     * names.  If null, the backend uses its schema column order.
+     */
+    private fun doInsert(instr: Instruction.InsertRow, state: VmState) {
+        val columns = instr.columns
+        val row = Row()
+        if (columns != null) {
+            val values = state.popN(columns.size)
+            for ((i, col) in columns.withIndex()) {
+                row[col] = sqlValueToBackend(values[i])
+            }
+        } else {
+            // Determine column count from the backend schema.
+            val colDefs = try { state.backend.columns(instr.table) } catch (e: Exception) { emptyList<ColumnDef>() }
+            val values = state.popN(colDefs.size)
+            for ((i, cd) in colDefs.withIndex()) {
+                row[cd.name] = sqlValueToBackend(values[i])
+            }
+        }
+        state.backend.insert(instr.table, row)
+        state.rowsAffected++
+    }
+
+    /**
+     * UpdateRows: update the current cursor row with the assignment expressions.
+     *
+     * The assignment column names come from the plan (stored in the UpdateRows
+     * instruction's context).  The codegen pushes one value per assignment
+     * expression before emitting UpdateRows.
+     *
+     * Since UpdateRows doesn't carry the column list in the Instruction, we
+     * read the schema and map positionally — the codegen emits values in schema
+     * order for UPDATE.  This matches the C# and Python references.
+     */
+    private fun doUpdate(instr: Instruction.UpdateRows, state: VmState) {
+        // The cursor for UPDATE is always the anonymous (null) cursor.
+        val cursor = state.cursors[null]
+        if (cursor !is Cursor) return
+        // Get column count from the schema to know how many values to pop.
+        val colDefs = try { state.backend.columns(instr.table) } catch (e: Exception) { emptyList<ColumnDef>() }
+        val values = state.popN(colDefs.size)
+        val assignments = LinkedHashMap<String, Any?>()
+        for ((i, cd) in colDefs.withIndex()) {
+            assignments[cd.name] = sqlValueToBackend(values[i])
+        }
+        state.backend.update(instr.table, cursor, assignments)
+        state.rowsAffected++
+    }
+
+    /**
+     * DeleteRows: delete the row at the current anonymous cursor position.
+     */
+    private fun doDelete(instr: Instruction.DeleteRows, state: VmState) {
+        val cursor = state.cursors[null]
+        if (cursor !is Cursor) return
+        state.backend.delete(instr.table, cursor)
+        state.rowsAffected++
+    }
+
+    // ── Post-operation instructions ───────────────────────────────────────────
+    //
+    // These operate on the completed result buffer *after* all EmitRow
+    // instructions have fired.  The codegen emits them just before Halt.
+
+    /**
+     * SortResult: sort the result buffer in-place.
+     *
+     * Each sort key carries:
+     *   - expression (used by codegen; the VM sorts by column name at Level 1)
+     *   - direction (ASC or DESC)
+     *   - nullsOrder (FIRST or LAST)
+     *
+     * We sort the result rows list directly (Kotlin's sort is stable, so equal
+     * keys preserve their insertion order — matching SQL's stable-sort guarantee).
+     *
+     * The SortKey from sql-planner carries:
+     *   - keyExpr: SqlExpr  — usually a Column reference; we evaluate it against the row
+     *   - direction: SortDir — ASC or DESC
+     *   - nullOrder: NullOrder — NULLS_FIRST or NULLS_LAST
+     */
+    private fun doSortResult(instr: Instruction.SortResult, state: VmState) {
+        if (state.resultRows.isEmpty() || instr.keys.isEmpty()) return
+
+        // Build column-name → position map from the first row's column list.
+        val colIndex: Map<String, Int> = buildColIndex(state)
+
+        state.resultRows.sortWith(Comparator { rowA, rowB ->
+            for (key in instr.keys) {
+                // Evaluate the key expression against both rows.
+                // For a Column reference, look up by column name in the result row.
+                // For other expressions, we fall back to NULL (can't re-evaluate
+                // arbitrary expressions without a full mini-interpreter here).
+                val a = evalSortKeyExpr(key.keyExpr, rowA, colIndex)
+                val b = evalSortKeyExpr(key.keyExpr, rowB, colIndex)
+
+                val cmp = sortCompare(a, b, key)
+                if (cmp != 0) return@Comparator cmp
+            }
+            0
+        })
+    }
+
+    /**
+     * Evaluate a sort key expression against a result row.
+     *
+     * For simple column references (the common case), we look up by name in
+     * the result row's column list.  For literal constants we return the value
+     * directly.  For other expressions we return NULL (sort key can't be
+     * evaluated without a full execution context at sort time).
+     */
+    private fun evalSortKeyExpr(
+        expr: com.codingadventures.sqlplanner.SqlExpr,
+        row: List<Pair<String, SqlValue>>,
+        colIndex: Map<String, Int>,
+    ): SqlValue = when (expr) {
+        is com.codingadventures.sqlplanner.SqlExpr.Column -> {
+            val idx = colIndex[expr.column.lowercase()]
+            row.getOrNull(idx ?: -1)?.second ?: SqlValue.Null
+        }
+        is com.codingadventures.sqlplanner.SqlExpr.Literal -> {
+            when (val v = expr.value) {
+                null       -> SqlValue.Null
+                is Long    -> SqlValue.IntVal(v)
+                is Int     -> SqlValue.IntVal(v.toLong())
+                is Double  -> SqlValue.FloatVal(v)
+                is Boolean -> SqlValue.BoolVal(v)
+                is String  -> SqlValue.TextVal(v)
+                else       -> SqlValue.TextVal(v.toString())
+            }
+        }
+        else -> SqlValue.Null
+    }
+
+    /**
+     * Compare two values for ORDER BY, respecting direction and NULL placement.
+     *
+     * Uses the actual sql-planner types:
+     *   - SortDir.ASC / SortDir.DESC
+     *   - NullOrder.NULLS_FIRST / NullOrder.NULLS_LAST
+     */
+    private fun sortCompare(
+        a: SqlValue,
+        b: SqlValue,
+        key: com.codingadventures.sqlplanner.SortKey,
+    ): Int {
+        // NULL placement.
+        val aNull = a is SqlValue.Null
+        val bNull = b is SqlValue.Null
+        if (aNull && bNull) return 0
+        val nullsFirst = key.nullOrder == com.codingadventures.sqlplanner.NullOrder.NULLS_FIRST
+        if (aNull) return if (nullsFirst) -1 else 1
+        if (bNull) return if (nullsFirst) 1 else -1
+
+        val cmp = sqlCompare(a, b)
+        return if (key.direction == com.codingadventures.sqlplanner.SortDir.DESC) -cmp else cmp
+    }
+
+    /**
+     * Build a column-name → position map from the current result rows.
+     *
+     * We look at the column names in the first result row (if any).
+     */
+    private fun buildColIndex(state: VmState): Map<String, Int> {
+        val first = state.resultRows.firstOrNull() ?: return emptyMap()
+        return first.mapIndexed { i, (name, _) -> name.lowercase() to i }.toMap()
+    }
+
+    /**
+     * DistinctResult: remove duplicate rows from the result buffer.
+     *
+     * Two rows are duplicates if every column value is SQL-equal.  For
+     * deduplication, NULL == NULL (unlike regular SQL equality).
+     */
+    private fun doDistinctResult(state: VmState) {
+        val seen = linkedSetOf<List<SqlValue>>()
+        state.resultRows.retainAll { row ->
+            val key = row.map { (_, v) -> v }
+            seen.add(key)
+        }
+    }
+
+    /**
+     * LimitResult: apply OFFSET then LIMIT to the result buffer.
+     *
+     * - [offset] rows are skipped (default 0).
+     * - At most [count] rows are kept (null = unlimited).
+     */
+    private fun doLimitResult(instr: Instruction.LimitResult, state: VmState) {
+        // Clamp the offset to [0, Int.MAX_VALUE] before narrowing to Int.
+        // A raw `.toInt()` on a Long > Int.MAX_VALUE silently overflows to a
+        // negative number, which would corrupt subList indices.
+        val start = (instr.offset ?: 0L)
+            .coerceAtLeast(0L)
+            .coerceAtMost(Int.MAX_VALUE.toLong())
+            .toInt()
+        val count = instr.count
+
+        val sliced = if (start >= state.resultRows.size) {
+            emptyList()
+        } else {
+            state.resultRows.subList(start, state.resultRows.size)
+        }
+
+        val limited = if (count == null) {
+            sliced.toList()
+        } else {
+            // Clamp count to [0, Int.MAX_VALUE] before narrowing for the same reason.
+            val safeCount = count
+                .coerceAtLeast(0L)
+                .coerceAtMost(Int.MAX_VALUE.toLong())
+                .toInt()
+            sliced.take(safeCount)
+        }
+
+        state.resultRows.clear()
+        state.resultRows.addAll(limited)
+    }
+
+    // ── DDL helpers ───────────────────────────────────────────────────────────
+
+    /**
+     * Convert a sql-planner [PlannerColumnDef] to a sql-backend [ColumnDef].
+     *
+     * The two types are structurally identical except for the `default` field:
+     *   - sql-planner carries `default: SqlExpr?` (an AST node)
+     *   - sql-backend carries `defaultValue: Any?` + `hasDefault: Boolean` (a raw value)
+     *
+     * For level-1 we only extract literal defaults; any non-literal SqlExpr
+     * default is dropped (rare and out-of-scope for the VM layer).  The backend
+     * enforces constraints itself so we just pass through the flags.
+     */
+    private fun convertColumnDef(src: PlannerColumnDef): ColumnDef {
+        val (defaultValue, hasDefault) = when (val d = src.default) {
+            null -> null to false
+            is PlannerSqlExpr.Literal -> d.value to true
+            else -> null to false   // non-literal default: drop (unsupported at L1)
+        }
+        return ColumnDef(
+            name          = src.name,
+            typeName      = src.typeName,
+            notNull       = src.notNull,
+            primaryKey    = src.primaryKey,
+            unique        = src.unique,
+            defaultValue  = defaultValue,
+            hasDefault    = hasDefault,
+        )
+    }
+
+    // ── Result construction ───────────────────────────────────────────────────
+
+    /**
+     * Convert the accumulated [VmState] into a [QueryResult].
+     *
+     * The result rows were stored as `List<Pair<String, SqlValue>>` during
+     * execution (column name + value).  Here we extract the column names
+     * (from the first row, or an empty list) and package everything up.
+     */
+    private fun buildResult(state: VmState): QueryResult {
+        val firstRow = state.resultRows.firstOrNull()
+        val columns = firstRow?.map { (name, _) -> name } ?: emptyList()
+        val rows = state.resultRows.map { row -> row.map { (_, v) -> v } }
+        return QueryResult(
+            columns = columns,
+            rows    = rows,
+            rowsAffected = state.rowsAffected,
+        )
+    }
+}

--- a/code/packages/kotlin/sql-vm/src/test/kotlin/com/codingadventures/sqlvm/SqlVmTest.kt
+++ b/code/packages/kotlin/sql-vm/src/test/kotlin/com/codingadventures/sqlvm/SqlVmTest.kt
@@ -1,0 +1,1686 @@
+package com.codingadventures.sqlvm
+
+// SqlVmTest.kt — Comprehensive tests for the Kotlin sql-vm package.
+//
+// Test philosophy
+// ───────────────
+// Rather than mocking the codegen, we build Program objects by hand — exactly
+// the way the codegen would.  This keeps tests fast and verifiable by inspection:
+// you can read the instruction sequence and reason about what the VM should do.
+//
+// Organisation
+// ────────────
+// Tests are grouped by instruction category.  Each group starts with a comment
+// explaining what is being tested and why the expected result is what it is.
+//
+// Coverage goals (lessons.md §>80% test coverage):
+//   - All Instruction variants
+//   - Three-valued NULL logic (AND / OR / comparisons)
+//   - Aggregate functions: COUNT, COUNT(*), SUM, AVG, MIN, MAX
+//   - GROUP BY with multiple groups
+//   - ORDER BY (ASC / DESC / NULLS FIRST / NULLS LAST)
+//   - DISTINCT
+//   - LIMIT / OFFSET
+//   - LIKE matching
+//   - IN list (including NULL semantics)
+//   - BETWEEN
+//   - DML: INSERT, UPDATE, DELETE
+//   - DDL: CREATE TABLE, DROP TABLE
+//   - Transactions: BEGIN, COMMIT, ROLLBACK
+//   - Stack operations: LoadConst, Pop
+//   - BinaryOp all operators
+//   - UnaryOp: NEG, NOT
+//
+// Note: test method names in backticks must NOT contain "--", ":", or other
+// JVM-illegal characters (lessons.md §Kotlin-specific notes).
+
+import com.codingadventures.sqlbackend.ColumnDef
+import com.codingadventures.sqlbackend.InMemoryBackend
+import com.codingadventures.sqlplanner.ColumnDef as PlannerColumnDef
+import com.codingadventures.sqlbackend.Row
+import com.codingadventures.sqlcodegen.AggFn
+import com.codingadventures.sqlcodegen.BinaryOp
+import com.codingadventures.sqlcodegen.Instruction
+import com.codingadventures.sqlcodegen.Program
+import com.codingadventures.sqlcodegen.SqlValue
+import com.codingadventures.sqlcodegen.UnaryOp
+import com.codingadventures.sqlplanner.NullOrder
+import com.codingadventures.sqlplanner.SortDir
+import com.codingadventures.sqlplanner.SortKey
+import com.codingadventures.sqlplanner.SqlExpr
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helper functions
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Build a [Program] from a vararg list of [Instruction]s. */
+private fun prog(vararg instrs: Instruction): Program = Program(instrs.toList())
+
+/** Shorthand: integer SQL literal. */
+private fun int(v: Long) = SqlValue.IntVal(v)
+private fun int(v: Int)  = SqlValue.IntVal(v.toLong())
+
+/** Shorthand: text SQL literal. */
+private fun txt(v: String) = SqlValue.TextVal(v)
+
+/** Shorthand: float SQL literal. */
+private fun flt(v: Double) = SqlValue.FloatVal(v)
+
+/** Shorthand: boolean SQL literal. */
+private fun bool(v: Boolean) = SqlValue.BoolVal(v)
+
+/** SQL NULL literal. */
+private val NULL = SqlValue.Null
+
+/** Create a backend pre-populated with a simple "users" table. */
+private fun backendWithUsers(vararg rows: Map<String, Any?>): InMemoryBackend {
+    val backend = InMemoryBackend()
+    backend.createTable(
+        "users",
+        listOf(
+            ColumnDef("id",   "INTEGER"),
+            ColumnDef("name", "TEXT"),
+            ColumnDef("age",  "INTEGER"),
+        ),
+        ifNotExists = false,
+    )
+    for (rowMap in rows) {
+        val row = Row()
+        rowMap.forEach { (k, v) -> row[k] = v }
+        backend.insert("users", row)
+    }
+    return backend
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test class
+// ─────────────────────────────────────────────────────────────────────────────
+
+class SqlVmTest {
+
+    private lateinit var backend: InMemoryBackend
+
+    @BeforeEach
+    fun setUp() {
+        // Fresh backend for each test — no shared mutable state.
+        backend = InMemoryBackend()
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Basic LoadConst and Halt
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `empty program returns empty result`() {
+        val result = SqlVm.execute(prog(Instruction.Halt), backend)
+        assertTrue(result.rows.isEmpty())
+        assertTrue(result.columns.isEmpty())
+        assertEquals(0, result.rowsAffected)
+    }
+
+    @Test
+    fun `LoadConst integer pushes value onto stack`() {
+        // A program that loads a constant and emits it as a single-column row.
+        val result = SqlVm.execute(
+            prog(
+                Instruction.BeginRow,
+                Instruction.LoadConst(int(42)),
+                Instruction.EmitColumn("val"),
+                Instruction.EmitRow,
+                Instruction.Halt,
+            ),
+            backend,
+        )
+        assertEquals(listOf("val"), result.columns)
+        assertEquals(1, result.rows.size)
+        assertEquals(int(42), result.rows[0][0])
+    }
+
+    @Test
+    fun `LoadConst text value`() {
+        val result = SqlVm.execute(
+            prog(
+                Instruction.BeginRow,
+                Instruction.LoadConst(txt("hello")),
+                Instruction.EmitColumn("greeting"),
+                Instruction.EmitRow,
+                Instruction.Halt,
+            ),
+            backend,
+        )
+        assertEquals(txt("hello"), result.rows[0][0])
+    }
+
+    @Test
+    fun `LoadConst NULL value`() {
+        val result = SqlVm.execute(
+            prog(
+                Instruction.BeginRow,
+                Instruction.LoadConst(NULL),
+                Instruction.EmitColumn("n"),
+                Instruction.EmitRow,
+                Instruction.Halt,
+            ),
+            backend,
+        )
+        assertEquals(NULL, result.rows[0][0])
+    }
+
+    @Test
+    fun `Pop discards top of stack`() {
+        // Push two values, pop one, emit the remaining value.
+        val result = SqlVm.execute(
+            prog(
+                Instruction.BeginRow,
+                Instruction.LoadConst(int(99)),
+                Instruction.LoadConst(int(1)),
+                Instruction.Pop,                    // discard 1; 99 is now on top
+                Instruction.EmitColumn("v"),
+                Instruction.EmitRow,
+                Instruction.Halt,
+            ),
+            backend,
+        )
+        assertEquals(int(99), result.rows[0][0])
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Arithmetic binary operators
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `BinaryOp ADD integers`() {
+        val r = evalExpr(Instruction.LoadConst(int(3)), Instruction.LoadConst(int(4)), Instruction.BinaryOpInstr(BinaryOp.ADD))
+        assertEquals(int(7), r)
+    }
+
+    @Test
+    fun `BinaryOp SUB integers`() {
+        val r = evalExpr(Instruction.LoadConst(int(10)), Instruction.LoadConst(int(3)), Instruction.BinaryOpInstr(BinaryOp.SUB))
+        assertEquals(int(7), r)
+    }
+
+    @Test
+    fun `BinaryOp MUL integers`() {
+        val r = evalExpr(Instruction.LoadConst(int(6)), Instruction.LoadConst(int(7)), Instruction.BinaryOpInstr(BinaryOp.MUL))
+        assertEquals(int(42), r)
+    }
+
+    @Test
+    fun `BinaryOp DIV integer`() {
+        val r = evalExpr(Instruction.LoadConst(int(10)), Instruction.LoadConst(int(3)), Instruction.BinaryOpInstr(BinaryOp.DIV))
+        assertEquals(int(3), r)  // integer division truncates
+    }
+
+    @Test
+    fun `BinaryOp DIV by zero returns NULL`() {
+        val r = evalExpr(Instruction.LoadConst(int(5)), Instruction.LoadConst(int(0)), Instruction.BinaryOpInstr(BinaryOp.DIV))
+        assertEquals(NULL, r)
+    }
+
+    @Test
+    fun `BinaryOp MOD`() {
+        val r = evalExpr(Instruction.LoadConst(int(10)), Instruction.LoadConst(int(3)), Instruction.BinaryOpInstr(BinaryOp.MOD))
+        assertEquals(int(1), r)
+    }
+
+    @Test
+    fun `BinaryOp ADD with float promotes to float`() {
+        val r = evalExpr(Instruction.LoadConst(int(3)), Instruction.LoadConst(flt(1.5)), Instruction.BinaryOpInstr(BinaryOp.ADD))
+        assertEquals(flt(4.5), r)
+    }
+
+    @Test
+    fun `BinaryOp with NULL propagates NULL`() {
+        val r = evalExpr(Instruction.LoadConst(NULL), Instruction.LoadConst(int(5)), Instruction.BinaryOpInstr(BinaryOp.ADD))
+        assertEquals(NULL, r)
+    }
+
+    @Test
+    fun `BinaryOp CONCAT strings`() {
+        val r = evalExpr(Instruction.LoadConst(txt("foo")), Instruction.LoadConst(txt("bar")), Instruction.BinaryOpInstr(BinaryOp.CONCAT))
+        assertEquals(txt("foobar"), r)
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Comparison operators
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `BinaryOp EQ true`() {
+        val r = evalExpr(Instruction.LoadConst(int(5)), Instruction.LoadConst(int(5)), Instruction.BinaryOpInstr(BinaryOp.EQ))
+        assertEquals(bool(true), r)
+    }
+
+    @Test
+    fun `BinaryOp EQ false`() {
+        val r = evalExpr(Instruction.LoadConst(int(5)), Instruction.LoadConst(int(6)), Instruction.BinaryOpInstr(BinaryOp.EQ))
+        assertEquals(bool(false), r)
+    }
+
+    @Test
+    fun `BinaryOp NEQ`() {
+        val r = evalExpr(Instruction.LoadConst(int(5)), Instruction.LoadConst(int(6)), Instruction.BinaryOpInstr(BinaryOp.NEQ))
+        assertEquals(bool(true), r)
+    }
+
+    @Test
+    fun `BinaryOp LT`() {
+        val r = evalExpr(Instruction.LoadConst(int(3)), Instruction.LoadConst(int(5)), Instruction.BinaryOpInstr(BinaryOp.LT))
+        assertEquals(bool(true), r)
+    }
+
+    @Test
+    fun `BinaryOp LTE equal`() {
+        val r = evalExpr(Instruction.LoadConst(int(5)), Instruction.LoadConst(int(5)), Instruction.BinaryOpInstr(BinaryOp.LTE))
+        assertEquals(bool(true), r)
+    }
+
+    @Test
+    fun `BinaryOp GT`() {
+        val r = evalExpr(Instruction.LoadConst(int(7)), Instruction.LoadConst(int(3)), Instruction.BinaryOpInstr(BinaryOp.GT))
+        assertEquals(bool(true), r)
+    }
+
+    @Test
+    fun `BinaryOp GTE`() {
+        val r = evalExpr(Instruction.LoadConst(int(5)), Instruction.LoadConst(int(5)), Instruction.BinaryOpInstr(BinaryOp.GTE))
+        assertEquals(bool(true), r)
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Three-valued logic: AND / OR
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `AND true and true is true`() {
+        val r = evalBinaryConst(bool(true), bool(true), BinaryOp.AND)
+        assertEquals(bool(true), r)
+    }
+
+    @Test
+    fun `AND true and false is false`() {
+        val r = evalBinaryConst(bool(true), bool(false), BinaryOp.AND)
+        assertEquals(bool(false), r)
+    }
+
+    @Test
+    fun `AND false and NULL is false`() {
+        // SQL: FALSE AND NULL = FALSE (because FALSE dominates AND)
+        val r = evalBinaryConst(bool(false), NULL, BinaryOp.AND)
+        assertEquals(bool(false), r)
+    }
+
+    @Test
+    fun `AND true and NULL is NULL`() {
+        val r = evalBinaryConst(bool(true), NULL, BinaryOp.AND)
+        assertEquals(NULL, r)
+    }
+
+    @Test
+    fun `OR true and NULL is true`() {
+        // SQL: TRUE OR NULL = TRUE (because TRUE dominates OR)
+        val r = evalBinaryConst(bool(true), NULL, BinaryOp.OR)
+        assertEquals(bool(true), r)
+    }
+
+    @Test
+    fun `OR false and NULL is NULL`() {
+        val r = evalBinaryConst(bool(false), NULL, BinaryOp.OR)
+        assertEquals(NULL, r)
+    }
+
+    @Test
+    fun `OR false and false is false`() {
+        val r = evalBinaryConst(bool(false), bool(false), BinaryOp.OR)
+        assertEquals(bool(false), r)
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Unary operators
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `UnaryOp NEG integer`() {
+        val r = evalUnary(int(5), UnaryOp.NEG)
+        assertEquals(int(-5), r)
+    }
+
+    @Test
+    fun `UnaryOp NEG NULL is NULL`() {
+        val r = evalUnary(NULL, UnaryOp.NEG)
+        assertEquals(NULL, r)
+    }
+
+    @Test
+    fun `UnaryOp NOT true is false`() {
+        val r = evalUnary(bool(true), UnaryOp.NOT)
+        assertEquals(bool(false), r)
+    }
+
+    @Test
+    fun `UnaryOp NOT false is true`() {
+        val r = evalUnary(bool(false), UnaryOp.NOT)
+        assertEquals(bool(true), r)
+    }
+
+    @Test
+    fun `UnaryOp NOT NULL is NULL`() {
+        val r = evalUnary(NULL, UnaryOp.NOT)
+        assertEquals(NULL, r)
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // IsNull / IsNotNull
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `IsNull pushes true for NULL`() {
+        val r = evalExpr(Instruction.LoadConst(NULL), Instruction.IsNull)
+        assertEquals(bool(true), r)
+    }
+
+    @Test
+    fun `IsNull pushes false for integer`() {
+        val r = evalExpr(Instruction.LoadConst(int(0)), Instruction.IsNull)
+        assertEquals(bool(false), r)
+    }
+
+    @Test
+    fun `IsNotNull pushes false for NULL`() {
+        val r = evalExpr(Instruction.LoadConst(NULL), Instruction.IsNotNull)
+        assertEquals(bool(false), r)
+    }
+
+    @Test
+    fun `IsNotNull pushes true for text`() {
+        val r = evalExpr(Instruction.LoadConst(txt("hello")), Instruction.IsNotNull)
+        assertEquals(bool(true), r)
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // BETWEEN
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `BETWEEN true when value in range`() {
+        // value=5, low=1, high=10  → TRUE
+        val r = evalExpr(
+            Instruction.LoadConst(int(5)),
+            Instruction.LoadConst(int(1)),
+            Instruction.LoadConst(int(10)),
+            Instruction.Between(),
+        )
+        assertEquals(bool(true), r)
+    }
+
+    @Test
+    fun `BETWEEN false when value below range`() {
+        val r = evalExpr(
+            Instruction.LoadConst(int(0)),
+            Instruction.LoadConst(int(1)),
+            Instruction.LoadConst(int(10)),
+            Instruction.Between(),
+        )
+        assertEquals(bool(false), r)
+    }
+
+    @Test
+    fun `BETWEEN true at boundary`() {
+        val r = evalExpr(
+            Instruction.LoadConst(int(1)),
+            Instruction.LoadConst(int(1)),
+            Instruction.LoadConst(int(10)),
+            Instruction.Between(),
+        )
+        assertEquals(bool(true), r)
+    }
+
+    @Test
+    fun `BETWEEN NULL propagates NULL`() {
+        val r = evalExpr(
+            Instruction.LoadConst(NULL),
+            Instruction.LoadConst(int(1)),
+            Instruction.LoadConst(int(10)),
+            Instruction.Between(),
+        )
+        assertEquals(NULL, r)
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // LIKE
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `LIKE percent matches any sequence`() {
+        // "hello" LIKE "hel%" → TRUE
+        val r = evalExpr(
+            Instruction.LoadConst(txt("hello")),
+            Instruction.LoadConst(txt("hel%")),
+            Instruction.Like,
+        )
+        assertEquals(bool(true), r)
+    }
+
+    @Test
+    fun `LIKE underscore matches single char`() {
+        val r = evalExpr(
+            Instruction.LoadConst(txt("cat")),
+            Instruction.LoadConst(txt("c_t")),
+            Instruction.Like,
+        )
+        assertEquals(bool(true), r)
+    }
+
+    @Test
+    fun `LIKE no match`() {
+        val r = evalExpr(
+            Instruction.LoadConst(txt("dog")),
+            Instruction.LoadConst(txt("cat%")),
+            Instruction.Like,
+        )
+        assertEquals(bool(false), r)
+    }
+
+    @Test
+    fun `LIKE NULL value returns NULL`() {
+        val r = evalExpr(
+            Instruction.LoadConst(NULL),
+            Instruction.LoadConst(txt("foo%")),
+            Instruction.Like,
+        )
+        assertEquals(NULL, r)
+    }
+
+    @Test
+    fun `LIKE is case insensitive`() {
+        val r = evalExpr(
+            Instruction.LoadConst(txt("Hello")),
+            Instruction.LoadConst(txt("hello")),
+            Instruction.Like,
+        )
+        assertEquals(bool(true), r)
+    }
+
+    @Test
+    fun `likeMatch helper percent at start`() {
+        assertTrue(SqlVm.likeMatch("the end", "%end"))
+    }
+
+    @Test
+    fun `likeMatch helper exact match`() {
+        assertTrue(SqlVm.likeMatch("abc", "abc"))
+    }
+
+    @Test
+    fun `likeMatch helper no match`() {
+        assertFalse(SqlVm.likeMatch("abc", "xyz%"))
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // IN list
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `InList found in list returns true`() {
+        val r = evalExpr(
+            Instruction.LoadConst(int(2)),
+            Instruction.LoadConst(int(1)),
+            Instruction.LoadConst(int(2)),
+            Instruction.LoadConst(int(3)),
+            Instruction.InList(3),
+        )
+        assertEquals(bool(true), r)
+    }
+
+    @Test
+    fun `InList not found returns false`() {
+        val r = evalExpr(
+            Instruction.LoadConst(int(99)),
+            Instruction.LoadConst(int(1)),
+            Instruction.LoadConst(int(2)),
+            Instruction.InList(2),
+        )
+        assertEquals(bool(false), r)
+    }
+
+    @Test
+    fun `InList empty list returns false`() {
+        val r = evalExpr(
+            Instruction.LoadConst(int(5)),
+            Instruction.InList(0),
+        )
+        assertEquals(bool(false), r)
+    }
+
+    @Test
+    fun `InList NULL needle returns NULL`() {
+        val r = evalExpr(
+            Instruction.LoadConst(NULL),
+            Instruction.LoadConst(int(1)),
+            Instruction.InList(1),
+        )
+        assertEquals(NULL, r)
+    }
+
+    @Test
+    fun `InList not found but NULL in list returns NULL`() {
+        val r = evalExpr(
+            Instruction.LoadConst(int(5)),
+            Instruction.LoadConst(int(1)),
+            Instruction.LoadConst(NULL),
+            Instruction.InList(2),
+        )
+        assertEquals(NULL, r)
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Scan / cursor — SELECT from table
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `scan empty table returns no rows`() {
+        backend.createTable("t", listOf(ColumnDef("x", "INTEGER")), ifNotExists = false)
+
+        val result = SqlVm.execute(
+            prog(
+                Instruction.OpenScan("t", "t"),
+                Instruction.Label("loop"),
+                Instruction.AdvanceCursor("t", "end"),
+                Instruction.BeginRow,
+                Instruction.LoadColumn("t", "x"),
+                Instruction.EmitColumn("x"),
+                Instruction.EmitRow,
+                Instruction.Jump("loop"),
+                Instruction.Label("end"),
+                Instruction.CloseScan("t"),
+                Instruction.Halt,
+            ),
+            backend,
+        )
+        assertTrue(result.rows.isEmpty())
+    }
+
+    @Test
+    fun `scan table with rows returns all rows`() {
+        backend = backendWithUsers(
+            mapOf("id" to 1L, "name" to "Alice", "age" to 30L),
+            mapOf("id" to 2L, "name" to "Bob",   "age" to 25L),
+        )
+
+        val result = SqlVm.execute(
+            prog(
+                Instruction.OpenScan("users", "users"),
+                Instruction.Label("loop"),
+                Instruction.AdvanceCursor("users", "end"),
+                Instruction.BeginRow,
+                Instruction.LoadColumn("users", "id"),
+                Instruction.EmitColumn("id"),
+                Instruction.LoadColumn("users", "name"),
+                Instruction.EmitColumn("name"),
+                Instruction.EmitRow,
+                Instruction.Jump("loop"),
+                Instruction.Label("end"),
+                Instruction.CloseScan("users"),
+                Instruction.Halt,
+            ),
+            backend,
+        )
+
+        assertEquals(2, result.rows.size)
+        assertEquals(listOf("id", "name"), result.columns)
+        assertEquals(int(1), result.rows[0][0])
+        assertEquals(txt("Alice"), result.rows[0][1])
+        assertEquals(int(2), result.rows[1][0])
+        assertEquals(txt("Bob"), result.rows[1][1])
+    }
+
+    @Test
+    fun `scan with filter skips non-matching rows`() {
+        backend = backendWithUsers(
+            mapOf("id" to 1L, "name" to "Alice", "age" to 30L),
+            mapOf("id" to 2L, "name" to "Bob",   "age" to 25L),
+            mapOf("id" to 3L, "name" to "Carol",  "age" to 35L),
+        )
+
+        // SELECT id FROM users WHERE age > 28
+        val result = SqlVm.execute(
+            prog(
+                Instruction.OpenScan("users", "users"),
+                Instruction.Label("loop"),
+                Instruction.AdvanceCursor("users", "end"),
+                // age > 28
+                Instruction.LoadColumn("users", "age"),
+                Instruction.LoadConst(int(28)),
+                Instruction.BinaryOpInstr(BinaryOp.GT),
+                Instruction.JumpIfFalse("skip"),
+                // emit
+                Instruction.BeginRow,
+                Instruction.LoadColumn("users", "id"),
+                Instruction.EmitColumn("id"),
+                Instruction.EmitRow,
+                Instruction.Label("skip"),
+                Instruction.Jump("loop"),
+                Instruction.Label("end"),
+                Instruction.CloseScan("users"),
+                Instruction.Halt,
+            ),
+            backend,
+        )
+
+        // Alice (30) and Carol (35) pass the filter; Bob (25) does not.
+        assertEquals(2, result.rows.size)
+        assertEquals(int(1), result.rows[0][0])
+        assertEquals(int(3), result.rows[1][0])
+    }
+
+    @Test
+    fun `LoadColumn returns NULL for missing column`() {
+        backend.createTable("t", listOf(ColumnDef("x", "INTEGER")), ifNotExists = false)
+        val row = Row(); row["x"] = 1L
+        backend.insert("t", row)
+
+        val result = SqlVm.execute(
+            prog(
+                Instruction.OpenScan("t", "t"),
+                Instruction.Label("loop"),
+                Instruction.AdvanceCursor("t", "end"),
+                Instruction.BeginRow,
+                Instruction.LoadColumn("t", "nonexistent"),
+                Instruction.EmitColumn("v"),
+                Instruction.EmitRow,
+                Instruction.Jump("loop"),
+                Instruction.Label("end"),
+                Instruction.CloseScan("t"),
+                Instruction.Halt,
+            ),
+            backend,
+        )
+        assertEquals(NULL, result.rows[0][0])
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // DDL: CREATE TABLE / DROP TABLE
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `CreateTableInstr creates a table`() {
+        val result = SqlVm.execute(
+            prog(
+                Instruction.CreateTableInstr(
+                    "products",
+                    ifNotExists = false,
+                    columns = listOf(PlannerColumnDef("id", "INTEGER", notNull = false, primaryKey = false, unique = false, default = null), PlannerColumnDef("name", "TEXT", notNull = false, primaryKey = false, unique = false, default = null)),
+                ),
+                Instruction.Halt,
+            ),
+            backend,
+        )
+        assertTrue(result.rows.isEmpty())
+        assertTrue(backend.tables().contains("products"))
+    }
+
+    @Test
+    fun `CreateTableInstr with ifNotExists is idempotent`() {
+        backend.createTable("t", listOf(ColumnDef("x", "INTEGER")), ifNotExists = false)
+        // Should NOT throw even though table exists.
+        SqlVm.execute(
+            prog(
+                Instruction.CreateTableInstr("t", ifNotExists = true, columns = listOf(PlannerColumnDef("x", "INTEGER", notNull = false, primaryKey = false, unique = false, default = null))),
+                Instruction.Halt,
+            ),
+            backend,
+        )
+    }
+
+    @Test
+    fun `DropTableInstr removes a table`() {
+        backend.createTable("t", listOf(ColumnDef("x", "INTEGER")), ifNotExists = false)
+        SqlVm.execute(
+            prog(Instruction.DropTableInstr("t", ifExists = false), Instruction.Halt),
+            backend,
+        )
+        assertFalse(backend.tables().contains("t"))
+    }
+
+    @Test
+    fun `DropTableInstr with ifExists is idempotent`() {
+        // Should NOT throw even though table does not exist.
+        SqlVm.execute(
+            prog(Instruction.DropTableInstr("no_such_table", ifExists = true), Instruction.Halt),
+            backend,
+        )
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // DML: INSERT
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `InsertRow inserts a single row`() {
+        backend.createTable("t", listOf(ColumnDef("x", "INTEGER"), ColumnDef("y", "TEXT")), ifNotExists = false)
+
+        val result = SqlVm.execute(
+            prog(
+                Instruction.LoadConst(int(7)),
+                Instruction.LoadConst(txt("hello")),
+                Instruction.InsertRow("t", listOf("x", "y")),
+                Instruction.Halt,
+            ),
+            backend,
+        )
+
+        assertEquals(1, result.rowsAffected)
+        val rows = backend.scan("t").let {
+            val out = mutableListOf<Row>()
+            while (true) out += it.next() ?: break
+            out
+        }
+        assertEquals(1, rows.size)
+        assertEquals(7L, rows[0]["x"])
+        assertEquals("hello", rows[0]["y"])
+    }
+
+    @Test
+    fun `InsertRow multiple rows`() {
+        backend.createTable("t", listOf(ColumnDef("v", "INTEGER")), ifNotExists = false)
+
+        SqlVm.execute(
+            prog(
+                Instruction.LoadConst(int(1)),
+                Instruction.InsertRow("t", listOf("v")),
+                Instruction.LoadConst(int(2)),
+                Instruction.InsertRow("t", listOf("v")),
+                Instruction.LoadConst(int(3)),
+                Instruction.InsertRow("t", listOf("v")),
+                Instruction.Halt,
+            ),
+            backend,
+        )
+
+        val rows = scanAll(backend, "t")
+        assertEquals(3, rows.size)
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // DML: DELETE
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `DeleteRows removes matching rows`() {
+        backend = backendWithUsers(
+            mapOf("id" to 1L, "name" to "Alice", "age" to 30L),
+            mapOf("id" to 2L, "name" to "Bob",   "age" to 25L),
+        )
+
+        // DELETE FROM users WHERE id = 1
+        SqlVm.execute(
+            prog(
+                Instruction.OpenScan("users", null),
+                Instruction.Label("loop"),
+                Instruction.AdvanceCursor(null, "end"),
+                Instruction.LoadColumn(null, "id"),
+                Instruction.LoadConst(int(1)),
+                Instruction.BinaryOpInstr(BinaryOp.EQ),
+                Instruction.JumpIfFalse("skip"),
+                Instruction.DeleteRows("users"),
+                Instruction.Label("skip"),
+                Instruction.Jump("loop"),
+                Instruction.Label("end"),
+                Instruction.CloseScan(null),
+                Instruction.Halt,
+            ),
+            backend,
+        )
+
+        val remaining = scanAll(backend, "users")
+        assertEquals(1, remaining.size)
+        assertEquals("Bob", remaining[0]["name"])
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Post-processing: LIMIT / OFFSET
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `LimitResult with count limits rows`() {
+        backend = backendWithUsers(
+            mapOf("id" to 1L, "name" to "A", "age" to 10L),
+            mapOf("id" to 2L, "name" to "B", "age" to 20L),
+            mapOf("id" to 3L, "name" to "C", "age" to 30L),
+        )
+
+        val result = SqlVm.execute(
+            prog(
+                Instruction.OpenScan("users", "u"),
+                Instruction.Label("loop"),
+                Instruction.AdvanceCursor("u", "end"),
+                Instruction.BeginRow,
+                Instruction.LoadColumn("u", "id"),
+                Instruction.EmitColumn("id"),
+                Instruction.EmitRow,
+                Instruction.Jump("loop"),
+                Instruction.Label("end"),
+                Instruction.CloseScan("u"),
+                Instruction.LimitResult(count = 2L, offset = null),
+                Instruction.Halt,
+            ),
+            backend,
+        )
+        assertEquals(2, result.rows.size)
+        assertEquals(int(1), result.rows[0][0])
+        assertEquals(int(2), result.rows[1][0])
+    }
+
+    @Test
+    fun `LimitResult with offset skips rows`() {
+        backend = backendWithUsers(
+            mapOf("id" to 1L, "name" to "A", "age" to 10L),
+            mapOf("id" to 2L, "name" to "B", "age" to 20L),
+            mapOf("id" to 3L, "name" to "C", "age" to 30L),
+        )
+
+        val result = SqlVm.execute(
+            prog(
+                Instruction.OpenScan("users", "u"),
+                Instruction.Label("loop"),
+                Instruction.AdvanceCursor("u", "end"),
+                Instruction.BeginRow,
+                Instruction.LoadColumn("u", "id"),
+                Instruction.EmitColumn("id"),
+                Instruction.EmitRow,
+                Instruction.Jump("loop"),
+                Instruction.Label("end"),
+                Instruction.CloseScan("u"),
+                Instruction.LimitResult(count = 1L, offset = 1L),
+                Instruction.Halt,
+            ),
+            backend,
+        )
+        assertEquals(1, result.rows.size)
+        assertEquals(int(2), result.rows[0][0])
+    }
+
+    @Test
+    fun `LimitResult null count returns all rows from offset`() {
+        backend = backendWithUsers(
+            mapOf("id" to 1L, "name" to "A", "age" to 10L),
+            mapOf("id" to 2L, "name" to "B", "age" to 20L),
+            mapOf("id" to 3L, "name" to "C", "age" to 30L),
+        )
+
+        val result = SqlVm.execute(
+            prog(
+                Instruction.OpenScan("users", "u"),
+                Instruction.Label("loop"),
+                Instruction.AdvanceCursor("u", "end"),
+                Instruction.BeginRow,
+                Instruction.LoadColumn("u", "id"),
+                Instruction.EmitColumn("id"),
+                Instruction.EmitRow,
+                Instruction.Jump("loop"),
+                Instruction.Label("end"),
+                Instruction.CloseScan("u"),
+                Instruction.LimitResult(count = null, offset = 1L),
+                Instruction.Halt,
+            ),
+            backend,
+        )
+        assertEquals(2, result.rows.size)
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Post-processing: DISTINCT
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `DistinctResult removes duplicates`() {
+        backend.createTable("t", listOf(ColumnDef("v", "INTEGER")), ifNotExists = false)
+        for (v in listOf(1L, 2L, 2L, 3L, 1L)) {
+            val row = Row(); row["v"] = v; backend.insert("t", row)
+        }
+
+        val result = SqlVm.execute(
+            prog(
+                Instruction.OpenScan("t", "t"),
+                Instruction.Label("loop"),
+                Instruction.AdvanceCursor("t", "end"),
+                Instruction.BeginRow,
+                Instruction.LoadColumn("t", "v"),
+                Instruction.EmitColumn("v"),
+                Instruction.EmitRow,
+                Instruction.Jump("loop"),
+                Instruction.Label("end"),
+                Instruction.CloseScan("t"),
+                Instruction.DistinctResult,
+                Instruction.Halt,
+            ),
+            backend,
+        )
+
+        assertEquals(3, result.rows.size)
+        val values = result.rows.map { it[0] }.toSet()
+        assertTrue(values.contains(int(1)))
+        assertTrue(values.contains(int(2)))
+        assertTrue(values.contains(int(3)))
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Post-processing: ORDER BY
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `SortResult ascending by integer column`() {
+        backend = backendWithUsers(
+            mapOf("id" to 3L, "name" to "C", "age" to 30L),
+            mapOf("id" to 1L, "name" to "A", "age" to 10L),
+            mapOf("id" to 2L, "name" to "B", "age" to 20L),
+        )
+
+        val result = SqlVm.execute(
+            prog(
+                Instruction.OpenScan("users", "u"),
+                Instruction.Label("loop"),
+                Instruction.AdvanceCursor("u", "end"),
+                Instruction.BeginRow,
+                Instruction.LoadColumn("u", "id"),
+                Instruction.EmitColumn("id"),
+                Instruction.EmitRow,
+                Instruction.Jump("loop"),
+                Instruction.Label("end"),
+                Instruction.CloseScan("u"),
+                Instruction.SortResult(
+                    keys = listOf(SortKey(SqlExpr.Column(null, "id"), direction = SortDir.ASC, nullOrder = NullOrder.NULLS_LAST)),
+                ),
+                Instruction.Halt,
+            ),
+            backend,
+        )
+
+        assertEquals(listOf(int(1), int(2), int(3)), result.rows.map { it[0] })
+    }
+
+    @Test
+    fun `SortResult descending`() {
+        backend = backendWithUsers(
+            mapOf("id" to 1L, "name" to "A", "age" to 10L),
+            mapOf("id" to 2L, "name" to "B", "age" to 20L),
+            mapOf("id" to 3L, "name" to "C", "age" to 30L),
+        )
+
+        val result = SqlVm.execute(
+            prog(
+                Instruction.OpenScan("users", "u"),
+                Instruction.Label("loop"),
+                Instruction.AdvanceCursor("u", "end"),
+                Instruction.BeginRow,
+                Instruction.LoadColumn("u", "id"),
+                Instruction.EmitColumn("id"),
+                Instruction.EmitRow,
+                Instruction.Jump("loop"),
+                Instruction.Label("end"),
+                Instruction.CloseScan("u"),
+                Instruction.SortResult(
+                    keys = listOf(SortKey(SqlExpr.Column(null, "id"), direction = SortDir.DESC, nullOrder = NullOrder.NULLS_LAST)),
+                ),
+                Instruction.Halt,
+            ),
+            backend,
+        )
+
+        assertEquals(listOf(int(3), int(2), int(1)), result.rows.map { it[0] })
+    }
+
+    @Test
+    fun `SortResult NULLs first`() {
+        backend.createTable("t", listOf(ColumnDef("v", "INTEGER")), ifNotExists = false)
+        for (v in listOf<Long?>(2L, null, 1L)) {
+            val row = Row(); row["v"] = v; backend.insert("t", row)
+        }
+
+        val result = SqlVm.execute(
+            prog(
+                Instruction.OpenScan("t", "t"),
+                Instruction.Label("loop"),
+                Instruction.AdvanceCursor("t", "end"),
+                Instruction.BeginRow,
+                Instruction.LoadColumn("t", "v"),
+                Instruction.EmitColumn("v"),
+                Instruction.EmitRow,
+                Instruction.Jump("loop"),
+                Instruction.Label("end"),
+                Instruction.CloseScan("t"),
+                Instruction.SortResult(
+                    keys = listOf(SortKey(SqlExpr.Column(null, "v"), direction = SortDir.ASC, nullOrder = NullOrder.NULLS_FIRST)),
+                ),
+                Instruction.Halt,
+            ),
+            backend,
+        )
+
+        assertEquals(NULL,   result.rows[0][0])
+        assertEquals(int(1), result.rows[1][0])
+        assertEquals(int(2), result.rows[2][0])
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Aggregation: COUNT, SUM, AVG, MIN, MAX
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `COUNT STAR over table`() {
+        backend = backendWithUsers(
+            mapOf("id" to 1L, "name" to "A", "age" to 10L),
+            mapOf("id" to 2L, "name" to "B", "age" to 20L),
+            mapOf("id" to 3L, "name" to "C", "age" to 30L),
+        )
+
+        val result = SqlVm.execute(buildCountStarProgram("users", "u"), backend)
+        assertEquals(1, result.rows.size)
+        assertEquals(int(3), result.rows[0][0])
+    }
+
+    @Test
+    fun `COUNT STAR over empty table returns zero`() {
+        backend.createTable("t", listOf(ColumnDef("x", "INTEGER")), ifNotExists = false)
+        val result = SqlVm.execute(buildCountStarProgram("t", "t"), backend)
+        assertEquals(1, result.rows.size)
+        assertEquals(int(0), result.rows[0][0])
+    }
+
+    @Test
+    fun `SUM of integer column`() {
+        backend = backendWithUsers(
+            mapOf("id" to 1L, "name" to "A", "age" to 10L),
+            mapOf("id" to 2L, "name" to "B", "age" to 20L),
+            mapOf("id" to 3L, "name" to "C", "age" to 30L),
+        )
+
+        val result = SqlVm.execute(buildSingleAggProgram("users", "u", "age", AggFn.SUM, "total"), backend)
+        assertEquals(1, result.rows.size)
+        assertEquals(int(60), result.rows[0][0])
+    }
+
+    @Test
+    fun `AVG of integer column`() {
+        backend = backendWithUsers(
+            mapOf("id" to 1L, "name" to "A", "age" to 10L),
+            mapOf("id" to 2L, "name" to "B", "age" to 20L),
+            mapOf("id" to 3L, "name" to "C", "age" to 30L),
+        )
+
+        val result = SqlVm.execute(buildSingleAggProgram("users", "u", "age", AggFn.AVG, "avg_age"), backend)
+        assertEquals(1, result.rows.size)
+        // 60 / 3 = 20.0
+        assertEquals(flt(20.0), result.rows[0][0])
+    }
+
+    @Test
+    fun `MIN of integer column`() {
+        backend = backendWithUsers(
+            mapOf("id" to 1L, "name" to "A", "age" to 30L),
+            mapOf("id" to 2L, "name" to "B", "age" to 10L),
+            mapOf("id" to 3L, "name" to "C", "age" to 20L),
+        )
+
+        val result = SqlVm.execute(buildSingleAggProgram("users", "u", "age", AggFn.MIN, "min_age"), backend)
+        assertEquals(int(10), result.rows[0][0])
+    }
+
+    @Test
+    fun `MAX of integer column`() {
+        backend = backendWithUsers(
+            mapOf("id" to 1L, "name" to "A", "age" to 30L),
+            mapOf("id" to 2L, "name" to "B", "age" to 10L),
+            mapOf("id" to 3L, "name" to "C", "age" to 20L),
+        )
+
+        val result = SqlVm.execute(buildSingleAggProgram("users", "u", "age", AggFn.MAX, "max_age"), backend)
+        assertEquals(int(30), result.rows[0][0])
+    }
+
+    @Test
+    fun `COUNT ignores NULLs`() {
+        backend.createTable("t", listOf(ColumnDef("v", "INTEGER")), ifNotExists = false)
+        for (v in listOf<Long?>(1L, null, 3L)) {
+            val row = Row(); row["v"] = v; backend.insert("t", row)
+        }
+        val result = SqlVm.execute(buildSingleAggProgram("t", "t", "v", AggFn.COUNT, "cnt"), backend)
+        assertEquals(int(2), result.rows[0][0])
+    }
+
+    @Test
+    fun `SUM ignores NULLs`() {
+        backend.createTable("t", listOf(ColumnDef("v", "INTEGER")), ifNotExists = false)
+        for (v in listOf<Long?>(5L, null, 10L)) {
+            val row = Row(); row["v"] = v; backend.insert("t", row)
+        }
+        val result = SqlVm.execute(buildSingleAggProgram("t", "t", "v", AggFn.SUM, "s"), backend)
+        assertEquals(int(15), result.rows[0][0])
+    }
+
+    @Test
+    fun `AVG over empty result returns NULL`() {
+        backend.createTable("t", listOf(ColumnDef("v", "INTEGER")), ifNotExists = false)
+        val result = SqlVm.execute(buildSingleAggProgram("t", "t", "v", AggFn.AVG, "a"), backend)
+        assertEquals(NULL, result.rows[0][0])
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Transactions
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `transaction commit persists insert`() {
+        backend.createTable("t", listOf(ColumnDef("v", "INTEGER")), ifNotExists = false)
+
+        SqlVm.execute(
+            prog(
+                Instruction.BeginTransaction,
+                Instruction.LoadConst(int(42)),
+                Instruction.InsertRow("t", listOf("v")),
+                Instruction.CommitTransaction,
+                Instruction.Halt,
+            ),
+            backend,
+        )
+
+        val rows = scanAll(backend, "t")
+        assertEquals(1, rows.size)
+        assertEquals(42L, rows[0]["v"])
+    }
+
+    @Test
+    fun `transaction rollback discards insert`() {
+        backend.createTable("t", listOf(ColumnDef("v", "INTEGER")), ifNotExists = false)
+
+        SqlVm.execute(
+            prog(
+                Instruction.BeginTransaction,
+                Instruction.LoadConst(int(99)),
+                Instruction.InsertRow("t", listOf("v")),
+                Instruction.RollbackTransaction,
+                Instruction.Halt,
+            ),
+            backend,
+        )
+
+        val rows = scanAll(backend, "t")
+        assertTrue(rows.isEmpty())
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Control flow: JumpIfTrue, JumpIfFalse, Jump
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `JumpIfTrue skips when condition is false`() {
+        // If 1 == 2 (false), skip to done without emitting; else emit 99.
+        val result = SqlVm.execute(
+            prog(
+                Instruction.LoadConst(int(1)),
+                Instruction.LoadConst(int(2)),
+                Instruction.BinaryOpInstr(BinaryOp.EQ),
+                Instruction.JumpIfTrue("done"),
+                Instruction.BeginRow,
+                Instruction.LoadConst(int(99)),
+                Instruction.EmitColumn("v"),
+                Instruction.EmitRow,
+                Instruction.Label("done"),
+                Instruction.Halt,
+            ),
+            backend,
+        )
+        // Condition is false → JumpIfTrue does NOT jump → row IS emitted.
+        assertEquals(1, result.rows.size)
+    }
+
+    @Test
+    fun `JumpIfFalse jumps when condition is false`() {
+        // If 5 > 10 (false), jump to done.
+        val result = SqlVm.execute(
+            prog(
+                Instruction.LoadConst(int(5)),
+                Instruction.LoadConst(int(10)),
+                Instruction.BinaryOpInstr(BinaryOp.GT),
+                Instruction.JumpIfFalse("done"),
+                Instruction.BeginRow,
+                Instruction.LoadConst(int(99)),
+                Instruction.EmitColumn("v"),
+                Instruction.EmitRow,
+                Instruction.Label("done"),
+                Instruction.Halt,
+            ),
+            backend,
+        )
+        // Condition is false → jump → row is NOT emitted.
+        assertTrue(result.rows.isEmpty())
+    }
+
+    @Test
+    fun `JumpIfFalse NULL is treated as false`() {
+        // NULL condition → JumpIfFalse should jump (NULL is falsy).
+        val result = SqlVm.execute(
+            prog(
+                Instruction.LoadConst(NULL),
+                Instruction.JumpIfFalse("done"),
+                Instruction.BeginRow,
+                Instruction.LoadConst(int(1)),
+                Instruction.EmitColumn("v"),
+                Instruction.EmitRow,
+                Instruction.Label("done"),
+                Instruction.Halt,
+            ),
+            backend,
+        )
+        assertTrue(result.rows.isEmpty())
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // LoadParam placeholder
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `LoadParam pushes NULL as placeholder`() {
+        val result = SqlVm.execute(
+            prog(
+                Instruction.BeginRow,
+                Instruction.LoadParam(0),
+                Instruction.EmitColumn("v"),
+                Instruction.EmitRow,
+                Instruction.Halt,
+            ),
+            backend,
+        )
+        assertEquals(NULL, result.rows[0][0])
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // QueryResult structure
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `multiple columns in result`() {
+        val result = SqlVm.execute(
+            prog(
+                Instruction.BeginRow,
+                Instruction.LoadConst(int(1)),
+                Instruction.EmitColumn("a"),
+                Instruction.LoadConst(txt("hello")),
+                Instruction.EmitColumn("b"),
+                Instruction.LoadConst(flt(3.14)),
+                Instruction.EmitColumn("c"),
+                Instruction.EmitRow,
+                Instruction.Halt,
+            ),
+            backend,
+        )
+        assertEquals(listOf("a", "b", "c"), result.columns)
+        assertEquals(int(1),    result.rows[0][0])
+        assertEquals(txt("hello"), result.rows[0][1])
+        assertEquals(flt(3.14), result.rows[0][2])
+    }
+
+    @Test
+    fun `rowsAffected is zero for SELECT`() {
+        val result = SqlVm.execute(
+            prog(
+                Instruction.BeginRow,
+                Instruction.LoadConst(int(1)),
+                Instruction.EmitColumn("v"),
+                Instruction.EmitRow,
+                Instruction.Halt,
+            ),
+            backend,
+        )
+        assertEquals(0, result.rowsAffected)
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Float arithmetic
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `float division`() {
+        val r = evalExpr(
+            Instruction.LoadConst(flt(7.0)),
+            Instruction.LoadConst(flt(2.0)),
+            Instruction.BinaryOpInstr(BinaryOp.DIV),
+        )
+        assertEquals(flt(3.5), r)
+    }
+
+    @Test
+    fun `integer and float ADD promotes to float`() {
+        val r = evalExpr(
+            Instruction.LoadConst(int(1)),
+            Instruction.LoadConst(flt(0.5)),
+            Instruction.BinaryOpInstr(BinaryOp.ADD),
+        )
+        assertEquals(flt(1.5), r)
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Edge cases
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `multiple EmitRow calls accumulate rows`() {
+        val result = SqlVm.execute(
+            prog(
+                Instruction.BeginRow,
+                Instruction.LoadConst(int(1)),
+                Instruction.EmitColumn("v"),
+                Instruction.EmitRow,
+                Instruction.BeginRow,
+                Instruction.LoadConst(int(2)),
+                Instruction.EmitColumn("v"),
+                Instruction.EmitRow,
+                Instruction.Halt,
+            ),
+            backend,
+        )
+        assertEquals(2, result.rows.size)
+        assertEquals(int(1), result.rows[0][0])
+        assertEquals(int(2), result.rows[1][0])
+    }
+
+    @Test
+    fun `stack underflow throws exception`() {
+        assertThrows<IllegalStateException> {
+            SqlVm.execute(
+                prog(Instruction.Pop, Instruction.Halt),
+                backend,
+            )
+        }
+    }
+
+    @Test
+    fun `unknown label throws exception`() {
+        assertThrows<IllegalStateException> {
+            SqlVm.execute(
+                prog(Instruction.Jump("nonexistent_label"), Instruction.Halt),
+                backend,
+            )
+        }
+    }
+
+    @Test
+    fun `BoolVal true in LoadConst`() {
+        val r = evalExpr(Instruction.LoadConst(bool(true)))
+        assertEquals(bool(true), r)
+    }
+
+    @Test
+    fun `BoolVal false in LoadConst`() {
+        val r = evalExpr(Instruction.LoadConst(bool(false)))
+        assertEquals(bool(false), r)
+    }
+
+    @Test
+    fun `NEG float`() {
+        val r = evalUnary(flt(2.5), UnaryOp.NEG)
+        assertEquals(flt(-2.5), r)
+    }
+
+    @Test
+    fun `MOD with floats`() {
+        val r = evalExpr(
+            Instruction.LoadConst(flt(7.5)),
+            Instruction.LoadConst(flt(2.0)),
+            Instruction.BinaryOpInstr(BinaryOp.MOD),
+        )
+        assertEquals(flt(1.5), r)
+    }
+
+    @Test
+    fun `CONCAT with null propagates null`() {
+        // SQLite/SQL standard: NULL || 'world' = NULL (NULL propagates through CONCAT).
+        val r = evalExpr(
+            Instruction.LoadConst(NULL),
+            Instruction.LoadConst(txt("world")),
+            Instruction.BinaryOpInstr(BinaryOp.CONCAT),
+        )
+        assertEquals(NULL, r)
+    }
+
+    @Test
+    fun `scan with null alias cursor`() {
+        backend.createTable("t", listOf(ColumnDef("x", "INTEGER")), ifNotExists = false)
+        val row = Row(); row["x"] = 5L; backend.insert("t", row)
+
+        // UPDATE pattern: anonymous cursor (alias=null)
+        val result = SqlVm.execute(
+            prog(
+                Instruction.OpenScan("t", null),
+                Instruction.Label("loop"),
+                Instruction.AdvanceCursor(null, "end"),
+                Instruction.BeginRow,
+                Instruction.LoadColumn(null, "x"),
+                Instruction.EmitColumn("x"),
+                Instruction.EmitRow,
+                Instruction.Jump("loop"),
+                Instruction.Label("end"),
+                Instruction.CloseScan(null),
+                Instruction.Halt,
+            ),
+            backend,
+        )
+        assertEquals(1, result.rows.size)
+        assertEquals(int(5), result.rows[0][0])
+    }
+
+    @Test
+    fun `LimitResult offset beyond size returns empty`() {
+        backend = backendWithUsers(
+            mapOf("id" to 1L, "name" to "A", "age" to 10L),
+        )
+        val result = SqlVm.execute(
+            prog(
+                Instruction.OpenScan("users", "u"),
+                Instruction.Label("loop"),
+                Instruction.AdvanceCursor("u", "end"),
+                Instruction.BeginRow,
+                Instruction.LoadColumn("u", "id"),
+                Instruction.EmitColumn("id"),
+                Instruction.EmitRow,
+                Instruction.Jump("loop"),
+                Instruction.Label("end"),
+                Instruction.CloseScan("u"),
+                Instruction.LimitResult(count = 10L, offset = 100L),
+                Instruction.Halt,
+            ),
+            backend,
+        )
+        assertTrue(result.rows.isEmpty())
+    }
+
+    @Test
+    fun `DROP TABLE then CREATE TABLE works`() {
+        backend.createTable("t", listOf(ColumnDef("x", "INTEGER")), ifNotExists = false)
+        SqlVm.execute(prog(Instruction.DropTableInstr("t", ifExists = false), Instruction.Halt), backend)
+        SqlVm.execute(prog(Instruction.CreateTableInstr("t", ifNotExists = false, columns = listOf(PlannerColumnDef("y", "TEXT", notNull = false, primaryKey = false, unique = false, default = null))), Instruction.Halt), backend)
+        assertTrue(backend.tables().contains("t"))
+    }
+
+    @Test
+    fun `DistinctResult with single row is unchanged`() {
+        val result = SqlVm.execute(
+            prog(
+                Instruction.BeginRow,
+                Instruction.LoadConst(int(1)),
+                Instruction.EmitColumn("v"),
+                Instruction.EmitRow,
+                Instruction.DistinctResult,
+                Instruction.Halt,
+            ),
+            backend,
+        )
+        assertEquals(1, result.rows.size)
+    }
+
+    @Test
+    fun `SortResult with no keys leaves order unchanged`() {
+        backend = backendWithUsers(
+            mapOf("id" to 3L, "name" to "C", "age" to 30L),
+            mapOf("id" to 1L, "name" to "A", "age" to 10L),
+        )
+        val result = SqlVm.execute(
+            prog(
+                Instruction.OpenScan("users", "u"),
+                Instruction.Label("loop"),
+                Instruction.AdvanceCursor("u", "end"),
+                Instruction.BeginRow,
+                Instruction.LoadColumn("u", "id"),
+                Instruction.EmitColumn("id"),
+                Instruction.EmitRow,
+                Instruction.Jump("loop"),
+                Instruction.Label("end"),
+                Instruction.CloseScan("u"),
+                Instruction.SortResult(keys = emptyList()),
+                Instruction.Halt,
+            ),
+            backend,
+        )
+        assertEquals(2, result.rows.size)
+    }
+
+    @Test
+    fun `MUL with NULL propagates NULL`() {
+        val r = evalExpr(
+            Instruction.LoadConst(int(5)),
+            Instruction.LoadConst(NULL),
+            Instruction.BinaryOpInstr(BinaryOp.MUL),
+        )
+        assertEquals(NULL, r)
+    }
+
+    @Test
+    fun `NEQ with equal values returns false`() {
+        val r = evalExpr(
+            Instruction.LoadConst(int(5)),
+            Instruction.LoadConst(int(5)),
+            Instruction.BinaryOpInstr(BinaryOp.NEQ),
+        )
+        assertEquals(bool(false), r)
+    }
+
+    @Test
+    fun `LTE with larger left returns false`() {
+        val r = evalExpr(
+            Instruction.LoadConst(int(10)),
+            Instruction.LoadConst(int(5)),
+            Instruction.BinaryOpInstr(BinaryOp.LTE),
+        )
+        assertEquals(bool(false), r)
+    }
+
+    @Test
+    fun `GTE with smaller left returns false`() {
+        val r = evalExpr(
+            Instruction.LoadConst(int(3)),
+            Instruction.LoadConst(int(5)),
+            Instruction.BinaryOpInstr(BinaryOp.GTE),
+        )
+        assertEquals(bool(false), r)
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Helpers for building test programs
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /**
+     * Execute a short expression-only program and return the single result value.
+     *
+     * The program emits exactly one row with column "result".
+     */
+    private fun evalExpr(vararg instrs: Instruction): SqlValue {
+        val full = mutableListOf<Instruction>()
+        full.add(Instruction.BeginRow)
+        full.addAll(instrs)
+        full.add(Instruction.EmitColumn("result"))
+        full.add(Instruction.EmitRow)
+        full.add(Instruction.Halt)
+        return SqlVm.execute(Program(full), backend).rows[0][0]
+    }
+
+    private fun evalBinaryConst(left: SqlValue, right: SqlValue, op: BinaryOp): SqlValue =
+        evalExpr(
+            Instruction.LoadConst(left),
+            Instruction.LoadConst(right),
+            Instruction.BinaryOpInstr(op),
+        )
+
+    private fun evalUnary(operand: SqlValue, op: UnaryOp): SqlValue =
+        evalExpr(Instruction.LoadConst(operand), Instruction.UnaryOpInstr(op))
+
+    /**
+     * Build a COUNT(*) aggregate program over [table] with cursor alias [alias].
+     */
+    private fun buildCountStarProgram(table: String, alias: String): Program = prog(
+        Instruction.OpenScan(table, alias),
+        Instruction.Label("loop"),
+        Instruction.AdvanceCursor(alias, "end"),
+        Instruction.InitAgg(0, AggFn.COUNT_STAR),
+        Instruction.LoadConst(NULL),
+        Instruction.UpdateAgg(0, AggFn.COUNT_STAR),
+        Instruction.Jump("loop"),
+        Instruction.Label("end"),
+        Instruction.CloseScan(alias),
+        // Finalize phase
+        Instruction.Label("finalize"),
+        Instruction.AdvanceGroup,
+        Instruction.BeginRow,
+        Instruction.FinalizeAgg(0, AggFn.COUNT_STAR),
+        Instruction.EmitColumn("count"),
+        Instruction.EmitRow,
+        Instruction.Jump("finalize"),
+        Instruction.Label("done"),
+        Instruction.Halt,
+    )
+
+    /**
+     * Build a single-aggregate program: SELECT agg_fn(column) FROM table.
+     */
+    private fun buildSingleAggProgram(
+        table: String,
+        alias: String,
+        column: String,
+        fn: AggFn,
+        resultAlias: String,
+    ): Program = prog(
+        Instruction.OpenScan(table, alias),
+        Instruction.Label("loop"),
+        Instruction.AdvanceCursor(alias, "end"),
+        Instruction.InitAgg(0, fn),
+        Instruction.LoadColumn(alias, column),
+        Instruction.UpdateAgg(0, fn),
+        Instruction.Jump("loop"),
+        Instruction.Label("end"),
+        Instruction.CloseScan(alias),
+        // Finalize phase
+        Instruction.Label("finalize"),
+        Instruction.AdvanceGroup,
+        Instruction.BeginRow,
+        Instruction.FinalizeAgg(0, fn),
+        Instruction.EmitColumn(resultAlias),
+        Instruction.EmitRow,
+        Instruction.Jump("finalize"),
+        Instruction.Label("done"),
+        Instruction.Halt,
+    )
+
+    /** Drain all rows from [table] into a list for inspection. */
+    private fun scanAll(b: InMemoryBackend, table: String): List<Row> {
+        val it = b.scan(table)
+        val out = mutableListOf<Row>()
+        while (true) out += it.next() ?: break
+        return out
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `code/packages/kotlin/sql-vm` — a JVM stack-machine bytecode VM that executes `Program` instruction lists (produced by `sql-codegen`) against a `Backend` and returns a `QueryResult`
- Dispatch loop mirrors CPython ceval.c / SQLite VDBE: simple while-loop over a flat `List<Instruction>`, no tree recursion
- SQL three-valued logic for AND/OR/NOT/NULL propagation; aggregate accumulators per group (COUNT, SUM, AVG, MIN, MAX); post-operation sort/distinct/limit applied after all EmitRow instructions
- Adds `CursorBackend` interface to `sql-backend` so `InMemoryBackend` can implement it; `sql-vm` uses `is CursorBackend` for type-safe dispatch instead of reflection

## Security fixes (applied before push)

- **HIGH (ReDoS)**: `likeMatch` replaced with linear-time two-pointer iterative matcher — no `Regex` conversion, no catastrophic backtracking on `%`-heavy patterns
- **MEDIUM (overflow)**: `LimitResult` clamps `Long` offset/count to `[0, Int.MAX_VALUE]` before narrowing to `Int` via `coerceAtMost(Int.MAX_VALUE.toLong()).toInt()`
- **LOW (reflection)**: `openCursorOrScan` uses `backend is CursorBackend` interface dispatch instead of `Class.getMethods().find { it.name == "openCursor" }.invoke(...)` — type-safe, obfuscation-friendly, no `ReflectiveOperationException`

## Test plan

- [ ] `gradle test` passes in `sql-vm` (BUILD SUCCESSFUL — all tests green)
- [ ] `gradle test` passes in `sql-backend` (CursorBackend interface + InMemoryBackend.openCursor override)
- [ ] Coverage threshold (≥80% line coverage) enforced via JaCoCo
- [ ] No test method names contain `--` or `:` (verified by grep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)