### PR TITLE
feat(asciimath): semicolon-separated fences lower to rows — third Sequence frontend

### DIFF
--- a/code/packages/rust/asciimath/CHANGELOG.md
+++ b/code/packages/rust/asciimath/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to the AsciiMath pluggable frontend.
 
+## [0.11.0] — 2026-06-30
+
+### Added — semicolon-separated fences lower to rows (third Sequence frontend to get rows)
+
+- A fence whose body contains a top-level semicolon — `(a, b; c, d)` — is now read as **rows**:
+  semicolons are the row separator and commas the within-row (column) separator, the classic
+  fenced-matrix notation. `(a, b; c, d)` lowers to `Sequence([Sequence([a, b]), Sequence([c, d])])`.
+  This mirrors the `latex` and `mathml` crates' semicolon-rows exactly, so **all three
+  Sequence-emitting frontends now agree on the neutral rows shape** — the same write-once-use-many
+  the flat `Sequence` list already demonstrated.
+- Degenerate shapes are predictable, identical to LaTeX/MathML: a **semicolon-only** fence `(a; b; c)`
+  — a column vector with no second column in any row — collapses to the same flat `Sequence([a, b, c])`
+  as a comma list; a **ragged** fence `(a; b, c)` stays faithful as `Sequence([a, Sequence([b, c])])`.
+  Each cell is still folded to a full relation. A comma-only fence is unchanged (flat `Sequence`),
+  and a separator-free fence is still plain grouping.
+- Adds a `Semicolon` token (`;`, previously an "unknown byte" error). `parse_group` records the
+  separator after each parsed relation in a bounded loop (never recursion) and groups rows at each
+  `;`; a leading/trailing/doubled `;` or `,` leaves a non-atom before the next `parse_relation` → a
+  clean spanned error, never a dropped row. No new AST node, no shared-crate change (reuses
+  `MathExpr::Sequence`, which already nests). 5 new tests (rows, semicolon-only flat, ragged, folded
+  cells, trailing-`;` error). `asciimath` 0.10.0 → 0.11.0.
+
 ## [0.10.0] — 2026-06-30
 
 ### Added — comma-separated fences lower to `Sequence`

--- a/code/packages/rust/asciimath/Cargo.toml
+++ b/code/packages/rust/asciimath/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "asciimath"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 description = "An AsciiMath parser that implements the math-frontend MathFrontend trait: turns AsciiMath (1/2, sqrt(x), x^2+y^2=r^2) into the neutral MathExpr AST. The second pluggable frontend after LaTeX (see ASM01/PFE01). Total, panic-free, spanned errors."
 license = "MIT"

--- a/code/packages/rust/asciimath/src/lib.rs
+++ b/code/packages/rust/asciimath/src/lib.rs
@@ -342,6 +342,54 @@ mod tests {
     }
 
     #[test]
+    fn semicolon_fence_is_rows_of_columns() {
+        // Semicolons are the ROW separator, commas the column separator — the fenced-matrix
+        // reading `(a, b; c, d)` → Sequence([Sequence([a, b]), Sequence([c, d])]). Mirrors the
+        // LaTeX and MathML fence reading.
+        assert_eq!(
+            p("(a,b;c,d)"),
+            MathExpr::Sequence(vec![
+                MathExpr::Sequence(vec![sym("a"), sym("b")]),
+                MathExpr::Sequence(vec![sym("c"), sym("d")]),
+            ])
+        );
+    }
+
+    #[test]
+    fn semicolon_only_fence_is_a_flat_sequence() {
+        // A column vector `(a; b; c)` has no second column in any row → the same flat
+        // Sequence([a, b, c]) as a comma list, no spurious one-element nesting.
+        assert_eq!(p("(a;b;c)"), MathExpr::Sequence(vec![sym("a"), sym("b"), sym("c")]));
+    }
+
+    #[test]
+    fn ragged_semicolon_fence_is_faithful() {
+        // `(a; b, c)` keeps its shape: row 1 is a single relation, row 2 is a pair.
+        assert_eq!(
+            p("(a;b,c)"),
+            MathExpr::Sequence(vec![sym("a"), MathExpr::Sequence(vec![sym("b"), sym("c")])])
+        );
+    }
+
+    #[test]
+    fn semicolon_rows_fold_each_cell() {
+        // Each cell is a full relation, not just a leaf: `(x+1,2;y)`.
+        assert_eq!(
+            p("(x+1,2;y)"),
+            MathExpr::Sequence(vec![
+                MathExpr::Sequence(vec![b(BinOp::Add, sym("x"), num(1)), num(2)]),
+                sym("y"),
+            ])
+        );
+    }
+
+    #[test]
+    fn trailing_semicolon_is_an_error_not_a_dropped_row() {
+        // A trailing separator leaves a non-atom before the next parse_relation → clean error.
+        assert!(AsciiMath.parse("(a,b;)").is_err());
+    }
+
+    #[test]
     fn det_of_a_matrix() {
         // det binds the matrix as its argument atom.
         assert_eq!(

--- a/code/packages/rust/asciimath/src/parser.rs
+++ b/code/packages/rust/asciimath/src/parser.rs
@@ -300,30 +300,62 @@ impl Parser<'_> {
         Ok(MathExpr::Matrix(rows))
     }
 
-    /// A bracketed group. With NO commas, parentheses are *grouping only* — the delimiter style
-    /// is dropped and the inner expression is returned directly (so `sqrt(x)` ≡ `sqrt x` and
-    /// `(1)/(2)` ≡ `1/2`). With one or more top-level commas, the fence is a LIST — `(a, b, c)`
-    /// → `MathExpr::Sequence([a, b, c])` — so the commas are preserved as list structure (a
-    /// coordinate tuple, an argument list) rather than rejected. Each item is a full relation.
-    /// Any closing bracket is accepted (AsciiMath treats them loosely). Note the matrix shape
-    /// `((a,b),(c,d))` is handled earlier by `parse_matrix` (an outer bracket immediately
-    /// followed by another opening bracket); this path sees only single-fence groups/lists.
+    /// A bracketed group. Three shapes, decided by the top-level separators:
+    ///
+    ///   * NO separator → parentheses are *grouping only* — the delimiter style is dropped and the
+    ///     inner expression is returned directly (so `sqrt(x)` ≡ `sqrt x` and `(1)/(2)` ≡ `1/2`).
+    ///   * `,` only → a flat LIST `(a, b, c)` → `MathExpr::Sequence([a, b, c])` (a coordinate tuple,
+    ///     an argument list), preserving the commas as list structure.
+    ///   * any `;` → ROWS. Semicolons are the row separator and commas the within-row (column)
+    ///     separator — the classic fenced-matrix reading `(a, b; c, d)` →
+    ///     `Sequence([Sequence([a, b]), Sequence([c, d])])`. A row with no comma is a single
+    ///     relation, so a semicolon-only fence `(a; b; c)` — a column vector — collapses to the same
+    ///     flat `Sequence([a, b, c])` as a comma list (no row has a second column); a ragged fence
+    ///     `(a; b, c)` stays faithful as `Sequence([a, Sequence([b, c])])`. Mirrors the LaTeX and
+    ///     MathML fence reading exactly.
+    ///
+    /// Each item is a full relation. Any closing bracket is accepted (AsciiMath treats them
+    /// loosely). Note the matrix shape `((a,b),(c,d))` is handled earlier by `parse_matrix` (an
+    /// outer bracket immediately followed by another opening bracket); this path sees only
+    /// single-fence groups/lists. The separator loops are bounded over `parse_relation` (each item
+    /// already depth-charged), never recursion, so a wide fence cannot overflow the stack; a
+    /// trailing/doubled separator leaves a non-atom before the next `parse_relation`, which returns
+    /// a clean spanned error.
     fn parse_group(&mut self) -> Result<MathExpr, FrontendError> {
         self.advance(); // opening bracket
-        let first = self.parse_relation()?;
-        let expr = if matches!(self.peek(), TokenKind::Comma) {
-            // Comma-separated list → Sequence. Mirrors the matrix row's cell loop: a bounded
-            // loop over `parse_relation` (each item already depth-charged), never recursion, so
-            // a wide `(a, b, …, z)` cannot overflow the stack. A trailing/doubled comma leaves a
-            // non-atom before the next `parse_relation`, which returns a clean spanned error.
-            let mut items = vec![first];
-            while matches!(self.peek(), TokenKind::Comma) {
-                self.advance();
-                items.push(self.parse_relation()?);
-            }
+        // Parse the fence body as a sequence of relations, recording the separator (`,` or `;`)
+        // that follows each one; `seps[i]` follows `items[i]`, so `seps.len() == items.len() - 1`.
+        let mut items = vec![self.parse_relation()?];
+        let mut seps: Vec<TokenKind> = Vec::new();
+        while matches!(self.peek(), TokenKind::Comma | TokenKind::Semicolon) {
+            seps.push(self.peek().clone());
+            self.advance();
+            items.push(self.parse_relation()?);
+        }
+        let expr = if seps.is_empty() {
+            // Grouping only.
+            items.pop().expect("one item")
+        } else if !seps.iter().any(|s| matches!(s, TokenKind::Semicolon)) {
+            // Comma-only: a flat list.
             MathExpr::Sequence(items)
         } else {
-            first
+            // Semicolons present: split into rows at each `;`, folding each row's comma-separated
+            // columns into an inner Sequence (a single-column row folds to that one relation).
+            let mut rows: Vec<MathExpr> = Vec::new();
+            let mut current: Vec<MathExpr> = Vec::new();
+            for (i, item) in items.into_iter().enumerate() {
+                current.push(item);
+                let ends_row = i >= seps.len() || matches!(seps[i], TokenKind::Semicolon);
+                if ends_row {
+                    if current.len() == 1 {
+                        rows.push(current.pop().expect("one column"));
+                    } else {
+                        rows.push(MathExpr::Sequence(std::mem::take(&mut current)));
+                    }
+                    current.clear();
+                }
+            }
+            MathExpr::Sequence(rows)
         };
         match self.peek() {
             TokenKind::RParen | TokenKind::RBracket | TokenKind::RBrace => {

--- a/code/packages/rust/asciimath/src/token.rs
+++ b/code/packages/rust/asciimath/src/token.rs
@@ -73,6 +73,9 @@ pub enum TokenKind {
     /// `,` — cell/row separator inside a matrix (`[[a,b],[c,d]]`). Outside a matrix the
     /// parser has no use for it and reports a clean error, never a panic.
     Comma,
+    /// `;` — the ROW separator inside a fenced list (`(a, b; c, d)` = rows of comma-separated
+    /// columns). Outside such a fence the parser reports a clean error, never a panic.
+    Semicolon,
     /// End of input (always the final token; zero-width span at the end).
     Eof,
 }
@@ -278,6 +281,7 @@ pub fn tokenize(src: &str) -> Result<Vec<Token>, FrontendError> {
             b'{' => (TokenKind::LBrace, i + 1),
             b'}' => (TokenKind::RBrace, i + 1),
             b',' => (TokenKind::Comma, i + 1),
+            b';' => (TokenKind::Semicolon, i + 1),
             b'"' => {
                 // A text literal runs to the next double-quote.
                 let mut j = i + 1;

--- a/code/specs/PFE01-pluggable-parser-frontends.md
+++ b/code/specs/PFE01-pluggable-parser-frontends.md
@@ -153,9 +153,13 @@ frontend additionally ships notation-specific golden tests.
   Since 0.20.0 it also mirrors MathML's **semicolon rows**: a fence with a top-level `;` —
   `(a, b; c, d)` — reads semicolons as the row separator and commas as the column separator →
   `Sequence([Sequence([a, b]), Sequence([c, d])])`, with the same degenerate handling (semicolon-only
-  collapses to a flat `Sequence`, ragged stays faithful). Both structural frontends (LaTeX, MathML)
-  now agree on the neutral rows shape.
+  collapses to a flat `Sequence`, ragged stays faithful). Since `asciimath` 0.11.0 all **three**
+  Sequence-emitting frontends (LaTeX, MathML, AsciiMath) agree on the neutral rows shape.
 - `asciimath` — the second frontend (terse ASCII math; see [ASM01](ASM01-asciimath-frontend.md)).
+  Since 0.11.0 it also reads semicolon-separated fences as rows: `(a, b; c, d)` →
+  `Sequence([Sequence([a, b]), Sequence([c, d])])` (a new `;` `Semicolon` token, comma-only stays a
+  flat list, semicolon-only collapses to flat, ragged stays faithful) — mirroring LaTeX and MathML, so
+  all three frontends emit the same neutral nested-`Sequence` rows.
 - `unicode-math` — the **third** frontend: Unicode plain math as people and models type it
   (`x² + y² = r²`, `√x`, `½`, `π·α`, `a ≤ b`). A small crate implementing the trait; its Greek /
   constant glyphs canonicalize to the same `Symbol` names as AsciiMath, so the notations agree on


### PR DESCRIPTION
## What

Extends the **`asciimath`** crate so a fence with a top-level semicolon — `(a, b; c, d)` — is read as **rows**: semicolons are the row separator and commas the within-row (column) separator, the classic fenced-matrix notation.

- `(a, b; c, d)` → `Sequence([Sequence([a, b]), Sequence([c, d])])` (rows of columns)
- comma-only `(a, b, c)` → flat `Sequence` (unchanged)
- separator-free `(a b)` → plain grouping (unchanged)

This mirrors the **`latex`** and **`mathml`** crates' semicolon-rows exactly, so **all three Sequence-emitting frontends (LaTeX, MathML, AsciiMath) now agree on the neutral nested-`Sequence` rows shape** — the same write-once-use-many the flat `Sequence` list already demonstrated.

## How

Adds a `Semicolon` token (`;` was previously an "unknown byte" error). `parse_group` records the separator after each parsed relation in a bounded `while let` loop (no recursion), then groups items into rows at each `;`. Degenerate shapes match LaTeX/MathML: **semicolon-only** `(a; b; c)` collapses to flat `Sequence([a, b, c])`; **ragged** `(a; b, c)` stays faithful as `Sequence([a, Sequence([b, c])])`. Each cell folds to a full relation.

**No new AST node, no shared-crate change** — reuses `MathExpr::Sequence` (already nests); `asciimath` is a leaf, so no downstream ripple.

## Robustness

A leading/trailing/doubled `;` or `,` leaves a non-atom before the next `parse_relation` → a clean spanned error, never a dropped row or panic. The loop is flat; nesting stays bounded by the existing `MAX_DEPTH`.

## Tests

5 new tests: rows-of-columns, semicolon-only flat, ragged, folded cells, trailing-`;` error. **`cargo test -p asciimath` = 48 passed**; `clippy -D warnings` clean. Spec `PFE01` updated. `asciimath` **0.10.0 → 0.11.0**.

## Security

`/security-review` **passed** (with an adversarial fuzz harness incl. 5000-wide fences) — bounded non-recursive loops, `expect()`s unreachable from untrusted input, malformed separators error cleanly, and the nested tree drops iteratively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)