### PR TITLE
feat(semantic-ir-to-python): keyword-parameter & argument emission (KW2)

### DIFF
--- a/code/packages/rust/semantic-ir-to-python/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-python/CHANGELOG.md
@@ -1,15 +1,38 @@
 # Changelog
 
-## Unreleased
+## 0.3.0 — keyword-parameter & keyword-argument emission (KW2)
 
-### Changed
+The backend now accepts `Feature::KeywordParams` and lowers keyword parameters
+and keyword arguments to their **native Python** forms — replacing the KW1
+compile-compat stubs (the panicking `Expr::KeywordArg` emit arm and the
+positional-fold of `ParamKind::Keyword`).
 
-- Compile-compat stub arms for the new core `semantic-ir` variants
-  `ParamKind::Keyword` / `Expr::KeywordArg` (KW1). The builtin-usage scan
-  recurses into the keyword arg's inner `value`; a single `Keyword` param
-  emits as a best-effort plain positional (combined with `Required`);
-  `emit_expr` follows the crate's unsupported-node convention. Real
-  keyword-parameter support is pending KW2–KW8.
+Python keyword parameters are *keyword-only* parameters: they sit after a `*`
+in the signature and bind by name only.
+
+- **Def side — keyword-only params.** A `ParamKind::Keyword` param becomes a
+  keyword-only parameter. The backend injects a single bare `*` separator
+  immediately before the first keyword param — **unless** a `Rest` (`*args`)
+  param is already present, since `*args` itself opens the keyword-only region
+  and a second bare `*` would be a `SyntaxError`. The validator's def-side
+  ordering (positional → `Rest` → `Keyword*` → `KwRest`) guarantees a single
+  whole-list lookahead for a `Rest` suffices. Examples:
+  - `[a(Required), b(Keyword,None), c(Keyword,default 1)]` → `def f(a, *, b, c=_SIR_MISSING):`
+  - `[rest(Rest), kw(Keyword,default 1)]` → `def g(*rest, kw=_SIR_MISSING):` (no extra `*`)
+- **Optional keyword defaults reuse the P2c machinery.** An optional keyword
+  param (`Keyword` + `default: Some`) emits the sentinel `name=_SIR_MISSING`
+  and is resolved in the body prologue — exactly like a positional optional —
+  so keyword defaults are **call-time** and may reference earlier params. (This
+  is a deliberate departure from a literal `name=<default-expr>` in the def, for
+  the same NameError / evaluation-time reasons documented in 0.2.0.)
+- **Call side — keyword arguments.** An `Expr::KeywordArg { name, value }`
+  (which the validator permits only inside a call's `args`, after all
+  positionals) emits as `name=value`, e.g. `greet("hi", name="ada")`.
+
+Verified with emitted-shape tests (required + optional keyword def, `*`-vs-`*args`
+separator, keyword call arg) and execution-proof tests that shell out to
+`python3`/`python` (skipped gracefully if absent): `greet("hi")` → `hi, world`
+and `greet("hi", name="ada")` → `hi, ada`.
 
 ## 0.2.0 — default-parameter emission via sentinel + body prologue (P2c)
 

--- a/code/packages/rust/semantic-ir-to-python/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-python"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Semantic IR → self-contained Python 3 source code (SIR14). Third backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-python/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-python/src/emit.rs
@@ -310,7 +310,37 @@ fn emit_function(out: &mut String, f: &Function) {
         first = false;
         out.push_str(&sanitize_ident(&c.name));
     }
+    // KW2 keyword-only `*` separator.  A `Keyword` param is Python-native as a
+    // *keyword-only* parameter — one that sits AFTER a `*` in the signature and
+    // is bound by name only (`def f(a, *, b, c=1)` accepts `f(1, b=2)` but
+    // rejects `f(1, 2)`).  Python opens the keyword-only region in one of two
+    // ways, and we must emit the separator exactly once:
+    //
+    //   * an explicit `*args` collector (SIR `Rest`) — everything after it is
+    //     already keyword-only, so it *is* the separator; a second bare `*`
+    //     would be a `SyntaxError` (`def f(*a, *, b)`).
+    //   * a bare `*` with no name — the form to emit when there is NO `Rest`.
+    //
+    // The validator's def-side ordering (positional → Rest → Keyword* → KwRest)
+    // guarantees every `Keyword` param follows any `Rest`, so a single lookahead
+    // suffices: does the whole list contain a `Rest`?  If not, we inject the
+    // bare `*` immediately before the FIRST `Keyword` param.  `kw_sep_needed`
+    // tracks "still owe a bare `*`", and is cleared the moment we emit one (so
+    // the second, third … keyword params do not each re-emit it).
+    let has_rest = f.params.iter().any(|p| p.kind == ParamKind::Rest);
+    let mut kw_sep_needed = !has_rest;
     for p in &f.params {
+        // Inject the bare `*` separator right before the first keyword param,
+        // when no `*args`/`Rest` already provides it.  The separator is a
+        // stand-alone list element, so it obeys the same comma rule as a param.
+        if p.kind == ParamKind::Keyword && kw_sep_needed {
+            if !first {
+                out.push_str(", ");
+            }
+            out.push('*');
+            first = false;
+            kw_sep_needed = false;
+        }
         if !first {
             out.push_str(", ");
         }
@@ -318,29 +348,24 @@ fn emit_function(out: &mut String, f: &Function) {
         // M3 variadic kinds map to Python's native variadic forms:
         //   Rest   (`*rest`)  → `*rest`   (collects trailing positionals)
         //   KwRest (`**opts`) → `**opts`  (collects trailing keywords)
-        // Both are faithful in Python; only the construction differs.
+        // Both are faithful in Python; only the construction differs.  A
+        // `Keyword` param takes no prefix: its name is emitted bare, but because
+        // it now sits after the `*` (or after `*args`) it is keyword-only.
         match p.kind {
             ParamKind::Rest => out.push('*'),
             ParamKind::KwRest => out.push_str("**"),
-            // KW1 compile-compat stub: a single keyword param (`Keyword`) is
-            // NOT the `**opts` collector, so it takes no prefix here — the
-            // shared `push_str(name)` below emits its name, giving a
-            // best-effort plain positional.  Real keyword-param syntax (order
-            // after `*`, name-only binding) lands in KW2–KW6; the validator
-            // rejects `Feature::KeywordParams` until then, so this arm is
-            // unreachable today.  Combined with `Required` as both emit no
-            // prefix.
             ParamKind::Required | ParamKind::Keyword => {}
         }
         out.push_str(&sanitize_ident(&p.name));
-        // P2c default parameters.  A defaulted param gets the *sentinel* as its
-        // native Python default — `name=_SIR_MISSING` — so callers may omit the
-        // trailing argument.  We deliberately do NOT emit `name=<expr>`: SIR
-        // defaults are call-time and may reference earlier params, which
-        // Python's def-time defaults cannot express (`def f(a, b=a)` is a
-        // NameError).  The real default is resolved in the body prologue below.
-        // (Only `Required` params carry a default; `*rest`/`**opts` never do.)
-        if p.kind == ParamKind::Required && p.default.is_some() {
+        // Default parameters (positional P2c *and* KW2 optional keyword params).
+        // A defaulted param gets the *sentinel* as its native Python default —
+        // `name=_SIR_MISSING` — so callers may omit the trailing/keyword
+        // argument.  We deliberately do NOT emit `name=<expr>`: SIR defaults are
+        // call-time and may reference earlier params, which Python's def-time
+        // defaults cannot express (`def f(a, b=a)` is a NameError).  The real
+        // default is resolved in the body prologue below, uniformly for both
+        // positional and keyword optionals.  (`*rest`/`**opts` never default.)
+        if matches!(p.kind, ParamKind::Required | ParamKind::Keyword) && p.default.is_some() {
             out.push_str("=_SIR_MISSING");
         }
     }
@@ -815,17 +840,17 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
             }
             out.push(')');
         }
-        // KW1 compile-compat stub: keyword arguments (`f(a: 1)`) are gated
-        // behind `Feature::KeywordParams`, which the validator rejects until
-        // real support lands in KW2–KW6.  Follow this crate's convention for
-        // an unsupported codegen node the capability check should have
-        // rejected (see the `Intrinsic` panic above): a positioned panic
-        // covering internal bugs only.  No real emission yet.
-        Expr::KeywordArg { span, .. } => {
-            panic!(
-                "python backend reached KW1 keyword-arg expression at {} — backend should have rejected it (real support pending KW2–KW6)",
-                span
-            );
+        // KW2 keyword argument.  A `KeywordArg { name, value }` reaches the
+        // backend only inside a call's `args` vec, after all positionals (the
+        // validator enforces both).  Python's native call syntax spells it
+        // `name=value` (`f(1, b=2)`), which binds `value` to the callee's
+        // keyword-only parameter `name`.  The name is a bare identifier here —
+        // not a string literal — so it is emitted through `sanitize_ident`,
+        // and the value lowers through the ordinary expression emitter.
+        Expr::KeywordArg { name, value, .. } => {
+            out.push_str(&sanitize_ident(name));
+            out.push('=');
+            emit_expr(out, value, indent);
         }
     }
 }

--- a/code/packages/rust/semantic-ir-to-python/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-python/src/lib.rs
@@ -56,6 +56,12 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     // rewrites each still-sentinel param to its (call-time, param-scoped)
     // default expression.  See `emit_function`.
     Feature::DefaultParams,
+    // KW2 keyword parameters & arguments — Python-native.  A `Keyword` param
+    // becomes a keyword-only parameter (after a bare `*`, or after an existing
+    // `*args`); a `KeywordArg` call element becomes `name=value`.  Optional
+    // keyword params reuse the same sentinel + body-prologue default machinery
+    // as positional optionals.  See `emit_function` / the `KeywordArg` emit arm.
+    Feature::KeywordParams,
     // SIR16 expression features — emitted natively (sequences → list,
     // maps → dict, short-circuit → truthy-guarded lambda, interpolation →
     // display-joined), per code/specs/sir-runtime.md.
@@ -1556,5 +1562,301 @@ mod tests {
             "unexpected range import; got:\n{}",
             a.source
         );
+    }
+
+    // ── KW2: keyword-parameter & keyword-argument emission ──────────────────
+    //
+    // These build SIR modules DIRECTLY (the Ruby/Python frontends do not yet
+    // produce keyword params — that is KW7/KW8), so we hand-assemble the
+    // `Keyword` params and `KeywordArg` call elements the validator now accepts.
+
+    /// Build `def greet(greeting, *, name=<default "world">): return "<greeting>, <name>"`
+    /// — one positional required param, one optional keyword param — as a
+    /// `Function`.  Reused by several KW2 tests below.
+    fn greet_function() -> Function {
+        use semantic_ir::{Param, ParamKind, Scope};
+        // Body: `return greeting + ", " + name` (SIR string concat).
+        let body_value = Expr::StrConcat {
+            parts: vec![
+                Expr::VarRef { name: "greeting".into(), scope: Scope::Param, span: s() },
+                Expr::StrLit { value: ", ".into(), span: s() },
+                Expr::VarRef { name: "name".into(), scope: Scope::Param, span: s() },
+            ],
+            span: s(),
+        };
+        Function {
+            name: "greet".into(),
+            params: vec![
+                Param {
+                    name: "greeting".into(),
+                    sir_type: None,
+                    kind: ParamKind::Required,
+                    default: None,
+                    span: s(),
+                },
+                Param {
+                    name: "name".into(),
+                    sir_type: None,
+                    kind: ParamKind::Keyword,
+                    default: Some(Box::new(Expr::StrLit { value: "world".into(), span: s() })),
+                    span: s(),
+                },
+            ],
+            return_type: None,
+            captures: vec![],
+            body: Block { stmts: vec![], value: body_value, span: s() },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        }
+    }
+
+    /// Assemble a module: `greet` (above) + a `main` whose body value is the
+    /// given call expression, printed via `print(...)`.
+    fn kw_module(main_value_call: Expr) -> Module {
+        let print_stmt = semantic_ir::Stmt::ExprStmt {
+            expr: Expr::BuiltinCall {
+                name: "print".into(),
+                args: vec![main_value_call],
+                effects: EffectSet::PURE,
+                span: s(),
+            },
+            span: s(),
+        };
+        let main = Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block { stmts: vec![print_stmt], value: Expr::NilLit { span: s() }, span: s() },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        };
+        Module {
+            name: "demo".into(),
+            manifest: FeatureManifest::from_features(&[
+                Feature::KeywordParams,
+                Feature::DefaultParams,
+                Feature::Strings,
+                Feature::StringInterpolation,
+                Feature::DynamicTyping,
+            ]),
+            imports: vec![],
+            exports: vec![],
+            functions: vec![greet_function(), main],
+            globals: vec![],
+            metadata: Metadata::new()
+                .with_source_language("test")
+                .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+            span: s(),
+        }
+    }
+
+    /// A `greet("hi", <keyword args…>)` call expression.
+    fn greet_call(kw_args: Vec<Expr>) -> Expr {
+        let mut args = vec![Expr::StrLit { value: "hi".into(), span: s() }];
+        args.extend(kw_args);
+        Expr::DirectCall { fn_name: "greet".into(), args, effects: EffectSet::PURE, span: s() }
+    }
+
+    #[test]
+    fn emit_keyword_param_def_uses_bare_star_separator_py() {
+        // `def greet(greeting, *, name=...)`: the bare `*` opens Python's
+        // keyword-only region, and the optional keyword param reuses the
+        // sentinel + prologue default machinery (so it emits `name=_SIR_MISSING`,
+        // NOT `name="world"`, giving call-time defaults).
+        let a = compile(&kw_module(greet_call(vec![]))).expect("compile to python");
+        assert!(
+            a.source.contains("def greet(greeting, *, name=_SIR_MISSING):"),
+            "keyword param must be keyword-only after a bare `*`; got:\n{}",
+            a.source
+        );
+        // The default resolves in the body prologue, not at def time.
+        assert!(
+            a.source.contains("    if name is _SIR_MISSING:"),
+            "optional keyword default must resolve via prologue; got:\n{}",
+            a.source
+        );
+    }
+
+    #[test]
+    fn emit_required_keyword_param_has_no_default_py() {
+        // A REQUIRED keyword param (`Keyword` + `default: None`) emits bare,
+        // still after the `*`: `def h(a, *, b):`.
+        use semantic_ir::{Param, ParamKind, Scope};
+        let f = Function {
+            name: "h".into(),
+            params: vec![
+                Param { name: "a".into(), sir_type: None, kind: ParamKind::Required, default: None, span: s() },
+                Param { name: "b".into(), sir_type: None, kind: ParamKind::Keyword, default: None, span: s() },
+            ],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts: vec![],
+                value: Expr::VarRef { name: "b".into(), scope: Scope::Param, span: s() },
+                span: s(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        };
+        // main: print(h("x", b="y")) — required keyword must be supplied.
+        let call = Expr::DirectCall {
+            fn_name: "h".into(),
+            args: vec![
+                Expr::StrLit { value: "x".into(), span: s() },
+                Expr::KeywordArg {
+                    name: "b".into(),
+                    value: Box::new(Expr::StrLit { value: "y".into(), span: s() }),
+                    span: s(),
+                },
+            ],
+            effects: EffectSet::PURE,
+            span: s(),
+        };
+        let print_stmt = semantic_ir::Stmt::ExprStmt {
+            expr: Expr::BuiltinCall {
+                name: "print".into(),
+                args: vec![call],
+                effects: EffectSet::PURE,
+                span: s(),
+            },
+            span: s(),
+        };
+        let main = Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block { stmts: vec![print_stmt], value: Expr::NilLit { span: s() }, span: s() },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        };
+        let m = Module {
+            name: "demo".into(),
+            manifest: FeatureManifest::from_features(&[
+                Feature::KeywordParams,
+                Feature::Strings,
+                Feature::DynamicTyping,
+            ]),
+            imports: vec![],
+            exports: vec![],
+            functions: vec![f, main],
+            globals: vec![],
+            metadata: Metadata::new()
+                .with_source_language("test")
+                .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+            span: s(),
+        };
+        let a = compile(&m).expect("compile to python");
+        assert!(
+            a.source.contains("def h(a, *, b):"),
+            "required keyword param must be bare after `*`; got:\n{}",
+            a.source
+        );
+        assert!(a.source.contains("h(\"x\", b=\"y\")"), "got:\n{}", a.source);
+    }
+
+    #[test]
+    fn emit_keyword_param_after_rest_has_no_extra_star_py() {
+        // When a `*args`/`Rest` param is present it ALREADY forces keyword-only,
+        // so the backend must NOT inject a second bare `*` (that is a Python
+        // SyntaxError): `def g(*rest, kw=_SIR_MISSING):`.
+        use semantic_ir::{Param, ParamKind, Scope};
+        let f = Function {
+            name: "g".into(),
+            params: vec![
+                Param { name: "rest".into(), sir_type: None, kind: ParamKind::Rest, default: None, span: s() },
+                Param {
+                    name: "kw".into(),
+                    sir_type: None,
+                    kind: ParamKind::Keyword,
+                    default: Some(Box::new(Expr::IntLit { value: 1, span: s() })),
+                    span: s(),
+                },
+            ],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts: vec![],
+                value: Expr::VarRef { name: "kw".into(), scope: Scope::Param, span: s() },
+                span: s(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        };
+        let m = Module {
+            name: "demo".into(),
+            manifest: FeatureManifest::from_features(&[
+                Feature::KeywordParams,
+                Feature::DefaultParams,
+                Feature::DynamicTyping,
+            ]),
+            imports: vec![],
+            exports: vec![],
+            functions: vec![f],
+            globals: vec![],
+            metadata: Metadata::new()
+                .with_source_language("test")
+                .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+            span: s(),
+        };
+        let a = compile(&m).expect("compile to python");
+        assert!(
+            a.source.contains("def g(*rest, kw=_SIR_MISSING):"),
+            "a Rest param already forces keyword-only; no extra `*`; got:\n{}",
+            a.source
+        );
+        assert!(
+            !a.source.contains("*rest, *,"),
+            "must not emit a second bare `*` after `*rest`; got:\n{}",
+            a.source
+        );
+    }
+
+    #[test]
+    fn emit_keyword_arg_at_call_site_py() {
+        // Call side: a positional arg stays bare, a `KeywordArg` becomes
+        // `name=value`: `greet("hi", name="ada")`.
+        let call = greet_call(vec![Expr::KeywordArg {
+            name: "name".into(),
+            value: Box::new(Expr::StrLit { value: "ada".into(), span: s() }),
+            span: s(),
+        }]);
+        let a = compile(&kw_module(call)).expect("compile to python");
+        assert!(
+            a.source.contains("greet(\"hi\", name=\"ada\")"),
+            "keyword arg must emit as `name=value` after the positional; got:\n{}",
+            a.source
+        );
+    }
+
+    #[test]
+    fn end_to_end_keyword_default_omitted_executes_py() {
+        // Execution-proof: `greet("hi")` omits the optional keyword `name`, so
+        // the prologue resolves it to "world" → prints `hi, world`.
+        let a = compile(&kw_module(greet_call(vec![]))).expect("compile to python");
+        if let Some(stdout) = run_emitted_python(&a.source) {
+            assert_eq!(stdout, "hi, world\n", "emitted python printed unexpected output");
+        }
+    }
+
+    #[test]
+    fn end_to_end_keyword_arg_supplied_executes_py() {
+        // Execution-proof: `greet("hi", name="ada")` supplies the keyword, so
+        // the default is suppressed → prints `hi, ada`.
+        let call = greet_call(vec![Expr::KeywordArg {
+            name: "name".into(),
+            value: Box::new(Expr::StrLit { value: "ada".into(), span: s() }),
+            span: s(),
+        }]);
+        let a = compile(&kw_module(call)).expect("compile to python");
+        if let Some(stdout) = run_emitted_python(&a.source) {
+            assert_eq!(stdout, "hi, ada\n", "emitted python printed unexpected output");
+        }
     }
 }


### PR DESCRIPTION
## What

**KW2** of the keyword-params cascade — replaces the KW1 compile-compat stubs in the Python backend with real native emission. Design: `code/specs/sir-keyword-params.md`.

- **Def side:** a `ParamKind::Keyword` param becomes a Python keyword-only parameter — a single bare `*` separator is injected before the first keyword param (suppressed when a `*args`/`Rest` already opens the keyword-only region, backed by the validator's `Required* Rest? Keyword* KwRest?` ordering). Optional keyword defaults reuse the crate's `_SIR_MISSING` sentinel + body-prologue resolution (the P2c default machinery) to preserve call-time, param-scoped default semantics — Python def-time defaults can't reference earlier params.
- **Call side:** `Expr::KeywordArg { name, value }` → `name=value` (name via `sanitize_ident`, value through the ordinary expr emitter).
- `Feature::KeywordParams` added to `ACCEPTED_FEATURES`.

## Verification

- `cargo test -p semantic-ir-to-python` — **77 passed** (+6: 4 emitted-shape, 2 execution-proof).
- **Execution-proof ran** (Python 3.13.14): `greet("hi")` → `hi, world`; `greet("hi", name="ada")` → `hi, ada`.
- Clippy: no new warnings on touched code.
- **Security review passed:** keyword names sanitized on both def and call sides; `*` separator can't emit invalid Python; safe (shell-less) subprocess in the execution test.

Part of the KW2–KW6 backend fan-out (all rebased on the merged KW1 core); frontends KW7 (Ruby → 1.0 unblock) + KW8 (Python) follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)