### PR TITLE
feat(semantic-ir-to-javascript): keyword-parameter & argument emission (KW4)

### DIFF
--- a/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
@@ -4,16 +4,56 @@ All notable changes to `semantic-ir-to-javascript` are documented here.
 
 ## Unreleased
 
-### Changed
-
-- Compile-compat stub arms for the new core `semantic-ir` variants
-  `ParamKind::Keyword` / `Expr::KeywordArg` (KW1). A single `Keyword` param
-  emits as a best-effort trailing positional (combined with `KwRest`);
-  `emit_expr` follows the crate's deferred-node convention (positioned
-  panic). Real keyword-parameter support is pending KW2–KW8.
-
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.4.0 — KW4 (keyword-parameter & argument emission)
+
+Replaces the KW1 compile-compat stubs with **real** keyword-parameter and
+keyword-argument emission.  JavaScript has no native keyword-argument call
+form, so — exactly as the TypeScript backend does (spec §4) — keyword
+constructs lower to a zero-dependency **options object**.  No runtime
+library is required; the lowering is direct.
+
+### Added
+
+- `accepts_features()` now declares `KeywordParams` (mirrors `DefaultParams`).
+- **Def side.** A function's `Keyword` params (`def f(a:)` / `def f(a: 1)`)
+  are folded into a single trailing options-object parameter `__kw`; the
+  body prologue destructures it: `const { b, c = <default> } = __kw ?? {};`.
+  A **required** keyword (`Keyword`, `default: None`) destructures bare; an
+  **optional** keyword (`Keyword`, `default: Some(e)`) carries a JS
+  destructuring default `name = <e>`, which fires on `undefined` exactly
+  like SIR optional-keyword semantics.  The `?? {}` guard lets an
+  all-optional callee be called with no options object.  When a keyword
+  name is not a valid JS identifier, the prologue emits the explicit
+  `{ "raw key": sanitized_local }` rename form so the object key still
+  matches the call site.  `__kw` is collision-safe: `sanitize_ident` never
+  produces a leading `__`, so no user parameter can sanitize to it.
+- **Call side.** In a call's `args`, positionals emit as before and every
+  `Expr::KeywordArg` collapses into one trailing object literal:
+  `f(1, b: 2, c: 3)` → `f(1, { b: 2, c: 3 })`; a call with only keyword
+  args → `f({ b: 2 })`; none → no trailing object.  `IndirectCall` routes
+  the same object as the last element of its argument array.  The object
+  key is the raw keyword `name`, matching the callee's destructuring
+  prologue.  A new `emit_call_args` helper drives both call sites.
+
+### Changed
+
+- The `emit_expr` `KeywordArg` arm is now a pure defensive panic: keyword
+  args are peeled off by `emit_call_args` before recursion, so reaching
+  that arm signals a backend bug rather than a deferred feature.
+
+### Tests
+
+- Emitted-shape unit tests: trailing `__kw` object + destructuring
+  prologue (required & optional keywords), keyword-only function, call-side
+  object collapse (positional+keyword, keyword-only, none), and the
+  `IndirectCall` object placement.
+- Execution-proof through `node` (skips gracefully if absent):
+  `add(5)` defaults the omitted keyword to 10 (→15) and
+  `add(5, delta: 100)` supplies it (→105); a required-keyword call
+  `pick(chosen: 7)` returns 7.
 
 ## 0.3.0 — P2d (default-parameter emission)
 

--- a/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-javascript"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "Semantic IR → self-contained JavaScript source code (SIR18). Fifth backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-javascript/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/emit.rs
@@ -59,7 +59,7 @@
 use std::cell::Cell;
 use std::fmt::Write;
 
-use semantic_ir::{Block, Expr, Function, Global, Module, ParamKind, Scope, Stmt};
+use semantic_ir::{Block, Expr, Function, Global, Module, Param, ParamKind, Scope, Stmt};
 
 use crate::runtime::RUNTIME;
 
@@ -152,14 +152,32 @@ fn emit_function(out: &mut String, f: &Function) {
         first = false;
         out.push_str(&sanitize_ident(&c.name));
     }
+    // JavaScript has no native keyword-argument call form, so `Keyword`
+    // params (`def f(a:)` / `def f(a: 1)`) are lowered — exactly as the
+    // TypeScript backend does (spec §4) — to a single trailing
+    // **options-object** parameter (`__kw`).  The individual keyword names
+    // are recovered in the body prologue by destructuring that object (see
+    // `emit_keyword_prologue`).  So here we emit every *non-keyword* param
+    // in the signature and, iff the function declares any keyword params, a
+    // final `__kw`.
+    //
+    // Why `__kw` is collision-safe: like the backend's other synthetic
+    // names (`__Sir`, `__l`, `__sir_stop_*`), it relies on the convention
+    // that SIR-source identifiers do not begin with the `__` runtime
+    // prefix — `sanitize_ident` never *produces* a leading `__` (it prefixes
+    // `_$`), so no user parameter can sanitize to `__kw`.
+    let has_keyword_params = f.params.iter().any(|p| p.kind == ParamKind::Keyword);
     for p in &f.params {
-        if !first {
-            out.push_str(", ");
-        }
-        first = false;
         match p.kind {
+            // Keyword params are not emitted positionally; they are folded
+            // into the single trailing `__kw` object emitted after the loop.
+            ParamKind::Keyword => continue,
             // `*rest` → native JS rest parameter.
             ParamKind::Rest => {
+                if !first {
+                    out.push_str(", ");
+                }
+                first = false;
                 out.push_str("...");
                 out.push_str(&sanitize_ident(&p.name));
             }
@@ -167,13 +185,11 @@ fn emit_function(out: &mut String, f: &Function) {
             // v0 binds it as a trailing ordinary parameter — but this
             // backend does not accept the features that produce KwRest
             // yet, so in practice only `Required` is reached here.
-            // KW1 compile-compat stub: a single `Keyword` param has no native
-            // JS form (JS has no keyword-argument call), so mirror the
-            // `KwRest` best-effort — emit it as a trailing ordinary parameter.
-            // Real keyword-param support lands in KW2–KW6; the validator
-            // rejects `Feature::KeywordParams` until then, so this arm is
-            // unreachable today.
-            ParamKind::Required | ParamKind::KwRest | ParamKind::Keyword => {
+            ParamKind::Required | ParamKind::KwRest => {
+                if !first {
+                    out.push_str(", ");
+                }
+                first = false;
                 out.push_str(&sanitize_ident(&p.name));
                 // P2d: a defaulted param (`Param { default: Some(e) }`)
                 // becomes a native JS default parameter `name = <e>`.
@@ -192,9 +208,70 @@ fn emit_function(out: &mut String, f: &Function) {
             }
         }
     }
+    if has_keyword_params {
+        if !first {
+            out.push_str(", ");
+        }
+        out.push_str("__kw");
+    }
     out.push_str(") {\n");
+    if has_keyword_params {
+        emit_keyword_prologue(out, &f.params, 2);
+    }
     emit_function_body(out, &f.body, 2);
     out.push_str("}\n");
+}
+
+/// Emit the body prologue that unpacks the trailing `__kw` options object
+/// into the function's keyword-param locals (KW4).
+///
+/// For `def f(a, b:, c: 1)` this emits, at the top of the body:
+///
+/// ```js
+///   const { b, c = 1 } = __kw ?? {};
+/// ```
+///
+/// - A **required** keyword (`Keyword`, `default == None`) destructures to a
+///   bare `name` — the validator has already guaranteed the caller supplied
+///   it, so the key is always present.
+/// - An **optional** keyword (`Keyword`, `default == Some(e)`) destructures
+///   with a JS default `name = <e>`, which fills in when the caller omits
+///   the key (property is `undefined`).  JS destructuring defaults fire on
+///   `undefined` exactly like SIR optional-keyword semantics.
+/// - The `?? {}` guard means a callee with only optional keywords still
+///   works when the caller passes no options object at all (`f(1)`).
+///
+/// The **object key** is the raw source `name` (it must match the key the
+/// call site writes); the **bound local** is `sanitize_ident(name)`.  When
+/// they differ we emit the explicit `{ key: local }` rename form.
+fn emit_keyword_prologue(out: &mut String, params: &[Param], indent: usize) {
+    let pad = " ".repeat(indent);
+    let _ = write!(out, "{pad}const {{ ");
+    let mut first = true;
+    for p in params.iter().filter(|p| p.kind == ParamKind::Keyword) {
+        if !first {
+            out.push_str(", ");
+        }
+        first = false;
+        let local = sanitize_ident(&p.name);
+        if local == p.name {
+            // Shorthand `{ name }` / `{ name = default }` — key and binding
+            // coincide because the source name is already a valid JS ident.
+            out.push_str(&local);
+        } else {
+            // Rename `{ "raw key": local }` — the object key stays the raw
+            // source name so it lines up with the call site, but the local
+            // binding is the sanitized identifier.
+            out.push_str(&quote_js_string(&p.name));
+            out.push_str(": ");
+            out.push_str(&local);
+        }
+        if let Some(default) = &p.default {
+            out.push_str(" = ");
+            emit_expr(out, default, indent);
+        }
+    }
+    out.push_str(" } = __kw ?? {};\n");
 }
 
 /// Emit a block as a **function body** — a flat statement list followed
@@ -412,7 +489,7 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
         // closure defaults are unchanged / deferred.
         Expr::DirectCall { fn_name, args, .. } => {
             let _ = write!(out, "{}(", sanitize_ident(fn_name));
-            emit_args(out, args, indent);
+            emit_call_args(out, args, indent);
             out.push(')');
         }
         // `__Sir.applyClosure(target, [args…])` — invokes a first-class
@@ -421,7 +498,7 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
             out.push_str("__Sir.applyClosure(");
             emit_expr(out, target, indent);
             out.push_str(", [");
-            emit_args(out, args, indent);
+            emit_call_args(out, args, indent);
             out.push_str("])");
         }
         Expr::BuiltinCall { name, args, .. } => emit_builtin_call(out, name, args, indent),
@@ -509,13 +586,14 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
                 "emit reached an Intrinsic `{name}` at {span} — backend should have rejected it"
             );
         }
-        // KW1 compile-compat stub: keyword arguments (`f(a: 1)`) are gated
-        // behind `Feature::KeywordParams`, rejected at the capability check
-        // until real support lands in KW2–KW6.  Follow this crate's deferred
-        // -node convention (see `StrConcat` above): a positioned panic
-        // covering backend bugs only.  No real emission yet.
+        // A keyword argument (`f(a: 1)`) is **not** a first-class value: the
+        // validator guarantees it appears only inside a call's `args` vec,
+        // and `emit_call_args` peels every `KeywordArg` off into the trailing
+        // options object *before* recursing into `emit_expr`.  Reaching this
+        // arm therefore means a backend bug (a `KeywordArg` somewhere it was
+        // never meant to be), so we panic with the offending span.
         Expr::KeywordArg { span, .. } => {
-            panic!("javascript backend reached a deferred `KeywordArg` at {span} — not accepted yet (real support pending KW2–KW6)");
+            panic!("javascript backend reached a `KeywordArg` outside call-argument position at {span} — this is a backend bug (keyword args are collapsed by emit_call_args)");
         }
     }
 }
@@ -547,6 +625,70 @@ fn emit_args(out: &mut String, args: &[Expr], indent: usize) {
             out.push_str(", ");
         }
         emit_expr(out, a, indent);
+    }
+}
+
+/// Emit a **call**'s argument list (KW4), splitting positional args from
+/// keyword args.
+///
+/// A call's `args` vec holds positionals first, then zero or more
+/// `Expr::KeywordArg` (the validator enforces this ordering and rejects
+/// duplicate keyword names).  JavaScript has no keyword-call syntax, so —
+/// mirroring the def-side `__kw` options object and the TypeScript backend
+/// (spec §4) — every `KeywordArg` collapses into a single trailing object
+/// literal:
+///
+/// ```text
+///   f(1, a: 2, b: 3)   →   f(1, { a: 2, b: 3 })
+///   f(1)               →   f(1)                    // no keyword args → no object
+///   f(a: 2)            →   f({ a: 2 })
+/// ```
+///
+/// The object key is the raw keyword `name` — the exact string the callee's
+/// destructuring prologue (`emit_keyword_prologue`) reads — so the two sides
+/// line up regardless of identifier sanitisation.
+fn emit_call_args(out: &mut String, args: &[Expr], indent: usize) {
+    // Positionals are every arg that is not a keyword.  Because the
+    // validator forbids a positional after a keyword, this is exactly the
+    // leading run of the vec; a `filter` is equivalent and order-preserving.
+    let positionals = args.iter().filter(|a| !matches!(a, Expr::KeywordArg { .. }));
+    let mut wrote_any = false;
+    for a in positionals {
+        if wrote_any {
+            out.push_str(", ");
+        }
+        wrote_any = true;
+        emit_expr(out, a, indent);
+    }
+
+    let mut first_kw = true;
+    for a in args {
+        if let Expr::KeywordArg { name, value, .. } = a {
+            if first_kw {
+                // Open the single trailing options object, preceded by a
+                // comma iff any positional args were already written.
+                if wrote_any {
+                    out.push_str(", ");
+                }
+                out.push_str("{ ");
+                first_kw = false;
+            } else {
+                out.push_str(", ");
+            }
+            // `key: value`.  A raw source name that is a valid JS ident can
+            // be a bare property key; otherwise quote it.  Either form is
+            // read back identically by the destructuring prologue.
+            if is_valid_js_ident(name) {
+                out.push_str(name);
+            } else {
+                out.push_str(&quote_js_string(name));
+            }
+            out.push_str(": ");
+            emit_expr(out, value, indent);
+        }
+    }
+    if !first_kw {
+        out.push_str(" }");
     }
 }
 
@@ -1527,6 +1669,132 @@ mod tests {
             span: s(),
         };
         assert_eq!(emit_e(&dc), "f(5)");
+    }
+
+    // ── KW4: keyword parameters & arguments ───────────────────────
+
+    fn kw_param(name: &str, default: Option<Expr>) -> Param {
+        Param {
+            name: name.into(),
+            sir_type: None,
+            kind: ParamKind::Keyword,
+            default: default.map(Box::new),
+            span: s(),
+        }
+    }
+
+    fn req_param(name: &str) -> Param {
+        Param { name: name.into(), sir_type: None, kind: ParamKind::Required, default: None, span: s() }
+    }
+
+    #[test]
+    fn emit_keyword_params_become_trailing_options_object() {
+        // def f(a, b:, c: 1)  →
+        //   function f(a, __kw) { const { b, c = 1 } = __kw ?? {}; … }
+        // `b` (no default) destructures bare; `c` (default 1) carries a JS
+        // destructuring default; both fold into the single trailing `__kw`.
+        let f = fun(
+            "f",
+            vec![req_param("a"), kw_param("b", None), kw_param("c", Some(int(1)))],
+            Block {
+                stmts: vec![],
+                value: Expr::VarRef { name: "b".into(), scope: Scope::Param, span: s() },
+                span: s(),
+            },
+        );
+        let mut out = String::new();
+        emit_function(&mut out, &f);
+        assert!(out.contains("function f(a, __kw) {"), "signature: {out}");
+        assert!(out.contains("const { b, c = 1 } = __kw ?? {};"), "prologue: {out}");
+    }
+
+    #[test]
+    fn emit_keyword_only_function_has_no_positional_params() {
+        // def f(x:)  →  function f(__kw) { const { x } = __kw ?? {}; … }
+        // A required keyword with no positionals: `__kw` is the *only*
+        // parameter, and `x` destructures without a default.
+        let f = fun(
+            "f",
+            vec![kw_param("x", None)],
+            Block {
+                stmts: vec![],
+                value: Expr::VarRef { name: "x".into(), scope: Scope::Param, span: s() },
+                span: s(),
+            },
+        );
+        let mut out = String::new();
+        emit_function(&mut out, &f);
+        assert!(out.contains("function f(__kw) {"), "signature: {out}");
+        assert!(out.contains("const { x } = __kw ?? {};"), "prologue: {out}");
+    }
+
+    #[test]
+    fn emit_function_without_keyword_params_has_no_kw_object() {
+        // A function with only positionals must be byte-for-byte unchanged:
+        // no `__kw` param, no destructuring prologue.
+        let f = fun(
+            "g",
+            vec![req_param("a")],
+            Block { stmts: vec![], value: int(0), span: s() },
+        );
+        let mut out = String::new();
+        emit_function(&mut out, &f);
+        assert!(out.contains("function g(a) {"), "got {out}");
+        assert!(!out.contains("__kw"), "no options object expected: {out}");
+    }
+
+    /// Build a `KeywordArg` call-argument.
+    fn kw_arg(name: &str, value: Expr) -> Expr {
+        Expr::KeywordArg { name: name.into(), value: Box::new(value), span: s() }
+    }
+
+    #[test]
+    fn emit_call_collapses_keyword_args_into_trailing_object() {
+        // f(1, b: 2, c: 3)  →  f(1, { b: 2, c: 3 })
+        let dc = Expr::DirectCall {
+            fn_name: "f".into(),
+            args: vec![int(1), kw_arg("b", int(2)), kw_arg("c", int(3))],
+            effects: EffectSet::PURE,
+            span: s(),
+        };
+        assert_eq!(emit_e(&dc), "f(1, { b: 2, c: 3 })");
+    }
+
+    #[test]
+    fn emit_call_with_only_keyword_args_has_no_leading_comma() {
+        // f(a: 2)  →  f({ a: 2 })  — no positionals, so no leading comma.
+        let dc = Expr::DirectCall {
+            fn_name: "f".into(),
+            args: vec![kw_arg("a", int(2))],
+            effects: EffectSet::PURE,
+            span: s(),
+        };
+        assert_eq!(emit_e(&dc), "f({ a: 2 })");
+    }
+
+    #[test]
+    fn emit_call_without_keyword_args_emits_no_object() {
+        // f(1, 2)  →  f(1, 2)  — plain positional call, unchanged.
+        let dc = Expr::DirectCall {
+            fn_name: "f".into(),
+            args: vec![int(1), int(2)],
+            effects: EffectSet::PURE,
+            span: s(),
+        };
+        assert_eq!(emit_e(&dc), "f(1, 2)");
+    }
+
+    #[test]
+    fn emit_indirect_call_keyword_args_go_into_the_arg_array() {
+        // Closure application routes args through `[…]`; the keyword object
+        // is the last element of that array: applyClosure(t, [1, { b: 2 }]).
+        let ic = Expr::IndirectCall {
+            target: Box::new(Expr::VarRef { name: "t".into(), scope: Scope::Local, span: s() }),
+            args: vec![int(1), kw_arg("b", int(2))],
+            effects: EffectSet::PURE,
+            span: s(),
+        };
+        assert_eq!(emit_e(&ic), "__Sir.applyClosure(t, [1, { b: 2 }])");
     }
 
     #[test]

--- a/code/packages/rust/semantic-ir-to-javascript/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/lib.rs
@@ -113,6 +113,13 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     // short DirectCall to the bare args (defaults fill omitted trailing
     // params).  See `emit_function` / `emit_expr`'s `DirectCall` arm.
     Feature::DefaultParams,
+    // KW4: keyword parameters & arguments.  JavaScript has no native
+    // keyword-call form, so `emit` lowers `Keyword` params to a trailing
+    // `__kw` options object (destructured in the body prologue) and each
+    // `Expr::KeywordArg` at a call site into a trailing object literal —
+    // the same zero-dependency, direct lowering the TypeScript backend
+    // uses (spec §4).  Accepted here exactly as `DefaultParams` is.
+    Feature::KeywordParams,
 ];
 
 impl Backend for JavaScriptBackend {

--- a/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
@@ -564,3 +564,216 @@ fn mutable_reassignment_updates_binding() {
         assert_eq!(stdout, "42");
     }
 }
+
+#[test]
+fn keyword_params_options_object_omitted_and_supplied() {
+    // KW4 discriminating execution-proof.  Build a module with a function
+    // that has one positional and one *optional* keyword param:
+    //
+    //   function add(base, __kw) { const { delta = 10 } = __kw ?? {};
+    //                              return base + delta; }
+    //   function main() { print(add(5)); print(add(5, delta: 100)); }
+    //
+    // - `add(5)`             omits the keyword → default 10 fires → 15.
+    // - `add(5, delta: 100)` supplies it       → 100 used         → 105.
+    //
+    // Printing 15 then 105 proves (a) the callee destructures `__kw` and its
+    // JS default fills an omitted keyword, and (b) a supplied `KeywordArg`
+    // collapses into the trailing options object and overrides the default.
+    use semantic_ir::{Param, ParamKind};
+
+    let base = Param {
+        name: "base".into(),
+        sir_type: None,
+        kind: ParamKind::Required,
+        default: None,
+        span: sp(),
+    };
+    let delta = Param {
+        name: "delta".into(),
+        sir_type: None,
+        kind: ParamKind::Keyword,
+        default: Some(Box::new(int(10))),
+        span: sp(),
+    };
+    let param_ref = |n: &str| Expr::VarRef { name: n.into(), scope: Scope::Param, span: sp() };
+
+    let add = Function {
+        name: "add".into(),
+        params: vec![base, delta],
+        return_type: None,
+        captures: vec![],
+        body: Block {
+            stmts: vec![],
+            value: bc("+", vec![param_ref("base"), param_ref("delta")]),
+            span: sp(),
+        },
+        effects: EffectSet::PURE,
+        metadata: Metadata::new(),
+        span: sp(),
+    };
+
+    let kw_arg = |name: &str, value: Expr| Expr::KeywordArg {
+        name: name.into(),
+        value: Box::new(value),
+        span: sp(),
+    };
+    let call_omitted = Expr::DirectCall {
+        fn_name: "add".into(),
+        args: vec![int(5)],
+        effects: EffectSet::PURE,
+        span: sp(),
+    };
+    let call_supplied = Expr::DirectCall {
+        fn_name: "add".into(),
+        args: vec![int(5), kw_arg("delta", int(100))],
+        effects: EffectSet::PURE,
+        span: sp(),
+    };
+
+    let main = Function {
+        name: "main".into(),
+        params: vec![],
+        return_type: None,
+        captures: vec![],
+        body: Block {
+            stmts: vec![print(call_omitted), print(call_supplied)],
+            value: Expr::NilLit { span: sp() },
+            span: sp(),
+        },
+        effects: EffectSet::PURE,
+        metadata: Metadata::new(),
+        span: sp(),
+    };
+
+    let module = Module {
+        name: "kwparams".into(),
+        manifest: FeatureManifest::from_features(&[
+            Feature::KeywordParams,
+            Feature::DynamicTyping,
+        ]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![add, main],
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("handbuilt")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: sp(),
+    };
+
+    // Shape check first (runs even without node): the callee folds the
+    // keyword into a trailing `__kw` object, destructures it with the JS
+    // default, and the supplied call collapses the keyword into an object.
+    let artifact = compile(&module).expect("compile to javascript");
+    assert!(
+        artifact.source.contains("function add(base, __kw) {"),
+        "expected trailing __kw options object, got:\n{}",
+        artifact.source
+    );
+    assert!(
+        artifact.source.contains("const { delta = 10 } = __kw ?? {};"),
+        "expected keyword destructuring prologue, got:\n{}",
+        artifact.source
+    );
+    assert!(
+        artifact.source.contains("__Sir.print(add(5))"),
+        "omitted-keyword call should have no options object, got:\n{}",
+        artifact.source
+    );
+    assert!(
+        artifact.source.contains("__Sir.print(add(5, { delta: 100 }))"),
+        "supplied keyword should collapse into a trailing object, got:\n{}",
+        artifact.source
+    );
+
+    if let Some(stdout) = run_module(&module, "kwparams") {
+        assert_eq!(
+            stdout, "15\n105",
+            "add(5) must default delta to 10 (→15); add(5, delta: 100) must use 100 (→105)"
+        );
+    }
+}
+
+#[test]
+fn required_keyword_param_supplied_by_call() {
+    // A *required* keyword (no default) must destructure bare and be filled
+    // by the caller.  Mirrors the spec's `greet(greeting:, …)` shape:
+    //
+    //   function pick(__kw) { const { chosen } = __kw ?? {}; return chosen; }
+    //   function main() { print(pick(chosen: 7)); }   → 7
+    use semantic_ir::{Param, ParamKind};
+
+    let chosen = Param {
+        name: "chosen".into(),
+        sir_type: None,
+        kind: ParamKind::Keyword,
+        default: None,
+        span: sp(),
+    };
+    let pick = Function {
+        name: "pick".into(),
+        params: vec![chosen],
+        return_type: None,
+        captures: vec![],
+        body: Block {
+            stmts: vec![],
+            value: Expr::VarRef { name: "chosen".into(), scope: Scope::Param, span: sp() },
+            span: sp(),
+        },
+        effects: EffectSet::PURE,
+        metadata: Metadata::new(),
+        span: sp(),
+    };
+    let call = Expr::DirectCall {
+        fn_name: "pick".into(),
+        args: vec![Expr::KeywordArg {
+            name: "chosen".into(),
+            value: Box::new(int(7)),
+            span: sp(),
+        }],
+        effects: EffectSet::PURE,
+        span: sp(),
+    };
+    let main = Function {
+        name: "main".into(),
+        params: vec![],
+        return_type: None,
+        captures: vec![],
+        body: Block { stmts: vec![print(call)], value: Expr::NilLit { span: sp() }, span: sp() },
+        effects: EffectSet::PURE,
+        metadata: Metadata::new(),
+        span: sp(),
+    };
+    let module = Module {
+        name: "kwreq".into(),
+        manifest: FeatureManifest::from_features(&[
+            Feature::KeywordParams,
+            Feature::DynamicTyping,
+        ]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![pick, main],
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("handbuilt")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: sp(),
+    };
+
+    let artifact = compile(&module).expect("compile to javascript");
+    assert!(
+        artifact.source.contains("function pick(__kw) {"),
+        "keyword-only function should have __kw as its sole param, got:\n{}",
+        artifact.source
+    );
+    assert!(
+        artifact.source.contains("const { chosen } = __kw ?? {};"),
+        "required keyword destructures bare (no default), got:\n{}",
+        artifact.source
+    );
+
+    if let Some(stdout) = run_module(&module, "kwreq") {
+        assert_eq!(stdout, "7", "pick(chosen: 7) must return 7");
+    }
+}


### PR DESCRIPTION
## What

**KW4** of the keyword-params cascade — replaces the KW1 compile-compat stubs in the JavaScript backend with real options-object emission. Design: `code/specs/sir-keyword-params.md` §4.

- **Def side:** `Keyword` params fold into a single trailing `__kw` param, destructured in a body prologue: `const { b, c = <default> } = __kw ?? {};` (required → bare name, optional → its default expression).
- **Call side:** trailing `Expr::KeywordArg`s collapse into one object literal `{ name: value }` (for both DirectCall and IndirectCall); no keyword args → no trailing object.
- `Feature::KeywordParams` added to `ACCEPTED_FEATURES`.

## Verification

- `cargo test -p semantic-ir-to-javascript` — **85 green** (69 unit + 16 integration).
- **Execution-proof ran** (node v24.16.0): `add(5)` → `15` (default fires), `add(5, delta:100)` → `105`, `pick(chosen:7)` → `7` (required keyword).
- Clippy: no new warnings on touched files.
- **Security review passed:** all user-derived identifiers sanitized (bound locals via `sanitize_ident`, object keys via `quote_js_string` or validated bare-ident); reserved-word keyword names handled; the `emit_expr` KeywordArg panic is unreachable for valid input (validator confines KeywordArg to call-arg position); safe shell-less subprocess in the node test.

No runtime library — pure options-object direct lowering. Part of the KW2–KW6 backend fan-out on the merged KW1 core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)