### PR TITLE
feat(semantic-ir-to-typescript): keyword-parameter & argument emission (KW3)

### DIFF
--- a/code/packages/rust/semantic-ir-to-typescript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-typescript/CHANGELOG.md
@@ -2,15 +2,49 @@
 
 ## Unreleased
 
-### Changed
+## 0.3.0 — keyword-parameter & argument emission (KW3)
 
-- Compile-compat stub arms for the new core `semantic-ir` variants
-  `ParamKind::Keyword` / `Expr::KeywordArg` (KW1). Analysis passes
-  (builtin-usage scan, assigned-local collection) recurse into the keyword
-  arg's inner `value`; a single `Keyword` param emits as a best-effort typed
-  positional (combined with `KwRest`); `emit_expr` follows the crate's
-  unsupported-node convention. Real keyword-parameter support is pending
-  KW2–KW8.
+Keyword parameters (`ParamKind::Keyword`) and keyword arguments
+(`Expr::KeywordArg`) now lower to real TypeScript, replacing the KW1
+compile-compat stubs. `Feature::KeywordParams` is added to the backend's
+accepted feature set (mirroring `DefaultParams`). See
+`code/specs/sir-keyword-params.md` §4.
+
+- **Def side — trailing options object.** TypeScript has no native keyword
+  arguments, so all of a function's `Keyword` params collapse into ONE trailing
+  parameter, `__kw`, appended after the positionals. The function body opens
+  with a destructure prologue binding each keyword:
+
+  ```text
+  def f(a, x:, y: 1)  →  function f(a: __Sir.Val, __kw: __Sir.Val): __Sir.Val {
+                           const { x, y = 1 } = (__kw ?? {}) as { [k: string]: __Sir.Val };
+                           …
+                         }
+  ```
+
+  A *required* keyword (`default: None`) destructures as a bare name; an
+  *optional* one (`default: Some(e)`) carries its default expression (`y = 1`),
+  so an omitted optional falls back to it. `__kw ?? {}` tolerates a caller that
+  supplies no keyword object at all (every keyword optional and omitted). The
+  `__`-prefix is the backend's reserved namespace (`__Sir`, `__l`, …), so
+  `__kw` cannot shadow a user binding. A function with no keyword params is
+  byte-for-byte unchanged (no `__kw`, no prologue).
+
+- **Call side — collapsed object literal.** Every `KeywordArg` in a call
+  (always trailing, per the validator) collapses into one trailing object
+  literal; positionals emit as before. `f(1, y: 2)` → `f(1, { y: 2 })`; a call
+  with no keyword args emits no trailing object.
+
+- **Direct lowering, no runtime helper** — same posture as `DefaultParams`.
+  Default and value expressions lower through the ordinary expression emitter.
+
+- **Tests.** Emitted-shape unit tests (destructure prologue for
+  required+optional; call collapsing to one/two-entry objects; positional +
+  keyword mix; no-keyword-args emits no object) plus a `node` execution proof
+  (`tests/run_with_node.rs`): the spec's `greet(greeting:, name: "world")`
+  program prints `hi, world` (optional omitted) and `hi, sir` (supplied), and a
+  positional+keyword mix prints `A!` / `B-`. Node is optional — the test
+  degrades to shape assertions when it is absent.
 
 ## 0.2.0 — default-parameter emission (P2b)
 

--- a/code/packages/rust/semantic-ir-to-typescript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-typescript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-typescript"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Semantic IR → self-contained TypeScript source code (SIR12). First backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-typescript/README.md
+++ b/code/packages/rust/semantic-ir-to-typescript/README.md
@@ -54,6 +54,15 @@ The TypeScript backend accepts these SIR features:
   padding) and the native default fills the rest. So `def f(a, b = a + 1)`
   emits `function f(a: __Sir.Val, b: __Sir.Val = __Sir.add(a, 1))`, and `f(5)`
   emits `f(5)`.
+- `KeywordParams` (KW3) — keyword parameters and arguments lower to the
+  conventional "options object". TypeScript has no native keyword arguments, so
+  a function's `Keyword` params collapse into ONE trailing `__kw` parameter,
+  destructured in the body prologue (required keyword → bare name, optional →
+  its default): `def f(a, x:, y: 1)` emits
+  `function f(a: __Sir.Val, __kw: __Sir.Val)` with
+  `const { x, y = 1 } = (__kw ?? {}) as { [k: string]: __Sir.Val };`. On the
+  call side every `KeywordArg` collapses into one trailing object literal:
+  `f(1, y: 2)` emits `f(1, { y: 2 })`. Direct lowering, no runtime helper.
 
 It **rejects**:
 

--- a/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
@@ -303,7 +303,42 @@ fn emit_function(out: &mut String, f: &Function) {
         first = false;
         let _ = write!(out, "{}: __Sir.Val", sanitize_ident(&c.name));
     }
+    // KW3 — keyword parameters lower to a single trailing "options object".
+    //
+    // TypeScript (like JavaScript) has NO native keyword-argument syntax: a
+    // caller cannot write `f(y: 2)` and have `y` bound by name to a formal
+    // parameter.  The idiomatic, zero-runtime equivalent is the *options
+    // object* — one trailing parameter that carries a bag of named values,
+    // destructured on entry.  So for a definition
+    //
+    //     def f(a, x:, y: 1)          # a positional, x required-kw, y opt-kw
+    //
+    // we emit
+    //
+    //     function f(a: __Sir.Val, __kw: __Sir.Val): __Sir.Val {
+    //       const { x, y = 1 } = (__kw ?? {}) as { [k: string]: __Sir.Val };
+    //       …
+    //     }
+    //
+    // The destructure carries each *optional* keyword's default (`y = 1`) and
+    // omits it for a *required* one (`x`) — matching the call side, which for
+    // a validator-accepted call always supplies every required keyword.  We
+    // split the param list rather than interleave: all `Keyword` params
+    // collapse into the ONE `__kw` object, appended after the positionals, so
+    // the arity of the JS parameter list stays `positionals + 1`.
+    //
+    // Why `__kw`?  The `__`-prefix is this backend's reserved namespace for
+    // synthesized bindings (`__Sir`, `__SirOop`, `__l`, `__sir_result`, …).
+    // A user keyword name never round-trips through the frontends as `__kw`,
+    // and `sanitize_ident` passes real user idents through verbatim, so the
+    // options-object parameter cannot shadow a user binding in practice.
+    let keyword_params: Vec<&semantic_ir::Param> = f.keyword_params();
     for p in &f.params {
+        // Keyword params are NOT emitted inline — they fold into the trailing
+        // `__kw` object handled after this loop.  Skip them here.
+        if p.kind == ParamKind::Keyword {
+            continue;
+        }
         if !first {
             out.push_str(", ");
         }
@@ -321,14 +356,8 @@ fn emit_function(out: &mut String, f: &Function) {
             ParamKind::Rest => {
                 let _ = write!(out, "...{}: __Sir.Val[]", sanitize_ident(&p.name));
             }
-            // KW1 compile-compat stub: a single `Keyword` param has no
-            // faithful native JS/TS declaration (JS has no keyword-call form),
-            // so mirror the `KwRest` best-effort — emit it as an ordinary
-            // trailing typed parameter (`name: __Sir.Val`).  The inner
-            // `Required`-only guard below withholds a default, matching the
-            // KwRest treatment.  Real keyword-param support lands in KW2–KW6;
-            // the validator rejects `Feature::KeywordParams` until then, so
-            // this arm is unreachable today.
+            // Keyword handled above (skipped); this arm covers positionals and
+            // the KwRest object fallback.
             ParamKind::Required | ParamKind::KwRest | ParamKind::Keyword => {
                 let _ = write!(out, "{}: __Sir.Val", sanitize_ident(&p.name));
                 // P2b default parameters.  A SIR default is evaluated
@@ -354,7 +383,39 @@ fn emit_function(out: &mut String, f: &Function) {
             }
         }
     }
+    // Append the single trailing options-object parameter iff the function has
+    // any keyword params.  (No keyword params → no `__kw`, so ordinary
+    // positional functions are byte-for-byte unchanged.)
+    if !keyword_params.is_empty() {
+        if !first {
+            out.push_str(", ");
+        }
+        out.push_str("__kw: __Sir.Val");
+    }
     out.push_str("): __Sir.Val {\n");
+
+    // Body prologue: destructure the options object into the keyword bindings.
+    // Each required keyword (`default: None`) is a bare name; each optional
+    // (`default: Some(e)`) carries its default expression, so an omitted
+    // optional falls back to `e`.  `__kw ?? {}` tolerates a caller that
+    // supplied NO keywords at all (the object is then absent → `undefined`),
+    // which happens when every keyword is optional and the call omits them.
+    if !keyword_params.is_empty() {
+        out.push_str("  const { ");
+        for (i, p) in keyword_params.iter().enumerate() {
+            if i > 0 {
+                out.push_str(", ");
+            }
+            out.push_str(&sanitize_ident(&p.name));
+            if let Some(default) = &p.default {
+                out.push_str(" = ");
+                emit_expr(out, default, 2);
+            }
+        }
+        // Cast the untyped `Val` to an index signature so the destructure
+        // typechecks under `strict` — the runtime shape is a plain object.
+        out.push_str(" } = (__kw ?? {}) as { [k: string]: __Sir.Val };\n");
+    }
 
     // Pre-pass: any local that is later reassigned must bind with `let`.
     MUTABLE_NAMES.with(|m| {
@@ -926,15 +987,16 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
             }
             out.push(')');
         }
-        // KW1 compile-compat stub: keyword arguments (`f(a: 1)`) are gated
-        // behind `Feature::KeywordParams`, which the validator rejects until
-        // real support lands in KW2–KW6.  Follow this crate's convention for
-        // an unsupported codegen node the capability check should have
-        // rejected (see the `Intrinsic` panic): a positioned panic covering
-        // internal bugs only.  No real emission yet.
+        // KW3 — a `KeywordArg` is NOT a first-class value: it only ever
+        // appears inside a call's `args`, where `emit_call_args` collapses the
+        // trailing run of them into one options-object literal (never routing
+        // them through `emit_expr`).  The validator (spec rule 6) rejects a
+        // `KeywordArg` in any other position, so reaching this arm means the
+        // call path bypassed `emit_call_args` — an internal backend bug.  A
+        // positioned panic surfaces it (mirrors the `Intrinsic` guard).
         Expr::KeywordArg { span, .. } => {
             panic!(
-                "typescript backend reached KW1 keyword-arg expression at {} — backend should have rejected it (real support pending KW2–KW6)",
+                "typescript backend reached a bare keyword-arg expression at {} — a KeywordArg must be collapsed by emit_call_args, never emitted as a value",
                 span
             );
         }
@@ -1066,22 +1128,43 @@ fn is_double_splat(a: &Expr) -> bool {
 ///
 /// v0 cut-line: mixing inline `key: value` pairs with `**h` at one call site is
 /// not modelled — only explicit `**map` operands are merged.
+///
+/// **KW3 — keyword arguments (`f(1, y: 2)`).**  A named keyword argument
+/// reaches the backend as an [`Expr::KeywordArg`] inside `args`, always AFTER
+/// every positional (the validator enforces the ordering).  The def side folds
+/// keyword *parameters* into a trailing `__kw` options object, so the call side
+/// must supply that object: every `KeywordArg` in this call collapses into ONE
+/// trailing object literal `{ name: value, … }`.  With no keyword args the
+/// object is omitted entirely, so an ordinary positional call is unchanged:
+///
+/// | SIR `args`                                   | emitted            |
+/// |----------------------------------------------|--------------------|
+/// | `[Int(1)]`                                    | `f(1)`             |
+/// | `[Int(1), KeywordArg{y, Int(2)}]`             | `f(1, { y: 2 })`   |
+/// | `[KeywordArg{x,…}, KeywordArg{y,…}]`          | `f({ x: …, y: … })`|
 fn emit_call_args(out: &mut String, args: &[Expr], indent: usize) {
+    // Split positionals from the trailing run of keyword arguments.  Because
+    // the validator guarantees every `KeywordArg` follows all positionals, the
+    // keyword args are exactly the trailing suffix — we partition once.
+    let n_positional = args.iter().take_while(|a| !is_keyword_arg(a)).count();
+    let positional = &args[..n_positional];
+    let keyword = &args[n_positional..];
+
     let mut first = true;
     let mut i = 0;
-    while i < args.len() {
+    while i < positional.len() {
         if !first {
             out.push_str(", ");
         }
         first = false;
-        if is_double_splat(&args[i]) {
+        if is_double_splat(&positional[i]) {
             // Gather this maximal contiguous run of `**` markers.
             let start = i;
-            while i < args.len() && is_double_splat(&args[i]) {
+            while i < positional.len() && is_double_splat(&positional[i]) {
                 i += 1;
             }
             out.push_str("__Sir.doubleSplatMerge(");
-            for (j, a) in args[start..i].iter().enumerate() {
+            for (j, a) in positional[start..i].iter().enumerate() {
                 if j > 0 {
                     out.push_str(", ");
                 }
@@ -1091,10 +1174,36 @@ fn emit_call_args(out: &mut String, args: &[Expr], indent: usize) {
             }
             out.push(')');
         } else {
-            emit_arg(out, &args[i], indent);
+            emit_arg(out, &positional[i], indent);
             i += 1;
         }
     }
+
+    // Collapse the trailing keyword arguments into one options-object literal
+    // that binds the callee's `__kw` parameter (see `emit_function`).  Each
+    // `KeywordArg { name, value }` becomes an object entry `name: <value>`;
+    // the value lowers through the ordinary expression emitter.
+    if !keyword.is_empty() {
+        if !first {
+            out.push_str(", ");
+        }
+        out.push_str("{ ");
+        for (j, a) in keyword.iter().enumerate() {
+            if j > 0 {
+                out.push_str(", ");
+            }
+            if let Expr::KeywordArg { name, value, .. } = a {
+                let _ = write!(out, "{}: ", sanitize_ident(name));
+                emit_expr(out, value, indent);
+            }
+        }
+        out.push_str(" }");
+    }
+}
+
+/// Is this argument a keyword argument (`f(y: 2)` → `Expr::KeywordArg`)?
+fn is_keyword_arg(a: &Expr) -> bool {
+    matches!(a, Expr::KeywordArg { .. })
 }
 
 fn emit_builtin_call(out: &mut String, name: &str, args: &[Expr], indent: usize) {

--- a/code/packages/rust/semantic-ir-to-typescript/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-typescript/src/lib.rs
@@ -114,6 +114,14 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     // inline (no runtime helper, no call-site padding).  Per
     // code/specs/sir-runtime.md.
     Feature::DefaultParams,
+    // KW3 keyword parameters & arguments — a `Keyword` param or an
+    // `Expr::KeywordArg`.  TypeScript has no native kwargs, so both lower to
+    // the conventional zero-runtime "options object" (see `emit::emit_function`
+    // / `emit::emit_call_args` and `code/specs/sir-keyword-params.md` §4): the
+    // callee gains a trailing `__kw` object destructured in its prologue, and a
+    // call collapses its keyword args into one trailing object literal.  Direct
+    // lowering, no runtime helper — mirrors how `DefaultParams` is declared.
+    Feature::KeywordParams,
 ];
 
 impl Backend for TypeScriptBackend {
@@ -1363,6 +1371,200 @@ mod tests {
             !a.source.contains("@coding-adventures/sir-runtime-range"),
             "unexpected range import; got:\n{}",
             a.source
+        );
+    }
+
+    // ── KW3: keyword parameters & arguments (options-object lowering) ──────
+
+    /// A callee with one required and one optional keyword param, plus a
+    /// leading positional, and two calls: one that omits the optional and one
+    /// that supplies it.  Mirrors the spec's canonical KW3 program shape.
+    fn keyword_module() -> Module {
+        use semantic_ir::{Param, ParamKind, Scope};
+
+        fn kw(name: &str, default: Option<Expr>) -> Param {
+            Param {
+                name: name.into(),
+                sir_type: None,
+                kind: ParamKind::Keyword,
+                default: default.map(Box::new),
+                span: s(),
+            }
+        }
+        let prefix = Param {
+            name: "prefix".into(),
+            sir_type: None,
+            kind: ParamKind::Required,
+            default: None,
+            span: s(),
+        };
+        // greet body just returns the required keyword `x` (value irrelevant to
+        // the shape assertions; the destructure prologue is what we inspect).
+        let f = Function {
+            name: "f".into(),
+            params: vec![
+                prefix,
+                kw("x", None),                                            // required keyword
+                kw("y", Some(Expr::IntLit { value: 1, span: s() })),      // optional keyword
+            ],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts: vec![],
+                value: Expr::VarRef { name: "x".into(), scope: Scope::Param, span: s() },
+                span: s(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        };
+
+        // f("p", x: 2)          — optional `y` omitted → one-entry object.
+        let call_omit = Expr::DirectCall {
+            fn_name: "f".into(),
+            args: vec![
+                Expr::StrLit { value: "p".into(), span: s() },
+                Expr::KeywordArg {
+                    name: "x".into(),
+                    value: Box::new(Expr::IntLit { value: 2, span: s() }),
+                    span: s(),
+                },
+            ],
+            effects: EffectSet::PURE,
+            span: s(),
+        };
+        // f("p", x: 2, y: 3)    — both keywords supplied → two-entry object.
+        let call_full = Expr::DirectCall {
+            fn_name: "f".into(),
+            args: vec![
+                Expr::StrLit { value: "p".into(), span: s() },
+                Expr::KeywordArg {
+                    name: "x".into(),
+                    value: Box::new(Expr::IntLit { value: 2, span: s() }),
+                    span: s(),
+                },
+                Expr::KeywordArg {
+                    name: "y".into(),
+                    value: Box::new(Expr::IntLit { value: 3, span: s() }),
+                    span: s(),
+                },
+            ],
+            effects: EffectSet::PURE,
+            span: s(),
+        };
+        let main = Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts: vec![semantic_ir::Stmt::ExprStmt { expr: call_omit, span: s() }],
+                value: call_full,
+                span: s(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        };
+        Module {
+            name: "kw".into(),
+            manifest: FeatureManifest::from_features(&[
+                Feature::KeywordParams,
+                Feature::Strings,
+                Feature::DynamicTyping,
+            ]),
+            imports: vec![],
+            exports: vec![],
+            functions: vec![f, main],
+            globals: vec![],
+            metadata: Metadata::new()
+                .with_source_language("test")
+                .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+            span: s(),
+        }
+    }
+
+    #[test]
+    fn keyword_params_fold_into_trailing_options_object_with_destructure() {
+        let m = keyword_module();
+        let a = compile(&m).expect("keyword module must compile (feature accepted)");
+        let src = &a.source;
+        // The positional `prefix` stays inline; both keyword params collapse
+        // into ONE trailing `__kw` object parameter.
+        assert!(
+            src.contains("function f(prefix: __Sir.Val, __kw: __Sir.Val): __Sir.Val {"),
+            "keyword params must fold into a single trailing __kw object; got:\n{src}"
+        );
+        // Prologue destructure: required keyword bare, optional carries default.
+        assert!(
+            src.contains(
+                "const { x, y = 1 } = (__kw ?? {}) as { [k: string]: __Sir.Val };"
+            ),
+            "prologue must destructure __kw, bare required + defaulted optional; got:\n{src}"
+        );
+    }
+
+    #[test]
+    fn keyword_call_collapses_args_into_single_object_literal() {
+        let m = keyword_module();
+        let a = compile(&m).expect("compile");
+        let src = &a.source;
+        // Omitting the optional → one-entry object; positional stays outside it.
+        assert!(
+            src.contains("f(\"p\", { x: 2 })"),
+            "omitted-optional call collapses keyword args to one object; got:\n{src}"
+        );
+        // Supplying both → two-entry object.
+        assert!(
+            src.contains("f(\"p\", { x: 2, y: 3 })"),
+            "full call collapses both keyword args into one object; got:\n{src}"
+        );
+    }
+
+    #[test]
+    fn no_keyword_args_emits_no_trailing_object() {
+        use semantic_ir::{Param, ParamKind, Scope};
+        // A callee with a keyword param, but a caller in an IndirectCall-free
+        // world that supplies only positionals for a purely-positional callee:
+        // here we build a callee with NO keyword params and confirm the call
+        // path is byte-for-byte the ordinary positional form (no `{ … }`).
+        let g = Function {
+            name: "g".into(),
+            params: vec![Param {
+                name: "a".into(),
+                sir_type: None,
+                kind: ParamKind::Required,
+                default: None,
+                span: s(),
+            }],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts: vec![],
+                value: Expr::VarRef { name: "a".into(), scope: Scope::Param, span: s() },
+                span: s(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        };
+        let call = Expr::DirectCall {
+            fn_name: "g".into(),
+            args: vec![Expr::IntLit { value: 7, span: s() }],
+            effects: EffectSet::PURE,
+            span: s(),
+        };
+        let mut m = module_with_main_body(vec![], call, &[Feature::DynamicTyping]);
+        m.functions.insert(0, g);
+        let a = compile(&m).expect("compile");
+        let src = &a.source;
+        assert!(
+            src.contains("function g(a: __Sir.Val): __Sir.Val {"),
+            "no keyword params → no __kw parameter; got:\n{src}"
+        );
+        assert!(
+            src.contains("g(7)") && !src.contains("g(7, {"),
+            "a call with no keyword args emits no trailing object; got:\n{src}"
         );
     }
 }

--- a/code/packages/rust/semantic-ir-to-typescript/tests/run_with_node.rs
+++ b/code/packages/rust/semantic-ir-to-typescript/tests/run_with_node.rs
@@ -1,0 +1,352 @@
+//! End-to-end integration test for KW3: SIR keyword params/args → TypeScript
+//! → runnable JavaScript → `node`.
+//!
+//! The unit tests in `src/lib.rs` prove the emitted *shape* (the trailing
+//! `__kw` options-object parameter, the destructure prologue, the collapsed
+//! call-site object literal).  This test proves the emitted *behaviour*: a
+//! keyword-using program actually produces the right stdout when executed.
+//!
+//! ## Why a TS→JS shim is needed here (and not in the JS backend)
+//!
+//! The JavaScript backend emits self-contained `.js` that `node` runs as-is.
+//! The TypeScript backend, by contrast, emits genuine TypeScript — `: __Sir.Val`
+//! annotations, an `as { … }` cast, and an `import * as __Sir from
+//! "@coding-adventures/sir-runtime-core"` — none of which bare `node` accepts.
+//! Rather than pull in a TypeScript toolchain (tsc/ts-node) as a test
+//! dependency, we perform a *minimal, mechanical* transform that is faithful
+//! for the small runtime surface these keyword programs touch:
+//!
+//!   1. strip the type annotations the emitter adds (`: __Sir.Val[]`,
+//!      `: __Sir.Val`, and the `as { [k: string]: __Sir.Val }` cast), and
+//!   2. replace the runtime import with a tiny inline `__Sir` stub providing
+//!      exactly the helpers the emitted code calls (`print`, `toDisplay`).
+//!
+//! The transform touches ONLY the type/preamble syntax — the actual emitted
+//! logic (the `__kw` destructure, the options-object call sites) runs
+//! unchanged, so what executes under `node` is precisely what the backend
+//! produced.  Node is optional: when it is absent the test degrades to the
+//! shape assertions and skips execution (mirroring the JS harness).
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use semantic_ir::{
+    Block, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, Param, ParamKind,
+    Scope, Span, Stmt,
+};
+use semantic_ir_to_typescript::compile;
+
+fn sp() -> Span {
+    Span::synthetic()
+}
+
+/// Is a working `node` on PATH?
+fn node_available() -> bool {
+    Command::new("node")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// A minimal `__Sir` runtime stub covering exactly the helpers the emitted
+/// keyword programs call.  `toDisplay` renders a value the way the real
+/// runtime does for the cases these tests exercise (strings verbatim); `print`
+/// writes one line to stdout.
+const SIR_STUB: &str = r#"const __Sir = {
+  toDisplay: (v) => (v === null ? "nil" : String(v)),
+  print: (v) => { console.log(__Sir.toDisplay(v)); return null; },
+};
+"#;
+
+/// Turn emitted TypeScript into runnable JavaScript for the node execution
+/// proof.  See the module doc-comment for why this is faithful.  Only
+/// type-syntax and the runtime import are rewritten.
+fn ts_to_runnable_js(ts: &str) -> String {
+    let mut js = ts.to_string();
+    // 1. Replace the runtime import line with the inline stub.
+    js = js.replace(
+        "import * as __Sir from \"@coding-adventures/sir-runtime-core\";\n",
+        SIR_STUB,
+    );
+    // 2. Drop the `as { … }` cast the `__kw` destructure carries.  (Fixed
+    //    text; the emitter always produces exactly this annotation.)
+    js = js.replace(" as { [k: string]: __Sir.Val }", "");
+    // 3. Strip type annotations.  `[]` variant first so `: __Sir.Val[]` is not
+    //    left with a dangling `[]`.
+    js = js.replace(": __Sir.Val[]", "");
+    js = js.replace(": __Sir.Val", "");
+    js
+}
+
+/// Compile a hand-built keyword module, transform to JS, run under node, and
+/// return trimmed stdout.  `None` when node is unavailable.
+fn run_module(module: &Module, tag: &str) -> Option<String> {
+    let artifact = compile(module).expect("compile to typescript");
+    if !node_available() {
+        eprintln!("note: `node` unavailable — skipping execution for `{tag}`");
+        return None;
+    }
+    let js = ts_to_runnable_js(&artifact.source);
+    let mut path: PathBuf = std::env::temp_dir();
+    path.push(format!("sir_ts_kw_{}_{}.js", tag, std::process::id()));
+    std::fs::write(&path, &js).expect("write temp js");
+    let output = Command::new("node").arg(&path).output().expect("spawn node");
+    let _ = std::fs::remove_file(&path);
+    assert!(
+        output.status.success(),
+        "node exited non-zero for `{tag}`:\nstdout: {}\nstderr: {}\nsource:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+        js,
+    );
+    let stdout = String::from_utf8(output.stdout).expect("utf8 stdout");
+    Some(stdout.trim_end_matches(['\n', '\r']).to_string())
+}
+
+// ── SIR builder helpers ────────────────────────────────────────────────
+
+fn kw_param(name: &str, default: Option<Expr>) -> Param {
+    Param {
+        name: name.into(),
+        sir_type: None,
+        kind: ParamKind::Keyword,
+        default: default.map(Box::new),
+        span: sp(),
+    }
+}
+
+fn str_lit(v: &str) -> Expr {
+    Expr::StrLit { value: v.into(), span: sp() }
+}
+
+fn param_ref(name: &str) -> Expr {
+    Expr::VarRef { name: name.into(), scope: Scope::Param, span: sp() }
+}
+
+fn kw_arg(name: &str, value: Expr) -> Expr {
+    Expr::KeywordArg { name: name.into(), value: Box::new(value), span: sp() }
+}
+
+fn print(expr: Expr) -> Stmt {
+    Stmt::ExprStmt {
+        expr: Expr::BuiltinCall {
+            name: "print".into(),
+            args: vec![expr],
+            effects: EffectSet::PURE,
+            span: sp(),
+        },
+        span: sp(),
+    }
+}
+
+/// Build the canonical KW3 program (from the spec's verification section):
+///
+///   def greet(greeting:, name: "world")
+///     "#{greeting}, #{name}"
+///   end
+///   print(greet(greeting: "hi"))            # omits the optional → "hi, world"
+///   print(greet(greeting: "hi", name: "sir"))   # supplies it     → "hi, sir"
+fn greet_module() -> Module {
+    // Body: greeting + ", " + name, via StrConcat (interpolation lowering).
+    let body_val = Expr::StrConcat {
+        parts: vec![param_ref("greeting"), str_lit(", "), param_ref("name")],
+        span: sp(),
+    };
+    let greet = Function {
+        name: "greet".into(),
+        params: vec![
+            kw_param("greeting", None),                 // required keyword
+            kw_param("name", Some(str_lit("world"))),   // optional keyword
+        ],
+        return_type: None,
+        captures: vec![],
+        body: Block { stmts: vec![], value: body_val, span: sp() },
+        effects: EffectSet::PURE,
+        metadata: Metadata::new(),
+        span: sp(),
+    };
+
+    let call_omit = Expr::DirectCall {
+        fn_name: "greet".into(),
+        args: vec![kw_arg("greeting", str_lit("hi"))],
+        effects: EffectSet::PURE,
+        span: sp(),
+    };
+    let call_full = Expr::DirectCall {
+        fn_name: "greet".into(),
+        args: vec![
+            kw_arg("greeting", str_lit("hi")),
+            kw_arg("name", str_lit("sir")),
+        ],
+        effects: EffectSet::PURE,
+        span: sp(),
+    };
+
+    let main = Function {
+        name: "main".into(),
+        params: vec![],
+        return_type: None,
+        captures: vec![],
+        body: Block {
+            stmts: vec![print(call_omit), print(call_full)],
+            value: Expr::NilLit { span: sp() },
+            span: sp(),
+        },
+        effects: EffectSet::PURE,
+        metadata: Metadata::new(),
+        span: sp(),
+    };
+
+    Module {
+        name: "kwgreet".into(),
+        manifest: FeatureManifest::from_features(&[
+            Feature::KeywordParams,
+            Feature::StringInterpolation,
+            Feature::Strings,
+            Feature::DynamicTyping,
+        ]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![greet, main],
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("handbuilt")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: sp(),
+    }
+}
+
+#[test]
+fn keyword_call_uses_default_when_optional_omitted() {
+    let module = greet_module();
+
+    // Shape check (runs even without node): the destructure prologue and the
+    // two collapsed call-site object literals.
+    let artifact = compile(&module).expect("compile");
+    let src = &artifact.source;
+    assert!(
+        src.contains("function greet(__kw: __Sir.Val): __Sir.Val {"),
+        "keyword params must fold into a single trailing __kw object; got:\n{src}"
+    );
+    assert!(
+        src.contains(
+            "const { greeting, name = \"world\" } = (__kw ?? {}) as { [k: string]: __Sir.Val };"
+        ),
+        "required keyword is bare, optional carries its default; got:\n{src}"
+    );
+    assert!(
+        src.contains("greet({ greeting: \"hi\" })"),
+        "omitting the optional collapses to a one-entry object; got:\n{src}"
+    );
+    assert!(
+        src.contains("greet({ greeting: \"hi\", name: \"sir\" })"),
+        "supplying both keywords collapses to a two-entry object; got:\n{src}"
+    );
+
+    // Behaviour check (runs when node is present).
+    if let Some(stdout) = run_module(&module, "greet") {
+        assert_eq!(
+            stdout, "hi, world\nhi, sir",
+            "greet(greeting: \"hi\") must default name to \"world\"; \
+             greet(greeting: \"hi\", name: \"sir\") must use \"sir\""
+        );
+    }
+}
+
+#[test]
+fn positional_and_keyword_mix_binds_both() {
+    // def label(prefix, tag: "-")
+    //   "#{prefix}#{tag}"
+    // end
+    // print(label("A", tag: "!"))   → "A!"
+    // print(label("B"))             → "B-"   (optional keyword defaulted)
+    let prefix = Param {
+        name: "prefix".into(),
+        sir_type: None,
+        kind: ParamKind::Required,
+        default: None,
+        span: sp(),
+    };
+    let tag = kw_param("tag", Some(str_lit("-")));
+    let body_val = Expr::StrConcat {
+        parts: vec![param_ref("prefix"), param_ref("tag")],
+        span: sp(),
+    };
+    let label = Function {
+        name: "label".into(),
+        params: vec![prefix, tag],
+        return_type: None,
+        captures: vec![],
+        body: Block { stmts: vec![], value: body_val, span: sp() },
+        effects: EffectSet::PURE,
+        metadata: Metadata::new(),
+        span: sp(),
+    };
+
+    let call_with_kw = Expr::DirectCall {
+        fn_name: "label".into(),
+        args: vec![str_lit("A"), kw_arg("tag", str_lit("!"))],
+        effects: EffectSet::PURE,
+        span: sp(),
+    };
+    let call_default = Expr::DirectCall {
+        fn_name: "label".into(),
+        args: vec![str_lit("B")],
+        effects: EffectSet::PURE,
+        span: sp(),
+    };
+
+    let main = Function {
+        name: "main".into(),
+        params: vec![],
+        return_type: None,
+        captures: vec![],
+        body: Block {
+            stmts: vec![print(call_with_kw), print(call_default)],
+            value: Expr::NilLit { span: sp() },
+            span: sp(),
+        },
+        effects: EffectSet::PURE,
+        metadata: Metadata::new(),
+        span: sp(),
+    };
+
+    let module = Module {
+        name: "kwmix".into(),
+        manifest: FeatureManifest::from_features(&[
+            Feature::KeywordParams,
+            Feature::StringInterpolation,
+            Feature::Strings,
+            Feature::DynamicTyping,
+        ]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![label, main],
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("handbuilt")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: sp(),
+    };
+
+    // Shape: the positional `prefix` stays inline; only `tag` folds into __kw.
+    let artifact = compile(&module).expect("compile");
+    let src = &artifact.source;
+    assert!(
+        src.contains("function label(prefix: __Sir.Val, __kw: __Sir.Val): __Sir.Val {"),
+        "positional param inline, keyword param via trailing __kw; got:\n{src}"
+    );
+    assert!(
+        src.contains("label(\"A\", { tag: \"!\" })"),
+        "positional then keyword object; got:\n{src}"
+    );
+    assert!(
+        src.contains("label(\"B\")"),
+        "no keyword args → no trailing object; got:\n{src}"
+    );
+
+    if let Some(stdout) = run_module(&module, "mix") {
+        assert_eq!(stdout, "A!\nB-", "keyword mix must bind positional and defaulted keyword");
+    }
+}


### PR DESCRIPTION
## What

**KW3** of the keyword-params cascade — replaces the KW1 compile-compat stubs in the TypeScript backend with real options-object emission. Design: `code/specs/sir-keyword-params.md` §4.

- **Def side:** `Keyword` params fold into one trailing `__kw: __Sir.Val` param, destructured in a body prologue: `const { x, y = <default> } = (__kw ?? {}) as { [k: string]: __Sir.Val };` (required → bare name, optional → its default expression).
- **Call side:** trailing `Expr::KeywordArg`s collapse into one object literal `{ name: value }`; no keyword args → positional call unchanged.
- `Feature::KeywordParams` added to `ACCEPTED_FEATURES`.

## Verification

- `cargo test -p semantic-ir-to-typescript` — **87 green** (85 lib + 2 integration).
- **Execution-proof ran** (node v24.16.0): `greet(greeting:"hi")` → `hi, world` (optional defaulted); `greet(greeting:"hi", name:"sir")` → `hi, sir`; positional+keyword mix → `A!`/`B-`.
- Clippy: no new warnings on touched lines.
- **Security review passed:** keyword names sanitized on both def (`sanitize_ident`) and call sides; key/binding stay in sync (validator resolves arg names against param names); prologue can't emit empty/duplicate destructure; the `emit_expr` KeywordArg panic is unreachable for valid input; the new node test harness (+ test-only TS→JS shim) is shell-less and fed test-controlled input only.

Note: this crate lacked a node execution harness, so I added `tests/run_with_node.rs` with a minimal test-only TS→JS shim (strips type annotations, stubs the runtime) — not part of the shipped emission path. No runtime library; pure options-object direct lowering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)