### PR TITLE
feat(semantic-ir-to-rust): keyword-parameter & argument emission (KW5)

### DIFF
--- a/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## Unreleased — reject keyword params mixed with rest/kwrest (hardening)
+
+### Fixed
+
+- **Reachable emit panic on validator-accepted input (DoS).** The core
+  validator's M3 ordering rule accepts a signature that mixes a keyword
+  parameter with a variadic slot (`Required* Rest? Keyword* KwRest?`),
+  e.g. Ruby `def f(a, *rest, x: 1)`. Because this backend accepts
+  `Feature::KeywordParams`, such a module reached the emitter's static
+  keyword→positional resolution path and hit the
+  `ParamKind::Rest | ParamKind::KwRest` `panic!` — a reachable panic on
+  validated input (and frontend-reachable once the Ruby frontend emits
+  keyword+splat methods). Static keyword resolution genuinely cannot
+  handle a variadic slot: a `*rest`/`**kwrest` param absorbs a *variable*
+  number of arguments, so the name→position map that keyword resolution
+  depends on is no longer a function of the signature alone (variable
+  arity breaks fixed slot indices). The backend now REJECTS such modules
+  cleanly at capability-check time (`reject_keyword_with_variadic`,
+  `BackendErrorKind::UnsupportedFeature`, message
+  `rust backend cannot emit a function mixing keyword parameters with
+  *rest/**kwrest (static keyword resolution requires fixed arity)`)
+  instead of panicking. With the check in place, the emit-side variadic
+  arm is now a true internal-bug guard, never reachable through the normal
+  `compile` path. The happy path (keyword params WITHOUT rest/kwrest) is
+  unchanged and still emits.
+
+### Added
+
+- Unit tests: keyword+`*rest` and keyword+`**kwrest` callees with a
+  keyword call are rejected via `compile()` (return `Err`, do NOT panic);
+  a keyword-only module (no variadic) still compiles.
+
 ## 0.6.0 — keyword-parameter & argument emission (KW5)
 
 Adds `Feature::KeywordParams` support: name-matched keyword parameters

--- a/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
@@ -1,14 +1,57 @@
 # Changelog
 
-## Unreleased
+## 0.6.0 — keyword-parameter & argument emission (KW5)
 
-### Changed
+Adds `Feature::KeywordParams` support: name-matched keyword parameters
+(`def f(a:)` / `def f(a: 1)`) and keyword arguments (`f(a: 1)`). Rust has
+**no native keyword-argument syntax**, so — per `sir-keyword-params.md`
+§4 — the backend performs **static keyword→positional resolution at emit
+time** (no runtime library). This replaces the KW1 compile-compat stub
+(a `KeywordArg` panic arm; `ParamKind::Keyword` folded into a positional
+arm) with real emission.
 
-- Compile-compat stub arms for the new core `semantic-ir` variants
-  `ParamKind::Keyword` / `Expr::KeywordArg` (KW1). Analysis passes recurse
-  into the keyword arg's inner `value`; codegen follows the crate's existing
-  unsupported-node convention. Real keyword-parameter support is pending
-  KW2–KW8.
+### Added
+
+- **Def-side positional-ization** — a `Keyword` param emits as an
+  ORDINARY positional Rust parameter in its declared order (the by-name
+  affordance is dropped; the name becomes the Rust parameter name). An
+  OPTIONAL keyword (one carrying a `default`) reuses the existing
+  `DefaultParams` body-top prologue unchanged — it is a defaulted
+  parameter like any other — so no new def-side machinery is required.
+- **Call-side static resolution** — for a `DirectCall` whose callee
+  signature is known, the emitter builds the FULL positional argument
+  list in the callee's DECLARED order: positionals fill positional params
+  in order; each `KeywordArg { name, value }` fills the callee param whose
+  name matches `name` (a name→position reorder); an omitted OPTIONAL
+  keyword is padded with the `__sir::missing()` sentinel so the callee's
+  prologue substitutes its default (deferring default evaluation to callee
+  scope — correct even when a default references an earlier param). The
+  result is a plain positional Rust call `f(a, b_val, c_default)`.
+- **`FN_PARAMS` thread-local signature table** — SIR function name → its
+  full parameter list (kinds + defaults). Where `FN_ARITY` records only
+  the param count, keyword resolution needs the params' ORDER, NAMES, and
+  DEFAULTS. Populated alongside `FN_ARITY` in
+  `emit_module_with_arity_table` and consulted by the `DirectCall`
+  emitter.
+- **`Feature::KeywordParams`** added to the backend's `ACCEPTED_FEATURES`
+  (mirroring `DefaultParams`).
+- **Unit tests** — def-side positional-ization + default prologue;
+  call-side supplied-keyword → positional; call-side omitted-optional →
+  sentinel; call-side name→declared-position reorder.
+- **Execution proof** (`tests/compile_and_run_keyword_params.rs`) — a
+  `def greet(greeting, name: "world") -> name` module, compiled with
+  `rustc` and run: `greet("hi")` prints `world` (default) and
+  `greet("hi", name: "ada")` prints `ada` (supplied), matching the
+  Python/TS reference for `name`. Skips gracefully if `rustc`/linker are
+  absent (`SIR_TEST_RUSTC_LINKER`).
+
+### Out of scope (documented)
+
+- **Indirect/closure keyword calls** — an `IndirectCall`/closure carrying
+  keywords has no statically-known signature, so keyword→position
+  resolution cannot run. The frontends do not emit this (spec
+  §"Out of scope"); the `emit_expr` `KeywordArg` arm keeps a positioned
+  panic documenting that narrow, internal-bug-only reachability.
 
 ## 0.5.0 — default-parameter emission (P2e)
 

--- a/code/packages/rust/semantic-ir-to-rust/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-rust"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "Semantic IR → self-contained Rust source code (SIR13). Second backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-rust/README.md
+++ b/code/packages/rust/semantic-ir-to-rust/README.md
@@ -87,6 +87,38 @@ language's **call-time, param-scope** semantics:
 
 Non-default behaviour is byte-for-byte unchanged.
 
+Accepts (KW5): `KeywordParams` — name-matched keyword parameters
+(`def f(a:)` / `def f(a: 1)`) and keyword arguments (`f(a: 1)`).  Rust has
+**no native keyword-argument syntax**, so the backend resolves keywords to
+a plain positional call **statically, at emit time** (no runtime library):
+
+- **Def side** — a `Keyword` param emits as an *ordinary positional*
+  Rust parameter in its declared order (the by-name affordance is dropped;
+  the name becomes the Rust parameter name).  An *optional* keyword (one
+  with a `default`) reuses the same `DefaultParams` body-top prologue —
+  it is a defaulted parameter like any other.
+- **Call side** — for a `DirectCall` whose callee signature is known
+  (looked up in a `FN_PARAMS` signature table, populated alongside
+  `FN_ARITY`), the emitter builds the full positional argument list in the
+  callee's *declared* order: positionals fill positional params in order;
+  each `KeywordArg { name, value }` fills the param whose name matches
+  (a name→position reorder); an omitted optional keyword is padded with
+  `__sir::missing()` so the callee's prologue substitutes its default
+  (deferring default evaluation to callee scope — correct even when a
+  default references an earlier param).  The result is a plain positional
+  Rust call `f(a, b_val, c_default)`.
+
+Worked example — `def greet(greeting, name: "world")`:
+
+```text
+  greet("hi")               → greet("hi", missing())   // name omitted → default "world"
+  greet("hi", name: "ada")  → greet("hi", "ada")        // name supplied by keyword
+```
+
+Out of scope (v0): an `IndirectCall`/closure call carrying keywords has no
+statically-known signature, so it cannot be resolved; the frontends do not
+emit it.
+
 Rejects: `TailCalls` (Rust does not guarantee TCO), `Intrinsics`
 (empty whitelist in v0), and the SIR17/18 features above.
 

--- a/code/packages/rust/semantic-ir-to-rust/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/emit.rs
@@ -817,11 +817,18 @@ fn emit_direct_call(out: &mut String, fn_name: &str, args: &[Expr], indent: usiz
                 Some(arg) => emit_expr(out, arg, indent),
                 None => out.push_str("__sir::missing()"),
             },
-            // `Rest`/`KwRest` are not accepted by this backend (their
-            // features are unaccepted, so the capability check rejects
-            // such modules before emit).  Unreachable on valid input.
+            // A `Rest`/`KwRest` param can only reach the keyword-resolution
+            // path when the callee ALSO has a `Keyword` param (this branch
+            // runs only for keyword-carrying signatures).  The backend's
+            // `reject_keyword_with_variadic` capability check (see `lib.rs`)
+            // now rejects any module mixing a keyword param with a
+            // `*rest`/`**kwrest` param BEFORE emit, because static
+            // keyword→positional resolution requires fixed arity.  This arm
+            // is therefore an INTERNAL-BUG guard: it fires only if that
+            // upstream check were removed or bypassed, never on a module
+            // that reached emit through the normal `compile` path.
             ParamKind::Rest | ParamKind::KwRest => panic!(
-                "rust backend reached a `{:?}` param of `{fn_name}` — capability check should have rejected variadic params",
+                "rust backend reached a `{:?}` param of `{fn_name}` — the keyword+variadic capability check should have rejected this module upstream",
                 p.kind
             ),
         }

--- a/code/packages/rust/semantic-ir-to-rust/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/emit.rs
@@ -21,7 +21,7 @@ use std::collections::HashSet;
 use std::fmt::Write;
 
 use semantic_ir::{
-    Block, Expr, Function, Global, Module, Scope, Stmt,
+    Block, Expr, Function, Global, Module, Param, ParamKind, Scope, Stmt,
 };
 
 use crate::runtime::RUNTIME;
@@ -499,34 +499,7 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
         }
         Expr::Block(b) => emit_block_as_expr(out, b, indent),
         Expr::DirectCall { fn_name, args, .. } => {
-            let _ = write!(out, "{}(", function_emit_name(fn_name));
-            emit_args(out, args, indent);
-            // ── DefaultParams (P2e) caller padding ─────────────────
-            //
-            // The IR call may carry FEWER args than the callee declares
-            // (the validator allows omitting trailing defaulted params).
-            // Rust fns are fixed-arity, so we PAD the omitted trailing
-            // positions with the `__sir::missing()` sentinel — the
-            // callee's prologue then swaps each sentinel for that param's
-            // default.  The callee's full param count comes from the same
-            // `FN_ARITY` table that `MakeClosure` already consults; it is
-            // keyed by the function's SIR name (`fn_name`), not its
-            // emitted name.  A callee absent from the table (e.g. a
-            // builtin reached via DirectCall) yields `0`, so `saturating_
-            // sub` pads nothing and the call is emitted unchanged.
-            let arity = FN_ARITY.with(|t| t.borrow().get(fn_name).copied().unwrap_or(0));
-            let pad_count = arity.saturating_sub(args.len());
-            for i in 0..pad_count {
-                // A comma precedes every sentinel that is not the very
-                // first emitted argument: either real args were emitted
-                // (so the first sentinel still needs a separator), or a
-                // prior sentinel was emitted.
-                if !args.is_empty() || i > 0 {
-                    out.push_str(", ");
-                }
-                out.push_str("__sir::missing()");
-            }
-            out.push(')');
+            emit_direct_call(out, fn_name, args, indent);
         }
         Expr::IndirectCall { target, args, .. } => {
             out.push_str("__sir::apply_closure(&(");
@@ -631,15 +604,20 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
         Expr::StrConcat { span, .. } => {
             panic!("rust backend reached SIR18 str-concat expression at {} — capability check should have rejected it", span);
         }
-        // KW1 compile-compat stub: keyword arguments (`f(a: 1)`) are gated
-        // behind `Feature::KeywordParams`, which the validator rejects until
-        // real support lands in KW2–KW6.  `emit_expr` is infallible, so we
-        // follow this crate's established convention for an unsupported node
-        // whose feature the capability check should already have rejected
-        // (see `StrConcat`/`Intrinsic` above): a positioned panic documenting
-        // the internal-bug-only reachability.  No real emission yet.
+        // KW5: a `KeywordArg` is never emitted as a stand-alone
+        // expression.  The validator guarantees it appears ONLY inside a
+        // call's `args` vec, and a `DirectCall` — the only call form that
+        // carries keywords in v0 — resolves each `KeywordArg` statically
+        // into its callee's declared parameter position inside
+        // `emit_direct_call` (it never routes the wrapper through
+        // `emit_expr`).  The single way to reach this arm is an
+        // `IndirectCall`/closure call carrying a keyword — the
+        // spec-documented out-of-scope case (`sir-keyword-params.md`
+        // §"Out of scope"), which the frontends do not emit.  A positioned
+        // panic documents that narrow, internal-bug-only reachability
+        // (matching `StrConcat`/`Intrinsic` above).
         Expr::KeywordArg { span, .. } => {
-            panic!("rust backend reached KW1 keyword-arg expression at {} — capability check should have rejected it (real support pending KW2–KW6)", span);
+            panic!("rust backend reached a stand-alone keyword-arg expression at {} — indirect/closure keyword calls are out of scope for v0 (see sir-keyword-params.md)", span);
         }
     }
 }
@@ -681,6 +659,174 @@ fn emit_args(out: &mut String, args: &[Expr], indent: usize) {
         }
         emit_expr(out, a, indent);
     }
+}
+
+/// Emit a `DirectCall` — resolving keyword arguments and defaulted
+/// parameters to a **plain positional** Rust call.
+///
+/// Rust has no native keyword arguments, so the whole affordance is
+/// resolved *statically*, at emit time, against the callee's known
+/// signature (looked up in `FN_PARAMS`).  This unifies two previously
+/// separate concerns into one pass:
+///
+///   1. **DefaultParams (P2e)** — omitted trailing positional defaults
+///      are padded with the `__sir::missing()` sentinel; the callee's
+///      body-top prologue swaps each sentinel for that param's default.
+///   2. **KeywordParams (KW5)** — a `KeywordArg { name, value }` names
+///      its target param, so we reorder it into that param's declared
+///      position; an omitted OPTIONAL keyword is filled with its own
+///      default expression (emitted inline, not via a sentinel).
+///
+/// ### Worked example (the case KW5 adds)
+///
+/// ```text
+///   def greet(greeting, name: "world")   // name is an optional keyword
+///
+///   greet("hi")                 args = [Str("hi")]
+///     → positional greeting = "hi"; name omitted → emit its default
+///     → greet(Str("hi"), Str("world"))
+///
+///   greet("hi", name: "ada")    args = [Str("hi"), KeywordArg{name, Str("ada")}]
+///     → positional greeting = "hi"; name supplied by keyword = "ada"
+///     → greet(Str("hi"), Str("ada"))
+/// ```
+///
+/// ### Resolution truth table (per callee param, left→right)
+///
+/// ```text
+///   param kind        supplied?                 emitted value
+///   ────────────────  ────────────────────────  ─────────────────────────
+///   positional (req)  yes (by position)         the positional arg
+///   positional (opt)  yes (by position)         the positional arg
+///   positional (opt)  no  (trailing, omitted)   __sir::missing()  (sentinel)
+///   Keyword           yes (by name match)       the KeywordArg's value
+///   Keyword (opt)     no  (omitted)             its default expression
+///   Keyword (req)     no                        — impossible: validator
+///                                                 rejects an omitted
+///                                                 required keyword
+/// ```
+///
+/// ### Fallback (no static signature)
+///
+/// A callee absent from `FN_PARAMS` (a builtin reached via `DirectCall`)
+/// or one with neither keyword params NOR keyword args is emitted by the
+/// original positional path (positional args + trailing `missing()`
+/// padding) — byte-for-byte unchanged from before KW5.
+fn emit_direct_call(out: &mut String, fn_name: &str, args: &[Expr], indent: usize) {
+    // Split the IR `args` (positionals first, then any `KeywordArg`s —
+    // the validator guarantees this ordering) into the two groups.
+    let mut positionals: Vec<&Expr> = Vec::new();
+    let mut keyword_args: Vec<(&str, &Expr)> = Vec::new();
+    for a in args {
+        match a {
+            Expr::KeywordArg { name, value, .. } => keyword_args.push((name.as_str(), value)),
+            other => positionals.push(other),
+        }
+    }
+
+    let sig = FN_PARAMS.with(|t| t.borrow().get(fn_name).cloned());
+
+    // Does the callee have any keyword params?  (An `IndirectCall`/builtin
+    // has no signature here, so `sig` is `None` and this is `false`.)
+    let callee_has_keyword_params = sig
+        .as_ref()
+        .map(|ps| ps.iter().any(|p| p.kind == ParamKind::Keyword))
+        .unwrap_or(false);
+
+    // Fast path: NO keyword arguments at the call site and NO keyword
+    // params on the callee.  This is every pre-KW5 call — resolve exactly
+    // as before (positional args + trailing `missing()` padding).  Keeping
+    // this path identical means non-keyword output is byte-for-byte
+    // unchanged.
+    if keyword_args.is_empty() && !callee_has_keyword_params {
+        let _ = write!(out, "{}(", function_emit_name(fn_name));
+        emit_args(out, args, indent);
+        let arity = FN_ARITY.with(|t| t.borrow().get(fn_name).copied().unwrap_or(0));
+        let pad_count = arity.saturating_sub(args.len());
+        for i in 0..pad_count {
+            if !args.is_empty() || i > 0 {
+                out.push_str(", ");
+            }
+            out.push_str("__sir::missing()");
+        }
+        out.push(')');
+        return;
+    }
+
+    // Keyword path.  If we reached here with keyword args or keyword
+    // params but NO static signature, that is the spec-documented
+    // out-of-scope case (an indirect/closure call carrying keywords).
+    // The frontends do not emit it; a `DirectCall` always names a known
+    // function, so `sig` is `Some`.  Guard defensively rather than emit
+    // a wrong call.
+    let Some(params) = sig else {
+        panic!(
+            "rust backend: keyword arguments to `{fn_name}` whose signature is not statically known — indirect/closure keyword calls are out of scope for v0 (see sir-keyword-params.md §\"Out of scope\")"
+        );
+    };
+
+    // Build the FULL positional argument list in the callee's DECLARED
+    // parameter order.  We consume positionals in order for the
+    // positional params, and match keyword args by name for the
+    // `Keyword` params.  (Every supplied keyword names a real `Keyword`
+    // param — the validator guarantees it — so nothing is left over.)
+    let mut pos_iter = positionals.iter();
+
+    let _ = write!(out, "{}(", function_emit_name(fn_name));
+    let mut first = true;
+    for p in &params {
+        if !first {
+            out.push_str(", ");
+        }
+        first = false;
+        match p.kind {
+            ParamKind::Keyword => {
+                // Matched by NAME.  Either the caller supplied it (emit
+                // its value) or it was omitted — in which case it is an
+                // OPTIONAL keyword (the validator rejects an omitted
+                // required keyword), so it carries a default.
+                //
+                // For an OMITTED optional keyword we emit the
+                // `__sir::missing()` sentinel and let the callee's
+                // body-top prologue substitute the default — the SAME
+                // mechanism that positional defaults use.  This is not
+                // just for symmetry: a keyword default may reference an
+                // EARLIER parameter (`def f(a, b: a)`), whose Rust binding
+                // exists only inside the callee body, not at this call
+                // site.  Evaluating the default in the prologue (where
+                // `a` is bound) is therefore the only correct place —
+                // exactly the call-time, param-scope semantics the
+                // positional-default prologue already provides.
+                if let Some((_, value)) = keyword_args.iter().find(|(n, _)| *n == p.name) {
+                    emit_expr(out, value, indent);
+                } else {
+                    debug_assert!(
+                        p.default.is_some(),
+                        "required keyword `{}` omitted at call to `{fn_name}` — validator should have rejected this",
+                        p.name
+                    );
+                    out.push_str("__sir::missing()");
+                }
+            }
+            // Positional param (Required, incl. positional-optional).
+            // Filled from the next positional argument if the caller
+            // supplied one; otherwise it is an omitted trailing default,
+            // padded with the `missing()` sentinel exactly as the fast
+            // path does (the callee's prologue substitutes the default).
+            ParamKind::Required => match pos_iter.next() {
+                Some(arg) => emit_expr(out, arg, indent),
+                None => out.push_str("__sir::missing()"),
+            },
+            // `Rest`/`KwRest` are not accepted by this backend (their
+            // features are unaccepted, so the capability check rejects
+            // such modules before emit).  Unreachable on valid input.
+            ParamKind::Rest | ParamKind::KwRest => panic!(
+                "rust backend reached a `{:?}` param of `{fn_name}` — capability check should have rejected variadic params",
+                p.kind
+            ),
+        }
+    }
+    out.push(')');
 }
 
 fn emit_builtin_call(out: &mut String, name: &str, args: &[Expr], indent: usize) {
@@ -857,10 +1003,24 @@ fn emit_make_closure(
 thread_local! {
     static FN_ARITY: std::cell::RefCell<std::collections::HashMap<String, usize>> =
         std::cell::RefCell::new(std::collections::HashMap::new());
+
+    /// Thread-local function *signature* table: SIR function name → its
+    /// full parameter list (kinds + defaults).  Where `FN_ARITY` records
+    /// only the param *count* (enough for `MakeClosure` drains and
+    /// default-arg padding), keyword→positional resolution (KW5) needs
+    /// the params themselves — their declared ORDER, their NAMES (to
+    /// match a `KeywordArg`), and their DEFAULTS (to fill an omitted
+    /// optional keyword).  Populated alongside `FN_ARITY` and consulted
+    /// by the `DirectCall` emitter.  A callee absent from this table
+    /// (e.g. a builtin reached via `DirectCall`) resolves to `None`, and
+    /// the emitter falls back to plain positional emission.
+    static FN_PARAMS: std::cell::RefCell<std::collections::HashMap<String, Vec<Param>>> =
+        std::cell::RefCell::new(std::collections::HashMap::new());
 }
 
 /// Wrap a call to `emit_module` so that `MakeClosure` can resolve
-/// each lambda's parameter count.  Public for direct use; the
+/// each lambda's parameter count and `DirectCall` can resolve a
+/// callee's keyword parameters.  Public for direct use; the
 /// crate-level `compile` entry point routes through here.
 pub fn emit_module_with_arity_table(m: &Module) -> String {
     FN_ARITY.with(|t| {
@@ -870,8 +1030,16 @@ pub fn emit_module_with_arity_table(m: &Module) -> String {
             t.insert(f.name.clone(), f.params.len());
         }
     });
+    FN_PARAMS.with(|t| {
+        let mut t = t.borrow_mut();
+        t.clear();
+        for f in &m.functions {
+            t.insert(f.name.clone(), f.params.clone());
+        }
+    });
     let out = emit_module(m);
     FN_ARITY.with(|t| t.borrow_mut().clear());
+    FN_PARAMS.with(|t| t.borrow_mut().clear());
     out
 }
 
@@ -1778,6 +1946,182 @@ mod tests {
         let out = emit_module_with_arity_table(&m);
         assert!(out.contains("g(__sir::Value::Int(1i64), __sir::Value::Int(2i64))"));
         assert!(!out.contains("__sir::missing()"));
+    }
+
+    // ── KeywordParams (KW5) ────────────────────────────────────────
+    //
+    // Rust has no native kwargs, so a `Keyword` param becomes an
+    // ORDINARY positional Rust parameter (def side), and a call's
+    // `KeywordArg`s are RESOLVED to positional order at emit time
+    // (call side).  These tests pin all three call-side outcomes:
+    // supplied-by-keyword, omitted-optional-keyword (filled with the
+    // sentinel so the callee prologue substitutes the default), and the
+    // name→position reorder.
+
+    /// Build `greet(greeting, name: <default>)`: a required positional
+    /// followed by an OPTIONAL keyword param.  Shared by the call-side
+    /// tests below.
+    fn greet_fn(default_name: Expr) -> Function {
+        Function {
+            name: "greet".into(),
+            params: vec![
+                Param { name: "greeting".into(), kind: ParamKind::Required, sir_type: None, default: None, span: s() },
+                Param { name: "name".into(), kind: ParamKind::Keyword, sir_type: None, default: Some(Box::new(default_name)), span: s() },
+            ],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts: vec![],
+                value: Expr::VarRef { name: "name".into(), scope: Scope::Param, span: s() },
+                span: s(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        }
+    }
+
+    fn kw_str(v: &str) -> Expr {
+        Expr::StrLit { value: v.into(), span: s() }
+    }
+
+    fn main_calling(call: Expr) -> Function {
+        Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block { stmts: vec![], value: call, span: s() },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        }
+    }
+
+    fn module_of(functions: Vec<Function>) -> Module {
+        Module {
+            name: "demo".into(),
+            manifest: FeatureManifest::new(),
+            imports: vec![],
+            exports: vec![],
+            functions,
+            globals: vec![],
+            metadata: Metadata::new()
+                .with_source_language("test")
+                .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+            span: s(),
+        }
+    }
+
+    /// Def side: a `Keyword` param is emitted as an ORDINARY positional
+    /// Rust parameter (the by-name affordance is dropped — the name
+    /// simply becomes the Rust parameter name), and an OPTIONAL keyword
+    /// (one with a default) reuses the default-param body-top prologue.
+    #[test]
+    fn emit_keyword_param_is_positional_with_default_prologue() {
+        let mut out = String::new();
+        emit_function(&mut out, &greet_fn(kw_str("world")));
+        // Both params are ordinary positional Rust parameters.
+        assert!(
+            out.contains("fn greet(greeting: __sir::Value, name: __sir::Value) -> __sir::Value"),
+            "keyword param should positional-ize; got:\n{out}"
+        );
+        // The optional keyword reuses the default-param prologue.
+        assert!(
+            out.contains("let name = if __sir::is_missing(&name) { __sir::Value::Str(::std::rc::Rc::from(\"world\")) } else { name };"),
+            "optional keyword missing its default prologue; got:\n{out}"
+        );
+    }
+
+    /// Call side, keyword SUPPLIED: `greet("hi", name: "ada")` resolves
+    /// to the plain positional call `greet("hi", "ada")` — the keyword
+    /// value fills its named param's declared position.
+    #[test]
+    fn emit_call_with_supplied_keyword_resolves_to_positional() {
+        let call = Expr::DirectCall {
+            fn_name: "greet".into(),
+            args: vec![
+                kw_str("hi"),
+                Expr::KeywordArg {
+                    name: "name".into(),
+                    value: Box::new(kw_str("ada")),
+                    span: s(),
+                },
+            ],
+            effects: EffectSet::PURE,
+            span: s(),
+        };
+        let m = module_of(vec![greet_fn(kw_str("world")), main_calling(call)]);
+        let out = emit_module_with_arity_table(&m);
+        assert!(
+            out.contains(
+                "greet(__sir::Value::Str(::std::rc::Rc::from(\"hi\")), __sir::Value::Str(::std::rc::Rc::from(\"ada\")))"
+            ),
+            "supplied keyword should resolve to positional; got:\n{out}"
+        );
+        // No sentinel — the keyword was supplied, not omitted.
+        assert!(!out.contains("greet(__sir::Value::Str(::std::rc::Rc::from(\"hi\")), __sir::missing())"));
+    }
+
+    /// Call side, keyword OMITTED: `greet("hi")` fills the omitted
+    /// optional keyword with the `__sir::missing()` sentinel — the
+    /// callee's body-top prologue then substitutes its default (this
+    /// defers default evaluation to callee scope, correct even when a
+    /// default references an earlier param).
+    #[test]
+    fn emit_call_omitting_optional_keyword_pads_sentinel() {
+        let call = Expr::DirectCall {
+            fn_name: "greet".into(),
+            args: vec![kw_str("hi")],
+            effects: EffectSet::PURE,
+            span: s(),
+        };
+        let m = module_of(vec![greet_fn(kw_str("world")), main_calling(call)]);
+        let out = emit_module_with_arity_table(&m);
+        assert!(
+            out.contains(
+                "greet(__sir::Value::Str(::std::rc::Rc::from(\"hi\")), __sir::missing())"
+            ),
+            "omitted optional keyword should pad the sentinel; got:\n{out}"
+        );
+    }
+
+    /// Call side, keyword REORDER: even when the caller writes the
+    /// keyword arg for an *earlier*-declared param, the emitter places
+    /// its value in the DECLARED param position, not the written order.
+    /// `f(x: 1)` with `def f(x:, y: 2)` → `f(1, missing())` (x supplied
+    /// by name, y omitted → sentinel).
+    #[test]
+    fn emit_call_reorders_keyword_to_declared_position() {
+        let f = Function {
+            name: "f".into(),
+            params: vec![
+                Param { name: "x".into(), kind: ParamKind::Keyword, sir_type: None, default: None, span: s() },
+                Param { name: "y".into(), kind: ParamKind::Keyword, sir_type: None, default: Some(Box::new(Expr::IntLit { value: 2, span: s() })), span: s() },
+            ],
+            return_type: None,
+            captures: vec![],
+            body: Block { stmts: vec![], value: Expr::VarRef { name: "x".into(), scope: Scope::Param, span: s() }, span: s() },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        };
+        let call = Expr::DirectCall {
+            fn_name: "f".into(),
+            args: vec![Expr::KeywordArg {
+                name: "x".into(),
+                value: Box::new(Expr::IntLit { value: 1, span: s() }),
+                span: s(),
+            }],
+            effects: EffectSet::PURE,
+            span: s(),
+        };
+        let m = module_of(vec![f, main_calling(call)]);
+        let out = emit_module_with_arity_table(&m);
+        assert!(
+            out.contains("f(__sir::Value::Int(1i64), __sir::missing())"),
+            "keyword should land in declared position with omitted trailing → sentinel; got:\n{out}"
+        );
     }
 
     #[test]

--- a/code/packages/rust/semantic-ir-to-rust/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/lib.rs
@@ -118,6 +118,36 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     // validator change (the core validator already permits omitting
     // trailing defaulted args in a `DirectCall`).
     Feature::DefaultParams,
+    // `KeywordParams` (KW5) adds name-matched keyword parameters
+    // (`def f(a:)` / `def f(a: 1)`) and keyword arguments (`f(a: 1)`).
+    // Rust has NO native keyword-argument syntax, so — per spec §4 — the
+    // backend performs STATIC keyword→positional resolution at emit time
+    // (no runtime library):
+    //
+    //   • Def side: a `Keyword` param emits as an ORDINARY positional
+    //     parameter in its declared order (the name simply becomes the
+    //     Rust parameter name; the by-name affordance is dropped).  An
+    //     OPTIONAL keyword (one carrying a `default`) reuses the very same
+    //     `DefaultParams` body-top prologue — it is a defaulted parameter
+    //     like any other — so no new def-side machinery is required.
+    //
+    //   • Call side: for a `DirectCall` whose callee signature is known
+    //     (looked up in the module's functions, exactly as default-param
+    //     padding consults the arity table), the backend builds the FULL
+    //     positional argument list in the callee's DECLARED order:
+    //       1. positional args fill positional params in order;
+    //       2. each `KeywordArg { name, value }` fills the callee param
+    //          whose name matches `name` (a name→position reorder);
+    //       3. any omitted OPTIONAL keyword param is filled by emitting
+    //          ITS default (via `Function::missing_keywords`), exactly as
+    //          trailing positional defaults are filled today.
+    //     The result is a plain positional Rust call `f(a, b_val, c_def)`.
+    //
+    // This is the same shape as the existing default-param call emission
+    // (fill omitted params with their defaults) plus a name→position
+    // reorder — so accepting the feature keeps the capability check and
+    // emit coverage consistent.
+    Feature::KeywordParams,
 ];
 
 impl Backend for RustBackend {

--- a/code/packages/rust/semantic-ir-to-rust/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/lib.rs
@@ -29,6 +29,7 @@ mod runtime;
 
 use semantic_ir::{
     Artifact, ArtifactMetadata, Backend, BackendError, BackendErrorKind, Feature, Module,
+    ParamKind,
 };
 
 pub use emit::sanitize_ident;
@@ -184,6 +185,15 @@ impl Backend for RustBackend {
             return Err(e);
         }
 
+        // 2b. Structural capability check the manifest cannot express:
+        //     reject any function that mixes a keyword parameter with a
+        //     `*rest`/`**kwrest` variadic slot.  Static keyword→positional
+        //     resolution (this backend's whole keyword strategy) requires
+        //     FIXED arity — see `reject_keyword_with_variadic`.
+        if let Some(e) = reject_keyword_with_variadic(module) {
+            return Err(e);
+        }
+
         // 3. TailCalls cannot be satisfied.
         if module.manifest.contains(Feature::TailCalls) {
             return Err(BackendError {
@@ -209,11 +219,67 @@ impl Backend for RustBackend {
     }
 }
 
+/// Reject a module whose any function mixes a keyword parameter with a
+/// `*rest`/`**kwrest` variadic parameter.
+///
+/// ## Why keyword + `*rest`/`**kwrest` cannot be statically resolved
+///
+/// This backend implements keyword parameters with **static**
+/// keyword→positional resolution at emit time (see the `KeywordParams`
+/// note in `ACCEPTED_FEATURES` and `emit.rs`): for each `DirectCall`, the
+/// emitter walks the callee's parameter list and routes every keyword
+/// argument to the Rust argument slot of the same-named parameter,
+/// producing a plain positional Rust call `f(a, b, c)`.  That
+/// name→position map is only well-defined because the arity is FIXED —
+/// parameter *i* always lands at Rust argument slot *i*.
+///
+/// The core validator's M3 ordering rule, however, PERMITS a signature
+/// that mixes a keyword parameter with a variadic slot — e.g. Ruby
+/// `def f(a, *rest, x: 1)` (the legal order is
+/// `Required* Rest? Keyword* KwRest?`).  A `Rest` (`*rest`) or `KwRest`
+/// (`**opts`) parameter absorbs a *variable* number of arguments, so the
+/// slot index of every parameter after it depends on how many arguments
+/// the caller actually passed.  The name→position map is then no longer a
+/// function of the signature alone — there is no fixed Rust argument slot
+/// to route a keyword into, so static resolution genuinely cannot be
+/// performed.
+///
+/// A backend carrying a runtime keyword-dispatch library could handle
+/// this; this backend deliberately has none.  It therefore rejects such a
+/// module cleanly HERE, rather than letting the emitter reach the
+/// `ParamKind::Rest | ParamKind::KwRest` arm in the keyword-resolution
+/// path and panic.  That panic was reachable on validator-accepted input
+/// (a DoS) before this check existed; with the check in place the emit
+/// arm is a true internal-bug guard.
+///
+/// Returns `Some(err)` for the FIRST offending function (fail-fast, like
+/// the other capability checks), or `None` if the module is clean.
+fn reject_keyword_with_variadic(module: &Module) -> Option<BackendError> {
+    for func in &module.functions {
+        let has_keyword = func.params.iter().any(|p| p.kind == ParamKind::Keyword);
+        let has_variadic = func
+            .params
+            .iter()
+            .any(|p| matches!(p.kind, ParamKind::Rest | ParamKind::KwRest));
+        if has_keyword && has_variadic {
+            return Some(BackendError {
+                kind: BackendErrorKind::UnsupportedFeature,
+                message: "rust backend cannot emit a function mixing keyword \
+                          parameters with *rest/**kwrest (static keyword \
+                          resolution requires fixed arity)"
+                    .into(),
+                span: func.span.clone(),
+            });
+        }
+    }
+    None
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use semantic_ir::{
-        Block, EffectSet, Expr, FeatureManifest, Function, Metadata, Span,
+        Block, EffectSet, Expr, FeatureManifest, Function, Metadata, Param, Scope, Span,
     };
 
     fn s() -> Span {
@@ -330,5 +396,219 @@ mod tests {
         m.name = "compiler/lexer".into();
         let a = compile(&m).expect("compile");
         assert_eq!(a.filename, "compiler_lexer.rs");
+    }
+
+    // ── Keyword + *rest/**kwrest rejection (hardening) ─────────────────
+    //
+    // The core validator's M3 ordering rule ACCEPTS a signature that mixes
+    // a keyword param with a variadic slot (`Required* Rest? Keyword*
+    // KwRest?`), e.g. Ruby `def f(a, *rest, x: 1)`.  This backend accepts
+    // `Feature::KeywordParams`, so such a module would formerly reach the
+    // emitter's keyword-resolution path and hit the
+    // `ParamKind::Rest | ParamKind::KwRest` panic — a reachable panic on
+    // validator-accepted input (a DoS).  `reject_keyword_with_variadic`
+    // now rejects these modules at capability-check time; these tests pin
+    // that (a) a keyword+rest callee with a keyword call is rejected via
+    // `compile()` WITHOUT panicking, and (b) a keyword+kwrest callee is
+    // likewise rejected.
+
+    /// Build `def f(a, *rest, name: <default>)`: a required positional,
+    /// then a `*rest`, then an OPTIONAL keyword — the exact shape the core
+    /// validator accepts but this backend cannot statically resolve.
+    fn kw_rest_fn() -> Function {
+        Function {
+            name: "f".into(),
+            params: vec![
+                Param {
+                    name: "a".into(),
+                    kind: ParamKind::Required,
+                    sir_type: None,
+                    default: None,
+                    span: s(),
+                },
+                Param {
+                    name: "rest".into(),
+                    kind: ParamKind::Rest,
+                    sir_type: None,
+                    default: None,
+                    span: s(),
+                },
+                Param {
+                    name: "name".into(),
+                    kind: ParamKind::Keyword,
+                    sir_type: None,
+                    default: Some(Box::new(Expr::StrLit {
+                        value: "world".into(),
+                        span: s(),
+                    })),
+                    span: s(),
+                },
+            ],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts: vec![],
+                value: Expr::VarRef {
+                    name: "name".into(),
+                    scope: Scope::Param,
+                    span: s(),
+                },
+                span: s(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        }
+    }
+
+    /// A `main` that calls `f("hi", name: "ada")` — a keyword call whose
+    /// static resolution would drive the emitter into the variadic panic
+    /// arm if the module were not rejected first.
+    fn main_calling_f_by_keyword() -> Function {
+        Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts: vec![],
+                value: Expr::DirectCall {
+                    fn_name: "f".into(),
+                    args: vec![
+                        Expr::StrLit { value: "hi".into(), span: s() },
+                        Expr::KeywordArg {
+                            name: "name".into(),
+                            value: Box::new(Expr::StrLit {
+                                value: "ada".into(),
+                                span: s(),
+                            }),
+                            span: s(),
+                        },
+                    ],
+                    effects: EffectSet::PURE,
+                    span: s(),
+                },
+                span: s(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        }
+    }
+
+    fn kw_module(functions: Vec<Function>) -> Module {
+        Module {
+            name: "demo".into(),
+            // Observed features for these functions: DynamicTyping (untyped
+            // params), KeywordParams (the keyword param), and Strings (the
+            // string-literal defaults / args).  A `*rest` param observes no
+            // feature of its own, so declaring exactly these keeps the
+            // validator's manifest comparison happy — the module is
+            // VALIDATOR-ACCEPTED, which is the whole point: the panic was
+            // reachable on validated input.
+            manifest: FeatureManifest::from_features(&[
+                Feature::DynamicTyping,
+                Feature::KeywordParams,
+                Feature::Strings,
+            ]),
+            imports: vec![],
+            exports: vec![],
+            functions,
+            globals: vec![],
+            metadata: Metadata::new()
+                .with_source_language("ruby")
+                .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+            span: s(),
+        }
+    }
+
+    #[test]
+    fn rejects_keyword_mixed_with_rest_without_panicking() {
+        let m = kw_module(vec![kw_rest_fn(), main_calling_f_by_keyword()]);
+        // `compile()` runs the capability check BEFORE emit, so this must
+        // return Err — never panic in the emitter's variadic arm.
+        let err = compile(&m).expect_err("keyword + *rest must be rejected");
+        assert_eq!(err.kind, BackendErrorKind::UnsupportedFeature);
+        assert!(
+            err.message.contains("keyword")
+                && err.message.contains("*rest/**kwrest")
+                && err.message.contains("fixed arity"),
+            "unexpected rejection message: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn rejects_keyword_mixed_with_kwrest_without_panicking() {
+        // Same shape but a `**kwrest` (KwRest) variadic instead of `*rest`.
+        let mut f = kw_rest_fn();
+        // Reorder to the M3-legal `Required* Keyword* KwRest?`: keyword
+        // BEFORE the KwRest slot (a `**opts` must come last).
+        f.params = vec![
+            Param { name: "a".into(), kind: ParamKind::Required, sir_type: None, default: None, span: s() },
+            Param {
+                name: "name".into(),
+                kind: ParamKind::Keyword,
+                sir_type: None,
+                default: Some(Box::new(Expr::StrLit { value: "world".into(), span: s() })),
+                span: s(),
+            },
+            Param { name: "opts".into(), kind: ParamKind::KwRest, sir_type: None, default: None, span: s() },
+        ];
+        let m = kw_module(vec![f, main_calling_f_by_keyword()]);
+        let err = compile(&m).expect_err("keyword + **kwrest must be rejected");
+        assert_eq!(err.kind, BackendErrorKind::UnsupportedFeature);
+        assert!(err.message.contains("*rest/**kwrest"));
+    }
+
+    #[test]
+    fn keyword_without_variadic_still_compiles() {
+        // Regression guard: the happy path (keyword params WITHOUT any
+        // rest/kwrest) must still emit — the rejection is narrow.
+        let f = Function {
+            name: "greet".into(),
+            params: vec![
+                Param { name: "greeting".into(), kind: ParamKind::Required, sir_type: None, default: None, span: s() },
+                Param {
+                    name: "name".into(),
+                    kind: ParamKind::Keyword,
+                    sir_type: None,
+                    default: Some(Box::new(Expr::StrLit { value: "world".into(), span: s() })),
+                    span: s(),
+                },
+            ],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts: vec![],
+                value: Expr::VarRef { name: "name".into(), scope: Scope::Param, span: s() },
+                span: s(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        };
+        let main = Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts: vec![],
+                value: Expr::DirectCall {
+                    fn_name: "greet".into(),
+                    args: vec![Expr::StrLit { value: "hi".into(), span: s() }],
+                    effects: EffectSet::PURE,
+                    span: s(),
+                },
+                span: s(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        };
+        let m = kw_module(vec![f, main]);
+        let a = compile(&m).expect("keyword-only module should still compile");
+        assert!(a.source.contains("fn greet("));
     }
 }

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_keyword_params.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_keyword_params.rs
@@ -1,0 +1,257 @@
+//! End-to-end proof for **KeywordParams** (KW5) in the Rust backend.
+//!
+//! Rust has NO native keyword-argument syntax, so — per
+//! `code/specs/sir-keyword-params.md` §4 — the backend resolves
+//! keywords to a plain positional call **statically, at emit time**
+//! (no runtime library).  The lib unit tests assert the emitted
+//! *shape*; this test closes the loop: it hand-builds a SIR module with
+//! an optional keyword parameter, emits Rust, compiles it with `rustc`,
+//! runs the binary, and checks stdout.
+//!
+//! ### Discriminating program
+//!
+//! Modelled on the sibling default-params execution proof.  `greet`
+//! returns its `name` keyword parameter, so the printed value IS the
+//! resolved keyword — exposing whether resolution and the default fill
+//! actually ran:
+//!
+//! ```text
+//!   def greet(greeting, name: "world") -> name   // name is an OPTIONAL keyword
+//!
+//!   greet("hi")               // name omitted   ⇒ default "world"  → "world"
+//!   greet("hi", name: "ada")  // name supplied   = "ada"           → "ada"
+//! ```
+//!
+//! Why return `name` rather than the full `"hi, world"` interpolation
+//! the spec's cross-backend reference program prints?  Building that
+//! string needs `StrConcat` (SIR18 interpolation), a feature this Rust
+//! backend does not accept — so, exactly as the default-params proof
+//! returns `b` to expose the resolved default, we return `name` to
+//! expose the resolved keyword.  The observable `"world"` / `"ada"`
+//! outputs still match what the Python/TS reference prints for `name`
+//! in the two calls, which is the load-bearing behaviour KW5 adds.
+//!
+//! `rustc` ships with every Rust toolchain, so this runs in CI.  A
+//! missing `rustc` or linker logs a skip rather than reddening the
+//! build (matching the sibling `compile_and_run_*` tests).
+
+use std::process::Command;
+
+use semantic_ir::{
+    Block, Effect, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, Param,
+    ParamKind, Scope, Span,
+};
+use semantic_ir_to_rust::compile;
+
+fn s() -> Span {
+    Span::synthetic()
+}
+
+fn slit(v: &str) -> Expr {
+    Expr::StrLit { value: v.into(), span: s() }
+}
+
+fn param_ref(name: &str) -> Expr {
+    Expr::VarRef { name: name.into(), scope: Scope::Param, span: s() }
+}
+
+/// `greet(arg0, name: value)` direct call.  `positional` is the
+/// leading positional argument; `name_kw` is an optional supplied
+/// keyword value (`None` omits the keyword).
+fn greet_call(positional: Expr, name_kw: Option<Expr>) -> Expr {
+    let mut args = vec![positional];
+    if let Some(v) = name_kw {
+        args.push(Expr::KeywordArg { name: "name".into(), value: Box::new(v), span: s() });
+    }
+    Expr::DirectCall { fn_name: "greet".into(), args, effects: EffectSet::PURE, span: s() }
+}
+
+/// `print(expr)` as an effectful statement.
+fn print_stmt(expr: Expr) -> semantic_ir::Stmt {
+    semantic_ir::Stmt::ExprStmt {
+        expr: Expr::BuiltinCall {
+            name: "print".into(),
+            args: vec![expr],
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            span: s(),
+        },
+        span: s(),
+    }
+}
+
+/// Build the discriminating module:
+///   greet(greeting, name: "world") -> name
+///   main: print(greet("hi")); print(greet("hi", name: "ada"))
+fn demo_module() -> Module {
+    let greet = Function {
+        name: "greet".into(),
+        params: vec![
+            Param { name: "greeting".into(), kind: ParamKind::Required, sir_type: None, default: None, span: s() },
+            // OPTIONAL keyword: kind == Keyword, default == Some("world").
+            Param {
+                name: "name".into(),
+                kind: ParamKind::Keyword,
+                sir_type: None,
+                default: Some(Box::new(slit("world"))),
+                span: s(),
+            },
+        ],
+        return_type: None,
+        captures: vec![],
+        // greet returns `name` — so the printed value IS the resolved keyword.
+        body: Block { stmts: vec![], value: param_ref("name"), span: s() },
+        effects: EffectSet::PURE,
+        metadata: Metadata::new(),
+        span: s(),
+    };
+
+    let main = Function {
+        name: "main".into(),
+        params: vec![],
+        return_type: None,
+        captures: vec![],
+        body: Block {
+            stmts: vec![
+                // greet("hi")              → name defaulted "world" → "world"
+                print_stmt(greet_call(slit("hi"), None)),
+                // greet("hi", name: "ada") → name supplied "ada"    → "ada"
+                print_stmt(greet_call(slit("hi"), Some(slit("ada")))),
+            ],
+            value: Expr::NilLit { span: s() },
+            span: s(),
+        },
+        effects: EffectSet::PURE.with(Effect::MayPrint),
+        metadata: Metadata::new(),
+        span: s(),
+    };
+
+    Module {
+        name: "keyword_params_demo".into(),
+        manifest: FeatureManifest::from_features(&[
+            Feature::DynamicTyping,
+            Feature::Strings,
+            Feature::DefaultParams,
+            Feature::KeywordParams,
+        ]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![greet, main],
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("test")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+fn rustc_available() -> bool {
+    Command::new("rustc")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+#[test]
+fn keyword_params_compile_and_run() {
+    if !rustc_available() {
+        eprintln!("skipping: rustc not on PATH");
+        return;
+    }
+
+    // 1. Emit.
+    let artifact = compile(&demo_module()).expect("module should compile to Rust source");
+
+    // Sanity: the emitted source carries the positional-ized keyword
+    // param + its default prologue, and the two resolved call shapes.
+    assert!(
+        artifact.source.contains("fn greet(greeting: __sir::Value, name: __sir::Value)"),
+        "expected keyword param positional-ized in emitted source:\n{}",
+        artifact.source
+    );
+    assert!(
+        artifact.source.contains("let name = if __sir::is_missing(&name)"),
+        "expected optional-keyword default prologue in emitted source:\n{}",
+        artifact.source
+    );
+    // Omitted keyword → sentinel; supplied keyword → its value in position.
+    assert!(
+        artifact.source.contains(
+            "greet(__sir::Value::Str(::std::rc::Rc::from(\"hi\")), __sir::missing())"
+        ),
+        "expected omitted-keyword call to pad the sentinel:\n{}",
+        artifact.source
+    );
+    assert!(
+        artifact.source.contains(
+            "greet(__sir::Value::Str(::std::rc::Rc::from(\"hi\")), __sir::Value::Str(::std::rc::Rc::from(\"ada\")))"
+        ),
+        "expected supplied-keyword call resolved to positional:\n{}",
+        artifact.source
+    );
+
+    // 2. Write the source to a unique temp file.
+    let dir = std::env::temp_dir();
+    let nonce = std::process::id();
+    let src_path = dir.join(format!("sir_kwparams_{nonce}.rs"));
+    let bin_path = dir.join(format!(
+        "sir_kwparams_{nonce}{}",
+        if cfg!(windows) { ".exe" } else { "" }
+    ));
+    std::fs::write(&src_path, &artifact.source).expect("write temp source");
+
+    // 3. Compile with rustc.  `--edition 2021` is required (raw idents +
+    //    2018+ closure capture).  An absent default linker can be pointed
+    //    at a working one via `SIR_TEST_RUSTC_LINKER` (e.g. `rust-lld`).
+    let mut cmd = Command::new("rustc");
+    cmd.arg("--edition").arg("2021").arg("-O");
+    if let Ok(linker) = std::env::var("SIR_TEST_RUSTC_LINKER") {
+        if !linker.is_empty() {
+            cmd.arg("-C").arg(format!("linker={linker}"));
+        }
+    }
+    let compile_out = cmd
+        .arg(&src_path)
+        .arg("-o")
+        .arg(&bin_path)
+        .output()
+        .expect("invoke rustc");
+    if !compile_out.status.success() {
+        let stderr = String::from_utf8_lossy(&compile_out.stderr);
+        // A missing linker is a host issue, not a codegen defect — skip.
+        if stderr.contains("linker")
+            && (stderr.contains("not found") || stderr.contains("No such file"))
+        {
+            eprintln!("skipping: no usable linker on host\n{stderr}");
+            let _ = std::fs::remove_file(&src_path);
+            return;
+        }
+        panic!(
+            "emitted Rust failed to compile:\n--- stderr ---\n{stderr}\n--- source ---\n{}",
+            artifact.source,
+        );
+    }
+
+    // 4. Run the binary and capture stdout.
+    let run_out = Command::new(&bin_path).output().expect("run compiled binary");
+    assert!(
+        run_out.status.success(),
+        "compiled binary exited non-zero:\n{}",
+        String::from_utf8_lossy(&run_out.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&run_out.stdout);
+    let lines: Vec<&str> = stdout.lines().collect();
+
+    // 5. Assert the program's observable behaviour:
+    //    greet("hi")              → name defaulted → "world"
+    //    greet("hi", name: "ada") → name supplied  → "ada"
+    assert_eq!(
+        lines,
+        vec!["world", "ada"],
+        "unexpected program output; full stdout:\n{stdout}"
+    );
+
+    // 6. Best-effort cleanup.
+    let _ = std::fs::remove_file(&src_path);
+    let _ = std::fs::remove_file(&bin_path);
+}


### PR DESCRIPTION
## What

**KW5** of the keyword-params cascade — replaces the KW1 compile-compat stubs in the Rust backend with real emission via **static keyword→positional resolution** (no runtime library). Design: `code/specs/sir-keyword-params.md` §4.

- **Def side:** a `Keyword` param emits as an ordinary positional Rust parameter; optional keywords reuse the existing `DefaultParams` body-top prologue.
- **Call side:** new `emit_direct_call` looks up the callee signature (new `FN_PARAMS` thread-local) and builds the positional arg list in **declared** order — positionals fill leading slots, each `KeywordArg` fills its name-matched slot, omitted optionals padded with `__sir::missing()` (callee prologue substitutes the default).
- `Feature::KeywordParams` added to `ACCEPTED_FEATURES`.

## Hardening (from security review)

Includes a follow-up commit: `reject_keyword_with_variadic` in the capability check rejects any function mixing a keyword param with `*rest`/`**kwrest` (e.g. `def f(a, *rest, x: 1)`) with a clean `UnsupportedFeature` error — static keyword→positional resolution needs fixed arity, so this shape can't be resolved. This closes a reachable emit-panic (the `Rest`/`KwRest` arm is now a true internal-bug guard). The companion [#7173](https://github.com/adhithyan15/coding-adventures/pull/7173) centrally rejects keyword args on indirect calls.

## Verification

- `cargo test -p semantic-ir-to-rust` — **75 lib + 6 integration** green (+3 hardening tests).
- **Execution-proof ran** (rustc via rust-lld): `greet("hi")` → `world` (optional keyword defaulted); `greet("hi", name: "ada")` → `ada`.
- Clippy: no new warnings on touched files.
- **Security-reviewed**; the two findings (keyword+rest panic; indirect-keyword panic) are remediated here + in #7173.

Note: the exec-proof returns `name` (not interpolated `"hi, world"`) — the Rust backend doesn't accept `StrConcat`; still discriminating on the keyword value + default-fill path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)