### PR TITLE
test(inline): port InlineFunctionsTest upstream suite (#88, CLOC12.137)

### DIFF
--- a/code/packages/rust/closure-pass-inline/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-inline/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 All notable changes to the `coding-adventures-closure-pass-inline` crate will be documented in this file.
 
+## [0.21.0] - 2026-06-30
+
+### Added — CLOC12 upstream test port (`InlineFunctionsTest`)
+
+Ported the function-inlining cases from Google Closure Compiler's
+`InlineFunctionsTest.java` into `tests/upstream/inline_functions_test.rs`,
+following the CLOC12.01 convention (header cites the Java source; `UPSTREAM_SHA`
+pins the tracked commit; `ATTRIBUTION.md` records Apache-2.0 provenance; a
+`[[test]]` entry wires the file in). Each case drives the real
+`source → bridge → inline → emit` chain and asserts on the emitted string — the
+same surface upstream uses.
+
+- **7 active `#[test]`s pass**: zero-param constant and string-literal returns,
+  a tiny body inlined at two call sites, argument substitution into a member
+  object (property name preserved), a call nested in a binary expression, and
+  the two decline cases (a non-call use of the callee; a multi-use body over the
+  size budget). Because only the inline pass runs, the dead callee declaration
+  is retained (removed downstream) and no folding happens (`d(2)` → `2*2`).
+- **6 `#[ignore = "blocked on gap-NNN"]` placeholders** record upstream
+  behaviors not yet covered, pinned to `code/specs/CLOC12-gaps.md` (CLOC12.137):
+  gap-127 local-declaration bodies, gap-128 `this`-using methods, gap-129
+  function-expression/arrow bindings, gap-130 void side-effect-only calls,
+  gap-131 explicit recursion guard.
+- **gap-132 — surfaced by this port.** A compound (non-leaf) argument
+  expression is declined rather than inlined: `function d(x){return x*2}
+  g(d(a+b));` is left as `g(d(a+b));` where upstream produces `g((a+b)*2);`. The
+  slice substitutes only simple (identifier/literal) arguments. This is a
+  conservative miss (not a miscompile); the fix needs single-use-parameter
+  detection plus precedence-preserving parenthesization. Documented as a
+  follow-up fix candidate.
+
+Test-only change — no production code touched. Crate version 0.20.0 → 0.21.0.
+
 ## [0.20.0] - 2026-06-20
 
 ### Added — CLOC23: function inlining across `for`-`of`

--- a/code/packages/rust/closure-pass-inline/Cargo.toml
+++ b/code/packages/rust/closure-pass-inline/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-inline"
-version = "0.20.0"
+version = "0.21.0"
 edition = "2021"
 description = "Function-inlining pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Substitutes small or single-use function bodies at their call sites to enable downstream folding and shrink call overhead."
 
@@ -19,3 +19,10 @@ coding-adventures-closure-pass-constant-fold = { path = "../closure-pass-constan
 # actual AST shape the parser produces (not hand-built ASTs).
 coding-adventures-javascript-parser = { path = "../javascript-parser" }
 coding-adventures-closure-emitter = { path = "../closure-emitter" }
+
+# Upstream-test ports live under `tests/upstream/`; Cargo only
+# auto-discovers `tests/*.rs` one level deep, so each ported file needs
+# an explicit `[[test]]` entry. Per CLOC12.01 §3.
+[[test]]
+name = "upstream_inline_functions"
+path = "tests/upstream/inline_functions_test.rs"

--- a/code/packages/rust/closure-pass-inline/README.md
+++ b/code/packages/rust/closure-pass-inline/README.md
@@ -308,3 +308,17 @@ Dev-deps:
   two-pass ordering integration test.
 - `coding-adventures-javascript-parser` + `coding-adventures-closure-emitter`
   for the source → bridge → inline → emit roundtrip tests.
+
+## Upstream conformance tests
+
+`tests/upstream/inline_functions_test.rs` ports Google Closure Compiler's
+`InlineFunctionsTest` (Apache-2.0; see `ATTRIBUTION.md` and `UPSTREAM_SHA`),
+per the CLOC12 test-port convention. It pins the 7 behaviors this pass
+supports today and records 6 upstream behaviors it does not — local-declaration
+bodies, `this`-using methods, function-expression/arrow bindings, void
+side-effect calls, an explicit recursion guard, and **compound-argument
+inlining** (`d(a+b)` → `(a+b)*2`, a conservative miss surfaced by this port) —
+as `#[ignore = "blocked on gap-NNN"]` placeholders tied to
+`code/specs/CLOC12-gaps.md` (gap-127 … gap-132). Run with
+`cargo test --test upstream_inline_functions` (add `-- --include-ignored` to
+list the pending gaps).

--- a/code/packages/rust/closure-pass-inline/tests/upstream/ATTRIBUTION.md
+++ b/code/packages/rust/closure-pass-inline/tests/upstream/ATTRIBUTION.md
@@ -1,0 +1,42 @@
+# Attribution
+
+Tests in this directory are ported from the Google Closure Compiler
+under the Apache License, Version 2.0:
+
+    https://github.com/google/closure-compiler
+    LICENSE: https://www.apache.org/licenses/LICENSE-2.0
+
+## Files ported
+
+- `inline_functions_test.rs`
+    - upstream: `test/com/google/javascript/jscomp/InlineFunctionsTest.java`
+    - tracked commit: see `UPSTREAM_SHA`
+
+## Translation notes
+
+Fifth port under CLOC12 (after constant-fold, dce, the emitter/source-map
+ports, and remove-unused-vars). Per CLOC12 §6, each upstream Java test file
+maps to one Rust file in the matching pass crate's `tests/upstream/` directory.
+
+- Upstream tests run against a JS source-string surface
+  (`test("function f(){return 1} f()", "1")`). This crate already exposes a
+  `source → bridge → inline → emit` round-trip in its unit tests, so the port
+  reuses that surface directly (an `inline_source(&str) -> String` helper)
+  rather than hand-building ASTs.
+
+- Two intrinsic differences from the Java oracle, both because the port runs
+  **only** the inline pass:
+  1. the dead callee declaration is retained (`remove-unused-vars` / `treeshake`
+     delete it downstream), so outputs carry a `function …{…};` prefix; and
+  2. no constant-folding runs after inlining, so `d(2)` inlines to `2*2`, not
+     `4` (folding is `constant-fold`'s job).
+
+- Our `InlinePass` implements the sound core: substitute a `return <expr>;`
+  body at its call site(s) — single-use always, multi-use under a size budget —
+  when every argument is a simple leaf (identifier/literal) and the body has no
+  free identifiers beyond the parameters. Behaviors upstream supports that this
+  slice does not are `#[ignore = "blocked on gap-NNN"]` placeholders pinned to
+  `code/specs/CLOC12-gaps.md` (gap-127 … gap-132). Notably **gap-132**, a
+  conservative miss surfaced by this port: a compound (non-leaf) argument
+  expression like `d(a + b)` is declined rather than inlined with
+  precedence-preserving parens.

--- a/code/packages/rust/closure-pass-inline/tests/upstream/UPSTREAM_SHA
+++ b/code/packages/rust/closure-pass-inline/tests/upstream/UPSTREAM_SHA
@@ -1,0 +1,13 @@
+# UPSTREAM_SHA
+#
+# Tracks google/closure-compiler at this commit. Every Rust file in
+# tests/upstream/ was ported from a Java file at this snapshot.
+#
+# Upgrade policy: bump this SHA only in a dedicated PR that re-ports
+# every Java source listed in ATTRIBUTION.md, diff-checks against the
+# previous port, and explicitly handles added / removed / renamed
+# tests per CLOC12 §4.
+
+commit:  5bb35ec1245dc1d3557481e5f8b4db344bcd1e6b
+date:    2026-05-28
+url:     https://github.com/google/closure-compiler/tree/5bb35ec1245dc1d3557481e5f8b4db344bcd1e6b

--- a/code/packages/rust/closure-pass-inline/tests/upstream/inline_functions_test.rs
+++ b/code/packages/rust/closure-pass-inline/tests/upstream/inline_functions_test.rs
@@ -1,0 +1,202 @@
+//! Ported from `InlineFunctionsTest.java` in `google/closure-compiler`,
+//! Apache-2.0. Upstream SHA: see `tests/upstream/UPSTREAM_SHA`.
+//!
+//! Translation policy: see
+//! `code/specs/CLOC12-upstream-test-suite-port.md`.
+//!
+//! CLOC12 port for the `inline` pass. Upstream `InlineFunctions` is a
+//! large pass; our `InlinePass` implements the provably-sound core:
+//! it substitutes the body of a `return <expr>;` function at its call
+//! site(s) — single-use always, multi-use under a conservative size
+//! budget — when every argument is safe to substitute and the body has
+//! no free identifiers beyond the parameters. See the crate docs.
+//!
+//! Like the crate's own behaviour tests, each case drives the real
+//! `source → bridge → inline → emit` chain (closurec's SIMPLE path) and
+//! asserts on the emitted string — the same surface upstream uses
+//! (`test("function f(){return 1} f()", "1")`). Two caveats vs. the Java
+//! oracle, both intrinsic to running ONLY this pass:
+//!
+//!   1. The dead callee declaration is left in place — `remove-unused-
+//!      vars` / `treeshake` delete it downstream. So where upstream
+//!      shows just the inlined call site, we also see the retained
+//!      `function …{…};` prefix.
+//!   2. No constant-folding runs after, so `d(2)` inlines to `2*2`
+//!      (not `4`) — folding is `constant-fold`'s job, a separate pass.
+//!
+//! Behaviors upstream supports that our slice does not are recorded as
+//! `#[ignore = "blocked on gap-NNN"]` placeholders pinned to
+//! `code/specs/CLOC12-gaps.md` (gap-127 … gap-131).
+
+use coding_adventures_closure_emitter::{emit, EmitOptions};
+use coding_adventures_closure_pass_inline::InlinePass;
+use coding_adventures_closure_pass_pipeline::{Pass, PassContext};
+use coding_adventures_correlation_vector::CVLog;
+use coding_adventures_javascript_parser::{bridge, parse_javascript_typed};
+use coding_adventures_javascript_tokens::EsVersion;
+use coding_adventures_type_sidecar::Sidecar;
+
+/// Parse `src`, bridge to a typed `Program`, run **only** `InlinePass`,
+/// and emit the result as minified JS — the same chain closurec's SIMPLE
+/// level uses. (Copied from the crate's own test helper; integration
+/// tests can't see the private one.)
+fn inline_source(src: &str) -> String {
+    let es = EsVersion::Es2025;
+    let node = parse_javascript_typed(src, es).expect("parse");
+    let prog = bridge::grammar_to_program(&node, es).expect("bridge");
+
+    let pass = InlinePass::new();
+    let sidecar = Sidecar::new();
+    let mut cv = CVLog::new(false);
+    let out = pass
+        .run(PassContext {
+            program: &prog,
+            sidecar: &sidecar,
+            cv: &mut cv,
+        })
+        .expect("inline");
+
+    let mut cv2 = CVLog::new(false);
+    let opts = EmitOptions {
+        source_map: false,
+        ..Default::default()
+    };
+    emit(&out.program, &sidecar, &mut cv2, &opts)
+        .expect("emit")
+        .code
+}
+
+// =====================================================================
+// Active ports — behaviors `InlinePass` supports today.
+// =====================================================================
+
+#[test]
+fn inlines_zero_param_constant_return() {
+    // upstream `inlineFunctions1`-style: `function f(){return 1} f()`
+    // → the call becomes `1`.
+    assert_eq!(
+        inline_source("function f() { return 1; } g(f());"),
+        "function f(){return 1};g(1);"
+    );
+}
+
+#[test]
+fn inlines_string_literal_return() {
+    assert_eq!(
+        inline_source("function s() { return \"hi\"; } g(s());"),
+        "function s(){return \"hi\"};g(\"hi\");"
+    );
+}
+
+#[test]
+fn inlines_zero_param_body_at_two_sites() {
+    // A tiny (1-node) body is under the multi-use budget, so both call
+    // sites are inlined.
+    assert_eq!(
+        inline_source("function one() { return 1; } a(one()); b(one());"),
+        "function one(){return 1};a(1);b(1);"
+    );
+}
+
+#[test]
+fn substitutes_argument_into_member_object() {
+    // `o` → `arr`, but `.length` (the property name) is untouched.
+    assert_eq!(
+        inline_source("function len(o) { return o.length; } use(len(arr));"),
+        "function len(o){return o.length};use(arr.length);"
+    );
+}
+
+#[test]
+fn inlines_call_nested_in_binary_expression() {
+    assert_eq!(
+        inline_source("function id(v) { return v; } use(id(a) + id(b));"),
+        "function id(v){return v};use(a+b);"
+    );
+}
+
+#[test]
+fn does_not_inline_when_a_use_is_not_a_call() {
+    // `f` used as a value (`keep(f)`) blocks inlining: substituting the
+    // calls would leave `f` referenced, so the decl couldn't be removed.
+    assert_eq!(
+        inline_source("function f(x) { return x * 2; } a(f(1)); keep(f);"),
+        "function f(x){return x*2};a(f(1));keep(f);"
+    );
+}
+
+#[test]
+fn does_not_inline_multi_use_over_budget() {
+    // `x * x * x` (5 nodes) exceeds the 1-param budget (2 + 1), so two
+    // call sites are declined to avoid output growth.
+    assert_eq!(
+        inline_source("function cube(x) { return x * x * x; } a(cube(p)); b(cube(q));"),
+        "function cube(x){return x*x*x};a(cube(p));b(cube(q));"
+    );
+}
+
+// =====================================================================
+// Not-yet-supported upstream behaviors — pinned to CLOC12-gaps.md.
+// =====================================================================
+
+#[test]
+#[ignore = "blocked on gap-127: inlining a function with local declarations (var/let in the body)"]
+fn inlines_function_with_local_variable() {
+    // upstream: `function f(x){ var y = x + 1; return y; } g(f(2));`
+    // inlines to the equivalent expression. Our slice only handles a
+    // single `return <expr>;` body with no locals.
+}
+
+#[test]
+#[ignore = "blocked on gap-128: inlining a method that references `this`"]
+fn inlines_method_using_this() {
+    // upstream inlines simple `this`-using method bodies at call sites
+    // where the receiver is known. Our slice bails on any free
+    // identifier (including `this`).
+}
+
+#[test]
+#[ignore = "blocked on gap-129: inlining a function expression / arrow assigned to a variable"]
+fn inlines_function_expression_binding() {
+    // upstream: `var f = function(x){return x*2}; g(f(3));` and the
+    // arrow form inline. Our slice only recognizes `function` *declarations*.
+}
+
+#[test]
+#[ignore = "blocked on gap-130: inlining a void (no-return) function called for its side effect only"]
+fn inlines_void_function_statement_call() {
+    // upstream: `function log(x){ console.log(x); } log(v);` inlines the
+    // body as a statement. Our slice targets value-position `return`
+    // bodies; broader void-statement inlining is future work.
+}
+
+#[test]
+#[ignore = "blocked on gap-131: inlining declines must cover a self-referential (recursive) callee explicitly"]
+fn does_not_inline_recursive_function() {
+    // upstream leaves `function f(x){return f(x)} g(f(1));` alone. Our
+    // slice happens to decline it (the body's free `f` reference fails
+    // the no-free-identifier gate), but there is no dedicated recursion
+    // guard — pinned so a future change that widens the free-identifier
+    // rule can't silently start inlining a recursive body.
+}
+
+#[test]
+#[ignore = "blocked on gap-132: inlining a COMPOUND (non-leaf) argument expression"]
+fn inlines_compound_argument_with_precedence_parens() {
+    // GAP FOUND BY THIS PORT. upstream inlines
+    // `function d(x){return x*2} g(d(a+b));` → `g((a+b)*2);`, adding the
+    // precedence-preserving parens. Our slice substitutes only *simple*
+    // arguments (a bare identifier or a literal); a compound argument
+    // like `a + b` is declined and the call is left intact
+    // (`g(d(a+b));`) — a conservative miss, not a miscompile. Closing
+    // this needs: (1) allow a compound arg when its parameter is used
+    // exactly once in the body (so it isn't duplicated / re-evaluated),
+    // and (2) parenthesize the substituted expression against the
+    // surrounding operator's precedence. See `code/specs/CLOC12-gaps.md`.
+    //
+    // When implemented, this becomes:
+    //   assert_eq!(
+    //       inline_source("function d(x) { return x * 2; } g(d(a + b));"),
+    //       "function d(x){return x*2};g((a+b)*2);"
+    //   );
+}

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -982,3 +982,40 @@ historical context with status `RESOLVED` and a link to the fix PR.
     `TEMPLATE_TAIL`, raising `LexerError: Unexpected sequence '` `` ` `` `'`.
   - gap-044b states the correct fix: an explicit mode stack in `GrammarLexer`
     (push template mode on `${`, pop on matching `}`).
+
+## CLOC12.137 — port `InlineFunctionsTest` into `closure-pass-inline`
+
+- **Status:** port landed; 7 active `#[test]`s pass, 6 `#[ignore]` gaps opened.
+- **What it is:** the fifth CLOC12 upstream port, covering the function-body
+  substitution that `InlineFunctions` performs.
+  `closure-pass-inline/tests/upstream/inline_functions_test.rs` drives the real
+  `source → bridge → inline → emit` chain and asserts on the emitted string. It
+  pins the sound core our `InlinePass` implements: substitute a `return <expr>;`
+  body at its call site(s) — single-use always, multi-use under a size budget —
+  when every argument is a simple leaf (identifier/literal) and the body has no
+  free identifiers beyond the parameters. 7 active cases pass (zero-param
+  constant/string returns, two-site inlining, member-object substitution,
+  nested-in-binary, decline-non-call-use, decline-over-budget-multi-use).
+- **New gaps** (executable `#[ignore = "blocked on gap-NNN"]` placeholders):
+  - **gap-127** — inlining a function with local declarations (`var`/`let` in
+    the body); the slice handles only a single `return <expr>;`.
+  - **gap-128** — inlining a method that references `this`; the slice bails on
+    any free identifier.
+  - **gap-129** — inlining a function *expression* / arrow bound to a variable
+    (`var f = function(x){…}`); the slice recognizes only `function`
+    declarations.
+  - **gap-130** — inlining a void (no-return) function called for its side
+    effect only; the slice targets value-position `return` bodies.
+  - **gap-131** — no dedicated recursion guard: a self-referential callee is
+    declined today only because its body's free self-reference fails the
+    no-free-identifier gate; pinned so widening that gate can't silently start
+    inlining a recursive body.
+  - **gap-132 (surfaced by this port)** — a **compound (non-leaf) argument**
+    expression is declined rather than inlined. `function d(x){return x*2}
+    g(d(a+b));` is left as `g(d(a+b));`; upstream inlines it to `g((a+b)*2);`.
+    Our slice substitutes only simple (identifier/literal) arguments. This is a
+    conservative miss, **not** a miscompile. The fix needs: (1) allow a compound
+    argument when its parameter is used exactly once in the body (so it isn't
+    duplicated / re-evaluated), and (2) parenthesize the substituted expression
+    against the surrounding operator's precedence. Candidate for a dedicated
+    follow-up fix PR.


### PR DESCRIPTION
## Why
Part of the **upstream-test-port** effort (#88): rewrite Google Closure Compiler's Java test suites in Rust to raise coverage from the canonical source of truth **and** surface real closurec gaps. Fifth CLOC12 port.

## What
Ports `InlineFunctionsTest.java` into `closure-pass-inline/tests/upstream/inline_functions_test.rs`, per the CLOC12.01 convention (`UPSTREAM_SHA` pin, `ATTRIBUTION.md`, `[[test]]` entry). Each case drives the real `source → bridge → inline → emit` chain and asserts on the emitted string — the same surface upstream uses. (Only the inline pass runs, so the dead callee decl is retained and no folding happens: `d(2)` → `2*2`.)

## Result
- **7 active `#[test]`s pass**: zero-param constant/string returns, a tiny body inlined at two call sites, argument substitution into a member object (property name preserved), a call nested in a binary expression, and two decline cases (a non-call use of the callee; a multi-use body over the size budget).
- **6 `#[ignore = "blocked on gap-NNN"]` placeholders** pinned to `code/specs/CLOC12-gaps.md` (CLOC12.137):

| gap | not-yet-covered upstream behavior |
|---|---|
| gap-127 | local-declaration bodies (`var`/`let` in the callee) |
| gap-128 | `this`-using methods |
| gap-129 | function-expression / arrow bindings |
| gap-130 | void (no-return) side-effect-only calls |
| gap-131 | explicit recursion guard |
| **gap-132** | **compound-argument inlining — surfaced by this port** |

### gap-132 (real gap found)
The pass declines a compound (non-leaf) argument: `function d(x){return x*2} g(d(a+b));` is left as `g(d(a+b));`, where upstream produces `g((a+b)*2);`. The slice substitutes only simple (identifier/literal) arguments. **Conservative miss, not a miscompile.** A follow-up fix (single-use-parameter detection + precedence-preserving parens) is queued.

## Safety
**Test-only** — no production/library code touched. Crate `0.20.0` → `0.21.0`; CHANGELOG + README + CLOC12-gaps.md updated. Inline security review: **PASSED** (no new deps, no unsafe/IO/injection; inputs are hardcoded literals; panics test-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)