### PR TITLE
feat(treeshake): correlation-vector deletion provenance (#89)

### DIFF
--- a/code/packages/rust/closure-pass-treeshake/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-treeshake/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to the `coding-adventures-closure-pass-treeshake` crate will be documented in this file.
 
+## [0.4.0] - 2026-06-30
+
+### Added — correlation-vector deletion provenance (#89)
+
+Treeshake is the whole-program analogue of DCE: it deletes unreferenced
+top-level `function` declarations. Like DCE, it must not delete code silently.
+Before this change the pass received the shared `CVLog` (via `PassContext`) but
+never used it, and returned `contributions: Vec::new()` — so a
+`--correlation_vector` consumer asking "what happened to `function foo`?" got no
+answer; the removed function vanished from the provenance graph.
+
+Now each removed function's own CV entry is **tombstoned** with a
+`DeletionRecord` via `CVLog::delete(cv_id, "treeshake",
+"removed-unreferenced-function", meta)` (meta carries the function's `name`), and
+one summary `Contribution` is emitted against the program root recording how
+many were removed. This mirrors the deletion provenance merged for the DCE and
+fold-control-flow passes.
+
+- **Byte-for-byte identical program output** — the same functions are removed;
+  only the CV log gains the deletion records and the summary contribution.
+- **Zero cost off the hot path** — `delete` is a no-op when the log is disabled
+  (production default), so tombstones only materialise under
+  `--correlation_vector`. The `changed`/`contributions` behavior for the
+  no-removal case is unchanged (still empty).
+- Four new tests: a removed function is tombstoned with `source == "treeshake"`
+  and the right reason/name; every function in a multi-removal is tombstoned; a
+  **referenced** function (kept alive by a call site) is NOT tombstoned; and a
+  disabled log still removes the dead function without panicking. Crate version
+  0.3.2 → 0.4.0.
+
 ## [0.3.2] - 2026-06-16
 
 ### Docs

--- a/code/packages/rust/closure-pass-treeshake/Cargo.toml
+++ b/code/packages/rust/closure-pass-treeshake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-treeshake"
-version = "0.3.2"
+version = "0.4.0"
 edition = "2021"
 description = "Tree-shaking pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Removes module exports and imports that aren't reachable from the program's entry points, eliminating whole-module dead weight that intra-module DCE can't see."
 

--- a/code/packages/rust/closure-pass-treeshake/README.md
+++ b/code/packages/rust/closure-pass-treeshake/README.md
@@ -74,6 +74,20 @@ Tree-shake runs late — after DCE has trimmed every module
 internally, after inline has fixed call-site references, after
 rename has settled on the final names.
 
+## Deletion provenance (correlation vector)
+
+When treeshake removes an unreferenced top-level `function`, it
+tombstones that function's own CV entry via `cv.delete(cv_id,
+"treeshake", "removed-unreferenced-function", meta)` (meta carries the
+function `name`), and emits one summary `Contribution` against the
+program root. So a `--correlation_vector` consumer asking "what happened
+to `function foo`?" gets a definite answer instead of the function
+silently vanishing from the provenance graph — the same audit trail the
+DCE and fold-control-flow passes record for what *they* delete. `delete`
+is a no-op when the log is disabled (the production default), so this
+costs nothing off the `--correlation_vector` path, and program output is
+byte-for-byte unchanged.
+
 ## Dependency whitelist
 
 - `coding-adventures-closure-pass-pipeline` — `Pass` trait + types.
@@ -82,7 +96,8 @@ rename has settled on the final names.
   future tree-shake will read module-level `external` attributes
   to seed the root set.
 - `coding_adventures_correlation_vector` — receives mutable
-  `CVLog` for per-removal `Contribution` emission.
+  `CVLog`; removed functions are tombstoned via `cv.delete()` and a
+  summary `Contribution` is emitted.
 - `serde_json` — `Contribution.meta` JSON values.
 
 Dev-deps:

--- a/code/packages/rust/closure-pass-treeshake/src/lib.rs
+++ b/code/packages/rust/closure-pass-treeshake/src/lib.rs
@@ -80,10 +80,12 @@
 use coding_adventures_closure_pass_pipeline::{
     IterationPolicy, Pass, PassContext, PassError, PassOutput, PassStats,
 };
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use coding_adventures_closure_scope_analyzer::{analyze, BindingId, BindingKind, ScopeId};
+use coding_adventures_correlation_vector::Contribution;
 use coding_adventures_javascript_ast::{Declaration, ProgramItem};
+use serde_json::json;
 
 /// `Pass::depends_on` value. CLOC06 canonical order pins DCE
 /// before tree-shake. Kept as a `const` so future tests / sibling
@@ -245,15 +247,53 @@ impl Pass for TreeshakePass {
 
         let mut new_body: Vec<ProgramItem> = Vec::with_capacity(ctx.program.body.len());
         let mut removed_count: usize = 0;
+        // Capture each removed function's own CV id (and name) BEFORE it
+        // is dropped, so we can tombstone the exact span that vanished.
+        let mut removed: Vec<(Option<String>, String)> = Vec::new();
         for item in &ctx.program.body {
             match item {
                 ProgramItem::Declaration(Declaration::FunctionDeclaration(fd))
                     if dead_names.contains(&fd.id.name) =>
                 {
                     removed_count += 1;
+                    removed.push((fd.cv.clone(), fd.id.name.clone()));
                     // Drop.
                 }
                 _ => new_body.push(item.clone()),
+            }
+        }
+
+        // Deletion provenance (#89). Treeshake is the whole-program
+        // analogue of DCE: it deletes unreferenced top-level functions.
+        // Like DCE, it must not delete code silently — each removed
+        // function's own CV entry is tombstoned with a `DeletionRecord`
+        // (via `CVLog::delete`), so a `--correlation_vector` consumer
+        // asking "what happened to `function foo`?" gets a definite
+        // answer: *treeshake removed it because it was unexported /
+        // unreferenced.* `delete` is a no-op when the log is disabled
+        // (production default), so this costs nothing off that path. We
+        // also emit one summary `Contribution` against the program root.
+        let mut contributions: Vec<Contribution> = Vec::new();
+        if removed_count > 0 {
+            for (cv_id, name) in &removed {
+                if let Some(id) = cv_id {
+                    let mut meta: HashMap<String, serde_json::Value> = HashMap::new();
+                    meta.insert("name".to_string(), json!(name));
+                    ctx.cv
+                        .delete(id, "treeshake", "removed-unreferenced-function", meta);
+                }
+            }
+            if let Some(prog_cv) = &ctx.program.cv {
+                contributions.push(Contribution {
+                    source: "treeshake".to_string(),
+                    tag: "removed-unreferenced-function".to_string(),
+                    meta: [
+                        ("removed".to_string(), json!(removed_count)),
+                        ("parent_cv".to_string(), json!(prog_cv)),
+                    ]
+                    .into_iter()
+                    .collect(),
+                });
             }
         }
 
@@ -263,7 +303,7 @@ impl Pass for TreeshakePass {
 
         Ok(PassOutput {
             program: new_program,
-            contributions: Vec::new(),
+            contributions,
             changed,
             diagnostics: Vec::new(),
             stats: PassStats {
@@ -467,6 +507,125 @@ mod tests {
         let mut p = program();
         p.body = items;
         p
+    }
+
+    // -----------------------------------------------------------------
+    // CV deletion provenance (#89).
+    //
+    // Mirror the pipeline: the lexer/parser `create` a CV entry per node
+    // and stamp its id onto the AST. So we `create` the function's entry
+    // FIRST, stamp its id, then run treeshake — otherwise `cv.delete`
+    // has no entry to tombstone and the assertion would be vacuous.
+    // Property: a treeshake-removed function's CV entry survives with a
+    // `DeletionRecord{source:"treeshake"}`, so "what happened to
+    // `function foo`?" stays answerable.
+    // -----------------------------------------------------------------
+
+    /// A `function <name>(){}` whose CV id is freshly created in `log`.
+    fn traced_fn_decl(log: &mut CVLog, name: &str) -> (ProgramItem, String) {
+        let id = log.create(None);
+        let item = ProgramItem::Declaration(Declaration::FunctionDeclaration(FunctionDeclaration {
+            cv: Some(id.clone()),
+            id: ident(name),
+            params: Vec::new(),
+            body: BlockStatement {
+                cv: None,
+                body: Vec::new(),
+            },
+            generator: false,
+            is_async: false,
+        }));
+        (item, id)
+    }
+
+    /// Like [`run_pass`] but threads the caller's CV log through so its
+    /// `DeletionRecord`s can be inspected after the pass returns.
+    fn run_capturing_cv(
+        prog: &Program,
+        cv: &mut CVLog,
+    ) -> coding_adventures_closure_pass_pipeline::PassOutput {
+        let sidecar = Sidecar::new();
+        let ctx = coding_adventures_closure_pass_pipeline::PassContext {
+            program: prog,
+            sidecar: &sidecar,
+            cv,
+        };
+        TreeshakePass::new().run(ctx).expect("pass ran")
+    }
+
+    #[test]
+    fn removed_function_is_tombstoned() {
+        let mut log = CVLog::new(true);
+        let (dead, dead_cv) = traced_fn_decl(&mut log, "dead");
+        let prog = program_with(vec![dead]);
+
+        let out = run_capturing_cv(&prog, &mut log);
+
+        assert!(out.changed);
+        assert!(out.program.body.is_empty());
+        let del = log
+            .get(&dead_cv)
+            .unwrap()
+            .deleted
+            .as_ref()
+            .expect("a removed function must be tombstoned");
+        assert_eq!(del.source, "treeshake");
+        assert_eq!(del.reason, "removed-unreferenced-function");
+        assert_eq!(del.meta.get("name").and_then(|v| v.as_str()), Some("dead"));
+    }
+
+    #[test]
+    fn each_removed_function_is_tombstoned() {
+        let mut log = CVLog::new(true);
+        let (f, f_cv) = traced_fn_decl(&mut log, "f");
+        let (g, g_cv) = traced_fn_decl(&mut log, "g");
+        let prog = program_with(vec![f, g]);
+
+        let out = run_capturing_cv(&prog, &mut log);
+
+        assert!(out.changed);
+        assert!(log.get(&f_cv).unwrap().deleted.is_some());
+        assert!(log.get(&g_cv).unwrap().deleted.is_some());
+    }
+
+    #[test]
+    fn referenced_function_is_not_tombstoned() {
+        // `function f(){} f();` — the call keeps f live, so it is
+        // neither removed nor tombstoned.
+        use coding_adventures_javascript_ast::{CallExpression, Expression};
+        let mut log = CVLog::new(true);
+        let (f, f_cv) = traced_fn_decl(&mut log, "f");
+        let call_f = ProgramItem::Statement(Statement::expression_statement(ExpressionStatement {
+            cv: None,
+            expression: Expression::CallExpression(CallExpression {
+                cv: None,
+                callee: Box::new(Expression::Identifier(ident("f"))),
+                arguments: Vec::new(),
+            }),
+        }));
+        let prog = program_with(vec![f, call_f]);
+
+        let out = run_capturing_cv(&prog, &mut log);
+
+        assert!(!out.changed, "a referenced function must survive");
+        assert!(
+            log.get(&f_cv).unwrap().deleted.is_none(),
+            "a surviving function must NOT be tombstoned"
+        );
+    }
+
+    #[test]
+    fn disabled_log_still_removes_without_panicking() {
+        // With CV disabled, `delete` is a no-op; the pass must still
+        // drop the dead function and never panic on the missing entry.
+        let mut log = CVLog::new(false);
+        let (dead, _cv) = traced_fn_decl(&mut log, "dead");
+        let prog = program_with(vec![dead]);
+
+        let out = run_capturing_cv(&prog, &mut log);
+
+        assert!(out.changed);
+        assert!(out.program.body.is_empty());
     }
 
     fn run_pass(prog: Program) -> coding_adventures_closure_pass_pipeline::PassOutput {


### PR DESCRIPTION
## Why
Part of **full CV tracing** (#89): make every closurec transformation auditable through the correlation vector. Extends the deletion-provenance pattern merged for DCE (#7160) and fold-control-flow (#7171) to the tree-shaking pass — the whole-program analogue of DCE, which *deletes* unreferenced top-level functions but recorded no per-function provenance.

Before, the pass received the shared `CVLog` via `PassContext` but never used it, returning `contributions: Vec::new()`. So a `--correlation_vector` consumer asking "what happened to `function foo`?" got **no answer** — the removed function vanished from the provenance graph.

## What
Each removed unreferenced function's own CV entry is now **tombstoned** via `CVLog::delete(cv_id, "treeshake", "removed-unreferenced-function", meta)` (meta carries the function `name`), plus one summary `Contribution` against the program root recording how many were removed.

## Safety
- **Byte-for-byte identical program output** — the same functions are removed; only the CV log + `PassOutput.contributions` gain records.
- **Zero cost off the hot path** — `delete` is a no-op when the log is disabled (production default). The no-removal case still returns empty contributions / `changed = false`.
- Inline security review: **PASSED** (disjoint field borrows, work bounded by removed functions, no unsafe, panics test-only, no injection surface — the function name is stored only as a JSON string value). Same pattern as merged #7160 / #7171.

## Tests
`closure-pass-treeshake` `0.3.2` → `0.4.0`. Four new tests: a removed function is tombstoned with `source == "treeshake"` + right reason/name; every function in a multi-removal is tombstoned; a **referenced** (called) function is NOT tombstoned; a disabled log still removes without panicking. 20 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)