### PR TITLE
feat(latex): under-arrow accents \underrightarrow / \underleftarrow / \underleftrightarrow

### DIFF
--- a/code/packages/rust/latex/CHANGELOG.md
+++ b/code/packages/rust/latex/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to the full-fidelity LaTeX parser crate.
 
+## [0.22.0] — 2026-06-30
+
+### Added — stretchy UNDER-arrow accents (the mirror of the over-arrow family)
+
+- **Under-arrow accents** (amsmath) — `\underrightarrow`, `\underleftarrow`, `\underleftrightarrow`.
+  These are the exact mirror of the existing `\overrightarrow`-family: a stretchy arrow drawn
+  **under** the argument rather than over it. Each lowers onto the existing `Underset` node over the
+  plain arrow symbol — the same annotation-under-a-body shape as `\underbrace` and an xarrow's
+  `[below]` label — so there is no new AST node and no frontend change:
+  `\underrightarrow{AB}` → `Underset { under: →, base: AB }` ≡ `\underset{\rightarrow}{AB}`, and
+  `to_latex` round-trips through `\underset`. Implemented via a new `under_arrow_base` table mirroring
+  `over_arrow_base`; missing `{body}` is a clean spanned error, never a panic.
+
 ## [0.21.0] — 2026-06-30
 
 ### Added — more stretchy accents & extensible arrows (all onto the existing Overset/Underset node)

--- a/code/packages/rust/latex/Cargo.toml
+++ b/code/packages/rust/latex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latex"
-version = "0.21.0"
+version = "0.22.0"
 edition = "2021"
 description = "A full-fidelity LaTeX parser (documents and math): a catcode-driven, text-mode-primary tokenizer and (in later layers) a structural + math parser producing a faithful AST. Standalone and reusable; will also implement the math-frontend MathFrontend trait."
 license = "MIT"

--- a/code/packages/rust/latex/README.md
+++ b/code/packages/rust/latex/README.md
@@ -32,7 +32,7 @@ with a **text-mode-primary** mode stack (LaTeX starts in text mode; math is ente
 |-------|----------|--------|
 | **L0 tokenizer** | catcode state machine → flat `Token` stream w/ byte spans | ✅ |
 | **L1 structural** | groups, `\cmd[opt]{arg}`, `\begin{env}…\end{env}`, text runs, raw math islands, `to_latex()` round-trip | ✅ |
-| **L2 math** | math AST (frac, binom, roots, scripts, big ops, functions, accents, `\left\right` fences, relations, `\overset`/`\underset`/`\stackrel` stacking, `\xrightarrow`-family extensible labelled arrows, `\overbrace`/`\underbrace` horizontal braces, and `\overrightarrow`-family stretchy over-arrow accents), precedence-climbing parser, `to_latex()` round-trip | ✅ |
+| **L2 math** | math AST (frac, binom, roots, scripts, big ops, functions, accents, `\left\right` fences, relations, `\overset`/`\underset`/`\stackrel` stacking, `\xrightarrow`-family extensible labelled arrows, `\overbrace`/`\underbrace` horizontal braces, and `\overrightarrow`/`\underrightarrow`-family stretchy over/under-arrow accents), precedence-climbing parser, `to_latex()` round-trip | ✅ |
 | **L3 environments** | math env family — `matrix`/`pmatrix`/`bmatrix`/`vmatrix`/`cases`/`aligned`/`align` plus `array`/`subarray` (mandatory `{col-spec}`) split on `&` and `\\` → `MathNode::Matrix`, round-trip; nesting + scripts | ✅ |
 | **L4 macros** | `\newcommand`/`\renewcommand`/`\providecommand` with positional `#1`..`#9`; bounded recursive expansion via `expand()` (L4a) | ✅ |
 | **L5 text breadth** | `\verb`/`verbatim` raw (L5a/b) + text accents `\'e`/`\c{c}` via `recognize_accents` (L5c) + sectioning/refs/preamble/font via `recognize_structure` (L5d) | ✅ |

--- a/code/packages/rust/latex/src/math.rs
+++ b/code/packages/rust/latex/src/math.rs
@@ -384,6 +384,27 @@ fn over_arrow_base(name: &str) -> Option<&'static str> {
     })
 }
 
+/// The stretchy UNDER-arrow accents `\underrightarrow` / `\underleftarrow` /
+/// `\underleftrightarrow` (amsmath) are the exact mirror of the over-arrow family: they draw a
+/// stretchy arrow UNDER the argument rather than over it. So they lower onto the existing
+/// [`MathNode::Underset`] node over the plain arrow symbol — the same annotation-under-a-body
+/// shape as `\underbrace` and the `[below]` label of an xarrow — and need no new AST node and no
+/// frontend change (`to_latex` round-trips through `\underset`). Returns the base arrow's
+/// control-word name, so `underrightarrow` → `rightarrow`, printing back as `\rightarrow`.
+///
+/// Truth table (command → arrow set under the body):
+///   \underrightarrow{AB}      → Underset{→,  AB}
+///   \underleftarrow{AB}       → Underset{←,  AB}
+///   \underleftrightarrow{AB}  → Underset{↔, AB}
+fn under_arrow_base(name: &str) -> Option<&'static str> {
+    Some(match name {
+        "underrightarrow" => "rightarrow",
+        "underleftarrow" => "leftarrow",
+        "underleftrightarrow" => "leftrightarrow",
+        _ => return None,
+    })
+}
+
 /// Math environments with `&`/`\\` row/column structure (L3). Case-sensitive — `bmatrix`
 /// (square brackets) and `Bmatrix` (braces) are different environments. The `array`/`subarray`
 /// grids take a **mandatory** column-spec argument (`\begin{array}{cc}`) — see
@@ -852,6 +873,19 @@ impl<'a> MathParser<'a> {
             let body = self.read_arg()?;
             return Ok(MathNode::Overset {
                 over: Box::new(MathNode::Sym(arrow.to_string())),
+                base: Box::new(body),
+            });
+        }
+        // `\underrightarrow{body}` / `\underleftarrow{body}` / `\underleftrightarrow{body}` — the
+        // mirror of the over-arrow accents: a stretchy arrow drawn UNDER the body. One mandatory
+        // `{body}` group; we lower to `Underset { under: <arrow>, base: body }` (see
+        // `under_arrow_base`), so `\underrightarrow{AB}` lowers identically to
+        // `\underset{\rightarrow}{AB}` — no new AST node, no frontend change.
+        if let Some(arrow) = under_arrow_base(name) {
+            self.bump();
+            let body = self.read_arg()?;
+            return Ok(MathNode::Underset {
+                under: Box::new(MathNode::Sym(arrow.to_string())),
                 base: Box::new(body),
             });
         }
@@ -2272,6 +2306,55 @@ mod tests {
     fn over_arrow_missing_mandatory_body_is_a_spanned_error() {
         // The `{body}` is mandatory; a trailing command with no argument is a clean error.
         assert!(parse_math(r"\overrightarrow").is_err());
+    }
+
+    // ---- stretchy UNDER-arrow accents (\underrightarrow & friends) --------------
+
+    #[test]
+    fn underrightarrow_is_the_arrow_set_under_the_body() {
+        // `\underrightarrow{AB}` ≡ a `\rightarrow` set UNDER the body `AB` — the mirror of
+        // `\overrightarrow`, lowering onto `Underset` instead of `Overset`.
+        let n = parse_math(r"\underrightarrow{AB}").unwrap();
+        match &n {
+            MathNode::Underset { under, base } => {
+                assert_eq!(**under, sym("rightarrow"));
+                // `AB` is implicit multiplication A·B
+                assert!(matches!(**base, MathNode::Bin(MBinOp::Mul, ..)));
+            }
+            other => panic!("expected Underset, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn under_arrows_use_their_own_base_arrow() {
+        // Each command maps to its own base arrow symbol, set under the body.
+        for (src, arrow) in [
+            (r"\underrightarrow{v}", "rightarrow"),
+            (r"\underleftarrow{w}", "leftarrow"),
+            (r"\underleftrightarrow{u}", "leftrightarrow"),
+        ] {
+            match &parse_math(src).unwrap() {
+                MathNode::Underset { under, .. } => assert_eq!(**under, sym(arrow), "{src}"),
+                other => panic!("expected Underset for {src}, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn under_arrow_round_trips_through_to_latex() {
+        // parse → to_latex → parse is a fixed point (surface normalises to \underset).
+        for src in [r"\underrightarrow{AB}", r"\underleftarrow{x}", r"\underleftrightarrow{PQ}"] {
+            let once = parse_math(src).unwrap();
+            assert!(once.to_latex().contains(r"\underset"), "{src} should print \\underset");
+            let twice = parse_math(&once.to_latex()).unwrap();
+            assert_eq!(once, twice, "round-trip changed the tree for {src:?}");
+        }
+    }
+
+    #[test]
+    fn under_arrow_missing_mandatory_body_is_a_spanned_error() {
+        // The `{body}` is mandatory; a trailing command with no argument is a clean error.
+        assert!(parse_math(r"\underrightarrow").is_err());
     }
 
     // ---- deep-tree Drop safety -------------------------------------------------


### PR DESCRIPTION
## What

Adds the amsmath **UNDER-arrow accents** to the `latex` math parser:

- `\underrightarrow{…}` → arrow drawn under the body
- `\underleftarrow{…}`
- `\underleftrightarrow{…}`

These are the exact **mirror** of the existing `\overrightarrow`-family (shipped in #7172): a stretchy arrow drawn *under* the argument rather than over it. Each lowers onto the **existing `Underset` node** over the plain arrow symbol — the same annotation-under-a-body shape as `\underbrace` and an xarrow's `[below]` label — so there is:

- **no new AST node**,
- **no frontend change**,
- **no `to_latex` change** (`\underrightarrow{AB}` lowers identically to `\underset{\rightarrow}{AB}` and round-trips through `\underset`).

Implemented via a new `under_arrow_base` table mirroring `over_arrow_base`, plus one dispatch block emitting `Underset`. A missing mandatory `{body}` is a clean spanned error, never a panic.

## Tests

4 new tests (arrow-under-body lowering, per-command base arrow, `to_latex` round-trip fixed-point, missing-body spanned error). **190 latex tests pass; clippy clean.**

## Security

Security review **PASSED** — pure structural lowering, no `unsafe`/I/O, O(1) match, recursion depth-guarded by `MAX_DEPTH`, forward progress via `bump()`, errors propagated via `?`.

latex `0.21.0` → `0.22.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)