### PR TITLE
feat(fold-control-flow): CV tombstones for block dead-code drop (#89 follow-up)

### DIFF
--- a/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to the `coding-adventures-closure-pass-fold-control-flow` crate will be documented in this file.
 
+## [0.16.0] - 2026-06-30
+
+### Added — CV tombstones for block dead-code-after-terminator (#89 follow-up)
+
+Closes the first of the two follow-ups noted in 0.15.0. The block-level
+dead-code-after-terminator drop (`fold_block_statement`, tag `removed-dead-code`)
+now tombstones each eliminated statement's own CV entry via the existing
+`record_fold_deleting` + `statement_cv` machinery, instead of emitting only a
+summary contribution. So `{ return; dead(); more(); }` → `{ return; }` records a
+`DeletionRecord{source:"fold-control-flow", reason:"removed-dead-code"}` on each
+of `dead()` / `more()`, exactly as the DCE pass records for the same
+dead-after-terminator drop it performs. The dropped statements' CV ids are
+captured in the block-fold loop before they are skipped.
+
+Byte-for-byte identical AST output; only the CV log gains the deletion records.
+`delete` is a no-op when the log is disabled (production default). One new test
+(`dead_code_after_terminator_is_tombstoned`); 36 unit + 13 upstream all green.
+Crate 0.15.0 → 0.16.0.
+
+The remaining follow-up — the constant-condition **ternary** collapse
+(`cond ? c : a` with a literal `cond`), whose discarded arm is an `Expression`
+and needs an `expression_cv` helper — is still open.
+
 ## [0.15.0] - 2026-06-30
 
 ### Added — correlation-vector deletion provenance for eliminated branches (#89)

--- a/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
+++ b/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-fold-control-flow"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 description = "Control-flow folding pass for the Closure Compiler clone. Slots between constant-fold and DCE per CLOC06's canonical pass set. Eliminates dead branches (`if (false) A else B → B`), removes unreachable code after `return`/`throw`, and collapses degenerate switch arms."
 

--- a/code/packages/rust/closure-pass-fold-control-flow/README.md
+++ b/code/packages/rust/closure-pass-fold-control-flow/README.md
@@ -84,12 +84,16 @@ vanishing from the provenance graph:
 - `if (true)  A else B` → `A` — the `else` branch **B** is tombstoned;
 - `if (false) A else B` → `B` — the `then` branch **A** is tombstoned;
 - `while (false) BODY`  → `;` — **BODY** is tombstoned.
+- `{ return; dead(); }` → `{ return; }` — the unreachable
+  dead-after-terminator statements are tombstoned (`removed-dead-code`),
+  matching what DCE records for the same drop.
 
 Rewrites that *preserve* both branches (`if→ternary`, `if→&&`, De Morgan
 swaps) do NOT tombstone — the content is restructured, not removed.
 `delete` is a no-op when the log is disabled (the production default),
-so this costs nothing off the `--correlation_vector` path. (Follow-ups:
-the block dead-code drop and the constant-condition ternary collapse.)
+so this costs nothing off the `--correlation_vector` path. (Remaining
+follow-up: the constant-condition ternary collapse, whose discarded arm
+is an `Expression` and needs an `expression_cv` helper.)
 
 ## Dependency whitelist
 

--- a/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
+++ b/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
@@ -449,9 +449,13 @@ fn fold_block_statement(b: &BlockStatement, st: &mut FoldState) -> BlockStatemen
     let mut new_body = Vec::with_capacity(b.body.len());
     let mut hit_terminator = false;
     let mut dropped_count = 0usize;
+    // Capture each dead-after-terminator statement's CV id so it can be
+    // tombstoned (see the `record_fold_deleting` call below).
+    let mut removed_cvs: Vec<Option<String>> = Vec::new();
     for s in &b.body {
         if hit_terminator {
             dropped_count += 1;
+            removed_cvs.push(statement_cv(s));
             continue;
         }
         let folded = fold_statement(s, st);
@@ -512,8 +516,13 @@ fn fold_block_statement(b: &BlockStatement, st: &mut FoldState) -> BlockStatemen
         }
     }
     if dropped_count > 0 {
-        st.record_fold(
+        // These statements are unreachable after a definite terminator
+        // (`return`/`throw`) and are eliminated — tombstone each so its
+        // span stays auditable, matching what DCE records for the same
+        // dead-after-terminator drop it performs.
+        st.record_fold_deleting(
             &b.cv,
+            &removed_cvs,
             "removed-dead-code",
             &format!("block with {} statements", b.body.len()),
             &format!("dropped {} statements after terminator", dropped_count),
@@ -1649,6 +1658,42 @@ mod tests {
             .as_ref()
             .expect("the eliminated `while (false)` body must be tombstoned");
         assert_eq!(del.reason, "folded-branch");
+    }
+
+    #[test]
+    fn dead_code_after_terminator_is_tombstoned() {
+        // `{ return; dead; }` — `dead` is unreachable after the `return`
+        // and is eliminated by the block dead-code drop, so its span must
+        // be tombstoned (matching what DCE records for the same drop).
+        let mut log = CVLog::new(true);
+        let dead_id = log.create(None);
+        let block = Statement::block_statement(BlockStatement {
+            cv: Some("blk.1".to_string()),
+            body: vec![
+                Statement::return_statement(ReturnStatement {
+                    cv: None,
+                    argument: None,
+                }),
+                expr_stmt(ident("dead"), Some(dead_id.as_str())),
+            ],
+        });
+        let prog = program().with_body(vec![ProgramItem::Statement(block)]);
+
+        let _out = run_capturing_cv(&prog, &mut log);
+
+        let del = log
+            .get(&dead_id)
+            .unwrap()
+            .deleted
+            .as_ref()
+            .expect("a statement after a terminator must be tombstoned");
+        assert_eq!(del.source, "fold-control-flow");
+        assert_eq!(del.reason, "removed-dead-code");
+        assert_eq!(
+            del.meta.get("container_cv").and_then(|v| v.as_str()),
+            Some("blk.1"),
+            "tombstone should record the enclosing block's cv"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Why
Closes the first of the two follow-ups noted in the merged [#7171](https://github.com/adhithyan15/coding-adventures/pull/7171) (fold-control-flow CV deletion provenance). That PR tombstoned eliminated `if`/`while` branches; this one extends the same provenance to the **block-level dead-code-after-terminator** drop, which was still emitting only a coarse summary contribution.

## What
`fold_block_statement` drops everything after a definite terminator (`return`/`throw`). Each dropped statement's CV id is now captured in the block-fold loop (the `hit_terminator` branch) *before* it is skipped, and passed to the existing `record_fold_deleting` helper — so each eliminated statement's own CV entry is tombstoned with `DeletionRecord{source:"fold-control-flow", reason:"removed-dead-code"}`, exactly as the DCE pass records for the same drop.

`{ return; dead(); more(); }` → `{ return; }` now tombstones both `dead()` and `more()`.

Reuses the `record_fold_deleting` + `statement_cv` machinery already merged in #7171 — a two-line production change plus one arg.

## Safety
- **Byte-for-byte identical AST output** — same statements dropped; only the CV log gains the deletion records.
- **Zero cost off the hot path** — `delete` is a no-op when the log is disabled (production default).
- Inline security review: **PASSED** (disjoint borrows, work bounded by dropped statements, no unsafe, no new panic path, no injection surface).

## Tests
`closure-pass-fold-control-flow` `0.15.0` → `0.16.0`. One new test (`dead_code_after_terminator_is_tombstoned`, incl. `container_cv` meta). 36 unit + 13 upstream all green.

## Remaining follow-up
The constant-condition **ternary** collapse (`cond ? c : a` with a literal `cond`), whose discarded arm is an `Expression` and needs an `expression_cv` helper — still open, noted in the CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)