### PR TITLE
fix(visicalc-swiftui): drop the resolved UI31-swiftui-commit-arity note

### DIFF
--- a/code/programs/swift/visicalc-swiftui/Sources/VisiCalc/Generated/Grid.swift
+++ b/code/programs/swift/visicalc-swiftui/Sources/VisiCalc/Generated/Grid.swift
@@ -8,6 +8,32 @@ enum GridEvent {
     case editCancel
 }
 
+extension GridEvent {
+    var mosaicName: String {
+        switch self {
+        case .navigate(row: _, col: _): return "onNavigate"
+        case .formulaChange(value: _): return "onFormulaChange"
+        case .editCommit: return "onEditCommit"
+        case .editCancel: return "onEditCancel"
+        }
+    }
+
+    var mosaicPayload: [String: Any] {
+        switch self {
+        case let .navigate(row: row, col: col): return ["row": row, "col": col]
+        case let .formulaChange(value: value): return ["value": value]
+        case .editCommit: return [:]
+        case .editCancel: return [:]
+        }
+    }
+
+    var mosaicEnvelope: [String: Any] {
+        var envelope = mosaicPayload
+        envelope["event"] = mosaicName
+        return envelope
+    }
+}
+
 struct GridView: View {
     let columnHeaders: [String]
     let viewportRows: [[String]]

--- a/code/programs/swift/visicalc-swiftui/scripts/build.sh
+++ b/code/programs/swift/visicalc-swiftui/scripts/build.sh
@@ -23,12 +23,10 @@
 #   swift run                  # macOS terminal target
 #   open Package.swift         # open in Xcode for iOS / macOS app
 #
-# NOTE: there's a known emitter glitch in the generated FormulaBar
-# (the `.onSubmit` handler emits `.commit(value: formula)` while
-# the `FormulaBarEvent` enum's `commit` case carries no associated
-# value). The Swift compiler will reject this. Track as
-# UI31-swiftui-commit-arity in a follow-up; meanwhile, hand-patch
-# the generated file or wait for the emitter fix before `swift run`.
+# (UI31-swiftui-commit-arity — RESOLVED.) The SwiftUI emitter now emits a
+# payloadless onCommit correctly: `emit onCommit ;` (no declared value) lowers to
+# `.onSubmit { dispatch(.commit) }` against an enum `case commit` with no associated
+# value, so the generated FormulaBar compiles as-is — no hand-patching needed.
 
 set -euo pipefail
 


### PR DESCRIPTION
## What

The SwiftUI `build.sh` carried a stale warning claiming the generated FormulaBar has a `.commit(value:)` vs payloadless-`commit` arity mismatch that "the Swift compiler will reject." That glitch is **already fixed** in the emitter — `mosaic-emit-swiftui` lowers a payloadless `emit onCommit ;` to `.onSubmit { dispatch(.commit) }` against an enum `case commit` with no associated value, so the generated code compiles as-is.

- Replaced the stale "hand-patch or wait for the emitter fix" note with a **RESOLVED** note.
- Refreshed the checked-in generated `Grid.swift` to match the current emitter output (event-envelope members) — the same generated-code currency the always-rebuild-`mosaic-compile` fix guarantees.

## Verification
- Regenerated via `scripts/build.sh`; the FormulaBar emits `dispatch(.commit)` (no `value:`) against `case commit`.
- `swift build` → **Build complete** (FormulaBar.swift + FormulaBar.touch.swift + Grid.swift compile). Earlier this session the full SwiftUI app was also verified building + running (edit→recompute) on both macOS and the iOS simulator.

Comment + emitter-generated-code only; no hand-written logic, no security surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)