### PR TITLE
feat(rename-globals): correlation-vector rename provenance (#89)

### DIFF
--- a/code/packages/rust/closure-pass-rename-globals/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename-globals/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename-globals` crate will be documented in this file.
 
+## [0.7.0] - 2026-06-30
+
+### Added — correlation-vector rename provenance (#89)
+
+Renaming is a transformation, not a deletion, so — unlike DCE / fold-control-flow
+/ treeshake, which *tombstone* removed nodes — this pass now records each global
+rename as a `renamed` **contribution** carrying `{from, to}`. Before, the pass
+returned `contributions: Vec::new()` and never touched the CV log, so renaming
+silently erased the link between a minified global (`a`) and its original name
+(`longName`): a `--correlation_vector` consumer had no way to recover it.
+
+`rename_globals` now returns its applied rename table (`(from, to)` pairs, sorted
+by original name for deterministic output) alongside the `changed` flag, and
+`run` maps each pair to a `Contribution{source:"rename-globals", tag:"renamed",
+meta:{from, to}}`. The pipeline attaches these to the program-root CV entry
+(`cv.contribute(prog_cv, …)`), so the rename table becomes queryable provenance.
+
+- **Byte-for-byte identical program output** — the renames applied are exactly
+  as before; only the returned `contributions` list is now populated. All 16
+  existing output tests are unchanged.
+- Two new tests: a renamed global emits one `renamed` contribution with the
+  right `from`/shorter `to`; a program with nothing to rename emits none.
+- `correlation-vector` moved from dev- to regular dependency; `serde_json` added
+  (for `Contribution.meta`). Crate version 0.6.0 → 0.7.0.
+
+**Scope / follow-up.** This attaches the rename *table* at the program root.
+Per-output-span provenance — contributing to each renamed identifier's *own* CV
+id — needs the log threaded through the `rename_apply_*` recursion and is a
+documented follow-up.
+
 ## [0.6.0] - 2026-06-20
 
 ### Added — CLOC23: global renaming across `for`-`of`

--- a/code/packages/rust/closure-pass-rename-globals/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename-globals/Cargo.toml
@@ -1,16 +1,17 @@
 [package]
 name = "coding-adventures-closure-pass-rename-globals"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 description = "Aggressive top-level (global) renaming pass for the Closure Compiler clone — the ADVANCED-level complement to closure-pass-rename. Shortens program-private top-level names, gated by an externs do-not-rename boundary."
 
 [dependencies]
 coding-adventures-closure-pass-pipeline = { path = "../closure-pass-pipeline" }
 coding-adventures-javascript-ast = { path = "../javascript-ast" }
+coding_adventures_correlation_vector = { path = "../correlation-vector" }
+serde_json = "1"
 
 [dev-dependencies]
 coding-adventures-javascript-tokens = { path = "../javascript-tokens" }
 coding-adventures-javascript-parser = { path = "../javascript-parser" }
 coding-adventures-closure-emitter = { path = "../closure-emitter" }
 coding-adventures-type-sidecar = { path = "../type-sidecar" }
-coding_adventures_correlation_vector = { path = "../correlation-vector" }

--- a/code/packages/rust/closure-pass-rename-globals/README.md
+++ b/code/packages/rust/closure-pass-rename-globals/README.md
@@ -60,8 +60,24 @@ top-level and locally is declared more than once, so neither renames it.)
 
 - `coding-adventures-closure-pass-pipeline` — `Pass` trait + types.
 - `coding-adventures-javascript-ast` — `Program` and the typed AST.
+- `coding_adventures_correlation_vector` — the `Contribution` type for
+  rename provenance (see below).
+- `serde_json` — `Contribution.meta` JSON values.
 
 Dev-deps: `coding-adventures-javascript-tokens`,
 `coding-adventures-javascript-parser`, `coding-adventures-closure-emitter`,
-`coding-adventures-type-sidecar`, `coding_adventures_correlation_vector`
-(source → bridge → pass → emit roundtrip tests).
+`coding-adventures-type-sidecar` (source → bridge → pass → emit roundtrip
+tests).
+
+## Rename provenance (correlation vector)
+
+Renaming is a transformation, not a deletion, so this pass records each
+global rename as a `renamed` **contribution** carrying `{from, to}`
+(rather than tombstoning, as the DCE / fold-control-flow / treeshake
+passes do for what they delete). The pipeline attaches these to the
+program-root CV entry, so a `--correlation_vector` consumer can map a
+minified global (`a`) back to its original source name (`longName`) —
+the rename *table* as queryable provenance. Program output is
+byte-for-byte unchanged. (Follow-up: per-output-span provenance —
+contributing to each renamed identifier's own CV id — needs the log
+threaded through the `rename_apply_*` recursion.)

--- a/code/packages/rust/closure-pass-rename-globals/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename-globals/src/lib.rs
@@ -68,7 +68,9 @@ use std::collections::{HashMap, HashSet};
 use coding_adventures_closure_pass_pipeline::{
     IterationPolicy, Pass, PassContext, PassError, PassOutput, PassStats,
 };
+use coding_adventures_correlation_vector::Contribution;
 use coding_adventures_javascript_ast::statement::TaggedStatement;
+use serde_json::json;
 use coding_adventures_javascript_ast::{
     AssignmentTarget, BindingTarget, Declaration, Expression, ForInit, FunctionParam, Program,
     ProgramItem, PropertyKey, Statement, VariableDeclaration,
@@ -136,11 +138,39 @@ impl Pass for RenameGlobalsPass {
     fn run(&self, ctx: PassContext<'_>) -> Result<PassOutput, PassError> {
         let mut program = ctx.program.clone();
         let mut nodes_touched: u32 = 1; // the program root
-        let changed = rename_globals(&mut program, &self.do_not_rename, &mut nodes_touched);
+        let (changed, renames) =
+            rename_globals(&mut program, &self.do_not_rename, &mut nodes_touched);
+
+        // CV provenance (#89): record every global rename as a `renamed`
+        // contribution carrying `{from, to}`. The pipeline attaches these
+        // to the program-root CV entry, so a `--correlation_vector`
+        // consumer can map a minified global (`a`) back to its original
+        // source name (`longName`) — provenance that rename otherwise
+        // erased. Emitted only when the log is enabled matters at the
+        // pipeline layer; here we always build the (cheap) list.
+        //
+        // This is the rename *table* (name → name), attached at the
+        // program root. Attaching a contribution to each renamed
+        // identifier's OWN CV id (per-output-span provenance) needs the
+        // log threaded through the `rename_apply_*` recursion and is a
+        // documented follow-up.
+        let contributions: Vec<Contribution> = renames
+            .into_iter()
+            .map(|(from, to)| Contribution {
+                source: "rename-globals".to_string(),
+                tag: "renamed".to_string(),
+                meta: [
+                    ("from".to_string(), json!(from)),
+                    ("to".to_string(), json!(to)),
+                ]
+                .into_iter()
+                .collect(),
+            })
+            .collect();
 
         Ok(PassOutput {
             program,
-            contributions: Vec::new(),
+            contributions,
             changed,
             diagnostics: Vec::new(),
             stats: PassStats { nodes_touched },
@@ -154,11 +184,17 @@ impl Pass for RenameGlobalsPass {
 
 /// Rename qualifying top-level bindings to fresh short names. Returns
 /// whether anything changed.
+/// Renames qualifying top-level bindings to fresh short names.
+///
+/// Returns `(changed, renames)` where `renames` is the applied rename
+/// table as `(from, to)` pairs sorted by original name (deterministic
+/// order for stable CV provenance). `renames` is empty exactly when
+/// `changed` is `false`.
 fn rename_globals(
     program: &mut Program,
     do_not_rename: &HashSet<String>,
     nodes_touched: &mut u32,
-) -> bool {
+) -> (bool, Vec<(String, String)>) {
     // 1. Declaration counts across the whole program (the shadow guard).
     let mut decl_counts: HashMap<String, usize> = HashMap::new();
     count_decl_names_program(program, &mut decl_counts, nodes_touched);
@@ -226,14 +262,20 @@ fn rename_globals(
     }
 
     if map.is_empty() {
-        return false;
+        return (false, Vec::new());
     }
 
     // 5. Apply: rewrite declarations + every use across the whole program.
     for item in &mut program.body {
         rename_apply_item(item, &map);
     }
-    true
+
+    // The rename table drives CV provenance (#89). Sort by original name
+    // so the emitted contributions are deterministic run to run.
+    let mut renames: Vec<(String, String)> =
+        map.into_iter().map(|(from, to)| (from, to)).collect();
+    renames.sort();
+    (true, renames)
 }
 
 /// Generates `a`, `b`, …, `z`, `aa`, `ab`, … skipping reserved words and
@@ -971,6 +1013,70 @@ mod tests {
 
     fn rename_source(src: &str) -> String {
         rename_source_with(src, &[])
+    }
+
+    /// Run the pass and return its CV contributions (the rename table).
+    fn rename_contributions(src: &str) -> Vec<Contribution> {
+        let es = EsVersion::Es2025;
+        let node = parse_javascript_typed(src, es).expect("parse");
+        let prog = bridge::grammar_to_program(&node, es).expect("bridge");
+        let pass = RenameGlobalsPass::with_no_externs();
+        let sidecar = Sidecar::new();
+        let mut cv = CVLog::new(true);
+        pass.run(PassContext {
+            program: &prog,
+            sidecar: &sidecar,
+            cv: &mut cv,
+        })
+        .expect("rename-globals")
+        .contributions
+    }
+
+    // ----- CV provenance (#89) -----
+
+    #[test]
+    fn emits_renamed_contribution_per_global() {
+        // `function longName(){} longName();` — `longName` (declared once,
+        // len>1, referenced) is renamed; the pass records a `renamed`
+        // contribution mapping the original name to its short form.
+        let contribs = rename_contributions("function longName(){} longName();");
+        let renamed: Vec<_> = contribs
+            .iter()
+            .filter(|c| c.source == "rename-globals" && c.tag == "renamed")
+            .collect();
+        assert_eq!(
+            renamed.len(),
+            1,
+            "expected exactly one renamed contribution; got {:?}",
+            contribs
+        );
+        let c = renamed[0];
+        assert_eq!(
+            c.meta.get("from").and_then(|v| v.as_str()),
+            Some("longName")
+        );
+        let to = c
+            .meta
+            .get("to")
+            .and_then(|v| v.as_str())
+            .expect("`to` present");
+        assert!(
+            to.len() < "longName".len(),
+            "renamed to a shorter name; got {:?}",
+            to
+        );
+    }
+
+    #[test]
+    fn no_contributions_when_nothing_renamed() {
+        // `x();` — `x` is a free global (used, not declared here), so
+        // there is nothing to rename and no contribution is emitted.
+        let contribs = rename_contributions("x();");
+        assert!(
+            contribs.is_empty(),
+            "expected no contributions; got {:?}",
+            contribs
+        );
     }
 
     // ----- metadata contract -----


### PR DESCRIPTION
## Why
Part of **full CV tracing** (#89). Renaming is a *transformation*, not a deletion — so unlike the DCE / fold-control-flow / treeshake passes (which tombstone what they remove), this pass needs to record the **rename table** so provenance isn't lost. Before, `run()` returned `contributions: Vec::new()` and never touched the CV log, so renaming silently erased the link between a minified global (`a`) and its original name (`longName`).

## What
`rename_globals` now returns its applied rename table (`(from, to)` pairs, sorted by original name for deterministic output) alongside the `changed` flag, and `run()` maps each pair to a `Contribution{source:"rename-globals", tag:"renamed", meta:{from, to}}`. The pipeline attaches these to the program-root CV entry (`cv.contribute(prog_cv, …)`), so a `--correlation_vector` consumer can map `a` back to `longName`.

No deep recursion threading needed — the rename map already exists in `rename_globals`; this just surfaces it.

## Safety
- **Byte-for-byte identical program output** — the renames applied are exactly as before; only the returned `contributions` list is now populated. All 16 existing output tests unchanged.
- Inline security review: **PASSED** (pure data transformation of owned strings into JSON-string metadata, no injection sink, no new panic path, no unsafe, bounded work, no new IO/supply-chain surface).

## Tests
`closure-pass-rename-globals` `0.6.0` → `0.7.0`. Two new tests: a renamed global emits one `renamed` contribution with the right `from`/shorter `to`; a program with nothing to rename emits none. 18 tests green. `correlation-vector` moved dev→regular dep; `serde_json` added.

## Scope / follow-up
This attaches the rename *table* at the program root. Per-output-span provenance (contributing to each renamed identifier's own CV id) needs the log threaded through the `rename_apply_*` recursion — a documented follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)