### PR TITLE
Add desired-state authorization preview

### DIFF
--- a/code/packages/rust/smart-home-platform-http/CHANGELOG.md
+++ b/code/packages/rust/smart-home-platform-http/CHANGELOG.md
@@ -14,6 +14,9 @@ All notable changes to this package will be documented in this file.
 - Added a read-only command-authorization preview route and browser dashboard
   Auth actions so local-controller users can inspect runtime grants before
   dispatching light commands.
+- Added a read-only desired-state authorization preview route and browser
+  dashboard Auth actions so target set/clear controls expose runtime grant
+  boundaries before mutating desired-state supervision targets.
 - Added browser dashboard action feedback that renders accepted command,
   scene, and desired-state mutation responses with command-result and
   desired-state readback links in the detail panel.

--- a/code/packages/rust/smart-home-platform-http/README.md
+++ b/code/packages/rust/smart-home-platform-http/README.md
@@ -51,6 +51,7 @@ stable local API responses for:
 - `/api/smart_home/capability_grants/:grant_id`
 - `/api/smart_home/authorization_decisions`
 - `/api/smart_home/command_authorization`
+- `/api/smart_home/desired_state_authorization`
 - `/api/smart_home/authorization_decisions/:decision_index`
 - `/api/smart_home/desired_states`
 - `POST /api/smart_home/desired_states/:entity_id`
@@ -88,7 +89,9 @@ projections, command-result audit records with
 command, bridge, correlation, room, status, and sort filters, indexed
 authorization decisions with principal, outcome, and sort filters, read-only
 command-authorization previews that evaluate the local API principal's tool and
-device-command grants without dispatching commands, capability grant
+device-command grants without dispatching commands, read-only desired-state
+authorization previews that evaluate set/clear tool grants without mutating
+targets, capability grant
 inventory/detail routes with principal, status, scope, capability, entity, and
 sort filters, and desired-state supervision targets.
 State-history reads expose registry-backed device events with Home Assistant
@@ -100,10 +103,10 @@ Runtime event-log reads accept Home Assistant entity aliases through
 state-expiration, and desired-state drift events.
 
 `GET /api/smart_home/smoke` exposes a machine-readable local-controller smoke
-plan with safe GET probes, a command-authorization preview, and a single
-runtime-authorized Home Assistant-style command probe. It lets scripts discover
-the dashboard/API/readiness checks and the exact request body to use for
-fixture-controller verification without scraping launch text.
+plan with safe GET probes, command and desired-state authorization previews,
+and a single runtime-authorized Home Assistant-style command probe. It lets
+scripts discover the dashboard/API/readiness checks and the exact request body
+to use for fixture-controller verification without scraping launch text.
 `GET /api/smart_home/smoke_script` renders that same plan as a copy-pasteable
 `sh` script using `curl`; set `SMART_HOME_BASE_URL` or `CURL` to override the
 defaults when the fixture controller runs on a custom address.
@@ -117,10 +120,11 @@ native API routes and sends light on/off, light brightness, scene, and
 desired-state set/clear actions through the existing Home
 Assistant-compatible and native service endpoints, preserving runtime
 authorization. Entity action cards expose command-authorization preview buttons
-for light on/off and brightness controls before dispatch. After command, scene,
-or desired-state mutations, the shell renders the accepted response in the
-detail panel with command-result, correlation, current-state, desired-state, or
-history readback links as applicable. Entity, service, scene, device, bridge,
+for light on/off and brightness controls before dispatch and desired-state
+authorization preview buttons before target set/clear actions. After command,
+scene, or desired-state mutations, the shell renders the accepted response in
+the detail panel with command-result, correlation, current-state, desired-state,
+or history readback links as applicable. Entity, service, scene, device, bridge,
 history, event-log, command-result, authorization, capability catalog, and
 capability-grant
 rows/cards expose read-only detail buttons that fetch the matching native detail
@@ -232,6 +236,8 @@ curl 'http://127.0.0.1:8123/api/smart_home/command_results?room_id=kitchen&limit
 curl 'http://127.0.0.1:8123/api/smart_home/command_results?bridge_id=bridge-1'
 curl 'http://127.0.0.1:8123/api/smart_home/command_results?sort=status_then_newest'
 curl 'http://127.0.0.1:8123/api/smart_home/command_authorization?entity_id=light.entity_light_1&command_type=turn_on'
+curl 'http://127.0.0.1:8123/api/smart_home/desired_state_authorization?entity_id=light.entity_light_1&operation=set'
+curl 'http://127.0.0.1:8123/api/smart_home/desired_state_authorization?entity_id=light.entity_light_1&operation=clear'
 curl 'http://127.0.0.1:8123/api/smart_home/capability_grants?principal_id=agent:home-assistant-local-api&status=active'
 curl 'http://127.0.0.1:8123/api/smart_home/capability_grants/grant:agent:home-assistant-local-api:local-api-full-access'
 curl 'http://127.0.0.1:8123/api/smart_home/authorization_decisions?principal_id=agent:home-assistant-local-api&sort=oldest_first'

--- a/code/packages/rust/smart-home-platform-http/src/lib.rs
+++ b/code/packages/rust/smart-home-platform-http/src/lib.rs
@@ -1076,6 +1076,8 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
       : "/api/smart_home/command_results?limit=8&sort=status_then_newest";
     const commandAuthorizationUrl = (entity, commandType) =>
       `/api/smart_home/command_authorization?entity_id=${encodeURIComponent(entityIdentity(entity))}&command_type=${encodeURIComponent(commandType)}`;
+    const desiredStateAuthorizationUrl = (entity, operation) =>
+      `/api/smart_home/desired_state_authorization?entity_id=${encodeURIComponent(entityIdentity(entity))}&operation=${encodeURIComponent(operation)}`;
     const sceneDetailUrl = (scene) =>
       `/api/smart_home/scenes/${encodeURIComponent(scene.home_assistant_scene_id || scene.scene_id)}`;
     const serviceDetailUrl = (service) => {
@@ -1331,7 +1333,7 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
               ${inspectButton(entityDesiredStateUrl(entity), "desired state", "Desired")}
               ${inspectButton(entityBridgeCommandsUrl(entity), "bridge command results", "Commands")}
               ${canToggle ? `${inspectButton(commandAuthorizationUrl(entity, "turn_on"), "turn on authorization", "Auth on")} ${inspectButton(commandAuthorizationUrl(entity, "turn_off"), "turn off authorization", "Auth off")} <button type="button" data-service="turn_on" data-entity="${entity.home_assistant_entity_id}">Turn on</button><button type="button" data-service="turn_off" data-entity="${entity.home_assistant_entity_id}">Turn off</button>` : ""}
-              ${canToggle ? `<button type="button" data-desired-action="on" data-entity="${entity.home_assistant_entity_id}">Target on</button><button type="button" data-desired-action="off" data-entity="${entity.home_assistant_entity_id}">Target off</button>` : ""}
+              ${canToggle ? `${inspectButton(desiredStateAuthorizationUrl(entity, "set"), "desired-state set authorization", "Auth target")} ${inspectButton(desiredStateAuthorizationUrl(entity, "clear"), "desired-state clear authorization", "Auth clear")} <button type="button" data-desired-action="on" data-entity="${entity.home_assistant_entity_id}">Target on</button><button type="button" data-desired-action="off" data-entity="${entity.home_assistant_entity_id}">Target off</button>` : ""}
             </div>
             ${canSetBrightness ? `
               <label class="range-control">
@@ -1391,7 +1393,7 @@ const DASHBOARD_HTML: &str = r##"<!doctype html>
           <td>${target.home_assistant_entity_id}<br><span class="muted">${target.entity_id}</span></td>
           <td>${deltasText(target.desired)}</td>
           <td>${target.requested_by}<br><span class="muted">${target.command_timeout_ms} ms</span></td>
-          <td><button type="button" data-clear-desired="${target.home_assistant_entity_id}">Clear</button></td>
+          <td>${inspectButton(desiredStateAuthorizationUrl(target, "clear"), "desired-state clear authorization", "Auth clear")} <button type="button" data-clear-desired="${target.home_assistant_entity_id}">Clear</button></td>
         </tr>
       `).join("") || `<tr><td colspan="4" class="muted">No desired-state targets</td></tr>`;
     };
@@ -2344,6 +2346,14 @@ pub fn home_assistant_runtime_web_app(runtime: SmartHomePlatformHttpRuntime) -> 
     {
         let runtime = runtime.clone();
         app.get(
+            "/api/smart_home/desired_state_authorization",
+            move |request| runtime_desired_state_authorization_response(&runtime, request),
+        );
+    }
+
+    {
+        let runtime = runtime.clone();
+        app.get(
             "/api/smart_home/authorization_decisions/:decision_index",
             move |request| runtime_authorization_decision_response(&runtime, request),
         );
@@ -3175,6 +3185,15 @@ const API_ROUTE_CATALOG: &[ApiRouteDescriptor] = &[
     },
     ApiRouteDescriptor {
         method: "GET",
+        path: "/api/smart_home/desired_state_authorization",
+        category: "authorization",
+        surface: "smart_home",
+        mutates_runtime: false,
+        runtime_authorized: false,
+        query_params: &["entity_id", "operation", "principal_id"],
+    },
+    ApiRouteDescriptor {
+        method: "GET",
         path: "/api/smart_home/authorization_decisions/:decision_index",
         category: "authorization",
         surface: "smart_home",
@@ -3881,6 +3900,46 @@ fn runtime_command_authorization_response(
     )
 }
 
+fn runtime_desired_state_authorization_response(
+    runtime: &SmartHomePlatformHttpRuntime,
+    request: &WebRequest,
+) -> WebResponse {
+    let Some(target) = query_string(request, "entity_id") else {
+        return api_error_response(ApiError::bad_request("missing entity_id"));
+    };
+    let operation = match query_string(request, "operation")
+        .map(desired_state_authorization_operation_from_label)
+        .transpose()
+    {
+        Ok(operation) => operation.unwrap_or(DesiredStateAuthorizationOperation::Set),
+        Err(error) => return api_error_response(error),
+    };
+    let principal_id = query_string(request, "principal_id")
+        .map(AgentId::trusted)
+        .unwrap_or_else(|| runtime.principal_id.clone());
+
+    let runtime_guard = runtime
+        .runtime
+        .lock()
+        .expect("smart-home runtime mutex should not be poisoned");
+    let entity = match runtime_entity(&runtime_guard, target) {
+        Ok(entity) => entity,
+        Err(error) => return api_error_response(error),
+    };
+    let grants = runtime_guard
+        .registry()
+        .capability_grants_for_principal(&principal_id);
+    let tool_decision = AuthorizationDecision::for_tool(
+        principal_id,
+        operation.tool(),
+        grants.iter().copied(),
+        runtime.now_ms,
+    );
+    WebResponse::json(
+        desired_state_authorization_preview_json(&entity, operation, &tool_decision).into_bytes(),
+    )
+}
+
 fn runtime_authorization_decision_response(
     runtime: &SmartHomePlatformHttpRuntime,
     request: &WebRequest,
@@ -4442,7 +4501,7 @@ fn runtime_bootstrap_json(
     let authorization_summary = runtime_guard.authorization_decision_summary(&authorization_query);
 
     format!(
-        "{{\"generated_at_ms\":{},\"version\":{},\"links\":{{\"readiness\":{},\"dashboard\":{},\"smoke\":{},\"smoke_script\":{},\"api\":{},\"states\":{},\"state_history\":{},\"command_results\":{},\"authorization_decisions\":{},\"command_authorization\":{},\"capability_grants\":{}}},\"health\":{},\"dashboard\":{},\"api\":{},\"state_gaps\":{},\"recent_activity\":{{\"events\":{{\"summary\":{}}},\"command_results\":{{\"summary\":{}}},\"authorization_decisions\":{{\"summary\":{}}}}}}}",
+        "{{\"generated_at_ms\":{},\"version\":{},\"links\":{{\"readiness\":{},\"dashboard\":{},\"smoke\":{},\"smoke_script\":{},\"api\":{},\"states\":{},\"state_history\":{},\"command_results\":{},\"authorization_decisions\":{},\"command_authorization\":{},\"desired_state_authorization\":{},\"capability_grants\":{}}},\"health\":{},\"dashboard\":{},\"api\":{},\"state_gaps\":{},\"recent_activity\":{{\"events\":{{\"summary\":{}}},\"command_results\":{{\"summary\":{}}},\"authorization_decisions\":{{\"summary\":{}}}}}}}",
         runtime.now_ms,
         json_string(VERSION),
         json_string("/api/smart_home/readiness"),
@@ -4455,6 +4514,7 @@ fn runtime_bootstrap_json(
         json_string("/api/smart_home/command_results"),
         json_string("/api/smart_home/authorization_decisions"),
         json_string("/api/smart_home/command_authorization"),
+        json_string("/api/smart_home/desired_state_authorization"),
         json_string("/api/smart_home/capability_grants"),
         runtime_health_json(runtime, runtime_guard),
         runtime_dashboard_json(runtime, runtime_guard),
@@ -4512,7 +4572,7 @@ fn runtime_smoke_json(
         .count();
 
     format!(
-        "{{\"generated_at_ms\":{},\"version\":{},\"status\":{},\"ready\":{},\"principal_id\":{},\"summary\":{{\"total_checks\":{},\"safe_get_checks\":{},\"mutating_checks\":{},\"runtime_authorized_checks\":{},\"blocking_readiness_checks\":{},\"attention_readiness_checks\":{}}},\"links\":{{\"self\":{},\"script\":{},\"dashboard\":{},\"readiness\":{},\"bootstrap\":{},\"api\":{},\"command_results\":{},\"authorization_decisions\":{},\"command_authorization\":{},\"capability_grants\":{}}},\"checks\":[{}]}}",
+        "{{\"generated_at_ms\":{},\"version\":{},\"status\":{},\"ready\":{},\"principal_id\":{},\"summary\":{{\"total_checks\":{},\"safe_get_checks\":{},\"mutating_checks\":{},\"runtime_authorized_checks\":{},\"blocking_readiness_checks\":{},\"attention_readiness_checks\":{}}},\"links\":{{\"self\":{},\"script\":{},\"dashboard\":{},\"readiness\":{},\"bootstrap\":{},\"api\":{},\"command_results\":{},\"authorization_decisions\":{},\"command_authorization\":{},\"desired_state_authorization\":{},\"capability_grants\":{}}},\"checks\":[{}]}}",
         runtime.now_ms,
         json_string(VERSION),
         json_string(status),
@@ -4533,6 +4593,7 @@ fn runtime_smoke_json(
         json_string("/api/smart_home/command_results"),
         json_string("/api/smart_home/authorization_decisions"),
         json_string("/api/smart_home/command_authorization"),
+        json_string("/api/smart_home/desired_state_authorization"),
         json_string("/api/smart_home/capability_grants"),
         checks
             .iter()
@@ -4711,6 +4772,7 @@ fn runtime_smoke_checks(
         ),
     ];
     checks.push(runtime_smoke_command_authorization_probe(&state));
+    checks.push(runtime_smoke_desired_state_authorization_probe(&state));
     checks.push(runtime_smoke_command_probe(&state));
     checks.extend([
         runtime_smoke_check(
@@ -4785,6 +4847,41 @@ fn runtime_smoke_command_authorization_probe(
         200,
         None,
         "Previews the local API principal's runtime grants for a light command without dispatching it.",
+    )
+}
+
+fn runtime_smoke_desired_state_authorization_probe(
+    state: &SmartHomePlatformHttpState,
+) -> RuntimeSmokeCheck {
+    let Some(target) = smoke_light_target(state) else {
+        return runtime_smoke_check(
+            "desired_state_authorization_preview",
+            "Desired-state authorization preview",
+            "GET",
+            "/api/smart_home/services?domain=light",
+            "authorization",
+            false,
+            false,
+            200,
+            None,
+            "No commandable light target is available; inspect the service catalog before previewing desired-state authorization.",
+        );
+    };
+
+    runtime_smoke_check(
+        "desired_state_authorization_preview",
+        "Desired-state authorization preview",
+        "GET",
+        format!(
+            "/api/smart_home/desired_state_authorization?entity_id={}&operation=set",
+            url_component(&target)
+        ),
+        "authorization",
+        false,
+        false,
+        200,
+        None,
+        "Previews the local API principal's runtime grants for desired-state set/clear tools without mutating targets.",
     )
 }
 
@@ -5175,6 +5272,43 @@ fn command_authorization_preview_json(
         json_id_array(matched_grants.iter().map(|grant_id| grant_id.as_str())),
         authorization_decision_json(tool_decision),
         authorization_decision_json(command_decision),
+    )
+}
+
+fn desired_state_authorization_preview_json(
+    entity: &Entity,
+    operation: DesiredStateAuthorizationOperation,
+    tool_decision: &AuthorizationDecision,
+) -> String {
+    let descriptor = operation.tool().descriptor();
+    format!(
+        "{{\"principal_id\":{},\"entity_id\":{},\"home_assistant_entity_id\":{},\"operation\":{},\"tool_id\":{},\"required_tier\":{},\"preview_only\":true,\"would_mutate_runtime\":true,\"authorized\":{},\"required_capabilities\":[{}],\"missing_capabilities\":[{}],\"matched_grants\":[{}],\"tool_decision\":{}}}",
+        json_string(tool_decision.principal_id.as_str()),
+        json_string(entity.entity_id.as_str()),
+        json_string(home_assistant_entity_id(entity)),
+        json_string(operation.label()),
+        json_string(descriptor.tool_id),
+        json_string(privilege_tier_label(tool_decision.required_tier)),
+        tool_decision.is_allowed(),
+        json_id_array(
+            tool_decision
+                .required_capabilities
+                .iter()
+                .map(|capability| capability.as_str())
+        ),
+        json_id_array(
+            tool_decision
+                .missing_capabilities
+                .iter()
+                .map(|capability| capability.as_str())
+        ),
+        json_id_array(
+            tool_decision
+                .matched_grants
+                .iter()
+                .map(|grant_id| grant_id.as_str())
+        ),
+        authorization_decision_json(tool_decision),
     )
 }
 
@@ -8091,6 +8225,40 @@ fn command_type_from_label(command_type: &str) -> Result<CommandType, ApiError> 
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DesiredStateAuthorizationOperation {
+    Set,
+    Clear,
+}
+
+impl DesiredStateAuthorizationOperation {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Set => "set",
+            Self::Clear => "clear",
+        }
+    }
+
+    fn tool(self) -> SmartHomeTool {
+        match self {
+            Self::Set => SmartHomeTool::SetDesiredState,
+            Self::Clear => SmartHomeTool::ClearDesiredState,
+        }
+    }
+}
+
+fn desired_state_authorization_operation_from_label(
+    operation: &str,
+) -> Result<DesiredStateAuthorizationOperation, ApiError> {
+    match operation {
+        "set" | "write" | "upsert" => Ok(DesiredStateAuthorizationOperation::Set),
+        "clear" | "delete" | "remove" => Ok(DesiredStateAuthorizationOperation::Clear),
+        other => Err(ApiError::bad_request(format!(
+            "unsupported desired-state authorization operation `{other}`"
+        ))),
+    }
+}
+
 fn capability_mode_label(mode: CapabilityMode) -> &'static str {
     match mode {
         CapabilityMode::Observe => "observe",
@@ -9355,6 +9523,75 @@ mod tests {
     }
 
     #[test]
+    fn runtime_web_app_previews_desired_state_authorization_without_mutation() {
+        let app = home_assistant_runtime_web_app(fixture_runtime(true));
+        let preview = response_body(
+            app.handle(request(
+                "GET",
+                "/api/smart_home/desired_state_authorization?entity_id=light.entity_light_1&operation=set",
+            ))
+            .into(),
+        );
+        assert!(preview.contains(r#""principal_id":"agent:home-assistant-local-api""#));
+        assert!(preview.contains(r#""entity_id":"entity-light-1""#));
+        assert!(preview.contains(r#""home_assistant_entity_id":"light.entity_light_1""#));
+        assert!(preview.contains(r#""operation":"set""#));
+        assert!(preview.contains(r#""tool_id":"smart_home.set_desired_state""#));
+        assert!(preview.contains(r#""required_tier":"low_risk""#));
+        assert!(preview.contains(r#""preview_only":true"#));
+        assert!(preview.contains(r#""would_mutate_runtime":true"#));
+        assert!(preview.contains(r#""authorized":true"#));
+        assert!(preview.contains(r#""required_capabilities":["smart_home.command.light"]"#));
+        assert!(preview.contains(r#""missing_capabilities":[]"#));
+        assert!(preview.contains(
+            r#""matched_grants":["grant:agent:home-assistant-local-api:local-api-full-access"]"#
+        ));
+        assert!(preview.contains(r#""tool_decision":{"outcome":"allowed""#));
+
+        let clear_preview = response_body(
+            app.handle(request(
+                "GET",
+                "/api/smart_home/desired_state_authorization?entity_id=light.entity_light_1&operation=clear",
+            ))
+            .into(),
+        );
+        assert!(clear_preview.contains(r#""operation":"clear""#));
+        assert!(clear_preview.contains(r#""tool_id":"smart_home.clear_desired_state""#));
+        assert!(clear_preview.contains(r#""authorized":true"#));
+
+        let desired_states = response_body(
+            app.handle(request(
+                "GET",
+                "/api/smart_home/desired_states?entity_id=light.entity_light_1",
+            ))
+            .into(),
+        );
+        assert!(desired_states.contains(r#""total_desired_states":0"#));
+
+        let denied_app = home_assistant_runtime_web_app(fixture_runtime(false));
+        let denied = response_body(
+            denied_app
+                .handle(request(
+                    "GET",
+                    "/api/smart_home/desired_state_authorization?entity_id=light.entity_light_1",
+                ))
+                .into(),
+        );
+        assert!(denied.contains(r#""operation":"set""#));
+        assert!(denied.contains(r#""authorized":false"#));
+        assert!(denied.contains(r#""missing_capabilities":["smart_home.command.light"]"#));
+        assert!(denied.contains(r#""tool_decision":{"outcome":"denied""#));
+
+        let invalid_operation: web_core::WebResponse = app
+            .handle(request(
+                "GET",
+                "/api/smart_home/desired_state_authorization?entity_id=light.entity_light_1&operation=blink",
+            ))
+            .into();
+        assert_eq!(invalid_operation.status, 400);
+    }
+
+    #[test]
     fn runtime_web_app_serves_dashboard_ready_capability_grants() {
         let app = home_assistant_runtime_web_app(fixture_runtime(true));
 
@@ -9530,6 +9767,9 @@ mod tests {
         assert!(bootstrap.contains(r#""states":"/api/smart_home/states""#));
         assert!(bootstrap
             .contains(r#""command_authorization":"/api/smart_home/command_authorization""#));
+        assert!(bootstrap.contains(
+            r#""desired_state_authorization":"/api/smart_home/desired_state_authorization""#
+        ));
         assert!(bootstrap.contains(r#""health":{"generated_at_ms":5000"#));
         assert!(bootstrap.contains(r#""dashboard":{"generated_at_ms":5000"#));
         assert!(bootstrap.contains(r#""api":{"version":"0.1.0""#));
@@ -9555,9 +9795,16 @@ mod tests {
         assert!(
             smoke.contains(r#""command_authorization":"/api/smart_home/command_authorization""#)
         );
+        assert!(smoke.contains(
+            r#""desired_state_authorization":"/api/smart_home/desired_state_authorization""#
+        ));
         assert!(smoke.contains(r#""check_id":"command_authorization_preview""#));
         assert!(smoke.contains(
             r#""path":"/api/smart_home/command_authorization?entity_id=light.entity_light_1&command_type=turn_on""#
+        ));
+        assert!(smoke.contains(r#""check_id":"desired_state_authorization_preview""#));
+        assert!(smoke.contains(
+            r#""path":"/api/smart_home/desired_state_authorization?entity_id=light.entity_light_1&operation=set""#
         ));
         assert!(smoke.contains(r#""check_id":"command_probe""#));
         assert!(smoke.contains(r#""path":"/api/services/light/turn_on""#));
@@ -9567,18 +9814,18 @@ mod tests {
 
         let smoke_json: JsonValue =
             serde_json::from_str(&smoke).expect("smoke plan response is JSON");
-        assert_eq!(smoke_json["summary"]["total_checks"], 11);
-        assert_eq!(smoke_json["summary"]["safe_get_checks"], 10);
+        assert_eq!(smoke_json["summary"]["total_checks"], 12);
+        assert_eq!(smoke_json["summary"]["safe_get_checks"], 11);
         assert_eq!(smoke_json["summary"]["mutating_checks"], 1);
         assert_eq!(smoke_json["summary"]["runtime_authorized_checks"], 1);
         assert_eq!(smoke_json["summary"]["blocking_readiness_checks"], 0);
         assert_eq!(smoke_json["summary"]["attention_readiness_checks"], 1);
         assert_eq!(
-            smoke_json["checks"][7]["request_body"]["entity_id"],
+            smoke_json["checks"][8]["request_body"]["entity_id"],
             "light.entity_light_1"
         );
         assert_eq!(
-            smoke_json["checks"][7]["request_body"]["brightness_pct"],
+            smoke_json["checks"][8]["request_body"]["brightness_pct"],
             75
         );
     }
@@ -9605,9 +9852,12 @@ mod tests {
             r#"run_check 'Command authorization preview' 'GET' '/api/smart_home/command_authorization?entity_id=light.entity_light_1&command_type=turn_on' '200'"#
         ));
         assert!(script.contains(
+            r#"run_check 'Desired-state authorization preview' 'GET' '/api/smart_home/desired_state_authorization?entity_id=light.entity_light_1&operation=set' '200'"#
+        ));
+        assert!(script.contains(
             r#"run_check 'Command probe' 'POST' '/api/services/light/turn_on' '200' '{"entity_id":"light.entity_light_1","brightness_pct":75}'"#
         ));
-        assert!(script.contains("All smart-home smoke checks passed (11 checks)"));
+        assert!(script.contains("All smart-home smoke checks passed (12 checks)"));
     }
 
     #[test]
@@ -9640,6 +9890,9 @@ mod tests {
         ));
         assert!(catalog.contains(
             r#""path":"/api/smart_home/command_authorization","category":"authorization","surface":"smart_home","mutates_runtime":false,"runtime_authorized":false,"query_params":["command_type","entity_id","principal_id"]"#
+        ));
+        assert!(catalog.contains(
+            r#""path":"/api/smart_home/desired_state_authorization","category":"authorization","surface":"smart_home","mutates_runtime":false,"runtime_authorized":false,"query_params":["entity_id","operation","principal_id"]"#
         ));
         assert!(catalog.contains(
             r#""path":"/api/smart_home/state_history","category":"state_history","surface":"smart_home","mutates_runtime":false,"runtime_authorized":false,"query_params":["bridge_id","entity_id","event_type","from_ms","limit","observed_at_or_after_ms","observed_at_or_before_ms","received_at_or_after_ms","received_at_or_before_ms","room_id","sort","to_ms"]"#
@@ -10675,9 +10928,15 @@ mod tests {
         assert!(body.contains("commandAuthorizationUrl(entity, \"turn_off\")"));
         assert!(body.contains("commandAuthorizationUrl(entity, \"set_brightness\")"));
         assert!(body.contains("/api/smart_home/command_authorization?entity_id="));
+        assert!(body.contains("desiredStateAuthorizationUrl(entity, \"set\")"));
+        assert!(body.contains("desiredStateAuthorizationUrl(entity, \"clear\")"));
+        assert!(body.contains("desiredStateAuthorizationUrl(target, \"clear\")"));
+        assert!(body.contains("/api/smart_home/desired_state_authorization?entity_id="));
         assert!(body.contains("Auth on"));
         assert!(body.contains("Auth off"));
         assert!(body.contains("Auth brightness"));
+        assert!(body.contains("Auth target"));
+        assert!(body.contains("Auth clear"));
         assert!(body.contains("commandable capabilities"));
         assert!(body.contains("serviceDetailUrl(service)"));
         assert!(body.contains("roomDetailUrl(room)"));
@@ -10716,7 +10975,7 @@ mod tests {
         assert!(
             body.contains(r#"run_check 'Startup bundle' 'GET' '/api/smart_home/bootstrap' '200'"#)
         );
-        assert!(body.contains("All smart-home smoke checks passed (11 checks)"));
+        assert!(body.contains("All smart-home smoke checks passed (12 checks)"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a read-only desired-state authorization preview route for set/clear tool grants
- surface the preview from bootstrap, smoke plan/script, API catalog, and dashboard Auth buttons
- document the endpoint and cover allowed/denied/no-mutation behavior in HTTP tests

## Validation
- cargo fmt -p smart-home-platform-http
- cargo test -p smart-home-platform-http -- --nocapture
- sh BUILD
- git diff --check