### PR TITLE
feat(rename-properties): correlation-vector rename provenance (#89)

### DIFF
--- a/code/packages/rust/closure-pass-rename-properties/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename-properties/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename-properties` crate will be documented in this file.
 
+## [0.9.0] - 2026-06-30
+
+### Added — correlation-vector rename provenance (#89)
+
+Mirrors the rename-globals pass. Renaming is a transformation, not a deletion,
+so this pass now records each property rename as a `renamed` **contribution**
+carrying `{from, to}`. Before, `run()` returned `contributions: Vec::new()` and
+never touched the CV log, so property renaming silently erased the link between
+a minified property (`o.a`) and its original name (`o.longProp`): a
+`--correlation_vector` consumer had no way to recover it.
+
+`rename_properties` now returns its applied rename table (`(from, to)` pairs,
+sorted by original name for deterministic output) alongside the `changed` flag,
+and `run` maps each pair to a `Contribution{source:"rename-properties",
+tag:"renamed", meta:{from, to}}`. The pipeline attaches these to the
+program-root CV entry, so the rename table becomes queryable provenance.
+
+- **Byte-for-byte identical program output** — the renames applied are exactly
+  as before; only the returned `contributions` list is now populated. All 24
+  existing output tests are unchanged.
+- Two new tests: a renamed property emits one `renamed` contribution with the
+  right `from`/shorter `to`; a program whose only property is a built-in
+  (`o.length`) emits none.
+- `correlation-vector` moved from dev- to regular dependency; `serde_json` added
+  (for `Contribution.meta`). Crate version 0.8.0 → 0.9.0.
+
+**Scope / follow-up.** This attaches the rename *table* at the program root.
+Per-output-span provenance — contributing to each renamed property occurrence's
+own CV id — needs the log threaded through the `rewrite_*` recursion and is a
+documented follow-up.
+
 ## [0.8.0] - 2026-06-20
 
 ### Added — CLOC23: property renaming recurses through `for`-`of`

--- a/code/packages/rust/closure-pass-rename-properties/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename-properties/Cargo.toml
@@ -1,16 +1,17 @@
 [package]
 name = "coding-adventures-closure-pass-rename-properties"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 description = "Aggressive property renaming pass for the Closure Compiler clone (ADVANCED-only). Consistently shortens program-private object property names that are never quoted/computed and not in the built-in or externs do-not-rename boundary."
 
 [dependencies]
 coding-adventures-closure-pass-pipeline = { path = "../closure-pass-pipeline" }
 coding-adventures-javascript-ast = { path = "../javascript-ast" }
+coding_adventures_correlation_vector = { path = "../correlation-vector" }
+serde_json = "1"
 
 [dev-dependencies]
 coding-adventures-javascript-tokens = { path = "../javascript-tokens" }
 coding-adventures-javascript-parser = { path = "../javascript-parser" }
 coding-adventures-closure-emitter = { path = "../closure-emitter" }
 coding-adventures-type-sidecar = { path = "../type-sidecar" }
-coding_adventures_correlation_vector = { path = "../correlation-vector" }

--- a/code/packages/rust/closure-pass-rename-properties/README.md
+++ b/code/packages/rust/closure-pass-rename-properties/README.md
@@ -95,11 +95,28 @@ the common browser surface safe even when the externs file doesn't list it,
 but `--externs` remains the authoritative boundary for vendor-/library-
 specific external properties, so the opt-in gate stays.
 
+## Rename provenance (correlation vector)
+
+Renaming is a transformation, not a deletion, so this pass records each
+property rename as a `renamed` **contribution** carrying `{from, to}`
+(rather than tombstoning, as the DCE / fold-control-flow / treeshake
+passes do for what they delete). The pipeline attaches these to the
+program-root CV entry, so a `--correlation_vector` consumer can map a
+minified property (`o.a`) back to its original source name
+(`o.longProp`) — the rename *table* as queryable provenance. Mirrors the
+rename-globals pass; program output is byte-for-byte unchanged.
+(Follow-up: per-output-span provenance — contributing to each renamed
+occurrence's own CV id — needs the log threaded through the `rewrite_*`
+recursion.)
+
 ## Dependency whitelist
 
 - `coding-adventures-closure-pass-pipeline` — `Pass` trait + types.
 - `coding-adventures-javascript-ast` — `Program` and the typed AST.
+- `coding_adventures_correlation_vector` — the `Contribution` type for
+  rename provenance.
+- `serde_json` — `Contribution.meta` JSON values.
 
 Dev-deps: `coding-adventures-javascript-tokens`,
 `coding-adventures-javascript-parser`, `coding-adventures-closure-emitter`,
-`coding-adventures-type-sidecar`, `coding_adventures_correlation_vector`.
+`coding-adventures-type-sidecar`.

--- a/code/packages/rust/closure-pass-rename-properties/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename-properties/src/lib.rs
@@ -79,7 +79,9 @@ use std::collections::{HashMap, HashSet};
 use coding_adventures_closure_pass_pipeline::{
     IterationPolicy, Pass, PassContext, PassError, PassOutput, PassStats,
 };
+use coding_adventures_correlation_vector::Contribution;
 use coding_adventures_javascript_ast::statement::TaggedStatement;
+use serde_json::json;
 use coding_adventures_javascript_ast::{
     AssignmentTarget, Declaration, Expression, ForInit, Program, ProgramItem, PropertyKey,
     Statement,
@@ -774,11 +776,35 @@ impl Pass for RenamePropertiesPass {
     fn run(&self, ctx: PassContext<'_>) -> Result<PassOutput, PassError> {
         let mut program = ctx.program.clone();
         let mut nodes_touched: u32 = 1;
-        let changed = rename_properties(&mut program, &self.do_not_rename, &mut nodes_touched);
+        let (changed, renames) =
+            rename_properties(&mut program, &self.do_not_rename, &mut nodes_touched);
+
+        // CV provenance (#89): record every property rename as a `renamed`
+        // contribution carrying `{from, to}`. The pipeline attaches these
+        // to the program-root CV entry, so a `--correlation_vector`
+        // consumer can map a minified property (`o.a`) back to its
+        // original name (`o.longProp`) — provenance that renaming would
+        // otherwise erase. Mirrors the rename-globals pass. (Per-node
+        // span attachment — contributing to each renamed property
+        // occurrence's own CV id — is a documented follow-up that needs
+        // the log threaded through the `rewrite_*` recursion.)
+        let contributions: Vec<Contribution> = renames
+            .into_iter()
+            .map(|(from, to)| Contribution {
+                source: "rename-properties".to_string(),
+                tag: "renamed".to_string(),
+                meta: [
+                    ("from".to_string(), json!(from)),
+                    ("to".to_string(), json!(to)),
+                ]
+                .into_iter()
+                .collect(),
+            })
+            .collect();
 
         Ok(PassOutput {
             program,
-            contributions: Vec::new(),
+            contributions,
             changed,
             diagnostics: Vec::new(),
             stats: PassStats { nodes_touched },
@@ -813,11 +839,17 @@ impl Classify {
     }
 }
 
+/// Renames qualifying dotted property names to fresh short names.
+///
+/// Returns `(changed, renames)` where `renames` is the applied rename
+/// table as `(from, to)` pairs sorted by original name (deterministic
+/// order for stable CV provenance). `renames` is empty exactly when
+/// `changed` is `false`.
 fn rename_properties(
     program: &mut Program,
     do_not_rename: &HashSet<String>,
     nodes_touched: &mut u32,
-) -> bool {
+) -> (bool, Vec<(String, String)>) {
     // 1. Classify every property occurrence as dotted (renameable shape)
     //    or quoted (off-limits).
     let mut cls = Classify::default();
@@ -860,14 +892,19 @@ fn rename_properties(
     }
 
     if map.is_empty() {
-        return false;
+        return (false, Vec::new());
     }
 
     // 3. Rewrite every dotted / unquoted-key occurrence of a renamed name.
     for item in &mut program.body {
         rewrite_item(item, &map);
     }
-    true
+
+    // The rename table drives CV provenance (#89). Sort by original name
+    // so the emitted contributions are deterministic run to run.
+    let mut renames: Vec<(String, String)> = map.into_iter().collect();
+    renames.sort();
+    (true, renames)
 }
 
 /// Collect **every property name that appears anywhere** in `program` —
@@ -1448,6 +1485,70 @@ mod tests {
 
     fn rename(src: &str) -> String {
         rename_with(src, &[])
+    }
+
+    /// Run the pass and return its CV contributions (the rename table).
+    fn rename_contributions(src: &str) -> Vec<Contribution> {
+        let es = EsVersion::Es2025;
+        let node = parse_javascript_typed(src, es).expect("parse");
+        let prog = bridge::grammar_to_program(&node, es).expect("bridge");
+        let pass = RenamePropertiesPass::new(HashSet::new());
+        let sidecar = Sidecar::new();
+        let mut cv = CVLog::new(true);
+        pass.run(PassContext {
+            program: &prog,
+            sidecar: &sidecar,
+            cv: &mut cv,
+        })
+        .expect("rename-properties")
+        .contributions
+    }
+
+    // ----- CV provenance (#89) -----
+
+    #[test]
+    fn emits_renamed_contribution_per_property() {
+        // `o.longProp;` — `longProp` is dotted, unquoted, not a built-in,
+        // len>1 → renamed; the pass records a `renamed` contribution
+        // mapping the original property name to its short form.
+        let contribs = rename_contributions("o.longProp;");
+        let renamed: Vec<_> = contribs
+            .iter()
+            .filter(|c| c.source == "rename-properties" && c.tag == "renamed")
+            .collect();
+        assert_eq!(
+            renamed.len(),
+            1,
+            "expected exactly one renamed contribution; got {:?}",
+            contribs
+        );
+        let c = renamed[0];
+        assert_eq!(
+            c.meta.get("from").and_then(|v| v.as_str()),
+            Some("longProp")
+        );
+        let to = c
+            .meta
+            .get("to")
+            .and_then(|v| v.as_str())
+            .expect("`to` present");
+        assert!(
+            to.len() < "longProp".len(),
+            "renamed to a shorter name; got {:?}",
+            to
+        );
+    }
+
+    #[test]
+    fn no_contributions_when_nothing_renamed() {
+        // `o.length;` — `length` is a built-in property, never renamed,
+        // so there is nothing to rename and no contribution is emitted.
+        let contribs = rename_contributions("o.length;");
+        assert!(
+            contribs.is_empty(),
+            "expected no contributions; got {:?}",
+            contribs
+        );
     }
 
     // ----- metadata -----


### PR DESCRIPTION
## Why
Part of **full CV tracing** (#89), mirroring the merged [#7182](https://github.com/adhithyan15/coding-adventures/pull/7182) (rename-globals). Renaming is a *transformation*, not a deletion — so this pass records the **rename table** so provenance isn't lost. Before, `run()` returned `contributions: Vec::new()` and never touched the CV log, so property renaming silently erased the link between a minified property (`o.a`) and its original name (`o.longProp`).

## What
`rename_properties` now returns its applied rename table (`(from, to)` pairs, sorted by original name for deterministic output) alongside the `changed` flag, and `run()` maps each pair to a `Contribution{source:"rename-properties", tag:"renamed", meta:{from, to}}`. The pipeline attaches these to the program-root CV entry, so a `--correlation_vector` consumer can map `o.a` back to `o.longProp`.

## Safety
- **Byte-for-byte identical program output** — the renames applied are exactly as before; only the returned `contributions` list is now populated. All 24 existing output tests unchanged.
- Inline security review: **PASSED** (pure data transformation of owned strings into JSON-string metadata, no injection sink, no new panic path, no unsafe, bounded work, no new IO/supply-chain surface). Structurally identical to the approved rename-globals change.

## Tests
`closure-pass-rename-properties` `0.8.0` → `0.9.0`. Two new tests: a renamed property emits one `renamed` contribution with the right `from`/shorter `to`; a built-in property (`o.length`) emits none. 26 tests green. `correlation-vector` moved dev→regular dep; `serde_json` added.

## Scope / follow-up
Attaches the rename *table* at the program root; per-output-span provenance (each renamed occurrence's own CV id) needs the log threaded through the `rewrite_*` recursion — a documented follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)