### PR TITLE
feat(ruby-to-semantic-ir): keyword parameter & argument production (KW7 — Ruby-1.0 unblock)

### DIFF
--- a/code/grammars/ruby.grammar
+++ b/code/grammars/ruby.grammar
@@ -277,7 +277,39 @@ params       = "..." | param { COMMA param } ;
 # default subtree in the param scope.  Splat (`*rest`) and double-splat
 # (`**kwrest`) params never carry a default; the grammar is permissive
 # here and the lowerer attaches `Param.default` only to ordinary params.
-param        = [ "*" | "**" ] NAME [ EQUALS expression ] ;
+#
+# Phase KW7 (Ruby 1.0 unblock) — keyword parameters `name:` / `name: expr`.
+#
+# A `param` may instead carry a trailing `COLON [ expression ]` making it a
+# KEYWORD parameter (matched by name at the call site, not by position):
+#   `def f(a:)`     → required keyword (no default)
+#   `def f(a: 1)`   → optional keyword (default `1`)
+# The trailing suffix is a THREE-WAY choice keyed on the token right after
+# NAME:
+#   COLON   → keyword param   (KW7 — this branch)
+#   EQUALS  → positional optional/default param (P7)
+#   nothing → positional required param
+# The COLON is the sole discriminator between a keyword param and a
+# positional-default param — `a:` vs `a = 1` are DIFFERENT constructs
+# (`a:` is bound by name, `a = 1` by position), so keeping the two suffix
+# branches disjoint on their opening token (COLON vs EQUALS) is what keeps
+# lowering unambiguous.
+#
+# Disambiguation from hash/symbol syntax (`NAME COLON` also opens a
+# `hash_entry` `k: v` and a `hash_pattern_pair` `k:`): those rules are only
+# reachable inside a `{ … }` hash literal or a `case/in` pattern, never
+# inside a parenthesised parameter list.  A `param` is reached ONLY from
+# `params`, which is reached ONLY from the `def`/lambda `LPAREN … RPAREN`
+# frame — so the `NAME COLON` here can never collide with a hash-entry
+# parse.  The optional trailing `expression` after COLON is what separates
+# required (`a:`) from optional (`a: 1`); a bare `NAME COLON` at the end of
+# the list (next token `,` / `)`) cleanly matches the no-expression form
+# (same optional-tail shape as `hash_pattern_pair`).
+#
+# The suffix alternation lists the COLON branch BEFORE the EQUALS branch;
+# the two are disjoint on their first token so order is not load-bearing,
+# but keeping keyword-first mirrors the call-side `call_arg` ordering below.
+param        = [ "*" | "**" ] NAME [ COLON [ expression ] | EQUALS expression ] ;
 if_statement = "if" expression { !"else" !"elsif" !"end" statement } { elsif_clause } [ else_clause ] "end" ;
 elsif_clause = "elsif" expression { !"else" !"elsif" !"end" statement } ;
 else_clause  = "else" { !"end" statement } ;
@@ -474,7 +506,32 @@ scope_resolution = "::" ( NAME | KEYWORD ) ;
 # dead — the NAME branch shadows it — and listing it first would break
 # `m(...5)` since the parser does not backtrack across the call_arg
 # boundary once `...` is consumed.)
-call_arg     = [ "*" | "**" | "&" ] expression ;
+# Phase KW7 (Ruby 1.0 unblock) — keyword argument `name: expr`.
+#
+# `f(a: 1)` passes `1` to the callee's keyword parameter `a` BY NAME.  A
+# new leading alternative `NAME COLON expression` captures it and lowers to
+# an `Expr::KeywordArg { name, value }` — NOT a trailing hash literal.
+#
+# Why the keyword branch must be listed FIRST: without it, `f(a: 1)` would
+# funnel `a` into the `expression` branch, which parses `a` as a bare
+# `factor` and then STOPS (the trailing `{ dot_call | scope_resolution }`
+# postfix accepts only `.`/`::`, not `:`), leaving `: 1` unconsumed and the
+# RPAREN match failing.  (Real Ruby treats `f(a: 1)` as sugar for a trailing
+# keyword — equivalently a trailing implicit hash — but SIR models it as a
+# first-class `KeywordArg`, so we produce the keyword node directly rather
+# than a `hash_literal`.)  Listing `NAME COLON expression` before the
+# `[ "*" | "**" | "&" ] expression` branch makes the keyword form win
+# whenever a bare `NAME` is immediately followed by a COLON; every other
+# argument shape (a positional whose expression merely *starts* with a NAME
+# that is NOT followed by a colon, a splat, a block-pass) falls through to
+# the second branch unchanged.
+#
+# Disjointness: the two branches share a `NAME` opener, but the SECOND token
+# decides — COLON selects the keyword branch, anything else backtracks into
+# the positional `expression` branch.  A hash-literal argument written with
+# braces (`f({ a: 1 })`) still parses via the `expression` branch (its first
+# token is `{`, not a bare `NAME`), so explicit-hash args are unaffected.
+call_arg     = NAME COLON expression | [ "*" | "**" | "&" ] expression ;
 # Phase 6h — paren-less method call.  Idiomatic Ruby allows
 # `puts 1, 2` (no parens) when the call has at least one argument.
 #

--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.82.0] - 2026-06-30
+
+### Added (KW7 — keyword parameters & arguments, the Ruby-1.0 unblock)
+
+- The `param` rule now accepts a KEYWORD parameter:
+  `param = [ "*" | "**" ] NAME [ COLON [ expression ] | EQUALS expression ] ;`.
+  This makes `def f(a:)` (required keyword) and `def f(a: 1)` (optional
+  keyword) parse — core Ruby 2.0+ syntax that previously parse-panicked
+  because `param` had no colon branch. The suffix is a three-way choice keyed
+  on the token after `NAME`: `COLON` → keyword param, `EQUALS` → positional
+  optional/default (P7), nothing → positional required. The two suffix
+  branches are disjoint on their opening token, so lowering is unambiguous.
+- The `call_arg` rule now accepts a KEYWORD argument:
+  `call_arg = NAME COLON expression | [ "*" | "**" | "&" ] expression ;`.
+  This makes `f(a: 1)` and `f(1, y: 2)` parse a keyword argument. The
+  `NAME COLON expression` branch is listed FIRST so a bare `NAME` immediately
+  followed by a colon is captured as a keyword; every other argument shape
+  (positional, splat, block-pass, or an explicit brace hash `f({ a: 1 })`)
+  falls through to the second branch unchanged.
+- **Grammar disambiguation.** `NAME COLON` also opens a `hash_entry` (`k: v`)
+  and a `hash_pattern_pair` (`k:`), but those rules are only reachable inside
+  a `{ … }` hash literal or a `case/in` pattern — never inside a
+  parenthesised parameter list or a call-argument position. So the new
+  keyword `NAME COLON` forms never collide with hash-entry parsing.
+- Updated both `code/grammars/ruby.grammar` and the embedded `src/_grammar.rs`
+  (regenerated via `grammar-tools generate-rust-compiled-grammars ruby-parser`).
+- Five regression tests added (279 total, up from 274) pinning the parse-tree
+  shape of required/optional/mixed keyword params and keyword call args.
+- Cargo crate version bumped `0.3.0` → `0.4.0`.
+
 ## [0.81.0] - 2026-06-30
 
 ### Fixed (bare-identifier block bodies swallowed their `end`)

--- a/code/packages/rust/ruby-parser/Cargo.toml
+++ b/code/packages/rust/ruby-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-ruby-parser"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "Ruby parser — parses Ruby source code into an AST using the grammar-driven parser and the ruby.grammar file"
 

--- a/code/packages/rust/ruby-parser/src/_grammar.rs
+++ b/code/packages/rust/ruby-parser/src/_grammar.rs
@@ -393,12 +393,18 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::Literal { value: r#"**"#.to_string() },
                     ] }) },
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
-                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
-                        GrammarElement::TokenReference { name: r#"EQUALS"#.to_string() },
-                        GrammarElement::RuleReference { name: r#"expression"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Alternation { choices: vec![
+                        GrammarElement::Sequence { elements: vec![
+                            GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
+                            GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"expression"#.to_string() }) },
+                        ] },
+                        GrammarElement::Sequence { elements: vec![
+                            GrammarElement::TokenReference { name: r#"EQUALS"#.to_string() },
+                            GrammarElement::RuleReference { name: r#"expression"#.to_string() },
+                        ] },
                     ] }) },
             ] },
-            line_number: 280,
+            line_number: 312,
         },
         GrammarRule {
             name: r#"if_statement"#.to_string(),
@@ -415,7 +421,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"else_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 281,
+            line_number: 313,
         },
         GrammarRule {
             name: r#"elsif_clause"#.to_string(),
@@ -429,7 +435,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 282,
+            line_number: 314,
         },
         GrammarRule {
             name: r#"else_clause"#.to_string(),
@@ -440,7 +446,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 283,
+            line_number: 315,
         },
         GrammarRule {
             name: r#"unless_statement"#.to_string(),
@@ -455,7 +461,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"else_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 284,
+            line_number: 316,
         },
         GrammarRule {
             name: r#"while_statement"#.to_string(),
@@ -468,7 +474,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 285,
+            line_number: 317,
         },
         GrammarRule {
             name: r#"until_statement"#.to_string(),
@@ -481,7 +487,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 286,
+            line_number: 318,
         },
         GrammarRule {
             name: r#"case_statement"#.to_string(),
@@ -495,7 +501,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"else_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 309,
+            line_number: 341,
         },
         GrammarRule {
             name: r#"when_clause"#.to_string(),
@@ -514,7 +520,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 310,
+            line_number: 342,
         },
         GrammarRule {
             name: r#"in_clause"#.to_string(),
@@ -529,7 +535,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 332,
+            line_number: 364,
         },
         GrammarRule {
             name: r#"pattern"#.to_string(),
@@ -541,7 +547,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"literal_pattern"#.to_string() },
                 GrammarElement::RuleReference { name: r#"binding_pattern"#.to_string() },
             ] },
-            line_number: 333,
+            line_number: 365,
         },
         GrammarRule {
             name: r#"literal_pattern"#.to_string(),
@@ -551,12 +557,12 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"symbol_literal"#.to_string() },
                 GrammarElement::TokenReference { name: r#"KEYWORD"#.to_string() },
             ] },
-            line_number: 334,
+            line_number: 366,
         },
         GrammarRule {
             name: r#"binding_pattern"#.to_string(),
             body: GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
-            line_number: 335,
+            line_number: 367,
         },
         GrammarRule {
             name: r#"array_pattern"#.to_string(),
@@ -577,7 +583,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
             ] },
-            line_number: 336,
+            line_number: 368,
         },
         GrammarRule {
             name: r#"hash_pattern"#.to_string(),
@@ -592,7 +598,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 337,
+            line_number: 369,
         },
         GrammarRule {
             name: r#"hash_pattern_pair"#.to_string(),
@@ -601,7 +607,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"pattern"#.to_string() }) },
             ] },
-            line_number: 338,
+            line_number: 370,
         },
         GrammarRule {
             name: r#"splat_pattern"#.to_string(),
@@ -609,7 +615,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"*"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::TokenReference { name: r#"NAME"#.to_string() }) },
             ] },
-            line_number: 345,
+            line_number: 377,
         },
         GrammarRule {
             name: r#"pin_pattern"#.to_string(),
@@ -617,7 +623,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"^"#.to_string() },
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
             ] },
-            line_number: 350,
+            line_number: 382,
         },
         GrammarRule {
             name: r#"class_pattern"#.to_string(),
@@ -633,7 +639,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
             ] },
-            line_number: 356,
+            line_number: 388,
         },
         GrammarRule {
             name: r#"begin_statement"#.to_string(),
@@ -649,7 +655,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"ensure_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 377,
+            line_number: 409,
         },
         GrammarRule {
             name: r#"rescue_clause"#.to_string(),
@@ -667,7 +673,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 386,
+            line_number: 418,
         },
         GrammarRule {
             name: r#"exception_list"#.to_string(),
@@ -678,7 +684,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
                     ] }) },
             ] },
-            line_number: 387,
+            line_number: 419,
         },
         GrammarRule {
             name: r#"ensure_clause"#.to_string(),
@@ -689,7 +695,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 388,
+            line_number: 420,
         },
         GrammarRule {
             name: r#"assignment"#.to_string(),
@@ -713,7 +719,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"expression"#.to_string() },
             ] },
-            line_number: 408,
+            line_number: 440,
         },
         GrammarRule {
             name: r#"rightward_assignment"#.to_string(),
@@ -722,7 +728,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"=>"#.to_string() },
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
             ] },
-            line_number: 427,
+            line_number: 459,
         },
         GrammarRule {
             name: r#"method_call"#.to_string(),
@@ -742,7 +748,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"dot_call"#.to_string() }) },
             ] },
-            line_number: 438,
+            line_number: 470,
         },
         GrammarRule {
             name: r#"dot_call"#.to_string(),
@@ -765,7 +771,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"block"#.to_string() }) },
             ] },
-            line_number: 439,
+            line_number: 471,
         },
         GrammarRule {
             name: r#"scope_resolution"#.to_string(),
@@ -776,19 +782,26 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"KEYWORD"#.to_string() },
                     ] }) },
             ] },
-            line_number: 447,
+            line_number: 479,
         },
         GrammarRule {
             name: r#"call_arg"#.to_string(),
-            body: GrammarElement::Sequence { elements: vec![
-                GrammarElement::Optional { element: Box::new(GrammarElement::Alternation { choices: vec![
-                        GrammarElement::Literal { value: r#"*"#.to_string() },
-                        GrammarElement::Literal { value: r#"**"#.to_string() },
-                        GrammarElement::Literal { value: r#"&"#.to_string() },
-                    ] }) },
-                GrammarElement::RuleReference { name: r#"expression"#.to_string() },
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                    GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
+                    GrammarElement::RuleReference { name: r#"expression"#.to_string() },
+                ] },
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::Optional { element: Box::new(GrammarElement::Alternation { choices: vec![
+                            GrammarElement::Literal { value: r#"*"#.to_string() },
+                            GrammarElement::Literal { value: r#"**"#.to_string() },
+                            GrammarElement::Literal { value: r#"&"#.to_string() },
+                        ] }) },
+                    GrammarElement::RuleReference { name: r#"expression"#.to_string() },
+                ] },
             ] },
-            line_number: 477,
+            line_number: 534,
         },
         GrammarRule {
             name: r#"method_call_no_paren"#.to_string(),
@@ -803,17 +816,17 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                     ] }) },
             ] },
-            line_number: 491,
+            line_number: 548,
         },
         GrammarRule {
             name: r#"expression_stmt"#.to_string(),
             body: GrammarElement::RuleReference { name: r#"expression"#.to_string() },
-            line_number: 492,
+            line_number: 549,
         },
         GrammarRule {
             name: r#"expression"#.to_string(),
             body: GrammarElement::RuleReference { name: r#"ternary"#.to_string() },
-            line_number: 599,
+            line_number: 656,
         },
         GrammarRule {
             name: r#"ternary"#.to_string(),
@@ -826,7 +839,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                     ] }) },
             ] },
-            line_number: 600,
+            line_number: 657,
         },
         GrammarRule {
             name: r#"range"#.to_string(),
@@ -849,7 +862,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) },
                 ] },
             ] },
-            line_number: 601,
+            line_number: 658,
         },
         GrammarRule {
             name: r#"logical_or"#.to_string(),
@@ -863,7 +876,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_and"#.to_string() },
                     ] }) },
             ] },
-            line_number: 602,
+            line_number: 659,
         },
         GrammarRule {
             name: r#"logical_and"#.to_string(),
@@ -877,7 +890,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_not"#.to_string() },
                     ] }) },
             ] },
-            line_number: 603,
+            line_number: 660,
         },
         GrammarRule {
             name: r#"logical_not"#.to_string(),
@@ -888,7 +901,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) }) },
                 GrammarElement::RuleReference { name: r#"comparison"#.to_string() },
             ] },
-            line_number: 610,
+            line_number: 667,
         },
         GrammarRule {
             name: r#"comparison"#.to_string(),
@@ -906,7 +919,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"sum"#.to_string() },
                     ] }) },
             ] },
-            line_number: 611,
+            line_number: 668,
         },
         GrammarRule {
             name: r#"sum"#.to_string(),
@@ -920,7 +933,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"term"#.to_string() },
                     ] }) },
             ] },
-            line_number: 612,
+            line_number: 669,
         },
         GrammarRule {
             name: r#"term"#.to_string(),
@@ -934,7 +947,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"factor"#.to_string() },
                     ] }) },
             ] },
-            line_number: 613,
+            line_number: 670,
         },
         GrammarRule {
             name: r#"factor"#.to_string(),
@@ -973,7 +986,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"scope_resolution"#.to_string() },
                     ] }) },
             ] },
-            line_number: 649,
+            line_number: 706,
         },
         GrammarRule {
             name: r#"lambda_literal"#.to_string(),
@@ -986,7 +999,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"block"#.to_string() },
             ] },
-            line_number: 668,
+            line_number: 725,
         },
         GrammarRule {
             name: r#"unary_minus"#.to_string(),
@@ -994,7 +1007,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"MINUS"#.to_string() },
                 GrammarElement::RuleReference { name: r#"factor"#.to_string() },
             ] },
-            line_number: 669,
+            line_number: 726,
         },
         GrammarRule {
             name: r#"defined_expression"#.to_string(),
@@ -1002,7 +1015,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"defined?"#.to_string() },
                 GrammarElement::RuleReference { name: r#"factor"#.to_string() },
             ] },
-            line_number: 680,
+            line_number: 737,
         },
         GrammarRule {
             name: r#"symbol_literal"#.to_string(),
@@ -1014,7 +1027,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
                     ] }) },
             ] },
-            line_number: 687,
+            line_number: 744,
         },
         GrammarRule {
             name: r#"array_literal"#.to_string(),
@@ -1029,7 +1042,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
             ] },
-            line_number: 688,
+            line_number: 745,
         },
         GrammarRule {
             name: r#"hash_literal"#.to_string(),
@@ -1044,7 +1057,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 689,
+            line_number: 746,
         },
         GrammarRule {
             name: r#"hash_entry"#.to_string(),
@@ -1064,7 +1077,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                 ] },
             ] },
-            line_number: 690,
+            line_number: 747,
         },
     ],
         version: 1,

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -4710,5 +4710,160 @@ mod tests {
             .collect();
         assert_eq!(ops, vec!["<<=".to_string(), ">>=".to_string()]);
     }
+
+    // -----------------------------------------------------------------------
+    // Phase KW7 (Ruby 1.0 unblock) — keyword parameters & arguments.
+    //
+    // Grammar additions:
+    //   param    = [ "*" | "**" ] NAME [ COLON [ expression ] | EQUALS expression ] ;
+    //   call_arg = NAME COLON expression | [ "*" | "**" | "&" ] expression ;
+    //
+    // These tests pin the PARSE-tree shape: a keyword param carries a COLON
+    // token child (and, for the optional form, a trailing `expression`); a
+    // keyword call arg is a `call_arg` node with a NAME token + COLON token +
+    // `expression` child.
+    // -----------------------------------------------------------------------
+
+    /// Collect the `param` subnodes of the first `def_statement`'s `params`.
+    fn def_param_nodes(ast: &GrammarASTNode) -> Vec<&GrammarASTNode> {
+        let def = find_def_statement(ast).expect("expected def_statement");
+        let params = def
+            .children
+            .iter()
+            .find_map(|c| match c {
+                ASTNodeOrToken::Node(n) if n.rule_name == "params" => Some(n),
+                _ => None,
+            })
+            .expect("expected params subnode");
+        params
+            .children
+            .iter()
+            .filter_map(|c| match c {
+                ASTNodeOrToken::Node(n) if n.rule_name == "param" => Some(n),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Does this `param` node carry a single-colon token (⇒ keyword param)?
+    fn param_has_colon(param: &GrammarASTNode) -> bool {
+        param.children.iter().any(|c| matches!(
+            c,
+            ASTNodeOrToken::Token(t)
+                if matches!(t.type_, lexer::token::TokenType::Colon) && t.value == ":"
+        ))
+    }
+
+    /// Does this `param` node carry a trailing `expression` (⇒ has a default)?
+    fn param_has_expression(param: &GrammarASTNode) -> bool {
+        param
+            .children
+            .iter()
+            .any(|c| matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "expression"))
+    }
+
+    #[test]
+    fn test_parse_required_keyword_param() {
+        // `def f(a:)` — a required keyword param: COLON present, no default.
+        let ast = parse_ruby("def f(a:)\nend");
+        let params = def_param_nodes(&ast);
+        assert_eq!(params.len(), 1);
+        assert!(param_has_colon(params[0]), "keyword param must carry a colon");
+        assert!(
+            !param_has_expression(params[0]),
+            "required keyword param must have NO default expression"
+        );
+    }
+
+    #[test]
+    fn test_parse_optional_keyword_param() {
+        // `def f(a: 1)` — an optional keyword param: COLON + default expr.
+        let ast = parse_ruby("def f(a: 1)\nend");
+        let params = def_param_nodes(&ast);
+        assert_eq!(params.len(), 1);
+        assert!(param_has_colon(params[0]), "keyword param must carry a colon");
+        assert!(
+            param_has_expression(params[0]),
+            "optional keyword param must carry a default expression"
+        );
+    }
+
+    #[test]
+    fn test_parse_mixed_positional_and_keyword_params() {
+        // `def f(a, b:, c: 2)` — one positional required, one required
+        // keyword, one optional keyword.  Pins the per-param shape.
+        let ast = parse_ruby("def f(a, b:, c: 2)\nend");
+        let params = def_param_nodes(&ast);
+        assert_eq!(params.len(), 3, "expected three params");
+        // a — positional: no colon, no default.
+        assert!(!param_has_colon(params[0]));
+        assert!(!param_has_expression(params[0]));
+        // b — required keyword: colon, no default.
+        assert!(param_has_colon(params[1]));
+        assert!(!param_has_expression(params[1]));
+        // c — optional keyword: colon + default.
+        assert!(param_has_colon(params[2]));
+        assert!(param_has_expression(params[2]));
+    }
+
+    #[test]
+    fn test_parse_keyword_call_arg() {
+        // `f(x: 1)` — a keyword call arg.  The `call_arg` node must carry a
+        // NAME token, a COLON token, and an `expression` child.
+        let ast = parse_ruby("f(x: 1)");
+        let call_arg = find_descendant(&ast, "call_arg").expect("expected call_arg");
+        let name = call_arg.children.iter().find_map(|c| match c {
+            ASTNodeOrToken::Token(t)
+                if matches!(t.type_, lexer::token::TokenType::Name) =>
+            {
+                Some(t.value.clone())
+            }
+            _ => None,
+        });
+        assert_eq!(name.as_deref(), Some("x"), "keyword arg name must be `x`");
+        assert!(
+            call_arg.children.iter().any(|c| matches!(
+                c,
+                ASTNodeOrToken::Token(t)
+                    if matches!(t.type_, lexer::token::TokenType::Colon) && t.value == ":"
+            )),
+            "keyword call arg must carry a colon token"
+        );
+        assert!(
+            call_arg
+                .children
+                .iter()
+                .any(|c| matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "expression")),
+            "keyword call arg must carry a value expression"
+        );
+    }
+
+    #[test]
+    fn test_parse_positional_then_keyword_call_args() {
+        // `f(1, y: 2)` — a positional arg followed by a keyword arg.  Two
+        // `call_arg` nodes: the first has NO colon (positional), the second
+        // has a colon (keyword).
+        let ast = parse_ruby("f(1, y: 2)");
+        let method_call =
+            find_descendant(&ast, "method_call").expect("expected method_call");
+        let call_args: Vec<&GrammarASTNode> = method_call
+            .children
+            .iter()
+            .filter_map(|c| match c {
+                ASTNodeOrToken::Node(n) if n.rule_name == "call_arg" => Some(n),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(call_args.len(), 2, "expected two call_args");
+        let colon = |ca: &GrammarASTNode| {
+            ca.children.iter().any(|c| matches!(
+                c,
+                ASTNodeOrToken::Token(t)
+                    if matches!(t.type_, lexer::token::TokenType::Colon) && t.value == ":"
+            ))
+        };
+        assert!(!colon(call_args[0]), "first arg is positional (no colon)");
+        assert!(colon(call_args[1]), "second arg is a keyword (colon)");
+    }
 }
 

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,15 +2,65 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
-## Unreleased
+## [0.100.0] - 2026-06-30
+
+### Added (KW7 — keyword parameter & argument production, the Ruby-1.0 unblock)
+
+The frontend now PRODUCES keyword parameters and keyword arguments — the
+single most-requested modern-Ruby gap. `def f(a:)` / `def f(a: 1)` and
+`f(a: 1)` previously could not even parse, let alone lower.
+
+- **Def side (`extract_params`).** A `param` whose grammar suffix is a COLON
+  (`a:` / `a: expr`) now lowers to `Param { kind: ParamKind::Keyword, .. }`.
+  Required-vs-optional rides on the existing `default` field exactly as
+  positional optionals do: a keyword param with a trailing `expression` (the
+  `a: 1` form) gets `default: Some(_)` (OPTIONAL keyword); one without (`a:`)
+  gets `default: None` (REQUIRED keyword). The COLON token is the sole
+  discriminator between a keyword param and a positional-default (`a = 1`)
+  param.
+- **Call side (`lower_call_arg`).** A `call_arg` node carrying a COLON
+  (`f(a: 1)`) now lowers to the first-class `Expr::KeywordArg { name, value }`
+  — NOT a trailing hash literal. Positional args stay bare and precede the
+  keyword (`g(1, y: 2)` → `args: [IntLit(1), KeywordArg{name:"y", ..}]`),
+  matching the core's "keywords trail positionals" contract that the SIR
+  validator enforces.
+- **Feature manifest.** Any keyword param OR keyword arg now observes
+  `Feature::KeywordParams`, and the manifest materialiser emits it (mirrors
+  how a positional default observes `DefaultParams`), so the SIR validator
+  accepts the used feature.
+- **Validator round-trip.** A required keyword omitted at a call site is
+  rejected by `semantic_ir::validate`; supplying it (or omitting an optional
+  keyword) validates. The frontend produces the required-ness; the core
+  enforces it.
 
 ### Changed
 
-- Compile-compat stub arms for the new core `semantic-ir` variant
-  `Expr::KeywordArg` (KW1). Every affected pass — the swap-safety reference
-  check, the `yield`-rewrite and call-normalization `&mut` visitors, and the
-  bound-name collector — recurses faithfully into the keyword arg's inner
-  `value`. Real keyword-argument lowering is pending KW2–KW8.
+- Compile-compat stub arms for the core `Expr::KeywordArg` variant (KW1) are
+  now backed by real production: the swap-safety reference check, the
+  `yield`-rewrite and call-normalization `&mut` visitors, and the bound-name
+  collector already recurse into the keyword arg's inner `value`.
+
+### Tests
+
+- Eleven new unit tests: `def f(a:)` → `Param{kind:Keyword, default:None}`;
+  `def f(a: 1)` → `default:Some(IntLit 1)`; a mixed
+  positional+required-keyword+optional-keyword signature lowers in declared
+  order; `f(x: 2)` → `Expr::KeywordArg{name:"x", value:IntLit 2}`; a keyword
+  arg follows a positional (`g(1, y: 2)`); the `KeywordParams` feature is
+  observed on both the def and call sides but not by ordinary positional
+  params; a required keyword omitted at a call is rejected by the validator
+  while supplying it (or omitting an optional keyword) validates.
+- End-to-end execution proof lives in `semantic-ir-to-python` (which already
+  depends on this crate as a dev-dependency):
+  `def greet(greeting:, name: "world")\n "#{greeting}, #{name}"\nend\n
+  print greet(greeting: "hi")\nprint greet(greeting: "hi", name: "ada")` →
+  Ruby SIR → Python source → CPython prints `hi, world` then `hi, ada`,
+  proving keyword params/args bind BY NAME through the whole pipeline (the
+  omitted optional `name` resolves to its default `"world"`).
+
+### Notes
+
+- Cargo crate version bumped `0.2.0` → `0.3.0`.
 
 ## [0.99.1] - 2026-06-30
 

--- a/code/packages/rust/ruby-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/ruby-to-semantic-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruby-to-semantic-ir"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Ruby AST → narrow-waist Semantic IR. Phase 5 of the Ruby parser project — first frontend for the ruby-parser → SIR pipeline."
 

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -250,6 +250,196 @@ mod tests {
         }
     }
 
+    // -----------------------------------------------------------------
+    // Phase KW7 (Ruby 1.0 unblock) — keyword parameters & arguments.
+    //
+    // The frontend now PRODUCES `Param { kind: Keyword }` for `def f(a:)` /
+    // `def f(a: 1)` and `Expr::KeywordArg` for `f(a: 1)`.  Required vs
+    // optional rides on the existing `default` field (`None` ⇒ required,
+    // `Some` ⇒ optional) exactly as positional optionals do — the
+    // distinguishing axis is `ParamKind::Keyword`.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn def_required_keyword_param_lowers_to_keyword_no_default() {
+        // `def f(a:)` → the single Param is `Keyword` with `default: None`.
+        let m = lower("def f(a:)\n  a + 0\nend\n");
+        let f = m.functions.iter().find(|f| f.name == "f").expect("fn f");
+        assert_eq!(f.params.len(), 1);
+        assert_eq!(f.params[0].kind, ParamKind::Keyword);
+        assert!(
+            f.params[0].default.is_none(),
+            "required keyword param must have NO default"
+        );
+    }
+
+    #[test]
+    fn def_optional_keyword_param_lowers_to_keyword_with_default_intlit() {
+        // `def f(a: 1)` → `Keyword` with `default: Some(IntLit 1)`.
+        let m = lower("def f(a: 1)\n  a + 0\nend\n");
+        let f = m.functions.iter().find(|f| f.name == "f").expect("fn f");
+        assert_eq!(f.params[0].kind, ParamKind::Keyword);
+        match &f.params[0].default {
+            Some(boxed) => assert!(
+                matches!(&**boxed, Expr::IntLit { value: 1, .. }),
+                "expected default IntLit(1), got {:?}",
+                boxed
+            ),
+            None => panic!("expected a default value, got None"),
+        }
+    }
+
+    #[test]
+    fn def_mixed_positional_and_keyword_params_lower_in_order() {
+        // `def f(a, b:, c: 2)` → positional-required `a`, required keyword
+        // `b`, optional keyword `c`.  The declared order is preserved.
+        let m = lower("def f(a, b:, c: 2)\n  a + b + c\nend\n");
+        let f = m.functions.iter().find(|f| f.name == "f").expect("fn f");
+        assert_eq!(f.params.len(), 3);
+        // a — positional required.
+        assert_eq!(f.params[0].kind, ParamKind::Required);
+        assert!(f.params[0].default.is_none());
+        // b — required keyword.
+        assert_eq!(f.params[1].kind, ParamKind::Keyword);
+        assert!(f.params[1].default.is_none());
+        // c — optional keyword with default 2.
+        assert_eq!(f.params[2].kind, ParamKind::Keyword);
+        assert!(
+            matches!(f.params[2].default.as_deref(), Some(Expr::IntLit { value: 2, .. })),
+            "c must default to IntLit(2)"
+        );
+    }
+
+    #[test]
+    fn keyword_param_observes_keyword_params_feature() {
+        // Any keyword param must make the manifest declare `KeywordParams`
+        // (the SIR validator gates the feature otherwise).
+        let m = lower("def f(a:)\n  a + 0\nend\n");
+        assert!(
+            m.manifest.contains(semantic_ir::Feature::KeywordParams),
+            "manifest should declare KeywordParams; declared = {:?}",
+            m.manifest
+        );
+    }
+
+    #[test]
+    fn positional_param_never_trips_keyword_params_feature() {
+        // Regression: an ordinary positional param must NOT observe
+        // KeywordParams (only a `:`-suffixed param or a keyword arg does).
+        let m = lower("def f(a)\n  a + 0\nend\n");
+        assert_eq!(
+            m.functions.iter().find(|f| f.name == "f").unwrap().params[0].kind,
+            ParamKind::Required
+        );
+        assert!(!m.manifest.contains(semantic_ir::Feature::KeywordParams));
+    }
+
+    #[test]
+    fn keyword_call_arg_lowers_to_keyword_arg_node() {
+        // `f(x: 2)` → the call's arg list holds an `Expr::KeywordArg`
+        // wrapper `{ name: "x", value: IntLit 2 }` (NOT a trailing hash).
+        // Use a BARE call to `f` (not wrapped in `puts`) so the arg is the
+        // direct child of the DirectCall.
+        let m = lower("def f(x:)\n  x + 0\nend\nf(x: 2)\n");
+        let body = main_body(&m);
+        match &body.value {
+            Expr::DirectCall { fn_name, args, .. } if fn_name == "f" => {
+                assert_eq!(args.len(), 1, "expected exactly one (keyword) arg");
+                match &args[0] {
+                    Expr::KeywordArg { name, value, .. } => {
+                        assert_eq!(name, "x");
+                        assert!(
+                            matches!(&**value, Expr::IntLit { value: 2, .. }),
+                            "keyword value must be IntLit(2), got {:?}",
+                            value
+                        );
+                    }
+                    other => panic!("expected KeywordArg, got {:?}", other),
+                }
+            }
+            other => panic!("expected DirectCall to f, got {:?}", other),
+        }
+        // The whole module round-trips through the validator.
+        assert!(
+            semantic_ir::validate(&m).is_ok(),
+            "module with a keyword call arg should validate: {:?}",
+            semantic_ir::validate(&m).issues
+        );
+    }
+
+    #[test]
+    fn keyword_arg_follows_positional_arg() {
+        // `g(1, y: 2)` → `args: [IntLit(1), KeywordArg{ name:"y", .. }]`.
+        // The positional stays bare and precedes the keyword.
+        let m = lower("def g(a, y:)\n  a + y\nend\ng(1, y: 2)\n");
+        let body = main_body(&m);
+        match &body.value {
+            Expr::DirectCall { fn_name, args, .. } if fn_name == "g" => {
+                assert_eq!(args.len(), 2);
+                assert!(
+                    matches!(&args[0], Expr::IntLit { value: 1, .. }),
+                    "first arg must be the bare positional IntLit(1), got {:?}",
+                    args[0]
+                );
+                assert!(
+                    matches!(&args[1], Expr::KeywordArg { name, .. } if name == "y"),
+                    "second arg must be the keyword `y`, got {:?}",
+                    args[1]
+                );
+            }
+            other => panic!("expected DirectCall to g, got {:?}", other),
+        }
+        assert!(semantic_ir::validate(&m).is_ok());
+    }
+
+    #[test]
+    fn keyword_arg_observes_keyword_params_feature() {
+        // A keyword ARG (call side) also trips the feature, even when the
+        // callee's params happen to be declared elsewhere.
+        let m = lower("def f(x:)\n  x + 0\nend\nf(x: 3)\n");
+        assert!(
+            m.manifest.contains(semantic_ir::Feature::KeywordParams),
+            "a keyword call arg must observe KeywordParams; manifest = {:?}",
+            m.manifest
+        );
+    }
+
+    #[test]
+    fn omitting_required_keyword_is_rejected_by_validator() {
+        // `def h(x:)` declares a REQUIRED keyword; a call `h()` that omits it
+        // must be rejected by the SIR validator (round-trip proof that the
+        // required-ness produced by the frontend is enforced downstream).
+        let m = lower("def h(x:)\n  x + 0\nend\nh()\n");
+        let result = semantic_ir::validate(&m);
+        assert!(
+            !result.is_ok(),
+            "omitting a required keyword must fail validation, but it passed"
+        );
+    }
+
+    #[test]
+    fn supplying_required_keyword_validates() {
+        // The mirror of the above: supplying the required keyword validates.
+        let m = lower("def h(x:)\n  x + 0\nend\nh(x: 9)\n");
+        assert!(
+            semantic_ir::validate(&m).is_ok(),
+            "supplying a required keyword should validate: {:?}",
+            semantic_ir::validate(&m).issues
+        );
+    }
+
+    #[test]
+    fn optional_keyword_may_be_omitted_at_call() {
+        // `def f(a: 1)` — an OPTIONAL keyword may be omitted; `f()` validates
+        // (the backend fills the default).
+        let m = lower("def f(a: 1)\n  a + 0\nend\nf()\n");
+        assert!(
+            semantic_ir::validate(&m).is_ok(),
+            "omitting an optional keyword should validate: {:?}",
+            semantic_ir::validate(&m).issues
+        );
+    }
+
     #[test]
     fn empty_program_compiles_to_nil_main() {
         let m = lower("");

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -179,6 +179,11 @@ pub fn compile(program: &GrammarASTNode, module_name: &str) -> Result<Module, Ru
         // lowers to `Param.default = Some(_)` and triggers the
         // `DefaultParams` feature (`extract_params`).
         Feature::DefaultParams,
+        // Phase KW7 (Ruby 1.0 unblock) — a keyword parameter (`a:` / `a: 1`,
+        // `ParamKind::Keyword`) or a keyword argument (`f(a: 1)`,
+        // `Expr::KeywordArg`) triggers the `KeywordParams` feature. Set by
+        // `extract_params` (def side) and `lower_call_arg` (call side).
+        Feature::KeywordParams,
     ] {
         if lw.features_used.contains(&f) {
             manifest.add(f);
@@ -5522,6 +5527,61 @@ impl Lowerer {
         &mut self,
         node: &GrammarASTNode,
     ) -> Result<Expr, RubyLowerError> {
+        // KW7 — keyword argument `name: value` (`f(a: 1)`).  The grammar's
+        // FIRST `call_arg` alternative is `NAME COLON expression`, so a
+        // keyword arg node carries a COLON token child (the single `:`).
+        // We detect that colon and, when present, produce the first-class
+        // `Expr::KeywordArg { name, value }` — NOT a trailing hash literal.
+        // (Real Ruby desugars `f(a: 1)` to a trailing implicit-hash keyword,
+        // but SIR models the keyword as its own node so backends can bind it
+        // to the callee's `Keyword` param by name.)  The COLON is matched by
+        // value: the lexer emits both `:` and `::` as Colon-typed tokens, but
+        // only the single `:` ever appears in this call_arg position (`::` is
+        // scope-resolution, which lives inside the `expression` branch).  A
+        // splat/block-pass prefix (`*`/`**`/`&`) never co-occurs with a
+        // keyword colon, so this check is unambiguous.
+        let has_kw_colon = node.children.iter().any(|c| match c {
+            ASTNodeOrToken::Token(t) => matches!(t.type_, TokenType::Colon) && t.value == ":",
+            _ => false,
+        });
+        if has_kw_colon {
+            // The keyword name is the leading NAME token; the value is the
+            // trailing `expression` child.
+            let name_tok = node
+                .children
+                .iter()
+                .find_map(|c| match c {
+                    ASTNodeOrToken::Token(t) if matches!(t.type_, TokenType::Name) => Some(t),
+                    _ => None,
+                })
+                .ok_or_else(|| RubyLowerError {
+                    message: "keyword call arg missing name token".to_string(),
+                    line: node.start_line.unwrap_or(0),
+                    column: node.start_column.unwrap_or(0),
+                })?;
+            let value_node = node
+                .children
+                .iter()
+                .find_map(|c| match c {
+                    ASTNodeOrToken::Node(n) if n.rule_name == "expression" => Some(n),
+                    _ => None,
+                })
+                .ok_or_else(|| RubyLowerError {
+                    message: "keyword call arg missing value expression".to_string(),
+                    line: node.start_line.unwrap_or(0),
+                    column: node.start_column.unwrap_or(0),
+                })?;
+            let value = self.lower_expression(value_node)?;
+            // Observe the feature so the SIR validator accepts the keyword
+            // arg (mirrors the def-side `extract_params` KeywordParams gate).
+            self.features_used.insert(Feature::KeywordParams);
+            return Ok(Expr::KeywordArg {
+                name: name_tok.value.clone(),
+                value: Box::new(value),
+                span: self.span_of(node),
+            });
+        }
+
         // Detect the leading `*` / `**` / `&` token (if present).  All
         // three land on Token children with their value preserved
         // (the 1.8-baseline state machine coalesces `**` into one
@@ -6268,11 +6328,30 @@ impl Lowerer {
                 continue;
             }
 
-            // Splat prefix → ParamKind (same detection as before).
-            let kind = param_node.children.iter().find_map(|cc| match cc {
+            // Splat prefix → ParamKind (same detection as before).  The
+            // KEYWORD kind (KW7) is NOT a prefix — it is signalled by a
+            // trailing COLON token instead (detected just below), so it is
+            // handled separately from the `*`/`**` prefix walk here.
+            let splat_kind = param_node.children.iter().find_map(|cc| match cc {
                 ASTNodeOrToken::Token(t) if t.value == "**" => Some(ParamKind::KwRest),
                 ASTNodeOrToken::Token(t) if t.value == "*" => Some(ParamKind::Rest),
                 _ => None,
+            });
+
+            // KW7 — keyword parameter discriminator.  The grammar's `param`
+            // suffix is `[ COLON [ expression ] | EQUALS expression ]`; a
+            // COLON token child means this is a *keyword* param (`a:` or
+            // `a: 1`), bound by name at the call site rather than by
+            // position.  A splat/double-splat never carries a colon, so a
+            // COLON unambiguously means `ParamKind::Keyword`.  (The COLON is
+            // matched from the token value — the lexer emits both `:` and
+            // `::` as Colon-typed tokens, but a param suffix only ever holds
+            // the single `:`.)
+            let is_keyword = param_node.children.iter().any(|cc| match cc {
+                ASTNodeOrToken::Token(t) => {
+                    matches!(t.type_, TokenType::Colon) && t.value == ":"
+                }
+                _ => false,
             });
 
             // The parameter Name token is the one that is not the
@@ -6291,21 +6370,50 @@ impl Lowerer {
                 continue;
             };
 
-            // Optional default — the trailing `expression` child (present
-            // only when the source wrote `name = expr`).  Rest/kwrest
-            // params keep `default: None`.
+            // The final param kind: KEYWORD wins over the (absent) splat
+            // prefix when a colon is present; otherwise it is the splat
+            // kind, defaulting to positional `Required`.
+            let kind = if is_keyword {
+                ParamKind::Keyword
+            } else {
+                splat_kind.unwrap_or(ParamKind::Required)
+            };
+
+            // Optional default — the trailing `expression` child.  For a
+            // positional param it is the `name = expr` default (P7); for a
+            // keyword param it is the `name: expr` default (KW7, present ⇒
+            // optional keyword, absent ⇒ required keyword).  In BOTH cases
+            // the lowered expression becomes `Param.default`.  Rest/kwrest
+            // splat params keep `default: None` (the grammar is permissive
+            // but Ruby never defaults a splat).
             let default_node = param_node.children.iter().find_map(|cc| match cc {
                 ASTNodeOrToken::Node(n) if n.rule_name == "expression" => Some(n),
                 _ => None,
             });
             let default = match (kind, default_node) {
-                (None, Some(expr_node)) => {
+                // Positional optional (`a = 1`) — the P7 path.
+                (ParamKind::Required, Some(expr_node)) => {
                     let lowered = self.lower_expression(expr_node)?;
                     self.features_used.insert(Feature::DefaultParams);
                     Some(Box::new(lowered))
                 }
+                // Keyword optional (`a: 1`) — the KW7 path.  A keyword param
+                // with a default is an OPTIONAL keyword; one without is a
+                // REQUIRED keyword (the validator enforces that required
+                // keywords are supplied at each call).
+                (ParamKind::Keyword, Some(expr_node)) => {
+                    let lowered = self.lower_expression(expr_node)?;
+                    Some(Box::new(lowered))
+                }
                 _ => None,
             };
+
+            // KW7 — any keyword param makes the module observe the
+            // `KeywordParams` feature so the SIR validator accepts it
+            // (mirrors how a positional default observes `DefaultParams`).
+            if kind == ParamKind::Keyword {
+                self.features_used.insert(Feature::KeywordParams);
+            }
 
             // Make THIS param visible to LATER params' defaults
             // (`def f(a, b = a)`), then record it.
@@ -6315,7 +6423,7 @@ impl Lowerer {
             params.push(Param {
                 name: name_tok.value.clone(),
                 sir_type: None,
-                kind: kind.unwrap_or(ParamKind::Required),
+                kind,
                 default,
                 span: self.span_of_token(name_tok),
             });

--- a/code/packages/rust/semantic-ir-to-python/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-python/CHANGELOG.md
@@ -34,6 +34,18 @@ separator, keyword call arg) and execution-proof tests that shell out to
 `python3`/`python` (skipped gracefully if absent): `greet("hi")` → `hi, world`
 and `greet("hi", name="ada")` → `hi, ada`.
 
+### KW7 — Ruby-frontend-driven execution proof (test only; emission unchanged)
+
+Once the Ruby frontend (`ruby-to-semantic-ir` 0.3.0) began PRODUCING keyword
+params/args (KW7), a full-pipeline execution-proof was added here (the natural
+home, since this crate already dev-depends on the Ruby frontend): Ruby SOURCE
+`def greet(greeting:, name: "world")\n "#{greeting}, #{name}"\nend\n
+print greet(greeting: "hi")\nprint greet(greeting: "hi", name: "ada")` →
+Ruby SIR → Python → CPython prints `hi, world` then `hi, ada`. This exercises
+the KW2 keyword-only-def + `name=value`-call emission end to end from real Ruby
+syntax (78 tests, up from 77). No emission behaviour changed, so the crate
+version is unchanged.
+
 ## 0.2.0 — default-parameter emission via sentinel + body prologue (P2c)
 
 The backend now accepts `Feature::DefaultParams` and lowers default parameters.

--- a/code/packages/rust/semantic-ir-to-python/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-python/src/lib.rs
@@ -147,7 +147,7 @@ impl Backend for PythonBackend {
 mod tests {
     use super::*;
     use semantic_ir::{
-        Block, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Span,
+        Block, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, ParamKind, Span,
     };
 
     fn s() -> Span {
@@ -349,6 +349,73 @@ mod tests {
             assert_eq!(
                 stdout, "6\n10\n",
                 "Ruby call-time param-scoped default produced wrong output"
+            );
+        }
+    }
+
+    #[test]
+    fn end_to_end_ruby_keyword_params_and_args_execute_py() {
+        // KW7 (Ruby-1.0 unblock) full-pipeline execution-proof: Ruby SOURCE
+        // with a keyword parameter list AND keyword call arguments →
+        // ruby-to-semantic-ir → semantic-ir-to-python → CPython.
+        //
+        //   def greet(greeting:, name: "world")
+        //     "#{greeting}, #{name}"
+        //   end
+        //
+        // `greeting:` is a REQUIRED keyword (no default); `name: "world"` is
+        // an OPTIONAL keyword.  Two calls exercise both paths:
+        //   • greet(greeting: "hi")              → omits `name` → "hi, world"
+        //   • greet(greeting: "hi", name: "ada") → supplies `name` → "hi, ada"
+        // so stdout must be `hi, world` then `hi, ada`.  This is the
+        // discriminating proof that the Ruby frontend now PRODUCES keyword
+        // params (`ParamKind::Keyword`) and keyword args (`Expr::KeywordArg`)
+        // and that they bind BY NAME end to end — the single most-requested
+        // modern-Ruby gap.
+        //
+        // NB: the output builtin is `print` rather than `puts` — `print` is
+        // one of the few builtins `sir-runtime-core` implements natively
+        // (same reason the P7 default-param execution-proof above uses it).
+        let src = "def greet(greeting:, name: \"world\")\n  \"#{greeting}, #{name}\"\nend\n\
+                   print greet(greeting: \"hi\")\n\
+                   print greet(greeting: \"hi\", name: \"ada\")\n";
+        let module = ruby_to_semantic_ir::compile_source(src, "demo").expect("lower ruby");
+
+        // Frontend must have produced keyword params and declared the feature.
+        assert!(
+            module.manifest.contains(Feature::KeywordParams),
+            "ruby frontend must declare KeywordParams; manifest = {:?}",
+            module.manifest
+        );
+        let greet = module
+            .functions
+            .iter()
+            .find(|f| f.name == "greet")
+            .expect("fn greet");
+        assert_eq!(greet.params[0].kind, ParamKind::Keyword);
+        assert!(
+            greet.params[0].default.is_none(),
+            "`greeting:` is a required keyword (no default)"
+        );
+        assert_eq!(greet.params[1].kind, ParamKind::Keyword);
+        assert!(
+            greet.params[1].default.is_some(),
+            "`name: \"world\"` is an optional keyword (has a default)"
+        );
+
+        let a = compile(&module).expect("compile to python");
+        // Python-native keyword-only shape: a bare `*` opens the keyword-only
+        // region; the optional keyword reuses the sentinel-default machinery.
+        assert!(
+            a.source.contains("def greet(*, greeting"),
+            "keyword params must be keyword-only after a bare `*`; got:\n{}",
+            a.source
+        );
+
+        if let Some(stdout) = run_emitted_python(&a.source) {
+            assert_eq!(
+                stdout, "hi, world\nhi, ada\n",
+                "Ruby keyword params/args produced wrong output"
             );
         }
     }


### PR DESCRIPTION
## What

**KW7** — the Ruby frontend now parses and lowers keyword parameters (`def f(a:)` / `def f(a: 1)`) and keyword arguments (`f(a: 1)`) into the SIR core's `ParamKind::Keyword` / `Expr::KeywordArg`. **This closes the single critical Ruby-1.0 gap** the readiness survey identified. Design: `code/specs/sir-keyword-params.md`.

## Grammar (`ruby.grammar` + regenerated `_grammar.rs`)

- **Def:** `param = [ "*" | "**" ] NAME [ COLON [ expression ] | EQUALS expression ]` — the `COLON` branch is a keyword param (required if no default expr, optional if present), disjoint from the `EQUALS` positional-default branch.
- **Call:** `call_arg = NAME COLON expression | [ "*" | "**" | "&" ] expression` — keyword branch first, so `f(a: 1)` produces a keyword arg, not a trailing hash. Explicit-brace hashes (`f({a: 1})`) still take the expression branch.

Disambiguation is token-disjoint (`COLON` vs `EQUALS`; `NAME COLON` in param/call position never collides with `hash_entry`/`hash_pattern_pair`, which are only reachable inside `{…}`/`case-in`). Documented inline.

## Lowering (`ruby-to-semantic-ir/src/lower.rs`)

`extract_params` maps `NAME COLON [expr]` → `Param{kind:Keyword, default}`; `lower_call_arg` maps `NAME COLON expr` → `Expr::KeywordArg`. `Feature::KeywordParams` declared whenever produced.

## Verification

- `coding-adventures-ruby-parser` **279 passed** (+5); `ruby-to-semantic-ir` **393 passed** (+11); `semantic-ir-to-python` **78 passed** (+1 e2e).
- **End-to-end execution-proof (CPython):** Ruby `def greet(greeting:, name: "world"); "#{greeting}, #{name}"; end` → SIR → Python → ran: `greet(greeting: "hi")` → `hi, world`; `greet(greeting: "hi", name: "ada")` → `hi, ada`.
- Clippy clean on touched lines; `cargo build --workspace` clean (bar the pre-existing Unix-only crate).
- **Security review passed:** memoized packrat parser bounds backtracking (no ReDoS); no panics in lowering (`.ok_or_else` errors, not unwrap); feature-gating enforced by the validator; safe shell-less subprocess in the e2e test.

**Not a 1.0 bump** — this lands the feature only. After merge I'll surface an updated Ruby-1.0 readiness summary for a go/no-go decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)