### PR TITLE
feat(adj-ladder): rung-17 respiratory ventilation mechanics (new organ system, compute_dimensioned)

### DIFF
--- a/code/specs/data/adj-ladder/rung17_alveolar_ventilation/gen_items.py
+++ b/code/specs/data/adj-ladder/rung17_alveolar_ventilation/gen_items.py
@@ -1,0 +1,165 @@
+"""Generate rung-17 (respiratory ventilation mechanics) items.json for the ADJ-LADDER.
+
+Rung 17 opens ANOTHER new organ system on the quantitative band — **pulmonary / respiratory
+mechanics** — using the same contamination-safe shape as the pharmacokinetics rung (rung 8) and
+the cardiac-hemodynamics rung (rung 16): a small table of *observed* bedside quantities, and a
+tight family of mutually-confusable formulas built **only from those observed quantities** (no
+numeric literal anywhere in any program), so nothing structural can leak into the answer.
+
+The clinical setup is a single ventilation assessment. We observe three quantities:
+
+  TV   tidal volume            (mL)          — air moved per breath
+  RR   respiratory rate        (breaths/min) — breaths per minute
+  VD   (anatomic) dead space   (mL)          — conducting-airway volume that does not exchange gas
+
+From those three, the three textbook bedside ventilation parameters fall out as **exact
+combinations** of the observed quantities — no constant required:
+
+  MV   minute ventilation          = TV * RR           (mL/min)  [ volume/breath * breaths/min ]
+  VA   alveolar ventilation        = (TV - VD) * RR     (mL/min)  [ only the gas-exchanging part ]
+  VDm  dead-space ventilation/min  = VD * RR            (mL/min)  [ = MV - VA ]
+
+This rung is richer than rungs 8/16 (pure ratios / a product): it combines a **subtraction** of
+two observed quantities with a **product** — `VA = (TV - VD) * RR` — exercising the engine's
+arithmetic across `+`, `-`, `*` and grouping parentheses, all on a respiratory stem.
+
+Each parameter is a `compute_dimensioned` program (observe the three quantities + `let answer =
+formula`); the ADJ engine carries the arithmetic and the harness reads the scalar via the existing
+`compute_dimensioned` extractor — no harness/engine change, exactly as rungs 8 and 16.
+
+Contamination-safe by construction: every formula is built only from the three observed
+quantities via `+`, `-`, `*` — **no structural constants** — so every program literal is grounded
+in the stem. The five options are a tight family over the same three quantities: the three real
+parameters {MV, VA, VDm} plus the two classic slips —
+
+  (TV + VD) * RR  — ADDING the dead space instead of subtracting it (inflating alveolar ventilation), and
+  TV - VD         — the alveolar volume PER BREATH, forgetting to multiply by the rate,
+
+which are exactly the mistakes a student makes (wrong sign on dead space; dropping the ×RR). Gold
+rotates A–E by index.
+
+Note on table choice: the five family values can collide for special quantity relations (e.g.
+VDm = VD*RR equals the alveolar-per-breath TV-VD only for particular values). The tables below are
+chosen so the five family values are pairwise distinct — with a comfortable margin — for every
+item, asserted at build time.
+"""
+import json
+
+LETTERS = ["A", "B", "C", "D", "E"]
+
+# (TV, RR, VD) observed quantities. The five ventilation-family values are asserted
+# pairwise-distinct (with margin) below.
+#   TV  = tidal volume         (mL)
+#   RR  = respiratory rate     (breaths/min)
+#   VD  = anatomic dead space  (mL)
+TABLES = [
+    (500, 12, 150),
+    (600, 14, 160),
+    (450, 16, 140),
+    (550, 10, 150),
+    (700, 15, 170),
+    (400, 18, 130),
+    (650, 11, 155),
+]
+
+# The option family (5 members), all built from the observed quantities tv/rr/vd via `+ - *`.
+#   key -> (display name, formula-as-adj)
+# Only the first three are *queried* (used as gold); all five always appear as the options.
+FAMILY = [
+    ("mv", "minute ventilation (MV)", "tv * rr"),
+    ("va", "alveolar ventilation (VA)", "(tv - vd) * rr"),
+    ("vdm", "dead-space ventilation per minute", "vd * rr"),
+    ("va_wrong", "dead-space-added ventilation", "(tv + vd) * rr"),
+    ("alv_breath", "alveolar volume per breath", "tv - vd"),
+]
+QUERIED = ["mv", "va", "vdm"]
+ORDER = [k for k, _, _ in FAMILY]
+
+
+def scalar(v):
+    return {"value": v, "unit": "scalar"}
+
+
+def family_values(tv, rr, vd):
+    # Operation order mirrors the ADJ program exactly, so the Python option value and the engine
+    # result are the same IEEE-double (well within the harness's 1e-9 match tolerance).
+    return {
+        "mv": tv * rr,
+        "va": (tv - vd) * rr,
+        "vdm": vd * rr,
+        "va_wrong": (tv + vd) * rr,
+        "alv_breath": tv - vd,
+    }
+
+
+def build():
+    name_of = {k: nm for k, nm, _ in FAMILY}
+    formula_of = {k: f for k, _, f in FAMILY}
+    items = []
+    idx = 0
+    for tv, rr, vd in TABLES:
+        fv = family_values(tv, rr, vd)
+        # Pairwise-distinct with a comfortable margin so the harness never sees two options
+        # matching the gold value within its 1e-9 tolerance.
+        vals = [fv[k] for k in ORDER]
+        for i in range(len(vals)):
+            for j in range(i + 1, len(vals)):
+                assert abs(vals[i] - vals[j]) > 1e-6, (tv, rr, vd, ORDER[i], ORDER[j], fv)
+        for key in QUERIED:
+            gold_val = fv[key]
+            gold_pos = idx % 5
+            others = [fv[k] for k in ORDER if abs(fv[k] - gold_val) > 1e-12]
+            opts_vals = others[:]
+            opts_vals.insert(gold_pos, gold_val)
+            opts_vals = opts_vals[:5]
+            if abs(opts_vals[gold_pos] - gold_val) > 1e-12:
+                opts_vals[gold_pos] = gold_val
+            assert len({round(v, 9) for v in opts_vals}) == 5, (key, tv, rr, vd, opts_vals)
+            options = {LETTERS[i]: scalar(opts_vals[i]) for i in range(5)}
+            items.append({
+                "id": f"r17av-{idx + 1:02d}",
+                "qtype": "ventilation_parameter",
+                "stem": (
+                    f"A ventilation assessment shows a tidal volume of {tv} mL, a respiratory rate "
+                    f"of {rr} breaths/min, and an anatomic dead space of {vd} mL. What is the "
+                    f"patient's {name_of[key]}?"
+                ),
+                "program": (
+                    f"observe tv({tv})\n"
+                    f"observe rr({rr})\n"
+                    f"observe vd({vd})\n"
+                    f"let answer = {formula_of[key]}\n"
+                    "? answer\n"
+                ),
+                "answer_from": {"type": "compute_dimensioned", "name": "answer"},
+                "options": options,
+                "gold_letter": LETTERS[gold_pos],
+            })
+            idx += 1
+    return {
+        "description": (
+            "ADJ-LADDER rung 17 — respiratory ventilation parameters from a single bedside "
+            "assessment (a NEW organ system: pulmonary mechanics). From three stated quantities "
+            "(tidal volume TV, respiratory rate RR, anatomic dead space VD) compute the minute "
+            "ventilation (MV = TV*RR), alveolar ventilation (VA = (TV-VD)*RR), or dead-space "
+            "ventilation per minute (VDm = VD*RR). Each item is a compute_dimensioned program "
+            "(observe the three quantities, let answer = formula); the ADJ engine carries the "
+            "arithmetic — a subtraction combined with a product — and the harness matches the scalar "
+            "to the printed options. Contamination-safe: every parameter is built only from the "
+            "three observed quantities via + - * — no constant leaks. The five options are a family "
+            "over the same quantities, so the distractors are exactly the slips students make: adding "
+            "the dead space instead of subtracting it, or dropping the multiply-by-rate."
+        ),
+        "items": items,
+    }
+
+
+if __name__ == "__main__":
+    doc = build()
+    with open("items.json", "w") as f:
+        json.dump(doc, f, indent=2)
+        f.write("\n")
+    print("wrote items.json:", len(doc["items"]), "items")
+    for it in doc["items"]:
+        print(it["id"], it["qtype"], "gold", it["gold_letter"],
+              "=", round(it["options"][it["gold_letter"]]["value"], 4))

--- a/code/specs/data/adj-ladder/rung17_alveolar_ventilation/items.json
+++ b/code/specs/data/adj-ladder/rung17_alveolar_ventilation/items.json
@@ -1,0 +1,698 @@
+{
+  "description": "ADJ-LADDER rung 17 \u2014 respiratory ventilation parameters from a single bedside assessment (a NEW organ system: pulmonary mechanics). From three stated quantities (tidal volume TV, respiratory rate RR, anatomic dead space VD) compute the minute ventilation (MV = TV*RR), alveolar ventilation (VA = (TV-VD)*RR), or dead-space ventilation per minute (VDm = VD*RR). Each item is a compute_dimensioned program (observe the three quantities, let answer = formula); the ADJ engine carries the arithmetic \u2014 a subtraction combined with a product \u2014 and the harness matches the scalar to the printed options. Contamination-safe: every parameter is built only from the three observed quantities via + - * \u2014 no constant leaks. The five options are a family over the same quantities, so the distractors are exactly the slips students make: adding the dead space instead of subtracting it, or dropping the multiply-by-rate.",
+  "items": [
+    {
+      "id": "r17av-01",
+      "qtype": "ventilation_parameter",
+      "stem": "A ventilation assessment shows a tidal volume of 500 mL, a respiratory rate of 12 breaths/min, and an anatomic dead space of 150 mL. What is the patient's minute ventilation (MV)?",
+      "program": "observe tv(500)\nobserve rr(12)\nobserve vd(150)\nlet answer = tv * rr\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 6000,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 4200,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 1800,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 7800,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 350,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r17av-02",
+      "qtype": "ventilation_parameter",
+      "stem": "A ventilation assessment shows a tidal volume of 500 mL, a respiratory rate of 12 breaths/min, and an anatomic dead space of 150 mL. What is the patient's alveolar ventilation (VA)?",
+      "program": "observe tv(500)\nobserve rr(12)\nobserve vd(150)\nlet answer = (tv - vd) * rr\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 6000,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 4200,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 1800,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 7800,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 350,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r17av-03",
+      "qtype": "ventilation_parameter",
+      "stem": "A ventilation assessment shows a tidal volume of 500 mL, a respiratory rate of 12 breaths/min, and an anatomic dead space of 150 mL. What is the patient's dead-space ventilation per minute?",
+      "program": "observe tv(500)\nobserve rr(12)\nobserve vd(150)\nlet answer = vd * rr\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 6000,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 4200,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 1800,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 7800,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 350,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r17av-04",
+      "qtype": "ventilation_parameter",
+      "stem": "A ventilation assessment shows a tidal volume of 600 mL, a respiratory rate of 14 breaths/min, and an anatomic dead space of 160 mL. What is the patient's minute ventilation (MV)?",
+      "program": "observe tv(600)\nobserve rr(14)\nobserve vd(160)\nlet answer = tv * rr\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 6160,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2240,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 10640,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 8400,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 440,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r17av-05",
+      "qtype": "ventilation_parameter",
+      "stem": "A ventilation assessment shows a tidal volume of 600 mL, a respiratory rate of 14 breaths/min, and an anatomic dead space of 160 mL. What is the patient's alveolar ventilation (VA)?",
+      "program": "observe tv(600)\nobserve rr(14)\nobserve vd(160)\nlet answer = (tv - vd) * rr\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 8400,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2240,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 10640,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 440,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 6160,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r17av-06",
+      "qtype": "ventilation_parameter",
+      "stem": "A ventilation assessment shows a tidal volume of 600 mL, a respiratory rate of 14 breaths/min, and an anatomic dead space of 160 mL. What is the patient's dead-space ventilation per minute?",
+      "program": "observe tv(600)\nobserve rr(14)\nobserve vd(160)\nlet answer = vd * rr\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 2240,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 8400,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 6160,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 10640,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 440,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r17av-07",
+      "qtype": "ventilation_parameter",
+      "stem": "A ventilation assessment shows a tidal volume of 450 mL, a respiratory rate of 16 breaths/min, and an anatomic dead space of 140 mL. What is the patient's minute ventilation (MV)?",
+      "program": "observe tv(450)\nobserve rr(16)\nobserve vd(140)\nlet answer = tv * rr\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 4960,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 7200,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 2240,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 9440,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 310,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r17av-08",
+      "qtype": "ventilation_parameter",
+      "stem": "A ventilation assessment shows a tidal volume of 450 mL, a respiratory rate of 16 breaths/min, and an anatomic dead space of 140 mL. What is the patient's alveolar ventilation (VA)?",
+      "program": "observe tv(450)\nobserve rr(16)\nobserve vd(140)\nlet answer = (tv - vd) * rr\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 7200,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2240,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 4960,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 9440,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 310,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r17av-09",
+      "qtype": "ventilation_parameter",
+      "stem": "A ventilation assessment shows a tidal volume of 450 mL, a respiratory rate of 16 breaths/min, and an anatomic dead space of 140 mL. What is the patient's dead-space ventilation per minute?",
+      "program": "observe tv(450)\nobserve rr(16)\nobserve vd(140)\nlet answer = vd * rr\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 7200,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 4960,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 9440,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 2240,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 310,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r17av-10",
+      "qtype": "ventilation_parameter",
+      "stem": "A ventilation assessment shows a tidal volume of 550 mL, a respiratory rate of 10 breaths/min, and an anatomic dead space of 150 mL. What is the patient's minute ventilation (MV)?",
+      "program": "observe tv(550)\nobserve rr(10)\nobserve vd(150)\nlet answer = tv * rr\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 4000,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 1500,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 7000,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 400,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 5500,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r17av-11",
+      "qtype": "ventilation_parameter",
+      "stem": "A ventilation assessment shows a tidal volume of 550 mL, a respiratory rate of 10 breaths/min, and an anatomic dead space of 150 mL. What is the patient's alveolar ventilation (VA)?",
+      "program": "observe tv(550)\nobserve rr(10)\nobserve vd(150)\nlet answer = (tv - vd) * rr\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 4000,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 5500,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 1500,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 7000,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 400,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r17av-12",
+      "qtype": "ventilation_parameter",
+      "stem": "A ventilation assessment shows a tidal volume of 550 mL, a respiratory rate of 10 breaths/min, and an anatomic dead space of 150 mL. What is the patient's dead-space ventilation per minute?",
+      "program": "observe tv(550)\nobserve rr(10)\nobserve vd(150)\nlet answer = vd * rr\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 5500,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 1500,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 4000,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 7000,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 400,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r17av-13",
+      "qtype": "ventilation_parameter",
+      "stem": "A ventilation assessment shows a tidal volume of 700 mL, a respiratory rate of 15 breaths/min, and an anatomic dead space of 170 mL. What is the patient's minute ventilation (MV)?",
+      "program": "observe tv(700)\nobserve rr(15)\nobserve vd(170)\nlet answer = tv * rr\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 7950,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2550,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 10500,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 13050,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 530,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r17av-14",
+      "qtype": "ventilation_parameter",
+      "stem": "A ventilation assessment shows a tidal volume of 700 mL, a respiratory rate of 15 breaths/min, and an anatomic dead space of 170 mL. What is the patient's alveolar ventilation (VA)?",
+      "program": "observe tv(700)\nobserve rr(15)\nobserve vd(170)\nlet answer = (tv - vd) * rr\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 10500,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2550,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 13050,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 7950,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 530,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r17av-15",
+      "qtype": "ventilation_parameter",
+      "stem": "A ventilation assessment shows a tidal volume of 700 mL, a respiratory rate of 15 breaths/min, and an anatomic dead space of 170 mL. What is the patient's dead-space ventilation per minute?",
+      "program": "observe tv(700)\nobserve rr(15)\nobserve vd(170)\nlet answer = vd * rr\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 10500,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 7950,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 13050,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 530,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 2550,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r17av-16",
+      "qtype": "ventilation_parameter",
+      "stem": "A ventilation assessment shows a tidal volume of 400 mL, a respiratory rate of 18 breaths/min, and an anatomic dead space of 130 mL. What is the patient's minute ventilation (MV)?",
+      "program": "observe tv(400)\nobserve rr(18)\nobserve vd(130)\nlet answer = tv * rr\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 7200,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 4860,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 2340,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 9540,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 270,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r17av-17",
+      "qtype": "ventilation_parameter",
+      "stem": "A ventilation assessment shows a tidal volume of 400 mL, a respiratory rate of 18 breaths/min, and an anatomic dead space of 130 mL. What is the patient's alveolar ventilation (VA)?",
+      "program": "observe tv(400)\nobserve rr(18)\nobserve vd(130)\nlet answer = (tv - vd) * rr\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 7200,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 4860,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 2340,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 9540,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 270,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r17av-18",
+      "qtype": "ventilation_parameter",
+      "stem": "A ventilation assessment shows a tidal volume of 400 mL, a respiratory rate of 18 breaths/min, and an anatomic dead space of 130 mL. What is the patient's dead-space ventilation per minute?",
+      "program": "observe tv(400)\nobserve rr(18)\nobserve vd(130)\nlet answer = vd * rr\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 7200,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 4860,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 2340,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 9540,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 270,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r17av-19",
+      "qtype": "ventilation_parameter",
+      "stem": "A ventilation assessment shows a tidal volume of 650 mL, a respiratory rate of 11 breaths/min, and an anatomic dead space of 155 mL. What is the patient's minute ventilation (MV)?",
+      "program": "observe tv(650)\nobserve rr(11)\nobserve vd(155)\nlet answer = tv * rr\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 5445,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 1705,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 8855,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 7150,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 495,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r17av-20",
+      "qtype": "ventilation_parameter",
+      "stem": "A ventilation assessment shows a tidal volume of 650 mL, a respiratory rate of 11 breaths/min, and an anatomic dead space of 155 mL. What is the patient's alveolar ventilation (VA)?",
+      "program": "observe tv(650)\nobserve rr(11)\nobserve vd(155)\nlet answer = (tv - vd) * rr\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 7150,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 1705,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 8855,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 495,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 5445,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r17av-21",
+      "qtype": "ventilation_parameter",
+      "stem": "A ventilation assessment shows a tidal volume of 650 mL, a respiratory rate of 11 breaths/min, and an anatomic dead space of 155 mL. What is the patient's dead-space ventilation per minute?",
+      "program": "observe tv(650)\nobserve rr(11)\nobserve vd(155)\nlet answer = vd * rr\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 1705,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 7150,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 5445,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 8855,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 495,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    }
+  ]
+}

--- a/code/specs/data/adj-ladder/test_ladder_eval.py
+++ b/code/specs/data/adj-ladder/test_ladder_eval.py
@@ -54,6 +54,7 @@ SELF_CONTAINED_RUNGS = (
     "rung14_indeterminate_decision",
     "rung15_fractional_excretion_urea",
     "rung16_cardiac_output",
+    "rung17_alveolar_ventilation",
 )
 
 


### PR DESCRIPTION
## What

Adds **rung-17 (respiratory ventilation mechanics)** to the ADJ-LADDER — opening **another new organ system (pulmonary mechanics)** on the quantitative band.

From three observed bedside quantities — tidal volume **TV** (mL), respiratory rate **RR** (breaths/min), anatomic dead space **VD** (mL) — the three textbook ventilation parameters fall out as exact combinations, **no constant required**:

| parameter | formula |
|-----------|---------|
| MV — minute ventilation | `TV * RR` |
| VA — alveolar ventilation | `(TV - VD) * RR` |
| VDm — dead-space ventilation / min | `VD * RR` (= MV − VA) |

## How it fits

Mirrors **rung-8 (PK)** and **rung-16 (cardiac)** exactly: each item is a `compute_dimensioned` program (observe the three quantities, `let answer = formula`); the ADJ engine carries the arithmetic and the harness matches the scalar to the printed options — **no harness/engine change**.

Richer than rungs 8/16: `VA = (TV - VD) * RR` combines a **subtraction** of two observed quantities with a **product**, exercising the engine across `+ - *` and grouping **parentheses** on a respiratory stem. (Verified the engine evaluates `(tv - vd) * rr` correctly — 4200 for 500/12/150, dim=scalar.)

## Contamination-safety

Every formula is built **only** from the three observed quantities via `+ - *` — no structural constant leaks, so every program literal is grounded in the stem. The five options are a family over the same quantities `{MV, VA, VDm, (TV+VD)*RR, TV-VD}`, so the distractors are exactly the slips students make: adding the dead space instead of subtracting it, or dropping the multiply-by-rate. Gold rotates A–E; 7 tables × 3 queried = **21 items**; the five values are asserted pairwise-distinct per item.

## Gate

`rung17_alveolar_ventilation` registered in `SELF_CONTAINED_RUNGS`. Gate green:
- `test_cached_engine_selects_every_gold` — **0 wrong / 0 abstain**
- `test_contamination_check_clean` — clean
- `test_items_json_valid` — valid

Security review passed (`gen_items.py` is a data-only offline generator, no eval/exec/injection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)