### PR TITLE
feat(python-to-semantic-ir): keyword parameter & argument production (KW8)

### DIFF
--- a/code/packages/rust/python-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/python-to-semantic-ir/CHANGELOG.md
@@ -4,15 +4,64 @@ All notable changes to `python-to-semantic-ir` are documented here.
 
 ## Unreleased
 
-### Changed
-
-- Compile-compat stub arm for the new core `semantic-ir` variant
-  `Expr::KeywordArg` (KW1) — the callee-collection pass recurses into the
-  keyword arg's inner `value`. Real keyword-argument lowering is pending
-  KW2–KW8.
-
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to semantic versioning.
+
+## 0.7.0 — 2026-06-30
+
+**KW8**: produce **keyword parameters & keyword arguments**.  Python's
+keyword-only parameters (`def f(a, *, x, y=1)`) now lower to
+`Param { kind: ParamKind::Keyword, .. }`, and keyword arguments at a call
+site (`f(1, y=2)`) lower to `Expr::KeywordArg { name, value }`.  This
+completes the frontend half of the [`sir-keyword-params`](../../../specs/sir-keyword-params.md)
+cascade for Python: the core (KW1) and the Python backend (KW2) already
+landed on `main`, so a keyword-using Python program now round-trips
+Python → SIR → Python and executes.
+
+### Added
+
+- **Keyword-only parameters** — a parameter that follows a bare `*` in a
+  `def` signature (`def f(a, *, x, y=1)`) is *keyword-only* and lowers to
+  `Param { kind: ParamKind::Keyword, .. }`.  Required-vs-optional rides on
+  the existing `default` field, exactly as it does for positional
+  optionals: `x` (no default) → `Keyword` + `default: None` (a **required**
+  keyword); `y=1` → `Keyword` + `default: Some(IntLit(1))` (an **optional**
+  keyword).  Positional params *before* the `*` keep `ParamKind::Required`.
+  The `*` boundary is not hunted for as a token — the parser already models
+  it *structurally*: keyword-only params are `param_with_default` children
+  of a nested `star_params` node, whereas positional params are direct
+  children of `parameter_list`.  `def_param_specs` walks both, stamping the
+  kind by nesting.
+- **Keyword arguments** — an explicit `name=value` call argument
+  (`f(1, y=2)`) lowers to `Expr::KeywordArg { name, value }`, appended to
+  the call's `args` vec **after** the positionals (the core IR models
+  keyword args as trailing `args` elements, not a parallel `kwargs` field).
+  The `NAME EQUALS expression` argument shape is detected by its leading
+  `NAME` + `EQUALS` tokens, so a `**dict` double-splat (which names no
+  single parameter) is never mistaken for a keyword argument and keeps its
+  existing treatment.
+- **`Feature::KeywordParams`** is declared in the manifest whenever any
+  keyword parameter *or* keyword argument is produced — matching what the
+  validator observes (mirrors the `DefaultParams` declaration).
+- Tests: lowering assertions (`def f(a, *, x, y=1)` → the exact
+  `[Required a, Keyword x/None, Keyword y/Some(1)]` param vector; `f(x=1)` →
+  `KeywordArg{name:"x"}`; a positional+keyword mix preserving order),
+  validator round-trips (a supplied required keyword validates; an **omitted
+  required keyword** is rejected), rejection of the out-of-subset `*args`
+  and `**kwargs` rest params, and an **execution-proof** e2e
+  (`e2e_keyword_parameter`) — `def greet(greeting, *, name="world")` run via
+  `python3` prints `world` (default) then `ada` (override).
+
+### Changed
+
+- The internal `def`-parameter spec threaded through `lower_def` →
+  `lower_callable` → `push_function` grew from `(name, Option<Expr>)` to
+  `(name, ParamKind, Option<Expr>)` (aliased `ParamSpec`) so a parameter's
+  keyword-only-ness reaches `Param.kind`.  `param_spec` now binds a default
+  only to the `expression` that follows an `=` token (previously it bound
+  any child node), hardening it against a would-be type-annotation child.
+- Compile-compat stub arm for the core `Expr::KeywordArg` variant (added in
+  KW1) is now a real lowering path on the call side.
 
 ## 0.6.0 — 2026-06-30
 

--- a/code/packages/rust/python-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/python-to-semantic-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "python-to-semantic-ir"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 description = "Python CST → narrow-waist Semantic IR (SIR17). Second frontend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/python-to-semantic-ir/README.md
+++ b/code/packages/rust/python-to-semantic-ir/README.md
@@ -156,6 +156,8 @@ nesting into a clean error rather than a native stack overflow.
 | `def f(a, b): …`                       | top-level `Function { name f, params [a, b], body }`  | `DynamicTyping`†       |
 | `def f(a, b=10): …`                     | `Param { name b, default: Some(IntLit 10) }` (P8)     | `DefaultParams`        |
 | `f(5)` (omitting a defaulted arg)       | *partial* `DirectCall { args [IntLit 5] }`            | `DefaultParams`        |
+| `def f(a, *, x, y=1): …`                 | `Param { kind Keyword, .. }` for `x`, `y` (KW8)       | `KeywordParams`        |
+| `f(1, y=2)`                             | `args [IntLit 1, KeywordArg { name y, value 2 }]`     | `KeywordParams`        |
 | `return expr` (tail)                   | function body `value = expr`                          | —                      |
 | `return` / no return (tail)            | function body `value = NilLit` (implicit `None`)      | —                      |
 | `return expr` (non-tail / early)       | **error** — "early return not supported in v0"        | —                      |
@@ -215,6 +217,28 @@ have defaults.
 > under the IR it is re-evaluated per call.  That is a deliberate,
 > documented v0 choice.
 
+**Keyword parameters & arguments (KW8).**  A parameter that follows a bare
+`*` in a `def` signature is **keyword-only** — it can only be supplied *by
+name* at the call site — and lowers to `Param { kind: ParamKind::Keyword }`.
+Required-vs-optional rides on the existing `default` field exactly as it
+does for positional optionals: in `def f(a, *, x, y=1)`, `x` (no default)
+is a **required** keyword (`Keyword` + `default: None`) and `y=1` is an
+**optional** keyword (`Keyword` + `default: Some(IntLit 1)`); the positional
+`a` before the `*` stays `Required`.  The `*` boundary is not scanned for as
+a token — the parser models it *structurally*, nesting the keyword-only
+`param_with_default` nodes inside a `star_params` node while positional
+params are direct children of `parameter_list`, so the lowerer stamps the
+kind by nesting.  On the call side an explicit `name=value` argument
+(`f(1, y=2)`) lowers to `Expr::KeywordArg { name, value }` appended to the
+call's `args` **after** the positionals (the core IR carries keyword args as
+trailing `args` elements, not a parallel `kwargs` field).  A keyword
+argument is distinguished from a `**dict` double-splat by its leading `NAME`
++ `=` tokens, so `**dict` (which names no single parameter) is never
+mis-lowered as a keyword.  Any keyword parameter or argument declares
+`Feature::KeywordParams`.  The out-of-subset positional-rest `*args` and
+keyword-rest `**kwargs` params are rejected with a positioned error rather
+than silently dropped.
+
 ### Collections (M5)
 
 | Python source              | SIR lowering                                  | Feature declared |
@@ -259,10 +283,12 @@ Everything past M5 returns a clear positioned `PythonLowerError`:
 - list / dict **comprehensions**, **slicing** (`xs[a:b]`), **tuple** /
   **set** literals, and list/dict **methods** (`.append` / `.keys` /
   `.get` — these need the SIR runtime-library)
-- keyword arguments, `*args` / `**kwargs`, keyword-only parameters,
-  multi-level capture chaining (capturing a variable two scopes up)
-  — note **positional default parameters** (`def f(a=1)`) are now
-  supported (P8); only the keyword/variadic forms remain deferred
+- `*args` / `**kwargs` (positional-rest / keyword-rest params — `Rest` /
+  `KwRest` are not yet modelled by this crate), multi-level capture chaining
+  (capturing a variable two scopes up) — note **positional default
+  parameters** (`def f(a=1)`, P8) and **keyword parameters / arguments**
+  (`def f(*, x)`, `f(x=1)`, KW8) are now supported; only the variadic
+  rest forms remain deferred
 - tuple / multi-target `for` (`for k, v in …`), multi-target / chained
   assignment, attribute targets, bitwise operators, the power operator
   (`**`)

--- a/code/packages/rust/python-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/python-to-semantic-ir/src/lib.rs
@@ -55,9 +55,14 @@
 //!   so a *mutable* default (`def f(x=[])`) is re-evaluated per call — a
 //!   documented v0 choice.  A default referencing another parameter is a
 //!   Python `NameError` and is not supported.
+//! - **keyword parameters & arguments** (KW8) — a param after a bare `*`
+//!   (`def f(a, *, x, y=1)`) is keyword-only and lowers to
+//!   `Param { kind: ParamKind::Keyword }` (required if it has no default,
+//!   optional if it does); a `name=value` call argument (`f(1, y=2)`)
+//!   lowers to `Expr::KeywordArg`.  Either declares `Feature::KeywordParams`.
 //!
-//! Collections / comprehensions / decorators / `*args` & **keyword**
-//! arguments are deferred to later milestones; unhandled forms return a
+//! Collections / comprehensions / decorators / `*args` & `**kwargs` rest
+//! parameters are deferred to later milestones; unhandled forms return a
 //! clear `PythonLowerError`.
 //!
 //! See `code/specs/SIR17-python-to-semantic-ir.md` for the full
@@ -1292,6 +1297,160 @@ mod tests {
         assert!(v.is_ok(), "partial call must validate: {:?}", v.issues);
     }
 
+    // ── keyword parameters & arguments (KW8) ──────────────────────────
+    //
+    // Def-side: a param after a bare `*` is keyword-only — `Keyword` kind,
+    // required (no default) or optional (with default).  Call-side: an
+    // explicit `name=value` argument lowers to `Expr::KeywordArg`, appended
+    // to `args` after positionals.  Both declare `Feature::KeywordParams`.
+
+    /// Locate the first `DirectCall` to `fn_name` in `main` (value or a
+    /// statement), returning its `args`.
+    fn direct_call_args<'a>(m: &'a semantic_ir::Module, fn_name: &str) -> &'a [Expr] {
+        if let Expr::DirectCall { fn_name: n, args, .. } = main_value(m) {
+            if n == fn_name {
+                return args;
+            }
+        }
+        for s in main_stmts(m) {
+            if let Stmt::ExprStmt { expr: Expr::DirectCall { fn_name: n, args, .. }, .. } = s {
+                if n == fn_name {
+                    return args;
+                }
+            }
+        }
+        panic!("no DirectCall to `{fn_name}` found in main");
+    }
+
+    #[test]
+    fn keyword_only_params_lower_to_keyword_kind() {
+        use semantic_ir::ParamKind;
+        // `def f(a, *, x, y=1)` — `a` positional (Required), `x` a REQUIRED
+        // keyword (Keyword + default None), `y` an OPTIONAL keyword
+        // (Keyword + default Some(1)).
+        let m = lower("def f(a, *, x, y=1):\n    return a\n");
+        let f = func(&m, "f");
+        assert_eq!(f.params.len(), 3);
+
+        assert_eq!(f.params[0].name, "a");
+        assert_eq!(f.params[0].kind, ParamKind::Required);
+        assert!(f.params[0].default.is_none());
+
+        assert_eq!(f.params[1].name, "x");
+        assert_eq!(f.params[1].kind, ParamKind::Keyword);
+        assert!(
+            f.params[1].default.is_none(),
+            "`x` (no default) is a REQUIRED keyword param"
+        );
+
+        assert_eq!(f.params[2].name, "y");
+        assert_eq!(f.params[2].kind, ParamKind::Keyword);
+        match f.params[2].default.as_deref() {
+            Some(Expr::IntLit { value, .. }) => assert_eq!(*value, 1),
+            other => panic!("expected y's default = IntLit(1), got {other:?}"),
+        }
+
+        // A keyword param declares KeywordParams in the manifest.
+        assert!(
+            m.manifest.contains(Feature::KeywordParams),
+            "a keyword parameter must declare KeywordParams"
+        );
+    }
+
+    #[test]
+    fn keyword_argument_lowers_to_keyword_arg() {
+        // `f(x=1)` → a single `KeywordArg { name: "x", value: IntLit(1) }`.
+        let m = lower("def f(a, *, x):\n    return a\n\nf(0, x=1)\n");
+        let args = direct_call_args(&m, "f");
+        assert_eq!(args.len(), 2, "one positional + one keyword arg");
+        assert!(
+            matches!(args[0], Expr::IntLit { value: 0, .. }),
+            "positional 0 stays bare"
+        );
+        match &args[1] {
+            Expr::KeywordArg { name, value, .. } => {
+                assert_eq!(name, "x");
+                assert!(matches!(**value, Expr::IntLit { value: 1, .. }));
+            }
+            other => panic!("expected KeywordArg, got {other:?}"),
+        }
+        assert!(
+            m.manifest.contains(Feature::KeywordParams),
+            "a keyword argument must declare KeywordParams"
+        );
+    }
+
+    #[test]
+    fn positional_and_keyword_argument_mix_preserves_order() {
+        // `f(1, y=2)` — positional `1` first (bare), keyword `y=2` after.
+        let m = lower("def f(a, *, y):\n    return a\n\nf(1, y=2)\n");
+        let args = direct_call_args(&m, "f");
+        assert_eq!(args.len(), 2);
+        assert!(matches!(args[0], Expr::IntLit { value: 1, .. }));
+        match &args[1] {
+            Expr::KeywordArg { name, value, .. } => {
+                assert_eq!(name, "y");
+                assert!(matches!(**value, Expr::IntLit { value: 2, .. }));
+            }
+            other => panic!("expected KeywordArg y=2, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn keyword_params_module_validates() {
+        // A keyword-param callee with a supplied required keyword + an
+        // omitted optional keyword round-trips through the validator.
+        let m = lower(
+            "def greet(greeting, *, name=\"world\"):\n    return greeting\n\ngreet(\"hi\", name=\"ada\")\n",
+        );
+        let v = semantic_ir::validate(&m);
+        assert!(
+            v.is_ok(),
+            "module with keyword params/args must validate: {:?}",
+            v.issues
+        );
+    }
+
+    #[test]
+    fn omitting_required_keyword_is_rejected_by_validator() {
+        // `x` is a REQUIRED keyword (no default); the call `need(0)` supplies
+        // no `x=…`, so the validator must reject the lowered module (rule 5:
+        // every required keyword must be supplied).
+        let m = lower("def need(a, *, x):\n    return a\n\nneed(0)\n");
+        let v = semantic_ir::validate(&m);
+        assert!(
+            !v.is_ok(),
+            "omitting a required keyword arg must fail validation"
+        );
+    }
+
+    #[test]
+    fn star_args_rest_param_is_rejected() {
+        // `*args` positional-rest is outside the KW8 subset — rejected with a
+        // positioned error (not silently dropped).  A leading positional is
+        // required for the parameter list to parse (v3.10's `parameter_list`
+        // opens with a mandatory positional `param_with_default`).
+        let err = compile_source("def f(a, *args, x):\n    return x\n", "t")
+            .expect_err("*args must be rejected");
+        assert!(
+            err.message.contains("*args") || err.message.contains("positional-rest"),
+            "got: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn double_star_kwargs_param_is_rejected() {
+        // `**kwargs` keyword-rest is outside the KW8 subset — rejected.
+        let err = compile_source("def f(a, **kw):\n    return a\n", "t")
+            .expect_err("**kwargs must be rejected");
+        assert!(
+            err.message.contains("**kwargs") || err.message.contains("keyword-rest"),
+            "got: {}",
+            err.message
+        );
+    }
+
     // ══════════════════════════════════════════════════════════════════
     // M5: collections — list & dict literals, subscript, len, set
     // ══════════════════════════════════════════════════════════════════
@@ -1853,6 +2012,34 @@ print(f(5, 100))
 ";
         if let Some(out) = run_roundtrip(src) {
             assert_eq!(out, "15\n105", "f(5)=15 then f(5,100)=105");
+        }
+    }
+
+    #[test]
+    fn e2e_keyword_parameter() {
+        // The KW8 acceptance check: a keyword-only param with a default,
+        // exercised both ways — `greet("hi")` omits the keyword (name ←
+        // "world") and `greet("hi", name="ada")` supplies it.  Lower →
+        // SIR → validate → emit Python (native keyword-only `def` +
+        // `name=value` call) → run → assert stdout, via the same
+        // PYTHONPATH-aware harness the P8 default-param e2e uses.
+        //
+        // The body returns `name` directly (rather than an f-string, which
+        // is outside the M5 subset) so the proof does not depend on string
+        // concatenation semantics — the value threaded by the keyword is
+        // exactly what is printed.
+        let src = "\
+def greet(greeting, *, name=\"world\"):
+    return name
+
+print(greet(\"hi\"))
+print(greet(\"hi\", name=\"ada\"))
+";
+        if let Some(out) = run_roundtrip(src) {
+            assert_eq!(
+                out, "world\nada",
+                "greet(\"hi\")=world then greet(\"hi\", name=\"ada\")=ada"
+            );
         }
     }
 

--- a/code/packages/rust/python-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/python-to-semantic-ir/src/lower.rs
@@ -157,7 +157,9 @@
 //!
 //! - collection *comprehensions* / *slicing* / *methods*      → deferred
 //!   (list & dict literals / index / `len` / subscript-assign land in M5)
-//! - `*args` / keyword & default arguments                    → deferred
+//! - `*args` / `**kwargs` rest parameters                      → deferred
+//!   (positional/keyword **default** params land in P8; keyword-only
+//!   params & keyword args land in KW8)
 //! - decorators / classes / `with` / `try` / generators       → deferred
 //! - `global` / `nonlocal`, multi-target assignment           → deferred
 //!
@@ -199,6 +201,14 @@ const MAX_BLOCK_DEPTH: usize = 256;
 /// is also recognised structurally inside `for` headers (M3); here it is
 /// a general expression-position builtin (`range(n)` outside a `for`).
 const BUILTIN_CALLS: &[&str] = &["print", "len", "range"];
+
+/// One extracted `def`-parameter spec: its name, its [`ParamKind`]
+/// (`Required` for a positional param, `Keyword` for a keyword-only one
+/// after the `*` boundary), and the still-unlowered CST node of its
+/// default value (`Some` for an optional param, `None` for a required
+/// one).  The default is borrowed from the `def` CST (lifetime `'a`) and
+/// lowered by the caller in the enclosing scope.
+type ParamSpec<'a> = (String, ParamKind, Option<&'a GrammarASTNode>);
 
 // ---------------------------------------------------------------------------
 // Public error type
@@ -1244,9 +1254,13 @@ impl Lowerer {
         // The bounded `lower_expr_in` reuses the `MAX_EXPR_DEPTH`-capped
         // expression walk, so a pathologically deep default fails cleanly.
         let specs = self.def_param_specs(def)?;
-        let mut params: Vec<(String, Option<Expr>)> = Vec::with_capacity(specs.len());
+        let mut params: Vec<(String, ParamKind, Option<Expr>)> = Vec::with_capacity(specs.len());
         let mut any_default = false;
-        for (pname, default_node) in specs {
+        let mut any_keyword = false;
+        for (pname, kind, default_node) in specs {
+            if kind == ParamKind::Keyword {
+                any_keyword = true;
+            }
             let default = match default_node {
                 Some(node) => {
                     any_default = true;
@@ -1254,13 +1268,19 @@ impl Lowerer {
                 }
                 None => None,
             };
-            params.push((pname, default));
+            params.push((pname, kind, default));
         }
         if any_default {
             // A `Param.default = Some(_)` is exactly what the validator
             // observes as `DefaultParams`; declare it here so the manifest
             // matches.
             self.observed.add(Feature::DefaultParams);
+        }
+        if any_keyword {
+            // A `Param.kind == Keyword` is exactly what the validator
+            // observes as `KeywordParams`; declare it so the manifest
+            // matches (mirrors the `DefaultParams` line above).
+            self.observed.add(Feature::KeywordParams);
         }
         let suite = self
             .first_child_named(def, "suite")
@@ -1270,14 +1290,49 @@ impl Lowerer {
         self.lower_callable(&name, &params, suite, enclosing, depth, span)
     }
 
-    /// Extract a `def_stmt`'s parameters as `(name, optional default-value
-    /// CST node)` pairs.
+    /// Extract a `def_stmt`'s parameters as `(name, kind, optional
+    /// default-value CST node)` triples.
     ///
-    /// A *plain* positional parameter (`a`) yields `(name, None)`.  A
-    /// *defaulted* one (`b = 10`) yields `(name, Some(<expression node>))`
-    /// — the `param_with_default` node carries an extra `=` token and an
+    /// A *plain* positional parameter (`a`) yields
+    /// `(name, ParamKind::Required, None)`.  A *defaulted* one (`b = 10`)
+    /// yields `(name, ParamKind::Required, Some(<expression node>))` — the
+    /// `param_with_default` node carries an extra `=` token and an
     /// `expression` child, which the caller lowers (in the **enclosing**
     /// scope) into the IR's `Param.default`.
+    ///
+    /// ## The keyword-only `*` boundary (KW8)
+    ///
+    /// Python's grammar splits a parameter list at a bare `*` (or `*args`):
+    /// every parameter that follows is **keyword-only** — it can only be
+    /// supplied by name at the call site.  The parser models this split
+    /// structurally: positional params are `param_with_default` children of
+    /// `parameter_list` **directly**, while the keyword-only params live as
+    /// `param_with_default` children of a nested **`star_params`** node
+    /// (`* [NAME] (, param_with_default)*  [, double_star_param]`).  So the
+    /// `*`-boundary is not a token we hunt for — it is *the tree shape*:
+    ///
+    /// ```text
+    ///   def f(a, *, x, y=1):
+    ///   parameter_list
+    ///     param_with_default(a)          ← positional  → Required
+    ///     star_params
+    ///       *                            ← the boundary marker
+    ///       param_with_default(x)        ← keyword-only → Keyword, default None
+    ///       param_with_default(y=1)      ← keyword-only → Keyword, default Some(1)
+    /// ```
+    ///
+    /// We therefore emit `ParamKind::Required` for every `param_with_default`
+    /// that is a *direct* child of `parameter_list`, and `ParamKind::Keyword`
+    /// for every `param_with_default` nested inside a `star_params`.  A
+    /// keyword param with no default (`x`) is a **required** keyword; one
+    /// with a default (`y=1`) is an **optional** keyword — the required-ness
+    /// rides entirely on the `default` field, exactly as it does for
+    /// positional optionals (there is no separate "is-required" flag).
+    ///
+    /// The `*args` positional-rest name and the `**kwargs` keyword-rest that
+    /// may bracket the keyword-only region are outside the KW8 subset (the
+    /// crate does not yet model `Rest`/`KwRest` params) and are rejected
+    /// with a positioned error rather than silently dropped.
     ///
     /// ## Python def-time semantics vs. the IR's call-time model
     ///
@@ -1294,23 +1349,97 @@ impl Lowerer {
     fn def_param_specs<'a>(
         &self,
         def: &'a GrammarASTNode,
-    ) -> Result<Vec<(String, Option<&'a GrammarASTNode>)>, PythonLowerError> {
+    ) -> Result<Vec<ParamSpec<'a>>, PythonLowerError> {
         let parameters = match self.first_child_named(def, "parameters") {
             Some(p) => p,
             None => return Ok(vec![]), // `def f():` — no params.
         };
-        // `parameters → parameter_list → param_with_default+`.
+        // `parameters → parameter_list → param_with_default+ [star_params]`.
         let list = self
             .first_child_named(parameters, "parameter_list")
             .unwrap_or(parameters);
         let mut specs = Vec::new();
-        for pwd in child_nodes(list) {
-            if pwd.rule_name != "param_with_default" {
-                continue;
+        for child in child_nodes(list) {
+            match child.rule_name.as_str() {
+                // Positional param (before any `*`): Required.
+                "param_with_default" => {
+                    let (name, default) = self.param_spec(child)?;
+                    specs.push((name, ParamKind::Required, default));
+                }
+                // Everything after a bare `*` / `*args` is keyword-only.
+                // The `star_params` node holds the boundary `*`, an
+                // optional `*args` NAME, the keyword-only params, and an
+                // optional `**kwargs`.
+                "star_params" => self.collect_keyword_only_params(child, &mut specs)?,
+                // `slash_params` (positional-only `/`) is not in the KW8
+                // subset — reject rather than mis-lower its params.
+                "slash_params" => {
+                    return Err(self.err_at(
+                        child,
+                        "unsupported: positional-only `/` parameters (deferred)".to_string(),
+                    ))
+                }
+                // A top-level `**kwargs` (no preceding `*`) — KwRest is not
+                // modelled by this crate yet.
+                "double_star_param" => {
+                    return Err(self.err_at(
+                        child,
+                        "unsupported: **kwargs keyword-rest parameter (deferred)".to_string(),
+                    ))
+                }
+                _ => {}
             }
-            specs.push(self.param_spec(pwd)?);
         }
         Ok(specs)
+    }
+
+    /// Harvest the keyword-only parameters out of a `star_params` node,
+    /// appending `(name, ParamKind::Keyword, default)` for each.
+    ///
+    /// A `star_params` looks like `* [NAME] (, param_with_default)* [, **kw]`.
+    /// The leading `*` is the keyword-only boundary; an optional bare NAME
+    /// immediately after it is the `*args` positional-rest, which this crate
+    /// does not yet model — its presence is rejected.  Any nested
+    /// `double_star_param` (`**kwargs`) is likewise rejected.  Every
+    /// `param_with_default` **inside** this node is keyword-only, so it maps
+    /// to `ParamKind::Keyword` (required if it has no default, optional if
+    /// it does).
+    fn collect_keyword_only_params<'a>(
+        &self,
+        star: &'a GrammarASTNode,
+        specs: &mut Vec<ParamSpec<'a>>,
+    ) -> Result<(), PythonLowerError> {
+        for child in &star.children {
+            match child {
+                // A bare NAME token directly under `star_params` is the
+                // `*args` rest name (`def f(*args, x): …`).  Rest params are
+                // outside the KW8 subset.
+                ASTNodeOrToken::Token(t)
+                    if matches!(t.type_, lexer::token::TokenType::Name)
+                        && t.type_name.is_none() =>
+                {
+                    return Err(self.err_at(
+                        star,
+                        "unsupported: *args positional-rest parameter (deferred)".to_string(),
+                    ))
+                }
+                ASTNodeOrToken::Token(_) => {} // `*` / `,` separators.
+                ASTNodeOrToken::Node(n) => match n.rule_name.as_str() {
+                    "param_with_default" => {
+                        let (name, default) = self.param_spec(n)?;
+                        specs.push((name, ParamKind::Keyword, default));
+                    }
+                    "double_star_param" => {
+                        return Err(self.err_at(
+                            n,
+                            "unsupported: **kwargs keyword-rest parameter (deferred)".to_string(),
+                        ))
+                    }
+                    _ => {}
+                },
+            }
+        }
+        Ok(())
     }
 
     /// Extract one parameter's `(name, optional default node)` from a
@@ -1320,14 +1449,22 @@ impl Lowerer {
     ///   - plain `a`     → `[NAME]`                       → `(name, None)`
     ///   - default `b=1` → `[NAME, EQUALS, expression]`   → `(name, Some(expr))`
     ///
-    /// Only positional defaults are modelled here; keyword-only markers and
-    /// `*args` / `**kwargs` never reach this rule in the M5 subset.
+    /// This is `ParamKind`-agnostic: the caller stamps `Required` (a direct
+    /// `parameter_list` child) or `Keyword` (nested in `star_params`) onto
+    /// the result.  A type-annotation `COLON expression` (`def f(a: int)`)
+    /// is not in the subset, but were one present its `expression` child
+    /// would be mistaken for a default — so we bind `default` only to the
+    /// `expression` that follows an `EQUALS` token.
     fn param_spec<'a>(
         &self,
         pwd: &'a GrammarASTNode,
     ) -> Result<(String, Option<&'a GrammarASTNode>), PythonLowerError> {
         let mut name: Option<String> = None;
         let mut default: Option<&GrammarASTNode> = None;
+        // Only the `expression` that follows an `=` is a default.  We track
+        // whether the last token seen was `=` so a (subset-external) type
+        // annotation `NAME : expression` could never be mistaken for one.
+        let mut seen_equals = false;
         for child in &pwd.children {
             match child {
                 ASTNodeOrToken::Token(t) => {
@@ -1336,14 +1473,16 @@ impl Lowerer {
                         && name.is_none()
                     {
                         name = Some(t.value.clone());
+                    } else if matches!(t.type_, lexer::token::TokenType::Equals) {
+                        seen_equals = true;
                     }
-                    // The `=` token is the marker only; the value that
-                    // follows is the `expression` node captured below.
                 }
-                // The default-value `expression` node (present only for a
-                // `name = expr` parameter).
+                // The default-value `expression` node — present only once an
+                // `=` has been seen (`name = expr`).
                 ASTNodeOrToken::Node(n) => {
-                    default = Some(n);
+                    if seen_equals {
+                        default = Some(n);
+                    }
                 }
             }
         }
@@ -1388,10 +1527,13 @@ impl Lowerer {
             value,
             span: span.clone(),
         };
-        // Lambdas in the M5 subset never carry defaults (rejected in
-        // `lambda_params`), so every param maps to `(name, None)`.
-        let lambda_params: Vec<(String, Option<Expr>)> =
-            params.iter().map(|n| (n.clone(), None)).collect();
+        // Lambdas in the M5 subset never carry defaults or keyword-only
+        // markers (both rejected in `lambda_params`), so every param maps to
+        // `(name, Required, None)`.
+        let lambda_params: Vec<(String, ParamKind, Option<Expr>)> = params
+            .iter()
+            .map(|n| (n.clone(), ParamKind::Required, None))
+            .collect();
         self.push_function(&fn_name, &lambda_params, &captures, body, span.clone());
 
         // A lambda always yields a retained closure value.
@@ -1442,7 +1584,7 @@ impl Lowerer {
     fn lower_callable(
         &mut self,
         name: &str,
-        params: &[(String, Option<Expr>)],
+        params: &[(String, ParamKind, Option<Expr>)],
         suite: &GrammarASTNode,
         enclosing: &mut FunctionCtx,
         depth: usize,
@@ -1454,7 +1596,7 @@ impl Lowerer {
         // a default expression sees the *enclosing* scope (it was already
         // lowered there by the caller), so it never contributes to the
         // body's free/bound sets here.
-        let mut bound: HashSet<String> = params.iter().map(|(n, _)| n.clone()).collect();
+        let mut bound: HashSet<String> = params.iter().map(|(n, _, _)| n.clone()).collect();
         self.collect_suite_bound_names(suite, &mut bound)?;
         let mut free = Vec::new();
         let mut seen = HashSet::new();
@@ -1464,7 +1606,7 @@ impl Lowerer {
 
         // ── Lower the body in the function's own context. ──
         let mut inner = FunctionCtx::new(
-            params.iter().map(|(n, _)| n.clone()).collect(),
+            params.iter().map(|(n, _, _)| n.clone()).collect(),
             captures.iter().cloned().collect(),
         );
         let body = self.lower_function_suite(suite, &mut inner, depth + 1)?;
@@ -1479,7 +1621,7 @@ impl Lowerer {
     fn push_function(
         &mut self,
         name: &str,
-        params: &[(String, Option<Expr>)],
+        params: &[(String, ParamKind, Option<Expr>)],
         captures: &[String],
         body: Block,
         span: Span,
@@ -1503,14 +1645,17 @@ impl Lowerer {
             name: name.to_string(),
             params: params
                 .iter()
-                .map(|(pname, default)| Param {
+                .map(|(pname, kind, default)| Param {
                     name: pname.clone(),
                     sir_type: None,
-                    // A defaulted positional param keeps `Required` kind —
-                    // `ParamKind` distinguishes only `Required`/`Rest`/
-                    // `KwRest`; the presence of a default lives in
-                    // `default`, not the kind.
-                    kind: ParamKind::Required,
+                    // The `kind` is decided by the parameter's position
+                    // relative to the keyword-only `*` boundary: `Required`
+                    // for a positional param (a direct `parameter_list`
+                    // child) and `Keyword` for a keyword-only one (nested in
+                    // `star_params`).  Required-vs-optional does NOT ride on
+                    // the kind — it rides on `default` (a positional or
+                    // keyword param with `default: Some(_)` is optional).
+                    kind: *kind,
                     default: default.clone().map(Box::new),
                     span: span.clone(),
                 })
@@ -1758,12 +1903,14 @@ impl Lowerer {
                 inner.insert(n);
             }
             if let Ok(specs) = self.def_param_specs(node) {
-                for (pname, default_node) in specs {
+                for (pname, _kind, default_node) in specs {
                     // A *default expression* is evaluated in the **enclosing**
                     // scope (Python def-time semantics), so any name it
                     // references is free against the *outer* `bound` set — not
                     // shadowed by the params.  Collect those before adding the
-                    // param itself to `inner`.
+                    // param itself to `inner`.  The keyword-only `_kind` does
+                    // not affect free-variable analysis (a keyword param binds
+                    // its name in the body exactly as a positional one does).
                     if let Some(default) = default_node {
                         self.collect_free_names(default, bound, free, seen, depth + 1)?;
                     }
@@ -2356,6 +2503,37 @@ impl Lowerer {
     }
 
     /// Lower the argument expressions of a call `suffix` (`( a, b, … )`).
+    ///
+    /// ## Keyword arguments (KW8) — `f(1, y=2)`
+    ///
+    /// The grammar gives an `argument` node one of four shapes; the two that
+    /// matter here are
+    ///
+    /// ```text
+    ///   argument → expression                 (a POSITIONAL argument)
+    ///   argument → NAME EQUALS expression      (a KEYWORD argument: `y=2`)
+    /// ```
+    ///
+    /// A positional argument lowers to its bare `Expr` (unchanged from
+    /// before).  A keyword argument lowers to an [`Expr::KeywordArg`] wrapper
+    /// `{ name, value }` that carries the parameter *name* alongside the
+    /// lowered value, and is appended to the same `args` vec — the core IR
+    /// models keyword arguments as ordinary `args` elements that trail the
+    /// positionals (the validator enforces the trailing rule), rather than a
+    /// parallel `kwargs` field.  Whenever any keyword argument is produced we
+    /// declare [`Feature::KeywordParams`] so the manifest matches what the
+    /// validator observes.
+    ///
+    /// ## Keyword arg vs. `**dict` splat — a deliberate distinction
+    ///
+    /// Only the explicit `NAME = value` spelling becomes a `KeywordArg`.  The
+    /// grammar's other two `argument` forms — `STAR expression` (`*seq`) and
+    /// `DOUBLE_STAR expression` (`**dict`, keyword-rest splat) — are NOT
+    /// keyword arguments: `**dict` names no single parameter, it unpacks a
+    /// mapping.  Those splat forms keep their existing (subset-external)
+    /// treatment via [`Self::single_arg_expr`], which returns the inner
+    /// `expression`; we detect the `NAME EQUALS` shape *first* by the leading
+    /// NAME + `=` tokens so a `**dict` never masquerades as a keyword arg.
     fn lower_call_args(
         &mut self,
         suffix: &GrammarASTNode,
@@ -2365,10 +2543,63 @@ impl Lowerer {
         let arg_nodes = self.call_arguments(suffix);
         let mut args = Vec::with_capacity(arg_nodes.len());
         for a in &arg_nodes {
-            let e = self.single_arg_expr(a)?;
-            args.push(self.lower_expr_d(e, ctx, depth + 1)?);
+            match self.keyword_arg_name(a) {
+                // `NAME = expression` → a keyword argument.
+                Some(kw_name) => {
+                    let value_node = self.single_arg_expr(a)?;
+                    let value = self.lower_expr_d(value_node, ctx, depth + 1)?;
+                    let span = self.span_of(a);
+                    self.observed.add(Feature::KeywordParams);
+                    args.push(Expr::KeywordArg {
+                        name: kw_name,
+                        value: Box::new(value),
+                        span,
+                    });
+                }
+                // A bare positional argument (or a `*`/`**` splat, whose
+                // token is dropped by `single_arg_expr` — unchanged v0).
+                None => {
+                    let e = self.single_arg_expr(a)?;
+                    args.push(self.lower_expr_d(e, ctx, depth + 1)?);
+                }
+            }
         }
         Ok(args)
+    }
+
+    /// If this `argument` node is the keyword form `NAME EQUALS expression`,
+    /// return the keyword name; otherwise `None`.
+    ///
+    /// The CST for `y=2` is `argument[ NAME("y"), EQUALS, expression ]`.  We
+    /// require **both** a leading bare `NAME` token and an `EQUALS` token so
+    /// that neither a positional `expression` (whose first descendant may be
+    /// a NAME atom, but which has no `EQUALS` *token child of the argument*)
+    /// nor a `**dict` splat (a `DOUBLE_STAR` token, no `EQUALS`) is ever
+    /// mistaken for a keyword argument.
+    fn keyword_arg_name(&self, arg: &GrammarASTNode) -> Option<String> {
+        let mut name: Option<String> = None;
+        let mut has_equals = false;
+        for child in &arg.children {
+            match child {
+                ASTNodeOrToken::Token(t)
+                    if matches!(t.type_, lexer::token::TokenType::Name)
+                        && t.type_name.is_none()
+                        && name.is_none() =>
+                {
+                    name = Some(t.value.clone());
+                }
+                ASTNodeOrToken::Token(t)
+                    if matches!(t.type_, lexer::token::TokenType::Equals) =>
+                {
+                    has_equals = true;
+                }
+                _ => {}
+            }
+        }
+        match (name, has_equals) {
+            (Some(n), true) => Some(n),
+            _ => None,
+        }
     }
 
     /// Lower a subscript `suffix` (`[ index ]`) applied to `base`,


### PR DESCRIPTION
## What

**KW8** — the Python frontend now lowers keyword-only parameters (`def f(a, *, x, y=1)`) to `ParamKind::Keyword` and keyword arguments (`f(x=1)`) to `Expr::KeywordArg`. Completes the keyword-params cascade. Design: `code/specs/sir-keyword-params.md`.

## What it does

- **Def side:** the parser models the `*` boundary structurally — keyword-only `param_with_default` nodes nest inside a `star_params` node. `def_param_specs` walks both, stamping `ParamKind::Keyword` (required if no default, optional if defaulted) vs `Required` for pre-`*` positionals. The param-spec tuple grew to `ParamSpec = (String, ParamKind, Option<Expr>)` threaded through `lower_def`/`lower_callable`/`push_function`.
- **Call side:** `f(1, y=2)` → `Expr::KeywordArg{name, value}` after positionals, detected by a leading `NAME` + `Equals` token (so `**dict` splats and positionals are never misclassified).
- `Feature::KeywordParams` declared whenever produced. `*args`/`**kwargs` remain clean positioned errors (this crate doesn't model Rest/KwRest — no regression).

## Verification

- `cargo test -p python-to-semantic-ir` — **122 passed** (+8: exact param-vector lowering, KeywordArg, positional+keyword order, validator round-trip, omitted-required-keyword rejection, `*args`/`**kwargs` rejection, e2e).
- **End-to-end execution-proof (python3):** `def greet(greeting, *, name="world"): return name` round-tripped Python → SIR → Python and ran: `greet("hi")` → `world` (default), `greet("hi", name="ada")` → `ada`.
- Clippy clean; `cargo build --workspace` clean (bar the pre-existing Unix-only crate).
- **Security review passed:** depth-guarded lowering (no ReDoS/unbounded recursion), no panics on untrusted input (positioned errors, not unwrap), feature-gating validator-enforced, correct keyword-vs-splat/positional classification, safe shell-less e2e subprocess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)