### PR TITLE
feat(latex): down-barb & under harpoon accents (complete the harpoon family)

### DIFF
--- a/code/packages/rust/latex/CHANGELOG.md
+++ b/code/packages/rust/latex/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to the full-fidelity LaTeX parser crate.
 
+## [0.23.0] — 2026-06-30
+
+### Added — down-barb & under harpoon accents (completing the harpoon accent family)
+
+- **Down-barb over-harpoons** (`harpoon` package) — `\overrightharpoondown`, `\overleftharpoondown`,
+  the down-barb siblings of the existing up-barb `\overrightharpoonup`/`\overleftharpoonup`. Added
+  to `over_arrow_base`, lowering onto `Overset` over the standard amsmath ⇁/↽ relation symbols.
+- **Under-harpoons** (`harpoon` package) — `\underrightharpoonup`, `\underleftharpoonup`,
+  `\underrightharpoondown`, `\underleftharpoondown`, the under-body mirror of the over-harpoons.
+  Added to `under_arrow_base`, lowering onto `Underset` over the plain harpoon symbol.
+
+Both extend the two existing base-name tables (no new machinery, no new AST node, no frontend
+change); `to_latex` round-trips through `\overset`/`\underset` over the plain harpoon symbol (an
+unknown control word re-parses to a `Sym`). Missing `{body}` is a clean spanned error. With the
+prior `\overrightharpoonup`/`\overleftharpoonup` and the `\underrightarrow` family, the crate now
+covers all four over/under × up/down harpoon accents.
+
 ## [0.22.0] — 2026-06-30
 
 ### Added — stretchy UNDER-arrow accents (the mirror of the over-arrow family)

--- a/code/packages/rust/latex/Cargo.toml
+++ b/code/packages/rust/latex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latex"
-version = "0.22.0"
+version = "0.23.0"
 edition = "2021"
 description = "A full-fidelity LaTeX parser (documents and math): a catcode-driven, text-mode-primary tokenizer and (in later layers) a structural + math parser producing a faithful AST. Standalone and reusable; will also implement the math-frontend MathFrontend trait."
 license = "MIT"

--- a/code/packages/rust/latex/src/math.rs
+++ b/code/packages/rust/latex/src/math.rs
@@ -380,6 +380,10 @@ fn over_arrow_base(name: &str) -> Option<&'static str> {
         "overleftrightarrow" => "leftrightarrow",
         "overrightharpoonup" => "rightharpoonup",
         "overleftharpoonup" => "leftharpoonup",
+        // Down-barb harpoon accents (the `harpoon` package) — the down-barb siblings of the
+        // up-barb over-harpoons above, over the standard amsmath ⇁/↽ relation symbols.
+        "overrightharpoondown" => "rightharpoondown",
+        "overleftharpoondown" => "leftharpoondown",
         _ => return None,
     })
 }
@@ -396,11 +400,19 @@ fn over_arrow_base(name: &str) -> Option<&'static str> {
 ///   \underrightarrow{AB}      → Underset{→,  AB}
 ///   \underleftarrow{AB}       → Underset{←,  AB}
 ///   \underleftrightarrow{AB}  → Underset{↔, AB}
+///
+/// The under-HARPOON accents (`harpoon` package) are the under-body mirror of the over-harpoons in
+/// [`over_arrow_base`]: `\underrightharpoonup{AB}` → `Underset{⇀, AB}`, etc., over the standard
+/// amsmath harpoon relation symbols (both up- and down-barb variants).
 fn under_arrow_base(name: &str) -> Option<&'static str> {
     Some(match name {
         "underrightarrow" => "rightarrow",
         "underleftarrow" => "leftarrow",
         "underleftrightarrow" => "leftrightarrow",
+        "underrightharpoonup" => "rightharpoonup",
+        "underleftharpoonup" => "leftharpoonup",
+        "underrightharpoondown" => "rightharpoondown",
+        "underleftharpoondown" => "leftharpoondown",
         _ => return None,
     })
 }
@@ -2355,6 +2367,52 @@ mod tests {
     fn under_arrow_missing_mandatory_body_is_a_spanned_error() {
         // The `{body}` is mandatory; a trailing command with no argument is a clean error.
         assert!(parse_math(r"\underrightarrow").is_err());
+    }
+
+    // ---- down-barb & under harpoon accents (the `harpoon` package) ---------------
+
+    #[test]
+    fn down_barb_over_harpoons_set_their_symbol_over_the_body() {
+        // The down-barb over-harpoons are the siblings of the up-barb ones, set OVER the body.
+        for (src, sym_name) in [
+            (r"\overrightharpoondown{x}", "rightharpoondown"),
+            (r"\overleftharpoondown{y}", "leftharpoondown"),
+        ] {
+            match &parse_math(src).unwrap() {
+                MathNode::Overset { over, .. } => assert_eq!(**over, sym(sym_name), "{src}"),
+                other => panic!("expected Overset for {src}, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn under_harpoons_set_their_symbol_under_the_body() {
+        // Both barb directions of the under-harpoon accents lower onto Underset.
+        for (src, sym_name) in [
+            (r"\underrightharpoonup{a}", "rightharpoonup"),
+            (r"\underleftharpoonup{b}", "leftharpoonup"),
+            (r"\underrightharpoondown{c}", "rightharpoondown"),
+            (r"\underleftharpoondown{d}", "leftharpoondown"),
+        ] {
+            match &parse_math(src).unwrap() {
+                MathNode::Underset { under, .. } => assert_eq!(**under, sym(sym_name), "{src}"),
+                other => panic!("expected Underset for {src}, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn harpoon_accents_round_trip_through_to_latex() {
+        for src in [
+            r"\overrightharpoondown{x}",
+            r"\overleftharpoondown{y}",
+            r"\underrightharpoonup{a}",
+            r"\underleftharpoondown{d}",
+        ] {
+            let once = parse_math(src).unwrap();
+            let twice = parse_math(&once.to_latex()).unwrap();
+            assert_eq!(once, twice, "round-trip changed the tree for {src:?}");
+        }
     }
 
     // ---- deep-tree Drop safety -------------------------------------------------


### PR DESCRIPTION
## What

Adds the six harpoon-accent commands (the `harpoon` package) that were missing next to the existing up-barb over-harpoons, **completing all four over/under × up/down harpoon accents**:

| command | position | lowers to |
|---------|----------|-----------|
| `\overrightharpoondown` / `\overleftharpoondown` | down-barb, over body | `Overset` over ⇁ / ↽ |
| `\underrightharpoonup` / `\underleftharpoonup` | up-barb, under body | `Underset` over ⇀ / ↼ |
| `\underrightharpoondown` / `\underleftharpoondown` | down-barb, under body | `Underset` over ⇁ / ↽ |

## How it fits

Each is the mirror/sibling of an already-supported accent and lowers onto the **existing `Overset`/`Underset` node** over the standard amsmath harpoon relation symbol — **no new machinery, no new AST node, no frontend change**. They just extend the two existing base-name tables (`over_arrow_base` / `under_arrow_base`), exactly as the merged over-harpoon (#7172) and under-arrow (#7178) accents did.

`to_latex` round-trips through `\overset`/`\underset` over the plain harpoon symbol — an unknown control word re-parses to a `Sym`, so `\rightharpoondown` etc. need no explicit symbol-table entry. Missing `{body}` is a clean spanned error.

## Tests

3 new tests (down-barb over-harpoons → Overset, all four under-harpoons → Underset, round-trip fixed-point). **193 latex tests pass; clippy clean.**

## Security

Security review **PASSED** — O(1) literal match arms reusing the already-audited `read_arg()?` / MAX_DEPTH path; no `unsafe`, no I/O, no new attack surface.

latex `0.22.0` → `0.23.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)