### PR TITLE
feat(fold-control-flow): CV tombstones for ternary-arm collapse (#89 follow-up)

### DIFF
--- a/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to the `coding-adventures-closure-pass-fold-control-flow` crate will be documented in this file.
 
+## [0.17.0] - 2026-06-30
+
+### Added — CV tombstones for constant-condition ternary collapse (#89 follow-up)
+
+Closes the second and final follow-up noted in 0.15.0 (the first, block dead-code,
+landed in 0.16.0). When `fold_conditional` collapses a `cond ? c : a` whose
+`cond` is a literal, the unreachable arm — an **`Expression`**, not a statement —
+is now tombstoned via the existing `record_fold_deleting`, matching what the
+`if`/`while` branch eliminations already do:
+
+- `(<truthy literal>) ? c : a` → `c` — the **`a`** (alternate) arm is tombstoned;
+- `(<falsy literal>)  ? c : a` → `a` — the **`c`** (consequent) arm is tombstoned.
+
+New helper `expression_cv` (the `Expression` analogue of `statement_cv`) — an
+exhaustive match over all 16 expression variants, so a new expression kind fails
+to compile rather than silently losing provenance.
+
+The `de-morgan-swap-not-ternary` rewrite (`!x ? c : a` → `x ? a : c`) deliberately
+does NOT tombstone — both arms are preserved, just swapped — and keeps plain
+`record_fold`.
+
+Byte-for-byte identical AST output; only the CV log gains the deletion records.
+`delete` is a no-op when the log is disabled (production default). Two new tests
+(true-arm and false-arm tombstoning). 38 unit + 13 upstream all green. Crate
+0.16.0 → 0.17.0. With this, **every** elimination site in the pass records
+deletion provenance.
+
 ## [0.16.0] - 2026-06-30
 
 ### Added — CV tombstones for block dead-code-after-terminator (#89 follow-up)

--- a/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
+++ b/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-fold-control-flow"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 description = "Control-flow folding pass for the Closure Compiler clone. Slots between constant-fold and DCE per CLOC06's canonical pass set. Eliminates dead branches (`if (false) A else B → B`), removes unreachable code after `return`/`throw`, and collapses degenerate switch arms."
 

--- a/code/packages/rust/closure-pass-fold-control-flow/README.md
+++ b/code/packages/rust/closure-pass-fold-control-flow/README.md
@@ -87,13 +87,16 @@ vanishing from the provenance graph:
 - `{ return; dead(); }` → `{ return; }` — the unreachable
   dead-after-terminator statements are tombstoned (`removed-dead-code`),
   matching what DCE records for the same drop.
+- `(<literal>) ? c : a` — the unreachable **arm** (an `Expression`) is
+  tombstoned via the `expression_cv` helper: a truthy `cond` discards
+  `a`, a falsy `cond` discards `c`.
 
 Rewrites that *preserve* both branches (`if→ternary`, `if→&&`, De Morgan
-swaps) do NOT tombstone — the content is restructured, not removed.
-`delete` is a no-op when the log is disabled (the production default),
-so this costs nothing off the `--correlation_vector` path. (Remaining
-follow-up: the constant-condition ternary collapse, whose discarded arm
-is an `Expression` and needs an `expression_cv` helper.)
+swaps — including `de-morgan-swap-not-ternary`) do NOT tombstone — the
+content is restructured, not removed. `delete` is a no-op when the log is
+disabled (the production default), so this costs nothing off the
+`--correlation_vector` path. **Every** elimination site in the pass now
+records deletion provenance.
 
 ## Dependency whitelist
 

--- a/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
+++ b/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
@@ -247,6 +247,36 @@ fn tagged_statement_cv(t: &TaggedStatement) -> Option<String> {
     }
 }
 
+/// Fetch an expression's own correlation-vector id, if it carries one.
+///
+/// The ternary-collapse site (`fold_conditional`) discards one *arm* of a
+/// `cond ? c : a` when `cond` is a literal — an `Expression`, not a
+/// statement — so it needs this alongside [`statement_cv`] to tombstone
+/// the exact expression that vanished. Exhaustive on purpose (no `_`
+/// wildcard): a new expression kind added upstream fails to compile here
+/// rather than silently losing provenance.
+fn expression_cv(expr: &Expression) -> Option<String> {
+    use Expression::*;
+    match expr {
+        Identifier(e) => e.cv.clone(),
+        NumericLiteral(e) => e.cv.clone(),
+        StringLiteral(e) => e.cv.clone(),
+        BooleanLiteral(e) => e.cv.clone(),
+        NullLiteral(e) => e.cv.clone(),
+        BigIntLiteral(e) => e.cv.clone(),
+        UndefinedLiteral(e) => e.cv.clone(),
+        BinaryExpression(e) => e.cv.clone(),
+        LogicalExpression(e) => e.cv.clone(),
+        UnaryExpression(e) => e.cv.clone(),
+        AssignmentExpression(e) => e.cv.clone(),
+        ConditionalExpression(e) => e.cv.clone(),
+        CallExpression(e) => e.cv.clone(),
+        MemberExpression(e) => e.cv.clone(),
+        ArrayExpression(e) => e.cv.clone(),
+        ObjectExpression(e) => e.cv.clone(),
+    }
+}
+
 // =====================================================================
 // Program / top-level
 // =====================================================================
@@ -1433,8 +1463,12 @@ fn fold_conditional(c: &ConditionalExpression, st: &mut FoldState) -> Expression
 
     match literal_truthy(&test) {
         Some(true) => {
-            st.record_fold(
+            // The `alternate` arm is statically unreachable and is
+            // discarded — tombstone it so its span stays auditable.
+            let discarded = [expression_cv(&alternate)];
+            st.record_fold_deleting(
                 &c.cv,
+                &discarded,
                 "folded-branch",
                 "(<truthy literal>) ? … : …",
                 "consequent",
@@ -1442,8 +1476,12 @@ fn fold_conditional(c: &ConditionalExpression, st: &mut FoldState) -> Expression
             consequent
         }
         Some(false) => {
-            st.record_fold(
+            // The `consequent` arm is statically unreachable and is
+            // discarded — tombstone it so its span stays auditable.
+            let discarded = [expression_cv(&consequent)];
+            st.record_fold_deleting(
                 &c.cv,
+                &discarded,
                 "folded-branch",
                 "(<falsy literal>) ? … : …",
                 "alternate",
@@ -1723,6 +1761,63 @@ mod tests {
             log.get(&a_id).unwrap().deleted.is_none(),
             "the alternate is preserved in the ternary, not discarded"
         );
+    }
+
+    #[test]
+    fn ternary_true_tombstones_discarded_alternate_arm() {
+        // `true ? kept : dead` → `kept` — the `dead` alternate arm is
+        // statically unreachable and eliminated, so it must be tombstoned.
+        let mut log = CVLog::new(true);
+        let dead_id = log.create(None);
+        let ternary = Expression::ConditionalExpression(ConditionalExpression {
+            cv: Some("tern.1".to_string()),
+            test: Box::new(boolean(true, None)),
+            consequent: Box::new(ident("kept")),
+            alternate: Box::new(Expression::Identifier(Identifier {
+                cv: Some(dead_id.clone()),
+                name: "dead".to_string(),
+            })),
+        });
+        let prog = program().with_body(vec![ProgramItem::Statement(expr_stmt(ternary, None))]);
+
+        let _out = run_capturing_cv(&prog, &mut log);
+
+        let del = log
+            .get(&dead_id)
+            .unwrap()
+            .deleted
+            .as_ref()
+            .expect("the discarded ternary `alternate` arm must be tombstoned");
+        assert_eq!(del.source, "fold-control-flow");
+        assert_eq!(del.reason, "folded-branch");
+    }
+
+    #[test]
+    fn ternary_false_tombstones_discarded_consequent_arm() {
+        // `false ? dead : kept` → `kept` — the `dead` consequent arm is
+        // statically unreachable and eliminated, so it must be tombstoned.
+        let mut log = CVLog::new(true);
+        let dead_id = log.create(None);
+        let ternary = Expression::ConditionalExpression(ConditionalExpression {
+            cv: Some("tern.2".to_string()),
+            test: Box::new(boolean(false, None)),
+            consequent: Box::new(Expression::Identifier(Identifier {
+                cv: Some(dead_id.clone()),
+                name: "dead".to_string(),
+            })),
+            alternate: Box::new(ident("kept")),
+        });
+        let prog = program().with_body(vec![ProgramItem::Statement(expr_stmt(ternary, None))]);
+
+        let _out = run_capturing_cv(&prog, &mut log);
+
+        let del = log
+            .get(&dead_id)
+            .unwrap()
+            .deleted
+            .as_ref()
+            .expect("the discarded ternary `consequent` arm must be tombstoned");
+        assert_eq!(del.reason, "folded-branch");
     }
 
     // ---------------- metadata + identity ---------------------


### PR DESCRIPTION
## Why
Closes the second and final follow-up noted in the fold-control-flow CV work (branch eliminations in [#7171](https://github.com/adhithyan15/coding-adventures/pull/7171), block dead-code in [#7179](https://github.com/adhithyan15/coding-adventures/pull/7179)). This one covers the **constant-condition ternary collapse**, whose discarded arm is an `Expression` (not a statement) and so needed a new accessor.

## What
When `fold_conditional` collapses a `cond ? c : a` whose `cond` is a literal, the unreachable arm is now tombstoned via the existing `record_fold_deleting`:

| fold | discarded arm tombstoned |
|---|---|
| `(<truthy literal>) ? c : a` → `c` | **`a`** (alternate) |
| `(<falsy literal>)  ? c : a` → `a` | **`c`** (consequent) |

New helper `expression_cv` — the `Expression` analogue of `statement_cv`, an exhaustive match over all 16 expression variants (a new expression kind fails to compile rather than silently losing provenance).

The `de-morgan-swap-not-ternary` rewrite (`!x ? c : a` → `x ? a : c`) deliberately does **not** tombstone — both arms are preserved, just swapped.

**With this, every elimination site in the pass records deletion provenance.**

## Safety
- **Byte-for-byte identical AST output** — same arm folded; only the CV log gains the deletion record.
- **Zero cost off the hot path** — `delete` is a no-op when the log is disabled (production default).
- Inline security review: **PASSED** (disjoint borrows, total exhaustive match, no unsafe, no new panic path, no injection surface).

## Tests
`closure-pass-fold-control-flow` `0.16.0` → `0.17.0`. Two new tests (true-arm and false-arm tombstoning). 38 unit + 13 upstream all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)