### PR TITLE
test(emitter): activate stale CodePrinter conformance placeholders (#88, CLOC12.138)

### DIFF
--- a/code/packages/rust/closure-emitter/CHANGELOG.md
+++ b/code/packages/rust/closure-emitter/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to the `coding-adventures-closure-emitter` crate will be documented in this file.
 
+## [0.18.12] - 2026-06-30
+
+### Test — activate stale CodePrinter conformance placeholders (#88, CLOC12.138)
+
+Three `#[ignore]`d placeholders in `tests/upstream/code_printer_test.rs` were
+left as documentation stubs when their underlying emitter features shipped
+(gap-025 number shortest-form in CLOC12.12, gap-026 quote-choice in CLOC12.11,
+gap-027 precedence-parens in CLOC12.10). This turns them into **active**
+byte-equal conformance tests against the emitter's actual output — no
+production code change:
+
+- `test_number_formatting_shortest_form` — `1E9`/`1E6`/`1E21` exponential
+  collapse, `100`→decimal tie, `0.5`, and `-0` sign preservation.
+- `test_string_quote_choice_minimises_escapes` — single-quote when the value has
+  more `"` than `'` (`she said "hi"` → `'she said "hi"'`), double otherwise.
+- `test_operator_precedence_inserts_inner_parens` — `a*(b+c)`, `(a+b)*c`, and
+  `a+b*c` (no parens where `*` already binds tighter).
+
+Also opened **gap-133** (CLOC12-gaps.md): the number formatter keeps `0.5`
+where upstream drops the leading zero to `.5` — a conservative miss (not a
+miscompile), tracked for a small `format_js_number` follow-up.
+
+Test-only + docs; crate version 0.18.11 → 0.18.12. Full emitter suite green
+(96 lib + 9 code_printer port, 3 unrelated placeholders still ignored).
+
 ## [0.18.11] - 2026-06-30
 
 ### Fixed — deep operator chains no longer overflow the native stack (DoS)

--- a/code/packages/rust/closure-emitter/Cargo.toml
+++ b/code/packages/rust/closure-emitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-emitter"
-version = "0.18.11"
+version = "0.18.12"
 edition = "2021"
 description = "JavaScript code emitter for the Closure Compiler clone. Per CLOC07's emit contract. Takes a finalized Program + sidecar and produces output JavaScript text + companion source map. Runs after every pass in the pipeline."
 

--- a/code/packages/rust/closure-emitter/tests/upstream/code_printer_test.rs
+++ b/code/packages/rust/closure-emitter/tests/upstream/code_printer_test.rs
@@ -217,43 +217,92 @@ fn test_string_literal_at_statement_position() {
     assert_emits(string("a"), "\"a\";");
 }
 
-/// Upstream tests cover number formatting like
-/// `assertPrint("1000000000", "1E9")` — using `1E9` exponential
-/// notation as shorter. Our emitter formats `1000000000` as
-/// `1000000000` (no exponent collapse).
+/// Upstream `testNumericKeys` / `testExponents`-style shortest-form
+/// number printing: the emitter picks whichever of the decimal or the
+/// uppercase-`E` exponential spelling is shorter (ties → decimal).
+///
+/// gap-025 RESOLVED — `format_js_number` in `closure-emitter` now does
+/// this (see CLOC12-gaps.md CLOC12.138). This was previously an
+/// `#[ignore]` placeholder; it is now an active conformance test.
 #[test]
-#[ignore = "blocked on gap-025: number-formatting (shortest-form / exponential) not implemented"]
 fn test_number_formatting_shortest_form() {
-    // assertPrint("1000000000", "1E9");
-    // Belongs in a future emitter-numeric-formatter slice.
+    // Exponential is strictly shorter → collapse (uppercase E, no `+`).
+    assert_emits(num(1_000_000_000.0), "1E9;"); // decimal 10 vs "1E9" 3
+    assert_emits(num(1_000_000.0), "1E6;"); //     decimal 7  vs "1E6" 3
+    assert_emits(num(1e21), "1E21;"); //           beyond i64, expo wins
+    // Tie or decimal-shorter → keep decimal.
+    assert_emits(num(100.0), "100;"); //           "100" 3 vs "1E2" 3 → tie→decimal
+    assert_emits(num(0.5), "0.5;"); //             "0.5" 3 vs "5E-1" 4 → decimal
+    // Negative zero must keep its sign (`1/-0 === -Infinity`).
+    assert_emits(num(-0.0), "-0;");
 }
 
 /// Upstream `testStringQuoteChoice`-style — pick the quote that
-/// minimises escapes:
+/// minimises escapes: when the value contains more `"` than `'`, the
+/// single-quote spelling is shorter (no escaping of the inner `"`).
 ///
-///   assertPrint("var x = \"single 'quote'\";", "var x='single \\'quote\\''");
-///   assertPrint("var x = \"a\\nb\";", "var x=\"a\\nb\"");
-///
-/// Our emitter always uses double quotes and doesn't switch to
-/// single. Gap-026.
+/// gap-026 RESOLVED — `emit_string` now does this (CLOC12-gaps.md
+/// CLOC12.138). Previously an `#[ignore]` placeholder; now active.
 #[test]
-#[ignore = "blocked on gap-026: quote-choice optimisation not implemented"]
 fn test_string_quote_choice_minimises_escapes() {
-    // Belongs in a future emitter-string-escape slice.
+    // More `"` than `'` → single-quote form (inner `"` need no escape).
+    assert_emits(string("she said \"hi\""), "'she said \"hi\"';");
+    // `'` present, no `"` → default double-quote form (tie/dq-not-more).
+    assert_emits(string("o'malley"), "\"o'malley\";");
+    // No quotes at all → default double.
+    assert_emits(string("plain"), "\"plain\";");
 }
 
 /// Upstream `testOperatorPrecedence`-style — when a higher-precedence
 /// operator contains a lower-precedence subexpression, the
-/// subexpression needs parens to preserve evaluation order:
+/// subexpression needs parens to preserve evaluation order.
 ///
-///   assertPrint("(a+b)*c", "(a+b)*c");
-///   assertPrint("a*(b+c)", "a*(b+c)");
-///
-/// Our emitter doesn't model operator precedence — it doesn't emit
-/// inner parens, and it wraps the outer expression in parens
-/// unconditionally. Filed as gap-027.
+/// gap-027 RESOLVED — the emitter now models operator precedence and
+/// inserts exactly the parens needed (CLOC12-gaps.md CLOC12.138).
+/// Previously an `#[ignore]` placeholder; now active.
 #[test]
-#[ignore = "blocked on gap-027: precedence-aware paren insertion not implemented"]
 fn test_operator_precedence_inserts_inner_parens() {
-    // Would assert that `a * (b + c)` emits with the inner parens.
+    // `a * (b + c)` — `+` is lower precedence than `*`, so the right
+    // operand needs parens to preserve evaluation order.
+    let a_times_b_plus_c = Expression::BinaryExpression(BinaryExpression {
+        cv: None,
+        operator: BinaryOperator::Mul,
+        left: Box::new(ident("a")),
+        right: Box::new(Expression::BinaryExpression(BinaryExpression {
+            cv: None,
+            operator: BinaryOperator::Add,
+            left: Box::new(ident("b")),
+            right: Box::new(ident("c")),
+        })),
+    });
+    assert_emits(a_times_b_plus_c, "a*(b+c);");
+
+    // `(a + b) * c` — the SAME associativity note: `a + b` (lower prec)
+    // on the left of `*` also needs parens.
+    let a_plus_b_times_c = Expression::BinaryExpression(BinaryExpression {
+        cv: None,
+        operator: BinaryOperator::Mul,
+        left: Box::new(Expression::BinaryExpression(BinaryExpression {
+            cv: None,
+            operator: BinaryOperator::Add,
+            left: Box::new(ident("a")),
+            right: Box::new(ident("b")),
+        })),
+        right: Box::new(ident("c")),
+    });
+    assert_emits(a_plus_b_times_c, "(a+b)*c;");
+
+    // `a + b * c` — `*` binds tighter, so NO parens are needed.
+    let a_plus_b_times_c_noparen = Expression::BinaryExpression(BinaryExpression {
+        cv: None,
+        operator: BinaryOperator::Add,
+        left: Box::new(ident("a")),
+        right: Box::new(Expression::BinaryExpression(BinaryExpression {
+            cv: None,
+            operator: BinaryOperator::Mul,
+            left: Box::new(ident("b")),
+            right: Box::new(ident("c")),
+        })),
+    });
+    assert_emits(a_plus_b_times_c_noparen, "a+b*c;");
 }

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -186,21 +186,21 @@ historical context with status `RESOLVED` and a link to the fix PR.
 - **Status:** RESOLVED in CLOC12.12
 - **Upstream test:** `CodePrinterTest` lines like `assertPrint("1000000000", "1E9")`
 - **Ported file:** `closure-emitter/tests/upstream/code_printer_test.rs`
-- **Resolution:** `format_js_number` now computes both decimal and exponential forms for finite non-zero numbers and returns the shorter (ties → decimal). `format_exponential_uppercase` wraps Rust's `{:e}` formatter and uppercases the `e`. Examples: `1000000000` → `1E9`, `5000000` → `5E6`, `1.5e-10` → `1.5E-10`. Small integers and decimals stay decimal. NaN/Infinity unchanged. The `test_number_formatting_shortest_form` ignored placeholder in `tests/upstream/code_printer_test.rs` stays — to be re-port'd with real upstream `assertPrint` lines in a follow-up; the underlying emitter behaviour is in place.
+- **Resolution:** `format_js_number` now computes both decimal and exponential forms for finite non-zero numbers and returns the shorter (ties → decimal). `format_exponential_uppercase` wraps Rust's `{:e}` formatter and uppercases the `e`. Examples: `1000000000` → `1E9`, `5000000` → `5E6`, `1.5e-10` → `1.5E-10`. Small integers and decimals stay decimal. NaN/Infinity unchanged. **CLOC12.138:** the `test_number_formatting_shortest_form` placeholder is now an **active** conformance test (`1E9`, `1E6`, `1E21`, `100`→decimal tie, `0.5`, `-0`) — the follow-up re-port is done. (Residual finer optimisation not yet done: Closure drops the leading zero on `0.5` → `.5`; ours keeps `0.5`. Filed as gap-133 below.)
 
 ### gap-026 — String quote-choice optimisation not implemented
 
 - **Status:** RESOLVED in CLOC12.11
 - **Upstream test:** `CodePrinterTest` quote-choice lines
 - **Ported file:** `closure-emitter/tests/upstream/code_printer_test.rs`
-- **Resolution:** Added `choose_quote_and_escape(value)` + `escape_str_sq` helpers in `closure-emitter/src/lib.rs`. `emit_string` now picks single-quote when value contains strictly more `"` than `'` (each saved `\"` is one fewer escape); double-quote otherwise (canonical, ties picked toward double). `ascii_only` mode still always uses double — that's upstream's own invariant. Six new inline tests cover all branches. The `test_string_quote_choice_minimises_escapes` ignored placeholder in the upstream port file will be re-port'd with real upstream `assertPrint` cases in a follow-up.
+- **Resolution:** Added `choose_quote_and_escape(value)` + `escape_str_sq` helpers in `closure-emitter/src/lib.rs`. `emit_string` now picks single-quote when value contains strictly more `"` than `'` (each saved `\"` is one fewer escape); double-quote otherwise (canonical, ties picked toward double). `ascii_only` mode still always uses double — that's upstream's own invariant. Six new inline tests cover all branches. **CLOC12.138:** the `test_string_quote_choice_minimises_escapes` placeholder is now an **active** conformance test (`she said "hi"`→single-quote, `o'malley`→double, `plain`→double) — the follow-up re-port is done.
 
 ### gap-027 — Precedence-aware paren insertion not implemented
 
 - **Status:** RESOLVED in CLOC12.10 (incidental, via the same fix as gap-024)
 - **Upstream test:** `CodePrinterTest` operator-precedence lines (e.g. `a*(b+c)` keeps inner parens)
 - **Ported file:** `closure-emitter/tests/upstream/code_printer_test.rs`
-- **Resolution:** The precedence ladder added for gap-024 covers this directly. `emit_expression_inner(e, parent_prec)` checks `expr_prec(e) < parent_prec` and inserts parens when so — which means `a * (b + c)` correctly keeps the inner parens because `+` (prec 11) < `*` (prec 12). The `test_operator_precedence_inserts_inner_parens` ignored placeholder will be re-port'd with real upstream test cases in a follow-up; the emitter machinery is already in place.
+- **Resolution:** The precedence ladder added for gap-024 covers this directly. `emit_expression_inner(e, parent_prec)` checks `expr_prec(e) < parent_prec` and inserts parens when so — which means `a * (b + c)` correctly keeps the inner parens because `+` (prec 11) < `*` (prec 12). **CLOC12.138:** the `test_operator_precedence_inserts_inner_parens` placeholder is now an **active** conformance test (`a*(b+c)`, `(a+b)*c`, and `a+b*c` no-parens) — the follow-up re-port is done.
 
 ### gap-028 — VLQ encoder for source-map `mappings` field not implemented
 
@@ -1018,6 +1018,31 @@ historical context with status `RESOLVED` and a link to the fix PR.
     with no external use should be removed. A naive use-count sees `a`
     referenced by its own body and keeps it; needs reference-cycle detection
     (SCC over the binding→reference graph).
+
+## CLOC12.138 — activate the stale emitter-conformance placeholders (gap-025/026/027) + open gap-133
+
+- **Status:** three previously-`#[ignore]`d emitter conformance tests are now
+  **active** and passing; one new gap opened.
+- **What it was:** gap-025 (number shortest-form), gap-026 (string quote-choice),
+  and gap-027 (precedence-aware paren insertion) were all RESOLVED in the emitter
+  (CLOC12.10/11/12) but their `closure-emitter/tests/upstream/code_printer_test.rs`
+  placeholders were left `#[ignore]`d "to be re-port'd in a follow-up". This is
+  that follow-up: the three placeholders now carry real byte-equal assertions
+  against the emitter's actual output, converting them from documentation stubs
+  into executable conformance coverage:
+  - `test_number_formatting_shortest_form` — `1000000000`→`1E9`, `1000000`→`1E6`,
+    `1e21`→`1E21`, `100`→`100` (tie→decimal), `0.5`→`0.5`, `-0.0`→`-0`.
+  - `test_string_quote_choice_minimises_escapes` — `she said "hi"`→
+    `'she said "hi"'` (single-quote), `o'malley`→`"o'malley"`, `plain`→`"plain"`.
+  - `test_operator_precedence_inserts_inner_parens` — `a*(b+c)`, `(a+b)*c`, and
+    `a+b*c` (no parens where `*` already binds tighter).
+- **gap-133 (surfaced here)** — leading-zero drop for fractional literals.
+  Upstream Closure emits `.5` for `0.5` (and `-.5` for `-0.5`), dropping the
+  redundant leading zero; `format_js_number` keeps `0.5` because its
+  decimal-vs-exponential comparison never strips the leading `0`. A conservative
+  miss (both are valid, same-value JS), **not** a miscompile. Fix: after picking
+  the decimal spelling, strip a leading `0` before `.` (and after a `-`). Small,
+  self-contained follow-up in `format_js_number`.
   - **gap-126** — assignment-only dead var: `var a; a = 1;` (never read) should
     be removed. The analyzer counts the `a = 1` write as a reference, so `a`
     survives; needs write-vs-read reference classification so pure writes to an


### PR DESCRIPTION
## Why
Part of the **#88 upstream-test-port** effort. While surveying the emitter's `CodePrinterTest` port I found **3 `#[ignore]` placeholders were stale**: gap-025 (number shortest-form), gap-026 (string quote-choice), and gap-027 (precedence-aware parens) were all RESOLVED *in the emitter* (CLOC12.10/11/12), but their tests were left as empty stubs marked "to be re-port'd in a follow-up". This is that follow-up.

## What
Converts the three stubs into **active byte-equal conformance tests** against the emitter's actual output — no production code change:

- `test_number_formatting_shortest_form` — `1000000000`→`1E9`, `1000000`→`1E6`, `1e21`→`1E21`, `100`→`100` (tie→decimal), `0.5`, and `-0.0`→`-0` (sign preservation).
- `test_string_quote_choice_minimises_escapes` — `she said "hi"`→`'she said "hi"'` (single-quote saves escapes), `o'malley`→`"o'malley"`, `plain`→`"plain"`.
- `test_operator_precedence_inserts_inner_parens` — `a*(b+c)`, `(a+b)*c`, and `a+b*c` (no parens where `*` already binds tighter).

All three pass, confirming the emitter's number-formatting, quote-choice, and precedence machinery work end-to-end.

## Gap found
**gap-133** (CLOC12-gaps.md): the formatter keeps `0.5` where upstream Closure drops the leading zero → `.5` (and `-.5` for `-0.5`). A conservative minification miss, **not** a miscompile — tracked for a small `format_js_number` follow-up.

## Safety
**Test-only + docs** — no production/library code touched. `closure-emitter` `0.18.11` → `0.18.12`; CHANGELOG + CLOC12-gaps.md updated. Full emitter suite green (96 lib + 9 code_printer port; 3 unrelated placeholders still ignored). Inline security review: **PASSED** (no new deps, no unsafe/IO/injection; inputs are hardcoded literals; panics test-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)