### PR TITLE
feat(math-frontend,latex): fence delimiters as data — MathExpr::Fenced (arc PR-1)

### DIFF
--- a/code/packages/rust/adj-lang/src/adapter.rs
+++ b/code/packages/rust/adj-lang/src/adapter.rs
@@ -916,6 +916,11 @@ fn latex_math_to_expr_ast(expr: &MathExpr, source: &str) -> Result<ExprAst, Adap
         MathExpr::Number(n) => number_to_lit(n, source),
         MathExpr::Symbol(name) => Ok(ExprAst::Ref(name.clone())),
         MathExpr::Group(inner) => latex_math_to_expr_ast(inner, source),
+        // A delimited group (`(x)`, `[x]`, `|x|`) unwraps the same as a plain group for arithmetic
+        // lowering — the fence delimiters are presentation, not an operation. (latex now lowers a
+        // single-body fence to `Fenced` carrying its delimiters instead of the delimiter-less
+        // `Group`; this arm keeps the arithmetic meaning identical.)
+        MathExpr::Fenced { body, .. } => latex_math_to_expr_ast(body, source),
         MathExpr::Unary(UnaryOp::Pos, inner) => latex_math_to_expr_ast(inner, source),
         MathExpr::Unary(UnaryOp::Neg, inner) => Ok(ExprAst::Bin(
             ArithOp::Sub,

--- a/code/packages/rust/latex/CHANGELOG.md
+++ b/code/packages/rust/latex/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to the full-fidelity LaTeX parser crate.
 
+## [0.24.0] — 2026-06-30
+
+### Changed — fence delimiters preserved as data (frontend adapter)
+
+- The `MathFrontend` adapter now lowers a single-body fence to the new neutral
+  **`MathExpr::Fenced { open, body, close }`** (math-frontend 0.7.0) instead of the delimiter-less
+  `MathExpr::Group`, carrying the surface delimiters as data: `(x+1)` → `Fenced("(", …, ")")`,
+  `[x]` → `Fenced("[", …, "]")`, `\left|x\right|` → `Fenced("|", …, "|")`. An absolute value / norm
+  is no longer indistinguishable from a parenthesised group. The latex frontend declares the new
+  `fenced_delimiters` capability (via `Capabilities::all()`).
+- A **comma-list** fence still lowers to `MathExpr::Sequence` (delimiters dropped, matching MathML
+  `<mfenced>` / AsciiMath) — carrying delimiters on sequences is a later slice of this arc.
+- The internal `MathNode` and `to_latex` round-trip are unchanged; this only affects the neutral
+  lowering. Golden tests updated to assert the preserved delimiters.
+
 ## [0.23.0] — 2026-06-30
 
 ### Added — down-barb & under harpoon accents (completing the harpoon accent family)

--- a/code/packages/rust/latex/Cargo.toml
+++ b/code/packages/rust/latex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latex"
-version = "0.23.0"
+version = "0.24.0"
 edition = "2021"
 description = "A full-fidelity LaTeX parser (documents and math): a catcode-driven, text-mode-primary tokenizer and (in later layers) a structural + math parser producing a faithful AST. Standalone and reusable; will also implement the math-frontend MathFrontend trait."
 license = "MIT"

--- a/code/packages/rust/latex/src/frontend.rs
+++ b/code/packages/rust/latex/src/frontend.rs
@@ -14,7 +14,9 @@
 //! The neutral AST deliberately drops *presentation* and keeps *meaning*, so this lowering:
 //! - `\times`, `\cdot`, and juxtaposition all become [`BinOp::Mul`]; `\dfrac`/`\tfrac`/`\frac`
 //!   all become [`MathExpr::Frac`] — two source strings that mean the same math lower equal.
-//! - fence *style* is dropped: `(…)`, `[…]`, `\left(…\right)` all become [`MathExpr::Group`].
+//! - fence *delimiters* are preserved as data: `(x)`, `[x]`, `|x|`, `\left(x\right)` become
+//!   [`MathExpr::Fenced`] carrying their open/close strings (a comma-list body still lowers to
+//!   [`MathExpr::Sequence`] with delimiters dropped — carrying them there is a later slice).
 //! - matrix *delimiter* is dropped: `pmatrix`/`bmatrix`/`cases`/… all become [`MathExpr::Matrix`].
 //! - `base^sup` → [`BinOp::Pow`]; `base_sub` → [`MathExpr::Subscript`]; both → `Pow(Subscript(…))`.
 //! - an accent (`\hat{x}`, `\vec{v}`) lowers to the neutral [`MathExpr::Accent`] (a diacritic
@@ -97,7 +99,9 @@ enum Build {
     Call(Func),
     Accent(String),
     BigOp { op: BigOp, has_lower: bool, has_upper: bool },
-    Group,
+    /// Assemble a `MathExpr::Fenced { open, body, close }` from the top finished child,
+    /// preserving the surface delimiters carried on `MathNode::Fenced { left, right }`.
+    Fenced { open: String, close: String },
     Rel(RelOp),
     Matrix { row_lens: Vec<usize> },
     /// Assemble a `MathExpr::Sequence` from the top `len` finished children.
@@ -266,15 +270,19 @@ fn lower(root: MathNode, span: (usize, usize)) -> Result<MathExpr, FrontendError
                         work.push(Task::Node(*l));
                     }
                 }
-                // Fence style is presentation; the meaning is "this is grouped" — unless the
-                // body is a comma list, in which case the fence is a Sequence (a tuple / list),
-                // and the delimiters drop just as for MathML `<mfenced>` and AsciiMath `(a,b,c)`.
-                MathNode::Fenced { body, .. } => {
+                // A fence brackets its body; we preserve *which* delimiters were used as data on
+                // the neutral `MathExpr::Fenced { open, close }` — so `|x|` (abs/norm) is no
+                // longer confused with `(x)`. EXCEPTION: a comma-list body is a Sequence (a tuple
+                // / list) whose delimiters still drop, matching MathML `<mfenced>` and AsciiMath
+                // `(a,b,c)` (carrying delimiters on sequences is a later slice of this arc).
+                MathNode::Fenced { left, body, right } => {
+                    let open = std::mem::take(left);
+                    let close = std::mem::take(right);
                     let body = take_box(body);
                     if !matches!(body, MathNode::Sequence(_)) {
-                        work.push(Task::Build(Build::Group));
+                        work.push(Task::Build(Build::Fenced { open, close }));
                     }
-                    // A Sequence body lowers via its own arm (no Group wrapper).
+                    // A Sequence body lowers via its own arm (delimiters dropped, for now).
                     work.push(Task::Node(body));
                 }
                 // A comma-separated sequence — the fence's delimiters are already dropped.
@@ -369,9 +377,9 @@ fn lower(root: MathNode, span: (usize, usize)) -> Result<MathExpr, FrontendError
                     let lower = if has_lower { Some(Box::new(pop!())) } else { None };
                     vals.push(MathExpr::BigOp { op, lower, upper, body: Box::new(body) });
                 }
-                Build::Group => {
+                Build::Fenced { open, close } => {
                     let inner = pop!();
-                    vals.push(MathExpr::Group(Box::new(inner)));
+                    vals.push(MathExpr::Fenced { open, body: Box::new(inner), close });
                 }
                 Build::Matrix { row_lens } => {
                     let total: usize = row_lens.iter().sum();
@@ -592,11 +600,17 @@ mod tests {
     fn symbols_text_and_groups() {
         assert_eq!(m(r"\pi"), MathExpr::Symbol("pi".into()));
         assert_eq!(m(r"\text{kg}"), MathExpr::Text("kg".into()));
-        // fence style dropped to Group.
+        // Fence delimiters are preserved as data on MathExpr::Fenced.
         match &m("(a+b)") {
-            MathExpr::Group(inner) => assert!(matches!(**inner, MathExpr::Bin(BinOp::Add, ..))),
-            other => panic!("expected Group, got {other:?}"),
+            MathExpr::Fenced { open, body, close } => {
+                assert_eq!((open.as_str(), close.as_str()), ("(", ")"));
+                assert!(matches!(**body, MathExpr::Bin(BinOp::Add, ..)));
+            }
+            other => panic!("expected Fenced, got {other:?}"),
         }
+        // Bracket / bar fences carry their own delimiters — no longer confused with parens.
+        assert!(matches!(m("[x]"), MathExpr::Fenced { ref open, ref close, .. } if open == "[" && close == "]"));
+        assert!(matches!(m(r"\left|x\right|"), MathExpr::Fenced { ref open, ref close, .. } if open == "|" && close == "|"));
     }
 
     #[test]
@@ -619,8 +633,8 @@ mod tests {
                 num(2),
             ])
         );
-        // A comma-free fence still lowers to Group (unchanged).
-        assert!(matches!(m("(a + b)"), MathExpr::Group(_)));
+        // A comma-free fence lowers to Fenced (single body, delimiters preserved).
+        assert!(matches!(m("(a + b)"), MathExpr::Fenced { .. }));
     }
 
     #[test]

--- a/code/packages/rust/math-frontend/CHANGELOG.md
+++ b/code/packages/rust/math-frontend/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to the pluggable parser-frontend framework.
 
+## [0.7.0] — 2026-06-30
+
+### Added — fence delimiters as data (`MathExpr::Fenced`)
+
+- New neutral node **`MathExpr::Fenced { open: String, body, close: String }`** — a delimited
+  group that carries *which* delimiters bracketed it, so `|x|` (absolute value / norm) is no
+  longer indistinguishable from `(x)`. Where `MathExpr::Group` records only *that* a subexpression
+  was parenthesised (style dropped), `Fenced` preserves the surface open/close strings (`"("`,
+  `"["`, `"\\{"`, `"\\langle"`, `"|"`, `"."` for an omitted `\left.`). Kept distinct from
+  `Sequence` (a comma list) and `Matrix` (rows): `Fenced` brackets a single inner expression.
+- New capability flag **`Capabilities::fenced_delimiters`** (+ `with_fenced_delimiters()`), wired
+  into `all()`, the conformance `collect_used` walker, and the honesty check (`over_emitted`), so a
+  frontend emitting `Fenced` without declaring it is flagged — the gate polices the new node.
+- The iterative `Drop` for `MathExpr` handles `Fenced` (deep fence nesting frees without overflow).
+
+This is the first slice of the fence-delimiters arc; individual frontends adopt `Fenced` one at a
+time (latex first, in this release). Carrying delimiters on comma-list `Sequence` bodies is a later
+slice.
+
 ## [0.6.0] — 2026-06-30
 
 ### Added — neutral `Sequence` node (comma-separated lists in fences)

--- a/code/packages/rust/math-frontend/Cargo.toml
+++ b/code/packages/rust/math-frontend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "math-frontend"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 description = "A pluggable parser-frontend framework: a neutral math AST (MathExpr), a MathFrontend trait + registry, and a shared conformance harness. Notation parsers (LaTeX, AsciiMath, MathML, …) implement the trait so any consumer lowers ONE neutral tree."
 license = "MIT"

--- a/code/packages/rust/math-frontend/src/conformance.rs
+++ b/code/packages/rust/math-frontend/src/conformance.rs
@@ -94,7 +94,7 @@ pub fn check_frontend(frontend: &dyn MathFrontend, samples: &[&str]) -> Conforma
 /// Names of capabilities that `used` requires but `declared` did not advertise.
 fn over_emitted(used: Capabilities, declared: Capabilities) -> Vec<&'static str> {
     let mut v = Vec::new();
-    let pairs: [(&str, bool, bool); 14] = [
+    let pairs: [(&str, bool, bool); 15] = [
         ("fractions", used.fractions, declared.fractions),
         ("roots", used.roots, declared.roots),
         ("powers", used.powers, declared.powers),
@@ -109,6 +109,7 @@ fn over_emitted(used: Capabilities, declared: Capabilities) -> Vec<&'static str>
         ("accents", used.accents, declared.accents),
         ("oversets", used.oversets, declared.oversets),
         ("sequences", used.sequences, declared.sequences),
+        ("fenced_delimiters", used.fenced_delimiters, declared.fenced_delimiters),
     ];
     for (label, used_it, declared_it) in pairs {
         if used_it && !declared_it {
@@ -181,6 +182,10 @@ fn collect_used(e: &MathExpr, caps: &mut Capabilities) {
             collect_used(b, caps);
         }
         MathExpr::Group(a) => collect_used(a, caps),
+        MathExpr::Fenced { body, .. } => {
+            caps.fenced_delimiters = true;
+            collect_used(body, caps);
+        }
         MathExpr::Text(_) => caps.text = true,
         MathExpr::Matrix(rows) => {
             caps.matrices = true;
@@ -384,6 +389,44 @@ mod tests {
             fn capabilities(&self) -> Capabilities { Capabilities::none().with_sequences() }
         }
         assert!(check_frontend(&SequenceHonest, &["a,b,c"]).passed());
+    }
+
+    #[test]
+    fn fenced_delimiters_over_and_under_claim() {
+        // A frontend that emits a `Fenced` but declares `none()` must be flagged for the
+        // `fenced_delimiters` capability — the gate polices the new delimiter node too.
+        struct FencedOverClaimer;
+        impl MathFrontend for FencedOverClaimer {
+            fn name(&self) -> &str { "fenced" }
+            fn parse(&self, _src: &str) -> Result<MathExpr, FrontendError> {
+                Ok(MathExpr::Fenced {
+                    open: "|".into(),
+                    body: Box::new(MathExpr::Symbol("x".into())),
+                    close: "|".into(),
+                })
+            }
+            fn capabilities(&self) -> Capabilities { Capabilities::none() }
+        }
+        let r = check_frontend(&FencedOverClaimer, &["|x|"]);
+        assert!(!r.passed());
+        assert!(r.issues.iter().any(|i| i.contains("fenced_delimiters")));
+
+        // Declaring `with_fenced_delimiters()` makes emitting a Fenced conforming.
+        struct FencedHonest;
+        impl MathFrontend for FencedHonest {
+            fn name(&self) -> &str { "fenced-honest" }
+            fn parse(&self, _src: &str) -> Result<MathExpr, FrontendError> {
+                Ok(MathExpr::Fenced {
+                    open: "[".into(),
+                    body: Box::new(MathExpr::Symbol("y".into())),
+                    close: "]".into(),
+                })
+            }
+            fn capabilities(&self) -> Capabilities {
+                Capabilities::none().with_fenced_delimiters()
+            }
+        }
+        assert!(check_frontend(&FencedHonest, &["[y]"]).passed());
     }
 
     #[test]

--- a/code/packages/rust/math-frontend/src/expr.rs
+++ b/code/packages/rust/math-frontend/src/expr.rs
@@ -282,6 +282,21 @@ pub enum MathExpr {
     /// the items as a delimited list, not a product. The items appear in source order; an
     /// empty sequence is not representable (a fence with no items is not a list).
     Sequence(Vec<MathExpr>),
+    /// A **delimited** group that carries its opening and closing fence as data: `(x+1)`,
+    /// `[a]`, `\{s\}`, `\langle v\rangle`, `|z|`, `\left(\frac a b\right)`. Where
+    /// [`MathExpr::Group`] records only *that* a subexpression was parenthesised (style dropped),
+    /// `Fenced` preserves *which* delimiters bracketed it, so a bar (`|x|`, an absolute value /
+    /// norm) is no longer indistinguishable from a paren `(x)`, and a renderer can reproduce the
+    /// exact brackets. `open`/`close` are the surface delimiter strings (`"("`, `"["`, `"\\{"`,
+    /// `"\\langle"`, `"|"`, or `"."` for an omitted `\left.`/`\right.`) — a `String` so the
+    /// open-ended set of TeX delimiters needs no enum churn. Kept DISTINCT from `Sequence` (a
+    /// comma list, whose items are separated) and `Matrix` (rows/cells): a `Fenced` brackets a
+    /// *single* inner expression.
+    Fenced {
+        open: String,
+        body: Box<MathExpr>,
+        close: String,
+    },
 }
 
 /// Drop a `MathExpr` **iteratively** so freeing a deeply-nested tree cannot overflow the
@@ -341,6 +356,7 @@ fn take_children(e: &mut MathExpr, out: &mut Vec<MathExpr>) {
         }
         MathExpr::Call { arg, .. } => take(arg, out),
         MathExpr::Accent { body, .. } => take(body, out),
+        MathExpr::Fenced { body, .. } => take(body, out),
         MathExpr::Overset { over: a, base: b } | MathExpr::Underset { under: a, base: b } => {
             take(a, out);
             take(b, out);

--- a/code/packages/rust/math-frontend/src/frontend.rs
+++ b/code/packages/rust/math-frontend/src/frontend.rs
@@ -71,6 +71,9 @@ pub struct Capabilities {
     pub oversets: bool,
     /// Emits comma-separated sequences ([`crate::MathExpr::Sequence`]: fenced lists `(a, b, c)`).
     pub sequences: bool,
+    /// Emits delimited groups that carry their fence as data ([`crate::MathExpr::Fenced`]:
+    /// `(x+1)`, `[a]`, `|z|`, `\left(…\right)`), preserving *which* delimiters bracketed the body.
+    pub fenced_delimiters: bool,
 }
 
 impl Capabilities {
@@ -97,6 +100,7 @@ impl Capabilities {
             accents: true,
             oversets: true,
             sequences: true,
+            fenced_delimiters: true,
         }
     }
 
@@ -114,6 +118,7 @@ impl Capabilities {
     pub fn with_accents(mut self) -> Self { self.accents = true; self }
     pub fn with_oversets(mut self) -> Self { self.oversets = true; self }
     pub fn with_sequences(mut self) -> Self { self.sequences = true; self }
+    pub fn with_fenced_delimiters(mut self) -> Self { self.fenced_delimiters = true; self }
 }
 
 /// The contract every notation parser implements.


### PR DESCRIPTION
## What

First slice of the **fence-delimiters-as-data** arc — the biggest remaining structural gap in the neutral math AST. Surfaces **which** delimiters bracketed a group, so an absolute value / norm `|x|` is no longer indistinguishable from a parenthesised group `(x)`.

## `math-frontend` 0.6.0 → 0.7.0

- New neutral node **`MathExpr::Fenced { open: String, body, close: String }`**. Where `MathExpr::Group` records only *that* a subexpression was parenthesised (style dropped), `Fenced` preserves the surface open/close strings (`(`, `[`, `\{`, `\langle`, `|`, or `.` for an omitted `\left.`). Distinct from `Sequence` (a comma list) and `Matrix` (rows).
- New capability **`Capabilities::fenced_delimiters`** (+ `with_fenced_delimiters()`), wired into `all()`, the conformance `collect_used` walker, and the `over_emitted` honesty check — a frontend emitting `Fenced` without declaring it is flagged.
- The iterative `Drop` for `MathExpr` handles `Fenced` (deep fence nesting frees without stack overflow), mirroring the `Accent` arm.

## `latex` 0.23.0 → 0.24.0

- The `MathFrontend` adapter lowers a **single-body** fence to `MathExpr::Fenced` carrying the delimiters (via a new `Build::Fenced` worklist step replacing `Build::Group`) instead of the delimiter-less `Group`: `(x+1)` → `Fenced("(", …, ")")`, `[x]` → `Fenced("[", …, "]")`, `\left|x\right|` → `Fenced("|", …, "|")`.
- A **comma-list** fence still lowers to `MathExpr::Sequence` (delimiters dropped, matching MathML `<mfenced>` / AsciiMath) — carrying them there is a later slice.
- Internal `MathNode` and `to_latex` round-trip unchanged; only the neutral lowering.

## Why it slices cleanly

Conformance is **per-frontend** via a `Capabilities` bitset, so `mathml`/`asciimath`/`unicode-math` still emit `Group` and remain conformant **unchanged** — they adopt `Fenced` in later PRs. Adding the `MathExpr` variant compiled across all consumers with **no exhaustive-match breaks** (frontends *construct* `MathExpr`; only `take_children` Drop + `collect_used` match on it, both given `Fenced` arms).

## Tests / verification

Full workspace builds. **latex 193, math-frontend 36, mathml 48, asciimath 49, unicode-math 29, adj-lang 86** tests pass; clippy clean. New conformance test asserts the honesty gate flags a `Fenced` over-claimer; golden tests assert the preserved delimiters. Security review passed (deep-fence Drop safe, `mem::take` of delimiter Strings sound, `pop!()` stack invariant held).

🤖 Generated with [Claude Code](https://claude.com/claude-code)