### PR TITLE
test(rename-globals): port RenameVarsTest (#88, CLOC12.139)

### DIFF
--- a/code/packages/rust/closure-pass-rename-globals/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename-globals/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename-globals` crate will be documented in this file.
 
+## [0.7.1] - 2026-06-30
+
+### Added — CLOC12 upstream test port (`RenameVarsTest`)
+
+Ported the applicable cases from Google Closure Compiler's `RenameVarsTest.java`
+into `tests/upstream/rename_vars_test.rs`, following the CLOC12.01 convention
+(header cites the Java source; `UPSTREAM_SHA` pins the tracked commit;
+`ATTRIBUTION.md` records Apache-2.0 provenance; a `[[test]]` entry wires the file
+in). The pass exposes a source-string surface through public crate APIs, so —
+unlike the AST-builder ports — each case drives the real
+`source → bridge → rename → emit` chain and asserts on the emitted string, the
+same surface upstream uses.
+
+- **8 active `#[test]`s pass**: two globals → `a`/`b`, all-uses-rewritten, a
+  global function-declaration rename, the reserved-extern case (keeps only the
+  reserved `apiHandler`, renames the ordinary global `helper`→`a`), a
+  free/undeclared global left untouched, a dotted property key left untouched, a
+  global used as a computed-member index renamed, and a single-character global
+  left un-lengthened.
+- **No new closurec bug** — the port validated correct behavior; one draft
+  expectation was corrected during authoring (the reserved-extern case).
+- **4 `#[ignore = "blocked on gap-NNN"]` placeholders** for upstream behavior
+  the global-only pass does not cover: function-local renaming (gap-134),
+  parameter renaming (gap-135), short-name reuse across disjoint scopes
+  (gap-136), and pseudo-name / stable-name mode (gap-137). Pinned to
+  `code/specs/CLOC12-gaps.md` §CLOC12.139; run with `--include-ignored` to track
+  progress as they close.
+
+No library code changed — this release is test coverage plus docs.
+
 ## [0.7.0] - 2026-06-30
 
 ### Added — correlation-vector rename provenance (#89)

--- a/code/packages/rust/closure-pass-rename-globals/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename-globals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename-globals"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 description = "Aggressive top-level (global) renaming pass for the Closure Compiler clone — the ADVANCED-level complement to closure-pass-rename. Shortens program-private top-level names, gated by an externs do-not-rename boundary."
 
@@ -15,3 +15,9 @@ coding-adventures-javascript-tokens = { path = "../javascript-tokens" }
 coding-adventures-javascript-parser = { path = "../javascript-parser" }
 coding-adventures-closure-emitter = { path = "../closure-emitter" }
 coding-adventures-type-sidecar = { path = "../type-sidecar" }
+
+# CLOC12 upstream test-suite port. Integration test built against the crate's
+# public API; needs an explicit `[[test]]` entry. Per CLOC12.01 §3.
+[[test]]
+name = "upstream_rename_vars"
+path = "tests/upstream/rename_vars_test.rs"

--- a/code/packages/rust/closure-pass-rename-globals/README.md
+++ b/code/packages/rust/closure-pass-rename-globals/README.md
@@ -81,3 +81,18 @@ the rename *table* as queryable provenance. Program output is
 byte-for-byte unchanged. (Follow-up: per-output-span provenance —
 contributing to each renamed identifier's own CV id — needs the log
 threaded through the `rename_apply_*` recursion.)
+
+## Upstream conformance tests
+
+`tests/upstream/rename_vars_test.rs` ports Google Closure Compiler's
+`RenameVarsTest` (Apache-2.0; see `ATTRIBUTION.md` and `UPSTREAM_SHA`), per the
+CLOC12 test-port convention. Because the pass exposes a source-string surface
+through public crate APIs, the port drives the real `source → bridge → rename →
+emit` chain and asserts on the emitted string — the same `test(js, expected)`
+surface upstream uses. It pins the 8 global-renaming behaviors this pass
+supports today and records 4 upstream behaviors it does not — function-local
+renaming, parameter renaming, short-name reuse across disjoint scopes, and
+pseudo-name mode — as `#[ignore = "blocked on gap-NNN"]` placeholders tied to
+`code/specs/CLOC12-gaps.md` (gap-134 … gap-137). Run with
+`cargo test --test upstream_rename_vars` (add `-- --include-ignored` to list the
+pending gaps).

--- a/code/packages/rust/closure-pass-rename-globals/tests/upstream/ATTRIBUTION.md
+++ b/code/packages/rust/closure-pass-rename-globals/tests/upstream/ATTRIBUTION.md
@@ -1,0 +1,45 @@
+# Attribution
+
+Tests in this directory are ported from the Google Closure Compiler
+under the Apache License, Version 2.0:
+
+    https://github.com/google/closure-compiler
+    LICENSE: https://www.apache.org/licenses/LICENSE-2.0
+
+## Files ported
+
+- `rename_vars_test.rs`
+    - upstream: `test/com/google/javascript/jscomp/RenameVarsTest.java`
+    - tracked commit: see `UPSTREAM_SHA`
+
+## Translation notes
+
+CLOC12 port for the `rename-globals` pass (after constant-fold, dce, the
+emitter / source-map ports, remove-unused-vars, inline, and
+fold-control-flow). Per CLOC12 §6, each upstream Java test file maps to one
+Rust file in the matching pass crate's `tests/upstream/` directory.
+
+- Unlike the AST-builder ports (dce, remove-unused-vars), `rename-globals`
+  exposes everything a source-string surface needs through public crate
+  APIs, so this port drives the real `source → bridge → RenameGlobalsPass →
+  emit` chain and asserts on the emitted string — the same surface upstream
+  `RenameVarsTest` uses (`test(js, expected)`).
+
+- **What our pass does today:** it renames **GLOBAL-scope** bindings
+  (top-level `function` names and `var` / `let` / `const` targets) to the
+  shortest fresh names `a`, `b`, `c`, … in first-appearance order. It leaves
+  untouched: names already 1 character long (no shrink available), free /
+  undeclared globals (`window`, `console`, a called-but-undeclared
+  `helper()`), dotted property keys (`obj.total`), and any name in the
+  do-not-rename (externs) set.
+
+- **What upstream `RenameVars` additionally does** — renaming **local**
+  variables and function parameters, the pseudo-name / stable-name and
+  `_GLOBAL_`-prefix reservation modes, and re-using freed short names across
+  disjoint local scopes — our pass does not cover yet. Those cases are
+  ported as `#[ignore = "blocked on gap-NNN"]` placeholders pinned to
+  `code/specs/CLOC12-gaps.md` (gap-134 … gap-137) so they go live the moment
+  each gap closes.
+
+Every active test that *disagrees* with our pass is a real closurec defect,
+not a translation artifact — that is the entire point of the port.

--- a/code/packages/rust/closure-pass-rename-globals/tests/upstream/UPSTREAM_SHA
+++ b/code/packages/rust/closure-pass-rename-globals/tests/upstream/UPSTREAM_SHA
@@ -1,0 +1,13 @@
+# UPSTREAM_SHA
+#
+# Tracks google/closure-compiler at this commit. Every Rust file in
+# tests/upstream/ was ported from a Java file at this snapshot.
+#
+# Upgrade policy: bump this SHA only in a dedicated PR that re-ports
+# every Java source listed in ATTRIBUTION.md, diff-checks against the
+# previous port, and explicitly handles added / removed / renamed
+# tests per CLOC12 §4.
+
+commit:  5bb35ec1245dc1d3557481e5f8b4db344bcd1e6b
+date:    2026-05-28
+url:     https://github.com/google/closure-compiler/tree/5bb35ec1245dc1d3557481e5f8b4db344bcd1e6b

--- a/code/packages/rust/closure-pass-rename-globals/tests/upstream/rename_vars_test.rs
+++ b/code/packages/rust/closure-pass-rename-globals/tests/upstream/rename_vars_test.rs
@@ -1,0 +1,214 @@
+//! Ported from `RenameVarsTest.java` in `google/closure-compiler`,
+//! Apache-2.0. Upstream SHA: see `tests/upstream/UPSTREAM_SHA`.
+//!
+//! Translation policy: see
+//! `code/specs/CLOC12-upstream-test-suite-port.md`.
+//!
+//! This is a CLOC12 port for the `rename-globals` pass. Upstream
+//! `RenameVars` renames *every* variable — globals, locals, and parameters
+//! — to short names, with several reservation / stability modes. Our
+//! `RenameGlobalsPass` implements the provably-sound global slice: it
+//! renames **GLOBAL-scope** bindings (top-level `function` names and
+//! `var` / `let` / `const` targets) to the shortest fresh names
+//! `a`, `b`, `c`, … in first-appearance order, and leaves everything else
+//! alone (names already one character long, free/undeclared globals, dotted
+//! property keys, and any do-not-rename extern).
+//!
+//! So the file splits in two:
+//!
+//! - **Active `#[test]`s** — the upstream behaviors our pass genuinely
+//!   supports today, driving the real `source → bridge → rename → emit`
+//!   chain (the pass exposes a source-string surface through public crate
+//!   APIs, so — unlike the dce / remove-unused-vars AST-builder ports — we
+//!   assert on the emitted string exactly as upstream's `test(js, expected)`
+//!   does).
+//! - **`#[ignore = "blocked on gap-NNN"]` placeholders** — upstream intent
+//!   our global-only pass does not cover yet (local / parameter renaming,
+//!   pseudo-name mode, short-name reuse across scopes), each pinned to a
+//!   `gap-NNN` entry in `code/specs/CLOC12-gaps.md`. Run with
+//!   `--include-ignored` to measure progress as those gaps close.
+//!
+//! Every active test that *disagrees* with our pass is a real closurec
+//! defect, not a translation artifact — the whole point of the port.
+
+use coding_adventures_closure_emitter::{emit, EmitOptions};
+use coding_adventures_closure_pass_pipeline::{Pass, PassContext};
+use coding_adventures_closure_pass_rename_globals::RenameGlobalsPass;
+use coding_adventures_correlation_vector::CVLog;
+use coding_adventures_javascript_parser::{bridge, parse_javascript_typed};
+use coding_adventures_javascript_tokens::EsVersion;
+use coding_adventures_type_sidecar::Sidecar;
+use std::collections::HashSet;
+
+/// Parse `src`, bridge to a typed `Program`, run `RenameGlobalsPass` with the
+/// given do-not-rename (externs) set, and emit the minified result — the same
+/// chain closurec's ADVANCED level uses. Returns the emitted string.
+fn rename_with(src: &str, externs: &[&str]) -> String {
+    let es = EsVersion::Es2025;
+    let node = parse_javascript_typed(src, es).expect("parse");
+    let prog = bridge::grammar_to_program(&node, es).expect("bridge");
+
+    let set: HashSet<String> = externs.iter().map(|s| s.to_string()).collect();
+    let pass = RenameGlobalsPass::new(set);
+    let sidecar = Sidecar::new();
+    let mut cv = CVLog::new(false);
+    let out = pass
+        .run(PassContext {
+            program: &prog,
+            sidecar: &sidecar,
+            cv: &mut cv,
+        })
+        .expect("rename-globals");
+
+    let mut cv2 = CVLog::new(false);
+    let opts = EmitOptions {
+        source_map: false,
+        ..Default::default()
+    };
+    emit(&out.program, &sidecar, &mut cv2, &opts)
+        .expect("emit")
+        .code
+}
+
+fn rename(src: &str) -> String {
+    rename_with(src, &[])
+}
+
+// ===================================================================
+// Active ports — behaviors the global renamer supports today.
+// ===================================================================
+
+/// Upstream `testRenameSimple`: two distinct globals get the two shortest
+/// names in appearance order.
+#[test]
+fn renames_two_globals_to_a_and_b() {
+    assert_eq!(
+        rename("var alpha = 1; var beta = 2; use(alpha, beta);"),
+        "var a=1;var b=2;use(a,b);"
+    );
+}
+
+/// Every use of a renamed global is rewritten consistently — the binding and
+/// all reads collapse to the same short name.
+#[test]
+fn rewrites_all_uses_of_a_renamed_global() {
+    assert_eq!(
+        rename("var counter = 0; bump(counter); bump(counter);"),
+        "var a=0;bump(a);bump(a);"
+    );
+}
+
+/// A top-level `function` declaration is a global binding and is renamed like
+/// any other (upstream renames function names too).
+#[test]
+fn renames_a_global_function_declaration() {
+    assert_eq!(
+        rename("function computeTotal() { return 1; } computeTotal();"),
+        "function a(){return 1};a();"
+    );
+}
+
+/// Upstream `testDoNotRenameExterns`: the reserved name `apiHandler` is never
+/// touched, while the ordinary global `helper` is renamed to the first free
+/// short name `a` — at both its declaration and its call inside the reserved
+/// function's body.
+#[test]
+fn does_not_rename_reserved_extern() {
+    assert_eq!(
+        rename_with(
+            "function apiHandler() { return helper(); } function helper() { return 1; }",
+            &["apiHandler"],
+        ),
+        "function apiHandler(){return a()};function a(){return 1};",
+    );
+}
+
+/// A free/undeclared global referenced but never bound (`window`) is left
+/// exactly as written — the renamer only touches names it can see a binding
+/// for.
+#[test]
+fn leaves_free_undeclared_globals_untouched() {
+    assert_eq!(
+        rename("function greet() { console.log(window); } greet();"),
+        "function a(){console.log(window)};a();"
+    );
+}
+
+/// Upstream keeps property accesses stable: `obj.total` is a member key, not a
+/// variable reference, so it is never renamed even when a same-named global
+/// exists.
+#[test]
+fn does_not_rename_dotted_property_keys() {
+    assert_eq!(
+        rename("var total = 1; read(obj.total);"),
+        "var a=1;read(obj.total);"
+    );
+}
+
+/// A computed member `obj[key]` *does* reference the global `key`, so the
+/// index is renamed while the (undeclared) `obj` stays.
+#[test]
+fn renames_global_used_as_computed_member_index() {
+    assert_eq!(
+        rename("var key = 2; read(obj[key]);"),
+        "var a=2;read(obj[a]);"
+    );
+}
+
+/// Upstream never lengthens a name: a global already one character long has no
+/// shorter form available, so it is left as-is.
+#[test]
+fn does_not_rename_already_single_char_global() {
+    assert_eq!(rename("function f() { return 1; } f();"), "function f(){return 1};f();");
+}
+
+// ===================================================================
+// Ignored ports — upstream intent the global-only pass does not cover.
+// Each is pinned to a gap in code/specs/CLOC12-gaps.md.
+// ===================================================================
+
+/// Upstream `RenameVars` also renames LOCAL variables inside function bodies.
+/// Our pass only renames globals, so `inner` is left untouched today.
+#[test]
+#[ignore = "blocked on gap-134: rename-globals does not rename function-local variables"]
+fn renames_a_local_variable() {
+    assert_eq!(
+        rename("function f() { var innerLongName = 1; return innerLongName; } f();"),
+        "function a(){var b=1;return b};a();"
+    );
+}
+
+/// Upstream renames function PARAMETERS. Our pass leaves parameter names alone.
+#[test]
+#[ignore = "blocked on gap-135: rename-globals does not rename function parameters"]
+fn renames_a_function_parameter() {
+    assert_eq!(
+        rename("function f(longParam) { return longParam; } f(1);"),
+        "function a(b){return b};a(1);"
+    );
+}
+
+/// Upstream can re-use a freed short name across two DISJOINT local scopes
+/// (both locals may become `a`). Our global-only pass never allocates local
+/// names at all.
+#[test]
+#[ignore = "blocked on gap-136: rename-globals does not reuse short names across disjoint local scopes"]
+fn reuses_short_names_across_disjoint_scopes() {
+    assert_eq!(
+        rename("function f() { var longOne = 1; return longOne; } function g() { var longTwo = 2; return longTwo; }"),
+        "function a(){var c=1;return c};function b(){var c=2;return c}"
+    );
+}
+
+/// Upstream's pseudo-name mode maps each original name to a stable
+/// human-readable placeholder rather than a minimal short name. Our pass has
+/// no pseudo-name mode.
+#[test]
+#[ignore = "blocked on gap-137: rename-globals has no pseudo-name / stable-name mode"]
+fn pseudo_name_mode_uses_stable_placeholders() {
+    // Upstream `$longName$$` style placeholder; unsupported today.
+    assert_eq!(
+        rename("var longName = 1; use(longName);"),
+        "var $longName$$=1;use($longName$$);"
+    );
+}

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -1084,3 +1084,35 @@ historical context with status `RESOLVED` and a link to the fix PR.
     duplicated / re-evaluated), and (2) parenthesize the substituted expression
     against the surrounding operator's precedence. Candidate for a dedicated
     follow-up fix PR.
+
+## CLOC12.139 — port `RenameVarsTest` into `closure-pass-rename-globals`
+
+- **Status:** port landed; 8 active `#[test]`s pass, 4 `#[ignore]` gaps opened.
+- **What it is:** the sixth CLOC12 upstream port. `closure-pass-rename-globals`
+  exposes everything a source-string surface needs through public crate APIs,
+  so — unlike the AST-builder ports (dce, remove-unused-vars) — this port drives
+  the real `source → bridge → RenameGlobalsPass → emit` chain and asserts on the
+  emitted string, exactly as upstream `RenameVarsTest`'s `test(js, expected)`.
+  It pins the sound global slice our `RenameGlobalsPass` implements: rename
+  top-level `function` names and `var`/`let`/`const` targets to the shortest
+  fresh names `a`, `b`, `c`, … in first-appearance order, leaving untouched
+  names already one character long, free/undeclared globals, dotted property
+  keys, and any do-not-rename extern. 8 active cases pass (two-globals→`a`/`b`,
+  all-uses-rewritten, function-decl rename, reserved-extern-skipped-but-ordinary-
+  global-renamed, free-global-untouched, dotted-key-untouched, computed-member-
+  index-renamed, single-char-not-lengthened).
+- **No new closurec bug surfaced** — one expectation was corrected during the
+  port (the reserved-extern case renames the *ordinary* global `helper`→`a`
+  while keeping only the reserved `apiHandler`, which is the correct behavior).
+- **New gaps** (executable `#[ignore = "blocked on gap-NNN"]` placeholders):
+  - **gap-134** — rename **function-local** variables. Upstream `RenameVars`
+    shortens locals too; our pass only renames globals, so a body-local
+    `var innerLongName` is left as written.
+  - **gap-135** — rename **function parameters**. Upstream shortens parameter
+    names; our pass leaves them untouched.
+  - **gap-136** — **reuse** a freed short name across two disjoint local scopes
+    (both locals may become `a`). Our global-only pass never allocates local
+    names, so it cannot reuse them.
+  - **gap-137** — **pseudo-name / stable-name mode**: upstream can map each
+    original name to a stable human-readable placeholder instead of a minimal
+    short name. Our pass has only the minimal-short-name mode.


### PR DESCRIPTION
## What & why (#88 — upstream test-suite port)

Sixth CLOC12 upstream port. `closure-pass-rename-globals` exposes a source-string surface through public crate APIs, so — unlike the AST-builder ports (dce, remove-unused-vars) — this port drives the **real `source → bridge → RenameGlobalsPass → emit` chain** and asserts on the emitted string, exactly as upstream `RenameVarsTest`'s `test(js, expected)`.

## Coverage

**8 active `#[test]`s pass**, pinning the sound global slice our pass implements — rename top-level `function` names and `var`/`let`/`const` targets to the shortest fresh names `a`,`b`,`c` in first-appearance order:

- two globals → `a`/`b`; every use rewritten consistently
- a global function-declaration renamed
- reserved-extern case: only the reserved `apiHandler` is kept, the ordinary global `helper` is renamed to `a` (at decl **and** its call site)
- free/undeclared global (`window`) left untouched
- dotted property key (`obj.total`) left untouched
- global used as a computed-member index (`obj[key]`) renamed
- single-character global not lengthened

**No new closurec bug surfaced** — the port validated correct behavior (one draft expectation was corrected during authoring).

## Gaps staked (`#[ignore = "blocked on gap-NNN"]`)

4 upstream behaviors the global-only pass does not cover yet, pinned to `code/specs/CLOC12-gaps.md` §CLOC12.139:
- **gap-134** — function-local variable renaming
- **gap-135** — function-parameter renaming
- **gap-136** — short-name reuse across disjoint local scopes
- **gap-137** — pseudo-name / stable-name mode

## Verification

- `cargo test --test upstream_rename_vars`: **8 passed, 4 ignored**.
- Full crate suite green (18 lib + port). **No library code changed** — test coverage + docs only.
- Inline security review: **PASSED** (test-only; no `unsafe`, no I/O, no untrusted input, dev-only `[[test]]`).

Bumps `closure-pass-rename-globals` 0.7.0 → 0.7.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)