### PR TITLE
docs(spec): sir-collection-methods — executable collection methods across all languages

### DIFF
--- a/code/specs/sir-collection-methods.md
+++ b/code/specs/sir-collection-methods.md
@@ -1,0 +1,165 @@
+# sir-collection-methods — executable collection methods across all languages
+
+## Status
+
+New. Design/spec PR (specs-first). The next cascade under the full-syntax mandate,
+chosen after the keyword-params cascade landed and the Ruby-1.0 bump was **held**
+to close more gaps first.
+
+Goal: make **collection methods** — `.map` / `.each` / `.select` / `.reject` /
+`.reduce`/`.inject` / `.push`/`<<` / `.pop` / `.length`/`.size` / `.keys` /
+`.values` / `.include?` / `.first` / `.last` / … — **parse, lower, and execute
+end-to-end in every source language and every backend**. These are ubiquitous in
+real Ruby/Python/JS; closing this gap is the single biggest step toward "run real
+programs."
+
+This is the mandate's **backend-runtime-library arm**: where a target language has
+no native form (Go, and the reflective/uniform-dispatch cases), the backend ships a
+small runtime library that implements the operation; where a native form exists
+(JS `.map`, Python `.append`), the backend may direct-lower.
+
+## Current state (from the 2026-07-01 dispatch survey — what already works)
+
+The narrow waist for a method call **already exists** and needs no new node:
+
+```
+BuiltinCall { name: "__method__", args: [receiver, StrLit(method_name), ...args], effects, span }
+```
+- Receiver at `args[0]`; method name is always a `StrLit` at `args[1]`; call args follow;
+  an optional trailing block is a `MakeClosure` (RB1) / `block_pass` envelope.
+
+What is **already implemented** (do not rebuild):
+- **Ruby frontend** (`ruby-to-semantic-ir`): every `recv.meth(...)`/`recv.meth { }` already
+  lowers to `__method__` dispatch (`lower.rs` `fold_one_dot_call`). ✅
+- **Python + TypeScript backends**: already emit dispatch to their OOP runtime
+  (`_sir_oop_call_method` / `__SirOop.callMethod`), and **`sir-runtime-oop`
+  (Python + TS) already implements 50+ collection methods** across Array / Hash /
+  String / Numeric / Symbol, including block-passing (`apply` over `Closure`) and
+  `Symbol#to_proc` (`&:sym`). ✅ So **Ruby→Python and Ruby→TS collection code runs
+  today.**
+- **JavaScript backend**: accepts `__method__`; routes to the JS OOP runtime.
+  (Verify end-to-end as part of KWc below.)
+
+The **real gaps** this cascade closes:
+1. **Python & JavaScript frontends** currently **defer** all method/attribute calls to a
+   positioned error (only `console.log` is special-cased in JS). → they never produce
+   collection-method dispatch.
+2. **Go & Rust backends reject** any `__method__` dispatch (they don't accept the OOP
+   feature gate). Go has **no** native method forms, so it needs a **new Go runtime
+   library**; Rust needs a **new Rust runtime library** (or an iterator-based
+   direct-lowering).
+3. **No dedicated feature flag**: `__method__` is implicitly gated by OOP features
+   (`Classes`/`InstanceVars`/…). Collection methods have nothing to do with classes,
+   so they can't be enabled without dragging in class semantics.
+
+## Design
+
+### C1 — core: a `Feature::MethodDispatch` flag (`semantic-ir`)
+
+Add `Feature::MethodDispatch`, observed by the validator whenever a
+`BuiltinCall("__method__", …)` is present. This **decouples** method dispatch from
+`Classes`/OOP so a backend can accept collection methods without accepting classes,
+and lets each backend gate cleanly. (This is a core `Feature` enum addition — a
+*variant*, so per the cross-PR lesson every downstream `Feature` match must gain an
+arm and `cargo build --workspace` must pass before merge. The observation/gating
+mirrors how `DefaultParams`/`KeywordParams` were wired.)
+
+Backends that already dispatch (Python/TS/JS) add `MethodDispatch` to their accepted
+set; Go/Rust add it once their runtime lands (C5/C6).
+
+No change to the `__method__` convention itself.
+
+### C2 — Python frontend production (`python-to-semantic-ir`)
+
+Lower Python method/attribute calls (currently deferred) to `__method__` dispatch,
+mirroring Ruby's `fold_one_dot_call`:
+- `lst.append(x)` → `BuiltinCall("__method__", [lst, StrLit("append"), x])`
+- `lst.map(...)`, `d.keys()`, `d.values()`, `s.upper()`, `lst.pop()`, membership, etc.
+- Python has no trailing-block syntax; higher-order calls pass a lambda/closure as an
+  ordinary arg (already `MakeClosure`). Comprehensions stay out of scope (separate
+  cascade).
+- Declare `Feature::MethodDispatch` when produced.
+
+### C3 — JavaScript frontend production (`javascript-to-semantic-ir`)
+
+Lower JS member-method calls (currently deferred except `console.log`) to
+`__method__` dispatch: `arr.map(fn)`, `arr.push(x)`, `arr.filter(fn)`,
+`obj.hasOwnProperty(k)`, `str.toUpperCase()`, `.length` (property → `length`
+dispatch or `SeqLen`), etc. Keep `console.log` special-casing. Declare the feature.
+
+### C4 — verify/complete the JavaScript backend dispatch
+
+Confirm `semantic-ir-to-javascript` emits `__method__` through a JS OOP runtime and
+executes the v0 catalog through `node`; fill any missing catalog coverage so JS
+reaches parity with Python/TS. Add `MethodDispatch` to accepted features.
+
+### C5 — Go backend runtime library + dispatch (`semantic-ir-to-go` + new Go runtime)
+
+The largest piece. Go has no native method dispatch, so:
+- Ship a **new Go runtime package** (`sir-runtime-oop` Go analogue, e.g.
+  `code/packages/go/sir-runtime-oop`) providing `CallMethod(recv, name, args…, block)`
+  with the same v0 catalog (Array/Hash/String/Numeric), block application over the Go
+  closure representation, and `Symbol#to_proc`. Model it on the Python/TS runtime's
+  catalog for behavioural parity (same method names, same semantics), execution-proofed
+  against the reference backends.
+- Emit `__method__` → `sirruntimeoop.CallMethod(recv, "name", args…)`; import the
+  package conditionally (mirror the Python/TS runtime-import gating). Accept
+  `Feature::MethodDispatch`.
+- Where a Go-native form is trivially correct and cheaper (`len(x)` for `length`/`size`
+  already via `SeqLen`), keep direct-lowering; route the rest through the runtime.
+
+### C6 — Rust backend runtime library + dispatch (`semantic-ir-to-rust` + new Rust runtime)
+
+Same shape as Go: a **new Rust runtime crate** implementing the catalog over the Rust
+`Value` representation with block application, or an iterator-based direct-lowering
+where it's clean. Emit dispatch to it; accept `MethodDispatch`. (Rust's owned/borrow
+model makes a `Value`-boxed runtime the pragmatic v0 — match the runtime-lib approach
+rather than fighting the type system with native iterators.)
+
+### Native-vs-runtime policy (per the mandate)
+
+- **Direct-lower** when the target has a faithful native form the backend can emit
+  without the runtime (e.g. `length`/`size` → existing `SeqLen`; a later optimization
+  pass could direct-lower JS `.map`/Python `.append`). Correctness first: v0 routes
+  through the runtime uniformly except where a native node already exists.
+- **Runtime library** everywhere else (all of Go; the reflective/block cases).
+
+## Milestones (one PR per crate; core first)
+
+| # | Crate | Content |
+|---|-------|---------|
+| C0 | `code/specs/` | **this spec** (design PR, surfaced first) |
+| C1 | `semantic-ir` | `Feature::MethodDispatch` + validator observation + downstream `Feature`-match arms (workspace-build gate) |
+| C2 | `python-to-semantic-ir` | lower `.method(...)`/attribute calls → `__method__` (execution-proof Python→Python) |
+| C3 | `javascript-to-semantic-ir` | lower member-method calls → `__method__` (execution-proof JS→JS) |
+| C4 | `semantic-ir-to-javascript` (+ JS runtime) | confirm/complete dispatch + catalog parity (node exec-proof) |
+| C5 | `code/packages/go/sir-runtime-oop` + `semantic-ir-to-go` | Go runtime lib + dispatch emission (go-run exec-proof vs reference) |
+| C6 | `sir-runtime-oop` (Rust) + `semantic-ir-to-rust` | Rust runtime lib + dispatch emission (rustc exec-proof vs reference) |
+
+**Sequencing:** C1 (core `Feature` variant) merges **first**; the rest rebase on it.
+C2/C3 (frontends) and C4 are independent, disjoint lanes that can run in parallel once
+C1 lands. C5/C6 (new runtime packages + their backends) are the largest and mutually
+disjoint. Every backend/frontend PR: tests via the linker override, clippy clean,
+security-review gate, `cargo build --workspace` before pushing anything core-touching.
+
+## Verification
+
+- **C1:** validator observes `MethodDispatch` on any `__method__`; gating test; workspace build.
+- **Frontends (C2/C3):** lowering-assertion tests (`.append`/`.map`/`.keys` → correct dispatch
+  shape) + round-trip through `validate` + **execution-proof** (Python→Python via python3,
+  JS→JS via node) of a small collection program (`[1,2,3].map/select/reduce`, `dict.keys`).
+- **Backends (C4/C5/C6):** emitted-shape tests + **execution-proof** through the native toolchain
+  (node/go run/rustc), diffing stdout against the Python/TS reference for the same SIR module
+  (e.g. Ruby `[1,2,3].select { |x| x.even? }.map { |x| x*10 }` → `[20]` in every backend).
+- **Runtime parity:** the Go/Rust runtime catalogs match the Python/TS method names + semantics
+  (same v0 set); a shared golden-program suite runs through all five backends.
+
+## Out of scope (documented)
+
+- Comprehensions (`[x*2 for x in xs]`, Ruby `map`-via-block is in scope but Python/Ruby
+  comprehension *syntax* is a separate cascade).
+- User-defined method resolution order / mixins (`include`/`extend`) — a later cascade;
+  this cascade is built-in collection/String/Numeric methods on core types only.
+- Lazy enumerators, `Enumerator`, `each_with_object`-style accumulators beyond the v0 catalog.
+- The native-direct-lowering optimization pass (v0 routes through the runtime uniformly
+  except where a native SIR node already exists).


### PR DESCRIPTION
## What

Design/spec PR for the **collection-methods cascade** — the next full-syntax-mandate cascade you chose (after holding the Ruby-1.0 bump). Goal: `.map`/`.each`/`.select`/`.reduce`/`.push`/`.length`/`.keys`/`.include?`/… **parse, lower, and execute end-to-end in every language.** Specs-first — one markdown file, surfaced for your review before any code.

## Key finding: much already exists

A dispatch survey showed the machinery is further along than expected:
- **Core dispatch node exists** — `BuiltinCall("__method__", [recv, StrLit(name), ...args])`. **No new IR node needed.**
- **Ruby frontend already emits it**; **Python + TS backends + `sir-runtime-oop` already implement 50+ collection methods** (Array/Hash/String/Numeric) with block-passing + `Symbol#to_proc`. So **Ruby → Python/TS collection code already runs today.**

## The real gaps (what this cascade actually builds)

1. **Python & JS frontends defer** all method calls → lower them to dispatch (mirror Ruby's `fold_one_dot_call`).
2. **Go & Rust backends reject** dispatch → **new Go/Rust runtime libraries** + dispatch emission. Go has no native methods, so its runtime is the **biggest single piece**.
3. **No clean feature gate** → add `Feature::MethodDispatch` (decouples collection methods from class/OOP semantics).

## Milestones

| # | Crate | Content |
|---|---|---|
| C0 | specs | this spec |
| C1 | `semantic-ir` | `Feature::MethodDispatch` (core variant — workspace-build gate) |
| C2 | `python-to-semantic-ir` | lower `.method()` → dispatch |
| C3 | `javascript-to-semantic-ir` | lower member calls → dispatch |
| C4 | `semantic-ir-to-javascript` | confirm/complete JS dispatch + catalog parity |
| C5 | new Go `sir-runtime-oop` + `semantic-ir-to-go` | Go runtime lib + dispatch |
| C6 | new Rust runtime + `semantic-ir-to-rust` | Rust runtime lib + dispatch |

C1 first; C2/C3/C4 parallel after; C5/C6 the big disjoint pieces. Execution-proof through each native toolchain vs the Python/TS reference; security-review per PR.

## For your review — the scoping decision worth flagging

**C5/C6 (Go + Rust runtime libraries) are a large lift** — effectively porting the `sir-runtime-oop` catalog to two new languages. C2/C3/C4 (Python/JS frontends + JS backend) are **high-value and much cheaper**, since the backends+runtime already handle the dispatch. I'll confirm the phasing with you before starting code (see the message accompanying this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)