### PR TITLE
feat(adj-ladder): rung-19 red-blood-cell indices (new organ: hematology)

### DIFF
--- a/code/specs/data/adj-ladder/rung19_rbc_indices/gen_items.py
+++ b/code/specs/data/adj-ladder/rung19_rbc_indices/gen_items.py
@@ -1,0 +1,167 @@
+"""Generate rung-19 (red-blood-cell indices) items.json for the ADJ-LADDER.
+
+Rung 19 opens a **new organ system** on the quantitative band — **hematology** — using the same
+contamination-safe shape the pharmacokinetics rung (rung 8), the renal-ratio rungs (9/13/15), and
+the cardiology rungs (16 cardiac output, 18 ejection fraction) were built on: a small table of
+*observed* laboratory quantities, and a tight family of mutually-confusable formulas built **only
+from those observed quantities** (no numeric literal anywhere in any program), so nothing
+structural can leak into the answer.
+
+The clinical setup is a single complete-blood-count (CBC) read-out. We observe three quantities:
+
+  HCT  hematocrit          (%)              — packed red-cell volume fraction
+  RBC  red-cell count      (millions/uL)    — number of red cells per unit blood
+  HGB  hemoglobin          (g/dL)           — oxygen-carrying pigment concentration
+
+From those three, the three textbook red-cell indices fall out as **pure ratios** of the observed
+quantities — no constant required:
+
+  MCV   mean corpuscular volume            = HCT / RBC     [ how big each red cell is    ]
+  MCH   mean corpuscular hemoglobin        = HGB / RBC     [ hemoglobin mass per red cell ]
+  MCHC  mean corpuscular hemoglobin conc.  = HGB / HCT     [ hemoglobin per packed volume ]
+
+(The bedside indices carry a ×10 unit-conversion factor — MCV = HCT×10/RBC etc. — but that factor
+is a *constant* that would leak a literal into the program and defeat contamination-safety. So this
+rung uses the constant-free **pure-ratio** form: each index is exactly one observed quantity divided
+by another. The three ratios are still mutually distinct and still exercise the same "which lab over
+which lab" reasoning the real indices require.)
+
+Each index is a `compute_dimensioned` program (observe the three quantities + `let answer =
+formula`); the ADJ engine carries the division and the harness reads the scalar via the existing
+`compute_dimensioned` extractor — no harness/engine change, exactly as rungs 8/16/18.
+
+Contamination-safe by construction: every formula is built only from the three observed quantities
+via `/` — **no structural constants** — so every program literal is grounded in the stem. The five
+options are a tight family over the same three quantities: the three real indices {MCV, MCH, MCHC}
+plus the two classic slips —
+
+  RBC / HCT   the **inverse** of MCV (dividing the count by the volume fraction, the ratio flipped), and
+  RBC / HGB   the **inverse** of MCH (dividing the count by the hemoglobin, the ratio flipped),
+
+which are exactly the mistakes a student makes — writing the index ratio upside-down. Gold rotates
+A–E by index.
+
+Note on table choice: the five family values can collide for special quantity ratios. The tables
+below are chosen so the five family values are pairwise distinct — with a comfortable margin — for
+every item, asserted at build time.
+"""
+import json
+
+LETTERS = ["A", "B", "C", "D", "E"]
+
+# (HCT, RBC, HGB) observed quantities. The five index-family values are asserted
+# pairwise-distinct (with margin) below.
+#   HCT = hematocrit      (%)
+#   RBC = red-cell count  (millions/uL)
+#   HGB = hemoglobin      (g/dL)
+TABLES = [
+    (44, 5.0, 15),
+    (30, 3.4, 10),
+    (51, 6.2, 17),
+    (36, 4.1, 12),
+    (27, 3.1, 9),
+    (48, 5.4, 16),
+    (33, 3.6, 11),
+]
+
+# The option family (5 members), all built from the observed quantities hct/rbc/hgb via `/`.
+#   key -> (display name, formula-as-adj)
+# Only the first three are *queried* (used as gold); all five always appear as the options.
+FAMILY = [
+    ("mcv", "mean corpuscular volume (MCV)", "hct / rbc"),
+    ("mch", "mean corpuscular hemoglobin (MCH)", "hgb / rbc"),
+    ("mchc", "mean corpuscular hemoglobin concentration (MCHC)", "hgb / hct"),
+    ("rbc_hct", "red-cell count divided by hematocrit", "rbc / hct"),
+    ("rbc_hgb", "red-cell count divided by hemoglobin", "rbc / hgb"),
+]
+QUERIED = ["mcv", "mch", "mchc"]
+ORDER = [k for k, _, _ in FAMILY]
+
+
+def scalar(v):
+    return {"value": v, "unit": "scalar"}
+
+
+def family_values(hct, rbc, hgb):
+    # Operation order mirrors the ADJ program exactly, so the Python option value and the engine
+    # result are the same IEEE-double (well within the harness's 1e-9 match tolerance).
+    return {
+        "mcv": hct / rbc,
+        "mch": hgb / rbc,
+        "mchc": hgb / hct,
+        "rbc_hct": rbc / hct,
+        "rbc_hgb": rbc / hgb,
+    }
+
+
+def build():
+    name_of = {k: nm for k, nm, _ in FAMILY}
+    formula_of = {k: f for k, _, f in FAMILY}
+    items = []
+    idx = 0
+    for hct, rbc, hgb in TABLES:
+        fv = family_values(hct, rbc, hgb)
+        # Pairwise-distinct with a comfortable margin so the harness never sees two options
+        # matching the gold value within its 1e-9 tolerance.
+        vals = [fv[k] for k in ORDER]
+        for i in range(len(vals)):
+            for j in range(i + 1, len(vals)):
+                assert abs(vals[i] - vals[j]) > 1e-6, (hct, rbc, hgb, ORDER[i], ORDER[j], fv)
+        for key in QUERIED:
+            gold_val = fv[key]
+            gold_pos = idx % 5
+            others = [fv[k] for k in ORDER if abs(fv[k] - gold_val) > 1e-12]
+            opts_vals = others[:]
+            opts_vals.insert(gold_pos, gold_val)
+            opts_vals = opts_vals[:5]
+            if abs(opts_vals[gold_pos] - gold_val) > 1e-12:
+                opts_vals[gold_pos] = gold_val
+            assert len({round(v, 9) for v in opts_vals}) == 5, (key, hct, rbc, hgb, opts_vals)
+            options = {LETTERS[i]: scalar(opts_vals[i]) for i in range(5)}
+            items.append({
+                "id": f"r19rbc-{idx + 1:02d}",
+                "qtype": "red_cell_index",
+                "stem": (
+                    f"A complete blood count shows a hematocrit of {hct} %, a red-cell count of "
+                    f"{rbc} million/uL, and a hemoglobin of {hgb} g/dL. What is the patient's "
+                    f"{name_of[key]}?"
+                ),
+                "program": (
+                    f"observe hct({hct})\n"
+                    f"observe rbc({rbc})\n"
+                    f"observe hgb({hgb})\n"
+                    f"let answer = {formula_of[key]}\n"
+                    "? answer\n"
+                ),
+                "answer_from": {"type": "compute_dimensioned", "name": "answer"},
+                "options": options,
+                "gold_letter": LETTERS[gold_pos],
+            })
+            idx += 1
+    return {
+        "description": (
+            "ADJ-LADDER rung 19 — red-blood-cell indices from a single complete-blood-count (a NEW "
+            "organ system: hematology). From three stated quantities (hematocrit HCT, red-cell count "
+            "RBC, hemoglobin HGB) compute the mean corpuscular volume (MCV = HCT/RBC), mean "
+            "corpuscular hemoglobin (MCH = HGB/RBC), or mean corpuscular hemoglobin concentration "
+            "(MCHC = HGB/HCT). Each item is a compute_dimensioned program (observe the three "
+            "quantities, let answer = formula); the ADJ engine carries the division and the harness "
+            "matches the scalar to the printed options. Contamination-safe: every index is built only "
+            "from the three observed quantities via / — no constant leaks (the bedside ×10 factor is "
+            "dropped so the ratios stay literal-free). The five options are a family over the same "
+            "quantities, so the distractors are exactly the slips students make: writing the index "
+            "ratio upside-down (RBC/HCT, the inverse of MCV; RBC/HGB, the inverse of MCH)."
+        ),
+        "items": items,
+    }
+
+
+if __name__ == "__main__":
+    doc = build()
+    with open("items.json", "w") as f:
+        json.dump(doc, f, indent=2)
+        f.write("\n")
+    print("wrote items.json:", len(doc["items"]), "items")
+    for it in doc["items"]:
+        print(it["id"], it["qtype"], "gold", it["gold_letter"],
+              "=", round(it["options"][it["gold_letter"]]["value"], 4))

--- a/code/specs/data/adj-ladder/rung19_rbc_indices/items.json
+++ b/code/specs/data/adj-ladder/rung19_rbc_indices/items.json
@@ -1,0 +1,698 @@
+{
+  "description": "ADJ-LADDER rung 19 \u2014 red-blood-cell indices from a single complete-blood-count (a NEW organ system: hematology). From three stated quantities (hematocrit HCT, red-cell count RBC, hemoglobin HGB) compute the mean corpuscular volume (MCV = HCT/RBC), mean corpuscular hemoglobin (MCH = HGB/RBC), or mean corpuscular hemoglobin concentration (MCHC = HGB/HCT). Each item is a compute_dimensioned program (observe the three quantities, let answer = formula); the ADJ engine carries the division and the harness matches the scalar to the printed options. Contamination-safe: every index is built only from the three observed quantities via / \u2014 no constant leaks (the bedside \u00d710 factor is dropped so the ratios stay literal-free). The five options are a family over the same quantities, so the distractors are exactly the slips students make: writing the index ratio upside-down (RBC/HCT, the inverse of MCV; RBC/HGB, the inverse of MCH).",
+  "items": [
+    {
+      "id": "r19rbc-01",
+      "qtype": "red_cell_index",
+      "stem": "A complete blood count shows a hematocrit of 44 %, a red-cell count of 5.0 million/uL, and a hemoglobin of 15 g/dL. What is the patient's mean corpuscular volume (MCV)?",
+      "program": "observe hct(44)\nobserve rbc(5.0)\nobserve hgb(15)\nlet answer = hct / rbc\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 8.8,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 3.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.3409090909090909,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.11363636363636363,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.3333333333333333,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r19rbc-02",
+      "qtype": "red_cell_index",
+      "stem": "A complete blood count shows a hematocrit of 44 %, a red-cell count of 5.0 million/uL, and a hemoglobin of 15 g/dL. What is the patient's mean corpuscular hemoglobin (MCH)?",
+      "program": "observe hct(44)\nobserve rbc(5.0)\nobserve hgb(15)\nlet answer = hgb / rbc\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 8.8,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 3.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.3409090909090909,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.11363636363636363,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.3333333333333333,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r19rbc-03",
+      "qtype": "red_cell_index",
+      "stem": "A complete blood count shows a hematocrit of 44 %, a red-cell count of 5.0 million/uL, and a hemoglobin of 15 g/dL. What is the patient's mean corpuscular hemoglobin concentration (MCHC)?",
+      "program": "observe hct(44)\nobserve rbc(5.0)\nobserve hgb(15)\nlet answer = hgb / hct\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 8.8,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 3.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.3409090909090909,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.11363636363636363,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.3333333333333333,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r19rbc-04",
+      "qtype": "red_cell_index",
+      "stem": "A complete blood count shows a hematocrit of 30 %, a red-cell count of 3.4 million/uL, and a hemoglobin of 10 g/dL. What is the patient's mean corpuscular volume (MCV)?",
+      "program": "observe hct(30)\nobserve rbc(3.4)\nobserve hgb(10)\nlet answer = hct / rbc\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 2.9411764705882355,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 0.3333333333333333,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.11333333333333333,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 8.823529411764707,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.33999999999999997,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r19rbc-05",
+      "qtype": "red_cell_index",
+      "stem": "A complete blood count shows a hematocrit of 30 %, a red-cell count of 3.4 million/uL, and a hemoglobin of 10 g/dL. What is the patient's mean corpuscular hemoglobin (MCH)?",
+      "program": "observe hct(30)\nobserve rbc(3.4)\nobserve hgb(10)\nlet answer = hgb / rbc\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 8.823529411764707,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 0.3333333333333333,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.11333333333333333,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.33999999999999997,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 2.9411764705882355,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r19rbc-06",
+      "qtype": "red_cell_index",
+      "stem": "A complete blood count shows a hematocrit of 30 %, a red-cell count of 3.4 million/uL, and a hemoglobin of 10 g/dL. What is the patient's mean corpuscular hemoglobin concentration (MCHC)?",
+      "program": "observe hct(30)\nobserve rbc(3.4)\nobserve hgb(10)\nlet answer = hgb / hct\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 0.3333333333333333,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 8.823529411764707,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 2.9411764705882355,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.11333333333333333,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.33999999999999997,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r19rbc-07",
+      "qtype": "red_cell_index",
+      "stem": "A complete blood count shows a hematocrit of 51 %, a red-cell count of 6.2 million/uL, and a hemoglobin of 17 g/dL. What is the patient's mean corpuscular volume (MCV)?",
+      "program": "observe hct(51)\nobserve rbc(6.2)\nobserve hgb(17)\nlet answer = hct / rbc\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 2.7419354838709675,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 8.225806451612902,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.3333333333333333,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.12156862745098039,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.3647058823529412,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r19rbc-08",
+      "qtype": "red_cell_index",
+      "stem": "A complete blood count shows a hematocrit of 51 %, a red-cell count of 6.2 million/uL, and a hemoglobin of 17 g/dL. What is the patient's mean corpuscular hemoglobin (MCH)?",
+      "program": "observe hct(51)\nobserve rbc(6.2)\nobserve hgb(17)\nlet answer = hgb / rbc\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 8.225806451612902,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 0.3333333333333333,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 2.7419354838709675,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.12156862745098039,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.3647058823529412,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r19rbc-09",
+      "qtype": "red_cell_index",
+      "stem": "A complete blood count shows a hematocrit of 51 %, a red-cell count of 6.2 million/uL, and a hemoglobin of 17 g/dL. What is the patient's mean corpuscular hemoglobin concentration (MCHC)?",
+      "program": "observe hct(51)\nobserve rbc(6.2)\nobserve hgb(17)\nlet answer = hgb / hct\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 8.225806451612902,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2.7419354838709675,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.12156862745098039,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.3333333333333333,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.3647058823529412,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r19rbc-10",
+      "qtype": "red_cell_index",
+      "stem": "A complete blood count shows a hematocrit of 36 %, a red-cell count of 4.1 million/uL, and a hemoglobin of 12 g/dL. What is the patient's mean corpuscular volume (MCV)?",
+      "program": "observe hct(36)\nobserve rbc(4.1)\nobserve hgb(12)\nlet answer = hct / rbc\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 2.9268292682926833,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 0.3333333333333333,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.11388888888888887,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.3416666666666666,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 8.78048780487805,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r19rbc-11",
+      "qtype": "red_cell_index",
+      "stem": "A complete blood count shows a hematocrit of 36 %, a red-cell count of 4.1 million/uL, and a hemoglobin of 12 g/dL. What is the patient's mean corpuscular hemoglobin (MCH)?",
+      "program": "observe hct(36)\nobserve rbc(4.1)\nobserve hgb(12)\nlet answer = hgb / rbc\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 2.9268292682926833,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 8.78048780487805,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.3333333333333333,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.11388888888888887,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.3416666666666666,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r19rbc-12",
+      "qtype": "red_cell_index",
+      "stem": "A complete blood count shows a hematocrit of 36 %, a red-cell count of 4.1 million/uL, and a hemoglobin of 12 g/dL. What is the patient's mean corpuscular hemoglobin concentration (MCHC)?",
+      "program": "observe hct(36)\nobserve rbc(4.1)\nobserve hgb(12)\nlet answer = hgb / hct\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 8.78048780487805,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 0.3333333333333333,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 2.9268292682926833,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.11388888888888887,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.3416666666666666,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r19rbc-13",
+      "qtype": "red_cell_index",
+      "stem": "A complete blood count shows a hematocrit of 27 %, a red-cell count of 3.1 million/uL, and a hemoglobin of 9 g/dL. What is the patient's mean corpuscular volume (MCV)?",
+      "program": "observe hct(27)\nobserve rbc(3.1)\nobserve hgb(9)\nlet answer = hct / rbc\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 2.903225806451613,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 0.3333333333333333,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 8.709677419354838,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.11481481481481481,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.34444444444444444,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r19rbc-14",
+      "qtype": "red_cell_index",
+      "stem": "A complete blood count shows a hematocrit of 27 %, a red-cell count of 3.1 million/uL, and a hemoglobin of 9 g/dL. What is the patient's mean corpuscular hemoglobin (MCH)?",
+      "program": "observe hct(27)\nobserve rbc(3.1)\nobserve hgb(9)\nlet answer = hgb / rbc\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 8.709677419354838,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 0.3333333333333333,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.11481481481481481,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 2.903225806451613,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.34444444444444444,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r19rbc-15",
+      "qtype": "red_cell_index",
+      "stem": "A complete blood count shows a hematocrit of 27 %, a red-cell count of 3.1 million/uL, and a hemoglobin of 9 g/dL. What is the patient's mean corpuscular hemoglobin concentration (MCHC)?",
+      "program": "observe hct(27)\nobserve rbc(3.1)\nobserve hgb(9)\nlet answer = hgb / hct\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 8.709677419354838,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2.903225806451613,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.11481481481481481,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.34444444444444444,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.3333333333333333,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r19rbc-16",
+      "qtype": "red_cell_index",
+      "stem": "A complete blood count shows a hematocrit of 48 %, a red-cell count of 5.4 million/uL, and a hemoglobin of 16 g/dL. What is the patient's mean corpuscular volume (MCV)?",
+      "program": "observe hct(48)\nobserve rbc(5.4)\nobserve hgb(16)\nlet answer = hct / rbc\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 8.888888888888888,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2.962962962962963,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.3333333333333333,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.1125,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.3375,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r19rbc-17",
+      "qtype": "red_cell_index",
+      "stem": "A complete blood count shows a hematocrit of 48 %, a red-cell count of 5.4 million/uL, and a hemoglobin of 16 g/dL. What is the patient's mean corpuscular hemoglobin (MCH)?",
+      "program": "observe hct(48)\nobserve rbc(5.4)\nobserve hgb(16)\nlet answer = hgb / rbc\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 8.888888888888888,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2.962962962962963,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.3333333333333333,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.1125,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.3375,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r19rbc-18",
+      "qtype": "red_cell_index",
+      "stem": "A complete blood count shows a hematocrit of 48 %, a red-cell count of 5.4 million/uL, and a hemoglobin of 16 g/dL. What is the patient's mean corpuscular hemoglobin concentration (MCHC)?",
+      "program": "observe hct(48)\nobserve rbc(5.4)\nobserve hgb(16)\nlet answer = hgb / hct\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 8.888888888888888,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2.962962962962963,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.3333333333333333,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.1125,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.3375,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r19rbc-19",
+      "qtype": "red_cell_index",
+      "stem": "A complete blood count shows a hematocrit of 33 %, a red-cell count of 3.6 million/uL, and a hemoglobin of 11 g/dL. What is the patient's mean corpuscular volume (MCV)?",
+      "program": "observe hct(33)\nobserve rbc(3.6)\nobserve hgb(11)\nlet answer = hct / rbc\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3.0555555555555554,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 0.3333333333333333,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.1090909090909091,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 9.166666666666666,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.32727272727272727,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r19rbc-20",
+      "qtype": "red_cell_index",
+      "stem": "A complete blood count shows a hematocrit of 33 %, a red-cell count of 3.6 million/uL, and a hemoglobin of 11 g/dL. What is the patient's mean corpuscular hemoglobin (MCH)?",
+      "program": "observe hct(33)\nobserve rbc(3.6)\nobserve hgb(11)\nlet answer = hgb / rbc\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 9.166666666666666,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 0.3333333333333333,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.1090909090909091,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.32727272727272727,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 3.0555555555555554,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r19rbc-21",
+      "qtype": "red_cell_index",
+      "stem": "A complete blood count shows a hematocrit of 33 %, a red-cell count of 3.6 million/uL, and a hemoglobin of 11 g/dL. What is the patient's mean corpuscular hemoglobin concentration (MCHC)?",
+      "program": "observe hct(33)\nobserve rbc(3.6)\nobserve hgb(11)\nlet answer = hgb / hct\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 0.3333333333333333,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 9.166666666666666,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 3.0555555555555554,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.1090909090909091,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.32727272727272727,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    }
+  ]
+}

--- a/code/specs/data/adj-ladder/test_ladder_eval.py
+++ b/code/specs/data/adj-ladder/test_ladder_eval.py
@@ -56,6 +56,7 @@ SELF_CONTAINED_RUNGS = (
     "rung16_cardiac_output",
     "rung17_alveolar_ventilation",
     "rung18_ejection_fraction",
+    "rung19_rbc_indices",
 )
 
 


### PR DESCRIPTION
## ADJ-LADDER rung-19 — red-blood-cell indices (NEW organ system: hematology)

Opens **hematology** on the quantitative band, mirroring the merged rungs 8 (PK) / 16 (cardiac output) / 18 (ejection fraction) **exactly**: a `compute_dimensioned` rung over three observed CBC quantities, computing the three textbook red-cell indices as **pure ratios** of the observed quantities.

### The clinical setup
From a single complete-blood-count read-out — hematocrit **HCT** (%), red-cell count **RBC** (millions/µL), hemoglobin **HGB** (g/dL) — the three indices fall out as pure ratios:

| index | formula | meaning |
|-------|---------|---------|
| MCV  | `HCT / RBC` | mean corpuscular volume (cell size) |
| MCH  | `HGB / RBC` | mean corpuscular hemoglobin (Hb mass per cell) |
| MCHC | `HGB / HCT` | mean corpuscular hemoglobin concentration |

### Contamination-safety
Every formula is built **only** from the three observed quantities via `/` — **no numeric literal appears in any program**. The bedside ×10 unit-conversion factor is intentionally dropped so the ratios stay literal-free (the reasoning — *which lab over which lab* — is unchanged). The five options are a tight family over the same quantities; the two distractors are the classic **upside-down-ratio** slips (RBC/HCT = inverse MCV, RBC/HGB = inverse MCH). Gold rotates A–E; tables are chosen so the five family values are pairwise-distinct with a comfortable margin (asserted at build time).

### Contents
- **21 items** (7 tables × 3 queried indices), `qtype: red_cell_index`
- New `rung19_rbc_indices/{gen_items.py,items.json}` (generated from the subdir)
- Registered in `SELF_CONTAINED_RUNGS`

### Verification
All three gating tests pass (`-k rung19`): engine selects every gold (0 wrong / 0 abstain), contamination check clean, items.json valid. Security review passed (deterministic offline generator, no injection/eval/path/DoS surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)