### PR TITLE
test(rename-properties): port RenamePropertiesTest (#88, CLOC12.140)

### DIFF
--- a/code/packages/rust/closure-pass-rename-properties/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename-properties/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename-properties` crate will be documented in this file.
 
+## [0.9.1] - 2026-07-01
+
+### Added — CLOC12 upstream test port (`RenamePropertiesTest`)
+
+Ported the applicable cases from Google Closure Compiler's
+`RenamePropertiesTest.java` into `tests/upstream/rename_properties_test.rs`,
+following the CLOC12.01 convention (header cites the Java source; `UPSTREAM_SHA`
+pins the tracked commit; `ATTRIBUTION.md` records Apache-2.0 provenance; a
+`[[test]]` entry wires the file in). Like the `rename-globals` port, the pass
+exposes a source-string surface through public crate APIs, so each case drives
+the real `source → bridge → rename → emit` chain and asserts on the emitted
+string.
+
+- **8 active `#[test]`s pass**: a private property renamed consistently across
+  dotted reads, reads-and-object-literal-keys collapsing to one short name,
+  distinct names assigned down a member chain (`a.a.b`), quoted-access poisoning
+  the rename (`o["mode"]` leaves `.mode` alone), built-in / DOM names left
+  untouched, a single-character property un-shortened, a computed-subscript
+  index untouched, and an externs property preserved.
+- **No new closurec bug** — every active expectation matched the pass on the
+  first run.
+- **3 `#[ignore = "blocked on gap-NNN"]` placeholders** for upstream behavior the
+  name-based pass does not cover: type-/heap-aware disambiguation of same-named
+  properties (gap-138), frequency-ordered short-name assignment (gap-139), and a
+  cross-module shared rename map (gap-140). Pinned to
+  `code/specs/CLOC12-gaps.md` §CLOC12.140; run with `--include-ignored` to track
+  progress as they close.
+
+No library code changed — this release is test coverage plus docs.
+
 ## [0.9.0] - 2026-06-30
 
 ### Added — correlation-vector rename provenance (#89)

--- a/code/packages/rust/closure-pass-rename-properties/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename-properties/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename-properties"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 description = "Aggressive property renaming pass for the Closure Compiler clone (ADVANCED-only). Consistently shortens program-private object property names that are never quoted/computed and not in the built-in or externs do-not-rename boundary."
 
@@ -15,3 +15,9 @@ coding-adventures-javascript-tokens = { path = "../javascript-tokens" }
 coding-adventures-javascript-parser = { path = "../javascript-parser" }
 coding-adventures-closure-emitter = { path = "../closure-emitter" }
 coding-adventures-type-sidecar = { path = "../type-sidecar" }
+
+# CLOC12 upstream test-suite port. Integration test built against the crate's
+# public API; needs an explicit `[[test]]` entry. Per CLOC12.01 §3.
+[[test]]
+name = "upstream_rename_properties"
+path = "tests/upstream/rename_properties_test.rs"

--- a/code/packages/rust/closure-pass-rename-properties/README.md
+++ b/code/packages/rust/closure-pass-rename-properties/README.md
@@ -120,3 +120,19 @@ recursion.)
 Dev-deps: `coding-adventures-javascript-tokens`,
 `coding-adventures-javascript-parser`, `coding-adventures-closure-emitter`,
 `coding-adventures-type-sidecar`.
+
+## Upstream conformance tests
+
+`tests/upstream/rename_properties_test.rs` ports Google Closure Compiler's
+`RenamePropertiesTest` (Apache-2.0; see `ATTRIBUTION.md` and `UPSTREAM_SHA`), per
+the CLOC12 test-port convention. Because the pass exposes a source-string surface
+through public crate APIs, the port drives the real `source → bridge → rename →
+emit` chain and asserts on the emitted string — the same `test(js, expected)`
+surface upstream uses. It pins the 8 name-based renaming behaviors this pass
+supports today and records 3 upstream behaviors it does not — type-/heap-aware
+disambiguation of same-named properties, frequency-ordered short-name
+assignment, and a cross-module shared rename map — as
+`#[ignore = "blocked on gap-NNN"]` placeholders tied to
+`code/specs/CLOC12-gaps.md` (gap-138 … gap-140). Run with
+`cargo test --test upstream_rename_properties` (add `-- --include-ignored` to
+list the pending gaps).

--- a/code/packages/rust/closure-pass-rename-properties/tests/upstream/ATTRIBUTION.md
+++ b/code/packages/rust/closure-pass-rename-properties/tests/upstream/ATTRIBUTION.md
@@ -1,0 +1,48 @@
+# Attribution
+
+Tests in this directory are ported from the Google Closure Compiler
+under the Apache License, Version 2.0:
+
+    https://github.com/google/closure-compiler
+    LICENSE: https://www.apache.org/licenses/LICENSE-2.0
+
+## Files ported
+
+- `rename_properties_test.rs`
+    - upstream: `test/com/google/javascript/jscomp/RenamePropertiesTest.java`
+    - tracked commit: see `UPSTREAM_SHA`
+
+## Translation notes
+
+CLOC12 port for the `rename-properties` pass (seventh port under CLOC12, after
+constant-fold, dce, the emitter / source-map ports, remove-unused-vars, inline,
+fold-control-flow, and rename-globals). Per CLOC12 §6, each upstream Java test
+file maps to one Rust file in the matching pass crate's `tests/upstream/`
+directory.
+
+- Like the `rename-globals` port (and unlike the AST-builder ports), the pass
+  exposes a source-string surface through public crate APIs, so this port drives
+  the real `source → bridge → RenamePropertiesPass → emit` chain and asserts on
+  the emitted string, the same surface upstream `RenamePropertiesTest` uses
+  (`test(js, expected)`).
+
+- **What our pass does today:** it renames **dotted, unquoted** property names
+  (member accesses `o.prop` and object-literal keys `{prop: v}`) to the shortest
+  fresh names `a`, `b`, `c`, … in first-appearance order, applied consistently to
+  every occurrence of the same name. It leaves untouched: names accessed via a
+  computed / quoted subscript anywhere in the program (`o["prop"]` — renaming the
+  dotted form would desync from the string form), names already one character
+  long, a curated set of built-in / DOM property names (`length`, `push`,
+  `toString`, `innerHTML`, `addEventListener`, …), and any name in the externs
+  do-not-rename set.
+
+- **What upstream `RenameProperties` additionally does** — type-/heap-aware
+  renaming that can distinguish same-named properties on unrelated objects,
+  aggressive cross-module renaming, and the affinity/frequency-ordered
+  short-name assignment that packs the hottest properties into the shortest
+  names — our name-based pass does not do. Those are ported as
+  `#[ignore = "blocked on gap-NNN"]` placeholders pinned to
+  `code/specs/CLOC12-gaps.md` (gap-138 … gap-140).
+
+Every active test that *disagrees* with our pass is a real closurec defect, not
+a translation artifact — that is the entire point of the port.

--- a/code/packages/rust/closure-pass-rename-properties/tests/upstream/UPSTREAM_SHA
+++ b/code/packages/rust/closure-pass-rename-properties/tests/upstream/UPSTREAM_SHA
@@ -1,0 +1,13 @@
+# UPSTREAM_SHA
+#
+# Tracks google/closure-compiler at this commit. Every Rust file in
+# tests/upstream/ was ported from a Java file at this snapshot.
+#
+# Upgrade policy: bump this SHA only in a dedicated PR that re-ports
+# every Java source listed in ATTRIBUTION.md, diff-checks against the
+# previous port, and explicitly handles added / removed / renamed
+# tests per CLOC12 §4.
+
+commit:  5bb35ec1245dc1d3557481e5f8b4db344bcd1e6b
+date:    2026-05-28
+url:     https://github.com/google/closure-compiler/tree/5bb35ec1245dc1d3557481e5f8b4db344bcd1e6b

--- a/code/packages/rust/closure-pass-rename-properties/tests/upstream/rename_properties_test.rs
+++ b/code/packages/rust/closure-pass-rename-properties/tests/upstream/rename_properties_test.rs
@@ -1,0 +1,199 @@
+//! Ported from `RenamePropertiesTest.java` in `google/closure-compiler`,
+//! Apache-2.0. Upstream SHA: see `tests/upstream/UPSTREAM_SHA`.
+//!
+//! Translation policy: see
+//! `code/specs/CLOC12-upstream-test-suite-port.md`.
+//!
+//! This is a CLOC12 port for the `rename-properties` pass. Upstream
+//! `RenameProperties` is heap-/type-aware: it can rename same-named properties
+//! on unrelated objects independently and packs the hottest properties into the
+//! shortest names. Our `RenamePropertiesPass` implements the sound name-based
+//! slice: rename **dotted, unquoted** property names (member accesses `o.prop`
+//! and object-literal keys `{prop: v}`) to the shortest fresh names
+//! `a`, `b`, `c`, … in first-appearance order, applied consistently to every
+//! occurrence of the same name. It leaves untouched a name accessed via a
+//! computed/quoted subscript anywhere (`o["prop"]`), a name already one
+//! character long, a curated set of built-in / DOM names, and any externs
+//! do-not-rename entry.
+//!
+//! So the file splits in two:
+//!
+//! - **Active `#[test]`s** — behaviors our pass supports today, driving the real
+//!   `source → bridge → rename → emit` chain and asserting on the emitted string
+//!   (the pass exposes a source-string surface through public crate APIs, so —
+//!   like the `rename-globals` port — we assert on strings exactly as upstream's
+//!   `test(js, expected)`).
+//! - **`#[ignore = "blocked on gap-NNN"]` placeholders** — upstream intent our
+//!   name-based pass does not cover (type-aware disambiguation, cross-module
+//!   renaming, frequency-ordered assignment), each pinned to a `gap-NNN` entry
+//!   in `code/specs/CLOC12-gaps.md`.
+//!
+//! Every active test that *disagrees* with our pass is a real closurec defect,
+//! not a translation artifact — the whole point of the port.
+
+use coding_adventures_closure_emitter::{emit, EmitOptions};
+use coding_adventures_closure_pass_pipeline::{Pass, PassContext};
+use coding_adventures_closure_pass_rename_properties::RenamePropertiesPass;
+use coding_adventures_correlation_vector::CVLog;
+use coding_adventures_javascript_parser::{bridge, parse_javascript_typed};
+use coding_adventures_javascript_tokens::EsVersion;
+use coding_adventures_type_sidecar::Sidecar;
+use std::collections::HashSet;
+
+/// Parse `src`, bridge to a typed `Program`, run `RenamePropertiesPass` with the
+/// given externs (do-not-rename) set, and emit the minified result — the same
+/// chain closurec's ADVANCED level uses. Returns the emitted string.
+fn rename_with(src: &str, externs: &[&str]) -> String {
+    let es = EsVersion::Es2025;
+    let node = parse_javascript_typed(src, es).expect("parse");
+    let prog = bridge::grammar_to_program(&node, es).expect("bridge");
+
+    let set: HashSet<String> = externs.iter().map(|s| s.to_string()).collect();
+    let pass = RenamePropertiesPass::new(set);
+    let sidecar = Sidecar::new();
+    let mut cv = CVLog::new(false);
+    let out = pass
+        .run(PassContext {
+            program: &prog,
+            sidecar: &sidecar,
+            cv: &mut cv,
+        })
+        .expect("rename-properties");
+
+    let mut cv2 = CVLog::new(false);
+    let opts = EmitOptions {
+        source_map: false,
+        ..Default::default()
+    };
+    emit(&out.program, &sidecar, &mut cv2, &opts)
+        .expect("emit")
+        .code
+}
+
+fn rename(src: &str) -> String {
+    rename_with(src, &[])
+}
+
+// ===================================================================
+// Active ports — behaviors the property renamer supports today.
+// ===================================================================
+
+/// Upstream `testRenameProperties` core: a program-private property is renamed
+/// to the shortest name, consistently at every dotted read.
+#[test]
+fn renames_a_private_property_consistently() {
+    assert_eq!(
+        rename("read(a.renderMode); read(b.renderMode);"),
+        "read(a.a);read(b.a);"
+    );
+}
+
+/// The rename spans dotted reads *and* object-literal keys of the same name —
+/// they collapse to one short name.
+#[test]
+fn renames_reads_and_object_literal_keys_alike() {
+    assert_eq!(
+        rename("read(a.renderMode); var c = { renderMode: 3 };"),
+        "read(a.a);var c={a:3};"
+    );
+}
+
+/// Distinct property names get distinct short names in first-appearance order,
+/// including down a member chain.
+#[test]
+fn distinct_properties_get_distinct_names() {
+    assert_eq!(rename("read(a.outerField.innerField);"), "read(a.a.b);");
+}
+
+/// Upstream `testQuotedProperty`: a property accessed via a quoted subscript
+/// anywhere (`o["mode"]`) poisons the rename of its dotted form — otherwise the
+/// two spellings would desync. Both are left as written.
+#[test]
+fn quoted_access_poisons_the_rename() {
+    assert_eq!(
+        rename("read(obj.mode); read(other[\"mode\"]);"),
+        "read(obj.mode);read(other[\"mode\"]);"
+    );
+}
+
+/// A built-in / DOM property name is never renamed; a program-private one
+/// alongside it still is.
+#[test]
+fn leaves_builtin_names_untouched() {
+    assert_eq!(
+        rename("var n = arr.length; s.toString(); var o = { tally: 1 };"),
+        "var n=arr.length;s.toString();var o={a:1};"
+    );
+}
+
+/// A single-character property name has no shorter form, so it is left as-is.
+#[test]
+fn does_not_rename_single_char_property() {
+    assert_eq!(rename("read(obj.x); read(obj.x);"), "read(obj.x);read(obj.x);");
+}
+
+/// A computed subscript `obj[idx]` is not a property *name* position, so `idx`
+/// is untouched while a sibling dotted `.field` is renamed.
+#[test]
+fn computed_subscript_index_is_not_renamed() {
+    assert_eq!(
+        rename("var v = obj[idx]; read(obj.field);"),
+        "var v=obj[idx];read(obj.a);"
+    );
+}
+
+/// Upstream `testExterns`: a property listed in the externs do-not-rename set is
+/// preserved, while a program-private sibling is still renamed.
+#[test]
+fn does_not_rename_externs_property() {
+    assert_eq!(
+        rename_with("read(el.innerHTML); read(el.secretField);", &["innerHTML"]),
+        "read(el.innerHTML);read(el.a);"
+    );
+}
+
+// ===================================================================
+// Ignored ports — upstream intent the name-based pass does not cover.
+// Each is pinned to a gap in code/specs/CLOC12-gaps.md.
+// ===================================================================
+
+/// Upstream is type-aware: the same property name on two UNRELATED object types
+/// can be renamed to two different short names. Our name-based pass renames a
+/// name once, globally, so both `.state` reads collapse to the same `a`.
+#[test]
+#[ignore = "blocked on gap-138: rename-properties is name-based, not type-/heap-aware disambiguation"]
+fn type_aware_disambiguation_of_same_name() {
+    // Upstream (heap-aware) could give Widget#state and Store#state distinct
+    // short names; our pass cannot.
+    assert_eq!(
+        rename("new Widget().state; new Store().state;"),
+        "new Widget().a;new Store().b;"
+    );
+}
+
+/// Upstream orders short-name assignment by property FREQUENCY, so the most-used
+/// property gets `a`. Our pass assigns by first appearance regardless of count.
+#[test]
+#[ignore = "blocked on gap-139: rename-properties assigns short names by appearance order, not usage frequency"]
+fn frequency_ordered_short_name_assignment() {
+    // `hot` is used 3x, `cold` 1x; upstream gives `hot`→a. Ours gives the
+    // first-seen `cold`→a.
+    assert_eq!(
+        rename("o.cold; o.hot; o.hot; o.hot;"),
+        "o.b;o.a;o.a;o.a;"
+    );
+}
+
+/// Upstream can rename a property consistently across separately-compiled
+/// modules via a shared rename map. Our single-program pass has no cross-module
+/// map.
+#[test]
+#[ignore = "blocked on gap-140: rename-properties has no cross-module shared rename map"]
+fn cross_module_consistent_renaming() {
+    // Placeholder: exercised here as a single program, but the intent is a
+    // stable map reused across compilations.
+    assert_eq!(
+        rename("moduleA.sharedProp; moduleB.sharedProp;"),
+        "moduleA.a;moduleB.a;"
+    );
+}

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -1116,3 +1116,33 @@ historical context with status `RESOLVED` and a link to the fix PR.
   - **gap-137** — **pseudo-name / stable-name mode**: upstream can map each
     original name to a stable human-readable placeholder instead of a minimal
     short name. Our pass has only the minimal-short-name mode.
+
+## CLOC12.140 — port `RenamePropertiesTest` into `closure-pass-rename-properties`
+
+- **Status:** port landed; 8 active `#[test]`s pass, 3 `#[ignore]` gaps opened.
+- **What it is:** the seventh CLOC12 upstream port. Like the `rename-globals`
+  port, `closure-pass-rename-properties` exposes a source-string surface through
+  public crate APIs, so this port drives the real
+  `source → bridge → RenamePropertiesPass → emit` chain and asserts on the
+  emitted string, exactly as upstream `RenamePropertiesTest`'s
+  `test(js, expected)`. It pins the sound name-based slice our pass implements:
+  rename dotted, unquoted property names (member accesses and object-literal
+  keys) to the shortest fresh names `a`, `b`, `c`, … in first-appearance order,
+  consistently across every occurrence, leaving untouched a name accessed via a
+  quoted/computed subscript anywhere, a single-character name, a curated set of
+  built-in / DOM names, and any externs entry. 8 active cases pass (consistent
+  private-property rename, reads-and-object-literal-keys collapse, distinct-name
+  assignment down a member chain, quoted-access-poisons-rename, built-in-names-
+  untouched, single-char-untouched, computed-index-untouched, externs-preserved).
+- **No new closurec bug surfaced** — every active expectation matched the pass
+  on the first run.
+- **New gaps** (executable `#[ignore = "blocked on gap-NNN"]` placeholders):
+  - **gap-138** — **type-/heap-aware disambiguation**: upstream can rename the
+    same property name on two unrelated object types to two different short
+    names. Our pass renames a name once, globally.
+  - **gap-139** — **frequency-ordered short-name assignment**: upstream packs
+    the most-used property into the shortest name; our pass assigns by first
+    appearance regardless of usage count.
+  - **gap-140** — **cross-module shared rename map**: upstream can keep a
+    property rename stable across separately-compiled modules via a shared map;
+    our single-program pass has no such map.


### PR DESCRIPTION
## What & why (#88 — upstream test-suite port)

Seventh CLOC12 upstream port. Like the `rename-globals` port, `closure-pass-rename-properties` exposes a source-string surface through public crate APIs, so this port drives the **real `source → bridge → RenamePropertiesPass → emit` chain** and asserts on the emitted string, exactly as upstream `RenamePropertiesTest`'s `test(js, expected)`.

## Coverage

**8 active `#[test]`s pass**, pinning the sound name-based slice — rename dotted, unquoted property names (member accesses + object-literal keys) to shortest fresh names `a`,`b`,`c` in first-appearance order, consistently across every occurrence:

- a private property renamed consistently across dotted reads
- reads and object-literal keys of one name collapse to a single short name
- distinct names assigned down a member chain (`a.outerField.innerField` → `a.a.b`)
- **quoted access poisons the rename** (`o["mode"]` present → `.mode` left alone, avoiding desync)
- built-in / DOM names (`length`, `toString`, …) untouched
- a single-character property not shortened
- a computed-subscript index (`obj[idx]`) untouched
- an externs property preserved while a sibling is renamed

**No new closurec bug surfaced** — every active expectation matched the pass on the first run.

## Gaps staked (`#[ignore = "blocked on gap-NNN"]`)

3 upstream behaviors the name-based pass does not cover, pinned to `code/specs/CLOC12-gaps.md` §CLOC12.140:
- **gap-138** — type-/heap-aware disambiguation of same-named properties on unrelated types
- **gap-139** — frequency-ordered short-name assignment (hottest property → shortest name)
- **gap-140** — cross-module shared rename map

## Verification

- `cargo test --test upstream_rename_properties`: **8 passed, 3 ignored**.
- Full crate suite green (26 lib + port + doc). **No library code changed** — test coverage + docs only.
- Inline security review: **PASSED** (test-only; no `unsafe`, no I/O, no untrusted input, dev-only `[[test]]`).

Bumps `closure-pass-rename-properties` 0.9.0 → 0.9.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)