### PR TITLE
feat(mathml): adopt neutral Fenced node for single-body <mfenced> (fence-delimiters PR-2)

### DIFF
--- a/code/packages/rust/mathml/CHANGELOG.md
+++ b/code/packages/rust/mathml/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to the Presentation-MathML frontend crate.
 
+## [0.6.0] — 2026-07-01
+
+### Added — adopt the neutral `Fenced` node (fence delimiters as data)
+
+The `mathml` frontend now lowers a **single-body** `<mfenced>` to the neutral
+**`MathExpr::Fenced { open, body, close }`** (added to `math-frontend` 0.7.0 and first adopted by
+the `latex` frontend), carrying **which** delimiters bracketed the group instead of dropping them.
+Previously a bare `<mfenced>` folded to `Group`, which records only *that* a sub-expression was
+fenced — so `<mfenced open="|" close="|">x</mfenced>` (an absolute value / norm) was indistinguishable
+from `<mfenced>x</mfenced>` (a parenthesised group). Now the `open`/`close` attributes are preserved.
+
+- A single-body `<mfenced>` → `Fenced` with its `open`/`close` delimiters. A bare `<mfenced>` with no
+  attributes uses MathML's own defaults `(` / `)`; custom brackets (`open="["`, `open="{"`,
+  `open="⟨"`, `open="|"`, an omitted `.`) are carried verbatim. **Comma / semicolon lists are
+  unchanged** — they still lower to `Sequence` (which drops the delimiters; carrying them on the list
+  shape is a later slice of the fence arc).
+- The lexer still discards attributes as presentation, so the `<mfenced>` handler **re-reads** its
+  `open`/`close` off the start-tag's byte span via a new `tag_attr` helper (the `Parser` now keeps the
+  source bytes). Entity references in a delimiter value (`&lang;` → ⟨, `&#x2308;` → ⌈) are decoded
+  through the same entity table as character data.
+- `Capabilities::fenced_delimiters` is now declared (`with_fenced_delimiters()`), so the conformance
+  harness polices the newly-emitted node — a frontend emitting `Fenced` without declaring it is flagged.
+- +4 tests (default `(`/`)`, custom `[`/`]`, `|`/`|` absolute value, entity-decoded `⌈`/`⌉`);
+  the previous `mfenced_without_commas_lowers_to_group` test becomes `…_lowers_to_fenced`. Downstream
+  consumers (`latex`, `asciimath`, `unicode-math`, `adj-lang`, `adj-lang-cli`) build and pass unchanged.
+
 ## [0.5.0] — 2026-06-30
 
 ### Added — PR-5: semicolon-separated `<mfenced>` lowers to rows

--- a/code/packages/rust/mathml/Cargo.toml
+++ b/code/packages/rust/mathml/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mathml"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "A Presentation-MathML reader that implements the math-frontend MathFrontend trait: turns <math>…</math> (mn/mi/mo/mrow/mfrac/msup/msub/msqrt/mroot/mtext/mtable/mover/munder/mfenced + named functions) into the neutral MathExpr AST. The fourth pluggable frontend after LaTeX and AsciiMath (see PFE01). Total, panic-free, spanned errors."
 license = "MIT"

--- a/code/packages/rust/mathml/README.md
+++ b/code/packages/rust/mathml/README.md
@@ -27,7 +27,7 @@ tree.
 | `<msqrt>x</msqrt>` / `<mroot>x n</mroot>` | `Root` (degree `None` / `Some(n)`) |
 | `<mover>b a</mover>` / `<munder>b a</munder>` | `Overset { over: a, base: b }` / `Underset { under: a, base: b }` (PR-2) |
 | `<munderover>b u o</munderover>` | `Underset { under: u, base: Overset { over: o, base: b } }` (PR-2) |
-| `<mfenced>…</mfenced>` | `Group` over the folded contents (PR-2) |
+| `<mfenced>…</mfenced>` | single body → `Fenced { open, body, close }` carrying the `open`/`close` delimiters (default `(`/`)`, so `\|x\|` ≠ `(x)`); comma / semicolon lists → `Sequence` |
 | `<mtable><mtr><mtd>…</mtd></mtr></mtable>` | `Matrix(rows × cells)` (PR-2) |
 | `<mi>sin</mi> … x` (applied) | `Call { func: Sin, arg: x }` (PR-3) |
 
@@ -40,8 +40,10 @@ operator — so `<mover><mi>x</mi><mo>^</mo></mover>` is "x with a hat". An `<mi
 function (sin, cos, ln, …) **applied to an argument** becomes a `Call`; the same name with no argument
 stays a plain `Symbol`.
 
-Deferred to PR-4: `<mfenced>` separator modelling (a comma-separated `(a, b)` list) — needs a neutral
-*list* node the AST does not yet have; today a fence's contents fold as one row.
+Fence-delimiters arc (remaining slice): a comma / semicolon `<mfenced>` list still lowers to
+`Sequence`, which drops the surrounding `open`/`close` delimiters. Carrying delimiters on the list
+shape (a `Fenced`-of-`Sequence`, or a delimiters field on `Sequence`) is a later slice, tracked with
+the same slice in the `latex` frontend.
 
 ## Contract
 

--- a/code/packages/rust/mathml/src/lib.rs
+++ b/code/packages/rust/mathml/src/lib.rs
@@ -68,10 +68,12 @@ impl MathFrontend for MathMl {
         // PR-1 surface: fractions (`<mfrac>`), roots (`<msqrt>`/`<mroot>`), powers (`<msup>` →
         // `Pow`), relations (`<mo>=`/`<` …), implicit multiplication (adjacent operands in a row),
         // text (`<mtext>`), and ± / ∓ (`<mo>±`). Subscripts are core (not a capability flag).
-        // PR-2 adds matrices (`<mtable>`) and over/under-sets (`<mover>`/`<munder>`/`<munderover>`);
-        // a plain `<mfenced>` lowers to `Group` (core). PR-3 adds named-function recognition
-        // (`<mi>sin</mi>` applied to an argument → `Call`). PR-4 adds sequences: an `<mfenced>` with
-        // comma separators (`(a, b, c)`) lowers to `Sequence` instead of folding the commas away.
+        // PR-2 adds matrices (`<mtable>`) and over/under-sets (`<mover>`/`<munder>`/`<munderover>`).
+        // PR-3 adds named-function recognition (`<mi>sin</mi>` applied to an argument → `Call`).
+        // PR-4 adds sequences: an `<mfenced>` with comma separators (`(a, b, c)`) lowers to
+        // `Sequence` instead of folding the commas away. The fence-delimiters slice adopts the
+        // neutral `Fenced` node: a single-body `<mfenced>` now lowers to `Fenced { open, body,
+        // close }`, carrying its `open`/`close` delimiters as data (so `|x|` ≠ `(x)`).
         Capabilities::none()
             .with_fractions()
             .with_roots()
@@ -84,6 +86,7 @@ impl MathFrontend for MathMl {
             .with_oversets()
             .with_functions()
             .with_sequences()
+            .with_fenced_delimiters()
     }
 }
 
@@ -347,11 +350,63 @@ mod tests {
     }
 
     #[test]
-    fn mfenced_without_commas_lowers_to_group() {
-        // A fence with no comma separators is an ordinary parenthesised sub-expression:
-        // <mfenced><mrow>x + 1</mrow></mfenced> → Group(Add(x,1)).
+    fn mfenced_without_commas_lowers_to_fenced() {
+        // A fence with no comma separators is a single delimited group. It lowers to the neutral
+        // `Fenced` node carrying its delimiters — a bare `<mfenced>` defaults to `(`/`)`:
+        // <mfenced><mrow>x + 1</mrow></mfenced> → Fenced("(", Add(x,1), ")").
         let e = p("<mfenced><mrow><mi>x</mi><mo>+</mo><mn>1</mn></mrow></mfenced>");
-        assert_eq!(e, MathExpr::Group(Box::new(b(BinOp::Add, sym("x"), num(1)))));
+        assert_eq!(
+            e,
+            MathExpr::Fenced {
+                open: "(".to_string(),
+                body: Box::new(b(BinOp::Add, sym("x"), num(1))),
+                close: ")".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn mfenced_carries_custom_bracket_delimiters() {
+        // `open`/`close` attributes are meaning-bearing and preserved on `Fenced`: an interval
+        // `[x]` must not be confused with a parenthesised group `(x)`.
+        let e = p("<mfenced open=\"[\" close=\"]\"><mi>x</mi></mfenced>");
+        assert_eq!(
+            e,
+            MathExpr::Fenced {
+                open: "[".to_string(),
+                body: Box::new(sym("x")),
+                close: "]".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn mfenced_carries_bar_delimiters_for_absolute_value() {
+        // `|x|` (absolute value / norm) — the case that motivated the node — round-trips its bars.
+        let e = p("<mfenced open=\"|\" close=\"|\"><mi>x</mi></mfenced>");
+        assert_eq!(
+            e,
+            MathExpr::Fenced {
+                open: "|".to_string(),
+                body: Box::new(sym("x")),
+                close: "|".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn mfenced_decodes_entity_delimiters() {
+        // Delimiter attributes may be entity references (`&#x2308;` = ⌈, `&#x2309;` = ⌉ — ceiling).
+        // They are decoded through the same entity table as character data.
+        let e = p("<mfenced open=\"&#x2308;\" close=\"&#x2309;\"><mi>x</mi></mfenced>");
+        assert_eq!(
+            e,
+            MathExpr::Fenced {
+                open: "\u{2308}".to_string(),
+                body: Box::new(sym("x")),
+                close: "\u{2309}".to_string(),
+            }
+        );
     }
 
     #[test]

--- a/code/packages/rust/mathml/src/parser.rs
+++ b/code/packages/rust/mathml/src/parser.rs
@@ -270,6 +270,78 @@ fn decode_entity(name: &str) -> String {
     mapped.to_string()
 }
 
+/// Read an attribute's value out of an already-lexed start-tag byte span
+/// (`src[span.0..span.1]` = `<name … attr="value" …>`). The lexer drops attributes as it scans
+/// (they are presentation), so a handler that needs a *meaning-bearing* one — the `open`/`close`
+/// delimiters on `<mfenced>` — re-reads it from the source slice here. `attr` matches only as a
+/// whole word (the byte before it must be whitespace, so `open` never matches inside another
+/// attribute name); the value may be single- or double-quoted; entity references in the value are
+/// decoded (`&lang;` → ⟨, `&#x2016;` → ‖). Returns `None` when the attribute is absent.
+fn tag_attr(src: &[u8], span: (usize, usize), attr: &str) -> Option<String> {
+    let end = span.1.min(src.len());
+    let start = span.0.min(end);
+    let tag = &src[start..end];
+    let key = attr.as_bytes();
+    // Start at 1: the byte at index 0 is `<`, and every real attribute is preceded by whitespace.
+    let mut i = 1;
+    while i + key.len() <= tag.len() {
+        if tag[i - 1].is_ascii_whitespace() && tag[i..].starts_with(key) {
+            let mut j = i + key.len();
+            while j < tag.len() && tag[j].is_ascii_whitespace() {
+                j += 1;
+            }
+            if j < tag.len() && tag[j] == b'=' {
+                j += 1;
+                while j < tag.len() && tag[j].is_ascii_whitespace() {
+                    j += 1;
+                }
+                if j < tag.len() && (tag[j] == b'"' || tag[j] == b'\'') {
+                    let quote = tag[j];
+                    j += 1;
+                    let val_start = j;
+                    while j < tag.len() && tag[j] != quote {
+                        j += 1;
+                    }
+                    return Some(decode_attr_value(&tag[val_start..j]));
+                }
+            }
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Decode entity references (`&name;`, `&#NN;`) inside an attribute value, reusing the same entity
+/// table as character data. Non-entity bytes pass through (lossy UTF-8, matching the lexer).
+fn decode_attr_value(raw: &[u8]) -> String {
+    let s = String::from_utf8_lossy(raw);
+    let mut out = String::new();
+    let mut rest: &str = &s;
+    loop {
+        match rest.find('&') {
+            None => {
+                out.push_str(rest);
+                break;
+            }
+            Some(amp) => {
+                out.push_str(&rest[..amp]);
+                match rest[amp + 1..].find(';') {
+                    Some(semi) => {
+                        out.push_str(&decode_entity(&rest[amp + 1..amp + 1 + semi]));
+                        rest = &rest[amp + 1 + semi + 1..];
+                    }
+                    None => {
+                        // A bare `&` with no terminator: keep it verbatim, stop.
+                        out.push_str(&rest[amp..]);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    out
+}
+
 // ---- element-tree builder ---------------------------------------------------------------------
 
 /// One processed child of a row: either a finished operand expression, or a raw `<mo>` operator
@@ -283,11 +355,15 @@ struct Parser {
     events: Vec<Event>,
     pos: usize,
     src_len: usize,
+    /// The original source bytes. The lexer discards attributes as it scans (they are
+    /// presentation), but a handler that needs a *meaning-bearing* attribute — the `open`/`close`
+    /// delimiters on `<mfenced>` — re-reads it here from the start-tag's byte span (`tag_attr`).
+    src: Vec<u8>,
 }
 
 impl Parser {
-    fn new(events: Vec<Event>, src_len: usize) -> Self {
-        Parser { events, pos: 0, src_len }
+    fn new(events: Vec<Event>, src: &[u8]) -> Self {
+        Parser { events, pos: 0, src_len: src.len(), src: src.to_vec() }
     }
 
     fn peek(&self) -> Option<&Event> {
@@ -464,7 +540,11 @@ impl Parser {
             }
             // `<mfenced>…</mfenced>` — a fence. Three shapes, decided by the top-level separators:
             //
-            //   * NO separator            → an ordinary parenthesised group `(a b)` → `Group`.
+            //   * NO separator            → a single delimited group → `Fenced { open, body, close }`,
+            //                               carrying WHICH delimiters bracketed it (the `open`/`close`
+            //                               attributes, default `(`/`)`) so `|x|` (absolute value) is
+            //                               kept distinct from `(x)`. This is the mathml frontend
+            //                               adopting the neutral `Fenced` node (latex already does).
             //   * `<mo>,</mo>` only       → a flat LIST `(a, b, c)` → `Sequence([a, b, c])`.
             //   * any `<mo>;</mo>`        → ROWS. Semicolons are the row separator and commas the
             //                               within-row (column) separator — the classic fenced-matrix
@@ -476,16 +556,25 @@ impl Parser {
             //                               second column). A ragged fence `(a; b, c)` is faithful:
             //                               `Sequence([a, Sequence([b, c])])`.
             //
-            // The delimiters and the `open`/`close`/`separators` *attributes* are presentation and
-            // dropped like all attributes — only *literal* `<mo>,</mo>`/`<mo>;</mo>` children are
-            // read as separators, matching how the comma list already worked.
+            // The `separators` attribute is presentation and dropped — only *literal* `<mo>,</mo>`/
+            // `<mo>;</mo>` children are read as separators, matching how the comma list already
+            // worked. The `open`/`close` delimiter attributes, however, ARE meaning-bearing for the
+            // single-body case and re-read from the tag span into `Fenced` (the comma/semicolon list
+            // cases still lower to `Sequence`, which drops them — a later slice of the fence arc).
             "mfenced" => {
                 let kids = self.parse_row_children(name, depth)?;
                 let has_comma = kids.iter().any(|c| matches!(c, Child::Op(s) if s == ","));
                 let has_semicolon = kids.iter().any(|c| matches!(c, Child::Op(s) if s == ";"));
                 if !has_comma && !has_semicolon {
                     let inner = fold_row(kids, span, depth)?;
-                    return Ok(Child::Expr(MathExpr::Group(Box::new(inner))));
+                    // MathML's own defaults for a bare `<mfenced>` are `(` and `)`.
+                    let open = tag_attr(&self.src, span, "open").unwrap_or_else(|| "(".to_string());
+                    let close = tag_attr(&self.src, span, "close").unwrap_or_else(|| ")".to_string());
+                    return Ok(Child::Expr(MathExpr::Fenced {
+                        open,
+                        body: Box::new(inner),
+                        close,
+                    }));
                 }
                 if !has_semicolon {
                     // Comma-only: a flat list. Each comma-delimited segment folds to one expression.
@@ -981,6 +1070,6 @@ fn func_of(name: &str) -> Option<Func> {
 /// The crate entry point: parse a Presentation-MathML string into the neutral [`MathExpr`].
 pub fn parse(src: &str) -> Result<MathExpr, FrontendError> {
     let events = Lexer::new(src).events()?;
-    let mut parser = Parser::new(events, src.len());
+    let mut parser = Parser::new(events, src.as_bytes());
     parser.parse_document()
 }


### PR DESCRIPTION
## Fence-delimiters arc — PR-2: mathml adopts `MathExpr::Fenced`

PR-1 added the neutral **`MathExpr::Fenced { open, body, close }`** node to `math-frontend` 0.7.0 and had the **latex** frontend lower single-body `\left(…\right)` fences onto it. This PR-2 adopts `Fenced` in the **mathml** frontend — the second frontend on the arc — where MathML's `<mfenced open="…" close="…">` element carries the delimiters as attributes, a perfect fit.

### What changed
A single-body `<mfenced>` now lowers to `Fenced { open, body, close }` carrying **which** delimiters bracketed the group, instead of dropping them to a plain `Group`:

| input | before | after |
|-------|--------|-------|
| `<mfenced>x</mfenced>` | `Group(x)` | `Fenced("(", x, ")")` (MathML defaults) |
| `<mfenced open="[" close="]">x</mfenced>` | `Group(x)` | `Fenced("[", x, "]")` |
| `<mfenced open="|" close="|">x</mfenced>` | `Group(x)` | `Fenced("|", x, "|")` — absolute value, no longer confused with `(x)` |

Comma/semicolon lists are **unchanged** (still `Sequence`, which drops the delimiters — carrying them on the list shape is a later slice of the arc, noted in the README/CHANGELOG).

### How
The lexer discards attributes as presentation, so the `<mfenced>` handler **re-reads** its `open`/`close` off the start-tag's byte span via a new `tag_attr` helper (the `Parser` now keeps the source bytes). Entity references in a delimiter value (`&lang;` → ⟨, `&#x2308;` → ⌈) are decoded through the same entity table as character data. `Capabilities::fenced_delimiters` is now declared so the conformance harness polices the newly-emitted node.

### Why it slices cleanly
Conformance is **per-frontend** via the `Capabilities` bitset (no cross-frontend equality), so adopting `Fenced` in mathml leaves asciimath/unicode-math conformant and unchanged. mathml is a leaf frontend (no workspace crate depends on it), so the 0.5.0 → 0.6.0 bump is safe.

### Verification
- **448 tests pass** across `mathml` + all downstream consumers (`math-frontend`, `latex`, `asciimath`, `unicode-math`, `adj-lang`) + `adj-lang-cli` golden suite (38); `cargo clippy -p mathml` clean.
- +4 mathml tests (default `(`/`)`, custom `[`/`]`, `|`/`|` abs value, entity-decoded `⌈`/`⌉`); `mfenced_without_commas_lowers_to_group` → `…_lowers_to_fenced`.
- **Security review PASSED** — the hand-rolled `tag_attr` byte-scan and `decode_attr_value` `&str` slicing were traced: all indices bounds-checked and char-boundary-safe (`&`/`;` are ASCII), spans clamped with `.min(src.len())`, guaranteed termination, no `unsafe`, no panic path on adversarial MathML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)