### PR TITLE
feat(inline-variables): CV `propagated` contributions (#89)

### DIFF
--- a/code/packages/rust/closure-pass-inline-variables/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-inline-variables/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to the `coding-adventures-closure-pass-inline-variables` crate will be documented in this file.
 
+## [0.7.0] - 2026-07-01
+
+### Added — CV provenance for constant propagation (#89)
+
+The pass now records every constant it propagates as a `propagated`
+correlation-vector contribution carrying `{name, value, sites}` — the original
+`const` name, a compact rendering of its literal value, and how many use sites
+the literal replaced. Propagation *dissolves* the binding: its declaration
+becomes unreferenced (remove-unused-vars deletes it) and the literal is copied
+to each reader, so without this record the minified output has no trace that a
+named constant ever stood there. These contributions let a `--correlation_vector`
+consumer map an inlined literal back to the `const` it came from.
+
+- Records emit in program (source) order, one per propagated constant, so the
+  contribution list is deterministic run to run.
+- `value` renders numbers/bigints from their raw text, strings quoted, and
+  `true`/`false`/`null`/`undefined` literally.
+- Attached at the program root — a coarse name→value/site-count *table*. Tagging
+  each substituted literal's own CV id is a documented follow-up, mirroring the
+  inline / rename passes.
+- Emitted JS is byte-identical: contributions are pure metadata. Verified by the
+  full closurec end-to-end suite.
+
+`coding_adventures_correlation_vector` moves from a dev-dependency to a runtime
+dependency (the pass now names `Contribution`), and `serde_json` is added for
+the `json!` meta values. Three new unit tests cover a single-use propagation
+(`sites: 1`), a multi-use propagation (`sites: 2`), and the no-propagation
+(`let`, empty table) case.
+
 ## [0.6.1] - 2026-06-30
 
 ### Changed — test sync for closure-emitter boolean shorthand

--- a/code/packages/rust/closure-pass-inline-variables/Cargo.toml
+++ b/code/packages/rust/closure-pass-inline-variables/Cargo.toml
@@ -1,12 +1,16 @@
 [package]
 name = "coding-adventures-closure-pass-inline-variables"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2021"
 description = "Constant-propagation pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Replaces references to a top-level `const` bound to a literal with the literal itself, so the binding becomes unused and remove-unused-vars deletes it."
 
 [dependencies]
 coding-adventures-closure-pass-pipeline = { path = "../closure-pass-pipeline" }
 coding-adventures-javascript-ast = { path = "../javascript-ast" }
+# Correlation-vector provenance (#89): the pass emits `propagated`
+# contributions, so this is now a runtime dependency (was dev-only).
+coding_adventures_correlation_vector = { path = "../correlation-vector" }
+serde_json = "1"
 
 [dev-dependencies]
 coding-adventures-javascript-tokens = { path = "../javascript-tokens" }
@@ -16,4 +20,3 @@ coding-adventures-closure-pass-constant-fold = { path = "../closure-pass-constan
 coding-adventures-javascript-parser = { path = "../javascript-parser" }
 coding-adventures-closure-emitter = { path = "../closure-emitter" }
 coding-adventures-type-sidecar = { path = "../type-sidecar" }
-coding_adventures_correlation_vector = { path = "../correlation-vector" }

--- a/code/packages/rust/closure-pass-inline-variables/README.md
+++ b/code/packages/rust/closure-pass-inline-variables/README.md
@@ -60,6 +60,37 @@ The pass only propagates; it leaves the emptied `const` for
 `remove-unused-vars` to delete (mirroring how `inline` leaves dead
 functions for `treeshake`).
 
+## Correlation-vector provenance (#89)
+
+Propagation *dissolves* a constant: its `const` declaration becomes unreferenced
+(remove-unused-vars deletes it) and the literal is copied to each reader. After
+that the minified output has no trace that a named constant ever stood there —
+the exact kind of provenance loss the correlation vector exists to prevent.
+
+So the pass records one `propagated` contribution per constant it propagates,
+carrying the original name, a compact rendering of the literal value, and the
+number of use sites it replaced:
+
+```text
+const N = 42; use(N);
+  → contribution { source: "inline-variables", tag: "propagated",
+                   meta: { name: "N", value: "42", sites: 1 } }
+
+const K = 1; a(K); b(K);
+  → contribution { …, meta: { name: "K", value: "1", sites: 2 } }
+```
+
+Records emit in program (source) order, one per propagated constant, so the list
+is deterministic run to run, and the pipeline attaches them to the program-root
+CV entry — where a `--correlation_vector` consumer can read an inlined literal
+back to the `const` it came from. `value` renders numbers/bigints from raw text,
+strings quoted, and `true`/`false`/`null`/`undefined` literally.
+
+This is the propagation *table*; tagging each substituted literal's own CV id is
+a documented follow-up shared with the inline / rename passes. Contributions are
+pure metadata: the emitted JS is byte-identical with or without the CV log
+enabled.
+
 ## Where it sits
 
 `depends_on = ["constant-fold"]` so a folded initializer

--- a/code/packages/rust/closure-pass-inline-variables/src/lib.rs
+++ b/code/packages/rust/closure-pass-inline-variables/src/lib.rs
@@ -103,6 +103,8 @@ use std::collections::HashMap;
 use coding_adventures_closure_pass_pipeline::{
     IterationPolicy, Pass, PassContext, PassError, PassOutput, PassStats,
 };
+use coding_adventures_correlation_vector::Contribution;
+use serde_json::json;
 use coding_adventures_javascript_ast::statement::TaggedStatement;
 use coding_adventures_javascript_ast::{
     AssignmentTarget, BindingTarget, Declaration, Expression, ForInit, FunctionParam, Program,
@@ -166,11 +168,45 @@ impl Pass for InlineVariablesPass {
     fn run(&self, ctx: PassContext<'_>) -> Result<PassOutput, PassError> {
         let mut program = ctx.program.clone();
         let mut nodes_touched: u32 = 1; // the program root
-        let changed = inline_variables_program(&mut program, &mut nodes_touched);
+        let mut propagated: Vec<PropagatedConst> = Vec::new();
+        let changed =
+            inline_variables_program(&mut program, &mut nodes_touched, &mut propagated);
+
+        // CV provenance (#89): record every constant we propagated as a
+        // `propagated` contribution carrying `{name, value, sites}` — the
+        // original `const` name, a compact rendering of its literal value,
+        // and how many use sites the literal was substituted into.
+        // Propagation *dissolves* the binding: its declaration becomes
+        // unreferenced (remove-unused-vars deletes it) and the literal is
+        // copied to each reader, so without this record the minified output
+        // has no trace that a named constant ever stood there. The pipeline
+        // attaches these to the program-root CV entry, so a
+        // `--correlation_vector` consumer can map an inlined literal back to
+        // the `const` it came from. Records come out in program (source)
+        // order, one per propagated constant, so the emitted list is
+        // deterministic run to run.
+        //
+        // This is the propagation *table* (name → value/site-count); tagging
+        // each substituted literal's OWN CV id is a documented follow-up,
+        // mirroring the inline / rename passes.
+        let contributions: Vec<Contribution> = propagated
+            .into_iter()
+            .map(|p| Contribution {
+                source: "inline-variables".to_string(),
+                tag: "propagated".to_string(),
+                meta: [
+                    ("name".to_string(), json!(p.name)),
+                    ("value".to_string(), json!(p.value)),
+                    ("sites".to_string(), json!(p.sites)),
+                ]
+                .into_iter()
+                .collect(),
+            })
+            .collect();
 
         Ok(PassOutput {
             program,
-            contributions: Vec::new(),
+            contributions,
             changed,
             diagnostics: Vec::new(),
             stats: PassStats { nodes_touched },
@@ -189,9 +225,38 @@ struct ConstCandidate {
     value: Expression,
 }
 
+/// One propagation event for CV provenance (#89): the original `const`
+/// name, a compact rendering of its literal value, and how many use sites
+/// the literal replaced. `run` turns each into a `propagated` contribution.
+struct PropagatedConst {
+    name: String,
+    value: String,
+    sites: usize,
+}
+
+/// A compact source-like rendering of a literal for the `value` meta field.
+/// Covers exactly the variants [`is_literal`] admits; anything else is
+/// unreachable here but rendered as `"?"` defensively.
+fn literal_repr(expr: &Expression) -> String {
+    match expr {
+        Expression::NumericLiteral(n) => n.raw.clone(),
+        Expression::StringLiteral(s) => format!("{:?}", s.value), // quoted
+        Expression::BooleanLiteral(b) => b.value.to_string(),
+        Expression::NullLiteral(_) => "null".to_string(),
+        Expression::BigIntLiteral(b) => b.raw.clone(),
+        Expression::UndefinedLiteral(_) => "undefined".to_string(),
+        _ => "?".to_string(),
+    }
+}
+
 /// Walk the whole program and propagate every qualifying top-level
-/// `const = literal`. Returns whether anything changed.
-fn inline_variables_program(program: &mut Program, nodes_touched: &mut u32) -> bool {
+/// `const = literal`. Returns whether anything changed. `propagated`
+/// accumulates each propagation for CV provenance.
+fn inline_variables_program(
+    program: &mut Program,
+    nodes_touched: &mut u32,
+    propagated: &mut Vec<PropagatedConst>,
+) -> bool {
     // Phase 1 — count how many times each name is declared as a binding
     // anywhere in the program (function names, parameters, var/let/const
     // targets). A candidate's name must be declared exactly once, so no
@@ -273,6 +338,14 @@ fn inline_variables_program(program: &mut Program, nodes_touched: &mut u32) -> b
         }
         if propagate_all(program, cand) {
             changed = true;
+            // CV: the literal was substituted into all `uses` sites (gate
+            // above guarantees `uses > 0`), after which the `const`
+            // declaration is unreferenced.
+            propagated.push(PropagatedConst {
+                name: cand.name.clone(),
+                value: literal_repr(&cand.value),
+                sites: uses,
+            });
         }
     }
     changed
@@ -981,7 +1054,7 @@ mod tests {
     use coding_adventures_closure_emitter::{emit, EmitOptions};
     use coding_adventures_closure_pass_constant_fold::ConstantFoldPass;
     use coding_adventures_closure_pass_pipeline::{PassContext, PassPipeline, PipelineOutput};
-    use coding_adventures_correlation_vector::CVLog;
+    use coding_adventures_correlation_vector::{CVLog, Contribution};
     use coding_adventures_javascript_ast::{Program, SourceType};
     use coding_adventures_javascript_parser::{bridge, parse_javascript_typed};
     use coding_adventures_javascript_tokens::EsVersion;
@@ -1016,6 +1089,64 @@ mod tests {
         emit(&out.program, &sidecar, &mut cv2, &opts)
             .expect("emit")
             .code
+    }
+
+    /// Parse `src`, bridge, run the pass, and return its CV contributions —
+    /// the propagation table (#89 provenance).
+    fn propagate_contributions(src: &str) -> Vec<Contribution> {
+        let es = EsVersion::Es2025;
+        let node = parse_javascript_typed(src, es).expect("parse");
+        let prog = bridge::grammar_to_program(&node, es).expect("bridge");
+        let pass = InlineVariablesPass::new();
+        let sidecar = Sidecar::new();
+        let mut cv = CVLog::new(true);
+        pass.run(PassContext {
+            program: &prog,
+            sidecar: &sidecar,
+            cv: &mut cv,
+        })
+        .expect("inline-variables")
+        .contributions
+    }
+
+    // ----- CV provenance (#89): `propagated` contributions -----
+
+    #[test]
+    fn single_use_propagation_records_value_and_one_site() {
+        // `const N = 42; use(N);` → the literal is propagated to its lone use.
+        let contribs = propagate_contributions("const N = 42; use(N);");
+        assert_eq!(contribs.len(), 1, "one propagated const; got {contribs:?}");
+        let c = &contribs[0];
+        assert_eq!(c.source, "inline-variables");
+        assert_eq!(c.tag, "propagated");
+        assert_eq!(c.meta.get("name").and_then(|v| v.as_str()), Some("N"));
+        assert_eq!(c.meta.get("value").and_then(|v| v.as_str()), Some("42"));
+        assert_eq!(c.meta.get("sites").and_then(|v| v.as_u64()), Some(1));
+    }
+
+    #[test]
+    fn multi_use_propagation_records_site_count() {
+        // A short literal used twice is propagated to BOTH sites.
+        let contribs = propagate_contributions("const K = 1; a(K); b(K);");
+        assert_eq!(contribs.len(), 1, "one propagated const; got {contribs:?}");
+        assert_eq!(
+            contribs[0].meta.get("name").and_then(|v| v.as_str()),
+            Some("K")
+        );
+        assert_eq!(
+            contribs[0].meta.get("sites").and_then(|v| v.as_u64()),
+            Some(2)
+        );
+    }
+
+    #[test]
+    fn no_propagation_emits_no_contributions() {
+        // `let` is reassignable — never propagated, so the table is empty.
+        let contribs = propagate_contributions("let x = 1; use(x);");
+        assert!(
+            contribs.is_empty(),
+            "expected no contributions; got {contribs:?}"
+        );
     }
 
     // ----- metadata contract -----


### PR DESCRIPTION
## What & why (#89 — full CV tracing)

Constant propagation **dissolves** a `const`: its declaration becomes unreferenced (remove-unused-vars deletes it) and the literal is copied to each reader. After that the minified output has **no trace** that a named constant ever stood there — exactly the provenance loss the correlation vector exists to prevent.

This records every propagation as a `propagated` correlation-vector contribution carrying `{name, value, sites}`:

```
const N = 42; use(N);        → { source:"inline-variables", tag:"propagated", meta:{name:"N", value:"42", sites:1} }
const K = 1; a(K); b(K);     → { …, meta:{name:"K", value:"1", sites:2} }
```

## Implementation

- A `PropagatedConst { name, value, sites }` accumulator is threaded into `inline_variables_program`; Phase 3 pushes one record per propagated constant (`sites` = its use count).
- `literal_repr` renders the 6 literal variants the pass admits — numbers/bigints from raw text, strings quoted, `true`/`false`/`null`/`undefined` literally.
- Records emit in program (source) order → deterministic. Coarse program-root table; per-output-span tagging is a documented follow-up shared with the inline / rename passes.
- `coding_adventures_correlation_vector` moves from a **dev-dependency to a runtime dependency** (the pass now names `Contribution`), and `serde_json` is added for `json!` meta values.

## Verification

- **27 pass-crate tests** green (3 new: single-use `sites:1`, multi-use `sites:2`, no-propagation `let` empty table).
- **closurec end-to-end** suite green — emitted JS **byte-identical** (contributions are pure metadata).
- Inline security review: **PASSED** (no `unsafe` / I/O / untrusted-input unwrap / ReDoS; `json!` on owned `String`/`usize` is total; the dep move is workspace-local + standard `serde_json`).

Bumps `closure-pass-inline-variables` 0.6.1 → 0.7.0.

Extends #89 provenance beyond the 8 transforming passes to const-propagation; only collapse-properties remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)