### PR TITLE
feat(js): lower member-method calls to __method__ dispatch + hardened runtime (C3/C4 — collection methods)

### DIFF
--- a/code/packages/rust/javascript-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/javascript-to-semantic-ir/CHANGELOG.md
@@ -4,15 +4,49 @@ All notable changes to `javascript-to-semantic-ir` are documented here.
 
 ## Unreleased
 
+The format is based on [Keep a Changelog](https://keepachangelog.com/),
+and this project adheres to [Semantic Versioning](https://semver.org/).
+
+## 0.7.0
+
+**Member-method calls → `__method__` dispatch (C3 — collection methods).**
+The frontend previously *deferred* every member-method call (`arr.map(fn)`,
+`arr.push(x)`, `str.toUpperCase()`, …) to a positioned error, special-casing
+only `console.log`.  It now lowers them to the SIR method-dispatch
+convention — `BuiltinCall("__method__", [receiver, StrLit("method"),
+args…])` — exactly as the Ruby frontend does.  This is the JavaScript arm of
+the `sir-collection-methods` cascade; collection code (`.map`/`.filter`/
+`.push`/`.reduce`/…) now lowers, validates, and executes end-to-end through
+the JS backend.
+
+### Added
+
+- **Member-method-call lowering.**  A dotted call `recv.method(args…)` (other
+  than `console.log`) lowers to `BuiltinCall("__method__", [recv,
+  StrLit("method"), args…])`: the receiver at `args[0]`, the method name
+  always a `StrLit` at `args[1]`, the call arguments following.  The synthetic
+  method-name `StrLit` declares `Feature::Strings` (no dedicated
+  `MethodDispatch` feature in v0 — `Strings` is what the validator observes).
+- **Chained method calls.**  A flat call chain `xs.filter(f).map(g)` folds one
+  step at a time — each `.method(args)` wraps the accumulated expression as
+  the receiver of the next `__method__` dispatch.
+- **Callback arguments.**  An arrow / function argument (`arr.map(x => x*2)`)
+  reuses the existing closure lowering, arriving as a `MakeClosure` in the
+  dispatch's argument list (the JS higher-order convention — no trailing-block
+  syntax).
+- Lowering-assertion tests (`push`/`pop`/`map`/`filter`/`toUpperCase`,
+  chaining, `console.log` non-regression, deferred computed calls) plus node
+  execution-proofs (`xs.push(4); xs.length` → `4`; `.map`+`.reduce` → `12`;
+  `.filter`+`.includes` → `#t`).
+
 ### Changed
 
+- `console.log` keeps its dedicated `print` lowering (not routed through
+  `__method__`); a *computed* member call (`obj[expr](…)`) stays deferred.
 - Compile-compat stub arm for the new core `semantic-ir` variant
   `Expr::KeywordArg` (KW1) — the effect-inference pass recurses into the
   keyword arg's inner `value` so purity analysis stays
   conservative-correct. Real keyword-argument lowering is pending KW2–KW8.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/),
-and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## 0.6.0
 

--- a/code/packages/rust/javascript-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/javascript-to-semantic-ir/CHANGELOG.md
@@ -7,6 +7,26 @@ All notable changes to `javascript-to-semantic-ir` are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+### Security
+
+- **Reject reflective-gadget method names at lowering time (C3, defense in
+  depth).**  The method name in a `recv.method(args…)` dispatch is
+  attacker-controlled and flows verbatim into a `StrLit` that every backend
+  turns into a dynamic `recv[name]` property lookup.  A handful of JavaScript
+  member names are reflective gadgets that make that lookup arbitrary-code
+  execution — most dangerously `constructor`, which yields the `Function`
+  constructor (`id.constructor("return …evil…")` → RCE once a native
+  higher-order method such as `Array.prototype.map` invokes the result).
+  `make_method_dispatch` now refuses to lower any name on a fixed denylist —
+  `constructor`, `__proto__`, `prototype`, `apply`, `call`, `bind`,
+  `__defineGetter__`, `__defineSetter__`, `__lookupGetter__`,
+  `__lookupSetter__` — with a positioned error, so the dangerous `StrLit`
+  never enters SIR and every backend is protected at the source.  The
+  frontend stays otherwise permissive; the JS runtime's method allowlist is
+  the tight complementary gate.  Regression tests assert the
+  `xs.map(id.constructor("…"))` gadget and `obj.__proto__` / `fn.apply` are
+  rejected.
+
 ## 0.7.0
 
 **Member-method calls → `__method__` dispatch (C3 — collection methods).**

--- a/code/packages/rust/javascript-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/javascript-to-semantic-ir/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "javascript-to-semantic-ir"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
-description = "JavaScript (GrammarASTNode CST) → narrow-waist Semantic IR. SIR19 frontend, milestone M5 (collections) + default parameters."
+description = "JavaScript (GrammarASTNode CST) → narrow-waist Semantic IR. SIR19 frontend, milestone M5 (collections) + default parameters + member-method dispatch (C3)."
 
 [dependencies]
 coding-adventures-javascript-parser = { path = "../javascript-parser" }

--- a/code/packages/rust/javascript-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/javascript-to-semantic-ir/src/lib.rs
@@ -1131,6 +1131,158 @@ mod tests {
         assert!(has_print, "expected a print BuiltinCall in main");
     }
 
+    // ── C3: member-method calls → `__method__` dispatch ────────────
+    //
+    // `recv.method(args…)` (other than `console.log`) lowers to
+    // `BuiltinCall("__method__", [recv, StrLit("method"), args…])`: the
+    // receiver at `args[0]`, the method name always a `StrLit` at `args[1]`,
+    // the call arguments following.  These tests pin the envelope shape, the
+    // `Feature::Strings` declaration, closure-arg lowering, and chaining.
+
+    /// Assert `e` is a `__method__` dispatch, returning `(method, args)` —
+    /// where `args` is the *whole* argument vector (receiver at `[0]`,
+    /// `StrLit(method)` at `[1]`, call args at `[2..]`).
+    fn expect_method(e: &Expr) -> (String, &[Expr]) {
+        match e {
+            Expr::BuiltinCall { name, args, .. } if name == "__method__" => {
+                assert!(args.len() >= 2, "dispatch needs receiver + method name");
+                let method = match &args[1] {
+                    Expr::StrLit { value, .. } => value.clone(),
+                    other => panic!("method name must be a StrLit, got {other:?}"),
+                };
+                (method, args.as_slice())
+            }
+            other => panic!("expected __method__ dispatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn push_lowers_to_method_dispatch() {
+        // `arr.push(1)` → __method__(VarRef arr, "push", IntLit 1).
+        let m = lower("let arr = [0]; arr.push(1);");
+        assert_valid(&m);
+        let (method, args) = expect_method(main_value(&m));
+        assert_eq!(method, "push");
+        assert_eq!(args.len(), 3, "receiver + name + one call arg");
+        assert!(matches!(&args[0], Expr::VarRef { name, .. } if name == "arr"));
+        assert!(matches!(&args[2], Expr::IntLit { value: 1, .. }));
+        // The synthetic method-name StrLit declares Strings.
+        assert!(m.manifest.contains(Feature::Strings));
+    }
+
+    #[test]
+    fn pop_lowers_to_zero_arg_method_dispatch() {
+        // `arr.pop()` → __method__(VarRef arr, "pop") — no trailing args.
+        let m = lower("let arr = [1, 2]; arr.pop();");
+        assert_valid(&m);
+        let (method, args) = expect_method(main_value(&m));
+        assert_eq!(method, "pop");
+        assert_eq!(args.len(), 2, "receiver + name only");
+        assert!(matches!(&args[0], Expr::VarRef { name, .. } if name == "arr"));
+    }
+
+    #[test]
+    fn map_with_arrow_callback_lowers_to_dispatch_with_closure() {
+        // `arr.map(x => x * 2)` → __method__(arr, "map", MakeClosure{…}).
+        // The arrow reuses the existing closure lowering, so the callback
+        // arrives as a MakeClosure argument.
+        let m = lower("let arr = [1, 2, 3]; arr.map(x => x * 2);");
+        assert_valid(&m);
+        let (method, args) = expect_method(main_value(&m));
+        assert_eq!(method, "map");
+        assert_eq!(args.len(), 3, "receiver + name + closure arg");
+        assert!(
+            matches!(&args[2], Expr::MakeClosure { .. }),
+            "callback should lower to MakeClosure, got {:?}",
+            &args[2]
+        );
+        assert!(m.manifest.contains(Feature::Closures));
+        assert!(m.manifest.contains(Feature::Strings));
+    }
+
+    #[test]
+    fn map_with_named_function_callback_passes_closure() {
+        // A named function passed by reference (`arr.map(dbl)`) resolves to a
+        // value and lowers as an IndirectCall-able closure handle argument.
+        let m = lower("function dbl(x) { return x * 2; } let arr = [1]; arr.map(dbl);");
+        assert_valid(&m);
+        let (method, args) = expect_method(main_value(&m));
+        assert_eq!(method, "map");
+        assert_eq!(args.len(), 3);
+        // `dbl` names a module function → passed as a MakeClosure handle.
+        assert!(matches!(&args[2], Expr::MakeClosure { .. } | Expr::VarRef { .. }));
+    }
+
+    #[test]
+    fn string_method_lowers_to_dispatch() {
+        // `s.toUpperCase()` → __method__(VarRef s, "toUpperCase").
+        let m = lower("let s = \"hi\"; s.toUpperCase();");
+        assert_valid(&m);
+        let (method, args) = expect_method(main_value(&m));
+        assert_eq!(method, "toUpperCase");
+        assert_eq!(args.len(), 2);
+        assert!(matches!(&args[0], Expr::VarRef { name, .. } if name == "s"));
+    }
+
+    #[test]
+    fn chained_methods_nest_dispatch() {
+        // `xs.filter(f).map(g)` → the outer `.map` dispatch whose *receiver*
+        // (args[0]) is itself the inner `.filter` dispatch.
+        let m = lower(
+            "let xs = [1, 2, 3]; \
+             let f = (x) => x > 1; \
+             let g = (x) => x * 10; \
+             xs.filter(f).map(g);",
+        );
+        assert_valid(&m);
+        let (outer_method, outer_args) = expect_method(main_value(&m));
+        assert_eq!(outer_method, "map");
+        // The receiver of `.map` is the `.filter` dispatch.
+        let (inner_method, inner_args) = expect_method(&outer_args[0]);
+        assert_eq!(inner_method, "filter");
+        // Innermost receiver is `xs`.
+        assert!(matches!(&inner_args[0], Expr::VarRef { name, .. } if name == "xs"));
+    }
+
+    #[test]
+    fn method_on_object_property_lowers_receiver_via_member_read() {
+        // A deeper receiver: `box.items.push(9)` — the receiver `box.items`
+        // is a member read (MapGet), folded before the `.push` dispatch.
+        let m = lower("let box = {items: [1]}; box.items.push(9);");
+        assert_valid(&m);
+        let (method, args) = expect_method(main_value(&m));
+        assert_eq!(method, "push");
+        assert!(matches!(&args[0], Expr::MapGet { .. }));
+        assert!(matches!(&args[2], Expr::IntLit { value: 9, .. }));
+    }
+
+    #[test]
+    fn console_log_still_lowers_to_print_not_method_dispatch() {
+        // Guard against a regression: `console.log` must keep its dedicated
+        // `print` lowering rather than being swept into `__method__`.
+        let m = lower("console.log(1);");
+        assert_valid(&m);
+        match main_value(&m) {
+            Expr::BuiltinCall { name, .. } => {
+                assert_eq!(name, "print", "console.log must stay a print builtin");
+            }
+            other => panic!("expected print BuiltinCall, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn computed_member_call_stays_deferred() {
+        // `obj[key](x)` is a *computed* member call — not a named method — so
+        // it remains a positioned error, not a `__method__` dispatch.
+        let err = compile_source("let obj = {}; let key = \"m\"; obj[key](1);", "test")
+            .expect_err("computed member call should be deferred");
+        assert!(
+            err.message.contains("deferred") || err.message.contains("non-identifier"),
+            "unexpected message: {}",
+            err.message
+        );
+    }
+
     #[test]
     fn zero_arg_call() {
         let m = lower("function h() { return 42; } h();");
@@ -1405,10 +1557,16 @@ mod tests {
     }
 
     #[test]
-    fn method_call_other_than_console_log_is_deferred() {
-        let err = compile_source("let o = 0; o.foo(1);", "test")
-            .expect_err("arbitrary method call deferred");
-        assert!(err.message.contains("deferred"), "got: {}", err.message);
+    fn method_call_other_than_console_log_lowers_to_dispatch() {
+        // C3: previously deferred, a general member-method call now lowers to
+        // the `__method__` dispatch envelope (receiver, StrLit(name), args…).
+        let m = lower("let o = [0]; o.foo(1);");
+        assert_valid(&m);
+        let (method, args) = expect_method(main_value(&m));
+        assert_eq!(method, "foo");
+        assert_eq!(args.len(), 3);
+        assert!(matches!(&args[0], Expr::VarRef { name, .. } if name == "o"));
+        assert!(matches!(&args[2], Expr::IntLit { value: 1, .. }));
     }
 
     #[test]

--- a/code/packages/rust/javascript-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/javascript-to-semantic-ir/src/lower.rs
@@ -247,11 +247,14 @@
 //! `f(args)` dispatches on the callee:
 //!   * a known top-level/synthesised `function` name → [`DirectCall`];
 //!   * `console.log(x)` (and the M1–M3 builtin map) → [`BuiltinCall`];
+//!   * any *other* dotted member call `recv.method(args…)` → the SIR
+//!     method-dispatch envelope `BuiltinCall("__method__", [recv,
+//!     StrLit("method"), args…])` (C3 — collection methods);
 //!   * any other callee that resolves to a *value* (a local/param/captured
 //!     closure handle) → [`IndirectCall`] on that value.
 //!
-//! Member-call methods other than `console.log`, and calling a
-//! non-identifier callee, are deferred (M5).
+//! Calling a *computed* member (`obj[expr](…)`) or a non-identifier callee
+//! is deferred.
 //!
 //! ### Recursion bound
 //!
@@ -315,8 +318,9 @@
 //! Spread (`[...xs]` / `{...o}`), array elisions (`[1, , 3]`), object
 //! shorthand (`{x}`), computed keys (`{[e]: v}`), numeric keys (`{0: v}`),
 //! object methods / getters / setters, `.length` *assignment* (a resize, with
-//! no IR node), array methods (`.map`/`.push`/… — these would need
-//! runtime-library support, per the project mandate), classes, `this`/`new`,
+//! no IR node) — note that array/collection method **calls** (`.map`/`.push`/…)
+//! are now lowered to `__method__` dispatch (C3), routed to the backend's OOP
+//! runtime; classes, `this`/`new`,
 //! generators / `async`/`await`, **rest** params (`...args`),
 //! destructuring, and template literals all remain positioned errors.
 //!
@@ -1536,26 +1540,147 @@ impl Lowerer {
     /// CST: `[callee, arguments]`.  Dispatch on the callee:
     ///   * a bare identifier that names a module `function` → `DirectCall`;
     ///   * `console.log(x)` → `BuiltinCall("print", [x])`;
+    ///   * any *other* dotted member call `recv.method(a, b)` → the SIR
+    ///     **method-dispatch convention**
+    ///     `BuiltinCall("__method__", [recv, StrLit("method"), a, b])`
+    ///     (C3 — collection methods; see below);
     ///   * a bare identifier resolving to a closure *value* (local / param /
     ///     capture) → `IndirectCall` on that value.
     ///
-    /// Other member-call methods and non-identifier callees are deferred.
+    /// ## Member-method calls → `__method__` dispatch (C3)
+    ///
+    /// The narrow waist for a method call already exists and needs **no new
+    /// IR node**: every frontend packs `recv.meth(arg1, arg2)` as
+    ///
+    /// ```text
+    /// BuiltinCall {
+    ///     name:    "__method__",
+    ///     args:    [recv_expr, StrLit("meth"), arg1_expr, arg2_expr, …],
+    ///     effects, span,
+    /// }
+    /// ```
+    ///
+    /// with the **receiver at `args[0]`**, the **method name always a
+    /// `StrLit` at `args[1]`**, and the call arguments following.  This is
+    /// exactly how the Ruby frontend lowers `recv.meth(…)`
+    /// (`ruby-to-semantic-ir`'s `fold_one_dot_call`); a backend routes the
+    /// envelope to its OOP runtime (`__SirOop.callMethod` / the JS runtime's
+    /// method dispatcher), so `arr.map`/`arr.push`/`str.toUpperCase()` run
+    /// end-to-end without any per-method backend change.
+    ///
+    /// The synthetic `StrLit` method name is the reason we declare
+    /// [`Feature::Strings`] — the SIR validator observes `Strings` for every
+    /// `StrLit`, so the manifest must match.  We deliberately do **not**
+    /// invent a `MethodDispatch` feature here: `__method__` is not gated by a
+    /// dedicated flag in v0, and `Strings` is what makes validation pass.
+    ///
+    /// A callback argument (`arr.map(x => x * 2)`) lowers through the
+    /// crate's existing arrow/closure path, so it arrives as a
+    /// [`MakeClosure`](Expr::MakeClosure) in the argument list — the JS
+    /// higher-order convention (pass a callable, no trailing-block syntax).
+    ///
+    /// `console.log(...)` keeps its dedicated `print` lowering (below); a
+    /// *computed* member call (`obj[expr](…)`) stays deferred.
     fn lower_call_expression(
         &mut self,
         node: &GrammarASTNode,
         depth: usize,
     ) -> Result<Expr, JsLowerError> {
         let span = self.span_of(node);
-        let nodes = child_nodes(node);
-        let callee = nodes
-            .first()
-            .ok_or_else(|| self.unsupported(node, "call_expression (no callee)"))?;
-        let args_node = child_node_named(node, "arguments")
-            .ok_or_else(|| self.unsupported(node, "call_expression (no arguments)"))?;
-        let arg_exprs = self.lower_arguments(args_node, depth)?;
 
+        // ## The flat call chain (learned by probing the parser)
+        //
+        // A chained call `xs.filter(f).map(g)` is **flat** in the CST: the
+        // parser emits a *single* `call_expression` whose children are
+        //
+        // ```text
+        // [ callee, arguments, (Dot, Name, arguments)* ]
+        // ```
+        //
+        // — e.g. `xs.filter(f).map(g)` →
+        // `[member_expr(xs.filter), args(f), ., map, args(g)]`.  The first
+        // `[callee, arguments]` pair is the base call; each trailing
+        // `.name(args)` triple is a further method invocation whose receiver
+        // is the accumulated call so far.  We therefore lower the base call,
+        // then fold each `.name(args)` step into a `__method__` dispatch with
+        // the running expression as `args[0]`.  The fold is iterative (a
+        // long chain costs no native stack); every lowered argument still
+        // consumes the `MAX_EXPR_DEPTH` budget through `lower_arguments`.
+        let children = &node.children;
+        let callee = children
+            .iter()
+            .find_map(|c| match c {
+                ASTNodeOrToken::Node(n) => Some(n),
+                ASTNodeOrToken::Token(_) => None,
+            })
+            .ok_or_else(|| self.unsupported(node, "call_expression (no callee)"))?;
+        // The first `arguments` node (and its child index) — the base call's
+        // argument list.
+        let first_args_idx = children
+            .iter()
+            .position(|c| matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "arguments"))
+            .ok_or_else(|| self.unsupported(node, "call_expression (no arguments)"))?;
+        let base_args_node = match &children[first_args_idx] {
+            ASTNodeOrToken::Node(n) => n,
+            ASTNodeOrToken::Token(_) => unreachable!("position found an arguments Node"),
+        };
+        let base_args = self.lower_arguments(base_args_node, depth)?;
+
+        // Lower the *base* call segment (`callee(base_args)`).
+        let mut acc = self.lower_base_call(callee, base_args, span.clone())?;
+
+        // Fold each trailing `.name(args)` method step into a `__method__`
+        // dispatch on the running receiver.
+        let mut i = first_args_idx + 1;
+        while i < children.len() {
+            // Expect `Dot`, `Name`, `arguments`.
+            let is_dot =
+                matches!(&children[i], ASTNodeOrToken::Token(t) if t.value == ".");
+            if !is_dot {
+                // A computed step (`…[expr](…)`) or other trailing access is
+                // not a named method → deferred.
+                return Err(JsLowerError {
+                    message: "computed / non-dot call chain step is deferred".to_string(),
+                    line: span.start_line,
+                    column: span.start_col,
+                });
+            }
+            let method_tok = match children.get(i + 1) {
+                Some(ASTNodeOrToken::Token(t)) if matches!(t.type_, TokenType::Name) => t,
+                _ => return Err(self.unsupported(node, "call chain (non-name method)")),
+            };
+            let args_node = match children.get(i + 2) {
+                Some(ASTNodeOrToken::Node(n)) if n.rule_name == "arguments" => n,
+                _ => return Err(self.unsupported(node, "call chain (method without arguments)")),
+            };
+            let step_args = self.lower_arguments(args_node, depth)?;
+            let name_span = self.span_of_token(method_tok);
+            acc = self.make_method_dispatch(acc, method_tok.value.clone(), name_span, step_args, span.clone());
+            i += 3;
+        }
+
+        Ok(acc)
+    }
+
+    /// Lower the *base* segment of a call chain — `callee(args)` with the
+    /// callee already lowered from its CST node.  Dispatches exactly as the
+    /// original single-call lowering did:
+    ///   * `console.log(...)` → `BuiltinCall("print", …)` (kept intact);
+    ///   * any *other* dotted member callee `recv.method` → `__method__`
+    ///     dispatch (C3);
+    ///   * a bare module-function name → `DirectCall`;
+    ///   * a bare value name (a closure handle) → `IndirectCall`.
+    ///
+    /// A computed / non-identifier callee stays deferred.
+    fn lower_base_call(
+        &mut self,
+        callee: &GrammarASTNode,
+        arg_exprs: Vec<Expr>,
+        span: Span,
+    ) -> Result<Expr, JsLowerError> {
         // `console.log(...)` → builtin print.  Detect the two-segment
-        // member callee `member_expression[ console, ., log ]`.
+        // member callee `member_expression[ console, ., log ]` and keep its
+        // dedicated lowering intact (do not route it through `__method__`).
         if let Some((obj, method)) = member_callee_parts(callee) {
             if obj == "console" && method == "log" {
                 // `print` may print; mark the effect so backends emit it.
@@ -1566,14 +1691,22 @@ impl Lowerer {
                     span,
                 });
             }
-            return Err(JsLowerError {
-                message: format!(
-                    "method call `{obj}.{method}(…)` is deferred past M4 (only \
-                     `console.log` is supported)"
-                ),
-                line: span.start_line,
-                column: span.start_col,
-            });
+        }
+
+        // Any *other* dotted member call `recv.method(args…)` → `__method__`
+        // dispatch (C3).  We peel the callee to its branching
+        // `member_expression` and require the **final** access to be a
+        // `.name` (a dot method); the receiver is everything before it,
+        // lowered through the ordinary member-read path (so `obj.inner.push`
+        // folds the `obj.inner` map read as the receiver of `.push`).  A
+        // computed final access (`obj[expr](…)`) is not a named method and
+        // stays deferred.
+        if let Some((method_tok, last_access)) = dotted_method_callee(callee) {
+            let name_span = self.span_of_token(method_tok);
+            let method = method_tok.value.clone();
+            let branch = peel_to_branch(callee);
+            let recv = self.lower_member_prefix(branch, last_access, &span)?;
+            return Ok(self.make_method_dispatch(recv, method, name_span, arg_exprs, span));
         }
 
         // A bare-identifier callee.
@@ -1611,6 +1744,32 @@ impl Lowerer {
             line: span.start_line,
             column: span.start_col,
         })
+    }
+
+    /// Build the SIR method-dispatch envelope
+    /// `BuiltinCall("__method__", [receiver, StrLit(method), args…])` and
+    /// declare [`Feature::Strings`] for the synthetic method-name `StrLit`.
+    /// This is the single narrow-waist convention every backend routes to
+    /// its OOP runtime (see [`lower_call_expression`](Self::lower_call_expression)).
+    fn make_method_dispatch(
+        &mut self,
+        receiver: Expr,
+        method: String,
+        name_span: Span,
+        args: Vec<Expr>,
+        span: Span,
+    ) -> Expr {
+        self.features_used.add(Feature::Strings);
+        let mut full_args = Vec::with_capacity(args.len() + 2);
+        full_args.push(receiver);
+        full_args.push(Expr::StrLit { value: method, span: name_span });
+        full_args.extend(args);
+        Expr::BuiltinCall {
+            name: "__method__".to_string(),
+            args: full_args,
+            effects: EffectSet::PURE,
+            span,
+        }
     }
 
     /// Lower the `arguments` node (`( argument_list? )`) into a `Vec<Expr>`.
@@ -3467,6 +3626,48 @@ fn member_callee_parts(callee: &GrammarASTNode) -> Option<(String, String)> {
         .value
         .clone();
     Some((obj, method))
+}
+
+/// If `callee` peels to a `member_expression` whose **final** access is a
+/// dot-name (`recv.method`), return the method-name `Name` token together
+/// with the child index of that final `.` token (its access position in the
+/// flat member chain).  The caller uses the index to split off the receiver
+/// prefix via [`lower_member_prefix`](Lowerer::lower_member_prefix).
+///
+/// The receiver may be *any* expression — a bare identifier (`arr.map`) or a
+/// deeper member chain (`obj.inner.push`, where the receiver `obj.inner` is a
+/// map read folded before the `.push` dispatch).  We therefore do **not**
+/// constrain the receiver's shape here (unlike [`member_callee_parts`], which
+/// only matches a bare-identifier object for the `console.log` special case).
+/// A *chained* call (`xs.filter(f).map(g)`) is folded one step at a time by
+/// [`lower_call_expression`](Lowerer::lower_call_expression) — each step's
+/// base callee reaching this helper is a plain `member_expression`.
+///
+/// Returns `None` for a bare identifier (not a member access) or when the
+/// final access is a *computed* subscript (`obj[expr](…)`) — those are not
+/// named methods and stay deferred.
+fn dotted_method_callee(callee: &GrammarASTNode) -> Option<(&Token, usize)> {
+    let branch = peel_to_branch(callee);
+    if branch.rule_name != "member_expression" {
+        return None;
+    }
+    // Locate the *final* access token (`.` or `[`) in the flat chain.
+    let last_access = branch
+        .children
+        .iter()
+        .rposition(|c| matches!(c, ASTNodeOrToken::Token(t) if t.value == "." || t.value == "["))?;
+    // The final access must be a dot — a named method, not a computed
+    // subscript — followed by a `Name` token (the method name).
+    let is_dot =
+        matches!(&branch.children[last_access], ASTNodeOrToken::Token(t) if t.value == ".");
+    if !is_dot {
+        return None;
+    }
+    let method_tok = match branch.children.get(last_access + 1) {
+        Some(ASTNodeOrToken::Token(t)) if matches!(t.type_, TokenType::Name) => t,
+        _ => return None,
+    };
+    Some((method_tok, last_access))
 }
 
 /// Detect *genuine* mutual recursion: a cycle of length ≥ 2 in the static

--- a/code/packages/rust/javascript-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/javascript-to-semantic-ir/src/lower.rs
@@ -1655,7 +1655,7 @@ impl Lowerer {
             };
             let step_args = self.lower_arguments(args_node, depth)?;
             let name_span = self.span_of_token(method_tok);
-            acc = self.make_method_dispatch(acc, method_tok.value.clone(), name_span, step_args, span.clone());
+            acc = self.make_method_dispatch(acc, method_tok.value.clone(), name_span, step_args, span.clone())?;
             i += 3;
         }
 
@@ -1706,7 +1706,7 @@ impl Lowerer {
             let method = method_tok.value.clone();
             let branch = peel_to_branch(callee);
             let recv = self.lower_member_prefix(branch, last_access, &span)?;
-            return Ok(self.make_method_dispatch(recv, method, name_span, arg_exprs, span));
+            return self.make_method_dispatch(recv, method, name_span, arg_exprs, span);
         }
 
         // A bare-identifier callee.
@@ -1751,6 +1751,27 @@ impl Lowerer {
     /// declare [`Feature::Strings`] for the synthetic method-name `StrLit`.
     /// This is the single narrow-waist convention every backend routes to
     /// its OOP runtime (see [`lower_call_expression`](Self::lower_call_expression)).
+    ///
+    /// # Security — reject dangerous method names at lowering time
+    ///
+    /// The method name here is *attacker-controlled*: it is a source-level
+    /// identifier from an untrusted input program, and it flows verbatim into
+    /// a `StrLit` that every backend uses to perform a dynamic property
+    /// lookup on the receiver (`recv[name]`).  A handful of JavaScript member
+    /// names are *reflective gadgets* that turn that lookup into code
+    /// execution — most dangerously `constructor`, which on any function
+    /// yields the `Function` constructor and lets a translated program build
+    /// and run arbitrary code (`id.constructor("…evil…")` → RCE).  `apply`,
+    /// `call`, `bind`, `__proto__`, `prototype`, and the
+    /// `__define/lookup*etter__` pair are the other prototype-chain escape
+    /// hatches.
+    ///
+    /// We therefore refuse to *lower* any of those names: the dangerous
+    /// `StrLit` never enters SIR, so every backend — not just the JS runtime,
+    /// which carries its own allowlist as the tight gate — is protected at the
+    /// source.  The frontend stays otherwise permissive (unknown-but-harmless
+    /// method names still lower fine); this denylist blocks only the names
+    /// that are *never* legitimate collection/String/Number methods.
     fn make_method_dispatch(
         &mut self,
         receiver: Expr,
@@ -1758,18 +1779,29 @@ impl Lowerer {
         name_span: Span,
         args: Vec<Expr>,
         span: Span,
-    ) -> Expr {
+    ) -> Result<Expr, JsLowerError> {
+        if is_dangerous_method_name(&method) {
+            return Err(JsLowerError {
+                message: format!(
+                    "method `{method}` is a reflective JavaScript gadget \
+                     (a prototype/constructor escape hatch) and is refused at \
+                     lowering time to prevent arbitrary-code execution"
+                ),
+                line: name_span.start_line,
+                column: name_span.start_col,
+            });
+        }
         self.features_used.add(Feature::Strings);
         let mut full_args = Vec::with_capacity(args.len() + 2);
         full_args.push(receiver);
         full_args.push(Expr::StrLit { value: method, span: name_span });
         full_args.extend(args);
-        Expr::BuiltinCall {
+        Ok(Expr::BuiltinCall {
             name: "__method__".to_string(),
             args: full_args,
             effects: EffectSet::PURE,
             span,
-        }
+        })
     }
 
     /// Lower the `arguments` node (`( argument_list? )`) into a `Vec<Expr>`.
@@ -3626,6 +3658,36 @@ fn member_callee_parts(callee: &GrammarASTNode) -> Option<(String, String)> {
         .value
         .clone();
     Some((obj, method))
+}
+
+/// Method names that must never be lowered into a `__method__` dispatch
+/// because they are reflective JavaScript gadgets — prototype-chain and
+/// constructor escape hatches that turn an ordinary `recv[name]` property
+/// lookup into arbitrary-code execution.
+///
+/// The headline gadget is `constructor`: on any function value it resolves to
+/// the global `Function` constructor, so a translated untrusted program of the
+/// form `id.constructor("return …")` synthesises and runs attacker code (an
+/// RCE — a native higher-order method such as `Array.prototype.map` will then
+/// happily invoke the resulting function).  `apply`/`call`/`bind` re-bind
+/// `this`, and `__proto__`/`prototype`/`__define*etter__`/`__lookup*etter__`
+/// walk or mutate the prototype chain.  None of these is ever a legitimate
+/// collection / String / Number method, so we reject them outright here —
+/// this is defense in depth in front of the JS runtime's own allowlist.
+fn is_dangerous_method_name(name: &str) -> bool {
+    matches!(
+        name,
+        "constructor"
+            | "__proto__"
+            | "prototype"
+            | "apply"
+            | "call"
+            | "bind"
+            | "__defineGetter__"
+            | "__defineSetter__"
+            | "__lookupGetter__"
+            | "__lookupSetter__"
+    )
 }
 
 /// If `callee` peels to a `member_expression` whose **final** access is a

--- a/code/packages/rust/javascript-to-semantic-ir/tests/e2e_node.rs
+++ b/code/packages/rust/javascript-to-semantic-ir/tests/e2e_node.rs
@@ -223,6 +223,64 @@ fn array_map_reduce_runs_in_node() {
     assert_eq!(out, "12");
 }
 
+// ── SECURITY (C3): reflective-gadget method names are refused ─────────
+//
+// `recv.method(args…)` lowers to a `__method__` dispatch whose method name is
+// attacker-controlled.  A handful of JavaScript member names are reflective
+// gadgets that would turn the backend's `recv[name]` lookup into arbitrary
+// code execution — most dangerously `constructor`, which yields the
+// `Function` constructor:
+//
+//     function id(x){ return x; }
+//     let xs = [1];
+//     xs.map( id.constructor("return …evil…") );   // RCE
+//
+// The frontend now refuses to *lower* those names, so the dangerous `StrLit`
+// never enters SIR (protecting every backend).  These tests assert the
+// gadget program is rejected at compile time — it never reaches node.  No
+// `node` gate: the rejection happens in the node-independent lowering pass.
+
+#[test]
+fn constructor_gadget_is_rejected_at_lowering() {
+    // The C3-brief RCE gadget: `id.constructor("…")` must not lower.
+    let src = "function id(x){ return x; } \
+               let xs = [1]; \
+               xs.map(id.constructor(\"return 1\"));";
+    let err = compile_source(src, "prog")
+        .expect_err("`constructor` method dispatch must be refused, not lowered");
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("constructor"),
+        "error should name the refused gadget, got: {msg}"
+    );
+}
+
+#[test]
+fn proto_gadget_is_rejected_at_lowering() {
+    // `obj.__proto__(…)` — a prototype-chain escape hatch — is refused too.
+    let src = "let obj = {}; obj.__proto__(1);";
+    let err = compile_source(src, "prog")
+        .expect_err("`__proto__` method dispatch must be refused, not lowered");
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("__proto__"),
+        "error should name the refused gadget, got: {msg}"
+    );
+}
+
+#[test]
+fn apply_gadget_is_rejected_at_lowering() {
+    // `fn.apply(…)` re-binds `this`; also on the denylist.
+    let src = "function f(){ return 1; } f.apply(null);";
+    let err = compile_source(src, "prog")
+        .expect_err("`apply` method dispatch must be refused, not lowered");
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("apply"),
+        "error should name the refused gadget, got: {msg}"
+    );
+}
+
 #[test]
 fn array_filter_includes_runs_in_node() {
     if !node_available() {

--- a/code/packages/rust/javascript-to-semantic-ir/tests/e2e_node.rs
+++ b/code/packages/rust/javascript-to-semantic-ir/tests/e2e_node.rs
@@ -178,3 +178,64 @@ fn mutual_recursion_runs_in_node() {
     // SIR `print` renders booleans Lisp-style (`#t`/`#f`).
     assert_eq!(out, "#t");
 }
+
+// ── C3: collection-method dispatch (`__method__`) executes ─────────────
+//
+// These prove the frontend's `__method__` lowering runs end-to-end: the JS
+// backend routes the dispatch envelope to the runtime's `callMethod`, which
+// invokes the JS-native array/string method (unwrapping any `Closure`
+// callback).  The example in the C3 brief — `xs.push(4)` then `xs.length`
+// → `4` — is the canonical case: a mutating method call plus a length read.
+
+#[test]
+fn array_push_length_runs_in_node() {
+    if !node_available() {
+        eprintln!("skipping array_push_length_runs_in_node: `node` not available");
+        return;
+    }
+    // `xs.push(4)` lowers to __method__ dispatch → runtime `callMethod`;
+    // `xs.length` is a property read (SeqLen).  After the push the length
+    // is 4.
+    let out = run_via_node(
+        "array_push_length",
+        "const xs = [1, 2, 3]; xs.push(4); console.log(xs.length);",
+    );
+    assert_eq!(out, "4");
+}
+
+#[test]
+fn array_map_reduce_runs_in_node() {
+    if !node_available() {
+        eprintln!("skipping array_map_reduce_runs_in_node: `node` not available");
+        return;
+    }
+    // Higher-order dispatch: `.map` with an arrow callback (lowered to a
+    // MakeClosure argument, unwrapped by the runtime), then `.reduce` with a
+    // two-param accumulator and an initial value.  [1,2,3] → *2 → [2,4,6] →
+    // sum → 12.
+    let out = run_via_node(
+        "array_map_reduce",
+        "const xs = [1, 2, 3]; \
+         const doubled = xs.map(x => x * 2); \
+         const total = doubled.reduce((a, b) => a + b, 0); \
+         console.log(total);",
+    );
+    assert_eq!(out, "12");
+}
+
+#[test]
+fn array_filter_includes_runs_in_node() {
+    if !node_available() {
+        eprintln!("skipping array_filter_includes_runs_in_node: `node` not available");
+        return;
+    }
+    // `.filter` (closure callback) then `.includes` (value membership).
+    // [1,2,3,4] keep >2 → [3,4]; includes(4) → true (printed `#t`).
+    let out = run_via_node(
+        "array_filter_includes",
+        "const xs = [1, 2, 3, 4]; \
+         const big = xs.filter(x => x > 2); \
+         console.log(big.includes(4));",
+    );
+    assert_eq!(out, "#t");
+}

--- a/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
@@ -7,6 +7,26 @@ All notable changes to `semantic-ir-to-javascript` are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.0 — method dispatch (`__method__`) execution
+
+Adds the minimal runtime support the JavaScript frontend's C3 member-method
+lowering needs to **run**.  A method call `recv.meth(args…)` reaches the
+backend as `BuiltinCall("__method__", [recv, StrLit("meth"), args…])`; the
+emitter now routes it to a new runtime helper, `__Sir.callMethod`, which
+invokes the JS-native method on the receiver (arrays' `push`/`pop`/`map`/
+`filter`/`forEach`/`includes`/`reduce`/…, strings' `toUpperCase`/…) and
+unwraps any `Closure` callback argument into a plain JS function.  This lets
+JavaScript→SIR→JS collection programs execute end-to-end under `node`.
+
+### Added
+
+- `emit_builtin_call` special-cases `BuiltinCall("__method__", [recv,
+  StrLit(name), args…])` → `__Sir.callMethod(recv, "name", args…)` (receiver
+  first, method name second, call args after).
+- Runtime `callMethod(recv, name, ...args)`: unwraps `Closure` args via
+  `applyClosure`, accepts `length` as a nullary method, and dispatches to the
+  native `recv[name]` method (throwing a clear `TypeError` when absent).
+
 ## 0.4.0 — KW4 (keyword-parameter & argument emission)
 
 Replaces the KW1 compile-compat stubs with **real** keyword-parameter and

--- a/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
@@ -7,6 +7,25 @@ All notable changes to `semantic-ir-to-javascript` are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Security
+
+- **Allowlist method-dispatch names in `callMethod` to block a
+  Function-constructor RCE (C3).**  `callMethod(recv, name, …args)` performed
+  an unrestricted dynamic `recv[name]` lookup with an attacker-controlled
+  `name`.  A translated untrusted program could therefore reach reflective
+  gadgets — chiefly `constructor`, which on any function yields the global
+  `Function` constructor, letting `id.constructor("return …evil…")` synthesise
+  and run arbitrary code (a native higher-order method like
+  `Array.prototype.map` then invokes it → remote code execution).  `apply`,
+  `call`, `bind`, `__proto__`, `prototype`, and the `__define/lookup*etter__`
+  pair were equally reachable.  `callMethod` now dispatches **only** through a
+  fixed allowlist of known-safe Array / String / Number methods; any name
+  outside it (every gadget included) throws a `TypeError` *before* the lookup.
+  This is the primary, load-bearing gate — the emitted JS is what executes.
+  A node execution-proof asserts `callMethod(id, "constructor", …)` throws
+  instead of building a function.  `length` remains special-cased ahead of the
+  allowlist as a property read.
+
 ## 0.5.0 — method dispatch (`__method__`) execution
 
 Adds the minimal runtime support the JavaScript frontend's C3 member-method

--- a/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "semantic-ir-to-javascript"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
-description = "Semantic IR → self-contained JavaScript source code (SIR18). Fifth backend for the SIR10 narrow-waist IR."
+description = "Semantic IR → self-contained JavaScript source code (SIR18). Fifth backend for the SIR10 narrow-waist IR. Includes __method__ dispatch execution (C3)."
 
 [dependencies]
 semantic-ir = { path = "../semantic-ir" }

--- a/code/packages/rust/semantic-ir-to-javascript/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/emit.rs
@@ -713,6 +713,22 @@ fn emit_call_args(out: &mut String, args: &[Expr], indent: usize) {
 /// runtime helpers; an unknown builtin lands on `callBuiltin` so a new
 /// builtin needs no backend change to *run* (only to be idiomatic).
 fn emit_builtin_call(out: &mut String, name: &str, args: &[Expr], indent: usize) {
+    // Method dispatch (`recv.meth(args…)` → `BuiltinCall("__method__",
+    // [recv, StrLit("meth"), args…])`, produced by the Ruby/JS frontends)
+    // routes to the runtime's `callMethod(recv, name, args…)`, which applies
+    // the JS-native method (arrays' `push`/`map`/… or strings'
+    // `toUpperCase`/…) and unwraps any `Closure` callback argument.  The
+    // method name is always a `StrLit` at `args[1]`.
+    if name == "__method__" && args.len() >= 2 {
+        out.push_str("__Sir.callMethod(");
+        emit_expr(out, &args[0], indent); // receiver
+        for a in &args[1..] {
+            out.push_str(", ");
+            emit_expr(out, a, indent); // StrLit(method), then call args
+        }
+        out.push(')');
+        return;
+    }
     // 2-argument binary operators → native infix.
     if args.len() == 2 {
         let infix = match name {
@@ -1185,6 +1201,35 @@ mod tests {
             emit_e(&bc("print", vec![Expr::IntLit { value: 7, span: s() }])),
             "__Sir.print(7)"
         );
+    }
+
+    #[test]
+    fn emit_method_dispatch_routes_to_call_method() {
+        // `arr.push(1)` → BuiltinCall("__method__", [arr, "push", 1]) →
+        // `__Sir.callMethod(arr, "push", 1)`.  Receiver first, method name
+        // (a StrLit) second, call args after.
+        let e = bc(
+            "__method__",
+            vec![
+                Expr::VarRef { name: "arr".into(), scope: Scope::Local, span: s() },
+                Expr::StrLit { value: "push".into(), span: s() },
+                Expr::IntLit { value: 1, span: s() },
+            ],
+        );
+        assert_eq!(emit_e(&e), r#"__Sir.callMethod(arr, "push", 1)"#);
+    }
+
+    #[test]
+    fn emit_zero_arg_method_dispatch() {
+        // `s.toUpperCase()` → __method__(s, "toUpperCase") → no trailing args.
+        let e = bc(
+            "__method__",
+            vec![
+                Expr::VarRef { name: "s".into(), scope: Scope::Local, span: s() },
+                Expr::StrLit { value: "toUpperCase".into(), span: s() },
+            ],
+        );
+        assert_eq!(emit_e(&e), r#"__Sir.callMethod(s, "toUpperCase")"#);
     }
 
     #[test]

--- a/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
@@ -162,10 +162,45 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
   // the readable `__Sir.print(x)` rather than `__Sir.builtins["print"](x)`.
   function print(x) { console.log(format(x)); return null; }
 
+  // ── method dispatch (`__method__`) ─────────────────────────────
+  // `recv.meth(args…)` reaches the backend as
+  // `BuiltinCall("__method__", [recv, "meth", args…])`; the emitter routes
+  // it here as `callMethod(recv, "meth", args…)`.  We dispatch to the
+  // JS-native method on the receiver — arrays' `push`/`pop`/`map`/`filter`/
+  // `forEach`/`includes`/`reduce`/…, strings' `toUpperCase`/… — so
+  // frontend collection code runs end-to-end (C3/C4).
+  //
+  // A callback argument arrives as a `Closure` (the frontend lowers an
+  // arrow / function argument to `MakeClosure`); `unwrapArg` turns it into
+  // an ordinary JS function via `applyClosure`, so `arr.map(fn)` and
+  // friends receive a callable the native method can invoke.  `length` is
+  // accepted as a zero-arg method too (a property read spelled as a call),
+  // though the frontend normally lowers bare `.length` to `SeqLen`.
+  function unwrapArg(a) {
+    if (a instanceof Closure) {
+      // Native higher-order methods pass (element, index, array); the SIR
+      // closure only binds the params it declared, so extra JS arguments
+      // are harmlessly ignored by `applyClosure`'s spread.
+      return (...xs) => applyClosure(a, xs);
+    }
+    return a;
+  }
+  function callMethod(recv, name, ...rawArgs) {
+    const args = rawArgs.map(unwrapArg);
+    // `length` as a nullary method mirrors the property.
+    if (name === "length" && args.length === 0) { return recv.length; }
+    const m = recv == null ? undefined : recv[name];
+    if (typeof m !== "function") {
+      throw new TypeError(
+        "method `" + name + "` is not defined on " + format(recv));
+    }
+    return m.apply(recv, args);
+  }
+
   return {
     Sym, Pair, Closure,
     intern, applyClosure, truthy, format, print,
-    builtins, builtinClosure, callBuiltin,
+    builtins, builtinClosure, callBuiltin, callMethod,
   };
 })();
 "##;
@@ -193,7 +228,7 @@ mod tests {
     fn runtime_exports_the_helpers_the_emitter_calls() {
         for needed in [
             "intern", "applyClosure", "truthy", "format",
-            "builtins", "builtinClosure", "callBuiltin",
+            "builtins", "builtinClosure", "callBuiltin", "callMethod",
             "class Sym", "class Pair", "class Closure",
         ] {
             assert!(RUNTIME.contains(needed), "runtime missing `{needed}`");

--- a/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
@@ -185,10 +185,52 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
     }
     return a;
   }
+  // ── method-name allowlist (SECURITY, load-bearing) ─────────────
+  // `name` here is ATTACKER-CONTROLLED: it originates as a source-level
+  // method name in an untrusted input program and reaches us verbatim.
+  // `recv[name]` is therefore an *unrestricted* dynamic property lookup, and
+  // a handful of JavaScript member names are reflective gadgets that turn
+  // that lookup into arbitrary-code execution.  The worst is `constructor`:
+  // on any function it yields the `Function` constructor, so a translated
+  // program can write
+  //     id.constructor("return …payload…")
+  // to synthesise and run evil code — and a native higher-order method
+  // (Array.prototype.map/filter/…) will then invoke the result.  That is a
+  // remote-code-execution hole.  `apply`/`call`/`bind` re-bind `this`, and
+  // `__proto__`/`prototype`/`__define*etter__`/`__lookup*etter__`/`valueOf`/
+  // `hasOwnProperty` are the other prototype-chain escape hatches.
+  //
+  // We therefore dispatch ONLY through this fixed allowlist of known-safe
+  // collection / String / Number methods.  Anything not on the list — every
+  // gadget above included, none of which appear here — is rejected with a
+  // TypeError *before* any property is looked up or invoked.  This is the
+  // primary gate: the emitted JS is what actually executes, so the allowlist
+  // must live here (the frontend denylist is defense in depth in front of it).
+  const METHOD_ALLOWLIST = new Set([
+    // Array
+    "push", "pop", "shift", "unshift", "slice", "splice", "concat",
+    "map", "filter", "reduce", "reduceRight", "forEach", "includes",
+    "indexOf", "lastIndexOf", "join", "sort", "reverse", "find",
+    "findIndex", "some", "every", "flat", "flatMap", "fill", "at",
+    "keys", "values", "entries",
+    // String
+    "toUpperCase", "toLowerCase", "trim", "trimStart", "trimEnd", "split",
+    "charAt", "charCodeAt", "codePointAt", "substring", "repeat",
+    "startsWith", "endsWith", "replace", "replaceAll", "padStart", "padEnd",
+    // Number
+    "toFixed", "toString",
+  ]);
   function callMethod(recv, name, ...rawArgs) {
     const args = rawArgs.map(unwrapArg);
-    // `length` as a nullary method mirrors the property.
+    // `length` as a nullary method mirrors the property.  Kept special-cased
+    // ahead of the allowlist: it is a property read, not a method call.
     if (name === "length" && args.length === 0) { return recv.length; }
+    // SECURITY gate: refuse any name outside the allowlist so reflective
+    // gadgets (`constructor`, `__proto__`, `apply`, …) can never be reached.
+    if (!METHOD_ALLOWLIST.has(name)) {
+      throw new TypeError(
+        "method `" + name + "` is not an allowed collection method");
+    }
     const m = recv == null ? undefined : recv[name];
     if (typeof m !== "function") {
       throw new TypeError(

--- a/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
@@ -777,3 +777,127 @@ fn required_keyword_param_supplied_by_call() {
         assert_eq!(stdout, "7", "pick(chosen: 7) must return 7");
     }
 }
+
+// ── SECURITY: runtime `callMethod` allowlist blocks the RCE gadget ─────
+//
+// `callMethod(recv, name, …)` performs a dynamic `recv[name]` lookup with an
+// attacker-controlled `name`.  Without a gate, `name = "constructor"` on a
+// function receiver yields the global `Function` constructor and lets a
+// translated untrusted program synthesise and run arbitrary code — a remote
+// code-execution hole.  The runtime now dispatches only through a fixed
+// allowlist of safe collection/String/Number methods; anything else throws a
+// `TypeError` *before* the lookup.  This test builds a module that emits
+// `__Sir.callMethod(fn, "constructor", "…")` directly (bypassing the frontend
+// denylist, to exercise the runtime's own gate) and asserts node throws
+// rather than executing the payload.
+
+/// Compile + run a module expecting node to FAIL (non-zero exit).  Returns
+/// the captured stderr so the caller can assert on the thrown message.
+/// Returns `None` when node is unavailable.
+fn run_module_expecting_failure(module: &Module, tag: &str) -> Option<String> {
+    let artifact = compile(module).expect("compile to javascript");
+    if !node_available() {
+        eprintln!("note: `node` unavailable — skipping execution for `{tag}`");
+        return None;
+    }
+    let mut path: PathBuf = std::env::temp_dir();
+    path.push(format!("sir_js_{}_{}.js", tag, std::process::id()));
+    std::fs::write(&path, &artifact.source).expect("write temp js");
+    let output = Command::new("node").arg(&path).output().expect("spawn node");
+    let _ = std::fs::remove_file(&path);
+    assert!(
+        !output.status.success(),
+        "SECURITY: node UNEXPECTEDLY SUCCEEDED for `{tag}` — the gadget was \
+         not blocked!\nstdout: {}\nsource:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        artifact.source,
+    );
+    Some(String::from_utf8_lossy(&output.stderr).to_string())
+}
+
+#[test]
+fn runtime_rejects_constructor_gadget() {
+    // Build:  function id(x) { return x; }
+    //         function main() { print(callMethod(id, "constructor", "return 1")); }
+    // where `callMethod(id, "constructor", …)` is the raw __method__ envelope.
+    // Unguarded, `id["constructor"]` is `Function`, and invoking it would
+    // build+run code.  The allowlist must reject "constructor" with a
+    // TypeError so node exits non-zero.
+    use semantic_ir::Param;
+
+    let id = Function {
+        name: "id".into(),
+        params: vec![Param {
+            name: "x".into(),
+            sir_type: None,
+            kind: semantic_ir::ParamKind::Required,
+            default: None,
+            span: sp(),
+        }],
+        return_type: None,
+        captures: vec![],
+        body: Block {
+            stmts: vec![],
+            value: Expr::VarRef { name: "x".into(), scope: Scope::Param, span: sp() },
+            span: sp(),
+        },
+        effects: EffectSet::PURE,
+        metadata: Metadata::new(),
+        span: sp(),
+    };
+
+    // The raw method-dispatch envelope: BuiltinCall("__method__",
+    // [receiver, "constructor", payload]) → __Sir.callMethod(id, "constructor",
+    // "return 1").  `id` is referenced as a global function handle.
+    let gadget = bc(
+        "__method__",
+        vec![
+            Expr::VarRef { name: "id".into(), scope: Scope::Global, span: sp() },
+            Expr::StrLit { value: "constructor".into(), span: sp() },
+            Expr::StrLit { value: "return 1".into(), span: sp() },
+        ],
+    );
+
+    let main = Function {
+        name: "main".into(),
+        params: vec![],
+        return_type: None,
+        captures: vec![],
+        body: Block { stmts: vec![print(gadget)], value: Expr::NilLit { span: sp() }, span: sp() },
+        effects: EffectSet::PURE,
+        metadata: Metadata::new(),
+        span: sp(),
+    };
+
+    let module = Module {
+        name: "rce_gadget".into(),
+        manifest: FeatureManifest::from_features(&[
+            Feature::Strings,
+            Feature::DynamicTyping,
+        ]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![id, main],
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("handbuilt")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: sp(),
+    };
+
+    // Shape check (runs without node): the emitted call routes to callMethod
+    // with the dangerous name — proving we are genuinely exercising the gate.
+    let artifact = compile(&module).expect("compile to javascript");
+    assert!(
+        artifact.source.contains(r#"__Sir.callMethod(id, "constructor", "return 1")"#),
+        "expected the raw constructor gadget in emitted source, got:\n{}",
+        artifact.source
+    );
+
+    if let Some(stderr) = run_module_expecting_failure(&module, "rce_gadget") {
+        assert!(
+            stderr.contains("not an allowed collection method"),
+            "expected the allowlist TypeError, got stderr:\n{stderr}"
+        );
+    }
+}


### PR DESCRIPTION
## What

**C3** (+ the essential slice of **C4**) of the collection-methods cascade. Two crates:
- `javascript-to-semantic-ir` (frontend): lowers `recv.method(args)` (previously deferred except `console.log`) → `BuiltinCall("__method__", [recv, StrLit("method"), ...args])`, mirroring the Ruby frontend. Chained calls fold step-by-step; arrow/function callbacks reuse existing `MakeClosure` lowering; `console.log` retained.
- `semantic-ir-to-javascript` (backend): the JS backend had **no** `__method__` handler (unlike TS), so emitted dispatch would throw under node. Added `emit_builtin_call` routing `__method__` → `__Sir.callMethod(recv, "name", ...args)` + a runtime `callMethod` helper — the minimal C4 work needed for an honest execution-proof.

Declares `Feature::Strings` for the synthetic method-name literal (no `MethodDispatch` feature invented — deferred Phase-2).

## Security hardening (in this PR)

The security review caught a **HIGH-severity RCE**: name-indexed dispatch (`recv[name](...)`) with a source-controlled name let a translated program reach the `Function` constructor — `xs.map(id.constructor("…payload…"))` → arbitrary code execution in the host running the translated JS. Fixed with defense in depth:
- **Runtime allowlist (primary):** `callMethod` gates through a fixed `Set` allowlist of known-safe Array/String/Number methods, throwing `TypeError` **before** the `recv[name]` lookup. `constructor`/`__proto__`/`prototype`/`apply`/`call`/`bind`/`__defineGetter__`… are rejected. (`Set.has`, not object indexing, so the check itself can't be prototype-polluted.)
- **Frontend denylist (defense in depth):** dangerous method names are rejected at lowering with a positioned error, so the dangerous `StrLit` never enters SIR (protecting every backend).

## Verification

- `javascript-to-semantic-ir`: **124 unit + 13 e2e** (incl. 3 security regressions); `semantic-ir-to-javascript`: **71 unit + 17 node** (incl. 1 security regression).
- **Security regressions execute:** `xs.map(id.constructor("…"))` now fails at lowering; the raw `callMethod(x,"constructor",…)` envelope makes node throw `TypeError` and exit non-zero.
- **Collection proofs (node) still pass:** `xs.push(4); xs.length`→`4`; `.map(x=>x*2).reduce(+,0)`→`12`; `.filter(x=>x>2).includes(4)`→`#t`.
- Clippy clean; `cargo build --workspace` clean (bar pre-existing Unix-only crate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)