### PR TITLE
feat(adj-ladder): rung-20 hepatic panel indices (new organ: hepatology)

### DIFF
--- a/code/specs/data/adj-ladder/rung20_hepatic_indices/gen_items.py
+++ b/code/specs/data/adj-ladder/rung20_hepatic_indices/gen_items.py
@@ -1,0 +1,172 @@
+"""Generate rung-20 (hepatic panel indices) items.json for the ADJ-LADDER.
+
+Rung 20 opens a **new organ system** on the quantitative band — **hepatology** — using the same
+contamination-safe shape as the pharmacokinetics rung (8), the renal-ratio rungs (9/13/15), the
+cardiology rungs (16/18), and the hematology rung (19): a small table of *observed* laboratory
+quantities, and a tight family of mutually-confusable formulas built **only from those observed
+quantities** (no numeric literal anywhere in any program), so nothing structural can leak.
+
+The clinical setup is a single liver-function panel. We observe four quantities:
+
+  AST   aspartate aminotransferase   (U/L)     — the "SGOT" transaminase
+  ALT   alanine aminotransferase     (U/L)     — the "SGPT" transaminase, liver-specific
+  DBIL  direct (conjugated) bilirubin (mg/dL)  — post-conjugation, water-soluble
+  IBIL  indirect (unconjugated) bilirubin (mg/dL) — pre-conjugation, albumin-bound
+
+From those four, three textbook hepatic indices fall out as **pure ratios** of the observed
+quantities — no constant required:
+
+  DE RITIS   AST : ALT ratio            = AST / ALT            [ >2 suggests alcoholic liver injury ]
+  DIRECT %   conjugated fraction        = DBIL / (DBIL + IBIL) [ high → obstructive / hepatocellular ]
+  INDIRECT % unconjugated fraction      = IBIL / (DBIL + IBIL) [ high → hemolysis / Gilbert ]
+
+Note the bilirubin fractions divide by **total bilirubin = DBIL + IBIL**, which is itself derived
+from the two observed components — so the denominator is a *sum of observed quantities*, never a
+constant. This exercises the engine across **division AND an inner addition-in-parentheses** —
+the same `(a + b)` grouping the ventilation/ejection rungs (17/18) used for subtraction — on a
+hepatology stem. Total bilirubin is deliberately NOT observed (it is computed), so no `×`-factor or
+constant appears.
+
+Each index is a `compute_dimensioned` program (observe the four quantities + `let answer =
+formula`); the ADJ engine carries the arithmetic and the harness reads the scalar via the existing
+`compute_dimensioned` extractor — no harness/engine change, exactly as rungs 8/16/18/19.
+
+Contamination-safe by construction: every formula is built only from the four observed quantities
+via `/`, `+`, and grouping `( )` — **no structural constants** — so every program literal is
+grounded in the stem. The five options are a tight family over the same quantities: the three real
+indices {De Ritis, direct %, indirect %} plus the two classic slips —
+
+  DBIL / IBIL   the direct-to-indirect *ratio* (confused with the direct *fraction* of total), and
+  ALT / AST     the **inverse** De Ritis ratio (the ratio written upside-down),
+
+which are exactly the mistakes a student makes. Gold rotates A–E by index.
+
+Note on table choice: the five family values can collide for special quantity ratios (e.g.
+De Ritis AST/ALT equals DBIL/IBIL whenever AST·IBIL = ALT·DBIL). The tables below are chosen so the
+five family values are pairwise distinct — with a comfortable margin — for every item, asserted at
+build time.
+"""
+import json
+
+LETTERS = ["A", "B", "C", "D", "E"]
+
+# (AST, ALT, DBIL, IBIL) observed quantities. The five index-family values are asserted
+# pairwise-distinct (with margin) below.
+#   AST  = aspartate aminotransferase  (U/L)
+#   ALT  = alanine aminotransferase    (U/L)
+#   DBIL = direct bilirubin            (mg/dL)
+#   IBIL = indirect bilirubin          (mg/dL)
+TABLES = [
+    (90, 45, 5, 3),
+    (60, 50, 4, 6),
+    (120, 40, 7, 2),
+    (75, 50, 3, 5),
+    (100, 80, 8, 4),
+    (45, 90, 2, 7),
+    (66, 55, 5, 4),
+]
+
+# The option family (5 members), all built from the observed quantities ast/alt/dbil/ibil via
+# `/`, `+`, and grouping. key -> (display name, formula-as-adj). Only the first three are *queried*
+# (used as gold); all five always appear as the options.
+FAMILY = [
+    ("de_ritis", "AST:ALT (De Ritis) ratio", "ast / alt"),
+    ("direct_frac", "direct (conjugated) fraction of total bilirubin", "dbil / (dbil + ibil)"),
+    ("indirect_frac", "indirect (unconjugated) fraction of total bilirubin", "ibil / (dbil + ibil)"),
+    ("di_ratio", "direct-to-indirect bilirubin ratio", "dbil / ibil"),
+    ("alt_ast", "ALT:AST ratio", "alt / ast"),
+]
+QUERIED = ["de_ritis", "direct_frac", "indirect_frac"]
+ORDER = [k for k, _, _ in FAMILY]
+
+
+def scalar(v):
+    return {"value": v, "unit": "scalar"}
+
+
+def family_values(ast, alt, dbil, ibil):
+    # Operation order mirrors the ADJ program exactly, so the Python option value and the engine
+    # result are the same IEEE-double (well within the harness's 1e-9 match tolerance).
+    return {
+        "de_ritis": ast / alt,
+        "direct_frac": dbil / (dbil + ibil),
+        "indirect_frac": ibil / (dbil + ibil),
+        "di_ratio": dbil / ibil,
+        "alt_ast": alt / ast,
+    }
+
+
+def build():
+    name_of = {k: nm for k, nm, _ in FAMILY}
+    formula_of = {k: f for k, _, f in FAMILY}
+    items = []
+    idx = 0
+    for ast, alt, dbil, ibil in TABLES:
+        fv = family_values(ast, alt, dbil, ibil)
+        # Pairwise-distinct with a comfortable margin so the harness never sees two options
+        # matching the gold value within its 1e-9 tolerance.
+        vals = [fv[k] for k in ORDER]
+        for i in range(len(vals)):
+            for j in range(i + 1, len(vals)):
+                assert abs(vals[i] - vals[j]) > 1e-6, (ast, alt, dbil, ibil, ORDER[i], ORDER[j], fv)
+        for key in QUERIED:
+            gold_val = fv[key]
+            gold_pos = idx % 5
+            others = [fv[k] for k in ORDER if abs(fv[k] - gold_val) > 1e-12]
+            opts_vals = others[:]
+            opts_vals.insert(gold_pos, gold_val)
+            opts_vals = opts_vals[:5]
+            if abs(opts_vals[gold_pos] - gold_val) > 1e-12:
+                opts_vals[gold_pos] = gold_val
+            assert len({round(v, 9) for v in opts_vals}) == 5, (key, ast, alt, dbil, ibil, opts_vals)
+            options = {LETTERS[i]: scalar(opts_vals[i]) for i in range(5)}
+            items.append({
+                "id": f"r20hep-{idx + 1:02d}",
+                "qtype": "hepatic_index",
+                "stem": (
+                    f"A liver-function panel shows AST {ast} U/L, ALT {alt} U/L, direct bilirubin "
+                    f"{dbil} mg/dL, and indirect bilirubin {ibil} mg/dL. What is the patient's "
+                    f"{name_of[key]}?"
+                ),
+                "program": (
+                    f"observe ast({ast})\n"
+                    f"observe alt({alt})\n"
+                    f"observe dbil({dbil})\n"
+                    f"observe ibil({ibil})\n"
+                    f"let answer = {formula_of[key]}\n"
+                    "? answer\n"
+                ),
+                "answer_from": {"type": "compute_dimensioned", "name": "answer"},
+                "options": options,
+                "gold_letter": LETTERS[gold_pos],
+            })
+            idx += 1
+    return {
+        "description": (
+            "ADJ-LADDER rung 20 — hepatic panel indices from a single liver-function test (a NEW "
+            "organ system: hepatology). From four stated quantities (AST, ALT, direct bilirubin DBIL, "
+            "indirect bilirubin IBIL) compute the AST:ALT De Ritis ratio (AST/ALT), the direct "
+            "(conjugated) fraction of total bilirubin (DBIL/(DBIL+IBIL)), or the indirect "
+            "(unconjugated) fraction (IBIL/(DBIL+IBIL)). Each item is a compute_dimensioned program "
+            "(observe the four quantities, let answer = formula); the ADJ engine carries the "
+            "arithmetic — a division AND an inner sum-in-parentheses for total bilirubin — and the "
+            "harness matches the scalar to the printed options. Contamination-safe: every index is "
+            "built only from the four observed quantities via /, +, and grouping — no constant leaks "
+            "(total bilirubin is derived from its components, not observed, so no x-factor appears). "
+            "The five options are a family over the same quantities, so the distractors are exactly "
+            "the slips students make: the direct-to-indirect ratio (DBIL/IBIL, confused with the "
+            "direct fraction) and the inverse De Ritis ratio (ALT/AST, written upside-down)."
+        ),
+        "items": items,
+    }
+
+
+if __name__ == "__main__":
+    doc = build()
+    with open("items.json", "w") as f:
+        json.dump(doc, f, indent=2)
+        f.write("\n")
+    print("wrote items.json:", len(doc["items"]), "items")
+    for it in doc["items"]:
+        print(it["id"], it["qtype"], "gold", it["gold_letter"],
+              "=", round(it["options"][it["gold_letter"]]["value"], 4))

--- a/code/specs/data/adj-ladder/rung20_hepatic_indices/items.json
+++ b/code/specs/data/adj-ladder/rung20_hepatic_indices/items.json
@@ -1,0 +1,698 @@
+{
+  "description": "ADJ-LADDER rung 20 \u2014 hepatic panel indices from a single liver-function test (a NEW organ system: hepatology). From four stated quantities (AST, ALT, direct bilirubin DBIL, indirect bilirubin IBIL) compute the AST:ALT De Ritis ratio (AST/ALT), the direct (conjugated) fraction of total bilirubin (DBIL/(DBIL+IBIL)), or the indirect (unconjugated) fraction (IBIL/(DBIL+IBIL)). Each item is a compute_dimensioned program (observe the four quantities, let answer = formula); the ADJ engine carries the arithmetic \u2014 a division AND an inner sum-in-parentheses for total bilirubin \u2014 and the harness matches the scalar to the printed options. Contamination-safe: every index is built only from the four observed quantities via /, +, and grouping \u2014 no constant leaks (total bilirubin is derived from its components, not observed, so no x-factor appears). The five options are a family over the same quantities, so the distractors are exactly the slips students make: the direct-to-indirect ratio (DBIL/IBIL, confused with the direct fraction) and the inverse De Ritis ratio (ALT/AST, written upside-down).",
+  "items": [
+    {
+      "id": "r20hep-01",
+      "qtype": "hepatic_index",
+      "stem": "A liver-function panel shows AST 90 U/L, ALT 45 U/L, direct bilirubin 5 mg/dL, and indirect bilirubin 3 mg/dL. What is the patient's AST:ALT (De Ritis) ratio?",
+      "program": "observe ast(90)\nobserve alt(45)\nobserve dbil(5)\nobserve ibil(3)\nlet answer = ast / alt\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 2.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 0.625,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.375,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 1.6666666666666667,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.5,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r20hep-02",
+      "qtype": "hepatic_index",
+      "stem": "A liver-function panel shows AST 90 U/L, ALT 45 U/L, direct bilirubin 5 mg/dL, and indirect bilirubin 3 mg/dL. What is the patient's direct (conjugated) fraction of total bilirubin?",
+      "program": "observe ast(90)\nobserve alt(45)\nobserve dbil(5)\nobserve ibil(3)\nlet answer = dbil / (dbil + ibil)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 2.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 0.625,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.375,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 1.6666666666666667,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.5,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r20hep-03",
+      "qtype": "hepatic_index",
+      "stem": "A liver-function panel shows AST 90 U/L, ALT 45 U/L, direct bilirubin 5 mg/dL, and indirect bilirubin 3 mg/dL. What is the patient's indirect (unconjugated) fraction of total bilirubin?",
+      "program": "observe ast(90)\nobserve alt(45)\nobserve dbil(5)\nobserve ibil(3)\nlet answer = ibil / (dbil + ibil)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 2.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 0.625,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.375,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 1.6666666666666667,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.5,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r20hep-04",
+      "qtype": "hepatic_index",
+      "stem": "A liver-function panel shows AST 60 U/L, ALT 50 U/L, direct bilirubin 4 mg/dL, and indirect bilirubin 6 mg/dL. What is the patient's AST:ALT (De Ritis) ratio?",
+      "program": "observe ast(60)\nobserve alt(50)\nobserve dbil(4)\nobserve ibil(6)\nlet answer = ast / alt\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 0.4,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 0.6,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.6666666666666666,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 1.2,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.8333333333333334,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r20hep-05",
+      "qtype": "hepatic_index",
+      "stem": "A liver-function panel shows AST 60 U/L, ALT 50 U/L, direct bilirubin 4 mg/dL, and indirect bilirubin 6 mg/dL. What is the patient's direct (conjugated) fraction of total bilirubin?",
+      "program": "observe ast(60)\nobserve alt(50)\nobserve dbil(4)\nobserve ibil(6)\nlet answer = dbil / (dbil + ibil)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 1.2,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 0.6,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.6666666666666666,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.8333333333333334,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.4,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r20hep-06",
+      "qtype": "hepatic_index",
+      "stem": "A liver-function panel shows AST 60 U/L, ALT 50 U/L, direct bilirubin 4 mg/dL, and indirect bilirubin 6 mg/dL. What is the patient's indirect (unconjugated) fraction of total bilirubin?",
+      "program": "observe ast(60)\nobserve alt(50)\nobserve dbil(4)\nobserve ibil(6)\nlet answer = ibil / (dbil + ibil)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 0.6,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 1.2,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.4,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.6666666666666666,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.8333333333333334,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r20hep-07",
+      "qtype": "hepatic_index",
+      "stem": "A liver-function panel shows AST 120 U/L, ALT 40 U/L, direct bilirubin 7 mg/dL, and indirect bilirubin 2 mg/dL. What is the patient's AST:ALT (De Ritis) ratio?",
+      "program": "observe ast(120)\nobserve alt(40)\nobserve dbil(7)\nobserve ibil(2)\nlet answer = ast / alt\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 0.7777777777777778,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 3.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.2222222222222222,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 3.5,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.3333333333333333,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r20hep-08",
+      "qtype": "hepatic_index",
+      "stem": "A liver-function panel shows AST 120 U/L, ALT 40 U/L, direct bilirubin 7 mg/dL, and indirect bilirubin 2 mg/dL. What is the patient's direct (conjugated) fraction of total bilirubin?",
+      "program": "observe ast(120)\nobserve alt(40)\nobserve dbil(7)\nobserve ibil(2)\nlet answer = dbil / (dbil + ibil)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 0.2222222222222222,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.7777777777777778,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 3.5,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.3333333333333333,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r20hep-09",
+      "qtype": "hepatic_index",
+      "stem": "A liver-function panel shows AST 120 U/L, ALT 40 U/L, direct bilirubin 7 mg/dL, and indirect bilirubin 2 mg/dL. What is the patient's indirect (unconjugated) fraction of total bilirubin?",
+      "program": "observe ast(120)\nobserve alt(40)\nobserve dbil(7)\nobserve ibil(2)\nlet answer = ibil / (dbil + ibil)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 0.7777777777777778,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 3.5,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.2222222222222222,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.3333333333333333,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r20hep-10",
+      "qtype": "hepatic_index",
+      "stem": "A liver-function panel shows AST 75 U/L, ALT 50 U/L, direct bilirubin 3 mg/dL, and indirect bilirubin 5 mg/dL. What is the patient's AST:ALT (De Ritis) ratio?",
+      "program": "observe ast(75)\nobserve alt(50)\nobserve dbil(3)\nobserve ibil(5)\nlet answer = ast / alt\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 0.375,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 0.625,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.6,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.6666666666666666,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1.5,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r20hep-11",
+      "qtype": "hepatic_index",
+      "stem": "A liver-function panel shows AST 75 U/L, ALT 50 U/L, direct bilirubin 3 mg/dL, and indirect bilirubin 5 mg/dL. What is the patient's direct (conjugated) fraction of total bilirubin?",
+      "program": "observe ast(75)\nobserve alt(50)\nobserve dbil(3)\nobserve ibil(5)\nlet answer = dbil / (dbil + ibil)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 0.375,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 1.5,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.625,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.6,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.6666666666666666,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r20hep-12",
+      "qtype": "hepatic_index",
+      "stem": "A liver-function panel shows AST 75 U/L, ALT 50 U/L, direct bilirubin 3 mg/dL, and indirect bilirubin 5 mg/dL. What is the patient's indirect (unconjugated) fraction of total bilirubin?",
+      "program": "observe ast(75)\nobserve alt(50)\nobserve dbil(3)\nobserve ibil(5)\nlet answer = ibil / (dbil + ibil)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 1.5,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 0.625,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.375,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.6,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.6666666666666666,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r20hep-13",
+      "qtype": "hepatic_index",
+      "stem": "A liver-function panel shows AST 100 U/L, ALT 80 U/L, direct bilirubin 8 mg/dL, and indirect bilirubin 4 mg/dL. What is the patient's AST:ALT (De Ritis) ratio?",
+      "program": "observe ast(100)\nobserve alt(80)\nobserve dbil(8)\nobserve ibil(4)\nlet answer = ast / alt\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 0.6666666666666666,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 0.3333333333333333,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 1.25,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 2.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.8,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r20hep-14",
+      "qtype": "hepatic_index",
+      "stem": "A liver-function panel shows AST 100 U/L, ALT 80 U/L, direct bilirubin 8 mg/dL, and indirect bilirubin 4 mg/dL. What is the patient's direct (conjugated) fraction of total bilirubin?",
+      "program": "observe ast(100)\nobserve alt(80)\nobserve dbil(8)\nobserve ibil(4)\nlet answer = dbil / (dbil + ibil)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 1.25,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 0.3333333333333333,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 2.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.6666666666666666,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.8,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r20hep-15",
+      "qtype": "hepatic_index",
+      "stem": "A liver-function panel shows AST 100 U/L, ALT 80 U/L, direct bilirubin 8 mg/dL, and indirect bilirubin 4 mg/dL. What is the patient's indirect (unconjugated) fraction of total bilirubin?",
+      "program": "observe ast(100)\nobserve alt(80)\nobserve dbil(8)\nobserve ibil(4)\nlet answer = ibil / (dbil + ibil)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 1.25,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 0.6666666666666666,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 2.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.8,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.3333333333333333,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r20hep-16",
+      "qtype": "hepatic_index",
+      "stem": "A liver-function panel shows AST 45 U/L, ALT 90 U/L, direct bilirubin 2 mg/dL, and indirect bilirubin 7 mg/dL. What is the patient's AST:ALT (De Ritis) ratio?",
+      "program": "observe ast(45)\nobserve alt(90)\nobserve dbil(2)\nobserve ibil(7)\nlet answer = ast / alt\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 0.5,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 0.2222222222222222,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.7777777777777778,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.2857142857142857,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 2.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r20hep-17",
+      "qtype": "hepatic_index",
+      "stem": "A liver-function panel shows AST 45 U/L, ALT 90 U/L, direct bilirubin 2 mg/dL, and indirect bilirubin 7 mg/dL. What is the patient's direct (conjugated) fraction of total bilirubin?",
+      "program": "observe ast(45)\nobserve alt(90)\nobserve dbil(2)\nobserve ibil(7)\nlet answer = dbil / (dbil + ibil)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 0.5,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 0.2222222222222222,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.7777777777777778,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.2857142857142857,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 2.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r20hep-18",
+      "qtype": "hepatic_index",
+      "stem": "A liver-function panel shows AST 45 U/L, ALT 90 U/L, direct bilirubin 2 mg/dL, and indirect bilirubin 7 mg/dL. What is the patient's indirect (unconjugated) fraction of total bilirubin?",
+      "program": "observe ast(45)\nobserve alt(90)\nobserve dbil(2)\nobserve ibil(7)\nlet answer = ibil / (dbil + ibil)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 0.5,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 0.2222222222222222,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.7777777777777778,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.2857142857142857,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 2.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r20hep-19",
+      "qtype": "hepatic_index",
+      "stem": "A liver-function panel shows AST 66 U/L, ALT 55 U/L, direct bilirubin 5 mg/dL, and indirect bilirubin 4 mg/dL. What is the patient's AST:ALT (De Ritis) ratio?",
+      "program": "observe ast(66)\nobserve alt(55)\nobserve dbil(5)\nobserve ibil(4)\nlet answer = ast / alt\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 0.5555555555555556,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 0.4444444444444444,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 1.25,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 1.2,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.8333333333333334,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r20hep-20",
+      "qtype": "hepatic_index",
+      "stem": "A liver-function panel shows AST 66 U/L, ALT 55 U/L, direct bilirubin 5 mg/dL, and indirect bilirubin 4 mg/dL. What is the patient's direct (conjugated) fraction of total bilirubin?",
+      "program": "observe ast(66)\nobserve alt(55)\nobserve dbil(5)\nobserve ibil(4)\nlet answer = dbil / (dbil + ibil)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 1.2,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 0.4444444444444444,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 1.25,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.8333333333333334,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.5555555555555556,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r20hep-21",
+      "qtype": "hepatic_index",
+      "stem": "A liver-function panel shows AST 66 U/L, ALT 55 U/L, direct bilirubin 5 mg/dL, and indirect bilirubin 4 mg/dL. What is the patient's indirect (unconjugated) fraction of total bilirubin?",
+      "program": "observe ast(66)\nobserve alt(55)\nobserve dbil(5)\nobserve ibil(4)\nlet answer = ibil / (dbil + ibil)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 0.4444444444444444,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 1.2,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.5555555555555556,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 1.25,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.8333333333333334,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    }
+  ]
+}

--- a/code/specs/data/adj-ladder/test_ladder_eval.py
+++ b/code/specs/data/adj-ladder/test_ladder_eval.py
@@ -57,6 +57,7 @@ SELF_CONTAINED_RUNGS = (
     "rung17_alveolar_ventilation",
     "rung18_ejection_fraction",
     "rung19_rbc_indices",
+    "rung20_hepatic_indices",
 )
 
 


### PR DESCRIPTION
## ADJ-LADDER rung-20 — hepatic panel indices (NEW organ system: hepatology)

Opens **hepatology** on the quantitative band, mirroring the merged rungs 8 (PK) / 16 (cardiac output) / 18 (ejection fraction) / 19 (RBC indices): a `compute_dimensioned` rung over four observed liver-function quantities, computing three textbook hepatic indices as constant-free formulas.

### The clinical setup
From a single LFT panel — **AST**, **ALT** (U/L), direct bilirubin **DBIL**, indirect bilirubin **IBIL** (mg/dL):

| index | formula | meaning |
|-------|---------|---------|
| De Ritis | `AST / ALT` | AST:ALT ratio (>2 → alcoholic liver injury) |
| direct % | `DBIL / (DBIL + IBIL)` | conjugated fraction of total bilirubin |
| indirect % | `IBIL / (DBIL + IBIL)` | unconjugated fraction of total bilirubin |

### Richer than a pure ratio
The bilirubin fractions divide by **total bilirubin = DBIL + IBIL**, itself derived from the two observed components — so the denominator is a **sum-in-parentheses**, exercising the engine across *division AND an inner addition* (the same `( )` grouping rungs 17/18 used for subtraction, now for a sum). Total bilirubin is deliberately **not** observed (it is computed), so no ×-factor or constant appears.

### Contamination-safety
Every formula is built **only** from the four observed quantities via `/`, `+`, and grouping — **no numeric literal appears in any program**. The five options are a tight family over the same quantities; the two distractors are the classic slips: the direct-to-indirect **ratio** (DBIL/IBIL, confused with the direct **fraction**) and the **inverse** De Ritis ratio (ALT/AST). Gold rotates A–E; tables chosen so the five family values are pairwise-distinct with a comfortable margin (asserted at build; avoids AST·IBIL == ALT·DBIL collisions).

### Contents
- **21 items** (7 tables × 3 queried indices), `qtype: hepatic_index`
- New `rung20_hepatic_indices/{gen_items.py,items.json}` (generated from the subdir)
- Registered in `SELF_CONTAINED_RUNGS`

### Verification
All three gating tests pass (`-k rung20`): engine selects every gold — **including the sum-in-denominator** — (0 wrong / 0 abstain), contamination check clean, items.json valid. Security review passed (deterministic offline generator, no injection/eval/path/DoS surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)