### PR TITLE
feat(latex): comma/semicolon fence lists keep their delimiters (fence-delimiters PR-3)

### DIFF
--- a/code/packages/rust/latex/CHANGELOG.md
+++ b/code/packages/rust/latex/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to the full-fidelity LaTeX parser crate.
 
+## [0.25.0] — 2026-07-01
+
+### Changed — comma/semicolon fence lists now keep their delimiters (`Fenced`-of-`Sequence`)
+
+The fence-delimiters arc's remaining slice: a **comma- or semicolon-separated** fence body now
+carries its delimiters too. Previously a single-body fence lowered to `MathExpr::Fenced { open,
+body, close }` (0.24.0) but a *list* fence (`(a, b)`, `[a, b]`, `\left(a, b\right)`, semicolon
+rows) lowered to a bare `MathExpr::Sequence`, **dropping** the surrounding brackets — so `(a, b)`
+and `[a, b]` were indistinguishable. Now the frontend adapter wraps the list in a `Fenced` carrying
+the open/close strings: `(a, b)` → `Fenced { open: "(", body: Sequence([a, b]), close: ")" }`,
+distinct from `[a, b]` → `Fenced { open: "[", … }`. **Both** the delimiters and the list structure
+are preserved.
+
+- The change is a one-line relaxation in the neutral-lowering worklist (`frontend.rs`): the
+  `MathNode::Fenced` arm now always pushes a `Build::Fenced` wrapper, instead of skipping it when
+  the body is a `Sequence`. The inner `Sequence` still builds via its own arm; the `Fenced` build
+  wraps it. No new node, no capability change (`fenced_delimiters` + `sequences` already declared).
+- Matrices (`pmatrix`/`bmatrix`/…) are unaffected — their delimiter style stays presentation on
+  `Matrix` as before; only `\left…\right` / `( ) [ ]` *list* fences are wrapped.
+- Tests `comma_fence_lowers_to_sequence` / `semicolon_fence_lowers_to_nested_sequence` become
+  `…_lowers_to_fenced_sequence` / `…_lowers_to_fenced_nested_sequence`, asserting the delimiters are
+  now carried around the (unchanged) inner sequence. All downstream consumers (`math-frontend`,
+  `mathml`, `asciimath`, `unicode-math`, `adj-lang`, `adj-lang-cli`) build and pass unchanged — the
+  `adj-lang` adapter already unwraps `Fenced` to its body, so a `Fenced`-of-`Sequence` lowers
+  exactly as the bare `Sequence` did (both non-arithmetic).
+
 ## [0.24.0] — 2026-06-30
 
 ### Changed — fence delimiters preserved as data (frontend adapter)

--- a/code/packages/rust/latex/Cargo.toml
+++ b/code/packages/rust/latex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latex"
-version = "0.24.0"
+version = "0.25.0"
 edition = "2021"
 description = "A full-fidelity LaTeX parser (documents and math): a catcode-driven, text-mode-primary tokenizer and (in later layers) a structural + math parser producing a faithful AST. Standalone and reusable; will also implement the math-frontend MathFrontend trait."
 license = "MIT"

--- a/code/packages/rust/latex/src/frontend.rs
+++ b/code/packages/rust/latex/src/frontend.rs
@@ -15,8 +15,9 @@
 //! - `\times`, `\cdot`, and juxtaposition all become [`BinOp::Mul`]; `\dfrac`/`\tfrac`/`\frac`
 //!   all become [`MathExpr::Frac`] — two source strings that mean the same math lower equal.
 //! - fence *delimiters* are preserved as data: `(x)`, `[x]`, `|x|`, `\left(x\right)` become
-//!   [`MathExpr::Fenced`] carrying their open/close strings (a comma-list body still lowers to
-//!   [`MathExpr::Sequence`] with delimiters dropped — carrying them there is a later slice).
+//!   [`MathExpr::Fenced`] carrying their open/close strings (so `|x|` abs/norm ≠ `(x)`). A
+//!   comma-list body keeps its delimiters too: `(a, b)` → `Fenced { body: Sequence([a, b]) }`,
+//!   distinct from `[a, b]` — both the delimiters and the list structure are preserved.
 //! - matrix *delimiter* is dropped: `pmatrix`/`bmatrix`/`cases`/… all become [`MathExpr::Matrix`].
 //! - `base^sup` → [`BinOp::Pow`]; `base_sub` → [`MathExpr::Subscript`]; both → `Pow(Subscript(…))`.
 //! - an accent (`\hat{x}`, `\vec{v}`) lowers to the neutral [`MathExpr::Accent`] (a diacritic
@@ -272,17 +273,15 @@ fn lower(root: MathNode, span: (usize, usize)) -> Result<MathExpr, FrontendError
                 }
                 // A fence brackets its body; we preserve *which* delimiters were used as data on
                 // the neutral `MathExpr::Fenced { open, close }` — so `|x|` (abs/norm) is no
-                // longer confused with `(x)`. EXCEPTION: a comma-list body is a Sequence (a tuple
-                // / list) whose delimiters still drop, matching MathML `<mfenced>` and AsciiMath
-                // `(a,b,c)` (carrying delimiters on sequences is a later slice of this arc).
+                // longer confused with `(x)`. This holds for a comma-list body too: a tuple
+                // `(a, b)` lowers to `Fenced { body: Sequence([a, b]) }`, keeping BOTH the
+                // delimiters and the list structure (so `(a, b)` and `[a, b]` are distinct). The
+                // Sequence still builds via its own arm below; the `Fenced` build wraps it.
                 MathNode::Fenced { left, body, right } => {
                     let open = std::mem::take(left);
                     let close = std::mem::take(right);
                     let body = take_box(body);
-                    if !matches!(body, MathNode::Sequence(_)) {
-                        work.push(Task::Build(Build::Fenced { open, close }));
-                    }
-                    // A Sequence body lowers via its own arm (delimiters dropped, for now).
+                    work.push(Task::Build(Build::Fenced { open, close }));
                     work.push(Task::Node(body));
                 }
                 // A comma-separated sequence — the fence's delimiters are already dropped.
@@ -613,21 +612,43 @@ mod tests {
         assert!(matches!(m(r"\left|x\right|"), MathExpr::Fenced { ref open, ref close, .. } if open == "|" && close == "|"));
     }
 
+    /// Unwrap a `Fenced { open, body, close }`, asserting the delimiters, and return the body — so
+    /// the comma/semicolon-list tests can check the inner Sequence while also verifying that the
+    /// fence's delimiters are now carried (rather than dropped).
+    fn fenced_body(e: MathExpr, open: &str, close: &str) -> MathExpr {
+        // Match by reference and clone the body: `MathExpr` implements `Drop` (iterative), so a
+        // field cannot be moved out of it by pattern.
+        match &e {
+            MathExpr::Fenced { open: o, body, close: c } => {
+                assert_eq!((o.as_str(), c.as_str()), (open, close));
+                (**body).clone()
+            }
+            other => panic!("expected Fenced({open:?}, .., {close:?}), got {other:?}"),
+        }
+    }
+
     #[test]
-    fn comma_fence_lowers_to_sequence() {
-        // A comma-separated fence is a LIST → MathExpr::Sequence (delimiters dropped, as for
-        // MathML `<mfenced>` and AsciiMath `(a,b,c)`). The third frontend on the neutral node.
+    fn comma_fence_lowers_to_fenced_sequence() {
+        // A comma-separated fence is a LIST → MathExpr::Sequence, now WRAPPED in a `Fenced` that
+        // keeps the delimiters (so `(a, b)` and `[a, b]` are distinguishable — both the brackets
+        // and the list structure are preserved).
         let sym = |s: &str| MathExpr::Symbol(s.into());
         assert_eq!(
-            m("(a, b, c)"),
+            fenced_body(m("(a, b, c)"), "(", ")"),
             MathExpr::Sequence(vec![sym("a"), sym("b"), sym("c")])
         );
-        // `\left(…\right)` and bracket fences lower the same way.
-        assert_eq!(m(r"\left(a, b\right)"), MathExpr::Sequence(vec![sym("a"), sym("b")]));
-        assert_eq!(m("[x, y]"), MathExpr::Sequence(vec![sym("x"), sym("y")]));
+        // `\left(…\right)` and bracket fences carry their own delimiters around the list.
+        assert_eq!(
+            fenced_body(m(r"\left(a, b\right)"), "(", ")"),
+            MathExpr::Sequence(vec![sym("a"), sym("b")])
+        );
+        assert_eq!(
+            fenced_body(m("[x, y]"), "[", "]"),
+            MathExpr::Sequence(vec![sym("x"), sym("y")])
+        );
         // Each item is a full expression, not just a leaf.
         assert_eq!(
-            m("(x + 1, 2)"),
+            fenced_body(m("(x + 1, 2)"), "(", ")"),
             MathExpr::Sequence(vec![
                 MathExpr::Bin(BinOp::Add, Box::new(sym("x")), Box::new(num(1))),
                 num(2),
@@ -638,12 +659,12 @@ mod tests {
     }
 
     #[test]
-    fn semicolon_fence_lowers_to_nested_sequence() {
-        // A semicolon fence is ROWS of columns → a nested MathExpr::Sequence (matching MathML
-        // `<mfenced>` semicolon rows). `(a, b; c, d)` → Sequence([Sequence([a,b]), Sequence([c,d])]).
+    fn semicolon_fence_lowers_to_fenced_nested_sequence() {
+        // A semicolon fence is ROWS of columns → a nested MathExpr::Sequence, wrapped in a `Fenced`
+        // carrying the delimiters. `(a, b; c, d)` → Fenced("(", Sequence([Seq[a,b], Seq[c,d]]), ")").
         let sym = |s: &str| MathExpr::Symbol(s.into());
         assert_eq!(
-            m("(a, b; c, d)"),
+            fenced_body(m("(a, b; c, d)"), "(", ")"),
             MathExpr::Sequence(vec![
                 MathExpr::Sequence(vec![sym("a"), sym("b")]),
                 MathExpr::Sequence(vec![sym("c"), sym("d")]),
@@ -651,17 +672,20 @@ mod tests {
         );
         // `\left(…;…\right)` lowers the same way.
         assert_eq!(
-            m(r"\left(a, b; c, d\right)"),
+            fenced_body(m(r"\left(a, b; c, d\right)"), "(", ")"),
             MathExpr::Sequence(vec![
                 MathExpr::Sequence(vec![sym("a"), sym("b")]),
                 MathExpr::Sequence(vec![sym("c"), sym("d")]),
             ])
         );
         // A semicolon-only fence collapses to a flat Sequence (no row has a second column).
-        assert_eq!(m("(a; b; c)"), MathExpr::Sequence(vec![sym("a"), sym("b"), sym("c")]));
+        assert_eq!(
+            fenced_body(m("(a; b; c)"), "(", ")"),
+            MathExpr::Sequence(vec![sym("a"), sym("b"), sym("c")])
+        );
         // A ragged fence keeps its shape.
         assert_eq!(
-            m("(a; b, c)"),
+            fenced_body(m("(a; b, c)"), "(", ")"),
             MathExpr::Sequence(vec![sym("a"), MathExpr::Sequence(vec![sym("b"), sym("c")])])
         );
     }


### PR DESCRIPTION
## Fence-delimiters arc — PR-3: comma/semicolon fence lists keep their delimiters

The arc so far: PR-1 gave latex single-body fences the neutral `MathExpr::Fenced { open, body, close }`; PR-2 adopted it in the mathml frontend. This PR-3 closes the **remaining slice explicitly called out in the latex + mathml READMEs**: a comma- or semicolon-separated **list** fence still dropped its delimiters (lowered to a bare `Sequence`), so `(a, b)` and `[a, b]` were indistinguishable. Now they're preserved.

> **Note on branch name:** the branch is `latex-fenced-asciimath` (I first scoped PR-3 as an asciimath adoption), but asciimath has **no explicit delimiter form** — its `()`/`[]`/`{}` are purely dual-use grouping that's *unwrapped* (`(1)/(2)≡1/2`), so wrapping them in `Fenced` would break grouping semantics. The clean, well-defined slice is the list-fence one in **latex** (where `\left…\right` and `()`/`[]` are genuine fences with known delimiters), so this PR does that instead.

### What changed
| input | before | after |
|-------|--------|-------|
| `(a, b)` | `Sequence([a,b])` | `Fenced { "(", Sequence([a,b]), ")" }` |
| `[a, b]` | `Sequence([a,b])` | `Fenced { "[", Sequence([a,b]), "]" }` |
| `(a,b; c,d)` | `Sequence([Seq,Seq])` | `Fenced { "(", Sequence([Seq,Seq]), ")" }` |

Both the delimiters **and** the list structure are preserved.

### Implementation
A **one-line relaxation** in the iterative neutral-lowering worklist (`frontend.rs`): the `MathNode::Fenced` arm now always pushes a `Build::Fenced` wrapper instead of skipping it when the body is a `Sequence`. The inner `Sequence` still builds via its own arm; the `Fenced` build wraps it. No new node, no `unsafe`, no capability change (`fenced_delimiters` + `sequences` already declared). Lowering stays **iterative** (heap worklist, no added recursion) so deep trees don't overflow the stack, and the iterative `Drop` is untouched. Matrices (`pmatrix`/`bmatrix`/…) are unaffected — their delimiter style stays presentation on `Matrix`.

### Verification
- **512 tests pass** across `latex` + all consumers (`math-frontend`, `mathml`, `asciimath`, `unicode-math`, `adj-lang`) + `adj-lang-cli` golden suite; `cargo clippy -p latex` clean.
- The two comma/semicolon fence tests are renamed to `…_lowers_to_fenced_sequence` / `…_lowers_to_fenced_nested_sequence` and assert the delimiters are now carried around the (unchanged) inner sequence, via a new `fenced_body` test helper.
- The `adj-lang` adapter already unwraps `Fenced` to its body, so a `Fenced`-of-`Sequence` lowers exactly as the bare `Sequence` did (both non-arithmetic) — no downstream behavior change.
- **Security review PASSED** — confirmed no new recursion (worklist stays iterative), the `Build::Fenced` pop invariant holds (body builds first, leaves exactly one value), no panic path, `Drop` stays iterative.

latex 0.24.0 → 0.25.0 (path dep, no version pins downstream).

🤖 Generated with [Claude Code](https://claude.com/claude-code)