### PR TITLE
feat(mathml): comma/semicolon list fences carry their delimiters (0.7.0)

### DIFF
--- a/code/packages/rust/mathml/CHANGELOG.md
+++ b/code/packages/rust/mathml/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to the Presentation-MathML frontend crate.
 
+## [0.7.0] — 2026-07-01
+
+### Changed — comma/semicolon list fences now carry their delimiters too
+
+`0.6.0` adopted the neutral `MathExpr::Fenced` node for **single-body** `<mfenced>`, but a
+comma/semicolon **list** `<mfenced>` still lowered to a bare `Sequence`, silently dropping which
+delimiters bracketed the list — so `(a, b)` and `[a, b]` were indistinguishable. This release wraps
+**every** `<mfenced>` shape in `Fenced`, mirroring the `latex` frontend (`latex` 0.25.0):
+
+- A comma list `(a, b, c)` → `Fenced { open, body: Sequence([a, b, c]), close }`.
+- A semicolon/row fence `(a, b; c, d)` → `Fenced { open, body: Sequence([Sequence([a, b]),
+  Sequence([c, d])]), close }` — both the delimiters and the row/column structure are preserved.
+- The wrapping `Fenced` reads the same `open`/`close` off the start-tag byte span (default `(`/`)`),
+  so `[a, b]`, `{a, b}`, `⟨a, b⟩` are now distinct from `(a, b)`.
+- Downstream is unaffected: the `adj-lang` adapter unwraps `Fenced`, so a `Fenced`-of-`Sequence`
+  lowers exactly as the bare `Sequence` did — only the delimiters, previously dropped, are now
+  carried. Verified across `latex`/`mathml`/`asciimath`/`unicode-math`/`adj-lang`/`adj-lang-cli`.
+
+This completes the list-fence delimiter slice for both `latex` and `mathml`.
+
 ## [0.6.0] — 2026-07-01
 
 ### Added — adopt the neutral `Fenced` node (fence delimiters as data)

--- a/code/packages/rust/mathml/Cargo.toml
+++ b/code/packages/rust/mathml/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mathml"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 description = "A Presentation-MathML reader that implements the math-frontend MathFrontend trait: turns <math>…</math> (mn/mi/mo/mrow/mfrac/msup/msub/msqrt/mroot/mtext/mtable/mover/munder/mfenced + named functions) into the neutral MathExpr AST. The fourth pluggable frontend after LaTeX and AsciiMath (see PFE01). Total, panic-free, spanned errors."
 license = "MIT"

--- a/code/packages/rust/mathml/README.md
+++ b/code/packages/rust/mathml/README.md
@@ -27,7 +27,7 @@ tree.
 | `<msqrt>x</msqrt>` / `<mroot>x n</mroot>` | `Root` (degree `None` / `Some(n)`) |
 | `<mover>b a</mover>` / `<munder>b a</munder>` | `Overset { over: a, base: b }` / `Underset { under: a, base: b }` (PR-2) |
 | `<munderover>b u o</munderover>` | `Underset { under: u, base: Overset { over: o, base: b } }` (PR-2) |
-| `<mfenced>…</mfenced>` | single body → `Fenced { open, body, close }` carrying the `open`/`close` delimiters (default `(`/`)`, so `\|x\|` ≠ `(x)`); comma / semicolon lists → `Sequence` |
+| `<mfenced>…</mfenced>` | every shape → `Fenced { open, body, close }` carrying the `open`/`close` delimiters (default `(`/`)`, so `\|x\|` ≠ `(x)` and `(a,b)` ≠ `[a,b]`); a comma / semicolon list is the `Sequence` body of that `Fenced` |
 | `<mtable><mtr><mtd>…</mtd></mtr></mtable>` | `Matrix(rows × cells)` (PR-2) |
 | `<mi>sin</mi> … x` (applied) | `Call { func: Sin, arg: x }` (PR-3) |
 
@@ -40,10 +40,11 @@ operator — so `<mover><mi>x</mi><mo>^</mo></mover>` is "x with a hat". An `<mi
 function (sin, cos, ln, …) **applied to an argument** becomes a `Call`; the same name with no argument
 stays a plain `Symbol`.
 
-Fence-delimiters arc (remaining slice): a comma / semicolon `<mfenced>` list still lowers to
-`Sequence`, which drops the surrounding `open`/`close` delimiters. Carrying delimiters on the list
-shape (a `Fenced`-of-`Sequence`, or a delimiters field on `Sequence`) is a later slice, tracked with
-the same slice in the `latex` frontend.
+Fence-delimiters arc (complete for `mathml`): a comma / semicolon `<mfenced>` list now lowers to a
+`Fenced`-of-`Sequence`, carrying the surrounding `open`/`close` delimiters rather than dropping them —
+so `(a, b)` and `[a, b]` are distinct while the list/row structure is preserved as the `Fenced` body.
+This mirrors the `latex` frontend (`latex` 0.25.0). The `adj-lang` adapter unwraps `Fenced`, so the
+`Fenced`-of-`Sequence` lowers exactly as the bare `Sequence` did downstream.
 
 ## Contract
 

--- a/code/packages/rust/mathml/src/lib.rs
+++ b/code/packages/rust/mathml/src/lib.rs
@@ -72,8 +72,10 @@ impl MathFrontend for MathMl {
         // PR-3 adds named-function recognition (`<mi>sin</mi>` applied to an argument → `Call`).
         // PR-4 adds sequences: an `<mfenced>` with comma separators (`(a, b, c)`) lowers to
         // `Sequence` instead of folding the commas away. The fence-delimiters slice adopts the
-        // neutral `Fenced` node: a single-body `<mfenced>` now lowers to `Fenced { open, body,
-        // close }`, carrying its `open`/`close` delimiters as data (so `|x|` ≠ `(x)`).
+        // neutral `Fenced` node for EVERY `<mfenced>` shape: a single-body `<mfenced>` lowers to
+        // `Fenced { open, body, close }`, and a comma/semicolon LIST lowers to `Fenced { open,
+        // body: Sequence(..), close }` — always carrying its `open`/`close` delimiters as data (so
+        // `|x|` ≠ `(x)` and `(a, b)` ≠ `[a, b]`).
         Capabilities::none()
             .with_fractions()
             .with_roots()
@@ -118,6 +120,20 @@ mod tests {
     }
     fn b(op: BinOp, l: MathExpr, r: MathExpr) -> MathExpr {
         MathExpr::Bin(op, Box::new(l), Box::new(r))
+    }
+
+    /// Unwrap a `Fenced { open, body, close }`, asserting the delimiters, and return the body — so the
+    /// comma/semicolon-list tests can check the inner `Sequence` while also verifying that the fence's
+    /// delimiters are now carried (rather than dropped). `MathExpr` implements `Drop` (iterative), so a
+    /// field cannot be moved out by pattern; match by reference and clone the body.
+    fn fenced_body(e: MathExpr, open: &str, close: &str) -> MathExpr {
+        match &e {
+            MathExpr::Fenced { open: o, body, close: c } => {
+                assert_eq!((o.as_str(), c.as_str()), (open, close));
+                (**body).clone()
+            }
+            other => panic!("expected Fenced({open:?}, .., {close:?}), got {other:?}"),
+        }
     }
 
     // ---- leaf tokens -----------------------------------------------------------
@@ -410,10 +426,23 @@ mod tests {
     }
 
     #[test]
-    fn mfenced_comma_separated_becomes_sequence() {
-        // A fence with comma separators is a LIST: <mfenced>a, b, c</mfenced> → Sequence([a,b,c]).
+    fn mfenced_comma_separated_becomes_fenced_sequence() {
+        // A fence with comma separators is a LIST wrapped in a `Fenced` carrying its delimiters:
+        // <mfenced>a, b, c</mfenced> → Fenced("(", Sequence([a,b,c]), ")"). A bare fence defaults to
+        // `(`/`)`, so `(a, b, c)` stays distinguishable from `[a, b, c]`.
         let e = p("<mfenced><mi>a</mi><mo>,</mo><mi>b</mi><mo>,</mo><mi>c</mi></mfenced>");
-        assert_eq!(e, MathExpr::Sequence(vec![sym("a"), sym("b"), sym("c")]));
+        assert_eq!(
+            fenced_body(e, "(", ")"),
+            MathExpr::Sequence(vec![sym("a"), sym("b"), sym("c")])
+        );
+    }
+
+    #[test]
+    fn mfenced_comma_list_carries_custom_bracket_delimiters() {
+        // The wrapping `Fenced` reads the `open`/`close` attributes, so `[a, b]` is now distinct from
+        // `(a, b)` — the bracket flavour is preserved around the list, not dropped.
+        let e = p("<mfenced open=\"[\" close=\"]\"><mi>a</mi><mo>,</mo><mi>b</mi></mfenced>");
+        assert_eq!(fenced_body(e, "[", "]"), MathExpr::Sequence(vec![sym("a"), sym("b")]));
     }
 
     #[test]
@@ -421,29 +450,29 @@ mod tests {
         // Each item between commas is itself folded to one expression, not just a leaf.
         let e = p("<mfenced><mrow><mi>x</mi><mo>+</mo><mn>1</mn></mrow><mo>,</mo><mn>2</mn></mfenced>");
         assert_eq!(
-            e,
+            fenced_body(e, "(", ")"),
             MathExpr::Sequence(vec![b(BinOp::Add, sym("x"), num(1)), num(2)])
         );
     }
 
     #[test]
     fn mfenced_pair_is_a_two_item_sequence() {
-        // The common coordinate-pair case `(a, b)` → Sequence([a, b]).
+        // The common coordinate-pair case `(a, b)` → Fenced("(", Sequence([a, b]), ")").
         let e = p("<mfenced><mi>a</mi><mo>,</mo><mi>b</mi></mfenced>");
-        assert_eq!(e, MathExpr::Sequence(vec![sym("a"), sym("b")]));
+        assert_eq!(fenced_body(e, "(", ")"), MathExpr::Sequence(vec![sym("a"), sym("b")]));
     }
 
     #[test]
     fn mfenced_semicolon_rows_of_comma_columns_nest() {
         // Semicolons are the ROW separator, commas the column separator — the fenced-matrix
-        // reading `(a, b; c, d)` → Sequence([Sequence([a, b]), Sequence([c, d])]).
+        // reading `(a, b; c, d)` → Fenced("(", Sequence([Sequence([a, b]), Sequence([c, d])]), ")").
         let e = p(concat!(
             "<mfenced>",
             "<mi>a</mi><mo>,</mo><mi>b</mi><mo>;</mo><mi>c</mi><mo>,</mo><mi>d</mi>",
             "</mfenced>"
         ));
         assert_eq!(
-            e,
+            fenced_body(e, "(", ")"),
             MathExpr::Sequence(vec![
                 MathExpr::Sequence(vec![sym("a"), sym("b")]),
                 MathExpr::Sequence(vec![sym("c"), sym("d")]),
@@ -454,9 +483,13 @@ mod tests {
     #[test]
     fn mfenced_semicolon_only_is_a_flat_sequence() {
         // A column vector `(a; b; c)` has no second column in any row, so it collapses to the same
-        // flat Sequence([a, b, c]) as a comma list — no spurious one-element nesting.
+        // flat Sequence([a, b, c]) as a comma list — no spurious one-element nesting — still wrapped
+        // in the delimiter-carrying `Fenced`.
         let e = p("<mfenced><mi>a</mi><mo>;</mo><mi>b</mi><mo>;</mo><mi>c</mi></mfenced>");
-        assert_eq!(e, MathExpr::Sequence(vec![sym("a"), sym("b"), sym("c")]));
+        assert_eq!(
+            fenced_body(e, "(", ")"),
+            MathExpr::Sequence(vec![sym("a"), sym("b"), sym("c")])
+        );
     }
 
     #[test]
@@ -464,7 +497,7 @@ mod tests {
         // A ragged fence `(a; b, c)` keeps its shape: row 1 is a single expr, row 2 is a pair.
         let e = p("<mfenced><mi>a</mi><mo>;</mo><mi>b</mi><mo>,</mo><mi>c</mi></mfenced>");
         assert_eq!(
-            e,
+            fenced_body(e, "(", ")"),
             MathExpr::Sequence(vec![sym("a"), MathExpr::Sequence(vec![sym("b"), sym("c")])])
         );
     }
@@ -479,7 +512,7 @@ mod tests {
             "</mfenced>"
         ));
         assert_eq!(
-            e,
+            fenced_body(e, "(", ")"),
             MathExpr::Sequence(vec![
                 MathExpr::Sequence(vec![b(BinOp::Add, sym("x"), num(1)), num(2)]),
                 sym("y"),

--- a/code/packages/rust/mathml/src/parser.rs
+++ b/code/packages/rust/mathml/src/parser.rs
@@ -558,46 +558,52 @@ impl Parser {
             //
             // The `separators` attribute is presentation and dropped — only *literal* `<mo>,</mo>`/
             // `<mo>;</mo>` children are read as separators, matching how the comma list already
-            // worked. The `open`/`close` delimiter attributes, however, ARE meaning-bearing for the
-            // single-body case and re-read from the tag span into `Fenced` (the comma/semicolon list
-            // cases still lower to `Sequence`, which drops them — a later slice of the fence arc).
+            // worked. The `open`/`close` delimiter attributes ARE meaning-bearing in ALL three shapes
+            // and re-read from the tag span into a wrapping `Fenced` — so a comma list `(a, b)` is kept
+            // distinct from `[a, b]`, and the row structure is preserved as the `Fenced` body. This
+            // mirrors the latex frontend, which likewise wraps its list fences in `Fenced` of a
+            // `Sequence`. The adj-lang adapter unwraps `Fenced`, so a `Fenced`-of-`Sequence` lowers
+            // exactly as the bare `Sequence` did — no downstream behaviour changes, only the delimiters
+            // are now carried rather than silently dropped.
             "mfenced" => {
                 let kids = self.parse_row_children(name, depth)?;
                 let has_comma = kids.iter().any(|c| matches!(c, Child::Op(s) if s == ","));
                 let has_semicolon = kids.iter().any(|c| matches!(c, Child::Op(s) if s == ";"));
-                if !has_comma && !has_semicolon {
-                    let inner = fold_row(kids, span, depth)?;
-                    // MathML's own defaults for a bare `<mfenced>` are `(` and `)`.
-                    let open = tag_attr(&self.src, span, "open").unwrap_or_else(|| "(".to_string());
-                    let close = tag_attr(&self.src, span, "close").unwrap_or_else(|| ")".to_string());
-                    return Ok(Child::Expr(MathExpr::Fenced {
-                        open,
-                        body: Box::new(inner),
-                        close,
-                    }));
-                }
-                if !has_semicolon {
+                // MathML's own defaults for a bare `<mfenced>` are `(` and `)`. Read once — every
+                // shape below carries the same open/close on its wrapping `Fenced`.
+                let open = tag_attr(&self.src, span, "open").unwrap_or_else(|| "(".to_string());
+                let close = tag_attr(&self.src, span, "close").unwrap_or_else(|| ")".to_string());
+                let body = if !has_comma && !has_semicolon {
+                    // A single delimited group — the body is just the folded row.
+                    fold_row(kids, span, depth)?
+                } else if !has_semicolon {
                     // Comma-only: a flat list. Each comma-delimited segment folds to one expression.
                     let items = split_fence_children(kids, ",")
                         .into_iter()
                         .map(|seg| fold_row(seg, span, depth))
                         .collect::<Result<Vec<_>, _>>()?;
-                    return Ok(Child::Expr(MathExpr::Sequence(items)));
-                }
-                // Semicolon present: split into rows first, then columns within each row.
-                let mut rows: Vec<MathExpr> = Vec::new();
-                for row in split_fence_children(kids, ";") {
-                    if row.iter().any(|c| matches!(c, Child::Op(s) if s == ",")) {
-                        let cols = split_fence_children(row, ",")
-                            .into_iter()
-                            .map(|seg| fold_row(seg, span, depth))
-                            .collect::<Result<Vec<_>, _>>()?;
-                        rows.push(MathExpr::Sequence(cols));
-                    } else {
-                        rows.push(fold_row(row, span, depth)?);
+                    MathExpr::Sequence(items)
+                } else {
+                    // Semicolon present: split into rows first, then columns within each row.
+                    let mut rows: Vec<MathExpr> = Vec::new();
+                    for row in split_fence_children(kids, ";") {
+                        if row.iter().any(|c| matches!(c, Child::Op(s) if s == ",")) {
+                            let cols = split_fence_children(row, ",")
+                                .into_iter()
+                                .map(|seg| fold_row(seg, span, depth))
+                                .collect::<Result<Vec<_>, _>>()?;
+                            rows.push(MathExpr::Sequence(cols));
+                        } else {
+                            rows.push(fold_row(row, span, depth)?);
+                        }
                     }
-                }
-                Ok(Child::Expr(MathExpr::Sequence(rows)))
+                    MathExpr::Sequence(rows)
+                };
+                Ok(Child::Expr(MathExpr::Fenced {
+                    open,
+                    body: Box::new(body),
+                    close,
+                }))
             }
             // `<mtable>` of `<mtr>` rows of `<mtd>` cells → MathExpr::Matrix (delimiter style is
             // not part of MathML's mtable, so nothing to drop). Parsed structurally below.


### PR DESCRIPTION
## Summary

Completes the **fence-delimiters slice** for the `mathml` frontend, mirroring what `latex` 0.25.0 (#7216) did for its list fences. `0.6.0` (#7207) adopted the neutral `MathExpr::Fenced` node for a **single-body** `<mfenced>`, but a comma/semicolon **list** `<mfenced>` still lowered to a bare `Sequence` — silently dropping *which* delimiters bracketed the list, so `(a, b)` and `[a, b]` were indistinguishable.

This wraps **every** `<mfenced>` shape in `Fenced`:

| MathML | neutral AST |
|---|---|
| `(a, b, c)` | `Fenced("(", Sequence([a,b,c]), ")")` |
| `(a, b; c, d)` | `Fenced("(", Sequence([Seq[a,b], Seq[c,d]]), ")")` |
| `[a, b]` | `Fenced("[", Sequence([a,b]), "]")` |

The wrapping `Fenced` reads the same `open`/`close` off the start-tag byte span (default `(`/`)`), so bracket/brace/angle list flavours are now distinct while the row/column structure is preserved as the `Fenced` body.

## Why this is safe downstream

The `adj-lang` adapter **unwraps** `Fenced`, so a `Fenced`-of-`Sequence` lowers *exactly* as the bare `Sequence` did — only the delimiters, previously dropped, are now carried. No downstream behaviour changes.

## Implementation

The `mfenced` arm now reads `open`/`close` **once**, computes the `body` (single fold / comma `Sequence` / semicolon rows) in an if/else-let, then constructs one `Fenced`. No new node, no capability change, still iterative (no added recursion; `MathExpr` Drop stays iterative).

## Verification

- Added a `fenced_body` test helper (match by-ref + clone — `MathExpr` has `Drop`); updated 6 list/row tests to unwrap the wrapping `Fenced`, plus 1 new test for custom `[ ]` list delimiters; renamed `mfenced_comma_separated_becomes_sequence` → `…_fenced_sequence`.
- Full consumer suite green: `mathml` + `math-frontend` + `latex` + `asciimath` + `unicode-math` + `adj-lang` + `adj-lang-cli` (22 suites, 0 failures).
- Security review: PASSED (bounded recursion `MAX_DEPTH=64`, bounds-safe `tag_attr`, iterative Drop, no `unsafe`, additive change).
- `mathml` 0.6.0 → 0.7.0; CHANGELOG + README updated.

This completes the list-fence delimiter slice for **both** `latex` and `mathml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)