### PR TITLE
test(constant-fold): activate gap-141 upstream placeholder (#88, CLOC12.141)

### DIFF
--- a/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to the `coding-adventures-closure-pass-constant-fold` crate will be documented in this file.
 
+## [0.80.0] - 2026-07-01
+
+### Test — activate the gap-141 upstream placeholder (#88, CLOC12.141)
+
+`folds_math_unary_methods` in
+`tests/upstream/peephole_replace_known_methods_test.rs` was an
+`#[ignore = "blocked on gap-141"]` placeholder pinning upstream's
+`Math.abs`/`floor`/`ceil`/`round` folds. gap-141 shipped in 0.79.0 (#7217), so
+the placeholder is now an **active** conformance test — and it gained `ceil`
+(`Math.ceil(4.2)` → `5`) and `round` (`Math.round(2.5)` → `3`, half toward
+`+Infinity`) assertions alongside the original `abs`/`floor` cases. The port's
+module header and `CLOC12-gaps.md` §CLOC12.141 are updated to mark gap-141
+RESOLVED; gaps 142 (`Array#join`) and 143 (`String#concat` coercion) remain the
+two `#[ignore]` placeholders.
+
+No library code changed — this release is test coverage plus docs.
+
 ## [0.79.0] - 2026-07-01
 
 ### Added — fold the unary numeric `Math` methods (closes gap-141)

--- a/code/packages/rust/closure-pass-constant-fold/Cargo.toml
+++ b/code/packages/rust/closure-pass-constant-fold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-constant-fold"
-version = "0.79.0"
+version = "0.80.0"
 edition = "2021"
 description = "Constant-folding optimization pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Folds compile-time-evaluable expressions like `2 + 3 → 5`."
 

--- a/code/packages/rust/closure-pass-constant-fold/tests/upstream/peephole_replace_known_methods_test.rs
+++ b/code/packages/rust/closure-pass-constant-fold/tests/upstream/peephole_replace_known_methods_test.rs
@@ -7,9 +7,10 @@
 //! Upstream `PeepholeReplaceKnownMethods` folds calls to well-known,
 //! side-effect-free String / Array / Math methods on constant receivers
 //! (`"abcdef".indexOf("cd")` → `2`). Our `ConstantFoldPass` implements a large
-//! slice of the String methods and the numeric `Math.max`/`Math.min`; this port
-//! pins those and records the upstream behaviors we do not fold yet as
-//! `#[ignore = "blocked on gap-NNN"]` placeholders.
+//! slice of the String methods and the numeric `Math` methods (`max`/`min` and
+//! the unary `abs`/`floor`/`ceil`/`round`); this port pins those and records the
+//! upstream behaviors we do not fold yet as `#[ignore = "blocked on gap-NNN"]`
+//! placeholders.
 //!
 //! Built on the same AST-builder surface as the sibling
 //! `peephole_fold_constants_test.rs` port (closurec has no public
@@ -208,13 +209,20 @@ fn does_not_fold_on_non_constant_receiver() {
 // Each is pinned to a gap in code/specs/CLOC12-gaps.md.
 // ===================================================================
 
-/// Upstream folds `Math.abs`/`floor`/`ceil`/`round` on numeric literals. Our
-/// pass folds only `Math.max`/`Math.min` today.
+/// Upstream folds `Math.abs`/`floor`/`ceil`/`round` on a single numeric
+/// literal. gap-141 RESOLVED (CLOC12.141) — our pass now folds all four
+/// alongside the pre-existing `Math.max`/`Math.min`. Previously an
+/// `#[ignore]` placeholder; now an active conformance test.
+///
+/// `Math.round` follows ECMAScript §21.3.2.28 (round-half-toward-`+Infinity`),
+/// so `Math.round(2.5)` is `3`. The negative-zero declines (`Math.ceil(-0.4)`
+/// etc.) are exercised in the pass's own unit tests, not here.
 #[test]
-#[ignore = "blocked on gap-141: constant-fold does not fold Math.abs/floor/ceil/round"]
 fn folds_math_unary_methods() {
     assert_num(call(ident("Math"), "abs", vec![n(-5.0)]), 5.0);
     assert_num(call(ident("Math"), "floor", vec![n(4.7)]), 4.0);
+    assert_num(call(ident("Math"), "ceil", vec![n(4.2)]), 5.0);
+    assert_num(call(ident("Math"), "round", vec![n(2.5)]), 3.0);
 }
 
 /// Upstream folds `[a,b,c].join(sep)` on an array literal of constants. Our

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -1161,11 +1161,14 @@ historical context with status `RESOLVED` and a link to the fix PR.
   non-constant receiver. All 10 active cases pass on the first run.
 - **No new closurec bug surfaced** — every fold matched the pass exactly.
 - **New gaps** (executable `#[ignore = "blocked on gap-NNN"]` placeholders):
-  - **gap-141** — fold `Math.abs`/`floor`/`ceil`/`round` on numeric literals.
-    Our pass folds only `Math.max`/`Math.min` today.
-  - **gap-142** — fold `Array.prototype.join` on an array literal of constants
-    (`[a,b,c].join("-")` → `"a-b-c"`). Our pass folds String methods but not
-    Array#join.
+  - **gap-141** — ~~fold `Math.abs`/`floor`/`ceil`/`round` on numeric
+    literals~~ **RESOLVED** (constant-fold 0.79.0, PR #7217; folds all four
+    with round-half-toward-`+Infinity` and negative-zero declines). The
+    `folds_math_unary_methods` placeholder is now an **active** conformance
+    test (also covers `ceil`/`round`) as of constant-fold 0.80.0.
+  - **gap-142** *(still open)* — fold `Array.prototype.join` on an array literal
+    of constants (`[a,b,c].join("-")` → `"a-b-c"`). Our pass folds String
+    methods but not Array#join.
   - **gap-143** — fold `String#concat` with **non-string (coerced) args**
     (`"x".concat(1, 2)` → `"x12"`). Our concat fold handles string args only.
 


### PR DESCRIPTION
## Summary

gap-141 (fold `Math.abs`/`floor`/`ceil`/`round` on numeric literals) shipped in constant-fold 0.79.0 ([#7217](https://github.com/adhithyan15/coding-adventures/pull/7217)). Its `folds_math_unary_methods` conformance test in `tests/upstream/peephole_replace_known_methods_test.rs` was still an `#[ignore = "blocked on gap-141"]` placeholder — this flips it to **active** and extends it to cover all four folds:

- `Math.abs(-5)` → `5`, `Math.floor(4.7)` → `4` (original assertions)
- `Math.ceil(4.2)` → `5`, `Math.round(2.5)` → `3` (round-half-toward-`+Infinity`, per ECMAScript §21.3.2.28)

## Docs

- Port module header updated to list the unary `Math` folds alongside `max`/`min`.
- `code/specs/CLOC12-gaps.md` §CLOC12.141 marks **gap-141 RESOLVED**; gaps 142 (`Array#join`) and 143 (`String#concat` coercion) remain the two `#[ignore]` placeholders.

## Scope / safety

- **Test-only** — no library/`src` code changed. Bumps constant-fold 0.79.0 → 0.80.0.
- Full suite green: 333 lib + 14 + 11 active upstream-port tests (2 still ignored on gaps 142/143).
- Inline security review: PASSED (no user input, no `unsafe`, no I/O; assertions over hard-coded numeric-literal AST).

🤖 Generated with [Claude Code](https://claude.com/claude-code)