### PR TITLE
feat(unicode-math): accents from Unicode combining diacritics (0.5.0)

### DIFF
--- a/code/packages/rust/unicode-math/CHANGELOG.md
+++ b/code/packages/rust/unicode-math/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to the unicode-math pluggable frontend.
 
+## [0.5.0] — 2026-07-01
+
+### Added — accents (Unicode combining diacritics)
+
+The frontend now reads a **combining diacritic** over the preceding glyph and lowers it to the
+neutral **`MathExpr::Accent`** — the same node LaTeX `\hat{x}` and MathML `<mover>` produce, with
+matching accent names, so a consumer that already lowers `Accent` gets Unicode accents for free.
+
+- `x̂` (U+0302) → `Accent("hat", x)`, `v⃗` (U+20D7) → `Accent("vec", v)`, `x̄` (U+0304) → `bar`,
+  `x̃` (U+0303) → `tilde`, `ẋ` (U+0307) → `dot`, `ẍ` (U+0308) → `ddot`. Names match the LaTeX
+  accent commands and the AsciiMath frontend, keeping one neutral spelling across notations.
+- The tokenizer emits a standalone `TokenKind::Accent(name)`; the parser attaches it **postfix** to
+  the atom just parsed, binding tighter than sub/superscripts and operators — `x̂²` ⇒ `(x̂)²`,
+  `x̂ + y` ⇒ `Accent(hat, x) + y`. Stacked marks are supported via a loop (no recursion).
+- A combining mark with no preceding base is a clean spanned error, never a panic (totality holds).
+- `Capabilities::accents` is now declared (`with_accents()`), bringing unicode-math to accent parity
+  with latex/mathml/asciimath; the shared `check_frontend` harness enforces the honesty.
+
 ## [0.4.0] — 2026-06-30
 
 ### Added — PR-4: matrices (full parity with AsciiMath)

--- a/code/packages/rust/unicode-math/Cargo.toml
+++ b/code/packages/rust/unicode-math/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unicode-math"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "A Unicode plain-math parser that implements the math-frontend MathFrontend trait: turns the math people and models actually type (x² + y² = r², √x, ½, π·α, a ≤ b) into the neutral MathExpr AST. The third pluggable frontend after LaTeX and AsciiMath (see PFE01). Total, panic-free, spanned errors."
 license = "MIT"

--- a/code/packages/rust/unicode-math/README.md
+++ b/code/packages/rust/unicode-math/README.md
@@ -57,7 +57,9 @@ dependency cycle); a consumer registers it.
 PR-1 covered numbers/symbols/scripts/fractions/roots/relations/±∓; **PR-2** adds the big operators
 `∑ ∏ ∫ ∮ ∐` (with optional bounds) and the explicit ASCII script operators `^`/`_`; **PR-3** adds
 **named functions** (`sin cos tan … ln log exp`, longest-match so `sinx` ⇒ `sin·x`); **PR-4** adds **matrices**
-`[[a,b],[c,d]]` — reaching **full parity with the AsciiMath frontend**. The only remaining
-AsciiMath construct, embedded `\text`, has no Unicode plain-math equivalent and is out of scope (a
-clean spanned error, never a panic). As in AsciiMath there are no multi-letter variables: a
-non-function letter run like `xy` is the product `x·y` (write distinct symbols, or use glyphs).
+`[[a,b],[c,d]]`; and **accents** — Unicode combining diacritics over the preceding glyph, `x̂` (hat),
+`v⃗` (vec), `x̄` (bar), `x̃` (tilde), `ẋ` (dot), `ẍ` (ddot) — lowering to the same `MathExpr::Accent`
+as LaTeX `\hat{x}` and MathML `<mover>`. The accent binds tighter than scripts, so `x̂²` is `(x̂)²`.
+The only remaining AsciiMath construct, embedded `\text`, has no Unicode plain-math equivalent and is
+out of scope (a clean spanned error, never a panic). As in AsciiMath there are no multi-letter
+variables: a non-function letter run like `xy` is the product `x·y` (write distinct symbols, or use glyphs).

--- a/code/packages/rust/unicode-math/src/lib.rs
+++ b/code/packages/rust/unicode-math/src/lib.rs
@@ -22,9 +22,11 @@
 //! the **big operators** `∑ ∏ ∫ ∮ ∐` with optional lower/upper bounds (PR-2, e.g. `∑_(i=1)^n i`);
 //! **named functions** `sin cos tan … ln log exp` applied to the next atom (PR-3, `sin x`, `log(x)`,
 //! `arcsin x` — longest-match, so `sinx` ⇒ `sin·x`); the relations `= ≠ < ≤ > ≥ ≈ ≡`; and
-//! **matrices** `[[a,b],[c,d]]` (PR-4, rows in `[…]` or `(…)`). The only remaining gap vs the
-//! AsciiMath frontend is embedded `\text` (no Unicode equivalent) — an out-of-scope input is a
-//! clean spanned error, never a panic.
+//! **matrices** `[[a,b],[c,d]]` (PR-4, rows in `[…]` or `(…)`); and **accents** written as Unicode
+//! combining diacritics over the preceding glyph — `x̂` (hat), `v⃗` (vec), `x̄` (bar), `x̃` (tilde),
+//! `ẋ` (dot), `ẍ` (ddot) — lowering to the same [`MathExpr::Accent`] as LaTeX `\hat{x}` and MathML
+//! `<mover>`. The only remaining gap vs the AsciiMath frontend is embedded `\text` (no Unicode
+//! equivalent) — an out-of-scope input is a clean spanned error, never a panic.
 //!
 //! ```
 //! use unicode_math::UnicodeMath;
@@ -66,8 +68,9 @@ impl MathFrontend for UnicodeMath {
     fn capabilities(&self) -> Capabilities {
         // `fractions` covers both `a/b` and the vulgar-fraction glyphs; `powers` covers Unicode
         // superscripts and the ASCII `^` operator; `plusminus` covers `±`/`∓`; `big_operators`
-        // covers `∑ ∏ ∫ ∮ ∐` (PR-2). `functions`, `matrices`, and `text` are PR-3 — declared OFF
-        // so the conformance harness holds us honest. (Subscripts need no flag: `Subscript` is
+        // covers `∑ ∏ ∫ ∮ ∐` (PR-2). `functions`, `matrices` are PR-3. `accents` covers the Unicode
+        // combining diacritics (`x̂`/`v⃗`/`x̄`/`x̃`/`ẋ`/`ẍ` → `MathExpr::Accent`), bringing this
+        // frontend to parity with latex/mathml/asciimath. (Subscripts need no flag: `Subscript` is
         // not a gated capability.)
         Capabilities::none()
             .with_fractions()
@@ -79,6 +82,7 @@ impl MathFrontend for UnicodeMath {
             .with_big_operators()
             .with_functions()
             .with_matrices()
+            .with_accents()
     }
 }
 
@@ -153,6 +157,39 @@ mod tests {
             p("∛x"),
             MathExpr::Root { degree: Some(Box::new(num(3))), radicand: Box::new(sym("x")) }
         );
+    }
+
+    // ---- accents (combining diacritics) ----------------------------------------
+    fn accent(name: &str, body: MathExpr) -> MathExpr {
+        MathExpr::Accent { accent: name.to_string(), body: Box::new(body) }
+    }
+
+    #[test]
+    fn combining_diacritics_are_accents() {
+        // Each combining mark sits over the preceding glyph and lowers to the SAME neutral
+        // `MathExpr::Accent` that LaTeX `\hat{x}` / MathML `<mover>` produce (matching accent names).
+        assert_eq!(p("x\u{0302}"), accent("hat", sym("x")));    // x̂
+        assert_eq!(p("v\u{20D7}"), accent("vec", sym("v")));    // v⃗
+        assert_eq!(p("x\u{0304}"), accent("bar", sym("x")));    // x̄
+        assert_eq!(p("x\u{0303}"), accent("tilde", sym("x")));  // x̃
+        assert_eq!(p("x\u{0307}"), accent("dot", sym("x")));    // ẋ
+        assert_eq!(p("x\u{0308}"), accent("ddot", sym("x")));   // ẍ
+    }
+
+    #[test]
+    fn accent_binds_tighter_than_scripts_and_operators() {
+        // `x̂²` is (x̂)² — the accent attaches to the base before the power.
+        assert_eq!(p("x\u{0302}\u{00B2}"), b(BinOp::Pow, accent("hat", sym("x")), num(2)));
+        // In a sum, only the marked glyph is decorated: `x̂ + y` = Accent(hat,x) + y.
+        assert_eq!(p("x\u{0302} + y"), b(BinOp::Add, accent("hat", sym("x")), sym("y")));
+        // A hatted x times y: `x̂y` ⇒ (x̂)·y.
+        assert_eq!(p("x\u{0302}y"), b(BinOp::Mul, accent("hat", sym("x")), sym("y")));
+    }
+
+    #[test]
+    fn leading_combining_mark_is_a_clean_error() {
+        // A combining mark with no base atom is a spanned error, never a panic (totality).
+        assert!(UnicodeMath.parse("\u{0302}").is_err());
     }
 
     // ---- operators / precedence / relations ------------------------------------
@@ -308,8 +345,9 @@ mod tests {
         assert!(c.big_operators); // PR-2: ∑ ∏ ∫ ∮ ∐
         assert!(c.functions);     // PR-3: sin/cos/log/… → Call
         assert!(c.matrices);      // PR-4: [[a,b],[c,d]]
-        // `text` is the last remaining gap (no Unicode equivalent); the rest are not AsciiMath's.
-        assert!(!c.text && !c.binomials && !c.accents && !c.oversets);
+        assert!(c.accents);       // combining diacritics x̂/v⃗/x̄/x̃/ẋ/ẍ → Accent
+        // `text` is the last remaining gap (no Unicode equivalent); the rest are not emitted.
+        assert!(!c.text && !c.binomials && !c.oversets);
     }
 
     #[test]
@@ -339,6 +377,8 @@ mod tests {
                 "log(x) + 1",   // function with a grouped argument
                 "arcsin x",     // longest-match function name
                 "[[a,b],[c,d]]", // matrix (PR-4)
+                "x̂",            // combining hat → Accent("hat", x)
+                "v⃗ + x̄",       // vec and bar accents in an expression
                 "[[a,b],[c]]",   // error: ragged matrix rows
                 "1 +",   // error: trailing operator
                 "(x",    // error: missing close

--- a/code/packages/rust/unicode-math/src/parser.rs
+++ b/code/packages/rust/unicode-math/src/parser.rs
@@ -166,6 +166,13 @@ impl Parser<'_> {
 
     fn parse_script(&mut self) -> Result<MathExpr, FrontendError> {
         let mut base = self.parse_atom()?;
+        // A combining diacritic follows its base glyph (`x` + U+0302 renders `x̂`), so it attaches
+        // POSTFIX to the atom just parsed — `x̂` ⇒ Accent("hat", x). A loop allows stacked marks
+        // (`x̂̄`), and binding TIGHTER than scripts gives the natural reading `x̂²` ⇒ (x̂)².
+        while let TokenKind::Accent(name) = self.peek().clone() {
+            self.advance();
+            base = MathExpr::Accent { accent: name, body: Box::new(base) };
+        }
         // Subscript then superscript (`a₁²` ⇒ (a₁)²), each at most once — the natural reading.
         // Either form is accepted: a Unicode glyph run (a numeral, e.g. `₁`/`²`) or the explicit
         // ASCII operator (`_`/`^`) whose operand is the next single atom (`a_i`, `x^2` ≡ `x²`).

--- a/code/packages/rust/unicode-math/src/token.rs
+++ b/code/packages/rust/unicode-math/src/token.rs
@@ -41,6 +41,11 @@ pub enum TokenKind {
     Super(String),
     /// A subscript run normalised to a plain numeral (`"1"`) — becomes a subscript.
     Sub(String),
+    /// A combining diacritic that sits OVER the preceding atom — `x̂` (hat), `v⃗` (vec), `x̄` (bar),
+    /// `x̃` (tilde), `ẋ` (dot), `ẍ` (ddot). Carries the canonical accent name (`"hat"`, `"vec"`, …)
+    /// matching the LaTeX/MathML frontends, so `x̂` and `\hat{x}` lower to the same
+    /// [`math_frontend::MathExpr::Accent`]. Postfix: the parser attaches it to the atom just parsed.
+    Accent(String),
     /// A vulgar-fraction glyph already split into `(numerator, denominator)` numerals.
     VulgarFrac(String, String),
     Plus,
@@ -140,6 +145,23 @@ fn subscript_char(c: char) -> Option<char> {
         '₀' => '0', '₁' => '1', '₂' => '2', '₃' => '3', '₄' => '4',
         '₅' => '5', '₆' => '6', '₇' => '7', '₈' => '8', '₉' => '9',
         '₊' => '+', '₋' => '-',
+        _ => return None,
+    })
+}
+
+/// Map a Unicode **combining diacritic** to its canonical accent name, or `None`. A combining mark
+/// follows the base character it decorates (`x` + U+0302 renders as `x̂`), so the scanner emits it as
+/// a standalone `Accent` token the parser attaches to the preceding atom. The names match the LaTeX
+/// accent commands (`\hat`, `\vec`, …) and MathML `<mover>` accents, so every notation lowers to the
+/// same neutral [`math_frontend::MathExpr::Accent`] — write once, read everywhere.
+fn accent_name(c: char) -> Option<&'static str> {
+    Some(match c {
+        '\u{0302}' => "hat",    // ◌̂  combining circumflex accent → \hat
+        '\u{0303}' => "tilde",  // ◌̃  combining tilde            → \tilde
+        '\u{0304}' => "bar",    // ◌̄  combining macron           → \bar
+        '\u{0307}' => "dot",    // ◌̇  combining dot above        → \dot
+        '\u{0308}' => "ddot",   // ◌̈  combining diaeresis        → \ddot
+        '\u{20D7}' => "vec",    // ◌⃗  combining right arrow above → \vec
         _ => return None,
     })
 }
@@ -275,6 +297,12 @@ pub fn tokenize(src: &str) -> Result<Vec<Token>, FrontendError> {
         }
         if let Some(name) = constant_glyph(c) {
             toks.push(Token { kind: TokenKind::Sym(name.into()), span: one });
+            i += 1;
+            continue;
+        }
+        // ── combining diacritic → an accent over the preceding atom ──────────────────────────────
+        if let Some(name) = accent_name(c) {
+            toks.push(Token { kind: TokenKind::Accent(name.into()), span: one });
             i += 1;
             continue;
         }


### PR DESCRIPTION
## Summary

The `unicode-math` frontend now reads a **combining diacritic** over the preceding glyph and lowers it to the neutral **`MathExpr::Accent`** — the same node LaTeX `\hat{x}` and MathML `<mover>` produce, with matching accent names. A consumer that already lowers `Accent` (e.g. `adj-lang`) gets Unicode accents **for free** — zero consumer change. This brings unicode-math to **accent parity** with latex/mathml/asciimath (the last of the four frontends to gain it).

| glyph | codepoint | → `MathExpr::Accent` |
|---|---|---|
| `x̂` | U+0302 | `hat` |
| `x̃` | U+0303 | `tilde` |
| `x̄` | U+0304 | `bar` |
| `ẋ` | U+0307 | `dot` |
| `ẍ` | U+0308 | `ddot` |
| `v⃗` | U+20D7 | `vec` |

## Implementation

- **Tokenizer**: a new `accent_name(char) → Option<&'static str>` map + a scan branch emitting a standalone `TokenKind::Accent(name)` (alongside the existing single-codepoint recognizers; same bounds-checked span).
- **Parser**: `parse_script` attaches the accent **postfix** to the atom just parsed, in a loop (stacked marks OK), binding **tighter than scripts/operators** — `x̂²` ⇒ `(x̂)²`, `x̂ + y` ⇒ `Accent(hat, x) + y`, `x̂y` ⇒ `(x̂)·y`.
- A combining mark with no preceding base is a **clean spanned error, never a panic** (totality holds).
- `Capabilities::accents` declared (`with_accents()`); the shared `check_frontend` harness enforces honesty.

## Verification

- unicode-math: 32 unit + 1 doctest green; new tests cover all six marks, precedence, and the leading-mark error.
- Full consumer suite green: `unicode-math` + `math-frontend` + `latex` + `mathml` + `asciimath` + `adj-lang` + `adj-lang-cli` (22 suites, 0 failures).
- Security review: PASSED (`forbid(unsafe_code)`, bounded iterative loop, guarded recursion, iterative `Drop` with a 300k-deep regression test — no new panic/OOB/DoS surface).
- `unicode-math` 0.4.0 → 0.5.0; CHANGELOG + README updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)