### PR TITLE
test(closure-emitter): port CodePrinter string-escape cases (#88, CLOC12.143)

### DIFF
--- a/code/packages/rust/closure-emitter/CHANGELOG.md
+++ b/code/packages/rust/closure-emitter/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to the `coding-adventures-closure-emitter` crate will be documented in this file.
 
+## [0.18.14] - 2026-07-01
+
+### Test — CodePrinter string-escape port (#88, CLOC12.143)
+
+New upstream port `tests/upstream/code_printer_string_escape_test.rs` (registered
+as the `upstream_code_printer_string_escape` test target), extending the
+CodePrinter coverage beyond the quote-choice case already active in
+`code_printer_test.rs` (gap-026). It pins the **escape sequences** `emit_string`
+emits, in both the default double-quote path and the single-quote path that
+quote-choice selects:
+
+- **7 active `#[test]`s** (all pass on the first run — no new emitter bug):
+  backslash doubling (`a\b` → `"a\\b"`), the `\n`/`\r`/`\t` short escapes, an
+  "other" control char as upper-case `\uXXXX` (`U+0007` → ``), the
+  U+2028/U+2029 line-terminator escapes, printable non-ASCII left verbatim
+  (`café` stays `café` in the default non-`ascii_only` mode), and two
+  single-quote-path cases (backslash still doubles; the active `'` is escaped
+  while `"` stays bare).
+
+No library code changed — this release is test coverage plus docs.
+
 ## [0.18.13] - 2026-07-01
 
 ### Test — CodePrinter number-formatting port (#88, CLOC12.142)

--- a/code/packages/rust/closure-emitter/Cargo.toml
+++ b/code/packages/rust/closure-emitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-emitter"
-version = "0.18.13"
+version = "0.18.14"
 edition = "2021"
 description = "JavaScript code emitter for the Closure Compiler clone. Per CLOC07's emit contract. Takes a finalized Program + sidecar and produces output JavaScript text + companion source map. Runs after every pass in the pipeline."
 
@@ -32,6 +32,10 @@ path = "tests/upstream/code_printer_declarations_test.rs"
 [[test]]
 name = "upstream_code_printer_trailing_comma"
 path = "tests/upstream/code_printer_trailing_comma_test.rs"
+
+[[test]]
+name = "upstream_code_printer_string_escape"
+path = "tests/upstream/code_printer_string_escape_test.rs"
 
 [[test]]
 name = "upstream_code_printer_numbers"

--- a/code/packages/rust/closure-emitter/tests/upstream/code_printer_string_escape_test.rs
+++ b/code/packages/rust/closure-emitter/tests/upstream/code_printer_string_escape_test.rs
@@ -1,0 +1,149 @@
+//! Ported from `CodePrinterTest.java` in `google/closure-compiler`,
+//! Apache-2.0. Upstream SHA: see `tests/upstream/UPSTREAM_SHA`.
+//!
+//! Translation policy: see
+//! `code/specs/CLOC12-upstream-test-suite-port.md`.
+//!
+//! # What this file covers
+//!
+//! `CodePrinterTest.java`'s string-escaping family (`testEscape`,
+//! `testUnicode`, the `\n`/`\t`/`\\` cases threaded through
+//! `assertPrint`). The sibling `code_printer_test.rs` already actives
+//! the *quote-choice* case (`she said "hi"` → single quotes to avoid
+//! escaping the inner `"`, gap-026). This file pins the **escape
+//! sequences themselves** for both the default double-quote path and
+//! the single-quote path that quote-choice selects.
+//!
+//! ## How the emitter escapes (recap of `choose_quote_and_escape`)
+//!
+//! The emitter counts `"` vs `'` in the value and wraps in whichever
+//! needs fewer escapes (tie → double). Inside the chosen quotes it
+//! escapes, in both paths:
+//!
+//! ```text
+//!   \  → \\        \n → \n        \r → \r        \t → \t
+//!   U+2028 →              U+2029 →
+//!   any other control (< U+0020) → \uXXXX   (upper-case, 4 hex digits)
+//! ```
+//!
+//! plus the *active* quote character (`"` in the double path, `'` in
+//! the single path). Everything else — including printable non-ASCII —
+//! is emitted verbatim (this is the default, non-`ascii_only`, mode).
+
+use coding_adventures_closure_emitter::{emit, EmitOptions};
+use coding_adventures_correlation_vector::CVLog;
+use coding_adventures_javascript_ast::{
+    Expression, ExpressionStatement, Program, ProgramItem, SourceType, Statement, StringLiteral,
+};
+use coding_adventures_javascript_tokens::EsVersion;
+use coding_adventures_type_sidecar::Sidecar;
+
+// =====================================================================
+// Test-support helpers (mirrors `code_printer_test.rs`)
+// =====================================================================
+
+fn string(v: &str) -> Expression {
+    Expression::StringLiteral(StringLiteral {
+        cv: None,
+        value: v.to_string(),
+        // `raw` is ignored by the emitter for string literals — it re-derives
+        // the shortest correctly-escaped spelling from `value` — but we fill it
+        // for shape parity with the other ports' `string()` helper.
+        raw: format!("\"{}\"", v),
+    })
+}
+
+fn stmt(expr: Expression) -> ProgramItem {
+    ProgramItem::Statement(Statement::expression_statement(ExpressionStatement {
+        cv: None,
+        expression: expr,
+    }))
+}
+
+fn program_with(item: ProgramItem) -> Program {
+    Program::new_untraced(EsVersion::Es2025, SourceType::Module).with_body(vec![item])
+}
+
+fn emit_default(prog: Program) -> String {
+    let sidecar = Sidecar::new();
+    let mut cv = CVLog::new(false);
+    emit(&prog, &sidecar, &mut cv, &EmitOptions::default())
+        .expect("emit failed")
+        .code
+}
+
+/// Upstream `assertPrint(input, expected)` reshaped for our AST surface:
+/// emit `expr` as the single statement of a program and assert the
+/// resulting code equals `expected_emitted`.
+fn assert_emits(expr: Expression, expected_emitted: &str) {
+    let code = emit_default(program_with(stmt(expr)));
+    assert_eq!(
+        code, expected_emitted,
+        "emit output did not match expected\n  actual:   {:?}\n  expected: {:?}",
+        code, expected_emitted
+    );
+}
+
+// =====================================================================
+// Active — double-quote path escapes (default; tie → double quotes)
+// =====================================================================
+
+/// A literal backslash doubles: `a\b` → `"a\\b"`.
+#[test]
+fn escapes_backslash() {
+    assert_emits(string("a\\b"), "\"a\\\\b\";");
+}
+
+/// Newline / carriage-return / tab collapse to their short escapes.
+#[test]
+fn escapes_newline_return_tab() {
+    assert_emits(string("a\nb"), "\"a\\nb\";");
+    assert_emits(string("a\rb"), "\"a\\rb\";");
+    assert_emits(string("a\tb"), "\"a\\tb\";");
+}
+
+/// An "other" control character (below U+0020, not one of the named
+/// escapes) becomes a 4-hex-digit `\uXXXX` with upper-case hex — here
+/// U+0007 BELL → ``.
+#[test]
+fn escapes_other_control_char_as_u_hex() {
+    assert_emits(string("a\u{07}b"), "\"a\\u0007b\";");
+}
+
+/// The ECMAScript line terminators U+2028 / U+2029 are escaped even
+/// though they sit above U+0020 — an unescaped one is a pre-ES2019
+/// `SyntaxError` inside a string literal.
+#[test]
+fn escapes_line_and_paragraph_separators() {
+    assert_emits(string("a\u{2028}b"), "\"a\\u2028b\";");
+    assert_emits(string("a\u{2029}b"), "\"a\\u2029b\";");
+}
+
+/// A printable non-ASCII codepoint is emitted VERBATIM in the default
+/// (non-`ascii_only`) mode — `café` stays `café`, not `café`.
+#[test]
+fn printable_non_ascii_stays_verbatim() {
+    assert_emits(string("caf\u{e9}"), "\"caf\u{e9}\";");
+}
+
+// =====================================================================
+// Active — single-quote path (quote-choice) escapes
+// =====================================================================
+
+/// When the value has more `"` than `'`, the emitter switches to
+/// single quotes (fewer escapes). The backslash rule is unchanged
+/// across quote styles, so `""\` (two double quotes, one backslash)
+/// prints single-quoted with the `"` left bare and the `\` doubled:
+/// `'""\\'`.
+#[test]
+fn single_quote_path_still_escapes_backslash() {
+    assert_emits(string("\"\"\\"), "'\"\"\\\\';");
+}
+
+/// In the single-quote path the active quote `'` is the one that gets
+/// escaped, while `"` is left bare. A value with two `"` and one `'`
+/// picks single quotes and escapes only the `'`: `'"\'"'`.
+#[test]
+fn single_quote_path_escapes_the_single_quote() {
+    assert_emits(string("\"'\""), "'\"\\'\"';");
+}

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -1191,3 +1191,22 @@ historical context with status `RESOLVED` and a link to the fix PR.
   still keeps the `0` — distinct from the source-preserving byte-identity path
   that already elides it (gap-107 / gap-113). No new gap number is opened; the
   placeholders reference the existing **gap-133** from CLOC12.138.
+
+## CLOC12.143 — CodePrinter string-escape port (emitter)
+
+- **What it is:** the tenth CLOC12 upstream port and the third into
+  `closure-emitter` (alongside the CodePrinter core / declarations /
+  trailing-comma / numbers ports). New file
+  `tests/upstream/code_printer_string_escape_test.rs`, registered as the
+  `upstream_code_printer_string_escape` test target. It reshapes upstream
+  `CodePrinterTest.java`'s string-escaping assertions onto our AST surface (a
+  `StringLiteral` emitted as a single expression-statement) and pins the escape
+  sequences `emit_string` / `choose_quote_and_escape` produce.
+- **7 active `#[test]`s pass on the first run** (no new emitter bug): backslash
+  doubling, the `\n`/`\r`/`\t` short escapes, an "other" control char as
+  upper-case `\uXXXX` (`U+0007` → ``), the U+2028/U+2029 line-terminator
+  escapes, printable non-ASCII left verbatim in the default (non-`ascii_only`)
+  mode, and two single-quote-path cases selected by quote-choice.
+- **No `#[ignore]` placeholders** — every case the emitter handles today is an
+  active conformance test. (The `ascii_only` `\uXXXX` escaping of printable
+  non-ASCII is a separate `EmitOptions` path and is left for a follow-up port.)


### PR DESCRIPTION
## Summary

Tenth CLOC12 upstream port (#88), third into `closure-emitter`. New file `tests/upstream/code_printer_string_escape_test.rs`, registered as the `upstream_code_printer_string_escape` `[[test]]` target. Extends CodePrinter coverage beyond the quote-choice case already active in `code_printer_test.rs` (gap-026), pinning the **escape sequences** `emit_string` / `choose_quote_and_escape` produce.

## What's covered (7 active tests — all pass on first run, no new bug)

Default double-quote path:
- backslash doubling (`a\b` → `"a\\b"`)
- `\n` / `\r` / `\t` short escapes
- "other" control char as upper-case `\uXXXX` (`U+0007` → ``)
- U+2028 / U+2029 line-terminator escapes (unescaped → pre-ES2019 SyntaxError)
- printable non-ASCII left verbatim in default (non-`ascii_only`) mode (`café` stays `café`)

Single-quote path (selected by quote-choice when `"` outnumber `'`):
- backslash still doubles
- the active `'` is escaped while `"` stays bare

## Scope / safety

- **Test-only** — no library/`src` code changed. Bumps `closure-emitter` 0.18.13 → 0.18.14; documents the port at CLOC12.143 in `code/specs/CLOC12-gaps.md`.
- Full `closure-emitter` suite green (96 lib + all upstream port targets).
- No `#[ignore]` placeholders — every case the emitter handles today is active. (The `ascii_only` `\uXXXX` escaping of printable non-ASCII is a separate `EmitOptions` path, left for a follow-up port.)
- Inline security review: PASSED (no user input, no `unsafe`, no I/O; assertions over hard-coded string-literal AST).

🤖 Generated with [Claude Code](https://claude.com/claude-code)