### PR TITLE
[codex] Pin select list parser repair evidence

### DIFF
--- a/code/packages/rust/html-parser/tests/whatwg_select_list_audit_test.rs
+++ b/code/packages/rust/html-parser/tests/whatwg_select_list_audit_test.rs
@@ -6,6 +6,14 @@ use std::collections::{BTreeMap, HashMap};
 
 const TREE_CONSTRUCTION_SMOKE: &str = include_str!("fixtures/html5lib-tree-construction-smoke.dat");
 const WHATWG_SELECT_LIST_AUDIT: &str = include_str!("fixtures/whatwg-select-list-audit.json");
+const POST_PARSE_REPAIR_EVIDENCE: &[(&str, &str)] = &[
+    ("tables01-dat-442", "select-in-table"),
+    ("template-dat-475", "option-implied-end"),
+    ("tests1-dat-600", "optgroup-boundary"),
+    ("tests1-dat-675", "stray-select-end-tags"),
+    ("tests-innerhtml-1-dat-75", "select-fragment-context"),
+    ("tests2-dat-40", "select-shell"),
+];
 
 #[derive(Debug, Deserialize)]
 struct SelectListAuditSuite {
@@ -67,6 +75,46 @@ fn whatwg_select_list_audit_cases_match_parser_dom_dump() {
             actual, source_case.document,
             "case `{}` ({}) failed for input {:?}",
             case.id, case.axis, source_case.data
+        );
+    }
+}
+
+#[test]
+fn whatwg_select_list_audit_tracks_post_parse_repair_evidence() {
+    let suite = load_suite();
+    let audit_cases = suite
+        .cases
+        .iter()
+        .map(|case| (case.id.as_str(), case))
+        .collect::<HashMap<_, _>>();
+    let smoke_cases = parse_tree_construction_cases(TREE_CONSTRUCTION_SMOKE)
+        .into_iter()
+        .map(|case| (case.source.clone(), case))
+        .collect::<HashMap<_, _>>();
+
+    for (case_id, expected_axis) in POST_PARSE_REPAIR_EVIDENCE {
+        let audit_case = audit_cases.get(case_id).unwrap_or_else(|| {
+            panic!("post-parse repair evidence case `{case_id}` should be audited")
+        });
+        assert_eq!(
+            audit_case.axis, *expected_axis,
+            "post-parse repair evidence case `{case_id}` should stay on its focused audit axis"
+        );
+
+        let source_case = smoke_cases
+            .get(&audit_case.source)
+            .unwrap_or_else(|| panic!("case `{case_id}` should exist in smoke fixture"));
+        let actual = actual_dom_dump_for_tree_case(source_case).unwrap_or_else(|error| {
+            panic!(
+                "case `{}` ({}) parse failed: {error}",
+                audit_case.id, audit_case.axis
+            )
+        });
+
+        assert_eq!(
+            actual, source_case.document,
+            "post-parse repair evidence case `{}` ({}) failed for input {:?}",
+            audit_case.id, audit_case.axis, source_case.data
         );
     }
 }


### PR DESCRIPTION
## Summary
- Add a select/list post-parse repair evidence gate over representative html5lib cases.
- Cover select-in-table, option implied-end, optgroup boundaries, stray select end-tags, select fragments, and ordinary select shell recovery.
- Keep the evidence executable by reusing the existing parser DOM dump comparison path.

## Validation
- cargo test -p coding-adventures-html-parser font_newline_before_bold_stays_outside_reconstructed_font
- cargo test -p coding-adventures-html-parser whatwg_document_shell_audit_tracks_post_parse_repair_evidence
- cargo test -p coding-adventures-html-parser whatwg_head_body_audit_tracks_post_parse_repair_evidence
- cargo test -p coding-adventures-html-parser whatwg_form_interactive_audit_tracks_post_parse_repair_evidence
- cargo test -p coding-adventures-html-parser whatwg_legacy_element_audit_tracks_post_parse_repair_evidence
- cargo test -p coding-adventures-html-parser whatwg_paragraph_audit_tracks_post_parse_repair_evidence
- cargo test -p coding-adventures-html-parser whatwg_block_boundary_audit_tracks_post_parse_repair_evidence
- cargo test -p coding-adventures-html-parser whatwg_table_audit_tracks_post_parse_repair_evidence
- cargo test -p coding-adventures-html-parser whatwg_formatting_audit_tracks_post_parse_repair_evidence
- cargo test -p coding-adventures-html-parser whatwg_text_control_audit_tracks_post_parse_repair_evidence
- cargo test -p coding-adventures-html-parser whatwg_ruby_audit_tracks_post_parse_repair_evidence
- cargo test -p coding-adventures-html-parser whatwg_list_item_audit_tracks_post_parse_repair_evidence
- cargo test -p coding-adventures-html-parser whatwg_template_audit_tracks_post_parse_repair_evidence
- cargo test -p coding-adventures-html-parser whatwg_select_list_audit_tracks_post_parse_repair_evidence
- cargo test -p coding-adventures-html-parser whatwg_document_shell_audit_cases_match_parser_dom_dump
- cargo test -p coding-adventures-html-parser whatwg_head_body_audit_cases_match_parser_dom_dump
- cargo test -p coding-adventures-html-parser whatwg_form_interactive_audit_cases_match_parser_dom_dump
- cargo test -p coding-adventures-html-parser whatwg_table_audit_cases_match_parser_dom_dump
- cargo test -p coding-adventures-html-parser whatwg_formatting_audit_cases_match_parser_dom_dump
- cargo test -p coding-adventures-html-parser whatwg_paragraph_audit_cases_match_parser_dom_dump
- cargo test -p coding-adventures-html-parser whatwg_text_control_audit_cases_match_parser_dom_dump
- cargo test -p coding-adventures-html-parser whatwg_block_boundary_audit_cases_match_parser_dom_dump
- cargo test -p coding-adventures-html-parser whatwg_select_list_audit_cases_match_parser_dom_dump
- cargo test -p coding-adventures-html-parser html5lib_tree_construction_smoke_cases_match_dom_dump
- cargo test -p coding-adventures-html-parser
- CARGO_BUILD_JOBS=2 cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser
- python3 -m json.tool code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json >/dev/null
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py
- git diff --check
