### PR TITLE
feat(asciimath): plus-or-minus (+- → ±, -+ → ∓) (0.12.0)

### DIFF
--- a/code/packages/rust/asciimath/CHANGELOG.md
+++ b/code/packages/rust/asciimath/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to the AsciiMath pluggable frontend.
 
+## [0.12.0] — 2026-07-01
+
+### Added — plus-or-minus (`+-` → ±, `-+` → ∓)
+
+The frontend now reads the AsciiMath plus-or-minus spellings and lowers them to the same neutral
+`BinOp::PlusMinus` / `BinOp::MinusPlus` the `latex` (`\pm`/`\mp`) and `unicode-math` (`±`/`∓`)
+frontends emit — so a consumer that already lowers those binops gets the AsciiMath spelling for free.
+
+- The tokenizer emits `TokenKind::PlusMinus` for a **contiguous** `+-` and `TokenKind::MinusPlus` for
+  `-+`; the parser handles them in the additive loop at the same precedence as `+`/`-`
+  (`a +- b + c` ⇒ `(a ± b) + c`).
+- A bare `+`/`-` is unchanged, and `a + -b` (add-then-unary-minus, with a space) still parses as
+  before — only the contiguous two-character sequences are the ± / ∓ operators.
+- `Capabilities::plusminus` is now declared (`with_plusminus()`); the shared `check_frontend` harness
+  enforces the honesty. Verified across the full frontend + adj-lang + adj-lang-cli consumer suite.
+
 ## [0.11.0] — 2026-06-30
 
 ### Added — semicolon-separated fences lower to rows (third Sequence frontend to get rows)

--- a/code/packages/rust/asciimath/Cargo.toml
+++ b/code/packages/rust/asciimath/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "asciimath"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 description = "An AsciiMath parser that implements the math-frontend MathFrontend trait: turns AsciiMath (1/2, sqrt(x), x^2+y^2=r^2) into the neutral MathExpr AST. The second pluggable frontend after LaTeX (see ASM01/PFE01). Total, panic-free, spanned errors."
 license = "MIT"

--- a/code/packages/rust/asciimath/README.md
+++ b/code/packages/rust/asciimath/README.md
@@ -33,6 +33,7 @@ second notation.
 | `xy` | `x · y` (implicit product of single letters, the AsciiMath rule) |
 | `sinx`, `pir` | `sin x` / `pi · r` (greedy longest-match splits glued keywords, the AsciiMath rule) |
 | `a + b`, `a - b`, `a*b`, `a xx b`, `a -: b` | `Bin(Add/Sub/Mul/Div)` |
+| `a +- b`, `a -+ b` | `Bin(PlusMinus/MinusPlus)` (± / ∓, same node as LaTeX `\pm`/`\mp`) |
 | `a b` (juxtaposition) | `Bin(Mul)` (implicit multiplication) |
 | `1/2` | `Frac` |
 | `x^2`, `a_i`, `a_i^2` | `Bin(Pow)` / `Subscript` / `Pow(Subscript)` |

--- a/code/packages/rust/asciimath/src/lib.rs
+++ b/code/packages/rust/asciimath/src/lib.rs
@@ -14,7 +14,7 @@
 //! the shared `check_frontend` harness).
 //!
 //! ## What it covers (PR-1)
-//! Numbers (exact), variables/constants, `+ - * / ^ _`, juxtaposition (implicit `·`),
+//! Numbers (exact), variables/constants, `+ - * / ^ _` (plus `+-`/`-+` → ±/∓), juxtaposition (implicit `·`),
 //! `a/b` fractions, `sqrt`/`root(n)(x)`, named functions, relations, grouping, and `"text"`.
 //! Matrices and big operators (`sum`/`prod`/`int`) are PR-2 (ASM01 §5).
 //!
@@ -63,9 +63,10 @@ impl MathFrontend for AsciiMath {
         // (`overset(a)(b)`/`stackrel(a)(b)`/`underset(a)(b)`, emitted as
         // `MathExpr::Overset`/`Underset` since math-frontend 0.5.0) + `sequences`
         // (a comma-separated fence `(a, b, c)` → `MathExpr::Sequence` since math-frontend
-        // 0.6.0). `plusminus`/`binomials` are not part of AsciiMath's core spelling here.
-        // Declaring `implicit_mul` is a parser-behavior claim (juxtaposition ⇒ `Mul`) the
-        // goldens cover.
+        // 0.6.0) + `plusminus` (`+-`/`-+` → `BinOp::PlusMinus`/`MinusPlus`, the AsciiMath spelling
+        // of `±`/`∓`, matching the latex/unicode-math frontends). `binomials` is not part of
+        // AsciiMath's core spelling here. Declaring `implicit_mul` is a parser-behavior claim
+        // (juxtaposition ⇒ `Mul`) the goldens cover.
         Capabilities::none()
             .with_fractions()
             .with_roots()
@@ -79,6 +80,7 @@ impl MathFrontend for AsciiMath {
             .with_accents()
             .with_oversets()
             .with_sequences()
+            .with_plusminus()
     }
 }
 
@@ -186,6 +188,27 @@ mod tests {
         assert!(matches!(p("a = b"), MathExpr::Rel(RelOp::Eq, _, _)));
         // A right-arrow inside a limit bound parses (no `-`/`>` breakage): `lim_(x -> 0) f`.
         assert!(matches!(p("lim_(x -> 0) f"), MathExpr::BigOp { .. }));
+    }
+
+    // ---- plus-or-minus ---------------------------------------------------------
+    #[test]
+    fn plus_minus_and_minus_plus() {
+        // `+-` / `-+` are the AsciiMath spellings of ± / ∓, lowering to the same neutral BinOp the
+        // latex (`\pm`/`\mp`) and unicode-math (`±`/`∓`) frontends emit.
+        assert_eq!(p("a +- b"), b(BinOp::PlusMinus, sym("a"), sym("b")));
+        assert_eq!(p("a -+ b"), b(BinOp::MinusPlus, sym("a"), sym("b")));
+        assert_eq!(p("a+-b"), b(BinOp::PlusMinus, sym("a"), sym("b"))); // contiguous, no spaces
+        // Same additive precedence as `+`: `a +- b + c` ⇒ (a ± b) + c.
+        assert_eq!(
+            p("a +- b + c"),
+            b(BinOp::Add, b(BinOp::PlusMinus, sym("a"), sym("b")), sym("c"))
+        );
+        // A bare `+` / `-` and `a + -b` (add-then-unary-minus) are unaffected.
+        assert_eq!(p("a + b"), b(BinOp::Add, sym("a"), sym("b")));
+        assert_eq!(
+            p("a + -b"),
+            b(BinOp::Add, sym("a"), MathExpr::Unary(UnaryOp::Neg, Box::new(sym("b"))))
+        );
     }
 
     // ---- operators & precedence ------------------------------------------------
@@ -480,7 +503,8 @@ mod tests {
         assert!(c.matrices && c.big_operators); // PR-2 breadth
         assert!(c.accents); // PR-2b: hat/bar/vec/dot/ddot/tilde/ul
         assert!(c.oversets && c.sequences); // overset/underset + comma-separated fence → Sequence
-        assert!(!c.plusminus && !c.binomials); // not part of AsciiMath's core spelling
+        assert!(c.plusminus); // `+-`/`-+` → ±/∓
+        assert!(!c.binomials); // not part of AsciiMath's core spelling here
     }
 
     // ---- accents (PR-2b) -------------------------------------------------------
@@ -579,6 +603,8 @@ mod tests {
                 "overset(a)(b)",   // over-set annotation (PR-3c emitter) → MathExpr::Overset
                 "underset(a)(b)",  // under-set annotation → MathExpr::Underset
                 "(a,b,c)",         // comma-separated fence → MathExpr::Sequence
+                "a +- b",          // plus-or-minus → BinOp::PlusMinus (±)
+                "x -+ y",          // minus-or-plus → BinOp::MinusPlus (∓)
                 "1 +",   // error: trailing operator (span in range, not a panic)
                 "(x",    // error: missing close
                 "",      // error: empty

--- a/code/packages/rust/asciimath/src/parser.rs
+++ b/code/packages/rust/asciimath/src/parser.rs
@@ -112,6 +112,9 @@ impl Parser<'_> {
             let op = match self.peek() {
                 TokenKind::Plus => BinOp::Add,
                 TokenKind::Minus => BinOp::Sub,
+                // `+-`/`-+` (±/∓) bind at the same additive level as `+`/`-`.
+                TokenKind::PlusMinus => BinOp::PlusMinus,
+                TokenKind::MinusPlus => BinOp::MinusPlus,
                 _ => break,
             };
             self.advance();

--- a/code/packages/rust/asciimath/src/token.rs
+++ b/code/packages/rust/asciimath/src/token.rs
@@ -44,6 +44,10 @@ pub enum TokenKind {
     Text(String),
     Plus,
     Minus,
+    /// `+-` — plus-or-minus (the AsciiMath spelling of `±`, the pair {a+b, a−b}).
+    PlusMinus,
+    /// `-+` — minus-or-plus (`∓`, the opposite pairing {a−b, a+b}).
+    MinusPlus,
     /// `*` (and `**`) — multiplication.
     Star,
     /// `/` — built-up fraction.
@@ -239,10 +243,17 @@ pub fn tokenize(src: &str) -> Result<Vec<Token>, FrontendError> {
 
         let next = bytes.get(i + 1).copied();
         let (kind, end) = match c {
-            b'+' => (TokenKind::Plus, i + 1),
+            // `+-` is the AsciiMath spelling of `±`; a bare `+` stays addition. (Contiguous only,
+            // so `a + -b` is still add-then-unary-minus.)
+            b'+' => match next {
+                Some(b'-') => (TokenKind::PlusMinus, i + 2),
+                _ => (TokenKind::Plus, i + 1),
+            },
             b'-' => match next {
                 Some(b':') => (TokenKind::Div, i + 2),
                 Some(b'=') => (TokenKind::Equiv, i + 2),
+                // `-+` is the AsciiMath spelling of `∓` (minus-or-plus).
+                Some(b'+') => (TokenKind::MinusPlus, i + 2),
                 // Punctuation arrow `->`: emit the same identifier the word form `rarr` does, so it
                 // flows through the existing symbol table (PR-3a) and lowers to `Symbol("rightarrow")`.
                 // No new token kind, no parser change. (`a->b` ⇒ `a · → · b`; `lim_(x->0)` unaffected.)


### PR DESCRIPTION
## Summary

The `asciimath` frontend now reads the AsciiMath **plus-or-minus** spellings and lowers them to the same neutral `BinOp::PlusMinus` / `BinOp::MinusPlus` the `latex` (`\pm`/`\mp`) and `unicode-math` (`±`/`∓`) frontends emit — a consumer that already lowers those binops gets the AsciiMath spelling **for free**. This closes asciimath's last common operator gap vs the other frontends.

| AsciiMath | → neutral |
|---|---|
| `a +- b` | `Bin(PlusMinus, a, b)` (±) |
| `a -+ b` | `Bin(MinusPlus, a, b)` (∓) |

## Implementation

- **Tokenizer**: a **contiguous** `+-` emits `TokenKind::PlusMinus`, `-+` emits `TokenKind::MinusPlus` (2-byte consume via the pre-existing bounds-checked `next` peek — structurally identical to the existing `-:`/`-=`/`->` two-byte handling).
- **Parser**: the additive loop maps them to `BinOp::PlusMinus`/`MinusPlus` at the **same precedence** as `+`/`-` — `a +- b + c` ⇒ `(a ± b) + c`.
- A bare `+`/`-` is unchanged, and `a + -b` (add-then-unary-minus, **with a space**) still parses as before — only the contiguous two-character sequences are the ± / ∓ operators.

## Verification

- asciimath: 49 unit + 1 doctest green; new tests cover `+-`/`-+`, contiguity, precedence, and the `a + -b` non-regression.
- `Capabilities::plusminus` declared (`with_plusminus()`); capability-honesty + conformance-harness tests updated.
- Full consumer suite green: `asciimath` + `math-frontend` + `latex` + `mathml` + `unicode-math` + `adj-lang` + `adj-lang-cli` (22 suites, 0 failures).
- Security review: PASSED (bounds-checked peek, no new panic/OOB/DoS, no `unsafe`, maps to existing `BinOp` variants).
- `asciimath` 0.11.0 → 0.12.0; CHANGELOG + README updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)