### PR TITLE
feat(constant-fold): fold Array.prototype.join on array literals (closes gap-142)

### DIFF
--- a/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 All notable changes to the `coding-adventures-closure-pass-constant-fold` crate will be documented in this file.
 
+## [0.81.0] - 2026-07-01
+
+### Added — fold `Array.prototype.join` on an array literal of constants (closes gap-142)
+
+`[a, b, c].join(sep)` on an array literal whose elements are all compile-time
+constants now folds to a string literal:
+
+```
+["a","b","c"].join("-")  → "a-b-c"      [1,2,3].join()   → "1,2,3"
+[].join("-")             → ""           [1,true,null].join(",") → "1,true,"
+```
+
+- Each element is coerced the way `Array.prototype.join` does (ECMAScript
+  §23.1.3.16): `null`, `undefined`, and array **holes** all become `""`;
+  numbers and booleans take their `String(...)` form; strings pass through.
+- The separator is either **absent** (defaults to `","`) or a single **string
+  literal**. A numeric separator (`[1,2].join(0)` → `"102"`, separator coerces
+  to `"0"`) or any non-literal separator is DECLINED — left for the runtime so
+  the fold stays obviously correct.
+- We DECLINE (leave the call intact) when any element is something whose string
+  form is runtime-dependent — a nested array/object, an identifier, a call, a
+  template literal, etc.
+- **DoS guard:** `fold_array_join` caps the accumulated result length
+  (mirroring `fold_string_repeat`), so a crafted array literal can't materialize
+  an oversized string at compile time.
+
+This resolves gap-142 (opened by the `PeepholeReplaceKnownMethods` port). Seven
+new unit tests cover the string/number/boolean/nullish/hole coercions, the
+default-comma separator, the empty array, and the non-constant-element /
+non-string-separator / nested-array declines; the `folds_array_join` upstream
+placeholder is now an active conformance test. Verified against the full
+closurec end-to-end suite and the downstream pass consumers — all green; the
+change is purely additive (previously-unfoldable joins now fold).
+
 ## [0.80.0] - 2026-07-01
 
 ### Test — activate the gap-141 upstream placeholder (#88, CLOC12.141)

--- a/code/packages/rust/closure-pass-constant-fold/Cargo.toml
+++ b/code/packages/rust/closure-pass-constant-fold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-constant-fold"
-version = "0.80.0"
+version = "0.81.0"
 edition = "2021"
 description = "Constant-folding optimization pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Folds compile-time-evaluable expressions like `2 + 3 → 5`."
 

--- a/code/packages/rust/closure-pass-constant-fold/README.md
+++ b/code/packages/rust/closure-pass-constant-fold/README.md
@@ -68,9 +68,11 @@ Plus `coding-adventures-javascript-tokens` as a dev-dependency for
 - `peephole_replace_known_methods_test.rs` — `PeepholeReplaceKnownMethodsTest`.
   Pins the String-method folds this pass performs (indexOf, lastIndexOf, case
   conversion, slice, substring, substr, charAt, charCodeAt, repeat, trim,
-  includes/startsWith/endsWith) and records the upstream folds it does not yet
-  perform — `Math.abs`/`floor`/`ceil`/`round`, `Array#join`, and `String#concat`
-  with coerced non-string args — as `#[ignore = "blocked on gap-NNN"]`
-  placeholders tied to `code/specs/CLOC12-gaps.md` (gap-141 … gap-143). Run with
+  includes/startsWith/endsWith), the numeric `Math.abs`/`floor`/`ceil`/`round`
+  and `Math.max`/`Math.min` folds, and the `Array.prototype.join` fold on an
+  array literal of constants (gap-142, `["a","b"].join("-")` → `"a-b"`). The one
+  remaining upstream fold it does not yet perform — `String#concat` with coerced
+  non-string args — is recorded as an `#[ignore = "blocked on gap-143"]`
+  placeholder tied to `code/specs/CLOC12-gaps.md`. Run with
   `cargo test --test upstream_peephole_replace_known_methods` (add
-  `-- --include-ignored` to list the pending gaps).
+  `-- --include-ignored` to list the pending gap).

--- a/code/packages/rust/closure-pass-constant-fold/src/lib.rs
+++ b/code/packages/rust/closure-pass-constant-fold/src/lib.rs
@@ -571,6 +571,61 @@ fn fold_expression(expr: &Expression, st: &mut FoldState) -> Expression {
 /// the computed form `"x"["toUpperCase"]()`, and a method on a non-literal
 /// (`s.toUpperCase()`) all pass through unchanged. We still recurse into the
 /// callee and arguments so nested constants inside them fold.
+/// Coerce a single array-literal element to the string `Array.prototype.join`
+/// would produce for it, or `None` if the element is not a compile-time
+/// constant we can represent faithfully.
+///
+/// Truth table (mirrors ECMAScript's per-element `ToString`, with the
+/// join-specific rule that `null`/`undefined`/holes stringify to `""`):
+///
+/// ```text
+///   element            join string
+///   ----------------   -----------
+///   hole (elision)     ""
+///   null               ""
+///   undefined          ""
+///   "abc"              abc
+///   42                 42          (String(Number))
+///   true / false       true / false
+///   anything else      None  → decline the whole fold
+/// ```
+fn join_element_str(element: &Option<Expression>) -> Option<String> {
+    match element {
+        // A hole (`[1, , 3]`) and the two nullish literals all join as `""`.
+        None => Some(String::new()),
+        Some(Expression::NullLiteral(_)) => Some(String::new()),
+        Some(Expression::UndefinedLiteral(_)) => Some(String::new()),
+        Some(Expression::StringLiteral(s)) => Some(s.value.clone()),
+        Some(Expression::NumericLiteral(n)) => Some(format_js_number(n.value)),
+        Some(Expression::BooleanLiteral(b)) => {
+            Some(if b.value { "true" } else { "false" }.to_string())
+        }
+        // Nested arrays/objects, identifiers, calls, template literals, … all
+        // have runtime-dependent string forms — decline so the call stands.
+        _ => None,
+    }
+}
+
+/// Fold `array.join(sep)` when every element is a join-representable constant.
+/// Returns the joined string, or `None` to leave the call intact.
+///
+/// A length cap (mirroring `fold_string_repeat`'s DoS guard) prevents a crafted
+/// array literal from materializing an oversized string at compile time.
+fn fold_array_join(arr: &ArrayExpression, sep: &str) -> Option<String> {
+    const MAX_JOIN_LEN: usize = 100_000;
+    let mut parts: Vec<String> = Vec::with_capacity(arr.elements.len());
+    let mut total = 0usize;
+    for element in &arr.elements {
+        let piece = join_element_str(element)?;
+        total = total.saturating_add(piece.len()).saturating_add(sep.len());
+        if total > MAX_JOIN_LEN {
+            return None;
+        }
+        parts.push(piece);
+    }
+    Some(parts.join(sep))
+}
+
 fn fold_call(c: &CallExpression, st: &mut FoldState) -> Expression {
     let callee = fold_expression(&c.callee, st);
     let arguments: Vec<Expression> = c.arguments.iter().map(|a| fold_expression(a, st)).collect();
@@ -1111,6 +1166,47 @@ fn fold_call(c: &CallExpression, st: &mut FoldState) -> Expression {
                             let after = if value { "true" } else { "false" };
                             let new_cv = st.fork_cv(&parent, &before, after);
                             return stamp_literal_cv(FoldedLiteral::Boolean(value), new_cv);
+                        }
+                    }
+                }
+            }
+
+            // ---- `[a, b, c].join(sep)` on an array literal of constants ----
+            //
+            // `["a","b","c"].join("-")` → `"a-b-c"`, `[1,2,3].join()` →
+            // `"1,2,3"` (the separator defaults to `","`), `[].join("-")` →
+            // `""` (ECMAScript §23.1.3.16). Each element is coerced to a string
+            // the way `Array.prototype.join` does: `null`, `undefined`, and
+            // array HOLES all become the empty string `""`; numbers and
+            // booleans take their `String(...)` form. We DECLINE (leave the
+            // call intact) if any element is something we cannot coerce at
+            // compile time without changing semantics — a nested array/object
+            // (its own `toString` runs at runtime), an identifier, a call, etc.
+            // — or if the separator is anything other than an absent argument or
+            // a single STRING literal (a numeric separator like `[1,2].join(0)`
+            // coerces to `"0"`, which we leave for the runtime to keep the fold
+            // obviously correct). `fold_array_join` also caps the result length
+            // as an algorithmic-blowup guard.
+            if let (Expression::ArrayExpression(arr), Expression::Identifier(id)) =
+                (m.object.as_ref(), m.property.as_ref())
+            {
+                if id.name == "join" {
+                    let sep = match arguments.as_slice() {
+                        [] => Some(",".to_string()),
+                        [Expression::StringLiteral(s)] => Some(s.value.clone()),
+                        _ => None,
+                    };
+                    if let Some(sep) = sep {
+                        if let Some(result) = fold_array_join(arr, &sep) {
+                            let parent = c.cv.clone();
+                            let sep_src = match arguments.first() {
+                                Some(Expression::StringLiteral(s)) => format!("\"{}\"", s.value),
+                                _ => String::new(),
+                            };
+                            let before = format!("[...].join({sep_src})");
+                            let after = format!("\"{result}\"");
+                            let new_cv = st.fork_cv(&parent, &before, &after);
+                            return stamp_literal_cv(FoldedLiteral::String(result), new_cv);
                         }
                     }
                 }
@@ -11204,5 +11300,108 @@ mod tests {
             .diagnostics
             .iter()
             .any(|d| d.group.0 == "pipeline.fixed-point-not-yet-iterated"));
+    }
+
+    // =================================================================
+    // Array.prototype.join folding (gap-142 / CLOC12.141)
+    // =================================================================
+
+    /// Build `[<elements>].join(<sep_arg?>)` as a CallExpression.
+    fn join_call(elements: Vec<Option<Expression>>, sep_arg: Option<Expression>) -> Expression {
+        let arr = Expression::ArrayExpression(ArrayExpression {
+            cv: None,
+            elements,
+        });
+        Expression::CallExpression(CallExpression {
+            cv: Some("c.cv".to_string()),
+            callee: Box::new(member(arr, "join")),
+            arguments: sep_arg.into_iter().collect(),
+        })
+    }
+
+    #[test]
+    fn fold_array_join_strings_with_separator() {
+        let c = join_call(
+            vec![
+                Some(string("a", None)),
+                Some(string("b", None)),
+                Some(string("c", None)),
+            ],
+            Some(string("-", None)),
+        );
+        assert_eq!(folded_string(c).as_deref(), Some("a-b-c"));
+    }
+
+    #[test]
+    fn fold_array_join_default_separator_is_comma() {
+        // No separator argument → `,` (ECMAScript §23.1.3.16).
+        let c = join_call(
+            vec![
+                Some(num(1.0, None)),
+                Some(num(2.0, None)),
+                Some(num(3.0, None)),
+            ],
+            None,
+        );
+        assert_eq!(folded_string(c).as_deref(), Some("1,2,3"));
+    }
+
+    #[test]
+    fn fold_array_join_coerces_mixed_constants() {
+        // Numbers, booleans, null, undefined, and holes each coerce the way
+        // `join` does: nullish + holes → "", number/boolean → String(...).
+        let c = join_call(
+            vec![
+                Some(num(1.0, None)),
+                Some(boolean(true, None)),
+                Some(Expression::NullLiteral(NullLiteral { cv: None })),
+                None, // a hole
+                Some(string("x", None)),
+            ],
+            Some(string(",", None)),
+        );
+        // 1 , "true" , "" , "" , "x"  →  "1,true,,,x"
+        assert_eq!(folded_string(c).as_deref(), Some("1,true,,,x"));
+    }
+
+    #[test]
+    fn fold_array_join_empty_array_is_empty_string() {
+        let c = join_call(vec![], Some(string("-", None)));
+        assert_eq!(folded_string(c).as_deref(), Some(""));
+    }
+
+    #[test]
+    fn array_join_non_constant_element_does_not_fold() {
+        // An identifier element has a runtime-dependent string form → decline.
+        let c = join_call(
+            vec![Some(string("a", None)), Some(ident("x"))],
+            Some(string("-", None)),
+        );
+        assert_eq!(folded_string(c), None);
+    }
+
+    #[test]
+    fn array_join_non_string_separator_does_not_fold() {
+        // A numeric separator (`[1,2].join(0)` → "102") coerces to "0"; we
+        // leave it for the runtime to keep the fold obviously correct.
+        let c = join_call(
+            vec![Some(num(1.0, None)), Some(num(2.0, None))],
+            Some(num(0.0, None)),
+        );
+        assert_eq!(folded_string(c), None);
+    }
+
+    #[test]
+    fn array_join_nested_array_element_does_not_fold() {
+        // A nested array element runs its own `toString` at runtime → decline.
+        let nested = Expression::ArrayExpression(ArrayExpression {
+            cv: None,
+            elements: vec![Some(num(1.0, None))],
+        });
+        let c = join_call(
+            vec![Some(string("a", None)), Some(nested)],
+            Some(string("-", None)),
+        );
+        assert_eq!(folded_string(c), None);
     }
 }

--- a/code/packages/rust/closure-pass-constant-fold/tests/upstream/peephole_replace_known_methods_test.rs
+++ b/code/packages/rust/closure-pass-constant-fold/tests/upstream/peephole_replace_known_methods_test.rs
@@ -225,10 +225,12 @@ fn folds_math_unary_methods() {
     assert_num(call(ident("Math"), "round", vec![n(2.5)]), 3.0);
 }
 
-/// Upstream folds `[a,b,c].join(sep)` on an array literal of constants. Our
-/// pass folds String methods but not Array#join.
+/// Upstream folds `[a,b,c].join(sep)` on an array literal of constants.
+/// gap-142 RESOLVED (CLOC12.141) — our pass now folds it. Previously an
+/// `#[ignore]` placeholder; now an active conformance test. The default-`,`
+/// separator and the numeric-element coercion are exercised in the pass's own
+/// unit tests.
 #[test]
-#[ignore = "blocked on gap-142: constant-fold does not fold Array.prototype.join on array literals"]
 fn folds_array_join() {
     use coding_adventures_javascript_ast::ArrayExpression;
     let arr = Expression::ArrayExpression(ArrayExpression {

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -1166,9 +1166,13 @@ historical context with status `RESOLVED` and a link to the fix PR.
     with round-half-toward-`+Infinity` and negative-zero declines). The
     `folds_math_unary_methods` placeholder is now an **active** conformance
     test (also covers `ceil`/`round`) as of constant-fold 0.80.0.
-  - **gap-142** *(still open)* — fold `Array.prototype.join` on an array literal
-    of constants (`[a,b,c].join("-")` → `"a-b-c"`). Our pass folds String
-    methods but not Array#join.
+  - **gap-142** — ~~fold `Array.prototype.join` on an array literal of
+    constants (`[a,b,c].join("-")` → `"a-b-c"`)~~ **RESOLVED** (constant-fold
+    0.81.0). Folds when every element is a join-representable constant
+    (strings, numbers, booleans, `null`/`undefined`/holes → `""`) and the
+    separator is absent (`","`) or a string literal; declines non-constant
+    elements, nested arrays/objects, and non-string separators; DoS length cap.
+    The `folds_array_join` placeholder is now an **active** conformance test.
   - **gap-143** — fold `String#concat` with **non-string (coerced) args**
     (`"x".concat(1, 2)` → `"x12"`). Our concat fold handles string args only.
 


### PR DESCRIPTION
## Summary

`[a, b, c].join(sep)` on an array literal whose elements are all compile-time constants now folds to a string literal at compile time (ECMAScript §23.1.3.16). Resolves **gap-142** (opened by the `PeepholeReplaceKnownMethods` port).

```
["a","b","c"].join("-")  → "a-b-c"      [1,2,3].join()          → "1,2,3"
[].join("-")             → ""           [1,true,null].join(",") → "1,true,"
```

## Semantics

- **Per-element coercion** matches `Array.prototype.join`: `null`, `undefined`, and array **holes** all become `""`; numbers and booleans take their `String(...)` form; strings pass through.
- **Separator** is either absent (defaults to `","`) or a single **string literal**. A numeric separator (`[1,2].join(0)` → `"102"`, separator coerces to `"0"`) or any non-literal separator is **declined** — left for the runtime so the fold stays obviously correct.
- **Declines** (leaves the call intact) when any element's string form is runtime-dependent — a nested array/object, an identifier, a call, a template literal, etc.
- **DoS guard:** `fold_array_join` caps the accumulated result length at 100 KB (mirroring `fold_string_repeat`), checked *before* each push and using `saturating_add`, so a crafted array literal of large string literals can't materialize an oversized string at compile time.

## Tests / scope

- **7 new unit tests** cover the string/number/boolean/nullish/hole coercions, default-comma separator, empty array, and the non-constant-element / non-string-separator / nested-array declines.
- The `folds_array_join` upstream placeholder in `peephole_replace_known_methods_test.rs` is now an **active** conformance test (only gap-143 remains ignored there).
- Full constant-fold suite green (340 lib + ports); verified against the **closurec end-to-end suite (685 tests)** and downstream pass consumers (fold-control-flow, inline-variables, dce, emitter) — all green. The change is purely additive.
- Bumps constant-fold 0.80.0 → 0.81.0; marks gap-142 RESOLVED in `code/specs/CLOC12-gaps.md`; updates the crate README.
- Inline security review: **PASSED** (DoS guard verified correct — cap checked before push, `saturating_add`, no panic path; pure in-memory AST→AST, no `unsafe`/I/O).

🤖 Generated with [Claude Code](https://claude.com/claude-code)