### PR TITLE
feat(constant-fold): String#concat coerces primitive-constant args (closes gap-143)

### DIFF
--- a/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to the `coding-adventures-closure-pass-constant-fold` crate will be documented in this file.
 
+## [0.82.0] - 2026-07-01
+
+### Added — `String#concat` coerces primitive-constant arguments (closes gap-143)
+
+`"x".concat(1, 2)` now folds to `"x12"`. The existing `String.prototype.concat`
+fold only accepted string-literal arguments; it now applies `ToString` to the
+primitive-constant argument forms, matching ECMAScript §22.1.3.4:
+
+```
+"x".concat(1, 2)   → "x12"       "a".concat(true)       → "atrue"
+"a".concat(null)   → "anull"     "a".concat(undefined)  → "aundefined"
+```
+
+- Coercion table: string → itself, number → `String(n)`, boolean →
+  `"true"`/`"false"`, `null` → `"null"`, `undefined` → `"undefined"`. **Note
+  this differs from `Array#join`** (0.81.0), where `null`/`undefined` coerce to
+  `""` — `concat` runs `ToString`, whose null/undefined forms are the words.
+- A non-constant argument (identifier, call), an **object**, or an array still
+  makes the fold **decline** — those have runtime-dependent `toString`.
+- The existing UTF-16 length cap (`MAX_CONCAT_UNITS`) still guards against a
+  crafted oversized result.
+
+This resolves gap-143 — the last open gap from the `PeepholeReplaceKnownMethods`
+port, so **that port is now fully active** (gaps 141/142/143 all closed). Four
+new/updated unit tests cover the numeric/boolean/nullish coercions and the
+object-argument decline; the `folds_string_concat_with_coerced_args` upstream
+placeholder is now an active conformance test. Verified against the full
+closurec end-to-end suite and the downstream pass consumers — all green; the
+change is purely additive (previously-declined concat calls now fold).
+
 ## [0.81.0] - 2026-07-01
 
 ### Added — fold `Array.prototype.join` on an array literal of constants (closes gap-142)

--- a/code/packages/rust/closure-pass-constant-fold/Cargo.toml
+++ b/code/packages/rust/closure-pass-constant-fold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-constant-fold"
-version = "0.81.0"
+version = "0.82.0"
 edition = "2021"
 description = "Constant-folding optimization pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Folds compile-time-evaluable expressions like `2 + 3 → 5`."
 

--- a/code/packages/rust/closure-pass-constant-fold/README.md
+++ b/code/packages/rust/closure-pass-constant-fold/README.md
@@ -69,10 +69,11 @@ Plus `coding-adventures-javascript-tokens` as a dev-dependency for
   Pins the String-method folds this pass performs (indexOf, lastIndexOf, case
   conversion, slice, substring, substr, charAt, charCodeAt, repeat, trim,
   includes/startsWith/endsWith), the numeric `Math.abs`/`floor`/`ceil`/`round`
-  and `Math.max`/`Math.min` folds, and the `Array.prototype.join` fold on an
-  array literal of constants (gap-142, `["a","b"].join("-")` → `"a-b"`). The one
-  remaining upstream fold it does not yet perform — `String#concat` with coerced
-  non-string args — is recorded as an `#[ignore = "blocked on gap-143"]`
-  placeholder tied to `code/specs/CLOC12-gaps.md`. Run with
-  `cargo test --test upstream_peephole_replace_known_methods` (add
-  `-- --include-ignored` to list the pending gap).
+  and `Math.max`/`Math.min` folds, the `Array.prototype.join` fold on an
+  array literal of constants (gap-142, `["a","b"].join("-")` → `"a-b"`), and
+  the `String#concat` fold with `ToString`-coerced primitive arguments (gap-143,
+  `"x".concat(1, 2)` → `"x12"`). **This port is now fully active** — gaps
+  141/142/143 are all closed, so there are no remaining `#[ignore]`
+  placeholders. Run with
+  `cargo test --test upstream_peephole_replace_known_methods` (every case is
+  active — nothing is ignored).

--- a/code/packages/rust/closure-pass-constant-fold/src/lib.rs
+++ b/code/packages/rust/closure-pass-constant-fold/src/lib.rs
@@ -745,9 +745,11 @@ fn fold_call(c: &CallExpression, st: &mut FoldState) -> Expression {
                 //
                 // `"a".concat("b", "c")` → `"abc"`, `"".concat("x")` → `"x"`,
                 // `"a".concat()` → `"a"` (ECMAScript §22.1.3.4, the variadic
-                // form). Every argument must itself be a STRING literal — JS
-                // coerces non-strings via `ToString` (`"a".concat(1)` → `"a1"`),
-                // but we don't model that coercion, so a numeric/identifier
+                // form). JS coerces every argument via `ToString`, and we now
+                // model that for the primitive constants: `"x".concat(1, 2)` →
+                // `"x12"`, `"a".concat(true)` → `"atrue"`, `"a".concat(null)` →
+                // `"anull"` (note `ToString(null)` is `"null"`, NOT `""` — that
+                // is `Array#join`'s rule). A non-constant / object / array
                 // argument makes `fold_string_concat_call` decline and the call
                 // is left for the runtime. Concatenating valid strings can only
                 // ever yield valid UTF-16 (no surrogate pair is ever split, the
@@ -3065,6 +3067,38 @@ fn fold_string_repeat(value: &str, args: &[Expression]) -> Option<String> {
 ///   pieces all come from the source, so this is a defensive cap (and
 ///   `checked_add` stops the running length from overflowing) rather than a
 ///   true blowup vector, but it mirrors the `repeat`/`pad` guards.
+/// Coerce a single `String.prototype.concat` argument to the string JS would
+/// pass to the concatenation, or `None` if it is not a compile-time constant we
+/// can coerce faithfully.
+///
+/// `concat` runs `ToString` on every argument (ECMAScript §22.1.3.4), which is
+/// where this differs from `Array.prototype.join`: `join` maps `null`/
+/// `undefined` to the empty string, but `ToString(null)` is `"null"` and
+/// `ToString(undefined)` is `"undefined"`.
+///
+/// ```text
+///   argument        concat string
+///   -------------   -------------
+///   "abc"           abc
+///   42              42          (String(Number))
+///   true / false    true / false
+///   null            null
+///   undefined       undefined
+///   anything else   None  → decline the whole fold
+/// ```
+fn concat_arg_str(arg: &Expression) -> Option<String> {
+    match arg {
+        Expression::StringLiteral(s) => Some(s.value.clone()),
+        Expression::NumericLiteral(n) => Some(format_js_number(n.value)),
+        Expression::BooleanLiteral(b) => Some(if b.value { "true" } else { "false" }.to_string()),
+        Expression::NullLiteral(_) => Some("null".to_string()),
+        Expression::UndefinedLiteral(_) => Some("undefined".to_string()),
+        // Objects, arrays, identifiers, calls, … have runtime-dependent string
+        // forms — decline so the call stands.
+        _ => None,
+    }
+}
+
 fn fold_string_concat_call(value: &str, args: &[Expression]) -> Option<String> {
     /// Cap on the folded result's length, in UTF-16 code units.
     const MAX_CONCAT_UNITS: usize = 100_000;
@@ -3072,15 +3106,12 @@ fn fold_string_concat_call(value: &str, args: &[Expression]) -> Option<String> {
     let mut units = value.encode_utf16().count();
     let mut out = String::from(value);
     for a in args {
-        let piece = match a {
-            Expression::StringLiteral(s) => &s.value,
-            _ => return None,
-        };
+        let piece = concat_arg_str(a)?;
         units = units.checked_add(piece.encode_utf16().count())?;
         if units > MAX_CONCAT_UNITS {
             return None;
         }
-        out.push_str(piece);
+        out.push_str(&piece);
     }
     Some(out)
 }
@@ -10584,18 +10615,70 @@ mod tests {
         }
     }
 
-    #[test]
-    fn concat_non_string_argument_does_not_fold() {
-        // `"a".concat(1)` is `"a1"` in JS via ToString, but we don't model that
-        // coercion — leave it for the runtime rather than guess.
-        let c = Expression::CallExpression(CallExpression {
+    /// Build `"<recv>".concat(<args…>)` from arbitrary argument expressions.
+    fn concat_call_exprs(recv: &str, args: Vec<Expression>) -> Expression {
+        Expression::CallExpression(CallExpression {
             cv: Some("c.cv".to_string()),
-            callee: Box::new(member(string("a", None), "concat")),
-            arguments: vec![num(1.0, None)],
+            callee: Box::new(member(string(recv, None), "concat")),
+            arguments: args,
+        })
+    }
+
+    fn folded_concat(recv: &str, args: Vec<Expression>) -> Option<String> {
+        let (out, _, changed, _) = run_pass(program_with_expr(concat_call_exprs(recv, args), true));
+        if !changed {
+            return None;
+        }
+        match extract_expr(&out) {
+            Expression::StringLiteral(s) => Some(s.value.clone()),
+            other => panic!("expected a string literal; got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn concat_coerces_numeric_arguments() {
+        // `"x".concat(1, 2)` → `"x12"` (ToString on each argument) — gap-143.
+        assert_eq!(
+            folded_concat("x", vec![num(1.0, None), num(2.0, None)]).as_deref(),
+            Some("x12")
+        );
+        // Mixed with a string argument.
+        assert_eq!(
+            folded_concat("a", vec![string("b", None), num(3.0, None)]).as_deref(),
+            Some("ab3")
+        );
+    }
+
+    #[test]
+    fn concat_coerces_boolean_and_nullish_arguments() {
+        // ToString(true)="true", ToString(false)="false".
+        assert_eq!(
+            folded_concat("a", vec![boolean(true, None), boolean(false, None)]).as_deref(),
+            Some("atruefalse")
+        );
+        // ToString(null)="null", ToString(undefined)="undefined" — note this is
+        // DIFFERENT from Array#join, where nullish coerces to "".
+        assert_eq!(
+            folded_concat(
+                "x",
+                vec![
+                    Expression::NullLiteral(NullLiteral { cv: None }),
+                    Expression::UndefinedLiteral(UndefinedLiteral { cv: None }),
+                ],
+            )
+            .as_deref(),
+            Some("xnullundefined")
+        );
+    }
+
+    #[test]
+    fn concat_object_argument_does_not_fold() {
+        // An object argument has a runtime-dependent `toString` → decline.
+        let obj = Expression::ObjectExpression(ObjectExpression {
+            cv: None,
+            properties: vec![],
         });
-        let (out, _, changed, _) = run_pass(program_with_expr(c, true));
-        assert!(!changed, "concat with a numeric argument must not fold");
-        assert!(matches!(extract_expr(&out), Expression::CallExpression(_)));
+        assert_eq!(folded_concat("a", vec![obj]), None);
     }
 
     #[test]

--- a/code/packages/rust/closure-pass-constant-fold/tests/upstream/peephole_replace_known_methods_test.rs
+++ b/code/packages/rust/closure-pass-constant-fold/tests/upstream/peephole_replace_known_methods_test.rs
@@ -240,11 +240,12 @@ fn folds_array_join() {
     assert_str(call(arr, "join", vec![s("-")]), "a-b-c");
 }
 
-/// Upstream folds `"a".concat("b","c")` — covered by our pass for strings, but
-/// the *number*-coercing form `"x".concat(1, 2)` is an upstream case we do not
-/// fold (coercion of non-string args).
+/// Upstream folds `"x".concat(1, 2)` → `"x12"` by coercing each argument via
+/// `ToString`. gap-143 RESOLVED (CLOC12.141) — our pass now coerces the
+/// primitive-constant argument forms. Previously an `#[ignore]` placeholder;
+/// now an active conformance test. With this the whole
+/// `PeepholeReplaceKnownMethods` port is active (gaps 141/142/143 all closed).
 #[test]
-#[ignore = "blocked on gap-143: constant-fold does not fold String#concat with non-string (coerced) args"]
 fn folds_string_concat_with_coerced_args() {
     assert_str(call(s("x"), "concat", vec![n(1.0), n(2.0)]), "x12");
 }

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -1173,8 +1173,13 @@ historical context with status `RESOLVED` and a link to the fix PR.
     separator is absent (`","`) or a string literal; declines non-constant
     elements, nested arrays/objects, and non-string separators; DoS length cap.
     The `folds_array_join` placeholder is now an **active** conformance test.
-  - **gap-143** — fold `String#concat` with **non-string (coerced) args**
-    (`"x".concat(1, 2)` → `"x12"`). Our concat fold handles string args only.
+  - **gap-143** — ~~fold `String#concat` with **non-string (coerced) args**
+    (`"x".concat(1, 2)` → `"x12"`)~~ **RESOLVED** (constant-fold 0.82.0). The
+    concat fold now applies `ToString` to primitive-constant arguments
+    (number/boolean/`null`→`"null"`/`undefined`→`"undefined"`); objects/arrays/
+    non-constants still decline. The `folds_string_concat_with_coerced_args`
+    placeholder is now an **active** conformance test. **With this the whole
+    `PeepholeReplaceKnownMethods` port is active — gaps 141/142/143 all closed.**
 
 ## CLOC12.142 — CodePrinter number-formatting port (emitter)
 


### PR DESCRIPTION
## Summary

`"x".concat(1, 2)` now folds to `"x12"`. The existing `String.prototype.concat` fold only accepted string-literal arguments; it now applies `ToString` to the primitive-constant argument forms (ECMAScript §22.1.3.4). Resolves **gap-143** — the last open gap from the `PeepholeReplaceKnownMethods` port, so **that port is now fully active (gaps 141/142/143 all closed)**.

```
"x".concat(1, 2)  → "x12"       "a".concat(true)      → "atrue"
"a".concat(null)  → "anull"     "a".concat(undefined) → "aundefined"
```

## Semantics

- **Coercion table** (`concat_arg_str`): string → itself, number → `String(n)`, boolean → `"true"`/`"false"`, `null` → `"null"`, `undefined` → `"undefined"`.
- **Note the contrast with `Array#join`** (shipped in 0.81.0): join maps `null`/`undefined`/holes to `""`, but `concat` runs `ToString`, whose null/undefined forms are the literal words `"null"`/`"undefined"`.
- An **object**, array, identifier, call, or any other non-constant argument still makes the fold **decline** — those have runtime-dependent `toString`.
- The existing UTF-16 length cap (`MAX_CONCAT_UNITS`, `checked_add`) is unchanged and still guards against an oversized result.

## Tests / scope

- **4 new/updated unit tests** cover the numeric, boolean, and nullish coercions and the object-argument decline (the old `concat_non_string_argument_does_not_fold` is replaced since numeric args now fold).
- The `folds_string_concat_with_coerced_args` upstream placeholder is now an **active** conformance test — `peephole_replace_known_methods_test.rs` has **no remaining `#[ignore]`s**.
- Full constant-fold suite green (342 lib + ports); verified against the **closurec end-to-end suite (685 tests)** and downstream pass consumers — all green. Purely additive.
- Bumps constant-fold 0.81.0 → 0.82.0; marks gap-143 RESOLVED in `code/specs/CLOC12-gaps.md`; updates the crate README.
- Inline security review: **PASSED** (DoS cap still effective with coerced pieces; number coercion is bounded ≤ ~24 chars; no panic path; no `unsafe`/I/O).

🤖 Generated with [Claude Code](https://claude.com/claude-code)