### PR TITLE
feat(mathml): binomial coefficients — <mfrac linethickness="0"> → Binom (0.8.0)

### DIFF
--- a/code/packages/rust/mathml/CHANGELOG.md
+++ b/code/packages/rust/mathml/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to the Presentation-MathML frontend crate.
 
+## [0.8.0] — 2026-07-01
+
+### Added — binomial coefficients (`<mfrac linethickness="0">` → `Binom`)
+
+A `<mfrac>` whose fraction bar has **zero thickness** (`linethickness="0"`) is
+Presentation-MathML's encoding of a **binomial coefficient** "n choose k" — the same
+top-over-bottom stack with the division rule suppressed, and exactly what LaTeX `\binom{n}{k}` /
+`{n \choose k}` export to. It now lowers to the neutral `MathExpr::Binom` node (the SAME node the
+`latex` frontend already emits for `\binom`), distinct from `MathExpr::Frac`:
+
+- `<mfrac linethickness="0"><mi>n</mi><mi>k</mi></mfrac>` → `Binom(n, k)` (source order — numerator
+  = top = n).
+- Every length spelling of zero is recognised (`0`, `0pt`, `0.0em`, `0px`); the keyword thicknesses
+  (`thin`/`medium`/`thick`), any nonzero length, and an absent attribute all stay an ordinary `Frac`.
+- The `linethickness` attribute is re-read from the start-tag byte span (the same mechanism
+  `<mfenced>` uses for its `open`/`close` delimiters) — the lexer still discards presentation
+  attributes.
+- `capabilities()` now declares `binomials`, closing the last shape gap vs the `latex` frontend.
+  Downstream is unaffected: the `Binom` node already existed and is already lowered by the
+  `adj-lang` adapter. Verified across `latex`/`mathml`/`asciimath`/`unicode-math`/`adj-lang`/
+  `adj-lang-cli`.
+
 ## [0.7.0] — 2026-07-01
 
 ### Changed — comma/semicolon list fences now carry their delimiters too

--- a/code/packages/rust/mathml/Cargo.toml
+++ b/code/packages/rust/mathml/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mathml"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 description = "A Presentation-MathML reader that implements the math-frontend MathFrontend trait: turns <math>…</math> (mn/mi/mo/mrow/mfrac/msup/msub/msqrt/mroot/mtext/mtable/mover/munder/mfenced + named functions) into the neutral MathExpr AST. The fourth pluggable frontend after LaTeX and AsciiMath (see PFE01). Total, panic-free, spanned errors."
 license = "MIT"

--- a/code/packages/rust/mathml/README.md
+++ b/code/packages/rust/mathml/README.md
@@ -21,6 +21,7 @@ tree.
 | `<mo>+ - * / = &lt; &gt; ≤ ≥ ≠ ≈ ≡ ± ∓</mo>` | the matching `Bin`/`Rel` operator |
 | `<mrow>…</mrow>` | a folded row: operator precedence (relations < ± / +− < × ÷), implicit multiplication of adjacent operands, unary signs, and `(`…`)` fences → `Group` |
 | `<mfrac>a b</mfrac>` | `Frac(a, b)` |
+| `<mfrac linethickness="0">n k</mfrac>` | `Binom(n, k)` (a zero-thickness bar is the binomial coefficient "n choose k" — same node as LaTeX `\binom{n}{k}`; any nonzero/keyword/absent thickness stays `Frac`) |
 | `<msup>b e</msup>` | `Bin(Pow, b, e)` |
 | `<msub>b s</msub>` | `Subscript(b, s)` |
 | `<msubsup>b s e</msubsup>` | `Bin(Pow, Subscript(b, s), e)` |

--- a/code/packages/rust/mathml/src/lib.rs
+++ b/code/packages/rust/mathml/src/lib.rs
@@ -19,7 +19,9 @@
 //! The core presentation element set: `<mn>` numbers (exact), `<mi>` identifiers, `<mo>` operators
 //! (`+ - * / = < > ≤ ≥ ≠ ≈ ≡ ± ∓` and their entity spellings), `<mrow>` rows (with operator
 //! precedence, implicit multiplication of adjacent operands, unary signs, and `(`…`)` fences),
-//! `<mfrac>` → [`MathExpr::Frac`], `<msup>` → `Pow`, `<msub>` → [`MathExpr::Subscript`],
+//! `<mfrac>` → [`MathExpr::Frac`] (or, when its bar is zero-thickness — `linethickness="0"`, the
+//! binomial-coefficient encoding — [`MathExpr::Binom`]), `<msup>` → `Pow`, `<msub>` →
+//! [`MathExpr::Subscript`],
 //! `<msubsup>`, `<msqrt>`/`<mroot>` → [`MathExpr::Root`], and `<mtext>` → [`MathExpr::Text`]. The
 //! `<math>`/`<mstyle>`/`<mpadded>` wrappers are transparent. Attributes, namespace prefixes
 //! (`m:math` ≡ `math`), the XML declaration, comments, and DOCTYPE are ignored.
@@ -76,6 +78,9 @@ impl MathFrontend for MathMl {
         // `Fenced { open, body, close }`, and a comma/semicolon LIST lowers to `Fenced { open,
         // body: Sequence(..), close }` — always carrying its `open`/`close` delimiters as data (so
         // `|x|` ≠ `(x)` and `(a, b)` ≠ `[a, b]`).
+        // The binomials slice reads `<mfrac>`'s `linethickness`: a zero-thickness bar
+        // (`linethickness="0"`) is MathML's binomial coefficient "n choose k" → `Binom` (the SAME
+        // node the latex `\binom` emits); any nonzero/absent thickness stays a `Frac`.
         Capabilities::none()
             .with_fractions()
             .with_roots()
@@ -84,6 +89,7 @@ impl MathFrontend for MathMl {
             .with_implicit_mul()
             .with_text()
             .with_plusminus()
+            .with_binomials()
             .with_matrices()
             .with_oversets()
             .with_functions()
@@ -214,6 +220,45 @@ mod tests {
     fn mfrac_is_frac_like_latex_and_asciimath() {
         let e = p("<mfrac><mn>1</mn><mn>2</mn></mfrac>");
         assert_eq!(e, MathExpr::Frac(Box::new(num(1)), Box::new(num(2))));
+    }
+
+    #[test]
+    fn mfrac_linethickness_zero_is_a_binomial() {
+        // A zero-thickness fraction bar is MathML's binomial coefficient "n choose k" — the SAME
+        // neutral node LaTeX `\binom{n}{k}` emits, distinct from `Frac`. The `n`/`k` stay in source
+        // order (numerator = top = n).
+        assert_eq!(
+            p(r#"<mfrac linethickness="0"><mi>n</mi><mi>k</mi></mfrac>"#),
+            MathExpr::Binom(Box::new(sym("n")), Box::new(sym("k")))
+        );
+        // Every unit spelling of zero suppresses the bar (0pt / 0.0em / 0px), and single-quoted
+        // attributes work too.
+        for zero in ["0", "0pt", "0.0em", "0px"] {
+            assert_eq!(
+                p(&format!(r#"<mfrac linethickness="{zero}"><mn>5</mn><mn>2</mn></mfrac>"#)),
+                MathExpr::Binom(Box::new(num(5)), Box::new(num(2))),
+                "linethickness={zero:?} should be a binomial",
+            );
+        }
+        // A nonzero or keyword thickness — and an absent attribute — stay ordinary fractions.
+        for frac in [
+            r#"<mfrac linethickness="1"><mn>1</mn><mn>2</mn></mfrac>"#,
+            r#"<mfrac linethickness="2px"><mn>1</mn><mn>2</mn></mfrac>"#,
+            r#"<mfrac linethickness="thin"><mn>1</mn><mn>2</mn></mfrac>"#,
+            r#"<mfrac linethickness="medium"><mn>1</mn><mn>2</mn></mfrac>"#,
+            "<mfrac><mn>1</mn><mn>2</mn></mfrac>",
+        ] {
+            assert_eq!(
+                p(frac),
+                MathExpr::Frac(Box::new(num(1)), Box::new(num(2))),
+                "{frac} should stay a fraction",
+            );
+        }
+        // Binom and Frac with the same operands are NOT equal — the zero-bar carries meaning.
+        assert_ne!(
+            p(r#"<mfrac linethickness="0"><mn>1</mn><mn>2</mn></mfrac>"#),
+            p("<mfrac><mn>1</mn><mn>2</mn></mfrac>"),
+        );
     }
 
     #[test]
@@ -649,6 +694,7 @@ mod tests {
             "<mi>x</mi>",
             "<math><mn>1</mn><mo>+</mo><mn>2</mn></math>",
             "<mfrac><mn>1</mn><mn>2</mn></mfrac>",
+            r#"<mfrac linethickness="0"><mi>n</mi><mi>k</mi></mfrac>"#,
             "<msup><mi>x</mi><mn>2</mn></msup>",
             "<msqrt><mi>x</mi></msqrt>",
             "<math><mi>x</mi><mo>=</mo><mn>1</mn></math>",

--- a/code/packages/rust/mathml/src/parser.rs
+++ b/code/packages/rust/mathml/src/parser.rs
@@ -311,6 +311,25 @@ fn tag_attr(src: &[u8], span: (usize, usize), attr: &str) -> Option<String> {
     None
 }
 
+/// Is an `<mfrac>`'s `linethickness` value a ZERO thickness — i.e. a binomial-coefficient stack
+/// rather than a fraction? MathML thickness values are either a `<length>` (a number with an
+/// optional unit: `0`, `0pt`, `0.0em`, `2px`) or one of the keywords `thin`/`medium`/`thick`.
+/// Only a length whose numeric part is zero suppresses the bar; the keywords and any nonzero
+/// length are ordinary (non-zero) fractions, and an absent attribute (`None`) defaults to the
+/// normal bar. We read the leading numeric run (digits + `.`) and test it against zero, so every
+/// unit spelling of "zero" (`0`, `0pt`, `0.0em`, `0px`) is caught while `thin` — which has no
+/// numeric prefix — is not.
+fn linethickness_is_zero(value: Option<&str>) -> bool {
+    match value {
+        None => false,
+        Some(raw) => {
+            let s = raw.trim();
+            let num: String = s.chars().take_while(|c| c.is_ascii_digit() || *c == '.').collect();
+            !num.is_empty() && num.parse::<f64>().map(|n| n == 0.0).unwrap_or(false)
+        }
+    }
+}
+
 /// Decode entity references (`&name;`, `&#NN;`) inside an attribute value, reusing the same entity
 /// table as character data. Non-entity bytes pass through (lossy UTF-8, matching the lexer).
 fn decode_attr_value(raw: &[u8]) -> String {
@@ -477,7 +496,19 @@ impl Parser {
                 let mut it = args.into_iter();
                 let num = it.next().unwrap();
                 let den = it.next().unwrap();
-                Ok(Child::Expr(MathExpr::Frac(Box::new(num), Box::new(den))))
+                // A fraction whose bar has ZERO thickness (`linethickness="0"`) is MathML's
+                // encoding of a binomial coefficient "n choose k" — the same top-over-bottom stack
+                // with the division rule suppressed. It is exactly what LaTeX `\binom{n}{k}` /
+                // `{n \choose k}` export to, and it lowers to the neutral `Binom` node (distinct
+                // from `Frac`, the SAME as the latex frontend emits). Any nonzero or absent
+                // thickness — including the keyword widths `thin`/`medium`/`thick` — is an ordinary
+                // fraction. (`linethickness` is meaning-bearing here, so we re-read it from the
+                // start-tag span, the same way `<mfenced>` re-reads its `open`/`close` delimiters.)
+                if linethickness_is_zero(tag_attr(&self.src, span, "linethickness").as_deref()) {
+                    Ok(Child::Expr(MathExpr::Binom(Box::new(num), Box::new(den))))
+                } else {
+                    Ok(Child::Expr(MathExpr::Frac(Box::new(num), Box::new(den))))
+                }
             }
             "mroot" => {
                 let args = self.read_n_args(name, 2, depth)?;


### PR DESCRIPTION
## What

A `<mfrac>` whose fraction bar has **zero thickness** (`linethickness="0"`) is Presentation-MathML's encoding of a **binomial coefficient** "n choose k" — the same top-over-bottom stack with the division rule suppressed, and exactly what LaTeX `\binom{n}{k}` / `{n \choose k}` export to. It now lowers to the neutral `MathExpr::Binom` node (the **same** node the `latex` frontend already emits for `\binom`), distinct from `MathExpr::Frac`.

| MathML | → neutral `MathExpr` |
|--------|----------------------|
| `<mfrac><mn>1</mn><mn>2</mn></mfrac>` | `Frac(1, 2)` |
| `<mfrac linethickness="0"><mi>n</mi><mi>k</mi></mfrac>` | `Binom(n, k)` |

## How
- The `mfrac` arm re-reads `linethickness` from the start-tag byte span via the existing `tag_attr` helper (the **same** mechanism `<mfenced>` uses for its `open`/`close` delimiters — the lexer still discards presentation attributes).
- A small pure helper `linethickness_is_zero` takes the leading numeric run and parses it as `f64` to test for zero, so **every** length spelling of zero is caught (`0`, `0pt`, `0.0em`, `0px`) while the keyword thicknesses (`thin`/`medium`/`thick`), any nonzero length, and an absent attribute all stay an ordinary `Frac`.
- `capabilities()` now declares `binomials`, **closing the last shape gap vs the `latex` frontend**.

## Why it's safe / self-contained
- Downstream is unaffected: the `Binom` node already existed in `math-frontend` and is already lowered by the `adj-lang` adapter (write-once/read-everywhere).
- `#![forbid(unsafe_code)]` holds; helper is a single linear pass, no regex/recursion, `f64::parse` is total.

## Verification
- `cargo test` green across **mathml / math-frontend / latex / asciimath / unicode-math / adj-lang / adj-lang-cli**; `cargo clippy -p mathml` clean.
- New unit test covers all zero spellings, the keyword/nonzero/absent fraction cases, and `Binom ≠ Frac` with equal operands. A conformance sample is added so the declared capability is exercised by `check_frontend`.
- README + CHANGELOG updated; version 0.7.0 → 0.8.0.
- Security review: **PASSED** (no vulnerabilities).

🤖 Generated with [Claude Code](https://claude.com/claude-code)