### PR TITLE
test(closure-emitter): port CodePrinter ASCII-only escape cases (#88, CLOC12.144)

### DIFF
--- a/code/packages/rust/closure-emitter/CHANGELOG.md
+++ b/code/packages/rust/closure-emitter/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to the `coding-adventures-closure-emitter` crate will be documented in this file.
 
+## [0.18.15] - 2026-07-01
+
+### Test — CodePrinter ASCII-only escape port (#88, CLOC12.144)
+
+New upstream port `tests/upstream/code_printer_ascii_escape_test.rs` (registered
+as the `upstream_code_printer_ascii_escape` test target), covering the
+`--output_charset=US-ASCII` mode from `CodePrinterTest.testUnicode` — our
+`EmitOptions { ascii_only: true }` path (`escape_ascii_only`). The sibling
+`code_printer_string_escape_test.rs` pins the DEFAULT (non-ASCII passthrough)
+mode; this pins the distinct ASCII-only branch of `emit_string`.
+
+- **7 active `#[test]`s** (all pass on the first run — no new emitter bug):
+  printable ASCII verbatim; a Latin-1 accent (`é` → `é`); a BMP CJK
+  ideograph (`中` → `中`); an astral code point using the braced form
+  (`💩` → `{1F4A9}`); a control char (`U+0007` → ``); the named
+  `\n`/`\t` escapes still applying; and the `ascii_only`-always-double-quotes
+  rule (a value of two `"` prints `"\"\""`, not single-quoted).
+
+No library code changed — this release is test coverage plus docs.
+
 ## [0.18.14] - 2026-07-01
 
 ### Test — CodePrinter string-escape port (#88, CLOC12.143)

--- a/code/packages/rust/closure-emitter/Cargo.toml
+++ b/code/packages/rust/closure-emitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-emitter"
-version = "0.18.14"
+version = "0.18.15"
 edition = "2021"
 description = "JavaScript code emitter for the Closure Compiler clone. Per CLOC07's emit contract. Takes a finalized Program + sidecar and produces output JavaScript text + companion source map. Runs after every pass in the pipeline."
 
@@ -40,3 +40,7 @@ path = "tests/upstream/code_printer_string_escape_test.rs"
 [[test]]
 name = "upstream_code_printer_numbers"
 path = "tests/upstream/code_printer_numbers_test.rs"
+
+[[test]]
+name = "upstream_code_printer_ascii_escape"
+path = "tests/upstream/code_printer_ascii_escape_test.rs"

--- a/code/packages/rust/closure-emitter/tests/upstream/code_printer_ascii_escape_test.rs
+++ b/code/packages/rust/closure-emitter/tests/upstream/code_printer_ascii_escape_test.rs
@@ -1,0 +1,134 @@
+//! Ported from `CodePrinterTest.java` in `google/closure-compiler`,
+//! Apache-2.0. Upstream SHA: see `tests/upstream/UPSTREAM_SHA`.
+//!
+//! Translation policy: see
+//! `code/specs/CLOC12-upstream-test-suite-port.md`.
+//!
+//! # What this file covers
+//!
+//! Upstream `CodePrinterTest.testUnicode`-style output under the
+//! **`--output_charset=US-ASCII`** setting — the mode where every
+//! non-ASCII code point is escaped to a `\uXXXX` sequence so the
+//! output is pure ASCII. Our emitter models this as
+//! `EmitOptions { ascii_only: true }`, handled by `escape_ascii_only`.
+//! The sibling `code_printer_string_escape_test.rs` pins the DEFAULT
+//! (non-ASCII-passthrough) mode; this file pins the ASCII-only path,
+//! which is a distinct branch of `emit_string`.
+//!
+//! ## How the emitter escapes under `ascii_only` (recap)
+//!
+//! ```text
+//!   \  → \\        "  → \"        \n → \n    \r → \r    \t → \t
+//!   control (< U+0020)           → \uXXXX        (upper-case, 4 digits)
+//!   printable ASCII (0x20-0x7E)  → verbatim
+//!   non-ASCII, U+0080..=U+FFFF   → \uXXXX        (upper-case, 4 digits)
+//!   non-ASCII, > U+FFFF (astral) → \u{XXXXXX}    (upper-case, braces)
+//! ```
+//!
+//! `ascii_only` ALWAYS wraps in double quotes (unlike the default
+//! mode's quote-choice optimisation), escaping any inner `"`.
+
+use coding_adventures_closure_emitter::{emit, EmitOptions};
+use coding_adventures_correlation_vector::CVLog;
+use coding_adventures_javascript_ast::{
+    Expression, ExpressionStatement, Program, ProgramItem, SourceType, Statement, StringLiteral,
+};
+use coding_adventures_javascript_tokens::EsVersion;
+use coding_adventures_type_sidecar::Sidecar;
+
+// =====================================================================
+// Test-support helpers
+// =====================================================================
+
+fn string(v: &str) -> Expression {
+    Expression::StringLiteral(StringLiteral {
+        cv: None,
+        value: v.to_string(),
+        raw: format!("\"{}\"", v),
+    })
+}
+
+fn stmt(expr: Expression) -> ProgramItem {
+    ProgramItem::Statement(Statement::expression_statement(ExpressionStatement {
+        cv: None,
+        expression: expr,
+    }))
+}
+
+fn program_with(item: ProgramItem) -> Program {
+    Program::new_untraced(EsVersion::Es2025, SourceType::Module).with_body(vec![item])
+}
+
+/// Emit a program with `ascii_only` turned on.
+fn emit_ascii(prog: Program) -> String {
+    let sidecar = Sidecar::new();
+    let mut cv = CVLog::new(false);
+    let opts = EmitOptions {
+        ascii_only: true,
+        ..EmitOptions::default()
+    };
+    emit(&prog, &sidecar, &mut cv, &opts)
+        .expect("emit failed")
+        .code
+}
+
+/// Emit `expr` as a single statement under `ascii_only` and assert the
+/// resulting code equals `expected_emitted`.
+fn assert_ascii(expr: Expression, expected_emitted: &str) {
+    let code = emit_ascii(program_with(stmt(expr)));
+    assert_eq!(
+        code, expected_emitted,
+        "ascii_only emit output did not match expected\n  actual:   {:?}\n  expected: {:?}",
+        code, expected_emitted
+    );
+}
+
+// =====================================================================
+// Active — ascii_only escaping
+// =====================================================================
+
+/// Printable ASCII passes through untouched.
+#[test]
+fn printable_ascii_stays_verbatim() {
+    assert_ascii(string("abc XYZ 123 !~"), "\"abc XYZ 123 !~\";");
+}
+
+/// A Latin-1 accented letter (`U+00E9 é`) becomes `é` — upper-case,
+/// four hex digits.
+#[test]
+fn latin1_non_ascii_escapes_to_u_hex() {
+    assert_ascii(string("caf\u{e9}"), "\"caf\\u00E9\";");
+}
+
+/// A BMP CJK ideograph (`U+4E2D 中`) becomes `中`.
+#[test]
+fn bmp_non_ascii_escapes_to_u_hex() {
+    assert_ascii(string("\u{4e2d}"), "\"\\u4E2D\";");
+}
+
+/// An astral-plane code point (`U+1F4A9 💩`, above U+FFFF) uses the
+/// braced `\u{XXXXXX}` form rather than a surrogate pair.
+#[test]
+fn astral_code_point_uses_braced_escape() {
+    assert_ascii(string("\u{1f4a9}"), "\"\\u{1F4A9}\";");
+}
+
+/// Control characters still take the `\uXXXX` form (`U+0007` → ``).
+#[test]
+fn control_char_escapes_to_u_hex() {
+    assert_ascii(string("a\u{07}b"), "\"a\\u0007b\";");
+}
+
+/// The named short escapes still apply under `ascii_only`.
+#[test]
+fn named_escapes_still_apply() {
+    assert_ascii(string("a\nb\tc"), "\"a\\nb\\tc\";");
+}
+
+/// Unlike the default mode's quote-choice, `ascii_only` ALWAYS uses
+/// double quotes and escapes any inner `"` — a value of two double
+/// quotes prints as `"\"\""`, not single-quoted.
+#[test]
+fn ascii_only_always_double_quotes() {
+    assert_ascii(string("\"\""), "\"\\\"\\\"\";");
+}

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -1217,3 +1217,20 @@ historical context with status `RESOLVED` and a link to the fix PR.
 - **No `#[ignore]` placeholders** — every case the emitter handles today is an
   active conformance test. (The `ascii_only` `\uXXXX` escaping of printable
   non-ASCII is a separate `EmitOptions` path and is left for a follow-up port.)
+
+## CLOC12.144 — CodePrinter ASCII-only escape port (emitter)
+
+- **What it is:** the eleventh CLOC12 upstream port and the fourth into
+  `closure-emitter`. New file `tests/upstream/code_printer_ascii_escape_test.rs`,
+  registered as the `upstream_code_printer_ascii_escape` test target. It covers
+  upstream `CodePrinterTest.testUnicode`'s `--output_charset=US-ASCII` behavior
+  — our `EmitOptions { ascii_only: true }` path (`escape_ascii_only`), the
+  distinct sibling of the default-mode string-escape port (CLOC12.143).
+- **7 active `#[test]`s pass on the first run** (no new emitter bug): printable
+  ASCII verbatim, a Latin-1 accent (`é` → `é`), a BMP CJK ideograph
+  (`中` → `中`), an astral code point using the braced form (`💩` →
+  `\u{1F4A9}`), a control char (`U+0007` → ``), the named `\n`/`\t`
+  escapes still applying, and the `ascii_only`-always-double-quotes rule (a
+  value of two `"` prints `"\"\""`, not single-quoted).
+- **No `#[ignore]` placeholders.** The ASCII-only `\uXXXX` escaping that the
+  CLOC12.143 port noted as a follow-up is now covered here.


### PR DESCRIPTION
## Summary

Eleventh CLOC12 upstream port (#88), fourth into `closure-emitter`. New file `tests/upstream/code_printer_ascii_escape_test.rs` (registered as the `upstream_code_printer_ascii_escape` `[[test]]` target), covering the `--output_charset=US-ASCII` mode from `CodePrinterTest.testUnicode` — our `EmitOptions { ascii_only: true }` path (`escape_ascii_only`). The sibling `code_printer_string_escape_test.rs` (CLOC12.143) pins the DEFAULT non-ASCII-passthrough mode; this pins the distinct ASCII-only branch of `emit_string`.

## What's covered (7 active tests — all pass on first run, no new bug)

- printable ASCII passes through verbatim
- Latin-1 accent: `é` (U+00E9) → `é`
- BMP CJK ideograph: `中` (U+4E2D) → `中`
- astral code point uses the braced form: `💩` (U+1F4A9) → `\u{1F4A9}`
- control char: `U+0007` → ``
- named `\n`/`\t` escapes still apply
- `ascii_only` always double-quotes (unlike default-mode quote-choice): a value of two `"` prints `"\"\""`, not single-quoted

## Scope / safety

- **Test-only** — no library/`src` code changed. Bumps `closure-emitter` 0.18.14 → 0.18.15; documents the port at CLOC12.144 in `code/specs/CLOC12-gaps.md`.
- Full `closure-emitter` suite green (96 lib + all upstream port targets). No `#[ignore]` placeholders — the ascii_only escaping the CLOC12.143 port left as a follow-up is now covered.
- Inline security review: PASSED (no user input, no `unsafe`, no I/O; assertions over hard-coded string-literal AST).

🤖 Generated with [Claude Code](https://claude.com/claude-code)