### PR TITLE
feat(adj-ladder): rung-25 lipid indices (TC:HDL, TG:HDL, non-HDL fraction) constant-free rung

### DIFF
--- a/code/specs/data/adj-ladder/rung25_lipid_indices/gen_items.py
+++ b/code/specs/data/adj-ladder/rung25_lipid_indices/gen_items.py
@@ -1,0 +1,171 @@
+"""Generate rung-25 (lipid indices) items.json for the ADJ-LADDER.
+
+Rung 25 opens the **lipid-panel** on the quantitative band — the cardiovascular-risk arithmetic of a
+fasting lipid profile (atherogenic ratios, insulin-resistance surrogate, non-HDL cholesterol) — using
+the same contamination-safe shape as the oxygen rung (24) and the iron rung (23): a small table of
+*observed* laboratory quantities and a tight family of mutually-confusable formulas built **only from
+those observed quantities** (no numeric literal anywhere in any program), so nothing structural can
+leak.
+
+The clinical setup is a single fasting lipid panel. Three quantities are measured:
+
+  TC    total cholesterol     (mg/dL)
+  HDL   HDL cholesterol       (mg/dL) — the "good" fraction
+  TG    triglycerides         (mg/dL)
+
+Three textbook lipid indices fall out as pure functions of the observed quantities — no constant
+required. Two are **pure ratios** and one puts a **derived difference in the numerator** (non-HDL
+cholesterol = TC − HDL, computed from its two observed components, never a constant — the same
+subtraction-in-numerator shape the oxygen rung used):
+
+  TC:HDL RATIO         TC / HDL            [ atherogenic / cardiac-risk ratio; higher = worse ]
+  TG:HDL RATIO         TG / HDL            [ insulin-resistance surrogate; higher = worse ]
+  NON-HDL FRACTION     (TC − HDL) / TC     [ =non-HDL/TC; the atherogenic-cholesterol share ]
+
+Each index is a `compute_dimensioned` program (observe the three quantities + `let answer = formula`);
+the ADJ engine carries the arithmetic and the harness reads the scalar via the existing
+`compute_dimensioned` extractor — no harness/engine change, exactly as rungs 8/16/18/19/20/21/22/23/24.
+This exercises the engine across **division AND an inner subtraction-in-parentheses** (non-HDL =
+TC − HDL) on a fresh lipid-panel stem, mixing two pure ratios with one difference-in-numerator index.
+
+Contamination-safe by construction: every formula is built only from the three observed quantities via
+`/`, `−`, and grouping `( )` — **no structural constants** (non-HDL is computed, not observed, so no
+x-factor appears) — so every program literal is grounded in the stem. The observed quantities carry
+**digit-free identifiers** (`total_cholesterol`, `hdl`, `triglycerides`) so no numeral hides inside a
+variable name. The five options are a tight family over the same quantities: the three real indices plus
+the two classic slips —
+
+  HDL / TC             the **inverse** TC:HDL ratio (the HDL fraction, written upside-down), and
+  TC / TG              the total-cholesterol-to-triglyceride ratio (a plausible but non-standard mix),
+
+which are exactly the mistakes a student makes. Gold rotates A-E by index.
+
+Note on table choice: the five family values can collide for special quantity ratios. The tables below
+are chosen so the five family values are pairwise distinct — with a comfortable margin — for every item,
+asserted at build time. HDL is always below TC (a physiologic panel), so the non-HDL fraction stays a
+fraction in (0, 1).
+"""
+import json
+
+LETTERS = ["A", "B", "C", "D", "E"]
+
+# (TC, HDL, TG) observed quantities, all mg/dL. The five index-family values are asserted
+# pairwise-distinct (with margin) below. TC > HDL for every row (non-HDL fraction in (0, 1)).
+#   TC  = total cholesterol
+#   HDL = HDL cholesterol
+#   TG  = triglycerides
+TABLES = [
+    (200, 50, 150),
+    (240, 40, 200),
+    (180, 60, 90),
+    (220, 55, 100),
+    (150, 50, 100),
+    (210, 42, 168),
+    (250, 50, 125),
+]
+
+# The option family (5 members), all built from the observed quantities via `/`, `-`, grouping. Every
+# identifier is DIGIT-FREE. key -> (display name, formula-as-adj). Only the first three are *queried*
+# (used as gold); all five always appear as the options.
+FAMILY = [
+    ("tc_hdl", "total-cholesterol-to-HDL ratio", "total_cholesterol / hdl"),
+    ("tg_hdl", "triglyceride-to-HDL ratio", "triglycerides / hdl"),
+    ("non_hdl_frac", "non-HDL fraction of total cholesterol",
+     "(total_cholesterol - hdl) / total_cholesterol"),
+    ("hdl_tc", "HDL fraction of total cholesterol", "hdl / total_cholesterol"),
+    ("tc_tg", "total-cholesterol-to-triglyceride ratio", "total_cholesterol / triglycerides"),
+]
+QUERIED = ["tc_hdl", "tg_hdl", "non_hdl_frac"]
+ORDER = [k for k, _, _ in FAMILY]
+
+
+def scalar(v):
+    return {"value": v, "unit": "scalar"}
+
+
+def family_values(tc, hdl, tg):
+    # Operation order mirrors the ADJ program exactly, so the Python option value and the engine
+    # result are the same IEEE-double (well within the harness's 1e-9 match tolerance).
+    return {
+        "tc_hdl": tc / hdl,
+        "tg_hdl": tg / hdl,
+        "non_hdl_frac": (tc - hdl) / tc,
+        "hdl_tc": hdl / tc,
+        "tc_tg": tc / tg,
+    }
+
+
+def build():
+    name_of = {k: nm for k, nm, _ in FAMILY}
+    formula_of = {k: f for k, _, f in FAMILY}
+    items = []
+    idx = 0
+    for tc, hdl, tg in TABLES:
+        assert tc > hdl, (tc, hdl)  # non-HDL fraction must be a fraction in (0, 1)
+        fv = family_values(tc, hdl, tg)
+        # Pairwise-distinct with a comfortable margin so the harness never sees two options
+        # matching the gold value within its 1e-9 tolerance.
+        vals = [fv[k] for k in ORDER]
+        for i in range(len(vals)):
+            for j in range(i + 1, len(vals)):
+                assert abs(vals[i] - vals[j]) > 1e-6, (tc, hdl, tg, ORDER[i], ORDER[j], fv)
+        for key in QUERIED:
+            gold_val = fv[key]
+            gold_pos = idx % 5
+            others = [fv[k] for k in ORDER if abs(fv[k] - gold_val) > 1e-12]
+            opts_vals = others[:]
+            opts_vals.insert(gold_pos, gold_val)
+            opts_vals = opts_vals[:5]
+            if abs(opts_vals[gold_pos] - gold_val) > 1e-12:
+                opts_vals[gold_pos] = gold_val
+            assert len({round(v, 9) for v in opts_vals}) == 5, (key, tc, hdl, tg, opts_vals)
+            options = {LETTERS[i]: scalar(opts_vals[i]) for i in range(5)}
+            items.append({
+                "id": f"r25lip-{idx + 1:02d}",
+                "qtype": "lipid_index",
+                "stem": (
+                    f"A fasting lipid panel shows total cholesterol {tc} mg/dL, HDL cholesterol {hdl} "
+                    f"mg/dL, and triglycerides {tg} mg/dL. What is the patient's {name_of[key]}?"
+                ),
+                "program": (
+                    f"observe total_cholesterol({tc})\n"
+                    f"observe hdl({hdl})\n"
+                    f"observe triglycerides({tg})\n"
+                    f"let answer = {formula_of[key]}\n"
+                    "? answer\n"
+                ),
+                "answer_from": {"type": "compute_dimensioned", "name": "answer"},
+                "options": options,
+                "gold_letter": LETTERS[gold_pos],
+            })
+            idx += 1
+    return {
+        "description": (
+            "ADJ-LADDER rung 25 — lipid indices from a single fasting lipid panel (a NEW panel: lipid "
+            "metabolism / cardiovascular risk). From three stated quantities (total cholesterol TC, HDL "
+            "cholesterol HDL, triglycerides TG) compute the TC:HDL atherogenic ratio (TC/HDL), the TG:HDL "
+            "insulin-resistance surrogate (TG/HDL), or the non-HDL fraction ((TC-HDL)/TC). Each item is a "
+            "compute_dimensioned program (observe the three quantities, let answer = formula); the ADJ "
+            "engine carries the arithmetic — two pure divisions AND an inner difference-in-parentheses for "
+            "the non-HDL cholesterol (non-HDL = TC - HDL) — and the harness matches the scalar to the "
+            "printed options. Contamination-safe: every index is built only from the three observed "
+            "quantities via /, -, and grouping — no constant leaks (non-HDL is derived from its components, "
+            "not observed) — and the observed quantities carry digit-free identifiers so no numeral hides "
+            "inside a variable name. The five options are a family over the same quantities, so the "
+            "distractors are exactly the slips students make: the inverse TC:HDL ratio (HDL/TC, the HDL "
+            "fraction written upside-down) and the total-cholesterol-to-triglyceride ratio (TC/TG, a "
+            "plausible but non-standard mix)."
+        ),
+        "items": items,
+    }
+
+
+if __name__ == "__main__":
+    doc = build()
+    with open("items.json", "w") as f:
+        json.dump(doc, f, indent=2)
+        f.write("\n")
+    print("wrote items.json:", len(doc["items"]), "items")
+    for it in doc["items"]:
+        print(it["id"], it["qtype"], "gold", it["gold_letter"],
+              "=", round(it["options"][it["gold_letter"]]["value"], 4))

--- a/code/specs/data/adj-ladder/rung25_lipid_indices/items.json
+++ b/code/specs/data/adj-ladder/rung25_lipid_indices/items.json
@@ -1,0 +1,698 @@
+{
+  "description": "ADJ-LADDER rung 25 \u2014 lipid indices from a single fasting lipid panel (a NEW panel: lipid metabolism / cardiovascular risk). From three stated quantities (total cholesterol TC, HDL cholesterol HDL, triglycerides TG) compute the TC:HDL atherogenic ratio (TC/HDL), the TG:HDL insulin-resistance surrogate (TG/HDL), or the non-HDL fraction ((TC-HDL)/TC). Each item is a compute_dimensioned program (observe the three quantities, let answer = formula); the ADJ engine carries the arithmetic \u2014 two pure divisions AND an inner difference-in-parentheses for the non-HDL cholesterol (non-HDL = TC - HDL) \u2014 and the harness matches the scalar to the printed options. Contamination-safe: every index is built only from the three observed quantities via /, -, and grouping \u2014 no constant leaks (non-HDL is derived from its components, not observed) \u2014 and the observed quantities carry digit-free identifiers so no numeral hides inside a variable name. The five options are a family over the same quantities, so the distractors are exactly the slips students make: the inverse TC:HDL ratio (HDL/TC, the HDL fraction written upside-down) and the total-cholesterol-to-triglyceride ratio (TC/TG, a plausible but non-standard mix).",
+  "items": [
+    {
+      "id": "r25lip-01",
+      "qtype": "lipid_index",
+      "stem": "A fasting lipid panel shows total cholesterol 200 mg/dL, HDL cholesterol 50 mg/dL, and triglycerides 150 mg/dL. What is the patient's total-cholesterol-to-HDL ratio?",
+      "program": "observe total_cholesterol(200)\nobserve hdl(50)\nobserve triglycerides(150)\nlet answer = total_cholesterol / hdl\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 4.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 3.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.75,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.25,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1.3333333333333333,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r25lip-02",
+      "qtype": "lipid_index",
+      "stem": "A fasting lipid panel shows total cholesterol 200 mg/dL, HDL cholesterol 50 mg/dL, and triglycerides 150 mg/dL. What is the patient's triglyceride-to-HDL ratio?",
+      "program": "observe total_cholesterol(200)\nobserve hdl(50)\nobserve triglycerides(150)\nlet answer = triglycerides / hdl\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 4.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 3.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.75,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.25,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1.3333333333333333,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r25lip-03",
+      "qtype": "lipid_index",
+      "stem": "A fasting lipid panel shows total cholesterol 200 mg/dL, HDL cholesterol 50 mg/dL, and triglycerides 150 mg/dL. What is the patient's non-HDL fraction of total cholesterol?",
+      "program": "observe total_cholesterol(200)\nobserve hdl(50)\nobserve triglycerides(150)\nlet answer = (total_cholesterol - hdl) / total_cholesterol\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 4.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 3.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.75,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.25,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1.3333333333333333,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r25lip-04",
+      "qtype": "lipid_index",
+      "stem": "A fasting lipid panel shows total cholesterol 240 mg/dL, HDL cholesterol 40 mg/dL, and triglycerides 200 mg/dL. What is the patient's total-cholesterol-to-HDL ratio?",
+      "program": "observe total_cholesterol(240)\nobserve hdl(40)\nobserve triglycerides(200)\nlet answer = total_cholesterol / hdl\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 5.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 0.8333333333333334,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.16666666666666666,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 6.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1.2,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r25lip-05",
+      "qtype": "lipid_index",
+      "stem": "A fasting lipid panel shows total cholesterol 240 mg/dL, HDL cholesterol 40 mg/dL, and triglycerides 200 mg/dL. What is the patient's triglyceride-to-HDL ratio?",
+      "program": "observe total_cholesterol(240)\nobserve hdl(40)\nobserve triglycerides(200)\nlet answer = triglycerides / hdl\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 6.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 0.8333333333333334,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.16666666666666666,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 1.2,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 5.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r25lip-06",
+      "qtype": "lipid_index",
+      "stem": "A fasting lipid panel shows total cholesterol 240 mg/dL, HDL cholesterol 40 mg/dL, and triglycerides 200 mg/dL. What is the patient's non-HDL fraction of total cholesterol?",
+      "program": "observe total_cholesterol(240)\nobserve hdl(40)\nobserve triglycerides(200)\nlet answer = (total_cholesterol - hdl) / total_cholesterol\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 0.8333333333333334,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 5.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.16666666666666666,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1.2,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r25lip-07",
+      "qtype": "lipid_index",
+      "stem": "A fasting lipid panel shows total cholesterol 180 mg/dL, HDL cholesterol 60 mg/dL, and triglycerides 90 mg/dL. What is the patient's total-cholesterol-to-HDL ratio?",
+      "program": "observe total_cholesterol(180)\nobserve hdl(60)\nobserve triglycerides(90)\nlet answer = total_cholesterol / hdl\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 1.5,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 3.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.6666666666666666,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.3333333333333333,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 2.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r25lip-08",
+      "qtype": "lipid_index",
+      "stem": "A fasting lipid panel shows total cholesterol 180 mg/dL, HDL cholesterol 60 mg/dL, and triglycerides 90 mg/dL. What is the patient's triglyceride-to-HDL ratio?",
+      "program": "observe total_cholesterol(180)\nobserve hdl(60)\nobserve triglycerides(90)\nlet answer = triglycerides / hdl\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 0.6666666666666666,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 1.5,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.3333333333333333,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 2.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r25lip-09",
+      "qtype": "lipid_index",
+      "stem": "A fasting lipid panel shows total cholesterol 180 mg/dL, HDL cholesterol 60 mg/dL, and triglycerides 90 mg/dL. What is the patient's non-HDL fraction of total cholesterol?",
+      "program": "observe total_cholesterol(180)\nobserve hdl(60)\nobserve triglycerides(90)\nlet answer = (total_cholesterol - hdl) / total_cholesterol\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 1.5,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.3333333333333333,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.6666666666666666,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 2.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r25lip-10",
+      "qtype": "lipid_index",
+      "stem": "A fasting lipid panel shows total cholesterol 220 mg/dL, HDL cholesterol 55 mg/dL, and triglycerides 100 mg/dL. What is the patient's total-cholesterol-to-HDL ratio?",
+      "program": "observe total_cholesterol(220)\nobserve hdl(55)\nobserve triglycerides(100)\nlet answer = total_cholesterol / hdl\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 1.8181818181818181,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 0.75,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.25,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 2.2,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 4.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r25lip-11",
+      "qtype": "lipid_index",
+      "stem": "A fasting lipid panel shows total cholesterol 220 mg/dL, HDL cholesterol 55 mg/dL, and triglycerides 100 mg/dL. What is the patient's triglyceride-to-HDL ratio?",
+      "program": "observe total_cholesterol(220)\nobserve hdl(55)\nobserve triglycerides(100)\nlet answer = triglycerides / hdl\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 1.8181818181818181,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 4.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.75,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.25,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 2.2,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r25lip-12",
+      "qtype": "lipid_index",
+      "stem": "A fasting lipid panel shows total cholesterol 220 mg/dL, HDL cholesterol 55 mg/dL, and triglycerides 100 mg/dL. What is the patient's non-HDL fraction of total cholesterol?",
+      "program": "observe total_cholesterol(220)\nobserve hdl(55)\nobserve triglycerides(100)\nlet answer = (total_cholesterol - hdl) / total_cholesterol\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 4.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 0.75,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 1.8181818181818181,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.25,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 2.2,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r25lip-13",
+      "qtype": "lipid_index",
+      "stem": "A fasting lipid panel shows total cholesterol 150 mg/dL, HDL cholesterol 50 mg/dL, and triglycerides 100 mg/dL. What is the patient's total-cholesterol-to-HDL ratio?",
+      "program": "observe total_cholesterol(150)\nobserve hdl(50)\nobserve triglycerides(100)\nlet answer = total_cholesterol / hdl\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 2.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 0.6666666666666666,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 3.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.3333333333333333,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1.5,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r25lip-14",
+      "qtype": "lipid_index",
+      "stem": "A fasting lipid panel shows total cholesterol 150 mg/dL, HDL cholesterol 50 mg/dL, and triglycerides 100 mg/dL. What is the patient's triglyceride-to-HDL ratio?",
+      "program": "observe total_cholesterol(150)\nobserve hdl(50)\nobserve triglycerides(100)\nlet answer = triglycerides / hdl\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 0.6666666666666666,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.3333333333333333,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 2.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1.5,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r25lip-15",
+      "qtype": "lipid_index",
+      "stem": "A fasting lipid panel shows total cholesterol 150 mg/dL, HDL cholesterol 50 mg/dL, and triglycerides 100 mg/dL. What is the patient's non-HDL fraction of total cholesterol?",
+      "program": "observe total_cholesterol(150)\nobserve hdl(50)\nobserve triglycerides(100)\nlet answer = (total_cholesterol - hdl) / total_cholesterol\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.3333333333333333,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 1.5,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.6666666666666666,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r25lip-16",
+      "qtype": "lipid_index",
+      "stem": "A fasting lipid panel shows total cholesterol 210 mg/dL, HDL cholesterol 42 mg/dL, and triglycerides 168 mg/dL. What is the patient's total-cholesterol-to-HDL ratio?",
+      "program": "observe total_cholesterol(210)\nobserve hdl(42)\nobserve triglycerides(168)\nlet answer = total_cholesterol / hdl\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 5.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 4.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.8,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.2,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1.25,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r25lip-17",
+      "qtype": "lipid_index",
+      "stem": "A fasting lipid panel shows total cholesterol 210 mg/dL, HDL cholesterol 42 mg/dL, and triglycerides 168 mg/dL. What is the patient's triglyceride-to-HDL ratio?",
+      "program": "observe total_cholesterol(210)\nobserve hdl(42)\nobserve triglycerides(168)\nlet answer = triglycerides / hdl\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 5.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 4.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.8,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.2,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1.25,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r25lip-18",
+      "qtype": "lipid_index",
+      "stem": "A fasting lipid panel shows total cholesterol 210 mg/dL, HDL cholesterol 42 mg/dL, and triglycerides 168 mg/dL. What is the patient's non-HDL fraction of total cholesterol?",
+      "program": "observe total_cholesterol(210)\nobserve hdl(42)\nobserve triglycerides(168)\nlet answer = (total_cholesterol - hdl) / total_cholesterol\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 5.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 4.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.8,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.2,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1.25,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r25lip-19",
+      "qtype": "lipid_index",
+      "stem": "A fasting lipid panel shows total cholesterol 250 mg/dL, HDL cholesterol 50 mg/dL, and triglycerides 125 mg/dL. What is the patient's total-cholesterol-to-HDL ratio?",
+      "program": "observe total_cholesterol(250)\nobserve hdl(50)\nobserve triglycerides(125)\nlet answer = total_cholesterol / hdl\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 2.5,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 0.8,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.2,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 5.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 2.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r25lip-20",
+      "qtype": "lipid_index",
+      "stem": "A fasting lipid panel shows total cholesterol 250 mg/dL, HDL cholesterol 50 mg/dL, and triglycerides 125 mg/dL. What is the patient's triglyceride-to-HDL ratio?",
+      "program": "observe total_cholesterol(250)\nobserve hdl(50)\nobserve triglycerides(125)\nlet answer = triglycerides / hdl\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 5.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 0.8,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.2,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 2.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 2.5,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r25lip-21",
+      "qtype": "lipid_index",
+      "stem": "A fasting lipid panel shows total cholesterol 250 mg/dL, HDL cholesterol 50 mg/dL, and triglycerides 125 mg/dL. What is the patient's non-HDL fraction of total cholesterol?",
+      "program": "observe total_cholesterol(250)\nobserve hdl(50)\nobserve triglycerides(125)\nlet answer = (total_cholesterol - hdl) / total_cholesterol\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 0.8,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 5.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 2.5,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.2,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 2.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    }
+  ]
+}

--- a/code/specs/data/adj-ladder/test_ladder_eval.py
+++ b/code/specs/data/adj-ladder/test_ladder_eval.py
@@ -62,6 +62,7 @@ SELF_CONTAINED_RUNGS = (
     "rung22_thyroid_indices",
     "rung23_iron_studies",
     "rung24_oxygen_extraction",
+    "rung25_lipid_indices",
 )
 
 


### PR DESCRIPTION
## What

ADJ-LADDER **rung-25 — lipid indices**, a new-organ constant-free `compute_dimensioned` rung. Opens **lipid metabolism / cardiovascular risk** (the fasting lipid panel) and **mixes two pure ratios with one subtraction-in-numerator** index (reinforcing rung-24's `(a − b)/a` shape on a fresh panel).

From three observed lipid quantities — total cholesterol `TC`, HDL cholesterol `HDL`, triglycerides `TG`:

| index | formula |
|-------|---------|
| TC:HDL ratio (atherogenic) | `TC / HDL` |
| TG:HDL ratio (insulin-resistance surrogate) | `TG / HDL` |
| non-HDL fraction | `(TC − HDL) / TC` |

Non-HDL cholesterol `(TC − HDL)` is **derived** (never observed), so every index is built only from the three observed quantities via `/`, `−`, and grouping — **no structural constant leaks**. Exercises the engine across division **and** an inner difference-in-parentheses.

## Contamination-safety
- Every program literal is one of the three stem values.
- **Digit-free identifiers** (`total_cholesterol` / `hdl` / `triglycerides`) — no numeral hides inside a variable name.
- 5-option family over the same quantities; distractors are the classic slips: the inverse TC:HDL ratio (`HDL/TC`, upside-down HDL fraction) and `TC/TG` (a plausible non-standard mix).
- Gold rotates A–E; 7 tables × 3 queried = **21 items**; `TC > HDL` enforced; five family values asserted pairwise-distinct with margin at build.

## Verification
- Registered `rung25_lipid_indices` in `SELF_CONTAINED_RUNGS`; gate **green (3/3)** — engine selects every gold (0 wrong / 0 abstain), contamination clean, items valid.
- **No harness/engine change** — reuses the existing `compute_dimensioned` extractor, exactly as rungs 8/16/17/18/19/20/21/22/23/24.
- Security review: **PASSED** (data-only generator; no eval/injection/path/DoS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)