### PR TITLE
test(rename): port RenameVars upstream suite (#88, CLOC12.145)

### DIFF
--- a/code/packages/rust/closure-pass-rename/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename` crate will be documented in this file.
 
+## [0.11.0] - 2026-07-01
+
+### Added — upstream `RenameVarsTest.java` conformance port (#88, CLOC12.145)
+
+The **first** CLOC12 upstream-test port into this crate. New file
+`tests/upstream/rename_vars_test.rs` (registered as the `upstream_rename_vars`
+test target) reshapes upstream `RenameVarsTest.java` onto our surface, driving
+the **real** source → `grammar_to_program` bridge → `RenamePass` → `emit`
+roundtrip — the exact chain closurec's SIMPLE level uses — so each case is
+`assert_eq!(rename(src), expected)` on emitted JS.
+
+- **12 active `#[test]`s pass on the first run** (no new rename defect): leaf
+  parameter and local `var`/`let`/`const` renaming at declaration + every use
+  site; multiple params distinct; param+local together; reserved-name
+  avoidance (a fresh short name never captures a referenced free global);
+  property access and non-computed object keys never renamed; computed member
+  index renamed; single-char names left alone; and two soundness guards (catch
+  bindings reserved, and a name declared twice is skipped).
+- **4 `#[ignore = "blocked on gap-NNN"]` placeholders** pin the whole-program
+  `RenameVars` behaviors closurec deliberately splits out or defers —
+  gap-144 (globals, owned by `rename-globals`), gap-145 (non-leaf function
+  params), gap-146 (function declaration names), gap-147 (frequency-biased
+  name allocation). Each is pinned to `code/specs/CLOC12-gaps.md`.
+
+This is a **test-only** change: no `src/` file is touched, so there is no
+emitter/pass ripple into downstream consumers. Scaffolding files
+`tests/upstream/{UPSTREAM_SHA,ATTRIBUTION.md}` were added per the CLOC12 port
+convention.
+
 ## [0.10.0] - 2026-06-30
 
 ### Added — correlation-vector rename provenance (#89)

--- a/code/packages/rust/closure-pass-rename/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 description = "Variable renaming pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Replaces non-exported binding names with shorter identifiers to reduce output size while preserving externally-visible names and semantics."
 
@@ -18,3 +18,10 @@ coding-adventures-javascript-tokens = { path = "../javascript-tokens" }
 # actual AST shape the parser produces (not hand-built ASTs).
 coding-adventures-javascript-parser = { path = "../javascript-parser" }
 coding-adventures-closure-emitter = { path = "../closure-emitter" }
+
+# Upstream-test ports live under `tests/upstream/`; Cargo only
+# auto-discovers `tests/*.rs` one level deep, so each ported file needs
+# an explicit `[[test]]` entry. Per CLOC12.01 §3.
+[[test]]
+name = "upstream_rename_vars"
+path = "tests/upstream/rename_vars_test.rs"

--- a/code/packages/rust/closure-pass-rename/README.md
+++ b/code/packages/rust/closure-pass-rename/README.md
@@ -104,6 +104,23 @@ has decided which functions stay. Renaming earlier wastes work on
 bindings that'll get deleted and makes the inliner's heuristic
 harder.
 
+## Upstream conformance tests
+
+`tests/upstream/` ports Google Closure Compiler tests (Apache-2.0; see
+`ATTRIBUTION.md` and `UPSTREAM_SHA`), per the CLOC12 test-port convention:
+
+- `rename_vars_test.rs` — `RenameVarsTest.java`. Drives the real source →
+  bridge → `RenamePass` → emit roundtrip and pins the local-renaming
+  behaviors this pass performs (leaf parameter and `var`/`let`/`const` local
+  renaming, reserved-name avoidance, property/object-key preservation, and the
+  catch-binding / redeclaration soundness guards). **12 active `#[test]`s**
+  plus **4 `#[ignore]` placeholders** for the whole-program `RenameVars`
+  behaviors closurec splits out or defers (globals → `rename-globals`, non-leaf
+  function params, function-declaration names, frequency-biased allocation),
+  each pinned to gap-144 … gap-147 in `code/specs/CLOC12-gaps.md`. Run with
+  `cargo test --test upstream_rename_vars` (add `--include-ignored` to measure
+  gap progress).
+
 ## Dependency whitelist
 
 - `coding-adventures-closure-pass-pipeline` — `Pass` trait + types.

--- a/code/packages/rust/closure-pass-rename/tests/upstream/ATTRIBUTION.md
+++ b/code/packages/rust/closure-pass-rename/tests/upstream/ATTRIBUTION.md
@@ -1,0 +1,71 @@
+# Attribution
+
+Tests in this directory are ported from the Google Closure Compiler
+under the Apache License, Version 2.0:
+
+    https://github.com/google/closure-compiler
+    LICENSE: https://www.apache.org/licenses/LICENSE-2.0
+
+## Files ported
+
+- `rename_vars_test.rs`
+    - upstream: `test/com/google/javascript/jscomp/RenameVarsTest.java`
+    - tracked commit: see `UPSTREAM_SHA`
+
+## Translation notes
+
+Twelfth port under CLOC12 (after constant-fold ×2, dce, fold-control-flow,
+inline, remove-unused-vars, rename-globals, rename-properties, and the
+emitter CodePrinter ×4 ports). Per CLOC12 §6, each upstream Java test file
+maps to one Rust file in the matching pass crate's `tests/upstream/`
+directory. This is the **first** port into `closure-pass-rename`.
+
+Unlike the hand-built-AST ports (`dce`, `remove-unused-vars`), the rename
+crate already carries `javascript-parser` + `closure-emitter` as
+dev-dependencies, so this port drives the **real** source →
+`grammar_to_program` bridge → `RenamePass` → `emit` roundtrip — the exact
+chain closurec's SIMPLE level uses. Each case is `assert_eq!(rename(src),
+expected)` on the emitted string, mirroring upstream's
+`test("var x=1; x", "var a=1; a")` shape (modulo the emitter's
+minified-but-spaced output: binary operators keep spaces and function
+declarations get a trailing `;`).
+
+### What our pass supports (active `#[test]`s)
+
+Upstream `RenameVars` is a single whole-program renamer that shortens
+**every** non-externed binding — globals, all nested function scopes, and
+function *names* — using a frequency-biased name generator so the most
+common identifiers get the shortest names. closurec deliberately **splits**
+that responsibility: `RenamePass` (this crate) is the conservative,
+provably-sound **local** renamer — it shortens parameters and uniquely-bound
+`var`/`let`/`const` locals of **leaf** functions (no nested functions),
+while global renaming lives in the separate `rename-globals` pass (ADVANCED
+only). The active cases pin the local-renaming behaviors that correspond to
+upstream `RenameVars` intent restricted to a single leaf scope:
+
+- leaf parameter and local `var`/`let`/`const` renaming, at declaration and
+  every use site (upstream `testRenameSimple` / `testRenameLocals`);
+- reserved-name avoidance — a fresh short name never captures a referenced
+  free global (upstream `testRenameLocalsWithNamesReservedForGlobals`);
+- property names and non-computed object keys are never renamed (they are
+  not variable references);
+- soundness guards that upstream gets "for free" from full scope analysis
+  but which we enforce explicitly: catch bindings are reserved, a name
+  declared twice is skipped, single-char names are left alone.
+
+### What we do NOT do yet (`#[ignore = "blocked on gap-NNN"]`)
+
+- **gap-144** — rename **global** variables in this pass. closurec routes
+  globals through `rename-globals`; upstream `RenameVars` renames them in
+  one sweep (`testRenameGlobals`).
+- **gap-145** — rename parameters/locals of **non-leaf** (nesting)
+  functions (`testRenameNested`-style whole-program renaming).
+- **gap-146** — rename **function declaration names** themselves
+  (upstream shortens `function longName(){}` → `function a(){}`).
+- **gap-147** — **frequency-biased** name allocation: upstream orders the
+  generated names so the most-referenced variable gets the 1-char name
+  (`testBias*`); ours allocates in declaration order.
+
+Each ignored placeholder is pinned to a `gap-NNN` entry in
+`code/specs/CLOC12-gaps.md`; running with `--include-ignored` measures
+progress as those gaps close.

--- a/code/packages/rust/closure-pass-rename/tests/upstream/UPSTREAM_SHA
+++ b/code/packages/rust/closure-pass-rename/tests/upstream/UPSTREAM_SHA
@@ -1,0 +1,13 @@
+# UPSTREAM_SHA
+#
+# Tracks google/closure-compiler at this commit. Every Rust file in
+# tests/upstream/ was ported from a Java file at this snapshot.
+#
+# Upgrade policy: bump this SHA only in a dedicated PR that re-ports
+# every Java source listed in ATTRIBUTION.md, diff-checks against the
+# previous port, and explicitly handles added / removed / renamed
+# tests per CLOC12 §4.
+
+commit:  5bb35ec1245dc1d3557481e5f8b4db344bcd1e6b
+date:    2026-05-28
+url:     https://github.com/google/closure-compiler/tree/5bb35ec1245dc1d3557481e5f8b4db344bcd1e6b

--- a/code/packages/rust/closure-pass-rename/tests/upstream/rename_vars_test.rs
+++ b/code/packages/rust/closure-pass-rename/tests/upstream/rename_vars_test.rs
@@ -1,0 +1,256 @@
+//! Ported from `RenameVarsTest.java` in `google/closure-compiler`,
+//! Apache-2.0. Upstream SHA: see `tests/upstream/UPSTREAM_SHA`.
+//!
+//! Translation policy: see
+//! `code/specs/CLOC12-upstream-test-suite-port.md`.
+//!
+//! # What this file covers
+//!
+//! The **first** CLOC12 port into `closure-pass-rename`. Upstream
+//! `RenameVars` is a whole-program variable renamer: it shortens every
+//! non-externed binding — globals, all nested function scopes, and the
+//! function *names* themselves — with a frequency-biased name generator.
+//!
+//! closurec deliberately **splits** that job. `RenamePass` (this crate)
+//! is the conservative, provably-sound **local** renamer: it shortens
+//! parameters and uniquely-bound `var`/`let`/`const` locals of **leaf**
+//! functions (functions with no nested function), leaving globals to the
+//! separate `rename-globals` pass. So this port mirrors upstream
+//! `RenameVars` intent *restricted to a single leaf scope* for the
+//! active cases, and pins the remaining whole-program behaviors as
+//! `#[ignore = "blocked on gap-NNN"]` placeholders.
+//!
+//! ## Harness
+//!
+//! The rename crate carries `javascript-parser` + `closure-emitter` as
+//! dev-dependencies, so — unlike the hand-built-AST `dce` /
+//! `remove-unused-vars` ports — these cases drive the **real** source →
+//! `grammar_to_program` bridge → `RenamePass` → `emit` roundtrip, the
+//! exact chain closurec's SIMPLE level uses. Each case is
+//! `assert_eq!(rename(src), expected)` on the emitted string.
+//!
+//! NOTE on whitespace: assertions are against raw `closure-emitter`
+//! output — binary operators keep spaces and function declarations get a
+//! trailing `;`. What the port pins is *which identifiers were renamed*,
+//! not the (separate) WHITESPACE_ONLY tightening.
+
+use coding_adventures_closure_emitter::{emit, EmitOptions};
+use coding_adventures_closure_pass_pipeline::{Pass, PassContext};
+use coding_adventures_closure_pass_rename::RenamePass;
+use coding_adventures_correlation_vector::CVLog;
+use coding_adventures_javascript_parser::{bridge, parse_javascript_typed};
+use coding_adventures_javascript_tokens::EsVersion;
+use coding_adventures_type_sidecar::Sidecar;
+
+// =====================================================================
+// Test-support harness
+// =====================================================================
+
+/// Parse `src`, bridge it to a typed `Program`, run `RenamePass`, and
+/// emit the result as minified JS. Returns the emitted string.
+fn rename(src: &str) -> String {
+    let es = EsVersion::Es2025;
+    let node = parse_javascript_typed(src, es).expect("parse");
+    let prog = bridge::grammar_to_program(&node, es).expect("bridge");
+
+    let pass = RenamePass::new();
+    let sidecar = Sidecar::new();
+    let mut cv = CVLog::new(false);
+    let out = pass
+        .run(PassContext {
+            program: &prog,
+            sidecar: &sidecar,
+            cv: &mut cv,
+        })
+        .expect("rename");
+
+    let mut cv2 = CVLog::new(false);
+    let opts = EmitOptions {
+        source_map: false,
+        ..Default::default()
+    };
+    emit(&out.program, &sidecar, &mut cv2, &opts)
+        .expect("emit")
+        .code
+}
+
+// =====================================================================
+// Active — behaviors our local renamer supports today
+// =====================================================================
+
+/// Upstream `testRenameSimple` (restricted to a leaf scope): a single
+/// local `var` is shortened at its declaration and its use.
+#[test]
+fn rename_simple_local_var() {
+    assert_eq!(
+        rename("function f() { var longName = 1; return longName; }"),
+        "function f(){var a=1;return a};"
+    );
+}
+
+/// Upstream `testRenameLocals`: parameters are locals too, shortened at
+/// the declaration and every use site.
+#[test]
+fn rename_leaf_parameter() {
+    assert_eq!(
+        rename("function f(longName) { return longName + 1; }"),
+        "function f(a){return a+1};"
+    );
+}
+
+/// Multiple parameters get distinct fresh names, in declaration order.
+#[test]
+fn rename_multiple_params_distinctly() {
+    assert_eq!(
+        rename("function f(first, second) { return first * second; }"),
+        "function f(a,b){return a*b};"
+    );
+}
+
+/// `const` and `let` locals are renamed just like `var`.
+#[test]
+fn rename_local_const_and_let() {
+    assert_eq!(
+        rename("function f() { const total = 1; let partial = 2; return total + partial; }"),
+        "function f(){const a=1;let b=2;return a+b};"
+    );
+}
+
+/// Parameter and local together — both uniquely bound, both shortened,
+/// param first (declaration order).
+#[test]
+fn rename_param_and_local_together() {
+    assert_eq!(
+        rename("function f(input) { var doubled = input * 2; return doubled; }"),
+        "function f(a){var b=a*2;return b};"
+    );
+}
+
+/// Upstream `testRenameLocalsWithNamesReservedForGlobals`: a fresh short
+/// name must never capture a referenced free global. Here the body reads
+/// global `a`, so the parameter cannot become `a` — it gets `b`.
+#[test]
+fn fresh_name_avoids_referenced_global() {
+    assert_eq!(
+        rename("function f(longName) { return a + longName; }"),
+        "function f(b){return a+b};"
+    );
+}
+
+/// A property access (`obj.longName`) is NOT a variable reference — the
+/// member name stays. The receiver param `obj` IS renamed.
+#[test]
+fn does_not_rename_property_access() {
+    assert_eq!(
+        rename("function f(obj) { return obj.longName; }"),
+        "function f(a){return a.longName};"
+    );
+}
+
+/// A non-computed object-literal key is a property name, never renamed.
+#[test]
+fn does_not_rename_object_literal_key() {
+    assert_eq!(
+        rename("function f(val) { return { keyName: val }; }"),
+        "function f(a){return {keyName:a}};"
+    );
+}
+
+/// A computed member `obj[idx]` IS a use position — `idx` is renamed.
+#[test]
+fn renames_computed_member_index() {
+    assert_eq!(
+        rename("function f(obj, idx) { return obj[idx]; }"),
+        "function f(a,b){return a[b]};"
+    );
+}
+
+/// A single-character name is already minimal — the generator can't
+/// shrink it, so nothing changes.
+#[test]
+fn single_char_name_left_alone() {
+    assert_eq!(
+        rename("function f(x) { return x + 1; }"),
+        "function f(x){return x+1};"
+    );
+}
+
+/// Soundness (catch bindings are reserved): a caught name is never used
+/// as a fresh short name. The catch param here is literally `a`, so the
+/// function param `longName` must become `b`, not alias the caught value.
+#[test]
+fn fresh_name_avoids_catch_binding() {
+    assert_eq!(
+        rename("function f(longName) { try { risky(); } catch (a) { use(a, longName); } }"),
+        "function f(b){try{risky()}catch(a){use(a,b)}};"
+    );
+}
+
+/// Soundness: a name declared twice (function-scope `var` + block-scope
+/// `let`) is two distinct bindings; renaming "every use" would conflate
+/// them, so the name is skipped entirely. `keep`, declared once, is
+/// renamed.
+#[test]
+fn skips_name_declared_twice() {
+    assert_eq!(
+        rename(
+            "function f() { var total = 1; { let total = 2; sink(total); } var keep = total; return keep; }"
+        ),
+        "function f(){var total=1;{let total=2;sink(total)}var a=total;return a};"
+    );
+}
+
+// =====================================================================
+// Ignored — whole-program `RenameVars` behaviors we do not do yet.
+// Each is pinned to a gap in code/specs/CLOC12-gaps.md. The `expected`
+// strings encode the upstream behavior we are aiming for, so flipping
+// `#[ignore]` off is a one-line change once the gap closes.
+// =====================================================================
+
+/// Upstream `testRenameGlobals`: a top-level `var` is shortened. Ours
+/// leaves globals to the separate `rename-globals` pass, so the local
+/// renamer is a no-op here today.
+#[test]
+#[ignore = "blocked on gap-144: RenamePass does not rename globals (rename-globals owns that)"]
+fn rename_global_var() {
+    assert_eq!(rename("var longName = 1; use(longName);"), "var a=1;use(a);");
+}
+
+/// Upstream renames parameters of nested (non-leaf) functions too. Ours
+/// only touches leaf functions, so `outer`'s param `param` stays.
+#[test]
+#[ignore = "blocked on gap-145: non-leaf (nesting) function params not renamed"]
+fn rename_non_leaf_function_param() {
+    assert_eq!(
+        rename(
+            "function outer(param) { function inner() { return 1; } return inner() + param; }"
+        ),
+        "function outer(a){function inner(){return 1};return inner()+a};"
+    );
+}
+
+/// Upstream shortens the function *name* itself. Ours preserves
+/// declaration names (they may be externally referenced).
+#[test]
+#[ignore = "blocked on gap-146: function declaration names not renamed"]
+fn rename_function_declaration_name() {
+    assert_eq!(
+        rename("function longFnName() { return 1; } longFnName();"),
+        "function a(){return 1};a();"
+    );
+}
+
+/// Upstream's frequency-biased generator hands the 1-char name to the
+/// most-referenced variable. Here `rare` is used once and `often` three
+/// times, so upstream would make `often` → `a` and `rare` → `b`; ours
+/// allocates in declaration order (`rare` → `a`, `often` → `b`).
+#[test]
+#[ignore = "blocked on gap-147: name allocation is declaration-order, not frequency-biased"]
+fn frequency_biased_name_allocation() {
+    assert_eq!(
+        rename(
+            "function f() { var rare = 1; var often = 2; return often + often + often + rare; }"
+        ),
+        "function f(){var b=1;var a=2;return a+a+a+b};"
+    );
+}

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -1239,3 +1239,49 @@ historical context with status `RESOLVED` and a link to the fix PR.
   value of two `"` prints `"\"\""`, not single-quoted).
 - **No `#[ignore]` placeholders.** The ASCII-only `\uXXXX` escaping that the
   CLOC12.143 port noted as a follow-up is now covered here.
+
+## CLOC12.145 — RenameVars port (rename)
+
+- **What it is:** the twelfth CLOC12 upstream port and the **first** into
+  `closure-pass-rename`. New file `tests/upstream/rename_vars_test.rs`,
+  registered as the `upstream_rename_vars` test target, ported from upstream
+  `RenameVarsTest.java`. Unlike the hand-built-AST ports, it drives the real
+  source → `grammar_to_program` bridge → `RenamePass` → `emit` roundtrip (the
+  crate already carries `javascript-parser` + `closure-emitter` dev-deps), so
+  each case is `assert_eq!(rename(src), expected)` on emitted JS.
+- **12 active `#[test]`s pass on the first run** (no new rename bug): leaf
+  local `var`/`let`/`const` and parameter renaming at declaration + use sites,
+  multiple params distinct, param+local together, reserved-name avoidance
+  (fresh name never captures a referenced free global), property access and
+  non-computed object keys never renamed, computed member index renamed,
+  single-char names left alone, and two soundness guards (catch bindings
+  reserved; a name declared twice is skipped).
+- **4 `#[ignore]` placeholders** pin the whole-program `RenameVars` behaviors
+  closurec deliberately does not do in this pass — see gap-144 … gap-147.
+
+### gap-144 — RenamePass does not rename global variables
+
+Upstream `RenameVars` (`testRenameGlobals`) shortens top-level bindings in the
+same sweep as locals. closurec **splits** the responsibility: global renaming
+lives in the separate `rename-globals` pass (ADVANCED only), so `RenamePass`
+leaves a top-level `var longName` untouched. Placeholder:
+`rename_global_var`.
+
+### gap-145 — non-leaf (nesting) function params not renamed
+
+`RenamePass` only renames **leaf** functions (no nested function). Upstream
+renames every scope. A parameter of a function that contains a nested function
+is left verbatim today. Placeholder: `rename_non_leaf_function_param`.
+
+### gap-146 — function declaration names not renamed
+
+Upstream shortens the function *name* itself (`function longName(){}` →
+`function a(){}`). closurec preserves declaration names (they may be externally
+referenced; renaming them belongs to `rename-globals` with export awareness).
+Placeholder: `rename_function_declaration_name`.
+
+### gap-147 — name allocation is declaration-order, not frequency-biased
+
+Upstream's generator (`testBias*`) hands the shortest name to the
+most-referenced variable to improve gzip. `RenamePass` allocates fresh names in
+declaration order. Placeholder: `frequency_biased_name_allocation`.


### PR DESCRIPTION
## Summary

First CLOC12 upstream-test port into **`closure-pass-rename`** (#88). Ports google/closure-compiler's `RenameVarsTest.java` into `tests/upstream/rename_vars_test.rs`, driving the **real** source → `grammar_to_program` bridge → `RenamePass` → `emit` roundtrip — the exact chain closurec's SIMPLE level uses — so each case is `assert_eq!(rename(src), expected)` on emitted JS.

## Results

- **12 active `#[test]`s pass on the first run** — no new rename defect surfaced. Cover: leaf parameter + `var`/`let`/`const` local renaming at declaration and every use site; multiple params distinct; param+local together; reserved-name avoidance (a fresh short name never captures a referenced free global); property access + non-computed object keys never renamed; computed member index renamed; single-char names left alone; and two soundness guards (catch bindings reserved; a name declared twice is skipped).
- **4 `#[ignore = "blocked on gap-NNN"]` placeholders** pin the whole-program `RenameVars` behaviors closurec deliberately splits out or defers:
  - **gap-144** — global renaming (owned by the separate `rename-globals` pass)
  - **gap-145** — non-leaf (nesting) function params
  - **gap-146** — function-declaration names
  - **gap-147** — frequency-biased name allocation

Each gap is documented in `code/specs/CLOC12-gaps.md` (new **CLOC12.145** section). Running with `--include-ignored` measures progress as gaps close.

## Scope / safety

- **Test-only**: no `src/` file is touched, so there is no emitter/pass ripple into downstream consumers. Full crate suite green (33 lib + 12 port, 4 ignored).
- Adds `tests/upstream/{UPSTREAM_SHA,ATTRIBUTION.md}` scaffolding per the CLOC12 port convention; registers the `upstream_rename_vars` `[[test]]` target; bumps the crate 0.10.0 → 0.11.0 with CHANGELOG + README.
- Inline security review: **PASSED** (test-only, no untrusted input, no `unsafe`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)