### PR TITLE
feat(asciimath): delimiter-wrapping functions abs/norm/floor/ceil → Fenced (0.13.0)

### DIFF
--- a/code/packages/rust/asciimath/CHANGELOG.md
+++ b/code/packages/rust/asciimath/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to the AsciiMath pluggable frontend.
 
+## [0.13.0] — 2026-07-01
+
+### Added — delimiter-wrapping functions (`abs`/`norm`/`floor`/`ceil` → `Fenced`)
+
+The frontend now reads AsciiMath's delimiter-wrapping functions and lowers each to the neutral
+`MathExpr::Fenced { open, body, close }` node (the same node the `latex` and `mathml` frontends emit
+for their fenced forms), carrying the specific bracket pair as data:
+
+- `abs(x)` → `Fenced { open: "|", body: x, close: "|" }`  (|x|)
+- `norm(v)` → `Fenced { … "‖" … "‖" }`  (‖v‖, U+2016)
+- `floor(x)` → `Fenced { … "⌊" … "⌋" }`  (⌊x⌋, U+230A/U+230B)
+- `ceil(x)` → `Fenced { … "⌈" … "⌉" }`  (⌈x⌉, U+2308/U+2309)
+
+Each takes the next single atom as its body (the `sqrt x` convention — `abs(x)` reads the `(x)`
+group, whose parens normalise away), so `abs(x+y)` fences the whole group. Because the bracket kind
+is preserved, a bar `|x|` is no longer indistinguishable from a paren `(x)`. Recognised via the
+parser's own keyword tables (a single `fenced_delim_of`, shared with the tokenizer's longest-match
+scan through `is_keyword`, so lexer and parser can't drift). `capabilities()` now declares
+`fenced_delimiters`, closing that gap vs the `latex`/`mathml` frontends; the conformance harness
+enforces it. No consumer change — the `Fenced` node already existed and is lowered by the `adj-lang`
+adapter; verified across `latex`/`mathml`/`asciimath`/`unicode-math`/`adj-lang`/`adj-lang-cli`.
+
 ## [0.12.0] — 2026-07-01
 
 ### Added — plus-or-minus (`+-` → ±, `-+` → ∓)

--- a/code/packages/rust/asciimath/Cargo.toml
+++ b/code/packages/rust/asciimath/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "asciimath"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "An AsciiMath parser that implements the math-frontend MathFrontend trait: turns AsciiMath (1/2, sqrt(x), x^2+y^2=r^2) into the neutral MathExpr AST. The second pluggable frontend after LaTeX (see ASM01/PFE01). Total, panic-free, spanned errors."
 license = "MIT"

--- a/code/packages/rust/asciimath/README.md
+++ b/code/packages/rust/asciimath/README.md
@@ -41,6 +41,7 @@ second notation.
 | `root(3)(x)`, `root 3 x` | `Root { degree: Some(3), .. }` |
 | `sin x`, `ln(x)` | `Call { func, arg }` |
 | `a = b`, `x <= y`, `a != b` | `Rel` |
+| `abs(x)`, `norm(v)`, `floor(x)`, `ceil(x)` | `Fenced { open, body, close }` — the bracket pair \|·\|, ‖·‖, ⌊·⌋, ⌈·⌉ (same node as LaTeX `\left…\right`); a bar `\|x\|` ≠ a paren `(x)` |
 | `( .. )`, `[ .. ]`, `{ .. }` | `Group` |
 | `"kg"` (text literal) | `Text` |
 

--- a/code/packages/rust/asciimath/src/lib.rs
+++ b/code/packages/rust/asciimath/src/lib.rs
@@ -64,9 +64,11 @@ impl MathFrontend for AsciiMath {
         // `MathExpr::Overset`/`Underset` since math-frontend 0.5.0) + `sequences`
         // (a comma-separated fence `(a, b, c)` → `MathExpr::Sequence` since math-frontend
         // 0.6.0) + `plusminus` (`+-`/`-+` → `BinOp::PlusMinus`/`MinusPlus`, the AsciiMath spelling
-        // of `±`/`∓`, matching the latex/unicode-math frontends). `binomials` is not part of
-        // AsciiMath's core spelling here. Declaring `implicit_mul` is a parser-behavior claim
-        // (juxtaposition ⇒ `Mul`) the goldens cover.
+        // of `±`/`∓`, matching the latex/unicode-math frontends) + `fenced_delimiters` (the
+        // delimiter-wrapping functions `abs(x)`→|x|, `norm(v)`→‖v‖, `floor(x)`→⌊x⌋, `ceil(x)`→⌈x⌉,
+        // each → `MathExpr::Fenced` carrying its bracket pair, like the latex/mathml frontends).
+        // `binomials` is not part of AsciiMath's core spelling here. Declaring `implicit_mul` is a
+        // parser-behavior claim (juxtaposition ⇒ `Mul`) the goldens cover.
         Capabilities::none()
             .with_fractions()
             .with_roots()
@@ -81,6 +83,7 @@ impl MathFrontend for AsciiMath {
             .with_oversets()
             .with_sequences()
             .with_plusminus()
+            .with_fenced_delimiters()
     }
 }
 
@@ -504,7 +507,31 @@ mod tests {
         assert!(c.accents); // PR-2b: hat/bar/vec/dot/ddot/tilde/ul
         assert!(c.oversets && c.sequences); // overset/underset + comma-separated fence → Sequence
         assert!(c.plusminus); // `+-`/`-+` → ±/∓
+        assert!(c.fenced_delimiters); // abs/norm/floor/ceil → Fenced with their bracket pairs
         assert!(!c.binomials); // not part of AsciiMath's core spelling here
+    }
+
+    // ---- fenced delimiters -----------------------------------------------------
+    #[test]
+    fn fenced_delimiter_functions_lower_to_fenced() {
+        // `abs`/`norm`/`floor`/`ceil` take the next single atom (the `sqrt x` convention; `abs(x)`
+        // reads the `(x)` group, whose parens normalise away) and lower to `MathExpr::Fenced`
+        // carrying the specific bracket pair — distinct from a function `Call` and a plain `Group`.
+        let fenced = |open: &str, body: MathExpr, close: &str| MathExpr::Fenced {
+            open: open.to_string(),
+            body: Box::new(body),
+            close: close.to_string(),
+        };
+        assert_eq!(p("abs(x)"), fenced("|", sym("x"), "|"));
+        assert_eq!(p("norm(v)"), fenced("\u{2016}", sym("v"), "\u{2016}"));
+        assert_eq!(p("floor(x)"), fenced("\u{230A}", sym("x"), "\u{230B}"));
+        assert_eq!(p("ceil(x)"), fenced("\u{2308}", sym("x"), "\u{2309}"));
+        // The body is a full atom: `abs(x+y)` fences the whole group (parens normalise away).
+        assert_eq!(p("abs(x+y)"), fenced("|", b(BinOp::Add, sym("x"), sym("y")), "|"));
+        // A bar carries its delimiters, so |x| is NOT the same as the paren group (x).
+        assert_ne!(p("abs(x)"), p("(x)"));
+        // Greedy longest-match keeps the keyword whole: `abs` splits from a glued suffix.
+        assert_eq!(p("abs x"), fenced("|", sym("x"), "|"));
     }
 
     // ---- accents (PR-2b) -------------------------------------------------------
@@ -605,6 +632,10 @@ mod tests {
                 "(a,b,c)",         // comma-separated fence → MathExpr::Sequence
                 "a +- b",          // plus-or-minus → BinOp::PlusMinus (±)
                 "x -+ y",          // minus-or-plus → BinOp::MinusPlus (∓)
+                "abs(x)",          // delimiter-wrapping function → MathExpr::Fenced (|x|)
+                "norm(v)",         // norm → Fenced (‖v‖)
+                "floor(x)",        // floor → Fenced (⌊x⌋)
+                "ceil(x)",         // ceil → Fenced (⌈x⌉)
                 "1 +",   // error: trailing operator (span in range, not a panic)
                 "(x",    // error: missing close
                 "",      // error: empty

--- a/code/packages/rust/asciimath/src/parser.rs
+++ b/code/packages/rust/asciimath/src/parser.rs
@@ -410,6 +410,22 @@ impl Parser<'_> {
             let body = self.parse_atom()?;
             return Ok(MathExpr::Accent { accent: accent.to_string(), body: Box::new(body) });
         }
+        // Delimiter-wrapping functions: `abs(x)` → |x|, `norm(v)` → ‖v‖, `floor(x)` → ⌊x⌋,
+        // `ceil(x)` → ⌈x⌉. Each takes the next single atom as its body (the same "one atom
+        // argument" convention as `sqrt`/functions — `abs(x)` reads the `(x)` group, whose parens
+        // normalise away) and lowers to the neutral `MathExpr::Fenced { open, body, close }`
+        // carrying the specific delimiter pair. Distinct from a function `Call` (a named operator
+        // applied to an argument) and from a plain paren `Group` (which records no delimiters), so
+        // `abs(x)` (|x|) is no longer indistinguishable from `(x)`. Needs the `Fenced` node.
+        if let Some((open, close)) = fenced_delim_of(word) {
+            self.advance();
+            let body = self.parse_atom()?;
+            return Ok(MathExpr::Fenced {
+                open: open.to_string(),
+                body: Box::new(body),
+                close: close.to_string(),
+            });
+        }
         // Over/under-set annotations: `overset(a)(b)`/`stackrel(a)(b)` and `underset(a)(b)`
         // (also the paren-free `stackrel a b` form). TWO atoms — the annotation then the base —
         // lowered to the neutral `MathExpr::Overset`/`Underset` (a sub-expression centered OVER /
@@ -511,6 +527,7 @@ pub(crate) fn is_keyword(word: &str) -> bool {
     func_of(word).is_some()
         || bigop_of(word).is_some()
         || accent_of(word).is_some()
+        || fenced_delim_of(word).is_some()
         || constant_of(word).is_some()
         || matches!(word, "sqrt" | "root" | "overset" | "stackrel" | "underset" | "xx" | "cdot" | "div")
 }
@@ -530,6 +547,21 @@ fn accent_of(word: &str) -> Option<&'static str> {
         "dot" => "dot",
         "ddot" => "ddot",
         "tilde" => "tilde",
+        _ => return None,
+    })
+}
+
+/// Map an AsciiMath delimiter-wrapping function word to its `(open, close)` fence pair, or `None`.
+/// AsciiMath spells these as prefix words taking one argument (like `sqrt`): `abs(x)` → |x|,
+/// `norm(v)` → ‖v‖ (U+2016 double vertical line), `floor(x)` → ⌊x⌋ (U+230A/U+230B), `ceil(x)` →
+/// ⌈x⌉ (U+2308/U+2309). Each wraps its one-atom argument in the neutral [`MathExpr::Fenced`] node
+/// carrying these delimiters, so the bracket kind is preserved (a bar `|x|` is not a paren `(x)`).
+fn fenced_delim_of(word: &str) -> Option<(&'static str, &'static str)> {
+    Some(match word {
+        "abs" => ("|", "|"),
+        "norm" => ("\u{2016}", "\u{2016}"),
+        "floor" => ("\u{230A}", "\u{230B}"),
+        "ceil" => ("\u{2308}", "\u{2309}"),
         _ => return None,
     })
 }


### PR DESCRIPTION
## What

AsciiMath's **delimiter-wrapping functions** now lower to the neutral `MathExpr::Fenced { open, body, close }` node (the **same** node the `latex` and `mathml` frontends emit for their fenced forms), each carrying its specific bracket pair as data:

| AsciiMath | → neutral `MathExpr` |
|-----------|----------------------|
| `abs(x)` | `Fenced { "\|", x, "\|" }`  (\|x\|) |
| `norm(v)` | `Fenced { "‖", v, "‖" }`  (‖v‖, U+2016) |
| `floor(x)` | `Fenced { "⌊", x, "⌋" }`  (⌊x⌋, U+230A/B) |
| `ceil(x)` | `Fenced { "⌈", x, "⌉" }`  (⌈x⌉, U+2308/9) |

Each takes the next single atom as its body (the `sqrt x` convention — `abs(x)` reads the `(x)` group, whose parens normalise away), so `abs(x+y)` fences the whole group. Because the bracket kind is preserved, a bar `|x|` is no longer indistinguishable from a paren `(x)`.

## How
- A single pure `fenced_delim_of(word)` lookup, **shared with the tokenizer's longest-match scan through `is_keyword`** so the lexer and parser can't drift.
- The dispatch arm reuses the existing **depth-guarded** `self.parse_atom()` for the body — no new recursion path (capped at `MAX_DEPTH`).
- `capabilities()` now declares `fenced_delimiters`, **closing that gap vs the `latex`/`mathml` frontends**; the conformance harness enforces it.

## Why it's safe / self-contained
- Downstream is unaffected: the `Fenced` node already existed in `math-frontend` and is already lowered by the `adj-lang` adapter (write-once/read-everywhere).
- `#![forbid(unsafe_code)]` holds; the helper returns `&'static str` delimiter literals via a total match.

## Verification
- `cargo test` green across **asciimath / math-frontend / latex / mathml / unicode-math / adj-lang / adj-lang-cli**; `cargo clippy -p asciimath` clean.
- New unit test covers all four forms, the group body (`abs(x+y)`), the paren-vs-bar distinction (`abs(x)` ≠ `(x)`), and the paren-free `abs x`. Four conformance samples added.
- README + CHANGELOG updated; version 0.12.0 → 0.13.0.
- Security review: **PASSED** (recursion depth-guarded; no unsafe/panic/DoS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)