### PR TITLE
[codex] test(html-parser): pin foreign repair evidence

### DIFF
--- a/code/packages/rust/html-parser/tests/whatwg_foreign_audit_test.rs
+++ b/code/packages/rust/html-parser/tests/whatwg_foreign_audit_test.rs
@@ -6,6 +6,13 @@ use std::collections::{BTreeMap, HashMap};
 
 const TREE_CONSTRUCTION_SMOKE: &str = include_str!("fixtures/html5lib-tree-construction-smoke.dat");
 const WHATWG_FOREIGN_AUDIT: &str = include_str!("fixtures/whatwg-foreign-audit.json");
+const POST_PARSE_REPAIR_EVIDENCE: &[(&str, &str)] = &[
+    ("domjs-unsafe-dat-121", "svg-boundary"),
+    ("html5test-com-dat-294", "mathml-boundary"),
+    ("namespace-sensitivity-dat-326", "html-integration-point"),
+    ("adoption01-dat-13", "table-foreign-boundary"),
+    ("foreign-fragment-dat-1", "foreign-fragment"),
+];
 
 #[derive(Debug, Deserialize)]
 struct ForeignAuditSuite {
@@ -66,6 +73,46 @@ fn whatwg_foreign_audit_cases_match_parser_dom_dump() {
             actual, source_case.document,
             "case `{}` ({}) failed for input {:?}",
             case.id, case.axis, source_case.data
+        );
+    }
+}
+
+#[test]
+fn whatwg_foreign_audit_tracks_post_parse_repair_evidence() {
+    let suite = load_suite();
+    let audit_cases = suite
+        .cases
+        .iter()
+        .map(|case| (case.id.as_str(), case))
+        .collect::<HashMap<_, _>>();
+    let smoke_cases = parse_tree_construction_cases(TREE_CONSTRUCTION_SMOKE)
+        .into_iter()
+        .map(|case| (case.source.clone(), case))
+        .collect::<HashMap<_, _>>();
+
+    for (case_id, expected_axis) in POST_PARSE_REPAIR_EVIDENCE {
+        let audit_case = audit_cases.get(case_id).unwrap_or_else(|| {
+            panic!("post-parse repair evidence case `{case_id}` should be audited")
+        });
+        assert_eq!(
+            audit_case.axis, *expected_axis,
+            "post-parse repair evidence case `{case_id}` should stay on its focused audit axis"
+        );
+
+        let source_case = smoke_cases
+            .get(&audit_case.source)
+            .unwrap_or_else(|| panic!("case `{case_id}` should exist in smoke fixture"));
+        let actual = actual_dom_dump_for_tree_case(source_case).unwrap_or_else(|error| {
+            panic!(
+                "case `{}` ({}) parse failed: {error}",
+                audit_case.id, audit_case.axis
+            )
+        });
+
+        assert_eq!(
+            actual, source_case.document,
+            "post-parse repair evidence case `{}` ({}) failed for input {:?}",
+            audit_case.id, audit_case.axis, source_case.data
         );
     }
 }


### PR DESCRIPTION
## Summary
- add a foreign-content post-parse repair evidence gate covering SVG, MathML, HTML integration point, table-boundary, and foreign fragment axes
- keep the selected evidence cases tied to their focused WHATWG audit axes and html5lib DOM dumps

## Validation
- cargo test -p coding-adventures-html-parser font_newline_before_bold_stays_outside_reconstructed_font
- cargo test -p coding-adventures-html-parser whatwg_document_shell_audit_tracks_post_parse_repair_evidence
- cargo test -p coding-adventures-html-parser whatwg_head_body_audit_tracks_post_parse_repair_evidence
- cargo test -p coding-adventures-html-parser whatwg_form_interactive_audit_tracks_post_parse_repair_evidence
- cargo test -p coding-adventures-html-parser whatwg_legacy_element_audit_tracks_post_parse_repair_evidence
- cargo test -p coding-adventures-html-parser whatwg_paragraph_audit_tracks_post_parse_repair_evidence
- cargo test -p coding-adventures-html-parser whatwg_block_boundary_audit_tracks_post_parse_repair_evidence
- cargo test -p coding-adventures-html-parser whatwg_table_audit_tracks_post_parse_repair_evidence
- cargo test -p coding-adventures-html-parser whatwg_formatting_audit_tracks_post_parse_repair_evidence
- cargo test -p coding-adventures-html-parser whatwg_text_control_audit_tracks_post_parse_repair_evidence
- cargo test -p coding-adventures-html-parser whatwg_ruby_audit_tracks_post_parse_repair_evidence
- cargo test -p coding-adventures-html-parser whatwg_list_item_audit_tracks_post_parse_repair_evidence
- cargo test -p coding-adventures-html-parser whatwg_template_audit_tracks_post_parse_repair_evidence
- cargo test -p coding-adventures-html-parser whatwg_select_list_audit_tracks_post_parse_repair_evidence
- cargo test -p coding-adventures-html-parser whatwg_frameset_audit_tracks_post_parse_repair_evidence
- cargo test -p coding-adventures-html-parser whatwg_foreign_audit_tracks_post_parse_repair_evidence
- cargo test -p coding-adventures-html-parser whatwg_document_shell_audit_cases_match_parser_dom_dump
- cargo test -p coding-adventures-html-parser whatwg_head_body_audit_cases_match_parser_dom_dump
- cargo test -p coding-adventures-html-parser whatwg_form_interactive_audit_cases_match_parser_dom_dump
- cargo test -p coding-adventures-html-parser whatwg_table_audit_cases_match_parser_dom_dump
- cargo test -p coding-adventures-html-parser whatwg_formatting_audit_cases_match_parser_dom_dump
- cargo test -p coding-adventures-html-parser whatwg_paragraph_audit_cases_match_parser_dom_dump
- cargo test -p coding-adventures-html-parser whatwg_text_control_audit_cases_match_parser_dom_dump
- cargo test -p coding-adventures-html-parser whatwg_block_boundary_audit_cases_match_parser_dom_dump
- cargo test -p coding-adventures-html-parser whatwg_select_list_audit_cases_match_parser_dom_dump
- cargo test -p coding-adventures-html-parser whatwg_frameset_audit_cases_match_parser_dom_dump
- cargo test -p coding-adventures-html-parser whatwg_foreign_audit_cases_match_parser_dom_dump
- cargo test -p coding-adventures-html-parser html5lib_tree_construction_smoke_cases_match_dom_dump
- cargo test -p coding-adventures-html-parser
- CARGO_BUILD_JOBS=2 cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser
- python3 -m json.tool code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json >/dev/null
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py
- git diff --check