### PR TITLE
feat(adj-ladder): rung-26 mineral indices (Ca×P product + Ca/P ratios) constant-free rung

### DIFF
--- a/code/specs/data/adj-ladder/rung26_mineral_indices/gen_items.py
+++ b/code/specs/data/adj-ladder/rung26_mineral_indices/gen_items.py
@@ -1,0 +1,171 @@
+"""Generate rung-26 (mineral indices) items.json for the ADJ-LADDER.
+
+Rung 26 opens the **bone / mineral-metabolism** panel on the quantitative band — the calcium-phosphate
+arithmetic of CKD-MBD (chronic-kidney-disease mineral & bone disorder), where the calcium-phosphate
+product predicts metastatic (vascular/soft-tissue) calcification — using the same contamination-safe
+shape as the lipid rung (25) and the iron rung (23): a small table of *observed* laboratory quantities
+and a tight family of mutually-confusable formulas built **only from those observed quantities** (no
+numeric literal anywhere in any program), so nothing structural can leak.
+
+The clinical setup is a single mineral panel. Three quantities are measured:
+
+  CA    serum calcium      (mg/dL)
+  PHOS  serum phosphate    (mg/dL)
+  ALB   serum albumin      (g/dL)
+
+Three textbook mineral indices fall out as pure functions of the observed quantities — no constant
+required. Crucially this rung introduces a **PRODUCT** in the numerator (the calcium-phosphate
+product, CA·PHOS), contrasted directly against the DIVISION forms, so the family exercises the engine
+across `*` and `/` on a fresh panel (like the cardiac rung mixed a product with an index-division):
+
+  CALCIUM-PHOSPHATE PRODUCT   CA * PHOS     [ =CPP; >55 mg^2/dL^2 → calcification risk ]
+  CALCIUM:PHOSPHATE RATIO     CA / PHOS     [ the ratio — deliberately contrasted with the product ]
+  PHOSPHATE:CALCIUM RATIO     PHOS / CA     [ the inverse ratio (upside-down) ]
+
+Each index is a `compute_dimensioned` program (observe the three quantities + `let answer = formula`);
+the ADJ engine carries the arithmetic and the harness reads the scalar via the existing
+`compute_dimensioned` extractor — no harness/engine change, exactly as rungs 8/16/…/24/25. The core
+confusion this rung tests is **product vs ratio** (CA·PHOS vs CA/PHOS) — a genuine student slip — plus
+the ratio's direction (CA/PHOS vs PHOS/CA).
+
+Contamination-safe by construction: every formula is built only from the three observed quantities via
+`*`, `/` — **no structural constants** — so every program literal is grounded in the stem. The
+observed quantities carry **digit-free identifiers** (`calcium`, `phosphate`, `albumin`) so no numeral
+hides inside a variable name. The five options are a tight family over the same quantities: the three
+real indices plus the two classic slips —
+
+  CA / ALB       the calcium-to-albumin ratio (a plausible mineral-panel ratio — but albumin is the
+                 *correction* input, not a divisor of the product), and
+  PHOS / ALB     the phosphate-to-albumin ratio (the same mix-up on the other analyte),
+
+which are exactly the mistakes a student makes. Gold rotates A-E by index.
+
+Note on scale: the calcium-phosphate product lives on a different magnitude (tens) from the ratios
+(order 1), so it never collides with them; the ratio pairs are reciprocals (distinct when CA != PHOS).
+The tables below are chosen so the five family values are pairwise distinct — with a comfortable margin
+— for every item, asserted at build time (CA != PHOS enforced so the two ratios never coincide).
+"""
+import json
+
+LETTERS = ["A", "B", "C", "D", "E"]
+
+# (CA, PHOS, ALB) observed quantities. CA in mg/dL, PHOS in mg/dL, ALB in g/dL. The five index-family
+# values are asserted pairwise-distinct (with margin) below. CA != PHOS for every row (so the CA:PHOS
+# and PHOS:CA ratios never coincide).
+#   CA   = serum calcium
+#   PHOS = serum phosphate
+#   ALB  = serum albumin
+TABLES = [
+    (10, 4, 5),
+    (9, 3, 4),
+    (8, 2, 4),
+    (12, 6, 4),
+    (10, 5, 4),
+    (11, 4, 5),
+    (9, 6, 3),
+]
+
+# The option family (5 members), all built from the observed quantities via `*` / `/`. Every
+# identifier is DIGIT-FREE. key -> (display name, formula-as-adj). Only the first three are *queried*
+# (used as gold); all five always appear as the options.
+FAMILY = [
+    ("ca_phos_product", "calcium-phosphate product", "calcium * phosphate"),
+    ("ca_phos_ratio", "calcium-to-phosphate ratio", "calcium / phosphate"),
+    ("phos_ca_ratio", "phosphate-to-calcium ratio", "phosphate / calcium"),
+    ("ca_alb_ratio", "calcium-to-albumin ratio", "calcium / albumin"),
+    ("phos_alb_ratio", "phosphate-to-albumin ratio", "phosphate / albumin"),
+]
+QUERIED = ["ca_phos_product", "ca_phos_ratio", "phos_ca_ratio"]
+ORDER = [k for k, _, _ in FAMILY]
+
+
+def scalar(v):
+    return {"value": v, "unit": "scalar"}
+
+
+def family_values(ca, phos, alb):
+    # Operation order mirrors the ADJ program exactly, so the Python option value and the engine
+    # result are the same IEEE-double (well within the harness's 1e-9 match tolerance).
+    return {
+        "ca_phos_product": ca * phos,
+        "ca_phos_ratio": ca / phos,
+        "phos_ca_ratio": phos / ca,
+        "ca_alb_ratio": ca / alb,
+        "phos_alb_ratio": phos / alb,
+    }
+
+
+def build():
+    name_of = {k: nm for k, nm, _ in FAMILY}
+    formula_of = {k: f for k, _, f in FAMILY}
+    items = []
+    idx = 0
+    for ca, phos, alb in TABLES:
+        assert ca != phos, (ca, phos)  # else CA:PHOS and PHOS:CA ratios coincide
+        fv = family_values(ca, phos, alb)
+        # Pairwise-distinct with a comfortable margin so the harness never sees two options
+        # matching the gold value within its 1e-9 tolerance.
+        vals = [fv[k] for k in ORDER]
+        for i in range(len(vals)):
+            for j in range(i + 1, len(vals)):
+                assert abs(vals[i] - vals[j]) > 1e-6, (ca, phos, alb, ORDER[i], ORDER[j], fv)
+        for key in QUERIED:
+            gold_val = fv[key]
+            gold_pos = idx % 5
+            others = [fv[k] for k in ORDER if abs(fv[k] - gold_val) > 1e-12]
+            opts_vals = others[:]
+            opts_vals.insert(gold_pos, gold_val)
+            opts_vals = opts_vals[:5]
+            if abs(opts_vals[gold_pos] - gold_val) > 1e-12:
+                opts_vals[gold_pos] = gold_val
+            assert len({round(v, 9) for v in opts_vals}) == 5, (key, ca, phos, alb, opts_vals)
+            options = {LETTERS[i]: scalar(opts_vals[i]) for i in range(5)}
+            items.append({
+                "id": f"r26min-{idx + 1:02d}",
+                "qtype": "mineral_index",
+                "stem": (
+                    f"A mineral panel shows serum calcium {ca} mg/dL, phosphate {phos} mg/dL, and "
+                    f"albumin {alb} g/dL. What is the patient's {name_of[key]}?"
+                ),
+                "program": (
+                    f"observe calcium({ca})\n"
+                    f"observe phosphate({phos})\n"
+                    f"observe albumin({alb})\n"
+                    f"let answer = {formula_of[key]}\n"
+                    "? answer\n"
+                ),
+                "answer_from": {"type": "compute_dimensioned", "name": "answer"},
+                "options": options,
+                "gold_letter": LETTERS[gold_pos],
+            })
+            idx += 1
+    return {
+        "description": (
+            "ADJ-LADDER rung 26 — mineral indices from a single mineral panel (a NEW panel: bone / "
+            "mineral metabolism, CKD-MBD). From three stated quantities (serum calcium CA, phosphate "
+            "PHOS, albumin ALB) compute the calcium-phosphate product (CA*PHOS), the calcium-to-phosphate "
+            "ratio (CA/PHOS), or the phosphate-to-calcium ratio (PHOS/CA). Each item is a "
+            "compute_dimensioned program (observe the three quantities, let answer = formula); the ADJ "
+            "engine carries the arithmetic — a PRODUCT (CA*PHOS) contrasted with the DIVISION forms, "
+            "exercising the engine across * and / on a fresh mineral-panel stem — and the harness matches "
+            "the scalar to the printed options. Contamination-safe: every index is built only from the "
+            "three observed quantities via * and / — no constant leaks — and the observed quantities carry "
+            "digit-free identifiers so no numeral hides inside a variable name. The five options are a "
+            "family over the same quantities, so the distractors are exactly the slips students make: the "
+            "calcium-to-albumin ratio (CA/ALB, confusing the correction input with a divisor) and the "
+            "phosphate-to-albumin ratio (PHOS/ALB, the same mix-up on the other analyte). The core "
+            "confusion tested is product vs ratio (CA*PHOS vs CA/PHOS) plus the ratio's direction."
+        ),
+        "items": items,
+    }
+
+
+if __name__ == "__main__":
+    doc = build()
+    with open("items.json", "w") as f:
+        json.dump(doc, f, indent=2)
+        f.write("\n")
+    print("wrote items.json:", len(doc["items"]), "items")
+    for it in doc["items"]:
+        print(it["id"], it["qtype"], "gold", it["gold_letter"],
+              "=", round(it["options"][it["gold_letter"]]["value"], 4))

--- a/code/specs/data/adj-ladder/rung26_mineral_indices/items.json
+++ b/code/specs/data/adj-ladder/rung26_mineral_indices/items.json
@@ -1,0 +1,698 @@
+{
+  "description": "ADJ-LADDER rung 26 \u2014 mineral indices from a single mineral panel (a NEW panel: bone / mineral metabolism, CKD-MBD). From three stated quantities (serum calcium CA, phosphate PHOS, albumin ALB) compute the calcium-phosphate product (CA*PHOS), the calcium-to-phosphate ratio (CA/PHOS), or the phosphate-to-calcium ratio (PHOS/CA). Each item is a compute_dimensioned program (observe the three quantities, let answer = formula); the ADJ engine carries the arithmetic \u2014 a PRODUCT (CA*PHOS) contrasted with the DIVISION forms, exercising the engine across * and / on a fresh mineral-panel stem \u2014 and the harness matches the scalar to the printed options. Contamination-safe: every index is built only from the three observed quantities via * and / \u2014 no constant leaks \u2014 and the observed quantities carry digit-free identifiers so no numeral hides inside a variable name. The five options are a family over the same quantities, so the distractors are exactly the slips students make: the calcium-to-albumin ratio (CA/ALB, confusing the correction input with a divisor) and the phosphate-to-albumin ratio (PHOS/ALB, the same mix-up on the other analyte). The core confusion tested is product vs ratio (CA*PHOS vs CA/PHOS) plus the ratio's direction.",
+  "items": [
+    {
+      "id": "r26min-01",
+      "qtype": "mineral_index",
+      "stem": "A mineral panel shows serum calcium 10 mg/dL, phosphate 4 mg/dL, and albumin 5 g/dL. What is the patient's calcium-phosphate product?",
+      "program": "observe calcium(10)\nobserve phosphate(4)\nobserve albumin(5)\nlet answer = calcium * phosphate\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 40,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2.5,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.4,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 2.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.8,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r26min-02",
+      "qtype": "mineral_index",
+      "stem": "A mineral panel shows serum calcium 10 mg/dL, phosphate 4 mg/dL, and albumin 5 g/dL. What is the patient's calcium-to-phosphate ratio?",
+      "program": "observe calcium(10)\nobserve phosphate(4)\nobserve albumin(5)\nlet answer = calcium / phosphate\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 40,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2.5,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.4,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 2.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.8,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r26min-03",
+      "qtype": "mineral_index",
+      "stem": "A mineral panel shows serum calcium 10 mg/dL, phosphate 4 mg/dL, and albumin 5 g/dL. What is the patient's phosphate-to-calcium ratio?",
+      "program": "observe calcium(10)\nobserve phosphate(4)\nobserve albumin(5)\nlet answer = phosphate / calcium\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 40,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2.5,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.4,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 2.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.8,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r26min-04",
+      "qtype": "mineral_index",
+      "stem": "A mineral panel shows serum calcium 9 mg/dL, phosphate 3 mg/dL, and albumin 4 g/dL. What is the patient's calcium-phosphate product?",
+      "program": "observe calcium(9)\nobserve phosphate(3)\nobserve albumin(4)\nlet answer = calcium * phosphate\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 0.3333333333333333,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 2.25,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 27,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.75,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r26min-05",
+      "qtype": "mineral_index",
+      "stem": "A mineral panel shows serum calcium 9 mg/dL, phosphate 3 mg/dL, and albumin 4 g/dL. What is the patient's calcium-to-phosphate ratio?",
+      "program": "observe calcium(9)\nobserve phosphate(3)\nobserve albumin(4)\nlet answer = calcium / phosphate\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 27,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 0.3333333333333333,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 2.25,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.75,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 3.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r26min-06",
+      "qtype": "mineral_index",
+      "stem": "A mineral panel shows serum calcium 9 mg/dL, phosphate 3 mg/dL, and albumin 4 g/dL. What is the patient's phosphate-to-calcium ratio?",
+      "program": "observe calcium(9)\nobserve phosphate(3)\nobserve albumin(4)\nlet answer = phosphate / calcium\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 0.3333333333333333,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 27,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 3.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 2.25,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.75,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r26min-07",
+      "qtype": "mineral_index",
+      "stem": "A mineral panel shows serum calcium 8 mg/dL, phosphate 2 mg/dL, and albumin 4 g/dL. What is the patient's calcium-phosphate product?",
+      "program": "observe calcium(8)\nobserve phosphate(2)\nobserve albumin(4)\nlet answer = calcium * phosphate\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 4.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 16,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.25,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 2.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.5,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r26min-08",
+      "qtype": "mineral_index",
+      "stem": "A mineral panel shows serum calcium 8 mg/dL, phosphate 2 mg/dL, and albumin 4 g/dL. What is the patient's calcium-to-phosphate ratio?",
+      "program": "observe calcium(8)\nobserve phosphate(2)\nobserve albumin(4)\nlet answer = calcium / phosphate\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 16,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 0.25,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 4.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 2.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.5,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r26min-09",
+      "qtype": "mineral_index",
+      "stem": "A mineral panel shows serum calcium 8 mg/dL, phosphate 2 mg/dL, and albumin 4 g/dL. What is the patient's phosphate-to-calcium ratio?",
+      "program": "observe calcium(8)\nobserve phosphate(2)\nobserve albumin(4)\nlet answer = phosphate / calcium\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 16,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 4.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 2.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.25,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.5,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r26min-10",
+      "qtype": "mineral_index",
+      "stem": "A mineral panel shows serum calcium 12 mg/dL, phosphate 6 mg/dL, and albumin 4 g/dL. What is the patient's calcium-phosphate product?",
+      "program": "observe calcium(12)\nobserve phosphate(6)\nobserve albumin(4)\nlet answer = calcium * phosphate\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 2.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 0.5,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 3.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 1.5,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 72,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r26min-11",
+      "qtype": "mineral_index",
+      "stem": "A mineral panel shows serum calcium 12 mg/dL, phosphate 6 mg/dL, and albumin 4 g/dL. What is the patient's calcium-to-phosphate ratio?",
+      "program": "observe calcium(12)\nobserve phosphate(6)\nobserve albumin(4)\nlet answer = calcium / phosphate\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 2.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 72,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.5,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 3.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1.5,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r26min-12",
+      "qtype": "mineral_index",
+      "stem": "A mineral panel shows serum calcium 12 mg/dL, phosphate 6 mg/dL, and albumin 4 g/dL. What is the patient's phosphate-to-calcium ratio?",
+      "program": "observe calcium(12)\nobserve phosphate(6)\nobserve albumin(4)\nlet answer = phosphate / calcium\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 72,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 0.5,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 2.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 3.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1.5,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r26min-13",
+      "qtype": "mineral_index",
+      "stem": "A mineral panel shows serum calcium 10 mg/dL, phosphate 5 mg/dL, and albumin 4 g/dL. What is the patient's calcium-phosphate product?",
+      "program": "observe calcium(10)\nobserve phosphate(5)\nobserve albumin(4)\nlet answer = calcium * phosphate\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 2.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 0.5,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 50,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 2.5,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1.25,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r26min-14",
+      "qtype": "mineral_index",
+      "stem": "A mineral panel shows serum calcium 10 mg/dL, phosphate 5 mg/dL, and albumin 4 g/dL. What is the patient's calcium-to-phosphate ratio?",
+      "program": "observe calcium(10)\nobserve phosphate(5)\nobserve albumin(4)\nlet answer = calcium / phosphate\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 50,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 0.5,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 2.5,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 2.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1.25,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r26min-15",
+      "qtype": "mineral_index",
+      "stem": "A mineral panel shows serum calcium 10 mg/dL, phosphate 5 mg/dL, and albumin 4 g/dL. What is the patient's phosphate-to-calcium ratio?",
+      "program": "observe calcium(10)\nobserve phosphate(5)\nobserve albumin(4)\nlet answer = phosphate / calcium\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 50,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 2.5,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 1.25,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.5,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r26min-16",
+      "qtype": "mineral_index",
+      "stem": "A mineral panel shows serum calcium 11 mg/dL, phosphate 4 mg/dL, and albumin 5 g/dL. What is the patient's calcium-phosphate product?",
+      "program": "observe calcium(11)\nobserve phosphate(4)\nobserve albumin(5)\nlet answer = calcium * phosphate\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 44,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2.75,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.36363636363636365,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 2.2,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.8,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r26min-17",
+      "qtype": "mineral_index",
+      "stem": "A mineral panel shows serum calcium 11 mg/dL, phosphate 4 mg/dL, and albumin 5 g/dL. What is the patient's calcium-to-phosphate ratio?",
+      "program": "observe calcium(11)\nobserve phosphate(4)\nobserve albumin(5)\nlet answer = calcium / phosphate\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 44,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2.75,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.36363636363636365,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 2.2,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.8,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r26min-18",
+      "qtype": "mineral_index",
+      "stem": "A mineral panel shows serum calcium 11 mg/dL, phosphate 4 mg/dL, and albumin 5 g/dL. What is the patient's phosphate-to-calcium ratio?",
+      "program": "observe calcium(11)\nobserve phosphate(4)\nobserve albumin(5)\nlet answer = phosphate / calcium\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 44,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2.75,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.36363636363636365,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 2.2,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.8,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r26min-19",
+      "qtype": "mineral_index",
+      "stem": "A mineral panel shows serum calcium 9 mg/dL, phosphate 6 mg/dL, and albumin 3 g/dL. What is the patient's calcium-phosphate product?",
+      "program": "observe calcium(9)\nobserve phosphate(6)\nobserve albumin(3)\nlet answer = calcium * phosphate\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 1.5,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 0.6666666666666666,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 3.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 54,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 2.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r26min-20",
+      "qtype": "mineral_index",
+      "stem": "A mineral panel shows serum calcium 9 mg/dL, phosphate 6 mg/dL, and albumin 3 g/dL. What is the patient's calcium-to-phosphate ratio?",
+      "program": "observe calcium(9)\nobserve phosphate(6)\nobserve albumin(3)\nlet answer = calcium / phosphate\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 54,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 0.6666666666666666,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 3.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 2.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1.5,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r26min-21",
+      "qtype": "mineral_index",
+      "stem": "A mineral panel shows serum calcium 9 mg/dL, phosphate 6 mg/dL, and albumin 3 g/dL. What is the patient's phosphate-to-calcium ratio?",
+      "program": "observe calcium(9)\nobserve phosphate(6)\nobserve albumin(3)\nlet answer = phosphate / calcium\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 0.6666666666666666,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 54,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 1.5,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 3.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 2.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    }
+  ]
+}

--- a/code/specs/data/adj-ladder/test_ladder_eval.py
+++ b/code/specs/data/adj-ladder/test_ladder_eval.py
@@ -63,6 +63,7 @@ SELF_CONTAINED_RUNGS = (
     "rung23_iron_studies",
     "rung24_oxygen_extraction",
     "rung25_lipid_indices",
+    "rung26_mineral_indices",
 )
 
 


### PR DESCRIPTION
## What

ADJ-LADDER **rung-26 — mineral indices**, a new-organ constant-free `compute_dimensioned` rung. Opens **bone / mineral metabolism** (CKD-MBD) and **reintroduces a PRODUCT** in the numerator — the calcium-phosphate product — unused in the recent ratio/sum/difference rungs, so the family exercises the engine across `*` and `/`.

From three observed mineral quantities — serum calcium `CA`, phosphate `PHOS`, albumin `ALB`:

| index | formula |
|-------|---------|
| calcium-phosphate product (CPP) | `CA * PHOS` |
| calcium:phosphate ratio | `CA / PHOS` |
| phosphate:calcium ratio | `PHOS / CA` |

The core confusion tested is **product vs ratio** (`CA*PHOS` vs `CA/PHOS`) plus the ratio's direction — genuine student slips.

## Contamination-safety
- Every index is built only from the three observed quantities via `*` and `/` — **no structural constant leaks**.
- Every program literal is one of the three stem values; **digit-free identifiers** (`calcium` / `phosphate` / `albumin`).
- 5-option family; distractors are the classic slips: `CA/ALB` (confusing the correction input with a divisor) and `PHOS/ALB`.
- Gold rotates A–E; 7 tables × 3 = **21 items**; `CA != PHOS` enforced (so the two ratios never coincide); the product lives on a tens-scale that never collides with the order-1 ratios; five family values asserted pairwise-distinct with margin at build.

## Verification
- Registered `rung26_mineral_indices` in `SELF_CONTAINED_RUNGS`; gate **green (3/3)** — engine selects every gold (0 wrong / 0 abstain, confirming the product form), contamination clean, items valid.
- **No harness/engine change** — reuses the existing `compute_dimensioned` extractor, exactly as rungs 8/16/17/18/19/20/21/22/23/24/25.
- Security review: **PASSED** (data-only generator; no eval/injection/path/DoS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)