### PR TITLE
test(inline-variables): port InlineVariables upstream suite (#88, CLOC12.146)

### DIFF
--- a/code/packages/rust/closure-pass-inline-variables/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-inline-variables/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to the `coding-adventures-closure-pass-inline-variables` crate will be documented in this file.
 
+## [0.8.0] - 2026-07-01
+
+### Added — upstream `InlineVariablesTest.java` conformance port (#88, CLOC12.146)
+
+The **first** CLOC12 upstream-test port into this crate. New file
+`tests/upstream/inline_variables_test.rs` (registered as the
+`upstream_inline_variables` test target) reshapes upstream
+`InlineVariablesTest.java` onto our surface, driving the **real** source →
+`grammar_to_program` bridge → `InlineVariablesPass` → `emit` roundtrip, so each
+case is `assert_eq!(propagate(src), expected)` on emitted JS.
+
+- **13 active `#[test]`s pass on the first run** (no new propagation defect):
+  single-use const-literal propagation, propagation into a larger expression,
+  a short literal duplicated across multiple sites, boolean/null literals, the
+  multi-use size budget (a long literal is declined at multiple sites but
+  propagated at a single site), `let`/`var` never propagated, non-literal
+  initializers declined, the shadowed-name guard, property names never
+  replaced while computed member indices are, and two TDZ soundness cases
+  (inert-prefix propagates; code-before-declaration declines).
+- **3 `#[ignore = "blocked on gap-NNN"]` placeholders** pin the whole-program
+  `InlineVariables` behaviors closurec does not do in this pass —
+  gap-148 (single-assignment `let`/`var` inlining), gap-149 (identifier-alias
+  initializers), gap-150 (removing the dead `const` husk, which
+  `remove-unused-vars` owns). Each is pinned to `code/specs/CLOC12-gaps.md`.
+
+This is a **test-only** change: no `src/` file is touched, so there is no
+ripple into downstream consumers. Scaffolding files
+`tests/upstream/{UPSTREAM_SHA,ATTRIBUTION.md}` were added per the CLOC12 port
+convention.
+
 ## [0.7.0] - 2026-07-01
 
 ### Added — CV provenance for constant propagation (#89)

--- a/code/packages/rust/closure-pass-inline-variables/Cargo.toml
+++ b/code/packages/rust/closure-pass-inline-variables/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-inline-variables"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 description = "Constant-propagation pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Replaces references to a top-level `const` bound to a literal with the literal itself, so the binding becomes unused and remove-unused-vars deletes it."
 
@@ -20,3 +20,10 @@ coding-adventures-closure-pass-constant-fold = { path = "../closure-pass-constan
 coding-adventures-javascript-parser = { path = "../javascript-parser" }
 coding-adventures-closure-emitter = { path = "../closure-emitter" }
 coding-adventures-type-sidecar = { path = "../type-sidecar" }
+
+# Upstream-test ports live under `tests/upstream/`; Cargo only
+# auto-discovers `tests/*.rs` one level deep, so each ported file needs
+# an explicit `[[test]]` entry. Per CLOC12.01 §3.
+[[test]]
+name = "upstream_inline_variables"
+path = "tests/upstream/inline_variables_test.rs"

--- a/code/packages/rust/closure-pass-inline-variables/README.md
+++ b/code/packages/rust/closure-pass-inline-variables/README.md
@@ -98,6 +98,23 @@ enabled.
 It runs before `remove-unused-vars` (which clears the emptied
 declaration) and feeds `constant-fold` on the next fixed-point sweep.
 
+## Upstream conformance tests
+
+`tests/upstream/` ports Google Closure Compiler tests (Apache-2.0; see
+`ATTRIBUTION.md` and `UPSTREAM_SHA`), per the CLOC12 test-port convention:
+
+- `inline_variables_test.rs` — `InlineVariablesTest.java`. Drives the real
+  source → bridge → `InlineVariablesPass` → emit roundtrip and pins the
+  const-literal propagation this pass performs (single/multi-use with the size
+  budget, boolean/null literals, the shadow + TDZ soundness guards, and
+  property-vs-computed-member handling). **13 active `#[test]`s** plus **3
+  `#[ignore]` placeholders** for the whole-`InlineVariables` behaviors this
+  pass does not do (single-assignment `let`/`var` inlining, identifier-alias
+  initializers, and dead-declaration removal — owned by `remove-unused-vars`),
+  each pinned to gap-148 … gap-150 in `code/specs/CLOC12-gaps.md`. Run with
+  `cargo test --test upstream_inline_variables` (add `--include-ignored` to
+  measure gap progress).
+
 ## Dependency whitelist
 
 - `coding-adventures-closure-pass-pipeline` — `Pass` trait + types.

--- a/code/packages/rust/closure-pass-inline-variables/tests/upstream/ATTRIBUTION.md
+++ b/code/packages/rust/closure-pass-inline-variables/tests/upstream/ATTRIBUTION.md
@@ -1,0 +1,65 @@
+# Attribution
+
+Tests in this directory are ported from the Google Closure Compiler
+under the Apache License, Version 2.0:
+
+    https://github.com/google/closure-compiler
+    LICENSE: https://www.apache.org/licenses/LICENSE-2.0
+
+## Files ported
+
+- `inline_variables_test.rs`
+    - upstream: `test/com/google/javascript/jscomp/InlineVariablesTest.java`
+    - tracked commit: see `UPSTREAM_SHA`
+
+## Translation notes
+
+CLOC12 port into `closure-pass-inline-variables` — the **first** upstream
+port for this crate. Per CLOC12 §6, each upstream Java test file maps to one
+Rust file in the matching pass crate's `tests/upstream/` directory.
+
+The crate carries `javascript-parser` + `closure-emitter` as dev-dependencies,
+so — like the `rename` and `constant-fold` ports — each case drives the
+**real** source → `grammar_to_program` bridge → `InlineVariablesPass` → `emit`
+roundtrip. Each case is `assert_eq!(propagate(src), expected)` on emitted JS,
+mirroring upstream's `test("var x = 1; alert(x)", "alert(1)")` shape (modulo
+the emitter's minified-but-spaced output and boolean shorthand `true` → `!0`).
+
+### What our pass supports (active `#[test]`s)
+
+closurec's `InlineVariablesPass` implements the **provably-sound const-literal
+propagation** core of upstream `InlineVariables`: it replaces uses of a
+`const` bound to a **literal** with that literal, under a multi-use size
+budget (a long literal is only propagated when it has a single use), with two
+soundness guards upstream gets from full flow analysis:
+
+- **TDZ**: a `const` is only propagated when everything sequenced before its
+  declaration is *inert* (literal-valued `const`s / hoisted-but-uncalled
+  function declarations), so no code can observe the binding in its temporal
+  dead zone.
+- **shadowing**: a name declared more than once (e.g. a top-level `const` plus
+  a function parameter of the same name) is declined.
+
+Property names (`obj.RATE`) are never replaced; computed member indices
+(`obj[RATE]`) are. `let`/`var` are never propagated (reassignable), and a
+non-literal initializer (identifier alias, call, member) is declined.
+
+**Important divergence:** our pass only *propagates* — it leaves the now-dead
+`const X = …;` husk in place for the downstream `remove-unused-vars` pass to
+delete. Upstream `InlineVariables` removes the declaration itself once every
+reference is inlined. So the active cases assert the husk **remains**.
+
+### What we do NOT do yet (`#[ignore = "blocked on gap-NNN"]`)
+
+- **gap-148** — inline a single-assignment `let`/`var` (assigned once, never
+  reassigned). Upstream inlines any effectively-constant variable, not only
+  `const`.
+- **gap-149** — inline an **identifier alias** initializer (`const A = B;` →
+  uses of `A` become `B`) when the alias target is not reassigned.
+- **gap-150** — **remove the dead declaration** after all references are
+  inlined (upstream deletes `const R = 2;` once `R` has no remaining uses;
+  ours leaves the husk for `remove-unused-vars`).
+
+Each ignored placeholder is pinned to a `gap-NNN` entry in
+`code/specs/CLOC12-gaps.md`; running with `--include-ignored` measures
+progress as those gaps close.

--- a/code/packages/rust/closure-pass-inline-variables/tests/upstream/UPSTREAM_SHA
+++ b/code/packages/rust/closure-pass-inline-variables/tests/upstream/UPSTREAM_SHA
@@ -1,0 +1,13 @@
+# UPSTREAM_SHA
+#
+# Tracks google/closure-compiler at this commit. Every Rust file in
+# tests/upstream/ was ported from a Java file at this snapshot.
+#
+# Upgrade policy: bump this SHA only in a dedicated PR that re-ports
+# every Java source listed in ATTRIBUTION.md, diff-checks against the
+# previous port, and explicitly handles added / removed / renamed
+# tests per CLOC12 §4.
+
+commit:  5bb35ec1245dc1d3557481e5f8b4db344bcd1e6b
+date:    2026-05-28
+url:     https://github.com/google/closure-compiler/tree/5bb35ec1245dc1d3557481e5f8b4db344bcd1e6b

--- a/code/packages/rust/closure-pass-inline-variables/tests/upstream/inline_variables_test.rs
+++ b/code/packages/rust/closure-pass-inline-variables/tests/upstream/inline_variables_test.rs
@@ -1,0 +1,225 @@
+//! Ported from `InlineVariablesTest.java` in `google/closure-compiler`,
+//! Apache-2.0. Upstream SHA: see `tests/upstream/UPSTREAM_SHA`.
+//!
+//! Translation policy: see
+//! `code/specs/CLOC12-upstream-test-suite-port.md`.
+//!
+//! # What this file covers
+//!
+//! The **first** CLOC12 port into `closure-pass-inline-variables`.
+//! Upstream `InlineVariables` inlines any *effectively-constant* variable
+//! (a `var`/`let`/`const` assigned exactly once and never reassigned),
+//! substituting its value at every reference and then deleting the
+//! declaration.
+//!
+//! closurec's `InlineVariablesPass` implements the provably-sound
+//! **const-literal** core of that: it replaces uses of a `const` bound to
+//! a **literal** with that literal, under a multi-use size budget, with
+//! TDZ and shadowing soundness guards — and (a deliberate divergence) it
+//! only *propagates*, leaving the now-dead `const X = …;` husk for the
+//! downstream `remove-unused-vars` pass to delete. So the active cases
+//! assert the husk **remains**, and the whole-`InlineVariables` behaviors
+//! (single-assignment `let`/`var`, alias initializers, husk removal) are
+//! pinned as `#[ignore = "blocked on gap-NNN"]` placeholders.
+//!
+//! ## Harness
+//!
+//! The crate carries `javascript-parser` + `closure-emitter` dev-deps, so
+//! each case drives the **real** source → `grammar_to_program` bridge →
+//! `InlineVariablesPass` → `emit` roundtrip. Each is
+//! `assert_eq!(propagate(src), expected)` on emitted JS.
+//!
+//! NOTE on emit: assertions are against raw `closure-emitter` output —
+//! binary operators keep spaces, statements end in `;`, and booleans use
+//! Closure shorthand (`true` → `!0`, `false` → `!1`).
+
+use coding_adventures_closure_emitter::{emit, EmitOptions};
+use coding_adventures_closure_pass_inline_variables::InlineVariablesPass;
+use coding_adventures_closure_pass_pipeline::{Pass, PassContext};
+use coding_adventures_correlation_vector::CVLog;
+use coding_adventures_javascript_parser::{bridge, parse_javascript_typed};
+use coding_adventures_javascript_tokens::EsVersion;
+use coding_adventures_type_sidecar::Sidecar;
+
+// =====================================================================
+// Test-support harness
+// =====================================================================
+
+/// Parse `src`, bridge to a typed `Program`, run `InlineVariablesPass`,
+/// and emit the result as minified JS. Returns the emitted string.
+fn propagate(src: &str) -> String {
+    let es = EsVersion::Es2025;
+    let node = parse_javascript_typed(src, es).expect("parse");
+    let prog = bridge::grammar_to_program(&node, es).expect("bridge");
+
+    let pass = InlineVariablesPass::new();
+    let sidecar = Sidecar::new();
+    let mut cv = CVLog::new(false);
+    let out = pass
+        .run(PassContext {
+            program: &prog,
+            sidecar: &sidecar,
+            cv: &mut cv,
+        })
+        .expect("inline-variables");
+
+    let mut cv2 = CVLog::new(false);
+    let opts = EmitOptions {
+        source_map: false,
+        ..Default::default()
+    };
+    emit(&out.program, &sidecar, &mut cv2, &opts)
+        .expect("emit")
+        .code
+}
+
+// =====================================================================
+// Active — const-literal propagation our pass performs today.
+// (The dead `const X=…;` husk is EXPECTED to remain — see module docs.)
+// =====================================================================
+
+/// Upstream `testSimpleInlineConst` (const-literal subset): a single use
+/// of a literal `const` is replaced by the literal.
+#[test]
+fn inline_single_use_const_literal() {
+    assert_eq!(propagate("const RATE = 2; use(RATE);"), "const RATE=2;use(2);");
+}
+
+/// The literal is substituted inside a larger expression.
+#[test]
+fn inline_const_into_expression() {
+    assert_eq!(
+        propagate("const RATE = 2; total(base * RATE);"),
+        "const RATE=2;total(base*2);"
+    );
+}
+
+/// A short literal is worth duplicating across multiple sites.
+#[test]
+fn inline_short_literal_at_multiple_sites() {
+    assert_eq!(
+        propagate("const N = 3; a(N); b(N); c(N);"),
+        "const N=3;a(3);b(3);c(3);"
+    );
+}
+
+/// Boolean and null literals propagate (booleans via Closure shorthand).
+#[test]
+fn inline_boolean_and_null_literals() {
+    assert_eq!(
+        propagate("const ON = true; const NONE = null; f(ON, NONE);"),
+        "const ON=!0;const NONE=null;f(!0,null);"
+    );
+}
+
+/// Upstream `testNoInlineConstantWithComplexValue`-style budget: a long
+/// literal used at MULTIPLE sites is not worth duplicating — declined.
+#[test]
+fn does_not_inline_long_literal_at_multiple_sites() {
+    assert_eq!(
+        propagate("const MSG = \"a long message value\"; a(MSG); b(MSG);"),
+        "const MSG=\"a long message value\";a(MSG);b(MSG);"
+    );
+}
+
+/// A long literal at a SINGLE site is always worth it.
+#[test]
+fn inline_long_literal_at_single_site() {
+    assert_eq!(
+        propagate("const MSG = \"a long message value\"; a(MSG);"),
+        "const MSG=\"a long message value\";a(\"a long message value\");"
+    );
+}
+
+/// `let` / `var` are reassignable — never propagated by this pass.
+#[test]
+fn does_not_inline_let_or_var() {
+    assert_eq!(propagate("let X = 5; use(X);"), "let X=5;use(X);");
+    assert_eq!(propagate("var Y = 5; use(Y);"), "var Y=5;use(Y);");
+}
+
+/// A non-literal initializer (identifier alias / call) is declined —
+/// could be reassigned or have side effects.
+#[test]
+fn does_not_inline_non_literal_value() {
+    assert_eq!(propagate("const X = other; use(X);"), "const X=other;use(X);");
+    assert_eq!(propagate("const X = make(); use(X);"), "const X=make();use(X);");
+}
+
+/// Upstream `testNoInlineWithShadow`: a name declared twice (const plus a
+/// function parameter of the same name) is declined — a use could resolve
+/// to either binding.
+#[test]
+fn does_not_inline_shadowed_name() {
+    assert_eq!(
+        propagate("const RATE = 2; function f(RATE) { return RATE; }"),
+        "const RATE=2;function f(RATE){return RATE};"
+    );
+}
+
+/// A property name (`obj.RATE`) is not a use of the const — not replaced.
+#[test]
+fn does_not_replace_property_name() {
+    assert_eq!(
+        propagate("const RATE = 2; use(obj.RATE);"),
+        "const RATE=2;use(obj.RATE);"
+    );
+}
+
+/// A computed member `obj[RATE]` IS a use position — replaced.
+#[test]
+fn replaces_computed_member_index() {
+    assert_eq!(
+        propagate("const RATE = 2; use(obj[RATE]);"),
+        "const RATE=2;use(obj[2]);"
+    );
+}
+
+/// Soundness (TDZ): with an inert prefix (only literal `const`s before
+/// it), a `const` is safe to propagate.
+#[test]
+fn inline_through_inert_const_prefix() {
+    assert_eq!(
+        propagate("const A = 1; const X = 2; f(A, X);"),
+        "const A=1;const X=2;f(1,2);"
+    );
+}
+
+/// Soundness (TDZ): a top-level call `g()` runs before `const X`
+/// initializes; `g` could read `X` in its temporal dead zone and throw.
+/// Propagating the literal would erase that throw — declined.
+#[test]
+fn does_not_inline_when_code_runs_before_declaration() {
+    assert_eq!(propagate("g(); const X = 5; use(X);"), "g();const X=5;use(X);");
+}
+
+// =====================================================================
+// Ignored — whole-`InlineVariables` behaviors we do not do yet.
+// The `expected` strings encode the upstream target, so flipping
+// `#[ignore]` off is a one-line change once the gap closes.
+// =====================================================================
+
+/// Upstream inlines a single-assignment `let`/`var` (assigned once, never
+/// reassigned) and removes the declaration. Ours only propagates `const`.
+#[test]
+#[ignore = "blocked on gap-148: only const literals propagate; single-assignment let/var not inlined"]
+fn inline_single_assignment_let() {
+    assert_eq!(propagate("let X = 5; use(X);"), "use(5);");
+}
+
+/// Upstream inlines an identifier-alias initializer (`const A = B` → uses
+/// of `A` become `B`) when the alias target is not reassigned.
+#[test]
+#[ignore = "blocked on gap-149: identifier-alias initializers not inlined"]
+fn inline_identifier_alias() {
+    assert_eq!(propagate("const A = B; use(A);"), "use(B);");
+}
+
+/// Upstream removes the dead declaration once every reference is inlined.
+/// Ours leaves the husk for `remove-unused-vars` (so today the const
+/// remains — see the active `inline_single_use_const_literal`).
+#[test]
+#[ignore = "blocked on gap-150: dead const declaration husk not removed (remove-unused-vars owns that)"]
+fn removes_dead_const_after_inlining() {
+    assert_eq!(propagate("const R = 2; use(R);"), "use(2);");
+}

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -1285,3 +1285,47 @@ Placeholder: `rename_function_declaration_name`.
 Upstream's generator (`testBias*`) hands the shortest name to the
 most-referenced variable to improve gzip. `RenamePass` allocates fresh names in
 declaration order. Placeholder: `frequency_biased_name_allocation`.
+
+## CLOC12.146 — InlineVariables port (inline-variables)
+
+- **What it is:** a CLOC12 upstream port and the **first** into
+  `closure-pass-inline-variables`. New file
+  `tests/upstream/inline_variables_test.rs`, registered as the
+  `upstream_inline_variables` test target, ported from upstream
+  `InlineVariablesTest.java`. Drives the real source → `grammar_to_program`
+  bridge → `InlineVariablesPass` → `emit` roundtrip (the crate carries
+  `javascript-parser` + `closure-emitter` dev-deps), so each case is
+  `assert_eq!(propagate(src), expected)` on emitted JS.
+- **13 active `#[test]`s pass on the first run** (no new propagation bug):
+  single-use const-literal propagation, propagation into an expression, a
+  short literal at multiple sites, boolean/null literals, the multi-use size
+  budget (long literal declined at multiple sites, propagated at a single
+  site), `let`/`var` never propagated, non-literal initializers declined, the
+  shadowed-name guard, property names never replaced while computed member
+  indices are, and two TDZ soundness cases.
+- **3 `#[ignore]` placeholders** pin whole-`InlineVariables` behaviors this
+  pass does not do — see gap-148 … gap-150.
+
+  (Numbering note: this port was authored off `origin/main` in parallel with
+  the rename port CLOC12.145 / gap-144…147, so it deliberately takes the next
+  free numbers CLOC12.146 / gap-148…150 to avoid collision when both merge.)
+
+### gap-148 — single-assignment `let`/`var` not inlined
+
+closurec's `InlineVariablesPass` only propagates `const` bound to a literal.
+Upstream `InlineVariables` inlines any *effectively-constant* variable — a
+`let`/`var` assigned exactly once and never reassigned — and removes the
+declaration. Placeholder: `inline_single_assignment_let`.
+
+### gap-149 — identifier-alias initializers not inlined
+
+Upstream inlines `const A = B;` (an identifier-alias initializer), replacing
+uses of `A` with `B` when the alias target is not reassigned. Ours declines any
+non-literal initializer. Placeholder: `inline_identifier_alias`.
+
+### gap-150 — dead `const` declaration husk not removed
+
+closurec's pass only *propagates*: after inlining every reference it leaves the
+now-dead `const R = 2;` in place for the downstream `remove-unused-vars` pass
+to delete. Upstream `InlineVariables` removes the declaration itself once it has
+no remaining uses. Placeholder: `removes_dead_const_after_inlining`.


### PR DESCRIPTION
## Summary

CLOC12 upstream-test port and the **first** into **`closure-pass-inline-variables`** (#88). Ports google/closure-compiler's `InlineVariablesTest.java` into `tests/upstream/inline_variables_test.rs`, driving the **real** source → `grammar_to_program` bridge → `InlineVariablesPass` → `emit` roundtrip, so each case is `assert_eq!(propagate(src), expected)` on emitted JS.

## Results

- **13 active `#[test]`s pass on the first run** — no new propagation defect. Cover: single-use const-literal propagation, propagation into a larger expression, a short literal duplicated across multiple sites, boolean/null literals, the multi-use size budget (long literal declined at multiple sites, propagated at a single site), `let`/`var` never propagated, non-literal initializers declined, the shadowed-name guard, property names never replaced while computed member indices are, and two TDZ soundness cases (inert-prefix propagates; code-before-declaration declines).
- **3 `#[ignore = "blocked on gap-NNN"]` placeholders** pin whole-`InlineVariables` behaviors this pass does not do:
  - **gap-148** — single-assignment `let`/`var` inlining
  - **gap-149** — identifier-alias initializers
  - **gap-150** — removing the dead `const` husk (owned by `remove-unused-vars`)

## Scope / safety

- **Test-only**: no `src/` file is touched, so there is no downstream ripple. Full crate suite green (27 lib + 13 port, 3 ignored).
- Adds `tests/upstream/{UPSTREAM_SHA,ATTRIBUTION.md}` scaffolding; registers the `upstream_inline_variables` `[[test]]` target; bumps the crate 0.7.0 → 0.8.0 with CHANGELOG + README.
- **Numbering**: authored off `origin/main` in parallel with the rename port (CLOC12.145 / gap-144…147), so this deliberately takes CLOC12.146 / gap-148…150 to avoid collision. A `code/specs/CLOC12-gaps.md` rebase against the now-merged rename port keeps both sections.
- Inline security review: **PASSED** (test-only, no untrusted input, no `unsafe`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)