### PR TITLE
feat(visicalc-android): wire the demo to the Rust engine over JNI (was static)

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -840,6 +840,7 @@ members = [
     "spreadsheet-core",
     "number-format-core",
     "spreadsheet-core-wasm",
+    "spreadsheet-android-jni",
     "spreadsheet-capi",
     "spreadsheet-wasm",
 ]

--- a/code/packages/rust/jni-bridge/src/lib.rs
+++ b/code/packages/rust/jni-bridge/src/lib.rs
@@ -68,6 +68,12 @@
 //! }
 //! ```
 
+// C `char` is signed (i8) on x86_64/aarch64 desktop but UNSIGNED (u8) on
+// Android/aarch64, so JNI string-pointer types must use `c_char`, not a hardcoded
+// `i8`, to cross-compile for Android. `CString::as_ptr()` already returns `*const
+// c_char`, so this is a no-op on desktop and a fix on Android.
+use core::ffi::c_char;
+
 use std::ffi::{CStr, CString, c_void};
 use std::ptr::null_mut;
 
@@ -266,7 +272,7 @@ pub unsafe fn jni_find_class(env: *mut JNIEnv, name: &str) -> jclass {
         Ok(c) => c,
         Err(_) => return null_mut(),
     };
-    type F = unsafe extern "C" fn(*mut JNIEnv, *const i8) -> jclass;
+    type F = unsafe extern "C" fn(*mut JNIEnv, *const c_char) -> jclass;
     let f: F = table_fn(env, FIND_CLASS_OFFSET);
     f(env, cs.as_ptr())
 }
@@ -296,7 +302,7 @@ pub unsafe fn jni_throw_new(env: *mut JNIEnv, class_name: &str, msg: &str) {
         Ok(c) => c,
         Err(_) => CString::new("<message contained NUL byte>").unwrap(),
     };
-    type F = unsafe extern "C" fn(*mut JNIEnv, jclass, *const i8) -> jint;
+    type F = unsafe extern "C" fn(*mut JNIEnv, jclass, *const c_char) -> jint;
     let f: F = table_fn(env, THROW_NEW_OFFSET);
     f(env, cls, cs.as_ptr());
 }
@@ -337,8 +343,8 @@ pub unsafe fn jni_get_string_utf(env: *mut JNIEnv, s: jstring) -> Option<String>
     if s.is_null() {
         return None;
     }
-    type GetF = unsafe extern "C" fn(*mut JNIEnv, jstring, *mut jboolean) -> *const i8;
-    type RelF = unsafe extern "C" fn(*mut JNIEnv, jstring, *const i8);
+    type GetF = unsafe extern "C" fn(*mut JNIEnv, jstring, *mut jboolean) -> *const c_char;
+    type RelF = unsafe extern "C" fn(*mut JNIEnv, jstring, *const c_char);
     let get_chars: GetF = table_fn(env, GET_STRING_UTF_CHARS_OFFSET);
     let release:   RelF = table_fn(env, RELEASE_STRING_UTF_CHARS_OFFSET);
 
@@ -365,7 +371,7 @@ pub unsafe fn jni_new_string_utf(env: *mut JNIEnv, s: &str) -> jstring {
         Ok(c) => c,
         Err(_) => return null_mut(),
     };
-    type F = unsafe extern "C" fn(*mut JNIEnv, *const i8) -> jstring;
+    type F = unsafe extern "C" fn(*mut JNIEnv, *const c_char) -> jstring;
     let f: F = table_fn(env, NEW_STRING_UTF_OFFSET);
     f(env, cs.as_ptr())
 }
@@ -390,7 +396,7 @@ pub unsafe fn jni_get_method_id(
 ) -> jmethodID {
     let cn = match CString::new(name) { Ok(c) => c, Err(_) => return null_mut() };
     let cs = match CString::new(sig)  { Ok(c) => c, Err(_) => return null_mut() };
-    type F = unsafe extern "C" fn(*mut JNIEnv, jclass, *const i8, *const i8) -> jmethodID;
+    type F = unsafe extern "C" fn(*mut JNIEnv, jclass, *const c_char, *const c_char) -> jmethodID;
     let f: F = table_fn(env, GET_METHOD_ID_OFFSET);
     f(env, cls, cn.as_ptr(), cs.as_ptr())
 }
@@ -409,7 +415,7 @@ pub unsafe fn jni_get_field_id(
 ) -> jfieldID {
     let cn = match CString::new(name) { Ok(c) => c, Err(_) => return null_mut() };
     let cs = match CString::new(sig)  { Ok(c) => c, Err(_) => return null_mut() };
-    type F = unsafe extern "C" fn(*mut JNIEnv, jclass, *const i8, *const i8) -> jfieldID;
+    type F = unsafe extern "C" fn(*mut JNIEnv, jclass, *const c_char, *const c_char) -> jfieldID;
     let f: F = table_fn(env, GET_FIELD_ID_OFFSET);
     f(env, cls, cn.as_ptr(), cs.as_ptr())
 }

--- a/code/packages/rust/spreadsheet-android-jni/Cargo.toml
+++ b/code/packages/rust/spreadsheet-android-jni/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "spreadsheet-android-jni"
+version = "0.1.0"
+edition = "2021"
+description = "JNI native library bridging the com.example.visicalc Android host to spreadsheet-core"
+publish = false
+
+[lib]
+# cdylib → the libspreadsheet_android_jni.so that Android loads via
+# System.loadLibrary("spreadsheet_android_jni"). `lib` too so `cargo test --lib`
+# can exercise the pure-Rust helpers without a JVM. Android can't use the JVM
+# Foreign Function & Memory API the Compose *Desktop* demo uses (FFM isn't on
+# Android), so the engine is reached through JNI + a cross-compiled .so instead.
+crate-type = ["cdylib", "lib"]
+name = "spreadsheet_android_jni"
+
+[dependencies]
+jni-bridge             = { path = "../jni-bridge" }
+spreadsheet-core-wasm  = { path = "../spreadsheet-core-wasm" }

--- a/code/packages/rust/spreadsheet-android-jni/src/lib.rs
+++ b/code/packages/rust/spreadsheet-android-jni/src/lib.rs
@@ -1,0 +1,145 @@
+//! spreadsheet-android-jni — JNI bridge from the `com.example.visicalc` Android
+//! host to the shared Rust spreadsheet engine (`spreadsheet-core`, reached through
+//! the same `spreadsheet-core-wasm::SpreadsheetSession` the C-ABI facade wraps).
+//!
+//! Why JNI and not the JVM Foreign Function & Memory API? The Compose *Desktop*
+//! demo loads the engine through FFM (JDK 21+). Android's ART runtime has no FFM,
+//! so a native library there is reached the classic way: `System.loadLibrary` +
+//! `native` methods whose symbols are `Java_<package>_<Class>_<method>`. We build
+//! those `extern "C"` exports directly on top of the zero-dependency `jni-bridge`
+//! crate (no `jni`/`jni-sys`/`bindgen`), cross-compile this crate to a per-ABI
+//! `.so`, and drop it in the app's `jniLibs/`.
+//!
+//! The session lives on the native heap as a boxed `SpreadsheetSession`; the Java
+//! side holds it as an opaque `long` handle and must call `nativeFree` when done.
+//! All calls are expected on a single (UI) thread — the handle is not synchronised.
+
+use jni_bridge::{jint, jlong, jstring, JNIEnv, jclass};
+use jni_bridge::{jni_get_string_utf, jni_new_string_utf};
+use spreadsheet_core_wasm::SpreadsheetSession;
+
+/// `long` handle → `&mut SpreadsheetSession`. Returns from the caller with a
+/// default value when the handle is null (a disposed/never-created session).
+macro_rules! session {
+    ($ptr:expr, $env:expr, $ret:expr) => {{
+        if $ptr == 0 {
+            return $ret;
+        }
+        &mut *($ptr as *mut SpreadsheetSession)
+    }};
+}
+
+/// Create a new, empty session. Free it with `nativeFree`.
+///
+/// # Safety
+/// Called by the JVM. Returns a heap pointer as a `long`; the Java side must pass
+/// it back unchanged and free it exactly once.
+#[no_mangle]
+pub unsafe extern "C" fn Java_com_example_visicalc_Engine_nativeNewSession(
+    _env: *mut JNIEnv,
+    _class: jclass,
+) -> jlong {
+    let session = Box::new(SpreadsheetSession::new());
+    Box::into_raw(session) as jlong
+}
+
+/// Free a session created by `nativeNewSession`. Safe to call with 0 (no-op).
+///
+/// # Safety
+/// `ptr` must be a handle from `nativeNewSession` that has not already been freed.
+#[no_mangle]
+pub unsafe extern "C" fn Java_com_example_visicalc_Engine_nativeFree(
+    _env: *mut JNIEnv,
+    _class: jclass,
+    ptr: jlong,
+) {
+    if ptr != 0 {
+        drop(Box::from_raw(ptr as *mut SpreadsheetSession));
+    }
+}
+
+/// `set_cell(a1, raw)` → JSON status string (`{"ok":true}` / error).
+///
+/// # Safety
+/// `ptr` must be a live session handle; `a1`/`raw` valid `jstring`s or null.
+#[no_mangle]
+pub unsafe extern "C" fn Java_com_example_visicalc_Engine_nativeSetCell(
+    env: *mut JNIEnv,
+    _class: jclass,
+    ptr: jlong,
+    a1: jstring,
+    raw: jstring,
+) -> jstring {
+    let session = session!(ptr, env, jni_new_string_utf(env, "{\"ok\":false}"));
+    let a1 = jni_get_string_utf(env, a1).unwrap_or_default();
+    let raw = jni_get_string_utf(env, raw).unwrap_or_default();
+    let status = session.set_cell(&a1, &raw);
+    jni_new_string_utf(env, &status)
+}
+
+/// `get_display(a1)` → the cell's formatted display string.
+///
+/// # Safety
+/// `ptr` must be a live session handle; `a1` a valid `jstring` or null.
+#[no_mangle]
+pub unsafe extern "C" fn Java_com_example_visicalc_Engine_nativeGetDisplay(
+    env: *mut JNIEnv,
+    _class: jclass,
+    ptr: jlong,
+    a1: jstring,
+) -> jstring {
+    let session = session!(ptr, env, jni_new_string_utf(env, ""));
+    let a1 = jni_get_string_utf(env, a1).unwrap_or_default();
+    jni_new_string_utf(env, &session.get_display(&a1))
+}
+
+/// `get_raw(a1)` → the cell's typed source string (for the formula bar).
+///
+/// # Safety
+/// `ptr` must be a live session handle; `a1` a valid `jstring` or null.
+#[no_mangle]
+pub unsafe extern "C" fn Java_com_example_visicalc_Engine_nativeGetRaw(
+    env: *mut JNIEnv,
+    _class: jclass,
+    ptr: jlong,
+    a1: jstring,
+) -> jstring {
+    let session = session!(ptr, env, jni_new_string_utf(env, ""));
+    let a1 = jni_get_string_utf(env, a1).unwrap_or_default();
+    jni_new_string_utf(env, &session.get_raw(&a1))
+}
+
+/// `get_display_window(row0, col0, row1, col1)` → display-window JSON (each cell
+/// rendered through its format). The Kotlin side parses this into the grid rows.
+///
+/// # Safety
+/// `ptr` must be a live session handle.
+#[no_mangle]
+pub unsafe extern "C" fn Java_com_example_visicalc_Engine_nativeGetDisplayWindow(
+    env: *mut JNIEnv,
+    _class: jclass,
+    ptr: jlong,
+    row0: jint,
+    col0: jint,
+    row1: jint,
+    col1: jint,
+) -> jstring {
+    let session = session!(ptr, env, jni_new_string_utf(env, "{}"));
+    let json = session.get_display_window(row0 as u32, col0 as u32, row1 as u32, col1 as u32);
+    jni_new_string_utf(env, &json)
+}
+
+/// `column_letters(index)` → the A1-style letters for a 1-based column index.
+///
+/// # Safety
+/// `ptr` must be a live session handle.
+#[no_mangle]
+pub unsafe extern "C" fn Java_com_example_visicalc_Engine_nativeColumnLetters(
+    env: *mut JNIEnv,
+    _class: jclass,
+    ptr: jlong,
+    index: jint,
+) -> jstring {
+    let session = session!(ptr, env, jni_new_string_utf(env, ""));
+    jni_new_string_utf(env, &session.column_letters(index as u32))
+}

--- a/code/programs/kotlin/visicalc-android/.gitignore
+++ b/code/programs/kotlin/visicalc-android/.gitignore
@@ -6,3 +6,5 @@ build/
 local.properties
 captures/
 .cxx/
+# Cross-compiled engine .so (built by scripts/build.sh, like other demos' native/)
+app/src/main/jniLibs/

--- a/code/programs/kotlin/visicalc-android/app/src/main/java/com/example/visicalc/Engine.kt
+++ b/code/programs/kotlin/visicalc-android/app/src/main/java/com/example/visicalc/Engine.kt
@@ -1,0 +1,82 @@
+package com.example.visicalc
+
+import org.json.JSONObject
+
+/**
+ * Engine — the Android host's binding to the shared Rust spreadsheet engine.
+ *
+ * The Compose *Desktop* sibling reaches the engine through the JVM Foreign
+ * Function & Memory API (JDK 21+). Android's ART runtime has no FFM, so here the
+ * engine is reached the classic way: a cross-compiled native library
+ * (`libspreadsheet_android_jni.so`, built from the `spreadsheet-android-jni` Rust
+ * crate on top of `spreadsheet-core`) loaded via `System.loadLibrary`, with
+ * `native` methods whose JNI symbols are `Java_com_example_visicalc_Engine_*`.
+ *
+ * The session lives on the native heap; this object holds it as an opaque `Long`
+ * handle and frees it in [close]. All calls happen on the UI thread.
+ */
+class Engine : AutoCloseable {
+    private val ptr: Long = nativeNewSession()
+
+    init {
+        // The classic cross-footing budget — the identical seed every other
+        // VisiCalc demo uses (E column = row sums, row 5 = column sums, E5 = grand
+        // total 169), so the Android grid shows the SAME engine-COMPUTED values,
+        // not the hard-coded placeholders it used before.
+        val cells = arrayOf(
+            "A1" to "15", "B1" to "3", "C1" to "12", "D1" to "8", "E1" to "=SUM(A1:D1)",
+            "A2" to "8", "B2" to "14", "C2" to "7", "D2" to "22", "E2" to "=SUM(A2:D2)",
+            "A3" to "12", "B3" to "9", "C3" to "18", "D3" to "6", "E3" to "=SUM(A3:D3)",
+            "A4" to "4", "B4" to "11", "C4" to "3", "D4" to "17", "E4" to "=SUM(A4:D4)",
+            "A5" to "=SUM(A1:A4)", "B5" to "=SUM(B1:B4)", "C5" to "=SUM(C1:C4)",
+            "D5" to "=SUM(D1:D4)", "E5" to "=SUM(E1:E4)",
+        )
+        for ((a1, raw) in cells) nativeSetCell(ptr, a1, raw)
+    }
+
+    /** Write a cell's source and recompute; returns the engine's JSON status. */
+    fun setCell(a1: String, raw: String): String = nativeSetCell(ptr, a1, raw)
+
+    /** A cell's typed source string (for the formula bar). */
+    fun rawAt(a1: String): String = nativeGetRaw(ptr, a1)
+
+    /** The A1-style letters for a 1-based column index (1 → "A"). */
+    fun columnLetters(index: Int): String = nativeColumnLetters(ptr, index)
+
+    /**
+     * The demo's 5×5 grid as the host expects it: one row per sheet row 1..5, each
+     * `[rowLabel, A, B, C, D, E]` where A..E are the engine's format-rendered
+     * display strings. Parses the engine's `{"cells":[[…],…]}` window JSON.
+     */
+    fun viewportRows(rows: Int = 5, cols: Int = 5): List<List<String>> {
+        val json = nativeGetDisplayWindow(ptr, 1, 1, rows, cols)
+        val cells = JSONObject(json).optJSONArray("cells") ?: return emptyList()
+        return (0 until cells.length()).map { r ->
+            val row = cells.getJSONArray(r)
+            val values = (0 until row.length()).map { c -> row.getString(c) }
+            listOf((r + 1).toString()) + values
+        }
+    }
+
+    override fun close() {
+        nativeFree(ptr)
+    }
+
+    // ── JNI bindings ────────────────────────────────────────────────────────
+    // Instance `external` methods so the JNI symbols are exactly
+    // `Java_com_example_visicalc_Engine_native*` (the implicit `this`/jclass second
+    // argument is ignored on the Rust side). See spreadsheet-android-jni.
+    private external fun nativeNewSession(): Long
+    private external fun nativeFree(ptr: Long)
+    private external fun nativeSetCell(ptr: Long, a1: String, raw: String): String
+    private external fun nativeGetDisplay(ptr: Long, a1: String): String
+    private external fun nativeGetRaw(ptr: Long, a1: String): String
+    private external fun nativeGetDisplayWindow(ptr: Long, row0: Int, col0: Int, row1: Int, col1: Int): String
+    private external fun nativeColumnLetters(ptr: Long, index: Int): String
+
+    companion object {
+        init {
+            System.loadLibrary("spreadsheet_android_jni")
+        }
+    }
+}

--- a/code/programs/kotlin/visicalc-android/app/src/main/java/com/example/visicalc/MainActivity.kt
+++ b/code/programs/kotlin/visicalc-android/app/src/main/java/com/example/visicalc/MainActivity.kt
@@ -30,6 +30,7 @@ import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.material.darkColors
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -40,18 +41,11 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 
-// 5×5 sample dataset shared with every other visicalc-* demo.
-// Each row's leading cell is the row-label ("1".."5"), matching the
-// shape the other VC2-* demos feed their Grid: the column count lines
-// up 1:1 with columnHeaders (leading "" corner) and columnWidths
-// (leading 48px gutter), so row numbers march down the left edge.
-private val sampleRows: List<List<String>> = listOf(
-    listOf("1", "15", "3",  "12", "8",  "5"),
-    listOf("2", "8",  "14", "7",  "22", "11"),
-    listOf("3", "12", "9",  "18", "6",  "25"),
-    listOf("4", "4",  "11", "3",  "17", "9"),
-    listOf("5", "7",  "5",  "13", "10", "19"),
-)
+// The A1 address of a selected (row, col) in the grid's coordinate space:
+// column 0 is the row-label gutter (no cell), column 1 → "A"; selectedRow is
+// 0-based (0 → sheet row 1).
+private fun cellAddress(selectedRow: Double, selectedCol: Double): String =
+    "${('A' + selectedCol.toInt() - 1)}${selectedRow.toInt() + 1}"
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -75,12 +69,22 @@ private fun VisiCalcApp() {
     // coordinate (mosaic-emit-compose lowers `number`-typed slots
     // to `Double` so verbatim Expr like `r == editRow` compiles).
     // Column 0 is the row-label gutter; the first data cell is column 1.
+    // The Rust engine, reached over JNI (see Engine.kt). Seeded with the shared
+    // cross-footing budget, it holds the cells / dependency graph / recalc — the
+    // grid below renders ITS computed values, and edits write back through it.
+    val engine = remember { Engine() }
+    // Free the native session (the boxed SpreadsheetSession on the Rust heap) when
+    // this composable leaves the tree, so the handle doesn't leak.
+    DisposableEffect(Unit) { onDispose { engine.close() } }
+    var viewportRows by remember { mutableStateOf(engine.viewportRows()) }
+
     var selectedRow by remember { mutableStateOf(0.0) }
     var selectedCol by remember { mutableStateOf(1.0) }
     var editRow     by remember { mutableStateOf(-1.0) }
     var editCol     by remember { mutableStateOf(-1.0) }
     var editContent by remember { mutableStateOf("") }
-    var formulaText by remember { mutableStateOf("=SUM(B1:B5)") }
+    // Start showing A1's source ("15") in the bar, like the sibling demos.
+    var formulaText by remember { mutableStateOf(engine.rawAt("A1")) }
 
     Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
         Text(
@@ -100,9 +104,22 @@ private fun VisiCalcApp() {
                 dispatch = { event ->
                     when (event) {
                         is FormulaBarEvent.FormulaChange -> formulaText = event.value
-                        is FormulaBarEvent.Commit -> { /* no-op for v0.1.0 */ }
+                        is FormulaBarEvent.Commit -> {
+                            // Write the edit through to the engine and recompute;
+                            // every dependent cell (E-column row sums, row-5 column
+                            // sums, the grand total) updates in the refreshed grid.
+                            if (selectedCol.toInt() >= 1) {
+                                val a1 = cellAddress(selectedRow, selectedCol)
+                                engine.setCell(a1, formulaText)
+                                viewportRows = engine.viewportRows()
+                                formulaText = engine.rawAt(a1)
+                            }
+                        }
                         is FormulaBarEvent.Cancel ->
-                            formulaText = sampleRows[selectedRow.toInt()][selectedCol.toInt()]
+                            formulaText =
+                                if (selectedCol.toInt() >= 1)
+                                    engine.rawAt(cellAddress(selectedRow, selectedCol))
+                                else ""
                     }
                 },
             )
@@ -115,7 +132,7 @@ private fun VisiCalcApp() {
                 // Leading "" is the empty corner above the row-label
                 // gutter; A–E label the five data columns.
                 columnHeaders = listOf("", "A", "B", "C", "D", "E"),
-                viewportRows = sampleRows,
+                viewportRows = viewportRows,
                 columnWidths = listOf(48.0, 96.0, 96.0, 96.0, 96.0, 96.0),
                 totalHeight = 0.0,
                 selectedRow = selectedRow,
@@ -128,12 +145,12 @@ private fun VisiCalcApp() {
                         is GridEvent.Navigate -> {
                             selectedRow = event.row
                             selectedCol = event.col
-                            val r = event.row.toInt()
-                            val c = event.col.toInt()
-                            if (r in sampleRows.indices &&
-                                c in sampleRows[r].indices) {
-                                formulaText = sampleRows[r][c]
-                            }
+                            // Load the newly-selected cell's SOURCE into the bar
+                            // (A1 → "15", E1 → "=SUM(A1:D1)") from the engine.
+                            formulaText =
+                                if (event.col.toInt() >= 1)
+                                    engine.rawAt(cellAddress(event.row, event.col))
+                                else ""
                         }
                         is GridEvent.FormulaChange -> editContent = event.value
                         is GridEvent.EditCommit -> {

--- a/code/programs/kotlin/visicalc-android/scripts/build.sh
+++ b/code/programs/kotlin/visicalc-android/scripts/build.sh
@@ -69,6 +69,37 @@ generate() {
 generate "FormulaBar" "$SRC/FormulaBar.desktop.mll"
 generate "Grid"       "$SRC/Grid.desktop.mll"
 
+
+# ── Engine (Rust → per-ABI .so via the NDK) ──────────────────────────────────
+# Android's ART runtime has no JVM Foreign Function & Memory API (the path the
+# Compose *Desktop* demo uses), so the shared engine is reached over JNI: this
+# cross-compiles the `spreadsheet-android-jni` crate (a zero-dep jni-bridge shim
+# over spreadsheet-core) to a `.so` per ABI and stages it into jniLibs/, where
+# `System.loadLibrary("spreadsheet_android_jni")` (Engine.kt) loads it.
+NDK_ROOT="${ANDROID_NDK_HOME:-${ANDROID_HOME:-$HOME/Library/Android/sdk}/ndk/28.2.13676358}"
+TC="$(ls -d "$NDK_ROOT/toolchains/llvm/prebuilt/"*/ 2>/dev/null | head -1)"
+MIN_API=26
+if [ -n "$TC" ]; then
+  for pair in "arm64-v8a:aarch64-linux-android" "x86_64:x86_64-linux-android"; do
+    abi="${pair%%:*}"; target="${pair##*:}"
+    LINKER="$TC/bin/${target}${MIN_API}-clang"
+    [ -x "$LINKER" ] || continue
+    upper="$(printf '%s' "$target" | tr 'a-z-' 'A-Z_')"
+    under="$(printf '%s' "$target" | tr '-' '_')"
+    echo "Cross-compiling engine for $abi ($target)..."
+    ( cd "$REPO_ROOT/code/packages/rust"       && "$(command -v rustup)" target add "$target" >/dev/null 2>&1 || true
+      env "CARGO_TARGET_${upper}_LINKER=$LINKER" "CC_${under}=$LINKER" "AR_${under}=$TC/bin/llvm-ar"         cargo build -q -p spreadsheet-android-jni --target "$target" --release )
+    so="$REPO_ROOT/code/packages/rust/target/$target/release/libspreadsheet_android_jni.so"
+    if [ -f "$so" ]; then
+      mkdir -p "$DEMO_DIR/app/src/main/jniLibs/$abi"
+      cp "$so" "$DEMO_DIR/app/src/main/jniLibs/$abi/"
+      echo "  staged -> app/src/main/jniLibs/$abi/libspreadsheet_android_jni.so"
+    fi
+  done
+else
+  echo "WARN: Android NDK not found at $NDK_ROOT — skipping engine cross-compile."
+fi
+
 echo "Done. Generated:"
 ls -la "$OUT_DIR" | grep -E '\.kt$'
 echo


### PR DESCRIPTION
## Why

The Android demo rendered **hard-coded `sampleRows`** — it was never engine-backed. Android's ART runtime has no JVM Foreign Function & Memory API (the path the Compose *Desktop* demo uses), so the engine has to be reached the classic way: `System.loadLibrary` + `native` methods over a cross-compiled `.so`. This wires it to the shared `spreadsheet-core` engine so the grid shows the **same computed values** as every other backend.

## What

- **New crate `code/packages/rust/spreadsheet-android-jni`** — a zero-dependency JNI shim built on the repo's `jni-bridge` (no `jni`/`jni-sys`/bindgen), exposing `Java_com_example_visicalc_Engine_native*` over a boxed `SpreadsheetSession` handle (new/free, set-cell, get-display/raw, get-display-window JSON, column-letters). Cross-compiles to a per-ABI `.so`.
- **`jni-bridge` portability fix** — it hardcoded `*const i8` for JNI string pointers, which only compiles where `c_char == i8` (desktop). On Android/aarch64 `c_char` is unsigned (`u8`), so the cross-compile failed. Switched to `*const c_char`: a **no-op on desktop** (verified: `jni-bridge` tests pass and `conduit-jni` / `silicon-rust-jni` / `irc-server-native-jni` still build), a fix on Android.
- **Kotlin `Engine.kt`** — `System.loadLibrary` + `external` JNI bindings, parses the `{"cells":[…]}` window JSON with `org.json`, seeds the shared cross-footing budget, frees the native session via a `DisposableEffect`. **`MainActivity`** now renders `engine.viewportRows()` and its formula bar edits write through `engine.setCell` and refresh (edit → recompute).
- **`scripts/build.sh`** cross-compiles the engine to `arm64-v8a` + `x86_64` via the NDK and stages the `.so` into `jniLibs/` (git-ignored, like other demos' `native/`).

## Verification
Installed + launched on a **Pixel 9 (API 36) emulator**: the engine `.so` loads (no `UnsatisfiedLinkError`), and the grid shows engine-**computed** values — row 5 is the live column sums **39/37/40/53** (`=SUM(A1:A4)` …), not the old static placeholders (7/5/13/10/19). APK bundles `lib/arm64-v8a/libspreadsheet_android_jni.so`.

Security review: PASSED — the opaque-handle round-trip is the standard pattern (null-guarded free, single-`val` handle, single-thread sequential `&mut`, no double-free/UAF/aliasing); the `c_char` change is sound; no injection/DoS surface (window JSON is trusted engine output; build.sh uses fixed paths).

Known minor follow-up (not in this PR): the E-column row-sums scroll off the narrow phone screen — a cosmetic horizontal-overflow, fixable with a horizontal scroll like the iOS SwiftUI fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)