### PR TITLE
feat(sir-exceptions): thread user-defined class ancestry into rescue matching (E2, python+ts)

### DIFF
--- a/code/packages/python/sir-runtime-exceptions/CHANGELOG.md
+++ b/code/packages/python/sir-runtime-exceptions/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.2.0 — user-defined exception-class ancestry (E2)
+
+Adds `register_ancestry(mapping)`: the SIR backend threads user
+`class Child < Parent` edges here at program init (an explicit
+`{childClassName: superclassName}` string map — no `eval`/reflection), so
+`rescue_matches` walks a user class up through its registered superclass and on
+into the built-in table. A `rescue StandardError` now catches a raised user
+`MyErr < StandardError`.
+
+- User edges are **additive**: they layer over the frozen built-in ancestry
+  without replacing it, so built-in matching is unchanged. A user class with no
+  registered edge still matches only by exact name (or via `Exception` / a bare
+  `rescue`).
+- The cycle guard in `_is_ancestor_or_self` already tolerates a malformed
+  self-referential edge.
+- `register_ancestry` is re-exported from the package root.
+
 ## 0.1.0 — initial release
 
 First release of the SIR exception runtime for Python, per

--- a/code/packages/python/sir-runtime-exceptions/README.md
+++ b/code/packages/python/sir-runtime-exceptions/README.md
@@ -41,6 +41,7 @@ feature (a `try`/`rescue` or a `raise`); pure modules never gain the dependency.
 | `raise_error(class_name="RuntimeError", message=None) -> NoReturn` | Raise a `SirError`. Bare `raise_error()` re-raises as a generic `RuntimeError`. |
 | `class_of_thrown(exc) -> str` | The SIR class name of a caught value (native errors → `StandardError`). |
 | `rescue_matches(exc, class_names) -> bool` | Does a caught value match a `rescue` clause naming `class_names`? Empty list = bare `rescue` (catch-all). |
+| `register_ancestry(mapping) -> None` | Merge user `{childClassName: superclassName}` edges (from `class Child < Parent`) into the ancestry the matcher walks, so `rescue StandardError` catches a raised user `MyErr < StandardError`. Additive over the built-in table; explicit string map (no reflection). |
 
 ### Emitted shape
 

--- a/code/packages/python/sir-runtime-exceptions/pyproject.toml
+++ b/code/packages/python/sir-runtime-exceptions/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sir-runtime-exceptions"
-version = "0.1.0"
+version = "0.2.0"
 description = "Exception runtime for Semantic-IR-emitted Python — SIR exception base class, raise helper, and rescue-clause class matching"
 requires-python = ">=3.12"
 dependencies = []

--- a/code/packages/python/sir-runtime-exceptions/src/coding_adventures_sir_runtime_exceptions/__init__.py
+++ b/code/packages/python/sir-runtime-exceptions/src/coding_adventures_sir_runtime_exceptions/__init__.py
@@ -16,11 +16,13 @@ ship here, imported by the emitted module::
 It implements **SIR** semantics (not any one source language's), so a future
 JavaScript -> SIR -> Python path reuses it.  See ``code/specs/sir-runtime.md``.
 
-**v0 limitation:** user-defined exception-class ancestry is unknown (no SIR
-exception-class symbol table), so ``rescue StandardError`` matches only the
-built-in subclasses and user classes match by exact name; a bare re-raise
-becomes a generic ``RuntimeError``.  Both await frontend threading of the
-exception model.
+**User ancestry (E2):** the backend threads ``class Child < Parent`` edges here
+via :func:`register_ancestry` at program init, so ``rescue StandardError`` also
+catches a raised user ``MyErr < StandardError``.  User edges are additive over
+the built-in table; a user class with no registered superclass still matches by
+exact name (or via ``Exception`` / a bare ``rescue``).  A bare re-raise still
+becomes a generic ``RuntimeError`` (awaits frontend threading of the in-flight
+exception).
 """
 
 from __future__ import annotations
@@ -30,6 +32,7 @@ from .exceptions import (
     Val,
     class_of_thrown,
     raise_error,
+    register_ancestry,
     rescue_matches,
 )
 
@@ -38,5 +41,6 @@ __all__ = [
     "Val",
     "class_of_thrown",
     "raise_error",
+    "register_ancestry",
     "rescue_matches",
 ]

--- a/code/packages/python/sir-runtime-exceptions/src/coding_adventures_sir_runtime_exceptions/exceptions.py
+++ b/code/packages/python/sir-runtime-exceptions/src/coding_adventures_sir_runtime_exceptions/exceptions.py
@@ -22,13 +22,17 @@ have no faithful native equivalent and live here:
 a future JavaScript->SIR->Python path reuses them unchanged.  See
 ``code/specs/sir-runtime.md``.
 
-**Honest v0 limitation.**  SIR has no exception-class symbol table, so the
-ancestry of *user-defined* exception classes is unknown here.  We bake in the
-common built-in Ruby hierarchy (so ``rescue StandardError`` catches a
-``RuntimeError``/``ArgumentError``/…), match user classes by exact name, and let
-the universal root ``Exception`` (and a bare ``rescue``) catch anything.  Full
-user-class ancestry awaits a frontend that threads class definitions into the
-exception model.
+**User-class ancestry (E2).**  The built-in table below is fixed, but SIR *does*
+carry ``class MyErr < StandardError`` edges in ``Stmt::ClassDef``.  The backend
+threads them here with :func:`register_ancestry` at program init, so a
+``rescue StandardError`` catches a raised ``MyErr`` even though ``MyErr`` is not
+in the built-in table.  We keep this an **explicit string→string map** — no
+``eval``/reflection, no walking real Python classes — because the SIR class
+names are just tags, not live Python types.  User edges are *additive*: they
+extend the chain up to a built-in root (``StandardError → Exception``) and never
+mutate the built-in entries, so built-in matching is unchanged.  A user class
+with no registered superclass still matches only by exact name (or via
+``Exception`` / a bare ``rescue``), exactly as before.
 """
 
 from __future__ import annotations
@@ -53,7 +57,7 @@ Val = Any
 #        ├─ NameError ─ NoMethodError      ├─ RangeError
 #        ├─ IndexError ─ KeyError          ├─ ZeroDivisionError
 #        ├─ IOError    ├─ StopIteration    └─ NotImplementedError
-_ANCESTRY: dict[str, str] = {
+_BUILTIN_ANCESTRY: dict[str, str] = {
     "RuntimeError": "StandardError",
     "ArgumentError": "StandardError",
     "TypeError": "StandardError",
@@ -68,6 +72,38 @@ _ANCESTRY: dict[str, str] = {
     "NotImplementedError": "StandardError",
     "StandardError": "Exception",
 }
+
+# The *live* ancestry the matcher walks.  Seeded from the built-in table and
+# then extended in place by :func:`register_ancestry` with user ``child ->
+# superclass`` edges.  We start from a copy so a caller can never mutate the
+# frozen built-in reference, and so tests can restore a pristine state by
+# re-seeding.  A *user* edge that names a built-in child (e.g. redefining
+# ``RuntimeError``) is honoured — last writer wins — but the emitter never does
+# that; it only registers genuinely new class names.
+_ANCESTRY: dict[str, str] = dict(_BUILTIN_ANCESTRY)
+
+
+def register_ancestry(mapping: dict[str, str]) -> None:
+    """Merge user ``{childClassName: superclassName}`` edges into the ancestry.
+
+    Called once at program init with the module's ``class Child < Parent``
+    pairs, *before* any ``rescue`` runs.  After this, :func:`rescue_matches`
+    walks a user child up through its registered superclass and on into the
+    built-in table — so ``rescue StandardError`` catches a raised
+    ``MyErr < StandardError``.
+
+    The mapping is an **explicit string→string map**: keys and values are SIR
+    class-name tags, not Python classes.  We deliberately do no reflection and
+    trust no live type — the frontend already knows the static superclass edge,
+    so threading it as data keeps the runtime free of ``eval``/import magic.
+
+    Idempotent and additive: re-registering the same edge is a no-op, and user
+    edges layer on top of the built-in table without replacing it (a chain like
+    ``Grandchild -> Child -> StandardError -> Exception`` resolves by walking
+    both layers).  :func:`_is_ancestor_or_self` already guards against cycles,
+    so a malformed self-referential edge cannot loop forever.
+    """
+    _ANCESTRY.update(mapping)
 
 
 # ── The SIR exception object ─────────────────────────────────────────────────

--- a/code/packages/python/sir-runtime-exceptions/tests/test_exceptions.py
+++ b/code/packages/python/sir-runtime-exceptions/tests/test_exceptions.py
@@ -8,8 +8,10 @@ from coding_adventures_sir_runtime_exceptions import (
     SirError,
     class_of_thrown,
     raise_error,
+    register_ancestry,
     rescue_matches,
 )
+from coding_adventures_sir_runtime_exceptions import exceptions as _exc_mod
 
 
 class TestSirError:
@@ -79,5 +81,58 @@ class TestRescueMatches:
         assert rescue_matches(SirError("TypeError"), ["KeyError", "TypeError"]) is True
 
     def test_user_class_matches_only_by_exact_name(self) -> None:
+        # Without a registered ancestry edge, a user class matches only itself.
         assert rescue_matches(SirError("MyError"), ["MyError"]) is True
         assert rescue_matches(SirError("MyError"), ["StandardError"]) is False
+
+
+@pytest.fixture(autouse=True)
+def _restore_ancestry() -> None:
+    """Snapshot and restore the live ancestry so a `register_ancestry` in one
+    test cannot leak edges into another (the table is module-global mutable)."""
+    saved = dict(_exc_mod._ANCESTRY)
+    yield
+    _exc_mod._ANCESTRY.clear()
+    _exc_mod._ANCESTRY.update(saved)
+
+
+class TestRegisterAncestry:
+    """E2: user `class Child < Parent` edges threaded from the backend."""
+
+    def test_registered_user_edge_matches_builtin_ancestor(self) -> None:
+        # Before registration: user class matches only by exact name.
+        assert rescue_matches(SirError("UserErr"), ["StandardError"]) is False
+        register_ancestry({"UserErr": "StandardError"})
+        # After: it descends from StandardError, and on up to Exception.
+        assert rescue_matches(SirError("UserErr"), ["StandardError"]) is True
+        assert rescue_matches(SirError("UserErr"), ["Exception"]) is True
+        # Exact name still matches.
+        assert rescue_matches(SirError("UserErr"), ["UserErr"]) is True
+
+    def test_unrelated_user_class_still_not_matched(self) -> None:
+        register_ancestry({"UserErr": "StandardError"})
+        # A different user class with no edge does not match StandardError.
+        assert rescue_matches(SirError("OtherErr"), ["StandardError"]) is False
+        # And UserErr does not match an unrelated built-in it does not descend
+        # from.
+        assert rescue_matches(SirError("UserErr"), ["TypeError"]) is False
+
+    def test_multi_level_user_chain(self) -> None:
+        # Grandchild -> Child -> RuntimeError -> StandardError -> Exception.
+        register_ancestry({"Child": "RuntimeError", "Grandchild": "Child"})
+        assert rescue_matches(SirError("Grandchild"), ["RuntimeError"]) is True
+        assert rescue_matches(SirError("Grandchild"), ["StandardError"]) is True
+        assert rescue_matches(SirError("Grandchild"), ["Child"]) is True
+
+    def test_registration_is_additive_and_idempotent(self) -> None:
+        register_ancestry({"UserErr": "StandardError"})
+        register_ancestry({"UserErr": "StandardError"})  # no-op re-register
+        # Built-in edges are untouched.
+        assert rescue_matches(SirError("ArgumentError"), ["StandardError"]) is True
+        assert rescue_matches(SirError("UserErr"), ["StandardError"]) is True
+
+    def test_self_referential_edge_does_not_loop(self) -> None:
+        # A malformed self-edge must not hang the matcher (cycle guard).
+        register_ancestry({"Loopy": "Loopy"})
+        assert rescue_matches(SirError("Loopy"), ["Loopy"]) is True
+        assert rescue_matches(SirError("Loopy"), ["StandardError"]) is False

--- a/code/packages/rust/semantic-ir-to-python/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-python/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.4.0 — user-defined exception-class ancestry (E2)
+
+The backend now threads user `class Child < Parent` inheritance edges into the
+exception matcher, so a `rescue StandardError` catches a raised user
+`MyErr < StandardError` — not just built-in subclasses.
+
+- **Emit.** For any module that uses `Feature::Exceptions` **and** declares at
+  least one class with a superclass, the emitter collects every
+  `Stmt::ClassDef { name, superclass: Some(sc) }` pair (walking nested class /
+  module / try / loop bodies) and emits a single program-init
+  `_sir_exc_register_ancestry({"MyErr": "StandardError", …})` call, placed
+  after the runtime imports and before any function or `main` runs. Modules with
+  no superclass edge emit no registration (no empty, meaningless call).
+- **Runtime alias.** The exception-runtime import header now also aliases
+  `register_ancestry as _sir_exc_register_ancestry`.
+- Built-in matching is unchanged; user edges are purely additive. Requires
+  `coding-adventures-sir-runtime-exceptions >= 0.2.0`.
+
 ## 0.3.0 — keyword-parameter & keyword-argument emission (KW2)
 
 The backend now accepts `Feature::KeywordParams` and lowers keyword parameters

--- a/code/packages/rust/semantic-ir-to-python/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-python"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "Semantic IR → self-contained Python 3 source code (SIR14). Third backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-python/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-python/src/emit.rs
@@ -47,6 +47,123 @@ fn uses_exceptions(m: &Module) -> bool {
     m.manifest.contains(Feature::Exceptions)
 }
 
+/// Collect every `class Child < Parent` edge in the module as `(child, parent)`
+/// pairs, in source order, de-duplicated (first edge for a name wins).
+///
+/// **Why (E2).**  A `rescue StandardError` must catch a raised user
+/// `MyErr < StandardError`, but the exception runtime only knows the built-in
+/// hierarchy — it has no way to learn that `MyErr` descends from
+/// `StandardError` unless we *tell* it.  `Stmt::ClassDef` carries exactly that
+/// static edge, so we harvest the `superclass`-bearing class defs here and emit
+/// a single `register_ancestry({...})` call at program init (see
+/// [`emit_module`]).  Classes without a superclass (`class Foo`) contribute no
+/// edge — they still match by exact name, unchanged.
+///
+/// The walk mirrors [`stmt_uses_builtin`]: exhaustive over the statement forms
+/// that nest bodies (`ClassDef`/`ModuleDef`/`SingletonClassDef`/`TryCatch` and
+/// the loops), so a class defined *inside* a `begin`/loop/class body is still
+/// found.  A `ClassDef`'s own nested `body` is walked too — Ruby's frontend
+/// hoists method `def`s out, but a nested class declaration would remain.
+fn collect_user_ancestry(m: &Module) -> Vec<(String, String)> {
+    let mut pairs: Vec<(String, String)> = Vec::new();
+    let mut seen: BTreeSet<String> = BTreeSet::new();
+    for f in &m.functions {
+        collect_ancestry_in_block(&f.body, &mut pairs, &mut seen);
+    }
+    pairs
+}
+
+fn collect_ancestry_in_block(
+    b: &Block,
+    pairs: &mut Vec<(String, String)>,
+    seen: &mut BTreeSet<String>,
+) {
+    collect_ancestry_in_stmts(&b.stmts, pairs, seen);
+    collect_ancestry_in_expr(&b.value, pairs, seen);
+}
+
+fn collect_ancestry_in_stmts(
+    stmts: &[Stmt],
+    pairs: &mut Vec<(String, String)>,
+    seen: &mut BTreeSet<String>,
+) {
+    for s in stmts {
+        collect_ancestry_in_stmt(s, pairs, seen);
+    }
+}
+
+fn collect_ancestry_in_stmt(
+    s: &Stmt,
+    pairs: &mut Vec<(String, String)>,
+    seen: &mut BTreeSet<String>,
+) {
+    match s {
+        Stmt::ClassDef { name, superclass, body, .. } => {
+            if let Some(sup) = superclass {
+                if seen.insert(name.clone()) {
+                    pairs.push((name.clone(), sup.clone()));
+                }
+            }
+            collect_ancestry_in_stmts(body, pairs, seen);
+        }
+        Stmt::ModuleDef { body, .. } | Stmt::SingletonClassDef { body, .. } => {
+            collect_ancestry_in_stmts(body, pairs, seen);
+        }
+        Stmt::While { body, .. }
+        | Stmt::ForRange { body, .. }
+        | Stmt::ForEach { body, .. } => {
+            collect_ancestry_in_block(body, pairs, seen);
+        }
+        Stmt::TryCatch { body, rescues, ensure_body, .. } => {
+            collect_ancestry_in_stmts(body, pairs, seen);
+            for r in rescues {
+                collect_ancestry_in_stmts(&r.body, pairs, seen);
+            }
+            if let Some(e) = ensure_body {
+                collect_ancestry_in_stmts(e, pairs, seen);
+            }
+        }
+        // A class declaration only surfaces as a `Stmt::ClassDef`; the remaining
+        // statement forms carry expressions, which may embed a block (e.g. an
+        // `if` in value position) that in turn holds a class def.  Recurse into
+        // any nested expression so those are not missed.
+        Stmt::LetBinding { value, .. }
+        | Stmt::LetStarBinding { value, .. }
+        | Stmt::Assign { value, .. }
+        | Stmt::ExprStmt { expr: value, .. } => {
+            collect_ancestry_in_expr(value, pairs, seen);
+        }
+        Stmt::SeqSet { seq, index, value, .. } => {
+            collect_ancestry_in_expr(seq, pairs, seen);
+            collect_ancestry_in_expr(index, pairs, seen);
+            collect_ancestry_in_expr(value, pairs, seen);
+        }
+        Stmt::MapSet { map, key, value, .. } => {
+            collect_ancestry_in_expr(map, pairs, seen);
+            collect_ancestry_in_expr(key, pairs, seen);
+            collect_ancestry_in_expr(value, pairs, seen);
+        }
+    }
+}
+
+fn collect_ancestry_in_expr(
+    e: &Expr,
+    pairs: &mut Vec<(String, String)>,
+    seen: &mut BTreeSet<String>,
+) {
+    match e {
+        Expr::If { then_branch, else_branch, .. } => {
+            collect_ancestry_in_block(then_branch, pairs, seen);
+            collect_ancestry_in_block(else_branch, pairs, seen);
+        }
+        Expr::Block(b) => collect_ancestry_in_block(b, pairs, seen),
+        // No other expression form can nest a statement block that could hold a
+        // class declaration (calls/literals carry only sub-*expressions*), so
+        // there is nothing further to descend into for ancestry purposes.
+        _ => {}
+    }
+}
+
 /// True if the module uses cons pairs, in which case the emitted artifact
 /// imports `coding-adventures-sir-runtime-pairs` (the `cons`/`car`/`cdr`/
 /// `pair?` helpers, extracted from core).
@@ -220,6 +337,31 @@ pub fn emit_module(m: &Module) -> String {
     // Only range-using modules import the range runtime.
     if uses_range(m) {
         out.push_str(crate::runtime::RUNTIME_RANGE);
+    }
+    // E2: thread user `class Child < Parent` ancestry into the exception
+    // matcher at program init, *before* any function or main body runs, so a
+    // `rescue StandardError` catches a raised user `MyErr < StandardError`.
+    // Gated on both the exception import (so the helper exists) and the
+    // presence of at least one superclass edge (so we never emit an empty,
+    // meaningless registration for a module that has classes but no
+    // inheritance).
+    if uses_exceptions(m) {
+        let pairs = collect_user_ancestry(m);
+        if !pairs.is_empty() {
+            out.push_str("\n_sir_exc_register_ancestry({");
+            for (i, (child, parent)) in pairs.iter().enumerate() {
+                if i > 0 {
+                    out.push_str(", ");
+                }
+                let _ = write!(
+                    out,
+                    "{}: {}",
+                    quote_py_string(child),
+                    quote_py_string(parent)
+                );
+            }
+            out.push_str("})\n");
+        }
     }
     emit_globals(&mut out, &m.globals);
     for f in &m.functions {

--- a/code/packages/rust/semantic-ir-to-python/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-python/src/lib.rs
@@ -221,6 +221,10 @@ mod tests {
             py_root.join("sir-runtime-oop/src"),
             py_root.join("sir-runtime-range/src"),
             py_root.join("sir-runtime-regex/src"),
+            // E2 execution-proof runs emitted `try/rescue` + `register_ancestry`
+            // through a real interpreter, so the exceptions runtime must be
+            // importable too.
+            py_root.join("sir-runtime-exceptions/src"),
         ])
         .expect("join PYTHONPATH");
 
@@ -1266,6 +1270,127 @@ mod tests {
         assert!(src.contains("e = __exc"), "got:\n{}", src);
         assert!(src.contains("raise\n"), "got:\n{}", src);
         assert!(src.contains("finally:"), "got:\n{}", src);
+    }
+
+    #[test]
+    fn emits_register_ancestry_for_user_subclass_py() {
+        // E2: a `class MyErr < StandardError` in a throwing module threads its
+        // superclass edge to the exception runtime via a single program-init
+        // `register_ancestry` call, before `main` runs.
+        let module = ruby_to_semantic_ir::compile_source(
+            "class MyErr < StandardError\nend\nbegin\n  raise MyErr, \"x\"\nrescue StandardError => e\n  print(\"caught\")\nend\n",
+            "demo",
+        )
+        .expect("lower ruby");
+        let a = compile(&module).expect("compile to python");
+        let src = &a.source;
+        assert!(
+            src.contains("register_ancestry as _sir_exc_register_ancestry"),
+            "expected the register_ancestry alias; got:\n{}",
+            src
+        );
+        assert!(
+            src.contains("_sir_exc_register_ancestry({\"MyErr\": \"StandardError\"})"),
+            "expected the user ancestry registration; got:\n{}",
+            src
+        );
+        // The registration must precede the user's main function so ancestry is
+        // known before any rescue runs.
+        let reg = src.find("_sir_exc_register_ancestry(").expect("reg present");
+        let main = src.find("def _sir_user_main").expect("main present");
+        assert!(reg < main, "registration must come before main; got:\n{}", src);
+    }
+
+    #[test]
+    fn no_register_ancestry_when_no_user_superclass_py() {
+        // A throwing module whose only class has *no* superclass (or has no
+        // classes at all) must NOT emit an empty, meaningless registration.
+        let module = ruby_to_semantic_ir::compile_source(
+            "class Foo\nend\nbegin\n  raise RuntimeError, \"boom\"\nrescue RuntimeError => e\n  print(\"x\")\nend\n",
+            "demo",
+        )
+        .expect("lower ruby");
+        let a = compile(&module).expect("compile to python");
+        assert!(
+            !a.source.contains("_sir_exc_register_ancestry("),
+            "should not register ancestry with no superclass edge; got:\n{}",
+            a.source
+        );
+    }
+
+    #[test]
+    fn execution_user_subclass_rescued_by_ancestor_py() {
+        // E2 execution-proof: `raise MyErr` (a user `StandardError` subclass)
+        // *is* caught by `rescue StandardError` at runtime — proving the
+        // registered user edge is walked by the matcher, not just emitted.
+        let module = ruby_to_semantic_ir::compile_source(
+            "class MyErr < StandardError\nend\nbegin\n  raise MyErr, \"x\"\nrescue StandardError => e\n  print(\"caught\")\nend\n",
+            "demo",
+        )
+        .expect("lower ruby");
+        let a = compile(&module).expect("compile to python");
+        if let Some(stdout) = run_emitted_python(&a.source) {
+            // `print("caught")` emits the string plus a trailing newline.
+            assert_eq!(
+                stdout, "caught\n",
+                "user subclass should be rescued by its ancestor"
+            );
+        }
+    }
+
+    #[test]
+    fn execution_unrelated_user_class_not_rescued_py() {
+        // The dual: a user class that does NOT descend from the rescued type is
+        // NOT caught, so the exception propagates (the interpreter exits
+        // non-zero and `run_emitted_python` would panic on a success assertion).
+        // We assert the *shape* of non-matching here and prove propagation via
+        // a direct interpreter run that expects a failure exit.
+        let module = ruby_to_semantic_ir::compile_source(
+            "class Other < RuntimeError\nend\nbegin\n  raise Other, \"y\"\nrescue TypeError => e\n  print(\"wrong\")\nend\n",
+            "demo",
+        )
+        .expect("lower ruby");
+        let a = compile(&module).expect("compile to python");
+        let src = &a.source;
+        // `Other` descends from RuntimeError, not TypeError, so the emitted
+        // rescue names only TypeError and the registration records the true edge.
+        assert!(
+            src.contains("_sir_exc_register_ancestry({\"Other\": \"RuntimeError\"})"),
+            "got:\n{}",
+            src
+        );
+        assert!(
+            src.contains("if _sir_exc_rescue_matches(__exc, [\"TypeError\"]):"),
+            "got:\n{}",
+            src
+        );
+
+        // Direct interpreter run: the program must *fail* (uncaught re-raise).
+        let exe = ["python3", "python"].into_iter().find(|e| python_is_runnable(e));
+        if let Some(exe) = exe {
+            let py_root =
+                std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../python");
+            let pythonpath = std::env::join_paths([
+                py_root.join("sir-runtime-core/src"),
+                py_root.join("sir-runtime-oop/src"),
+                py_root.join("sir-runtime-exceptions/src"),
+            ])
+            .expect("join PYTHONPATH");
+            let file = std::env::temp_dir()
+                .join(format!("sir_e2_nomatch_{}.py", std::process::id()));
+            std::fs::write(&file, &a.source).expect("write temp python");
+            let out = std::process::Command::new(exe)
+                .arg(&file)
+                .env("PYTHONPATH", &pythonpath)
+                .output()
+                .expect("spawn python");
+            let _ = std::fs::remove_file(&file);
+            assert!(
+                !out.status.success(),
+                "unrelated user class must NOT be rescued (expected propagation); stdout={:?}",
+                String::from_utf8_lossy(&out.stdout)
+            );
+        }
     }
 
     #[test]

--- a/code/packages/rust/semantic-ir-to-python/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-python/src/runtime.rs
@@ -37,6 +37,7 @@ pub const RUNTIME_EXC: &str = r##"# ── SIR exception runtime (imported from 
 from coding_adventures_sir_runtime_exceptions import (
     raise_error as _sir_exc_raise_error,
     rescue_matches as _sir_exc_rescue_matches,
+    register_ancestry as _sir_exc_register_ancestry,
 )
 "##;
 
@@ -173,6 +174,7 @@ mod tests {
         assert!(RUNTIME_EXC.contains("from coding_adventures_sir_runtime_exceptions import"));
         assert!(RUNTIME_EXC.contains("raise_error as _sir_exc_raise_error"));
         assert!(RUNTIME_EXC.contains("rescue_matches as _sir_exc_rescue_matches"));
+        assert!(RUNTIME_EXC.contains("register_ancestry as _sir_exc_register_ancestry"));
         assert!(RUNTIME_OOP.ends_with('\n'));
         assert!(RUNTIME_EXC.ends_with('\n'));
     }

--- a/code/packages/rust/semantic-ir-to-typescript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-typescript/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+## 0.4.0 — user-defined exception-class ancestry (E2)
+
+The backend now threads user `class Child < Parent` inheritance edges into the
+exception matcher, so a `rescue StandardError` catches a raised user
+`MyErr < StandardError` — not just built-in subclasses.
+
+- **Emit.** For any module that uses `Feature::Exceptions` **and** declares at
+  least one class with a superclass, the emitter collects every
+  `Stmt::ClassDef { name, superclass: Some(sc) }` pair (walking nested class /
+  module / try / loop bodies) and emits a single program-init
+  `__SirExc.registerAncestry({"MyErr": "StandardError", …})` call, placed after
+  the runtime imports and before any function or `main` runs. Modules with no
+  superclass edge emit no registration (no empty, meaningless call).
+- Built-in matching is unchanged; user edges are purely additive. Requires
+  `@coding-adventures/sir-runtime-exceptions >= 0.2.0`.
+
 ## 0.3.0 — keyword-parameter & argument emission (KW3)
 
 Keyword parameters (`ParamKind::Keyword`) and keyword arguments

--- a/code/packages/rust/semantic-ir-to-typescript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-typescript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-typescript"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "Semantic IR → self-contained TypeScript source code (SIR12). First backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
@@ -56,6 +56,117 @@ fn uses_exceptions(m: &Module) -> bool {
     m.manifest.contains(Feature::Exceptions)
 }
 
+/// Collect every `class Child < Parent` edge in the module as `(child, parent)`
+/// pairs, in source order, de-duplicated (first edge for a name wins).
+///
+/// **Why (E2).**  A `rescue StandardError` must catch a raised user
+/// `MyErr < StandardError`, but the exception runtime only knows the built-in
+/// hierarchy — it cannot learn that `MyErr` descends from `StandardError`
+/// unless we *tell* it.  `Stmt::ClassDef` carries exactly that static edge, so
+/// we harvest the `superclass`-bearing class defs here and emit a single
+/// `registerAncestry({...})` call at program init (see [`emit_module`]).
+/// Classes without a superclass (`class Foo`) contribute no edge — they still
+/// match by exact name, unchanged.
+///
+/// The walk mirrors the builtin-usage scan: exhaustive over the statement forms
+/// that nest bodies (`ClassDef`/`ModuleDef`/`SingletonClassDef`/`TryCatch` and
+/// the loops), so a class defined *inside* a `begin`/loop/class body is still
+/// found.
+fn collect_user_ancestry(m: &Module) -> Vec<(String, String)> {
+    let mut pairs: Vec<(String, String)> = Vec::new();
+    let mut seen: HashSet<String> = HashSet::new();
+    for f in &m.functions {
+        collect_ancestry_in_block(&f.body, &mut pairs, &mut seen);
+    }
+    pairs
+}
+
+fn collect_ancestry_in_block(
+    b: &Block,
+    pairs: &mut Vec<(String, String)>,
+    seen: &mut HashSet<String>,
+) {
+    collect_ancestry_in_stmts(&b.stmts, pairs, seen);
+    collect_ancestry_in_expr(&b.value, pairs, seen);
+}
+
+fn collect_ancestry_in_stmts(
+    stmts: &[Stmt],
+    pairs: &mut Vec<(String, String)>,
+    seen: &mut HashSet<String>,
+) {
+    for s in stmts {
+        collect_ancestry_in_stmt(s, pairs, seen);
+    }
+}
+
+fn collect_ancestry_in_stmt(
+    s: &Stmt,
+    pairs: &mut Vec<(String, String)>,
+    seen: &mut HashSet<String>,
+) {
+    match s {
+        Stmt::ClassDef { name, superclass, body, .. } => {
+            if let Some(sup) = superclass {
+                if seen.insert(name.clone()) {
+                    pairs.push((name.clone(), sup.clone()));
+                }
+            }
+            collect_ancestry_in_stmts(body, pairs, seen);
+        }
+        Stmt::ModuleDef { body, .. } | Stmt::SingletonClassDef { body, .. } => {
+            collect_ancestry_in_stmts(body, pairs, seen);
+        }
+        Stmt::While { body, .. }
+        | Stmt::ForRange { body, .. }
+        | Stmt::ForEach { body, .. } => {
+            collect_ancestry_in_block(body, pairs, seen);
+        }
+        Stmt::TryCatch { body, rescues, ensure_body, .. } => {
+            collect_ancestry_in_stmts(body, pairs, seen);
+            for r in rescues {
+                collect_ancestry_in_stmts(&r.body, pairs, seen);
+            }
+            if let Some(e) = ensure_body {
+                collect_ancestry_in_stmts(e, pairs, seen);
+            }
+        }
+        Stmt::LetBinding { value, .. }
+        | Stmt::LetStarBinding { value, .. }
+        | Stmt::Assign { value, .. }
+        | Stmt::ExprStmt { expr: value, .. } => {
+            collect_ancestry_in_expr(value, pairs, seen);
+        }
+        Stmt::SeqSet { seq, index, value, .. } => {
+            collect_ancestry_in_expr(seq, pairs, seen);
+            collect_ancestry_in_expr(index, pairs, seen);
+            collect_ancestry_in_expr(value, pairs, seen);
+        }
+        Stmt::MapSet { map, key, value, .. } => {
+            collect_ancestry_in_expr(map, pairs, seen);
+            collect_ancestry_in_expr(key, pairs, seen);
+            collect_ancestry_in_expr(value, pairs, seen);
+        }
+    }
+}
+
+fn collect_ancestry_in_expr(
+    e: &Expr,
+    pairs: &mut Vec<(String, String)>,
+    seen: &mut HashSet<String>,
+) {
+    match e {
+        Expr::If { then_branch, else_branch, .. } => {
+            collect_ancestry_in_block(then_branch, pairs, seen);
+            collect_ancestry_in_block(else_branch, pairs, seen);
+        }
+        Expr::Block(b) => collect_ancestry_in_block(b, pairs, seen),
+        // No other expression form can nest a statement block that could hold a
+        // class declaration (calls/literals carry only sub-*expressions*).
+        _ => {}
+    }
+}
+
 /// True if the module uses cons pairs, in which case the emitted artifact
 /// imports `@coding-adventures/sir-runtime-pairs` (the `cons`/`car`/`cdr`/
 /// `pair?` helpers, extracted from core).
@@ -240,6 +351,31 @@ pub fn emit_module(m: &Module) -> String {
     // Only range-using modules import the range runtime.
     if uses_range(m) {
         out.push_str(crate::runtime::RUNTIME_RANGE);
+    }
+    // E2: thread user `class Child < Parent` ancestry into the exception
+    // matcher at program init, *before* any function or main body runs, so a
+    // `rescue StandardError` catches a raised user `MyErr < StandardError`.
+    // Gated on both the exception import (so the helper exists) and the
+    // presence of at least one superclass edge (so we never emit an empty,
+    // meaningless registration for a module that has classes but no
+    // inheritance).
+    if uses_exceptions(m) {
+        let pairs = collect_user_ancestry(m);
+        if !pairs.is_empty() {
+            out.push_str("\n__SirExc.registerAncestry({");
+            for (i, (child, parent)) in pairs.iter().enumerate() {
+                if i > 0 {
+                    out.push_str(", ");
+                }
+                let _ = write!(
+                    out,
+                    "{}: {}",
+                    quote_ts_string(child),
+                    quote_ts_string(parent)
+                );
+            }
+            out.push_str("});\n");
+        }
     }
     emit_globals(&mut out, &m.globals);
     for f in &m.functions {

--- a/code/packages/rust/semantic-ir-to-typescript/tests/run_with_node.rs
+++ b/code/packages/rust/semantic-ir-to-typescript/tests/run_with_node.rs
@@ -36,6 +36,286 @@ use semantic_ir::{
 };
 use semantic_ir_to_typescript::compile;
 
+/// A minimal `__SirExc` runtime stub for the E2 execution proof, mirroring the
+/// real `sir-runtime-exceptions` package's logic: the built-in ancestry table,
+/// a mutable live copy, `registerAncestry` that merges user edges, and a
+/// `rescueMatches` that walks the merged chain.  We inline it (rather than
+/// resolve the workspace package under bare `node`) for the same reason the
+/// `__Sir` stub is inlined — see the module doc-comment.  Keeping the built-in
+/// table and merge here means the proof genuinely exercises "user edge is
+/// walked", not just "the emitted call is syntactically present".
+const SIR_EXC_STUB: &str = r#"const __SirExc = (() => {
+  const BUILTIN = {
+    RuntimeError: "StandardError", ArgumentError: "StandardError",
+    TypeError: "StandardError", NameError: "StandardError",
+    NoMethodError: "NameError", IndexError: "StandardError",
+    KeyError: "IndexError", RangeError: "StandardError",
+    ZeroDivisionError: "StandardError", IOError: "StandardError",
+    StopIteration: "StandardError", NotImplementedError: "StandardError",
+    StandardError: "Exception",
+  };
+  const ANCESTRY = { ...BUILTIN };
+  class SirError extends Error {
+    constructor(sirClass, message) {
+      super(message == null ? sirClass : String(message));
+      this.sirClass = sirClass;
+    }
+  }
+  const registerAncestry = (m) => { for (const k of Object.keys(m)) ANCESTRY[k] = m[k]; };
+  const raiseError = (c, m) => { throw new SirError(c ?? "RuntimeError", m); };
+  const classOfThrown = (e) => (e instanceof SirError ? e.sirClass : "StandardError");
+  const isAncestorOrSelf = (actual, target) => {
+    let cur = actual; const seen = new Set();
+    while (cur !== undefined && !seen.has(cur)) {
+      if (cur === target) return true;
+      seen.add(cur); cur = ANCESTRY[cur];
+    }
+    return false;
+  };
+  const rescueMatches = (e, names) => {
+    if (names.length === 0) return true;
+    const actual = classOfThrown(e);
+    return names.some((n) => n === "Exception" || isAncestorOrSelf(actual, n));
+  };
+  return { registerAncestry, raiseError, rescueMatches };
+})();
+"#;
+
+/// A minimal `__SirOop` stub: the E2 programs only call `defineClass`, which
+/// for exception purposes is a no-op (ancestry is threaded via `__SirExc`).
+const SIR_OOP_STUB: &str = r#"const __SirOop = { defineClass: () => null };
+"#;
+
+/// Transform emitted TypeScript that imports the core + OOP + exceptions
+/// runtimes into runnable JavaScript by swapping each import for its inline
+/// stub and stripping type syntax.  Faithful for the E2 surface (see the
+/// `__SirExc` stub doc).
+fn ts_to_runnable_js_with_exceptions(ts: &str) -> String {
+    let mut js = ts.to_string();
+    js = js.replace(
+        "import * as __Sir from \"@coding-adventures/sir-runtime-core\";\n",
+        SIR_STUB,
+    );
+    js = js.replace(
+        "import * as __SirOop from \"@coding-adventures/sir-runtime-oop\";\n",
+        SIR_OOP_STUB,
+    );
+    js = js.replace(
+        "import * as __SirExc from \"@coding-adventures/sir-runtime-exceptions\";\n",
+        SIR_EXC_STUB,
+    );
+    js = js.replace(" as { [k: string]: __Sir.Val }", "");
+    js = js.replace(": __Sir.Val[]", "");
+    js = js.replace(": __Sir.Val", "");
+    js
+}
+
+/// Run a compiled exception-using module under node, returning `(success,
+/// stdout)`.  `None` when node is unavailable.  Unlike [`run_module`] this does
+/// NOT assert a zero exit — the no-match proof expects a non-zero exit from an
+/// unrescued re-throw.
+fn run_exc_module(module: &Module, tag: &str) -> Option<(bool, String)> {
+    let artifact = compile(module).expect("compile to typescript");
+    if !node_available() {
+        eprintln!("note: `node` unavailable — skipping execution for `{tag}`");
+        return None;
+    }
+    let js = ts_to_runnable_js_with_exceptions(&artifact.source);
+    let mut path: PathBuf = std::env::temp_dir();
+    path.push(format!("sir_ts_exc_{}_{}.js", tag, std::process::id()));
+    std::fs::write(&path, &js).expect("write temp js");
+    let output = Command::new("node").arg(&path).output().expect("spawn node");
+    let _ = std::fs::remove_file(&path);
+    let stdout = String::from_utf8_lossy(&output.stdout)
+        .trim_end_matches(['\n', '\r'])
+        .to_string();
+    Some((output.status.success(), stdout))
+}
+
+fn sir_span() -> Span {
+    Span::synthetic()
+}
+
+/// Build `class <name> < <superclass>; end; begin; raise <name>, "x"; rescue
+/// <rescued> => e; print("caught"); end` as a hand-built SIR module.  Mirrors
+/// what the Ruby frontend lowers, so the TS execution proof does not depend on
+/// the Ruby crate.
+fn exc_module(name: &str, superclass: &str, rescued: &str) -> Module {
+    let classdef = Stmt::ClassDef {
+        name: name.into(),
+        superclass: Some(superclass.into()),
+        body: vec![],
+        span: sir_span(),
+    };
+    let raise = Stmt::ExprStmt {
+        expr: Expr::BuiltinCall {
+            name: "raise".into(),
+            args: vec![
+                Expr::VarRef { name: name.into(), scope: Scope::Const, span: sir_span() },
+                str_lit("x"),
+            ],
+            effects: EffectSet::PURE,
+            span: sir_span(),
+        },
+        span: sir_span(),
+    };
+    let try_stmt = Stmt::TryCatch {
+        body: vec![raise],
+        rescues: vec![semantic_ir::RescueClause {
+            exception_types: vec![rescued.into()],
+            binding: Some("e".into()),
+            body: vec![print(str_lit("caught"))],
+            span: sir_span(),
+        }],
+        ensure_body: None,
+        span: sir_span(),
+    };
+    let main = Function {
+        name: "main".into(),
+        params: vec![],
+        return_type: None,
+        captures: vec![],
+        body: Block {
+            stmts: vec![classdef, try_stmt],
+            value: Expr::NilLit { span: sir_span() },
+            span: sir_span(),
+        },
+        effects: EffectSet::PURE,
+        metadata: Metadata::new(),
+        span: sir_span(),
+    };
+    Module {
+        name: "excmod".into(),
+        manifest: FeatureManifest::from_features(&[
+            Feature::Exceptions,
+            Feature::Classes,
+            Feature::Constants,
+            Feature::Strings,
+            Feature::DynamicTyping,
+        ]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![main],
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("handbuilt")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: sir_span(),
+    }
+}
+
+#[test]
+fn e2_emits_register_ancestry_for_user_subclass_ts() {
+    // The module has a `class MyErr < StandardError`, so a single program-init
+    // `registerAncestry` call threads its edge before any code runs.
+    let module = exc_module("MyErr", "StandardError", "StandardError");
+    let artifact = compile(&module).expect("compile");
+    let src = &artifact.source;
+    assert!(
+        src.contains("__SirExc.registerAncestry({\"MyErr\": \"StandardError\"});"),
+        "expected user ancestry registration; got:\n{src}"
+    );
+    // Must precede `function main` so ancestry is known before any rescue.
+    let reg = src.find("__SirExc.registerAncestry(").expect("reg present");
+    let main = src.find("function main").expect("main present");
+    assert!(reg < main, "registration must come before main; got:\n{src}");
+}
+
+#[test]
+fn e2_no_register_ancestry_without_superclass_ts() {
+    // A throwing module whose only class has no superclass emits no empty,
+    // meaningless registration.
+    let classdef = Stmt::ClassDef {
+        name: "Foo".into(),
+        superclass: None,
+        body: vec![],
+        span: sir_span(),
+    };
+    let raise = Stmt::ExprStmt {
+        expr: Expr::BuiltinCall {
+            name: "raise".into(),
+            args: vec![
+                Expr::VarRef { name: "RuntimeError".into(), scope: Scope::Const, span: sir_span() },
+                str_lit("boom"),
+            ],
+            effects: EffectSet::PURE,
+            span: sir_span(),
+        },
+        span: sir_span(),
+    };
+    let try_stmt = Stmt::TryCatch {
+        body: vec![raise],
+        rescues: vec![semantic_ir::RescueClause {
+            exception_types: vec!["RuntimeError".into()],
+            binding: None,
+            body: vec![print(str_lit("x"))],
+            span: sir_span(),
+        }],
+        ensure_body: None,
+        span: sir_span(),
+    };
+    let main = Function {
+        name: "main".into(),
+        params: vec![],
+        return_type: None,
+        captures: vec![],
+        body: Block {
+            stmts: vec![classdef, try_stmt],
+            value: Expr::NilLit { span: sir_span() },
+            span: sir_span(),
+        },
+        effects: EffectSet::PURE,
+        metadata: Metadata::new(),
+        span: sir_span(),
+    };
+    let module = Module {
+        name: "excmod".into(),
+        manifest: FeatureManifest::from_features(&[
+            Feature::Exceptions,
+            Feature::Classes,
+            Feature::Constants,
+            Feature::Strings,
+            Feature::DynamicTyping,
+        ]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![main],
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("handbuilt")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: sir_span(),
+    };
+    let artifact = compile(&module).expect("compile");
+    assert!(
+        !artifact.source.contains("__SirExc.registerAncestry("),
+        "should not register ancestry with no superclass edge; got:\n{}",
+        artifact.source
+    );
+}
+
+#[test]
+fn e2_user_subclass_rescued_by_ancestor_executes_ts() {
+    // Execution proof: `raise MyErr` (a user `StandardError` subclass) IS caught
+    // by `rescue StandardError` under node — the registered edge is walked.
+    let module = exc_module("MyErr", "StandardError", "StandardError");
+    if let Some((ok, stdout)) = run_exc_module(&module, "match") {
+        assert!(ok, "matched program should exit zero; stdout={stdout:?}");
+        assert_eq!(stdout, "caught", "user subclass must be rescued by its ancestor");
+    }
+}
+
+#[test]
+fn e2_unrelated_user_class_not_rescued_executes_ts() {
+    // Dual: `Other < RuntimeError` raised, `rescue TypeError` does NOT catch it,
+    // so the exception propagates and node exits non-zero (nothing printed).
+    let module = exc_module("Other", "RuntimeError", "TypeError");
+    if let Some((ok, stdout)) = run_exc_module(&module, "nomatch") {
+        assert!(!ok, "unmatched program must propagate (exit non-zero)");
+        assert_ne!(stdout, "caught", "unrelated user class must not be rescued");
+    }
+}
+
 fn sp() -> Span {
     Span::synthetic()
 }

--- a/code/packages/typescript/sir-runtime-exceptions/CHANGELOG.md
+++ b/code/packages/typescript/sir-runtime-exceptions/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.2.0 — user-defined exception-class ancestry (E2)
+
+Adds `registerAncestry(mapping)`: the SIR backend threads user
+`class Child < Parent` edges here at program init (an explicit
+`{childClassName: superclassName}` string map — no `eval`/reflection), so
+`rescueMatches` walks a user class up through its registered superclass and on
+into the built-in table. A `rescue StandardError` now catches a raised user
+`MyErr extends StandardError`.
+
+- User edges are **additive**: they layer over the frozen built-in ancestry
+  (`BUILTIN_ANCESTRY`, spread into a mutable live copy) without replacing it, so
+  built-in matching is unchanged. A user class with no registered edge still
+  matches only by exact name (or via `Exception` / a bare `rescue`).
+- The cycle guard in `isAncestorOrSelf` already tolerates a malformed
+  self-referential edge.
+
 ## 0.1.0 — initial release
 
 First release of the SIR exception runtime for TypeScript/JavaScript, per

--- a/code/packages/typescript/sir-runtime-exceptions/README.md
+++ b/code/packages/typescript/sir-runtime-exceptions/README.md
@@ -42,6 +42,7 @@ dependency.
 | `raiseError(className?, message?): never` | Throw a `SirError`. Bare `raiseError()` re-raises as a generic `RuntimeError`. |
 | `classOfThrown(err): string` | The SIR class name of a caught value (native errors and non-errors → `StandardError`). |
 | `rescueMatches(err, classNames): boolean` | Does a caught value match a `rescue` clause naming `classNames`? Empty list = bare `rescue` (catch-all). |
+| `registerAncestry(mapping): void` | Merge user `{childClassName: superclassName}` edges (from `class Child < Parent`) into the ancestry the matcher walks, so `rescue StandardError` catches a raised user `MyErr extends StandardError`. Additive over the built-in table; explicit string map (no reflection). |
 
 ### Emitted shape
 

--- a/code/packages/typescript/sir-runtime-exceptions/package-lock.json
+++ b/code/packages/typescript/sir-runtime-exceptions/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coding-adventures/sir-runtime-exceptions",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coding-adventures/sir-runtime-exceptions",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "devDependencies": {
         "@vitest/coverage-v8": "^4.1.0",

--- a/code/packages/typescript/sir-runtime-exceptions/package.json
+++ b/code/packages/typescript/sir-runtime-exceptions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/sir-runtime-exceptions",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Exception runtime for Semantic-IR-emitted TypeScript/JavaScript — SIR exception base class, raise helper, and rescue-clause class matching",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/sir-runtime-exceptions/src/index.ts
+++ b/code/packages/typescript/sir-runtime-exceptions/src/index.ts
@@ -24,13 +24,17 @@
  * so a future JavaScript→SIR→TS path reuses them unchanged.  See
  * `code/specs/sir-runtime.md`.
  *
- * **Honest v0 limitation.**  SIR has no exception-class symbol table, so the
- * ancestry of *user-defined* exception classes is unknown here.  We bake in the
- * common built-in Ruby hierarchy (so `rescue StandardError` catches a
- * `RuntimeError`/`ArgumentError`/…), match user classes by exact name, and let
- * the universal root `Exception` (and a bare `rescue`) catch anything.  Full
- * user-class ancestry awaits a frontend that threads class definitions into the
- * exception model.
+ * **User-class ancestry (E2).**  The built-in table below is fixed, but SIR
+ * *does* carry `class MyErr < StandardError` edges in `Stmt::ClassDef`.  The
+ * backend threads them here with {@link registerAncestry} at program init, so a
+ * `rescue StandardError` catches a raised `MyErr` even though `MyErr` is not in
+ * the built-in table.  We keep this an **explicit string→string map** — no
+ * `eval`/reflection, no walking real JS classes — because the SIR class names
+ * are just tags, not live constructors.  User edges are *additive*: they extend
+ * the chain up to a built-in root (`StandardError → Exception`) and never mutate
+ * the built-in entries, so built-in matching is unchanged.  A user class with no
+ * registered superclass still matches only by exact name (or via `Exception` / a
+ * bare `rescue`), exactly as before.
  */
 
 /** The SIR universal value type at this package's boundary. */
@@ -55,7 +59,7 @@ export type Val = any;
  *    ├─ IOError    ├─ StopIteration    └─ NotImplementedError
  * ```
  */
-const ANCESTRY: Readonly<Record<string, string>> = {
+const BUILTIN_ANCESTRY: Readonly<Record<string, string>> = {
   RuntimeError: "StandardError",
   ArgumentError: "StandardError",
   TypeError: "StandardError",
@@ -70,6 +74,39 @@ const ANCESTRY: Readonly<Record<string, string>> = {
   NotImplementedError: "StandardError",
   StandardError: "Exception",
 };
+
+/**
+ * The *live* ancestry the matcher walks.  Seeded from the built-in table and
+ * then extended in place by {@link registerAncestry} with user
+ * `child → superclass` edges.  We start from a spread copy so callers can never
+ * mutate the frozen built-in reference.
+ */
+const ANCESTRY: Record<string, string> = { ...BUILTIN_ANCESTRY };
+
+/**
+ * Merge user `{childClassName: superclassName}` edges into the ancestry.
+ *
+ * Called once at program init with the module's `class Child < Parent` pairs,
+ * *before* any `rescue` runs.  After this, {@link rescueMatches} walks a user
+ * child up through its registered superclass and on into the built-in table —
+ * so `rescue StandardError` catches a raised `MyErr extends StandardError`.
+ *
+ * The mapping is an **explicit string→string map**: keys and values are SIR
+ * class-name tags, not JS constructors.  We deliberately do no reflection and
+ * trust no live type — the frontend already knows the static superclass edge,
+ * so threading it as data keeps the runtime free of `eval`/import magic.
+ *
+ * Idempotent and additive: re-registering the same edge is a no-op, and user
+ * edges layer on top of the built-in table without replacing it (a chain like
+ * `Grandchild → Child → StandardError → Exception` resolves by walking both
+ * layers).  {@link isAncestorOrSelf} already guards against cycles, so a
+ * malformed self-referential edge cannot loop forever.
+ */
+export function registerAncestry(mapping: Record<string, string>): void {
+  for (const child of Object.keys(mapping)) {
+    ANCESTRY[child] = mapping[child];
+  }
+}
 
 /**
  * A SIR exception: a native `Error` tagged with its Ruby class name.

--- a/code/packages/typescript/sir-runtime-exceptions/tests/exceptions.test.ts
+++ b/code/packages/typescript/sir-runtime-exceptions/tests/exceptions.test.ts
@@ -3,6 +3,7 @@ import {
   SirError,
   raiseError,
   classOfThrown,
+  registerAncestry,
   rescueMatches,
 } from "../src/index.js";
 
@@ -115,5 +116,48 @@ describe("rescueMatches", () => {
     expect(rescueMatches(new SirError("MyError"), ["StandardError"])).toBe(
       false,
     );
+  });
+});
+
+describe("registerAncestry (E2)", () => {
+  // Each test uses distinct class names so a registration in one cannot leak
+  // into another (the live ancestry table is module-global and mutable).
+  it("threads a user edge so rescue matches a built-in ancestor", () => {
+    // Before registration: matches only by exact name.
+    expect(rescueMatches(new SirError("E2Sub"), ["StandardError"])).toBe(false);
+    registerAncestry({ E2Sub: "StandardError" });
+    // After: it descends from StandardError and on up to Exception.
+    expect(rescueMatches(new SirError("E2Sub"), ["StandardError"])).toBe(true);
+    expect(rescueMatches(new SirError("E2Sub"), ["Exception"])).toBe(true);
+    expect(rescueMatches(new SirError("E2Sub"), ["E2Sub"])).toBe(true);
+  });
+
+  it("leaves an unrelated user class unmatched", () => {
+    registerAncestry({ E2Known: "StandardError" });
+    expect(rescueMatches(new SirError("E2Unknown"), ["StandardError"])).toBe(
+      false,
+    );
+    expect(rescueMatches(new SirError("E2Known"), ["TypeError"])).toBe(false);
+  });
+
+  it("walks a multi-level user chain up into the built-in table", () => {
+    registerAncestry({ E2Child: "RuntimeError", E2Grand: "E2Child" });
+    expect(rescueMatches(new SirError("E2Grand"), ["RuntimeError"])).toBe(true);
+    expect(rescueMatches(new SirError("E2Grand"), ["StandardError"])).toBe(true);
+    expect(rescueMatches(new SirError("E2Grand"), ["E2Child"])).toBe(true);
+  });
+
+  it("is additive: built-in edges are untouched by user registration", () => {
+    registerAncestry({ E2Add: "StandardError" });
+    expect(rescueMatches(new SirError("ArgumentError"), ["StandardError"])).toBe(
+      true,
+    );
+    expect(rescueMatches(new SirError("E2Add"), ["StandardError"])).toBe(true);
+  });
+
+  it("does not loop on a self-referential edge (cycle guard)", () => {
+    registerAncestry({ E2Loop: "E2Loop" });
+    expect(rescueMatches(new SirError("E2Loop"), ["E2Loop"])).toBe(true);
+    expect(rescueMatches(new SirError("E2Loop"), ["StandardError"])).toBe(false);
   });
 });


### PR DESCRIPTION
## What

**E2** of the exception-hierarchy cascade — makes user-defined exception classes participate in typed `rescue` matching for the Python & TS backends. Design: `code/specs/sir-exception-hierarchy.md` (PR #7255).

Built-in typed rescue already worked (`rescue ArgumentError` vs `rescue StandardError` match by a hardcoded ancestry). But a user `class MyErr < StandardError` matched only by **exact name** — `rescue StandardError` missed a raised `MyErr`. This threads `Stmt::ClassDef { superclass }` into the runtime matcher.

- **Runtimes** (`sir-runtime-exceptions`, python + ts): new `register_ancestry(mapping)` / `registerAncestry(mapping)` merges an explicit `{child: superclass}` string map into the ancestry table (seeded from the now-frozen built-in table). User edges are additive; the ancestry walk has a `seen`-set cycle guard.
- **Backends** (python + ts): a `collect_user_ancestry` walker gathers `ClassDef { name, superclass: Some }` pairs and emits one program-init `register_ancestry({...})` call (gated on `Feature::Exceptions` + ≥1 edge; names string-escaped). JS ancestry is handled in E1 (untouched here to avoid conflict).

## Verification

- `cargo test -p semantic-ir-to-python` **82**, `-p semantic-ir-to-typescript` **85+6**; runtime suites **21 pytest (100% cov) + 21 vitest**.
- **Execution-proof:** python3 & node — `class MyErr < StandardError; raise MyErr; rescue StandardError` → `caught`; an unrelated class propagates (not caught).
- Clippy clean; `cargo build --workspace` clean (bar pre-existing Unix-only crate).
- **Security review passed:** cycle-safe walk (`seen`-set bounds arbitrary user cycles A→B→A), no prototype-pollution (`__proto__` key is a benign no-op; no false match/hang), class names escaped in emitted source, explicit string-map — no eval/reflection.

Part of exception-hierarchy Phase 1 (with E1 JS-backend exceptions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)