### PR TITLE
feat(semantic-ir-to-javascript): exception handling (try/catch/raise) + user-class ancestry (E1)

### DIFF
--- a/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
@@ -26,6 +26,67 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instead of building a function.  `length` remains special-cased ahead of the
   allowlist as a property read.
 
+## 0.6.0 — exception handling (try/catch/raise) + user-class ancestry (E1)
+
+### Added
+
+- **`Stmt::TryCatch` lowers to native `try`/`catch`/`finally` (E1).**  The
+  backend previously *panicked* on any `TryCatch`.  It now emits a native
+  `try { <body> } catch (__exc) { … } finally { <ensure> }`.  Because a native
+  `catch` binds one variable and catches everything while Ruby has an ordered
+  list of *typed* `rescue` clauses, the catch body is an if/else-if chain that
+  asks `__Sir.rescueMatches(__exc, ["Foo", "Bar"])` for each clause in source
+  order, binds `=> e` when present, and re-`throw`s the original exception if
+  no clause matches (Ruby's "propagate when unrescued").  An empty
+  `exception_types` is a bare `rescue` (catch-all).  Mirrors the TypeScript
+  backend's `TryCatch` arm exactly, minus the type annotation on the binding.
+- **`raise` builtin lowers to `__Sir.raiseError` (E1).**  `raise Foo, "msg"`
+  (a `Const` class name + message) → `__Sir.raiseError("Foo", <msg>)`;
+  `raise Foo` → `__Sir.raiseError("Foo")`; a non-`Const` first arg
+  (`raise "msg"`) → `__Sir.raiseError("RuntimeError", <arg>)`; bare `raise` →
+  `__Sir.raiseError()` (a generic `RuntimeError` re-raise).  Matches the TS
+  backend's shape.
+- **Inlined exception runtime.**  Ported the plain-JS-compatible pieces of the
+  published `@coding-adventures/sir-runtime-exceptions` package into the
+  backend's self-contained `__Sir` IIFE: a class-name-tagged `SirError` (a real
+  `Error` subclass), `raiseError(cls, msg)`, `rescueMatches(exc, classNames)`,
+  and the built-in Ruby `ANCESTRY` table (so `rescue StandardError` catches a
+  `RuntimeError`/`ArgumentError`/…).  No `import`/`require`; the emitted `.js`
+  still runs directly under `node`.
+- **User-defined class ancestry (E2, the JS half).**  Added
+  `__Sir.registerAncestry(map)`, which merges a user
+  `{ childClass: superclassName }` map into the runtime's ancestry lookup.  The
+  emitter collects every `Stmt::ClassDef { name, superclass: Some(_) }` pair in
+  the module (recursing into nested bodies) and emits one
+  `__Sir.registerAncestry({ … })` at program init — so
+  `class MyErr < StandardError; raise MyErr; rescue StandardError` matches
+  through the merged chain.  A `ClassDef` body's (non-`def`) statements are now
+  emitted inline instead of panicking.
+- **Accepts `Feature::Exceptions`, `Feature::Classes`, and `Feature::Constants`.**
+  Exceptions and classes are lowered as above; `Constants` is accepted because
+  `raise Foo` names its class as a `Const` `VarRef` (consumed by the `raise` arm
+  as a string) — any other constant read emits its bare identifier.
+
+### Security
+
+- **Ancestry dispatch is by explicit table lookup, never reflection.**
+  `rescueMatches` / `isAncestorOrSelf` resolve a class's superclass chain via
+  `ancestry[cur]` string-map reads only — no `eval`, no dynamic code
+  synthesis; class and method names are treated as pure data.  The mutable
+  ancestry map is `Object.create(null)` (prototype-less), so a user class
+  literally named `constructor`/`__proto__` cannot poison the lookup, and a
+  malformed (cyclic) user map terminates via a `seen` guard.
+
+### Tests
+
+- Emitted-shape unit tests for the `TryCatch` else-chain, the four `raise`
+  shapes, and one-shot `registerAncestry` emission (present iff a class
+  inherits).
+- Four `node` execution-proofs: built-in ancestry (`ArgumentError` caught by
+  `rescue StandardError`), bare `rescue` catch-all, an unmatched type
+  re-raising to a non-zero exit, and USER ancestry
+  (`class MyErr < StandardError` caught by `rescue StandardError`).
+
 ## 0.5.0 — method dispatch (`__method__`) execution
 
 Adds the minimal runtime support the JavaScript frontend's C3 member-method

--- a/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "semantic-ir-to-javascript"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
-description = "Semantic IR → self-contained JavaScript source code (SIR18). Fifth backend for the SIR10 narrow-waist IR. Includes __method__ dispatch execution (C3)."
+description = "Semantic IR → self-contained JavaScript source code (SIR18). Fifth backend for the SIR10 narrow-waist IR. Includes __method__ dispatch execution (C3) and exception handling (try/catch/raise) with user-class ancestry (E1)."
 
 [dependencies]
 semantic-ir = { path = "../semantic-ir" }

--- a/code/packages/rust/semantic-ir-to-javascript/README.md
+++ b/code/packages/rust/semantic-ir-to-javascript/README.md
@@ -65,29 +65,40 @@ surface the emitter lowers today. JavaScript supports every SIR16 feature
 natively (arrays, `Map`, `while`/`for`, reassignable `let`), so each
 lowering is direct.
 
-| Accepted (v0 + SIR16)      | Rejected (deferred / unsupported)            |
-|----------------------------|----------------------------------------------|
-| `Closures`                 | `Classes`, `Modules`, `InstanceVars` (SIR17) |
-| `Pairs`                    | `ClassVars`, `Constants`, `Exceptions`       |
-| `Symbols`                  | `StringInterpolation` (`StrConcat`, SIR18)   |
-| `Strings`                  | `TailCalls` (V8 has no reliable TCO)         |
-| `DynamicTyping`            | `Intrinsics` (empty whitelist)               |
-| `OptionalTypeAnnotations`  |                                              |
-| `MutualRecursion`          |                                              |
-| `Globals`                  |                                              |
-| `Floats` (SIR16)           |                                              |
-| `ShortCircuit` (SIR16)     |                                              |
-| `Sequences` (SIR16)        |                                              |
-| `Maps` (SIR16)             |                                              |
-| `MutableBindings` (SIR16)  |                                              |
-| `Loops` (SIR16)            |                                              |
-| `DefaultParams` (P2d)      |                                              |
+| Accepted (v0 + SIR16 + E1)  | Rejected (deferred / unsupported)            |
+|-----------------------------|----------------------------------------------|
+| `Closures`                  | `Modules`, `InstanceVars` (SIR17)            |
+| `Pairs`                     | `ClassVars`                                  |
+| `Symbols`                   | `StringInterpolation` (`StrConcat`, SIR18)   |
+| `Strings`                   | `TailCalls` (V8 has no reliable TCO)         |
+| `DynamicTyping`             | `Intrinsics` (empty whitelist)               |
+| `OptionalTypeAnnotations`   |                                              |
+| `MutualRecursion`           |                                              |
+| `Globals`                   |                                              |
+| `Floats` (SIR16)            |                                              |
+| `ShortCircuit` (SIR16)      |                                              |
+| `Sequences` (SIR16)         |                                              |
+| `Maps` (SIR16)              |                                              |
+| `MutableBindings` (SIR16)   |                                              |
+| `Loops` (SIR16)             |                                              |
+| `DefaultParams` (P2d)       |                                              |
+| `KeywordParams` (KW4)       |                                              |
+| `Exceptions` (E1, SIR17)    |                                              |
+| `Classes` (E2 ancestry)     |                                              |
+| `Constants`                 |                                              |
 
 `accepts_intrinsics()` is empty. The accept-set is deliberately matched
 to what `emit` handles, so a module using a deferred node is turned away
 *before* lowering rather than mis-compiled — and every accepted feature
 has a real emit arm (the residual `panic!` guards cover only the
-rejected SIR17/18 nodes).
+still-deferred SIR17/18 nodes — `Modules`, `SingletonClassDef` OOP
+dispatch, instance/class variables, and string interpolation).
+
+`Classes` is accepted only to the depth exceptions need: a `ClassDef`
+supplies its `superclass` *ancestry edge* (so `raise MyErr; rescue
+StandardError` matches when `class MyErr < StandardError`) and its
+non-`def` body statements are emitted inline. OOP method dispatch and
+instantiation are **not** modelled.
 
 ### SIR16 lowering at a glance
 
@@ -103,6 +114,41 @@ rejected SIR17/18 nodes).
 | `While`                          | `while (__Sir.truthy(cond)) { … }`              |
 | `ForRange`                       | direction-aware C-style `for` (bounds once)     |
 | `ForEach`                        | `for (let x of iter) { … }`                     |
+
+### Exceptions (E1) — `try`/`catch`/`raise`
+
+`Stmt::TryCatch` lowers to a **native** `try`/`catch`/`finally`. A native
+`catch` binds one variable and catches everything, but Ruby has an ordered
+list of *typed* `rescue` clauses, so the catch body is an if/else-if chain
+that asks the runtime `__Sir.rescueMatches(__exc, [...classNames])` for
+each clause in source order — running the first match, binding `=> e` when
+present, and re-`throw`ing the original exception if none match:
+
+```js
+try {
+  __Sir.raiseError("ArgumentError", "x");
+} catch (__exc) {
+  if (__Sir.rescueMatches(__exc, ["StandardError"])) {
+    const e = __exc;
+    __Sir.print("caught");
+  } else {
+    throw __exc;
+  }
+}
+```
+
+An empty `exception_types` is a bare `rescue` (catch-all → `rescueMatches`
+returns `true`); an `ensure` becomes a `finally`. The `raise` builtin
+lowers to `__Sir.raiseError(cls, msg)` (`raise Foo, "m"` →
+`raiseError("Foo", "m")`; a non-class first arg → an implicit
+`RuntimeError`; bare `raise` → a generic re-raise).
+
+**User-class ancestry (E2 half).** So that `rescue StandardError` catches a
+`raise MyErr` when `class MyErr < StandardError`, the emitter collects
+every `ClassDef` inheritance edge and emits one `__Sir.registerAncestry({
+"MyErr": "StandardError" })` at program init, merging the pairs into the
+runtime's ancestry table. Dispatch is a pure string-map walk — never
+`eval` or reflection (see the runtime section).
 
 ### Default parameters (P2d)
 
@@ -176,6 +222,33 @@ a runtime call:
 A **variadic** operator (`(+ 1 2 3)` — more than two args) and any
 unrecognised builtin fall back to `__Sir.callBuiltin("+", […])`, so a new
 builtin runs without a backend change.
+
+### Exception helpers (E1)
+
+The inlined `__Sir` also carries the exception runtime — a plain-JS port
+of the published `@coding-adventures/sir-runtime-exceptions` package, so
+the artifact stays self-contained:
+
+- `SirError` — a real `Error` subclass tagged with its Ruby class name in
+  `.sirClass`; what `raise` throws.
+- `raiseError(cls, msg)` — throws a `SirError`; the target of a lowered
+  `raise`.
+- `rescueMatches(exc, classNames)` — the per-clause dispatcher: `true` for
+  a bare `rescue` (empty list) or `Exception` (universal root), otherwise
+  a superclass-chain walk over the ancestry table.
+- `registerAncestry(map)` — merges user `{ child: "Super" }` edges into the
+  ancestry lookup (called once at program init for the module's inheriting
+  classes).
+
+The built-in Ruby ancestry (`RuntimeError`/`ArgumentError`/… →
+`StandardError` → `Exception`) is baked in, so `rescue StandardError`
+catches the everyday subclasses out of the box.
+
+**Security.** Ancestry resolution is a pure `ancestry[cur]` string-map
+walk — never `eval` or dynamic property reflection; class and method names
+are treated strictly as data. The mutable map is `Object.create(null)`
+(prototype-less), so a user class named `constructor`/`__proto__` cannot
+poison the lookup, and a cyclic user map terminates via a `seen` guard.
 
 ## Output format
 

--- a/code/packages/rust/semantic-ir-to-javascript/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/emit.rs
@@ -45,16 +45,27 @@
 //!   `for…of`, with the `while`/`for-range` tests routed through
 //!   `__Sir.truthy` and a direction-aware, once-evaluated `for-range`.
 //!
+//! ## Exceptions (E1, SIR17)
+//!
+//! `Stmt::TryCatch` lowers to a native `try`/`catch`/`finally` whose catch
+//! body is a `__Sir.rescueMatches`-guarded if/else-if chain, and the
+//! `raise` builtin lowers to `__Sir.raiseError(cls, msg)` — mirroring the
+//! TypeScript backend but against the *inlined* exception runtime.  A
+//! `ClassDef`'s inheritance edge is collected into one
+//! `__Sir.registerAncestry({ … })` at program init so a `rescue
+//! StandardError` catches a `raise MyErr` when `class MyErr < StandardError`
+//! (E2's JS half); the class body's non-`def` statements are emitted inline.
+//!
 //! ## Deferred nodes (still rejected at the capability check)
 //!
-//! String interpolation (`StrConcat`) and the SIR17/18 OOP/exception
-//! scopes (`ClassDef`/`ModuleDef`/`SingletonClassDef`, `TryCatch`, the
-//! `Instance`/`ClassVar`/`Const` scopes) and `Intrinsic` are **not
-//! emitted**.  Their `Feature`s are absent from the backend's
-//! `accepts_features()` list, so a module that uses them is rejected at
-//! the capability check *before* lowering — the `panic!` arms below are
-//! defence-in-depth that fire only on a backend bug (the accept-set
-//! drifting out of sync with what `emit` handles), never on user input.
+//! String interpolation (`StrConcat`), the remaining SIR17 OOP scopes
+//! (`ModuleDef`, `SingletonClassDef` dispatch, the `Instance`/`ClassVar`
+//! scopes), and `Intrinsic` are **not emitted**.  Their `Feature`s are
+//! absent from the backend's `accepts_features()` list, so a module that
+//! uses them is rejected at the capability check *before* lowering — the
+//! `panic!` arms below are defence-in-depth that fire only on a backend bug
+//! (the accept-set drifting out of sync with what `emit` handles), never on
+//! user input.
 
 use std::cell::Cell;
 use std::fmt::Write;
@@ -90,6 +101,7 @@ pub fn emit_module(m: &Module) -> String {
     // file — including the inlined runtime — runs under strict semantics.
     out.push_str("\"use strict\";\n\n");
     out.push_str(RUNTIME);
+    emit_ancestry_registration(&mut out, m);
     emit_globals(&mut out, &m.globals);
     for f in &m.functions {
         out.push('\n');
@@ -132,6 +144,72 @@ fn emit_module_footer(out: &mut String, m: &Module) {
     }
     if m.functions.iter().any(|f| f.name == "main") {
         out.push_str("main();\n");
+    }
+}
+
+/// Emit the module's user-defined exception-class ancestry (E2, the JS
+/// half) once, at program init, as a single `__Sir.registerAncestry({
+/// child: "Super", … })` call — right after the runtime and before any
+/// user code runs.  This merges the module's `class Child < Super` edges
+/// into the runtime's ancestry table so a `rescue StandardError` matches
+/// a `raise MyErr` when `class MyErr < StandardError`.
+///
+/// We register **eagerly at init** rather than at each `ClassDef` site
+/// because a `raise`/`rescue` may lexically precede the class definition
+/// (Ruby's classes are resolved by name, not by source order); the merged
+/// table must already be complete the first time `rescueMatches` runs.
+/// If the module defines no inheriting classes, nothing is emitted (a
+/// pure non-OOP module gains no init noise).
+fn emit_ancestry_registration(out: &mut String, m: &Module) {
+    let mut pairs: Vec<(&str, &str)> = Vec::new();
+    for f in &m.functions {
+        collect_ancestry(&f.body.stmts, &mut pairs);
+    }
+    if pairs.is_empty() {
+        return;
+    }
+    out.push_str("\n__Sir.registerAncestry({");
+    for (i, (child, sup)) in pairs.iter().enumerate() {
+        if i > 0 {
+            out.push(',');
+        }
+        let _ = write!(out, " {}: {}", quote_js_string(child), quote_js_string(sup));
+    }
+    out.push_str(" });\n");
+}
+
+/// Walk a statement list (recursing into every nested body) collecting
+/// `(childClass, superclassName)` pairs from each `Stmt::ClassDef` whose
+/// `superclass` is `Some`.  Base classes (`class Foo`, no `< Bar`) carry
+/// no edge and are skipped.  The recursion covers class bodies, loop /
+/// try / rescue / ensure bodies, and both branches of an `If` statement,
+/// so a class declared inside any of them is still registered.
+fn collect_ancestry<'a>(stmts: &'a [Stmt], pairs: &mut Vec<(&'a str, &'a str)>) {
+    for s in stmts {
+        match s {
+            Stmt::ClassDef { name, superclass, body, .. } => {
+                if let Some(sup) = superclass {
+                    pairs.push((name.as_str(), sup.as_str()));
+                }
+                collect_ancestry(body, pairs);
+            }
+            Stmt::ModuleDef { body, .. } | Stmt::SingletonClassDef { body, .. } => {
+                collect_ancestry(body, pairs);
+            }
+            Stmt::TryCatch { body, rescues, ensure_body, .. } => {
+                collect_ancestry(body, pairs);
+                for r in rescues {
+                    collect_ancestry(&r.body, pairs);
+                }
+                if let Some(ens) = ensure_body {
+                    collect_ancestry(ens, pairs);
+                }
+            }
+            Stmt::While { body, .. }
+            | Stmt::ForRange { body, .. }
+            | Stmt::ForEach { body, .. } => collect_ancestry(&body.stmts, pairs),
+            _ => {}
+        }
     }
 }
 
@@ -415,18 +493,76 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
             emit_expr(out, value, indent);
             out.push_str(");\n");
         }
-        // ── Deferred (rejected at the capability check) ────────────
-        // The following statement kinds belong to SIR17/18 features this
-        // backend does not accept.  Reaching them means the accept-set
-        // drifted out of sync with `emit`; fail loudly rather than emit
-        // silently-wrong code.
-        Stmt::ClassDef { span, .. }
-        | Stmt::ModuleDef { span, .. }
-        | Stmt::SingletonClassDef { span, .. } => {
-            panic!("javascript backend reached a deferred OOP declaration at {span} — not accepted yet");
+        // ── SIR17: class / module / singleton declarations ─────────
+        // The Ruby→SIR frontend hoists method `def`s to top-level
+        // functions, so a `ClassDef` body carries only its non-`def`
+        // statements (constant / class-variable assigns).  This backend
+        // does not model OOP method dispatch or instantiation; a class is
+        // accepted only for its *ancestry edge* (E2) — the `superclass`
+        // pair is collected separately (see `collect_ancestry`) and
+        // emitted once as `__Sir.registerAncestry({ … })` at program init.
+        // Here we just emit the body statements in source order.
+        Stmt::ClassDef { body, .. }
+        | Stmt::ModuleDef { body, .. }
+        | Stmt::SingletonClassDef { body, .. } => {
+            for st in body {
+                emit_stmt(out, st, indent);
+            }
         }
-        Stmt::TryCatch { span, .. } => {
-            panic!("javascript backend reached a deferred `TryCatch` at {span} — not accepted yet");
+        // `begin … rescue … ensure … end` → native `try { … } catch
+        // (__exc) { … } finally { … }`.  A native `catch` binds *one*
+        // variable and catches *everything*, while Ruby has an ordered
+        // list of typed `rescue` clauses, so the catch body is an
+        // if/else-if chain that asks the runtime `rescueMatches(exc,
+        // [class names])` for each clause in source order and re-`throw`s
+        // if none match (matching Ruby's "propagate when unrescued").
+        // Mirrors the TypeScript backend's `TryCatch` arm exactly, minus
+        // the type annotation on the `=> e` binding.
+        Stmt::TryCatch { body, rescues, ensure_body, .. } => {
+            let _ = writeln!(out, "{pad}try {{");
+            for st in body {
+                emit_stmt(out, st, indent + 2);
+            }
+            let _ = write!(out, "{pad}}}");
+            if !rescues.is_empty() {
+                out.push_str(" catch (__exc) {\n");
+                let inner = indent + 2;
+                let ipad = " ".repeat(inner);
+                for (i, r) in rescues.iter().enumerate() {
+                    // Build the `["Foo", "Bar"]` class-name array; an empty
+                    // list is a bare `rescue` (catch-all) → `[]`.
+                    let mut types = String::from("[");
+                    for (j, t) in r.exception_types.iter().enumerate() {
+                        if j > 0 {
+                            types.push_str(", ");
+                        }
+                        types.push_str(&quote_js_string(t));
+                    }
+                    types.push(']');
+                    let kw = if i == 0 { "if" } else { "} else if" };
+                    let _ = writeln!(out, "{ipad}{kw} (__Sir.rescueMatches(__exc, {types})) {{");
+                    // `rescue Foo => e` binds the caught value as a local.
+                    if let Some(bind) = &r.binding {
+                        let _ = writeln!(out, "{ipad}  const {} = __exc;", sanitize_ident(bind));
+                    }
+                    for st in &r.body {
+                        emit_stmt(out, st, inner + 2);
+                    }
+                }
+                // No clause matched → propagate the original exception.
+                let _ = writeln!(out, "{ipad}}} else {{");
+                let _ = writeln!(out, "{ipad}  throw __exc;");
+                let _ = writeln!(out, "{ipad}}}");
+                let _ = write!(out, "{pad}}}");
+            }
+            if let Some(ens) = ensure_body {
+                out.push_str(" finally {\n");
+                for st in ens {
+                    emit_stmt(out, st, indent + 2);
+                }
+                let _ = write!(out, "{pad}}}");
+            }
+            out.push('\n');
         }
     }
 }
@@ -610,9 +746,20 @@ fn emit_var_ref(out: &mut String, name: &str, scope: Scope) {
         Scope::Builtin => {
             let _ = write!(out, "__Sir.builtinClosure({})", quote_js_string(name));
         }
-        // The OOP scopes are not accepted by this backend; a validated,
-        // capability-checked module never carries them here.
-        Scope::Instance | Scope::ClassVar | Scope::Const => {
+        // A `Const` reference (`Feature::Constants`) resolves to a bare
+        // identifier — a top-level `const`/`let` binding the frontend
+        // emitted for the constant.  In practice the dominant `Const` use
+        // reaching this backend is an exception *class name* as the first
+        // argument of `raise`, which the `raise` builtin arm consumes as a
+        // *string* (it never calls `emit_expr` on that Const), so a class
+        // name never needs a real binding.  Any other `Const` — a genuine
+        // named constant read for its value — emits its bare name.
+        Scope::Const => {
+            out.push_str(&sanitize_ident(name));
+        }
+        // The remaining OOP scopes are not accepted by this backend; a
+        // validated, capability-checked module never carries them here.
+        Scope::Instance | Scope::ClassVar => {
             panic!("javascript backend reached a deferred scope `{}` — not accepted yet", scope.name());
         }
     }
@@ -725,6 +872,37 @@ fn emit_builtin_call(out: &mut String, name: &str, args: &[Expr], indent: usize)
         for a in &args[1..] {
             out.push_str(", ");
             emit_expr(out, a, indent); // StrLit(method), then call args
+        }
+        out.push(')');
+        return;
+    }
+    // `raise` (SIR17) → throw a SIR exception via the inlined runtime.
+    // Mirrors the TypeScript backend's `raise` arm; the first argument
+    // decides the shape:
+    //   • a `Const` class name (`raise Foo` / `raise Foo, "msg"`) → the
+    //     class name is passed as a *string* (built-in classes need no
+    //     binding), with the optional message second →
+    //     `__Sir.raiseError("Foo"[, <msg>])`;
+    //   • any other first arg (`raise "msg"`) → an implicit `RuntimeError`
+    //     carrying that value as the message (matching Ruby) →
+    //     `__Sir.raiseError("RuntimeError", <arg>)`;
+    //   • no args (bare `raise`) → a generic re-raise →
+    //     `__Sir.raiseError()` (the runtime defaults to `RuntimeError`).
+    if name == "raise" {
+        out.push_str("__Sir.raiseError(");
+        match args.first() {
+            None => {}
+            Some(Expr::VarRef { name: cn, scope: Scope::Const, .. }) => {
+                out.push_str(&quote_js_string(cn));
+                if let Some(msg) = args.get(1) {
+                    out.push_str(", ");
+                    emit_expr(out, msg, indent);
+                }
+            }
+            Some(other) => {
+                out.push_str("\"RuntimeError\", ");
+                emit_expr(out, other, indent);
+            }
         }
         out.push(')');
         return;
@@ -1027,7 +1205,7 @@ fn format_float(v: f64) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use semantic_ir::{CaptureValue, EffectSet, Metadata, Param, Span};
+    use semantic_ir::{CaptureValue, EffectSet, Metadata, Param, RescueClause, Span};
 
     fn s() -> Span {
         Span::synthetic()
@@ -1872,5 +2050,179 @@ mod tests {
         assert!(out.contains("function main() {"));
         assert!(out.contains("main();\n"));
         assert!(out.ends_with('\n'));
+    }
+
+    // ── E1: exceptions (raise / TryCatch) ─────────────────────────
+
+    /// `raise Foo, "msg"` (a `Const` class + message) → the class name is
+    /// a *string literal*, the message follows.
+    #[test]
+    fn emit_raise_const_class_with_message() {
+        let e = bc(
+            "raise",
+            vec![
+                Expr::VarRef { name: "ArgumentError".into(), scope: Scope::Const, span: s() },
+                Expr::StrLit { value: "boom".into(), span: s() },
+            ],
+        );
+        assert_eq!(emit_e(&e), r#"__Sir.raiseError("ArgumentError", "boom")"#);
+    }
+
+    /// `raise Foo` (no message) → just the class-name string.
+    #[test]
+    fn emit_raise_const_class_no_message() {
+        let e = bc(
+            "raise",
+            vec![Expr::VarRef { name: "RuntimeError".into(), scope: Scope::Const, span: s() }],
+        );
+        assert_eq!(emit_e(&e), r#"__Sir.raiseError("RuntimeError")"#);
+    }
+
+    /// Bare `raise` (no args) → `raiseError()`, which the runtime defaults
+    /// to a generic `RuntimeError` re-raise.
+    #[test]
+    fn emit_raise_bare_reraises() {
+        assert_eq!(emit_e(&bc("raise", vec![])), "__Sir.raiseError()");
+    }
+
+    /// `raise "msg"` (a non-`Const` first arg) → an implicit `RuntimeError`
+    /// carrying the value as the message, matching Ruby and the TS backend.
+    #[test]
+    fn emit_raise_non_const_is_runtime_error_with_message() {
+        let e = bc("raise", vec![Expr::StrLit { value: "oops".into(), span: s() }]);
+        assert_eq!(emit_e(&e), r#"__Sir.raiseError("RuntimeError", "oops")"#);
+    }
+
+    /// A `TryCatch` with one typed, bound rescue emits a native
+    /// `try { … } catch (__exc) { if (rescueMatches(…)) { … } else { throw
+    /// __exc; } }` — the rescueMatches-guarded else-chain.
+    #[test]
+    fn emit_try_catch_emits_rescue_matches_else_chain() {
+        let st = Stmt::TryCatch {
+            body: vec![Stmt::ExprStmt {
+                expr: bc("print", vec![Expr::StrLit { value: "try".into(), span: s() }]),
+                span: s(),
+            }],
+            rescues: vec![RescueClause {
+                exception_types: vec!["StandardError".into()],
+                binding: Some("e".into()),
+                body: vec![Stmt::ExprStmt {
+                    expr: bc("print", vec![Expr::StrLit { value: "caught".into(), span: s() }]),
+                    span: s(),
+                }],
+                span: s(),
+            }],
+            ensure_body: None,
+            span: s(),
+        };
+        let out = emit_s(&st);
+        assert!(out.contains("try {"), "got:\n{out}");
+        assert!(out.contains("catch (__exc) {"), "got:\n{out}");
+        assert!(
+            out.contains(r#"if (__Sir.rescueMatches(__exc, ["StandardError"])) {"#),
+            "got:\n{out}"
+        );
+        assert!(out.contains("const e = __exc;"), "got:\n{out}");
+        assert!(out.contains("} else {"), "got:\n{out}");
+        assert!(out.contains("throw __exc;"), "got:\n{out}");
+    }
+
+    /// A bare `rescue` (empty `exception_types`) emits the catch-all
+    /// `rescueMatches(__exc, [])`; multiple clauses chain with `else if`;
+    /// an `ensure` becomes a `finally`.
+    #[test]
+    fn emit_try_catch_bare_rescue_chain_and_finally() {
+        let st = Stmt::TryCatch {
+            body: vec![],
+            rescues: vec![
+                RescueClause {
+                    exception_types: vec!["TypeError".into()],
+                    binding: None,
+                    body: vec![],
+                    span: s(),
+                },
+                RescueClause {
+                    exception_types: vec![], // bare `rescue`
+                    binding: None,
+                    body: vec![],
+                    span: s(),
+                },
+            ],
+            ensure_body: Some(vec![]),
+            span: s(),
+        };
+        let out = emit_s(&st);
+        assert!(out.contains(r#"if (__Sir.rescueMatches(__exc, ["TypeError"])) {"#), "got:\n{out}");
+        assert!(out.contains("} else if (__Sir.rescueMatches(__exc, [])) {"), "got:\n{out}");
+        assert!(out.contains("finally {"), "got:\n{out}");
+    }
+
+    // ── E2 (JS half): user-defined class ancestry ─────────────────
+
+    /// A `class MyErr < StandardError` inside a function body is collected
+    /// into a single `__Sir.registerAncestry({ … })` emitted at program
+    /// init (after the runtime, before user functions run).
+    #[test]
+    fn emit_module_registers_user_class_ancestry() {
+        let class_def = Stmt::ClassDef {
+            name: "MyErr".into(),
+            superclass: Some("StandardError".into()),
+            body: vec![],
+            span: s(),
+        };
+        let m = Module {
+            name: "demo".into(),
+            manifest: semantic_ir::FeatureManifest::new(),
+            imports: vec![],
+            exports: vec![],
+            functions: vec![fun(
+                "main",
+                vec![],
+                Block { stmts: vec![class_def], value: Expr::NilLit { span: s() }, span: s() },
+            )],
+            globals: vec![],
+            metadata: Metadata::new().with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+            span: s(),
+        };
+        let out = emit_module(&m);
+        assert!(
+            out.contains(r#"__Sir.registerAncestry({ "MyErr": "StandardError" });"#),
+            "got:\n{out}"
+        );
+        // Registration precedes the user's `main` so the table is complete
+        // before any `rescueMatches` runs.
+        let reg = out.find("__Sir.registerAncestry({").unwrap();
+        let main = out.find("function main(").unwrap();
+        assert!(reg < main, "registerAncestry call must precede user functions");
+    }
+
+    /// A base class (`class Foo`, no superclass) carries no ancestry edge,
+    /// so a module with only base classes emits no `registerAncestry`.
+    #[test]
+    fn emit_module_omits_registration_without_inheritance() {
+        let class_def = Stmt::ClassDef {
+            name: "Foo".into(),
+            superclass: None,
+            body: vec![],
+            span: s(),
+        };
+        let m = Module {
+            name: "demo".into(),
+            manifest: semantic_ir::FeatureManifest::new(),
+            imports: vec![],
+            exports: vec![],
+            functions: vec![fun(
+                "main",
+                vec![],
+                Block { stmts: vec![class_def], value: Expr::NilLit { span: s() }, span: s() },
+            )],
+            globals: vec![],
+            metadata: Metadata::new().with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+            span: s(),
+        };
+        // The runtime *defines* `registerAncestry`, so only the *call*
+        // `__Sir.registerAncestry({` marks a real registration — and that
+        // must be absent for a module with no inheriting classes.
+        assert!(!emit_module(&m).contains("__Sir.registerAncestry({"));
     }
 }

--- a/code/packages/rust/semantic-ir-to-javascript/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/lib.rs
@@ -87,7 +87,9 @@ impl Default for JavaScriptBackend {
 ///
 /// `TailCalls` and `Intrinsics` are excluded deliberately (the former is
 /// fundamentally unsupported on V8; the latter has an empty whitelist).
-/// The SIR17/18 OOP / exception / string-interpolation features are
+/// SIR17 exceptions (`Exceptions`), the class *ancestry* slice of
+/// `Classes`, and `Constants` are accepted (E1 / E2's JS half); the
+/// remaining SIR17/18 OOP-dispatch and string-interpolation features stay
 /// excluded because their emit arms are deferred — a module that declares
 /// one is rejected here, never silently mis-compiled.
 const ACCEPTED_FEATURES: &[Feature] = &[
@@ -120,6 +122,29 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     // the same zero-dependency, direct lowering the TypeScript backend
     // uses (spec §4).  Accepted here exactly as `DefaultParams` is.
     Feature::KeywordParams,
+    // Constants — a `Const`-scoped `VarRef` (an uppercase name like a
+    // class or a named constant).  Accepted because a `raise Foo` names
+    // its exception class as a `Const` VarRef; the `raise` arm consumes
+    // that Const as a *string* class name, and any other constant read
+    // emits its bare identifier.  See `emit_var_ref`'s `Const` arm.
+    Feature::Constants,
+    // E1 (SIR17): structured exception handling.  `Stmt::TryCatch` lowers
+    // to a native `try { … } catch (__exc) { … } finally { … }` whose
+    // catch body is a `__Sir.rescueMatches`-guarded if/else-if chain, and
+    // the `raise` builtin lowers to `__Sir.raiseError(cls, msg)` — the
+    // same direct lowering the TypeScript backend uses, but against the
+    // *inlined* exception runtime rather than an imported package.  See
+    // `emit`'s `TryCatch` / `raise` arms and `runtime::RUNTIME`.
+    Feature::Exceptions,
+    // E2 (SIR17): class definitions — accepted here only to the extent E1
+    // needs them.  A `class MyErr < StandardError` supplies a user
+    // ancestry edge so `raise MyErr; rescue StandardError` matches; the
+    // emitter collects every `ClassDef { name, superclass: Some(_) }` pair
+    // into one `__Sir.registerAncestry({ … })` at program init and emits
+    // the class body's (non-`def`) statements inline.  Method dispatch /
+    // instantiation are NOT modelled — the frontend hoists method `def`s
+    // out of the body, so an exception-class body carries only assigns.
+    Feature::Classes,
 ];
 
 impl Backend for JavaScriptBackend {
@@ -281,13 +306,23 @@ mod tests {
     }
 
     #[test]
-    fn rejects_sir17_exceptions_feature() {
-        // A still-deferred SIR17 feature must be turned away at the
-        // capability check.
+    fn accepts_sir17_exceptions_feature() {
+        // E1: the SIR17 exception feature is now lowered (TryCatch →
+        // native try/catch, `raise` → `__Sir.raiseError`), so a module
+        // declaring it passes the capability check.
         let mut m = minimal_module();
         m.manifest = FeatureManifest::from_features(&[Feature::Exceptions]);
-        let err = compile(&m).expect_err("exceptions rejected");
-        assert_eq!(err.kind, BackendErrorKind::UnsupportedFeature);
+        compile(&m).expect("exceptions accepted");
+    }
+
+    #[test]
+    fn accepts_sir17_classes_feature() {
+        // E2 (JS half): `Feature::Classes` is accepted for its ancestry
+        // edge — a `class Child < Super` supplies a user-defined
+        // superclass relation the exception runtime merges in.
+        let mut m = minimal_module();
+        m.manifest = FeatureManifest::from_features(&[Feature::Classes]);
+        compile(&m).expect("classes accepted");
     }
 
     #[test]

--- a/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
@@ -239,10 +239,147 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
     return m.apply(recv, args);
   }
 
+  // ── exceptions (SIR17 `Feature::Exceptions`) ───────────────────
+  // Most SIR lowers to native JavaScript, and exception handling is
+  // *mostly* native too: `Stmt::TryCatch` becomes a real
+  // `try { … } catch (__exc) { … } finally { … }`.  Two pieces have no
+  // faithful native equivalent and live here — mirroring the published
+  // TypeScript `@coding-adventures/sir-runtime-exceptions` package
+  // (ported to plain JS so the JavaScript backend stays self-contained,
+  // no `import`/`require`):
+  //
+  //   1. A *class-tagged* thrown object.  Ruby's `raise ArgumentError,
+  //      "boom"` names a **class** and carries a message; JavaScript's
+  //      `throw` takes any value and its `Error` has no Ruby class tag.
+  //      `SirError` is a real `Error` (so stack traces work) that also
+  //      records the SIR class name in `sirClass`.
+  //   2. Rescue-clause *type matching*.  A native `catch` binds one
+  //      variable and catches everything; Ruby's ordered typed `rescue`
+  //      clauses match a *set* of classes (and their subclasses) and
+  //      fall through otherwise.  `rescueMatches` answers "does this
+  //      caught value match this clause's class list?" so the emitted
+  //      `catch` body dispatches to the right clause (or re-`throw`s).
+
+  // Built-in Ruby exception ancestry: subclass name → immediate
+  // superclass name.  Walked by `isAncestorOrSelf` so a
+  // `rescue StandardError` also catches the everyday subclasses a program
+  // raises.  A curated slice of Ruby's tree (the classes a frontend is
+  // likely to name), each chaining up to `StandardError → Exception`.
+  //
+  //   Exception
+  //   └─ StandardError
+  //      ├─ RuntimeError ├─ ArgumentError ├─ TypeError
+  //      ├─ NameError ─ NoMethodError      ├─ RangeError
+  //      ├─ IndexError ─ KeyError          ├─ ZeroDivisionError
+  //      ├─ IOError    ├─ StopIteration    └─ NotImplementedError
+  //
+  // `ancestry` starts as a copy of the built-in table; user-defined
+  // classes are merged in at program init via `registerAncestry` (below).
+  const BUILTIN_ANCESTRY = {
+    RuntimeError: "StandardError",
+    ArgumentError: "StandardError",
+    TypeError: "StandardError",
+    NameError: "StandardError",
+    NoMethodError: "NameError",
+    IndexError: "StandardError",
+    KeyError: "IndexError",
+    RangeError: "StandardError",
+    ZeroDivisionError: "StandardError",
+    IOError: "StandardError",
+    StopIteration: "StandardError",
+    NotImplementedError: "StandardError",
+    StandardError: "Exception",
+  };
+  // A *mutable* lookup seeded from the built-ins.  `Object.create(null)`
+  // gives a prototype-less map so a user class literally named
+  // `"constructor"`/`"__proto__"` cannot poison the lookup — dispatch is
+  // pure DATA, never reflection.
+  const ancestry = Object.assign(Object.create(null), BUILTIN_ANCESTRY);
+
+  // Merge a user `{ childClass: superclassName }` map into `ancestry`
+  // (E2, the JS half of user-defined class ancestry).  The emitter
+  // collects the module's `class Child < Super` pairs and emits ONE
+  // `__Sir.registerAncestry(...)` call at program init, so
+  // `class MyErr < StandardError; raise MyErr; rescue StandardError`
+  // matches through the merged chain.  Own-keys only (no inherited
+  // prototype keys) keeps the merge to explicit source-declared pairs.
+  function registerAncestry(map) {
+    if (map == null) { return; }
+    for (const child of Object.keys(map)) {
+      ancestry[child] = map[child];
+    }
+  }
+
+  // A SIR exception: a native `Error` tagged with its Ruby class name.
+  // `sirClass` is what `rescueMatches` dispatches on; `message` is the
+  // human string `raise Klass, "msg"` carries (defaulting to the class
+  // name, matching Ruby's `exception.message`).
+  class SirError extends Error {
+    constructor(sirClass, message) {
+      const text =
+        message === undefined || message === null ? sirClass : String(message);
+      super(text);
+      this.sirClass = sirClass;
+      this.name = sirClass;
+      // Restore the prototype chain so `err instanceof SirError` holds.
+      Object.setPrototypeOf(this, new.target.prototype);
+    }
+  }
+
+  // Raise a SIR exception of class `className` with an optional message.
+  // Emitted for `raise Foo, "msg"` → `raiseError("Foo", "msg")`,
+  // `raise Foo` → `raiseError("Foo")`, and bare `raise` → `raiseError()`
+  // → a generic `RuntimeError` (SIR v0 does not thread the in-flight
+  // exception into a bare re-raise; documented limitation).
+  function raiseError(className, message) {
+    throw new SirError(className === undefined ? "RuntimeError" : className, message);
+  }
+
+  // The SIR class name of a caught value.  A `SirError` reports its tag;
+  // any other thrown value (a native `Error`, a bare string, …) is
+  // bucketed as `StandardError` — the everyday rescuable root — so a
+  // `rescue StandardError` / bare `rescue` also catches JS runtime errors.
+  function classOfThrown(err) {
+    if (err instanceof SirError) { return err.sirClass; }
+    return "StandardError";
+  }
+
+  // `true` if `actual` is `target` or any of its registered ancestors.
+  // The `seen` guard makes a malformed (cyclic) user ancestry map
+  // terminate rather than loop forever.  Lookup is by EXPLICIT table
+  // (`ancestry[cur]`), never `eval`/reflection — class names are data.
+  function isAncestorOrSelf(actual, target) {
+    let cur = actual;
+    const seen = new Set();
+    while (cur !== undefined && cur !== null && !seen.has(cur)) {
+      if (cur === target) { return true; }
+      seen.add(cur);
+      cur = ancestry[cur];
+    }
+    return false;
+  }
+
+  // Does a caught value match a rescue clause naming `classNames`?
+  //   - empty `classNames` → a bare `rescue` (catch-all) → always true.
+  //   - `Exception` → Ruby's universal root → matches anything.
+  //   - otherwise: matches if the value's class equals or descends from
+  //     any named class (per `ancestry`; user classes by exact name or
+  //     registered chain).
+  // The emitted `catch` calls this once per clause in source order,
+  // running the first match's body and re-`throw`ing if none match.
+  function rescueMatches(err, classNames) {
+    if (classNames.length === 0) { return true; }
+    const actual = classOfThrown(err);
+    return classNames.some(
+      (name) => name === "Exception" || isAncestorOrSelf(actual, name),
+    );
+  }
+
   return {
     Sym, Pair, Closure,
     intern, applyClosure, truthy, format, print,
     builtins, builtinClosure, callBuiltin, callMethod,
+    SirError, raiseError, rescueMatches, registerAncestry,
   };
 })();
 "##;
@@ -272,8 +409,29 @@ mod tests {
             "intern", "applyClosure", "truthy", "format",
             "builtins", "builtinClosure", "callBuiltin", "callMethod",
             "class Sym", "class Pair", "class Closure",
+            // Exception runtime (SIR17): the four helpers the emitter
+            // references from its TryCatch / raise / ClassDef arms.
+            "class SirError", "raiseError", "rescueMatches", "registerAncestry",
         ] {
             assert!(RUNTIME.contains(needed), "runtime missing `{needed}`");
         }
+    }
+
+    #[test]
+    fn runtime_bakes_in_builtin_exception_ancestry() {
+        // `rescue StandardError` must catch the everyday subclasses, so the
+        // built-in ancestry table has to chain them up to StandardError.
+        assert!(RUNTIME.contains("ArgumentError: \"StandardError\""));
+        assert!(RUNTIME.contains("StandardError: \"Exception\""));
+    }
+
+    #[test]
+    fn runtime_dispatches_ancestry_by_table_not_reflection() {
+        // SECURITY: ancestry lookup is an explicit map read, never `eval`
+        // or dynamic code synthesis.  A prototype-less map keeps a user
+        // class named `constructor`/`__proto__` from poisoning the lookup.
+        assert!(RUNTIME.contains("ancestry[cur]"));
+        assert!(RUNTIME.contains("Object.create(null)"));
+        assert!(!RUNTIME.contains("eval("));
     }
 }

--- a/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
@@ -16,7 +16,8 @@ use std::process::Command;
 
 use semantic_ir::nodes::MapEntry;
 use semantic_ir::{
-    Block, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, Scope, Span, Stmt,
+    Block, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, RescueClause,
+    Scope, Span, Stmt,
 };
 use semantic_ir_to_javascript::compile;
 
@@ -899,5 +900,148 @@ fn runtime_rejects_constructor_gadget() {
             stderr.contains("not an allowed collection method"),
             "expected the allowlist TypeError, got stderr:\n{stderr}"
         );
+    }
+}
+
+// ── E1: exception execution-proof (run under `node`) ───────────────────
+//
+// The unit tests in `emit.rs` prove the emitted *shape*; these prove the
+// emitted *behaviour* by compiling a hand-built SIR module and running the
+// self-contained `.js` under Node, comparing stdout (or, for the
+// re-raise case, asserting a non-zero exit).
+
+/// A string literal expression.
+fn str_(v: &str) -> Expr {
+    Expr::StrLit { value: v.into(), span: sp() }
+}
+
+/// A `Const`-scoped var-ref — how the Ruby frontend spells a bare class
+/// name like `ArgumentError` at a `raise` site.
+fn const_ref(name: &str) -> Expr {
+    Expr::VarRef { name: name.into(), scope: Scope::Const, span: sp() }
+}
+
+/// A `raise Class, "msg"` statement.
+fn raise(class: &str, msg: &str) -> Stmt {
+    Stmt::ExprStmt { expr: bc("raise", vec![const_ref(class), str_(msg)]), span: sp() }
+}
+
+/// (a) Built-in ancestry: `begin; raise ArgumentError, "x"; rescue
+/// StandardError => e; puts "caught"; end` → "caught".  `ArgumentError`
+/// chains up to `StandardError` via the baked-in ancestry table.
+#[test]
+fn try_catch_builtin_ancestry_catches() {
+    let try_catch = Stmt::TryCatch {
+        body: vec![raise("ArgumentError", "x")],
+        rescues: vec![RescueClause {
+            exception_types: vec!["StandardError".into()],
+            binding: Some("e".into()),
+            body: vec![print(str_("caught"))],
+            span: sp(),
+        }],
+        ensure_body: None,
+        span: sp(),
+    };
+    let module = module_with_main(
+        vec![try_catch],
+        Expr::NilLit { span: sp() },
+        &[Feature::Exceptions, Feature::Constants, Feature::Strings],
+    );
+    if let Some(stdout) = run_module(&module, "exc_builtin") {
+        assert_eq!(stdout, "caught");
+    }
+}
+
+/// (b) A bare `rescue` (no exception types) is a catch-all: it must catch
+/// a `raise RuntimeError, "y"` and print "rescued".
+#[test]
+fn bare_rescue_catches_anything() {
+    let try_catch = Stmt::TryCatch {
+        body: vec![raise("RuntimeError", "y")],
+        rescues: vec![RescueClause {
+            exception_types: vec![], // bare `rescue`
+            binding: None,
+            body: vec![print(str_("rescued"))],
+            span: sp(),
+        }],
+        ensure_body: None,
+        span: sp(),
+    };
+    let module = module_with_main(
+        vec![try_catch],
+        Expr::NilLit { span: sp() },
+        &[Feature::Exceptions, Feature::Constants, Feature::Strings],
+    );
+    if let Some(stdout) = run_module(&module, "exc_bare") {
+        assert_eq!(stdout, "rescued");
+    }
+}
+
+/// (c) An unmatched rescue type must NOT catch: `raise TypeError` under a
+/// `rescue ArgumentError` re-raises past the inner handler, so the program
+/// exits non-zero (uncaught exception escapes to node).
+#[test]
+fn unmatched_rescue_type_reraises() {
+    let try_catch = Stmt::TryCatch {
+        body: vec![raise("TypeError", "nope")],
+        rescues: vec![RescueClause {
+            exception_types: vec!["ArgumentError".into()],
+            binding: None,
+            body: vec![print(str_("should-not-print"))],
+            span: sp(),
+        }],
+        ensure_body: None,
+        span: sp(),
+    };
+    let module = module_with_main(
+        vec![try_catch],
+        Expr::NilLit { span: sp() },
+        &[Feature::Exceptions, Feature::Constants, Feature::Strings],
+    );
+    if let Some(stderr) = run_module_expecting_failure(&module, "exc_reraise") {
+        // The escaping exception is our TypeError, and the inner handler's
+        // line never ran.
+        assert!(stderr.contains("TypeError") || stderr.contains("nope"), "stderr:\n{stderr}");
+        assert!(!stderr.contains("should-not-print"));
+    }
+}
+
+/// (d) USER ancestry (E2): `class MyErr < StandardError; …; begin; raise
+/// MyErr, "z"; rescue StandardError => e; puts "user-caught"; end` →
+/// "user-caught".  The class edge is registered at init via
+/// `__Sir.registerAncestry`, so `MyErr` chains up to `StandardError`.
+#[test]
+fn try_catch_user_ancestry_catches() {
+    let class_def = Stmt::ClassDef {
+        name: "MyErr".into(),
+        superclass: Some("StandardError".into()),
+        body: vec![],
+        span: sp(),
+    };
+    let try_catch = Stmt::TryCatch {
+        body: vec![raise("MyErr", "z")],
+        rescues: vec![RescueClause {
+            exception_types: vec!["StandardError".into()],
+            binding: Some("e".into()),
+            body: vec![print(str_("user-caught"))],
+            span: sp(),
+        }],
+        ensure_body: None,
+        span: sp(),
+    };
+    let module = module_with_main(
+        vec![class_def, try_catch],
+        Expr::NilLit { span: sp() },
+        &[Feature::Exceptions, Feature::Classes, Feature::Constants, Feature::Strings],
+    );
+    // Shape check (runs without node): the user edge is registered once.
+    let artifact = compile(&module).expect("compile");
+    assert!(
+        artifact.source.contains(r#"__Sir.registerAncestry({ "MyErr": "StandardError" });"#),
+        "expected user ancestry registration, got:\n{}",
+        artifact.source
+    );
+    if let Some(stdout) = run_module(&module, "exc_user_ancestry") {
+        assert_eq!(stdout, "user-caught");
     }
 }


### PR DESCRIPTION
## What

**E1** of the exception-hierarchy cascade — the JS backend now **executes** exception handling (previously `Stmt::TryCatch` panicked "not accepted yet"). Mirrors the TS backend. Design: `code/specs/sir-exception-hierarchy.md` (PR #7255).

- **TryCatch:** native `try { … } catch (__exc) { if (__Sir.rescueMatches(__exc, [...])) { const e = __exc; … } else if … else { throw __exc } } finally { … }` — rescue order preserved, empty types = catch-all, `=> e` bound.
- **raise:** `raise Foo, "msg"` → `__Sir.raiseError("Foo", <msg>)` (throws a class-tagged `SirError`); bare `raise` re-raises.
- **Runtime:** ported `SirError`/`rescueMatches`/built-in `ANCESTRY` into the inlined `__Sir` object, plus `registerAncestry` — the ancestry map is `Object.create(null)` (prototype-pollution-proof) and the walk has a `seen`-set cycle guard.
- **User-class ancestry (E2's JS half, folded in):** collects `ClassDef { name, superclass }` edges and emits a one-shot `__Sir.registerAncestry({...})` at program init, so `class MyErr < StandardError; raise MyErr; rescue StandardError` matches.
- Accepts `Feature::Exceptions`/`Classes`/`Constants`.

## Verification

- `cargo test -p semantic-ir-to-javascript` — **82 lib + 21 integration**.
- **Execution-proof (node):** built-in ancestry catch → `caught`; bare rescue → `rescued`; unmatched type re-raises (non-zero exit, inner handler never runs); **user ancestry** `MyErr < StandardError` → `user-caught`.
- Clippy clean; `cargo build --workspace` clean (bar pre-existing Unix-only crate).
- **Security + soundness review passed:** no prototype-pollution (null-proto map), cycle-bounded walk, escaped names, no eval. The `Feature::Classes` acceptance is sound — methods hoist to top-level `Function`s (so `ClassDef` bodies are ordinary statements), and any class needing ivar/cvar state is **rejected cleanly** by the validator, never mis-emitted.

Completes exception-hierarchy Phase 1 with E2 ([#7261](https://github.com/adhithyan15/coding-adventures/pull/7261)). Deviation: JS backend is self-contained (no `__SirExc`/npm import) — all helpers live in the inlined `__Sir` object.

🤖 Generated with [Claude Code](https://claude.com/claude-code)