### PR TITLE
test(dce): port UnreachableCodeElimination upstream suite (#88, CLOC12.148)

### DIFF
--- a/code/packages/rust/closure-pass-dce/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-dce/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable changes to the `coding-adventures-closure-pass-dce` crate will be documented in this file.
 
+## [0.17.0] - 2026-07-01
+
+### Added — upstream `UnreachableCodeEliminationTest.java` conformance port (#88, CLOC12.148)
+
+The **second** CLOC12 upstream-test port into this crate (alongside the
+`PeepholeRemoveDeadCode` port). New file
+`tests/upstream/unreachable_code_elimination_test.rs` (registered as the
+`upstream_unreachable_code_elimination` test target) reshapes upstream
+`UnreachableCodeEliminationTest.java` onto our typed-AST surface — built by
+hand via the same helper style as the sibling port — asserting the surviving
+function-body statements after running only `DcePass`.
+
+- **8 active `#[test]`s pass on the first run** (no new DCE defect):
+  drop-single/multiple statements after `return`, drop after `throw`, keep
+  reachable code before the terminator, bare `return` unchanged, empty-statement
+  removal, dead-code cleanup inside a nested (`if`-consequent) block, and the
+  hoisting-soundness *decline* — a dead tail carrying a `var` is kept verbatim
+  (declining to truncate is never a miscompile).
+- **2 `#[ignore = "blocked on gap-NNN"]` placeholders** pin the CFG-based
+  reachability upstream does that this pass does not — gap-151 (code after an
+  `if` whose every branch terminates) and gap-152 (code after `break`/`continue`
+  in a general loop block; ours only treats them as terminators in switch
+  cases). Each is pinned to `code/specs/CLOC12-gaps.md`.
+
+Notably the nested-block case surfaced (and now documents) the interaction with
+the existing block-flattening step: a bare `{ return }` block flattens into its
+parent, so the port wraps the nested block in an `if`-consequent to test
+interior cleanup in isolation.
+
+This is a **test-only** change: no `src/` file is touched, so there is no
+ripple into downstream consumers. Bumps the crate 0.16.0 → 0.17.0.
+
 ## [0.16.0] - 2026-06-30
 
 ### Added — correlation-vector deletion provenance (#89, full CV tracing)

--- a/code/packages/rust/closure-pass-dce/Cargo.toml
+++ b/code/packages/rust/closure-pass-dce/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-dce"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 description = "Dead-code elimination pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Drops code after definite-terminator statements and removes EmptyStatement noise."
 
@@ -22,3 +22,7 @@ coding-adventures-closure-pass-fold-control-flow = { path = "../closure-pass-fol
 [[test]]
 name = "upstream_peephole_remove_dead_code"
 path = "tests/upstream/peephole_remove_dead_code_test.rs"
+
+[[test]]
+name = "upstream_unreachable_code_elimination"
+path = "tests/upstream/unreachable_code_elimination_test.rs"

--- a/code/packages/rust/closure-pass-dce/README.md
+++ b/code/packages/rust/closure-pass-dce/README.md
@@ -94,6 +94,23 @@ Once the AST grows the needed variants:
   (constant-discriminant `switch` collapse, dead ternary arms), which
   currently emit only a summary contribution.
 
+## Upstream conformance tests
+
+`tests/upstream/` ports Google Closure Compiler tests (Apache-2.0; see
+`ATTRIBUTION.md` and `UPSTREAM_SHA`), per the CLOC12 test-port convention:
+
+- `peephole_remove_dead_code_test.rs` — `PeepholeRemoveDeadCodeTest.java`
+  (block flattening, no-op labelled statements, …).
+- `unreachable_code_elimination_test.rs` — `UnreachableCodeEliminationTest.java`.
+  Pins the block-level reachability cleanup this pass performs
+  (drop-after-`return`/`throw`, empty-statement removal, nested-block
+  recursion, and the hoisting-soundness decline when a dead tail carries a
+  `var`/`function`). **8 active `#[test]`s** plus **2 `#[ignore]` placeholders**
+  for the CFG-based reachability we don't do yet (`if`-both-branches-terminate →
+  gap-151; `break`/`continue` in a general loop block → gap-152), pinned in
+  `code/specs/CLOC12-gaps.md`. Run with
+  `cargo test --test upstream_unreachable_code_elimination`.
+
 ## Dependency whitelist
 
 - `coding-adventures-closure-pass-pipeline` — `Pass` trait + types.

--- a/code/packages/rust/closure-pass-dce/tests/upstream/ATTRIBUTION.md
+++ b/code/packages/rust/closure-pass-dce/tests/upstream/ATTRIBUTION.md
@@ -13,6 +13,17 @@ under the Apache License, Version 2.0:
     - blob SHA at port time: `db5fe5af7e3dcba58560a0338c315d262dfbc04a`
     - tracked commit: see `UPSTREAM_SHA`
 
+- `unreachable_code_elimination_test.rs`
+    - upstream: `test/com/google/javascript/jscomp/UnreachableCodeEliminationTest.java`
+    - tracked commit: see `UPSTREAM_SHA`
+    - Pins the block-level reachability cleanup `DcePass` performs today
+      (drop-after-`return`/`throw`, empty-statement removal, nested-block
+      recursion, and the hoisting-soundness *decline* when a dead tail
+      carries a `var`/`function`). Upstream's full CFG-based analysis —
+      code after an `if`-both-branches-terminate (gap-151) and after
+      `break`/`continue` in a general loop block (gap-152) — is pinned as
+      `#[ignore]` placeholders.
+
 ## Translation notes
 
 This is the **second** port under CLOC12 (after

--- a/code/packages/rust/closure-pass-dce/tests/upstream/unreachable_code_elimination_test.rs
+++ b/code/packages/rust/closure-pass-dce/tests/upstream/unreachable_code_elimination_test.rs
@@ -1,0 +1,300 @@
+//! Ported from `UnreachableCodeEliminationTest.java` in
+//! `google/closure-compiler`, Apache-2.0. Upstream SHA: see
+//! `tests/upstream/UPSTREAM_SHA`.
+//!
+//! Translation policy: see
+//! `code/specs/CLOC12-upstream-test-suite-port.md`.
+//!
+//! # What this file covers
+//!
+//! The **second** CLOC12 port into `closure-pass-dce` (alongside the
+//! `PeepholeRemoveDeadCode` port). Upstream `UnreachableCodeElimination`
+//! walks the control-flow graph and deletes any statement that cannot be
+//! reached — code after a `return`/`throw`, code after `break`/`continue`
+//! inside a loop, code after an `if` whose every branch terminates, empty
+//! statements, and so on — while preserving *hoisted* `var`/`function`
+//! declarations (which are reachable regardless of textual position).
+//!
+//! closurec's `DcePass` implements the **provably-sound block-level core**
+//! of that: inside any `BlockStatement.body` it drops everything after a
+//! `ReturnStatement`/`ThrowStatement`, drops `EmptyStatement`s, and (for
+//! hoisting soundness) *declines* to truncate a tail that contains a
+//! `var`/`function` (or a compound statement that could wrap one) — a
+//! decline is never a miscompile, and `remove-unused-vars` cleans a
+//! genuinely-dead hoisted binding downstream. Break/continue are only
+//! treated as terminators inside switch-case consequents, not at the
+//! general block level, and an `if`-both-branches-terminate is not yet
+//! recognised — those are the gaps.
+//!
+//! ## Harness
+//!
+//! `closure-pass-dce` has no source-string entry point in its test
+//! harness, so — exactly as the sibling `PeepholeRemoveDeadCode` port
+//! does — each case is built directly on the typed AST via small helpers
+//! and compared statement-by-statement against the expected function
+//! body. `assert_dce_yields` models upstream `fold(input, expected)`;
+//! `assert_dce_same` models `foldSame(input)`.
+
+use coding_adventures_closure_pass_dce::DcePass;
+use coding_adventures_closure_pass_pipeline::{Pass, PassContext};
+use coding_adventures_correlation_vector::CVLog;
+use coding_adventures_javascript_ast::{
+    statement::TaggedStatement, BlockStatement, BreakStatement, Declaration, EmptyStatement,
+    Expression, ExpressionStatement, FunctionDeclaration, Identifier, IfStatement, NumericLiteral,
+    Program, ProgramItem, ReturnStatement, SourceType, Statement, ThrowStatement, VarKind,
+    VariableDeclaration, VariableDeclarator, WhileStatement,
+};
+use coding_adventures_javascript_ast::BindingTarget;
+use coding_adventures_javascript_tokens::EsVersion;
+use coding_adventures_type_sidecar::Sidecar;
+
+// =====================================================================
+// Test-support helpers (mirroring the sibling PeepholeRemoveDeadCode port)
+// =====================================================================
+
+fn ident(name: &str) -> Expression {
+    Expression::Identifier(Identifier {
+        cv: None,
+        name: name.to_string(),
+    })
+}
+
+fn num(v: f64) -> Expression {
+    Expression::NumericLiteral(NumericLiteral {
+        cv: None,
+        value: v,
+        raw: format!("{}", v as i64),
+    })
+}
+
+/// A bare `name;` expression statement — a reachable, side-effecting-ish
+/// statement used as the "dead tail" the pass should drop.
+fn expr_stmt(name: &str) -> Statement {
+    Statement::expression_statement(ExpressionStatement {
+        cv: None,
+        expression: ident(name),
+    })
+}
+
+fn return_stmt(arg: Option<Expression>) -> Statement {
+    Statement::return_statement(ReturnStatement { cv: None, argument: arg })
+}
+
+fn throw_stmt(arg: Expression) -> Statement {
+    Statement::throw_statement(ThrowStatement { cv: None, argument: arg })
+}
+
+fn empty_stmt() -> Statement {
+    Statement::empty_statement(EmptyStatement { cv: None })
+}
+
+fn break_stmt() -> Statement {
+    Statement::break_statement(BreakStatement { cv: None, label: None })
+}
+
+fn block(body: Vec<Statement>) -> Statement {
+    Statement::block_statement(BlockStatement { cv: None, body })
+}
+
+/// A `var name = value;` declaration statement — carries a *hoisted*
+/// binding, so a DCE tail containing it must NOT be truncated.
+fn var_stmt(name: &str, value: Expression) -> Statement {
+    Statement::Declaration(Declaration::VariableDeclaration(VariableDeclaration {
+        cv: None,
+        kind: VarKind::Var,
+        declarations: vec![VariableDeclarator {
+            cv: None,
+            id: BindingTarget::Identifier(Identifier { cv: None, name: name.to_string() }),
+            init: Some(value),
+        }],
+    }))
+}
+
+fn if_stmt(test: Expression, consequent: Statement, alternate: Option<Statement>) -> Statement {
+    Statement::if_statement(IfStatement {
+        cv: None,
+        test,
+        consequent: Box::new(consequent),
+        alternate: alternate.map(Box::new),
+    })
+}
+
+fn while_stmt(test: Expression, body: Statement) -> Statement {
+    Statement::while_statement(WhileStatement {
+        cv: None,
+        test,
+        body: Box::new(body),
+    })
+}
+
+fn function_body(body: Vec<Statement>) -> Program {
+    let fdecl = Declaration::FunctionDeclaration(FunctionDeclaration {
+        cv: None,
+        id: Identifier { cv: None, name: "f".to_string() },
+        params: vec![],
+        body: BlockStatement { cv: None, body },
+        generator: false,
+        is_async: false,
+    });
+    Program::new_untraced(EsVersion::Es2025, SourceType::Module)
+        .with_body(vec![ProgramItem::Declaration(fdecl)])
+}
+
+fn run_dce(prog: Program) -> Program {
+    let pass = DcePass::new();
+    let sidecar = Sidecar::new();
+    let mut cv = CVLog::new(false);
+    pass.run(PassContext { program: &prog, sidecar: &sidecar, cv: &mut cv })
+        .expect("DCE pass run failed")
+        .program
+}
+
+fn function_body_stmts(prog: &Program) -> Vec<Statement> {
+    let ProgramItem::Declaration(Declaration::FunctionDeclaration(f)) = &prog.body[0] else {
+        panic!("expected FunctionDeclaration at body[0]");
+    };
+    f.body.body.clone()
+}
+
+/// Upstream `fold(input, expected)`.
+fn assert_dce_yields(input_body: Vec<Statement>, expected_body: Vec<Statement>) {
+    let folded = run_dce(function_body(input_body));
+    assert_eq!(
+        function_body_stmts(&folded),
+        expected_body,
+        "DCE output did not match expected"
+    );
+}
+
+/// Upstream `foldSame(input)`.
+fn assert_dce_same(body: Vec<Statement>) {
+    let before = body.clone();
+    let folded = run_dce(function_body(body));
+    assert_eq!(function_body_stmts(&folded), before, "DCE changed statements it should have kept");
+}
+
+// =====================================================================
+// Active — reachability cleanup the pass performs today
+// =====================================================================
+
+/// Upstream `testRemoveUnreachableCode` (return subset): a single
+/// statement after `return` is unreachable and dropped.
+#[test]
+fn drops_single_statement_after_return() {
+    assert_dce_yields(
+        vec![return_stmt(None), expr_stmt("x")],
+        vec![return_stmt(None)],
+    );
+}
+
+/// Multiple dead statements after `return` all go.
+#[test]
+fn drops_multiple_statements_after_return() {
+    assert_dce_yields(
+        vec![return_stmt(Some(num(1.0))), expr_stmt("x"), expr_stmt("y")],
+        vec![return_stmt(Some(num(1.0)))],
+    );
+}
+
+/// Code after a `throw` is unreachable and dropped.
+#[test]
+fn drops_statement_after_throw() {
+    assert_dce_yields(
+        vec![throw_stmt(ident("e")), expr_stmt("x")],
+        vec![throw_stmt(ident("e"))],
+    );
+}
+
+/// Reachable code BEFORE the terminator is kept.
+#[test]
+fn keeps_reachable_code_before_return() {
+    assert_dce_same(vec![expr_stmt("x"), return_stmt(None)]);
+}
+
+/// A bare `return` with nothing after it is unchanged.
+#[test]
+fn bare_return_unchanged() {
+    assert_dce_same(vec![return_stmt(None)]);
+}
+
+/// Upstream `testRemoveUselessNameStatements`-adjacent: empty statements
+/// are dropped from a block.
+#[test]
+fn drops_empty_statements() {
+    assert_dce_yields(
+        vec![expr_stmt("x"), empty_stmt(), empty_stmt()],
+        vec![expr_stmt("x")],
+    );
+}
+
+/// Dead-after-return cleanup reaches into a NESTED block. The block is an
+/// `if`-consequent (not subject to the top-level block-flattening that
+/// would splice a bare `{ return }` into the function body), so it stays a
+/// block and we can assert its interior was cleaned.
+#[test]
+fn drops_dead_code_in_nested_block() {
+    assert_dce_yields(
+        vec![if_stmt(
+            ident("c"),
+            block(vec![return_stmt(None), expr_stmt("x")]),
+            None,
+        )],
+        vec![if_stmt(ident("c"), block(vec![return_stmt(None)]), None)],
+    );
+}
+
+/// SOUNDNESS (hoisting): a tail after `return` that contains a hoisted
+/// `var` is NOT truncated — the declaration is reachable regardless of
+/// position. closurec conservatively keeps the whole tail (upstream would
+/// keep the hoisted `var x` but drop its initializer and the dead call;
+/// see gap-153). Declining to truncate is never a miscompile.
+#[test]
+fn declines_to_truncate_tail_with_hoisted_var() {
+    assert_dce_same(vec![
+        return_stmt(None),
+        var_stmt("x", num(1.0)),
+        expr_stmt("g"),
+    ]);
+}
+
+// =====================================================================
+// Ignored — upstream reachability analysis we do not do yet.
+// =====================================================================
+
+/// Upstream removes code after an `if` whose EVERY branch terminates
+/// (`if (c) return; else return; y();` → the `y()` is unreachable). Ours
+/// only truncates after a *direct* terminator statement; an `IfStatement`
+/// is not `is_terminator`, so `y()` survives today.
+#[test]
+#[ignore = "blocked on gap-151: if-both-branches-terminate not recognised as making the tail unreachable"]
+fn drops_code_after_if_both_branches_return() {
+    assert_dce_yields(
+        vec![
+            if_stmt(
+                ident("c"),
+                block(vec![return_stmt(None)]),
+                Some(block(vec![return_stmt(None)])),
+            ),
+            expr_stmt("y"),
+        ],
+        vec![if_stmt(
+            ident("c"),
+            block(vec![return_stmt(None)]),
+            Some(block(vec![return_stmt(None)])),
+        )],
+    );
+}
+
+/// Upstream treats `break`/`continue` as terminating the enclosing loop
+/// body, so code after a `break` inside a loop is unreachable
+/// (`while (c) { break; y(); }` → `while (c) { break; }`). closurec only
+/// treats break/continue as terminators inside switch-case consequents,
+/// so the loop-body `y()` survives today.
+#[test]
+#[ignore = "blocked on gap-152: break/continue only terminate switch cases, not general loop blocks"]
+fn drops_code_after_break_in_loop_block() {
+    assert_dce_yields(
+        vec![while_stmt(ident("c"), block(vec![break_stmt(), expr_stmt("y")]))],
+        vec![while_stmt(ident("c"), block(vec![break_stmt()]))],
+    );
+}

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -1353,3 +1353,39 @@ no remaining uses. Placeholder: `removes_dead_const_after_inlining`.
   (Numbering note: authored off `origin/main` in parallel with the
   inline-variables port CLOC12.146 / gap-148…150, so this takes CLOC12.147 to
   avoid collision when both merge. This port opens no new gaps.)
+
+## CLOC12.148 — UnreachableCodeElimination port (dce)
+
+- **What it is:** the **second** CLOC12 upstream port into `closure-pass-dce`
+  (alongside the `PeepholeRemoveDeadCode` port). New file
+  `tests/upstream/unreachable_code_elimination_test.rs`, registered as the
+  `upstream_unreachable_code_elimination` test target, ported from upstream
+  `UnreachableCodeEliminationTest.java`. Hand-built typed-AST harness (the crate
+  has no source-string entry point), asserting surviving function-body
+  statements after running only `DcePass`.
+- **8 active `#[test]`s pass on the first run** (no new DCE bug): drop
+  single/multiple statements after `return`, drop after `throw`, keep reachable
+  code before the terminator, bare `return` unchanged, empty-statement removal,
+  dead-code cleanup inside a nested `if`-consequent block, and the
+  hoisting-soundness decline (a dead tail carrying a `var` is kept verbatim).
+- **2 `#[ignore]` placeholders** — see gap-151, gap-152.
+
+  (Numbering note: authored off `origin/main` in parallel with the emitter
+  object-literal port CLOC12.147, so this takes CLOC12.148 to avoid collision
+  when both merge.)
+
+### gap-151 — `if`-both-branches-terminate not recognised as unreachable
+
+Upstream removes code after an `if` whose every branch terminates
+(`if (c) return; else return; y();` → the `y()` is unreachable). closurec's DCE
+only truncates after a *direct* terminator statement; an `IfStatement` is not
+`is_terminator`, so the trailing `y()` survives today. Placeholder:
+`drops_code_after_if_both_branches_return`.
+
+### gap-152 — `break`/`continue` only terminate switch cases, not loop blocks
+
+Upstream treats `break`/`continue` as ending the enclosing loop body, so code
+after a `break` inside a loop is unreachable (`while (c) { break; y(); }` →
+`while (c) { break; }`). closurec only treats break/continue as terminators
+inside switch-case consequents (`is_case_terminator`), so the loop-body `y()`
+survives. Placeholder: `drops_code_after_break_in_loop_block`.


### PR DESCRIPTION
## Summary

Second CLOC12 upstream-test port into **`closure-pass-dce`** (#88), alongside the existing `PeepholeRemoveDeadCode` port. Ports google/closure-compiler's `UnreachableCodeEliminationTest.java` into `tests/upstream/unreachable_code_elimination_test.rs` — a hand-built typed-AST harness (the crate has no source-string entry point) asserting the surviving function-body statements after running only `DcePass`.

## Results

- **8 active `#[test]`s pass on the first run** — no new DCE defect. Cover: drop single/multiple statements after `return`, drop after `throw`, keep reachable code before the terminator, bare `return` unchanged, empty-statement removal, dead-code cleanup inside a nested `if`-consequent block, and the hoisting-soundness *decline* (a dead tail carrying a `var` is kept verbatim — declining to truncate is never a miscompile).
- **2 `#[ignore = "blocked on gap-NNN"]` placeholders** pin the CFG-based reachability upstream does that this pass does not:
  - **gap-151** — code after an `if` whose every branch terminates
  - **gap-152** — code after `break`/`continue` in a general loop block (ours only treats them as terminators in switch cases)

The nested-block case surfaced (and now documents) the interaction with the existing block-flattening step: a bare `{ return }` block flattens into its parent, so the port wraps the nested block in an `if`-consequent to test interior cleanup in isolation.

## Scope / safety

- **Test-only**: no `src/` file is touched, so there is no downstream ripple. Full dce `cargo test` green (56 lib + both port suites).
- Registers the `upstream_unreachable_code_elimination` `[[test]]` target; bumps the crate 0.16.0 → 0.17.0 with CHANGELOG + README; adds the entry to `tests/upstream/ATTRIBUTION.md` and a CLOC12.148 section to `code/specs/CLOC12-gaps.md`.
- **Numbering**: authored off `origin/main` in parallel with the emitter object-literal port (CLOC12.147 / #7256), so this takes CLOC12.148 / gap-151,152. A `CLOC12-gaps.md` rebase may be needed once that sibling merges.
- Inline security review: **PASSED** (test-only, no untrusted input, no `unsafe`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)