### PR TITLE
feat(adj-lang): latex "x^n" emits native ComputeOp::Pow (lifts ≤8 cap)

### DIFF
--- a/code/packages/rust/adj-constraint-solver/CHANGELOG.md
+++ b/code/packages/rust/adj-constraint-solver/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.11.0] - 2026-07-01 — polynomial path reads `ComputeOp::Pow`
+
+### Changed
+
+- `poly_of` (the univariate-polynomial recogniser behind the nonlinear root
+  tactic) now understands `ComputeOp::Pow(base, n)` for a **constant
+  non-negative integer** exponent `n`: it folds `base` into a polynomial `n`
+  times (`base^0 = 1`). This keeps `constrain latex "$x^2 = 4$"` solving as a
+  quadratic (→ {±2}) — and `x^3`, `x^4` as cubics/quartics — now that the
+  adj-lang latex adapter lowers `x^n` to a native `Pow` node rather than an
+  `x*x*…` expansion (adj-lang 0.20.0). A symbolic or fractional exponent is
+  (as before) not polynomial → the constraint is treated as non-linear.
+- `n` is bounded by `MAX_POLY_POW` (64) so a pathological `x^{huge}` cannot
+  balloon the coefficient vector; the univariate solvers cover only degree ≤ 4,
+  so the cap loses nothing real.
+
 ## [0.10.0] - 2026-06-14 — general boolean-clause recognizer (n-ary combinations scale)
 
 ### Added / Changed

--- a/code/packages/rust/adj-constraint-solver/Cargo.toml
+++ b/code/packages/rust/adj-constraint-solver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-constraint-solver"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 description = "Solver bridge for the adj-lang constraint sublanguage. Takes an adj-lang ConstraintSystem (symbols + constrain/solve/check), classifies it, and dispatches the linear-equality case to cas-solve's exact rational Gaussian elimination — returning solved values traced back to the constraints. The first slice (B2a) of the ADJ constraint-solving arc; SAT / linear-integer / inequality feasibility and optimization follow."
 

--- a/code/packages/rust/adj-constraint-solver/src/lib.rs
+++ b/code/packages/rust/adj-constraint-solver/src/lib.rs
@@ -2001,6 +2001,12 @@ fn substitute_observed(
 /// (`p[0] + p[1]·x + p[2]·x² + …`).
 type Poly = Vec<f64>;
 
+/// The largest constant integer exponent [`poly_of`] will expand a `base ^ n`
+/// into (repeated multiplication). The univariate root solvers cover only
+/// degree ≤ 4, so this bound is generous; it exists purely to stop an
+/// adversarial `x^{huge}` from allocating an enormous coefficient vector.
+const MAX_POLY_POW: f64 = 64.0;
+
 /// Build the polynomial of `e` in the single unknown `x`, or `None` if `e`
 /// isn't a polynomial in `x` (e.g. division *by* `x`, an aggregation, or a free
 /// reference — observed refs have already been substituted to literals).
@@ -2023,6 +2029,42 @@ fn poly_of(e: &ComputeExpr, x: &str) -> Option<Poly> {
                     } else {
                         None
                     }
+                }
+                // `base ^ n` is a polynomial iff the exponent is a constant
+                // **non-negative integer** (`ComputeOp::Pow` from a LaTeX `x^n`):
+                // then it is `base` multiplied by itself `n` times (`base^0 = 1`),
+                // so a latex `x^2 = 4` still solves as a quadratic, `x^3` as a
+                // cubic, etc. A symbolic or fractional exponent is not polynomial.
+                // `n` is capped at `MAX_POLY_POW` so a pathological `x^{10^9}`
+                // cannot balloon the coefficient vector (the univariate solvers
+                // handle only degree ≤ 4 anyway, so the cap loses nothing real).
+                ComputeOp::Pow => {
+                    if poly_degree(&pb) != 0 {
+                        return None;
+                    }
+                    let n = pb[0];
+                    if !(n.is_finite() && n.fract() == 0.0 && (0.0..=MAX_POLY_POW).contains(&n)) {
+                        return None;
+                    }
+                    // Cap the CUMULATIVE result degree, not just this exponent:
+                    // `pa` may itself be a high-degree polynomial from an inner
+                    // power, so nested powers like `(((x^64)^64)^64)` would
+                    // otherwise compound (64 → 4096 → 262144 → …), ballooning the
+                    // coefficient vector (`poly_mul` is O(len²)). The base degree
+                    // times `n` must stay within `MAX_POLY_POW`; a constant base
+                    // has degree 0 so `c^n` still expands cheaply.
+                    let base_deg = poly_degree(&pa);
+                    if base_deg
+                        .checked_mul(n as usize)
+                        .is_none_or(|d| (d as f64) > MAX_POLY_POW)
+                    {
+                        return None;
+                    }
+                    let mut acc = vec![1.0];
+                    for _ in 0..(n as u32) {
+                        acc = poly_mul(&acc, &pa);
+                    }
+                    Some(acc)
                 }
                 _ => None,
             }
@@ -2407,6 +2449,46 @@ mod tests {
             SolveOutcome::SolvedRoots { roots, .. } => roots.clone(),
             other => panic!("expected SolvedRoots, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn quadratic_via_latex_power_still_solves() {
+        // `constrain latex "$x^2 = 4$"` now lowers to a native ComputeOp::Pow
+        // node (not `x*x`); the polynomial path must still read it as a quadratic
+        // and find {±2}. Guards against a regression from the Pow rewrite.
+        let r = roots(&solve_src(
+            "symbol x : scalar\nconstrain latex \"$x^2 = 4$\"\nsolve for { x }\n",
+        ));
+        assert_eq!(r.len(), 2);
+        assert!((r[0] - -2.0).abs() < 1e-6, "{r:?}");
+        assert!((r[1] - 2.0).abs() < 1e-6, "{r:?}");
+    }
+
+    #[test]
+    fn cubic_via_latex_power_still_solves() {
+        // A latex `x^3` lowers to Pow too; the cubic solver still finds the root.
+        let r = roots(&solve_src(
+            "symbol x : scalar\nconstrain latex \"$x^3 = 8$\"\nsolve for { x }\n",
+        ));
+        assert!(r.iter().any(|v| (v - 2.0).abs() < 1e-6), "{r:?}");
+    }
+
+    #[test]
+    fn nested_powers_do_not_explode_the_polynomial_degree() {
+        // `(((x^64)^64)^64) = 1` would compound to degree ~262144+ without the
+        // cumulative-degree cap. It must return quickly as Unknown (not solved,
+        // not hung) — the constraint is simply not treated as a small polynomial.
+        let out = solve_src(
+            "symbol x : scalar\n\
+             constrain latex \"$((x^{64})^{64})^{64} = 1$\"\n\
+             solve for { x }\n",
+        );
+        // Any non-panicking, promptly-returned outcome is acceptable; it must not
+        // be a solved low-degree polynomial (the degree is far beyond the cap).
+        assert!(
+            !matches!(out, SolveOutcome::SolvedRoots { .. }),
+            "nested powers must not be expanded into a solvable polynomial: {out:?}"
+        );
     }
 
     #[test]

--- a/code/packages/rust/adj-lang/CHANGELOG.md
+++ b/code/packages/rust/adj-lang/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## [0.20.0] - 2026-07-01 — native `^` power in `latex "…"` (emit `ComputeOp::Pow`)
+
+### Changed
+
+- The `latex "…"` adapter now lowers `x^n` to a **single native power node**
+  (`ArithOp::Pow` → `logic_engine::ComputeOp::Pow`) instead of expanding it to a
+  parse-time `x*x*…` chain. Two consequences:
+  - The old **integer-exponent cap (0–8) is gone** — `latex "$x^{10}$"` (and
+    higher) now compute; the engine computes the power and applies its own
+    dimensional / overflow (`NonFinite`) rules.
+  - The derivation tree shows one `^` step rather than a multiplication chain.
+  The exponent must still be a **non-negative integer literal** (a symbolic
+  exponent like `x^y` remains unsupported on this surface — a later slice).
+- Added `ArithOp::Pow` to the `let`-formula AST (produced only by the latex
+  adapter; the surface arithmetic grammar does not yet spell `^`). Removed the
+  now-unused `expand_power` helper.
+
+### Notes
+
+- A latex `x^2 = 4` constraint still solves as a quadratic: the constraint
+  solver's polynomial recogniser was taught to read `ComputeOp::Pow` (see
+  adj-constraint-solver 0.11.0), so no solving capability regresses.
+
 ## [0.19.0] - 2026-06-27 — predicate RHS expressions
 
 ### Added

--- a/code/packages/rust/adj-lang/Cargo.toml
+++ b/code/packages/rust/adj-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang"
-version = "0.18.0"
+version = "0.20.0"
 edition = "2021"
 description = "Surface-syntax frontend for the adjudication framework's probabilistic-logic rulebooks. Lexes, parses, and lowers a domain-expert-readable DSL into a `logic-engine` KnowledgeBase. Dissolves ADJ46 awkwardness items A10 (rulebook syntax) and A4 (joint contributions syntactically distinct)."
 

--- a/code/packages/rust/adj-lang/src/adapter.rs
+++ b/code/packages/rust/adj-lang/src/adapter.rs
@@ -934,8 +934,18 @@ fn latex_math_to_expr_ast(expr: &MathExpr, source: &str) -> Result<ExprAst, Adap
             latex_bin(ArithOp::Div, lhs, rhs, source)
         }
         MathExpr::Bin(BinOp::Pow, base, exponent) => {
+            // `x^n` lowers to a single native power node (`ArithOp::Pow` →
+            // `ComputeOp::Pow`), not the old parse-time `x*x*…` expansion — so
+            // there is no integer-exponent cap and the derivation tree shows one
+            // `^` step. The exponent must still be a non-negative integer literal
+            // (a symbolic exponent like `x^y` is a later slice); the engine
+            // computes it and enforces its own dimensional/overflow rules.
             let n = latex_power_exponent(exponent, source)?;
-            expand_power(base, n, source)
+            Ok(ExprAst::Bin(
+                ArithOp::Pow,
+                Box::new(latex_math_to_expr_ast(base, source)?),
+                Box::new(ExprAst::Lit(n)),
+            ))
         }
         MathExpr::Rel(_, _, _) => Err(AdapterError::UnsupportedLatexMath {
             source: source.to_string(),
@@ -980,7 +990,14 @@ fn number_to_lit(number: &Number, source: &str) -> Result<ExprAst, AdapterError>
     Ok(ExprAst::Lit(value))
 }
 
-fn latex_power_exponent(expr: &MathExpr, source: &str) -> Result<usize, AdapterError> {
+/// Validate a LaTeX power exponent and return it as a whole-number `f64` (for a
+/// `ExprAst::Lit`). The exponent must be a **non-negative integer literal** — a
+/// symbolic exponent (`x^y`) is not yet supported on the `latex "…"` surface. No
+/// upper bound is imposed now that the base lowers to a single native
+/// `ComputeOp::Pow` node (rather than an `x*x*…` expansion whose tree size grew
+/// with the exponent); the engine computes the power and applies its own
+/// dimensional and overflow (`NonFinite`) guards.
+fn latex_power_exponent(expr: &MathExpr, source: &str) -> Result<f64, AdapterError> {
     let MathExpr::Number(n) = expr else {
         return Err(AdapterError::UnsupportedLatexMath {
             source: source.to_string(),
@@ -993,25 +1010,13 @@ fn latex_power_exponent(expr: &MathExpr, source: &str) -> Result<usize, AdapterE
             detail: format!("exponent is outside f64 range: {}", n.as_written()),
         });
     };
-    if !(v.is_finite() && v.fract() == 0.0 && v >= 0.0 && v <= 8.0) {
+    if !(v.is_finite() && v.fract() == 0.0 && v >= 0.0) {
         return Err(AdapterError::UnsupportedLatexMath {
             source: source.to_string(),
-            detail: "only integer exponents from 0 through 8 are supported".into(),
+            detail: "only non-negative integer exponents are supported".into(),
         });
     }
-    Ok(v as usize)
-}
-
-fn expand_power(base: &MathExpr, exponent: usize, source: &str) -> Result<ExprAst, AdapterError> {
-    if exponent == 0 {
-        return Ok(ExprAst::Lit(1.0));
-    }
-    let base = latex_math_to_expr_ast(base, source)?;
-    let mut acc = base.clone();
-    for _ in 1..exponent {
-        acc = ExprAst::Bin(ArithOp::Mul, Box::new(acc), Box::new(base.clone()));
-    }
-    Ok(acc)
+    Ok(v)
 }
 
 fn lower_latex_relop(op: MathRelOp, source: &str) -> Result<RelOp, AdapterError> {

--- a/code/packages/rust/adj-lang/src/ast.rs
+++ b/code/packages/rust/adj-lang/src/ast.rs
@@ -77,6 +77,10 @@ pub enum ArithOp {
     Sub,
     Mul,
     Div,
+    /// Exponentiation, `base ^ exponent`. Produced by the `latex "…"` adapter
+    /// for `x^n` (lowered to `logic_engine::ComputeOp::Pow`); the surface
+    /// arithmetic grammar does not yet spell `^` directly.
+    Pow,
 }
 
 /// An aggregation operator in a `let` formula — reduces every

--- a/code/packages/rust/adj-lang/src/lower.rs
+++ b/code/packages/rust/adj-lang/src/lower.rs
@@ -715,6 +715,7 @@ fn lower_arith_op(op: ArithOp) -> ComputeOp {
         ArithOp::Sub => ComputeOp::Sub,
         ArithOp::Mul => ComputeOp::Mul,
         ArithOp::Div => ComputeOp::Div,
+        ArithOp::Pow => ComputeOp::Pow,
     }
 }
 
@@ -1731,10 +1732,29 @@ contributes 1000000 from answer == 60 to correct
             compile("symbol x : scalar\nconstrain latex \"$x^2 = 4$\"\nsolve for { x }\n").unwrap();
         let c = &lowered.constraints.constraints[0];
         assert_eq!(c.op, crate::ast::RelOp::Eq);
+        // `x^2` now lowers to a single native power node (ComputeOp::Pow), not the
+        // old `x*x` expansion; the constraint solver's polynomial path still reads
+        // it as a quadratic (see adj-constraint-solver `poly_of`).
         assert!(matches!(
             c.lhs,
-            logic_engine::ComputeExpr::Bin(logic_engine::ComputeOp::Mul, _, _)
+            logic_engine::ComputeExpr::Bin(logic_engine::ComputeOp::Pow, _, _)
         ));
+    }
+
+    #[test]
+    fn native_latex_power_computes_as_one_node_without_the_old_cap() {
+        // `x^{10}` used to be rejected (expansion capped at exponent 8); it now
+        // lowers to a single ComputeOp::Pow node and computes: 2^10 = 1024.
+        // (A single-letter symbol — LaTeX math reads `base` as b·a·s·e.)
+        let d = crate::compile_and_decide(
+            "observe x(2)\n\
+             let answer = latex \"$x^{10}$\"\n\
+             prior 0.10 for correct\n\
+             contributes 1000000 from answer == 1024 to correct\n\
+             ? correct\n",
+        )
+        .unwrap();
+        assert!(d.ranked[0].posterior > 0.99, "{d:?}");
     }
 
     #[test]


### PR DESCRIPTION
## What

Second consumer-side slice of the LaTeX/math arc (after [#7259](https://github.com/adhithyan15/coding-adventures/pull/7259)'s engine `ComputeOp::Pow`). The adj-lang `latex "…"` adapter now lowers `x^n` to a **single native power node** instead of the parse-time `x*x*…` expansion — which **removes the old integer-exponent cap of 8**. `latex "$x^{10}$"` now computes `2^10 = 1024` as one derivation node.

## adj-lang

- Add `ArithOp::Pow` to the `let`-formula AST; map it in `lower_arith_op` (`ArithOp::Pow` → `logic_engine::ComputeOp::Pow`).
- `latex_math_to_expr_ast`'s `Bin(Pow)` arm emits `ExprAst::Bin(ArithOp::Pow, base, Lit(n))`; removed the now-dead `expand_power` helper. The exponent must still be a **non-negative integer literal** (symbolic `x^y` is a later slice); the engine computes the power and applies its own dimensional / overflow (`NonFinite`) guards.

## adj-constraint-solver (no-regression fix)

`latex_math_to_expr_ast` is **shared** with the `constrain` path, so `x^2 = 4` constraints now emit `Pow` too. To avoid regressing quadratic solving, `poly_of` learned a `ComputeOp::Pow` arm: a constant non-negative integer exponent folds `poly_mul` `n` times (`base^0 = 1`), so latex `x^2 = 4` still solves as a quadratic (`{±2}`), `x^3`/`x^4` as cubics/quartics.

**DoS guard** (found + fixed via inline security review): beyond the per-exponent `MAX_POLY_POW = 64`, a **cumulative-degree** cap (`base_deg × n ≤ 64`) prevents nested powers `(((x^64)^64)^64)` from compounding the polynomial degree (64 → 4096 → …) and ballooning the coefficient vector. A regression test asserts the nested case returns promptly as a non-solvable outcome.

## Tests

adj-lang **87**, adj-constraint-solver **60** (incl. latex-power quadratic/cubic solves + nested-power DoS guard), adj-lang-cli **38**, adjudication-pipeline — all green. Clippy clean of new lints.

`adj-lang` 0.18.0 → 0.20.0, `adj-constraint-solver` 0.10.0 → 0.11.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)