### PR TITLE
feat(semantic-ir-to-rust): exception handling via catch_unwind + ancestry (E4)

### DIFF
--- a/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
@@ -1,5 +1,90 @@
 # Changelog
 
+## 0.8.0 — exception handling via catch_unwind + ancestry (E4)
+
+Makes the Rust backend **accept and execute** structured exceptions
+(`Feature::Exceptions`). Before this change `Stmt::TryCatch` and the
+`raise` builtin hit `panic!` guards in `emit.rs` (the feature was not in
+`ACCEPTED_FEATURES`), so any `begin/rescue/ensure` module was rejected.
+Rust has no native exceptions, so v0 maps Ruby's exception model onto
+Rust's **unwinding panic** machinery — a *localized* transform touching
+only the `raise`/`TryCatch` arms; every other emit path is unchanged.
+
+### Added
+
+- **Runtime (`runtime.rs`).** An exception model in the inline `__sir`
+  module:
+  - `SirError { class: String, msg: String }` — the panic payload. `msg`
+    is a `String` (not `Value`) because `std::panic::panic_any<M>` requires
+    `M: Send`, and our `Rc`-based `Value` is not `Send`; the message is
+    rendered at raise time, matching Ruby's string `exception.message`.
+  - `raise(class, msg: Value) -> !` → `std::panic::panic_any(SirError{…})`;
+    `reraise() -> !` for a bare `raise`.
+  - `exc_from_payload(Box<dyn Any + Send>) -> SirError` — downcasts the
+    caught payload to a `SirError`, or **`resume_unwind`s** a non-`SirError`
+    payload (a genuine Rust panic is never swallowed as a rescuable
+    exception).
+  - `rescue_matches(&SirError, &[&str]) -> bool` over an **explicit**
+    built-in ancestry table (a verbatim parity port of the TS
+    `sir-runtime-exceptions` `ANCESTRY`) merged with user edges, with a
+    `seen`-set **cycle guard**. `exc_value(&SirError) -> Value` re-wraps the
+    message for a `rescue … => e` binding.
+  - `register_ancestry(&[(&str, &str)])` — the ONLY channel for user
+    ancestry edges (no reflection). `install_panic_hook()` quiets Rust's
+    default panic banner for `SirError` payloads; `report_uncaught` renders
+    an unrescued exception (`Class: message`) and exits non-zero.
+- **Emit (`emit.rs`).**
+  - `raise` arm: a `Const` class name (`raise Foo`/`raise Foo, "m"`) is
+    **lifted to a string literal** (never emitted as a runtime `Const`
+    read); a non-const first arg → `raise("RuntimeError", <arg>)`; bare
+    `raise` → `reraise()`.
+  - `Stmt::TryCatch` → a `std::panic::catch_unwind(AssertUnwindSafe(||
+    {…}))` region whose `match` dispatches rescue clauses in order via
+    `rescue_matches`, binds `=> e` with `exc_value`, and **runs `ensure` on
+    every path** (Ok, matched, and unmatched-before-`resume_unwind`).
+  - `main` wraps the user body in a top-level `catch_unwind` so an uncaught
+    SIR exception exits cleanly non-zero; the module's `ClassDef` ancestry
+    edges are registered once at init (`register_ancestry`), and the quiet
+    panic hook is installed.
+  - `Stmt::ClassDef` (empty-body exception subclass) emits no runtime code —
+    it is pure ancestry metadata.
+
+### Accepted features
+
+- `Feature::Exceptions`, plus `Feature::Classes` and `Feature::Constants`
+  **for the narrow exception use case only**:
+  - `Classes` — an empty-body exception-subclass declaration `class MyErr <
+    StandardError; end` (methods hoist to top-level `Function`s). A
+    **non-empty** class body is rejected cleanly by `reject_stateful_class`.
+  - `Constants` — a `raise MyErr` names its class via a `Scope::Const`
+    VarRef (lifted to a string). Any **other** `Const` reference is rejected
+    cleanly by `reject_const_ref`, keeping the acceptance sound (no
+    `emit_var_ref` `Const` panic on validated input).
+
+### Tests
+
+- Emitted-shape unit tests (`emit.rs`): `raise` variants, `TryCatch` →
+  `catch_unwind`/`match`, ensure-on-all-paths, empty ClassDef.
+- Capability-gate unit tests (`lib.rs`): accept exceptions/subclass, reject
+  stateful class, reject non-raise const ref, allow raise-class-name const.
+- Runtime-shape tests (`runtime.rs`): exception helpers present, explicit
+  table + cycle guard, non-`SirError` passthrough.
+- Execution-proof through `rustc` (`tests/compile_and_run_exceptions.rs`,
+  gated on `SIR_TEST_RUSTC_LINKER`): (a) typed rescue via built-in ancestry,
+  (b) bare rescue, (c) unmatched re-raise exits non-zero, (d) ensure runs on
+  caught + uncaught, (e) user ancestry `MyErr < StandardError` caught by
+  `rescue StandardError`.
+
+### Security
+
+- Rescue matching is an **explicit ancestry-table lookup** — never
+  reflection / type-name introspection. A `seen`-set cycle guard bounds the
+  ancestry walk. A non-`SirError` panic (a real Rust bug) is `resume_unwind`
+  ed, never mis-dispatched to a rescue. `AssertUnwindSafe` is used for
+  generated code only (documented rationale: the `Err` path re-derives what
+  it needs and never reads partially-mutated captured state). No new
+  `unsafe`.
+
 ## 0.7.0 — collection-method dispatch + runtime catalog (C6)
 
 Makes the Rust backend **execute** collection-method dispatch. A

--- a/code/packages/rust/semantic-ir-to-rust/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-rust"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 description = "Semantic IR → self-contained Rust source code (SIR13). Second backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-rust/README.md
+++ b/code/packages/rust/semantic-ir-to-rust/README.md
@@ -62,8 +62,10 @@ Accepts (SIR16 / v1 — **all six** features, full v1 parity): `Floats`,
 
 With all six SIR16 features accepted, every SIR16 IR node has a real emit
 arm — no reachable `panic!` remains for v1.  The remaining emit panics
-cover SIR17/18 nodes (classes, modules, try/catch, string interpolation,
-instance/class/const vars) whose features stay unaccepted.
+cover SIR17/18 nodes (modules, string interpolation, instance/class vars,
+non-exception constant refs) whose features stay unaccepted; `try/catch`
+and exception-subclass `class` declarations are now accepted (see
+**Exceptions (E4)** below).
 
 Accepts (P2e): `DefaultParams` — a `Param` may carry a `default`
 expression that runs when the caller omits that trailing argument.  Rust
@@ -153,8 +155,52 @@ rather than panicking:
   (`unknown_method`), never a reflective lookup on the raw name.  No new
   `unsafe`.
 
+Executes (E4): **exception handling**.  `Feature::Exceptions` (Ruby
+`begin/rescue/ensure`, `raise`) is accepted.  Rust has **no native
+exceptions**, so v0 maps the SIR exception model onto Rust's **unwinding
+panic** machinery — a *localized* transform touching only the
+`raise`/`TryCatch` arms:
+
+- **`raise`** → `__sir::raise("Class", <msg>)`, which
+  `std::panic::panic_any(SirError { class, msg })`.  A `Const` class name
+  (`raise Foo`/`raise Foo, "m"`) is **lifted to a string literal** (never a
+  runtime constant read); a non-const first arg → `raise("RuntimeError",
+  <arg>)`; bare `raise` → `__sir::reraise()`.
+- **`TryCatch`** → a `std::panic::catch_unwind(AssertUnwindSafe(|| { …
+  }))` region.  Its `match` runs `ensure` on the `Ok` (no-exception) arm;
+  on the `Err` arm it downcasts the payload with `exc_from_payload`
+  (**re-`resume_unwind`ing a non-`SirError` panic** — a real Rust bug is
+  never swallowed as a rescue), then dispatches the rescue clauses in
+  source order via `rescue_matches`, binding `=> e` with `exc_value`.  A
+  matched clause runs its body then `ensure`; an unmatched exception runs
+  `ensure` then `resume_unwind`s (re-raise).  **`ensure` runs on every
+  path.**  `main` wraps the user body in a top-level `catch_unwind` so an
+  uncaught exception exits cleanly non-zero (`Class: message`).
+- **Ancestry matching** — `rescue_matches(&SirError, &[&str])` walks an
+  **explicit** built-in ancestry table (a verbatim parity port of the TS
+  `sir-runtime-exceptions` `ANCESTRY`: `ArgumentError`/`TypeError`/… →
+  `StandardError` → `Exception`, etc.) merged with **user edges** collected
+  from the module's `ClassDef { name, superclass }` pairs and registered
+  once at init via `register_ancestry`.  So `class MyErr < StandardError`
+  makes a raised `MyErr` catchable by `rescue StandardError`.  A `seen`-set
+  **cycle guard** bounds the walk.
+- **Classes/Constants — narrow acceptance.**  `Feature::Classes` is
+  accepted only for an **empty-body** exception-subclass declaration
+  (`class MyErr < StandardError; end`; methods hoist to top-level
+  `Function`s); a non-empty body is rejected cleanly by
+  `reject_stateful_class`.  `Feature::Constants` is accepted only because
+  `raise MyErr` names its class via a `Const` VarRef (lifted to a string);
+  any other `Const` reference is rejected cleanly by `reject_const_ref`.
+- **Security** — rescue matching is the explicit table lookup only, never
+  reflection; the cycle guard is mandatory; a non-`SirError` panic passes
+  through untouched.  `AssertUnwindSafe` is used for generated code (the
+  `Err` path re-derives what it needs and never reads partially-mutated
+  captured state).  No new `unsafe`.
+
 Rejects: `TailCalls` (Rust does not guarantee TCO), `Intrinsics`
-(empty whitelist in v0), and the SIR17/18 features above.
+(empty whitelist in v0), and the remaining SIR17/18 features above
+(`Modules`, `InstanceVars`, `ClassVars`, `StringInterpolation`,
+non-exception `Constants`/stateful `Classes`).
 
 ## Value model
 
@@ -184,7 +230,10 @@ enum Value {
 SIR's synthesised `main` function is renamed to `__sir_user_main`
 in the generated Rust because `main` is Rust's process entry
 point.  The emitter generates its own `main()` that calls `_init()`
-(if present) then `__sir_user_main()`.
+(if present) then `__sir_user_main()`.  For an exception-using module,
+`main()` additionally installs the quiet panic hook, registers the
+module's user ancestry, and wraps the body in a top-level `catch_unwind`
+so an uncaught SIR exception exits cleanly non-zero.
 
 ## Tests
 
@@ -193,6 +242,14 @@ point.  The emitter generates its own `main()` that calls `_init()`
 Covers per-node lowering, identifier sanitisation (including
 raw-identifier syntax for Rust keywords), deterministic output,
 and end-to-end pipelines from Twig source.
+
+Exception execution-proof (`tests/compile_and_run_exceptions.rs`) compiles
+emitted Rust with `rustc` and runs it, checking five cases against the
+Python/TS reference behaviour: typed rescue via built-in ancestry, bare
+rescue, unmatched re-raise (non-zero exit), `ensure` on caught + uncaught
+paths, and user ancestry (`MyErr < StandardError`).  It skips (never fails)
+when no linker is available; point it at one via `SIR_TEST_RUSTC_LINKER`
+(e.g. the toolchain's bundled `rust-lld`).
 
 ## Related crates
 

--- a/code/packages/rust/semantic-ir-to-rust/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/emit.rs
@@ -109,16 +109,124 @@ fn emit_globals(out: &mut String, globals: &[Global]) {
 fn emit_main(out: &mut String, m: &Module) {
     out.push('\n');
     out.push_str("fn main() {\n");
-    if m.functions.iter().any(|f| f.name == "_init") {
-        out.push_str("    let _ = _init();\n");
+
+    // ── exception runtime init (Feature::Exceptions) ────────────────
+    //
+    // When the module uses exceptions we (1) install a quiet panic hook so
+    // a SIR `raise` doesn't print Rust's default panic banner, and (2)
+    // register the module's user-defined exception ancestry so
+    // `rescue StandardError` catches a raised `class MyErr < StandardError`.
+    // Both are pure init side-effects, emitted only when needed so
+    // exception-free modules are byte-for-byte unchanged.
+    let uses_exceptions = m.manifest.contains(semantic_ir::Feature::Exceptions);
+    if uses_exceptions {
+        out.push_str("    __sir::install_panic_hook();\n");
+        emit_ancestry_registration(out, m);
     }
-    if m.functions.iter().any(|f| f.name == "main") {
-        // SIR's `main` was renamed to `__sir_user_main` during
-        // function emission (Rust's `main` is reserved for the
-        // process entry point).  Call it here.
-        out.push_str("    let _ = __sir_user_main();\n");
+
+    // The user body runs under a top-level `catch_unwind` so an *uncaught*
+    // SIR exception (one that unwound past every `TryCatch`) is rendered
+    // cleanly (`Class: message`) and exits non-zero, exactly as Ruby prints
+    // an unrescued exception at top level — rather than as a raw Rust panic.
+    // A *non-`SirError`* panic (a genuine Rust bug) is re-raised via
+    // `exc_from_payload`'s `resume_unwind`, so real crashes keep their Rust
+    // semantics.  Exception-free modules skip the wrapper entirely.
+    let run_body = |out: &mut String, indent: &str| {
+        if m.functions.iter().any(|f| f.name == "_init") {
+            let _ = writeln!(out, "{}let _ = _init();", indent);
+        }
+        if m.functions.iter().any(|f| f.name == "main") {
+            // SIR's `main` was renamed to `__sir_user_main` during
+            // function emission (Rust's `main` is reserved for the
+            // process entry point).  Call it here.
+            let _ = writeln!(out, "{}let _ = __sir_user_main();", indent);
+        }
+    };
+
+    if uses_exceptions {
+        out.push_str(
+            "    let __r = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {\n",
+        );
+        run_body(out, "        ");
+        out.push_str("    }));\n");
+        out.push_str("    if let Err(__payload) = __r {\n");
+        out.push_str("        let __exc = __sir::exc_from_payload(__payload);\n");
+        out.push_str("        __sir::report_uncaught(&__exc);\n");
+        out.push_str("    }\n");
+    } else {
+        run_body(out, "    ");
     }
     out.push_str("}\n");
+}
+
+/// Emit the one-shot `__sir::register_ancestry(&[…])` call that threads the
+/// module's user-defined exception ancestry into the rescue matcher.
+///
+/// We collect every `Stmt::ClassDef { name, superclass: Some(sup) }` reachable
+/// in the module (top-level and nested), producing `(sub, sup)` edges.  A class
+/// with no superclass contributes no edge (its ancestry is either a built-in or
+/// unknown, matched by exact name — the honest v0 contract).  When the module
+/// declares no such edges we emit nothing, keeping the output minimal.
+fn emit_ancestry_registration(out: &mut String, m: &Module) {
+    let mut edges: Vec<(String, String)> = Vec::new();
+    for f in &m.functions {
+        collect_ancestry_block(&f.body, &mut edges);
+    }
+    if edges.is_empty() {
+        return;
+    }
+    out.push_str("    __sir::register_ancestry(&[");
+    for (i, (sub, sup)) in edges.iter().enumerate() {
+        if i > 0 {
+            out.push_str(", ");
+        }
+        let _ = write!(out, "({}, {})", quote_rs_string(sub), quote_rs_string(sup));
+    }
+    out.push_str("]);\n");
+}
+
+/// Walk a block's statements collecting `ClassDef` ancestry edges.
+fn collect_ancestry_block(b: &Block, edges: &mut Vec<(String, String)>) {
+    for s in &b.stmts {
+        collect_ancestry_stmt(s, edges);
+    }
+}
+
+/// Collect `(subclass, superclass)` edges from a statement, recursing into
+/// nested class/try bodies so a `class MyErr < StandardError` inside a
+/// `begin`/`class` still registers.
+fn collect_ancestry_stmt(s: &Stmt, edges: &mut Vec<(String, String)>) {
+    match s {
+        Stmt::ClassDef { name, superclass: Some(sup), body, .. } => {
+            edges.push((name.clone(), sup.clone()));
+            for st in body {
+                collect_ancestry_stmt(st, edges);
+            }
+        }
+        Stmt::ClassDef { body, .. }
+        | Stmt::ModuleDef { body, .. }
+        | Stmt::SingletonClassDef { body, .. } => {
+            for st in body {
+                collect_ancestry_stmt(st, edges);
+            }
+        }
+        Stmt::TryCatch { body, rescues, ensure_body, .. } => {
+            for st in body {
+                collect_ancestry_stmt(st, edges);
+            }
+            for r in rescues {
+                for st in &r.body {
+                    collect_ancestry_stmt(st, edges);
+                }
+            }
+            if let Some(ens) = ensure_body {
+                for st in ens {
+                    collect_ancestry_stmt(st, edges);
+                }
+            }
+        }
+        _ => {}
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -450,11 +558,31 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
         Stmt::Assign { span, .. } => {
             panic!("rust backend reached an Assign to an unsupported scope at {} — capability check should have rejected it", span);
         }
-        // SIR17 (classes) — `Feature::Classes` is not accepted by
-        // this backend, so a class-using module is rejected by the
-        // capability check before emit.  Reaching this arm is a bug.
-        Stmt::ClassDef { span, .. } => {
-            panic!("rust backend reached SIR17 class-def statement at {} — capability check should have rejected it", span);
+        // SIR17 (classes) — `Feature::Classes` is accepted ONLY for the
+        // narrow exception-subclass use case: `class MyErr < StandardError;
+        // end`.  The Ruby frontend hoists method `def`s to top-level
+        // `Function`s, so an accepted class body is empty (the structural
+        // capability check `reject_stateful_class` rejects any non-empty
+        // body before emit).  The class name → superclass edge is threaded
+        // into the exception matcher at program init (see
+        // `emit_ancestry_registration`); the declaration itself emits no
+        // runtime code here — it exists purely as ancestry metadata.  We
+        // emit a comment marker so the output is self-documenting.
+        Stmt::ClassDef { name, superclass, body, .. } => {
+            match superclass {
+                Some(sup) => {
+                    let _ = writeln!(out, "{}// class {} < {} (exception ancestry registered at init)", pad, sanitize_comment(name), sanitize_comment(sup));
+                }
+                None => {
+                    let _ = writeln!(out, "{}// class {} (no ancestry edge)", pad, sanitize_comment(name));
+                }
+            }
+            // Body is empty for accepted (exception-subclass) classes, but
+            // emit any statements defensively in case a future frontend
+            // populates it with backend-supported statements.
+            for st in body {
+                emit_stmt(out, st, indent);
+            }
         }
         Stmt::ModuleDef { span, .. } => {
             panic!("rust backend reached SIR17 module-def statement at {} — capability check should have rejected it", span);
@@ -462,9 +590,165 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
         Stmt::SingletonClassDef { span, .. } => {
             panic!("rust backend reached SIR17 singleton-class-def statement at {} — capability check should have rejected it", span);
         }
-        Stmt::TryCatch { span, .. } => {
-            panic!("rust backend reached SIR17 try-catch statement at {} — capability check should have rejected it", span);
+        // `begin … rescue … ensure … end` → a `catch_unwind` region.  See
+        // `emit_try_catch` for the full mapping and its ensure-ordering
+        // guarantees.
+        Stmt::TryCatch { body, rescues, ensure_body, .. } => {
+            emit_try_catch(out, body, rescues, ensure_body, indent);
         }
+    }
+}
+
+/// Emit a `Stmt::TryCatch` as a `std::panic::catch_unwind` region.
+///
+/// ## Mapping (Ruby `begin/rescue/ensure` → Rust unwinding)
+///
+/// ```text
+/// {
+///     let __r = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+///         <try body>              // may panic_any(SirError) via raise
+///     }));
+///     match __r {
+///         Ok(_) => { <ensure> }                       // no exception
+///         Err(__payload) => {
+///             let __exc = __sir::exc_from_payload(__payload); // downcast or re-panic
+///             if __sir::rescue_matches(&__exc, &["Foo","Bar"]) {
+///                 let e = __sir::exc_value(&__exc);    // `rescue … => e`
+///                 <rescue body>; <ensure>
+///             } else if … { … }
+///             else { <ensure>; std::panic::resume_unwind(Box::new(__exc)); } // re-raise
+///         }
+///     }
+/// }
+/// ```
+///
+/// ## Why `AssertUnwindSafe`
+///
+/// `catch_unwind` requires its closure to be `UnwindSafe`, a marker that a
+/// panic mid-closure can't leave a shared value in a torn state observable
+/// afterwards.  Our value model is `Rc<RefCell<…>>` (`Seq`/`Map`), which is
+/// *not* `UnwindSafe`.  In generated code this is sound to assert: on the
+/// `Err` path we do not read any partially-mutated captured binding — the
+/// rescue/ensure bodies re-derive what they need — and Ruby semantics
+/// deliberately expose "state as of the raise" to a rescue anyway.  So we
+/// wrap the closure in `AssertUnwindSafe`, exactly as the reference
+/// backends rely on their host's `try`/`catch` seeing post-throw state.
+///
+/// ## Ensure runs on ALL paths
+///
+/// The `ensure` body is emitted into **every** arm: the `Ok` (no-exception)
+/// arm, each matched-rescue arm, and the unmatched `else` arm (immediately
+/// before `resume_unwind`).  This guarantees `ensure` runs whether the body
+/// completed normally, an exception was caught, or an exception is being
+/// re-raised — matching Ruby's `ensure`.  We inline it per-arm (rather than
+/// a single post-match block) because the re-raise arm must run `ensure`
+/// *before* it diverges via `resume_unwind`.
+///
+/// ## Non-`SirError` panics pass through
+///
+/// `exc_from_payload` downcasts the caught payload; a payload that is NOT a
+/// `SirError` (a genuine Rust panic — index OOB, `unwrap` on `None`) is
+/// `resume_unwind`-ed there, so it is never mis-dispatched to a rescue
+/// clause.  A `rescue` can only ever catch a value a SIR `raise` produced.
+fn emit_try_catch(
+    out: &mut String,
+    body: &[Stmt],
+    rescues: &[semantic_ir::RescueClause],
+    ensure_body: &Option<Vec<Stmt>>,
+    indent: usize,
+) {
+    let pad = indent_str(indent);
+    let inner = indent + 1;
+    let ipad = indent_str(inner);
+    let arm = indent + 2;
+    let arm_pad = indent_str(arm);
+
+    // Helper: emit the ensure body (if any) at a given indent.
+    let emit_ensure = |out: &mut String, at: usize| {
+        if let Some(ens) = ensure_body {
+            emit_bare_stmts(out, ens, at);
+        }
+    };
+
+    let _ = writeln!(out, "{}{{", pad);
+    let _ = writeln!(
+        out,
+        "{}let __r = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {{",
+        ipad
+    );
+    emit_bare_stmts(out, body, arm);
+    // The closure yields `()` — the try body is a statement list with no
+    // value slot (like a `ClassDef` body), so nothing is returned.
+    let _ = writeln!(out, "{}}}));", ipad);
+
+    let _ = writeln!(out, "{}match __r {{", ipad);
+    // ── Ok: no exception ─────────────────────────────────────────────
+    let _ = writeln!(out, "{}Ok(_) => {{", arm_pad);
+    emit_ensure(out, arm + 1);
+    let _ = writeln!(out, "{}}}", arm_pad);
+    // ── Err: an unwind occurred ──────────────────────────────────────
+    let _ = writeln!(out, "{}Err(__payload) => {{", arm_pad);
+    let dpad = indent_str(arm + 1);
+    let _ = writeln!(out, "{}let __exc = __sir::exc_from_payload(__payload);", dpad);
+    if rescues.is_empty() {
+        // No rescue clauses: run ensure, then re-raise the exception.
+        emit_ensure(out, arm + 1);
+        let _ = writeln!(
+            out,
+            "{}std::panic::resume_unwind(Box::new(__exc));",
+            dpad
+        );
+    } else {
+        for (i, r) in rescues.iter().enumerate() {
+            let kw = if i == 0 { "if" } else { "}} else if" };
+            let mut types = String::from("&[");
+            for (j, t) in r.exception_types.iter().enumerate() {
+                if j > 0 {
+                    types.push_str(", ");
+                }
+                types.push_str(&quote_rs_string(t));
+            }
+            types.push(']');
+            let _ = writeln!(
+                out,
+                "{}{} __sir::rescue_matches(&__exc, {}) {{",
+                dpad, kw, types
+            );
+            let bpad = indent_str(arm + 2);
+            // `rescue Foo => e` binds the caught exception's message value.
+            if let Some(bind) = &r.binding {
+                let _ = writeln!(
+                    out,
+                    "{}let {}: __sir::Value = __sir::exc_value(&__exc);",
+                    bpad,
+                    sanitize_ident(bind)
+                );
+            }
+            emit_bare_stmts(out, &r.body, arm + 2);
+            emit_ensure(out, arm + 2);
+        }
+        // No clause matched → run ensure, then re-raise (propagate).
+        let _ = writeln!(out, "{}}} else {{", dpad);
+        emit_ensure(out, arm + 2);
+        let _ = writeln!(
+            out,
+            "{}std::panic::resume_unwind(Box::new(__exc));",
+            indent_str(arm + 2)
+        );
+        let _ = writeln!(out, "{}}}", dpad);
+    }
+    let _ = writeln!(out, "{}}}", arm_pad);
+    let _ = writeln!(out, "{}}}", ipad);
+    let _ = writeln!(out, "{}}}", pad);
+}
+
+/// Emit a bare statement list (a `Vec<Stmt>`, as carried by `TryCatch`,
+/// `ClassDef`, and `RescueClause` bodies — no trailing value slot) at the
+/// given indent.  Each statement is emitted via the ordinary `emit_stmt`
+/// path.
+fn emit_bare_stmts(out: &mut String, stmts: &[Stmt], indent: usize) {
+    for s in stmts {
+        emit_stmt(out, s, indent);
     }
 }
 
@@ -837,6 +1121,51 @@ fn emit_direct_call(out: &mut String, fn_name: &str, args: &[Expr], indent: usiz
 }
 
 fn emit_builtin_call(out: &mut String, name: &str, args: &[Expr], indent: usize) {
+    // `raise` → panic with a class-tagged `SirError` payload (SIR17
+    // Exceptions).  The first argument decides the shape, mirroring the
+    // TS backend's `raiseError` emission:
+    //   • a `Const` class name (`raise Foo` / `raise Foo, "msg"`) → the
+    //     class name is LIFTED to a Rust string literal (never emitted as
+    //     a `Const` VarRef, which this backend cannot read), with the
+    //     optional message second — or the class name itself as the
+    //     default message when none is given;
+    //   • any other first arg (`raise "msg"`) → an implicit `RuntimeError`
+    //     carrying that value as the message (matching Ruby);
+    //   • no args (bare `raise`) → a generic re-raise (`RuntimeError`).
+    //
+    // Lifting the `Const` name here is what makes accepting
+    // `Feature::Constants` sound: the ONLY `Const` reference this backend
+    // lowers is a raise class name, and it becomes a `&str` — never a
+    // runtime constant read (which stays rejected by `reject_const_ref`).
+    if name == "raise" {
+        match args.first() {
+            None => {
+                out.push_str("__sir::reraise()");
+            }
+            Some(Expr::VarRef { name: cn, scope: Scope::Const, .. }) => {
+                let _ = write!(out, "__sir::raise({}, ", quote_rs_string(cn));
+                match args.get(1) {
+                    Some(msg) => emit_expr(out, msg, indent),
+                    None => {
+                        // Ruby's default message is the class name itself.
+                        let _ = write!(
+                            out,
+                            "__sir::Value::Str(::std::rc::Rc::from({}))",
+                            quote_rs_string(cn)
+                        );
+                    }
+                }
+                out.push(')');
+            }
+            Some(other) => {
+                out.push_str("__sir::raise(\"RuntimeError\", ");
+                emit_expr(out, other, indent);
+                out.push(')');
+            }
+        }
+        return;
+    }
+
     // Variadic helpers take a Vec<Value>; fixed-arity helpers take
     // positional Value arguments.  This matches the inlined runtime
     // signatures.
@@ -1375,11 +1704,23 @@ fn emit_stmt_inline(out: &mut String, s: &Stmt, indent: usize) {
         Stmt::Assign { span, .. } => {
             panic!("rust backend (inline) reached an Assign to an unsupported scope at {} — capability check should have rejected it", span);
         }
-        // SIR17 (classes) — unreachable: rejected by the capability
-        // check, and a class declaration has no inline-expression
-        // form regardless.
-        Stmt::ClassDef { span, .. } => {
-            panic!("rust backend (inline) reached SIR17 class-def statement at {} — capability check should have rejected it", span);
+        // SIR17 (classes) — an accepted (exception-subclass) class
+        // declaration emits no runtime code; its ancestry edge is
+        // registered at init.  In a block-as-expression context we emit
+        // just the self-documenting comment (multi-line is faithful in a
+        // Rust `{ … }`), reusing the same helpers as the loop arms.
+        Stmt::ClassDef { name, superclass, body, .. } => {
+            match superclass {
+                Some(sup) => {
+                    let _ = write!(out, "/* class {} < {} */ ", sanitize_comment(name), sanitize_comment(sup));
+                }
+                None => {
+                    let _ = write!(out, "/* class {} */ ", sanitize_comment(name));
+                }
+            }
+            for st in body {
+                emit_stmt_inline(out, st, indent);
+            }
         }
         Stmt::ModuleDef { span, .. } => {
             panic!("rust backend (inline) reached SIR17 module-def statement at {} — capability check should have rejected it", span);
@@ -1387,8 +1728,13 @@ fn emit_stmt_inline(out: &mut String, s: &Stmt, indent: usize) {
         Stmt::SingletonClassDef { span, .. } => {
             panic!("rust backend (inline) reached SIR17 singleton-class-def statement at {} — capability check should have rejected it", span);
         }
-        Stmt::TryCatch { span, .. } => {
-            panic!("rust backend (inline) reached SIR17 try-catch statement at {} — capability check should have rejected it", span);
+        // `begin … rescue … ensure … end` in a block-as-expression
+        // context.  The multi-line `catch_unwind` region the shared
+        // `emit_try_catch` helper renders is faithful inside a Rust
+        // `{ … }`, so the inline path reuses it rather than maintaining a
+        // second shape (same strategy as the loop arms above).
+        Stmt::TryCatch { body, rescues, ensure_body, .. } => {
+            emit_try_catch(out, body, rescues, ensure_body, indent);
         }
     }
 }
@@ -2814,5 +3160,160 @@ mod tests {
         let mut out = String::new();
         emit_function(&mut out, &f);
         assert!(out.contains("let mut acc: __sir::Value = __sir::Value::Int(0i64);"), "got: {out}");
+    }
+
+    // ── E4: exception emission shape ───────────────────────────────
+
+    fn constref(name: &str) -> Expr {
+        Expr::VarRef { name: name.into(), scope: Scope::Const, span: s() }
+    }
+
+    fn builtin(name: &str, args: Vec<Expr>) -> Expr {
+        Expr::BuiltinCall { name: name.into(), args, effects: EffectSet::PURE, span: s() }
+    }
+
+    fn strlit(v: &str) -> Expr {
+        Expr::StrLit { value: v.into(), span: s() }
+    }
+
+    #[test]
+    fn emit_raise_const_class_with_message() {
+        // `raise ArgumentError, "bad"` → __sir::raise("ArgumentError", <msg>)
+        let mut out = String::new();
+        emit_expr(
+            &mut out,
+            &builtin("raise", vec![constref("ArgumentError"), strlit("bad")]),
+            0,
+        );
+        assert!(
+            out.starts_with(r#"__sir::raise("ArgumentError", "#),
+            "got: {out}"
+        );
+        assert!(out.contains(r#""bad""#), "got: {out}");
+    }
+
+    #[test]
+    fn emit_raise_const_class_defaults_message_to_class_name() {
+        // `raise RuntimeError` → __sir::raise("RuntimeError", Str("RuntimeError"))
+        let mut out = String::new();
+        emit_expr(&mut out, &builtin("raise", vec![constref("RuntimeError")]), 0);
+        assert!(out.contains(r#"__sir::raise("RuntimeError""#), "got: {out}");
+        assert!(out.contains(r#"Rc::from("RuntimeError")"#), "got: {out}");
+    }
+
+    #[test]
+    fn emit_raise_nonconst_first_arg_is_runtime_error() {
+        // `raise "boom"` → __sir::raise("RuntimeError", <arg>)
+        let mut out = String::new();
+        emit_expr(&mut out, &builtin("raise", vec![strlit("boom")]), 0);
+        assert!(out.contains(r#"__sir::raise("RuntimeError", "#), "got: {out}");
+        assert!(out.contains(r#""boom""#), "got: {out}");
+    }
+
+    #[test]
+    fn emit_bare_raise_is_reraise() {
+        // bare `raise` → __sir::reraise()
+        let mut out = String::new();
+        emit_expr(&mut out, &builtin("raise", vec![]), 0);
+        assert_eq!(out, "__sir::reraise()");
+    }
+
+    #[test]
+    fn emit_try_catch_uses_catch_unwind_and_match() {
+        // begin; raise ArgumentError,"x"; rescue StandardError=>e; <e>; end
+        let tc = Stmt::TryCatch {
+            body: vec![Stmt::ExprStmt {
+                expr: builtin("raise", vec![constref("ArgumentError"), strlit("x")]),
+                span: s(),
+            }],
+            rescues: vec![semantic_ir::RescueClause {
+                exception_types: vec!["StandardError".into()],
+                binding: Some("e".into()),
+                body: vec![Stmt::ExprStmt { expr: local("e"), span: s() }],
+                span: s(),
+            }],
+            ensure_body: None,
+            span: s(),
+        };
+        let mut out = String::new();
+        emit_stmt(&mut out, &tc, 1);
+        assert!(out.contains("std::panic::catch_unwind"), "got: {out}");
+        assert!(out.contains("std::panic::AssertUnwindSafe"), "got: {out}");
+        assert!(out.contains("match __r {"), "got: {out}");
+        assert!(out.contains("let __exc = __sir::exc_from_payload(__payload);"), "got: {out}");
+        assert!(
+            out.contains(r#"if __sir::rescue_matches(&__exc, &["StandardError"])"#),
+            "got: {out}"
+        );
+        // `=> e` binds the exception value.
+        assert!(out.contains("let e: __sir::Value = __sir::exc_value(&__exc);"), "got: {out}");
+        // No rescue matched → re-raise.
+        assert!(out.contains("std::panic::resume_unwind(Box::new(__exc));"), "got: {out}");
+    }
+
+    #[test]
+    fn emit_try_catch_ensure_runs_on_all_paths() {
+        // ensure body must appear in the Ok arm, the matched arm, AND the
+        // unmatched-else arm (before resume_unwind).
+        let tc = Stmt::TryCatch {
+            body: vec![Stmt::ExprStmt {
+                expr: builtin("raise", vec![constref("ArgumentError"), strlit("x")]),
+                span: s(),
+            }],
+            rescues: vec![semantic_ir::RescueClause {
+                exception_types: vec!["TypeError".into()],
+                binding: None,
+                body: vec![Stmt::ExprStmt { expr: int(1), span: s() }],
+                span: s(),
+            }],
+            ensure_body: Some(vec![Stmt::ExprStmt {
+                expr: builtin("print", vec![int(9)]),
+                span: s(),
+            }]),
+            span: s(),
+        };
+        let mut out = String::new();
+        emit_stmt(&mut out, &tc, 1);
+        // The ensure body (`print(9)`) must appear three times: Ok arm,
+        // matched arm, unmatched-else arm.
+        let count = out.matches("__sir::print(__sir::Value::Int(9i64))").count();
+        assert_eq!(count, 3, "ensure should run on all 3 paths; got {count}:\n{out}");
+    }
+
+    #[test]
+    fn emit_try_catch_no_rescue_runs_ensure_then_reraises() {
+        // begin; …; ensure …; end  (no rescue) → ensure then resume_unwind.
+        let tc = Stmt::TryCatch {
+            body: vec![Stmt::ExprStmt { expr: int(1), span: s() }],
+            rescues: vec![],
+            ensure_body: Some(vec![Stmt::ExprStmt {
+                expr: builtin("print", vec![int(9)]),
+                span: s(),
+            }]),
+            span: s(),
+        };
+        let mut out = String::new();
+        emit_stmt(&mut out, &tc, 1);
+        assert!(out.contains("Err(__payload) => {"), "got: {out}");
+        // ensure appears in both Ok and Err arms.
+        let count = out.matches("__sir::print(__sir::Value::Int(9i64))").count();
+        assert_eq!(count, 2, "got {count}:\n{out}");
+        assert!(out.contains("std::panic::resume_unwind(Box::new(__exc));"), "got: {out}");
+    }
+
+    #[test]
+    fn emit_classdef_registers_ancestry_comment_no_runtime_code() {
+        // `class MyErr < StandardError; end` emits only a marker comment.
+        let cd = Stmt::ClassDef {
+            name: "MyErr".into(),
+            superclass: Some("StandardError".into()),
+            body: vec![],
+            span: s(),
+        };
+        let mut out = String::new();
+        emit_stmt(&mut out, &cd, 1);
+        assert!(out.contains("class MyErr < StandardError"), "got: {out}");
+        // No runtime statement is emitted for the class body.
+        assert!(!out.contains("__sir::"), "class def should emit no runtime code; got: {out}");
     }
 }

--- a/code/packages/rust/semantic-ir-to-rust/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/lib.rs
@@ -546,6 +546,18 @@ fn const_ref_in_expr(e: &Expr) -> Option<BackendError> {
         Expr::MapGet { map, key, .. } => {
             const_ref_in_expr(map).or_else(|| const_ref_in_expr(key))
         }
+        // A closure's captured values are ordinary expressions emitted at the
+        // capture site — a `Const` VarRef hiding in a capture would otherwise
+        // slip past this gate and reach the `Scope::Const` emit panic (a
+        // reachable backend DoS on a validated module).  Walk each capture.
+        Expr::MakeClosure { captures, .. } => {
+            for c in captures {
+                if let Some(err) = const_ref_in_expr(&c.value) {
+                    return Some(err);
+                }
+            }
+            None
+        }
         // Leaf / already-supported expressions carry no nested Const.
         _ => None,
     }
@@ -999,6 +1011,44 @@ mod tests {
         };
         let err = compile(&exc_module(vec![stmt], &[Feature::Constants]))
             .expect_err("bare const ref rejected");
+        assert_eq!(err.kind, BackendErrorKind::UnsupportedFeature);
+        assert!(err.message.contains("constant reference"), "got: {}", err.message);
+    }
+
+    #[test]
+    fn rejects_const_reference_hidden_in_closure_capture() {
+        // Regression: a `Const` VarRef buried in a `MakeClosure` capture must be
+        // rejected by the capability gate, NOT reach the `Scope::Const` emit
+        // panic (a reachable backend DoS on a validated, feature-consistent
+        // module — `Closures` + `Constants` are both accepted).
+        let stmt = Stmt::LetBinding {
+            name: "f".into(),
+            sir_type: None,
+            value: Expr::MakeClosure {
+                fn_name: "lam".into(),
+                captures: vec![semantic_ir::CaptureValue {
+                    name: "c".into(),
+                    value: Expr::VarRef { name: "PI".into(), scope: Scope::Const, span: s() },
+                }],
+                span: s(),
+            },
+            span: s(),
+        };
+        // A real `lam` target so the module VALIDATES (else it fails earlier as
+        // InvalidModule and never reaches the backend const-ref gate).
+        let mut m = exc_module(vec![stmt], &[Feature::Constants, Feature::Closures]);
+        m.functions.push(Function {
+            name: "lam".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![semantic_ir::Capture { name: "c".into(), sir_type: None }],
+            body: Block { stmts: vec![], value: Expr::NilLit { span: s() }, span: s() },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        });
+        let err = compile(&m)
+            .expect_err("const ref in closure capture must be rejected, not panic");
         assert_eq!(err.kind, BackendErrorKind::UnsupportedFeature);
         assert!(err.message.contains("constant reference"), "got: {}", err.message);
     }

--- a/code/packages/rust/semantic-ir-to-rust/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/lib.rs
@@ -28,8 +28,8 @@ mod emit;
 mod runtime;
 
 use semantic_ir::{
-    Artifact, ArtifactMetadata, Backend, BackendError, BackendErrorKind, Feature, Module,
-    ParamKind,
+    Artifact, ArtifactMetadata, Backend, BackendError, BackendErrorKind, Expr, Feature, Module,
+    ParamKind, Scope, Stmt,
 };
 
 pub use emit::sanitize_ident;
@@ -149,6 +149,31 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     // reorder — so accepting the feature keeps the capability check and
     // emit coverage consistent.
     Feature::KeywordParams,
+    // ── SIR17 (E4) — exceptions ────────────────────────────────────
+    // `Exceptions` lowers `Stmt::TryCatch` to a `std::panic::catch_unwind`
+    // region and `raise` to a `panic_any(SirError{…})`, with a runtime
+    // `rescue_matches` over a built-in + user ancestry table (see
+    // `runtime.rs`).  All emit is localized to the `raise`/`TryCatch`
+    // arms; every other node is unchanged.
+    Feature::Exceptions,
+    // `Classes` is accepted ONLY to permit the narrow exception-subclass
+    // declaration `class MyErr < StandardError; end`, whose sole purpose
+    // is to contribute an ancestry edge to the exception matcher (threaded
+    // at init by `emit_ancestry_registration`).  The Ruby frontend hoists
+    // method `def`s to top-level `Function`s, so an accepted class body is
+    // EMPTY; a class carrying executable state (instance/class vars,
+    // constants, or any other statement in its body) is rejected cleanly
+    // by `reject_stateful_class` below — NEVER mis-emitted.  This mirrors
+    // the E1 JS-review soundness argument: the ClassDef is pure metadata.
+    Feature::Classes,
+    // `Constants` is accepted ONLY because a `raise MyErr` names its class
+    // via a `Scope::Const` VarRef (the Ruby frontend's lowering), which
+    // sets `Feature::Constants` in the manifest.  The emitter LIFTS that
+    // Const class name to a string literal in the `raise` arm — it never
+    // reads a runtime constant.  Any OTHER `Const` reference (a genuine
+    // constant read/assign this backend cannot lower) is rejected cleanly
+    // by `reject_const_ref` below, keeping this acceptance sound.
+    Feature::Constants,
 ];
 
 impl Backend for RustBackend {
@@ -191,6 +216,19 @@ impl Backend for RustBackend {
         //     resolution (this backend's whole keyword strategy) requires
         //     FIXED arity — see `reject_keyword_with_variadic`.
         if let Some(e) = reject_keyword_with_variadic(module) {
+            return Err(e);
+        }
+
+        // 2c. Exception-feature soundness gates (E4).  `Feature::Classes`
+        //     and `Feature::Constants` are accepted ONLY for the narrow
+        //     exception use case (an exception-subclass declaration and a
+        //     `raise MyErr` class name), so reject anything broader that
+        //     the emitter genuinely cannot lower — BEFORE emit, so those
+        //     emit paths are true internal-bug guards, not DoS surfaces.
+        if let Some(e) = reject_stateful_class(module) {
+            return Err(e);
+        }
+        if let Some(e) = reject_const_ref(module) {
             return Err(e);
         }
 
@@ -275,11 +313,261 @@ fn reject_keyword_with_variadic(module: &Module) -> Option<BackendError> {
     None
 }
 
+/// Reject a `Stmt::ClassDef` whose body is **non-empty** (E4 soundness).
+///
+/// `Feature::Classes` is accepted only for the exception-subclass idiom
+/// `class MyErr < StandardError; end`, whose body is empty because the Ruby
+/// frontend hoists method `def`s to top-level `Function`s.  A NON-empty body
+/// carries executable class state (constant / class-variable assigns, or any
+/// other statement) that this backend has no object model to emit — so we
+/// reject it cleanly HERE rather than letting emit produce nonsense (or reach
+/// a panic for a nested unsupported node).  This keeps the ClassDef emit arm a
+/// pure ancestry-metadata path.
+///
+/// Returns `Some(err)` for the FIRST offending class (fail-fast), else `None`.
+fn reject_stateful_class(module: &Module) -> Option<BackendError> {
+    for func in &module.functions {
+        if let Some(e) = stateful_class_in_stmts(&func.body.stmts) {
+            return Some(e);
+        }
+    }
+    None
+}
+
+fn stateful_class_in_stmts(stmts: &[Stmt]) -> Option<BackendError> {
+    for s in stmts {
+        match s {
+            Stmt::ClassDef { name, body, span, .. } => {
+                if !body.is_empty() {
+                    return Some(BackendError {
+                        kind: BackendErrorKind::UnsupportedFeature,
+                        message: format!(
+                            "rust backend accepts only empty-body (exception-subclass) \
+                             class declarations; class `{name}` has a non-empty body \
+                             (class state / methods are out of scope for this backend)"
+                        ),
+                        span: span.clone(),
+                    });
+                }
+            }
+            // Recurse into nested statement lists so a stateful class nested
+            // in a try/rescue/ensure or module body is still caught.
+            Stmt::ModuleDef { body, .. } | Stmt::SingletonClassDef { body, .. } => {
+                if let Some(e) = stateful_class_in_stmts(body) {
+                    return Some(e);
+                }
+            }
+            Stmt::TryCatch { body, rescues, ensure_body, .. } => {
+                if let Some(e) = stateful_class_in_stmts(body) {
+                    return Some(e);
+                }
+                for r in rescues {
+                    if let Some(e) = stateful_class_in_stmts(&r.body) {
+                        return Some(e);
+                    }
+                }
+                if let Some(ens) = ensure_body {
+                    if let Some(e) = stateful_class_in_stmts(ens) {
+                        return Some(e);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Reject any `Scope::Const` reference the backend cannot lower (E4
+/// soundness).
+///
+/// `Feature::Constants` is accepted only because `raise MyErr` names its
+/// exception class through a `Scope::Const` VarRef, which the `raise` emit
+/// arm LIFTS to a string literal (never a runtime constant read).  Every
+/// OTHER `Const` reference — a `Const` VarRef that is not a raise class name,
+/// or an `Assign`/`ExprStmt` to a `Const` — has no backend lowering and would
+/// otherwise reach the `emit_var_ref` `Scope::Const` panic on validated input
+/// (a DoS).  We reject such modules cleanly here.
+///
+/// The ALLOWED shape is exactly `BuiltinCall("raise", [VarRef{Const}, …])`
+/// with the Const as the first argument; we walk every expression and flag a
+/// `Const` VarRef found in any other position.
+///
+/// Returns `Some(err)` for the FIRST offending reference, else `None`.
+fn reject_const_ref(module: &Module) -> Option<BackendError> {
+    for func in &module.functions {
+        if let Some(e) = const_ref_in_stmts(&func.body.stmts) {
+            return Some(e);
+        }
+        if let Some(e) = const_ref_in_expr(&func.body.value) {
+            return Some(e);
+        }
+    }
+    None
+}
+
+fn const_ref_in_stmts(stmts: &[Stmt]) -> Option<BackendError> {
+    for s in stmts {
+        if let Some(e) = const_ref_in_stmt(s) {
+            return Some(e);
+        }
+    }
+    None
+}
+
+fn const_ref_in_stmt(s: &Stmt) -> Option<BackendError> {
+    match s {
+        Stmt::LetBinding { value, .. }
+        | Stmt::LetStarBinding { value, .. }
+        | Stmt::ExprStmt { expr: value, .. } => const_ref_in_expr(value),
+        Stmt::Assign { scope: Scope::Const, span, .. } => Some(unsupported_const(span.clone())),
+        Stmt::Assign { value, .. } => const_ref_in_expr(value),
+        Stmt::While { cond, body, .. } => {
+            const_ref_in_expr(cond).or_else(|| const_ref_in_block(body))
+        }
+        Stmt::ForRange { start, stop, step, body, .. } => const_ref_in_expr(start)
+            .or_else(|| const_ref_in_expr(stop))
+            .or_else(|| const_ref_in_expr(step))
+            .or_else(|| const_ref_in_block(body)),
+        Stmt::ForEach { iter, body, .. } => {
+            const_ref_in_expr(iter).or_else(|| const_ref_in_block(body))
+        }
+        Stmt::SeqSet { seq, index, value, .. } => const_ref_in_expr(seq)
+            .or_else(|| const_ref_in_expr(index))
+            .or_else(|| const_ref_in_expr(value)),
+        Stmt::MapSet { map, key, value, .. } => const_ref_in_expr(map)
+            .or_else(|| const_ref_in_expr(key))
+            .or_else(|| const_ref_in_expr(value)),
+        Stmt::ClassDef { body, .. }
+        | Stmt::ModuleDef { body, .. }
+        | Stmt::SingletonClassDef { body, .. } => const_ref_in_stmts(body),
+        Stmt::TryCatch { body, rescues, ensure_body, .. } => {
+            if let Some(e) = const_ref_in_stmts(body) {
+                return Some(e);
+            }
+            for r in rescues {
+                if let Some(e) = const_ref_in_stmts(&r.body) {
+                    return Some(e);
+                }
+            }
+            if let Some(ens) = ensure_body {
+                if let Some(e) = const_ref_in_stmts(ens) {
+                    return Some(e);
+                }
+            }
+            None
+        }
+    }
+}
+
+fn const_ref_in_block(b: &semantic_ir::Block) -> Option<BackendError> {
+    const_ref_in_stmts(&b.stmts).or_else(|| const_ref_in_expr(&b.value))
+}
+
+fn const_ref_in_expr(e: &Expr) -> Option<BackendError> {
+    match e {
+        // A `Const` VarRef standing alone (not a raise class name) cannot be
+        // lowered — flag it.
+        Expr::VarRef { scope: Scope::Const, span, .. } => Some(unsupported_const(span.clone())),
+        // `raise` is the ONE allowed home for a `Const`: its first argument
+        // may be a `Const` class name (lifted to a string).  Skip that slot;
+        // still scan the remaining arguments (the message expression, etc.).
+        Expr::BuiltinCall { name, args, .. } if name == "raise" => {
+            let skip_first = matches!(
+                args.first(),
+                Some(Expr::VarRef { scope: Scope::Const, .. })
+            );
+            let start = if skip_first { 1 } else { 0 };
+            for a in &args[start.min(args.len())..] {
+                if let Some(err) = const_ref_in_expr(a) {
+                    return Some(err);
+                }
+            }
+            None
+        }
+        Expr::BuiltinCall { args, .. } | Expr::DirectCall { args, .. } => {
+            for a in args {
+                if let Some(err) = const_ref_in_expr(a) {
+                    return Some(err);
+                }
+            }
+            None
+        }
+        Expr::IndirectCall { target, args, .. } => {
+            if let Some(err) = const_ref_in_expr(target) {
+                return Some(err);
+            }
+            for a in args {
+                if let Some(err) = const_ref_in_expr(a) {
+                    return Some(err);
+                }
+            }
+            None
+        }
+        Expr::Intrinsic { args, .. } => {
+            for a in args {
+                if let Some(err) = const_ref_in_expr(a) {
+                    return Some(err);
+                }
+            }
+            None
+        }
+        Expr::If { cond, then_branch, else_branch, .. } => const_ref_in_expr(cond)
+            .or_else(|| const_ref_in_block(then_branch))
+            .or_else(|| const_ref_in_block(else_branch)),
+        Expr::Block(b) => const_ref_in_block(b),
+        Expr::LogicalAnd { lhs, rhs, .. } | Expr::LogicalOr { lhs, rhs, .. } => {
+            const_ref_in_expr(lhs).or_else(|| const_ref_in_expr(rhs))
+        }
+        Expr::KeywordArg { value, .. } => const_ref_in_expr(value),
+        Expr::SeqLit { items, .. } | Expr::StrConcat { parts: items, .. } => {
+            for it in items {
+                if let Some(err) = const_ref_in_expr(it) {
+                    return Some(err);
+                }
+            }
+            None
+        }
+        Expr::SeqIndex { seq, index, .. } => {
+            const_ref_in_expr(seq).or_else(|| const_ref_in_expr(index))
+        }
+        Expr::SeqLen { seq, .. } => const_ref_in_expr(seq),
+        Expr::MapLit { entries, .. } => {
+            for entry in entries {
+                if let Some(err) = const_ref_in_expr(&entry.key) {
+                    return Some(err);
+                }
+                if let Some(err) = const_ref_in_expr(&entry.value) {
+                    return Some(err);
+                }
+            }
+            None
+        }
+        Expr::MapGet { map, key, .. } => {
+            const_ref_in_expr(map).or_else(|| const_ref_in_expr(key))
+        }
+        // Leaf / already-supported expressions carry no nested Const.
+        _ => None,
+    }
+}
+
+fn unsupported_const(span: semantic_ir::Span) -> BackendError {
+    BackendError {
+        kind: BackendErrorKind::UnsupportedFeature,
+        message: "rust backend cannot lower a constant reference; the only \
+                  accepted `Const` is an exception class name in `raise Foo` \
+                  (lifted to a string literal)"
+            .into(),
+        span,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use semantic_ir::{
-        Block, EffectSet, Expr, FeatureManifest, Function, Metadata, Param, Scope, Span,
+        Block, EffectSet, Expr, FeatureManifest, Function, Metadata, Param, RescueClause, Scope,
+        Span, Stmt,
     };
 
     fn s() -> Span {
@@ -610,5 +898,116 @@ mod tests {
         let m = kw_module(vec![f, main]);
         let a = compile(&m).expect("keyword-only module should still compile");
         assert!(a.source.contains("fn greet("));
+    }
+
+    // ── E4: exception feature acceptance + soundness gates ─────────
+
+    fn exc_module(stmts: Vec<Stmt>, features: &[Feature]) -> Module {
+        let mut m = minimal_module();
+        m.functions[0].body = Block {
+            stmts,
+            value: Expr::NilLit { span: s() },
+            span: s(),
+        };
+        let mut feats = vec![Feature::Exceptions, Feature::Strings];
+        feats.extend_from_slice(features);
+        m.manifest = FeatureManifest::from_features(&feats);
+        m
+    }
+
+    fn raise_stmt(cls: &str) -> Stmt {
+        Stmt::ExprStmt {
+            expr: Expr::BuiltinCall {
+                name: "raise".into(),
+                args: vec![
+                    Expr::VarRef { name: cls.into(), scope: Scope::Const, span: s() },
+                    Expr::StrLit { value: "m".into(), span: s() },
+                ],
+                effects: EffectSet::PURE,
+                span: s(),
+            },
+            span: s(),
+        }
+    }
+
+    #[test]
+    fn accepts_exceptions_and_emits_try_catch() {
+        let tc = Stmt::TryCatch {
+            body: vec![raise_stmt("ArgumentError")],
+            rescues: vec![RescueClause {
+                exception_types: vec!["StandardError".into()],
+                binding: Some("e".into()),
+                body: vec![],
+                span: s(),
+            }],
+            ensure_body: None,
+            span: s(),
+        };
+        let a = compile(&exc_module(vec![tc], &[Feature::Constants])).expect("exceptions accepted");
+        assert!(a.source.contains("std::panic::catch_unwind"), "got:\n{}", a.source);
+        assert!(
+            a.source.contains(r#"__sir::raise("ArgumentError", "#),
+            "got:\n{}",
+            a.source
+        );
+        assert!(a.source.contains("__sir::install_panic_hook();"), "got:\n{}", a.source);
+    }
+
+    #[test]
+    fn accepts_exception_subclass_class_def_and_registers_ancestry() {
+        let cd = Stmt::ClassDef {
+            name: "MyErr".into(),
+            superclass: Some("StandardError".into()),
+            body: vec![],
+            span: s(),
+        };
+        let a = compile(&exc_module(vec![cd], &[Feature::Classes]))
+            .expect("empty-body exception subclass accepted");
+        assert!(
+            a.source.contains(r#"__sir::register_ancestry(&[("MyErr", "StandardError")]);"#),
+            "got:\n{}",
+            a.source
+        );
+    }
+
+    #[test]
+    fn rejects_stateful_class_body() {
+        // A class whose body carries an executable statement is out of scope.
+        let cd = Stmt::ClassDef {
+            name: "Widget".into(),
+            superclass: None,
+            body: vec![Stmt::ExprStmt {
+                expr: Expr::IntLit { value: 1, span: s() },
+                span: s(),
+            }],
+            span: s(),
+        };
+        let err = compile(&exc_module(vec![cd], &[Feature::Classes]))
+            .expect_err("stateful class rejected");
+        assert_eq!(err.kind, BackendErrorKind::UnsupportedFeature);
+        assert!(err.message.contains("non-empty body"), "got: {}", err.message);
+    }
+
+    #[test]
+    fn rejects_non_raise_const_reference() {
+        // A `Const` VarRef that is NOT a raise class name has no lowering.
+        let stmt = Stmt::LetBinding {
+            name: "x".into(),
+            sir_type: None,
+            value: Expr::VarRef { name: "PI".into(), scope: Scope::Const, span: s() },
+            span: s(),
+        };
+        let err = compile(&exc_module(vec![stmt], &[Feature::Constants]))
+            .expect_err("bare const ref rejected");
+        assert_eq!(err.kind, BackendErrorKind::UnsupportedFeature);
+        assert!(err.message.contains("constant reference"), "got: {}", err.message);
+    }
+
+    #[test]
+    fn allows_const_only_as_raise_class_name() {
+        // `raise Foo, "m"` — the Const is the class name → allowed.
+        let a = compile(&exc_module(vec![raise_stmt("Foo")], &[Feature::Constants]))
+            .expect("raise-class-name const is allowed");
+        assert!(a.source.contains(r#"__sir::raise("Foo", "#), "got:\n{}", a.source);
     }
 }

--- a/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
@@ -1250,6 +1250,237 @@ pub const RUNTIME: &str = r##"mod __sir {
             }),
         }))
     }
+
+    // ── exception model (SIR17 Exceptions) ────────────────────────────
+    //
+    // Rust has NO native exceptions.  Ruby's `begin/rescue/ensure`
+    // maps onto Rust's *unwinding panic* machinery: a `raise` becomes a
+    // `std::panic::panic_any(SirError { … })` carrying a class-tagged
+    // payload, and a `TryCatch` region runs its body under
+    // `std::panic::catch_unwind`, then downcasts the caught payload back
+    // to a `SirError` to dispatch the rescue clauses.  See `emit.rs` for
+    // the emitted shape; this module is the runtime half.
+    //
+    // Why panic-unwind and not a `Result`-threading discipline?  Threading
+    // a `Result` would demand rewriting *every* emitted expression into a
+    // `?`-propagating form and changing every `fn … -> Value` signature to
+    // `-> Result<Value, SirError>`.  Panic-unwind is a *localized*
+    // transform: only `raise` and `TryCatch` change; all other emit arms
+    // are byte-for-byte unchanged, matching how the TS/Python backends add
+    // exceptions as a localized `throw`/`try` transform over otherwise
+    // unchanged code.
+    //
+    // SECURITY: rescue matching is an EXPLICIT ancestry-table lookup —
+    // never reflection / type-name introspection.  The built-in table is a
+    // small curated slice of Ruby's hierarchy (parity with the TS
+    // `sir-runtime-exceptions` `ANCESTRY`); user classes contribute edges
+    // only through `register_ancestry`, emitted from the module's own
+    // `ClassDef { superclass }` pairs.  A `seen`-set cycle guard bounds the
+    // ancestry walk so a malicious/cyclic edge set can never spin forever.
+
+    /// A raised SIR exception: a Ruby/SIR class name plus a message.
+    ///
+    /// This is the panic *payload* — `raise` calls `panic_any(SirError{…})`
+    /// and a `TryCatch` recovers it with `catch_unwind` + `downcast`.
+    ///
+    /// ## Why `msg: String` (not `Value`)
+    ///
+    /// `std::panic::panic_any<M>` requires `M: Any + Send + 'static`, but our
+    /// `Value` model is built on `Rc` (single-threaded by design) and is
+    /// therefore NOT `Send`.  So the payload cannot carry a raw `Value`.  A
+    /// `raise Klass, msg` renders `msg` to its string form *at raise time*
+    /// (via `format`) and stores that `String` — which is `Send` — exactly as
+    /// Ruby's `exception.message` is a string.  `exc_value` re-wraps it as a
+    /// `Value::Str` for a `rescue … => e` binding.  This keeps the whole
+    /// unwinding path `Send`-clean with no `unsafe`, at the cost of a
+    /// non-string message value being flattened to its printed form — an
+    /// acceptable v0 fidelity trade (Ruby itself expects a string message).
+    #[derive(Clone)]
+    pub struct SirError {
+        /// The Ruby/SIR class this was raised as (`ArgumentError`, `MyErr`…).
+        pub class: String,
+        /// The message Ruby's `raise Klass, "msg"` carries, rendered to a
+        /// string.  When no message is given, the class name is used (Ruby's
+        /// default `exception.message`).
+        pub msg: String,
+    }
+
+    // Built-in Ruby exception ancestry: subclass → immediate superclass.
+    // A verbatim parity port of the TS `sir-runtime-exceptions` `ANCESTRY`
+    // table.  Every entry ultimately chains up to `StandardError →
+    // Exception`.  Kept as a match (not a `HashMap`) so it is a pure,
+    // allocation-free, compile-time-closed lookup — the runtime can only
+    // ever return an edge this function spells out.
+    fn builtin_super(class: &str) -> Option<&'static str> {
+        match class {
+            "RuntimeError" => Some("StandardError"),
+            "ArgumentError" => Some("StandardError"),
+            "TypeError" => Some("StandardError"),
+            "NameError" => Some("StandardError"),
+            "NoMethodError" => Some("NameError"),
+            "IndexError" => Some("StandardError"),
+            "KeyError" => Some("IndexError"),
+            "RangeError" => Some("StandardError"),
+            "ZeroDivisionError" => Some("StandardError"),
+            "IOError" => Some("StandardError"),
+            "StopIteration" => Some("StandardError"),
+            "NotImplementedError" => Some("StandardError"),
+            "StandardError" => Some("Exception"),
+            _ => None,
+        }
+    }
+
+    thread_local! {
+        // User-defined ancestry edges (subclass → superclass), populated
+        // once at program init from the module's `ClassDef` pairs via
+        // `register_ancestry`.  Consulted *in addition to* the built-in
+        // table so `class MyErr < StandardError` makes a raised `MyErr`
+        // catchable by `rescue StandardError`.
+        static USER_ANCESTRY: RefCell<HashMap<String, String>> =
+            RefCell::new(HashMap::new());
+    }
+
+    /// Register user-defined `subclass → superclass` edges, once at init.
+    ///
+    /// The emitter collects every `Stmt::ClassDef { name, superclass:
+    /// Some(sup) }` in the module and emits a single call to this with all
+    /// the pairs.  This is the ONLY way a user edge enters the matcher —
+    /// there is no reflection over runtime type names.
+    pub fn register_ancestry(edges: &[(&str, &str)]) {
+        USER_ANCESTRY.with(|m| {
+            let mut m = m.borrow_mut();
+            for (sub, sup) in edges {
+                m.insert((*sub).to_string(), (*sup).to_string());
+            }
+        });
+    }
+
+    /// The immediate superclass of `class`, consulting the user table first
+    /// (so a user edge can extend, but a built-in is the fallback).
+    fn super_of(class: &str) -> Option<String> {
+        if let Some(sup) = USER_ANCESTRY.with(|m| m.borrow().get(class).cloned()) {
+            return Some(sup);
+        }
+        builtin_super(class).map(|s| s.to_string())
+    }
+
+    /// `true` if `actual` is `target` or descends from it via the merged
+    /// built-in + user ancestry.  The `seen` set bounds the walk so a
+    /// cyclic edge set (`A→B→A`) terminates instead of looping forever.
+    fn is_ancestor_or_self(actual: &str, target: &str) -> bool {
+        let mut cur = actual.to_string();
+        let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+        loop {
+            if cur == target {
+                return true;
+            }
+            if !seen.insert(cur.clone()) {
+                return false; // cycle — stop.
+            }
+            match super_of(&cur) {
+                Some(next) => cur = next,
+                None => return false,
+            }
+        }
+    }
+
+    /// Does a caught `SirError` match a rescue clause naming `class_names`?
+    ///
+    /// - An **empty** list is a bare `rescue` (catch-all) → always `true`.
+    /// - `Exception` is Ruby's universal root → matches anything.
+    /// - Otherwise the error matches if its class equals, or descends from,
+    ///   any named class (per the merged ancestry table).
+    ///
+    /// Parity with the TS `rescueMatches`.
+    pub fn rescue_matches(exc: &SirError, class_names: &[&str]) -> bool {
+        if class_names.is_empty() {
+            return true;
+        }
+        class_names
+            .iter()
+            .any(|name| *name == "Exception" || is_ancestor_or_self(&exc.class, name))
+    }
+
+    /// The message value a rescue binding (`rescue … => e`) sees — the
+    /// exception's message, re-wrapped as a `Value::Str`.  Ruby would bind an
+    /// exception *object* here; SIR v0 has no exception-object model, so the
+    /// message string is the honest stand-in (the same choice the TS backend
+    /// makes, where `=> e` binds the thrown value's message).
+    pub fn exc_value(exc: &SirError) -> Value {
+        Value::Str(Rc::from(exc.msg.as_str()))
+    }
+
+    /// Raise a SIR exception of `class` with message `msg` by panicking with
+    /// a `SirError` payload.  The `msg` `Value` is rendered to a string at
+    /// raise time (see `SirError`'s doc for why the payload cannot carry a
+    /// raw `Value`).  Declared `-> !` (never returns) so control-flow
+    /// analysis knows code after a `raise` is unreachable.
+    ///
+    /// A quiet panic hook (installed by `install_panic_hook`, called at
+    /// program init) suppresses Rust's default `thread 'main' panicked …`
+    /// banner for *our* `SirError` payloads on the caught path, so a rescued
+    /// exception prints no spurious stderr noise.  A genuine (non-`SirError`)
+    /// Rust panic still prints normally.
+    pub fn raise(class: &str, msg: Value) -> ! {
+        std::panic::panic_any(SirError { class: class.to_string(), msg: format(&msg) })
+    }
+
+    /// Bare `raise` with no in-flight exception threaded: re-raise as a
+    /// generic `RuntimeError` (SIR v0 does not carry the current exception
+    /// into a bare re-raise — documented limitation, parity with TS).
+    pub fn reraise() -> ! {
+        std::panic::panic_any(SirError {
+            class: "RuntimeError".to_string(),
+            msg: "RuntimeError".to_string(),
+        })
+    }
+
+    /// Recover a `SirError` from a `catch_unwind` payload, or **re-panic**.
+    ///
+    /// A `catch_unwind` `Err` payload is `Box<dyn Any + Send>`.  If it
+    /// downcasts to our `SirError`, that is a SIR-level `raise` we should
+    /// dispatch to rescue clauses.  If it does NOT — it is a *genuine Rust
+    /// panic* (an index-out-of-bounds, an `unwrap` on `None`, an internal
+    /// bug), which must NEVER be silently swallowed as if it were a
+    /// rescuable Ruby exception.  We `resume_unwind` it so it propagates
+    /// exactly as an uncaught panic would, preserving Rust's own crash
+    /// semantics.  This is the security-critical passthrough: a rescue
+    /// clause can only ever catch a value that a `raise` produced.
+    pub fn exc_from_payload(payload: Box<dyn std::any::Any + Send>) -> SirError {
+        match payload.downcast::<SirError>() {
+            Ok(e) => *e,
+            Err(other) => std::panic::resume_unwind(other),
+        }
+    }
+
+    /// Install a quiet panic hook so a *`SirError`* panic (a SIR `raise`)
+    /// does not print Rust's default panic banner to stderr — the
+    /// `catch_unwind` in a `TryCatch` is responsible for that exception, and
+    /// an *uncaught* one already renders its own message via `report_uncaught`.
+    /// A non-`SirError` panic (a real Rust bug) still prints normally.
+    ///
+    /// Idempotent-safe to call once at program init.
+    pub fn install_panic_hook() {
+        let default = std::panic::take_hook();
+        std::panic::set_hook(Box::new(move |info| {
+            if info.payload().is::<SirError>() {
+                // A SIR raise: stay silent here.  If it is ultimately
+                // uncaught, the process still aborts with a non-zero status
+                // (the unwind reaches `main` and terminates the thread); the
+                // top-level `catch_unwind` in `main` prints a clean message.
+                return;
+            }
+            default(info);
+        }));
+    }
+
+    /// Render an uncaught SIR exception (one that unwound past every
+    /// `TryCatch`) as Ruby would at top level (`Class: message`) and exit
+    /// non-zero.  Called by the `main`-level `catch_unwind` wrapper.
+    pub fn report_uncaught(exc: &SirError) -> ! {
+        eprintln!("{}: {}", exc.class, exc.msg);
+        std::process::exit(1)
+    }
 }
 "##;
 
@@ -1356,5 +1587,44 @@ mod tests {
         // ForEach reconciliation: `seq_iter` must snapshot a `Value::Seq`
         // (the new real sequence) as well as walk a cons-list.
         assert!(RUNTIME.contains("if let Value::Seq(items) = v"));
+    }
+
+    #[test]
+    fn runtime_declares_exception_helpers() {
+        // E4: the inline runtime must ship the exception model + matcher so a
+        // `raise`/`TryCatch` program runs end to end.
+        for helper in &[
+            "pub struct SirError",
+            "pub fn raise",
+            "pub fn reraise",
+            "pub fn exc_from_payload",
+            "pub fn exc_value",
+            "pub fn rescue_matches",
+            "pub fn register_ancestry",
+            "pub fn install_panic_hook",
+            "pub fn report_uncaught",
+        ] {
+            assert!(RUNTIME.contains(helper), "runtime missing `{}`", helper);
+        }
+    }
+
+    #[test]
+    fn runtime_rescue_matcher_is_explicit_table_with_cycle_guard() {
+        // SECURITY: rescue matching is an EXPLICIT ancestry table (no
+        // reflection), and the ancestry walk carries a `seen`-set cycle
+        // guard so a cyclic edge set terminates.
+        assert!(RUNTIME.contains("fn builtin_super"), "missing explicit ancestry table");
+        // A representative built-in edge (parity with the TS ANCESTRY).
+        assert!(RUNTIME.contains(r#""ArgumentError" => Some("StandardError")"#));
+        assert!(RUNTIME.contains(r#""StandardError" => Some("Exception")"#));
+        // Cycle guard.
+        assert!(RUNTIME.contains("seen.insert"), "missing cycle guard");
+    }
+
+    #[test]
+    fn runtime_non_sir_error_payload_is_resumed_not_swallowed() {
+        // A non-`SirError` panic payload must be re-raised, never treated as
+        // a rescuable exception.
+        assert!(RUNTIME.contains("std::panic::resume_unwind(other)"));
     }
 }

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_exceptions.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_exceptions.rs
@@ -1,0 +1,317 @@
+//! End-to-end proof for the **E4 exception runtime** in the Rust backend.
+//!
+//! Rust has no native exceptions.  This backend maps Ruby's
+//! `begin/rescue/ensure` onto Rust's *unwinding panic* machinery:
+//!
+//!   * `raise Foo, "m"` → `__sir::raise("Foo", <m>)` → `panic_any(SirError{…})`
+//!   * `begin … rescue … ensure … end` → a `std::panic::catch_unwind` region
+//!     that downcasts the caught payload to a `SirError` and dispatches the
+//!     rescue clauses via `__sir::rescue_matches` over a built-in + user
+//!     ancestry table (parity with the TS `sir-runtime-exceptions`).
+//!
+//! Unit tests (in `emit.rs`) assert the emitted *shape*; this test hand-builds
+//! SIR modules, emits Rust, compiles with `rustc`, runs the binary, and checks
+//! stdout / exit status against the behaviour the Python/TS reference produces
+//! for the same SIR module.  The five cases (per spec §Verification):
+//!
+//!   (a) `raise ArgumentError,"x"; rescue StandardError=>e` → prints a marker
+//!       (built-in ancestry: `ArgumentError < StandardError`).
+//!   (b) bare `rescue` catches anything.
+//!   (c) an unmatched rescue re-raises → the process exits non-zero and the
+//!       inner handler does NOT print.
+//!   (d) `ensure` runs on the caught path AND on the uncaught (re-raised) path.
+//!   (e) user ancestry: `class MyErr < StandardError; raise MyErr; rescue
+//!       StandardError` catches (edge registered at init).
+//!
+//! `StrLit` interpolation is not accepted by the Rust backend, so — like the
+//! other Rust exec-proof tests — assertions are on simple integer markers the
+//! `print` path renders.
+//!
+//! If `rustc` (or a usable linker) is unavailable the test logs a skip rather
+//! than failing.  The host points the test at a working linker via
+//! `SIR_TEST_RUSTC_LINKER` (e.g. the toolchain's bundled `rust-lld`).
+
+use std::process::Command;
+
+use semantic_ir::{
+    Block, Effect, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module,
+    RescueClause, Scope, Span, Stmt,
+};
+use semantic_ir_to_rust::compile;
+
+fn s() -> Span {
+    Span::synthetic()
+}
+
+fn ilit(v: i64) -> Expr {
+    Expr::IntLit { value: v, span: s() }
+}
+
+fn slit(v: &str) -> Expr {
+    Expr::StrLit { value: v.into(), span: s() }
+}
+
+fn constref(name: &str) -> Expr {
+    Expr::VarRef { name: name.into(), scope: Scope::Const, span: s() }
+}
+
+fn call(name: &str, args: Vec<Expr>, eff: EffectSet) -> Expr {
+    Expr::BuiltinCall { name: name.into(), args, effects: eff, span: s() }
+}
+
+fn print_stmt(e: Expr) -> Stmt {
+    Stmt::ExprStmt {
+        expr: call("print", vec![e], EffectSet::PURE.with(Effect::MayPrint)),
+        span: s(),
+    }
+}
+
+/// `raise Class, "msg"` as an expression statement.
+fn raise_stmt(cls: &str, msg: &str) -> Stmt {
+    Stmt::ExprStmt {
+        expr: call(
+            "raise",
+            vec![constref(cls), slit(msg)],
+            EffectSet::PURE.with(Effect::MayThrow).with(Effect::Divergent),
+        ),
+        span: s(),
+    }
+}
+
+fn rescue(types: &[&str], binding: Option<&str>, body: Vec<Stmt>) -> RescueClause {
+    RescueClause {
+        exception_types: types.iter().map(|t| (*t).to_string()).collect(),
+        binding: binding.map(|b| b.to_string()),
+        body,
+        span: s(),
+    }
+}
+
+/// Assemble a single-`main` module from a body of statements.
+fn module_from_main(stmts: Vec<Stmt>, features: &[Feature]) -> Module {
+    let main_fn = Function {
+        name: "main".into(),
+        params: vec![],
+        return_type: None,
+        captures: vec![],
+        body: Block { stmts, value: Expr::NilLit { span: s() }, span: s() },
+        effects: EffectSet::PURE.with(Effect::MayPrint),
+        metadata: Metadata::new(),
+        span: s(),
+    };
+    let mut feats = vec![Feature::Exceptions, Feature::Strings];
+    feats.extend_from_slice(features);
+    Module {
+        name: "exc_demo".into(),
+        manifest: FeatureManifest::from_features(&feats),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![main_fn],
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("test")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+fn rustc_available() -> bool {
+    Command::new("rustc")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Compile emitted Rust source and run the binary, returning
+/// `(stdout, exit_success)`.  Returns `None` if the host has no usable
+/// linker (a skip, never a failure).
+fn compile_and_run(source: &str, tag: &str) -> Option<(String, bool)> {
+    let dir = std::env::temp_dir();
+    let nonce = format!("{}_{}", std::process::id(), tag);
+    let src_path = dir.join(format!("sir_exc_{nonce}.rs"));
+    let bin_path = dir.join(format!("sir_exc_{nonce}{}", if cfg!(windows) { ".exe" } else { "" }));
+    std::fs::write(&src_path, source).expect("write temp source");
+
+    let mut cmd = Command::new("rustc");
+    cmd.arg("--edition").arg("2021").arg("-O");
+    if let Ok(linker) = std::env::var("SIR_TEST_RUSTC_LINKER") {
+        if !linker.is_empty() {
+            cmd.arg("-C").arg(format!("linker={linker}"));
+        }
+    }
+    let compile_out = cmd
+        .arg(&src_path)
+        .arg("-o")
+        .arg(&bin_path)
+        .output()
+        .expect("invoke rustc");
+    if !compile_out.status.success() {
+        let stderr = String::from_utf8_lossy(&compile_out.stderr);
+        if stderr.contains("linker") && (stderr.contains("not found") || stderr.contains("No such file")) {
+            eprintln!("skipping: no usable linker on host\n{stderr}");
+            let _ = std::fs::remove_file(&src_path);
+            return None;
+        }
+        panic!(
+            "emitted Rust failed to compile:\n--- stderr ---\n{stderr}\n--- source ---\n{source}"
+        );
+    }
+
+    let run_out = Command::new(&bin_path).output().expect("run compiled binary");
+    let stdout = String::from_utf8_lossy(&run_out.stdout).to_string();
+    let ok = run_out.status.success();
+    let _ = std::fs::remove_file(&src_path);
+    let _ = std::fs::remove_file(&bin_path);
+    Some((stdout, ok))
+}
+
+/// (a) built-in ancestry: `rescue StandardError` catches a raised
+/// `ArgumentError` (`ArgumentError < StandardError`).  Prints `1`.
+#[test]
+fn typed_rescue_catches_via_builtin_ancestry() {
+    if !rustc_available() {
+        eprintln!("skipping: rustc not on PATH");
+        return;
+    }
+    let tc = Stmt::TryCatch {
+        body: vec![raise_stmt("ArgumentError", "x"), print_stmt(ilit(99))], // 99 unreached
+        rescues: vec![rescue(&["StandardError"], Some("e"), vec![print_stmt(ilit(1))])],
+        ensure_body: None,
+        span: s(),
+    };
+    let src = compile(&module_from_main(vec![tc], &[Feature::Constants]))
+        .expect("compile")
+        .source;
+    let Some((stdout, ok)) = compile_and_run(&src, "typed") else { return };
+    assert!(ok, "process should exit 0 (exception caught)");
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert_eq!(lines, vec!["1"], "expected only the rescue marker; got {stdout:?}");
+}
+
+/// (b) bare `rescue` (empty type list) catches anything.  Prints `2`.
+#[test]
+fn bare_rescue_catches_anything() {
+    if !rustc_available() {
+        eprintln!("skipping: rustc not on PATH");
+        return;
+    }
+    let tc = Stmt::TryCatch {
+        body: vec![raise_stmt("TypeError", "boom")],
+        rescues: vec![rescue(&[], None, vec![print_stmt(ilit(2))])],
+        ensure_body: None,
+        span: s(),
+    };
+    let src = compile(&module_from_main(vec![tc], &[Feature::Constants]))
+        .expect("compile")
+        .source;
+    let Some((stdout, ok)) = compile_and_run(&src, "bare") else { return };
+    assert!(ok, "process should exit 0 (bare rescue caught)");
+    assert_eq!(stdout.lines().collect::<Vec<_>>(), vec!["2"], "got {stdout:?}");
+}
+
+/// (c) an unmatched rescue re-raises: the process exits NON-zero and the inner
+/// handler does not print.  We rescue only `TypeError` but raise
+/// `ArgumentError` (not a `TypeError` subclass) → propagates.
+#[test]
+fn unmatched_rescue_reraises_nonzero() {
+    if !rustc_available() {
+        eprintln!("skipping: rustc not on PATH");
+        return;
+    }
+    let tc = Stmt::TryCatch {
+        body: vec![raise_stmt("ArgumentError", "x")],
+        // Rescue a DIFFERENT, unrelated class → no match → re-raise.
+        rescues: vec![rescue(&["TypeError"], None, vec![print_stmt(ilit(7))])],
+        ensure_body: None,
+        span: s(),
+    };
+    let src = compile(&module_from_main(vec![tc], &[Feature::Constants]))
+        .expect("compile")
+        .source;
+    let Some((stdout, ok)) = compile_and_run(&src, "unmatched") else { return };
+    assert!(!ok, "process should exit non-zero (exception unrescued)");
+    assert!(
+        !stdout.contains('7'),
+        "the non-matching handler must NOT run; got stdout {stdout:?}"
+    );
+}
+
+/// (d) `ensure` runs on BOTH the caught path and the uncaught (re-raised)
+/// path.  Two programs:
+///   * caught: rescue matches → ensure prints `9`, exit 0, stdout `1\n9`.
+///   * uncaught: no match → ensure prints `9` before re-raise, exit non-zero,
+///     stdout contains `9`.
+#[test]
+fn ensure_runs_on_caught_and_uncaught() {
+    if !rustc_available() {
+        eprintln!("skipping: rustc not on PATH");
+        return;
+    }
+
+    // Caught path.
+    let caught = Stmt::TryCatch {
+        body: vec![raise_stmt("ArgumentError", "x")],
+        rescues: vec![rescue(&["StandardError"], None, vec![print_stmt(ilit(1))])],
+        ensure_body: Some(vec![print_stmt(ilit(9))]),
+        span: s(),
+    };
+    let src = compile(&module_from_main(vec![caught], &[Feature::Constants]))
+        .expect("compile")
+        .source;
+    if let Some((stdout, ok)) = compile_and_run(&src, "ensure_caught") {
+        assert!(ok, "caught path should exit 0");
+        assert_eq!(
+            stdout.lines().collect::<Vec<_>>(),
+            vec!["1", "9"],
+            "rescue then ensure; got {stdout:?}"
+        );
+    } else {
+        return;
+    }
+
+    // Uncaught path: ensure still runs before the re-raise.
+    let uncaught = Stmt::TryCatch {
+        body: vec![raise_stmt("ArgumentError", "x")],
+        rescues: vec![rescue(&["TypeError"], None, vec![print_stmt(ilit(1))])],
+        ensure_body: Some(vec![print_stmt(ilit(9))]),
+        span: s(),
+    };
+    let src = compile(&module_from_main(vec![uncaught], &[Feature::Constants]))
+        .expect("compile")
+        .source;
+    if let Some((stdout, ok)) = compile_and_run(&src, "ensure_uncaught") {
+        assert!(!ok, "uncaught path should exit non-zero");
+        assert!(stdout.contains('9'), "ensure must run before re-raise; got {stdout:?}");
+        assert!(!stdout.contains('1'), "non-matching rescue must not run; got {stdout:?}");
+    }
+}
+
+/// (e) user-defined ancestry: `class MyErr < StandardError` makes a raised
+/// `MyErr` catchable by `rescue StandardError` (edge registered at init).
+/// Prints `5`.
+#[test]
+fn user_ancestry_matches_superclass() {
+    if !rustc_available() {
+        eprintln!("skipping: rustc not on PATH");
+        return;
+    }
+    let classdef = Stmt::ClassDef {
+        name: "MyErr".into(),
+        superclass: Some("StandardError".into()),
+        body: vec![],
+        span: s(),
+    };
+    let tc = Stmt::TryCatch {
+        body: vec![raise_stmt("MyErr", "custom")],
+        rescues: vec![rescue(&["StandardError"], Some("e"), vec![print_stmt(ilit(5))])],
+        ensure_body: None,
+        span: s(),
+    };
+    let src = compile(&module_from_main(vec![classdef, tc], &[Feature::Constants, Feature::Classes]))
+        .expect("compile")
+        .source;
+    let Some((stdout, ok)) = compile_and_run(&src, "user_ancestry") else { return };
+    assert!(ok, "process should exit 0 (user-ancestry match caught)");
+    assert_eq!(stdout.lines().collect::<Vec<_>>(), vec!["5"], "got {stdout:?}");
+}


### PR DESCRIPTION
## What

**E4** of the exception-hierarchy cascade — the Rust backend now **executes** exceptions (previously `TryCatch`/`raise` panicked as "capability check should have rejected it"). Rust has no native exceptions, so this maps to `std::panic::catch_unwind` + a `SirError` panic payload. Design: `code/specs/sir-exception-hierarchy.md` (PR #7255). Completes Phase 2 with E3 (Go).

- **raise → `__sir::raise("Foo", msg)`** which `panic_any(SirError{class, msg})`. Because the `Rc`-based `Value` isn't `Send` (and `panic_any` requires `Send`), the message is rendered to a `String` at raise time.
- **TryCatch → `catch_unwind(AssertUnwindSafe(|| <try>))`** + match: matched rescue binds `=> e` and runs; unmatched → `resume_unwind` (re-raise); `ensure` runs on every path.
- **Non-`SirError` passthrough:** `exc_from_payload` downcasts to `SirError` or `resume_unwind`s the original — a genuine Rust panic (OOB, unwrap-on-None) is **re-raised, never mis-dispatched** to a rescue clause. (Note: this is the opposite of E3 Go / Python / TS / JS, which catch host faults as StandardError — the divergence is tracked in the cross-backend follow-up.)
- **Runtime:** `SirError`, `rescue_matches` + built-in ancestry + `register_ancestry` for user edges (`seen`-set cycle guard, explicit table — no reflection), and `install_panic_hook` that only silences `SirError` payloads (real panics keep the default hook's diagnostics).
- Accepts `Feature::Exceptions`/`Classes`/`Constants`, guarded by `reject_stateful_class` + `reject_const_ref`.

## Verification

- `cargo test -p semantic-ir-to-rust` — **97 lib + integration** green.
- **Execution-proof (rustc + rust-lld):** built-in ancestry catch; bare rescue; unmatched re-raise (non-zero exit); `ensure` on caught + uncaught paths; user ancestry `MyErr < StandardError` → caught.
- Clippy clean; `cargo build --workspace` clean (bar pre-existing Unix-only crate).
- **Security review passed** (no new `unsafe`; `catch_unwind`/`AssertUnwindSafe` logic-only, no memory-unsafety; cycle-bounded ancestry; escaped names; panic-hook preserves real diagnostics). **Fixed a review finding**: `reject_const_ref` now walks `MakeClosure` captures — a `Const` VarRef hidden in a closure capture previously reached the emit panic (reachable DoS on a validated module); now cleanly rejected (regression test added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)