### PR TITLE
feat(adj-lang): latex \sqrt{x} lowers to x ^ 0.5 (reuses ComputeOp::Pow)

### DIFF
--- a/code/packages/rust/adj-lang/CHANGELOG.md
+++ b/code/packages/rust/adj-lang/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [0.21.0] - 2026-07-01 — `\sqrt{x}` in `latex "…"` (lowers to `x ^ 0.5`)
+
+### Added
+
+- The `latex "…"` adapter now accepts a **square root** `\sqrt{x}` (a
+  `MathExpr::Root` with no explicit degree), lowering it to `x ^ 0.5` on the
+  native `ComputeOp::Pow` (adj-lang 0.20.0 / logic-engine 0.27.0). No new engine
+  op: the power engine computes `√9 = 3` for a dimensionless (`Scalar`) base and
+  cleanly rejects a dimensioned base (a `√dollars` has no representable
+  half-dimension — a `DimensionMismatch`, not a silently-wrong number).
+
+### Notes
+
+- An **nth root** `\sqrt[n]{x}` (a `Root` with an explicit degree) is still
+  unsupported — its `1/n` exponent needs a dedicated non-integer path — and
+  falls through to the existing `UnsupportedLatexMath` error. A square-root
+  constraint (`constrain latex "$\sqrt{x} = 3$"`) is non-polynomial (a
+  fractional exponent), so the solver treats it as `Unknown`, as before.
+
 ## [0.20.0] - 2026-07-01 — native `^` power in `latex "…"` (emit `ComputeOp::Pow`)
 
 ### Changed

--- a/code/packages/rust/adj-lang/Cargo.toml
+++ b/code/packages/rust/adj-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang"
-version = "0.20.0"
+version = "0.21.0"
 edition = "2021"
 description = "Surface-syntax frontend for the adjudication framework's probabilistic-logic rulebooks. Lexes, parses, and lowers a domain-expert-readable DSL into a `logic-engine` KnowledgeBase. Dissolves ADJ46 awkwardness items A10 (rulebook syntax) and A4 (joint contributions syntactically distinct)."
 

--- a/code/packages/rust/adj-lang/src/adapter.rs
+++ b/code/packages/rust/adj-lang/src/adapter.rs
@@ -947,6 +947,20 @@ fn latex_math_to_expr_ast(expr: &MathExpr, source: &str) -> Result<ExprAst, Adap
                 Box::new(ExprAst::Lit(n)),
             ))
         }
+        // A square root `\sqrt{x}` (a `Root` with no explicit degree) lowers to
+        // `x ^ 0.5`, reusing the native `ComputeOp::Pow`. The engine computes it
+        // for a dimensionless (Scalar) base — `√9 = 3` — and cleanly rejects a
+        // dimensioned base (a `√dollars` has no representable half-dimension), so
+        // no new engine op is needed. An nth root `\sqrt[n]{x}` (degree present)
+        // is a later slice: its `1/n` exponent needs its own non-integer path.
+        MathExpr::Root {
+            degree: None,
+            radicand,
+        } => Ok(ExprAst::Bin(
+            ArithOp::Pow,
+            Box::new(latex_math_to_expr_ast(radicand, source)?),
+            Box::new(ExprAst::Lit(0.5)),
+        )),
         MathExpr::Rel(_, _, _) => Err(AdapterError::UnsupportedLatexMath {
             source: source.to_string(),
             detail: "relation-valued LaTeX is only valid in `constrain latex`".into(),

--- a/code/packages/rust/adj-lang/src/lower.rs
+++ b/code/packages/rust/adj-lang/src/lower.rs
@@ -1758,6 +1758,34 @@ contributes 1000000 from answer == 60 to correct
     }
 
     #[test]
+    fn native_latex_square_root_computes() {
+        // `\sqrt{9}` lowers to `9 ^ 0.5` (reusing ComputeOp::Pow) and computes 3
+        // for a dimensionless base.
+        let d = crate::compile_and_decide(
+            "let answer = latex \"$\\sqrt{9}$\"\n\
+             prior 0.10 for correct\n\
+             contributes 1000000 from answer == 3 to correct\n\
+             ? correct\n",
+        )
+        .unwrap();
+        assert!(d.ranked[0].posterior > 0.99, "{d:?}");
+    }
+
+    #[test]
+    fn native_latex_square_root_of_an_observed_scalar_computes() {
+        // `\sqrt{x}` over an observed dimensionless value: √16 = 4.
+        let d = crate::compile_and_decide(
+            "observe x(16)\n\
+             let answer = latex \"$\\sqrt{x}$\"\n\
+             prior 0.10 for correct\n\
+             contributes 1000000 from answer == 4 to correct\n\
+             ? correct\n",
+        )
+        .unwrap();
+        assert!(d.ranked[0].posterior > 0.99, "{d:?}");
+    }
+
+    #[test]
     fn all_relational_operators_parse() {
         for (src, want) in [
             ("constrain a >= 1", crate::ast::RelOp::Ge),


### PR DESCRIPTION
## What

Third consumer-side slice of the LaTeX/math arc (after [#7259](https://github.com/adhithyan15/coding-adventures/pull/7259) engine `Pow` and [#7267](https://github.com/adhithyan15/coding-adventures/pull/7267) adapter-emits-`Pow`). The `latex "…"` adapter now accepts a **square root**: a `MathExpr::Root` with no explicit degree (`\sqrt{x}`) lowers to `x ^ 0.5` on the native `ComputeOp::Pow`.

**No new engine op** — it reuses the merged power operator:
- a dimensionless (`Scalar`) base computes: `\sqrt{9} = 3`, `\sqrt{16} = 4`;
- a dimensioned base is a clean `DimensionMismatch` (a `√dollars` has no representable half-dimension);
- a negative radicand (`\sqrt{-9}` → `powf` `NaN`) surfaces as a clean `ComputeError::NonFinite`, never a silent `NaN` (confirmed in the inline security review).

## Scope

adj-lang only — one match arm in `latex_math_to_expr_ast` + two lower tests.

An **nth root** `\sqrt[n]{x}` (a `Root` *with* a degree) is still unsupported — its `1/n` exponent needs a dedicated non-integer path — and falls through to the existing `UnsupportedLatexMath` error. A square-root **constraint** is non-polynomial (fractional exponent), so the solver treats it as `Unknown`.

## Tests

adj-lang **89** (2 new: `√9=3`, `√16=4` over an observed value), adj-constraint-solver **60**, adj-lang-cli **38**, adjudication-pipeline — all green. Clippy clean of new lints.

`adj-lang` 0.20.0 → 0.21.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)