### PR TITLE
feat(adj-ladder): rung-30 body mass index (constant-free)

### DIFF
--- a/code/specs/data/adj-ladder/rung30_body_mass_index/gen_items.py
+++ b/code/specs/data/adj-ladder/rung30_body_mass_index/gen_items.py
@@ -1,0 +1,172 @@
+"""Generate rung-30 (body mass index) items.json for the ADJ-LADDER.
+
+Rung 30 opens the **anthropometric / nutritional** panel on the quantitative band — the arithmetic of the
+body mass index (BMI), the bedside index that stratifies underweight / normal / overweight / obese. It uses
+the same contamination-safe shape as the serum-protein rung (29), the coagulation rung (28), and the urine
+rung (27): a small table of *observed* quantities and a tight family of mutually-confusable formulas built
+**only from those observed quantities** (no numeric literal anywhere in any program), so nothing structural
+can leak.
+
+The clinical setup is a single anthropometric measurement. Two quantities are measured:
+
+  WEIGHT  body mass       (kg)
+  HEIGHT  body height     (m)
+
+BMI falls out as a pure function of the observed quantities — no constant required (metric BMI is exactly
+`kg / m^2`). That is what makes this rung distinctive: BMI is a quantity **divided by a SQUARE** — `WEIGHT /
+(HEIGHT * HEIGHT)` — a shape not yet seen on the ladder (rung-24 put a difference in the numerator, rung-27
+summed inside a difference, rung-29 divided by a difference; this rung divides *by a product of the same
+quantity with itself*). The core confusion this rung tests is remembering to **square the height** before
+dividing (the classic slip is `WEIGHT / HEIGHT`, forgetting the square):
+
+  BODY MASS INDEX      WEIGHT / (HEIGHT * HEIGHT)  [ =BMI, kg/m^2 ]
+  WEIGHT:HEIGHT RATIO  WEIGHT / HEIGHT            [ the slip: divided by height, not height-squared ]
+  HEIGHT SQUARED       HEIGHT * HEIGHT            [ the denominator alone, m^2 ]
+
+Each index is a `compute_dimensioned` program (observe the two quantities + `let answer = formula`); the ADJ
+engine carries the arithmetic and the harness reads the scalar via the existing `compute_dimensioned`
+extractor — no harness/engine change, exactly as rungs 8/16/…/28/29. This rung exercises the engine across a
+PRODUCT in the denominator (`HEIGHT * HEIGHT`) contrasted with a plain division.
+
+Contamination-safe by construction: every formula is built only from the two observed quantities via `*`,
+`/` — **no structural constants** — so every program literal is grounded in the stem (`HEIGHT` appears twice
+in the BMI denominator, but it is the observed *identifier*, not a numeral). The observed quantities carry
+**digit-free identifiers** (`weight`, `height`) so no numeral hides inside a variable name. The five options
+are a tight family over the same quantities: the three real indices plus the two classic slips —
+
+  (HEIGHT * HEIGHT) / WEIGHT    the *inverted* BMI (upside-down), and
+  WEIGHT * HEIGHT              the weight-times-height product (multiplying instead of dividing),
+
+which are exactly the mistakes a student makes. Gold rotates A-E by index.
+
+Note on scale: BMI is order ~20-40, the weight:height ratio is order ~30-60, height-squared is order ~2-4,
+the inverted BMI is order ~0.03, and the weight-times-height product is order ~100 — five very different
+magnitudes, so no two family values collide; the tables below are chosen so the five family values are
+pairwise distinct — with a comfortable margin — for every item, asserted at build time.
+"""
+import json
+
+LETTERS = ["A", "B", "C", "D", "E"]
+
+# (WEIGHT, HEIGHT) observed quantities. WEIGHT in kg, HEIGHT in m. The five index-family values are
+# asserted pairwise-distinct (with margin) below.
+#   WEIGHT = body mass
+#   HEIGHT = body height
+TABLES = [
+    (72, 1.8),
+    (80, 2.0),
+    (90, 1.8),
+    (60, 1.5),
+    (100, 2.0),
+    (50, 1.6),
+    (77, 1.75),
+]
+
+# The option family (5 members), all built from the observed quantities via `*` / `/`. Every identifier is
+# DIGIT-FREE. key -> (display name, formula-as-adj). Only the first three are *queried* (used as gold); all
+# five always appear as the options.
+FAMILY = [
+    ("bmi", "body mass index", "weight / (height * height)"),
+    ("weight_height_ratio", "weight-to-height ratio", "weight / height"),
+    ("height_squared", "height squared", "height * height"),
+    ("inverse_bmi", "inverse BMI (height-squared over weight)", "(height * height) / weight"),
+    ("weight_height_product", "weight-times-height product", "weight * height"),
+]
+QUERIED = ["bmi", "weight_height_ratio", "height_squared"]
+ORDER = [k for k, _, _ in FAMILY]
+
+
+def scalar(v):
+    return {"value": v, "unit": "scalar"}
+
+
+def family_values(weight, height):
+    # Operation order mirrors the ADJ program exactly, so the Python option value and the engine
+    # result are the same IEEE-double (well within the harness's 1e-9 match tolerance).
+    return {
+        "bmi": weight / (height * height),
+        "weight_height_ratio": weight / height,
+        "height_squared": height * height,
+        "inverse_bmi": (height * height) / weight,
+        "weight_height_product": weight * height,
+    }
+
+
+def build():
+    name_of = {k: nm for k, nm, _ in FAMILY}
+    formula_of = {k: f for k, _, f in FAMILY}
+    items = []
+    idx = 0
+
+    def num(x):
+        return int(x) if float(x).is_integer() else x
+
+    for weight, height in TABLES:
+        assert weight > 0 and height > 0, (weight, height)
+        fv = family_values(weight, height)
+        # Pairwise-distinct with a comfortable margin so the harness never sees two options
+        # matching the gold value within its 1e-9 tolerance.
+        vals = [fv[key] for key in ORDER]
+        for i in range(len(vals)):
+            for j in range(i + 1, len(vals)):
+                assert abs(vals[i] - vals[j]) > 1e-6, (weight, height, ORDER[i], ORDER[j], fv)
+        for key in QUERIED:
+            gold_val = fv[key]
+            gold_pos = idx % 5
+            others = [fv[k2] for k2 in ORDER if abs(fv[k2] - gold_val) > 1e-12]
+            opts_vals = others[:]
+            opts_vals.insert(gold_pos, gold_val)
+            opts_vals = opts_vals[:5]
+            if abs(opts_vals[gold_pos] - gold_val) > 1e-12:
+                opts_vals[gold_pos] = gold_val
+            assert len({round(v, 9) for v in opts_vals}) == 5, (key, weight, height, opts_vals)
+            options = {LETTERS[i]: scalar(opts_vals[i]) for i in range(5)}
+            items.append({
+                "id": f"r30bmi-{idx + 1:02d}",
+                "qtype": "body_mass_index",
+                "stem": (
+                    f"A patient weighs {num(weight)} kg and is {num(height)} m tall. What is the patient's "
+                    f"{name_of[key]}?"
+                ),
+                "program": (
+                    f"observe weight({num(weight)})\n"
+                    f"observe height({num(height)})\n"
+                    f"let answer = {formula_of[key]}\n"
+                    "? answer\n"
+                ),
+                "answer_from": {"type": "compute_dimensioned", "name": "answer"},
+                "options": options,
+                "gold_letter": LETTERS[gold_pos],
+            })
+            idx += 1
+    return {
+        "description": (
+            "ADJ-LADDER rung 30 — body mass index from a single anthropometric measurement (a NEW panel: "
+            "anthropometric / nutritional). From two stated quantities (body weight WEIGHT in kg, height "
+            "HEIGHT in m) compute the body mass index (WEIGHT/(HEIGHT*HEIGHT)), the weight-to-height ratio "
+            "(WEIGHT/HEIGHT), or height squared (HEIGHT*HEIGHT). Each item is a compute_dimensioned program "
+            "(observe the two quantities, let answer = formula); the ADJ engine carries the arithmetic — a "
+            "NEW shape, a quantity DIVIDED BY A SQUARE (WEIGHT/(HEIGHT*HEIGHT)), so a PRODUCT in the "
+            "denominator is contrasted with a plain division — and the harness matches the scalar to the "
+            "printed options. Contamination-safe: every index is built only from the two observed "
+            "quantities via * and / — no constant leaks (metric BMI is exactly kg/m^2), and HEIGHT appears "
+            "twice only as the observed identifier — and the observed quantities carry digit-free "
+            "identifiers so no numeral hides inside a variable name. The five options are a family over the "
+            "same quantities, so the distractors are exactly the slips students make: the inverted BMI "
+            "((HEIGHT*HEIGHT)/WEIGHT) and the weight-times-height product (WEIGHT*HEIGHT, multiplying "
+            "instead of dividing). The core confusion tested is remembering to square the height before "
+            "dividing (the classic WEIGHT/HEIGHT slip)."
+        ),
+        "items": items,
+    }
+
+
+if __name__ == "__main__":
+    doc = build()
+    with open("items.json", "w") as f:
+        json.dump(doc, f, indent=2)
+        f.write("\n")
+    print("wrote items.json:", len(doc["items"]), "items")
+    for it in doc["items"]:
+        print(it["id"], it["qtype"], "gold", it["gold_letter"],
+              "=", round(it["options"][it["gold_letter"]]["value"], 4))

--- a/code/specs/data/adj-ladder/rung30_body_mass_index/items.json
+++ b/code/specs/data/adj-ladder/rung30_body_mass_index/items.json
@@ -1,0 +1,698 @@
+{
+  "description": "ADJ-LADDER rung 30 \u2014 body mass index from a single anthropometric measurement (a NEW panel: anthropometric / nutritional). From two stated quantities (body weight WEIGHT in kg, height HEIGHT in m) compute the body mass index (WEIGHT/(HEIGHT*HEIGHT)), the weight-to-height ratio (WEIGHT/HEIGHT), or height squared (HEIGHT*HEIGHT). Each item is a compute_dimensioned program (observe the two quantities, let answer = formula); the ADJ engine carries the arithmetic \u2014 a NEW shape, a quantity DIVIDED BY A SQUARE (WEIGHT/(HEIGHT*HEIGHT)), so a PRODUCT in the denominator is contrasted with a plain division \u2014 and the harness matches the scalar to the printed options. Contamination-safe: every index is built only from the two observed quantities via * and / \u2014 no constant leaks (metric BMI is exactly kg/m^2), and HEIGHT appears twice only as the observed identifier \u2014 and the observed quantities carry digit-free identifiers so no numeral hides inside a variable name. The five options are a family over the same quantities, so the distractors are exactly the slips students make: the inverted BMI ((HEIGHT*HEIGHT)/WEIGHT) and the weight-times-height product (WEIGHT*HEIGHT, multiplying instead of dividing). The core confusion tested is remembering to square the height before dividing (the classic WEIGHT/HEIGHT slip).",
+  "items": [
+    {
+      "id": "r30bmi-01",
+      "qtype": "body_mass_index",
+      "stem": "A patient weighs 72 kg and is 1.8 m tall. What is the patient's body mass index?",
+      "program": "observe weight(72)\nobserve height(1.8)\nlet answer = weight / (height * height)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 22.22222222222222,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 40.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 3.24,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.045000000000000005,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 129.6,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r30bmi-02",
+      "qtype": "body_mass_index",
+      "stem": "A patient weighs 72 kg and is 1.8 m tall. What is the patient's weight-to-height ratio?",
+      "program": "observe weight(72)\nobserve height(1.8)\nlet answer = weight / height\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 22.22222222222222,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 40.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 3.24,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.045000000000000005,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 129.6,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r30bmi-03",
+      "qtype": "body_mass_index",
+      "stem": "A patient weighs 72 kg and is 1.8 m tall. What is the patient's height squared?",
+      "program": "observe weight(72)\nobserve height(1.8)\nlet answer = height * height\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 22.22222222222222,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 40.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 3.24,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.045000000000000005,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 129.6,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r30bmi-04",
+      "qtype": "body_mass_index",
+      "stem": "A patient weighs 80 kg and is 2 m tall. What is the patient's body mass index?",
+      "program": "observe weight(80)\nobserve height(2)\nlet answer = weight / (height * height)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 40.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 4.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.05,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 20.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 160.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r30bmi-05",
+      "qtype": "body_mass_index",
+      "stem": "A patient weighs 80 kg and is 2 m tall. What is the patient's weight-to-height ratio?",
+      "program": "observe weight(80)\nobserve height(2)\nlet answer = weight / height\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 20.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 4.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.05,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 160.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 40.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r30bmi-06",
+      "qtype": "body_mass_index",
+      "stem": "A patient weighs 80 kg and is 2 m tall. What is the patient's height squared?",
+      "program": "observe weight(80)\nobserve height(2)\nlet answer = height * height\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 4.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 20.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 40.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.05,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 160.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r30bmi-07",
+      "qtype": "body_mass_index",
+      "stem": "A patient weighs 90 kg and is 1.8 m tall. What is the patient's body mass index?",
+      "program": "observe weight(90)\nobserve height(1.8)\nlet answer = weight / (height * height)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 50.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 27.777777777777775,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 3.24,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.036000000000000004,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 162.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r30bmi-08",
+      "qtype": "body_mass_index",
+      "stem": "A patient weighs 90 kg and is 1.8 m tall. What is the patient's weight-to-height ratio?",
+      "program": "observe weight(90)\nobserve height(1.8)\nlet answer = weight / height\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 27.777777777777775,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 3.24,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 50.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.036000000000000004,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 162.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r30bmi-09",
+      "qtype": "body_mass_index",
+      "stem": "A patient weighs 90 kg and is 1.8 m tall. What is the patient's height squared?",
+      "program": "observe weight(90)\nobserve height(1.8)\nlet answer = height * height\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 27.777777777777775,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 50.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.036000000000000004,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 3.24,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 162.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r30bmi-10",
+      "qtype": "body_mass_index",
+      "stem": "A patient weighs 60 kg and is 1.5 m tall. What is the patient's body mass index?",
+      "program": "observe weight(60)\nobserve height(1.5)\nlet answer = weight / (height * height)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 40.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2.25,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.0375,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 90.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 26.666666666666668,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r30bmi-11",
+      "qtype": "body_mass_index",
+      "stem": "A patient weighs 60 kg and is 1.5 m tall. What is the patient's weight-to-height ratio?",
+      "program": "observe weight(60)\nobserve height(1.5)\nlet answer = weight / height\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 40.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 26.666666666666668,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 2.25,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.0375,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 90.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r30bmi-12",
+      "qtype": "body_mass_index",
+      "stem": "A patient weighs 60 kg and is 1.5 m tall. What is the patient's height squared?",
+      "program": "observe weight(60)\nobserve height(1.5)\nlet answer = height * height\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 26.666666666666668,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2.25,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 40.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.0375,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 90.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r30bmi-13",
+      "qtype": "body_mass_index",
+      "stem": "A patient weighs 100 kg and is 2 m tall. What is the patient's body mass index?",
+      "program": "observe weight(100)\nobserve height(2)\nlet answer = weight / (height * height)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 50.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 4.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 25.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.04,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 200.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r30bmi-14",
+      "qtype": "body_mass_index",
+      "stem": "A patient weighs 100 kg and is 2 m tall. What is the patient's weight-to-height ratio?",
+      "program": "observe weight(100)\nobserve height(2)\nlet answer = weight / height\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 25.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 4.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.04,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 50.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 200.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r30bmi-15",
+      "qtype": "body_mass_index",
+      "stem": "A patient weighs 100 kg and is 2 m tall. What is the patient's height squared?",
+      "program": "observe weight(100)\nobserve height(2)\nlet answer = height * height\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 25.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 50.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.04,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 200.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 4.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r30bmi-16",
+      "qtype": "body_mass_index",
+      "stem": "A patient weighs 50 kg and is 1.6 m tall. What is the patient's body mass index?",
+      "program": "observe weight(50)\nobserve height(1.6)\nlet answer = weight / (height * height)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 19.531249999999996,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 31.25,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 2.5600000000000005,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.05120000000000001,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 80.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r30bmi-17",
+      "qtype": "body_mass_index",
+      "stem": "A patient weighs 50 kg and is 1.6 m tall. What is the patient's weight-to-height ratio?",
+      "program": "observe weight(50)\nobserve height(1.6)\nlet answer = weight / height\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 19.531249999999996,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 31.25,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 2.5600000000000005,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.05120000000000001,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 80.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r30bmi-18",
+      "qtype": "body_mass_index",
+      "stem": "A patient weighs 50 kg and is 1.6 m tall. What is the patient's height squared?",
+      "program": "observe weight(50)\nobserve height(1.6)\nlet answer = height * height\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 19.531249999999996,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 31.25,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 2.5600000000000005,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.05120000000000001,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 80.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r30bmi-19",
+      "qtype": "body_mass_index",
+      "stem": "A patient weighs 77 kg and is 1.75 m tall. What is the patient's body mass index?",
+      "program": "observe weight(77)\nobserve height(1.75)\nlet answer = weight / (height * height)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 44.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 3.0625,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.03977272727272727,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 25.142857142857142,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 134.75,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r30bmi-20",
+      "qtype": "body_mass_index",
+      "stem": "A patient weighs 77 kg and is 1.75 m tall. What is the patient's weight-to-height ratio?",
+      "program": "observe weight(77)\nobserve height(1.75)\nlet answer = weight / height\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 25.142857142857142,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 3.0625,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.03977272727272727,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 134.75,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 44.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r30bmi-21",
+      "qtype": "body_mass_index",
+      "stem": "A patient weighs 77 kg and is 1.75 m tall. What is the patient's height squared?",
+      "program": "observe weight(77)\nobserve height(1.75)\nlet answer = height * height\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3.0625,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 25.142857142857142,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 44.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.03977272727272727,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 134.75,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    }
+  ]
+}

--- a/code/specs/data/adj-ladder/test_ladder_eval.py
+++ b/code/specs/data/adj-ladder/test_ladder_eval.py
@@ -67,6 +67,7 @@ SELF_CONTAINED_RUNGS = (
     "rung27_urine_anion_gap",
     "rung28_coagulation_ratios",
     "rung29_serum_protein_indices",
+    "rung30_body_mass_index",
 )
 
 


### PR DESCRIPTION
## What

Adds **rung-30** to the ADJ-LADDER: body mass index from a single anthropometric measurement — a NEW panel (**anthropometric / nutritional**). From two observed quantities (body weight `WEIGHT` in kg, height `HEIGHT` in m), compute one of:

| index | formula |
|---|---|
| body mass index | `WEIGHT / (HEIGHT * HEIGHT)` (BMI, kg/m²) |
| weight:height ratio | `WEIGHT / HEIGHT` |
| height squared | `HEIGHT * HEIGHT` |

plus two slip distractors: the inverted BMI `(HEIGHT*HEIGHT)/WEIGHT` and the weight-times-height product `WEIGHT*HEIGHT`. Five-member confusable family, gold rotates A–E.

## Why this rung

**New arithmetic shape for the ladder**: a quantity **divided by a square** — `WEIGHT/(HEIGHT*HEIGHT)` — a **product in the denominator**, contrasted with a plain division. Earlier rungs divided by a difference (rung-29) or a single quantity; this squares the height first. Core confusion tested: remembering to **square the height** before dividing (the classic `WEIGHT/HEIGHT` slip).

## Contamination-safety

Every formula is built **only** from the two observed quantities via `*`, `/` — **no numeric literal in any program** (metric BMI is exactly kg/m², no constant) — and `HEIGHT` appears twice only as the observed *identifier*, not a numeral. Digit-free identifiers (`weight` / `height`). Family values asserted **pairwise-distinct** (margin) per item at build time.

## Tests

7 tables × 3 queried = **21 items**. Registered in `SELF_CONTAINED_RUNGS`; all 3 gate tests pass (0 wrong / 0 abstain, contamination-clean, items.json valid).

🤖 Generated with [Claude Code](https://claude.com/claude-code)