### PR TITLE
[codex] test(html-parser): pin fragment context repair evidence

### DIFF
--- a/code/packages/rust/html-parser/tests/whatwg_fragment_context_audit_test.rs
+++ b/code/packages/rust/html-parser/tests/whatwg_fragment_context_audit_test.rs
@@ -7,6 +7,24 @@ use std::collections::{BTreeMap, HashMap};
 const TREE_CONSTRUCTION_SMOKE: &str = include_str!("fixtures/html5lib-tree-construction-smoke.dat");
 const WHATWG_FRAGMENT_CONTEXT_AUDIT: &str =
     include_str!("fixtures/whatwg-fragment-context-audit.json");
+const POST_PARSE_REPAIR_EVIDENCE: &[(&str, &str, &str)] = &[
+    ("tests4-dat-1", "div", "fragment-basic-context"),
+    ("tests4-dat-2", "textarea", "fragment-text-mode-context"),
+    ("tests4-dat-6", "html", "fragment-shell-context"),
+    ("tests6-dat-7", "div", "fragment-block-context"),
+    ("tests6-dat-18", "caption", "fragment-table-context"),
+    (
+        "tests-innerhtml-1-dat-75",
+        "select",
+        "fragment-select-context",
+    ),
+    (
+        "foreign-fragment-dat-1",
+        "svg path",
+        "fragment-foreign-context",
+    ),
+    ("template-dat-109", "template", "fragment-template-context"),
+];
 
 #[derive(Debug, Deserialize)]
 struct FragmentContextAuditSuite {
@@ -80,6 +98,55 @@ fn whatwg_fragment_context_audit_cases_match_parser_dom_dump() {
             actual, source_case.document,
             "case `{}` ({}) failed for input {:?}",
             case.id, case.axis, source_case.data
+        );
+    }
+}
+
+#[test]
+fn whatwg_fragment_context_audit_tracks_post_parse_repair_evidence() {
+    let suite = load_suite();
+    let audit_cases = suite
+        .cases
+        .iter()
+        .map(|case| (case.id.as_str(), case))
+        .collect::<HashMap<_, _>>();
+    let smoke_cases = parse_tree_construction_cases(TREE_CONSTRUCTION_SMOKE)
+        .into_iter()
+        .map(|case| (case.source.clone(), case))
+        .collect::<HashMap<_, _>>();
+
+    for (case_id, expected_context, expected_axis) in POST_PARSE_REPAIR_EVIDENCE {
+        let audit_case = audit_cases.get(case_id).unwrap_or_else(|| {
+            panic!("post-parse repair evidence case `{case_id}` should be audited")
+        });
+        assert_eq!(
+            audit_case.context, *expected_context,
+            "post-parse repair evidence case `{case_id}` should keep its focused fragment context"
+        );
+        assert_eq!(
+            audit_case.axis, *expected_axis,
+            "post-parse repair evidence case `{case_id}` should stay on its focused audit axis"
+        );
+
+        let source_case = smoke_cases
+            .get(&audit_case.source)
+            .unwrap_or_else(|| panic!("case `{case_id}` should exist in smoke fixture"));
+        assert_eq!(
+            source_case.fragment_context.as_deref(),
+            Some(*expected_context),
+            "post-parse repair evidence case `{case_id}` should keep its smoke fragment context"
+        );
+        let actual = actual_dom_dump_for_tree_case(source_case).unwrap_or_else(|error| {
+            panic!(
+                "case `{}` ({}) parse failed: {error}",
+                audit_case.id, audit_case.axis
+            )
+        });
+
+        assert_eq!(
+            actual, source_case.document,
+            "post-parse repair evidence case `{}` ({}) failed for input {:?}",
+            audit_case.id, audit_case.axis, source_case.data
         );
     }
 }


### PR DESCRIPTION
## Summary

- Add explicit post-parse repair evidence coverage to the WHATWG fragment-context parser audit.
- Pin one representative case for each fragment-context axis, including table, foreign-content, shell, text-mode, block, select, basic, and template contexts.
- Assert both the focused audit axis and the fragment context string before rechecking the parser DOM dump against the smoke fixture.

## Validation

From `code/packages/rust`:

- `cargo test -p coding-adventures-html-parser font_newline_before_bold_stays_outside_reconstructed_font`
- `cargo test -p coding-adventures-html-parser whatwg_document_shell_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_head_body_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_form_interactive_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_legacy_element_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_paragraph_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_block_boundary_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_table_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_formatting_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_text_control_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_ruby_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_list_item_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_template_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_select_list_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_frameset_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_foreign_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_void_element_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_noscript_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_fragment_context_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_document_shell_audit_cases_match_parser_dom_dump`
- `cargo test -p coding-adventures-html-parser whatwg_head_body_audit_cases_match_parser_dom_dump`
- `cargo test -p coding-adventures-html-parser whatwg_form_interactive_audit_cases_match_parser_dom_dump`
- `cargo test -p coding-adventures-html-parser whatwg_table_audit_cases_match_parser_dom_dump`
- `cargo test -p coding-adventures-html-parser whatwg_formatting_audit_cases_match_parser_dom_dump`
- `cargo test -p coding-adventures-html-parser whatwg_paragraph_audit_cases_match_parser_dom_dump`
- `cargo test -p coding-adventures-html-parser whatwg_text_control_audit_cases_match_parser_dom_dump`
- `cargo test -p coding-adventures-html-parser whatwg_block_boundary_audit_cases_match_parser_dom_dump`
- `cargo test -p coding-adventures-html-parser whatwg_select_list_audit_cases_match_parser_dom_dump`
- `cargo test -p coding-adventures-html-parser whatwg_frameset_audit_cases_match_parser_dom_dump`
- `cargo test -p coding-adventures-html-parser whatwg_foreign_audit_cases_match_parser_dom_dump`
- `cargo test -p coding-adventures-html-parser whatwg_void_element_audit_cases_match_parser_dom_dump`
- `cargo test -p coding-adventures-html-parser whatwg_noscript_audit_cases_match_parser_dom_dump`
- `cargo test -p coding-adventures-html-parser whatwg_fragment_context_audit_cases_match_parser_dom_dump`
- `cargo test -p coding-adventures-html-parser html5lib_tree_construction_smoke_cases_match_dom_dump`
- `cargo test -p coding-adventures-html-parser`
- `CARGO_BUILD_JOBS=2 cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser`

From the worktree root:

- `python3 -m json.tool code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json >/dev/null`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py`
- `git diff --check`