### PR TITLE
feat(adj-lang): nth root \sqrt[n]{x} → x^(1/n) in latex "…"

### DIFF
--- a/code/packages/rust/adj-lang/CHANGELOG.md
+++ b/code/packages/rust/adj-lang/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [0.22.0] - 2026-07-01 — nth root `\sqrt[n]{x}` in `latex "…"` (lowers to `x ^ (1/n)`)
+
+### Added
+
+- The `latex "…"` adapter now accepts an **nth root** `\sqrt[n]{x}` (a
+  `MathExpr::Root` *with* an explicit degree), lowering it to `x ^ (1/n)` on the
+  native `ComputeOp::Pow` — the reciprocal exponent `1/n` is computed once at
+  adapt time and emitted as a single `Lit`. The cube root `\sqrt[3]{27}`
+  computes `27 ^ (1/3) = 3`; the fourth root `\sqrt[4]{16}` computes `2`. This
+  completes the radical family alongside the square root `\sqrt{x}` (0.21.0):
+  both reuse the one power engine, so no new engine op is needed.
+- The degree `n` must be a **positive integer** literal (`\sqrt[3]{…}`,
+  `\sqrt[4]{…}`). A symbolic degree (`\sqrt[k]{…}`) has no numeric value and a
+  zero degree would make `1/0` undefined, so both are rejected at adapt time
+  (`UnsupportedLatexMath`), never silently mislowered.
+
+### Notes
+
+- As with the square root, a fractional-power base carries the engine's own
+  dimensional rule: a `Scalar` (dimensionless) base computes cleanly, and a
+  dimensioned base (a `\sqrt[3]{dollars}` has no representable third-dimension)
+  is a `DimensionMismatch`, not a silently-wrong number. An nth-root *constraint*
+  (`constrain latex "$\sqrt[3]{x} = 3$"`) is non-polynomial (a fractional
+  exponent), so the solver treats it as `Unknown`, as before.
+
 ## [0.21.0] - 2026-07-01 — `\sqrt{x}` in `latex "…"` (lowers to `x ^ 0.5`)
 
 ### Added

--- a/code/packages/rust/adj-lang/Cargo.toml
+++ b/code/packages/rust/adj-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang"
-version = "0.21.0"
+version = "0.22.0"
 edition = "2021"
 description = "Surface-syntax frontend for the adjudication framework's probabilistic-logic rulebooks. Lexes, parses, and lowers a domain-expert-readable DSL into a `logic-engine` KnowledgeBase. Dissolves ADJ46 awkwardness items A10 (rulebook syntax) and A4 (joint contributions syntactically distinct)."
 

--- a/code/packages/rust/adj-lang/src/adapter.rs
+++ b/code/packages/rust/adj-lang/src/adapter.rs
@@ -951,8 +951,7 @@ fn latex_math_to_expr_ast(expr: &MathExpr, source: &str) -> Result<ExprAst, Adap
         // `x ^ 0.5`, reusing the native `ComputeOp::Pow`. The engine computes it
         // for a dimensionless (Scalar) base — `√9 = 3` — and cleanly rejects a
         // dimensioned base (a `√dollars` has no representable half-dimension), so
-        // no new engine op is needed. An nth root `\sqrt[n]{x}` (degree present)
-        // is a later slice: its `1/n` exponent needs its own non-integer path.
+        // no new engine op is needed.
         MathExpr::Root {
             degree: None,
             radicand,
@@ -961,6 +960,26 @@ fn latex_math_to_expr_ast(expr: &MathExpr, source: &str) -> Result<ExprAst, Adap
             Box::new(latex_math_to_expr_ast(radicand, source)?),
             Box::new(ExprAst::Lit(0.5)),
         )),
+        // An nth root `\sqrt[n]{x}` (degree present) lowers to `x ^ (1/n)`, again
+        // reusing the native `ComputeOp::Pow` — the cube root `\sqrt[3]{27}`
+        // computes `27 ^ (1/3) = 3`. The degree `n` must be a *positive integer*
+        // literal (`\sqrt[3]{…}`, `\sqrt[4]{…}`); a symbolic degree (`\sqrt[k]{…}`)
+        // and a non-positive degree are rejected. The fractional exponent `1/n` is
+        // computed once at adapt time and emitted as a single `Lit`, so — exactly
+        // like the square root — the engine sees one `Pow` node and applies its own
+        // dimensional rule (a fractional power of a dimensioned base has no
+        // representable dimension and is rejected; a Scalar base computes cleanly).
+        MathExpr::Root {
+            degree: Some(degree),
+            radicand,
+        } => {
+            let n = latex_root_degree(degree, source)?;
+            Ok(ExprAst::Bin(
+                ArithOp::Pow,
+                Box::new(latex_math_to_expr_ast(radicand, source)?),
+                Box::new(ExprAst::Lit(1.0 / n)),
+            ))
+        }
         MathExpr::Rel(_, _, _) => Err(AdapterError::UnsupportedLatexMath {
             source: source.to_string(),
             detail: "relation-valued LaTeX is only valid in `constrain latex`".into(),
@@ -1028,6 +1047,36 @@ fn latex_power_exponent(expr: &MathExpr, source: &str) -> Result<f64, AdapterErr
         return Err(AdapterError::UnsupportedLatexMath {
             source: source.to_string(),
             detail: "only non-negative integer exponents are supported".into(),
+        });
+    }
+    Ok(v)
+}
+
+/// Validate an nth-root degree (`n` in `\sqrt[n]{x}`) and return it as a
+/// whole-number `f64`, so the caller can build the reciprocal exponent `1/n`. The
+/// degree must be a **positive integer literal** (`\sqrt[3]{…}`, `\sqrt[4]{…}`): a
+/// symbolic degree (`\sqrt[k]{…}`) has no numeric value, and a zero or negative
+/// degree has no root meaning (a `1/0` exponent is undefined). We reuse the same
+/// finite/integer discipline as `latex_power_exponent`, but exclude `0` (the
+/// exponent's denominator) — `n ≥ 1`, so `\sqrt[1]{x}` degenerates cleanly to
+/// `x^1 = x`, and `\sqrt[3]{27}` becomes `27^(1/3) = 3`.
+fn latex_root_degree(expr: &MathExpr, source: &str) -> Result<f64, AdapterError> {
+    let MathExpr::Number(n) = expr else {
+        return Err(AdapterError::UnsupportedLatexMath {
+            source: source.to_string(),
+            detail: "only a positive integer root degree is supported in ADJ arithmetic".into(),
+        });
+    };
+    let Some(v) = n.to_f64() else {
+        return Err(AdapterError::UnsupportedLatexMath {
+            source: source.to_string(),
+            detail: format!("root degree is outside f64 range: {}", n.as_written()),
+        });
+    };
+    if !(v.is_finite() && v.fract() == 0.0 && v >= 1.0) {
+        return Err(AdapterError::UnsupportedLatexMath {
+            source: source.to_string(),
+            detail: "only a positive integer root degree is supported".into(),
         });
     }
     Ok(v)

--- a/code/packages/rust/adj-lang/src/lower.rs
+++ b/code/packages/rust/adj-lang/src/lower.rs
@@ -1786,6 +1786,61 @@ contributes 1000000 from answer == 60 to correct
     }
 
     #[test]
+    fn native_latex_cube_root_computes() {
+        // `\sqrt[3]{27}` lowers to `27 ^ (1/3)` (reusing ComputeOp::Pow) and
+        // computes 3 for a dimensionless base — the nth-root slice on top of the
+        // square root: a degree present emits the reciprocal exponent `1/n`.
+        let d = crate::compile_and_decide(
+            "let answer = latex \"$\\sqrt[3]{27}$\"\n\
+             prior 0.10 for correct\n\
+             contributes 1000000 from answer == 3 to correct\n\
+             ? correct\n",
+        )
+        .unwrap();
+        assert!(d.ranked[0].posterior > 0.99, "{d:?}");
+    }
+
+    #[test]
+    fn native_latex_fourth_root_of_an_observed_scalar_computes() {
+        // `\sqrt[4]{x}` over an observed dimensionless value: the fourth root of
+        // 16 is 2 (16 ^ (1/4) = 2).
+        let d = crate::compile_and_decide(
+            "observe x(16)\n\
+             let answer = latex \"$\\sqrt[4]{x}$\"\n\
+             prior 0.10 for correct\n\
+             contributes 1000000 from answer == 2 to correct\n\
+             ? correct\n",
+        )
+        .unwrap();
+        assert!(d.ranked[0].posterior > 0.99, "{d:?}");
+    }
+
+    #[test]
+    fn native_latex_symbolic_root_degree_is_rejected() {
+        // `\sqrt[k]{x}` — a symbolic degree has no numeric value, so the reciprocal
+        // exponent `1/k` cannot be formed. It must be rejected, not silently
+        // mislowered.
+        let err = compile(
+            "observe x(16)\n\
+             let answer = latex \"$\\sqrt[k]{x}$\"\n\
+             ? answer\n",
+        );
+        assert!(err.is_err(), "symbolic root degree must be rejected: {err:?}");
+    }
+
+    #[test]
+    fn native_latex_zero_root_degree_is_rejected() {
+        // `\sqrt[0]{x}` — a zero degree would make the exponent `1/0` undefined, so
+        // it is rejected at adapt time (positive integer degrees only).
+        let err = compile(
+            "observe x(16)\n\
+             let answer = latex \"$\\sqrt[0]{x}$\"\n\
+             ? answer\n",
+        );
+        assert!(err.is_err(), "zero root degree must be rejected: {err:?}");
+    }
+
+    #[test]
     fn all_relational_operators_parse() {
         for (src, want) in [
             ("constrain a >= 1", crate::ast::RelOp::Ge),


### PR DESCRIPTION
## What

Completes the **radical family** in the `latex "…"` adapter: an **nth root** `\sqrt[n]{x}` (a `MathExpr::Root` *with* an explicit degree) now lowers to `x ^ (1/n)` on the native `ComputeOp::Pow`, reusing the same power engine as the square root `\sqrt{x}` (shipped in adj-lang 0.21). No new engine op.

- Cube root `\sqrt[3]{27}` computes `27 ^ (1/3) = 3`.
- Fourth root `\sqrt[4]{16}` computes `2`.

## How

- New adapter arm `MathExpr::Root { degree: Some(degree), radicand }` → `Bin(Pow, radicand, Lit(1.0/n))`.
- New `latex_root_degree` helper validates the degree as a **positive integer literal** (finite, whole, `>= 1`). A symbolic degree (`\sqrt[k]{x}`) has no numeric value and a zero degree would make `1/0` undefined — both are rejected as `UnsupportedLatexMath`, never silently mislowered. The `n >= 1` floor guarantees `1/n` is always finite in `(0, 1]`.
- The reciprocal exponent `1/n` is computed once at adapt time and emitted as a single `Lit`, so the derivation tree is **O(1)** regardless of `n` (no expansion DoS).

## Semantics

As with the square root, a fractional-power base carries the engine's own **dimensional rule**: a `Scalar` (dimensionless) base computes cleanly, a dimensioned base is a `DimensionMismatch` (a `\sqrt[3]{dollars}` has no representable third-dimension). An nth-root *constraint* stays non-polynomial (`Unknown` to the solver), as before.

## Tests

`cargo test -p adj-lang -p adj-constraint-solver -p adj-lang-cli -p adjudication-pipeline` all green. New tests: cube-root=3, fourth-root-of-16=2, and rejection of the symbolic (`\sqrt[k]{x}`) and zero-degree (`\sqrt[0]{x}`) cases.

Security-reviewed (Rust): PASSED — division-by-zero and Inf/NaN provably excluded by the `n >= 1` + `is_finite` gate; no unbounded expansion; no panics on untrusted input.

adj-lang 0.21 → 0.22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)