### PR TITLE
feat(visicalc-deno): VisiCalc on Deno Desktop (10th backend, WASM engine)

### DIFF
--- a/code/programs/typescript/visicalc-deno/.gitignore
+++ b/code/programs/typescript/visicalc-deno/.gitignore
@@ -1,0 +1,5 @@
+# Compiled `deno desktop` output (rebuilt by `deno desktop`, like other demos'
+# build artifacts) and any local Deno cache.
+*.app/
+*.dylib
+.deno/

--- a/code/programs/typescript/visicalc-deno/BUILD
+++ b/code/programs/typescript/visicalc-deno/BUILD
@@ -1,0 +1,8 @@
+# visicalc-deno — VisiCalc on Deno Desktop (WASM engine path).
+#
+# No build step / dependencies to install: Deno resolves the two embedded assets
+# from the sibling ../visicalc-html at compile time.
+#
+#   deno task desktop   # open a dev window (deno desktop -A main.ts)
+#   deno task build     # compile a self-contained VisiCalc.app
+#   deno task dev       # server only; open http://localhost:8791

--- a/code/programs/typescript/visicalc-deno/CHANGELOG.md
+++ b/code/programs/typescript/visicalc-deno/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## 0.1.0
+
+- Initial VisiCalc host on **Deno Desktop** (Deno 2.9 `deno desktop`) — the tenth
+  cross-backend host. Serves the engine-backed web VisiCalc (the HTML demo's
+  `index.html` + the WASM `spreadsheet-core` engine) via `Deno.serve()`; `deno
+  desktop` wraps it in a native webview window.
+- Assets (`index.html` + `vendor/spreadsheet-engine-wasm.js`) are embedded via
+  text-import attributes so the compiled `.app` is self-contained (no runtime
+  filesystem dependency on the sibling demo).
+- Verified on macOS: the window renders computed values (E-column row sums, row-5
+  column sums, grand total 169); editing a cell recomputes live.

--- a/code/programs/typescript/visicalc-deno/README.md
+++ b/code/programs/typescript/visicalc-deno/README.md
@@ -1,0 +1,42 @@
+# VisiCalc — Deno Desktop demo
+
+Tenth cross-backend VisiCalc host. Uses **Deno 2.9's `deno desktop`**, which
+bundles your code + the Deno runtime + a webview into one native app per
+platform and opens a window pointed at your `Deno.serve()` handler.
+
+Like the Electron host (which wraps the React bundle), this "wrapper" reuses the
+web VisiCalc — but here the webview is Deno's own, with **zero third-party
+dependencies**. It serves the exact same engine-backed page the HTML demo runs:
+the shared Rust `spreadsheet-core` engine compiled to WebAssembly. The grid shows
+the engine's *computed* values (E-column row sums, row-5 column sums, grand total
+169) and edits recompute live.
+
+## How it fits
+
+```
+code/programs/mosaic/visicalc/{FormulaBar,Grid}.*   (Mosaic UI source)
+        │  mosaic-compile --backend html
+        ▼
+code/programs/typescript/visicalc-html/             (engine-backed web app)
+   index.html + vendor/spreadsheet-engine-wasm.js  ── embedded via text imports ──┐
+                                                                                   ▼
+                                                        main.ts  ── deno desktop ──▶  native window
+```
+
+`index.html` and the one script it loads (`vendor/spreadsheet-engine-wasm.js`,
+the base64-embedded WASM engine) are embedded into `main.ts` via text-import
+attributes, so the compiled `.app` is self-contained.
+
+## Run
+
+```
+deno task desktop   # open a dev window  (deno desktop -A main.ts)
+deno task build     # compile a self-contained VisiCalc.app
+deno task dev       # server only — open http://localhost:8791
+```
+
+## Follow-up
+
+A native-engine variant that loads `libspreadsheet_capi` through `Deno.dlopen`
+(FFI) instead of WASM — mirroring the Qt/Flutter/SwiftUI native-engine path — is
+tracked separately.

--- a/code/programs/typescript/visicalc-deno/deno.json
+++ b/code/programs/typescript/visicalc-deno/deno.json
@@ -1,0 +1,9 @@
+{
+  "name": "@coding-adventures/visicalc-deno",
+  "version": "0.1.0",
+  "tasks": {
+    "dev": "deno run --allow-net main.ts",
+    "desktop": "deno desktop -A main.ts",
+    "build": "deno desktop -A --output VisiCalc.app main.ts"
+  }
+}

--- a/code/programs/typescript/visicalc-deno/main.ts
+++ b/code/programs/typescript/visicalc-deno/main.ts
@@ -1,0 +1,51 @@
+// main.ts — VisiCalc on Deno Desktop (Deno 2.9's `deno desktop`).
+//
+// Tenth cross-backend VisiCalc host. Deno Desktop bundles your code + the Deno
+// runtime + a webview into one native app per platform; `deno desktop main.ts`
+// opens a window pointed at whatever your `Deno.serve()` handler serves (Deno.serve
+// automatically binds to the address the webview navigates to). So this backend
+// serves the SAME engine-backed web VisiCalc the HTML demo runs — the Rust
+// `spreadsheet-core` engine compiled to WebAssembly — and Deno wraps it in a
+// desktop window. Sibling to the Electron host; here the "wrapper" is Deno's
+// built-in webview, with zero third-party dependencies.
+//
+//   Run in a window:   deno desktop -A main.ts
+//   Build an app:      deno desktop -A --output VisiCalc.app main.ts
+//   Server only (dev): deno run --allow-net main.ts   (open http://localhost:8791)
+//
+// The two files the HTML demo needs (its `index.html` and the one script it
+// loads, `vendor/spreadsheet-engine-wasm.js` — the base64-embedded WASM engine)
+// are EMBEDDED here via text-import attributes. That's what makes the compiled
+// `deno desktop` app self-contained: it serves them from memory, so there is no
+// runtime filesystem dependency on the sibling demo's directory (an earlier
+// version read them at runtime and 404'd once compiled, because the source tree
+// isn't inside the app bundle).
+//
+// The FFI variant (loading libspreadsheet_capi via Deno.dlopen instead of WASM)
+// is a follow-up — this is the WASM path, reusing the browser engine as-is.
+
+import indexHtml from "../visicalc-html/index.html" with { type: "text" };
+import engineJs from "../visicalc-html/vendor/spreadsheet-engine-wasm.js" with {
+  type: "text",
+};
+
+// Path → [content-type, body]. index.html loads exactly one asset
+// (`vendor/spreadsheet-engine-wasm.js`); both are embedded above.
+const HTML = "text/html; charset=utf-8";
+const JS = "text/javascript; charset=utf-8";
+const ASSETS: Record<string, [string, string]> = {
+  "/": [HTML, indexHtml],
+  "/index.html": [HTML, indexHtml],
+  "/vendor/spreadsheet-engine-wasm.js": [JS, engineJs],
+};
+
+// `deno desktop` points the webview at this server automatically; a fixed port
+// also lets you open it in a browser during `deno run` dev.
+Deno.serve({ hostname: "127.0.0.1", port: 8791 }, (req: Request): Response => {
+  const { pathname } = new URL(req.url);
+  const hit = ASSETS[pathname];
+  if (hit) {
+    return new Response(hit[1], { headers: { "content-type": hit[0] } });
+  }
+  return new Response("Not found", { status: 404 });
+});


### PR DESCRIPTION
## What

A new cross-backend VisiCalc host using **Deno 2.9's `deno desktop`** — the tenth backend. Deno Desktop bundles your code + the Deno runtime + a webview into one native app per platform and opens a window pointed at your `Deno.serve()` handler. This serves the **same engine-backed web VisiCalc** the HTML demo runs (the Rust `spreadsheet-core` engine compiled to WebAssembly), so the window shows the engine's **computed** values — with **zero third-party dependencies** (Deno's built-in webview, no Electron/CEF).

- `main.ts`: a `Deno.serve()` handler (bound to loopback) returning the demo's `index.html` and the one asset it loads (`vendor/spreadsheet-engine-wasm.js`), both **embedded via text-import attributes** so the compiled `.app` is self-contained. Response bodies come only from a fixed 3-entry asset map keyed by exact pathname — no filesystem reads at request time, no path-traversal surface.
- `deno.json` tasks (`dev`/`desktop`/`build`), README, CHANGELOG, BUILD.

## Verification
On macOS, `deno desktop -A main.ts` builds `visicalc-deno.app` and the webview window renders **computed** values — E-column row sums **38/51/45/35**, row-5 column sums **39/37/40/53**, grand total **169**; editing a cell recomputes live (the HTML demo's engine).

Security review: PASSED — fixed in-memory asset map, exact-key lookup, no request data reflected, no fs/eval/fetch at request time; bound to `127.0.0.1`.

## Follow-up (not in this PR)
A native-engine variant loading `libspreadsheet_capi` via `Deno.dlopen` (FFI) instead of WASM — mirroring the Qt/Flutter native path — is tracked separately (PR-F).

🤖 Generated with [Claude Code](https://claude.com/claude-code)