### PR TITLE
[codex] test(html-parser): pin tree insertion repair evidence

### DIFF
--- a/code/packages/rust/html-parser/tests/whatwg_tree_insertion_audit_test.rs
+++ b/code/packages/rust/html-parser/tests/whatwg_tree_insertion_audit_test.rs
@@ -6,6 +6,21 @@ use std::collections::{BTreeMap, HashMap};
 
 const TREE_CONSTRUCTION_SMOKE: &str = include_str!("fixtures/html5lib-tree-construction-smoke.dat");
 const WHATWG_TREE_INSERTION_AUDIT: &str = include_str!("fixtures/whatwg-tree-insertion-audit.json");
+const POST_PARSE_REPAIR_EVIDENCE: &[(&str, &str, &str)] = &[
+    ("adoption01-dat-1", "adoption01.dat:1", "adoption-agency"),
+    ("tables01-dat-436", "tables01.dat:436", "table-insertion"),
+    ("template-dat-455", "template.dat:455", "template-insertion"),
+    (
+        "tests-innerhtml-1-dat-1",
+        "tests_innerHTML_1.dat:1",
+        "html-fragment",
+    ),
+    (
+        "foreign-fragment-dat-1",
+        "foreign-fragment.dat:1",
+        "foreign-fragment",
+    ),
+];
 
 #[derive(Debug, Deserialize)]
 struct TreeInsertionSuite {
@@ -66,6 +81,50 @@ fn whatwg_tree_insertion_audit_cases_match_parser_dom_dump() {
             actual, source_case.document,
             "case `{}` ({}) failed for input {:?}",
             case.id, case.axis, source_case.data
+        );
+    }
+}
+
+#[test]
+fn whatwg_tree_insertion_audit_tracks_post_parse_repair_evidence() {
+    let suite = load_suite();
+    let audit_cases = suite
+        .cases
+        .iter()
+        .map(|case| (case.id.as_str(), case))
+        .collect::<HashMap<_, _>>();
+    let smoke_cases = parse_tree_construction_cases(TREE_CONSTRUCTION_SMOKE)
+        .into_iter()
+        .map(|case| (case.source.clone(), case))
+        .collect::<HashMap<_, _>>();
+
+    for (case_id, expected_source, expected_axis) in POST_PARSE_REPAIR_EVIDENCE {
+        let audit_case = audit_cases.get(case_id).unwrap_or_else(|| {
+            panic!("post-parse repair evidence case `{case_id}` should be audited")
+        });
+        assert_eq!(
+            audit_case.source, *expected_source,
+            "post-parse repair evidence case `{case_id}` should stay tied to its smoke fixture row"
+        );
+        assert_eq!(
+            audit_case.axis, *expected_axis,
+            "post-parse repair evidence case `{case_id}` should stay on its focused audit axis"
+        );
+
+        let source_case = smoke_cases
+            .get(*expected_source)
+            .unwrap_or_else(|| panic!("case `{case_id}` should exist in smoke fixture"));
+        let actual = actual_dom_dump_for_tree_case(source_case).unwrap_or_else(|error| {
+            panic!(
+                "case `{}` ({}) parse failed: {error}",
+                audit_case.id, audit_case.axis
+            )
+        });
+
+        assert_eq!(
+            actual, source_case.document,
+            "post-parse repair evidence case `{}` ({}) failed for input {:?}",
+            audit_case.id, audit_case.axis, source_case.data
         );
     }
 }


### PR DESCRIPTION
## Summary
- Add post-parse repair evidence coverage to the WHATWG tree insertion audit test.
- Pin representative audited smoke fixture rows for adoption-agency, table insertion, template insertion, HTML fragment, and foreign fragment recovery.
- Assert each evidence case remains tied to its focused audit axis and still matches the parser DOM dump.

## Validation
- `cargo test -p coding-adventures-html-parser font_newline_before_bold_stays_outside_reconstructed_font`
- `cargo test -p coding-adventures-html-parser whatwg_*_audit_tracks_post_parse_repair_evidence` for all existing evidence families plus `whatwg_tree_insertion_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_*_audit_cases_match_parser_dom_dump` for all existing DOM-dump audit families plus `whatwg_tree_insertion_audit_cases_match_parser_dom_dump`
- `cargo test -p coding-adventures-html-parser html5lib_tree_construction_smoke_cases_match_dom_dump`
- `cargo test -p coding-adventures-html-parser`
- `CARGO_BUILD_JOBS=2 cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser`
- `python3 -m json.tool code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json >/dev/null`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py`
- `git diff --check`