### PR TITLE
fix(mosaic-emit-compose): wire HostInput onCommit so formula-bar edits commit

### DIFF
--- a/code/packages/rust/mosaic-emit-compose/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-compose/src/pipeline.rs
@@ -111,6 +111,11 @@ pub fn from_pipeline(
     .unwrap();
     writeln!(
         out,
+        "import androidx.compose.foundation.text.KeyboardActions"
+    )
+    .unwrap();
+    writeln!(
+        out,
         "import androidx.compose.foundation.text.KeyboardOptions"
     )
     .unwrap();
@@ -125,6 +130,7 @@ pub fn from_pipeline(
     writeln!(out, "import androidx.compose.ui.graphics.Color").unwrap();
     writeln!(out, "import androidx.compose.ui.text.TextStyle").unwrap();
     writeln!(out, "import androidx.compose.ui.text.font.FontFamily").unwrap();
+    writeln!(out, "import androidx.compose.ui.text.input.ImeAction").unwrap();
     writeln!(out, "import androidx.compose.ui.text.input.KeyboardType").unwrap();
     writeln!(out, "import androidx.compose.ui.unit.dp").unwrap();
     writeln!(out, "import androidx.compose.ui.unit.sp").unwrap();
@@ -1666,6 +1672,29 @@ fn emit_host_input(
         // satisfy BasicTextField's required parameter — emit a
         // no-op closure.
         writeln!(out, "{inner}onValueChange = {{ }},").unwrap();
+    }
+
+    // onCommit — a payloadless "the user finished editing" event (Enter). Compose
+    // has no free-standing submit on a BasicTextField, so wire it to the soft
+    // keyboard's Done IME action and make the field single-line, so Enter (soft or
+    // hardware keyboard) fires the commit instead of inserting a newline. Without
+    // this the generated field could take keystrokes but never dispatch onCommit —
+    // the host's write-through / recompute was unreachable. Mirrors the SwiftUI
+    // emitter's `.onSubmit { dispatch(.commit) }`.
+    if let Some(emit_name) = find_emit_ref_prop(node, "onCommit") {
+        let case = pascalize(&strip_on_prefix(emit_name));
+        validate_safe_identifier(&case).map_err(PipelineEmitError::UnsafeEmitName)?;
+        writeln!(out, "{inner}singleLine = true,").unwrap();
+        writeln!(
+            out,
+            "{inner}keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),"
+        )
+        .unwrap();
+        writeln!(
+            out,
+            "{inner}keyboardActions = KeyboardActions(onDone = {{ dispatch({component_name}Event.{case}) }}),"
+        )
+        .unwrap();
     }
 
     if let Some(style) = &style {

--- a/code/programs/kotlin/visicalc-android/app/src/main/java/com/example/visicalc/FormulaBar.kt
+++ b/code/programs/kotlin/visicalc-android/app/src/main/java/com/example/visicalc/FormulaBar.kt
@@ -16,20 +16,38 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.Button
+import androidx.compose.material.Checkbox
+import androidx.compose.material.RadioButton
 import androidx.compose.material.Text
+import androidx.compose.material.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 
 sealed class FormulaBarEvent {
-    data class FormulaChange(val value: String) : FormulaBarEvent()
-    data object Commit : FormulaBarEvent()
-    data object Cancel : FormulaBarEvent()
+    abstract val mosaicName: String
+    open val mosaicPayload: Map<String, Any?> = emptyMap()
+    val mosaicEnvelope: Map<String, Any?> get() = mapOf("event" to mosaicName) + mosaicPayload
+    data class FormulaChange(val value: String) : FormulaBarEvent() {
+        override val mosaicName: String = "onFormulaChange"
+        override val mosaicPayload: Map<String, Any?> get() = mapOf("value" to value)
+    }
+    data object Commit : FormulaBarEvent() {
+        override val mosaicName: String = "onCommit"
+    }
+    data object Cancel : FormulaBarEvent() {
+        override val mosaicName: String = "onCancel"
+    }
 }
 
 @Composable
@@ -48,6 +66,13 @@ fun FormulaBar(
         BasicTextField(
             value = formula,
             onValueChange = { v -> dispatch(FormulaBarEvent.FormulaChange(v)) },
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+            keyboardActions = KeyboardActions(onDone = { dispatch(FormulaBarEvent.Commit) }),
+            modifier = Modifier
+                .background(Color.Transparent)
+                .padding(4.dp),
+            textStyle = TextStyle(color = Color(0xFFCCCCCC), fontFamily = FontFamily.Monospace, fontSize = 13.sp),
             enabled = !readOnly,
         )
     }

--- a/code/programs/kotlin/visicalc-android/app/src/main/java/com/example/visicalc/Grid.kt
+++ b/code/programs/kotlin/visicalc-android/app/src/main/java/com/example/visicalc/Grid.kt
@@ -16,21 +16,42 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.Button
+import androidx.compose.material.Checkbox
+import androidx.compose.material.RadioButton
 import androidx.compose.material.Text
+import androidx.compose.material.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 
 sealed class GridEvent {
-    data class Navigate(val row: Double, val col: Double) : GridEvent()
-    data class FormulaChange(val value: String) : GridEvent()
-    data object EditCommit : GridEvent()
-    data object EditCancel : GridEvent()
+    abstract val mosaicName: String
+    open val mosaicPayload: Map<String, Any?> = emptyMap()
+    val mosaicEnvelope: Map<String, Any?> get() = mapOf("event" to mosaicName) + mosaicPayload
+    data class Navigate(val row: Double, val col: Double) : GridEvent() {
+        override val mosaicName: String = "onNavigate"
+        override val mosaicPayload: Map<String, Any?> get() = mapOf("row" to row, "col" to col)
+    }
+    data class FormulaChange(val value: String) : GridEvent() {
+        override val mosaicName: String = "onFormulaChange"
+        override val mosaicPayload: Map<String, Any?> get() = mapOf("value" to value)
+    }
+    data object EditCommit : GridEvent() {
+        override val mosaicName: String = "onEditCommit"
+    }
+    data object EditCancel : GridEvent() {
+        override val mosaicName: String = "onEditCancel"
+    }
 }
 
 @Composable
@@ -66,6 +87,7 @@ fun Grid(
                     Box(
                         modifier = Modifier
                             .width(columnWidths[_kotlinIdxch].dp)
+                            .height(24.dp)
                             .background(Color(0xFF2D2D30))
                             .border(1.dp, Color(0xFF3F3F46)),
                         contentAlignment = Alignment.Center,
@@ -97,6 +119,10 @@ fun Grid(
                                 BasicTextField(
                                     value = editContent,
                                     onValueChange = { v -> dispatch(GridEvent.FormulaChange(v)) },
+                                    singleLine = true,
+                                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                                    keyboardActions = KeyboardActions(onDone = { dispatch(GridEvent.EditCommit) }),
+                                    textStyle = TextStyle(color = if ( r == selectedRow && c == selectedCol ) Color(0xFFFFFFFF) else Color(0xFFCCCCCC), fontFamily = FontFamily.Monospace, fontSize = 12.sp),
                                 )
                             } else {
                                 Text(( v ), color = if ( r == selectedRow && c == selectedCol ) Color(0xFFFFFFFF) else Color(0xFFCCCCCC), fontFamily = FontFamily.Monospace, fontSize = 12.sp)

--- a/code/programs/kotlin/visicalc-compose/src/main/kotlin/generated/FormulaBar.kt
+++ b/code/programs/kotlin/visicalc-compose/src/main/kotlin/generated/FormulaBar.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.Button
 import androidx.compose.material.Checkbox
@@ -28,6 +29,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -64,6 +66,9 @@ fun FormulaBar(
         BasicTextField(
             value = formula,
             onValueChange = { v -> dispatch(FormulaBarEvent.FormulaChange(v)) },
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+            keyboardActions = KeyboardActions(onDone = { dispatch(FormulaBarEvent.Commit) }),
             modifier = Modifier
                 .background(Color.Transparent)
                 .padding(4.dp),

--- a/code/programs/kotlin/visicalc-compose/src/main/kotlin/generated/Grid.kt
+++ b/code/programs/kotlin/visicalc-compose/src/main/kotlin/generated/Grid.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.Button
 import androidx.compose.material.Checkbox
@@ -28,6 +29,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -117,6 +119,9 @@ fun Grid(
                                 BasicTextField(
                                     value = editContent,
                                     onValueChange = { v -> dispatch(GridEvent.FormulaChange(v)) },
+                                    singleLine = true,
+                                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                                    keyboardActions = KeyboardActions(onDone = { dispatch(GridEvent.EditCommit) }),
                                     textStyle = TextStyle(color = if ( r == selectedRow && c == selectedCol ) Color(0xFFFFFFFF) else Color(0xFFCCCCCC), fontFamily = FontFamily.Monospace, fontSize = 12.sp),
                                 )
                             } else {


### PR DESCRIPTION
## What

The Compose emitter lowered a `HostInput`'s `onChange` (→ `onValueChange`) but **dropped `onCommit` entirely**, so the generated `BasicTextField` could take keystrokes but had no way to dispatch the commit event. On **Android and Compose Desktop** the formula bar was effectively read-only — you could type, but the host's write-through / recompute was unreachable. Wired, but not working.

## Fix
When a `HostInput` declares `onCommit`, emit:
```kotlin
singleLine = true,
keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
keyboardActions = KeyboardActions(onDone = { dispatch(<Event>.<Case>) }),
```
so Enter (soft or hardware keyboard) fires the commit — mirroring the SwiftUI emitter's `.onSubmit { dispatch(.commit) }`. Added the `KeyboardActions`/`ImeAction` imports. The interpolated event-case name goes through the existing `validate_safe_identifier` guard. Regenerated the Android + Compose-Desktop `FormulaBar`/`Grid` to match.

## Verification
- All 31 `mosaic-emit-compose` tests pass.
- **Live on a Pixel 9 (API 36) emulator:** typed `100` into A1's formula bar and pressed Enter → the commit fired → **A5 = SUM(A1:A4) recomputed 39 → 124** (B5/C5/D5 unchanged). The Android VisiCalc demo is now interactively editable, not just render-only.

Codegen change only; the generated output is static keyboard-handler code with a validated identifier — no input-handling or injection surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)