### PR TITLE
feat(javascript-ast,closurec): CLOC12.149 — FunctionExpression node + emit + pass handling

### DIFF
--- a/code/packages/rust/closure-emitter/CHANGELOG.md
+++ b/code/packages/rust/closure-emitter/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to the `coding-adventures-closure-emitter` crate will be documented in this file.
 
+## [0.19.0] - 2026-07-01
+
+### Added — CLOC12.149: emit `FunctionExpression`
+
+Adds `emit_function_expression` (the expression sibling of
+`emit_function_declaration`: optional name, and no trailing `;` since a
+function *value* is not a declaration). Tags `FunctionExpression` below
+`PREC_PRIMARY` in `expr_prec` so a call/member parent wraps it
+(`(function(){})()`, `(function(){}).x`), and wraps a leading one in
+`emit_expression_statement` (a statement starting with `function` would
+otherwise parse as a declaration). +5 tests.
+
 ## [0.18.16] - 2026-07-01
 
 ### Test — CodePrinter object-literal port (#88, CLOC12.147)

--- a/code/packages/rust/closure-emitter/Cargo.toml
+++ b/code/packages/rust/closure-emitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-emitter"
-version = "0.18.16"
+version = "0.19.0"
 edition = "2021"
 description = "JavaScript code emitter for the Closure Compiler clone. Per CLOC07's emit contract. Takes a finalized Program + sidecar and produces output JavaScript text + companion source map. Runs after every pass in the pipeline."
 

--- a/code/packages/rust/closure-emitter/src/lib.rs
+++ b/code/packages/rust/closure-emitter/src/lib.rs
@@ -70,7 +70,7 @@ use coding_adventures_javascript_ast::{
     Declaration, DebuggerStatement, DoWhileStatement,
     EmptyStatement, Expression, ExpressionStatement, ForInStatement, ForInit, ForOfStatement,
     ForStatement,
-    FunctionDeclaration,
+    FunctionDeclaration, FunctionExpression,
     FunctionParam, Identifier, IfStatement, LabeledStatement, LogicalExpression, LogicalOperator,
     MemberExpression, NullLiteral, NumericLiteral, ObjectExpression, Program, ProgramItem,
     Property, PropertyKey, PropertyKind, ReturnStatement, Statement, StringLiteral,
@@ -381,7 +381,16 @@ impl<'a> Emitter<'a> {
         // precedence-aware emit at parent_prec = 0, which means no
         // wrapping unless an inner expression has a lower-precedence
         // child that requires it.
-        let needs_paren = matches!(es.expression, Expression::ObjectExpression(_));
+        // A leading `{` parses as a block and a leading `function`
+        // parses as a function *declaration* — both mis-parse a bare
+        // expression statement, so wrap them. (The general "leftmost
+        // token" problem — e.g. a call whose callee is a function
+        // expression — is handled by each child's own precedence wrap;
+        // this covers the direct cases.)
+        let needs_paren = matches!(
+            es.expression,
+            Expression::ObjectExpression(_) | Expression::FunctionExpression(_)
+        );
         self.maybe_map(&es.cv);
         if needs_paren {
             self.write_str("(");
@@ -835,6 +844,59 @@ impl<'a> Emitter<'a> {
         }
     }
 
+    /// Emit a [`FunctionExpression`] — a function in *value* position.
+    ///
+    /// Byte-identical to [`Self::emit_function_declaration`] for the
+    /// `function`/`*`/params/body run, with two deliberate differences:
+    ///
+    /// 1. **`id` is optional.** An anonymous `function () {}` prints no
+    ///    name (`function(){}`); a named one prints it (`function f(){}`).
+    ///    `required_ws()` is only invoked in the named case — it emits a
+    ///    separating space *only when the adjacent tokens would otherwise
+    ///    merge* (`function f`, but `function*f` needs none because `*`
+    ///    already delimits), exactly as the declaration relies on.
+    /// 2. **No trailing `;`.** A function *declaration* appends a
+    ///    normalising `;` after its `}` (gap-030 part B); an expression
+    ///    must not — it is embedded inside a larger expression/statement
+    ///    whose own emitter owns the terminator. Appending one here would
+    ///    corrupt e.g. `f(function(){})` into `f(function(){};)`.
+    ///
+    /// Parenthesisation in the two contexts where a bare
+    /// `function (){}` would be mis-parsed — at the *start* of an
+    /// expression statement (parses as a declaration) and as a *call
+    /// callee* (`function(){}()` is a syntax error) — is handled by the
+    /// precedence machinery: [`expr_prec`] tags `FunctionExpression`
+    /// below `PREC_PRIMARY`, so a call/member parent wraps it, and
+    /// [`Self::emit_expression_statement`] wraps a leading one.
+    fn emit_function_expression(&mut self, f: &FunctionExpression) {
+        self.maybe_map(&f.cv);
+        if f.is_async {
+            self.write_str("async");
+            self.required_ws();
+        }
+        self.write_str("function");
+        if f.generator {
+            self.write_str("*");
+        }
+        if let Some(id) = &f.id {
+            self.required_ws();
+            self.emit_identifier(id);
+        }
+        self.write_str("(");
+        for (i, p) in f.params.iter().enumerate() {
+            if i > 0 {
+                self.write_str(",");
+                self.pretty_ws();
+            }
+            match p {
+                FunctionParam::Identifier(id) => self.emit_identifier(id),
+            }
+        }
+        self.write_str(")");
+        self.pretty_ws();
+        self.emit_block_statement(&f.body);
+    }
+
     // ---- Expressions ---------------------------------------------
 
     /// Public entry: emit an expression assuming the loosest binding
@@ -889,6 +951,7 @@ impl<'a> Emitter<'a> {
             Expression::MemberExpression(m) => self.emit_member(m),
             Expression::ArrayExpression(a) => self.emit_array(a),
             Expression::ObjectExpression(o) => self.emit_object(o),
+            Expression::FunctionExpression(f) => self.emit_function_expression(f),
         }
         if needs_parens {
             self.write_str(")");
@@ -1517,6 +1580,18 @@ fn expr_prec(e: &Expression) -> u8 {
         | Expression::MemberExpression(_) => PREC_PRIMARY,
 
         Expression::UnaryExpression(_) => PREC_UNARY,
+        // A function expression is primary-*ish*, but two contexts
+        // mis-parse a bare one: as a call callee (`function(){}()` is a
+        // syntax error) and as a member object (`function(){}.x`). Tag
+        // it below PREC_PRIMARY (reusing PREC_UNARY, the same trick the
+        // boolean/undefined cases use) so a call/member parent wraps it
+        // into `(function(){})()` / `(function(){}).x`. Operator and
+        // assignment parents bind looser than PREC_UNARY, so
+        // `x=function(){}` and `function(){}+1` stay unwrapped (valid).
+        // The remaining mis-parse — a function expression at the *start*
+        // of an expression statement — is wrapped by
+        // `emit_expression_statement`, not here.
+        Expression::FunctionExpression(_) => PREC_UNARY,
         // `true`/`false` are emitted as `!0`/`!1` (see `emit_boolean`), which
         // are UnaryExpressions — precedence `PREC_UNARY`, NOT primary. Tagging
         // them here is what makes `emit_expression_inner` parenthesise them in
@@ -3603,5 +3678,102 @@ mod tests {
             site: "test",
         };
         assert_error(&e);
+    }
+
+    // ---- FunctionExpression (CLOC12.149) ----------------------
+
+    /// Build a `FunctionExpression` value: `id` name (or anonymous),
+    /// simple identifier params, and a body of statements.
+    fn fexpr(id: Option<&str>, params: &[&str], body: Vec<Statement>) -> Expression {
+        Expression::FunctionExpression(FunctionExpression {
+            cv: None,
+            id: id.map(|n| Identifier { cv: None, name: n.to_string() }),
+            params: params
+                .iter()
+                .map(|p| FunctionParam::Identifier(Identifier { cv: None, name: p.to_string() }))
+                .collect(),
+            body: BlockStatement { cv: None, body },
+            generator: false,
+            is_async: false,
+        })
+    }
+
+    /// An anonymous function expression at the START of an expression
+    /// statement must be parenthesised — a leading `function` otherwise
+    /// parses as a declaration.
+    #[test]
+    fn function_expression_at_statement_start_is_parenthesised() {
+        assert_eq!(emit_expr(fexpr(None, &[], vec![])), "(function(){});");
+    }
+
+    /// An IIFE: the function-expression callee needs parens because
+    /// `function(){}()` is a syntax error.
+    #[test]
+    fn function_expression_iife_wraps_callee() {
+        let iife = Expression::CallExpression(CallExpression {
+            cv: None,
+            callee: Box::new(fexpr(None, &[], vec![])),
+            arguments: vec![],
+        });
+        assert_eq!(emit_expr(iife), "(function(){})();");
+    }
+
+    /// As a call ARGUMENT the function expression needs no parens (the
+    /// argument context is the loosest), and crucially no stray `;` is
+    /// appended after its body `}` — that trailing-`;` normalisation is
+    /// a function *declaration* rule only.
+    #[test]
+    fn function_expression_as_argument_has_no_parens_or_trailing_semi() {
+        let call = Expression::CallExpression(CallExpression {
+            cv: None,
+            callee: Box::new(ident("g")),
+            arguments: vec![fexpr(None, &[], vec![])],
+        });
+        assert_eq!(emit_expr(call), "g(function(){});");
+    }
+
+    /// A *named* function expression prints its name (body-local), and
+    /// params + a return body emit like the declaration form.
+    #[test]
+    fn named_function_expression_with_params_and_body() {
+        let call = Expression::CallExpression(CallExpression {
+            cv: None,
+            callee: Box::new(ident("use")),
+            arguments: vec![fexpr(
+                Some("f"),
+                &["a", "b"],
+                vec![Statement::return_statement(ReturnStatement {
+                    cv: None,
+                    argument: Some(ident("a")),
+                })],
+            )],
+        });
+        // The `;` after the last block statement is dropped in compact
+        // mode (`{return a}`), so the only `;` is the outer statement's.
+        assert_eq!(emit_expr(call), "use(function f(a,b){return a});");
+    }
+
+    /// Generator and async flags render their prefixes (`*` fuses with
+    /// no separating space; `async` needs one).
+    #[test]
+    fn function_expression_generator_and_async_flags() {
+        let mut generator = fexpr(None, &[], vec![]);
+        if let Expression::FunctionExpression(f) = &mut generator {
+            f.generator = true;
+        }
+        assert_eq!(emit_expr(generator), "(function*(){});");
+
+        let async_call = {
+            let mut fe = fexpr(None, &[], vec![]);
+            if let Expression::FunctionExpression(f) = &mut fe {
+                f.is_async = true;
+            }
+            Expression::CallExpression(CallExpression {
+                cv: None,
+                callee: Box::new(ident("h")),
+                arguments: vec![fe],
+            })
+        };
+        assert_eq!(emit_expr(async_call), "h(async function(){});");
     }
 }

--- a/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the `coding-adventures-closure-pass-constant-fold` crate will be documented in this file.
 
+## [0.83.0] - 2026-07-01
+
+### Added — CLOC12.149: fold inside `FunctionExpression` bodies
+
+`fold_expression` now recurses into a `FunctionExpression` body via
+`fold_statement`, exactly as `fold_declaration` does for a
+`FunctionDeclaration`, so constants inside `var f = function(){ return
+1+1; }` fold. The function itself is not a foldable constant.
+
 ## [0.82.0] - 2026-07-01
 
 ### Added — `String#concat` coerces primitive-constant arguments (closes gap-143)

--- a/code/packages/rust/closure-pass-constant-fold/Cargo.toml
+++ b/code/packages/rust/closure-pass-constant-fold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-constant-fold"
-version = "0.82.0"
+version = "0.83.0"
 edition = "2021"
 description = "Constant-folding optimization pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Folds compile-time-evaluable expressions like `2 + 3 → 5`."
 

--- a/code/packages/rust/closure-pass-constant-fold/src/lib.rs
+++ b/code/packages/rust/closure-pass-constant-fold/src/lib.rs
@@ -94,7 +94,7 @@ use coding_adventures_javascript_ast::{
     BinaryOperator, BlockStatement, BooleanLiteral, CallExpression, ConditionalExpression,
     Declaration, Expression, ExpressionStatement, ForInStatement, ForInit, ForOfStatement,
     ForStatement,
-    FunctionDeclaration, Identifier,
+    FunctionDeclaration, FunctionExpression, Identifier,
     IfStatement, LogicalExpression, LogicalOperator, MemberExpression, NullLiteral, NumericLiteral,
     ObjectExpression, Program, ProgramItem, Property, PropertyKey, PropertyKind, ReturnStatement, Statement,
     StringLiteral, UnaryExpression, UnaryOperator, UndefinedLiteral, VariableDeclaration,
@@ -542,6 +542,26 @@ fn fold_expression(expr: &Expression, st: &mut FoldState) -> Expression {
                 })
                 .collect(),
         }),
+
+        // A function *value*: fold constants inside its body exactly as
+        // we do for a `FunctionDeclaration` (see `fold_declaration`).
+        // The function itself is not a foldable constant; we descend so
+        // that `var f = function () { return 1 + 1; }` folds to
+        // `... return 2; ...`. `id`/`params` are structural — passed
+        // through untouched.
+        Expression::FunctionExpression(f) => {
+            Expression::FunctionExpression(FunctionExpression {
+                cv: f.cv.clone(),
+                id: f.id.clone(),
+                params: f.params.clone(),
+                body: BlockStatement {
+                    cv: f.body.cv.clone(),
+                    body: f.body.body.iter().map(|s| fold_statement(s, st)).collect(),
+                },
+                generator: f.generator,
+                is_async: f.is_async,
+            })
+        }
     }
 }
 

--- a/code/packages/rust/closure-pass-dce/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-dce/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the `coding-adventures-closure-pass-dce` crate will be documented in this file.
 
+## [0.18.0] - 2026-07-01
+
+### Added — CLOC12.149: DCE inside `FunctionExpression` bodies
+
+`dce_expression` recurses into a `FunctionExpression` body via
+`dce_block_statement` (mirroring `dce_declaration` for a
+`FunctionDeclaration`), so dead code after a `return`/`throw` inside a
+function value is eliminated.
+
 ## [0.17.0] - 2026-07-01
 
 ### Added — upstream `UnreachableCodeEliminationTest.java` conformance port (#88, CLOC12.148)

--- a/code/packages/rust/closure-pass-dce/Cargo.toml
+++ b/code/packages/rust/closure-pass-dce/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-dce"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 description = "Dead-code elimination pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Drops code after definite-terminator statements and removes EmptyStatement noise."
 

--- a/code/packages/rust/closure-pass-dce/src/lib.rs
+++ b/code/packages/rust/closure-pass-dce/src/lib.rs
@@ -75,7 +75,7 @@ use coding_adventures_javascript_ast::{
     Declaration, EmptyStatement, Expression, ExpressionStatement, ForInStatement, ForInit,
     ForOfStatement,
     ForStatement,
-    FunctionDeclaration, IfStatement, LogicalExpression, MemberExpression, NullLiteral,
+    FunctionDeclaration, FunctionExpression, IfStatement, LogicalExpression, MemberExpression, NullLiteral,
     NumericLiteral, ObjectExpression, Program, ProgramItem, Property, PropertyKey,
     ReturnStatement, Statement, StringLiteral, UnaryExpression, UndefinedLiteral, VarKind,
     DoWhileStatement, VariableDeclaration, VariableDeclarator, WhileStatement,
@@ -1243,6 +1243,18 @@ fn dce_expression(expr: &Expression, st: &mut DceState) -> Expression {
                     method: p.method,
                 })
                 .collect(),
+        }),
+        // Recurse into a function-value's body exactly as `dce_declaration`
+        // does for a `FunctionDeclaration` — dead code after a
+        // `return`/`throw` inside `var f = function(){ return; g(); }`
+        // is just as dead as in a named function.
+        Expression::FunctionExpression(f) => Expression::FunctionExpression(FunctionExpression {
+            cv: f.cv.clone(),
+            id: f.id.clone(),
+            params: f.params.clone(),
+            body: dce_block_statement(&f.body, st),
+            generator: f.generator,
+            is_async: f.is_async,
         }),
     }
 }

--- a/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the `coding-adventures-closure-pass-fold-control-flow` crate will be documented in this file.
 
+## [0.18.0] - 2026-07-01
+
+### Added — CLOC12.149: fold control flow inside `FunctionExpression`
+
+`fold_expression` recurses into a `FunctionExpression` body (fold +
+`var` hoist), mirroring the `FunctionDeclaration` arm; `expression_cv`
+gains a `FunctionExpression` arm so provenance is preserved.
+
 ## [0.17.0] - 2026-06-30
 
 ### Added — CV tombstones for constant-condition ternary collapse (#89 follow-up)

--- a/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
+++ b/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-fold-control-flow"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 description = "Control-flow folding pass for the Closure Compiler clone. Slots between constant-fold and DCE per CLOC06's canonical pass set. Eliminates dead branches (`if (false) A else B → B`), removes unreachable code after `return`/`throw`, and collapses degenerate switch arms."
 

--- a/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
+++ b/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
@@ -58,7 +58,7 @@ use coding_adventures_javascript_ast::{
     statement::TaggedStatement, ArrayExpression, AssignmentExpression, AssignmentOperator,
     AssignmentTarget, BinaryExpression, BindingTarget, BlockStatement, CallExpression,
     ConditionalExpression, Declaration, EmptyStatement, Expression, ExpressionStatement, ForInit,
-    ForInStatement, ForOfStatement, ForStatement, FunctionDeclaration, Identifier, IfStatement,
+    ForInStatement, ForOfStatement, ForStatement, FunctionDeclaration, FunctionExpression, Identifier, IfStatement,
     LogicalExpression,
     LogicalOperator,
     MemberExpression, ObjectExpression, Program, ProgramItem, Property, PropertyKey,
@@ -274,6 +274,7 @@ fn expression_cv(expr: &Expression) -> Option<String> {
         MemberExpression(e) => e.cv.clone(),
         ArrayExpression(e) => e.cv.clone(),
         ObjectExpression(e) => e.cv.clone(),
+        FunctionExpression(e) => e.cv.clone(),
     }
 }
 
@@ -1422,6 +1423,21 @@ fn fold_expression(expr: &Expression, st: &mut FoldState) -> Expression {
                 })
                 .collect(),
         }),
+        // Fold control flow inside a function *value*'s body, mirroring
+        // the `FunctionDeclaration` arm in `fold_declaration` (fold the
+        // body, then hoist its `var`s to the function top).
+        Expression::FunctionExpression(f) => {
+            let folded_body = fold_block_statement(&f.body, st);
+            let hoisted_body = hoist_function_body_vars(&folded_body, st);
+            Expression::FunctionExpression(FunctionExpression {
+                cv: f.cv.clone(),
+                id: f.id.clone(),
+                params: f.params.clone(),
+                body: hoisted_body,
+                generator: f.generator,
+                is_async: f.is_async,
+            })
+        }
     }
 }
 

--- a/code/packages/rust/closure-pass-inline-variables/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-inline-variables/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `coding-adventures-closure-pass-inline-variables` crate will be documented in this file.
 
+## [0.9.0] - 2026-07-01
+
+### Added — CLOC12.149: propagate through `FunctionExpression` bodies
+
+`count_uses_expr` and `propagate_in_expr` now recurse into a
+`FunctionExpression` body (via the `_stmt` helpers), keeping the use
+count and the substitution walk over the same positions. Over-counting
+under param/self-name shadowing is conservative — it only declines an
+inline, never performs a wrong one.
+
 ## [0.8.0] - 2026-07-01
 
 ### Added — upstream `InlineVariablesTest.java` conformance port (#88, CLOC12.146)

--- a/code/packages/rust/closure-pass-inline-variables/Cargo.toml
+++ b/code/packages/rust/closure-pass-inline-variables/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-inline-variables"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 description = "Constant-propagation pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Replaces references to a top-level `const` bound to a literal with the literal itself, so the binding becomes unused and remove-unused-vars deletes it."
 

--- a/code/packages/rust/closure-pass-inline-variables/src/lib.rs
+++ b/code/packages/rust/closure-pass-inline-variables/src/lib.rs
@@ -778,6 +778,16 @@ fn count_uses_expr(expr: &Expression, name: &str, count: &mut usize) {
                 count_uses_expr(&prop.value, name, count);
             }
         }
+        // Count uses of `name` inside a function *value*'s body, exactly
+        // as the `FunctionDeclaration` arm above does. Over-counting
+        // under shadowing (a param or the fn's own name equal to `name`)
+        // is conservative — it only *prevents* an inline, never produces
+        // a wrong one — matching the declaration's existing posture.
+        Expression::FunctionExpression(fe) => {
+            for s in &fe.body.body {
+                count_uses_stmt(s, name, count);
+            }
+        }
     }
 }
 
@@ -1024,6 +1034,15 @@ fn propagate_in_expr(expr: &mut Expression, cand: &ConstCandidate) -> bool {
                     }
                 }
                 changed |= propagate_in_expr(&mut prop.value, cand);
+            }
+        }
+        // Propagate the candidate into a function *value*'s body,
+        // mirroring the `FunctionDeclaration` arm in `propagate_in_decl`.
+        // Kept consistent with `count_uses_expr` above so the use count
+        // and the substitution walk cover the same positions.
+        Expression::FunctionExpression(fe) => {
+            for s in &mut fe.body.body {
+                changed |= propagate_in_stmt(s, cand);
             }
         }
     }

--- a/code/packages/rust/closure-pass-inline/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-inline/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `coding-adventures-closure-pass-inline` crate will be documented in this file.
 
+## [0.23.0] - 2026-07-01
+
+### Added — CLOC12.149: inline across `FunctionExpression` bodies
+
+All seven expression walks gain a `FunctionExpression` arm: use tally,
+call inlining, param mutation detection, node-count budget, binding-ident
+collection, and `substitute`/`rename_in_expr` (the last two remove the
+function's own name/params from the map before recursing, so a shadowed
+reference is left untouched). Sound over function values.
+
 ## [0.22.0] - 2026-06-30
 
 ### Added — CV provenance for inlining (#89)

--- a/code/packages/rust/closure-pass-inline/Cargo.toml
+++ b/code/packages/rust/closure-pass-inline/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-inline"
-version = "0.22.0"
+version = "0.23.0"
 edition = "2021"
 description = "Function-inlining pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Substitutes small or single-use function bodies at their call sites to enable downstream folding and shrink call overhead."
 

--- a/code/packages/rust/closure-pass-inline/src/lib.rs
+++ b/code/packages/rust/closure-pass-inline/src/lib.rs
@@ -472,6 +472,12 @@ fn expr_node_count(expr: &Expression) -> usize {
                 key + expr_node_count(&p.value)
             })
             .sum(),
+        // A function *value* is heavy: count its params and one unit per
+        // body statement. This is only a size heuristic for the multi-use
+        // budget (never a correctness input), and counting the body keeps
+        // a candidate whose value embeds a function from looking
+        // deceptively cheap.
+        Expression::FunctionExpression(fe) => fe.params.len() + fe.body.body.len(),
     }
 }
 
@@ -763,6 +769,20 @@ fn collect_binding_idents_expr(expr: &Expression, out: &mut HashSet<String>) {
                 collect_binding_idents_expr(&prop.value, out);
             }
         }
+        // A function *value* binds its own name (if named) and its params
+        // at its boundary; record them so an inline never captures or
+        // collides with them. (Its body's own `var`/`let`/`const` live in
+        // a nested scope that this top-level-helper inliner does not
+        // substitute into.)
+        Expression::FunctionExpression(fe) => {
+            if let Some(id) = &fe.id {
+                out.insert(id.name.clone());
+            }
+            for p in &fe.params {
+                let FunctionParam::Identifier(id) = p;
+                out.insert(id.name.clone());
+            }
+        }
     }
 }
 
@@ -1009,6 +1029,15 @@ fn tally_expr(expr: &Expression, cand: &InlineCandidate, t: &mut Tally) {
                     }
                 }
                 tally_expr(&prop.value, cand, t);
+            }
+        }
+        // Count uses of the candidate inside a function *value*'s body —
+        // a closure over the candidate is still a use. Mirrors the
+        // `FunctionDeclaration` arm in `tally_decl`; over-counting under
+        // shadowing only makes the pass decline to inline, never wrong.
+        Expression::FunctionExpression(fe) => {
+            for s in &fe.body.body {
+                tally_stmt(s, cand, t);
             }
         }
     }
@@ -1269,6 +1298,14 @@ fn inline_in_expr(expr: &mut Expression, cand: &InlineCandidate) -> bool {
                 changed |= inline_in_expr(&mut prop.value, cand);
             }
         }
+        // Inline candidate calls that appear inside a function *value*'s
+        // body too, mirroring the `FunctionDeclaration` arm in
+        // `inline_in_decl`.
+        Expression::FunctionExpression(fe) => {
+            for s in &mut fe.body.body {
+                changed |= inline_in_stmt(s, cand);
+            }
+        }
     }
     changed
 }
@@ -1359,6 +1396,23 @@ fn substitute(expr: &mut Expression, map: &HashMap<String, Expression>) {
                     }
                 }
                 substitute(&mut prop.value, map);
+            }
+        }
+        // Substitute param→arg inside a function *value*'s body, but a
+        // param or the fn's own name SHADOWS the substituted parameter of
+        // the same spelling — remove those keys before recursing so a
+        // shadowed reference is left untouched.
+        Expression::FunctionExpression(fe) => {
+            let mut inner = map.clone();
+            if let Some(id) = &fe.id {
+                inner.remove(&id.name);
+            }
+            for p in &fe.params {
+                let FunctionParam::Identifier(id) = p;
+                inner.remove(&id.name);
+            }
+            for s in &mut fe.body.body {
+                substitute_in_stmt(s, &inner);
             }
         }
     }
@@ -1692,6 +1746,15 @@ fn expr_collect_mutated_params(
                     }
                 }
                 expr_collect_mutated_params(&prop.value, params, out);
+            }
+        }
+        // An assignment to an outer param INSIDE a function value's body
+        // (a closure mutating the param) counts as a mutation. Recurse via
+        // the statement helper. Over-detection only makes the pass decline
+        // to inline (a param treated as mutated is not substituted).
+        Expression::FunctionExpression(fe) => {
+            for s in &fe.body.body {
+                stmt_collect_mutated_params(s, params, out);
             }
         }
         Expression::Identifier(_)
@@ -3100,6 +3163,22 @@ fn rename_in_expr(expr: &mut Expression, map: &HashMap<String, String>) {
                     }
                 }
                 rename_in_expr(&mut prop.value, map);
+            }
+        }
+        // Alpha-rename uses inside a function *value*'s body, but its own
+        // name and params SHADOW any outer name being renamed — drop those
+        // keys before recursing so a shadowed use keeps its (inner) name.
+        Expression::FunctionExpression(fe) => {
+            let mut inner = map.clone();
+            if let Some(id) = &fe.id {
+                inner.remove(&id.name);
+            }
+            for p in &fe.params {
+                let FunctionParam::Identifier(id) = p;
+                inner.remove(&id.name);
+            }
+            for s in &mut fe.body.body {
+                rename_in_stmt(s, &inner);
             }
         }
     }

--- a/code/packages/rust/closure-pass-rename-globals/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename-globals/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename-globals` crate will be documented in this file.
 
+## [0.8.0] - 2026-07-01
+
+### Added — CLOC12.149: rename globals through `FunctionExpression`
+
+`collect_all_idents_expr` records a function value's name + params +
+body idents (avoid-set). `rename_apply_expr` recurses into the body with
+the function's own name and params **removed from the active map**, so a
+shadowed local is left untouched while genuine globals inside the body
+are still renamed — a self-contained soundness guarantee.
+
 ## [0.7.1] - 2026-06-30
 
 ### Added — CLOC12 upstream test port (`RenameVarsTest`)

--- a/code/packages/rust/closure-pass-rename-globals/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename-globals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename-globals"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2021"
 description = "Aggressive top-level (global) renaming pass for the Closure Compiler clone — the ADVANCED-level complement to closure-pass-rename. Shortens program-private top-level names, gated by an externs do-not-rename boundary."
 

--- a/code/packages/rust/closure-pass-rename-globals/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename-globals/src/lib.rs
@@ -686,6 +686,21 @@ fn collect_all_idents_expr(expr: &Expression, out: &mut HashSet<String>) {
                 collect_all_idents_expr(&prop.value, out);
             }
         }
+        // A function *value* introduces its own name (if any) and params
+        // as identifiers, and its body references more — record them all
+        // so a renamed global never collides with any of them.
+        Expression::FunctionExpression(fe) => {
+            if let Some(id) = &fe.id {
+                out.insert(id.name.clone());
+            }
+            for p in &fe.params {
+                let FunctionParam::Identifier(id) = p;
+                out.insert(id.name.clone());
+            }
+            for s in &fe.body.body {
+                collect_all_idents_stmt(s, out);
+            }
+        }
     }
 }
 
@@ -946,6 +961,27 @@ fn rename_apply_expr(expr: &mut Expression, map: &HashMap<String, String>) {
                     }
                 }
                 rename_apply_expr(&mut prop.value, map);
+            }
+        }
+        // A function *value*'s own name (if named) and its params are
+        // LOCAL bindings that shadow any global of the same spelling.
+        // Recurse into the body with those names REMOVED from the active
+        // map, so genuine global uses inside the body are renamed while a
+        // shadowed use (referring to the param / self-name) is left
+        // untouched — a self-contained soundness guarantee that does not
+        // depend on the candidate-selection step having seen this
+        // function expression.
+        Expression::FunctionExpression(fe) => {
+            let mut inner = map.clone();
+            if let Some(id) = &fe.id {
+                inner.remove(&id.name);
+            }
+            for p in &fe.params {
+                let FunctionParam::Identifier(id) = p;
+                inner.remove(&id.name);
+            }
+            for s in &mut fe.body.body {
+                rename_apply_stmt(s, &inner);
             }
         }
     }

--- a/code/packages/rust/closure-pass-rename-properties/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename-properties/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename-properties` crate will be documented in this file.
 
+## [0.10.0] - 2026-07-01
+
+### Added — CLOC12.149: rename properties inside `FunctionExpression`
+
+`classify_expr` and `rewrite_expr` recurse into a `FunctionExpression`
+body so a quoted `o["foo"]` written there still disables renaming of
+`foo`, and dotted accesses inside are rewritten. Variable bindings
+(name/params) never touch the property namespace.
+
 ## [0.9.1] - 2026-07-01
 
 ### Added — CLOC12 upstream test port (`RenamePropertiesTest`)

--- a/code/packages/rust/closure-pass-rename-properties/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename-properties/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename-properties"
-version = "0.9.1"
+version = "0.10.0"
 edition = "2021"
 description = "Aggressive property renaming pass for the Closure Compiler clone (ADVANCED-only). Consistently shortens program-private object property names that are never quoted/computed and not in the built-in or externs do-not-rename boundary."
 

--- a/code/packages/rust/closure-pass-rename-properties/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename-properties/src/lib.rs
@@ -1199,6 +1199,20 @@ fn classify_expr(expr: &Expression, cls: &mut Classify) {
                 classify_expr(&prop.value, cls);
             }
         }
+        // Classify property accesses inside a function *value*'s body — a
+        // quoted `o["foo"]` written there must still DISABLE renaming of
+        // `foo`, so we cannot skip the body (that would risk an unsound
+        // rename). The fn's name/params are variable bindings, never
+        // property names, so they don't touch the property namespace.
+        // `nodes_touched` counts statements/declarations for stats only;
+        // `classify_expr` isn't threaded it, so a throwaway counter is
+        // used for the nested walk.
+        Expression::FunctionExpression(fe) => {
+            let mut nested = 0u32;
+            for s in &fe.body.body {
+                classify_stmt(s, cls, &mut nested);
+            }
+        }
     }
 }
 
@@ -1418,6 +1432,13 @@ fn rewrite_expr(expr: &mut Expression, map: &HashMap<String, String>) {
                     }
                 }
                 rewrite_expr(&mut prop.value, map);
+            }
+        }
+        // Rewrite property accesses inside a function *value*'s body, the
+        // mirror of classifying them above.
+        Expression::FunctionExpression(fe) => {
+            for s in &mut fe.body.body {
+                rewrite_stmt(s, map);
             }
         }
     }

--- a/code/packages/rust/closure-pass-rename/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename` crate will be documented in this file.
 
+## [0.12.0] - 2026-07-01
+
+### Added — CLOC12.149: rename locals through `FunctionExpression`
+
+`collect_all_idents_expr` records a nested function value's name +
+params + body idents (fresh-name avoidance). `rewrite_uses_expr` recurses
+into the body with the function's own name/params removed from the map,
+so a closure-over use of a renamed outer local is rewritten while a
+shadowed use keeps its inner name.
+
 ## [0.11.0] - 2026-07-01
 
 ### Added — upstream `RenameVarsTest.java` conformance port (#88, CLOC12.145)

--- a/code/packages/rust/closure-pass-rename/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 description = "Variable renaming pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Replaces non-exported binding names with shorter identifiers to reduce output size while preserving externally-visible names and semantics."
 

--- a/code/packages/rust/closure-pass-rename/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename/src/lib.rs
@@ -964,6 +964,22 @@ fn collect_all_idents_expr(expr: &Expression, out: &mut HashSet<String>) {
                 collect_all_idents_expr(&prop.value, out);
             }
         }
+        // A function *value* introduces its own name (if any), its params,
+        // and whatever its body references. Record them all so a fresh
+        // short name chosen for an OUTER local can never collide with —
+        // or capture — a name used inside the nested function.
+        Expression::FunctionExpression(fe) => {
+            if let Some(id) = &fe.id {
+                out.insert(id.name.clone());
+            }
+            for p in &fe.params {
+                let FunctionParam::Identifier(id) = p;
+                out.insert(id.name.clone());
+            }
+            for s in &fe.body.body {
+                collect_all_idents_stmt(s, out);
+            }
+        }
     }
 }
 
@@ -1206,6 +1222,26 @@ fn rewrite_uses_expr(expr: &mut Expression, map: &HashMap<String, String>) {
                     }
                 }
                 rewrite_uses_expr(&mut prop.value, map);
+            }
+        }
+        // A nested function *value* closes over the enclosing function's
+        // locals, so uses of a renamed outer local inside its body must be
+        // rewritten too. BUT the nested function's own name and params
+        // SHADOW any outer local of the same spelling — inside the body
+        // those identifiers refer to the inner binding. Remove them from
+        // the active map before recursing so a shadowed use is left
+        // untouched while a genuine closure-over use is renamed.
+        Expression::FunctionExpression(fe) => {
+            let mut inner = map.clone();
+            if let Some(id) = &fe.id {
+                inner.remove(&id.name);
+            }
+            for p in &fe.params {
+                let FunctionParam::Identifier(id) = p;
+                inner.remove(&id.name);
+            }
+            for s in &mut fe.body.body {
+                rewrite_uses_stmt(s, &inner);
             }
         }
     }

--- a/code/packages/rust/closure-scope-analyzer/CHANGELOG.md
+++ b/code/packages/rust/closure-scope-analyzer/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `coding-adventures-closure-scope-analyzer` crate will be documented in this file.
 
+## [0.10.0] - 2026-07-01
+
+### Added — CLOC12.149: scope-analyze `FunctionExpression`
+
+Adds `walk_function_expression`, mirroring `walk_function_declaration`
+except a named function expression's name is **body-local** (bound inside
+the function's own scope for self-recursion, not the enclosing scope).
+Params become Param bindings in the function scope; the body is walked in
+that scope. Keeps renaming/inlining consumers sound over function values.
+
 ## [0.9.0] - 2026-06-20
 
 ### Added — CLOC23: scope analysis for `for`-`of`

--- a/code/packages/rust/closure-scope-analyzer/Cargo.toml
+++ b/code/packages/rust/closure-scope-analyzer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-scope-analyzer"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 description = "Lexical scope + symbol-table analyzer for the Closure Compiler clone. Per CLOC13 — produces a `ScopeAnalysis` consumed by the rename, inline, treeshake, collapse-properties, and remove-unused-vars passes."
 

--- a/code/packages/rust/closure-scope-analyzer/src/lib.rs
+++ b/code/packages/rust/closure-scope-analyzer/src/lib.rs
@@ -68,7 +68,7 @@
 use coding_adventures_javascript_ast::statement::TaggedStatement;
 use coding_adventures_javascript_ast::{
     AssignmentTarget, BindingTarget, BlockStatement, CvId, Declaration, Expression, ForInit,
-    FunctionDeclaration, FunctionParam, Program, ProgramItem, Property, PropertyKey, Statement,
+    FunctionDeclaration, FunctionExpression, FunctionParam, Program, ProgramItem, Property, PropertyKey, Statement,
     VarKind, VariableDeclaration,
 };
 use serde::{Deserialize, Serialize};
@@ -564,6 +564,60 @@ fn walk_function_declaration(
     }
 }
 
+/// Walk a `FunctionExpression`. Mirrors [`walk_function_declaration`]
+/// with one deliberate difference rooted in JS scoping semantics:
+///
+/// A function *declaration* hoists its name into the **enclosing**
+/// scope. A named function *expression*'s name is **body-local** — it
+/// binds only inside the function's own scope, so the function can refer
+/// to itself for recursion (`var f = function rec(n){ return rec(n-1); }`)
+/// without leaking `rec` outward. So we create the function scope first
+/// and, when the expression is named, bind the name *inside* that scope
+/// (not the enclosing one). Anonymous expressions bind no name at all.
+///
+/// Getting this right matters for renaming soundness: a body reference to
+/// the function's own name must resolve to this local binding, never to a
+/// free/global of the same spelling.
+fn walk_function_expression(
+    fe: &FunctionExpression,
+    ctx: WalkCtx,
+    analysis: &mut ScopeAnalysis,
+    pending: &mut Vec<PendingReference>,
+) {
+    let function_scope = emit_scope(ScopeKind::Function, ctx.current, analysis);
+
+    // Named function expression: the name is visible ONLY inside the
+    // body, bound in the function's own scope.
+    if let Some(id) = &fe.id {
+        emit_binding(
+            id.name.clone(),
+            BindingKind::Function,
+            function_scope,
+            id.cv.clone(),
+            analysis,
+        );
+    }
+
+    for param in &fe.params {
+        let FunctionParam::Identifier(id) = param;
+        emit_binding(
+            id.name.clone(),
+            BindingKind::Param,
+            function_scope,
+            id.cv.clone(),
+            analysis,
+        );
+    }
+
+    let inner_ctx = WalkCtx {
+        current: function_scope,
+        enclosing_function: function_scope,
+    };
+    for stmt in &fe.body.body {
+        walk_statement(stmt, inner_ctx, analysis, pending);
+    }
+}
+
 fn walk_block_statement(
     block: &BlockStatement,
     ctx: WalkCtx,
@@ -800,6 +854,9 @@ fn walk_expression(
             for prop in &oe.properties {
                 walk_property(prop, ctx, analysis, pending);
             }
+        }
+        Expression::FunctionExpression(fe) => {
+            walk_function_expression(fe, ctx, analysis, pending);
         }
     }
 }

--- a/code/packages/rust/javascript-ast/CHANGELOG.md
+++ b/code/packages/rust/javascript-ast/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to the `coding-adventures-javascript-ast` crate will be documented in this file.
 
+## [0.14.0] - 2026-07-01
+
+### Added — CLOC12.149: `FunctionExpression` (function in value position)
+
+Adds `FunctionExpression { cv, id: Option<Identifier>, params, body, generator,
+is_async }` and the `Expression::FunctionExpression` variant — the expression
+sibling of `FunctionDeclaration`, covering `var f = function () {}`, IIFEs
+(`(function () {})()`), and function-valued properties/arguments. The one
+structural difference from the declaration is `id: Option<Identifier>`: an
+anonymous `function () {}` has no name, and a *named* function expression's name
+is body-local (visible only for self-recursion inside its own body), never bound
+in the enclosing scope. `params` / `body` / `generator` / `is_async` reuse
+`FunctionParam` and `BlockStatement`, so a pass walking a function body does not
+care which form produced it. `is_async` serializes as JSON `"async"` per ESTree,
+and `id`/`cv` are omitted from the wire format when `None`.
+
+This is the **AST-node slice** of a bottom-up `FunctionExpression` rollout: the
+parser→typed-AST bridge (`javascript-parser` currently declines
+`function_expression` as `UnsupportedSyntax`), emitter printing, and pass
+traversal land in follow-on slices. Arrow functions, methods, getters/setters,
+and class expressions remain Phase 3.
+
 ## [0.13.0] - 2026-06-20
 
 ### Changed — CLOC24: `DebuggerStatement` doc reflects stripping

--- a/code/packages/rust/javascript-ast/Cargo.toml
+++ b/code/packages/rust/javascript-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-javascript-ast"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 description = "Backend-agnostic JavaScript AST — full ESTree-compatible node taxonomy with optional per-node CV id. Reusable by the Closure-Compiler-clone and the future V8-in-Rust clone. Per CLOC02 / CLOC09."
 

--- a/code/packages/rust/javascript-ast/README.md
+++ b/code/packages/rust/javascript-ast/README.md
@@ -26,6 +26,21 @@ whitelist is what keeps the AST reusable.
 - A `CvId` type alias for `String` (matching the current `correlation-vector`
   representation; see the module docs for the migration plan).
 
+## Phase 1.x variant additions
+
+Beyond the Phase 1 core, variants are added incrementally as the passes and
+emitter grow a need for them — each behind its own `CLOC12.NN` slice:
+
+- `BigIntLiteral` (CLOC12.15), `UndefinedLiteral` (CLOC12.16).
+- `FunctionExpression` (CLOC12.149) — a function used in **value** position
+  (`var f = function () {}`, IIFEs `(function () {})()`, function-valued
+  properties/arguments). The expression sibling of `FunctionDeclaration`; the
+  only structural difference is `id: Option<Identifier>` (anonymous, or a
+  body-local name). Rolled out bottom-up: this crate adds the node; the
+  `javascript-parser` bridge, `closure-emitter`, and the passes wire it up in
+  follow-on slices. (Arrow functions, methods, getters/setters, and classes
+  remain Phase 3.)
+
 ## What's coming (follow-up PRs)
 
 Per CLOC02:

--- a/code/packages/rust/javascript-ast/src/expression.rs
+++ b/code/packages/rust/javascript-ast/src/expression.rs
@@ -10,12 +10,17 @@
 //!   [`ConditionalExpression`].
 //! - Application: [`CallExpression`], [`MemberExpression`].
 //! - Composites: [`ArrayExpression`], [`ObjectExpression`].
+//! - Callables: [`FunctionExpression`] (Phase 1.x — added in CLOC12.149;
+//!   the expression sibling of [`crate::FunctionDeclaration`], e.g.
+//!   `var f = function () {}`, IIFEs, function-valued properties).
 //!
 //! Every struct carries `cv: Option<CvId>` first per the CLOC09
 //! amendment. Operator enums serialize to ESTree-canonical operator
 //! strings (`"=="`, `"==="`, `"&&"`, etc.) via per-variant
 //! `#[serde(rename = "...")]`.
 
+use crate::declaration::FunctionParam;
+use crate::statement::BlockStatement;
 use crate::CvId;
 use serde::{Deserialize, Serialize};
 
@@ -44,6 +49,7 @@ pub enum Expression {
     MemberExpression(MemberExpression),
     ArrayExpression(ArrayExpression),
     ObjectExpression(ObjectExpression),
+    FunctionExpression(FunctionExpression),
 }
 
 // ---------------------------------------------------------------------
@@ -402,6 +408,58 @@ pub enum PropertyKey {
     NumericLiteral(NumericLiteral),
     /// When the property is `[expr]: value` (computed = true).
     Expression(Box<Expression>),
+}
+
+// ---------------------------------------------------------------------
+// FunctionExpression — a function used in value position
+// ---------------------------------------------------------------------
+
+/// `function (p1, p2) { body }` or the *named* form
+/// `function f(p1, p2) { body }`, appearing where an **expression** is
+/// expected — the right side of an assignment (`var g = function () {}`),
+/// an argument (`arr.map(function (x) { return x; })`), a property value
+/// (`{ run: function () {} }`), or the callee of an IIFE
+/// (`(function () {})()`).
+///
+/// # How it differs from [`crate::FunctionDeclaration`]
+///
+/// A declaration *binds a name in the enclosing scope* and is a
+/// statement; an expression *produces a function value* and its name
+/// (if any) is visible **only inside its own body** (so a named
+/// function expression can recurse by its own name without leaking that
+/// name outward). That single semantic difference is exactly why `id`
+/// here is `Option<Identifier>` — anonymous function expressions are the
+/// common case — whereas a declaration's `id` is mandatory.
+///
+/// ```text
+///   declaration:  function f(){}      f is bound in the outer scope
+///   expression:   (function f(){})    f is bound ONLY inside the body
+///   expression:   (function (){})     anonymous — no name at all
+/// ```
+///
+/// `params`, `body`, `generator`, and `is_async` carry the identical
+/// meaning as on [`crate::FunctionDeclaration`], and the two share the
+/// [`FunctionParam`] and [`BlockStatement`] types so passes that walk a
+/// function body do not care which form produced it.
+///
+/// Added in Phase 1.x (CLOC09 §"future Phase 1.x FunctionExpression").
+/// Arrow functions, methods, getters/setters, and class expressions
+/// remain Phase 3.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FunctionExpression {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub cv: Option<CvId>,
+    /// `None` for an anonymous `function () {}`; `Some` for a named
+    /// `function f() {}` expression (the name is body-local — see the
+    /// type-level docs).
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub id: Option<Identifier>,
+    pub params: Vec<FunctionParam>,
+    pub body: BlockStatement,
+    pub generator: bool,
+    #[serde(rename = "async")]
+    pub is_async: bool,
 }
 
 #[cfg(test)]
@@ -866,5 +924,87 @@ mod tests {
             let json = serde_json::to_string(&k).expect("serialize");
             assert_eq!(json, format!("\"{}\"", expected));
         }
+    }
+
+    // -----------------------------------------------------------------
+    // FunctionExpression (Phase 1.x, CLOC09) — the expression sibling of
+    // FunctionDeclaration. Round-trips + tag + the `id`-is-optional and
+    // `async`-renames-to-JSON contracts.
+    // -----------------------------------------------------------------
+    use crate::declaration::FunctionParam as TestFunctionParam;
+    use crate::statement::{BlockStatement as TestBlock, ReturnStatement, Statement};
+
+    /// `function f(x) { return x; }` used in value position.
+    fn named_fn_expr() -> Expression {
+        Expression::FunctionExpression(FunctionExpression {
+            cv: Some("fe.1".to_string()),
+            id: Some(Identifier { cv: None, name: "f".to_string() }),
+            params: vec![TestFunctionParam::Identifier(Identifier {
+                cv: None,
+                name: "x".to_string(),
+            })],
+            body: TestBlock {
+                cv: None,
+                body: vec![Statement::return_statement(ReturnStatement {
+                    cv: None,
+                    argument: Some(Expression::Identifier(Identifier {
+                        cv: None,
+                        name: "x".to_string(),
+                    })),
+                })],
+            },
+            generator: false,
+            is_async: false,
+        })
+    }
+
+    /// Anonymous `function () {}`.
+    fn anon_fn_expr() -> Expression {
+        Expression::FunctionExpression(FunctionExpression {
+            cv: None,
+            id: None,
+            params: vec![],
+            body: TestBlock { cv: None, body: vec![] },
+            generator: false,
+            is_async: false,
+        })
+    }
+
+    #[test]
+    fn function_expression_named_roundtrips_and_tags() {
+        let e = named_fn_expr();
+        assert_eq!(e.clone(), roundtrip(e.clone()));
+        assert_eq!(type_tag(&e), "FunctionExpression");
+    }
+
+    #[test]
+    fn function_expression_anonymous_roundtrips() {
+        let e = anon_fn_expr();
+        assert_eq!(e.clone(), roundtrip(e.clone()));
+        assert_eq!(type_tag(&e), "FunctionExpression");
+    }
+
+    #[test]
+    fn function_expression_anonymous_omits_id_in_json() {
+        // `id: None` must NOT appear in the wire format — an anonymous
+        // function expression has no `id` key at all (ESTree uses
+        // `"id": null`, but our `skip_serializing_if` omits it; both
+        // deserialize back to `None`, which is what round-trip asserts).
+        let json = serde_json::to_string(&anon_fn_expr()).expect("serialize");
+        assert!(!json.contains("\"id\""), "anonymous fn-expr should omit id; got {}", json);
+    }
+
+    #[test]
+    fn function_expression_async_key_renames() {
+        // The `is_async` field serializes as JSON `"async"` (ESTree),
+        // exactly as on FunctionDeclaration.
+        let mut e = anon_fn_expr();
+        if let Expression::FunctionExpression(f) = &mut e {
+            f.is_async = true;
+        }
+        let json = serde_json::to_string(&e).expect("serialize");
+        assert!(json.contains("\"async\":true"), "expected async key; got {}", json);
+        assert!(!json.contains("isAsync"), "must not leak Rust field name; got {}", json);
+        assert_eq!(e.clone(), roundtrip(e));
     }
 }

--- a/code/packages/rust/javascript-ast/src/lib.rs
+++ b/code/packages/rust/javascript-ast/src/lib.rs
@@ -134,8 +134,8 @@ pub use declaration::{
 pub use expression::{
     ArrayExpression, AssignmentExpression, AssignmentOperator, AssignmentTarget,
     BigIntLiteral, BinaryExpression, BinaryOperator, BooleanLiteral, CallExpression,
-    ConditionalExpression, Expression, Identifier, LogicalExpression, LogicalOperator,
-    MemberExpression,
+    ConditionalExpression, Expression, FunctionExpression, Identifier, LogicalExpression,
+    LogicalOperator, MemberExpression,
     NullLiteral, NumericLiteral, ObjectExpression, Property, PropertyKey, PropertyKind,
     StringLiteral, UnaryExpression, UnaryOperator, UndefinedLiteral,
 };

--- a/code/specs/CLOC09-ast-taxonomy.md
+++ b/code/specs/CLOC09-ast-taxonomy.md
@@ -486,8 +486,8 @@ matches ESTree exactly.
 
 This is the only field-name divergence Phase 1 introduces. It
 applies anywhere a function-like node has the async flag
-(`FunctionDeclaration`, future Phase 1.x `FunctionExpression`,
-Phase 3 `ArrowFunctionExpression`, `Method`, `ClassMethod`,
+(`FunctionDeclaration`, Phase 1.x `FunctionExpression` — landed in
+CLOC12.149, Phase 3 `ArrowFunctionExpression`, `Method`, `ClassMethod`,
 etc.).
 
 ## Why split `Statement` and `Declaration` enums
@@ -610,6 +610,16 @@ implementations are independent follow-ups.
 - Phase 1.5: `Visitor` / `VisitorMut` traits with a default
   walk implementation; revise after seeing the first real pass
   body.
+- Phase 1.x incremental variant additions (landed as the passes
+  and emitter grew a need for them, each behind its own CLOC12.NN
+  slice + gap entry): `BigIntLiteral` (CLOC12.15), `UndefinedLiteral`
+  (CLOC12.16), and **`FunctionExpression` (CLOC12.149)** — the
+  expression sibling of `FunctionDeclaration` (`var f = function () {}`,
+  IIFEs, function-valued properties). `id` is `Option<Identifier>`
+  (anonymous vs. named-but-body-local); `params` / `body` /
+  `generator` / `is_async` reuse the declaration's types. Landed
+  bottom-up: AST node first (this slice), then the parser→typed-AST
+  bridge, emitter printing, and pass traversal in follow-on slices.
 - Phase 2: leaf coverage gaps + control-flow variants
   (`SwitchStatement`, `TryStatement`, etc.).
 - Phase 3: patterns, arrow functions, classes.

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -1389,3 +1389,28 @@ after a `break` inside a loop is unreachable (`while (c) { break; y(); }` →
 `while (c) { break; }`). closurec only treats break/continue as terminators
 inside switch-case consequents (`is_case_terminator`), so the loop-body `y()`
 survives. Placeholder: `drops_code_after_break_in_loop_block`.
+
+## CLOC12.149 — `FunctionExpression` (function in value position)
+
+**Landed (AST + emitter + passes):** `Expression::FunctionExpression` is now a
+first-class node (`javascript-ast`), the emitter prints it (statement-start and
+call-callee parenthesisation, no trailing `;`), and every optimisation pass
+(`constant-fold`, `fold-control-flow`, `dce`, `inline`, `inline-variables`,
+`rename`, `rename-globals`, `rename-properties`, `scope-analyzer`) handles it
+soundly — recursing into the body, with the function's own name/params removed
+from the active rename/substitute map so a shadowed binding is never rewritten.
+The expression sibling of `FunctionDeclaration`; `id` is `Option<Identifier>`
+(anonymous, or a body-local name). Spec: CLOC09 §"Phase 1.x FunctionExpression".
+
+### gap-153 — bridge still declines `function_expression`
+
+The parser/grammar already produce `function_expression` (and `arrow_function`,
+`async_function_expression`, `generator_expression`), but the typed-AST bridge
+(`javascript-parser::bridge`) still maps them to `UnsupportedSyntax`, so no
+`FunctionExpression` reaches the pipeline yet — any program containing one falls
+back to WHITESPACE_ONLY. **Next slice:** convert `function_expression` →
+`Expression::FunctionExpression` in the bridge (remove it from the `unsupported`
+list), add a closurec end-to-end fixture (IIFE, function-valued property,
+callback), and port the upstream `CodePrinter`/function-expression conformance
+cases now unblocked. Arrow functions, methods, getters/setters, and class
+expressions remain Phase 3.


### PR DESCRIPTION
## What & why

The JS parser/grammar already produce `function_expression`, but the typed-AST **bridge declined them** because `Expression` had no `FunctionExpression` variant — so the emitter and every optimization pass could not represent a function used in **value position** (`var f = function(){}`, IIFEs `(function(){})()`, function-valued properties/args). This lands the **AST-node slice end-to-end** through the emitter and all passes.

Spec-scheduled in [CLOC09](code/specs/CLOC09-ast-taxonomy.md) as "Phase 1.x FunctionExpression".

## Why one atomic PR across 11 crates

Adding a variant to the shared `Expression` enum is **one atomic breaking change** — CI builds the workspace, so every exhaustive `match Expression` must compile in the same PR. "One PR per crate" cannot apply to a breaking enum change. Each consumer already handles `FunctionDeclaration`, so the new arms route the function-expression body through the identical, already-sound machinery.

## Changes

- **javascript-ast** (0.13→0.14): `Expression::FunctionExpression { cv, id: Option<Identifier>, params, body, generator, is_async }` — the expression sibling of `FunctionDeclaration`; `id` optional (anonymous, or a body-local self-name). +4 serde/roundtrip tests.
- **closure-emitter** (0.18.16→0.19): `emit_function_expression` (optional name, **no** trailing `;`); `expr_prec` tags it below `PREC_PRIMARY` so call/member parents wrap it (`(function(){})()`, `(function(){}).x`); statement-start wrap. +5 tests.
- **Passes** (all sound; recurse into the body; rename/inline/substitute remove the function's own name+params from the active map before recursing so a **shadowed binding is never rewritten**):
  - `scope-analyzer` — `walk_function_expression` (named FE's name is **body-local**).
  - `constant-fold`, `fold-control-flow`, `dce` — fold/clean inside the body.
  - `inline`, `inline-variables` — tally/inline/propagate/mutation/rename.
  - `rename`, `rename-globals`, `rename-properties` — shadow-correct rewrite + avoid-set.

## Spec

- CLOC09 records FunctionExpression as landed (Phase 1.x).
- CLOC12-gaps adds **CLOC12.149** + **gap-153**: the bridge still declines `function_expression` — the bridge-enable + closurec e2e + upstream conformance ports are the next slice.

## Verification

All 11 crates + closurec CLI + pipeline + treeshake/collapse/remove-unused-vars **build and test green — no regressions**. Security review passed (shadow-reduction, body-local naming, trailing-`;` omission, no new DoS class all confirmed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)