### PR TITLE
feat(visicalc-react): back the React/Electron grid with the shared WASM engine

### DIFF
--- a/code/programs/typescript/visicalc/.gitignore
+++ b/code/programs/typescript/visicalc/.gitignore
@@ -11,3 +11,6 @@ src/components/
 
 # OS junk
 .DS_Store
+
+# Vendored engine bundle — copied from visicalc-html/vendor by scripts/build.sh
+public/spreadsheet-engine-wasm.js

--- a/code/programs/typescript/visicalc/README.md
+++ b/code/programs/typescript/visicalc/README.md
@@ -53,6 +53,39 @@ npm run dev       # rebuilds components then starts Vite at http://localhost:517
 `npm run dev` runs `scripts/build.sh` first, so the components are always
 fresh before the dev server starts.
 
+## The engine
+
+The grid renders *computed* spreadsheet values, not raw text. Those come
+from the shared Rust [`spreadsheet-core`](../../../packages/rust/spreadsheet-core)
+engine — the exact same engine the SwiftUI / Qt / Flutter / Compose /
+Android backends drive through native FFI/JNI. On the web the engine is
+compiled to WebAssembly.
+
+- `scripts/build.sh` vendors the engine bundle into
+  `public/spreadsheet-engine-wasm.js` (copied from the single committed
+  source in [`../visicalc-html/vendor/`](../visicalc-html/vendor); the copy
+  is git-ignored, not a second duplicate). Vite copies `public/` into
+  `dist/`, and `index.html` loads it as a classic script that resolves
+  `window.__spreadsheetEngineReady` before React mounts.
+- [`src/app/engine.ts`](src/app/engine.ts) wraps the workbook in a small
+  React-friendly view: `window(...)` returns the visible slice of computed
+  display strings, `raw(row,col)` returns a cell's source for the formula
+  bar, and `setCell(row,col,value)` writes through and recomputes.
+- The bundle self-contains its `.wasm` (embedded base64 +
+  `WebAssembly.instantiate`, no separate `fetch`), so it loads identically
+  under a dev server (`http://`) and under Electron's `file://`.
+
+### Electron
+
+[`../visicalc-electron`](../visicalc-electron) is a thin desktop shell that
+loads this program's `dist/index.html` in a `BrowserWindow`:
+
+```bash
+cd code/programs/typescript/visicalc-electron
+npm install
+npm start        # build:react (this program) then launches Electron
+```
+
 ## Architecture (UI26 §1)
 
 ```
@@ -81,12 +114,15 @@ Three structural invariants:
 1. **Mosaic components are dumb renderers.** They know nothing about
    spreadsheets — they just render the props they're given and fire the
    events declared in their `.mil` interface.
-2. **The host owns all state** in a single `useReducer`. Cell values,
-   selection, edit state, viewport — all of it.
-3. **Formula evaluation is out of scope** for this demo. The host stores
-   raw string values per cell and displays them as-is. Replacing that
-   with a real expression evaluator is a separate parallel track (see
-   the formula-engine work, tracked separately from the UI queue).
+2. **The host owns UI state** in a single `useReducer` — selection, edit
+   buffer, and viewport. Cell *values* and formula evaluation live in the
+   engine, not the reducer.
+3. **Formula evaluation runs in the shared Rust engine.** The same
+   `spreadsheet-core` engine every other VisiCalc backend uses is compiled
+   to WASM and bound in [`src/app/engine.ts`](src/app/engine.ts). The grid
+   renders the engine's *computed* values (e.g. `=SUM(A1:D1)` shows `38`),
+   and commits write through to the engine, which recomputes every
+   dependent. See "The engine" below.
 
 ## Known limitations of this v1 (deferred to follow-up PRs)
 
@@ -117,9 +153,10 @@ contributor can pick them up:
    through to the generated `<input placeholder="...">`. The FormulaBar
    `.mll` carries `placeholder: "Enter formula"` directly.
 
-4. **No formula evaluation.** Cells store and display raw strings.
-   `editCommit` is where a real formula engine would plug in; see
-   UI26 §11 and the separate formula-engine track for details.
+4. ~~**No formula evaluation.**~~ *Resolved.* Cells are now evaluated by
+   the shared Rust `spreadsheet-core` engine (compiled to WASM), bound in
+   [`src/app/engine.ts`](src/app/engine.ts). `editCommit` writes the edit
+   through to the engine, which recomputes dependents. See "The engine".
 
 5. ~~**No column-widths binding.**~~ *Resolved.* The Grid emitter now
    reads the optional `column-widths` slot ref (UI26 §2.1) and emits a

--- a/code/programs/typescript/visicalc/index.html
+++ b/code/programs/typescript/visicalc/index.html
@@ -18,6 +18,9 @@
   </head>
   <body>
     <div id="root"></div>
+    <!-- The Rust spreadsheet-core engine, compiled to WASM (same bundle the HTML demo
+         ships). It sets window.__spreadsheetEngineReady + window.SpreadsheetEngine. -->
+    <script src="/spreadsheet-engine-wasm.js"></script>
     <script type="module" src="/src/app/main.tsx"></script>
   </body>
 </html>

--- a/code/programs/typescript/visicalc/scripts/build.sh
+++ b/code/programs/typescript/visicalc/scripts/build.sh
@@ -65,5 +65,23 @@ echo "Compiling FormulaBar..."
 # each generated .tsx file, so the host (src/app/state.ts) imports
 # `GridEvent` and `FormulaBarEvent` directly. No re-export shims needed.
 
+# Vendor the shared Rust spreadsheet-core engine (compiled to WASM) into
+# `public/` so Vite copies it into `dist/` and index.html can load it. The
+# React host renders the engine's *computed* values (see src/app/engine.ts);
+# without this the grid is empty because the reducer stores raw strings with
+# no formula evaluation. We copy from the sibling HTML demo's committed vendor
+# copy — the single source of truth for the bundle — rather than committing a
+# second ~890 KB duplicate here (public/spreadsheet-engine-wasm.js is gitignored).
+ENGINE_SRC="$REPO_ROOT/code/programs/typescript/visicalc-html/vendor/spreadsheet-engine-wasm.js"
+PUBLIC_DIR="$DEMO_DIR/public"
+mkdir -p "$PUBLIC_DIR"
+if [ -f "$ENGINE_SRC" ]; then
+  echo "Vendoring engine bundle -> public/spreadsheet-engine-wasm.js"
+  cp "$ENGINE_SRC" "$PUBLIC_DIR/spreadsheet-engine-wasm.js"
+else
+  echo "ERROR: engine bundle not found at $ENGINE_SRC" >&2
+  exit 1
+fi
+
 echo "Done. Generated:"
 ls -la "$OUT_DIR"

--- a/code/programs/typescript/visicalc/src/app/App.tsx
+++ b/code/programs/typescript/visicalc/src/app/App.tsx
@@ -13,42 +13,106 @@
 // `list<text>` and this file carried a `@ts-expect-error` to mask the
 // resulting `Array<string>` vs `Array<Array<string>>` mismatch.
 
-import { useReducer, useMemo, useEffect, useCallback } from "react";
+import {
+  useReducer,
+  useMemo,
+  useEffect,
+  useCallback,
+  useRef,
+  useState,
+} from "react";
 import { Grid } from "../components/Grid";
 import { FormulaBar } from "../components/FormulaBar";
-import { initialState, reducer } from "./state";
-import { buildViewportRows, cellLabel, cellKey } from "./util";
+import { initialState, reducer, type AppAction } from "./state";
+import { cellLabel } from "./util";
+import { loadEngine, type Engine } from "./engine";
 
 export function App() {
   const [state, dispatch] = useReducer(reducer, initialState);
 
-  // Derived: the 2-D viewport slice the Grid component is given.
-  // Recomputed each render; O(viewportSize * totalCols) is negligible.
+  // The Rust spreadsheet-core engine, compiled to WASM (see engine.ts). It holds
+  // the cells / dependency graph / recalc; the grid renders ITS computed values
+  // and commits write through to it — unlike the reducer-only v0.1.0, whose cells
+  // were raw strings with no formula evaluation (so the grid was empty).
+  const engineRef = useRef<Engine | null>(null);
+  const [ready, setReady] = useState(false);
+  const [rev, setRev] = useState(0); // bump to re-derive after a mutation
+
+  useEffect(() => {
+    let live = true;
+    loadEngine().then((e) => {
+      if (!live) return;
+      engineRef.current = e;
+      setReady(true);
+      setRev((r) => r + 1);
+    });
+    return () => {
+      live = false;
+    };
+  }, []);
+
+  // Derived: the 2-D viewport slice the Grid is given — the engine's *computed*
+  // display strings for the visible window. Re-derived when the engine mutates
+  // (rev) or the viewport moves.
   const viewportRows = useMemo(
     () =>
-      buildViewportRows(
-        state.cells,
-        state.viewportOffset,
-        state.viewportSize,
-        state.totalRows,
-        state.totalCols,
-      ),
-    [
-      state.cells,
-      state.viewportOffset,
-      state.viewportSize,
-      state.totalRows,
-      state.totalCols,
-    ],
+      ready && engineRef.current
+        ? engineRef.current.window(
+            state.viewportOffset,
+            state.viewportSize,
+            state.totalRows,
+            state.totalCols,
+          )
+        : [],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [ready, rev, state.viewportOffset, state.viewportSize, state.totalRows, state.totalCols],
   );
 
-  // The formula bar shows either the live edit content (when editing)
-  // or the raw value of the selected cell (when not editing).
+  // The formula bar shows the live edit buffer while editing, else the selected
+  // cell's raw SOURCE (=SUM(A1:D1), not the computed 38) read from the engine.
   const isEditingSelected =
     state.editRow === state.selectedRow && state.editCol === state.selectedCol;
   const formulaBarValue = isEditingSelected
     ? state.editContent
-    : state.cells[cellKey(state.selectedRow, state.selectedCol)] ?? "";
+    : ready && engineRef.current
+      ? engineRef.current.raw(state.selectedRow, state.selectedCol)
+      : "";
+
+  // Intercept commits: write the buffered edit through to the engine (which
+  // recomputes every dependent), then let the reducer update UI state and bump
+  // `rev` so the grid re-reads the engine. `editCommit` is the grid's inline
+  // edit; `commit` is the formula bar's. Both buffer into state.editContent.
+  const engineDispatch = useCallback(
+    (action: AppAction) => {
+      // editStart: seed the edit buffer with the cell's SOURCE from the engine
+      // (the reducer reads state.cells, which is empty now that the engine owns
+      // the data — so an edit would otherwise start blank).
+      if (action.type === "editStart" && engineRef.current) {
+        dispatch(action);
+        dispatch({
+          type: "formulaChange",
+          value: engineRef.current.raw(action.row, action.col),
+        });
+        return;
+      }
+      if (
+        (action.type === "editCommit" || action.type === "commit") &&
+        engineRef.current &&
+        state.editRow !== -1
+      ) {
+        engineRef.current.setCell(
+          state.editRow,
+          state.editCol,
+          state.editContent,
+        );
+        dispatch(action);
+        setRev((r) => r + 1);
+        return;
+      }
+      dispatch(action);
+    },
+    [state.editRow, state.editCol, state.editContent],
+  );
 
   // Keyboard handling (UI26 §8). We attach a single keydown listener
   // on window because navigation is a host concern, not a Grid concern.
@@ -61,32 +125,32 @@ export function App() {
       const c = state.selectedCol;
       switch (e.key) {
         case "ArrowUp":
-          if (r > 0) dispatch({ type: "navigate", row: r - 1, col: c });
+          if (r > 0) engineDispatch({ type: "navigate", row: r - 1, col: c });
           e.preventDefault();
           break;
         case "ArrowDown":
           if (r + 1 < state.totalRows)
-            dispatch({ type: "navigate", row: r + 1, col: c });
+            engineDispatch({ type: "navigate", row: r + 1, col: c });
           e.preventDefault();
           break;
         case "ArrowLeft":
-          if (c > 0) dispatch({ type: "navigate", row: r, col: c - 1 });
+          if (c > 0) engineDispatch({ type: "navigate", row: r, col: c - 1 });
           e.preventDefault();
           break;
         case "ArrowRight":
           if (c + 1 < state.totalCols)
-            dispatch({ type: "navigate", row: r, col: c + 1 });
+            engineDispatch({ type: "navigate", row: r, col: c + 1 });
           e.preventDefault();
           break;
         case "Enter":
         case "F2":
-          dispatch({ type: "editStart", row: r, col: c });
+          engineDispatch({ type: "editStart", row: r, col: c });
           e.preventDefault();
           break;
         default:
           // Any single printable character starts editing.
           if (e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey) {
-            dispatch({ type: "editStart", row: r, col: c });
+            engineDispatch({ type: "editStart", row: r, col: c });
           }
       }
     },
@@ -96,6 +160,7 @@ export function App() {
       state.editRow,
       state.totalRows,
       state.totalCols,
+      engineDispatch,
     ],
   );
 
@@ -110,7 +175,7 @@ export function App() {
         cellAddress={cellLabel(state.selectedRow, state.selectedCol)}
         formula={formulaBarValue}
         readOnly={false}
-        dispatch={dispatch}
+        dispatch={engineDispatch}
       />
       <Grid
         columnHeaders={state.columnHeaders}
@@ -134,7 +199,7 @@ export function App() {
         // UI28-1 / U29-D1 — the live edit buffer Grid threads into the
         // inline <input value=...> when the user is editing a cell.
         editContent={state.editContent}
-        dispatch={dispatch}
+        dispatch={engineDispatch}
       />
     </div>
   );

--- a/code/programs/typescript/visicalc/src/app/engine.ts
+++ b/code/programs/typescript/visicalc/src/app/engine.ts
@@ -1,0 +1,93 @@
+// engine.ts — the React host's binding to the shared Rust spreadsheet engine.
+//
+// The other VisiCalc backends (SwiftUI/Qt/Flutter/Compose/Android) reach the Rust
+// `spreadsheet-core` engine through a native FFI/JNI bridge. On the web the engine
+// is compiled to WebAssembly; this module loads the SAME bundle the HTML demo ships
+// (`public/spreadsheet-engine-wasm.js`, added to index.html), so the React grid
+// renders the engine's *computed* values and edits recompute — instead of the empty
+// placeholder grid the reducer-only version showed (its cells were raw strings with
+// no formula evaluation).
+//
+// The bundle is a global-script IIFE: it resolves `window.__spreadsheetEngineReady`
+// with an `Engine` whose `createSpreadsheet()` returns a `workbook` with the same
+// operations the C-ABI/WASM facade exposes.
+
+// The one asset the demo loads sets these globals (see index.html).
+interface Workbook {
+  setCells(cells: Record<string, string>): void;
+  setCell(a1: string, raw: string): unknown;
+  getRaw(a1: string): string;
+  getDisplayWindow(
+    row0: number,
+    col0: number,
+    row1: number,
+    col1: number,
+  ): { rows: number; cols: number; cells: string[][] };
+  columnLetters(index: number): string;
+}
+declare global {
+  interface Window {
+    __spreadsheetEngineReady?: Promise<{ createSpreadsheet(): Workbook }>;
+  }
+}
+
+// The classic cross-footing budget — the identical seed every other VisiCalc demo
+// uses (E column = row sums, row 5 = column sums, E5 = grand total 169), so the
+// React/Electron grid shows the SAME engine-computed values.
+const SEED: Record<string, string> = {
+  A1: "15", B1: "3", C1: "12", D1: "8", E1: "=SUM(A1:D1)",
+  A2: "8", B2: "14", C2: "7", D2: "22", E2: "=SUM(A2:D2)",
+  A3: "12", B3: "9", C3: "18", D3: "6", E3: "=SUM(A3:D3)",
+  A4: "4", B4: "11", C4: "3", D4: "17", E4: "=SUM(A4:D4)",
+  A5: "=SUM(A1:A4)", B5: "=SUM(B1:B4)", C5: "=SUM(C1:C4)",
+  D5: "=SUM(D1:D4)", E5: "=SUM(E1:E4)",
+};
+
+/** A thin, React-friendly view of the engine workbook. */
+export interface Engine {
+  /**
+   * The visible window as a 2-D array of display strings — the exact shape the
+   * generated Grid consumes (row-major, `totalCols` columns per row, no row
+   * label). `viewportOffset` is 0-based; the engine addresses are 1-based.
+   */
+  window(
+    viewportOffset: number,
+    viewportSize: number,
+    totalRows: number,
+    totalCols: number,
+  ): string[][];
+  /** A cell's typed source (for the formula bar). (row, col) are 0-based. */
+  raw(row: number, col: number): string;
+  /** Write a cell's source and recompute. (row, col) are 0-based. */
+  setCell(row: number, col: number, value: string): void;
+}
+
+function a1(row: number, col: number): string {
+  return `${String.fromCharCode(65 + col)}${row + 1}`;
+}
+
+/** Load + seed the WASM engine, returning the React-friendly view. */
+export async function loadEngine(): Promise<Engine> {
+  const ready = window.__spreadsheetEngineReady;
+  if (!ready) {
+    throw new Error(
+      "spreadsheet engine bundle not loaded — is <script src='/spreadsheet-engine-wasm.js'> in index.html?",
+    );
+  }
+  const rt = await ready;
+  const wb = rt.createSpreadsheet();
+  wb.setCells(SEED);
+  return {
+    window(viewportOffset, viewportSize, totalRows, totalCols) {
+      const row1 = Math.min(viewportOffset + viewportSize, totalRows);
+      if (row1 < viewportOffset + 1) return [];
+      return wb.getDisplayWindow(viewportOffset + 1, 1, row1, totalCols).cells;
+    },
+    raw(row, col) {
+      return wb.getRaw(a1(row, col));
+    },
+    setCell(row, col, value) {
+      wb.setCell(a1(row, col), value);
+    },
+  };
+}


### PR DESCRIPTION
## What

The React VisiCalc host — and the **Electron** desktop shell that wraps its build — rendered an **empty grid**: `initialState.cells = {}` and the reducer stored raw strings with no formula evaluation, so `=SUM(A1:D1)` never became `38`. This PR wires the host to the **same Rust `spreadsheet-core` engine** every other backend drives (SwiftUI/Qt/Flutter/Compose/Android via native FFI/JNI), here compiled to WebAssembly — the identical bundle the HTML demo ships.

## Changes

- **`src/app/engine.ts`** (new) — loads `window.__spreadsheetEngineReady`, seeds the cross-footing budget, exposes a React-friendly view: `window(offset,size,rows,cols)` → computed display slice, `raw(r,c)` → cell source for the formula bar, `setCell(r,c,v)` → write-through + recompute.
- **`App.tsx`** — derive `viewportRows` + formula-bar value from the engine; add `engineDispatch` (seeds edit buffer from `engine.raw` on editStart; writes `editCommit`/`commit` through to the engine + bumps a rev counter so the grid re-reads). Route keydown + FormulaBar + Grid through it.
- **`index.html`** — load the engine bundle as a classic script before the module entry (so `__spreadsheetEngineReady` is set before React mounts).
- **`scripts/build.sh`** — vendor the engine into `public/` (copied from the single committed source in `visicalc-html/vendor`; the copy is gitignored, not a 890 KB duplicate). Bundle self-contains its `.wasm` (embedded base64 + `WebAssembly.instantiate`, no `fetch`) → loads identically under `http://` and Electron's `file://`.
- **`README.md`** — correct the now-false "no formula evaluation" invariant + limitation; document the engine binding and Electron shell.

## Verification

The produced `dist/` bundle (the exact one Electron loads) renders the engine-computed budget:

| | A | B | C | D | E |
|---|---|---|---|---|---|
| 1 | 15 | 3 | 12 | 8 | **38** |
| … | | | | | |
| 5 | **39** | **37** | **40** | **53** | **169** |

Zero console errors. Editing **A1 15→100** recomputes **E1→123, A5→124, E5→254** — proving compute-on-load *and* recompute-on-edit. Electron launches clean and loads this verified `dist/index.html`; its window isn't screen-capturable in the headless automation context, but it loads the identical, functionally-verified bundle via `file://`.

Security review: **PASSED** (no eval/innerHTML sinks; shell expansions quoted; same-origin local asset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)