### PR TITLE
feat(visicalc-qt): runtime desktop/touch FormulaBar layout toggle

### DIFF
--- a/code/programs/cpp/visicalc-qt/README.md
+++ b/code/programs/cpp/visicalc-qt/README.md
@@ -84,6 +84,26 @@ are `Q_INVOKABLE`, so a windowed QML grid (rendering only the visible rectangle
 of an unbounded sheet, the Qt sibling of the web/SwiftUI infinite views) binds
 to them directly.
 
+### The touch FormulaBar layout (`FormulaBarTouch.qml`)
+
+The **Touch bar** button (shown in classic-grid mode) swaps the formula bar
+between two layouts generated from the *same* `FormulaBar.mil` interface:
+
+- **Desktop** (`FormulaBar.desktop.mll` → `FormulaBar.qml`): a `RowLayout` —
+  the cell-address label sits to the **left** of the input.
+- **Touch** (`FormulaBar.touch.mll` → `FormulaBarTouch.qml`): a `ColumnLayout` —
+  the address label stacks **above** a full-width input, the arrangement that
+  fits a phone-width viewport.
+
+`scripts/build.sh` emits both QML files (the touch one as `FormulaBarTouch.qml`
+because a QML type name is its file basename), `qml/qmldir` registers both, and
+`main.qml` mounts both bound to the same `model` + shared `commitFormula()` /
+`cancelFormula()` handlers — only one is `visible` at a time. This is the UI30
+"one component, many layouts, identical host contract" invariant made a runtime
+toggle: the native analogue of the web demo's `touch.html`, which pivots the
+same `FormulaBar.touch.mll` to `flex-direction: column`. Editing behaves
+identically in both — the layout is the only thing that changes.
+
 ### The scrollable infinite GUI (`InfiniteSheet.qml`)
 
 The **Infinite sheet** button in the running app toggles from the classic 5×5

--- a/code/programs/cpp/visicalc-qt/main.qml
+++ b/code/programs/cpp/visicalc-qt/main.qml
@@ -53,6 +53,27 @@ Window {
     // the active view participates in layout.
     property bool infinite: true
 
+    // Which FormulaBar LAYOUT is showing in classic-grid mode: the desktop Row
+    // (address label left of the input) or the UI30 touch Column (address label
+    // stacked ABOVE a full-width input, bigger tap target). Both are generated
+    // from the SAME FormulaBar.mil interface — only the .mll spatial arrangement
+    // differs — so they share `formulaText`, the model, and the commit/cancel
+    // handlers below. This is the "one component, many layouts" invariant made
+    // runtime-switchable, the native analogue of the web demo's layout toggle.
+    property bool touch: false
+
+    // Shared FormulaBar handlers — reused by BOTH layout variants so the two
+    // bars are behaviourally identical and only their shape differs.
+    function commitFormula() {
+        if (model) {
+            model.setSelected(root.formulaText);
+            root.formulaText = model.selectedRaw; // canonicalised source
+        }
+    }
+    function cancelFormula() {
+        root.formulaText = model ? model.selectedRaw : "";
+    }
+
     ColumnLayout {
         anchors.fill: parent
         spacing: 0
@@ -74,18 +95,27 @@ Window {
                 font.pixelSize: 11
                 font.letterSpacing: 1.0
             }
+            // Toggle the FormulaBar layout variant. Only meaningful in classic-
+            // grid mode (the infinite sheet has no formula bar), so it's hidden
+            // when the infinite view is active.
+            Button {
+                visible: !root.infinite
+                text: root.touch ? "Desktop bar" : "Touch bar"
+                onClicked: root.touch = !root.touch
+            }
             Button {
                 text: root.infinite ? "Classic grid" : "Infinite sheet"
                 onClicked: root.infinite = !root.infinite
             }
         }
 
-        // FormulaBar — the AUTO-GENERATED component. The host pushes the
-        // selected cell's address + source in; on commit (Enter) it writes the
-        // edited text to the engine via `model.setSelected`, which recomputes.
+        // FormulaBar — DESKTOP layout (Row: address label left of the input).
+        // AUTO-GENERATED from FormulaBar.desktop.mll. The host pushes the
+        // selected cell's address + source in; on commit (Enter) the shared
+        // root.commitFormula() writes through to the engine, which recomputes.
         FormulaBar {
             id: formulaBar
-            visible: !root.infinite
+            visible: !root.infinite && !root.touch
             Layout.fillWidth: true
             Layout.topMargin: 8
             cellAddress: model ? model.cellAddress : ""
@@ -93,13 +123,26 @@ Window {
             readOnly: false
 
             onFormulaChange: (value) => root.formulaText = value
-            onCommit: {
-                if (model) {
-                    model.setSelected(root.formulaText);
-                    root.formulaText = model.selectedRaw; // canonicalised source
-                }
-            }
-            onCancel: { root.formulaText = model ? model.selectedRaw : "" }
+            onCommit: root.commitFormula()
+            onCancel: root.cancelFormula()
+        }
+
+        // FormulaBar — TOUCH layout (Column: address label stacked ABOVE a
+        // full-width input). AUTO-GENERATED from FormulaBar.touch.mll. Same
+        // .mil interface, same model contract, same shared handlers as the
+        // desktop bar above — only the spatial arrangement differs (UI30).
+        FormulaBarTouch {
+            id: formulaBarTouch
+            visible: !root.infinite && root.touch
+            Layout.fillWidth: true
+            Layout.topMargin: 8
+            cellAddress: model ? model.cellAddress : ""
+            formula: root.formulaText
+            readOnly: false
+
+            onFormulaChange: (value) => root.formulaText = value
+            onCommit: root.commitFormula()
+            onCancel: root.cancelFormula()
         }
 
         // Grid — AUTO-GENERATED. Its `viewportRows` is bound to the engine's

--- a/code/programs/cpp/visicalc-qt/qml/qmldir
+++ b/code/programs/cpp/visicalc-qt/qml/qmldir
@@ -11,4 +11,5 @@
 # build/ keeps both well-behaved under version control.
 module qml
 FormulaBar 1.0 ../build/FormulaBar.qml
+FormulaBarTouch 1.0 ../build/FormulaBarTouch.qml
 Grid 1.0 ../build/Grid.qml

--- a/code/programs/cpp/visicalc-qt/scripts/build.sh
+++ b/code/programs/cpp/visicalc-qt/scripts/build.sh
@@ -51,12 +51,26 @@ SRC="$REPO_ROOT/code/programs/mosaic/visicalc"
 OUT_DIR="$DEMO_DIR/build"
 mkdir -p "$OUT_DIR"
 
-echo "Compiling FormulaBar (Qt / QML)..."
+echo "Compiling FormulaBar — desktop layout (Qt / QML)..."
 "$MOSAIC_COMPILE" --backend qt \
   --interface "$SRC/FormulaBar.mil" \
   --layout    "$SRC/FormulaBar.desktop.mll" \
   --style     "$SRC/FormulaBar.dark.msl" \
   -o "$OUT_DIR/FormulaBar.qml"
+
+echo "Compiling FormulaBar — touch layout (Qt / QML)..."
+# UI30 touch variant: FormulaBar.touch.mll stacks the address label ABOVE a
+# full-width input (Column) instead of the desktop Row. Same .mil interface,
+# same slot/emit wiring — only the spatial arrangement differs, so main.qml can
+# swap FormulaBar <-> FormulaBarTouch at runtime against the identical model
+# contract (the UI30 "one component, many layouts" invariant). We emit it as
+# FormulaBarTouch.qml because a QML component's type name is its file basename,
+# and both variants must coexist in the `qml` module.
+"$MOSAIC_COMPILE" --backend qt \
+  --interface "$SRC/FormulaBar.mil" \
+  --layout    "$SRC/FormulaBar.touch.mll" \
+  --style     "$SRC/FormulaBar.dark.msl" \
+  -o "$OUT_DIR/FormulaBarTouch.qml"
 
 echo "Compiling Grid (Qt / QML)..."
 # UI34 — Grid is now generated from the shared visicalc/mosaic/


### PR DESCRIPTION
## What

The native VisiCalc demos only ever showed the **desktop** layout. This adds a real **touch/mobile** layout variant to the Qt demo with a runtime toggle — the first of the native backends (Compose/Flutter/Android to follow).

Qt already had a `property bool infinite` toggle; this adds `property bool touch` that swaps the formula bar between two layouts generated from the **same** `FormulaBar.mil` interface:

| variant | source | shape |
|---|---|---|
| desktop | `FormulaBar.desktop.mll` → `FormulaBar.qml` | `RowLayout` — address label **left** of input |
| touch | `FormulaBar.touch.mll` → `FormulaBarTouch.qml` | `ColumnLayout` — address label **above** full-width input |

This is the UI30 *"one component, many layouts, identical host contract"* invariant made a runtime switch — the native analogue of the web demo's `touch.html` (same `FormulaBar.touch.mll`, pivoted to `flex-direction: column`).

## Changes

- **`scripts/build.sh`** — emit the touch variant as `build/FormulaBarTouch.qml` (named `*Touch` because a QML type name is its file basename, so both coexist in the `qml` module).
- **`qml/qmldir`** — register `FormulaBarTouch`.
- **`main.qml`** — add `property bool touch`, a "Touch bar"/"Desktop bar" button (classic-grid mode only), and mount **both** variants bound to the same `model`; only the active one is `visible`. Commit/cancel logic factored into shared `root.commitFormula()`/`cancelFormula()` so both bars behave identically — only the shape differs.
- **`README.md`** — document the touch layout + toggle.

## Verification

- `bash scripts/build.sh` emits `FormulaBarTouch.qml` with a **`ColumnLayout`** root vs `FormulaBar.qml`'s **`RowLayout`** — the divergence is real.
- `qmake && make` builds clean; the app launches loading **both** QML variants with **zero binding/type errors** (only the pre-existing signal-param deprecation warning), proving `main.qml`'s toggle wiring resolves both.
- The identical `FormulaBar.touch.mll` rendered through the web emitter (`touch.html`) shows the stacked layout at a 375px mobile viewport — corroborating visual (the native Qt window isn't screen-capturable in this headless automation context; a Screen Recording TCC limitation, not an app defect).

Security review: **PASSED** (fixed in-repo paths under `set -euo pipefail`; no eval/dynamic-QML; second widget binds the same already-vetted model sink — no new trust boundary).

Follow-up (same PR-H track): extend the touch toggle to Compose/Flutter/Android.

🤖 Generated with [Claude Code](https://claude.com/claude-code)