### PR TITLE
feat(adj-ladder): rung-33 ventricular stroke work (product of two differences)

### DIFF
--- a/code/specs/data/adj-ladder/rung33_stroke_work/gen_items.py
+++ b/code/specs/data/adj-ladder/rung33_stroke_work/gen_items.py
@@ -1,0 +1,214 @@
+"""Generate rung-33 (ventricular stroke work) items.json for the ADJ-LADDER.
+
+Rung 33 opens the **cardiovascular ventricular-mechanics** panel on the quantitative band — the arithmetic of
+the ventricle's pressure-volume work over one beat. On the pressure-volume loop, the work the ventricle does to
+eject blood is (to a first approximation) the *area* of the loop: how much blood it moves times the pressure it
+moves it against. The two edges of that rectangle are the **stroke volume** (how much the chamber empties) and
+the **pulse pressure** (how far the arterial pressure swings), and the stroke-work estimate is their product.
+It uses the same contamination-safe shape as the respiratory rung (32), the Starling rung (31), and the
+body-mass rung (30): a small table of *observed* volumes and pressures and a tight family of mutually-confusable
+formulas built **only from those observed quantities** (no numeric literal anywhere in any program), so nothing
+structural can leak.
+
+The clinical setup is a single ventricle characterised over one cardiac cycle. FOUR quantities are measured —
+two chamber volumes (mL) and two arterial pressures (mmHg):
+
+  END_DIASTOLIC_VOLUME   EDV   volume in the ventricle when it is fullest, just before ejection   (larger volume)
+  END_SYSTOLIC_VOLUME    ESV   volume left in the ventricle after ejection                        (smaller volume)
+  SYSTOLIC_PRESSURE      SBP   peak arterial pressure during ejection                             (higher pressure)
+  DIASTOLIC_PRESSURE     DBP   trough arterial pressure between beats                             (lower pressure)
+
+The stroke-work estimate is the **volume the ventricle ejected multiplied by the pressure it swings through** —
+a *product of two differences* — `(EDV − ESV) * (SBP − DBP)`. That is what makes this rung distinctive: it is a
+NEW arithmetic shape on the ladder — a product whose TWO factors are each their own difference (rung-31
+subtracted one difference from another; rung-32 divided one difference by another; this rung MULTIPLIES one
+difference by another). The core confusion this rung tests is pairing the right two quantities into each
+difference (a volume difference times a pressure difference), rather than crossing a volume with a pressure:
+
+  STROKE WORK ESTIMATE   (EDV − ESV) * (SBP − DBP)   [ ejected volume  x  pressure swing = loop area ]
+  STROKE VOLUME          EDV − ESV                   [ the volume ejected, one factor ]
+  PULSE PRESSURE         SBP − DBP                   [ the pressure swing, the other factor ]
+
+Each index is a `compute_dimensioned` program (observe the four quantities + `let answer = formula`); the ADJ
+engine carries the arithmetic and the harness reads the scalar via the existing `compute_dimensioned`
+extractor — no harness/engine change, exactly as rungs 8/16/…/31/32. This rung exercises the engine across a
+MULTIPLICATION of two parenthesised DIFFERENCES.
+
+Contamination-safe by construction: every formula is built only from the four observed quantities via `-`, `*`,
+`+` — **no structural constants** — so every program literal is grounded in the stem. Neither the stroke volume
+nor the pulse pressure ever appears as a literal (each is computed from the observed quantities). The observed
+quantities carry **digit-free identifiers** (`end_diastolic_volume`, `end_systolic_volume`, `systolic_pressure`,
+`diastolic_pressure`) so no numeral hides inside a variable name. The five options are a tight family over the
+same quantities: the three real indices plus the two classic slips —
+
+  CROSSED PRODUCT   (EDV − DBP) * (SBP − ESV)   the volumes and pressures *crossed* (a volume minus a pressure), and
+  SUMMED AREA       (EDV − ESV) + (SBP − DBP)   the two differences ADDED instead of multiplied (a perimeter, not an area),
+
+which are exactly the mistakes a student makes. Gold rotates A-E by index.
+
+Note on scale: the stroke-work estimate is order 1e3 (SV ~ 70-90 mL times PP ~ 40-60 mmHg ~ 3000-5000), while
+the stroke volume (tens of mL) and pulse pressure (tens of mmHg) are two orders of magnitude smaller, and the
+summed area (~120-150) sits between them; the crossed product is close to but never equal to the stroke work.
+The tables below are chosen so the five family values are pairwise distinct — with a comfortable margin — for
+every item, asserted at build time (stroke volume and pulse pressure both strictly positive, and the crossed
+product kept off the stroke-work value so no two options collide).
+"""
+import json
+
+LETTERS = ["A", "B", "C", "D", "E"]
+
+# (END_DIASTOLIC_VOLUME, END_SYSTOLIC_VOLUME, SYSTOLIC_PRESSURE, DIASTOLIC_PRESSURE) observed per beat. Volumes
+# in mL, pressures in mmHg. EDV exceeds ESV (the chamber ejected blood) and SBP exceeds DBP (the pressure
+# swings up during ejection), so both differences are strictly positive. The five family values are asserted
+# pairwise-distinct (with margin) below — in particular the crossed product is kept off the stroke-work value.
+#   EDV = end-diastolic volume    (fullest, larger)
+#   ESV = end-systolic volume     (after ejection, smaller)
+#   SBP = systolic pressure       (peak, higher)
+#   DBP = diastolic pressure      (trough, lower)
+TABLES = [
+    (124, 52, 126, 78),
+    (135, 60, 130, 85),
+    (150, 70, 140, 90),
+    (128, 48, 118, 74),
+    (142, 55, 148, 88),
+    (118, 45, 110, 66),
+    (155, 72, 135, 82),
+]
+
+# The option family (5 members), all built from the observed quantities via `-` / `*` / `+`. Every identifier
+# is DIGIT-FREE. key -> (display name, formula-as-adj). Only the first three are *queried* (used as gold); all
+# five always appear as the options.
+FAMILY = [
+    (
+        "stroke_work_estimate",
+        "stroke work estimate",
+        "(end_diastolic_volume - end_systolic_volume) * (systolic_pressure - diastolic_pressure)",
+    ),
+    (
+        "stroke_volume",
+        "stroke volume",
+        "end_diastolic_volume - end_systolic_volume",
+    ),
+    (
+        "pulse_pressure",
+        "pulse pressure",
+        "systolic_pressure - diastolic_pressure",
+    ),
+    (
+        "crossed_product",
+        "crossed product (volume and pressure crossed)",
+        "(end_diastolic_volume - diastolic_pressure) * (systolic_pressure - end_systolic_volume)",
+    ),
+    (
+        "summed_area",
+        "summed differences (stroke volume plus pulse pressure)",
+        "(end_diastolic_volume - end_systolic_volume) + (systolic_pressure - diastolic_pressure)",
+    ),
+]
+QUERIED = ["stroke_work_estimate", "stroke_volume", "pulse_pressure"]
+ORDER = [k for k, _, _ in FAMILY]
+
+
+def scalar(v):
+    return {"value": v, "unit": "scalar"}
+
+
+def family_values(edv, esv, sbp, dbp):
+    # Operation order mirrors the ADJ program exactly, so the Python option value and the engine
+    # result are the same IEEE-double (well within the harness's 1e-9 match tolerance).
+    stroke_volume = edv - esv
+    pulse_pressure = sbp - dbp
+    return {
+        "stroke_work_estimate": stroke_volume * pulse_pressure,
+        "stroke_volume": stroke_volume,
+        "pulse_pressure": pulse_pressure,
+        "crossed_product": (edv - dbp) * (sbp - esv),
+        "summed_area": stroke_volume + pulse_pressure,
+    }
+
+
+def build():
+    name_of = {k: nm for k, nm, _ in FAMILY}
+    formula_of = {k: f for k, _, f in FAMILY}
+    items = []
+    idx = 0
+
+    def num(x):
+        return int(x) if float(x).is_integer() else x
+
+    for edv, esv, sbp, dbp in TABLES:
+        stroke_volume = edv - esv
+        pulse_pressure = sbp - dbp
+        assert stroke_volume > 0 and pulse_pressure > 0, (edv, esv, sbp, dbp)
+        fv = family_values(edv, esv, sbp, dbp)
+        # Pairwise-distinct with a comfortable margin so the harness never sees two options
+        # matching the gold value within its 1e-9 tolerance.
+        vals = [fv[key] for key in ORDER]
+        for i in range(len(vals)):
+            for j in range(i + 1, len(vals)):
+                assert abs(vals[i] - vals[j]) > 1e-6, (edv, esv, sbp, dbp, ORDER[i], ORDER[j], fv)
+        for key in QUERIED:
+            gold_val = fv[key]
+            gold_pos = idx % 5
+            others = [fv[k2] for k2 in ORDER if abs(fv[k2] - gold_val) > 1e-12]
+            opts_vals = others[:]
+            opts_vals.insert(gold_pos, gold_val)
+            opts_vals = opts_vals[:5]
+            if abs(opts_vals[gold_pos] - gold_val) > 1e-12:
+                opts_vals[gold_pos] = gold_val
+            assert len({round(v, 9) for v in opts_vals}) == 5, (key, edv, esv, sbp, dbp, opts_vals)
+            options = {LETTERS[i]: scalar(opts_vals[i]) for i in range(5)}
+            items.append({
+                "id": f"r33stroke-{idx + 1:02d}",
+                "qtype": "stroke_work",
+                "stem": (
+                    f"A single cardiac cycle is characterised for one ventricle: the end-diastolic volume is "
+                    f"{num(edv)} mL and the end-systolic volume is {num(esv)} mL; the systolic pressure is "
+                    f"{num(sbp)} mmHg and the diastolic pressure is {num(dbp)} mmHg. What is the patient's "
+                    f"{name_of[key]}?"
+                ),
+                "program": (
+                    f"observe end_diastolic_volume({num(edv)})\n"
+                    f"observe end_systolic_volume({num(esv)})\n"
+                    f"observe systolic_pressure({num(sbp)})\n"
+                    f"observe diastolic_pressure({num(dbp)})\n"
+                    f"let answer = {formula_of[key]}\n"
+                    "? answer\n"
+                ),
+                "answer_from": {"type": "compute_dimensioned", "name": "answer"},
+                "options": options,
+                "gold_letter": LETTERS[gold_pos],
+            })
+            idx += 1
+    return {
+        "description": (
+            "ADJ-LADDER rung 33 — ventricular stroke work from paired chamber volumes and arterial pressures "
+            "over one beat (a NEW panel: cardiovascular ventricular mechanics). From four stated quantities "
+            "(end-diastolic volume EDV, end-systolic volume ESV, systolic pressure SBP, diastolic pressure DBP) "
+            "compute the stroke work estimate ((EDV-ESV)*(SBP-DBP)), the stroke volume (EDV-ESV), or the pulse "
+            "pressure (SBP-DBP). Each item is a compute_dimensioned program (observe the four quantities, let "
+            "answer = formula); the ADJ engine carries the arithmetic — a NEW shape, a PRODUCT OF TWO "
+            "DIFFERENCES ((EDV-ESV)*(SBP-DBP)), so one parenthesised difference is multiplied by another — and "
+            "the harness matches the scalar to the printed options. Contamination-safe: every index is built "
+            "only from the four observed quantities via -, * and + — no constant leaks (stroke work is a pure "
+            "product of differences), and neither the stroke volume nor the pulse pressure ever appears as a "
+            "literal (each is computed from the observed quantities) — and the observed quantities carry "
+            "digit-free identifiers so no numeral hides inside a variable name. The five options are a family "
+            "over the same quantities, so the distractors are exactly the slips students make: the crossed "
+            "product ((EDV-DBP)*(SBP-ESV), a volume and a pressure crossed into each difference) and the summed "
+            "area ((EDV-ESV)+(SBP-DBP), the two differences added instead of multiplied). The core confusion "
+            "tested is multiplying a volume difference by a pressure difference with each pairing correct."
+        ),
+        "items": items,
+    }
+
+
+if __name__ == "__main__":
+    doc = build()
+    with open("items.json", "w") as f:
+        json.dump(doc, f, indent=2)
+        f.write("\n")
+    print("wrote items.json:", len(doc["items"]), "items")
+    for it in doc["items"]:
+        print(it["id"], it["qtype"], "gold", it["gold_letter"],
+              "=", round(it["options"][it["gold_letter"]]["value"], 4))

--- a/code/specs/data/adj-ladder/rung33_stroke_work/items.json
+++ b/code/specs/data/adj-ladder/rung33_stroke_work/items.json
@@ -1,0 +1,698 @@
+{
+  "description": "ADJ-LADDER rung 33 \u2014 ventricular stroke work from paired chamber volumes and arterial pressures over one beat (a NEW panel: cardiovascular ventricular mechanics). From four stated quantities (end-diastolic volume EDV, end-systolic volume ESV, systolic pressure SBP, diastolic pressure DBP) compute the stroke work estimate ((EDV-ESV)*(SBP-DBP)), the stroke volume (EDV-ESV), or the pulse pressure (SBP-DBP). Each item is a compute_dimensioned program (observe the four quantities, let answer = formula); the ADJ engine carries the arithmetic \u2014 a NEW shape, a PRODUCT OF TWO DIFFERENCES ((EDV-ESV)*(SBP-DBP)), so one parenthesised difference is multiplied by another \u2014 and the harness matches the scalar to the printed options. Contamination-safe: every index is built only from the four observed quantities via -, * and + \u2014 no constant leaks (stroke work is a pure product of differences), and neither the stroke volume nor the pulse pressure ever appears as a literal (each is computed from the observed quantities) \u2014 and the observed quantities carry digit-free identifiers so no numeral hides inside a variable name. The five options are a family over the same quantities, so the distractors are exactly the slips students make: the crossed product ((EDV-DBP)*(SBP-ESV), a volume and a pressure crossed into each difference) and the summed area ((EDV-ESV)+(SBP-DBP), the two differences added instead of multiplied). The core confusion tested is multiplying a volume difference by a pressure difference with each pairing correct.",
+  "items": [
+    {
+      "id": "r33stroke-01",
+      "qtype": "stroke_work",
+      "stem": "A single cardiac cycle is characterised for one ventricle: the end-diastolic volume is 124 mL and the end-systolic volume is 52 mL; the systolic pressure is 126 mmHg and the diastolic pressure is 78 mmHg. What is the patient's stroke work estimate?",
+      "program": "observe end_diastolic_volume(124)\nobserve end_systolic_volume(52)\nobserve systolic_pressure(126)\nobserve diastolic_pressure(78)\nlet answer = (end_diastolic_volume - end_systolic_volume) * (systolic_pressure - diastolic_pressure)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3456,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 72,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 48,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 3404,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 120,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r33stroke-02",
+      "qtype": "stroke_work",
+      "stem": "A single cardiac cycle is characterised for one ventricle: the end-diastolic volume is 124 mL and the end-systolic volume is 52 mL; the systolic pressure is 126 mmHg and the diastolic pressure is 78 mmHg. What is the patient's stroke volume?",
+      "program": "observe end_diastolic_volume(124)\nobserve end_systolic_volume(52)\nobserve systolic_pressure(126)\nobserve diastolic_pressure(78)\nlet answer = end_diastolic_volume - end_systolic_volume\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3456,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 72,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 48,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 3404,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 120,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r33stroke-03",
+      "qtype": "stroke_work",
+      "stem": "A single cardiac cycle is characterised for one ventricle: the end-diastolic volume is 124 mL and the end-systolic volume is 52 mL; the systolic pressure is 126 mmHg and the diastolic pressure is 78 mmHg. What is the patient's pulse pressure?",
+      "program": "observe end_diastolic_volume(124)\nobserve end_systolic_volume(52)\nobserve systolic_pressure(126)\nobserve diastolic_pressure(78)\nlet answer = systolic_pressure - diastolic_pressure\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3456,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 72,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 48,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 3404,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 120,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r33stroke-04",
+      "qtype": "stroke_work",
+      "stem": "A single cardiac cycle is characterised for one ventricle: the end-diastolic volume is 135 mL and the end-systolic volume is 60 mL; the systolic pressure is 130 mmHg and the diastolic pressure is 85 mmHg. What is the patient's stroke work estimate?",
+      "program": "observe end_diastolic_volume(135)\nobserve end_systolic_volume(60)\nobserve systolic_pressure(130)\nobserve diastolic_pressure(85)\nlet answer = (end_diastolic_volume - end_systolic_volume) * (systolic_pressure - diastolic_pressure)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 75,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 45,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 3500,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 3375,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 120,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r33stroke-05",
+      "qtype": "stroke_work",
+      "stem": "A single cardiac cycle is characterised for one ventricle: the end-diastolic volume is 135 mL and the end-systolic volume is 60 mL; the systolic pressure is 130 mmHg and the diastolic pressure is 85 mmHg. What is the patient's stroke volume?",
+      "program": "observe end_diastolic_volume(135)\nobserve end_systolic_volume(60)\nobserve systolic_pressure(130)\nobserve diastolic_pressure(85)\nlet answer = end_diastolic_volume - end_systolic_volume\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3375,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 45,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 3500,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 120,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 75,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r33stroke-06",
+      "qtype": "stroke_work",
+      "stem": "A single cardiac cycle is characterised for one ventricle: the end-diastolic volume is 135 mL and the end-systolic volume is 60 mL; the systolic pressure is 130 mmHg and the diastolic pressure is 85 mmHg. What is the patient's pulse pressure?",
+      "program": "observe end_diastolic_volume(135)\nobserve end_systolic_volume(60)\nobserve systolic_pressure(130)\nobserve diastolic_pressure(85)\nlet answer = systolic_pressure - diastolic_pressure\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 45,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 3375,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 75,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 3500,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 120,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r33stroke-07",
+      "qtype": "stroke_work",
+      "stem": "A single cardiac cycle is characterised for one ventricle: the end-diastolic volume is 150 mL and the end-systolic volume is 70 mL; the systolic pressure is 140 mmHg and the diastolic pressure is 90 mmHg. What is the patient's stroke work estimate?",
+      "program": "observe end_diastolic_volume(150)\nobserve end_systolic_volume(70)\nobserve systolic_pressure(140)\nobserve diastolic_pressure(90)\nlet answer = (end_diastolic_volume - end_systolic_volume) * (systolic_pressure - diastolic_pressure)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 80,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 4000,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 50,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 4200,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 130,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r33stroke-08",
+      "qtype": "stroke_work",
+      "stem": "A single cardiac cycle is characterised for one ventricle: the end-diastolic volume is 150 mL and the end-systolic volume is 70 mL; the systolic pressure is 140 mmHg and the diastolic pressure is 90 mmHg. What is the patient's stroke volume?",
+      "program": "observe end_diastolic_volume(150)\nobserve end_systolic_volume(70)\nobserve systolic_pressure(140)\nobserve diastolic_pressure(90)\nlet answer = end_diastolic_volume - end_systolic_volume\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 4000,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 50,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 80,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 4200,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 130,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r33stroke-09",
+      "qtype": "stroke_work",
+      "stem": "A single cardiac cycle is characterised for one ventricle: the end-diastolic volume is 150 mL and the end-systolic volume is 70 mL; the systolic pressure is 140 mmHg and the diastolic pressure is 90 mmHg. What is the patient's pulse pressure?",
+      "program": "observe end_diastolic_volume(150)\nobserve end_systolic_volume(70)\nobserve systolic_pressure(140)\nobserve diastolic_pressure(90)\nlet answer = systolic_pressure - diastolic_pressure\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 4000,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 80,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 4200,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 50,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 130,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r33stroke-10",
+      "qtype": "stroke_work",
+      "stem": "A single cardiac cycle is characterised for one ventricle: the end-diastolic volume is 128 mL and the end-systolic volume is 48 mL; the systolic pressure is 118 mmHg and the diastolic pressure is 74 mmHg. What is the patient's stroke work estimate?",
+      "program": "observe end_diastolic_volume(128)\nobserve end_systolic_volume(48)\nobserve systolic_pressure(118)\nobserve diastolic_pressure(74)\nlet answer = (end_diastolic_volume - end_systolic_volume) * (systolic_pressure - diastolic_pressure)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 80,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 44,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 3780,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 124,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 3520,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r33stroke-11",
+      "qtype": "stroke_work",
+      "stem": "A single cardiac cycle is characterised for one ventricle: the end-diastolic volume is 128 mL and the end-systolic volume is 48 mL; the systolic pressure is 118 mmHg and the diastolic pressure is 74 mmHg. What is the patient's stroke volume?",
+      "program": "observe end_diastolic_volume(128)\nobserve end_systolic_volume(48)\nobserve systolic_pressure(118)\nobserve diastolic_pressure(74)\nlet answer = end_diastolic_volume - end_systolic_volume\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 80,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 3520,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 44,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 3780,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 124,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r33stroke-12",
+      "qtype": "stroke_work",
+      "stem": "A single cardiac cycle is characterised for one ventricle: the end-diastolic volume is 128 mL and the end-systolic volume is 48 mL; the systolic pressure is 118 mmHg and the diastolic pressure is 74 mmHg. What is the patient's pulse pressure?",
+      "program": "observe end_diastolic_volume(128)\nobserve end_systolic_volume(48)\nobserve systolic_pressure(118)\nobserve diastolic_pressure(74)\nlet answer = systolic_pressure - diastolic_pressure\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3520,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 44,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 80,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 3780,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 124,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r33stroke-13",
+      "qtype": "stroke_work",
+      "stem": "A single cardiac cycle is characterised for one ventricle: the end-diastolic volume is 142 mL and the end-systolic volume is 55 mL; the systolic pressure is 148 mmHg and the diastolic pressure is 88 mmHg. What is the patient's stroke work estimate?",
+      "program": "observe end_diastolic_volume(142)\nobserve end_systolic_volume(55)\nobserve systolic_pressure(148)\nobserve diastolic_pressure(88)\nlet answer = (end_diastolic_volume - end_systolic_volume) * (systolic_pressure - diastolic_pressure)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 87,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 60,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 5220,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 5022,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 147,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r33stroke-14",
+      "qtype": "stroke_work",
+      "stem": "A single cardiac cycle is characterised for one ventricle: the end-diastolic volume is 142 mL and the end-systolic volume is 55 mL; the systolic pressure is 148 mmHg and the diastolic pressure is 88 mmHg. What is the patient's stroke volume?",
+      "program": "observe end_diastolic_volume(142)\nobserve end_systolic_volume(55)\nobserve systolic_pressure(148)\nobserve diastolic_pressure(88)\nlet answer = end_diastolic_volume - end_systolic_volume\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 5220,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 60,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 5022,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 87,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 147,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r33stroke-15",
+      "qtype": "stroke_work",
+      "stem": "A single cardiac cycle is characterised for one ventricle: the end-diastolic volume is 142 mL and the end-systolic volume is 55 mL; the systolic pressure is 148 mmHg and the diastolic pressure is 88 mmHg. What is the patient's pulse pressure?",
+      "program": "observe end_diastolic_volume(142)\nobserve end_systolic_volume(55)\nobserve systolic_pressure(148)\nobserve diastolic_pressure(88)\nlet answer = systolic_pressure - diastolic_pressure\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 5220,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 87,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 5022,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 147,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 60,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r33stroke-16",
+      "qtype": "stroke_work",
+      "stem": "A single cardiac cycle is characterised for one ventricle: the end-diastolic volume is 118 mL and the end-systolic volume is 45 mL; the systolic pressure is 110 mmHg and the diastolic pressure is 66 mmHg. What is the patient's stroke work estimate?",
+      "program": "observe end_diastolic_volume(118)\nobserve end_systolic_volume(45)\nobserve systolic_pressure(110)\nobserve diastolic_pressure(66)\nlet answer = (end_diastolic_volume - end_systolic_volume) * (systolic_pressure - diastolic_pressure)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3212,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 73,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 44,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 3380,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 117,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r33stroke-17",
+      "qtype": "stroke_work",
+      "stem": "A single cardiac cycle is characterised for one ventricle: the end-diastolic volume is 118 mL and the end-systolic volume is 45 mL; the systolic pressure is 110 mmHg and the diastolic pressure is 66 mmHg. What is the patient's stroke volume?",
+      "program": "observe end_diastolic_volume(118)\nobserve end_systolic_volume(45)\nobserve systolic_pressure(110)\nobserve diastolic_pressure(66)\nlet answer = end_diastolic_volume - end_systolic_volume\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3212,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 73,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 44,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 3380,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 117,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r33stroke-18",
+      "qtype": "stroke_work",
+      "stem": "A single cardiac cycle is characterised for one ventricle: the end-diastolic volume is 118 mL and the end-systolic volume is 45 mL; the systolic pressure is 110 mmHg and the diastolic pressure is 66 mmHg. What is the patient's pulse pressure?",
+      "program": "observe end_diastolic_volume(118)\nobserve end_systolic_volume(45)\nobserve systolic_pressure(110)\nobserve diastolic_pressure(66)\nlet answer = systolic_pressure - diastolic_pressure\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3212,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 73,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 44,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 3380,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 117,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r33stroke-19",
+      "qtype": "stroke_work",
+      "stem": "A single cardiac cycle is characterised for one ventricle: the end-diastolic volume is 155 mL and the end-systolic volume is 72 mL; the systolic pressure is 135 mmHg and the diastolic pressure is 82 mmHg. What is the patient's stroke work estimate?",
+      "program": "observe end_diastolic_volume(155)\nobserve end_systolic_volume(72)\nobserve systolic_pressure(135)\nobserve diastolic_pressure(82)\nlet answer = (end_diastolic_volume - end_systolic_volume) * (systolic_pressure - diastolic_pressure)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 83,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 53,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 4599,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 4399,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 136,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r33stroke-20",
+      "qtype": "stroke_work",
+      "stem": "A single cardiac cycle is characterised for one ventricle: the end-diastolic volume is 155 mL and the end-systolic volume is 72 mL; the systolic pressure is 135 mmHg and the diastolic pressure is 82 mmHg. What is the patient's stroke volume?",
+      "program": "observe end_diastolic_volume(155)\nobserve end_systolic_volume(72)\nobserve systolic_pressure(135)\nobserve diastolic_pressure(82)\nlet answer = end_diastolic_volume - end_systolic_volume\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 4399,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 53,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 4599,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 136,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 83,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r33stroke-21",
+      "qtype": "stroke_work",
+      "stem": "A single cardiac cycle is characterised for one ventricle: the end-diastolic volume is 155 mL and the end-systolic volume is 72 mL; the systolic pressure is 135 mmHg and the diastolic pressure is 82 mmHg. What is the patient's pulse pressure?",
+      "program": "observe end_diastolic_volume(155)\nobserve end_systolic_volume(72)\nobserve systolic_pressure(135)\nobserve diastolic_pressure(82)\nlet answer = systolic_pressure - diastolic_pressure\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 53,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 4399,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 83,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 4599,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 136,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    }
+  ]
+}

--- a/code/specs/data/adj-ladder/test_ladder_eval.py
+++ b/code/specs/data/adj-ladder/test_ladder_eval.py
@@ -70,6 +70,7 @@ SELF_CONTAINED_RUNGS = (
     "rung30_body_mass_index",
     "rung31_starling_filtration",
     "rung32_respiratory_exchange_ratio",
+    "rung33_stroke_work",
 )
 
 


### PR DESCRIPTION
## Summary

Adds **ADJ-LADDER rung 33** — a NEW-organ, constant-free `compute_dimensioned` rung opening the **cardiovascular ventricular-mechanics** panel and cycling the arithmetic to a **product of two differences**.

From four observed per-beat quantities — end-diastolic volume, end-systolic volume, systolic pressure, diastolic pressure — the mutually-confusable family computes:

| index | formula | shape |
|---|---|---|
| **stroke work estimate** | `(EDV − ESV) * (SBP − DBP)` | product of two differences (headline) |
| **stroke volume** | `EDV − ESV` | one factor |
| **pulse pressure** | `SBP − DBP` | the other factor |
| crossed product *(distractor)* | `(EDV − DBP) * (SBP − ESV)` | a volume and a pressure crossed into each difference |
| summed area *(distractor)* | `(EDV − ESV) + (SBP − DBP)` | the two differences added, not multiplied |

The three real indices are queried as gold; all five appear as options.

## Arithmetic-shape progression
- rung-31 Starling: **difference of two differences** `(a−b) − (c−d)`
- rung-32 respiratory exchange: **ratio of two differences** `(a−b) / (c−d)`
- **rung-33 stroke work: product of two differences** `(a−b) * (c−d)` ← new shape

## Contamination-safety (by construction)
- Every formula is built **only** from the four observed quantities via `-`, `*`, `+` — **no structural constants**.
- Neither the stroke volume nor the pulse pressure ever appears as a literal (each is computed from the observed quantities).
- Observed quantities carry **digit-free identifiers** (`end_diastolic_volume`, `end_systolic_volume`, `systolic_pressure`, `diastolic_pressure`) — no numeral hides in a variable name.
- 7 tables × 3 queried indices = **21 items**; gold rotates A–E; the five family values are asserted **pairwise-distinct with margin** at build (the crossed product is kept off the stroke-work value).

## Verification
Registered in `SELF_CONTAINED_RUNGS`; the rung-33 gate passes **3/3** — the cached engine selects every gold (0 wrong / 0 abstain), contamination-clean, `items.json` valid:

```
$ python3 -m pytest test_ladder_eval.py -k rung33_stroke_work -q
3 passed, 210 deselected in 0.41s
```

No harness or engine change — pure additive dataset + one-line tuple registration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)