### PR TITLE
feat(semantic-ir-to-go): user-defined class OOP runtime + emit (O4)

### DIFF
--- a/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
@@ -1,5 +1,62 @@
 # Changelog
 
+## 0.9.0
+
+### Added
+
+- **User-defined class OOP — method dispatch, `new`, `self`, `super` (O4).**
+  The Go backend now EXECUTES real user-defined classes (the Go analogue of the
+  Python/TS `sir-runtime-oop` O1 path), not just exception subclasses.  The
+  method↔class association — which the Ruby frontend loses when it HOISTS every
+  `def` to a detached top-level function — is recovered at RUNTIME via explicit
+  `(class, method)` map tables.
+  - **Inlined Go runtime** (`runtime.rs`, verbatim in every artifact):
+    - `SirInstance { Class string; Ivars map[string]Value }` + `_sir_new_instance`.
+    - Instance/class method tables `map[string]Value` keyed by a NUL-joined
+      `class + "\x00" + method` string (a NUL cannot appear in an identifier, so
+      the flattened key is unambiguous) — `_sir_def_method` /
+      `_sir_def_class_method`.
+    - `_sir_call_new(cls, args…)` — allocate → push self → resolve an inherited
+      `initialize` (walking the SHARED `_sir_ancestry` table, seen-guarded) →
+      apply → pop self via `defer` → return the instance.
+    - `_sir_call_method` extended: a `*SirInstance` receiver resolves the user
+      method table walking ancestry (push self, apply, pop via `defer`); a miss
+      falls through to universal Object methods, else the NoMethodError floor.
+      NON-instance receivers reach the existing collection/built-in catalog
+      **UNCHANGED**.
+    - `_sir_call_super(method, cls, args…)` — walk from the superclass, apply
+      with the CURRENT self still bound (no push/pop — `super` re-dispatches on
+      the same receiver).
+    - `_sir_current_self()` (`__self__`), `_sir_ivar_get`/`_sir_ivar_set` on the
+      current self (self-stack top, with a default-self so top-level `@x` never
+      panics), and `_sir_cvar_get`/`_sir_cvar_set` for class variables.
+  - **Emit arms** (`emit::emit_builtin_call`, mirroring `__method__`):
+    `__new__`→`_sir_call_new`, `__super__`→`_sir_call_super`,
+    `__def_method__`/`__def_class_method__`→ the table registrations,
+    `__self__`→`_sir_current_self`.  Class/method names ride in as `StrLit`s and
+    are emitted through `quote_go_string` — never interpolated.
+  - **`@ivar` / `@@cvar`** (`emit::emit_var_ref` + `emit_stmt`):
+    `VarRef`/`Assign{scope:Instance}` → `_sir_ivar_get`/`set("@x", …)`;
+    `scope:ClassVar` → the `_sir_cvar_*` helpers.
+  - **Feature acceptance** (`lib.rs`): `ACCEPTED_FEATURES` now includes
+    `InstanceVars` + `ClassVars` (alongside the existing `Classes`/`Constants`),
+    so a REAL OO module is accepted and routed through the runtime.  The existing
+    soundness gate still cleanly REJECTS genuinely-unsupported constructs — a
+    general `Const` used as a value, a `Const` assignment, a `ModuleDef`
+    (`Feature::Modules` stays unaccepted — no mixin/MRO runtime in v0).
+  - **SECURITY (the C3 RCE lesson).**  Dispatch is ONLY an explicit map lookup on
+    the `(class, method)` key — NEVER Go `reflect`/`MethodByName` on a
+    source-derived name.  A class/method named `constructor`/`__proto__` is just
+    a map key (a miss → the clean NoMethodError floor).  Every ancestry walk
+    carries a `seen` set so a cyclic hierarchy TERMINATES; self-stack pops go
+    through `defer` so a panic still unwinds correctly.
+  - **Tests.**  Emitted-shape unit tests for the five builtins + `@ivar`/`@@cvar`
+    refs, plus `tests/compile_and_run_oop.rs` execution proofs through `go run`:
+    P1 (`Dog.new("Rex").speak` → `Rex`), P2 (inheritance + `super`, parent-set
+    ivar visible → `4`), a security case (class/method named `constructor`
+    dispatches the user method; unknown `__proto__` hits the NoMethodError
+    floor), and a cyclic-ancestry-terminates case.
+
 ## 0.8.0
 
 ### Added

--- a/code/packages/rust/semantic-ir-to-go/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-go/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-go"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 description = "Semantic IR → self-contained Go source code (SIR15). Fourth backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-go/README.md
+++ b/code/packages/rust/semantic-ir-to-go/README.md
@@ -231,10 +231,42 @@ func() {
   catches a raised `MyErr`.
 - **Security.**  Rescue matching is an **explicit string-map lookup**, never
   reflection on a Go type name; the ancestry walk carries a `seen` set so a
-  cyclic user hierarchy (`class A<B; class B<A`) terminates.  `Feature::Classes`/
-  `Constants` are accepted **only** for exception subclasses / `raise ClassName`
-  refs — any other class/const usage is rejected cleanly by
-  `check_exception_soundness`, so accepting them never admits general OOP.
+  cyclic user hierarchy (`class A<B; class B<A`) terminates.  The
+  `_sir_ancestry` table this builds is **shared** with the O4 OOP class
+  hierarchy below — one hierarchy for the whole runtime.
+
+## O4 — user-defined class OOP (`InstanceVars` / `ClassVars` + `Classes`)
+
+The backend EXECUTES real user-defined classes — method dispatch, `Foo.new`,
+`self`, `super`, `@ivar`/`@@cvar` — not just exception subclasses.  Because the
+Ruby frontend HOISTS every method to a detached top-level function, the
+method↔class association is recovered at **runtime** with explicit tables.
+
+- **Instances.**  `SirInstance { Class string; Ivars map[string]Value }`; an
+  `@ivar` reads/writes the *current self* (a single-threaded self-stack top,
+  with a default-self so top-level `@x` never panics).  This is the documented
+  v0 model; true per-object/per-thread `self` is out of scope for v0.
+- **Method tables.**  Instance and class methods live in `map[string]Value`
+  keyed by a NUL-joined `class + "\x00" + method` string, populated by emitted
+  `__def_method__` / `__def_class_method__` registrations.  The stored value is
+  the hoisted top-level function as a `*Closure`, invoked via `_sir_apply`.
+- **`new` / `super` / `self`.**  `Foo.new(args)` (`__new__`) allocates, pushes
+  self, resolves an inherited `initialize` (walking the shared `_sir_ancestry`,
+  seen-guarded), applies it, and pops self via `defer`; `super` (`__super__`)
+  walks from the superclass with the **current** self still bound; `self`
+  (`__self__`) returns the self-stack top.
+- **Dispatch.**  `recv.m(args)` reaches `_sir_call_method`; a `*SirInstance`
+  receiver resolves the user table walking ancestry (a miss falls through to the
+  universal Object methods, else the NoMethodError floor).  Non-instance
+  receivers reach the C5 collection catalog **unchanged**.
+- **Security.**  Dispatch is an **explicit `(class, method)` map lookup** —
+  never Go `reflect`/`MethodByName` on a source-derived name.  A class/method
+  named `constructor`/`__proto__` is just a map key (a miss → the clean
+  NoMethodError floor).  Ancestry walks are cycle-guarded; self-stack pops go
+  through `defer` so a panic still unwinds.  `Feature::Modules` stays
+  **unaccepted** (no mixin/MRO runtime in v0), and a general `Const` used as a
+  value / a `Const` assignment / a `ModuleDef` are still rejected cleanly by the
+  soundness gate — the widened acceptance never admits those.
 
 ## Value model
 

--- a/code/packages/rust/semantic-ir-to-go/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/emit.rs
@@ -343,6 +343,21 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
             emit_expr(out, value, indent);
             out.push('\n');
         }
+        // ── O4 `@ivar` / `@@cvar` writes ────────────────────────────
+        // `@x = v` sets the ivar on the current self; `@@x = v` sets the
+        // class variable.  The full sigil name is the runtime key.  The
+        // helper returns the value; we discard it (`_ = …`) in statement
+        // position.
+        Stmt::Assign { name, scope: Scope::Instance, value, .. } => {
+            let _ = write!(out, "{}_ = _sir_ivar_set({}, ", pad, quote_go_string(name));
+            emit_expr(out, value, indent);
+            out.push_str(")\n");
+        }
+        Stmt::Assign { name, scope: Scope::ClassVar, value, .. } => {
+            let _ = write!(out, "{}_ = _sir_cvar_set({}, ", pad, quote_go_string(name));
+            emit_expr(out, value, indent);
+            out.push_str(")\n");
+        }
         // ── SIR16 loops (Loops) ─────────────────────────────────────
         Stmt::While { cond, body, .. } => emit_while(out, cond, body, indent),
         Stmt::ForRange { var, start, stop, step, body, .. } => {
@@ -373,10 +388,10 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
             emit_expr(out, value, indent);
             out.push_str(")\n");
         }
-        // An `Assign` to an Instance/ClassVar/Const/Builtin scope: those
-        // scopes belong to SIR17 features this backend does not accept
-        // (or, for Builtin, are never produced by any frontend), so a
-        // validated module never reaches here.
+        // An `Assign` to a Const/Builtin scope: `Const` writes have no
+        // runtime store here (rejected by `check_no_general_const`), and
+        // `Builtin` is never produced by any frontend, so a validated module
+        // never reaches this arm.  (Instance/ClassVar are handled above.)
         Stmt::Assign { span, .. } => {
             panic!("go backend reached an Assign to an unsupported scope at {} — capability check should have rejected it", span);
         }
@@ -744,15 +759,13 @@ fn emit_var_ref(out: &mut String, name: &str, scope: Scope) {
             let _ = write!(out, "_sir_builtin_closure({})", quote_go_string(name));
         }
         Scope::Instance => {
-            // SIR17 Phase 15a — `Feature::InstanceVars` is not in this
-            // backend's accepted set, so an instance-var-using module is
-            // rejected at the capability check before emit.  Unreachable.
-            panic!("go backend reached SIR17 instance-var ref `{}` — capability check should have rejected it", name);
+            // O4 — `@ivar` read.  Routes through the runtime's current-self
+            // store; the full sigil name (`@x`) is preserved as the key.
+            let _ = write!(out, "_sir_ivar_get({})", quote_go_string(name));
         }
         Scope::ClassVar => {
-            // SIR17 Phase 15b — `Feature::ClassVars` likewise unaccepted;
-            // class-var modules are rejected before emit.  Unreachable.
-            panic!("go backend reached SIR17 class-var ref `{}` — capability check should have rejected it", name);
+            // O4 — `@@cvar` read (single flat namespace keyed by `@@name`).
+            let _ = write!(out, "_sir_cvar_get({})", quote_go_string(name));
         }
         Scope::Const => {
             // SIR17 Phase 15c — `Feature::Constants` likewise unaccepted;
@@ -981,6 +994,64 @@ fn emit_builtin_call(out: &mut String, name: &str, args: &[Expr], indent: usize)
             out.push_str("})");
             return;
         }
+    }
+    // ── O4 user-defined-class OOP builtins ─────────────────────────
+    //
+    // The Ruby frontend (O2) emits five OOP builtins that mirror the
+    // `__method__`→`_sir_call_method` routing.  Class and method NAMES ride
+    // in as `StrLit`s and are emitted through `quote_go_string` — never
+    // interpolated — so the runtime side is a pure `(class, method)` map
+    // lookup with no reflection (the C3 RCE discipline).
+    //
+    //   __new__(StrLit(cls), args…)               → _sir_call_new("cls", args…)
+    //   __super__(StrLit(m), StrLit(cls), args…)  → _sir_call_super("m", "cls", args…)
+    //   __def_method__(StrLit(cls), StrLit(m), fn)       → _sir_def_method("cls", "m", fn)
+    //   __def_class_method__(StrLit(cls), StrLit(m), fn) → _sir_def_class_method("cls", "m", fn)
+    //   __self__()                                → _sir_current_self()
+    if name == "__new__" {
+        if let Some(Expr::StrLit { value: cls, .. }) = args.first() {
+            let _ = write!(out, "_sir_call_new({}", quote_go_string(cls));
+            for a in &args[1..] {
+                out.push_str(", ");
+                emit_expr(out, a, indent);
+            }
+            out.push(')');
+            return;
+        }
+    }
+    if name == "__super__" {
+        if let (Some(Expr::StrLit { value: meth, .. }), Some(Expr::StrLit { value: cls, .. })) =
+            (args.first(), args.get(1))
+        {
+            let _ = write!(
+                out,
+                "_sir_call_super({}, {}",
+                quote_go_string(meth),
+                quote_go_string(cls)
+            );
+            for a in &args[2..] {
+                out.push_str(", ");
+                emit_expr(out, a, indent);
+            }
+            out.push(')');
+            return;
+        }
+    }
+    if (name == "__def_method__" || name == "__def_class_method__") && args.len() >= 3 {
+        if let (Expr::StrLit { value: cls, .. }, Expr::StrLit { value: meth, .. }) =
+            (&args[0], &args[1])
+        {
+            let helper =
+                if name == "__def_method__" { "_sir_def_method" } else { "_sir_def_class_method" };
+            let _ = write!(out, "{}({}, {}, ", helper, quote_go_string(cls), quote_go_string(meth));
+            emit_expr(out, &args[2], indent);
+            out.push(')');
+            return;
+        }
+    }
+    if name == "__self__" {
+        out.push_str("_sir_current_self()");
+        return;
     }
     // ── SIR17 exceptions (E3): `raise` → panic ─────────────────────
     //
@@ -2499,5 +2570,158 @@ mod tests {
             src.contains(r#""MyErr": "StandardError","#),
             "must register the MyErr → StandardError edge; got:\n{src}"
         );
+    }
+
+    // ── O4: user-defined-class OOP emission shapes ────────────────────────
+
+    fn builtin(name: &str, args: Vec<Expr>) -> Expr {
+        Expr::BuiltinCall { name: name.into(), args, effects: EffectSet::PURE, span: s() }
+    }
+
+    fn str_lit(v: &str) -> Expr {
+        Expr::StrLit { value: v.into(), span: s() }
+    }
+
+    /// `__new__("Dog", arg)` → `_sir_call_new("Dog", <arg>)`.
+    #[test]
+    fn new_emits_call_new_with_class_name_string() {
+        let e = builtin("__new__", vec![str_lit("Dog"), str_lit("Rex")]);
+        let mut out = String::new();
+        emit_expr(&mut out, &e, 0);
+        assert_eq!(out, r#"_sir_call_new("Dog", Value("Rex"))"#);
+    }
+
+    /// A class name with a NUL/quote is still safely quoted (no interpolation).
+    #[test]
+    fn new_with_zero_args_emits_bare_call() {
+        let e = builtin("__new__", vec![str_lit("Widget")]);
+        let mut out = String::new();
+        emit_expr(&mut out, &e, 0);
+        assert_eq!(out, r#"_sir_call_new("Widget")"#);
+    }
+
+    /// `__super__("describe", "Cat", arg)` → `_sir_call_super("describe", "Cat", <arg>)`.
+    #[test]
+    fn super_emits_call_super_with_method_and_class() {
+        let e = builtin(
+            "__super__",
+            vec![str_lit("describe"), str_lit("Cat"), Expr::IntLit { value: 4, span: s() }],
+        );
+        let mut out = String::new();
+        emit_expr(&mut out, &e, 0);
+        assert_eq!(out, r#"_sir_call_super("describe", "Cat", Value(int64(4)))"#);
+    }
+
+    /// `__def_method__("Dog", "speak", <closure>)` → `_sir_def_method("Dog", "speak", <closure>)`.
+    #[test]
+    fn def_method_emits_registration() {
+        FN_ARITY.with(|t| t.borrow_mut().insert("speak_impl".into(), 0));
+        let closure =
+            Expr::MakeClosure { fn_name: "speak_impl".into(), captures: vec![], span: s() };
+        let e = builtin("__def_method__", vec![str_lit("Dog"), str_lit("speak"), closure]);
+        let mut out = String::new();
+        emit_expr(&mut out, &e, 0);
+        FN_ARITY.with(|t| t.borrow_mut().clear());
+        assert!(
+            out.starts_with(r#"_sir_def_method("Dog", "speak", _sir_make_closure("#),
+            "unexpected emit: {out}"
+        );
+    }
+
+    /// `__def_class_method__` routes to the class-method table registration.
+    #[test]
+    fn def_class_method_emits_class_registration() {
+        FN_ARITY.with(|t| t.borrow_mut().insert("zero_impl".into(), 0));
+        let closure =
+            Expr::MakeClosure { fn_name: "zero_impl".into(), captures: vec![], span: s() };
+        let e = builtin("__def_class_method__", vec![str_lit("Counter"), str_lit("zero"), closure]);
+        let mut out = String::new();
+        emit_expr(&mut out, &e, 0);
+        FN_ARITY.with(|t| t.borrow_mut().clear());
+        assert!(
+            out.starts_with(r#"_sir_def_class_method("Counter", "zero", _sir_make_closure("#),
+            "unexpected emit: {out}"
+        );
+    }
+
+    /// `__self__()` → `_sir_current_self()`.
+    #[test]
+    fn self_emits_current_self() {
+        let e = builtin("__self__", vec![]);
+        let mut out = String::new();
+        emit_expr(&mut out, &e, 0);
+        assert_eq!(out, "_sir_current_self()");
+    }
+
+    /// A `@ivar` read (`VarRef{Instance}`) → `_sir_ivar_get("@name")`.
+    #[test]
+    fn ivar_ref_emits_ivar_get() {
+        let e = Expr::VarRef { name: "@name".into(), scope: Scope::Instance, span: s() };
+        let mut out = String::new();
+        emit_expr(&mut out, &e, 0);
+        assert_eq!(out, r#"_sir_ivar_get("@name")"#);
+    }
+
+    /// A `@@cvar` read (`VarRef{ClassVar}`) → `_sir_cvar_get("@@count")`.
+    #[test]
+    fn cvar_ref_emits_cvar_get() {
+        let e = Expr::VarRef { name: "@@count".into(), scope: Scope::ClassVar, span: s() };
+        let mut out = String::new();
+        emit_expr(&mut out, &e, 0);
+        assert_eq!(out, r#"_sir_cvar_get("@@count")"#);
+    }
+
+    /// A `@ivar` write (`Assign{Instance}`) → `_ = _sir_ivar_set("@x", <v>)`.
+    #[test]
+    fn ivar_assign_emits_ivar_set() {
+        let s0 = Stmt::Assign {
+            name: "@x".into(),
+            scope: Scope::Instance,
+            value: Expr::IntLit { value: 7, span: s() },
+            span: s(),
+        };
+        let mut out = String::new();
+        emit_stmt(&mut out, &s0, 0);
+        assert_eq!(out, "_ = _sir_ivar_set(\"@x\", Value(int64(7)))\n");
+    }
+
+    /// A `@@cvar` write (`Assign{ClassVar}`) → `_ = _sir_cvar_set("@@n", <v>)`.
+    #[test]
+    fn cvar_assign_emits_cvar_set() {
+        let s0 = Stmt::Assign {
+            name: "@@n".into(),
+            scope: Scope::ClassVar,
+            value: Expr::IntLit { value: 0, span: s() },
+            span: s(),
+        };
+        let mut out = String::new();
+        emit_stmt(&mut out, &s0, 0);
+        assert_eq!(out, "_ = _sir_cvar_set(\"@@n\", Value(int64(0)))\n");
+    }
+
+    /// The OOP runtime helpers must be present in every emitted program's
+    /// inlined preamble.
+    #[test]
+    fn runtime_preamble_carries_oop_helpers() {
+        for helper in &[
+            "type SirInstance struct",
+            "func _sir_new_instance(cls string) *SirInstance",
+            "func _sir_def_method(cls string, method string, fn Value) Value",
+            "func _sir_def_class_method(cls string, method string, fn Value) Value",
+            "func _sir_call_new(cls string, args ...Value) Value",
+            "func _sir_call_super(method string, cls string, args ...Value) Value",
+            "func _sir_current_self() Value",
+            "func _sir_ivar_get(name string) Value",
+            "func _sir_ivar_set(name string, value Value) Value",
+            "func _sir_cvar_get(name string) Value",
+            "func _sir_cvar_set(name string, value Value) Value",
+            "func _sir_resolve_instance_method(cls string, method string) (Value, bool)",
+        ] {
+            assert!(RUNTIME.contains(helper), "runtime missing `{}`", helper);
+        }
+        // Dispatch keys on a NUL-joined (class, method) string — never reflection.
+        assert!(RUNTIME.contains(r#"return cls + "\x00" + method"#));
+        // The user-object path in call_method must resolve + push/pop self.
+        assert!(RUNTIME.contains("if inst, ok := recv.(*SirInstance); ok"));
     }
 }

--- a/code/packages/rust/semantic-ir-to-go/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/lib.rs
@@ -125,24 +125,37 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     // with a deferred `recover` (Go has no native try/catch) and the `raise`
     // builtin onto `panic(_sir_new_error(...))`.  See `emit::emit_try_catch`.
     Feature::Exceptions,
-    // `Classes` + `Constants` are accepted ONLY to admit exception-*subclass*
-    // declarations and the `raise Foo`/`rescue Foo` class-name refs they
-    // carry — NOT general OOP.  A `class MyErr < StandardError` contributes a
-    // single ANCESTRY edge (registered at init) and its `raise ClassName`
-    // first-arg is a `VarRef{Const}` intercepted in `emit::emit_builtin_call`.
+    // ── O4 — user-defined-class OOP ────────────────────────────────
     //
-    // Accepting these two features is SOUND because the ONLY class/const
-    // shapes the backend can emit are those two exception-specific ones; any
-    // OTHER class/const usage is rejected CLEANLY (not mis-emitted) by
-    // `check_exception_soundness` below:
-    //   * a class body carrying instance/class variables observes
-    //     `InstanceVars`/`ClassVars` (NOT accepted) → rejected at the manifest
-    //     gate; a method-bearing class hoists its `def`s to top-level
-    //     Functions, so the ClassDef body is ordinary supported statements;
-    //   * a `Const` reference or assignment OUTSIDE the whitelisted
-    //     `raise ClassName` position → rejected by `check_no_general_const`.
+    // `Classes` + `Constants` were first accepted (post-E3) only to admit
+    // exception-*subclass* declarations; O4 widens acceptance to REAL
+    // user-defined classes by ALSO accepting `InstanceVars`/`ClassVars`.  A
+    // real OO module now routes through the inlined OOP runtime (see
+    // `runtime::RUNTIME` — `_sir_call_new`/`_sir_call_super`/the
+    // `*SirInstance` path in `_sir_call_method`, `_sir_ivar_get`/`set`,
+    // `_sir_cvar_get`/`set`) rather than being rejected:
+    //   * `class C < B` still contributes ONE ANCESTRY edge (shared with the
+    //     exception hierarchy) registered at init;
+    //   * instance methods hoist to top-level Functions and are wired to their
+    //     class at runtime by emitted `__def_method__` registrations;
+    //   * `C.new`/`super`/`self` lower to the `__new__`/`__super__`/`__self__`
+    //     builtins, whose class/method NAMES ride in as `StrLit`s (never a
+    //     `Const` ref) and are emitted through `quote_go_string` — so dispatch
+    //     stays a pure `(class, method)` map lookup, NEVER reflection;
+    //   * `@ivar`/`@@cvar` lower to `VarRef`/`Assign{Instance|ClassVar}`,
+    //     emitted as `_sir_ivar_get/set` / `_sir_cvar_get/set`.
+    //
+    // Accepting these features stays SOUND: the widened surface does NOT emit a
+    // general `Const` reference (a class name reaches the backend only as a
+    // `StrLit` inside a builtin, or a `raise Foo` first-arg `Const` — both
+    // handled explicitly), so `check_exception_soundness` below STILL cleanly
+    // rejects genuinely-unsupported constructs — a `Const` used as a value
+    // (`x = MyClass`), a `Const` assignment (`FOO = 4`), and a `ModuleDef`
+    // (`Feature::Modules` remains UNACCEPTED — no mixin/MRO runtime in v0).
     Feature::Classes,
     Feature::Constants,
+    Feature::InstanceVars,
+    Feature::ClassVars,
 ];
 
 impl Backend for GoBackend {
@@ -786,17 +799,17 @@ mod tests {
         assert!(a.source.contains(r#", "length", []Value{}"#));
     }
 
-    // ── E3 soundness: full OOP class semantics stay REJECTED ──────────────
+    // ── O4: a class carrying instance vars is now ACCEPTED ────────────────
     //
-    // Post-E3 the Go backend accepts `Feature::Classes`/`Constants`, but ONLY
-    // for exception subclasses.  A class carrying INSTANCE VARIABLES observes
-    // `Feature::InstanceVars` (which we do NOT accept), so it is rejected at
-    // the manifest gate — accepting `Classes` never admits real OOP.
-    // (`Block`, `Stmt`, `Scope`, … are already imported by the KW6 test
-    // block above; `sp()` is the shared span helper.)
-
+    // Pre-O4 this exact module (a `ClassDef` whose body assigns `@count`,
+    // observing `Feature::InstanceVars`) was REJECTED at the manifest gate.
+    // O4 accepts `InstanceVars`/`ClassVars`, so a real OO module now compiles:
+    // the ivar assign lowers to `_sir_ivar_set("@count", …)` and the class
+    // itself emits no top-level code (its ancestry edge, if any, registers at
+    // init).  (`Block`, `Stmt`, `Scope`, … are already imported by the KW6
+    // test block above; `sp()` is the shared span helper.)
     #[test]
-    fn class_with_instance_vars_still_rejected() {
+    fn class_with_instance_vars_now_accepted() {
         // class Counter; @count = 0; end   (an ivar assign in the body)
         let class = Stmt::ClassDef {
             name: "Counter".into(),
@@ -828,6 +841,7 @@ mod tests {
             manifest: FeatureManifest::from_features(&[
                 Feature::Classes,
                 Feature::InstanceVars,
+                Feature::MutableBindings,
             ]),
             imports: vec![],
             exports: vec![],
@@ -838,14 +852,12 @@ mod tests {
                 .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
             span: sp(),
         };
-        // Rejected CLEANLY (an `Err`, never a panic/mis-emit).  The rejection
-        // may come from the manifest gate (`InstanceVars` unaccepted) — the
-        // point is that accepting `Classes` never admits real OOP.
-        let err = compile(&m).expect_err("instance-var class must stay rejected");
-        assert!(matches!(
-            err.kind,
-            BackendErrorKind::UnsupportedFeature | BackendErrorKind::InvalidModule
-        ));
+        let a = compile(&m).expect("O4: instance-var class must now compile");
+        assert!(
+            a.source.contains(r#"_sir_ivar_set("@count", "#),
+            "expected ivar-set emission; got:\n{}",
+            a.source
+        );
     }
 
     // A general constant assignment (`FOO = 4`) is rejected CLEANLY — the E3

--- a/code/packages/rust/semantic-ir-to-go/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/runtime.rs
@@ -982,6 +982,33 @@ func _sir_sym_to_proc(sym Value) Value {
 
 // Public dispatch entry point emitted for every `__method__` call.
 func _sir_call_method(recv Value, name string, args []Value) Value {
+	// ── O4 user-object path ────────────────────────────────────────
+	//
+	// When `recv` is a user `*SirInstance`, a method registered via
+	// `_sir_def_method` (walking the class's ancestry through the shared
+	// `_sir_ancestry` table) is dispatched FIRST: push the receiver as the
+	// current self, apply the stored closure, pop via `defer` (panic-safe).
+	// Resolution is an EXPLICIT `(class, method)` map lookup — never
+	// reflection — so a method named `constructor`/`__proto__` simply misses.
+	//
+	// Only if NO user method resolves does dispatch FALL THROUGH to the
+	// universal Object methods below (so `obj.class` / `obj.nil?` still work
+	// on an instance).  A `*SirInstance` is neither Seq/Map/String/etc., so
+	// it skips the collection/primitive catalogs entirely and is UNCHANGED
+	// for those receiver types.
+	if inst, ok := recv.(*SirInstance); ok {
+		if fn, found := _sir_resolve_instance_method(inst.Class, name); found {
+			_sir_push_self(inst)
+			defer _sir_pop_self()
+			return _sir_apply(fn, args)
+		}
+		// Universal Object methods (class/nil?/==/…) still apply to an
+		// instance; anything else is the controlled NoMethodError floor.
+		if v, ok := _sir_object_method(recv, name, args); ok {
+			return v
+		}
+		return _sir_method_unknown(recv, name)
+	}
 	// Type-specific catalogs first (a String is neither Seq nor Map).
 	// `bool` is checked before the numeric arm so `true`/`false` never
 	// enter the numeric catalog (they resolve only universal methods).
@@ -1031,6 +1058,11 @@ func _sir_method_unknown(recv Value, name string) Value {
 func _sir_ruby_class_name(v Value) string {
 	if v == nil {
 		return "NilClass"
+	}
+	// A user instance reports its own class tag (so `obj.class` and a
+	// NoMethodError message name the real class, e.g. `Dog`).
+	if inst, ok := v.(*SirInstance); ok {
+		return inst.Class
 	}
 	switch t := v.(type) {
 	case bool:
@@ -1699,6 +1731,206 @@ func _sir_rescue_matches(r any, classNames []string) bool {
 		}
 	}
 	return false
+}
+
+// ── O4 user-defined-class OOP (instances, method tables, self/super) ──
+//
+// The Ruby→SIR frontend HOISTS every `def` inside a class to a detached
+// top-level function with NO receiver — nothing in the IR records that
+// `speak` belongs to `Dog`.  We recover that association at RUNTIME with two
+// explicit method tables, populated by emitted `__def_method__` /
+// `__def_class_method__` registrations.  This is the Go analogue of the
+// Python/TS `sir-runtime-oop` `call_new`/`call_super`/`call_method`
+// user-object path, ported for cross-backend behavioural parity.
+//
+// ── SECURITY (the C3 RCE lesson, restated for OOP) ────────────────────
+// Dispatch is ONLY an explicit map lookup on the `(class, method)` key —
+// NEVER Go `reflect`/`MethodByName` on a source-derived name.  A class or
+// method perversely named `constructor` / `__proto__` / `initialize` is JUST
+// a map key: absent from the table ⇒ a clean miss ⇒ the ordinary
+// `_sir_method_unknown` (NoMethodError-shaped) floor or a `nil` `super`
+// result, never host behaviour.  Every ancestry walk carries a `seen` set so
+// a malicious cyclic hierarchy (`class A<B; class B<A`) TERMINATES instead of
+// looping forever.  Self-stack pops go through `defer`, so even a panic inside
+// a method body still unwinds the stack correctly.
+
+// A SIR object instance: a class-name tag plus a bag of instance variables.
+// `Ivars` is keyed by the FULL Ruby sigil name (`"@name"`), matching how the
+// frontend lowers an `@ivar` reference — the sigil is part of the key, never
+// stripped, so `@x` and a hypothetical local `x` can never collide.
+type SirInstance struct {
+	Class string
+	Ivars map[string]Value
+}
+
+// Allocate a fresh instance tagged with `cls` and an empty ivar bag.
+func _sir_new_instance(cls string) *SirInstance {
+	return &SirInstance{Class: cls, Ivars: make(map[string]Value)}
+}
+
+// ── Method tables ─────────────────────────────────────────────────────
+//
+// Instance methods (`def m`) and class methods (`def self.m`) live in two
+// separate maps keyed by `class + "\x00" + method`.  A NUL joiner is used
+// (rather than a `[2]string` composite key) because a NUL byte cannot appear
+// in a Ruby class or method identifier, so the flattened key is unambiguous —
+// and, crucially, it is a PLAIN VALUE lookup with no reflection.  The value is
+// a `*Closure` (the hoisted top-level function captured by an emitted
+// `MakeClosure`), invoked via `_sir_apply`.
+var _sir_instance_methods = make(map[string]Value)
+var _sir_class_methods = make(map[string]Value)
+
+// The NUL-joined table key for a `(class, method)` pair.
+func _sir_method_key(cls string, method string) string {
+	return cls + "\x00" + method
+}
+
+// Register an instance method (`__def_method__`) / class method
+// (`__def_class_method__`).  Called once per method at program init.  Each
+// returns the closure so the emitter may use the registration in expression
+// position, mirroring the other builtins' `Value`-returning convention.
+func _sir_def_method(cls string, method string, fn Value) Value {
+	_sir_instance_methods[_sir_method_key(cls, method)] = fn
+	return fn
+}
+
+func _sir_def_class_method(cls string, method string, fn Value) Value {
+	_sir_class_methods[_sir_method_key(cls, method)] = fn
+	return fn
+}
+
+// Resolve `method` on `cls` OR any registered ancestor, walking the SHARED
+// `_sir_ancestry` table (the very table exception `rescue` uses — one
+// hierarchy for the whole runtime).  The `seen` set makes the walk total even
+// for a cyclic user hierarchy.  Returns the closure and `true` on a hit, or
+// `(nil, false)` when unresolved.
+func _sir_resolve_instance_method(cls string, method string) (Value, bool) {
+	cur := cls
+	seen := make(map[string]bool)
+	for cur != "" && !seen[cur] {
+		if fn, ok := _sir_instance_methods[_sir_method_key(cur, method)]; ok {
+			return fn, true
+		}
+		seen[cur] = true
+		cur = _sir_ancestry[cur] // "" when `cur` has no registered super
+	}
+	return nil, false
+}
+
+// ── Current-self stack + instance-variable store ──────────────────────
+//
+// The single-threaded self-stack: `_sir_call_new` / instance-method dispatch
+// push the receiver before running a body and pop after (via `defer`), so an
+// `@ivar` reference inside the body reads the right object with NO explicit
+// `self` parameter.  This is the documented v0 model — correct for the
+// single-threaded transpiled scripts we target; true per-object/per-thread
+// binding is out of scope for v0 (consistent with the runtime note).
+var _sir_self_stack []*SirInstance
+
+// A program that never pushes a self (a top-level `@x`) still needs somewhere
+// to put instance variables; this default object provides it so `@x`
+// reads/writes never panic.
+var _sir_default_self = &SirInstance{Class: "Object", Ivars: make(map[string]Value)}
+
+func _sir_current_self_obj() *SirInstance {
+	if len(_sir_self_stack) > 0 {
+		return _sir_self_stack[len(_sir_self_stack)-1]
+	}
+	return _sir_default_self
+}
+
+func _sir_push_self(obj *SirInstance) {
+	_sir_self_stack = append(_sir_self_stack, obj)
+}
+
+func _sir_pop_self() {
+	if len(_sir_self_stack) > 0 {
+		_sir_self_stack = _sir_self_stack[:len(_sir_self_stack)-1]
+	}
+}
+
+// `__self__` — a bare `self` in a method body.  Returns the current receiver
+// (top of the self-stack), or `nil` (Ruby `nil`) at top level where no
+// receiver is bound — never the internal default-self sentinel.
+func _sir_current_self() Value {
+	if len(_sir_self_stack) > 0 {
+		return _sir_self_stack[len(_sir_self_stack)-1]
+	}
+	return nil
+}
+
+// `@ivar` read: the value on the current self, or `nil` for an unset ivar
+// (Ruby reads an unset `@x` as nil — no error).
+func _sir_ivar_get(name string) Value {
+	if v, ok := _sir_current_self_obj().Ivars[name]; ok {
+		return v
+	}
+	return nil
+}
+
+// `@ivar` write on the current self; returns the written value so `@x = v`
+// can be used in expression position.
+func _sir_ivar_set(name string, value Value) Value {
+	_sir_current_self_obj().Ivars[name] = value
+	return value
+}
+
+// ── Class-variable store (`@@cvar`) ───────────────────────────────────
+//
+// Ruby class variables are shared across a class and its instances.  The v0
+// model keys them by their bare `@@name` in a single flat namespace (matching
+// the Python/TS reference's single-namespace `cvar` store), which faithfully
+// models single-class programs; per-class-hierarchy scoping awaits a frontend
+// that threads the enclosing class.
+var _sir_cvars = make(map[string]Value)
+
+func _sir_cvar_get(name string) Value {
+	if v, ok := _sir_cvars[name]; ok {
+		return v
+	}
+	return nil
+}
+
+func _sir_cvar_set(name string, value Value) Value {
+	_sir_cvars[name] = value
+	return value
+}
+
+// `Foo.new(args…)` — allocate a `cls` instance and run its `initialize`.
+//
+// Allocates via `_sir_new_instance`, pushes the new object as the current
+// self, and — if an `initialize` is registered for `cls` or any ancestor —
+// invokes it with `args` (so `@ivar` assignments in the constructor land on
+// the new object).  Self is popped via `defer` (so a panic in `initialize`
+// still unwinds cleanly), and the object is always returned — even with no
+// `initialize` (a plain allocation).
+func _sir_call_new(cls string, args ...Value) Value {
+	obj := _sir_new_instance(cls)
+	_sir_push_self(obj)
+	defer _sir_pop_self()
+	if initializer, ok := _sir_resolve_instance_method(cls, "initialize"); ok {
+		_sir_apply(initializer, args)
+	}
+	return obj
+}
+
+// `super` — re-run `method` from `cls`'s PARENT.
+//
+// Walks from `_sir_ancestry[cls]` upward and invokes the first ancestor
+// implementation of `method` with `args`, keeping the CURRENT self bound
+// (`super` is a re-dispatch on the same receiver, so there is no push/pop
+// here).  If no ancestor defines the method, returns `nil` (Ruby `nil`) — the
+// runtime's honest floor, consistent with `_sir_call_method`'s user-object
+// path.
+func _sir_call_super(method string, cls string, args ...Value) Value {
+	parent := _sir_ancestry[cls] // "" when `cls` has no registered super
+	if parent == "" {
+		return nil
+	}
+	if fn, ok := _sir_resolve_instance_method(parent, method); ok {
+		return _sir_apply(fn, args)
+	}
+	return nil
 }
 
 "##;

--- a/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_oop.rs
+++ b/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_oop.rs
@@ -1,0 +1,371 @@
+//! Execution proof for O4 user-defined-class OOP: hand-build a SIR module,
+//! emit Go, run it with `go run`, and assert the observable behaviour matches
+//! Ruby object semantics (method dispatch, `new`→`initialize`, inheritance +
+//! `super`, `@ivar` through the current-self stack).
+//!
+//! The Go backend has NO native object model — the frontend HOISTS every
+//! method to a detached top-level function, and the runtime recovers the
+//! method↔class association at RUNTIME via explicit `(class, method)` map
+//! tables (`runtime::RUNTIME`).  These cases prove the mapping end-to-end:
+//!
+//!   P1  `Dog.new("Rex").speak` — `initialize` stores `@name`, `speak` reads
+//!       it back through the current-self stack → prints "Rex".
+//!   P2  inheritance + `super` — `Cat < Animal`; `Animal#initialize` sets
+//!       `@legs`, `Cat#initialize` calls `super` then a `describe` reads the
+//!       parent-set ivar → prints "4" (discriminating: proves super ran AND
+//!       the parent-set ivar is visible on the SAME self).
+//!   SEC a class AND method named `constructor` — a source-derived name that
+//!       is host-significant in JS engines — is JUST a map key here: it
+//!       dispatches the USER method (a clean lookup), never host behaviour,
+//!       and an UNregistered `__proto__` call hits the NoMethodError floor.
+//!   CYC a cyclic ancestry (`A < B`, `B < A`) TERMINATES rather than looping:
+//!       `A.new` with no `initialize` anywhere returns cleanly (exit 0).
+//!
+//! To avoid StrLit interpolation (which the Go backend rejects) every program
+//! prints a single value — the ivar or a numeric marker — with no `#{}`.
+//!
+//! A missing `go` toolchain logs a skip rather than reddening the build
+//! (mirrors `compile_and_run_exceptions.rs`).
+
+use std::process::Command;
+
+use semantic_ir::{
+    Block, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, Param, ParamKind,
+    Scope, Span, Stmt,
+};
+use semantic_ir_to_go::compile;
+
+fn s() -> Span {
+    Span::synthetic()
+}
+
+fn str_lit(v: &str) -> Expr {
+    Expr::StrLit { value: v.into(), span: s() }
+}
+
+fn int_lit(n: i64) -> Expr {
+    Expr::IntLit { value: n, span: s() }
+}
+
+fn param_ref(name: &str) -> Expr {
+    Expr::VarRef { name: name.into(), scope: Scope::Param, span: s() }
+}
+
+fn param(name: &str) -> Param {
+    Param {
+        name: name.into(),
+        sir_type: None,
+        kind: ParamKind::Required,
+        default: None,
+        span: s(),
+    }
+}
+
+fn ivar_ref(name: &str) -> Expr {
+    Expr::VarRef { name: name.into(), scope: Scope::Instance, span: s() }
+}
+
+fn ivar_set(name: &str, value: Expr) -> Stmt {
+    Stmt::Assign { name: name.into(), scope: Scope::Instance, value, span: s() }
+}
+
+fn builtin(name: &str, args: Vec<Expr>) -> Expr {
+    Expr::BuiltinCall { name: name.into(), args, effects: EffectSet::PURE, span: s() }
+}
+
+fn print_stmt(v: Expr) -> Stmt {
+    Stmt::ExprStmt { expr: builtin("print", vec![v]), span: s() }
+}
+
+/// A hoisted method as a top-level function: `captures` are always empty
+/// (methods use the self-stack, not captures), params are positional.
+fn method_fn(fn_name: &str, params: Vec<Param>, body_stmts: Vec<Stmt>, value: Expr) -> Function {
+    Function {
+        name: fn_name.into(),
+        params,
+        return_type: None,
+        captures: vec![],
+        body: Block { stmts: body_stmts, value, span: s() },
+        effects: EffectSet::PURE,
+        metadata: Metadata::new(),
+        span: s(),
+    }
+}
+
+/// A `MakeClosure` over a hoisted method function (what `__def_method__`
+/// receives as its third argument).
+fn closure_of(fn_name: &str) -> Expr {
+    Expr::MakeClosure { fn_name: fn_name.into(), captures: vec![], span: s() }
+}
+
+fn def_method(cls: &str, meth: &str, fn_name: &str) -> Stmt {
+    Stmt::ExprStmt {
+        expr: builtin(
+            "__def_method__",
+            vec![str_lit(cls), str_lit(meth), closure_of(fn_name)],
+        ),
+        span: s(),
+    }
+}
+
+fn class_def(name: &str, superclass: Option<&str>, body: Vec<Stmt>) -> Stmt {
+    Stmt::ClassDef {
+        name: name.into(),
+        superclass: superclass.map(|s| s.to_string()),
+        body,
+        span: s(),
+    }
+}
+
+/// Assemble a module from a list of top-level functions + a `main` body.
+fn module_from(
+    name: &str,
+    mut functions: Vec<Function>,
+    main_stmts: Vec<Stmt>,
+    features: &[Feature],
+) -> Module {
+    functions.push(method_fn(
+        "main",
+        vec![],
+        main_stmts,
+        Expr::NilLit { span: s() },
+    ));
+    let mut fs = vec![
+        Feature::Classes,
+        Feature::InstanceVars,
+        Feature::Strings,
+        Feature::MutableBindings,
+        Feature::Closures,
+        Feature::DynamicTyping,
+    ];
+    fs.extend_from_slice(features);
+    Module {
+        name: name.into(),
+        manifest: FeatureManifest::from_features(&fs),
+        imports: vec![],
+        exports: vec![],
+        functions,
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("test")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+fn go_available() -> bool {
+    Command::new("go")
+        .arg("version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Emit `m` to Go, run it, and return `(success, stdout)`.  A COMPILE error
+/// (bad emit) panics loudly; a runtime non-zero exit returns the flag.
+fn emit_and_run(m: &Module, nonce: &str) -> (bool, String) {
+    let artifact = compile(m).expect("module should compile to Go source");
+    let dir = std::env::temp_dir();
+    let pid = std::process::id();
+    let src_path = dir.join(format!("sir_go_oop_{pid}_{nonce}.go"));
+    std::fs::write(&src_path, &artifact.source).expect("write temp source");
+    let run_out = Command::new("go")
+        .arg("run")
+        .arg(&src_path)
+        .output()
+        .expect("invoke go run");
+    if !run_out.status.success() {
+        let stderr = String::from_utf8_lossy(&run_out.stderr);
+        if stderr.contains("cannot")
+            || stderr.contains("syntax error")
+            || stderr.contains("undefined:")
+        {
+            let _ = std::fs::remove_file(&src_path);
+            panic!(
+                "emitted Go failed to COMPILE:\n--- stderr ---\n{stderr}\n--- source ---\n{}",
+                artifact.source
+            );
+        }
+    }
+    let stdout = String::from_utf8_lossy(&run_out.stdout).into_owned();
+    let ok = run_out.status.success();
+    let _ = std::fs::remove_file(&src_path);
+    (ok, stdout)
+}
+
+/// P1 — `Dog.new("Rex").speak` prints "Rex".
+///
+/// ```ruby
+/// class Dog
+///   def initialize(name); @name = name; end
+///   def speak; @name; end
+/// end
+/// print(Dog.new("Rex").speak)
+/// ```
+#[test]
+fn p1_dog_initialize_and_speak() {
+    if !go_available() {
+        eprintln!("skipping: go not on PATH");
+        return;
+    }
+    // def initialize(name); @name = name; end
+    let init = method_fn(
+        "Dog_initialize",
+        vec![param("name")],
+        vec![ivar_set("@name", param_ref("name"))],
+        Expr::NilLit { span: s() },
+    );
+    // def speak; @name; end   (value position: read the ivar back)
+    let speak = method_fn("Dog_speak", vec![], vec![], ivar_ref("@name"));
+
+    let class = class_def(
+        "Dog",
+        None,
+        vec![
+            def_method("Dog", "initialize", "Dog_initialize"),
+            def_method("Dog", "speak", "Dog_speak"),
+        ],
+    );
+    // Dog.new("Rex").speak → __method__(__new__("Dog", "Rex"), "speak")
+    let new_dog = builtin("__new__", vec![str_lit("Dog"), str_lit("Rex")]);
+    let speak_call = builtin("__method__", vec![new_dog, str_lit("speak")]);
+    let main = vec![class, print_stmt(speak_call)];
+
+    let m = module_from("p1_dog", vec![init, speak], main, &[]);
+    let (ok, out) = emit_and_run(&m, "p1");
+    assert!(ok, "P1 should exit 0; stdout:\n{out}");
+    assert_eq!(out.trim(), "Rex", "initialize-set @name must be readable through speak");
+}
+
+/// P2 — inheritance + `super`: `Cat < Animal`; the parent-set `@legs` is
+/// visible on the same self after `super`.  Prints "4".
+///
+/// ```ruby
+/// class Animal
+///   def initialize; @legs = 4; end
+/// end
+/// class Cat < Animal
+///   def initialize; super; end   # sets @legs via the parent on THIS self
+///   def legs; @legs; end
+/// end
+/// print(Cat.new.legs)
+/// ```
+#[test]
+fn p2_inheritance_and_super() {
+    if !go_available() {
+        eprintln!("skipping: go not on PATH");
+        return;
+    }
+    // Animal#initialize: @legs = 4
+    let animal_init = method_fn(
+        "Animal_initialize",
+        vec![],
+        vec![ivar_set("@legs", int_lit(4))],
+        Expr::NilLit { span: s() },
+    );
+    // Cat#initialize: super("initialize", "Cat")  — re-dispatch on same self
+    let cat_init = method_fn(
+        "Cat_initialize",
+        vec![],
+        vec![Stmt::ExprStmt {
+            expr: builtin("__super__", vec![str_lit("initialize"), str_lit("Cat")]),
+            span: s(),
+        }],
+        Expr::NilLit { span: s() },
+    );
+    // Cat#legs: @legs
+    let cat_legs = method_fn("Cat_legs", vec![], vec![], ivar_ref("@legs"));
+
+    let animal = class_def(
+        "Animal",
+        None,
+        vec![def_method("Animal", "initialize", "Animal_initialize")],
+    );
+    let cat = class_def(
+        "Cat",
+        Some("Animal"),
+        vec![
+            def_method("Cat", "initialize", "Cat_initialize"),
+            def_method("Cat", "legs", "Cat_legs"),
+        ],
+    );
+    let new_cat = builtin("__new__", vec![str_lit("Cat")]);
+    let legs_call = builtin("__method__", vec![new_cat, str_lit("legs")]);
+    let main = vec![animal, cat, print_stmt(legs_call)];
+
+    let m = module_from("p2_cat", vec![animal_init, cat_init, cat_legs], main, &[]);
+    let (ok, out) = emit_and_run(&m, "p2");
+    assert!(ok, "P2 should exit 0; stdout:\n{out}");
+    assert_eq!(
+        out.trim(),
+        "4",
+        "super must run the parent initialize on the SAME self, setting @legs"
+    );
+}
+
+/// SECURITY — a class AND method named `constructor` dispatch the USER method
+/// via a plain map lookup (never host/JS-engine behaviour), and an
+/// UNregistered `__proto__` call hits the clean NoMethodError floor (non-zero
+/// exit, no host effect).
+#[test]
+fn security_reserved_names_are_just_map_keys() {
+    if !go_available() {
+        eprintln!("skipping: go not on PATH");
+        return;
+    }
+    // A user method literally named `constructor` returns a marker int.
+    let ctor = method_fn("Weird_constructor", vec![], vec![], int_lit(99));
+    let class = class_def(
+        "constructor",
+        None,
+        vec![def_method("constructor", "constructor", "Weird_constructor")],
+    );
+    // new on a class named `constructor`, then call the `constructor` method.
+    let obj = builtin("__new__", vec![str_lit("constructor")]);
+    let call = builtin("__method__", vec![obj, str_lit("constructor")]);
+    let main = vec![class, print_stmt(call)];
+
+    let m = module_from("sec_ctor", vec![ctor], main, &[]);
+    let (ok, out) = emit_and_run(&m, "sec1");
+    assert!(ok, "reserved-name dispatch should run the USER method and exit 0; stdout:\n{out}");
+    assert_eq!(out.trim(), "99", "the (class, method) map lookup — not host behaviour — must win");
+
+    // A DIFFERENT program: call an UNregistered `__proto__` on a plain object
+    // → the NoMethodError floor (non-zero exit), never a host `__proto__`.
+    let obj2 = builtin("__new__", vec![str_lit("Plain")]);
+    let bad = builtin("__method__", vec![obj2, str_lit("__proto__")]);
+    let m2 = module_from(
+        "sec_proto",
+        vec![],
+        vec![class_def("Plain", None, vec![]), print_stmt(bad)],
+        &[],
+    );
+    let (ok2, out2) = emit_and_run(&m2, "sec2");
+    assert!(!ok2, "an unknown method (`__proto__`) must hit the NoMethodError floor (non-zero exit); stdout:\n{out2}");
+}
+
+/// CYCLE — a cyclic ancestry (`A < B`, `B < A`) must TERMINATE.  `A.new` with
+/// no `initialize` registered anywhere walks the cycle once (seen-guarded) and
+/// returns the plain allocation, exiting 0 rather than looping forever.
+#[test]
+fn cyclic_ancestry_terminates() {
+    if !go_available() {
+        eprintln!("skipping: go not on PATH");
+        return;
+    }
+    let a = class_def("A", Some("B"), vec![]);
+    let b = class_def("B", Some("A"), vec![]);
+    // A.new — no initialize anywhere; the ancestry walk must not loop.
+    let obj = builtin("__new__", vec![str_lit("A")]);
+    // Print a marker AFTER the allocation to prove we got past it.
+    let main = vec![
+        a,
+        b,
+        Stmt::LetBinding { name: "x".into(), sir_type: None, value: obj, span: s() },
+        print_stmt(int_lit(1)),
+    ];
+    let m = module_from("cyc", vec![], main, &[]);
+    let (ok, out) = emit_and_run(&m, "cyc");
+    assert!(ok, "cyclic ancestry must terminate and exit 0; stdout:\n{out}");
+    assert_eq!(out.trim(), "1", "allocation past a cyclic hierarchy must complete");
+}


### PR DESCRIPTION
## What

**O4** of the classes/OOP cascade — the Go backend now **executes** user-defined-class OOP (Go analogue of O1 python/ts + O3 js). Design: `code/specs/sir-classes-oop.md` (PR #7279).

- **Inline Go OOP runtime:** `SirInstance{Class, Ivars}`; instance/class method tables `map[string]Value` keyed `class+"\x00"+method`; `_sir_def_method`/`_sir_def_class_method`; `_sir_call_new` (allocate → push self → inherited `initialize` → return; pop via `defer`); `*SirInstance` path in `_sir_call_method`; `_sir_call_super` (ancestry walk, same receiver); `_sir_current_self`; `_sir_ivar_get/set`. Reuses the E3 exception ancestry table for the class hierarchy.
- **Emit arms** for `__new__`/`__super__`/`__def_method__`/`__def_class_method__`/`__self__` + `@ivar`/`@@cvar`; names via `quote_go_string`.
- Accepts `InstanceVars`/`ClassVars` for real classes (was narrow exception-subclass only); `Modules` stays unaccepted (no mixins/MRO in v0).

## Security

Dispatch is **explicit `map` lookup** on the `class\x00method` key — no `reflect`/`MethodByName`/`eval`. `constructor`/`__proto__` as class/method names are inert keys (miss → `NoMethodError` floor). Ancestry walks `seen`-guarded; self-stack pops via `defer` (panic-safe); the `*SirInstance` branch is guarded + early-returns so the C5 collection allowlist / E3 exception paths are untouched (no regression). Names escaped through `quote_go_string`.

## Verification

- `cargo test -p semantic-ir-to-go` — **108** (91 lib/emit + 17 integration).
- **Execution-proof (`go run`):** P1 `Dog.new("Rex").speak`→`Rex`; P2 inheritance+`super` (parent-set `@legs` on same self)→`4`; SEC (`constructor` class+method → user method / `__proto__` → NoMethodError floor); CYC (`A<B, B<A` terminates).
- Soundness gate still cleanly rejects `ModuleDef` / general `Const`-as-value / `Const` assignment. Clippy clean; `cargo build --workspace` clean (bar pre-existing Unix-only crate).
- **Security review passed** (no reflection, guarded passthrough, cycle-safe, panic-safe self-stack, escaped names).

Part of OOP Phase 2/3 (with O3 js pushed; O5 rust building; O2 ruby frontend held for O1 merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)