### PR TITLE
[codex] test(html-parser): pin misc recovery repair evidence

### DIFF
--- a/code/packages/rust/html-parser/tests/whatwg_misc_recovery_audit_test.rs
+++ b/code/packages/rust/html-parser/tests/whatwg_misc_recovery_audit_test.rs
@@ -7,6 +7,39 @@ use std::collections::{BTreeMap, HashMap};
 const TREE_CONSTRUCTION_SMOKE: &str = include_str!("fixtures/html5lib-tree-construction-smoke.dat");
 const WHATWG_MISC_RECOVERY_AUDIT: &str =
     include_str!("fixtures/whatwg-misc-recovery-audit.json");
+const POST_PARSE_REPAIR_EVIDENCE: &[(&str, &str, &str)] = &[
+    (
+        "comments01-dat-79",
+        "comments01.dat:79",
+        "xml-pi-looking-markup",
+    ),
+    (
+        "domjs-unsafe-dat-147",
+        "domjs-unsafe.dat:147",
+        "duplicate-doctype-recovery",
+    ),
+    (
+        "html5test-com-dat-283",
+        "html5test-com.dat:283",
+        "bogus-comment-and-cdata",
+    ),
+    (
+        "plain-text-unsafe-dat-356",
+        "plain-text-unsafe.dat:356",
+        "text-whitespace-shell",
+    ),
+    ("tests1-dat-601", "tests1.dat:601", "malformed-tag-open"),
+    (
+        "tests19-dat-1021",
+        "tests19.dat:1021",
+        "legacy-compat-elements",
+    ),
+    (
+        "webkit01-dat-8",
+        "webkit01.dat:8",
+        "custom-element-recovery",
+    ),
+];
 
 #[derive(Debug, Deserialize)]
 struct MiscRecoveryAuditSuite {
@@ -69,6 +102,50 @@ fn whatwg_misc_recovery_audit_cases_match_parser_dom_dump() {
             actual, source_case.document,
             "case `{}` ({}) failed for input {:?}",
             case.id, case.axis, source_case.data
+        );
+    }
+}
+
+#[test]
+fn whatwg_misc_recovery_audit_tracks_post_parse_repair_evidence() {
+    let suite = load_suite();
+    let audit_cases = suite
+        .cases
+        .iter()
+        .map(|case| (case.id.as_str(), case))
+        .collect::<HashMap<_, _>>();
+    let smoke_cases = parse_tree_construction_cases(TREE_CONSTRUCTION_SMOKE)
+        .into_iter()
+        .map(|case| (case.source.clone(), case))
+        .collect::<HashMap<_, _>>();
+
+    for (case_id, expected_source, expected_axis) in POST_PARSE_REPAIR_EVIDENCE {
+        let audit_case = audit_cases.get(case_id).unwrap_or_else(|| {
+            panic!("post-parse repair evidence case `{case_id}` should be audited")
+        });
+        assert_eq!(
+            audit_case.source, *expected_source,
+            "post-parse repair evidence case `{case_id}` should stay tied to its smoke fixture row"
+        );
+        assert_eq!(
+            audit_case.axis, *expected_axis,
+            "post-parse repair evidence case `{case_id}` should stay on its focused audit axis"
+        );
+
+        let source_case = smoke_cases
+            .get(*expected_source)
+            .unwrap_or_else(|| panic!("case `{case_id}` should exist in smoke fixture"));
+        let actual = actual_dom_dump_for_tree_case(source_case).unwrap_or_else(|error| {
+            panic!(
+                "case `{}` ({}) parse failed: {error}",
+                audit_case.id, audit_case.axis
+            )
+        });
+
+        assert_eq!(
+            actual, source_case.document,
+            "post-parse repair evidence case `{}` ({}) failed for input {:?}",
+            audit_case.id, audit_case.axis, source_case.data
         );
     }
 }


### PR DESCRIPTION
## Summary
- Add post-parse repair evidence coverage for the WHATWG miscellaneous recovery audit.
- Pin representative smoke fixture rows across XML/PI-looking markup, bogus comment/CDATA recovery, text shell recovery, malformed tag-open recovery, legacy compatibility elements, custom elements, and duplicate doctype recovery.
- Assert each pinned row remains tied to the expected smoke fixture source and still matches the parser DOM dump.

## Validation
- `cargo test -p coding-adventures-html-parser whatwg_misc_recovery_audit_tracks_post_parse_repair_evidence`
- Full focused parser audit matrix, including evidence and DOM-dump tests through tree insertion plus misc recovery
- `cargo test -p coding-adventures-html-parser`
- `CARGO_BUILD_JOBS=2 cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser`
- `python3 -m json.tool code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json >/dev/null`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py`
- `git diff --check`