### PR TITLE
feat(latex): floor & ceiling in latex "…" → ComputeOp::Floor / ComputeOp::Ceil

### DIFF
--- a/code/packages/rust/adj-lang/CHANGELOG.md
+++ b/code/packages/rust/adj-lang/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [0.24.0] - 2026-07-02 — floor & ceiling in `latex "…"` (lower to `ComputeOp::Floor` / `ComputeOp::Ceil`)
+
+### Added
+
+- The `latex "…"` adapter now lowers a **floor fence** `\left\lfloor x\right\rfloor`
+  and a **ceiling fence** `\left\lceil x\right\rceil` (a `MathExpr::Fenced` whose
+  delimiters are `\lfloor`/`\rfloor` or `\lceil`/`\rceil`) to the native
+  `ComputeOp::Floor` / `ComputeOp::Ceil` via new `ExprAst::Floor` / `ExprAst::Ceil`.
+  This mirrors the absolute-value slice exactly: a delimiter pair → a unary op,
+  reusing `ComputeExpr::Unary`. `⌊7/2⌋ = 3`, `⌈7/2⌉ = 4`.
+- Any **other** delimiter pair (`|x|` abs, `(x)`, `[x]`, `\langle x\rangle`) keeps
+  its existing meaning — only `\lfloor`/`\rfloor` and `\lceil`/`\rceil` carry the
+  floor / ceiling meaning; the latex frontend already surfaces those control-word
+  delimiters as data, so no latex-crate change was needed.
+
+### Notes
+
+- Floor and ceiling are **dimension-preserving** (`⌊3.7 mmol⌋ = 3 mmol`), so a
+  dimensioned operand computes cleanly, and the exact rational sidecar snaps to an
+  integer (`⌊7/2⌋ = 3/1`). Floor rounds toward −∞ (`⌊−7/2⌋ = −4`).
+
 ## [0.23.0] - 2026-07-01 — absolute value `|x|` in `latex "…"` (lowers to `ComputeOp::Abs`)
 
 ### Fixed / Added

--- a/code/packages/rust/adj-lang/Cargo.toml
+++ b/code/packages/rust/adj-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang"
-version = "0.23.0"
+version = "0.24.0"
 edition = "2021"
 description = "Surface-syntax frontend for the adjudication framework's probabilistic-logic rulebooks. Lexes, parses, and lowers a domain-expert-readable DSL into a `logic-engine` KnowledgeBase. Dissolves ADJ46 awkwardness items A10 (rulebook syntax) and A4 (joint contributions syntactically distinct)."
 

--- a/code/packages/rust/adj-lang/src/adapter.rs
+++ b/code/packages/rust/adj-lang/src/adapter.rs
@@ -929,6 +929,18 @@ fn latex_math_to_expr_ast(expr: &MathExpr, source: &str) -> Result<ExprAst, Adap
         MathExpr::Fenced { open, body, close } if open == "|" && close == "|" => Ok(ExprAst::Abs(
             Box::new(latex_math_to_expr_ast(body, source)?),
         )),
+        // A `\left\lfloor x\right\rfloor` fence is a FLOOR, `\left\lceil x\right\rceil`
+        // a CEILING — each lowers to its native dimension-preserving unary op, NOT to
+        // a bare `x`. The latex frontend carries the control-word delimiters verbatim
+        // (`\lfloor`/`\rfloor`, `\lceil`/`\rceil`), exactly as it carries `|` for abs,
+        // so we match on those delimiter strings. Any OTHER pair falls through to the
+        // presentation-grouping arm below.
+        MathExpr::Fenced { open, body, close } if open == "\\lfloor" && close == "\\rfloor" => {
+            Ok(ExprAst::Floor(Box::new(latex_math_to_expr_ast(body, source)?)))
+        }
+        MathExpr::Fenced { open, body, close } if open == "\\lceil" && close == "\\rceil" => {
+            Ok(ExprAst::Ceil(Box::new(latex_math_to_expr_ast(body, source)?)))
+        }
         MathExpr::Fenced { body, .. } => latex_math_to_expr_ast(body, source),
         MathExpr::Unary(UnaryOp::Pos, inner) => latex_math_to_expr_ast(inner, source),
         MathExpr::Unary(UnaryOp::Neg, inner) => Ok(ExprAst::Bin(

--- a/code/packages/rust/adj-lang/src/ast.rs
+++ b/code/packages/rust/adj-lang/src/ast.rs
@@ -105,10 +105,18 @@ pub enum ExprAst {
     Lit(f64),
     /// A binary arithmetic operation.
     Bin(ArithOp, Box<ExprAst>, Box<ExprAst>),
-    /// An absolute value, `|x|` — the only unary arithmetic form. Lowers to the
-    /// native `ComputeOp::Abs` (dimension-preserving). Produced by the `latex "…"`
+    /// An absolute value, `|x|` — a unary arithmetic form. Lowers to the native
+    /// `ComputeOp::Abs` (dimension-preserving). Produced by the `latex "…"`
     /// adapter from a `|…|`/`\left|…\right|` fence.
     Abs(Box<ExprAst>),
+    /// A floor, `⌊x⌋` — the greatest integer ≤ x. Lowers to the native
+    /// `ComputeOp::Floor` (dimension-preserving). Produced by the `latex "…"`
+    /// adapter from a `\left\lfloor…\right\rfloor` fence.
+    Floor(Box<ExprAst>),
+    /// A ceiling, `⌈x⌉` — the least integer ≥ x. Lowers to the native
+    /// `ComputeOp::Ceil` (dimension-preserving). Produced by the `latex "…"`
+    /// adapter from a `\left\lceil…\right\rceil` fence.
+    Ceil(Box<ExprAst>),
     /// An aggregation over every observation of a slot.
     Agg(AggOp, String),
 }

--- a/code/packages/rust/adj-lang/src/lower.rs
+++ b/code/packages/rust/adj-lang/src/lower.rs
@@ -706,6 +706,8 @@ fn lower_expr(expr: &ExprAst) -> ComputeExpr {
             Box::new(lower_expr(b)),
         ),
         ExprAst::Abs(a) => ComputeExpr::Unary(ComputeOp::Abs, Box::new(lower_expr(a))),
+        ExprAst::Floor(a) => ComputeExpr::Unary(ComputeOp::Floor, Box::new(lower_expr(a))),
+        ExprAst::Ceil(a) => ComputeExpr::Unary(ComputeOp::Ceil, Box::new(lower_expr(a))),
         ExprAst::Agg(op, slot) => ComputeExpr::Agg(lower_agg_op(*op), slot.clone()),
     }
 }
@@ -1841,6 +1843,39 @@ contributes 1000000 from answer == 60 to correct
              let answer = latex \"$\\left|x\\right|$\"\n\
              prior 0.10 for correct\n\
              contributes 1000000 from answer == 5 to correct\n\
+             ? correct\n",
+        )
+        .unwrap();
+        assert!(d.ranked[0].posterior > 0.99, "{d:?}");
+    }
+
+    #[test]
+    fn native_latex_floor_rounds_a_quotient_down() {
+        // `⌊a / b⌋` with a=7, b=2 is ⌊3.5⌋ = 3 (the greatest integer ≤ 3.5),
+        // computed on the native ComputeOp::Floor — the `\lfloor…\rfloor` fence
+        // is honoured, not silently dropped to the bare quotient 3.5.
+        let d = crate::compile_and_decide(
+            "observe a(7)\n\
+             observe b(2)\n\
+             let answer = latex \"$\\left\\lfloor a / b\\right\\rfloor$\"\n\
+             prior 0.10 for correct\n\
+             contributes 1000000 from answer == 3 to correct\n\
+             ? correct\n",
+        )
+        .unwrap();
+        assert!(d.ranked[0].posterior > 0.99, "{d:?}");
+    }
+
+    #[test]
+    fn native_latex_ceiling_rounds_a_quotient_up() {
+        // `⌈a / b⌉` with a=7, b=2 is ⌈3.5⌉ = 4 (the least integer ≥ 3.5),
+        // computed on the native ComputeOp::Ceil via the `\lceil…\rceil` fence.
+        let d = crate::compile_and_decide(
+            "observe a(7)\n\
+             observe b(2)\n\
+             let answer = latex \"$\\left\\lceil a / b\\right\\rceil$\"\n\
+             prior 0.10 for correct\n\
+             contributes 1000000 from answer == 4 to correct\n\
              ? correct\n",
         )
         .unwrap();

--- a/code/packages/rust/logic-engine/CHANGELOG.md
+++ b/code/packages/rust/logic-engine/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.29.0] - 2026-07-02 — native floor & ceiling (`ComputeOp::Floor` / `ComputeOp::Ceil`)
+
+### Added
+
+- **`ComputeOp::Floor`** (`⌊x⌋`, greatest integer ≤ x) and **`ComputeOp::Ceil`**
+  (`⌈x⌉`, least integer ≥ x) — two more **unary**, **dimension-preserving** ops
+  carried in the existing `ComputeExpr::Unary`, mirroring `Abs`. They make a
+  LaTeX `\left\lfloor x\right\rfloor` / `\left\lceil x\right\rceil` (adj-lang's
+  `latex "…"` surface) computable as a single native node.
+- Like `Abs`, both are dimension-preserving — the magnitude snaps to an integer
+  but the **unit does not** (`⌊3.7 mmol⌋ = 3 mmol`, `⌈3.2 mmol⌉ = 4 mmol`) — so
+  the operand's dimension flows straight through, and they reuse the n-ary
+  `DerivationNode::Op` node (one operand): no new audit-tree variant.
+- The **exact rational sidecar stays exact**: `ExactRational` keeps `den > 0`, so
+  `⌊num/den⌋ = num.div_euclid(den)` (Euclidean division floors) and
+  `⌈num/den⌉` adds one only when the division leaves a remainder — each result an
+  integer `q/1`. Floor rounds toward −∞ (`⌊−7/2⌋ = −4`, NOT −3).
+- Evaluated in the shared `#[inline(never)] eval_unary` helper, so the deeply
+  recursive `eval` frame stays small (the macOS stack-overflow guard from the
+  `Abs` slice still holds).
+
 ## [0.28.0] - 2026-07-01 — native absolute value (`ComputeOp::Abs`)
 
 ### Added

--- a/code/packages/rust/logic-engine/Cargo.toml
+++ b/code/packages/rust/logic-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logic-engine"
-version = "0.28.0"
+version = "0.29.0"
 edition = "2021"
 description = "Probability-aware facts, rules, KB, SLD find-first/enumerate + WMC posterior + LP19e likelihood-ratio Bayesian aggregation."
 

--- a/code/packages/rust/logic-engine/src/compute.rs
+++ b/code/packages/rust/logic-engine/src/compute.rs
@@ -194,6 +194,17 @@ pub enum ComputeOp {
     /// `|x|`/`\left|x\right|` (adj-lang's `latex "…"` surface) computable instead
     /// of being silently dropped to a bare `x`.
     Abs,
+    /// Floor, `⌊x⌋` — the greatest integer ≤ x. Like [`ComputeOp::Abs`] it is
+    /// **unary** and **dimension-preserving** (⌊3.7 mmol⌋ = 3 mmol: the magnitude
+    /// snaps down to an integer, the unit is untouched). It is carried in a
+    /// [`ComputeExpr::Unary`] and makes a LaTeX `\left\lfloor x\right\rfloor`
+    /// (adj-lang's `latex "…"` surface) computable as a single native node.
+    Floor,
+    /// Ceiling, `⌈x⌉` — the least integer ≥ x. The exact mirror of
+    /// [`ComputeOp::Floor`]: unary, dimension-preserving (⌈3.2 mmol⌉ = 4 mmol),
+    /// carried in a [`ComputeExpr::Unary`], lowered from a LaTeX
+    /// `\left\lceil x\right\rceil`.
+    Ceil,
     Sum,
     Count,
     Min,
@@ -211,6 +222,8 @@ impl ComputeOp {
             ComputeOp::Div => "/",
             ComputeOp::Pow => "^",
             ComputeOp::Abs => "abs",
+            ComputeOp::Floor => "floor",
+            ComputeOp::Ceil => "ceil",
             ComputeOp::Sum => "sum",
             ComputeOp::Count => "count",
             ComputeOp::Min => "min",
@@ -233,9 +246,10 @@ pub enum ComputeExpr {
     Lit(f64),
     /// A binary operation: `Add`/`Sub`/`Mul`/`Div`/`Pow` only.
     Bin(ComputeOp, Box<ComputeExpr>, Box<ComputeExpr>),
-    /// A unary operation: `Abs` only. Kept distinct from [`ComputeExpr::Bin`] so
-    /// the arity is honest (a unary op has one operand, not two) — it lowers to a
-    /// [`DerivationNode::Op`] with a single-element `operands` vec.
+    /// A unary operation: `Abs`/`Floor`/`Ceil`. Kept distinct from
+    /// [`ComputeExpr::Bin`] so the arity is honest (a unary op has one operand,
+    /// not two) — it lowers to a [`DerivationNode::Op`] with a single-element
+    /// `operands` vec.
     Unary(ComputeOp, Box<ComputeExpr>),
     /// An aggregation over **every** observation of a slot:
     /// `Sum`/`Count`/`Min`/`Max`/`Avg`.
@@ -590,9 +604,9 @@ fn eval(
     }
 }
 
-/// Evaluate a unary op (`Abs`) into a derivation node + dimension. Split out of
-/// [`eval`] and marked `#[inline(never)]` so its locals live in their own stack
-/// frame rather than enlarging every one of `eval`'s up-to-`MAX_EVAL_DEPTH`
+/// Evaluate a unary op (`Abs`/`Floor`/`Ceil`) into a derivation node + dimension.
+/// Split out of [`eval`] and marked `#[inline(never)]` so its locals live in their
+/// own stack frame rather than enlarging every one of `eval`'s up-to-`MAX_EVAL_DEPTH`
 /// recursive frames — a fatter `eval` frame multiplied across 256 levels can
 /// overflow a small (macOS ~2 MB) thread stack *before* the depth guard trips,
 /// which would turn the "clean `TooDeep`, never a stack overflow" guarantee into
@@ -605,29 +619,44 @@ fn eval_unary(
     depth: usize,
 ) -> Result<(DerivationNode, Dimension, Option<ExactRational>), ComputeError> {
     let (operand, dim, exact) = eval(a, kb, depth + 1)?;
-    // `Abs` is the only unary op. It is **dimension-preserving**: the magnitude
-    // may flip sign but the unit does not (`|−3 dollars| = 3 dollars`), so —
-    // unlike `Pow`, which recomputes the dimension — the operand's dimension
-    // flows straight through.
+    // Every unary op here is **dimension-preserving**: the magnitude may change
+    // (sign flip for `Abs`, snap to an integer for `Floor`/`Ceil`) but the unit
+    // does not (`|−3 dollars| = 3 dollars`, `⌊3.7 mmol⌋ = 3 mmol`), so — unlike
+    // `Pow`, which recomputes the dimension — the operand's dimension flows
+    // straight through.
+    let value = operand.value();
     let result = match op {
-        ComputeOp::Abs => operand.value().abs(),
+        ComputeOp::Abs => value.abs(),
+        ComputeOp::Floor => value.floor(),
+        ComputeOp::Ceil => value.ceil(),
         _ => {
             return Err(ComputeError::MalformedExpr {
                 detail: "non-unary operator in unary position",
             })
         }
     };
-    // `abs()` cannot introduce a non-finite value (|±∞| = ∞ was already
-    // non-finite; |NaN| = NaN), but the operand is finite-checked at its own
-    // producing op, so a finite operand yields a finite result. Guard anyway —
-    // cheap defense-in-depth, same contract as the binary ops.
+    // None of these can introduce a non-finite value from a finite operand
+    // (|±∞|/⌊±∞⌋/⌈±∞⌉ were already non-finite; NaN stays NaN), and the operand is
+    // finite-checked at its own producing op. Guard anyway — cheap
+    // defense-in-depth, same contract as the binary ops.
     if !result.is_finite() {
         return Err(ComputeError::NonFinite { op });
     }
-    // The exact sidecar stays exact: |num/den| = |num|/den (den is kept positive
-    // by `ExactRational`), so an integer/rational operand keeps its exactness
-    // through the absolute value.
-    let exact = exact.and_then(|r| r.num.checked_abs().and_then(|n| ExactRational::new(n, r.den)));
+    // The exact sidecar stays exact. `ExactRational` keeps `den > 0`, so:
+    //   • |num/den| = |num|/den (abs of the numerator);
+    //   • ⌊num/den⌋ = num.div_euclid(den) (Euclidean division floors for den > 0);
+    //   • ⌈num/den⌉ = that quotient plus one when the division leaves a remainder.
+    // Each result is an integer, carried as `q/1`.
+    let exact = exact.and_then(|r| match op {
+        ComputeOp::Abs => r.num.checked_abs().and_then(|n| ExactRational::new(n, r.den)),
+        ComputeOp::Floor => ExactRational::new(r.num.div_euclid(r.den), 1),
+        ComputeOp::Ceil => {
+            let q = r.num.div_euclid(r.den);
+            let q = if r.num.rem_euclid(r.den) != 0 { q.checked_add(1)? } else { q };
+            ExactRational::new(q, 1)
+        }
+        _ => None,
+    });
     Ok((
         DerivationNode::Op {
             op,
@@ -906,6 +935,78 @@ mod tests {
         assert_eq!(d.value, 4.0);
         // Same dimension as the operand `m` (money/usd), NOT collapsed to Scalar.
         assert_eq!(d.dim, kb.observed_dimensioned("m").unwrap().0.dim);
+    }
+
+    #[test]
+    fn floor_rounds_down_toward_negative_infinity_and_stays_exact() {
+        // ⌊7/2⌋ = 3 (the greatest integer ≤ 3.5), and the exact sidecar snaps to
+        // the integer 3/1. Euclidean division floors: 7.div_euclid(2) == 3.
+        let d = compute(
+            "fl",
+            &ComputeExpr::Unary(
+                ComputeOp::Floor,
+                Box::new(bin(ComputeOp::Div, ComputeExpr::Lit(7.0), ComputeExpr::Lit(2.0))),
+            ),
+            &kb_with(vec![]),
+        )
+        .unwrap();
+        assert_eq!(d.value, 3.0);
+        assert_eq!(d.dim, Dimension::Scalar);
+        assert_eq!(d.exact, ExactRational::new(3, 1));
+    }
+
+    #[test]
+    fn floor_of_a_negative_value_rounds_down_not_toward_zero() {
+        // ⌊−7/2⌋ = −4 (NOT −3): floor rounds toward −∞, so a negative
+        // non-integer snaps DOWN. (−7).div_euclid(2) == −4, the Euclidean floor.
+        let d = compute(
+            "fl",
+            &ComputeExpr::Unary(
+                ComputeOp::Floor,
+                Box::new(bin(ComputeOp::Div, ComputeExpr::Lit(-7.0), ComputeExpr::Lit(2.0))),
+            ),
+            &kb_with(vec![]),
+        )
+        .unwrap();
+        assert_eq!(d.value, -4.0);
+        assert_eq!(d.exact, ExactRational::new(-4, 1));
+    }
+
+    #[test]
+    fn ceil_rounds_up_and_preserves_the_operand_dimension() {
+        // ⌈7/2⌉ = 4 (the least integer ≥ 3.5). Ceil is dimension-preserving:
+        // ⌈dollars⌉ is still dollars, NOT collapsed to Scalar.
+        let kb = kb_with(vec![money("m", 7, "usd")]);
+        let d = compute(
+            "ce",
+            &ComputeExpr::Unary(
+                ComputeOp::Ceil,
+                Box::new(bin(ComputeOp::Div, refexpr("m"), ComputeExpr::Lit(2.0))),
+            ),
+            &kb,
+        )
+        .unwrap();
+        assert_eq!(d.value, 4.0);
+        assert_eq!(d.exact, ExactRational::new(4, 1));
+        // Same dimension as the operand `m` (money/usd).
+        assert_eq!(d.dim, kb.observed_dimensioned("m").unwrap().0.dim);
+    }
+
+    #[test]
+    fn ceil_of_an_exact_integer_is_the_integer_itself() {
+        // ⌈6/2⌉ = 3 — an exact integer has no remainder, so ceil leaves it be
+        // (the `+1` fires only when the Euclidean division leaves a remainder).
+        let d = compute(
+            "ce",
+            &ComputeExpr::Unary(
+                ComputeOp::Ceil,
+                Box::new(bin(ComputeOp::Div, ComputeExpr::Lit(6.0), ComputeExpr::Lit(2.0))),
+            ),
+            &kb_with(vec![]),
+        )
+        .unwrap();
+        assert_eq!(d.value, 3.0);
+        assert_eq!(d.exact, ExactRational::new(3, 1));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Extends the native LaTeX consumer surface with **floor** ⌊x⌋ and **ceiling** ⌈x⌉ — two more dimension-preserving unary ops, mirroring the just-shipped absolute-value slice exactly: a fence delimiter pair → a `ComputeExpr::Unary` op.

| LaTeX | op | result |
|---|---|---|
| `\left\lfloor x\right\rfloor` | `ComputeOp::Floor` | greatest integer ≤ x |
| `\left\lceil x\right\rceil` | `ComputeOp::Ceil` | least integer ≥ x |

## What changed
- **logic-engine** — `ComputeOp::Floor` / `ComputeOp::Ceil`, evaluated in the shared `#[inline(never)] eval_unary` helper so the deeply-recursive `eval` frame stays small (the macOS stack-overflow guard from the Abs slice still holds). Dimension-preserving (`⌊3.7 mmol⌋ = 3 mmol`). The **exact-rational sidecar stays exact**: `⌊num/den⌋ = num.div_euclid(den)` (Euclidean division floors for `den>0`), `⌈num/den⌉` adds one only on a remainder — each an integer `q/1`. Floor rounds toward −∞ (`⌊−7/2⌋ = −4`).
- **adj-lang** — `ExprAst::Floor`/`Ceil` + adapter `Fenced` arms matching the control-word delimiters `\lfloor`/`\rfloor` and `\lceil`/`\rceil`, + lowering to the native ops.
- **latex crate — no change**: it already surfaces `\left…\right` control-word delimiters as data (exactly as it carries `|` for abs).
- **adj-constraint-solver — no change**: its `ComputeExpr::Unary` walkers are op-generic, so Floor/Ceil flow through untouched.

## Verification
- 4 new engine tests (floor down / floor of a negative rounds toward −∞ / ceil up + dimension-preserving / ceil of an exact integer) + 2 new adj-lang lower tests (`⌊a/b⌋=3`, `⌈a/b⌉=4`).
- Full `logic-engine` (141) + `adj-lang` (97) + `adj-constraint-solver` + `adj-lang-cli` (21) suites green; `adjudication-pipeline` builds.
- `logic-engine` 0.28→0.29, `adj-lang` 0.23→0.24; both CHANGELOGs updated.

Security-reviewed (inline): no reachable panic on attacker-controlled num/den — `den≥1` invariant makes `div_euclid`/`rem_euclid` overflow-free, and the ceil `+1` is `checked_add`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)