### PR TITLE
[codex] test(html-parser): pin character reference audit evidence

### DIFF
--- a/code/packages/rust/html-parser/tests/whatwg_character_reference_audit_test.rs
+++ b/code/packages/rust/html-parser/tests/whatwg_character_reference_audit_test.rs
@@ -7,6 +7,38 @@ use std::collections::{BTreeMap, HashMap};
 const TREE_CONSTRUCTION_SMOKE: &str = include_str!("fixtures/html5lib-tree-construction-smoke.dat");
 const WHATWG_CHARACTER_REFERENCE_AUDIT: &str =
     include_str!("fixtures/whatwg-character-reference-audit.json");
+const CHARACTER_REFERENCE_EVIDENCE: &[(&str, &str, &str)] = &[
+    (
+        "entities01-dat-170",
+        "entities01.dat:170",
+        "character-reference-named-boundary",
+    ),
+    (
+        "entities01-dat-178",
+        "entities01.dat:178",
+        "character-reference-ambiguous-ampersand",
+    ),
+    (
+        "entities01-dat-181",
+        "entities01.dat:181",
+        "character-reference-numeric-boundary",
+    ),
+    (
+        "entities02-dat-245",
+        "entities02.dat:245",
+        "character-reference-attribute-boundary",
+    ),
+    (
+        "tests16-dat-849",
+        "tests16.dat:849",
+        "character-reference-rcdata-boundary",
+    ),
+    (
+        "tests4-dat-4",
+        "tests4.dat:4",
+        "character-reference-fragment-context",
+    ),
+];
 
 #[derive(Debug, Deserialize)]
 struct CharacterReferenceAuditSuite {
@@ -68,6 +100,50 @@ fn whatwg_character_reference_audit_cases_match_parser_dom_dump() {
             actual, source_case.document,
             "case `{}` ({}) failed for input {:?}",
             case.id, case.axis, source_case.data
+        );
+    }
+}
+
+#[test]
+fn whatwg_character_reference_audit_tracks_executable_evidence() {
+    let suite = load_suite();
+    let audit_cases = suite
+        .cases
+        .iter()
+        .map(|case| (case.id.as_str(), case))
+        .collect::<HashMap<_, _>>();
+    let smoke_cases = parse_tree_construction_cases(TREE_CONSTRUCTION_SMOKE)
+        .into_iter()
+        .map(|case| (case.source.clone(), case))
+        .collect::<HashMap<_, _>>();
+
+    for (case_id, expected_source, expected_axis) in CHARACTER_REFERENCE_EVIDENCE {
+        let audit_case = audit_cases.get(case_id).unwrap_or_else(|| {
+            panic!("character-reference evidence case `{case_id}` should be audited")
+        });
+        assert_eq!(
+            audit_case.source, *expected_source,
+            "character-reference evidence case `{case_id}` should stay tied to its smoke fixture row"
+        );
+        assert_eq!(
+            audit_case.axis, *expected_axis,
+            "character-reference evidence case `{case_id}` should stay on its focused audit axis"
+        );
+
+        let source_case = smoke_cases
+            .get(*expected_source)
+            .unwrap_or_else(|| panic!("case `{case_id}` should exist in smoke fixture"));
+        let actual = actual_dom_dump_for_tree_case(source_case).unwrap_or_else(|error| {
+            panic!(
+                "case `{}` ({}) parse failed: {error}",
+                audit_case.id, audit_case.axis
+            )
+        });
+
+        assert_eq!(
+            actual, source_case.document,
+            "character-reference evidence case `{}` ({}) failed for input {:?}",
+            audit_case.id, audit_case.axis, source_case.data
         );
     }
 }


### PR DESCRIPTION
## Summary
- add a focused executable evidence guard for the WHATWG character-reference audit suite
- pin representative smoke fixture rows for named, ambiguous ampersand, numeric, attribute, RCDATA, and fragment-context character reference axes
- assert each pinned row still parses to the expected DOM dump through the parser harness

## Validation
- `cargo test -p coding-adventures-html-parser whatwg_character_reference_audit_tracks_executable_evidence`
- focused parser audit matrix including post-parse-repair evidence guards, audit DOM-dump checks, character-reference audit checks, and html5lib smoke DOM dump
- `cargo test -p coding-adventures-html-parser`
- `CARGO_BUILD_JOBS=2 cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser`
- `python3 -m json.tool code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json >/dev/null`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py`
- `git diff --check`