### PR TITLE
feat(adj-ladder): rung-35 dialysis solute mass balance (difference of two products)

### DIFF
--- a/code/specs/data/adj-ladder/rung35_dialysis_clearance/gen_items.py
+++ b/code/specs/data/adj-ladder/rung35_dialysis_clearance/gen_items.py
@@ -1,0 +1,211 @@
+"""Generate rung-35 (dialysis solute mass balance) items.json for the ADJ-LADDER.
+
+Rung 35 opens the **renal-replacement / dialysis clearance** panel on the quantitative band — the arithmetic of
+how much solute a dialyzer actually removes over a session. Solute is conserved: the amount entering on the blood
+side (its **volume times its concentration**) minus the amount leaving in the spent effluent (its own volume
+times its own concentration) is the amount cleared. It uses the same contamination-safe shape as the
+fluid-admixture rung (34), the stroke-work rung (33), and the respiratory rung (32): a small table of *observed*
+volumes and concentrations and a tight family of mutually-confusable formulas built **only from those observed
+quantities** (no numeric literal anywhere in any program), so nothing structural can leak.
+
+The clinical setup is a single dialysis session's mass balance. FOUR quantities are measured — two volumes (L)
+and two concentrations (mmol/L):
+
+  INFLOW_VOLUME          Vi   volume processed on the inflow (blood) side
+  INFLOW_CONCENTRATION   Ci   solute concentration entering
+  OUTFLOW_VOLUME         Vo   volume of spent effluent leaving
+  OUTFLOW_CONCENTRATION  Co   solute concentration leaving (lower — the dialyzer pulled solute out)
+
+The net solute removed is the **amount that entered minus the amount that left** — a *difference of two
+products* — `(INFLOW_VOLUME * INFLOW_CONCENTRATION) - (OUTFLOW_VOLUME * OUTFLOW_CONCENTRATION)`. That is what
+makes this rung distinctive: it is a NEW arithmetic shape on the ladder — a difference whose TWO terms are each
+their own product. This continues the two-operand-composition series: rung-31 subtracted one difference from
+another, rung-32 divided one difference by another, rung-33 multiplied one difference by another, rung-34 ADDED
+one product to another, and rung-35 SUBTRACTS one product from another. The core confusion this rung tests is
+pairing the right volume with the right concentration inside each product (a side's own volume times its own
+concentration), rather than crossing them:
+
+  NET SOLUTE REMOVED         (Vi * Ci) - (Vo * Co)   [ solute in − solute out = amount cleared ]
+  INFLOW SOLUTE              Vi * Ci                  [ the solute entering, one term ]
+  OUTFLOW SOLUTE             Vo * Co                  [ the solute leaving, the other term ]
+
+Each index is a `compute_dimensioned` program (observe the four quantities + `let answer = formula`); the ADJ
+engine carries the arithmetic and the harness reads the scalar via the existing `compute_dimensioned`
+extractor — no harness/engine change, exactly as rungs 8/16/…/33/34. This rung exercises the engine across a
+SUBTRACTION of two parenthesised PRODUCTS.
+
+Contamination-safe by construction: every formula is built only from the four observed quantities via `*`, `-`,
+`+` — **no structural constants** — so every program literal is grounded in the stem. Neither side's solute
+amount ever appears as a literal (each is computed from the observed volume and concentration). The observed
+quantities carry **digit-free identifiers** (`inflow_volume`, `inflow_concentration`, `outflow_volume`,
+`outflow_concentration`) so no numeral hides inside a variable name. The five options are a tight family over the
+same quantities: the three real indices plus the two classic slips —
+
+  CROSSED PRODUCTS DIFFERENCE   (Vi * Co) - (Vo * Ci)   each volume paired with the OTHER side's concentration, and
+  SUMMED PRODUCTS               (Vi * Ci) + (Vo * Co)   the two amounts ADDED instead of subtracted,
+
+which are exactly the mistakes a student makes. Gold rotates A-E by index.
+
+Note on scale: the summed products is the largest value, the inflow solute next (it exceeds the outflow solute
+so the net removed is strictly positive), then the net removed and the outflow solute, and the crossed-products
+difference is a small (sometimes negative — the sign-slip) value; the tables below are chosen so the five family
+values are pairwise distinct — with a comfortable margin — for every item, asserted at build time (inflow solute
+> outflow solute so the net removed is strictly positive, and no two family values collide).
+"""
+import json
+
+LETTERS = ["A", "B", "C", "D", "E"]
+
+# (INFLOW_VOLUME, INFLOW_CONCENTRATION, OUTFLOW_VOLUME, OUTFLOW_CONCENTRATION) observed per session. Volumes in
+# L, concentrations in mmol/L, so each product is an amount in mmol. The inflow amount (Vi*Ci) exceeds the
+# outflow amount (Vo*Co) on every row, so the net solute removed is strictly positive. The five family values
+# are asserted pairwise-distinct (with margin) below.
+#   Vi = inflow (blood-side) volume        Ci = its concentration (higher, pre-dialysis)
+#   Vo = outflow (effluent) volume         Co = its concentration (lower, post-dialysis)
+TABLES = [
+    (4, 120, 2, 80),
+    (5, 130, 3, 70),
+    (3, 150, 2, 90),
+    (4, 140, 3, 85),
+    (5, 110, 2, 95),
+    (3, 160, 2, 100),
+    (4, 125, 2, 70),
+]
+
+# The option family (5 members), all built from the observed quantities via `*` / `-` / `+`. Every identifier
+# is DIGIT-FREE. key -> (display name, formula-as-adj). Only the first three are *queried* (used as gold); all
+# five always appear as the options.
+FAMILY = [
+    (
+        "net_solute_removed",
+        "net solute removed by the dialyzer",
+        "(inflow_volume * inflow_concentration) - (outflow_volume * outflow_concentration)",
+    ),
+    (
+        "inflow_solute",
+        "solute entering on the inflow side",
+        "inflow_volume * inflow_concentration",
+    ),
+    (
+        "outflow_solute",
+        "solute leaving in the effluent",
+        "outflow_volume * outflow_concentration",
+    ),
+    (
+        "crossed_products_difference",
+        "crossed-products difference (each volume with the other side's concentration)",
+        "(inflow_volume * outflow_concentration) - (outflow_volume * inflow_concentration)",
+    ),
+    (
+        "summed_products",
+        "summed amounts (inflow plus outflow, added not subtracted)",
+        "(inflow_volume * inflow_concentration) + (outflow_volume * outflow_concentration)",
+    ),
+]
+QUERIED = ["net_solute_removed", "inflow_solute", "outflow_solute"]
+ORDER = [k for k, _, _ in FAMILY]
+
+
+def scalar(v):
+    return {"value": v, "unit": "scalar"}
+
+
+def family_values(vi, ci, vo, co):
+    # Operation order mirrors the ADJ program exactly, so the Python option value and the engine
+    # result are the same IEEE-double (well within the harness's 1e-9 match tolerance).
+    inflow_amount = vi * ci
+    outflow_amount = vo * co
+    return {
+        "net_solute_removed": inflow_amount - outflow_amount,
+        "inflow_solute": inflow_amount,
+        "outflow_solute": outflow_amount,
+        "crossed_products_difference": (vi * co) - (vo * ci),
+        "summed_products": inflow_amount + outflow_amount,
+    }
+
+
+def build():
+    name_of = {k: nm for k, nm, _ in FAMILY}
+    formula_of = {k: f for k, _, f in FAMILY}
+    items = []
+    idx = 0
+
+    def num(x):
+        return int(x) if float(x).is_integer() else x
+
+    for vi, ci, vo, co in TABLES:
+        inflow_amount = vi * ci
+        outflow_amount = vo * co
+        assert inflow_amount > 0 and outflow_amount > 0, (vi, ci, vo, co)
+        assert inflow_amount > outflow_amount, (vi, ci, vo, co)  # net removed strictly positive
+        fv = family_values(vi, ci, vo, co)
+        # Pairwise-distinct with a comfortable margin so the harness never sees two options
+        # matching the gold value within its 1e-9 tolerance.
+        vals = [fv[key] for key in ORDER]
+        for i in range(len(vals)):
+            for j in range(i + 1, len(vals)):
+                assert abs(vals[i] - vals[j]) > 1e-6, (vi, ci, vo, co, ORDER[i], ORDER[j], fv)
+        for key in QUERIED:
+            gold_val = fv[key]
+            gold_pos = idx % 5
+            others = [fv[k2] for k2 in ORDER if abs(fv[k2] - gold_val) > 1e-12]
+            opts_vals = others[:]
+            opts_vals.insert(gold_pos, gold_val)
+            opts_vals = opts_vals[:5]
+            if abs(opts_vals[gold_pos] - gold_val) > 1e-12:
+                opts_vals[gold_pos] = gold_val
+            assert len({round(v, 9) for v in opts_vals}) == 5, (key, vi, ci, vo, co, opts_vals)
+            options = {LETTERS[i]: scalar(opts_vals[i]) for i in range(5)}
+            items.append({
+                "id": f"r35dialysis-{idx + 1:02d}",
+                "qtype": "dialysis_clearance",
+                "stem": (
+                    f"Over one dialysis session, {num(vi)} L is processed on the inflow side at a solute "
+                    f"concentration of {num(ci)} mmol/L, and {num(vo)} L of spent effluent leaves at "
+                    f"{num(co)} mmol/L. What is the {name_of[key]}?"
+                ),
+                "program": (
+                    f"observe inflow_volume({num(vi)})\n"
+                    f"observe inflow_concentration({num(ci)})\n"
+                    f"observe outflow_volume({num(vo)})\n"
+                    f"observe outflow_concentration({num(co)})\n"
+                    f"let answer = {formula_of[key]}\n"
+                    "? answer\n"
+                ),
+                "answer_from": {"type": "compute_dimensioned", "name": "answer"},
+                "options": options,
+                "gold_letter": LETTERS[gold_pos],
+            })
+            idx += 1
+    return {
+        "description": (
+            "ADJ-LADDER rung 35 — net solute removed in a dialysis session from two volumes and two "
+            "concentrations (a NEW panel: renal-replacement / dialysis clearance). From four stated quantities "
+            "(inflow volume Vi, inflow concentration Ci, outflow volume Vo, outflow concentration Co) compute "
+            "the net solute removed ((Vi*Ci)-(Vo*Co)), the inflow solute (Vi*Ci), or the outflow solute "
+            "(Vo*Co). Each item is a compute_dimensioned program (observe the four quantities, let answer = "
+            "formula); the ADJ engine carries the arithmetic — a NEW shape, a DIFFERENCE OF TWO PRODUCTS "
+            "((Vi*Ci)-(Vo*Co)), so one parenthesised product is subtracted from another — and the harness "
+            "matches the scalar to the printed options. Contamination-safe: every index is built only from the "
+            "four observed quantities via *, - and + — no constant leaks (each amount is a pure "
+            "volume*concentration product), and neither side's solute amount ever appears as a literal (each is "
+            "computed from the observed volume and concentration) — and the observed quantities carry digit-free "
+            "identifiers so no numeral hides inside a variable name. The five options are a family over the same "
+            "quantities, so the distractors are exactly the slips students make: the crossed-products difference "
+            "((Vi*Co)-(Vo*Ci), each volume with the other side's concentration) and the summed products "
+            "((Vi*Ci)+(Vo*Co), the two amounts added instead of subtracted). The core confusion tested is "
+            "subtracting one volume*concentration product from another with each pairing correct."
+        ),
+        "items": items,
+    }
+
+
+if __name__ == "__main__":
+    doc = build()
+    with open("items.json", "w") as f:
+        json.dump(doc, f, indent=2)
+        f.write("\n")
+    print("wrote items.json:", len(doc["items"]), "items")
+    for it in doc["items"]:
+        print(it["id"], it["qtype"], "gold", it["gold_letter"],
+              "=", round(it["options"][it["gold_letter"]]["value"], 4))

--- a/code/specs/data/adj-ladder/rung35_dialysis_clearance/items.json
+++ b/code/specs/data/adj-ladder/rung35_dialysis_clearance/items.json
@@ -1,0 +1,698 @@
+{
+  "description": "ADJ-LADDER rung 35 \u2014 net solute removed in a dialysis session from two volumes and two concentrations (a NEW panel: renal-replacement / dialysis clearance). From four stated quantities (inflow volume Vi, inflow concentration Ci, outflow volume Vo, outflow concentration Co) compute the net solute removed ((Vi*Ci)-(Vo*Co)), the inflow solute (Vi*Ci), or the outflow solute (Vo*Co). Each item is a compute_dimensioned program (observe the four quantities, let answer = formula); the ADJ engine carries the arithmetic \u2014 a NEW shape, a DIFFERENCE OF TWO PRODUCTS ((Vi*Ci)-(Vo*Co)), so one parenthesised product is subtracted from another \u2014 and the harness matches the scalar to the printed options. Contamination-safe: every index is built only from the four observed quantities via *, - and + \u2014 no constant leaks (each amount is a pure volume*concentration product), and neither side's solute amount ever appears as a literal (each is computed from the observed volume and concentration) \u2014 and the observed quantities carry digit-free identifiers so no numeral hides inside a variable name. The five options are a family over the same quantities, so the distractors are exactly the slips students make: the crossed-products difference ((Vi*Co)-(Vo*Ci), each volume with the other side's concentration) and the summed products ((Vi*Ci)+(Vo*Co), the two amounts added instead of subtracted). The core confusion tested is subtracting one volume*concentration product from another with each pairing correct.",
+  "items": [
+    {
+      "id": "r35dialysis-01",
+      "qtype": "dialysis_clearance",
+      "stem": "Over one dialysis session, 4 L is processed on the inflow side at a solute concentration of 120 mmol/L, and 2 L of spent effluent leaves at 80 mmol/L. What is the net solute removed by the dialyzer?",
+      "program": "observe inflow_volume(4)\nobserve inflow_concentration(120)\nobserve outflow_volume(2)\nobserve outflow_concentration(80)\nlet answer = (inflow_volume * inflow_concentration) - (outflow_volume * outflow_concentration)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 320,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 480,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 160,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 80,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 640,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r35dialysis-02",
+      "qtype": "dialysis_clearance",
+      "stem": "Over one dialysis session, 4 L is processed on the inflow side at a solute concentration of 120 mmol/L, and 2 L of spent effluent leaves at 80 mmol/L. What is the solute entering on the inflow side?",
+      "program": "observe inflow_volume(4)\nobserve inflow_concentration(120)\nobserve outflow_volume(2)\nobserve outflow_concentration(80)\nlet answer = inflow_volume * inflow_concentration\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 320,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 480,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 160,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 80,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 640,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r35dialysis-03",
+      "qtype": "dialysis_clearance",
+      "stem": "Over one dialysis session, 4 L is processed on the inflow side at a solute concentration of 120 mmol/L, and 2 L of spent effluent leaves at 80 mmol/L. What is the solute leaving in the effluent?",
+      "program": "observe inflow_volume(4)\nobserve inflow_concentration(120)\nobserve outflow_volume(2)\nobserve outflow_concentration(80)\nlet answer = outflow_volume * outflow_concentration\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 320,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 480,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 160,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 80,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 640,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r35dialysis-04",
+      "qtype": "dialysis_clearance",
+      "stem": "Over one dialysis session, 5 L is processed on the inflow side at a solute concentration of 130 mmol/L, and 3 L of spent effluent leaves at 70 mmol/L. What is the net solute removed by the dialyzer?",
+      "program": "observe inflow_volume(5)\nobserve inflow_concentration(130)\nobserve outflow_volume(3)\nobserve outflow_concentration(70)\nlet answer = (inflow_volume * inflow_concentration) - (outflow_volume * outflow_concentration)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 650,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 210,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": -40,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 440,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 860,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r35dialysis-05",
+      "qtype": "dialysis_clearance",
+      "stem": "Over one dialysis session, 5 L is processed on the inflow side at a solute concentration of 130 mmol/L, and 3 L of spent effluent leaves at 70 mmol/L. What is the solute entering on the inflow side?",
+      "program": "observe inflow_volume(5)\nobserve inflow_concentration(130)\nobserve outflow_volume(3)\nobserve outflow_concentration(70)\nlet answer = inflow_volume * inflow_concentration\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 440,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 210,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": -40,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 860,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 650,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r35dialysis-06",
+      "qtype": "dialysis_clearance",
+      "stem": "Over one dialysis session, 5 L is processed on the inflow side at a solute concentration of 130 mmol/L, and 3 L of spent effluent leaves at 70 mmol/L. What is the solute leaving in the effluent?",
+      "program": "observe inflow_volume(5)\nobserve inflow_concentration(130)\nobserve outflow_volume(3)\nobserve outflow_concentration(70)\nlet answer = outflow_volume * outflow_concentration\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 210,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 440,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 650,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": -40,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 860,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r35dialysis-07",
+      "qtype": "dialysis_clearance",
+      "stem": "Over one dialysis session, 3 L is processed on the inflow side at a solute concentration of 150 mmol/L, and 2 L of spent effluent leaves at 90 mmol/L. What is the net solute removed by the dialyzer?",
+      "program": "observe inflow_volume(3)\nobserve inflow_concentration(150)\nobserve outflow_volume(2)\nobserve outflow_concentration(90)\nlet answer = (inflow_volume * inflow_concentration) - (outflow_volume * outflow_concentration)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 450,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 270,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 180,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": -30,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 630,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r35dialysis-08",
+      "qtype": "dialysis_clearance",
+      "stem": "Over one dialysis session, 3 L is processed on the inflow side at a solute concentration of 150 mmol/L, and 2 L of spent effluent leaves at 90 mmol/L. What is the solute entering on the inflow side?",
+      "program": "observe inflow_volume(3)\nobserve inflow_concentration(150)\nobserve outflow_volume(2)\nobserve outflow_concentration(90)\nlet answer = inflow_volume * inflow_concentration\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 270,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 180,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 450,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": -30,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 630,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r35dialysis-09",
+      "qtype": "dialysis_clearance",
+      "stem": "Over one dialysis session, 3 L is processed on the inflow side at a solute concentration of 150 mmol/L, and 2 L of spent effluent leaves at 90 mmol/L. What is the solute leaving in the effluent?",
+      "program": "observe inflow_volume(3)\nobserve inflow_concentration(150)\nobserve outflow_volume(2)\nobserve outflow_concentration(90)\nlet answer = outflow_volume * outflow_concentration\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 270,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 450,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": -30,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 180,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 630,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r35dialysis-10",
+      "qtype": "dialysis_clearance",
+      "stem": "Over one dialysis session, 4 L is processed on the inflow side at a solute concentration of 140 mmol/L, and 3 L of spent effluent leaves at 85 mmol/L. What is the net solute removed by the dialyzer?",
+      "program": "observe inflow_volume(4)\nobserve inflow_concentration(140)\nobserve outflow_volume(3)\nobserve outflow_concentration(85)\nlet answer = (inflow_volume * inflow_concentration) - (outflow_volume * outflow_concentration)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 560,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 255,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": -80,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 815,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 305,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r35dialysis-11",
+      "qtype": "dialysis_clearance",
+      "stem": "Over one dialysis session, 4 L is processed on the inflow side at a solute concentration of 140 mmol/L, and 3 L of spent effluent leaves at 85 mmol/L. What is the solute entering on the inflow side?",
+      "program": "observe inflow_volume(4)\nobserve inflow_concentration(140)\nobserve outflow_volume(3)\nobserve outflow_concentration(85)\nlet answer = inflow_volume * inflow_concentration\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 560,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 305,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 255,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": -80,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 815,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r35dialysis-12",
+      "qtype": "dialysis_clearance",
+      "stem": "Over one dialysis session, 4 L is processed on the inflow side at a solute concentration of 140 mmol/L, and 3 L of spent effluent leaves at 85 mmol/L. What is the solute leaving in the effluent?",
+      "program": "observe inflow_volume(4)\nobserve inflow_concentration(140)\nobserve outflow_volume(3)\nobserve outflow_concentration(85)\nlet answer = outflow_volume * outflow_concentration\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 305,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 255,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 560,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": -80,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 815,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r35dialysis-13",
+      "qtype": "dialysis_clearance",
+      "stem": "Over one dialysis session, 5 L is processed on the inflow side at a solute concentration of 110 mmol/L, and 2 L of spent effluent leaves at 95 mmol/L. What is the net solute removed by the dialyzer?",
+      "program": "observe inflow_volume(5)\nobserve inflow_concentration(110)\nobserve outflow_volume(2)\nobserve outflow_concentration(95)\nlet answer = (inflow_volume * inflow_concentration) - (outflow_volume * outflow_concentration)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 550,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 190,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 360,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 255,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 740,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r35dialysis-14",
+      "qtype": "dialysis_clearance",
+      "stem": "Over one dialysis session, 5 L is processed on the inflow side at a solute concentration of 110 mmol/L, and 2 L of spent effluent leaves at 95 mmol/L. What is the solute entering on the inflow side?",
+      "program": "observe inflow_volume(5)\nobserve inflow_concentration(110)\nobserve outflow_volume(2)\nobserve outflow_concentration(95)\nlet answer = inflow_volume * inflow_concentration\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 360,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 190,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 255,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 550,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 740,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r35dialysis-15",
+      "qtype": "dialysis_clearance",
+      "stem": "Over one dialysis session, 5 L is processed on the inflow side at a solute concentration of 110 mmol/L, and 2 L of spent effluent leaves at 95 mmol/L. What is the solute leaving in the effluent?",
+      "program": "observe inflow_volume(5)\nobserve inflow_concentration(110)\nobserve outflow_volume(2)\nobserve outflow_concentration(95)\nlet answer = outflow_volume * outflow_concentration\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 360,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 550,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 255,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 740,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 190,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r35dialysis-16",
+      "qtype": "dialysis_clearance",
+      "stem": "Over one dialysis session, 3 L is processed on the inflow side at a solute concentration of 160 mmol/L, and 2 L of spent effluent leaves at 100 mmol/L. What is the net solute removed by the dialyzer?",
+      "program": "observe inflow_volume(3)\nobserve inflow_concentration(160)\nobserve outflow_volume(2)\nobserve outflow_concentration(100)\nlet answer = (inflow_volume * inflow_concentration) - (outflow_volume * outflow_concentration)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 280,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 480,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 200,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": -20,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 680,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r35dialysis-17",
+      "qtype": "dialysis_clearance",
+      "stem": "Over one dialysis session, 3 L is processed on the inflow side at a solute concentration of 160 mmol/L, and 2 L of spent effluent leaves at 100 mmol/L. What is the solute entering on the inflow side?",
+      "program": "observe inflow_volume(3)\nobserve inflow_concentration(160)\nobserve outflow_volume(2)\nobserve outflow_concentration(100)\nlet answer = inflow_volume * inflow_concentration\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 280,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 480,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 200,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": -20,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 680,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r35dialysis-18",
+      "qtype": "dialysis_clearance",
+      "stem": "Over one dialysis session, 3 L is processed on the inflow side at a solute concentration of 160 mmol/L, and 2 L of spent effluent leaves at 100 mmol/L. What is the solute leaving in the effluent?",
+      "program": "observe inflow_volume(3)\nobserve inflow_concentration(160)\nobserve outflow_volume(2)\nobserve outflow_concentration(100)\nlet answer = outflow_volume * outflow_concentration\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 280,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 480,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 200,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": -20,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 680,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r35dialysis-19",
+      "qtype": "dialysis_clearance",
+      "stem": "Over one dialysis session, 4 L is processed on the inflow side at a solute concentration of 125 mmol/L, and 2 L of spent effluent leaves at 70 mmol/L. What is the net solute removed by the dialyzer?",
+      "program": "observe inflow_volume(4)\nobserve inflow_concentration(125)\nobserve outflow_volume(2)\nobserve outflow_concentration(70)\nlet answer = (inflow_volume * inflow_concentration) - (outflow_volume * outflow_concentration)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 500,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 140,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 30,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 360,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 640,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r35dialysis-20",
+      "qtype": "dialysis_clearance",
+      "stem": "Over one dialysis session, 4 L is processed on the inflow side at a solute concentration of 125 mmol/L, and 2 L of spent effluent leaves at 70 mmol/L. What is the solute entering on the inflow side?",
+      "program": "observe inflow_volume(4)\nobserve inflow_concentration(125)\nobserve outflow_volume(2)\nobserve outflow_concentration(70)\nlet answer = inflow_volume * inflow_concentration\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 360,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 140,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 30,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 640,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 500,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r35dialysis-21",
+      "qtype": "dialysis_clearance",
+      "stem": "Over one dialysis session, 4 L is processed on the inflow side at a solute concentration of 125 mmol/L, and 2 L of spent effluent leaves at 70 mmol/L. What is the solute leaving in the effluent?",
+      "program": "observe inflow_volume(4)\nobserve inflow_concentration(125)\nobserve outflow_volume(2)\nobserve outflow_concentration(70)\nlet answer = outflow_volume * outflow_concentration\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 140,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 360,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 500,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 30,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 640,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    }
+  ]
+}

--- a/code/specs/data/adj-ladder/test_ladder_eval.py
+++ b/code/specs/data/adj-ladder/test_ladder_eval.py
@@ -72,6 +72,7 @@ SELF_CONTAINED_RUNGS = (
     "rung32_respiratory_exchange_ratio",
     "rung33_stroke_work",
     "rung34_fluid_admixture",
+    "rung35_dialysis_clearance",
 )
 
 


### PR DESCRIPTION
## Summary

Adds **ADJ-LADDER rung 35** — a NEW-organ, constant-free `compute_dimensioned` rung opening the **renal-replacement / dialysis clearance** panel and cycling the arithmetic to a **difference of two products**.

From four observed quantities — two volumes and two concentrations across a dialyzer — the mutually-confusable family computes:

| index | formula | shape |
|---|---|---|
| **net solute removed** | `(Vi·Ci) − (Vo·Co)` | difference of two products (headline) |
| **inflow solute** | `Vi·Ci` | one term |
| **outflow solute** | `Vo·Co` | the other term |
| crossed-products difference *(distractor)* | `(Vi·Co) − (Vo·Ci)` | each volume with the OTHER side's concentration |
| summed products *(distractor)* | `(Vi·Ci) + (Vo·Co)` | the two amounts added, not subtracted |

The three real indices are queried as gold; all five appear as options.

## Arithmetic-shape progression (two-operand compositions — series complete)
- rung-31 Starling: **difference** of two differences `(a−b) − (c−d)`
- rung-32 respiratory exchange: **ratio** of two differences `(a−b) / (c−d)`
- rung-33 stroke work: **product** of two differences `(a−b) · (c−d)`
- rung-34 admixture: **sum** of two products `(a·b) + (c·d)`
- **rung-35 dialysis: difference of two products** `(a·b) − (c·d)` ← new shape

## Contamination-safety (by construction)
- Every formula is built **only** from the four observed quantities via `*`, `-`, `+` — **no structural constants** (each amount is a pure volume·concentration product).
- Neither side's solute amount ever appears as a literal (each is computed from the observed volume and concentration).
- Observed quantities carry **digit-free identifiers** (`inflow_volume`, `inflow_concentration`, `outflow_volume`, `outflow_concentration`).
- 7 tables × 3 queried indices = **21 items**; gold rotates A–E; the five family values are asserted **pairwise-distinct with margin** at build (inflow amount > outflow so the net removed is strictly positive).

## Verification
Registered in `SELF_CONTAINED_RUNGS`; the rung-35 gate passes **3/3** — the cached engine selects every gold (0 wrong / 0 abstain), contamination-clean, `items.json` valid:

```
$ python3 -m pytest test_ladder_eval.py -k rung35_dialysis_clearance -q
3 passed, 216 deselected in 0.55s
```

No harness or engine change — pure additive dataset + one-line tuple registration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)