### PR TITLE
feat(latex): round-to-nearest in latex "…" → ComputeOp::Round

### DIFF
--- a/code/packages/rust/adj-lang/CHANGELOG.md
+++ b/code/packages/rust/adj-lang/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [0.25.0] - 2026-07-02 — round-to-nearest in `latex "…"` (lowers to `ComputeOp::Round`)
+
+### Added
+
+- The `latex "…"` adapter now lowers the standard **nearest-integer fence**
+  `\left\lfloor x\right\rceil` (floor-left, ceil-right — a `MathExpr::Fenced` with
+  delimiters `\lfloor`/`\rceil`) to the native `ComputeOp::Round` via a new
+  `ExprAst::Round`. Round is nearest with **ties away from zero** (`⌊7/2⌉ = 4`).
+- The asymmetric delimiters matter: `\lfloor…\rfloor` is floor, `\lfloor…\rceil`
+  is round — the distinct *closing* delimiter selects the op, so the round arm sits
+  beside the existing floor/ceil arms with no ambiguity. The latex frontend already
+  surfaces these control-word delimiters as data, so no latex-crate change was
+  needed.
+
+### Notes
+
+- Round is **dimension-preserving** (`⌊3.6 mmol⌉ = 4 mmol`) and the exact rational
+  sidecar snaps to an integer. Truncation toward zero (`\operatorname{trunc}`) has
+  no bracket notation and is deferred to the future named-function slice.
+
 ## [0.24.0] - 2026-07-02 — floor & ceiling in `latex "…"` (lower to `ComputeOp::Floor` / `ComputeOp::Ceil`)
 
 ### Added

--- a/code/packages/rust/adj-lang/Cargo.toml
+++ b/code/packages/rust/adj-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang"
-version = "0.24.0"
+version = "0.25.0"
 edition = "2021"
 description = "Surface-syntax frontend for the adjudication framework's probabilistic-logic rulebooks. Lexes, parses, and lowers a domain-expert-readable DSL into a `logic-engine` KnowledgeBase. Dissolves ADJ46 awkwardness items A10 (rulebook syntax) and A4 (joint contributions syntactically distinct)."
 

--- a/code/packages/rust/adj-lang/src/adapter.rs
+++ b/code/packages/rust/adj-lang/src/adapter.rs
@@ -941,6 +941,14 @@ fn latex_math_to_expr_ast(expr: &MathExpr, source: &str) -> Result<ExprAst, Adap
         MathExpr::Fenced { open, body, close } if open == "\\lceil" && close == "\\rceil" => {
             Ok(ExprAst::Ceil(Box::new(latex_math_to_expr_ast(body, source)?)))
         }
+        // The standard NEAREST-INTEGER fence is asymmetric — floor on the left,
+        // ceiling on the right — `\left\lfloor x\right\rceil`. It rounds to the
+        // nearest integer (ties away from zero) and lowers to `ComputeOp::Round`.
+        // Its distinct closing delimiter (`\rceil`, not `\rfloor`) keeps it separate
+        // from the plain floor arm above.
+        MathExpr::Fenced { open, body, close } if open == "\\lfloor" && close == "\\rceil" => {
+            Ok(ExprAst::Round(Box::new(latex_math_to_expr_ast(body, source)?)))
+        }
         MathExpr::Fenced { body, .. } => latex_math_to_expr_ast(body, source),
         MathExpr::Unary(UnaryOp::Pos, inner) => latex_math_to_expr_ast(inner, source),
         MathExpr::Unary(UnaryOp::Neg, inner) => Ok(ExprAst::Bin(

--- a/code/packages/rust/adj-lang/src/ast.rs
+++ b/code/packages/rust/adj-lang/src/ast.rs
@@ -117,6 +117,11 @@ pub enum ExprAst {
     /// `ComputeOp::Ceil` (dimension-preserving). Produced by the `latex "…"`
     /// adapter from a `\left\lceil…\right\rceil` fence.
     Ceil(Box<ExprAst>),
+    /// A round-to-nearest, `⌊x⌉` (ties away from zero). Lowers to the native
+    /// `ComputeOp::Round` (dimension-preserving). Produced by the `latex "…"`
+    /// adapter from the nearest-integer fence `\left\lfloor…\right\rceil`
+    /// (floor-left, ceil-right).
+    Round(Box<ExprAst>),
     /// An aggregation over every observation of a slot.
     Agg(AggOp, String),
 }

--- a/code/packages/rust/adj-lang/src/lower.rs
+++ b/code/packages/rust/adj-lang/src/lower.rs
@@ -708,6 +708,7 @@ fn lower_expr(expr: &ExprAst) -> ComputeExpr {
         ExprAst::Abs(a) => ComputeExpr::Unary(ComputeOp::Abs, Box::new(lower_expr(a))),
         ExprAst::Floor(a) => ComputeExpr::Unary(ComputeOp::Floor, Box::new(lower_expr(a))),
         ExprAst::Ceil(a) => ComputeExpr::Unary(ComputeOp::Ceil, Box::new(lower_expr(a))),
+        ExprAst::Round(a) => ComputeExpr::Unary(ComputeOp::Round, Box::new(lower_expr(a))),
         ExprAst::Agg(op, slot) => ComputeExpr::Agg(lower_agg_op(*op), slot.clone()),
     }
 }
@@ -1874,6 +1875,24 @@ contributes 1000000 from answer == 60 to correct
             "observe a(7)\n\
              observe b(2)\n\
              let answer = latex \"$\\left\\lceil a / b\\right\\rceil$\"\n\
+             prior 0.10 for correct\n\
+             contributes 1000000 from answer == 4 to correct\n\
+             ? correct\n",
+        )
+        .unwrap();
+        assert!(d.ranked[0].posterior > 0.99, "{d:?}");
+    }
+
+    #[test]
+    fn native_latex_nearest_integer_fence_rounds_a_quotient() {
+        // The asymmetric nearest-integer fence `⌊a / b⌉` = `\left\lfloor…\right\rceil`
+        // (floor-left, ceil-right) rounds to the nearest integer, ties away from
+        // zero: ⌊7/2⌉ = ⌊3.5⌉ = 4, computed on the native ComputeOp::Round — NOT the
+        // floor 3 (that would be `\rfloor`), so the asymmetric delimiters matter.
+        let d = crate::compile_and_decide(
+            "observe a(7)\n\
+             observe b(2)\n\
+             let answer = latex \"$\\left\\lfloor a / b\\right\\rceil$\"\n\
              prior 0.10 for correct\n\
              contributes 1000000 from answer == 4 to correct\n\
              ? correct\n",

--- a/code/packages/rust/logic-engine/CHANGELOG.md
+++ b/code/packages/rust/logic-engine/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.30.0] - 2026-07-02 — native round-to-nearest (`ComputeOp::Round`)
+
+### Added
+
+- **`ComputeOp::Round`** (`⌊x⌉`, nearest integer, **ties away from zero**) — a
+  third rounding unary op alongside `Floor`/`Ceil`, carried in the existing
+  `ComputeExpr::Unary` and evaluated in the shared `#[inline(never)] eval_unary`
+  helper (the macOS stack-frame guard still holds). It makes the standard
+  nearest-integer LaTeX fence `\left\lfloor x\right\rceil` (adj-lang's `latex "…"`
+  surface) computable as a single native node.
+- Dimension-preserving like `Floor`/`Ceil` (`⌊3.6 mmol⌉ = 4 mmol`). The **exact
+  rational sidecar stays exact**: truncate toward zero, then bump one step outward
+  when the fractional part reaches a half (`2·|rem| ≥ den`), matching Rust's
+  `f64::round` — `⌊5/2⌉ = 3`, `⌊−5/2⌉ = −3`, `⌊7/3⌉ = 2`. The `den − arem` compare
+  (with `arem = |rem| < den`) sidesteps the overflow a bare `2·arem` could hit, and
+  the outward bump is a `checked_add` (drops the exact sidecar rather than
+  panicking on the i128 edge).
+
 ## [0.29.0] - 2026-07-02 — native floor & ceiling (`ComputeOp::Floor` / `ComputeOp::Ceil`)
 
 ### Added

--- a/code/packages/rust/logic-engine/Cargo.toml
+++ b/code/packages/rust/logic-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logic-engine"
-version = "0.29.0"
+version = "0.30.0"
 edition = "2021"
 description = "Probability-aware facts, rules, KB, SLD find-first/enumerate + WMC posterior + LP19e likelihood-ratio Bayesian aggregation."
 

--- a/code/packages/rust/logic-engine/src/compute.rs
+++ b/code/packages/rust/logic-engine/src/compute.rs
@@ -205,6 +205,13 @@ pub enum ComputeOp {
     /// carried in a [`ComputeExpr::Unary`], lowered from a LaTeX
     /// `\left\lceil x\right\rceil`.
     Ceil,
+    /// Round to the nearest integer, `⌊x⌉`, with **ties away from zero**
+    /// (matching Rust's `f64::round`: `⌊2.5⌉ = 3`, `⌊−2.5⌉ = −3`). Like
+    /// [`ComputeOp::Floor`]/[`ComputeOp::Ceil`] it is unary and
+    /// dimension-preserving (`⌊3.6 mmol⌉ = 4 mmol`), carried in a
+    /// [`ComputeExpr::Unary`], and lowered from the standard nearest-integer
+    /// LaTeX fence `\left\lfloor x\right\rceil` (floor-left, ceil-right).
+    Round,
     Sum,
     Count,
     Min,
@@ -224,6 +231,7 @@ impl ComputeOp {
             ComputeOp::Abs => "abs",
             ComputeOp::Floor => "floor",
             ComputeOp::Ceil => "ceil",
+            ComputeOp::Round => "round",
             ComputeOp::Sum => "sum",
             ComputeOp::Count => "count",
             ComputeOp::Min => "min",
@@ -246,7 +254,7 @@ pub enum ComputeExpr {
     Lit(f64),
     /// A binary operation: `Add`/`Sub`/`Mul`/`Div`/`Pow` only.
     Bin(ComputeOp, Box<ComputeExpr>, Box<ComputeExpr>),
-    /// A unary operation: `Abs`/`Floor`/`Ceil`. Kept distinct from
+    /// A unary operation: `Abs`/`Floor`/`Ceil`/`Round`. Kept distinct from
     /// [`ComputeExpr::Bin`] so the arity is honest (a unary op has one operand,
     /// not two) — it lowers to a [`DerivationNode::Op`] with a single-element
     /// `operands` vec.
@@ -620,8 +628,8 @@ fn eval_unary(
 ) -> Result<(DerivationNode, Dimension, Option<ExactRational>), ComputeError> {
     let (operand, dim, exact) = eval(a, kb, depth + 1)?;
     // Every unary op here is **dimension-preserving**: the magnitude may change
-    // (sign flip for `Abs`, snap to an integer for `Floor`/`Ceil`) but the unit
-    // does not (`|−3 dollars| = 3 dollars`, `⌊3.7 mmol⌋ = 3 mmol`), so — unlike
+    // (sign flip for `Abs`, snap to an integer for `Floor`/`Ceil`/`Round`) but the
+    // unit does not (`|−3 dollars| = 3 dollars`, `⌊3.7 mmol⌋ = 3 mmol`), so — unlike
     // `Pow`, which recomputes the dimension — the operand's dimension flows
     // straight through.
     let value = operand.value();
@@ -629,6 +637,7 @@ fn eval_unary(
         ComputeOp::Abs => value.abs(),
         ComputeOp::Floor => value.floor(),
         ComputeOp::Ceil => value.ceil(),
+        ComputeOp::Round => value.round(),
         _ => {
             return Err(ComputeError::MalformedExpr {
                 detail: "non-unary operator in unary position",
@@ -636,8 +645,8 @@ fn eval_unary(
         }
     };
     // None of these can introduce a non-finite value from a finite operand
-    // (|±∞|/⌊±∞⌋/⌈±∞⌉ were already non-finite; NaN stays NaN), and the operand is
-    // finite-checked at its own producing op. Guard anyway — cheap
+    // (|±∞|/⌊±∞⌋/⌈±∞⌉/⌊±∞⌉ were already non-finite; NaN stays NaN), and the operand
+    // is finite-checked at its own producing op. Guard anyway — cheap
     // defense-in-depth, same contract as the binary ops.
     if !result.is_finite() {
         return Err(ComputeError::NonFinite { op });
@@ -645,7 +654,11 @@ fn eval_unary(
     // The exact sidecar stays exact. `ExactRational` keeps `den > 0`, so:
     //   • |num/den| = |num|/den (abs of the numerator);
     //   • ⌊num/den⌋ = num.div_euclid(den) (Euclidean division floors for den > 0);
-    //   • ⌈num/den⌉ = that quotient plus one when the division leaves a remainder.
+    //   • ⌈num/den⌉ = that quotient plus one when the division leaves a remainder;
+    //   • ⌊num/den⌉ = round to nearest with TIES AWAY FROM ZERO (matching
+    //     `f64::round`): truncate toward zero, then bump one step outward when the
+    //     fractional part reaches a half (2·|rem| ≥ den). The `den − arem` compare
+    //     avoids the overflow a bare `2·arem` could hit; `arem = |rem| < den`.
     // Each result is an integer, carried as `q/1`.
     let exact = exact.and_then(|r| match op {
         ComputeOp::Abs => r.num.checked_abs().and_then(|n| ExactRational::new(n, r.den)),
@@ -654,6 +667,18 @@ fn eval_unary(
             let q = r.num.div_euclid(r.den);
             let q = if r.num.rem_euclid(r.den) != 0 { q.checked_add(1)? } else { q };
             ExactRational::new(q, 1)
+        }
+        ComputeOp::Round => {
+            let q = r.num / r.den; // truncate toward zero (den > 0 ⇒ no overflow)
+            let rem = r.num % r.den; // in (−den, den), sign of the numerator
+            let arem = if rem >= 0 { rem } else { -rem }; // |rem| < den ⇒ no overflow
+            let bump = if arem >= r.den - arem {
+                // fractional part ≥ 1/2 → round away from zero (ties away from zero)
+                if r.num >= 0 { 1 } else { -1 }
+            } else {
+                0
+            };
+            ExactRational::new(q.checked_add(bump)?, 1)
         }
         _ => None,
     });
@@ -1007,6 +1032,61 @@ mod tests {
         .unwrap();
         assert_eq!(d.value, 3.0);
         assert_eq!(d.exact, ExactRational::new(3, 1));
+    }
+
+    #[test]
+    fn round_ties_go_away_from_zero_and_stay_exact() {
+        // ⌊5/2⌉ = 3, not 2 — a half rounds AWAY from zero (matching f64::round),
+        // and the exact sidecar snaps to the integer 3/1.
+        let d = compute(
+            "rd",
+            &ComputeExpr::Unary(
+                ComputeOp::Round,
+                Box::new(bin(ComputeOp::Div, ComputeExpr::Lit(5.0), ComputeExpr::Lit(2.0))),
+            ),
+            &kb_with(vec![]),
+        )
+        .unwrap();
+        assert_eq!(d.value, 3.0);
+        assert_eq!(d.dim, Dimension::Scalar);
+        assert_eq!(d.exact, ExactRational::new(3, 1));
+    }
+
+    #[test]
+    fn round_of_a_negative_half_goes_away_from_zero_too() {
+        // ⌊−5/2⌉ = −3 (NOT −2): ties away from zero is symmetric, so a negative
+        // half rounds down. Matches f64::round((-2.5)) == -3.0.
+        let d = compute(
+            "rd",
+            &ComputeExpr::Unary(
+                ComputeOp::Round,
+                Box::new(bin(ComputeOp::Div, ComputeExpr::Lit(-5.0), ComputeExpr::Lit(2.0))),
+            ),
+            &kb_with(vec![]),
+        )
+        .unwrap();
+        assert_eq!(d.value, -3.0);
+        assert_eq!(d.exact, ExactRational::new(-3, 1));
+    }
+
+    #[test]
+    fn round_below_a_half_stays_down_and_preserves_dimension() {
+        // ⌊7/3⌉ = 2 (2.33… rounds down, fractional part < ½). Round is
+        // dimension-preserving: ⌊dollars⌉ is still dollars, NOT collapsed to Scalar.
+        let kb = kb_with(vec![money("m", 7, "usd")]);
+        let d = compute(
+            "rd",
+            &ComputeExpr::Unary(
+                ComputeOp::Round,
+                Box::new(bin(ComputeOp::Div, refexpr("m"), ComputeExpr::Lit(3.0))),
+            ),
+            &kb,
+        )
+        .unwrap();
+        assert_eq!(d.value, 2.0);
+        assert_eq!(d.exact, ExactRational::new(2, 1));
+        // Same dimension as the operand `m` (money/usd).
+        assert_eq!(d.dim, kb.observed_dimensioned("m").unwrap().0.dim);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds a third rounding unary op alongside **Floor**/**Ceil**: **round-to-nearest** ⌊x⌉ with **ties away from zero** (matching Rust's `f64::round`). Mirrors the floor/ceil slice exactly — a fence delimiter pair → a `ComputeExpr::Unary` op.

| LaTeX | op | result |
|---|---|---|
| `\left\lfloor x\right\rfloor` | `Floor` | ⌊x⌋ |
| `\left\lceil x\right\rceil` | `Ceil` | ⌈x⌉ |
| **`\left\lfloor x\right\rceil`** | **`Round`** | ⌊x⌉ (nearest, ties away from 0) |

The nearest-integer notation is the **asymmetric** floor-left/ceil-right fence; its distinct *closing* delimiter (`\rceil` vs `\rfloor`) selects Round, so it sits beside the floor/ceil arms with no ambiguity.

## What changed
- **logic-engine** — `ComputeOp::Round`, evaluated in the shared `#[inline(never)] eval_unary` helper (macOS stack-frame guard holds). Dimension-preserving (`⌊3.6 mmol⌉ = 4 mmol`). The **exact-rational sidecar stays exact**: truncate toward zero, then bump one step outward when the fractional part reaches a half (`2·|rem| ≥ den`, tested as `arem ≥ den−arem` to dodge the overflow a bare `2·arem` could hit) — `⌊5/2⌉=3`, `⌊−5/2⌉=−3`, `⌊7/3⌉=2`. Outward bump is `checked_add` (drops the exact sidecar rather than panicking on the i128 edge).
- **adj-lang** — `ExprAst::Round` + adapter `Fenced` arm for `\lfloor`/`\rceil`, + lowering.
- **latex crate + solver — no change** (control-word delimiters already flow as data; solver `Unary` walkers are op-generic).

Truncation toward zero has no standard bracket notation → deferred to the future named-function slice (`\operatorname{trunc}`).

## Verification
- 3 new engine tests (ties away from zero / negative half also away / below-half stays down + dimension-preserving) + 1 new adj-lang lower test (`⌊7/2⌉=4` via the asymmetric fence, distinct from floor's 3).
- Full `logic-engine` (144) + `adj-lang` (98) + `adj-constraint-solver` + `adj-lang-cli` suites green; `adjudication-pipeline` builds.
- `logic-engine` 0.29→0.30, `adj-lang` 0.24→0.25; both CHANGELOGs updated.

Security-reviewed (inline): every i128 op in the Round arm is provably panic-free under the `den≥1`, `num≠i128::MIN` invariants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)