### PR TITLE
feat(ruby): def self.m class methods + super-as-expression (#59)

### DIFF
--- a/code/grammars/ruby.grammar
+++ b/code/grammars/ruby.grammar
@@ -25,7 +25,7 @@
 # than PUTS, TRUE, FALSE, NIL as token types.
 
 program      = { statement } ;
-statement    = endless_def_statement | def_statement | class_statement | module_statement | if_statement | unless_statement | while_statement | until_statement | case_statement | begin_statement | return_statement | break_statement | next_statement | redo_statement | retry_statement | yield_statement | super_statement | alias_statement | undef_statement | multi_assignment | modifier_statement | rightward_assignment | assignment | defined_expression | method_with_block | method_call | method_call_no_paren | expression_stmt ;
+statement    = endless_def_statement | def_statement | class_statement | module_statement | if_statement | unless_statement | while_statement | until_statement | case_statement | begin_statement | return_statement | break_statement | next_statement | redo_statement | retry_statement | yield_statement | alias_statement | undef_statement | multi_assignment | modifier_statement | rightward_assignment | assignment | defined_expression | method_with_block | method_call | method_call_no_paren | expression_stmt ;
 # Phase 6r — multiple assignment `a, b = 1, 2`.
 #
 # Placed BEFORE `modifier_statement` and `assignment` so the multi-LHS
@@ -112,13 +112,39 @@ modifier_statement = ( assignment | method_call_no_paren | method_call | express
 # the same `!"rescue" !"ensure"` negative-lookahead as begin_statement so
 # it stops at the first clause; the lowerer wraps the body + clauses in a
 # `Stmt::TryCatch` (Phase 16a) when any clause is present.
-def_statement = "def" NAME [ LPAREN [ params ] RPAREN ] { !"rescue" !"ensure" !"end" statement } { rescue_clause } [ ensure_clause ] "end" ;
+#
+# Issue #59 (OOP-cascade unblock) — CLASS-METHOD / singleton-method
+# definitions `def self.m` and `def Recv.m`.  A method definition may now
+# carry an OPTIONAL RECEIVER prefix (`def_receiver`) before the method
+# name: `def self.zero; end` (a class method on the enclosing class) and
+# `def Foo.bar(x); end` (a singleton method on the constant `Foo`).  The
+# receiver is `self` (the dominant idiom for class methods, mirroring
+# `class << self` in Phase 14e) or a bare `NAME`/constant, followed by a
+# literal `.` and then the method name.  The `.` is a `Dot` token matched
+# by VALUE (same convention as `dot_call`), so `def self . m` and
+# `def self.m` both parse.  The lowerer keys on the PRESENCE of the
+# `def_receiver` node: absent → an ordinary instance method (unchanged);
+# present → a class-method registration (`__def_class_method__`).  Because
+# the receiver is OPTIONAL, every pre-existing `def m` continues to parse
+# byte-for-byte as before (the optional group cleanly matches nothing when
+# the token after the method name is `(`, `=`, a newline, or a body
+# statement — none of which is a `.`).
+def_statement = "def" [ def_receiver ] NAME [ LPAREN [ params ] RPAREN ] { !"rescue" !"ensure" !"end" statement } { rescue_clause } [ ensure_clause ] "end" ;
+# The receiver prefix of a class/singleton method definition: `self.` or
+# `Const.` (or `name.`).  `singleton_receiver` (Phase 14e — `self | NAME`)
+# is reused verbatim so the `self`/`NAME` choice stays in one place.  The
+# trailing `.` is matched by literal VALUE (the lexer emits `.` as a `Dot`
+# token; matching the value keeps this in step with `dot_call`'s `"."`).
+def_receiver = singleton_receiver "." ;
 # Phase 7c — Ruby 3.0 endless method definition: `def foo = expr` and
 # `def foo(x, y) = expr`.  No `end`, no block body — just a single
 # expression after the `=`.  Placed BEFORE `def_statement` in the
 # `statement` alternation so PEG tries the endless form first; if the
 # `=` isn't present the parser falls through to the block form.
-endless_def_statement = "def" NAME [ LPAREN [ params ] RPAREN ] EQUALS expression ;
+#
+# Issue #59 — the same optional `def_receiver` prefix admits endless
+# class-method definitions `def self.m = expr` / `def Foo.m = expr`.
+endless_def_statement = "def" [ def_receiver ] NAME [ LPAREN [ params ] RPAREN ] EQUALS expression ;
 # Phase 6f — class/module namespace declarations.  The body is a
 # sequence of statements (which may include nested `def`s).  Like
 # `def_statement`, the body repetition uses a negative lookahead so it
@@ -230,11 +256,18 @@ yield_args = LPAREN [ call_arg { COMMA call_arg } ] RPAREN
 # The bare-vs-`super()` distinction is semantically load-bearing in Ruby
 # (zsuper forwards the caller's args; `super()` forwards none), so the
 # lowerer keys on the PRESENCE of a `super_args` node: absent → bare
-# zsuper, present → explicit (even with zero call_args).  Placed in
-# `statement` right after `yield_statement` and BEFORE the
-# `method_call*` family so the KEYWORD-tagged `super` token doesn't fall
-# through to `method_call_no_paren` and lose its dedicated lowering.
-super_statement = "super" [ super_args ] ;
+# zsuper, present → explicit (even with zero call_args).
+#
+# Issue #59 (OOP-cascade unblock) — `super` is now an EXPRESSION, not a
+# statement.  The old `super_statement` (a `statement`-alternation member)
+# could parse only a stand-alone `super`, so `super + " tail"`, `x = super`
+# and `puts(super)` failed.  The dedicated `super_expr` production (spliced
+# into `factor`, see below) subsumes ALL forms; a stand-alone `super` line
+# now parses as `expression_stmt → … → factor → super_expr`, so
+# `super_statement` was removed from the `statement` alternation to avoid it
+# shadowing the expression form (a PEG match of the statement rule consumes
+# only `super` and cannot backtrack, leaving a trailing `+ 1` orphaned).
+# `super_args` is retained — `super_expr` reuses it verbatim.
 super_args = LPAREN [ call_arg { COMMA call_arg } ] RPAREN
            | call_arg { COMMA call_arg } ;
 # Phase 6s — splat (`*args`) and double-splat (`**kwargs`) parameters.
@@ -467,7 +500,13 @@ rightward_assignment = expression "=>" NAME ;
 #
 # Setter calls (`foo.bar = 1`) and bracket access (`arr[0]`) are
 # deliberately out of scope for this chunk — they get their own phases.
-method_call  = ( NAME | KEYWORD ) LPAREN [ call_arg { COMMA call_arg } ] RPAREN { dot_call } ;
+# Issue #59 — the `KEYWORD` head is guarded with `!"super"` so a statement
+# `super(x, y)` / `super()` does NOT match here (which would mislower it as
+# an ordinary call to a method literally named `super`).  `super` in every
+# form now routes through `factor`'s `super_expr`; the guard hands the
+# `super` token off to `expression_stmt → … → super_expr` instead.  Every
+# other keyword-led call (`puts(1)`, value-keyword receivers) is unaffected.
+method_call  = ( NAME | !"super" KEYWORD ) LPAREN [ call_arg { COMMA call_arg } ] RPAREN { dot_call } ;
 dot_call     = "." ( NAME | KEYWORD ) [ LPAREN [ call_arg { COMMA call_arg } ] RPAREN ] [ block ] ;
 # Phase 15d (FC) — scope-resolution operator `Foo::Bar` (and chains
 # `A::B::C`).  The lexer emits `::` as a `Colon` token whose VALUE is
@@ -545,7 +584,10 @@ call_arg     = NAME COLON expression | [ "*" | "**" | "&" ] expression ;
 # greedily — matching idiomatic Ruby.  `puts(1) + 2`, by contrast,
 # matches `method_call` first and leaves `+ 2` for downstream rules
 # (same as existing behaviour pre-6h).
-method_call_no_paren = ( NAME | KEYWORD ) expression { COMMA expression } ;
+# Issue #59 — `!"super"` guard mirrors `method_call`: a parenless
+# `super x` at statement level routes to `super_expr` (via expression_stmt),
+# not to a spurious paren-less call to a method named `super`.
+method_call_no_paren = ( NAME | !"super" KEYWORD ) expression { COMMA expression } ;
 expression_stmt = expression ;
 # Phase 6i — comparison operators at the top of the precedence pyramid.
 #
@@ -703,7 +745,41 @@ term         = factor { ( STAR | SLASH ) factor } ;
 # every block body and every optional-expression statement at once.  Value
 # keywords (`nil`/`true`/`false`/`self`) are untouched, so `puts nil` etc.
 # still parse.  The `!"…"` lookaheads only peek; they consume nothing.
-factor       = ( defined_expression | lambda_literal | method_call | NUMBER | STRING | NAME | ( !"end" !"rescue" !"ensure" !"else" !"elsif" !"when" !"then" !"in" !"do" KEYWORD ) | symbol_literal | array_literal | hash_literal | LPAREN expression RPAREN | unary_minus ) { dot_call | scope_resolution } ;
+# Issue #59 (OOP-cascade unblock) — `super` as an EXPRESSION.
+#
+# Phase 22d gave `super` a statement-only form (`super_statement`).  But
+# `super` is a *value-producing* keyword: `x = super`, `super + " tail"`,
+# `puts(super)` all use its return value in expression position.  A
+# dedicated `super_expr` production is spliced into `factor` FIRST (before
+# the bare `NAME`/guarded-`KEYWORD` atoms) so the leading `super` keyword
+# is claimed here — otherwise the guarded `KEYWORD` atom would match the
+# bare `super` token and leave any `(args)` / parenless args dangling
+# (the exact factor-KEYWORD swallow hazard documented on the `KEYWORD`
+# atom below, and why `defined?`/`alias`/`undef` are handled specially).
+#
+# `super` is intentionally NOT added to the factor `KEYWORD`-guard
+# exclusion list: unlike `end`/`rescue`/`else`/… (which never denote a
+# value and must stay OUT of expressions so block bodies close), `super`
+# DOES denote a value and belongs IN expressions.  Handling it via its
+# own production — rather than relaxing the guard — keeps the arg-carrying
+# forms (`super(x)`, `super x`) intact while the guard continues to
+# protect block terminators.
+#
+# The argument forms reuse `super_args` (Phase 22d) verbatim, so
+# `super()`, `super(x)` and `super x` in expression position lower the
+# same way they do as statements.  A bare `super` (no `super_args`) is the
+# zsuper form; the lowerer keys on the presence of the `super_args` node
+# exactly as `super_statement` does.
+#
+# Precedence note: a parenless `super x + 1` binds as `super(x + 1)`
+# because `super_args`' parenless branch pulls a whole `call_arg`
+# (→ `expression`) greedily — matching `yield x + 1` and idiomatic Ruby.
+# To add to the *result* of a bare `super`, parenthesise the zsuper form
+# is not required — `super + 1` has no `super_args` (the `+` cannot begin
+# a `call_arg`/`LPAREN`), so it parses as bare-`super` then the enclosing
+# `sum` applies `+ 1` to the produced value.
+super_expr   = "super" [ super_args ] ;
+factor       = ( defined_expression | lambda_literal | super_expr | method_call | NUMBER | STRING | NAME | ( !"end" !"rescue" !"ensure" !"else" !"elsif" !"when" !"then" !"in" !"do" KEYWORD ) | symbol_literal | array_literal | hash_literal | LPAREN expression RPAREN | unary_minus ) { dot_call | scope_resolution } ;
 # Phase 6w — arrow-lambda literal `->(params){body}` / `->{body}`.
 #
 # Ruby 1.9+ shorthand for creating a `Proc`/`Lambda`.  The parameter

--- a/code/packages/rust/ruby-parser/CHANGELOG.md
+++ b/code/packages/rust/ruby-parser/CHANGELOG.md
@@ -2,6 +2,50 @@
 
 All notable changes to the `coding-adventures-ruby-parser` crate will be documented in this file.
 
+## [0.5.0] - 2026-07-01
+
+(Cargo manifest minor bump 0.4.0 → 0.5.0.  Note: the older CHANGELOG headers
+use a separate 0.8x sequence that had drifted from the manifest version; this
+entry tracks the actual `Cargo.toml` version, matching the convention adopted
+by `ruby-to-semantic-ir`.)
+
+### Added (Issue #59 — class-method defs `def self.m` + `super` as an expression)
+
+Two grammar limitations that blocked the just-merged OOP cascade (O1–O5) are
+lifted. Both required `ruby.grammar` changes and a regenerated
+`src/_grammar.rs` (via `grammar-tools generate-rust-compiled-grammars
+ruby-parser`).
+
+- **Class-method / singleton-method definitions `def self.m` / `def Recv.m`.**
+  `def_statement` and `endless_def_statement` gained an OPTIONAL leading
+  `def_receiver` prefix:
+  `def_statement = "def" [ def_receiver ] NAME [ LPAREN [ params ] RPAREN ] … "end" ;`
+  with `def_receiver = singleton_receiver "." ;` (reusing Phase 14e's
+  `singleton_receiver = self | NAME`). So `def self.zero; end` and
+  `def Foo.bar(x); end` now parse. The prefix is optional, so every prior
+  `def m` parses byte-for-byte as before (the optional group matches nothing
+  unless a `.` follows the receiver token).
+
+- **`super` as an EXPRESSION.** A dedicated `super_expr = "super" [ super_args ]`
+  production is spliced into `factor` (FIRST, before the bare `NAME`/guarded
+  `KEYWORD` atoms) so `x = super`, `super + 1`, and `puts(super)` parse.
+  Previously `super` was statement-only (`super_statement`), so any
+  `super`-in-expression form parse-panicked.
+
+### Changed
+
+- **`super_statement` removed from the `statement` alternation.** All `super`
+  forms now route through `factor`'s `super_expr` (a stand-alone `super` line
+  parses as `expression_stmt → … → super_expr`). Keeping the old statement
+  rule would have shadowed the expression form — a PEG match of
+  `super_statement` consumes only `super` and cannot backtrack, orphaning a
+  trailing `+ 1`. `super_args` is retained (reused by `super_expr`).
+- **`method_call` / `method_call_no_paren` KEYWORD head guarded with
+  `!"super"`.** A statement `super(x, y)` / `super x` must NOT match these
+  rules (which would mislower it as an ordinary call to a method literally
+  named `super`); the guard hands `super` to `super_expr` instead. Every other
+  keyword-led call (`puts(1)`, value-keyword receivers) is unchanged.
+
 ## [0.82.0] - 2026-06-30
 
 ### Added (KW7 — keyword parameters & arguments, the Ruby-1.0 unblock)

--- a/code/packages/rust/ruby-parser/Cargo.toml
+++ b/code/packages/rust/ruby-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-ruby-parser"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "Ruby parser — parses Ruby source code into an AST using the grammar-driven parser and the ruby.grammar file"
 

--- a/code/packages/rust/ruby-parser/src/_grammar.rs
+++ b/code/packages/rust/ruby-parser/src/_grammar.rs
@@ -34,7 +34,6 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"redo_statement"#.to_string() },
                 GrammarElement::RuleReference { name: r#"retry_statement"#.to_string() },
                 GrammarElement::RuleReference { name: r#"yield_statement"#.to_string() },
-                GrammarElement::RuleReference { name: r#"super_statement"#.to_string() },
                 GrammarElement::RuleReference { name: r#"alias_statement"#.to_string() },
                 GrammarElement::RuleReference { name: r#"undef_statement"#.to_string() },
                 GrammarElement::RuleReference { name: r#"multi_assignment"#.to_string() },
@@ -99,6 +98,7 @@ pub fn parser_grammar() -> ParserGrammar {
             name: r#"def_statement"#.to_string(),
             body: GrammarElement::Sequence { elements: vec![
                 GrammarElement::Literal { value: r#"def"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"def_receiver"#.to_string() }) },
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
                         GrammarElement::TokenReference { name: r#"LPAREN"#.to_string() },
@@ -115,12 +115,21 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"ensure_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 115,
+            line_number: 132,
+        },
+        GrammarRule {
+            name: r#"def_receiver"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"singleton_receiver"#.to_string() },
+                GrammarElement::Literal { value: r#"."#.to_string() },
+            ] },
+            line_number: 138,
         },
         GrammarRule {
             name: r#"endless_def_statement"#.to_string(),
             body: GrammarElement::Sequence { elements: vec![
                 GrammarElement::Literal { value: r#"def"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"def_receiver"#.to_string() }) },
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
                         GrammarElement::TokenReference { name: r#"LPAREN"#.to_string() },
@@ -130,7 +139,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"EQUALS"#.to_string() },
                 GrammarElement::RuleReference { name: r#"expression"#.to_string() },
             ] },
-            line_number: 121,
+            line_number: 147,
         },
         GrammarRule {
             name: r#"class_statement"#.to_string(),
@@ -159,7 +168,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::Literal { value: r#"end"#.to_string() },
                 ] },
             ] },
-            line_number: 142,
+            line_number: 168,
         },
         GrammarRule {
             name: r#"singleton_receiver"#.to_string(),
@@ -167,7 +176,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"self"#.to_string() },
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
             ] },
-            line_number: 144,
+            line_number: 170,
         },
         GrammarRule {
             name: r#"module_statement"#.to_string(),
@@ -180,7 +189,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 145,
+            line_number: 171,
         },
         GrammarRule {
             name: r#"method_with_block"#.to_string(),
@@ -202,7 +211,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"block"#.to_string() },
             ] },
-            line_number: 147,
+            line_number: 173,
         },
         GrammarRule {
             name: r#"block"#.to_string(),
@@ -210,7 +219,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"do_block"#.to_string() },
                 GrammarElement::RuleReference { name: r#"brace_block"#.to_string() },
             ] },
-            line_number: 148,
+            line_number: 174,
         },
         GrammarRule {
             name: r#"do_block"#.to_string(),
@@ -223,7 +232,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 149,
+            line_number: 175,
         },
         GrammarRule {
             name: r#"brace_block"#.to_string(),
@@ -233,7 +242,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"statement"#.to_string() }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 150,
+            line_number: 176,
         },
         GrammarRule {
             name: r#"block_params"#.to_string(),
@@ -254,7 +263,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Literal { value: r#"|"#.to_string() },
             ] },
-            line_number: 160,
+            line_number: 186,
         },
         GrammarRule {
             name: r#"return_statement"#.to_string(),
@@ -262,7 +271,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"return"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"expression"#.to_string() }) },
             ] },
-            line_number: 162,
+            line_number: 188,
         },
         GrammarRule {
             name: r#"break_statement"#.to_string(),
@@ -270,7 +279,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"break"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"expression"#.to_string() }) },
             ] },
-            line_number: 163,
+            line_number: 189,
         },
         GrammarRule {
             name: r#"next_statement"#.to_string(),
@@ -278,17 +287,17 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"next"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"expression"#.to_string() }) },
             ] },
-            line_number: 164,
+            line_number: 190,
         },
         GrammarRule {
             name: r#"redo_statement"#.to_string(),
             body: GrammarElement::Literal { value: r#"redo"#.to_string() },
-            line_number: 168,
+            line_number: 194,
         },
         GrammarRule {
             name: r#"retry_statement"#.to_string(),
             body: GrammarElement::Literal { value: r#"retry"#.to_string() },
-            line_number: 172,
+            line_number: 198,
         },
         GrammarRule {
             name: r#"alias_statement"#.to_string(),
@@ -297,7 +306,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
             ] },
-            line_number: 183,
+            line_number: 209,
         },
         GrammarRule {
             name: r#"undef_statement"#.to_string(),
@@ -305,7 +314,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"undef"#.to_string() },
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
             ] },
-            line_number: 195,
+            line_number: 221,
         },
         GrammarRule {
             name: r#"yield_statement"#.to_string(),
@@ -313,7 +322,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"yield"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"yield_args"#.to_string() }) },
             ] },
-            line_number: 217,
+            line_number: 243,
         },
         GrammarRule {
             name: r#"yield_args"#.to_string(),
@@ -337,15 +346,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) },
                 ] },
             ] },
-            line_number: 218,
-        },
-        GrammarRule {
-            name: r#"super_statement"#.to_string(),
-            body: GrammarElement::Sequence { elements: vec![
-                GrammarElement::Literal { value: r#"super"#.to_string() },
-                GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"super_args"#.to_string() }) },
-            ] },
-            line_number: 237,
+            line_number: 244,
         },
         GrammarRule {
             name: r#"super_args"#.to_string(),
@@ -369,7 +370,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) },
                 ] },
             ] },
-            line_number: 238,
+            line_number: 271,
         },
         GrammarRule {
             name: r#"params"#.to_string(),
@@ -383,7 +384,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) },
                 ] },
             ] },
-            line_number: 267,
+            line_number: 300,
         },
         GrammarRule {
             name: r#"param"#.to_string(),
@@ -404,7 +405,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] },
                     ] }) },
             ] },
-            line_number: 312,
+            line_number: 345,
         },
         GrammarRule {
             name: r#"if_statement"#.to_string(),
@@ -421,7 +422,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"else_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 313,
+            line_number: 346,
         },
         GrammarRule {
             name: r#"elsif_clause"#.to_string(),
@@ -435,7 +436,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 314,
+            line_number: 347,
         },
         GrammarRule {
             name: r#"else_clause"#.to_string(),
@@ -446,7 +447,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 315,
+            line_number: 348,
         },
         GrammarRule {
             name: r#"unless_statement"#.to_string(),
@@ -461,7 +462,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"else_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 316,
+            line_number: 349,
         },
         GrammarRule {
             name: r#"while_statement"#.to_string(),
@@ -474,7 +475,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 317,
+            line_number: 350,
         },
         GrammarRule {
             name: r#"until_statement"#.to_string(),
@@ -487,7 +488,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 318,
+            line_number: 351,
         },
         GrammarRule {
             name: r#"case_statement"#.to_string(),
@@ -501,7 +502,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"else_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 341,
+            line_number: 374,
         },
         GrammarRule {
             name: r#"when_clause"#.to_string(),
@@ -520,7 +521,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 342,
+            line_number: 375,
         },
         GrammarRule {
             name: r#"in_clause"#.to_string(),
@@ -535,7 +536,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 364,
+            line_number: 397,
         },
         GrammarRule {
             name: r#"pattern"#.to_string(),
@@ -547,7 +548,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"literal_pattern"#.to_string() },
                 GrammarElement::RuleReference { name: r#"binding_pattern"#.to_string() },
             ] },
-            line_number: 365,
+            line_number: 398,
         },
         GrammarRule {
             name: r#"literal_pattern"#.to_string(),
@@ -557,12 +558,12 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"symbol_literal"#.to_string() },
                 GrammarElement::TokenReference { name: r#"KEYWORD"#.to_string() },
             ] },
-            line_number: 366,
+            line_number: 399,
         },
         GrammarRule {
             name: r#"binding_pattern"#.to_string(),
             body: GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
-            line_number: 367,
+            line_number: 400,
         },
         GrammarRule {
             name: r#"array_pattern"#.to_string(),
@@ -583,7 +584,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
             ] },
-            line_number: 368,
+            line_number: 401,
         },
         GrammarRule {
             name: r#"hash_pattern"#.to_string(),
@@ -598,7 +599,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 369,
+            line_number: 402,
         },
         GrammarRule {
             name: r#"hash_pattern_pair"#.to_string(),
@@ -607,7 +608,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"pattern"#.to_string() }) },
             ] },
-            line_number: 370,
+            line_number: 403,
         },
         GrammarRule {
             name: r#"splat_pattern"#.to_string(),
@@ -615,7 +616,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"*"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::TokenReference { name: r#"NAME"#.to_string() }) },
             ] },
-            line_number: 377,
+            line_number: 410,
         },
         GrammarRule {
             name: r#"pin_pattern"#.to_string(),
@@ -623,7 +624,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"^"#.to_string() },
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
             ] },
-            line_number: 382,
+            line_number: 415,
         },
         GrammarRule {
             name: r#"class_pattern"#.to_string(),
@@ -639,7 +640,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
             ] },
-            line_number: 388,
+            line_number: 421,
         },
         GrammarRule {
             name: r#"begin_statement"#.to_string(),
@@ -655,7 +656,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"ensure_clause"#.to_string() }) },
                 GrammarElement::Literal { value: r#"end"#.to_string() },
             ] },
-            line_number: 409,
+            line_number: 442,
         },
         GrammarRule {
             name: r#"rescue_clause"#.to_string(),
@@ -673,7 +674,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 418,
+            line_number: 451,
         },
         GrammarRule {
             name: r#"exception_list"#.to_string(),
@@ -684,7 +685,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
                     ] }) },
             ] },
-            line_number: 419,
+            line_number: 452,
         },
         GrammarRule {
             name: r#"ensure_clause"#.to_string(),
@@ -695,7 +696,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"statement"#.to_string() },
                     ] }) },
             ] },
-            line_number: 420,
+            line_number: 453,
         },
         GrammarRule {
             name: r#"assignment"#.to_string(),
@@ -719,7 +720,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"expression"#.to_string() },
             ] },
-            line_number: 440,
+            line_number: 473,
         },
         GrammarRule {
             name: r#"rightward_assignment"#.to_string(),
@@ -728,14 +729,17 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"=>"#.to_string() },
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
             ] },
-            line_number: 459,
+            line_number: 492,
         },
         GrammarRule {
             name: r#"method_call"#.to_string(),
             body: GrammarElement::Sequence { elements: vec![
                 GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
                         GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
-                        GrammarElement::TokenReference { name: r#"KEYWORD"#.to_string() },
+                        GrammarElement::Sequence { elements: vec![
+                            GrammarElement::NegativeLookahead { element: Box::new(GrammarElement::Literal { value: r#"super"#.to_string() }) },
+                            GrammarElement::TokenReference { name: r#"KEYWORD"#.to_string() },
+                        ] },
                     ] }) },
                 GrammarElement::TokenReference { name: r#"LPAREN"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
@@ -748,7 +752,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"dot_call"#.to_string() }) },
             ] },
-            line_number: 470,
+            line_number: 509,
         },
         GrammarRule {
             name: r#"dot_call"#.to_string(),
@@ -771,7 +775,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"block"#.to_string() }) },
             ] },
-            line_number: 471,
+            line_number: 510,
         },
         GrammarRule {
             name: r#"scope_resolution"#.to_string(),
@@ -782,7 +786,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"KEYWORD"#.to_string() },
                     ] }) },
             ] },
-            line_number: 479,
+            line_number: 518,
         },
         GrammarRule {
             name: r#"call_arg"#.to_string(),
@@ -801,14 +805,17 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                 ] },
             ] },
-            line_number: 534,
+            line_number: 573,
         },
         GrammarRule {
             name: r#"method_call_no_paren"#.to_string(),
             body: GrammarElement::Sequence { elements: vec![
                 GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
                         GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
-                        GrammarElement::TokenReference { name: r#"KEYWORD"#.to_string() },
+                        GrammarElement::Sequence { elements: vec![
+                            GrammarElement::NegativeLookahead { element: Box::new(GrammarElement::Literal { value: r#"super"#.to_string() }) },
+                            GrammarElement::TokenReference { name: r#"KEYWORD"#.to_string() },
+                        ] },
                     ] }) },
                 GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
@@ -816,17 +823,17 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                     ] }) },
             ] },
-            line_number: 548,
+            line_number: 590,
         },
         GrammarRule {
             name: r#"expression_stmt"#.to_string(),
             body: GrammarElement::RuleReference { name: r#"expression"#.to_string() },
-            line_number: 549,
+            line_number: 591,
         },
         GrammarRule {
             name: r#"expression"#.to_string(),
             body: GrammarElement::RuleReference { name: r#"ternary"#.to_string() },
-            line_number: 656,
+            line_number: 698,
         },
         GrammarRule {
             name: r#"ternary"#.to_string(),
@@ -839,7 +846,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                     ] }) },
             ] },
-            line_number: 657,
+            line_number: 699,
         },
         GrammarRule {
             name: r#"range"#.to_string(),
@@ -862,7 +869,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) },
                 ] },
             ] },
-            line_number: 658,
+            line_number: 700,
         },
         GrammarRule {
             name: r#"logical_or"#.to_string(),
@@ -876,7 +883,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_and"#.to_string() },
                     ] }) },
             ] },
-            line_number: 659,
+            line_number: 701,
         },
         GrammarRule {
             name: r#"logical_and"#.to_string(),
@@ -890,7 +897,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"logical_not"#.to_string() },
                     ] }) },
             ] },
-            line_number: 660,
+            line_number: 702,
         },
         GrammarRule {
             name: r#"logical_not"#.to_string(),
@@ -901,7 +908,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) }) },
                 GrammarElement::RuleReference { name: r#"comparison"#.to_string() },
             ] },
-            line_number: 667,
+            line_number: 709,
         },
         GrammarRule {
             name: r#"comparison"#.to_string(),
@@ -919,7 +926,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"sum"#.to_string() },
                     ] }) },
             ] },
-            line_number: 668,
+            line_number: 710,
         },
         GrammarRule {
             name: r#"sum"#.to_string(),
@@ -933,7 +940,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"term"#.to_string() },
                     ] }) },
             ] },
-            line_number: 669,
+            line_number: 711,
         },
         GrammarRule {
             name: r#"term"#.to_string(),
@@ -947,7 +954,15 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"factor"#.to_string() },
                     ] }) },
             ] },
-            line_number: 670,
+            line_number: 712,
+        },
+        GrammarRule {
+            name: r#"super_expr"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"super"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"super_args"#.to_string() }) },
+            ] },
+            line_number: 781,
         },
         GrammarRule {
             name: r#"factor"#.to_string(),
@@ -955,6 +970,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
                         GrammarElement::RuleReference { name: r#"defined_expression"#.to_string() },
                         GrammarElement::RuleReference { name: r#"lambda_literal"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"super_expr"#.to_string() },
                         GrammarElement::RuleReference { name: r#"method_call"#.to_string() },
                         GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() },
                         GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
@@ -986,7 +1002,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"scope_resolution"#.to_string() },
                     ] }) },
             ] },
-            line_number: 706,
+            line_number: 782,
         },
         GrammarRule {
             name: r#"lambda_literal"#.to_string(),
@@ -999,7 +1015,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"block"#.to_string() },
             ] },
-            line_number: 725,
+            line_number: 801,
         },
         GrammarRule {
             name: r#"unary_minus"#.to_string(),
@@ -1007,7 +1023,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"MINUS"#.to_string() },
                 GrammarElement::RuleReference { name: r#"factor"#.to_string() },
             ] },
-            line_number: 726,
+            line_number: 802,
         },
         GrammarRule {
             name: r#"defined_expression"#.to_string(),
@@ -1015,7 +1031,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"defined?"#.to_string() },
                 GrammarElement::RuleReference { name: r#"factor"#.to_string() },
             ] },
-            line_number: 737,
+            line_number: 813,
         },
         GrammarRule {
             name: r#"symbol_literal"#.to_string(),
@@ -1027,7 +1043,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
                     ] }) },
             ] },
-            line_number: 744,
+            line_number: 820,
         },
         GrammarRule {
             name: r#"array_literal"#.to_string(),
@@ -1042,7 +1058,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
             ] },
-            line_number: 745,
+            line_number: 821,
         },
         GrammarRule {
             name: r#"hash_literal"#.to_string(),
@@ -1057,7 +1073,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 746,
+            line_number: 822,
         },
         GrammarRule {
             name: r#"hash_entry"#.to_string(),
@@ -1077,7 +1093,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::RuleReference { name: r#"expression"#.to_string() },
                 ] },
             ] },
-            line_number: 747,
+            line_number: 823,
         },
     ],
         version: 1,

--- a/code/packages/rust/ruby-parser/src/lib.rs
+++ b/code/packages/rust/ruby-parser/src/lib.rs
@@ -3093,11 +3093,13 @@ mod tests {
 
     #[test]
     fn test_parse_super_bare() {
-        // Phase 22d — bare `super` (zsuper): no argument list.  Must
-        // parse as a `super_statement` with NO `super_args` child (the
-        // absence is what marks it as implicit-forward zsuper).
+        // Phase 22d / Issue #59 — bare `super` (zsuper): no argument list.
+        // Now parses as a `super_expr` (the statement-only `super_statement`
+        // was folded into `factor` so `super` works in expression position)
+        // with NO `super_args` child (the absence marks it as implicit-forward
+        // zsuper).
         let ast = parse_ruby("super");
-        let sup = find_descendant(&ast, "super_statement").expect("expected super_statement");
+        let sup = find_descendant(&ast, "super_expr").expect("expected super_expr");
         assert!(tree_has_token_value(sup, "super"), "expected `super` keyword");
         assert!(
             find_descendant(sup, "super_args").is_none(),
@@ -3107,11 +3109,11 @@ mod tests {
 
     #[test]
     fn test_parse_super_empty_parens() {
-        // Phase 22d — `super()`: explicit empty arg list.  A
+        // Phase 22d / Issue #59 — `super()`: explicit empty arg list.  A
         // `super_args` node IS present (with zero `call_arg` children),
         // distinguishing it from bare zsuper.
         let ast = parse_ruby("super()");
-        let sup = find_descendant(&ast, "super_statement").expect("expected super_statement");
+        let sup = find_descendant(&ast, "super_expr").expect("expected super_expr");
         let args = find_descendant(sup, "super_args").expect("expected super_args node");
         let arg_count = args
             .children
@@ -3123,10 +3125,10 @@ mod tests {
 
     #[test]
     fn test_parse_super_with_args() {
-        // Phase 22d — `super(x, y)`: explicit args.  `super_args` holds
-        // two `call_arg` children.
+        // Phase 22d / Issue #59 — `super(x, y)`: explicit args.  `super_args`
+        // holds two `call_arg` children.
         let ast = parse_ruby("super(x, y)");
-        let sup = find_descendant(&ast, "super_statement").expect("expected super_statement");
+        let sup = find_descendant(&ast, "super_expr").expect("expected super_expr");
         let args = find_descendant(sup, "super_args").expect("expected super_args node");
         let arg_count = args
             .children
@@ -4864,6 +4866,120 @@ mod tests {
         };
         assert!(!colon(call_args[0]), "first arg is positional (no colon)");
         assert!(colon(call_args[1]), "second arg is a keyword (colon)");
+    }
+
+    // -----------------------------------------------------------------------
+    // Issue #59 — class-method definitions `def self.m` / `def Foo.m`
+    // -----------------------------------------------------------------------
+
+    /// `def self.zero; end` parses to a `def_statement` carrying a
+    /// `def_receiver` whose singleton receiver is `self`.
+    #[test]
+    fn test_parse_def_self_method() {
+        let ast = parse_ruby("def self.zero\nend");
+        let def = find_descendant(&ast, "def_statement").expect("expected def_statement");
+        let recv = find_descendant(def, "def_receiver").expect("expected def_receiver");
+        // The receiver holds `self` (a KEYWORD token) via singleton_receiver.
+        let sr = find_descendant(recv, "singleton_receiver").expect("singleton_receiver");
+        let has_self = sr.children.iter().any(|c| matches!(
+            c,
+            ASTNodeOrToken::Token(t) if t.value == "self"
+        ));
+        assert!(has_self, "def self.m receiver must be `self`");
+    }
+
+    /// `def Foo.bar(x); end` parses to a `def_statement` with a `def_receiver`
+    /// naming the constant `Foo` and a normal parameter list.
+    #[test]
+    fn test_parse_def_const_method_with_params() {
+        let ast = parse_ruby("def Foo.bar(x)\nend");
+        let def = find_descendant(&ast, "def_statement").expect("expected def_statement");
+        let recv = find_descendant(def, "def_receiver").expect("expected def_receiver");
+        let sr = find_descendant(recv, "singleton_receiver").expect("singleton_receiver");
+        let has_foo = sr.children.iter().any(|c| matches!(
+            c,
+            ASTNodeOrToken::Token(t) if t.value == "Foo"
+        ));
+        assert!(has_foo, "def Foo.bar receiver must be `Foo`");
+        // The parameter `x` is still parsed under a `params` node.
+        assert!(find_descendant(def, "params").is_some(), "expected params");
+    }
+
+    /// A plain `def m` (no receiver) must NOT grow a `def_receiver` node —
+    /// the optional prefix cleanly matches nothing (regression guard).
+    #[test]
+    fn test_parse_def_no_receiver_unchanged() {
+        let ast = parse_ruby("def zero\n  0\nend");
+        let def = find_descendant(&ast, "def_statement").expect("expected def_statement");
+        assert!(
+            find_descendant(def, "def_receiver").is_none(),
+            "plain `def m` must have NO def_receiver node"
+        );
+    }
+
+    /// Endless class-method form `def self.zero = 0`.
+    #[test]
+    fn test_parse_endless_def_self_method() {
+        let ast = parse_ruby("def self.zero = 0");
+        let def =
+            find_descendant(&ast, "endless_def_statement").expect("expected endless_def_statement");
+        assert!(
+            find_descendant(def, "def_receiver").is_some(),
+            "def self.zero = 0 must carry a def_receiver"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Issue #59 — `super` as an expression (`super_expr`)
+    // -----------------------------------------------------------------------
+
+    /// `x = super` parses `super` in expression position as a `super_expr`
+    /// (the RHS of the assignment), not a statement-level `super_statement`.
+    #[test]
+    fn test_parse_super_as_assignment_rhs() {
+        let ast = parse_ruby("x = super");
+        let sup = find_descendant(&ast, "super_expr").expect("expected super_expr");
+        assert!(
+            find_descendant(sup, "super_args").is_none(),
+            "bare super (expr) must have NO super_args node"
+        );
+    }
+
+    /// `super + 1` parses as a `sum` whose left operand is a bare
+    /// `super_expr` — the `+` cannot begin a `call_arg`, so `super` stays
+    /// bare and the `+ 1` applies to its produced value.
+    #[test]
+    fn test_parse_super_plus_expr() {
+        let ast = parse_ruby("super + 1");
+        let sup = find_descendant(&ast, "super_expr").expect("expected super_expr");
+        assert!(
+            find_descendant(sup, "super_args").is_none(),
+            "`super + 1` — super must be bare (no super_args)"
+        );
+        // The `+ 1` lives outside super_expr, under a `sum`.
+        assert!(find_descendant(&ast, "sum").is_some(), "expected a sum node");
+    }
+
+    /// `puts(super)` — `super` used as a call argument (deep in expression
+    /// position) parses as a `super_expr`.
+    #[test]
+    fn test_parse_super_as_call_arg() {
+        let ast = parse_ruby("puts(super)");
+        assert!(
+            find_descendant(&ast, "super_expr").is_some(),
+            "super inside puts(...) must parse as super_expr"
+        );
+    }
+
+    /// `super + \" tail\"` (the P3 execution-proof shape) parses with a bare
+    /// `super_expr` on the left of a `sum`.
+    #[test]
+    fn test_parse_super_string_concat() {
+        let ast = parse_ruby("super + \" tail\"");
+        assert!(
+            find_descendant(&ast, "super_expr").is_some(),
+            "expected super_expr"
+        );
     }
 }
 

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,51 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.5.0] - 2026-07-01
+
+(Cargo manifest minor bump 0.4.0 → 0.5.0.)
+
+### Added (Issue #59 — class-method defs `def self.m` + `super` as an expression)
+
+Lowering support for the two grammar features unblocked in
+`coding-adventures-ruby-parser` 0.5.0.
+
+- **`def self.m` / `def Recv.m` → class-method registration.** A `def` (or
+  endless `def`) carrying a `def_receiver` node now routes to the
+  ALREADY-EXISTING `register_class_method` path (previously unreachable — the
+  grammar had no receiver production): it emits
+  `__def_class_method__("Class", "m", MakeClosure(fn))` instead of
+  `__def_method__`, and hoists the body under a `_cm`-suffixed class-qualified
+  top-level name (`Counter__zero_cm`) so a class method and an instance method
+  of the same name on the same class never collide.
+
+- **Class-method CALL dispatch `Foo.bar` → `__class_method__`.** A non-`new`
+  method call on a CONSTANT receiver (`Counter.zero`, `Foo.bar(x)`) now lowers
+  to a new `__class_method__("Foo", "bar", …args)` builtin (routed by the
+  Python backend to `_sir_oop_call_class_method`, the ancestry-walking lookup
+  in the `def self.m` table). `.new` on a const still routes to `__new__` (the
+  implicit constructor); a method call on a NON-constant receiver
+  (`obj.meth`) still routes through `__method__`.
+
+- **`super` in expression position → `__super__` as an `Expr`.** The
+  `super`-lowering logic moved into a shared `lower_super_expr` helper that
+  returns an `Expr::BuiltinCall("__super__", …)` (rather than a `Stmt`), so
+  `x = super`, `super + 1`, and `puts(super)` slot the `__super__` marker
+  anywhere an expression goes. The statement form (a bare `super` line) wraps
+  the same helper in an `ExprStmt`. The zsuper param-forwarding / explicit-arg
+  behaviour is unchanged.
+
+### Deferred / known gaps
+
+- **String concatenation via `super + "…"`** (or any Ruby `str + str`) is a
+  PRE-EXISTING pipeline limitation unrelated to #59: Ruby `+` lowers to the
+  numeric-seeded `_sir_plus` (`add` starts `total = 0`), so `"a" + "b"` raises
+  `int + str` at runtime. The #59 super-as-expression execution-proof therefore
+  uses `super + 1` (numeric); string `+` awaits a polymorphic-`+` follow-up.
+- **Class-method CALL dispatch is wired for the Python backend only.** The
+  JS/Go/Rust backends have no `call_class_method` runtime yet, so
+  `__class_method__` is not emitted there (a per-backend follow-up).
+
 ## [0.4.0] - 2026-07-01
 
 (Cargo manifest minor bump 0.3.0 → 0.4.0.  Note: earlier CHANGELOG headers use

--- a/code/packages/rust/ruby-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/ruby-to-semantic-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruby-to-semantic-ir"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "Ruby AST → narrow-waist Semantic IR. Phase 5 of the Ruby parser project — first frontend for the ruby-parser → SIR pipeline."
 

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -6223,16 +6223,21 @@ mod tests {
         // `__super__("", "")` (method + class are empty — no enclosing context).
         // The in-class param-forwarding case is covered by
         // `bare_super_forwards_enclosing_params` in the O2 section.
+        //
+        // Issue #59 — `super` is now an EXPRESSION (`super_expr` in `factor`),
+        // so a bare `super` as the SOLE top-level statement is promoted to the
+        // module's tail `value` (like any bare expression), not `stmts[0]`.
+        // The lowered SHAPE (`__super__(method, class, …)`) is unchanged.
         let m = lower("super\n");
         let b = main_body(&m);
-        match &b.stmts[0] {
-            Stmt::ExprStmt { expr: Expr::BuiltinCall { name, args, .. }, .. } => {
+        match &b.value {
+            Expr::BuiltinCall { name, args, .. } => {
                 assert_eq!(name, "__super__", "bare super lowers to __super__");
                 assert_eq!(args.len(), 2, "method + class names, no forwarded params");
                 assert!(matches!(&args[0], Expr::StrLit { value, .. } if value.is_empty()));
                 assert!(matches!(&args[1], Expr::StrLit { value, .. } if value.is_empty()));
             }
-            other => panic!("expected ExprStmt(BuiltinCall(__super__, …)), got {:?}", other),
+            other => panic!("expected tail BuiltinCall(__super__, …), got {:?}", other),
         }
     }
 
@@ -6240,14 +6245,15 @@ mod tests {
     fn super_empty_parens_lowers_to_super_builtin_no_args() {
         // `super()` forwards NO arguments: `__super__(method, class)` with no
         // trailing operands (at the top level the two names are empty strings).
+        // Issue #59 — promoted to the module tail `value` (super is an expr).
         let m = lower("super()\n");
         let b = main_body(&m);
-        match &b.stmts[0] {
-            Stmt::ExprStmt { expr: Expr::BuiltinCall { name, args, .. }, .. } => {
+        match &b.value {
+            Expr::BuiltinCall { name, args, .. } => {
                 assert_eq!(name, "__super__", "super() lowers to __super__");
                 assert_eq!(args.len(), 2, "super() forwards zero extra args");
             }
-            other => panic!("expected ExprStmt(BuiltinCall(__super__, …)), got {:?}", other),
+            other => panic!("expected tail BuiltinCall(__super__, …), got {:?}", other),
         }
     }
 
@@ -6263,14 +6269,15 @@ mod tests {
             result
         );
         let b = main_body(&m);
-        match &b.stmts[0] {
-            Stmt::ExprStmt { expr: Expr::BuiltinCall { name, args, .. }, .. } => {
+        // Issue #59 — promoted to the module tail `value` (super is an expr).
+        match &b.value {
+            Expr::BuiltinCall { name, args, .. } => {
                 assert_eq!(name, "__super__");
                 assert_eq!(args.len(), 4, "method, class, then the two forwarded args");
                 assert!(matches!(&args[2], Expr::IntLit { value: 1, .. }));
                 assert!(matches!(&args[3], Expr::IntLit { value: 2, .. }));
             }
-            other => panic!("expected ExprStmt(BuiltinCall(__super__, …)), got {:?}", other),
+            other => panic!("expected tail BuiltinCall(__super__, …), got {:?}", other),
         }
     }
 
@@ -8539,6 +8546,171 @@ b = "y"
         );
     }
 
+    /// Issue #59 — find the `__super__` `BuiltinCall` args in a function body,
+    /// searching BOTH the statement list and the tail `value` slot.  `super` is
+    /// now an expression, so a method whose sole/last line is `super` puts the
+    /// `__super__` call in `body.value`, not `body.stmts`.
+    fn find_super_args(f: &semantic_ir::Function) -> Option<&[Expr]> {
+        for s in &f.body.stmts {
+            if let Stmt::ExprStmt { expr: Expr::BuiltinCall { name, args, .. }, .. } = s {
+                if name == "__super__" {
+                    return Some(args);
+                }
+            }
+        }
+        if let Expr::BuiltinCall { name, args, .. } = &f.body.value {
+            if name == "__super__" {
+                return Some(args);
+            }
+        }
+        None
+    }
+
+    // -----------------------------------------------------------------------
+    // Issue #59 — class-method defs (`def self.m`) + class-method calls
+    // (`Foo.bar`), plus `super` in expression position.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn def_self_method_registers_as_class_method() {
+        // `class Counter; def self.zero; 0; end; end` — the receiver-bearing
+        // `def self.zero` must register in the CLASS-method table via
+        // `__def_class_method__("Counter", "zero", MakeClosure(Counter__zero_cm))`
+        // (NOT `__def_method__`), and hoist under a `_cm`-suffixed name.
+        let m = lower("class Counter\n  def self.zero\n    0\n  end\nend\n");
+        // Hoisted under the class-method-qualified name.
+        assert!(
+            m.functions.iter().any(|f| f.name == "Counter__zero_cm"),
+            "expected class-method-qualified `Counter__zero_cm`; got {:?}",
+            m.functions.iter().map(|f| &f.name).collect::<Vec<_>>()
+        );
+        // A `__def_class_method__` registration exists (and NO `__def_method__`
+        // for `zero`).
+        let regs: Vec<(&str, &str)> = main_body(&m)
+            .stmts
+            .iter()
+            .filter_map(|s| match s {
+                Stmt::ExprStmt { expr: Expr::BuiltinCall { name, args, .. }, .. } => {
+                    let meth = match args.get(1) {
+                        Some(Expr::StrLit { value, .. }) => value.as_str(),
+                        _ => "",
+                    };
+                    Some((name.as_str(), meth))
+                }
+                _ => None,
+            })
+            .collect();
+        assert!(
+            regs.contains(&("__def_class_method__", "zero")),
+            "expected __def_class_method__ for `zero`; got {:?}",
+            regs
+        );
+        assert!(
+            !regs.iter().any(|(n, meth)| *n == "__def_method__" && *meth == "zero"),
+            "class method `zero` must NOT register as an instance method"
+        );
+    }
+
+    #[test]
+    fn class_method_call_lowers_to_class_method_dispatch() {
+        // `Counter.zero` — a NON-`new` method call on a CONSTANT receiver is a
+        // class-method dispatch: `__class_method__("Counter", "zero")`.
+        let m = lower("Counter.zero\n");
+        match &main_body(&m).value {
+            Expr::BuiltinCall { name, args, .. } => {
+                assert_eq!(name, "__class_method__");
+                assert!(matches!(&args[0], Expr::StrLit { value, .. } if value == "Counter"));
+                assert!(matches!(&args[1], Expr::StrLit { value, .. } if value == "zero"));
+            }
+            other => panic!("expected __class_method__ dispatch, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn class_method_call_with_args_forwards_them() {
+        // `Foo.bar(x)` → `__class_method__("Foo", "bar", VarRef(x))`.
+        let m = lower("Foo.bar(1)\n");
+        match &main_body(&m).value {
+            Expr::BuiltinCall { name, args, .. } => {
+                assert_eq!(name, "__class_method__");
+                assert_eq!(args.len(), 3, "class, method, then the forwarded arg");
+                assert!(matches!(&args[2], Expr::IntLit { value: 1, .. }));
+            }
+            other => panic!("expected __class_method__ dispatch, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn dot_new_on_const_still_routes_to_new_not_class_method() {
+        // Regression guard — `Foo.new` is the implicit constructor class method
+        // and must still lower to `__new__`, NOT `__class_method__`.
+        let m = lower("Foo.new\n");
+        match &main_body(&m).value {
+            Expr::BuiltinCall { name, .. } => {
+                assert_eq!(name, "__new__", "`.new` must route to __new__");
+            }
+            other => panic!("expected __new__, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn instance_method_call_on_local_still_uses_method_envelope() {
+        // Regression guard — a method call on a NON-constant receiver (`obj.m`)
+        // must still route through `__method__`, not `__class_method__`.
+        let m = lower("obj = 1\nobj.foo\n");
+        match &main_body(&m).value {
+            Expr::BuiltinCall { name, .. } => {
+                assert_eq!(name, "__method__", "instance dispatch stays __method__");
+            }
+            other => panic!("expected __method__, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn super_as_subexpression_lowers_to_super_builtin() {
+        // Issue #59 — `super` used as a SUB-expression (`x = super + 1`) lowers
+        // to `+`( __super__(…), 1 ) — the `__super__` sits in expression
+        // position inside the binary op.
+        let m = lower(
+            "class Cat\n  def describe\n    result = super + 1\n    result\n  end\nend\n",
+        );
+        let f = m
+            .functions
+            .iter()
+            .find(|f| f.name == "Cat__describe")
+            .expect("Cat__describe");
+        // The `result = super + 1` binding: RHS is `+`(super, 1).
+        let has_super_in_binop = f.body.stmts.iter().any(|s| {
+            let rhs = match s {
+                Stmt::LetBinding { value, .. } => Some(value),
+                Stmt::Assign { value, .. } => Some(value),
+                _ => None,
+            };
+            matches!(
+                rhs,
+                Some(Expr::BuiltinCall { name, args, .. })
+                    if name == "+"
+                        && matches!(&args[0], Expr::BuiltinCall { name: n, .. } if n == "__super__")
+            )
+        });
+        assert!(
+            has_super_in_binop,
+            "expected `super + 1` to lower to +(__super__(…), 1); body = {:?}",
+            f.body.stmts
+        );
+    }
+
+    #[test]
+    fn def_self_endless_method_registers_as_class_method() {
+        // Endless form `def self.zero = 0` also registers as a class method.
+        let m = lower("class Counter\n  def self.zero = 0\nend\n");
+        assert!(
+            m.functions.iter().any(|f| f.name == "Counter__zero_cm"),
+            "expected `Counter__zero_cm`; got {:?}",
+            m.functions.iter().map(|f| &f.name).collect::<Vec<_>>()
+        );
+    }
+
     #[test]
     fn class_def_emits_method_registration() {
         // `class Dog; def speak; end; end` produces a `ClassDef` for Dog PLUS a
@@ -8638,20 +8810,10 @@ b = "y"
             .iter()
             .find(|f| f.name == "Cat__describe")
             .expect("Cat__describe");
-        // The super statement is the (only) body statement.
-        let call = f
-            .body
-            .stmts
-            .iter()
-            .find_map(|s| match s {
-                Stmt::ExprStmt { expr: Expr::BuiltinCall { name, args, .. }, .. }
-                    if name == "__super__" =>
-                {
-                    Some(args)
-                }
-                _ => None,
-            })
-            .expect("__super__ call in body");
+        // Issue #59 — `super(a)` is the method's tail expression, so it lands in
+        // `body.value` (super is now an expression, not a statement); helper
+        // scans both slots.
+        let call = find_super_args(f).expect("__super__ call in body");
         assert_eq!(call.len(), 3, "__super__(method, class, arg)");
         assert!(matches!(&call[0], Expr::StrLit { value, .. } if value == "describe"));
         assert!(matches!(&call[1], Expr::StrLit { value, .. } if value == "Cat"));
@@ -8670,19 +8832,8 @@ b = "y"
             "class C\n  def m(a, b)\n    super\n  end\nend\n",
         );
         let f = m.functions.iter().find(|f| f.name == "C__m").expect("C__m");
-        let call = f
-            .body
-            .stmts
-            .iter()
-            .find_map(|s| match s {
-                Stmt::ExprStmt { expr: Expr::BuiltinCall { name, args, .. }, .. }
-                    if name == "__super__" =>
-                {
-                    Some(args)
-                }
-                _ => None,
-            })
-            .expect("__super__ call");
+        // Issue #59 — bare `super` is the tail expression → `body.value`.
+        let call = find_super_args(f).expect("__super__ call");
         assert!(matches!(&call[0], Expr::StrLit { value, .. } if value == "m"));
         assert!(matches!(&call[1], Expr::StrLit { value, .. } if value == "C"));
         // Remaining args are the two params (sorted for determinism: a, b).

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -1063,96 +1063,20 @@ impl Lowerer {
                     span: self.span_of(node),
                 })
             }
-            "super_statement" => {
-                // Phase 22d — `super` keyword.
-                //
-                // Grammar shape:
-                //   super_statement = "super" [ super_args ] ;
-                //   super_args      = LPAREN [ call_arg { COMMA call_arg } ] RPAREN
-                //                   | call_arg { COMMA call_arg } ;
-                //
-                // Two distinct lowerings keyed on whether a `super_args`
-                // node is PRESENT:
-                //   - present → explicit arg list (`super()`, `super(x)`,
-                //     `super x`): the lowered args are forwarded.
-                //   - absent  → bare `super` ("zsuper") forwards ALL of the
-                //     enclosing method's arguments implicitly.  Real Ruby
-                //     re-passes the *current* method's parameters; O2 makes
-                //     that concrete by forwarding a `VarRef` to each of the
-                //     enclosing method's params (in declaration order) —
-                //     captured in `current_params` — so `def describe;
-                //     super; end` inside a param-taking method forwards
-                //     them.  (A method that takes no params forwards
-                //     nothing, which is also correct.)
-                //
-                // O2 (OOP production) — `super` is emitted as the OOP-runtime
-                // builtin `__super__(method_name, class_name, …args)`.  The
-                // runtime walks from `class_name`'s *parent* to find the first
-                // ancestor implementation of `method_name` and runs it with the
-                // *current* self still bound.  We thread the enclosing method +
-                // class names from the lowerer context (`current_method` /
-                // `current_class`).  Outside a class method (`super` at top
-                // level — not legal Ruby, but the parser admits it) both are
-                // empty strings; the runtime then finds no parent and returns
-                // nil, which is the honest floor.
-                //
-                // Effects: PURE, matching `yield` — `super` dispatches to
-                // a parent method whose own effects are accounted for at
-                // its definition/call site; modelling the marker as PURE
-                // keeps the effect lattice from double-counting.
-                let super_args_node = self.find_node_child(node, "super_args");
-                let forwarded: Vec<Expr> = if let Some(sa) = super_args_node {
-                    let call_arg_nodes: Vec<&GrammarASTNode> = sa
-                        .children
-                        .iter()
-                        .filter_map(|c| match c {
-                            ASTNodeOrToken::Node(n) if n.rule_name == "call_arg" => Some(n),
-                            _ => None,
-                        })
-                        .collect();
-                    call_arg_nodes
-                        .into_iter()
-                        .map(|n| self.lower_call_arg(n))
-                        .collect::<Result<Vec<_>, _>>()?
-                } else {
-                    // Bare `super` (zsuper): forward the enclosing method's
-                    // params by reference, in a stable order.  `current_params`
-                    // is a `HashSet`, so sort for determinism (the emitted
-                    // program is otherwise non-reproducible run to run).
-                    let mut params: Vec<String> =
-                        self.current_params.iter().cloned().collect();
-                    params.sort();
-                    params
-                        .into_iter()
-                        .map(|p| Expr::VarRef {
-                            name: p,
-                            scope: Scope::Param,
-                            span: self.span_of(node),
-                        })
-                        .collect()
-                };
-                let method_name = self.current_method.clone().unwrap_or_default();
-                let class_name = self.current_class.clone().unwrap_or_default();
-                self.features_used.insert(Feature::Classes);
-                self.features_used.insert(Feature::Strings);
-                let mut full_args: Vec<Expr> = Vec::with_capacity(forwarded.len() + 2);
-                full_args.push(Expr::StrLit {
-                    value: method_name,
-                    span: self.span_of(node),
-                });
-                full_args.push(Expr::StrLit {
-                    value: class_name,
-                    span: self.span_of(node),
-                });
-                full_args.extend(forwarded);
+            "super_expr" => {
+                // Issue #59 — `super` used in EXPRESSION position but reached
+                // here as a bare statement (`super`, `super()`, `super(x)`,
+                // `super x` written on their own line).  The grammar routes
+                // ALL `super` forms through `factor`'s `super_expr` production
+                // now (the old statement-only `super_statement` is gone), so a
+                // stand-alone `super` line arrives as an `expression_stmt`
+                // wrapping a `super_expr`.  The value-producing lowering lives
+                // in `lower_super_expr`; wrap its result in an `ExprStmt` for
+                // the statement context.
+                let expr = self.lower_super_expr(node)?;
                 Ok(Stmt::ExprStmt {
-                    expr: Expr::BuiltinCall {
-                        name: "__super__".to_string(),
-                        args: full_args,
-                        effects: EffectSet::PURE,
-                        span: self.span_of(node),
-                    },
                     span: self.span_of(node),
+                    expr,
                 })
             }
             "return_statement" | "break_statement" | "next_statement" => {
@@ -3067,36 +2991,46 @@ impl Lowerer {
             };
             match inner.rule_name.as_str() {
                 "def_statement" => {
+                    // Issue #59 — a `def_receiver` child (`def self.m` /
+                    // `def Recv.m`) marks this as a CLASS method: it registers
+                    // in the class-method table (`__def_class_method__`) rather
+                    // than the instance-method table.  The hoisted top-level
+                    // function name is qualified so it never collides with a
+                    // same-named instance method or a class method of another
+                    // class (the `_cm` suffix keeps class methods distinct from
+                    // the instance method `C__m`).
+                    let is_class_method = self.def_has_receiver(inner);
                     let mut func = self.lower_def_statement(inner)?;
                     let method_name = func.name.clone();
-                    // Qualify the hoisted top-level name so same-named methods in
-                    // different classes (and a parent/child `super` target) do not
-                    // collide.  The runtime table key stays the bare method name.
-                    let fn_name = self.qualified_method_fn_name(class_name, &method_name);
+                    let fn_name = if is_class_method {
+                        self.qualified_class_method_fn_name(class_name, &method_name)
+                    } else {
+                        self.qualified_method_fn_name(class_name, &method_name)
+                    };
                     func.name = fn_name.clone();
                     self.user_functions.push(func);
-                    // Instance-method registration.  (`def self.m` class methods
-                    // do not currently parse — the grammar's `def` rule has no
-                    // receiver production — so every hoisted `def` here is an
-                    // instance method.  When the grammar gains `def self.m`,
-                    // route those to `register_class_method`.)
-                    registrations.push(self.register_instance_method(
-                        class_name,
-                        &method_name,
-                        &fn_name,
-                    ));
+                    registrations.push(if is_class_method {
+                        self.register_class_method(class_name, &method_name, &fn_name)
+                    } else {
+                        self.register_instance_method(class_name, &method_name, &fn_name)
+                    });
                 }
                 "endless_def_statement" => {
+                    let is_class_method = self.def_has_receiver(inner);
                     let mut func = self.lower_endless_def_statement(inner)?;
                     let method_name = func.name.clone();
-                    let fn_name = self.qualified_method_fn_name(class_name, &method_name);
+                    let fn_name = if is_class_method {
+                        self.qualified_class_method_fn_name(class_name, &method_name)
+                    } else {
+                        self.qualified_method_fn_name(class_name, &method_name)
+                    };
                     func.name = fn_name.clone();
                     self.user_functions.push(func);
-                    registrations.push(self.register_instance_method(
-                        class_name,
-                        &method_name,
-                        &fn_name,
-                    ));
+                    registrations.push(if is_class_method {
+                        self.register_class_method(class_name, &method_name, &fn_name)
+                    } else {
+                        self.register_instance_method(class_name, &method_name, &fn_name)
+                    });
                 }
                 "method_call_no_paren" | "method_call" => {
                     // `attr_accessor :x, :y` / `attr_reader` / `attr_writer`
@@ -3135,6 +3069,24 @@ impl Lowerer {
         format!("{}__{}", sanitize(class_name), sanitize(method_name))
     }
 
+    /// Issue #59 — the collision-safe top-level function name a CLASS method
+    /// (`def self.m`) hoists to: `Counter#self.zero` → `"Counter__zero_cm"`.
+    /// Uses the same sanitisation as [`Self::qualified_method_fn_name`] plus a
+    /// `_cm` suffix so a class method and an instance method of the *same* name
+    /// on the *same* class hoist to DISTINCT top-level functions (Ruby allows
+    /// `def m` and `def self.m` to coexist).  The runtime class-method table is
+    /// keyed on the bare method name, so dispatch is unaffected by the suffix.
+    fn qualified_class_method_fn_name(&self, class_name: &str, method_name: &str) -> String {
+        format!("{}_cm", self.qualified_method_fn_name(class_name, method_name))
+    }
+
+    /// Issue #59 — does this `def_statement` / `endless_def_statement` carry a
+    /// `def_receiver` (`def self.m` / `def Recv.m`)?  Presence marks it as a
+    /// class/singleton method; absence is an ordinary instance method.
+    fn def_has_receiver(&self, node: &GrammarASTNode) -> bool {
+        self.find_node_child(node, "def_receiver").is_some()
+    }
+
     /// O2 — build the registration statement for an instance method:
     /// `__def_method__("C", "m", MakeClosure { fn_name, captures: [] })`.  The
     /// table is keyed on the *bare* method name `m` (so dispatch by name works),
@@ -3152,11 +3104,11 @@ impl Lowerer {
         self.register_method_call("__def_method__", class_name, method_name, fn_name)
     }
 
-    /// O2 — build the registration statement for a class method (`def self.m`):
-    /// `__def_class_method__("C", "m", MakeClosure { fn_name, captures: [] })`.
-    /// Currently unreachable (the grammar has no `def self.m` receiver form), but
-    /// kept so the class-method path is ready the moment the grammar admits it.
-    #[allow(dead_code)]
+    /// O2 / Issue #59 — build the registration statement for a class method
+    /// (`def self.m`): `__def_class_method__("C", "m", MakeClosure { fn_name,
+    /// captures: [] })`.  Now reachable: the grammar's `def_receiver` production
+    /// (#59) lets `def self.m` parse, and `lower_class_body` routes any
+    /// receiver-bearing `def` here.
     fn register_class_method(
         &mut self,
         class_name: &str,
@@ -6891,6 +6843,89 @@ impl Lowerer {
     // expression / term / factor
     // -------------------------------------------------------------------
 
+    /// Issue #59 — lower a `super_expr` (or, historically, `super_statement`)
+    /// node to the value-producing `__super__(method, class, …args)` builtin.
+    ///
+    /// Grammar shape (Phase 22d, now hosted in `factor` per #59):
+    ///   super_expr = "super" [ super_args ] ;
+    ///   super_args = LPAREN [ call_arg { COMMA call_arg } ] RPAREN
+    ///              | call_arg { COMMA call_arg } ;
+    ///
+    /// Two distinct lowerings keyed on whether a `super_args` node is PRESENT:
+    ///   - present → explicit arg list (`super()`, `super(x)`, `super x`): the
+    ///     lowered args are forwarded verbatim.
+    ///   - absent  → bare `super` ("zsuper") forwards ALL of the enclosing
+    ///     method's arguments implicitly.  Real Ruby re-passes the *current*
+    ///     method's parameters; O2 makes that concrete by forwarding a `VarRef`
+    ///     to each of the enclosing method's params (declaration order — well,
+    ///     sorted for determinism, since `current_params` is a set), so
+    ///     `def describe; super; end` inside a param-taking method forwards
+    ///     them.  A method that takes no params forwards nothing.
+    ///
+    /// O2 (OOP production) — `super` is emitted as the OOP-runtime builtin
+    /// `__super__(method_name, class_name, …args)`.  The runtime walks from
+    /// `class_name`'s *parent* to find the first ancestor implementation of
+    /// `method_name` and runs it with the *current* self still bound.  We
+    /// thread the enclosing method + class names from the lowerer context
+    /// (`current_method` / `current_class`).  Outside a class method (`super`
+    /// at top level — not legal Ruby, but the parser admits it) both are empty
+    /// strings; the runtime then finds no parent and returns nil (the honest
+    /// floor).
+    ///
+    /// Effects: PURE, matching `yield` — `super` dispatches to a parent method
+    /// whose own effects are accounted for at its definition/call site;
+    /// modelling the marker as PURE keeps the effect lattice from
+    /// double-counting.  Returning an `Expr` (not a `Stmt`) is what lets #59's
+    /// `super + " tail"` / `x = super` slot `super` anywhere an expression goes.
+    fn lower_super_expr(&mut self, node: &GrammarASTNode) -> Result<Expr, RubyLowerError> {
+        let super_args_node = self.find_node_child(node, "super_args");
+        let forwarded: Vec<Expr> = if let Some(sa) = super_args_node {
+            let call_arg_nodes: Vec<&GrammarASTNode> = sa
+                .children
+                .iter()
+                .filter_map(|c| match c {
+                    ASTNodeOrToken::Node(n) if n.rule_name == "call_arg" => Some(n),
+                    _ => None,
+                })
+                .collect();
+            call_arg_nodes
+                .into_iter()
+                .map(|n| self.lower_call_arg(n))
+                .collect::<Result<Vec<_>, _>>()?
+        } else {
+            let mut params: Vec<String> = self.current_params.iter().cloned().collect();
+            params.sort();
+            params
+                .into_iter()
+                .map(|p| Expr::VarRef {
+                    name: p,
+                    scope: Scope::Param,
+                    span: self.span_of(node),
+                })
+                .collect()
+        };
+        let method_name = self.current_method.clone().unwrap_or_default();
+        let class_name = self.current_class.clone().unwrap_or_default();
+        self.features_used.insert(Feature::Classes);
+        self.features_used.insert(Feature::Strings);
+        let mut full_args: Vec<Expr> = Vec::with_capacity(forwarded.len() + 2);
+        full_args.push(Expr::StrLit {
+            value: method_name,
+            span: self.span_of(node),
+        });
+        full_args.push(Expr::StrLit {
+            value: class_name,
+            span: self.span_of(node),
+        });
+        full_args.extend(forwarded);
+        Ok(Expr::BuiltinCall {
+            name: "__super__".to_string(),
+            args: full_args,
+            effects: EffectSet::PURE,
+            span: self.span_of(node),
+        })
+    }
+
     fn lower_expression(&mut self, node: &GrammarASTNode) -> Result<Expr, RubyLowerError> {
         // Pass through wrapper rules transparently — the parser
         // sometimes nests `expression → sum → term → factor → expression`.
@@ -6966,6 +7001,11 @@ impl Lowerer {
             "method_call" => self.lower_method_call(node),
             // Phase 6w — arrow-lambda literal `->(params){body}`.
             "lambda_literal" => self.lower_lambda_literal(node),
+            // Issue #59 — `super` as an expression (`x = super`,
+            // `super + " tail"`, `puts(super)`).  Lowers to the same
+            // value-producing `__super__(method, class, …args)` builtin the
+            // statement form uses.
+            "super_expr" => self.lower_super_expr(node),
             // The parser sometimes wraps a bare token into an "expression_stmt"
             // when reached as the RHS of an assignment.  Recurse into it.
             "expression_stmt" => {
@@ -8712,6 +8752,41 @@ impl Lowerer {
                     span,
                 });
             }
+        }
+
+        // Issue #59 — a NON-`new` method call on a *constant* receiver
+        // (`Counter.zero`, `Foo.bar(x)`) is a CLASS-METHOD dispatch.  It lowers
+        // to `__class_method__(StrLit("Counter"), StrLit("zero"), …args)`,
+        // which the backend routes to the OOP runtime's `call_class_method`
+        // (ancestry-walking lookup in the `def self.m` table registered by
+        // `__def_class_method__`).  We special-case it here, before the generic
+        // `__method__` envelope, and ONLY when the receiver is a bare constant
+        // ref — so an instance method call on a non-constant (`obj.meth`,
+        // `arr.zero`) still routes through `__method__` unchanged.  `.new` was
+        // handled just above (it routes to `__new__`, the implicit constructor
+        // class method), so it never reaches here.  Chaining is preserved: in
+        // `Foo.bar.baz`, this folds `.bar` into a `__class_method__` call and
+        // `apply_dot_chain` then folds `.baz` with that call as the receiver of
+        // an outer `__method__` — exactly the nesting `.new(...).meth` uses.
+        if let Expr::VarRef { name: class_name, scope: Scope::Const, .. } = &receiver {
+            self.features_used.insert(Feature::Classes);
+            self.features_used.insert(Feature::Strings);
+            let mut cm_args: Vec<Expr> = Vec::with_capacity(args.len() + 2);
+            cm_args.push(Expr::StrLit {
+                value: class_name.clone(),
+                span: name_span.clone(),
+            });
+            cm_args.push(Expr::StrLit {
+                value: method_name.clone(),
+                span: name_span,
+            });
+            cm_args.extend(args);
+            return Ok(Expr::BuiltinCall {
+                name: "__class_method__".to_string(),
+                args: cm_args,
+                effects: EffectSet::PURE,
+                span,
+            });
         }
 
         // Pack as BuiltinCall("__method__", [receiver, StrLit(method),

--- a/code/packages/rust/semantic-ir-to-python/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-python/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [0.6.0] - 2026-07-01
+
+### Added (Issue #59 — class-method CALL dispatch)
+
+- **`__class_method__("Class", "method", …args)` → `_sir_oop_call_class_method`.**
+  The Ruby frontend (ruby-to-semantic-ir 0.5.0) now emits `__class_method__`
+  for a class-method call on a constant receiver (`Counter.zero`); the emitter
+  routes it to the OOP runtime's ancestry-walking `call_class_method`. The
+  helper is added to the `RUNTIME_OOP` import header and to the OOP-import
+  gating list (`is_oop`), so a module using class-method calls pulls in the
+  runtime dependency.
+
+### Tests (Issue #59 — class-method + super-as-expression execution proofs)
+
+- `end_to_end_ruby_class_method_def_and_call_executes_py` — real
+  `def self.zero; Counter.new; end` factory; `Counter.zero.val` runs and prints
+  `42` under a live interpreter.
+- `end_to_end_ruby_super_as_expression_executes_py` — `def describe; super + 1; end`
+  with inheritance; the parent's `describe` (40) flows into the enclosing `+`,
+  printing `41`. (Uses numeric `+`; string `super + "…"` is a pre-existing
+  `_sir_plus` gap — see ruby-to-semantic-ir CHANGELOG.)
+- Both use `print` rather than `puts`, since `puts` has no runtime dispatch
+  entry on this branch (a parallel PR adds it).
+
 ## Unreleased
 
 ### Tests (O2 — Ruby OOP end-to-end execution proofs)

--- a/code/packages/rust/semantic-ir-to-python/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-python"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "Semantic IR → self-contained Python 3 source code (SIR14). Third backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-python/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-python/src/emit.rs
@@ -48,6 +48,9 @@ fn uses_oop(m: &Module) -> bool {
         || module_uses_builtin(m, "__super__")
         || module_uses_builtin(m, "__def_method__")
         || module_uses_builtin(m, "__def_class_method__")
+        // Issue #59 — a class-method CALL (`Foo.bar` on a const receiver)
+        // routes to `_sir_oop_call_class_method`, so it needs the OOP import.
+        || module_uses_builtin(m, "__class_method__")
         || module_uses_builtin(m, "__self__")
 }
 
@@ -1166,6 +1169,16 @@ fn emit_builtin_call(out: &mut String, name: &str, args: &[Expr], indent: usize)
     }
     if name == "__super__" && args.len() >= 2 {
         out.push_str("_sir_oop_call_super(");
+        emit_args(out, args, indent);
+        out.push(')');
+        return;
+    }
+    // Issue #59 — class-method call `Foo.bar(args)` (const receiver) →
+    // `_sir_oop_call_class_method("Foo", "bar", args…)`.  The class + method
+    // names arrive as `StrLit`s and are emitted via the normal expression path
+    // (`quote_py_string`), so no source-derived name is interpolated raw.
+    if name == "__class_method__" && args.len() >= 2 {
+        out.push_str("_sir_oop_call_class_method(");
         emit_args(out, args, indent);
         out.push(')');
         return;

--- a/code/packages/rust/semantic-ir-to-python/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-python/src/lib.rs
@@ -1293,6 +1293,100 @@ mod tests {
         assert!(a.source.contains("    LEGS = 4"), "got:\n{}", a.source);
     }
 
+    // -----------------------------------------------------------------------
+    // Issue #59 — class-method defs (`def self.m`) + `super` as an expression.
+    // Full Ruby SOURCE → SIR → Python, run through a real interpreter.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn end_to_end_ruby_class_method_def_and_call_executes_py() {
+        // A REAL class method: `def self.zero` allocates and returns a
+        // `Counter` (the classic factory idiom).  `Counter.zero` dispatches to
+        // it via `__class_method__` → `_sir_oop_call_class_method`, and the
+        // returned object answers an instance method.
+        //
+        // NOTE: `print` (not `puts`) — the `puts` builtin has no runtime
+        // dispatch entry on this branch (a parallel PR adds it), so `puts` in a
+        // *run* execution-proof raises `NameError`.  `print` maps to
+        // `_sir_print`, which is in the core dispatch table and appends a
+        // newline, so `print(c.val)` emits "42\n".
+        let module = ruby_to_semantic_ir::compile_source(
+            "class Counter\n\
+            \x20 def self.zero\n\
+            \x20   Counter.new\n\
+            \x20 end\n\
+            \x20 def val\n\
+            \x20   42\n\
+            \x20 end\n\
+            end\n\
+            c = Counter.zero\n\
+            print(c.val)\n",
+            "demo",
+        )
+        .expect("lower ruby");
+        let a = compile(&module).expect("compile to python");
+        // The class-method registration + dispatch wiring is present.
+        assert!(
+            a.source.contains("_sir_oop_def_class_method(\"Counter\", \"zero\""),
+            "expected class-method registration; got:\n{}",
+            a.source
+        );
+        assert!(
+            a.source.contains("_sir_oop_call_class_method(\"Counter\", \"zero\")"),
+            "expected class-method dispatch; got:\n{}",
+            a.source
+        );
+        if let Some(out) = run_emitted_python(&a.source) {
+            assert_eq!(out, "42\n", "Counter.zero.val must print 42");
+        }
+    }
+
+    #[test]
+    fn end_to_end_ruby_super_as_expression_executes_py() {
+        // `super` used as an EXPRESSION: `def describe; super + 1; end` takes
+        // the PARENT's `describe` result and adds 1.  Exercises both
+        // super-as-subexpression lowering and the `__super__` runtime dispatch,
+        // run end to end — the produced value flows into the enclosing `+`.
+        //
+        // The value is numeric (not `super + " tail"` string-concat) on
+        // purpose: Ruby's `str + str` lowers to the numeric-init `_sir_plus`
+        // (`add` seeds `total = 0`), so string `+` concatenation is a
+        // PRE-EXISTING pipeline gap unrelated to #59 — see the CHANGELOG's
+        // "deferred" note.  `super + 1` proves the #59 feature (super in
+        // expression position) without depending on that separate gap.
+        let module = ruby_to_semantic_ir::compile_source(
+            "class Animal\n\
+            \x20 def describe\n\
+            \x20   40\n\
+            \x20 end\n\
+            end\n\
+            class Cat < Animal\n\
+            \x20 def describe\n\
+            \x20   super + 1\n\
+            \x20 end\n\
+            end\n\
+            c = Cat.new\n\
+            print(c.describe)\n",
+            "demo",
+        )
+        .expect("lower ruby");
+        let a = compile(&module).expect("compile to python");
+        assert!(
+            a.source.contains("_sir_oop_call_super(\"describe\", \"Cat\")"),
+            "expected super dispatch from Cat; got:\n{}",
+            a.source
+        );
+        // The super call sits INSIDE the `+` — proving expression position.
+        assert!(
+            a.source.contains("_sir_plus(_sir_oop_call_super(\"describe\", \"Cat\"), 1)"),
+            "expected super to sit inside `+`; got:\n{}",
+            a.source
+        );
+        if let Some(out) = run_emitted_python(&a.source) {
+            assert_eq!(out, "41\n", "super (40) + 1 must be 41");
+        }
+    }
+
     #[test]
     fn end_to_end_ruby_class_var_py() {
         let module = ruby_to_semantic_ir::compile_source(

--- a/code/packages/rust/semantic-ir-to-python/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-python/src/runtime.rs
@@ -25,6 +25,7 @@ from coding_adventures_sir_runtime_oop import (
     call_method as _sir_oop_call_method,
     call_new as _sir_oop_call_new,
     call_super as _sir_oop_call_super,
+    call_class_method as _sir_oop_call_class_method,
     def_method as _sir_oop_def_method,
     def_class_method as _sir_oop_def_class_method,
     current_self as _sir_oop_current_self,


### PR DESCRIPTION
## What

Closes two Ruby grammar gaps surfaced by the OOP cascade (O2), unblocking more real object-oriented Ruby toward the north star.

- **`def self.m` / `def Foo.m` class methods** — the `def` rule gained an optional `def_receiver = singleton_receiver "."` prefix (reusing Phase-14e `singleton_receiver = self | NAME`). Plain `def m` is byte-for-byte unchanged. Lowers to the (previously unreachable) `__def_class_method__` registration; class-method **calls** `Counter.zero` / `Foo.bar(x)` (non-`new` calls on a const receiver) now lower to a new `__class_method__("Class","method",args)` builtin.
- **`super` as an expression** — added `super_expr` into `factor` (removed the statement-only `super_statement` that shadowed it; guarded `method_call`/`method_call_no_paren` KEYWORD heads with `!"super"`), so `x = super`, `super + 1`, `puts(super)` parse. Lowers to `__super__` in expression position.
- Regenerated `_grammar.rs` via `grammar-tools generate-rust-compiled-grammars ruby-parser`. Python backend emits `__class_method__`→`_sir_oop_call_class_method` (runtime fn already existed).

## Verification

- `coding-adventures-ruby-parser` **287** (+9); `ruby-to-semantic-ir` **412** (+7); `semantic-ir-to-python` **94** (+2). Updated the 5 O2 super tests for the value-slot shift (super is now an expression).
- **Execution-proof (python):** `def self.zero; Counter.new; end` → `Counter.zero.val` → `42`; `def describe; super + 1; end` (inheritance) → `41`.
- Clippy clean; `cargo build --workspace` clean (bar pre-existing Unix-only crate).
- **Security review passed** (packrat memoization bounds backtracking; `super_expr` no left-recursion; no panics on malformed input; class/method names carried as opaque `StrLit` data, quoted on emit; feature-gated; no `unsafe`).

## Deferred (tracked)

Class-method **call** dispatch is wired for the **Python backend only** — JS/TS/Go/Rust need a `call_class_method` runtime + emit arm (follow-up task #61; additive/non-breaking — no cross-backend class-method tests today). String `super + "…"` awaits the pre-existing string-`+` operator gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)