### PR TITLE
[codex] test(html-parser): require parser audit evidence guards

### DIFF
--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -170,7 +170,8 @@ python3 code/packages/rust/html-parser/tests/fixtures/check_html5lib_tree_constr
 ```
 
 Validate that every focused WHATWG parser audit fixture has a matching Rust
-test that parses the fixture and replays the cases through the DOM-dump harness:
+test that parses the fixture, replays the cases through the DOM-dump harness,
+and pins representative executable evidence cases:
 
 ```bash
 python3 code/packages/rust/html-parser/tests/fixtures/check_whatwg_audit_rust_tests.py \

--- a/code/packages/rust/html-parser/tests/fixtures/check_whatwg_audit_rust_tests.py
+++ b/code/packages/rust/html-parser/tests/fixtures/check_whatwg_audit_rust_tests.py
@@ -37,7 +37,8 @@ def parse_args() -> argparse.Namespace:
         description=(
             "Check that every focused WHATWG parser audit fixture has a "
             "matching Rust test that parses the fixture and replays its cases "
-            "through the parser DOM-dump harness."
+            "through the parser DOM-dump harness, with a focused executable "
+            "evidence guard for representative cases."
         )
     )
     parser.add_argument(
@@ -108,6 +109,16 @@ def check_test_file(audit_path: Path) -> list[str]:
     for label, snippet in required_snippets.items():
         if snippet not in text:
             errors.append(f"{test_path.name} is missing {label}: {snippet}")
+
+    evidence_guards = [
+        f"fn whatwg_{rust_name}_audit_tracks_post_parse_repair_evidence()",
+        f"fn whatwg_{rust_name}_audit_tracks_executable_evidence()",
+    ]
+    if not any(snippet in text for snippet in evidence_guards):
+        errors.append(
+            f"{test_path.name} is missing executable evidence guard: "
+            + " or ".join(evidence_guards)
+        )
 
     return errors
 


### PR DESCRIPTION
## Summary
- require each focused WHATWG parser audit Rust test to include an executable evidence guard
- accept both the post-parse-repair evidence guard naming used by repair-focused suites and the executable evidence guard used by character-reference coverage
- update the parser fixture README so the audit-test checker documents evidence guards as part of the contract

## Validation
- `python3 code/packages/rust/html-parser/tests/fixtures/check_whatwg_audit_rust_tests.py --check`
- focused parser audit matrix including post-parse-repair evidence guards, character-reference evidence, audit DOM-dump checks, and html5lib smoke DOM dump
- `cargo test -p coding-adventures-html-parser`
- `CARGO_BUILD_JOBS=2 cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser`
- `python3 -m json.tool code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json >/dev/null`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py`
- `git diff --check`