### PR TITLE
feat(sir): puts builtin with Ruby semantics across all backends (#60)

### DIFF
--- a/code/packages/python/sir-runtime-core/CHANGELOG.md
+++ b/code/packages/python/sir-runtime-core/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to `coding-adventures-sir-runtime-core` are documented here.
 
+## [0.1.5] - 2026-07-01
+
+### Added (`puts` — Ruby's most common output method)
+
+- New `sir_puts(*args)` implementing Ruby `puts` semantics, and a `"puts"`
+  entry in the builtin dispatch table (so backends that route builtins by name
+  reach it). Exposed from the package root and re-exported in `__all__`.
+- Semantics, matching Ruby exactly:
+  - `puts` (no args) → a single newline.
+  - `puts x` → `x.to_s` + newline, **unless** the rendered text already ends in
+    `"\n"` (then no second newline: `puts "x\n"` prints `x\n`, not `x\n\n`).
+  - `puts a, b` → each argument on its own line, in order.
+  - `puts []` → a single newline (an argument that flattens to nothing still
+    prints a blank line).
+  - `puts [1, [2, 3]]` → each **element** on its own line, arrays flattened
+    recursively (`1\n2\n3\n`).
+  - `puts nil` → a blank line (not the display form `"nil"`).
+- Also bumps `pyproject.toml` to `0.1.5` (it had lagged the changelog at
+  `0.1.2`).
+
 ## [0.1.4] - 2026-06-21
 
 ### Added (Q10g — proc-vs-lambda arity)

--- a/code/packages/python/sir-runtime-core/CHANGELOG.md
+++ b/code/packages/python/sir-runtime-core/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to `coding-adventures-sir-runtime-core` are documented here.
 
+## [0.1.6] - 2026-07-01
+
+### Security — cycle-guard the `puts` array flatten (CWE-674)
+
+- `_puts_one` flattened arrays by recursing per element with **no bound**. A
+  list is a shared, mutable reference, so a translated program can build a
+  self-referential array (`a = []; a << a; puts a`) or a pathologically deep
+  one; the unguarded recursion raised `RecursionError` — a denial of service
+  (uncontrolled recursion). `_puts_one` / `sir_puts` now thread a `seen` set of
+  `id(list)` on the active flatten path: a list re-encountered within its own
+  subtree is a cycle and is printed as Ruby's `[...]` placeholder + newline
+  instead of recursing, so `puts a` on a self-referential array now
+  **terminates** exactly as real Ruby does. Non-cyclic output is unchanged
+  (`puts [1, [2, 3]]` → `1\n2\n3\n`); new regression tests
+  (`test_puts_self_referential_array_terminates`,
+  `test_puts_mutually_recursive_arrays_terminate`) cover the cyclic cases.
+- Bumps `pyproject.toml` to `0.1.6`.
+
 ## [0.1.5] - 2026-07-01
 
 ### Added (`puts` — Ruby's most common output method)

--- a/code/packages/python/sir-runtime-core/README.md
+++ b/code/packages/python/sir-runtime-core/README.md
@@ -16,6 +16,7 @@ prelude into every file:
 | `Symbol` / `intern` | Interned identity objects; Python has no symbol type. |
 | `Pair` / `cons` / `car` / `cdr` | Lisp cons cells; no native type. |
 | `eq`, `to_display`, `print` | Symbol-aware equality and Lisp/Ruby display (`nil`, `#t`/`#f`). |
+| `sir_puts` (`puts`) | Ruby `puts`: per-arg line, arrays flattened element-per-line, no double trailing newline, no-arg → one newline. |
 | `add`/`sub`/`mul`/`div`, `lt`/`gt` | Variadic folds + truncating-integer `/`. |
 | `Closure`/`apply`/`make_closure`, global store, builtin dispatch | Uniform closure handles + SIR `Globals`. |
 

--- a/code/packages/python/sir-runtime-core/pyproject.toml
+++ b/code/packages/python/sir-runtime-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sir-runtime-core"
-version = "0.1.5"
+version = "0.1.6"
 description = "Core runtime for Semantic-IR-emitted Python — SIR truthiness, symbols, equality, display, arithmetic, closures, globals"
 requires-python = ">=3.12"
 dependencies = ["coding-adventures-sir-runtime-pairs"]

--- a/code/packages/python/sir-runtime-core/pyproject.toml
+++ b/code/packages/python/sir-runtime-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sir-runtime-core"
-version = "0.1.2"
+version = "0.1.5"
 description = "Core runtime for Semantic-IR-emitted Python — SIR truthiness, symbols, equality, display, arithmetic, closures, globals"
 requires-python = ">=3.12"
 dependencies = ["coding-adventures-sir-runtime-pairs"]

--- a/code/packages/python/sir-runtime-core/src/coding_adventures_sir_runtime_core/__init__.py
+++ b/code/packages/python/sir-runtime-core/src/coding_adventures_sir_runtime_core/__init__.py
@@ -32,6 +32,7 @@ from .runtime import (
     global_set,
     make_closure,
     sir_print,
+    sir_puts,
 )
 from .symbols import Symbol, intern
 from .values import eq, is_null, is_number, is_symbol, to_display, truthy
@@ -80,6 +81,7 @@ __all__ = [
     "global_get",
     "global_get_static",
     "sir_print",
+    "sir_puts",
     "print",
     "call_builtin",
     "builtin_closure",

--- a/code/packages/python/sir-runtime-core/src/coding_adventures_sir_runtime_core/runtime.py
+++ b/code/packages/python/sir-runtime-core/src/coding_adventures_sir_runtime_core/runtime.py
@@ -195,7 +195,7 @@ def sir_print(v: Any) -> None:
     return None
 
 
-def _puts_one(v: Any) -> None:
+def _puts_one(v: Any, seen: set[int]) -> None:
     """Emit a single ``puts`` argument, honouring Ruby's per-value rules.
 
     Ruby ``puts`` is deceptively subtle.  For one argument it behaves as:
@@ -222,11 +222,33 @@ def _puts_one(v: Any) -> None:
     ``[1, 2]``    ``1\\n2\\n``
     ``[1, [2]]``  ``1\\n2\\n``
     ============  ================
+
+    **Cycle safety.**  A list is a shared, mutable reference, so a program can
+    build a *cyclic* array (``a = []; a << a``).  The element-per-line flatten
+    recurses through nested arrays, so it MUST be cycle-guarded or a self-
+    referential array raises ``RecursionError`` (a DoS: CWE-674, uncontrolled
+    recursion).  ``seen`` holds the ``id()`` of the lists currently on the
+    active flatten path.  A list ALREADY on the path is a cycle: rather than
+    recurse forever we write the ``[...]`` placeholder then a newline, matching
+    real Ruby (``puts a`` on a self-referential array prints ``[...]`` and
+    terminates).  (We emit the literal placeholder rather than ``str(v)``:
+    Python's cycle-safe ``repr`` would render the *containing* level too, e.g.
+    ``[[...]]`` for ``a = [a]``, whereas Ruby prints a bare ``[...]``.)  A list
+    removed from ``seen`` on exit still flattens in full via a sibling path —
+    only a true self-cycle is short-circuited, so non-cyclic output is
+    unchanged (``puts [1, [2, 3]]`` still prints ``1\\n2\\n3\\n``).
     """
     # A sequence is a Python ``list`` in the runtime-core value model.
     if isinstance(v, list):
+        vid = id(v)
+        if vid in seen:
+            # Cycle: emit Ruby's `[...]` placeholder and stop recursing.
+            print("[...]")
+            return None
+        seen.add(vid)
         for item in v:
-            _puts_one(item)
+            _puts_one(item, seen)
+        seen.discard(vid)
         return None
     text = values.to_display(v)
     # Ruby suppresses the added newline only when the rendered text already
@@ -265,6 +287,10 @@ def sir_puts(*args: Any) -> None:
         # `puts` with no arguments writes exactly one newline.
         print()
         return None
+    # `seen` guards the array-flatten recursion in `_puts_one` against cyclic
+    # arrays (see its docstring); a fresh, shared set across the args suffices
+    # because each handle is removed on exit.
+    seen: set[int] = set()
     for a in args:
         # `puts []` (an empty array as the sole argument) must still emit one
         # newline — Ruby prints a blank line when an argument flattens to
@@ -272,7 +298,7 @@ def sir_puts(*args: Any) -> None:
         if isinstance(a, list) and len(a) == 0:
             print()
         else:
-            _puts_one(a)
+            _puts_one(a, seen)
     return None
 
 

--- a/code/packages/python/sir-runtime-core/src/coding_adventures_sir_runtime_core/runtime.py
+++ b/code/packages/python/sir-runtime-core/src/coding_adventures_sir_runtime_core/runtime.py
@@ -195,6 +195,87 @@ def sir_print(v: Any) -> None:
     return None
 
 
+def _puts_one(v: Any) -> None:
+    """Emit a single ``puts`` argument, honouring Ruby's per-value rules.
+
+    Ruby ``puts`` is deceptively subtle.  For one argument it behaves as:
+
+    - **Array** → recurse over the *elements*, one per line.  Nesting is
+      flattened: ``puts [1, [2, 3]]`` prints ``1\\n2\\n3\\n``.  An **empty**
+      array prints nothing here (the caller's top-level ``puts []`` still
+      emits a single newline — see :func:`sir_puts` — because ``puts`` with
+      an empty argument list of its own writes one newline).
+    - **nil** → a blank line (``nil.to_s`` is ``""``, then the newline).
+    - **anything else** → its display string, then a newline — *unless* the
+      string already ends in ``"\\n"``, in which case Ruby does **not** add a
+      second newline (``puts "x\\n"`` prints ``x\\n``, not ``x\\n\\n``).
+
+    Truth table (single arg → stdout):
+
+    ============  ================
+    argument      bytes written
+    ============  ================
+    ``"x"``       ``x\\n``
+    ``"x\\n"``     ``x\\n``
+    ``nil``       ``\\n``
+    ``[]``        (nothing)
+    ``[1, 2]``    ``1\\n2\\n``
+    ``[1, [2]]``  ``1\\n2\\n``
+    ============  ================
+    """
+    # A sequence is a Python ``list`` in the runtime-core value model.
+    if isinstance(v, list):
+        for item in v:
+            _puts_one(item)
+        return None
+    text = values.to_display(v)
+    # Ruby suppresses the added newline only when the rendered text already
+    # ends in one — so ``puts "x\n"`` and ``puts "x"`` produce identical
+    # output.  ``to_display(nil)`` is ``"nil"`` for ``print`` semantics, but
+    # ``puts nil`` must be a *blank* line, so nil is special-cased.
+    if v is None:
+        print()
+        return None
+    if text.endswith("\n"):
+        # Already newline-terminated: write verbatim, no extra newline.
+        print(text, end="")
+    else:
+        print(text)
+    return None
+
+
+def sir_puts(*args: Any) -> None:
+    """Ruby ``puts``: write each argument on its own line (see :func:`_puts_one`).
+
+    Ruby's ``puts`` is variadic and array-flattening:
+
+    - ``puts`` (no args) → a single newline.
+    - ``puts x`` → ``x`` on its own line (arrays flattened element-per-line;
+      a value already ending in ``"\\n"`` is not double-spaced; ``nil`` is a
+      blank line).
+    - ``puts a, b`` → each argument handled independently, in order.
+    - ``puts []`` → a single newline (an empty argument *value* still counts
+      as "print a line").
+
+    The empty-array top-level case is why the no-argument-list and the
+    ``[]``-argument cases converge on one newline: Ruby treats ``puts`` with
+    nothing *to* print as "print an empty line".
+    """
+    if not args:
+        # `puts` with no arguments writes exactly one newline.
+        print()
+        return None
+    for a in args:
+        # `puts []` (an empty array as the sole argument) must still emit one
+        # newline — Ruby prints a blank line when an argument flattens to
+        # nothing.  `_puts_one([])` writes nothing, so detect that here.
+        if isinstance(a, list) and len(a) == 0:
+            print()
+        else:
+            _puts_one(a)
+    return None
+
+
 # --- Builtin dispatch ------------------------------------------------------
 
 _builtins: dict[str, Callable[..., Any]] = {
@@ -213,6 +294,7 @@ _builtins: dict[str, Callable[..., Any]] = {
     "number?": values.is_number,
     "symbol?": values.is_symbol,
     "print": sir_print,
+    "puts": sir_puts,
 }
 
 

--- a/code/packages/python/sir-runtime-core/tests/test_core.py
+++ b/code/packages/python/sir-runtime-core/tests/test_core.py
@@ -100,6 +100,75 @@ def test_print_uses_display(capsys: pytest.CaptureFixture[str]) -> None:
     assert out == "nil\n"
 
 
+# --- puts (Ruby semantics) -------------------------------------------------
+
+
+def test_puts_no_args_prints_single_newline(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert sir.sir_puts() is None
+    assert capsys.readouterr().out == "\n"
+
+
+def test_puts_string_appends_newline(capsys: pytest.CaptureFixture[str]) -> None:
+    sir.sir_puts("hello")
+    assert capsys.readouterr().out == "hello\n"
+
+
+def test_puts_does_not_double_trailing_newline(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # Ruby: a value already ending in "\n" is not double-spaced.
+    sir.sir_puts("x\n")
+    assert capsys.readouterr().out == "x\n"
+
+
+def test_puts_multiple_args_one_per_line(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    sir.sir_puts("a", "b")
+    assert capsys.readouterr().out == "a\nb\n"
+
+
+def test_puts_array_flattens_one_element_per_line(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    sir.sir_puts([1, 2, 3])
+    assert capsys.readouterr().out == "1\n2\n3\n"
+    # Nested arrays are flattened recursively.
+    sir.sir_puts([1, [2, 3]])
+    assert capsys.readouterr().out == "1\n2\n3\n"
+
+
+def test_puts_empty_array_prints_single_newline(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    sir.sir_puts([])
+    assert capsys.readouterr().out == "\n"
+
+
+def test_puts_nil_prints_blank_line(capsys: pytest.CaptureFixture[str]) -> None:
+    # `puts nil` is a blank line — NOT the display form "nil".
+    sir.sir_puts(None)
+    assert capsys.readouterr().out == "\n"
+
+
+def test_puts_reference_program(capsys: pytest.CaptureFixture[str]) -> None:
+    # The canonical execution-proof program: `puts "hello"; puts; puts [1,2,3]`
+    sir.sir_puts("hello")
+    sir.sir_puts()
+    sir.sir_puts([1, 2, 3])
+    assert capsys.readouterr().out == "hello\n\n1\n2\n3\n"
+
+
+def test_puts_routes_through_call_builtin(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # The backends dispatch `puts` by name through `call_builtin`.
+    assert sir.call_builtin("puts", ["hi"]) is None
+    assert capsys.readouterr().out == "hi\n"
+
+
 # --- arithmetic ------------------------------------------------------------
 
 

--- a/code/packages/python/sir-runtime-core/tests/test_core.py
+++ b/code/packages/python/sir-runtime-core/tests/test_core.py
@@ -169,6 +169,33 @@ def test_puts_routes_through_call_builtin(
     assert capsys.readouterr().out == "hi\n"
 
 
+def test_puts_self_referential_array_terminates(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # Regression (security, CWE-674 uncontrolled recursion): `a = []; a << a;
+    # puts a` in Ruby prints `[...]` and terminates.  Without the cycle guard
+    # the element-per-line flatten recurses forever and raises RecursionError
+    # (a DoS).  The guard must terminate AND render the cycle as Ruby's
+    # `[...]`.
+    a: list = []
+    a.append(a)
+    assert sir.sir_puts(a) is None
+    assert capsys.readouterr().out == "[...]\n"
+
+
+def test_puts_mutually_recursive_arrays_terminate(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # A cycle through two arrays (a -> b -> a) is still a cycle on the flatten
+    # path.  `puts a` flattens a's element (b, not yet seen), then b's element
+    # (a, already on the path) → `[...]`.  Terminates rather than diverging.
+    a: list = []
+    b: list = [a]
+    a.append(b)
+    assert sir.sir_puts(a) is None
+    assert capsys.readouterr().out == "[...]\n"
+
+
 # --- arithmetic ------------------------------------------------------------
 
 

--- a/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
@@ -16,6 +16,22 @@
   puts [1,2,3]` under `go run` and asserts stdout is exactly
   `hello\n\n1\n2\n3\n` (the Ruby reference output).
 
+### Security — cycle-guard the `puts` array flatten (CWE-674)
+
+- `_sir_puts_one` flattened arrays by recursing per element with **no bound**.
+  A `*Seq` is a shared, mutable handle, so a translated program can build a
+  self-referential array (`a = []; a << a; puts a`) or a pathologically deep
+  one; the unguarded recursion overflowed the Go stack and aborted the process
+  — a denial of service (uncontrolled recursion). The flatten now threads a
+  `visited` set of the `*Seq` pointers on the active path (the same identity
+  key `_sir_format` uses): a handle re-encountered within its own subtree is a
+  cycle and renders as Ruby's `[...]` placeholder + newline instead of
+  recursing, so `puts a` on a self-referential array now **terminates** exactly
+  as real Ruby does. Non-cyclic output is byte-for-byte unchanged
+  (`puts [1,[2,3]]` → `1\n2\n3\n`); a new regression test
+  (`puts_cyclic_array_terminates`) proves the self-referential case exits
+  cleanly with `[...]\n`.
+
 ## 0.9.0
 
 ### Added

--- a/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.10.0
+
+### Added — `puts` builtin (Ruby semantics)
+
+- The Go backend now emits and executes Ruby's `puts`, the most common output
+  method. `puts` maps to a new variadic runtime helper `_sir_puts([]Value{…})`
+  (routed both by the emit helper table and the `_sir_call_builtin_by_name`
+  dispatch), reusing `_sir_format` for element rendering.
+- Ruby semantics implemented exactly: no-arg → one newline; `puts x` →
+  `x.to_s` + newline (no double newline when the text already ends in `"\n"`);
+  `puts a, b` → one line per arg; `puts []` → a single newline; a `*Seq` is
+  flattened recursively, one **element** per line; `puts nil` → a blank line.
+- Execution proof `compile_and_run_puts.rs` runs `puts "hello"; puts;
+  puts [1,2,3]` under `go run` and asserts stdout is exactly
+  `hello\n\n1\n2\n3\n` (the Ruby reference output).
+
 ## 0.9.0
 
 ### Added

--- a/code/packages/rust/semantic-ir-to-go/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-go/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-go"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 description = "Semantic IR → self-contained Go source code (SIR15). Fourth backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-go/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/emit.rs
@@ -1110,6 +1110,7 @@ fn emit_builtin_call(out: &mut String, name: &str, args: &[Expr], indent: usize)
         "number?" => "_sir_is_number",
         "symbol?" => "_sir_is_symbol",
         "print" => "_sir_print",
+        "puts" => "_sir_puts",
         "global_set" => {
             // Two args, special signature.
             out.push_str("_sir_global_set(");
@@ -2434,6 +2435,48 @@ mod tests {
         let mut out = String::new();
         emit_expr(&mut out, &raise, 0);
         assert_eq!(out, r#"func() Value { panic(_sir_new_error("RuntimeError", nil)) }()"#);
+    }
+
+    /// `puts` routes to the variadic `_sir_puts` runtime helper (same
+    /// call shape as `_sir_print`, passing all args as a `[]Value`).  This
+    /// lets `puts a, b` (multiple args) reach the runtime intact.
+    #[test]
+    fn emit_puts_routes_to_sir_puts() {
+        // Single arg.
+        let puts1 = Expr::BuiltinCall {
+            name: "puts".into(),
+            args: vec![Expr::StrLit { value: "hi".into(), span: s() }],
+            effects: EffectSet::PURE,
+            span: s(),
+        };
+        let mut out = String::new();
+        emit_expr(&mut out, &puts1, 0);
+        assert_eq!(out, r#"_sir_puts([]Value{Value("hi")})"#);
+
+        // Multiple args — all forwarded (Ruby `puts a, b`).
+        let puts2 = Expr::BuiltinCall {
+            name: "puts".into(),
+            args: vec![
+                Expr::StrLit { value: "a".into(), span: s() },
+                Expr::StrLit { value: "b".into(), span: s() },
+            ],
+            effects: EffectSet::PURE,
+            span: s(),
+        };
+        let mut out2 = String::new();
+        emit_expr(&mut out2, &puts2, 0);
+        assert_eq!(out2, r#"_sir_puts([]Value{Value("a"), Value("b")})"#);
+
+        // No args — a bare `puts`.
+        let puts0 = Expr::BuiltinCall {
+            name: "puts".into(),
+            args: vec![],
+            effects: EffectSet::PURE,
+            span: s(),
+        };
+        let mut out0 = String::new();
+        emit_expr(&mut out0, &puts0, 0);
+        assert_eq!(out0, "_sir_puts([]Value{})");
     }
 
     fn print_stmt(v: Expr) -> Stmt {

--- a/code/packages/rust/semantic-ir-to-go/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/runtime.rs
@@ -486,6 +486,67 @@ func _sir_print(args []Value) Value {
 	return nil
 }
 
+// ── puts (Ruby semantics) ──────────────────────────────────────
+//
+// Ruby's `puts` is THE common output method and is deceptively subtle:
+//
+//   - `puts`            → one newline.
+//   - `puts x`          → `x.to_s` then a newline, UNLESS `x.to_s` already
+//                         ends in "\n" (then no second newline is added):
+//                         `puts "x\n"` prints `x\n`, not `x\n\n`.
+//   - `puts a, b`       → each argument on its own line, in order.
+//   - `puts nil`        → a blank line (`nil.to_s` is "", then the newline).
+//   - `puts []`         → a single newline (an argument that flattens to
+//                         nothing still prints a blank line).
+//   - `puts [1,[2,3]]`  → each ELEMENT on its own line, arrays flattened
+//                         recursively: `1\n2\n3\n`.
+//
+// `puts` is variadic, so it takes the whole `[]Value` (unlike the fixed-arity
+// `_sir_print`).  We write raw bytes with `fmt.Print`/`os.Stdout` rather than
+// `fmt.Println` so the trailing-newline-suppression rule can be honoured.
+func _sir_puts(args []Value) Value {
+	if len(args) == 0 {
+		// No arguments: exactly one newline.
+		fmt.Print("\n")
+		return nil
+	}
+	for _, a := range args {
+		// `puts []` (empty array arg) still writes one blank line — Ruby
+		// prints a line when an argument flattens to nothing.  A recursive
+		// flatten of an empty seq writes nothing, so detect it here.
+		if s, ok := a.(*Seq); ok && len(s.Items) == 0 {
+			fmt.Print("\n")
+			continue
+		}
+		_sir_puts_one(a)
+	}
+	return nil
+}
+
+// Emit a single `puts` argument.  Arrays recurse (element-per-line, nested
+// arrays flattened); everything else renders via `_sir_format` then a
+// newline — suppressed when the text already ends in one.  `nil` is a blank
+// line (`_sir_format(nil)` is "nil" for `print`, but `puts nil` is a blank
+// line, so nil is special-cased).
+func _sir_puts_one(v Value) {
+	if s, ok := v.(*Seq); ok {
+		for _, item := range s.Items {
+			_sir_puts_one(item)
+		}
+		return
+	}
+	if v == nil {
+		fmt.Print("\n")
+		return
+	}
+	text := _sir_format(v)
+	if strings.HasSuffix(text, "\n") {
+		fmt.Print(text)
+	} else {
+		fmt.Print(text + "\n")
+	}
+}
+
 // ── format (cycle-safe) ────────────────────────────────────────
 //
 // `*Seq`/`*Map` are *shared, mutable* handles, so an emitted program
@@ -879,6 +940,8 @@ func _sir_call_builtin_by_name(name string, args []Value) Value {
 		return _sir_is_symbol(args)
 	case "print":
 		return _sir_print(args)
+	case "puts":
+		return _sir_puts(args)
 	case "global_set":
 		return _sir_global_set(args[0], args[1])
 	case "global_get":
@@ -2074,7 +2137,7 @@ mod tests {
             "_sir_eq", "_sir_lt", "_sir_gt",
             "_sir_cons", "_sir_car", "_sir_cdr",
             "_sir_is_null", "_sir_is_pair", "_sir_is_number", "_sir_is_symbol",
-            "_sir_print", "_sir_global_set", "_sir_global_get",
+            "_sir_print", "_sir_puts", "_sir_global_set", "_sir_global_get",
             "_sir_apply", "_sir_make_closure", "_sir_intern", "_sir_truthy",
             "_sir_format", "_sir_builtin_closure", "_sir_call_builtin_by_name",
             // E3 exception helpers.

--- a/code/packages/rust/semantic-ir-to-go/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/runtime.rs
@@ -510,6 +510,15 @@ func _sir_puts(args []Value) Value {
 		fmt.Print("\n")
 		return nil
 	}
+	// A `*Seq` is a shared, mutable handle, so a program can build a
+	// *cyclic* array (`a = []; a << a`).  The element-per-line flatten below
+	// recurses through nested arrays, so — like `_sir_format` — it MUST be
+	// cycle-guarded or a self-referential array overflows the Go stack (a
+	// DoS: CWE-674, uncontrolled recursion).  We thread a `visited` set of
+	// the `*Seq` pointers on the active flatten path; the top-level args each
+	// share one set (a handle removed on exit still prints in full via a
+	// sibling path — only a true self-cycle is short-circuited).
+	visited := make(map[Value]bool)
 	for _, a := range args {
 		// `puts []` (empty array arg) still writes one blank line — Ruby
 		// prints a line when an argument flattens to nothing.  A recursive
@@ -518,7 +527,7 @@ func _sir_puts(args []Value) Value {
 			fmt.Print("\n")
 			continue
 		}
-		_sir_puts_one(a)
+		_sir_puts_one(a, visited)
 	}
 	return nil
 }
@@ -528,11 +537,30 @@ func _sir_puts(args []Value) Value {
 // newline — suppressed when the text already ends in one.  `nil` is a blank
 // line (`_sir_format(nil)` is "nil" for `print`, but `puts nil` is a blank
 // line, so nil is special-cased).
-func _sir_puts_one(v Value) {
+//
+// Cycle safety: `visited` holds the `*Seq` pointers currently on the active
+// flatten path.  A seq ALREADY on the path is a cycle (`a = []; a << a`):
+// rather than recurse forever we write Ruby's `[...]` placeholder then a
+// newline, matching real Ruby (`puts a` on a self-referential array prints
+// `[...]` and terminates).  (We emit the literal placeholder rather than
+// `_sir_format(v)`: that formatter starts a fresh visited set, so it would
+// render the *containing* level too — `[[...]]` for `a = [a]` — whereas Ruby
+// prints a bare `[...]`.)  A seq reached twice by *sibling* (non-cyclic) paths
+// is fully flattened both times, because each is removed from `visited` on
+// exit — only a handle re-appearing *within its own subtree* is short-
+// circuited.  Non-cyclic output is unchanged (`puts [1,[2,3]]` still prints
+// `1\n2\n3\n`).
+func _sir_puts_one(v Value, visited map[Value]bool) {
 	if s, ok := v.(*Seq); ok {
-		for _, item := range s.Items {
-			_sir_puts_one(item)
+		if visited[v] {
+			fmt.Print("[...]\n")
+			return
 		}
+		visited[v] = true
+		for _, item := range s.Items {
+			_sir_puts_one(item, visited)
+		}
+		delete(visited, v)
 		return
 	}
 	if v == nil {

--- a/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_puts.rs
+++ b/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_puts.rs
@@ -21,8 +21,8 @@
 use std::process::Command;
 
 use semantic_ir::{
-    Block, Effect, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, Span,
-    Stmt,
+    Block, Effect, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, Scope,
+    Span, Stmt,
 };
 use semantic_ir_to_go::compile;
 
@@ -36,6 +36,10 @@ fn ilit(v: i64) -> Expr {
 
 fn slit(v: &str) -> Expr {
     Expr::StrLit { value: v.into(), span: s() }
+}
+
+fn var(name: &str) -> Expr {
+    Expr::VarRef { name: name.into(), scope: Scope::Local, span: s() }
 }
 
 /// `puts(args…)` as an effectful statement (MayPrint, matching the frontend).
@@ -61,6 +65,55 @@ fn demo_module() -> Module {
 
     Module {
         name: "puts_demo".into(),
+        manifest: FeatureManifest::from_features(&[Feature::Sequences, Feature::Strings]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block { stmts, value: Expr::NilLit { span: s() }, span: s() },
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            metadata: Metadata::new(),
+            span: s(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("test")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+/// Build a module equivalent to the Ruby program
+///
+///     a = [nil]
+///     a[0] = a
+///     puts a
+///
+/// i.e. a *self-referential* array.  Real Ruby is cycle-aware: `puts a`
+/// prints `[...]` and terminates.  Before the cycle guard the emitted
+/// `_sir_puts_one` recursed per-element with no bound, so this program
+/// overflowed the Go stack and aborted (CWE-674, uncontrolled recursion — a
+/// DoS).  The guard must make it terminate.
+fn cyclic_module() -> Module {
+    let stmts = vec![
+        // a = [nil]  (a one-slot seq we can then point at itself)
+        Stmt::LetBinding {
+            name: "a".into(),
+            sir_type: None,
+            value: Expr::SeqLit { items: vec![Expr::NilLit { span: s() }], span: s() },
+            span: s(),
+        },
+        // a[0] = a  (close the cycle)
+        Stmt::SeqSet { seq: var("a"), index: ilit(0), value: var("a"), span: s() },
+        // puts a
+        puts_stmt(vec![var("a")]),
+    ];
+
+    Module {
+        name: "puts_cyclic".into(),
         manifest: FeatureManifest::from_features(&[Feature::Sequences, Feature::Strings]),
         imports: vec![],
         exports: vec![],
@@ -131,4 +184,44 @@ fn puts_compiles_and_matches_ruby_output() {
     );
 
     let _ = std::fs::remove_file(&src_path);
+}
+
+/// Regression (security, CWE-674): `puts` on a self-referential array must
+/// TERMINATE — printing a `[...]` cycle placeholder like Ruby — rather than
+/// recursing until the Go stack overflows and the process aborts.
+#[test]
+fn puts_cyclic_array_terminates() {
+    if !go_available() {
+        eprintln!("skipping: go not on PATH");
+        return;
+    }
+
+    let artifact = compile(&cyclic_module()).expect("cyclic module should compile to Go source");
+
+    let dir = std::env::temp_dir();
+    let nonce = std::process::id();
+    let src_path = dir.join(format!("sir_go_puts_cyclic_{nonce}.go"));
+    std::fs::write(&src_path, &artifact.source).expect("write temp source");
+
+    let run_out = Command::new("go")
+        .arg("run")
+        .arg(&src_path)
+        .output()
+        .expect("invoke go run");
+
+    let stdout = String::from_utf8_lossy(&run_out.stdout);
+    let stderr = String::from_utf8_lossy(&run_out.stderr);
+    let _ = std::fs::remove_file(&src_path);
+
+    // The program must exit SUCCESSFULLY (no stack-overflow abort) …
+    assert!(
+        run_out.status.success(),
+        "cyclic puts should terminate cleanly, not overflow; stderr: {stderr}"
+    );
+    // … and render the cycle as Ruby does: `[...]` on its own line.
+    let normalised = stdout.replace("\r\n", "\n");
+    assert_eq!(
+        normalised, "[...]\n",
+        "unexpected cyclic puts output; full stdout (escaped): {stdout:?}"
+    );
 }

--- a/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_puts.rs
+++ b/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_puts.rs
@@ -1,0 +1,134 @@
+//! End-to-end proof for the `puts` builtin (Ruby semantics) in the Go
+//! backend.
+//!
+//! Ruby's `puts` is the most common output method, and its semantics are
+//! subtle enough that a *shape* assertion in a unit test is not enough — we
+//! must prove the emitted Go actually produces the exact byte stream Ruby
+//! would.  This test hand-builds a SIR module equivalent to the Ruby program
+//!
+//!     puts "hello"
+//!     puts
+//!     puts [1, 2, 3]
+//!
+//! emits Go, runs it with `go run`, and asserts stdout is **exactly**
+//! `hello\n\n1\n2\n3\n` — the Ruby reference output (a line for `hello`, a
+//! blank line for the no-arg `puts`, then each array element on its own
+//! line).
+//!
+//! Gates on `go` being available; logs a skip rather than failing when the
+//! toolchain is absent (mirrors `compile_and_run_loops.rs`).
+
+use std::process::Command;
+
+use semantic_ir::{
+    Block, Effect, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, Span,
+    Stmt,
+};
+use semantic_ir_to_go::compile;
+
+fn s() -> Span {
+    Span::synthetic()
+}
+
+fn ilit(v: i64) -> Expr {
+    Expr::IntLit { value: v, span: s() }
+}
+
+fn slit(v: &str) -> Expr {
+    Expr::StrLit { value: v.into(), span: s() }
+}
+
+/// `puts(args…)` as an effectful statement (MayPrint, matching the frontend).
+fn puts_stmt(args: Vec<Expr>) -> Stmt {
+    Stmt::ExprStmt {
+        expr: Expr::BuiltinCall {
+            name: "puts".into(),
+            args,
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            span: s(),
+        },
+        span: s(),
+    }
+}
+
+/// Build a module whose `main` runs `puts "hello"; puts; puts [1,2,3]`.
+fn demo_module() -> Module {
+    let stmts = vec![
+        puts_stmt(vec![slit("hello")]),
+        puts_stmt(vec![]),
+        puts_stmt(vec![Expr::SeqLit { items: vec![ilit(1), ilit(2), ilit(3)], span: s() }]),
+    ];
+
+    Module {
+        name: "puts_demo".into(),
+        manifest: FeatureManifest::from_features(&[Feature::Sequences, Feature::Strings]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block { stmts, value: Expr::NilLit { span: s() }, span: s() },
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            metadata: Metadata::new(),
+            span: s(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("test")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+fn go_available() -> bool {
+    Command::new("go")
+        .arg("version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+#[test]
+fn puts_compiles_and_matches_ruby_output() {
+    if !go_available() {
+        eprintln!("skipping: go not on PATH");
+        return;
+    }
+
+    let artifact = compile(&demo_module()).expect("module should compile to Go source");
+
+    let dir = std::env::temp_dir();
+    let nonce = std::process::id();
+    let src_path = dir.join(format!("sir_go_puts_{nonce}.go"));
+    std::fs::write(&src_path, &artifact.source).expect("write temp source");
+
+    let run_out = Command::new("go")
+        .arg("run")
+        .arg(&src_path)
+        .output()
+        .expect("invoke go run");
+
+    if !run_out.status.success() {
+        let stderr = String::from_utf8_lossy(&run_out.stderr);
+        let _ = std::fs::remove_file(&src_path);
+        panic!(
+            "emitted Go failed to compile/run:\n--- stderr ---\n{stderr}\n--- source ---\n{}",
+            artifact.source,
+        );
+    }
+
+    // Exact byte-for-byte match against the Ruby reference output.
+    let stdout = String::from_utf8_lossy(&run_out.stdout);
+    // Go may emit CRLF line endings on Windows via fmt; normalise before
+    // comparing so the assertion tests the *semantics* (one line per unit),
+    // not the platform's newline convention.
+    let normalised = stdout.replace("\r\n", "\n");
+    assert_eq!(
+        normalised, "hello\n\n1\n2\n3\n",
+        "unexpected puts output; full stdout (escaped): {stdout:?}"
+    );
+
+    let _ = std::fs::remove_file(&src_path);
+}

--- a/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
@@ -20,6 +20,21 @@ All notable changes to `semantic-ir-to-javascript` are documented here.
   `puts "hello"; puts; puts [1,2,3]` under `node` and asserts stdout is exactly
   `hello\n\n1\n2\n3\n` (the Ruby reference output).
 
+### Security — cycle-guard the `puts` array flatten (CWE-674)
+
+- `putsOne` flattened arrays by recursing per element with **no bound**. A JS
+  array is a shared, mutable reference, so a translated program can build a
+  self-referential array (`a = []; a << a; puts a`) or a pathologically deep
+  one; the unguarded recursion threw `RangeError: Maximum call stack size
+  exceeded` — a denial of service (uncontrolled recursion). The flatten now
+  threads a `Set` of the array references on the active path: an array
+  re-encountered within its own subtree is a cycle and is written as Ruby's
+  `[...]` placeholder + newline instead of recursing, so `puts a` on a
+  self-referential array now **terminates** exactly as real Ruby does.
+  Non-cyclic output is byte-for-byte unchanged (`puts [1,[2,3]]` →
+  `1\n2\n3\n`); a new regression test (`puts_cyclic_array_terminates`) proves
+  the self-referential case exits cleanly with `[...]\n`.
+
 ## Unreleased
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),

--- a/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to `semantic-ir-to-javascript` are documented here.
 
+## 0.8.0 — `puts` builtin (Ruby semantics)
+
+### Added
+
+- The JavaScript backend now emits and executes Ruby's `puts`, the most common
+  output method. `puts` maps to a new variadic runtime helper `__Sir.puts(...)`
+  (routed by the emit helper table, with a matching `builtins["puts"]` entry),
+  reusing `format` for element rendering.
+- Ruby semantics implemented exactly: no-arg → one newline; `puts x` →
+  `x` + newline (no double newline when the text already ends in `"\n"`);
+  `puts a, b` → one line per arg; `puts []` → a single newline; a native array
+  is flattened recursively, one **element** per line; `puts null` → a blank
+  line. Writes via `process.stdout.write` (not `console.log`) so the
+  trailing-newline suppression is honoured.
+- Execution proof `run_with_node.rs::puts_matches_ruby_output` runs
+  `puts "hello"; puts; puts [1,2,3]` under `node` and asserts stdout is exactly
+  `hello\n\n1\n2\n3\n` (the Ruby reference output).
+
 ## Unreleased
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),

--- a/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-javascript"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 description = "Semantic IR → self-contained JavaScript source code (SIR18). Fifth backend for the SIR10 narrow-waist IR. Includes __method__ dispatch execution (C3), exception handling (try/catch/raise) with user-class ancestry (E1), and user-defined-class OOP — instantiation, method dispatch, super, self, and @ivar/@@cvar access (O3)."
 

--- a/code/packages/rust/semantic-ir-to-javascript/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/emit.rs
@@ -1068,6 +1068,7 @@ fn emit_builtin_call(out: &mut String, name: &str, args: &[Expr], indent: usize)
     // live in the bracket-indexed dispatch table.
     let helper = match name {
         "print" => Some("__Sir.print"),
+        "puts" => Some("__Sir.puts"),
         "cons" => Some("__Sir.builtins[\"cons\"]"),
         "car" => Some("__Sir.builtins[\"car\"]"),
         "cdr" => Some("__Sir.builtins[\"cdr\"]"),
@@ -1484,6 +1485,28 @@ mod tests {
             emit_e(&bc("print", vec![Expr::IntLit { value: 7, span: s() }])),
             "__Sir.print(7)"
         );
+    }
+
+    /// `puts` routes to the variadic `__Sir.puts(...)` runtime helper.  All
+    /// arguments are forwarded (Ruby `puts a, b`), and a bare `puts` becomes
+    /// `__Sir.puts()`.
+    #[test]
+    fn emit_builtin_puts_routes_to_runtime() {
+        assert_eq!(
+            emit_e(&bc("puts", vec![Expr::IntLit { value: 7, span: s() }])),
+            "__Sir.puts(7)"
+        );
+        assert_eq!(
+            emit_e(&bc(
+                "puts",
+                vec![
+                    Expr::IntLit { value: 1, span: s() },
+                    Expr::IntLit { value: 2, span: s() },
+                ],
+            )),
+            "__Sir.puts(1, 2)"
+        );
+        assert_eq!(emit_e(&bc("puts", vec![])), "__Sir.puts()");
     }
 
     #[test]

--- a/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
@@ -137,6 +137,7 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
     "symbol?": (x) => x instanceof Sym,
     "len": (x) => x.length,
     "print": (x) => { console.log(format(x)); return null; },
+    "puts": (...args) => puts(...args),
     "range": (start, stop, step) => {
       const out = [];
       const s = step === undefined || step === null ? 1 : step;
@@ -161,6 +162,40 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
   // `print` is promoted to a top-level member so emitted code can write
   // the readable `__Sir.print(x)` rather than `__Sir.builtins["print"](x)`.
   function print(x) { console.log(format(x)); return null; }
+
+  // ── puts (Ruby semantics) ──────────────────────────────────────
+  //
+  // Ruby's `puts` is THE common output method and is deceptively subtle:
+  //
+  //   - `puts`            → one newline.
+  //   - `puts x`          → `x.to_s` then a newline, UNLESS `x.to_s` already
+  //                         ends in "\n" (then no second newline is added):
+  //                         `puts "x\n"` prints `x\n`, not `x\n\n`.
+  //   - `puts a, b`       → each argument on its own line, in order.
+  //   - `puts nil`        → a blank line (`nil.to_s` is "", then the newline).
+  //   - `puts []`         → a single newline (an argument that flattens to
+  //                         nothing still prints a blank line).
+  //   - `puts [1,[2,3]]`  → each ELEMENT on its own line, arrays flattened
+  //                         recursively: `1\n2\n3\n`.
+  //
+  // We write via `process.stdout.write` rather than `console.log` because
+  // `console.log` unconditionally appends a newline, defeating the
+  // trailing-newline-suppression rule.  A sequence is a native JS array.
+  function putsOne(v) {
+    if (Array.isArray(v)) { for (const item of v) { putsOne(item); } return; }
+    if (v === null || v === undefined) { process.stdout.write("\n"); return; }
+    const text = format(v);
+    process.stdout.write(text.endsWith("\n") ? text : text + "\n");
+  }
+  function puts(...args) {
+    if (args.length === 0) { process.stdout.write("\n"); return null; }
+    for (const a of args) {
+      // `puts []` (empty array arg) still writes one blank line.
+      if (Array.isArray(a) && a.length === 0) { process.stdout.write("\n"); }
+      else { putsOne(a); }
+    }
+    return null;
+  }
 
   // ── method dispatch (`__method__`) ─────────────────────────────
   // `recv.meth(args…)` reaches the backend as
@@ -559,7 +594,7 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
 
   return {
     Sym, Pair, Closure,
-    intern, applyClosure, truthy, format, print,
+    intern, applyClosure, truthy, format, print, puts,
     builtins, builtinClosure, callBuiltin, callMethod,
     SirError, raiseError, rescueMatches, registerAncestry,
     // OOP (O3): instantiation, method definition + dispatch, super,

--- a/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
@@ -181,18 +181,38 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
   // We write via `process.stdout.write` rather than `console.log` because
   // `console.log` unconditionally appends a newline, defeating the
   // trailing-newline-suppression rule.  A sequence is a native JS array.
-  function putsOne(v) {
-    if (Array.isArray(v)) { for (const item of v) { putsOne(item); } return; }
+  // Cycle safety: a JS array is a shared, mutable reference, so a program can
+  // build a *cyclic* array (`a = []; a << a`).  The element-per-line flatten
+  // recurses through nested arrays, so it MUST be cycle-guarded or a self-
+  // referential array throws `RangeError: Maximum call stack size exceeded`
+  // (a DoS: CWE-674, uncontrolled recursion).  `seen` is a `Set` of the array
+  // references currently on the active flatten path.  A array ALREADY on the
+  // path is a cycle: rather than recurse forever we write `[...]` and a
+  // newline — matching real Ruby, where `puts a` on a self-referential array
+  // prints `[...]` and terminates.  (`format` is not itself cycle-guarded, so
+  // we emit the placeholder directly instead of calling it on the cycle.)  An
+  // array removed from `seen` on exit still flattens in full via a sibling
+  // path — only a true self-cycle is short-circuited, so non-cyclic output is
+  // unchanged (`puts [1,[2,3]]` still prints `1\n2\n3\n`).
+  function putsOne(v, seen) {
+    if (Array.isArray(v)) {
+      if (seen.has(v)) { process.stdout.write("[...]\n"); return; }
+      seen.add(v);
+      for (const item of v) { putsOne(item, seen); }
+      seen.delete(v);
+      return;
+    }
     if (v === null || v === undefined) { process.stdout.write("\n"); return; }
     const text = format(v);
     process.stdout.write(text.endsWith("\n") ? text : text + "\n");
   }
   function puts(...args) {
     if (args.length === 0) { process.stdout.write("\n"); return null; }
+    const seen = new Set();
     for (const a of args) {
       // `puts []` (empty array arg) still writes one blank line.
       if (Array.isArray(a) && a.length === 0) { process.stdout.write("\n"); }
-      else { putsOne(a); }
+      else { putsOne(a, seen); }
     }
     return null;
   }

--- a/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
@@ -1340,3 +1340,63 @@ fn oop_cyclic_ancestry_terminates() {
         );
     }
 }
+
+// ── puts builtin (Ruby semantics) ──────────────────────────────────────
+
+/// Compile a hand-built module, run it under `node`, and return the **raw**
+/// stdout (newlines preserved).  Unlike `run_module`, this does NOT trim
+/// trailing newlines — `puts` semantics hinge on the exact byte stream (a
+/// trailing blank line is meaningful).  Returns `None` when Node is absent.
+fn run_module_raw(module: &Module, tag: &str) -> Option<String> {
+    let artifact = compile(module).expect("compile to javascript");
+    if !node_available() {
+        eprintln!("note: `node` unavailable — skipping execution for `{tag}`");
+        return None;
+    }
+    let mut path: PathBuf = std::env::temp_dir();
+    path.push(format!("sir_js_{}_{}.js", tag, std::process::id()));
+    std::fs::write(&path, &artifact.source).expect("write temp js");
+    let output = Command::new("node").arg(&path).output().expect("spawn node");
+    let _ = std::fs::remove_file(&path);
+    assert!(
+        output.status.success(),
+        "node exited non-zero for `{tag}`:\nstdout: {}\nstderr: {}\nsource:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+        artifact.source,
+    );
+    // Normalise CRLF → LF so the assertion tests the semantics (one line per
+    // unit), not the platform newline convention.
+    Some(String::from_utf8(output.stdout).expect("utf8 stdout").replace("\r\n", "\n"))
+}
+
+#[test]
+fn puts_matches_ruby_output() {
+    // Ruby: `puts "hello"; puts; puts [1, 2, 3]`
+    //   → "hello\n"   (string + newline)
+    //   → "\n"        (no-arg puts → one blank line)
+    //   → "1\n2\n3\n" (each array element on its own line)
+    let puts_hello = Stmt::ExprStmt {
+        expr: bc("puts", vec![str_("hello")]),
+        span: sp(),
+    };
+    let puts_bare = Stmt::ExprStmt { expr: bc("puts", vec![]), span: sp() };
+    let puts_arr = Stmt::ExprStmt {
+        expr: bc(
+            "puts",
+            vec![Expr::SeqLit { items: vec![int(1), int(2), int(3)], span: sp() }],
+        ),
+        span: sp(),
+    };
+    let module = module_with_main(
+        vec![puts_hello, puts_bare, puts_arr],
+        Expr::NilLit { span: sp() },
+        &[Feature::Sequences, Feature::Strings],
+    );
+    if let Some(stdout) = run_module_raw(&module, "puts") {
+        assert_eq!(
+            stdout, "hello\n\n1\n2\n3\n",
+            "unexpected puts output (escaped): {stdout:?}"
+        );
+    }
+}

--- a/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
@@ -1400,3 +1400,34 @@ fn puts_matches_ruby_output() {
         );
     }
 }
+
+/// Regression (security, CWE-674): `puts` on a self-referential array must
+/// TERMINATE — printing a `[...]` cycle placeholder like Ruby — rather than
+/// recursing until Node throws `RangeError: Maximum call stack size exceeded`.
+///
+/// Ruby:  `a = [nil]; a[0] = a; puts a`  → `[...]\n`.
+#[test]
+fn puts_cyclic_array_terminates() {
+    let stmts = vec![
+        // a = [nil]
+        let_("a", Expr::SeqLit { items: vec![Expr::NilLit { span: sp() }], span: sp() }),
+        // a[0] = a
+        Stmt::SeqSet { seq: local("a"), index: int(0), value: local("a"), span: sp() },
+        // puts a
+        Stmt::ExprStmt { expr: bc("puts", vec![local("a")]), span: sp() },
+    ];
+    let module = module_with_main(
+        stmts,
+        Expr::NilLit { span: sp() },
+        &[Feature::Sequences, Feature::MutableBindings],
+    );
+    // `run_module_raw` asserts a clean (zero) exit; a stack overflow would
+    // exit non-zero and fail the test — so reaching the assert proves
+    // termination.  The output matches Ruby's `[...]` cycle rendering.
+    if let Some(stdout) = run_module_raw(&module, "puts_cyclic") {
+        assert_eq!(
+            stdout, "[...]\n",
+            "unexpected cyclic puts output (escaped): {stdout:?}"
+        );
+    }
+}

--- a/code/packages/rust/semantic-ir-to-python/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-python/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.7.0 — `puts` builtin (Ruby semantics)
+
+### Changed
+
+- `puts` now maps **directly** to the variadic runtime helper `_sir_puts(...)`
+  (like `print` → `_sir_print`) instead of routing through the generic
+  `_sir_call_builtin("puts", […])` dispatch. This is possible now that
+  `sir-runtime-core` implements Ruby `puts` semantics; the previous
+  dispatch-table routing would have failed at runtime because `puts` was not
+  registered. A `sir_puts as _sir_puts` import alias was added to the runtime
+  header. Existing Ruby→Python e2e tests were updated to the new call shape,
+  and `end_to_end_ruby_to_python_puts` now runs the emitted Python under a real
+  interpreter and asserts `puts "hello"` prints exactly `hello\n`.
+
 ## [0.6.0] - 2026-07-01
 
 ### Added (Issue #59 — class-method CALL dispatch)

--- a/code/packages/rust/semantic-ir-to-python/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-python/src/emit.rs
@@ -1378,6 +1378,9 @@ fn emit_builtin_call(out: &mut String, name: &str, args: &[Expr], indent: usize)
         "number?" => "_sir_is_number",
         "symbol?" => "_sir_is_symbol",
         "print" => "_sir_print",
+        // `_sir_puts` is variadic (`sir_puts(*args)`), so `_sir_puts(a, b)`
+        // forwards every argument (Ruby `puts a, b`).
+        "puts" => "_sir_puts",
         "global_set" => "_sir_global_set",
         "global_get" => "_sir_global_get",
         _ => {

--- a/code/packages/rust/semantic-ir-to-python/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-python/src/lib.rs
@@ -822,7 +822,10 @@ mod tests {
     #[test]
     fn end_to_end_ruby_to_python_puts() {
         // `puts("hello")` → a top-level `main` that calls the `puts`
-        // builtin through the runtime dispatcher.
+        // builtin.  `puts` now maps directly to the variadic runtime helper
+        // `_sir_puts(...)` (like `print` → `_sir_print`), rather than routing
+        // through the generic `_sir_call_builtin` dispatch, now that the
+        // runtime implements Ruby `puts` semantics.
         let module = ruby_to_semantic_ir::compile_source("puts(\"hello\")\n", "demo")
             .expect("lower ruby");
         let a = compile(&module).expect("compile to python");
@@ -832,12 +835,18 @@ mod tests {
             a.source
         );
         assert!(
-            a.source.contains("_sir_call_builtin(\"puts\", [\"hello\"])"),
+            a.source.contains("_sir_puts(\"hello\")"),
             "expected the puts call with the string literal; got:\n{}",
             a.source
         );
         assert!(a.source.contains("_sir_user_main()"), "expected main invocation");
         assert!(a.filename.ends_with(".py"));
+
+        // Execution proof: `puts "hello"` must emit exactly `hello\n` under a
+        // real interpreter (Ruby's `puts` string+newline semantics).
+        if let Some(stdout) = run_emitted_python(&a.source) {
+            assert_eq!(stdout, "hello\n", "puts should print `hello` + newline");
+        }
     }
 
     #[test]
@@ -861,7 +870,7 @@ mod tests {
             a.source
         );
         assert!(
-            a.source.contains("_sir_call_builtin(\"puts\", [add(1, 2)])"),
+            a.source.contains("_sir_puts(add(1, 2))"),
             "expected puts(add(1, 2)); got:\n{}",
             a.source
         );
@@ -878,7 +887,7 @@ mod tests {
         .expect("lower ruby");
         let a = compile(&module).expect("compile to python");
         assert!(
-            a.source.contains("_sir_call_builtin(\"puts\", [_sir_plus(x, y)])"),
+            a.source.contains("_sir_puts(_sir_plus(x, y))"),
             "expected puts(x + y) referencing both locals; got:\n{}",
             a.source
         );

--- a/code/packages/rust/semantic-ir-to-python/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-python/src/runtime.rs
@@ -112,6 +112,7 @@ from coding_adventures_sir_runtime_core import (
     is_number as _sir_is_number,
     is_symbol as _sir_is_symbol,
     sir_print as _sir_print,
+    sir_puts as _sir_puts,
     to_display as _sir_to_display,
 )
 
@@ -168,6 +169,7 @@ mod tests {
             "is_number as _sir_is_number",
             "is_symbol as _sir_is_symbol",
             "sir_print as _sir_print",
+            "sir_puts as _sir_puts",
             "to_display as _sir_to_display",
         ] {
             assert!(RUNTIME.contains(alias), "runtime missing alias `{}`", alias);

--- a/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.10.0 — `puts` builtin (Ruby semantics)
+
+### Added
+
+- The Rust backend now emits and executes Ruby's `puts`, the most common
+  output method. `puts` maps to a new **variadic** runtime helper
+  `__sir::puts(vec![…])` (routed both by the emit helper table and
+  `call_builtin_by_name`), reusing `__sir::format` for element rendering.
+- Ruby semantics implemented exactly: no-arg → one newline; `puts x` →
+  `x.to_s` + newline (no double newline when the text already ends in `"\n"`);
+  `puts a, b` → one line per arg; `puts []` → a single newline; a
+  `Value::Seq` is flattened recursively, one **element** per line; `puts nil`
+  → a blank line.
+- Execution proof `compile_and_run_puts.rs` compiles `puts "hello"; puts;
+  puts [1,2,3]` with `rustc`, runs it, and asserts stdout is exactly
+  `hello\n\n1\n2\n3\n` (the Ruby reference output).
+
 ## 0.9.0 — user-defined class OOP runtime + emit (O5)
 
 Makes the Rust backend **accept and execute** real user-defined-class OOP

--- a/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
@@ -17,6 +17,23 @@
   puts [1,2,3]` with `rustc`, runs it, and asserts stdout is exactly
   `hello\n\n1\n2\n3\n` (the Ruby reference output).
 
+### Security — cycle-guard the `puts` array flatten (CWE-674)
+
+- `__sir::puts_one` flattened arrays by recursing per element with **no
+  bound**. A `Value::Seq` is a shared, mutable `Rc<RefCell<..>>` handle, so a
+  translated program can build a self-referential array
+  (`a = []; a << a; puts a`) or a pathologically deep one; the unguarded
+  recursion overflowed the native stack and aborted — a denial of service
+  (uncontrolled recursion). The flatten now threads a `visited` set of the `Rc`
+  handle addresses on the active path (the same `seq_handle_id` key
+  `__sir::format` uses): a handle re-encountered within its own subtree is a
+  cycle and renders as Ruby's `[...]` placeholder + newline instead of
+  recursing, so `puts a` on a self-referential array now **terminates** exactly
+  as real Ruby does. Non-cyclic output is byte-for-byte unchanged
+  (`puts [1,[2,3]]` → `1\n2\n3\n`); a new regression test
+  (`puts_cyclic_array_terminates`) proves the self-referential case exits
+  cleanly with `[...]\n`.
+
 ## 0.9.0 — user-defined class OOP runtime + emit (O5)
 
 Makes the Rust backend **accept and execute** real user-defined-class OOP

--- a/code/packages/rust/semantic-ir-to-rust/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-rust"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 description = "Semantic IR → self-contained Rust source code (SIR13). Second backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-rust/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/emit.rs
@@ -1323,6 +1323,8 @@ fn emit_builtin_call(out: &mut String, name: &str, args: &[Expr], indent: usize)
         "number?" => ("__sir::is_number", false),
         "symbol?" => ("__sir::is_symbol", false),
         "print" => ("__sir::print", false),
+        // `puts` is variadic (`puts a, b`) → takes the whole `Vec<Value>`.
+        "puts" => ("__sir::puts", true),
         "global_set" => ("__sir::global_set_call", false),
         "global_get" => ("__sir::global_get_call", false),
         // ── collection-method dispatch (C6) ───────────────────────────
@@ -3329,6 +3331,29 @@ mod tests {
 
     fn strlit(v: &str) -> Expr {
         Expr::StrLit { value: v.into(), span: s() }
+    }
+
+    /// `puts` routes to the **variadic** `__sir::puts(vec![…])` helper, so
+    /// `puts a, b` (multiple args) reaches the runtime intact — unlike the
+    /// fixed-arity `__sir::print`.
+    #[test]
+    fn emit_puts_routes_to_variadic_helper() {
+        // Single arg.
+        let mut out = String::new();
+        emit_expr(&mut out, &builtin("puts", vec![strlit("hi")]), 0);
+        assert!(out.starts_with("__sir::puts(vec!["), "got: {out}");
+        assert!(out.contains(r#""hi""#), "got: {out}");
+
+        // Multiple args, both forwarded.
+        let mut out2 = String::new();
+        emit_expr(&mut out2, &builtin("puts", vec![strlit("a"), strlit("b")]), 0);
+        assert!(out2.starts_with("__sir::puts(vec!["), "got: {out2}");
+        assert!(out2.contains(r#""a""#) && out2.contains(r#""b""#), "got: {out2}");
+
+        // No args — a bare `puts`.
+        let mut out0 = String::new();
+        emit_expr(&mut out0, &builtin("puts", vec![]), 0);
+        assert_eq!(out0, "__sir::puts(vec![])");
     }
 
     #[test]

--- a/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
@@ -333,6 +333,72 @@ pub const RUNTIME: &str = r##"mod __sir {
         Value::Nil
     }
 
+    // ── puts (Ruby semantics) ──────────────────────────────────────
+    //
+    // Ruby's `puts` is THE common output method and is deceptively subtle:
+    //
+    //   - `puts`            → one newline.
+    //   - `puts x`          → `x.to_s` then a newline, UNLESS `x.to_s`
+    //                         already ends in "\n" (no second newline):
+    //                         `puts "x\n"` prints `x\n`, not `x\n\n`.
+    //   - `puts a, b`       → each argument on its own line, in order.
+    //   - `puts nil`        → a blank line (`nil.to_s` is "", then newline).
+    //   - `puts []`         → a single newline (an argument flattening to
+    //                         nothing still prints a blank line).
+    //   - `puts [1,[2,3]]`  → each ELEMENT on its own line, arrays flattened
+    //                         recursively: `1\n2\n3\n`.
+    //
+    // `puts` is variadic, so it takes the whole `Vec<Value>` (unlike the
+    // fixed-arity `print`).  We use `print!` (no trailing newline) so the
+    // trailing-newline-suppression rule can be honoured.
+    pub fn puts(args: Vec<Value>) -> Value {
+        if args.is_empty() {
+            // No arguments: exactly one newline.
+            print!("\n");
+            return Value::Nil;
+        }
+        for a in &args {
+            // `puts []` (empty array arg) still writes one blank line — Ruby
+            // prints a line when an argument flattens to nothing.  A
+            // recursive flatten of an empty seq writes nothing, so detect it.
+            if let Value::Seq(items) = a {
+                if items.borrow().is_empty() {
+                    print!("\n");
+                    continue;
+                }
+            }
+            puts_one(a);
+        }
+        Value::Nil
+    }
+
+    // Emit a single `puts` argument.  Arrays recurse (element-per-line,
+    // nested arrays flattened); everything else renders via `format` then a
+    // newline — suppressed when the text already ends in one.  `nil` is a
+    // blank line (`format(nil)` is "nil" for `print`, but `puts nil` is a
+    // blank line, so nil is special-cased).
+    fn puts_one(v: &Value) {
+        if let Value::Seq(items) = v {
+            // Clone the handle's items to avoid holding the borrow across the
+            // recursive call (a nested seq re-borrows the same `RefCell`).
+            let snapshot: Vec<Value> = items.borrow().clone();
+            for item in &snapshot {
+                puts_one(item);
+            }
+            return;
+        }
+        if matches!(v, Value::Nil) {
+            print!("\n");
+            return;
+        }
+        let text = format(v);
+        if text.ends_with('\n') {
+            print!("{}", text);
+        } else {
+            println!("{}", text);
+        }
+    }
+
     // ── format ────────────────────────────────────────────────────
     //
     // Cycle safety.  `Value::Seq`/`Value::Map` are *shared, mutable*
@@ -831,6 +897,7 @@ pub const RUNTIME: &str = r##"mod __sir {
             "number?" => is_number(args.into_iter().next().unwrap_or(Value::Nil)),
             "symbol?" => is_symbol(args.into_iter().next().unwrap_or(Value::Nil)),
             "print" => print(args.into_iter().next().unwrap_or(Value::Nil)),
+            "puts" => puts(args),
             "global_set" => {
                 let mut it = args.into_iter();
                 let key = it.next().unwrap_or(Value::Nil);
@@ -1868,7 +1935,7 @@ mod tests {
         for op in &[
             "plus", "minus", "times", "divide", "eq", "lt", "gt",
             "cons", "car", "cdr", "is_null", "is_pair", "is_number",
-            "is_symbol", "print", "global_set", "global_get",
+            "is_symbol", "print", "puts", "global_set", "global_get",
             "apply_closure", "intern", "truthy", "format",
             "call_builtin_by_name", "builtin_closure",
         ] {

--- a/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
@@ -357,6 +357,16 @@ pub const RUNTIME: &str = r##"mod __sir {
             print!("\n");
             return Value::Nil;
         }
+        // A `Value::Seq` is a shared, mutable `Rc<RefCell<..>>` handle, so a
+        // program can build a *cyclic* array (`a = []; a << a`).  The
+        // element-per-line flatten below recurses through nested arrays, so —
+        // like `format` — it MUST be cycle-guarded or a self-referential array
+        // overflows the native stack and aborts (a DoS: CWE-674, uncontrolled
+        // recursion).  We thread a `visited` set of the `Rc` handle addresses
+        // on the active flatten path (the same `seq_handle_id` key `format`
+        // uses); a handle removed on exit still flattens in full via a sibling
+        // path — only a true self-cycle is short-circuited.
+        let mut visited: std::collections::HashSet<usize> = std::collections::HashSet::new();
         for a in &args {
             // `puts []` (empty array arg) still writes one blank line — Ruby
             // prints a line when an argument flattens to nothing.  A
@@ -367,7 +377,7 @@ pub const RUNTIME: &str = r##"mod __sir {
                     continue;
                 }
             }
-            puts_one(a);
+            puts_one(a, &mut visited);
         }
         Value::Nil
     }
@@ -377,14 +387,35 @@ pub const RUNTIME: &str = r##"mod __sir {
     // newline — suppressed when the text already ends in one.  `nil` is a
     // blank line (`format(nil)` is "nil" for `print`, but `puts nil` is a
     // blank line, so nil is special-cased).
-    fn puts_one(v: &Value) {
+    //
+    // Cycle safety: `visited` holds the `Rc` addresses of the seqs currently
+    // on the active flatten path.  A seq ALREADY on the path is a cycle
+    // (`a = []; a << a`): rather than recurse forever we write Ruby's `[...]`
+    // placeholder then a newline, matching real Ruby (`puts a` on a self-
+    // referential array prints `[...]` and terminates).  (We emit the literal
+    // placeholder rather than `format(v)`: that formatter starts a fresh
+    // visited set, so it would render the *containing* level too — `[[...]]`
+    // for `a = [a]` — whereas Ruby prints a bare `[...]`.)  A seq reached twice
+    // by *sibling* (non-cyclic) paths is flattened in full both times because
+    // it is removed from `visited` on exit — only a handle re-appearing
+    // *within its own subtree* is short-circuited.  Non-cyclic output is
+    // unchanged (`puts [1,[2,3]]` still prints `1\n2\n3\n`).
+    fn puts_one(v: &Value, visited: &mut std::collections::HashSet<usize>) {
         if let Value::Seq(items) = v {
+            let id = seq_handle_id(items);
+            if !visited.insert(id) {
+                // Already on the active path ⇒ cycle: emit Ruby's `[...]`
+                // placeholder and a newline, then stop recursing.
+                println!("[...]");
+                return;
+            }
             // Clone the handle's items to avoid holding the borrow across the
             // recursive call (a nested seq re-borrows the same `RefCell`).
             let snapshot: Vec<Value> = items.borrow().clone();
             for item in &snapshot {
-                puts_one(item);
+                puts_one(item, visited);
             }
+            visited.remove(&id);
             return;
         }
         if matches!(v, Value::Nil) {

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_puts.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_puts.rs
@@ -19,8 +19,8 @@
 use std::process::Command;
 
 use semantic_ir::{
-    Block, Effect, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, Span,
-    Stmt,
+    Block, Effect, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, Scope,
+    Span, Stmt,
 };
 use semantic_ir_to_rust::compile;
 
@@ -34,6 +34,10 @@ fn ilit(v: i64) -> Expr {
 
 fn slit(v: &str) -> Expr {
     Expr::StrLit { value: v.into(), span: s() }
+}
+
+fn var(name: &str) -> Expr {
+    Expr::VarRef { name: name.into(), scope: Scope::Local, span: s() }
 }
 
 /// `puts(args…)` as an effectful statement (MayPrint, matching the frontend).
@@ -80,6 +84,51 @@ fn demo_module() -> Module {
     }
 }
 
+/// Build a module equivalent to the Ruby program
+///
+///     a = [nil]
+///     a[0] = a
+///     puts a
+///
+/// i.e. a *self-referential* array.  Real Ruby is cycle-aware: `puts a`
+/// prints `[...]` and terminates.  Before the cycle guard the emitted
+/// `puts_one` recursed per-element with no bound, so this program overflowed
+/// the native stack and aborted (CWE-674, uncontrolled recursion — a DoS).
+fn cyclic_module() -> Module {
+    let stmts = vec![
+        Stmt::LetBinding {
+            name: "a".into(),
+            sir_type: None,
+            value: Expr::SeqLit { items: vec![Expr::NilLit { span: s() }], span: s() },
+            span: s(),
+        },
+        Stmt::SeqSet { seq: var("a"), index: ilit(0), value: var("a"), span: s() },
+        puts_stmt(vec![var("a")]),
+    ];
+
+    Module {
+        name: "puts_cyclic".into(),
+        manifest: FeatureManifest::from_features(&[Feature::Sequences, Feature::Strings]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block { stmts, value: Expr::NilLit { span: s() }, span: s() },
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            metadata: Metadata::new(),
+            span: s(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("test")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
 fn rustc_available() -> bool {
     Command::new("rustc")
         .arg("--version")
@@ -88,20 +137,18 @@ fn rustc_available() -> bool {
         .unwrap_or(false)
 }
 
-#[test]
-fn puts_compiles_and_matches_ruby_output() {
-    if !rustc_available() {
-        eprintln!("skipping: rustc not on PATH");
-        return;
-    }
-
-    let artifact = compile(&demo_module()).expect("module should compile to Rust source");
+/// Compile `module` to Rust, build with `rustc`, run the binary, and return
+/// its normalised (CRLF→LF) stdout.  Returns `None` when the toolchain or a
+/// usable linker is unavailable (the caller then skips).  Panics on a genuine
+/// compile/run failure so a real regression is loud.
+fn compile_run(module: &Module, tag: &str) -> Option<String> {
+    let artifact = compile(module).expect("module should compile to Rust source");
 
     let dir = std::env::temp_dir();
     let nonce = std::process::id();
-    let src_path = dir.join(format!("sir_puts_{nonce}.rs"));
+    let src_path = dir.join(format!("sir_puts_{tag}_{nonce}.rs"));
     let bin_path = dir.join(format!(
-        "sir_puts_{nonce}{}",
+        "sir_puts_{tag}_{nonce}{}",
         if cfg!(windows) { ".exe" } else { "" }
     ));
     std::fs::write(&src_path, &artifact.source).expect("write temp source");
@@ -128,7 +175,7 @@ fn puts_compiles_and_matches_ruby_output() {
         {
             eprintln!("skipping: no usable linker on host\n{stderr}");
             let _ = std::fs::remove_file(&src_path);
-            return;
+            return None;
         }
         panic!(
             "emitted Rust failed to compile:\n--- stderr ---\n{stderr}\n--- source ---\n{}",
@@ -137,20 +184,46 @@ fn puts_compiles_and_matches_ruby_output() {
     }
 
     let run_out = Command::new(&bin_path).output().expect("run compiled binary");
-    assert!(
-        run_out.status.success(),
-        "compiled binary exited non-zero:\n{}",
-        String::from_utf8_lossy(&run_out.stderr),
-    );
-
-    // Exact byte-for-byte match against the Ruby reference output.
-    let stdout = String::from_utf8_lossy(&run_out.stdout);
-    let normalised = stdout.replace("\r\n", "\n");
-    assert_eq!(
-        normalised, "hello\n\n1\n2\n3\n",
-        "unexpected puts output; full stdout (escaped): {stdout:?}"
-    );
-
+    let stderr = String::from_utf8_lossy(&run_out.stderr).into_owned();
+    let stdout = String::from_utf8_lossy(&run_out.stdout).into_owned();
     let _ = std::fs::remove_file(&src_path);
     let _ = std::fs::remove_file(&bin_path);
+
+    // A stack-overflow abort (the pre-fix cyclic behaviour) exits non-zero;
+    // surface it as a test failure with the captured stderr.
+    assert!(
+        run_out.status.success(),
+        "compiled binary exited non-zero (should terminate cleanly):\n{stderr}",
+    );
+    Some(stdout.replace("\r\n", "\n"))
+}
+
+#[test]
+fn puts_compiles_and_matches_ruby_output() {
+    if !rustc_available() {
+        eprintln!("skipping: rustc not on PATH");
+        return;
+    }
+    let Some(out) = compile_run(&demo_module(), "demo") else { return };
+    // Exact byte-for-byte match against the Ruby reference output.
+    assert_eq!(
+        out, "hello\n\n1\n2\n3\n",
+        "unexpected puts output; full stdout (escaped): {out:?}"
+    );
+}
+
+/// Regression (security, CWE-674): `puts` on a self-referential array must
+/// TERMINATE — printing a `[...]` cycle placeholder like Ruby — rather than
+/// recursing until the native stack overflows and the process aborts.
+#[test]
+fn puts_cyclic_array_terminates() {
+    if !rustc_available() {
+        eprintln!("skipping: rustc not on PATH");
+        return;
+    }
+    let Some(out) = compile_run(&cyclic_module(), "cyclic") else { return };
+    assert_eq!(
+        out, "[...]\n",
+        "unexpected cyclic puts output; full stdout (escaped): {out:?}"
+    );
 }

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_puts.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_puts.rs
@@ -1,0 +1,156 @@
+//! End-to-end proof for the `puts` builtin (Ruby semantics) in the Rust
+//! backend.
+//!
+//! Ruby's `puts` is the most common output method, and its semantics are
+//! subtle enough that a *shape* assertion in a unit test is not enough — we
+//! must prove the emitted Rust actually produces the exact byte stream Ruby
+//! would.  This test hand-builds a SIR module equivalent to the Ruby program
+//!
+//!     puts "hello"
+//!     puts
+//!     puts [1, 2, 3]
+//!
+//! emits Rust, compiles it with `rustc`, runs the binary, and asserts stdout
+//! is **exactly** `hello\n\n1\n2\n3\n` — the Ruby reference output.
+//!
+//! Gates on `rustc` being available and degrades gracefully when the host
+//! linker is missing (mirrors `compile_and_run_loops.rs`).
+
+use std::process::Command;
+
+use semantic_ir::{
+    Block, Effect, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, Span,
+    Stmt,
+};
+use semantic_ir_to_rust::compile;
+
+fn s() -> Span {
+    Span::synthetic()
+}
+
+fn ilit(v: i64) -> Expr {
+    Expr::IntLit { value: v, span: s() }
+}
+
+fn slit(v: &str) -> Expr {
+    Expr::StrLit { value: v.into(), span: s() }
+}
+
+/// `puts(args…)` as an effectful statement (MayPrint, matching the frontend).
+fn puts_stmt(args: Vec<Expr>) -> Stmt {
+    Stmt::ExprStmt {
+        expr: Expr::BuiltinCall {
+            name: "puts".into(),
+            args,
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            span: s(),
+        },
+        span: s(),
+    }
+}
+
+/// Build a module whose `main` runs `puts "hello"; puts; puts [1,2,3]`.
+fn demo_module() -> Module {
+    let stmts = vec![
+        puts_stmt(vec![slit("hello")]),
+        puts_stmt(vec![]),
+        puts_stmt(vec![Expr::SeqLit { items: vec![ilit(1), ilit(2), ilit(3)], span: s() }]),
+    ];
+
+    Module {
+        name: "puts_demo".into(),
+        manifest: FeatureManifest::from_features(&[Feature::Sequences, Feature::Strings]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block { stmts, value: Expr::NilLit { span: s() }, span: s() },
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            metadata: Metadata::new(),
+            span: s(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("test")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+fn rustc_available() -> bool {
+    Command::new("rustc")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+#[test]
+fn puts_compiles_and_matches_ruby_output() {
+    if !rustc_available() {
+        eprintln!("skipping: rustc not on PATH");
+        return;
+    }
+
+    let artifact = compile(&demo_module()).expect("module should compile to Rust source");
+
+    let dir = std::env::temp_dir();
+    let nonce = std::process::id();
+    let src_path = dir.join(format!("sir_puts_{nonce}.rs"));
+    let bin_path = dir.join(format!(
+        "sir_puts_{nonce}{}",
+        if cfg!(windows) { ".exe" } else { "" }
+    ));
+    std::fs::write(&src_path, &artifact.source).expect("write temp source");
+
+    // `--edition 2021` matches the emitted runtime; an optional linker
+    // override lets hosts without the default linker point at `rust-lld`.
+    let mut cmd = Command::new("rustc");
+    cmd.arg("--edition").arg("2021").arg("-O");
+    if let Ok(linker) = std::env::var("SIR_TEST_RUSTC_LINKER") {
+        if !linker.is_empty() {
+            cmd.arg("-C").arg(format!("linker={linker}"));
+        }
+    }
+    let compile_out = cmd
+        .arg(&src_path)
+        .arg("-o")
+        .arg(&bin_path)
+        .output()
+        .expect("invoke rustc");
+    if !compile_out.status.success() {
+        let stderr = String::from_utf8_lossy(&compile_out.stderr);
+        if stderr.contains("linker")
+            && (stderr.contains("not found") || stderr.contains("No such file"))
+        {
+            eprintln!("skipping: no usable linker on host\n{stderr}");
+            let _ = std::fs::remove_file(&src_path);
+            return;
+        }
+        panic!(
+            "emitted Rust failed to compile:\n--- stderr ---\n{stderr}\n--- source ---\n{}",
+            artifact.source,
+        );
+    }
+
+    let run_out = Command::new(&bin_path).output().expect("run compiled binary");
+    assert!(
+        run_out.status.success(),
+        "compiled binary exited non-zero:\n{}",
+        String::from_utf8_lossy(&run_out.stderr),
+    );
+
+    // Exact byte-for-byte match against the Ruby reference output.
+    let stdout = String::from_utf8_lossy(&run_out.stdout);
+    let normalised = stdout.replace("\r\n", "\n");
+    assert_eq!(
+        normalised, "hello\n\n1\n2\n3\n",
+        "unexpected puts output; full stdout (escaped): {stdout:?}"
+    );
+
+    let _ = std::fs::remove_file(&src_path);
+    let _ = std::fs::remove_file(&bin_path);
+}

--- a/code/packages/rust/semantic-ir-to-typescript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-typescript/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.6.0 — `puts` builtin (Ruby semantics)
+
+### Added
+
+- `puts` now maps **directly** to the variadic runtime helper `__Sir.puts(...)`
+  (like `print` → `__Sir.print`) instead of routing through the generic
+  `__Sir.callBuiltin("puts", […])` dispatch. This is possible now that
+  `@coding-adventures/sir-runtime-core` implements Ruby `puts` semantics
+  (string+newline, no-arg → one newline, arrays flattened element-per-line,
+  trailing-newline suppression).
+- Execution proof `run_with_node.rs::end_to_end_ruby_puts_executes_ts` lowers
+  real Ruby `puts "hi"` through `ruby-to-semantic-ir`, compiles to TypeScript,
+  and runs the result under `node`, asserting stdout is exactly `hi\n`.
+
 ## Unreleased
 
 ### Tests (O2 — Ruby OOP end-to-end execution proof)

--- a/code/packages/rust/semantic-ir-to-typescript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-typescript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-typescript"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "Semantic IR → self-contained TypeScript source code (SIR12). First backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
@@ -1582,6 +1582,9 @@ fn emit_builtin_call(out: &mut String, name: &str, args: &[Expr], indent: usize)
         "number?" => "__Sir.isNumber",
         "symbol?" => "__Sir.isSymbol",
         "print" => "__Sir.print",
+        // `puts` is variadic in the runtime (`puts(...args)`), so a direct
+        // `__Sir.puts(a, b)` forwards every argument (Ruby `puts a, b`).
+        "puts" => "__Sir.puts",
         "global_set" => "__Sir.globalSet",
         "global_get" => "__Sir.globalGet",
         // Unknown builtin: route through the dispatch table.  This

--- a/code/packages/rust/semantic-ir-to-typescript/tests/run_with_node.rs
+++ b/code/packages/rust/semantic-ir-to-typescript/tests/run_with_node.rs
@@ -964,3 +964,75 @@ fn end_to_end_ruby_oop_new_and_dispatch_executes_ts() {
     assert_eq!(stdout, "Rex says woof", "P1 OOP dispatch produced wrong output under node");
 }
 
+
+// ── End-to-end: Ruby `puts` → TypeScript → node ────────────────────────
+//
+// Proves the Ruby frontend's `puts` (a `BuiltinCall("puts", …)`) drives the
+// runtime-core `puts` through the TypeScript backend end-to-end.  As with the
+// other node proofs, the workspace runtime package can't be resolved under
+// bare `node`, so the runtime import is swapped for a faithful inline stub
+// implementing Ruby `puts` semantics (string+newline, no-arg → one newline).
+
+/// A `__Sir` stub whose `puts` mirrors the real runtime-core: variadic,
+/// writes each string arg + "\n" via process.stdout.write (so the exact byte
+/// stream — including a trailing blank line — is observable), and a no-arg
+/// `puts` writes one newline.
+const SIR_PUTS_STUB: &str = r#"const __Sir = {
+  toDisplay: (v) => (v === null ? "nil" : String(v)),
+  puts: (...args) => {
+    if (args.length === 0) { process.stdout.write("\n"); return null; }
+    for (const a of args) {
+      const t = __Sir.toDisplay(a);
+      process.stdout.write(t.endsWith("\n") ? t : t + "\n");
+    }
+    return null;
+  },
+};
+"#;
+
+fn ruby_puts_ts_to_runnable_js(ts: &str) -> String {
+    let mut js = ts.to_string();
+    js = js.replace(
+        "import * as __Sir from \"@coding-adventures/sir-runtime-core\";\n",
+        SIR_PUTS_STUB,
+    );
+    js = js.replace(" as { [k: string]: __Sir.Val }", "");
+    js = js.replace(": __Sir.Val[]", "");
+    js = js.replace(": __Sir.Val", "");
+    js
+}
+
+#[test]
+fn end_to_end_ruby_puts_executes_ts() {
+    // `puts "hi"` lowered from real Ruby → TS → node must print exactly
+    // `hi\n` (Ruby's string+newline semantics).
+    let module = ruby_to_semantic_ir::compile_source("puts \"hi\"\n", "demo")
+        .expect("lower ruby");
+    let artifact = compile(&module).expect("compile to typescript");
+
+    // Shape: `puts` maps to the variadic `__Sir.puts(...)` helper.
+    assert!(
+        artifact.source.contains("__Sir.puts(\"hi\")"),
+        "expected puts to map to __Sir.puts; got:\n{}",
+        artifact.source
+    );
+
+    if !node_available() {
+        eprintln!("note: `node` unavailable — skipping Ruby puts TS execution proof");
+        return;
+    }
+    let js = ruby_puts_ts_to_runnable_js(&artifact.source);
+    let mut path: PathBuf = std::env::temp_dir();
+    path.push(format!("sir_ts_ruby_puts_{}.js", std::process::id()));
+    std::fs::write(&path, &js).expect("write temp js");
+    let output = Command::new("node").arg(&path).output().expect("spawn node");
+    let _ = std::fs::remove_file(&path);
+    assert!(
+        output.status.success(),
+        "node exited non-zero:\nstderr: {}\nsource:\n{}",
+        String::from_utf8_lossy(&output.stderr),
+        js
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout).replace("\r\n", "\n");
+    assert_eq!(stdout, "hi\n", "Ruby `puts \"hi\"` should print `hi` + newline");
+}

--- a/code/packages/typescript/sir-runtime-core/CHANGELOG.md
+++ b/code/packages/typescript/sir-runtime-core/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to `@coding-adventures/sir-runtime-core` are documented here.
 
+## [0.1.7] - 2026-07-01
+
+### Security — cycle-guard the `puts` array flatten (CWE-674)
+
+- `putsOne` flattened arrays by recursing per element with **no bound**. An
+  array is a shared, mutable reference, so a translated program can build a
+  self-referential array (`a = []; a << a; puts a`) or a pathologically deep
+  one; the unguarded recursion threw `RangeError: Maximum call stack size
+  exceeded` — a denial of service (uncontrolled recursion). `putsOne` / `puts`
+  now thread a `Set` of the array references on the active flatten path: an
+  array re-encountered within its own subtree is a cycle and is written as
+  Ruby's `[...]` placeholder + newline instead of recursing, so `puts a` on a
+  self-referential array now **terminates** exactly as real Ruby does.
+  Non-cyclic output is unchanged (`puts([1, [2, 3]])` → `1\n2\n3\n`); new
+  regression tests cover the self-referential and mutually-recursive cases.
+- Bumps `package.json` to `0.1.7`.
+
 ## [0.1.6] - 2026-07-01
 
 ### Added (`puts` — Ruby's most common output method)

--- a/code/packages/typescript/sir-runtime-core/CHANGELOG.md
+++ b/code/packages/typescript/sir-runtime-core/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to `@coding-adventures/sir-runtime-core` are documented here.
 
+## [0.1.6] - 2026-07-01
+
+### Added (`puts` — Ruby's most common output method)
+
+- New `puts(...args)` implementing Ruby `puts` semantics, and a `"puts"` entry
+  in the builtin dispatch table (so backends that route builtins by name reach
+  it). Exported from the package root.
+- Semantics, matching Ruby exactly:
+  - `puts()` (no args) → a single newline.
+  - `puts(x)` → `x` + newline, **unless** the rendered text already ends in
+    `"\n"` (then no second newline: `puts("x\n")` writes `x\n`, not `x\n\n`).
+  - `puts(a, b)` → each argument on its own line, in order.
+  - `puts([])` → a single newline (an argument that flattens to nothing still
+    writes a blank line).
+  - `puts([1, [2, 3]])` → each **element** on its own line, arrays flattened
+    recursively (`1\n2\n3\n`).
+  - `puts(null)` → a blank line (not the display form `"nil"`).
+- Writes via `process.stdout.write` (not `console.log`) so the
+  trailing-newline suppression rule can be honoured. Reuses `toDisplay` for
+  element rendering.
+
 ## [0.1.5] - 2026-06-21
 
 ### Added (Q10f — call-position `**h` merge helper)

--- a/code/packages/typescript/sir-runtime-core/README.md
+++ b/code/packages/typescript/sir-runtime-core/README.md
@@ -16,6 +16,7 @@ namespace into every file:
 | `Sym` / `intern` | Interned identity objects; JS has no symbol *value* type with names. |
 | `Pair` / `cons` / `car` / `cdr` | Lisp cons cells; no native type. |
 | `eq`, `toDisplay`, `print` | Symbol-aware equality and Lisp/Ruby display (`nil`, `#t`/`#f`). |
+| `puts` | Ruby `puts`: per-arg line, arrays flattened element-per-line, no double trailing newline, no-arg → one newline. |
 | `add`/`sub`/`mul`/`div`, `lt`/`gt` | Variadic folds + truncating-integer `/`. |
 | `Closure`/`apply`/`makeClosure`, global store, builtin dispatch | Uniform closure handles + SIR `Globals`. |
 

--- a/code/packages/typescript/sir-runtime-core/package-lock.json
+++ b/code/packages/typescript/sir-runtime-core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coding-adventures/sir-runtime-core",
-  "version": "0.1.3",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coding-adventures/sir-runtime-core",
-      "version": "0.1.3",
+      "version": "0.1.6",
       "license": "MIT",
       "dependencies": {
         "@coding-adventures/sir-runtime-pairs": "file:../sir-runtime-pairs"

--- a/code/packages/typescript/sir-runtime-core/package-lock.json
+++ b/code/packages/typescript/sir-runtime-core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coding-adventures/sir-runtime-core",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coding-adventures/sir-runtime-core",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "license": "MIT",
       "dependencies": {
         "@coding-adventures/sir-runtime-pairs": "file:../sir-runtime-pairs"

--- a/code/packages/typescript/sir-runtime-core/package.json
+++ b/code/packages/typescript/sir-runtime-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/sir-runtime-core",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Core runtime for Semantic-IR-emitted TypeScript/JavaScript — SIR truthiness, symbols, pairs, equality, display, arithmetic, closures, globals",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/sir-runtime-core/package.json
+++ b/code/packages/typescript/sir-runtime-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/sir-runtime-core",
-  "version": "0.1.3",
+  "version": "0.1.6",
   "description": "Core runtime for Semantic-IR-emitted TypeScript/JavaScript — SIR truthiness, symbols, pairs, equality, display, arithmetic, closures, globals",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/sir-runtime-core/src/index.ts
+++ b/code/packages/typescript/sir-runtime-core/src/index.ts
@@ -31,6 +31,7 @@ export {
   globalGet,
   globalGetStatic,
   print,
+  puts,
   callBuiltin,
   builtinClosure,
   doubleSplatMerge,

--- a/code/packages/typescript/sir-runtime-core/src/runtime.ts
+++ b/code/packages/typescript/sir-runtime-core/src/runtime.ts
@@ -107,6 +107,68 @@ export function print(v: Val): null {
   return null;
 }
 
+/**
+ * Emit a single `puts` argument, honouring Ruby's per-value rules.
+ *
+ * Ruby `puts` is deceptively subtle. For one argument:
+ * - **Array** → recurse over the *elements*, one per line, flattening
+ *   nesting (`puts [1, [2, 3]]` → `1\n2\n3\n`). An **empty** array writes
+ *   nothing here (the top-level `puts []` still emits one newline — see
+ *   {@link puts}).
+ * - **nil** → a blank line (`nil.to_s` is `""`, then the newline).
+ * - **anything else** → its display string then a newline, *unless* the
+ *   string already ends in `"\n"`, in which case Ruby does not add a second
+ *   (`puts "x\n"` → `x\n`, not `x\n\n`).
+ *
+ * We write via `process.stdout.write` rather than `console.log` because
+ * `console.log` unconditionally appends its own newline, which would defeat
+ * the trailing-newline suppression rule.
+ */
+function putsOne(v: Val): void {
+  if (Array.isArray(v)) {
+    for (const item of v) {
+      putsOne(item);
+    }
+    return;
+  }
+  if (v === null) {
+    process.stdout.write("\n");
+    return;
+  }
+  const text = toDisplay(v);
+  // Suppress the added newline when the rendered text already ends in one,
+  // so `puts "x\n"` and `puts "x"` produce identical output.
+  process.stdout.write(text.endsWith("\n") ? text : text + "\n");
+}
+
+/**
+ * Ruby `puts`: write each argument on its own line (see {@link putsOne}).
+ *
+ * - `puts()` (no args) → a single newline.
+ * - `puts(x)` → `x` on its own line (arrays flattened element-per-line; a
+ *   value already ending in `"\n"` is not double-spaced; `nil` is a blank
+ *   line).
+ * - `puts(a, b)` → each argument handled independently, in order.
+ * - `puts([])` → a single newline: Ruby prints a blank line when an argument
+ *   flattens to nothing, which is why the no-arg and empty-array cases
+ *   converge on one newline.
+ */
+export function puts(...args: Val[]): null {
+  if (args.length === 0) {
+    process.stdout.write("\n");
+    return null;
+  }
+  for (const a of args) {
+    if (Array.isArray(a) && a.length === 0) {
+      // Empty array as an argument still writes one newline.
+      process.stdout.write("\n");
+    } else {
+      putsOne(a);
+    }
+  }
+  return null;
+}
+
 // --- Builtin dispatch ------------------------------------------------------
 
 const builtins: Record<string, (...args: Val[]) => Val> = {
@@ -125,6 +187,7 @@ const builtins: Record<string, (...args: Val[]) => Val> = {
   "number?": (v) => isNumber(v!),
   "symbol?": (v) => isSymbol(v!),
   print: (v) => print(v!),
+  puts: (...args) => puts(...args),
 };
 
 /** Invoke a builtin by SIR name with a list of arguments. */

--- a/code/packages/typescript/sir-runtime-core/src/runtime.ts
+++ b/code/packages/typescript/sir-runtime-core/src/runtime.ts
@@ -123,12 +123,30 @@ export function print(v: Val): null {
  * We write via `process.stdout.write` rather than `console.log` because
  * `console.log` unconditionally appends its own newline, which would defeat
  * the trailing-newline suppression rule.
+ *
+ * **Cycle safety.** An array is a shared, mutable reference, so a program can
+ * build a *cyclic* array (`a = []; a << a`). The element-per-line flatten
+ * recurses through nested arrays, so it MUST be cycle-guarded or a self-
+ * referential array throws `RangeError: Maximum call stack size exceeded` (a
+ * DoS: CWE-674, uncontrolled recursion). `seen` is a `Set` of the array
+ * references currently on the active flatten path. An array ALREADY on the
+ * path is a cycle: rather than recurse forever we write `[...]` then a newline
+ * — matching real Ruby, where `puts a` on a self-referential array prints
+ * `[...]` and terminates. An array removed from `seen` on exit still flattens
+ * in full via a sibling path — only a true self-cycle is short-circuited, so
+ * non-cyclic output is unchanged (`puts [1, [2, 3]]` still prints `1\n2\n3\n`).
  */
-function putsOne(v: Val): void {
+function putsOne(v: Val, seen: Set<unknown>): void {
   if (Array.isArray(v)) {
-    for (const item of v) {
-      putsOne(item);
+    if (seen.has(v)) {
+      process.stdout.write("[...]\n");
+      return;
     }
+    seen.add(v);
+    for (const item of v) {
+      putsOne(item, seen);
+    }
+    seen.delete(v);
     return;
   }
   if (v === null) {
@@ -158,12 +176,13 @@ export function puts(...args: Val[]): null {
     process.stdout.write("\n");
     return null;
   }
+  const seen = new Set<unknown>();
   for (const a of args) {
     if (Array.isArray(a) && a.length === 0) {
       // Empty array as an argument still writes one newline.
       process.stdout.write("\n");
     } else {
-      putsOne(a);
+      putsOne(a, seen);
     }
   }
   return null;

--- a/code/packages/typescript/sir-runtime-core/tests/core.test.ts
+++ b/code/packages/typescript/sir-runtime-core/tests/core.test.ts
@@ -143,6 +143,29 @@ describe("puts (Ruby semantics)", () => {
       "hi\n",
     );
   });
+
+  it("terminates on a self-referential array (cycle-guarded, CWE-674)", () => {
+    // `a = []; a << a; puts a` in Ruby prints `[...]` and terminates.  Without
+    // the cycle guard the element-per-line flatten recurses forever and throws
+    // `RangeError: Maximum call stack size exceeded` (a DoS).  The guard must
+    // both terminate AND render the cycle as `[...]`, matching Ruby.
+    const a: unknown[] = [];
+    a.push(a);
+    expect(capture(() => sir.puts(a))).toBe("[...]\n");
+  });
+
+  it("terminates on a mutually-recursive array pair", () => {
+    // Two arrays referencing each other (a -> b -> a) still forms a cycle on
+    // the flatten path; both must render `[...]` at the back-reference rather
+    // than diverging.  `puts a` flattens a's element (b), then b's element (a),
+    // which is already on the path → `[...]`.
+    const a: unknown[] = [];
+    const b: unknown[] = [a];
+    a.push(b);
+    // a = [b], b = [a].  puts a: flatten a → element b (array, not seen) →
+    // flatten b → element a (already on path) → `[...]`.
+    expect(capture(() => sir.puts(a))).toBe("[...]\n");
+  });
 });
 
 describe("arithmetic", () => {

--- a/code/packages/typescript/sir-runtime-core/tests/core.test.ts
+++ b/code/packages/typescript/sir-runtime-core/tests/core.test.ts
@@ -79,6 +79,72 @@ describe("predicates and display", () => {
   });
 });
 
+describe("puts (Ruby semantics)", () => {
+  // `puts` writes via process.stdout.write (not console.log) so the
+  // trailing-newline-suppression rule can be honoured; capture that stream.
+  function capture(fn: () => void): string {
+    let out = "";
+    const spy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation((chunk: string | Uint8Array): boolean => {
+        out += String(chunk);
+        return true;
+      });
+    try {
+      fn();
+    } finally {
+      spy.mockRestore();
+    }
+    return out;
+  }
+
+  it("no args prints a single newline", () => {
+    expect(capture(() => expect(sir.puts()).toBe(null))).toBe("\n");
+  });
+
+  it("a string is followed by a newline", () => {
+    expect(capture(() => sir.puts("hello"))).toBe("hello\n");
+  });
+
+  it("does not double a trailing newline", () => {
+    expect(capture(() => sir.puts("x\n"))).toBe("x\n");
+  });
+
+  it("multiple args go one per line", () => {
+    expect(capture(() => sir.puts("a", "b"))).toBe("a\nb\n");
+  });
+
+  it("an array is flattened, one element per line", () => {
+    expect(capture(() => sir.puts([1, 2, 3]))).toBe("1\n2\n3\n");
+    expect(capture(() => sir.puts([1, [2, 3]]))).toBe("1\n2\n3\n");
+  });
+
+  it("an empty array prints a single newline", () => {
+    expect(capture(() => sir.puts([]))).toBe("\n");
+  });
+
+  it("nil prints a blank line (not the display form)", () => {
+    expect(capture(() => sir.puts(null))).toBe("\n");
+  });
+
+  it("matches the reference program output", () => {
+    // `puts "hello"; puts; puts [1,2,3]`
+    expect(
+      capture(() => {
+        sir.puts("hello");
+        sir.puts();
+        sir.puts([1, 2, 3]);
+      }),
+    ).toBe("hello\n\n1\n2\n3\n");
+  });
+
+  it("routes through callBuiltin by name", () => {
+    expect(capture(() => expect(sir.callBuiltin("puts", ["hi"])).toBe(null))).toBe(
+      "hi\n",
+    );
+  });
+});
+
 describe("arithmetic", () => {
   it("variadic", () => {
     expect(sir.add(1, 2, 3)).toBe(6);


### PR DESCRIPTION
## What

Adds Ruby's `puts` — the most common output method — to all 5 backend runtimes with faithful semantics. The Ruby frontend already emitted `BuiltinCall("puts", args)`; the gap was purely runtime (only `print` was cataloged, so `puts` hit the unknown-builtin floor and panicked/threw).

**Semantics:** `puts` → one newline; `puts x` → `x.to_s` + `\n` (no double newline if already newline-terminated); `puts a, b` → each on its own line; `puts [1,2,3]` → each **element** on its own line (arrays flattened recursively); `puts nil` → blank line.

Implemented in Python `sir-runtime-core` (`sir_puts`), TS `sir-runtime-core` (`puts`), and the inline Go/Rust/JS runtimes; backend emit arms map `puts`→the runtime fn.

## Security hardening (review-caught, fixed in this PR)

The initial array-flatten recursion was **unguarded** → a self-referential array (`a=[]; a<<a; puts a`) or pathological nesting overflowed the stack (CWE-674, all 5 backends). Fixed with an **identity-set cycle guard** on the flatten path in every backend (Go `*Seq` ptr set, Rust `Rc::as_ptr` set, JS/TS array-ref `Set`, Python `id()` set); handles removed on exit so sibling (non-cyclic) reuse still flattens. A self-referential array now prints `[...]` and terminates — matching Ruby. Regression tests (self-referential + mutually-recursive) added per backend.

## Verification

- Go **110**, Rust **114 unit + integration**, JS **27 node**, Python backend **92**, TS backend **99**; Python `sir-runtime-core` pytest **52** (98.9% cov, ruff+mypy clean); TS vitest **35**.
- **Execution-proof (all toolchains):** `puts "hello"; puts; puts [1,2,3]` → `hello\n\n1\n2\n3\n` exactly (Go/Rust/JS via native run; Python/TS via Ruby→backend e2e). Cyclic-array regression terminates with `[...]`.
- Clippy clean; `cargo build --workspace` clean (bar pre-existing Unix-only crate).
- Security-reviewed; the DoS finding is fixed + regression-tested.

Note: a pre-existing TS `sir-runtime-core` `tsc --noEmit` `@types/node` gap (unrelated, fails identically on base) is flagged for a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)