### PR TITLE
Retire redundant paragraph trailing block repair

### DIFF
--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -8620,10 +8620,6 @@ fn repair_tricky_adoption_agency_in(nodes: &mut Vec<Node>) {
             repair_tricky_adoption_agency_in(&mut element.children);
         }
 
-        if repair_paragraph_trailing_block_continuation(nodes, index) {
-            index += 1;
-            continue;
-        }
         if repair_paragraph_inside_previous_font_continuation(nodes, index) {
             continue;
         }
@@ -8636,49 +8632,6 @@ fn repair_tricky_adoption_agency_in(nodes: &mut Vec<Node>) {
         }
         index += 1;
     }
-}
-
-fn repair_paragraph_trailing_block_continuation(nodes: &mut Vec<Node>, index: usize) -> bool {
-    let Some(Node::Element(paragraph)) = nodes.get_mut(index) else {
-        return false;
-    };
-    if paragraph.name != "p" {
-        return false;
-    }
-
-    let Some(block_index) = paragraph
-        .children
-        .iter()
-        .position(|child| matches!(child, Node::Element(element) if element.name == "b"))
-    else {
-        return false;
-    };
-    let trailing_newline = block_index
-        .checked_sub(1)
-        .and_then(|text_index| split_tail_text(&mut paragraph.children[..=text_index], "\n"))
-        .map(Node::text);
-    let Some(trailing_newline) = trailing_newline else {
-        return false;
-    };
-
-    let mut continuation = paragraph.children.split_off(block_index);
-    continuation.insert(0, trailing_newline);
-    for (offset, node) in continuation.into_iter().enumerate() {
-        nodes.insert(index + 1 + offset, node);
-    }
-    true
-}
-
-fn split_tail_text(nodes: &mut [Node], tail: &str) -> Option<String> {
-    let Node::Text(text) = nodes.last_mut()? else {
-        return None;
-    };
-    if !text.data.ends_with(tail) {
-        return None;
-    }
-    let keep_len = text.data.len() - tail.len();
-    text.data.truncate(keep_len);
-    Some(tail.to_string())
 }
 
 fn repair_paragraph_inside_previous_font_continuation(nodes: &mut Vec<Node>, index: usize) -> bool {

--- a/code/packages/rust/html-parser/tests/whatwg_block_boundary_audit_test.rs
+++ b/code/packages/rust/html-parser/tests/whatwg_block_boundary_audit_test.rs
@@ -5,8 +5,7 @@ use serde::Deserialize;
 use std::collections::{BTreeMap, HashMap};
 
 const TREE_CONSTRUCTION_SMOKE: &str = include_str!("fixtures/html5lib-tree-construction-smoke.dat");
-const WHATWG_BLOCK_BOUNDARY_AUDIT: &str =
-    include_str!("fixtures/whatwg-block-boundary-audit.json");
+const WHATWG_BLOCK_BOUNDARY_AUDIT: &str = include_str!("fixtures/whatwg-block-boundary-audit.json");
 const POST_PARSE_REPAIR_EVIDENCE: &[(&str, &str)] = &[
     ("tricky01-dat-5", "block-formatting-boundary"),
     ("tricky01-dat-6", "block-table-boundary"),

--- a/code/packages/rust/html-parser/tests/whatwg_document_shell_audit_test.rs
+++ b/code/packages/rust/html-parser/tests/whatwg_document_shell_audit_test.rs
@@ -5,8 +5,7 @@ use serde::Deserialize;
 use std::collections::{BTreeMap, HashMap};
 
 const TREE_CONSTRUCTION_SMOKE: &str = include_str!("fixtures/html5lib-tree-construction-smoke.dat");
-const WHATWG_DOCUMENT_SHELL_AUDIT: &str =
-    include_str!("fixtures/whatwg-document-shell-audit.json");
+const WHATWG_DOCUMENT_SHELL_AUDIT: &str = include_str!("fixtures/whatwg-document-shell-audit.json");
 const POST_PARSE_REPAIR_EVIDENCE: &[(&str, &str)] = &[
     ("tricky01-dat-3", "html-element-boundary"),
     ("tests26-dat-1251", "body-frameset-boundary"),

--- a/code/packages/rust/html-parser/tests/whatwg_frameset_audit_test.rs
+++ b/code/packages/rust/html-parser/tests/whatwg_frameset_audit_test.rs
@@ -120,8 +120,7 @@ fn whatwg_frameset_audit_tracks_post_parse_repair_evidence() {
 }
 
 fn load_suite() -> FramesetAuditSuite {
-    serde_json::from_str(WHATWG_FRAMESET_AUDIT)
-        .expect("WHATWG frameset audit fixture should parse")
+    serde_json::from_str(WHATWG_FRAMESET_AUDIT).expect("WHATWG frameset audit fixture should parse")
 }
 
 fn assert_axis_count(suite: &FramesetAuditSuite, axis: &str, minimum: usize) {

--- a/code/packages/rust/html-parser/tests/whatwg_legacy_element_audit_test.rs
+++ b/code/packages/rust/html-parser/tests/whatwg_legacy_element_audit_test.rs
@@ -5,8 +5,7 @@ use serde::Deserialize;
 use std::collections::{BTreeMap, HashMap};
 
 const TREE_CONSTRUCTION_SMOKE: &str = include_str!("fixtures/html5lib-tree-construction-smoke.dat");
-const WHATWG_LEGACY_ELEMENT_AUDIT: &str =
-    include_str!("fixtures/whatwg-legacy-element-audit.json");
+const WHATWG_LEGACY_ELEMENT_AUDIT: &str = include_str!("fixtures/whatwg-legacy-element-audit.json");
 const POST_PARSE_REPAIR_EVIDENCE: &[(&str, &str)] = &[
     ("tricky01-dat-3", "tricky-parser-recovery"),
     ("tricky01-dat-8", "tricky-parser-recovery"),

--- a/code/packages/rust/html-parser/tests/whatwg_misc_recovery_audit_test.rs
+++ b/code/packages/rust/html-parser/tests/whatwg_misc_recovery_audit_test.rs
@@ -5,8 +5,7 @@ use serde::Deserialize;
 use std::collections::{BTreeMap, HashMap};
 
 const TREE_CONSTRUCTION_SMOKE: &str = include_str!("fixtures/html5lib-tree-construction-smoke.dat");
-const WHATWG_MISC_RECOVERY_AUDIT: &str =
-    include_str!("fixtures/whatwg-misc-recovery-audit.json");
+const WHATWG_MISC_RECOVERY_AUDIT: &str = include_str!("fixtures/whatwg-misc-recovery-audit.json");
 const POST_PARSE_REPAIR_EVIDENCE: &[(&str, &str, &str)] = &[
     (
         "comments01-dat-79",

--- a/code/packages/rust/html-parser/tests/whatwg_template_audit_test.rs
+++ b/code/packages/rust/html-parser/tests/whatwg_template_audit_test.rs
@@ -124,8 +124,7 @@ fn whatwg_template_audit_tracks_post_parse_repair_evidence() {
 }
 
 fn load_suite() -> TemplateAuditSuite {
-    serde_json::from_str(WHATWG_TEMPLATE_AUDIT)
-        .expect("WHATWG template audit fixture should parse")
+    serde_json::from_str(WHATWG_TEMPLATE_AUDIT).expect("WHATWG template audit fixture should parse")
 }
 
 fn assert_axis_count(suite: &TemplateAuditSuite, axis: &str, minimum: usize) {

--- a/code/packages/rust/html-parser/tests/whatwg_text_control_audit_test.rs
+++ b/code/packages/rust/html-parser/tests/whatwg_text_control_audit_test.rs
@@ -5,8 +5,7 @@ use serde::Deserialize;
 use std::collections::{BTreeMap, HashMap};
 
 const TREE_CONSTRUCTION_SMOKE: &str = include_str!("fixtures/html5lib-tree-construction-smoke.dat");
-const WHATWG_TEXT_CONTROL_AUDIT: &str =
-    include_str!("fixtures/whatwg-text-control-audit.json");
+const WHATWG_TEXT_CONTROL_AUDIT: &str = include_str!("fixtures/whatwg-text-control-audit.json");
 const POST_PARSE_REPAIR_EVIDENCE: &[(&str, &str)] = &[
     ("scripted-ark-dat-1", "script-rawtext"),
     ("scripted-webkit01-dat-2", "script-rawtext"),


### PR DESCRIPTION
## Summary
- remove the now-redundant `repair_paragraph_trailing_block_continuation` post-parse branch and its private text-splitting helper
- keep the remaining adoption-agency repair pass intact, relying on the executable WHATWG/html5lib evidence to prove the paragraph continuation path is no longer needed
- let rustfmt normalize nearby generated audit test `include_str!` constants

## Validation
- `cargo test -p coding-adventures-html-parser font_newline_before_bold_stays_outside_reconstructed_font`
- focused parser matrix: 40 WHATWG/html5lib audit filters
- `cargo test -p coding-adventures-html-parser`
- `CARGO_BUILD_JOBS=2 cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser`
- `python3 -m json.tool code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json >/dev/null`
- `python3 code/packages/rust/html-parser/tests/fixtures/check_whatwg_audit_rust_tests.py --check`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py`
- `git diff --check`
