### PR TITLE
feat(latex): rest of the trig family (inverse / hyperbolic / reciprocal) → ComputeOp

### DIFF
--- a/code/packages/rust/adj-lang/CHANGELOG.md
+++ b/code/packages/rust/adj-lang/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [0.27.0] - 2026-07-02 — rest of the trig family in `latex "…"` (`\arcsin`…/`\sinh`…/`\cot`/`\sec`/`\csc`)
+
+### Added
+
+- The `latex "…"` adapter now lowers the **inverse** (`\arcsin`/`\arccos`/`\arctan`),
+  **hyperbolic** (`\sinh`/`\cosh`/`\tanh`), and **reciprocal** (`\cot`/`\sec`/`\csc`)
+  trig functions to their native transcendental `ComputeOp`s via the existing
+  `ExprAst::Call` / `NamedFn` mechanism — the `Func` variants the latex frontend
+  already parses but the adapter previously rejected as "not yet supported". No
+  latex-crate change; each is a `Scalar → Scalar` call.
+
+### Notes
+
+- The remaining `Func` variants are still a clean, explicit adapter error: the
+  aggregate/multi-arg `min`/`max`/`gcd`/`lcm`/`det` (await a binary/variadic slice)
+  and an unknown `Other` such as `\operatorname{trunc}` (truncation awaits faithful
+  `\operatorname{…}(x)` juxtaposition handling).
+
 ## [0.26.0] - 2026-07-02 — named transcendental functions in `latex "…"` (`\sin`/`\cos`/`\tan`/`\ln`/`\log`/`\exp`)
 
 ### Added

--- a/code/packages/rust/adj-lang/Cargo.toml
+++ b/code/packages/rust/adj-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2021"
 description = "Surface-syntax frontend for the adjudication framework's probabilistic-logic rulebooks. Lexes, parses, and lowers a domain-expert-readable DSL into a `logic-engine` KnowledgeBase. Dissolves ADJ46 awkwardness items A10 (rulebook syntax) and A4 (joint contributions syntactically distinct)."
 

--- a/code/packages/rust/adj-lang/src/adapter.rs
+++ b/code/packages/rust/adj-lang/src/adapter.rs
@@ -1012,9 +1012,10 @@ fn latex_math_to_expr_ast(expr: &MathExpr, source: &str) -> Result<ExprAst, Adap
         // A named-function call `\sin(x)`, `\ln(x)`, `\exp(x)`, … lowers to the
         // matching native transcendental op via `ExprAst::Call`. Only the curated
         // single-argument transcendental set is supported; the other `Func`
-        // variants (min/max/gcd/lcm/det, the inverse and hyperbolic trig, and an
-        // unknown `Other`) have no single-argument scalar lowering yet and are a
-        // clean, explicit error rather than a silent mis-lowering.
+        // variants (the aggregate/multi-arg `min`/`max`/`gcd`/`lcm`/`det` and an
+        // unknown `Other` such as `\operatorname{trunc}`) have no single-argument
+        // scalar lowering yet and are a clean, explicit error rather than a silent
+        // mis-lowering.
         MathExpr::Call { func, arg } => {
             let named = match func {
                 Func::Sin => NamedFn::Sin,
@@ -1023,6 +1024,15 @@ fn latex_math_to_expr_ast(expr: &MathExpr, source: &str) -> Result<ExprAst, Adap
                 Func::Ln => NamedFn::Ln,
                 Func::Log => NamedFn::Log,
                 Func::Exp => NamedFn::Exp,
+                Func::Asin => NamedFn::Asin,
+                Func::Acos => NamedFn::Acos,
+                Func::Atan => NamedFn::Atan,
+                Func::Sinh => NamedFn::Sinh,
+                Func::Cosh => NamedFn::Cosh,
+                Func::Tanh => NamedFn::Tanh,
+                Func::Cot => NamedFn::Cot,
+                Func::Sec => NamedFn::Sec,
+                Func::Csc => NamedFn::Csc,
                 other => {
                     return Err(AdapterError::UnsupportedLatexMath {
                         source: source.to_string(),

--- a/code/packages/rust/adj-lang/src/ast.rs
+++ b/code/packages/rust/adj-lang/src/ast.rs
@@ -97,6 +97,24 @@ pub enum NamedFn {
     Log,
     /// Exponential, `e^x` (`\exp`).
     Exp,
+    /// Inverse sine (`\arcsin`).
+    Asin,
+    /// Inverse cosine (`\arccos`).
+    Acos,
+    /// Inverse tangent (`\arctan`).
+    Atan,
+    /// Hyperbolic sine (`\sinh`).
+    Sinh,
+    /// Hyperbolic cosine (`\cosh`).
+    Cosh,
+    /// Hyperbolic tangent (`\tanh`).
+    Tanh,
+    /// Cotangent, cos/sin (`\cot`).
+    Cot,
+    /// Secant, 1/cos (`\sec`).
+    Sec,
+    /// Cosecant, 1/sin (`\csc`).
+    Csc,
 }
 
 /// An aggregation operator in a `let` formula — reduces every

--- a/code/packages/rust/adj-lang/src/lower.rs
+++ b/code/packages/rust/adj-lang/src/lower.rs
@@ -722,6 +722,15 @@ fn lower_named_fn(f: NamedFn) -> ComputeOp {
         NamedFn::Ln => ComputeOp::Ln,
         NamedFn::Log => ComputeOp::Log,
         NamedFn::Exp => ComputeOp::Exp,
+        NamedFn::Asin => ComputeOp::Asin,
+        NamedFn::Acos => ComputeOp::Acos,
+        NamedFn::Atan => ComputeOp::Atan,
+        NamedFn::Sinh => ComputeOp::Sinh,
+        NamedFn::Cosh => ComputeOp::Cosh,
+        NamedFn::Tanh => ComputeOp::Tanh,
+        NamedFn::Cot => ComputeOp::Cot,
+        NamedFn::Sec => ComputeOp::Sec,
+        NamedFn::Csc => ComputeOp::Csc,
     }
 }
 
@@ -1943,6 +1952,31 @@ contributes 1000000 from answer == 60 to correct
         )
         .unwrap();
         assert!(d.ranked[0].posterior > 0.99, "{d:?}");
+    }
+
+    #[test]
+    fn native_latex_extended_trig_family_lowers() {
+        // The rest of the trig family the latex frontend parses — hyperbolic
+        // `\cosh(x)` (cosh 0 = 1) and inverse `\arctan(x)` (atan 0 = 0) — now lower
+        // to the native ComputeOp::Cosh/Atan instead of erroring as unsupported.
+        let cosh = crate::compile_and_decide(
+            "observe x(0)\n\
+             let answer = latex \"$\\cosh(x)$\"\n\
+             prior 0.10 for correct\n\
+             contributes 1000000 from answer == 1 to correct\n\
+             ? correct\n",
+        )
+        .unwrap();
+        assert!(cosh.ranked[0].posterior > 0.99, "{cosh:?}");
+        let atan = crate::compile_and_decide(
+            "observe x(0)\n\
+             let answer = latex \"$\\arctan(x)$\"\n\
+             prior 0.10 for correct\n\
+             contributes 1000000 from answer == 0 to correct\n\
+             ? correct\n",
+        )
+        .unwrap();
+        assert!(atan.ranked[0].posterior > 0.99, "{atan:?}");
     }
 
     #[test]

--- a/code/packages/rust/logic-engine/CHANGELOG.md
+++ b/code/packages/rust/logic-engine/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.32.0] - 2026-07-02 — the rest of the trig family (inverse / hyperbolic / reciprocal)
+
+### Added
+
+- Nine more transcendental unary ops completing the standard trig set the LaTeX
+  frontend already parses: **inverse** `Asin`/`Acos`/`Atan`, **hyperbolic**
+  `Sinh`/`Cosh`/`Tanh`, and **reciprocal** `Cot` (cos/sin), `Sec` (1/cos), `Csc`
+  (1/sin). Carried in the existing `ComputeExpr::Unary`, same contract as the
+  earlier transcendentals: `Scalar → Scalar` (a dimensioned operand is a rejected
+  category error), exact-rational sidecar dropped, evaluated in the shared
+  `#[inline(never)] eval_unary` helper.
+- Domain and pole errors go through the non-finite guard rather than a
+  silently-wrong number: `asin`/`acos` outside `[−1, 1]` → `NaN`; `cot`/`csc` at a
+  multiple of π and `sec` at an odd multiple of π/2 → `±∞` (the reciprocal
+  definitions divide by a zero primary).
+
 ## [0.31.0] - 2026-07-02 — native transcendental functions (`sin`/`cos`/`tan`/`ln`/`log`/`exp`)
 
 ### Added

--- a/code/packages/rust/logic-engine/Cargo.toml
+++ b/code/packages/rust/logic-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logic-engine"
-version = "0.31.0"
+version = "0.32.0"
 edition = "2021"
 description = "Probability-aware facts, rules, KB, SLD find-first/enumerate + WMC posterior + LP19e likelihood-ratio Bayesian aggregation."
 

--- a/code/packages/rust/logic-engine/src/compute.rs
+++ b/code/packages/rust/logic-engine/src/compute.rs
@@ -228,6 +228,23 @@ pub enum ComputeOp {
     Ln,
     Log,
     Exp,
+    /// The rest of the standard trig family: the **inverse** functions `asin`,
+    /// `acos`, `atan` (`\arcsin`/`\arccos`/`\arctan`), the **hyperbolic**
+    /// functions `sinh`, `cosh`, `tanh`, and the **reciprocal** functions `cot`
+    /// (cos/sin), `sec` (1/cos), `csc` (1/sin). Same contract as the other
+    /// transcendentals — `Scalar → Scalar`, exact sidecar dropped, domain and
+    /// pole errors (`asin`/`acos` outside [−1, 1]; `cot`/`csc` at a multiple of π;
+    /// `sec` at an odd multiple of π/2) caught by the non-finite guard. They
+    /// complete the trig set the LaTeX frontend already parses.
+    Asin,
+    Acos,
+    Atan,
+    Sinh,
+    Cosh,
+    Tanh,
+    Cot,
+    Sec,
+    Csc,
     Sum,
     Count,
     Min,
@@ -254,6 +271,15 @@ impl ComputeOp {
             ComputeOp::Ln => "ln",
             ComputeOp::Log => "log",
             ComputeOp::Exp => "exp",
+            ComputeOp::Asin => "asin",
+            ComputeOp::Acos => "acos",
+            ComputeOp::Atan => "atan",
+            ComputeOp::Sinh => "sinh",
+            ComputeOp::Cosh => "cosh",
+            ComputeOp::Tanh => "tanh",
+            ComputeOp::Cot => "cot",
+            ComputeOp::Sec => "sec",
+            ComputeOp::Csc => "csc",
             ComputeOp::Sum => "sum",
             ComputeOp::Count => "count",
             ComputeOp::Min => "min",
@@ -658,7 +684,21 @@ fn eval_unary(
     // ops use (the operand's dimension vs the required `Scalar`).
     let transcendental = matches!(
         op,
-        ComputeOp::Sin | ComputeOp::Cos | ComputeOp::Tan | ComputeOp::Ln | ComputeOp::Log | ComputeOp::Exp
+        ComputeOp::Sin
+            | ComputeOp::Cos
+            | ComputeOp::Tan
+            | ComputeOp::Ln
+            | ComputeOp::Log
+            | ComputeOp::Exp
+            | ComputeOp::Asin
+            | ComputeOp::Acos
+            | ComputeOp::Atan
+            | ComputeOp::Sinh
+            | ComputeOp::Cosh
+            | ComputeOp::Tanh
+            | ComputeOp::Cot
+            | ComputeOp::Sec
+            | ComputeOp::Csc
     );
     if transcendental && !dim.is_scalar() {
         return Err(ComputeError::DimensionMismatch {
@@ -683,6 +723,17 @@ fn eval_unary(
         ComputeOp::Ln => value.ln(),
         ComputeOp::Log => value.log10(),
         ComputeOp::Exp => value.exp(),
+        ComputeOp::Asin => value.asin(),
+        ComputeOp::Acos => value.acos(),
+        ComputeOp::Atan => value.atan(),
+        ComputeOp::Sinh => value.sinh(),
+        ComputeOp::Cosh => value.cosh(),
+        ComputeOp::Tanh => value.tanh(),
+        // Reciprocal trig defined from the primaries; a zero denominator (a pole)
+        // becomes ±∞ and is caught by the finite guard below.
+        ComputeOp::Cot => value.cos() / value.sin(),
+        ComputeOp::Sec => 1.0 / value.cos(),
+        ComputeOp::Csc => 1.0 / value.sin(),
         _ => {
             return Err(ComputeError::MalformedExpr {
                 detail: "non-unary operator in unary position",
@@ -1185,6 +1236,49 @@ mod tests {
                 .unwrap_err();
             assert!(matches!(err, ComputeError::NonFinite { op: ComputeOp::Ln }), "x={x}: {err:?}");
         }
+    }
+
+    #[test]
+    fn hyperbolic_and_inverse_trig_anchors_are_pi_free() {
+        // π-free sanity anchors for the extended trig family: sinh(0)=0, cosh(0)=1,
+        // tanh(0)=0, asin(0)=0, acos(1)=0, atan(0)=0. All Scalar, exact dropped.
+        let cases = [
+            (ComputeOp::Sinh, 0.0, 0.0),
+            (ComputeOp::Cosh, 0.0, 1.0),
+            (ComputeOp::Tanh, 0.0, 0.0),
+            (ComputeOp::Asin, 0.0, 0.0),
+            (ComputeOp::Acos, 1.0, 0.0),
+            (ComputeOp::Atan, 0.0, 0.0),
+        ];
+        for (op, x, want) in cases {
+            let d = compute("t", &ComputeExpr::Unary(op, Box::new(ComputeExpr::Lit(x))), &kb_with(vec![])).unwrap();
+            assert!((d.value - want).abs() < 1e-12, "{op:?}({x}) = {} want {want}", d.value);
+            assert_eq!(d.dim, Dimension::Scalar);
+            assert_eq!(d.exact, None);
+        }
+    }
+
+    #[test]
+    fn reciprocal_trig_uses_the_primary_definitions() {
+        // sec(0) = 1/cos(0) = 1 (a clean value); csc(0) = 1/sin(0) and cot(0) =
+        // cos(0)/sin(0) are poles (sin 0 = 0 → ±∞) and are rejected by the finite
+        // guard, never a silently-wrong number.
+        let sec0 = compute("s", &ComputeExpr::Unary(ComputeOp::Sec, Box::new(ComputeExpr::Lit(0.0))), &kb_with(vec![])).unwrap();
+        assert_eq!(sec0.value, 1.0);
+        assert_eq!(sec0.dim, Dimension::Scalar);
+        for op in [ComputeOp::Csc, ComputeOp::Cot] {
+            let err = compute("p", &ComputeExpr::Unary(op, Box::new(ComputeExpr::Lit(0.0))), &kb_with(vec![])).unwrap_err();
+            assert!(matches!(err, ComputeError::NonFinite { .. }), "{op:?}(0): {err:?}");
+        }
+    }
+
+    #[test]
+    fn arcsine_outside_its_domain_is_a_clean_nonfinite_error() {
+        // asin is only defined on [−1, 1]; asin(2) = NaN in IEEE → rejected, not
+        // flowed into a verdict.
+        let err = compute("a", &ComputeExpr::Unary(ComputeOp::Asin, Box::new(ComputeExpr::Lit(2.0))), &kb_with(vec![]))
+            .unwrap_err();
+        assert!(matches!(err, ComputeError::NonFinite { op: ComputeOp::Asin }), "{err:?}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Completes the standard trig set the LaTeX frontend **already parses** by wiring nine more transcendental unary ops, via the same mechanism as the just-merged sin/cos/tan/ln/log/exp slice (fieldless `ComputeOp` variants reusing `ComputeExpr::Unary`, evaluated in the shared `#[inline(never)] eval_unary`).

| family | LaTeX | ops |
|---|---|---|
| inverse | `\arcsin`/`\arccos`/`\arctan` | `Asin`/`Acos`/`Atan` |
| hyperbolic | `\sinh`/`\cosh`/`\tanh` | `Sinh`/`Cosh`/`Tanh` |
| reciprocal | `\cot`/`\sec`/`\csc` | `Cot` (cos/sin), `Sec` (1/cos), `Csc` (1/sin) |

All `Scalar → Scalar` (a dimensioned operand is a rejected category error), exact-rational sidecar dropped. Domain/pole errors go through the existing non-finite guard: `asin`/`acos` outside [−1,1] → NaN; `cot`/`csc` at a multiple of π and `sec` at an odd multiple of π/2 → ±∞ (reciprocal of a zero primary).

## What changed
- **logic-engine** — 9 new `ComputeOp` variants + `eval_unary` arms + the `transcendental` classifier + `symbol()`.
- **adj-lang** — `NamedFn` variants + adapter `Func` arms + lowering. These are the `Func` variants the latex frontend already parses but the adapter previously rejected as *"not yet supported"* — now they lower to native ops. The remaining variants (aggregate `min`/`max`/`gcd`/`lcm`/`det`, unknown `Other` like `\operatorname{trunc}`) stay a clean explicit adapter error.
- **latex crate + constraint-solver — no change** (solver `Unary` walkers are op-generic).

## Verification
- 3 new engine tests (π-free hyperbolic/inverse anchors / reciprocal poles reject + `sec(0)=1` / `asin` out-of-domain → `NonFinite`) + 1 new adj-lang lower test (`\cosh(0)=1`, `\arctan(0)=0`).
- Full `logic-engine` (151) + `adj-lang` (101) + `adj-constraint-solver` + `adj-lang-cli` suites green; `adjudication-pipeline` builds.
- `logic-engine` 0.31→0.32, `adj-lang` 0.26→0.27; both CHANGELOGs updated.

Security-reviewed (inline, against the worktree source): f64 trig methods are total, the `is_finite` guard blocks every NaN/±inf (incl. reciprocal poles), no integer arithmetic, no panic/DoS path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)