### PR TITLE
feat(sir-runtime-core): polymorphic +/* for strings and arrays (PO1)

### DIFF
--- a/code/packages/python/sir-runtime-core/CHANGELOG.md
+++ b/code/packages/python/sir-runtime-core/CHANGELOG.md
@@ -2,6 +2,48 @@
 
 All notable changes to `coding-adventures-sir-runtime-core` are documented here.
 
+## [0.1.7] - 2026-07-01
+
+### Added — polymorphic `+` / `*` for strings and arrays (PO1 of sir-polymorphic-operators)
+
+Ruby's `+` and `*` are polymorphic on the receiver type, but the runtime only
+implemented the **numeric** case. `mul` now dispatches explicitly on the runtime
+tag (`isinstance`, never reflection) to match Ruby exactly, and `add` is fixed to
+concatenate strings/arrays as well as sum numbers. See
+[`code/specs/sir-polymorphic-operators.md`](../../../specs/sir-polymorphic-operators.md).
+
+- **`add` (`+`)** now handles all three Ruby arms:
+  - `add(1, 2, 3) == 6` (numeric, unchanged), `add() == 0` (identity, unchanged).
+  - `add("a", "b") == "ab"` and `add("foo", "bar", "baz") == "foobarbaz"` (String
+    concat).
+  - `add([1], [2]) == [1, 2]` (Array concat, a **fresh** list — operands are not
+    mutated, matching Ruby's non-destructive `Array#+`).
+  - Fix: the fold is now **seeded with the first operand** instead of the integer
+    `0`. The previous `total = 0; total += a` raised `TypeError` on the very first
+    string/array operand (`0 + "a"`), so string/array `+` was silently broken;
+    seeding from `args[0]` starts the fold in the right type. Numeric results are
+    identical (addition is associative).
+- **`mul` (`*`)** now implements Ruby's four arms, dispatched on the two-operand
+  (binary) shape the frontend lowers, with the variadic numeric fold preserved for
+  the pure-numeric case:
+  - `str × int` → repeated string (`mul("ab", 3) == "ababab"`; count `<= 0` → `""`).
+  - `list × int` → repeated-element list (`mul([0], 3) == [0, 0, 0]`; fresh list).
+  - `list × str` → join elements with the separator, using the canonical
+    `to_display` (element `to_s`, not `repr`): `mul([1, 2], ", ") == "1, 2"`,
+    `mul([None, True], "|") == "nil|#t"`.
+  - Otherwise the numeric fold, unchanged: `mul() == 1`, `mul(2, 3, 4) == 24`.
+  - `bool` is excluded from the integer repeat/join arms (it is an `int` subclass
+    in Python but not a SIR number, per `values.is_number`), so a bool count is
+    never treated as a repeat count.
+- No core-IR or frontend change — this is a runtime-only correctness fix on the
+  Python backend. New regression tests cover every arm plus numeric preservation
+  and non-aliasing (`test_add_string_concat`, `test_add_array_concat`,
+  `test_add_array_concat_does_not_alias_operands`, `test_mul_string_repeat`,
+  `test_mul_array_repeat`, `test_mul_array_repeat_does_not_alias_operand`,
+  `test_mul_array_join_with_string`, `test_mul_numeric_fold_unchanged`,
+  `test_mul_bool_count_is_not_treated_as_a_repeat`).
+- Bumps `pyproject.toml` to `0.1.7`.
+
 ## [0.1.6] - 2026-07-01
 
 ### Security — cycle-guard the `puts` array flatten (CWE-674)

--- a/code/packages/python/sir-runtime-core/README.md
+++ b/code/packages/python/sir-runtime-core/README.md
@@ -17,7 +17,7 @@ prelude into every file:
 | `Pair` / `cons` / `car` / `cdr` | Lisp cons cells; no native type. |
 | `eq`, `to_display`, `print` | Symbol-aware equality and Lisp/Ruby display (`nil`, `#t`/`#f`). |
 | `sir_puts` (`puts`) | Ruby `puts`: per-arg line, arrays flattened element-per-line, no double trailing newline, no-arg → one newline. |
-| `add`/`sub`/`mul`/`div`, `lt`/`gt` | Variadic folds + truncating-integer `/`. |
+| `add`/`sub`/`mul`/`div`, `lt`/`gt` | Variadic folds + truncating-integer `/`. `add`/`mul` are **polymorphic** like Ruby's `+`/`*`: `add` concatenates strings (`"a"+"b"`) and arrays (`[1]+[2]`) as well as summing numbers; `mul` repeats strings (`"ab"*3`) and arrays (`[0]*3`) and joins arrays with a string separator (`[1,2]*", " → "1, 2"`). |
 | `Closure`/`apply`/`make_closure`, global store, builtin dispatch | Uniform closure handles + SIR `Globals`. |
 
 It implements **SIR** semantics, not any one source language's — so a Ruby

--- a/code/packages/python/sir-runtime-core/pyproject.toml
+++ b/code/packages/python/sir-runtime-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sir-runtime-core"
-version = "0.1.6"
+version = "0.1.7"
 description = "Core runtime for Semantic-IR-emitted Python — SIR truthiness, symbols, equality, display, arithmetic, closures, globals"
 requires-python = ">=3.12"
 dependencies = ["coding-adventures-sir-runtime-pairs"]

--- a/code/packages/python/sir-runtime-core/src/coding_adventures_sir_runtime_core/arithmetic.py
+++ b/code/packages/python/sir-runtime-core/src/coding_adventures_sir_runtime_core/arithmetic.py
@@ -18,12 +18,37 @@ from __future__ import annotations
 
 from typing import Any
 
+from .values import to_display
+
 
 def add(*args: Any) -> Any:
-    """Variadic sum; ``add()`` is ``0``."""
-    total: Any = 0
-    for a in args:
-        total += a
+    """Variadic sum; ``add()`` is ``0``.
+
+    Ruby's ``+`` is **polymorphic on the receiver type**, and because a SIR
+    array is a plain Python ``list`` and a SIR string is a ``str``, Python's
+    own ``+`` already gives us all three Ruby behaviours *for free* — no
+    explicit ``isinstance`` dispatch is needed here:
+
+    | Operands            | ``+`` result  | Ruby         |
+    |---------------------|---------------|--------------|
+    | ints/floats         | numeric sum   | ``1 + 2``    |
+    | ``str`` + ``str``   | concatenation | ``"a"+"b"``  |
+    | ``list`` + ``list`` | concatenation | ``[1]+[2]``  |
+
+    The one subtlety: we **seed the fold with the first operand** rather than
+    with the integer ``0``. Seeding from ``0`` (``total = 0; total += a``) only
+    works for numbers — ``0 + "a"`` / ``0 + [1]`` raise ``TypeError`` — so the
+    string/array cases would break. Seeding from ``args[0]`` starts the fold in
+    the right type; for the numeric case the result is identical because
+    addition is associative (``0 + a + b == a + b``). ``list`` concatenation
+    with ``+`` produces a *fresh* list (no aliasing), matching Ruby's
+    non-destructive ``Array#+``. The empty-sum identity ``add() == 0`` is kept.
+    """
+    if not args:
+        return 0
+    total: Any = args[0]
+    for a in args[1:]:
+        total = total + a
     return total
 
 
@@ -40,7 +65,56 @@ def sub(*args: Any) -> Any:
 
 
 def mul(*args: Any) -> Any:
-    """Variadic product; ``mul()`` is ``1``."""
+    """Variadic product; ``mul()`` is ``1``.
+
+    Ruby's ``*`` is **polymorphic on the receiver type**, and unlike ``+`` the
+    native Python ``*`` does *not* line up with Ruby for every case, so we
+    dispatch explicitly on the runtime tag (``isinstance``, never reflection —
+    see the dynamic-dispatch RCE lesson). Ruby's four arms:
+
+    | Receiver × operand | Ruby result           | Example              |
+    |--------------------|-----------------------|----------------------|
+    | ``str`` × ``int``  | repeated string        | ``"ab"*3 → "ababab"``|
+    | ``list`` × ``int`` | repeated-element list  | ``[0]*3 → [0,0,0]``  |
+    | ``list`` × ``str`` | join elements → string | ``[1,2]*", " → "1, 2"``|
+    | numbers            | numeric product        | ``2*3 → 6``          |
+
+    ``*`` is **binary** in Ruby, so the string/array arms handle exactly the
+    two-operand shape the frontend lowers. The pure-numeric case keeps the
+    variadic fold (``mul() == 1``, ``mul(2, 3, 4) == 24``) that SIR's builtin
+    contract shares with the Lisp/Twig frontends.
+
+    Notes on the arms:
+
+    * ``str`` × ``int`` with ``int <= 0`` → ``""`` — Python's own ``"ab" * 0``
+      and ``"ab" * -1`` already yield ``""``, matching Ruby's ``String#*``.
+    * ``list`` × ``int`` uses Python's ``list * int`` (fresh list, non-negative
+      count clamps to empty), matching Ruby's ``Array#*`` with an Integer.
+    * ``list`` × ``str`` joins with :func:`to_display` — the runtime's canonical
+      element display — so ``[1, 2] * ", "`` renders as ``"1, 2"`` (element
+      ``to_s``, not Python's ``repr``), matching Ruby's ``Array#*`` with a
+      String separator.
+    """
+    # --- string/array arms (Ruby's binary `*`) -----------------------------
+    # These only apply to the two-operand shape the frontend emits for `*`.
+    if len(args) == 2:
+        left, right = args
+        # bool is an int subclass in Python but is NOT a SIR count/number
+        # (see values.is_number); exclude it so `"ab" * True` is not treated
+        # as a repeat with count 1.
+        right_is_int = isinstance(right, int) and not isinstance(right, bool)
+
+        if isinstance(left, str) and right_is_int:
+            # "ab" * 3 -> "ababab"; count <= 0 -> "" (Python matches Ruby).
+            return left * right
+        if isinstance(left, list) and right_is_int:
+            # [0] * 3 -> [0, 0, 0]; fresh list, count <= 0 -> [].
+            return left * right
+        if isinstance(left, list) and isinstance(right, str):
+            # [1, 2] * ", " -> "1, 2" (element to_s, canonical SIR display).
+            return right.join(to_display(el) for el in left)
+
+    # --- numeric variadic fold (unchanged) ---------------------------------
     acc: Any = 1
     for a in args:
         acc *= a

--- a/code/packages/python/sir-runtime-core/tests/test_core.py
+++ b/code/packages/python/sir-runtime-core/tests/test_core.py
@@ -209,6 +209,84 @@ def test_variadic_arithmetic() -> None:
     assert sir.mul() == 1
 
 
+def test_add_string_concat() -> None:
+    # Ruby's `+` is polymorphic: two strings concatenate.
+    assert sir.add("a", "b") == "ab"
+    assert sir.add("foo", "bar", "baz") == "foobarbaz"
+    # A single string argument is returned unchanged (fold of one).
+    assert sir.add("solo") == "solo"
+
+
+def test_add_array_concat() -> None:
+    # SIR arrays are plain Python lists, so `+` concatenates them.
+    assert sir.add([1], [2]) == [1, 2]
+    assert sir.add([1, 2], [3], [4, 5]) == [1, 2, 3, 4, 5]
+
+
+def test_add_array_concat_does_not_alias_operands() -> None:
+    # Ruby's Array#+ is non-destructive: the inputs must be untouched.
+    a = [1]
+    b = [2]
+    result = sir.add(a, b)
+    assert result == [1, 2]
+    result.append(99)
+    assert a == [1]  # first operand not mutated
+    assert b == [2]  # second operand not mutated
+
+
+def test_mul_string_repeat() -> None:
+    # "ab" * 3 -> "ababab"; non-positive counts -> "".
+    assert sir.mul("ab", 3) == "ababab"
+    assert sir.mul("ab", 0) == ""
+    assert sir.mul("ab", -1) == ""
+
+
+def test_mul_array_repeat() -> None:
+    # [0] * 3 -> [0, 0, 0]; a fresh list, non-positive count -> [].
+    assert sir.mul([0], 3) == [0, 0, 0]
+    assert sir.mul([1, 2], 2) == [1, 2, 1, 2]
+    assert sir.mul([1], 0) == []
+
+
+def test_mul_array_repeat_does_not_alias_operand() -> None:
+    src = [1]
+    result = sir.mul(src, 3)
+    assert result == [1, 1, 1]
+    result.append(9)
+    assert src == [1]  # source list untouched
+
+
+def test_mul_array_join_with_string() -> None:
+    # [1, 2] * ", " -> "1, 2" (element to_s via the canonical SIR display).
+    assert sir.mul([1, 2], ", ") == "1, 2"
+    assert sir.mul(["a", "b", "c"], "-") == "a-b-c"
+    assert sir.mul([], ", ") == ""
+    # Join uses to_display, not repr: nil renders as "nil", not "None".
+    assert sir.mul([None, True], "|") == "nil|#t"
+
+
+def test_mul_numeric_fold_unchanged() -> None:
+    # Regression: the pure-numeric variadic fold is preserved exactly.
+    assert sir.mul() == 1
+    assert sir.mul(2, 3) == 6
+    assert sir.mul(2, 3, 4) == 24
+    assert sir.mul(5) == 5
+    # Float promotion still works.
+    assert sir.mul(2, 2.5) == 5.0
+
+
+def test_mul_bool_count_is_not_treated_as_a_repeat() -> None:
+    # bool is an int subclass in Python but NOT a SIR number (see
+    # values.is_number), so the string/array repeat arms must exclude it: a
+    # bool count is not an integer repeat count. `"ab" * True` therefore does
+    # NOT go through the repeat arm — it falls through to the numeric fold,
+    # where Python's `1 * "ab" * True` yields the string once ("ab"), which is
+    # distinct from the repeat arm's `"ab" * True` (which would also be "ab"
+    # here, but for larger truthy-int-like values the distinction matters and
+    # the arm intentionally never fires on a bool).
+    assert sir.mul("ab", True) == "ab"
+
+
 def test_truncating_division() -> None:
     assert sir.div(7, 2) == 3
     assert sir.div(-7, 2) == -3  # truncates toward zero, not floor


### PR DESCRIPTION
Python milestone of the **sir-polymorphic-operators** cascade (spec merged in #7325). Runtime-only — only `code/packages/python/sir-runtime-core/`.

- **`add`**: fixed a real latent bug — the fold was seeded with integer `0`, so string/array `+` raised `TypeError` (`0 + "a"`). Now seeds from `args[0]`; numeric result unchanged (associativity), `add()==0` preserved, list concat returns a fresh list.
- **`mul`**: explicit `isinstance` dispatch (never reflection) — `str×int` repeat, `list×int` repeat, `list×str` join via `to_display`, else numeric fold. `bool` excluded from int arms.

61 tests pass, 100% coverage on arithmetic.py, ruff clean. Security review: PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)