### PR TITLE
feat(sir-go): polymorphic +/* for strings and arrays (PO4)

### DIFF
--- a/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Changelog
 
+## 0.11.0
+
+### Added — polymorphic `+` / `*` for strings and arrays (sir-polymorphic-operators PO4)
+
+- Ruby overloads `+` and `*` by receiver type, and every case lowers to the
+  same SIR builtins (`_sir_plus` / `_sir_times`). The Go runtime helpers were
+  previously **numeric-only** — they ran `_sir_as_int`/`_sir_as_float` on every
+  operand — so `"a" + "b"` and `[1] + [2]` produced garbage or panicked. Both
+  helpers now dispatch on the FIRST operand's runtime tag via a Go **type
+  switch** (never reflection — the [[dynamic-dispatch-rce]] discipline) and add
+  the string/array arms ahead of the unchanged numeric fold:
+  - `_sir_plus`: first operand a `string` → concatenate all operands as strings
+    (`"a"+"b"` → `"ab"`); first operand a `*Seq` → concatenate element slices
+    into a **fresh** backing array with no aliasing of any input (`[1]+[2]` →
+    `[1, 2]`); otherwise the existing int/float-promoting numeric fold.
+  - `_sir_times`: `string × Integer` → repeat via `strings.Repeat` (`"ab"*3` →
+    `"ababab"`; a non-positive count yields `""`, clamped so `strings.Repeat`
+    never panics); `*Seq × Integer` → repeat the element list into a fresh slice
+    (`[0]*3` → `[0, 0, 0]`; non-positive → empty array); `*Seq × string` → join
+    the elements with the separator using the same value-display helper `puts`
+    uses (`_sir_format`), so `[1,2]*", "` → `"1, 2"`; otherwise the numeric fold.
+- Numeric `+`/`*` semantics (int64 fast path, int→float promotion, variadic
+  fold) are **preserved exactly** — the new arms only run when the first operand
+  is a string/`*Seq`. Ruby `+`/`*` are binary; the string/array arms fold
+  left-associatively over the variadic operand list.
+- A controlled-panic helper `_sir_as_string` coerces string-`+` operands (a
+  non-string operand — e.g. `"a" + 1` — panics with a Ruby-shaped "no implicit
+  conversion of Integer into String" message rather than emitting garbage; the
+  strict `TypeError` is deferred to the typed-runtime-errors cascade).
+- Execution proof `compile_and_run_polyops.rs` runs `"a"+"b"`, `"ab"*3`,
+  `[1]+[2]`, `[0]*3`, `[1,2]*", "`, and the numeric regressions `1+2` / `2*3`
+  under `go run` and asserts stdout is exactly `ab\nababab\n[1, 2]\n[0, 0, 0]\n1, 2\n3\n6\n`.
+- **Overflow guard (security):** the `*` repeat arms compute `len × count` in a
+  fixed-width host `int`, which on a large count could overflow (wrapping to a
+  negative/absurd `make` capacity → opaque panic) or drive a multi-gigabyte
+  allocation → OOM. Both arms now short-circuit an empty receiver (also avoiding
+  a huge append loop) and guard `count > maxInt/len` with a controlled
+  `panic("argument too big")` — matching Ruby's `ArgumentError: argument too
+  big` — before any `strings.Repeat`/`make`. The count is program-controlled, so
+  this closes a reachable resource-exhaustion vector.
+
 ## 0.10.0
 
 ### Added — `puts` builtin (Ruby semantics)

--- a/code/packages/rust/semantic-ir-to-go/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-go/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-go"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 description = "Semantic IR → self-contained Go source code (SIR15). Fourth backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-go/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/runtime.rs
@@ -209,7 +209,50 @@ func _sir_as_float(v Value) float64 {
 	panic("expected number")
 }
 
+// ── polymorphic `+` (sir-polymorphic-operators PO4) ────────────
+//
+// Ruby overloads `+` by receiver type; all cases lower to `_sir_plus`,
+// so the runtime dispatches on the FIRST operand's tag (a Go type switch
+// — NEVER reflection, per the [[dynamic-dispatch-rce]] discipline):
+//
+//   | args[0] tag | behaviour                                        |
+//   |-------------|--------------------------------------------------|
+//   | string      | concatenate ALL operands as strings → string     |
+//   | *Seq        | concatenate element slices → NEW *Seq (no alias) |
+//   | otherwise   | numeric fold (int/float promotion), unchanged    |
+//
+// Ruby `+` is binary, but the SIR builtin is variadic; the string/array
+// arms fold left-associatively over ≥2 operands, preserving the existing
+// variadic contract of the numeric path.
 func _sir_plus(args []Value) Value {
+	if len(args) > 0 {
+		switch first := args[0].(type) {
+		case string:
+			// String concat.  Every operand must itself be a string —
+			// Ruby raises TypeError on `"a" + 1` (deferred to the
+			// typed-runtime-errors cascade); here `_sir_as_string`
+			// gives a controlled panic rather than silent garbage.
+			var out string
+			for _, a := range args {
+				out += _sir_as_string(a)
+			}
+			return out
+		case *Seq:
+			// Array concat: build a FRESH backing slice so the result
+			// never aliases any input's backing array (Ruby `+` returns
+			// a new array; only `concat`/`<<` mutate in place).
+			out := make([]Value, 0, len(first.Items))
+			out = append(out, first.Items...)
+			for _, a := range args[1:] {
+				s, ok := a.(*Seq)
+				if !ok {
+					panic("no implicit conversion of " + _sir_ruby_class_name(a) + " into Array")
+				}
+				out = append(out, s.Items...)
+			}
+			return &Seq{Items: out}
+		}
+	}
 	if _sir_any_float(args) {
 		var total float64
 		for _, a := range args {
@@ -222,6 +265,16 @@ func _sir_plus(args []Value) Value {
 		total += _sir_as_int(a)
 	}
 	return total
+}
+
+// Coerce an operand to a Go string for the string `+` arm.  A genuine
+// string passes through; anything else is a controlled panic (Ruby would
+// raise TypeError — the typed-runtime-errors cascade will refine this).
+func _sir_as_string(v Value) string {
+	if s, ok := v.(string); ok {
+		return s
+	}
+	panic("no implicit conversion of " + _sir_ruby_class_name(v) + " into String")
 }
 
 func _sir_minus(args []Value) Value {
@@ -248,7 +301,77 @@ func _sir_minus(args []Value) Value {
 	return acc
 }
 
+// ── polymorphic `*` (sir-polymorphic-operators PO4) ────────────
+//
+// Ruby `*` is binary and overloaded by the RECEIVER (first operand):
+//
+//   | args[0]  | args[1] | behaviour                                    |
+//   |----------|---------|----------------------------------------------|
+//   | string   | Integer | repeat the string N times ("ab"*3 → ababab)  |
+//   | string   | int ≤ 0 | "" (Ruby raises on negative, but "" is the   |
+//   |          |         |   never-raise floor here)                    |
+//   | *Seq     | Integer | repeat the element list N times ([0]*3)      |
+//   | *Seq     | string  | join elements with the separator ([1,2]*", ")|
+//   | otherwise| —       | numeric fold (int/float promotion), unchanged|
+//
+// Dispatch is on the runtime tag via a Go type switch — never reflection.
+// The string/array arms handle the common BINARY case (Ruby `*` is
+// binary); anything else falls through to the variadic numeric fold, so
+// existing numeric semantics are preserved exactly.
 func _sir_times(args []Value) Value {
+	if len(args) == 2 {
+		switch recv := args[0].(type) {
+		case string:
+			// String × Integer → repeat.  A non-positive count (or an
+			// empty receiver) yields the empty string.  Guard the
+			// product len(recv)*n against host-int overflow: Ruby raises
+			// `ArgumentError: argument too big` for an oversized repeat,
+			// so we panic with the same controlled message rather than
+			// let strings.Repeat overflow `int` (opaque panic) or attempt
+			// a multi-gigabyte allocation and OOM the process.
+			n := _sir_as_int(args[1])
+			if n <= 0 || len(recv) == 0 {
+				return ""
+			}
+			maxInt := int64(^uint(0) >> 1)
+			if n > maxInt/int64(len(recv)) {
+				panic("argument too big")
+			}
+			return strings.Repeat(recv, int(n))
+		case *Seq:
+			// Seq × string → join with separator, using the SAME
+			// value-display helper the runtime uses for `puts`
+			// (`_sir_format`), so an element renders identically whether
+			// printed or joined.
+			if sep, ok := args[1].(string); ok {
+				parts := make([]string, len(recv.Items))
+				for i, x := range recv.Items {
+					parts[i] = _sir_format(x)
+				}
+				return strings.Join(parts, sep)
+			}
+			// Seq × Integer → repeat the element list into a FRESH
+			// backing slice (no aliasing of the input).  A non-positive
+			// count (or an empty receiver) yields an empty array; the
+			// empty-receiver short-circuit also avoids spinning the
+			// append loop for a huge count.  Guard len(Items)*n against
+			// host-int overflow (Ruby raises `ArgumentError: argument
+			// too big`) so `make` never receives a wrapped/negative cap.
+			n := _sir_as_int(args[1])
+			if n <= 0 || len(recv.Items) == 0 {
+				return &Seq{Items: []Value{}}
+			}
+			maxInt := int64(^uint(0) >> 1)
+			if n > maxInt/int64(len(recv.Items)) {
+				panic("argument too big")
+			}
+			out := make([]Value, 0, len(recv.Items)*int(n))
+			for i := int64(0); i < n; i++ {
+				out = append(out, recv.Items...)
+			}
+			return &Seq{Items: out}
+		}
+	}
 	if _sir_any_float(args) {
 		acc := 1.0
 		for _, a := range args {

--- a/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_polyops.rs
+++ b/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_polyops.rs
@@ -1,0 +1,160 @@
+//! End-to-end proof for the **polymorphic `+` / `*`** operators
+//! (sir-polymorphic-operators, PO4) in the Go backend.
+//!
+//! Ruby overloads `+` and `*` by receiver type, and every case lowers to
+//! the same SIR builtins (`_sir_plus` / `_sir_times`).  Before PO4 the Go
+//! runtime helpers were NUMERIC-ONLY (`_sir_as_int`/`_sir_as_float` on
+//! every operand), so `"a" + "b"` and `[1] + [2]` produced garbage or
+//! panicked.  A *shape* assertion cannot catch that — we must prove the
+//! emitted Go actually produces the byte stream Ruby would.
+//!
+//! This test hand-builds a SIR module equivalent to the Ruby program
+//!
+//!     print "a" + "b"      # => ab
+//!     print "ab" * 3       # => ababab
+//!     print [1] + [2]      # => [1, 2]  (Go backend array display)
+//!     print [0] * 3        # => [0, 0, 0]
+//!     print [1, 2] * ", "  # => 1, 2    (Array join via *)
+//!     print 1 + 2          # => 3       (numeric regression)
+//!     print 2 * 3          # => 6       (numeric regression)
+//!
+//! emits Go, runs it with `go run`, and asserts stdout is EXACTLY the
+//! concatenation of each `print`'s output (one line each, `print` uses
+//! `_sir_format` + a trailing newline).
+//!
+//! Gates on `go` being available; logs a skip rather than failing when the
+//! toolchain is absent (mirrors `compile_and_run_puts.rs`).
+
+use std::process::Command;
+
+use semantic_ir::{
+    Block, Effect, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module,
+    Span, Stmt,
+};
+use semantic_ir_to_go::compile;
+
+fn s() -> Span {
+    Span::synthetic()
+}
+
+fn ilit(v: i64) -> Expr {
+    Expr::IntLit { value: v, span: s() }
+}
+
+fn slit(v: &str) -> Expr {
+    Expr::StrLit { value: v.into(), span: s() }
+}
+
+fn seq(items: Vec<Expr>) -> Expr {
+    Expr::SeqLit { items, span: s() }
+}
+
+/// `(name arg0 arg1 ...)` builtin call, pure.
+fn call(name: &str, args: Vec<Expr>) -> Expr {
+    Expr::BuiltinCall { name: name.into(), args, effects: EffectSet::PURE, span: s() }
+}
+
+/// `print(expr)` as an effectful statement — `_sir_print` renders the
+/// value via `_sir_format` and appends a newline, so each call emits
+/// exactly one line and the results are trivially assertable.
+fn print_stmt(expr: Expr) -> Stmt {
+    Stmt::ExprStmt {
+        expr: Expr::BuiltinCall {
+            name: "print".into(),
+            args: vec![expr],
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            span: s(),
+        },
+        span: s(),
+    }
+}
+
+/// Build a module whose `main` prints each polymorphic-operator result on
+/// its own line, in the order documented in the module comment above.
+fn demo_module() -> Module {
+    let stmts = vec![
+        // "a" + "b" → ab
+        print_stmt(call("+", vec![slit("a"), slit("b")])),
+        // "ab" * 3 → ababab
+        print_stmt(call("*", vec![slit("ab"), ilit(3)])),
+        // [1] + [2] → [1, 2]
+        print_stmt(call("+", vec![seq(vec![ilit(1)]), seq(vec![ilit(2)])])),
+        // [0] * 3 → [0, 0, 0]
+        print_stmt(call("*", vec![seq(vec![ilit(0)]), ilit(3)])),
+        // [1, 2] * ", " → 1, 2
+        print_stmt(call("*", vec![seq(vec![ilit(1), ilit(2)]), slit(", ")])),
+        // 1 + 2 → 3 (numeric regression)
+        print_stmt(call("+", vec![ilit(1), ilit(2)])),
+        // 2 * 3 → 6 (numeric regression)
+        print_stmt(call("*", vec![ilit(2), ilit(3)])),
+    ];
+
+    Module {
+        name: "polyops_demo".into(),
+        manifest: FeatureManifest::from_features(&[Feature::Sequences, Feature::Strings]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block { stmts, value: Expr::NilLit { span: s() }, span: s() },
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            metadata: Metadata::new(),
+            span: s(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("test")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+fn go_available() -> bool {
+    Command::new("go")
+        .arg("version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+#[test]
+fn polymorphic_ops_compile_and_match_ruby_output() {
+    if !go_available() {
+        eprintln!("skipping: go not on PATH");
+        return;
+    }
+
+    let artifact = compile(&demo_module()).expect("module should compile to Go source");
+
+    let dir = std::env::temp_dir();
+    let nonce = std::process::id();
+    let src_path = dir.join(format!("sir_go_polyops_{nonce}.go"));
+    std::fs::write(&src_path, &artifact.source).expect("write temp source");
+
+    let run_out = Command::new("go").arg("run").arg(&src_path).output().expect("invoke go run");
+
+    if !run_out.status.success() {
+        let stderr = String::from_utf8_lossy(&run_out.stderr);
+        let _ = std::fs::remove_file(&src_path);
+        panic!(
+            "emitted Go failed to compile/run:\n--- stderr ---\n{stderr}\n--- source ---\n{}",
+            artifact.source,
+        );
+    }
+
+    let stdout = String::from_utf8_lossy(&run_out.stdout);
+    // Normalise CRLF (Go's fmt may emit CRLF on Windows) so the assertion
+    // tests semantics, not the platform newline convention.
+    let normalised = stdout.replace("\r\n", "\n");
+    assert_eq!(
+        normalised,
+        // "a"+"b"  "ab"*3   [1]+[2]   [0]*3        [1,2]*", "  1+2  2*3
+        "ab\nababab\n[1, 2]\n[0, 0, 0]\n1, 2\n3\n6\n",
+        "unexpected polymorphic-op output; full stdout (escaped): {stdout:?}"
+    );
+
+    let _ = std::fs::remove_file(&src_path);
+}


### PR DESCRIPTION
Go milestone of the **sir-polymorphic-operators** cascade (spec #7325). Runtime-only — only `code/packages/rust/semantic-ir-to-go/`.

`_sir_plus`/`_sir_times` were numeric-only, so `"a"+"b"`, `[1]+[2]`, `"ab"*3`, `[0]*3` produced garbage. Now type-switch on the first operand (never reflection): `+` string-concat / fresh-slice Seq-concat; `*` str-repeat / Seq-repeat / Seq-join via `_sir_format`; else the unchanged numeric fold.

**Security (review-driven):** the `*` repeat arms guard `len*count` against host-int overflow with a controlled `panic("argument too big")` (matching Ruby's `ArgumentError`) and short-circuit empty receivers — closing a reachable overflow/OOM vector on a program-controlled count.

Execution-proofed via `go run`. Security review: 2 MEDIUM + 1 LOW found and fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)