### PR TITLE
feat(sir-rust): polymorphic +/* for strings and arrays (PO5)

### DIFF
--- a/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
@@ -1,5 +1,89 @@
 # Changelog
 
+## 0.11.0 — polymorphic `+` / `*` for strings and arrays (PO5)
+
+Implements the Rust milestone of the **sir-polymorphic-operators** cascade.
+Ruby's `+` and `*` are overloaded by receiver type, but the Rust backend's
+runtime `plus`/`times` were **numeric-only**: they called `as_i64`/`as_f64`
+on every operand, so `"a" + "b"` produced integer garbage (a correctness
+gap on the core translation path, not a missing stdlib method). Both
+helpers are now **type-polymorphic**, matching Ruby exactly. This is a
+**runtime-only** change — no core semantic-IR change and no frontend change;
+`+`/`*` already lower to `__sir::plus`/`__sir::times`.
+
+**Overflow guard (security):** the `*` repeat arms compute `len * count` where
+`count` is cast from a program-controlled `i64`. Both arms now guard the product
+with `checked_mul` and panic `"argument too big"` (matching Ruby's
+`ArgumentError`) on overflow, and the Seq-repeat arm short-circuits an empty
+receiver (also avoiding a huge `0..count` loop) — closing a reachable
+overflow/OOM vector before any `str::repeat`/`Vec::with_capacity`.
+
+### Semantics (dispatched on the FIRST operand's tag)
+
+| expression      | result      | arm                        |
+|-----------------|-------------|----------------------------|
+| `"a" + "b"`     | `"ab"`      | `Str` → concat all args    |
+| `[1] + [2]`     | `[1, 2]`    | `Seq` → new concatenated   |
+| `"ab" * 3`      | `"ababab"`  | `Str * Int` → repeat       |
+| `[0] * 3`       | `[0, 0, 0]` | `Seq * Int` → repeat       |
+| `[1, 2] * ", "` | `"1, 2"`    | `Seq * Str` → join         |
+| `1 + 2`         | `3`         | numeric fold (**unchanged**) |
+| `2 * 3`         | `6`         | numeric fold (**unchanged**) |
+
+### Changed
+
+- **`plus` (`runtime.rs`).** Dispatches on `args.first()` via an explicit
+  `match`:
+  - `Value::Str` first operand → concatenate every operand's string
+    contents into a new `Value::Str`. Each operand must be a `Str` (a
+    non-`Str` operand panics with `string + expects strings, …` rather than
+    silently coercing; typed `TypeError` on `"a" + 1` is deferred to the
+    sir-typed-runtime-errors cascade).
+  - `Value::Seq` first operand → concatenate the element vectors into a
+    **fresh** `Value::Seq` (via `seq_lit`), never aliasing or mutating an
+    input handle (Ruby `Array#+` returns a new array).
+  - Otherwise → the **unchanged** numeric int/float promotion fold.
+- **`times` (`runtime.rs`).** Dispatches on `args.first()`; a `Str`/`Seq`
+  first operand folds left-associatively pairwise through a new
+  `times_binary(lhs, rhs)` atom (Ruby `*` is binary; the SIR builtin is
+  variadic, so this preserves the variadic contract), with three arms:
+  - `Str * Int` → repeat the string N times (N ≤ 0 → empty string).
+  - `Seq * Int` → a fresh `Seq` with the element vector repeated N times
+    (N ≤ 0 → empty), never aliasing the input.
+  - `Seq * Str` → join the elements with the separator, returning a
+    `Value::Str` (elements rendered via the same `format` display `Array#join`
+    uses).
+  - Any other first operand → the **unchanged** numeric fold.
+
+### Security
+
+- Dispatch is an **explicit `match` on the runtime tag** of the first
+  operand — never a reflective / name-indexed lookup (the
+  dynamic-dispatch-RCE lesson). The string/array arms are hand-written; a
+  first operand that is neither `Str` nor `Seq` takes exactly the pre-existing
+  numeric path. No new `unsafe`.
+
+### Tests
+
+- **Execution proof** (`tests/compile_and_run_polymorphic_ops.rs`, gated on
+  `SIR_TEST_RUSTC_LINKER`): a single suite that hand-builds a
+  `puts`/`print (<lhs> <op> <rhs>)` SIR module per case, emits Rust, compiles
+  with `rustc`, runs the binary, and asserts stdout against the Ruby
+  reference — `"a"+"b"→ab`, `"ab"*3→ababab`, `[1]+[2]→[1, 2]` (bracketed via
+  `print`/`format`), `[0]*3→[0, 0, 0]`, `[1,2]*", "→1, 2`, plus regressions
+  `1+2→3` and `2*3→6` proving the numeric path is unchanged.
+- **Runtime-shape unit test** (`runtime.rs`) pinning the new polymorphic arms
+  (`string + expects strings`, `array + expects arrays`, `fn times_binary`
+  with the three `(lhs, rhs)` arms) and the `match args.first()` tag dispatch
+  (no reflection).
+
+### Notes
+
+- No `Feature` variant added and no accepted-feature change: `+`/`*` were
+  already accepted and lowering; this only makes their **string/array** cases
+  correct instead of producing numeric garbage. Every existing test passes
+  unchanged.
+
 ## 0.10.0 — `puts` builtin (Ruby semantics)
 
 ### Added

--- a/code/packages/rust/semantic-ir-to-rust/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-rust"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 description = "Semantic IR → self-contained Rust source code (SIR13). Second backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-rust/README.md
+++ b/code/packages/rust/semantic-ir-to-rust/README.md
@@ -235,6 +235,38 @@ lowers OOP to a small family of builtins the backend routes to the inline
   body, and `reject_const_ref` skips only the lifted-to-string OOP name
   slots.  No new `unsafe`.
 
+Executes (PO5): **polymorphic `+` / `*`** on strings and arrays
+(sir-polymorphic-operators).  Ruby overloads `+`/`*` by receiver type;
+before this change the runtime `plus`/`times` were **numeric-only**, so
+`"a" + "b"` called `as_i64("a")` and produced integer garbage.  Both
+helpers now **dispatch on the tag of the first operand** via an explicit
+`match` (never reflection — see the dynamic-dispatch-RCE lesson), adding
+the string/array arms *ahead of* the unchanged numeric fold:
+
+| expression      | result      | arm                       |
+|-----------------|-------------|---------------------------|
+| `"a" + "b"`     | `"ab"`      | `Str` → concat all args   |
+| `[1] + [2]`     | `[1, 2]`    | `Seq` → new concatenated  |
+| `"ab" * 3`      | `"ababab"`  | `Str * Int` → repeat      |
+| `[0] * 3`       | `[0, 0, 0]` | `Seq * Int` → repeat      |
+| `[1, 2] * ", "` | `"1, 2"`    | `Seq * Str` → join        |
+| `1 + 2`         | `3`         | numeric fold (unchanged)  |
+| `2 * 3`         | `6`         | numeric fold (unchanged)  |
+
+- **`plus`** — a `Str` first operand concatenates every operand's string
+  contents into a new `Str`; a `Seq` first operand concatenates the element
+  vectors into a **fresh** `Seq` (no aliasing/shared mutation of inputs);
+  anything else takes the unchanged int/float promotion fold.
+- **`times`** — `Str * Int` repeats the string (count ≤ 0 → `""`); `Seq *
+  Int` repeats the element vector into a fresh `Seq`; `Seq * String` joins
+  the elements with the separator (via the same `format` display `join`
+  uses).  `*` is binary in Ruby but the SIR builtin is variadic, so the
+  string/array arms fold **left-associatively** pairwise (`times_binary`),
+  preserving the variadic contract; the numeric path is unchanged.
+- **No core-IR or frontend change** — this is purely the backend runtime.
+  `+`/`*` already lower to `__sir::plus`/`__sir::times`; only those two
+  helpers gained the polymorphic arms.
+
 Rejects: `TailCalls` (Rust does not guarantee TCO), `Intrinsics`
 (empty whitelist in v0), `StringInterpolation`, and a stateful (non-empty
 body) `Class`/`Module` or a non-name-slot `Const` reference (rejected

--- a/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
@@ -201,19 +201,72 @@ pub const RUNTIME: &str = r##"mod __sir {
     // (including `times`' wrapping).  The moment *any* operand is a
     // `Float`, the whole fold promotes to f64 — matching the
     // "int op float ⇒ float" rule of Python/Ruby/JS.
+    // `plus` is POLYMORPHIC on the tag of the FIRST operand, matching
+    // Ruby's `+` (overloaded by receiver type).  The dispatch is an
+    // explicit `match` on the first operand's variant — never reflection
+    // (see [[dynamic-dispatch-rce]]): a `String` receiver concatenates,
+    // a `Seq` receiver concatenates element vectors, and everything else
+    // falls through to the UNCHANGED numeric fold below.
+    //
+    // | first arg   | behaviour                                   |
+    // |-------------|---------------------------------------------|
+    // | `Str`       | concatenate all args' string contents → Str |
+    // | `Seq`       | concatenate the element vecs into a NEW Seq |
+    // | otherwise   | numeric int/float fold (unchanged)          |
+    //
+    // Ruby `+` is binary; the SIR builtin is variadic (numeric fold), so
+    // the string/array arms fold left-associatively over ≥2 operands,
+    // preserving the existing variadic contract.
     pub fn plus(args: Vec<Value>) -> Value {
-        if any_float(&args) {
-            let mut total = 0.0f64;
-            for a in &args {
-                total += as_f64(a);
+        match args.first() {
+            // ── String concatenation ──────────────────────────────
+            // `"a" + "b"` → `"ab"`.  Ruby's `String#+` requires a String
+            // right-hand operand (`"a" + 1` raises `TypeError`); typed
+            // rejection belongs to the sir-typed-runtime-errors cascade, so
+            // here we require every operand be a `Str` and concatenate their
+            // contents — a non-Str operand panics with a clear message rather
+            // than silently coercing to integer garbage.
+            Some(Value::Str(_)) => {
+                let mut out = String::new();
+                for a in &args {
+                    match a {
+                        Value::Str(s) => out.push_str(s),
+                        other => panic!("string + expects strings, got {}", format(other)),
+                    }
+                }
+                Value::Str(Rc::from(out.as_str()))
             }
-            return Value::Float(total);
+            // ── Array concatenation ───────────────────────────────
+            // `[1] + [2]` → `[1, 2]`.  Build a FRESH `Seq` from the
+            // concatenated element snapshots — never alias or mutate an
+            // input handle (Ruby `Array#+` returns a new array).  Each
+            // operand must itself be a `Seq`.
+            Some(Value::Seq(_)) => {
+                let mut out: Vec<Value> = Vec::new();
+                for a in &args {
+                    match a {
+                        Value::Seq(items) => out.extend(items.borrow().iter().cloned()),
+                        other => panic!("array + expects arrays, got {}", format(other)),
+                    }
+                }
+                seq_lit(out)
+            }
+            // ── Numeric fold (UNCHANGED) ──────────────────────────
+            _ => {
+                if any_float(&args) {
+                    let mut total = 0.0f64;
+                    for a in &args {
+                        total += as_f64(a);
+                    }
+                    return Value::Float(total);
+                }
+                let mut total: i64 = 0;
+                for a in args {
+                    total += as_i64(&a);
+                }
+                Value::Int(total)
+            }
         }
-        let mut total: i64 = 0;
-        for a in args {
-            total += as_i64(&a);
-        }
-        Value::Int(total)
     }
 
     pub fn minus(args: Vec<Value>) -> Value {
@@ -240,19 +293,116 @@ pub const RUNTIME: &str = r##"mod __sir {
         Value::Int(acc)
     }
 
+    // `times` is POLYMORPHIC on the tag of the FIRST operand, matching
+    // Ruby's `*`.  Dispatch is an explicit `match` (never reflection):
+    //
+    // | first arg | 2nd arg | behaviour                              |
+    // |-----------|---------|----------------------------------------|
+    // | `Str`     | `Int n` | repeat the string n times (n≤0 → "")   |
+    // | `Seq`     | `Int n` | new Seq with elements repeated n times |
+    // | `Seq`     | `Str s` | join elements with `s` → Str           |
+    // | otherwise | —       | numeric int/float fold (unchanged)     |
+    //
+    // Ruby `*` is binary; the SIR builtin is variadic (numeric fold).  The
+    // string/array arms fold left-associatively pairwise, so `"ab" * 2 * 2`
+    // repeats then repeats again — the natural extension of the binary
+    // operator that preserves the variadic contract.  The join arm produces
+    // a `Str`, so a subsequent operand would fold via the `Str` receiver
+    // (repeat), matching left-associative Ruby chaining.
     pub fn times(args: Vec<Value>) -> Value {
-        if any_float(&args) {
-            let mut acc = 1.0f64;
-            for a in &args {
-                acc *= as_f64(a);
+        match args.first() {
+            Some(Value::Str(_)) | Some(Value::Seq(_)) => {
+                // Fold left-associatively over the operands: seed with the
+                // first, apply `times_binary` against each subsequent operand.
+                let mut it = args.into_iter();
+                let mut acc = it.next().expect("first() was Some");
+                for rhs in it {
+                    acc = times_binary(acc, rhs);
+                }
+                acc
             }
-            return Value::Float(acc);
+            // ── Numeric fold (UNCHANGED) ──────────────────────────
+            _ => {
+                if any_float(&args) {
+                    let mut acc = 1.0f64;
+                    for a in &args {
+                        acc *= as_f64(a);
+                    }
+                    return Value::Float(acc);
+                }
+                let mut acc: i64 = 1;
+                for a in args {
+                    acc = acc.wrapping_mul(as_i64(&a));
+                }
+                Value::Int(acc)
+            }
         }
-        let mut acc: i64 = 1;
-        for a in args {
-            acc = acc.wrapping_mul(as_i64(&a));
+    }
+
+    // The binary `*` for a String/Seq left operand — the atom the variadic
+    // `times` fold applies pairwise.  Kept separate so the three
+    // string/array behaviours (string repeat, array repeat, array join)
+    // live in one explicit `match` on `(lhs, rhs)`.
+    fn times_binary(lhs: Value, rhs: Value) -> Value {
+        match (&lhs, &rhs) {
+            // `"ab" * 3` → `"ababab"`.  A count ≤ 0 yields the empty
+            // string (Ruby `"ab" * 0 == ""`, and negative counts raise in
+            // Ruby but we clamp to empty for the never-raise floor).
+            (Value::Str(s), Value::Int(n)) => {
+                let count = if *n > 0 { *n as usize } else { 0 };
+                // Guard `len * count` against `usize` overflow: `count` is cast
+                // from a program-controlled `i64`, so an oversized repeat could
+                // overflow (bogus size into `str::repeat`) or drive an
+                // unbounded allocation.  Ruby raises `ArgumentError: argument
+                // too big`; panic with the same controlled message rather than
+                // overflow/OOM.
+                if s.len().checked_mul(count).is_none() {
+                    panic!("argument too big");
+                }
+                Value::Str(Rc::from(s.repeat(count).as_str()))
+            }
+            // `[0] * 3` → `[0, 0, 0]`.  A fresh Seq whose element snapshot
+            // is repeated n times (n ≤ 0 → empty), never aliasing the input.
+            (Value::Seq(items), Value::Int(n)) => {
+                let count = if *n > 0 { *n as usize } else { 0 };
+                let snapshot = items.borrow().clone();
+                // Short-circuit an empty receiver (also avoids spinning the
+                // `0..count` loop for a huge count), and guard the capacity
+                // multiply against `usize` overflow — same program-controlled
+                // count as the string arm.  `checked_mul` → controlled
+                // `argument too big` panic (Ruby's `ArgumentError`) instead of
+                // a wrapped/absurd `Vec::with_capacity` request.
+                if snapshot.is_empty() || count == 0 {
+                    return seq_lit(Vec::new());
+                }
+                let total = snapshot
+                    .len()
+                    .checked_mul(count)
+                    .unwrap_or_else(|| panic!("argument too big"));
+                let mut out: Vec<Value> = Vec::with_capacity(total);
+                for _ in 0..count {
+                    out.extend(snapshot.iter().cloned());
+                }
+                seq_lit(out)
+            }
+            // `[1, 2] * ", "` → `"1, 2"` (Ruby `Array#*` with a String is
+            // `join`).  Element rendering uses the same `format` display the
+            // rest of the backend uses (so it matches `Array#join`).
+            (Value::Seq(items), Value::Str(sep)) => {
+                let joined = items
+                    .borrow()
+                    .iter()
+                    .map(format)
+                    .collect::<Vec<_>>()
+                    .join(sep);
+                Value::Str(Rc::from(joined.as_str()))
+            }
+            (l, r) => panic!(
+                "unsupported operands for *: {} and {}",
+                format(l),
+                format(r)
+            ),
         }
-        Value::Int(acc)
     }
 
     pub fn divide(args: Vec<Value>) -> Value {
@@ -1972,6 +2122,25 @@ mod tests {
         ] {
             assert!(RUNTIME.contains(op), "runtime missing `{}`", op);
         }
+    }
+
+    #[test]
+    fn runtime_plus_times_are_polymorphic() {
+        // sir-polymorphic-operators (PO5): `plus`/`times` dispatch on the
+        // first operand's tag via an explicit `match` (String/Seq arms
+        // ahead of the numeric fold), never reflection.
+        // `plus` gains the String-concat and Seq-concat arms.
+        assert!(RUNTIME.contains("string + expects strings"));
+        assert!(RUNTIME.contains("array + expects arrays"));
+        // `times` gains the binary String/Seq atom with the three arms
+        // (string repeat, array repeat, array join).
+        assert!(RUNTIME.contains("fn times_binary"));
+        assert!(RUNTIME.contains("(Value::Str(s), Value::Int(n))"));
+        assert!(RUNTIME.contains("(Value::Seq(items), Value::Int(n))"));
+        assert!(RUNTIME.contains("(Value::Seq(items), Value::Str(sep))"));
+        // Dispatch is a `match args.first()` on the runtime tag — no
+        // reflective / name-indexed lookup (see [[dynamic-dispatch-rce]]).
+        assert!(RUNTIME.contains("match args.first()"));
     }
 
     #[test]

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_polymorphic_ops.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_polymorphic_ops.rs
@@ -1,0 +1,231 @@
+//! End-to-end proof for POLYMORPHIC `+` / `*` (Ruby semantics) in the Rust
+//! backend (sir-polymorphic-operators PO5).
+//!
+//! Ruby's `+` and `*` are overloaded by receiver type, and before this change
+//! the Rust runtime's `plus`/`times` were numeric-only — `"a" + "b"` called
+//! `as_i64("a")` and produced integer garbage.  A *shape* assertion is not
+//! enough here; we must prove the emitted Rust actually produces the exact
+//! bytes Ruby would.  Each case hand-builds a SIR module of the form
+//! `puts (<lhs> <op> <rhs>)`, emits Rust, compiles it with `rustc`, runs the
+//! binary, and asserts stdout against the Ruby reference:
+//!
+//! | expression      | output        | printed via |
+//! |-----------------|---------------|-------------|
+//! | `"a" + "b"`     | `ab`          | `puts`      |
+//! | `"ab" * 3`      | `ababab`      | `puts`      |
+//! | `[1] + [2]`     | `[1, 2]`      | `print`     |
+//! | `[0] * 3`       | `[0, 0, 0]`   | `print`     |
+//! | `[1, 2] * ", "` | `1, 2`        | `puts`      |
+//! | `1 + 2`         | `3` (regr.)   | `puts`      |
+//! | `2 * 3`         | `6` (regr.)   | `puts`      |
+//!
+//! The array-VALUED cases use `print` (which renders through `__sir::format`,
+//! giving the bracketed `[1, 2]` display) rather than `puts` (which flattens a
+//! Seq element-per-line), so the assertion pins the array display form exactly
+//! as the spec's reference table lists it.
+//!
+//! Gates on `rustc` being available and degrades gracefully when the host
+//! linker is missing (mirrors `compile_and_run_puts.rs`).
+
+use std::process::Command;
+
+use semantic_ir::{
+    Block, Effect, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, Span,
+    Stmt,
+};
+use semantic_ir_to_rust::compile;
+
+fn s() -> Span {
+    Span::synthetic()
+}
+
+fn ilit(v: i64) -> Expr {
+    Expr::IntLit { value: v, span: s() }
+}
+
+fn slit(v: &str) -> Expr {
+    Expr::StrLit { value: v.into(), span: s() }
+}
+
+fn seq(items: Vec<Expr>) -> Expr {
+    Expr::SeqLit { items, span: s() }
+}
+
+/// A binary builtin call `<name>(lhs, rhs)` — `+` lowers to `__sir::plus`,
+/// `*` to `__sir::times`.
+fn binop(name: &str, lhs: Expr, rhs: Expr) -> Expr {
+    Expr::BuiltinCall {
+        name: name.into(),
+        args: vec![lhs, rhs],
+        effects: EffectSet::PURE,
+        span: s(),
+    }
+}
+
+/// `<builtin>(expr)` as an effectful statement (MayPrint, matching the
+/// frontend) — `builtin` is `"puts"` or `"print"`.
+fn print_like_stmt(builtin: &str, expr: Expr) -> Stmt {
+    Stmt::ExprStmt {
+        expr: Expr::BuiltinCall {
+            name: builtin.into(),
+            args: vec![expr],
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            span: s(),
+        },
+        span: s(),
+    }
+}
+
+/// Build a module whose `main` runs `<builtin> (<expr>)`.
+fn print_module(builtin: &str, tag: &str, expr: Expr) -> Module {
+    Module {
+        name: format!("polyops_{tag}"),
+        manifest: FeatureManifest::from_features(&[Feature::Sequences, Feature::Strings]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts: vec![print_like_stmt(builtin, expr)],
+                value: Expr::NilLit { span: s() },
+                span: s(),
+            },
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            metadata: Metadata::new(),
+            span: s(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("test")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+fn rustc_available() -> bool {
+    Command::new("rustc")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Compile `module` to Rust, build with `rustc`, run the binary, and return
+/// its normalised (CRLF→LF) stdout.  Returns `None` when the toolchain or a
+/// usable linker is unavailable (the caller then skips).  Panics on a genuine
+/// compile/run failure so a real regression is loud.
+fn compile_run(module: &Module, tag: &str) -> Option<String> {
+    let artifact = compile(module).expect("module should compile to Rust source");
+
+    let dir = std::env::temp_dir();
+    let nonce = std::process::id();
+    let src_path = dir.join(format!("sir_polyops_{tag}_{nonce}.rs"));
+    let bin_path = dir.join(format!(
+        "sir_polyops_{tag}_{nonce}{}",
+        if cfg!(windows) { ".exe" } else { "" }
+    ));
+    std::fs::write(&src_path, &artifact.source).expect("write temp source");
+
+    let mut cmd = Command::new("rustc");
+    cmd.arg("--edition").arg("2021").arg("-O");
+    if let Ok(linker) = std::env::var("SIR_TEST_RUSTC_LINKER") {
+        if !linker.is_empty() {
+            cmd.arg("-C").arg(format!("linker={linker}"));
+        }
+    }
+    let compile_out = cmd
+        .arg(&src_path)
+        .arg("-o")
+        .arg(&bin_path)
+        .output()
+        .expect("invoke rustc");
+    if !compile_out.status.success() {
+        let stderr = String::from_utf8_lossy(&compile_out.stderr);
+        if stderr.contains("linker")
+            && (stderr.contains("not found") || stderr.contains("No such file"))
+        {
+            eprintln!("skipping: no usable linker on host\n{stderr}");
+            let _ = std::fs::remove_file(&src_path);
+            return None;
+        }
+        panic!(
+            "emitted Rust failed to compile:\n--- stderr ---\n{stderr}\n--- source ---\n{}",
+            artifact.source,
+        );
+    }
+
+    let run_out = Command::new(&bin_path).output().expect("run compiled binary");
+    let stderr = String::from_utf8_lossy(&run_out.stderr).into_owned();
+    let stdout = String::from_utf8_lossy(&run_out.stdout).into_owned();
+    let _ = std::fs::remove_file(&src_path);
+    let _ = std::fs::remove_file(&bin_path);
+
+    assert!(
+        run_out.status.success(),
+        "compiled binary exited non-zero (should terminate cleanly):\n{stderr}",
+    );
+    Some(stdout.replace("\r\n", "\n"))
+}
+
+/// Compile+run a `<builtin> (<expr>)` module and assert its stdout, unless the
+/// toolchain is unavailable (in which case the whole suite is skipped up front
+/// by the caller).
+fn assert_output(builtin: &str, tag: &str, expr: Expr, expected: &str) {
+    let Some(out) = compile_run(&print_module(builtin, tag, expr), tag) else {
+        return;
+    };
+    assert_eq!(
+        out, expected,
+        "unexpected output for {tag}; full stdout (escaped): {out:?}"
+    );
+}
+
+/// The whole polymorphic-operator suite in one test so `rustc` is invoked once
+/// per case only when the toolchain is actually present.
+#[test]
+fn polymorphic_plus_times_match_ruby() {
+    if !rustc_available() {
+        eprintln!("skipping: rustc not on PATH");
+        return;
+    }
+
+    // ── `+` string concatenation: "a" + "b" → "ab" ──────────────────
+    assert_output("puts", "str_concat", binop("+", slit("a"), slit("b")), "ab\n");
+
+    // ── `*` string repeat: "ab" * 3 → "ababab" ──────────────────────
+    assert_output("puts", "str_repeat", binop("*", slit("ab"), ilit(3)), "ababab\n");
+
+    // ── `+` array concat: [1] + [2] → [1, 2] ────────────────────────
+    // Printed via `print` so the bracketed Seq display form is asserted.
+    assert_output(
+        "print",
+        "arr_concat",
+        binop("+", seq(vec![ilit(1)]), seq(vec![ilit(2)])),
+        "[1, 2]\n",
+    );
+
+    // ── `*` array repeat: [0] * 3 → [0, 0, 0] ───────────────────────
+    assert_output(
+        "print",
+        "arr_repeat",
+        binop("*", seq(vec![ilit(0)]), ilit(3)),
+        "[0, 0, 0]\n",
+    );
+
+    // ── `*` array join: [1, 2] * ", " → "1, 2" (a String) ───────────
+    assert_output(
+        "puts",
+        "arr_join",
+        binop("*", seq(vec![ilit(1), ilit(2)]), slit(", ")),
+        "1, 2\n",
+    );
+
+    // ── regression: numeric `+` unchanged: 1 + 2 → 3 ───────────────
+    assert_output("puts", "num_plus", binop("+", ilit(1), ilit(2)), "3\n");
+
+    // ── regression: numeric `*` unchanged: 2 * 3 → 6 ───────────────
+    assert_output("puts", "num_times", binop("*", ilit(2), ilit(3)), "6\n");
+}


### PR DESCRIPTION
Rust milestone of the **sir-polymorphic-operators** cascade (spec #7325). Runtime-only — only `code/packages/rust/semantic-ir-to-rust/`.

`plus`/`times` were numeric-only (`as_i64`/`as_f64`), so `"a"+"b"` etc. produced integer garbage. Now `match` on the first operand's `Value` tag (never reflection): `+` Str-concat / fresh-Vec Seq-concat; `*` (via `times_binary`) Str-repeat / Seq-repeat / Seq-join via `format`; else the unchanged numeric fold.

**Security (review-driven):** the `*` repeat arms guard `len*count` with `checked_mul` → `panic("argument too big")` (Ruby's `ArgumentError`) on `usize` overflow, and Seq-repeat short-circuits an empty receiver — closing a reachable overflow/OOM vector.

Execution-proofed via `rustc`; 115 unit tests green, no warnings. Security review: 1 MEDIUM + 1 LOW found and fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)