### PR TITLE
feat(adj-ladder): rung-38 serum anion gap (three-term successive difference)

### DIFF
--- a/code/specs/data/adj-ladder/rung38_serum_anion_gap/gen_items.py
+++ b/code/specs/data/adj-ladder/rung38_serum_anion_gap/gen_items.py
@@ -1,0 +1,200 @@
+"""Generate rung-38 (serum anion gap) items.json for the ADJ-LADDER.
+
+Rung 38 opens the **acid-base / serum-electrolyte** panel on the quantitative band — the arithmetic of the serum
+anion gap, the single most-computed number at the bedside for sorting out a metabolic acidosis. The anion gap
+asks: of the sodium cations in serum, how many are balanced by the two anions the lab routinely measures
+(chloride and bicarbonate)? Whatever is left over is the "gap" — the unmeasured anions (lactate, ketoacids,
+etc.). You take the sodium and subtract BOTH measured anions from it. It uses the same contamination-safe shape
+as the CSF:serum rung (37), the transfusion-pooling rung (36) and the dialysis rung (35): a small table of
+*observed* electrolytes and a tight family of mutually-confusable formulas built **only from those observed
+quantities** (no numeric literal anywhere in any program), so nothing structural can leak.
+
+The clinical setup is a basic metabolic panel. THREE quantities are measured — all in mEq/L:
+
+  SODIUM        the serum sodium cation                (high — the dominant cation)
+  CHLORIDE      the serum chloride anion               (the first measured anion)
+  BICARBONATE   the serum bicarbonate anion            (the second measured anion)
+
+The serum anion gap is **sodium with both measured anions subtracted from it** — a *three-term successive
+difference* — `sodium - chloride - bicarbonate`. That is what makes this rung distinctive: it is a NEW arithmetic
+shape on the ladder — a single running subtraction of THREE observed terms, `a - b - c`. Every prior rung
+composed exactly TWO sub-expressions (rung-31 subtracted one difference from another, rung-36 divided a
+sum-of-products by a sum, rung-37 divided one sum by another); this rung chains two subtractions across three
+raw observed quantities with no interior grouping — the associativity of a left-folded difference is the whole
+point. The core confusion this rung tests is subtracting BOTH anions from the sodium (rather than adding the two
+anions, subtracting only one, or crossing the wrong pair):
+
+  ANION GAP            sodium - chloride - bicarbonate   [ sodium minus BOTH measured anions — the unmeasured-anion gap ]
+  MEASURED ANIONS      chloride + bicarbonate            [ the two measured anions added — the amount subtracted from Na ]
+  SODIUM - CHLORIDE    sodium - chloride                 [ only the first anion subtracted (the partial difference) ]
+
+Each index is a `compute_dimensioned` program (observe the three quantities + `let answer = formula`); the ADJ
+engine carries the arithmetic and the harness reads the scalar via the existing `compute_dimensioned`
+extractor — no harness/engine change, exactly as rungs 8/16/…/36/37. This rung exercises the engine across a
+LEFT-FOLDED chain of TWO subtractions (`(sodium - chloride) - bicarbonate`).
+
+Contamination-safe by construction: every formula is built only from the three observed quantities via `-` and
+`+` — **no structural constants** — so every program literal is grounded in the stem. The gap itself never
+appears as a literal (it is computed from the observed electrolytes). The observed quantities carry **digit-free
+identifiers** (`sodium`, `chloride`, `bicarbonate`) so no numeral hides inside a variable name. The five options
+are a tight family over the same quantities: the three real indices plus the two classic slips —
+
+  SODIUM - BICARB   sodium - bicarbonate               the WRONG anion subtracted (bicarbonate instead of chloride), and
+  ALL SUMMED        sodium + chloride + bicarbonate    the anions ADDED to the sodium instead of subtracted,
+
+which are exactly the mistakes a student makes. Gold rotates A-E by index.
+
+Note on scale: the anion gap is small (order 8-16 mEq/L — sodium is only slightly more than the two anions
+combined), the measured-anion sum is order 120-135, the sodium-minus-chloride partial difference is order 35, the
+sodium-minus-bicarbonate distractor is order 115, and the all-summed distractor is order 260; the tables below
+are chosen so the five family values are pairwise distinct — with a comfortable margin — for every item, asserted
+at build time (all three electrolytes positive and the gap strictly positive, and no two family values collide).
+"""
+import json
+
+LETTERS = ["A", "B", "C", "D", "E"]
+
+# (SODIUM, CHLORIDE, BICARBONATE) observed serum electrolytes, all in mEq/L. Sodium is the dominant cation; the
+# gap sodium - chloride - bicarbonate stays in the physiologic 7-18 band. All three are strictly positive and the
+# gap is strictly positive. The five family values are asserted pairwise-distinct (with margin) below.
+TABLES = [
+    (140, 104, 24),
+    (138, 100, 22),
+    (142, 108, 26),
+    (136, 98, 20),
+    (145, 110, 25),
+    (139, 102, 23),
+    (141, 106, 28),
+]
+
+# The option family (5 members), all built from the observed quantities via `-` / `+`. Every identifier is
+# DIGIT-FREE. key -> (display name, formula-as-adj). Only the first three are *queried* (used as gold); all five
+# always appear as the options.
+FAMILY = [
+    (
+        "anion_gap",
+        "serum anion gap",
+        "sodium - chloride - bicarbonate",
+    ),
+    (
+        "measured_anions",
+        "sum of the measured anions",
+        "chloride + bicarbonate",
+    ),
+    (
+        "sodium_minus_chloride",
+        "sodium with only chloride subtracted",
+        "sodium - chloride",
+    ),
+    (
+        "sodium_minus_bicarb",
+        "sodium with the wrong anion (bicarbonate) subtracted",
+        "sodium - bicarbonate",
+    ),
+    (
+        "all_summed",
+        "sodium and both anions all added together",
+        "sodium + chloride + bicarbonate",
+    ),
+]
+QUERIED = ["anion_gap", "measured_anions", "sodium_minus_chloride"]
+ORDER = [k for k, _, _ in FAMILY]
+
+
+def scalar(v):
+    return {"value": v, "unit": "scalar"}
+
+
+def family_values(na, cl, hco3):
+    # Operation order mirrors the ADJ program exactly (a left-folded difference: (na - cl) - hco3), so the
+    # Python option value and the engine result are the same IEEE-double (well within the harness's 1e-9 match
+    # tolerance).
+    return {
+        "anion_gap": na - cl - hco3,
+        "measured_anions": cl + hco3,
+        "sodium_minus_chloride": na - cl,
+        "sodium_minus_bicarb": na - hco3,
+        "all_summed": na + cl + hco3,
+    }
+
+
+def build():
+    name_of = {k: nm for k, nm, _ in FAMILY}
+    formula_of = {k: f for k, _, f in FAMILY}
+    items = []
+    idx = 0
+
+    def num(x):
+        return int(x) if float(x).is_integer() else x
+
+    for na, cl, hco3 in TABLES:
+        assert na > 0 and cl > 0 and hco3 > 0, (na, cl, hco3)
+        assert na - cl - hco3 > 0, (na, cl, hco3)
+        fv = family_values(na, cl, hco3)
+        # Pairwise-distinct with a comfortable margin so the harness never sees two options
+        # matching the gold value within its 1e-9 tolerance.
+        vals = [fv[key] for key in ORDER]
+        for i in range(len(vals)):
+            for j in range(i + 1, len(vals)):
+                assert abs(vals[i] - vals[j]) > 1e-6, (na, cl, hco3, ORDER[i], ORDER[j], fv)
+        for key in QUERIED:
+            gold_val = fv[key]
+            gold_pos = idx % 5
+            others = [fv[k2] for k2 in ORDER if abs(fv[k2] - gold_val) > 1e-12]
+            opts_vals = others[:]
+            opts_vals.insert(gold_pos, gold_val)
+            opts_vals = opts_vals[:5]
+            if abs(opts_vals[gold_pos] - gold_val) > 1e-12:
+                opts_vals[gold_pos] = gold_val
+            assert len({round(v, 9) for v in opts_vals}) == 5, (key, na, cl, hco3, opts_vals)
+            options = {LETTERS[i]: scalar(opts_vals[i]) for i in range(5)}
+            items.append({
+                "id": f"r38ag-{idx + 1:02d}",
+                "qtype": "serum_anion_gap",
+                "stem": (
+                    f"A basic metabolic panel shows a serum sodium of {num(na)} mEq/L, a chloride of "
+                    f"{num(cl)} mEq/L, and a bicarbonate of {num(hco3)} mEq/L. What is the {name_of[key]}?"
+                ),
+                "program": (
+                    f"observe sodium({num(na)})\n"
+                    f"observe chloride({num(cl)})\n"
+                    f"observe bicarbonate({num(hco3)})\n"
+                    f"let answer = {formula_of[key]}\n"
+                    "? answer\n"
+                ),
+                "answer_from": {"type": "compute_dimensioned", "name": "answer"},
+                "options": options,
+                "gold_letter": LETTERS[gold_pos],
+            })
+            idx += 1
+    return {
+        "description": (
+            "ADJ-LADDER rung 38 — serum anion gap from three stated serum electrolytes (a NEW panel: acid-base / "
+            "serum-electrolyte analysis). From three stated values (sodium, chloride, bicarbonate) compute the "
+            "anion gap (sodium-chloride-bicarbonate), the measured-anion sum (chloride+bicarbonate), or the "
+            "sodium-minus-chloride partial difference (sodium-chloride). Each item is a compute_dimensioned "
+            "program (observe the three quantities, let answer = formula); the ADJ engine carries the "
+            "arithmetic — a NEW shape, a THREE-TERM SUCCESSIVE DIFFERENCE (sodium-chloride-bicarbonate), a "
+            "left-folded chain of two subtractions with no interior grouping — and the harness matches the scalar "
+            "to the printed options. Contamination-safe: every index is built only from the three observed "
+            "electrolytes via - and + — no constant leaks (the anion gap is a pure running subtraction), and the "
+            "gap itself never appears as a literal (it is computed from the observed electrolytes) — and the "
+            "observed quantities carry digit-free identifiers so no numeral hides inside a variable name. The five "
+            "options are a family over the same quantities, so the distractors are exactly the slips students "
+            "make: subtracting the WRONG anion (sodium-bicarbonate, using bicarbonate in place of chloride) and "
+            "ADDING the two anions to the sodium (sodium+chloride+bicarbonate) instead of subtracting them. The "
+            "core confusion tested is subtracting BOTH measured anions from the sodium."
+        ),
+        "items": items,
+    }
+
+
+if __name__ == "__main__":
+    doc = build()
+    with open("items.json", "w") as f:
+        json.dump(doc, f, indent=2)
+        f.write("\n")
+    print("wrote items.json:", len(doc["items"]), "items")
+    for it in doc["items"]:
+        print(it["id"], it["qtype"], "gold", it["gold_letter"],
+              "=", round(it["options"][it["gold_letter"]]["value"], 6))

--- a/code/specs/data/adj-ladder/rung38_serum_anion_gap/items.json
+++ b/code/specs/data/adj-ladder/rung38_serum_anion_gap/items.json
@@ -1,0 +1,698 @@
+{
+  "description": "ADJ-LADDER rung 38 \u2014 serum anion gap from three stated serum electrolytes (a NEW panel: acid-base / serum-electrolyte analysis). From three stated values (sodium, chloride, bicarbonate) compute the anion gap (sodium-chloride-bicarbonate), the measured-anion sum (chloride+bicarbonate), or the sodium-minus-chloride partial difference (sodium-chloride). Each item is a compute_dimensioned program (observe the three quantities, let answer = formula); the ADJ engine carries the arithmetic \u2014 a NEW shape, a THREE-TERM SUCCESSIVE DIFFERENCE (sodium-chloride-bicarbonate), a left-folded chain of two subtractions with no interior grouping \u2014 and the harness matches the scalar to the printed options. Contamination-safe: every index is built only from the three observed electrolytes via - and + \u2014 no constant leaks (the anion gap is a pure running subtraction), and the gap itself never appears as a literal (it is computed from the observed electrolytes) \u2014 and the observed quantities carry digit-free identifiers so no numeral hides inside a variable name. The five options are a family over the same quantities, so the distractors are exactly the slips students make: subtracting the WRONG anion (sodium-bicarbonate, using bicarbonate in place of chloride) and ADDING the two anions to the sodium (sodium+chloride+bicarbonate) instead of subtracting them. The core confusion tested is subtracting BOTH measured anions from the sodium.",
+  "items": [
+    {
+      "id": "r38ag-01",
+      "qtype": "serum_anion_gap",
+      "stem": "A basic metabolic panel shows a serum sodium of 140 mEq/L, a chloride of 104 mEq/L, and a bicarbonate of 24 mEq/L. What is the serum anion gap?",
+      "program": "observe sodium(140)\nobserve chloride(104)\nobserve bicarbonate(24)\nlet answer = sodium - chloride - bicarbonate\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 12,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 128,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 36,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 116,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 268,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r38ag-02",
+      "qtype": "serum_anion_gap",
+      "stem": "A basic metabolic panel shows a serum sodium of 140 mEq/L, a chloride of 104 mEq/L, and a bicarbonate of 24 mEq/L. What is the sum of the measured anions?",
+      "program": "observe sodium(140)\nobserve chloride(104)\nobserve bicarbonate(24)\nlet answer = chloride + bicarbonate\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 12,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 128,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 36,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 116,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 268,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r38ag-03",
+      "qtype": "serum_anion_gap",
+      "stem": "A basic metabolic panel shows a serum sodium of 140 mEq/L, a chloride of 104 mEq/L, and a bicarbonate of 24 mEq/L. What is the sodium with only chloride subtracted?",
+      "program": "observe sodium(140)\nobserve chloride(104)\nobserve bicarbonate(24)\nlet answer = sodium - chloride\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 12,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 128,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 36,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 116,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 268,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r38ag-04",
+      "qtype": "serum_anion_gap",
+      "stem": "A basic metabolic panel shows a serum sodium of 138 mEq/L, a chloride of 100 mEq/L, and a bicarbonate of 22 mEq/L. What is the serum anion gap?",
+      "program": "observe sodium(138)\nobserve chloride(100)\nobserve bicarbonate(22)\nlet answer = sodium - chloride - bicarbonate\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 122,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 38,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 116,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 16,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 260,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r38ag-05",
+      "qtype": "serum_anion_gap",
+      "stem": "A basic metabolic panel shows a serum sodium of 138 mEq/L, a chloride of 100 mEq/L, and a bicarbonate of 22 mEq/L. What is the sum of the measured anions?",
+      "program": "observe sodium(138)\nobserve chloride(100)\nobserve bicarbonate(22)\nlet answer = chloride + bicarbonate\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 16,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 38,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 116,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 260,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 122,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r38ag-06",
+      "qtype": "serum_anion_gap",
+      "stem": "A basic metabolic panel shows a serum sodium of 138 mEq/L, a chloride of 100 mEq/L, and a bicarbonate of 22 mEq/L. What is the sodium with only chloride subtracted?",
+      "program": "observe sodium(138)\nobserve chloride(100)\nobserve bicarbonate(22)\nlet answer = sodium - chloride\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 38,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 16,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 122,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 116,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 260,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r38ag-07",
+      "qtype": "serum_anion_gap",
+      "stem": "A basic metabolic panel shows a serum sodium of 142 mEq/L, a chloride of 108 mEq/L, and a bicarbonate of 26 mEq/L. What is the serum anion gap?",
+      "program": "observe sodium(142)\nobserve chloride(108)\nobserve bicarbonate(26)\nlet answer = sodium - chloride - bicarbonate\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 134,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 34,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 116,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 276,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r38ag-08",
+      "qtype": "serum_anion_gap",
+      "stem": "A basic metabolic panel shows a serum sodium of 142 mEq/L, a chloride of 108 mEq/L, and a bicarbonate of 26 mEq/L. What is the sum of the measured anions?",
+      "program": "observe sodium(142)\nobserve chloride(108)\nobserve bicarbonate(26)\nlet answer = chloride + bicarbonate\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 34,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 134,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 116,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 276,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r38ag-09",
+      "qtype": "serum_anion_gap",
+      "stem": "A basic metabolic panel shows a serum sodium of 142 mEq/L, a chloride of 108 mEq/L, and a bicarbonate of 26 mEq/L. What is the sodium with only chloride subtracted?",
+      "program": "observe sodium(142)\nobserve chloride(108)\nobserve bicarbonate(26)\nlet answer = sodium - chloride\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 134,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 116,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 34,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 276,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r38ag-10",
+      "qtype": "serum_anion_gap",
+      "stem": "A basic metabolic panel shows a serum sodium of 136 mEq/L, a chloride of 98 mEq/L, and a bicarbonate of 20 mEq/L. What is the serum anion gap?",
+      "program": "observe sodium(136)\nobserve chloride(98)\nobserve bicarbonate(20)\nlet answer = sodium - chloride - bicarbonate\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 118,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 38,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 116,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 254,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 18,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r38ag-11",
+      "qtype": "serum_anion_gap",
+      "stem": "A basic metabolic panel shows a serum sodium of 136 mEq/L, a chloride of 98 mEq/L, and a bicarbonate of 20 mEq/L. What is the sum of the measured anions?",
+      "program": "observe sodium(136)\nobserve chloride(98)\nobserve bicarbonate(20)\nlet answer = chloride + bicarbonate\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 118,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 18,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 38,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 116,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 254,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r38ag-12",
+      "qtype": "serum_anion_gap",
+      "stem": "A basic metabolic panel shows a serum sodium of 136 mEq/L, a chloride of 98 mEq/L, and a bicarbonate of 20 mEq/L. What is the sodium with only chloride subtracted?",
+      "program": "observe sodium(136)\nobserve chloride(98)\nobserve bicarbonate(20)\nlet answer = sodium - chloride\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 18,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 38,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 118,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 116,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 254,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r38ag-13",
+      "qtype": "serum_anion_gap",
+      "stem": "A basic metabolic panel shows a serum sodium of 145 mEq/L, a chloride of 110 mEq/L, and a bicarbonate of 25 mEq/L. What is the serum anion gap?",
+      "program": "observe sodium(145)\nobserve chloride(110)\nobserve bicarbonate(25)\nlet answer = sodium - chloride - bicarbonate\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 135,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 35,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 10,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 120,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 280,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r38ag-14",
+      "qtype": "serum_anion_gap",
+      "stem": "A basic metabolic panel shows a serum sodium of 145 mEq/L, a chloride of 110 mEq/L, and a bicarbonate of 25 mEq/L. What is the sum of the measured anions?",
+      "program": "observe sodium(145)\nobserve chloride(110)\nobserve bicarbonate(25)\nlet answer = chloride + bicarbonate\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 10,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 35,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 120,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 135,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 280,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r38ag-15",
+      "qtype": "serum_anion_gap",
+      "stem": "A basic metabolic panel shows a serum sodium of 145 mEq/L, a chloride of 110 mEq/L, and a bicarbonate of 25 mEq/L. What is the sodium with only chloride subtracted?",
+      "program": "observe sodium(145)\nobserve chloride(110)\nobserve bicarbonate(25)\nlet answer = sodium - chloride\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 10,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 135,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 120,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 280,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 35,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r38ag-16",
+      "qtype": "serum_anion_gap",
+      "stem": "A basic metabolic panel shows a serum sodium of 139 mEq/L, a chloride of 102 mEq/L, and a bicarbonate of 23 mEq/L. What is the serum anion gap?",
+      "program": "observe sodium(139)\nobserve chloride(102)\nobserve bicarbonate(23)\nlet answer = sodium - chloride - bicarbonate\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 14,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 125,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 37,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 116,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 264,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r38ag-17",
+      "qtype": "serum_anion_gap",
+      "stem": "A basic metabolic panel shows a serum sodium of 139 mEq/L, a chloride of 102 mEq/L, and a bicarbonate of 23 mEq/L. What is the sum of the measured anions?",
+      "program": "observe sodium(139)\nobserve chloride(102)\nobserve bicarbonate(23)\nlet answer = chloride + bicarbonate\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 14,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 125,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 37,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 116,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 264,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r38ag-18",
+      "qtype": "serum_anion_gap",
+      "stem": "A basic metabolic panel shows a serum sodium of 139 mEq/L, a chloride of 102 mEq/L, and a bicarbonate of 23 mEq/L. What is the sodium with only chloride subtracted?",
+      "program": "observe sodium(139)\nobserve chloride(102)\nobserve bicarbonate(23)\nlet answer = sodium - chloride\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 14,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 125,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 37,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 116,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 264,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r38ag-19",
+      "qtype": "serum_anion_gap",
+      "stem": "A basic metabolic panel shows a serum sodium of 141 mEq/L, a chloride of 106 mEq/L, and a bicarbonate of 28 mEq/L. What is the serum anion gap?",
+      "program": "observe sodium(141)\nobserve chloride(106)\nobserve bicarbonate(28)\nlet answer = sodium - chloride - bicarbonate\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 134,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 35,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 113,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 7,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 275,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r38ag-20",
+      "qtype": "serum_anion_gap",
+      "stem": "A basic metabolic panel shows a serum sodium of 141 mEq/L, a chloride of 106 mEq/L, and a bicarbonate of 28 mEq/L. What is the sum of the measured anions?",
+      "program": "observe sodium(141)\nobserve chloride(106)\nobserve bicarbonate(28)\nlet answer = chloride + bicarbonate\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 7,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 35,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 113,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 275,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 134,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r38ag-21",
+      "qtype": "serum_anion_gap",
+      "stem": "A basic metabolic panel shows a serum sodium of 141 mEq/L, a chloride of 106 mEq/L, and a bicarbonate of 28 mEq/L. What is the sodium with only chloride subtracted?",
+      "program": "observe sodium(141)\nobserve chloride(106)\nobserve bicarbonate(28)\nlet answer = sodium - chloride\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 35,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 7,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 134,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 113,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 275,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    }
+  ]
+}

--- a/code/specs/data/adj-ladder/test_ladder_eval.py
+++ b/code/specs/data/adj-ladder/test_ladder_eval.py
@@ -75,6 +75,7 @@ SELF_CONTAINED_RUNGS = (
     "rung35_dialysis_clearance",
     "rung36_transfusion_pooling",
     "rung37_csf_serum_ratio",
+    "rung38_serum_anion_gap",
 )
 
 


### PR DESCRIPTION
## Summary

Adds ADJ-LADDER **rung 38 — the serum anion gap**, cycling to a genuinely NEW arithmetic shape: a **three-term successive difference** `sodium - chloride - bicarbonate`, i.e. a left-folded chain of two subtractions `(a - b) - c` across three raw observed quantities with **no interior grouping**.

Every prior rung composed exactly *two* sub-expressions (rung-31 difference-of-differences, rung-32 ratio-of-differences, rung-36 weighted-average, rung-37 ratio-of-two-sums). This rung is the first to chain subtractions over three flat terms — the associativity of a left-folded difference is the whole point.

**New panel:** acid-base / serum-electrolyte analysis (the most-computed bedside number for a metabolic acidosis).

## The family (5 mutually-confusable options over the same 3 observed quantities)

| option | formula | role |
|---|---|---|
| anion gap | `sodium - chloride - bicarbonate` | **the gap** — sodium minus BOTH measured anions |
| measured anions | `chloride + bicarbonate` | the two measured anions added |
| Na − Cl | `sodium - chloride` | only the first anion subtracted (partial) |
| Na − HCO₃ *(distractor)* | `sodium - bicarbonate` | the WRONG anion subtracted |
| all summed *(distractor)* | `sodium + chloride + bicarbonate` | anions ADDED to Na instead of subtracted |

First three are queried as gold (gold rotates A–E); all five always appear as options. The distractors are exactly the slips a student makes.

## Contamination-safe by construction
- Every formula is built **only** from the three observed quantities via `-` and `+` — no numeric literal in any program.
- Digit-free identifiers (`sodium`, `chloride`, `bicarbonate`) — no numeral hides in a variable name.
- The gap never appears as a literal (always computed from the observed electrolytes).

## Mechanics
- 7 tables × 3 queried = **21 items**; each is a `compute_dimensioned` program (`observe` the three quantities, `let answer = formula`, `? answer`).
- Runs on the existing engine + harness with **no engine/harness change** — exactly as rungs 8/16/…/36/37.
- Pairwise-distinctness of all five family values (with margin) asserted at build time; the gap is asserted strictly positive.

## Verification
- Registered in `SELF_CONTAINED_RUNGS`; the rung-38 gate passes **3/3** (every gold selected — 0 wrong / 0 abstain; contamination clean; items.json valid).
- Security-reviewed (inline): pure offline data generator, no external input, no deserialization, fixed local write path — PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
