### PR TITLE
feat(latex): inverse-trig in latex "…" → ComputeOp::Asin/Acos/Atan

### DIFF
--- a/code/packages/rust/adj-lang/CHANGELOG.md
+++ b/code/packages/rust/adj-lang/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.27.0] - 2026-07-01 — inverse-trig in `latex "…"` (`\arcsin`/`\arccos`/`\arctan`)
+
+### Added
+
+- The `latex "…"` adapter now lowers **inverse-trig calls** — `\arcsin(x)`,
+  `\arccos(x)`, `\arctan(x)` (a `MathExpr::Call` with `Func::Asin/Acos/Atan`) — to
+  the new `NamedFn::Asin/Acos/Atan` and thence to `ComputeOp::Asin/Acos/Atan` in
+  the engine. Same `Scalar → Scalar` contract as the forward-trig family.
+- Domain errors (operand outside [−1, 1] for arcsin/arccos) surface as
+  `ComputeError::NonFinite` through the engine's non-finite guard — never a silent
+  NaN in a verdict.
+- 3 integration tests in `lower.rs`: `\arcsin(0)=0`, `\arccos(1)=0`, `\arctan(0)=0`.
+- Unrecognised `Func` variants still produce a clean adapter error (unchanged).
+
 ## [0.26.0] - 2026-07-02 — named transcendental functions in `latex "…"` (`\sin`/`\cos`/`\tan`/`\ln`/`\log`/`\exp`)
 
 ### Added

--- a/code/packages/rust/adj-lang/Cargo.toml
+++ b/code/packages/rust/adj-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2021"
 description = "Surface-syntax frontend for the adjudication framework's probabilistic-logic rulebooks. Lexes, parses, and lowers a domain-expert-readable DSL into a `logic-engine` KnowledgeBase. Dissolves ADJ46 awkwardness items A10 (rulebook syntax) and A4 (joint contributions syntactically distinct)."
 

--- a/code/packages/rust/adj-lang/src/adapter.rs
+++ b/code/packages/rust/adj-lang/src/adapter.rs
@@ -1020,6 +1020,13 @@ fn latex_math_to_expr_ast(expr: &MathExpr, source: &str) -> Result<ExprAst, Adap
                 Func::Sin => NamedFn::Sin,
                 Func::Cos => NamedFn::Cos,
                 Func::Tan => NamedFn::Tan,
+                // Inverse-trig family: `\arcsin(x)` / `\arccos(x)` / `\arctan(x)`.
+                // Operand must be in [−1, 1] for arcsin/arccos; arctan accepts all reals.
+                // Domain errors (|x|>1 for arcsin/arccos) surface as the NonFinite guard
+                // in the engine — the engine never silently emits a NaN.
+                Func::Asin => NamedFn::Asin,
+                Func::Acos => NamedFn::Acos,
+                Func::Atan => NamedFn::Atan,
                 Func::Ln => NamedFn::Ln,
                 Func::Log => NamedFn::Log,
                 Func::Exp => NamedFn::Exp,

--- a/code/packages/rust/adj-lang/src/ast.rs
+++ b/code/packages/rust/adj-lang/src/ast.rs
@@ -91,6 +91,12 @@ pub enum NamedFn {
     Sin,
     Cos,
     Tan,
+    /// Inverse sine, `arcsin(x)` — result in radians, domain [−1, 1] (`\arcsin`).
+    Asin,
+    /// Inverse cosine, `arccos(x)` — result in radians, domain [−1, 1] (`\arccos`).
+    Acos,
+    /// Inverse tangent, `arctan(x)` — result in radians, all reals (`\arctan`).
+    Atan,
     /// Natural logarithm (`\ln`).
     Ln,
     /// Base-10 logarithm (`\log`).

--- a/code/packages/rust/adj-lang/src/lower.rs
+++ b/code/packages/rust/adj-lang/src/lower.rs
@@ -719,6 +719,9 @@ fn lower_named_fn(f: NamedFn) -> ComputeOp {
         NamedFn::Sin => ComputeOp::Sin,
         NamedFn::Cos => ComputeOp::Cos,
         NamedFn::Tan => ComputeOp::Tan,
+        NamedFn::Asin => ComputeOp::Asin,
+        NamedFn::Acos => ComputeOp::Acos,
+        NamedFn::Atan => ComputeOp::Atan,
         NamedFn::Ln => ComputeOp::Ln,
         NamedFn::Log => ComputeOp::Log,
         NamedFn::Exp => ComputeOp::Exp,
@@ -1939,6 +1942,51 @@ contributes 1000000 from answer == 60 to correct
              let answer = latex \"$\\cos(x)$\"\n\
              prior 0.10 for correct\n\
              contributes 1000000 from answer == 1 to correct\n\
+             ? correct\n",
+        )
+        .unwrap();
+        assert!(d.ranked[0].posterior > 0.99, "{d:?}");
+    }
+
+    #[test]
+    fn native_latex_arcsin_of_zero_is_zero() {
+        // `\arcsin(x)` with x=0 is 0 — a domain-safe anchor that the named-function
+        // call lowers through NamedFn::Asin → ComputeOp::Asin and the engine computes
+        // as f64::asin(0.0)=0.0.
+        let d = crate::compile_and_decide(
+            "observe x(0)\n\
+             let answer = latex \"$\\arcsin(x)$\"\n\
+             prior 0.10 for correct\n\
+             contributes 1000000 from answer == 0 to correct\n\
+             ? correct\n",
+        )
+        .unwrap();
+        assert!(d.ranked[0].posterior > 0.99, "{d:?}");
+    }
+
+    #[test]
+    fn native_latex_arccos_of_one_is_zero() {
+        // `\arccos(x)` with x=1 is 0 — domain-safe anchor: arccos(1)=0 in radians.
+        let d = crate::compile_and_decide(
+            "observe x(1)\n\
+             let answer = latex \"$\\arccos(x)$\"\n\
+             prior 0.10 for correct\n\
+             contributes 1000000 from answer == 0 to correct\n\
+             ? correct\n",
+        )
+        .unwrap();
+        assert!(d.ranked[0].posterior > 0.99, "{d:?}");
+    }
+
+    #[test]
+    fn native_latex_arctan_of_zero_is_zero() {
+        // `\arctan(x)` with x=0 is 0 — defined on all reals, never produces a
+        // domain error. Lowered through NamedFn::Atan → ComputeOp::Atan.
+        let d = crate::compile_and_decide(
+            "observe x(0)\n\
+             let answer = latex \"$\\arctan(x)$\"\n\
+             prior 0.10 for correct\n\
+             contributes 1000000 from answer == 0 to correct\n\
              ? correct\n",
         )
         .unwrap();

--- a/code/packages/rust/logic-engine/CHANGELOG.md
+++ b/code/packages/rust/logic-engine/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.32.0] - 2026-07-01 — inverse-trig unary ops (`arcsin`/`arccos`/`arctan`)
+
+### Added
+
+- Three **inverse-trig** unary ops — `ComputeOp::Asin`, `Acos`, `Atan` — carried in
+  the existing `ComputeExpr::Unary` (no new node type), evaluated in `eval_unary`.
+  They make LaTeX `\arcsin(x)` / `\arccos(x)` / `\arctan(x)` calls (adj-lang's
+  `latex "…"` surface) computable as single native nodes.
+- Like all transcendentals: operand must be dimensionless (`Scalar`); result is
+  `Scalar`; exact-rational sidecar is dropped (inverse-trig is irrational). A
+  dimensioned operand raises `DimensionMismatch`.
+- Domain errors surface through the non-finite guard: `arcsin`/`arccos` of a value
+  outside [−1, 1] produces `NaN` in IEEE, caught as `ComputeError::NonFinite` before
+  it can propagate into a verdict. `arctan` is defined on all reals and never
+  produces a non-finite result.
+- `ComputeOp::symbol()` returns `"arcsin"` / `"arccos"` / `"arctan"` for audit
+  rendering.
+- 4 unit tests: identity anchors (arcsin(0)=0, arccos(1)=0, arctan(0)=0),
+  round-trip (arcsin(sin(π/6))=π/6), out-of-domain NonFinite guard, dimension error.
+
 ## [0.31.0] - 2026-07-02 — native transcendental functions (`sin`/`cos`/`tan`/`ln`/`log`/`exp`)
 
 ### Added

--- a/code/packages/rust/logic-engine/Cargo.toml
+++ b/code/packages/rust/logic-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logic-engine"
-version = "0.31.0"
+version = "0.32.0"
 edition = "2021"
 description = "Probability-aware facts, rules, KB, SLD find-first/enumerate + WMC posterior + LP19e likelihood-ratio Bayesian aggregation."
 

--- a/code/packages/rust/logic-engine/src/compute.rs
+++ b/code/packages/rust/logic-engine/src/compute.rs
@@ -213,18 +213,25 @@ pub enum ComputeOp {
     /// LaTeX fence `\left\lfloor x\right\rceil` (floor-left, ceil-right).
     Round,
     /// The named **transcendental** unary functions `sin`, `cos`, `tan`, `ln`
-    /// (natural log), `log` (base-10), `exp`. Unlike the rounding unary ops these
-    /// are **not** dimension-preserving: a transcendental is only defined on a
-    /// pure number, so the operand must be dimensionless (`Scalar`) and the
-    /// result is `Scalar` (`sin(3 dollars)` is a category error, rejected). They
-    /// are irrational in general, so they drop the exact-rational sidecar. Each
-    /// is carried in a [`ComputeExpr::Unary`] and lowered from a LaTeX
-    /// `\sin(x)` / `\ln(x)` / `\exp(x)` … named-function call (adj-lang's
-    /// `latex "…"` surface). Domain errors (`ln` of a non-positive number,
-    /// `exp` overflow, `tan` at a pole) surface as the usual non-finite guard.
+    /// (natural log), `log` (base-10), `exp`, and the **inverse-trig** family
+    /// `arcsin`, `arccos`, `arctan`. Unlike the rounding unary ops these are
+    /// **not** dimension-preserving: a transcendental is only defined on a pure
+    /// number, so the operand must be dimensionless (`Scalar`) and the result is
+    /// `Scalar` (`sin(3 dollars)` is a category error, rejected). They are
+    /// irrational in general, so they drop the exact-rational sidecar. Each is
+    /// carried in a [`ComputeExpr::Unary`] and lowered from a LaTeX named-function
+    /// call (adj-lang's `latex "…"` surface). Domain errors (`ln` of a non-positive
+    /// number, `exp` overflow, `tan` at a pole, `arcsin`/`arccos` outside [−1, 1])
+    /// surface as the usual non-finite guard — never a silently-wrong number.
     Sin,
     Cos,
     Tan,
+    /// Inverse sine — result in radians, defined on [−1, 1] (`\arcsin`).
+    Asin,
+    /// Inverse cosine — result in radians, defined on [−1, 1] (`\arccos`).
+    Acos,
+    /// Inverse tangent — result in radians, defined on all reals (`\arctan`).
+    Atan,
     Ln,
     Log,
     Exp,
@@ -251,6 +258,9 @@ impl ComputeOp {
             ComputeOp::Sin => "sin",
             ComputeOp::Cos => "cos",
             ComputeOp::Tan => "tan",
+            ComputeOp::Asin => "arcsin",
+            ComputeOp::Acos => "arccos",
+            ComputeOp::Atan => "arctan",
             ComputeOp::Ln => "ln",
             ComputeOp::Log => "log",
             ComputeOp::Exp => "exp",
@@ -636,8 +646,8 @@ fn eval(
 }
 
 /// Evaluate a unary op — the rounding family (`Abs`/`Floor`/`Ceil`/`Round`) or a
-/// transcendental (`Sin`/`Cos`/`Tan`/`Ln`/`Log`/`Exp`) — into a derivation node +
-/// dimension.
+/// transcendental (`Sin`/`Cos`/`Tan`/`Asin`/`Acos`/`Atan`/`Ln`/`Log`/`Exp`) —
+/// into a derivation node + dimension.
 /// Split out of [`eval`] and marked `#[inline(never)]` so its locals live in their
 /// own stack frame rather than enlarging every one of `eval`'s up-to-`MAX_EVAL_DEPTH`
 /// recursive frames — a fatter `eval` frame multiplied across 256 levels can
@@ -658,7 +668,15 @@ fn eval_unary(
     // ops use (the operand's dimension vs the required `Scalar`).
     let transcendental = matches!(
         op,
-        ComputeOp::Sin | ComputeOp::Cos | ComputeOp::Tan | ComputeOp::Ln | ComputeOp::Log | ComputeOp::Exp
+        ComputeOp::Sin
+            | ComputeOp::Cos
+            | ComputeOp::Tan
+            | ComputeOp::Asin
+            | ComputeOp::Acos
+            | ComputeOp::Atan
+            | ComputeOp::Ln
+            | ComputeOp::Log
+            | ComputeOp::Exp
     );
     if transcendental && !dim.is_scalar() {
         return Err(ComputeError::DimensionMismatch {
@@ -680,6 +698,12 @@ fn eval_unary(
         ComputeOp::Sin => value.sin(),
         ComputeOp::Cos => value.cos(),
         ComputeOp::Tan => value.tan(),
+        // arcsin/arccos are defined on [−1, 1]; outside that domain f64 returns NaN,
+        // which the non-finite guard below converts to a clean ComputeError::NonFinite.
+        ComputeOp::Asin => value.asin(),
+        ComputeOp::Acos => value.acos(),
+        // arctan is defined on all reals; it never produces a non-finite result.
+        ComputeOp::Atan => value.atan(),
         ComputeOp::Ln => value.ln(),
         ComputeOp::Log => value.log10(),
         ComputeOp::Exp => value.exp(),
@@ -1160,6 +1184,67 @@ mod tests {
         let c = compute("c", &ComputeExpr::Unary(ComputeOp::Cos, Box::new(ComputeExpr::Lit(0.0))), &kb_with(vec![])).unwrap();
         assert_eq!(c.value, 1.0);
         assert_eq!(c.dim, Dimension::Scalar);
+    }
+
+    #[test]
+    fn arcsin_of_zero_is_zero_arccos_of_one_is_zero_arctan_of_zero_is_zero() {
+        // Identity anchors that don't depend on π: arcsin(0)=0, arccos(1)=0, arctan(0)=0.
+        // All three are transcendental: operand is Scalar, result is Scalar, exact sidecar
+        // is dropped.
+        let kb = kb_with(vec![]);
+        let s = compute("s", &ComputeExpr::Unary(ComputeOp::Asin, Box::new(ComputeExpr::Lit(0.0))), &kb).unwrap();
+        assert_eq!(s.value, 0.0);
+        assert_eq!(s.dim, Dimension::Scalar);
+        assert_eq!(s.exact, None);
+
+        let c = compute("c", &ComputeExpr::Unary(ComputeOp::Acos, Box::new(ComputeExpr::Lit(1.0))), &kb).unwrap();
+        assert_eq!(c.value, 0.0);
+        assert_eq!(c.dim, Dimension::Scalar);
+
+        let t = compute("t", &ComputeExpr::Unary(ComputeOp::Atan, Box::new(ComputeExpr::Lit(0.0))), &kb).unwrap();
+        assert_eq!(t.value, 0.0);
+        assert_eq!(t.dim, Dimension::Scalar);
+    }
+
+    #[test]
+    fn arcsin_and_arccos_are_inverses_of_sin_and_cos() {
+        // arcsin(sin(x)) = x and arccos(cos(x)) = x for x in [−π/2, π/2] and [0, π].
+        // Use x = π/6 (30°): sin(π/6)=0.5 → arcsin(0.5)=π/6; cos(π/6)=√3/2 → arccos(√3/2)=π/6.
+        let half_pi_over_3 = std::f64::consts::PI / 6.0;
+        let kb = kb_with(vec![]);
+        let inner_sin = ComputeExpr::Unary(ComputeOp::Sin, Box::new(ComputeExpr::Lit(half_pi_over_3)));
+        let roundtrip = compute("r", &ComputeExpr::Unary(ComputeOp::Asin, Box::new(inner_sin)), &kb).unwrap();
+        assert!((roundtrip.value - half_pi_over_3).abs() < 1e-12, "{}", roundtrip.value);
+
+        let inner_cos = ComputeExpr::Unary(ComputeOp::Cos, Box::new(ComputeExpr::Lit(half_pi_over_3)));
+        let roundtrip2 = compute("r2", &ComputeExpr::Unary(ComputeOp::Acos, Box::new(inner_cos)), &kb).unwrap();
+        assert!((roundtrip2.value - half_pi_over_3).abs() < 1e-12, "{}", roundtrip2.value);
+    }
+
+    #[test]
+    fn arcsin_of_out_of_domain_value_is_a_clean_nonfinite_error() {
+        // arcsin(2) and arccos(−2) are outside [−1, 1] → NaN in IEEE → NonFinite error.
+        // The engine must never let NaN propagate silently into a verdict.
+        let kb = kb_with(vec![]);
+        let err = compute("a", &ComputeExpr::Unary(ComputeOp::Asin, Box::new(ComputeExpr::Lit(2.0))), &kb)
+            .unwrap_err();
+        assert!(matches!(err, ComputeError::NonFinite { op: ComputeOp::Asin }), "{err:?}");
+
+        let err2 = compute("a2", &ComputeExpr::Unary(ComputeOp::Acos, Box::new(ComputeExpr::Lit(-2.0))), &kb)
+            .unwrap_err();
+        assert!(matches!(err2, ComputeError::NonFinite { op: ComputeOp::Acos }), "{err2:?}");
+    }
+
+    #[test]
+    fn inverse_trig_of_a_dimensioned_operand_is_a_category_error() {
+        // arctan(4 dollars) is meaningless — inverse trig is only defined on pure numbers.
+        let kb = kb_with(vec![money("m", 4, "usd")]);
+        let err = compute("a", &ComputeExpr::Unary(ComputeOp::Atan, Box::new(refexpr("m"))), &kb)
+            .unwrap_err();
+        assert!(
+            matches!(err, ComputeError::DimensionMismatch { op: ComputeOp::Atan, .. }),
+            "{err:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Wires `\arcsin`, `\arccos`, `\arctan` through the full ADJ stack: `math-frontend::Func` → `NamedFn` → `ComputeOp` → `f64` dispatch
- Adds `Asin`/`Acos`/`Atan` variants to `NamedFn` (adj-lang AST) and `ComputeOp` (logic-engine)
- Domain errors for `arcsin`/`arccos` (|x| > 1 → NaN) are caught by the existing `NonFinite` guard in `eval_unary` — never silently propagated
- 4 unit tests in `logic-engine` (correctness, round-trip, domain error, dimension mismatch) + 3 integration tests in `adj-lang` via `compile_and_decide`

## Packages changed

| Package | Old version | New version |
|---------|-------------|-------------|
| `logic-engine` | 0.31.0 | 0.32.0 |
| `adj-lang` | 0.26.0 | 0.27.0 |

## Test plan

- [ ] `cargo test -p logic-engine` — 4 new tests pass (arcsin/arccos/arctan correctness, round-trip via π/6, domain error → NonFinite, dimensioned operand → DimensionMismatch)
- [ ] `cargo test -p adj-lang` — 3 new integration tests pass (`\arcsin(0)=0`, `\arccos(1)=0`, `\arctan(0)=0`)
- [ ] No regressions in existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)