### PR TITLE
feat(adj-lang,logic-engine): binary min/max — \min(a,b)/\max(a,b) → ComputeOp::Min2/Max2

### DIFF
--- a/code/packages/rust/adj-lang/CHANGELOG.md
+++ b/code/packages/rust/adj-lang/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [0.28.0] - 2026-07-02 — binary `\min(a, b)` / `\max(a, b)` in `latex "…"`
+
+### Added
+
+- The `latex "…"` adapter now lowers the **binary** `\min(a, b)` / `\max(a, b)`
+  to the native `ComputeOp::Min2` / `Max2` — the **first two-argument (binary)
+  `Call` lowering**. The latex frontend parses the call's parenthesised argument
+  as a two-element `Sequence`; the adapter peels the transparent `Group`/`Fenced`
+  wrapper, requires **exactly two** operands, and builds the new
+  `ExprAst::Call2(BinFn, …)` → `ComputeExpr::Bin(Min2/Max2, …)`. These are the
+  `Func::Min`/`Func::Max` variants the frontend already parsed but the adapter
+  previously rejected as "not yet supported".
+- New surface AST: `BinFn { Min, Max }` and `ExprAst::Call2(BinFn, Box, Box)`,
+  kept distinct from the single-argument `NamedFn`/`ExprAst::Call` (honest arity)
+  and from the slot-reducing `AggOp::Min`/`Max`.
+- A one-argument (`\min(a)`) or three-argument (`\min(a, b, c)`) call has no
+  binary lowering and is a clean, explicit `UnsupportedLatexMath` error rather
+  than a silent mis-lowering. `gcd`/`lcm`/`det`/`Other` remain unsupported.
+
+### Tests
+
+- Two lower tests: `\min(a, b)` / `\max(a, b)` compute-and-decide to the correct
+  selected operand, and wrong-arity (`\min(a)`, `\min(a, b, c)`) is rejected.
+
 ## [0.27.0] - 2026-07-02 — rest of the trig family in `latex "…"` (`\arcsin`…/`\sinh`…/`\cot`/`\sec`/`\csc`)
 
 ### Added

--- a/code/packages/rust/adj-lang/Cargo.toml
+++ b/code/packages/rust/adj-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang"
-version = "0.27.0"
+version = "0.28.0"
 edition = "2021"
 description = "Surface-syntax frontend for the adjudication framework's probabilistic-logic rulebooks. Lexes, parses, and lowers a domain-expert-readable DSL into a `logic-engine` KnowledgeBase. Dissolves ADJ46 awkwardness items A10 (rulebook syntax) and A4 (joint contributions syntactically distinct)."
 

--- a/code/packages/rust/adj-lang/src/adapter.rs
+++ b/code/packages/rust/adj-lang/src/adapter.rs
@@ -32,8 +32,8 @@ use math_frontend::{BinOp, Func, MathExpr, Number, RelOp as MathRelOp, UnaryOp};
 use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode};
 
 use crate::ast::{
-    AggOp, Annotation, ArithOp, CmpOp, Define, DefineKind, Evidence, ExprAst, NamedFn, OptDir,
-    Program, RelOp, RuleLiteral, Statement, Term, TrustTierName,
+    AggOp, Annotation, ArithOp, BinFn, CmpOp, Define, DefineKind, Evidence, ExprAst, NamedFn,
+    OptDir, Program, RelOp, RuleLiteral, Statement, Term, TrustTierName,
 };
 
 /// Errors raised while adapting a generic AST to the typed AST.
@@ -1009,14 +1009,30 @@ fn latex_math_to_expr_ast(expr: &MathExpr, source: &str) -> Result<ExprAst, Adap
                 Box::new(ExprAst::Lit(1.0 / n)),
             ))
         }
-        // A named-function call `\sin(x)`, `\ln(x)`, `\exp(x)`, … lowers to the
-        // matching native transcendental op via `ExprAst::Call`. Only the curated
-        // single-argument transcendental set is supported; the other `Func`
-        // variants (the aggregate/multi-arg `min`/`max`/`gcd`/`lcm`/`det` and an
-        // unknown `Other` such as `\operatorname{trunc}`) have no single-argument
-        // scalar lowering yet and are a clean, explicit error rather than a silent
-        // mis-lowering.
+        // A named-function call. The single-argument transcendental set
+        // (`\sin(x)`, `\ln(x)`, `\exp(x)`, …) lowers to the matching native
+        // transcendental op via `ExprAst::Call`; the two-argument `\min(a, b)` /
+        // `\max(a, b)` lower to the native binary ops via `ExprAst::Call2` (their
+        // argument is a two-element `Sequence`, usually inside the call's
+        // parentheses). The remaining `Func` variants (aggregate/multi-arg
+        // `gcd`/`lcm`/`det` and an unknown `Other` such as `\operatorname{trunc}`)
+        // have no lowering yet and are a clean, explicit error rather than a
+        // silent mis-lowering.
         MathExpr::Call { func, arg } => {
+            // Binary min/max first — their argument is a comma-list, not a scalar.
+            if let Func::Min | Func::Max = func {
+                let bin = if matches!(func, Func::Min) {
+                    BinFn::Min
+                } else {
+                    BinFn::Max
+                };
+                let (a, b) = latex_two_args(arg, source, func)?;
+                return Ok(ExprAst::Call2(
+                    bin,
+                    Box::new(latex_math_to_expr_ast(a, source)?),
+                    Box::new(latex_math_to_expr_ast(b, source)?),
+                ));
+            }
             let named = match func {
                 Func::Sin => NamedFn::Sin,
                 Func::Cos => NamedFn::Cos,
@@ -1112,6 +1128,40 @@ fn latex_power_exponent(expr: &MathExpr, source: &str) -> Result<f64, AdapterErr
         });
     }
     Ok(v)
+}
+
+/// Peel a binary named-function argument (`\min(a, b)` / `\max(a, b)`) into its
+/// two operands. The latex frontend parses the parenthesised comma-list as a
+/// `Sequence([a, b])`, usually wrapped in a `Group`/`Fenced` (the `(…)`), so we
+/// strip those transparent wrappers and require **exactly two** items — a
+/// one-arg (`\min(a)`) or three-arg (`\min(a, b, c)`) call has no binary lowering
+/// and is a clean, explicit error rather than a silent mis-lowering.
+fn latex_two_args<'a>(
+    arg: &'a MathExpr,
+    source: &str,
+    func: &Func,
+) -> Result<(&'a MathExpr, &'a MathExpr), AdapterError> {
+    // Strip transparent parenthesisation to reach the underlying sequence.
+    let mut inner = arg;
+    loop {
+        match inner {
+            MathExpr::Group(b) => inner = b,
+            MathExpr::Fenced { body, .. } => inner = body,
+            _ => break,
+        }
+    }
+    if let MathExpr::Sequence(items) = inner {
+        if items.len() == 2 {
+            return Ok((&items[0], &items[1]));
+        }
+    }
+    Err(AdapterError::UnsupportedLatexMath {
+        source: source.to_string(),
+        detail: format!(
+            "{func:?} takes exactly two comma-separated arguments in ADJ arithmetic \
+             (e.g. \\min(a, b)); got {inner:?}"
+        ),
+    })
 }
 
 /// Validate an nth-root degree (`n` in `\sqrt[n]{x}`) and return it as a

--- a/code/packages/rust/adj-lang/src/ast.rs
+++ b/code/packages/rust/adj-lang/src/ast.rs
@@ -117,6 +117,20 @@ pub enum NamedFn {
     Csc,
 }
 
+/// A **binary** named function in a `let` formula — the two-argument set the
+/// `latex "…"` surface understands. Each maps to a native binary
+/// `logic_engine::ComputeOp` carried in a `ComputeExpr::Bin`. Kept distinct from
+/// the single-argument [`NamedFn`] (so the arity is honest) and from the
+/// slot-reducing [`AggOp`] `Min`/`Max` (which fold *every* observation of one
+/// slot, not two sub-expressions).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BinFn {
+    /// `\min(a, b)` — the smaller of two quantities.
+    Min,
+    /// `\max(a, b)` — the larger of two quantities.
+    Max,
+}
+
 /// An aggregation operator in a `let` formula — reduces every
 /// observation of a slot.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -161,6 +175,12 @@ pub enum ExprAst {
     /// transcendental `ComputeOp` (`Scalar → Scalar`, exact dropped). Produced by
     /// the `latex "…"` adapter from a `MathExpr::Call`.
     Call(NamedFn, Box<ExprAst>),
+    /// A **binary** named function applied to two arguments (`\min(a, b)`,
+    /// `\max(a, b)`). Lowers to the matching native binary `ComputeOp`
+    /// (`ComputeOp::Min2`/`Max2`) carried in a `ComputeExpr::Bin`. Produced by the
+    /// `latex "…"` adapter from a `MathExpr::Call` whose argument is a
+    /// two-element `Sequence`.
+    Call2(BinFn, Box<ExprAst>, Box<ExprAst>),
     /// An aggregation over every observation of a slot.
     Agg(AggOp, String),
 }

--- a/code/packages/rust/adj-lang/src/lower.rs
+++ b/code/packages/rust/adj-lang/src/lower.rs
@@ -32,8 +32,8 @@ use logic_engine::{
 use std::collections::HashMap;
 
 use crate::ast::{
-    AggOp, Annotation, ArithOp, CmpOp, Define, DefineKind, Evidence, ExprAst, NamedFn, OptDir,
-    Program, RelOp, Statement, Term as AstTerm, TrustTierName,
+    AggOp, Annotation, ArithOp, BinFn, CmpOp, Define, DefineKind, Evidence, ExprAst, NamedFn,
+    OptDir, Program, RelOp, Statement, Term as AstTerm, TrustTierName,
 };
 
 /// One lowered constraint: `lhs <op> rhs`, with both sides kept as
@@ -710,7 +710,19 @@ fn lower_expr(expr: &ExprAst) -> ComputeExpr {
         ExprAst::Ceil(a) => ComputeExpr::Unary(ComputeOp::Ceil, Box::new(lower_expr(a))),
         ExprAst::Round(a) => ComputeExpr::Unary(ComputeOp::Round, Box::new(lower_expr(a))),
         ExprAst::Call(f, a) => ComputeExpr::Unary(lower_named_fn(*f), Box::new(lower_expr(a))),
+        ExprAst::Call2(f, a, b) => ComputeExpr::Bin(
+            lower_bin_fn(*f),
+            Box::new(lower_expr(a)),
+            Box::new(lower_expr(b)),
+        ),
         ExprAst::Agg(op, slot) => ComputeExpr::Agg(lower_agg_op(*op), slot.clone()),
+    }
+}
+
+fn lower_bin_fn(f: BinFn) -> ComputeOp {
+    match f {
+        BinFn::Min => ComputeOp::Min2,
+        BinFn::Max => ComputeOp::Max2,
     }
 }
 
@@ -1977,6 +1989,45 @@ contributes 1000000 from answer == 60 to correct
         )
         .unwrap();
         assert!(atan.ranked[0].posterior > 0.99, "{atan:?}");
+    }
+
+    #[test]
+    fn native_latex_binary_min_max_lower_to_native_ops() {
+        // `\min(a, b)` / `\max(a, b)` — the first BINARY-Call lowering. The latex
+        // frontend parses the argument as a two-element Sequence; the adapter now
+        // lowers it to ComputeOp::Min2/Max2 instead of erroring as unsupported.
+        let mn = crate::compile_and_decide(
+            "observe a(3)\n\
+             observe b(8)\n\
+             let answer = latex \"$\\min(a, b)$\"\n\
+             prior 0.10 for correct\n\
+             contributes 1000000 from answer == 3 to correct\n\
+             ? correct\n",
+        )
+        .unwrap();
+        assert!(mn.ranked[0].posterior > 0.99, "{mn:?}");
+        let mx = crate::compile_and_decide(
+            "observe a(3)\n\
+             observe b(8)\n\
+             let answer = latex \"$\\max(a, b)$\"\n\
+             prior 0.10 for correct\n\
+             contributes 1000000 from answer == 8 to correct\n\
+             ? correct\n",
+        )
+        .unwrap();
+        assert!(mx.ranked[0].posterior > 0.99, "{mx:?}");
+    }
+
+    #[test]
+    fn native_latex_min_with_wrong_arity_is_rejected() {
+        // `\min(a)` (one arg) and `\min(a, b, c)` (three args) have no binary
+        // lowering — a clean, explicit error rather than a silent mis-lowering.
+        for src in [
+            "observe a(3)\nlet answer = latex \"$\\min(a)$\"\n? answer\n",
+            "observe a(3)\nobserve b(8)\nobserve c(1)\nlet answer = latex \"$\\min(a, b, c)$\"\n? answer\n",
+        ] {
+            assert!(compile(src).is_err(), "wrong-arity min must be rejected: {src:?}");
+        }
     }
 
     #[test]

--- a/code/packages/rust/logic-engine/CHANGELOG.md
+++ b/code/packages/rust/logic-engine/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.33.0] - 2026-07-02 — binary min/max (`Min2`/`Max2`), the first binary-Call op
+
+### Added
+
+- Two binary compute ops **`ComputeOp::Min2`** / **`ComputeOp::Max2`** —
+  `min(a, b)` / `max(a, b)` over exactly TWO operands, carried in the existing
+  `ComputeExpr::Bin` (the first binary-`Call` lowering, from a LaTeX
+  `\min(a, b)` / `\max(a, b)`). Distinct from the slot-reducing aggregation
+  `Min`/`Max` (which fold *every* observation of one slot).
+- Evaluation is a **selection, not a combine**: dimensionally they behave like
+  addition (both operands must share a dimension — `min(usd, days)` is the same
+  `DimensionMismatch` category error as `usd + days` — and the result carries
+  that shared dimension), the value is one operand chosen unchanged (ties pick
+  the left), and the exact-rational sidecar is preserved verbatim from the
+  winning operand (no rounding, no arithmetic). A non-finite operand is a clean
+  `NonFinite` error rather than letting a NaN silently win a comparison.
+- `symbol()` renders both as `min` / `max` for audit.
+
+### Tests
+
+- Four engine tests: extreme-operand selection (with a two-operand `Op` node
+  shape assertion), exact-rational preservation of the winner, shared-dimension
+  carry + mismatch rejection (`min(usd, usd)` vs `min(usd, days)`), and
+  non-finite-operand rejection.
+
 ## [0.32.0] - 2026-07-02 — the rest of the trig family (inverse / hyperbolic / reciprocal)
 
 ### Added

--- a/code/packages/rust/logic-engine/Cargo.toml
+++ b/code/packages/rust/logic-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logic-engine"
-version = "0.32.0"
+version = "0.33.0"
 edition = "2021"
 description = "Probability-aware facts, rules, KB, SLD find-first/enumerate + WMC posterior + LP19e likelihood-ratio Bayesian aggregation."
 

--- a/code/packages/rust/logic-engine/src/compute.rs
+++ b/code/packages/rust/logic-engine/src/compute.rs
@@ -245,6 +245,20 @@ pub enum ComputeOp {
     Cot,
     Sec,
     Csc,
+    /// Binary **minimum** / **maximum** — `min(a, b)` / `max(a, b)` over exactly
+    /// TWO operands. Unlike the aggregation [`ComputeOp::Min`]/[`ComputeOp::Max`]
+    /// (which reduce *every* observation of a single slot), these are honest
+    /// binary ops carried in a [`ComputeExpr::Bin`] with two sub-expressions —
+    /// the first binary-`Call` lowering, from a LaTeX `\min(a, b)` / `\max(a, b)`
+    /// (adj-lang's `latex "…"` surface). Dimensionally they behave like addition:
+    /// both operands must share a dimension (`min(usd, days)` is a category
+    /// error, exactly like `usd + days`) and the result carries that dimension.
+    /// They *select* one operand unchanged, so the exact-rational sidecar is
+    /// preserved from whichever operand won (no rounding, no new value). This is
+    /// what makes a capped/floored clinical quantity (a dose capped at a ceiling,
+    /// the worse of two labs) computable as a single native node.
+    Min2,
+    Max2,
     Sum,
     Count,
     Min,
@@ -280,6 +294,8 @@ impl ComputeOp {
             ComputeOp::Cot => "cot",
             ComputeOp::Sec => "sec",
             ComputeOp::Csc => "csc",
+            ComputeOp::Min2 => "min",
+            ComputeOp::Max2 => "max",
             ComputeOp::Sum => "sum",
             ComputeOp::Count => "count",
             ComputeOp::Min => "min",
@@ -542,6 +558,46 @@ fn eval(
                     (Some(a), Some(b)) if b.den == 1 => a.powi(b.num),
                     _ => None,
                 };
+                return Ok((
+                    DerivationNode::Op {
+                        op: *op,
+                        operands: vec![lhs, rhs],
+                        result,
+                    },
+                    result_dim,
+                    exact,
+                ));
+            }
+            // Binary min/max are also special: not a symmetric *combine* but a
+            // *selection*. Like addition both operands must share a dimension
+            // (`min(usd, days)` is a category error), so we reuse `DimOp::Add`
+            // purely for that same-dimension check and to carry the shared
+            // dimension through — but the value is one operand chosen unchanged,
+            // and the exact-rational sidecar is that same winning operand (no
+            // arithmetic, so nothing is lost).
+            if *op == ComputeOp::Min2 || *op == ComputeOp::Max2 {
+                let result_dim =
+                    Dimension::combine(DimOp::Add, &dim_l, &dim_r).map_err(|e| match e {
+                        crate::DimError::Mismatch { lhs, rhs, .. } => {
+                            ComputeError::DimensionMismatch { op: *op, lhs, rhs }
+                        }
+                    })?;
+                let (x, y) = (lhs.value(), rhs.value());
+                // A non-finite operand (a `Lit(NaN)`/`inf` in an LLM-emitted IR)
+                // would make the comparison meaningless, so reject it up front
+                // rather than let a NaN silently "win" a comparison.
+                if !x.is_finite() || !y.is_finite() {
+                    return Err(ComputeError::NonFinite { op: *op });
+                }
+                // Ties pick the LEFT operand (deterministic; the values are equal
+                // anyway). `min` takes the smaller, `max` the larger.
+                let pick_left = if *op == ComputeOp::Min2 {
+                    x <= y
+                } else {
+                    x >= y
+                };
+                let result = if pick_left { x } else { y };
+                let exact = if pick_left { exact_l } else { exact_r };
                 return Ok((
                     DerivationNode::Op {
                         op: *op,
@@ -1430,6 +1486,106 @@ mod tests {
         )
         .unwrap();
         assert!((avg.value - 20.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn binary_min_max_select_the_extreme_operand() {
+        // min(a, b) / max(a, b) as honest BINARY ops over two sub-expressions —
+        // distinct from the slot-reducing aggregation Min/Max. Selection, not a
+        // new value.
+        let kb = kb_with(vec![
+            Fact::certain(compound("a", vec![int(3)])),
+            Fact::certain(compound("b", vec![int(8)])),
+        ]);
+        let lo = compute(
+            "lo",
+            &bin(ComputeOp::Min2, refexpr("a"), refexpr("b")),
+            &kb,
+        )
+        .unwrap();
+        assert_eq!(lo.value, 3.0);
+        let hi = compute(
+            "hi",
+            &bin(ComputeOp::Max2, refexpr("a"), refexpr("b")),
+            &kb,
+        )
+        .unwrap();
+        assert_eq!(hi.value, 8.0);
+        // The result node is a two-operand Op, not an aggregation over one slot.
+        match &hi.tree {
+            DerivationNode::Op { op, operands, .. } => {
+                assert_eq!(*op, ComputeOp::Max2);
+                assert_eq!(operands.len(), 2);
+            }
+            other => panic!("expected a binary Op node, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn binary_min_max_preserve_the_winning_operands_exact_rational() {
+        // The winner is selected UNCHANGED, so its exact-rational sidecar carries
+        // through verbatim — no rounding, no arithmetic. `min(3, 8) = 3` keeps 3/1.
+        let kb = kb_with(vec![
+            Fact::certain(compound("a", vec![int(3)])),
+            Fact::certain(compound("b", vec![int(8)])),
+        ]);
+        let lo = compute(
+            "lo",
+            &bin(ComputeOp::Min2, refexpr("a"), refexpr("b")),
+            &kb,
+        )
+        .unwrap();
+        assert_eq!(lo.exact, ExactRational::new(3, 1));
+        let hi = compute(
+            "hi",
+            &bin(ComputeOp::Max2, refexpr("a"), refexpr("b")),
+            &kb,
+        )
+        .unwrap();
+        assert_eq!(hi.exact, ExactRational::new(8, 1));
+    }
+
+    #[test]
+    fn binary_min_carries_the_shared_dimension_and_rejects_a_mismatch() {
+        // Like addition: both operands must share a dimension. `min(usd, usd)`
+        // stays usd; `min(usd, days)` is the same category error as `usd + days`.
+        let kb = kb_with(vec![
+            money("cap", 200, "usd"),
+            money("dose", 150, "usd"),
+            Fact::certain(compound(
+                "age",
+                vec![compound("duration", vec![int(5), atom("days")])],
+            )),
+        ]);
+        let capped = compute(
+            "capped",
+            &bin(ComputeOp::Min2, refexpr("dose"), refexpr("cap")),
+            &kb,
+        )
+        .unwrap();
+        assert_eq!(capped.value, 150.0);
+        let err = compute(
+            "bad",
+            &bin(ComputeOp::Max2, refexpr("cap"), refexpr("age")),
+            &kb,
+        )
+        .unwrap_err();
+        assert!(matches!(err, ComputeError::DimensionMismatch { .. }), "{err:?}");
+    }
+
+    #[test]
+    fn binary_min_max_reject_a_non_finite_operand() {
+        // A NaN/inf operand (an LLM-emitted `Lit(NaN)`) would make the comparison
+        // meaningless, so it is a clean NonFinite error rather than a NaN silently
+        // "winning".
+        let kb = kb_with(vec![Fact::certain(compound("a", vec![int(3)]))]);
+        let err = compute(
+            "x",
+            &bin(ComputeOp::Min2, refexpr("a"), ComputeExpr::Lit(f64::NAN)),
+            &kb,
+        )
+        .unwrap_err();
+        assert!(matches!(err, ComputeError::NonFinite { .. }), "{err:?}");
     }
 
     #[test]

--- a/code/packages/rust/logic-engine/src/compute.rs
+++ b/code/packages/rust/logic-engine/src/compute.rs
@@ -515,145 +515,14 @@ fn eval(
             }
         }
 
-        ComputeExpr::Bin(op, a, b) => {
-            let (lhs, dim_l, exact_l) = eval(a, kb, depth + 1)?;
-            let (rhs, dim_r, exact_r) = eval(b, kb, depth + 1)?;
-            // Power is special: not a symmetric combine. The exponent must be
-            // dimensionless and the result dimension is `base ^ exponent`
-            // (`x^0 = scalar`, `x^2 = x·x`), so it bypasses the `dim_op` +
-            // `Dimension::combine` path the additive/multiplicative ops share.
-            if *op == ComputeOp::Pow {
-                // An exponent with a dimension (`x ^ money(…)`) is a category
-                // error — you cannot raise to a "3 dollars" power.
-                if !dim_r.is_scalar() {
-                    return Err(ComputeError::DimensionMismatch {
-                        op: *op,
-                        lhs: dim_l.tag(),
-                        rhs: dim_r.tag(),
-                    });
-                }
-                let (base, exponent) = (lhs.value(), rhs.value());
-                // Guard the *inputs* before `powf`, not just the result: `powf`
-                // special-cases `1.0.powf(NaN) == 1.0` and `1.0.powf(inf) == 1.0`,
-                // so a non-finite exponent (a `Lit(NaN)` in an LLM-emitted IR) with
-                // a unit base would otherwise launder into a clean `1.0`, violating
-                // the "no silently-wrong number" contract. (`base` is already
-                // finite-checked upstream; re-checking is cheap defense-in-depth.)
-                if !base.is_finite() || !exponent.is_finite() {
-                    return Err(ComputeError::NonFinite { op: *op });
-                }
-                let result_dim = dim_l.pow(exponent).map_err(|e| match e {
-                    crate::DimError::Mismatch { lhs, rhs, .. } => {
-                        ComputeError::DimensionMismatch { op: *op, lhs, rhs }
-                    }
-                })?;
-                let result = base.powf(exponent);
-                if !result.is_finite() {
-                    return Err(ComputeError::NonFinite { op: *op });
-                }
-                // Exact sidecar only for a non-negative integer exponent of an
-                // exact base — `(3/2)^2 = 9/4` stays exact; anything else keeps
-                // just the `f64` result.
-                let exact = match (exact_l, exact_r) {
-                    (Some(a), Some(b)) if b.den == 1 => a.powi(b.num),
-                    _ => None,
-                };
-                return Ok((
-                    DerivationNode::Op {
-                        op: *op,
-                        operands: vec![lhs, rhs],
-                        result,
-                    },
-                    result_dim,
-                    exact,
-                ));
-            }
-            // Binary min/max are also special: not a symmetric *combine* but a
-            // *selection*. Like addition both operands must share a dimension
-            // (`min(usd, days)` is a category error), so we reuse `DimOp::Add`
-            // purely for that same-dimension check and to carry the shared
-            // dimension through — but the value is one operand chosen unchanged,
-            // and the exact-rational sidecar is that same winning operand (no
-            // arithmetic, so nothing is lost).
-            if *op == ComputeOp::Min2 || *op == ComputeOp::Max2 {
-                let result_dim =
-                    Dimension::combine(DimOp::Add, &dim_l, &dim_r).map_err(|e| match e {
-                        crate::DimError::Mismatch { lhs, rhs, .. } => {
-                            ComputeError::DimensionMismatch { op: *op, lhs, rhs }
-                        }
-                    })?;
-                let (x, y) = (lhs.value(), rhs.value());
-                // A non-finite operand (a `Lit(NaN)`/`inf` in an LLM-emitted IR)
-                // would make the comparison meaningless, so reject it up front
-                // rather than let a NaN silently "win" a comparison.
-                if !x.is_finite() || !y.is_finite() {
-                    return Err(ComputeError::NonFinite { op: *op });
-                }
-                // Ties pick the LEFT operand (deterministic; the values are equal
-                // anyway). `min` takes the smaller, `max` the larger.
-                let pick_left = if *op == ComputeOp::Min2 {
-                    x <= y
-                } else {
-                    x >= y
-                };
-                let result = if pick_left { x } else { y };
-                let exact = if pick_left { exact_l } else { exact_r };
-                return Ok((
-                    DerivationNode::Op {
-                        op: *op,
-                        operands: vec![lhs, rhs],
-                        result,
-                    },
-                    result_dim,
-                    exact,
-                ));
-            }
-            // Dimensional check FIRST: usd + days is a category error regardless
-            // of the magnitudes.
-            let dimop = dim_op(*op).ok_or(ComputeError::MalformedExpr {
-                detail: "aggregation operator in binary position",
-            })?;
-            let result_dim = Dimension::combine(dimop, &dim_l, &dim_r).map_err(|e| match e {
-                crate::DimError::Mismatch { lhs, rhs, .. } => {
-                    ComputeError::DimensionMismatch { op: *op, lhs, rhs }
-                }
-            })?;
-            let (x, y) = (lhs.value(), rhs.value());
-            let result = match op {
-                ComputeOp::Add => x + y,
-                ComputeOp::Sub => x - y,
-                ComputeOp::Mul => x * y,
-                ComputeOp::Div => {
-                    if y == 0.0 {
-                        return Err(ComputeError::DivisionByZero);
-                    }
-                    x / y
-                }
-                _ => unreachable!("dim_op already rejected non-binary ops"),
-            };
-            if !result.is_finite() {
-                return Err(ComputeError::NonFinite { op: *op });
-            }
-            let exact = match (exact_l, exact_r) {
-                (Some(a), Some(b)) => match op {
-                    ComputeOp::Add => a.add(b),
-                    ComputeOp::Sub => a.sub(b),
-                    ComputeOp::Mul => a.mul(b),
-                    ComputeOp::Div => a.div(b),
-                    _ => None,
-                },
-                _ => None,
-            };
-            Ok((
-                DerivationNode::Op {
-                    op: *op,
-                    operands: vec![lhs, rhs],
-                    result,
-                },
-                result_dim,
-                exact,
-            ))
-        }
+        // Delegated to an `#[inline(never)]` helper for the SAME reason as the
+        // unary arm below: the binary arm's locals (the `Pow`, `Min2`/`Max2` and
+        // additive/multiplicative branches) would otherwise enlarge `eval`'s own
+        // stack frame, and a fatter frame multiplied across `MAX_EVAL_DEPTH`
+        // levels of recursion can overflow a small (macOS ~2 MB) thread stack
+        // *before* the depth guard trips — turning the "clean `TooDeep`, never a
+        // stack overflow" guarantee into the abort it promises to prevent.
+        ComputeExpr::Bin(op, a, b) => eval_binary(*op, a, b, kb, depth),
 
         // Delegated to an `#[inline(never)]` helper so the unary arm's locals do
         // NOT enlarge `eval`'s own stack frame. `eval` recurses up to
@@ -715,6 +584,162 @@ fn eval(
             ))
         }
     }
+}
+
+/// Evaluate a binary op — `Pow`, binary `Min2`/`Max2`, or the additive/
+/// multiplicative family (`Add`/`Sub`/`Mul`/`Div`) — into a derivation node +
+/// dimension.
+/// Split out of [`eval`] and marked `#[inline(never)]` for the SAME stack-frame
+/// reason as [`eval_unary`]: this arm's locals (three distinct branches) would
+/// otherwise enlarge every one of `eval`'s up-to-`MAX_EVAL_DEPTH` recursive
+/// frames, and a fatter frame multiplied across 256 levels can overflow a small
+/// (macOS ~2 MB) thread stack *before* the depth guard trips — turning the
+/// "clean `TooDeep`, never a stack overflow" guarantee into the abort it
+/// promises to prevent.
+#[inline(never)]
+fn eval_binary(
+    op: ComputeOp,
+    a: &ComputeExpr,
+    b: &ComputeExpr,
+    kb: &KnowledgeBase,
+    depth: usize,
+) -> Result<(DerivationNode, Dimension, Option<ExactRational>), ComputeError> {
+    let (lhs, dim_l, exact_l) = eval(a, kb, depth + 1)?;
+    let (rhs, dim_r, exact_r) = eval(b, kb, depth + 1)?;
+    // Power is special: not a symmetric combine. The exponent must be
+    // dimensionless and the result dimension is `base ^ exponent`
+    // (`x^0 = scalar`, `x^2 = x·x`), so it bypasses the `dim_op` +
+    // `Dimension::combine` path the additive/multiplicative ops share.
+    if op == ComputeOp::Pow {
+        // An exponent with a dimension (`x ^ money(…)`) is a category
+        // error — you cannot raise to a "3 dollars" power.
+        if !dim_r.is_scalar() {
+            return Err(ComputeError::DimensionMismatch {
+                op,
+                lhs: dim_l.tag(),
+                rhs: dim_r.tag(),
+            });
+        }
+        let (base, exponent) = (lhs.value(), rhs.value());
+        // Guard the *inputs* before `powf`, not just the result: `powf`
+        // special-cases `1.0.powf(NaN) == 1.0` and `1.0.powf(inf) == 1.0`,
+        // so a non-finite exponent (a `Lit(NaN)` in an LLM-emitted IR) with
+        // a unit base would otherwise launder into a clean `1.0`, violating
+        // the "no silently-wrong number" contract. (`base` is already
+        // finite-checked upstream; re-checking is cheap defense-in-depth.)
+        if !base.is_finite() || !exponent.is_finite() {
+            return Err(ComputeError::NonFinite { op });
+        }
+        let result_dim = dim_l.pow(exponent).map_err(|e| match e {
+            crate::DimError::Mismatch { lhs, rhs, .. } => {
+                ComputeError::DimensionMismatch { op, lhs, rhs }
+            }
+        })?;
+        let result = base.powf(exponent);
+        if !result.is_finite() {
+            return Err(ComputeError::NonFinite { op });
+        }
+        // Exact sidecar only for a non-negative integer exponent of an
+        // exact base — `(3/2)^2 = 9/4` stays exact; anything else keeps
+        // just the `f64` result.
+        let exact = match (exact_l, exact_r) {
+            (Some(a), Some(b)) if b.den == 1 => a.powi(b.num),
+            _ => None,
+        };
+        return Ok((
+            DerivationNode::Op {
+                op,
+                operands: vec![lhs, rhs],
+                result,
+            },
+            result_dim,
+            exact,
+        ));
+    }
+    // Binary min/max are also special: not a symmetric *combine* but a
+    // *selection*. Like addition both operands must share a dimension
+    // (`min(usd, days)` is a category error), so we reuse `DimOp::Add`
+    // purely for that same-dimension check and to carry the shared
+    // dimension through — but the value is one operand chosen unchanged,
+    // and the exact-rational sidecar is that same winning operand (no
+    // arithmetic, so nothing is lost).
+    if op == ComputeOp::Min2 || op == ComputeOp::Max2 {
+        let result_dim = Dimension::combine(DimOp::Add, &dim_l, &dim_r).map_err(|e| match e {
+            crate::DimError::Mismatch { lhs, rhs, .. } => {
+                ComputeError::DimensionMismatch { op, lhs, rhs }
+            }
+        })?;
+        let (x, y) = (lhs.value(), rhs.value());
+        // A non-finite operand (a `Lit(NaN)`/`inf` in an LLM-emitted IR)
+        // would make the comparison meaningless, so reject it up front
+        // rather than let a NaN silently "win" a comparison.
+        if !x.is_finite() || !y.is_finite() {
+            return Err(ComputeError::NonFinite { op });
+        }
+        // Ties pick the LEFT operand (deterministic; the values are equal
+        // anyway). `min` takes the smaller, `max` the larger.
+        let pick_left = if op == ComputeOp::Min2 {
+            x <= y
+        } else {
+            x >= y
+        };
+        let result = if pick_left { x } else { y };
+        let exact = if pick_left { exact_l } else { exact_r };
+        return Ok((
+            DerivationNode::Op {
+                op,
+                operands: vec![lhs, rhs],
+                result,
+            },
+            result_dim,
+            exact,
+        ));
+    }
+    // Dimensional check FIRST: usd + days is a category error regardless
+    // of the magnitudes.
+    let dimop = dim_op(op).ok_or(ComputeError::MalformedExpr {
+        detail: "aggregation operator in binary position",
+    })?;
+    let result_dim = Dimension::combine(dimop, &dim_l, &dim_r).map_err(|e| match e {
+        crate::DimError::Mismatch { lhs, rhs, .. } => {
+            ComputeError::DimensionMismatch { op, lhs, rhs }
+        }
+    })?;
+    let (x, y) = (lhs.value(), rhs.value());
+    let result = match op {
+        ComputeOp::Add => x + y,
+        ComputeOp::Sub => x - y,
+        ComputeOp::Mul => x * y,
+        ComputeOp::Div => {
+            if y == 0.0 {
+                return Err(ComputeError::DivisionByZero);
+            }
+            x / y
+        }
+        _ => unreachable!("dim_op already rejected non-binary ops"),
+    };
+    if !result.is_finite() {
+        return Err(ComputeError::NonFinite { op });
+    }
+    let exact = match (exact_l, exact_r) {
+        (Some(a), Some(b)) => match op {
+            ComputeOp::Add => a.add(b),
+            ComputeOp::Sub => a.sub(b),
+            ComputeOp::Mul => a.mul(b),
+            ComputeOp::Div => a.div(b),
+            _ => None,
+        },
+        _ => None,
+    };
+    Ok((
+        DerivationNode::Op {
+            op,
+            operands: vec![lhs, rhs],
+            result,
+        },
+        result_dim,
+        exact,
+    ))
 }
 
 /// Evaluate a unary op — the rounding family (`Abs`/`Floor`/`Ceil`/`Round`) or a
@@ -815,11 +840,18 @@ fn eval_unary(
     //     avoids the overflow a bare `2·arem` could hit; `arem = |rem| < den`.
     // Each result is an integer, carried as `q/1`.
     let exact = exact.and_then(|r| match op {
-        ComputeOp::Abs => r.num.checked_abs().and_then(|n| ExactRational::new(n, r.den)),
+        ComputeOp::Abs => r
+            .num
+            .checked_abs()
+            .and_then(|n| ExactRational::new(n, r.den)),
         ComputeOp::Floor => ExactRational::new(r.num.div_euclid(r.den), 1),
         ComputeOp::Ceil => {
             let q = r.num.div_euclid(r.den);
-            let q = if r.num.rem_euclid(r.den) != 0 { q.checked_add(1)? } else { q };
+            let q = if r.num.rem_euclid(r.den) != 0 {
+                q.checked_add(1)?
+            } else {
+                q
+            };
             ExactRational::new(q, 1)
         }
         ComputeOp::Round => {
@@ -828,7 +860,11 @@ fn eval_unary(
             let arem = if rem >= 0 { rem } else { -rem }; // |rem| < den ⇒ no overflow
             let bump = if arem >= r.den - arem {
                 // fractional part ≥ 1/2 → round away from zero (ties away from zero)
-                if r.num >= 0 { 1 } else { -1 }
+                if r.num >= 0 {
+                    1
+                } else {
+                    -1
+                }
             } else {
                 0
             };
@@ -838,7 +874,11 @@ fn eval_unary(
     });
     // Rounding preserves the operand's dimension; a transcendental collapses to a
     // pure number (`Scalar`).
-    let result_dim = if transcendental { Dimension::Scalar } else { dim };
+    let result_dim = if transcendental {
+        Dimension::Scalar
+    } else {
+        dim
+    };
     Ok((
         DerivationNode::Op {
             op,
@@ -1044,12 +1084,7 @@ mod tests {
     fn a_dimensioned_exponent_is_a_category_error() {
         // x ^ (money) is meaningless — the exponent must be dimensionless.
         let kb = kb_with(vec![quantity("x", 2, "index"), money("e", 3, "usd")]);
-        let err = compute(
-            "p",
-            &bin(ComputeOp::Pow, refexpr("x"), refexpr("e")),
-            &kb,
-        )
-        .unwrap_err();
+        let err = compute("p", &bin(ComputeOp::Pow, refexpr("x"), refexpr("e")), &kb).unwrap_err();
         assert!(matches!(
             err,
             ComputeError::DimensionMismatch {
@@ -1127,7 +1162,11 @@ mod tests {
             "fl",
             &ComputeExpr::Unary(
                 ComputeOp::Floor,
-                Box::new(bin(ComputeOp::Div, ComputeExpr::Lit(7.0), ComputeExpr::Lit(2.0))),
+                Box::new(bin(
+                    ComputeOp::Div,
+                    ComputeExpr::Lit(7.0),
+                    ComputeExpr::Lit(2.0),
+                )),
             ),
             &kb_with(vec![]),
         )
@@ -1145,7 +1184,11 @@ mod tests {
             "fl",
             &ComputeExpr::Unary(
                 ComputeOp::Floor,
-                Box::new(bin(ComputeOp::Div, ComputeExpr::Lit(-7.0), ComputeExpr::Lit(2.0))),
+                Box::new(bin(
+                    ComputeOp::Div,
+                    ComputeExpr::Lit(-7.0),
+                    ComputeExpr::Lit(2.0),
+                )),
             ),
             &kb_with(vec![]),
         )
@@ -1182,7 +1225,11 @@ mod tests {
             "ce",
             &ComputeExpr::Unary(
                 ComputeOp::Ceil,
-                Box::new(bin(ComputeOp::Div, ComputeExpr::Lit(6.0), ComputeExpr::Lit(2.0))),
+                Box::new(bin(
+                    ComputeOp::Div,
+                    ComputeExpr::Lit(6.0),
+                    ComputeExpr::Lit(2.0),
+                )),
             ),
             &kb_with(vec![]),
         )
@@ -1199,7 +1246,11 @@ mod tests {
             "rd",
             &ComputeExpr::Unary(
                 ComputeOp::Round,
-                Box::new(bin(ComputeOp::Div, ComputeExpr::Lit(5.0), ComputeExpr::Lit(2.0))),
+                Box::new(bin(
+                    ComputeOp::Div,
+                    ComputeExpr::Lit(5.0),
+                    ComputeExpr::Lit(2.0),
+                )),
             ),
             &kb_with(vec![]),
         )
@@ -1217,7 +1268,11 @@ mod tests {
             "rd",
             &ComputeExpr::Unary(
                 ComputeOp::Round,
-                Box::new(bin(ComputeOp::Div, ComputeExpr::Lit(-5.0), ComputeExpr::Lit(2.0))),
+                Box::new(bin(
+                    ComputeOp::Div,
+                    ComputeExpr::Lit(-5.0),
+                    ComputeExpr::Lit(2.0),
+                )),
             ),
             &kb_with(vec![]),
         )
@@ -1252,8 +1307,12 @@ mod tests {
         // operand is a pure number, the result is a pure number (Scalar), and the
         // exact-rational sidecar is dropped (a transcendental is irrational).
         let inner = ComputeExpr::Unary(ComputeOp::Ln, Box::new(ComputeExpr::Lit(5.0)));
-        let d = compute("e", &ComputeExpr::Unary(ComputeOp::Exp, Box::new(inner)), &kb_with(vec![]))
-            .unwrap();
+        let d = compute(
+            "e",
+            &ComputeExpr::Unary(ComputeOp::Exp, Box::new(inner)),
+            &kb_with(vec![]),
+        )
+        .unwrap();
         assert!((d.value - 5.0).abs() < 1e-9, "{}", d.value);
         assert_eq!(d.dim, Dimension::Scalar);
         assert_eq!(d.exact, None);
@@ -1262,9 +1321,19 @@ mod tests {
     #[test]
     fn sin_of_zero_is_zero_and_cos_of_zero_is_one() {
         // Sanity anchors that don't depend on π: sin(0)=0, cos(0)=1.
-        let s = compute("s", &ComputeExpr::Unary(ComputeOp::Sin, Box::new(ComputeExpr::Lit(0.0))), &kb_with(vec![])).unwrap();
+        let s = compute(
+            "s",
+            &ComputeExpr::Unary(ComputeOp::Sin, Box::new(ComputeExpr::Lit(0.0))),
+            &kb_with(vec![]),
+        )
+        .unwrap();
         assert_eq!(s.value, 0.0);
-        let c = compute("c", &ComputeExpr::Unary(ComputeOp::Cos, Box::new(ComputeExpr::Lit(0.0))), &kb_with(vec![])).unwrap();
+        let c = compute(
+            "c",
+            &ComputeExpr::Unary(ComputeOp::Cos, Box::new(ComputeExpr::Lit(0.0))),
+            &kb_with(vec![]),
+        )
+        .unwrap();
         assert_eq!(c.value, 1.0);
         assert_eq!(c.dim, Dimension::Scalar);
     }
@@ -1275,10 +1344,20 @@ mod tests {
         // pure number. The engine rejects it with a DimensionMismatch (operand
         // dimension vs the required Scalar), NOT a silently-wrong number.
         let kb = kb_with(vec![money("m", 4, "usd")]);
-        let err = compute("l", &ComputeExpr::Unary(ComputeOp::Ln, Box::new(refexpr("m"))), &kb)
-            .unwrap_err();
+        let err = compute(
+            "l",
+            &ComputeExpr::Unary(ComputeOp::Ln, Box::new(refexpr("m"))),
+            &kb,
+        )
+        .unwrap_err();
         assert!(
-            matches!(err, ComputeError::DimensionMismatch { op: ComputeOp::Ln, .. }),
+            matches!(
+                err,
+                ComputeError::DimensionMismatch {
+                    op: ComputeOp::Ln,
+                    ..
+                }
+            ),
             "{err:?}"
         );
     }
@@ -1288,9 +1367,16 @@ mod tests {
         // ln(0) = −∞ and ln(−1) = NaN in IEEE — both are rejected by the finite
         // guard rather than flowing a non-finite value into a verdict.
         for x in [0.0, -1.0] {
-            let err = compute("l", &ComputeExpr::Unary(ComputeOp::Ln, Box::new(ComputeExpr::Lit(x))), &kb_with(vec![]))
-                .unwrap_err();
-            assert!(matches!(err, ComputeError::NonFinite { op: ComputeOp::Ln }), "x={x}: {err:?}");
+            let err = compute(
+                "l",
+                &ComputeExpr::Unary(ComputeOp::Ln, Box::new(ComputeExpr::Lit(x))),
+                &kb_with(vec![]),
+            )
+            .unwrap_err();
+            assert!(
+                matches!(err, ComputeError::NonFinite { op: ComputeOp::Ln }),
+                "x={x}: {err:?}"
+            );
         }
     }
 
@@ -1307,8 +1393,17 @@ mod tests {
             (ComputeOp::Atan, 0.0, 0.0),
         ];
         for (op, x, want) in cases {
-            let d = compute("t", &ComputeExpr::Unary(op, Box::new(ComputeExpr::Lit(x))), &kb_with(vec![])).unwrap();
-            assert!((d.value - want).abs() < 1e-12, "{op:?}({x}) = {} want {want}", d.value);
+            let d = compute(
+                "t",
+                &ComputeExpr::Unary(op, Box::new(ComputeExpr::Lit(x))),
+                &kb_with(vec![]),
+            )
+            .unwrap();
+            assert!(
+                (d.value - want).abs() < 1e-12,
+                "{op:?}({x}) = {} want {want}",
+                d.value
+            );
             assert_eq!(d.dim, Dimension::Scalar);
             assert_eq!(d.exact, None);
         }
@@ -1319,12 +1414,25 @@ mod tests {
         // sec(0) = 1/cos(0) = 1 (a clean value); csc(0) = 1/sin(0) and cot(0) =
         // cos(0)/sin(0) are poles (sin 0 = 0 → ±∞) and are rejected by the finite
         // guard, never a silently-wrong number.
-        let sec0 = compute("s", &ComputeExpr::Unary(ComputeOp::Sec, Box::new(ComputeExpr::Lit(0.0))), &kb_with(vec![])).unwrap();
+        let sec0 = compute(
+            "s",
+            &ComputeExpr::Unary(ComputeOp::Sec, Box::new(ComputeExpr::Lit(0.0))),
+            &kb_with(vec![]),
+        )
+        .unwrap();
         assert_eq!(sec0.value, 1.0);
         assert_eq!(sec0.dim, Dimension::Scalar);
         for op in [ComputeOp::Csc, ComputeOp::Cot] {
-            let err = compute("p", &ComputeExpr::Unary(op, Box::new(ComputeExpr::Lit(0.0))), &kb_with(vec![])).unwrap_err();
-            assert!(matches!(err, ComputeError::NonFinite { .. }), "{op:?}(0): {err:?}");
+            let err = compute(
+                "p",
+                &ComputeExpr::Unary(op, Box::new(ComputeExpr::Lit(0.0))),
+                &kb_with(vec![]),
+            )
+            .unwrap_err();
+            assert!(
+                matches!(err, ComputeError::NonFinite { .. }),
+                "{op:?}(0): {err:?}"
+            );
         }
     }
 
@@ -1332,9 +1440,21 @@ mod tests {
     fn arcsine_outside_its_domain_is_a_clean_nonfinite_error() {
         // asin is only defined on [−1, 1]; asin(2) = NaN in IEEE → rejected, not
         // flowed into a verdict.
-        let err = compute("a", &ComputeExpr::Unary(ComputeOp::Asin, Box::new(ComputeExpr::Lit(2.0))), &kb_with(vec![]))
-            .unwrap_err();
-        assert!(matches!(err, ComputeError::NonFinite { op: ComputeOp::Asin }), "{err:?}");
+        let err = compute(
+            "a",
+            &ComputeExpr::Unary(ComputeOp::Asin, Box::new(ComputeExpr::Lit(2.0))),
+            &kb_with(vec![]),
+        )
+        .unwrap_err();
+        assert!(
+            matches!(
+                err,
+                ComputeError::NonFinite {
+                    op: ComputeOp::Asin
+                }
+            ),
+            "{err:?}"
+        );
     }
 
     #[test]
@@ -1342,11 +1462,18 @@ mod tests {
         // 10 ^ 400 overflows f64 → a NonFinite error, never a silent `inf`.
         let err = compute(
             "big",
-            &bin(ComputeOp::Pow, ComputeExpr::Lit(10.0), ComputeExpr::Lit(400.0)),
+            &bin(
+                ComputeOp::Pow,
+                ComputeExpr::Lit(10.0),
+                ComputeExpr::Lit(400.0),
+            ),
             &kb_with(vec![]),
         )
         .unwrap_err();
-        assert!(matches!(err, ComputeError::NonFinite { op: ComputeOp::Pow }));
+        assert!(matches!(
+            err,
+            ComputeError::NonFinite { op: ComputeOp::Pow }
+        ));
     }
 
     #[test]
@@ -1497,19 +1624,9 @@ mod tests {
             Fact::certain(compound("a", vec![int(3)])),
             Fact::certain(compound("b", vec![int(8)])),
         ]);
-        let lo = compute(
-            "lo",
-            &bin(ComputeOp::Min2, refexpr("a"), refexpr("b")),
-            &kb,
-        )
-        .unwrap();
+        let lo = compute("lo", &bin(ComputeOp::Min2, refexpr("a"), refexpr("b")), &kb).unwrap();
         assert_eq!(lo.value, 3.0);
-        let hi = compute(
-            "hi",
-            &bin(ComputeOp::Max2, refexpr("a"), refexpr("b")),
-            &kb,
-        )
-        .unwrap();
+        let hi = compute("hi", &bin(ComputeOp::Max2, refexpr("a"), refexpr("b")), &kb).unwrap();
         assert_eq!(hi.value, 8.0);
         // The result node is a two-operand Op, not an aggregation over one slot.
         match &hi.tree {
@@ -1529,19 +1646,9 @@ mod tests {
             Fact::certain(compound("a", vec![int(3)])),
             Fact::certain(compound("b", vec![int(8)])),
         ]);
-        let lo = compute(
-            "lo",
-            &bin(ComputeOp::Min2, refexpr("a"), refexpr("b")),
-            &kb,
-        )
-        .unwrap();
+        let lo = compute("lo", &bin(ComputeOp::Min2, refexpr("a"), refexpr("b")), &kb).unwrap();
         assert_eq!(lo.exact, ExactRational::new(3, 1));
-        let hi = compute(
-            "hi",
-            &bin(ComputeOp::Max2, refexpr("a"), refexpr("b")),
-            &kb,
-        )
-        .unwrap();
+        let hi = compute("hi", &bin(ComputeOp::Max2, refexpr("a"), refexpr("b")), &kb).unwrap();
         assert_eq!(hi.exact, ExactRational::new(8, 1));
     }
 
@@ -1570,7 +1677,10 @@ mod tests {
             &kb,
         )
         .unwrap_err();
-        assert!(matches!(err, ComputeError::DimensionMismatch { .. }), "{err:?}");
+        assert!(
+            matches!(err, ComputeError::DimensionMismatch { .. }),
+            "{err:?}"
+        );
     }
 
     #[test]

--- a/code/packages/rust/logic-engine/src/compute.rs
+++ b/code/packages/rust/logic-engine/src/compute.rs
@@ -453,6 +453,12 @@ fn dim_op(op: ComputeOp) -> Option<DimOp> {
         ComputeOp::Sub => Some(DimOp::Sub),
         ComputeOp::Mul => Some(DimOp::Mul),
         ComputeOp::Div => Some(DimOp::Div),
+        // Binary min/max behave dimensionally like addition: both operands must
+        // share a dimension (`min(usd, days)` is the same category error as
+        // `usd + days`) and the result carries that shared dimension. Reusing
+        // `DimOp::Add` lets them flow through the general binary path with no
+        // extra locals in the deeply-recursive `eval` frame.
+        ComputeOp::Min2 | ComputeOp::Max2 => Some(DimOp::Add),
         _ => None,
     }
 }
@@ -515,14 +521,136 @@ fn eval(
             }
         }
 
-        // Delegated to an `#[inline(never)]` helper for the SAME reason as the
-        // unary arm below: the binary arm's locals (the `Pow`, `Min2`/`Max2` and
-        // additive/multiplicative branches) would otherwise enlarge `eval`'s own
-        // stack frame, and a fatter frame multiplied across `MAX_EVAL_DEPTH`
-        // levels of recursion can overflow a small (macOS ~2 MB) thread stack
-        // *before* the depth guard trips — turning the "clean `TooDeep`, never a
-        // stack overflow" guarantee into the abort it promises to prevent.
-        ComputeExpr::Bin(op, a, b) => eval_binary(*op, a, b, kb, depth),
+        ComputeExpr::Bin(op, a, b) => {
+            let (lhs, dim_l, exact_l) = eval(a, kb, depth + 1)?;
+            let (rhs, dim_r, exact_r) = eval(b, kb, depth + 1)?;
+            // Power is special: not a symmetric combine. The exponent must be
+            // dimensionless and the result dimension is `base ^ exponent`
+            // (`x^0 = scalar`, `x^2 = x·x`), so it bypasses the `dim_op` +
+            // `Dimension::combine` path the additive/multiplicative ops share.
+            if *op == ComputeOp::Pow {
+                // An exponent with a dimension (`x ^ money(…)`) is a category
+                // error — you cannot raise to a "3 dollars" power.
+                if !dim_r.is_scalar() {
+                    return Err(ComputeError::DimensionMismatch {
+                        op: *op,
+                        lhs: dim_l.tag(),
+                        rhs: dim_r.tag(),
+                    });
+                }
+                let (base, exponent) = (lhs.value(), rhs.value());
+                // Guard the *inputs* before `powf`, not just the result: `powf`
+                // special-cases `1.0.powf(NaN) == 1.0` and `1.0.powf(inf) == 1.0`,
+                // so a non-finite exponent (a `Lit(NaN)` in an LLM-emitted IR) with
+                // a unit base would otherwise launder into a clean `1.0`, violating
+                // the "no silently-wrong number" contract. (`base` is already
+                // finite-checked upstream; re-checking is cheap defense-in-depth.)
+                if !base.is_finite() || !exponent.is_finite() {
+                    return Err(ComputeError::NonFinite { op: *op });
+                }
+                let result_dim = dim_l.pow(exponent).map_err(|e| match e {
+                    crate::DimError::Mismatch { lhs, rhs, .. } => {
+                        ComputeError::DimensionMismatch { op: *op, lhs, rhs }
+                    }
+                })?;
+                let result = base.powf(exponent);
+                if !result.is_finite() {
+                    return Err(ComputeError::NonFinite { op: *op });
+                }
+                // Exact sidecar only for a non-negative integer exponent of an
+                // exact base — `(3/2)^2 = 9/4` stays exact; anything else keeps
+                // just the `f64` result.
+                let exact = match (exact_l, exact_r) {
+                    (Some(a), Some(b)) if b.den == 1 => a.powi(b.num),
+                    _ => None,
+                };
+                return Ok((
+                    DerivationNode::Op {
+                        op: *op,
+                        operands: vec![lhs, rhs],
+                        result,
+                    },
+                    result_dim,
+                    exact,
+                ));
+            }
+            // Dimensional check FIRST: usd + days is a category error regardless
+            // of the magnitudes. `dim_op` maps the additive/multiplicative ops AND
+            // binary min/max (which combine like addition — see `dim_op`).
+            let dimop = dim_op(*op).ok_or(ComputeError::MalformedExpr {
+                detail: "aggregation operator in binary position",
+            })?;
+            let result_dim = Dimension::combine(dimop, &dim_l, &dim_r).map_err(|e| match e {
+                crate::DimError::Mismatch { lhs, rhs, .. } => {
+                    ComputeError::DimensionMismatch { op: *op, lhs, rhs }
+                }
+            })?;
+            let (x, y) = (lhs.value(), rhs.value());
+            // Binary min/max are folded into this general path (rather than a
+            // separate block) so they add NO extra locals to `eval`'s frame — it
+            // recurses up to `MAX_EVAL_DEPTH` levels, so every byte here is
+            // multiplied 256× and a fatter frame can overflow a small (macOS ~2 MB)
+            // thread stack before the depth guard trips. min/max SELECT one operand
+            // (no arithmetic); a `NaN` operand would let `f64::min`/`max` silently
+            // drop the NaN and return the finite side, so we produce `NaN`
+            // explicitly and let the shared `is_finite` guard below reject it.
+            let result = match op {
+                ComputeOp::Add => x + y,
+                ComputeOp::Sub => x - y,
+                ComputeOp::Mul => x * y,
+                ComputeOp::Div => {
+                    if y == 0.0 {
+                        return Err(ComputeError::DivisionByZero);
+                    }
+                    x / y
+                }
+                ComputeOp::Min2 => {
+                    if x.is_nan() || y.is_nan() {
+                        f64::NAN
+                    } else if x <= y {
+                        x
+                    } else {
+                        y
+                    }
+                }
+                ComputeOp::Max2 => {
+                    if x.is_nan() || y.is_nan() {
+                        f64::NAN
+                    } else if x >= y {
+                        x
+                    } else {
+                        y
+                    }
+                }
+                _ => unreachable!("dim_op already rejected non-binary ops"),
+            };
+            if !result.is_finite() {
+                return Err(ComputeError::NonFinite { op: *op });
+            }
+            let exact = match (exact_l, exact_r) {
+                (Some(a), Some(b)) => match op {
+                    ComputeOp::Add => a.add(b),
+                    ComputeOp::Sub => a.sub(b),
+                    ComputeOp::Mul => a.mul(b),
+                    ComputeOp::Div => a.div(b),
+                    // min/max select an operand UNCHANGED, so the winner's exact
+                    // rational carries through verbatim (ties pick the left).
+                    ComputeOp::Min2 => Some(if x <= y { a } else { b }),
+                    ComputeOp::Max2 => Some(if x >= y { a } else { b }),
+                    _ => None,
+                },
+                _ => None,
+            };
+            Ok((
+                DerivationNode::Op {
+                    op: *op,
+                    operands: vec![lhs, rhs],
+                    result,
+                },
+                result_dim,
+                exact,
+            ))
+        }
 
         // Delegated to an `#[inline(never)]` helper so the unary arm's locals do
         // NOT enlarge `eval`'s own stack frame. `eval` recurses up to
@@ -584,162 +712,6 @@ fn eval(
             ))
         }
     }
-}
-
-/// Evaluate a binary op — `Pow`, binary `Min2`/`Max2`, or the additive/
-/// multiplicative family (`Add`/`Sub`/`Mul`/`Div`) — into a derivation node +
-/// dimension.
-/// Split out of [`eval`] and marked `#[inline(never)]` for the SAME stack-frame
-/// reason as [`eval_unary`]: this arm's locals (three distinct branches) would
-/// otherwise enlarge every one of `eval`'s up-to-`MAX_EVAL_DEPTH` recursive
-/// frames, and a fatter frame multiplied across 256 levels can overflow a small
-/// (macOS ~2 MB) thread stack *before* the depth guard trips — turning the
-/// "clean `TooDeep`, never a stack overflow" guarantee into the abort it
-/// promises to prevent.
-#[inline(never)]
-fn eval_binary(
-    op: ComputeOp,
-    a: &ComputeExpr,
-    b: &ComputeExpr,
-    kb: &KnowledgeBase,
-    depth: usize,
-) -> Result<(DerivationNode, Dimension, Option<ExactRational>), ComputeError> {
-    let (lhs, dim_l, exact_l) = eval(a, kb, depth + 1)?;
-    let (rhs, dim_r, exact_r) = eval(b, kb, depth + 1)?;
-    // Power is special: not a symmetric combine. The exponent must be
-    // dimensionless and the result dimension is `base ^ exponent`
-    // (`x^0 = scalar`, `x^2 = x·x`), so it bypasses the `dim_op` +
-    // `Dimension::combine` path the additive/multiplicative ops share.
-    if op == ComputeOp::Pow {
-        // An exponent with a dimension (`x ^ money(…)`) is a category
-        // error — you cannot raise to a "3 dollars" power.
-        if !dim_r.is_scalar() {
-            return Err(ComputeError::DimensionMismatch {
-                op,
-                lhs: dim_l.tag(),
-                rhs: dim_r.tag(),
-            });
-        }
-        let (base, exponent) = (lhs.value(), rhs.value());
-        // Guard the *inputs* before `powf`, not just the result: `powf`
-        // special-cases `1.0.powf(NaN) == 1.0` and `1.0.powf(inf) == 1.0`,
-        // so a non-finite exponent (a `Lit(NaN)` in an LLM-emitted IR) with
-        // a unit base would otherwise launder into a clean `1.0`, violating
-        // the "no silently-wrong number" contract. (`base` is already
-        // finite-checked upstream; re-checking is cheap defense-in-depth.)
-        if !base.is_finite() || !exponent.is_finite() {
-            return Err(ComputeError::NonFinite { op });
-        }
-        let result_dim = dim_l.pow(exponent).map_err(|e| match e {
-            crate::DimError::Mismatch { lhs, rhs, .. } => {
-                ComputeError::DimensionMismatch { op, lhs, rhs }
-            }
-        })?;
-        let result = base.powf(exponent);
-        if !result.is_finite() {
-            return Err(ComputeError::NonFinite { op });
-        }
-        // Exact sidecar only for a non-negative integer exponent of an
-        // exact base — `(3/2)^2 = 9/4` stays exact; anything else keeps
-        // just the `f64` result.
-        let exact = match (exact_l, exact_r) {
-            (Some(a), Some(b)) if b.den == 1 => a.powi(b.num),
-            _ => None,
-        };
-        return Ok((
-            DerivationNode::Op {
-                op,
-                operands: vec![lhs, rhs],
-                result,
-            },
-            result_dim,
-            exact,
-        ));
-    }
-    // Binary min/max are also special: not a symmetric *combine* but a
-    // *selection*. Like addition both operands must share a dimension
-    // (`min(usd, days)` is a category error), so we reuse `DimOp::Add`
-    // purely for that same-dimension check and to carry the shared
-    // dimension through — but the value is one operand chosen unchanged,
-    // and the exact-rational sidecar is that same winning operand (no
-    // arithmetic, so nothing is lost).
-    if op == ComputeOp::Min2 || op == ComputeOp::Max2 {
-        let result_dim = Dimension::combine(DimOp::Add, &dim_l, &dim_r).map_err(|e| match e {
-            crate::DimError::Mismatch { lhs, rhs, .. } => {
-                ComputeError::DimensionMismatch { op, lhs, rhs }
-            }
-        })?;
-        let (x, y) = (lhs.value(), rhs.value());
-        // A non-finite operand (a `Lit(NaN)`/`inf` in an LLM-emitted IR)
-        // would make the comparison meaningless, so reject it up front
-        // rather than let a NaN silently "win" a comparison.
-        if !x.is_finite() || !y.is_finite() {
-            return Err(ComputeError::NonFinite { op });
-        }
-        // Ties pick the LEFT operand (deterministic; the values are equal
-        // anyway). `min` takes the smaller, `max` the larger.
-        let pick_left = if op == ComputeOp::Min2 {
-            x <= y
-        } else {
-            x >= y
-        };
-        let result = if pick_left { x } else { y };
-        let exact = if pick_left { exact_l } else { exact_r };
-        return Ok((
-            DerivationNode::Op {
-                op,
-                operands: vec![lhs, rhs],
-                result,
-            },
-            result_dim,
-            exact,
-        ));
-    }
-    // Dimensional check FIRST: usd + days is a category error regardless
-    // of the magnitudes.
-    let dimop = dim_op(op).ok_or(ComputeError::MalformedExpr {
-        detail: "aggregation operator in binary position",
-    })?;
-    let result_dim = Dimension::combine(dimop, &dim_l, &dim_r).map_err(|e| match e {
-        crate::DimError::Mismatch { lhs, rhs, .. } => {
-            ComputeError::DimensionMismatch { op, lhs, rhs }
-        }
-    })?;
-    let (x, y) = (lhs.value(), rhs.value());
-    let result = match op {
-        ComputeOp::Add => x + y,
-        ComputeOp::Sub => x - y,
-        ComputeOp::Mul => x * y,
-        ComputeOp::Div => {
-            if y == 0.0 {
-                return Err(ComputeError::DivisionByZero);
-            }
-            x / y
-        }
-        _ => unreachable!("dim_op already rejected non-binary ops"),
-    };
-    if !result.is_finite() {
-        return Err(ComputeError::NonFinite { op });
-    }
-    let exact = match (exact_l, exact_r) {
-        (Some(a), Some(b)) => match op {
-            ComputeOp::Add => a.add(b),
-            ComputeOp::Sub => a.sub(b),
-            ComputeOp::Mul => a.mul(b),
-            ComputeOp::Div => a.div(b),
-            _ => None,
-        },
-        _ => None,
-    };
-    Ok((
-        DerivationNode::Op {
-            op,
-            operands: vec![lhs, rhs],
-            result,
-        },
-        result_dim,
-        exact,
-    ))
 }
 
 /// Evaluate a unary op — the rounding family (`Abs`/`Floor`/`Ceil`/`Round`) or a

--- a/lessons.md
+++ b/lessons.md
@@ -984,14 +984,32 @@ stack in debug builds. `cargo test -p <crate>` locally is NOT sufficient to catc
 it (margin is runner-dependent); the guard is the deep-nesting stack test on CI
 macOS.
 
-Recurrence (PR #7343, adding binary `Min2`/`Max2`): the same overflow re-appeared
-because only the `Unary` arm had been extracted — the `Bin` arm was still inline,
-and adding a `Min2`/`Max2` branch to it enlarged `eval`'s frame again. Fix was to
-extract the ENTIRE `Bin` arm into `#[inline(never)] fn eval_binary` (mirroring
-`eval_unary`). Reinforced rule: don't just extract the arm you're editing —
-**every** recursive arm of a depth-capped `eval`-style function that carries
-non-trivial locals should live in its own `#[inline(never)]` helper, so a future
-addition to any of them can't re-inflate the shared frame.
+Recurrence (PR #7343, adding binary `Min2`/`Max2`): the same overflow re-appeared,
+and the FIRST two fixes made it WORSE — a cautionary tale about the mechanism:
+  1. Adding a separate `if op == Min2 || Max2 { let result_dim…; let (x,y)…;
+     let result…; let exact…; }` block BEFORE the general path DUPLICATED those
+     locals (the general path has the identical set), so the frame grew by a full
+     extra copy → still overflowed.
+  2. Extracting the whole `Bin` arm into `#[inline(never)] fn eval_binary`
+     (mirroring `eval_unary`) made it WORSE, not better: the `deeply_nested` test
+     nests `Bin(Add, …)` 306 deep, so the recursion is `eval → eval_binary → eval
+     → eval_binary → …` — **two** stack frames per nesting level instead of one.
+     Even though each `eval` frame shrank, the total (`eval`+`eval_binary`) × 256
+     exceeded the single inline frame × 256. Extraction only helps when the
+     extracted helper is NOT on the deep-recursion path (e.g. `eval_unary` is fine
+     because the test doesn't nest unary ops 256-deep).
+The fix that WORKED: keep the `Bin` arm inline and FOLD min/max into the EXISTING
+`result`/`exact` `match op { … }` arms (and map them through `dim_op` like
+addition), adding ZERO new persistent locals — match arms share the frame's slots,
+they don't each get their own. Frame(after) ≈ frame(main), so CI behaviour matches
+the passing baseline.
+Corrected rule: to add an op to a depth-capped recursive `eval`, FOLD it into the
+existing match arms (reuse the shared locals); do NOT add a parallel `if`-block
+(duplicates locals) and do NOT extract the recursive arm into a helper that then
+sits ON the recursion path (doubles frame COUNT). `cargo test` locally cannot
+verify the margin — local debug frames are so fat that even `main` overflows at
+`RUST_MIN_STACK=5MB`, yet passes on CI at 2MB; the only reliable check is the
+delta-vs-main (no new locals) plus the CI macOS run itself.
 
 Discovered: 2026-07-02 during logic-engine abs-value CI (PR #7299 fix commit adf710c3).
 

--- a/lessons.md
+++ b/lessons.md
@@ -984,6 +984,15 @@ stack in debug builds. `cargo test -p <crate>` locally is NOT sufficient to catc
 it (margin is runner-dependent); the guard is the deep-nesting stack test on CI
 macOS.
 
+Recurrence (PR #7343, adding binary `Min2`/`Max2`): the same overflow re-appeared
+because only the `Unary` arm had been extracted — the `Bin` arm was still inline,
+and adding a `Min2`/`Max2` branch to it enlarged `eval`'s frame again. Fix was to
+extract the ENTIRE `Bin` arm into `#[inline(never)] fn eval_binary` (mirroring
+`eval_unary`). Reinforced rule: don't just extract the arm you're editing —
+**every** recursive arm of a depth-capped `eval`-style function that carries
+non-trivial locals should live in its own `#[inline(never)]` helper, so a future
+addition to any of them can't re-inflate the shared frame.
+
 Discovered: 2026-07-02 during logic-engine abs-value CI (PR #7299 fix commit adf710c3).
 
 ---


### PR DESCRIPTION
## Summary

The **first binary-`Call` lowering**: LaTeX `\min(a, b)` / `\max(a, b)` now compute as **native binary ops** instead of erroring as *"not yet supported"*. min/max are common in clinical formulas (a dose capped at a ceiling, the worse of two labs), and this introduces the two-argument call machinery reusable later for `gcd`/`lcm`.

## logic-engine — `ComputeOp::Min2` / `Max2`
Binary min/max over exactly **two** operands, carried in the existing `ComputeExpr::Bin` — distinct from the slot-reducing aggregation `Min`/`Max` (which fold *every* observation of one slot). Evaluation is a **selection, not a combine**:
- **Dimensionally like addition** — both operands must share a dimension (`min(usd, days)` is the same `DimensionMismatch` category error as `usd + days`), and the result carries that shared dimension.
- The value is **one operand chosen unchanged** (ties pick the left); the **exact-rational sidecar is preserved verbatim** from the winning operand (no rounding, no arithmetic).
- A **non-finite operand** is a clean `NonFinite` error rather than letting a NaN silently win a comparison.
- `symbol()` renders both as `min` / `max`.

## adj-lang — `\min(a, b)` / `\max(a, b)` surface
- New surface AST `BinFn { Min, Max }` and `ExprAst::Call2(BinFn, Box, Box)`, kept distinct from the single-argument `NamedFn`/`ExprAst::Call` (honest arity) and the slot-reducing `AggOp::Min`/`Max`.
- The adapter peels the transparent `Group`/`Fenced` wrapper around the call's argument (the latex frontend parses the parenthesised comma-list as a two-element `Sequence`), requires **exactly two** operands, and lowers to `ComputeExpr::Bin(Min2/Max2, …)`. These are the `Func::Min`/`Func::Max` variants the frontend already parsed but the adapter previously rejected.
- A one-argument (`\min(a)`) or three-argument (`\min(a, b, c)`) call has **no binary lowering** and is a clean, explicit `UnsupportedLatexMath` error. `gcd`/`lcm`/`det`/`Other` remain unsupported.

**latex crate + constraint-solver — no change** (the solver's `Bin` walkers are op-generic).

## Verification
- 4 engine tests (extreme-operand selection with a two-operand `Op`-node shape assertion; exact-rational preservation of the winner; shared-dimension carry + mismatch rejection `min(usd,usd)` vs `min(usd,days)`; non-finite-operand rejection) + 2 adj-lang lower tests (`\min`/`\max` compute-and-decide to the selected operand; wrong-arity rejected).
- Full `logic-engine` (155) + `adj-lang` (103) + `adj-constraint-solver` + `adj-lang-cli` + `adjudication-pipeline` suites green.
- `logic-engine` 0.32→0.33, `adj-lang` 0.27→0.28; both CHANGELOGs updated.

Security-reviewed (inline, against the worktree source): no OOB (indices reached only after `len()==2`), the wrapper-peel `loop` is finite over an acyclic `Box` AST, no use-after-move (`ExactRational` is `Copy`; the derivation nodes move once into the operands vec), NaN/inf guarded, recursion depth-bounded — PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
