### PR TITLE
feat(javascript-parser,closurec): gap-153 — bridge function_expression → typed FunctionExpression

### DIFF
--- a/code/packages/rust/javascript-parser/CHANGELOG.md
+++ b/code/packages/rust/javascript-parser/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to the `coding-adventures-javascript-parser` crate will be documented in this file.
 
+## [0.20.0] - 2026-07-01
+
+### Added — CLOC12.149 / gap-153: bridge `function_expression` → `Expression::FunctionExpression`
+
+The typed-AST bridge now converts a `function_expression` grammar node to the
+`Expression::FunctionExpression` node (landed in `javascript-ast` 0.14) instead
+of declining it as `UnsupportedSyntax`. A function in **value** position — an
+IIFE `(function(){})()`, an assigned function `x = function(){}`, a named
+recursive `function f(){…f()…}`, or a callback `arr.map(function(x){…})` — now
+flows through the full typed pipeline, so closurec optimises *inside* the body
+rather than falling back to WHITESPACE_ONLY.
+
+`convert_function_expression` mirrors `convert_function_declaration` with the one
+grammatical difference that the **name is optional** (`id: Option<Identifier>`):
+`function () {}` is anonymous; a named function expression's name is body-local
+(self-reference for recursion), never bound in the enclosing scope. Generators,
+async functions, arrow functions, classes, and template literals remain declined
+(separate future slices). +4 bridge tests (IIFE callee shape, named body-local
+name, anonymous no-id, all four value positions convert).
+
 ## [0.19.11] - 2026-06-30
 
 ### Changed — opt into the parser's recursion-depth guard (DoS backstop)

--- a/code/packages/rust/javascript-parser/Cargo.toml
+++ b/code/packages/rust/javascript-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-javascript-parser"
-version = "0.19.11"
+version = "0.20.0"
 edition = "2021"
 description = "JavaScript parser — parses JavaScript source code against any ECMAScript edition (es1 through es2025) using the grammar-driven parser. Includes correlation-vector plumbing per CLOC03 and a typed-AST bridge (GrammarASTNode → javascript_ast::Program) per CLOC12.136."
 

--- a/code/packages/rust/javascript-parser/src/bridge.rs
+++ b/code/packages/rust/javascript-parser/src/bridge.rs
@@ -55,7 +55,8 @@ use coding_adventures_javascript_ast::{
     expression::{
         ArrayExpression, AssignmentExpression, AssignmentOperator, AssignmentTarget,
         BigIntLiteral, BinaryExpression, BinaryOperator, BooleanLiteral, CallExpression,
-        ConditionalExpression, Expression, Identifier, LogicalExpression, LogicalOperator,
+        ConditionalExpression, Expression, FunctionExpression, Identifier, LogicalExpression,
+        LogicalOperator,
         MemberExpression, NullLiteral, NumericLiteral, ObjectExpression, Property,
         PropertyKey, PropertyKind, StringLiteral, UnaryExpression, UnaryOperator,
         UndefinedLiteral,
@@ -946,6 +947,58 @@ fn convert_function_declaration(node: &GrammarASTNode) -> Result<FunctionDeclara
     })
 }
 
+fn convert_function_expression(node: &GrammarASTNode) -> Result<FunctionExpression, BridgeError> {
+    // function_expression = "function" [ NAME ] LPAREN [ formal_parameters ] RPAREN
+    //                       LBRACE function_body RBRACE ;
+    // Structurally identical to `function_declaration` (see above) with ONE
+    // difference: the NAME is OPTIONAL. `function () {}` is anonymous;
+    // `function f () {}` in value position binds `f` only inside its own body
+    // (a body-local self-reference for recursion), never in the enclosing
+    // scope. So a missing name is NOT an error here — it's the common case.
+    let name = node.children.iter().find_map(|c| match c {
+        ASTNodeOrToken::Token(t)
+            if t.value != "function"
+                && t.value != "("
+                && t.value != ")"
+                && t.value != "{"
+                && t.value != "}" =>
+        {
+            Some(t.value.clone())
+        }
+        _ => None,
+    });
+
+    let nodes = node_children(node);
+    let mut params = Vec::new();
+    let mut body_node: Option<&GrammarASTNode> = None;
+
+    for n in &nodes {
+        match n.rule_name.as_str() {
+            "formal_parameters" => {
+                params = convert_formal_parameters(n)?;
+            }
+            "function_body" => {
+                body_node = Some(n);
+            }
+            _ => {}
+        }
+    }
+
+    let body = match body_node {
+        Some(n) => convert_function_body(n)?,
+        None => BlockStatement { cv: None, body: vec![] },
+    };
+
+    Ok(FunctionExpression {
+        cv: None,
+        id: name.map(|name| Identifier { cv: None, name }),
+        params,
+        body,
+        generator: false,
+        is_async: false,
+    })
+}
+
 fn convert_formal_parameters(node: &GrammarASTNode) -> Result<Vec<FunctionParam>, BridgeError> {
     // formal_parameters = formal_parameter { COMMA formal_parameter } [ COMMA ]
     // formal_parameter = ( NAME | binding_pattern ) [ EQUALS assignment_expression ]
@@ -1057,19 +1110,24 @@ fn convert_expression(node: &GrammarASTNode) -> Result<Expression, BridgeError> 
         "array_literal" => convert_array_literal(node),
         "object_literal" => convert_object_literal(node),
 
-        // Function-valued and ES2015+ expression forms the typed bridge does
-        // not yet represent (Phase 2). DECLINE GRACEFULLY (`UnsupportedSyntax`
-        // → the CLI falls back to WHITESPACE_ONLY and still emits valid JS).
-        //
-        // `function_expression` MUST be here alongside its siblings
-        // (`generator_expression`, `async_function_expression`, …): a plain
-        // function expression in value position — an IIFE `(function(){})()`,
-        // an assigned function `x = function(){}`, a callback
-        // `f(function(){})` — is extremely common, and without this entry it
-        // fell through to the `InternalError` arm below, aborting the whole
-        // compile (`exit 2`, no output) on valid input.
-        "function_expression"
-        | "arrow_function"
+        // A plain (non-generator, non-async) function in value position —
+        // an IIFE `(function(){})()`, an assigned function
+        // `x = function(){}`, a named recursive `function f(){…f()…}`, a
+        // callback `arr.map(function(x){return x})`. Now that the typed AST
+        // has `Expression::FunctionExpression` (CLOC12.149), convert it
+        // instead of declining, so closurec optimises through it rather than
+        // falling back to WHITESPACE_ONLY. (gap-153.)
+        "function_expression" => {
+            convert_function_expression(node).map(Expression::FunctionExpression)
+        }
+
+        // The remaining function-valued and ES2015+ expression forms the
+        // typed bridge does not yet represent. DECLINE GRACEFULLY
+        // (`UnsupportedSyntax` → the CLI falls back to WHITESPACE_ONLY and
+        // still emits valid JS). Generators/async carry evaluation semantics
+        // the passes don't model yet; arrow functions, classes, and template
+        // literals are separate future AST slices.
+        "arrow_function"
         | "async_arrow_function"
         | "yield_expression"
         | "await_expression"
@@ -2841,24 +2899,77 @@ mod tests {
     }
 
     #[test]
-    fn function_expressions_decline_gracefully_not_hard_error() {
-        // A `function` expression in value position — an IIFE, an assigned
-        // function, a callback argument — is Phase 2. It must decline with
-        // `UnsupportedSyntax` (→ WHITESPACE_ONLY fallback, valid output), NOT
-        // raise an `Internal` error (a hard `exit 2` compile abort).
-        // Regression: `function_expression` was missing from the unsupported
-        // list in `convert_expression`, so it fell through to the
-        // `InternalError` catch-all and `(function(){})();` failed to compile.
+    fn function_expressions_convert_to_typed_nodes() {
+        // CLOC12.149 / gap-153: a `function` expression in value position —
+        // an IIFE, an assigned function, a callback argument, a named
+        // recursive one — now converts to `Expression::FunctionExpression`
+        // instead of declining. (It used to fall back to WHITESPACE_ONLY.)
         for src in [
             "(function(){})();",
             "x=function(){};",
             "f(function(){});",
             "var g=function h(){};",
         ] {
-            match bridge(src) {
-                Err(BridgeError::UnsupportedSyntax { .. }) => {} // graceful decline
-                other => panic!("expected UnsupportedSyntax for {src:?}, got {other:?}"),
+            bridge(src).unwrap_or_else(|e| panic!("expected {src:?} to bridge, got {e}"));
+        }
+    }
+
+    /// Walk to the `FunctionExpression` inside a `var g = <fe>;` program. A
+    /// `var` at statement position wraps as
+    /// `ProgramItem::Statement(Statement::Declaration(..))`.
+    fn bridge_var_init_fn_expr(src: &str) -> FunctionExpression {
+        let p = bridge_ok(src);
+        match &p.body[0] {
+            ProgramItem::Statement(Statement::Declaration(Declaration::VariableDeclaration(vd))) => {
+                match vd.declarations[0].init.as_ref().expect("init") {
+                    Expression::FunctionExpression(fe) => fe.clone(),
+                    other => panic!("expected FunctionExpression init, got {other:?}"),
+                }
             }
+            other => panic!("expected a VariableDeclaration statement, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn named_function_expression_carries_body_local_name() {
+        // `var g = function h (a) { return a; }` — the expression's own name
+        // is `h` (body-local), distinct from the outer binding `g`; one param
+        // `a`; a return body.
+        let fe = bridge_var_init_fn_expr("var g=function h(a){return a;};");
+        assert_eq!(fe.id.as_ref().map(|i| i.name.as_str()), Some("h"));
+        assert_eq!(fe.params.len(), 1);
+        assert!(!fe.generator && !fe.is_async);
+        assert_eq!(fe.body.body.len(), 1, "one return statement");
+    }
+
+    #[test]
+    fn anonymous_function_expression_has_no_id() {
+        // `var g = function () {}` — anonymous, so `id` is `None`.
+        let fe = bridge_var_init_fn_expr("var g=function(){};");
+        assert!(fe.id.is_none(), "anonymous fn-expr must have no id");
+        assert!(fe.params.is_empty());
+        assert!(fe.body.body.is_empty());
+    }
+
+    #[test]
+    fn iife_callee_is_a_function_expression() {
+        // `(function(){})()` — the CallExpression's callee is a
+        // FunctionExpression (the IIFE shape closurec must optimise/emit).
+        let p = bridge_ok("(function(){})();");
+        match &p.body[0] {
+            ProgramItem::Statement(Statement::Tagged(
+                coding_adventures_javascript_ast::statement::TaggedStatement::ExpressionStatement(es),
+            )) => match &es.expression {
+                Expression::CallExpression(call) => {
+                    assert!(
+                        matches!(*call.callee, Expression::FunctionExpression(_)),
+                        "IIFE callee should be a FunctionExpression, got {:?}",
+                        call.callee
+                    );
+                }
+                other => panic!("expected a CallExpression, got {other:?}"),
+            },
+            other => panic!("expected an ExpressionStatement, got {other:?}"),
         }
     }
 

--- a/code/programs/rust/closurec/tests/diff/simple-function-expression/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-function-expression/expected.stdout
@@ -1,0 +1,1 @@
+var factory=function make(n){return 3};var obj={run:function(){return 6}};(function(){var y;y=7})();arr.map(function(x){return x+0});

--- a/code/programs/rust/closurec/tests/diff/simple-function-expression/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/simple-function-expression/flags.txt
@@ -1,0 +1,4 @@
+--js
+tests/diff/simple-function-expression/input/a.js
+--compilation_level
+SIMPLE

--- a/code/programs/rust/closurec/tests/diff/simple-function-expression/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-function-expression/input/a.js
@@ -1,0 +1,6 @@
+// A function *value* in every common position — closurec must optimise
+// INSIDE each body, not fall back to WHITESPACE_ONLY (gap-153).
+var factory = function make(n) { return 1 + 2; };   // named fn-expr (RHS)
+var obj = { run: function () { return 2 * 3; } };    // function-valued property
+(function () { var y = 3 + 4; })();                  // IIFE
+arr.map(function (x) { return x + 0; });             // callback argument

--- a/code/programs/rust/closurec/tests/diff_simple_function_expression.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_function_expression.rs
@@ -1,0 +1,60 @@
+//! Integration test for the `tests/diff/simple-function-expression/` fixture.
+//!
+//! Exercises CLOC12.149 / gap-153 — a `function` in **value** position now
+//! flows through the full SIMPLE pipeline end-to-end (parser → typed-AST
+//! bridge → passes → emitter) instead of declining at the bridge and falling
+//! back to WHITESPACE_ONLY.
+//!
+//! The fixture puts a function expression in every common position — a named
+//! RHS (`var f = function make(n){…}`), a function-valued property
+//! (`{run: function(){…}}`), an IIFE (`(function(){…})()`), and a callback
+//! argument (`arr.map(function(x){…}))` — each with a foldable body. The
+//! expected output proves constant-fold and fold-control-flow ran *inside*
+//! those bodies (`1+2`→`3`, `2*3`→`6`, `3+4`→`7` with the IIFE's `var`
+//! hoisted), which a WHITESPACE_ONLY passthrough would NOT do.
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
+
+fn read_flags() -> Vec<String> {
+    let raw = std::fs::read_to_string("tests/diff/simple-function-expression/flags.txt")
+        .expect("read flags.txt");
+    raw.lines()
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[test]
+fn simple_function_expression_fixture_matches_expected_stdout() {
+    let flags = read_flags();
+    let out = Command::new(BINARY)
+        .args(&flags)
+        .output()
+        .expect("run closurec");
+
+    assert!(
+        out.status.success(),
+        "exit: {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let actual = String::from_utf8_lossy(&out.stdout);
+    let expected = std::fs::read_to_string("tests/diff/simple-function-expression/expected.stdout")
+        .expect("read expected.stdout");
+    assert_eq!(
+        actual.trim_end_matches('\n'),
+        expected.trim_end_matches('\n'),
+        "mismatch.\nactual:\n{actual}\nexpected:\n{expected}",
+    );
+
+    // Guard the *point* of the fixture: the bodies were optimised, so the
+    // folded constants must be present and the pre-fold expressions gone.
+    // (A WHITESPACE_ONLY fallback would still contain `1+2` / `2*3` / `3+4`.)
+    let a = actual.replace(' ', "");
+    assert!(a.contains("return 3") || a.contains("return3"), "1+2 not folded: {actual}");
+    assert!(!a.contains("1+2") && !a.contains("2*3") && !a.contains("3+4"),
+        "a pre-fold expression survived — did it fall back to WHITESPACE_ONLY? {actual}");
+}

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -1402,15 +1402,16 @@ from the active rename/substitute map so a shadowed binding is never rewritten.
 The expression sibling of `FunctionDeclaration`; `id` is `Option<Identifier>`
 (anonymous, or a body-local name). Spec: CLOC09 §"Phase 1.x FunctionExpression".
 
-### gap-153 — bridge still declines `function_expression`
+### gap-153 — bridge declines `function_expression` — **RESOLVED** (javascript-parser 0.20.0)
 
-The parser/grammar already produce `function_expression` (and `arrow_function`,
-`async_function_expression`, `generator_expression`), but the typed-AST bridge
-(`javascript-parser::bridge`) still maps them to `UnsupportedSyntax`, so no
-`FunctionExpression` reaches the pipeline yet — any program containing one falls
-back to WHITESPACE_ONLY. **Next slice:** convert `function_expression` →
-`Expression::FunctionExpression` in the bridge (remove it from the `unsupported`
-list), add a closurec end-to-end fixture (IIFE, function-valued property,
-callback), and port the upstream `CodePrinter`/function-expression conformance
-cases now unblocked. Arrow functions, methods, getters/setters, and class
-expressions remain Phase 3.
+The typed-AST bridge (`javascript-parser::bridge`) now converts
+`function_expression` → `Expression::FunctionExpression` via
+`convert_function_expression` (mirrors `convert_function_declaration`, name
+optional), removed from the `UnsupportedSyntax` list. A function in value
+position — IIFE `(function(){})()`, assigned `x = function(){}`, named recursive
+`function f(){…f()…}`, callback `arr.map(function(x){…})` — flows through the full
+pipeline; closurec optimises **inside** the body instead of falling back to
+WHITESPACE_ONLY. Proven by the `tests/diff/simple-function-expression/` closurec
+fixture (all four value positions fold their bodies at SIMPLE) plus 4 bridge
+unit tests. Generators/async, arrow functions (`arrow_function`), classes, and
+template literals remain declined — separate future AST slices.


### PR DESCRIPTION
## What & why

**PR2 of the FunctionExpression arc** — PR1 ([#7288](https://github.com/adhithyan15/coding-adventures/pull/7288), merged) landed the `Expression::FunctionExpression` AST node + emitter + sound handling in all 10 passes. The typed-AST **bridge still declined `function_expression`** as `UnsupportedSyntax`, so any program with a function in *value* position fell back to WHITESPACE_ONLY. This PR wires the bridge to convert it, making function expressions reachable **end-to-end through the real optimization pipeline**. (gap-153.)

## Changes

- **javascript-parser** (0.19.11→0.20.0): `convert_function_expression` mirrors `convert_function_declaration` with one grammatical difference — the **name is optional** (`id: Option<Identifier>`): `function () {}` is anonymous; a named function expression's name is body-local (self-reference for recursion), never bound in the enclosing scope. Removed `function_expression` from the `UnsupportedSyntax` arm; generators/async/arrow/class/template stay declined (future slices). **+4 bridge tests** (IIFE callee shape, named body-local name + params + body, anonymous no-id, all four value positions convert).
- **closurec** (test-only — no `src/` change, so **no version bump**, which sidesteps the cli.spec.json/help-fixture version-sync trap): `tests/diff/simple-function-expression/` fixture + `diff_simple_function_expression` integration test.

## Proof it's the real pipeline, not a passthrough

Driving a named RHS fn-expr, a function-valued property, an IIFE, and a callback arg through **SIMPLE**:

```
var factory=function make(n){return 3};var obj={run:function(){return 6}};(function(){var y;y=7})();arr.map(function(x){return x+0});
```

`1+2`→`3`, `2*3`→`6`, `3+4`→`7` are folded **inside** the function-expression bodies, and the IIFE's `var` is hoisted — a WHITESPACE_ONLY fallback would leave `1+2`/`2*3`/`3+4` intact. The fixture test asserts the pre-fold expressions are gone.

## Verification

javascript-parser (100 tests) + full closurec suite (685 unit + all integration fixtures) **green, no regressions**. Security review passed (no new panics; recursion bounded by the parser's existing `with_max_depth` DoS backstop; no injection).

Spec: CLOC12-gaps **gap-153 marked RESOLVED**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)