### PR TITLE
feat(sir-js): typed runtime errors — ZeroDivision/Index/Key/NoMethod (T3)

### DIFF
--- a/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
@@ -22,6 +22,13 @@ All notable changes to `semantic-ir-to-javascript` are documented here.
     default → `KeyError`. A supplied default (`fetch(k, d)`) is returned
     instead of raising, matching Ruby. Handled in `callMethod` ahead of the
     method allowlist (negative array indices count from the end).
+    - **Security (CWE-470):** `arr.fetch` first validates its index is a real
+      integer (`typeof === "number" && Number.isInteger`) — a non-integer,
+      source-controlled index (`arr.fetch("constructor")`, `"__proto__"`, …)
+      raises `TypeError` (Ruby: *no implicit conversion of String into
+      Integer*) instead of sailing past the `NaN`-poisoned bounds checks to a
+      reflective `recv[idx]` read that would leak prototype/host gadgets and
+      bypass the allowlist. Regression: `t3_array_fetch_non_integer_index_raises_type_error_not_gadget`.
   - **Unknown method** (an allowlist miss, or a `SirInstance` method miss) →
     `NoMethodError` (`undefined method \`x\` for <class>`) via a new
     `classDescription` receiver-describer, replacing the previous JS-native

--- a/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 All notable changes to `semantic-ir-to-javascript` are documented here.
 
+## 0.10.0 — typed runtime errors (ZeroDivision/Index/Key/NoMethod, T3)
+
+### Added
+
+- Faulting emitted-runtime operations now raise the **correct typed
+  `SirError`** (matching Ruby), so a translated
+  `begin; …; rescue ZeroDivisionError => e; …; end` catches them — and
+  identically across backends (sir-typed-runtime-errors, T3). Runtime-only:
+  no core-IR / frontend change.
+  - **Division by zero** (`1 / 0`, `1.0 / 0`) → `ZeroDivisionError`
+    (`"divided by 0"`). Native JS `/` yields `Infinity`, so the emitter now
+    routes the 2-arg `/` builtin through a new inlined `__Sir.divide(a, b)`
+    helper that adds an explicit `b === 0` check (covering integer-zero,
+    float-zero, and `-0` divisors uniformly) and `raiseError`s the typed
+    error. Non-zero divisors divide natively as before — no numeric program
+    changes. (`-`/`%` and comparisons keep native infix.)
+  - **`arr.fetch(oob)`** → `IndexError`; **`hash.fetch(missing)`** with no
+    default → `KeyError`. A supplied default (`fetch(k, d)`) is returned
+    instead of raising, matching Ruby. Handled in `callMethod` ahead of the
+    method allowlist (negative array indices count from the end).
+  - **Unknown method** (an allowlist miss, or a `SirInstance` method miss) →
+    `NoMethodError` (`undefined method \`x\` for <class>`) via a new
+    `classDescription` receiver-describer, replacing the previous JS-native
+    `TypeError` floor (which a `rescue` would miss or catch over-broadly).
+- The plain index operators `arr[i]` / `hash[k]` are **unchanged**: they
+  still return `nil` (Ruby does NOT raise for `[]`) — no over-raise.
+- Dispatch remains an explicit runtime **tag** test / typed-string raise,
+  never reflection / `eval` on a source-derived name
+  ([[dynamic-dispatch-rce]]); the method allowlist still blocks reflective
+  gadgets — now surfacing the rejection as a typed `NoMethodError`.
+- Execution proofs in `run_with_node.rs` (`t3_*`) run each case under `node`
+  and assert the typed clause catches (`1/0`→ZeroDivisionError,
+  `arr.fetch(oob)`→IndexError, `h.fetch(miss)`→KeyError,
+  `obj.frobnicate`→NoMethodError), that `ZeroDivisionError` also chains up to
+  `StandardError`, that `arr[oob]`/`h[miss]` still return `nil` (no
+  over-raise), and that `fetch` with a default returns it.
+
 ## 0.9.0 — polymorphic `+` / `*` for strings and arrays (PO3)
 
 ### Added

--- a/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-javascript"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 description = "Semantic IR → self-contained JavaScript source code (SIR18). Fifth backend for the SIR10 narrow-waist IR. Includes __method__ dispatch execution (C3), exception handling (try/catch/raise) with user-class ancestry (E1), and user-defined-class OOP — instantiation, method dispatch, super, self, and @ivar/@@cvar access (O3)."
 

--- a/code/packages/rust/semantic-ir-to-javascript/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/emit.rs
@@ -1032,6 +1032,10 @@ fn emit_builtin_call(out: &mut String, name: &str, args: &[Expr], indent: usize)
         let poly = match name {
             "+" => Some("__Sir.plus"),
             "*" => Some("__Sir.times"),
+            // `/` routes through the runtime `divide` helper, which ADDS
+            // the Ruby zero-divisor check (native JS `/` yields `Infinity`,
+            // not a `ZeroDivisionError`).  See `runtime::divide`.
+            "/" => Some("__Sir.divide"),
             _ => None,
         };
         if let Some(helper) = poly {
@@ -1476,10 +1480,18 @@ mod tests {
     #[test]
     fn emit_builtin_arithmetic_is_native_infix() {
         let two = || vec![Expr::IntLit { value: 1, span: s() }, Expr::IntLit { value: 2, span: s() }];
-        // `-`/`/`/`%` stay native infix (numeric-only in the SIR contract).
+        // `-`/`%` stay native infix (numeric-only in the SIR contract).
         assert_eq!(emit_e(&bc("-", two())), "(1 - 2)");
-        assert_eq!(emit_e(&bc("/", two())), "(1 / 2)");
         assert_eq!(emit_e(&bc("%", two())), "(1 % 2)");
+    }
+
+    #[test]
+    fn emit_builtin_divide_routes_through_runtime_helper() {
+        // `/` routes through `__Sir.divide`, which adds the Ruby
+        // zero-divisor check (native JS `/` yields `Infinity`, not a
+        // `ZeroDivisionError`).  The numeric result is otherwise identical.
+        let two = || vec![Expr::IntLit { value: 1, span: s() }, Expr::IntLit { value: 2, span: s() }];
+        assert_eq!(emit_e(&bc("/", two())), "__Sir.divide(1, 2)");
     }
 
     #[test]

--- a/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
@@ -352,6 +352,30 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
     return numFold(args, 1, (x, y) => x * y);
   }
 
+  // ── division `/` (Ruby ZeroDivisionError) ──────────────────────
+  //
+  // Ruby raises `ZeroDivisionError` ("divided by 0") for `1 / 0` — for BOTH
+  // integer and float receivers (`1 / 0` and `1.0 / 0` both raise; Ruby's
+  // `Float#/` by an integer zero raises, unlike bare float math which gives
+  // `Infinity`).  Native JavaScript `/` never throws: `1 / 0 === Infinity`
+  // and `0 / 0 === NaN`.  So the backend routes the binary `/` builtin
+  // through this helper, which ADDS the explicit zero-divisor check and
+  // raises a typed `SirError` (`ZeroDivisionError`) that a translated
+  // `rescue ZeroDivisionError` catches — matching Ruby exactly.
+  //
+  // We only special-case a divisor that is exactly `0` (integer or the
+  // float `0`/`-0`); any other numeric divisor divides natively as before,
+  // so no existing numeric program changes.  Note `1.0 / 0.0` in Ruby also
+  // raises `ZeroDivisionError` (it does NOT return `Float::INFINITY`), and
+  // `0 === -0` and `0 === 0.0` in JS, so the single `=== 0` test covers the
+  // integer-zero, float-zero, and negative-zero divisors uniformly.
+  function divide(a, b) {
+    if (b === 0) {
+      raiseError("ZeroDivisionError", "divided by 0");
+    }
+    return a / b;
+  }
+
   // ── method dispatch (`__method__`) ─────────────────────────────
   // `recv.meth(args…)` reaches the backend as
   // `BuiltinCall("__method__", [recv, "meth", args…])`; the emitter routes
@@ -432,18 +456,72 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
     // `length` as a nullary method mirrors the property.  Kept special-cased
     // ahead of the allowlist: it is a property read, not a method call.
     if (name === "length" && args.length === 0) { return recv.length; }
+    // ── `.fetch` (Ruby typed lookup) ──────────────────────────────
+    // Ruby's `.fetch` is the *raising* sibling of the `[]` index op (which
+    // stays nil-returning): a sequence `arr.fetch(i)` past the end raises
+    // `IndexError`, and a hash `h.fetch(k)` with a MISSING key and NO
+    // default (no second arg / block) raises `KeyError`.  Both are typed
+    // `SirError`s here so a translated `rescue IndexError` / `rescue
+    // KeyError` catches them.  A supplied default arg (`fetch(k, d)`) is
+    // returned instead of raising, matching Ruby.  Handled AHEAD of the
+    // allowlist because native arrays have no `fetch` and native `Map`'s
+    // `fetch` does not exist / does not match Ruby's semantics.
+    if (name === "fetch") {
+      if (Array.isArray(recv)) {
+        // Ruby allows a negative index (counts from the end); an index
+        // resolving outside `0 .. length-1` is out of bounds.
+        const raw = args[0];
+        const idx = raw < 0 ? recv.length + raw : raw;
+        if (idx < 0 || idx >= recv.length) {
+          if (args.length >= 2) { return args[1]; }
+          raiseError("IndexError",
+            "index " + format(raw) + " outside of array bounds: " +
+            (recv.length === 0 ? "0...0" :
+              "-" + recv.length + "..." + recv.length));
+        }
+        return recv[idx];
+      }
+      if (recv instanceof Map) {
+        if (recv.has(args[0])) { return recv.get(args[0]); }
+        if (args.length >= 2) { return args[1]; }
+        raiseError("KeyError", "key not found: " + format(args[0]));
+      }
+      // A `.fetch` on any other receiver has no Ruby-collection meaning
+      // here; fall through to the unknown-method NoMethodError below.
+    }
     // SECURITY gate: refuse any name outside the allowlist so reflective
     // gadgets (`constructor`, `__proto__`, `apply`, …) can never be reached.
+    // An allowlist miss is a *genuinely unknown* method, so — matching Ruby
+    // — we raise a typed `NoMethodError` (rescuable via `rescue
+    // NoMethodError`) rather than a JS-native `TypeError` (which a `rescue`
+    // would either miss or, worse, catch as an over-broad StandardError).
+    // The reflective gadgets never appear in the allowlist, so they still
+    // land here and are rejected before any property is looked up.
     if (!METHOD_ALLOWLIST.has(name)) {
-      throw new TypeError(
-        "method `" + name + "` is not an allowed collection method");
+      raiseError("NoMethodError",
+        "undefined method `" + name + "` for " + classDescription(recv));
     }
     const m = recv == null ? undefined : recv[name];
     if (typeof m !== "function") {
-      throw new TypeError(
-        "method `" + name + "` is not defined on " + format(recv));
+      raiseError("NoMethodError",
+        "undefined method `" + name + "` for " + classDescription(recv));
     }
     return m.apply(recv, args);
+  }
+
+  // A Ruby-ish description of a receiver for a `NoMethodError` message —
+  // e.g. `nil`, `an instance of Array`, `an instance of String`.  Pure
+  // TAG tests on the runtime representation, never reflection on a
+  // source-derived name, so no gadget is reachable from here.
+  function classDescription(recv) {
+    if (recv === null || recv === undefined) { return "nil"; }
+    if (Array.isArray(recv)) { return "an instance of Array"; }
+    if (recv instanceof Map) { return "an instance of Hash"; }
+    if (typeof recv === "string") { return "an instance of String"; }
+    if (typeof recv === "number") { return "an instance of Numeric"; }
+    if (typeof recv === "boolean") { return recv ? "true" : "false"; }
+    if (recv instanceof Sym) { return "an instance of Symbol"; }
+    return "an instance of Object";
   }
 
   // ── exceptions (SIR17 `Feature::Exceptions`) ───────────────────
@@ -750,7 +828,7 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
   return {
     Sym, Pair, Closure,
     intern, applyClosure, truthy, format, print, puts,
-    plus, times,
+    plus, times, divide,
     builtins, builtinClosure, callBuiltin, callMethod,
     SirError, raiseError, rescueMatches, registerAncestry,
     // OOP (O3): instantiation, method definition + dispatch, super,
@@ -854,6 +932,31 @@ mod tests {
         // a raw RangeError.
         assert!(RUNTIME.contains(r#"raiseError("ArgumentError", "argument too big")"#));
         assert!(RUNTIME.contains("Number.MAX_SAFE_INTEGER"));
+    }
+
+    #[test]
+    fn runtime_typed_errors_divide_fetch_unknown_method() {
+        // T3 (sir-typed-runtime-errors): the faulting runtime ops raise the
+        // CORRECT typed SirError, matching Ruby.
+
+        // Division by zero → ZeroDivisionError ("divided by 0").  The helper
+        // adds the check native JS `/` lacks (it yields Infinity).
+        assert!(RUNTIME.contains("function divide(a, b)"));
+        assert!(RUNTIME.contains(r#"raiseError("ZeroDivisionError", "divided by 0")"#));
+        assert!(RUNTIME.contains("plus, times, divide,"), "divide must be exported");
+
+        // `.fetch` raises typed errors: IndexError for a sequence OOB,
+        // KeyError for a missing hash key (no default).
+        assert!(RUNTIME.contains(r#"if (name === "fetch")"#));
+        assert!(RUNTIME.contains(r#"raiseError("IndexError","#));
+        assert!(RUNTIME.contains(r#"raiseError("KeyError", "key not found: ""#));
+
+        // An unknown method raises NoMethodError (not a JS-native TypeError).
+        assert!(RUNTIME.contains(r#"raiseError("NoMethodError","#));
+        assert!(RUNTIME.contains(r#""undefined method `" + name + "` for " + classDescription(recv)"#));
+        assert!(RUNTIME.contains("function classDescription(recv)"));
+        // The old JS-native TypeError floor for the allowlist miss is gone.
+        assert!(!RUNTIME.contains("is not an allowed collection method"));
     }
 
     #[test]

--- a/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
@@ -471,6 +471,19 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
         // Ruby allows a negative index (counts from the end); an index
         // resolving outside `0 .. length-1` is out of bounds.
         const raw = args[0];
+        // SECURITY: `raw` is a source-controlled value and MUST be a real
+        // integer before it can index `recv`.  A non-numeric string
+        // (`"constructor"`, `"__proto__"`, `"push"`, …) would sail past the
+        // `NaN`-poisoned bounds checks below (every comparison with NaN is
+        // false) and reach `recv[raw]` — a reflective property read that
+        // leaks prototype/host gadgets and bypasses the method allowlist.
+        // Ruby itself raises here (`TypeError: no implicit conversion of
+        // String into Integer`), so reject a non-integer index with the same
+        // typed error rather than ever indexing by a source-derived name.
+        if (typeof raw !== "number" || !Number.isInteger(raw)) {
+          raiseError("TypeError",
+            "no implicit conversion of " + classDescription(raw) + " into Integer");
+        }
         const idx = raw < 0 ? recv.length + raw : raw;
         if (idx < 0 || idx >= recv.length) {
           if (args.length >= 2) { return args[1]; }

--- a/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
@@ -1691,6 +1691,27 @@ fn t3_array_fetch_oob_raises_index_error() {
     );
 }
 
+/// SECURITY (CWE-470): `arr.fetch("constructor")` — a non-integer,
+/// source-controlled index — must raise `TypeError` (Ruby: "no implicit
+/// conversion of String into Integer") rather than falling through the
+/// `NaN`-poisoned bounds checks to `recv["constructor"]`, which would leak
+/// the `Array` constructor / prototype gadgets and bypass the method
+/// allowlist.  A translated `rescue TypeError` catches it.
+#[test]
+fn t3_array_fetch_non_integer_index_raises_type_error_not_gadget() {
+    let arr = seq(vec![int(1), int(2)]);
+    assert_typed_rescue_catches(
+        vec![Stmt::ExprStmt {
+            expr: bc("__method__", vec![arr, str_("fetch"), str_("constructor")]),
+            span: sp(),
+        }],
+        "TypeError",
+        "Integer",
+        &[Feature::Sequences, Feature::Strings, Feature::DynamicTyping],
+        "t3_arr_fetch_gadget",
+    );
+}
+
 /// `hash.fetch(missing)` with no default raises `KeyError`.
 #[test]
 fn t3_hash_fetch_missing_raises_key_error() {

--- a/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
@@ -896,9 +896,15 @@ fn runtime_rejects_constructor_gadget() {
     );
 
     if let Some(stderr) = run_module_expecting_failure(&module, "rce_gadget") {
+        // The gadget name is not on the allowlist, so — as with any unknown
+        // method (T3) — it is rejected with a typed `NoMethodError` *before*
+        // any `recv[name]` lookup.  The load-bearing property is that the
+        // `"return 1"` payload was NEVER synthesised/executed (node threw
+        // instead of printing a result), and the miss surfaces as our
+        // NoMethodError, not an executed host `Function` payload.
         assert!(
-            stderr.contains("not an allowed collection method"),
-            "expected the allowlist TypeError, got stderr:\n{stderr}"
+            stderr.contains("NoMethodError") || stderr.contains("undefined method"),
+            "expected the allowlist rejection (NoMethodError), got stderr:\n{stderr}"
         );
     }
 }
@@ -1585,5 +1591,196 @@ fn poly_string_repeat_overflow_is_rejected() {
             stderr.contains("argument too big"),
             "expected the ArgumentError overflow guard, got stderr:\n{stderr}"
         );
+    }
+}
+
+// ── T3: typed runtime errors (ZeroDivision/Index/Key/NoMethod) ─────────
+//
+// The sir-typed-runtime-errors cascade: a faulting emitted runtime op must
+// raise the CORRECT typed `SirError` (matching Ruby) so a translated
+// `begin; …; rescue ZeroDivisionError => e; …; end` catches it.  These
+// execution-proofs build the `begin/rescue` (a `Stmt::TryCatch`) around
+// each faulting op and assert — under Node — that the specific typed clause
+// fires (printing the class name via `e.class` … but the frontend has no
+// `.class` yet, so instead we print a fixed marker from the matching
+// clause).  The nil-returning index ops (`arr[oob]`/`h[miss]`) prove the
+// non-over-raise: they print `nil`, NOT an error.
+
+/// Wrap `body` in `begin; <body>; rescue <class> => e; puts <marker>; end`
+/// and assert the marker prints (i.e. the typed clause caught the fault).
+fn assert_typed_rescue_catches(
+    body: Vec<Stmt>,
+    class: &str,
+    marker: &str,
+    features: &[Feature],
+    tag: &str,
+) {
+    let mut feats = vec![Feature::Exceptions, Feature::Constants, Feature::Strings];
+    feats.extend_from_slice(features);
+    let try_catch = Stmt::TryCatch {
+        body,
+        rescues: vec![RescueClause {
+            exception_types: vec![class.into()],
+            binding: Some("e".into()),
+            body: vec![print(str_(marker))],
+            span: sp(),
+        }],
+        ensure_body: None,
+        span: sp(),
+    };
+    let module = module_with_main(vec![try_catch], Expr::NilLit { span: sp() }, &feats);
+    if let Some(stdout) = run_module(&module, tag) {
+        assert_eq!(stdout, marker, "expected the `{class}` clause to catch");
+    }
+}
+
+/// `begin; 1 / 0; rescue ZeroDivisionError => e; puts "zde"; end` → "zde".
+/// Native JS `1 / 0 === Infinity`; the runtime `divide` helper adds the
+/// zero-divisor check and raises the typed `ZeroDivisionError`.
+#[test]
+fn t3_int_div_by_zero_raises_zero_division_error() {
+    assert_typed_rescue_catches(
+        vec![Stmt::ExprStmt { expr: bc("/", vec![int(1), int(0)]), span: sp() }],
+        "ZeroDivisionError",
+        "zde",
+        &[],
+        "t3_int_zde",
+    );
+}
+
+/// `1.0 / 0` also raises `ZeroDivisionError` in Ruby (float receiver, integer
+/// zero divisor) — the helper's `b === 0` test covers the float case too.
+#[test]
+fn t3_float_div_by_zero_raises_zero_division_error() {
+    assert_typed_rescue_catches(
+        vec![Stmt::ExprStmt { expr: bc("/", vec![float(1.0), int(0)]), span: sp() }],
+        "ZeroDivisionError",
+        "zde-f",
+        &[Feature::Floats],
+        "t3_float_zde",
+    );
+}
+
+/// A `ZeroDivisionError` is also caught by `rescue StandardError` (it chains
+/// up the built-in ancestry) — proving the typed error is a real SirError in
+/// the hierarchy, not an over-broad host fault.
+#[test]
+fn t3_zero_division_caught_by_standard_error() {
+    assert_typed_rescue_catches(
+        vec![Stmt::ExprStmt { expr: bc("/", vec![int(1), int(0)]), span: sp() }],
+        "StandardError",
+        "zde-std",
+        &[],
+        "t3_zde_std",
+    );
+}
+
+/// `arr.fetch(100)` out of bounds raises `IndexError`.
+#[test]
+fn t3_array_fetch_oob_raises_index_error() {
+    let arr = seq(vec![int(10), int(20), int(30)]);
+    assert_typed_rescue_catches(
+        vec![Stmt::ExprStmt {
+            expr: bc("__method__", vec![arr, str_("fetch"), int(100)]),
+            span: sp(),
+        }],
+        "IndexError",
+        "idx",
+        &[Feature::Sequences, Feature::DynamicTyping],
+        "t3_arr_fetch_oob",
+    );
+}
+
+/// `hash.fetch(missing)` with no default raises `KeyError`.
+#[test]
+fn t3_hash_fetch_missing_raises_key_error() {
+    let map = Expr::MapLit {
+        entries: vec![MapEntry { key: str_("a"), value: int(1) }],
+        span: sp(),
+    };
+    assert_typed_rescue_catches(
+        vec![Stmt::ExprStmt {
+            expr: bc("__method__", vec![map, str_("fetch"), str_("missing")]),
+            span: sp(),
+        }],
+        "KeyError",
+        "key",
+        &[Feature::Maps, Feature::DynamicTyping],
+        "t3_hash_fetch_miss",
+    );
+}
+
+/// An unknown method (`arr.frobnicate`) raises `NoMethodError`, NOT a
+/// JS-native TypeError — so a translated `rescue NoMethodError` catches it.
+#[test]
+fn t3_unknown_method_raises_no_method_error() {
+    let arr = seq(vec![int(1)]);
+    assert_typed_rescue_catches(
+        vec![Stmt::ExprStmt {
+            expr: bc("__method__", vec![arr, str_("frobnicate")]),
+            span: sp(),
+        }],
+        "NoMethodError",
+        "nme",
+        &[Feature::Sequences, Feature::DynamicTyping],
+        "t3_unknown_method",
+    );
+}
+
+/// NON-over-raise: `arr[oob]` and `h[miss]` still return **nil** (Ruby does
+/// NOT raise for `[]`).  A begin/rescue around them must NOT fire; the
+/// program prints `nil` twice.
+#[test]
+fn t3_index_ops_return_nil_no_over_raise() {
+    // begin; puts(arr[100]); puts(h["missing"]); rescue => e; puts "SHOULD-NOT"; end
+    let arr = seq(vec![int(10), int(20)]);
+    let map = Expr::MapLit {
+        entries: vec![MapEntry { key: str_("a"), value: int(1) }],
+        span: sp(),
+    };
+    let try_catch = Stmt::TryCatch {
+        body: vec![
+            print(Expr::SeqIndex { seq: Box::new(arr), index: Box::new(int(100)), span: sp() }),
+            print(Expr::MapGet { map: Box::new(map), key: Box::new(str_("missing")), span: sp() }),
+        ],
+        rescues: vec![RescueClause {
+            exception_types: vec![], // bare rescue — would catch ANY raise
+            binding: None,
+            body: vec![print(str_("SHOULD-NOT-RESCUE"))],
+            span: sp(),
+        }],
+        ensure_body: None,
+        span: sp(),
+    };
+    let module = module_with_main(
+        vec![try_catch],
+        Expr::NilLit { span: sp() },
+        &[
+            Feature::Exceptions,
+            Feature::Constants,
+            Feature::Strings,
+            Feature::Sequences,
+            Feature::Maps,
+        ],
+    );
+    if let Some(stdout) = run_module(&module, "t3_index_nil") {
+        // Two nils printed; the (bare) rescue never fired.
+        assert_eq!(stdout, "nil\nnil", "index ops must return nil, not raise");
+    }
+}
+
+/// `arr.fetch(oob, default)` with a supplied default returns the default
+/// instead of raising — matching Ruby's `fetch(i, d)`.
+#[test]
+fn t3_array_fetch_with_default_returns_default() {
+    // print(arr.fetch(100, 42)) → 42 (no raise).
+    let arr = seq(vec![int(10)]);
+    let module = module_with_main(
+        vec![print(bc("__method__", vec![arr, str_("fetch"), int(100), int(42)]))],
+        Expr::NilLit { span: sp() },
+        &[Feature::Sequences, Feature::DynamicTyping, Feature::Strings],
+    );
+    if let Some(stdout) = run_module(&module, "t3_fetch_default") {
+        assert_eq!(stdout, "42", "fetch with a default must return it, not raise");
     }
 }


### PR DESCRIPTION
JavaScript milestone of the **sir-typed-runtime-errors** cascade (spec on main, #53). Runtime-only — only `code/packages/rust/semantic-ir-to-javascript/`.

Faulting emitted-runtime ops now raise the correct **typed** `SirError` so a translated `rescue` catches them, uniformly:
- `1/0` / `1.0/0` → `ZeroDivisionError` (2-arg `/` routes through a new `__Sir.divide` with an explicit `b === 0` check; native JS gave `Infinity`).
- `arr.fetch(oob)` → `IndexError`; `hash.fetch(miss)` → `KeyError` (default arg returns instead of raising).
- unknown method → `NoMethodError` (`undefined method 'x' for <class>`), replacing the JS-native `TypeError` floor.
- `arr[i]`/`hash[k]` **unchanged** → still nil (no over-raise).

**Security (review-driven, HIGH, CWE-470):** the initial `.fetch` array arm did `recv[idx]` with a source-controlled index ahead of the allowlist — a non-numeric string (`arr.fetch("constructor")`, `"__proto__"`) passed the `NaN` bounds checks and leaked prototype/host gadgets. Fixed: `.fetch` validates the index is a real integer, else raises Ruby's `TypeError: no implicit conversion of String into Integer`. Regression test added.

Exec-proofed via node; 99 lib + 44 integration green, 0 warnings. Dispatch stays explicit tag/allowlist, never reflection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)