### PR TITLE
feat(adj-ladder): rung-39 CBC leukocyte differential total (three-term sum)

### DIFF
--- a/code/specs/data/adj-ladder/rung39_wbc_differential/gen_items.py
+++ b/code/specs/data/adj-ladder/rung39_wbc_differential/gen_items.py
@@ -1,0 +1,201 @@
+"""Generate rung-39 (CBC leukocyte differential total) items.json for the ADJ-LADDER.
+
+Rung 39 opens the **hematology / complete-blood-count differential** panel on the quantitative band — the
+arithmetic of adding up the absolute counts of the white-cell populations. When the lab reports a differential it
+gives an absolute count (cells per microliter) for each leukocyte type; summing the major populations recovers the
+combined count. It uses the same contamination-safe shape as the anion-gap rung (38), the CSF:serum rung (37) and
+the transfusion-pooling rung (36): a small table of *observed* absolute counts and a tight family of
+mutually-confusable formulas built **only from those observed quantities** (no numeric literal anywhere in any
+program), so nothing structural can leak.
+
+The clinical setup is a leukocyte differential. FOUR populations are measured — all as absolute counts in
+cells/uL:
+
+  NEUTROPHILS    the neutrophil absolute count       (usually the largest population)
+  LYMPHOCYTES    the lymphocyte absolute count        (the second-largest)
+  MONOCYTES      the monocyte absolute count          (a minor population)
+  EOSINOPHILS    the eosinophil absolute count        (a minor population — the odd one out here)
+
+The combined count of the three major populations is **their sum** — a *three-term sum* —
+`NEUTROPHILS + LYMPHOCYTES + MONOCYTES`. That is what makes this rung distinctive: it is a NEW arithmetic shape on
+the ladder — a flat sum of THREE observed terms, `a + b + c`, all addition. The nearest prior rung (38, serum
+anion gap) chained two SUBTRACTIONS across three terms (`a - b - c`); every other prior rung composed exactly two
+sub-expressions (rung-36 weighted-average, rung-37 ratio-of-two-sums). This rung is the first pure three-term
+ADDITION. The core confusion this rung tests is adding the three MAJOR populations (and no others), rather than
+dropping one, adding the wrong pair, or sweeping in the eosinophils too:
+
+  MAJOR SUM       NEUTROPHILS + LYMPHOCYTES + MONOCYTES   [ the three major populations summed ]
+  NEU + LYM       NEUTROPHILS + LYMPHOCYTES               [ only the two largest (a partial sum) ]
+  LYM + MON       LYMPHOCYTES + MONOCYTES                 [ the two non-neutrophil majors (a partial sum) ]
+
+Each index is a `compute_dimensioned` program (observe the four quantities + `let answer = formula`); the ADJ
+engine carries the arithmetic and the harness reads the scalar via the existing `compute_dimensioned`
+extractor — no harness/engine change, exactly as rungs 8/16/…/37/38. This rung exercises the engine across a
+flat THREE-TERM ADDITION (`(neutrophils + lymphocytes) + monocytes`).
+
+Contamination-safe by construction: every formula is built only from the four observed quantities via `+` —
+**no structural constants** — so every program literal is grounded in the stem. No total ever appears as a
+literal (each is computed from the observed counts). The observed quantities carry **digit-free identifiers**
+(`neutrophils`, `lymphocytes`, `monocytes`, `eosinophils`) so no numeral hides inside a variable name. The five
+options are a tight family over the same quantities: the three real sums plus the two classic slips —
+
+  ALL FOUR       NEUTROPHILS + LYMPHOCYTES + MONOCYTES + EOSINOPHILS   the eosinophils swept in too (a four-term sum), and
+  NEU + EOS      NEUTROPHILS + EOSINOPHILS                             a wrong pair (a major plus the odd minor),
+
+which are exactly the mistakes a student makes. Gold rotates A-E by index.
+
+Note on scale: the major sum is order 6000-8000 cells/uL, the neutrophil+lymphocyte partial is order 6000-7200,
+the lymphocyte+monocyte partial is order 1500-3800, the all-four distractor is the major sum plus the eosinophils
+(a few hundred more), and the neutrophil+eosinophil distractor is order 3500-6500; the tables below are chosen so
+the five family values are pairwise distinct — with a comfortable margin — for every item, asserted at build time
+(all four counts positive so every sum is positive, and no two family values collide).
+"""
+import json
+
+LETTERS = ["A", "B", "C", "D", "E"]
+
+# (NEUTROPHILS, LYMPHOCYTES, MONOCYTES, EOSINOPHILS) observed absolute counts, all in cells/uL. Neutrophils are the
+# largest population, lymphocytes second, monocytes and eosinophils minor. All four are strictly positive, so every
+# sum is positive. The five family values are asserted pairwise-distinct (with margin) below.
+TABLES = [
+    (4000, 2000, 500, 150),
+    (5500, 1500, 700, 300),
+    (3200, 2800, 400, 250),
+    (6000, 1200, 300, 450),
+    (4800, 2400, 600, 100),
+    (3600, 2600, 900, 150),
+    (5000, 1000, 450, 350),
+]
+
+# The option family (5 members), all built from the observed quantities via `+`. Every identifier is DIGIT-FREE.
+# key -> (display name, formula-as-adj). Only the first three are *queried* (used as gold); all five always appear
+# as the options.
+FAMILY = [
+    (
+        "major_sum",
+        "combined count of the three major populations (neutrophils, lymphocytes, monocytes)",
+        "neutrophils + lymphocytes + monocytes",
+    ),
+    (
+        "neu_plus_lym",
+        "combined count of neutrophils and lymphocytes only",
+        "neutrophils + lymphocytes",
+    ),
+    (
+        "lym_plus_mon",
+        "combined count of lymphocytes and monocytes only",
+        "lymphocytes + monocytes",
+    ),
+    (
+        "all_four",
+        "count with the eosinophils swept in too (all four populations)",
+        "neutrophils + lymphocytes + monocytes + eosinophils",
+    ),
+    (
+        "neu_plus_eos",
+        "wrong pair (a major population plus the odd minor one)",
+        "neutrophils + eosinophils",
+    ),
+]
+QUERIED = ["major_sum", "neu_plus_lym", "lym_plus_mon"]
+ORDER = [k for k, _, _ in FAMILY]
+
+
+def scalar(v):
+    return {"value": v, "unit": "scalar"}
+
+
+def family_values(neu, lym, mon, eos):
+    # Operation order mirrors the ADJ program exactly (a left-folded sum: (neu + lym) + mon), so the Python option
+    # value and the engine result are the same IEEE-double (well within the harness's 1e-9 match tolerance).
+    return {
+        "major_sum": neu + lym + mon,
+        "neu_plus_lym": neu + lym,
+        "lym_plus_mon": lym + mon,
+        "all_four": neu + lym + mon + eos,
+        "neu_plus_eos": neu + eos,
+    }
+
+
+def build():
+    name_of = {k: nm for k, nm, _ in FAMILY}
+    formula_of = {k: f for k, _, f in FAMILY}
+    items = []
+    idx = 0
+
+    def num(x):
+        return int(x) if float(x).is_integer() else x
+
+    for neu, lym, mon, eos in TABLES:
+        assert neu > 0 and lym > 0 and mon > 0 and eos > 0, (neu, lym, mon, eos)
+        fv = family_values(neu, lym, mon, eos)
+        # Pairwise-distinct with a comfortable margin so the harness never sees two options
+        # matching the gold value within its 1e-9 tolerance.
+        vals = [fv[key] for key in ORDER]
+        for i in range(len(vals)):
+            for j in range(i + 1, len(vals)):
+                assert abs(vals[i] - vals[j]) > 1e-6, (neu, lym, mon, eos, ORDER[i], ORDER[j], fv)
+        for key in QUERIED:
+            gold_val = fv[key]
+            gold_pos = idx % 5
+            others = [fv[k2] for k2 in ORDER if abs(fv[k2] - gold_val) > 1e-12]
+            opts_vals = others[:]
+            opts_vals.insert(gold_pos, gold_val)
+            opts_vals = opts_vals[:5]
+            if abs(opts_vals[gold_pos] - gold_val) > 1e-12:
+                opts_vals[gold_pos] = gold_val
+            assert len({round(v, 9) for v in opts_vals}) == 5, (key, neu, lym, mon, eos, opts_vals)
+            options = {LETTERS[i]: scalar(opts_vals[i]) for i in range(5)}
+            items.append({
+                "id": f"r39wbc-{idx + 1:02d}",
+                "qtype": "wbc_differential",
+                "stem": (
+                    f"A complete-blood-count differential reports absolute counts of {num(neu)} neutrophils, "
+                    f"{num(lym)} lymphocytes, {num(mon)} monocytes, and {num(eos)} eosinophils (all in cells/uL). "
+                    f"What is the {name_of[key]}?"
+                ),
+                "program": (
+                    f"observe neutrophils({num(neu)})\n"
+                    f"observe lymphocytes({num(lym)})\n"
+                    f"observe monocytes({num(mon)})\n"
+                    f"observe eosinophils({num(eos)})\n"
+                    f"let answer = {formula_of[key]}\n"
+                    "? answer\n"
+                ),
+                "answer_from": {"type": "compute_dimensioned", "name": "answer"},
+                "options": options,
+                "gold_letter": LETTERS[gold_pos],
+            })
+            idx += 1
+    return {
+        "description": (
+            "ADJ-LADDER rung 39 — CBC leukocyte differential totals from four stated absolute counts (a NEW panel: "
+            "hematology / complete-blood-count differential). From four stated counts (neutrophils, lymphocytes, "
+            "monocytes, eosinophils) compute the major sum (neutrophils+lymphocytes+monocytes), the "
+            "neutrophil+lymphocyte partial (neutrophils+lymphocytes), or the lymphocyte+monocyte partial "
+            "(lymphocytes+monocytes). Each item is a compute_dimensioned program (observe the four quantities, "
+            "let answer = formula); the ADJ engine carries the arithmetic — a NEW shape, a flat THREE-TERM SUM "
+            "(neutrophils+lymphocytes+monocytes), all addition (the nearest prior rung, 38, chained two "
+            "subtractions a-b-c; this is the first pure three-term addition) — and the harness matches the scalar "
+            "to the printed options. Contamination-safe: every index is built only from the four observed counts "
+            "via + — no constant leaks (a differential total is a pure sum), and no total ever appears as a literal "
+            "(each is computed from the observed counts) — and the observed quantities carry digit-free identifiers "
+            "so no numeral hides inside a variable name. The five options are a family over the same quantities, so "
+            "the distractors are exactly the slips students make: sweeping in the eosinophils too "
+            "(neutrophils+lymphocytes+monocytes+eosinophils, a four-term sum) and a wrong pair "
+            "(neutrophils+eosinophils, a major plus the odd minor). The core confusion tested is adding the three "
+            "MAJOR populations and no others."
+        ),
+        "items": items,
+    }
+
+
+if __name__ == "__main__":
+    doc = build()
+    with open("items.json", "w") as f:
+        json.dump(doc, f, indent=2)
+        f.write("\n")
+    print("wrote items.json:", len(doc["items"]), "items")
+    for it in doc["items"]:
+        print(it["id"], it["qtype"], "gold", it["gold_letter"],
+              "=", round(it["options"][it["gold_letter"]]["value"], 6))

--- a/code/specs/data/adj-ladder/rung39_wbc_differential/items.json
+++ b/code/specs/data/adj-ladder/rung39_wbc_differential/items.json
@@ -1,0 +1,698 @@
+{
+  "description": "ADJ-LADDER rung 39 \u2014 CBC leukocyte differential totals from four stated absolute counts (a NEW panel: hematology / complete-blood-count differential). From four stated counts (neutrophils, lymphocytes, monocytes, eosinophils) compute the major sum (neutrophils+lymphocytes+monocytes), the neutrophil+lymphocyte partial (neutrophils+lymphocytes), or the lymphocyte+monocyte partial (lymphocytes+monocytes). Each item is a compute_dimensioned program (observe the four quantities, let answer = formula); the ADJ engine carries the arithmetic \u2014 a NEW shape, a flat THREE-TERM SUM (neutrophils+lymphocytes+monocytes), all addition (the nearest prior rung, 38, chained two subtractions a-b-c; this is the first pure three-term addition) \u2014 and the harness matches the scalar to the printed options. Contamination-safe: every index is built only from the four observed counts via + \u2014 no constant leaks (a differential total is a pure sum), and no total ever appears as a literal (each is computed from the observed counts) \u2014 and the observed quantities carry digit-free identifiers so no numeral hides inside a variable name. The five options are a family over the same quantities, so the distractors are exactly the slips students make: sweeping in the eosinophils too (neutrophils+lymphocytes+monocytes+eosinophils, a four-term sum) and a wrong pair (neutrophils+eosinophils, a major plus the odd minor). The core confusion tested is adding the three MAJOR populations and no others.",
+  "items": [
+    {
+      "id": "r39wbc-01",
+      "qtype": "wbc_differential",
+      "stem": "A complete-blood-count differential reports absolute counts of 4000 neutrophils, 2000 lymphocytes, 500 monocytes, and 150 eosinophils (all in cells/uL). What is the combined count of the three major populations (neutrophils, lymphocytes, monocytes)?",
+      "program": "observe neutrophils(4000)\nobserve lymphocytes(2000)\nobserve monocytes(500)\nobserve eosinophils(150)\nlet answer = neutrophils + lymphocytes + monocytes\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 6500,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6000,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 2500,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 6650,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 4150,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r39wbc-02",
+      "qtype": "wbc_differential",
+      "stem": "A complete-blood-count differential reports absolute counts of 4000 neutrophils, 2000 lymphocytes, 500 monocytes, and 150 eosinophils (all in cells/uL). What is the combined count of neutrophils and lymphocytes only?",
+      "program": "observe neutrophils(4000)\nobserve lymphocytes(2000)\nobserve monocytes(500)\nobserve eosinophils(150)\nlet answer = neutrophils + lymphocytes\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 6500,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6000,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 2500,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 6650,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 4150,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r39wbc-03",
+      "qtype": "wbc_differential",
+      "stem": "A complete-blood-count differential reports absolute counts of 4000 neutrophils, 2000 lymphocytes, 500 monocytes, and 150 eosinophils (all in cells/uL). What is the combined count of lymphocytes and monocytes only?",
+      "program": "observe neutrophils(4000)\nobserve lymphocytes(2000)\nobserve monocytes(500)\nobserve eosinophils(150)\nlet answer = lymphocytes + monocytes\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 6500,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6000,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 2500,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 6650,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 4150,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r39wbc-04",
+      "qtype": "wbc_differential",
+      "stem": "A complete-blood-count differential reports absolute counts of 5500 neutrophils, 1500 lymphocytes, 700 monocytes, and 300 eosinophils (all in cells/uL). What is the combined count of the three major populations (neutrophils, lymphocytes, monocytes)?",
+      "program": "observe neutrophils(5500)\nobserve lymphocytes(1500)\nobserve monocytes(700)\nobserve eosinophils(300)\nlet answer = neutrophils + lymphocytes + monocytes\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 7000,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2200,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 8000,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 7700,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 5800,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r39wbc-05",
+      "qtype": "wbc_differential",
+      "stem": "A complete-blood-count differential reports absolute counts of 5500 neutrophils, 1500 lymphocytes, 700 monocytes, and 300 eosinophils (all in cells/uL). What is the combined count of neutrophils and lymphocytes only?",
+      "program": "observe neutrophils(5500)\nobserve lymphocytes(1500)\nobserve monocytes(700)\nobserve eosinophils(300)\nlet answer = neutrophils + lymphocytes\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 7700,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2200,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 8000,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 5800,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 7000,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r39wbc-06",
+      "qtype": "wbc_differential",
+      "stem": "A complete-blood-count differential reports absolute counts of 5500 neutrophils, 1500 lymphocytes, 700 monocytes, and 300 eosinophils (all in cells/uL). What is the combined count of lymphocytes and monocytes only?",
+      "program": "observe neutrophils(5500)\nobserve lymphocytes(1500)\nobserve monocytes(700)\nobserve eosinophils(300)\nlet answer = lymphocytes + monocytes\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 2200,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 7700,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 7000,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 8000,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 5800,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r39wbc-07",
+      "qtype": "wbc_differential",
+      "stem": "A complete-blood-count differential reports absolute counts of 3200 neutrophils, 2800 lymphocytes, 400 monocytes, and 250 eosinophils (all in cells/uL). What is the combined count of the three major populations (neutrophils, lymphocytes, monocytes)?",
+      "program": "observe neutrophils(3200)\nobserve lymphocytes(2800)\nobserve monocytes(400)\nobserve eosinophils(250)\nlet answer = neutrophils + lymphocytes + monocytes\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 6000,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6400,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 3200,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 6650,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 3450,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r39wbc-08",
+      "qtype": "wbc_differential",
+      "stem": "A complete-blood-count differential reports absolute counts of 3200 neutrophils, 2800 lymphocytes, 400 monocytes, and 250 eosinophils (all in cells/uL). What is the combined count of neutrophils and lymphocytes only?",
+      "program": "observe neutrophils(3200)\nobserve lymphocytes(2800)\nobserve monocytes(400)\nobserve eosinophils(250)\nlet answer = neutrophils + lymphocytes\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 6400,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 3200,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 6000,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 6650,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 3450,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r39wbc-09",
+      "qtype": "wbc_differential",
+      "stem": "A complete-blood-count differential reports absolute counts of 3200 neutrophils, 2800 lymphocytes, 400 monocytes, and 250 eosinophils (all in cells/uL). What is the combined count of lymphocytes and monocytes only?",
+      "program": "observe neutrophils(3200)\nobserve lymphocytes(2800)\nobserve monocytes(400)\nobserve eosinophils(250)\nlet answer = lymphocytes + monocytes\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 6400,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6000,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 6650,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 3200,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 3450,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r39wbc-10",
+      "qtype": "wbc_differential",
+      "stem": "A complete-blood-count differential reports absolute counts of 6000 neutrophils, 1200 lymphocytes, 300 monocytes, and 450 eosinophils (all in cells/uL). What is the combined count of the three major populations (neutrophils, lymphocytes, monocytes)?",
+      "program": "observe neutrophils(6000)\nobserve lymphocytes(1200)\nobserve monocytes(300)\nobserve eosinophils(450)\nlet answer = neutrophils + lymphocytes + monocytes\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 7200,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 1500,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 7950,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 6450,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 7500,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r39wbc-11",
+      "qtype": "wbc_differential",
+      "stem": "A complete-blood-count differential reports absolute counts of 6000 neutrophils, 1200 lymphocytes, 300 monocytes, and 450 eosinophils (all in cells/uL). What is the combined count of neutrophils and lymphocytes only?",
+      "program": "observe neutrophils(6000)\nobserve lymphocytes(1200)\nobserve monocytes(300)\nobserve eosinophils(450)\nlet answer = neutrophils + lymphocytes\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 7200,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 7500,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 1500,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 7950,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 6450,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r39wbc-12",
+      "qtype": "wbc_differential",
+      "stem": "A complete-blood-count differential reports absolute counts of 6000 neutrophils, 1200 lymphocytes, 300 monocytes, and 450 eosinophils (all in cells/uL). What is the combined count of lymphocytes and monocytes only?",
+      "program": "observe neutrophils(6000)\nobserve lymphocytes(1200)\nobserve monocytes(300)\nobserve eosinophils(450)\nlet answer = lymphocytes + monocytes\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 7500,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 1500,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 7200,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 7950,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 6450,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r39wbc-13",
+      "qtype": "wbc_differential",
+      "stem": "A complete-blood-count differential reports absolute counts of 4800 neutrophils, 2400 lymphocytes, 600 monocytes, and 100 eosinophils (all in cells/uL). What is the combined count of the three major populations (neutrophils, lymphocytes, monocytes)?",
+      "program": "observe neutrophils(4800)\nobserve lymphocytes(2400)\nobserve monocytes(600)\nobserve eosinophils(100)\nlet answer = neutrophils + lymphocytes + monocytes\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 7200,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 3000,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 7800,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 7900,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 4900,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r39wbc-14",
+      "qtype": "wbc_differential",
+      "stem": "A complete-blood-count differential reports absolute counts of 4800 neutrophils, 2400 lymphocytes, 600 monocytes, and 100 eosinophils (all in cells/uL). What is the combined count of neutrophils and lymphocytes only?",
+      "program": "observe neutrophils(4800)\nobserve lymphocytes(2400)\nobserve monocytes(600)\nobserve eosinophils(100)\nlet answer = neutrophils + lymphocytes\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 7800,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 3000,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 7900,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 7200,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 4900,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r39wbc-15",
+      "qtype": "wbc_differential",
+      "stem": "A complete-blood-count differential reports absolute counts of 4800 neutrophils, 2400 lymphocytes, 600 monocytes, and 100 eosinophils (all in cells/uL). What is the combined count of lymphocytes and monocytes only?",
+      "program": "observe neutrophils(4800)\nobserve lymphocytes(2400)\nobserve monocytes(600)\nobserve eosinophils(100)\nlet answer = lymphocytes + monocytes\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 7800,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 7200,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 7900,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 4900,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 3000,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r39wbc-16",
+      "qtype": "wbc_differential",
+      "stem": "A complete-blood-count differential reports absolute counts of 3600 neutrophils, 2600 lymphocytes, 900 monocytes, and 150 eosinophils (all in cells/uL). What is the combined count of the three major populations (neutrophils, lymphocytes, monocytes)?",
+      "program": "observe neutrophils(3600)\nobserve lymphocytes(2600)\nobserve monocytes(900)\nobserve eosinophils(150)\nlet answer = neutrophils + lymphocytes + monocytes\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 7100,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6200,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 3500,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 7250,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 3750,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r39wbc-17",
+      "qtype": "wbc_differential",
+      "stem": "A complete-blood-count differential reports absolute counts of 3600 neutrophils, 2600 lymphocytes, 900 monocytes, and 150 eosinophils (all in cells/uL). What is the combined count of neutrophils and lymphocytes only?",
+      "program": "observe neutrophils(3600)\nobserve lymphocytes(2600)\nobserve monocytes(900)\nobserve eosinophils(150)\nlet answer = neutrophils + lymphocytes\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 7100,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6200,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 3500,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 7250,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 3750,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r39wbc-18",
+      "qtype": "wbc_differential",
+      "stem": "A complete-blood-count differential reports absolute counts of 3600 neutrophils, 2600 lymphocytes, 900 monocytes, and 150 eosinophils (all in cells/uL). What is the combined count of lymphocytes and monocytes only?",
+      "program": "observe neutrophils(3600)\nobserve lymphocytes(2600)\nobserve monocytes(900)\nobserve eosinophils(150)\nlet answer = lymphocytes + monocytes\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 7100,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6200,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 3500,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 7250,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 3750,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r39wbc-19",
+      "qtype": "wbc_differential",
+      "stem": "A complete-blood-count differential reports absolute counts of 5000 neutrophils, 1000 lymphocytes, 450 monocytes, and 350 eosinophils (all in cells/uL). What is the combined count of the three major populations (neutrophils, lymphocytes, monocytes)?",
+      "program": "observe neutrophils(5000)\nobserve lymphocytes(1000)\nobserve monocytes(450)\nobserve eosinophils(350)\nlet answer = neutrophils + lymphocytes + monocytes\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 6000,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 1450,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 6800,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 6450,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 5350,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r39wbc-20",
+      "qtype": "wbc_differential",
+      "stem": "A complete-blood-count differential reports absolute counts of 5000 neutrophils, 1000 lymphocytes, 450 monocytes, and 350 eosinophils (all in cells/uL). What is the combined count of neutrophils and lymphocytes only?",
+      "program": "observe neutrophils(5000)\nobserve lymphocytes(1000)\nobserve monocytes(450)\nobserve eosinophils(350)\nlet answer = neutrophils + lymphocytes\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 6450,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 1450,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 6800,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 5350,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 6000,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r39wbc-21",
+      "qtype": "wbc_differential",
+      "stem": "A complete-blood-count differential reports absolute counts of 5000 neutrophils, 1000 lymphocytes, 450 monocytes, and 350 eosinophils (all in cells/uL). What is the combined count of lymphocytes and monocytes only?",
+      "program": "observe neutrophils(5000)\nobserve lymphocytes(1000)\nobserve monocytes(450)\nobserve eosinophils(350)\nlet answer = lymphocytes + monocytes\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 1450,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6450,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 6000,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 6800,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 5350,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    }
+  ]
+}

--- a/code/specs/data/adj-ladder/test_ladder_eval.py
+++ b/code/specs/data/adj-ladder/test_ladder_eval.py
@@ -76,6 +76,7 @@ SELF_CONTAINED_RUNGS = (
     "rung36_transfusion_pooling",
     "rung37_csf_serum_ratio",
     "rung38_serum_anion_gap",
+    "rung39_wbc_differential",
 )
 
 


### PR DESCRIPTION
## Summary

Adds ADJ-LADDER **rung 39 — the CBC leukocyte differential total**, cycling to a genuinely NEW arithmetic shape: a flat **three-term sum** `neutrophils + lymphocytes + monocytes` — all addition.

The nearest prior rung (38, serum anion gap) chained two *subtractions* across three terms (`a − b − c`); every other prior rung composed exactly two sub-expressions (rung-36 weighted-average, rung-37 ratio-of-two-sums). This is the **first pure three-term addition** on the ladder.

**New panel:** hematology / complete-blood-count differential (summing absolute leukocyte counts).

## The family (5 mutually-confusable options over the same 4 observed counts)

| option | formula | role |
|---|---|---|
| major sum | `neutrophils + lymphocytes + monocytes` | **the three major populations summed** |
| neu + lym | `neutrophils + lymphocytes` | the two largest (partial) |
| lym + mon | `lymphocytes + monocytes` | the two non-neutrophil majors (partial) |
| all four *(distractor)* | `neutrophils + lymphocytes + monocytes + eosinophils` | eosinophils swept in too (four-term sum) |
| neu + eos *(distractor)* | `neutrophils + eosinophils` | a wrong pair (major + odd minor) |

First three are queried as gold (gold rotates A–E); all five always appear as options. The distractors are exactly the slips a student makes.

## Contamination-safe by construction
- Every formula is built **only** from the four observed counts via `+` — no numeric literal in any program.
- Digit-free identifiers (`neutrophils`, `lymphocytes`, `monocytes`, `eosinophils`).
- No total ever appears as a literal (always computed from the observed counts).

## Mechanics
- 7 tables × 3 queried = **21 items**; each is a `compute_dimensioned` program (`observe` the four quantities, `let answer = formula`, `? answer`).
- Runs on the existing engine + harness with **no engine/harness change** — exactly as rungs 8/16/…/37/38.
- Pairwise-distinctness of all five family values (with margin) asserted at build time.

## Verification
- Registered in `SELF_CONTAINED_RUNGS`; the rung-39 gate passes **3/3** (every gold selected — 0 wrong / 0 abstain; contamination clean; items.json valid).
- Security-reviewed (inline): pure offline data generator, no external input, no deserialization, fixed local write path — PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
