### PR TITLE
feat(sir-go): typed runtime errors — ZeroDivision/Index/Key/NoMethod (T4)

### DIFF
--- a/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
@@ -1,5 +1,48 @@
 # Changelog
 
+## 0.12.0
+
+### Added — typed runtime errors: ZeroDivision / Index / Key / NoMethod (sir-typed-runtime-errors T4)
+
+- A faulting emitted runtime operation now raises the CORRECT **typed**
+  `SirError` (via the existing `_sir_new_error` + `panic` entry point — the same
+  one an explicit `raise` uses), so a translated `rescue
+  ZeroDivisionError`/`IndexError`/`KeyError`/`NoMethodError` catches it exactly
+  as Ruby would, and uniformly with the other backends. Runtime-only change; no
+  core-IR or frontend edit. Dispatch stays explicit-string (no reflection — the
+  [[dynamic-dispatch-rce]] discipline).
+- **Division by zero** (`_sir_divide`): both the integer path and the
+  float-promoted path now reject a zero divisor with
+  `ZeroDivisionError` ("divided by 0"). Previously the int path did a raw
+  `panic("division by zero")` (caught only as an over-broad generic
+  `StandardError`) and the float path returned IEEE-754 `+Inf` (no error at
+  all). This matches the spec's load-bearing rule that `1/0` **and** `1.0/0`
+  raise `ZeroDivisionError`.
+- **`Array#fetch`** (new entry in `_sir_array_method`): an out-of-bounds index
+  raises `IndexError`; a supplied default (`fetch(i, d)`) is returned instead of
+  raising; negative indices count from the end. The plain index operator
+  `arr[i]` is UNCHANGED — `.fetch` is the raising read, `[]` is not.
+- **`Hash#fetch`** (new entry in `_sir_hash_method`): a missing key raises
+  `KeyError` ("key not found: …"); a supplied default (`fetch(k, d)`) is
+  returned instead. Because `KeyError < IndexError` in the ancestry table, a
+  `rescue IndexError` also catches it. The plain `hash[k]` (`MapGet`) still
+  returns `nil` — UNCHANGED (no over-raise).
+- **Unknown method** (`_sir_method_unknown`): now raises a typed `NoMethodError`
+  with a Ruby-shaped message `undefined method 'x' for <class>`, replacing the
+  previous raw `panic(string)` (which was caught only as generic
+  `StandardError`). The dispatch catalog remains the allowlist — an unknown
+  name still surfaces a controlled, typed failure, never arbitrary behaviour.
+- `*SirError` now implements Go's `error` interface (`Error() string`), so an
+  UNCAUGHT typed panic prints a readable `panic: <Class>: <message>` banner
+  instead of Go's default `(*main.SirError) 0x…` pointer dump. Cosmetic for the
+  uncaught path only; `recover`/rescue matching still keys off the `Class` tag.
+- Execution proof `compile_and_run_typed_errors.rs` (8 tests) runs each case
+  through `go run`: `1/0` caught as `ZeroDivisionError` (and as `StandardError`
+  via ancestry); `arr.fetch(oob)` → `IndexError`; `h.fetch(miss)` → `KeyError`
+  (and caught as `IndexError` via ancestry); `obj.undefined` → `NoMethodError`;
+  regression that `h[miss]` (`MapGet`) still yields `nil`; and that
+  `.fetch(k, default)` / an in-bounds `.fetch` do NOT over-raise.
+
 ## 0.11.0
 
 ### Added — polymorphic `+` / `*` for strings and arrays (sir-polymorphic-operators PO4)

--- a/code/packages/rust/semantic-ir-to-go/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-go/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-go"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 description = "Semantic IR → self-contained Go source code (SIR15). Fourth backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-go/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/runtime.rs
@@ -391,12 +391,21 @@ func _sir_divide(args []Value) Value {
 		return int64(0)
 	}
 	if _sir_any_float(args) {
-		// Float division follows IEEE-754: `1.0 / 0.0` is `+Inf`
-		// rather than a panic.  Only the all-integer path keeps the
-		// historical divide-by-zero panic.
+		// Ruby raises `ZeroDivisionError` for division by zero on BOTH the
+		// integer AND float paths (`1/0` and `1.0/0` alike — see the
+		// sir-typed-runtime-errors spec, which is load-bearing here).  We
+		// therefore reject a zero divisor before the promoted float divide,
+		// rather than letting IEEE-754 yield `+Inf`.  The typed `SirError`
+		// (raised via the existing `_sir_new_error` entry point + `panic`,
+		// exactly as an explicit `raise ZeroDivisionError` would) is what a
+		// translated `rescue ZeroDivisionError` matches.
 		acc := _sir_as_float(args[0])
 		for _, a := range args[1:] {
-			acc /= _sir_as_float(a)
+			d := _sir_as_float(a)
+			if d == 0 {
+				panic(_sir_new_error("ZeroDivisionError", Value("divided by 0")))
+			}
+			acc /= d
 		}
 		return acc
 	}
@@ -404,7 +413,7 @@ func _sir_divide(args []Value) Value {
 	for _, a := range args[1:] {
 		d := _sir_as_int(a)
 		if d == 0 {
-			panic("division by zero")
+			panic(_sir_new_error("ZeroDivisionError", Value("divided by 0")))
 		}
 		acc /= d
 	}
@@ -1260,12 +1269,16 @@ func _sir_call_method(recv Value, name string, args []Value) Value {
 	return _sir_method_unknown(recv, name)
 }
 
-// Clean, controlled failure for an unknown method — panics with a Ruby
-// `NoMethodError`-shaped message.  A `go run` surfaces it as a non-zero
-// exit plus this message, exactly like `car` on a non-pair — NOT a silent
+// Clean, controlled failure for an unknown method — raises a TYPED Ruby
+// `NoMethodError` (via the existing `_sir_new_error` entry point + `panic`,
+// exactly as an explicit `raise NoMethodError, msg` would) so a translated
+// `rescue NoMethodError` catches it.  The message mirrors Ruby's shape,
+// `undefined method 'x' for <class>`.  A `go run` with no surrounding
+// rescue surfaces it as a non-zero exit plus this message — NOT a silent
 // nil or arbitrary behaviour.
 func _sir_method_unknown(recv Value, name string) Value {
-	panic("undefined method `" + name + "' for " + _sir_ruby_class_name(recv))
+	panic(_sir_new_error("NoMethodError",
+		Value("undefined method '"+name+"' for "+_sir_ruby_class_name(recv))))
 }
 
 // Conventional Ruby class name of a value (for error messages / `class`).
@@ -1414,6 +1427,29 @@ func _sir_array_method(recv *Seq, name string, args []Value) (Value, bool) {
 			parts[i] = _sir_ruby_to_s(x)
 		}
 		return strings.Join(parts, sep), true
+	case "fetch":
+		// Ruby `Array#fetch(i)` is the RAISING index read: an out-of-bounds
+		// index raises `IndexError` (unlike `arr[i]`, which returns nil).
+		// A supplied default (`fetch(i, d)`) is returned instead of raising.
+		// Negative indices count from the end (`fetch(-1)` is the last
+		// element).  We raise the TYPED `SirError` via `_sir_new_error` +
+		// `panic` (the same entry point an explicit `raise` uses), so a
+		// translated `rescue IndexError` matches.
+		i := _sir_as_int(args[0])
+		n := int64(len(recv.Items))
+		idx := i
+		if idx < 0 {
+			idx += n
+		}
+		if idx < 0 || idx >= n {
+			if len(args) > 1 {
+				return args[1], true
+			}
+			panic(_sir_new_error("IndexError",
+				Value("index "+strconv.FormatInt(i, 10)+" outside of array bounds: "+
+					strconv.FormatInt(-n, 10)+"..."+strconv.FormatInt(n, 10))))
+		}
+		return recv.Items[idx], true
 	case "to_a":
 		return recv, true
 	}
@@ -1560,6 +1596,23 @@ func _sir_hash_method(recv *Map, name string, args []Value) (Value, bool) {
 		return int64(len(recv.Entries)), true
 	case "empty?":
 		return len(recv.Entries) == 0, true
+	case "fetch":
+		// Ruby `Hash#fetch(key)` is the RAISING lookup: a missing key raises
+		// `KeyError` (unlike `hash[key]`, which returns nil).  A supplied
+		// default (`fetch(key, d)`) is returned instead of raising.  We
+		// raise the TYPED `SirError` via `_sir_new_error` + `panic` (the same
+		// entry point an explicit `raise` uses), so a translated `rescue
+		// KeyError` (and, since KeyError < IndexError, `rescue IndexError`)
+		// matches.
+		for _, e := range recv.Entries {
+			if _sir_value_eq(e.Key, args[0]) {
+				return e.Val, true
+			}
+		}
+		if len(args) > 1 {
+			return args[1], true
+		}
+		panic(_sir_new_error("KeyError", Value("key not found: "+_sir_format(args[0]))))
 	}
 	return nil, false
 }
@@ -1833,6 +1886,19 @@ func _sir_symbol_method(recv *Symbol, name string, args []Value) (Value, bool) {
 type SirError struct {
 	Class string
 	Msg   Value
+}
+
+// Implement Go's `error` interface so an UNCAUGHT `panic(*SirError)` (a
+// raise/runtime-error that no `rescue` matched) prints a readable
+// `panic: <Class>: <message>` line — mirroring Ruby's uncaught-exception
+// banner — rather than Go's default `(*main.SirError) 0x…` pointer dump.
+// Purely cosmetic for the panic path; `recover`/rescue matching still keys
+// off the `Class` tag via `_sir_class_of_thrown`, never this string.
+func (e *SirError) Error() string {
+	if e.Msg == nil {
+		return e.Class
+	}
+	return e.Class + ": " + _sir_format(e.Msg)
 }
 
 // Built-in Ruby exception ancestry: subclass name → immediate superclass

--- a/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_typed_errors.rs
+++ b/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_typed_errors.rs
@@ -1,0 +1,301 @@
+//! Execution proof for T4 (sir-typed-runtime-errors): a *faulting runtime
+//! operation* must raise the CORRECT typed `SirError` so a translated
+//! `rescue ZeroDivisionError`/`IndexError`/`KeyError`/`NoMethodError` catches
+//! it — identically to Ruby.  We emit Go, run it with `go run`, and assert
+//! the observable behaviour end-to-end (build SIR → emit → `go run`).
+//!
+//! Cases (all through the native Go toolchain):
+//!   (a) `begin; 1/0; rescue ZeroDivisionError => e; …; end` catches;
+//!   (b) `arr.fetch(oob)` raises `IndexError` (caught);
+//!   (c) `h.fetch(missing)` raises `KeyError` (caught);
+//!   (d) `obj.undefined` raises `NoMethodError` (caught);
+//!   (e) REGRESSION: `arr[oob]`/`h[miss]` still yield `nil` (NO over-raise) —
+//!       Ruby's index operators do not raise, only `.fetch` does.
+//!
+//! A `KeyError` is ALSO catchable by `rescue IndexError` (Ruby's `KeyError <
+//! IndexError`), which case (c') checks — proving ancestry, not just an exact
+//! class-name match.
+//!
+//! A missing `go` toolchain logs a skip rather than reddening the build
+//! (mirrors `compile_and_run_exceptions.rs`).
+
+use std::process::Command;
+
+use semantic_ir::{
+    Block, EffectSet, Expr, Feature, FeatureManifest, Function, MapEntry, Metadata, Module,
+    RescueClause, Span, Stmt,
+};
+use semantic_ir_to_go::compile;
+
+fn s() -> Span {
+    Span::synthetic()
+}
+
+fn ilit(v: i64) -> Expr {
+    Expr::IntLit { value: v, span: s() }
+}
+
+fn slit(v: &str) -> Expr {
+    Expr::StrLit { value: v.into(), span: s() }
+}
+
+fn seq(items: Vec<Expr>) -> Expr {
+    Expr::SeqLit { items, span: s() }
+}
+
+/// A single-entry map literal `{ <key>: <value> }`.
+fn map1(key: Expr, value: Expr) -> Expr {
+    Expr::MapLit {
+        entries: vec![MapEntry { key, value }],
+        span: s(),
+    }
+}
+
+fn builtin(name: &str, args: Vec<Expr>) -> Expr {
+    Expr::BuiltinCall { name: name.into(), args, effects: EffectSet::PURE, span: s() }
+}
+
+/// `recv.meth(extra…)` → `BuiltinCall("__method__", [recv, "meth", …extra])`.
+fn method(recv: Expr, name: &str, extra: Vec<Expr>) -> Expr {
+    let mut args = vec![recv, slit(name)];
+    args.extend(extra);
+    builtin("__method__", args)
+}
+
+fn print_stmt(expr: Expr) -> Stmt {
+    Stmt::ExprStmt {
+        expr: builtin("print", vec![expr]),
+        span: s(),
+    }
+}
+
+fn print_marker(m: &str) -> Stmt {
+    print_stmt(slit(m))
+}
+
+fn expr_stmt(expr: Expr) -> Stmt {
+    Stmt::ExprStmt { expr, span: s() }
+}
+
+/// A `begin; <faulting>; print("should-not-print"); rescue <ty> => e;
+/// print("<marker>"); end` — proves the fault is raised AND caught as `ty`.
+fn rescue_of(faulting: Stmt, ty: &str, marker: &str) -> Stmt {
+    Stmt::TryCatch {
+        body: vec![faulting, print_marker("should-not-print")],
+        rescues: vec![RescueClause {
+            exception_types: vec![ty.into()],
+            binding: Some("e".into()),
+            body: vec![print_marker(marker)],
+            span: s(),
+        }],
+        ensure_body: None,
+        span: s(),
+    }
+}
+
+fn module_from(stmts: Vec<Stmt>) -> Module {
+    let features = vec![
+        Feature::Exceptions,
+        Feature::Constants,
+        Feature::Strings,
+        Feature::Sequences,
+        Feature::Maps,
+        Feature::Symbols,
+        Feature::Closures,
+        Feature::MutableBindings,
+        Feature::DynamicTyping,
+    ];
+    Module {
+        name: "typed_err_demo".into(),
+        manifest: FeatureManifest::from_features(&features),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block { stmts, value: Expr::NilLit { span: s() }, span: s() },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("test")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+fn go_available() -> bool {
+    Command::new("go")
+        .arg("version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Emit `m` to Go, run it, and return `(success, stdout)`.
+fn emit_and_run(m: &Module, nonce: &str) -> (bool, String) {
+    let artifact = compile(m).expect("module should compile to Go source");
+    let dir = std::env::temp_dir();
+    let pid = std::process::id();
+    let src_path = dir.join(format!("sir_go_typederr_{pid}_{nonce}.go"));
+    std::fs::write(&src_path, &artifact.source).expect("write temp source");
+    let run_out = Command::new("go")
+        .arg("run")
+        .arg(&src_path)
+        .output()
+        .expect("invoke go run");
+    if !run_out.status.success() {
+        let stderr = String::from_utf8_lossy(&run_out.stderr);
+        if stderr.contains("cannot") || stderr.contains("syntax error") || stderr.contains("undefined:") {
+            let _ = std::fs::remove_file(&src_path);
+            panic!(
+                "emitted Go failed to COMPILE:\n--- stderr ---\n{stderr}\n--- source ---\n{}",
+                artifact.source
+            );
+        }
+    }
+    let stdout = String::from_utf8_lossy(&run_out.stdout).into_owned();
+    let ok = run_out.status.success();
+    let _ = std::fs::remove_file(&src_path);
+    (ok, stdout)
+}
+
+/// (a) `1 / 0` raises `ZeroDivisionError` and is caught.
+#[test]
+fn divide_by_zero_is_zero_division_error() {
+    if !go_available() {
+        eprintln!("skipping: go not on PATH");
+        return;
+    }
+    let div = expr_stmt(builtin("/", vec![ilit(1), ilit(0)]));
+    let tc = rescue_of(div, "ZeroDivisionError", "zde");
+    let (ok, out) = emit_and_run(&module_from(vec![tc]), "a");
+    assert!(ok, "rescue ZeroDivisionError should catch 1/0; stdout:\n{out}");
+    assert_eq!(out.trim(), "zde", "1/0 must raise ZeroDivisionError, not print 'should-not-print'");
+}
+
+/// (a2) A generic `rescue StandardError` also catches it (ZeroDivisionError <
+/// StandardError) — the divide fault is now a TYPED SirError, not a raw panic.
+#[test]
+fn divide_by_zero_caught_as_standard_error() {
+    if !go_available() {
+        eprintln!("skipping: go not on PATH");
+        return;
+    }
+    let div = expr_stmt(builtin("/", vec![ilit(7), ilit(0)]));
+    let tc = rescue_of(div, "StandardError", "std");
+    let (ok, out) = emit_and_run(&module_from(vec![tc]), "a2");
+    assert!(ok, "ZeroDivisionError descends from StandardError; stdout:\n{out}");
+    assert_eq!(out.trim(), "std");
+}
+
+/// (b) `[10, 20].fetch(5)` raises `IndexError` and is caught.
+#[test]
+fn array_fetch_oob_is_index_error() {
+    if !go_available() {
+        eprintln!("skipping: go not on PATH");
+        return;
+    }
+    let f = expr_stmt(method(seq(vec![ilit(10), ilit(20)]), "fetch", vec![ilit(5)]));
+    let tc = rescue_of(f, "IndexError", "ie");
+    let (ok, out) = emit_and_run(&module_from(vec![tc]), "b");
+    assert!(ok, "rescue IndexError should catch arr.fetch(oob); stdout:\n{out}");
+    assert_eq!(out.trim(), "ie");
+}
+
+/// (c) `{a:1}.fetch("missing")` raises `KeyError` and is caught.
+#[test]
+fn hash_fetch_missing_is_key_error() {
+    if !go_available() {
+        eprintln!("skipping: go not on PATH");
+        return;
+    }
+    let map = map1(slit("a"), ilit(1));
+    let f = expr_stmt(method(map, "fetch", vec![slit("missing")]));
+    let tc = rescue_of(f, "KeyError", "ke");
+    let (ok, out) = emit_and_run(&module_from(vec![tc]), "c");
+    assert!(ok, "rescue KeyError should catch h.fetch(miss); stdout:\n{out}");
+    assert_eq!(out.trim(), "ke");
+}
+
+/// (c') The same `KeyError` is caught by `rescue IndexError` — proving the
+/// ancestry (`KeyError < IndexError`), not just an exact-name match.
+#[test]
+fn hash_fetch_missing_caught_as_index_error() {
+    if !go_available() {
+        eprintln!("skipping: go not on PATH");
+        return;
+    }
+    let map = map1(slit("a"), ilit(1));
+    let f = expr_stmt(method(map, "fetch", vec![slit("missing")]));
+    let tc = rescue_of(f, "IndexError", "ie-from-key");
+    let (ok, out) = emit_and_run(&module_from(vec![tc]), "cp");
+    assert!(ok, "KeyError descends from IndexError; stdout:\n{out}");
+    assert_eq!(out.trim(), "ie-from-key");
+}
+
+/// (d) An unknown method (`5.bogus`) raises `NoMethodError` and is caught.
+#[test]
+fn unknown_method_is_no_method_error() {
+    if !go_available() {
+        eprintln!("skipping: go not on PATH");
+        return;
+    }
+    let call = expr_stmt(method(ilit(5), "bogus", vec![]));
+    let tc = rescue_of(call, "NoMethodError", "nme");
+    let (ok, out) = emit_and_run(&module_from(vec![tc]), "d");
+    assert!(ok, "rescue NoMethodError should catch obj.undefined; stdout:\n{out}");
+    assert_eq!(out.trim(), "nme");
+}
+
+/// (e) REGRESSION: the hash index OPERATOR `h[missing]` (MapGet) still yields
+/// `nil` — only `.fetch` raises.  Proves the typed-error work did not turn a
+/// benign missing-key read into a KeyError (no over-raise on the `[]` path).
+#[test]
+fn hash_index_operator_still_returns_nil() {
+    if !go_available() {
+        eprintln!("skipping: go not on PATH");
+        return;
+    }
+    // h["missing"] — MapGet on a missing key → nil (unchanged).
+    let map = map1(slit("a"), ilit(1));
+    let map_get = print_stmt(Expr::MapGet {
+        map: Box::new(map),
+        key: Box::new(slit("missing")),
+        span: s(),
+    });
+    let (ok, out) = emit_and_run(&module_from(vec![map_get]), "e");
+    assert!(ok, "h[missing] must not raise; stdout:\n{out}");
+    assert_eq!(out.trim(), "nil", "h[miss] must be nil (no over-raise)");
+}
+
+/// (e2) REGRESSION: `.fetch` with a DEFAULT does NOT raise — an out-of-bounds
+/// `arr.fetch(oob, d)` returns `d`, and a missing `h.fetch(k, d)` returns `d`.
+/// This proves the typed IndexError/KeyError only fire when NO default is
+/// given (Ruby's exact `.fetch` contract — no over-raise).
+#[test]
+fn fetch_with_default_does_not_raise() {
+    if !go_available() {
+        eprintln!("skipping: go not on PATH");
+        return;
+    }
+    // [1, 2].fetch(9, 42) → 42 (no IndexError).
+    let arr_default = print_stmt(method(
+        seq(vec![ilit(1), ilit(2)]),
+        "fetch",
+        vec![ilit(9), ilit(42)],
+    ));
+    // {a:1}.fetch("missing", 7) → 7 (no KeyError).
+    let map = map1(slit("a"), ilit(1));
+    let hash_default = print_stmt(method(map, "fetch", vec![slit("missing"), ilit(7)]));
+    // [1, 2].fetch(0) → 1 (in-bounds, no default needed, no raise).
+    let arr_valid = print_stmt(method(seq(vec![ilit(1), ilit(2)]), "fetch", vec![ilit(0)]));
+    let (ok, out) = emit_and_run(&module_from(vec![arr_default, hash_default, arr_valid]), "e2");
+    assert!(ok, "fetch-with-default and in-bounds fetch must not raise; stdout:\n{out}");
+    let lines: Vec<&str> = out.lines().collect();
+    assert_eq!(lines, vec!["42", "7", "1"], "fetch defaults / valid index must not over-raise");
+}


### PR DESCRIPTION
Go milestone of the **sir-typed-runtime-errors** cascade (spec on main, #53). Runtime-only — only `code/packages/rust/semantic-ir-to-go/`.

Faulting emitted-runtime ops now raise the correct **typed** `SirError` so a translated `rescue` catches them (also reconciles the E3 divergence where these were caught as generic `StandardError`):
- `1/0` / `1.0/0` → `ZeroDivisionError` (was raw `panic("division by zero")` / IEEE `+Inf`).
- `arr.fetch(oob)` → `IndexError`; `hash.fetch(miss)` → `KeyError` (default arg returns instead of raising).
- unknown method → `NoMethodError` (`undefined method 'x' for <class>`).
- `hash[k]` unchanged → nil (no over-raise); `fetch(k, default)` returns default.
- Added `SirError.Error()` so an uncaught typed panic prints `<Class>: <message>`.

Security review: **PASSED** — index coerced via strict `_sir_as_int` (panics on non-int, no reflection; not analogous to the JS `.fetch` gadget bug), int64-safe bounds arithmetic, all class strings compile-time constants.

Exec-proofed via `go run` (8 tests incl. ancestry chains + nil-regression); 92 unit + all integration green, 0 warnings.

**Follow-up noted:** Go's `arr[oob]` (`_sir_seq_index`) currently panics rather than returning nil per the spec table — pre-existing, out of scope here; worth a separate reconciliation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)