### PR TITLE
feat(sir-runtime-core/oop): typed runtime errors — ZeroDivision/Index/Key/NoMethod (T1)

### DIFF
--- a/code/packages/python/sir-runtime-core/BUILD
+++ b/code/packages/python/sir-runtime-core/BUILD
@@ -1,5 +1,6 @@
 uv venv --quiet --clear
 uv pip install -e ../sir-runtime-pairs --quiet
+uv pip install -e ../sir-runtime-exceptions --quiet
 uv pip install -e .[dev] --quiet
 .venv/bin/python -m ruff check src tests
 .venv/bin/python -m mypy

--- a/code/packages/python/sir-runtime-core/CHANGELOG.md
+++ b/code/packages/python/sir-runtime-core/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to `coding-adventures-sir-runtime-core` are documented here.
 
+## [0.1.8] - 2026-07-01
+
+### Added — typed division-by-zero (T1 of sir-typed-runtime-errors)
+
+Ruby's `1 / 0` (and, per the SIR error spec, `1.0 / 0`) raises
+`ZeroDivisionError`. Python's native `/` also raises on a zero divisor, but as a
+**native** `ZeroDivisionError` — which the SIR rescue matcher only sees as an
+over-broad `StandardError`, so a Ruby `rescue ZeroDivisionError` would miss it.
+See
+[`code/specs/sir-typed-runtime-errors.md`](../../../specs/sir-typed-runtime-errors.md).
+
+- **`div`** now catches the native `ZeroDivisionError` and re-raises it as a
+  **typed** `SirError` (`sir_class == "ZeroDivisionError"`, message
+  `"divided by 0"`) via the shared `raise_error` entry point from
+  `coding-adventures-sir-runtime-exceptions`. So `begin; 1 / 0; rescue
+  ZeroDivisionError => e; end` now catches it, and `rescue StandardError` / a bare
+  `rescue` still catch it via the ancestry walk. Applies per fold-step, so a
+  variadic `div(a, b, 0)` reports the zero divisor it actually hit.
+- No reflection or `eval`: the typed raise is an explicit class-name string,
+  identical in shape to the `raise ZeroDivisionError` the frontend already emits.
+
+### Dependency
+
+- Added `coding-adventures-sir-runtime-exceptions` (a leaf package, no cycle) so
+  `div` can reach the typed-raise entry point.
+
 ## [0.1.7] - 2026-07-01
 
 ### Added — polymorphic `+` / `*` for strings and arrays (PO1 of sir-polymorphic-operators)

--- a/code/packages/python/sir-runtime-core/README.md
+++ b/code/packages/python/sir-runtime-core/README.md
@@ -17,7 +17,7 @@ prelude into every file:
 | `Pair` / `cons` / `car` / `cdr` | Lisp cons cells; no native type. |
 | `eq`, `to_display`, `print` | Symbol-aware equality and Lisp/Ruby display (`nil`, `#t`/`#f`). |
 | `sir_puts` (`puts`) | Ruby `puts`: per-arg line, arrays flattened element-per-line, no double trailing newline, no-arg → one newline. |
-| `add`/`sub`/`mul`/`div`, `lt`/`gt` | Variadic folds + truncating-integer `/`. `add`/`mul` are **polymorphic** like Ruby's `+`/`*`: `add` concatenates strings (`"a"+"b"`) and arrays (`[1]+[2]`) as well as summing numbers; `mul` repeats strings (`"ab"*3`) and arrays (`[0]*3`) and joins arrays with a string separator (`[1,2]*", " → "1, 2"`). |
+| `add`/`sub`/`mul`/`div`, `lt`/`gt` | Variadic folds + truncating-integer `/`. `add`/`mul` are **polymorphic** like Ruby's `+`/`*`: `add` concatenates strings (`"a"+"b"`) and arrays (`[1]+[2]`) as well as summing numbers; `mul` repeats strings (`"ab"*3`) and arrays (`[0]*3`) and joins arrays with a string separator (`[1,2]*", " → "1, 2"`). **`div` by zero raises a typed `ZeroDivisionError`** (T1) — Python's native fault is re-raised as a rescue-matchable `SirError`, so `begin; 1/0; rescue ZeroDivisionError; end` catches it. |
 | `Closure`/`apply`/`make_closure`, global store, builtin dispatch | Uniform closure handles + SIR `Globals`. |
 
 It implements **SIR** semantics, not any one source language's — so a Ruby

--- a/code/packages/python/sir-runtime-core/pyproject.toml
+++ b/code/packages/python/sir-runtime-core/pyproject.toml
@@ -4,10 +4,13 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sir-runtime-core"
-version = "0.1.7"
+version = "0.1.8"
 description = "Core runtime for Semantic-IR-emitted Python — SIR truthiness, symbols, equality, display, arithmetic, closures, globals"
 requires-python = ">=3.12"
-dependencies = ["coding-adventures-sir-runtime-pairs"]
+dependencies = [
+    "coding-adventures-sir-runtime-pairs",
+    "coding-adventures-sir-runtime-exceptions",
+]
 license = "MIT"
 authors = [{ name = "Adhithya Rajasekaran" }]
 readme = "README.md"
@@ -34,6 +37,7 @@ dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.4", "mypy>=1.10"]
 # the local path for editable dev/test installs (mirrors the aes -> gf256 setup).
 [tool.uv.sources]
 coding-adventures-sir-runtime-pairs = { path = "../sir-runtime-pairs", editable = true }
+coding-adventures-sir-runtime-exceptions = { path = "../sir-runtime-exceptions", editable = true }
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/coding_adventures_sir_runtime_core"]

--- a/code/packages/python/sir-runtime-core/src/coding_adventures_sir_runtime_core/arithmetic.py
+++ b/code/packages/python/sir-runtime-core/src/coding_adventures_sir_runtime_core/arithmetic.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from coding_adventures_sir_runtime_exceptions import raise_error
+
 from .values import to_display
 
 
@@ -123,12 +125,39 @@ def mul(*args: Any) -> Any:
 
 def div(*args: Any) -> Any:
     """Variadic quotient with **truncating integer** division (toward
-    zero), matching SIR semantics rather than Python's float ``/``."""
+    zero), matching SIR semantics rather than Python's float ``/``.
+
+    **Division by zero is a *typed* error (T1).**  Ruby's ``1 / 0`` (and,
+    per the SIR error spec, ``1.0 / 0`` too) raises ``ZeroDivisionError`` with
+    the message ``"divided by 0"``.  Python's own ``/`` *also* raises on a zero
+    divisor — but as a **native** ``ZeroDivisionError``, which the SIR rescue
+    matcher only sees as an over-broad ``StandardError`` (``class_of_thrown``
+    treats every non-:class:`SirError` as ``StandardError``).  So a Ruby
+    ``rescue ZeroDivisionError`` would *miss* it.
+
+    We therefore **catch the native fault and re-raise it as a typed
+    :class:`SirError`** — the exact class the ancestry names (``ZeroDivisionError
+    -> StandardError -> Exception``), so ``rescue ZeroDivisionError`` matches it
+    precisely and ``rescue StandardError`` / a bare ``rescue`` still catch it.
+    This is the "wrap the native error" half of the T1 contract; the entry point
+    (:func:`raise_error`) is the same explicit-string raise the frontend already
+    emits for ``raise ZeroDivisionError`` — no reflection, no ``eval``.
+
+    Wrapping happens per-fold-step, so a variadic ``div(a, b, 0)`` reports the
+    zero divisor it actually hit.  The message matches Ruby verbatim (``"divided
+    by 0"``) for a faithful ``e.message``.
+    """
     if not args:
         return 0
     acc = args[0]
     for a in args[1:]:
-        acc = int(acc / a)
+        try:
+            acc = int(acc / a)
+        except ZeroDivisionError:
+            # Re-raise as the typed SIR error via the shared entry point.  The
+            # native ``ZeroDivisionError`` remains chained as ``__context__``;
+            # that's cosmetic — the rescue matcher dispatches on ``sir_class``.
+            raise_error("ZeroDivisionError", "divided by 0")
     return acc
 
 

--- a/code/packages/python/sir-runtime-core/tests/test_core.py
+++ b/code/packages/python/sir-runtime-core/tests/test_core.py
@@ -294,6 +294,56 @@ def test_truncating_division() -> None:
     assert sir.div(9, 3, 1) == 3
 
 
+# ── Typed division-by-zero (T1) ───────────────────────────────────────────────
+
+
+def test_int_division_by_zero_raises_typed_zero_division_error() -> None:
+    # Ruby's ``1 / 0`` raises ZeroDivisionError.  We re-raise Python's native
+    # fault as a *typed* SirError so a Ruby ``rescue ZeroDivisionError`` matches
+    # it (not merely the over-broad StandardError).
+    from coding_adventures_sir_runtime_exceptions import SirError
+
+    with pytest.raises(SirError) as excinfo:
+        sir.div(1, 0)
+    assert excinfo.value.sir_class == "ZeroDivisionError"
+    assert excinfo.value.args[0] == "divided by 0"
+
+
+def test_float_division_by_zero_raises_typed_zero_division_error() -> None:
+    # Per the SIR error spec, ``1.0 / 0`` is also a ZeroDivisionError (Python's
+    # ``1.0 / 0`` raises natively too, so the same wrap applies).
+    from coding_adventures_sir_runtime_exceptions import SirError
+
+    with pytest.raises(SirError) as excinfo:
+        sir.div(1.0, 0)
+    assert excinfo.value.sir_class == "ZeroDivisionError"
+
+
+def test_division_by_zero_reports_the_step_that_faulted() -> None:
+    # A variadic fold that only hits the zero divisor mid-chain still raises.
+    from coding_adventures_sir_runtime_exceptions import SirError
+
+    with pytest.raises(SirError) as excinfo:
+        sir.div(10, 2, 0)
+    assert excinfo.value.sir_class == "ZeroDivisionError"
+
+
+def test_zero_division_error_is_rescue_matchable() -> None:
+    # End-to-end: the typed error the runtime raises is caught by a rescue clause
+    # naming ZeroDivisionError, its StandardError ancestor, or a bare rescue —
+    # exactly the ``begin; 1/0; rescue ZeroDivisionError; end`` shape.
+    from coding_adventures_sir_runtime_exceptions import rescue_matches
+
+    try:
+        sir.div(1, 0)
+        raise AssertionError("div(1, 0) did not raise")  # pragma: no cover
+    except Exception as exc:  # noqa: BLE001 - emitted rescue catches broadly then dispatches
+        assert rescue_matches(exc, ["ZeroDivisionError"]) is True
+        assert rescue_matches(exc, ["StandardError"]) is True  # ancestry walk
+        assert rescue_matches(exc, []) is True  # bare rescue
+        assert rescue_matches(exc, ["KeyError"]) is False  # unrelated clause misses
+
+
 def test_comparisons() -> None:
     assert sir.lt(1, 2) is True
     assert sir.gt(2, 1) is True

--- a/code/packages/python/sir-runtime-oop/BUILD
+++ b/code/packages/python/sir-runtime-oop/BUILD
@@ -1,5 +1,6 @@
 uv venv --quiet --clear
 uv pip install -e ../sir-runtime-pairs --quiet
+uv pip install -e ../sir-runtime-exceptions --quiet
 uv pip install -e ../sir-runtime-core --quiet
 uv pip install -e .[dev] --quiet
 .venv/bin/python -m ruff check src tests

--- a/code/packages/python/sir-runtime-oop/CHANGELOG.md
+++ b/code/packages/python/sir-runtime-oop/CHANGELOG.md
@@ -2,6 +2,45 @@
 
 All notable changes to `coding-adventures-sir-runtime-oop` are documented here.
 
+## [0.1.10] - 2026-07-01
+
+### Changed — typed runtime errors (T1 of sir-typed-runtime-errors)
+
+Faulting Ruby method calls now raise the **typed** `SirError` the rescue matcher
+names, replacing the old blanket nil floor for `.fetch` misses and unknown
+methods — so `rescue IndexError` / `rescue KeyError` / `rescue NoMethodError`
+catch them, identically to Ruby. See
+[`code/specs/sir-typed-runtime-errors.md`](../../../specs/sir-typed-runtime-errors.md).
+
+- **`Array#fetch`** — added to the array catalog. Returns the element for an
+  in-range index (negatives count from the end), like `arr[i]`; an
+  **out-of-bounds** index with no default now raises `IndexError`
+  (`"index N outside of array bounds: -M...M"`). A second argument supplies a
+  default returned instead of raising.
+- **`Hash#fetch`** — a **missing** key with no default now raises `KeyError`
+  (`"key not found: <inspect>"`) instead of returning nil. A second argument
+  still supplies a default.
+- **Unknown method** — `call_method`'s floor now raises `NoMethodError`
+  (`"undefined method 'x' for <class>"`) for a **genuinely unknown** method
+  (`obj.undefined`, `nil.foo`, `"s".scan`). A *known* block-taking method invoked
+  **without** a block (e.g. `[1,2,3].map`, `5.times`) still returns nil — Ruby
+  returns an Enumerator there, the documented v0 floor — discriminated by
+  `_responds_to`.
+- **Unchanged (no over-raise):** the plain index operators `arr[i]` / `hash[k]`
+  still return nil (Ruby does not raise for `[]`); they are emitted as native
+  Python subscripts and never route through `.fetch` / `call_method`. Catalogued
+  accessors that legitimately return nil (`arr.first` on empty, `hash.dig` miss,
+  `str.index` miss) are unaffected.
+- No reflection or `eval`: every typed raise is an explicit class-name string via
+  the shared `raise_error` entry point; the unknown method name is interpolated
+  as an opaque message string, never used to reflect a Python attribute (the C3
+  dynamic-dispatch RCE lesson).
+
+### Dependency
+
+- Added `coding-adventures-sir-runtime-exceptions` for the typed-raise entry
+  point.
+
 ## [0.1.9] - 2026-07-01
 
 ### Added (O1 — user class/instance method tables + new/super/self)

--- a/code/packages/python/sir-runtime-oop/README.md
+++ b/code/packages/python/sir-runtime-oop/README.md
@@ -45,8 +45,20 @@ _sir_oop.cvar_set("@@count", 0)                   # @@count = 0
 `recv.meth(args…)` reaches the backend as `BuiltinCall("__method__", …)` and is
 dispatched by `call_method`, in order: reflective built-ins
 (`is_a?`/`kind_of?`/`instance_of?`/`class`) → user `define_method` table →
-built-in catalog → `nil` floor. `respond_to?` reports exactly which names
-resolve, so an out-of-catalog method is both `nil` *and* `respond_to? == False`.
+built-in catalog → floor. `respond_to?` reports exactly which names resolve.
+
+**Floor (T1 — typed runtime errors).** A **genuinely unknown** method
+(`obj.undefined`, `nil.foo`, `"s".scan` — `respond_to? == False`) now raises a
+typed `NoMethodError` (`"undefined method 'x' for <class>"`), so a Ruby `rescue
+NoMethodError` catches it. A *known* block-taking method invoked **without** a
+block (e.g. `[1,2,3].map`, `5.times`) still returns `nil` — Ruby returns an
+Enumerator there, the documented v0 floor. See
+`code/specs/sir-typed-runtime-errors.md`.
+
+**Typed `.fetch` faults.** `Array#fetch(i)` out of bounds (no default) raises
+`IndexError`; `Hash#fetch(k)` on a missing key (no default) raises `KeyError` —
+matching Ruby. The plain index operators `arr[i]` / `hash[k]` are emitted as
+native Python subscripts and still return `nil` (Ruby does not raise for `[]`).
 
 The catalog currently covers (item **M1a** of `code/specs/sir-method-dispatch.md`)
 the **non-block `Array`** surface — `length`/`size`/`count`, `first`/`last`,
@@ -80,7 +92,8 @@ plus **`Array#join`**.
 backend emits a `&:sym` block-pass on a dispatched call as
 `_sir_oop_sym_to_proc(intern("sym"))`; applying the closure dispatches the named
 method on its first argument (the rest forwarded), through `call_method`, so an
-unknown method still bottoms out at `nil`. Operator symbols (`&:+`) are native
+unknown method raises `NoMethodError` (T1) — as `[42].map(&:undefined)` does in
+Ruby. Operator symbols (`&:+`) are native
 arithmetic, not in the dispatch catalog — a documented v0 boundary.
 
 ### Kernel flow-control + boolean operators (item **M6**)
@@ -106,9 +119,11 @@ The universal-catalog completion the spec's v0 surface called for:
 Because the frontend does not thread receivers into method bodies, the *current
 self* is a process-global stack (not a true per-call binding) and class
 variables share a single namespace keyed by bare name. This faithfully models
-single-instance / single-class programs and never raises on the OO surface, but
-full multi-object Ruby semantics await a frontend that carries receivers into
-methods (out of scope for the backend). See `code/specs/sir-runtime.md`.
+single-instance / single-class programs, but full multi-object Ruby semantics
+await a frontend that carries receivers into methods (out of scope for the
+backend). (As of T1 the dispatch surface *does* raise typed `NoMethodError` /
+`IndexError` / `KeyError` for genuine faults — see the dispatch section above —
+rather than the earlier blanket nil floor.) See `code/specs/sir-runtime.md`.
 
 ## Where it fits
 

--- a/code/packages/python/sir-runtime-oop/pyproject.toml
+++ b/code/packages/python/sir-runtime-oop/pyproject.toml
@@ -4,10 +4,13 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sir-runtime-oop"
-version = "0.1.9"
+version = "0.1.10"
 description = "OOP runtime for Semantic-IR-emitted Python — class registry, is_a?/ancestry, instance- and class-variable stores, reflective method dispatch"
 requires-python = ">=3.12"
-dependencies = ["coding-adventures-sir-runtime-core"]
+dependencies = [
+    "coding-adventures-sir-runtime-core",
+    "coding-adventures-sir-runtime-exceptions",
+]
 license = "MIT"
 authors = [{ name = "Adhithya Rajasekaran" }]
 readme = "README.md"
@@ -32,6 +35,7 @@ dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.4", "mypy>=1.10"]
 
 [tool.uv.sources]
 coding-adventures-sir-runtime-core = { path = "../sir-runtime-core", editable = true }
+coding-adventures-sir-runtime-exceptions = { path = "../sir-runtime-exceptions", editable = true }
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/coding_adventures_sir_runtime_oop"]

--- a/code/packages/python/sir-runtime-oop/src/coding_adventures_sir_runtime_oop/oop.py
+++ b/code/packages/python/sir-runtime-oop/src/coding_adventures_sir_runtime_oop/oop.py
@@ -43,6 +43,15 @@ from typing import Any
 # :class:`Symbol` that ``String#to_sym`` / ``Symbol#upcase`` return.
 from coding_adventures_sir_runtime_core import Closure, Symbol, apply, eq, intern, truthy
 
+# Typed-error entry point (T1).  A faulting Ruby method — ``arr.fetch`` out of
+# bounds, ``hash.fetch`` on a missing key, an unknown method — must raise the
+# *typed* :class:`SirError` the rescue matcher names (``IndexError`` / ``KeyError``
+# / ``NoMethodError``), not the ``nil`` floor and not a native Python error (which
+# the matcher only sees as an over-broad ``StandardError``).  ``raise_error`` is
+# the same explicit-string raise the frontend already emits for ``raise Klass`` —
+# no reflection on the source-derived method name (the C3 RCE lesson).
+from coding_adventures_sir_runtime_exceptions import raise_error
+
 # The SIR universal value type at this package's boundary.
 Val = Any
 
@@ -463,6 +472,7 @@ _ARRAY_METHODS = frozenset(
         "empty?",
         "to_a",
         "join",
+        "fetch",
     }
 )
 
@@ -822,6 +832,22 @@ def _array_method(recv: list[Val], name: str, args: list[Val]) -> Val:
         # Ruby ``Array#join``: elements rendered with ``to_s`` (default sep "").
         sep = args[0] if args else ""
         return sep.join(_ruby_to_s(item) for item in recv)
+    if name == "fetch":
+        # Ruby ``Array#fetch(i)``: like ``arr[i]`` for an *in-range* index
+        # (negative indices count from the end), but an **out-of-bounds** index
+        # with no default raises ``IndexError`` (T1) — unlike ``arr[i]``, which
+        # returns nil.  A second argument supplies a default returned instead of
+        # raising.  (The block form ``fetch(i) { … }`` is out of v0 scope.)
+        index = args[0]
+        length = len(recv)
+        if isinstance(index, int) and -length <= index < length:
+            return recv[index]
+        if len(args) > 1:
+            return args[1]
+        raise_error(
+            "IndexError",
+            f"index {index} outside of array bounds: {-length}...{length}",
+        )
     return _MISS
 
 
@@ -890,9 +916,15 @@ def _hash_method(recv: dict[Val, Val], name: str, args: list[Val]) -> Val:
     if name in ("has_value?", "value?"):
         return args[0] in recv.values()
     if name == "fetch":
+        # Ruby ``Hash#fetch(k)``: returns the value for ``k`` if present; a
+        # **missing** key with no default raises ``KeyError`` (T1) — unlike
+        # ``hash[k]``, which returns nil.  A second argument supplies a default
+        # returned instead of raising.  (The block form is out of v0 scope.)
         if args[0] in recv:
             return recv[args[0]]
-        return args[1] if len(args) > 1 else None
+        if len(args) > 1:
+            return args[1]
+        raise_error("KeyError", f"key not found: {_ruby_inspect(args[0])}")
     if name in ("size", "length"):
         return len(recv)
     if name == "empty?":
@@ -1422,7 +1454,28 @@ def call_method(recv: Val, name: str, *args: Val) -> Val:
     if result is not _MISS:
         return result
 
-    return None
+    # ── Floor (T1) ────────────────────────────────────────────────────────────
+    # Nothing above returned a value for ``name`` on ``recv``.  Two distinct
+    # cases hide here, and Ruby treats them differently:
+    #
+    #   1. **Known method, wrong call shape** — a *catalogued* method invoked in
+    #      a form v0 doesn't implement, e.g. a block-taking ``map``/``times``
+    #      called *without* a block.  Ruby returns an Enumerator; the honest v0
+    #      floor is ``nil`` (documented).  This is NOT a missing method, so it
+    #      must not raise ``NoMethodError``.
+    #   2. **Genuinely unknown method** — ``obj.undefined``, ``nil.foo``,
+    #      ``"s".scan`` (no catalog entry at all).  This is exactly Ruby's
+    #      ``NoMethodError`` (T1), replacing the old blanket nil floor.
+    #
+    # :func:`_responds_to` is the precise discriminator: it reports catalog +
+    # reflective + ``define_method`` membership, so a name it knows is case 1
+    # (nil) and a name it doesn't is case 2 (raise).  The message mirrors Ruby's
+    # shape (``undefined method 'x' for <receiver class>``); ``name`` is
+    # interpolated as an opaque string, never used to reflect a Python attribute
+    # (the C3 dynamic-dispatch RCE lesson).
+    if _responds_to(recv, name):
+        return None
+    raise_error("NoMethodError", f"undefined method '{name}' for {class_of(recv)}")
 
 
 # --- Symbol#to_proc (&:sym) ------------------------------------------------

--- a/code/packages/python/sir-runtime-oop/tests/test_oop.py
+++ b/code/packages/python/sir-runtime-oop/tests/test_oop.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 from coding_adventures_sir_runtime_core import Closure
+from coding_adventures_sir_runtime_exceptions import SirError
 
 import coding_adventures_sir_runtime_oop as oop
 from coding_adventures_sir_runtime_oop import Val
@@ -128,10 +129,15 @@ def test_instance_of_requires_exact_non_ancestor_match() -> None:
     assert oop.call_method(d, "instance_of?", "Animal") is False
 
 
-def test_class_returns_class_name_and_unknown_methods_return_nil() -> None:
+def test_class_returns_class_name_and_unknown_methods_raise_no_method_error() -> None:
     assert oop.call_method(oop.new_instance("Foo"), "class") == "Foo"
     assert oop.call_method(3, "class") == "Integer"
-    assert oop.call_method(3, "no_such_method") is None
+    # A genuinely unknown method now raises a typed NoMethodError (T1), not the
+    # old nil floor — so a Ruby ``rescue NoMethodError`` catches it.
+    with pytest.raises(SirError) as excinfo:
+        oop.call_method(3, "no_such_method")
+    assert excinfo.value.sir_class == "NoMethodError"
+    assert excinfo.value.args[0] == "undefined method 'no_such_method' for Integer"
 
 
 def test_define_method_backs_the_dispatch_fallback() -> None:
@@ -170,6 +176,28 @@ def test_array_include_and_index() -> None:
     assert oop.call_method([1, 2, 3], "include?", 9) is False
     assert oop.call_method([1, 2, 3], "index", 3) == 2
     assert oop.call_method([1, 2, 3], "index", 9) is None
+
+
+def test_array_fetch_in_range_and_negative_index() -> None:
+    # ``Array#fetch`` returns the element for an in-range index (negative counts
+    # from the end), like ``arr[i]`` — the difference is only on out-of-bounds.
+    assert oop.call_method([10, 20, 30], "fetch", 0) == 10
+    assert oop.call_method([10, 20, 30], "fetch", 2) == 30
+    assert oop.call_method([10, 20, 30], "fetch", -1) == 30
+
+
+def test_array_fetch_out_of_bounds_with_default_returns_default() -> None:
+    # A second argument supplies the value returned instead of raising.
+    assert oop.call_method([10, 20], "fetch", 5, 99) == 99
+
+
+def test_array_fetch_out_of_bounds_raises_index_error() -> None:
+    # Ruby ``Array#fetch`` out of bounds with no default raises IndexError (T1) —
+    # unlike ``arr[i]``, which returns nil.
+    with pytest.raises(SirError) as excinfo:
+        oop.call_method([10, 20], "fetch", 100)
+    assert excinfo.value.sir_class == "IndexError"
+    assert excinfo.value.args[0] == "index 100 outside of array bounds: -2...2"
 
 
 def test_array_mutating_push_pop_shift_unshift() -> None:
@@ -251,14 +279,23 @@ def test_respond_to_reports_catalog_membership() -> None:
     assert oop.call_method([1], "respond_to?", "each_slice") is False
 
 
-def test_unknown_method_returns_nil_not_raise() -> None:
-    # A block method called WITHOUT a block bottoms out at nil (Ruby returns an
-    # Enumerator; v0 floor is nil — see spec).
+def test_known_block_method_without_block_still_returns_nil() -> None:
+    # A *known* block method called WITHOUT a block bottoms out at nil (Ruby
+    # returns an Enumerator; v0 floor is nil — see spec).  This is a wrong-shape
+    # invocation of a catalogued method, NOT a missing method, so it must NOT
+    # raise NoMethodError (T1): ``_responds_to`` reports ``map``/``times`` as
+    # known, keeping the nil floor.
     assert oop.call_method([1, 2, 3], "map") is None
-    # An out-of-catalog String method (scan needs a regex engine — later PR).
-    assert oop.call_method("hi", "scan") is None
-    # Numeric has no catalog yet (M1c-Numeric), so every method is the nil floor.
     assert oop.call_method(5, "times") is None
+
+
+def test_out_of_catalog_method_raises_no_method_error() -> None:
+    # An out-of-catalog String method (scan needs a regex engine — later PR) is a
+    # genuinely unknown method → typed NoMethodError (T1).
+    with pytest.raises(SirError) as excinfo:
+        oop.call_method("hi", "scan")
+    assert excinfo.value.sir_class == "NoMethodError"
+    assert excinfo.value.args[0] == "undefined method 'scan' for String"
 
 
 # ── built-in method catalog: block-taking Array/Enumerable (M1b) ──────────────
@@ -345,10 +382,19 @@ def test_hash_key_value_membership() -> None:
 def test_hash_fetch_dig_to_a() -> None:
     h = {"a": 1, "b": 2}
     assert oop.call_method(h, "fetch", "a") == 1
-    assert oop.call_method(h, "fetch", "z") is None
+    # Missing key with an explicit default returns the default (no raise).
     assert oop.call_method(h, "fetch", "z", 99) == 99
     assert oop.call_method(h, "dig", "b") == 2
     assert oop.call_method(h, "to_a") == [["a", 1], ["b", 2]]
+
+
+def test_hash_fetch_missing_key_raises_key_error() -> None:
+    # Ruby ``Hash#fetch`` on a missing key with no default raises KeyError (T1) —
+    # unlike ``hash[k]``, which returns nil.
+    with pytest.raises(SirError) as excinfo:
+        oop.call_method({"a": 1}, "fetch", "z")
+    assert excinfo.value.sir_class == "KeyError"
+    assert excinfo.value.args[0] == 'key not found: "z"'
 
 
 def test_hash_store_merge_delete_clear_invert() -> None:
@@ -385,11 +431,15 @@ def test_hash_each_key_each_value() -> None:
     assert vs == [1, 2]
 
 
-def test_hash_respond_to_and_nil_floor() -> None:
+def test_hash_respond_to_and_no_method_error_floor() -> None:
     assert oop.call_method({"a": 1}, "respond_to?", "keys") is True
     assert oop.call_method({"a": 1}, "respond_to?", "each") is True
     assert oop.call_method({"a": 1}, "respond_to?", "transform_keys") is False
-    assert oop.call_method({"a": 1}, "transform_keys") is None
+    # An out-of-catalog Hash method is genuinely unknown → NoMethodError (T1).
+    with pytest.raises(SirError) as excinfo:
+        oop.call_method({"a": 1}, "transform_keys")
+    assert excinfo.value.sir_class == "NoMethodError"
+    assert excinfo.value.args[0] == "undefined method 'transform_keys' for Hash"
     # Universal Object methods still resolve on a Hash receiver.
     assert oop.call_method({"a": 1}, "nil?") is False
 
@@ -467,11 +517,14 @@ def test_string_each_char_block() -> None:
     assert result == "abc"
 
 
-def test_string_respond_to_and_nil_floor() -> None:
+def test_string_respond_to_and_no_method_error_floor() -> None:
     assert oop.call_method("x", "respond_to?", "upcase") is True
     assert oop.call_method("x", "respond_to?", "each_char") is True
     assert oop.call_method("x", "respond_to?", "scan") is False
-    assert oop.call_method("x", "scan") is None
+    # An out-of-catalog String method is genuinely unknown → NoMethodError (T1).
+    with pytest.raises(SirError) as excinfo:
+        oop.call_method("x", "scan")
+    assert excinfo.value.sir_class == "NoMethodError"
     # Universal Object methods still resolve on a String receiver.
     assert oop.call_method("x", "nil?") is False
     assert oop.call_method("x", "class") == "String"
@@ -537,12 +590,16 @@ def test_numeric_block_times_upto_downto_step() -> None:
     assert step == [0, 5, 10]
 
 
-def test_numeric_respond_to_and_nil_floor() -> None:
+def test_numeric_respond_to_and_floor() -> None:
     assert oop.call_method(5, "respond_to?", "even?") is True
     assert oop.call_method(5, "respond_to?", "times") is True
     assert oop.call_method(5, "respond_to?", "bit_length") is False
-    assert oop.call_method(5, "bit_length") is None
-    # A block method called without a block bottoms out at the nil floor.
+    # An out-of-catalog numeric method is genuinely unknown → NoMethodError (T1).
+    with pytest.raises(SirError) as excinfo:
+        oop.call_method(5, "bit_length")
+    assert excinfo.value.sir_class == "NoMethodError"
+    assert excinfo.value.args[0] == "undefined method 'bit_length' for Integer"
+    # A *known* block method called without a block bottoms out at the nil floor.
     assert oop.call_method(5, "times") is None
 
 
@@ -573,9 +630,13 @@ def test_nil_true_false_to_s_inspect() -> None:
     assert oop.call_method(True, "to_s") == "true"
     assert oop.call_method(False, "to_s") == "false"
     assert oop.call_method(True, "inspect") == "true"
-    # bool resolves only Object methods, never the numeric catalog.
+    # bool resolves only Object methods, never the numeric catalog — so a
+    # numeric method on a boolean is unknown → NoMethodError (T1).
     assert oop.call_method(True, "respond_to?", "even?") is False
-    assert oop.call_method(True, "even?") is None
+    with pytest.raises(SirError) as excinfo:
+        oop.call_method(True, "even?")
+    assert excinfo.value.sir_class == "NoMethodError"
+    assert excinfo.value.args[0] == "undefined method 'even?' for TrueClass"
 
 
 def test_object_to_s_inspect_collections() -> None:
@@ -653,12 +714,16 @@ def test_sym_to_proc_accepts_bare_string_name() -> None:
     assert apply(proc, ["hi"]) == "HI"
 
 
-def test_sym_to_proc_out_of_catalog_method_returns_nil() -> None:
+def test_sym_to_proc_out_of_catalog_method_raises_no_method_error() -> None:
     from coding_adventures_sir_runtime_core import apply, intern
 
-    # An unknown method bottoms out at nil (never-raise OO surface).
+    # ``(&:no_such_method)`` applied to a value dispatches an unknown method, so
+    # it raises NoMethodError (T1) just like a direct ``x.no_such_method`` —
+    # matching Ruby, where ``[42].map(&:no_such_method)`` raises NoMethodError.
     proc = oop.sym_to_proc(intern("no_such_method"))
-    assert apply(proc, [42]) is None
+    with pytest.raises(SirError) as excinfo:
+        apply(proc, [42])
+    assert excinfo.value.sir_class == "NoMethodError"
 
 
 def test_sym_to_proc_drives_array_block_method_dispatch() -> None:
@@ -789,8 +854,10 @@ def test_kernel_respond_to_is_honest() -> None:
     assert oop.call_method(True, "respond_to?", "&") is True
     # A non-bool receiver does not respond to the boolean operators.
     assert oop.call_method(5, "respond_to?", "^") is False
-    # An out-of-catalog name is still both nil and respond_to? == False.
-    assert oop.call_method(True, "nonexistent_method") is None
+    # An out-of-catalog name is both NoMethodError (T1) and respond_to? == False.
+    with pytest.raises(SirError) as excinfo:
+        oop.call_method(True, "nonexistent_method")
+    assert excinfo.value.sir_class == "NoMethodError"
     assert oop.call_method(True, "respond_to?", "nonexistent_method") is False
 
 
@@ -934,3 +1001,71 @@ def test_reset_oop_clears_method_tables() -> None:
     # After reset the tables are empty → nil floor.
     assert oop.call_class_method("Dog", "make") is None
     assert oop.call_super("speak", "Dog") is None
+
+
+# ── Typed runtime errors: end-to-end rescue-matchability (T1) ─────────────────
+#
+# These prove the *emitted rescue shape* works: a Ruby ``begin; <op>; rescue
+# <Class> => e; end`` lowers to a native ``try/except`` that catches broadly and
+# then calls ``rescue_matches(exc, [<Class>])`` per clause.  A faulting op must
+# raise a typed SirError so the right clause fires (and unrelated clauses miss).
+
+
+def test_array_fetch_oob_is_rescued_as_index_error() -> None:
+    from coding_adventures_sir_runtime_exceptions import rescue_matches
+
+    try:
+        oop.call_method([1, 2], "fetch", 100)
+        raise AssertionError("fetch did not raise")  # pragma: no cover
+    except Exception as exc:  # noqa: BLE001 - mirrors the emitted broad catch
+        assert rescue_matches(exc, ["IndexError"]) is True
+        assert rescue_matches(exc, ["StandardError"]) is True
+        assert rescue_matches(exc, ["KeyError"]) is False  # sibling clause misses
+
+
+def test_hash_fetch_miss_is_rescued_as_key_error() -> None:
+    from coding_adventures_sir_runtime_exceptions import rescue_matches
+
+    try:
+        oop.call_method({"a": 1}, "fetch", "z")
+        raise AssertionError("fetch did not raise")  # pragma: no cover
+    except Exception as exc:  # noqa: BLE001
+        assert rescue_matches(exc, ["KeyError"]) is True
+        # KeyError < IndexError < StandardError in the built-in ancestry, so a
+        # ``rescue IndexError`` also catches a raised KeyError (Ruby semantics).
+        assert rescue_matches(exc, ["IndexError"]) is True
+        assert rescue_matches(exc, ["StandardError"]) is True
+
+
+def test_unknown_method_is_rescued_as_no_method_error() -> None:
+    from coding_adventures_sir_runtime_exceptions import rescue_matches
+
+    try:
+        oop.call_method(oop.new_instance("Widget"), "undefined")
+        raise AssertionError("dispatch did not raise")  # pragma: no cover
+    except Exception as exc:  # noqa: BLE001
+        assert rescue_matches(exc, ["NoMethodError"]) is True
+        # NoMethodError < NameError < StandardError — a ``rescue NameError``
+        # catches it too (Ruby semantics).
+        assert rescue_matches(exc, ["NameError"]) is True
+        assert rescue_matches(exc, ["StandardError"]) is True
+
+
+def test_nil_unknown_method_is_no_method_error() -> None:
+    # ``nil.foo`` raises NoMethodError in Ruby (not the old silent nil).
+    with pytest.raises(SirError) as excinfo:
+        oop.call_method(None, "foo")
+    assert excinfo.value.sir_class == "NoMethodError"
+    assert excinfo.value.args[0] == "undefined method 'foo' for NilClass"
+
+
+def test_index_operator_still_returns_nil_no_over_raise() -> None:
+    # REGRESSION: ``.fetch`` raises, but the plain index operator ``arr[i]`` /
+    # ``hash[k]`` must NOT — Ruby returns nil there.  The backend emits ``[]`` as
+    # a *native* Python subscript that never routes through ``call_method`` /
+    # ``.fetch``, so the two paths stay independent.  A missing hash key via the
+    # ``dict.get`` semantics the ``[]`` lowering relies on still yields nil, and
+    # the catalogued (non-fetch) accessors keep their nil returns.
+    assert {"a": 1}.get("missing") is None  # the [] lowering's miss → nil
+    assert oop.call_method([], "first") is None  # empty-array accessor stays nil
+    assert oop.call_method({"a": 1}, "dig", "z") is None  # dig miss stays nil


### PR DESCRIPTION
Python milestone of the **sir-typed-runtime-errors** cascade (spec on main, #53). Runtime-only — `sir-runtime-core` (div) + `sir-runtime-oop` (fetch, unknown-method).

Faulting runtime ops now raise the correct **typed** `SirError` so a translated `rescue` catches them:
- `1/0` / `1.0/0` → `ZeroDivisionError` (`div` wraps native error → rescue-matchable, per fold-step).
- `arr.fetch(oob)` → `IndexError`; `hash.fetch(miss)` → `KeyError` (default arg honored).
- unknown method → `NoMethodError` (`undefined method 'x' for <class>`), replacing the old blanket nil floor. Genuine unknowns raise; a wrong-shape call to a *known* block-method (`map`/`times` without a block) still returns nil (Ruby Enumerator floor) — discriminated via the `_responds_to` allowlist.
- `arr[i]`/`hash[k]` unchanged → nil (no over-raise).
- Wires `sir-runtime-exceptions` (leaf dep) into both packages (pyproject + uv sources + BUILD, leaf-to-root).

Security review: **PASSED** — `_responds_to` is a pure frozenset allowlist (no `getattr`/`eval`/reflection), `.fetch` guards `isinstance(index, int)` before subscript, message construction is cycle-safe.

core 65 + oop 102 tests pass; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)