### PR TITLE
feat(visicalc-flutter): runtime desktop/touch FormulaBar layout toggle

### DIFF
--- a/code/programs/dart/visicalc-flutter/README.md
+++ b/code/programs/dart/visicalc-flutter/README.md
@@ -89,6 +89,27 @@ Volatile per-platform caches (`android/.gradle/`, `ios/Pods/`,
 `xcuserdata/`, etc.) are gitignored — `flutter build` regenerates
 them on first run.
 
+## The touch FormulaBar layout (`FormulaBarTouch`)
+
+The **Touch bar** button (shown in classic-grid mode) swaps the formula bar
+between two widgets generated from the *same* `FormulaBar.mil` interface:
+
+- **Desktop** (`FormulaBar.desktop.mll` → `FormulaBar`): a `Row` — the
+  cell-address label sits to the **left** of the input.
+- **Touch** (`FormulaBar.touch.mll` → `FormulaBarTouch`): a `Column` — the
+  address label stacks **above** a full-width input, the phone arrangement.
+
+`scripts/build.sh` emits both into `lib/generated/`. The Flutter emitter names
+the widget after the `.mil` component (`FormulaBar`) and also emits the shared
+`sealed class FormulaBarEvent` + subclasses, so to let both widgets coexist the
+touch output has its **duplicate** event classes stripped — it `import`s them
+from `formula_bar.dart` instead — and its widget + constructor renamed to
+`FormulaBarTouch`. `main.dart` holds a `_touch` flag and renders one or the
+other, passing the identical `_onFormulaBarEvent` — editing behaves the same in
+both; only the shape changes. This is the UI30 "one component, many layouts,
+identical host contract" invariant made a runtime toggle — the Flutter sibling
+of the Qt and Compose demos' toggles and the web demo's switcher.
+
 ## Infinite virtualized sheet
 
 `SpreadsheetSession` (`lib/engine.dart`) also binds the engine's **viewport

--- a/code/programs/dart/visicalc-flutter/lib/main.dart
+++ b/code/programs/dart/visicalc-flutter/lib/main.dart
@@ -19,6 +19,7 @@
 import 'package:flutter/material.dart';
 import 'engine.dart';
 import 'generated/formula_bar.dart';
+import 'generated/formula_bar_touch.dart';
 import 'generated/grid.dart';
 import 'infinite_grid.dart';
 
@@ -97,6 +98,14 @@ class _VisiCalcHomeState extends State<VisiCalcHome> {
   // on the same engine via the viewport primitive).
   bool _infinite = false;
 
+  // Which FormulaBar LAYOUT is showing in classic-grid mode: the desktop Row
+  // (address label left of the input) or the UI30 touch Column (address label
+  // stacked ABOVE a full-width input). Both are generated from the SAME
+  // FormulaBar.mil interface — only the .mll spatial arrangement differs — so
+  // they share FormulaBarEvent + _onFormulaBarEvent. "One component, many
+  // layouts" made a runtime toggle (the Flutter sibling of the Qt/Compose ones).
+  bool _touch = false;
+
   String get _cellAddress {
     // Column 0 is the row-label gutter; data columns A–E start at
     // index 1, so the letter is offset by one (`65 + col - 1`).
@@ -167,6 +176,13 @@ class _VisiCalcHomeState extends State<VisiCalcHome> {
                         ),
                       ),
                     ),
+                    // The layout toggle only applies to the classic grid's
+                    // formula bar (the infinite view has none), so hide it there.
+                    if (!_infinite)
+                      TextButton(
+                        onPressed: () => setState(() => _touch = !_touch),
+                        child: Text(_touch ? 'Desktop bar' : 'Touch bar'),
+                      ),
                     TextButton(
                       onPressed: () => setState(() => _infinite = !_infinite),
                       child: Text(_infinite ? 'Classic grid' : 'Infinite sheet'),
@@ -179,12 +195,22 @@ class _VisiCalcHomeState extends State<VisiCalcHome> {
               if (_infinite)
                 const Expanded(child: InfiniteGrid())
               else ...[
-                FormulaBar(
-                  cellAddress: _cellAddress,
-                  formula: _formula,
-                  readOnly: false,
-                  dispatch: _onFormulaBarEvent,
-                ),
+                // Desktop (Row) vs touch (Column) — both generated from the same
+                // FormulaBar.mil, sharing FormulaBarEvent + _onFormulaBarEvent.
+                if (_touch)
+                  FormulaBarTouch(
+                    cellAddress: _cellAddress,
+                    formula: _formula,
+                    readOnly: false,
+                    dispatch: _onFormulaBarEvent,
+                  )
+                else
+                  FormulaBar(
+                    cellAddress: _cellAddress,
+                    formula: _formula,
+                    readOnly: false,
+                    dispatch: _onFormulaBarEvent,
+                  ),
                 Expanded(
                   child: Padding(
                     padding: const EdgeInsets.symmetric(horizontal: 16),

--- a/code/programs/dart/visicalc-flutter/scripts/build.sh
+++ b/code/programs/dart/visicalc-flutter/scripts/build.sh
@@ -43,12 +43,44 @@ SRC="$REPO_ROOT/code/programs/mosaic/visicalc"
 OUT_DIR="$DEMO_DIR/lib/generated"
 mkdir -p "$OUT_DIR"
 
-echo "Compiling FormulaBar (Flutter)..."
+echo "Compiling FormulaBar (Flutter, desktop)..."
 "$MOSAIC_COMPILE" --backend flutter \
   --interface "$SRC/FormulaBar.mil" \
   --layout    "$SRC/FormulaBar.desktop.mll" \
   --style     "$SRC/FormulaBar.dark.msl" \
   -o "$OUT_DIR/formula_bar.dart"
+
+# UI30 touch variant: FormulaBar.touch.mll stacks the address label ABOVE a
+# full-width input (Column) instead of the desktop Row. Same FormulaBar.mil
+# interface, so main.dart can swap FormulaBar <-> FormulaBarTouch at runtime
+# against the identical dispatch contract. The Flutter emitter names the widget
+# after the .mil component (FormulaBar) and also emits the shared
+# `sealed class FormulaBarEvent` + subclasses; to let both widgets coexist we
+# (1) strip the DUPLICATE event classes from the touch output and instead
+# `import 'formula_bar.dart'` to reuse them, and (2) rename the widget +
+# constructor to FormulaBarTouch. Result: one event type, two layouts.
+echo "Compiling FormulaBar (Flutter, touch)..."
+"$MOSAIC_COMPILE" --backend flutter \
+  --interface "$SRC/FormulaBar.mil" \
+  --layout    "$SRC/FormulaBar.touch.mll" \
+  --style     "$SRC/FormulaBar.dark.msl" \
+  -o "$OUT_DIR/formula_bar_touch.dart.raw"
+# awk: inject `import 'formula_bar.dart';` right after the material import, and
+# drop the event-class block (from `sealed class FormulaBarEvent {` up to, but
+# excluding, `class FormulaBar extends StatelessWidget {`). sed: rename the
+# widget class + its constructor. (No newlines in the sed replacement, so it is
+# portable across BSD/macOS + GNU sed.)
+awk '
+  /^import '\''package:flutter\/material.dart'\'';/ { print; print "import '\''formula_bar.dart'\'';"; next }
+  /^sealed class FormulaBarEvent \{/ { skip = 1 }
+  /^class FormulaBar extends StatelessWidget \{/ { skip = 0 }
+  skip { next }
+  { print }
+' "$OUT_DIR/formula_bar_touch.dart.raw" \
+  | sed -e 's/class FormulaBar extends StatelessWidget/class FormulaBarTouch extends StatelessWidget/' \
+        -e 's/const FormulaBar(/const FormulaBarTouch(/' \
+  > "$OUT_DIR/formula_bar_touch.dart"
+rm -f "$OUT_DIR/formula_bar_touch.dart.raw"
 
 echo "Compiling Grid (Flutter)..."
 # UI34 — Grid is now generated from the shared visicalc/mosaic/


### PR DESCRIPTION
## What

Brings the mobile/touch layout toggle to the **Flutter** demo — the native sibling of the merged Qt ([#7298](https://github.com/adhithyan15/coding-adventures/pull/7298)) and Compose ([#7340](https://github.com/adhithyan15/coding-adventures/pull/7340)) toggles and the web switcher ([#7338](https://github.com/adhithyan15/coding-adventures/pull/7338)). A **Touch bar** button (classic-grid mode) swaps the formula bar between two widgets generated from the **same** `FormulaBar.mil` interface:

| variant | source | shape |
|---|---|---|
| desktop | `FormulaBar.desktop.mll` → `FormulaBar` | `Row` — address label **left** of input |
| touch | `FormulaBar.touch.mll` → `FormulaBarTouch` | `Column` — address label **above** full-width input |

## The wrinkle (same as Compose)

The Flutter emitter names the widget after the `.mil` component (`FormulaBar`) and also emits the shared `sealed class FormulaBarEvent` + subclasses. So `scripts/build.sh` post-processes the touch output: strip the **duplicate** event classes and `import 'formula_bar.dart'` to reuse them (awk), and rename the widget + constructor to `FormulaBarTouch` (sed, no-newline replacement → BSD/GNU portable). One event type, two layouts.

## Changes

- **`scripts/build.sh`** — emit `lib/generated/formula_bar_touch.dart` (mosaic-compile `--layout FormulaBar.touch.mll` + awk/sed). Mirrors how `formula_bar.dart` is already generated (both regenerated by build.sh, not committed — matching the existing convention; `grid.dart` left untouched).
- **`lib/main.dart`** — `_touch` flag + toggle TextButton (classic-grid only) + render `FormulaBarTouch`/`FormulaBar` by the flag, sharing `_onFormulaBarEvent`.
- **`README.md`** — document it.

## Verification

- `bash scripts/build.sh` emits `formula_bar_touch.dart` with a **`Column`** root (vs `formula_bar.dart`'s **`Row`**) that imports the shared `FormulaBarEvent`.
- **`flutter analyze lib/` — zero errors** in the touched files (only 2 pre-existing emitter warnings in the unrelated generated `grid.dart`, left as-is).
- No CI build gate exists for this demo (no BUILD file), and the desktop window isn't screen-capturable in this headless automation context; `analyze` + the Column-vs-Row divergence confirm the change.

Security review: **PASSED** (build.sh takes no external input; fixed in-repo paths under `set -euo pipefail`; static awk/sed; fixed-path temp; the touch widget adds no new engine/FFI path — same shared dispatch as desktop).

With this, the touch/desktop toggle is live on **web, Qt, Compose, and Flutter**. Next in the loop: Android, then Deno FFI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)