### PR TITLE
feat(sir-rust): typed runtime errors — ZeroDivision/Index/Key/NoMethod (T5)

### DIFF
--- a/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
@@ -1,5 +1,75 @@
 # Changelog
 
+## 0.12.0 — typed runtime errors: ZeroDivision / Index / Key / NoMethod (T5)
+
+Implements the Rust milestone (**T5**) of the **sir-typed-runtime-errors**
+cascade. A translated `begin/rescue <Class>` that rescues a *runtime* fault —
+`ZeroDivisionError`, `IndexError`, `KeyError`, `NoMethodError` — must now catch
+it, matching Ruby (and the other four backends). Previously these faults were
+either an uncatchable host `panic!` (division by zero) or a silent `nil` floor
+(unknown method), so `rescue ZeroDivisionError` / `rescue NoMethodError` missed
+them entirely. This is a **runtime-only** change (no core semantic-IR, no
+frontend change): the faulting operations now raise the correct typed
+`SirError` via the existing `raise` entry point (`panic_any(SirError{…})`), so
+the existing `catch_unwind` + `rescue_matches` ancestry machinery dispatches
+them to the right clause.
+
+The typed-raise is explicit-string (a fixed class name + a data-only message);
+there is no reflection over runtime type names — the same C3-allowlist
+discipline the dispatch catalog already upholds. Genuine **non-`SirError` host
+faults** (a real codegen/translator bug — an `unwrap` on `None`, an internal
+`panic!`) are still **re-raised uncaught** by `exc_from_payload`
+(`resume_unwind`), never swallowed by a bare `rescue`: only a value a `raise`
+produced can ever be caught.
+
+### Precise Ruby semantics (load-bearing — no over-raise)
+
+| operation (Ruby)        | before                     | after (T5)                       |
+|-------------------------|----------------------------|----------------------------------|
+| `1 / 0`, `1.0 / 0`      | `panic!` (uncatchable)     | `ZeroDivisionError` ("divided by 0") |
+| `arr.fetch(oob)`        | (no `fetch`)               | `IndexError`                     |
+| `hash.fetch(miss)`      | (no `fetch`)               | `KeyError`                       |
+| `arr.fetch(i, default)` | —                          | returns `default` (no raise)     |
+| `obj.undefined`         | silent `nil` floor         | `NoMethodError` (`undefined method 'x' for <Class>`) |
+| `arr[oob]`, `hash[miss]`| `nil` (arr[] via floor)    | `nil` (unchanged — explicit `[]` arm) |
+
+### Changed (all in the inlined `RUNTIME` string, `runtime.rs`)
+
+- **`divide`.** A zero divisor on the int path OR the float path now raises a
+  typed `ZeroDivisionError` (was an int-only uncatchable `panic!`; the float
+  path previously returned IEEE `inf`). Ruby raises for both `1/0` and `1.0/0`.
+- **`array_method`.** Added `Array#fetch` (strict indexed read — `IndexError`
+  out of bounds, honours a negative index and a supplied default) and
+  `Array#[]` (lenient read — `nil` out of bounds, so `arr[i]` never reaches the
+  new `NoMethodError` floor).
+- **`map_method`.** Added `Hash#fetch` (strict keyed read — `KeyError` on a
+  missing key, or a supplied default) and `Hash#[]` (lenient — `nil` on miss).
+- **Unknown-method floor split into two helpers.** `unknown_method` remains the
+  `nil` floor for a KNOWN method used block-less (`map`/`select`/`reduce`
+  without a block — Ruby returns an `Enumerator`, we floor to `nil`) and for the
+  defensive receiver-type guards. A new `no_method_error` raises a typed
+  `NoMethodError` for a genuinely unknown method name; a new `ruby_class_name`
+  renders the receiver's Ruby class for the message (parity port of the Go
+  backend's `_sir_ruby_class_name`). The true catalog fall-throughs
+  (Array/Map/String/Numeric/Symbol `_` arms, `call_method`'s Bool/default arms,
+  and `dispatch_user_method`'s unresolved-instance-method arm) now raise via
+  `no_method_error`.
+
+### Tests
+
+- New exec-proof integration test `compile_and_run_typed_runtime_errors.rs`:
+  builds SIR, emits Rust, compiles with `rustc`, runs, and asserts a
+  `begin/rescue` catches `1/0`→`ZeroDivisionError`, `1.0/0`→`ZeroDivisionError`,
+  `arr.fetch(oob)`→`IndexError`, `hash.fetch(miss)`→`KeyError`,
+  `obj.undefined`→`NoMethodError` (and its superclass `NameError`), that
+  `fetch` with a default does not raise, and that `arr[oob]` / `hash[miss]`
+  still return `nil` (no over-raise).
+- Updated `compile_and_run_collection_methods.rs` (the `[1].bogus_xyz` case
+  moved to the new test — it now raises rather than flooring to `nil`) and
+  `compile_and_run_oop.rs` (the security "`drop` is inert data" and cyclic-
+  ancestry-terminates cases now `rescue NoMethodError` and prove the surfaced
+  typed error is CONTROLLED — never a host `Drop`/reflection, never a hang).
+
 ## 0.11.0 — polymorphic `+` / `*` for strings and arrays (PO5)
 
 Implements the Rust milestone of the **sir-polymorphic-operators** cascade.

--- a/code/packages/rust/semantic-ir-to-rust/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-rust"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 description = "Semantic IR → self-contained Rust source code (SIR13). Second backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-rust/README.md
+++ b/code/packages/rust/semantic-ir-to-rust/README.md
@@ -150,10 +150,15 @@ rather than panicking:
     `zero?`, `times`; plus a universal `to_s`.
   - Block-taking methods apply the trailing closure via `apply_closure`;
     `sym_to_proc` implements `Symbol#to_proc` (`&:sym`).
+  - **Strict vs. lenient reads** — `Array#[]` / `Hash#[]` are lenient (out of
+    bounds / missing key ⇒ `nil`, Ruby parity), while `Array#fetch` /
+    `Hash#fetch` are strict (raise `IndexError` / `KeyError`, or return a
+    supplied default).
 - **Security** — the catalog *is* the allowlist.  Dispatch is the explicit
-  match only; an unknown method name returns a controlled Ruby `nil`
-  (`unknown_method`), never a reflective lookup on the raw name.  No new
-  `unsafe`.
+  match only; a genuinely unknown method name raises a controlled, typed
+  `NoMethodError` (`no_method_error`, carrying only the data name string),
+  never a reflective lookup on the raw name.  (A KNOWN method used block-less
+  still floors to Ruby `nil` via `unknown_method`.)  No new `unsafe`.
 
 Executes (E4): **exception handling**.  `Feature::Exceptions` (Ruby
 `begin/rescue/ensure`, `raise`) is accepted.  Rust has **no native
@@ -227,8 +232,9 @@ lowers OOP to a small family of builtins the backend routes to the inline
   `Exceptions`.
 - **Security** — every method/class lookup is an EXPLICIT `HashMap::get` on
   a `(class, method)` key — never reflection or `dyn Any`-by-name.  A
-  class/method literally named `constructor`/`new`/`drop` is inert data; a
-  miss floors to the honest `Nil`/NoMethodError boundary.  The ancestry walk
+  class/method literally named `constructor`/`new`/`drop` is inert data; an
+  unresolved instance method surfaces a controlled, typed `NoMethodError`
+  (never a host callable).  The ancestry walk
   carries a `seen`-set **cycle guard** (a cyclic `A < B < A` hierarchy
   terminates).  Widening `Classes`/`Constants` acceptance stays sound:
   `reject_stateful_class` still rejects a class/module with an executable

--- a/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
@@ -410,12 +410,19 @@ pub const RUNTIME: &str = r##"mod __sir {
             return Value::Int(0);
         }
         if any_float(&args) {
-            // Float division follows IEEE-754: `1.0 / 0.0` is `inf`
-            // rather than a panic.  Only the all-integer path keeps the
-            // historical divide-by-zero panic.
+            // Ruby raises `ZeroDivisionError` for `/` by zero on BOTH int
+            // and float operands (`1/0` and `1.0/0` both raise — Ruby does
+            // NOT hand back IEEE `inf` here, unlike a bare host `f64` `/`).
+            // We surface it as a typed `SirError` (via `raise`) so a
+            // translated `rescue ZeroDivisionError` matches it, rather than
+            // producing an uncatchable host `panic!` or a silent `inf`.
             let mut acc = as_f64(&args[0]);
             for a in &args[1..] {
-                acc /= as_f64(a);
+                let d = as_f64(a);
+                if d == 0.0 {
+                    raise("ZeroDivisionError", Value::Str(Rc::from("divided by 0")));
+                }
+                acc /= d;
             }
             return Value::Float(acc);
         }
@@ -423,7 +430,9 @@ pub const RUNTIME: &str = r##"mod __sir {
         for a in &args[1..] {
             let d = as_i64(a);
             if d == 0 {
-                panic!("division by zero");
+                // Typed `ZeroDivisionError` (was an uncatchable `panic!`)
+                // so `rescue ZeroDivisionError` catches it — Ruby parity.
+                raise("ZeroDivisionError", Value::Str(Rc::from("divided by 0")));
             }
             acc /= d;
         }
@@ -1109,9 +1118,10 @@ pub const RUNTIME: &str = r##"mod __sir {
     // reachable method is written out by hand below.  There is NO
     // reflective / dynamic lookup that could turn an attacker-controlled
     // method name into arbitrary behaviour: a name we do not enumerate
-    // simply falls through to `unknown_method`, which returns a controlled
-    // error value (Ruby `nil`, matching the Python reference's honest
-    // floor) — never an out-of-catalog effect.  This mirrors the C3 RCE
+    // simply falls through to `no_method_error`, which raises a typed
+    // `NoMethodError` carrying only the (data) name string — never an
+    // out-of-catalog effect.  (A KNOWN method used block-less floors to
+    // `unknown_method`'s `nil` instead — see those helpers.)  This mirrors the C3 RCE
     // lesson: the allowlist is the whole security boundary, so it must be
     // a closed, hand-written set, never a table keyed by the raw name.
     //
@@ -1149,13 +1159,59 @@ pub const RUNTIME: &str = r##"mod __sir {
         }
     }
 
-    // The honest "not in the catalog for this receiver" floor.  Ruby would
-    // raise `NoMethodError`; the reference runtimes instead return `nil`
-    // (the never-raise-on-the-OO-surface invariant).  We match that — a
-    // *controlled* value, never undefined behaviour — but keep the name in
-    // one place so the intent (and the security boundary) is explicit.
+    // The `nil` floor for a KNOWN method used in a shape Ruby tolerates
+    // without a value — e.g. a block-taking method (`map`, `select`,
+    // `reduce`) called WITHOUT its block.  Ruby returns an `Enumerator`
+    // there; SIR v0 has no `Enumerator`, so we floor to `nil` (a controlled
+    // value, never undefined behaviour) rather than raising.  This is
+    // distinct from `no_method_error` below: a name that is genuinely NOT
+    // in the catalog is a Ruby `NoMethodError`, but a block-less `map` is
+    // not an *unknown* method.  Also used for the defensive receiver-type
+    // guards at each catalog's entry, which are unreachable in practice
+    // (dispatch already routed by type).
     fn unknown_method(_recv: &Value, _name: &str) -> Value {
         Value::Nil
+    }
+
+    // The conventional Ruby class name of a value — for a `NoMethodError`
+    // message and nothing else.  A closed match (never reflection on a
+    // host type name), a verbatim parity port of the Go backend's
+    // `_sir_ruby_class_name`.  A user instance reports its own class tag so
+    // `obj.undefined` names the real class (e.g. `Dog`).
+    fn ruby_class_name(v: &Value) -> String {
+        match v {
+            Value::Nil => "NilClass".to_string(),
+            Value::Bool(true) => "TrueClass".to_string(),
+            Value::Bool(false) => "FalseClass".to_string(),
+            Value::Int(_) => "Integer".to_string(),
+            Value::Float(_) => "Float".to_string(),
+            Value::Str(_) => "String".to_string(),
+            Value::Sym(_) => "Symbol".to_string(),
+            Value::Seq(_) => "Array".to_string(),
+            Value::Map(_) => "Hash".to_string(),
+            Value::Pair(_) => "Pair".to_string(),
+            Value::Closure(_) => "Proc".to_string(),
+            Value::Instance(id) => instance_class(*id),
+            Value::Missing => "Object".to_string(),
+        }
+    }
+
+    // The honest "no such method" boundary: a name genuinely absent from
+    // the receiver's catalog (or an instance's method table) is a Ruby
+    // `NoMethodError`.  We surface a typed `SirError` (via `raise`) with the
+    // Ruby-shaped message `undefined method 'x' for <Class>`, so a
+    // translated `rescue NoMethodError` (or `rescue NameError`, its
+    // superclass) catches it — replacing the old silent `nil` floor for a
+    // truly-unknown method.  Resolution stays a closed match on the name
+    // (never a reflective host lookup — the C3 allowlist discipline), so
+    // this only ever fires for a name no catalog arm claimed.
+    fn no_method_error(recv: &Value, name: &str) -> ! {
+        raise(
+            "NoMethodError",
+            Value::Str(Rc::from(
+                format!("undefined method '{}' for {}", name, ruby_class_name(recv)).as_str(),
+            )),
+        )
     }
 
     /// Dispatch collection method `name` on `recv`.
@@ -1201,9 +1257,9 @@ pub const RUNTIME: &str = r##"mod __sir {
             // `bool` is checked before the numeric arm on purpose: a Ruby
             // `true`/`false` is not a Numeric, so it never resolves the
             // numeric catalog.
-            Value::Bool(_) => unknown_method(&recv, name),
+            Value::Bool(_) => no_method_error(&recv, name),
             Value::Int(_) | Value::Float(_) => numeric_method(recv, name, args),
-            _ => unknown_method(&recv, name),
+            _ => no_method_error(&recv, name),
         }
     }
 
@@ -1223,6 +1279,23 @@ pub const RUNTIME: &str = r##"mod __sir {
             "length" | "size" => Value::Int(items_rc.borrow().len() as i64),
             "first" => items_rc.borrow().first().cloned().unwrap_or(Value::Nil),
             "last" => items_rc.borrow().last().cloned().unwrap_or(Value::Nil),
+            // `Array#[]` — the LENIENT indexed read (the OO-surface `arr[i]`,
+            // as opposed to the strict SIR-native `SeqIndex` primitive).  Ruby
+            // returns `nil` for an out-of-bounds index (it does NOT raise —
+            // that is `fetch`'s job), and folds a negative index from the end.
+            // This arm keeps `arr[oob] ⇒ nil` from falling through to the
+            // `no_method_error` floor.
+            "[]" => {
+                let items = items_rc.borrow();
+                let len = items.len() as i64;
+                let raw = as_i64(pos.first().unwrap_or(&Value::Nil));
+                let idx = if raw < 0 { raw + len } else { raw };
+                if idx >= 0 && idx < len {
+                    items[idx as usize].clone()
+                } else {
+                    Value::Nil
+                }
+            }
             "reverse" => {
                 let mut v = items_rc.borrow().clone();
                 v.reverse();
@@ -1262,6 +1335,33 @@ pub const RUNTIME: &str = r##"mod __sir {
                 recv
             }
             "pop" => items_rc.borrow_mut().pop().unwrap_or(Value::Nil),
+            // `Array#fetch(i)` is the STRICT indexed read: unlike `arr[i]`
+            // (which returns `nil` out of bounds), a `fetch` past the end
+            // (or a negative index past the front) raises `IndexError` in
+            // Ruby.  We surface a typed `SirError` so `rescue IndexError`
+            // matches.  A supplied default arg (`fetch(i, default)`) is
+            // returned instead of raising, matching Ruby.
+            "fetch" => {
+                let items = items_rc.borrow();
+                let len = items.len() as i64;
+                let raw = as_i64(pos.first().unwrap_or(&Value::Nil));
+                // Ruby folds a negative index from the end (`-1` ⇒ last).
+                let idx = if raw < 0 { raw + len } else { raw };
+                if idx >= 0 && idx < len {
+                    items[idx as usize].clone()
+                } else if let Some(default) = pos.get(1) {
+                    default.clone()
+                } else {
+                    drop(items);
+                    raise(
+                        "IndexError",
+                        Value::Str(Rc::from(
+                            format!("index {} outside of array bounds: {}...{}", raw, -len, len)
+                                .as_str(),
+                        )),
+                    );
+                }
+            }
             // ── block-taking Array methods ────────────────────────
             "each" => {
                 if let Some(b) = &block {
@@ -1364,7 +1464,7 @@ pub const RUNTIME: &str = r##"mod __sir {
                 }
                 acc
             }
-            _ => unknown_method(&recv, name),
+            _ => no_method_error(&recv, name),
         }
     }
 
@@ -1382,10 +1482,48 @@ pub const RUNTIME: &str = r##"mod __sir {
         match name {
             "keys" => seq_lit(entries_rc.borrow().iter().map(|(k, _)| k.clone()).collect()),
             "values" => seq_lit(entries_rc.borrow().iter().map(|(_, v)| v.clone()).collect()),
+            // `Hash#[]` — the LENIENT keyed read (the OO-surface `hash[k]`,
+            // as opposed to the SIR-native `MapGet`).  Ruby returns `nil` for a
+            // missing key (never raises — that is `fetch`'s job).  Keeps
+            // `hash[miss] ⇒ nil` from reaching the `no_method_error` floor.
+            "[]" => {
+                let needle = pos.first().cloned().unwrap_or(Value::Nil);
+                entries_rc
+                    .borrow()
+                    .iter()
+                    .find(|(k, _)| value_eq(k, &needle))
+                    .map(|(_, v)| v.clone())
+                    .unwrap_or(Value::Nil)
+            }
             "size" | "length" => Value::Int(entries_rc.borrow().len() as i64),
             "has_key?" | "key?" | "include?" | "member?" => {
                 let needle = pos.first().cloned().unwrap_or(Value::Nil);
                 Value::Bool(entries_rc.borrow().iter().any(|(k, _)| value_eq(k, &needle)))
+            }
+            // `Hash#fetch(k)` is the STRICT keyed read: unlike `hash[k]`
+            // (which returns `nil` for a missing key), a `fetch` of an
+            // absent key raises `KeyError` in Ruby.  We surface a typed
+            // `SirError` so `rescue KeyError` matches.  A supplied default
+            // arg (`fetch(k, default)`) is returned instead of raising.
+            "fetch" => {
+                let needle = pos.first().cloned().unwrap_or(Value::Nil);
+                let hit = entries_rc
+                    .borrow()
+                    .iter()
+                    .find(|(k, _)| value_eq(k, &needle))
+                    .map(|(_, v)| v.clone());
+                match hit {
+                    Some(v) => v,
+                    None => match pos.get(1) {
+                        Some(default) => default.clone(),
+                        None => raise(
+                            "KeyError",
+                            Value::Str(Rc::from(
+                                format!("key not found: {}", format(&needle)).as_str(),
+                            )),
+                        ),
+                    },
+                }
             }
             "each" | "each_pair" => {
                 if let Some(b) = &block {
@@ -1418,7 +1556,7 @@ pub const RUNTIME: &str = r##"mod __sir {
                 }
                 None => unknown_method(&recv, name),
             },
-            _ => unknown_method(&recv, name),
+            _ => no_method_error(&recv, name),
         }
     }
 
@@ -1453,7 +1591,7 @@ pub const RUNTIME: &str = r##"mod __sir {
                 };
                 seq_lit(parts)
             }
-            _ => unknown_method(&recv, name),
+            _ => no_method_error(&recv, name),
         }
     }
 
@@ -1484,7 +1622,7 @@ pub const RUNTIME: &str = r##"mod __sir {
                 let _ = pos;
                 recv
             }
-            _ => unknown_method(&recv, name),
+            _ => no_method_error(&recv, name),
         }
     }
 
@@ -1520,7 +1658,7 @@ pub const RUNTIME: &str = r##"mod __sir {
             "length" | "size" => Value::Int(s.chars().count() as i64),
             "upcase" => intern(&s.to_uppercase()),
             "downcase" => intern(&s.to_lowercase()),
-            _ => unknown_method(&recv, name),
+            _ => no_method_error(&recv, name),
         }
     }
 
@@ -1989,7 +2127,10 @@ pub const RUNTIME: &str = r##"mod __sir {
         };
         match resolve_method(&METHOD_TABLE, Some(class), name) {
             Some(f) => apply_with_self(&f, recv.clone(), args),
-            None => unknown_method(recv, name),
+            // An instance method genuinely absent from the class's table
+            // (and all ancestors) is a Ruby `NoMethodError` — surface it
+            // typed so `rescue NoMethodError` catches it.
+            None => no_method_error(recv, name),
         }
     }
 

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_collection_methods.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_collection_methods.rs
@@ -19,7 +19,10 @@
 //!   * `[1,2,3].length`                     → `3`
 //!   * `[1,2,3].reduce(0) { |a,x| a+x }`    → `6`  (and `.inject` too)
 //!   * `[1,2,3].map(&:to_s).join(",")`      → `"1,2,3"`  (`Symbol#to_proc`)
-//!   * `[1].bogus_xyz`                       → `nil`  (unknown ⇒ clean floor)
+//!
+//! (An *unknown* method now raises a typed `NoMethodError` rather than
+//! flooring to `nil` — cascade `sir-typed-runtime-errors`, T5 — so that case
+//! moved to `compile_and_run_typed_runtime_errors.rs`, which catches it.)
 //!
 //! `StrLit` interpolation is not accepted by the Rust backend, so — like
 //! the other Rust exec-proof tests — assertions are on numeric / array /
@@ -201,8 +204,13 @@ fn full_demo() -> Module {
         print_stmt(method(slit("hello"), "upcase", vec![])),
         // 8. [3,1,2].sort  → [1, 2, 3]
         print_stmt(method(seq(vec![ilit(3), ilit(1), ilit(2)]), "sort", vec![])),
-        // 9. [1].bogus_xyz  → nil  (unknown method ⇒ clean nil floor, no panic)
-        print_stmt(method(seq(vec![ilit(1)]), "bogus_xyz", vec![])),
+        // (An unknown method — `[1].bogus_xyz` — now raises a *typed*
+        //  `NoMethodError` rather than flooring to `nil` (cascade
+        //  `sir-typed-runtime-errors`, T5).  That surfaced boundary is proved
+        //  end-to-end in `compile_and_run_typed_runtime_errors.rs`, which
+        //  wraps it in `begin/rescue NoMethodError`; here we only exercise the
+        //  *resolvable* catalog, so the closed dispatch stays observable
+        //  without aborting this program.)
     ];
 
     demo_module(main_stmts, block_fns)
@@ -283,7 +291,6 @@ fn collection_methods_compile_and_run() {
             "1,2,3",     // map(&:to_s).join(",")
             "HELLO",     // "hello".upcase
             "[1, 2, 3]", // sort
-            "nil",       // bogus_xyz ⇒ clean nil floor
         ],
         "unexpected program output; full stdout:\n{stdout}"
     );

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_oop.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_oop.rs
@@ -33,8 +33,8 @@
 use std::process::Command;
 
 use semantic_ir::{
-    Block, Effect, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, Scope,
-    Span, Stmt,
+    Block, Effect, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module,
+    RescueClause, Scope, Span, Stmt,
 };
 use semantic_ir_to_rust::compile;
 
@@ -168,6 +168,24 @@ fn class_def(name: &str, superclass: Option<&str>) -> Stmt {
         name: name.into(),
         superclass: superclass.map(|s| s.to_string()),
         body: vec![],
+        span: s(),
+    }
+}
+
+/// `begin <fault>; rescue <class>; <on_catch> end` — used to prove a runtime
+/// fault surfaces as a CATCHABLE typed exception (T5 typed-runtime-errors:
+/// an unresolved instance method now raises `NoMethodError` rather than
+/// flooring to `nil`).
+fn begin_rescue(fault: Stmt, class: &str, on_catch: Vec<Stmt>) -> Stmt {
+    Stmt::TryCatch {
+        body: vec![fault],
+        rescues: vec![RescueClause {
+            exception_types: vec![class.to_string()],
+            binding: None,
+            body: on_catch,
+            span: s(),
+        }],
+        ensure_body: None,
         span: s(),
     }
 }
@@ -324,8 +342,10 @@ fn p2_inheritance_and_super() {
 /// instance.  Two guarantees: (1) the `constructor`-named class + its
 /// methods work purely as map data (`get` returns the ivar marker `7`),
 /// never reaching a host callable; (2) calling an unregistered method
-/// (`drop`) floors cleanly to `nil` (never a host `Drop`/reflection), and
-/// the process still exits 0.  Prints `7` then `nil`.
+/// (`drop`) surfaces a CONTROLLED typed `NoMethodError` (never a host
+/// `Drop`/reflection) — T5 makes the old silent `nil` floor a catchable
+/// error, so we `rescue NoMethodError` and print `8`, and the process still
+/// exits 0.  Prints `7` then `8`.
 #[test]
 fn security_reflective_name_is_inert_data() {
     if !rustc_available() {
@@ -347,10 +367,15 @@ fn security_reflective_name_is_inert_data() {
         def_method_stmt("constructor", "get", "ctor_get"),
         // The class name (Const-like) is passed as a string; `get` works.
         print_stmt(method_call(call("__new__", vec![slit("constructor")]), "get", vec![])),
-        // An UNREGISTERED method name (`drop`) → clean nil floor, no host call.
-        print_stmt(method_call(call("__new__", vec![slit("constructor")]), "drop", vec![])),
+        // An UNREGISTERED method name (`drop`) → a CONTROLLED, catchable
+        // `NoMethodError` (never a host `Drop`/reflection).  Caught → print 8.
+        begin_rescue(
+            print_stmt(method_call(call("__new__", vec![slit("constructor")]), "drop", vec![])),
+            "NoMethodError",
+            vec![print_stmt(ilit(8))],
+        ),
     ];
-    let m = oop_module(vec![init, get], main, &[]);
+    let m = oop_module(vec![init, get], main, &[Feature::Exceptions]);
     let src = compile(&m).expect("compile security").source;
     // The emitted runtime must never turn a source name into a host call:
     // no `recv.name`-style reflection appears — dispatch is HashMap-keyed.
@@ -360,16 +385,17 @@ fn security_reflective_name_is_inert_data() {
     );
     let Some((stdout, ok)) = compile_and_run(&src, "security") else { return };
     assert!(ok, "security process should exit 0; stdout {stdout:?}");
-    assert_eq!(stdout.lines().collect::<Vec<_>>(), vec!["7", "nil"], "got {stdout:?}");
+    assert_eq!(stdout.lines().collect::<Vec<_>>(), vec!["7", "8"], "got {stdout:?}");
 }
 
 /// Cyclic ancestry must TERMINATE (not hang) and floor to `nil`.
 ///
 /// We register `class A < B` and `class B < A` (a cycle), define NO method
 /// named `missing`, then call `A.new.missing`.  `resolve_method`'s `seen`
-/// guard bounds the ancestry walk, so the call returns `nil` and the program
-/// exits — proving the walk cannot loop forever on a malformed hierarchy.
-/// Prints `nil`.
+/// guard bounds the ancestry walk, so the walk TERMINATES (rather than
+/// looping forever) with the method unresolved — which T5 surfaces as a
+/// catchable `NoMethodError`.  We `rescue NoMethodError` and print `3`,
+/// proving the walk cannot hang on a malformed hierarchy.  Prints `3`.
 #[test]
 fn cyclic_ancestry_terminates() {
     if !rustc_available() {
@@ -379,13 +405,17 @@ fn cyclic_ancestry_terminates() {
     let main = vec![
         class_def("A", Some("B")),
         class_def("B", Some("A")),
-        print_stmt(method_call(call("__new__", vec![slit("A")]), "missing", vec![])),
+        begin_rescue(
+            print_stmt(method_call(call("__new__", vec![slit("A")]), "missing", vec![])),
+            "NoMethodError",
+            vec![print_stmt(ilit(3))],
+        ),
     ];
-    let m = oop_module(vec![], main, &[]);
+    let m = oop_module(vec![], main, &[Feature::Exceptions]);
     let src = compile(&m).expect("compile cyclic").source;
     let Some((stdout, ok)) = compile_and_run(&src, "cyclic") else { return };
     assert!(ok, "cyclic-ancestry process should exit 0 (walk terminates); stdout {stdout:?}");
-    assert_eq!(stdout.lines().collect::<Vec<_>>(), vec!["nil"], "got {stdout:?}");
+    assert_eq!(stdout.lines().collect::<Vec<_>>(), vec!["3"], "got {stdout:?}");
 }
 
 /// The self-stack pops even when a method body panics (RAII guard).  We can

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_typed_runtime_errors.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_typed_runtime_errors.rs
@@ -1,0 +1,312 @@
+//! End-to-end proof for the **T5 typed runtime errors** in the Rust backend
+//! (cascade `sir-typed-runtime-errors`).
+//!
+//! Ruby raises a *typed* exception for four high-frequency runtime faults, and
+//! a translated `begin/rescue <Class>` must catch the matching one:
+//!
+//!   * `1 / 0` (and `1.0 / 0`)   → `ZeroDivisionError`
+//!   * `arr.fetch(oob)`          → `IndexError`
+//!   * `hash.fetch(missing)`     → `KeyError`
+//!   * `obj.undefined_method`    → `NoMethodError`
+//!
+//! …while the LENIENT index reads still return `nil` and must NOT raise:
+//!
+//!   * `arr[oob]`                → `nil`
+//!   * `hash[missing]`           → `nil`
+//!
+//! Before T5 these faults were an uncatchable host `panic!` (division) or a
+//! silent `nil` floor (unknown method).  The Rust backend now surfaces each as
+//! a typed `SirError` (`panic_any(SirError{ class, msg })`), so the existing
+//! `catch_unwind` + `rescue_matches` machinery dispatches it to the right
+//! `rescue` clause.
+//!
+//! Like the sibling exec-proof tests, we hand-build SIR modules, emit Rust,
+//! compile with `rustc`, run the binary, and assert on the integer markers the
+//! `print` path renders.  A missing `rustc`/linker is a *skip*, never a
+//! failure; the host points us at a working linker via `SIR_TEST_RUSTC_LINKER`.
+
+use std::process::Command;
+
+use semantic_ir::nodes::MapEntry;
+use semantic_ir::{
+    Block, Effect, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module,
+    RescueClause, Span, Stmt,
+};
+use semantic_ir_to_rust::compile;
+
+fn s() -> Span {
+    Span::synthetic()
+}
+
+fn ilit(v: i64) -> Expr {
+    Expr::IntLit { value: v, span: s() }
+}
+
+fn flit(v: f64) -> Expr {
+    Expr::FloatLit { value: v, span: s() }
+}
+
+fn slit(v: &str) -> Expr {
+    Expr::StrLit { value: v.into(), span: s() }
+}
+
+fn call(name: &str, args: Vec<Expr>, eff: EffectSet) -> Expr {
+    Expr::BuiltinCall { name: name.into(), args, effects: eff, span: s() }
+}
+
+/// `recv.meth(args…)` — the `__method__` dispatch envelope.
+fn method(recv: Expr, name: &str, mut args: Vec<Expr>) -> Expr {
+    let mut all = vec![recv, slit(name)];
+    all.append(&mut args);
+    call("__method__", all, EffectSet::PURE)
+}
+
+fn seq(items: Vec<Expr>) -> Expr {
+    Expr::SeqLit { items, span: s() }
+}
+
+fn map_lit(entries: Vec<(Expr, Expr)>) -> Expr {
+    Expr::MapLit {
+        entries: entries.into_iter().map(|(key, value)| MapEntry { key, value }).collect(),
+        span: s(),
+    }
+}
+
+fn map_get(m: Expr, k: Expr) -> Expr {
+    Expr::MapGet { map: Box::new(m), key: Box::new(k), span: s() }
+}
+
+fn print_stmt(e: Expr) -> Stmt {
+    Stmt::ExprStmt {
+        expr: call("print", vec![e], EffectSet::PURE.with(Effect::MayPrint)),
+        span: s(),
+    }
+}
+
+fn rescue(types: &[&str], binding: Option<&str>, body: Vec<Stmt>) -> RescueClause {
+    RescueClause {
+        exception_types: types.iter().map(|t| (*t).to_string()).collect(),
+        binding: binding.map(|b| b.to_string()),
+        body,
+        span: s(),
+    }
+}
+
+/// Assemble a single-`main` module from a body of statements.  `Sequences`,
+/// `Maps`, and `Closures` features are always on so the collection catalog and
+/// the `__method__` envelope are available.
+fn module_from_main(stmts: Vec<Stmt>, extra: &[Feature]) -> Module {
+    let main_fn = Function {
+        name: "main".into(),
+        params: vec![],
+        return_type: None,
+        captures: vec![],
+        body: Block { stmts, value: Expr::NilLit { span: s() }, span: s() },
+        effects: EffectSet::PURE.with(Effect::MayPrint),
+        metadata: Metadata::new(),
+        span: s(),
+    };
+    let mut feats = vec![
+        Feature::Exceptions,
+        Feature::Strings,
+        Feature::Sequences,
+        Feature::Maps,
+        Feature::Closures,
+        Feature::Floats,
+    ];
+    feats.extend_from_slice(extra);
+    Module {
+        name: "typed_rt_err_demo".into(),
+        manifest: FeatureManifest::from_features(&feats),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![main_fn],
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("test")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+fn rustc_available() -> bool {
+    Command::new("rustc")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Compile emitted Rust and run it, returning `(stdout, exit_success)`.
+/// `None` = the host has no usable linker (a skip, never a failure).
+fn compile_and_run(source: &str, tag: &str) -> Option<(String, bool)> {
+    let dir = std::env::temp_dir();
+    let nonce = format!("{}_{}", std::process::id(), tag);
+    let src_path = dir.join(format!("sir_rterr_{nonce}.rs"));
+    let bin_path =
+        dir.join(format!("sir_rterr_{nonce}{}", if cfg!(windows) { ".exe" } else { "" }));
+    std::fs::write(&src_path, source).expect("write temp source");
+
+    let mut cmd = Command::new("rustc");
+    cmd.arg("--edition").arg("2021").arg("-O");
+    if let Ok(linker) = std::env::var("SIR_TEST_RUSTC_LINKER") {
+        if !linker.is_empty() {
+            cmd.arg("-C").arg(format!("linker={linker}"));
+        }
+    }
+    let compile_out = cmd
+        .arg(&src_path)
+        .arg("-o")
+        .arg(&bin_path)
+        .output()
+        .expect("invoke rustc");
+    if !compile_out.status.success() {
+        let stderr = String::from_utf8_lossy(&compile_out.stderr);
+        if stderr.contains("linker") && (stderr.contains("not found") || stderr.contains("No such file")) {
+            eprintln!("skipping: no usable linker on host\n{stderr}");
+            let _ = std::fs::remove_file(&src_path);
+            return None;
+        }
+        panic!("emitted Rust failed to compile:\n--- stderr ---\n{stderr}\n--- source ---\n{source}");
+    }
+
+    let run_out = Command::new(&bin_path).output().expect("run compiled binary");
+    let stdout = String::from_utf8_lossy(&run_out.stdout).to_string();
+    let ok = run_out.status.success();
+    let _ = std::fs::remove_file(&src_path);
+    let _ = std::fs::remove_file(&bin_path);
+    Some((stdout, ok))
+}
+
+/// Wrap a single faulting expression in `begin <fault>; rescue <class> => e;
+/// print(marker); end`, compile+run, and assert the process exits 0 (the
+/// exception was CAUGHT) printing only the marker (the fault line never runs
+/// to completion, so it prints nothing).
+fn assert_typed_rescue_catches(fault: Expr, rescue_class: &str, marker: i64, tag: &str) {
+    let tc = Stmt::TryCatch {
+        // The fault sits inside a `print`, so if it did NOT raise we'd see its
+        // (wrong) value on stdout — but it must raise before printing.
+        body: vec![print_stmt(fault)],
+        rescues: vec![rescue(&[rescue_class], Some("e"), vec![print_stmt(ilit(marker))])],
+        ensure_body: None,
+        span: s(),
+    };
+    let src = compile(&module_from_main(vec![tc], &[])).expect("compile").source;
+    let Some((stdout, ok)) = compile_and_run(&src, tag) else { return };
+    assert!(ok, "[{tag}] process should exit 0 (exception caught); stdout={stdout:?}");
+    assert_eq!(
+        stdout.lines().collect::<Vec<_>>(),
+        vec![marker.to_string()],
+        "[{tag}] expected only the rescue marker {marker}; got {stdout:?}"
+    );
+}
+
+/// `1 / 0` raises `ZeroDivisionError` (int path) → caught → prints `1`.
+#[test]
+fn int_divide_by_zero_raises_zero_division_error() {
+    if !rustc_available() {
+        eprintln!("skipping: rustc not on PATH");
+        return;
+    }
+    let fault = call("/", vec![ilit(1), ilit(0)], EffectSet::PURE);
+    assert_typed_rescue_catches(fault, "ZeroDivisionError", 1, "int_div0");
+}
+
+/// `1.0 / 0` raises `ZeroDivisionError` (float path — Ruby raises here too,
+/// it does NOT hand back `inf`) → caught → prints `2`.
+#[test]
+fn float_divide_by_zero_raises_zero_division_error() {
+    if !rustc_available() {
+        eprintln!("skipping: rustc not on PATH");
+        return;
+    }
+    let fault = call("/", vec![flit(1.0), ilit(0)], EffectSet::PURE);
+    assert_typed_rescue_catches(fault, "ZeroDivisionError", 2, "float_div0");
+}
+
+/// `[10, 20].fetch(5)` (out of bounds) raises `IndexError` → caught → `3`.
+#[test]
+fn array_fetch_oob_raises_index_error() {
+    if !rustc_available() {
+        eprintln!("skipping: rustc not on PATH");
+        return;
+    }
+    let fault = method(seq(vec![ilit(10), ilit(20)]), "fetch", vec![ilit(5)]);
+    assert_typed_rescue_catches(fault, "IndexError", 3, "arr_fetch_oob");
+}
+
+/// `{"a" => 1}.fetch("z")` (missing key) raises `KeyError` → caught → `4`.
+#[test]
+fn hash_fetch_missing_raises_key_error() {
+    if !rustc_available() {
+        eprintln!("skipping: rustc not on PATH");
+        return;
+    }
+    let fault = method(map_lit(vec![(slit("a"), ilit(1))]), "fetch", vec![slit("z")]);
+    assert_typed_rescue_catches(fault, "KeyError", 4, "hash_fetch_miss");
+}
+
+/// `[1].undefined_method` raises `NoMethodError` → caught → `6`.
+#[test]
+fn unknown_method_raises_no_method_error() {
+    if !rustc_available() {
+        eprintln!("skipping: rustc not on PATH");
+        return;
+    }
+    let fault = method(seq(vec![ilit(1)]), "undefined_method", vec![]);
+    assert_typed_rescue_catches(fault, "NoMethodError", 6, "no_method");
+}
+
+/// `NoMethodError` also matches its superclass `NameError` (ancestry) → `7`.
+#[test]
+fn no_method_error_matches_name_error_ancestor() {
+    if !rustc_available() {
+        eprintln!("skipping: rustc not on PATH");
+        return;
+    }
+    let fault = method(ilit(42), "not_a_real_method", vec![]);
+    assert_typed_rescue_catches(fault, "NameError", 7, "no_method_ancestor");
+}
+
+/// The LENIENT reads do NOT raise: `arr[oob]` and `hash[miss]` both yield
+/// `nil`.  Program prints `nil` twice and exits 0 — proving no over-raise.
+#[test]
+fn lenient_index_reads_return_nil_no_overraise() {
+    if !rustc_available() {
+        eprintln!("skipping: rustc not on PATH");
+        return;
+    }
+    let stmts = vec![
+        // arr[oob] via the OO-surface `[]` method → nil (NOT IndexError).
+        print_stmt(method(seq(vec![ilit(10), ilit(20)]), "[]", vec![ilit(9)])),
+        // hash[miss] via the native `MapGet` → nil (NOT KeyError).
+        print_stmt(map_get(map_lit(vec![(slit("a"), ilit(1))]), slit("z"))),
+    ];
+    let src = compile(&module_from_main(stmts, &[])).expect("compile").source;
+    let Some((stdout, ok)) = compile_and_run(&src, "lenient_nil") else { return };
+    assert!(ok, "process should exit 0 (no over-raise); stdout={stdout:?}");
+    assert_eq!(
+        stdout.lines().collect::<Vec<_>>(),
+        vec!["nil", "nil"],
+        "arr[oob] and hash[miss] must both be nil; got {stdout:?}"
+    );
+}
+
+/// `fetch` WITH a default arg does not raise: `[1].fetch(9, 42)` → `42`, and
+/// `{}.fetch("k", 42)` → `42`.  Confirms we do not over-raise when Ruby would
+/// return the default.
+#[test]
+fn fetch_with_default_does_not_raise() {
+    if !rustc_available() {
+        eprintln!("skipping: rustc not on PATH");
+        return;
+    }
+    let stmts = vec![
+        print_stmt(method(seq(vec![ilit(1)]), "fetch", vec![ilit(9), ilit(42)])),
+        print_stmt(method(map_lit(vec![(slit("a"), ilit(1))]), "fetch", vec![slit("k"), ilit(7)])),
+    ];
+    let src = compile(&module_from_main(stmts, &[])).expect("compile").source;
+    let Some((stdout, ok)) = compile_and_run(&src, "fetch_default") else { return };
+    assert!(ok, "fetch-with-default should not raise; stdout={stdout:?}");
+    assert_eq!(stdout.lines().collect::<Vec<_>>(), vec!["42", "7"], "got {stdout:?}");
+}


### PR DESCRIPTION
Rust milestone of the **sir-typed-runtime-errors** cascade (spec on main, #53) — the last of 5 backends. Runtime-only — only `code/packages/rust/semantic-ir-to-rust/`.

Faulting emitted-runtime ops now raise the correct **typed** `SirError` (`raise`→`panic_any(SirError)`) so a translated `rescue` catches them (also reconciles the E4 divergence where `1/0` was an uncatchable `panic!`):
- `1/0` / `1.0/0` → `ZeroDivisionError` (was int-only uncatchable `panic!` / float `inf`).
- `arr.fetch(oob)` → `IndexError`; `hash.fetch(miss)` → `KeyError` (negative-index + default aware).
- unknown method → `NoMethodError` (`undefined method 'x' for <Class>`), via new `no_method_error` + `ruby_class_name` (parity port of Go).
- Added lenient `arr[i]`/`hash[k]` arms → nil on OOB/miss (no over-raise).
- Genuine non-`SirError` host faults still `resume_unwind` (never swallowed by a bare `rescue`) — verified by the still-passing re-raise test.

Security review: **PASSED** — `name` only formats into the message (never reaches reflective dispatch; dispatch stays explicit `match`), fetch index arithmetic is i64/bounds-safe, no `unsafe`/UAF, borrows dropped before unwind.

Exec-proofed via rustc (8 tests incl. ancestry chains + nil regression); 14 test groups green, 0 new warnings.

**Follow-up noted:** `arr.fetch("non_int")` currently hits `as_i64`'s `panic!` (uncatchable) where Ruby raises a catchable `TypeError` — a narrow parity gap (JS/Python raise TypeError here), worth a later cross-backend parity pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)