### PR TITLE
feat(adj-lang,logic-engine): binary gcd/lcm — \gcd(a,b)/\lcm(a,b) → ComputeOp::Gcd/Lcm

### DIFF
--- a/code/packages/rust/adj-lang/CHANGELOG.md
+++ b/code/packages/rust/adj-lang/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [0.29.0] - 2026-07-02 — binary `\gcd(a, b)` / `\lcm(a, b)` in `latex "…"`
+
+### Added
+
+- The `latex "…"` adapter now lowers **`\gcd(a, b)`** / **`\lcm(a, b)`** to the
+  native `ComputeOp::Gcd` / `Lcm`, reusing the same two-argument binary-`Call`
+  path as `\min`/`\max`: `BinFn` gains `Gcd`/`Lcm`, the adapter maps
+  `Func::Gcd`/`Func::Lcm` → `ExprAst::Call2` (peeling the transparent
+  `Group`/`Fenced` around the two-element `Sequence`, exactly-two enforced), and
+  `lower_bin_fn` routes them to the engine ops. These are the `Func::Gcd`/`Lcm`
+  variants the latex frontend already parsed but the adapter previously rejected.
+  Only `Func::Det` and unknown `Other` remain unsupported.
+
+### Tests
+
+- One lower test: `\gcd(12, 18)` compute-and-decides to 6 and `\lcm(4, 6)` to 12.
+
 ## [0.28.0] - 2026-07-02 — binary `\min(a, b)` / `\max(a, b)` in `latex "…"`
 
 ### Added

--- a/code/packages/rust/adj-lang/Cargo.toml
+++ b/code/packages/rust/adj-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang"
-version = "0.28.0"
+version = "0.29.0"
 edition = "2021"
 description = "Surface-syntax frontend for the adjudication framework's probabilistic-logic rulebooks. Lexes, parses, and lowers a domain-expert-readable DSL into a `logic-engine` KnowledgeBase. Dissolves ADJ46 awkwardness items A10 (rulebook syntax) and A4 (joint contributions syntactically distinct)."
 

--- a/code/packages/rust/adj-lang/src/adapter.rs
+++ b/code/packages/rust/adj-lang/src/adapter.rs
@@ -1012,20 +1012,21 @@ fn latex_math_to_expr_ast(expr: &MathExpr, source: &str) -> Result<ExprAst, Adap
         // A named-function call. The single-argument transcendental set
         // (`\sin(x)`, `\ln(x)`, `\exp(x)`, …) lowers to the matching native
         // transcendental op via `ExprAst::Call`; the two-argument `\min(a, b)` /
-        // `\max(a, b)` lower to the native binary ops via `ExprAst::Call2` (their
-        // argument is a two-element `Sequence`, usually inside the call's
-        // parentheses). The remaining `Func` variants (aggregate/multi-arg
-        // `gcd`/`lcm`/`det` and an unknown `Other` such as `\operatorname{trunc}`)
-        // have no lowering yet and are a clean, explicit error rather than a
-        // silent mis-lowering.
+        // `\max(a, b)` / `\gcd(a, b)` / `\lcm(a, b)` lower to the native binary ops
+        // via `ExprAst::Call2` (their argument is a two-element `Sequence`, usually
+        // inside the call's parentheses). The remaining `Func` variants (`det` and
+        // an unknown `Other` such as `\operatorname{trunc}`) have no lowering yet
+        // and are a clean, explicit error rather than a silent mis-lowering.
         MathExpr::Call { func, arg } => {
-            // Binary min/max first — their argument is a comma-list, not a scalar.
-            if let Func::Min | Func::Max = func {
-                let bin = if matches!(func, Func::Min) {
-                    BinFn::Min
-                } else {
-                    BinFn::Max
-                };
+            // Binary functions first — their argument is a comma-list, not a scalar.
+            let binfn = match func {
+                Func::Min => Some(BinFn::Min),
+                Func::Max => Some(BinFn::Max),
+                Func::Gcd => Some(BinFn::Gcd),
+                Func::Lcm => Some(BinFn::Lcm),
+                _ => None,
+            };
+            if let Some(bin) = binfn {
                 let (a, b) = latex_two_args(arg, source, func)?;
                 return Ok(ExprAst::Call2(
                     bin,
@@ -1052,11 +1053,16 @@ fn latex_math_to_expr_ast(expr: &MathExpr, source: &str) -> Result<ExprAst, Adap
                 other => {
                     return Err(AdapterError::UnsupportedLatexMath {
                         source: source.to_string(),
-                        detail: format!("named function not yet supported in ADJ arithmetic: {other:?}"),
+                        detail: format!(
+                            "named function not yet supported in ADJ arithmetic: {other:?}"
+                        ),
                     })
                 }
             };
-            Ok(ExprAst::Call(named, Box::new(latex_math_to_expr_ast(arg, source)?)))
+            Ok(ExprAst::Call(
+                named,
+                Box::new(latex_math_to_expr_ast(arg, source)?),
+            ))
         }
         MathExpr::Rel(_, _, _) => Err(AdapterError::UnsupportedLatexMath {
             source: source.to_string(),

--- a/code/packages/rust/adj-lang/src/ast.rs
+++ b/code/packages/rust/adj-lang/src/ast.rs
@@ -129,6 +129,10 @@ pub enum BinFn {
     Min,
     /// `\max(a, b)` — the larger of two quantities.
     Max,
+    /// `\gcd(a, b)` — greatest common divisor (integer operands).
+    Gcd,
+    /// `\lcm(a, b)` — least common multiple (integer operands).
+    Lcm,
 }
 
 /// An aggregation operator in a `let` formula — reduces every

--- a/code/packages/rust/adj-lang/src/lower.rs
+++ b/code/packages/rust/adj-lang/src/lower.rs
@@ -723,6 +723,8 @@ fn lower_bin_fn(f: BinFn) -> ComputeOp {
     match f {
         BinFn::Min => ComputeOp::Min2,
         BinFn::Max => ComputeOp::Max2,
+        BinFn::Gcd => ComputeOp::Gcd,
+        BinFn::Lcm => ComputeOp::Lcm,
     }
 }
 
@@ -2031,6 +2033,32 @@ contributes 1000000 from answer == 60 to correct
     }
 
     #[test]
+    fn native_latex_binary_gcd_lcm_lower_to_native_ops() {
+        // `\gcd(a, b)` / `\lcm(a, b)` reuse the binary-Call path (Call2) and lower
+        // to ComputeOp::Gcd/Lcm. gcd(12, 18) = 6; lcm(4, 6) = 12.
+        let g = crate::compile_and_decide(
+            "observe a(12)\n\
+             observe b(18)\n\
+             let answer = latex \"$\\gcd(a, b)$\"\n\
+             prior 0.10 for correct\n\
+             contributes 1000000 from answer == 6 to correct\n\
+             ? correct\n",
+        )
+        .unwrap();
+        assert!(g.ranked[0].posterior > 0.99, "{g:?}");
+        let l = crate::compile_and_decide(
+            "observe a(4)\n\
+             observe b(6)\n\
+             let answer = latex \"$\\lcm(a, b)$\"\n\
+             prior 0.10 for correct\n\
+             contributes 1000000 from answer == 12 to correct\n\
+             ? correct\n",
+        )
+        .unwrap();
+        assert!(l.ranked[0].posterior > 0.99, "{l:?}");
+    }
+
+    #[test]
     fn native_latex_symbolic_root_degree_is_rejected() {
         // `\sqrt[k]{x}` — a symbolic degree has no numeric value, so the reciprocal
         // exponent `1/k` cannot be formed. It must be rejected, not silently
@@ -2040,7 +2068,10 @@ contributes 1000000 from answer == 60 to correct
              let answer = latex \"$\\sqrt[k]{x}$\"\n\
              ? answer\n",
         );
-        assert!(err.is_err(), "symbolic root degree must be rejected: {err:?}");
+        assert!(
+            err.is_err(),
+            "symbolic root degree must be rejected: {err:?}"
+        );
     }
 
     #[test]

--- a/code/packages/rust/logic-engine/CHANGELOG.md
+++ b/code/packages/rust/logic-engine/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.34.0] - 2026-07-02 — binary gcd/lcm (`Gcd`/`Lcm`) integer ops
+
+### Added
+
+- Two binary compute ops **`ComputeOp::Gcd`** / **`ComputeOp::Lcm`** —
+  `gcd(a, b)` / `lcm(a, b)` over exactly TWO operands, from a LaTeX
+  `\gcd(a, b)` / `\lcm(a, b)`. They reuse the `Min2`/`Max2` binary-`Call` path
+  (folded into the general binary arm + `dim_op`, so `eval`'s recursive frame is
+  unchanged), but are **integer number-theoretic**: both operands must be exact
+  integers in the exactly-representable range (`|v| ≤ 2^53`); a non-integer
+  (`2.5`), NaN/inf, or out-of-range value is a clean `MalformedExpr`, never a
+  silent truncation.
+- Value computed by a leaf `#[inline(never)] int_gcd_lcm` helper (NOT on the
+  recursion path, so its loop locals don't enlarge the recursive frame): `gcd`
+  is Euclid on the magnitudes (`gcd(0, 0) = 0`, `gcd(n, 0) = |n|`), `lcm(a, b) =
+  (|a| / gcd) · |b|` in `i128` (`lcm(_, 0) = 0`), with the shared `is_finite`
+  guard as backstop. Dimensionally they combine like addition (a bare
+  dimensionless integer stays one). Exact-rational sidecar dropped — the f64 is
+  exact for the in-range integer results. `symbol()` renders `gcd` / `lcm`.
+
+### Tests
+
+- Three engine tests: gcd(12,18)=6 / lcm(4,6)=12, the zero edge cases
+  (`gcd(0,0)`, `gcd(n,0)`, `lcm(_,0)`), and non-integer-operand rejection.
+
 ## [0.33.0] - 2026-07-02 — binary min/max (`Min2`/`Max2`), the first binary-Call op
 
 ### Added

--- a/code/packages/rust/logic-engine/Cargo.toml
+++ b/code/packages/rust/logic-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logic-engine"
-version = "0.33.0"
+version = "0.34.0"
 edition = "2021"
 description = "Probability-aware facts, rules, KB, SLD find-first/enumerate + WMC posterior + LP19e likelihood-ratio Bayesian aggregation."
 

--- a/code/packages/rust/logic-engine/src/compute.rs
+++ b/code/packages/rust/logic-engine/src/compute.rs
@@ -259,6 +259,18 @@ pub enum ComputeOp {
     /// the worse of two labs) computable as a single native node.
     Min2,
     Max2,
+    /// Binary **gcd** / **lcm** — `gcd(a, b)` / `lcm(a, b)` over exactly TWO
+    /// operands, from a LaTeX `\gcd(a, b)` / `\lcm(a, b)`. Reuses the binary-`Call`
+    /// path like `Min2`/`Max2`, but they are **integer number-theoretic** ops: both
+    /// operands must be integer-valued (a non-integer like `2.5` is a
+    /// `MalformedExpr`, not silently truncated), and dimensionally they combine
+    /// like addition (a bare count / dimensionless integer in practice). `gcd` is
+    /// Euclid on the magnitudes (`gcd(0, 0) = 0`); `lcm(a, b) = |a·b| / gcd(a, b)`
+    /// with `lcm(_, 0) = 0`, and an overflow to non-finite is caught by the shared
+    /// guard. The value is exact for realistic integer inputs, so the
+    /// exact-rational sidecar is dropped (the f64 already carries it).
+    Gcd,
+    Lcm,
     Sum,
     Count,
     Min,
@@ -296,6 +308,8 @@ impl ComputeOp {
             ComputeOp::Csc => "csc",
             ComputeOp::Min2 => "min",
             ComputeOp::Max2 => "max",
+            ComputeOp::Gcd => "gcd",
+            ComputeOp::Lcm => "lcm",
             ComputeOp::Sum => "sum",
             ComputeOp::Count => "count",
             ComputeOp::Min => "min",
@@ -459,8 +473,55 @@ fn dim_op(op: ComputeOp) -> Option<DimOp> {
         // `DimOp::Add` lets them flow through the general binary path with no
         // extra locals in the deeply-recursive `eval` frame.
         ComputeOp::Min2 | ComputeOp::Max2 => Some(DimOp::Add),
+        // gcd/lcm are number-theoretic on (dimensionless) integers; combine like
+        // addition so a bare count stays a bare count. The integer requirement is
+        // enforced on the values, not the dimension.
+        ComputeOp::Gcd | ComputeOp::Lcm => Some(DimOp::Add),
         _ => None,
     }
+}
+
+/// Compute a binary integer `gcd`/`lcm` on two already-evaluated operand values.
+/// A **leaf** helper (it does NOT call `eval`, so it never sits on the recursion
+/// path) marked `#[inline(never)]` so its loop locals live in their own frame
+/// rather than enlarging the deeply-recursive `eval`/`eval_binary` frame.
+///
+/// Contract: both operands must be **exact integers** in the exactly-representable
+/// range (`|v| ≤ 2^53`); a non-integer (`2.5`), NaN/inf, or out-of-range value is a
+/// clean error, never a silent truncation. `gcd` is Euclid on the magnitudes
+/// (`gcd(0, 0) = 0`, `gcd(n, 0) = |n|`); `lcm(a, b) = |a·b| / gcd(a, b)` with
+/// `lcm(_, 0) = 0`. Everything is done in `i128` so no intermediate overflows; the
+/// caller's shared `is_finite` guard is the final backstop.
+#[inline(never)]
+fn int_gcd_lcm(op: ComputeOp, x: f64, y: f64) -> Result<f64, ComputeError> {
+    // `2^53` is the largest integer every f64 represents exactly — beyond it an
+    // f64 "integer" is already ambiguous, so gcd/lcm on it would be meaningless.
+    const LIMIT: f64 = 9_007_199_254_740_992.0; // 2^53
+    if x.fract() != 0.0 || y.fract() != 0.0 || x.abs() > LIMIT || y.abs() > LIMIT {
+        return Err(ComputeError::MalformedExpr {
+            detail: "gcd/lcm requires integer operands within the exact range",
+        });
+    }
+    let a = (x as i128).unsigned_abs();
+    let b = (y as i128).unsigned_abs();
+    // Euclid's algorithm on the magnitudes.
+    let (mut p, mut q) = (a, b);
+    while q != 0 {
+        let r = p % q;
+        p = q;
+        q = r;
+    }
+    let g = p; // gcd(a, b); 0 iff both operands are 0
+    let value = match op {
+        ComputeOp::Gcd => g as f64,
+        // lcm: divide first (a/g is exact) then multiply, in i128 so the product
+        // cannot overflow the integer type; the f64 cast + caller's finite guard
+        // handle any magnitude concern.
+        ComputeOp::Lcm if g == 0 => 0.0,
+        ComputeOp::Lcm => ((a / g) * b) as f64,
+        _ => unreachable!("int_gcd_lcm only handles Gcd/Lcm"),
+    };
+    Ok(value)
 }
 
 /// Recursively evaluate a sub-expression into a derivation node **and its
@@ -622,6 +683,11 @@ fn eval(
                         y
                     }
                 }
+                // gcd/lcm are integer number-theoretic ops. Delegated to a leaf
+                // `#[inline(never)]` helper (NOT on the recursion path) so its
+                // Euclid-loop locals live in their own frame, not `eval`'s. A
+                // non-integer operand is a clean `MalformedExpr`.
+                ComputeOp::Gcd | ComputeOp::Lcm => int_gcd_lcm(*op, x, y)?,
                 _ => unreachable!("dim_op already rejected non-binary ops"),
             };
             if !result.is_finite() {
@@ -1668,6 +1734,62 @@ mod tests {
         )
         .unwrap_err();
         assert!(matches!(err, ComputeError::NonFinite { .. }), "{err:?}");
+    }
+
+    #[test]
+    fn binary_gcd_lcm_compute_integer_results() {
+        // gcd(12, 18) = 6; lcm(4, 6) = 12. Euclid + divide-then-multiply.
+        let kb = kb_with(vec![
+            Fact::certain(compound("a", vec![int(12)])),
+            Fact::certain(compound("b", vec![int(18)])),
+            Fact::certain(compound("c", vec![int(4)])),
+            Fact::certain(compound("d", vec![int(6)])),
+        ]);
+        let g = compute("g", &bin(ComputeOp::Gcd, refexpr("a"), refexpr("b")), &kb).unwrap();
+        assert_eq!(g.value, 6.0);
+        let l = compute("l", &bin(ComputeOp::Lcm, refexpr("c"), refexpr("d")), &kb).unwrap();
+        assert_eq!(l.value, 12.0);
+    }
+
+    #[test]
+    fn binary_gcd_lcm_zero_edge_cases() {
+        // gcd(0, 0) = 0; gcd(n, 0) = |n|; lcm(_, 0) = 0.
+        let kb = kb_with(vec![
+            Fact::certain(compound("z", vec![int(0)])),
+            Fact::certain(compound("n", vec![int(7)])),
+        ]);
+        assert_eq!(
+            compute("g0", &bin(ComputeOp::Gcd, refexpr("z"), refexpr("z")), &kb)
+                .unwrap()
+                .value,
+            0.0
+        );
+        assert_eq!(
+            compute("gn", &bin(ComputeOp::Gcd, refexpr("n"), refexpr("z")), &kb)
+                .unwrap()
+                .value,
+            7.0
+        );
+        assert_eq!(
+            compute("l0", &bin(ComputeOp::Lcm, refexpr("n"), refexpr("z")), &kb)
+                .unwrap()
+                .value,
+            0.0
+        );
+    }
+
+    #[test]
+    fn binary_gcd_rejects_a_non_integer_operand() {
+        // gcd(12, 2.5) — a non-integer operand is a clean MalformedExpr, never a
+        // silent truncation.
+        let kb = kb_with(vec![Fact::certain(compound("a", vec![int(12)]))]);
+        let err = compute(
+            "x",
+            &bin(ComputeOp::Gcd, refexpr("a"), ComputeExpr::Lit(2.5)),
+            &kb,
+        )
+        .unwrap_err();
+        assert!(matches!(err, ComputeError::MalformedExpr { .. }), "{err:?}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes out the common binary `Func` variants: `\gcd(a, b)` / `\lcm(a, b)` now compute as native `ComputeOp::Gcd` / `Lcm`, **reusing the two-argument binary-`Call` machinery** (`Call2` / `BinFn` / `latex_two_args`) landed in the min/max slice. These are the `Func::Gcd`/`Func::Lcm` variants the latex frontend already parsed but the adapter had rejected as *"not yet supported"*.

## logic-engine — `ComputeOp::Gcd` / `Lcm`
Binary gcd/lcm over exactly **two** operands, **folded into the general binary arm + `dim_op` exactly like `Min2`/`Max2`** — so `eval`'s deeply-recursive frame is unchanged (no stack-overflow regression). They are **integer number-theoretic** ops:
- Both operands must be **exact integers** in `|v| ≤ 2^53`; a non-integer (`2.5`), NaN/inf, or out-of-range value is a clean `MalformedExpr` — never a silent truncation.
- Value computed by a **leaf `#[inline(never)] int_gcd_lcm` helper** (not on the recursion path, so its loop locals don't touch the recursive frame): `gcd` is Euclid on the magnitudes (`gcd(0,0)=0`, `gcd(n,0)=|n|`); `lcm(a,b) = (|a|/gcd)·|b|` in `i128`, **divide-before-multiply** so no overflow and no precision loss (`lcm(_,0)=0`); the shared `is_finite` guard is the backstop.
- Dimensionally combine like addition (a bare dimensionless integer stays one). Exact-rational sidecar dropped — the f64 is exact for in-range integer results. `symbol()` renders `gcd`/`lcm`.

## adj-lang — `\gcd(a, b)` / `\lcm(a, b)` surface
- `BinFn` gains `Gcd`/`Lcm`; the adapter maps `Func::Gcd`/`Func::Lcm` → `ExprAst::Call2` via the same `latex_two_args` peel (transparent `Group`/`Fenced` stripped, **exactly two** operands enforced); `lower_bin_fn` routes to the engine ops. Only `Func::Det` and unknown `Other` remain unsupported.

**latex crate + constraint-solver — no change** (op-generic `Bin` walkers).

## Verification
- 3 engine tests (gcd(12,18)=6 / lcm(4,6)=12; zero edge cases `gcd(0,0)`/`gcd(n,0)`/`lcm(_,0)`; non-integer-operand rejection) + 1 adj-lang lower test (`\gcd(12,18)`→6, `\lcm(4,6)`→12).
- Full `logic-engine` (158, incl. the `deeply_nested` macOS stack guard) + `adj-lang` (104) + `adj-constraint-solver` + `adj-lang-cli` + `adjudication-pipeline` suites green.
- `logic-engine` 0.33→0.34, `adj-lang` 0.28→0.29; both CHANGELOGs updated.

Security-reviewed (inline, against the worktree source): the integer guard makes the `f64→i128` cast always safe and rejects NaN/inf; Euclid terminates (remainder strictly decreases); `lcm` in `i128` cannot overflow for `|v|≤2^53`; `unsigned_abs` avoids the `i128::MIN` negation panic; `latex_two_args` indexes only after the `len()==2` check — PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
