### PR TITLE
Style Engram collection action buttons across Mosaic backends

### DIFF
--- a/code/packages/mosaic-pkg-collection-actions/src/CollectionActions.dark.msl
+++ b/code/packages/mosaic-pkg-collection-actions/src/CollectionActions.dark.msl
@@ -134,10 +134,86 @@ style CollectionActions {
   }
 
   part import-export-actions {
+    gap : 8 ;
     padding-bottom : 8 ;
   }
 
   part note-actions {
+    gap : 8 ;
     padding-bottom : 8 ;
+  }
+
+  part destructive-actions {
+    gap : 8 ;
+  }
+
+  part import-button {
+    background    : "#0e7490" ;
+    border-width  : 1 ;
+    border-color  : "#155e75" ;
+    border-radius : 6 ;
+    color         : "#ecfeff" ;
+    font-weight   : 700 ;
+    padding       : 8 ;
+  }
+
+  part export-button {
+    background    : "#334155" ;
+    border-width  : 1 ;
+    border-color  : "#64748b" ;
+    border-radius : 6 ;
+    color         : "#f8fafc" ;
+    font-weight   : 700 ;
+    padding       : 8 ;
+  }
+
+  part prune-unused-media-button {
+    background    : "#b45309" ;
+    border-width  : 1 ;
+    border-color  : "#92400e" ;
+    border-radius : 6 ;
+    color         : "#fffbeb" ;
+    font-weight   : 700 ;
+    padding       : 8 ;
+  }
+
+  part add-note-button {
+    background    : "#0f766e" ;
+    border-width  : 1 ;
+    border-color  : "#134e4a" ;
+    border-radius : 6 ;
+    color         : "#ecfdf5" ;
+    font-weight   : 700 ;
+    padding       : 8 ;
+  }
+
+  part add-note-type-button {
+    background    : "#0f766e" ;
+    border-width  : 1 ;
+    border-color  : "#134e4a" ;
+    border-radius : 6 ;
+    color         : "#ecfdf5" ;
+    font-weight   : 700 ;
+    padding       : 8 ;
+  }
+
+  part delete-note-button {
+    background    : "#be123c" ;
+    border-width  : 1 ;
+    border-color  : "#881337" ;
+    border-radius : 6 ;
+    color         : "#fff1f2" ;
+    font-weight   : 700 ;
+    padding       : 8 ;
+  }
+
+  part delete-note-type-button {
+    background    : "#be123c" ;
+    border-width  : 1 ;
+    border-color  : "#881337" ;
+    border-radius : 6 ;
+    color         : "#fff1f2" ;
+    font-weight   : 700 ;
+    padding       : 8 ;
   }
 }

--- a/code/packages/mosaic-pkg-collection-actions/tests/package_compiles.rs
+++ b/code/packages/mosaic-pkg-collection-actions/tests/package_compiles.rs
@@ -169,15 +169,63 @@ fn collection_actions_layout_wires_counts_and_actions() {
 fn collection_actions_package_emitters_accept_workflow_surface() {
     let tmp = tempfile::tempdir().expect("temp dist root");
     let backends = [
-        (Backend::Html, "html/CollectionActions.html"),
-        (Backend::React, "react/CollectionActions.tsx"),
-        (Backend::SwiftUI, "swiftui/CollectionActions.swift"),
-        (Backend::Qt, "qt/CollectionActions.qml"),
-        (Backend::Xaml, "xaml/CollectionActions.xaml"),
-        (Backend::Flutter, "flutter/CollectionActions.dart"),
+        (
+            Backend::React,
+            "react/CollectionActions.tsx",
+            "background: \"#0e7490\"",
+            "background: \"#be123c\"",
+        ),
+        (
+            Backend::Electron,
+            "electron/CollectionActions.tsx",
+            "background: \"#0e7490\"",
+            "background: \"#be123c\"",
+        ),
+        (
+            Backend::SwiftUI,
+            "swiftui/CollectionActions.swift",
+            "Color(red: 0.055, green: 0.455, blue: 0.565)",
+            "Color(red: 0.745, green: 0.071, blue: 0.235)",
+        ),
+        (
+            Backend::Qt,
+            "qt/CollectionActions.qml",
+            "color: \"#0e7490\"",
+            "color: \"#be123c\"",
+        ),
+        (
+            Backend::WebComponent,
+            "webcomponent/CollectionActions.js",
+            "background: #0e7490",
+            "background: #be123c",
+        ),
+        (
+            Backend::Html,
+            "html/CollectionActions.html",
+            "background: #0e7490",
+            "background: #be123c",
+        ),
+        (
+            Backend::Xaml,
+            "xaml/CollectionActions.xaml",
+            "Background=\"#0e7490\"",
+            "Background=\"#be123c\"",
+        ),
+        (
+            Backend::Flutter,
+            "flutter/CollectionActions.dart",
+            "Color(0xFF0E7490)",
+            "Color(0xFFBE123C)",
+        ),
+        (
+            Backend::Compose,
+            "compose/CollectionActions.kt",
+            "Color(0xFF0E7490)",
+            "Color(0xFFBE123C)",
+        ),
     ];
 
-    for (backend, expected_artifact) in backends {
+    for (backend, expected_artifact, primary_button_style, destructive_button_style) in backends {
         let result = build_package(&BuildOptions {
             package_root: package_root(),
             output_root: tmp.path().to_path_buf(),
@@ -190,6 +238,17 @@ fn collection_actions_package_emitters_accept_workflow_surface() {
         assert!(
             tmp.path().join(expected_artifact).exists(),
             "{backend:?} did not write {expected_artifact}"
+        );
+
+        let artifact = fs::read_to_string(tmp.path().join(expected_artifact))
+            .unwrap_or_else(|e| panic!("failed to read {expected_artifact}: {e}"));
+        assert!(
+            artifact.contains(primary_button_style),
+            "{backend:?} did not lower the import-button style into {expected_artifact}"
+        );
+        assert!(
+            artifact.contains(destructive_button_style),
+            "{backend:?} did not lower the delete-button style into {expected_artifact}"
         );
     }
 

--- a/code/specs/mosaic-compile.json
+++ b/code/specs/mosaic-compile.json
@@ -111,7 +111,7 @@
           "id": "backend",
           "long": "backend",
           "short": "b",
-          "description": "Backend to compile for: 'react', 'swiftui', 'qt', 'xaml', 'webcomponent', 'html', or 'flutter'",
+          "description": "Backend to compile for: 'react', 'electron', 'swiftui', 'qt', 'xaml', 'webcomponent', 'html', 'flutter', or 'compose'",
           "type": "string",
           "required": true
         },


### PR DESCRIPTION
## Summary
- add native styles for the reusable CollectionActions HostButton parts, including spacing for action rows
- extend the package smoke test to verify button style lowering across React, Electron, SwiftUI, Qt, WebComponent, HTML, XAML, Flutter, and Compose
- update mosaic-compile pkg help text to list Electron and Compose

## Verification
- cargo test --manifest-path code/packages/mosaic-pkg-collection-actions/Cargo.toml -- --nocapture
- cargo test -p mosaic-compile pkg_backend_mapping_exposes_native_and_web_package_backends -- --nocapture
- cargo run -q -p mosaic-compile -- pkg --help
- ./scripts/build-all.ps1 from code/programs/mosaic/engram-app
- cargo test --manifest-path code/programs/mosaic/engram-app/Cargo.toml -- --nocapture
- in-app browser computed-style check for React demo collection action buttons