### PR TITLE
feat(adj-lang,logic-engine): \operatorname{trunc}(x) — truncation toward zero → ComputeOp::Trunc

### DIFF
--- a/code/packages/rust/adj-lang/CHANGELOG.md
+++ b/code/packages/rust/adj-lang/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [0.30.0] - 2026-07-02 — `\operatorname{trunc}(x)` truncation in `latex "…"`
+
+### Added
+
+- The `latex "…"` adapter now lowers **`\operatorname{trunc}(x)`** to the native
+  `ComputeOp::Trunc` (truncate toward zero) via a new `ExprAst::Trunc`. Because
+  `\operatorname{…}` is a TEXT command, the frontend parses
+  `\operatorname{trunc}(x)` NOT as a function call but as an implicit
+  multiplication (juxtaposition) — `Bin(Mul, Text("trunc"), (x))`. The adapter
+  recognises that exact operator-name shape (a new `operator_name_is` helper)
+  above the general `Bin(Mul, …)` arm, so a genuine product (`2x`) still
+  multiplies; only a `trunc`-named text factor is intercepted. This is the last
+  common scalar unary the surface was missing.
+
+### Tests
+
+- Two lower tests: `\operatorname{trunc}(a/b)` with `a=7, b=2` compute-and-decides
+  to 3, and `\operatorname{trunc}((0 - a)/b)` to −3 (toward zero, NOT the floor −4).
+
 ## [0.29.0] - 2026-07-02 — binary `\gcd(a, b)` / `\lcm(a, b)` in `latex "…"`
 
 ### Added

--- a/code/packages/rust/adj-lang/Cargo.toml
+++ b/code/packages/rust/adj-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang"
-version = "0.29.0"
+version = "0.30.0"
 edition = "2021"
 description = "Surface-syntax frontend for the adjudication framework's probabilistic-logic rulebooks. Lexes, parses, and lowers a domain-expert-readable DSL into a `logic-engine` KnowledgeBase. Dissolves ADJ46 awkwardness items A10 (rulebook syntax) and A4 (joint contributions syntactically distinct)."
 

--- a/code/packages/rust/adj-lang/src/adapter.rs
+++ b/code/packages/rust/adj-lang/src/adapter.rs
@@ -958,6 +958,21 @@ fn latex_math_to_expr_ast(expr: &MathExpr, source: &str) -> Result<ExprAst, Adap
         )),
         MathExpr::Bin(BinOp::Add, lhs, rhs) => latex_bin(ArithOp::Add, lhs, rhs, source),
         MathExpr::Bin(BinOp::Sub, lhs, rhs) => latex_bin(ArithOp::Sub, lhs, rhs, source),
+        // `\operatorname{trunc}(x)` — truncation toward zero. `\operatorname{…}` is a
+        // TEXT command (like `\text`/`\mathrm`), so the frontend parses
+        // `\operatorname{trunc}(x)` NOT as a function call but as an *implicit
+        // multiplication* (juxtaposition) of the operator name `Text("trunc")` and its
+        // parenthesised argument: `Bin(Mul, Text("trunc"), (x))`. We recognise that
+        // exact shape here — the operator-name juxtaposition path — and lower it to the
+        // dimension-preserving `ComputeOp::Trunc` (via `ExprAst::Trunc`). This arm sits
+        // ABOVE the general `Bin(Mul, …)` so a genuine product (`2x`) still multiplies;
+        // only a `trunc`-named text factor is intercepted, and only when it is the LEFT
+        // operand of the juxtaposition (`\operatorname{trunc}(x)` itself). Anything else
+        // named (`\operatorname{sgn}(x)`) falls through to the general Mul arm, where the
+        // bare `Text` factor is an explicit `UnsupportedLatexMath` — never a mis-lowering.
+        MathExpr::Bin(BinOp::Mul, lhs, rhs) if operator_name_is(lhs, "trunc") => {
+            Ok(ExprAst::Trunc(Box::new(latex_math_to_expr_ast(rhs, source)?)))
+        }
         MathExpr::Bin(BinOp::Mul, lhs, rhs) => latex_bin(ArithOp::Mul, lhs, rhs, source),
         MathExpr::Bin(BinOp::Div, lhs, rhs) | MathExpr::Frac(lhs, rhs) => {
             latex_bin(ArithOp::Div, lhs, rhs, source)
@@ -1014,9 +1029,11 @@ fn latex_math_to_expr_ast(expr: &MathExpr, source: &str) -> Result<ExprAst, Adap
         // transcendental op via `ExprAst::Call`; the two-argument `\min(a, b)` /
         // `\max(a, b)` / `\gcd(a, b)` / `\lcm(a, b)` lower to the native binary ops
         // via `ExprAst::Call2` (their argument is a two-element `Sequence`, usually
-        // inside the call's parentheses). The remaining `Func` variants (`det` and
-        // an unknown `Other` such as `\operatorname{trunc}`) have no lowering yet
-        // and are a clean, explicit error rather than a silent mis-lowering.
+        // inside the call's parentheses). (`\operatorname{trunc}(x)` is NOT a `Call` — an
+        // operator name is text, so it arrives as a `Bin(Mul, Text("trunc"), (x))`
+        // juxtaposition handled in the `Bin` arm above.) The remaining `Func` variants
+        // (`det` and an unknown `Other`) have no lowering yet and are a clean, explicit
+        // error rather than a silent mis-lowering.
         MathExpr::Call { func, arg } => {
             // Binary functions first — their argument is a comma-list, not a scalar.
             let binfn = match func {
@@ -1073,6 +1090,15 @@ fn latex_math_to_expr_ast(expr: &MathExpr, source: &str) -> Result<ExprAst, Adap
             detail: format!("unsupported ADJ arithmetic subset: {other:?}"),
         }),
     }
+}
+
+/// Is `expr` an operator-name text (`\operatorname{name}`, `\mathrm{name}`, `\text{name}`)
+/// whose content equals `name`? The frontend lowers all of these to `MathExpr::Text`, so a
+/// juxtaposed `\operatorname{trunc}(x)` arrives as `Bin(Mul, Text("trunc"), (x))`. We match
+/// on the trimmed content (the raw text group can carry surrounding spaces) so
+/// `\operatorname{trunc}` and `\operatorname{ trunc }` both count.
+fn operator_name_is(expr: &MathExpr, name: &str) -> bool {
+    matches!(expr, MathExpr::Text(s) if s.trim() == name)
 }
 
 fn latex_bin(

--- a/code/packages/rust/adj-lang/src/ast.rs
+++ b/code/packages/rust/adj-lang/src/ast.rs
@@ -174,6 +174,13 @@ pub enum ExprAst {
     /// adapter from the nearest-integer fence `\left\lfloor…\right\rceil`
     /// (floor-left, ceil-right).
     Round(Box<ExprAst>),
+    /// A truncation toward zero, `trunc(x)` — drop the fractional part, keeping the
+    /// sign (`trunc(3.7) = 3`, `trunc(−3.7) = −3`; contrast `Floor`, which rounds
+    /// toward −∞). Lowers to the native `ComputeOp::Trunc` (dimension-preserving).
+    /// Produced by the `latex "…"` adapter from a `\operatorname{trunc}(x)` — the
+    /// operator-name juxtaposition (`Text("trunc")` implicitly multiplied by its
+    /// parenthesised argument).
+    Trunc(Box<ExprAst>),
     /// A named **transcendental** function applied to one argument
     /// (`\sin(x)`, `\ln(x)`, `\exp(x)`, …). Lowers to the matching native
     /// transcendental `ComputeOp` (`Scalar → Scalar`, exact dropped). Produced by

--- a/code/packages/rust/adj-lang/src/lower.rs
+++ b/code/packages/rust/adj-lang/src/lower.rs
@@ -709,6 +709,7 @@ fn lower_expr(expr: &ExprAst) -> ComputeExpr {
         ExprAst::Floor(a) => ComputeExpr::Unary(ComputeOp::Floor, Box::new(lower_expr(a))),
         ExprAst::Ceil(a) => ComputeExpr::Unary(ComputeOp::Ceil, Box::new(lower_expr(a))),
         ExprAst::Round(a) => ComputeExpr::Unary(ComputeOp::Round, Box::new(lower_expr(a))),
+        ExprAst::Trunc(a) => ComputeExpr::Unary(ComputeOp::Trunc, Box::new(lower_expr(a))),
         ExprAst::Call(f, a) => ComputeExpr::Unary(lower_named_fn(*f), Box::new(lower_expr(a))),
         ExprAst::Call2(f, a, b) => ComputeExpr::Bin(
             lower_bin_fn(*f),
@@ -1930,6 +1931,41 @@ contributes 1000000 from answer == 60 to correct
              let answer = latex \"$\\left\\lfloor a / b\\right\\rceil$\"\n\
              prior 0.10 for correct\n\
              contributes 1000000 from answer == 4 to correct\n\
+             ? correct\n",
+        )
+        .unwrap();
+        assert!(d.ranked[0].posterior > 0.99, "{d:?}");
+    }
+
+    #[test]
+    fn native_latex_trunc_drops_a_positive_fraction_toward_zero() {
+        // `\operatorname{trunc}(a / b)` with a=7, b=2 is trunc(3.5) = 3, computed on
+        // the native ComputeOp::Trunc via the operator-name juxtaposition path
+        // (`Bin(Mul, Text("trunc"), (a / b))`) — NOT silently dropped to the bare
+        // quotient 3.5.
+        let d = crate::compile_and_decide(
+            "observe a(7)\n\
+             observe b(2)\n\
+             let answer = latex \"$\\operatorname{trunc}(a / b)$\"\n\
+             prior 0.10 for correct\n\
+             contributes 1000000 from answer == 3 to correct\n\
+             ? correct\n",
+        )
+        .unwrap();
+        assert!(d.ranked[0].posterior > 0.99, "{d:?}");
+    }
+
+    #[test]
+    fn native_latex_trunc_of_a_negative_quotient_goes_toward_zero_not_down() {
+        // trunc(−7/2) = −3 (toward zero), the whole distinction from floor, which
+        // would give −4 (toward −∞). Confirms the operator-name path reaches
+        // ComputeOp::Trunc and not ComputeOp::Floor.
+        let d = crate::compile_and_decide(
+            "observe a(7)\n\
+             observe b(2)\n\
+             let answer = latex \"$\\operatorname{trunc}((0 - a) / b)$\"\n\
+             prior 0.10 for correct\n\
+             contributes 1000000 from answer == -3 to correct\n\
              ? correct\n",
         )
         .unwrap();

--- a/code/packages/rust/logic-engine/CHANGELOG.md
+++ b/code/packages/rust/logic-engine/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.35.0] - 2026-07-02 — truncation toward zero (`Trunc`)
+
+### Added
+
+- Unary compute op **`ComputeOp::Trunc`** — `trunc(x)` drops the fractional
+  part toward zero (`trunc(3.7) = 3`, `trunc(−3.7) = −3`), completing the
+  rounding family beside `Abs`/`Floor`/`Ceil`/`Round`. It is **dimension-
+  preserving** (`trunc(3.7 mmol) = 3 mmol`) — folded into the existing
+  `eval_unary` match arms (the f64 `value.trunc()` and the exact `num / den`,
+  Rust integer division toward zero for `den > 0`), so `eval`'s recursive frame
+  is unchanged. Contrast `Floor`, which rounds toward −∞ (`⌊−3.7⌋ = −4`): they
+  agree only for a non-negative operand.
+- Lowered from a LaTeX `\operatorname{trunc}(x)` on adj-lang's `latex "…"`
+  surface (the operator-name juxtaposition path).
+
+### Tests
+
+- Two unit tests: `trunc(7/2) = 3` (dimension-preserving), and `trunc(−7/2) =
+  −3` (toward zero, NOT the `Floor` −4).
+
 ## [0.34.0] - 2026-07-02 — binary gcd/lcm (`Gcd`/`Lcm`) integer ops
 
 ### Added

--- a/code/packages/rust/logic-engine/Cargo.toml
+++ b/code/packages/rust/logic-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logic-engine"
-version = "0.34.0"
+version = "0.35.0"
 edition = "2021"
 description = "Probability-aware facts, rules, KB, SLD find-first/enumerate + WMC posterior + LP19e likelihood-ratio Bayesian aggregation."
 

--- a/code/packages/rust/logic-engine/src/compute.rs
+++ b/code/packages/rust/logic-engine/src/compute.rs
@@ -212,6 +212,16 @@ pub enum ComputeOp {
     /// [`ComputeExpr::Unary`], and lowered from the standard nearest-integer
     /// LaTeX fence `\left\lfloor x\right\rceil` (floor-left, ceil-right).
     Round,
+    /// Truncate toward zero, `trunc(x)` — drop the fractional part, keeping the
+    /// integer part with the operand's sign (`trunc(3.7) = 3`, `trunc(−3.7) = −3`).
+    /// Contrast [`ComputeOp::Floor`] (toward −∞: `⌊−3.7⌋ = −4`) — they agree only
+    /// for a non-negative operand. Like the rest of the rounding family it is
+    /// **unary** and **dimension-preserving** (`trunc(3.7 mmol) = 3 mmol`), carried
+    /// in a [`ComputeExpr::Unary`], and lowered from a LaTeX `\operatorname{trunc}(x)`
+    /// — the operator-name juxtaposition surface (adj-lang's `latex "…"`). The exact
+    /// sidecar stays exact: `trunc(num/den) = num / den` (Rust integer division
+    /// truncates toward zero for `den > 0`, carried as `q/1`).
+    Trunc,
     /// The named **transcendental** unary functions `sin`, `cos`, `tan`, `ln`
     /// (natural log), `log` (base-10), `exp`. Unlike the rounding unary ops these
     /// are **not** dimension-preserving: a transcendental is only defined on a
@@ -291,6 +301,7 @@ impl ComputeOp {
             ComputeOp::Floor => "floor",
             ComputeOp::Ceil => "ceil",
             ComputeOp::Round => "round",
+            ComputeOp::Trunc => "trunc",
             ComputeOp::Sin => "sin",
             ComputeOp::Cos => "cos",
             ComputeOp::Tan => "tan",
@@ -836,6 +847,7 @@ fn eval_unary(
         ComputeOp::Floor => value.floor(),
         ComputeOp::Ceil => value.ceil(),
         ComputeOp::Round => value.round(),
+        ComputeOp::Trunc => value.trunc(),
         ComputeOp::Sin => value.sin(),
         ComputeOp::Cos => value.cos(),
         ComputeOp::Tan => value.tan(),
@@ -908,6 +920,10 @@ fn eval_unary(
             };
             ExactRational::new(q.checked_add(bump)?, 1)
         }
+        // trunc(num/den) truncates toward zero — exactly Rust's integer division for
+        // den > 0 (no `div_euclid`, which would floor toward −∞). The result is an
+        // integer, carried as q/1.
+        ComputeOp::Trunc => ExactRational::new(r.num / r.den, 1),
         _ => None,
     });
     // Rounding preserves the operand's dimension; a transcendental collapses to a
@@ -1337,6 +1353,47 @@ mod tests {
         assert_eq!(d.exact, ExactRational::new(2, 1));
         // Same dimension as the operand `m` (money/usd).
         assert_eq!(d.dim, kb.observed_dimensioned("m").unwrap().0.dim);
+    }
+
+    #[test]
+    fn trunc_drops_the_fraction_toward_zero_and_preserves_dimension() {
+        // trunc(7/2) = 3 (3.5 → drop the .5). Trunc is dimension-preserving:
+        // trunc(dollars) is still dollars, NOT collapsed to Scalar.
+        let kb = kb_with(vec![money("m", 7, "usd")]);
+        let d = compute(
+            "tr",
+            &ComputeExpr::Unary(
+                ComputeOp::Trunc,
+                Box::new(bin(ComputeOp::Div, refexpr("m"), ComputeExpr::Lit(2.0))),
+            ),
+            &kb,
+        )
+        .unwrap();
+        assert_eq!(d.value, 3.0);
+        assert_eq!(d.exact, ExactRational::new(3, 1));
+        assert_eq!(d.dim, kb.observed_dimensioned("m").unwrap().0.dim);
+    }
+
+    #[test]
+    fn trunc_of_a_negative_value_goes_toward_zero_not_down() {
+        // trunc(−7/2) = −3 (toward zero), NOT −4 the way Floor rounds toward −∞.
+        // This is the whole point of adding Trunc beside Floor: (−7)/2 == −3 in
+        // Rust integer division (truncation), vs (−7).div_euclid(2) == −4.
+        let d = compute(
+            "tr",
+            &ComputeExpr::Unary(
+                ComputeOp::Trunc,
+                Box::new(bin(
+                    ComputeOp::Div,
+                    ComputeExpr::Lit(-7.0),
+                    ComputeExpr::Lit(2.0),
+                )),
+            ),
+            &kb_with(vec![]),
+        )
+        .unwrap();
+        assert_eq!(d.value, -3.0);
+        assert_eq!(d.exact, ExactRational::new(-3, 1));
     }
 
     #[test]


### PR DESCRIPTION
## `\operatorname{trunc}(x)` — truncation toward zero → `ComputeOp::Trunc`

Adds truncation-toward-zero to the `latex "…"` surface — **the last common scalar unary** the frontend already parsed but the adapter did not consume. Completes the rounding family (`Abs`/`Floor`/`Ceil`/`Round`) with `Trunc`.

### logic-engine
- **`ComputeOp::Trunc`** — unary, **dimension-preserving** (`trunc(3.7 mmol) = 3 mmol`). Folded into the **existing** `eval_unary` match arms (f64 `value.trunc()` + exact `num / den`, Rust integer division toward zero for `den > 0`), so `eval`'s recursive frame is unchanged — no new frame on the depth-capped recursion path, no parallel if-block or helper (the macOS stack-overflow discipline from the min/max PR).
- Contrast `Floor` (toward −∞: `⌊−3.7⌋ = −4`); `trunc(−3.7) = −3`. They agree only for a non-negative operand. Excluded from the transcendental set → stays dimension-preserving, exact sidecar kept.
- Two unit tests: `trunc(7/2) = 3` (dimension-preserving) and `trunc(−7/2) = −3` (toward zero, NOT the `Floor` −4).

### adj-lang
- **`ExprAst::Trunc`** + lowering to `ComputeOp::Trunc`.
- Adapter recognises the **operator-name juxtaposition**. `\operatorname{…}` is a TEXT command, so `\operatorname{trunc}(x)` parses NOT as a `Call` but as an implicit multiplication `Bin(Mul, Text("trunc"), (x))`. A new arm **above** the general `Bin(Mul)` arm (guarded by a new `operator_name_is` helper) intercepts exactly that shape; a genuine product (`2x`) still multiplies, and any other operator name falls through to an explicit `UnsupportedLatexMath` — never a silent mis-lowering. The parse shape was empirically confirmed before wiring.
- Two end-to-end lower tests via `compile_and_decide`: `\operatorname{trunc}(a/b)` = 3 and `\operatorname{trunc}((0 - a)/b)` = −3.

The full unary math surface + binary `\min`/`\max` + binary `\gcd`/`\lcm` are now consumed; only `Func::Det` (matrix, no scalar meaning) and unknown `Other` remain unsupported.

### Housekeeping
- Versions: logic-engine 0.34.0 → 0.35.0, adj-lang 0.29.0 → 0.30.0; CHANGELOGs updated.
- Tests: 4 new (2 engine + 2 lowering) all pass; downstream consumers (adj-constraint-solver, adj-lang-cli, adjudication-pipeline) green.
- Security-reviewed inline — **PASSED** (i128 division safe under the `den > 0` `ExactRational` invariant, finite-guard covers the f64 arm, recursion bounded by `MAX_EVAL_DEPTH`, adapter arm correctly ordered, no injection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
