### PR TITLE
[codex] Expand fostered nobr repair evidence

### DIFF
--- a/code/packages/rust/html-parser/tests/whatwg_form_interactive_audit_test.rs
+++ b/code/packages/rust/html-parser/tests/whatwg_form_interactive_audit_test.rs
@@ -8,6 +8,7 @@ const TREE_CONSTRUCTION_SMOKE: &str = include_str!("fixtures/html5lib-tree-const
 const WHATWG_FORM_INTERACTIVE_AUDIT: &str =
     include_str!("fixtures/whatwg-form-interactive-audit.json");
 const POST_PARSE_REPAIR_EVIDENCE: &[(&str, &str)] = &[
+    ("tests26-dat-4", "interactive-formatting"),
     ("tests26-dat-1251", "interactive-formatting"),
     ("tricky01-dat-5", "form-control"),
     ("tricky01-dat-7", "interactive-formatting"),

--- a/code/packages/rust/html-parser/tests/whatwg_formatting_audit_test.rs
+++ b/code/packages/rust/html-parser/tests/whatwg_formatting_audit_test.rs
@@ -10,6 +10,7 @@ const POST_PARSE_REPAIR_EVIDENCE: &[(&str, &str)] = &[
     ("adoption01-dat-16", "formatting-reconstruction"),
     ("scripted-adoption01-dat-1", "adoption-agency-formatting"),
     ("scripted-ark-dat-1", "adoption-agency-formatting"),
+    ("tests26-dat-4", "interactive-formatting-boundary"),
     ("tricky01-dat-1", "adoption-agency-formatting"),
     ("tricky01-dat-3", "adoption-agency-formatting"),
     ("tricky01-dat-7", "interactive-formatting-boundary"),

--- a/code/packages/rust/html-parser/tests/whatwg_head_body_audit_test.rs
+++ b/code/packages/rust/html-parser/tests/whatwg_head_body_audit_test.rs
@@ -10,6 +10,7 @@ const POST_PARSE_REPAIR_EVIDENCE: &[(&str, &str)] = &[
     ("scripted-adoption01-dat-1", "head-text-mode"),
     ("scripted-webkit01-dat-1", "head-text-mode"),
     ("scripted-webkit01-dat-2", "head-text-mode"),
+    ("tests26-dat-4", "body-boundary"),
     ("tests26-dat-1251", "body-boundary"),
     ("tricky01-dat-3", "body-boundary"),
 ];

--- a/code/packages/rust/html-parser/tests/whatwg_table_audit_test.rs
+++ b/code/packages/rust/html-parser/tests/whatwg_table_audit_test.rs
@@ -8,11 +8,13 @@ const TREE_CONSTRUCTION_SMOKE: &str = include_str!("fixtures/html5lib-tree-const
 const WHATWG_TABLE_AUDIT: &str = include_str!("fixtures/whatwg-table-audit.json");
 const POST_PARSE_REPAIR_EVIDENCE: &[(&str, &str)] = &[
     ("adoption01-dat-6", "foster-parenting"),
+    ("tests26-dat-4", "cell-boundary"),
     ("tests26-dat-1251", "cell-boundary"),
     ("tricky01-dat-6", "cell-boundary"),
     ("tricky01-dat-7", "row-group-boundary"),
     ("tricky01-dat-8", "cell-boundary"),
 ];
+const DUPLICATE_FOSTERED_NOBR_ROWS: &[(&str, &str)] = &[("tests26-dat-4", "tests26-dat-1251")];
 
 #[derive(Debug, Deserialize)]
 struct TableAuditSuite {
@@ -115,6 +117,54 @@ fn whatwg_table_audit_tracks_post_parse_repair_evidence() {
             actual, source_case.document,
             "post-parse repair evidence case `{}` ({}) failed for input {:?}",
             audit_case.id, audit_case.axis, source_case.data
+        );
+    }
+}
+
+#[test]
+fn whatwg_table_audit_keeps_duplicate_fostered_nobr_rows_in_lockstep() {
+    let suite = load_suite();
+    let audit_cases = suite
+        .cases
+        .iter()
+        .map(|case| (case.id.as_str(), case))
+        .collect::<HashMap<_, _>>();
+    let smoke_cases = parse_tree_construction_cases(TREE_CONSTRUCTION_SMOKE)
+        .into_iter()
+        .map(|case| (case.source.clone(), case))
+        .collect::<HashMap<_, _>>();
+
+    for (left_id, right_id) in DUPLICATE_FOSTERED_NOBR_ROWS {
+        let left = audit_cases
+            .get(left_id)
+            .unwrap_or_else(|| panic!("duplicate evidence case `{left_id}` should be audited"));
+        let right = audit_cases
+            .get(right_id)
+            .unwrap_or_else(|| panic!("duplicate evidence case `{right_id}` should be audited"));
+
+        assert_eq!(
+            left.axis, right.axis,
+            "duplicate fostered `nobr` evidence rows should stay on the same audit axis"
+        );
+        assert_eq!(
+            left.reason, right.reason,
+            "duplicate fostered `nobr` evidence rows should keep the same audit reason"
+        );
+
+        let left_source = smoke_cases
+            .get(&left.source)
+            .unwrap_or_else(|| panic!("case `{left_id}` should exist in smoke fixture"));
+        let right_source = smoke_cases
+            .get(&right.source)
+            .unwrap_or_else(|| panic!("case `{right_id}` should exist in smoke fixture"));
+
+        assert_eq!(
+            left_source.data, right_source.data,
+            "duplicate fostered `nobr` evidence rows should keep matching input"
+        );
+        assert_eq!(
+            left_source.document, right_source.document,
+            "duplicate fostered `nobr` evidence rows should keep matching expected DOM"
         );
     }
 }


### PR DESCRIPTION
## Summary
- include the earlier duplicate `tests26-dat-4` fostered `nobr` table-cell row in the focused post-parse repair evidence guards
- add a table-audit lockstep check proving `tests26-dat-4` and `tests26-dat-1251` keep identical smoke input, expected DOM, axis, and reason metadata

## Validation
- `cargo fmt -p coding-adventures-html-parser`
- `cargo test -p coding-adventures-html-parser font_newline_before_bold_stays_outside_reconstructed_font`
- all focused `whatwg_*_tracks_post_parse_repair_evidence` / executable evidence tests requested by the monitor
- all focused `whatwg_*_cases_match_parser_dom_dump` tests requested by the monitor
- `cargo test -p coding-adventures-html-parser html5lib_tree_construction_smoke_cases_match_dom_dump`
- `cargo test -p coding-adventures-html-parser`
- `CARGO_BUILD_JOBS=2 cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser`
- `python3 -m json.tool code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json >/dev/null`
- `python3 code/packages/rust/html-parser/tests/fixtures/check_whatwg_audit_rust_tests.py --check`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py`
- `git diff --check`
