### PR TITLE
feat(sir-ts): mixin MRO — include/extend module method resolution (MX3)

### DIFF
--- a/code/packages/rust/semantic-ir-to-typescript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-typescript/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## 0.7.0 — Ruby mixins: `include` / `extend` emit arms (MX3)
+
+Part of the `sir-mixins` cascade (spec `code/specs/sir-mixins.md`). Adds the
+TypeScript emit arms for the mixin builtins the Ruby frontend (MX1) lowers, so
+the emitted code drives the `@coding-adventures/sir-runtime-oop` MX3 runtime
+(`0.1.11`). Class/method/module names all arrive as `StrLit`s and emit through
+the normal expression path (`quote_ts_string`) — no source-derived name is ever
+interpolated raw (the C3 RCE lesson).
+
+### Added
+
+- **`__include__("Owner", "M")` → `__SirOop.includeModule("Owner", "M")`** and
+  **`__extend__("Owner", "M")` → `__SirOop.extendModule("Owner", "M")`** — the
+  two mixin directives now route to the OOP runtime's include-list and
+  class-method-copy helpers.
+- **`__class_method__("Class", "method", …args)` →
+  `__SirOop.callClassMethod(...)`** (issue #59, mirrored from the Python
+  backend, which already had it). Previously a `Foo.bar` class-method call fell
+  through to the generic `__Sir.callBuiltin("__class_method__", […])` dispatch
+  on the TS side; it now routes to the OOP runtime, which is what makes a
+  method mixed in via `extend M` callable as `Owner.method`.
+- The OOP-runtime import gate now also fires on `__include__`, `__extend__`,
+  and `__class_method__`.
+- Execution proofs in `run_with_node.rs` (MX3): five tests lower real Ruby
+  mixin programs → TypeScript → `node`, proving an included module method is
+  callable, a class method shadows the module's, the most-recently-included
+  module wins, a diamond include resolves once, and `extend` makes a module
+  method a class method. Plus emit-shape unit tests for the three new arms.
+
 ## 0.6.0 — `puts` builtin (Ruby semantics)
 
 ### Added

--- a/code/packages/rust/semantic-ir-to-typescript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-typescript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-typescript"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 description = "Semantic IR → self-contained TypeScript source code (SIR12). First backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
@@ -57,7 +57,14 @@ fn uses_oop(m: &Module) -> bool {
         || module_uses_builtin(m, "__super__")
         || module_uses_builtin(m, "__def_method__")
         || module_uses_builtin(m, "__def_class_method__")
+        || module_uses_builtin(m, "__class_method__")
         || module_uses_builtin(m, "__self__")
+        // Mixin directives (MX3): `include M` / `extend M` route to the OOP
+        // runtime's `includeModule`/`extendModule`, so their presence pulls in
+        // the import (the frontend pairs them with module `__def_method__`s,
+        // which already gate, but the gate must not depend on that).
+        || module_uses_builtin(m, "__include__")
+        || module_uses_builtin(m, "__extend__")
 }
 
 /// True if the module uses exception handling, in which case the emitted
@@ -1424,6 +1431,41 @@ fn emit_builtin_call(out: &mut String, name: &str, args: &[Expr], indent: usize)
         out.push(')');
         return;
     }
+    // Class-method CALL dispatch `Foo.bar(args)` (const receiver) →
+    // `__SirOop.callClassMethod("Foo", "bar", args…)` (issue #59, mirrored from
+    // the Python backend).  Needed for `extend M`'s methods (registered as class
+    // methods) to be callable as `Owner.method`.  The class + method names
+    // arrive as `StrLit`s through the normal expression path — never a raw
+    // source-derived name (the C3 RCE lesson).
+    if name == "__class_method__" && args.len() >= 2 {
+        out.push_str("__SirOop.callClassMethod(");
+        emit_args(out, args, indent);
+        out.push(')');
+        return;
+    }
+    // Mixin directives (MX3).  The Ruby frontend (MX1) lowers `include M` /
+    // `extend M` in a class/module body to these two builtins, both carrying the
+    // owner and module names as `StrLit`s (never a source-derived value that is
+    // interpolated raw — the C3 RCE lesson):
+    //
+    //   __include__("Owner", "M")  → __SirOop.includeModule("Owner", "M")
+    //   __extend__("Owner", "M")   → __SirOop.extendModule("Owner", "M")
+    //
+    // `includeModule` appends `M` to the owner's include-order list (consulted
+    // by the method-resolution walk); `extendModule` copies `M`'s instance
+    // methods into the owner's class-method table (`Owner.method`).
+    if name == "__include__" && args.len() == 2 {
+        out.push_str("__SirOop.includeModule(");
+        emit_args(out, args, indent);
+        out.push(')');
+        return;
+    }
+    if name == "__extend__" && args.len() == 2 {
+        out.push_str("__SirOop.extendModule(");
+        emit_args(out, args, indent);
+        out.push(')');
+        return;
+    }
     if name == "__self__" && args.is_empty() {
         out.push_str("__SirOop.currentSelfVal()");
         return;
@@ -2301,6 +2343,33 @@ mod tests {
         let mut out = String::new();
         emit_expr(&mut out, &e, 0);
         assert_eq!(out, "__SirOop.currentSelfVal()");
+    }
+
+    #[test]
+    fn class_method_call_emits_call_class_method_ts() {
+        // __class_method__("Counter", "zero") → __SirOop.callClassMethod("Counter", "zero").
+        let e = ts_builtin("__class_method__", vec![ts_str_lit("Counter"), ts_str_lit("zero")]);
+        let mut out = String::new();
+        emit_expr(&mut out, &e, 0);
+        assert_eq!(out, r#"__SirOop.callClassMethod("Counter", "zero")"#);
+    }
+
+    #[test]
+    fn mixin_include_emits_include_module_ts() {
+        // __include__("Greeter", "Loud") → __SirOop.includeModule("Greeter", "Loud").
+        let e = ts_builtin("__include__", vec![ts_str_lit("Greeter"), ts_str_lit("Loud")]);
+        let mut out = String::new();
+        emit_expr(&mut out, &e, 0);
+        assert_eq!(out, r#"__SirOop.includeModule("Greeter", "Loud")"#);
+    }
+
+    #[test]
+    fn mixin_extend_emits_extend_module_ts() {
+        // __extend__("Widget", "Describable") → __SirOop.extendModule("Widget", "Describable").
+        let e = ts_builtin("__extend__", vec![ts_str_lit("Widget"), ts_str_lit("Describable")]);
+        let mut out = String::new();
+        emit_expr(&mut out, &e, 0);
+        assert_eq!(out, r#"__SirOop.extendModule("Widget", "Describable")"#);
     }
 
     #[test]

--- a/code/packages/rust/semantic-ir-to-typescript/tests/run_with_node.rs
+++ b/code/packages/rust/semantic-ir-to-typescript/tests/run_with_node.rs
@@ -1349,3 +1349,247 @@ fn t2_index_ops_still_return_nil_no_overraise_ts() {
         );
     }
 }
+
+// ── MX3: Ruby mixins (include / extend) → TypeScript → node execution proof ───
+//
+// MX1 (merged) lowers `module M`, `include M`, and `extend M` to the
+// `__def_method__` / `__include__` / `__extend__` builtins; MX3 makes the TS
+// OOP runtime EXECUTE them.  These proofs lower REAL Ruby through
+// `ruby-to-semantic-ir`, compile to TypeScript, and run under `node` — the same
+// programs the reference (Python) backend proves.
+//
+// As with every node proof here, the workspace runtime cannot be resolved under
+// bare `node`, so we swap the OOP import for a faithful inline `__SirOop` stub
+// that TRANSCRIBES the real MX3 logic added to `@coding-adventures/sir-runtime-oop`:
+//   • `includeModule` appends to the owner's include-order list;
+//   • `extendModule` copies a module's instance methods into the owner's
+//     class-method table;
+//   • `resolveInstanceMethod` walks Ruby's MRO — class first, then its modules
+//     most-recent-first (depth-first, `seen`-de-duplicated for diamonds), then
+//     the superclass — so a class method SHADOWS a module method and a diamond
+//     resolves once.
+// Keeping the real MRO here means the proof exercises "the mixed-in method is
+// found by the module-aware walk", not just that the emitted calls are present.
+
+const SIR_OOP_MIXIN_STUB: &str = r#"const __SirOop = (() => {
+  const SEP = "\x00";
+  const key = (c, m) => c + SEP + m;
+  const supers = new Map();
+  const instanceMethods = new Map();
+  const classMethods = new Map();
+  const includedModules = new Map();
+  const selfStack = [];
+  const defaultSelf = { sirClass: "Object", ivars: new Map() };
+  class SirInstance { constructor(c) { this.sirClass = c; this.ivars = new Map(); } }
+  const curSelf = () => (selfStack.length ? selfStack[selfStack.length - 1] : defaultSelf);
+  const superclassOf = (n) => (supers.has(n) ? supers.get(n) : null);
+  const defineClass = (n, s) => { supers.set(n, s ?? null); };
+  const defMethod = (c, m, fn) => { instanceMethods.set(key(c, m), fn); };
+  const defClassMethod = (c, m, fn) => { classMethods.set(key(c, m), fn); };
+  const ivarSet = (n, v) => { curSelf().ivars.set(n, v); return v; };
+  const ivarGet = (n) => { const iv = curSelf().ivars; return iv.has(n) ? iv.get(n) : null; };
+  const includeModule = (owner, mod) => {
+    const list = includedModules.get(owner);
+    if (list === undefined) includedModules.set(owner, [mod]);
+    else if (!list.includes(mod)) list.push(mod);
+  };
+  const extendModule = (owner, mod) => {
+    const prefix = mod + SEP;
+    for (const [k, fn] of instanceMethods) {
+      if (k.startsWith(prefix)) classMethods.set(key(owner, k.slice(prefix.length)), fn);
+    }
+  };
+  const resolve = (className, methodName) => {
+    const seen = new Set();
+    const searchOwner = (owner) => {
+      if (seen.has(owner)) return null;
+      seen.add(owner);
+      const own = instanceMethods.get(key(owner, methodName));
+      if (own !== undefined) return own;
+      const mods = includedModules.get(owner);
+      if (mods !== undefined) {
+        for (let i = mods.length - 1; i >= 0; i--) {
+          const hit = searchOwner(mods[i]);
+          if (hit !== null) return hit;
+        }
+      }
+      return null;
+    };
+    let cur = className; const seenClasses = new Set();
+    while (cur !== null && !seenClasses.has(cur)) {
+      seenClasses.add(cur);
+      const hit = searchOwner(cur);
+      if (hit !== null) return hit;
+      cur = superclassOf(cur);
+    }
+    return null;
+  };
+  const resolveClass = (className, methodName) => {
+    let cur = className; const seen = new Set();
+    while (cur !== null && !seen.has(cur)) {
+      const fn = classMethods.get(key(cur, methodName));
+      if (fn !== undefined) return fn;
+      seen.add(cur); cur = superclassOf(cur);
+    }
+    return null;
+  };
+  const callNew = (c, ...args) => {
+    const obj = new SirInstance(c);
+    selfStack.push(obj);
+    try { const init = resolve(c, "initialize"); if (init !== null) __Sir.apply(init, args); }
+    finally { selfStack.pop(); }
+    return obj;
+  };
+  const callMethod = (recv, name, ...args) => {
+    if (recv instanceof SirInstance) {
+      const fn = resolve(recv.sirClass, name);
+      if (fn !== null) {
+        selfStack.push(recv);
+        try { return __Sir.apply(fn, args); } finally { selfStack.pop(); }
+      }
+    }
+    return null;
+  };
+  const callClassMethod = (c, name, ...args) => {
+    const fn = resolveClass(c, name);
+    return fn === null ? null : __Sir.apply(fn, args);
+  };
+  return { defineClass, defMethod, defClassMethod, includeModule, extendModule,
+           callNew, callMethod, callClassMethod, ivarSet, ivarGet };
+})();
+"#;
+
+/// A `__Sir` stub carrying `Closure` + `apply` (for method closures) plus a
+/// Ruby-flavoured `puts` (string+newline; the MX3 programs print via `puts`).
+const SIR_CLOSURE_MIXIN_STUB: &str = r#"const __Sir = {
+  Closure: class { constructor(fn) { this.fn = fn; } },
+  apply: (c, args) => c.fn(...args),
+  toDisplay: (v) => (v === null ? "nil" : String(v)),
+  puts: (...args) => {
+    if (args.length === 0) { process.stdout.write("\n"); return null; }
+    for (const a of args) {
+      const t = __Sir.toDisplay(a);
+      process.stdout.write(t.endsWith("\n") ? t : t + "\n");
+    }
+    return null;
+  },
+};
+"#;
+
+fn ruby_mixin_ts_to_runnable_js(ts: &str) -> String {
+    let mut js = ts.to_string();
+    js = js.replace(
+        "import * as __Sir from \"@coding-adventures/sir-runtime-core\";\n",
+        SIR_CLOSURE_MIXIN_STUB,
+    );
+    js = js.replace(
+        "import * as __SirOop from \"@coding-adventures/sir-runtime-oop\";\n",
+        SIR_OOP_MIXIN_STUB,
+    );
+    js = js.replace(" as { [k: string]: __Sir.Val }", "");
+    js = js.replace(": __Sir.Val[]", "");
+    js = js.replace(": __Sir.Val", "");
+    js
+}
+
+/// Compile a Ruby-lowered mixin module → TS → JS with the MX3 stub, run under
+/// node, and return trimmed stdout.  `None` when node is unavailable.
+fn run_mixin_source(src: &str, tag: &str) -> Option<String> {
+    let module = ruby_to_semantic_ir::compile_source(src, tag).expect("lower ruby");
+    let artifact = compile(&module).expect("compile to typescript");
+    if !node_available() {
+        eprintln!("note: `node` unavailable — skipping MX3 execution for `{tag}`");
+        return None;
+    }
+    let js = ruby_mixin_ts_to_runnable_js(&artifact.source);
+    let mut path: PathBuf = std::env::temp_dir();
+    path.push(format!("sir_ts_mixin_{}_{}.js", tag, std::process::id()));
+    std::fs::write(&path, &js).expect("write temp js");
+    let output = Command::new("node").arg(&path).output().expect("spawn node");
+    let _ = std::fs::remove_file(&path);
+    assert!(
+        output.status.success(),
+        "node exited non-zero for `{tag}`:\nstdout: {}\nstderr: {}\nsource:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+        js,
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout)
+        .trim_end_matches(['\n', '\r'])
+        .to_string();
+    Some(stdout)
+}
+
+#[test]
+fn mx3_included_module_method_is_callable_ts() {
+    // A module instance method mixed into a class is found on an instance.
+    let src = "module Greeter\n  def greet\n    \"hello\"\n  end\nend\n\
+               class Person\n  include Greeter\nend\n\
+               puts Person.new.greet\n";
+    // Shape: the mixin directive maps to the runtime helper.
+    let module = ruby_to_semantic_ir::compile_source(src, "mx_inc").expect("lower ruby");
+    let artifact = compile(&module).expect("compile");
+    assert!(
+        artifact.source.contains("__SirOop.includeModule(\"Person\", \"Greeter\")"),
+        "include must map to includeModule; got:\n{}",
+        artifact.source
+    );
+    if let Some(stdout) = run_mixin_source(src, "mx_inc") {
+        assert_eq!(stdout, "hello", "mixed-in module method must be callable");
+    }
+}
+
+#[test]
+fn mx3_class_method_shadows_module_method_ts() {
+    // The class defines `greet` itself → class-first MRO shadows the module's.
+    let src = "module Greeter\n  def greet\n    \"from module\"\n  end\nend\n\
+               class Person\n  include Greeter\n  def greet\n    \"from class\"\n  end\nend\n\
+               puts Person.new.greet\n";
+    if let Some(stdout) = run_mixin_source(src, "mx_shadow") {
+        assert_eq!(stdout, "from class", "class method must shadow the included module's");
+    }
+}
+
+#[test]
+fn mx3_most_recently_included_module_wins_ts() {
+    // Two modules define the same method; the LAST included wins (reverse walk).
+    let src = "module A\n  def who\n    \"A\"\n  end\nend\n\
+               module B\n  def who\n    \"B\"\n  end\nend\n\
+               class C\n  include A\n  include B\nend\n\
+               puts C.new.who\n";
+    if let Some(stdout) = run_mixin_source(src, "mx_recent") {
+        assert_eq!(stdout, "B", "most recently included module wins the MRO");
+    }
+}
+
+#[test]
+fn mx3_diamond_include_resolves_once_ts() {
+    // Diamond: C includes X and Y, both of which include Base.  Base#tag is
+    // found exactly once (the `seen` set de-duplicates), and the program runs.
+    let src = "module Base\n  def tag\n    \"base\"\n  end\nend\n\
+               module X\n  include Base\nend\n\
+               module Y\n  include Base\nend\n\
+               class C\n  include X\n  include Y\nend\n\
+               puts C.new.tag\n";
+    if let Some(stdout) = run_mixin_source(src, "mx_diamond") {
+        assert_eq!(stdout, "base", "diamond include must resolve the shared module once");
+    }
+}
+
+#[test]
+fn mx3_extend_makes_module_method_a_class_method_ts() {
+    // `extend M` mixes M's instance methods as CLASS methods → `Widget.describe`.
+    let src = "module Describable\n  def describe\n    \"a widget\"\n  end\nend\n\
+               class Widget\n  extend Describable\nend\n\
+               puts Widget.describe\n";
+    let module = ruby_to_semantic_ir::compile_source(src, "mx_ext").expect("lower ruby");
+    let artifact = compile(&module).expect("compile");
+    assert!(
+        artifact.source.contains("__SirOop.extendModule(\"Widget\", \"Describable\")"),
+        "extend must map to extendModule; got:\n{}",
+        artifact.source
+    );
+    if let Some(stdout) = run_mixin_source(src, "mx_ext") {
+        assert_eq!(stdout, "a widget", "extend must make the module method a class method");
+    }
+}

--- a/code/packages/typescript/sir-runtime-oop/CHANGELOG.md
+++ b/code/packages/typescript/sir-runtime-oop/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable changes to `@coding-adventures/sir-runtime-oop` are documented here.
 
+## [0.1.11] - 2026-07-02
+
+### Added — Ruby mixins: `include` / `extend` + module-aware MRO (MX3)
+
+Part of the `sir-mixins` cascade (spec `code/specs/sir-mixins.md`). The OOP
+runtime now executes Ruby mixins: a module registers its `def`s via the
+existing `defMethod` keyed on the *module* name (as the frontend's MX1 lowering
+emits), and two new helpers weave modules into an owner's method resolution.
+All dispatch stays explicit-table and cycle-guarded (never reflection — the C3
+RCE lesson).
+
+- **`includeModule(owner, moduleName)`** (from `__include__("Owner", "M")`) —
+  appends `M` to the owner's per-owner **include-order list**
+  (`includedModules`). A repeated include is a no-op.
+- **`extendModule(owner, moduleName)`** (from `__extend__("Owner", "M")`) —
+  copies the module's instance methods into the owner's **class-method** table,
+  so they become callable as `Owner.method` (Ruby `extend`).
+- **Module-aware MRO in `resolveInstanceMethod`.** The method-resolution walk
+  now implements Ruby's method resolution order: class → the class's included
+  modules **most-recent-first** (depth-first, recursing into a module's own
+  includes) → superclass → its modules → … A single `seen` set spans the whole
+  walk, so a **diamond** include (a module reachable by two paths) resolves
+  **once** at its earliest position, and a module that (transitively) includes
+  itself terminates rather than looping. A class's own method **shadows** a
+  module's (class-first); a module's method shadows the superclass's.
+- `resetOop` now also clears `includedModules`.
+- Extensive vitest coverage: included-method callable, class-shadows-module,
+  most-recent-included-wins, superclass-module reachability, diamond-resolves-
+  once, self-include terminates, re-include de-duplicated, `extend`→class
+  method (and NOT an instance method), multi-method extend, reset clears the
+  include table.
+
 ## [0.1.10] - 2026-07-01
 
 ### Changed — typed runtime errors from `.fetch` and unknown methods (T2)

--- a/code/packages/typescript/sir-runtime-oop/package.json
+++ b/code/packages/typescript/sir-runtime-oop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/sir-runtime-oop",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "OOP runtime for Semantic-IR-emitted TypeScript/JavaScript — class registry, is_a?/ancestry, instance- and class-variable stores, and reflective method dispatch",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/sir-runtime-oop/src/index.ts
+++ b/code/packages/typescript/sir-runtime-oop/src/index.ts
@@ -243,13 +243,72 @@ function methodKey(className: string, methodName: string): string {
 const instanceMethods = new Map<string, Closure>();
 const classMethods = new Map<string, Closure>();
 
+// ── Mixins: per-owner included-module list (MX3) ─────────────────────────────
+//
+// Ruby's `include M` weaves module `M` into an owner's ancestry *between the
+// owner and its superclass*.  Because a module registers its `def`s exactly
+// like a class (via `__def_method__` keyed by the MODULE name), the only new
+// state the method-resolution walk needs is **which modules each owner
+// includes, in include order**.  We keep that as an explicit list per owner —
+// no reflection, no scanning the whole method table (the C3 RCE lesson: every
+// dispatch decision is a plain `Map`/array lookup on a source-derived name we
+// merely *store*, never *interpret*).
+//
+//     includedModules.get("Greeter") -> ["Loud", "Polite"]   // include order
+//
+// Ruby searches the *most recently included* module first, so the resolution
+// walk iterates this list in **reverse** (`Polite` before `Loud`).  A diamond
+// (a module reachable by two paths) is de-duplicated by the walk's `seen` set,
+// so it is searched once — at its earliest (deepest-first) position.
+const includedModules = new Map<string, string[]>();
+
 /**
  * Register instance method `methodName` for `className` (`def m`).  Emitted by
  * the frontend as `__def_method__`; `fn` is the hoisted top-level function as a
- * `Closure`.
+ * `Closure`.  A *module* body's `def` registers here too — the frontend keys it
+ * on the module name, so `owner` is simply a module rather than a class.
  */
 export function defMethod(className: string, methodName: string, fn: Closure): void {
   instanceMethods.set(methodKey(className, methodName), fn);
+}
+
+/**
+ * Record that `owner` `include`s module `moduleName` (`include M` in a
+ * class/module body → `__include__("Owner", "M")`).  Appended in include order;
+ * a repeated include of the same module is a no-op (Ruby re-orders rather than
+ * duplicates, but the resolution walk's `seen` set already de-duplicates, so
+ * keeping the first position is faithful for the mechanisms this cascade
+ * covers).  The module's own `def`s must already be registered (the frontend
+ * emits the module's `__def_method__`s before any `__include__` referencing it).
+ */
+export function includeModule(owner: string, moduleName: string): void {
+  const list = includedModules.get(owner);
+  if (list === undefined) {
+    includedModules.set(owner, [moduleName]);
+  } else if (!list.includes(moduleName)) {
+    list.push(moduleName);
+  }
+}
+
+/**
+ * Mix module `moduleName`'s instance methods into `owner` as **class methods**
+ * (`extend M` → `__extend__("Owner", "M")`).  Ruby's `extend` makes the
+ * module's methods callable on the class/singleton itself (`Owner.method`), so
+ * each `def` the module registered as an *instance* method is copied into
+ * `owner`'s class-method table.  We copy the closures explicitly (a plain
+ * table-to-table transfer, never reflection) at extend time; a module method
+ * added *after* the `extend` is not retroactively picked up (v0 floor — real
+ * programs `extend` after defining the module, which the frontend guarantees by
+ * emitting the module's `__def_method__`s first).
+ */
+export function extendModule(owner: string, moduleName: string): void {
+  const prefix = moduleName + METHOD_KEY_SEP;
+  for (const [k, fn] of instanceMethods) {
+    if (k.startsWith(prefix)) {
+      const methodName = k.slice(prefix.length);
+      classMethods.set(methodKey(owner, methodName), fn);
+    }
+  }
 }
 
 /**
@@ -260,16 +319,59 @@ export function defClassMethod(className: string, methodName: string, fn: Closur
   classMethods.set(methodKey(className, methodName), fn);
 }
 
-/** Find `methodName` on `className` or any registered ancestor.  Walks the
- * superclass chain (cycle-guarded, reusing the `isA` `seen`-set pattern) and
- * returns the first matching `Closure`, or `null` if unresolved. */
+/**
+ * Find `methodName` on `className` or any registered ancestor, walking Ruby's
+ * **method resolution order** (MRO) — the mixin-aware generalisation of the
+ * plain superclass chain (MX3):
+ *
+ *     class C  →  C's included modules (most-recent-first)  →
+ *     C's superclass  →  its included modules  →  …  →  Object
+ *
+ * At each class in the ancestry we check the class's own table first (so a
+ * method the **class defines itself shadows a module's** — class-first MRO),
+ * then its included modules in **reverse** include order (Ruby searches the
+ * last-included module first).  A module in turn can itself `include` further
+ * modules, so the walk recurses into a module's own `includedModules` before
+ * moving on — this is the depth-first, most-recent-first linearisation.
+ *
+ * **Cycle / diamond guard.**  A single `seen` set spans the *entire* walk
+ * (classes and modules alike), so a module reachable by two paths (a diamond)
+ * is searched exactly **once**, at its earliest (deepest-first) position, and a
+ * module that (transitively) includes itself terminates rather than looping —
+ * reusing the exception-ancestry `seen`-set discipline.
+ *
+ * Returns the first matching `Closure`, or `null` if unresolved.
+ */
 function resolveInstanceMethod(className: string, methodName: string): Closure | null {
-  let cur: string | null = className;
   const seen = new Set<string>();
-  while (cur !== null && !seen.has(cur)) {
-    const fn = instanceMethods.get(methodKey(cur, methodName));
-    if (fn !== undefined) return fn;
-    seen.add(cur);
+
+  // Search `owner`'s own table, then (depth-first, most-recent-first) the
+  // modules it includes.  Returns the resolved closure or `null` for this
+  // subtree; the shared `seen` set makes the whole search diamond-safe.
+  function searchOwnerAndModules(owner: string): Closure | null {
+    if (seen.has(owner)) return null;
+    seen.add(owner);
+    const own = instanceMethods.get(methodKey(owner, methodName));
+    if (own !== undefined) return own;
+    const mods = includedModules.get(owner);
+    if (mods !== undefined) {
+      // Reverse include order: the most recently included module wins.
+      for (let i = mods.length - 1; i >= 0; i--) {
+        const hit = searchOwnerAndModules(mods[i]!);
+        if (hit !== null) return hit;
+      }
+    }
+    return null;
+  }
+
+  // Ascend the superclass chain; at each class search it + its modules before
+  // moving up.  `seen` also guards a cyclic superclass registration.
+  let cur: string | null = className;
+  const seenClasses = new Set<string>();
+  while (cur !== null && !seenClasses.has(cur)) {
+    seenClasses.add(cur);
+    const hit = searchOwnerAndModules(cur);
+    if (hit !== null) return hit;
     cur = superclassOf(cur);
   }
   return null;
@@ -1525,4 +1627,5 @@ export function resetOop(): void {
   methods.clear();
   instanceMethods.clear();
   classMethods.clear();
+  includedModules.clear();
 }

--- a/code/packages/typescript/sir-runtime-oop/tests/oop.test.ts
+++ b/code/packages/typescript/sir-runtime-oop/tests/oop.test.ts
@@ -16,6 +16,8 @@ import {
   defineClass,
   defineMethod,
   defMethod,
+  extendModule,
+  includeModule,
   isA,
   ivarGet,
   ivarSet,
@@ -937,5 +939,113 @@ describe("O1: user method tables, callNew / callSuper / self / class methods", (
     resetOop();
     expect(callClassMethod("Dog", "make")).toBeNull();
     expect(callSuper("speak", "Dog")).toBeNull();
+  });
+});
+
+// ── Mixins: include / extend / MRO (MX3) ─────────────────────────────────────
+//
+// A module registers its `def`s via `defMethod` keyed on the MODULE name
+// (exactly as the frontend emits `__def_method__("M", …)`); `includeModule`
+// then weaves the module into an owner's ancestry, and the method-resolution
+// walk (`callMethod`) finds the mixed-in method.  These tests exercise the four
+// spec-mandated behaviours end-to-end through the real dispatch path.
+describe("mixins: include / extend / MRO (MX3)", () => {
+  it("a module method included into a class is callable on an instance", () => {
+    defineClass("Person", null);
+    defMethod("Greeter", "greet", new Closure(() => "hello"));
+    includeModule("Person", "Greeter");
+    expect(callMethod(callNew("Person"), "greet")).toBe("hello");
+  });
+
+  it("a class method shadows an included module's method (class-first MRO)", () => {
+    defineClass("Person", null);
+    defMethod("Greeter", "greet", new Closure(() => "from module"));
+    defMethod("Person", "greet", new Closure(() => "from class"));
+    includeModule("Person", "Greeter");
+    expect(callMethod(callNew("Person"), "greet")).toBe("from class");
+  });
+
+  it("the most recently included module wins (reverse include order)", () => {
+    defineClass("C", null);
+    defMethod("A", "who", new Closure(() => "A"));
+    defMethod("B", "who", new Closure(() => "B"));
+    includeModule("C", "A");
+    includeModule("C", "B");
+    expect(callMethod(callNew("C"), "who")).toBe("B");
+  });
+
+  it("a superclass's included module is reachable (module shadows superclass, class shadows module)", () => {
+    // Base defines `rank`; a mixed-in module on the subclass shadows it; the
+    // subclass's own method shadows the module — full class→module→super MRO.
+    defineClass("Animal", null);
+    defineClass("Dog", "Animal");
+    defMethod("Animal", "rank", new Closure(() => "animal"));
+    defMethod("Trainable", "rank", new Closure(() => "trainable"));
+    includeModule("Dog", "Trainable");
+    // module (on Dog) shadows the Animal superclass method.
+    expect(callMethod(callNew("Dog"), "rank")).toBe("trainable");
+    // adding a Dog-own method shadows the module in turn.
+    defMethod("Dog", "rank", new Closure(() => "dog"));
+    expect(callMethod(callNew("Dog"), "rank")).toBe("dog");
+  });
+
+  it("a diamond include resolves the shared module once (cycle/dedup guard)", () => {
+    // C includes X and Y; both include Base.  Base#tag is found once and the
+    // walk terminates — no infinite loop even though Base is reachable twice.
+    defineClass("C", null);
+    defMethod("Base", "tag", new Closure(() => "base"));
+    includeModule("X", "Base");
+    includeModule("Y", "Base");
+    includeModule("C", "X");
+    includeModule("C", "Y");
+    expect(callMethod(callNew("C"), "tag")).toBe("base");
+  });
+
+  it("a self-including module terminates rather than looping", () => {
+    defineClass("C", null);
+    defMethod("Loopy", "ping", new Closure(() => "pong"));
+    includeModule("Loopy", "Loopy"); // pathological self-include
+    includeModule("C", "Loopy");
+    expect(callMethod(callNew("C"), "ping")).toBe("pong");
+    // an unresolved method still bottoms out (NoMethodError), not a hang.
+    expect(() => callMethod(callNew("C"), "nope")).toThrow(SirError);
+  });
+
+  it("a re-included module is not duplicated (first position kept)", () => {
+    defineClass("C", null);
+    defMethod("M", "hi", new Closure(() => "hi"));
+    includeModule("C", "M");
+    includeModule("C", "M"); // repeat is a no-op
+    expect(callMethod(callNew("C"), "hi")).toBe("hi");
+  });
+
+  it("extend makes a module's instance methods class methods on the owner", () => {
+    defineClass("Widget", null);
+    defMethod("Describable", "describe", new Closure(() => "a widget"));
+    extendModule("Widget", "Describable");
+    expect(callClassMethod("Widget", "describe")).toBe("a widget");
+    // extend does NOT make it an instance method.
+    expect(() => callMethod(callNew("Widget"), "describe")).toThrow(SirError);
+  });
+
+  it("extend copies every current module method into the class-method table", () => {
+    defineClass("W", null);
+    defMethod("Two", "a", new Closure(() => "a!"));
+    defMethod("Two", "b", new Closure(() => "b!"));
+    extendModule("W", "Two");
+    expect(callClassMethod("W", "a")).toBe("a!");
+    expect(callClassMethod("W", "b")).toBe("b!");
+  });
+
+  it("resetOop clears the included-modules table", () => {
+    defineClass("Person", null);
+    defMethod("Greeter", "greet", new Closure(() => "hi"));
+    includeModule("Person", "Greeter");
+    resetOop();
+    // After reset, re-register only the class + module def (no include): the
+    // mixed-in method must no longer resolve, proving the include list cleared.
+    defineClass("Person", null);
+    defMethod("Greeter", "greet", new Closure(() => "hi"));
+    expect(() => callMethod(callNew("Person"), "greet")).toThrow(SirError);
   });
 });


### PR DESCRIPTION
MX3 of the **sir-mixins** cascade (spec + MX1 frontend merged). Runtime-only — `sir-runtime-oop` (TS, `index.ts`) + `semantic-ir-to-typescript` emit arms.

Makes the TS OOP runtime execute Ruby mixins:
- `includeModule`/`extendModule` register into a per-owner `includedModules: Map<string,string[]>`.
- `resolveInstanceMethod` rewritten to Ruby MRO: **class → included modules (reverse/most-recent-first, depth-first) → superclass → its modules → …**, single `seen` set (diamond resolves once; self-include terminates).
- `extend` copies module methods into `classMethods`; class method **shadows** module; module shadows superclass.
- Also adds the `__class_method__` → `callClassMethod` emit arm (was missing on TS; needed to prove `extend` — bonus progress on #61).

Security review: **PASSED** — Map-keyed lookups (no `recv[name]`/`eval`/reflection), `seen`-guarded MRO terminates on cycles, Maps are immune to `__proto__`/`constructor` prototype pollution, names emit via `quote_ts_string`.

Execution-proofed by lowering **real Ruby** → TS → node (5 proofs) + vitest 105 + cargo 93 unit/19 integration green. Pre-existing #62 tsc gap untouched.

Note (non-security, follow-up): a class and module sharing a name in one hierarchy could skip a table via the shared `seen` — narrow Ruby-fidelity edge, not exploitable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)