### PR TITLE
feat(sir-go): mixin MRO — include/extend module method resolution (MX5)

### DIFF
--- a/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
@@ -1,5 +1,51 @@
 # Changelog
 
+## 0.13.0
+
+### Added — Ruby mixins: `module` + `include` / `extend` MRO (sir-mixins MX5)
+
+- The Go backend's emitted OOP runtime now EXECUTES Ruby mixins. A method
+  defined in a `module` and mixed into a class via `include` is found through
+  the class's Method Resolution Order; `extend` exposes a module's methods as
+  class methods. Runtime-only change; no core-IR or frontend edit. Dispatch
+  stays explicit NAME-keyed map lookup — NEVER reflection (the
+  [[dynamic-dispatch-rce]] discipline).
+- **`Feature::Modules` is now ACCEPTED.** A `Stmt::ModuleDef` (`module M; …;
+  end`) is hosted as a method *owner* alongside classes: its body's `def`s
+  register via the SAME `__def_method__("M", …)` builtin classes use (keyed by
+  the module name), and its body is emitted in order like a `ClassDef` body.
+  Previously `ModuleDef` was rejected at the soundness gate; the gate now
+  recurses into a module body for the residual `Const` checks instead.
+- **`__include__("Owner", "M")` → `_sir_include`** — appends `M` to a per-owner
+  included-module list (`_sir_included_modules map[string][]string`) in include
+  order. Ruby searches the most-recently-included module first, so the
+  resolution walk iterates this slice in REVERSE.
+- **MRO-extended method resolution** (`_sir_resolve_instance_method`): the walk
+  now follows class → its included modules (reverse, recursing so a module that
+  itself includes another is honoured) → superclass → its modules → … → Object.
+  A class's own method SHADOWS an included module's; a module method shadows the
+  superclass's. A module reached via two paths (a diamond) resolves ONCE, at its
+  earliest position, because the `seen` set skips an already-visited owner. The
+  walk is cycle-guarded (a self-including module or cyclic class hierarchy
+  TERMINATES).
+- **`__extend__("Owner", "M")` → `_sir_extend`** — copies `M`'s instance
+  methods (including those `M` itself includes) into `Owner`'s class-method
+  table, so they become callable as `Owner.method`. An entry `Owner` already
+  defines is not overwritten (own/class method shadows the extended module's).
+- **`__class_method__("C", "m", args…)` → `_sir_call_class_method`** — a new
+  emit arm + runtime helper wiring class-method *calls* (`Foo.bar`) through an
+  ancestry-walking lookup in the class-method table (which `extend` populates).
+  An unresolved name hits the controlled `NoMethodError` floor.
+- Emit arms added for `__include__`, `__extend__`, and `__class_method__`; all
+  owner/module/method NAMES ride in as `StrLit`s emitted through
+  `quote_go_string` (never interpolated), keeping the runtime side reflection-free.
+- Tests: five `go run` execution proofs (`compile_and_run_mixins.rs`) — an
+  included-module method callable on an instance, a class method shadowing the
+  module's, a module method shadowing the superclass's with a diamond include
+  resolving once, `extend` making a module method a class method, and a mixed-in
+  method reading an including class's `@ivar` through the shared self-stack —
+  plus emit + runtime unit tests for the new arms and helpers.
+
 ## 0.12.0
 
 ### Added — typed runtime errors: ZeroDivision / Index / Key / NoMethod (sir-typed-runtime-errors T4)

--- a/code/packages/rust/semantic-ir-to-go/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-go/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-go"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Semantic IR → self-contained Go source code (SIR15). Fourth backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-go/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/emit.rs
@@ -416,14 +416,22 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
                 emit_stmt(out, st, indent);
             }
         }
-        // Modules/singleton classes are not part of the E3 exception surface
-        // (`Feature::Modules` is not accepted; a `SingletonClassDef` observes
-        // `Feature::Classes` but the Ruby frontend only emits it for OOP, not
-        // exception subclasses).  A `ModuleDef` is rejected at the gate; a
-        // `SingletonClassDef` that slipped through carries no ancestry meaning
-        // here, so — defensively — emit its (hoisted-out) body statements.
-        Stmt::ModuleDef { span, .. } => {
-            panic!("go backend reached SIR17 module-def statement at {} — capability check should have rejected it", span);
+        // A `SingletonClassDef` observes `Feature::Classes` but the Ruby
+        // frontend only emits it for OOP, not exception subclasses; it carries
+        // no ancestry meaning here, so — defensively — emit its (hoisted-out)
+        // body statements.  (`ModuleDef` is handled above, as a MX5 mixin
+        // method owner.)
+        // MX5 (mixins) — a `module M; …; end` is a method OWNER, exactly like a
+        // class: the frontend hoists each module `def` to a top-level function
+        // and the `ModuleDef` body reaching here is the sequence of
+        // `__def_method__("M", …)` / `__include__` / `__extend__`
+        // registrations that wire those methods into the runtime tables.  Emit
+        // them in order (no ancestry edge — a module has no superclass), just
+        // like the `ClassDef` arm above.
+        Stmt::ModuleDef { body, .. } => {
+            for st in body {
+                emit_stmt(out, st, indent);
+            }
         }
         Stmt::SingletonClassDef { body, .. } => {
             for st in body {
@@ -1052,6 +1060,51 @@ fn emit_builtin_call(out: &mut String, name: &str, args: &[Expr], indent: usize)
     if name == "__self__" {
         out.push_str("_sir_current_self()");
         return;
+    }
+    // ── MX5 mixins: `include` / `extend` / class-method call ───────
+    //
+    // The mixin frontend (MX1) lowers module directives to two builtins,
+    // and a class-method call (`Foo.bar`) to a third — all carrying
+    // class/module/method NAMES as `StrLit`s emitted through
+    // `quote_go_string` (never interpolated), so the runtime side is a
+    // pure NAME-keyed map operation with no reflection (the C3 RCE
+    // discipline).
+    //
+    //   __include__(StrLit(owner), StrLit(m))          → _sir_include("owner", "m")
+    //   __extend__(StrLit(owner), StrLit(m))           → _sir_extend("owner", "m")
+    //   __class_method__(StrLit(cls), StrLit(m), args…)→ _sir_call_class_method("cls", "m", args…)
+    if (name == "__include__" || name == "__extend__") && args.len() >= 2 {
+        if let (Expr::StrLit { value: owner, .. }, Expr::StrLit { value: module, .. }) =
+            (&args[0], &args[1])
+        {
+            let helper = if name == "__include__" { "_sir_include" } else { "_sir_extend" };
+            let _ = write!(
+                out,
+                "{}({}, {})",
+                helper,
+                quote_go_string(owner),
+                quote_go_string(module)
+            );
+            return;
+        }
+    }
+    if name == "__class_method__" && args.len() >= 2 {
+        if let (Expr::StrLit { value: cls, .. }, Expr::StrLit { value: meth, .. }) =
+            (&args[0], &args[1])
+        {
+            let _ = write!(
+                out,
+                "_sir_call_class_method({}, {}",
+                quote_go_string(cls),
+                quote_go_string(meth)
+            );
+            for a in &args[2..] {
+                out.push_str(", ");
+                emit_expr(out, a, indent);
+            }
+            out.push(')');
+            return;
+        }
     }
     // ── SIR17 exceptions (E3): `raise` → panic ─────────────────────
     //
@@ -2685,6 +2738,38 @@ mod tests {
             out.starts_with(r#"_sir_def_class_method("Counter", "zero", _sir_make_closure("#),
             "unexpected emit: {out}"
         );
+    }
+
+    /// MX5 — `__include__("C", "M")` → `_sir_include("C", "M")` (NAME-keyed,
+    /// quoted, no reflection).
+    #[test]
+    fn include_emits_include_directive() {
+        let e = builtin("__include__", vec![str_lit("Person"), str_lit("Greet")]);
+        let mut out = String::new();
+        emit_expr(&mut out, &e, 0);
+        assert_eq!(out, r#"_sir_include("Person", "Greet")"#);
+    }
+
+    /// MX5 — `__extend__("C", "M")` → `_sir_extend("C", "M")`.
+    #[test]
+    fn extend_emits_extend_directive() {
+        let e = builtin("__extend__", vec![str_lit("Registry"), str_lit("Counting")]);
+        let mut out = String::new();
+        emit_expr(&mut out, &e, 0);
+        assert_eq!(out, r#"_sir_extend("Registry", "Counting")"#);
+    }
+
+    /// MX5 — `__class_method__("C", "m", arg)` → `_sir_call_class_method("C",
+    /// "m", <arg>)`; args follow the two NAME strings.
+    #[test]
+    fn class_method_call_emits_dispatch() {
+        let e = builtin(
+            "__class_method__",
+            vec![str_lit("Registry"), str_lit("total"), Expr::IntLit { value: 5, span: s() }],
+        );
+        let mut out = String::new();
+        emit_expr(&mut out, &e, 0);
+        assert_eq!(out, r#"_sir_call_class_method("Registry", "total", Value(int64(5)))"#);
     }
 
     /// `__self__()` → `_sir_current_self()`.

--- a/code/packages/rust/semantic-ir-to-go/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/lib.rs
@@ -150,12 +150,27 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     // `StrLit` inside a builtin, or a `raise Foo` first-arg `Const` — both
     // handled explicitly), so `check_exception_soundness` below STILL cleanly
     // rejects genuinely-unsupported constructs — a `Const` used as a value
-    // (`x = MyClass`), a `Const` assignment (`FOO = 4`), and a `ModuleDef`
-    // (`Feature::Modules` remains UNACCEPTED — no mixin/MRO runtime in v0).
+    // (`x = MyClass`) and a `Const` assignment (`FOO = 4`).  (`Feature::Modules`
+    // is now ACCEPTED for MX5 mixins; see the note on it below.)
     Feature::Classes,
     Feature::Constants,
     Feature::InstanceVars,
     Feature::ClassVars,
+    // ── MX5 — Ruby mixins (`module` + `include` / `extend`) ────────
+    //
+    // `Modules` admits `module M; …; end` (`Stmt::ModuleDef`) — a method
+    // *owner* alongside classes.  A module body's `def`s hoist and register
+    // via the SAME `__def_method__("M", …)` builtin classes use (keyed by the
+    // module name); `include M` / `extend M` lower to the `__include__` /
+    // `__extend__` builtins, whose owner/module NAMES ride in as `StrLit`s
+    // (never a `Const`), so the runtime side stays a pure NAME-keyed map
+    // operation — NEVER reflection.  Method resolution follows Ruby's MRO
+    // (class → its included modules in reverse → superclass → …), cycle-guarded
+    // (see `runtime::RUNTIME` — `_sir_included_modules`,
+    // `_sir_resolve_instance_method`, `_sir_extend`, `_sir_call_class_method`).
+    // A `ModuleDef` body reaching emit is now hosted (not rejected); the
+    // soundness gate below recurses into it for the residual `Const` checks.
+    Feature::Modules,
 ];
 
 impl Backend for GoBackend {
@@ -295,8 +310,8 @@ fn check_no_keyword_rest_mix(module: &Module, errs: &mut Vec<BackendError>) {
 /// we reject those modules CLEANLY here (an honest "unsupported construct"
 /// error) rather than let a `panic!` or a mis-emit through.  Rejected:
 ///
-///   * a `ModuleDef` (`module M; …; end`) — a namespace, not an exception
-///     subclass; the backend has no OOP runtime to host it;
+///   * (a `ModuleDef` is NO LONGER rejected — MX5 hosts it as a mixin method
+///     owner; we recurse into its body for the residual const checks);
 ///   * a `Const` reference (`VarRef{Const}`) ANYWHERE except as the first
 ///     argument of a `raise` builtin — a general constant-as-value (`x =
 ///     MyClass`) has no runtime representation here;
@@ -339,15 +354,14 @@ fn check_soundness_stmt(s: &semantic_ir::Stmt, errs: &mut Vec<BackendError>) {
                 span.clone(),
             ));
         }
-        Stmt::ModuleDef { name, span, .. } => {
-            errs.push(unsupported(
-                &format!(
-                    "go backend cannot emit a module definition `{}` — the exception \
-                     backend supports only exception-subclass class declarations",
-                    name
-                ),
-                span.clone(),
-            ));
+        // MX5 — a `ModuleDef` is now a HOSTED method owner (mixins).  Its body
+        // still may not carry an unsupported `Const` use, so recurse into it
+        // for the same residual const/module checks a class body gets, rather
+        // than rejecting the module wholesale.
+        Stmt::ModuleDef { body, .. } => {
+            for st in body {
+                check_soundness_stmt(st, errs);
+            }
         }
         Stmt::LetBinding { value, .. }
         | Stmt::LetStarBinding { value, .. }

--- a/code/packages/rust/semantic-ir-to-go/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/runtime.rs
@@ -2079,22 +2079,166 @@ func _sir_def_class_method(cls string, method string, fn Value) Value {
 	return fn
 }
 
-// Resolve `method` on `cls` OR any registered ancestor, walking the SHARED
-// `_sir_ancestry` table (the very table exception `rescue` uses — one
-// hierarchy for the whole runtime).  The `seen` set makes the walk total even
-// for a cyclic user hierarchy.  Returns the closure and `true` on a hit, or
-// `(nil, false)` when unresolved.
+// ── MX5 mixins: per-owner included-module list ────────────────────────
+//
+// `include M` inside `class C` (or `module C`) records that `C`'s method
+// resolution must consult `M` — BEFORE ascending to `C`'s superclass, and
+// AFTER `C`'s own methods.  We keep this as an explicit per-owner slice of
+// module names, appended in SOURCE (include) order.  Ruby searches the
+// MOST-RECENTLY-included module first, so the resolution walk iterates this
+// slice in REVERSE (see `_sir_resolve_instance_method`).
+//
+// A module is itself an "owner" in the method table (`module M; def foo`
+// registers `_sir_instance_methods[("M","foo")]` via `__def_method__`), so a
+// module that itself `include`s another module contributes ITS includes too
+// when the walk recurses into it — Ruby's transitive mixin inclusion.
+//
+// SECURITY: this is a plain `map[string][]string` keyed by source-derived
+// NAMES with no reflection (the C3 RCE discipline).  The MRO walk carries a
+// `seen` set so a module that (transitively) includes itself TERMINATES.
+var _sir_included_modules = make(map[string][]string)
+
+// `__include__("Owner", "M")` — record that `Owner` mixes in `M`.  Appends in
+// include order (idempotent duplicates are harmless: the MRO walk's `seen` set
+// de-dups a diamond, and appending a name twice just makes the second visit a
+// no-op).  Returns nil (the directive has no Ruby value the emitter needs).
+func _sir_include(owner string, module string) Value {
+	_sir_included_modules[owner] = append(_sir_included_modules[owner], module)
+	return nil
+}
+
+// `__extend__("Owner", "M")` — mix `M`'s INSTANCE methods in as `Owner`'s
+// CLASS (singleton) methods, so they become callable as `Owner.method`.  We
+// SNAPSHOT `M`'s registered instance methods (including those `M` itself
+// includes, via the same MRO walk used for instances) and copy each into
+// `Owner`'s class-method table.  An entry `Owner` already defines is NOT
+// overwritten (a class/own method shadows an extended module method), matching
+// Ruby's singleton-first precedence.  Copy-at-extend-time is the v0 model:
+// methods defined on `M` AFTER the `extend` are not retroactively added, which
+// is sufficient because the frontend emits every `__def_method__` for `M`
+// before any `__extend__` that names it (registrations run in source order,
+// module def before the including class).
+func _sir_extend(owner string, module string) Value {
+	for _, name := range _sir_module_method_names(module) {
+		key := _sir_method_key(owner, name)
+		if _, exists := _sir_class_methods[key]; exists {
+			continue
+		}
+		if fn, ok := _sir_resolve_instance_method(module, name); ok {
+			_sir_class_methods[key] = fn
+		}
+	}
+	return nil
+}
+
+// The instance-method NAMES reachable on `module` (its own defs plus those of
+// modules IT includes), for `_sir_extend` to copy.  Walks the same
+// include-list MRO as instance resolution, `seen`-guarded against a cyclic
+// include, and de-dups names so each method is copied once (the earliest,
+// most-specific definition wins — we only add a name the first time it is
+// seen).
+func _sir_module_method_names(module string) []string {
+	var names []string
+	added := make(map[string]bool)
+	seenOwners := make(map[string]bool)
+	var walk func(owner string)
+	walk = func(owner string) {
+		if owner == "" || seenOwners[owner] {
+			return
+		}
+		seenOwners[owner] = true
+		prefix := owner + "\x00"
+		for key := range _sir_instance_methods {
+			if len(key) > len(prefix) && key[:len(prefix)] == prefix {
+				name := key[len(prefix):]
+				if !added[name] {
+					added[name] = true
+					names = append(names, name)
+				}
+			}
+		}
+		mods := _sir_included_modules[owner]
+		for i := len(mods) - 1; i >= 0; i-- {
+			walk(mods[i])
+		}
+	}
+	walk(module)
+	return names
+}
+
+// Resolve `method` on `cls` following Ruby's MRO (Method Resolution Order):
+//
+//	cls  →  cls's included modules (REVERSE / most-recent-first)  →
+//	cls's superclass  →  its included modules  →  …  →  Object
+//
+// A class's OWN method shadows any module it includes; a module method shadows
+// the superclass's (module comes before the superclass in the ancestor list).
+// A module included via TWO paths (a diamond) resolves ONCE, at its earliest
+// position, because the `seen` set skips an owner already visited.
+//
+// The walk is a depth-first, most-recent-first, de-duplicated linearisation
+// (the exact order the spec's truth table documents).  It shares the runtime's
+// single `_sir_ancestry` table for the superclass chain (the same table
+// exception `rescue` uses).  The `seen` set makes the walk TOTAL even for a
+// cyclic class hierarchy OR a self-including module.  Returns the closure and
+// `true` on a hit, or `(nil, false)` when unresolved.
 func _sir_resolve_instance_method(cls string, method string) (Value, bool) {
-	cur := cls
 	seen := make(map[string]bool)
-	for cur != "" && !seen[cur] {
-		if fn, ok := _sir_instance_methods[_sir_method_key(cur, method)]; ok {
+	// `resolveOwner` checks `owner`'s own methods, then (reverse-order) its
+	// included modules — each of which may itself include further modules,
+	// so it recurses.  Returns the closure on the first hit.
+	var resolveOwner func(owner string) (Value, bool)
+	resolveOwner = func(owner string) (Value, bool) {
+		if owner == "" || seen[owner] {
+			return nil, false
+		}
+		seen[owner] = true
+		if fn, ok := _sir_instance_methods[_sir_method_key(owner, method)]; ok {
 			return fn, true
 		}
-		seen[cur] = true
+		// Included modules search most-recently-included first (Ruby's rule),
+		// so iterate the include-order slice in REVERSE.  A module search
+		// recurses so a module that itself includes another module is honoured.
+		mods := _sir_included_modules[owner]
+		for i := len(mods) - 1; i >= 0; i-- {
+			if fn, ok := resolveOwner(mods[i]); ok {
+				return fn, true
+			}
+		}
+		return nil, false
+	}
+	cur := cls
+	for cur != "" {
+		if seen[cur] {
+			// The class chain itself is cyclic (`A<B, B<A`): stop.
+			break
+		}
+		if fn, ok := resolveOwner(cur); ok {
+			return fn, true
+		}
 		cur = _sir_ancestry[cur] // "" when `cur` has no registered super
 	}
 	return nil, false
+}
+
+// `Foo.bar(args…)` — a CLASS-method call (`__class_method__`).  Resolves `bar`
+// in `Foo`'s class-method table, walking the ancestry so an inherited
+// `def self.bar` is found, and INCLUDING methods mixed in via `extend` (which
+// `_sir_extend` copied into the class-method table).  No `self` is pushed —
+// v0 class methods run without an instance receiver.  An unresolved name hits
+// the controlled NoMethodError floor, never reflection.
+func _sir_call_class_method(cls string, method string, args ...Value) Value {
+	cur := cls
+	seen := make(map[string]bool)
+	for cur != "" && !seen[cur] {
+		if fn, ok := _sir_class_methods[_sir_method_key(cur, method)]; ok {
+			return _sir_apply(fn, args)
+		}
+		seen[cur] = true
+		cur = _sir_ancestry[cur]
+	}
+	panic(_sir_new_error("NoMethodError",
+		Value("undefined method '"+method+"' for "+cls)))
 }
 
 // ── Current-self stack + instance-variable store ──────────────────────
@@ -2376,5 +2520,21 @@ mod tests {
         assert!(RUNTIME.contains(r#""KeyError":            "IndexError""#));
         // The cycle-guard `seen` set must be present (no unbounded walk).
         assert!(RUNTIME.contains("seen := make(map[string]bool)"));
+    }
+
+    // MX5: the mixin tables + helpers must be present, and the MRO walk must
+    // consult the per-owner included-module list (reverse order).
+    #[test]
+    fn runtime_includes_mixin_helpers() {
+        assert!(RUNTIME.contains("var _sir_included_modules = make(map[string][]string)"));
+        assert!(RUNTIME.contains("func _sir_include(owner string, module string) Value"));
+        assert!(RUNTIME.contains("func _sir_extend(owner string, module string) Value"));
+        assert!(RUNTIME.contains(
+            "func _sir_call_class_method(cls string, method string, args ...Value) Value"
+        ));
+        // The MRO walk consults the included-module list in REVERSE (most
+        // recently included first) and recurses per owner.
+        assert!(RUNTIME.contains("mods := _sir_included_modules[owner]"));
+        assert!(RUNTIME.contains("for i := len(mods) - 1; i >= 0; i--"));
     }
 }

--- a/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_mixins.rs
+++ b/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_mixins.rs
@@ -1,0 +1,342 @@
+//! Execution proof for MX5 mixins (Ruby `module` + `include` / `extend`):
+//! hand-build a SIR module, emit Go, run it with `go run`, and assert the
+//! observable behaviour matches Ruby's mixin semantics — the module method is
+//! found through the class's MRO, a class-defined method SHADOWS the module's,
+//! a diamond include resolves ONCE, and `extend` makes a module method a CLASS
+//! method callable as `Owner.method`.
+//!
+//! The Go backend has NO native module/mixin model — the frontend HOISTS every
+//! module method to a detached top-level function and registers it via
+//! `__def_method__("M", name, closure)` keyed by the MODULE name.  A directive
+//! `__include__("C", "M")` records `M` on `C`'s included-module list, and the
+//! runtime's method-resolution walk (`_sir_resolve_instance_method`) follows
+//! Ruby's MRO: class → its included modules (reverse) → superclass → …  These
+//! cases prove that end to end.
+//!
+//! A missing `go` toolchain logs a skip rather than reddening the build
+//! (mirrors `compile_and_run_oop.rs`).
+
+use std::process::Command;
+
+use semantic_ir::{
+    Block, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, Param, Scope,
+    Span, Stmt,
+};
+use semantic_ir_to_go::compile;
+
+fn s() -> Span {
+    Span::synthetic()
+}
+
+fn str_lit(v: &str) -> Expr {
+    Expr::StrLit { value: v.into(), span: s() }
+}
+
+fn int_lit(n: i64) -> Expr {
+    Expr::IntLit { value: n, span: s() }
+}
+
+fn ivar_ref(name: &str) -> Expr {
+    Expr::VarRef { name: name.into(), scope: Scope::Instance, span: s() }
+}
+
+fn ivar_set(name: &str, value: Expr) -> Stmt {
+    Stmt::Assign { name: name.into(), scope: Scope::Instance, value, span: s() }
+}
+
+fn builtin(name: &str, args: Vec<Expr>) -> Expr {
+    Expr::BuiltinCall { name: name.into(), args, effects: EffectSet::PURE, span: s() }
+}
+
+fn print_stmt(v: Expr) -> Stmt {
+    Stmt::ExprStmt { expr: builtin("print", vec![v]), span: s() }
+}
+
+/// A hoisted method as a top-level function (no captures; methods use the
+/// self-stack, not captures).
+fn method_fn(fn_name: &str, params: Vec<Param>, body_stmts: Vec<Stmt>, value: Expr) -> Function {
+    Function {
+        name: fn_name.into(),
+        params,
+        return_type: None,
+        captures: vec![],
+        body: Block { stmts: body_stmts, value, span: s() },
+        effects: EffectSet::PURE,
+        metadata: Metadata::new(),
+        span: s(),
+    }
+}
+
+fn closure_of(fn_name: &str) -> Expr {
+    Expr::MakeClosure { fn_name: fn_name.into(), captures: vec![], span: s() }
+}
+
+/// `__def_method__("Owner", "meth", <closure>)` — register `meth` on `Owner`
+/// (a class OR a module name — same builtin either way).
+fn def_method(owner: &str, meth: &str, fn_name: &str) -> Stmt {
+    Stmt::ExprStmt {
+        expr: builtin("__def_method__", vec![str_lit(owner), str_lit(meth), closure_of(fn_name)]),
+        span: s(),
+    }
+}
+
+fn include_stmt(owner: &str, module: &str) -> Stmt {
+    Stmt::ExprStmt {
+        expr: builtin("__include__", vec![str_lit(owner), str_lit(module)]),
+        span: s(),
+    }
+}
+
+fn extend_stmt(owner: &str, module: &str) -> Stmt {
+    Stmt::ExprStmt {
+        expr: builtin("__extend__", vec![str_lit(owner), str_lit(module)]),
+        span: s(),
+    }
+}
+
+fn class_def(name: &str, superclass: Option<&str>, body: Vec<Stmt>) -> Stmt {
+    Stmt::ClassDef { name: name.into(), superclass: superclass.map(|s| s.to_string()), body, span: s() }
+}
+
+fn module_def(name: &str, body: Vec<Stmt>) -> Stmt {
+    Stmt::ModuleDef { name: name.into(), body, span: s() }
+}
+
+/// Assemble a module from top-level functions + a `main` body.
+fn module_from(name: &str, mut functions: Vec<Function>, main_stmts: Vec<Stmt>) -> Module {
+    functions.push(method_fn("main", vec![], main_stmts, Expr::NilLit { span: s() }));
+    let fs = vec![
+        Feature::Classes,
+        Feature::Modules,
+        Feature::InstanceVars,
+        Feature::Strings,
+        Feature::MutableBindings,
+        Feature::Closures,
+        Feature::DynamicTyping,
+    ];
+    Module {
+        name: name.into(),
+        manifest: FeatureManifest::from_features(&fs),
+        imports: vec![],
+        exports: vec![],
+        functions,
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("test")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+fn go_available() -> bool {
+    Command::new("go").arg("version").output().map(|o| o.status.success()).unwrap_or(false)
+}
+
+/// Emit `m` to Go, run it, return `(success, stdout)`.  A COMPILE error panics
+/// loudly; a runtime non-zero exit returns the flag.
+fn emit_and_run(m: &Module, nonce: &str) -> (bool, String) {
+    let artifact = compile(m).expect("module should compile to Go source");
+    let dir = std::env::temp_dir();
+    let pid = std::process::id();
+    let src_path = dir.join(format!("sir_go_mixins_{pid}_{nonce}.go"));
+    std::fs::write(&src_path, &artifact.source).expect("write temp source");
+    let run_out =
+        Command::new("go").arg("run").arg(&src_path).output().expect("invoke go run");
+    if !run_out.status.success() {
+        let stderr = String::from_utf8_lossy(&run_out.stderr);
+        if stderr.contains("cannot") || stderr.contains("syntax error") || stderr.contains("undefined:") {
+            let _ = std::fs::remove_file(&src_path);
+            panic!(
+                "emitted Go failed to COMPILE:\n--- stderr ---\n{stderr}\n--- source ---\n{}",
+                artifact.source
+            );
+        }
+    }
+    let stdout = String::from_utf8_lossy(&run_out.stdout).into_owned();
+    let ok = run_out.status.success();
+    let _ = std::fs::remove_file(&src_path);
+    (ok, stdout)
+}
+
+/// MX-A — a module method is found through an including class's MRO.
+///
+/// ```ruby
+/// module Greet
+///   def hello; 1; end
+/// end
+/// class Person
+///   include Greet
+/// end
+/// print(Person.new.hello)   # => 1
+/// ```
+#[test]
+fn included_module_method_is_callable() {
+    if !go_available() {
+        eprintln!("skipping: go not on PATH");
+        return;
+    }
+    let hello = method_fn("Greet_hello", vec![], vec![], int_lit(1));
+    let module = module_def("Greet", vec![def_method("Greet", "hello", "Greet_hello")]);
+    let class = class_def("Person", None, vec![include_stmt("Person", "Greet")]);
+    let new_p = builtin("__new__", vec![str_lit("Person")]);
+    let call = builtin("__method__", vec![new_p, str_lit("hello")]);
+    let main = vec![module, class, print_stmt(call)];
+
+    let m = module_from("mx_a", vec![hello], main);
+    let (ok, out) = emit_and_run(&m, "a");
+    assert!(ok, "MX-A should exit 0; stdout:\n{out}");
+    assert_eq!(out.trim(), "1", "a method from an included module must be reachable on an instance");
+}
+
+/// MX-B — a class-defined method SHADOWS the module's (class-first MRO).
+///
+/// ```ruby
+/// module M
+///   def kind; 1; end   # module says 1
+/// end
+/// class C
+///   include M
+///   def kind; 2; end   # class says 2 — class wins
+/// end
+/// print(C.new.kind)    # => 2
+/// ```
+#[test]
+fn class_method_shadows_module_method() {
+    if !go_available() {
+        eprintln!("skipping: go not on PATH");
+        return;
+    }
+    let m_kind = method_fn("M_kind", vec![], vec![], int_lit(1));
+    let c_kind = method_fn("C_kind", vec![], vec![], int_lit(2));
+    let module = module_def("M", vec![def_method("M", "kind", "M_kind")]);
+    let class = class_def(
+        "C",
+        None,
+        vec![include_stmt("C", "M"), def_method("C", "kind", "C_kind")],
+    );
+    let new_c = builtin("__new__", vec![str_lit("C")]);
+    let call = builtin("__method__", vec![new_c, str_lit("kind")]);
+    let main = vec![module, class, print_stmt(call)];
+
+    let m = module_from("mx_b", vec![m_kind, c_kind], main);
+    let (ok, out) = emit_and_run(&m, "b");
+    assert!(ok, "MX-B should exit 0; stdout:\n{out}");
+    assert_eq!(out.trim(), "2", "the class's own method must shadow the included module's");
+}
+
+/// MX-C — a module method shadows the SUPERCLASS's (module precedes super in
+/// the MRO), and a diamond include resolves ONCE (terminates).
+///
+/// ```ruby
+/// module Shared
+///   def tag; 10; end
+/// end
+/// class Base
+///   def tag; 20; end          # superclass method
+/// end
+/// class Derived < Base
+///   include Shared            # module beats the superclass
+///   include Shared            # diamond / duplicate include — resolves once
+/// end
+/// print(Derived.new.tag)      # => 10
+/// ```
+#[test]
+fn module_shadows_super_and_diamond_resolves_once() {
+    if !go_available() {
+        eprintln!("skipping: go not on PATH");
+        return;
+    }
+    let shared_tag = method_fn("Shared_tag", vec![], vec![], int_lit(10));
+    let base_tag = method_fn("Base_tag", vec![], vec![], int_lit(20));
+    let module = module_def("Shared", vec![def_method("Shared", "tag", "Shared_tag")]);
+    let base = class_def("Base", None, vec![def_method("Base", "tag", "Base_tag")]);
+    // Two includes of the same module (the diamond / duplicate) — the walk's
+    // `seen` set must visit `Shared` once and terminate.
+    let derived = class_def(
+        "Derived",
+        Some("Base"),
+        vec![include_stmt("Derived", "Shared"), include_stmt("Derived", "Shared")],
+    );
+    let new_d = builtin("__new__", vec![str_lit("Derived")]);
+    let call = builtin("__method__", vec![new_d, str_lit("tag")]);
+    let main = vec![module, base, derived, print_stmt(call)];
+
+    let m = module_from("mx_c", vec![shared_tag, base_tag], main);
+    let (ok, out) = emit_and_run(&m, "c");
+    assert!(ok, "MX-C should exit 0 (diamond must terminate); stdout:\n{out}");
+    assert_eq!(out.trim(), "10", "an included module must shadow the superclass's method");
+}
+
+/// MX-D — `extend M` makes `M`'s instance method a CLASS method callable as
+/// `Owner.method`.
+///
+/// ```ruby
+/// module Counting
+///   def total; 42; end
+/// end
+/// class Registry
+///   extend Counting
+/// end
+/// print(Registry.total)   # => 42
+/// ```
+#[test]
+fn extend_makes_module_method_a_class_method() {
+    if !go_available() {
+        eprintln!("skipping: go not on PATH");
+        return;
+    }
+    let total = method_fn("Counting_total", vec![], vec![], int_lit(42));
+    let module = module_def("Counting", vec![def_method("Counting", "total", "Counting_total")]);
+    let class = class_def("Registry", None, vec![extend_stmt("Registry", "Counting")]);
+    // Registry.total — a class-method call on a Const receiver.
+    let call = builtin("__class_method__", vec![str_lit("Registry"), str_lit("total")]);
+    let main = vec![module, class, print_stmt(call)];
+
+    let m = module_from("mx_d", vec![total], main);
+    let (ok, out) = emit_and_run(&m, "d");
+    assert!(ok, "MX-D should exit 0; stdout:\n{out}");
+    assert_eq!(out.trim(), "42", "extend must expose the module method as a class method");
+}
+
+/// MX-E — a module can carry state through the current-self stack: a mixed-in
+/// method reads an `@ivar` set by the including class's own method, proving the
+/// module method runs on the SAME receiver (the self-stack is shared).
+///
+/// ```ruby
+/// module Named
+///   def name; @name; end
+/// end
+/// class Widget
+///   include Named
+///   def initialize; @name = 7; end
+/// end
+/// print(Widget.new.name)   # => 7
+/// ```
+#[test]
+fn module_method_reads_including_class_ivar() {
+    if !go_available() {
+        eprintln!("skipping: go not on PATH");
+        return;
+    }
+    let name = method_fn("Named_name", vec![], vec![], ivar_ref("@name"));
+    let init = method_fn(
+        "Widget_initialize",
+        vec![],
+        vec![ivar_set("@name", int_lit(7))],
+        Expr::NilLit { span: s() },
+    );
+    let module = module_def("Named", vec![def_method("Named", "name", "Named_name")]);
+    let class = class_def(
+        "Widget",
+        None,
+        vec![include_stmt("Widget", "Named"), def_method("Widget", "initialize", "Widget_initialize")],
+    );
+    let new_w = builtin("__new__", vec![str_lit("Widget")]);
+    let call = builtin("__method__", vec![new_w, str_lit("name")]);
+    let main = vec![module, class, print_stmt(call)];
+
+    let m = module_from("mx_e", vec![name, init], main);
+    let (ok, out) = emit_and_run(&m, "e");
+    assert!(ok, "MX-E should exit 0; stdout:\n{out}");
+    assert_eq!(out.trim(), "7", "a mixed-in method must run on the same self and see its @ivars");
+}


### PR DESCRIPTION
MX5 of the **sir-mixins** cascade (spec + MX1 frontend merged). Runtime-only — `semantic-ir-to-go` (emitted Go runtime + emit arms).

Makes the Go backend's emitted OOP runtime execute Ruby mixins:
- `_sir_include`/`_sir_extend` register into `_sir_included_modules map[string][]string` (include order).
- `_sir_resolve_instance_method` rewritten to Ruby MRO: **class → included modules (reverse) → superclass → its modules → …**, `seen`-guarded (diamond once; self-include terminates).
- `_sir_extend` copies module methods into the class-method table; class method **shadows** module; module shadows superclass.
- `Stmt::ModuleDef` now emits its body (was `panic!`); `Feature::Modules` accepted.
- Adds `_sir_call_class_method` (ancestry-walking class-method dispatch — was entirely absent on Go; bonus progress on #61, required to prove `extend`).

Security review: **PASSED** — string-keyed `map` access (no `reflect`/dynamic dispatch), all cycle walks terminate via `seen`, names via `quote_go_string`, nil-map-safe.

Execution-proofed via `go run` (5 proofs incl. real Ruby lowering: mixed-in call, class shadows module, diamond, `extend`→class method, module reads including-class ivar). 96 lib + 5 mixin + all integration green, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)