### PR TITLE
fix: repair full-build-on-main failures (nib mul_expr, es2025 grammar, aztec lint)

### DIFF
--- a/code/packages/lua/nib_ir_compiler/CHANGELOG.md
+++ b/code/packages/lua/nib_ir_compiler/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.1.1
+
+- Fixed: handle `mul_expr` in expression dispatch. LANG-FULL N1 added a
+  multiplicative precedence level between `add_expr` and `bitwise_expr`;
+  `mul_expr` was missing from `expression_rules`, so `expression_children`
+  filtered it out and `compile_add` emitted no `ADD`/`ADD_IMM` for arithmetic
+  such as `a +% b`. `mul_expr` is now in the rule table and routes through
+  `compile_add`. Mirrors the Elixir fix (#5747).
+
 ## 0.1.0
 
 - add the first Lua Nib IR compiler package

--- a/code/packages/lua/nib_ir_compiler/src/coding_adventures/nib_ir_compiler/init.lua
+++ b/code/packages/lua/nib_ir_compiler/src/coding_adventures/nib_ir_compiler/init.lua
@@ -10,6 +10,10 @@ local expression_rules = {
     eq_expr = true,
     cmp_expr = true,
     add_expr = true,
+    -- mul_expr sits between add_expr and bitwise_expr in the precedence cascade
+    -- (LANG-FULL N1). It must be here so expression_children does not filter it
+    -- out when add_expr walks its operands.
+    mul_expr = true,
     bitwise_expr = true,
     unary_expr = true,
     primary = true,
@@ -188,7 +192,9 @@ function Compiler:emit_expr_into(node, register_index)
         return
     end
 
-    if node.rule_name == "add_expr" then
+    if node.rule_name == "add_expr" or node.rule_name == "mul_expr" then
+        -- mul_expr shares add_expr's binary-operand lowering (same-type operands,
+        -- numeric result), so it routes through the same compile path.
         self:compile_add(node, register_index)
         return
     end

--- a/code/packages/perl/grammar-tools/CHANGELOG.md
+++ b/code/packages/perl/grammar-tools/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.3.0] - 2026-07-02
+
+### Added
+
+- `parse_token_grammar` now tolerates the F10 declarative-lexer-mode directives
+  `start_mode:` and the `transitions:` section (whose indented lines are
+  `on TOKEN -> set-mode NAME` rules, not `NAME = pattern` definitions). Flat
+  consumers record `start_mode`/`transitions` on the `TokenGrammar` but ignore
+  them, so a modal grammar (e.g. `ecmascript/es2025.tokens`) now parses under a
+  flat lexer instead of dying with "Expected token definition (NAME = pattern)".
+- `TokenGrammar` gains `start_mode` and `transitions` accessors.
+
 ## [0.2.0] - 2026-04-04
 
 ### Added

--- a/code/packages/perl/grammar-tools/lib/CodingAdventures/GrammarTools.pm
+++ b/code/packages/perl/grammar-tools/lib/CodingAdventures/GrammarTools.pm
@@ -148,6 +148,8 @@ sub definitions { $_[0]->{definitions} }
 #   error_definitions — arrayref of error-recovery TokenDefinition objects
 #   reserved_keywords — arrayref of keywords that cause lex errors
 #   groups            — hashref of group name => PatternGroup
+#   start_mode        — initial mode for F10 declarative modal lexers ('' if none)
+#   transitions       — arrayref of raw "on ... -> set-mode ..." rule strings
 
 package CodingAdventures::GrammarTools::TokenGrammar;
 
@@ -165,6 +167,8 @@ sub new {
         error_definitions => [],
         reserved_keywords => [],
         groups            => {},
+        start_mode        => '',
+        transitions       => [],
     }, $class;
 }
 
@@ -179,6 +183,8 @@ sub skip_definitions  { $_[0]->{skip_definitions}  }
 sub error_definitions { $_[0]->{error_definitions} }
 sub reserved_keywords { $_[0]->{reserved_keywords} }
 sub groups            { $_[0]->{groups}            }
+sub start_mode        { $_[0]->{start_mode}        }
+sub transitions       { $_[0]->{transitions}       }
 
 # token_names()
 #
@@ -401,6 +407,23 @@ sub parse_token_grammar {
             next;
         }
 
+        # start_mode: directive (F10 declarative lexer modes)
+        #
+        # Declares the initial mode a modal lexer begins in. Flat consumers —
+        # which ignore modes and tokenize in a single first-match-wins pass —
+        # accept and remember it but take no action on it. This lets a richer
+        # grammar (e.g. ecmascript/es2025.tokens, which models regex-vs-division
+        # via `start_mode`/`group`/`transitions`) still parse under a flat lexer.
+        if (substr($stripped, 0, 11) eq 'start_mode:') {
+            my $sm = substr($stripped, 11);
+            $sm =~ s/^\s+|\s+$//g;
+            return (undef, "Line $line_number: Missing value after 'start_mode:'")
+                if $sm eq '';
+            $grammar->{start_mode} = $sm;
+            $current_section = '';
+            next;
+        }
+
         # Group header: "group NAME:"
         if ($stripped =~ /^group\s+/ && substr($stripped, -1) eq ':') {
             my $group_name = substr($stripped, 6, length($stripped) - 7);
@@ -451,6 +474,14 @@ sub parse_token_grammar {
             $current_section = 'soft_keywords';
             next;
         }
+        # transitions: section (F10 declarative lexer modes) — its indented
+        # lines are "on TOKEN -> set-mode NAME" rules, not "NAME = pattern"
+        # definitions. Flat consumers record the raw rules but do not act on
+        # them (see start_mode: above).
+        if ($stripped eq 'transitions:' || $stripped eq 'transitions :') {
+            $current_section = 'transitions';
+            next;
+        }
 
         # Inside a section: lines must be indented
         if ($current_section ne '') {
@@ -470,6 +501,11 @@ sub parse_token_grammar {
                 }
                 elsif ($current_section eq 'reserved') {
                     push @{ $grammar->{reserved_keywords} }, $stripped if $stripped ne '';
+                }
+                elsif ($current_section eq 'transitions') {
+                    # F10 mode-transition rule. Recorded verbatim for modal
+                    # consumers; flat lexers ignore it (no pattern to compile).
+                    push @{ $grammar->{transitions} }, $stripped if $stripped ne '';
                 }
                 elsif ($current_section eq 'skip') {
                     my $eq_pos = index($stripped, '=');

--- a/code/packages/perl/grammar-tools/t/01-basic.t
+++ b/code/packages/perl/grammar-tools/t/01-basic.t
@@ -142,6 +142,29 @@ subtest 'parse_token_grammar: keywords section' => sub {
     is($g->keywords, ['if', 'else'], 'keywords parsed');
 };
 
+# F10 declarative lexer modes: flat consumers must accept (and ignore)
+# start_mode:/transitions: rather than mistaking them for token definitions.
+subtest 'parse_token_grammar: start_mode directive' => sub {
+    my $src = "start_mode: default\nNAME = /[a-z]+/\n";
+    my ($g, $err) = CodingAdventures::GrammarTools->parse_token_grammar($src);
+    ok(!$err, 'no error');
+    is($g->start_mode, 'default', 'start_mode parsed');
+    is($g->keywords, [], 'no spurious keywords');
+};
+
+subtest 'parse_token_grammar: transitions section ignored by flat consumer' => sub {
+    my $src = "start_mode: default\n"
+        . "NAME = /[a-z]+/\n"
+        . "transitions:\n"
+        . "  # comment inside transitions\n"
+        . "  on NAME -> set-mode div\n"
+        . "  on (LPAREN | COMMA) -> set-mode default\n";
+    my ($g, $err) = CodingAdventures::GrammarTools->parse_token_grammar($src);
+    ok(!$err, 'no error on transition rules');
+    is(scalar @{ $g->transitions }, 2, 'two transition rules recorded');
+    is(scalar @{ $g->definitions }, 1, 'transition lines are not token definitions');
+};
+
 subtest 'parse_token_grammar: skip section' => sub {
     my $src = "NAME = /[a-zA-Z]+/\nskip:\n  WHITESPACE = /[ \\t]+/\n";
     my ($g, $err) = CodingAdventures::GrammarTools->parse_token_grammar($src);

--- a/code/packages/perl/nib-type-checker/CHANGELOG.md
+++ b/code/packages/perl/nib-type-checker/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.1.1] - 2026-07-02
+
+### Fixed
+
+- Handle `mul_expr` in expression dispatch. LANG-FULL N1 inserted a
+  multiplicative precedence level (`add_expr → mul_expr → bitwise_expr`), but
+  `mul_expr` was missing from `%_EXPRESSION_RULE`, so `_expression_children`
+  filtered it out when `add_expr` walked its operands. Arithmetic like
+  `1 +% 2` then inferred `undef`, which slipped past compatibility checks — so
+  an invalid `let x: bool = 1 +% 2;` was accepted instead of raising a
+  type error. `mul_expr` now routes through `_check_add_expression` (shared
+  numeric semantics). Mirrors the Elixir/Ruby/Lua fixes (#5747).
+
 ## [0.1.0] - 2026-04-18
 
 ### Added

--- a/code/packages/perl/nib-type-checker/lib/CodingAdventures/NibTypeChecker.pm
+++ b/code/packages/perl/nib-type-checker/lib/CodingAdventures/NibTypeChecker.pm
@@ -55,9 +55,12 @@ use constant {
     TYPE_BOOL => 'bool',
 };
 
+# mul_expr sits between add_expr and bitwise_expr in the precedence cascade
+# (LANG-FULL N1). It must be in this set so _expression_children does not filter
+# it out when add_expr walks its operands.
 my %_EXPRESSION_RULE = map { $_ => 1 } qw(
-    expr or_expr and_expr eq_expr cmp_expr add_expr bitwise_expr unary_expr
-    primary call_expr
+    expr or_expr and_expr eq_expr cmp_expr add_expr mul_expr bitwise_expr
+    unary_expr primary call_expr
 );
 
 sub check_source {
@@ -382,7 +385,9 @@ sub _check_expression {
     elsif ($subject->rule_name eq 'primary') {
         $result = _check_primary($state, $subject);
     }
-    elsif ($subject->rule_name eq 'add_expr') {
+    elsif ($subject->rule_name eq 'add_expr' || $subject->rule_name eq 'mul_expr') {
+        # mul_expr shares additive numeric semantics (same-type operands,
+        # numeric result), so it routes through the same checker.
         $result = _check_add_expression($state, $subject);
     }
     elsif ($subject->rule_name eq 'or_expr'

--- a/code/packages/perl/nib-type-checker/t/01-basic.t
+++ b/code/packages/perl/nib-type-checker/t/01-basic.t
@@ -37,6 +37,21 @@ NIB
     );
 };
 
+subtest 'infers the type of multi-operand arithmetic (mul_expr cascade)' => sub {
+    # Regression: `1 +% 2` parses as an add_expr whose operands are mul_expr
+    # nodes (LANG-FULL N1 precedence level). If mul_expr is filtered out of the
+    # operand walk the expression infers undef, and an invalid bool initializer
+    # slips through unchecked. It must be rejected as a u4-vs-bool mismatch.
+    my $result = check_source('fn main() { let x: bool = 1 +% 2; }');
+
+    ok(!$result->{ok}, 'type check failed');
+    like(
+        $result->{errors}[0]{message},
+        qr/type 'u4'/,
+        'arithmetic operand inferred as u4, not undef',
+    );
+};
+
 subtest 'reports parse failures through the protocol result' => sub {
     my $result = check_source('fn main(');
 

--- a/code/packages/ruby/aztec_code/CHANGELOG.md
+++ b/code/packages/ruby/aztec_code/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Removed the redundant `keyword_init: true` on the internal `SymbolSpec`
+  struct. Ruby 3.2+ Structs accept keyword arguments natively (the gem targets
+  `>= 3.3.0`), so the option was flagged by standardrb's
+  `Style/RedundantStructKeywordInit`. No behavioral change — callers still
+  construct with keywords.
+
 ## [0.1.0] — 2026-04-26
 
 ### Added

--- a/code/packages/ruby/aztec_code/lib/coding_adventures/aztec_code.rb
+++ b/code/packages/ruby/aztec_code/lib/coding_adventures/aztec_code.rb
@@ -243,9 +243,11 @@ module CodingAdventures
     #
     # Returned by select_symbol; carries every dimension the rest of the
     # pipeline needs (no further capacity-table lookups required).
+    # Ruby 3.2+ Structs accept keyword arguments natively, so `keyword_init: true`
+    # is redundant here (and flagged by Style/RedundantStructKeywordInit). Callers
+    # still construct with keywords — e.g. SymbolSpec.new(compact: true, ...).
     SymbolSpec = Struct.new(
-      :compact, :layers, :data_cw_count, :ecc_cw_count, :total_bits,
-      keyword_init: true
+      :compact, :layers, :data_cw_count, :ecc_cw_count, :total_bits
     )
 
     # =========================================================================

--- a/code/packages/ruby/nib_ir_compiler/CHANGELOG.md
+++ b/code/packages/ruby/nib_ir_compiler/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.1.1
+
+- Fixed: handle `mul_expr` in expression dispatch. Same root cause as the
+  nib_type_checker fix — LANG-FULL N1 added a multiplicative precedence level
+  between `add_expr` and `bitwise_expr`, and `mul_expr` was missing from
+  `expression_rule?`, so `compile_add` saw no operands and emitted no
+  `ADD`/`ADD_IMM` for arithmetic like `a +% b`. `mul_expr` now routes through
+  `compile_add`. Mirrors the Elixir fix (#5747).
+
 ## 0.1.0
 
 - add the first Ruby Nib IR compiler package

--- a/code/packages/ruby/nib_ir_compiler/lib/coding_adventures/nib_ir_compiler/compiler.rb
+++ b/code/packages/ruby/nib_ir_compiler/lib/coding_adventures/nib_ir_compiler/compiler.rb
@@ -121,7 +121,10 @@ module CodingAdventures
           return
         end
 
-        if node.rule_name == "add_expr"
+        if node.rule_name == "add_expr" || node.rule_name == "mul_expr"
+          # mul_expr shares add_expr's binary-operand lowering (LANG-FULL N1
+          # inserted a multiplicative precedence level between add_expr and
+          # bitwise_expr), so it routes through the same compile path.
           compile_add(node, register_index)
           return
         end
@@ -304,7 +307,10 @@ module CodingAdventures
       end
 
       def expression_rule?(name)
-        %w[expr or_expr and_expr eq_expr cmp_expr add_expr bitwise_expr unary_expr primary call_expr].include?(name)
+        # mul_expr sits between add_expr and bitwise_expr in the precedence
+        # cascade (LANG-FULL N1). It must be here so expression_children does not
+        # filter it out when add_expr walks its operands.
+        %w[expr or_expr and_expr eq_expr cmp_expr add_expr mul_expr bitwise_expr unary_expr primary call_expr].include?(name)
       end
     end
 

--- a/code/packages/ruby/nib_type_checker/CHANGELOG.md
+++ b/code/packages/ruby/nib_type_checker/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.1.1
+
+- Fixed: handle `mul_expr` in expression dispatch. LANG-FULL N1 inserted a
+  multiplicative precedence level (`add_expr → mul_expr → bitwise_expr`), but
+  `mul_expr` was missing from `expression_rule?`, so `expression_children`
+  filtered it out when `add_expr` walked its operands. Any arithmetic (`a +% b`),
+  call, or literal under the cascade then inferred `nil`, producing spurious
+  "return/let expects T, got " errors. `mul_expr` now routes through the
+  additive checker (shared numeric semantics). Mirrors the Elixir/TypeScript
+  fix (#5747).
+
 ## 0.1.0
 
 - add the first Ruby Nib type checker package

--- a/code/packages/ruby/nib_type_checker/lib/coding_adventures/nib_type_checker/checker.rb
+++ b/code/packages/ruby/nib_type_checker/lib/coding_adventures/nib_type_checker/checker.rb
@@ -192,7 +192,10 @@ module CodingAdventures
             else
               check_expr(first_expr_child, scope)
             end
-          when "add_expr"
+          when "add_expr", "mul_expr"
+            # mul_expr shares additive semantics: same-type numeric operands,
+            # numeric result (LITERAL if both operands are unresolved integer
+            # literals). Routing it through check_add_expr avoids a parallel path.
             check_add_expr(node, scope)
           when "call_expr"
             check_call_expr(node, scope)
@@ -308,7 +311,10 @@ module CodingAdventures
       end
 
       def expression_rule?(name)
-        %w[expr or_expr and_expr eq_expr cmp_expr add_expr bitwise_expr unary_expr primary call_expr].include?(name)
+        # mul_expr sits between add_expr and bitwise_expr in the precedence
+        # cascade (LANG-FULL N1). It must be here so expression_children does not
+        # filter it out when add_expr walks its operands.
+        %w[expr or_expr and_expr eq_expr cmp_expr add_expr mul_expr bitwise_expr unary_expr primary call_expr].include?(name)
       end
 
       def unwrap_top_decl(node)


### PR DESCRIPTION
## Problem

The **Full build on main merge** CI step (which builds/tests *every* package, not just the diff-affected set) was red on `main` — see runs [84692950611](https://github.com/adhithyan15/coding-adventures/actions/runs/28565837801/job/84692950611) (shard-3) and [84692950579](https://github.com/adhithyan15/coding-adventures/actions/runs/28565837801/job/84692950579) (shard-4). The other shards were cancelled by fail-fast.

Four independent breakages, each a **latent bug that passed its own PR's sharded diff CI** because the affected package wasn't in that PR's diff (the cross-PR gap).

## Fixes

1. **`mul_expr` expression dispatch** — `ruby/nib_type_checker`, `ruby/nib_ir_compiler`, `lua/nib_ir_compiler`. LANG-FULL N1 inserted a multiplicative precedence level (`add_expr → mul_expr → bitwise_expr`); #5747 fixed only Elixir/TS. With `mul_expr` absent from the expression-rule allow-lists, `expression_children` filtered it out when `add_expr` walked its operands, so `a +% b` inferred no type (spurious "return expects T, got " errors) / emitted no `ADD` opcodes. Added `mul_expr` to the allow-lists and routed it through the existing additive path. `ruby/nib_ir_compiler` was only dep-skipped in the failing run but had the same latent bug — fixed proactively. `nib_wasm_compiler` delegates to it.

2. **F10 modal grammar parsing** — `perl/grammar-tools` (unblocks `perl/javascript-lexer`). `parse_token_grammar` died with "Expected token definition (NAME = pattern)" on `ecmascript/es2025.tokens`, which uses `start_mode:`/`group`/`transitions:` to model regex-vs-division. Taught the parser to accept and record `start_mode:` and the `transitions:` section; flat consumers ignore modes. Added regression subtests.

3. **standardrb lint** — `ruby/aztec_code`. `Style/RedundantStructKeywordInit` flagged `keyword_init: true` on `SymbolSpec` (redundant in Ruby ≥3.2; gem targets ≥3.3.0). Removed — no behavioral change.

## Verification

- **Perl**: verified directly — `es2025` (and es2020–es2024) tokenize `let` → `LET`.
- **Ruby/Lua**: runtimes unavailable locally; verified by tracing failing test expectations against the reference Elixir fix (#5747). CI confirms.
- Security review: passed (no vulnerabilities).
- CHANGELOGs updated for all touched packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)