### PR TITLE
feat(sir-js): mixin MRO — include/extend module method resolution (MX4)

### DIFF
--- a/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
@@ -2,6 +2,59 @@
 
 All notable changes to `semantic-ir-to-javascript` are documented here.
 
+## 0.11.0 — mixins: `include` / `extend` module method resolution (MX4)
+
+### Added
+
+- The inlined `__Sir` OOP runtime now executes **Ruby mixins** — a module's
+  methods are found via `include` / `extend` — so a translated
+  `module M; def foo; …; end; end` + `include M` resolves `foo` on including
+  classes' instances, identically to the reference backends
+  (sir-mixins, MX4). Runtime-only: no core-IR / frontend change (the merged
+  MX1 frontend already lowers module bodies + `include` / `extend`).
+  - `Feature::Modules` is now **accepted** by the JS backend. A module body's
+    `def`s register into the SAME `methodTable` a class uses, keyed by the
+    module name (via the existing `__def_method__` builtin — an "owner" is now
+    a class *or* a module).
+  - **`include M`** → `__include__("Owner", "M")` →
+    `__Sir.includeModule("Owner", "M")`, appending `M` to a per-owner
+    `includedModules` list in include order.
+  - **`extend M`** → `__extend__("Owner", "M")` →
+    `__Sir.extendModule("Owner", "M")`, appending to a per-owner
+    `extendedModules` list; `M`'s (instance) methods become **class methods**
+    of the owner, callable as `Owner.method`.
+  - **`Klass.method(args…)`** on a constant receiver →
+    `__class_method__("Klass", "method", args…)` →
+    `__Sir.callClassMethod(…)` (the class-method dispatch arm — previously
+    unhandled by this backend), resolving through the class-method MRO.
+  - **`resolveMethod` now follows Ruby's MRO**: for a receiver of class `C`
+    the walk searches `C` → `C`'s included modules **most-recent-first**
+    (reverse of include order, each expanded depth-first through its own
+    `include`s) → `C`'s superclass → its modules → … A class-defined method
+    **shadows** a mixed-in module method (class-first MRO), and a **diamond**
+    include (a module reached via two paths) is resolved **once** at its
+    earliest position. `super` and `initialize` resolution are MRO-aware too.
+
+### Security
+
+- Dispatch stays **explicit-table, cycle-guarded** (the C3 RCE bar). The new
+  `includedModules` / `extendedModules` are real `Map`s keyed by owner *name
+  strings* holding module *name strings* — never `Object` properties — so a
+  module or owner literally named `constructor` / `__proto__` is inert data,
+  never a prototype write or a reflective host callable. A single shared
+  `seen` set spans the whole MRO walk, so a self-including module
+  (`module M; include M; end`) or a cyclic hierarchy **terminates** with a
+  `NoMethodError` instead of looping.
+
+### Tests
+
+- Unit (emit shape): `__include__` / `__extend__` / `__class_method__` route
+  to the runtime helpers.
+- Execution-proofs under Node (hand-built SIR mirroring the MX1 frontend):
+  included-module method callable; class method shadows module; diamond
+  include resolves once; `extend` makes a class method; self-including module
+  terminates.
+
 ## 0.10.0 — typed runtime errors (ZeroDivision/Index/Key/NoMethod, T3)
 
 ### Added

--- a/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "semantic-ir-to-javascript"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
-description = "Semantic IR → self-contained JavaScript source code (SIR18). Fifth backend for the SIR10 narrow-waist IR. Includes __method__ dispatch execution (C3), exception handling (try/catch/raise) with user-class ancestry (E1), and user-defined-class OOP — instantiation, method dispatch, super, self, and @ivar/@@cvar access (O3)."
+description = "Semantic IR → self-contained JavaScript source code (SIR18). Fifth backend for the SIR10 narrow-waist IR. Includes __method__ dispatch execution (C3), exception handling (try/catch/raise) with user-class ancestry (E1), user-defined-class OOP — instantiation, method dispatch, super, self, and @ivar/@@cvar access (O3) — and Ruby mixins (module include/extend with MRO method resolution, MX4)."
 
 [dependencies]
 semantic-ir = { path = "../semantic-ir" }

--- a/code/packages/rust/semantic-ir-to-javascript/README.md
+++ b/code/packages/rust/semantic-ir-to-javascript/README.md
@@ -65,10 +65,10 @@ surface the emitter lowers today. JavaScript supports every SIR16 feature
 natively (arrays, `Map`, `while`/`for`, reassignable `let`), so each
 lowering is direct.
 
-| Accepted (v0 + SIR16 + E1 + O3) | Rejected (deferred / unsupported)        |
+| Accepted (v0 + SIR16 + E1 + O3 + MX4) | Rejected (deferred / unsupported)  |
 |---------------------------------|------------------------------------------|
-| `Closures`                      | `Modules` (SIR17)                        |
-| `Pairs`                         | `StringInterpolation` (`StrConcat`, SIR18) |
+| `Closures`                      | `StringInterpolation` (`StrConcat`, SIR18) |
+| `Pairs`                         | `SingletonClassDef` OOP dispatch         |
 | `Symbols`                       | `TailCalls` (V8 has no reliable TCO)     |
 | `Strings`                       | `Intrinsics` (empty whitelist)           |
 | `DynamicTyping`                 |                                          |
@@ -87,14 +87,15 @@ lowering is direct.
 | `Classes` (E2 ancestry + O3 OOP)|                                          |
 | `InstanceVars` (O3)             |                                          |
 | `ClassVars` (O3)                |                                          |
+| `Modules` (MX4 mixins)          |                                          |
 | `Constants`                     |                                          |
 
 `accepts_intrinsics()` is empty. The accept-set is deliberately matched
 to what `emit` handles, so a module using a deferred node is turned away
 *before* lowering rather than mis-compiled — and every accepted feature
 has a real emit arm (the residual `panic!` guards cover only the
-still-deferred SIR17/18 nodes — `Modules`, `SingletonClassDef` OOP
-dispatch, and string interpolation).
+still-deferred SIR18 nodes — `SingletonClassDef` OOP dispatch and string
+interpolation).
 
 `Classes` now covers **full user-defined-class OOP (O3)**: a `ClassDef`
 supplies its `superclass` *ancestry edge* (so `raise MyErr; rescue
@@ -131,6 +132,29 @@ and an exception thrown mid-method still unwinds cleanly.  A `SirInstance`
 receiver dispatches to the user method table; every **other** receiver
 (array, string, …) falls through to the unchanged built-in / collection
 path, so collection methods and exceptions are not regressed.
+
+### Mixins — `include` / `extend` (MX4)
+
+A `module M … end` registers its `def`s into the **same** `methodTable` a
+class uses (keyed by the module name), and the two mixin directives lower to
+one builtin each; dispatch then follows Ruby's **Method Resolution Order**.
+
+| SIR (from MX1 frontend)         | JavaScript emitted                          |
+|---------------------------------|---------------------------------------------|
+| `include Greet` in `class C`    | `__Sir.includeModule("C", "Greet")`         |
+| `extend Counter` in `class C`   | `__Sir.extendModule("C", "Counter")`        |
+| `Widget.tally(1)` (const recv)  | `__Sir.callClassMethod("Widget", "tally", 1)` |
+
+`__Sir.resolveMethod` walks the MRO: **class → its included modules
+most-recent-first (each expanded depth-first through its own `include`s) →
+superclass → …**  A class-defined method **shadows** a mixed-in module
+method, a **diamond** include resolves the shared module **once**, and
+`extend` promotes a module's instance methods to **class methods** (found by
+`callClassMethod`).  The per-owner `includedModules` / `extendedModules` are
+real `Map`s keyed by *name strings* holding module *name strings* — the same
+explicit-table, no-reflection bar as the method tables — and a single shared
+`seen` set makes a self-including module or cyclic hierarchy **terminate**
+(`NoMethodError`) rather than loop.
 
 ### SIR16 lowering at a glance
 

--- a/code/packages/rust/semantic-ir-to-javascript/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/emit.rs
@@ -990,6 +990,49 @@ fn emit_builtin_call(out: &mut String, name: &str, args: &[Expr], indent: usize)
         out.push_str("__Sir.currentSelf()");
         return;
     }
+    // ── mixins (MX4): include / extend / class-method call ───────────
+    // The frontend lowers Ruby mixin surface to three more OOP builtins,
+    // each keyed by class/module *name-string* literals (never a live
+    // object), so the runtime dispatches by explicit `Map` key — a module
+    // named `constructor` is inert data, same bar as the method tables.
+    //
+    //   `include M` in `class C` → `__include__("C", "M")`
+    //                              → `__Sir.includeModule("C", "M")`
+    //   `extend  M` in `class C` → `__extend__("C", "M")`
+    //                              → `__Sir.extendModule("C", "M")`
+    //   `Klass.m(args…)`         → `__class_method__("Klass", "m", args…)`
+    //                              → `__Sir.callClassMethod("Klass", "m", args…)`
+    if name == "__include__" && args.len() == 2 {
+        // args: [owner-name, module-name].
+        out.push_str("__Sir.includeModule(");
+        emit_oop_name_arg(out, &args[0]);
+        out.push_str(", ");
+        emit_oop_name_arg(out, &args[1]);
+        out.push(')');
+        return;
+    }
+    if name == "__extend__" && args.len() == 2 {
+        // args: [owner-name, module-name].
+        out.push_str("__Sir.extendModule(");
+        emit_oop_name_arg(out, &args[0]);
+        out.push_str(", ");
+        emit_oop_name_arg(out, &args[1]);
+        out.push(')');
+        return;
+    }
+    if name == "__class_method__" && args.len() >= 2 {
+        // args: [class-name, method-name, call-args…].
+        out.push_str("__Sir.callClassMethod(");
+        emit_oop_name_arg(out, &args[0]);
+        out.push_str(", ");
+        emit_oop_name_arg(out, &args[1]);
+        for a in &args[2..] {
+            out.push_str(", ");
+            emit_expr(out, a, indent);
+        }
+        out.push(')');
+        return;
+    }
     // `raise` (SIR17) → throw a SIR exception via the inlined runtime.
     // Mirrors the TypeScript backend's `raise` arm; the first argument
     // decides the shape:
@@ -1657,6 +1700,42 @@ mod tests {
     #[test]
     fn emit_self_routes_to_current_self() {
         assert_eq!(emit_e(&bc("__self__", vec![])), "__Sir.currentSelf()");
+    }
+
+    // ── mixins (MX4): include / extend / class-method call ───────────
+
+    #[test]
+    fn emit_include_routes_to_include_module() {
+        // `include Greet` in `class Robot` → __include__("Robot", "Greet")
+        //                                   → __Sir.includeModule("Robot", "Greet").
+        let e = bc("__include__", vec![strlit("Robot"), strlit("Greet")]);
+        assert_eq!(emit_e(&e), r#"__Sir.includeModule("Robot", "Greet")"#);
+    }
+
+    #[test]
+    fn emit_extend_routes_to_extend_module() {
+        // `extend Counter` in `class Widget` → __extend__("Widget", "Counter")
+        //                                     → __Sir.extendModule("Widget", "Counter").
+        let e = bc("__extend__", vec![strlit("Widget"), strlit("Counter")]);
+        assert_eq!(emit_e(&e), r#"__Sir.extendModule("Widget", "Counter")"#);
+    }
+
+    #[test]
+    fn emit_class_method_call_routes_to_call_class_method() {
+        // `Widget.tally(1)` → __class_method__("Widget", "tally", 1)
+        //                    → __Sir.callClassMethod("Widget", "tally", 1).
+        let e = bc(
+            "__class_method__",
+            vec![strlit("Widget"), strlit("tally"), Expr::IntLit { value: 1, span: s() }],
+        );
+        assert_eq!(emit_e(&e), r#"__Sir.callClassMethod("Widget", "tally", 1)"#);
+    }
+
+    #[test]
+    fn emit_class_method_call_no_args() {
+        // `Widget.count` (no call args) → __class_method__("Widget", "count").
+        let e = bc("__class_method__", vec![strlit("Widget"), strlit("count")]);
+        assert_eq!(emit_e(&e), r#"__Sir.callClassMethod("Widget", "count")"#);
     }
 
     #[test]

--- a/code/packages/rust/semantic-ir-to-javascript/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/lib.rs
@@ -162,6 +162,18 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     // matching Ruby's "no prior declaration" rule for these scopes).
     Feature::InstanceVars,
     Feature::ClassVars,
+    // MX4 (SIR mixins): `module M … end` + `include` / `extend`.  A module
+    // body's `def`s register into the SAME runtime method table as a class
+    // (keyed by the module name via `__def_method__`), and `include M` /
+    // `extend M` lower to `__include__("Owner","M")` / `__extend__(…)` — the
+    // frontend triggers `Feature::Modules` for all three.  The inlined OOP
+    // runtime's method-resolution walk now follows Ruby's MRO (class →
+    // included modules, most-recent-first → superclass → …), and `extend`
+    // registers a module's methods as class ("singleton") methods, so a
+    // mixed-in method is found on an including class's instances (`include`)
+    // or on the class itself (`extend`).  See `emit`'s `__include__` /
+    // `__extend__` / `__class_method__` arms and `runtime::resolveMethod`.
+    Feature::Modules,
 ];
 
 impl Backend for JavaScriptBackend {

--- a/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
@@ -445,7 +445,7 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
     // Resolution is `resolveMethod` → explicit `Map.get` on the
     // `(class, method)` key; a name like `constructor` simply misses.
     if (recv instanceof SirInstance) {
-      const fn = resolveMethod(methodTable, recv.sirClass, name);
+      const fn = resolveMethod(methodTable, recv.sirClass, name, includedModules);
       if (fn === undefined) {
         raiseError("NoMethodError",
           "undefined method `" + name + "` for an instance of `" +
@@ -727,17 +727,114 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
     classMethodTable.set(methodKey(cls, name), fn);
   }
 
-  // Resolve `name` on `cls` or any ancestor, walking the SAME `ancestry`
-  // table the exception runtime uses.  `seen` guards a malformed cyclic
-  // hierarchy so the walk terminates instead of looping forever.  Lookup
-  // is `table.get(methodKey(cur, name))` — explicit data, never `[name]`.
-  function resolveMethod(table, cls, name) {
-    let cur = cls;
+  // ── mixins (MX4): `include` / `extend` ─────────────────────────────
+  //
+  // A *module* registers its `def`s exactly like a class (via `defMethod`
+  // keyed by the module name — an "owner" is now a class OR a module).
+  // Two per-owner association lists connect an owner to the modules mixed
+  // into it, in Ruby's include order:
+  //
+  //   • `includedModules[owner] = [M1, M2, …]` — `include M` appends `M`.
+  //     Ruby searches the MOST-RECENTLY-included module first, so the MRO
+  //     walk iterates this list in REVERSE.  The module's *instance*
+  //     methods become instance methods of the owner.
+  //   • `extendedModules[owner] = [M1, M2, …]` — `extend M` appends `M`.
+  //     The module's *instance* methods become CLASS ("singleton")
+  //     methods of the owner (callable as `Owner.method`).
+  //
+  // SECURITY (the same bar as the method tables): both are real `Map`s
+  // keyed on the owner *name string*, holding arrays of module *name
+  // strings*.  Nothing here is `Object`-property access, so a module or
+  // owner literally named `__proto__` / `constructor` is inert data — a
+  // Map key / array element, never a prototype write or a host callable.
+  const includedModules = new Map();
+  const extendedModules = new Map();
+  // Append `mod` to `owner`'s list in `map`, preserving include order and
+  // idempotently allowing a re-include (Ruby keeps the first position; a
+  // repeat is harmless — the MRO walk de-dupes with its `seen` set).
+  function appendModule(map, owner, mod) {
+    let list = map.get(owner);
+    if (list === undefined) { list = []; map.set(owner, list); }
+    list.push(mod);
+  }
+  // `include M` inside `class C` (or module) → `includeModule("C", "M")`.
+  function includeModule(owner, mod) { appendModule(includedModules, owner, mod); }
+  // `extend M` → `extendModule("C", "M")` (M's methods become CLASS methods).
+  function extendModule(owner, mod) { appendModule(extendedModules, owner, mod); }
+
+  // Resolve `name` on `cls` following Ruby's Method Resolution Order (MRO),
+  // walking the SAME `ancestry` table the exception runtime uses AND the
+  // per-owner module lists.  For each class in the superclass chain the
+  // walk checks, in order:
+  //
+  //   1. the class's OWN entry in `ownerTable` (a class-defined method
+  //      SHADOWS a mixed module method — class-first MRO);
+  //   2. its mixed-in modules, MOST-RECENT-FIRST (reverse of mix order),
+  //      each recursively expanded so a module's OWN `include`d modules are
+  //      searched too (depth-first);
+  //   3. then it ascends to the superclass and repeats.
+  //
+  // Two tables split the class's own methods from a MODULE's methods:
+  //   • instance dispatch: `ownerTable = moduleTable = methodTable`, and
+  //     `topModules = includedModules` — a class and its included modules
+  //     both live in `methodTable`.
+  //   • class-method dispatch (`extend`): `ownerTable = classMethodTable`
+  //     (the class's own `def self.m`), `moduleTable = methodTable` (a
+  //     module's plain `def foo` — `extend` promotes those to class
+  //     methods), and `topModules = extendedModules`.
+  // Below the top owner we always follow a module's `includedModules` and
+  // read from `moduleTable`, because a module mixes in *instance* methods
+  // regardless of whether the top owner included or extended it.
+  //
+  // A single shared `seen` set spans the WHOLE walk, so a diamond include
+  // (a module reached via two paths) is checked ONCE at its earliest
+  // position, and a cyclic hierarchy / self-including module terminates
+  // instead of looping.  Every lookup is `table.get(methodKey(owner,
+  // name))` — explicit data, never `[name]` / reflection.
+  function resolveMethod(ownerTable, cls, name, topModules) {
     const seen = new Set();
+    // Search a MODULE `mod` (and, depth-first, its own included modules).
+    // A module's methods always live in `methodTable` (instance methods).
+    function searchModule(mod) {
+      if (mod === undefined || mod === null || seen.has(mod)) {
+        return undefined;
+      }
+      seen.add(mod);
+      const own = methodTable.get(methodKey(mod, name));
+      if (own !== undefined) { return own; }
+      const mods = includedModules.get(mod);
+      if (mods !== undefined) {
+        for (let i = mods.length - 1; i >= 0; i--) {
+          const fn = searchModule(mods[i]);
+          if (fn !== undefined) { return fn; }
+        }
+      }
+      return undefined;
+    }
+    // Search a CLASS `owner`: its own table first, then its top-level
+    // mixed-in modules (most-recently-mixed wins → reverse iteration).
+    function searchOwner(owner) {
+      if (owner === undefined || owner === null || seen.has(owner)) {
+        return undefined;
+      }
+      seen.add(owner);
+      const own = ownerTable.get(methodKey(owner, name));
+      if (own !== undefined) { return own; }
+      const mods = topModules === undefined ? undefined : topModules.get(owner);
+      if (mods !== undefined) {
+        for (let i = mods.length - 1; i >= 0; i--) {
+          const fn = searchModule(mods[i]);
+          if (fn !== undefined) { return fn; }
+        }
+      }
+      return undefined;
+    }
+    // Walk the superclass chain; the `ancestry` edge itself is also
+    // `seen`-guarded above, so a cyclic `ancestry` map still terminates.
+    let cur = cls;
     while (cur !== undefined && cur !== null && !seen.has(cur)) {
-      const fn = table.get(methodKey(cur, name));
+      const fn = searchOwner(cur);
       if (fn !== undefined) { return fn; }
-      seen.add(cur);
       cur = ancestry[cur];
     }
     return undefined;
@@ -776,9 +873,28 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
   // valid: `new` just yields a bare instance.
   function callNew(cls, ...args) {
     const obj = newInstance(cls);
-    const init = resolveMethod(methodTable, cls, "initialize");
+    const init = resolveMethod(methodTable, cls, "initialize", includedModules);
     if (init !== undefined) { applyWithSelf(init, obj, args); }
     return obj;
+  }
+
+  // `Klass.m(args…)` on a CONSTANT receiver → `callClassMethod("Klass",
+  // "m", args…)`.  Resolves through the CLASS-method MRO: the class's own
+  // `def self.m` table first, then any `extend`ed modules (most-recently-
+  // extended first), ascending the superclass chain — the class-method
+  // analogue of instance dispatch, so `extend M` makes `M`'s instance
+  // methods callable as `Klass.m`.  `self` is bound to the class-name
+  // string for the duration (a module's method body may read `self`),
+  // mirroring Ruby where `self` inside a class method is the class.  A
+  // miss is a NoMethodError, matching Ruby's `undefined method` for a
+  // class receiver.
+  function callClassMethod(cls, name, ...args) {
+    const fn = resolveMethod(classMethodTable, cls, name, extendedModules);
+    if (fn === undefined) {
+      raiseError("NoMethodError",
+        "undefined method `" + name + "` for class `" + cls + "`");
+    }
+    return applyWithSelf(fn, cls, args);
   }
 
   // `super(args…)` inside method `method` of class `cls` →
@@ -787,7 +903,7 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
   // it with the CURRENT `self` still bound — `super` reuses the live
   // receiver.  A missing super method is a NoMethodError, matching Ruby.
   function callSuper(method, cls, ...args) {
-    const fn = resolveMethod(methodTable, ancestry[cls], method);
+    const fn = resolveMethod(methodTable, ancestry[cls], method, includedModules);
     if (fn === undefined) {
       raiseError("NoMethodError",
         "super: no superclass method `" + method + "` for `" + cls + "`");
@@ -849,6 +965,8 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
     SirInstance, newInstance, callNew, callSuper,
     defMethod, defClassMethod, currentSelf,
     ivarGet, ivarSet, cvarGet, cvarSet,
+    // Mixins (MX4): include/extend registration + class-method dispatch.
+    includeModule, extendModule, callClassMethod,
   };
 })();
 "##;
@@ -886,6 +1004,8 @@ mod tests {
             "class SirInstance", "callNew", "callSuper",
             "defMethod", "defClassMethod", "currentSelf",
             "ivarGet", "ivarSet", "cvarGet", "cvarSet",
+            // Mixins (MX4): include/extend + class-method dispatch.
+            "includeModule", "extendModule", "callClassMethod",
         ] {
             assert!(RUNTIME.contains(needed), "runtime missing `{needed}`");
         }
@@ -900,7 +1020,8 @@ mod tests {
         // data (a Map miss), not a reflective gadget.
         assert!(RUNTIME.contains("const methodTable = new Map();"));
         assert!(RUNTIME.contains(r#"return cls + "\x00" + name;"#));
-        assert!(RUNTIME.contains("table.get(methodKey(cur, name))"));
+        assert!(RUNTIME.contains("ownerTable.get(methodKey(owner, name))"));
+        assert!(RUNTIME.contains("methodTable.get(methodKey(mod, name))"));
         // No dynamic-code gadget is ever *invoked*: `new Function(` and
         // `eval(` as calls appear nowhere in the runtime (the phrase
         // "new Function" occurs only in the SECURITY comment prose, so we
@@ -910,6 +1031,12 @@ mod tests {
         // The ivar / instance bags are prototype-less, so a `"__proto__"`
         // name is data and cannot poison a prototype chain.
         assert!(RUNTIME.contains("this.ivars = Object.create(null);"));
+        // MX4: the per-owner mixin lists are real `Map`s (not `{}`), keyed
+        // by the owner NAME string and holding module NAME strings — so a
+        // module/owner named `__proto__` is inert data, never a prototype
+        // write, matching the method-table bar.
+        assert!(RUNTIME.contains("const includedModules = new Map();"));
+        assert!(RUNTIME.contains("const extendedModules = new Map();"));
     }
 
     #[test]

--- a/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
@@ -1347,6 +1347,210 @@ fn oop_cyclic_ancestry_terminates() {
     }
 }
 
+// ── MX4: mixin (module include / extend) execution-proof ───────────────
+//
+// A *module* registers its `def`s exactly like a class — via
+// `__def_method__` keyed by the module NAME (an "owner" is now a class OR
+// a module).  `include M` / `extend M` lower to the two mixin builtins
+// `__include__("Owner","M")` / `__extend__("Owner","M")`, and the inlined
+// OOP runtime's `resolveMethod` now follows Ruby's MRO (class → included
+// modules most-recent-first → superclass → …).  These hand-built SIR
+// modules mirror exactly what the (merged) Ruby MX1 frontend emits, then
+// run the self-contained `.js` under Node and assert stdout.
+
+/// `include M` inside owner `Owner` → `__include__("Owner", "M")`.
+fn include_(owner: &str, module: &str) -> Stmt {
+    Stmt::ExprStmt {
+        expr: bc("__include__", vec![str_(owner), str_(module)]),
+        span: sp(),
+    }
+}
+/// `extend M` inside owner `Owner` → `__extend__("Owner", "M")`.
+fn extend_(owner: &str, module: &str) -> Stmt {
+    Stmt::ExprStmt {
+        expr: bc("__extend__", vec![str_(owner), str_(module)]),
+        span: sp(),
+    }
+}
+
+/// Like `oop_module`, but also flags `Feature::Modules` (the feature the
+/// frontend triggers for `module` / `include` / `extend`).
+fn mixin_module(methods: Vec<Function>, main_stmts: Vec<Stmt>) -> Module {
+    let mut functions = methods;
+    functions.push(func("main", vec![], main_stmts, Expr::NilLit { span: sp() }));
+    Module {
+        name: "mixin".into(),
+        manifest: FeatureManifest::from_features(&[
+            Feature::Classes,
+            Feature::Modules,
+            Feature::InstanceVars,
+            Feature::Closures,
+            Feature::Strings,
+            Feature::DynamicTyping,
+            Feature::Constants,
+            Feature::MutableBindings,
+        ]),
+        imports: vec![],
+        exports: vec![],
+        functions,
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("handbuilt")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: sp(),
+    }
+}
+
+/// MX4 (a) — a module's instance method, `include`d into a class, is
+/// found on an instance of that class:
+///   module Greet; def hello; print("hi from module"); end; end
+///   class Robot; include Greet; end
+///   Robot.new.hello   →   "hi from module"
+#[test]
+fn mixin_included_module_method_is_callable() {
+    let hello = func(
+        "Greet__hello",
+        vec![],
+        vec![print(str_("hi from module"))],
+        Expr::NilLit { span: sp() },
+    );
+    // Module method registers keyed by the MODULE name, exactly like a class.
+    let make = bc("__new__", vec![str_("Robot")]);
+    let call = bc("__method__", vec![make, str_("hello")]);
+    let main = vec![
+        def_method("Greet", "hello", "Greet__hello"),
+        include_("Robot", "Greet"),
+        Stmt::ExprStmt { expr: call, span: sp() },
+    ];
+    let module = mixin_module(vec![hello], main);
+
+    // Shape: include lowers to the runtime registration.
+    let artifact = compile(&module).expect("compile");
+    assert!(
+        artifact.source.contains(r#"__Sir.includeModule("Robot", "Greet")"#),
+        "{}",
+        artifact.source
+    );
+
+    if let Some(stdout) = run_module(&module, "mixin_include") {
+        assert_eq!(stdout, "hi from module");
+    }
+}
+
+/// MX4 (b) — a method the CLASS defines itself SHADOWS the module's
+/// (class-first MRO):
+///   module M; def who; print("module"); end; end
+///   class C; include M; def who; print("class"); end; end
+///   C.new.who   →   "class"
+#[test]
+fn mixin_class_method_shadows_module() {
+    let mod_who = func("M__who", vec![], vec![print(str_("module"))], Expr::NilLit { span: sp() });
+    let cls_who = func("C__who", vec![], vec![print(str_("class"))], Expr::NilLit { span: sp() });
+    let make = bc("__new__", vec![str_("C")]);
+    let call = bc("__method__", vec![make, str_("who")]);
+    let main = vec![
+        def_method("M", "who", "M__who"),
+        // The class both includes M and defines its own `who`.
+        include_("C", "M"),
+        def_method("C", "who", "C__who"),
+        Stmt::ExprStmt { expr: call, span: sp() },
+    ];
+    let module = mixin_module(vec![mod_who, cls_who], main);
+    if let Some(stdout) = run_module(&module, "mixin_shadow") {
+        assert_eq!(stdout, "class", "class-defined method must shadow the module's");
+    }
+}
+
+/// MX4 (c) — a DIAMOND include resolves the shared module ONCE and finds
+/// the method (the `seen`-guarded MRO walk de-dupes and terminates):
+///   module Base; def tag; print("base"); end; end
+///   module Left;  include Base; end
+///   module Right; include Base; end
+///   class C; include Left; include Right; end
+///   C.new.tag   →   "base"     (Base reached via two paths, resolved once)
+#[test]
+fn mixin_diamond_include_resolves_once() {
+    let tag = func("Base__tag", vec![], vec![print(str_("base"))], Expr::NilLit { span: sp() });
+    let make = bc("__new__", vec![str_("C")]);
+    let call = bc("__method__", vec![make, str_("tag")]);
+    let main = vec![
+        def_method("Base", "tag", "Base__tag"),
+        // Two intermediate modules each include Base (the diamond's arms).
+        include_("Left", "Base"),
+        include_("Right", "Base"),
+        // The class includes both arms.
+        include_("C", "Left"),
+        include_("C", "Right"),
+        Stmt::ExprStmt { expr: call, span: sp() },
+    ];
+    let module = mixin_module(vec![tag], main);
+    if let Some(stdout) = run_module(&module, "mixin_diamond") {
+        assert_eq!(stdout, "base", "diamond include must resolve Base once and find `tag`");
+    }
+}
+
+/// MX4 (d) — `extend M` makes M's instance methods CLASS methods of the
+/// owner (callable as `Owner.method`):
+///   module Counter; def describe; print("i am a class method"); end; end
+///   class Widget; extend Counter; end
+///   Widget.describe   →   "i am a class method"
+#[test]
+fn mixin_extend_makes_class_method() {
+    let describe = func(
+        "Counter__describe",
+        vec![],
+        vec![print(str_("i am a class method"))],
+        Expr::NilLit { span: sp() },
+    );
+    // `Widget.describe` on a constant receiver → __class_method__("Widget","describe").
+    let call = bc("__class_method__", vec![str_("Widget"), str_("describe")]);
+    let main = vec![
+        def_method("Counter", "describe", "Counter__describe"),
+        extend_("Widget", "Counter"),
+        Stmt::ExprStmt { expr: call, span: sp() },
+    ];
+    let module = mixin_module(vec![describe], main);
+
+    let artifact = compile(&module).expect("compile");
+    assert!(
+        artifact.source.contains(r#"__Sir.extendModule("Widget", "Counter")"#),
+        "{}",
+        artifact.source
+    );
+    assert!(
+        artifact.source.contains(r#"__Sir.callClassMethod("Widget", "describe")"#),
+        "{}",
+        artifact.source
+    );
+
+    if let Some(stdout) = run_module(&module, "mixin_extend") {
+        assert_eq!(stdout, "i am a class method");
+    }
+}
+
+/// MX4 (e, security) — a SELF-including module must not loop forever: the
+/// shared `seen` set terminates the MRO walk.  `module M; include M; end`
+/// then a call to a MISSING method walks M → M (guarded) → NoMethodError,
+/// so Node exits non-zero rather than hanging.
+#[test]
+fn mixin_self_including_module_terminates() {
+    let make = bc("__new__", vec![str_("C")]);
+    let call = bc("__method__", vec![make, str_("missing")]);
+    let main = vec![
+        // M includes itself; C includes M — the walk must not loop.
+        include_("M", "M"),
+        include_("C", "M"),
+        Stmt::ExprStmt { expr: call, span: sp() },
+    ];
+    let module = mixin_module(vec![], main);
+    if let Some(stderr) = run_module_expecting_failure(&module, "mixin_cycle") {
+        assert!(
+            stderr.contains("NoMethodError") || stderr.contains("undefined method"),
+            "self-including module must terminate with a method-miss, got stderr:\n{stderr}"
+        );
+    }
+}
+
 // ── puts builtin (Ruby semantics) ──────────────────────────────────────
 
 /// Compile a hand-built module, run it under `node`, and return the **raw**


### PR DESCRIPTION
MX4 of the **sir-mixins** cascade (spec + MX1 frontend merged). Runtime-only — `semantic-ir-to-javascript` (inlined runtime + emit arms).

Makes the JS backend's emitted OOP runtime execute Ruby mixins:
- `includeModule`/`extendModule` register into per-owner `includedModules`/`extendedModules` `Map`s.
- `resolveMethod` rewritten to Ruby MRO: **class → included modules (reverse, depth-first) → superclass → its modules → …**, single shared `seen` set (diamond once; self-include terminates); `super`/`initialize` MRO-aware.
- `extend` → module methods become class methods; class method **shadows** module; module shadows superclass.
- `Feature::Modules` accepted; adds `callClassMethod` + `__class_method__` emit arm (was absent on JS — bonus progress on #61, required to prove `extend`).

Security review: **PASSED** — Map-keyed dispatch (no `eval`/`Function`/`recv[name]`; runtime self-tests assert their absence), `ancestry` is `Object.create(null)`, Maps immune to `__proto__`/`constructor` pollution, single `seen` set terminates all cycles, names via `quote_js_string`.

Execution-proofed under node (5 proofs: mixed-in call, class shadows module, diamond once, `extend`→class method, self-include terminates). 103 lib + 49 integration green, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)