### PR TITLE
feat(adj-lang): n-ary \min/\max/\gcd/\lcm in latex "…" (variadic left-fold)

### DIFF
--- a/code/packages/rust/adj-lang/CHANGELOG.md
+++ b/code/packages/rust/adj-lang/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [0.31.0] - 2026-07-02 — n-ary `\min`/`\max`/`\gcd`/`\lcm` in `latex "…"`
+
+### Changed
+
+- `\min`/`\max`/`\gcd`/`\lcm` now accept **two OR MORE** comma-separated arguments
+  (previously exactly two). Because these ops are associative, an n-ary call
+  **left-folds** into a chain of the existing binary `ExprAst::Call2` —
+  `\min(a, b, c)` becomes `min(min(a, b), c)` — so it reuses the native
+  `ComputeOp::Min2`/`Max2`/`Gcd`/`Lcm` with **no engine change** and no n-ary op.
+  A two-arg call is unchanged (a single `Call2`). `latex_two_args` (exactly-two)
+  became `latex_nary_args` (≥ 2). A single-arg `\min(a)` is still a clean
+  `UnsupportedLatexMath` error.
+
+### Tests
+
+- n-ary lower test: `\min(a,b,c,d)=2`, `\max(a,b,c,d)=9`, `\gcd(24,36,60)=12`,
+  `\lcm(2,3,4)=12`. The wrong-arity test now asserts only the one-arg rejection
+  (three-plus args are valid).
+
 ## [0.30.0] - 2026-07-02 — `\operatorname{trunc}(x)` truncation in `latex "…"`
 
 ### Added

--- a/code/packages/rust/adj-lang/Cargo.toml
+++ b/code/packages/rust/adj-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang"
-version = "0.30.0"
+version = "0.31.0"
 edition = "2021"
 description = "Surface-syntax frontend for the adjudication framework's probabilistic-logic rulebooks. Lexes, parses, and lowers a domain-expert-readable DSL into a `logic-engine` KnowledgeBase. Dissolves ADJ46 awkwardness items A10 (rulebook syntax) and A4 (joint contributions syntactically distinct)."
 

--- a/code/packages/rust/adj-lang/src/adapter.rs
+++ b/code/packages/rust/adj-lang/src/adapter.rs
@@ -1026,10 +1026,11 @@ fn latex_math_to_expr_ast(expr: &MathExpr, source: &str) -> Result<ExprAst, Adap
         }
         // A named-function call. The single-argument transcendental set
         // (`\sin(x)`, `\ln(x)`, `\exp(x)`, …) lowers to the matching native
-        // transcendental op via `ExprAst::Call`; the two-argument `\min(a, b)` /
-        // `\max(a, b)` / `\gcd(a, b)` / `\lcm(a, b)` lower to the native binary ops
-        // via `ExprAst::Call2` (their argument is a two-element `Sequence`, usually
-        // inside the call's parentheses). (`\operatorname{trunc}(x)` is NOT a `Call` — an
+        // transcendental op via `ExprAst::Call`; the variadic `\min` / `\max` /
+        // `\gcd` / `\lcm` (`\min(a, b)`, `\max(a, b, c)`, …) left-fold their
+        // two-or-more comma-separated operands into a chain of the native binary op
+        // via `ExprAst::Call2` (the argument is a `Sequence`, usually inside the
+        // call's parentheses). (`\operatorname{trunc}(x)` is NOT a `Call` — an
         // operator name is text, so it arrives as a `Bin(Mul, Text("trunc"), (x))`
         // juxtaposition handled in the `Bin` arm above.) The remaining `Func` variants
         // (`det` and an unknown `Other`) have no lowering yet and are a clean, explicit
@@ -1044,12 +1045,25 @@ fn latex_math_to_expr_ast(expr: &MathExpr, source: &str) -> Result<ExprAst, Adap
                 _ => None,
             };
             if let Some(bin) = binfn {
-                let (a, b) = latex_two_args(arg, source, func)?;
-                return Ok(ExprAst::Call2(
-                    bin,
-                    Box::new(latex_math_to_expr_ast(a, source)?),
-                    Box::new(latex_math_to_expr_ast(b, source)?),
-                ));
+                // Two OR MORE comma-separated arguments. `min`/`max`/`gcd`/`lcm` are
+                // associative, so an n-ary call left-folds into a chain of the binary
+                // `Call2` node — `min(a, b, c)` becomes `min(min(a, b), c)` — which is
+                // exact and needs no n-ary engine op (the fold reuses `ComputeOp::Min2`
+                // /`Max2`/`Gcd`/`Lcm`). A two-arg call folds to a single `Call2`,
+                // identical to before.
+                let args = latex_nary_args(arg, source, func)?;
+                let mut operands = args.into_iter();
+                // `latex_nary_args` guarantees ≥ 2 items, so the first `next()` is Some.
+                let first = operands.next().expect("latex_nary_args guarantees ≥ 2 args");
+                let mut acc = latex_math_to_expr_ast(first, source)?;
+                for operand in operands {
+                    acc = ExprAst::Call2(
+                        bin,
+                        Box::new(acc),
+                        Box::new(latex_math_to_expr_ast(operand, source)?),
+                    );
+                }
+                return Ok(acc);
             }
             let named = match func {
                 Func::Sin => NamedFn::Sin,
@@ -1162,17 +1176,18 @@ fn latex_power_exponent(expr: &MathExpr, source: &str) -> Result<f64, AdapterErr
     Ok(v)
 }
 
-/// Peel a binary named-function argument (`\min(a, b)` / `\max(a, b)`) into its
-/// two operands. The latex frontend parses the parenthesised comma-list as a
-/// `Sequence([a, b])`, usually wrapped in a `Group`/`Fenced` (the `(…)`), so we
-/// strip those transparent wrappers and require **exactly two** items — a
-/// one-arg (`\min(a)`) or three-arg (`\min(a, b, c)`) call has no binary lowering
-/// and is a clean, explicit error rather than a silent mis-lowering.
-fn latex_two_args<'a>(
+/// Peel a variadic named-function argument (`\min(a, b)`, `\max(a, b, c)`, …) into
+/// its operand list. The latex frontend parses the parenthesised comma-list as a
+/// `Sequence([a, b, …])`, usually wrapped in a `Group`/`Fenced` (the `(…)`), so we
+/// strip those transparent wrappers and require **two or more** items — the caller
+/// left-folds them into a chain of the associative binary op. A one-arg (`\min(a)`)
+/// call, or a non-comma argument, has no such lowering and is a clean, explicit
+/// error rather than a silent mis-lowering.
+fn latex_nary_args<'a>(
     arg: &'a MathExpr,
     source: &str,
     func: &Func,
-) -> Result<(&'a MathExpr, &'a MathExpr), AdapterError> {
+) -> Result<Vec<&'a MathExpr>, AdapterError> {
     // Strip transparent parenthesisation to reach the underlying sequence.
     let mut inner = arg;
     loop {
@@ -1183,15 +1198,15 @@ fn latex_two_args<'a>(
         }
     }
     if let MathExpr::Sequence(items) = inner {
-        if items.len() == 2 {
-            return Ok((&items[0], &items[1]));
+        if items.len() >= 2 {
+            return Ok(items.iter().collect());
         }
     }
     Err(AdapterError::UnsupportedLatexMath {
         source: source.to_string(),
         detail: format!(
-            "{func:?} takes exactly two comma-separated arguments in ADJ arithmetic \
-             (e.g. \\min(a, b)); got {inner:?}"
+            "{func:?} takes two or more comma-separated arguments in ADJ arithmetic \
+             (e.g. \\min(a, b) or \\min(a, b, c)); got {inner:?}"
         ),
     })
 }

--- a/code/packages/rust/adj-lang/src/lower.rs
+++ b/code/packages/rust/adj-lang/src/lower.rs
@@ -2057,15 +2057,67 @@ contributes 1000000 from answer == 60 to correct
     }
 
     #[test]
-    fn native_latex_min_with_wrong_arity_is_rejected() {
-        // `\min(a)` (one arg) and `\min(a, b, c)` (three args) have no binary
-        // lowering — a clean, explicit error rather than a silent mis-lowering.
-        for src in [
-            "observe a(3)\nlet answer = latex \"$\\min(a)$\"\n? answer\n",
-            "observe a(3)\nobserve b(8)\nobserve c(1)\nlet answer = latex \"$\\min(a, b, c)$\"\n? answer\n",
-        ] {
-            assert!(compile(src).is_err(), "wrong-arity min must be rejected: {src:?}");
-        }
+    fn native_latex_min_with_one_argument_is_rejected() {
+        // `\min(a)` (a single argument) has no fold — min/max/gcd/lcm need TWO or
+        // more operands — so it is a clean, explicit error rather than a silent
+        // mis-lowering. (Three-or-more args ARE now accepted; see the n-ary test.)
+        let src = "observe a(3)\nlet answer = latex \"$\\min(a)$\"\n? answer\n";
+        assert!(compile(src).is_err(), "one-arg min must be rejected: {src:?}");
+    }
+
+    #[test]
+    fn native_latex_nary_min_max_left_fold_over_three_or_more_args() {
+        // `\min`/`\max`/`\gcd`/`\lcm` accept TWO OR MORE comma-separated operands and
+        // left-fold into a chain of the associative binary op — min(a, b, c) =
+        // min(min(a, b), c) — reusing ComputeOp::Min2/Max2/Gcd/Lcm, no n-ary engine op.
+        // min(7, 3, 9, 2) = 2; max(7, 3, 9, 2) = 9.
+        let mn = crate::compile_and_decide(
+            "observe a(7)\n\
+             observe b(3)\n\
+             observe c(9)\n\
+             observe d(2)\n\
+             let answer = latex \"$\\min(a, b, c, d)$\"\n\
+             prior 0.10 for correct\n\
+             contributes 1000000 from answer == 2 to correct\n\
+             ? correct\n",
+        )
+        .unwrap();
+        assert!(mn.ranked[0].posterior > 0.99, "{mn:?}");
+        let mx = crate::compile_and_decide(
+            "observe a(7)\n\
+             observe b(3)\n\
+             observe c(9)\n\
+             observe d(2)\n\
+             let answer = latex \"$\\max(a, b, c, d)$\"\n\
+             prior 0.10 for correct\n\
+             contributes 1000000 from answer == 9 to correct\n\
+             ? correct\n",
+        )
+        .unwrap();
+        assert!(mx.ranked[0].posterior > 0.99, "{mx:?}");
+        // gcd(24, 36, 60) = 12 (three-arg gcd fold); lcm(2, 3, 4) = 12.
+        let g = crate::compile_and_decide(
+            "observe a(24)\n\
+             observe b(36)\n\
+             observe c(60)\n\
+             let answer = latex \"$\\gcd(a, b, c)$\"\n\
+             prior 0.10 for correct\n\
+             contributes 1000000 from answer == 12 to correct\n\
+             ? correct\n",
+        )
+        .unwrap();
+        assert!(g.ranked[0].posterior > 0.99, "{g:?}");
+        let l = crate::compile_and_decide(
+            "observe a(2)\n\
+             observe b(3)\n\
+             observe c(4)\n\
+             let answer = latex \"$\\lcm(a, b, c)$\"\n\
+             prior 0.10 for correct\n\
+             contributes 1000000 from answer == 12 to correct\n\
+             ? correct\n",
+        )
+        .unwrap();
+        assert!(l.ranked[0].posterior > 0.99, "{l:?}");
     }
 
     #[test]


### PR DESCRIPTION
## n-ary `\min`/`\max`/`\gcd`/`\lcm` in `latex "…"` (variadic left-fold)

Generalizes `\min`/`\max`/`\gcd`/`\lcm` on the `latex "…"` surface from **exactly two** arguments to **two or more**.

Because these ops are **associative**, an n-ary call **left-folds** into a chain of the existing binary `ExprAst::Call2` — `\min(a, b, c)` becomes `min(min(a, b), c)` — so it reuses the native `ComputeOp::Min2`/`Max2`/`Gcd`/`Lcm` with **no engine change** and no n-ary op. A two-arg call folds to a single `Call2`, identical to before.

### Change
- `latex_two_args` (exactly-two) → **`latex_nary_args`** (≥ 2): peels the transparent `Group`/`Fenced` wrappers, requires a `Sequence` of ≥ 2 items, else a clean `UnsupportedLatexMath`.
- The binfn arm iterates the operands and **left-folds** them into `Call2` — siblings are processed **iteratively** (a `for` loop), so no added stack depth.
- A single-arg `\min(a)` is still rejected (needs ≥ 2 operands).
- **Adapter-only**; the engine and AST are untouched (the fold is expressed purely in existing `Call2`/`ComputeOp` nodes). Left-fold is exact for all four ops: `gcd(a,b,c)=gcd(gcd(a,b),c)`, `lcm` likewise.

### Tests
- n-ary lower test via `compile_and_decide`: `\min(a,b,c,d)=2`, `\max(a,b,c,d)=9`, `\gcd(24,36,60)=12`, `\lcm(2,3,4)=12`.
- The wrong-arity test now asserts only the **one-arg** rejection (three-plus args are valid).
- Consumer crates (adj-constraint-solver, adj-lang-cli, adjudication-pipeline) + logic-engine green.

### Housekeeping
- Version: adj-lang 0.30.0 → 0.31.0; CHANGELOG updated.
- Security-reviewed inline — **PASSED** (the `≥ 2` guard makes the fold's first-operand `.expect` provably unreachable; siblings iterate so no new recursion/DoS vector; no injection — pure in-memory AST transform).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
