### PR TITLE
feat(adj-ladder): rung-43 compounded IV admixture total drug mass (sum of three products)

### DIFF
--- a/code/specs/data/adj-ladder/rung43_compounded_admixture/gen_items.py
+++ b/code/specs/data/adj-ladder/rung43_compounded_admixture/gen_items.py
@@ -1,0 +1,198 @@
+"""Generate rung-43 (compounded IV admixture total drug mass) items.json for the ADJ-LADDER.
+
+Rung 43 opens the **compounding pharmacy / IV admixture** panel on the quantitative band — the arithmetic of the
+total drug mass in a bag compounded from SEVERAL additives, each contributing (its volume x its concentration).
+This rung introduces a genuinely NEW arithmetic shape on the ladder: a **sum of THREE products** —
+`a*b + c*d + e*f`. It extends rung-34 (which summed TWO products) to three, so it is the natural generalisation of
+that shape rather than a repeat.
+
+The setup: three additives go into one bag. Each additive `i` contributes `volume_i * concentration_i` of drug.
+The total drug mass is the sum of the three per-additive amounts:
+
+  TOTAL MASS   volume_a*concentration_a + volume_b*concentration_b + volume_c*concentration_c   [ all three products summed ]
+  FIRST TWO    volume_a*concentration_a + volume_b*concentration_b                               [ the first two additives only ]
+  LAST TWO     volume_b*concentration_b + volume_c*concentration_c                               [ the last two additives only ]
+
+The **total mass** is what makes this rung distinctive — it is the ladder's first **sum of three products**: three
+`volume*concentration` products added together. Contrast the neighbours: rung-34 summed *two* products
+(`a*b + c*d`), rung-38/39/40 were flat three-term diff/sum/product of single terms; none summed three *products*.
+(The first-two and last-two partial sums ride alongside as the two-additive sub-totals, so the panel teaches the
+whole build-up — exactly as rung-34 shipped its two component products and rung-42 its component quantities beside
+the headline figure.)
+
+Each index is a `compute_dimensioned` program (`observe` the six quantities + `let answer = formula`); the ADJ
+engine carries the arithmetic — three `volume*concentration` products summed — and the harness reads the scalar via
+the existing `compute_dimensioned` extractor. No harness/engine change, exactly as rungs 8/16/.../41/42. This rung
+exercises the engine across a **sum of three products** (`(va*ca) + (vb*cb) + (vc*cc)`).
+
+Contamination-safe by construction: every formula is built ONLY from the six observed quantities via `*` and `+` —
+**no structural constants** — so no numeric literal appears in any program, and no per-additive amount or total
+ever appears as a literal (each is computed from the observed volumes and concentrations). The observed quantities
+carry **digit-free identifiers** (`volume_a`, `concentration_a`, `volume_b`, `concentration_b`, `volume_c`,
+`concentration_c`) so no numeral hides inside a variable name.
+
+The five options are a tight family over the same six quantities: the three real readouts plus the two classic
+slips —
+
+  CROSSED       volume_a*concentration_b + volume_b*concentration_c + volume_c*concentration_a   each volume paired
+                                                                                                 with the WRONG
+                                                                                                 additive's
+                                                                                                 concentration, and
+  ALL SUMMED    volume_a + concentration_a + volume_b + concentration_b + volume_c + concentration_c   every quantity
+                                                                                                 added, ignoring the
+                                                                                                 products,
+
+which are exactly the mistakes a student makes (mismatching volume with concentration, or adding raw quantities
+instead of forming each additive's product first). Gold rotates A-E by index. QUERIED (used as gold) = the three
+real readouts; all five always appear as options.
+
+Distinctness: all six observed quantities are positive, so every product and sum is positive; the tables below are
+chosen so the five family values are pairwise distinct with a comfortable margin, asserted at build time.
+"""
+import json
+
+LETTERS = ["A", "B", "C", "D", "E"]
+
+# (VOLUME_A, CONCENTRATION_A, VOLUME_B, CONCENTRATION_B, VOLUME_C, CONCENTRATION_C) — volumes in mL, concentrations
+# in mg/mL, all strictly positive. The five family values are asserted pairwise-distinct (with margin) below.
+TABLES = [
+    (2, 10, 3, 20, 1, 30),
+    (4, 5, 2, 15, 3, 10),
+    (1, 40, 2, 20, 5, 4),
+    (3, 10, 1, 50, 2, 25),
+    (2, 25, 4, 10, 1, 60),
+    (5, 4, 3, 20, 2, 15),
+    (2, 30, 1, 40, 3, 10),
+]
+
+# The option family (5 members), all built from the six observed quantities via * and +. Every identifier is
+# DIGIT-FREE. key -> (display name, formula-as-adj). Only the first three are *queried* (used as gold); all five
+# always appear as the options.
+FAMILY = [
+    (
+        "total_mass",
+        "total drug mass in the bag (all three additive amounts summed)",
+        "volume_a * concentration_a + volume_b * concentration_b + volume_c * concentration_c",
+    ),
+    (
+        "first_two",
+        "combined mass of the first two additives only",
+        "volume_a * concentration_a + volume_b * concentration_b",
+    ),
+    (
+        "last_two",
+        "combined mass of the last two additives only",
+        "volume_b * concentration_b + volume_c * concentration_c",
+    ),
+    (
+        "crossed",
+        "each volume multiplied by the WRONG additive's concentration (a mismatched pairing)",
+        "volume_a * concentration_b + volume_b * concentration_c + volume_c * concentration_a",
+    ),
+    (
+        "all_summed",
+        "every quantity added together, ignoring the volume-times-concentration products",
+        "volume_a + concentration_a + volume_b + concentration_b + volume_c + concentration_c",
+    ),
+]
+QUERIED = ["total_mass", "first_two", "last_two"]
+ORDER = [k for k, _, _ in FAMILY]
+
+
+def scalar(v):
+    return {"value": v, "unit": "scalar"}
+
+
+def family_values(va, ca, vb, cb, vc, cc):
+    # Operation order mirrors the ADJ programs exactly (products bind tighter than +, left-folded sums), so the
+    # Python option value and the engine result are the same IEEE-double (within the harness's 1e-9 tolerance).
+    return {
+        "total_mass": va * ca + vb * cb + vc * cc,
+        "first_two": va * ca + vb * cb,
+        "last_two": vb * cb + vc * cc,
+        "crossed": va * cb + vb * cc + vc * ca,
+        "all_summed": va + ca + vb + cb + vc + cc,
+    }
+
+
+def build():
+    name_of = {k: nm for k, nm, _ in FAMILY}
+    formula_of = {k: f for k, _, f in FAMILY}
+    items = []
+    idx = 0
+
+    def num(x):
+        return int(x) if float(x).is_integer() else x
+
+    for va, ca, vb, cb, vc, cc in TABLES:
+        assert all(q > 0 for q in (va, ca, vb, cb, vc, cc)), (va, ca, vb, cb, vc, cc)
+        fv = family_values(va, ca, vb, cb, vc, cc)
+        # Pairwise-distinct with a comfortable margin so the harness never sees two options
+        # matching the gold value within its 1e-9 tolerance.
+        vals = [fv[key] for key in ORDER]
+        for i in range(len(vals)):
+            for j in range(i + 1, len(vals)):
+                assert abs(vals[i] - vals[j]) > 1e-6, (va, ca, vb, cb, vc, cc, ORDER[i], ORDER[j], fv)
+        for key in QUERIED:
+            gold_val = fv[key]
+            gold_pos = idx % 5
+            others = [fv[k2] for k2 in ORDER if abs(fv[k2] - gold_val) > 1e-12]
+            opts_vals = others[:]
+            opts_vals.insert(gold_pos, gold_val)
+            opts_vals = opts_vals[:5]
+            if abs(opts_vals[gold_pos] - gold_val) > 1e-12:
+                opts_vals[gold_pos] = gold_val
+            assert len({round(v, 9) for v in opts_vals}) == 5, (key, va, ca, vb, cb, vc, cc, opts_vals)
+            options = {LETTERS[i]: scalar(opts_vals[i]) for i in range(5)}
+            items.append({
+                "id": f"r43mix-{idx + 1:02d}",
+                "qtype": "compounded_admixture",
+                "stem": (
+                    f"An IV bag is compounded from three additives: {num(va)} mL of a {num(ca)} mg/mL drug, "
+                    f"{num(vb)} mL of a {num(cb)} mg/mL drug, and {num(vc)} mL of a {num(cc)} mg/mL drug. "
+                    f"What is the {name_of[key]}?"
+                ),
+                "program": (
+                    f"observe volume_a({num(va)})\n"
+                    f"observe concentration_a({num(ca)})\n"
+                    f"observe volume_b({num(vb)})\n"
+                    f"observe concentration_b({num(cb)})\n"
+                    f"observe volume_c({num(vc)})\n"
+                    f"observe concentration_c({num(cc)})\n"
+                    f"let answer = {formula_of[key]}\n"
+                    "? answer\n"
+                ),
+                "answer_from": {"type": "compute_dimensioned", "name": "answer"},
+                "options": options,
+                "gold_letter": LETTERS[gold_pos],
+            })
+            idx += 1
+    return {
+        "description": (
+            "ADJ-LADDER rung 43 — compounded IV admixture total drug mass from six stated quantities (a NEW panel: "
+            "compounding pharmacy / IV admixture). Three additives each contribute volume*concentration of drug; "
+            "compute the total mass (va*ca + vb*cb + vc*cc), the first-two subtotal (va*ca + vb*cb), or the last-two "
+            "subtotal (vb*cb + vc*cc). Each item is a compute_dimensioned program (observe the six quantities, let "
+            "answer = formula); the ADJ engine carries the arithmetic — a NEW shape, a SUM OF THREE PRODUCTS "
+            "(va*ca + vb*cb + vc*cc), extending rung-34's sum-of-two-products to three — and the harness matches the "
+            "scalar to the printed options. Contamination-safe: every index is built only from the six observed "
+            "quantities via * and + — no constant leaks, and no per-additive amount or total ever appears as a "
+            "literal (each is computed) — and the observed quantities carry digit-free identifiers so no numeral "
+            "hides inside a variable name. The five options are a family over the same six quantities, so the "
+            "distractors are exactly the slips students make: pairing each volume with the WRONG additive's "
+            "concentration, and adding every raw quantity instead of forming each product first. The core confusion "
+            "tested is summing the three volume-times-concentration products."
+        ),
+        "items": items,
+    }
+
+
+if __name__ == "__main__":
+    doc = build()
+    with open("items.json", "w") as f:
+        json.dump(doc, f, indent=2)
+        f.write("\n")
+    print("wrote items.json:", len(doc["items"]), "items")
+    for it in doc["items"]:
+        print(it["id"], it["qtype"], "gold", it["gold_letter"],
+              "=", round(it["options"][it["gold_letter"]]["value"], 6))

--- a/code/specs/data/adj-ladder/rung43_compounded_admixture/items.json
+++ b/code/specs/data/adj-ladder/rung43_compounded_admixture/items.json
@@ -1,0 +1,698 @@
+{
+  "description": "ADJ-LADDER rung 43 \u2014 compounded IV admixture total drug mass from six stated quantities (a NEW panel: compounding pharmacy / IV admixture). Three additives each contribute volume*concentration of drug; compute the total mass (va*ca + vb*cb + vc*cc), the first-two subtotal (va*ca + vb*cb), or the last-two subtotal (vb*cb + vc*cc). Each item is a compute_dimensioned program (observe the six quantities, let answer = formula); the ADJ engine carries the arithmetic \u2014 a NEW shape, a SUM OF THREE PRODUCTS (va*ca + vb*cb + vc*cc), extending rung-34's sum-of-two-products to three \u2014 and the harness matches the scalar to the printed options. Contamination-safe: every index is built only from the six observed quantities via * and + \u2014 no constant leaks, and no per-additive amount or total ever appears as a literal (each is computed) \u2014 and the observed quantities carry digit-free identifiers so no numeral hides inside a variable name. The five options are a family over the same six quantities, so the distractors are exactly the slips students make: pairing each volume with the WRONG additive's concentration, and adding every raw quantity instead of forming each product first. The core confusion tested is summing the three volume-times-concentration products.",
+  "items": [
+    {
+      "id": "r43mix-01",
+      "qtype": "compounded_admixture",
+      "stem": "An IV bag is compounded from three additives: 2 mL of a 10 mg/mL drug, 3 mL of a 20 mg/mL drug, and 1 mL of a 30 mg/mL drug. What is the total drug mass in the bag (all three additive amounts summed)?",
+      "program": "observe volume_a(2)\nobserve concentration_a(10)\nobserve volume_b(3)\nobserve concentration_b(20)\nobserve volume_c(1)\nobserve concentration_c(30)\nlet answer = volume_a * concentration_a + volume_b * concentration_b + volume_c * concentration_c\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 110,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 80,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 90,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 140,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 66,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r43mix-02",
+      "qtype": "compounded_admixture",
+      "stem": "An IV bag is compounded from three additives: 2 mL of a 10 mg/mL drug, 3 mL of a 20 mg/mL drug, and 1 mL of a 30 mg/mL drug. What is the combined mass of the first two additives only?",
+      "program": "observe volume_a(2)\nobserve concentration_a(10)\nobserve volume_b(3)\nobserve concentration_b(20)\nobserve volume_c(1)\nobserve concentration_c(30)\nlet answer = volume_a * concentration_a + volume_b * concentration_b\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 110,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 80,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 90,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 140,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 66,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r43mix-03",
+      "qtype": "compounded_admixture",
+      "stem": "An IV bag is compounded from three additives: 2 mL of a 10 mg/mL drug, 3 mL of a 20 mg/mL drug, and 1 mL of a 30 mg/mL drug. What is the combined mass of the last two additives only?",
+      "program": "observe volume_a(2)\nobserve concentration_a(10)\nobserve volume_b(3)\nobserve concentration_b(20)\nobserve volume_c(1)\nobserve concentration_c(30)\nlet answer = volume_b * concentration_b + volume_c * concentration_c\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 110,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 80,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 90,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 140,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 66,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r43mix-04",
+      "qtype": "compounded_admixture",
+      "stem": "An IV bag is compounded from three additives: 4 mL of a 5 mg/mL drug, 2 mL of a 15 mg/mL drug, and 3 mL of a 10 mg/mL drug. What is the total drug mass in the bag (all three additive amounts summed)?",
+      "program": "observe volume_a(4)\nobserve concentration_a(5)\nobserve volume_b(2)\nobserve concentration_b(15)\nobserve volume_c(3)\nobserve concentration_c(10)\nlet answer = volume_a * concentration_a + volume_b * concentration_b + volume_c * concentration_c\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 50,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 60,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 95,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 80,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 39,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r43mix-05",
+      "qtype": "compounded_admixture",
+      "stem": "An IV bag is compounded from three additives: 4 mL of a 5 mg/mL drug, 2 mL of a 15 mg/mL drug, and 3 mL of a 10 mg/mL drug. What is the combined mass of the first two additives only?",
+      "program": "observe volume_a(4)\nobserve concentration_a(5)\nobserve volume_b(2)\nobserve concentration_b(15)\nobserve volume_c(3)\nobserve concentration_c(10)\nlet answer = volume_a * concentration_a + volume_b * concentration_b\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 80,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 60,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 95,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 39,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 50,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r43mix-06",
+      "qtype": "compounded_admixture",
+      "stem": "An IV bag is compounded from three additives: 4 mL of a 5 mg/mL drug, 2 mL of a 15 mg/mL drug, and 3 mL of a 10 mg/mL drug. What is the combined mass of the last two additives only?",
+      "program": "observe volume_a(4)\nobserve concentration_a(5)\nobserve volume_b(2)\nobserve concentration_b(15)\nobserve volume_c(3)\nobserve concentration_c(10)\nlet answer = volume_b * concentration_b + volume_c * concentration_c\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 60,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 80,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 50,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 95,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 39,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r43mix-07",
+      "qtype": "compounded_admixture",
+      "stem": "An IV bag is compounded from three additives: 1 mL of a 40 mg/mL drug, 2 mL of a 20 mg/mL drug, and 5 mL of a 4 mg/mL drug. What is the total drug mass in the bag (all three additive amounts summed)?",
+      "program": "observe volume_a(1)\nobserve concentration_a(40)\nobserve volume_b(2)\nobserve concentration_b(20)\nobserve volume_c(5)\nobserve concentration_c(4)\nlet answer = volume_a * concentration_a + volume_b * concentration_b + volume_c * concentration_c\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 80,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 100,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 60,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 228,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 72,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r43mix-08",
+      "qtype": "compounded_admixture",
+      "stem": "An IV bag is compounded from three additives: 1 mL of a 40 mg/mL drug, 2 mL of a 20 mg/mL drug, and 5 mL of a 4 mg/mL drug. What is the combined mass of the first two additives only?",
+      "program": "observe volume_a(1)\nobserve concentration_a(40)\nobserve volume_b(2)\nobserve concentration_b(20)\nobserve volume_c(5)\nobserve concentration_c(4)\nlet answer = volume_a * concentration_a + volume_b * concentration_b\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 100,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 60,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 80,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 228,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 72,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r43mix-09",
+      "qtype": "compounded_admixture",
+      "stem": "An IV bag is compounded from three additives: 1 mL of a 40 mg/mL drug, 2 mL of a 20 mg/mL drug, and 5 mL of a 4 mg/mL drug. What is the combined mass of the last two additives only?",
+      "program": "observe volume_a(1)\nobserve concentration_a(40)\nobserve volume_b(2)\nobserve concentration_b(20)\nobserve volume_c(5)\nobserve concentration_c(4)\nlet answer = volume_b * concentration_b + volume_c * concentration_c\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 100,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 80,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 228,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 60,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 72,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r43mix-10",
+      "qtype": "compounded_admixture",
+      "stem": "An IV bag is compounded from three additives: 3 mL of a 10 mg/mL drug, 1 mL of a 50 mg/mL drug, and 2 mL of a 25 mg/mL drug. What is the total drug mass in the bag (all three additive amounts summed)?",
+      "program": "observe volume_a(3)\nobserve concentration_a(10)\nobserve volume_b(1)\nobserve concentration_b(50)\nobserve volume_c(2)\nobserve concentration_c(25)\nlet answer = volume_a * concentration_a + volume_b * concentration_b + volume_c * concentration_c\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 80,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 100,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 195,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 91,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 130,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r43mix-11",
+      "qtype": "compounded_admixture",
+      "stem": "An IV bag is compounded from three additives: 3 mL of a 10 mg/mL drug, 1 mL of a 50 mg/mL drug, and 2 mL of a 25 mg/mL drug. What is the combined mass of the first two additives only?",
+      "program": "observe volume_a(3)\nobserve concentration_a(10)\nobserve volume_b(1)\nobserve concentration_b(50)\nobserve volume_c(2)\nobserve concentration_c(25)\nlet answer = volume_a * concentration_a + volume_b * concentration_b\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 80,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 130,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 100,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 195,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 91,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r43mix-12",
+      "qtype": "compounded_admixture",
+      "stem": "An IV bag is compounded from three additives: 3 mL of a 10 mg/mL drug, 1 mL of a 50 mg/mL drug, and 2 mL of a 25 mg/mL drug. What is the combined mass of the last two additives only?",
+      "program": "observe volume_a(3)\nobserve concentration_a(10)\nobserve volume_b(1)\nobserve concentration_b(50)\nobserve volume_c(2)\nobserve concentration_c(25)\nlet answer = volume_b * concentration_b + volume_c * concentration_c\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 130,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 100,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 80,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 195,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 91,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r43mix-13",
+      "qtype": "compounded_admixture",
+      "stem": "An IV bag is compounded from three additives: 2 mL of a 25 mg/mL drug, 4 mL of a 10 mg/mL drug, and 1 mL of a 60 mg/mL drug. What is the total drug mass in the bag (all three additive amounts summed)?",
+      "program": "observe volume_a(2)\nobserve concentration_a(25)\nobserve volume_b(4)\nobserve concentration_b(10)\nobserve volume_c(1)\nobserve concentration_c(60)\nlet answer = volume_a * concentration_a + volume_b * concentration_b + volume_c * concentration_c\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 90,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 100,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 150,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 285,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 102,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r43mix-14",
+      "qtype": "compounded_admixture",
+      "stem": "An IV bag is compounded from three additives: 2 mL of a 25 mg/mL drug, 4 mL of a 10 mg/mL drug, and 1 mL of a 60 mg/mL drug. What is the combined mass of the first two additives only?",
+      "program": "observe volume_a(2)\nobserve concentration_a(25)\nobserve volume_b(4)\nobserve concentration_b(10)\nobserve volume_c(1)\nobserve concentration_c(60)\nlet answer = volume_a * concentration_a + volume_b * concentration_b\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 150,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 100,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 285,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 90,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 102,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r43mix-15",
+      "qtype": "compounded_admixture",
+      "stem": "An IV bag is compounded from three additives: 2 mL of a 25 mg/mL drug, 4 mL of a 10 mg/mL drug, and 1 mL of a 60 mg/mL drug. What is the combined mass of the last two additives only?",
+      "program": "observe volume_a(2)\nobserve concentration_a(25)\nobserve volume_b(4)\nobserve concentration_b(10)\nobserve volume_c(1)\nobserve concentration_c(60)\nlet answer = volume_b * concentration_b + volume_c * concentration_c\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 150,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 90,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 285,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 102,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 100,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r43mix-16",
+      "qtype": "compounded_admixture",
+      "stem": "An IV bag is compounded from three additives: 5 mL of a 4 mg/mL drug, 3 mL of a 20 mg/mL drug, and 2 mL of a 15 mg/mL drug. What is the total drug mass in the bag (all three additive amounts summed)?",
+      "program": "observe volume_a(5)\nobserve concentration_a(4)\nobserve volume_b(3)\nobserve concentration_b(20)\nobserve volume_c(2)\nobserve concentration_c(15)\nlet answer = volume_a * concentration_a + volume_b * concentration_b + volume_c * concentration_c\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 110,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 80,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 90,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 153,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 49,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r43mix-17",
+      "qtype": "compounded_admixture",
+      "stem": "An IV bag is compounded from three additives: 5 mL of a 4 mg/mL drug, 3 mL of a 20 mg/mL drug, and 2 mL of a 15 mg/mL drug. What is the combined mass of the first two additives only?",
+      "program": "observe volume_a(5)\nobserve concentration_a(4)\nobserve volume_b(3)\nobserve concentration_b(20)\nobserve volume_c(2)\nobserve concentration_c(15)\nlet answer = volume_a * concentration_a + volume_b * concentration_b\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 110,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 80,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 90,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 153,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 49,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r43mix-18",
+      "qtype": "compounded_admixture",
+      "stem": "An IV bag is compounded from three additives: 5 mL of a 4 mg/mL drug, 3 mL of a 20 mg/mL drug, and 2 mL of a 15 mg/mL drug. What is the combined mass of the last two additives only?",
+      "program": "observe volume_a(5)\nobserve concentration_a(4)\nobserve volume_b(3)\nobserve concentration_b(20)\nobserve volume_c(2)\nobserve concentration_c(15)\nlet answer = volume_b * concentration_b + volume_c * concentration_c\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 110,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 80,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 90,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 153,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 49,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r43mix-19",
+      "qtype": "compounded_admixture",
+      "stem": "An IV bag is compounded from three additives: 2 mL of a 30 mg/mL drug, 1 mL of a 40 mg/mL drug, and 3 mL of a 10 mg/mL drug. What is the total drug mass in the bag (all three additive amounts summed)?",
+      "program": "observe volume_a(2)\nobserve concentration_a(30)\nobserve volume_b(1)\nobserve concentration_b(40)\nobserve volume_c(3)\nobserve concentration_c(10)\nlet answer = volume_a * concentration_a + volume_b * concentration_b + volume_c * concentration_c\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 100,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 70,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 180,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 130,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 86,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r43mix-20",
+      "qtype": "compounded_admixture",
+      "stem": "An IV bag is compounded from three additives: 2 mL of a 30 mg/mL drug, 1 mL of a 40 mg/mL drug, and 3 mL of a 10 mg/mL drug. What is the combined mass of the first two additives only?",
+      "program": "observe volume_a(2)\nobserve concentration_a(30)\nobserve volume_b(1)\nobserve concentration_b(40)\nobserve volume_c(3)\nobserve concentration_c(10)\nlet answer = volume_a * concentration_a + volume_b * concentration_b\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 130,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 70,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 180,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 86,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 100,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r43mix-21",
+      "qtype": "compounded_admixture",
+      "stem": "An IV bag is compounded from three additives: 2 mL of a 30 mg/mL drug, 1 mL of a 40 mg/mL drug, and 3 mL of a 10 mg/mL drug. What is the combined mass of the last two additives only?",
+      "program": "observe volume_a(2)\nobserve concentration_a(30)\nobserve volume_b(1)\nobserve concentration_b(40)\nobserve volume_c(3)\nobserve concentration_c(10)\nlet answer = volume_b * concentration_b + volume_c * concentration_c\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 70,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 130,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 100,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 180,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 86,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    }
+  ]
+}

--- a/code/specs/data/adj-ladder/test_ladder_eval.py
+++ b/code/specs/data/adj-ladder/test_ladder_eval.py
@@ -80,6 +80,7 @@ SELF_CONTAINED_RUNGS = (
     "rung40_lesion_volume",
     "rung41_split_renal_function",
     "rung42_hemofiltration_concentration",
+    "rung43_compounded_admixture",
 )
 
 


### PR DESCRIPTION
## ADJ-LADDER rung 43 — compounded IV admixture total drug mass (sum of three products)

Adds the next ADJ-LADDER rung. Opens a **NEW panel** (compounding pharmacy / IV admixture) and introduces a genuinely **NEW arithmetic shape**: a **sum of THREE products** — `volume_a*concentration_a + volume_b*concentration_b + volume_c*concentration_c`. It extends rung-34 (sum of **two** products) to three — the natural generalisation, not a repeat.

### Clinical setup
Three additives go into one bag; each contributes `volume*concentration` of drug; the **total drug mass** is the three per-additive amounts summed. The **first-two** and **last-two** partial sums ride alongside as the two-additive subtotals (as rung-34 shipped its two component products and rung-42 its component quantities beside the headline figure).

### Mechanics (unchanged from the rung pattern)
Each index is a `compute_dimensioned` program (`observe` the six quantities, `let answer = formula`, `? answer`); the ADJ engine carries the arithmetic — three `volume*concentration` products summed — and the harness reads the scalar via the existing `compute_dimensioned` extractor. **No harness/engine change**, exactly as rungs 8/16/…/41/42.

### Contamination-safe by construction
- Every formula is built **only** from the six observed quantities via `*` and `+` — **no structural constants** — so no numeric literal appears in any program.
- No per-additive amount or total is ever a literal (each is computed).
- Observed quantities carry **digit-free identifiers** (`volume_a`, `concentration_a`, `volume_b`, `concentration_b`, `volume_c`, `concentration_c`).

### Family of 5 mutually-confusable options
`total_mass` (the new sum-of-three-products), `first_two`, `last_two`, plus two classic slips — `crossed` (each volume × the **wrong** additive's concentration) and `all_summed` (every raw quantity added, ignoring the products). First 3 queried as gold; all 5 always appear. Gold rotates A–E. **7 tables × 3 = 21 items**, five family values asserted **pairwise-distinct with margin** at build time.

### Gate
Registers `rung43_compounded_admixture` in `SELF_CONTAINED_RUNGS`. Gated **3/3** (engine selects every gold, 0 wrong / 0 abstain; contamination clean; `items.json` valid). Security-reviewed inline — **PASSED**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
