### PR TITLE
feat(cloc): CLOC12.152 — bridge concise-body arrow functions (gap-155)

### DIFF
--- a/code/packages/rust/javascript-parser/CHANGELOG.md
+++ b/code/packages/rust/javascript-parser/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable changes to the `coding-adventures-javascript-parser` crate will be documented in this file.
 
+## [0.21.0] - 2026-07-02
+
+### Added — CLOC12.152 / gap-155: bridge `arrow_function` → `Expression::ArrowFunctionExpression`
+
+The typed-AST bridge now converts **concise-body arrow functions** (`x => x + 1`,
+`(a, b) => a + b`, `() => 1`, `arr.map(x => x)`) instead of declining them as
+`UnsupportedSyntax`. `convert_arrow_function` reads `arrow_parameters`
+(`NAME` → one identifier param; `( formal_parameters )` → the list; `()` → none)
+and the `concise_body`'s expression, producing an `ArrowFunctionExpression` with
+an `ArrowBody::Expression`. This unblocks the full SIMPLE pipeline *inside* arrow
+bodies end-to-end (e.g. `var f = x => 1 + 2` → `var f = x => 3`) rather than
+falling back to WHITESPACE_ONLY.
+
+Two deliberate conservative guards, both to avoid a **miscompile** given current
+grammar limitations (see `CLOC12-gaps.md`):
+
+- **Block-bodied arrows aren't reachable (gap-156).** The ECMAScript grammar
+  currently rejects a statement block body — `x => { return x; }` fails to parse
+  — so the bridge only ever sees a concise `concise_body`. The `ArrowBody::Block`
+  path is written and ready for when the grammar is fixed.
+- **`() => {}` / object-body arrows DECLINE.** Because the block alternative
+  isn't taken, the grammar reads the braces of `() => {}` as an empty *object
+  literal* concise body — indistinguishable from a genuine `() => ({})`. Since we
+  cannot tell an empty-block arrow (returns `undefined`) from an object-returning
+  one, the bridge declines any arrow whose concise body is an `ObjectExpression`,
+  falling back to whitespace-only (which re-emits the source unchanged — always
+  correct). Only an optimisation is forgone, never correctness.
+
+Async arrows (`async x => x`) parse under the separate `async_arrow_function`
+rule and remain declined for now. 5 new bridge tests; a closurec e2e diff
+fixture (`tests/diff/simple-arrow-function/`) proves the fold-inside-body win.
+
 ## [0.20.0] - 2026-07-01
 
 ### Added — CLOC12.149 / gap-153: bridge `function_expression` → `Expression::FunctionExpression`

--- a/code/packages/rust/javascript-parser/Cargo.toml
+++ b/code/packages/rust/javascript-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-javascript-parser"
-version = "0.20.0"
+version = "0.21.0"
 edition = "2021"
 description = "JavaScript parser — parses JavaScript source code against any ECMAScript edition (es1 through es2025) using the grammar-driven parser. Includes correlation-vector plumbing per CLOC03 and a typed-AST bridge (GrammarASTNode → javascript_ast::Program) per CLOC12.136."
 

--- a/code/packages/rust/javascript-parser/src/bridge.rs
+++ b/code/packages/rust/javascript-parser/src/bridge.rs
@@ -53,7 +53,8 @@ use coding_adventures_javascript_ast::{
         VariableDeclaration, VariableDeclarator,
     },
     expression::{
-        ArrayExpression, AssignmentExpression, AssignmentOperator, AssignmentTarget,
+        ArrayExpression, ArrowBody, ArrowFunctionExpression, AssignmentExpression,
+        AssignmentOperator, AssignmentTarget,
         BigIntLiteral, BinaryExpression, BinaryOperator, BooleanLiteral, CallExpression,
         ConditionalExpression, Expression, FunctionExpression, Identifier, LogicalExpression,
         LogicalOperator,
@@ -999,6 +1000,119 @@ fn convert_function_expression(node: &GrammarASTNode) -> Result<FunctionExpressi
     })
 }
 
+// ---------------------------------------------------------------------
+// ArrowFunctionExpression (CLOC12.152 — bridge enable)
+// ---------------------------------------------------------------------
+
+/// Convert an `arrow_function` grammar node into an
+/// [`ArrowFunctionExpression`].
+///
+/// ```text
+///   arrow_function   = arrow_parameters ARROW concise_body ;
+///   arrow_parameters = NAME | LPAREN [ formal_parameters ] RPAREN ;
+///   concise_body     = assignment_expression | LBRACE function_body RBRACE ;
+/// ```
+///
+/// # Two grammar limitations this bridge works around
+///
+/// 1. **Block bodies don't parse (gap-156).** The current ECMAScript
+///    grammar rejects a *statement* block body — `x => { return x; }`
+///    fails to parse outright — so the parser only ever produces a
+///    **concise** (expression) `concise_body`. This converter therefore
+///    always yields [`ArrowBody::Expression`]; the emitter and passes
+///    already model [`ArrowBody::Block`] for when the grammar is fixed.
+/// 2. **`() => {}` mis-parses as an empty-*object* concise body.** Because
+///    the block alternative isn't taken, the grammar reads the braces of
+///    `() => {}` as an empty **object literal** returned by a concise body
+///    (`() => ({})`), which is a *different value* than the real
+///    empty-block arrow (which returns `undefined`). We cannot tell the
+///    two apart from the parse tree — the distinguishing information was
+///    already lost — so to avoid a **miscompile** we DECLINE any arrow
+///    whose concise body is an object literal (falling back to
+///    whitespace-only, which re-emits the source unchanged and is always
+///    correct). Genuine object-returning arrows (`x => ({a:1})`) decline
+///    too; that only forgoes an optimisation, never correctness.
+///
+/// Async arrows (`async x => x`) parse under the separate
+/// `async_arrow_function` rule and remain declined for now — a follow-up
+/// once the async evaluation model lands.
+fn convert_arrow_function(node: &GrammarASTNode) -> Result<ArrowFunctionExpression, BridgeError> {
+    let children = node_children(node);
+
+    let mut params = Vec::new();
+    let mut body: Option<ArrowBody> = None;
+
+    for n in &children {
+        match n.rule_name.as_str() {
+            "arrow_parameters" => params = convert_arrow_parameters(n)?,
+            "concise_body" => body = Some(convert_concise_body(n)?),
+            _ => {}
+        }
+    }
+
+    let body = body.ok_or_else(|| internal(node, "arrow_function: missing concise_body"))?;
+
+    // Guard against the `() => {}` ambiguity described above: an
+    // object-literal concise body cannot be distinguished from an empty
+    // block body, so decline rather than risk a miscompile.
+    if let ArrowBody::Expression(e) = &body {
+        if matches!(**e, Expression::ObjectExpression(_)) {
+            return Err(unsupported(node));
+        }
+    }
+
+    Ok(ArrowFunctionExpression {
+        cv: None,
+        params,
+        body,
+        is_async: false,
+    })
+}
+
+/// `arrow_parameters = NAME | LPAREN [ formal_parameters ] RPAREN`.
+///
+/// A parenthesised list wraps a `formal_parameters` node; a single bare
+/// identifier is just a `NAME` token (no wrapper); `()` has neither.
+fn convert_arrow_parameters(node: &GrammarASTNode) -> Result<Vec<FunctionParam>, BridgeError> {
+    for c in &node.children {
+        if let ASTNodeOrToken::Node(n) = c {
+            if n.rule_name == "formal_parameters" {
+                return convert_formal_parameters(n);
+            }
+        }
+    }
+    // No `formal_parameters` node → either `()` (no NAME tokens) or a bare
+    // single `NAME` identifier. Any token that is not a paren is that name.
+    let params = node
+        .children
+        .iter()
+        .filter_map(|c| match c {
+            ASTNodeOrToken::Token(t) if t.value != "(" && t.value != ")" => {
+                Some(FunctionParam::Identifier(Identifier { cv: None, name: t.value.clone() }))
+            }
+            _ => None,
+        })
+        .collect();
+    Ok(params)
+}
+
+/// `concise_body = assignment_expression | LBRACE function_body RBRACE`.
+///
+/// In practice only the expression alternative is reachable today (see the
+/// gap-156 note on [`convert_arrow_function`]); the `function_body` arm is
+/// kept so the bridge is already correct once the grammar parses block
+/// bodies.
+fn convert_concise_body(node: &GrammarASTNode) -> Result<ArrowBody, BridgeError> {
+    for n in node_children(node) {
+        if n.rule_name == "function_body" {
+            return Ok(ArrowBody::Block(convert_function_body(n)?));
+        }
+        return Ok(ArrowBody::Expression(Box::new(convert_expression(n)?)));
+    }
+    // Only brace tokens, no inner node → an empty block body `() => {}`.
+    Ok(ArrowBody::Block(BlockStatement { cv: None, body: vec![] }))
+}
+
 fn convert_formal_parameters(node: &GrammarASTNode) -> Result<Vec<FunctionParam>, BridgeError> {
     // formal_parameters = formal_parameter { COMMA formal_parameter } [ COMMA ]
     // formal_parameter = ( NAME | binding_pattern ) [ EQUALS assignment_expression ]
@@ -1121,14 +1235,20 @@ fn convert_expression(node: &GrammarASTNode) -> Result<Expression, BridgeError> 
             convert_function_expression(node).map(Expression::FunctionExpression)
         }
 
+        // Concise-body arrow function (CLOC12.152). `convert_arrow_function`
+        // itself declines the ambiguous `() => {}` / object-body case and
+        // (until the grammar parses them) never sees a block body.
+        "arrow_function" => {
+            convert_arrow_function(node).map(Expression::ArrowFunctionExpression)
+        }
+
         // The remaining function-valued and ES2015+ expression forms the
         // typed bridge does not yet represent. DECLINE GRACEFULLY
         // (`UnsupportedSyntax` → the CLI falls back to WHITESPACE_ONLY and
         // still emits valid JS). Generators/async carry evaluation semantics
-        // the passes don't model yet; arrow functions, classes, and template
+        // the passes don't model yet; async arrows, classes, and template
         // literals are separate future AST slices.
-        "arrow_function"
-        | "async_arrow_function"
+        "async_arrow_function"
         | "yield_expression"
         | "await_expression"
         | "generator_expression"
@@ -2971,6 +3091,96 @@ mod tests {
             },
             other => panic!("expected an ExpressionStatement, got {other:?}"),
         }
+    }
+
+    // ---- ArrowFunctionExpression (CLOC12.152 bridge enable) ------
+
+    /// Pull the arrow-function initialiser out of `var f = <arrow>;`.
+    fn bridge_var_init_arrow(src: &str) -> ArrowFunctionExpression {
+        let p = bridge_ok(src);
+        match &p.body[0] {
+            ProgramItem::Statement(Statement::Declaration(Declaration::VariableDeclaration(vd))) => {
+                match vd.declarations[0].init.as_ref().expect("init") {
+                    Expression::ArrowFunctionExpression(a) => a.clone(),
+                    other => panic!("expected ArrowFunctionExpression init, got {other:?}"),
+                }
+            }
+            other => panic!("expected a VariableDeclaration statement, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn arrow_single_param_concise_body_converts() {
+        // `var f = x => x + 1` — one param `x`, a concise (expression) body.
+        let a = bridge_var_init_arrow("var f=x=>x+1;");
+        assert!(!a.is_async);
+        assert_eq!(a.params.len(), 1);
+        let FunctionParam::Identifier(p) = &a.params[0];
+        assert_eq!(p.name, "x");
+        assert!(
+            matches!(a.body, ArrowBody::Expression(_)),
+            "concise body must be ArrowBody::Expression, got {:?}",
+            a.body
+        );
+    }
+
+    #[test]
+    fn arrow_multi_param_and_empty_param_convert() {
+        let a = bridge_var_init_arrow("var g=(a,b)=>a;");
+        assert_eq!(a.params.len(), 2);
+        let empty = bridge_var_init_arrow("var h=()=>1;");
+        assert!(empty.params.is_empty(), "`()` yields zero params");
+        assert!(matches!(empty.body, ArrowBody::Expression(_)));
+    }
+
+    #[test]
+    fn arrow_callback_argument_converts() {
+        // `arr.map(x => x)` — the callback arg is an ArrowFunctionExpression.
+        let p = bridge_ok("arr.map(x=>x);");
+        match &p.body[0] {
+            ProgramItem::Statement(Statement::Tagged(
+                coding_adventures_javascript_ast::statement::TaggedStatement::ExpressionStatement(es),
+            )) => match &es.expression {
+                Expression::CallExpression(call) => assert!(
+                    matches!(&call.arguments[0], Expression::ArrowFunctionExpression(_)),
+                    "callback arg should be an arrow, got {:?}",
+                    call.arguments[0]
+                ),
+                other => panic!("expected CallExpression, got {other:?}"),
+            },
+            other => panic!("expected ExpressionStatement, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn arrow_object_concise_body_is_declined() {
+        // `() => ({})` / `() => {}` are indistinguishable in the current
+        // grammar (both parse as an object-literal concise body), so the
+        // bridge DECLINES them (UnsupportedSyntax) rather than risk the
+        // empty-block-vs-object miscompile. A declined program surfaces as a
+        // bridge error → the CLI's whitespace-only passthrough.
+        assert!(
+            grammar_to_program(
+                &crate::parse_javascript("var f=()=>({a:1});", "es2025").expect("parse"),
+                DEFAULT_ES_VERSION,
+            )
+            .is_err(),
+            "object-body arrow must decline to avoid the () => {{}} ambiguity"
+        );
+    }
+
+    #[test]
+    fn async_arrow_is_still_declined() {
+        // Async arrows parse under `async_arrow_function` and remain declined
+        // (safe whitespace-only passthrough) until the async model lands.
+        assert!(
+            grammar_to_program(
+                &crate::parse_javascript("var f=async x=>x;", "es2025").expect("parse"),
+                DEFAULT_ES_VERSION,
+            )
+            .is_err(),
+            "async arrow should still decline"
+        );
     }
 
     /// Pull the single `ForOfStatement` out of a one-statement program.

--- a/code/programs/rust/closurec/tests/diff/simple-arrow-function/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-arrow-function/expected.stdout
@@ -1,0 +1,1 @@
+var factory=n=>3;var scaled=(a,b)=>a+12;arr.map(x=>x+4);

--- a/code/programs/rust/closurec/tests/diff/simple-arrow-function/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/simple-arrow-function/flags.txt
@@ -1,0 +1,4 @@
+--js
+tests/diff/simple-arrow-function/input/a.js
+--compilation_level
+SIMPLE

--- a/code/programs/rust/closurec/tests/diff/simple-arrow-function/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-arrow-function/input/a.js
@@ -1,0 +1,8 @@
+// Concise-body arrow functions in common positions — closurec must optimise
+// INSIDE each arrow body (constant-fold), not fall back to WHITESPACE_ONLY.
+// (Block-bodied arrows `x => { ... }` are blocked on a grammar limitation —
+// see CLOC12-gaps gap-156 — and object-body arrows decline to avoid the
+// `() => {}` empty-block-vs-object ambiguity.)
+var factory = n => 1 + 2;          // concise body: 1+2 folds to 3
+var scaled = (a, b) => a + 3 * 4;  // multi-param: 3*4 folds to 12 inside
+arr.map(x => x + (5 - 1));         // callback argument: 5-1 folds to 4

--- a/code/programs/rust/closurec/tests/diff_simple_arrow_function.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_arrow_function.rs
@@ -1,0 +1,67 @@
+//! Integration test for the `tests/diff/simple-arrow-function/` fixture.
+//!
+//! Exercises CLOC12.152 — a concise-body **arrow function** (`x => expr`) now
+//! flows through the full SIMPLE pipeline end-to-end (parser → typed-AST bridge
+//! → passes → emitter) instead of declining at the bridge and falling back to
+//! WHITESPACE_ONLY.
+//!
+//! The fixture puts a concise-body arrow in several positions — a single-param
+//! RHS (`var f = n => 1+2`), a multi-param RHS (`var g = (a,b) => a+3*4`), and
+//! a callback argument (`arr.map(x => x + (5-1))`) — each with a foldable body.
+//! The expected output proves constant-fold ran *inside* those arrow bodies
+//! (`1+2`→`3`, `3*4`→`12`, `5-1`→`4`), which a WHITESPACE_ONLY passthrough
+//! would NOT do.
+//!
+//! Block-bodied arrows (`x => { return x; }`) are blocked on a grammar
+//! limitation (CLOC12-gaps gap-156) and object-body arrows decline to avoid the
+//! `() => {}` empty-block-vs-object ambiguity — neither appears here.
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
+
+fn read_flags() -> Vec<String> {
+    let raw = std::fs::read_to_string("tests/diff/simple-arrow-function/flags.txt")
+        .expect("read flags.txt");
+    raw.lines()
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[test]
+fn simple_arrow_function_fixture_matches_expected_stdout() {
+    let flags = read_flags();
+    let out = Command::new(BINARY)
+        .args(&flags)
+        .output()
+        .expect("run closurec");
+
+    assert!(
+        out.status.success(),
+        "exit: {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let actual = String::from_utf8_lossy(&out.stdout);
+    let expected = std::fs::read_to_string("tests/diff/simple-arrow-function/expected.stdout")
+        .expect("read expected.stdout");
+    assert_eq!(
+        actual.trim_end_matches('\n'),
+        expected.trim_end_matches('\n'),
+        "mismatch.\nactual:\n{actual}\nexpected:\n{expected}",
+    );
+
+    // Guard the *point* of the fixture: the arrow bodies were optimised, so the
+    // folded constants must be present and the pre-fold expressions gone.
+    // (A WHITESPACE_ONLY fallback would still contain `1+2` / `3*4` / `5-1`.)
+    let a = actual.replace(' ', "");
+    assert!(a.contains("=>3"), "1+2 not folded inside the arrow: {actual}");
+    assert!(a.contains("+12"), "3*4 not folded inside the arrow: {actual}");
+    assert!(a.contains("+4"), "5-1 not folded inside the arrow: {actual}");
+    assert!(
+        !a.contains("1+2") && !a.contains("3*4") && !a.contains("5-1"),
+        "a pre-fold expression survived — did it fall back to WHITESPACE_ONLY? {actual}"
+    );
+}

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -1458,3 +1458,41 @@ emits `()=>{}.x`, which mis-parses the `{}` as a block body. This is the same
 leftmost-token class as the general expression-statement `{`-wrap and is rare in
 practice (an object-literal-rooted concise body used as a member/call base);
 deferred until a general leftmost-token analysis lands.
+
+## CLOC12.152 — bridge `arrow_function` → `Expression::ArrowFunctionExpression`
+
+The `javascript-parser` typed-AST bridge (0.21.0) now converts **concise-body
+arrow functions** (`x => x + 1`, `(a, b) => a + b`, `() => 1`,
+`arr.map(x => x)`) — `convert_arrow_function` reads `arrow_parameters`
+(`NAME` → one param; `( formal_parameters )` → the list; `()` → none) and the
+`concise_body` expression, yielding an `ArrowFunctionExpression` with an
+`ArrowBody::Expression`. This unblocks the SIMPLE pipeline *inside* arrow bodies
+end-to-end (`var f = x => 1 + 2` → `var f = x => 3`) instead of the previous
+whitespace-only fallback. 5 bridge tests + a closurec e2e diff fixture
+(`tests/diff/simple-arrow-function/`).
+
+### gap-155 — bridge declines `arrow_function` — **RESOLVED** (javascript-parser 0.21.0)
+
+Previously the bridge listed `arrow_function` under `UnsupportedSyntax`. Now
+resolved for concise-body arrows (see above). Async / block-bodied / object-body
+arrows remain out of scope per gap-156 and the async note.
+
+### gap-156 — grammar rejects block-bodied arrows; `() => {}` mis-parses as object body
+
+Two *grammar*-level limitations (in `code/grammars/ecmascript/*.grammar`, not the
+bridge) constrain CLOC12.152 to concise expression bodies:
+
+1. **Block-bodied arrows fail to parse.** `x => { return x; }` — the
+   `concise_body = … | LBRACE function_body RBRACE` alternative is not taken by
+   the generated parser, so a statement block body is a hard parse error. The
+   bridge's `ArrowBody::Block` path and the emitter/passes already model block
+   bodies; only the parser needs fixing (a separate grammar PR).
+2. **`() => {}` is read as an empty-*object* concise body.** With the block
+   alternative unavailable, `{}` after `=>` parses as an empty object literal —
+   i.e. `() => ({})` — which returns a *different value* (an object) than the
+   real empty-block arrow (returns `undefined`). The distinguishing information
+   is already lost in the parse tree, so the bridge **declines** any arrow whose
+   concise body is an `ObjectExpression` (falls back to whitespace-only, which
+   re-emits the source unchanged and is always correct). Genuine object-returning
+   arrows (`x => ({a:1})`) decline too — forgoing an optimisation, never
+   correctness. Fixing the grammar's block-body parse resolves both.


### PR DESCRIPTION
## What

The `javascript-parser` typed-AST **bridge** (0.21.0) now converts **concise-body arrow functions** — `x => x + 1`, `(a, b) => a + b`, `() => 1`, `arr.map(x => x)` — into `Expression::ArrowFunctionExpression` instead of declining them as `UnsupportedSyntax`. This is PR2 of the arrow arc (PR1 [#7371](https://github.com/adhithyan15/coding-adventures/pull/7371) landed the node + emitter + passes).

**The win:** closurec now runs the full SIMPLE pipeline *inside* arrow bodies end-to-end — `var f = x => 1 + 2` → `var f = x => 3` — instead of falling back to WHITESPACE_ONLY.

## How

`convert_arrow_function` reads `arrow_parameters` (`NAME` → one identifier param; `( formal_parameters )` → the list; `()` → none) and the `concise_body` expression, producing an `ArrowBody::Expression`.

## Two conservative guards — for correctness, not convenience

I probed the actual grammar parse tree before writing the converter and found two real traps (documented as **gap-156**):

1. **Block-bodied arrows don't parse.** The ECMAScript grammar rejects `x => { return x; }` outright, so the bridge only ever sees a concise body. The `ArrowBody::Block` path is written and ready for when the grammar is fixed.
2. **`() => {}` mis-parses as an empty-*object* concise body** (`() => ({})`) — indistinguishable from a genuine object-returning arrow, and a *different value* than the real empty-block arrow (`undefined`). Since the parse tree has already lost the distinction, the bridge **declines** any arrow whose concise body is an `ObjectExpression`, falling back to whitespace-only (re-emits source unchanged — always correct). Only an optimisation is forgone, never correctness. This prevents a miscompile that naive enablement would introduce.

Async arrows (`async x => x`, separate `async_arrow_function` rule) remain declined for now.

## Verification

- **5 new bridge tests**: concise single/multi/empty-param convert; callback-arg arrow; object-body declines; async declines
- **closurec e2e diff fixture** (`tests/diff/simple-arrow-function/`, test-only — no closurec version bump) proving `n=>1+2`→`n=>3`, `(a,b)=>a+3*4`→`a+12`, `x=>x+(5-1)`→`x+4` all fold *inside* the arrow bodies
- javascript-parser **105 tests pass**, closurec suite green, 0 failed
- inline security review: **PASSED** (no panics/unwrap/indexing on the untrusted parse tree in the new functions; recursion bounded; decline guard verified to prevent the miscompile)

## Specs

`CLOC12-gaps.md`: gap-155 marked **RESOLVED**; gap-156 documents the grammar block-body limitation for a future grammar PR.

## Follow-up

- **PR3** — upstream CodePrinter arrow conformance port (emit-level)

🤖 Generated with [Claude Code](https://claude.com/claude-code)