### PR TITLE
feat(adj-ladder): rung-44 indicator-dilution mixed concentration (product-over-sum)

### DIFF
--- a/code/specs/data/adj-ladder/rung44_indicator_dilution/gen_items.py
+++ b/code/specs/data/adj-ladder/rung44_indicator_dilution/gen_items.py
@@ -1,0 +1,229 @@
+"""Generate rung-44 (indicator-dilution mixed concentration) items.json for the ADJ-LADDER.
+
+Rung 44 opens the **indicator / tracer dilution** panel on the quantitative band — the arithmetic of what a
+tracer's concentration becomes once a known bolus of it distributes through a combined blood volume. A bolus
+carries a fixed amount of indicator (`indicator_volume * indicator_concentration` of dye); when that amount
+spreads through the sum of two compartments (`central_volume + peripheral_volume`), the resulting mixed
+concentration is the bolus amount divided by the total distribution volume. This rung introduces a genuinely NEW
+arithmetic shape on the ladder: **product-over-sum** — `(a * b) / (c + d)` — a product in the numerator divided by
+a sum in the denominator.
+
+The setup: an indicator bolus of `indicator_volume` (mL) at `indicator_concentration` (mg/mL) is injected and
+distributes through a `central_volume` (L) plus a `peripheral_volume` (L). The mixed concentration is the injected
+amount over the volume it distributes through:
+
+  MIXED CONCENTRATION   (indicator_volume * indicator_concentration) / (central_volume + peripheral_volume)   [ the concentration after distribution ]
+  INDICATOR MASS        indicator_volume * indicator_concentration                                            [ the numerator: injected amount ]
+  DISTRIBUTION VOLUME   central_volume + peripheral_volume                                                    [ the denominator: total volume ]
+
+The **mixed concentration** is what makes this rung distinctive — it is the ladder's first **product-over-sum**: a
+parenthesised product divided by a parenthesised sum. Contrast the neighbours already on the ladder: rung-37 was a
+*ratio of two sums* `(a+b)/(c+d)`, rung-41 a *difference-over-sum* `(a-b)/(a+b)`, rung-42 a *sum-over-difference*
+`(a+b)/(c-d)`; none divided a PRODUCT by a SUM. (The indicator mass `indicator_volume * indicator_concentration`
+and the distribution volume `central_volume + peripheral_volume` ride alongside as the two component quantities, so
+the panel teaches the whole calculation — exactly as rung-42 shipped its total-solute and remaining-volume beside
+the headline concentration.)
+
+Each index is a `compute_dimensioned` program (`observe` the four quantities + `let answer = formula`); the ADJ
+engine carries the arithmetic — including the inner `(indicator_volume * indicator_concentration)` product and the
+`(central_volume + peripheral_volume)` sum — and the harness reads the scalar via the existing
+`compute_dimensioned` extractor. No harness/engine change, exactly as rungs 8/16/.../42/43. This rung exercises the
+engine across a **product divided by a sum**.
+
+Contamination-safe by construction: every formula is built ONLY from the four observed quantities via `*`, `+` and
+`/` — **no structural constants** — so no numeric literal appears in any program, and neither the injected mass,
+the distribution volume, nor any concentration is ever a literal (each is computed from the observed quantities).
+The observed quantities carry **digit-free identifiers** (`indicator_volume`, `indicator_concentration`,
+`central_volume`, `peripheral_volume`) so no numeral hides inside a variable name.
+
+The five options are a tight family over the same four quantities: the three real readouts plus the two classic
+slips —
+
+  CENTRAL ONLY       (indicator_volume * indicator_concentration) / central_volume        divide by the CENTRAL
+                                                                                            compartment alone,
+                                                                                            forgetting the
+                                                                                            peripheral one, and
+  SUMMED NUMERATOR   (indicator_volume + indicator_concentration) / (central_volume + peripheral_volume)   ADD the
+                                                                                            two indicator quantities
+                                                                                            instead of multiplying
+                                                                                            them,
+
+which are exactly the mistakes a student makes (dropping a compartment from the denominator, or adding the bolus's
+volume and concentration instead of forming their product). Gold rotates A-E by index. QUERIED (used as gold) = the
+three real readouts; all five always appear as options.
+
+Distinctness: all four observed quantities are positive, so every product and sum is positive and every denominator
+is strictly positive (no division by zero); the tables below are chosen so the five family values are pairwise
+distinct with a comfortable margin, asserted at build time.
+"""
+import json
+
+LETTERS = ["A", "B", "C", "D", "E"]
+
+# (INDICATOR_VOLUME, INDICATOR_CONCENTRATION, CENTRAL_VOLUME, PERIPHERAL_VOLUME) — bolus volume in mL, bolus
+# concentration in mg/mL, compartment volumes in L, all strictly positive. The five family values are asserted
+# pairwise-distinct (with margin) below.
+TABLES = [
+    (2, 10, 3, 2),
+    (4, 5, 3, 5),
+    (2, 20, 4, 4),
+    (5, 4, 3, 2),
+    (3, 10, 2, 4),
+    (2, 25, 5, 3),
+    (4, 10, 6, 2),
+]
+
+# The option family (5 members), all built from the four observed quantities via *, + and /. Every identifier is
+# DIGIT-FREE. key -> (display name, formula-as-adj). Only the first three are *queried* (used as gold); all five
+# always appear as the options.
+FAMILY = [
+    (
+        "mixed_concentration",
+        "mixed concentration after distribution (injected amount over the total volume)",
+        "(indicator_volume * indicator_concentration) / (central_volume + peripheral_volume)",
+    ),
+    (
+        "indicator_mass",
+        "the injected indicator amount (bolus volume times its concentration)",
+        "indicator_volume * indicator_concentration",
+    ),
+    (
+        "distribution_volume",
+        "the total distribution volume (central plus peripheral)",
+        "central_volume + peripheral_volume",
+    ),
+    (
+        "central_only",
+        "injected amount over the CENTRAL compartment alone, forgetting the peripheral one (a wrong denominator)",
+        "(indicator_volume * indicator_concentration) / central_volume",
+    ),
+    (
+        "summed_numerator",
+        "the two indicator quantities ADDED instead of multiplied, over the total volume (a wrong numerator)",
+        "(indicator_volume + indicator_concentration) / (central_volume + peripheral_volume)",
+    ),
+]
+QUERIED = ["mixed_concentration", "indicator_mass", "distribution_volume"]
+ORDER = [k for k, _, _ in FAMILY]
+
+
+def scalar(v):
+    return {"value": v, "unit": "scalar"}
+
+
+def family_values(indicator_volume, indicator_concentration, central_volume, peripheral_volume):
+    # Operation order mirrors the ADJ programs exactly (product binds tighter than +, division over the
+    # parenthesised sum), so the Python option value and the engine result are the same IEEE-double (well within
+    # the harness's 1e-9 match tolerance).
+    mass = indicator_volume * indicator_concentration
+    total = central_volume + peripheral_volume
+    return {
+        "mixed_concentration": mass / total,
+        "indicator_mass": mass,
+        "distribution_volume": total,
+        "central_only": mass / central_volume,
+        "summed_numerator": (indicator_volume + indicator_concentration) / total,
+    }
+
+
+def build():
+    name_of = {k: nm for k, nm, _ in FAMILY}
+    formula_of = {k: f for k, _, f in FAMILY}
+    items = []
+    idx = 0
+
+    def num(x):
+        return int(x) if float(x).is_integer() else x
+
+    for indicator_volume, indicator_concentration, central_volume, peripheral_volume in TABLES:
+        assert all(
+            q > 0
+            for q in (indicator_volume, indicator_concentration, central_volume, peripheral_volume)
+        ), (indicator_volume, indicator_concentration, central_volume, peripheral_volume)
+        fv = family_values(indicator_volume, indicator_concentration, central_volume, peripheral_volume)
+        # Pairwise-distinct with a comfortable margin so the harness never sees two options
+        # matching the gold value within its 1e-9 tolerance.
+        vals = [fv[key] for key in ORDER]
+        for i in range(len(vals)):
+            for j in range(i + 1, len(vals)):
+                assert abs(vals[i] - vals[j]) > 1e-6, (
+                    indicator_volume,
+                    indicator_concentration,
+                    central_volume,
+                    peripheral_volume,
+                    ORDER[i],
+                    ORDER[j],
+                    fv,
+                )
+        for key in QUERIED:
+            gold_val = fv[key]
+            gold_pos = idx % 5
+            others = [fv[k2] for k2 in ORDER if abs(fv[k2] - gold_val) > 1e-12]
+            opts_vals = others[:]
+            opts_vals.insert(gold_pos, gold_val)
+            opts_vals = opts_vals[:5]
+            if abs(opts_vals[gold_pos] - gold_val) > 1e-12:
+                opts_vals[gold_pos] = gold_val
+            assert len({round(v, 9) for v in opts_vals}) == 5, (
+                key,
+                indicator_volume,
+                indicator_concentration,
+                central_volume,
+                peripheral_volume,
+                opts_vals,
+            )
+            options = {LETTERS[i]: scalar(opts_vals[i]) for i in range(5)}
+            items.append({
+                "id": f"r44dil-{idx + 1:02d}",
+                "qtype": "indicator_dilution",
+                "stem": (
+                    f"A tracer bolus of {num(indicator_volume)} mL at {num(indicator_concentration)} mg/mL is "
+                    f"injected and distributes through a central volume of {num(central_volume)} L plus a "
+                    f"peripheral volume of {num(peripheral_volume)} L. What is the {name_of[key]}?"
+                ),
+                "program": (
+                    f"observe indicator_volume({num(indicator_volume)})\n"
+                    f"observe indicator_concentration({num(indicator_concentration)})\n"
+                    f"observe central_volume({num(central_volume)})\n"
+                    f"observe peripheral_volume({num(peripheral_volume)})\n"
+                    f"let answer = {formula_of[key]}\n"
+                    "? answer\n"
+                ),
+                "answer_from": {"type": "compute_dimensioned", "name": "answer"},
+                "options": options,
+                "gold_letter": LETTERS[gold_pos],
+            })
+            idx += 1
+    return {
+        "description": (
+            "ADJ-LADDER rung 44 — indicator-dilution mixed concentration from four stated quantities (a NEW panel: "
+            "indicator / tracer dilution). From a tracer bolus (its volume and concentration) and two distribution "
+            "compartments compute the mixed concentration ((indicator_volume*indicator_concentration)/"
+            "(central_volume+peripheral_volume)), the injected indicator mass (indicator_volume*"
+            "indicator_concentration), or the total distribution volume (central_volume+peripheral_volume). Each "
+            "item is a compute_dimensioned program (observe the four quantities, let answer = formula); the ADJ "
+            "engine carries the arithmetic — a NEW shape, PRODUCT-OVER-SUM (a*b)/(c+d), the first quotient on the "
+            "ladder to divide a parenthesised product by a parenthesised sum (distinct from rung-37 ratio-of-two-"
+            "sums (a+b)/(c+d), rung-41 difference-over-sum (a-b)/(a+b), and rung-42 sum-over-difference (a+b)/(c-d)) "
+            "— and the harness matches the scalar to the printed options. Contamination-safe: every index is built "
+            "only from the four observed quantities via *, + and / — no constant leaks, and neither the injected "
+            "mass, the distribution volume, nor any concentration ever appears as a literal (each is computed) — and "
+            "the observed quantities carry digit-free identifiers so no numeral hides inside a variable name. The "
+            "five options are a family over the same four quantities, so the distractors are exactly the slips "
+            "students make: dividing by the central compartment alone (dropping the peripheral one), and adding the "
+            "bolus's volume and concentration instead of multiplying them. The core confusion tested is dividing the "
+            "injected product by the pooled (summed) distribution volume."
+        ),
+        "items": items,
+    }
+
+
+if __name__ == "__main__":
+    doc = build()
+    with open("items.json", "w") as f:
+        json.dump(doc, f, indent=2)
+        f.write("\n")
+    print("wrote items.json:", len(doc["items"]), "items")
+    for it in doc["items"]:
+        print(it["id"], it["qtype"], "gold", it["gold_letter"],
+              "=", round(it["options"][it["gold_letter"]]["value"], 6))

--- a/code/specs/data/adj-ladder/rung44_indicator_dilution/items.json
+++ b/code/specs/data/adj-ladder/rung44_indicator_dilution/items.json
@@ -1,0 +1,698 @@
+{
+  "description": "ADJ-LADDER rung 44 \u2014 indicator-dilution mixed concentration from four stated quantities (a NEW panel: indicator / tracer dilution). From a tracer bolus (its volume and concentration) and two distribution compartments compute the mixed concentration ((indicator_volume*indicator_concentration)/(central_volume+peripheral_volume)), the injected indicator mass (indicator_volume*indicator_concentration), or the total distribution volume (central_volume+peripheral_volume). Each item is a compute_dimensioned program (observe the four quantities, let answer = formula); the ADJ engine carries the arithmetic \u2014 a NEW shape, PRODUCT-OVER-SUM (a*b)/(c+d), the first quotient on the ladder to divide a parenthesised product by a parenthesised sum (distinct from rung-37 ratio-of-two-sums (a+b)/(c+d), rung-41 difference-over-sum (a-b)/(a+b), and rung-42 sum-over-difference (a+b)/(c-d)) \u2014 and the harness matches the scalar to the printed options. Contamination-safe: every index is built only from the four observed quantities via *, + and / \u2014 no constant leaks, and neither the injected mass, the distribution volume, nor any concentration ever appears as a literal (each is computed) \u2014 and the observed quantities carry digit-free identifiers so no numeral hides inside a variable name. The five options are a family over the same four quantities, so the distractors are exactly the slips students make: dividing by the central compartment alone (dropping the peripheral one), and adding the bolus's volume and concentration instead of multiplying them. The core confusion tested is dividing the injected product by the pooled (summed) distribution volume.",
+  "items": [
+    {
+      "id": "r44dil-01",
+      "qtype": "indicator_dilution",
+      "stem": "A tracer bolus of 2 mL at 10 mg/mL is injected and distributes through a central volume of 3 L plus a peripheral volume of 2 L. What is the mixed concentration after distribution (injected amount over the total volume)?",
+      "program": "observe indicator_volume(2)\nobserve indicator_concentration(10)\nobserve central_volume(3)\nobserve peripheral_volume(2)\nlet answer = (indicator_volume * indicator_concentration) / (central_volume + peripheral_volume)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 4.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 20,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 6.666666666666667,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 2.4,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r44dil-02",
+      "qtype": "indicator_dilution",
+      "stem": "A tracer bolus of 2 mL at 10 mg/mL is injected and distributes through a central volume of 3 L plus a peripheral volume of 2 L. What is the the injected indicator amount (bolus volume times its concentration)?",
+      "program": "observe indicator_volume(2)\nobserve indicator_concentration(10)\nobserve central_volume(3)\nobserve peripheral_volume(2)\nlet answer = indicator_volume * indicator_concentration\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 4.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 20,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 6.666666666666667,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 2.4,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r44dil-03",
+      "qtype": "indicator_dilution",
+      "stem": "A tracer bolus of 2 mL at 10 mg/mL is injected and distributes through a central volume of 3 L plus a peripheral volume of 2 L. What is the the total distribution volume (central plus peripheral)?",
+      "program": "observe indicator_volume(2)\nobserve indicator_concentration(10)\nobserve central_volume(3)\nobserve peripheral_volume(2)\nlet answer = central_volume + peripheral_volume\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 4.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 20,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 6.666666666666667,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 2.4,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r44dil-04",
+      "qtype": "indicator_dilution",
+      "stem": "A tracer bolus of 4 mL at 5 mg/mL is injected and distributes through a central volume of 3 L plus a peripheral volume of 5 L. What is the mixed concentration after distribution (injected amount over the total volume)?",
+      "program": "observe indicator_volume(4)\nobserve indicator_concentration(5)\nobserve central_volume(3)\nobserve peripheral_volume(5)\nlet answer = (indicator_volume * indicator_concentration) / (central_volume + peripheral_volume)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 20,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 6.666666666666667,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 2.5,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1.125,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r44dil-05",
+      "qtype": "indicator_dilution",
+      "stem": "A tracer bolus of 4 mL at 5 mg/mL is injected and distributes through a central volume of 3 L plus a peripheral volume of 5 L. What is the the injected indicator amount (bolus volume times its concentration)?",
+      "program": "observe indicator_volume(4)\nobserve indicator_concentration(5)\nobserve central_volume(3)\nobserve peripheral_volume(5)\nlet answer = indicator_volume * indicator_concentration\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 2.5,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 6.666666666666667,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 1.125,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 20,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r44dil-06",
+      "qtype": "indicator_dilution",
+      "stem": "A tracer bolus of 4 mL at 5 mg/mL is injected and distributes through a central volume of 3 L plus a peripheral volume of 5 L. What is the the total distribution volume (central plus peripheral)?",
+      "program": "observe indicator_volume(4)\nobserve indicator_concentration(5)\nobserve central_volume(3)\nobserve peripheral_volume(5)\nlet answer = central_volume + peripheral_volume\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2.5,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 20,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 6.666666666666667,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1.125,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r44dil-07",
+      "qtype": "indicator_dilution",
+      "stem": "A tracer bolus of 2 mL at 20 mg/mL is injected and distributes through a central volume of 4 L plus a peripheral volume of 4 L. What is the mixed concentration after distribution (injected amount over the total volume)?",
+      "program": "observe indicator_volume(2)\nobserve indicator_concentration(20)\nobserve central_volume(4)\nobserve peripheral_volume(4)\nlet answer = (indicator_volume * indicator_concentration) / (central_volume + peripheral_volume)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 40,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 5.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 10.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 2.75,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r44dil-08",
+      "qtype": "indicator_dilution",
+      "stem": "A tracer bolus of 2 mL at 20 mg/mL is injected and distributes through a central volume of 4 L plus a peripheral volume of 4 L. What is the the injected indicator amount (bolus volume times its concentration)?",
+      "program": "observe indicator_volume(2)\nobserve indicator_concentration(20)\nobserve central_volume(4)\nobserve peripheral_volume(4)\nlet answer = indicator_volume * indicator_concentration\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 5.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 40,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 10.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 2.75,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r44dil-09",
+      "qtype": "indicator_dilution",
+      "stem": "A tracer bolus of 2 mL at 20 mg/mL is injected and distributes through a central volume of 4 L plus a peripheral volume of 4 L. What is the the total distribution volume (central plus peripheral)?",
+      "program": "observe indicator_volume(2)\nobserve indicator_concentration(20)\nobserve central_volume(4)\nobserve peripheral_volume(4)\nlet answer = central_volume + peripheral_volume\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 5.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 40,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 10.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 2.75,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r44dil-10",
+      "qtype": "indicator_dilution",
+      "stem": "A tracer bolus of 5 mL at 4 mg/mL is injected and distributes through a central volume of 3 L plus a peripheral volume of 2 L. What is the mixed concentration after distribution (injected amount over the total volume)?",
+      "program": "observe indicator_volume(5)\nobserve indicator_concentration(4)\nobserve central_volume(3)\nobserve peripheral_volume(2)\nlet answer = (indicator_volume * indicator_concentration) / (central_volume + peripheral_volume)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 20,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 6.666666666666667,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 1.8,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 4.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r44dil-11",
+      "qtype": "indicator_dilution",
+      "stem": "A tracer bolus of 5 mL at 4 mg/mL is injected and distributes through a central volume of 3 L plus a peripheral volume of 2 L. What is the the injected indicator amount (bolus volume times its concentration)?",
+      "program": "observe indicator_volume(5)\nobserve indicator_concentration(4)\nobserve central_volume(3)\nobserve peripheral_volume(2)\nlet answer = indicator_volume * indicator_concentration\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 20,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 4.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 6.666666666666667,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1.8,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r44dil-12",
+      "qtype": "indicator_dilution",
+      "stem": "A tracer bolus of 5 mL at 4 mg/mL is injected and distributes through a central volume of 3 L plus a peripheral volume of 2 L. What is the the total distribution volume (central plus peripheral)?",
+      "program": "observe indicator_volume(5)\nobserve indicator_concentration(4)\nobserve central_volume(3)\nobserve peripheral_volume(2)\nlet answer = central_volume + peripheral_volume\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 4.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 20,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 6.666666666666667,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1.8,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r44dil-13",
+      "qtype": "indicator_dilution",
+      "stem": "A tracer bolus of 3 mL at 10 mg/mL is injected and distributes through a central volume of 2 L plus a peripheral volume of 4 L. What is the mixed concentration after distribution (injected amount over the total volume)?",
+      "program": "observe indicator_volume(3)\nobserve indicator_concentration(10)\nobserve central_volume(2)\nobserve peripheral_volume(4)\nlet answer = (indicator_volume * indicator_concentration) / (central_volume + peripheral_volume)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 30,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 5.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 15.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 2.1666666666666665,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r44dil-14",
+      "qtype": "indicator_dilution",
+      "stem": "A tracer bolus of 3 mL at 10 mg/mL is injected and distributes through a central volume of 2 L plus a peripheral volume of 4 L. What is the the injected indicator amount (bolus volume times its concentration)?",
+      "program": "observe indicator_volume(3)\nobserve indicator_concentration(10)\nobserve central_volume(2)\nobserve peripheral_volume(4)\nlet answer = indicator_volume * indicator_concentration\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 5.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 15.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 30,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 2.1666666666666665,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r44dil-15",
+      "qtype": "indicator_dilution",
+      "stem": "A tracer bolus of 3 mL at 10 mg/mL is injected and distributes through a central volume of 2 L plus a peripheral volume of 4 L. What is the the total distribution volume (central plus peripheral)?",
+      "program": "observe indicator_volume(3)\nobserve indicator_concentration(10)\nobserve central_volume(2)\nobserve peripheral_volume(4)\nlet answer = central_volume + peripheral_volume\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 5.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 30,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 15.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 2.1666666666666665,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 6,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r44dil-16",
+      "qtype": "indicator_dilution",
+      "stem": "A tracer bolus of 2 mL at 25 mg/mL is injected and distributes through a central volume of 5 L plus a peripheral volume of 3 L. What is the mixed concentration after distribution (injected amount over the total volume)?",
+      "program": "observe indicator_volume(2)\nobserve indicator_concentration(25)\nobserve central_volume(5)\nobserve peripheral_volume(3)\nlet answer = (indicator_volume * indicator_concentration) / (central_volume + peripheral_volume)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 6.25,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 50,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 10.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 3.375,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r44dil-17",
+      "qtype": "indicator_dilution",
+      "stem": "A tracer bolus of 2 mL at 25 mg/mL is injected and distributes through a central volume of 5 L plus a peripheral volume of 3 L. What is the the injected indicator amount (bolus volume times its concentration)?",
+      "program": "observe indicator_volume(2)\nobserve indicator_concentration(25)\nobserve central_volume(5)\nobserve peripheral_volume(3)\nlet answer = indicator_volume * indicator_concentration\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 6.25,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 50,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 10.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 3.375,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r44dil-18",
+      "qtype": "indicator_dilution",
+      "stem": "A tracer bolus of 2 mL at 25 mg/mL is injected and distributes through a central volume of 5 L plus a peripheral volume of 3 L. What is the the total distribution volume (central plus peripheral)?",
+      "program": "observe indicator_volume(2)\nobserve indicator_concentration(25)\nobserve central_volume(5)\nobserve peripheral_volume(3)\nlet answer = central_volume + peripheral_volume\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 6.25,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 50,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 10.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 3.375,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r44dil-19",
+      "qtype": "indicator_dilution",
+      "stem": "A tracer bolus of 4 mL at 10 mg/mL is injected and distributes through a central volume of 6 L plus a peripheral volume of 2 L. What is the mixed concentration after distribution (injected amount over the total volume)?",
+      "program": "observe indicator_volume(4)\nobserve indicator_concentration(10)\nobserve central_volume(6)\nobserve peripheral_volume(2)\nlet answer = (indicator_volume * indicator_concentration) / (central_volume + peripheral_volume)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 40,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 6.666666666666667,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 5.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1.75,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r44dil-20",
+      "qtype": "indicator_dilution",
+      "stem": "A tracer bolus of 4 mL at 10 mg/mL is injected and distributes through a central volume of 6 L plus a peripheral volume of 2 L. What is the the injected indicator amount (bolus volume times its concentration)?",
+      "program": "observe indicator_volume(4)\nobserve indicator_concentration(10)\nobserve central_volume(6)\nobserve peripheral_volume(2)\nlet answer = indicator_volume * indicator_concentration\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 5.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 6.666666666666667,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 1.75,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 40,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r44dil-21",
+      "qtype": "indicator_dilution",
+      "stem": "A tracer bolus of 4 mL at 10 mg/mL is injected and distributes through a central volume of 6 L plus a peripheral volume of 2 L. What is the the total distribution volume (central plus peripheral)?",
+      "program": "observe indicator_volume(4)\nobserve indicator_concentration(10)\nobserve central_volume(6)\nobserve peripheral_volume(2)\nlet answer = central_volume + peripheral_volume\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 5.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 40,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 6.666666666666667,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1.75,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    }
+  ]
+}

--- a/code/specs/data/adj-ladder/test_ladder_eval.py
+++ b/code/specs/data/adj-ladder/test_ladder_eval.py
@@ -81,6 +81,7 @@ SELF_CONTAINED_RUNGS = (
     "rung41_split_renal_function",
     "rung42_hemofiltration_concentration",
     "rung43_compounded_admixture",
+    "rung44_indicator_dilution",
 )
 
 


### PR DESCRIPTION
## ADJ-LADDER rung-44 — indicator-dilution mixed concentration (product-over-sum)

Adds **rung 44** to the ADJ-LADDER: a **new quantitative panel** (indicator / tracer dilution) that introduces a **genuinely new arithmetic shape** — **product-over-sum**, `(a * b) / (c + d)`.

### What's new — the shape
A tracer bolus carries `indicator_volume * indicator_concentration` of dye and distributes through `central_volume + peripheral_volume`. The **mixed concentration** is the injected amount over the total distribution volume:

```
mixed_concentration = (indicator_volume * indicator_concentration) / (central_volume + peripheral_volume)
```

This is the **first ladder quotient that divides a parenthesised product by a parenthesised sum**, distinct from:
- rung-37 ratio-of-two-sums `(a+b)/(c+d)`
- rung-41 difference-over-sum `(a-b)/(a+b)`
- rung-42 sum-over-difference `(a+b)/(c-d)`

### The panel
Three real readouts are queried as gold — `mixed_concentration`, `indicator_mass` (the numerator product), `distribution_volume` (the denominator sum) — against two classic slips as distractors:
- **central_only**: divide by the central compartment alone, dropping the peripheral one — `(iv*ic)/central_volume`
- **summed_numerator**: add the bolus's volume and concentration instead of multiplying — `(iv+ic)/(cv+pv)`

21 items (7 tables × 3 queried); gold rotates A–E.

### Faithful-by-construction
- Each item is a `compute_dimensioned` program (`observe` the four quantities, `let answer = formula`); the ADJ engine carries the arithmetic and the existing harness reads the scalar — **no engine/harness change**, exactly as rungs 8/16/…/42/43.
- **No numeric constants**: every formula is built only from the four observed quantities via `*`, `+`, `/`. No per-quantity amount ever appears as a literal.
- **Digit-free identifiers** (`indicator_volume`, `indicator_concentration`, `central_volume`, `peripheral_volume`) — no numeral hides in a variable name.
- Five family values asserted **pairwise-distinct** (margin > 1e-6) at build time; every denominator strictly positive.

### Verification
- `python3 -m pytest test_ladder_eval.py -k rung44 -q` → **3 passed** (engine selects every gold, 0 wrong / 0 abstain; contamination clean; items.json valid).
- Registered `rung44_indicator_dilution` in `SELF_CONTAINED_RUNGS`.
- Security review: **PASSED** (data-only generator, no external input, no eval/exec/subprocess/network).

### Files
- `code/specs/data/adj-ladder/rung44_indicator_dilution/gen_items.py` (new)
- `code/specs/data/adj-ladder/rung44_indicator_dilution/items.json` (new, generated)
- `code/specs/data/adj-ladder/test_ladder_eval.py` (register rung)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
