### PR TITLE
[codex] Add fostered nobr cross-axis repair evidence

### DIFF
--- a/code/packages/rust/html-parser/tests/whatwg_table_audit_test.rs
+++ b/code/packages/rust/html-parser/tests/whatwg_table_audit_test.rs
@@ -6,9 +6,11 @@ use std::collections::{BTreeMap, HashMap};
 
 const TREE_CONSTRUCTION_SMOKE: &str = include_str!("fixtures/html5lib-tree-construction-smoke.dat");
 const WHATWG_BLOCK_BOUNDARY_AUDIT: &str = include_str!("fixtures/whatwg-block-boundary-audit.json");
+const WHATWG_DOCUMENT_SHELL_AUDIT: &str = include_str!("fixtures/whatwg-document-shell-audit.json");
 const WHATWG_FORMATTING_AUDIT: &str = include_str!("fixtures/whatwg-formatting-audit.json");
 const WHATWG_FORM_INTERACTIVE_AUDIT: &str =
     include_str!("fixtures/whatwg-form-interactive-audit.json");
+const WHATWG_HEAD_BODY_AUDIT: &str = include_str!("fixtures/whatwg-head-body-audit.json");
 const WHATWG_LEGACY_ELEMENT_AUDIT: &str = include_str!("fixtures/whatwg-legacy-element-audit.json");
 const WHATWG_PARAGRAPH_AUDIT: &str = include_str!("fixtures/whatwg-paragraph-audit.json");
 const WHATWG_TABLE_AUDIT: &str = include_str!("fixtures/whatwg-table-audit.json");
@@ -21,6 +23,26 @@ const POST_PARSE_REPAIR_EVIDENCE: &[(&str, &str)] = &[
     ("tricky01-dat-8", "cell-boundary"),
 ];
 const DUPLICATE_FOSTERED_NOBR_ROWS: &[(&str, &str)] = &[("tests26-dat-4", "tests26-dat-1251")];
+const FOSTERED_NOBR_REPAIR_CASE_IDS: &[&str] = &["tests26-dat-4", "tests26-dat-1251"];
+const FOSTERED_NOBR_REPAIR_SUITES: &[(&str, &str, &str)] = &[
+    (
+        "document-shell",
+        WHATWG_DOCUMENT_SHELL_AUDIT,
+        "body-frameset-boundary",
+    ),
+    (
+        "form-interactive",
+        WHATWG_FORM_INTERACTIVE_AUDIT,
+        "interactive-formatting",
+    ),
+    (
+        "formatting",
+        WHATWG_FORMATTING_AUDIT,
+        "interactive-formatting-boundary",
+    ),
+    ("head-body", WHATWG_HEAD_BODY_AUDIT, "body-boundary"),
+    ("table", WHATWG_TABLE_AUDIT, "cell-boundary"),
+];
 const INSANELY_BADLY_NESTED_REPAIR_CASE_ID: &str = "tricky01-dat-8";
 const INSANELY_BADLY_NESTED_REPAIR_SUITES: &[(&str, &str, &str)] = &[
     (
@@ -218,6 +240,79 @@ fn whatwg_table_audit_keeps_duplicate_fostered_nobr_rows_in_lockstep() {
 }
 
 #[test]
+fn whatwg_table_audit_keeps_fostered_nobr_repair_cases_cross_axis() {
+    let smoke_cases = parse_tree_construction_cases(TREE_CONSTRUCTION_SMOKE)
+        .into_iter()
+        .map(|case| (case.source.clone(), case))
+        .collect::<HashMap<_, _>>();
+    let mut duplicate_source_data = None;
+    let mut duplicate_source_document = None;
+
+    for case_id in FOSTERED_NOBR_REPAIR_CASE_IDS {
+        let mut shared_source = None;
+
+        for (suite_name, fixture, expected_axis) in FOSTERED_NOBR_REPAIR_SUITES {
+            let audit_case = generic_audit_case(fixture, suite_name, case_id);
+            assert_eq!(
+                audit_case.axis, *expected_axis,
+                "`{suite_name}` should keep fostered `nobr` repair row `{case_id}` on its focused axis"
+            );
+            assert!(
+                !audit_case.reason.is_empty(),
+                "`{suite_name}` should keep a reason for fostered `nobr` repair row `{case_id}`"
+            );
+
+            if let Some(source) = &shared_source {
+                assert_eq!(
+                    audit_case.source, *source,
+                    "`{suite_name}` should point fostered `nobr` repair row `{case_id}` at the same html5lib source as the other audit axes"
+                );
+            } else {
+                shared_source = Some(audit_case.source);
+            }
+        }
+
+        let shared_source =
+            shared_source.expect("fostered `nobr` repair evidence should include a source row");
+        let source_case = smoke_cases
+            .get(&shared_source)
+            .unwrap_or_else(|| panic!("case `{shared_source}` should exist in smoke fixture"));
+        assert!(
+            source_case
+                .data
+                .contains("<b><nobr>1<table><tr><td><nobr></b><i><nobr>2<nobr></i>3"),
+            "repair evidence should stay tied to the duplicated fostered `nobr` html5lib input"
+        );
+
+        if let Some(previous_data) = &duplicate_source_data {
+            assert_eq!(
+                source_case.data, *previous_data,
+                "duplicated fostered `nobr` repair rows should keep matching input"
+            );
+        } else {
+            duplicate_source_data = Some(source_case.data.clone());
+        }
+        if let Some(previous_document) = &duplicate_source_document {
+            assert_eq!(
+                source_case.document, *previous_document,
+                "duplicated fostered `nobr` repair rows should keep matching expected DOM"
+            );
+        } else {
+            duplicate_source_document = Some(source_case.document.clone());
+        }
+
+        let actual = actual_dom_dump_for_tree_case(source_case).unwrap_or_else(|error| {
+            panic!("case `{shared_source}` (`{case_id}`) parse failed: {error}")
+        });
+        assert_eq!(
+            actual, source_case.document,
+            "cross-axis fostered `nobr` repair evidence case `{shared_source}` failed for input {:?}",
+            source_case.data
+        );
+    }
+}
+
+#[test]
 fn whatwg_table_audit_keeps_insanely_badly_nested_repair_case_cross_axis() {
     let smoke_cases = parse_tree_construction_cases(TREE_CONSTRUCTION_SMOKE)
         .into_iter()
@@ -226,7 +321,8 @@ fn whatwg_table_audit_keeps_insanely_badly_nested_repair_case_cross_axis() {
     let mut shared_source = None;
 
     for (suite_name, fixture, expected_axis) in INSANELY_BADLY_NESTED_REPAIR_SUITES {
-        let audit_case = generic_audit_case(fixture, suite_name);
+        let audit_case =
+            generic_audit_case(fixture, suite_name, INSANELY_BADLY_NESTED_REPAIR_CASE_ID);
         assert_eq!(
             audit_case.axis, *expected_axis,
             "`{suite_name}` should keep the insanely badly nested repair row on its focused axis"
@@ -270,18 +366,14 @@ fn load_suite() -> TableAuditSuite {
     serde_json::from_str(WHATWG_TABLE_AUDIT).expect("WHATWG table audit fixture should parse")
 }
 
-fn generic_audit_case(fixture: &str, suite_name: &str) -> GenericAuditCase {
+fn generic_audit_case(fixture: &str, suite_name: &str, case_id: &str) -> GenericAuditCase {
     let suite = serde_json::from_str::<GenericAuditSuite>(fixture)
         .unwrap_or_else(|error| panic!("`{suite_name}` audit fixture should parse: {error}"));
     suite
         .cases
         .into_iter()
-        .find(|case| case.id == INSANELY_BADLY_NESTED_REPAIR_CASE_ID)
-        .unwrap_or_else(|| {
-            panic!(
-                "`{suite_name}` should audit repair case `{INSANELY_BADLY_NESTED_REPAIR_CASE_ID}`"
-            )
-        })
+        .find(|case| case.id == case_id)
+        .unwrap_or_else(|| panic!("`{suite_name}` should audit repair case `{case_id}`"))
 }
 
 fn assert_axis_count(suite: &TableAuditSuite, axis: &str, minimum: usize) {


### PR DESCRIPTION
## Summary
- Add executable cross-axis audit coverage for the duplicated fostered `nobr` table-cell repair rows (`tests26-dat-4` and `tests26-dat-1251`).
- Verify the rows stay present across document-shell, head/body, form-interactive, formatting, and table audit fixtures with their focused axes.
- Reuse the generic repair-case helper for both fostered `nobr` and insanely badly nested table evidence.

## Validation
- `cargo fmt -p coding-adventures-html-parser`
- Targeted parser audit tests from the monitor, including `whatwg_table_audit_keeps_fostered_nobr_repair_cases_cross_axis`
- `cargo test -p coding-adventures-html-parser`
- `CARGO_BUILD_JOBS=2 cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser`
- `python3 -m json.tool code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json >/dev/null`
- `python3 code/packages/rust/html-parser/tests/fixtures/check_whatwg_audit_rust_tests.py --check`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py`
- `git diff --check`