### PR TITLE
fix(security): resolve CodeQL high-severity alerts

### DIFF
--- a/code/programs/typescript/visicalc-html/infinite.html
+++ b/code/programs/typescript/visicalc-html/infinite.html
@@ -642,8 +642,12 @@
       var n = workbook.replaceAll(q, r, false); // case-insensitive
       render();
       formulaEl.value = workbook.getRaw(a1(selRow, selCol));
-      statusEl.innerHTML += " &nbsp;·&nbsp; replaced " + esc(q) + " → " + esc(r) +
-        " in " + n + " cell(s)";
+      // The find/replace terms are user-controlled, so keep them out of the HTML
+      // sink entirely: append them as a DOM text node (which can never be parsed
+      // as markup) rather than concatenating into innerHTML. The static separator
+      // still goes through insertAdjacentHTML so its entities render.
+      statusEl.insertAdjacentHTML("beforeend", " &nbsp;·&nbsp; replaced ");
+      statusEl.appendChild(document.createTextNode(q + " → " + r + " in " + n + " cell(s)"));
     });
 
     // Save / load: serialize the whole workbook to a single JSON document and

--- a/code/specs/data/mycin-2026/recall/test_acid_base_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_acid_base_recall.py
@@ -24,6 +24,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from urllib.parse import urlsplit
 
 HERE = Path(__file__).resolve().parent
 ADJ = HERE / "acid-base-edges.adj"
@@ -66,7 +67,8 @@ def test_library_is_pure_adj_and_fully_grounded() -> None:
     for line in text.splitlines():
         line = line.strip()
         if line.startswith("locator "):
-            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+            locator_url = line.split('"')[1] if '"' in line else line
+            assert urlsplit(locator_url).hostname == "www.ncbi.nlm.nih.gov", f"non-NCBI locator: {line}"
     assert not (HERE / "acid_base_edge_ground.py").exists()
     assert not (HERE / "acid-base-edge-grounding.json").exists()
     assert not (HERE / "acid-base-edge-manifest.json").exists()

--- a/code/specs/data/mycin-2026/recall/test_autonomic_receptor_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_autonomic_receptor_recall.py
@@ -24,6 +24,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from urllib.parse import urlsplit
 
 HERE = Path(__file__).resolve().parent
 ADJ = HERE / "autonomic-receptor-edges.adj"
@@ -68,7 +69,8 @@ def test_library_is_pure_adj_and_fully_grounded() -> None:
     for line in text.splitlines():
         line = line.strip()
         if line.startswith("locator "):
-            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+            locator_url = line.split('"')[1] if '"' in line else line
+            assert urlsplit(locator_url).hostname == "www.ncbi.nlm.nih.gov", f"non-NCBI locator: {line}"
     assert not (HERE / "autonomic_receptor_edge_ground.py").exists()
     assert not (HERE / "autonomic-receptor-edge-grounding.json").exists()
     assert not (HERE / "autonomic-receptor-edge-manifest.json").exists()

--- a/code/specs/data/mycin-2026/recall/test_biochem_amino_acid_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_biochem_amino_acid_recall.py
@@ -24,6 +24,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from urllib.parse import urlsplit
 
 HERE = Path(__file__).resolve().parent
 ADJ = HERE / "biochem-amino-acid-edges.adj"
@@ -72,7 +73,8 @@ def test_library_is_pure_adj_and_fully_grounded() -> None:
     for line in text.splitlines():
         line = line.strip()
         if line.startswith("locator "):
-            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+            locator_url = line.split('"')[1] if '"' in line else line
+            assert urlsplit(locator_url).hostname == "www.ncbi.nlm.nih.gov", f"non-NCBI locator: {line}"
     assert not (HERE / "biochem_amino_acid_edge_ground.py").exists()
     assert not (HERE / "biochem-amino-acid-edge-grounding.json").exists()
     assert not (HERE / "biochem-amino-acid-edge-manifest.json").exists()

--- a/code/specs/data/mycin-2026/recall/test_bone_cell_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_bone_cell_recall.py
@@ -24,6 +24,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from urllib.parse import urlsplit
 
 HERE = Path(__file__).resolve().parent
 ADJ = HERE / "bone-cell-edges.adj"
@@ -66,7 +67,8 @@ def test_library_is_pure_adj_and_fully_grounded() -> None:
     for line in text.splitlines():
         line = line.strip()
         if line.startswith("locator "):
-            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+            locator_url = line.split('"')[1] if '"' in line else line
+            assert urlsplit(locator_url).hostname == "www.ncbi.nlm.nih.gov", f"non-NCBI locator: {line}"
     assert not (HERE / "bone_cell_edge_ground.py").exists()
     assert not (HERE / "bone-cell-edge-grounding.json").exists()
     assert not (HERE / "bone-cell-edge-manifest.json").exists()

--- a/code/specs/data/mycin-2026/recall/test_brachial_plexus_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_brachial_plexus_recall.py
@@ -22,6 +22,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from urllib.parse import urlsplit
 
 HERE = Path(__file__).resolve().parent
 ADJ = HERE / "brachial-plexus-edges.adj"
@@ -66,7 +67,8 @@ def test_library_is_pure_adj_and_fully_grounded() -> None:
     for line in text.splitlines():
         line = line.strip()
         if line.startswith("locator "):
-            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+            locator_url = line.split('"')[1] if '"' in line else line
+            assert urlsplit(locator_url).hostname == "www.ncbi.nlm.nih.gov", f"non-NCBI locator: {line}"
     assert not (HERE / "brachial_plexus_edge_ground.py").exists()
     assert not (HERE / "brachial-plexus-edge-grounding.json").exists()
     assert not (HERE / "brachial-plexus-edge-manifest.json").exists()

--- a/code/specs/data/mycin-2026/recall/test_cerebral_artery_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_cerebral_artery_recall.py
@@ -24,6 +24,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from urllib.parse import urlsplit
 
 HERE = Path(__file__).resolve().parent
 ADJ = HERE / "cerebral-artery-edges.adj"
@@ -69,7 +70,8 @@ def test_library_is_pure_adj_and_fully_grounded() -> None:
     for line in text.splitlines():
         line = line.strip()
         if line.startswith("locator "):
-            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+            locator_url = line.split('"')[1] if '"' in line else line
+            assert urlsplit(locator_url).hostname == "www.ncbi.nlm.nih.gov", f"non-NCBI locator: {line}"
     assert not (HERE / "cerebral_artery_edge_ground.py").exists()
     assert not (HERE / "cerebral-artery-edge-grounding.json").exists()
     assert not (HERE / "cerebral-artery-edge-manifest.json").exists()

--- a/code/specs/data/mycin-2026/recall/test_collagen_defect_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_collagen_defect_recall.py
@@ -24,6 +24,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from urllib.parse import urlsplit
 
 HERE = Path(__file__).resolve().parent
 ADJ = HERE / "collagen-defect-edges.adj"
@@ -67,7 +68,8 @@ def test_library_is_pure_adj_and_fully_grounded() -> None:
     for line in text.splitlines():
         line = line.strip()
         if line.startswith("locator "):
-            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+            locator_url = line.split('"')[1] if '"' in line else line
+            assert urlsplit(locator_url).hostname == "www.ncbi.nlm.nih.gov", f"non-NCBI locator: {line}"
     assert not (HERE / "collagen_defect_edge_ground.py").exists()
     assert not (HERE / "collagen-defect-edge-grounding.json").exists()
     assert not (HERE / "collagen-defect-edge-manifest.json").exists()

--- a/code/specs/data/mycin-2026/recall/test_complement_protein_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_complement_protein_recall.py
@@ -24,6 +24,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from urllib.parse import urlsplit
 
 HERE = Path(__file__).resolve().parent
 ADJ = HERE / "complement-protein-edges.adj"
@@ -66,7 +67,8 @@ def test_library_is_pure_adj_and_fully_grounded() -> None:
     for line in text.splitlines():
         line = line.strip()
         if line.startswith("locator "):
-            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+            locator_url = line.split('"')[1] if '"' in line else line
+            assert urlsplit(locator_url).hostname == "www.ncbi.nlm.nih.gov", f"non-NCBI locator: {line}"
     assert not (HERE / "complement_protein_edge_ground.py").exists()
     assert not (HERE / "complement-protein-edge-grounding.json").exists()
     assert not (HERE / "complement-protein-edge-manifest.json").exists()

--- a/code/specs/data/mycin-2026/recall/test_conduction_system_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_conduction_system_recall.py
@@ -24,6 +24,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from urllib.parse import urlsplit
 
 HERE = Path(__file__).resolve().parent
 ADJ = HERE / "conduction-system-edges.adj"
@@ -66,7 +67,8 @@ def test_library_is_pure_adj_and_fully_grounded() -> None:
     for line in text.splitlines():
         line = line.strip()
         if line.startswith("locator "):
-            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+            locator_url = line.split('"')[1] if '"' in line else line
+            assert urlsplit(locator_url).hostname == "www.ncbi.nlm.nih.gov", f"non-NCBI locator: {line}"
     assert not (HERE / "conduction_system_edge_ground.py").exists()
     assert not (HERE / "conduction-system-edge-grounding.json").exists()
     assert not (HERE / "conduction-system-edge-manifest.json").exists()

--- a/code/specs/data/mycin-2026/recall/test_coronary_territory_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_coronary_territory_recall.py
@@ -27,6 +27,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from urllib.parse import urlsplit
 
 HERE = Path(__file__).resolve().parent
 ADJ = HERE / "coronary-territory-edges.adj"
@@ -72,7 +73,8 @@ def test_library_is_pure_adj_and_fully_grounded() -> None:
     for line in text.splitlines():
         line = line.strip()
         if line.startswith("locator "):
-            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+            locator_url = line.split('"')[1] if '"' in line else line
+            assert urlsplit(locator_url).hostname == "www.ncbi.nlm.nih.gov", f"non-NCBI locator: {line}"
     assert not (HERE / "coronary_territory_edge_ground.py").exists()
     assert not (HERE / "coronary-territory-edge-grounding.json").exists()
     assert not (HERE / "coronary-territory-edge-manifest.json").exists()

--- a/code/specs/data/mycin-2026/recall/test_cranial_nerve_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_cranial_nerve_recall.py
@@ -22,6 +22,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from urllib.parse import urlsplit
 
 HERE = Path(__file__).resolve().parent
 ADJ = HERE / "cranial-nerve-edges.adj"
@@ -69,7 +70,8 @@ def test_library_is_pure_adj_and_fully_grounded() -> None:
     for line in text.splitlines():
         line = line.strip()
         if line.startswith("locator "):
-            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+            locator_url = line.split('"')[1] if '"' in line else line
+            assert urlsplit(locator_url).hostname == "www.ncbi.nlm.nih.gov", f"non-NCBI locator: {line}"
     assert not (HERE / "cranial_nerve_edge_ground.py").exists()
     assert not (HERE / "cranial-nerve-edge-grounding.json").exists()
     assert not (HERE / "cranial-nerve-edge-manifest.json").exists()

--- a/code/specs/data/mycin-2026/recall/test_diuretic_site_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_diuretic_site_recall.py
@@ -22,6 +22,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from urllib.parse import urlsplit
 
 HERE = Path(__file__).resolve().parent
 ADJ = HERE / "diuretic-site-edges.adj"
@@ -67,7 +68,8 @@ def test_library_is_pure_adj_and_fully_grounded() -> None:
     for line in text.splitlines():
         line = line.strip()
         if line.startswith("locator "):
-            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+            locator_url = line.split('"')[1] if '"' in line else line
+            assert urlsplit(locator_url).hostname == "www.ncbi.nlm.nih.gov", f"non-NCBI locator: {line}"
     assert not (HERE / "diuretic_site_edge_ground.py").exists()
     assert not (HERE / "diuretic-site-edge-grounding.json").exists()
     assert not (HERE / "diuretic-site-edge-manifest.json").exists()

--- a/code/specs/data/mycin-2026/recall/test_dural_sinus_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_dural_sinus_recall.py
@@ -24,6 +24,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from urllib.parse import urlsplit
 
 HERE = Path(__file__).resolve().parent
 ADJ = HERE / "dural-sinus-edges.adj"
@@ -67,7 +68,8 @@ def test_library_is_pure_adj_and_fully_grounded() -> None:
     for line in text.splitlines():
         line = line.strip()
         if line.startswith("locator "):
-            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+            locator_url = line.split('"')[1] if '"' in line else line
+            assert urlsplit(locator_url).hostname == "www.ncbi.nlm.nih.gov", f"non-NCBI locator: {line}"
     assert not (HERE / "dural_sinus_edge_ground.py").exists()
     assert not (HERE / "dural-sinus-edge-grounding.json").exists()
     assert not (HERE / "dural-sinus-edge-manifest.json").exists()

--- a/code/specs/data/mycin-2026/recall/test_ecg_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_ecg_recall.py
@@ -22,6 +22,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from urllib.parse import urlsplit
 
 HERE = Path(__file__).resolve().parent
 ADJ = HERE / "ecg-edges.adj"
@@ -69,7 +70,8 @@ def test_library_is_pure_adj_and_fully_grounded() -> None:
     for line in text.splitlines():
         line = line.strip()
         if line.startswith("locator "):
-            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+            locator_url = line.split('"')[1] if '"' in line else line
+            assert urlsplit(locator_url).hostname == "www.ncbi.nlm.nih.gov", f"non-NCBI locator: {line}"
     assert not (HERE / "ecg_edge_ground.py").exists()
     assert not (HERE / "ecg-edge-grounding.json").exists()
     assert not (HERE / "ecg-edge-manifest.json").exists()

--- a/code/specs/data/mycin-2026/recall/test_embryo_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_embryo_recall.py
@@ -22,6 +22,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from urllib.parse import urlsplit
 
 HERE = Path(__file__).resolve().parent
 ADJ = HERE / "embryo-edges.adj"
@@ -72,7 +73,8 @@ def test_library_is_pure_adj_and_fully_grounded() -> None:
     for line in text.splitlines():
         line = line.strip()
         if line.startswith("locator "):
-            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+            locator_url = line.split('"')[1] if '"' in line else line
+            assert urlsplit(locator_url).hostname == "www.ncbi.nlm.nih.gov", f"non-NCBI locator: {line}"
     assert not (HERE / "embryo_edge_ground.py").exists()
     assert not (HERE / "embryo-edge-grounding.json").exists()
     assert not (HERE / "embryo-edge-manifest.json").exists()

--- a/code/specs/data/mycin-2026/recall/test_enzyme_deficiency_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_enzyme_deficiency_recall.py
@@ -22,6 +22,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from urllib.parse import urlsplit
 
 HERE = Path(__file__).resolve().parent
 ADJ = HERE / "enzyme-deficiency-edges.adj"
@@ -70,7 +71,8 @@ def test_library_is_pure_adj_and_fully_grounded() -> None:
     for line in text.splitlines():
         line = line.strip()
         if line.startswith("locator "):
-            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+            locator_url = line.split('"')[1] if '"' in line else line
+            assert urlsplit(locator_url).hostname == "www.ncbi.nlm.nih.gov", f"non-NCBI locator: {line}"
     assert not (HERE / "enzyme_deficiency_edge_ground.py").exists()
     assert not (HERE / "enzyme-deficiency-edge-grounding.json").exists()
     assert not (HERE / "enzyme-deficiency-edge-manifest.json").exists()

--- a/code/specs/data/mycin-2026/recall/test_epidermis_layer_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_epidermis_layer_recall.py
@@ -24,6 +24,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from urllib.parse import urlsplit
 
 HERE = Path(__file__).resolve().parent
 ADJ = HERE / "epidermis-layer-edges.adj"
@@ -67,7 +68,8 @@ def test_library_is_pure_adj_and_fully_grounded() -> None:
     for line in text.splitlines():
         line = line.strip()
         if line.startswith("locator "):
-            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+            locator_url = line.split('"')[1] if '"' in line else line
+            assert urlsplit(locator_url).hostname == "www.ncbi.nlm.nih.gov", f"non-NCBI locator: {line}"
     assert not (HERE / "epidermis_layer_edge_ground.py").exists()
     assert not (HERE / "epidermis-layer-edge-grounding.json").exists()
     assert not (HERE / "epidermis-layer-edge-manifest.json").exists()

--- a/code/specs/data/mycin-2026/recall/test_exocrine_gland_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_exocrine_gland_recall.py
@@ -25,6 +25,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from urllib.parse import urlsplit
 
 HERE = Path(__file__).resolve().parent
 ADJ = HERE / "exocrine-gland-edges.adj"
@@ -68,7 +69,8 @@ def test_library_is_pure_adj_and_fully_grounded() -> None:
     for line in text.splitlines():
         line = line.strip()
         if line.startswith("locator "):
-            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+            locator_url = line.split('"')[1] if '"' in line else line
+            assert urlsplit(locator_url).hostname == "www.ncbi.nlm.nih.gov", f"non-NCBI locator: {line}"
     assert not (HERE / "exocrine_gland_edge_ground.py").exists()
     assert not (HERE / "exocrine-gland-edge-grounding.json").exists()
     assert not (HERE / "exocrine-gland-edge-manifest.json").exists()

--- a/code/specs/data/mycin-2026/recall/test_exotoxin_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_exotoxin_recall.py
@@ -22,6 +22,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from urllib.parse import urlsplit
 
 HERE = Path(__file__).resolve().parent
 ADJ = HERE / "exotoxin-edges.adj"
@@ -69,7 +70,8 @@ def test_library_is_pure_adj_and_fully_grounded() -> None:
     for line in text.splitlines():
         line = line.strip()
         if line.startswith("locator "):
-            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+            locator_url = line.split('"')[1] if '"' in line else line
+            assert urlsplit(locator_url).hostname == "www.ncbi.nlm.nih.gov", f"non-NCBI locator: {line}"
     assert not (HERE / "exotoxin_edge_ground.py").exists()
     assert not (HERE / "exotoxin-edge-grounding.json").exists()
     assert not (HERE / "exotoxin-edge-manifest.json").exists()

--- a/code/specs/data/mycin-2026/recall/test_fetal_shunt_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_fetal_shunt_recall.py
@@ -24,6 +24,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from urllib.parse import urlsplit
 
 HERE = Path(__file__).resolve().parent
 ADJ = HERE / "fetal-shunt-edges.adj"
@@ -68,7 +69,8 @@ def test_library_is_pure_adj_and_fully_grounded() -> None:
     for line in text.splitlines():
         line = line.strip()
         if line.startswith("locator "):
-            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+            locator_url = line.split('"')[1] if '"' in line else line
+            assert urlsplit(locator_url).hostname == "www.ncbi.nlm.nih.gov", f"non-NCBI locator: {line}"
     assert not (HERE / "fetal_shunt_edge_ground.py").exists()
     assert not (HERE / "fetal-shunt-edge-grounding.json").exists()
     assert not (HERE / "fetal-shunt-edge-manifest.json").exists()

--- a/code/specs/data/mycin-2026/recall/test_germ_layer_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_germ_layer_recall.py
@@ -24,6 +24,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from urllib.parse import urlsplit
 
 HERE = Path(__file__).resolve().parent
 ADJ = HERE / "germ-layer-edges.adj"
@@ -65,7 +66,8 @@ def test_library_is_pure_adj_and_fully_grounded() -> None:
     for line in text.splitlines():
         line = line.strip()
         if line.startswith("locator "):
-            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+            locator_url = line.split('"')[1] if '"' in line else line
+            assert urlsplit(locator_url).hostname == "www.ncbi.nlm.nih.gov", f"non-NCBI locator: {line}"
     assert not (HERE / "germ_layer_edge_ground.py").exists()
     assert not (HERE / "germ-layer-edge-grounding.json").exists()
     assert not (HERE / "germ-layer-edge-manifest.json").exists()

--- a/code/specs/data/mycin-2026/recall/test_gi_hormone_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_gi_hormone_recall.py
@@ -23,6 +23,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from urllib.parse import urlsplit
 
 HERE = Path(__file__).resolve().parent
 ADJ = HERE / "gi-hormone-edges.adj"
@@ -65,7 +66,8 @@ def test_library_is_pure_adj_and_fully_grounded() -> None:
     for line in text.splitlines():
         line = line.strip()
         if line.startswith("locator "):
-            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+            locator_url = line.split('"')[1] if '"' in line else line
+            assert urlsplit(locator_url).hostname == "www.ncbi.nlm.nih.gov", f"non-NCBI locator: {line}"
     assert not (HERE / "gi_hormone_edge_ground.py").exists()
     assert not (HERE / "gi-hormone-edge-grounding.json").exists()
     assert not (HERE / "gi-hormone-edge-manifest.json").exists()

--- a/code/specs/data/mycin-2026/recall/test_gi_wall_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_gi_wall_recall.py
@@ -24,6 +24,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from urllib.parse import urlsplit
 
 HERE = Path(__file__).resolve().parent
 ADJ = HERE / "gi-wall-edges.adj"
@@ -66,7 +67,8 @@ def test_library_is_pure_adj_and_fully_grounded() -> None:
     for line in text.splitlines():
         line = line.strip()
         if line.startswith("locator "):
-            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+            locator_url = line.split('"')[1] if '"' in line else line
+            assert urlsplit(locator_url).hostname == "www.ncbi.nlm.nih.gov", f"non-NCBI locator: {line}"
     assert not (HERE / "gi_wall_edge_ground.py").exists()
     assert not (HERE / "gi-wall-edge-grounding.json").exists()
     assert not (HERE / "gi-wall-edge-manifest.json").exists()

--- a/code/specs/data/mycin-2026/recall/test_glycogen_storage_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_glycogen_storage_recall.py
@@ -23,6 +23,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from urllib.parse import urlsplit
 
 HERE = Path(__file__).resolve().parent
 ADJ = HERE / "glycogen-storage-edges.adj"
@@ -65,7 +66,8 @@ def test_library_is_pure_adj_and_fully_grounded() -> None:
     for line in text.splitlines():
         line = line.strip()
         if line.startswith("locator "):
-            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+            locator_url = line.split('"')[1] if '"' in line else line
+            assert urlsplit(locator_url).hostname == "www.ncbi.nlm.nih.gov", f"non-NCBI locator: {line}"
     assert not (HERE / "glycogen_storage_edge_ground.py").exists()
     assert not (HERE / "glycogen-storage-edge-grounding.json").exists()
     assert not (HERE / "glycogen-storage-edge-manifest.json").exists()

--- a/code/specs/data/mycin-2026/recall/test_heart_valve_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_heart_valve_recall.py
@@ -23,6 +23,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from urllib.parse import urlsplit
 
 HERE = Path(__file__).resolve().parent
 ADJ = HERE / "heart-valve-edges.adj"
@@ -65,7 +66,8 @@ def test_library_is_pure_adj_and_fully_grounded() -> None:
     for line in text.splitlines():
         line = line.strip()
         if line.startswith("locator "):
-            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+            locator_url = line.split('"')[1] if '"' in line else line
+            assert urlsplit(locator_url).hostname == "www.ncbi.nlm.nih.gov", f"non-NCBI locator: {line}"
     assert not (HERE / "heart_valve_edge_ground.py").exists()
     assert not (HERE / "heart-valve-edge-grounding.json").exists()
     assert not (HERE / "heart-valve-edge-manifest.json").exists()

--- a/code/specs/data/mycin-2026/recall/test_hypersensitivity_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_hypersensitivity_recall.py
@@ -23,6 +23,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from urllib.parse import urlsplit
 
 HERE = Path(__file__).resolve().parent
 ADJ = HERE / "hypersensitivity-edges.adj"
@@ -65,7 +66,8 @@ def test_library_is_pure_adj_and_fully_grounded() -> None:
     for line in text.splitlines():
         line = line.strip()
         if line.startswith("locator "):
-            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+            locator_url = line.split('"')[1] if '"' in line else line
+            assert urlsplit(locator_url).hostname == "www.ncbi.nlm.nih.gov", f"non-NCBI locator: {line}"
     assert not (HERE / "hypersensitivity_edge_ground.py").exists()
     assert not (HERE / "hypersensitivity-edge-grounding.json").exists()
     assert not (HERE / "hypersensitivity-edge-manifest.json").exists()

--- a/code/specs/data/mycin-2026/recall/test_hypothalamic_hormone_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_hypothalamic_hormone_recall.py
@@ -26,6 +26,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from urllib.parse import urlsplit
 
 HERE = Path(__file__).resolve().parent
 ADJ = HERE / "hypothalamic-hormone-edges.adj"
@@ -69,7 +70,8 @@ def test_library_is_pure_adj_and_fully_grounded() -> None:
     for line in text.splitlines():
         line = line.strip()
         if line.startswith("locator "):
-            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+            locator_url = line.split('"')[1] if '"' in line else line
+            assert urlsplit(locator_url).hostname == "www.ncbi.nlm.nih.gov", f"non-NCBI locator: {line}"
     assert not (HERE / "hypothalamic_hormone_edge_ground.py").exists()
     assert not (HERE / "hypothalamic-hormone-edge-grounding.json").exists()
     assert not (HERE / "hypothalamic-hormone-edge-manifest.json").exists()

--- a/code/specs/data/mycin-2026/recall/test_ig_isotype_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_ig_isotype_recall.py
@@ -24,6 +24,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from urllib.parse import urlsplit
 
 HERE = Path(__file__).resolve().parent
 ADJ = HERE / "ig-isotype-edges.adj"
@@ -66,7 +67,8 @@ def test_library_is_pure_adj_and_fully_grounded() -> None:
     for line in text.splitlines():
         line = line.strip()
         if line.startswith("locator "):
-            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+            locator_url = line.split('"')[1] if '"' in line else line
+            assert urlsplit(locator_url).hostname == "www.ncbi.nlm.nih.gov", f"non-NCBI locator: {line}"
     assert not (HERE / "ig_isotype_edge_ground.py").exists()
     assert not (HERE / "ig-isotype-edge-grounding.json").exists()
     assert not (HERE / "ig-isotype-edge-manifest.json").exists()

--- a/code/specs/data/mycin-2026/recall/test_islet_cell_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_islet_cell_recall.py
@@ -23,6 +23,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from urllib.parse import urlsplit
 
 HERE = Path(__file__).resolve().parent
 ADJ = HERE / "islet-cell-edges.adj"
@@ -66,7 +67,8 @@ def test_library_is_pure_adj_and_fully_grounded() -> None:
     for line in text.splitlines():
         line = line.strip()
         if line.startswith("locator "):
-            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+            locator_url = line.split('"')[1] if '"' in line else line
+            assert urlsplit(locator_url).hostname == "www.ncbi.nlm.nih.gov", f"non-NCBI locator: {line}"
     assert not (HERE / "islet_cell_edge_ground.py").exists()
     assert not (HERE / "islet-cell-edge-grounding.json").exists()
     assert not (HERE / "islet-cell-edge-manifest.json").exists()

--- a/code/specs/data/mycin-2026/recall/test_lung_volume_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_lung_volume_recall.py
@@ -23,6 +23,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from urllib.parse import urlsplit
 
 HERE = Path(__file__).resolve().parent
 ADJ = HERE / "lung-volume-edges.adj"
@@ -66,7 +67,8 @@ def test_library_is_pure_adj_and_fully_grounded() -> None:
     for line in text.splitlines():
         line = line.strip()
         if line.startswith("locator "):
-            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+            locator_url = line.split('"')[1] if '"' in line else line
+            assert urlsplit(locator_url).hostname == "www.ncbi.nlm.nih.gov", f"non-NCBI locator: {line}"
     assert not (HERE / "lung_volume_edge_ground.py").exists()
     assert not (HERE / "lung-volume-edge-grounding.json").exists()
     assert not (HERE / "lung-volume-edge-manifest.json").exists()

--- a/code/specs/data/mycin-2026/recall/test_lysosomal_storage_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_lysosomal_storage_recall.py
@@ -24,6 +24,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from urllib.parse import urlsplit
 
 HERE = Path(__file__).resolve().parent
 ADJ = HERE / "lysosomal-storage-edges.adj"
@@ -69,7 +70,8 @@ def test_library_is_pure_adj_and_fully_grounded() -> None:
     for line in text.splitlines():
         line = line.strip()
         if line.startswith("locator "):
-            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+            locator_url = line.split('"')[1] if '"' in line else line
+            assert urlsplit(locator_url).hostname == "www.ncbi.nlm.nih.gov", f"non-NCBI locator: {line}"
     assert not (HERE / "lysosomal_storage_edge_ground.py").exists()
     assert not (HERE / "lysosomal-storage-edge-grounding.json").exists()
     assert not (HERE / "lysosomal-storage-edge-manifest.json").exists()

--- a/code/specs/data/mycin-2026/recall/test_msk_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_msk_recall.py
@@ -22,6 +22,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from urllib.parse import urlsplit
 
 HERE = Path(__file__).resolve().parent
 ADJ = HERE / "msk-edges.adj"
@@ -70,7 +71,8 @@ def test_library_is_pure_adj_and_fully_grounded() -> None:
     for line in text.splitlines():
         line = line.strip()
         if line.startswith("locator "):
-            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+            locator_url = line.split('"')[1] if '"' in line else line
+            assert urlsplit(locator_url).hostname == "www.ncbi.nlm.nih.gov", f"non-NCBI locator: {line}"
     assert not (HERE / "msk_edge_ground.py").exists()
     assert not (HERE / "msk-edge-grounding.json").exists()
     assert not (HERE / "msk-edge-manifest.json").exists()

--- a/code/specs/data/mycin-2026/recall/test_muscle_fiber_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_muscle_fiber_recall.py
@@ -25,6 +25,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from urllib.parse import urlsplit
 
 HERE = Path(__file__).resolve().parent
 ADJ = HERE / "muscle-fiber-edges.adj"
@@ -66,7 +67,8 @@ def test_library_is_pure_adj_and_fully_grounded() -> None:
     for line in text.splitlines():
         line = line.strip()
         if line.startswith("locator "):
-            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+            locator_url = line.split('"')[1] if '"' in line else line
+            assert urlsplit(locator_url).hostname == "www.ncbi.nlm.nih.gov", f"non-NCBI locator: {line}"
     assert not (HERE / "muscle_fiber_edge_ground.py").exists()
     assert not (HERE / "muscle-fiber-edge-grounding.json").exists()
     assert not (HERE / "muscle-fiber-edge-manifest.json").exists()

--- a/code/specs/data/mycin-2026/recall/test_nephron_transporter_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_nephron_transporter_recall.py
@@ -26,6 +26,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from urllib.parse import urlsplit
 
 HERE = Path(__file__).resolve().parent
 ADJ = HERE / "nephron-transporter-edges.adj"
@@ -72,7 +73,8 @@ def test_library_is_pure_adj_and_fully_grounded() -> None:
     for line in text.splitlines():
         line = line.strip()
         if line.startswith("locator "):
-            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+            locator_url = line.split('"')[1] if '"' in line else line
+            assert urlsplit(locator_url).hostname == "www.ncbi.nlm.nih.gov", f"non-NCBI locator: {line}"
     assert not (HERE / "nephron_transporter_edge_ground.py").exists()
     assert not (HERE / "nephron-transporter-edge-grounding.json").exists()
     assert not (HERE / "nephron-transporter-edge-manifest.json").exists()

--- a/code/specs/data/mycin-2026/recall/test_nerve_injury_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_nerve_injury_recall.py
@@ -22,6 +22,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from urllib.parse import urlsplit
 
 HERE = Path(__file__).resolve().parent
 ADJ = HERE / "nerve-injury-edges.adj"
@@ -70,7 +71,8 @@ def test_library_is_pure_adj_and_fully_grounded() -> None:
     for line in text.splitlines():
         line = line.strip()
         if line.startswith("locator "):
-            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+            locator_url = line.split('"')[1] if '"' in line else line
+            assert urlsplit(locator_url).hostname == "www.ncbi.nlm.nih.gov", f"non-NCBI locator: {line}"
     assert not (HERE / "nerve_injury_edge_ground.py").exists()
     assert not (HERE / "nerve-injury-edge-grounding.json").exists()
     assert not (HERE / "nerve-injury-edge-manifest.json").exists()

--- a/code/specs/data/mycin-2026/recall/test_organelle_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_organelle_recall.py
@@ -23,6 +23,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from urllib.parse import urlsplit
 
 HERE = Path(__file__).resolve().parent
 ADJ = HERE / "organelle-edges.adj"
@@ -67,7 +68,8 @@ def test_library_is_pure_adj_and_fully_grounded() -> None:
     for line in text.splitlines():
         line = line.strip()
         if line.startswith("locator "):
-            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+            locator_url = line.split('"')[1] if '"' in line else line
+            assert urlsplit(locator_url).hostname == "www.ncbi.nlm.nih.gov", f"non-NCBI locator: {line}"
     assert not (HERE / "organelle_edge_ground.py").exists()
     assert not (HERE / "organelle-edge-grounding.json").exists()
     assert not (HERE / "organelle-edge-manifest.json").exists()

--- a/code/specs/data/mycin-2026/recall/test_pharyngeal_arch_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_pharyngeal_arch_recall.py
@@ -24,6 +24,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from urllib.parse import urlsplit
 
 HERE = Path(__file__).resolve().parent
 ADJ = HERE / "pharyngeal-arch-edges.adj"
@@ -67,7 +68,8 @@ def test_library_is_pure_adj_and_fully_grounded() -> None:
     for line in text.splitlines():
         line = line.strip()
         if line.startswith("locator "):
-            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+            locator_url = line.split('"')[1] if '"' in line else line
+            assert urlsplit(locator_url).hostname == "www.ncbi.nlm.nih.gov", f"non-NCBI locator: {line}"
     assert not (HERE / "pharyngeal_arch_edge_ground.py").exists()
     assert not (HERE / "pharyngeal-arch-edge-grounding.json").exists()
     assert not (HERE / "pharyngeal-arch-edge-manifest.json").exists()

--- a/code/specs/data/mycin-2026/recall/test_pituitary_hormone_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_pituitary_hormone_recall.py
@@ -24,6 +24,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from urllib.parse import urlsplit
 
 HERE = Path(__file__).resolve().parent
 ADJ = HERE / "pituitary-hormone-edges.adj"
@@ -68,7 +69,8 @@ def test_library_is_pure_adj_and_fully_grounded() -> None:
     for line in text.splitlines():
         line = line.strip()
         if line.startswith("locator "):
-            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+            locator_url = line.split('"')[1] if '"' in line else line
+            assert urlsplit(locator_url).hostname == "www.ncbi.nlm.nih.gov", f"non-NCBI locator: {line}"
     assert not (HERE / "pituitary_hormone_edge_ground.py").exists()
     assert not (HERE / "pituitary-hormone-edge-grounding.json").exists()
     assert not (HERE / "pituitary-hormone-edge-manifest.json").exists()

--- a/code/specs/data/mycin-2026/recall/test_psych_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_psych_recall.py
@@ -22,6 +22,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from urllib.parse import urlsplit
 
 HERE = Path(__file__).resolve().parent
 ADJ = HERE / "psych-edges.adj"
@@ -67,7 +68,8 @@ def test_library_is_pure_adj_and_fully_grounded() -> None:
     for line in text.splitlines():
         line = line.strip()
         if line.startswith("locator "):
-            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+            locator_url = line.split('"')[1] if '"' in line else line
+            assert urlsplit(locator_url).hostname == "www.ncbi.nlm.nih.gov", f"non-NCBI locator: {line}"
     assert not (HERE / "psych_edge_ground.py").exists()
     assert not (HERE / "psych-edge-grounding.json").exists()
     assert not (HERE / "psych-edge-manifest.json").exists()

--- a/code/specs/data/mycin-2026/recall/test_ratelimit_enzyme_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_ratelimit_enzyme_recall.py
@@ -24,6 +24,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from urllib.parse import urlsplit
 
 HERE = Path(__file__).resolve().parent
 ADJ = HERE / "ratelimit-enzyme-edges.adj"
@@ -70,7 +71,8 @@ def test_library_is_pure_adj_and_fully_grounded() -> None:
     for line in text.splitlines():
         line = line.strip()
         if line.startswith("locator "):
-            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+            locator_url = line.split('"')[1] if '"' in line else line
+            assert urlsplit(locator_url).hostname == "www.ncbi.nlm.nih.gov", f"non-NCBI locator: {line}"
     assert not (HERE / "ratelimit_enzyme_edge_ground.py").exists()
     assert not (HERE / "ratelimit-enzyme-edge-grounding.json").exists()
     assert not (HERE / "ratelimit-enzyme-edge-manifest.json").exists()

--- a/code/specs/data/mycin-2026/recall/test_spinal_tract_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_spinal_tract_recall.py
@@ -24,6 +24,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from urllib.parse import urlsplit
 
 HERE = Path(__file__).resolve().parent
 ADJ = HERE / "spinal-tract-edges.adj"
@@ -68,7 +69,8 @@ def test_library_is_pure_adj_and_fully_grounded() -> None:
     for line in text.splitlines():
         line = line.strip()
         if line.startswith("locator "):
-            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+            locator_url = line.split('"')[1] if '"' in line else line
+            assert urlsplit(locator_url).hostname == "www.ncbi.nlm.nih.gov", f"non-NCBI locator: {line}"
     assert not (HERE / "spinal_tract_edge_ground.py").exists()
     assert not (HERE / "spinal-tract-edge-grounding.json").exists()
     assert not (HERE / "spinal-tract-edge-manifest.json").exists()

--- a/code/specs/data/mycin-2026/recall/test_tox_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_tox_recall.py
@@ -22,6 +22,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from urllib.parse import urlsplit
 
 HERE = Path(__file__).resolve().parent
 ADJ = HERE / "tox-edges.adj"
@@ -67,7 +68,8 @@ def test_library_is_pure_adj_and_fully_grounded() -> None:
     for line in text.splitlines():
         line = line.strip()
         if line.startswith("locator "):
-            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+            locator_url = line.split('"')[1] if '"' in line else line
+            assert urlsplit(locator_url).hostname == "www.ncbi.nlm.nih.gov", f"non-NCBI locator: {line}"
     assert not (HERE / "tox_edge_ground.py").exists()
     assert not (HERE / "tox-edge-grounding.json").exists()
     assert not (HERE / "tox-edge-manifest.json").exists()

--- a/code/specs/data/mycin-2026/recall/test_urine_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_urine_recall.py
@@ -22,6 +22,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from urllib.parse import urlsplit
 
 HERE = Path(__file__).resolve().parent
 ADJ = HERE / "urine-edges.adj"
@@ -68,7 +69,8 @@ def test_library_is_pure_adj_and_fully_grounded() -> None:
     for line in text.splitlines():
         line = line.strip()
         if line.startswith("locator "):
-            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+            locator_url = line.split('"')[1] if '"' in line else line
+            assert urlsplit(locator_url).hostname == "www.ncbi.nlm.nih.gov", f"non-NCBI locator: {line}"
     assert not (HERE / "urine_edge_ground.py").exists()
     assert not (HERE / "urine-edge-grounding.json").exists()
     assert not (HERE / "urine-edge-manifest.json").exists()

--- a/code/specs/data/mycin-2026/recall/test_vitamin_activation_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_vitamin_activation_recall.py
@@ -24,6 +24,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from urllib.parse import urlsplit
 
 HERE = Path(__file__).resolve().parent
 ADJ = HERE / "vitamin-activation-edges.adj"
@@ -66,7 +67,8 @@ def test_library_is_pure_adj_and_fully_grounded() -> None:
     for line in text.splitlines():
         line = line.strip()
         if line.startswith("locator "):
-            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+            locator_url = line.split('"')[1] if '"' in line else line
+            assert urlsplit(locator_url).hostname == "www.ncbi.nlm.nih.gov", f"non-NCBI locator: {line}"
     assert not (HERE / "vitamin_activation_edge_ground.py").exists()
     assert not (HERE / "vitamin-activation-edge-grounding.json").exists()
     assert not (HERE / "vitamin-activation-edge-manifest.json").exists()

--- a/code/specs/data/mycin-2026/recall/test_wbc_recall.py
+++ b/code/specs/data/mycin-2026/recall/test_wbc_recall.py
@@ -23,6 +23,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from urllib.parse import urlsplit
 
 HERE = Path(__file__).resolve().parent
 ADJ = HERE / "wbc-edges.adj"
@@ -66,7 +67,8 @@ def test_library_is_pure_adj_and_fully_grounded() -> None:
     for line in text.splitlines():
         line = line.strip()
         if line.startswith("locator "):
-            assert "https://www.ncbi.nlm.nih.gov/" in line, f"non-NCBI locator: {line}"
+            locator_url = line.split('"')[1] if '"' in line else line
+            assert urlsplit(locator_url).hostname == "www.ncbi.nlm.nih.gov", f"non-NCBI locator: {line}"
     assert not (HERE / "wbc_edge_ground.py").exists()
     assert not (HERE / "wbc-edge-grounding.json").exists()
     assert not (HERE / "wbc-edge-manifest.json").exists()


### PR DESCRIPTION
Resolves the open CodeQL code-scanning alerts (58 total) across four rules.

## Code fixes (46 files)

**`py/incomplete-url-substring-sanitization` — 45 alerts (recall test files)**
Replaced the substring check `"https://www.ncbi.nlm.nih.gov/" in line` with a
proper host comparison:
```python
locator_url = line.split('"')[1] if '"' in line else line
assert urlsplit(locator_url).hostname == "www.ncbi.nlm.nih.gov", ...
```
`urlsplit().hostname` lowercases and strips userinfo/port, so spoofs like
`...ncbi.nlm.nih.gov.evil.com` or `evil.com/?x=...ncbi...` are rejected. This is
strictly tighter than the old check and makes the locator-provenance assertion
correct, not merely present-as-substring.

**`js/xss-through-dom` — 1 alert (`visicalc-html/infinite.html`)**
The find/replace terms are user-controlled. They now append via
`document.createTextNode(...)` (a text node can never be parsed as markup)
instead of concatenating into `innerHTML`. The static separator still uses
`insertAdjacentHTML` with a literal string — no taint reaches it.

## Dismissed as won't-fix (12 alerts)

`py/clear-text-logging-sensitive-data` (11) + `py/clear-text-storage-sensitive-data` (1)
in the `mycin-2026/fhir` and `warm` demos. These are educational CLIs that
print/serialize a FHIR chart from **synthetic fixtures** — displaying the chart
is the tool's entire purpose and the data never leaves the machine. CodeQL keys
on medically-shaped field names. Dismissed via the code-scanning API with
justification.

## Verification
- File-shape tests exercising the changed assert pass.
- `ruff check` clean on all 45 changed test files.
- Security-review sub-agent: **PASSED — no vulnerabilities found** (1 round).

🤖 Generated with [Claude Code](https://claude.com/claude-code)