### PR TITLE
feat(latex): \bmod / \pmod modulo in latex "…" — new ComputeOp::Mod

### DIFF
--- a/code/packages/rust/adj-lang/CHANGELOG.md
+++ b/code/packages/rust/adj-lang/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.32.0] - 2026-07-02 — `\bmod` / `\pmod` modulo in `latex "…"`
+
+### Added
+
+- `latex "a \bmod b"` and `latex "a \pmod{b}"` now compute the **modulo** `a mod b`
+  (the remainder with the sign of the dividend). New `ArithOp::Mod` lowers to the new
+  `logic_engine::ComputeOp::Mod`. `\bmod`/`\pmod` are not in the frontend's operator
+  tables, so they parse as a bare `Symbol("bmod")`/`Symbol("pmod")` inside an implicit
+  multiplication — `a \bmod b` → `Bin(Mul, Bin(Mul, a, bmod), b)`. The adapter
+  recognises that operator-name-juxtaposition shape (the same technique used for
+  `\operatorname{trunc}(x)`) via a `mod_juxtaposition_lhs` helper and lowers it to
+  `a mod b`. The arm sits above the general `Bin(Mul, …)` so genuine products still
+  multiply; the congruence form `x \equiv y \pmod{n}` parses as a rejected `Rel(Equiv)`,
+  so only the direct remainder computes — never a mis-lowered congruence. +adapter and
+  lower unit tests.
+
 ## [0.31.0] - 2026-07-02 — n-ary `\min`/`\max`/`\gcd`/`\lcm` in `latex "…"`
 
 ### Changed

--- a/code/packages/rust/adj-lang/Cargo.toml
+++ b/code/packages/rust/adj-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang"
-version = "0.31.0"
+version = "0.32.0"
 edition = "2021"
 description = "Surface-syntax frontend for the adjudication framework's probabilistic-logic rulebooks. Lexes, parses, and lowers a domain-expert-readable DSL into a `logic-engine` KnowledgeBase. Dissolves ADJ46 awkwardness items A10 (rulebook syntax) and A4 (joint contributions syntactically distinct)."
 

--- a/code/packages/rust/adj-lang/src/adapter.rs
+++ b/code/packages/rust/adj-lang/src/adapter.rs
@@ -973,6 +973,26 @@ fn latex_math_to_expr_ast(expr: &MathExpr, source: &str) -> Result<ExprAst, Adap
         MathExpr::Bin(BinOp::Mul, lhs, rhs) if operator_name_is(lhs, "trunc") => {
             Ok(ExprAst::Trunc(Box::new(latex_math_to_expr_ast(rhs, source)?)))
         }
+        // `a \bmod b` / `a \pmod{b}` — the modulo operator. `\bmod`/`\pmod` are not in
+        // the frontend's operator tables, so they lower to a bare `Symbol("bmod")` /
+        // `Symbol("pmod")` and the whole expression parses as a LEFT-associated implicit
+        // multiplication (juxtaposition): `a \bmod b` → `Bin(Mul, Bin(Mul, a, bmod), b)`.
+        // We recognise that exact shape — the operator-name-juxtaposition path, just like
+        // `\operatorname{trunc}(x)` above — and lower it to `ArithOp::Mod` (→
+        // `ComputeOp::Mod`): `real_lhs mod rhs`. This arm sits ABOVE the general
+        // `Bin(Mul, …)` so a genuine product (`2x`) still multiplies; only the
+        // `bmod`/`pmod` marker as the RIGHT factor of the LEFT operand is intercepted.
+        // (The congruence form `x \equiv y \pmod{n}` parses as a `Rel(Equiv, …)`, which
+        // the ADJ arithmetic subset rejects — so only the direct `a \bmod b` /
+        // `a \pmod{b}` remainder computes, never a mis-lowered congruence.)
+        MathExpr::Bin(BinOp::Mul, lhs, rhs) if mod_juxtaposition_lhs(lhs).is_some() => {
+            let real_lhs = mod_juxtaposition_lhs(lhs).expect("guard checked Some");
+            Ok(ExprAst::Bin(
+                ArithOp::Mod,
+                Box::new(latex_math_to_expr_ast(real_lhs, source)?),
+                Box::new(latex_math_to_expr_ast(rhs, source)?),
+            ))
+        }
         MathExpr::Bin(BinOp::Mul, lhs, rhs) => latex_bin(ArithOp::Mul, lhs, rhs, source),
         MathExpr::Bin(BinOp::Div, lhs, rhs) | MathExpr::Frac(lhs, rhs) => {
             latex_bin(ArithOp::Div, lhs, rhs, source)
@@ -1113,6 +1133,20 @@ fn latex_math_to_expr_ast(expr: &MathExpr, source: &str) -> Result<ExprAst, Adap
 /// `\operatorname{trunc}` and `\operatorname{ trunc }` both count.
 fn operator_name_is(expr: &MathExpr, name: &str) -> bool {
     matches!(expr, MathExpr::Text(s) if s.trim() == name)
+}
+
+/// Is `expr` the LEFT operand of a `\bmod`/`\pmod` juxtaposition — i.e.
+/// `Bin(Mul, real_lhs, Symbol("bmod"|"pmod"))`? The frontend has no operator table
+/// entry for `\bmod`/`\pmod`, so it lowers them to a bare `Symbol` that ends up as the
+/// right factor of the left operand of the surrounding implicit multiplication. If the
+/// shape matches, return `real_lhs` (the dividend expression); otherwise `None`.
+fn mod_juxtaposition_lhs(expr: &MathExpr) -> Option<&MathExpr> {
+    if let MathExpr::Bin(BinOp::Mul, real_lhs, marker) = expr {
+        if matches!(marker.as_ref(), MathExpr::Symbol(s) if s == "bmod" || s == "pmod") {
+            return Some(real_lhs);
+        }
+    }
+    None
 }
 
 fn latex_bin(

--- a/code/packages/rust/adj-lang/src/ast.rs
+++ b/code/packages/rust/adj-lang/src/ast.rs
@@ -81,6 +81,13 @@ pub enum ArithOp {
     /// for `x^n` (lowered to `logic_engine::ComputeOp::Pow`); the surface
     /// arithmetic grammar does not yet spell `^` directly.
     Pow,
+    /// Modulo, `a mod b` — the remainder carrying the sign of the dividend
+    /// (`7 mod 3 = 1`, `−7 mod 3 = −1`). Produced by the `latex "…"` adapter for
+    /// `a \bmod b` / `a \pmod{b}` (lowered to `logic_engine::ComputeOp::Mod`); the
+    /// surface arithmetic grammar does not spell `mod` directly. Like the engine op
+    /// it combines dimensionally like addition (operands share a dimension, the
+    /// remainder carries it) and rejects a zero divisor.
+    Mod,
 }
 
 /// A named **transcendental** function in a `let` formula — the curated

--- a/code/packages/rust/adj-lang/src/lower.rs
+++ b/code/packages/rust/adj-lang/src/lower.rs
@@ -756,6 +756,7 @@ fn lower_arith_op(op: ArithOp) -> ComputeOp {
         ArithOp::Mul => ComputeOp::Mul,
         ArithOp::Div => ComputeOp::Div,
         ArithOp::Pow => ComputeOp::Pow,
+        ArithOp::Mod => ComputeOp::Mod,
     }
 }
 
@@ -1970,6 +1971,53 @@ contributes 1000000 from answer == 60 to correct
         )
         .unwrap();
         assert!(d.ranked[0].posterior > 0.99, "{d:?}");
+    }
+
+    #[test]
+    fn native_latex_bmod_computes_the_remainder() {
+        // `a \bmod b` with a=7, b=3 is 7 mod 3 = 1, computed on the native
+        // ComputeOp::Mod via the operator-name-juxtaposition path: `\bmod` has no
+        // operator-table entry, so it lowers to Symbol("bmod") inside the implicit
+        // multiplication `Bin(Mul, Bin(Mul, a, bmod), b)`, which the adapter
+        // recognises as `a mod b` — NOT the bare product `a * bmod * b`.
+        let d = crate::compile_and_decide(
+            "observe a(7)\n\
+             observe b(3)\n\
+             let answer = latex \"$a \\bmod b$\"\n\
+             prior 0.10 for correct\n\
+             contributes 1000000 from answer == 1 to correct\n\
+             ? correct\n",
+        )
+        .unwrap();
+        assert!(d.ranked[0].posterior > 0.99, "{d:?}");
+    }
+
+    #[test]
+    fn native_latex_pmod_matches_bmod_and_carries_the_dividend_sign() {
+        // `a \pmod{b}` computes the same remainder as `\bmod` (a=7, b=3 → 1); and a
+        // negative dividend keeps its sign — `(0 − a) \bmod b` = −7 mod 3 = −1 (Rust
+        // `%`), the whole point of ComputeOp::Mod versus a Euclidean/floored modulo
+        // (which would give +2).
+        let p = crate::compile_and_decide(
+            "observe a(7)\n\
+             observe b(3)\n\
+             let answer = latex \"$a \\pmod{b}$\"\n\
+             prior 0.10 for correct\n\
+             contributes 1000000 from answer == 1 to correct\n\
+             ? correct\n",
+        )
+        .unwrap();
+        assert!(p.ranked[0].posterior > 0.99, "{p:?}");
+        let neg = crate::compile_and_decide(
+            "observe a(7)\n\
+             observe b(3)\n\
+             let answer = latex \"$(0 - a) \\bmod b$\"\n\
+             prior 0.10 for correct\n\
+             contributes 1000000 from answer == -1 to correct\n\
+             ? correct\n",
+        )
+        .unwrap();
+        assert!(neg.ranked[0].posterior > 0.99, "{neg:?}");
     }
 
     #[test]

--- a/code/packages/rust/logic-engine/CHANGELOG.md
+++ b/code/packages/rust/logic-engine/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.36.0] - 2026-07-02 — binary modulo (`Mod`)
+
+### Added
+
+- `ComputeOp::Mod` — binary modulo `a mod b`, the remainder carrying the **sign of
+  the dividend** (`7 mod 3 = 1`, `−7 mod 3 = −1`, `7.5 mod 2 = 1.5`), matching Rust's
+  `f64::%` (truncated division / C `fmod`). Folded into the **existing** general binary
+  `eval` arm next to `Div` (a single inline expression — no extra locals on the
+  deeply-recursive path, preserving the clean-`TooDeep`-never-overflow contract):
+  dimensionally it combines like addition (both operands must share a dimension and the
+  remainder carries it — `7 mmol mod 3 mmol = 1 mmol`, while `7 mmol mod 3` is a category
+  error), a zero divisor is a clean `DivisionByZero` (never a `NaN`), and — unlike
+  `Gcd`/`Lcm` — it does **not** require integer operands. The exact-rational sidecar is
+  dropped (the `f64` remainder already carries the value). This makes a LaTeX
+  `a \bmod b` / `a \pmod{b}` (adj-lang's `latex "…"` surface) computable as a single
+  native node. `symbol()` renders it `"mod"`. +4 unit tests (remainder + dimension
+  preservation, sign-of-dividend / real operands, zero-divisor error, dimension
+  mismatch).
+
 ## [0.35.0] - 2026-07-02 — truncation toward zero (`Trunc`)
 
 ### Added

--- a/code/packages/rust/logic-engine/Cargo.toml
+++ b/code/packages/rust/logic-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logic-engine"
-version = "0.35.0"
+version = "0.36.0"
 edition = "2021"
 description = "Probability-aware facts, rules, KB, SLD find-first/enumerate + WMC posterior + LP19e likelihood-ratio Bayesian aggregation."
 

--- a/code/packages/rust/logic-engine/src/compute.rs
+++ b/code/packages/rust/logic-engine/src/compute.rs
@@ -281,6 +281,19 @@ pub enum ComputeOp {
     /// exact-rational sidecar is dropped (the f64 already carries it).
     Gcd,
     Lcm,
+    /// Binary **modulo** — `a mod b`, the remainder of `a` divided by `b` carrying
+    /// the **sign of the dividend** (`7 mod 3 = 1`, `−7 mod 3 = −1`, `7.5 mod 2 = 1.5`),
+    /// matching Rust's `f64::%` (truncated division, C `fmod`). Lowered from a LaTeX
+    /// `a \bmod b` / `a \pmod{b}` (adj-lang's `latex "…"` surface). Reuses the general
+    /// binary path like [`ComputeOp::Div`]: dimensionally it combines like addition —
+    /// both operands must share a dimension and the remainder carries it
+    /// (`7 mmol mod 3 mmol = 1 mmol`, while `7 mmol mod 3` is a category error, exactly
+    /// like `usd + days`) — and a zero divisor is a clean [`ComputeError::DivisionByZero`],
+    /// never a silent `NaN`. Unlike [`ComputeOp::Gcd`]/[`ComputeOp::Lcm`] it does NOT
+    /// require integer operands (it is the *real* remainder). The exact-rational sidecar
+    /// is dropped — the `f64` remainder already carries the value for the realistic
+    /// integer / short-decimal cases (like gcd/lcm).
+    Mod,
     Sum,
     Count,
     Min,
@@ -321,6 +334,7 @@ impl ComputeOp {
             ComputeOp::Max2 => "max",
             ComputeOp::Gcd => "gcd",
             ComputeOp::Lcm => "lcm",
+            ComputeOp::Mod => "mod",
             ComputeOp::Sum => "sum",
             ComputeOp::Count => "count",
             ComputeOp::Min => "min",
@@ -488,6 +502,11 @@ fn dim_op(op: ComputeOp) -> Option<DimOp> {
         // addition so a bare count stays a bare count. The integer requirement is
         // enforced on the values, not the dimension.
         ComputeOp::Gcd | ComputeOp::Lcm => Some(DimOp::Add),
+        // modulo `a mod b` combines like addition: both operands must share a
+        // dimension and the remainder carries it (`7 mmol mod 3 mmol = 1 mmol`,
+        // `7 mmol mod 3` a category error). Flows through the general binary path
+        // with no extra `eval` locals.
+        ComputeOp::Mod => Some(DimOp::Add),
         _ => None,
     }
 }
@@ -675,6 +694,16 @@ fn eval(
                         return Err(ComputeError::DivisionByZero);
                     }
                     x / y
+                }
+                // modulo `a mod b` — the remainder with the sign of the dividend
+                // (Rust `%` / C `fmod`). Inline like `Div` (a single expression, no
+                // extra `eval` locals on the deeply-recursive path); a zero divisor is
+                // a clean error, never a `NaN`.
+                ComputeOp::Mod => {
+                    if y == 0.0 {
+                        return Err(ComputeError::DivisionByZero);
+                    }
+                    x % y
                 }
                 ComputeOp::Min2 => {
                     if x.is_nan() || y.is_nan() {
@@ -1394,6 +1423,70 @@ mod tests {
         .unwrap();
         assert_eq!(d.value, -3.0);
         assert_eq!(d.exact, ExactRational::new(-3, 1));
+    }
+
+    #[test]
+    fn modulo_returns_the_remainder_and_preserves_dimension() {
+        // 7 mmol mod 3 mmol = 1 mmol. Modulo combines dimensionally like addition:
+        // both operands share a dimension and the remainder carries it (NOT collapsed
+        // to Scalar). The exact-rational sidecar is dropped (like gcd/lcm).
+        let kb = kb_with(vec![quantity("a", 7, "mmol"), quantity("b", 3, "mmol")]);
+        let d = compute(
+            "m",
+            &bin(ComputeOp::Mod, refexpr("a"), refexpr("b")),
+            &kb,
+        )
+        .unwrap();
+        assert_eq!(d.value, 1.0);
+        assert_eq!(d.dim, kb.observed_dimensioned("a").unwrap().0.dim);
+        assert_eq!(d.exact, None);
+    }
+
+    #[test]
+    fn modulo_carries_the_sign_of_the_dividend() {
+        // −7 mod 3 = −1 (sign of the DIVIDEND, Rust `%` / C fmod), NOT +2 the way a
+        // Euclidean/floored modulo would give. 7.5 mod 2 = 1.5 (real operands allowed,
+        // unlike gcd/lcm).
+        let neg = compute(
+            "m",
+            &bin(ComputeOp::Mod, ComputeExpr::Lit(-7.0), ComputeExpr::Lit(3.0)),
+            &kb_with(vec![]),
+        )
+        .unwrap();
+        assert_eq!(neg.value, -1.0);
+        let frac = compute(
+            "m",
+            &bin(ComputeOp::Mod, ComputeExpr::Lit(7.5), ComputeExpr::Lit(2.0)),
+            &kb_with(vec![]),
+        )
+        .unwrap();
+        assert_eq!(frac.value, 1.5);
+    }
+
+    #[test]
+    fn modulo_by_zero_is_a_clean_error_not_a_nan() {
+        // A zero divisor is a `DivisionByZero`, exactly like `Div` — never a silent NaN.
+        let err = compute(
+            "m",
+            &bin(ComputeOp::Mod, ComputeExpr::Lit(7.0), ComputeExpr::Lit(0.0)),
+            &kb_with(vec![]),
+        )
+        .unwrap_err();
+        assert!(matches!(err, ComputeError::DivisionByZero));
+    }
+
+    #[test]
+    fn modulo_of_mismatched_dimensions_is_a_category_error() {
+        // 7 mmol mod 3 (scalar) shares no dimension → the same category error as
+        // `usd + days` (modulo combines like addition in `dim_op`).
+        let kb = kb_with(vec![quantity("a", 7, "mmol")]);
+        let err = compute(
+            "m",
+            &bin(ComputeOp::Mod, refexpr("a"), ComputeExpr::Lit(3.0)),
+            &kb,
+        )
+        .unwrap_err();
+        assert!(matches!(err, ComputeError::DimensionMismatch { .. }));
     }
 
     #[test]


### PR DESCRIPTION
## LaTeX consumer: `\bmod` / `\pmod` modulo → `ComputeOp::Mod`

Adds a **genuinely new engine op — binary modulo** — and wires the `latex "…"` surface to it, so a math-tuned model emitting `a \bmod b` (or `a \pmod{b}`) computes the remainder natively.

### The new op (`logic-engine`)
`ComputeOp::Mod` — `a mod b`, the remainder with the **sign of the dividend** (`7 mod 3 = 1`, `−7 mod 3 = −1`, `7.5 mod 2 = 1.5`), matching Rust's `f64::%` / C `fmod`. Folded into the **existing** general binary `eval` arm right next to `Div` — a single inline expression, **no extra locals on the deeply-recursive path** (preserving the clean-`TooDeep`-never-stack-overflow contract; the macOS ~2 MB test-thread concern that governs this file):
- **Dimensional**: combines like addition via `dim_op` — both operands must share a dimension and the remainder carries it (`7 mmol mod 3 mmol = 1 mmol`; `7 mmol mod 3` is a category error, exactly like `usd + days`).
- **Zero divisor**: a clean `DivisionByZero`, never a silent `NaN`.
- **Real operands**: unlike `Gcd`/`Lcm`, no integer requirement. Exact-rational sidecar dropped (the `f64` already carries the value).

### The surface wiring (`adj-lang`)
`\bmod`/`\pmod` have **no operator-table entry** in the LaTeX frontend, so `a \bmod b` parses as a left-associated implicit multiplication with the marker as a bare symbol: `Bin(Mul, Bin(Mul, a, Symbol("bmod")), b)`. The adapter recognises that **operator-name-juxtaposition** shape (the same technique already used for `\operatorname{trunc}(x)`) via a `mod_juxtaposition_lhs` helper and lowers it to `ArithOp::Mod` → `ComputeOp::Mod`. The arm sits **above** the general `Bin(Mul, …)`, so genuine products (`2x`) still multiply; only the `bmod`/`pmod` marker is intercepted. The congruence form `x \equiv y \pmod{n}` parses as a `Rel(Equiv, …)` that the ADJ arithmetic subset rejects — so only the direct `a \bmod b` / `a \pmod{b}` remainder computes, never a mis-lowered congruence. (Shape confirmed empirically before wiring.)

### Verification
- `cargo test -p logic-engine -p adj-lang -p adj-lang-cli -p adj-constraint-solver` — **all green**.
- +4 engine unit tests (remainder + dimension preservation, sign-of-dividend / real operands, zero-divisor error, dimension mismatch) and +2 end-to-end `\bmod`/`\pmod` tests through the full parse→lower→engine path.
- `adjudication-pipeline` (downstream consumer) builds. No other crate matches `ComputeOp` exhaustively beyond the already-tested `adj-constraint-solver`.
- No latex / math-frontend / mathml churn (adapter-side recognition keeps the blast radius to `adj-lang` + `logic-engine`).
- No `cargo fmt` run (brace form kept, matching CI-green neighbours).

### Files
- `logic-engine/src/compute.rs`, `logic-engine/{Cargo.toml,CHANGELOG.md}` (0.35.0 → 0.36.0)
- `adj-lang/src/{ast.rs,lower.rs,adapter.rs}`, `adj-lang/{Cargo.toml,CHANGELOG.md}` (0.31.0 → 0.32.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
