### PR TITLE
feat(adj-ladder): rung-45 weight/time-normalized elimination rate (difference-over-product)

### DIFF
--- a/code/specs/data/adj-ladder/rung45_elimination_rate/gen_items.py
+++ b/code/specs/data/adj-ladder/rung45_elimination_rate/gen_items.py
@@ -1,0 +1,227 @@
+"""Generate rung-45 (weight-and-time-normalized drug elimination rate) items.json for the ADJ-LADDER.
+
+Rung 45 opens the **pharmacokinetic elimination-rate** panel on the quantitative band — the arithmetic of how fast a
+drug leaves the body once you normalise the amount eliminated to the patient's body weight AND the elapsed time.
+Between two measurements the amount eliminated is `administered_dose − residual_dose`; expressing that as a rate per
+kilogram per hour divides it by the PRODUCT of the body weight and the elapsed time. This rung introduces a
+genuinely NEW arithmetic shape on the ladder: **difference-over-product** — `(a − b) / (c · d)` — a difference in the
+numerator divided by a product in the denominator.
+
+The setup: a drug is given (`administered_dose`, mg) and later `residual_dose` (mg) remains; the patient weighs
+`body_weight` (kg) and `elapsed_time` (h) has passed. The weight-and-time-normalised elimination rate is the amount
+that left divided by the weight-times-time product:
+
+  ELIMINATION RATE      (administered_dose − residual_dose) / (body_weight · elapsed_time)   [ mg per kg per hour ]
+  ELIMINATED AMOUNT     administered_dose − residual_dose                                     [ the numerator: what left ]
+  WEIGHT·TIME PRODUCT   body_weight · elapsed_time                                            [ the denominator ]
+
+The **elimination rate** is what makes this rung distinctive — it is the ladder's first **difference-over-product**:
+a parenthesised difference divided by a parenthesised product. Contrast the neighbours already on the ladder: rung-41
+was a *difference-over-sum* `(a−b)/(a+b)`, rung-42 a *sum-over-difference* `(a+b)/(c−d)`, rung-44 a *product-over-sum*
+`(a·b)/(c+d)`; none divided a DIFFERENCE by a PRODUCT. (The eliminated amount `administered_dose − residual_dose` and
+the weight·time product `body_weight · elapsed_time` ride alongside as the two component quantities, so the panel
+teaches the whole calculation — exactly as rung-44 shipped its injected mass and distribution volume beside the
+headline concentration.)
+
+Each index is a `compute_dimensioned` program (`observe` the four quantities + `let answer = formula`); the ADJ
+engine carries the arithmetic — including the inner `(administered_dose − residual_dose)` difference and the
+`(body_weight · elapsed_time)` product — and the harness reads the scalar via the existing `compute_dimensioned`
+extractor. No harness/engine change, exactly as rungs 8/16/.../43/44. This rung exercises the engine across a
+**difference divided by a product**.
+
+Contamination-safe by construction: every formula is built ONLY from the four observed quantities via `−`, `·` and
+`/` — **no structural constants** — so no numeric literal appears in any program, and neither the eliminated amount,
+the weight·time product, nor any rate is ever a literal (each is computed from the observed quantities). The observed
+quantities carry **digit-free identifiers** (`administered_dose`, `residual_dose`, `body_weight`, `elapsed_time`) so
+no numeral hides inside a variable name.
+
+The five options are a tight family over the same four quantities: the three real readouts plus the two classic
+slips —
+
+  WEIGHT ONLY         (administered_dose − residual_dose) / body_weight                       normalise by weight
+                                                                                              alone, forgetting the
+                                                                                              elapsed time, and
+  SUMMED DENOMINATOR  (administered_dose − residual_dose) / (body_weight + elapsed_time)      ADD the weight and time
+                                                                                              instead of multiplying
+                                                                                              them,
+
+which are exactly the mistakes a student makes (dropping a normaliser, or adding two quantities that should be
+multiplied). Gold rotates A-E by index. QUERIED (used as gold) = the three real readouts; all five always appear as
+options.
+
+Distinctness: the tables below are chosen with `administered_dose > residual_dose` (so the eliminated amount — and
+every numerator — is strictly positive) and all four quantities positive (so every denominator is strictly positive,
+no division by zero); the five family values are asserted pairwise-distinct with a comfortable margin at build time.
+"""
+import json
+
+LETTERS = ["A", "B", "C", "D", "E"]
+
+# (ADMINISTERED_DOSE, RESIDUAL_DOSE, BODY_WEIGHT, ELAPSED_TIME) — doses in mg, weight in kg, time in h.
+# ADMINISTERED_DOSE > RESIDUAL_DOSE > 0 so the eliminated amount (every numerator) is strictly positive, and
+# BODY_WEIGHT, ELAPSED_TIME > 0 so every denominator is strictly positive. The five family values are asserted
+# pairwise-distinct (with margin) below.
+TABLES = [
+    (100, 20, 4, 2),
+    (120, 30, 3, 3),
+    (90, 10, 5, 2),
+    (60, 12, 3, 4),
+    (80, 20, 4, 3),
+    (150, 30, 6, 2),
+    (200, 40, 4, 4),
+]
+
+# The option family (5 members), all built from the four observed quantities via -, * and /. Every identifier is
+# DIGIT-FREE. key -> (display name, formula-as-adj). Only the first three are *queried* (used as gold); all five
+# always appear as the options.
+FAMILY = [
+    (
+        "elimination_rate",
+        "weight-and-time-normalised elimination rate (amount eliminated over weight times time)",
+        "(administered_dose - residual_dose) / (body_weight * elapsed_time)",
+    ),
+    (
+        "eliminated_amount",
+        "the amount of drug eliminated (administered minus residual)",
+        "administered_dose - residual_dose",
+    ),
+    (
+        "weight_time_product",
+        "the weight-times-time product (the normalising denominator)",
+        "body_weight * elapsed_time",
+    ),
+    (
+        "weight_only",
+        "amount eliminated over the body weight ALONE, forgetting the elapsed time (a wrong denominator)",
+        "(administered_dose - residual_dose) / body_weight",
+    ),
+    (
+        "summed_denominator",
+        "amount eliminated over weight PLUS time (the two normalisers added instead of multiplied)",
+        "(administered_dose - residual_dose) / (body_weight + elapsed_time)",
+    ),
+]
+QUERIED = ["elimination_rate", "eliminated_amount", "weight_time_product"]
+ORDER = [k for k, _, _ in FAMILY]
+
+
+def scalar(v):
+    return {"value": v, "unit": "scalar"}
+
+
+def family_values(administered_dose, residual_dose, body_weight, elapsed_time):
+    # Operation order mirrors the ADJ programs exactly (difference in the numerator, product in the denominator),
+    # so the Python option value and the engine result are the same IEEE-double (well within the harness's 1e-9
+    # match tolerance).
+    eliminated = administered_dose - residual_dose
+    product = body_weight * elapsed_time
+    return {
+        "elimination_rate": eliminated / product,
+        "eliminated_amount": eliminated,
+        "weight_time_product": product,
+        "weight_only": eliminated / body_weight,
+        "summed_denominator": eliminated / (body_weight + elapsed_time),
+    }
+
+
+def build():
+    name_of = {k: nm for k, nm, _ in FAMILY}
+    formula_of = {k: f for k, _, f in FAMILY}
+    items = []
+    idx = 0
+
+    def num(x):
+        return int(x) if float(x).is_integer() else x
+
+    for administered_dose, residual_dose, body_weight, elapsed_time in TABLES:
+        assert administered_dose > residual_dose > 0 and body_weight > 0 and elapsed_time > 0, (
+            administered_dose,
+            residual_dose,
+            body_weight,
+            elapsed_time,
+        )
+        fv = family_values(administered_dose, residual_dose, body_weight, elapsed_time)
+        # Pairwise-distinct with a comfortable margin so the harness never sees two options
+        # matching the gold value within its 1e-9 tolerance.
+        vals = [fv[key] for key in ORDER]
+        for i in range(len(vals)):
+            for j in range(i + 1, len(vals)):
+                assert abs(vals[i] - vals[j]) > 1e-6, (
+                    administered_dose,
+                    residual_dose,
+                    body_weight,
+                    elapsed_time,
+                    ORDER[i],
+                    ORDER[j],
+                    fv,
+                )
+        for key in QUERIED:
+            gold_val = fv[key]
+            gold_pos = idx % 5
+            others = [fv[k2] for k2 in ORDER if abs(fv[k2] - gold_val) > 1e-12]
+            opts_vals = others[:]
+            opts_vals.insert(gold_pos, gold_val)
+            opts_vals = opts_vals[:5]
+            if abs(opts_vals[gold_pos] - gold_val) > 1e-12:
+                opts_vals[gold_pos] = gold_val
+            assert len({round(v, 9) for v in opts_vals}) == 5, (
+                key,
+                administered_dose,
+                residual_dose,
+                body_weight,
+                elapsed_time,
+                opts_vals,
+            )
+            options = {LETTERS[i]: scalar(opts_vals[i]) for i in range(5)}
+            items.append({
+                "id": f"r45elr-{idx + 1:02d}",
+                "qtype": "elimination_rate",
+                "stem": (
+                    f"A {num(administered_dose)} mg dose is given to a {num(body_weight)} kg patient; after "
+                    f"{num(elapsed_time)} h, {num(residual_dose)} mg remains. What is the {name_of[key]}?"
+                ),
+                "program": (
+                    f"observe administered_dose({num(administered_dose)})\n"
+                    f"observe residual_dose({num(residual_dose)})\n"
+                    f"observe body_weight({num(body_weight)})\n"
+                    f"observe elapsed_time({num(elapsed_time)})\n"
+                    f"let answer = {formula_of[key]}\n"
+                    "? answer\n"
+                ),
+                "answer_from": {"type": "compute_dimensioned", "name": "answer"},
+                "options": options,
+                "gold_letter": LETTERS[gold_pos],
+            })
+            idx += 1
+    return {
+        "description": (
+            "ADJ-LADDER rung 45 — weight-and-time-normalised drug elimination rate from four stated quantities (a "
+            "NEW panel: pharmacokinetic elimination rate). From an administered and a residual dose plus the body "
+            "weight and elapsed time compute the elimination rate ((administered_dose-residual_dose)/(body_weight*"
+            "elapsed_time)), the eliminated amount (administered_dose-residual_dose), or the weight*time product "
+            "(body_weight*elapsed_time). Each item is a compute_dimensioned program (observe the four quantities, "
+            "let answer = formula); the ADJ engine carries the arithmetic — a NEW shape, DIFFERENCE-OVER-PRODUCT "
+            "(a-b)/(c*d), the first quotient on the ladder to divide a parenthesised difference by a parenthesised "
+            "product (distinct from rung-41 difference-over-sum (a-b)/(a+b), rung-42 sum-over-difference (a+b)/(c-d), "
+            "and rung-44 product-over-sum (a*b)/(c+d)) — and the harness matches the scalar to the printed options. "
+            "Contamination-safe: every index is built only from the four observed quantities via -, * and / — no "
+            "constant leaks, and neither the eliminated amount, the weight*time product, nor any rate ever appears "
+            "as a literal (each is computed) — and the observed quantities carry digit-free identifiers so no "
+            "numeral hides inside a variable name. The five options are a family over the same four quantities, so "
+            "the distractors are exactly the slips students make: normalising by the body weight alone (dropping the "
+            "elapsed time), and ADDING the weight and time instead of multiplying them. The core confusion tested is "
+            "dividing the eliminated amount by the weight-times-time product."
+        ),
+        "items": items,
+    }
+
+
+if __name__ == "__main__":
+    doc = build()
+    with open("items.json", "w") as f:
+        json.dump(doc, f, indent=2)
+        f.write("\n")
+    print("wrote items.json:", len(doc["items"]), "items")
+    for it in doc["items"]:
+        print(it["id"], it["qtype"], "gold", it["gold_letter"],
+              "=", round(it["options"][it["gold_letter"]]["value"], 6))

--- a/code/specs/data/adj-ladder/rung45_elimination_rate/items.json
+++ b/code/specs/data/adj-ladder/rung45_elimination_rate/items.json
@@ -1,0 +1,698 @@
+{
+  "description": "ADJ-LADDER rung 45 \u2014 weight-and-time-normalised drug elimination rate from four stated quantities (a NEW panel: pharmacokinetic elimination rate). From an administered and a residual dose plus the body weight and elapsed time compute the elimination rate ((administered_dose-residual_dose)/(body_weight*elapsed_time)), the eliminated amount (administered_dose-residual_dose), or the weight*time product (body_weight*elapsed_time). Each item is a compute_dimensioned program (observe the four quantities, let answer = formula); the ADJ engine carries the arithmetic \u2014 a NEW shape, DIFFERENCE-OVER-PRODUCT (a-b)/(c*d), the first quotient on the ladder to divide a parenthesised difference by a parenthesised product (distinct from rung-41 difference-over-sum (a-b)/(a+b), rung-42 sum-over-difference (a+b)/(c-d), and rung-44 product-over-sum (a*b)/(c+d)) \u2014 and the harness matches the scalar to the printed options. Contamination-safe: every index is built only from the four observed quantities via -, * and / \u2014 no constant leaks, and neither the eliminated amount, the weight*time product, nor any rate ever appears as a literal (each is computed) \u2014 and the observed quantities carry digit-free identifiers so no numeral hides inside a variable name. The five options are a family over the same four quantities, so the distractors are exactly the slips students make: normalising by the body weight alone (dropping the elapsed time), and ADDING the weight and time instead of multiplying them. The core confusion tested is dividing the eliminated amount by the weight-times-time product.",
+  "items": [
+    {
+      "id": "r45elr-01",
+      "qtype": "elimination_rate",
+      "stem": "A 100 mg dose is given to a 4 kg patient; after 2 h, 20 mg remains. What is the weight-and-time-normalised elimination rate (amount eliminated over weight times time)?",
+      "program": "observe administered_dose(100)\nobserve residual_dose(20)\nobserve body_weight(4)\nobserve elapsed_time(2)\nlet answer = (administered_dose - residual_dose) / (body_weight * elapsed_time)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 10.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 80,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 20.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 13.333333333333334,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r45elr-02",
+      "qtype": "elimination_rate",
+      "stem": "A 100 mg dose is given to a 4 kg patient; after 2 h, 20 mg remains. What is the the amount of drug eliminated (administered minus residual)?",
+      "program": "observe administered_dose(100)\nobserve residual_dose(20)\nobserve body_weight(4)\nobserve elapsed_time(2)\nlet answer = administered_dose - residual_dose\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 10.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 80,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 20.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 13.333333333333334,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r45elr-03",
+      "qtype": "elimination_rate",
+      "stem": "A 100 mg dose is given to a 4 kg patient; after 2 h, 20 mg remains. What is the the weight-times-time product (the normalising denominator)?",
+      "program": "observe administered_dose(100)\nobserve residual_dose(20)\nobserve body_weight(4)\nobserve elapsed_time(2)\nlet answer = body_weight * elapsed_time\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 10.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 80,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 20.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 13.333333333333334,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r45elr-04",
+      "qtype": "elimination_rate",
+      "stem": "A 120 mg dose is given to a 3 kg patient; after 3 h, 30 mg remains. What is the weight-and-time-normalised elimination rate (amount eliminated over weight times time)?",
+      "program": "observe administered_dose(120)\nobserve residual_dose(30)\nobserve body_weight(3)\nobserve elapsed_time(3)\nlet answer = (administered_dose - residual_dose) / (body_weight * elapsed_time)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 90,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 9,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 30.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 10.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 15.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r45elr-05",
+      "qtype": "elimination_rate",
+      "stem": "A 120 mg dose is given to a 3 kg patient; after 3 h, 30 mg remains. What is the the amount of drug eliminated (administered minus residual)?",
+      "program": "observe administered_dose(120)\nobserve residual_dose(30)\nobserve body_weight(3)\nobserve elapsed_time(3)\nlet answer = administered_dose - residual_dose\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 10.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 9,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 30.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 15.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 90,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r45elr-06",
+      "qtype": "elimination_rate",
+      "stem": "A 120 mg dose is given to a 3 kg patient; after 3 h, 30 mg remains. What is the the weight-times-time product (the normalising denominator)?",
+      "program": "observe administered_dose(120)\nobserve residual_dose(30)\nobserve body_weight(3)\nobserve elapsed_time(3)\nlet answer = body_weight * elapsed_time\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 9,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 10.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 90,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 30.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 15.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r45elr-07",
+      "qtype": "elimination_rate",
+      "stem": "A 90 mg dose is given to a 5 kg patient; after 2 h, 10 mg remains. What is the weight-and-time-normalised elimination rate (amount eliminated over weight times time)?",
+      "program": "observe administered_dose(90)\nobserve residual_dose(10)\nobserve body_weight(5)\nobserve elapsed_time(2)\nlet answer = (administered_dose - residual_dose) / (body_weight * elapsed_time)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 80,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 8.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 10,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 16.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 11.428571428571429,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r45elr-08",
+      "qtype": "elimination_rate",
+      "stem": "A 90 mg dose is given to a 5 kg patient; after 2 h, 10 mg remains. What is the the amount of drug eliminated (administered minus residual)?",
+      "program": "observe administered_dose(90)\nobserve residual_dose(10)\nobserve body_weight(5)\nobserve elapsed_time(2)\nlet answer = administered_dose - residual_dose\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 8.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 10,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 80,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 16.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 11.428571428571429,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r45elr-09",
+      "qtype": "elimination_rate",
+      "stem": "A 90 mg dose is given to a 5 kg patient; after 2 h, 10 mg remains. What is the the weight-times-time product (the normalising denominator)?",
+      "program": "observe administered_dose(90)\nobserve residual_dose(10)\nobserve body_weight(5)\nobserve elapsed_time(2)\nlet answer = body_weight * elapsed_time\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 8.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 80,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 16.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 10,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 11.428571428571429,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r45elr-10",
+      "qtype": "elimination_rate",
+      "stem": "A 60 mg dose is given to a 3 kg patient; after 4 h, 12 mg remains. What is the weight-and-time-normalised elimination rate (amount eliminated over weight times time)?",
+      "program": "observe administered_dose(60)\nobserve residual_dose(12)\nobserve body_weight(3)\nobserve elapsed_time(4)\nlet answer = (administered_dose - residual_dose) / (body_weight * elapsed_time)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 48,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 12,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 16.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 6.857142857142857,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 4.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r45elr-11",
+      "qtype": "elimination_rate",
+      "stem": "A 60 mg dose is given to a 3 kg patient; after 4 h, 12 mg remains. What is the the amount of drug eliminated (administered minus residual)?",
+      "program": "observe administered_dose(60)\nobserve residual_dose(12)\nobserve body_weight(3)\nobserve elapsed_time(4)\nlet answer = administered_dose - residual_dose\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 48,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 4.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 12,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 16.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 6.857142857142857,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r45elr-12",
+      "qtype": "elimination_rate",
+      "stem": "A 60 mg dose is given to a 3 kg patient; after 4 h, 12 mg remains. What is the the weight-times-time product (the normalising denominator)?",
+      "program": "observe administered_dose(60)\nobserve residual_dose(12)\nobserve body_weight(3)\nobserve elapsed_time(4)\nlet answer = body_weight * elapsed_time\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 4.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 12,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 48,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 16.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 6.857142857142857,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r45elr-13",
+      "qtype": "elimination_rate",
+      "stem": "A 80 mg dose is given to a 4 kg patient; after 3 h, 20 mg remains. What is the weight-and-time-normalised elimination rate (amount eliminated over weight times time)?",
+      "program": "observe administered_dose(80)\nobserve residual_dose(20)\nobserve body_weight(4)\nobserve elapsed_time(3)\nlet answer = (administered_dose - residual_dose) / (body_weight * elapsed_time)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 60,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 12,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 5.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 15.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 8.571428571428571,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r45elr-14",
+      "qtype": "elimination_rate",
+      "stem": "A 80 mg dose is given to a 4 kg patient; after 3 h, 20 mg remains. What is the the amount of drug eliminated (administered minus residual)?",
+      "program": "observe administered_dose(80)\nobserve residual_dose(20)\nobserve body_weight(4)\nobserve elapsed_time(3)\nlet answer = administered_dose - residual_dose\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 5.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 12,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 15.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 60,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 8.571428571428571,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r45elr-15",
+      "qtype": "elimination_rate",
+      "stem": "A 80 mg dose is given to a 4 kg patient; after 3 h, 20 mg remains. What is the the weight-times-time product (the normalising denominator)?",
+      "program": "observe administered_dose(80)\nobserve residual_dose(20)\nobserve body_weight(4)\nobserve elapsed_time(3)\nlet answer = body_weight * elapsed_time\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 5.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 60,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 15.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 8.571428571428571,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 12,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r45elr-16",
+      "qtype": "elimination_rate",
+      "stem": "A 150 mg dose is given to a 6 kg patient; after 2 h, 30 mg remains. What is the weight-and-time-normalised elimination rate (amount eliminated over weight times time)?",
+      "program": "observe administered_dose(150)\nobserve residual_dose(30)\nobserve body_weight(6)\nobserve elapsed_time(2)\nlet answer = (administered_dose - residual_dose) / (body_weight * elapsed_time)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 10.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 120,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 12,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 20.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 15.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r45elr-17",
+      "qtype": "elimination_rate",
+      "stem": "A 150 mg dose is given to a 6 kg patient; after 2 h, 30 mg remains. What is the the amount of drug eliminated (administered minus residual)?",
+      "program": "observe administered_dose(150)\nobserve residual_dose(30)\nobserve body_weight(6)\nobserve elapsed_time(2)\nlet answer = administered_dose - residual_dose\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 10.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 120,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 12,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 20.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 15.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r45elr-18",
+      "qtype": "elimination_rate",
+      "stem": "A 150 mg dose is given to a 6 kg patient; after 2 h, 30 mg remains. What is the the weight-times-time product (the normalising denominator)?",
+      "program": "observe administered_dose(150)\nobserve residual_dose(30)\nobserve body_weight(6)\nobserve elapsed_time(2)\nlet answer = body_weight * elapsed_time\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 10.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 120,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 12,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 20.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 15.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r45elr-19",
+      "qtype": "elimination_rate",
+      "stem": "A 200 mg dose is given to a 4 kg patient; after 4 h, 40 mg remains. What is the weight-and-time-normalised elimination rate (amount eliminated over weight times time)?",
+      "program": "observe administered_dose(200)\nobserve residual_dose(40)\nobserve body_weight(4)\nobserve elapsed_time(4)\nlet answer = (administered_dose - residual_dose) / (body_weight * elapsed_time)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 160,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 16,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 40.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 10.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 20.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r45elr-20",
+      "qtype": "elimination_rate",
+      "stem": "A 200 mg dose is given to a 4 kg patient; after 4 h, 40 mg remains. What is the the amount of drug eliminated (administered minus residual)?",
+      "program": "observe administered_dose(200)\nobserve residual_dose(40)\nobserve body_weight(4)\nobserve elapsed_time(4)\nlet answer = administered_dose - residual_dose\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 10.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 16,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 40.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 20.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 160,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r45elr-21",
+      "qtype": "elimination_rate",
+      "stem": "A 200 mg dose is given to a 4 kg patient; after 4 h, 40 mg remains. What is the the weight-times-time product (the normalising denominator)?",
+      "program": "observe administered_dose(200)\nobserve residual_dose(40)\nobserve body_weight(4)\nobserve elapsed_time(4)\nlet answer = body_weight * elapsed_time\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 16,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 10.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 160,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 40.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 20.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    }
+  ]
+}

--- a/code/specs/data/adj-ladder/test_ladder_eval.py
+++ b/code/specs/data/adj-ladder/test_ladder_eval.py
@@ -82,6 +82,7 @@ SELF_CONTAINED_RUNGS = (
     "rung42_hemofiltration_concentration",
     "rung43_compounded_admixture",
     "rung44_indicator_dilution",
+    "rung45_elimination_rate",
 )
 
 


### PR DESCRIPTION
## ADJ-LADDER rung-45 — weight/time-normalized elimination rate (difference-over-product)

Adds **rung 45**: a **new quantitative panel** (pharmacokinetic elimination rate) introducing a **genuinely new arithmetic shape** — **difference-over-product**, `(a − b) / (c · d)`.

### What's new — the shape
Between two measurements the amount eliminated is `administered_dose − residual_dose`; the weight-and-time-normalised elimination rate divides that difference by the product `body_weight · elapsed_time`:

```
elimination_rate = (administered_dose - residual_dose) / (body_weight * elapsed_time)
```

First ladder quotient dividing a parenthesised **difference** by a parenthesised **product**, distinct from:
- rung-41 difference-over-sum `(a-b)/(a+b)`
- rung-42 sum-over-difference `(a+b)/(c-d)`
- rung-44 product-over-sum `(a*b)/(c+d)`

### The panel
Three real readouts queried as gold — `elimination_rate`, `eliminated_amount` (numerator difference), `weight_time_product` (denominator product) — against two classic slips:
- **weight_only**: normalise by body weight alone, dropping the elapsed time — `(ad−rd)/body_weight`
- **summed_denominator**: add the weight and time instead of multiplying — `(ad−rd)/(bw+et)`

21 items (7 tables × 3 queried); gold rotates A–E.

### Faithful-by-construction
- Each item is a `compute_dimensioned` program (`observe` the four quantities, `let answer = formula`); the ADJ engine carries the arithmetic, the existing harness reads the scalar — **no engine/harness change**.
- **No numeric constants**: every formula is built only from the four observed quantities via `−`, `*`, `/`.
- **Digit-free identifiers** (`administered_dose`, `residual_dose`, `body_weight`, `elapsed_time`).
- Tables use `administered_dose > residual_dose > 0` (positive numerators) and positive weight/time (positive denominators, no division by zero); five family values asserted **pairwise-distinct** (margin > 1e-6) at build time.

### Verification
- `pytest test_ladder_eval.py -k rung45 -q` → **3 passed** (engine selects every gold, 0 wrong / 0 abstain; contamination clean; items.json valid).
- Registered `rung45_elimination_rate` in `SELF_CONTAINED_RUNGS`.
- Security review: **PASSED** (data-only generator, no external input, no eval/exec/subprocess/network).

### Files
- `code/specs/data/adj-ladder/rung45_elimination_rate/gen_items.py` (new)
- `code/specs/data/adj-ladder/rung45_elimination_rate/items.json` (new, generated)
- `code/specs/data/adj-ladder/test_ladder_eval.py` (register rung)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
