### PR TITLE
feat(latex): \operatorname{sgn} sign function in latex "…" — new ComputeOp::Sign

### DIFF
--- a/code/packages/rust/adj-lang/CHANGELOG.md
+++ b/code/packages/rust/adj-lang/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.33.0] - 2026-07-02 — `\operatorname{sgn}` sign function in `latex "…"`
+
+### Added
+
+- `latex "\operatorname{sgn}(x)"` now computes the **sign** `sgn(x)` (`−1`/`0`/`+1`).
+  New `ExprAst::Sign` lowers to the new `logic_engine::ComputeOp::Sign`. `\operatorname`
+  is a TEXT command, so `\operatorname{sgn}(x)` parses as the operator-name
+  juxtaposition `Bin(Mul, Text("sgn"), (x))` — the same shape the adapter already
+  recognises for `\operatorname{trunc}` — and lowers via `operator_name_is(lhs, "sgn")`.
+  Unlike the rounding ops, `sgn` collapses to a dimensionless `Scalar` while accepting a
+  dimensioned operand, so `\operatorname{sgn}(a - b)` (the sign of a net quantity)
+  computes to a clean ±1. +adapter and lower unit tests.
+
 ## [0.32.0] - 2026-07-02 — `\bmod` / `\pmod` modulo in `latex "…"`
 
 ### Added

--- a/code/packages/rust/adj-lang/Cargo.toml
+++ b/code/packages/rust/adj-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang"
-version = "0.32.0"
+version = "0.33.0"
 edition = "2021"
 description = "Surface-syntax frontend for the adjudication framework's probabilistic-logic rulebooks. Lexes, parses, and lowers a domain-expert-readable DSL into a `logic-engine` KnowledgeBase. Dissolves ADJ46 awkwardness items A10 (rulebook syntax) and A4 (joint contributions syntactically distinct)."
 

--- a/code/packages/rust/adj-lang/src/adapter.rs
+++ b/code/packages/rust/adj-lang/src/adapter.rs
@@ -973,6 +973,15 @@ fn latex_math_to_expr_ast(expr: &MathExpr, source: &str) -> Result<ExprAst, Adap
         MathExpr::Bin(BinOp::Mul, lhs, rhs) if operator_name_is(lhs, "trunc") => {
             Ok(ExprAst::Trunc(Box::new(latex_math_to_expr_ast(rhs, source)?)))
         }
+        // `\operatorname{sgn}(x)` — the sign function. Same operator-name-juxtaposition
+        // shape as `\operatorname{trunc}` above (`\operatorname{…}` is a TEXT command,
+        // so `\operatorname{sgn}(x)` parses as `Bin(Mul, Text("sgn"), (x))`). Lowers to
+        // the native `ComputeOp::Sign` (via `ExprAst::Sign`), which collapses the result
+        // to a dimensionless `Scalar` (a sign is ±1/0) while accepting a dimensioned
+        // operand — so `\operatorname{sgn}(a - b)` (the sign of a net quantity) computes.
+        MathExpr::Bin(BinOp::Mul, lhs, rhs) if operator_name_is(lhs, "sgn") => {
+            Ok(ExprAst::Sign(Box::new(latex_math_to_expr_ast(rhs, source)?)))
+        }
         // `a \bmod b` / `a \pmod{b}` — the modulo operator. `\bmod`/`\pmod` are not in
         // the frontend's operator tables, so they lower to a bare `Symbol("bmod")` /
         // `Symbol("pmod")` and the whole expression parses as a LEFT-associated implicit

--- a/code/packages/rust/adj-lang/src/ast.rs
+++ b/code/packages/rust/adj-lang/src/ast.rs
@@ -188,6 +188,14 @@ pub enum ExprAst {
     /// operator-name juxtaposition (`Text("trunc")` implicitly multiplied by its
     /// parenthesised argument).
     Trunc(Box<ExprAst>),
+    /// The **sign** function `sgn(x)` — `−1`/`0`/`+1` for a negative/zero/positive
+    /// operand. Lowers to the native `ComputeOp::Sign`, which — unlike the
+    /// dimension-preserving rounding ops — collapses the result to a dimensionless
+    /// `Scalar` (a sign is a pure number) while accepting a dimensioned operand.
+    /// Produced by the `latex "…"` adapter from a `\operatorname{sgn}(x)` — the
+    /// operator-name juxtaposition (`Text("sgn")` implicitly multiplied by its
+    /// parenthesised argument), exactly like `\operatorname{trunc}`.
+    Sign(Box<ExprAst>),
     /// A named **transcendental** function applied to one argument
     /// (`\sin(x)`, `\ln(x)`, `\exp(x)`, …). Lowers to the matching native
     /// transcendental `ComputeOp` (`Scalar → Scalar`, exact dropped). Produced by

--- a/code/packages/rust/adj-lang/src/lower.rs
+++ b/code/packages/rust/adj-lang/src/lower.rs
@@ -710,6 +710,7 @@ fn lower_expr(expr: &ExprAst) -> ComputeExpr {
         ExprAst::Ceil(a) => ComputeExpr::Unary(ComputeOp::Ceil, Box::new(lower_expr(a))),
         ExprAst::Round(a) => ComputeExpr::Unary(ComputeOp::Round, Box::new(lower_expr(a))),
         ExprAst::Trunc(a) => ComputeExpr::Unary(ComputeOp::Trunc, Box::new(lower_expr(a))),
+        ExprAst::Sign(a) => ComputeExpr::Unary(ComputeOp::Sign, Box::new(lower_expr(a))),
         ExprAst::Call(f, a) => ComputeExpr::Unary(lower_named_fn(*f), Box::new(lower_expr(a))),
         ExprAst::Call2(f, a, b) => ComputeExpr::Bin(
             lower_bin_fn(*f),
@@ -2018,6 +2019,48 @@ contributes 1000000 from answer == 60 to correct
         )
         .unwrap();
         assert!(neg.ranked[0].posterior > 0.99, "{neg:?}");
+    }
+
+    #[test]
+    fn native_latex_sgn_computes_the_sign() {
+        // `\operatorname{sgn}(x)` with x=5 is +1; with x=−5 (written 0−x) is −1 — the
+        // native ComputeOp::Sign via the operator-name-juxtaposition path
+        // (`Bin(Mul, Text("sgn"), (x))`), the same shape as `\operatorname{trunc}`.
+        let pos = crate::compile_and_decide(
+            "observe x(5)\n\
+             let answer = latex \"$\\operatorname{sgn}(x)$\"\n\
+             prior 0.10 for correct\n\
+             contributes 1000000 from answer == 1 to correct\n\
+             ? correct\n",
+        )
+        .unwrap();
+        assert!(pos.ranked[0].posterior > 0.99, "{pos:?}");
+        let neg = crate::compile_and_decide(
+            "observe x(5)\n\
+             let answer = latex \"$\\operatorname{sgn}(0 - x)$\"\n\
+             prior 0.10 for correct\n\
+             contributes 1000000 from answer == -1 to correct\n\
+             ? correct\n",
+        )
+        .unwrap();
+        assert!(neg.ranked[0].posterior > 0.99, "{neg:?}");
+    }
+
+    #[test]
+    fn native_latex_sgn_of_a_net_difference_gives_the_direction() {
+        // `\operatorname{sgn}(a - b)` with a=3, b=8 is sgn(−5) = −1 — the sign of a net
+        // quantity, computed as a single node. Confirms the adapter passes the inner
+        // difference through to ComputeOp::Sign (which returns a dimensionless ±1).
+        let d = crate::compile_and_decide(
+            "observe a(3)\n\
+             observe b(8)\n\
+             let answer = latex \"$\\operatorname{sgn}(a - b)$\"\n\
+             prior 0.10 for correct\n\
+             contributes 1000000 from answer == -1 to correct\n\
+             ? correct\n",
+        )
+        .unwrap();
+        assert!(d.ranked[0].posterior > 0.99, "{d:?}");
     }
 
     #[test]

--- a/code/packages/rust/logic-engine/CHANGELOG.md
+++ b/code/packages/rust/logic-engine/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.37.0] - 2026-07-02 — sign function (`Sign`)
+
+### Added
+
+- `ComputeOp::Sign` — the **mathematical** sign `sgn(x)`: `−1`/`0`/`+1` for a
+  negative/zero/positive operand (NOT `f64::signum`, which returns `±1` for zero).
+  A unary op folded into the **existing** `eval_unary` arm (no new recursion frame),
+  but dimensionally in a category of its own: a sign is a pure number, so `sgn`
+  **accepts any input dimension and collapses the result to `Scalar`** — unlike the
+  dimension-preserving rounding family (`|dollars| = dollars`) and unlike the
+  transcendentals (which reject a dimensioned operand). This makes the sign of a
+  dimensioned difference (`sgn(pressure_a − pressure_b)`, a net pressure/charge/trend
+  direction) a clean ±1. The result is exact (`±1`/`0` is rational), so the exact
+  sidecar is the sign of the numerator carried as `q/1`. A NaN operand is produced
+  explicitly so the shared non-finite guard rejects it rather than laundering it to
+  `0`. `symbol()` renders it `"sgn"`. Lowered from a LaTeX `\operatorname{sgn}(x)`
+  (adj-lang's `latex "…"` surface, operator-name juxtaposition like
+  `\operatorname{trunc}`). +4 unit tests (pos/neg/zero scalar,
+  dimensioned-operand-collapses-to-scalar, exact-sign sidecar, sign of a net
+  difference).
+
 ## [0.36.0] - 2026-07-02 — binary modulo (`Mod`)
 
 ### Added

--- a/code/packages/rust/logic-engine/Cargo.toml
+++ b/code/packages/rust/logic-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logic-engine"
-version = "0.36.0"
+version = "0.37.0"
 edition = "2021"
 description = "Probability-aware facts, rules, KB, SLD find-first/enumerate + WMC posterior + LP19e likelihood-ratio Bayesian aggregation."
 

--- a/code/packages/rust/logic-engine/src/compute.rs
+++ b/code/packages/rust/logic-engine/src/compute.rs
@@ -255,6 +255,21 @@ pub enum ComputeOp {
     Cot,
     Sec,
     Csc,
+    /// The **sign** function `sgn(x)` — `−1` for a negative operand, `0` for zero,
+    /// `+1` for a positive one. **Unary**, but dimensionally in a category of its own:
+    /// the sign of a quantity is a pure number (`sgn(−5 mmHg) = −1`, dimensionless),
+    /// so — unlike the dimension-*preserving* rounding family (`|dollars| = dollars`)
+    /// and unlike the transcendentals (which *reject* a dimensioned operand) — `sgn`
+    /// **accepts any dimension and collapses the result to `Scalar`**. That makes the
+    /// sign of a dimensioned difference (a net pressure, a net charge, a trend
+    /// direction) computable: `sgn(pressure_a − pressure_b)` is a clean ±1. It is exact
+    /// (`±1`/`0` is rational), so the exact sidecar is the sign of the numerator,
+    /// carried as `q/1`. Lowered from a LaTeX `\operatorname{sgn}(x)` — the
+    /// operator-name juxtaposition surface (like `\operatorname{trunc}`; adj-lang's
+    /// `latex "…"`). Note this is the **mathematical** sign (`sgn(0) = 0`), NOT
+    /// `f64::signum` (which returns `±1` for zero); a NaN operand is produced explicitly
+    /// so the shared non-finite guard rejects it rather than laundering it to `0`.
+    Sign,
     /// Binary **minimum** / **maximum** — `min(a, b)` / `max(a, b)` over exactly
     /// TWO operands. Unlike the aggregation [`ComputeOp::Min`]/[`ComputeOp::Max`]
     /// (which reduce *every* observation of a single slot), these are honest
@@ -330,6 +345,7 @@ impl ComputeOp {
             ComputeOp::Cot => "cot",
             ComputeOp::Sec => "sec",
             ComputeOp::Csc => "csc",
+            ComputeOp::Sign => "sgn",
             ComputeOp::Min2 => "min",
             ComputeOp::Max2 => "max",
             ComputeOp::Gcd => "gcd",
@@ -894,6 +910,20 @@ fn eval_unary(
         ComputeOp::Cot => value.cos() / value.sin(),
         ComputeOp::Sec => 1.0 / value.cos(),
         ComputeOp::Csc => 1.0 / value.sin(),
+        // The MATHEMATICAL sign: sgn(0) = 0 (NOT `f64::signum`, which returns ±1 for
+        // zero). A NaN operand yields NaN explicitly so the non-finite guard below
+        // rejects it, rather than the `else` branch laundering it to a clean `0`.
+        ComputeOp::Sign => {
+            if value.is_nan() {
+                f64::NAN
+            } else if value > 0.0 {
+                1.0
+            } else if value < 0.0 {
+                -1.0
+            } else {
+                0.0
+            }
+        }
         _ => {
             return Err(ComputeError::MalformedExpr {
                 detail: "non-unary operator in unary position",
@@ -953,11 +983,15 @@ fn eval_unary(
         // den > 0 (no `div_euclid`, which would floor toward −∞). The result is an
         // integer, carried as q/1.
         ComputeOp::Trunc => ExactRational::new(r.num / r.den, 1),
+        // sgn(num/den) = sign of the numerator (den > 0 doesn't affect the sign);
+        // `i64::signum` is the mathematical sign (0 → 0), carried as q/1.
+        ComputeOp::Sign => ExactRational::new(r.num.signum(), 1),
         _ => None,
     });
     // Rounding preserves the operand's dimension; a transcendental collapses to a
-    // pure number (`Scalar`).
-    let result_dim = if transcendental {
+    // pure number (`Scalar`); `sgn` also collapses to `Scalar` (a sign is
+    // dimensionless) but — unlike the transcendentals — accepts a dimensioned operand.
+    let result_dim = if transcendental || op == ComputeOp::Sign {
         Dimension::Scalar
     } else {
         dim
@@ -1487,6 +1521,92 @@ mod tests {
         )
         .unwrap_err();
         assert!(matches!(err, ComputeError::DimensionMismatch { .. }));
+    }
+
+    #[test]
+    fn sign_of_positive_negative_and_zero_scalars() {
+        // sgn(5) = 1, sgn(−5) = −1, sgn(0) = 0. Zero maps to zero — the MATHEMATICAL
+        // sign, NOT `f64::signum` (which returns +1 for zero). Result is a Scalar.
+        for (input, want) in [(5.0, 1.0), (-5.0, -1.0), (0.0, 0.0)] {
+            let d = compute(
+                "s",
+                &ComputeExpr::Unary(ComputeOp::Sign, Box::new(ComputeExpr::Lit(input))),
+                &kb_with(vec![]),
+            )
+            .unwrap();
+            assert_eq!(d.value, want, "sgn({input})");
+            assert_eq!(d.dim, Dimension::Scalar);
+        }
+    }
+
+    #[test]
+    fn sign_accepts_a_dimensioned_operand_and_collapses_to_scalar() {
+        // sgn(−3 mmol) = −1 (dimensionless). Unlike a transcendental, `sgn` does NOT
+        // reject a dimensioned operand — the sign of a quantity is a pure number — so
+        // the result is a Scalar −1, not a mmol and not a DimensionMismatch error.
+        let kb = kb_with(vec![quantity("a", -3, "mmol")]);
+        let d = compute(
+            "s",
+            &ComputeExpr::Unary(ComputeOp::Sign, Box::new(refexpr("a"))),
+            &kb,
+        )
+        .unwrap();
+        assert_eq!(d.value, -1.0);
+        assert_eq!(d.dim, Dimension::Scalar);
+    }
+
+    #[test]
+    fn sign_preserves_the_exact_sign_sidecar() {
+        // sgn(−7/2) = −1 and sgn(7/2) = +1, both exact (a sign is ±1, rational).
+        let neg = compute(
+            "s",
+            &ComputeExpr::Unary(
+                ComputeOp::Sign,
+                Box::new(bin(
+                    ComputeOp::Div,
+                    ComputeExpr::Lit(-7.0),
+                    ComputeExpr::Lit(2.0),
+                )),
+            ),
+            &kb_with(vec![]),
+        )
+        .unwrap();
+        assert_eq!(neg.value, -1.0);
+        assert_eq!(neg.exact, ExactRational::new(-1, 1));
+        let pos = compute(
+            "s",
+            &ComputeExpr::Unary(
+                ComputeOp::Sign,
+                Box::new(bin(
+                    ComputeOp::Div,
+                    ComputeExpr::Lit(7.0),
+                    ComputeExpr::Lit(2.0),
+                )),
+            ),
+            &kb_with(vec![]),
+        )
+        .unwrap();
+        assert_eq!(pos.value, 1.0);
+        assert_eq!(pos.exact, ExactRational::new(1, 1));
+    }
+
+    #[test]
+    fn sign_of_a_net_difference_gives_its_direction() {
+        // sgn(a − b) with a = 3 mmol, b = 8 mmol is sgn(−5 mmol) = −1: the DIRECTION of
+        // a net (dimensioned) quantity, computed as a single Scalar node. This is the
+        // whole point of accepting a dimensioned operand.
+        let kb = kb_with(vec![quantity("a", 3, "mmol"), quantity("b", 8, "mmol")]);
+        let d = compute(
+            "s",
+            &ComputeExpr::Unary(
+                ComputeOp::Sign,
+                Box::new(bin(ComputeOp::Sub, refexpr("a"), refexpr("b"))),
+            ),
+            &kb,
+        )
+        .unwrap();
+        assert_eq!(d.value, -1.0);
+        assert_eq!(d.dim, Dimension::Scalar);
     }
 
     #[test]


### PR DESCRIPTION
## LaTeX consumer: `\operatorname{sgn}` sign function → `ComputeOp::Sign`

Adds a **new engine op — the sign function** — and wires the `latex "…"` surface to it, so `\operatorname{sgn}(x)` computes the direction of a quantity (`−1`/`0`/`+1`) natively.

### The new op (`logic-engine`)
`ComputeOp::Sign` — the **mathematical** sign `sgn(x)`: `sgn(0) = 0` (NOT `f64::signum`, which returns `+1` for zero). Folded into the **existing** `eval_unary` arm (no new recursion frame — `deeply_nested…` stack-overflow test passes), but dimensionally in a **category of its own**:
- A sign is a pure number, so `sgn` **accepts any input dimension and collapses the result to `Scalar`** — unlike the dimension-*preserving* rounding family (`|dollars| = dollars`) and unlike the transcendentals (which *reject* a dimensioned operand). This makes `sgn(pressure_a − pressure_b)` — the direction of a net (dimensioned) quantity — a clean ±1.
- **Exact**: `±1`/`0` is rational, so the exact-rational sidecar is the sign of the numerator, carried as `q/1`.
- A NaN operand is produced explicitly so the shared non-finite guard rejects it (never laundered to `0`).

### The surface wiring (`adj-lang`)
`\operatorname{sgn}(x)` parses (like `\operatorname{trunc}`) as the operator-name juxtaposition `Bin(Mul, Text("sgn"), (x))` — `\operatorname` is a TEXT command. The adapter recognises it via the existing `operator_name_is(lhs, "sgn")` helper and lowers `ExprAst::Sign` → `ComputeOp::Sign`. (Parse shape confirmed empirically before wiring.) Reuses the operator-name-juxtaposition path already built for trunc — **no latex / math-frontend / mathml churn**; blast radius = `adj-lang` + `logic-engine`.

### Verification
- `cargo test -p logic-engine -p adj-lang -p adj-lang-cli -p adj-constraint-solver` — **all green**; the macOS `deeply_nested` stack-overflow guard passes.
- +4 engine unit tests (pos/neg/zero scalar; dimensioned-operand→Scalar; exact-sign sidecar; sign of a net difference) and +2 end-to-end `\operatorname{sgn}` tests through the full parse→lower→engine path.

### Files
- `logic-engine/src/compute.rs`, `logic-engine/{Cargo.toml,CHANGELOG.md}` (0.36.0 → 0.37.0)
- `adj-lang/src/{ast.rs,lower.rs,adapter.rs}`, `adj-lang/{Cargo.toml,CHANGELOG.md}` (0.32.0 → 0.33.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
