### PR TITLE
feat(adj-lang): \operatorname{floor/ceil/round} word spellings in latex "…"

### DIFF
--- a/code/packages/rust/adj-lang/CHANGELOG.md
+++ b/code/packages/rust/adj-lang/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.34.0] - 2026-07-02 — `\operatorname{floor/ceil/round}` word spellings in `latex "…"`
+
+### Added
+
+- `latex "\operatorname{floor}(x)"`, `\operatorname{ceil}(x)`, and `\operatorname{round}(x)`
+  now compute the **word-spelled roundings**, reaching the SAME `ComputeOp`s as their
+  already-supported Unicode-bracket twins (`⌊x⌋`→`Floor`, `⌈x⌉`→`Ceil`, `⌊x⌉`→`Round`): a
+  model that writes the operator *name* instead of the bracket lands on the identical node.
+  `\operatorname{…}` is a TEXT command, so each parses as the operator-name juxtaposition
+  `Bin(Mul, Text("floor"), (x))` — the same shape the adapter already recognises for
+  `\operatorname{trunc}`/`\operatorname{sgn}` — and lowers via `operator_name_is(lhs, …)` to
+  the existing `ExprAst::Floor`/`Ceil`/`Round` (dimension-preserving). Pure **adapter**
+  recognition: no engine, AST, or lowering change. +1 e2e unit test (floor/ceil/round).
+
 ## [0.33.0] - 2026-07-02 — `\operatorname{sgn}` sign function in `latex "…"`
 
 ### Added

--- a/code/packages/rust/adj-lang/Cargo.toml
+++ b/code/packages/rust/adj-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang"
-version = "0.33.0"
+version = "0.34.0"
 edition = "2021"
 description = "Surface-syntax frontend for the adjudication framework's probabilistic-logic rulebooks. Lexes, parses, and lowers a domain-expert-readable DSL into a `logic-engine` KnowledgeBase. Dissolves ADJ46 awkwardness items A10 (rulebook syntax) and A4 (joint contributions syntactically distinct)."
 

--- a/code/packages/rust/adj-lang/src/adapter.rs
+++ b/code/packages/rust/adj-lang/src/adapter.rs
@@ -982,6 +982,26 @@ fn latex_math_to_expr_ast(expr: &MathExpr, source: &str) -> Result<ExprAst, Adap
         MathExpr::Bin(BinOp::Mul, lhs, rhs) if operator_name_is(lhs, "sgn") => {
             Ok(ExprAst::Sign(Box::new(latex_math_to_expr_ast(rhs, source)?)))
         }
+        // `\operatorname{floor}(x)` / `\operatorname{ceil}(x)` / `\operatorname{round}(x)` —
+        // the word-spelled roundings. These are the operator-name twins of the Unicode-
+        // bracket forms already lowered elsewhere (`⌊x⌋` → `ExprAst::Floor`, `⌈x⌉` →
+        // `ExprAst::Ceil`, `⌊x⌉` → `ExprAst::Round`): a model that writes the *name* instead
+        // of the bracket should reach the SAME `ComputeOp`. `\operatorname{…}` is a TEXT
+        // command, so — exactly like `\operatorname{trunc}`/`\operatorname{sgn}` above —
+        // `\operatorname{floor}(x)` parses as the juxtaposition `Bin(Mul, Text("floor"), (x))`.
+        // We intercept that shape here, ABOVE the general `Bin(Mul, …)` product arm, so a
+        // genuine product (`2x`) still multiplies; only a `floor`/`ceil`/`round`-named text
+        // LEFT factor is captured, and each maps to its existing dimension-preserving
+        // `ExprAst` node (no engine/AST/lowering change — pure adapter recognition).
+        MathExpr::Bin(BinOp::Mul, lhs, rhs) if operator_name_is(lhs, "floor") => {
+            Ok(ExprAst::Floor(Box::new(latex_math_to_expr_ast(rhs, source)?)))
+        }
+        MathExpr::Bin(BinOp::Mul, lhs, rhs) if operator_name_is(lhs, "ceil") => {
+            Ok(ExprAst::Ceil(Box::new(latex_math_to_expr_ast(rhs, source)?)))
+        }
+        MathExpr::Bin(BinOp::Mul, lhs, rhs) if operator_name_is(lhs, "round") => {
+            Ok(ExprAst::Round(Box::new(latex_math_to_expr_ast(rhs, source)?)))
+        }
         // `a \bmod b` / `a \pmod{b}` — the modulo operator. `\bmod`/`\pmod` are not in
         // the frontend's operator tables, so they lower to a bare `Symbol("bmod")` /
         // `Symbol("pmod")` and the whole expression parses as a LEFT-associated implicit

--- a/code/packages/rust/adj-lang/src/lower.rs
+++ b/code/packages/rust/adj-lang/src/lower.rs
@@ -2064,6 +2064,46 @@ contributes 1000000 from answer == 60 to correct
     }
 
     #[test]
+    fn native_latex_operatorname_floor_ceil_round_word_spellings() {
+        // The word-spelled roundings reach the SAME ComputeOps as their Unicode-bracket
+        // twins (`⌊⌋`/`⌈⌉`/`⌊⌉`). `\operatorname{…}` is a TEXT command, so each parses as
+        // the operator-name juxtaposition `Bin(Mul, Text(name), (arg))` — the same shape as
+        // `\operatorname{trunc}`/`\operatorname{sgn}` — which the adapter now intercepts.
+        // Values chosen so the answer is unambiguous under any half-rounding convention:
+        //   floor(7/2) = floor(3.5) = 3,  ceil(7/2) = ceil(3.5) = 4,  round(9/4) = round(2.25) = 2.
+        let floor = crate::compile_and_decide(
+            "observe a(7)\n\
+             observe b(2)\n\
+             let answer = latex \"$\\operatorname{floor}(a / b)$\"\n\
+             prior 0.10 for correct\n\
+             contributes 1000000 from answer == 3 to correct\n\
+             ? correct\n",
+        )
+        .unwrap();
+        assert!(floor.ranked[0].posterior > 0.99, "{floor:?}");
+        let ceil = crate::compile_and_decide(
+            "observe a(7)\n\
+             observe b(2)\n\
+             let answer = latex \"$\\operatorname{ceil}(a / b)$\"\n\
+             prior 0.10 for correct\n\
+             contributes 1000000 from answer == 4 to correct\n\
+             ? correct\n",
+        )
+        .unwrap();
+        assert!(ceil.ranked[0].posterior > 0.99, "{ceil:?}");
+        let round = crate::compile_and_decide(
+            "observe a(9)\n\
+             observe b(4)\n\
+             let answer = latex \"$\\operatorname{round}(a / b)$\"\n\
+             prior 0.10 for correct\n\
+             contributes 1000000 from answer == 2 to correct\n\
+             ? correct\n",
+        )
+        .unwrap();
+        assert!(round.ranked[0].posterior > 0.99, "{round:?}");
+    }
+
+    #[test]
     fn native_latex_exp_of_ln_round_trips() {
         // `\exp(\ln(x))` with x=5 returns 5, computed on the native transcendental
         // ComputeOp::Exp/Ln via the `MathExpr::Call` → `ExprAst::Call` path. A


### PR DESCRIPTION
## LaTeX consumer slice: `\operatorname{floor/ceil/round}` word spellings

Math-tuned models write the rounding operators two ways: the Unicode brackets
(`⌊x⌋`, `⌈x⌉`, `⌊x⌉`) — already lowered to `ComputeOp::Floor/Ceil/Round` — and the
**word spellings** `\operatorname{floor}(x)` / `\operatorname{ceil}(x)` /
`\operatorname{round}(x)`. This PR makes the word spellings reach the **same**
compute nodes, so which surface the model picks no longer changes whether the
expression computes.

### Why an adapter-only change

`\operatorname{…}` is a TEXT command (like `\text`/`\mathrm`), so the frontend
parses `\operatorname{floor}(x)` **not** as a function call but as the operator-name
juxtaposition `Bin(Mul, Text("floor"), (x))` — the exact shape the adapter already
recognises for `\operatorname{trunc}` and `\operatorname{sgn}`. Empirically probed
before wiring (throwaway `latex/tests/` probe, deleted):

```
"\operatorname{floor}(x)" => Bin(Mul, Text("floor"), Fenced { open:"(", body:Symbol("x"), close:")" })
```

`floor`/`ceil`/`round` currently fall through to the general `Bin(Mul, …)` product
arm (a bare `Text` factor → `UnsupportedLatexMath`). Three new arms — mirroring the
`sgn` arm exactly — intercept the named factor and lower to the already-existing
`ExprAst::Floor/Ceil/Round` (dimension-preserving). **No engine, AST, or lowering
change** — the `ComputeOp`s and `ExprAst` variants already exist.

Also probed, for the record: factorial `n!` — the latex grammar rejects `!` as a
trailing token (no postfix operator), so that slice would need a parser-grammar
change, not an adapter one; deferred.

### Tests

`native_latex_operatorname_floor_ceil_round_word_spellings` — three end-to-end
`compile_and_decide` cases, values chosen unambiguous under any half-rounding
convention: `floor(7/2)=3`, `ceil(7/2)=4`, `round(9/4)=2`.

`cargo test -p logic-engine -p adj-lang -p adj-lang-cli -p adj-constraint-solver` green.
Security review: PASSED (pure AST-to-AST rewrite, no new recursion depth vs. the
mirrored `trunc` arm).

adj-lang 0.33.0 → 0.34.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
