### PR TITLE
test(closure-emitter): CLOC12.156 — CodePrinter template-literal conformance port

### DIFF
--- a/code/packages/rust/closure-emitter/CHANGELOG.md
+++ b/code/packages/rust/closure-emitter/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to the `coding-adventures-closure-emitter` crate will be documented in this file.
 
+## [0.21.2] - 2026-07-02
+
+### Test — CLOC12.156: CodePrinter template-literal conformance port
+
+New upstream port `tests/upstream/code_printer_template_test.rs` (from
+`CodePrinterTest.java`) isolating `emit_template_literal` /
+`emit_template_element` + the `PREC_PRIMARY` classification that landed with
+`Expression::TemplateLiteral` (CLOC12.154). **17 active `#[test]`s + 1
+`#[ignore]`.** Coverage: no-substitution templates (empty, escaped backtick
+`` `hel\`lo` ``, escaped `` \${ ``); a template as an unwrapped member-access
+object (`` `hello`.length ``) and as an unwrapped `+` / `==` operand
+(`` `hello`+world ``) — it is primary; and `${…}` substitution templates
+(single `` `${world}` ``, adjacent `` `${a}${b}` ``, text-interleaved
+`` `hello ${world}` ``, low-precedence body `` `${a+b}` ``, member-access body
+`` `${hello.length}` ``). Inputs are hand-constructed AST so the port exercises
+`${…}` substitution templates the grammar tokenises only as no-substitution
+today (gap-157) — the emitter already prints them; the parser can't yet feed
+them. Test-only; no `src/` change. The one ignored case (a quasi carrying a
+*literal* embedded newline) surfaces **gap-158** — `emit_template_element`
+routes `raw` through `write_str`, which forbids embedded `'\n'`. *Tagged*
+templates are intentionally not ported (no `TaggedTemplateExpression` AST node).
+
 ## [0.21.1] - 2026-07-02
 
 ### Test — CLOC12.153: CodePrinter arrow-function conformance port

--- a/code/packages/rust/closure-emitter/Cargo.toml
+++ b/code/packages/rust/closure-emitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-emitter"
-version = "0.21.1"
+version = "0.21.2"
 edition = "2021"
 description = "JavaScript code emitter for the Closure Compiler clone. Per CLOC07's emit contract. Takes a finalized Program + sidecar and produces output JavaScript text + companion source map. Runs after every pass in the pipeline."
 
@@ -56,3 +56,7 @@ path = "tests/upstream/code_printer_function_test.rs"
 [[test]]
 name = "upstream_code_printer_arrow"
 path = "tests/upstream/code_printer_arrow_test.rs"
+
+[[test]]
+name = "upstream_code_printer_template"
+path = "tests/upstream/code_printer_template_test.rs"

--- a/code/packages/rust/closure-emitter/README.md
+++ b/code/packages/rust/closure-emitter/README.md
@@ -105,6 +105,21 @@ test-port convention. Each file isolates one printing area:
   (including the `"__proto__"` exception), shorthand, and statement-start
   parenthesization. 13 active `#[test]`s, no `#[ignore]`. Run with
   `cargo test --test upstream_code_printer_object_literal`.
+- `code_printer_function_test.rs` — function-expression printing:
+  anonymous / named, params, body, IIFE, member-object and call-argument
+  wrapping, generator / async prefixes. Run with
+  `cargo test --test upstream_code_printer_function`.
+- `code_printer_arrow_test.rs` — arrow-function printing: param-paren drop,
+  concise vs block body, object-literal-body wrap, IIFE, member-object,
+  call-argument, async prefix. Run with
+  `cargo test --test upstream_code_printer_arrow`.
+- `code_printer_template_test.rs` — template-literal printing: no-substitution
+  templates (escaped backtick / `${`), a template as an unwrapped member-object
+  and binary operand (it is primary), and `${…}` substitution templates
+  (single / adjacent / text-interleaved / low-precedence and member-access
+  bodies). 17 active `#[test]`s + 1 `#[ignore]` (gap-158, a quasi with a
+  literal embedded newline). Run with
+  `cargo test --test upstream_code_printer_template`.
 
 ## Dependency whitelist
 

--- a/code/packages/rust/closure-emitter/tests/upstream/ATTRIBUTION.md
+++ b/code/packages/rust/closure-emitter/tests/upstream/ATTRIBUTION.md
@@ -38,6 +38,24 @@ under the Apache License, Version 2.0:
       port can exercise block-bodied arrows the grammar can't yet parse
       (gap-156).
 
+- `code_printer_template_test.rs`
+    - upstream: `test/com/google/javascript/jscomp/CodePrinterTest.java`
+      (the template-literal `` `…` `` printing cases, including `${…}`
+      substitutions and the multiline internal-whitespace case)
+    - tracked commit: see `UPSTREAM_SHA`
+    - Isolates `emit_template_literal` / `emit_template_element` + the
+      `PREC_PRIMARY` classification that landed with
+      `Expression::TemplateLiteral` (CLOC12.154). 17 active `#[test]`s and
+      1 `#[ignore]` — the emitter conforms to every covered shape
+      (no-substitution, escaped backtick / escaped `${`, member-object and
+      binary operands without wrapping, single / adjacent / text-interleaved
+      `${…}` substitutions, and low-precedence / member-access substitution
+      bodies). Inputs are hand-constructed AST so the port can exercise
+      `${…}` substitution templates the grammar tokenises only as
+      no-substitution today (gap-157). The one ignored case is a quasi
+      carrying a *literal* embedded newline, which the emitter's `write_str`
+      path rejects (gap-158).
+
 ## Translation notes
 
 Fourth port under CLOC12 (after `closure-pass-constant-fold` in
@@ -75,4 +93,7 @@ ignored ports.
 
 ## Skipped (intentionally not ported)
 
-None yet.
+- Upstream `CodePrinterTest`'s **tagged template** cases
+  (`` tag`${x} world` ``). We have no `TaggedTemplateExpression` AST node
+  yet, so these inputs cannot be hand-constructed. They come in with a
+  future tagged-template AST slice, not this port.

--- a/code/packages/rust/closure-emitter/tests/upstream/code_printer_template_test.rs
+++ b/code/packages/rust/closure-emitter/tests/upstream/code_printer_template_test.rs
@@ -1,0 +1,324 @@
+//! Ported from `CodePrinterTest.java` in `google/closure-compiler`,
+//! Apache-2.0. Upstream SHA: see `tests/upstream/UPSTREAM_SHA`.
+//!
+//! Translation policy: see
+//! `code/specs/CLOC12-upstream-test-suite-port.md`.
+//!
+//! # What this file covers
+//!
+//! Upstream `CodePrinterTest`'s **template-literal** printing cases — the
+//! backtick `` `…` `` form, both the no-substitution shape and the
+//! `${…}`-substitution shape. This is the tenth CodePrinter port into
+//! `closure-emitter` (after core / declarations / trailing-comma / numbers /
+//! string-escape / ascii-escape / object-literal / function-expression /
+//! arrow-function) and isolates `emit_template_literal` +
+//! `emit_template_element` + the `PREC_PRIMARY` classification that landed
+//! with `Expression::TemplateLiteral` (CLOC12.154).
+//!
+//! ## How the emitter prints a template literal (recap)
+//!
+//! A template is `quasis` (the fixed string parts) interleaved with
+//! `expressions` (the `${…}` inserts), under the structural invariant
+//! `quasis.len() == expressions.len() + 1` so a quasi both opens and closes
+//! the run:
+//!
+//! ```text
+//!   `q0${e0}q1${e1}…qN`
+//! ```
+//!
+//! Each quasi is emitted from its **raw** text verbatim (escape sequences
+//! intact) so the template round-trips byte-for-byte. (A quasi carrying a
+//! *literal* embedded newline is the one exception the emitter can't print
+//! yet — see the `raw_preserves_internal_newline` case and gap-158.) A
+//! `${…}` insert is a self-delimiting full-expression context, so the inner
+//! expression is emitted at the loosest precedence — the braces already fence
+//! it, so even a low-precedence body like `a+b` needs no parens.
+//!
+//! ```text
+//!   `hello`               no-substitution           → `hello`
+//!   `${world}`            single insert, empty edges → `${world}`
+//!   `hello ${world}`      text then insert           → `hello ${world}`
+//!   `${a}${b}`            adjacent inserts           → `${a}${b}`
+//!   `${a + b}`            low-prec insert body       → `${a+b}`
+//! ```
+//!
+//! ## A template is a PRIMARY expression
+//!
+//! `Expression::TemplateLiteral` classifies as `PREC_PRIMARY` — the tightest
+//! binding, a leaf token-run bounded by backticks. So it is **never**
+//! parenthesised as an operand or as a member-access object:
+//!
+//! ```text
+//!   `hello`.length        member object   → `hello`.length   (no wrap)
+//!   `hello` + world       `+` left operand → `hello`+world    (no wrap)
+//!   `hello` == world      `==` left operand → `hello`==world  (no wrap)
+//! ```
+//!
+//! ## Note on hand-constructed inputs
+//!
+//! These assertions build typed-AST inputs directly (upstream lex/parses
+//! source). That lets the port exercise **`${…}`-substitution** templates —
+//! multi-part `quasis` with `expressions` — which the emitter prints
+//! correctly even though the current grammar tokenises only no-substitution
+//! templates into the bridge (see CLOC12-gaps gap-157). The emitter is the
+//! unit under test here, not the parser.
+//!
+//! ## Tagged templates
+//!
+//! Upstream also covers `` tag`${x} world` `` (tagged template expressions).
+//! We have no `TaggedTemplateExpression` AST node yet, so those cases cannot
+//! be hand-constructed and are intentionally not ported (see ATTRIBUTION.md
+//! "Skipped").
+
+use coding_adventures_closure_emitter::{emit, EmitOptions};
+use coding_adventures_correlation_vector::CVLog;
+use coding_adventures_javascript_ast::{
+    BinaryExpression, BinaryOperator, Expression, ExpressionStatement, Identifier, MemberExpression,
+    Program, ProgramItem, SourceType, Statement, TemplateElement, TemplateLiteral,
+};
+use coding_adventures_javascript_tokens::EsVersion;
+use coding_adventures_type_sidecar::Sidecar;
+
+// =====================================================================
+// Test-support helpers
+// =====================================================================
+
+fn ident(name: &str) -> Expression {
+    Expression::Identifier(Identifier { cv: None, name: name.to_string() })
+}
+
+/// One template quasi built from its raw text. `cooked` mirrors `raw` for
+/// these ASCII cases; the emitter re-emits `raw` regardless.
+fn quasi(raw: &str, tail: bool) -> TemplateElement {
+    TemplateElement { cv: None, raw: raw.to_string(), cooked: Some(raw.to_string()), tail }
+}
+
+fn template(quasis: Vec<TemplateElement>, expressions: Vec<Expression>) -> Expression {
+    Expression::TemplateLiteral(TemplateLiteral { cv: None, quasis, expressions })
+}
+
+/// A no-substitution template: a single tail quasi, no inserts.
+fn template_no_sub(raw: &str) -> Expression {
+    template(vec![quasi(raw, true)], vec![])
+}
+
+fn member(object: Expression, property: &str) -> Expression {
+    Expression::MemberExpression(MemberExpression {
+        cv: None,
+        object: Box::new(object),
+        property: Box::new(ident(property)),
+        computed: false,
+    })
+}
+
+fn binary(op: BinaryOperator, left: Expression, right: Expression) -> Expression {
+    Expression::BinaryExpression(BinaryExpression {
+        cv: None,
+        operator: op,
+        left: Box::new(left),
+        right: Box::new(right),
+    })
+}
+
+fn stmt(expr: Expression) -> ProgramItem {
+    ProgramItem::Statement(Statement::expression_statement(ExpressionStatement {
+        cv: None,
+        expression: expr,
+    }))
+}
+
+fn emit_default(expr: Expression) -> String {
+    let prog =
+        Program::new_untraced(EsVersion::Es2025, SourceType::Module).with_body(vec![stmt(expr)]);
+    let sidecar = Sidecar::new();
+    let mut cv = CVLog::new(false);
+    emit(&prog, &sidecar, &mut cv, &EmitOptions::default())
+        .expect("emit failed")
+        .code
+}
+
+/// Upstream `assertPrint(input, expected)` reshaped: emit the expression as a
+/// single-statement program and assert the emitted code equals `expected`.
+fn assert_emits(expr: Expression, expected: &str) {
+    let code = emit_default(expr);
+    assert_eq!(
+        code, expected,
+        "template-literal emit output did not match\n  actual:   {:?}\n  expected: {:?}",
+        code, expected
+    );
+}
+
+// =====================================================================
+// Active — no-substitution templates
+// =====================================================================
+
+/// `assertPrintSame("`hello`")` — a plain template prints its raw text
+/// between backticks. A backtick is an unambiguous expression-statement
+/// start, so no leading paren wrap is added.
+#[test]
+fn no_substitution() {
+    assert_emits(template_no_sub("hello"), "`hello`;");
+}
+
+/// An empty template is a single empty quasi.
+#[test]
+fn empty_template() {
+    assert_emits(template_no_sub(""), "``;");
+}
+
+/// `assertPrintSame("`hel\\`lo`")` — an escaped backtick inside the literal
+/// is preserved verbatim by the raw round-trip (the emitter never re-escapes
+/// quasi text).
+#[test]
+fn raw_preserves_escaped_backtick() {
+    // The raw source between the delimiters is `hel\`lo` (a backslash then a
+    // backtick); emitted back unchanged.
+    assert_emits(template_no_sub("hel\\`lo"), "`hel\\`lo`;");
+}
+
+/// `assertPrintSame` for a template with a `${` that is escaped (`\\${`) — a
+/// literal dollar-brace, NOT a substitution — survives verbatim in the raw.
+#[test]
+fn raw_preserves_escaped_dollar_brace() {
+    assert_emits(template_no_sub("price: \\${x}"), "`price: \\${x}`;");
+}
+
+/// Upstream `testMultilineTemplateLiteralPreservesInternalWhitespace`: an
+/// internal newline (and its following indentation) is part of the raw text
+/// and *should* print exactly, never collapsed.
+///
+/// **Ignored — gap-158.** The emitter routes quasi text through `write_str`,
+/// which `debug_assert!`s the run contains no `'\n'` (newlines must go through
+/// `newline()` so the source-map line/col bookkeeping stays correct). A
+/// template quasi is the one primary token that can legitimately carry a raw
+/// newline, so `emit_template_element` needs a newline-aware write path before
+/// this case can pass. Tracked as gap-158; unignore when the emitter learns to
+/// split quasi raw on embedded newlines.
+#[test]
+#[ignore = "gap-158: emitter write_str forbids embedded newlines in template quasi raw"]
+fn raw_preserves_internal_newline() {
+    assert_emits(template_no_sub("hello\n  world"), "`hello\n  world`;");
+}
+
+// =====================================================================
+// Active — a template is a PRIMARY expression (never wrapped)
+// =====================================================================
+
+/// `assertPrintSame("`hello`.length")` — a template as a member-access
+/// object is a primary expression and needs no parens.
+#[test]
+fn member_object_no_wrap() {
+    assert_emits(member(template_no_sub("hello"), "length"), "`hello`.length;");
+}
+
+/// `assertPrintSame("`hello`.length.foo.bar")` — a member chain rooted on a
+/// template stays unwrapped the whole way down.
+#[test]
+fn member_chain_no_wrap() {
+    let m = member(member(member(template_no_sub("hello"), "length"), "foo"), "bar");
+    assert_emits(m, "`hello`.length.foo.bar;");
+}
+
+/// `assertPrintSame("`hello` + world")` — a template as the left operand of
+/// `+` needs no parens; the operator prints tight in compact mode.
+#[test]
+fn binary_add_left_operand() {
+    assert_emits(binary(BinaryOperator::Add, template_no_sub("hello"), ident("world")),
+        "`hello`+world;");
+}
+
+/// `assertPrintSame("`hello` == world")` — same for a comparison operator.
+#[test]
+fn binary_eq_left_operand() {
+    assert_emits(binary(BinaryOperator::Eq, template_no_sub("hello"), ident("world")),
+        "`hello`==world;");
+}
+
+/// `assertPrintSame("`hello` + `world`")` — two templates concatenated; each
+/// is primary so neither is wrapped.
+#[test]
+fn concat_two_templates() {
+    assert_emits(
+        binary(BinaryOperator::Add, template_no_sub("hello"), template_no_sub("world")),
+        "`hello`+`world`;",
+    );
+}
+
+// =====================================================================
+// Active — ${…} substitution templates
+// =====================================================================
+
+/// `assertPrintSame("`${world}`")` — a lone substitution with empty quasis on
+/// both edges.
+#[test]
+fn single_substitution_only() {
+    let t = template(vec![quasi("", false), quasi("", true)], vec![ident("world")]);
+    assert_emits(t, "`${world}`;");
+}
+
+/// `assertPrintSame("`hello ${world}`")` — fixed text then an insert; the
+/// leading quasi carries the literal `"hello "`.
+#[test]
+fn text_then_substitution() {
+    let t = template(vec![quasi("hello ", false), quasi("", true)], vec![ident("world")]);
+    assert_emits(t, "`hello ${world}`;");
+}
+
+/// `assertPrintSame("`${hello} world`")` — an insert then fixed text; the
+/// tail quasi carries `" world"`.
+#[test]
+fn substitution_then_text() {
+    let t = template(vec![quasi("", false), quasi(" world", true)], vec![ident("hello")]);
+    assert_emits(t, "`${hello} world`;");
+}
+
+/// `assertPrintSame("`${hello}${world}`")` — adjacent inserts have an empty
+/// quasi between them; the run still opens and closes with a (possibly empty)
+/// quasi.
+#[test]
+fn adjacent_substitutions() {
+    let t = template(
+        vec![quasi("", false), quasi("", false), quasi("", true)],
+        vec![ident("hello"), ident("world")],
+    );
+    assert_emits(t, "`${hello}${world}`;");
+}
+
+/// `assertPrintSame("`${a + b}`")` — a `${…}` context is the loosest, so a
+/// low-precedence additive body needs no inner parens; the braces fence it.
+#[test]
+fn substitution_body_low_precedence_no_parens() {
+    let sum = binary(BinaryOperator::Add, ident("a"), ident("b"));
+    let t = template(vec![quasi("", false), quasi("", true)], vec![sum]);
+    assert_emits(t, "`${a+b}`;");
+}
+
+/// `assertPrintSame("`${hello.length}`")` — a member-access substitution body
+/// prints normally inside the braces.
+#[test]
+fn substitution_body_member_access() {
+    let t = template(
+        vec![quasi("", false), quasi("", true)],
+        vec![member(ident("hello"), "length")],
+    );
+    assert_emits(t, "`${hello.length}`;");
+}
+
+/// `assertPrintSame("`${hello.length} ${world}`")` — two inserts separated by
+/// a fixed-text quasi.
+#[test]
+fn two_substitutions_with_text_between() {
+    let t = template(
+        vec![quasi("", false), quasi(" ", false), quasi("", true)],
+        vec![member(ident("hello"), "length"), ident("world")],
+    );
+    assert_emits(t, "`${hello.length} ${world}`;");
+}
+
+/// A substitution template as a member-access object is still primary — the
+/// whole `` `${x}` `` is unwrapped under `.length`.
+#[test]
+fn substitution_template_as_member_object() {
+    let t = template(vec![quasi("", false), quasi("", true)], vec![ident("x")]);
+    assert_emits(member(t, "length"), "`${x}`.length;");
+}

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -1576,3 +1576,38 @@ escape (`` `a\tb` ``) should have a `cooked` value with the escape *processed*
 this is never a correctness hazard for round-tripping; genuine cooked-value
 processing is a later refinement (needed once a pass reads `cooked` to fold a
 template to a string literal).
+
+## CLOC12.156 — CodePrinter template-literal conformance port (emitter)
+
+`closure-emitter` (0.21.2) gains `tests/upstream/code_printer_template_test.rs`
+— the tenth CodePrinter port, isolating `emit_template_literal` /
+`emit_template_element` + the `PREC_PRIMARY` classification that landed with
+`Expression::TemplateLiteral` (CLOC12.154). 17 active `#[test]`s and 1
+`#[ignore]`. Coverage: no-substitution templates (incl. empty, escaped
+backtick, escaped `${`), a template as an unwrapped member-access object and
+as an unwrapped `+` / `==` operand (it is primary), and `${…}` substitution
+templates (single, adjacent, text-interleaved, low-precedence body,
+member-access body). Inputs are hand-constructed AST so the port exercises
+`${…}` substitution templates the grammar tokenises only as no-substitution
+today (gap-157) — the emitter already prints them; the parser can't yet feed
+them. Test-only PR (no emitter code change); the one ignored case surfaces
+gap-158. *Tagged* templates are intentionally not ported (no
+`TaggedTemplateExpression` AST node — see the port's ATTRIBUTION).
+
+### gap-158 — emitter cannot print a template quasi with a *literal* embedded newline
+
+`emit_template_element` writes a quasi's `raw` text through the emitter's
+`write_str`, which `debug_assert!`s the run contains no `'\n'` — every newline
+must instead flow through `newline()` so the source-map line/column bookkeeping
+(and `line`/`col` counters) stay correct. A template quasi is the one *primary*
+token that can legitimately carry a raw newline (a multiline template such as
+`` `hello⏎world` `` preserves it verbatim per spec), so a quasi whose `raw`
+contains `\n` currently panics the emitter worker rather than printing. The fix
+is a newline-aware quasi-write path in `emit_template_element` (split `raw` on
+`\n`, emitting each segment via `write_str` and each break via `newline()`);
+until then the multiline case is `#[ignore]`d in the conformance port
+(`raw_preserves_internal_newline`). No correctness hazard for the shapes the
+bridge can actually produce today — the grammar's `TEMPLATE_NO_SUB` token can
+span newlines, but the no-substitution SIMPLE/ADVANCED path does not yet reach
+an input that stresses this (it declines multiline via the same token) — so
+this is an emitter-completeness gap, not a live miscompile.


### PR DESCRIPTION
## Summary

Tenth CodePrinter conformance port into `closure-emitter`, isolating `emit_template_literal` / `emit_template_element` + the `PREC_PRIMARY` classification that landed with `Expression::TemplateLiteral` (CLOC12.154). Test-only — no `src/` change.

New `tests/upstream/code_printer_template_test.rs` — **17 active `#[test]`s + 1 `#[ignore]`**:

- **No-substitution templates:** plain (`` `hello` ``), empty (`` `` ``), escaped backtick (`` `hel\`lo` ``), escaped `` \${ ``.
- **A template is PRIMARY** → never wrapped as a member-access object (`` `hello`.length ``, chained) or as a `+` / `==` operand (`` `hello`+world ``, `` `hello`==world ``, `` `hello`+`world` ``).
- **`${…}` substitution templates:** single (`` `${world}` ``), adjacent (`` `${a}${b}` ``), text-interleaved (`` `hello ${world}` ``, `` `${hello} world` ``), low-precedence body (`` `${a+b}` `` — no inner parens), member-access body (`` `${hello.length}` ``), and a substitution template as an unwrapped member object (`` `${x}`.length ``).

Inputs are hand-constructed AST (like the arrow port) so the port exercises `${…}` substitution templates the grammar tokenises only as no-substitution today (gap-157) — the emitter already prints them; the parser can't yet feed them.

## New gap-158

The one ignored case (`raw_preserves_internal_newline`) surfaces **gap-158**: `emit_template_element` routes quasi `raw` through `write_str`, which `debug_assert!`s no embedded `'\n'` (newlines must flow through `newline()` for source-map line/col bookkeeping). A multiline template quasi is the one primary token that can legitimately carry a raw newline; the fix is a newline-aware quasi-write path. Not a live miscompile — the no-substitution SIMPLE/ADVANCED path doesn't yet reach a multiline input.

*Tagged* templates (`` tag`…` ``) are intentionally not ported — no `TaggedTemplateExpression` AST node yet (see ATTRIBUTION "Skipped").

## Testing

- `cargo test -p coding-adventures-closure-emitter --test upstream_code_printer_template` → 17 passed, 1 ignored.
- `cargo test -p coding-adventures-closure-emitter` (full suite) → all green.
- Inline security review: **PASSED** (test-only, no unsafe / IO / user input).

## Housekeeping

`closure-emitter` 0.21.1 → 0.21.2 · `[[test]]` entry registered · ATTRIBUTION + CHANGELOG + README (also back-filled the stale function/arrow README entries) + CLOC12-gaps (CLOC12.156 + gap-158) updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)