### PR TITLE
[codex] Add pending spec audit evidence checks

### DIFF
--- a/code/packages/rust/html-parser/tests/whatwg_legacy_element_audit_test.rs
+++ b/code/packages/rust/html-parser/tests/whatwg_legacy_element_audit_test.rs
@@ -5,12 +5,43 @@ use serde::Deserialize;
 use std::collections::{BTreeMap, HashMap};
 
 const TREE_CONSTRUCTION_SMOKE: &str = include_str!("fixtures/html5lib-tree-construction-smoke.dat");
+const WHATWG_FRAMESET_AUDIT: &str = include_str!("fixtures/whatwg-frameset-audit.json");
 const WHATWG_LEGACY_ELEMENT_AUDIT: &str = include_str!("fixtures/whatwg-legacy-element-audit.json");
 const POST_PARSE_REPAIR_EVIDENCE: &[(&str, &str)] = &[
     ("tricky01-dat-3", "tricky-parser-recovery"),
     ("tricky01-dat-8", "tricky-parser-recovery"),
     ("tricky01-dat-9", "tricky-parser-recovery"),
 ];
+const PENDING_SPEC_BOUNDARY_EVIDENCE: &[PendingSpecBoundaryCase] = &[
+    PendingSpecBoundaryCase {
+        id: "pending-spec-changes-plain-text-unsafe-dat-345",
+        source: "pending-spec-changes-plain-text-unsafe.dat:345",
+        data_snippet: "<body><table>\0filler\0text\0",
+    },
+    PendingSpecBoundaryCase {
+        id: "pending-spec-changes-dat-346",
+        source: "pending-spec-changes.dat:346",
+        data_snippet: "<input type=\"hidden\"><frameset>",
+    },
+    PendingSpecBoundaryCase {
+        id: "pending-spec-changes-dat-347",
+        source: "pending-spec-changes.dat:347",
+        data_snippet: "<!DOCTYPE html><table><caption><svg>foo</table>bar",
+    },
+    PendingSpecBoundaryCase {
+        id: "pending-spec-changes-dat-348",
+        source: "pending-spec-changes.dat:348",
+        data_snippet: "<table><tr><td><svg><desc><td></desc><circle>",
+    },
+];
+const PENDING_SPEC_FRAMESET_CROSS_AXIS_CASES: &[(&str, &str)] =
+    &[("pending-spec-changes-dat-346", "body-compatibility")];
+
+struct PendingSpecBoundaryCase {
+    id: &'static str,
+    source: &'static str,
+    data_snippet: &'static str,
+}
 
 #[derive(Debug, Deserialize)]
 struct LegacyElementAuditSuite {
@@ -24,6 +55,19 @@ struct LegacyElementAuditSuite {
 
 #[derive(Debug, Deserialize)]
 struct LegacyElementAuditCase {
+    id: String,
+    source: String,
+    axis: String,
+    reason: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GenericAuditSuite {
+    cases: Vec<GenericAuditCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GenericAuditCase {
     id: String,
     source: String,
     axis: String,
@@ -113,6 +157,102 @@ fn whatwg_legacy_element_audit_tracks_post_parse_repair_evidence() {
             actual, source_case.document,
             "post-parse repair evidence case `{}` ({}) failed for input {:?}",
             audit_case.id, audit_case.axis, source_case.data
+        );
+    }
+}
+
+#[test]
+fn whatwg_legacy_element_audit_tracks_pending_spec_boundary_evidence() {
+    let suite = load_suite();
+    let audit_cases = suite
+        .cases
+        .iter()
+        .map(|case| (case.id.as_str(), case))
+        .collect::<HashMap<_, _>>();
+    let smoke_cases = parse_tree_construction_cases(TREE_CONSTRUCTION_SMOKE)
+        .into_iter()
+        .map(|case| (case.source.clone(), case))
+        .collect::<HashMap<_, _>>();
+
+    for evidence in PENDING_SPEC_BOUNDARY_EVIDENCE {
+        let audit_case = audit_cases.get(evidence.id).unwrap_or_else(|| {
+            panic!(
+                "pending spec boundary evidence case `{}` should be audited",
+                evidence.id
+            )
+        });
+        assert_eq!(
+            audit_case.source, evidence.source,
+            "pending spec boundary case `{}` should stay tied to its WHATWG source row",
+            evidence.id
+        );
+        assert_eq!(
+            audit_case.axis, "pending-spec-boundary",
+            "pending spec boundary case `{}` should stay on its focused audit axis",
+            evidence.id
+        );
+        assert!(
+            !audit_case.reason.is_empty(),
+            "pending spec boundary case `{}` should keep a fixture reason",
+            evidence.id
+        );
+
+        let source_case = smoke_cases
+            .get(evidence.source)
+            .unwrap_or_else(|| panic!("case `{}` should exist in smoke fixture", evidence.source));
+        assert!(
+            source_case.data.contains(evidence.data_snippet),
+            "pending spec boundary case `{}` should stay tied to its html5lib input",
+            evidence.id
+        );
+        let actual = actual_dom_dump_for_tree_case(source_case).unwrap_or_else(|error| {
+            panic!(
+                "case `{}` ({}) parse failed: {error}",
+                audit_case.id, audit_case.axis
+            )
+        });
+
+        assert_eq!(
+            actual, source_case.document,
+            "pending spec boundary evidence case `{}` ({}) failed for input {:?}",
+            audit_case.id, audit_case.axis, source_case.data
+        );
+    }
+}
+
+#[test]
+fn whatwg_legacy_element_audit_keeps_pending_spec_frameset_case_cross_axis() {
+    let legacy_suite = load_suite();
+    let frameset_suite: GenericAuditSuite = serde_json::from_str(WHATWG_FRAMESET_AUDIT)
+        .expect("WHATWG frameset audit fixture should parse");
+
+    for (case_id, expected_frameset_axis) in PENDING_SPEC_FRAMESET_CROSS_AXIS_CASES {
+        let legacy_case = legacy_suite
+            .cases
+            .iter()
+            .find(|case| case.id == *case_id)
+            .unwrap_or_else(|| panic!("legacy audit should include `{case_id}`"));
+        let frameset_case = frameset_suite
+            .cases
+            .iter()
+            .find(|case| case.id == *case_id)
+            .unwrap_or_else(|| panic!("frameset audit should include `{case_id}`"));
+
+        assert_eq!(
+            legacy_case.axis, "pending-spec-boundary",
+            "legacy audit should keep `{case_id}` on its pending spec axis"
+        );
+        assert_eq!(
+            frameset_case.axis, *expected_frameset_axis,
+            "frameset audit should keep `{case_id}` on its frameset-specific axis"
+        );
+        assert_eq!(
+            legacy_case.source, frameset_case.source,
+            "cross-axis pending spec case `{case_id}` should point at the same WHATWG source row"
+        );
+        assert!(
+            !legacy_case.reason.is_empty() && !frameset_case.reason.is_empty(),
+            "cross-axis pending spec case `{case_id}` should keep fixture reasons"
         );
     }
 }


### PR DESCRIPTION
## Summary
- Add executable evidence for the legacy-element pending spec boundary audit rows
- Pin each row to its html5lib/WHATWG source input snippet
- Add a cross-axis guard for the shared frameset pending-spec row

## Validation
- cargo test -p coding-adventures-html-parser whatwg_legacy_element_audit_tracks_pending_spec_boundary_evidence
- cargo test -p coding-adventures-html-parser whatwg_legacy_element_audit_keeps_pending_spec_frameset_case_cross_axis
- cargo test -p coding-adventures-html-parser whatwg_legacy_element_audit
- cargo test -p coding-adventures-html-parser
- CARGO_BUILD_JOBS=2 cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser
- python3 -m json.tool code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json >/dev/null
- python3 code/packages/rust/html-parser/tests/fixtures/check_whatwg_audit_rust_tests.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py
- git diff --check