### PR TITLE
Harden generated XAML build scripts

### DIFF
--- a/code/packages/rust/.cargo/config.toml
+++ b/code/packages/rust/.cargo/config.toml
@@ -1,10 +1,8 @@
-# On Windows, Ruby's MSYS2 ships its own `link.exe` which shadows the MSVC
-# linker. The MSVC dev environment step runs before Ruby in CI, but
-# `ruby/setup-ruby` prepends MSYS2 to PATH afterward, overriding it.
+# On Windows, Ruby's MSYS2 and Git can ship their own `link.exe` that shadows
+# the MSVC linker.
 #
-# lld-link is the MSVC-compatible LLVM linker that ships with Visual Studio
-# 2022 (at VC\Tools\Llvm\x64\bin\lld-link.exe). It is already in PATH via
-# the `ilammy/msvc-dev-cmd` step and is NOT overridden by MSYS2. Using it
-# as the linker avoids the MSYS2 `link.exe` conflict entirely.
+# rust-lld is the MSVC-compatible LLVM linker bundled with the Rust toolchain.
+# Using it avoids the shadowed `link.exe` conflict without requiring every
+# local dev shell to have Visual Studio's `lld-link.exe` on PATH.
 [target.x86_64-pc-windows-msvc]
-linker = "lld-link"
+linker = "rust-lld"

--- a/code/packages/rust/mosaic-emit-xaml/CHANGELOG.md
+++ b/code/packages/rust/mosaic-emit-xaml/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased] — VC2-xaml Grid: WinUI value translation + nested-For + per-column widths
 
+### Changed - XAML host build script reliability
+
+Generated `build.ps1` drivers now resolve `dotnet` from PATH or the standard
+`Program Files\dotnet\dotnet.exe` location before building, and fail with a
+non-zero exit code when the tool is unavailable. The `-Run` path also reports a
+missing executable or non-zero app exit instead of leaving the script looking
+green after a failed launch.
+
+The nested Windows Rust workspace config now uses the Rust-bundled `rust-lld`
+linker, matching the repo root and avoiding accidental resolution of Git/MSYS
+`link.exe` without requiring Visual Studio's `lld-link.exe` in local dev shells.
+
 ### Added - Mosaic event envelopes for WinUI hosts
 
 Generated non-empty `{Component}.Event.cs` unions now expose `MosaicName`,

--- a/code/packages/rust/mosaic-emit-xaml/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-xaml/src/pipeline.rs
@@ -3490,7 +3490,19 @@ fn emit_build_script(name: &str) -> String {
          #\n\
          param([switch]$Clean, [switch]$Run)\n\
          \n\
+         $ErrorActionPreference = \"Stop\"\n\
          $proj = Join-Path $PSScriptRoot \"{name}.csproj\"\n\
+         $dotnet = (Get-Command dotnet -ErrorAction SilentlyContinue).Source\n\
+         if (-not $dotnet) {{\n    \
+             $defaultDotnet = Join-Path $env:ProgramFiles \"dotnet\\dotnet.exe\"\n    \
+             if (Test-Path $defaultDotnet) {{\n        \
+                 $dotnet = $defaultDotnet\n    \
+             }}\n\
+         }}\n\
+         if (-not $dotnet) {{\n    \
+             Write-Error \"dotnet was not found on PATH or at $env:ProgramFiles\\dotnet\\dotnet.exe\"\n    \
+             exit 127\n\
+         }}\n\
          \n\
          if ($Clean) {{\n    \
              Remove-Item -Recurse -Force -ErrorAction SilentlyContinue (Join-Path $PSScriptRoot \"bin\")\n    \
@@ -3500,7 +3512,7 @@ fn emit_build_script(name: &str) -> String {
          # The Platform=x64 arg is required because WindowsAppSDK's\n\
          # self-contained mode rejects AnyCPU. The csproj's <Platforms>x64</Platforms>\n\
          # only declares the SET of platforms; the ACTIVE one comes from this arg.\n\
-         dotnet build $proj -c Debug -p:Platform=x64 --nologo\n\
+         & $dotnet build $proj -c Debug -p:Platform=x64 --nologo\n\
          $buildExitCode = $LASTEXITCODE\n\
          if ($buildExitCode -ne 0) {{\n    \
              exit $buildExitCode\n\
@@ -3517,8 +3529,13 @@ fn emit_build_script(name: &str) -> String {
              }}\n    \
              if (Test-Path $exe) {{\n        \
                  & $exe\n    \
+                 $runExitCode = $LASTEXITCODE\n        \
+                 if ($runExitCode -ne 0) {{\n            \
+                     exit $runExitCode\n        \
+                 }}\n    \
              }} else {{\n        \
                  Write-Host \"No .exe at $exe -- build must have failed.\" -ForegroundColor Red\n    \
+                 exit 1\n    \
              }}\n\
          }}\n"
     )
@@ -8678,6 +8695,9 @@ mod tests {
         assert!(p.main_window_cs.contains("Greeting"));
         // build.ps1 passes -p:Platform=x64.
         assert!(p.build_script.contains("-p:Platform=x64"));
+        assert!(p.build_script.contains("Get-Command dotnet"));
+        assert!(p.build_script.contains("dotnet\\dotnet.exe"));
+        assert!(p.build_script.contains("exit 127"));
         assert!(p.build_script.contains("$buildExitCode = $LASTEXITCODE"));
         assert!(p.build_script.contains("exit $buildExitCode"));
         // README documents the framework-dependent runtime requirement.


### PR DESCRIPTION
## Summary
- make generated XAML build.ps1 resolve dotnet from PATH or Program Files and fail loudly when unavailable
- propagate generated XAML launch failures from the -Run path
- use Rust-bundled rust-lld in the nested Windows Rust workspace config so local checks do not require Visual Studio's lld-link on PATH

## Validation
- cargo test -p mosaic-emit-xaml
- ./scripts/build-all.ps1 from code/programs/mosaic/engram-app
- ./build.ps1 -Clean from generated target/mosaic-engram-app/xaml
- controlled EngramApp.exe launch stayed alive for 8 seconds
- cargo test --manifest-path code/programs/mosaic/engram-app/Cargo.toml -- --nocapture