### PR TITLE
fix(closure-emitter): CLOC12.157 — newline-aware template quasi emit (gap-158)

### DIFF
--- a/code/packages/rust/closure-emitter/CHANGELOG.md
+++ b/code/packages/rust/closure-emitter/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to the `coding-adventures-closure-emitter` crate will be documented in this file.
 
+## [0.21.3] - 2026-07-02
+
+### Fixed — CLOC12.157 (gap-158): newline-aware template quasi emit
+
+`emit_template_element` now prints a template quasi whose `raw` text carries a
+**literal newline** — a multiline template `` `a⏎b` `` round-trips its interior
+line break byte-for-byte. Previously the quasi `raw` went straight to
+`write_str`, which `debug_assert!`s the run is newline-free (every `'\n'` must
+route through `newline()` so the source-map line/column bookkeeping stays
+correct); a multiline template therefore panicked the emitter worker. The fix
+splits `raw` on `'\n'`, writing each line segment via `write_str` and emitting a
+real `newline()` between segments, so `line` advances and `col` resets exactly
+as for any other newline. Single-line quasis are unaffected (one segment, no
+break). Other line-terminator bytes a raw may carry — a lone `'\r'` in a `\r\n`
+pair, and `U+2028` / `U+2029` — are written verbatim (bytes round-trip; only
+their column bookkeeping is approximate). Un-ignores the conformance port's
+`raw_preserves_internal_newline` (now 19 active `#[test]`s, **0 `#[ignore]`**)
+and adds three inline emitter tests. Resolves **gap-158**.
+
 ## [0.21.2] - 2026-07-02
 
 ### Test — CLOC12.156: CodePrinter template-literal conformance port

--- a/code/packages/rust/closure-emitter/Cargo.toml
+++ b/code/packages/rust/closure-emitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-emitter"
-version = "0.21.2"
+version = "0.21.3"
 edition = "2021"
 description = "JavaScript code emitter for the Closure Compiler clone. Per CLOC07's emit contract. Takes a finalized Program + sidecar and produces output JavaScript text + companion source map. Runs after every pass in the pipeline."
 

--- a/code/packages/rust/closure-emitter/README.md
+++ b/code/packages/rust/closure-emitter/README.md
@@ -117,8 +117,9 @@ test-port convention. Each file isolates one printing area:
   templates (escaped backtick / `${`), a template as an unwrapped member-object
   and binary operand (it is primary), and `${…}` substitution templates
   (single / adjacent / text-interleaved / low-precedence and member-access
-  bodies). 17 active `#[test]`s + 1 `#[ignore]` (gap-158, a quasi with a
-  literal embedded newline). Run with
+  bodies, and multiline quasis with literal interior newlines). 19 active
+  `#[test]`s, no `#[ignore]` (gap-158 resolved in CLOC12.157 — the emitter is
+  now newline-aware). Run with
   `cargo test --test upstream_code_printer_template`.
 
 ## Dependency whitelist

--- a/code/packages/rust/closure-emitter/src/lib.rs
+++ b/code/packages/rust/closure-emitter/src/lib.rs
@@ -1017,9 +1017,45 @@ impl<'a> Emitter<'a> {
     }
 
     /// Emit one [`TemplateElement`] — its verbatim `raw` text.
+    ///
+    /// A template quasi is the one *primary* token whose `raw` text may legally
+    /// contain a **literal newline**: a multiline template preserves its interior
+    /// line breaks byte-for-byte (`` `a⏎b` `` prints back with the newline
+    /// intact). Every other token the emitter writes is single-line.
+    ///
+    /// The low-level [`Self::write_str`] deliberately forbids an embedded `'\n'`
+    /// (it `debug_assert!`s the run is newline-free) because a raw newline must
+    /// route through [`Self::newline`] to keep the source-map line/column
+    /// bookkeeping correct — `write_str` only advances the *column*, whereas
+    /// `newline` bumps the *line* and resets the column. So we split `raw` on
+    /// `'\n'` and hand each line segment to `write_str`, emitting a real
+    /// `newline()` between segments:
+    ///
+    /// ```text
+    ///   raw = "a\nb\nc"   →   write_str("a") newline() write_str("b")
+    ///                          newline() write_str("c")
+    /// ```
+    ///
+    /// `str::split('\n')` yields `N + 1` pieces for `N` newlines, including an
+    /// empty leading piece when `raw` starts with `'\n'` and an empty trailing
+    /// piece when it ends with one; writing an empty `&str` is a harmless no-op,
+    /// so the line count still lands exactly on the number of `'\n'`s. Other
+    /// line-terminator bytes a raw may carry — a lone `'\r'` (as in a `\r\n`
+    /// pair, where the `'\r'` rides on the end of the preceding segment) and the
+    /// Unicode separators `U+2028` / `U+2029` — are written verbatim as ordinary
+    /// characters: bytes round-trip exactly, and only their column bookkeeping is
+    /// approximate, which is a source-map nicety, not an output-correctness bug.
     fn emit_template_element(&mut self, q: &TemplateElement) {
         self.maybe_map(&q.cv);
-        self.write_str(&q.raw);
+        let mut segments = q.raw.split('\n');
+        // There is always at least one segment (`split` never yields empty).
+        if let Some(first) = segments.next() {
+            self.write_str(first);
+            for segment in segments {
+                self.newline();
+                self.write_str(segment);
+            }
+        }
     }
 
     // ---- Expressions ---------------------------------------------
@@ -4093,5 +4129,30 @@ mod tests {
             computed: false,
         });
         assert_eq!(emit_expr(m), "`abc`.length;");
+    }
+
+    /// gap-158: a no-substitution template whose `raw` carries a *literal*
+    /// newline round-trips it verbatim — `emit_template_element` splits on
+    /// `'\n'` and routes the break through `newline()` instead of tripping
+    /// `write_str`'s no-embedded-newline assert.
+    #[test]
+    fn template_preserves_interior_newline() {
+        assert_eq!(emit_expr(template(vec![tquasi("a\nb", true)], vec![])), "`a\nb`;");
+    }
+
+    /// gap-158: the newline-aware path also covers quasis *inside* a `${…}`
+    /// substitution template — the leading quasi spans two lines around the
+    /// insert.
+    #[test]
+    fn template_substitution_quasi_preserves_newline() {
+        let t = template(vec![tquasi("a\nb", false), tquasi("c", true)], vec![ident("x")]);
+        assert_eq!(emit_expr(t), "`a\nb${x}c`;");
+    }
+
+    /// gap-158: a bare `'\n'` quasi (leading + trailing empty split segments)
+    /// emits just the newline — the empty segments write nothing.
+    #[test]
+    fn template_bare_newline_quasi() {
+        assert_eq!(emit_expr(template(vec![tquasi("\n", true)], vec![])), "`\n`;");
     }
 }

--- a/code/packages/rust/closure-emitter/tests/upstream/ATTRIBUTION.md
+++ b/code/packages/rust/closure-emitter/tests/upstream/ATTRIBUTION.md
@@ -45,16 +45,18 @@ under the Apache License, Version 2.0:
     - tracked commit: see `UPSTREAM_SHA`
     - Isolates `emit_template_literal` / `emit_template_element` + the
       `PREC_PRIMARY` classification that landed with
-      `Expression::TemplateLiteral` (CLOC12.154). 17 active `#[test]`s and
-      1 `#[ignore]` — the emitter conforms to every covered shape
+      `Expression::TemplateLiteral` (CLOC12.154). 19 active `#[test]`s and
+      **0 `#[ignore]`** — the emitter conforms to every covered shape
       (no-substitution, escaped backtick / escaped `${`, member-object and
       binary operands without wrapping, single / adjacent / text-interleaved
-      `${…}` substitutions, and low-precedence / member-access substitution
-      bodies). Inputs are hand-constructed AST so the port can exercise
-      `${…}` substitution templates the grammar tokenises only as
-      no-substitution today (gap-157). The one ignored case is a quasi
-      carrying a *literal* embedded newline, which the emitter's `write_str`
-      path rejects (gap-158).
+      `${…}` substitutions, low-precedence / member-access substitution
+      bodies, and multiline quasis with literal interior newlines). Inputs are
+      hand-constructed AST so the port can exercise `${…}` substitution
+      templates the grammar tokenises only as no-substitution today (gap-157).
+      The multiline case (`raw_preserves_internal_newline`) was `#[ignore]`d
+      under gap-158 until CLOC12.157 made `emit_template_element`
+      newline-aware; it and `raw_preserves_leading_and_trailing_newline` are
+      now active.
 
 ## Translation notes
 

--- a/code/packages/rust/closure-emitter/tests/upstream/code_printer_template_test.rs
+++ b/code/packages/rust/closure-emitter/tests/upstream/code_printer_template_test.rs
@@ -185,19 +185,24 @@ fn raw_preserves_escaped_dollar_brace() {
 
 /// Upstream `testMultilineTemplateLiteralPreservesInternalWhitespace`: an
 /// internal newline (and its following indentation) is part of the raw text
-/// and *should* print exactly, never collapsed.
+/// and prints exactly, never collapsed.
 ///
-/// **Ignored — gap-158.** The emitter routes quasi text through `write_str`,
-/// which `debug_assert!`s the run contains no `'\n'` (newlines must go through
-/// `newline()` so the source-map line/col bookkeeping stays correct). A
-/// template quasi is the one primary token that can legitimately carry a raw
-/// newline, so `emit_template_element` needs a newline-aware write path before
-/// this case can pass. Tracked as gap-158; unignore when the emitter learns to
-/// split quasi raw on embedded newlines.
+/// **gap-158 resolved.** `emit_template_element` now splits the quasi `raw` on
+/// `'\n'` and routes each break through `newline()` (keeping source-map
+/// line/column bookkeeping correct) instead of tripping `write_str`'s
+/// no-embedded-newline `debug_assert!`. The interior `"\n  "` — the line break
+/// plus its indentation — round-trips byte-for-byte.
 #[test]
-#[ignore = "gap-158: emitter write_str forbids embedded newlines in template quasi raw"]
 fn raw_preserves_internal_newline() {
     assert_emits(template_no_sub("hello\n  world"), "`hello\n  world`;");
+}
+
+/// A quasi that both *begins* and *ends* with a newline still round-trips: the
+/// leading and trailing empty split segments write nothing, so only the two
+/// interior `newline()`s advance the line counter — the raw bytes are exact.
+#[test]
+fn raw_preserves_leading_and_trailing_newline() {
+    assert_emits(template_no_sub("\nx\n"), "`\nx\n`;");
 }
 
 // =====================================================================

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -1594,20 +1594,49 @@ them. Test-only PR (no emitter code change); the one ignored case surfaces
 gap-158. *Tagged* templates are intentionally not ported (no
 `TaggedTemplateExpression` AST node — see the port's ATTRIBUTION).
 
-### gap-158 — emitter cannot print a template quasi with a *literal* embedded newline
+### gap-158 — emitter cannot print a template quasi with a *literal* embedded newline — **RESOLVED (closure-emitter 0.21.3, CLOC12.157)**
 
-`emit_template_element` writes a quasi's `raw` text through the emitter's
+`emit_template_element` wrote a quasi's `raw` text through the emitter's
 `write_str`, which `debug_assert!`s the run contains no `'\n'` — every newline
 must instead flow through `newline()` so the source-map line/column bookkeeping
 (and `line`/`col` counters) stay correct. A template quasi is the one *primary*
 token that can legitimately carry a raw newline (a multiline template such as
 `` `hello⏎world` `` preserves it verbatim per spec), so a quasi whose `raw`
-contains `\n` currently panics the emitter worker rather than printing. The fix
-is a newline-aware quasi-write path in `emit_template_element` (split `raw` on
-`\n`, emitting each segment via `write_str` and each break via `newline()`);
-until then the multiline case is `#[ignore]`d in the conformance port
-(`raw_preserves_internal_newline`). No correctness hazard for the shapes the
-bridge can actually produce today — the grammar's `TEMPLATE_NO_SUB` token can
-span newlines, but the no-substitution SIMPLE/ADVANCED path does not yet reach
-an input that stresses this (it declines multiline via the same token) — so
-this is an emitter-completeness gap, not a live miscompile.
+contained `\n` panicked the emitter worker rather than printing.
+
+**Fix (CLOC12.157):** `emit_template_element` now splits the quasi `raw` on
+`'\n'` and writes each line segment via `write_str` with a real `newline()`
+between segments — so `line` advances and `col` resets exactly as for any other
+newline, and the raw bytes round-trip. `str::split('\n')` yields `N + 1` pieces
+for `N` newlines (empty leading/trailing pieces for a raw that starts/ends with
+`'\n'` write nothing), so the line count lands exactly on the `'\n'` count.
+Single-line quasis are one segment → identical to before. The conformance
+port's `raw_preserves_internal_newline` is un-ignored and a
+`raw_preserves_leading_and_trailing_newline` case plus three inline emitter
+tests were added.
+
+**Residual (not a hazard):** other line-terminator bytes a raw may carry — a
+lone `'\r'` (the `'\r'` of a `\r\n` pair rides on the tail of the preceding
+segment) and the Unicode separators `U+2028` / `U+2029` — are written verbatim
+as ordinary characters: bytes round-trip exactly, and only their *column*
+bookkeeping is approximate (they don't increment `line`). That is a source-map
+nicety, not an output-correctness bug; a fully line-terminator-aware split is a
+later refinement if a source-map consumer ever needs column fidelity across
+CR / LS / PS inside a template.
+
+## CLOC12.157 — newline-aware template quasi emit (resolves gap-158)
+
+`closure-emitter` (0.21.3) makes `emit_template_element` newline-aware: a
+multiline template quasi (`raw` containing a literal `'\n'`) now prints its
+interior line break verbatim instead of panicking the emitter worker on
+`write_str`'s no-embedded-newline `debug_assert!`. See gap-158 (now RESOLVED)
+for the mechanism. First non-test-only change in the TemplateLiteral arc since
+CLOC12.154 — a real `src/` fix in the emitter. The CLOC12.156 conformance
+port's `raw_preserves_internal_newline` case is un-ignored (now 19 active
+`#[test]`s, 0 `#[ignore]` — the port fully conforms), and three inline emitter
+unit tests cover the no-sub, substitution-quasi, and bare-newline shapes. This
+completes multiline handling for the template shapes the emitter can be handed;
+the grammar still only tokenises no-substitution templates into the bridge
+(gap-157), so multiline templates reach the emitter today only via
+hand-constructed AST, but the emitter is now correct for when the bridge grows
+multiline support.


### PR DESCRIPTION
## Summary

Makes `emit_template_element` **newline-aware** so a JS template literal whose quasi `raw` text carries a *literal* newline — a multiline template `` `a⏎b` `` — prints its interior line break byte-for-byte. **Resolves gap-158.**

### Root cause

The quasi `raw` went straight to `write_str`, which `debug_assert!`s the run is newline-free: every `'\n'` must route through `newline()` so source-map line/column bookkeeping stays correct (`write_str` advances only the column; `newline` bumps the line and resets the column). A template quasi is the one PRIMARY token that can legitimately carry a raw newline, so any multiline template tripped the assert (a debug-build panic; in release it silently mis-tracked the line counter).

### Fix

Split the quasi `raw` on `'\n'`, write each line segment via `write_str`, emit a real `newline()` between segments. `str::split('\n')` yields N+1 pieces for N newlines (empty leading/trailing pieces for a raw starting/ending with `'\n'` write nothing), so `line` lands exactly on the `'\n'` count and the bytes round-trip. Single-line quasis are one segment → byte-identical to before.

**Residual (documented, not a hazard):** a lone `'\r'` (the CR of a `\r\n` pair) and `U+2028`/`U+2029` are written verbatim as ordinary chars — bytes round-trip exactly, only their column bookkeeping is approximate (they don't bump `line`). A fully line-terminator-aware split is a later refinement.

## Testing

- Un-ignore the CLOC12.156 conformance case `raw_preserves_internal_newline` + add `raw_preserves_leading_and_trailing_newline` → template port is now **19 active `#[test]`s, 0 `#[ignore]`**.
- 3 new inline emitter unit tests (no-sub multiline, substitution-quasi multiline, bare-newline quasi).
- `cargo test -p coding-adventures-closure-emitter` (full suite) → green.
- Downstream `closurec` suite → green.
- Inline security review: **PASSED** (no unsafe/IO/user input; the change *reduces* attack surface by removing a reachable debug-build panic on multiline-template input; work is linear, no recursion).

## Housekeeping

`closure-emitter` 0.21.2 → 0.21.3 · CHANGELOG / README / ATTRIBUTION / CLOC12-gaps (gap-158 marked RESOLVED + new CLOC12.157 section) updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)