### PR TITLE
feat(adj-lang): latex "\operatorname{min/max/gcd/lcm}" word spellings

### DIFF
--- a/code/packages/rust/adj-lang/CHANGELOG.md
+++ b/code/packages/rust/adj-lang/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [0.35.0] - 2026-07-02 — `\operatorname{min/max/gcd/lcm}` word spellings in `latex "…"`
+
+### Added
+
+- `latex "\operatorname{min}(a, b)"`, `\operatorname{max}(…)`, `\operatorname{gcd}(…)`, and
+  `\operatorname{lcm}(…)` now compute the **variadic binary functions**, reaching the SAME
+  native ops (`ComputeOp::Min2`/`Max2`/`Gcd`/`Lcm`) as their already-supported function-call
+  spellings (`\min(a, b)`, `\gcd(a, b, c)`): a model that writes the operator *name* instead
+  of the backslash macro lands on the identical node. `\operatorname{…}` is a TEXT command,
+  so — unlike `\min(…)`, which parses as a `Call` — `\operatorname{gcd}(a, b)` parses as the
+  operator-name juxtaposition `Bin(Mul, Text("gcd"), (a, b))` (the same shape the adapter
+  already recognises for `\operatorname{floor}`/`sgn`/`trunc`); the adapter matches via
+  `operator_name_is(lhs, …)` and folds the comma-separated argument `Sequence` through the
+  SAME `Call2` chain as the call spelling (`gcd(a, b, c)` → `gcd(gcd(a, b), c)`, associative).
+  Two-or-more operands accepted; a single argument is a clean, explicit error. Pure **adapter**
+  recognition: no engine, AST, or lowering change. The shared fold is factored into
+  `latex_nary_fold`, now used by both the `\min(…)` `Call` path and the `\operatorname{min}(…)`
+  juxtaposition path. +2 e2e unit tests (min/max/gcd/lcm word spellings; one-arg rejection).
+
 ## [0.34.0] - 2026-07-02 — `\operatorname{floor/ceil/round}` word spellings in `latex "…"`
 
 ### Added

--- a/code/packages/rust/adj-lang/Cargo.toml
+++ b/code/packages/rust/adj-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang"
-version = "0.34.0"
+version = "0.35.0"
 edition = "2021"
 description = "Surface-syntax frontend for the adjudication framework's probabilistic-logic rulebooks. Lexes, parses, and lowers a domain-expert-readable DSL into a `logic-engine` KnowledgeBase. Dissolves ADJ46 awkwardness items A10 (rulebook syntax) and A4 (joint contributions syntactically distinct)."
 

--- a/code/packages/rust/adj-lang/src/adapter.rs
+++ b/code/packages/rust/adj-lang/src/adapter.rs
@@ -1002,6 +1002,31 @@ fn latex_math_to_expr_ast(expr: &MathExpr, source: &str) -> Result<ExprAst, Adap
         MathExpr::Bin(BinOp::Mul, lhs, rhs) if operator_name_is(lhs, "round") => {
             Ok(ExprAst::Round(Box::new(latex_math_to_expr_ast(rhs, source)?)))
         }
+        // `\operatorname{min}(a, b)` / `\operatorname{max}(…)` / `\operatorname{gcd}(…)` /
+        // `\operatorname{lcm}(…)` — the operator-name spellings of the variadic binary
+        // functions. The function-call spellings (`\min(a, b)`, `\gcd(a, b, c)`) already
+        // lower in the `Call` arm below via `Func::Min`/`Max`/`Gcd`/`Lcm`; a model that
+        // writes `\operatorname{gcd}` instead of `\gcd` should reach the SAME native op.
+        // But `\operatorname{…}` is a TEXT command, so — exactly like the single-argument
+        // `\operatorname{floor}`/`\operatorname{sgn}` above — `\operatorname{gcd}(a, b)`
+        // does NOT parse as a `Call`; it parses as the juxtaposition
+        // `Bin(Mul, Text("gcd"), (a, b))`, whose right factor is the parenthesised
+        // comma-list. We recognise that exact shape here, ABOVE the general product arm, and
+        // reuse the SAME `latex_nary_fold` that the `Call` arm uses: the argument sequence
+        // left-folds into a chain of the binary `Call2` op (`gcd(a, b, c)` →
+        // `gcd(gcd(a, b), c)`), so no engine/AST/lowering change — pure adapter recognition.
+        MathExpr::Bin(BinOp::Mul, lhs, rhs) if operator_name_is(lhs, "min") => {
+            latex_nary_fold(rhs, source, BinFn::Min, "min")
+        }
+        MathExpr::Bin(BinOp::Mul, lhs, rhs) if operator_name_is(lhs, "max") => {
+            latex_nary_fold(rhs, source, BinFn::Max, "max")
+        }
+        MathExpr::Bin(BinOp::Mul, lhs, rhs) if operator_name_is(lhs, "gcd") => {
+            latex_nary_fold(rhs, source, BinFn::Gcd, "gcd")
+        }
+        MathExpr::Bin(BinOp::Mul, lhs, rhs) if operator_name_is(lhs, "lcm") => {
+            latex_nary_fold(rhs, source, BinFn::Lcm, "lcm")
+        }
         // `a \bmod b` / `a \pmod{b}` — the modulo operator. `\bmod`/`\pmod` are not in
         // the frontend's operator tables, so they lower to a bare `Symbol("bmod")` /
         // `Symbol("pmod")` and the whole expression parses as a LEFT-associated implicit
@@ -1099,20 +1124,9 @@ fn latex_math_to_expr_ast(expr: &MathExpr, source: &str) -> Result<ExprAst, Adap
                 // `Call2` node — `min(a, b, c)` becomes `min(min(a, b), c)` — which is
                 // exact and needs no n-ary engine op (the fold reuses `ComputeOp::Min2`
                 // /`Max2`/`Gcd`/`Lcm`). A two-arg call folds to a single `Call2`,
-                // identical to before.
-                let args = latex_nary_args(arg, source, func)?;
-                let mut operands = args.into_iter();
-                // `latex_nary_args` guarantees ≥ 2 items, so the first `next()` is Some.
-                let first = operands.next().expect("latex_nary_args guarantees ≥ 2 args");
-                let mut acc = latex_math_to_expr_ast(first, source)?;
-                for operand in operands {
-                    acc = ExprAst::Call2(
-                        bin,
-                        Box::new(acc),
-                        Box::new(latex_math_to_expr_ast(operand, source)?),
-                    );
-                }
-                return Ok(acc);
+                // identical to before. `latex_nary_fold` does the same work for the
+                // `\operatorname{min}(…)` operator-name spelling in the `Bin` arm above.
+                return latex_nary_fold(arg, source, bin, &format!("{func:?}"));
             }
             let named = match func {
                 Func::Sin => NamedFn::Sin,
@@ -1246,12 +1260,16 @@ fn latex_power_exponent(expr: &MathExpr, source: &str) -> Result<f64, AdapterErr
 /// left-folds them into a chain of the associative binary op. A one-arg (`\min(a)`)
 /// call, or a non-comma argument, has no such lowering and is a clean, explicit
 /// error rather than a silent mis-lowering.
-fn latex_nary_args<'a>(
-    arg: &'a MathExpr,
+fn latex_nary_fold(
+    arg: &MathExpr,
     source: &str,
-    func: &Func,
-) -> Result<Vec<&'a MathExpr>, AdapterError> {
-    // Strip transparent parenthesisation to reach the underlying sequence.
+    bin: BinFn,
+    label: &str,
+) -> Result<ExprAst, AdapterError> {
+    // Strip transparent parenthesisation to reach the underlying sequence. The
+    // function-call spelling wraps its args in a `Fenced` (the call's parentheses); the
+    // operator-name spelling arrives here already unwrapped to the `Fenced` right factor —
+    // both reduce to the inner `Sequence`.
     let mut inner = arg;
     loop {
         match inner {
@@ -1260,18 +1278,33 @@ fn latex_nary_args<'a>(
             _ => break,
         }
     }
-    if let MathExpr::Sequence(items) = inner {
-        if items.len() >= 2 {
-            return Ok(items.iter().collect());
+    let items = match inner {
+        MathExpr::Sequence(items) if items.len() >= 2 => items,
+        _ => {
+            return Err(AdapterError::UnsupportedLatexMath {
+                source: source.to_string(),
+                detail: format!(
+                    "{label} takes two or more comma-separated arguments in ADJ arithmetic \
+                     (e.g. \\min(a, b) or \\min(a, b, c)); got {inner:?}"
+                ),
+            })
         }
+    };
+    // `min`/`max`/`gcd`/`lcm` are associative, so the ≥2 operands left-fold into a chain of
+    // the binary `Call2` op — `gcd(a, b, c)` → `gcd(gcd(a, b), c)` — which is exact and
+    // needs no n-ary engine op.
+    let mut operands = items.iter();
+    // The `len() >= 2` guard above guarantees the first `next()` is `Some`.
+    let first = operands.next().expect("checked items.len() >= 2");
+    let mut acc = latex_math_to_expr_ast(first, source)?;
+    for operand in operands {
+        acc = ExprAst::Call2(
+            bin,
+            Box::new(acc),
+            Box::new(latex_math_to_expr_ast(operand, source)?),
+        );
     }
-    Err(AdapterError::UnsupportedLatexMath {
-        source: source.to_string(),
-        detail: format!(
-            "{func:?} takes two or more comma-separated arguments in ADJ arithmetic \
-             (e.g. \\min(a, b) or \\min(a, b, c)); got {inner:?}"
-        ),
-    })
+    Ok(acc)
 }
 
 /// Validate an nth-root degree (`n` in `\sqrt[n]{x}`) and return it as a

--- a/code/packages/rust/adj-lang/src/lower.rs
+++ b/code/packages/rust/adj-lang/src/lower.rs
@@ -2278,6 +2278,75 @@ contributes 1000000 from answer == 60 to correct
     }
 
     #[test]
+    fn native_latex_operatorname_nary_word_spellings() {
+        // `\operatorname{min}(a, b)` / `\operatorname{max}` / `\operatorname{gcd}` /
+        // `\operatorname{lcm}` — the operator-name spellings of the variadic binary
+        // functions. `\operatorname{…}` is a TEXT command, so these parse as the
+        // juxtaposition `Bin(Mul, Text("gcd"), (a, b))` rather than a `Call`; the adapter
+        // recognises that shape and folds through the SAME `Call2` chain as the `\gcd(…)`
+        // spelling, so a model that writes the operator name reaches the identical native
+        // op. Two-arg: min(3, 8) = 3; max(3, 8) = 8.
+        let mn = crate::compile_and_decide(
+            "observe a(3)\n\
+             observe b(8)\n\
+             let answer = latex \"$\\operatorname{min}(a, b)$\"\n\
+             prior 0.10 for correct\n\
+             contributes 1000000 from answer == 3 to correct\n\
+             ? correct\n",
+        )
+        .unwrap();
+        assert!(mn.ranked[0].posterior > 0.99, "{mn:?}");
+        let mx = crate::compile_and_decide(
+            "observe a(3)\n\
+             observe b(8)\n\
+             let answer = latex \"$\\operatorname{max}(a, b)$\"\n\
+             prior 0.10 for correct\n\
+             contributes 1000000 from answer == 8 to correct\n\
+             ? correct\n",
+        )
+        .unwrap();
+        assert!(mx.ranked[0].posterior > 0.99, "{mx:?}");
+        // Two-arg gcd/lcm: gcd(12, 18) = 6; lcm(4, 6) = 12.
+        let g = crate::compile_and_decide(
+            "observe a(12)\n\
+             observe b(18)\n\
+             let answer = latex \"$\\operatorname{gcd}(a, b)$\"\n\
+             prior 0.10 for correct\n\
+             contributes 1000000 from answer == 6 to correct\n\
+             ? correct\n",
+        )
+        .unwrap();
+        assert!(g.ranked[0].posterior > 0.99, "{g:?}");
+        // Three-or-more args left-fold identically to the `\gcd(…)` spelling:
+        // lcm(2, 3, 4) = 12.
+        let l = crate::compile_and_decide(
+            "observe a(2)\n\
+             observe b(3)\n\
+             observe c(4)\n\
+             let answer = latex \"$\\operatorname{lcm}(a, b, c)$\"\n\
+             prior 0.10 for correct\n\
+             contributes 1000000 from answer == 12 to correct\n\
+             ? correct\n",
+        )
+        .unwrap();
+        assert!(l.ranked[0].posterior > 0.99, "{l:?}");
+    }
+
+    #[test]
+    fn native_latex_operatorname_min_with_one_argument_is_rejected() {
+        // `\operatorname{min}(a)` — a single argument has no fold (min/max/gcd/lcm need
+        // TWO or more operands), so it is a clean, explicit error via the SAME
+        // `latex_nary_fold` guard the `\min(a)` spelling hits — never a silent
+        // mis-lowering into a bare product.
+        let src =
+            "observe a(3)\nlet answer = latex \"$\\operatorname{min}(a)$\"\n? answer\n";
+        assert!(
+            compile(src).is_err(),
+            "one-arg operatorname min must be rejected: {src:?}"
+        );
+    }
+
+    #[test]
     fn native_latex_symbolic_root_degree_is_rejected() {
         // `\sqrt[k]{x}` — a symbolic degree has no numeric value, so the reciprocal
         // exponent `1/k` cannot be formed. It must be rejected, not silently


### PR DESCRIPTION
## LaTeX consumer slice: `\operatorname{min/max/gcd/lcm}` word spellings

Math-tuned local models emit the variadic binary functions two ways: the backslash
macro (`\min(a, b)`, `\gcd(a, b, c)`) **and** the operator-name spelling
(`\operatorname{gcd}(a, b)`). The `latex "…"` surface already lowers the macro form via
the `Call` arm (`Func::Min`/`Max`/`Gcd`/`Lcm` → `ComputeOp::Min2`/`Max2`/`Gcd`/`Lcm`).
This PR makes the **operator-name spelling reach the identical native op** — a model that
writes the name instead of the macro lands on the same node.

### Why it needs a new arm (parse shape, probed empirically)

`\operatorname{…}` is a TEXT command, so — unlike `\min(…)`, which parses as a `Call` —
`\operatorname{gcd}(a, b)` parses as the operator-name **juxtaposition**:

```
Bin(Mul, Text("gcd"), Fenced{ "(", Sequence([a, b]), ")" })
```

the same shape the adapter already recognises for `\operatorname{floor}`/`sgn`/`trunc`.
The new arms match via `operator_name_is(lhs, "gcd")` and fold the comma-separated
argument `Sequence` through the **same** `Call2` chain as the macro path
(`gcd(a, b, c)` → `gcd(gcd(a, b), c)`, associative). Two-or-more operands accepted; a
single argument is a clean, explicit `UnsupportedLatexMath` error.

### What changed

- **`adapter.rs`** — four new operator-name arms (`min`/`max`/`gcd`/`lcm`) above the
  general product arm; the shared fold is factored into `latex_nary_fold`, now used by
  BOTH the `Call` path and the new juxtaposition path (the old `latex_nary_args` +
  inline fold is replaced — no duplication).
- **`lower.rs`** — +2 e2e unit tests (min/max/gcd/lcm word spellings across 2- and
  3-arg folds; one-arg rejection).
- Version 0.34.0 → 0.35.0; CHANGELOG prepended.

**Pure adapter recognition: no engine, AST, or lowering change.** `cargo test -p
logic-engine -p adj-lang -p adj-lang-cli -p adj-constraint-solver` green (114 adj-lang
tests pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
