### PR TITLE
feat(adj-ladder): rung-48 infusion delivered-volume (sum-times-difference (a+b)*(c-d))

### DIFF
--- a/code/specs/data/adj-ladder/rung48_infusion_delivered_volume/gen_items.py
+++ b/code/specs/data/adj-ladder/rung48_infusion_delivered_volume/gen_items.py
@@ -1,0 +1,226 @@
+"""Generate rung-48 (infusion delivered-volume) items.json for the ADJ-LADDER.
+
+Rung 48 opens the **infusion-therapy / delivered-volume** panel on the quantitative band — the arithmetic of the
+volume an IV pump actually delivers when two channels run together over a treatment window. Two lines infuse
+simultaneously at `rate_first` and `rate_second` (mL per hour); their combined rate is the SUM `rate_first +
+rate_second`. The window they run over is the DIFFERENCE between the clock the pump stops and the clock it starts,
+`stop_hour − start_hour` (hours). The volume delivered is the combined rate multiplied by the elapsed time. This rung
+introduces a genuinely NEW arithmetic shape on the ladder: **sum-times-difference** — `(a + b) · (c − d)` — a
+parenthesised sum multiplied by a parenthesised difference.
+
+The setup: two IV channels run at `rate_first` and `rate_second` mL/h from `start_hour` to `stop_hour`. The delivered
+volume is the combined rate times the elapsed time:
+
+  DELIVERED VOLUME   (rate_first + rate_second) · (stop_hour − start_hour)   [ mL ]
+  COMBINED RATE      rate_first + rate_second                                [ the first factor: both channels ]
+  ELAPSED TIME       stop_hour − start_hour                                  [ the second factor ]
+
+The **delivered volume** is what makes this rung distinctive — it is the ladder's first **sum-times-difference**: a
+parenthesised sum multiplied by a parenthesised difference. Contrast the neighbours already on the ladder: rung-33 was
+a *product of two differences* `(a−b)·(c−d)`, rung-34 a *sum of two products* `a·b + c·d`, rung-43 a *sum of three
+products*; none multiplied a SUM by a DIFFERENCE. (The combined rate `rate_first + rate_second` and the elapsed time
+`stop_hour − start_hour` ride alongside as the two component quantities, so the panel teaches the whole calculation —
+exactly as rung-46/47 shipped their component sums/products beside the headline figure.)
+
+Each index is a `compute_dimensioned` program (`observe` the four quantities + `let answer = formula`); the ADJ
+engine carries the arithmetic — including the inner `(rate_first + rate_second)` sum and the `(stop_hour −
+start_hour)` difference — and the harness reads the scalar via the existing `compute_dimensioned` extractor. No
+harness/engine change, exactly as rungs 8/16/.../46/47. This rung exercises the engine across a **sum multiplied by a
+difference**.
+
+Contamination-safe by construction: every formula is built ONLY from the four observed quantities via `+`, `−` and
+`·` — **no structural constants** — so no numeric literal appears in any program, and neither the combined rate, the
+elapsed time, nor any delivered-volume figure is ever a literal (each is computed from the observed quantities). The
+observed quantities carry **digit-free identifiers** (`rate_first`, `rate_second`, `start_hour`, `stop_hour`) so no
+numeral hides inside a variable name.
+
+The five options are a tight family over the same four quantities: the three real readouts plus the two classic
+slips —
+
+  SUMMED CLOCK    (rate_first + rate_second) · (stop_hour + start_hour)   ADD the two clock times instead of
+                                                                          subtracting them (elapsed should be a
+                                                                          difference), and
+  DIFF RATE       (rate_first − rate_second) · (stop_hour − start_hour)   SUBTRACT the two channel rates instead of
+                                                                          adding them (the combined rate should be a
+                                                                          sum),
+
+which are exactly the mistakes a student makes (adding two quantities that should be subtracted, or subtracting two
+quantities that should be added). Gold rotates A-E by index. QUERIED (used as gold) = the three real readouts; all
+five always appear as options.
+
+Distinctness: all four observed quantities are positive with `stop_hour > start_hour` and `rate_first ≠ rate_second`,
+so the combined rate and elapsed time are strictly positive and the two slips are well-defined and non-zero; the
+tables below are chosen so the five family values are pairwise distinct with a comfortable margin, asserted at build
+time.
+"""
+import json
+
+LETTERS = ["A", "B", "C", "D", "E"]
+
+# (RATE_FIRST, RATE_SECOND, START_HOUR, STOP_HOUR) — rates in mL/h, hours are clock readings. All four quantities are
+# strictly positive with STOP_HOUR > START_HOUR (so the elapsed time is positive) and RATE_FIRST != RATE_SECOND (so
+# the diff-rate slip is non-zero and distinct). The five family values are asserted pairwise-distinct (with margin)
+# below.
+TABLES = [
+    (60, 40, 2, 6),
+    (80, 20, 1, 5),
+    (90, 30, 1, 4),
+    (40, 25, 3, 9),
+    (55, 35, 2, 5),
+    (100, 60, 4, 10),
+    (45, 15, 1, 7),
+]
+
+# The option family (5 members), all built from the four observed quantities via +, - and *. Every identifier is
+# DIGIT-FREE. key -> (display name, formula-as-adj). Only the first three are *queried* (used as gold); all five
+# always appear as the options.
+FAMILY = [
+    (
+        "delivered_volume",
+        "delivered volume (combined rate times the elapsed time)",
+        "(rate_first + rate_second) * (stop_hour - start_hour)",
+    ),
+    (
+        "combined_rate",
+        "the combined infusion rate (the two channel rates added)",
+        "rate_first + rate_second",
+    ),
+    (
+        "elapsed_time",
+        "the elapsed time (stop clock minus start clock)",
+        "stop_hour - start_hour",
+    ),
+    (
+        "summed_clock",
+        "combined rate times the two clock times ADDED, not subtracted (a wrong window)",
+        "(rate_first + rate_second) * (stop_hour + start_hour)",
+    ),
+    (
+        "diff_rate",
+        "the two channel rates SUBTRACTED instead of added, times the elapsed time",
+        "(rate_first - rate_second) * (stop_hour - start_hour)",
+    ),
+]
+QUERIED = ["delivered_volume", "combined_rate", "elapsed_time"]
+ORDER = [k for k, _, _ in FAMILY]
+
+
+def scalar(v):
+    return {"value": v, "unit": "scalar"}
+
+
+def family_values(rate_first, rate_second, start_hour, stop_hour):
+    # Operation order mirrors the ADJ programs exactly (a sum times a difference), so the Python option value and the
+    # engine result are the same IEEE-double (well within the harness's 1e-9 match tolerance).
+    combined = rate_first + rate_second
+    elapsed = stop_hour - start_hour
+    return {
+        "delivered_volume": combined * elapsed,
+        "combined_rate": combined,
+        "elapsed_time": elapsed,
+        "summed_clock": combined * (stop_hour + start_hour),
+        "diff_rate": (rate_first - rate_second) * elapsed,
+    }
+
+
+def build():
+    name_of = {k: nm for k, nm, _ in FAMILY}
+    formula_of = {k: f for k, _, f in FAMILY}
+    items = []
+    idx = 0
+
+    def num(x):
+        return int(x) if float(x).is_integer() else x
+
+    for rate_first, rate_second, start_hour, stop_hour in TABLES:
+        assert (
+            rate_first > 0
+            and rate_second > 0
+            and start_hour > 0
+            and stop_hour > start_hour
+            and rate_first != rate_second
+        ), (rate_first, rate_second, start_hour, stop_hour)
+        fv = family_values(rate_first, rate_second, start_hour, stop_hour)
+        # Pairwise-distinct with a comfortable margin so the harness never sees two options
+        # matching the gold value within its 1e-9 tolerance.
+        vals = [fv[key] for key in ORDER]
+        for i in range(len(vals)):
+            for j in range(i + 1, len(vals)):
+                assert abs(vals[i] - vals[j]) > 1e-6, (
+                    rate_first,
+                    rate_second,
+                    start_hour,
+                    stop_hour,
+                    ORDER[i],
+                    ORDER[j],
+                    fv,
+                )
+        for key in QUERIED:
+            gold_val = fv[key]
+            gold_pos = idx % 5
+            others = [fv[k2] for k2 in ORDER if abs(fv[k2] - gold_val) > 1e-12]
+            opts_vals = others[:]
+            opts_vals.insert(gold_pos, gold_val)
+            opts_vals = opts_vals[:5]
+            if abs(opts_vals[gold_pos] - gold_val) > 1e-12:
+                opts_vals[gold_pos] = gold_val
+            assert len({round(v, 9) for v in opts_vals}) == 5, (
+                key,
+                rate_first,
+                rate_second,
+                start_hour,
+                stop_hour,
+                opts_vals,
+            )
+            options = {LETTERS[i]: scalar(opts_vals[i]) for i in range(5)}
+            items.append({
+                "id": f"r48inf-{idx + 1:02d}",
+                "qtype": "infusion_delivered_volume",
+                "stem": (
+                    f"Two IV channels run at {num(rate_first)} and {num(rate_second)} mL/h from hour "
+                    f"{num(start_hour)} to hour {num(stop_hour)}. What is the {name_of[key]}?"
+                ),
+                "program": (
+                    f"observe rate_first({num(rate_first)})\n"
+                    f"observe rate_second({num(rate_second)})\n"
+                    f"observe start_hour({num(start_hour)})\n"
+                    f"observe stop_hour({num(stop_hour)})\n"
+                    f"let answer = {formula_of[key]}\n"
+                    "? answer\n"
+                ),
+                "answer_from": {"type": "compute_dimensioned", "name": "answer"},
+                "options": options,
+                "gold_letter": LETTERS[gold_pos],
+            })
+            idx += 1
+    return {
+        "description": (
+            "ADJ-LADDER rung 48 — infusion delivered-volume from four stated quantities (a NEW panel: "
+            "infusion-therapy / delivered-volume). From two channel infusion rates plus a start clock and a stop "
+            "clock compute the delivered volume ((rate_first+rate_second)*(stop_hour-start_hour)), the combined rate "
+            "(rate_first+rate_second), or the elapsed time (stop_hour-start_hour). Each item is a compute_dimensioned "
+            "program (observe the four quantities, let answer = formula); the ADJ engine carries the arithmetic — a "
+            "NEW shape, SUM-TIMES-DIFFERENCE (a+b)*(c-d), the first product on the ladder to multiply a parenthesised "
+            "sum by a parenthesised difference (distinct from rung-33 product-of-two-differences (a-b)*(c-d), rung-34 "
+            "sum-of-two-products a*b+c*d, and rung-43 sum-of-three-products) — and the harness matches the scalar to "
+            "the printed options. Contamination-safe: every index is built only from the four observed quantities via "
+            "+, - and * — no constant leaks, and neither the combined rate, the elapsed time, nor any delivered-volume "
+            "figure ever appears as a literal (each is computed) — and the observed quantities carry digit-free "
+            "identifiers so no numeral hides inside a variable name. The five options are a family over the same four "
+            "quantities, so the distractors are exactly the slips students make: ADDING the two clock times instead of "
+            "subtracting them (a wrong window), and SUBTRACTING the two channel rates instead of adding them. The core "
+            "confusion tested is multiplying the combined-rate sum by the elapsed-time difference."
+        ),
+        "items": items,
+    }
+
+
+if __name__ == "__main__":
+    doc = build()
+    with open("items.json", "w") as f:
+        json.dump(doc, f, indent=2)
+        f.write("\n")
+    print("wrote items.json:", len(doc["items"]), "items")
+    for it in doc["items"]:
+        print(it["id"], it["qtype"], "gold", it["gold_letter"],
+              "=", round(it["options"][it["gold_letter"]]["value"], 6))

--- a/code/specs/data/adj-ladder/rung48_infusion_delivered_volume/items.json
+++ b/code/specs/data/adj-ladder/rung48_infusion_delivered_volume/items.json
@@ -1,0 +1,698 @@
+{
+  "description": "ADJ-LADDER rung 48 \u2014 infusion delivered-volume from four stated quantities (a NEW panel: infusion-therapy / delivered-volume). From two channel infusion rates plus a start clock and a stop clock compute the delivered volume ((rate_first+rate_second)*(stop_hour-start_hour)), the combined rate (rate_first+rate_second), or the elapsed time (stop_hour-start_hour). Each item is a compute_dimensioned program (observe the four quantities, let answer = formula); the ADJ engine carries the arithmetic \u2014 a NEW shape, SUM-TIMES-DIFFERENCE (a+b)*(c-d), the first product on the ladder to multiply a parenthesised sum by a parenthesised difference (distinct from rung-33 product-of-two-differences (a-b)*(c-d), rung-34 sum-of-two-products a*b+c*d, and rung-43 sum-of-three-products) \u2014 and the harness matches the scalar to the printed options. Contamination-safe: every index is built only from the four observed quantities via +, - and * \u2014 no constant leaks, and neither the combined rate, the elapsed time, nor any delivered-volume figure ever appears as a literal (each is computed) \u2014 and the observed quantities carry digit-free identifiers so no numeral hides inside a variable name. The five options are a family over the same four quantities, so the distractors are exactly the slips students make: ADDING the two clock times instead of subtracting them (a wrong window), and SUBTRACTING the two channel rates instead of adding them. The core confusion tested is multiplying the combined-rate sum by the elapsed-time difference.",
+  "items": [
+    {
+      "id": "r48inf-01",
+      "qtype": "infusion_delivered_volume",
+      "stem": "Two IV channels run at 60 and 40 mL/h from hour 2 to hour 6. What is the delivered volume (combined rate times the elapsed time)?",
+      "program": "observe rate_first(60)\nobserve rate_second(40)\nobserve start_hour(2)\nobserve stop_hour(6)\nlet answer = (rate_first + rate_second) * (stop_hour - start_hour)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 400,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 100,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 4,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 800,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 80,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r48inf-02",
+      "qtype": "infusion_delivered_volume",
+      "stem": "Two IV channels run at 60 and 40 mL/h from hour 2 to hour 6. What is the the combined infusion rate (the two channel rates added)?",
+      "program": "observe rate_first(60)\nobserve rate_second(40)\nobserve start_hour(2)\nobserve stop_hour(6)\nlet answer = rate_first + rate_second\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 400,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 100,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 4,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 800,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 80,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r48inf-03",
+      "qtype": "infusion_delivered_volume",
+      "stem": "Two IV channels run at 60 and 40 mL/h from hour 2 to hour 6. What is the the elapsed time (stop clock minus start clock)?",
+      "program": "observe rate_first(60)\nobserve rate_second(40)\nobserve start_hour(2)\nobserve stop_hour(6)\nlet answer = stop_hour - start_hour\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 400,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 100,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 4,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 800,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 80,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r48inf-04",
+      "qtype": "infusion_delivered_volume",
+      "stem": "Two IV channels run at 80 and 20 mL/h from hour 1 to hour 5. What is the delivered volume (combined rate times the elapsed time)?",
+      "program": "observe rate_first(80)\nobserve rate_second(20)\nobserve start_hour(1)\nobserve stop_hour(5)\nlet answer = (rate_first + rate_second) * (stop_hour - start_hour)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 100,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 4,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 600,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 400,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 240,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r48inf-05",
+      "qtype": "infusion_delivered_volume",
+      "stem": "Two IV channels run at 80 and 20 mL/h from hour 1 to hour 5. What is the the combined infusion rate (the two channel rates added)?",
+      "program": "observe rate_first(80)\nobserve rate_second(20)\nobserve start_hour(1)\nobserve stop_hour(5)\nlet answer = rate_first + rate_second\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 400,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 4,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 600,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 240,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 100,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r48inf-06",
+      "qtype": "infusion_delivered_volume",
+      "stem": "Two IV channels run at 80 and 20 mL/h from hour 1 to hour 5. What is the the elapsed time (stop clock minus start clock)?",
+      "program": "observe rate_first(80)\nobserve rate_second(20)\nobserve start_hour(1)\nobserve stop_hour(5)\nlet answer = stop_hour - start_hour\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 4,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 400,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 100,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 600,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 240,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r48inf-07",
+      "qtype": "infusion_delivered_volume",
+      "stem": "Two IV channels run at 90 and 30 mL/h from hour 1 to hour 4. What is the delivered volume (combined rate times the elapsed time)?",
+      "program": "observe rate_first(90)\nobserve rate_second(30)\nobserve start_hour(1)\nobserve stop_hour(4)\nlet answer = (rate_first + rate_second) * (stop_hour - start_hour)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 120,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 360,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 3,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 600,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 180,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r48inf-08",
+      "qtype": "infusion_delivered_volume",
+      "stem": "Two IV channels run at 90 and 30 mL/h from hour 1 to hour 4. What is the the combined infusion rate (the two channel rates added)?",
+      "program": "observe rate_first(90)\nobserve rate_second(30)\nobserve start_hour(1)\nobserve stop_hour(4)\nlet answer = rate_first + rate_second\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 360,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 3,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 120,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 600,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 180,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r48inf-09",
+      "qtype": "infusion_delivered_volume",
+      "stem": "Two IV channels run at 90 and 30 mL/h from hour 1 to hour 4. What is the the elapsed time (stop clock minus start clock)?",
+      "program": "observe rate_first(90)\nobserve rate_second(30)\nobserve start_hour(1)\nobserve stop_hour(4)\nlet answer = stop_hour - start_hour\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 360,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 120,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 600,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 3,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 180,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r48inf-10",
+      "qtype": "infusion_delivered_volume",
+      "stem": "Two IV channels run at 40 and 25 mL/h from hour 3 to hour 9. What is the delivered volume (combined rate times the elapsed time)?",
+      "program": "observe rate_first(40)\nobserve rate_second(25)\nobserve start_hour(3)\nobserve stop_hour(9)\nlet answer = (rate_first + rate_second) * (stop_hour - start_hour)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 65,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 780,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 90,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 390,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r48inf-11",
+      "qtype": "infusion_delivered_volume",
+      "stem": "Two IV channels run at 40 and 25 mL/h from hour 3 to hour 9. What is the the combined infusion rate (the two channel rates added)?",
+      "program": "observe rate_first(40)\nobserve rate_second(25)\nobserve start_hour(3)\nobserve stop_hour(9)\nlet answer = rate_first + rate_second\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 65,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 390,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 780,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 90,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r48inf-12",
+      "qtype": "infusion_delivered_volume",
+      "stem": "Two IV channels run at 40 and 25 mL/h from hour 3 to hour 9. What is the the elapsed time (stop clock minus start clock)?",
+      "program": "observe rate_first(40)\nobserve rate_second(25)\nobserve start_hour(3)\nobserve stop_hour(9)\nlet answer = stop_hour - start_hour\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 390,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 65,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 780,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 90,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r48inf-13",
+      "qtype": "infusion_delivered_volume",
+      "stem": "Two IV channels run at 55 and 35 mL/h from hour 2 to hour 5. What is the delivered volume (combined rate times the elapsed time)?",
+      "program": "observe rate_first(55)\nobserve rate_second(35)\nobserve start_hour(2)\nobserve stop_hour(5)\nlet answer = (rate_first + rate_second) * (stop_hour - start_hour)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 90,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 3,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 270,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 630,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 60,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r48inf-14",
+      "qtype": "infusion_delivered_volume",
+      "stem": "Two IV channels run at 55 and 35 mL/h from hour 2 to hour 5. What is the the combined infusion rate (the two channel rates added)?",
+      "program": "observe rate_first(55)\nobserve rate_second(35)\nobserve start_hour(2)\nobserve stop_hour(5)\nlet answer = rate_first + rate_second\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 270,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 3,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 630,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 90,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 60,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r48inf-15",
+      "qtype": "infusion_delivered_volume",
+      "stem": "Two IV channels run at 55 and 35 mL/h from hour 2 to hour 5. What is the the elapsed time (stop clock minus start clock)?",
+      "program": "observe rate_first(55)\nobserve rate_second(35)\nobserve start_hour(2)\nobserve stop_hour(5)\nlet answer = stop_hour - start_hour\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 270,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 90,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 630,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 60,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 3,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r48inf-16",
+      "qtype": "infusion_delivered_volume",
+      "stem": "Two IV channels run at 100 and 60 mL/h from hour 4 to hour 10. What is the delivered volume (combined rate times the elapsed time)?",
+      "program": "observe rate_first(100)\nobserve rate_second(60)\nobserve start_hour(4)\nobserve stop_hour(10)\nlet answer = (rate_first + rate_second) * (stop_hour - start_hour)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 960,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 160,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 2240,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 240,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r48inf-17",
+      "qtype": "infusion_delivered_volume",
+      "stem": "Two IV channels run at 100 and 60 mL/h from hour 4 to hour 10. What is the the combined infusion rate (the two channel rates added)?",
+      "program": "observe rate_first(100)\nobserve rate_second(60)\nobserve start_hour(4)\nobserve stop_hour(10)\nlet answer = rate_first + rate_second\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 960,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 160,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 2240,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 240,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r48inf-18",
+      "qtype": "infusion_delivered_volume",
+      "stem": "Two IV channels run at 100 and 60 mL/h from hour 4 to hour 10. What is the the elapsed time (stop clock minus start clock)?",
+      "program": "observe rate_first(100)\nobserve rate_second(60)\nobserve start_hour(4)\nobserve stop_hour(10)\nlet answer = stop_hour - start_hour\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 960,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 160,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 2240,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 240,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r48inf-19",
+      "qtype": "infusion_delivered_volume",
+      "stem": "Two IV channels run at 45 and 15 mL/h from hour 1 to hour 7. What is the delivered volume (combined rate times the elapsed time)?",
+      "program": "observe rate_first(45)\nobserve rate_second(15)\nobserve start_hour(1)\nobserve stop_hour(7)\nlet answer = (rate_first + rate_second) * (stop_hour - start_hour)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 60,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 480,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 360,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 180,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r48inf-20",
+      "qtype": "infusion_delivered_volume",
+      "stem": "Two IV channels run at 45 and 15 mL/h from hour 1 to hour 7. What is the the combined infusion rate (the two channel rates added)?",
+      "program": "observe rate_first(45)\nobserve rate_second(15)\nobserve start_hour(1)\nobserve stop_hour(7)\nlet answer = rate_first + rate_second\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 360,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 480,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 180,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 60,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r48inf-21",
+      "qtype": "infusion_delivered_volume",
+      "stem": "Two IV channels run at 45 and 15 mL/h from hour 1 to hour 7. What is the the elapsed time (stop clock minus start clock)?",
+      "program": "observe rate_first(45)\nobserve rate_second(15)\nobserve start_hour(1)\nobserve stop_hour(7)\nlet answer = stop_hour - start_hour\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 360,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 60,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 480,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 180,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    }
+  ]
+}

--- a/code/specs/data/adj-ladder/test_ladder_eval.py
+++ b/code/specs/data/adj-ladder/test_ladder_eval.py
@@ -85,6 +85,7 @@ SELF_CONTAINED_RUNGS = (
     "rung45_elimination_rate",
     "rung46_cost_per_patient_day",
     "rung47_ingestion_concentration",
+    "rung48_infusion_delivered_volume",
 )
 
 


### PR DESCRIPTION
## ADJ-LADDER rung-48 — infusion delivered-volume (sum-times-difference `(a+b)·(c−d)`)

Rung 48 opens the **infusion-therapy / delivered-volume** panel — a genuinely NEW clinical
domain (distinct from the toxicology / PK / pharmacoeconomics / dilution / renal / hepatic /
lipid / iron / thyroid / coag / protein / BMI / mineral panels already on the ladder) — and
introduces a genuinely NEW arithmetic **shape**: **sum-times-difference `(a + b) · (c − d)`**.

Two IV channels run at `rate_first` and `rate_second` mL/h from `start_hour` to `stop_hour`.
The delivered volume is the combined rate times the elapsed time:

| readout | formula |
|---|---|
| **delivered volume** | `(rate_first + rate_second) · (stop_hour − start_hour)` |
| combined rate | `rate_first + rate_second` (the sum factor) |
| elapsed time | `stop_hour − start_hour` (the difference factor) |

Distinct from the nearest neighbours: rung-33 was a *product of two differences* `(a−b)·(c−d)`,
rung-34 a *sum of two products* `a·b + c·d`, rung-43 a *sum of three products* — none multiplied
a **sum** by a **difference**.

### Shape/domain provenance
Shapes DONE: 31–47 (through rung-47 product-over-difference `(a·b)/(c−d)`). **AVOIDED**
product-over-product `(a·b)/(c·d)` (rung-15) and all of 31–47.

### Contamination-safe by construction
Every formula is built ONLY from the four observed quantities via `+`, `−`, `·` — no structural
constants, no numeric literal in any program, and neither the combined rate, the elapsed time,
nor any delivered-volume figure is ever a literal (each computed). Identifiers are **digit-free**
(`rate_first`, `rate_second`, `start_hour`, `stop_hour`). The five options are a tight family over
the same four quantities; the two distractors are exactly the student slips: **adding** the two
clock times instead of subtracting (`(a+b)·(c+d)`), and **subtracting** the two channel rates
instead of adding (`(a−b)·(c−d)`). Gold rotates A–E; QUERIED (gold) = the three real readouts.
Pairwise-distinctness (all 5 family values, margin > 1e-6) asserted at build with
`stop_hour > start_hour` and `rate_first ≠ rate_second`.

### Files (3)
- `rung48_infusion_delivered_volume/gen_items.py` — generator (literate)
- `rung48_infusion_delivered_volume/items.json` — 21 items (7 tables × 3 queried)
- `test_ladder_eval.py` — registered in `SELF_CONTAINED_RUNGS`

`pytest -k rung48` → 3/3 pass. Each index is a `compute_dimensioned` program; the ADJ engine
carries the arithmetic — no harness/engine change. Security review passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
