### PR TITLE
feat(adj-lang): latex "\operatorname{abs/exp/log/ln}" word spellings

### DIFF
--- a/code/packages/rust/adj-lang/CHANGELOG.md
+++ b/code/packages/rust/adj-lang/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.36.0] - 2026-07-02 — `\operatorname{abs/exp/log/ln}` word spellings in `latex "…"`
+
+### Added
+
+- `latex "\operatorname{abs}(x)"`, `\operatorname{exp}(x)`, `\operatorname{log}(x)`, and
+  `\operatorname{ln}(x)` now compute the **single-argument unary functions**, reaching the SAME
+  native nodes as their existing spellings: `abs`→`ExprAst::Abs` (the `|x|` absolute value,
+  dimension-preserving), and `exp`/`log`/`ln`→`ExprAst::Call(NamedFn::Exp/Log/Ln)` (the
+  transcendentals already lowered from the `\exp`/`\log`/`\ln` macro `Call`s). A model that writes
+  the operator *name* instead of the bracket/macro lands on the identical node. `\operatorname{…}`
+  is a TEXT command, so — exactly like `\operatorname{floor}`/`sgn`/`trunc` — these parse as the
+  operator-name juxtaposition `Bin(Mul, Text("exp"), (x))` rather than a `Call` or a `Fenced`; the
+  adapter matches via `operator_name_is(lhs, …)` and lowers to the existing node. Pure **adapter**
+  recognition: no engine, AST, or lowering change. +1 e2e unit test (abs(a−b)=7; exp(ln(x))
+  round-trip; base-10 log(1000)=3).
+
 ## [0.35.0] - 2026-07-02 — `\operatorname{min/max/gcd/lcm}` word spellings in `latex "…"`
 
 ### Added

--- a/code/packages/rust/adj-lang/Cargo.toml
+++ b/code/packages/rust/adj-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang"
-version = "0.35.0"
+version = "0.36.0"
 edition = "2021"
 description = "Surface-syntax frontend for the adjudication framework's probabilistic-logic rulebooks. Lexes, parses, and lowers a domain-expert-readable DSL into a `logic-engine` KnowledgeBase. Dissolves ADJ46 awkwardness items A10 (rulebook syntax) and A4 (joint contributions syntactically distinct)."
 

--- a/code/packages/rust/adj-lang/src/adapter.rs
+++ b/code/packages/rust/adj-lang/src/adapter.rs
@@ -1002,6 +1002,40 @@ fn latex_math_to_expr_ast(expr: &MathExpr, source: &str) -> Result<ExprAst, Adap
         MathExpr::Bin(BinOp::Mul, lhs, rhs) if operator_name_is(lhs, "round") => {
             Ok(ExprAst::Round(Box::new(latex_math_to_expr_ast(rhs, source)?)))
         }
+        // `\operatorname{abs}(x)` / `\operatorname{exp}(x)` / `\operatorname{log}(x)` /
+        // `\operatorname{ln}(x)` — the operator-name spellings of single-argument unary
+        // functions that ALREADY have a native op. `\exp`/`\ln`/`\log` lower in the `Call`
+        // arm below (`Func::Exp`/`Ln`/`Log` → the matching `NamedFn`), and `|x|` lowers to
+        // `ExprAst::Abs` via the absolute-value `Fenced` arm; a model that writes the
+        // operator *name* — `\operatorname{abs}(x)`, `\operatorname{exp}(x)` — should reach
+        // the SAME node. But `\operatorname{…}` is a TEXT command, so — exactly like the
+        // `\operatorname{floor}`/`sgn`/`trunc` roundings above — these parse NOT as a `Call`
+        // but as the operator-name juxtaposition `Bin(Mul, Text("exp"), (x))`. We recognise
+        // that shape here, ABOVE the general product arm, and lower to the existing node:
+        // `abs` → `ExprAst::Abs` (dimension-preserving), `exp`/`log`/`ln` →
+        // `ExprAst::Call(NamedFn::…)` (transcendental, Scalar→Scalar). Pure adapter
+        // recognition: no engine, AST, or lowering change.
+        MathExpr::Bin(BinOp::Mul, lhs, rhs) if operator_name_is(lhs, "abs") => {
+            Ok(ExprAst::Abs(Box::new(latex_math_to_expr_ast(rhs, source)?)))
+        }
+        MathExpr::Bin(BinOp::Mul, lhs, rhs) if operator_name_is(lhs, "exp") => {
+            Ok(ExprAst::Call(
+                NamedFn::Exp,
+                Box::new(latex_math_to_expr_ast(rhs, source)?),
+            ))
+        }
+        MathExpr::Bin(BinOp::Mul, lhs, rhs) if operator_name_is(lhs, "log") => {
+            Ok(ExprAst::Call(
+                NamedFn::Log,
+                Box::new(latex_math_to_expr_ast(rhs, source)?),
+            ))
+        }
+        MathExpr::Bin(BinOp::Mul, lhs, rhs) if operator_name_is(lhs, "ln") => {
+            Ok(ExprAst::Call(
+                NamedFn::Ln,
+                Box::new(latex_math_to_expr_ast(rhs, source)?),
+            ))
+        }
         // `\operatorname{min}(a, b)` / `\operatorname{max}(…)` / `\operatorname{gcd}(…)` /
         // `\operatorname{lcm}(…)` — the operator-name spellings of the variadic binary
         // functions. The function-call spellings (`\min(a, b)`, `\gcd(a, b, c)`) already

--- a/code/packages/rust/adj-lang/src/lower.rs
+++ b/code/packages/rust/adj-lang/src/lower.rs
@@ -2347,6 +2347,48 @@ contributes 1000000 from answer == 60 to correct
     }
 
     #[test]
+    fn native_latex_operatorname_unary_word_spellings() {
+        // `\operatorname{abs}(x)` / `\operatorname{exp}(x)` / `\operatorname{log}(x)` /
+        // `\operatorname{ln}(x)` — the operator-name spellings of single-argument unary
+        // functions that already have a native op. `\operatorname{…}` is a TEXT command, so
+        // these parse as the juxtaposition `Bin(Mul, Text("exp"), (x))` rather than a `Call`
+        // (`\exp`) or a `Fenced` (`|x|`); the adapter recognises that shape and lowers to the
+        // SAME node — `abs`→ExprAst::Abs, `exp`/`log`/`ln`→ExprAst::Call(NamedFn::…).
+        // abs(a - b) with a=3, b=10 → 7 (dimension-preserving magnitude).
+        let a = crate::compile_and_decide(
+            "observe a(3)\n\
+             observe b(10)\n\
+             let answer = latex \"$\\operatorname{abs}(a - b)$\"\n\
+             prior 0.10 for correct\n\
+             contributes 1000000 from answer == 7 to correct\n\
+             ? correct\n",
+        )
+        .unwrap();
+        assert!(a.ranked[0].posterior > 0.99, "{a:?}");
+        // exp(ln(x)) round-trips to x — exercises BOTH the exp and ln operator-name arms in
+        // one expression. x = 5 → 5.
+        let e = crate::compile_and_decide(
+            "observe x(5)\n\
+             let answer = latex \"$\\operatorname{exp}(\\operatorname{ln}(x))$\"\n\
+             prior 0.10 for correct\n\
+             contributes 1000000 from answer == 5 to correct\n\
+             ? correct\n",
+        )
+        .unwrap();
+        assert!(e.ranked[0].posterior > 0.99, "{e:?}");
+        // log is base-10 (distinct from ln): log(1000) = 3.
+        let l = crate::compile_and_decide(
+            "observe x(1000)\n\
+             let answer = latex \"$\\operatorname{log}(x)$\"\n\
+             prior 0.10 for correct\n\
+             contributes 1000000 from answer == 3 to correct\n\
+             ? correct\n",
+        )
+        .unwrap();
+        assert!(l.ranked[0].posterior > 0.99, "{l:?}");
+    }
+
+    #[test]
     fn native_latex_symbolic_root_degree_is_rejected() {
         // `\sqrt[k]{x}` — a symbolic degree has no numeric value, so the reciprocal
         // exponent `1/k` cannot be formed. It must be rejected, not silently


### PR DESCRIPTION
## LaTeX consumer slice: `\operatorname{abs/exp/log/ln}` word spellings

Math-tuned local models emit single-argument unary functions two ways: the backslash macro
(`\exp(x)`, `\ln(x)`) or the delimiter form (`|x|`), **and** the operator-name spelling
(`\operatorname{exp}(x)`, `\operatorname{abs}(x)`). The macro/`|x|` forms already lower; this
PR makes the **operator-name spelling reach the identical native node** — a model that writes
the name lands on the same AST.

### Why it needs new arms (parse shape, probed empirically)

`\operatorname{…}` is a TEXT command, so — unlike `\exp(x)` (a `Call`) or `|x|` (a `Fenced`) —
`\operatorname{exp}(x)` parses as the operator-name **juxtaposition**
`Bin(Mul, Text("exp"), Fenced(x))`, the same shape the adapter already recognises for
`\operatorname{floor}`/`ceil`/`round`/`sgn`/`trunc`. Four new arms match via
`operator_name_is(lhs, …)` and lower to the **existing** node:

| spelling | node | dimension |
|---|---|---|
| `\operatorname{abs}(x)` | `ExprAst::Abs` | preserving (magnitude) |
| `\operatorname{exp}(x)` | `ExprAst::Call(NamedFn::Exp)` | Scalar→Scalar |
| `\operatorname{log}(x)` | `ExprAst::Call(NamedFn::Log)` (base-10) | Scalar→Scalar |
| `\operatorname{ln}(x)` | `ExprAst::Call(NamedFn::Ln)` | Scalar→Scalar |

### What changed

- **`adapter.rs`** — four operator-name arms above the general product arm (mirrors the
  floor/sgn/trunc single-arg arms; `abs`→`Abs`, `exp`/`log`/`ln`→`Call(NamedFn::…)`).
- **`lower.rs`** — +1 e2e unit test: `abs(a−b)=7` (dimension-preserving magnitude),
  `exp(ln(x))` round-trip (both arms in one expr), base-10 `log(1000)=3` (distinct from ln).
- Version 0.35.0 → 0.36.0; CHANGELOG prepended.

**Pure adapter recognition: no engine, AST, or lowering change** (`ExprAst::Abs` and
`NamedFn::Exp/Log/Ln` all pre-existing). `cargo test -p logic-engine -p adj-lang -p
adj-lang-cli -p adj-constraint-solver` green (115 adj-lang tests). Security review passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
