### PR TITLE
[codex] Add noscript cross-axis audit evidence

### DIFF
--- a/code/packages/rust/html-parser/tests/whatwg_noscript_audit_test.rs
+++ b/code/packages/rust/html-parser/tests/whatwg_noscript_audit_test.rs
@@ -5,13 +5,150 @@ use serde::Deserialize;
 use std::collections::{BTreeMap, HashMap};
 
 const TREE_CONSTRUCTION_SMOKE: &str = include_str!("fixtures/html5lib-tree-construction-smoke.dat");
+const WHATWG_BLOCK_BOUNDARY_AUDIT: &str = include_str!("fixtures/whatwg-block-boundary-audit.json");
+const WHATWG_DOCUMENT_SHELL_AUDIT: &str = include_str!("fixtures/whatwg-document-shell-audit.json");
+const WHATWG_FORMATTING_AUDIT: &str = include_str!("fixtures/whatwg-formatting-audit.json");
+const WHATWG_FORM_INTERACTIVE_AUDIT: &str =
+    include_str!("fixtures/whatwg-form-interactive-audit.json");
+const WHATWG_FRAMESET_AUDIT: &str = include_str!("fixtures/whatwg-frameset-audit.json");
+const WHATWG_HEAD_BODY_AUDIT: &str = include_str!("fixtures/whatwg-head-body-audit.json");
+const WHATWG_LIST_ITEM_AUDIT: &str = include_str!("fixtures/whatwg-list-item-audit.json");
 const WHATWG_NOSCRIPT_AUDIT: &str = include_str!("fixtures/whatwg-noscript-audit.json");
+const WHATWG_PARAGRAPH_AUDIT: &str = include_str!("fixtures/whatwg-paragraph-audit.json");
+const WHATWG_SELECT_LIST_AUDIT: &str = include_str!("fixtures/whatwg-select-list-audit.json");
+const WHATWG_TABLE_AUDIT: &str = include_str!("fixtures/whatwg-table-audit.json");
+const WHATWG_TEXT_CONTROL_AUDIT: &str = include_str!("fixtures/whatwg-text-control-audit.json");
+const WHATWG_VOID_ELEMENT_AUDIT: &str = include_str!("fixtures/whatwg-void-element-audit.json");
+
+struct StrayNoscriptEndTagCase {
+    id: &'static str,
+    source: &'static str,
+    data_snippet: &'static str,
+    suites: &'static [(&'static str, &'static str, &'static str)],
+}
+
 const POST_PARSE_REPAIR_EVIDENCE: &[(&str, &str)] = &[
     ("noscript01-dat-327", "head-noscript-disabled"),
     ("tests16-dat-851", "comment-boundary"),
     ("tests16-dat-855", "textmode-descendant"),
     ("tests1-dat-675", "stray-noscript-end-tag"),
     ("webkit02-dat-2", "paragraph-noscript"),
+];
+const STRAY_NOSCRIPT_BODY_CROSS_AXIS_SUITES: &[(&str, &str, &str)] = &[
+    (
+        "block-boundary",
+        WHATWG_BLOCK_BOUNDARY_AUDIT,
+        "block-table-boundary",
+    ),
+    (
+        "document-shell",
+        WHATWG_DOCUMENT_SHELL_AUDIT,
+        "html-element-boundary",
+    ),
+    (
+        "form-interactive",
+        WHATWG_FORM_INTERACTIVE_AUDIT,
+        "stray-interactive-end-tags",
+    ),
+    (
+        "formatting",
+        WHATWG_FORMATTING_AUDIT,
+        "list-definition-boundary",
+    ),
+    ("frameset", WHATWG_FRAMESET_AUDIT, "noframes-content"),
+    ("head-body", WHATWG_HEAD_BODY_AUDIT, "head-text-mode"),
+    ("list-item", WHATWG_LIST_ITEM_AUDIT, "list-with-formatting"),
+    ("noscript", WHATWG_NOSCRIPT_AUDIT, "stray-noscript-end-tag"),
+    (
+        "paragraph",
+        WHATWG_PARAGRAPH_AUDIT,
+        "paragraph-formatting-boundary",
+    ),
+    (
+        "select-list",
+        WHATWG_SELECT_LIST_AUDIT,
+        "stray-select-end-tags",
+    ),
+    ("table", WHATWG_TABLE_AUDIT, "caption-colgroup"),
+    (
+        "text-control",
+        WHATWG_TEXT_CONTROL_AUDIT,
+        "stray-text-control-end-tags",
+    ),
+    (
+        "void-element",
+        WHATWG_VOID_ELEMENT_AUDIT,
+        "stray-void-end-tags",
+    ),
+];
+const STRAY_NOSCRIPT_TABLE_CROSS_AXIS_SUITES: &[(&str, &str, &str)] = &[
+    (
+        "block-boundary",
+        WHATWG_BLOCK_BOUNDARY_AUDIT,
+        "block-table-boundary",
+    ),
+    (
+        "document-shell",
+        WHATWG_DOCUMENT_SHELL_AUDIT,
+        "html-element-boundary",
+    ),
+    (
+        "form-interactive",
+        WHATWG_FORM_INTERACTIVE_AUDIT,
+        "stray-interactive-end-tags",
+    ),
+    (
+        "formatting",
+        WHATWG_FORMATTING_AUDIT,
+        "list-definition-boundary",
+    ),
+    ("frameset", WHATWG_FRAMESET_AUDIT, "noframes-content"),
+    ("head-body", WHATWG_HEAD_BODY_AUDIT, "head-text-mode"),
+    ("list-item", WHATWG_LIST_ITEM_AUDIT, "list-in-table"),
+    ("noscript", WHATWG_NOSCRIPT_AUDIT, "stray-noscript-end-tag"),
+    (
+        "paragraph",
+        WHATWG_PARAGRAPH_AUDIT,
+        "paragraph-table-boundary",
+    ),
+    (
+        "select-list",
+        WHATWG_SELECT_LIST_AUDIT,
+        "stray-select-end-tags",
+    ),
+    ("table", WHATWG_TABLE_AUDIT, "caption-colgroup"),
+    (
+        "text-control",
+        WHATWG_TEXT_CONTROL_AUDIT,
+        "stray-text-control-end-tags",
+    ),
+    ("void-element", WHATWG_VOID_ELEMENT_AUDIT, "void-in-table"),
+];
+const STRAY_NOSCRIPT_END_TAG_CROSS_AXIS_CASES: &[StrayNoscriptEndTagCase] = &[
+    StrayNoscriptEndTagCase {
+        id: "tests1-dat-110",
+        source: "tests1.dat:110",
+        data_snippet: "</strong></b></em></i>",
+        suites: STRAY_NOSCRIPT_BODY_CROSS_AXIS_SUITES,
+    },
+    StrayNoscriptEndTagCase {
+        id: "tests1-dat-111",
+        source: "tests1.dat:111",
+        data_snippet: "<table><tr></strong></b></em>",
+        suites: STRAY_NOSCRIPT_TABLE_CROSS_AXIS_SUITES,
+    },
+    StrayNoscriptEndTagCase {
+        id: "tests1-dat-675",
+        source: "tests1.dat:675",
+        data_snippet: "</strong></b></em></i>",
+        suites: STRAY_NOSCRIPT_BODY_CROSS_AXIS_SUITES,
+    },
+    StrayNoscriptEndTagCase {
+        id: "tests1-dat-676",
+        source: "tests1.dat:676",
+        data_snippet: "<table><tr></strong></b></em>",
+        suites: STRAY_NOSCRIPT_TABLE_CROSS_AXIS_SUITES,
+    },
 ];
 
 #[derive(Debug, Deserialize)]
@@ -30,6 +167,19 @@ struct NoscriptAuditCase {
     source: String,
     axis: String,
     scripting: String,
+    reason: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GenericAuditSuite {
+    cases: Vec<GenericAuditCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GenericAuditCase {
+    id: String,
+    source: String,
+    axis: String,
     reason: String,
 }
 
@@ -78,6 +228,96 @@ fn whatwg_noscript_audit_cases_match_parser_dom_dump() {
             "case `{}` ({}) failed for input {:?}",
             case.id, case.axis, source_case.data
         );
+    }
+}
+
+#[test]
+fn whatwg_noscript_audit_keeps_stray_end_tag_cases_cross_axis() {
+    let suite = load_suite();
+    let audit_cases = suite
+        .cases
+        .iter()
+        .map(|case| (case.id.as_str(), case))
+        .collect::<HashMap<_, _>>();
+    let smoke_cases = parse_tree_construction_cases(TREE_CONSTRUCTION_SMOKE)
+        .into_iter()
+        .map(|case| (case.source.clone(), case))
+        .collect::<HashMap<_, _>>();
+
+    for evidence in STRAY_NOSCRIPT_END_TAG_CROSS_AXIS_CASES {
+        let noscript_case = audit_cases.get(evidence.id).unwrap_or_else(|| {
+            panic!(
+                "stray noscript end-tag evidence case `{}` should be audited",
+                evidence.id
+            )
+        });
+        assert_eq!(
+            noscript_case.source, evidence.source,
+            "stray noscript end-tag case `{}` should stay tied to its smoke fixture row",
+            evidence.id
+        );
+        assert_eq!(
+            noscript_case.axis, "stray-noscript-end-tag",
+            "stray noscript end-tag case `{}` should stay on its focused audit axis",
+            evidence.id
+        );
+        assert!(
+            !noscript_case.scripting.is_empty() && !noscript_case.reason.is_empty(),
+            "stray noscript end-tag case `{}` should keep noscript audit metadata",
+            evidence.id
+        );
+
+        let source_case = smoke_cases
+            .get(evidence.source)
+            .unwrap_or_else(|| panic!("case `{}` should exist in smoke fixture", evidence.source));
+        assert!(
+            source_case.data.contains(evidence.data_snippet),
+            "stray noscript end-tag case `{}` should stay tied to its html5lib input",
+            evidence.id
+        );
+        let actual = actual_dom_dump_for_tree_case(source_case).unwrap_or_else(|error| {
+            panic!(
+                "case `{}` ({}) parse failed: {error}",
+                noscript_case.id, noscript_case.axis
+            )
+        });
+
+        assert_eq!(
+            actual, source_case.document,
+            "stray noscript end-tag evidence case `{}` ({}) failed for input {:?}",
+            noscript_case.id, noscript_case.axis, source_case.data
+        );
+
+        for (suite_name, suite_json, expected_axis) in evidence.suites {
+            let generic_suite: GenericAuditSuite = serde_json::from_str(suite_json)
+                .unwrap_or_else(|error| panic!("{suite_name} audit fixture should parse: {error}"));
+            let generic_case = generic_suite
+                .cases
+                .iter()
+                .find(|case| case.id == evidence.id)
+                .unwrap_or_else(|| {
+                    panic!(
+                        "{suite_name} audit should include stray noscript end-tag case `{}`",
+                        evidence.id
+                    )
+                });
+
+            assert_eq!(
+                generic_case.axis, *expected_axis,
+                "{suite_name} audit should keep `{}` on its focused axis",
+                evidence.id
+            );
+            assert_eq!(
+                generic_case.source, evidence.source,
+                "{suite_name} audit case `{}` should point at the same WHATWG source row",
+                evidence.id
+            );
+            assert!(
+                !generic_case.reason.is_empty(),
+                "{suite_name} audit case `{}` should keep a fixture reason",
+                evidence.id
+            );
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Add executable cross-axis evidence for four stray `</noscript>` html5lib smoke rows in the noscript audit test.
- Pin the body/table variants across block/document/form/formatting/frameset/head/list/noscript/paragraph/select/table/text/void audit axes.
- Replay the source smoke rows through the DOM-dump harness so the evidence stays tied to parser behavior.

## Tests
- `cargo test -p coding-adventures-html-parser whatwg_noscript_audit_keeps_stray_end_tag_cases_cross_axis`
- `cargo test -p coding-adventures-html-parser whatwg_noscript_audit`
- `cargo test -p coding-adventures-html-parser`
- `CARGO_BUILD_JOBS=2 cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser`
- `python3 -m json.tool code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json >/dev/null`
- `python3 code/packages/rust/html-parser/tests/fixtures/check_whatwg_audit_rust_tests.py --check`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py`
- `git diff --check`