### PR TITLE
[codex] Persist Engram web host snapshots

### DIFF
--- a/code/programs/mosaic/engram-app/CHANGELOG.md
+++ b/code/programs/mosaic/engram-app/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Persisted Engram Mosaic web, React, WebComponent, and Electron host snapshots
+  across launches, seeding from the built-in language-learning demo only when no
+  saved state is available.
 - Wired the generated Flutter Engram shell to the optional Mosaic host contract
   with a Dart FFI `engram-capi` adapter, shared slot hydration, and generated
   event-envelope routing through the Rust core.

--- a/code/programs/mosaic/engram-app/host/electron/host.js
+++ b/code/programs/mosaic/engram-app/host/electron/host.js
@@ -1,16 +1,79 @@
-import { readFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
+import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
 
-import { createEngramMosaicHost } from "./engram-mosaic-host-wasm.mjs";
+import { createEngramEngine } from "./engram-mosaic-host-wasm.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const wasmPath = join(here, "engram_engine.wasm");
+const snapshotPath =
+  process.env.ENGRAM_SNAPSHOT_PATH ?? join(homedir(), ".engram", "mosaic-snapshot.v1.json");
 
 export async function createMosaicHost() {
-  return createEngramMosaicHost(readFileSync(wasmPath), {
+  const engine = createEngramEngine(readFileSync(wasmPath), {
+    now: () => Date.now(),
+  });
+  hydrateEngine(engine);
+
+  const host = engine.createMosaicHost({
     deckId: "",
     now: () => Date.now(),
     onHostIntent: (intent) => ({ hostIntent: intent }),
   });
+  return withSnapshotPersistence(host, engine);
+}
+
+function hydrateEngine(engine) {
+  if (existsSync(snapshotPath)) {
+    try {
+      const loaded = engine.loadSnapshot(readFileSync(snapshotPath, "utf8"));
+      if (loaded.ok === true) {
+        return;
+      }
+      console.warn("Engram persisted snapshot was invalid; resetting demo state", loaded.error);
+    } catch (error) {
+      console.warn("Engram could not read persisted snapshot; resetting demo state", error);
+    }
+  }
+
+  engine.resetDemo();
+  persistSnapshot(engine);
+}
+
+function withSnapshotPersistence(host, engine) {
+  const handleEvent = host.handleEvent;
+  if (typeof handleEvent !== "function") {
+    return host;
+  }
+
+  return {
+    ...host,
+    async handleEvent(request) {
+      const result = await handleEvent(request);
+      if (!isErrorResult(result)) {
+        persistSnapshot(engine);
+      }
+      return result;
+    },
+  };
+}
+
+function persistSnapshot(engine) {
+  const snapshot = engine.snapshot();
+  if (snapshot.ok !== true || snapshot.state === undefined) {
+    console.warn("Engram snapshot could not be persisted", snapshot.error);
+    return;
+  }
+
+  try {
+    mkdirSync(dirname(snapshotPath), { recursive: true });
+    writeFileSync(snapshotPath, JSON.stringify(snapshot.state), "utf8");
+  } catch (error) {
+    console.warn("Engram could not persist snapshot", error);
+  }
+}
+
+function isErrorResult(result) {
+  return Boolean(result && typeof result === "object" && result.error);
 }

--- a/code/programs/mosaic/engram-app/host/web/engram-host.mjs
+++ b/code/programs/mosaic/engram-app/host/web/engram-host.mjs
@@ -1,7 +1,8 @@
-import { installEngramMosaicHost } from "./engram-mosaic-host-wasm.mjs";
+import { createEngramEngine } from "./engram-mosaic-host-wasm.mjs";
 
 const WASM_URL = "./engram_engine.wasm";
 const DECK_ID_STORAGE_KEY = "engram.deckId";
+const SNAPSHOT_STORAGE_KEY = "engram.snapshot.v1";
 const HOST_INTENT_EVENT = "engram-host-intent";
 const HOST_READY_EVENT = "mosaic-host-ready";
 
@@ -19,8 +20,12 @@ async function installEngramHost() {
     throw new Error(`failed to fetch Engram WASM module: ${response.status}`);
   }
 
-  installEngramMosaicHost(window, await response.arrayBuffer(), {
-    demo: true,
+  const engine = createEngramEngine(await response.arrayBuffer(), {
+    now: () => Date.now(),
+  });
+  hydrateEngine(engine);
+
+  const host = engine.createMosaicHost({
     deckId: selectedDeckId,
     now: () => Date.now(),
     onHostIntent: (intent, result) => {
@@ -31,11 +36,74 @@ async function installEngramHost() {
       );
     },
   });
+  window.mosaicHost = withSnapshotPersistence(host, engine);
   announceHostReady();
 }
 
+function hydrateEngine(engine) {
+  const snapshot = readStorage(SNAPSHOT_STORAGE_KEY);
+  if (snapshot) {
+    const loaded = engine.loadSnapshot(snapshot);
+    if (loaded.ok === true) {
+      return;
+    }
+    console.warn("Engram persisted snapshot was invalid; resetting demo state", loaded.error);
+  }
+
+  engine.resetDemo();
+  persistSnapshot(engine);
+}
+
+function withSnapshotPersistence(host, engine) {
+  const handleEvent = host.handleEvent;
+  if (typeof handleEvent !== "function") {
+    return host;
+  }
+
+  return {
+    ...host,
+    async handleEvent(request) {
+      const result = await handleEvent(request);
+      if (!isErrorResult(result)) {
+        persistSnapshot(engine);
+      }
+      return result;
+    },
+  };
+}
+
+function persistSnapshot(engine) {
+  const snapshot = engine.snapshot();
+  if (snapshot.ok !== true || snapshot.state === undefined) {
+    console.warn("Engram snapshot could not be persisted", snapshot.error);
+    return;
+  }
+  writeStorage(SNAPSHOT_STORAGE_KEY, JSON.stringify(snapshot.state));
+}
+
+function isErrorResult(result) {
+  return Boolean(result && typeof result === "object" && result.error);
+}
+
 function selectedDeckId() {
-  return window.localStorage.getItem(DECK_ID_STORAGE_KEY) ?? "";
+  return readStorage(DECK_ID_STORAGE_KEY) ?? "";
+}
+
+function readStorage(key) {
+  try {
+    return window.localStorage.getItem(key);
+  } catch (error) {
+    console.warn(`Engram could not read ${key} from localStorage`, error);
+    return null;
+  }
+}
+
+function writeStorage(key, value) {
+  try {
+    window.localStorage.setItem(key, value);
+  } catch (error) {
+    console.warn(`Engram could not write ${key} to localStorage`, error);
+  }
 }
 
 function announceHostReady() {

--- a/code/programs/mosaic/engram-app/host/web/engram-host.ts
+++ b/code/programs/mosaic/engram-app/host/web/engram-host.ts
@@ -1,16 +1,30 @@
-import { installEngramMosaicHost } from "./engram-mosaic-host-wasm";
+import { createEngramEngine } from "./engram-mosaic-host-wasm";
 
 type HostIntent = Record<string, unknown>;
 type HostResult = Record<string, unknown>;
-type HostedWindow = Window & {
-  mosaicHost?: {
-    getProps?: unknown;
-    handleEvent?: unknown;
-  };
+type HostRequest = { component: string; event?: unknown };
+type EngramMosaicHost = {
+  platform: string;
+  getProps?: (request: HostRequest) => unknown | Promise<unknown>;
+  handleEvent?: (request: HostRequest) => unknown | Promise<unknown>;
+};
+type EngramEngine = {
+  resetDemo: () => unknown;
+  snapshot: () => { ok?: boolean; state?: unknown; error?: unknown };
+  loadSnapshot: (snapshot: string) => { ok?: boolean; error?: unknown };
+  createMosaicHost: (options: {
+    deckId?: string | (() => string);
+    now?: number | (() => number);
+    onHostIntent?: (intent: HostIntent, result: HostResult) => unknown;
+  }) => EngramMosaicHost;
+};
+type HostedWindow = {
+  mosaicHost?: EngramMosaicHost;
 };
 
 const WASM_URL = "/engram_engine.wasm";
 const DECK_ID_STORAGE_KEY = "engram.deckId";
+const SNAPSHOT_STORAGE_KEY = "engram.snapshot.v1";
 const HOST_INTENT_EVENT = "engram-host-intent";
 const HOST_READY_EVENT = "mosaic-host-ready";
 
@@ -30,8 +44,12 @@ async function installEngramHost(): Promise<void> {
     throw new Error(`failed to fetch Engram WASM module: ${response.status}`);
   }
 
-  installEngramMosaicHost(target, await response.arrayBuffer(), {
-    demo: true,
+  const engine = createEngramEngine(await response.arrayBuffer(), {
+    now: () => Date.now(),
+  }) as EngramEngine;
+  hydrateEngine(engine);
+
+  const host = engine.createMosaicHost({
     deckId: selectedDeckId,
     now: () => Date.now(),
     onHostIntent: (intent: HostIntent, result: HostResult) => {
@@ -42,11 +60,82 @@ async function installEngramHost(): Promise<void> {
       );
     },
   });
+  target.mosaicHost = withSnapshotPersistence(host, engine);
   announceHostReady();
 }
 
+function hydrateEngine(engine: EngramEngine): void {
+  const snapshot = readStorage(SNAPSHOT_STORAGE_KEY);
+  if (snapshot) {
+    const loaded = engine.loadSnapshot(snapshot);
+    if (loaded.ok === true) {
+      return;
+    }
+    console.warn("Engram persisted snapshot was invalid; resetting demo state", loaded.error);
+  }
+
+  engine.resetDemo();
+  persistSnapshot(engine);
+}
+
+function withSnapshotPersistence(
+  host: EngramMosaicHost,
+  engine: EngramEngine,
+): EngramMosaicHost {
+  const handleEvent = host.handleEvent;
+  if (typeof handleEvent !== "function") {
+    return host;
+  }
+
+  return {
+    ...host,
+    async handleEvent(request: HostRequest) {
+      const result = await handleEvent(request);
+      if (!isErrorResult(result)) {
+        persistSnapshot(engine);
+      }
+      return result;
+    },
+  };
+}
+
+function persistSnapshot(engine: EngramEngine): void {
+  const snapshot = engine.snapshot();
+  if (snapshot.ok !== true || snapshot.state === undefined) {
+    console.warn("Engram snapshot could not be persisted", snapshot.error);
+    return;
+  }
+  writeStorage(SNAPSHOT_STORAGE_KEY, JSON.stringify(snapshot.state));
+}
+
+function isErrorResult(result: unknown): boolean {
+  return (
+    typeof result === "object" &&
+    result !== null &&
+    "error" in result &&
+    Boolean((result as { error?: unknown }).error)
+  );
+}
+
 function selectedDeckId(): string {
-  return window.localStorage.getItem(DECK_ID_STORAGE_KEY) ?? "";
+  return readStorage(DECK_ID_STORAGE_KEY) ?? "";
+}
+
+function readStorage(key: string): string | null {
+  try {
+    return window.localStorage.getItem(key);
+  } catch (error) {
+    console.warn(`Engram could not read ${key} from localStorage`, error);
+    return null;
+  }
+}
+
+function writeStorage(key: string, value: string): void {
+  try {
+    window.localStorage.setItem(key, value);
+  } catch (error) {
+    console.warn(`Engram could not write ${key} to localStorage`, error);
+  }
 }
 
 function announceHostReady(): void {

--- a/code/programs/mosaic/engram-app/host/web/engram-mosaic-host-wasm.d.ts
+++ b/code/programs/mosaic/engram-app/host/web/engram-mosaic-host-wasm.d.ts
@@ -4,6 +4,30 @@ export type EngramMosaicHost = {
   handleEvent?: (request: { component: string; event?: unknown }) => unknown | Promise<unknown>;
 };
 
+export type EngramEngine = {
+  reset: () => unknown;
+  resetDemo: () => unknown;
+  demoSnapshot: () => unknown;
+  snapshot: () => { ok?: boolean; state?: unknown; error?: unknown };
+  getState: () => unknown;
+  loadSnapshot: (snapshot: unknown) => { ok?: boolean; error?: unknown };
+  dispatch: (command: unknown) => unknown;
+  createMosaicHost: (options?: {
+    deckId?: string | (() => string);
+    now?: number | (() => number);
+    onHostIntent?: (intent: Record<string, unknown>, result: Record<string, unknown>) => unknown;
+  }) => EngramMosaicHost;
+};
+
+export function createEngramEngine(
+  wasmBytes: BufferSource | WebAssembly.Module,
+  options?: {
+    demo?: boolean;
+    deckId?: string | (() => string);
+    now?: number | (() => number);
+  },
+): EngramEngine;
+
 export function installEngramMosaicHost(
   targetWindow: Window,
   wasmBytes: BufferSource | WebAssembly.Module,

--- a/code/programs/mosaic/engram-app/tests/package_compiles.rs
+++ b/code/programs/mosaic/engram-app/tests/package_compiles.rs
@@ -674,6 +674,14 @@ fn native_project_shells_expose_engram_host_contract() {
         &html_host,
         "window.dispatchEvent(new CustomEvent(HOST_READY_EVENT));",
     );
+    assert_contains(&html_host, "createEngramEngine");
+    assert_contains(
+        &html_host,
+        "const SNAPSHOT_STORAGE_KEY = \"engram.snapshot.v1\";",
+    );
+    assert_contains(&html_host, "hydrateEngine(engine);");
+    assert_contains(&html_host, "withSnapshotPersistence(host, engine)");
+    assert_contains(&html_host, "persistSnapshot(engine);");
 
     let webcomponent_index = fs::read_to_string(tmp.path().join("webcomponent").join("index.html"))
         .expect("webcomponent/index.html");
@@ -756,6 +764,14 @@ fn native_project_shells_expose_engram_host_contract() {
         &webcomponent_host,
         "window.dispatchEvent(new CustomEvent(HOST_READY_EVENT));",
     );
+    assert_contains(&webcomponent_host, "createEngramEngine");
+    assert_contains(
+        &webcomponent_host,
+        "const SNAPSHOT_STORAGE_KEY = \"engram.snapshot.v1\";",
+    );
+    assert_contains(&webcomponent_host, "hydrateEngine(engine);");
+    assert_contains(&webcomponent_host, "withSnapshotPersistence(host, engine)");
+    assert_contains(&webcomponent_host, "persistSnapshot(engine);");
 
     let react_app = fs::read_to_string(tmp.path().join("react").join("src").join("main.tsx"))
         .expect("react/src/main.tsx");
@@ -849,7 +865,7 @@ fn native_project_shells_expose_engram_host_contract() {
     let react_host =
         fs::read_to_string(tmp.path().join("react").join("src").join("engram-host.ts"))
             .expect("react host");
-    assert_contains(&react_host, "installEngramMosaicHost");
+    assert_contains(&react_host, "createEngramEngine");
     assert_contains(&react_host, "engram_engine.wasm");
     assert_contains(
         &react_host,
@@ -859,6 +875,13 @@ fn native_project_shells_expose_engram_host_contract() {
         &react_host,
         "window.dispatchEvent(new CustomEvent(HOST_READY_EVENT));",
     );
+    assert_contains(
+        &react_host,
+        "const SNAPSHOT_STORAGE_KEY = \"engram.snapshot.v1\";",
+    );
+    assert_contains(&react_host, "hydrateEngine(engine);");
+    assert_contains(&react_host, "withSnapshotPersistence(host, engine)");
+    assert_contains(&react_host, "persistSnapshot(engine);");
     assert!(
         tmp.path()
             .join("react")
@@ -997,6 +1020,12 @@ fn native_project_shells_expose_engram_host_contract() {
         fs::read_to_string(tmp.path().join("electron").join("electron").join("host.js"))
             .expect("electron host.js");
     assert_contains(&electron_host, "createMosaicHost");
+    assert_contains(&electron_host, "createEngramEngine");
+    assert_contains(&electron_host, "ENGRAM_SNAPSHOT_PATH");
+    assert_contains(&electron_host, "mosaic-snapshot.v1.json");
+    assert_contains(&electron_host, "hydrateEngine(engine);");
+    assert_contains(&electron_host, "withSnapshotPersistence(host, engine)");
+    assert_contains(&electron_host, "persistSnapshot(engine);");
 
     let flutter_app = fs::read_to_string(tmp.path().join("flutter").join("lib").join("main.dart"))
         .expect("flutter/lib/main.dart");


### PR DESCRIPTION
## Summary
- Persist Engram Mosaic web, React, and WebComponent host snapshots in localStorage under `engram.snapshot.v1`.
- Persist the Electron host snapshot to `ENGRAM_SNAPSHOT_PATH` or `~/.engram/mosaic-snapshot.v1.json`.
- Seed from the built-in demo only when no saved snapshot is available, and save after successful host events.

## Validation
- `cargo test --manifest-path code\programs\mosaic\engram-app\Cargo.toml -- --nocapture`
- `code\programs\mosaic\engram-app\scripts\build-all.ps1`
- `npm run build` in `code\programs\mosaic\engram-app\target\mosaic-engram-app\react`
- `npm run build` in `code\programs\mosaic\engram-app\target\mosaic-engram-app\electron`
- Electron host runtime smoke with `ENGRAM_SNAPSHOT_PATH`
- `git diff --check`