### PR TITLE
feat(adj-ladder): rung-49 fractionated dose (distributive a*(b+c))

### DIFF
--- a/code/specs/data/adj-ladder/rung49_fractionated_dose/gen_items.py
+++ b/code/specs/data/adj-ladder/rung49_fractionated_dose/gen_items.py
@@ -1,0 +1,221 @@
+"""Generate rung-49 (fractionated radiotherapy total dose) items.json for the ADJ-LADDER.
+
+Rung 49 opens the **radiation-oncology / fractionated-dose** panel on the quantitative band — the arithmetic of the
+total radiation dose a course delivers when the same per-fraction dose is given across the fractions of two treatment
+phases. The dose delivered in a course is the per-fraction dose multiplied by the TOTAL number of fractions, and the
+total fractions is the SUM of the two phases (`fractions_one + fractions_two`). Multiplying the single per-fraction
+dose by that parenthesised sum introduces a genuinely NEW arithmetic shape on the ladder: **product-over-a-sum in the
+DISTRIBUTIVE sense** — `a · (b + c)` — one quantity multiplying a parenthesised sum of two.
+
+The setup: a course delivers `dose_per_fraction` Gy per fraction, given for `fractions_one` fractions in the first
+phase and `fractions_two` fractions in the second. The total dose is the per-fraction dose times the total fractions:
+
+  TOTAL DOSE        dose_per_fraction · (fractions_one + fractions_two)   [ Gy — the whole course ]
+  TOTAL FRACTIONS   fractions_one + fractions_two                         [ the summed count ]
+  PHASE-ONE DOSE    dose_per_fraction · fractions_one                     [ one distributed term: the first phase ]
+
+The **total dose** is what makes this rung distinctive — it is the ladder's first **distributive product-over-a-sum**:
+a single factor multiplying a parenthesised sum. Contrast the neighbours already on the ladder: rung-34 was a *sum of
+two products* `a·b + c·d`, rung-43 a *sum of three products*, rung-48 a *sum times a difference* `(a+b)·(c−d)`; none
+multiplied a lone factor by a parenthesised SUM. (The total fractions `fractions_one + fractions_two` and the
+phase-one dose `dose_per_fraction · fractions_one` ride alongside as component readouts, so the panel teaches the whole
+calculation — exactly as rungs 46/47/48 shipped their component sums/products beside the headline figure.)
+
+Each index is a `compute_dimensioned` program (`observe` the three quantities + `let answer = formula`); the ADJ
+engine carries the arithmetic — including the inner `(fractions_one + fractions_two)` sum — and the harness reads the
+scalar via the existing `compute_dimensioned` extractor. No harness/engine change, exactly as rungs 8/16/.../47/48.
+This rung exercises the engine across a **single factor times a parenthesised sum** — the distributive law
+`a·(b+c) = a·b + a·c` made computable.
+
+Contamination-safe by construction: every formula is built ONLY from the three observed quantities via `·`, `+` and
+`−` — **no structural constants** — so no numeric literal appears in any program, and neither the total fractions, the
+phase-one dose, nor any total-dose figure is ever a literal (each is computed from the observed quantities). The
+observed quantities carry **digit-free identifiers** (`dose_per_fraction`, `fractions_one`, `fractions_two`) so no
+numeral hides inside a variable name.
+
+The five options are a tight family over the same three quantities: the three real readouts plus the two classic
+slips —
+
+  DIFF VERSION   dose_per_fraction · (fractions_one − fractions_two)   SUBTRACT the two phases' fractions instead of
+                                                                       adding them, and
+  MISGROUPED     dose_per_fraction · fractions_one + fractions_two     forget to distribute over the second phase — add
+                                                                       the raw second-phase COUNT instead of the dose
+                                                                       it delivers (`+ fractions_two`, not
+                                                                       `+ dose_per_fraction · fractions_two`),
+
+which are exactly the mistakes a student makes (subtracting quantities that should be added, or breaking the
+distributive law by not scaling the second term). Gold rotates A-E by index. QUERIED (used as gold) = the three real
+readouts; all five always appear as options.
+
+Distinctness: all three observed quantities are positive with `fractions_one > fractions_two`, so every sum, product
+and difference is positive; the tables below are chosen so the five family values are pairwise distinct with a
+comfortable margin, asserted at build time.
+"""
+import json
+
+LETTERS = ["A", "B", "C", "D", "E"]
+
+# (DOSE_PER_FRACTION, FRACTIONS_ONE, FRACTIONS_TWO) — dose in Gy per fraction, fractions are plain positive counts.
+# All three quantities are strictly positive and FRACTIONS_ONE > FRACTIONS_TWO, so the phase difference is positive.
+# The five family values are asserted pairwise-distinct (with margin) below.
+TABLES = [
+    (3, 15, 10),
+    (2, 20, 12),
+    (4, 12, 5),
+    (5, 8, 6),
+    (3, 18, 8),
+    (2, 25, 15),
+    (6, 9, 4),
+]
+
+# The option family (5 members), all built from the three observed quantities via *, + and -. Every identifier is
+# DIGIT-FREE. key -> (display name, formula-as-adj). Only the first three are *queried* (used as gold); all five
+# always appear as the options.
+FAMILY = [
+    (
+        "total_dose",
+        "total course dose (the per-fraction dose times the total number of fractions)",
+        "dose_per_fraction * (fractions_one + fractions_two)",
+    ),
+    (
+        "total_fractions",
+        "the total number of fractions (the two phases added)",
+        "fractions_one + fractions_two",
+    ),
+    (
+        "phase_one_dose",
+        "the first phase's dose (the per-fraction dose times the first phase's fractions)",
+        "dose_per_fraction * fractions_one",
+    ),
+    (
+        "diff_version",
+        "per-fraction dose times the two phases SUBTRACTED, not added (a wrong total)",
+        "dose_per_fraction * (fractions_one - fractions_two)",
+    ),
+    (
+        "misgrouped",
+        "first phase's dose plus the raw second-phase COUNT, forgetting to scale it (broken distribution)",
+        "dose_per_fraction * fractions_one + fractions_two",
+    ),
+]
+QUERIED = ["total_dose", "total_fractions", "phase_one_dose"]
+ORDER = [k for k, _, _ in FAMILY]
+
+
+def scalar(v):
+    return {"value": v, "unit": "scalar"}
+
+
+def family_values(dose_per_fraction, fractions_one, fractions_two):
+    # Operation order mirrors the ADJ programs exactly (a single factor times a parenthesised sum), so the Python
+    # option value and the engine result are the same IEEE-double (well within the harness's 1e-9 match tolerance).
+    total_fractions = fractions_one + fractions_two
+    return {
+        "total_dose": dose_per_fraction * total_fractions,
+        "total_fractions": total_fractions,
+        "phase_one_dose": dose_per_fraction * fractions_one,
+        "diff_version": dose_per_fraction * (fractions_one - fractions_two),
+        "misgrouped": dose_per_fraction * fractions_one + fractions_two,
+    }
+
+
+def build():
+    name_of = {k: nm for k, nm, _ in FAMILY}
+    formula_of = {k: f for k, _, f in FAMILY}
+    items = []
+    idx = 0
+
+    def num(x):
+        return int(x) if float(x).is_integer() else x
+
+    for dose_per_fraction, fractions_one, fractions_two in TABLES:
+        assert (
+            dose_per_fraction > 0
+            and fractions_one > 0
+            and fractions_two > 0
+            and fractions_one > fractions_two
+        ), (dose_per_fraction, fractions_one, fractions_two)
+        fv = family_values(dose_per_fraction, fractions_one, fractions_two)
+        # Pairwise-distinct with a comfortable margin so the harness never sees two options
+        # matching the gold value within its 1e-9 tolerance.
+        vals = [fv[key] for key in ORDER]
+        for i in range(len(vals)):
+            for j in range(i + 1, len(vals)):
+                assert abs(vals[i] - vals[j]) > 1e-6, (
+                    dose_per_fraction,
+                    fractions_one,
+                    fractions_two,
+                    ORDER[i],
+                    ORDER[j],
+                    fv,
+                )
+        for key in QUERIED:
+            gold_val = fv[key]
+            gold_pos = idx % 5
+            others = [fv[k2] for k2 in ORDER if abs(fv[k2] - gold_val) > 1e-12]
+            opts_vals = others[:]
+            opts_vals.insert(gold_pos, gold_val)
+            opts_vals = opts_vals[:5]
+            if abs(opts_vals[gold_pos] - gold_val) > 1e-12:
+                opts_vals[gold_pos] = gold_val
+            assert len({round(v, 9) for v in opts_vals}) == 5, (
+                key,
+                dose_per_fraction,
+                fractions_one,
+                fractions_two,
+                opts_vals,
+            )
+            options = {LETTERS[i]: scalar(opts_vals[i]) for i in range(5)}
+            items.append({
+                "id": f"r49frx-{idx + 1:02d}",
+                "qtype": "fractionated_dose",
+                "stem": (
+                    f"A radiotherapy course delivers {num(dose_per_fraction)} Gy per fraction, given for "
+                    f"{num(fractions_one)} fractions in the first phase and {num(fractions_two)} in the second. "
+                    f"What is the {name_of[key]}?"
+                ),
+                "program": (
+                    f"observe dose_per_fraction({num(dose_per_fraction)})\n"
+                    f"observe fractions_one({num(fractions_one)})\n"
+                    f"observe fractions_two({num(fractions_two)})\n"
+                    f"let answer = {formula_of[key]}\n"
+                    "? answer\n"
+                ),
+                "answer_from": {"type": "compute_dimensioned", "name": "answer"},
+                "options": options,
+                "gold_letter": LETTERS[gold_pos],
+            })
+            idx += 1
+    return {
+        "description": (
+            "ADJ-LADDER rung 49 — fractionated radiotherapy total dose from three stated quantities (a NEW panel: "
+            "radiation-oncology / fractionated-dose). From a per-fraction dose plus the fraction counts of two "
+            "treatment phases compute the total course dose (dose_per_fraction*(fractions_one+fractions_two)), the "
+            "total fractions (fractions_one+fractions_two), or the first phase's dose "
+            "(dose_per_fraction*fractions_one). Each item is a compute_dimensioned program (observe the three "
+            "quantities, let answer = formula); the ADJ engine carries the arithmetic — a NEW shape, DISTRIBUTIVE "
+            "PRODUCT-OVER-A-SUM a*(b+c), the first product on the ladder to multiply a single factor by a "
+            "parenthesised sum (distinct from rung-34 sum-of-two-products a*b+c*d, rung-43 sum-of-three-products, and "
+            "rung-48 sum-times-difference (a+b)*(c-d)) — and the harness matches the scalar to the printed options. "
+            "Contamination-safe: every index is built only from the three observed quantities via *, + and - — no "
+            "constant leaks, and neither the total fractions, the phase-one dose, nor any total-dose figure ever "
+            "appears as a literal (each is computed) — and the observed quantities carry digit-free identifiers so no "
+            "numeral hides inside a variable name. The five options are a family over the same three quantities, so the "
+            "distractors are exactly the slips students make: SUBTRACTING the two phases instead of adding them, and "
+            "breaking the distributive law by adding the raw second-phase count instead of the dose it delivers "
+            "(a*b+c, not a*(b+c)). The core confusion tested is distributing the per-fraction dose over the summed "
+            "fraction count."
+        ),
+        "items": items,
+    }
+
+
+if __name__ == "__main__":
+    doc = build()
+    with open("items.json", "w") as f:
+        json.dump(doc, f, indent=2)
+        f.write("\n")
+    print("wrote items.json:", len(doc["items"]), "items")
+    for it in doc["items"]:
+        print(it["id"], it["qtype"], "gold", it["gold_letter"],
+              "=", round(it["options"][it["gold_letter"]]["value"], 6))

--- a/code/specs/data/adj-ladder/rung49_fractionated_dose/items.json
+++ b/code/specs/data/adj-ladder/rung49_fractionated_dose/items.json
@@ -1,0 +1,698 @@
+{
+  "description": "ADJ-LADDER rung 49 \u2014 fractionated radiotherapy total dose from three stated quantities (a NEW panel: radiation-oncology / fractionated-dose). From a per-fraction dose plus the fraction counts of two treatment phases compute the total course dose (dose_per_fraction*(fractions_one+fractions_two)), the total fractions (fractions_one+fractions_two), or the first phase's dose (dose_per_fraction*fractions_one). Each item is a compute_dimensioned program (observe the three quantities, let answer = formula); the ADJ engine carries the arithmetic \u2014 a NEW shape, DISTRIBUTIVE PRODUCT-OVER-A-SUM a*(b+c), the first product on the ladder to multiply a single factor by a parenthesised sum (distinct from rung-34 sum-of-two-products a*b+c*d, rung-43 sum-of-three-products, and rung-48 sum-times-difference (a+b)*(c-d)) \u2014 and the harness matches the scalar to the printed options. Contamination-safe: every index is built only from the three observed quantities via *, + and - \u2014 no constant leaks, and neither the total fractions, the phase-one dose, nor any total-dose figure ever appears as a literal (each is computed) \u2014 and the observed quantities carry digit-free identifiers so no numeral hides inside a variable name. The five options are a family over the same three quantities, so the distractors are exactly the slips students make: SUBTRACTING the two phases instead of adding them, and breaking the distributive law by adding the raw second-phase count instead of the dose it delivers (a*b+c, not a*(b+c)). The core confusion tested is distributing the per-fraction dose over the summed fraction count.",
+  "items": [
+    {
+      "id": "r49frx-01",
+      "qtype": "fractionated_dose",
+      "stem": "A radiotherapy course delivers 3 Gy per fraction, given for 15 fractions in the first phase and 10 in the second. What is the total course dose (the per-fraction dose times the total number of fractions)?",
+      "program": "observe dose_per_fraction(3)\nobserve fractions_one(15)\nobserve fractions_two(10)\nlet answer = dose_per_fraction * (fractions_one + fractions_two)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 75,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 25,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 45,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 15,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 55,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r49frx-02",
+      "qtype": "fractionated_dose",
+      "stem": "A radiotherapy course delivers 3 Gy per fraction, given for 15 fractions in the first phase and 10 in the second. What is the the total number of fractions (the two phases added)?",
+      "program": "observe dose_per_fraction(3)\nobserve fractions_one(15)\nobserve fractions_two(10)\nlet answer = fractions_one + fractions_two\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 75,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 25,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 45,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 15,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 55,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r49frx-03",
+      "qtype": "fractionated_dose",
+      "stem": "A radiotherapy course delivers 3 Gy per fraction, given for 15 fractions in the first phase and 10 in the second. What is the the first phase's dose (the per-fraction dose times the first phase's fractions)?",
+      "program": "observe dose_per_fraction(3)\nobserve fractions_one(15)\nobserve fractions_two(10)\nlet answer = dose_per_fraction * fractions_one\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 75,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 25,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 45,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 15,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 55,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r49frx-04",
+      "qtype": "fractionated_dose",
+      "stem": "A radiotherapy course delivers 2 Gy per fraction, given for 20 fractions in the first phase and 12 in the second. What is the total course dose (the per-fraction dose times the total number of fractions)?",
+      "program": "observe dose_per_fraction(2)\nobserve fractions_one(20)\nobserve fractions_two(12)\nlet answer = dose_per_fraction * (fractions_one + fractions_two)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 32,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 40,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 16,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 64,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 52,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r49frx-05",
+      "qtype": "fractionated_dose",
+      "stem": "A radiotherapy course delivers 2 Gy per fraction, given for 20 fractions in the first phase and 12 in the second. What is the the total number of fractions (the two phases added)?",
+      "program": "observe dose_per_fraction(2)\nobserve fractions_one(20)\nobserve fractions_two(12)\nlet answer = fractions_one + fractions_two\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 64,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 40,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 16,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 52,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 32,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r49frx-06",
+      "qtype": "fractionated_dose",
+      "stem": "A radiotherapy course delivers 2 Gy per fraction, given for 20 fractions in the first phase and 12 in the second. What is the the first phase's dose (the per-fraction dose times the first phase's fractions)?",
+      "program": "observe dose_per_fraction(2)\nobserve fractions_one(20)\nobserve fractions_two(12)\nlet answer = dose_per_fraction * fractions_one\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 40,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 64,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 32,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 16,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 52,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r49frx-07",
+      "qtype": "fractionated_dose",
+      "stem": "A radiotherapy course delivers 4 Gy per fraction, given for 12 fractions in the first phase and 5 in the second. What is the total course dose (the per-fraction dose times the total number of fractions)?",
+      "program": "observe dose_per_fraction(4)\nobserve fractions_one(12)\nobserve fractions_two(5)\nlet answer = dose_per_fraction * (fractions_one + fractions_two)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 17,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 68,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 48,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 28,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 53,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r49frx-08",
+      "qtype": "fractionated_dose",
+      "stem": "A radiotherapy course delivers 4 Gy per fraction, given for 12 fractions in the first phase and 5 in the second. What is the the total number of fractions (the two phases added)?",
+      "program": "observe dose_per_fraction(4)\nobserve fractions_one(12)\nobserve fractions_two(5)\nlet answer = fractions_one + fractions_two\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 68,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 48,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 17,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 28,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 53,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r49frx-09",
+      "qtype": "fractionated_dose",
+      "stem": "A radiotherapy course delivers 4 Gy per fraction, given for 12 fractions in the first phase and 5 in the second. What is the the first phase's dose (the per-fraction dose times the first phase's fractions)?",
+      "program": "observe dose_per_fraction(4)\nobserve fractions_one(12)\nobserve fractions_two(5)\nlet answer = dose_per_fraction * fractions_one\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 68,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 17,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 28,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 48,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 53,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r49frx-10",
+      "qtype": "fractionated_dose",
+      "stem": "A radiotherapy course delivers 5 Gy per fraction, given for 8 fractions in the first phase and 6 in the second. What is the total course dose (the per-fraction dose times the total number of fractions)?",
+      "program": "observe dose_per_fraction(5)\nobserve fractions_one(8)\nobserve fractions_two(6)\nlet answer = dose_per_fraction * (fractions_one + fractions_two)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 14,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 40,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 10,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 46,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 70,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r49frx-11",
+      "qtype": "fractionated_dose",
+      "stem": "A radiotherapy course delivers 5 Gy per fraction, given for 8 fractions in the first phase and 6 in the second. What is the the total number of fractions (the two phases added)?",
+      "program": "observe dose_per_fraction(5)\nobserve fractions_one(8)\nobserve fractions_two(6)\nlet answer = fractions_one + fractions_two\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 14,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 70,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 40,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 10,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 46,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r49frx-12",
+      "qtype": "fractionated_dose",
+      "stem": "A radiotherapy course delivers 5 Gy per fraction, given for 8 fractions in the first phase and 6 in the second. What is the the first phase's dose (the per-fraction dose times the first phase's fractions)?",
+      "program": "observe dose_per_fraction(5)\nobserve fractions_one(8)\nobserve fractions_two(6)\nlet answer = dose_per_fraction * fractions_one\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 70,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 40,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 14,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 10,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 46,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r49frx-13",
+      "qtype": "fractionated_dose",
+      "stem": "A radiotherapy course delivers 3 Gy per fraction, given for 18 fractions in the first phase and 8 in the second. What is the total course dose (the per-fraction dose times the total number of fractions)?",
+      "program": "observe dose_per_fraction(3)\nobserve fractions_one(18)\nobserve fractions_two(8)\nlet answer = dose_per_fraction * (fractions_one + fractions_two)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 26,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 54,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 78,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 30,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 62,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r49frx-14",
+      "qtype": "fractionated_dose",
+      "stem": "A radiotherapy course delivers 3 Gy per fraction, given for 18 fractions in the first phase and 8 in the second. What is the the total number of fractions (the two phases added)?",
+      "program": "observe dose_per_fraction(3)\nobserve fractions_one(18)\nobserve fractions_two(8)\nlet answer = fractions_one + fractions_two\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 78,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 54,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 30,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 26,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 62,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r49frx-15",
+      "qtype": "fractionated_dose",
+      "stem": "A radiotherapy course delivers 3 Gy per fraction, given for 18 fractions in the first phase and 8 in the second. What is the the first phase's dose (the per-fraction dose times the first phase's fractions)?",
+      "program": "observe dose_per_fraction(3)\nobserve fractions_one(18)\nobserve fractions_two(8)\nlet answer = dose_per_fraction * fractions_one\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 78,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 26,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 30,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 62,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 54,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r49frx-16",
+      "qtype": "fractionated_dose",
+      "stem": "A radiotherapy course delivers 2 Gy per fraction, given for 25 fractions in the first phase and 15 in the second. What is the total course dose (the per-fraction dose times the total number of fractions)?",
+      "program": "observe dose_per_fraction(2)\nobserve fractions_one(25)\nobserve fractions_two(15)\nlet answer = dose_per_fraction * (fractions_one + fractions_two)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 80,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 40,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 50,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 20,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 65,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r49frx-17",
+      "qtype": "fractionated_dose",
+      "stem": "A radiotherapy course delivers 2 Gy per fraction, given for 25 fractions in the first phase and 15 in the second. What is the the total number of fractions (the two phases added)?",
+      "program": "observe dose_per_fraction(2)\nobserve fractions_one(25)\nobserve fractions_two(15)\nlet answer = fractions_one + fractions_two\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 80,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 40,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 50,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 20,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 65,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r49frx-18",
+      "qtype": "fractionated_dose",
+      "stem": "A radiotherapy course delivers 2 Gy per fraction, given for 25 fractions in the first phase and 15 in the second. What is the the first phase's dose (the per-fraction dose times the first phase's fractions)?",
+      "program": "observe dose_per_fraction(2)\nobserve fractions_one(25)\nobserve fractions_two(15)\nlet answer = dose_per_fraction * fractions_one\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 80,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 40,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 50,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 20,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 65,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r49frx-19",
+      "qtype": "fractionated_dose",
+      "stem": "A radiotherapy course delivers 6 Gy per fraction, given for 9 fractions in the first phase and 4 in the second. What is the total course dose (the per-fraction dose times the total number of fractions)?",
+      "program": "observe dose_per_fraction(6)\nobserve fractions_one(9)\nobserve fractions_two(4)\nlet answer = dose_per_fraction * (fractions_one + fractions_two)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 13,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 54,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 30,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 78,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 58,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r49frx-20",
+      "qtype": "fractionated_dose",
+      "stem": "A radiotherapy course delivers 6 Gy per fraction, given for 9 fractions in the first phase and 4 in the second. What is the the total number of fractions (the two phases added)?",
+      "program": "observe dose_per_fraction(6)\nobserve fractions_one(9)\nobserve fractions_two(4)\nlet answer = fractions_one + fractions_two\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 78,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 54,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 30,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 58,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 13,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r49frx-21",
+      "qtype": "fractionated_dose",
+      "stem": "A radiotherapy course delivers 6 Gy per fraction, given for 9 fractions in the first phase and 4 in the second. What is the the first phase's dose (the per-fraction dose times the first phase's fractions)?",
+      "program": "observe dose_per_fraction(6)\nobserve fractions_one(9)\nobserve fractions_two(4)\nlet answer = dose_per_fraction * fractions_one\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 54,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 78,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 13,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 30,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 58,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    }
+  ]
+}

--- a/code/specs/data/adj-ladder/test_ladder_eval.py
+++ b/code/specs/data/adj-ladder/test_ladder_eval.py
@@ -86,6 +86,7 @@ SELF_CONTAINED_RUNGS = (
     "rung46_cost_per_patient_day",
     "rung47_ingestion_concentration",
     "rung48_infusion_delivered_volume",
+    "rung49_fractionated_dose",
 )
 
 


### PR DESCRIPTION
## ADJ-LADDER rung-49 — fractionated radiotherapy total dose (distributive `a·(b+c)`)

Rung 49 opens the **radiation-oncology / fractionated-dose** panel — a genuinely NEW clinical
domain (distinct from toxicology / PK / pharmacoeconomics / dilution / renal / hepatic / lipid /
iron / thyroid / coag / protein / BMI / mineral / infusion) — and introduces a genuinely NEW
arithmetic **shape**: the **distributive product-over-a-sum `a · (b + c)`** — one factor
multiplying a parenthesised sum of two.

A course delivers `dose_per_fraction` Gy per fraction, given for `fractions_one` fractions in a
first phase and `fractions_two` in a second. The total dose is the per-fraction dose times the
total fractions:

| readout | formula |
|---|---|
| **total dose** | `dose_per_fraction · (fractions_one + fractions_two)` |
| total fractions | `fractions_one + fractions_two` (the summed count) |
| phase-one dose | `dose_per_fraction · fractions_one` (one distributed term) |

Distinct from the nearest neighbours: rung-34 was a *sum of two products* `a·b + c·d`, rung-43 a
*sum of three products*, rung-48 a *sum times a difference* `(a+b)·(c−d)` — none multiplied a lone
factor by a parenthesised **sum**. This makes the distributive law `a·(b+c) = a·b + a·c`
computable.

### Shape/domain provenance
Shapes DONE: 31–48 (through rung-48 sum-times-difference). **AVOIDED** product-over-product
`(a·b)/(c·d)` (rung-15) and all of 31–48.

### Contamination-safe by construction
Every formula is built ONLY from the three observed quantities via `·`, `+`, `−` — no structural
constants, no numeric literal in any program, each figure computed. Identifiers are **digit-free**
(`dose_per_fraction`, `fractions_one`, `fractions_two`; "one"/"two" are word-spelled). The two
distractors are exactly the student slips: **subtracting** the two phases instead of adding
(`a·(b−c)`), and **breaking distribution** by adding the raw second-phase count instead of the
dose it delivers (`a·b + c`, not `a·(b+c)`). Gold rotates A–E; QUERIED = the three real readouts.
Pairwise-distinctness (all 5 family values, margin > 1e-6) asserted at build with
`fractions_one > fractions_two`.

### Files (3)
- `rung49_fractionated_dose/gen_items.py` — generator (literate)
- `rung49_fractionated_dose/items.json` — 21 items (7 tables × 3 queried)
- `test_ladder_eval.py` — registered in `SELF_CONTAINED_RUNGS`

`pytest -k rung49` → 3/3 pass. Each index is a `compute_dimensioned` program; the ADJ engine
carries the arithmetic — no harness/engine change. Security review passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
