### PR TITLE
feat(js-ast): CLOC12.158 — UpdateExpression (++/--) atomic node + emit + passes (PR1)

### DIFF
--- a/code/packages/rust/closure-emitter/CHANGELOG.md
+++ b/code/packages/rust/closure-emitter/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to the `coding-adventures-closure-emitter` crate will be documented in this file.
 
+## [0.22.0] - 2026-07-02
+
+### Added — CLOC12.158: emit `UpdateExpression` (`++` / `--`)
+
+`emit_update` prints the new `Expression::UpdateExpression` node —
+`++x` / `--x` (prefix: operator then operand) and `x++` / `x--` (postfix:
+operand then operator). Classified at `PREC_UNARY`, which is loose enough to
+wrap an exponentiation base (`(++x)**2` — a bare `++x**2` is a syntax error)
+and a member/call object (`(x++).y`), yet tight enough to print bare under a
+`!`/`typeof` parent (`!x++`, `typeof x++`). **Token-fusion seams** are handled
+without a new guard: `arg_starts_with_sign` now reports a *prefix* update's
+leading `+`/`-`, so the binary/unary emitters space the seam (`a- --b`, never
+`a---b` = `(a--)-b`; `a+ ++b`, never `a+++b` = `(a++)+b`), and a *postfix*
+update ending in `+`/`-` is spaced by the binary emitter's existing
+output-tail check (`x++ +y`). 8 new unit tests. No behaviour change for
+existing inputs (the bridge does not yet produce update nodes — PR2).
+
 ## [0.21.3] - 2026-07-02
 
 ### Fixed — CLOC12.157 (gap-158): newline-aware template quasi emit

--- a/code/packages/rust/closure-emitter/Cargo.toml
+++ b/code/packages/rust/closure-emitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-emitter"
-version = "0.21.3"
+version = "0.22.0"
 edition = "2021"
 description = "JavaScript code emitter for the Closure Compiler clone. Per CLOC07's emit contract. Takes a finalized Program + sidecar and produces output JavaScript text + companion source map. Runs after every pass in the pipeline."
 

--- a/code/packages/rust/closure-emitter/src/lib.rs
+++ b/code/packages/rust/closure-emitter/src/lib.rs
@@ -76,7 +76,7 @@ use coding_adventures_javascript_ast::{
     FunctionParam, Identifier, IfStatement, LabeledStatement, LogicalExpression, LogicalOperator,
     MemberExpression, NullLiteral, NumericLiteral, ObjectExpression, Program, ProgramItem,
     Property, PropertyKey, PropertyKind, ReturnStatement, Statement, StringLiteral,
-    SwitchCase, SwitchStatement, ThrowStatement, TryStatement, UnaryExpression, UnaryOperator,
+    SwitchCase, SwitchStatement, ThrowStatement, TryStatement, UnaryExpression, UnaryOperator, UpdateExpression, UpdateOperator,
     UndefinedLiteral, VarKind, VariableDeclaration, VariableDeclarator, WhileStatement,
 };
 use coding_adventures_type_sidecar::Sidecar;
@@ -1106,6 +1106,7 @@ impl<'a> Emitter<'a> {
             Expression::BinaryExpression(b) => self.emit_binary(b),
             Expression::LogicalExpression(l) => self.emit_logical(l),
             Expression::UnaryExpression(u) => self.emit_unary(u),
+            Expression::UpdateExpression(u) => self.emit_update(u),
             Expression::AssignmentExpression(a) => self.emit_assignment(a),
             Expression::ConditionalExpression(c) => self.emit_conditional(c),
             Expression::CallExpression(c) => self.emit_call(c),
@@ -1336,6 +1337,41 @@ impl<'a> Emitter<'a> {
         // `!(a == b)` printed as `!a == b`, which JS reparses as
         // `(!a) == b` — a different program.
         self.emit_expression_inner(&u.argument, PREC_UNARY);
+    }
+
+    /// Emit an update expression — `++x` / `x++` / `--x` / `x--`.
+    ///
+    /// ```text
+    ///   prefix:   <op><arg>     ++x   --x
+    ///   postfix:  <arg><op>     x++   x--
+    /// ```
+    ///
+    /// The operand is emitted at `PREC_UNARY` so anything looser is
+    /// parenthesised (a valid update target — an identifier or member — is
+    /// already tight, so this only matters defensively).
+    ///
+    /// **Seam hazards** are handled without a guard *here*:
+    ///   * A *prefix* update after a sign operator (`a - --b`, `-(--x)`) would
+    ///     fuse into `a---b` / `---x` and mis-tokenise; the binary/unary
+    ///     emitters guard that seam by consulting [`arg_starts_with_sign`],
+    ///     which reports a prefix update's leading `+`/`-`.
+    ///   * A *postfix* update ends in `+`/`-`, so a following binary `+`/`-`
+    ///     (`x++ + y`) would fuse; the binary emitter's left-seam check already
+    ///     inspects the emitted output tail and inserts the space.
+    /// The prefix operator's own seam with its operand never fuses: `++`/`--`
+    /// are already maximal-munch tokens, so `++ +x` and `+++x` tokenise
+    /// identically (and an update of a non-reference operand is invalid input
+    /// anyway).
+    fn emit_update(&mut self, u: &UpdateExpression) {
+        self.maybe_map(&u.cv);
+        let op = update_op_str(u.operator);
+        if u.prefix {
+            self.write_str(op);
+            self.emit_expression_inner(&u.argument, PREC_UNARY);
+        } else {
+            self.emit_expression_inner(&u.argument, PREC_UNARY);
+            self.write_str(op);
+        }
     }
 
     fn emit_assignment(&mut self, a: &AssignmentExpression) {
@@ -1743,6 +1779,13 @@ fn expr_prec(e: &Expression) -> u8 {
         | Expression::MemberExpression(_) => PREC_PRIMARY,
 
         Expression::UnaryExpression(_) => PREC_UNARY,
+        // Update (`++x` / `x++`) binds a hair tighter than the pure unary
+        // operators in the grammar, but tagging it at `PREC_UNARY` is the
+        // safe conservative choice: it is loose enough that an
+        // exponentiation base wraps it (`(x++)**2` — a bare `x++**2` is a
+        // syntax error) and tight enough that a `!`/`typeof` parent does not
+        // over-wrap it (`!x++`, `typeof x++` print bare, which is correct).
+        Expression::UpdateExpression(_) => PREC_UNARY,
         // A function expression is primary-*ish*, but two contexts
         // mis-parse a bare one: as a call callee (`function(){}()` is a
         // syntax error) and as a member object (`function(){}.x`). Tag
@@ -1801,6 +1844,24 @@ fn sign_op_char(op: UnaryOperator) -> Option<char> {
     }
 }
 
+/// The `++` / `--` operator as printed text.
+fn update_op_str(op: UpdateOperator) -> &'static str {
+    match op {
+        UpdateOperator::Increment => "++",
+        UpdateOperator::Decrement => "--",
+    }
+}
+
+/// The leading sign character of an update operator (`+` for `++`, `-` for
+/// `--`) — the character a *prefix* update prints first, and thus the one that
+/// can fuse with a preceding sign operator.
+fn update_op_lead_char(op: UpdateOperator) -> char {
+    match op {
+        UpdateOperator::Increment => '+',
+        UpdateOperator::Decrement => '-',
+    }
+}
+
 /// Would the unary argument `e`, emitted at `PREC_UNARY`, begin with the
 /// character `sign` (`-` or `+`)? Used by [`emit_unary`] to decide whether
 /// a separating space is required to avoid the `--` / `++` token fusion.
@@ -1819,6 +1880,18 @@ fn arg_starts_with_sign(e: &Expression, sign: char) -> bool {
     match e {
         Expression::UnaryExpression(u) => sign_op_char(u.operator) == Some(sign),
         Expression::NumericLiteral(n) => sign == '-' && n.value.is_sign_negative(),
+        // A *prefix* update prints its operator first, so `++x` begins with `+`
+        // and `--x` begins with `-` — either can fuse with a preceding sign
+        // operator (`a - --b` must print `a- --b`, never `a---b`, which JS
+        // reparses as `(a--)-b`). A *postfix* update begins with its operand,
+        // so recurse to see what that operand leads with.
+        Expression::UpdateExpression(u) => {
+            if u.prefix {
+                update_op_lead_char(u.operator) == sign
+            } else {
+                arg_starts_with_sign(&u.argument, sign)
+            }
+        }
         _ => false,
     }
 }
@@ -4154,5 +4227,108 @@ mod tests {
     #[test]
     fn template_bare_newline_quasi() {
         assert_eq!(emit_expr(template(vec![tquasi("\n", true)], vec![])), "`\n`;");
+    }
+
+    // ---- UpdateExpression (CLOC12.158) ------------------------
+
+    fn update(op: UpdateOperator, prefix: bool, arg: Expression) -> Expression {
+        Expression::UpdateExpression(UpdateExpression {
+            cv: None,
+            operator: op,
+            prefix,
+            argument: Box::new(arg),
+        })
+    }
+
+    fn binexpr(op: BinaryOperator, l: Expression, r: Expression) -> Expression {
+        Expression::BinaryExpression(BinaryExpression {
+            cv: None,
+            operator: op,
+            left: Box::new(l),
+            right: Box::new(r),
+        })
+    }
+
+    /// The four core shapes: prefix/postfix × increment/decrement.
+    #[test]
+    fn update_prefix_increment() {
+        assert_eq!(emit_expr(update(UpdateOperator::Increment, true, ident("x"))), "++x;");
+    }
+    #[test]
+    fn update_postfix_increment() {
+        assert_eq!(emit_expr(update(UpdateOperator::Increment, false, ident("x"))), "x++;");
+    }
+    #[test]
+    fn update_prefix_decrement() {
+        assert_eq!(emit_expr(update(UpdateOperator::Decrement, true, ident("x"))), "--x;");
+    }
+    #[test]
+    fn update_postfix_decrement() {
+        assert_eq!(emit_expr(update(UpdateOperator::Decrement, false, ident("x"))), "x--;");
+    }
+
+    /// `a - (--b)` must print `a- --b`, never `a---b` (which JS reparses as
+    /// `(a--)-b`). The binary `-` emitter inserts the seam space because
+    /// `arg_starts_with_sign` reports the prefix `--`'s leading `-`.
+    #[test]
+    fn prefix_decrement_after_minus_needs_space() {
+        let e = binexpr(
+            BinaryOperator::Sub,
+            ident("a"),
+            update(UpdateOperator::Decrement, true, ident("b")),
+        );
+        assert_eq!(emit_expr(e), "a- --b;");
+    }
+
+    /// `a + (++b)` must print `a+ ++b`, never `a+++b` (which JS reparses as
+    /// `(a++)+b`).
+    #[test]
+    fn prefix_increment_after_plus_needs_space() {
+        let e = binexpr(
+            BinaryOperator::Add,
+            ident("a"),
+            update(UpdateOperator::Increment, true, ident("b")),
+        );
+        assert_eq!(emit_expr(e), "a+ ++b;");
+    }
+
+    /// `(x++) + y`: the postfix `++` leaves the output ending in `+`, so the
+    /// following binary `+` needs a left-seam space (`x++ +y`) or the `++`
+    /// would swallow it into `x+++y` = `(x++)+y` — same value here, but the
+    /// emitter guards the seam unconditionally via the output-tail check.
+    #[test]
+    fn postfix_increment_before_plus_needs_space() {
+        let e = binexpr(
+            BinaryOperator::Add,
+            update(UpdateOperator::Increment, false, ident("x")),
+            ident("y"),
+        );
+        assert_eq!(emit_expr(e), "x++ +y;");
+    }
+
+    /// A postfix update as a member-access object is parenthesised: `x++` is
+    /// not a valid `MemberExpression` object, so `(x++).y` — the `PREC_UNARY`
+    /// tag forces the wrap under the primary-precedence member parent.
+    #[test]
+    fn postfix_update_as_member_object_is_wrapped() {
+        let m = Expression::MemberExpression(MemberExpression {
+            cv: None,
+            object: Box::new(update(UpdateOperator::Increment, false, ident("x"))),
+            property: Box::new(ident("y")),
+            computed: false,
+        });
+        assert_eq!(emit_expr(m), "(x++).y;");
+    }
+
+    /// A prefix update as an exponentiation base is parenthesised — a bare
+    /// `++x**2` is a syntax error, so `(++x)**2`.
+    #[test]
+    fn prefix_update_as_exponent_base_is_wrapped() {
+        let e = binexpr(
+            BinaryOperator::Exp,
+            update(UpdateOperator::Increment, true, ident("x")),
+            num(2.0),
+        );
+        assert_eq!(emit_expr(e), "(++x)**2;");
     }
 }

--- a/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `coding-adventures-closure-pass-constant-fold` crate will be documented in this file.
 
+## [0.85.1] - 2026-07-02
+
+### Changed — CLOC12.158: exhaustiveness for new `Expression::UpdateExpression`
+
+Handle the new `Expression::UpdateExpression` (`++x` / `x++` / `--x` / `x--`)
+variant added to `javascript-ast` (0.17.0): the pass recurses into the operand and preserves the read-modify-write verbatim (an update is never a constant and carries a side effect, so it is never folded away). No behaviour
+change for existing inputs — the bridge does not yet produce update
+expressions (that lands in the CLOC12.158 PR2 bridge-enable), so these arms
+are exercised only via hand-constructed AST today.
+
 ## [0.85.0] - 2026-07-02
 
 ### Added — CLOC12.154: `TemplateLiteral` traversal

--- a/code/packages/rust/closure-pass-constant-fold/Cargo.toml
+++ b/code/packages/rust/closure-pass-constant-fold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-constant-fold"
-version = "0.85.0"
+version = "0.85.1"
 edition = "2021"
 description = "Constant-folding optimization pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Folds compile-time-evaluable expressions like `2 + 3 → 5`."
 

--- a/code/packages/rust/closure-pass-constant-fold/src/lib.rs
+++ b/code/packages/rust/closure-pass-constant-fold/src/lib.rs
@@ -98,7 +98,7 @@ use coding_adventures_javascript_ast::{
     FunctionDeclaration, FunctionExpression, Identifier,
     IfStatement, LogicalExpression, LogicalOperator, MemberExpression, NullLiteral, NumericLiteral,
     ObjectExpression, Program, ProgramItem, Property, PropertyKey, PropertyKind, ReturnStatement, Statement,
-    StringLiteral, UnaryExpression, UnaryOperator, UndefinedLiteral, VariableDeclaration,
+    StringLiteral, UnaryExpression, UnaryOperator, UndefinedLiteral, UpdateExpression, VariableDeclaration,
     DoWhileStatement, VariableDeclarator, WhileStatement,
 };
 use serde_json::json;
@@ -505,6 +505,16 @@ fn fold_expression(expr: &Expression, st: &mut FoldState) -> Expression {
         Expression::BinaryExpression(b) => fold_binary(b, st),
         Expression::LogicalExpression(l) => fold_logical(l, st),
         Expression::UnaryExpression(u) => fold_unary(u, st),
+        // `++x` / `x++`: a read-modify-write with a side effect — never a
+        // constant, so we do NOT collapse it (dropping it would drop the
+        // mutation). Recurse into the argument only for the member-object case
+        // (`a[i].b++` etc.); the update node itself is preserved verbatim.
+        Expression::UpdateExpression(u) => Expression::UpdateExpression(UpdateExpression {
+            cv: u.cv.clone(),
+            operator: u.operator,
+            prefix: u.prefix,
+            argument: Box::new(fold_expression(&u.argument, st)),
+        }),
         Expression::ConditionalExpression(c) => fold_conditional(c, st),
 
         // Recurse but don't collapse — these have runtime semantics.

--- a/code/packages/rust/closure-pass-dce/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-dce/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `coding-adventures-closure-pass-dce` crate will be documented in this file.
 
+## [0.20.1] - 2026-07-02
+
+### Changed — CLOC12.158: exhaustiveness for new `Expression::UpdateExpression`
+
+Handle the new `Expression::UpdateExpression` (`++x` / `x++` / `--x` / `x--`)
+variant added to `javascript-ast` (0.17.0): the pass treats `x++`/`--x` as a side effect: it is NOT dead code even in value-discarded position, and is preserved (recursing only into the operand). No behaviour
+change for existing inputs — the bridge does not yet produce update
+expressions (that lands in the CLOC12.158 PR2 bridge-enable), so these arms
+are exercised only via hand-constructed AST today.
+
 ## [0.20.0] - 2026-07-02
 
 ### Added — CLOC12.154: `TemplateLiteral` traversal

--- a/code/packages/rust/closure-pass-dce/Cargo.toml
+++ b/code/packages/rust/closure-pass-dce/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-dce"
-version = "0.20.0"
+version = "0.20.1"
 edition = "2021"
 description = "Dead-code elimination pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Drops code after definite-terminator statements and removes EmptyStatement noise."
 

--- a/code/packages/rust/closure-pass-dce/src/lib.rs
+++ b/code/packages/rust/closure-pass-dce/src/lib.rs
@@ -78,7 +78,7 @@ use coding_adventures_javascript_ast::{
     ArrowBody, ArrowFunctionExpression, TemplateLiteral,
     FunctionDeclaration, FunctionExpression, IfStatement, LogicalExpression, MemberExpression, NullLiteral,
     NumericLiteral, ObjectExpression, Program, ProgramItem, Property, PropertyKey,
-    ReturnStatement, Statement, StringLiteral, UnaryExpression, UndefinedLiteral, VarKind,
+    ReturnStatement, Statement, StringLiteral, UnaryExpression, UndefinedLiteral, UpdateExpression, VarKind,
     DoWhileStatement, VariableDeclaration, VariableDeclarator, WhileStatement,
 };
 use serde_json::json;
@@ -1178,6 +1178,15 @@ fn dce_expression(expr: &Expression, st: &mut DceState) -> Expression {
             right: Box::new(dce_expression(&l.right, st)),
         }),
         Expression::UnaryExpression(u) => Expression::UnaryExpression(UnaryExpression {
+            cv: u.cv.clone(),
+            operator: u.operator,
+            prefix: u.prefix,
+            argument: Box::new(dce_expression(&u.argument, st)),
+        }),
+        // `++x` / `x++` has a side effect (mutates its operand), so it is NOT
+        // dead code even in value-discarded position — preserve it, recursing
+        // only into the argument.
+        Expression::UpdateExpression(u) => Expression::UpdateExpression(UpdateExpression {
             cv: u.cv.clone(),
             operator: u.operator,
             prefix: u.prefix,

--- a/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `coding-adventures-closure-pass-fold-control-flow` crate will be documented in this file.
 
+## [0.20.1] - 2026-07-02
+
+### Changed — CLOC12.158: exhaustiveness for new `Expression::UpdateExpression`
+
+Handle the new `Expression::UpdateExpression` (`++x` / `x++` / `--x` / `x--`)
+variant added to `javascript-ast` (0.17.0): the pass recurses into the operand and preserves the update node; `cv()` accessor extended. No behaviour
+change for existing inputs — the bridge does not yet produce update
+expressions (that lands in the CLOC12.158 PR2 bridge-enable), so these arms
+are exercised only via hand-constructed AST today.
+
 ## [0.20.0] - 2026-07-02
 
 ### Added — CLOC12.154: `TemplateLiteral` traversal

--- a/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
+++ b/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-fold-control-flow"
-version = "0.20.0"
+version = "0.20.1"
 edition = "2021"
 description = "Control-flow folding pass for the Closure Compiler clone. Slots between constant-fold and DCE per CLOC06's canonical pass set. Eliminates dead branches (`if (false) A else B → B`), removes unreachable code after `return`/`throw`, and collapses degenerate switch arms."
 

--- a/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
+++ b/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
@@ -63,7 +63,7 @@ use coding_adventures_javascript_ast::{
     LogicalExpression,
     LogicalOperator,
     MemberExpression, ObjectExpression, Program, ProgramItem, Property, PropertyKey,
-    ReturnStatement, Statement, UnaryExpression, UnaryOperator, VarKind, VariableDeclaration,
+    ReturnStatement, Statement, UnaryExpression, UnaryOperator, UpdateExpression, VarKind, VariableDeclaration,
     DoWhileStatement, VariableDeclarator, WhileStatement,
 };
 use serde_json::json;
@@ -269,6 +269,7 @@ fn expression_cv(expr: &Expression) -> Option<String> {
         BinaryExpression(e) => e.cv.clone(),
         LogicalExpression(e) => e.cv.clone(),
         UnaryExpression(e) => e.cv.clone(),
+        UpdateExpression(e) => e.cv.clone(),
         AssignmentExpression(e) => e.cv.clone(),
         ConditionalExpression(e) => e.cv.clone(),
         CallExpression(e) => e.cv.clone(),
@@ -1366,6 +1367,14 @@ fn fold_expression(expr: &Expression, st: &mut FoldState) -> Expression {
             right: Box::new(fold_expression(&l.right, st)),
         }),
         Expression::UnaryExpression(u) => Expression::UnaryExpression(UnaryExpression {
+            cv: u.cv.clone(),
+            operator: u.operator,
+            prefix: u.prefix,
+            argument: Box::new(fold_expression(&u.argument, st)),
+        }),
+        // `++x` / `x++`: recurse into the argument; the read-modify-write is
+        // preserved verbatim (it has a side effect and is not a constant).
+        Expression::UpdateExpression(u) => Expression::UpdateExpression(UpdateExpression {
             cv: u.cv.clone(),
             operator: u.operator,
             prefix: u.prefix,

--- a/code/packages/rust/closure-pass-inline-variables/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-inline-variables/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `coding-adventures-closure-pass-inline-variables` crate will be documented in this file.
 
+## [0.11.1] - 2026-07-02
+
+### Changed — CLOC12.158: exhaustiveness for new `Expression::UpdateExpression`
+
+Handle the new `Expression::UpdateExpression` (`++x` / `x++` / `--x` / `x--`)
+variant added to `javascript-ast` (0.17.0): the pass recurses into the operand for use-counting and propagation. No behaviour
+change for existing inputs — the bridge does not yet produce update
+expressions (that lands in the CLOC12.158 PR2 bridge-enable), so these arms
+are exercised only via hand-constructed AST today.
+
 ## [0.11.0] - 2026-07-02
 
 ### Added — CLOC12.154: `TemplateLiteral` traversal

--- a/code/packages/rust/closure-pass-inline-variables/Cargo.toml
+++ b/code/packages/rust/closure-pass-inline-variables/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-inline-variables"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 description = "Constant-propagation pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Replaces references to a top-level `const` bound to a literal with the literal itself, so the binding becomes unused and remove-unused-vars deletes it."
 

--- a/code/packages/rust/closure-pass-inline-variables/src/lib.rs
+++ b/code/packages/rust/closure-pass-inline-variables/src/lib.rs
@@ -739,6 +739,7 @@ fn count_uses_expr(expr: &Expression, name: &str, count: &mut usize) {
             count_uses_expr(&le.right, name, count);
         }
         Expression::UnaryExpression(ue) => count_uses_expr(&ue.argument, name, count),
+        Expression::UpdateExpression(ue) => count_uses_expr(&ue.argument, name, count),
         Expression::AssignmentExpression(ae) => {
             // The assignment TARGET is a write, not a use we propagate
             // into (you can't assign to a literal). Only the member-
@@ -1016,6 +1017,7 @@ fn propagate_in_expr(expr: &mut Expression, cand: &ConstCandidate) -> bool {
             changed |= propagate_in_expr(&mut le.right, cand);
         }
         Expression::UnaryExpression(ue) => changed |= propagate_in_expr(&mut ue.argument, cand),
+        Expression::UpdateExpression(ue) => changed |= propagate_in_expr(&mut ue.argument, cand),
         Expression::AssignmentExpression(ae) => {
             // The target identifier is a write — never replaced (a
             // `const` can't be assigned, and you can't assign to a

--- a/code/packages/rust/closure-pass-inline/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-inline/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `coding-adventures-closure-pass-inline` crate will be documented in this file.
 
+## [0.25.1] - 2026-07-02
+
+### Changed — CLOC12.158: exhaustiveness for new `Expression::UpdateExpression`
+
+Handle the new `Expression::UpdateExpression` (`++x` / `x++` / `--x` / `x--`)
+variant added to `javascript-ast` (0.17.0): the pass recurses into the operand for node-count / binding-collection / tally / inline / substitute / mutated-param / rename walks. No behaviour
+change for existing inputs — the bridge does not yet produce update
+expressions (that lands in the CLOC12.158 PR2 bridge-enable), so these arms
+are exercised only via hand-constructed AST today.
+
 ## [0.25.0] - 2026-07-02
 
 ### Added — CLOC12.154: `TemplateLiteral` traversal

--- a/code/packages/rust/closure-pass-inline/Cargo.toml
+++ b/code/packages/rust/closure-pass-inline/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-inline"
-version = "0.25.0"
+version = "0.25.1"
 edition = "2021"
 description = "Function-inlining pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Substitutes small or single-use function bodies at their call sites to enable downstream folding and shrink call overhead."
 

--- a/code/packages/rust/closure-pass-inline/src/lib.rs
+++ b/code/packages/rust/closure-pass-inline/src/lib.rs
@@ -441,6 +441,7 @@ fn expr_node_count(expr: &Expression) -> usize {
         Expression::BinaryExpression(be) => expr_node_count(&be.left) + expr_node_count(&be.right),
         Expression::LogicalExpression(le) => expr_node_count(&le.left) + expr_node_count(&le.right),
         Expression::UnaryExpression(ue) => expr_node_count(&ue.argument),
+        Expression::UpdateExpression(ue) => expr_node_count(&ue.argument),
         Expression::AssignmentExpression(ae) => {
             let left = match &ae.left {
                 AssignmentTarget::Identifier(_) => 1,
@@ -742,6 +743,7 @@ fn collect_binding_idents_expr(expr: &Expression, out: &mut HashSet<String>) {
             collect_binding_idents_expr(&le.right, out);
         }
         Expression::UnaryExpression(ue) => collect_binding_idents_expr(&ue.argument, out),
+        Expression::UpdateExpression(ue) => collect_binding_idents_expr(&ue.argument, out),
         Expression::AssignmentExpression(ae) => {
             match &ae.left {
                 AssignmentTarget::Identifier(id) => {
@@ -1003,6 +1005,7 @@ fn tally_expr(expr: &Expression, cand: &InlineCandidate, t: &mut Tally) {
             tally_expr(&le.right, cand, t);
         }
         Expression::UnaryExpression(ue) => tally_expr(&ue.argument, cand, t),
+        Expression::UpdateExpression(ue) => tally_expr(&ue.argument, cand, t),
         Expression::AssignmentExpression(ae) => {
             match &ae.left {
                 AssignmentTarget::Identifier(id) => {
@@ -1311,6 +1314,7 @@ fn inline_in_expr(expr: &mut Expression, cand: &InlineCandidate) -> bool {
             changed |= inline_in_expr(&mut le.right, cand);
         }
         Expression::UnaryExpression(ue) => changed |= inline_in_expr(&mut ue.argument, cand),
+        Expression::UpdateExpression(ue) => changed |= inline_in_expr(&mut ue.argument, cand),
         Expression::AssignmentExpression(ae) => {
             if let AssignmentTarget::MemberExpression(m) = &mut ae.left {
                 changed |= inline_in_member(m, cand);
@@ -1412,6 +1416,7 @@ fn substitute(expr: &mut Expression, map: &HashMap<String, Expression>) {
             substitute(&mut le.right, map);
         }
         Expression::UnaryExpression(ue) => substitute(&mut ue.argument, map),
+        Expression::UpdateExpression(ue) => substitute(&mut ue.argument, map),
         Expression::AssignmentExpression(ae) => {
             // The left side is an assignment *target*. In the safe slice
             // EXPR's only free identifiers are parameters; a parameter
@@ -1797,6 +1802,7 @@ fn expr_collect_mutated_params(
             expr_collect_mutated_params(&le.right, params, out);
         }
         Expression::UnaryExpression(ue) => expr_collect_mutated_params(&ue.argument, params, out),
+        Expression::UpdateExpression(ue) => expr_collect_mutated_params(&ue.argument, params, out),
         Expression::ConditionalExpression(ce) => {
             expr_collect_mutated_params(&ce.test, params, out);
             expr_collect_mutated_params(&ce.consequent, params, out);
@@ -3223,6 +3229,7 @@ fn rename_in_expr(expr: &mut Expression, map: &HashMap<String, String>) {
             rename_in_expr(&mut le.right, map);
         }
         Expression::UnaryExpression(ue) => rename_in_expr(&mut ue.argument, map),
+        Expression::UpdateExpression(ue) => rename_in_expr(&mut ue.argument, map),
         Expression::AssignmentExpression(ae) => {
             match &mut ae.left {
                 AssignmentTarget::Identifier(id) => {

--- a/code/packages/rust/closure-pass-rename-globals/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename-globals/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename-globals` crate will be documented in this file.
 
+## [0.10.1] - 2026-07-02
+
+### Changed — CLOC12.158: exhaustiveness for new `Expression::UpdateExpression`
+
+Handle the new `Expression::UpdateExpression` (`++x` / `x++` / `--x` / `x--`)
+variant added to `javascript-ast` (0.17.0): the pass recurses into the operand for ident collection and rename application. No behaviour
+change for existing inputs — the bridge does not yet produce update
+expressions (that lands in the CLOC12.158 PR2 bridge-enable), so these arms
+are exercised only via hand-constructed AST today.
+
 ## [0.10.0] - 2026-07-02
 
 ### Added — CLOC12.154: `TemplateLiteral` traversal

--- a/code/packages/rust/closure-pass-rename-globals/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename-globals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename-globals"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 description = "Aggressive top-level (global) renaming pass for the Closure Compiler clone — the ADVANCED-level complement to closure-pass-rename. Shortens program-private top-level names, gated by an externs do-not-rename boundary."
 

--- a/code/packages/rust/closure-pass-rename-globals/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename-globals/src/lib.rs
@@ -644,6 +644,7 @@ fn collect_all_idents_expr(expr: &Expression, out: &mut HashSet<String>) {
             collect_all_idents_expr(&le.right, out);
         }
         Expression::UnaryExpression(ue) => collect_all_idents_expr(&ue.argument, out),
+        Expression::UpdateExpression(ue) => collect_all_idents_expr(&ue.argument, out),
         Expression::AssignmentExpression(ae) => {
             match &ae.left {
                 AssignmentTarget::Identifier(id) => {
@@ -941,6 +942,7 @@ fn rename_apply_expr(expr: &mut Expression, map: &HashMap<String, String>) {
             rename_apply_expr(&mut le.right, map);
         }
         Expression::UnaryExpression(ue) => rename_apply_expr(&mut ue.argument, map),
+        Expression::UpdateExpression(ue) => rename_apply_expr(&mut ue.argument, map),
         Expression::AssignmentExpression(ae) => {
             match &mut ae.left {
                 AssignmentTarget::Identifier(id) => {

--- a/code/packages/rust/closure-pass-rename-properties/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename-properties/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename-properties` crate will be documented in this file.
 
+## [0.12.1] - 2026-07-02
+
+### Changed — CLOC12.158: exhaustiveness for new `Expression::UpdateExpression`
+
+Handle the new `Expression::UpdateExpression` (`++x` / `x++` / `--x` / `x--`)
+variant added to `javascript-ast` (0.17.0): the pass recurses into the operand for classification and rewriting. No behaviour
+change for existing inputs — the bridge does not yet produce update
+expressions (that lands in the CLOC12.158 PR2 bridge-enable), so these arms
+are exercised only via hand-constructed AST today.
+
 ## [0.12.0] - 2026-07-02
 
 ### Added — CLOC12.154: `TemplateLiteral` traversal

--- a/code/packages/rust/closure-pass-rename-properties/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename-properties/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename-properties"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2021"
 description = "Aggressive property renaming pass for the Closure Compiler clone (ADVANCED-only). Consistently shortens program-private object property names that are never quoted/computed and not in the built-in or externs do-not-rename boundary."
 

--- a/code/packages/rust/closure-pass-rename-properties/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename-properties/src/lib.rs
@@ -1155,6 +1155,7 @@ fn classify_expr(expr: &Expression, cls: &mut Classify) {
             classify_expr(&le.right, cls);
         }
         Expression::UnaryExpression(ue) => classify_expr(&ue.argument, cls),
+        Expression::UpdateExpression(ue) => classify_expr(&ue.argument, cls),
         Expression::AssignmentExpression(ae) => {
             if let AssignmentTarget::MemberExpression(m) = &ae.left {
                 classify_member(&m.object, &m.property, m.computed, cls);
@@ -1414,6 +1415,7 @@ fn rewrite_expr(expr: &mut Expression, map: &HashMap<String, String>) {
             rewrite_expr(&mut le.right, map);
         }
         Expression::UnaryExpression(ue) => rewrite_expr(&mut ue.argument, map),
+        Expression::UpdateExpression(ue) => rewrite_expr(&mut ue.argument, map),
         Expression::AssignmentExpression(ae) => {
             if let AssignmentTarget::MemberExpression(m) = &mut ae.left {
                 rewrite_member(&mut m.object, &mut m.property, m.computed, map);

--- a/code/packages/rust/closure-pass-rename/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename` crate will be documented in this file.
 
+## [0.14.1] - 2026-07-02
+
+### Changed — CLOC12.158: exhaustiveness for new `Expression::UpdateExpression`
+
+Handle the new `Expression::UpdateExpression` (`++x` / `x++` / `--x` / `x--`)
+variant added to `javascript-ast` (0.17.0): the pass recurses into the operand for ident collection and use rewriting. No behaviour
+change for existing inputs — the bridge does not yet produce update
+expressions (that lands in the CLOC12.158 PR2 bridge-enable), so these arms
+are exercised only via hand-constructed AST today.
+
 ## [0.14.0] - 2026-07-02
 
 ### Added — CLOC12.154: `TemplateLiteral` traversal

--- a/code/packages/rust/closure-pass-rename/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2021"
 description = "Variable renaming pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Replaces non-exported binding names with shorter identifiers to reduce output size while preserving externally-visible names and semantics."
 

--- a/code/packages/rust/closure-pass-rename/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename/src/lib.rs
@@ -922,6 +922,7 @@ fn collect_all_idents_expr(expr: &Expression, out: &mut HashSet<String>) {
             collect_all_idents_expr(&le.right, out);
         }
         Expression::UnaryExpression(ue) => collect_all_idents_expr(&ue.argument, out),
+        Expression::UpdateExpression(ue) => collect_all_idents_expr(&ue.argument, out),
         Expression::AssignmentExpression(ae) => {
             match &ae.left {
                 AssignmentTarget::Identifier(id) => {
@@ -1205,6 +1206,7 @@ fn rewrite_uses_expr(expr: &mut Expression, map: &HashMap<String, String>) {
             rewrite_uses_expr(&mut le.right, map);
         }
         Expression::UnaryExpression(ue) => rewrite_uses_expr(&mut ue.argument, map),
+        Expression::UpdateExpression(ue) => rewrite_uses_expr(&mut ue.argument, map),
         Expression::AssignmentExpression(ae) => {
             match &mut ae.left {
                 AssignmentTarget::Identifier(id) => {

--- a/code/packages/rust/closure-scope-analyzer/CHANGELOG.md
+++ b/code/packages/rust/closure-scope-analyzer/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `coding-adventures-closure-scope-analyzer` crate will be documented in this file.
 
+## [0.12.1] - 2026-07-02
+
+### Changed — CLOC12.158: exhaustiveness for new `Expression::UpdateExpression`
+
+Handle the new `Expression::UpdateExpression` (`++x` / `x++` / `--x` / `x--`)
+variant added to `javascript-ast` (0.17.0): the pass walks the operand so its identifier reference is resolved in scope. No behaviour
+change for existing inputs — the bridge does not yet produce update
+expressions (that lands in the CLOC12.158 PR2 bridge-enable), so these arms
+are exercised only via hand-constructed AST today.
+
 ## [0.12.0] - 2026-07-02
 
 ### Added — CLOC12.154: `TemplateLiteral` traversal

--- a/code/packages/rust/closure-scope-analyzer/Cargo.toml
+++ b/code/packages/rust/closure-scope-analyzer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-scope-analyzer"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2021"
 description = "Lexical scope + symbol-table analyzer for the Closure Compiler clone. Per CLOC13 — produces a `ScopeAnalysis` consumed by the rename, inline, treeshake, collapse-properties, and remove-unused-vars passes."
 

--- a/code/packages/rust/closure-scope-analyzer/src/lib.rs
+++ b/code/packages/rust/closure-scope-analyzer/src/lib.rs
@@ -861,6 +861,12 @@ fn walk_expression(
         Expression::UnaryExpression(ue) => {
             walk_expression(&ue.argument, ctx, analysis, pending);
         }
+        // `++x` / `x++`: the operand is both read AND written, but for scope
+        // resolution what matters is only that its identifier is *referenced*
+        // in this scope — the same as any other operand walk.
+        Expression::UpdateExpression(ue) => {
+            walk_expression(&ue.argument, ctx, analysis, pending);
+        }
         Expression::AssignmentExpression(ae) => {
             match &ae.left {
                 AssignmentTarget::Identifier(id) => {

--- a/code/packages/rust/javascript-ast/CHANGELOG.md
+++ b/code/packages/rust/javascript-ast/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to the `coding-adventures-javascript-ast` crate will be documented in this file.
 
+## [0.17.0] - 2026-07-02
+
+### Added — CLOC12.158: `UpdateExpression` (`++` / `--`)
+
+New `Expression::UpdateExpression` variant (`UpdateExpression { operator,
+prefix, argument }`) plus the `UpdateOperator` enum (`Increment` `++` /
+`Decrement` `--`), closing the long-standing Phase 2 gap noted in the
+`UnaryExpression` docs. Kept **distinct** from `UnaryExpression` because
+`++`/`--` are a read-modify-write: they carry a side effect (so DCE/purity
+passes must not drop them) and require a *writable reference* operand (an
+identifier or member), unlike the pure prefix unary operators. `prefix`
+distinguishes `++x` (yield the new value) from `x++` (yield the old value).
+This is the atomic node addition — the emitter and every exhaustive
+`Expression` match across the pass crates are updated in the same change so
+the workspace stays green; the parser bridge enable (grammar
+`postfix_expression` / prefix `++`/`--` → this node) is the follow-up PR2.
+
 ## [0.16.0] - 2026-07-02
 
 ### Added — CLOC12.154: `TemplateLiteral` (backtick template strings)

--- a/code/packages/rust/javascript-ast/Cargo.toml
+++ b/code/packages/rust/javascript-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-javascript-ast"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 description = "Backend-agnostic JavaScript AST — full ESTree-compatible node taxonomy with optional per-node CV id. Reusable by the Closure-Compiler-clone and the future V8-in-Rust clone. Per CLOC02 / CLOC09."
 

--- a/code/packages/rust/javascript-ast/README.md
+++ b/code/packages/rust/javascript-ast/README.md
@@ -53,6 +53,14 @@ emitter grow a need for them — each behind its own `CLOC12.NN` slice:
   `cooked` / `tail`. Node + `closure-emitter` + all pass traversals land in one
   atomic PR; the bridge-enable + conformance port follow. (Tagged templates
   `` tag`…` `` remain Phase 3.)
+- `UpdateExpression` (CLOC12.158) — the `++` / `--` read-modify-write forms
+  (`++x`, `x++`, `--x`, `x--`). `UpdateExpression { operator: UpdateOperator,
+  prefix: bool, argument: Box<Expression> }`. Distinct from `UnaryExpression`
+  because `++`/`--` carry a side effect (passes must not drop them) and require
+  a writable-reference operand; `prefix` splits `++x` (yield the new value)
+  from `x++` (yield the old value). Node + `closure-emitter` + all pass
+  traversals land in one atomic PR; the bridge-enable + conformance port
+  follow (gap-159).
 
 ## What's coming (follow-up PRs)
 

--- a/code/packages/rust/javascript-ast/src/expression.rs
+++ b/code/packages/rust/javascript-ast/src/expression.rs
@@ -57,6 +57,7 @@ pub enum Expression {
     FunctionExpression(FunctionExpression),
     ArrowFunctionExpression(ArrowFunctionExpression),
     TemplateLiteral(TemplateLiteral),
+    UpdateExpression(UpdateExpression),
 }
 
 // ---------------------------------------------------------------------
@@ -236,8 +237,10 @@ pub enum LogicalOperator {
 }
 
 /// Prefix unary: `-x`, `+x`, `!x`, `~x`, `typeof x`, `void x`, `delete x`.
-/// `prefix: true` in v1; ESTree's `UpdateExpression` (`++` / `--`) is
-/// deferred to Phase 2.
+/// `prefix: true` in v1. The **read-modify-write** operators `++` / `--` are
+/// *not* here — they carry a side effect and a writability requirement the
+/// pure unary operators do not, so they live in their own
+/// [`UpdateExpression`] node (as in ESTree).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct UnaryExpression {
@@ -257,6 +260,38 @@ pub enum UnaryOperator {
     #[serde(rename = "typeof")] TypeOf,
     #[serde(rename = "void")] Void,
     #[serde(rename = "delete")] Delete,
+}
+
+/// Update expression: `++x`, `x++`, `--x`, `x--`. ESTree's `UpdateExpression`.
+///
+/// Kept distinct from [`UnaryExpression`] because `++` / `--` **mutate** their
+/// operand — a read-modify-write — so unlike the pure unary operators they:
+///   * have a side effect (a DCE or purity pass must NOT treat `x++` as
+///     removable dead code, and a fold pass must NOT reorder past it), and
+///   * require a *writable reference* as their argument (an identifier or a
+///     member access), never an arbitrary value (`5++` is a syntax error).
+///
+/// `prefix` distinguishes the two evaluation orders, which differ in the value
+/// the expression *yields* (the mutation of the operand is identical):
+///
+/// ```text
+///   ++x   prefix:  increment x, then YIELD THE NEW value   (x was 1 → 2, yields 2)
+///   x++   postfix: YIELD THE OLD value, then increment x   (x was 1, yields 1 → x is 2)
+/// ```
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateExpression {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub cv: Option<CvId>,
+    pub operator: UpdateOperator,
+    pub prefix: bool,
+    pub argument: Box<Expression>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum UpdateOperator {
+    #[serde(rename = "++")] Increment,
+    #[serde(rename = "--")] Decrement,
 }
 
 /// `x = y`, `x += y`, etc. The target is an [`AssignmentTarget`]

--- a/code/packages/rust/javascript-ast/src/lib.rs
+++ b/code/packages/rust/javascript-ast/src/lib.rs
@@ -139,7 +139,7 @@ pub use expression::{
     LogicalOperator, MemberExpression,
     NullLiteral, NumericLiteral, ObjectExpression, Property, PropertyKey, PropertyKind,
     StringLiteral, TemplateElement, TemplateLiteral, UnaryExpression, UnaryOperator,
-    UndefinedLiteral,
+    UndefinedLiteral, UpdateExpression, UpdateOperator,
 };
 pub use statement::{
     BlockStatement, BreakStatement, CatchClause, ContinueStatement, DebuggerStatement,

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -1640,3 +1640,42 @@ the grammar still only tokenises no-substitution templates into the bridge
 (gap-157), so multiline templates reach the emitter today only via
 hand-constructed AST, but the emitter is now correct for when the bridge grows
 multiline support.
+
+## CLOC12.158 — `UpdateExpression` (`++` / `--`): atomic node + emit + passes (PR1)
+
+Adds `Expression::UpdateExpression` (`UpdateExpression { operator, prefix,
+argument }`) + the `UpdateOperator` enum (`++` / `--`) to `javascript-ast`
+(0.17.0) — the first fundamental non-template `Expression` node added since the
+arrow arc, and the last "Phase 2" expression form the 0.16.0 `UnaryExpression`
+docs still deferred. Kept **distinct** from `UnaryExpression`: `++`/`--` are a
+read-modify-write, so they (a) carry a side effect (DCE/purity must not drop
+`x++`) and (b) require a *writable reference* operand (identifier / member),
+never an arbitrary value. `prefix` splits `++x` (yield the new value) from
+`x++` (yield the old value).
+
+**Atomic scope (PR1):** the node, the emitter (`emit_update`, `closure-emitter`
+0.22.0), and every exhaustive `Expression` match across the pass crates land in
+one change so the workspace never has a broken build — same shape as the
+ArrowFunctionExpression (CLOC12.151) and TemplateLiteral (CLOC12.154) PR1s.
+Downstream crates gained a match arm (patch bumps): constant-fold, dce,
+fold-control-flow, inline, inline-variables, rename, rename-globals,
+rename-properties, scope-analyzer. Emitter handling: `PREC_UNARY` precedence
+(wraps an `**` base and a member/call object, prints bare under `!`/`typeof`)
+and token-fusion seams via `arg_starts_with_sign` reporting a prefix update's
+lead sign (`a- --b`, `a+ ++b`) plus the binary emitter's output-tail check for
+postfix (`x++ +y`). 8 emitter unit tests.
+
+### gap-159 — bridge declines `update_expression`; grammar `postfix_expression` / prefix `++`/`--` not yet converted
+
+The `javascript-parser` typed-AST bridge still returns `UnsupportedSyntax` for
+`++`/`--` (both the grammar's `postfix_expression = lhs [ ++ | -- ]` and the
+prefix `++x`/`--x` unary alternative) — the decline predates this node and was
+correct while the typed AST had no `UpdateExpression`. Now that the node exists,
+the bridge can convert it: `convert_postfix_expression` builds a postfix
+`UpdateExpression { prefix: false }`, and the prefix `++`/`--` unary arm builds
+`{ prefix: true }`, with the operand converted as a normal left-hand-side
+expression. That is the CLOC12.158 **PR2 bridge-enable** (with a closurec e2e
+diff fixture proving `for` / statement `i++` round-trips instead of dropping the
+whole file to WHITESPACE_ONLY). The **PR3 emit conformance port** ports upstream
+CodePrinter's update-operator cases (postfix/prefix, precedence, fusion) into
+`closure-emitter/tests/upstream/`.


### PR DESCRIPTION
## Summary

Adds the ESTree **`UpdateExpression`** node — the `++`/`--` read-modify-write forms `++x`, `x++`, `--x`, `x--` — the last "Phase 2" expression form the `UnaryExpression` docs still deferred, and the first fundamental non-template `Expression` node since the arrow arc. Atomic PR1 (node + emit + every exhaustive-match arm) so the workspace never has a broken build — same shape as ArrowFunctionExpression (CLOC12.151) and TemplateLiteral (CLOC12.154).

## `javascript-ast` (0.16.0 → 0.17.0)

- New `Expression::UpdateExpression(UpdateExpression { operator, prefix, argument })` + `UpdateOperator` enum (`++` Increment / `--` Decrement).
- Kept **distinct** from `UnaryExpression`: `++`/`--` are a read-modify-write, so they carry a **side effect** (DCE/purity must not drop `x++`) and require a **writable-reference** operand (identifier/member), unlike the pure unary operators. `prefix` splits `++x` (yield new value) from `x++` (yield old value).

## `closure-emitter` (0.21.3 → 0.22.0)

- `emit_update`: prefix `<op><arg>`, postfix `<arg><op>`.
- `PREC_UNARY` precedence — wraps an `**` base (`(++x)**2`; bare `++x**2` is a syntax error) and a member/call object (`(x++).y`), prints bare under `!`/`typeof` (`!x++`, `typeof x++`).
- **Token-fusion seams** handled without a new guard: `arg_starts_with_sign` now reports a *prefix* update's leading `+`/`-`, so the binary/unary emitters space `a- --b` (never `a---b` = `(a--)-b`) and `a+ ++b` (never `a+++b` = `(a++)+b`); a *postfix* update ending in `+`/`-` is spaced by the binary emitter's existing output-tail check (`x++ +y`). **8 new unit tests.**

## Downstream (patch bumps + match arms + CHANGELOGs)

constant-fold, dce, fold-control-flow, inline, inline-variables, rename, rename-globals, rename-properties, scope-analyzer. The read-modify-write is preserved verbatim by the transform passes (never folded away, never treated as dead code); the pure passes recurse into the operand.

## Behaviour / scope

No behaviour change for existing inputs — the `javascript-parser` bridge still declines `++`/`--` (**gap-159**), so these arms are exercised only via hand-constructed AST today. The **bridge-enable (PR2, closes gap-159)** and the **CodePrinter conformance port (PR3)** follow.

## Testing

- Full `closure-emitter` suite (126 lib incl. 8 new update tests + all ports) green.
- All 9 downstream pass/analyzer crates, `javascript-ast`, `javascript-parser`, and the `closurec` program suite green.
- Inline security review: **PASSED** — no unsafe/IO/deserialization-of-untrusted; no new panic, unbounded recursion (shares the existing 128 MiB emit-stack guard), or security-relevant miscompile (all `++`/`--` seams verified; precedence only ever over-parenthesizes, never under).

🤖 Generated with [Claude Code](https://claude.com/claude-code)