### PR TITLE
feat(adj-lang): latex "\operatorname{sin/cos/…}" trig-family word spellings

### DIFF
--- a/code/packages/rust/adj-lang/CHANGELOG.md
+++ b/code/packages/rust/adj-lang/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [0.37.0] - 2026-07-02 — `\operatorname{sin/cos/…}` trig-family word spellings in `latex "…"`
+
+### Added
+
+- `latex "\operatorname{sin}(x)"` and the whole **trigonometric family** — direct
+  (`sin`/`cos`/`tan`/`cot`/`sec`/`csc`), inverse (`asin`/`acos`/`atan` and their `arc…`
+  aliases), and hyperbolic (`sinh`/`cosh`/`tanh`) — now compute, reaching the SAME native
+  `ExprAst::Call(NamedFn::…)` as their backslash-macro spellings (`\sin(x)`, `\arctan(x)`). A
+  model that writes the operator *name* instead of the macro lands on the identical node.
+  `\operatorname{…}` is a TEXT command, so — exactly like `\operatorname{exp}`/`floor`/`sgn` —
+  these parse as the operator-name juxtaposition `Bin(Mul, Text("sin"), (x))` rather than a
+  `Call`; one consolidated adapter arm recognises the family via the new `operator_name_trig_fn`
+  helper (which maps the trimmed text name — accepting `arcsin`≡`asin` etc. — to its `NamedFn`)
+  and lowers to `ExprAst::Call` (transcendental, Scalar→Scalar). Pure **adapter** recognition:
+  no engine, AST, or lowering change. +1 e2e unit test (cos(0)=1; sinh(0)=0; arctan(0)=0 via
+  the alias path).
+
 ## [0.36.0] - 2026-07-02 — `\operatorname{abs/exp/log/ln}` word spellings in `latex "…"`
 
 ### Added

--- a/code/packages/rust/adj-lang/Cargo.toml
+++ b/code/packages/rust/adj-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang"
-version = "0.36.0"
+version = "0.37.0"
 edition = "2021"
 description = "Surface-syntax frontend for the adjudication framework's probabilistic-logic rulebooks. Lexes, parses, and lowers a domain-expert-readable DSL into a `logic-engine` KnowledgeBase. Dissolves ADJ46 awkwardness items A10 (rulebook syntax) and A4 (joint contributions syntactically distinct)."
 

--- a/code/packages/rust/adj-lang/src/adapter.rs
+++ b/code/packages/rust/adj-lang/src/adapter.rs
@@ -1036,6 +1036,25 @@ fn latex_math_to_expr_ast(expr: &MathExpr, source: &str) -> Result<ExprAst, Adap
                 Box::new(latex_math_to_expr_ast(rhs, source)?),
             ))
         }
+        // `\operatorname{sin}(x)` / `\operatorname{cos}(x)` / … — the operator-name spellings
+        // of the whole trigonometric family (direct sin/cos/tan/cot/sec/csc, inverse
+        // asin/acos/atan and their `arc…` aliases, hyperbolic sinh/cosh/tanh). The
+        // backslash-macro spellings (`\sin(x)`, `\arctan(x)`) already lower in the `Call`
+        // arm below via `Func::Sin`/`Atan`/…; a model that writes the operator *name* should
+        // reach the SAME native `NamedFn`. But `\operatorname{…}` is a TEXT command, so —
+        // exactly like `\operatorname{exp}`/`floor`/`sgn` above — `\operatorname{sin}(x)`
+        // parses NOT as a `Call` but as the operator-name juxtaposition
+        // `Bin(Mul, Text("sin"), (x))`. One consolidated arm handles the family: the
+        // `operator_name_trig_fn` helper maps the text name (trimmed) to its `NamedFn`, and
+        // we lower to `ExprAst::Call` (transcendental, Scalar→Scalar) — the same node the
+        // macro path produces. Pure adapter recognition: no engine, AST, or lowering change.
+        MathExpr::Bin(BinOp::Mul, lhs, rhs) if operator_name_trig_fn(lhs).is_some() => {
+            let named = operator_name_trig_fn(lhs).expect("guard guarantees Some");
+            Ok(ExprAst::Call(
+                named,
+                Box::new(latex_math_to_expr_ast(rhs, source)?),
+            ))
+        }
         // `\operatorname{min}(a, b)` / `\operatorname{max}(…)` / `\operatorname{gcd}(…)` /
         // `\operatorname{lcm}(…)` — the operator-name spellings of the variadic binary
         // functions. The function-call spellings (`\min(a, b)`, `\gcd(a, b, c)`) already
@@ -1210,6 +1229,33 @@ fn latex_math_to_expr_ast(expr: &MathExpr, source: &str) -> Result<ExprAst, Adap
 /// `\operatorname{trunc}` and `\operatorname{ trunc }` both count.
 fn operator_name_is(expr: &MathExpr, name: &str) -> bool {
     matches!(expr, MathExpr::Text(s) if s.trim() == name)
+}
+
+/// If `expr` is a trigonometric operator-name text (`\operatorname{sin}`, `\operatorname{arctan}`,
+/// `\operatorname{sinh}`, …), return the matching `NamedFn`; otherwise `None`. Same recognition as
+/// `operator_name_is` (a `MathExpr::Text` whose trimmed content is the name), but consolidated for
+/// the whole trig family so one adapter arm can lower `\operatorname{sin}(x)` to the SAME
+/// `ExprAst::Call(NamedFn::Sin)` the `\sin(x)` macro produces. The `arc…` spellings are accepted as
+/// aliases for the inverse functions (a model may write either `\operatorname{asin}` or
+/// `\operatorname{arcsin}`). `exp`/`log`/`ln` are intentionally NOT here — they have their own
+/// dedicated arms above (and `abs` lowers to `ExprAst::Abs`, not a `Call`).
+fn operator_name_trig_fn(expr: &MathExpr) -> Option<NamedFn> {
+    let MathExpr::Text(s) = expr else { return None };
+    match s.trim() {
+        "sin" => Some(NamedFn::Sin),
+        "cos" => Some(NamedFn::Cos),
+        "tan" => Some(NamedFn::Tan),
+        "cot" => Some(NamedFn::Cot),
+        "sec" => Some(NamedFn::Sec),
+        "csc" => Some(NamedFn::Csc),
+        "asin" | "arcsin" => Some(NamedFn::Asin),
+        "acos" | "arccos" => Some(NamedFn::Acos),
+        "atan" | "arctan" => Some(NamedFn::Atan),
+        "sinh" => Some(NamedFn::Sinh),
+        "cosh" => Some(NamedFn::Cosh),
+        "tanh" => Some(NamedFn::Tanh),
+        _ => None,
+    }
 }
 
 /// Is `expr` the LEFT operand of a `\bmod`/`\pmod` juxtaposition — i.e.

--- a/code/packages/rust/adj-lang/src/lower.rs
+++ b/code/packages/rust/adj-lang/src/lower.rs
@@ -2389,6 +2389,45 @@ contributes 1000000 from answer == 60 to correct
     }
 
     #[test]
+    fn native_latex_operatorname_trig_family_word_spellings() {
+        // `\operatorname{sin}(x)` / `\operatorname{cos}` / `\operatorname{arctan}` / … — the
+        // operator-name spellings of the whole trig family. `\operatorname{…}` is a TEXT command,
+        // so these parse as the juxtaposition `Bin(Mul, Text("sin"), (x))` rather than a `Call`
+        // (`\sin`); the adapter recognises that shape via `operator_name_trig_fn` and lowers to the
+        // SAME `ExprAst::Call(NamedFn::…)` the macro produces. Transcendental ⇒ Scalar→Scalar.
+        // cos(x) with x = 0 → 1.
+        let c = crate::compile_and_decide(
+            "observe x(0)\n\
+             let answer = latex \"$\\operatorname{cos}(x)$\"\n\
+             prior 0.10 for correct\n\
+             contributes 1000000 from answer == 1 to correct\n\
+             ? correct\n",
+        )
+        .unwrap();
+        assert!(c.ranked[0].posterior > 0.99, "{c:?}");
+        // sinh(x) with x = 0 → 0 (hyperbolic).
+        let sh = crate::compile_and_decide(
+            "observe x(0)\n\
+             let answer = latex \"$\\operatorname{sinh}(x)$\"\n\
+             prior 0.10 for correct\n\
+             contributes 1000000 from answer == 0 to correct\n\
+             ? correct\n",
+        )
+        .unwrap();
+        assert!(sh.ranked[0].posterior > 0.99, "{sh:?}");
+        // The `arc…` alias resolves to the same inverse function: arctan(x) with x = 0 → 0.
+        let at = crate::compile_and_decide(
+            "observe x(0)\n\
+             let answer = latex \"$\\operatorname{arctan}(x)$\"\n\
+             prior 0.10 for correct\n\
+             contributes 1000000 from answer == 0 to correct\n\
+             ? correct\n",
+        )
+        .unwrap();
+        assert!(at.ranked[0].posterior > 0.99, "{at:?}");
+    }
+
+    #[test]
     fn native_latex_symbolic_root_degree_is_rejected() {
         // `\sqrt[k]{x}` — a symbolic degree has no numeric value, so the reciprocal
         // exponent `1/k` cannot be formed. It must be rejected, not silently


### PR DESCRIPTION
## LaTeX consumer slice: `\operatorname{sin/cos/…}` trig-family word spellings

Math-tuned local models emit trig functions two ways: the backslash macro (`\sin(x)`,
`\arctan(x)`) **and** the operator-name spelling (`\operatorname{sin}(x)`). The macro form
already lowers; this PR makes the **operator-name spelling reach the identical native node**.

### Why it needs a new arm (parse shape, probed empirically)

`\operatorname{…}` is a TEXT command, so — unlike `\sin(x)` (a `Call`) — `\operatorname{sin}(x)`
parses as the operator-name **juxtaposition** `Bin(Mul, Text("sin"), Fenced(x))`, the same shape
the adapter already recognises for `\operatorname{exp}`/`floor`/`sgn`. One consolidated arm
handles the whole family via a new `operator_name_trig_fn` helper (text name → `NamedFn`), lowering
to the existing `ExprAst::Call(NamedFn::…)`:

| family | spellings |
|---|---|
| direct | `sin` `cos` `tan` `cot` `sec` `csc` |
| inverse | `asin`≡`arcsin` `acos`≡`arccos` `atan`≡`arctan` |
| hyperbolic | `sinh` `cosh` `tanh` |

The `arc…` spellings are accepted as aliases for the inverse functions. `exp`/`log`/`ln` are
intentionally *not* here — they have their own dedicated arms (and `abs` lowers to `ExprAst::Abs`,
not a `Call`).

### What changed

- **`adapter.rs`** — one consolidated operator-name trig arm + the `operator_name_trig_fn` lookup
  helper (pure string match, no regex/alloc).
- **`lower.rs`** — +1 e2e unit test: `cos(0)=1`, `sinh(0)=0` (hyperbolic), `arctan(0)=0` (exercises
  the `arc…` alias path).
- Version 0.36.0 → 0.37.0; CHANGELOG prepended.

**Pure adapter recognition: no engine, AST, or lowering change** (all `NamedFn` variants
pre-existing). `cargo test -p logic-engine -p adj-lang -p adj-lang-cli -p adj-constraint-solver`
green (116 adj-lang tests). Security review passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
