### PR TITLE
[codex] Persist Engram native host snapshots

### DIFF
--- a/code/programs/mosaic/engram-app/CHANGELOG.md
+++ b/code/programs/mosaic/engram-app/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Persisted Engram Mosaic SwiftUI, Qt, XAML, Flutter, and Compose native host
+  snapshots through `engram-capi`, matching the web/Electron snapshot behavior
+  with an `ENGRAM_SNAPSHOT_PATH` override and a shared home-directory fallback.
 - Persisted Engram Mosaic web, React, WebComponent, and Electron host snapshots
   across launches, seeding from the built-in language-learning demo only when no
   saved state is available.

--- a/code/programs/mosaic/engram-app/README.md
+++ b/code/programs/mosaic/engram-app/README.md
@@ -66,6 +66,9 @@ editing, and save/delete/cancel controls.
   `host/flutter/mosaic_host.dart` implements it with Dart FFI and
   `engram-capi`, hydrating Flutter slot props and routing generated Mosaic
   event envelopes back into the same core.
+- The web, Electron, and native host adapters persist raw Engram state snapshots
+  across launches. Set `ENGRAM_SNAPSHOT_PATH` to override the storage file; by
+  default host shells use `~/.engram/mosaic-snapshot.v1.json`.
 - Smoke tests now assert the generated Qt, SwiftUI, and XAML project shells
   expose the same Engram host contract slots, collection events, card-browser
   events, rating events, and Anki-style review action events as the shared Rust

--- a/code/programs/mosaic/engram-app/host/compose/MosaicHost.kt
+++ b/code/programs/mosaic/engram-app/host/compose/MosaicHost.kt
@@ -17,6 +17,7 @@ class MosaicHost {
                 api.eg_session_free(handle)
             }
         })
+        hydrateSession()
     }
 
     fun props(): Map<String, Any?> {
@@ -29,9 +30,45 @@ class MosaicHost {
         val api = capi ?: return emptyMap()
         val handle = session ?: return emptyMap()
         val eventJson = JSONObject(event).toString()
-        return hostResponseFromJson(
+        val response = hostResponseFromJson(
             takeCString(api.eg_handle_engram_app_event(handle, eventJson, deckId(), nowMs()), api)
         )
+        if (!response.containsKey("error")) {
+            persistSnapshot()
+        }
+        return response
+    }
+
+    private fun hydrateSession() {
+        val api = capi ?: return
+        val handle = session ?: return
+        val file = snapshotFile()
+        if (file.exists()) {
+            val loaded = runCatching {
+                val json = takeCString(api.eg_load_snapshot(handle, file.readText()), api)
+                jsonOk(json)
+            }.getOrDefault(false)
+            if (loaded) {
+                return
+            }
+            println("Engram Compose MosaicHost persisted snapshot was invalid; using demo state")
+        }
+        persistSnapshot()
+    }
+
+    private fun persistSnapshot() {
+        val api = capi ?: return
+        val handle = session ?: return
+        val json = takeCString(api.eg_snapshot(handle), api)
+        val root = runCatching { JSONObject(json) }.getOrNull() ?: return
+        if (!root.optBoolean("ok", true) || root.isNull("state")) {
+            return
+        }
+        runCatching {
+            val file = snapshotFile()
+            file.parentFile?.mkdirs()
+            file.writeText(root.get("state").toString())
+        }
     }
 
     private fun hostResponseFromJson(json: String): Map<String, Any?> {
@@ -66,6 +103,10 @@ class MosaicHost {
 
     private fun nowMs(): Long = System.currentTimeMillis()
 
+    private fun snapshotFile(): File =
+        System.getenv("ENGRAM_SNAPSHOT_PATH")?.takeIf { it.isNotBlank() }?.let(::File)
+            ?: File(File(System.getProperty("user.home"), ".engram"), "mosaic-snapshot.v1.json")
+
     private fun loadCapi(): EngramCapi? {
         val names = listOf(nativeLibraryFileName(), "engram_capi")
         val roots = listOfNotNull(
@@ -99,6 +140,8 @@ interface EngramCapi : Library {
     fun eg_session_new_demo(): Pointer?
     fun eg_session_free(session: Pointer?)
     fun eg_string_free(value: Pointer?)
+    fun eg_snapshot(session: Pointer?): Pointer?
+    fun eg_load_snapshot(session: Pointer?, snapshotJson: String): Pointer?
     fun eg_engram_app_props(session: Pointer?, deckId: String, nowMs: Long): Pointer?
     fun eg_handle_engram_app_event(
         session: Pointer?,
@@ -121,3 +164,6 @@ private fun jsonValue(value: Any?): Any? =
         is JSONArray -> jsonArrayToList(value)
         else -> value
     }
+
+private fun jsonOk(json: String): Boolean =
+    runCatching { JSONObject(json).optBoolean("ok", true) }.getOrDefault(false)

--- a/code/programs/mosaic/engram-app/host/flutter/mosaic_host.dart
+++ b/code/programs/mosaic/engram-app/host/flutter/mosaic_host.dart
@@ -12,6 +12,16 @@ typedef _EgSessionFreeNative = Void Function(Pointer<EgSession>);
 typedef _EgSessionFreeDart = void Function(Pointer<EgSession>);
 typedef _EgStringFreeNative = Void Function(Pointer<Utf8>);
 typedef _EgStringFreeDart = void Function(Pointer<Utf8>);
+typedef _EgSnapshotNative = Pointer<Utf8> Function(Pointer<EgSession>);
+typedef _EgSnapshotDart = Pointer<Utf8> Function(Pointer<EgSession>);
+typedef _EgLoadSnapshotNative = Pointer<Utf8> Function(
+  Pointer<EgSession>,
+  Pointer<Utf8>,
+);
+typedef _EgLoadSnapshotDart = Pointer<Utf8> Function(
+  Pointer<EgSession>,
+  Pointer<Utf8>,
+);
 typedef _EgEngramAppPropsNative = Pointer<Utf8> Function(
   Pointer<EgSession>,
   Pointer<Utf8>,
@@ -49,7 +59,9 @@ class MosaicHost {
     final session = api.egSessionNewDemo();
     if (session == nullptr) return null;
 
-    return MosaicHost._(api, session);
+    final host = MosaicHost._(api, session);
+    host._hydrateSession();
+    return host;
   }
 
   Map<String, Object?>? props() {
@@ -78,7 +90,11 @@ class MosaicHost {
             _nowMs(),
           ),
         );
-        return _hostResponseFromJson(json);
+        final response = _hostResponseFromJson(json);
+        if (response?['error'] == null) {
+          _persistSnapshot();
+        }
+        return response;
       });
     });
   }
@@ -101,6 +117,47 @@ class MosaicHost {
       _api.egStringFree(pointer);
     }
   }
+
+  void _hydrateSession() {
+    final file = File(_snapshotPath());
+    if (file.existsSync()) {
+      try {
+        final snapshot = file.readAsStringSync();
+        if (_loadSnapshot(snapshot)) {
+          return;
+        }
+      } catch (_) {}
+    }
+    _persistSnapshot();
+  }
+
+  bool _loadSnapshot(String snapshot) {
+    return _withNativeUtf8(snapshot, (snapshotPointer) {
+      final json = _takeCString(
+        _api.egLoadSnapshot(_session, snapshotPointer),
+      );
+      return _jsonOk(json);
+    });
+  }
+
+  void _persistSnapshot() {
+    final json = _takeCString(_api.egSnapshot(_session));
+    final Object? decoded;
+    try {
+      decoded = jsonDecode(json);
+    } catch (_) {
+      return;
+    }
+    if (decoded is! Map || decoded['ok'] == false || decoded['state'] == null) {
+      return;
+    }
+
+    try {
+      final file = File(_snapshotPath());
+      file.parent.createSync(recursive: true);
+      file.writeAsStringSync(jsonEncode(decoded['state']));
+    } catch (_) {}
+  }
 }
 
 class _EngramCapi {
@@ -116,6 +173,13 @@ class _EngramCapi {
             library.lookupFunction<_EgStringFreeNative, _EgStringFreeDart>(
           'eg_string_free',
         ),
+        egSnapshot = library.lookupFunction<_EgSnapshotNative, _EgSnapshotDart>(
+          'eg_snapshot',
+        ),
+        egLoadSnapshot =
+            library.lookupFunction<_EgLoadSnapshotNative, _EgLoadSnapshotDart>(
+          'eg_load_snapshot',
+        ),
         egEngramAppProps = library
             .lookupFunction<_EgEngramAppPropsNative, _EgEngramAppPropsDart>(
           'eg_engram_app_props',
@@ -127,6 +191,8 @@ class _EngramCapi {
   final _EgSessionNewDart egSessionNewDemo;
   final _EgSessionFreeDart egSessionFree;
   final _EgStringFreeDart egStringFree;
+  final _EgSnapshotDart egSnapshot;
+  final _EgLoadSnapshotDart egLoadSnapshot;
   final _EgEngramAppPropsDart egEngramAppProps;
   final _EgHandleEngramAppEventDart egHandleEngramAppEvent;
 
@@ -172,6 +238,15 @@ Map<String, Object?> _hostResponseFromJson(String json) {
   return response;
 }
 
+bool _jsonOk(String json) {
+  try {
+    final decoded = jsonDecode(json);
+    return decoded is Map && decoded['ok'] != false;
+  } catch (_) {
+    return false;
+  }
+}
+
 Map<String, Object?> _mosaicMap(Object? value) {
   if (value is! Map) return const <String, Object?>{};
   final out = <String, Object?>{};
@@ -196,6 +271,15 @@ T _withNativeUtf8<T>(String value, T Function(Pointer<Utf8>) body) {
 String _deckId() => Platform.environment['ENGRAM_DECK_ID'] ?? '';
 
 int _nowMs() => DateTime.now().toUtc().millisecondsSinceEpoch;
+
+String _snapshotPath() =>
+    Platform.environment['ENGRAM_SNAPSHOT_PATH'] ??
+    _joinPath(_joinPath(_homeDirectory(), '.engram'), 'mosaic-snapshot.v1.json');
+
+String _homeDirectory() =>
+    Platform.environment['HOME'] ??
+    Platform.environment['USERPROFILE'] ??
+    Directory.current.path;
 
 Iterable<String> _libraryCandidates() sync* {
   final fileName = _nativeLibraryFileName();

--- a/code/programs/mosaic/engram-app/host/qt/MosaicHost.cpp
+++ b/code/programs/mosaic/engram-app/host/qt/MosaicHost.cpp
@@ -4,6 +4,9 @@
 #include <QDateTime>
 #include <QDebug>
 #include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QJsonValue>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonParseError>
@@ -41,8 +44,12 @@ QVariantMap MosaicHost::handleEvent(const QVariantMap &event) {
   const QByteArray eventJson =
       QJsonDocument(QJsonObject::fromVariantMap(event)).toJson(QJsonDocument::Compact);
   const QByteArray deck = deckId();
-  return hostResponseFromJson(takeCString(
+  const QVariantMap response = hostResponseFromJson(takeCString(
       handleEngramAppEvent_(session_, eventJson.constData(), deck.constData(), nowMs())));
+  if (!response.contains(QStringLiteral("error"))) {
+    persistSnapshot();
+  }
+  return response;
 }
 
 bool MosaicHost::ensureLoaded() {
@@ -82,12 +89,15 @@ bool MosaicHost::ensureLoaded() {
   sessionNewDemo_ = resolveSymbol<EgSessionNewDemoFn>(library_, "eg_session_new_demo");
   sessionFree_ = resolveSymbol<EgSessionFreeFn>(library_, "eg_session_free");
   stringFree_ = resolveSymbol<EgStringFreeFn>(library_, "eg_string_free");
+  snapshot_ = resolveSymbol<EgSnapshotFn>(library_, "eg_snapshot");
+  loadSnapshot_ = resolveSymbol<EgLoadSnapshotFn>(library_, "eg_load_snapshot");
   engramAppProps_ = resolveSymbol<EgEngramAppPropsFn>(library_, "eg_engram_app_props");
   handleEngramAppEvent_ =
       resolveSymbol<EgHandleEngramAppEventFn>(library_, "eg_handle_engram_app_event");
 
   if (sessionNewDemo_ == nullptr || sessionFree_ == nullptr || stringFree_ == nullptr ||
-      engramAppProps_ == nullptr || handleEngramAppEvent_ == nullptr) {
+      snapshot_ == nullptr || loadSnapshot_ == nullptr || engramAppProps_ == nullptr ||
+      handleEngramAppEvent_ == nullptr) {
     qWarning() << "Engram MosaicHost loaded engram-capi but required symbols are missing";
     library_.unload();
     return false;
@@ -98,7 +108,57 @@ bool MosaicHost::ensureLoaded() {
     qWarning() << "Engram MosaicHost failed to create an Engram session";
     return false;
   }
+  hydrateSession();
   return true;
+}
+
+void MosaicHost::hydrateSession() {
+  const QString path = snapshotPath();
+  QFile file(path);
+  if (file.exists() && file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+    const QByteArray snapshot = file.readAll();
+    const QVariantMap loaded =
+        hostResponseFromJson(takeCString(loadSnapshot_(session_, snapshot.constData())));
+    if (!loaded.contains(QStringLiteral("error"))) {
+      return;
+    }
+    qWarning() << "Engram MosaicHost persisted snapshot was invalid; using demo state";
+  }
+
+  persistSnapshot();
+}
+
+void MosaicHost::persistSnapshot() {
+  if (session_ == nullptr || snapshot_ == nullptr) {
+    return;
+  }
+
+  const QString json = takeCString(snapshot_(session_));
+  QJsonParseError parseError;
+  const QJsonDocument document = QJsonDocument::fromJson(json.toUtf8(), &parseError);
+  if (parseError.error != QJsonParseError::NoError || !document.isObject()) {
+    qWarning() << "Engram MosaicHost could not parse snapshot JSON:" << parseError.errorString();
+    return;
+  }
+
+  const QJsonObject root = document.object();
+  if (root.value(QStringLiteral("ok")).toBool(true) == false ||
+      root.value(QStringLiteral("state")).isUndefined() ||
+      root.value(QStringLiteral("state")).isNull()) {
+    qWarning() << "Engram MosaicHost snapshot response was not persistable";
+    return;
+  }
+
+  const QString path = snapshotPath();
+  const QFileInfo info(path);
+  QDir().mkpath(info.absolutePath());
+  QFile file(path);
+  if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text)) {
+    qWarning() << "Engram MosaicHost could not persist snapshot:" << file.errorString();
+    return;
+  }
+
+  file.write(QJsonDocument(root.value(QStringLiteral("state")).toObject()).toJson(QJsonDocument::Compact));
 }
 
 QString MosaicHost::takeCString(char *value) const {
@@ -171,6 +231,14 @@ QString MosaicHost::mosaicPropName(const QString &name) const {
     }
   }
   return out;
+}
+
+QString MosaicHost::snapshotPath() const {
+  const QByteArray configured = qgetenv("ENGRAM_SNAPSHOT_PATH");
+  if (!configured.isEmpty()) {
+    return QString::fromLocal8Bit(configured);
+  }
+  return QDir::home().filePath(QStringLiteral(".engram/mosaic-snapshot.v1.json"));
 }
 
 QByteArray MosaicHost::deckId() const {

--- a/code/programs/mosaic/engram-app/host/qt/MosaicHost.h
+++ b/code/programs/mosaic/engram-app/host/qt/MosaicHost.h
@@ -22,14 +22,19 @@ private:
   using EgSessionNewDemoFn = void *(*)();
   using EgSessionFreeFn = void (*)(void *);
   using EgStringFreeFn = void (*)(char *);
+  using EgSnapshotFn = char *(*)(void *);
+  using EgLoadSnapshotFn = char *(*)(void *, const char *);
   using EgEngramAppPropsFn = char *(*)(void *, const char *, quint64);
   using EgHandleEngramAppEventFn = char *(*)(void *, const char *, const char *, quint64);
 
   bool ensureLoaded();
+  void hydrateSession();
+  void persistSnapshot();
   QString takeCString(char *value) const;
   QVariantMap hostResponseFromJson(const QString &json) const;
   QVariantMap camelCaseProps(const QVariantMap &props) const;
   QString mosaicPropName(const QString &name) const;
+  QString snapshotPath() const;
   QByteArray deckId() const;
   quint64 nowMs() const;
 
@@ -38,6 +43,8 @@ private:
   EgSessionNewDemoFn sessionNewDemo_ = nullptr;
   EgSessionFreeFn sessionFree_ = nullptr;
   EgStringFreeFn stringFree_ = nullptr;
+  EgSnapshotFn snapshot_ = nullptr;
+  EgLoadSnapshotFn loadSnapshot_ = nullptr;
   EgEngramAppPropsFn engramAppProps_ = nullptr;
   EgHandleEngramAppEventFn handleEngramAppEvent_ = nullptr;
 };

--- a/code/programs/mosaic/engram-app/host/swiftui/MosaicHost.swift
+++ b/code/programs/mosaic/engram-app/host/swiftui/MosaicHost.swift
@@ -3,10 +3,12 @@ import Foundation
 
 @objc final class MosaicHost: NSObject, MosaicHostBridgeObject {
     private var session: OpaquePointer?
+    private let snapshotFileName = "mosaic-snapshot.v1.json"
 
     override init() {
         self.session = eg_session_new_demo()
         super.init()
+        hydrateSession()
     }
 
     deinit {
@@ -41,7 +43,54 @@ import Foundation
                     currentTimeMillis()))
             }
         }
-        return hostResponseDictionary(from: json)
+        let response = hostResponseDictionary(from: json)
+        if response?["error"] == nil {
+            persistSnapshot()
+        }
+        return response
+    }
+
+    private func hydrateSession() {
+        guard let session else {
+            return
+        }
+        let url = snapshotURL()
+        if let data = try? Data(contentsOf: url),
+           let snapshot = String(data: data, encoding: .utf8) {
+            let json = snapshot.withCString { snapshotPointer in
+                takeCString(eg_load_snapshot(session, snapshotPointer))
+            }
+            if let root = decodeJsonObject(json),
+               (root["ok"] as? Bool) != false {
+                return
+            }
+            print("Engram persisted snapshot was invalid; using demo state")
+        }
+        persistSnapshot()
+    }
+
+    private func persistSnapshot() {
+        guard let session else {
+            return
+        }
+        let json = takeCString(eg_snapshot(session))
+        guard let root = decodeJsonObject(json),
+              (root["ok"] as? Bool) != false,
+              let state = root["state"],
+              JSONSerialization.isValidJSONObject(state),
+              let data = try? JSONSerialization.data(withJSONObject: state, options: []) else {
+            return
+        }
+
+        let url = snapshotURL()
+        do {
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true)
+            try data.write(to: url, options: [.atomic])
+        } catch {
+            print("Engram could not persist snapshot: \(error)")
+        }
     }
 
     private func hostResponseDictionary(from json: String) -> NSDictionary? {
@@ -95,6 +144,16 @@ import Foundation
 
     private func currentDeckId() -> String {
         ProcessInfo.processInfo.environment["ENGRAM_DECK_ID"] ?? ""
+    }
+
+    private func snapshotURL() -> URL {
+        if let configured = ProcessInfo.processInfo.environment["ENGRAM_SNAPSHOT_PATH"],
+           !configured.isEmpty {
+            return URL(fileURLWithPath: configured)
+        }
+        return FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".engram", isDirectory: true)
+            .appendingPathComponent(snapshotFileName)
     }
 
     private func currentTimeMillis() -> UInt64 {

--- a/code/programs/mosaic/engram-app/host/xaml/MosaicHost.cs
+++ b/code/programs/mosaic/engram-app/host/xaml/MosaicHost.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -15,6 +16,8 @@ public sealed record MosaicHostResult(string Status, MosaicHostIntent? HostInten
 public static class MosaicHost
 {
     private const string NativeLibrary = "engram_capi";
+    private const string SnapshotPathEnvironmentVariable = "ENGRAM_SNAPSHOT_PATH";
+    private const string SnapshotFileName = "mosaic-snapshot.v1.json";
     private static readonly object SessionLock = new();
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
     private static IntPtr Session = IntPtr.Zero;
@@ -72,10 +75,15 @@ public static class MosaicHost
                         CurrentDeckId(),
                         CurrentTimeMillis()));
                 using var document = JsonDocument.Parse(json);
-                return ApplyPropsFromRoot(
+                var result = ApplyPropsFromRoot(
                     component,
                     document.RootElement,
                     $"Status: Engram host handled {ev.MosaicName}");
+                if (!IsErrorRoot(document.RootElement))
+                {
+                    PersistSnapshot(session);
+                }
+                return result;
             }
             catch (Exception ex) when (IsNativeAvailabilityFailure(ex))
             {
@@ -280,8 +288,77 @@ public static class MosaicHost
         }
 
         session = Session;
+        HydrateSession(session);
         unavailable = "";
         return true;
+    }
+
+    private static void HydrateSession(IntPtr session)
+    {
+        var path = SnapshotPath();
+        if (File.Exists(path))
+        {
+            try
+            {
+                var snapshot = File.ReadAllText(path, Encoding.UTF8);
+                var json = Native.TakeString(Native.eg_load_snapshot(session, snapshot));
+                using var document = JsonDocument.Parse(json);
+                if (!IsErrorRoot(document.RootElement))
+                {
+                    return;
+                }
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or JsonException)
+            {
+                Console.Error.WriteLine($"Engram could not read persisted snapshot: {ex.Message}");
+            }
+        }
+
+        PersistSnapshot(session);
+    }
+
+    private static void PersistSnapshot(IntPtr session)
+    {
+        try
+        {
+            var json = Native.TakeString(Native.eg_snapshot(session));
+            using var document = JsonDocument.Parse(json);
+            if (IsErrorRoot(document.RootElement)
+                || !document.RootElement.TryGetProperty("state", out var state)
+                || state.ValueKind is JsonValueKind.Undefined or JsonValueKind.Null)
+            {
+                return;
+            }
+
+            var path = SnapshotPath();
+            var directory = Path.GetDirectoryName(path);
+            if (!string.IsNullOrEmpty(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+            File.WriteAllText(path, state.GetRawText(), Encoding.UTF8);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or JsonException)
+        {
+            Console.Error.WriteLine($"Engram could not persist snapshot: {ex.Message}");
+        }
+    }
+
+    private static bool IsErrorRoot(JsonElement root)
+    {
+        return root.TryGetProperty("ok", out var ok) && ok.ValueKind == JsonValueKind.False;
+    }
+
+    private static string SnapshotPath()
+    {
+        var configured = Environment.GetEnvironmentVariable(SnapshotPathEnvironmentVariable);
+        if (!string.IsNullOrWhiteSpace(configured))
+        {
+            return configured;
+        }
+
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        return Path.Combine(home, ".engram", SnapshotFileName);
     }
 
     private static MosaicHostResult HostUnavailable(string reason)
@@ -333,6 +410,14 @@ public static class MosaicHost
 
         [DllImport(NativeLibrary, EntryPoint = "eg_string_free", CallingConvention = CallingConvention.Cdecl)]
         internal static extern void eg_string_free(IntPtr value);
+
+        [DllImport(NativeLibrary, EntryPoint = "eg_snapshot", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern IntPtr eg_snapshot(IntPtr session);
+
+        [DllImport(NativeLibrary, EntryPoint = "eg_load_snapshot", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern IntPtr eg_load_snapshot(
+            IntPtr session,
+            [MarshalAs(UnmanagedType.LPUTF8Str)] string snapshotJson);
 
         [DllImport(NativeLibrary, EntryPoint = "eg_engram_app_props", CallingConvention = CallingConvention.Cdecl)]
         internal static extern IntPtr eg_engram_app_props(

--- a/code/programs/mosaic/engram-app/tests/package_compiles.rs
+++ b/code/programs/mosaic/engram-app/tests/package_compiles.rs
@@ -2485,6 +2485,12 @@ fn source_tree_has_expected_shape() {
     assert_contains(&xaml_host, "private static IntPtr Session = IntPtr.Zero");
     assert_contains(&xaml_host, "TryGetSession");
     assert_contains(&xaml_host, "Engram native host unavailable");
+    assert_contains(&xaml_host, "ENGRAM_SNAPSHOT_PATH");
+    assert_contains(&xaml_host, "mosaic-snapshot.v1.json");
+    assert_contains(&xaml_host, "HydrateSession");
+    assert_contains(&xaml_host, "PersistSnapshot");
+    assert_contains(&xaml_host, "eg_snapshot");
+    assert_contains(&xaml_host, "eg_load_snapshot");
     assert!(
         !xaml_host.contains("private static IntPtr Session = Native.eg_session_new()"),
         "xaml host template must not load the native library from a static field initializer"
@@ -2498,6 +2504,12 @@ fn source_tree_has_expected_shape() {
     assert_contains(&swiftui_host, "hostResponseDictionary");
     assert_contains(&swiftui_host, "\"hostIntent\"");
     assert_contains(&swiftui_host, "\"props\"");
+    assert_contains(&swiftui_host, "ENGRAM_SNAPSHOT_PATH");
+    assert_contains(&swiftui_host, "mosaic-snapshot.v1.json");
+    assert_contains(&swiftui_host, "hydrateSession");
+    assert_contains(&swiftui_host, "persistSnapshot");
+    assert_contains(&swiftui_host, "eg_snapshot");
+    assert_contains(&swiftui_host, "eg_load_snapshot");
 
     let qt_host = fs::read_to_string(package_root().join("host/qt/MosaicHost.cpp"))
         .expect("qt host template");
@@ -2508,6 +2520,12 @@ fn source_tree_has_expected_shape() {
     assert_contains(&qt_host, "hostResponseFromJson");
     assert_contains(&qt_host, "hostIntent");
     assert_contains(&qt_host, "props");
+    assert_contains(&qt_host, "ENGRAM_SNAPSHOT_PATH");
+    assert_contains(&qt_host, "mosaic-snapshot.v1.json");
+    assert_contains(&qt_host, "hydrateSession");
+    assert_contains(&qt_host, "persistSnapshot");
+    assert_contains(&qt_host, "eg_snapshot");
+    assert_contains(&qt_host, "eg_load_snapshot");
 
     let compose_host = fs::read_to_string(package_root().join("host/compose/MosaicHost.kt"))
         .expect("compose host template");
@@ -2518,6 +2536,12 @@ fn source_tree_has_expected_shape() {
     assert_contains(&compose_host, "JSONObject(event)");
     assert_contains(&compose_host, "\"hostIntent\"");
     assert_contains(&compose_host, "\"props\"");
+    assert_contains(&compose_host, "ENGRAM_SNAPSHOT_PATH");
+    assert_contains(&compose_host, "mosaic-snapshot.v1.json");
+    assert_contains(&compose_host, "hydrateSession");
+    assert_contains(&compose_host, "persistSnapshot");
+    assert_contains(&compose_host, "eg_snapshot");
+    assert_contains(&compose_host, "eg_load_snapshot");
 
     let flutter_host = fs::read_to_string(package_root().join("host/flutter/mosaic_host.dart"))
         .expect("flutter host template");
@@ -2529,6 +2553,12 @@ fn source_tree_has_expected_shape() {
     assert_contains(&flutter_host, "jsonEncode(event)");
     assert_contains(&flutter_host, "'hostIntent'");
     assert_contains(&flutter_host, "'props'");
+    assert_contains(&flutter_host, "ENGRAM_SNAPSHOT_PATH");
+    assert_contains(&flutter_host, "mosaic-snapshot.v1.json");
+    assert_contains(&flutter_host, "_hydrateSession");
+    assert_contains(&flutter_host, "_persistSnapshot");
+    assert_contains(&flutter_host, "eg_snapshot");
+    assert_contains(&flutter_host, "eg_load_snapshot");
 
     let build_script =
         fs::read_to_string(package_root().join("scripts/build-all.ps1")).expect("build-all.ps1");


### PR DESCRIPTION
## Summary
- Persist SwiftUI, Qt, XAML, Flutter, and Compose Engram native host snapshots through the existing `engram-capi` `eg_snapshot` / `eg_load_snapshot` ABI.
- Match the web/Electron storage contract with `ENGRAM_SNAPSHOT_PATH` override and `~/.engram/mosaic-snapshot.v1.json` fallback.
- Keep demo seeding only as a fallback when no valid saved snapshot exists, then save after successful generated host events.

## Validation
- `cargo fmt --manifest-path code\programs\mosaic\engram-app\Cargo.toml`
- `cargo test --manifest-path code\programs\mosaic\engram-app\Cargo.toml -- --nocapture`
- `code\programs\mosaic\engram-app\scripts\build-all.ps1`
- `npm run build` in `code\programs\mosaic\engram-app\target\mosaic-engram-app\react`
- `npm run build` in `code\programs\mosaic\engram-app\target\mosaic-engram-app\electron`
- `cargo test -p engram-capi c_abi -- --nocapture`
- `code\programs\mosaic\engram-app\target\mosaic-engram-app\xaml\build.ps1 -Clean` using local `C:\Program Files\dotnet\dotnet.exe` (.NET SDK 9.0.315)
- `git diff --check`

## Notes
- Dart/Flutter, Swift, Kotlin/JVM, CMake, and Qt SDK command-line tools were not installed on this Windows machine, so those native shells were validated through emission plus template contract tests rather than platform-native compilers.