### PR TITLE
feat(adj-lang): latex accents (\hat{x}, \bar{x}, …) compute transparently

### DIFF
--- a/code/packages/rust/adj-lang/CHANGELOG.md
+++ b/code/packages/rust/adj-lang/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.38.0] - 2026-07-02 — accent-wrapped operands (`\hat{x}`, `\bar{x}`, …) compute transparently in `latex "…"`
+
+### Added
+
+- `latex "\hat{x}"`, `\bar{x}`, `\vec{x}`, `\tilde{x}` and any other **accent** over an operand now
+  compute, lowering **transparently to the accented operand**. In arithmetic an accent is a
+  notational decoration, not an operation: a model that writes a statistics formula like
+  `\hat{p}(1 - \hat{p})` (estimated-variance numerator) or `\bar{x} - \bar{y}` (difference of means)
+  means the accented symbol to carry its operand's value — the hat/bar just marks it as an
+  estimate/mean in prose. The adapter recognises `MathExpr::Accent { body, .. }` and lowers to
+  `latex_math_to_expr_ast(body, …)`, so `\hat{a}(b - \hat{a})` computes as `a·(b − a)` with dimension
+  and value flowing through the decoration unchanged (previously an `UnsupportedLatexMath` error).
+  This is the first **non-function** LaTeX construct consumed after the named-operator surface
+  saturated. Pure **adapter** recognition: no engine, AST, or lowering change. +1 e2e unit test
+  (`\hat{a}(b − \hat{a})` = 21; `\bar{x} + \bar{y}` = 10).
+
 ## [0.37.0] - 2026-07-02 — `\operatorname{sin/cos/…}` trig-family word spellings in `latex "…"`
 
 ### Added

--- a/code/packages/rust/adj-lang/Cargo.toml
+++ b/code/packages/rust/adj-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang"
-version = "0.37.0"
+version = "0.38.0"
 edition = "2021"
 description = "Surface-syntax frontend for the adjudication framework's probabilistic-logic rulebooks. Lexes, parses, and lowers a domain-expert-readable DSL into a `logic-engine` KnowledgeBase. Dissolves ADJ46 awkwardness items A10 (rulebook syntax) and A4 (joint contributions syntactically distinct)."
 

--- a/code/packages/rust/adj-lang/src/adapter.rs
+++ b/code/packages/rust/adj-lang/src/adapter.rs
@@ -1211,6 +1211,15 @@ fn latex_math_to_expr_ast(expr: &MathExpr, source: &str) -> Result<ExprAst, Adap
                 Box::new(latex_math_to_expr_ast(arg, source)?),
             ))
         }
+        // `\hat{x}` / `\bar{x}` / `\vec{x}` / `\tilde{x}` / … — an accent over an operand. In
+        // arithmetic an accent is a NOTATIONAL decoration, not an operation: a model that writes a
+        // statistics formula like `\hat{p}(1 - \hat{p})` (estimated-variance numerator) or
+        // `\bar{x} - \bar{y}` (difference of means) means the accented symbol to carry the value of
+        // its operand — the hat/bar just marks it as an estimate/mean in prose. So we lower an
+        // `Accent` TRANSPARENTLY to its inner body: `\hat{a}(b - \hat{a})` computes as `a·(b − a)`,
+        // dimension and value flowing through the decoration unchanged. Pure adapter recognition:
+        // no engine, AST, or lowering change — the accent simply disappears at adapt time.
+        MathExpr::Accent { body, .. } => latex_math_to_expr_ast(body, source),
         MathExpr::Rel(_, _, _) => Err(AdapterError::UnsupportedLatexMath {
             source: source.to_string(),
             detail: "relation-valued LaTeX is only valid in `constrain latex`".into(),

--- a/code/packages/rust/adj-lang/src/lower.rs
+++ b/code/packages/rust/adj-lang/src/lower.rs
@@ -2428,6 +2428,36 @@ contributes 1000000 from answer == 60 to correct
     }
 
     #[test]
+    fn native_latex_accent_wrapped_operands_are_transparent() {
+        // `\hat{x}` / `\bar{x}` / … — an accent is a notational decoration, not an operation. A
+        // model that writes a statistics formula (`\hat{p}(1-\hat{p})`, `\bar{x} - \bar{y}`) means
+        // the accented symbol to carry its operand's value; the adapter lowers `Accent` transparently
+        // to its inner body. `\hat{a}(b - \hat{a})` with a=3, b=10 → 3*(10-3) = 21 (and the SAME `a`
+        // appears accented twice, confirming the decoration is stripped everywhere).
+        let h = crate::compile_and_decide(
+            "observe a(3)\n\
+             observe b(10)\n\
+             let answer = latex \"$\\hat{a}(b - \\hat{a})$\"\n\
+             prior 0.10 for correct\n\
+             contributes 1000000 from answer == 21 to correct\n\
+             ? correct\n",
+        )
+        .unwrap();
+        assert!(h.ranked[0].posterior > 0.99, "{h:?}");
+        // A different accent (`\bar`) over each operand of a sum: bar(x) + bar(y) with x=4, y=6 → 10.
+        let b = crate::compile_and_decide(
+            "observe x(4)\n\
+             observe y(6)\n\
+             let answer = latex \"$\\bar{x} + \\bar{y}$\"\n\
+             prior 0.10 for correct\n\
+             contributes 1000000 from answer == 10 to correct\n\
+             ? correct\n",
+        )
+        .unwrap();
+        assert!(b.ranked[0].posterior > 0.99, "{b:?}");
+    }
+
+    #[test]
     fn native_latex_symbolic_root_degree_is_rejected() {
         // `\sqrt[k]{x}` — a symbolic degree has no numeric value, so the reciprocal
         // exponent `1/k` cannot be formed. It must be rejected, not silently


### PR DESCRIPTION
## LaTeX consumer slice: accent-wrapped operands compute transparently

With the named-operator surface saturated (all rounding/sign/abs + 15 transcendentals + variadic
min/max/gcd/lcm + modulo, both macro and `\operatorname{…}` spellings), this is the **first
non-function LaTeX construct** consumed: **accents** (`\hat{x}`, `\bar{x}`, `\vec{x}`, `\tilde{x}`, …).

### Behaviour: transparent unwrap

In arithmetic an accent is a **notational decoration, not an operation**. A model that writes a
statistics formula like `\hat{p}(1 - \hat{p})` (estimated-variance numerator) or `\bar{x} - \bar{y}`
(difference of means) means the accented symbol to carry the value of its operand — the hat/bar just
marks it as an estimate/mean in prose. So the adapter lowers `MathExpr::Accent { body, .. }`
**transparently to its inner body**: `\hat{a}(b - \hat{a})` computes as `a·(b − a)`, with dimension
and value flowing through the decoration unchanged. Previously this was an `UnsupportedLatexMath`
error.

### Why probed empirically first

`\hat{x}` parses as `Accent { accent: "hat", body: Symbol("x") }` (confirmed with a throwaway probe,
deleted), and the adapter had no `Accent` arm — it fell through to the catch-all error. The new arm
sits just above the `Rel` arm and simply recurses into `body`, exactly like the ~15 existing
sub-node-recursing arms (Bin/Fenced/Call/Root); no new recursion-depth vector (AST depth is bounded
by the LaTeX parser's own limit).

### What changed

- **`adapter.rs`** — one arm: `MathExpr::Accent { body, .. } => latex_math_to_expr_ast(body, source)`.
- **`lower.rs`** — +1 e2e unit test: `\hat{a}(b − \hat{a})` = 21 (the same `a` appears accented
  twice, confirming the decoration is stripped everywhere); `\bar{x} + \bar{y}` = 10.
- Version 0.37.0 → 0.38.0; CHANGELOG prepended.

**Pure adapter recognition: no engine, AST, or lowering change.** `cargo test -p logic-engine -p
adj-lang -p adj-lang-cli -p adj-constraint-solver` green (117 adj-lang tests). Security review passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
