### PR TITLE
test(closure-emitter): CLOC12.158 PR3 — CodePrinter update-operator conformance port

### DIFF
--- a/code/packages/rust/closure-emitter/CHANGELOG.md
+++ b/code/packages/rust/closure-emitter/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to the `coding-adventures-closure-emitter` crate will be documented in this file.
 
+## [0.22.1] - 2026-07-02
+
+### Added — CLOC12.158 PR3: CodePrinter update-operator conformance port
+
+New upstream-cited test file `tests/upstream/code_printer_update_test.rs`
+(registered as the `upstream_code_printer_update` `[[test]]` target) porting
+the Closure Compiler `CodePrinterTest` update-operator (`++` / `--`) printing
+cases against `emit_update`. 14 active `#[test]`s, **0 `#[ignore]`** — prefix
+and postfix increment/decrement, a member operand (`a.b++`), bare printing
+under `!` / `typeof` (`!x++`, `typeof x++`), the `PREC_UNARY` precedence wraps
+(`(x++).y` member-object, `(++x)**2` exponent-base), and the token-fusion seams
+(`a- --b`, `a+ ++b`, `x++ +y`, `x-- -y`, plus the non-fusing `x++*y`). Inputs
+are hand-constructed typed AST; the bridge conversion of `++`/`--` (PR2,
+gap-159) is exercised separately in `javascript-parser`. Test-only change — no
+library behaviour change.
+
 ## [0.22.0] - 2026-07-02
 
 ### Added — CLOC12.158: emit `UpdateExpression` (`++` / `--`)

--- a/code/packages/rust/closure-emitter/Cargo.toml
+++ b/code/packages/rust/closure-emitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-emitter"
-version = "0.22.0"
+version = "0.22.1"
 edition = "2021"
 description = "JavaScript code emitter for the Closure Compiler clone. Per CLOC07's emit contract. Takes a finalized Program + sidecar and produces output JavaScript text + companion source map. Runs after every pass in the pipeline."
 
@@ -60,3 +60,7 @@ path = "tests/upstream/code_printer_arrow_test.rs"
 [[test]]
 name = "upstream_code_printer_template"
 path = "tests/upstream/code_printer_template_test.rs"
+
+[[test]]
+name = "upstream_code_printer_update"
+path = "tests/upstream/code_printer_update_test.rs"

--- a/code/packages/rust/closure-emitter/README.md
+++ b/code/packages/rust/closure-emitter/README.md
@@ -121,6 +121,12 @@ test-port convention. Each file isolates one printing area:
   `#[test]`s, no `#[ignore]` (gap-158 resolved in CLOC12.157 — the emitter is
   now newline-aware). Run with
   `cargo test --test upstream_code_printer_template`.
+- `code_printer_update_test.rs` — update-operator (`++` / `--`) printing:
+  prefix/postfix increment/decrement, a member operand (`a.b++`), bare printing
+  under `!` / `typeof`, the `PREC_UNARY` precedence wraps (`(x++).y`,
+  `(++x)**2`), and the token-fusion seams (`a- --b`, `a+ ++b`, `x++ +y`,
+  `x-- -y`, plus the non-fusing `x++*y`). 14 active `#[test]`s, no `#[ignore]`.
+  Run with `cargo test --test upstream_code_printer_update`.
 
 ## Dependency whitelist
 

--- a/code/packages/rust/closure-emitter/tests/upstream/ATTRIBUTION.md
+++ b/code/packages/rust/closure-emitter/tests/upstream/ATTRIBUTION.md
@@ -58,6 +58,23 @@ under the Apache License, Version 2.0:
       newline-aware; it and `raw_preserves_leading_and_trailing_newline` are
       now active.
 
+- `code_printer_update_test.rs`
+    - upstream: `test/com/google/javascript/jscomp/CodePrinterTest.java`
+      (the update-operator `++` / `--` printing cases — prefix/postfix ×
+      increment/decrement, precedence wraps, and the token-fusion seams)
+    - tracked commit: see `UPSTREAM_SHA`
+    - Isolates `emit_update` + the `PREC_UNARY` classification and the
+      `+`/`-` token-fusion seams that landed with
+      `Expression::UpdateExpression` (CLOC12.158). 14 active `#[test]`s and
+      **0 `#[ignore]`** — the emitter conforms to every covered shape
+      (prefix/postfix increment/decrement, member operand, bare under
+      `!` / `typeof`, member-object and exponent-base precedence wraps
+      `(x++).y` / `(++x)**2`, and the fusion seams `a- --b` / `a+ ++b` /
+      `x++ +y` / `x-- -y` plus the non-fusing `x++*y`). Inputs are
+      hand-constructed AST; the bridge conversion of `++`/`--`
+      (CLOC12.158 PR2, gap-159) is exercised separately in
+      `javascript-parser`.
+
 ## Translation notes
 
 Fourth port under CLOC12 (after `closure-pass-constant-fold` in

--- a/code/packages/rust/closure-emitter/tests/upstream/code_printer_update_test.rs
+++ b/code/packages/rust/closure-emitter/tests/upstream/code_printer_update_test.rs
@@ -1,0 +1,256 @@
+//! Ported from `CodePrinterTest.java` in `google/closure-compiler`,
+//! Apache-2.0. Upstream SHA: see `tests/upstream/UPSTREAM_SHA`.
+//!
+//! Translation policy: see
+//! `code/specs/CLOC12-upstream-test-suite-port.md`.
+//!
+//! # What this file covers
+//!
+//! Upstream `CodePrinterTest`'s **update-operator** printing cases — the
+//! `++` / `--` increment/decrement forms, in both prefix (`++x`, `--x`) and
+//! postfix (`x++`, `x--`) position. This is the eleventh CodePrinter port into
+//! `closure-emitter` (after core / declarations / trailing-comma / numbers /
+//! string-escape / ascii-escape / object-literal / function-expression /
+//! arrow-function / template) and isolates `emit_update` + the `PREC_UNARY`
+//! classification + the token-fusion seams that landed with
+//! `Expression::UpdateExpression` (CLOC12.158).
+//!
+//! ## How the emitter prints an update expression (recap)
+//!
+//! ```text
+//!   ++x     prefix increment    → ++x
+//!   x++     postfix increment   → x++
+//!   --x     prefix decrement    → --x
+//!   x--     postfix decrement   → x--
+//! ```
+//!
+//! An update is `PREC_UNARY`: loose enough to be parenthesised as an
+//! exponentiation base (`(++x)**2` — a bare `++x**2` is a syntax error) and as
+//! a member/call object (`(x++).y`, since `x++` is not a valid member base),
+//! yet tight enough to print **bare** under a `!` / `typeof` parent (`!x++`,
+//! `typeof x++`).
+//!
+//! ## Token-fusion seams
+//!
+//! `++`/`--` are maximal-munch tokens, so adjacency to a `+`/`-` must be
+//! guarded or the pair mis-tokenises into a *different* program:
+//!
+//! ```text
+//!   a - (--b)   must print   a- --b   (never a---b = (a--)-b)
+//!   a + (++b)   must print   a+ ++b   (never a+++b = (a++)+b)
+//!   (x++) + y   must print   x++ +y   (the trailing + of x++ meets the + op)
+//! ```
+//!
+//! The binary/unary emitters handle these: `arg_starts_with_sign` reports a
+//! prefix update's leading sign (right-seam), and the binary emitter's
+//! output-tail check catches a postfix update ending in a sign (left-seam).
+//!
+//! ## Note on hand-constructed inputs
+//!
+//! These assertions build typed-AST inputs directly (upstream lex/parses
+//! source). The emitter is the unit under test here — the bridge conversion of
+//! `++`/`--` (CLOC12.158 PR2) is exercised separately in `javascript-parser`.
+
+use coding_adventures_closure_emitter::{emit, EmitOptions};
+use coding_adventures_correlation_vector::CVLog;
+use coding_adventures_javascript_ast::{
+    BinaryExpression, BinaryOperator, Expression, ExpressionStatement, Identifier, MemberExpression,
+    NumericLiteral, Program, ProgramItem, SourceType, Statement, UnaryExpression, UnaryOperator,
+    UpdateExpression, UpdateOperator,
+};
+use coding_adventures_javascript_tokens::EsVersion;
+use coding_adventures_type_sidecar::Sidecar;
+
+// =====================================================================
+// Test-support helpers
+// =====================================================================
+
+fn ident(name: &str) -> Expression {
+    Expression::Identifier(Identifier { cv: None, name: name.to_string() })
+}
+
+fn num(v: f64) -> Expression {
+    Expression::NumericLiteral(NumericLiteral { cv: None, value: v, raw: format!("{}", v as i64) })
+}
+
+fn update(op: UpdateOperator, prefix: bool, arg: Expression) -> Expression {
+    Expression::UpdateExpression(UpdateExpression {
+        cv: None,
+        operator: op,
+        prefix,
+        argument: Box::new(arg),
+    })
+}
+
+fn binary(op: BinaryOperator, left: Expression, right: Expression) -> Expression {
+    Expression::BinaryExpression(BinaryExpression {
+        cv: None,
+        operator: op,
+        left: Box::new(left),
+        right: Box::new(right),
+    })
+}
+
+fn member(object: Expression, property: &str) -> Expression {
+    Expression::MemberExpression(MemberExpression {
+        cv: None,
+        object: Box::new(object),
+        property: Box::new(ident(property)),
+        computed: false,
+    })
+}
+
+fn stmt(expr: Expression) -> ProgramItem {
+    ProgramItem::Statement(Statement::expression_statement(ExpressionStatement {
+        cv: None,
+        expression: expr,
+    }))
+}
+
+fn emit_default(expr: Expression) -> String {
+    let prog =
+        Program::new_untraced(EsVersion::Es2025, SourceType::Module).with_body(vec![stmt(expr)]);
+    let sidecar = Sidecar::new();
+    let mut cv = CVLog::new(false);
+    emit(&prog, &sidecar, &mut cv, &EmitOptions::default())
+        .expect("emit failed")
+        .code
+}
+
+/// Upstream `assertPrint(input, expected)` reshaped: emit the expression as a
+/// single-statement program and assert the emitted code equals `expected`.
+fn assert_emits(expr: Expression, expected: &str) {
+    let code = emit_default(expr);
+    assert_eq!(
+        code, expected,
+        "update-operator emit output did not match\n  actual:   {:?}\n  expected: {:?}",
+        code, expected
+    );
+}
+
+// =====================================================================
+// Active — the four core shapes
+// =====================================================================
+
+/// `assertPrintSame("++x")` — prefix increment prints operator-then-operand.
+#[test]
+fn prefix_increment() {
+    assert_emits(update(UpdateOperator::Increment, true, ident("x")), "++x;");
+}
+
+/// `assertPrintSame("x++")` — postfix increment prints operand-then-operator.
+#[test]
+fn postfix_increment() {
+    assert_emits(update(UpdateOperator::Increment, false, ident("x")), "x++;");
+}
+
+/// `assertPrintSame("--x")` — prefix decrement.
+#[test]
+fn prefix_decrement() {
+    assert_emits(update(UpdateOperator::Decrement, true, ident("x")), "--x;");
+}
+
+/// `assertPrintSame("x--")` — postfix decrement.
+#[test]
+fn postfix_decrement() {
+    assert_emits(update(UpdateOperator::Decrement, false, ident("x")), "x--;");
+}
+
+/// A member operand: `a.b++` — the postfix operator follows the whole member.
+#[test]
+fn postfix_increment_on_member() {
+    assert_emits(update(UpdateOperator::Increment, false, member(ident("a"), "b")), "a.b++;");
+}
+
+// =====================================================================
+// Active — precedence: an update is PREC_UNARY
+// =====================================================================
+
+/// `assertPrintSame("!x++")` — a `!` (unary) parent prints a postfix update
+/// bare (`!(x++)` needs no parens).
+#[test]
+fn not_of_postfix_increment_is_bare() {
+    let e = Expression::UnaryExpression(UnaryExpression {
+        cv: None,
+        operator: UnaryOperator::Not,
+        prefix: true,
+        argument: Box::new(update(UpdateOperator::Increment, false, ident("x"))),
+    });
+    assert_emits(e, "!x++;");
+}
+
+/// `assertPrintSame("typeof x++")` — a `typeof` parent keeps its space and
+/// prints the update bare.
+#[test]
+fn typeof_of_postfix_increment_is_bare() {
+    let e = Expression::UnaryExpression(UnaryExpression {
+        cv: None,
+        operator: UnaryOperator::TypeOf,
+        prefix: true,
+        argument: Box::new(update(UpdateOperator::Increment, false, ident("x"))),
+    });
+    assert_emits(e, "typeof x++;");
+}
+
+/// A postfix update as a member-access object is parenthesised — `x++` is not
+/// a valid `MemberExpression` object, so `(x++).y`.
+#[test]
+fn postfix_update_as_member_object_is_wrapped() {
+    assert_emits(
+        member(update(UpdateOperator::Increment, false, ident("x")), "y"),
+        "(x++).y;",
+    );
+}
+
+/// A prefix update as an exponentiation base is parenthesised — a bare
+/// `++x**2` is a syntax error, so `(++x)**2`.
+#[test]
+fn prefix_update_as_exponent_base_is_wrapped() {
+    let e = binary(BinaryOperator::Exp, update(UpdateOperator::Increment, true, ident("x")), num(2.0));
+    assert_emits(e, "(++x)**2;");
+}
+
+// =====================================================================
+// Active — token-fusion seams
+// =====================================================================
+
+/// `a - (--b)` must print `a- --b`, never `a---b` (which JS reparses as
+/// `(a--)-b`).
+#[test]
+fn prefix_decrement_after_minus_needs_space() {
+    let e = binary(BinaryOperator::Sub, ident("a"), update(UpdateOperator::Decrement, true, ident("b")));
+    assert_emits(e, "a- --b;");
+}
+
+/// `a + (++b)` must print `a+ ++b`, never `a+++b` (which JS reparses as
+/// `(a++)+b`).
+#[test]
+fn prefix_increment_after_plus_needs_space() {
+    let e = binary(BinaryOperator::Add, ident("a"), update(UpdateOperator::Increment, true, ident("b")));
+    assert_emits(e, "a+ ++b;");
+}
+
+/// `(x++) + y` — the postfix `++` leaves the output ending in `+`, so the
+/// following binary `+` needs a left-seam space (`x++ +y`).
+#[test]
+fn postfix_increment_before_plus_needs_space() {
+    let e = binary(BinaryOperator::Add, update(UpdateOperator::Increment, false, ident("x")), ident("y"));
+    assert_emits(e, "x++ +y;");
+}
+
+/// A postfix update as a plain `+` left operand with a non-sign right operand
+/// still needs the left-seam space (`x++ *y` does NOT, but `x++ +y` does) —
+/// pin the `-` variant too: `x-- -y`.
+#[test]
+fn postfix_decrement_before_minus_needs_space() {
+    let e = binary(BinaryOperator::Sub, update(UpdateOperator::Decrement, false, ident("x")), ident("y"));
+    assert_emits(e, "x-- -y;");
+}
+
+/// A `*` seam does NOT fuse (`x++*y` is unambiguous), so no space is added —
+/// confirms the guard is scoped to `+`/`-` and does not over-space.
+#[test]
+fn postfix_increment_before_star_no_space() {
+    let e = binary(BinaryOperator::Mul, update(UpdateOperator::Increment, false, ident("x")), ident("y"));
+    assert_emits(e, "x++*y;");
+}

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -1685,6 +1685,13 @@ WHITESPACE_ONLY. 6 bridge tests + a closurec e2e diff fixture
 additive-with-unary-sign invariant (`a + +b`, `a - -b` stay binary, never
 mis-read as `++`) is pinned by a bridge test.
 
-The **PR3 emit conformance port** — the remaining follow-up — ports upstream
-CodePrinter's update-operator cases (postfix/prefix, precedence, fusion) into
-`closure-emitter/tests/upstream/`.
+The **PR3 emit conformance port** (closure-emitter 0.22.1, CLOC12.158 PR3)
+ports upstream CodePrinter's update-operator cases into
+`closure-emitter/tests/upstream/code_printer_update_test.rs` (registered as
+the `upstream_code_printer_update` `[[test]]` target): prefix/postfix
+increment/decrement, a member operand (`a.b++`), bare printing under `!` /
+`typeof`, the `PREC_UNARY` precedence wraps (`(x++).y`, `(++x)**2`), and the
+`+`/`-` token-fusion seams (`a- --b`, `a+ ++b`, `x++ +y`, `x-- -y`, plus the
+non-fusing `x++*y`). 14 active `#[test]`s, no `#[ignore]` — the emitter
+conforms to every covered shape. This completes the CLOC12.158
+`UpdateExpression` three-PR arc (node+emit → bridge → conformance).


### PR DESCRIPTION
## CLOC12.158 PR3 — CodePrinter update-operator conformance port

Third and final PR of the CLOC12.158 `UpdateExpression` (`++`/`--`) arc:

- **PR1** ([#7417](https://github.com/adhithyan15/coding-adventures/pull/7417)) — atomic node + `emit_update` + all pass match-arms
- **PR2** ([#7421](https://github.com/adhithyan15/coding-adventures/pull/7421)) — bridge-enable `++`/`--` → `UpdateExpression` (closes gap-159)
- **PR3** (this) — CodePrinter emit conformance port

### What this adds

A new upstream-cited test file `closure-emitter/tests/upstream/code_printer_update_test.rs` (registered as the `upstream_code_printer_update` `[[test]]` target), porting the Google Closure Compiler `CodePrinterTest` update-operator printing cases against `emit_update`. **14 active `#[test]`s, 0 `#[ignore]`**, all passing:

- prefix/postfix increment & decrement (`++x`, `x++`, `--x`, `x--`)
- a member operand (`a.b++`)
- bare printing under a `!` / `typeof` parent (`!x++`, `typeof x++`)
- the `PREC_UNARY` precedence wraps: member-object `(x++).y` and exponent-base `(++x)**2` (a bare `++x**2` is a syntax error)
- the `+`/`-` token-fusion seams that must not mis-tokenise: `a- --b` (never `a---b` = `(a--)-b`), `a+ ++b` (never `a+++b` = `(a++)+b`), `x++ +y`, `x-- -y`, plus the non-fusing control `x++*y`

Inputs are hand-constructed typed AST, mirroring the merged template/arrow ports — the emitter is the unit under test. The bridge conversion of `++`/`--` (PR2, gap-159) is exercised separately in `javascript-parser`.

### Docs
- closure-emitter `0.22.0` → `0.22.1`
- ATTRIBUTION entry, CHANGELOG `0.22.1` section, README upstream-ports list
- `CLOC12-gaps.md` gap-159 PR3 paragraph marks the three-PR arc complete

**Test-only change — no library behaviour change.**

### Verification
- `cargo test -p coding-adventures-closure-emitter --test upstream_code_printer_update` → 14 passed
- Full `cargo test -p coding-adventures-closure-emitter` → all suites green
- Inline security review → PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)