### PR TITLE
[codex] Wire XAML Anki file intents

### DIFF
--- a/code/packages/rust/mosaic-emit-xaml/CHANGELOG.md
+++ b/code/packages/rust/mosaic-emit-xaml/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased] — VC2-xaml Grid: WinUI value translation + nested-For + per-column widths
 
+### Added - XAML host intent extension point
+
+Generated WinUI project shells now preserve structured `HostIntent` values from
+optional `MosaicHost.HandleEvent` results and can delegate them to an
+app-provided asynchronous `MosaicHost.HandleHostIntent(Window, Component,
+HostIntent)` method. This lets app packages implement native file pickers or
+other platform-owned workflows without hand-patching generated `MainWindow`
+code.
+
 ### Changed - XAML host build script reliability
 
 Generated `build.ps1` drivers now resolve `dotnet` from PATH or the standard

--- a/code/packages/rust/mosaic-emit-xaml/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-xaml/src/pipeline.rs
@@ -3218,10 +3218,10 @@ fn emit_main_window_cs(
                      /// Receives Mosaic Dispatch events. Replace each arm's body with the\n    \
                      /// business logic that should run when that event fires.\n    \
                      /// </summary>\n    \
-                     private void OnComponentDispatch(object? sender, {name}Event ev)\n    \
+                     private async void OnComponentDispatch(object? sender, {name}Event ev)\n    \
                      {{\n        \
                          var component = sender as {name};\n        \
-                         var hostStatus = component is not null ? TryHandleMosaicHostEvent(component, ev) : null;\n        \
+                         var hostStatus = component is not null ? await TryHandleMosaicHostEvent(component, ev) : null;\n        \
                          if (hostStatus is not null) {{ this.StatusText.Text = hostStatus; return; }}\n        \
                          {dispatch_match}\n    \
                      }}\n\
@@ -3262,9 +3262,9 @@ fn emit_main_window_cs(
                      /// Receives Mosaic Dispatch events. Replace each arm's body with the\n    \
                      /// business logic that should run when that event fires.\n    \
                      /// </summary>\n    \
-                     private void OnComponentDispatch(object? sender, {name}Event ev)\n    \
+                     private async void OnComponentDispatch(object? sender, {name}Event ev)\n    \
                      {{\n        \
-                         var hostStatus = TryHandleMosaicHostEvent(this.Component, ev);\n        \
+                         var hostStatus = await TryHandleMosaicHostEvent(this.Component, ev);\n        \
                          if (hostStatus is not null) {{ this.StatusText.Text = hostStatus; return; }}\n        \
                          {dispatch_match}\n    \
                      }}\n\
@@ -3300,15 +3300,21 @@ fn build_optional_host_helpers(name: &str, namespace: &str) -> String {
              }}\n    \
          }}\n\
          \n    \
-         private string? TryHandleMosaicHostEvent({name} component, {name}Event ev)\n    \
+         private async System.Threading.Tasks.Task<string?> TryHandleMosaicHostEvent({name} component, {name}Event ev)\n    \
          {{\n        \
              var method = FindMosaicHostMethod(\"HandleEvent\", typeof({name}), typeof({name}Event));\n        \
              if (method is null) {{ return null; }}\n        \
              try\n        \
              {{\n            \
-                 return CoerceMosaicHostResult(\n                \
-                     method.Invoke(null, new object[] {{ component, ev }}),\n                \
-                     $\"Status: Mosaic host handled {{ev.MosaicName}}\");\n        \
+                 var result = await UnwrapMosaicHostResultAsync(method.Invoke(null, new object[] {{ component, ev }}));\n            \
+                 var status = CoerceMosaicHostResult(result, $\"Status: Mosaic host handled {{ev.MosaicName}}\");\n            \
+                 var intent = GetMosaicHostIntent(result);\n            \
+                 if (intent is not null)\n            \
+                 {{\n                \
+                     var intentStatus = await TryHandleMosaicHostIntent(component, intent);\n                \
+                     if (intentStatus is not null) {{ return intentStatus; }}\n            \
+                 }}\n            \
+                 return status;\n        \
              }}\n        \
              catch (System.Reflection.TargetInvocationException ex) when (ex.InnerException is not null)\n        \
              {{\n            \
@@ -3318,6 +3324,45 @@ fn build_optional_host_helpers(name: &str, namespace: &str) -> String {
              {{\n            \
                  return $\"Mosaic host failed: {{ex.GetType().Name}}: {{ex.Message}}\";\n        \
              }}\n    \
+         }}\n\
+         \n    \
+         private async System.Threading.Tasks.Task<string?> TryHandleMosaicHostIntent({name} component, object hostIntent)\n    \
+         {{\n        \
+             var hostType = FindMosaicHostType();\n        \
+             if (hostType is null) {{ return null; }}\n        \
+             var method = FindMosaicHostIntentMethod(hostType, hostIntent.GetType(), typeof({name}));\n        \
+             if (method is null) {{ return null; }}\n        \
+             try\n        \
+             {{\n            \
+                 var result = await UnwrapMosaicHostResultAsync(method.Invoke(null, new object[] {{ this, component, hostIntent }}));\n            \
+                 return CoerceMosaicHostResult(result, \"Status: Mosaic host handled host intent\");\n        \
+             }}\n        \
+             catch (System.Reflection.TargetInvocationException ex) when (ex.InnerException is not null)\n        \
+             {{\n            \
+                 return $\"Mosaic host intent failed: {{ex.InnerException.GetType().Name}}: {{ex.InnerException.Message}}\";\n        \
+             }}\n        \
+             catch (System.Exception ex)\n        \
+             {{\n            \
+                 return $\"Mosaic host intent failed: {{ex.GetType().Name}}: {{ex.Message}}\";\n        \
+             }}\n    \
+         }}\n\
+         \n    \
+         private static async System.Threading.Tasks.Task<object?> UnwrapMosaicHostResultAsync(object? result)\n    \
+         {{\n        \
+             if (result is System.Threading.Tasks.Task task)\n        \
+             {{\n            \
+                 await task.ConfigureAwait(true);\n            \
+                 return task.GetType().GetProperty(\"Result\")?.GetValue(task);\n        \
+             }}\n        \
+             return result;\n    \
+         }}\n\
+         \n    \
+         private static object? GetMosaicHostIntent(object? result)\n    \
+         {{\n        \
+             if (result is null || result is string) {{ return null; }}\n        \
+             return result.GetType().GetProperty(\n            \
+                 \"HostIntent\",\n            \
+                 System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public)?.GetValue(result);\n    \
          }}\n\
          \n    \
          private static string CoerceMosaicHostResult(object? result, string fallbackStatus)\n    \
@@ -3330,9 +3375,14 @@ fn build_optional_host_helpers(name: &str, namespace: &str) -> String {
              return statusProperty?.GetValue(result) as string ?? fallbackStatus;\n    \
          }}\n\
          \n    \
+         private static System.Type? FindMosaicHostType()\n    \
+         {{\n        \
+             return System.Type.GetType(\"{host_type}\");\n    \
+         }}\n\
+         \n    \
          private static System.Reflection.MethodInfo? FindMosaicHostMethod(string methodName, params System.Type[] parameterTypes)\n    \
          {{\n        \
-             var hostType = System.Type.GetType(\"{host_type}\");\n        \
+             var hostType = FindMosaicHostType();\n        \
              if (hostType is null) {{ return null; }}\n        \
              return hostType.GetMethod(\n            \
                  methodName,\n            \
@@ -3340,6 +3390,24 @@ fn build_optional_host_helpers(name: &str, namespace: &str) -> String {
                  binder: null,\n            \
                  types: parameterTypes,\n            \
                  modifiers: null);\n    \
+         }}\n\
+         \n    \
+         private static System.Reflection.MethodInfo? FindMosaicHostIntentMethod(\n        \
+             System.Type hostType,\n        \
+             System.Type hostIntentType,\n        \
+             System.Type componentType)\n    \
+         {{\n        \
+             foreach (var method in hostType.GetMethods(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static))\n        \
+             {{\n            \
+                 if (method.Name != \"HandleHostIntent\") {{ continue; }}\n            \
+                 var parameters = method.GetParameters();\n            \
+                 if (parameters.Length != 3) {{ continue; }}\n            \
+                 if (!parameters[0].ParameterType.IsAssignableFrom(typeof(Window))) {{ continue; }}\n            \
+                 if (!parameters[1].ParameterType.IsAssignableFrom(componentType)) {{ continue; }}\n            \
+                 if (!parameters[2].ParameterType.IsAssignableFrom(hostIntentType)) {{ continue; }}\n            \
+                 return method;\n        \
+             }}\n        \
+             return null;\n    \
          }}"
     )
 }
@@ -8690,6 +8758,13 @@ mod tests {
         assert!(p.main_window_cs.contains("TryApplyMosaicHostProps"));
         assert!(p.main_window_cs.contains("CoerceMosaicHostResult"));
         assert!(p.main_window_cs.contains("FindMosaicHostMethod"));
+        assert!(p
+            .main_window_cs
+            .contains("private async void OnComponentDispatch"));
+        assert!(p.main_window_cs.contains("await TryHandleMosaicHostEvent"));
+        assert!(p.main_window_cs.contains("TryHandleMosaicHostIntent"));
+        assert!(p.main_window_cs.contains("UnwrapMosaicHostResultAsync"));
+        assert!(p.main_window_cs.contains("HandleHostIntent"));
         assert!(p.main_window_cs.contains("Mosaic.Generated.MosaicHost"));
         // MainWindow constructor pre-populates the Greeting slot stub.
         assert!(p.main_window_cs.contains("Greeting"));

--- a/code/programs/mosaic/engram-app/CHANGELOG.md
+++ b/code/programs/mosaic/engram-app/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Wired the generated XAML Engram shell to handle Anki import/export
+  `hostIntent` payloads with WinUI file pickers and the shared `engram-capi`
+  APKG import/export functions, so package files round-trip through the native
+  Rust core instead of stopping at status text.
 - Persisted Engram Mosaic SwiftUI, Qt, XAML, Flutter, and Compose native host
   snapshots through `engram-capi`, matching the web/Electron snapshot behavior
   with an `ENGRAM_SNAPSHOT_PATH` override and a shared home-directory fallback.

--- a/code/programs/mosaic/engram-app/README.md
+++ b/code/programs/mosaic/engram-app/README.md
@@ -50,6 +50,9 @@ editing, and save/delete/cancel controls.
   `host/xaml/MosaicHost.cs` implements it with `engram-capi`, hydrating the
   generated WinUI dependency properties from the shared Rust facade and routing
   generated Mosaic event envelopes back into the same core.
+- The XAML host also handles Engram's Anki import/export `hostIntent` payloads
+  with WinUI file pickers, merging selected `.apkg` / `.colpkg` packages through
+  the native C ABI and saving current collection state back to `.apkg`.
 - The generated SwiftUI project shell has an optional `MosaicHost` hook.
   Engram's `host/swiftui/MosaicHost.swift` implements it with `engram-capi`
   through a staged `CEngram` Swift module, hydrating SwiftUI props and routing

--- a/code/programs/mosaic/engram-app/host/xaml/MosaicHost.cs
+++ b/code/programs/mosaic/engram-app/host/xaml/MosaicHost.cs
@@ -6,6 +6,12 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml;
+using Windows.Storage;
+using Windows.Storage.Pickers;
+using Windows.Storage.Streams;
+using WinRT.Interop;
 
 namespace Mosaic.Generated;
 
@@ -30,6 +36,19 @@ public static class MosaicHost
     static MosaicHost()
     {
         AppDomain.CurrentDomain.ProcessExit += (_, _) => FreeSession();
+    }
+
+    public static async Task<MosaicHostResult> HandleHostIntent(
+        Window owner,
+        EngramApp component,
+        MosaicHostIntent hostIntent)
+    {
+        return hostIntent.Type switch
+        {
+            "importAnki" => await ImportAnkiPackage(owner, component, hostIntent),
+            "exportAnki" => await ExportAnkiPackage(owner, hostIntent),
+            _ => new MosaicHostResult($"Status: host intent captured: {hostIntent.Type}", hostIntent),
+        };
     }
 
     public static MosaicHostResult ApplyProps(EngramApp component)
@@ -241,6 +260,210 @@ public static class MosaicHost
         return builder.ToString();
     }
 
+    private static async Task<MosaicHostResult> ImportAnkiPackage(
+        Window owner,
+        EngramApp component,
+        MosaicHostIntent hostIntent)
+    {
+        var file = await PickAnkiImportFile(owner, hostIntent);
+        if (file is null)
+        {
+            return new MosaicHostResult("Status: Anki import cancelled", hostIntent);
+        }
+
+        var buffer = await FileIO.ReadBufferAsync(file);
+        var data = BufferToBytes(buffer);
+
+        lock (SessionLock)
+        {
+            if (!TryGetSession(out var session, out var unavailable))
+            {
+                return HostUnavailable(unavailable);
+            }
+
+            try
+            {
+                var json = Native.TakeString(
+                    Native.eg_merge_anki_apkg(session, data, (UIntPtr)data.LongLength));
+                using var document = JsonDocument.Parse(json);
+                if (IsErrorRoot(document.RootElement))
+                {
+                    return new MosaicHostResult(
+                        $"Status: Anki import failed: {JsonString(document.RootElement, "error", "unknown error")}",
+                        hostIntent);
+                }
+
+                PersistSnapshot(session);
+                var propsJson = Native.TakeString(
+                    Native.eg_engram_app_props(session, CurrentDeckId(), CurrentTimeMillis()));
+                return ApplyPropsFromJson(
+                    component,
+                    propsJson,
+                    $"Status: Imported Anki package {file.Name}");
+            }
+            catch (Exception ex) when (IsNativeAvailabilityFailure(ex))
+            {
+                LoadError = Describe(ex);
+                Session = IntPtr.Zero;
+                return HostUnavailable(LoadError);
+            }
+        }
+    }
+
+    private static async Task<MosaicHostResult> ExportAnkiPackage(
+        Window owner,
+        MosaicHostIntent hostIntent)
+    {
+        var file = await PickAnkiExportFile(owner, hostIntent);
+        if (file is null)
+        {
+            return new MosaicHostResult("Status: Anki export cancelled", hostIntent);
+        }
+
+        byte[] data;
+        lock (SessionLock)
+        {
+            if (!TryGetSession(out var session, out var unavailable))
+            {
+                return HostUnavailable(unavailable);
+            }
+
+            try
+            {
+                var json = Native.TakeString(Native.eg_export_anki_apkg(session));
+                using var document = JsonDocument.Parse(json);
+                if (IsErrorRoot(document.RootElement))
+                {
+                    return new MosaicHostResult(
+                        $"Status: Anki export failed: {JsonString(document.RootElement, "error", "unknown error")}",
+                        hostIntent);
+                }
+
+                data = JsonByteArray(document.RootElement, "apkg");
+            }
+            catch (Exception ex) when (IsNativeAvailabilityFailure(ex))
+            {
+                LoadError = Describe(ex);
+                Session = IntPtr.Zero;
+                return HostUnavailable(LoadError);
+            }
+        }
+
+        await FileIO.WriteBytesAsync(file, data);
+        return new MosaicHostResult($"Status: Exported Anki package {file.Name}");
+    }
+
+    private static async Task<StorageFile?> PickAnkiImportFile(Window owner, MosaicHostIntent hostIntent)
+    {
+        var picker = new FileOpenPicker
+        {
+            SuggestedStartLocation = PickerLocationId.DocumentsLibrary,
+        };
+        foreach (var extension in HostIntentExtensions(
+            hostIntent,
+            "accept",
+            new List<string> { ".apkg", ".colpkg" }))
+        {
+            picker.FileTypeFilter.Add(extension);
+        }
+        InitializeWithWindow.Initialize(picker, WindowNative.GetWindowHandle(owner));
+        return await picker.PickSingleFileAsync();
+    }
+
+    private static async Task<StorageFile?> PickAnkiExportFile(Window owner, MosaicHostIntent hostIntent)
+    {
+        var picker = new FileSavePicker
+        {
+            SuggestedStartLocation = PickerLocationId.DocumentsLibrary,
+            SuggestedFileName = SuggestedAnkiFileName(hostIntent),
+        };
+        picker.FileTypeChoices.Add(
+            "Anki package",
+            HostIntentExtensions(hostIntent, "extensions", new List<string> { ".apkg" }));
+        InitializeWithWindow.Initialize(picker, WindowNative.GetWindowHandle(owner));
+        return await picker.PickSaveFileAsync();
+    }
+
+    private static IList<string> HostIntentExtensions(
+        MosaicHostIntent hostIntent,
+        string property,
+        IList<string> fallback)
+    {
+        try
+        {
+            using var document = JsonDocument.Parse(hostIntent.Json);
+            if (!document.RootElement.TryGetProperty(property, out var array)
+                || array.ValueKind != JsonValueKind.Array)
+            {
+                return fallback;
+            }
+
+            var values = new List<string>();
+            foreach (var item in array.EnumerateArray())
+            {
+                if (item.ValueKind != JsonValueKind.String)
+                {
+                    continue;
+                }
+                var extension = item.GetString();
+                if (string.IsNullOrWhiteSpace(extension))
+                {
+                    continue;
+                }
+                values.Add(extension.StartsWith('.') ? extension : $".{extension}");
+            }
+            return values.Count == 0 ? fallback : values;
+        }
+        catch (JsonException)
+        {
+            return fallback;
+        }
+    }
+
+    private static string SuggestedAnkiFileName(MosaicHostIntent hostIntent)
+    {
+        var name = "engram-collection";
+        try
+        {
+            using var document = JsonDocument.Parse(hostIntent.Json);
+            name = JsonString(document.RootElement, "deckId", name);
+        }
+        catch (JsonException)
+        {
+        }
+
+        foreach (var ch in Path.GetInvalidFileNameChars())
+        {
+            name = name.Replace(ch, '-');
+        }
+        return string.IsNullOrWhiteSpace(name) ? "engram-collection" : name;
+    }
+
+    private static byte[] BufferToBytes(IBuffer buffer)
+    {
+        var data = new byte[checked((int)buffer.Length)];
+        using var reader = DataReader.FromBuffer(buffer);
+        reader.ReadBytes(data);
+        return data;
+    }
+
+    private static byte[] JsonByteArray(JsonElement root, string property)
+    {
+        if (!root.TryGetProperty(property, out var array) || array.ValueKind != JsonValueKind.Array)
+        {
+            throw new JsonException($"missing byte array property '{property}'");
+        }
+
+        var bytes = new byte[array.GetArrayLength()];
+        var index = 0;
+        foreach (var item in array.EnumerateArray())
+        {
+            bytes[index] = item.GetByte();
+            index += 1;
+        }
+        return bytes;
+    }
+
     private static string CurrentDeckId()
     {
         return Environment.GetEnvironmentVariable("ENGRAM_DECK_ID") ?? "";
@@ -431,6 +654,15 @@ public static class MosaicHost
             [MarshalAs(UnmanagedType.LPUTF8Str)] string eventJson,
             [MarshalAs(UnmanagedType.LPUTF8Str)] string deckId,
             ulong now);
+
+        [DllImport(NativeLibrary, EntryPoint = "eg_export_anki_apkg", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern IntPtr eg_export_anki_apkg(IntPtr session);
+
+        [DllImport(NativeLibrary, EntryPoint = "eg_merge_anki_apkg", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern IntPtr eg_merge_anki_apkg(
+            IntPtr session,
+            [In] byte[] data,
+            UIntPtr dataLen);
 
         internal static string TakeString(IntPtr value)
         {

--- a/code/programs/mosaic/engram-app/tests/package_compiles.rs
+++ b/code/programs/mosaic/engram-app/tests/package_compiles.rs
@@ -2275,6 +2275,11 @@ fn native_project_shells_expose_engram_host_contract() {
         .expect("MainWindow.xaml.cs");
     assert_contains(&xaml_main_window, "TryApplyMosaicHostProps");
     assert_contains(&xaml_main_window, "CoerceMosaicHostResult");
+    assert_contains(&xaml_main_window, "private async void OnComponentDispatch");
+    assert_contains(&xaml_main_window, "await TryHandleMosaicHostEvent");
+    assert_contains(&xaml_main_window, "TryHandleMosaicHostIntent");
+    assert_contains(&xaml_main_window, "UnwrapMosaicHostResultAsync");
+    assert_contains(&xaml_main_window, "HandleHostIntent");
     assert_contains(
         &xaml_main_window,
         "FindMosaicHostMethod(\"ApplyProps\", typeof(EngramApp))",
@@ -2482,6 +2487,13 @@ fn source_tree_has_expected_shape() {
     assert_contains(&xaml_host, "public sealed record MosaicHostResult");
     assert_contains(&xaml_host, "HostIntentReceived");
     assert_contains(&xaml_host, "LastHostIntent");
+    assert_contains(&xaml_host, "HandleHostIntent");
+    assert_contains(&xaml_host, "FileOpenPicker");
+    assert_contains(&xaml_host, "FileSavePicker");
+    assert_contains(&xaml_host, "ImportAnkiPackage");
+    assert_contains(&xaml_host, "ExportAnkiPackage");
+    assert_contains(&xaml_host, "eg_merge_anki_apkg");
+    assert_contains(&xaml_host, "eg_export_anki_apkg");
     assert_contains(&xaml_host, "private static IntPtr Session = IntPtr.Zero");
     assert_contains(&xaml_host, "TryGetSession");
     assert_contains(&xaml_host, "Engram native host unavailable");


### PR DESCRIPTION
## Summary

- Teach generated Mosaic XAML project shells to preserve structured `HostIntent` results and delegate them to an optional async `MosaicHost.HandleHostIntent(...)` extension point.
- Implement Engram XAML Anki import/export host intents with WinUI file pickers and the existing `engram-capi` APKG merge/export APIs.
- Add package/emitter regression assertions and docs/changelog notes for the XAML native file flow.

## Validation

- `cargo test -p mosaic-emit-xaml -- --nocapture`
- `cargo test --manifest-path code/programs/mosaic/engram-app/Cargo.toml -- --nocapture`
- `./scripts/build-all.ps1` from `code/programs/mosaic/engram-app`
- `& 'C:\Program Files\dotnet\dotnet.exe' build .\EngramApp.csproj -p:Platform=x64` from generated XAML output
