### PR TITLE
feat(lang-full): AL-multidim-real — ALGOL 60 2D real arrays on all 7 backends

### DIFF
--- a/code/packages/rust/algol-iir-compiler/CHANGELOG.md
+++ b/code/packages/rust/algol-iir-compiler/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 0.24.0 — 2026-07-02 — AL-multidim-real: f64 multidim array elements (LANG-FULL)
+
+Proves that the N-dimensional array machinery added in 0.23.0 carries **`real`
+(f64) elements**, not just integers.  When AL-multidim first landed, f64
+multidim elements were flagged as a follow-up; this closes that gap.
+
+No compiler code changed — `emit_array_decl` already threads the declared
+`elem_ty` (here `ScalarType::Real`) into `declare_array`, and `array_get`/
+`array_set` ride the same 8-byte slots for f64 as for i64.  Only the flat-index
+computation is multidim; the element storage is identical to a 1-D `real array`.
+
+Two new unit tests (108 total):
+- `two_d_real_array_roundtrips` — store four doubles into `M[1:2, 1:2]`, read
+  `M[2,2]` back = 4.5
+- `two_d_real_array_sum` — sum all four cells (1.5+2.5+3.5+4.5) = 12.0 via the
+  f64 `add` path over multidim reads
+
+The 7-backend proof lives in `lang-aot` `lang_matrix.rs` (fractional cells
+summing to 42.0, floored via `entier`).
+
 ## 0.23.0 — 2026-07-01 — AL-multidim: N-dimensional integer arrays (LANG-FULL)
 
 **`ArrayDim` struct** (new): per-dimension record holding `lower_slot: String`

--- a/code/packages/rust/algol-iir-compiler/Cargo.toml
+++ b/code/packages/rust/algol-iir-compiler/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "algol-iir-compiler"
-version = "0.23.0"
+version = "0.24.0"
 edition = "2021"
-description = "ALGOL 60 scalar frontend for the LANG VM Rust chain, lowering parsed ALGOL into interpreter_ir::IIRModule. v0.23.0 (AL-multidim): N-dimensional integer arrays via row-major flat index; ArrayDim per-dim lower/stride slots, `integer array M[lo1:hi1, lo2:hi2]` syntax; all 7 backends via single alloc_array; v0.22.0 (boolean fix): emit_not_value uses ScalarType::Boolean+Operand::Bool(false); v0.21.0 (AL13-real-proc): real procedure unit test."
+description = "ALGOL 60 scalar frontend for the LANG VM Rust chain, lowering parsed ALGOL into interpreter_ir::IIRModule. v0.24.0 (AL-multidim-real): f64 multidim array elements proven — `real array M[lo1:hi1, lo2:hi2]` rides the multidim flat-index path with ScalarType::Real elem_ty; v0.23.0 (AL-multidim): N-dimensional integer arrays via row-major flat index; ArrayDim per-dim lower/stride slots; all 7 backends via single alloc_array; v0.22.0 (boolean fix): emit_not_value uses ScalarType::Boolean+Operand::Bool(false)."
 
 [dependencies]
 coding-adventures-algol-parser = { path = "../algol-parser" }

--- a/code/packages/rust/algol-iir-compiler/src/lib.rs
+++ b/code/packages/rust/algol-iir-compiler/src/lib.rs
@@ -4660,6 +4660,29 @@ mod tests {
         assert_eq!(run_f64(src), 2.5);
     }
 
+    /// A 2-D **`real`** array (AL-multidim-real): the multidim flat-index path
+    /// carries `f64` elements.  The `elem_ty` recorded at declaration is
+    /// `Real`, so `alloc_array`/`array_set`/`array_get` ride the same 8-byte
+    /// slots as 1-D real arrays — only the index computation is multidim.
+    /// Store four doubles into `M[1:2, 1:2]` and read one back.
+    #[test]
+    fn two_d_real_array_roundtrips() {
+        let src = "begin real array M[1:2, 1:2]; real result; \
+                   M[1,1] := 1.5; M[1,2] := 2.5; M[2,1] := 3.5; M[2,2] := 4.5; \
+                   result := M[2,2] end";
+        assert_eq!(run_f64(src), 4.5);
+    }
+
+    /// A 2-D `real` array sums all four cells: 1.5+2.5+3.5+4.5 = 12.0.
+    /// Proves independent cells and the f64 add path over multidim reads.
+    #[test]
+    fn two_d_real_array_sum() {
+        let src = "begin real array M[1:2, 1:2]; real result; \
+                   M[1,1] := 1.5; M[1,2] := 2.5; M[2,1] := 3.5; M[2,2] := 4.5; \
+                   result := M[1,1] + M[1,2] + M[2,1] + M[2,2] end";
+        assert_eq!(run_f64(src), 12.0);
+    }
+
     // ── AL4 string procedure parameters ─────────────────────────────────────
 
     /// A procedure with a string value parameter compiles: `specifier_scalar_type`

--- a/code/packages/rust/lang-aot/CHANGELOG.md
+++ b/code/packages/rust/lang-aot/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog — `lang-aot`
 
+## 0.166.0 — 2026-07-02 — AL-multidim-real: ALGOL 60 2D **real** array matrix proof cell (all 7 backends)
+
+**New matrix proof cell** (`lang_matrix.rs`): ALGOL 60 2D **real** (f64) array
+running on all 7 backends (NativeAot, Llvm, Wasm, Jvm, Clr, Vm, Jit).
+
+```algol60
+begin real array M[1:2, 1:2]; real sum; integer result;
+  M[1, 1] := 10.25; M[1, 2] := 10.25;
+  M[2, 1] := 10.75; M[2, 2] := 10.75;
+  sum := M[1, 1] + M[1, 2] + M[2, 1] + M[2, 2];
+  result := entier(sum) end
+```
+
+Same multidim flat-index lowering as the 0.165.0 integer cell, but the element
+type is `real`: the fractional doubles ride the E5 8-byte slots, are summed with
+the f64 `add` path to 42.0, then floored to an integer exit code via the E8
+`entier` (`real_to_int_floor`) conversion.  Proves f64 multidim elements — the
+follow-up flagged when AL-multidim first landed — with no backend change.
+Exit 42.  Requires `algol-iir-compiler` 0.24.0.
+
 ## 0.165.0 — 2026-07-01 — AL-multidim: ALGOL 60 2D array matrix proof cell (all 7 backends)
 
 **New matrix proof cell** (`lang_matrix.rs`): ALGOL 60 2D integer array

--- a/code/packages/rust/lang-aot/Cargo.toml
+++ b/code/packages/rust/lang-aot/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "lang-aot"
-version = "0.165.0"
+version = "0.166.0"
 edition = "2021"
-description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, and McCarthy Lisp to native executables through the shared IIR pipeline.  v0.165.0 (AL-multidim): ALGOL 60 2D array matrix proof cell runs on all 7 backends (NativeAot/Llvm/Wasm/Jvm/Clr/Vm/Jit); flat row-major index from algol-iir-compiler 0.23.0.  v0.164.0 (LANG-STR-RT): 7 NativeAot string-param cells unlocked."
+description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, and McCarthy Lisp to native executables through the shared IIR pipeline.  v0.166.0 (AL-multidim-real): ALGOL 60 2D **real** array matrix proof cell runs on all 7 backends; fractional f64 elements on the multidim flat-index path, floored via entier.  v0.165.0 (AL-multidim): 2D integer array cell on all 7 backends.  v0.164.0 (LANG-STR-RT): 7 NativeAot string-param cells unlocked."
 
 [dependencies]
 twig-aot              = { path = "../twig-aot" }

--- a/code/packages/rust/lang-aot/tests/lang_matrix.rs
+++ b/code/packages/rust/lang-aot/tests/lang_matrix.rs
@@ -1530,6 +1530,28 @@ const PROGRAMS: &[Prog] = &[
         expect: Expect::Exit(42),
         backends: &[NativeAot, Llvm, Wasm, Jvm, Clr, Vm, Jit],
     },
+    // ALGOL 60 — *two-dimensional **real** array* (LANG-FULL AL-multidim-real).
+    // Identical multidim flat-index machinery as the integer cell above, but the
+    // element type is `real` (f64).  The `algol-iir-compiler` records `elem_ty =
+    // Real` at declaration, so `alloc_array`/`array_set`/`array_get` carry the
+    // fractional doubles on the same 8-byte slots that E5 1-D real arrays use —
+    // only the *index* computation `(i−1)*2 + (j−1)` is multidim.  Four fractional
+    // cells are stored: `M[1,1]=10.25; M[1,2]=10.25; M[2,1]=10.75; M[2,2]=10.75`,
+    // summed with the f64 `add` path to `42.0`, then floored to an integer exit
+    // code via the E8 `entier` (`real_to_int_floor`) conversion.  This proves f64
+    // multidim elements — the follow-up flagged when AL-multidim first landed —
+    // run on **all 7 backends** with no backend change.  Exit 42.
+    Prog {
+        lang: Language::Algol60,
+        ext: "alg",
+        src: "begin real array M[1:2, 1:2]; real sum; integer result; \
+               M[1, 1] := 10.25; M[1, 2] := 10.25; \
+               M[2, 1] := 10.75; M[2, 2] := 10.75; \
+               sum := M[1, 1] + M[1, 2] + M[2, 1] + M[2, 2]; \
+               result := entier(sum) end",
+        expect: Expect::Exit(42),
+        backends: &[NativeAot, Llvm, Wasm, Jvm, Clr, Vm, Jit],
+    },
     // Brainfuck — build 65 on the tape and `putchar` it: prints `A`.
     // `lower_brainfuck_for_aot` widens the BF cell/ptr registers to `i64` (byte width
     // survives only at the tape boundary) for every code-gen backend. On LLVM (LM-L)

--- a/code/specs/LANG-FULL-IMPLEMENTATION.md
+++ b/code/specs/LANG-FULL-IMPLEMENTATION.md
@@ -14,7 +14,7 @@ program per language**, and each frontend is a **deliberate subset**:
 | Brainfuck | 1-loop "print A", nested-loop multiply (`"HA"`), two sequential loops (`"OK"`), stdin echo/transform, and canonical cat all run on all 7 backends | all 8 ops are cross-backend-proven by B1/B1-stdin/B1-eof; no current BF subset gap remains beyond adding more regression programs |
 | Dartmouth BASIC | `PRINT 42`, `PRINT "HELLO"` on all 7 backends, `GOSUB`/`RETURN`, arrays, data, functions, scalar real arithmetic, historical real formatting | literal-backed string variables, literal reassignment, literal `+` concat, variable-backed and chained concat assignment, `PRINT`/`IF` string concat expressions, multi-item string `PRINT` with `;` and `,`, literal-backed scalar string copy, copied-slot string equality, and equality/inequality/lexical-ordering string branches ✅ (BA4/E4); integer-literal `^` ✅ (BA-^); string arrays/input and general runtime-math `^` remain; `FOR`/`NEXT`, `IF`/`GOTO`, `DEF FN` (BA5), `DIM` real arrays (BA3/BA7), `READ`/`DATA`/`RESTORE` over real data (BA6/BA7), `GOSUB`/`RETURN` (BA1), and BA7 `f64` arithmetic/formatting all run on every backend |
 | Oct | `let`/`if` | rejects **all 10 Intel-8008 intrinsics** (its raison d'être); `&&`/`||` short-circuit ✅ (O1), u8 wrap + `~` ✅ (O2), `static` module globals ✅ (O3), logical `!` ✅ (O-!); intrinsics remain |
-| ALGOL 60 | `result := 17 mod 5` → 2 | `integer`/`real`/`boolean` scalars, typed procedures (including `real procedure` returning f64) ✅ (AL13, all 7 backends), switches, 1-D arrays ✅, N-dimensional integer arrays ✅ (AL-multidim, all 7 backends), `own` static-lifetime variables ✅ (AL6, all 7 backends), `abs`/`sign`/`entier`/`sqrt`/`sin`/`cos`/`ln`/`exp`/`arctan` standard functions ✅ (AL8 + E8, all 7 backends), literal `print`/`output` string I/O ✅, literal-backed string variables, scalar copy snapshots, multi-argument string `output`, literal-backed string equality/ordering predicates ✅ (AL4 foothold), string-typed value parameters in typed procedures ✅ (AL4-str-params, all 7 backends); no call-by-name, dynamic string variables/arrays |
+| ALGOL 60 | `result := 17 mod 5` → 2 | `integer`/`real`/`boolean` scalars, typed procedures (including `real procedure` returning f64) ✅ (AL13, all 7 backends), switches, 1-D arrays ✅, N-dimensional integer & real arrays ✅ (AL-multidim / AL-multidim-real, all 7 backends), `own` static-lifetime variables ✅ (AL6, all 7 backends), `abs`/`sign`/`entier`/`sqrt`/`sin`/`cos`/`ln`/`exp`/`arctan` standard functions ✅ (AL8 + E8, all 7 backends), literal `print`/`output` string I/O ✅, literal-backed string variables, scalar copy snapshots, multi-argument string `output`, literal-backed string equality/ordering predicates ✅ (AL4 foothold), string-typed value parameters in typed procedures ✅ (AL4-str-params, all 7 backends); no call-by-name, dynamic string variables/arrays |
 
 **Goal of this campaign:** make every language a *full* implementation —
 every construct in its grammar lowered to the shared IIR, running correctly on
@@ -649,12 +649,15 @@ backend immediately) come before the enabler-dependent items.
   `llvm.trap` via `clang` (PR-4a), WASM linear-memory+`unreachable` via `wasm-runtime` (PR-4b),
   and **native** x86_64/aarch64 `__twig_alloc_bytes`+`ud2`/`udf` trap (PR-4c — aarch64 local,
   x86_64 CI). The for-loop sum-of-squares array Prog now runs on LLVM too (the ALGOL-for-loop
-  guard-type fix landed in `algol-iir-compiler` 0.5.1). Array params + `f64` native elements
-  are follow-up.  **AL-multidim ✅**: `integer array M[1:2, 1:2]` (2D) runs on **all 7 backends**
+  guard-type fix landed in `algol-iir-compiler` 0.5.1). Array value parameters are follow-up.
+  **AL-multidim ✅**: `integer array M[1:2, 1:2]` (2D) runs on **all 7 backends**
   via row-major flat index `(i-lo1)*stride + (j-lo2)` computed during declaration; strides
   accumulated right-to-left; `alloc_array`/`array_set`/`array_get` with flat 0-based index;
   aarch64 NativeAot required large-frame split prologue (frames > 504 bytes → `SUB SP`+`STR`×2,
   frames ≤ 504 bytes unchanged); `algol-iir-compiler` 0.23.0 / `aarch64-backend` 0.20.0.
+  **AL-multidim-real ✅**: `real array M[1:2, 1:2]` (fractional f64 elements) runs on **all 7
+  backends** — same flat-index machinery carrying `ScalarType::Real` elements on the E5 8-byte
+  slots, summed and floored via `entier`; `algol-iir-compiler` 0.24.0 / `lang-aot` 0.166.0.
 - ✅ **AL3** — typed procedures with value parameters. `integer procedure sq(x);
   value x; integer x; sq := x*x; result := sq(7)` ⇒ exit 49, **verified by running**
   across native/LLVM/WASM/JVM/CLR/VM/JIT (`lang-aot` `lang_matrix.rs`). Lowered to a


### PR DESCRIPTION
## Summary

Proves **f64 multidimensional array elements** — the follow-up flagged when
AL-multidim first landed — run end-to-end on **all 7 LANG backends** (NativeAot,
Llvm, Wasm, Jvm, Clr, Vm, Jit). LANG-FULL **AL-multidim-real**.

Proof cell:
```algol60
begin real array M[1:2, 1:2]; real sum; integer result;
  M[1, 1] := 10.25; M[1, 2] := 10.25;
  M[2, 1] := 10.75; M[2, 2] := 10.75;
  sum := M[1, 1] + M[1, 2] + M[2, 1] + M[2, 2];
  result := entier(sum) end
```
→ exit `42` on every backend (fractional cells sum to 42.0, floored via `entier`).

## Changes

### `algol-iir-compiler` 0.24.0
- **No compiler code changed.** `emit_array_decl` already threads the declared
  `elem_ty` (here `ScalarType::Real`) into `declare_array`, and
  `array_get`/`array_set` ride the same 8-byte slots for f64 as for i64. Only
  the flat-index computation is multidim; element storage is identical to a 1-D
  `real array`.
- 2 new unit tests (108 total): `two_d_real_array_roundtrips` (store four
  doubles, read `M[2,2]`=4.5) and `two_d_real_array_sum` (sum all four = 12.0).

### `lang-aot` 0.166.0
- New AL-multidim-real matrix proof cell, verified on all 7 backends.

### Spec
- `LANG-FULL-IMPLEMENTATION.md` marks **AL-multidim-real ✅** and drops the
  "f64 native elements are follow-up" note (only array value parameters remain).

## Verification
- `cargo test -p algol-iir-compiler --lib` — 108 tests pass
- `cargo test -p lang-aot --test lang_matrix proven_columns_do_not_silently_skip` — pass (real 2D array runs on NativeAot + all native-present backends)
- `cargo test -p lang-aot --test lang_matrix matrix_every_proven_cell_agrees` — pass
- **Security review passed** (test-only change, no vulnerabilities).

🤖 Generated with [Claude Code](https://claude.com/claude-code)