### PR TITLE
fix(visicalc): light-theme grid had no gridlines — Grid.light.msl used stale part names

### DIFF
--- a/code/programs/mosaic/visicalc/Grid.light.msl
+++ b/code/programs/mosaic/visicalc/Grid.light.msl
@@ -1,9 +1,17 @@
 // Grid.light.msl — light theme for the spreadsheet grid (VC1.5).
 //
 // Companion to Grid.dark.msl. Identical structure — same sub-parts
-// (sheet, sheet/cell, sheet/header-cell, sheet/header-row,
-// sheet/data-row), same state blocks (selected, editing, even,
-// odd) — only the palette flips for a light system theme.
+// (sheet, cell, header-cell, header-row, data-row), same state blocks
+// (selected, editing, even, odd) — only the palette flips for a light
+// system theme.
+//
+// NB: an earlier cut of this file named the parts `sheet/cell`,
+// `sheet/header-cell`, … — the legacy monolithic-Grid naming removed in
+// U29-X1. Those names match no part in the mosaic-pkg-grid composition, so
+// the emitter produced UNSTYLED light cells (no borders → no gridlines). The
+// dark stylesheet always used the flat names (`cell`, `header-cell`, …); the
+// light one now matches. This only ever surfaced once the web switcher
+// actually rendered the light theme — before that, the light .msl was dead code.
 //
 // Palette mapping rationale (dark → light):
 //
@@ -34,7 +42,7 @@ style Grid {
   }
 
   // Body cells. The `border-*` triplet draws the gridlines.
-  part sheet/cell {
+  part cell {
     border-width: 1px ;
     border-style: solid ;
     border-color: #c8c8c8 ;
@@ -57,7 +65,7 @@ style Grid {
   }
 
   // Column-header cells.
-  part sheet/header-cell {
+  part header-cell {
     background:  #f3f3f3 ;
     color:       #555555 ;
     font-weight: normal ;
@@ -70,12 +78,12 @@ style Grid {
     height:      24px ;
   }
 
-  part sheet/header-row {
+  part header-row {
     height: 24px ;
   }
 
   // Body data rows: alternating zebra-stripe on light tones.
-  part sheet/data-row {
+  part data-row {
     height: 22px ;
 
     state even {

--- a/code/programs/typescript/visicalc-html/index.html
+++ b/code/programs/typescript/visicalc-html/index.html
@@ -250,7 +250,7 @@
       <tr>
         <!-- mosaic-for each="columnHeaders" as="h" index="ch" -->
           <th>
-            <div>
+            <div style="background: #f3f3f3; color: #555555; font-weight: normal; text-align: center; border-width: 1px; border-style: solid; border-color: #c8c8c8; height: 24px">
               <span>{{h}}</span>
             </div>
           </th>
@@ -262,7 +262,7 @@
         <tr>
           <!-- mosaic-for each="row" as="v" index="c" -->
             <td>
-              <div>
+              <div style="border-width: 1px; border-style: solid; border-color: #c8c8c8; padding: 2px; height: 22px">
                 <!-- mosaic-if when="( r == editRow &amp;&amp; c == editCol )" -->
                   <!-- emit "onFormulaChange" dropped: HTML is static -->
                   <!-- emit "onEditCommit" dropped: HTML is static -->

--- a/lessons.md
+++ b/lessons.md
@@ -1057,3 +1057,29 @@ Additional mini-sqlite Level 1 lessons:
   the `jacocoTestCoverageVerification` task.
 
 Discovered: 2026-07-01 during Java mini-sqlite Level 1 graduation (PR #7153).
+
+## Mosaic .msl part names must match the layout/package part names exactly (silent style drop)
+
+A stylesheet (`.msl`) styles named `part`s; the emitter matches each `part X {...}`
+block to a part of the same name in the layout (`.mll`) / resolved package composition.
+If a part name doesn't match, the emitter **silently drops** those styles — the element
+renders with NO styling, no error.
+
+`Grid.light.msl` was authored against the legacy monolithic-Grid naming
+(`sheet/cell`, `sheet/header-cell`, …) removed in U29-X1, while the shipped
+`mosaic-pkg-grid` composition (and `Grid.dark.msl`) use flat names (`cell`,
+`header-cell`, `header-row`, `data-row`). Result: the light-theme grid cells had
+no borders/background → **no gridlines**. It stayed hidden because the light theme
+was **dead code** (rendered by no demo) until the web dark/light switcher (PR #7338)
+finally exercised it.
+
+Lessons:
+- When you light up a previously-dead variant/theme, VERIFY IT ACTUALLY RENDERS
+  (drive it), don't assume parity with the working variant — the parallel file may
+  have drifted.
+- Keep sibling stylesheets' `part` names identical to each other and to the
+  layout/package parts. A quick guard: `diff <(grep '^\s*part ' X.dark.msl) <(grep '^\s*part ' X.light.msl)`.
+- Silent-drop-on-mismatch is a sharp edge in the emitter; a warning for unmatched
+  `part` blocks would have caught this at build time (possible follow-up).
+
+Discovered: 2026-07-02, light-theme grid had no gridlines after PR #7338 shipped the switcher.


### PR DESCRIPTION
## Bug

The web dark/light switcher ([#7338](https://github.com/adhithyan15/coding-adventures/pull/7338)) was the **first demo to ever render the light theme** — which surfaced a latent bug: in Light mode the grid had **no gridlines** (and no header/cell chrome).

## Root cause

`Grid.light.msl` styled parts named `sheet/cell`, `sheet/header-cell`, `sheet/header-row`, `sheet/data-row` — the **legacy monolithic-Grid naming removed in U29-X1**. The shipped `mosaic-pkg-grid` composition (and `Grid.dark.msl`) use the flat names `cell`, `header-cell`, `header-row`, `data-row`. The emitter **silently drops** style blocks whose part names don't match, so the light cells rendered unstyled. The dark stylesheet always used the flat names; the light one had drifted and stayed **dead code** until the switcher rendered it.

## Fix

- **`Grid.light.msl`** — rename the four parts to the flat names so the emitter applies the border/background/height styles (the values — `#c8c8c8` borders, `#f3f3f3` header, state blocks — were already correct). Comment updated.
- **`visicalc-html/index.html`** — re-embed the regenerated `grid-template-light` fragment (the demo inlines a static copy of the generated template); the light `<th>`/`<td>` divs now carry their style attributes.
- **`lessons.md`** — document the silent-drop-on-unmatched-part sharp edge + "verify a previously-dead variant actually renders."

## Verification

Live via the preview harness — toggling to **Light** now shows **1px `rgb(200,200,200)` (`#c8c8c8`) cell borders** (was `none`), the light-grey header row, and white sheet background. Gridlines restored; dark theme unchanged. Only the web switcher consumes the light `.msl`, so no native demo is affected.

**Before:** borderless light grid. **After:** proper gridlines (screenshot in the thread).

Follow-up (task chip): make `mosaic-compile` **warn** on unmatched `.msl` part blocks so this class of typo fails loudly at build time.

Security review: **PASSED** (static CSS values only; no interpolation, no new sink; the cell-value escaping path is untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)