### PR TITLE
[codex] Add template cross-axis audit evidence

### DIFF
--- a/code/packages/rust/html-parser/tests/whatwg_template_audit_test.rs
+++ b/code/packages/rust/html-parser/tests/whatwg_template_audit_test.rs
@@ -5,7 +5,25 @@ use serde::Deserialize;
 use std::collections::{BTreeMap, HashMap};
 
 const TREE_CONSTRUCTION_SMOKE: &str = include_str!("fixtures/html5lib-tree-construction-smoke.dat");
+const WHATWG_BLOCK_BOUNDARY_AUDIT: &str = include_str!("fixtures/whatwg-block-boundary-audit.json");
+const WHATWG_DOCUMENT_SHELL_AUDIT: &str = include_str!("fixtures/whatwg-document-shell-audit.json");
+const WHATWG_FOREIGN_AUDIT: &str = include_str!("fixtures/whatwg-foreign-audit.json");
+const WHATWG_FORM_INTERACTIVE_AUDIT: &str =
+    include_str!("fixtures/whatwg-form-interactive-audit.json");
+const WHATWG_FRAMESET_AUDIT: &str = include_str!("fixtures/whatwg-frameset-audit.json");
+const WHATWG_HEAD_BODY_AUDIT: &str = include_str!("fixtures/whatwg-head-body-audit.json");
+const WHATWG_SELECT_LIST_AUDIT: &str = include_str!("fixtures/whatwg-select-list-audit.json");
+const WHATWG_TABLE_AUDIT: &str = include_str!("fixtures/whatwg-table-audit.json");
 const WHATWG_TEMPLATE_AUDIT: &str = include_str!("fixtures/whatwg-template-audit.json");
+const WHATWG_TREE_INSERTION_AUDIT: &str = include_str!("fixtures/whatwg-tree-insertion-audit.json");
+const WHATWG_VOID_ELEMENT_AUDIT: &str = include_str!("fixtures/whatwg-void-element-audit.json");
+
+struct TemplateCrossAxisCase {
+    id: &'static str,
+    data_snippet: &'static str,
+    suites: &'static [(&'static str, &'static str, &'static str)],
+}
+
 const POST_PARSE_REPAIR_EVIDENCE: &[(&str, &str)] = &[
     ("template-dat-461", "eof-template"),
     ("template-dat-463", "table-template"),
@@ -13,6 +31,99 @@ const POST_PARSE_REPAIR_EVIDENCE: &[(&str, &str)] = &[
     ("template-dat-488", "nested-template"),
     ("template-dat-494", "frameset-template"),
     ("template-dat-512", "head-body-template"),
+];
+const SELECT_TEMPLATE_CROSS_AXIS_SUITES: &[(&str, &str, &str)] = &[
+    (
+        "form-interactive",
+        WHATWG_FORM_INTERACTIVE_AUDIT,
+        "select-option",
+    ),
+    ("select-list", WHATWG_SELECT_LIST_AUDIT, "select-shell"),
+    ("template", WHATWG_TEMPLATE_AUDIT, "select-template"),
+    (
+        "tree-insertion",
+        WHATWG_TREE_INSERTION_AUDIT,
+        "template-insertion",
+    ),
+];
+const TABLE_TEMPLATE_CROSS_AXIS_SUITES: &[(&str, &str, &str)] = &[
+    (
+        "block-boundary",
+        WHATWG_BLOCK_BOUNDARY_AUDIT,
+        "block-table-boundary",
+    ),
+    (
+        "document-shell",
+        WHATWG_DOCUMENT_SHELL_AUDIT,
+        "head-element-boundary",
+    ),
+    ("head-body", WHATWG_HEAD_BODY_AUDIT, "body-boundary"),
+    ("table", WHATWG_TABLE_AUDIT, "cell-boundary"),
+    ("template", WHATWG_TEMPLATE_AUDIT, "table-template"),
+    (
+        "tree-insertion",
+        WHATWG_TREE_INSERTION_AUDIT,
+        "template-insertion",
+    ),
+];
+const FRAMESET_TEMPLATE_CROSS_AXIS_SUITES: &[(&str, &str, &str)] = &[
+    (
+        "document-shell",
+        WHATWG_DOCUMENT_SHELL_AUDIT,
+        "head-element-boundary",
+    ),
+    ("frameset", WHATWG_FRAMESET_AUDIT, "template-boundary"),
+    (
+        "head-body",
+        WHATWG_HEAD_BODY_AUDIT,
+        "body-frameset-transition",
+    ),
+    ("template", WHATWG_TEMPLATE_AUDIT, "frameset-template"),
+    (
+        "tree-insertion",
+        WHATWG_TREE_INSERTION_AUDIT,
+        "template-insertion",
+    ),
+    (
+        "void-element",
+        WHATWG_VOID_ELEMENT_AUDIT,
+        "legacy-void-elements",
+    ),
+];
+const FOREIGN_TEMPLATE_CROSS_AXIS_SUITES: &[(&str, &str, &str)] = &[
+    ("foreign", WHATWG_FOREIGN_AUDIT, "svg-boundary"),
+    (
+        "template",
+        WHATWG_TEMPLATE_AUDIT,
+        "foreign-content-template",
+    ),
+    (
+        "tree-insertion",
+        WHATWG_TREE_INSERTION_AUDIT,
+        "template-insertion",
+    ),
+];
+const TEMPLATE_CROSS_AXIS_CASES: &[TemplateCrossAxisCase] = &[
+    TemplateCrossAxisCase {
+        id: "template-dat-473",
+        data_snippet: "<select><template></template></select>",
+        suites: SELECT_TEMPLATE_CROSS_AXIS_SUITES,
+    },
+    TemplateCrossAxisCase {
+        id: "template-dat-483",
+        data_snippet: "<body><table><template><td></tr><div></template></table>",
+        suites: TABLE_TEMPLATE_CROSS_AXIS_SUITES,
+    },
+    TemplateCrossAxisCase {
+        id: "template-dat-494",
+        data_snippet: "<frameset><template><frame></frame></template></frameset>",
+        suites: FRAMESET_TEMPLATE_CROSS_AXIS_SUITES,
+    },
+    TemplateCrossAxisCase {
+        id: "template-dat-553",
+        data_snippet: "<template><svg><template>",
+        suites: FOREIGN_TEMPLATE_CROSS_AXIS_SUITES,
+    },
 ];
 
 #[derive(Debug, Deserialize)]
@@ -27,6 +138,19 @@ struct TemplateAuditSuite {
 
 #[derive(Debug, Deserialize)]
 struct TemplateAuditCase {
+    id: String,
+    source: String,
+    axis: String,
+    reason: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GenericAuditSuite {
+    cases: Vec<GenericAuditCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GenericAuditCase {
     id: String,
     source: String,
     axis: String,
@@ -84,6 +208,61 @@ fn whatwg_template_audit_cases_match_parser_dom_dump() {
 }
 
 #[test]
+fn whatwg_template_audit_keeps_special_context_cases_cross_axis() {
+    let smoke_cases = parse_tree_construction_cases(TREE_CONSTRUCTION_SMOKE)
+        .into_iter()
+        .map(|case| (case.source.clone(), case))
+        .collect::<HashMap<_, _>>();
+
+    for evidence in TEMPLATE_CROSS_AXIS_CASES {
+        let mut shared_source = None;
+
+        for (suite_name, fixture, expected_axis) in evidence.suites {
+            let audit_case = generic_audit_case(fixture, suite_name, evidence.id);
+            assert_eq!(
+                audit_case.axis, *expected_axis,
+                "`{suite_name}` should keep template row `{}` on its focused axis",
+                evidence.id
+            );
+            assert!(
+                !audit_case.reason.is_empty(),
+                "`{suite_name}` should keep a reason for template row `{}`",
+                evidence.id
+            );
+
+            if let Some(source) = &shared_source {
+                assert_eq!(
+                    audit_case.source, *source,
+                    "`{suite_name}` should point template row `{}` at the same html5lib row as the other audit axes",
+                    evidence.id
+                );
+            } else {
+                shared_source = Some(audit_case.source);
+            }
+        }
+
+        let shared_source =
+            shared_source.expect("template evidence should include at least one suite");
+        let source_case = smoke_cases
+            .get(&shared_source)
+            .unwrap_or_else(|| panic!("case `{shared_source}` should exist in smoke fixture"));
+        assert!(
+            source_case.data.contains(evidence.data_snippet),
+            "template evidence row `{}` should stay tied to its html5lib input",
+            evidence.id
+        );
+
+        let actual = actual_dom_dump_for_tree_case(source_case)
+            .unwrap_or_else(|error| panic!("case `{shared_source}` parse failed: {error}"));
+        assert_eq!(
+            actual, source_case.document,
+            "cross-axis template evidence case `{shared_source}` failed for input {:?}",
+            source_case.data
+        );
+    }
+}
+
+#[test]
 fn whatwg_template_audit_tracks_post_parse_repair_evidence() {
     let suite = load_suite();
     let audit_cases = suite
@@ -125,6 +304,16 @@ fn whatwg_template_audit_tracks_post_parse_repair_evidence() {
 
 fn load_suite() -> TemplateAuditSuite {
     serde_json::from_str(WHATWG_TEMPLATE_AUDIT).expect("WHATWG template audit fixture should parse")
+}
+
+fn generic_audit_case(fixture: &str, suite_name: &str, case_id: &str) -> GenericAuditCase {
+    let suite = serde_json::from_str::<GenericAuditSuite>(fixture)
+        .unwrap_or_else(|error| panic!("`{suite_name}` audit fixture should parse: {error}"));
+    suite
+        .cases
+        .into_iter()
+        .find(|case| case.id == case_id)
+        .unwrap_or_else(|| panic!("`{suite_name}` should audit template case `{case_id}`"))
 }
 
 fn assert_axis_count(suite: &TemplateAuditSuite, axis: &str, minimum: usize) {


### PR DESCRIPTION
## Summary
- add executable cross-axis coverage for template audit rows that also appear in select, table, frameset, foreign-content, shell, and tree-insertion suites
- assert each pinned row keeps the expected audit axis, non-empty rationale, shared html5lib source, fixture snippet, and parser DOM dump parity

## Validation
- cargo test -p coding-adventures-html-parser whatwg_template_audit_keeps_special_context_cases_cross_axis
- cargo test -p coding-adventures-html-parser whatwg_template_audit
- cargo test -p coding-adventures-html-parser
- CARGO_BUILD_JOBS=2 cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser
- python3 -m json.tool code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json >/dev/null
- python3 code/packages/rust/html-parser/tests/fixtures/check_whatwg_audit_rust_tests.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py
- git diff --check
