### PR TITLE
feat(js-ast): CLOC12.159 PR1 — NewExpression atomic node + emit + passes

### DIFF
--- a/code/packages/rust/closure-emitter/CHANGELOG.md
+++ b/code/packages/rust/closure-emitter/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to the `coding-adventures-closure-emitter` crate will be documented in this file.
 
+## [0.23.0] - 2026-07-02
+
+### Added — CLOC12.159: emit `NewExpression` (`new X(args)`)
+
+`emit_new` prints the new `Expression::NewExpression` node: `new`, the callee,
+then the argument parens (always printed, so a no-argument node is emitted
+canonically as `new X()`). Two seams are handled: (1) a keyword-space
+separates `new` from an identifier/member callee (`newX` would fuse), spent
+only when the callee is not already parenthesised; (2) a callee whose member
+spine bottoms out in a **call** is wrapped (`new (f())()`, `new (a.b().c)()`),
+or the appended `(args)` would bind to the inner call (`new f()()` reparses as
+`(new f())()`). Classified at `PREC_PRIMARY` (the always-argumented form binds
+at member/call strength). 8 new unit tests. No behaviour change for existing
+inputs — the bridge does not yet produce `new` nodes (PR2).
+
+
 ## [0.22.1] - 2026-07-02
 
 ### Added — CLOC12.158 PR3: CodePrinter update-operator conformance port

--- a/code/packages/rust/closure-emitter/Cargo.toml
+++ b/code/packages/rust/closure-emitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-emitter"
-version = "0.22.1"
+version = "0.23.0"
 edition = "2021"
 description = "JavaScript code emitter for the Closure Compiler clone. Per CLOC07's emit contract. Takes a finalized Program + sidecar and produces output JavaScript text + companion source map. Runs after every pass in the pipeline."
 

--- a/code/packages/rust/closure-emitter/src/lib.rs
+++ b/code/packages/rust/closure-emitter/src/lib.rs
@@ -74,7 +74,7 @@ use coding_adventures_javascript_ast::{
     ForStatement,
     FunctionDeclaration, FunctionExpression,
     FunctionParam, Identifier, IfStatement, LabeledStatement, LogicalExpression, LogicalOperator,
-    MemberExpression, NullLiteral, NumericLiteral, ObjectExpression, Program, ProgramItem,
+    MemberExpression, NewExpression, NullLiteral, NumericLiteral, ObjectExpression, Program, ProgramItem,
     Property, PropertyKey, PropertyKind, ReturnStatement, Statement, StringLiteral,
     SwitchCase, SwitchStatement, ThrowStatement, TryStatement, UnaryExpression, UnaryOperator, UpdateExpression, UpdateOperator,
     UndefinedLiteral, VarKind, VariableDeclaration, VariableDeclarator, WhileStatement,
@@ -1110,6 +1110,7 @@ impl<'a> Emitter<'a> {
             Expression::AssignmentExpression(a) => self.emit_assignment(a),
             Expression::ConditionalExpression(c) => self.emit_conditional(c),
             Expression::CallExpression(c) => self.emit_call(c),
+            Expression::NewExpression(n) => self.emit_new(n),
             Expression::MemberExpression(m) => self.emit_member(m),
             Expression::ArrayExpression(a) => self.emit_array(a),
             Expression::ObjectExpression(o) => self.emit_object(o),
@@ -1441,6 +1442,57 @@ impl<'a> Emitter<'a> {
         self.write_str(")");
     }
 
+    /// Emit a `new` expression — `new Ctor(a, b)`.
+    ///
+    /// ```text
+    ///   new X()          →  new X()
+    ///   new a.b.c()      →  new a.b.c()      member-chain callee, no wrap
+    ///   new (f())()      →  new (f())()      call in the callee spine MUST wrap
+    /// ```
+    ///
+    /// # Two seams to get right
+    ///
+    /// 1. **`new` is a word keyword.** Directly before an identifier or member
+    ///    callee it would fuse (`newX` is one identifier), so a separator is
+    ///    required — exactly like `typeof`/`void`/`delete` in [`emit_unary`].
+    ///    When the callee is instead wrapped in parens (`new(f())()`) the `(`
+    ///    already separates the tokens, so no space is spent.
+    ///
+    /// 2. **The callee cannot end in a call.** The ECMAScript grammar makes the
+    ///    `new` target a `MemberExpression`, which excludes `CallExpression`.
+    ///    So if the callee's member spine bottoms out in a call, emitting it
+    ///    bare would let the `(args)` we append bind to that *inner* call:
+    ///    `new f()()` reparses as `(new f())()`. We parenthesise the callee in
+    ///    that case (`new (f())()`), which is the only shape that needs it — a
+    ///    plain identifier or a pure member chain (`a.b.c`) is a valid target
+    ///    as-is. See [`new_callee_needs_parens`].
+    ///
+    /// The non-wrapped callee is emitted at `PREC_PRIMARY`, which keeps member
+    /// chains paren-free while still wrapping anything looser (a binary,
+    /// conditional, etc. — not valid targets, but handled defensively).
+    fn emit_new(&mut self, n: &NewExpression) {
+        self.maybe_map(&n.cv);
+        self.write_str("new");
+        if new_callee_needs_parens(&n.callee) {
+            self.write_str("(");
+            self.emit_expression(&n.callee);
+            self.write_str(")");
+        } else {
+            // `new`↔callee is a keyword↔word boundary — always separate.
+            self.required_ws();
+            self.emit_expression_inner(&n.callee, PREC_PRIMARY);
+        }
+        self.write_str("(");
+        for (i, a) in n.arguments.iter().enumerate() {
+            if i > 0 {
+                self.write_str(",");
+                self.pretty_ws();
+            }
+            self.emit_expression(a);
+        }
+        self.write_str(")");
+    }
+
     fn emit_member(&mut self, m: &MemberExpression) {
         self.maybe_map(&m.cv);
         // The object must bind at least as tightly as member access, or the
@@ -1760,6 +1812,33 @@ fn logical_prec(op: LogicalOperator) -> u8 {
 /// Resolve the own precedence of any `Expression`. Used by
 /// `emit_expression_inner` to decide whether to wrap a child in
 /// parens given the parent's context precedence.
+/// Does a `new` target need to be wrapped in parens?
+///
+/// The `new` operator's callee is a `MemberExpression` per the grammar, which
+/// **cannot** itself be a call. If the callee's member spine bottoms out in a
+/// [`Expression::CallExpression`], the `(args)` that `emit_new` appends would
+/// otherwise bind to that inner call:
+///
+/// ```text
+///   new f()()      reparses as   (new f())()        WRONG — wrap → new (f())()
+///   new a.b().c()  reparses as   (new a.b()).c()    WRONG — wrap → new (a.b().c)()
+///   new a.b.c()                  new (a.b.c)()      OK   — pure member chain
+///   new X()                      new X()            OK   — plain identifier
+/// ```
+///
+/// We walk only the **member-object spine** (`MemberExpression::object`): a
+/// call reachable there is a call the appended `(args)` could attach to. Calls
+/// nested inside an argument list or a computed-member key (`new a[f()].g()`
+/// where `f()` is a key) are irrelevant — they are already closed off by their
+/// own brackets — so we do not descend into those.
+fn new_callee_needs_parens(callee: &Expression) -> bool {
+    match callee {
+        Expression::CallExpression(_) => true,
+        Expression::MemberExpression(m) => new_callee_needs_parens(&m.object),
+        _ => false,
+    }
+}
+
 fn expr_prec(e: &Expression) -> u8 {
     match e {
         // Atomic / left-associative primaries — never need wrapping
@@ -1786,6 +1865,15 @@ fn expr_prec(e: &Expression) -> u8 {
         // syntax error) and tight enough that a `!`/`typeof` parent does not
         // over-wrap it (`!x++`, `typeof x++` print bare, which is correct).
         Expression::UpdateExpression(_) => PREC_UNARY,
+        // `emit_new` ALWAYS prints the argument parens — a no-argument `new X`
+        // is emitted canonically as `new X()`. In that *argumented* spelling a
+        // `new` is a `MemberExpression` in the grammar and binds at member/call
+        // strength, so it tags at `PREC_PRIMARY` like a call: `new X().y` needs
+        // no extra parens (it already means `(new X()).y`), and as a call
+        // callee `new X().y()` stays paren-free. (Were we ever to drop the
+        // empty parens — a future minification — the no-arg form would need the
+        // looser bare-`NewExpression` precedence; we don't, so one tag suffices.)
+        Expression::NewExpression(_) => PREC_PRIMARY,
         // A function expression is primary-*ish*, but two contexts
         // mis-parse a bare one: as a call callee (`function(){}()` is a
         // syntax error) and as a member object (`function(){}.x`). Tag
@@ -4330,5 +4418,93 @@ mod tests {
             num(2.0),
         );
         assert_eq!(emit_expr(e), "(++x)**2;");
+    }
+
+    // ---- NewExpression (CLOC12.159) ------------------------------------
+
+    fn new_expr(callee: Expression, arguments: Vec<Expression>) -> Expression {
+        Expression::NewExpression(NewExpression {
+            cv: None,
+            callee: Box::new(callee),
+            arguments,
+        })
+    }
+    fn call(callee: Expression, arguments: Vec<Expression>) -> Expression {
+        Expression::CallExpression(CallExpression {
+            cv: None,
+            callee: Box::new(callee),
+            arguments,
+        })
+    }
+
+    /// `new X()` — plain identifier callee, empty args. A space separates the
+    /// `new` keyword from the identifier so they do not fuse into `newX`.
+    #[test]
+    fn new_identifier_no_args() {
+        assert_eq!(emit_expr(new_expr(ident("X"), vec![])), "new X();");
+    }
+
+    /// `new X(a, b)` — arguments are comma-separated, no trailing-space in the
+    /// minified form.
+    #[test]
+    fn new_with_args() {
+        assert_eq!(
+            emit_expr(new_expr(ident("X"), vec![ident("a"), ident("b")])),
+            "new X(a,b);"
+        );
+    }
+
+    /// `new a.b.c()` — a pure member-chain callee is a valid `new` target and
+    /// stays paren-free; the `new` keeps its separating space.
+    #[test]
+    fn new_member_chain_callee_not_wrapped() {
+        let callee = member(member(ident("a"), "b", false), "c", false);
+        assert_eq!(emit_expr(new_expr(callee, vec![])), "new a.b.c();");
+    }
+
+    /// `new (f())()` — a call in the callee spine MUST be parenthesised, or the
+    /// appended `()` would bind to the inner call (`new f()()` = `(new f())()`,
+    /// a different program). The wrapping paren also removes the need for the
+    /// `new`-keyword space.
+    #[test]
+    fn new_call_callee_is_wrapped() {
+        let callee = call(ident("f"), vec![]);
+        assert_eq!(emit_expr(new_expr(callee, vec![])), "new(f())();");
+    }
+
+    /// `new a.b().c()` — the callee's member spine bottoms out in a call
+    /// (`a.b()`), so the whole target is wrapped: `new (a.b().c)()`.
+    #[test]
+    fn new_callee_with_call_in_member_spine_is_wrapped() {
+        let callee = member(call(member(ident("a"), "b", false), vec![]), "c", false);
+        assert_eq!(emit_expr(new_expr(callee, vec![])), "new(a.b().c)();");
+    }
+
+    /// `(new X()).y` — an *argumented* `new` binds at member strength, so a
+    /// member parent needs NO extra parens (the `new X()` groups on its own):
+    /// `new X().y`.
+    #[test]
+    fn argumented_new_as_member_object_not_wrapped() {
+        let m = member(new_expr(ident("X"), vec![ident("a")]), "y", false);
+        assert_eq!(emit_expr(m), "new X(a).y;");
+    }
+
+    /// A no-argument `new X` is emitted canonically as `new X()` (the parens
+    /// are always printed), so it binds at member strength and as a member
+    /// object needs NO extra wrap: `new X().y`. The always-printed `()` is what
+    /// makes `new X.y` (which would reparse as `new (X.y)`) unreachable.
+    #[test]
+    fn no_arg_new_as_member_object_prints_argumented() {
+        let m = member(new_expr(ident("X"), vec![]), "y", false);
+        assert_eq!(emit_expr(m), "new X().y;");
+    }
+
+    /// `new` nests: the inner `new X()` is a valid target (not a call), so no
+    /// wrap is forced and the outer `new` keeps its keyword space:
+    /// `new new X()()`.
+    #[test]
+    fn nested_new_inner_not_wrapped() {
+        let inner = new_expr(ident("X"), vec![]);
+        assert_eq!(emit_expr(new_expr(inner, vec![])), "new new X()();");
     }
 }

--- a/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `coding-adventures-closure-pass-constant-fold` crate will be documented in this file.
 
+## [0.85.2] - 2026-07-02
+
+### Changed — CLOC12.159: handle `Expression::NewExpression`
+
+Added a `NewExpression` match arm mirroring `CallExpression` (recurse into the
+callee and each argument) so this crate compiles and traverses the new
+`Expression::NewExpression` variant. No behaviour change until the bridge
+produces `new` nodes (CLOC12.159 PR2).
+
+
 ## [0.85.1] - 2026-07-02
 
 ### Changed — CLOC12.158: exhaustiveness for new `Expression::UpdateExpression`

--- a/code/packages/rust/closure-pass-constant-fold/Cargo.toml
+++ b/code/packages/rust/closure-pass-constant-fold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-constant-fold"
-version = "0.85.1"
+version = "0.85.2"
 edition = "2021"
 description = "Constant-folding optimization pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Folds compile-time-evaluable expressions like `2 + 3 → 5`."
 

--- a/code/packages/rust/closure-pass-constant-fold/src/lib.rs
+++ b/code/packages/rust/closure-pass-constant-fold/src/lib.rs
@@ -91,7 +91,7 @@ use coding_adventures_closure_pass_pipeline::{
 use coding_adventures_correlation_vector::{CVLog, Contribution};
 use coding_adventures_javascript_ast::{
     statement::TaggedStatement, ArrayExpression, AssignmentExpression, BinaryExpression,
-    BinaryOperator, BlockStatement, BooleanLiteral, CallExpression, ConditionalExpression,
+    BinaryOperator, BlockStatement, BooleanLiteral, CallExpression, ConditionalExpression, NewExpression,
     Declaration, Expression, ExpressionStatement, ForInStatement, ForInit, ForOfStatement,
     ForStatement,
     ArrowBody, ArrowFunctionExpression, TemplateLiteral,
@@ -527,6 +527,14 @@ fn fold_expression(expr: &Expression, st: &mut FoldState) -> Expression {
             })
         }
         Expression::CallExpression(c) => fold_call(c, st),
+        // `new X(args)` constructs an object — a side-effecting operation, never
+        // a constant. Recurse into the callee and each argument (they may hold
+        // foldable subexpressions) but preserve the construction itself.
+        Expression::NewExpression(n) => Expression::NewExpression(NewExpression {
+            cv: n.cv.clone(),
+            callee: Box::new(fold_expression(&n.callee, st)),
+            arguments: n.arguments.iter().map(|a| fold_expression(a, st)).collect(),
+        }),
         Expression::MemberExpression(m) => fold_member(m, st),
         Expression::ArrayExpression(a) => Expression::ArrayExpression(ArrayExpression {
             cv: a.cv.clone(),

--- a/code/packages/rust/closure-pass-dce/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-dce/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `coding-adventures-closure-pass-dce` crate will be documented in this file.
 
+## [0.20.2] - 2026-07-02
+
+### Changed — CLOC12.159: handle `Expression::NewExpression`
+
+Added a `NewExpression` match arm mirroring `CallExpression` (recurse into the
+callee and each argument) so this crate compiles and traverses the new
+`Expression::NewExpression` variant. No behaviour change until the bridge
+produces `new` nodes (CLOC12.159 PR2).
+
+
 ## [0.20.1] - 2026-07-02
 
 ### Changed — CLOC12.158: exhaustiveness for new `Expression::UpdateExpression`

--- a/code/packages/rust/closure-pass-dce/Cargo.toml
+++ b/code/packages/rust/closure-pass-dce/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-dce"
-version = "0.20.1"
+version = "0.20.2"
 edition = "2021"
 description = "Dead-code elimination pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Drops code after definite-terminator statements and removes EmptyStatement noise."
 

--- a/code/packages/rust/closure-pass-dce/src/lib.rs
+++ b/code/packages/rust/closure-pass-dce/src/lib.rs
@@ -71,7 +71,7 @@ use coding_adventures_closure_pass_pipeline::{
 use coding_adventures_correlation_vector::{CVLog, Contribution};
 use coding_adventures_javascript_ast::{
     statement::TaggedStatement, ArrayExpression, AssignmentExpression, BigIntLiteral,
-    BinaryExpression, BlockStatement, BooleanLiteral, CallExpression, ConditionalExpression,
+    BinaryExpression, BlockStatement, BooleanLiteral, CallExpression, ConditionalExpression, NewExpression,
     Declaration, EmptyStatement, Expression, ExpressionStatement, ForInStatement, ForInit,
     ForOfStatement,
     ForStatement,
@@ -1212,6 +1212,13 @@ fn dce_expression(expr: &Expression, st: &mut DceState) -> Expression {
             cv: c.cv.clone(),
             callee: Box::new(dce_expression(&c.callee, st)),
             arguments: c.arguments.iter().map(|a| dce_expression(a, st)).collect(),
+        }),
+        // `new X(args)` has construction side effects — never elided; recurse
+        // into callee and arguments to reach any dead code nested within.
+        Expression::NewExpression(n) => Expression::NewExpression(NewExpression {
+            cv: n.cv.clone(),
+            callee: Box::new(dce_expression(&n.callee, st)),
+            arguments: n.arguments.iter().map(|a| dce_expression(a, st)).collect(),
         }),
         Expression::MemberExpression(m) => Expression::MemberExpression(MemberExpression {
             cv: m.cv.clone(),

--- a/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `coding-adventures-closure-pass-fold-control-flow` crate will be documented in this file.
 
+## [0.20.2] - 2026-07-02
+
+### Changed — CLOC12.159: handle `Expression::NewExpression`
+
+Added a `NewExpression` match arm mirroring `CallExpression` (recurse into the
+callee and each argument) so this crate compiles and traverses the new
+`Expression::NewExpression` variant. No behaviour change until the bridge
+produces `new` nodes (CLOC12.159 PR2).
+
+
 ## [0.20.1] - 2026-07-02
 
 ### Changed — CLOC12.158: exhaustiveness for new `Expression::UpdateExpression`

--- a/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
+++ b/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-fold-control-flow"
-version = "0.20.1"
+version = "0.20.2"
 edition = "2021"
 description = "Control-flow folding pass for the Closure Compiler clone. Slots between constant-fold and DCE per CLOC06's canonical pass set. Eliminates dead branches (`if (false) A else B → B`), removes unreachable code after `return`/`throw`, and collapses degenerate switch arms."
 

--- a/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
+++ b/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
@@ -56,7 +56,7 @@ use coding_adventures_closure_pass_pipeline::{
 use coding_adventures_correlation_vector::{CVLog, Contribution};
 use coding_adventures_javascript_ast::{
     statement::TaggedStatement, ArrayExpression, AssignmentExpression, AssignmentOperator,
-    AssignmentTarget, BinaryExpression, BindingTarget, BlockStatement, CallExpression,
+    AssignmentTarget, BinaryExpression, BindingTarget, BlockStatement, CallExpression, NewExpression,
     ConditionalExpression, Declaration, EmptyStatement, Expression, ExpressionStatement, ForInit,
     ArrowBody, ArrowFunctionExpression, TemplateLiteral,
     ForInStatement, ForOfStatement, ForStatement, FunctionDeclaration, FunctionExpression, Identifier, IfStatement,
@@ -273,6 +273,7 @@ fn expression_cv(expr: &Expression) -> Option<String> {
         AssignmentExpression(e) => e.cv.clone(),
         ConditionalExpression(e) => e.cv.clone(),
         CallExpression(e) => e.cv.clone(),
+        NewExpression(e) => e.cv.clone(),
         MemberExpression(e) => e.cv.clone(),
         ArrayExpression(e) => e.cv.clone(),
         ObjectExpression(e) => e.cv.clone(),
@@ -1393,6 +1394,11 @@ fn fold_expression(expr: &Expression, st: &mut FoldState) -> Expression {
             cv: c.cv.clone(),
             callee: Box::new(fold_expression(&c.callee, st)),
             arguments: c.arguments.iter().map(|a| fold_expression(a, st)).collect(),
+        }),
+        Expression::NewExpression(n) => Expression::NewExpression(NewExpression {
+            cv: n.cv.clone(),
+            callee: Box::new(fold_expression(&n.callee, st)),
+            arguments: n.arguments.iter().map(|a| fold_expression(a, st)).collect(),
         }),
         Expression::MemberExpression(m) => Expression::MemberExpression(MemberExpression {
             cv: m.cv.clone(),

--- a/code/packages/rust/closure-pass-inline-variables/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-inline-variables/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `coding-adventures-closure-pass-inline-variables` crate will be documented in this file.
 
+## [0.11.2] - 2026-07-02
+
+### Changed — CLOC12.159: handle `Expression::NewExpression`
+
+Added a `NewExpression` match arm mirroring `CallExpression` (recurse into the
+callee and each argument) so this crate compiles and traverses the new
+`Expression::NewExpression` variant. No behaviour change until the bridge
+produces `new` nodes (CLOC12.159 PR2).
+
+
 ## [0.11.1] - 2026-07-02
 
 ### Changed — CLOC12.158: exhaustiveness for new `Expression::UpdateExpression`

--- a/code/packages/rust/closure-pass-inline-variables/Cargo.toml
+++ b/code/packages/rust/closure-pass-inline-variables/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-inline-variables"
-version = "0.11.1"
+version = "0.11.2"
 edition = "2021"
 description = "Constant-propagation pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Replaces references to a top-level `const` bound to a literal with the literal itself, so the binding becomes unused and remove-unused-vars deletes it."
 

--- a/code/packages/rust/closure-pass-inline-variables/src/lib.rs
+++ b/code/packages/rust/closure-pass-inline-variables/src/lib.rs
@@ -761,6 +761,12 @@ fn count_uses_expr(expr: &Expression, name: &str, count: &mut usize) {
                 count_uses_expr(a, name, count);
             }
         }
+        Expression::NewExpression(ne) => {
+            count_uses_expr(&ne.callee, name, count);
+            for a in &ne.arguments {
+                count_uses_expr(a, name, count);
+            }
+        }
         Expression::MemberExpression(m) => {
             count_uses_member(&m.object, &m.property, m.computed, name, count)
         }
@@ -1035,6 +1041,12 @@ fn propagate_in_expr(expr: &mut Expression, cand: &ConstCandidate) -> bool {
         Expression::CallExpression(ce) => {
             changed |= propagate_in_expr(&mut ce.callee, cand);
             for a in &mut ce.arguments {
+                changed |= propagate_in_expr(a, cand);
+            }
+        }
+        Expression::NewExpression(ne) => {
+            changed |= propagate_in_expr(&mut ne.callee, cand);
+            for a in &mut ne.arguments {
                 changed |= propagate_in_expr(a, cand);
             }
         }

--- a/code/packages/rust/closure-pass-inline/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-inline/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `coding-adventures-closure-pass-inline` crate will be documented in this file.
 
+## [0.25.2] - 2026-07-02
+
+### Changed — CLOC12.159: handle `Expression::NewExpression`
+
+Added a `NewExpression` match arm mirroring `CallExpression` (recurse into the
+callee and each argument) so this crate compiles and traverses the new
+`Expression::NewExpression` variant. No behaviour change until the bridge
+produces `new` nodes (CLOC12.159 PR2).
+
+
 ## [0.25.1] - 2026-07-02
 
 ### Changed — CLOC12.158: exhaustiveness for new `Expression::UpdateExpression`

--- a/code/packages/rust/closure-pass-inline/Cargo.toml
+++ b/code/packages/rust/closure-pass-inline/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-inline"
-version = "0.25.1"
+version = "0.25.2"
 edition = "2021"
 description = "Function-inlining pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Substitutes small or single-use function bodies at their call sites to enable downstream folding and shrink call overhead."
 

--- a/code/packages/rust/closure-pass-inline/src/lib.rs
+++ b/code/packages/rust/closure-pass-inline/src/lib.rs
@@ -459,6 +459,9 @@ fn expr_node_count(expr: &Expression) -> usize {
         Expression::CallExpression(ce) => {
             expr_node_count(&ce.callee) + ce.arguments.iter().map(expr_node_count).sum::<usize>()
         }
+        Expression::NewExpression(ne) => {
+            expr_node_count(&ne.callee) + ne.arguments.iter().map(expr_node_count).sum::<usize>()
+        }
         Expression::MemberExpression(m) => {
             expr_node_count(&m.object) + expr_node_count(&m.property)
         }
@@ -766,6 +769,12 @@ fn collect_binding_idents_expr(expr: &Expression, out: &mut HashSet<String>) {
                 collect_binding_idents_expr(a, out);
             }
         }
+        Expression::NewExpression(ne) => {
+            collect_binding_idents_expr(&ne.callee, out);
+            for a in &ne.arguments {
+                collect_binding_idents_expr(a, out);
+            }
+        }
         Expression::MemberExpression(m) => {
             collect_binding_idents_member(&m.object, &m.property, m.computed, out)
         }
@@ -1041,6 +1050,16 @@ fn tally_expr(expr: &Expression, cand: &InlineCandidate, t: &mut Tally) {
             }
             tally_expr(&ce.callee, cand, t);
             for a in &ce.arguments {
+                tally_expr(a, cand, t);
+            }
+        }
+        // A `new X(args)` is a *construction*, not a function call the inliner
+        // can substitute — it never adds to `inlinable` / `arity_calls`. Its
+        // callee and arguments are still ordinary uses of the candidate, so
+        // recurse (mirrors the CallExpression tail without the call gate).
+        Expression::NewExpression(ne) => {
+            tally_expr(&ne.callee, cand, t);
+            for a in &ne.arguments {
                 tally_expr(a, cand, t);
             }
         }
@@ -1328,6 +1347,14 @@ fn inline_in_expr(expr: &mut Expression, cand: &InlineCandidate) -> bool {
         }
         // CallExpression handled above.
         Expression::CallExpression(_) => unreachable!("CallExpression handled before this match"),
+        // `new X(args)` is not an inlinable function call — recurse into the
+        // callee and arguments so a nested inlinable call is still reached.
+        Expression::NewExpression(ne) => {
+            changed |= inline_in_expr(&mut ne.callee, cand);
+            for a in &mut ne.arguments {
+                changed |= inline_in_expr(a, cand);
+            }
+        }
         Expression::MemberExpression(m) => changed |= inline_in_member(m, cand),
         Expression::ArrayExpression(ae) => {
             for el in ae.elements.iter_mut().flatten() {
@@ -1441,6 +1468,12 @@ fn substitute(expr: &mut Expression, map: &HashMap<String, Expression>) {
         Expression::CallExpression(ce) => {
             substitute(&mut ce.callee, map);
             for a in &mut ce.arguments {
+                substitute(a, map);
+            }
+        }
+        Expression::NewExpression(ne) => {
+            substitute(&mut ne.callee, map);
+            for a in &mut ne.arguments {
                 substitute(a, map);
             }
         }
@@ -1811,6 +1844,12 @@ fn expr_collect_mutated_params(
         Expression::CallExpression(ce) => {
             expr_collect_mutated_params(&ce.callee, params, out);
             for a in &ce.arguments {
+                expr_collect_mutated_params(a, params, out);
+            }
+        }
+        Expression::NewExpression(ne) => {
+            expr_collect_mutated_params(&ne.callee, params, out);
+            for a in &ne.arguments {
                 expr_collect_mutated_params(a, params, out);
             }
         }
@@ -3254,6 +3293,12 @@ fn rename_in_expr(expr: &mut Expression, map: &HashMap<String, String>) {
         Expression::CallExpression(ce) => {
             rename_in_expr(&mut ce.callee, map);
             for a in &mut ce.arguments {
+                rename_in_expr(a, map);
+            }
+        }
+        Expression::NewExpression(ne) => {
+            rename_in_expr(&mut ne.callee, map);
+            for a in &mut ne.arguments {
                 rename_in_expr(a, map);
             }
         }

--- a/code/packages/rust/closure-pass-rename-globals/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename-globals/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename-globals` crate will be documented in this file.
 
+## [0.10.2] - 2026-07-02
+
+### Changed — CLOC12.159: handle `Expression::NewExpression`
+
+Added a `NewExpression` match arm mirroring `CallExpression` (recurse into the
+callee and each argument) so this crate compiles and traverses the new
+`Expression::NewExpression` variant. No behaviour change until the bridge
+produces `new` nodes (CLOC12.159 PR2).
+
+
 ## [0.10.1] - 2026-07-02
 
 ### Changed — CLOC12.158: exhaustiveness for new `Expression::UpdateExpression`

--- a/code/packages/rust/closure-pass-rename-globals/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename-globals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename-globals"
-version = "0.10.1"
+version = "0.10.2"
 edition = "2021"
 description = "Aggressive top-level (global) renaming pass for the Closure Compiler clone — the ADVANCED-level complement to closure-pass-rename. Shortens program-private top-level names, gated by an externs do-not-rename boundary."
 

--- a/code/packages/rust/closure-pass-rename-globals/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename-globals/src/lib.rs
@@ -667,6 +667,12 @@ fn collect_all_idents_expr(expr: &Expression, out: &mut HashSet<String>) {
                 collect_all_idents_expr(a, out);
             }
         }
+        Expression::NewExpression(ne) => {
+            collect_all_idents_expr(&ne.callee, out);
+            for a in &ne.arguments {
+                collect_all_idents_expr(a, out);
+            }
+        }
         Expression::MemberExpression(m) => {
             collect_all_idents_member(&m.object, &m.property, m.computed, out)
         }
@@ -966,6 +972,12 @@ fn rename_apply_expr(expr: &mut Expression, map: &HashMap<String, String>) {
         Expression::CallExpression(ce) => {
             rename_apply_expr(&mut ce.callee, map);
             for a in &mut ce.arguments {
+                rename_apply_expr(a, map);
+            }
+        }
+        Expression::NewExpression(ne) => {
+            rename_apply_expr(&mut ne.callee, map);
+            for a in &mut ne.arguments {
                 rename_apply_expr(a, map);
             }
         }

--- a/code/packages/rust/closure-pass-rename-properties/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename-properties/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename-properties` crate will be documented in this file.
 
+## [0.12.2] - 2026-07-02
+
+### Changed — CLOC12.159: handle `Expression::NewExpression`
+
+Added a `NewExpression` match arm mirroring `CallExpression` (recurse into the
+callee and each argument) so this crate compiles and traverses the new
+`Expression::NewExpression` variant. No behaviour change until the bridge
+produces `new` nodes (CLOC12.159 PR2).
+
+
 ## [0.12.1] - 2026-07-02
 
 ### Changed — CLOC12.158: exhaustiveness for new `Expression::UpdateExpression`

--- a/code/packages/rust/closure-pass-rename-properties/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename-properties/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename-properties"
-version = "0.12.1"
+version = "0.12.2"
 edition = "2021"
 description = "Aggressive property renaming pass for the Closure Compiler clone (ADVANCED-only). Consistently shortens program-private object property names that are never quoted/computed and not in the built-in or externs do-not-rename boundary."
 

--- a/code/packages/rust/closure-pass-rename-properties/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename-properties/src/lib.rs
@@ -1173,6 +1173,12 @@ fn classify_expr(expr: &Expression, cls: &mut Classify) {
                 classify_expr(a, cls);
             }
         }
+        Expression::NewExpression(ne) => {
+            classify_expr(&ne.callee, cls);
+            for a in &ne.arguments {
+                classify_expr(a, cls);
+            }
+        }
         Expression::MemberExpression(m) => classify_member(&m.object, &m.property, m.computed, cls),
         Expression::ArrayExpression(ae) => {
             for el in ae.elements.iter().flatten() {
@@ -1430,6 +1436,12 @@ fn rewrite_expr(expr: &mut Expression, map: &HashMap<String, String>) {
         Expression::CallExpression(ce) => {
             rewrite_expr(&mut ce.callee, map);
             for a in &mut ce.arguments {
+                rewrite_expr(a, map);
+            }
+        }
+        Expression::NewExpression(ne) => {
+            rewrite_expr(&mut ne.callee, map);
+            for a in &mut ne.arguments {
                 rewrite_expr(a, map);
             }
         }

--- a/code/packages/rust/closure-pass-rename/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename` crate will be documented in this file.
 
+## [0.14.2] - 2026-07-02
+
+### Changed — CLOC12.159: handle `Expression::NewExpression`
+
+Added a `NewExpression` match arm mirroring `CallExpression` (recurse into the
+callee and each argument) so this crate compiles and traverses the new
+`Expression::NewExpression` variant. No behaviour change until the bridge
+produces `new` nodes (CLOC12.159 PR2).
+
+
 ## [0.14.1] - 2026-07-02
 
 ### Changed — CLOC12.158: exhaustiveness for new `Expression::UpdateExpression`

--- a/code/packages/rust/closure-pass-rename/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename"
-version = "0.14.1"
+version = "0.14.2"
 edition = "2021"
 description = "Variable renaming pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Replaces non-exported binding names with shorter identifiers to reduce output size while preserving externally-visible names and semantics."
 

--- a/code/packages/rust/closure-pass-rename/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename/src/lib.rs
@@ -945,6 +945,12 @@ fn collect_all_idents_expr(expr: &Expression, out: &mut HashSet<String>) {
                 collect_all_idents_expr(a, out);
             }
         }
+        Expression::NewExpression(ne) => {
+            collect_all_idents_expr(&ne.callee, out);
+            for a in &ne.arguments {
+                collect_all_idents_expr(a, out);
+            }
+        }
         Expression::MemberExpression(m) => {
             collect_all_idents_member(&m.object, &m.property, m.computed, out)
         }
@@ -1228,6 +1234,12 @@ fn rewrite_uses_expr(expr: &mut Expression, map: &HashMap<String, String>) {
         Expression::CallExpression(ce) => {
             rewrite_uses_expr(&mut ce.callee, map);
             for a in &mut ce.arguments {
+                rewrite_uses_expr(a, map);
+            }
+        }
+        Expression::NewExpression(ne) => {
+            rewrite_uses_expr(&mut ne.callee, map);
+            for a in &mut ne.arguments {
                 rewrite_uses_expr(a, map);
             }
         }

--- a/code/packages/rust/closure-scope-analyzer/CHANGELOG.md
+++ b/code/packages/rust/closure-scope-analyzer/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `coding-adventures-closure-scope-analyzer` crate will be documented in this file.
 
+## [0.12.2] - 2026-07-02
+
+### Changed — CLOC12.159: handle `Expression::NewExpression`
+
+Added a `NewExpression` match arm mirroring `CallExpression` (recurse into the
+callee and each argument) so this crate compiles and traverses the new
+`Expression::NewExpression` variant. No behaviour change until the bridge
+produces `new` nodes (CLOC12.159 PR2).
+
+
 ## [0.12.1] - 2026-07-02
 
 ### Changed — CLOC12.158: exhaustiveness for new `Expression::UpdateExpression`

--- a/code/packages/rust/closure-scope-analyzer/Cargo.toml
+++ b/code/packages/rust/closure-scope-analyzer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-scope-analyzer"
-version = "0.12.1"
+version = "0.12.2"
 edition = "2021"
 description = "Lexical scope + symbol-table analyzer for the Closure Compiler clone. Per CLOC13 — produces a `ScopeAnalysis` consumed by the rename, inline, treeshake, collapse-properties, and remove-unused-vars passes."
 

--- a/code/packages/rust/closure-scope-analyzer/src/lib.rs
+++ b/code/packages/rust/closure-scope-analyzer/src/lib.rs
@@ -893,6 +893,12 @@ fn walk_expression(
                 walk_expression(arg, ctx, analysis, pending);
             }
         }
+        Expression::NewExpression(ne) => {
+            walk_expression(&ne.callee, ctx, analysis, pending);
+            for arg in &ne.arguments {
+                walk_expression(arg, ctx, analysis, pending);
+            }
+        }
         Expression::MemberExpression(me) => {
             walk_member_expression_inner(&me.object, &me.property, me.computed, ctx, analysis, pending);
         }

--- a/code/packages/rust/javascript-ast/CHANGELOG.md
+++ b/code/packages/rust/javascript-ast/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to the `coding-adventures-javascript-ast` crate will be documented in this file.
 
+## [0.18.0] - 2026-07-02
+
+### Added — CLOC12.159: `Expression::NewExpression` (`new X(args)`)
+
+New `NewExpression { cv, callee, arguments }` variant of `Expression` for the
+`new` operator. Structurally a `CallExpression` (callee + arguments) but a
+distinct node because its evaluation semantics (object construction) and its
+grammar precedence differ — a pass must never rewrite one into the other.
+Re-exported from the crate root. This is the atomic node PR (PR1); the bridge
+conversion (PR2) and the CodePrinter conformance port (PR3) follow.
+
+
 ## [0.17.0] - 2026-07-02
 
 ### Added — CLOC12.158: `UpdateExpression` (`++` / `--`)

--- a/code/packages/rust/javascript-ast/Cargo.toml
+++ b/code/packages/rust/javascript-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-javascript-ast"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 description = "Backend-agnostic JavaScript AST — full ESTree-compatible node taxonomy with optional per-node CV id. Reusable by the Closure-Compiler-clone and the future V8-in-Rust clone. Per CLOC02 / CLOC09."
 

--- a/code/packages/rust/javascript-ast/README.md
+++ b/code/packages/rust/javascript-ast/README.md
@@ -61,6 +61,13 @@ emitter grow a need for them — each behind its own `CLOC12.NN` slice:
   from `x++` (yield the old value). Node + `closure-emitter` + all pass
   traversals land in one atomic PR; the bridge-enable + conformance port
   follow (gap-159).
+- `NewExpression` (CLOC12.159) — the `new` operator: `new Ctor(a, b)`.
+  `NewExpression { callee: Box<Expression>, arguments: Vec<Expression> }`.
+  Structurally a `CallExpression` but a distinct node: its semantics are object
+  *construction* (a pass must never rewrite `new f()` into `f()`), and its
+  callee excludes a trailing call (`new (f())()` needs the parens). Node +
+  `closure-emitter` + all pass traversals land in one atomic PR; the
+  bridge-enable + conformance port follow (gap-160).
 
 ## What's coming (follow-up PRs)
 

--- a/code/packages/rust/javascript-ast/src/expression.rs
+++ b/code/packages/rust/javascript-ast/src/expression.rs
@@ -58,6 +58,7 @@ pub enum Expression {
     ArrowFunctionExpression(ArrowFunctionExpression),
     TemplateLiteral(TemplateLiteral),
     UpdateExpression(UpdateExpression),
+    NewExpression(NewExpression),
 }
 
 // ---------------------------------------------------------------------
@@ -356,6 +357,62 @@ pub struct ConditionalExpression {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CallExpression {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub cv: Option<CvId>,
+    pub callee: Box<Expression>,
+    pub arguments: Vec<Expression>,
+}
+
+/// `new Ctor(a, b)` — construction via the `new` operator. Structurally a
+/// [`CallExpression`] with a `new` keyword, but a **distinct** node because
+/// its evaluation semantics and its precedence rules differ:
+///
+/// # Semantics
+///
+/// `new Ctor(args)` allocates a fresh object, runs `Ctor` with `this` bound to
+/// it, and yields the object (unless the constructor returns its own object).
+/// A [`CallExpression`] `Ctor(args)` merely calls the function. A pass may not
+/// rewrite one into the other.
+///
+/// # `arguments` may be empty
+///
+/// `new Ctor` (no parens) and `new Ctor()` (empty parens) are the **same**
+/// program — both carry `arguments: vec![]`. The two source spellings collapse
+/// to one node; the emitter chooses a canonical spelling.
+///
+/// # Precedence
+///
+/// Per the ECMAScript grammar the *argumented* form is a `MemberExpression`
+/// (`new MemberExpression Arguments`) while the *bare* form is a lower
+/// `NewExpression` (`new NewExpression`), so in source they bind differently:
+///
+/// ```text
+///   new X().y     parses as   (new X()).y     ← argumented: member binds after
+///   new X.y       parses as   new (X.y)       ← bare: the whole member is the target
+/// ```
+///
+/// The emitter sidesteps the split by **always printing the argument parens** —
+/// a no-argument node is emitted canonically as `new X()`, never bare `new X`.
+/// Every emitted `new` is therefore the argumented form and binds at
+/// member/call strength, so `new X().y` needs no extra parens. (Dropping the
+/// empty parens as a size win is a possible future optimization; it would
+/// reintroduce the looser bare-form precedence.)
+///
+/// # The callee (`callee`) excludes a trailing call
+///
+/// The `new` target is a `MemberExpression`, which by grammar cannot *be* a
+/// call. So if the callee's member spine bottoms out in a call, the target
+/// must be parenthesised or the `(args)` we emit would bind to the *inner*
+/// call instead:
+///
+/// ```text
+///   new (f())()   NOT   new f()()   (which is (new f())() — a different program)
+/// ```
+///
+/// The emitter's `emit_new` parenthesises exactly this case.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NewExpression {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub cv: Option<CvId>,
     pub callee: Box<Expression>,

--- a/code/packages/rust/javascript-ast/src/lib.rs
+++ b/code/packages/rust/javascript-ast/src/lib.rs
@@ -137,6 +137,7 @@ pub use expression::{
     BigIntLiteral, BinaryExpression, BinaryOperator, BooleanLiteral, CallExpression,
     ConditionalExpression, Expression, FunctionExpression, Identifier, LogicalExpression,
     LogicalOperator, MemberExpression,
+    NewExpression,
     NullLiteral, NumericLiteral, ObjectExpression, Property, PropertyKey, PropertyKind,
     StringLiteral, TemplateElement, TemplateLiteral, UnaryExpression, UnaryOperator,
     UndefinedLiteral, UpdateExpression, UpdateOperator,

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -1695,3 +1695,53 @@ increment/decrement, a member operand (`a.b++`), bare printing under `!` /
 non-fusing `x++*y`). 14 active `#[test]`s, no `#[ignore]` — the emitter
 conforms to every covered shape. This completes the CLOC12.158
 `UpdateExpression` three-PR arc (node+emit → bridge → conformance).
+
+## CLOC12.159 — `NewExpression` (`new X(args)`): atomic node + emit + passes (PR1)
+
+Adds `Expression::NewExpression { cv, callee, arguments }` to `javascript-ast`
+(0.18.0) — the `new` operator, `new Ctor(a, b)`. Structurally a
+`CallExpression` (callee + argument list) but a **separate** node: its
+evaluation semantics are object *construction* (a pass must never rewrite
+`new f()` into `f()`), and its grammar precedence differs (§ below).
+
+`closure-emitter` (0.23.0) `emit_new` prints `new`, the callee, then the
+argument parens. The parens are **always printed**, so a no-argument node is
+emitted canonically as `new X()` (never bare `new X`) — this keeps every
+emitted `new` in the *argumented* form, which binds at member/call strength
+(`PREC_PRIMARY`), so `new X().y` needs no extra parens. Two seams:
+
+  * **keyword space** — `new`↔identifier/member callee is a word↔word boundary
+    (`newX` would fuse), spent via `required_ws` unless the callee is already
+    parenthesised;
+  * **callee-with-call wrap** — the `new` target is a `MemberExpression` per
+    grammar and cannot itself be a call, so a callee whose member spine bottoms
+    out in a call is wrapped: `new (f())()`, `new (a.b().c)()` — otherwise the
+    appended `(args)` binds to the inner call (`new f()()` = `(new f())()`, a
+    different program). `new_callee_needs_parens` decides this.
+
+All nine downstream pass/analysis crates (`constant-fold`, `dce`,
+`fold-control-flow`, `inline`, `inline-variables`, `rename`, `rename-globals`,
+`rename-properties`, `scope-analyzer`) get a `NewExpression` match arm
+mirroring `CallExpression` (recurse callee + args), landed in the same atomic
+commit so the workspace never has a broken exhaustive `match`. The `inline`
+pass explicitly does **not** treat a `new` as an inlinable call (it is a
+construction), so its tally arm recurses without the call-inlining gate.
+
+8 new emitter unit tests (identifier/args/member-chain callee, call-callee and
+member-spine-call wraps, argumented-new as member object, no-arg canonical
+`new X()`, nested `new new X()()`). No behaviour change for existing inputs —
+the bridge still declines `new` (gap-160), so closurec falls back to
+WHITESPACE_ONLY on `new` for now. PR2 (bridge-enable) and PR3 (conformance
+port) follow.
+
+### gap-160 — bridge declines `new_expression` (`new X`)
+
+The `javascript-parser` typed-AST bridge's `convert_new_expression` passes a
+plain `member_expression` (no `new` keyword) straight through, but returns
+`UnsupportedSyntax { rule: "NewExpression" }` for the actual `"new" X` form —
+so any file containing `new` currently drops to WHITESPACE_ONLY. With the
+`Expression::NewExpression` node now in place (CLOC12.159 PR1), the bridge can
+convert it: PR2 will build `NewExpression { callee, arguments }` from the
+grammar node (the argument list comes from the `member_expression = "new"
+member_expression arguments` production) and add a closurec e2e diff fixture,
+closing this gap.


### PR DESCRIPTION
## CLOC12.159 PR1 — `NewExpression` (`new X(args)`): atomic node + emit + passes

First PR of the CLOC12.159 `NewExpression` arc, following the same three-PR shape as CLOC12.158 (UpdateExpression): **PR1** atomic node+emit+passes → **PR2** bridge-enable → **PR3** conformance port.

Adds `Expression::NewExpression { cv, callee: Box<Expression>, arguments: Vec<Expression> }` to `javascript-ast` for the `new` operator (`new Ctor(a, b)`). Structurally a `CallExpression` but a **distinct** node — its semantics are object *construction* (a pass must never rewrite `new f()` into `f()`) and its grammar precedence differs. The AST variant, the emitter, and every downstream exhaustive `match` land in **one commit** so the workspace never has a broken build.

### `closure-emitter` — `emit_new`
- Prints `new`, the callee, then the argument parens. The `()` is **always** printed, so a no-argument node emits canonically as `new X()` (never bare `new X`); every emitted `new` is the argumented form and binds at member/call strength (`PREC_PRIMARY`), so `new X().y` needs no extra parens.
- **keyword-space seam**: `new`↔identifier/member callee would fuse (`newX`), so `required_ws` separates them — skipped when the callee is parenthesised.
- **callee-with-call wrap**: the `new` target is a `MemberExpression` per grammar and cannot be a call, so a callee whose member spine bottoms out in a call is wrapped — `new (f())()`, `new (a.b().c)()` — or the appended `(args)` would bind to the inner call (`new f()()` = `(new f())()`, a miscompile). `new_callee_needs_parens` decides this.
- 8 new unit tests (identifier / args / member-chain callee, call-callee + member-spine wraps, argumented-new as member object, no-arg canonical `new X()`, nested `new new X()()`).

### 9 downstream pass/analysis crates
Each gets a `NewExpression` match arm mirroring `CallExpression` (recurse callee + args): `constant-fold`, `dce`, `fold-control-flow` (traversal + the exhaustive `expression_cv` provenance accessor), `inline`, `inline-variables`, `rename`, `rename-globals`, `rename-properties`, `scope-analyzer`. The `inline` pass deliberately does **not** count a `new` as an inlinable call (it is a construction), so its tally arm recurses without the call-inlining gate. `constant-fold`/`dce` treat `new` as unconditionally side-effecting (never folded, never elided).

### No behaviour change yet
The bridge still declines `new` (gap-160), so closurec falls back to WHITESPACE_ONLY on `new` for now. PR2 wires the bridge; PR3 ports the upstream CodePrinter cases.

### Versions
javascript-ast `0.17.0` → `0.18.0`, closure-emitter `0.22.1` → `0.23.0` (minor: new node), 9 passes patch-bumped, each with a CHANGELOG entry.

### Verification
- `cargo test` green: javascript-ast, closure-emitter (134 lib + all upstream suites), all 9 pass crates, and the downstream **closurec** CLI.
- Inline security review → **PASSED** (confirmed callee-wrapping soundness / no reparse miscompile, bounded recursion, correct semantic-preservation in transforms).

### Docs
javascript-ast README variant note; `CLOC12-gaps.md` CLOC12.159 section + **gap-160** (bridge declines `new_expression`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)