### PR TITLE
[codex] Add fragment context cross-axis audit evidence

### DIFF
--- a/code/packages/rust/html-parser/tests/whatwg_fragment_context_audit_test.rs
+++ b/code/packages/rust/html-parser/tests/whatwg_fragment_context_audit_test.rs
@@ -5,8 +5,28 @@ use serde::Deserialize;
 use std::collections::{BTreeMap, HashMap};
 
 const TREE_CONSTRUCTION_SMOKE: &str = include_str!("fixtures/html5lib-tree-construction-smoke.dat");
+const WHATWG_BLOCK_BOUNDARY_AUDIT: &str = include_str!("fixtures/whatwg-block-boundary-audit.json");
+const WHATWG_DOCUMENT_SHELL_AUDIT: &str = include_str!("fixtures/whatwg-document-shell-audit.json");
+const WHATWG_FORM_INTERACTIVE_AUDIT: &str =
+    include_str!("fixtures/whatwg-form-interactive-audit.json");
+const WHATWG_FORMATTING_AUDIT: &str = include_str!("fixtures/whatwg-formatting-audit.json");
 const WHATWG_FRAGMENT_CONTEXT_AUDIT: &str =
     include_str!("fixtures/whatwg-fragment-context-audit.json");
+const WHATWG_FRAMESET_AUDIT: &str = include_str!("fixtures/whatwg-frameset-audit.json");
+const WHATWG_TABLE_AUDIT: &str = include_str!("fixtures/whatwg-table-audit.json");
+const WHATWG_TEMPLATE_AUDIT: &str = include_str!("fixtures/whatwg-template-audit.json");
+const WHATWG_TEXT_CONTROL_AUDIT: &str = include_str!("fixtures/whatwg-text-control-audit.json");
+const WHATWG_TREE_INSERTION_AUDIT: &str = include_str!("fixtures/whatwg-tree-insertion-audit.json");
+const WHATWG_VOID_ELEMENT_AUDIT: &str = include_str!("fixtures/whatwg-void-element-audit.json");
+
+struct FragmentCrossAxisCase {
+    id: &'static str,
+    context: &'static str,
+    fragment_axis: &'static str,
+    data_snippet: &'static str,
+    suites: &'static [(&'static str, &'static str, &'static str)],
+}
+
 const POST_PARSE_REPAIR_EVIDENCE: &[(&str, &str, &str)] = &[
     ("tests4-dat-1", "div", "fragment-basic-context"),
     ("tests4-dat-2", "textarea", "fragment-text-mode-context"),
@@ -25,6 +45,116 @@ const POST_PARSE_REPAIR_EVIDENCE: &[(&str, &str, &str)] = &[
     ),
     ("template-dat-109", "template", "fragment-template-context"),
 ];
+const TEMPLATE_FRAGMENT_CROSS_AXIS_SUITES: &[(&str, &str, &str)] = &[
+    (
+        "block-boundary",
+        WHATWG_BLOCK_BOUNDARY_AUDIT,
+        "block-fragment-context",
+    ),
+    (
+        "form-interactive",
+        WHATWG_FORM_INTERACTIVE_AUDIT,
+        "form-control",
+    ),
+    (
+        "template",
+        WHATWG_TEMPLATE_AUDIT,
+        "template-fragment-context",
+    ),
+    (
+        "tree-insertion",
+        WHATWG_TREE_INSERTION_AUDIT,
+        "template-insertion",
+    ),
+    (
+        "void-element",
+        WHATWG_VOID_ELEMENT_AUDIT,
+        "void-fragment-context",
+    ),
+];
+const TABLE_FRAGMENT_CROSS_AXIS_SUITES: &[(&str, &str, &str)] = &[
+    (
+        "form-interactive",
+        WHATWG_FORM_INTERACTIVE_AUDIT,
+        "interactive-formatting",
+    ),
+    (
+        "formatting",
+        WHATWG_FORMATTING_AUDIT,
+        "interactive-formatting-boundary",
+    ),
+    ("table", WHATWG_TABLE_AUDIT, "table-fragment-context"),
+    (
+        "tree-insertion",
+        WHATWG_TREE_INSERTION_AUDIT,
+        "html-fragment",
+    ),
+    (
+        "void-element",
+        WHATWG_VOID_ELEMENT_AUDIT,
+        "void-fragment-context",
+    ),
+];
+const TEXT_MODE_FRAGMENT_CROSS_AXIS_SUITES: &[(&str, &str, &str)] = &[
+    (
+        "form-interactive",
+        WHATWG_FORM_INTERACTIVE_AUDIT,
+        "fragment-context",
+    ),
+    (
+        "formatting",
+        WHATWG_FORMATTING_AUDIT,
+        "formatting-reconstruction",
+    ),
+    (
+        "text-control",
+        WHATWG_TEXT_CONTROL_AUDIT,
+        "fragment-context",
+    ),
+];
+const FRAMESET_FRAGMENT_CROSS_AXIS_SUITES: &[(&str, &str, &str)] = &[
+    (
+        "document-shell",
+        WHATWG_DOCUMENT_SHELL_AUDIT,
+        "body-frameset-boundary",
+    ),
+    ("frameset", WHATWG_FRAMESET_AUDIT, "frame-element"),
+    (
+        "void-element",
+        WHATWG_VOID_ELEMENT_AUDIT,
+        "void-fragment-context",
+    ),
+];
+const FRAGMENT_CROSS_AXIS_CASES: &[FragmentCrossAxisCase] = &[
+    FragmentCrossAxisCase {
+        id: "template-dat-109",
+        context: "template",
+        fragment_axis: "fragment-template-context",
+        data_snippet: "<template><form><input name=\"q\"></form><div>second</div></template>",
+        suites: TEMPLATE_FRAGMENT_CROSS_AXIS_SUITES,
+    },
+    FragmentCrossAxisCase {
+        id: "tests-innerhtml-1-dat-13",
+        context: "table",
+        fragment_axis: "fragment-table-context",
+        data_snippet: "<a><colgroup><col>",
+        suites: TABLE_FRAGMENT_CROSS_AXIS_SUITES,
+    },
+    FragmentCrossAxisCase {
+        id: "tests4-dat-3",
+        context: "textarea",
+        fragment_axis: "fragment-text-mode-context",
+        data_snippet: "textarea content with <em>pseudo</em> <foo>markup",
+        suites: TEXT_MODE_FRAGMENT_CROSS_AXIS_SUITES,
+    },
+    FragmentCrossAxisCase {
+        id: "tests6-dat-30",
+        context: "frameset",
+        fragment_axis: "fragment-shell-context",
+        data_snippet: "</frameset><frame>",
+        suites: FRAMESET_FRAGMENT_CROSS_AXIS_SUITES,
+    },
+];
 
 #[derive(Debug, Deserialize)]
 struct FragmentContextAuditSuite {
@@ -41,6 +171,19 @@ struct FragmentContextAuditCase {
     id: String,
     source: String,
     context: String,
+    axis: String,
+    reason: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GenericAuditSuite {
+    cases: Vec<GenericAuditCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GenericAuditCase {
+    id: String,
+    source: String,
     axis: String,
     reason: String,
 }
@@ -103,6 +246,87 @@ fn whatwg_fragment_context_audit_cases_match_parser_dom_dump() {
 }
 
 #[test]
+fn whatwg_fragment_context_audit_keeps_special_context_cases_cross_axis() {
+    let suite = load_suite();
+    let fragment_cases = suite
+        .cases
+        .iter()
+        .map(|case| (case.id.as_str(), case))
+        .collect::<HashMap<_, _>>();
+    let smoke_cases = parse_tree_construction_cases(TREE_CONSTRUCTION_SMOKE)
+        .into_iter()
+        .map(|case| (case.source.clone(), case))
+        .collect::<HashMap<_, _>>();
+
+    for evidence in FRAGMENT_CROSS_AXIS_CASES {
+        let fragment_case = fragment_cases
+            .get(evidence.id)
+            .unwrap_or_else(|| panic!("fragment-context audit should include `{}`", evidence.id));
+        assert_eq!(
+            fragment_case.context, evidence.context,
+            "fragment-context row `{}` should keep its focused fragment context",
+            evidence.id
+        );
+        assert_eq!(
+            fragment_case.axis, evidence.fragment_axis,
+            "fragment-context row `{}` should stay on its focused audit axis",
+            evidence.id
+        );
+        assert!(
+            !fragment_case.reason.is_empty(),
+            "fragment-context row `{}` should keep a fixture reason",
+            evidence.id
+        );
+
+        for (suite_name, fixture, expected_axis) in evidence.suites {
+            let audit_case = generic_audit_case(fixture, suite_name, evidence.id);
+            assert_eq!(
+                audit_case.source, fragment_case.source,
+                "`{suite_name}` should point fragment row `{}` at the same html5lib row as the fragment audit",
+                evidence.id
+            );
+            assert_eq!(
+                audit_case.axis, *expected_axis,
+                "`{suite_name}` should keep fragment row `{}` on its focused axis",
+                evidence.id
+            );
+            assert!(
+                !audit_case.reason.is_empty(),
+                "`{suite_name}` should keep a reason for fragment row `{}`",
+                evidence.id
+            );
+        }
+
+        let source_case = smoke_cases
+            .get(&fragment_case.source)
+            .unwrap_or_else(|| panic!("case `{}` should exist in smoke fixture", evidence.id));
+        assert_eq!(
+            source_case.fragment_context.as_deref(),
+            Some(evidence.context),
+            "fragment row `{}` should keep its smoke fragment context",
+            evidence.id
+        );
+        assert!(
+            source_case.data.contains(evidence.data_snippet),
+            "fragment row `{}` should stay tied to its html5lib input",
+            evidence.id
+        );
+        let actual = actual_dom_dump_for_tree_case(source_case).unwrap_or_else(|error| {
+            panic!(
+                "case `{}` ({}) parse failed: {error}",
+                fragment_case.id, fragment_case.axis
+            )
+        });
+
+        assert_eq!(
+            actual, source_case.document,
+            "cross-axis fragment evidence case `{}` ({}) failed for input {:?}",
+            fragment_case.id, fragment_case.axis, source_case.data
+        );
+    }
+}
+
+#[test]
 fn whatwg_fragment_context_audit_tracks_post_parse_repair_evidence() {
     let suite = load_suite();
     let audit_cases = suite
@@ -154,6 +378,16 @@ fn whatwg_fragment_context_audit_tracks_post_parse_repair_evidence() {
 fn load_suite() -> FragmentContextAuditSuite {
     serde_json::from_str(WHATWG_FRAGMENT_CONTEXT_AUDIT)
         .expect("WHATWG fragment-context audit fixture should parse")
+}
+
+fn generic_audit_case(fixture: &str, suite_name: &str, case_id: &str) -> GenericAuditCase {
+    let suite = serde_json::from_str::<GenericAuditSuite>(fixture)
+        .unwrap_or_else(|error| panic!("`{suite_name}` audit fixture should parse: {error}"));
+    suite
+        .cases
+        .into_iter()
+        .find(|case| case.id == case_id)
+        .unwrap_or_else(|| panic!("`{suite_name}` should audit fragment case `{case_id}`"))
 }
 
 fn assert_axis_count(suite: &FragmentContextAuditSuite, axis: &str, minimum: usize) {


### PR DESCRIPTION
## Summary
- add executable cross-axis coverage for fragment-context audit rows that also appear in template, table, text-mode, frameset, tree-insertion, and void/form/formatting suites
- assert each pinned row keeps the expected fragment context, focused axis, shared html5lib source row, fixture input snippet, and parser DOM dump parity

## Validation
- cargo test -p coding-adventures-html-parser whatwg_fragment_context_audit_keeps_special_context_cases_cross_axis
- cargo test -p coding-adventures-html-parser whatwg_fragment_context_audit
- cargo test -p coding-adventures-html-parser
- CARGO_BUILD_JOBS=2 cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser
- python3 -m json.tool code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json >/dev/null
- python3 code/packages/rust/html-parser/tests/fixtures/check_whatwg_audit_rust_tests.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py
- git diff --check
