### PR TITLE
feat(adj-lang): latex over/under annotations (\overset, \underset, \overbrace, \underbrace) compute transparently

### DIFF
--- a/code/packages/rust/adj-lang/CHANGELOG.md
+++ b/code/packages/rust/adj-lang/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [0.40.0] - 2026-07-02 — over/under annotations (`\overset`, `\underset`, `\overbrace`, `\underbrace`) compute transparently in `latex "…"`
+
+### Added
+
+- `latex "\overset{note}{base}"`, `\underset{note}{base}`, `\overbrace{base}`, `\underbrace{base}` and
+  any other over/under annotation now **compute, lowering transparently to the `base`** and dropping
+  the annotation mark. Like an accent, an over/under mark is a notational decoration, not an
+  operation: `\overbrace{a + b}^{\text{sum}}` labels the sum in prose but computes `a + b`. Previously
+  these were an `UnsupportedLatexMath` error. (`\overline{x}`/`\underline{x}` already computed — they
+  parse as `Accent`, handled by the accent-transparent arm.) Pure adapter recognition — no engine,
+  AST, or lowering change; the arm recurses into the single `base` sub-node exactly like the accent
+  arm, so no new deep-walk vector. Note: `\sum`/`\prod`/`\int` (`MathExpr::BigOp`) remain unsupported —
+  a finite summation/product needs index-binding and bounded unrolling, a larger feature deferred to a
+  dedicated slice.
+
 ## [0.39.0] - 2026-07-02 — subscripted variables (`x_i`, `x_1`, `V_{max}`) bind as distinct names in `latex "…"`
 
 ### Added

--- a/code/packages/rust/adj-lang/Cargo.toml
+++ b/code/packages/rust/adj-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang"
-version = "0.39.0"
+version = "0.40.0"
 edition = "2021"
 description = "Surface-syntax frontend for the adjudication framework's probabilistic-logic rulebooks. Lexes, parses, and lowers a domain-expert-readable DSL into a `logic-engine` KnowledgeBase. Dissolves ADJ46 awkwardness items A10 (rulebook syntax) and A4 (joint contributions syntactically distinct)."
 

--- a/code/packages/rust/adj-lang/src/adapter.rs
+++ b/code/packages/rust/adj-lang/src/adapter.rs
@@ -1246,6 +1246,19 @@ fn latex_math_to_expr_ast(expr: &MathExpr, source: &str) -> Result<ExprAst, Adap
         // dimension and value flowing through the decoration unchanged. Pure adapter recognition:
         // no engine, AST, or lowering change — the accent simply disappears at adapt time.
         MathExpr::Accent { body, .. } => latex_math_to_expr_ast(body, source),
+        // `\overset{note}{base}` / `\underset{note}{base}` (and `\overbrace{base}` /
+        // `\underbrace{base}`, which parse as an `Overset`/`Underset` whose mark is a brace symbol) —
+        // an annotation placed OVER or UNDER a base. Like an accent, an over/under annotation is a
+        // NOTATIONAL decoration, not an operation: `\overbrace{a + b}^{\text{sum}}` labels the sum
+        // in prose but computes `a + b`, and `\underset{x \to 0}{\lim}`-style marks annotate without
+        // changing the base's value. So we lower `Overset`/`Underset` TRANSPARENTLY to the `base`,
+        // discarding the `over`/`under` mark — exactly as the `Accent` arm above drops its diacritic.
+        // The value and dimension flow through the annotation unchanged. Pure adapter recognition: no
+        // engine/AST/lowering change, and (like the accent arm) it recurses into a single strict
+        // sub-node, so no new deep-walk vector.
+        MathExpr::Overset { base, .. } | MathExpr::Underset { base, .. } => {
+            latex_math_to_expr_ast(base, source)
+        }
         MathExpr::Rel(_, _, _) => Err(AdapterError::UnsupportedLatexMath {
             source: source.to_string(),
             detail: "relation-valued LaTeX is only valid in `constrain latex`".into(),

--- a/code/packages/rust/adj-lang/src/lower.rs
+++ b/code/packages/rust/adj-lang/src/lower.rs
@@ -2458,6 +2458,35 @@ contributes 1000000 from answer == 60 to correct
     }
 
     #[test]
+    fn native_latex_overset_underset_are_transparent_to_base() {
+        // `\overset{note}{base}` / `\underset{note}{base}` (and `\overbrace`/`\underbrace`) — an
+        // over/under annotation is a notational decoration, not an operation; the value is the
+        // base's. The adapter lowers Overset/Underset transparently to `base`, dropping the mark.
+        // `\overset{\text{sum}}{a + b}` with a=3, b=4 → 7 (the annotation is discarded).
+        let over = crate::compile_and_decide(
+            "observe a(3)\n\
+             observe b(4)\n\
+             let answer = latex \"$\\overset{s}{a + b}$\"\n\
+             prior 0.10 for correct\n\
+             contributes 1000000 from answer == 7 to correct\n\
+             ? correct\n",
+        )
+        .unwrap();
+        assert!(over.ranked[0].posterior > 0.99, "{over:?}");
+        // `\underbrace{a * b}` (an Underset with a brace mark) with a=6, b=7 → 42.
+        let under = crate::compile_and_decide(
+            "observe a(6)\n\
+             observe b(7)\n\
+             let answer = latex \"$\\underbrace{a * b}$\"\n\
+             prior 0.10 for correct\n\
+             contributes 1000000 from answer == 42 to correct\n\
+             ? correct\n",
+        )
+        .unwrap();
+        assert!(under.ranked[0].posterior > 0.99, "{under:?}");
+    }
+
+    #[test]
     fn native_latex_subscripts_bind_as_distinct_variables() {
         // `x_i` / `x_1` / `V_{max}` — a subscript names a DISTINCT variable, not a computation.
         // The adapter mangles the subscript into a flat `base_sub` identifier that binds to a


### PR DESCRIPTION
## LaTeX consumer slice: over/under annotations compute transparently

`latex "\overset{note}{base}"`, `\underset{note}{base}`, `\overbrace{base}`, `\underbrace{base}` and any other
over/under annotation now **compute, lowering transparently to the `base`** and dropping the annotation mark.

### Behaviour: transparent unwrap to base

Like an accent, an over/under mark is a **notational decoration, not an operation**. `\overbrace{a + b}^{\text{sum}}`
labels the sum in prose but computes `a + b`; `\underset{x \to 0}{…}`-style marks annotate without changing the base's
value. So the adapter lowers `MathExpr::Overset { base, .. }` / `Underset { base, .. }` to the `base`, discarding the
mark. Previously these were an `UnsupportedLatexMath` error.

(`\overline{x}` / `\underline{x}` already computed — they parse as `MathExpr::Accent`, handled by the
accent-transparent arm shipped earlier. This slice covers the remaining `Overset`/`Underset` family.)

### Why probed empirically first

A throwaway `latex/tests/` probe (deleted) confirmed the shapes:
- `\overset{a}{b}` → `Overset { over: Symbol("a"), base: Symbol("b") }`
- `\underset{a}{b}` → `Underset { under: Symbol("a"), base: Symbol("b") }`
- `\overbrace{x}` → `Overset { over: Symbol("⏞"), base: Symbol("x") }` (the brace is the mark)

The adapter had no `Overset`/`Underset` arm → catch-all error. The new arm recurses into the single `base` sub-node,
exactly like the sibling `Accent`/`Group`/`Fenced` arms — no new tree-walking helper, so **no new recursion-depth /
stack-overflow vector**.

### What changed

- **`adapter.rs`** — one arm: `MathExpr::Overset { base, .. } | MathExpr::Underset { base, .. } => latex_math_to_expr_ast(base, source)`.
- **`lower.rs`** — +1 e2e test: `\overset{s}{a + b}` = 7 (annotation discarded); `\underbrace{a * b}` = 42.
- Version 0.39.0 → 0.40.0; CHANGELOG prepended.

### Deferred

`\sum` / `\prod` / `\int` (`MathExpr::BigOp`) remain unsupported and continue to error cleanly — a finite
summation/product needs index-binding and bounded unrolling of the body per index value, a larger feature to be done as
a dedicated slice (with the iterative-walker discipline to avoid the `Bin(Mul)`-spine stack-overflow hazard).

**Pure adapter recognition: no engine, AST, or lowering change.** `cargo test -p logic-engine -p adj-lang -p
adj-lang-cli -p adj-constraint-solver` green (120 adj-lang tests). Security review passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
