### PR TITLE
feat(js-parser): CLOC12.159 PR2 — bridge new X(args) → NewExpression (closes gap-160)

### DIFF
--- a/code/packages/rust/javascript-parser/CHANGELOG.md
+++ b/code/packages/rust/javascript-parser/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to the `coding-adventures-javascript-parser` crate will be documented in this file.
 
+## [0.24.0] - 2026-07-02
+
+### Added — CLOC12.159 PR2: bridge `new X(args)` → `NewExpression` (closes gap-160)
+
+The typed-AST bridge now converts the `new` operator instead of declining it to
+`UnsupportedSyntax` (which dragged the whole file to WHITESPACE_ONLY). `new`
+appears in **two** grammar productions, and both are handled:
+
+- **argumented** `new X(args)` parses as `member_expression = "new"
+  member_expression arguments` — `convert_member_expression` now builds a
+  `NewExpression { callee, arguments }` as the base and folds any trailing
+  `.NAME` / `[expr]` suffix onto it (so `new X().y` and `new X()[k]` convert
+  correctly);
+- **bare** `new X` parses as `new_expression = "new" new_expression` —
+  `convert_new_expression` builds a `NewExpression` with an **empty** argument
+  list (semantically identical to `new X()`).
+
+Arguments reuse `convert_arguments`, so a spread argument (`new X(...a)`) still
+declines gracefully (`SpreadElement` is a later slice). `new.target` still
+declines (`NewTarget`, Phase 3). 7 new bridge tests (identifier / args / member
+callee / bare / member-access-on-new / nested `new new X()` / spread-declines)
+plus a closurec e2e diff fixture (`tests/diff/simple-new-expression/`) proving
+`log(new Widget(1 + 2))` round-trips the construction while the argument folds
+to `3`.
+
 ## [0.23.0] - 2026-07-02
 
 ### Added — CLOC12.158 PR2: bridge `++` / `--` → `UpdateExpression` (closes gap-159)

--- a/code/packages/rust/javascript-parser/Cargo.toml
+++ b/code/packages/rust/javascript-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-javascript-parser"
-version = "0.23.0"
+version = "0.24.0"
 edition = "2021"
 description = "JavaScript parser — parses JavaScript source code against any ECMAScript edition (es1 through es2025) using the grammar-driven parser. Includes correlation-vector plumbing per CLOC03 and a typed-AST bridge (GrammarASTNode → javascript_ast::Program) per CLOC12.136."
 

--- a/code/packages/rust/javascript-parser/src/bridge.rs
+++ b/code/packages/rust/javascript-parser/src/bridge.rs
@@ -58,7 +58,7 @@ use coding_adventures_javascript_ast::{
         BigIntLiteral, BinaryExpression, BinaryOperator, BooleanLiteral, CallExpression,
         ConditionalExpression, Expression, FunctionExpression, Identifier, LogicalExpression,
         LogicalOperator,
-        MemberExpression, NullLiteral, NumericLiteral, ObjectExpression, Property,
+        MemberExpression, NewExpression, NullLiteral, NumericLiteral, ObjectExpression, Property,
         PropertyKey, PropertyKind, StringLiteral, TemplateElement, TemplateLiteral,
         UnaryExpression, UnaryOperator,
         UndefinedLiteral, UpdateExpression, UpdateOperator,
@@ -1845,11 +1845,19 @@ fn convert_new_expression(node: &GrammarASTNode) -> Result<Expression, BridgeErr
             .ok_or_else(|| internal(node, "new_expression: expected 1 child"))?;
         return convert_expression(child);
     }
-    // "new X" — NewExpression, Phase 2.
-    Err(BridgeError::UnsupportedSyntax {
-        rule: "NewExpression".to_string(),
-        location: loc(node),
-    })
+    // `"new" new_expression` — the BARE `new X` form (no argument parens). It is
+    // semantically identical to `new X()`, so we build a `NewExpression` with an
+    // EMPTY argument list; the emitter prints the canonical `new X()`. (The
+    // *argumented* `new X(args)` form is parsed as a `member_expression`, not a
+    // `new_expression`, and is converted in `convert_member_expression`.)
+    let callee_node =
+        sole_node(node).ok_or_else(|| internal(node, "new_expression: expected callee after `new`"))?;
+    let callee = convert_expression(callee_node)?;
+    Ok(Expression::NewExpression(NewExpression {
+        cv: None,
+        callee: Box::new(callee),
+        arguments: Vec::new(),
+    }))
 }
 
 // -------------------------------------------------------------------------
@@ -2060,10 +2068,17 @@ fn convert_member_expression(node: &GrammarASTNode) -> Result<Expression, Bridge
         });
     }
 
-    // `new` expression — Phase 2.
-    if node.children.iter().any(|c| matches!(c, ASTNodeOrToken::Token(t) if t.value == "new")) {
+    // `new.target` — a meta-property, Phase 3. (The argumented `new X(args)`
+    // form is converted below by the base-initialisation; only the
+    // `"new" DOT "target"` meta-property is still declined here.)
+    if has_token(node, "new")
+        && node
+            .children
+            .iter()
+            .any(|c| matches!(c, ASTNodeOrToken::Token(t) if t.value == "target"))
+    {
         return Err(BridgeError::UnsupportedSyntax {
-            rule: "NewExpression".to_string(),
+            rule: "NewTarget".to_string(),
             location: loc(node),
         });
     }
@@ -2099,13 +2114,57 @@ fn convert_member_expression(node: &GrammarASTNode) -> Result<Expression, Bridge
     // the rest of the chain.
     let children = &node.children;
 
-    // The base is the first child — always the primary_expression Node.
-    let mut base = match children.first() {
-        Some(ASTNodeOrToken::Node(n)) => convert_expression(n)?,
-        _ => return Err(internal(node, "member_expression: expected primary base")),
+    // The base is either a primary_expression (`a`, `a.b`, `a[k]` …) or the
+    // argumented `new` form `"new" member_expression arguments` (`new X(a,b)`).
+    // We compute the starting `base` and the index `i` where the suffix chain
+    // (`.NAME` / `[expr]`) begins, then the shared loop below folds any suffix
+    // (so `new X().y` and `new X()[k]` fold correctly).
+    let (mut base, mut i) = if matches!(
+        children.first(),
+        Some(ASTNodeOrToken::Token(t)) if t.value == "new"
+    ) {
+        // children: [Token("new"), Node(member_expression callee),
+        //            Node(arguments), <optional .NAME / [expr] suffixes>].
+        // The callee is the first Node child; the argument list is the first
+        // `arguments`-rule Node. Construct the `NewExpression` and resume the
+        // suffix walk just after the arguments node.
+        let callee_node = children.iter().find_map(|c| match c {
+            ASTNodeOrToken::Node(n) => Some(n),
+            _ => None,
+        });
+        let args_idx = children.iter().position(
+            |c| matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "arguments"),
+        );
+        match (callee_node, args_idx) {
+            (Some(callee_node), Some(args_idx)) => {
+                let callee = convert_expression(callee_node)?;
+                let args_node = match &children[args_idx] {
+                    ASTNodeOrToken::Node(n) => n,
+                    _ => unreachable!("args_idx points at a Node by construction"),
+                };
+                let arguments = convert_arguments(args_node)?;
+                let new_expr = Expression::NewExpression(NewExpression {
+                    cv: None,
+                    callee: Box::new(callee),
+                    arguments,
+                });
+                (new_expr, args_idx + 1)
+            }
+            _ => {
+                return Err(internal(
+                    node,
+                    "member_expression: `new` form missing callee or arguments",
+                ))
+            }
+        }
+    } else {
+        // A plain primary base — always the first child Node.
+        let base = match children.first() {
+            Some(ASTNodeOrToken::Node(n)) => convert_expression(n)?,
+            _ => return Err(internal(node, "member_expression: expected primary base")),
+        };
+        (base, 1)
     };
-
-    let mut i = 1;
     while i < children.len() {
         match &children[i] {
             // `.NAME` — non-computed (dot) property access.
@@ -4014,5 +4073,97 @@ mod tests {
     #[test]
     fn bare_operand_still_passes_through() {
         assert!(matches!(sole_expr("a;"), Expression::Identifier(i) if i.name == "a"));
+    }
+
+    // ---- NewExpression (CLOC12.159 PR2, closes gap-160) ----------------
+
+    /// `new X()` bridges to a `NewExpression` with the identifier callee and an
+    /// empty argument list — no longer declined to `UnsupportedSyntax`.
+    #[test]
+    fn new_identifier_no_args() {
+        match sole_expr("new X();") {
+            Expression::NewExpression(n) => {
+                assert!(matches!(&*n.callee, Expression::Identifier(i) if i.name == "X"));
+                assert!(n.arguments.is_empty());
+            }
+            other => panic!("expected NewExpression, got {other:?}"),
+        }
+    }
+
+    /// `new X(1, 2)` carries both arguments through in order.
+    #[test]
+    fn new_with_args() {
+        match sole_expr("new X(1, 2);") {
+            Expression::NewExpression(n) => {
+                assert!(matches!(&*n.callee, Expression::Identifier(i) if i.name == "X"));
+                assert_eq!(n.arguments.len(), 2);
+                assert!(matches!(&n.arguments[0], Expression::NumericLiteral(l) if l.value == 1.0));
+                assert!(matches!(&n.arguments[1], Expression::NumericLiteral(l) if l.value == 2.0));
+            }
+            other => panic!("expected NewExpression, got {other:?}"),
+        }
+    }
+
+    /// A member-chain callee is preserved: `new a.b(c)` constructs via `a.b`.
+    #[test]
+    fn new_member_callee() {
+        match sole_expr("new a.b(c);") {
+            Expression::NewExpression(n) => {
+                assert!(matches!(&*n.callee, Expression::MemberExpression(_)));
+                assert_eq!(n.arguments.len(), 1);
+            }
+            other => panic!("expected NewExpression, got {other:?}"),
+        }
+    }
+
+    /// A bare `new X` (no parens) is the same program as `new X()` — it bridges
+    /// to a `NewExpression` with an EMPTY argument list (never dropped).
+    #[test]
+    fn bare_new_no_parens() {
+        match sole_expr("new X;") {
+            Expression::NewExpression(n) => {
+                assert!(matches!(&*n.callee, Expression::Identifier(i) if i.name == "X"));
+                assert!(n.arguments.is_empty());
+            }
+            other => panic!("expected NewExpression, got {other:?}"),
+        }
+    }
+
+    /// `new X().y` — a member access on the construction result. The argumented
+    /// `new` is the member object and the `.y` suffix folds onto it.
+    #[test]
+    fn new_then_member_access() {
+        match sole_expr("new X().y;") {
+            Expression::MemberExpression(m) => {
+                assert!(matches!(&*m.object, Expression::NewExpression(_)));
+                assert!(matches!(&*m.property, Expression::Identifier(i) if i.name == "y"));
+                assert!(!m.computed);
+            }
+            other => panic!("expected MemberExpression over a NewExpression, got {other:?}"),
+        }
+    }
+
+    /// `new` nests: `new new X()` constructs with the result of an inner
+    /// construction — both bridge to `NewExpression` (never declined).
+    #[test]
+    fn nested_new() {
+        match sole_expr("new new X();") {
+            Expression::NewExpression(outer) => {
+                assert!(matches!(&*outer.callee, Expression::NewExpression(_)));
+            }
+            other => panic!("expected nested NewExpression, got {other:?}"),
+        }
+    }
+
+    /// A spread argument is still declined (SpreadElement is a later slice), so
+    /// `new X(...a)` gracefully falls back rather than dropping the spread.
+    #[test]
+    fn new_with_spread_arg_declines() {
+        // The whole file falls back to WHITESPACE_ONLY; `bridge` returns the raw
+        // `Result`, so assert the decline directly (rather than `bridge_ok`).
+        assert!(
+            bridge("new X(...a);").is_err(),
+            "spread argument in `new` should decline (SpreadElement not yet supported)"
+        );
     }
 }

--- a/code/programs/rust/closurec/tests/diff/simple-new-expression/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-new-expression/expected.stdout
@@ -1,0 +1,1 @@
+log(new Widget(3));

--- a/code/programs/rust/closurec/tests/diff/simple-new-expression/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/simple-new-expression/flags.txt
@@ -1,0 +1,4 @@
+--js
+tests/diff/simple-new-expression/input/a.js
+--compilation_level
+SIMPLE

--- a/code/programs/rust/closurec/tests/diff/simple-new-expression/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-new-expression/input/a.js
@@ -1,0 +1,10 @@
+// A `new` expression `new Widget(1 + 2)` (CLOC12.159 PR2) now flows through
+// the full SIMPLE pipeline (parser -> typed-AST bridge -> passes -> emitter)
+// instead of declining at the bridge and dragging the whole file to
+// WHITESPACE_ONLY. It sits as an argument to `log(...)` so the call keeps the
+// construction alive. Two facts prove the pipeline ran end-to-end: the
+// `new Widget(...)` round-trips (never dropped, and the bridge produced a real
+// NewExpression rather than declining), AND the argument `1 + 2` folds to `3`.
+// A WHITESPACE_ONLY fallback (which a bridge decline forces) would re-emit the
+// source verbatim, leaving `1 + 2` unfolded.
+log(new Widget(1 + 2));

--- a/code/programs/rust/closurec/tests/diff_simple_new_expression.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_new_expression.rs
@@ -1,0 +1,66 @@
+//! Integration test for the `tests/diff/simple-new-expression/` fixture.
+//!
+//! Exercises CLOC12.159 PR2 — a **`new` expression** (`new Widget(1 + 2)`) now
+//! flows through the full SIMPLE pipeline (parser → typed-AST bridge → passes →
+//! emitter) instead of declining at the bridge and dragging the whole file to
+//! WHITESPACE_ONLY (gap-160, now closed).
+//!
+//! The fixture puts `new Widget(1 + 2)` as an argument to `log(...)` so the
+//! call keeps the construction alive. Two facts prove the pipeline ran
+//! end-to-end:
+//!   1. the `new Widget(...)` round-trips — the bridge produced a real
+//!      `NewExpression` rather than declining, and
+//!   2. the argument `1 + 2` folds to `3`.
+//! A WHITESPACE_ONLY fallback — which a bridge decline would force — would
+//! instead re-emit the source verbatim, leaving `1 + 2` unfolded.
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
+
+fn read_flags() -> Vec<String> {
+    let raw = std::fs::read_to_string("tests/diff/simple-new-expression/flags.txt")
+        .expect("read flags.txt");
+    raw.lines()
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[test]
+fn simple_new_expression_fixture_matches_expected_stdout() {
+    let flags = read_flags();
+    let out = Command::new(BINARY)
+        .args(&flags)
+        .output()
+        .expect("run closurec");
+
+    assert!(
+        out.status.success(),
+        "exit: {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let actual = String::from_utf8_lossy(&out.stdout);
+    let expected = std::fs::read_to_string("tests/diff/simple-new-expression/expected.stdout")
+        .expect("read expected.stdout");
+    assert_eq!(
+        actual.trim_end_matches('\n'),
+        expected.trim_end_matches('\n'),
+        "mismatch.\nactual:\n{actual}\nexpected:\n{expected}",
+    );
+
+    // Guard the *point* of the fixture: the `new Widget(...)` construction
+    // survived (proving the bridge converted it, not WHITESPACE_ONLY) AND its
+    // argument `1 + 2` folded to `3` — proving the SIMPLE pipeline ran.
+    let a = actual.replace(' ', "");
+    assert!(
+        a.contains("newWidget(3)"),
+        "new expression did not round-trip with a folded arg: {actual}"
+    );
+    assert!(
+        !a.contains("1+2"),
+        "a pre-fold expression survived — did it fall back to WHITESPACE_ONLY? {actual}"
+    );
+}

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -1734,14 +1734,29 @@ the bridge still declines `new` (gap-160), so closurec falls back to
 WHITESPACE_ONLY on `new` for now. PR2 (bridge-enable) and PR3 (conformance
 port) follow.
 
-### gap-160 — bridge declines `new_expression` (`new X`)
+### gap-160 — bridge declines `new_expression` (`new X`) — **RESOLVED (javascript-parser 0.24.0, CLOC12.159 PR2)**
 
-The `javascript-parser` typed-AST bridge's `convert_new_expression` passes a
-plain `member_expression` (no `new` keyword) straight through, but returns
-`UnsupportedSyntax { rule: "NewExpression" }` for the actual `"new" X` form —
-so any file containing `new` currently drops to WHITESPACE_ONLY. With the
-`Expression::NewExpression` node now in place (CLOC12.159 PR1), the bridge can
-convert it: PR2 will build `NewExpression { callee, arguments }` from the
-grammar node (the argument list comes from the `member_expression = "new"
-member_expression arguments` production) and add a closurec e2e diff fixture,
-closing this gap.
+The `javascript-parser` typed-AST bridge declined the `new` operator to
+`UnsupportedSyntax`, so any file containing `new` dropped to WHITESPACE_ONLY.
+
+**Fix (CLOC12.159 PR2):** with the `Expression::NewExpression` node in place
+(PR1), the bridge now converts both grammar productions in which `new` appears:
+
+- **argumented** `new X(args)` parses as `member_expression = "new"
+  member_expression arguments` — `convert_member_expression` builds a
+  `NewExpression { callee, arguments }` (arguments via `convert_arguments`) as
+  the base and folds any trailing `.NAME` / `[expr]` suffix onto it, so
+  `new X().y` / `new X()[k]` convert correctly;
+- **bare** `new X` parses as `new_expression = "new" new_expression` —
+  `convert_new_expression` builds a `NewExpression` with an EMPTY argument list
+  (semantically identical to `new X()`; the emitter prints the canonical
+  `new X()`).
+
+A spread argument (`new X(...a)`) still declines (`SpreadElement`, later slice)
+and `new.target` still declines (`NewTarget`, Phase 3). 7 bridge tests + a
+closurec e2e diff fixture (`tests/diff/simple-new-expression/`) proving
+`log(new Widget(1 + 2))` round-trips the construction while `1 + 2` folds to
+`3` (a WHITESPACE_ONLY fallback would leave it unfolded).
+
+The **PR3 emit conformance port** — the remaining follow-up — ports upstream
+CodePrinter's `new`-operator cases into `closure-emitter/tests/upstream/`.


### PR DESCRIPTION
## CLOC12.159 PR2 — bridge `new X(args)` → `NewExpression` (closes gap-160)

Second PR of the CLOC12.159 `NewExpression` arc (after [#7440](https://github.com/adhithyan15/coding-adventures/pull/7440) PR1 — the atomic node + emit + passes). PR3 (conformance port) follows.

The `javascript-parser` typed-AST bridge now **converts** the `new` operator instead of declining it to `UnsupportedSyntax` — which dragged the whole file to WHITESPACE_ONLY. `new` appears in **two** grammar productions and both are handled:

- **argumented** `new X(args)` parses as `member_expression = "new" member_expression arguments` → `convert_member_expression` builds a `NewExpression { callee, arguments }` as the base and folds any trailing `.NAME` / `[expr]` suffix onto it (so `new X().y` and `new X()[k]` convert correctly);
- **bare** `new X` parses as `new_expression = "new" new_expression` → `convert_new_expression` builds a `NewExpression` with an **empty** argument list (semantically identical to `new X()`; the emitter prints canonical `new X()`).

Arguments reuse the existing `convert_arguments`, so a spread argument (`new X(...a)`) still declines gracefully (`SpreadElement` is a later slice). `new.target` still declines (`NewTarget`, Phase 3).

The whole SIMPLE/ADVANCED pipeline now runs on files containing `new` end-to-end instead of dropping to WHITESPACE_ONLY.

### Tests
- **7 new bridge tests**: identifier / args-in-order / member callee (`new a.b(c)`) / bare no-parens (`new X`) / member-access-on-new (`new X().y`) / nested (`new new X()`) / spread-declines.
- **closurec e2e diff fixture** (`tests/diff/simple-new-expression/`): `log(new Widget(1 + 2))` → `log(new Widget(3))`, proving the construction round-trips (bridge converted it, not WHITESPACE_ONLY) while the argument `1 + 2` folds to `3`.

### Verification
- Full `javascript-parser` suite — 121 passed.
- Full **closurec** suite — green.
- Inline security review → **PASSED** (confirmed the `unreachable!` is dead, no callee/arg mis-assignment or dropped suffix, no reachable panic/OOB, bounded recursion, safe WHITESPACE_ONLY degrade).

### Versions / docs
javascript-parser `0.23.0` → `0.24.0`; CHANGELOG `0.24.0` section; `CLOC12-gaps.md` **gap-160 → RESOLVED** with the two-production explanation + the remaining PR3 note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)