### PR TITLE
fix(ruby-sir): implicit return of trailing if/unless from method bodies (FC)

### DIFF
--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.6.1] - 2026-07-02
+
+### Fixed (FC — implicit return of a trailing `if`/`unless` from a method body)
+
+A Ruby method returns the value of its **last evaluated expression**, and
+`if`/`unless` are expressions. The frontend, however, only promoted a bare
+`expression_stmt`/`method_call` tail into the SIR `Block.value` slot — a body
+ending in a conditional left the `if` as a discarded statement and set
+`value = NilLit`. Every backend faithfully reproduced this, so a method like
+`def bigger(a, b); if a > b then a else b end; end` returned `nil` on Python,
+JavaScript, Go, and Rust alike (verified end to end: `puts bigger(10, 7)`
+printed a blank line before the fix, `10` after).
+
+- **Shared `lower_tail_value` helper.** The tail-promotion decision (previously
+  duplicated inline in `lower_program`, `lower_clause_statements`, and
+  `lower_def_statement`) is now one helper with a documented promotion table.
+  It promotes `expression_stmt`, `method_call`/`method_call_no_paren`, and now
+  **`if_statement`/`unless_statement`**; everything else (assignments, `while`,
+  …) returns `None` and stays a `Stmt`.
+- **Method and branch bodies fixed.** `lower_def_statement` and
+  `lower_clause_statements` route their tail through the helper, so a `def`
+  whose body ends in a conditional returns the branch value, and an `if` branch
+  that itself ends in an `if` promotes **recursively** (nested tail conditionals
+  each carry their value).
+- **Top-level unchanged.** A script's top-level value is not language-visible,
+  so `lower_program` keeps a bare trailing `if` as a statement (its pinned
+  behavior is intentional); only method/branch implicit returns changed.
+- **Still deferred:** implicit return of a trailing `case` or `begin`/`rescue`,
+  and of a block/lambda's tail conditional (follow-up milestones).
+- Five new unit tests (tail `if`, tail `unless`, leading-stmts-then-tail-`if`,
+  recursive nested tail `if`, validator pass); all downstream backend suites
+  (Python/TypeScript/JavaScript/Go/Rust — including the native compile-and-run
+  execution proofs) pass unchanged.
+
 ## [0.6.0] - 2026-07-01
 
 (Cargo manifest minor bump 0.5.0 → 0.6.0.)

--- a/code/packages/rust/ruby-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/ruby-to-semantic-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruby-to-semantic-ir"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "Ruby AST → narrow-waist Semantic IR. Phase 5 of the Ruby parser project — first frontend for the ruby-parser → SIR pipeline."
 

--- a/code/packages/rust/ruby-to-semantic-ir/README.md
+++ b/code/packages/rust/ruby-to-semantic-ir/README.md
@@ -53,6 +53,18 @@ parses (see [ruby-parser/src/_grammar.rs](../ruby-parser/src/_grammar.rs)):
   parameter scope and resolves earlier params as `Scope::Param`.  A
   defaulted param observes `Feature::DefaultParams`; a call that omits a
   defaulted arg (`f(5)`) lowers to a call with fewer args (no padding).
+- **Method bodies — implicit return (FC).**  Ruby has no explicit `return`;
+  a method's value is its **last evaluated expression**.  The tail statement
+  of a `def` body (and of each `if`/`unless` branch) is promoted into the SIR
+  `Block.value` slot the backends emit as the implicit return.  Besides bare
+  expressions and calls, a trailing **`if`/`unless`** is now promoted too:
+  `def bigger(a, b); if a > b then a else b end; end` returns the winning
+  branch (previously the conditional was left as a discarded statement and the
+  method returned `nil` on every backend).  Promotion recurses — a branch that
+  itself ends in an `if` carries its own value — so arbitrarily nested tail
+  conditionals all return correctly.  (A *script's* top-level value is not
+  language-visible, so a bare trailing `if` at program scope stays a
+  statement; only method/branch bodies implicitly return.)
 
 ## Usage
 
@@ -98,7 +110,10 @@ function).
 
 ## What's deferred
 
-- Control flow beyond v0, mixins, and refinements.
+- Control flow beyond v0 and refinements.
+- Implicit return of a trailing **`case`** or **`begin`/`rescue`** (only
+  `if`/`unless` tail conditionals promote to the block value so far), and of a
+  block/lambda's tail conditional.
 - The full set of Ruby's literal forms (regex, ranges, arrays,
   hashes, symbols, heredocs as runtime values — heredocs ARE lexed
   per Phase 3c, just not yet lowered to IR shape).

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -624,6 +624,117 @@ mod tests {
         assert!(m.exports.iter().any(|e| e.name == "main"));
     }
 
+    // ─────────────────────────────────────────────────────────────────
+    // Phase FC — implicit return of a trailing `if`/`unless` from a
+    // method body.  Ruby has no explicit `return`: a method's value is
+    // its last evaluated expression, and `if`/`unless` ARE expressions.
+    // Before this fix a body ending in a conditional promoted nothing to
+    // the block `value`, so the method returned `nil` on every backend.
+    // ─────────────────────────────────────────────────────────────────
+
+    /// Fetch the body `Block` of a lowered top-level `def` by name.
+    fn fn_body<'a>(m: &'a semantic_ir::Module, name: &str) -> &'a semantic_ir::Block {
+        &m.functions
+            .iter()
+            .find(|f| f.name == name)
+            .unwrap_or_else(|| panic!("expected `{}` function", name))
+            .body
+    }
+
+    #[test]
+    fn def_body_ending_in_if_returns_the_if_expr() {
+        // `bigger` ends in an `if/else` — the whole conditional is the
+        // method's return value, so it must land in `body.value` (NOT be
+        // dropped as a bare tail statement leaving `value = nil`).
+        let m = lower("def bigger(a, b)\n  if a > b\n    a\n  else\n    b\n  end\nend\n");
+        let body = fn_body(&m, "bigger");
+        match &body.value {
+            Expr::If { then_branch, else_branch, .. } => {
+                // Each branch's own tail promotes to a VarRef value.
+                assert!(
+                    matches!(&then_branch.value, Expr::VarRef { name, .. } if name == "a"),
+                    "then-branch value should be `a`, got {:?}",
+                    then_branch.value
+                );
+                assert!(
+                    matches!(&else_branch.value, Expr::VarRef { name, .. } if name == "b"),
+                    "else-branch value should be `b`, got {:?}",
+                    else_branch.value
+                );
+            }
+            other => panic!("expected body.value = Expr::If, got {:?}", other),
+        }
+        // The conditional was promoted, so it is NOT also left dangling as
+        // a discarded statement in the body.
+        assert!(
+            !body
+                .stmts
+                .iter()
+                .any(|s| matches!(s, Stmt::ExprStmt { expr: Expr::If { .. }, .. })),
+            "the tail `if` must be promoted to value, not duplicated as a stmt"
+        );
+    }
+
+    #[test]
+    fn def_body_ending_in_unless_returns_the_if_expr() {
+        // `unless c` lowers to `if !c` — still promoted to the body value.
+        let m = lower("def pick(a, b)\n  unless a\n    b\n  else\n    a\n  end\nend\n");
+        let body = fn_body(&m, "pick");
+        match &body.value {
+            Expr::If { cond, .. } => assert!(
+                matches!(&**cond, Expr::BuiltinCall { name, .. } if name == "not"),
+                "`unless` cond should be wrapped in `not`, got {:?}",
+                cond
+            ),
+            other => panic!("expected body.value = Expr::If, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn def_body_leading_stmts_then_tail_if_are_both_kept() {
+        // Statements BEFORE the tail conditional stay in `stmts`; only the
+        // final `if` is promoted to `value`.
+        let m = lower(
+            "def f(a)\n  x = a + 1\n  if x > 0\n    x\n  else\n    0\n  end\nend\n",
+        );
+        let body = fn_body(&m, "f");
+        assert!(
+            !body.stmts.is_empty(),
+            "the `x = a + 1` binding must remain a statement"
+        );
+        assert!(
+            matches!(&body.value, Expr::If { .. }),
+            "the tail `if` must be the body value, got {:?}",
+            body.value
+        );
+    }
+
+    #[test]
+    fn nested_tail_if_promotes_recursively() {
+        // The else-branch itself ends in an `if`; that inner conditional
+        // must promote to the else-branch's value (recursion through
+        // `lower_clause_statements` → `lower_tail_value`).
+        let m = lower(
+            "def grade(n)\n  if n > 90\n    1\n  else\n    if n > 80\n      2\n    else\n      3\n    end\n  end\nend\n",
+        );
+        let body = fn_body(&m, "grade");
+        let Expr::If { else_branch, .. } = &body.value else {
+            panic!("expected body.value = Expr::If, got {:?}", body.value);
+        };
+        assert!(
+            matches!(&else_branch.value, Expr::If { .. }),
+            "the nested tail `if` must promote to the else-branch value, got {:?}",
+            else_branch.value
+        );
+    }
+
+    #[test]
+    fn def_body_tail_if_module_passes_sir_validator() {
+        let m = lower("def bigger(a, b)\n  if a > b\n    a\n  else\n    b\n  end\nend\n");
+        let result = semantic_ir::validate(&m);
+        assert!(result.is_ok(), "validator rejected our output: {:?}", result);
+    }
+
     #[test]
     fn def_rest_param_lowers_to_kind_rest() {
         // M3: `def f(*r); end` → one Param whose kind is Rest (previously the

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -1378,27 +1378,18 @@ impl Lowerer {
                 column: s.start_column.unwrap_or(0),
             })?;
             let is_tail = i == last_idx;
-            let kind = inner.rule_name.as_str();
-            if is_tail && matches!(kind, "expression_stmt" | "method_call" | "method_call_no_paren") {
-                let v = match kind {
-                    "expression_stmt" => {
-                        let expr_node = self.first_node_child(inner).ok_or_else(|| {
-                            RubyLowerError {
-                                message: "expression_stmt had no expression child".to_string(),
-                                line: inner.start_line.unwrap_or(0),
-                                column: inner.start_column.unwrap_or(0),
-                            }
-                        })?;
-                        self.lower_expression(expr_node)?
-                    }
-                    "method_call" | "method_call_no_paren" => self.lower_method_call(inner)?,
-                    _ => unreachable!(),
-                };
-                value = Some(v);
-            } else {
-                // Phase 6r — multi-stmt fan-out for `multi_assignment`.
-                stmts_out.extend(self.lower_statement_inner_multi(inner)?);
+            // Phase FC — the branch's last value-producing statement becomes
+            // the branch `Block`'s implicit-return `value`; see
+            // [`Self::lower_tail_value`] for the promotion table (which now
+            // includes a trailing `if`/`unless`).
+            if is_tail {
+                if let Some(v) = self.lower_tail_value(inner)? {
+                    value = Some(v);
+                    continue;
+                }
             }
+            // Phase 6r — multi-stmt fan-out for `multi_assignment`.
+            stmts_out.extend(self.lower_statement_inner_multi(inner)?);
         }
         let value = value.unwrap_or(Expr::NilLit { span: self.span_of(node) });
         // Restore the outer scope's declared locals.
@@ -1408,6 +1399,64 @@ impl Lowerer {
             value,
             span: self.span_of(node),
         })
+    }
+
+    /// Phase FC — implicit-return tail promotion.
+    ///
+    /// In Ruby, the *value* of a method (or `if`/`unless` branch) body is
+    /// its **last evaluated expression** — there is no explicit `return`.
+    /// `def f; a + b; end` returns `a + b`; `def f; if c then a else b end;
+    /// end` returns whichever branch ran.  The SIR [`Block`] carries that
+    /// value in its dedicated `value` slot (kept distinct from the
+    /// side-effecting `stmts`), and every backend emits `value` as the
+    /// block's implicit return.  A tail statement therefore has to be
+    /// *promoted* out of `stmts` and into `value` — but only if it is a
+    /// form that actually produces a usable value.
+    ///
+    /// This helper is that decision, shared by every body-lowering site so
+    /// the rule stays identical everywhere:
+    ///
+    /// | tail `statement`'s inner rule        | promoted value                     |
+    /// |--------------------------------------|------------------------------------|
+    /// | `expression_stmt`                    | the bare expression                |
+    /// | `method_call` / `method_call_no_paren` | the call's result                |
+    /// | `if_statement` / `unless_statement`  | an [`Expr::If`] (branches recurse) |
+    /// | anything else (assignment, `while`…) | `None` — the node stays a `Stmt`   |
+    ///
+    /// Returning `None` tells the caller to route the node through
+    /// [`Self::lower_statement_inner_multi`] as an ordinary statement: its
+    /// value (if any) is unobservable in Ruby — a trailing `while`, for
+    /// instance, evaluates to `nil`, so it stays a `Stmt` and the block's
+    /// `value` falls back to `NilLit`.
+    ///
+    /// **Recursion.** [`Self::lower_if_or_unless`] builds each branch with
+    /// [`Self::lower_clause_statements`], which itself calls this helper.  So
+    /// a tail `if` whose branch *also* ends in an `if` promotes all the way
+    /// down — arbitrarily nested tail conditionals each carry their value,
+    /// with no special-casing.
+    ///
+    /// Note: this is used for method bodies and branch bodies, where Ruby's
+    /// implicit return is observable.  A *script's* top-level value is not
+    /// language-visible, so [`Self::lower_program`] keeps a bare trailing
+    /// `if` as a `Stmt` (see its own promotion list).
+    fn lower_tail_value(
+        &mut self,
+        inner: &GrammarASTNode,
+    ) -> Result<Option<Expr>, RubyLowerError> {
+        let value = match inner.rule_name.as_str() {
+            "expression_stmt" => {
+                let expr_node = self.first_node_child(inner).ok_or_else(|| RubyLowerError {
+                    message: "expression_stmt had no expression child".to_string(),
+                    line: inner.start_line.unwrap_or(0),
+                    column: inner.start_column.unwrap_or(0),
+                })?;
+                self.lower_expression(expr_node)?
+            }
+            "method_call" | "method_call_no_paren" => self.lower_method_call(inner)?,
+            "if_statement" | "unless_statement" => self.lower_if_or_unless(inner)?,
+            _ => return Ok(None),
+        };
+        Ok(Some(value))
     }
 
     // -------------------------------------------------------------------
@@ -4723,30 +4772,21 @@ impl Lowerer {
                         }
                     })?;
                     let is_tail = i == last_idx;
-                    let kind = inner.rule_name.as_str();
-                    if is_tail && matches!(kind, "expression_stmt" | "method_call" | "method_call_no_paren") {
-                        let v = match kind {
-                            "expression_stmt" => {
-                                let expr_node =
-                                    self.first_node_child(inner).ok_or_else(|| {
-                                        RubyLowerError {
-                                            message:
-                                                "expression_stmt had no expression child"
-                                                    .to_string(),
-                                            line: inner.start_line.unwrap_or(0),
-                                            column: inner.start_column.unwrap_or(0),
-                                        }
-                                    })?;
-                                self.lower_expression(expr_node)?
-                            }
-                            "method_call" | "method_call_no_paren" => self.lower_method_call(inner)?,
-                            _ => unreachable!(),
-                        };
-                        value = Some(v);
-                    } else {
-                        // Phase 6r — multi-stmt fan-out for `multi_assignment`.
-                        stmts_out.extend(self.lower_statement_inner_multi(inner)?);
+                    // Phase FC — Ruby methods have no explicit `return`: the
+                    // body's value is its last evaluated expression.  Promote
+                    // that tail into the `Block`'s `value` slot so the backends
+                    // emit it as the implicit return.  A trailing `if`/`unless`
+                    // now promotes too (via [`Self::lower_tail_value`]), so a
+                    // method whose body ends in a conditional returns the
+                    // branch value instead of `nil`.
+                    if is_tail {
+                        if let Some(v) = self.lower_tail_value(inner)? {
+                            value = Some(v);
+                            continue;
+                        }
                     }
+                    // Phase 6r — multi-stmt fan-out for `multi_assignment`.
+                    stmts_out.extend(self.lower_statement_inner_multi(inner)?);
                 }
             }
             (


### PR DESCRIPTION
## Problem

Driving a simple Ruby program through the SIR pipeline to all four backends surfaced a real correctness gap. Given:

```ruby
def bigger(a, b)
  if a > b
    a
  else
    b
  end
end
puts bigger(10, 7)
```

**every backend printed a blank line instead of `10`.** Ruby methods have no explicit `return` — a method's value is its last evaluated expression, and `if`/`unless` *are* expressions. But the frontend only promoted a bare `expression_stmt`/`method_call` tail into the SIR `Block.value` slot; a body ending in a conditional left the `if` as a discarded statement with `value = NilLit`. All five backends faithfully reproduced the nil return. `add` (trailing `a + b`) worked; `bigger` (trailing `if`) did not — proving the bug was upstream in `ruby-to-semantic-ir`, not codegen.

## Fix

- **Shared `lower_tail_value` helper** — the tail-promotion decision (previously duplicated inline in `lower_program`, `lower_clause_statements`, and `lower_def_statement`) is now one helper with a documented promotion table. It promotes `expression_stmt`, `method_call`/`method_call_no_paren`, and now **`if_statement`/`unless_statement`**; everything else (assignments, `while`, …) returns `None` and stays a `Stmt`.
- **Method + branch bodies** route their tail through the helper, so a `def` ending in a conditional returns the branch value, and an `if` branch that itself ends in an `if` promotes **recursively**.
- **Top-level `lower_program` unchanged** — a script's value isn't language-visible, and its tail-`if`-as-statement behavior is pinned by existing tests; only method/branch implicit returns changed.

## Verification

End-to-end through the real toolchains — `puts bigger(10, 7)`:

| Backend | Before | After |
|---|---|---|
| Python | *(blank)* | `10` |
| JavaScript (`node`) | *(blank)* | `10` |
| Go (`go run`) | *(blank)* | `10` |
| Rust (`rustc`) | *(blank)* | `10` |

- 5 new unit tests (tail `if`, tail `unless`, leading-stmts-then-tail-`if`, recursive nested tail `if`, validator pass).
- All 423 frontend tests pass; all 5 backend suites — Python/TypeScript/JavaScript/Go/Rust, **including the native compile-and-run execution proofs** — pass unchanged.
- Frontend crate is clippy-clean. Version 0.6.0 → 0.6.1; README + CHANGELOG updated.
- Security review: passed (compiler-lowering only; new recursion bounded by source nesting depth, no amplification vs. existing lowering).

## Still deferred (follow-up PRs)

Implicit return of a trailing `case` or `begin`/`rescue`, and of a block/lambda's tail conditional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)