### PR TITLE
test(closure-emitter): CLOC12.159 PR3 — CodePrinter new-operator conformance port

### DIFF
--- a/code/packages/rust/closure-emitter/CHANGELOG.md
+++ b/code/packages/rust/closure-emitter/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to the `coding-adventures-closure-emitter` crate will be documented in this file.
 
+## [0.23.1] - 2026-07-02
+
+### Added — CLOC12.159 PR3: CodePrinter new-operator conformance port
+
+New upstream-cited test file `tests/upstream/code_printer_new_test.rs`
+(registered as the `upstream_code_printer_new` `[[test]]` target) porting the
+Closure Compiler `CodePrinterTest` `new`-operator (`new Ctor(args)`) printing
+cases against `emit_new`. 10 active `#[test]`s, **0 `#[ignore]`** — identifier
+and member-chain callees (`new X()`, `new a.b.c()`), argument lists
+(`new X(a,b)`, `new X(a.b)`), the callee-with-call wraps (`new (f())()`,
+`new (a.b().c)()`), the `PREC_PRIMARY` member-object cases (`new X(a).y`,
+`new X().y`), nested `new new X()()`, and a call on a `new` member
+(`new X().m()`). Inputs are hand-constructed typed AST; the bridge conversion
+of `new` (PR2, gap-160) is exercised separately in `javascript-parser`.
+Test-only change — no library behaviour change. This completes the CLOC12.159
+`NewExpression` three-PR arc (node+emit → bridge → conformance).
+
 ## [0.23.0] - 2026-07-02
 
 ### Added — CLOC12.159: emit `NewExpression` (`new X(args)`)

--- a/code/packages/rust/closure-emitter/Cargo.toml
+++ b/code/packages/rust/closure-emitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-emitter"
-version = "0.23.0"
+version = "0.23.1"
 edition = "2021"
 description = "JavaScript code emitter for the Closure Compiler clone. Per CLOC07's emit contract. Takes a finalized Program + sidecar and produces output JavaScript text + companion source map. Runs after every pass in the pipeline."
 
@@ -64,3 +64,7 @@ path = "tests/upstream/code_printer_template_test.rs"
 [[test]]
 name = "upstream_code_printer_update"
 path = "tests/upstream/code_printer_update_test.rs"
+
+[[test]]
+name = "upstream_code_printer_new"
+path = "tests/upstream/code_printer_new_test.rs"

--- a/code/packages/rust/closure-emitter/README.md
+++ b/code/packages/rust/closure-emitter/README.md
@@ -127,6 +127,12 @@ test-port convention. Each file isolates one printing area:
   `(++x)**2`), and the token-fusion seams (`a- --b`, `a+ ++b`, `x++ +y`,
   `x-- -y`, plus the non-fusing `x++*y`). 14 active `#[test]`s, no `#[ignore]`.
   Run with `cargo test --test upstream_code_printer_update`.
+- `code_printer_new_test.rs` — `new`-operator (`new Ctor(args)`) printing:
+  identifier / member-chain callees, argument lists, the callee-with-call wraps
+  (`new (f())()`, `new (a.b().c)()`), the `PREC_PRIMARY` member-object cases
+  (`new X(a).y`, `new X().y`), nested `new new X()()`, and a call on a `new`
+  member (`new X().m()`). 10 active `#[test]`s, no `#[ignore]`. Run with
+  `cargo test --test upstream_code_printer_new`.
 
 ## Dependency whitelist
 

--- a/code/packages/rust/closure-emitter/tests/upstream/ATTRIBUTION.md
+++ b/code/packages/rust/closure-emitter/tests/upstream/ATTRIBUTION.md
@@ -75,6 +75,23 @@ under the Apache License, Version 2.0:
       (CLOC12.158 PR2, gap-159) is exercised separately in
       `javascript-parser`.
 
+- `code_printer_new_test.rs`
+    - upstream: `test/com/google/javascript/jscomp/CodePrinterTest.java`
+      (the `new`-operator `new Ctor(args)` printing cases — argument lists,
+      precedence, and the callee-with-call wrapping)
+    - tracked commit: see `UPSTREAM_SHA`
+    - Isolates `emit_new` + the `PREC_PRIMARY` classification, the
+      `new`-keyword space, and the callee-with-call wrap that landed with
+      `Expression::NewExpression` (CLOC12.159). 10 active `#[test]`s and
+      **0 `#[ignore]`** — the emitter conforms to every covered shape
+      (identifier / member-chain callee, argument lists, member argument,
+      the callee-with-call wraps `new (f())()` / `new (a.b().c)()`, the
+      argumented-`new`-as-member-object cases `new X(a).y` / `new X().y`,
+      nested `new new X()()`, and a call on a `new` member `new X().m()`).
+      Inputs are hand-constructed AST; the bridge conversion of `new`
+      (CLOC12.159 PR2, gap-160) is exercised separately in
+      `javascript-parser`.
+
 ## Translation notes
 
 Fourth port under CLOC12 (after `closure-pass-constant-fold` in

--- a/code/packages/rust/closure-emitter/tests/upstream/code_printer_new_test.rs
+++ b/code/packages/rust/closure-emitter/tests/upstream/code_printer_new_test.rs
@@ -1,0 +1,211 @@
+//! Ported from `CodePrinterTest.java` in `google/closure-compiler`,
+//! Apache-2.0. Upstream SHA: see `tests/upstream/UPSTREAM_SHA`.
+//!
+//! Translation policy: see
+//! `code/specs/CLOC12-upstream-test-suite-port.md`.
+//!
+//! # What this file covers
+//!
+//! Upstream `CodePrinterTest`'s **`new`-operator** printing cases — the
+//! `new Ctor(args)` construction form. This is the twelfth CodePrinter port
+//! into `closure-emitter` (after core / declarations / trailing-comma /
+//! numbers / string-escape / ascii-escape / object-literal /
+//! function-expression / arrow-function / template / update) and isolates
+//! `emit_new` + the `PREC_PRIMARY` classification, the `new`-keyword space, and
+//! the callee-with-call wrapping that landed with `Expression::NewExpression`
+//! (CLOC12.159).
+//!
+//! ## How the emitter prints a `new` expression (recap)
+//!
+//! ```text
+//!   new X()        → new X()          identifier callee, empty args
+//!   new X(a, b)    → new X(a,b)       argument list
+//!   new a.b.c()    → new a.b.c()      member-chain callee (a valid target)
+//! ```
+//!
+//! The argument parens are **always** printed, so a no-argument node is emitted
+//! canonically as `new X()` (never bare `new X`). Every emitted `new` is
+//! therefore the *argumented* form and binds at member/call strength
+//! (`PREC_PRIMARY`), so `new X().y` needs no extra parens.
+//!
+//! ## Two seams
+//!
+//! ```text
+//!   new X()         the `new` keyword needs a space before an identifier/member
+//!                   callee, or `newX` fuses into one identifier.
+//!   new (f())()     the `new` target is a MemberExpression per grammar and
+//!   new (a.b().c)() cannot BE a call — a callee whose member spine bottoms out
+//!                   in a call is wrapped, or the appended `(args)` binds to the
+//!                   inner call (`new f()()` = `(new f())()`, a different program).
+//! ```
+//!
+//! ## Note on hand-constructed inputs
+//!
+//! These assertions build typed-AST inputs directly (upstream lex/parses
+//! source). The emitter is the unit under test here — the bridge conversion of
+//! `new` (CLOC12.159 PR2, gap-160) is exercised separately in
+//! `javascript-parser`.
+
+use coding_adventures_closure_emitter::{emit, EmitOptions};
+use coding_adventures_correlation_vector::CVLog;
+use coding_adventures_javascript_ast::{
+    CallExpression, Expression, ExpressionStatement, Identifier, MemberExpression, NewExpression,
+    Program, ProgramItem, SourceType, Statement,
+};
+use coding_adventures_javascript_tokens::EsVersion;
+use coding_adventures_type_sidecar::Sidecar;
+
+// =====================================================================
+// Test-support helpers
+// =====================================================================
+
+fn ident(name: &str) -> Expression {
+    Expression::Identifier(Identifier { cv: None, name: name.to_string() })
+}
+
+fn member(object: Expression, property: &str) -> Expression {
+    Expression::MemberExpression(MemberExpression {
+        cv: None,
+        object: Box::new(object),
+        property: Box::new(ident(property)),
+        computed: false,
+    })
+}
+
+fn call(callee: Expression, arguments: Vec<Expression>) -> Expression {
+    Expression::CallExpression(CallExpression {
+        cv: None,
+        callee: Box::new(callee),
+        arguments,
+    })
+}
+
+fn new_expr(callee: Expression, arguments: Vec<Expression>) -> Expression {
+    Expression::NewExpression(NewExpression {
+        cv: None,
+        callee: Box::new(callee),
+        arguments,
+    })
+}
+
+fn stmt(expr: Expression) -> ProgramItem {
+    ProgramItem::Statement(Statement::expression_statement(ExpressionStatement {
+        cv: None,
+        expression: expr,
+    }))
+}
+
+fn emit_default(expr: Expression) -> String {
+    let prog =
+        Program::new_untraced(EsVersion::Es2025, SourceType::Module).with_body(vec![stmt(expr)]);
+    let sidecar = Sidecar::new();
+    let mut cv = CVLog::new(false);
+    emit(&prog, &sidecar, &mut cv, &EmitOptions::default())
+        .expect("emit failed")
+        .code
+}
+
+/// Upstream `assertPrint(input, expected)` reshaped: emit the expression as a
+/// single-statement program and assert the emitted code equals `expected`.
+fn assert_emits(expr: Expression, expected: &str) {
+    let code = emit_default(expr);
+    assert_eq!(
+        code, expected,
+        "new-operator emit output did not match\n  actual:   {:?}\n  expected: {:?}",
+        code, expected
+    );
+}
+
+// =====================================================================
+// Active — core shapes
+// =====================================================================
+
+/// `assertPrintSame("new X()")` — identifier callee, empty argument list. The
+/// `new` keeps a separating space so it does not fuse into `newX`.
+#[test]
+fn new_identifier_no_args() {
+    assert_emits(new_expr(ident("X"), vec![]), "new X();");
+}
+
+/// `assertPrintSame("new X(a,b)")` — the argument list prints comma-separated
+/// with no minified inter-argument space.
+#[test]
+fn new_with_args() {
+    assert_emits(
+        new_expr(ident("X"), vec![ident("a"), ident("b")]),
+        "new X(a,b);",
+    );
+}
+
+/// `assertPrintSame("new a.b.c()")` — a pure member-chain callee is a valid
+/// `new` target and stays paren-free.
+#[test]
+fn new_member_chain_callee_not_wrapped() {
+    let callee = member(member(ident("a"), "b"), "c");
+    assert_emits(new_expr(callee, vec![]), "new a.b.c();");
+}
+
+/// A member operand as a `new` argument round-trips: `new X(a.b)`.
+#[test]
+fn new_with_member_arg() {
+    assert_emits(
+        new_expr(ident("X"), vec![member(ident("a"), "b")]),
+        "new X(a.b);",
+    );
+}
+
+// =====================================================================
+// Active — callee-with-call wrapping
+// =====================================================================
+
+/// `new (f())()` — a call in the callee spine MUST be parenthesised, or the
+/// appended `()` would bind to the inner call (`new f()()` = `(new f())()`, a
+/// different program). The wrapping paren also removes the `new`-keyword space.
+#[test]
+fn new_call_callee_is_wrapped() {
+    assert_emits(new_expr(call(ident("f"), vec![]), vec![]), "new(f())();");
+}
+
+/// `new (a.b().c)()` — the callee's member spine bottoms out in a call
+/// (`a.b()`), so the whole target is wrapped.
+#[test]
+fn new_callee_with_call_in_member_spine_is_wrapped() {
+    let callee = member(call(member(ident("a"), "b"), vec![]), "c");
+    assert_emits(new_expr(callee, vec![]), "new(a.b().c)();");
+}
+
+// =====================================================================
+// Active — precedence (an argumented `new` is member/call strength)
+// =====================================================================
+
+/// `new X(a).y` — an argumented `new` binds at member strength, so a member
+/// parent needs NO extra parens: `new X(a).y`.
+#[test]
+fn argumented_new_as_member_object_not_wrapped() {
+    let m = member(new_expr(ident("X"), vec![ident("a")]), "y");
+    assert_emits(m, "new X(a).y;");
+}
+
+/// A no-argument `new X` is emitted canonically as `new X()` (the parens are
+/// always printed), so as a member object it needs no wrap: `new X().y`.
+#[test]
+fn no_arg_new_as_member_object_prints_argumented() {
+    let m = member(new_expr(ident("X"), vec![]), "y");
+    assert_emits(m, "new X().y;");
+}
+
+/// `new` nests: the inner `new X()` is a valid target (not a call), so no wrap
+/// is forced and the outer `new` keeps its keyword space: `new new X()()`.
+#[test]
+fn nested_new_inner_not_wrapped() {
+    let inner = new_expr(ident("X"), vec![]);
+    assert_emits(new_expr(inner, vec![]), "new new X()();");
+}
+
+/// A `new` result called as a function: `new X().m()` — a call whose callee is
+/// a member on the argumented `new`. All bind at `PREC_PRIMARY`, so no wraps.
+#[test]
+fn call_on_new_member_is_paren_free() {
+    let e = call(member(new_expr(ident("X"), vec![]), "m"), vec![]);
+    assert_emits(e, "new X().m();");
+}

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -1758,5 +1758,14 @@ closurec e2e diff fixture (`tests/diff/simple-new-expression/`) proving
 `log(new Widget(1 + 2))` round-trips the construction while `1 + 2` folds to
 `3` (a WHITESPACE_ONLY fallback would leave it unfolded).
 
-The **PR3 emit conformance port** — the remaining follow-up — ports upstream
-CodePrinter's `new`-operator cases into `closure-emitter/tests/upstream/`.
+The **PR3 emit conformance port** (closure-emitter 0.23.1, CLOC12.159 PR3)
+ports upstream CodePrinter's `new`-operator cases into
+`closure-emitter/tests/upstream/code_printer_new_test.rs` (registered as the
+`upstream_code_printer_new` `[[test]]` target): identifier / member-chain
+callees (`new X()`, `new a.b.c()`), argument lists (`new X(a,b)`, `new X(a.b)`),
+the callee-with-call wraps (`new (f())()`, `new (a.b().c)()`), the
+`PREC_PRIMARY` member-object cases (`new X(a).y`, `new X().y`), nested
+`new new X()()`, and a call on a `new` member (`new X().m()`). 10 active
+`#[test]`s, no `#[ignore]` — the emitter conforms to every covered shape. This
+completes the CLOC12.159 `NewExpression` three-PR arc (node+emit → bridge →
+conformance).


### PR DESCRIPTION
## CLOC12.159 PR3 — CodePrinter new-operator conformance port

Third and final PR of the CLOC12.159 `NewExpression` (`new`) arc:

- **PR1** ([#7440](https://github.com/adhithyan15/coding-adventures/pull/7440)) — atomic node + `emit_new` + all pass match-arms
- **PR2** ([#7446](https://github.com/adhithyan15/coding-adventures/pull/7446)) — bridge-enable `new X(args)` → `NewExpression` (closes gap-160)
- **PR3** (this) — CodePrinter emit conformance port

### What this adds

A new upstream-cited test file `closure-emitter/tests/upstream/code_printer_new_test.rs` (registered as the `upstream_code_printer_new` `[[test]]` target), porting the Google Closure Compiler `CodePrinterTest` `new`-operator (`new Ctor(args)`) printing cases against `emit_new`. **10 active `#[test]`s, 0 `#[ignore]`**, all passing:

- identifier / member-chain callees (`new X()`, `new a.b.c()`)
- argument lists (`new X(a,b)`, `new X(a.b)`)
- the **callee-with-call wraps**: `new (f())()` and `new (a.b().c)()` — a callee whose member spine bottoms out in a call must wrap, or the appended `(args)` would bind to the inner call (`new f()()` = `(new f())()`, a miscompile)
- the `PREC_PRIMARY` member-object cases: `new X(a).y` and `new X().y` (an argumented `new` binds at member/call strength)
- nested `new new X()()`
- a call on a `new` member: `new X().m()`

Inputs are hand-constructed typed AST, mirroring the merged update/template ports — the emitter is the unit under test. The bridge conversion of `new` (PR2, gap-160) is exercised separately in `javascript-parser`.

**Test-only change — no library behaviour change.**

### Versions / docs
closure-emitter `0.23.0` → `0.23.1`; ATTRIBUTION entry, CHANGELOG `0.23.1` section, README upstream-ports list; `CLOC12-gaps.md` gap-160 PR3 paragraph marks the three-PR arc complete.

### Verification
- `cargo test -p coding-adventures-closure-emitter --test upstream_code_printer_new` → 10 passed
- Full `cargo test -p coding-adventures-closure-emitter` → all suites green
- Inline security review → PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)