### PR TITLE
feat(mosaic-compile): warn on style parts that match no layout part

### DIFF
--- a/code/packages/rust/mosaic-compile/CHANGELOG.md
+++ b/code/packages/rust/mosaic-compile/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+### Added - warn on style parts that match no layout part (`--strict-style`)
+
+After compiling the `.msl`, mosaic-compile now checks it against the resolved
+layout's part map via `mosstyle_compiler::unmatched_parts` and prints a warning
+for every style `part` whose name matches no exported part — with a
+`did you mean` suggestion when a sub-path tail (`sheet/cell` → `cell`) is itself
+an exported part. The mosstyle `validate` step is deliberately lenient about
+sub-path names (it only checks the top-level segment), so a stale `sheet/cell`
+that the emitter silently ignores used to compile clean and render unstyled —
+that is how the VisiCalc light-theme grid lost its gridlines. The new `--strict-style`
+flag escalates the warning into a hard error (exit 1) for CI that wants to fail
+on stale stylesheets. Default behavior is unchanged (warning only, exit 0).
+
 ### Changed - shared package-reference resolver
 
 Pipeline mode now uses `mosaic-package-resolver::LayoutPackageResolver` for

--- a/code/packages/rust/mosaic-compile/src/main.rs
+++ b/code/packages/rust/mosaic-compile/src/main.rs
@@ -211,6 +211,13 @@ fn run(result: cli_builder::types::ParseResult) {
         .get("emit-project")
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
+    // --strict-style: escalate the "style part matches no layout part" warning
+    // (emitted for every build) into a hard error — for CI that wants to fail on
+    // stale stylesheets. Off by default.
+    let strict_style = flags
+        .get("strict-style")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
     // --package-manifest: when set, the .mll's component-reference
     // resolver auto-registers every name in [components].exports so
     // intra-package references work (e.g. Field → Input in
@@ -252,6 +259,7 @@ fn run(result: cli_builder::types::ParseResult) {
             variant,
             output_path,
             emit_project,
+            strict_style,
             package_manifest_path.as_deref(),
             package_search_path.as_deref(),
         );
@@ -603,6 +611,7 @@ fn run_pipeline(
     variant: Option<&str>,
     output_path: Option<&str>,
     emit_project: bool,
+    strict_style: bool,
     package_manifest_path: Option<&str>,
     package_search_path: Option<&str>,
 ) {
@@ -737,6 +746,43 @@ fn run_pipeline(
             }
             process::exit(1);
         });
+
+    // -- 3b. Warn on style parts that match no layout part ------------------
+    //
+    // `mosstyle_compiler::validate` (run inside `compile` above) is deliberately
+    // lenient about sub-path part names: it only checks the top-level segment,
+    // so a stylesheet that writes `sheet/cell` when the resolved composition
+    // exports a flat `cell` compiles cleanly — yet the emitter styles `cell`, so
+    // `sheet/cell` targets nothing and the element renders UNSTYLED. That is
+    // exactly how the VisiCalc light-theme grid silently lost its gridlines
+    // (Grid.light.msl used the legacy `sheet/cell` naming). Surface it here so
+    // the typo can't hide: a warning by default, a hard error under
+    // --strict-style for CI that wants to fail on stale stylesheets.
+    let unmatched =
+        mosstyle_compiler::unmatched_parts(&style_out.def, Some(&layout_out.part_map_json));
+    if !unmatched.is_empty() {
+        let component = &layout_out.def.component_name;
+        for u in &unmatched {
+            let hint = match &u.suggestion {
+                Some(s) => format!(
+                    " — did you mean `{s}`? (`{s}` is an exported part; the emitter targets flat part names)"
+                ),
+                None => String::new(),
+            };
+            eprintln!(
+                "mosaic-compile: warning: style part `{}` in {style_path} matches no part \
+                 exported by component `{component}` — it will not be styled{hint}",
+                u.name
+            );
+        }
+        if strict_style {
+            eprintln!(
+                "mosaic-compile: --strict-style: {} unmatched style part(s) — failing.",
+                unmatched.len()
+            );
+            process::exit(1);
+        }
+    }
 
     // -- 4. Branch on backend. React emits one .tsx file; XAML emits a
     // triple (.xaml, .xaml.cs, .Event.cs) plus zero-or-more RowVm .cs

--- a/code/packages/rust/mosstyle-compiler/CHANGELOG.md
+++ b/code/packages/rust/mosstyle-compiler/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+### Added - `unmatched_parts()` to catch style parts that match no layout part
+
+New public `unmatched_parts(&StyleDef, part_map_json) -> Vec<UnmatchedPart>`.
+Unlike `validate` — which accepts a sub-path `a/b` as long as its top-level `a`
+exists — this reports style parts whose FULL name is not an exact member of the
+layout's part map, with a `suggestion` when the sub-path tail is itself an
+exported part (the classic stale-naming typo). This is what mosaic-compile uses
+to warn when e.g. `Grid.light.msl` writes `sheet/cell` while the composition
+exports a flat `cell`: `validate` passed it, but the emitter styled `cell`, so
+the light-theme grid rendered with no gridlines and nobody noticed until the web
+switcher first rendered the light theme.
+
 ### Added - Lattice style emission
 
 - `CompileOutput` now includes `lattice`, a first-class scoped Lattice source

--- a/code/packages/rust/mosstyle-compiler/src/lib.rs
+++ b/code/packages/rust/mosstyle-compiler/src/lib.rs
@@ -581,6 +581,62 @@ fn parse_part_names(json: &str) -> HashSet<String> {
     names
 }
 
+/// A style `part` block whose name doesn't EXACTLY match any part the layout
+/// exports. See [`unmatched_parts`].
+#[derive(Debug, Clone, PartialEq)]
+pub struct UnmatchedPart {
+    /// The part name exactly as written in the `.msl` (e.g. `sheet/cell`).
+    pub name: String,
+    /// If `name` is a sub-path `head/tail` whose `tail` IS itself an exported
+    /// top-level part, the likely intended flat name — the classic stale-naming
+    /// typo. `None` otherwise.
+    pub suggestion: Option<String>,
+}
+
+/// Report style parts whose name is not an EXACT member of the layout's part
+/// map.
+///
+/// This is deliberately stricter than [`validate`], which accepts a sub-path
+/// `a/b` as long as its top-level `a` exists (so it stays primitive-agnostic
+/// about sub-part vocabularies). That leniency is a sharp edge: a stylesheet
+/// that writes `sheet/cell` when the resolved composition exports a FLAT `cell`
+/// passes `validate` cleanly, yet the emitter — which looks up the flat part
+/// name — finds no style and renders the element unstyled. That is exactly how
+/// the VisiCalc light-theme grid lost its gridlines: `Grid.light.msl` used the
+/// legacy `sheet/cell` naming that matched nothing the emitter styled, and
+/// because the light theme was dead code until the web switcher rendered it,
+/// nobody noticed. Callers use this to surface a build-time WARNING (or, under a
+/// strict flag, an error) so the typo can't hide again.
+///
+/// Returns an empty vec when no part map is supplied (nothing to check against).
+pub fn unmatched_parts(def: &StyleDef, part_map_json: Option<&str>) -> Vec<UnmatchedPart> {
+    let json = match part_map_json {
+        Some(j) => j,
+        None => return Vec::new(),
+    };
+    let known = parse_part_names(json);
+    let mut out = Vec::new();
+    for part in &def.parts {
+        if known.contains(&part.name) {
+            continue; // exact match — the emitter will style it.
+        }
+        // Not an exact match. If this is a sub-path `head/tail` and `tail` is
+        // itself an exported part, the author almost certainly meant the flat
+        // `tail` (the post-U29-X1 naming) — surface that as a suggestion.
+        let tail = part.name.rsplit('/').next().unwrap_or(&part.name);
+        let suggestion = if tail != part.name && known.contains(tail) {
+            Some(tail.to_string())
+        } else {
+            None
+        };
+        out.push(UnmatchedPart {
+            name: part.name.clone(),
+            suggestion,
+        });
+    }
+    out
+}
+
 // ===========================================================================
 // Full compile pipeline
 // ===========================================================================
@@ -1147,6 +1203,48 @@ mod tests {
         "#;
         let result = compile(src, None).expect("deep sub-paths should compile");
         assert_eq!(result.def.parts[0].name, "sheet/header/cell");
+    }
+
+    #[test]
+    fn unmatched_parts_flags_stale_subpath_naming() {
+        // A stylesheet that uses the legacy `sheet/cell` sub-path naming while
+        // the resolved layout exposes a FLAT `cell` (post-U29-X1). `validate`
+        // accepts it (the top-level `sheet` exists), but the emitter styles the
+        // flat `cell`, so `sheet/cell` targets nothing — this is exactly how the
+        // VisiCalc light-theme grid lost its gridlines.
+        let src = r#"
+          style Grid {
+            part sheet { background: #ffffff ; }
+            part sheet/cell { background: #000000 ; }
+          }
+        "#;
+        let def = compile(src, None).expect("compiles").def;
+        let part_map = r#"{"component":"Grid","parts":[{"name":"sheet"},{"name":"cell"}]}"#;
+
+        let unmatched = unmatched_parts(&def, Some(part_map));
+        assert_eq!(unmatched.len(), 1, "only sheet/cell is unmatched");
+        assert_eq!(unmatched[0].name, "sheet/cell");
+        assert_eq!(
+            unmatched[0].suggestion.as_deref(),
+            Some("cell"),
+            "the flat tail `cell` is a known part, so it is suggested"
+        );
+
+        // A stylesheet whose parts all match the layout exactly reports nothing.
+        let ok = r#"
+          style Grid {
+            part sheet { background: #ffffff ; }
+            part cell { background: #000000 ; }
+          }
+        "#;
+        let ok_def = compile(ok, None).expect("compiles").def;
+        assert!(
+            unmatched_parts(&ok_def, Some(part_map)).is_empty(),
+            "exactly-matching parts produce no warnings"
+        );
+
+        // With no part map there is nothing to check against → empty.
+        assert!(unmatched_parts(&def, None).is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Why

`mosstyle_compiler::validate` is deliberately lenient about sub-path part names — it only checks the top-level segment. So a stylesheet that writes `sheet/cell` when the resolved composition exports a **flat** `cell` compiles clean, yet the emitter (which looks up flat part names) styles nothing, and the element renders **unstyled**.

That is exactly how the VisiCalc light-theme grid silently lost its gridlines: `Grid.light.msl` used the legacy `sheet/cell` naming that matched nothing the emitter styled, and because the light theme was dead code until the web layout/theme switcher rendered it, nobody noticed. This PR makes that class of typo impossible to hide.

## What

- **mosstyle-compiler**: new public `unmatched_parts(&StyleDef, part_map_json) -> Vec<UnmatchedPart>` — stricter than `validate`. Reports every style part whose **full** name is not an exact member of the layout part map, with a `suggestion` when a sub-path tail (`sheet/cell` → `cell`) is itself an exported part (the classic stale-naming typo).
- **mosaic-compile**: after compiling the `.msl`, check it against the resolved layout's part map and print a warning per unmatched part (with the *"did you mean"* hint). New `--strict-style` flag escalates the warning into a hard error (exit 1) for CI that wants to fail on stale stylesheets. **Default behavior is unchanged** (warning only, exit 0).

## Verification

- `cargo test -p mosstyle-compiler` (29 + 1 doc), `-p mosaic-compile` (9), `-p mosaic-package-artifact-builder` (46) all pass.
- E2E: a stale `sheet/cell` stylesheet warns with the correct `did you mean cell?` / `did you mean header-cell?` suggestions; the fixed `Grid.dark.msl` produces 0 warnings; `--strict-style` exits 1.
- Zero shipped `.msl` files currently use sub-paths (`grep` returned 0), so the warning is pure signal today — no false positives on the existing tree.
- `/security-review` passed (no vulnerabilities): pure in-memory logic, output goes to stderr only, no injection sink, no new `unsafe`, safe defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)