### PR TITLE
feat(lang-full): AL-multidim-bounds — ALGOL 60 arbitrary/negative array lower bounds on all 7 backends

### DIFF
--- a/code/packages/rust/algol-iir-compiler/CHANGELOG.md
+++ b/code/packages/rust/algol-iir-compiler/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 0.26.0 — 2026-07-02 — AL-multidim-bounds: arbitrary/negative lower bounds (LANG-FULL)
+
+Proves that ALGOL's **arbitrary per-dimension lower bounds** (`[lo:hi]` with
+`lo ≠ 1`, including `0` and negative) compose correctly with the multidim
+row-major strides.  Each subscript is translated to `sub − lower` *before* the
+stride is applied: `flat = Σ_d (sub[d] − lower[d]) * stride[d]`.  The 1:N cells
+shipped so far never exercised `lower ≠ 1`, so this closes a real correctness
+gap in the multidim index math.
+
+No compiler code changed — `ArrayDim` already records a per-dimension
+`lower_slot`, and `resolve_array_index` already emits the `sub − lower`
+subtraction; this is a coverage-gap closure.
+
+Two new unit tests (113 total):
+- `two_d_array_arbitrary_lower_bounds` — `M[0:1, 2:4]`, flat index `(i)*3 + (j−2)`
+- `two_d_array_negative_lower_bounds` — `M[−2:−1, 0:1]`, flat `(i+2)*2 + j`
+
+The 7-backend proof lives in `lang-aot` `lang_matrix.rs` (`M[−1:1, 2:3]`, a
+negative and a non-zero lower bound, summing to 42).
+
 ## 0.25.0 — 2026-07-02 — AL-multidim-3D: 3-D integer arrays (LANG-FULL)
 
 Proves the multidim array machinery is genuinely **N-dimensional**, not

--- a/code/packages/rust/algol-iir-compiler/Cargo.toml
+++ b/code/packages/rust/algol-iir-compiler/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "algol-iir-compiler"
-version = "0.25.0"
+version = "0.26.0"
 edition = "2021"
-description = "ALGOL 60 scalar frontend for the LANG VM Rust chain, lowering parsed ALGOL into interpreter_ir::IIRModule. v0.25.0 (AL-multidim-3D): 3-D integer arrays proven — `integer array M[lo1:hi1, lo2:hi2, lo3:hi3]` exercises the N-dimensional stride product (stride[0]=size[1]*size[2]); v0.24.0 (AL-multidim-real): f64 multidim array elements proven; v0.23.0 (AL-multidim): N-dimensional integer arrays via row-major flat index; ArrayDim per-dim lower/stride slots; all 7 backends via single alloc_array."
+description = "ALGOL 60 scalar frontend for the LANG VM Rust chain, lowering parsed ALGOL into interpreter_ir::IIRModule. v0.26.0 (AL-multidim-bounds): multidim arrays with arbitrary/negative per-dimension lower bounds proven — `(sub − lower)` subtraction composes with row-major strides; v0.25.0 (AL-multidim-3D): 3-D integer arrays proven; v0.24.0 (AL-multidim-real): f64 multidim array elements proven; v0.23.0 (AL-multidim): N-dimensional integer arrays via row-major flat index."
 
 [dependencies]
 coding-adventures-algol-parser = { path = "../algol-parser" }

--- a/code/packages/rust/algol-iir-compiler/src/lib.rs
+++ b/code/packages/rust/algol-iir-compiler/src/lib.rs
@@ -4682,6 +4682,33 @@ mod tests {
         assert_eq!(run_i64(src), 42);
     }
 
+    /// A 2-D array with **arbitrary (non-1) lower bounds** per dimension
+    /// (AL-multidim-bounds).  ALGOL arrays carry an explicit lower bound
+    /// `[lo:hi]`, so each subscript is translated to `sub − lower` before the
+    /// row-major stride is applied: `flat = Σ_d (sub[d] − lower[d]) * stride[d]`.
+    /// For `M[0:1, 2:4]` the sizes are `(2, 3)`, strides `[3, 1]`, and the flat
+    /// index of `M[i,j]` is `(i−0)*3 + (j−2)`.  `M[1,4]` is the last cell:
+    /// `1*3 + 2 = 5`.  Proves the per-dimension lower-bound subtraction composes
+    /// with multidim strides (the 1:N cells never exercised `lower ≠ 1`).
+    #[test]
+    fn two_d_array_arbitrary_lower_bounds() {
+        let src = "begin integer array M[0:1, 2:4]; integer result; \
+                   M[0,2] := 100; M[1,4] := 42; result := M[1,4] end";
+        assert_eq!(run_i64(src), 42);
+    }
+
+    /// A 2-D array with **negative** lower bounds.  `M[-1:0, 0:1]` has sizes
+    /// `(2, 2)`, strides `[2, 1]`; `M[i,j]` → `(i−(−1))*2 + (j−0) = (i+1)*2 + j`.
+    /// `M[-1,0]` is flat 0, `M[0,1]` is flat `1*2 + 1 = 3`; storing 40 and 2 and
+    /// summing gives 42.
+    #[test]
+    fn two_d_array_negative_lower_bounds() {
+        let src = "begin integer array M[0-2 : 0-1, 0:1]; integer result; \
+                   M[0-2, 0] := 40; M[0-1, 1] := 2; \
+                   result := M[0-2, 0] + M[0-1, 1] end";
+        assert_eq!(run_i64(src), 42);
+    }
+
     /// Wrong number of subscripts for a 2-D array is a type error.
     #[test]
     fn rejects_wrong_subscript_count_for_2d_array() {

--- a/code/packages/rust/lang-aot/CHANGELOG.md
+++ b/code/packages/rust/lang-aot/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog — `lang-aot`
 
+## 0.169.0 — 2026-07-02 — AL-multidim-bounds: ALGOL 60 2D array with arbitrary/negative lower bounds (all 7 backends)
+
+**New matrix proof cell** (`lang_matrix.rs`): ALGOL 60 2D integer array with a
+**negative** lower bound on one axis and a non-zero one on the other, running on
+all 7 backends (NativeAot, Llvm, Wasm, Jvm, Clr, Vm, Jit).
+
+```algol60
+begin integer array M[0-1:1, 2:3]; integer result;
+  M[0-1, 2] := 40; M[1, 3] := 2;
+  result := M[0-1, 2] + M[1, 3] end
+```
+
+`M[-1:1, 2:3]` has sizes `(3, 2)`, strides `[2, 1]`, so `M[i,j]` folds to
+`(i−(−1))*2 + (j−2)`.  `M[-1,2]` is flat 0, `M[1,3]` is flat 5 (the last of 6
+cells — proving both the per-dimension `sub−lower` subtraction and the row
+stride).  The negative bound is written `0-1` since ALGOL number literals are
+unsigned.  No new IIR op, no backend change.  Requires `algol-iir-compiler`
+0.26.0.  Exit 42.
+
 ## 0.168.0 — 2026-07-02 — BA-DIM-2D: Dartmouth BASIC 2D DIM array matrix proof cell (all 7 backends)
 
 **New matrix proof cell** (`lang_matrix.rs`): Dartmouth BASIC two-dimensional

--- a/code/packages/rust/lang-aot/Cargo.toml
+++ b/code/packages/rust/lang-aot/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "lang-aot"
-version = "0.168.0"
+version = "0.169.0"
 edition = "2021"
-description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, and McCarthy Lisp to native executables through the shared IIR pipeline.  v0.168.0 (BA-DIM-2D): Dartmouth BASIC 2D DIM array matrix proof cell (`DIM A(1,2)`) runs on all 7 backends via row-major flat index.  v0.167.0 (AL-multidim-3D): ALGOL 60 3D integer array cell on all 7 backends.  v0.166.0 (AL-multidim-real): 2D real array cell on all 7 backends."
+description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, and McCarthy Lisp to native executables through the shared IIR pipeline.  v0.169.0 (AL-multidim-bounds): ALGOL 60 2D array with arbitrary/negative lower bounds (`M[0-1:1, 2:3]`) runs on all 7 backends — proves the per-dim `sub−lower` subtraction composes with strides.  v0.168.0 (BA-DIM-2D): Dartmouth BASIC 2D DIM array cell.  v0.167.0 (AL-multidim-3D): ALGOL 60 3D integer array cell on all 7 backends."
 
 [dependencies]
 twig-aot              = { path = "../twig-aot" }

--- a/code/packages/rust/lang-aot/tests/lang_matrix.rs
+++ b/code/packages/rust/lang-aot/tests/lang_matrix.rs
@@ -1573,6 +1573,28 @@ const PROGRAMS: &[Prog] = &[
         expect: Expect::Exit(42),
         backends: &[NativeAot, Llvm, Wasm, Jvm, Clr, Vm, Jit],
     },
+    // ALGOL 60 — *2-D array with arbitrary lower bounds* (LANG-FULL
+    // AL-multidim-bounds).  Unlike BASIC's fixed 0-based arrays, ALGOL arrays
+    // carry an explicit lower bound per dimension (`[lo:hi]`), so each subscript
+    // is translated to `sub − lower` *before* the row-major stride is applied:
+    // `flat = Σ_d (sub[d] − lower[d]) * stride[d]`.  This cell uses a **negative**
+    // lower bound on one axis and a non-zero one on the other: `M[-1:1, 2:3]` has
+    // sizes `(3, 2)`, strides `[2, 1]`, so `M[i,j]` → `(i−(−1))*2 + (j−2)`.
+    // Stores `M[-1,2]=40` (flat `0*2+0 = 0`) and `M[1,3]=2` (flat `2*2+1 = 5`,
+    // the last of 6 cells — proving both the lower-bound subtraction and the
+    // stride), then `M[-1,2] + M[1,3]` = 42.  The negative bound is written
+    // `0-1` since ALGOL number literals are unsigned.  Still only `alloc_array`/
+    // `array_set`/`array_get` with a flat index — **no backend change** — so it
+    // runs on **all 7 backends**.  Exit 42.
+    Prog {
+        lang: Language::Algol60,
+        ext: "alg",
+        src: "begin integer array M[0-1:1, 2:3]; integer result; \
+               M[0-1, 2] := 40; M[1, 3] := 2; \
+               result := M[0-1, 2] + M[1, 3] end",
+        expect: Expect::Exit(42),
+        backends: &[NativeAot, Llvm, Wasm, Jvm, Clr, Vm, Jit],
+    },
     // Brainfuck — build 65 on the tape and `putchar` it: prints `A`.
     // `lower_brainfuck_for_aot` widens the BF cell/ptr registers to `i64` (byte width
     // survives only at the tape boundary) for every code-gen backend. On LLVM (LM-L)

--- a/code/specs/LANG-FULL-IMPLEMENTATION.md
+++ b/code/specs/LANG-FULL-IMPLEMENTATION.md
@@ -671,6 +671,12 @@ backend immediately) come before the enabler-dependent items.
   proves the lowering is genuinely N-dimensional (stride product `stride[0]=size[1]*size[2]=4`,
   `stride[1]=2`, `stride[2]=1`); no compiler change (the right-to-left stride loop just walks one
   more iteration); `algol-iir-compiler` 0.25.0 / `lang-aot` 0.167.0.
+  **AL-multidim-bounds ✅**: `integer array M[-1:1, 2:3]` (arbitrary, incl. negative, per-dimension
+  lower bounds) runs on **all 7 backends** — proves the per-dim `sub−lower` subtraction composes
+  with the row-major strides (`flat = Σ_d (sub[d]−lower[d])*stride[d]`); no compiler change (the
+  `ArrayDim.lower_slot` subtraction already existed); `algol-iir-compiler` 0.26.0 / `lang-aot` 0.169.0.
+  Array **value parameters** (passing an array to a procedure) remain a follow-up — they need
+  managed-backend (JVM/CLR) call-signature work, not just the frontend.
 - ✅ **AL3** — typed procedures with value parameters. `integer procedure sq(x);
   value x; integer x; sq := x*x; result := sq(7)` ⇒ exit 49, **verified by running**
   across native/LLVM/WASM/JVM/CLR/VM/JIT (`lang-aot` `lang_matrix.rs`). Lowered to a


### PR DESCRIPTION
## Summary

Proves ALGOL's **arbitrary per-dimension lower bounds** (`[lo:hi]` with `lo ≠ 1`,
including `0` and **negative**) compose correctly with the multidim row-major
strides. Each subscript is translated to `sub − lower` *before* the stride is
applied: `flat = Σ_d (sub[d] − lower[d]) * stride[d]`. The `1:N` cells shipped
so far never exercised `lower ≠ 1`, so this closes a real correctness gap. Runs
on **all 7 backends** (NativeAot, Llvm, Wasm, Jvm, Clr, Vm, Jit). LANG-FULL
**AL-multidim-bounds**.

Proof cell:
```algol60
begin integer array M[0-1:1, 2:3]; integer result;
  M[0-1, 2] := 40; M[1, 3] := 2;
  result := M[0-1, 2] + M[1, 3] end
```
`M[-1:1, 2:3]` has sizes `(3, 2)`, strides `[2, 1]`, so `M[i,j]` → `(i−(−1))*2 + (j−2)`.
`M[-1,2]` is flat 0, `M[1,3]` is flat 5 (the last of 6 cells — proving both the
per-dimension `sub−lower` subtraction and the row stride). Sum = 42. (The
negative bound is written `0-1` since ALGOL number literals are unsigned.)

## Changes

### `algol-iir-compiler` 0.26.0
- **No compiler code changed.** `ArrayDim` already records a per-dimension
  `lower_slot`, and `resolve_array_index` already emits the `sub − lower`
  subtraction — this is a coverage-gap closure.
- 2 new unit tests (113 total): `two_d_array_arbitrary_lower_bounds`
  (`M[0:1, 2:4]`), `two_d_array_negative_lower_bounds` (`M[-2:-1, 0:1]`).

### `lang-aot` 0.169.0
- New AL-multidim-bounds matrix proof cell, verified on all 7 backends.

### Spec
- `LANG-FULL-IMPLEMENTATION.md` marks **AL-multidim-bounds ✅** and records that
  array **value parameters** remain a follow-up (they need managed-backend
  JVM/CLR call-signature work, not just the frontend).

## Verification
- `cargo test -p algol-iir-compiler --lib` — 113 tests pass
- `cargo test -p lang-aot --test lang_matrix proven_columns_do_not_silently_skip` — pass (runs on NativeAot + all native-present backends)
- `cargo test -p lang-aot --test lang_matrix matrix_every_proven_cell_agrees` — pass (all backends agree → 42)
- **Security review passed** (test-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)