### PR TITLE
feat(adj-ladder): rung-55 anesthesia fresh-gas volume (product of two sums (a+b)*(c+d))

### DIFF
--- a/code/specs/data/adj-ladder/rung55_fresh_gas_volume/gen_items.py
+++ b/code/specs/data/adj-ladder/rung55_fresh_gas_volume/gen_items.py
@@ -1,0 +1,224 @@
+"""Generate rung-55 (anesthesia fresh-gas volume) items.json for the ADJ-LADDER.
+
+Rung 55 opens the **anesthesia / fresh-gas-delivery** panel on the quantitative band — the arithmetic of how much fresh
+gas an anesthesia machine delivers over a whole case. The gas comes from two sources (oxygen and air) whose flows add
+to a combined fresh-gas flow, and the case runs through two phases (induction and maintenance) whose minutes add to the
+total time; the total gas delivered is the combined flow times the total time. Multiplying a sum of two by ANOTHER sum
+of two introduces a genuinely NEW arithmetic shape on the ladder: a **product of two sums** — `(a + b) · (c + d)` — the
+classic FOIL, two parenthesised sums multiplied.
+
+The setup: an anesthesia machine runs `oxygen_flow` of oxygen and `air_flow` of air (litres per minute), for an
+induction phase of `induction_minutes` and a maintenance phase of `maintenance_minutes`. The total fresh gas is the
+combined flow times the total time:
+
+  TOTAL GAS       (oxygen_flow + air_flow) · (induction_minutes + maintenance_minutes)   [ litres — the whole delivery ]
+  COMBINED FLOW   oxygen_flow + air_flow                                                 [ one sum: the fresh-gas flow ]
+  TOTAL TIME      induction_minutes + maintenance_minutes                                [ the other sum: the case time ]
+
+The **total gas** is what makes this rung distinctive — it is the ladder's first **product of two sums**: two
+parenthesised sums multiplied. Contrast the neighbours already on the ladder: rung-48 was a *sum times a difference*
+`(a+b)·(c−d)` and rung-37 a *ratio of two sums* `(a+b)/(c+d)`; neither multiplied a sum by a SUM. (The combined flow
+`oxygen_flow + air_flow` and the total time `induction_minutes + maintenance_minutes` ride alongside as component
+readouts, so the panel teaches the whole calculation — exactly as rungs 47-54 shipped their component
+sums/products/differences beside the headline figure.)
+
+Each index is a `compute_dimensioned` program (`observe` the four quantities + `let answer = formula`); the ADJ engine
+carries the arithmetic — including both parenthesised sums and their product — and the harness reads the scalar via the
+existing `compute_dimensioned` extractor. No harness/engine change, exactly as rungs 8/16/.../53/54. This rung exercises
+the engine across a **product of two parenthesised sums** — the distributive law `(a+b)·(c+d) = ac+ad+bc+bd` made
+computable.
+
+Contamination-safe by construction: every formula is built ONLY from the four observed quantities via `+` and `·` —
+**no structural constants** — so no numeric literal appears in any program, and neither the combined flow, the total
+time, nor any total-gas figure is ever a literal (each is computed from the observed quantities). The observed
+quantities carry **digit-free identifiers** (`oxygen_flow`, `air_flow`, `induction_minutes`, `maintenance_minutes`) so
+no numeral hides inside a variable name.
+
+The five options are a tight family over the same four quantities: the three real readouts plus the two classic slips —
+
+  SUM VERSION   (oxygen_flow + air_flow) + (induction_minutes + maintenance_minutes)   ADD the two sums instead of
+                                                                                       multiplying them, and
+  MISGROUPED    (oxygen_flow + air_flow) · induction_minutes + maintenance_minutes      multiply the flow by only the
+                                                                                       INDUCTION minutes and then add the
+                                                                                       maintenance minutes on
+                                                                                       (`… · induction + maintenance`,
+                                                                                       not `… · (induction +
+                                                                                       maintenance)`),
+
+which are exactly the mistakes a student makes (adding two totals that should be multiplied, or breaking the grouping so
+the flow multiplies only the first phase). Gold rotates A-E by index. QUERIED (used as gold) = the three real readouts;
+all five always appear as options.
+
+Distinctness: all four observed quantities are strictly positive, so every sum and product is positive; the tables
+below are chosen so the five family values are pairwise distinct with a comfortable margin, asserted at build time.
+"""
+import json
+
+LETTERS = ["A", "B", "C", "D", "E"]
+
+# (OXYGEN_FLOW, AIR_FLOW, INDUCTION_MINUTES, MAINTENANCE_MINUTES) — two gas-source flows (L/min) and two case phases
+# (min), all plain positive numbers. The five family values are asserted pairwise-distinct (with margin) below.
+TABLES = [
+    (2, 3, 10, 20),
+    (1, 4, 15, 25),
+    (3, 2, 8, 32),
+    (2, 2, 12, 18),
+    (4, 1, 20, 10),
+    (1, 2, 25, 35),
+    (3, 3, 9, 21),
+]
+
+# The option family (5 members), all built from the four observed quantities via + and *. Every identifier is
+# DIGIT-FREE. key -> (display name, formula-as-adj). Only the first three are *queried* (used as gold); all five
+# always appear as the options.
+FAMILY = [
+    (
+        "total_gas",
+        "total fresh gas delivered (the combined flow times the total case time)",
+        "(oxygen_flow + air_flow) * (induction_minutes + maintenance_minutes)",
+    ),
+    (
+        "combined_flow",
+        "the combined fresh-gas flow (oxygen plus air)",
+        "oxygen_flow + air_flow",
+    ),
+    (
+        "total_time",
+        "the total case time (induction plus maintenance minutes)",
+        "induction_minutes + maintenance_minutes",
+    ),
+    (
+        "sum_version",
+        "the combined flow and the total time ADDED, not multiplied (a wrong total)",
+        "(oxygen_flow + air_flow) + (induction_minutes + maintenance_minutes)",
+    ),
+    (
+        "misgrouped",
+        "the flow times only the INDUCTION minutes, with maintenance minutes added on (broken grouping)",
+        "(oxygen_flow + air_flow) * induction_minutes + maintenance_minutes",
+    ),
+]
+QUERIED = ["total_gas", "combined_flow", "total_time"]
+ORDER = [k for k, _, _ in FAMILY]
+
+
+def scalar(v):
+    return {"value": v, "unit": "scalar"}
+
+
+def family_values(oxygen_flow, air_flow, induction_minutes, maintenance_minutes):
+    # Operation order mirrors the ADJ programs exactly (a product of two parenthesised sums; and, for the misgrouped
+    # slip, the flow-times-induction product binds tighter than the trailing addition), so the Python option value and
+    # the engine result are the same IEEE-double (well within the harness's 1e-9 match tolerance).
+    flow = oxygen_flow + air_flow
+    time = induction_minutes + maintenance_minutes
+    return {
+        "total_gas": flow * time,
+        "combined_flow": flow,
+        "total_time": time,
+        "sum_version": flow + time,
+        "misgrouped": flow * induction_minutes + maintenance_minutes,
+    }
+
+
+def build():
+    name_of = {k: nm for k, nm, _ in FAMILY}
+    formula_of = {k: f for k, _, f in FAMILY}
+    items = []
+    idx = 0
+
+    def num(x):
+        return int(x) if float(x).is_integer() else x
+
+    for oxygen_flow, air_flow, induction_minutes, maintenance_minutes in TABLES:
+        assert (
+            oxygen_flow > 0
+            and air_flow > 0
+            and induction_minutes > 0
+            and maintenance_minutes > 0
+        ), (oxygen_flow, air_flow, induction_minutes, maintenance_minutes)
+        fv = family_values(oxygen_flow, air_flow, induction_minutes, maintenance_minutes)
+        # Pairwise-distinct with a comfortable margin so the harness never sees two options
+        # matching the gold value within its 1e-9 tolerance.
+        vals = [fv[key] for key in ORDER]
+        for i in range(len(vals)):
+            for j in range(i + 1, len(vals)):
+                assert abs(vals[i] - vals[j]) > 1e-6, (
+                    oxygen_flow,
+                    air_flow,
+                    induction_minutes,
+                    maintenance_minutes,
+                    ORDER[i],
+                    ORDER[j],
+                    fv,
+                )
+        for key in QUERIED:
+            gold_val = fv[key]
+            gold_pos = idx % 5
+            others = [fv[k2] for k2 in ORDER if abs(fv[k2] - gold_val) > 1e-12]
+            opts_vals = others[:]
+            opts_vals.insert(gold_pos, gold_val)
+            opts_vals = opts_vals[:5]
+            if abs(opts_vals[gold_pos] - gold_val) > 1e-12:
+                opts_vals[gold_pos] = gold_val
+            assert len({round(v, 9) for v in opts_vals}) == 5, (
+                key,
+                oxygen_flow,
+                air_flow,
+                induction_minutes,
+                maintenance_minutes,
+                opts_vals,
+            )
+            options = {LETTERS[i]: scalar(opts_vals[i]) for i in range(5)}
+            items.append({
+                "id": f"r55gas-{idx + 1:02d}",
+                "qtype": "fresh_gas_volume",
+                "stem": (
+                    f"An anesthesia machine runs {num(oxygen_flow)} L/min of oxygen and {num(air_flow)} L/min of air, "
+                    f"for a {num(induction_minutes)}-minute induction and a {num(maintenance_minutes)}-minute "
+                    f"maintenance phase. What is the {name_of[key]}?"
+                ),
+                "program": (
+                    f"observe oxygen_flow({num(oxygen_flow)})\n"
+                    f"observe air_flow({num(air_flow)})\n"
+                    f"observe induction_minutes({num(induction_minutes)})\n"
+                    f"observe maintenance_minutes({num(maintenance_minutes)})\n"
+                    f"let answer = {formula_of[key]}\n"
+                    "? answer\n"
+                ),
+                "answer_from": {"type": "compute_dimensioned", "name": "answer"},
+                "options": options,
+                "gold_letter": LETTERS[gold_pos],
+            })
+            idx += 1
+    return {
+        "description": (
+            "ADJ-LADDER rung 55 — anesthesia fresh-gas volume from four stated quantities (a NEW panel: anesthesia / "
+            "fresh-gas-delivery). From two gas-source flows (oxygen, air) and two case phases (induction, maintenance) "
+            "compute the total fresh gas ((oxygen_flow+air_flow)*(induction_minutes+maintenance_minutes)), the combined "
+            "flow (oxygen_flow+air_flow), or the total time (induction_minutes+maintenance_minutes). Each item is a "
+            "compute_dimensioned program (observe the four quantities, let answer = formula); the ADJ engine carries "
+            "the arithmetic — a NEW shape, PRODUCT OF TWO SUMS (a+b)*(c+d), the first on the ladder to multiply a sum "
+            "by another sum (distinct from rung-48 sum-times-difference (a+b)*(c-d) and rung-37 ratio-of-two-sums "
+            "(a+b)/(c+d)) — and the harness matches the scalar to the printed options. Contamination-safe: every index "
+            "is built only from the four observed quantities via + and * — no constant leaks, and neither the combined "
+            "flow, the total time, nor any total-gas figure ever appears as a literal (each is computed) — and the "
+            "observed quantities carry digit-free identifiers so no numeral hides inside a variable name. The five "
+            "options are a family over the same four quantities, so the distractors are exactly the slips students "
+            "make: ADDING the two sums instead of multiplying them, and breaking the grouping so the flow multiplies "
+            "only the induction phase ((a+b)*c+d, not (a+b)*(c+d)). The core confusion tested is multiplying two "
+            "grouped sums."
+        ),
+        "items": items,
+    }
+
+
+if __name__ == "__main__":
+    doc = build()
+    with open("items.json", "w") as f:
+        json.dump(doc, f, indent=2)
+        f.write("\n")
+    print("wrote items.json:", len(doc["items"]), "items")
+    for it in doc["items"]:
+        print(it["id"], it["qtype"], "gold", it["gold_letter"],
+              "=", round(it["options"][it["gold_letter"]]["value"], 6))

--- a/code/specs/data/adj-ladder/rung55_fresh_gas_volume/items.json
+++ b/code/specs/data/adj-ladder/rung55_fresh_gas_volume/items.json
@@ -1,0 +1,698 @@
+{
+  "description": "ADJ-LADDER rung 55 \u2014 anesthesia fresh-gas volume from four stated quantities (a NEW panel: anesthesia / fresh-gas-delivery). From two gas-source flows (oxygen, air) and two case phases (induction, maintenance) compute the total fresh gas ((oxygen_flow+air_flow)*(induction_minutes+maintenance_minutes)), the combined flow (oxygen_flow+air_flow), or the total time (induction_minutes+maintenance_minutes). Each item is a compute_dimensioned program (observe the four quantities, let answer = formula); the ADJ engine carries the arithmetic \u2014 a NEW shape, PRODUCT OF TWO SUMS (a+b)*(c+d), the first on the ladder to multiply a sum by another sum (distinct from rung-48 sum-times-difference (a+b)*(c-d) and rung-37 ratio-of-two-sums (a+b)/(c+d)) \u2014 and the harness matches the scalar to the printed options. Contamination-safe: every index is built only from the four observed quantities via + and * \u2014 no constant leaks, and neither the combined flow, the total time, nor any total-gas figure ever appears as a literal (each is computed) \u2014 and the observed quantities carry digit-free identifiers so no numeral hides inside a variable name. The five options are a family over the same four quantities, so the distractors are exactly the slips students make: ADDING the two sums instead of multiplying them, and breaking the grouping so the flow multiplies only the induction phase ((a+b)*c+d, not (a+b)*(c+d)). The core confusion tested is multiplying two grouped sums.",
+  "items": [
+    {
+      "id": "r55gas-01",
+      "qtype": "fresh_gas_volume",
+      "stem": "An anesthesia machine runs 2 L/min of oxygen and 3 L/min of air, for a 10-minute induction and a 20-minute maintenance phase. What is the total fresh gas delivered (the combined flow times the total case time)?",
+      "program": "observe oxygen_flow(2)\nobserve air_flow(3)\nobserve induction_minutes(10)\nobserve maintenance_minutes(20)\nlet answer = (oxygen_flow + air_flow) * (induction_minutes + maintenance_minutes)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 150,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 30,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 35,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 70,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r55gas-02",
+      "qtype": "fresh_gas_volume",
+      "stem": "An anesthesia machine runs 2 L/min of oxygen and 3 L/min of air, for a 10-minute induction and a 20-minute maintenance phase. What is the the combined fresh-gas flow (oxygen plus air)?",
+      "program": "observe oxygen_flow(2)\nobserve air_flow(3)\nobserve induction_minutes(10)\nobserve maintenance_minutes(20)\nlet answer = oxygen_flow + air_flow\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 150,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 30,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 35,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 70,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r55gas-03",
+      "qtype": "fresh_gas_volume",
+      "stem": "An anesthesia machine runs 2 L/min of oxygen and 3 L/min of air, for a 10-minute induction and a 20-minute maintenance phase. What is the the total case time (induction plus maintenance minutes)?",
+      "program": "observe oxygen_flow(2)\nobserve air_flow(3)\nobserve induction_minutes(10)\nobserve maintenance_minutes(20)\nlet answer = induction_minutes + maintenance_minutes\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 150,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 30,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 35,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 70,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r55gas-04",
+      "qtype": "fresh_gas_volume",
+      "stem": "An anesthesia machine runs 1 L/min of oxygen and 4 L/min of air, for a 15-minute induction and a 25-minute maintenance phase. What is the total fresh gas delivered (the combined flow times the total case time)?",
+      "program": "observe oxygen_flow(1)\nobserve air_flow(4)\nobserve induction_minutes(15)\nobserve maintenance_minutes(25)\nlet answer = (oxygen_flow + air_flow) * (induction_minutes + maintenance_minutes)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 40,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 45,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 200,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 100,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r55gas-05",
+      "qtype": "fresh_gas_volume",
+      "stem": "An anesthesia machine runs 1 L/min of oxygen and 4 L/min of air, for a 15-minute induction and a 25-minute maintenance phase. What is the the combined fresh-gas flow (oxygen plus air)?",
+      "program": "observe oxygen_flow(1)\nobserve air_flow(4)\nobserve induction_minutes(15)\nobserve maintenance_minutes(25)\nlet answer = oxygen_flow + air_flow\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 200,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 40,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 45,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 100,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 5,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r55gas-06",
+      "qtype": "fresh_gas_volume",
+      "stem": "An anesthesia machine runs 1 L/min of oxygen and 4 L/min of air, for a 15-minute induction and a 25-minute maintenance phase. What is the the total case time (induction plus maintenance minutes)?",
+      "program": "observe oxygen_flow(1)\nobserve air_flow(4)\nobserve induction_minutes(15)\nobserve maintenance_minutes(25)\nlet answer = induction_minutes + maintenance_minutes\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 40,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 200,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 45,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 100,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r55gas-07",
+      "qtype": "fresh_gas_volume",
+      "stem": "An anesthesia machine runs 3 L/min of oxygen and 2 L/min of air, for a 8-minute induction and a 32-minute maintenance phase. What is the total fresh gas delivered (the combined flow times the total case time)?",
+      "program": "observe oxygen_flow(3)\nobserve air_flow(2)\nobserve induction_minutes(8)\nobserve maintenance_minutes(32)\nlet answer = (oxygen_flow + air_flow) * (induction_minutes + maintenance_minutes)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 200,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 40,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 45,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 72,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r55gas-08",
+      "qtype": "fresh_gas_volume",
+      "stem": "An anesthesia machine runs 3 L/min of oxygen and 2 L/min of air, for a 8-minute induction and a 32-minute maintenance phase. What is the the combined fresh-gas flow (oxygen plus air)?",
+      "program": "observe oxygen_flow(3)\nobserve air_flow(2)\nobserve induction_minutes(8)\nobserve maintenance_minutes(32)\nlet answer = oxygen_flow + air_flow\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 200,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 40,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 45,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 72,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r55gas-09",
+      "qtype": "fresh_gas_volume",
+      "stem": "An anesthesia machine runs 3 L/min of oxygen and 2 L/min of air, for a 8-minute induction and a 32-minute maintenance phase. What is the the total case time (induction plus maintenance minutes)?",
+      "program": "observe oxygen_flow(3)\nobserve air_flow(2)\nobserve induction_minutes(8)\nobserve maintenance_minutes(32)\nlet answer = induction_minutes + maintenance_minutes\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 200,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 45,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 40,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 72,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r55gas-10",
+      "qtype": "fresh_gas_volume",
+      "stem": "An anesthesia machine runs 2 L/min of oxygen and 2 L/min of air, for a 12-minute induction and a 18-minute maintenance phase. What is the total fresh gas delivered (the combined flow times the total case time)?",
+      "program": "observe oxygen_flow(2)\nobserve air_flow(2)\nobserve induction_minutes(12)\nobserve maintenance_minutes(18)\nlet answer = (oxygen_flow + air_flow) * (induction_minutes + maintenance_minutes)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 4,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 30,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 34,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 66,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 120,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r55gas-11",
+      "qtype": "fresh_gas_volume",
+      "stem": "An anesthesia machine runs 2 L/min of oxygen and 2 L/min of air, for a 12-minute induction and a 18-minute maintenance phase. What is the the combined fresh-gas flow (oxygen plus air)?",
+      "program": "observe oxygen_flow(2)\nobserve air_flow(2)\nobserve induction_minutes(12)\nobserve maintenance_minutes(18)\nlet answer = oxygen_flow + air_flow\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 4,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 120,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 30,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 34,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 66,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r55gas-12",
+      "qtype": "fresh_gas_volume",
+      "stem": "An anesthesia machine runs 2 L/min of oxygen and 2 L/min of air, for a 12-minute induction and a 18-minute maintenance phase. What is the the total case time (induction plus maintenance minutes)?",
+      "program": "observe oxygen_flow(2)\nobserve air_flow(2)\nobserve induction_minutes(12)\nobserve maintenance_minutes(18)\nlet answer = induction_minutes + maintenance_minutes\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 120,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 30,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 4,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 34,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 66,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r55gas-13",
+      "qtype": "fresh_gas_volume",
+      "stem": "An anesthesia machine runs 4 L/min of oxygen and 1 L/min of air, for a 20-minute induction and a 10-minute maintenance phase. What is the total fresh gas delivered (the combined flow times the total case time)?",
+      "program": "observe oxygen_flow(4)\nobserve air_flow(1)\nobserve induction_minutes(20)\nobserve maintenance_minutes(10)\nlet answer = (oxygen_flow + air_flow) * (induction_minutes + maintenance_minutes)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 30,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 150,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 35,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 110,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r55gas-14",
+      "qtype": "fresh_gas_volume",
+      "stem": "An anesthesia machine runs 4 L/min of oxygen and 1 L/min of air, for a 20-minute induction and a 10-minute maintenance phase. What is the the combined fresh-gas flow (oxygen plus air)?",
+      "program": "observe oxygen_flow(4)\nobserve air_flow(1)\nobserve induction_minutes(20)\nobserve maintenance_minutes(10)\nlet answer = oxygen_flow + air_flow\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 150,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 30,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 35,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 110,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r55gas-15",
+      "qtype": "fresh_gas_volume",
+      "stem": "An anesthesia machine runs 4 L/min of oxygen and 1 L/min of air, for a 20-minute induction and a 10-minute maintenance phase. What is the the total case time (induction plus maintenance minutes)?",
+      "program": "observe oxygen_flow(4)\nobserve air_flow(1)\nobserve induction_minutes(20)\nobserve maintenance_minutes(10)\nlet answer = induction_minutes + maintenance_minutes\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 150,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 35,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 110,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 30,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r55gas-16",
+      "qtype": "fresh_gas_volume",
+      "stem": "An anesthesia machine runs 1 L/min of oxygen and 2 L/min of air, for a 25-minute induction and a 35-minute maintenance phase. What is the total fresh gas delivered (the combined flow times the total case time)?",
+      "program": "observe oxygen_flow(1)\nobserve air_flow(2)\nobserve induction_minutes(25)\nobserve maintenance_minutes(35)\nlet answer = (oxygen_flow + air_flow) * (induction_minutes + maintenance_minutes)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 180,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 3,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 60,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 63,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 110,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r55gas-17",
+      "qtype": "fresh_gas_volume",
+      "stem": "An anesthesia machine runs 1 L/min of oxygen and 2 L/min of air, for a 25-minute induction and a 35-minute maintenance phase. What is the the combined fresh-gas flow (oxygen plus air)?",
+      "program": "observe oxygen_flow(1)\nobserve air_flow(2)\nobserve induction_minutes(25)\nobserve maintenance_minutes(35)\nlet answer = oxygen_flow + air_flow\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 180,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 3,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 60,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 63,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 110,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r55gas-18",
+      "qtype": "fresh_gas_volume",
+      "stem": "An anesthesia machine runs 1 L/min of oxygen and 2 L/min of air, for a 25-minute induction and a 35-minute maintenance phase. What is the the total case time (induction plus maintenance minutes)?",
+      "program": "observe oxygen_flow(1)\nobserve air_flow(2)\nobserve induction_minutes(25)\nobserve maintenance_minutes(35)\nlet answer = induction_minutes + maintenance_minutes\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 180,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 3,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 60,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 63,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 110,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r55gas-19",
+      "qtype": "fresh_gas_volume",
+      "stem": "An anesthesia machine runs 3 L/min of oxygen and 3 L/min of air, for a 9-minute induction and a 21-minute maintenance phase. What is the total fresh gas delivered (the combined flow times the total case time)?",
+      "program": "observe oxygen_flow(3)\nobserve air_flow(3)\nobserve induction_minutes(9)\nobserve maintenance_minutes(21)\nlet answer = (oxygen_flow + air_flow) * (induction_minutes + maintenance_minutes)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 30,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 36,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 180,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 75,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r55gas-20",
+      "qtype": "fresh_gas_volume",
+      "stem": "An anesthesia machine runs 3 L/min of oxygen and 3 L/min of air, for a 9-minute induction and a 21-minute maintenance phase. What is the the combined fresh-gas flow (oxygen plus air)?",
+      "program": "observe oxygen_flow(3)\nobserve air_flow(3)\nobserve induction_minutes(9)\nobserve maintenance_minutes(21)\nlet answer = oxygen_flow + air_flow\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 180,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 30,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 36,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 75,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 6,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r55gas-21",
+      "qtype": "fresh_gas_volume",
+      "stem": "An anesthesia machine runs 3 L/min of oxygen and 3 L/min of air, for a 9-minute induction and a 21-minute maintenance phase. What is the the total case time (induction plus maintenance minutes)?",
+      "program": "observe oxygen_flow(3)\nobserve air_flow(3)\nobserve induction_minutes(9)\nobserve maintenance_minutes(21)\nlet answer = induction_minutes + maintenance_minutes\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 30,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 180,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 36,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 75,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    }
+  ]
+}

--- a/code/specs/data/adj-ladder/test_ladder_eval.py
+++ b/code/specs/data/adj-ladder/test_ladder_eval.py
@@ -92,6 +92,7 @@ SELF_CONTAINED_RUNGS = (
     "rung52_alveolar_ventilation",
     "rung53_caloric_density",
     "rung54_neutrophil_ratio",
+    "rung55_fresh_gas_volume",
 )
 
 


### PR DESCRIPTION
## ADJ-LADDER rung-55 — anesthesia fresh-gas volume (product of two sums `(a+b)*(c+d)`)

Rung 55 opens a **new clinical panel — anesthesia / fresh-gas delivery** — on the quantitative band, and introduces a
**genuinely new arithmetic shape: product of two sums `(a + b) · (c + d)`** (the classic FOIL — two parenthesised sums
multiplied). Distinct from rung-48's sum-times-difference `(a+b)·(c−d)` and rung-37's ratio-of-two-sums `(a+b)/(c+d)`;
neither multiplied a sum by another sum.

### The panel

Fresh gas comes from two sources (oxygen + air) whose flows add to a combined flow; the case runs through two phases
(induction + maintenance) whose minutes add to the total time. Total gas = combined flow × total time.

| readout | formula | shape |
|---|---|---|
| **total gas** (L) | `(oxygen_flow + air_flow) · (induction_minutes + maintenance_minutes)` | **`(a+b)·(c+d)`** |
| **combined flow** | `oxygen_flow + air_flow` | one sum `a+b` |
| **total time** | `induction_minutes + maintenance_minutes` | the other sum `c+d` |

Each of the three is QUERIED as gold; the two distractors are the classic student slips:

- **sum version** `(oxygen_flow + air_flow) + (induction_minutes + maintenance_minutes)` — ADD the two sums instead of
  multiplying;
- **misgrouped** `(oxygen_flow + air_flow) · induction_minutes + maintenance_minutes` — multiply the flow by only the
  induction minutes, then add maintenance on (`(a+b)·c + d`, not `(a+b)·(c+d)`).

Both distractors also confirm the ADJ engine honours multiplication-over-addition precedence and parenthesised grouping
(the gate matches the engine result to Python's).

7 tables × 3 queried readouts = **21 items**. Gold rotates A–E by `idx % 5`.

### Construction discipline (identical to rungs 47-54)

- Each item is a `compute_dimensioned` program; the ADJ engine carries the arithmetic, including both parenthesised sums
  and their product. **No harness/engine change.**
- **Contamination-safe:** every formula built ONLY from the four observed quantities via `+` and `·` — no structural
  constants, no numeric literal in any program, and neither sum nor the total ever appears as a literal (each is
  computed).
- **Digit-free identifiers** (`oxygen_flow`, `air_flow`, `induction_minutes`, `maintenance_minutes`).
- Family values asserted **pairwise-distinct** (margin `> 1e-6`) at build for every table. Pre-verified with a
  scratchpad distinctness checker before writing the generator.

### Files (3)

- `code/specs/data/adj-ladder/rung55_fresh_gas_volume/gen_items.py` — literate generator.
- `code/specs/data/adj-ladder/rung55_fresh_gas_volume/items.json` — 21 generated items.
- `code/specs/data/adj-ladder/test_ladder_eval.py` — `rung55_fresh_gas_volume` registered in `SELF_CONTAINED_RUNGS`.

Gate: `pytest -k rung55` → 3 passed. Data-only (ADJ items); security review passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
