### PR TITLE
feat(xml-parser): namespace-aware XML parser (OOXML M1)

### DIFF
--- a/code/grammars/xml.grammar
+++ b/code/grammars/xml.grammar
@@ -1,0 +1,101 @@
+# Parser grammar for XML 1.0 (structural subset used by OPC / OOXML)
+# @version 1
+#
+# This grammar describes the *shape* of an XML document as a tree of tokens.
+# It is deliberately structural: it recognises well-formed nesting of tags,
+# attributes, text, comments, CDATA sections, and processing instructions.
+# It does NOT try to enforce that a start tag `<w:p>` is matched by the
+# correct end tag `</w:p>` — a context-free grammar cannot express that
+# ("the two names must be equal" is a context-*sensitive* constraint). That
+# check, along with namespace resolution and entity decoding, is done by the
+# hand-written AST builder in `parser.rs` after this grammar has produced a
+# raw `GrammarASTNode` tree.
+#
+# Format: rule_name = definition ;
+#
+#   UPPERCASE names reference tokens from xml_rust.tokens
+#   lowercase names reference other grammar rules (may be recursive)
+#
+# Notation:
+#   |       alternation (or)
+#   { x }   zero or more repetitions
+#   [ x ]   optional (zero or one)
+#   ( x )   grouping
+#
+# The token stream (produced by the xml-lexer) looks like this for
+# `<w:p class="a">hi</w:p>`:
+#
+#   OPEN_TAG_START("<")  TAG_NAME("w:p")  TAG_NAME("class")  ATTR_EQUALS("=")
+#   ATTR_VALUE("\"a\"")  TAG_CLOSE(">")  TEXT("hi")
+#   CLOSE_TAG_START("</") TAG_NAME("w:p") TAG_CLOSE(">")
+#
+# Note that the lexer emits prefixed names (`w:p`), xmlns declarations
+# (`xmlns:w`), and attribute names all as plain TAG_NAME tokens, and that
+# ATTR_VALUE tokens still carry their surrounding quotes. Splitting prefixes,
+# stripping quotes, and decoding entities are all parser-layer jobs.
+
+# ---------------------------------------------------------------------------
+# document — the top-level entry point.
+#
+# A document is an optional prolog (XML declaration + leading comments /
+# processing instructions), then exactly one root element, then an optional
+# epilogue of trailing comments / processing instructions. Whitespace between
+# these top-level items is skipped by the lexer, so it does not appear here.
+# ---------------------------------------------------------------------------
+document = { misc } element { misc } ;
+
+# misc — the things that may appear before or after the root element: the
+# XML declaration (which is lexed as a processing instruction with target
+# "xml"), ordinary processing instructions, and comments.
+misc = pi | comment ;
+
+# ---------------------------------------------------------------------------
+# element — either a self-closing tag `<x/>` or a start tag / content /
+# end tag triple `<x> ... </x>`.
+#
+# Both alternatives share the same opening: `OPEN_TAG_START TAG_NAME { attribute }`.
+# We list the self-closing form first so the parser commits to SELF_CLOSE
+# when it is present; otherwise it backtracks and takes the TAG_CLOSE branch.
+# ---------------------------------------------------------------------------
+element = empty_element | container_element ;
+
+empty_element = OPEN_TAG_START TAG_NAME { attribute } SELF_CLOSE ;
+
+container_element =
+    OPEN_TAG_START TAG_NAME { attribute } TAG_CLOSE
+    { content }
+    CLOSE_TAG_START TAG_NAME TAG_CLOSE ;
+
+# attribute — a name, then (for XML) a required `= "value"` pair. The lexer
+# reuses the TAG_NAME pattern for attribute names, so `class` and `xmlns:w`
+# both arrive as TAG_NAME tokens.
+attribute = TAG_NAME ATTR_EQUALS ATTR_VALUE ;
+
+# ---------------------------------------------------------------------------
+# content — the sequence of things allowed between a start tag and its
+# matching end tag. Each alternative begins with a distinct token, so the
+# backtracking parser never has to look far ahead:
+#
+#   element     -> OPEN_TAG_START
+#   comment     -> COMMENT_START
+#   cdata       -> CDATA_START
+#   pi          -> PI_START
+#   ENTITY_REF  -> ENTITY_REF     (e.g. &amp;)
+#   CHAR_REF    -> CHAR_REF       (e.g. &#65; or &#x41;)
+#   TEXT        -> TEXT
+# ---------------------------------------------------------------------------
+content = element | comment | cdata | pi | CHAR_REF | ENTITY_REF | TEXT ;
+
+# comment — `<!-- ... -->`. The COMMENT_TEXT is optional so that the empty
+# comment `<!---->` parses.
+comment = COMMENT_START [ COMMENT_TEXT ] COMMENT_END ;
+
+# cdata — `<![CDATA[ ... ]]>`. CDATA_TEXT is optional so an empty section
+# `<![CDATA[]]>` parses. Its contents are verbatim (never entity-decoded).
+cdata = CDATA_START [ CDATA_TEXT ] CDATA_END ;
+
+# pi — a processing instruction `<?target ... ?>`. The XML declaration
+# `<?xml version="1.0"?>` is lexed as a PI with target "xml"; the AST builder
+# recognises that target and lifts version / encoding onto the document
+# rather than storing it as a node. PI_TEXT is optional (`<?target?>`).
+pi = PI_START PI_TARGET [ PI_TEXT ] PI_END ;

--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -344,6 +344,7 @@ members = [
     "vm-type-suggestions",
     "wasm-simulator",
     "xml-lexer",
+    "xml-parser",
     "arm1-gatelevel",
     "arm1-simulator",
     "immutable-list",

--- a/code/packages/rust/xml-parser/BUILD
+++ b/code/packages/rust/xml-parser/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-xml-parser -- --nocapture

--- a/code/packages/rust/xml-parser/BUILD_windows
+++ b/code/packages/rust/xml-parser/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-xml-parser -- --nocapture

--- a/code/packages/rust/xml-parser/CHANGELOG.md
+++ b/code/packages/rust/xml-parser/CHANGELOG.md
@@ -1,0 +1,49 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.1.0] - 2026-07-02
+
+### Added
+
+- Initial release of the XML parser crate (OOXML effort, milestone **M1**).
+- New parser grammar `code/grammars/xml.grammar` (structural nesting rules for
+  documents, elements, attributes, content, comments, CDATA, and processing
+  instructions), compiled to `src/_grammar.rs` via the `grammar-tools` CLI.
+- `parse_xml(source) -> Result<XmlDocument, ParseError>` — the primary entry
+  point, producing a namespace-aware, entity-decoded AST.
+- `create_xml_parser(source) -> GrammarParser` — factory returning the raw
+  generic parser, mirroring the repo's other `*-parser` crates.
+- Typed AST (`XmlDocument`, `XmlElement`, `XmlAttribute`, `XmlNode`,
+  `ParseError`) with navigation helpers `get_child`, `get_children`,
+  `get_attr`, and `text_content`.
+- Namespace resolution via a scope stack: default namespace applies to
+  elements (not unprefixed attributes), inner declarations shadow outer ones,
+  URIs compared case-sensitively, reserved `xml` / `xmlns` prefixes, and an
+  error on unbound prefixes.
+- Entity / character-reference decoding for text and attribute values
+  (`&amp;`, `&lt;`, `&gt;`, `&apos;`, `&quot;`, `&#N;`, `&#xH;`); CDATA left
+  verbatim.
+- XML-declaration handling: `version` / `encoding` are lifted onto the
+  document rather than stored as a processing-instruction node.
+- End-tag / start-tag name matching enforced by the AST builder (a check the
+  context-free grammar cannot express).
+- **Recursion-depth cap (DoS protection).** Both entry points enable the
+  parser's `with_max_depth(DEFAULT_MAX_RULE_DEPTH)` (128). XML nests without
+  bound, so a small crafted document (e.g. thousands of nested tags) would
+  otherwise recurse past the native stack and *abort the process* — an
+  uncatchable stack-overflow DoS directly reachable from `parse_xml` on
+  untrusted OOXML. Over-deep input now returns a normal `ParseError`. Covered
+  by `test_deeply_nested_input_errors_instead_of_overflowing` (20000 levels).
+- 73 unit tests + 1 doc-test covering structure, attributes, namespaces,
+  entities, CDATA, comments, PIs, the XML declaration, whitespace handling,
+  well-formedness errors, the recursion-depth guard, and two OOXML-flavoured
+  integration tests (`[Content_Types].xml` and `.rels`).
+
+### Known limitations
+
+- No DTD support (only the five predefined named entities) — matches the XML
+  subset OOXML/OPC uses.
+- Whitespace immediately following an entity reference in mixed text is
+  dropped by the underlying `xml-lexer` (a lexer-layer behavior, documented in
+  the spec and README); it does not affect element-structured OPC part files.

--- a/code/packages/rust/xml-parser/Cargo.toml
+++ b/code/packages/rust/xml-parser/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "coding-adventures-xml-parser"
+version = "0.1.0"
+edition = "2021"
+description = "XML parser — parses XML source text into a namespace-aware AST using the grammar-driven parser and the xml.grammar file, with entity decoding and XML-declaration extraction (OOXML/OPC milestone M1)"
+
+[dependencies]
+grammar-tools = { path = "../grammar-tools" }
+lexer = { path = "../lexer" }
+parser = { path = "../parser" }
+coding-adventures-xml-lexer = { path = "../xml-lexer" }

--- a/code/packages/rust/xml-parser/README.md
+++ b/code/packages/rust/xml-parser/README.md
@@ -1,0 +1,123 @@
+# XML Parser
+
+A grammar-driven, **namespace-aware** parser for XML that produces a typed
+Abstract Syntax Tree (AST). This is milestone **M1** of the OOXML effort: its
+AST is designed to be consumed by an OPC (Open Packaging Conventions) package
+reader that walks `[Content_Types].xml` and `.rels` files inside `.docx` /
+`.xlsx` / `.pptx` packages.
+
+See the spec: [`code/specs/XML01-xml-parser.md`](../../../specs/XML01-xml-parser.md).
+
+## What it does
+
+It parses XML source text into an [`XmlDocument`] whose elements carry
+**resolved** namespace names (a `(namespace_uri, local_name)` pair rather than
+a raw `prefix:local`), whose text is **entity-decoded**, and whose XML
+declaration's `version` / `encoding` are lifted onto the document.
+
+## How it fits in the stack
+
+```text
+Source text  ("<w:p xmlns:w=\"...\">hi</w:p>")
+      |
+      v
+xml-lexer            → Vec<Token>            (grammar-driven tokenizer)
+      |
+      v
+xml.grammar          → ParserGrammar         (structural nesting rules)
+      |
+      v
+parser::GrammarParser → GrammarASTNode tree  (generic rule/token tree)
+      |
+      v
+xml-parser (this)    → XmlDocument            (namespaces + entities + typing)
+```
+
+The lexer and grammar do the *structural* work. Everything a context-free
+grammar can't express — matching end-tag names to start tags, binding
+namespace prefixes to URIs, and decoding entity references — lives in this
+crate's `builder` and `namespace` modules.
+
+## Grammar rules
+
+```ebnf
+document          = { misc } element { misc } ;
+misc              = pi | comment ;
+element           = empty_element | container_element ;
+empty_element     = OPEN_TAG_START TAG_NAME { attribute } SELF_CLOSE ;
+container_element = OPEN_TAG_START TAG_NAME { attribute } TAG_CLOSE
+                    { content }
+                    CLOSE_TAG_START TAG_NAME TAG_CLOSE ;
+attribute         = TAG_NAME ATTR_EQUALS ATTR_VALUE ;
+content           = element | comment | cdata | pi | CHAR_REF | ENTITY_REF | TEXT ;
+comment           = COMMENT_START [ COMMENT_TEXT ] COMMENT_END ;
+cdata             = CDATA_START [ CDATA_TEXT ] CDATA_END ;
+pi                = PI_START PI_TARGET [ PI_TEXT ] PI_END ;
+```
+
+The grammar lives at `code/grammars/xml.grammar`; the compiled
+`src/_grammar.rs` is generated from it by the `grammar-tools` CLI.
+
+## Usage
+
+```rust
+use coding_adventures_xml_parser::parse_xml;
+
+let doc = parse_xml(r#"<note lang="en"><to>Alice</to></note>"#).unwrap();
+assert_eq!(doc.root.local_name, "note");
+assert_eq!(doc.root.get_attr(None, "lang"), Some("en"));
+
+let to = doc.root.get_child(None, "to").unwrap();
+assert_eq!(to.text_content(), "Alice");
+```
+
+An OOXML-flavoured example (`[Content_Types].xml`):
+
+```rust
+use coding_adventures_xml_parser::parse_xml;
+
+const CT: &str = "http://schemas.openxmlformats.org/package/2006/content-types";
+
+let src = r#"<?xml version="1.0" encoding="UTF-8"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/...relationships+xml"/>
+  <Override PartName="/word/document.xml" ContentType="application/...main+xml"/>
+</Types>"#;
+
+let doc = parse_xml(src).unwrap();
+assert_eq!(doc.version.as_deref(), Some("1.0"));
+
+// Elements inherit the default namespace...
+let over = doc.root.get_child(Some(CT), "Override").unwrap();
+// ...but unprefixed attributes are in NO namespace.
+assert_eq!(over.get_attr(None, "PartName"), Some("/word/document.xml"));
+```
+
+## Namespace rules to remember
+
+- The **default namespace** (`xmlns="…"`) applies to unprefixed **elements**,
+  but **not** to unprefixed **attributes** (those are always namespace-free).
+- Namespace **URIs are case-sensitive**.
+- `xml` and `xmlns` are reserved, always-bound prefixes.
+- An unbound prefix is a parse error.
+
+## Entity decoding
+
+`&amp; &lt; &gt; &apos; &quot;` and numeric references `&#N;` (decimal) /
+`&#xH;` (hex) are decoded in text and attribute values. **CDATA is verbatim**
+— never decoded. There is no DTD support, so no custom named entities exist
+(this matches the XML subset OOXML uses).
+
+## Known limitation (lexer-inherited)
+
+The `xml-lexer` skips whitespace *between* tokens in the default group, so a
+space immediately following an entity reference in mixed text (the space in
+`a &amp; b`) is consumed before the next `TEXT` token and does not reach the
+parser. Whitespace inside a single text run (`a  b`) is preserved. OPC part
+files are element-structured, so this does not affect the M1 goal.
+
+## Running tests
+
+```bash
+cargo test -p coding-adventures-xml-parser -- --nocapture
+```

--- a/code/packages/rust/xml-parser/required_capabilities.json
+++ b/code/packages/rust/xml-parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/xml-parser",
+  "capabilities": [],
+  "justification": "Pure computation. Parses an in-memory XML string into an AST. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/rust/xml-parser/src/_grammar.rs
+++ b/code/packages/rust/xml-parser/src/_grammar.rs
@@ -1,0 +1,115 @@
+// AUTO-GENERATED FILE — DO NOT EDIT
+// Source: xml.grammar
+// Regenerate with: grammar-tools compile-grammar xml.grammar
+//
+// This file embeds a ParserGrammar as native Rust data structures.
+// Call `parser_grammar()` instead of reading and parsing the .grammar file.
+
+use grammar_tools::parser_grammar::{GrammarElement, GrammarRule, ParserGrammar};
+
+pub fn parser_grammar() -> ParserGrammar {
+    ParserGrammar {
+        rules: vec![
+        GrammarRule {
+            name: r#"document"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"misc"#.to_string() }) },
+                GrammarElement::RuleReference { name: r#"element"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"misc"#.to_string() }) },
+            ] },
+            line_number: 45,
+        },
+        GrammarRule {
+            name: r#"misc"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::RuleReference { name: r#"pi"#.to_string() },
+                GrammarElement::RuleReference { name: r#"comment"#.to_string() },
+            ] },
+            line_number: 50,
+        },
+        GrammarRule {
+            name: r#"element"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::RuleReference { name: r#"empty_element"#.to_string() },
+                GrammarElement::RuleReference { name: r#"container_element"#.to_string() },
+            ] },
+            line_number: 60,
+        },
+        GrammarRule {
+            name: r#"empty_element"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"OPEN_TAG_START"#.to_string() },
+                GrammarElement::TokenReference { name: r#"TAG_NAME"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"attribute"#.to_string() }) },
+                GrammarElement::TokenReference { name: r#"SELF_CLOSE"#.to_string() },
+            ] },
+            line_number: 62,
+        },
+        GrammarRule {
+            name: r#"container_element"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"OPEN_TAG_START"#.to_string() },
+                GrammarElement::TokenReference { name: r#"TAG_NAME"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"attribute"#.to_string() }) },
+                GrammarElement::TokenReference { name: r#"TAG_CLOSE"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"content"#.to_string() }) },
+                GrammarElement::TokenReference { name: r#"CLOSE_TAG_START"#.to_string() },
+                GrammarElement::TokenReference { name: r#"TAG_NAME"#.to_string() },
+                GrammarElement::TokenReference { name: r#"TAG_CLOSE"#.to_string() },
+            ] },
+            line_number: 64,
+        },
+        GrammarRule {
+            name: r#"attribute"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"TAG_NAME"#.to_string() },
+                GrammarElement::TokenReference { name: r#"ATTR_EQUALS"#.to_string() },
+                GrammarElement::TokenReference { name: r#"ATTR_VALUE"#.to_string() },
+            ] },
+            line_number: 72,
+        },
+        GrammarRule {
+            name: r#"content"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::RuleReference { name: r#"element"#.to_string() },
+                GrammarElement::RuleReference { name: r#"comment"#.to_string() },
+                GrammarElement::RuleReference { name: r#"cdata"#.to_string() },
+                GrammarElement::RuleReference { name: r#"pi"#.to_string() },
+                GrammarElement::TokenReference { name: r#"CHAR_REF"#.to_string() },
+                GrammarElement::TokenReference { name: r#"ENTITY_REF"#.to_string() },
+                GrammarElement::TokenReference { name: r#"TEXT"#.to_string() },
+            ] },
+            line_number: 87,
+        },
+        GrammarRule {
+            name: r#"comment"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"COMMENT_START"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::TokenReference { name: r#"COMMENT_TEXT"#.to_string() }) },
+                GrammarElement::TokenReference { name: r#"COMMENT_END"#.to_string() },
+            ] },
+            line_number: 91,
+        },
+        GrammarRule {
+            name: r#"cdata"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"CDATA_START"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::TokenReference { name: r#"CDATA_TEXT"#.to_string() }) },
+                GrammarElement::TokenReference { name: r#"CDATA_END"#.to_string() },
+            ] },
+            line_number: 95,
+        },
+        GrammarRule {
+            name: r#"pi"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"PI_START"#.to_string() },
+                GrammarElement::TokenReference { name: r#"PI_TARGET"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::TokenReference { name: r#"PI_TEXT"#.to_string() }) },
+                GrammarElement::TokenReference { name: r#"PI_END"#.to_string() },
+            ] },
+            line_number: 101,
+        },
+    ],
+        version: 1,
+    }
+}

--- a/code/packages/rust/xml-parser/src/ast.rs
+++ b/code/packages/rust/xml-parser/src/ast.rs
@@ -1,0 +1,228 @@
+//! The XML Abstract Syntax Tree (AST).
+//!
+//! This module defines the *shape* of a parsed XML document — the data
+//! structures that the rest of the crate builds and that downstream consumers
+//! (an OPC package reader, in the OOXML effort) walk.
+//!
+//! # A quick tour of XML for a newcomer
+//!
+//! An XML document is a tree of **elements**. An element has a *name*, a bag
+//! of *attributes*, and a list of *children*. The children can be more
+//! elements, plain text, comments, and a few other things. Here is a tiny
+//! document:
+//!
+//! ```xml
+//! <note lang="en">
+//!   <to>Alice</to>
+//!   <body>Hi &amp; welcome</body>
+//! </note>
+//! ```
+//!
+//! - `note` is the **root element**. It has one attribute, `lang="en"`.
+//! - `to` and `body` are **child elements** of `note`.
+//! - `Alice` and `Hi & welcome` are **text**. (`&amp;` is an *entity
+//!   reference* that stands for the literal `&`; the parser decodes it.)
+//!
+//! # Namespaces — why a name is really two things
+//!
+//! XML lets documents from different vocabularies mix without their names
+//! colliding. A **namespace** is a URI (just an opaque identifier — it need
+//! not resolve to anything on the web) that scopes a set of names. In OOXML a
+//! Word document element looks like `<w:p>`, where `w` is a short *prefix*
+//! bound to the long namespace URI
+//! `http://schemas.openxmlformats.org/wordprocessingml/2006/main`.
+//!
+//! Because prefixes are just local shorthands (the same document could bind
+//! `w` to something else, or use a different prefix for the same URI), a
+//! *resolved* name is the pair `(namespace_uri, local_name)`. That is exactly
+//! what [`XmlElement`] and [`XmlAttribute`] store: the prefix is thrown away
+//! once resolved, and code compares against the stable URI. URIs are
+//! **case-sensitive**.
+
+// ===========================================================================
+// XmlDocument
+// ===========================================================================
+
+/// A whole parsed XML document.
+///
+/// The XML declaration `<?xml version="1.0" encoding="UTF-8"?>` is not stored
+/// as a node in the tree — instead its `version` and `encoding` pseudo-
+/// attributes are lifted onto this struct. Everything else in a well-formed
+/// document hangs off the single [`root`](XmlDocument::root) element.
+#[derive(Debug, Clone, PartialEq)]
+pub struct XmlDocument {
+    /// The single root element (XML documents have exactly one).
+    pub root: XmlElement,
+    /// The `version` from the XML declaration, if one was present.
+    pub version: Option<String>,
+    /// The `encoding` from the XML declaration, if one was present.
+    pub encoding: Option<String>,
+}
+
+// ===========================================================================
+// XmlElement
+// ===========================================================================
+
+/// A single XML element: a resolved name, its attributes, and its children.
+#[derive(Debug, Clone, PartialEq)]
+pub struct XmlElement {
+    /// The resolved namespace URI, or `None` if the element is in no
+    /// namespace. Resolution follows the prefix / default-namespace rules
+    /// described on this module.
+    pub namespace_uri: Option<String>,
+    /// The local part of the element's name (the part after the `prefix:`).
+    /// For `<w:p>` this is `"p"`; for `<note>` it is `"note"`.
+    pub local_name: String,
+    /// The element's attributes, in document order.
+    pub attributes: Vec<XmlAttribute>,
+    /// The element's children, in document order.
+    pub children: Vec<XmlNode>,
+}
+
+impl XmlElement {
+    /// Find the first *direct child element* matching a resolved name.
+    ///
+    /// `uri` is the namespace to match: pass `Some("...")` to require a
+    /// specific namespace, or `None` to require that the child is in *no*
+    /// namespace. `local` is the local name.
+    ///
+    /// Only direct children are searched (not grandchildren), which is what a
+    /// package reader wants when walking a known document shape.
+    pub fn get_child(&self, uri: Option<&str>, local: &str) -> Option<&XmlElement> {
+        self.child_elements()
+            .find(|e| e.namespace_uri.as_deref() == uri && e.local_name == local)
+    }
+
+    /// Like [`get_child`](XmlElement::get_child) but returns *every* matching
+    /// direct child element, in document order. Handy for repeated elements
+    /// such as `<Default>` / `<Override>` entries in `[Content_Types].xml`.
+    pub fn get_children(&self, uri: Option<&str>, local: &str) -> Vec<&XmlElement> {
+        self.child_elements()
+            .filter(|e| e.namespace_uri.as_deref() == uri && e.local_name == local)
+            .collect()
+    }
+
+    /// Look up an attribute value by resolved name, returning the (already
+    /// entity-decoded) value if present.
+    ///
+    /// Remember the asymmetry: an unprefixed attribute is in *no* namespace
+    /// even when the element sits inside a default namespace, so most OPC
+    /// attributes are looked up with `uri = None`.
+    pub fn get_attr(&self, uri: Option<&str>, local: &str) -> Option<&str> {
+        self.attributes
+            .iter()
+            .find(|a| a.namespace_uri.as_deref() == uri && a.local_name == local)
+            .map(|a| a.value.as_str())
+    }
+
+    /// Concatenate all descendant text — the element's text nodes and CDATA
+    /// sections, plus those of every nested element, in document order.
+    ///
+    /// This is the XML "string value" of an element. Comments and processing
+    /// instructions contribute nothing.
+    pub fn text_content(&self) -> String {
+        let mut out = String::new();
+        self.collect_text(&mut out);
+        out
+    }
+
+    fn collect_text(&self, out: &mut String) {
+        for child in &self.children {
+            match child {
+                XmlNode::Text(t) | XmlNode::CData(t) => out.push_str(t),
+                XmlNode::Element(e) => e.collect_text(out),
+                XmlNode::Comment(_) | XmlNode::ProcessingInstruction { .. } => {}
+            }
+        }
+    }
+
+    /// Iterator over just the child *elements* (skipping text, comments, etc.).
+    fn child_elements(&self) -> impl Iterator<Item = &XmlElement> {
+        self.children.iter().filter_map(|c| match c {
+            XmlNode::Element(e) => Some(e.as_ref()),
+            _ => None,
+        })
+    }
+}
+
+// ===========================================================================
+// XmlAttribute
+// ===========================================================================
+
+/// A resolved attribute: name pair plus its decoded value.
+#[derive(Debug, Clone, PartialEq)]
+pub struct XmlAttribute {
+    /// The resolved namespace URI, or `None`. Note that `xmlns` and
+    /// `xmlns:prefix` declarations are *consumed* during parsing and never
+    /// appear here as attributes.
+    pub namespace_uri: Option<String>,
+    /// The local part of the attribute name.
+    pub local_name: String,
+    /// The attribute value, with surrounding quotes stripped and entity /
+    /// character references decoded.
+    pub value: String,
+}
+
+// ===========================================================================
+// XmlNode
+// ===========================================================================
+
+/// One child in an element's content list.
+///
+/// An element's children are heterogeneous — text and elements can interleave
+/// ("mixed content"), and comments / CDATA / processing instructions can
+/// appear too — so a single enum captures all the possibilities.
+#[derive(Debug, Clone, PartialEq)]
+pub enum XmlNode {
+    /// A nested element. Boxed because [`XmlElement`] contains a `Vec` of
+    /// these, so without the indirection the type would be infinitely sized.
+    Element(Box<XmlElement>),
+    /// A run of character data, with entity / character references already
+    /// decoded.
+    Text(String),
+    /// The verbatim contents of a `<![CDATA[ ... ]]>` section. CDATA is *not*
+    /// entity-decoded — its whole point is to hold text like `<` and `&`
+    /// literally.
+    CData(String),
+    /// A `<!-- ... -->` comment's text (without the delimiters).
+    Comment(String),
+    /// A processing instruction `<?target text?>` (other than the XML
+    /// declaration, which is lifted onto [`XmlDocument`]).
+    ProcessingInstruction {
+        /// The PI target (the name right after `<?`).
+        target: String,
+        /// The rest of the PI, verbatim (may be empty).
+        text: String,
+    },
+}
+
+// ===========================================================================
+// ParseError
+// ===========================================================================
+
+/// A failure to parse XML source into an [`XmlDocument`].
+///
+/// Carries an optional 1-based line / column so callers can point at the
+/// offending spot. Some errors (e.g. a lexer-level failure) may not have a
+/// precise position, hence the `Option`s.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ParseError {
+    /// A human-readable description of what went wrong.
+    pub message: String,
+    /// The 1-based line where the problem was detected, if known.
+    pub line: Option<usize>,
+    /// The 1-based column where the problem was detected, if known.
+    pub column: Option<usize>,
+}
+
+impl std::fmt::Display for ParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match (self.line, self.column) {
+            (Some(l), Some(c)) => write!(f, "{} (line {}, column {})", self.message, l, c),
+            (Some(l), None) => write!(f, "{} (line {})", self.message, l),
+            _ => write!(f, "{}", self.message),
+        }
+    }
+}
+
+impl std::error::Error for ParseError {}

--- a/code/packages/rust/xml-parser/src/builder.rs
+++ b/code/packages/rust/xml-parser/src/builder.rs
@@ -1,0 +1,567 @@
+//! The AST builder: turn a raw `GrammarASTNode` tree into an [`XmlDocument`].
+//!
+//! `xml.grammar` only tells the [`GrammarParser`] how tokens may nest; it
+//! produces a generic tree keyed by rule names (`"document"`, `"element"`,
+//! `"attribute"`, …). This module walks that generic tree once and builds the
+//! typed, namespace-resolved [`XmlDocument`], doing the three jobs the grammar
+//! cannot:
+//!
+//! 1. **Well-formedness beyond nesting** — checking that each end tag names
+//!    the same element as its start tag (a context-sensitive constraint).
+//! 2. **Namespace resolution** — binding prefixes to URIs via a scope stack.
+//! 3. **Entity decoding** — turning `&amp;`, `&#65;`, etc. into real text.
+//!
+//! # How to read the generic tree
+//!
+//! The `parser` crate flattens token matches and repetitions into a node's
+//! `children` list, but wraps each *rule* reference in its own `Node`. So a
+//! `container_element` node's children are, in order:
+//!
+//! ```text
+//! Token(OPEN_TAG_START) Token(TAG_NAME) Node(attribute)* Token(TAG_CLOSE)
+//! Node(content)* Token(CLOSE_TAG_START) Token(TAG_NAME) Token(TAG_CLOSE)
+//! ```
+//!
+//! We navigate by walking those children and dispatching on token type name
+//! or child rule name.
+
+use std::collections::HashMap;
+
+use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode};
+
+use crate::ast::{ParseError, XmlAttribute, XmlDocument, XmlElement, XmlNode};
+use crate::namespace::{decode_entities, split_qname, NamespaceStack};
+
+// ===========================================================================
+// Small helpers over the generic tree
+// ===========================================================================
+
+/// Return the raw source text of a leaf token child, or `None` if this child
+/// is a sub-node rather than a token.
+fn token_value(child: &ASTNodeOrToken) -> Option<&str> {
+    match child {
+        ASTNodeOrToken::Token(t) => Some(t.value.as_str()),
+        ASTNodeOrToken::Node(_) => None,
+    }
+}
+
+/// Return the grammar token-type name of a leaf token child (e.g. "TAG_NAME"),
+/// or `None` if this child is a sub-node.
+fn token_type(child: &ASTNodeOrToken) -> Option<&str> {
+    match child {
+        ASTNodeOrToken::Token(t) => Some(t.effective_type_name()),
+        ASTNodeOrToken::Node(_) => None,
+    }
+}
+
+/// Position (line, column) of the first token under a node, for error
+/// reporting. Falls back to the node's recorded start position.
+fn node_position(node: &GrammarASTNode) -> (Option<usize>, Option<usize>) {
+    (node.start_line, node.start_column)
+}
+
+// ===========================================================================
+// Entry point
+// ===========================================================================
+
+/// Build an [`XmlDocument`] from the root `document` grammar node.
+pub fn build_document(root: &GrammarASTNode) -> Result<XmlDocument, ParseError> {
+    // The `document` rule is: { misc } element { misc }. Its children are a
+    // flat list of `Node(misc)` and one `Node(element)`. We scan for the XML
+    // declaration among the leading misc items and for the single element.
+    let mut version = None;
+    let mut encoding = None;
+    let mut root_element: Option<XmlElement> = None;
+
+    for child in &root.children {
+        let node = match child {
+            ASTNodeOrToken::Node(n) => n,
+            ASTNodeOrToken::Token(_) => continue,
+        };
+        match node.rule_name.as_str() {
+            "misc" => {
+                // misc wraps a single pi or comment. Only a `<?xml ...?>` PI
+                // carries the version/encoding we care about at this level.
+                if let Some(inner) = first_child_node(node) {
+                    if inner.rule_name == "pi" {
+                        if let Some((target, text)) = read_pi(inner) {
+                            if target == "xml" {
+                                let (v, e) = parse_xml_declaration(&text);
+                                version = v;
+                                encoding = e;
+                            }
+                        }
+                    }
+                }
+            }
+            "element" => {
+                let mut ns = NamespaceStack::new();
+                root_element = Some(build_element(node, &mut ns)?);
+            }
+            _ => {}
+        }
+    }
+
+    let root = root_element.ok_or_else(|| ParseError {
+        message: "document has no root element".to_string(),
+        line: None,
+        column: None,
+    })?;
+
+    Ok(XmlDocument {
+        root,
+        version,
+        encoding,
+    })
+}
+
+/// Return the first child that is a sub-node (skipping leaf tokens).
+fn first_child_node(node: &GrammarASTNode) -> Option<&GrammarASTNode> {
+    node.children.iter().find_map(|c| match c {
+        ASTNodeOrToken::Node(n) => Some(n),
+        ASTNodeOrToken::Token(_) => None,
+    })
+}
+
+// ===========================================================================
+// Elements
+// ===========================================================================
+
+/// Build an [`XmlElement`] from an `element` node (which wraps either an
+/// `empty_element` or a `container_element`).
+fn build_element(
+    element_node: &GrammarASTNode,
+    ns: &mut NamespaceStack,
+) -> Result<XmlElement, ParseError> {
+    let inner = first_child_node(element_node).ok_or_else(|| ParseError {
+        message: "malformed element node".to_string(),
+        line: element_node.start_line,
+        column: element_node.start_column,
+    })?;
+
+    match inner.rule_name.as_str() {
+        "empty_element" => build_start_tag(inner, &[], ns),
+        "container_element" => build_container(inner, ns),
+        other => Err(ParseError {
+            message: format!("unexpected element kind '{other}'"),
+            line: inner.start_line,
+            column: inner.start_column,
+        }),
+    }
+}
+
+/// Build a container element: start tag, content children, and the matching
+/// end tag (whose name we verify against the start tag).
+fn build_container(
+    node: &GrammarASTNode,
+    ns: &mut NamespaceStack,
+) -> Result<XmlElement, ParseError> {
+    // Split the children at TAG_CLOSE: everything before is the start tag
+    // (name + attributes); everything after, up to CLOSE_TAG_START, is
+    // content; then CLOSE_TAG_START TAG_NAME TAG_CLOSE.
+    let children = &node.children;
+
+    // Find the index of the first TAG_CLOSE (end of the start tag).
+    let start_tag_close = children
+        .iter()
+        .position(|c| token_type(c) == Some("TAG_CLOSE"))
+        .ok_or_else(|| ParseError {
+            message: "start tag missing '>'".to_string(),
+            line: node.start_line,
+            column: node.start_column,
+        })?;
+
+    // Find CLOSE_TAG_START (start of the end tag).
+    let close_start = children
+        .iter()
+        .position(|c| token_type(c) == Some("CLOSE_TAG_START"))
+        .ok_or_else(|| ParseError {
+            message: "element missing closing tag".to_string(),
+            line: node.start_line,
+            column: node.start_column,
+        })?;
+
+    // --- Start tag: children[0..=start_tag_close] ---
+    let start_slice = &children[..start_tag_close];
+    let content_slice = &children[start_tag_close + 1..close_start];
+
+    // The end tag name is the TAG_NAME between CLOSE_TAG_START and its
+    // TAG_CLOSE.
+    let end_name = children[close_start + 1..]
+        .iter()
+        .find_map(|c| {
+            if token_type(c) == Some("TAG_NAME") {
+                token_value(c)
+            } else {
+                None
+            }
+        })
+        .ok_or_else(|| ParseError {
+            message: "closing tag missing name".to_string(),
+            line: node.start_line,
+            column: node.start_column,
+        })?;
+
+    // Build the element from its start tag (this pushes a namespace scope).
+    let start_name = start_slice
+        .iter()
+        .find_map(|c| {
+            if token_type(c) == Some("TAG_NAME") {
+                token_value(c)
+            } else {
+                None
+            }
+        })
+        .ok_or_else(|| ParseError {
+            message: "start tag missing name".to_string(),
+            line: node.start_line,
+            column: node.start_column,
+        })?
+        .to_string();
+
+    // Well-formedness: start and end names must be the *raw* qualified names
+    // matched literally (XML matches on the qname text, prefix included).
+    if start_name != end_name {
+        let (l, c) = node_position(node);
+        return Err(ParseError {
+            message: format!(
+                "mismatched tags: <{start_name}> closed by </{end_name}>"
+            ),
+            line: l,
+            column: c,
+        });
+    }
+
+    build_start_tag(node, content_slice, ns)
+}
+
+/// Build an element from a node whose children begin with the start tag
+/// (`OPEN_TAG_START TAG_NAME attribute*`), with `content_children` supplying
+/// the already-sliced content nodes (empty for a self-closing element).
+///
+/// This function owns the namespace scope lifecycle: it collects this tag's
+/// `xmlns` declarations, pushes a scope, resolves names and builds children,
+/// then pops.
+fn build_start_tag(
+    node: &GrammarASTNode,
+    content_children: &[ASTNodeOrToken],
+    ns: &mut NamespaceStack,
+) -> Result<XmlElement, ParseError> {
+    // Collect the raw (qname, raw_value) attribute pairs and the element's
+    // own qualified name.
+    let mut raw_attributes: Vec<(String, String)> = Vec::new();
+    let mut element_qname: Option<String> = None;
+    let mut seen_tag_name = false;
+
+    for child in &node.children {
+        // Stop scanning the start tag once we reach its closing token: for a
+        // container the first TAG_CLOSE ends the start tag; for an empty
+        // element SELF_CLOSE ends it.
+        match token_type(child) {
+            Some("TAG_CLOSE") | Some("SELF_CLOSE") => break,
+            Some("TAG_NAME") if !seen_tag_name => {
+                element_qname = token_value(child).map(|s| s.to_string());
+                seen_tag_name = true;
+                continue;
+            }
+            _ => {}
+        }
+        if let ASTNodeOrToken::Node(attr) = child {
+            if attr.rule_name == "attribute" {
+                let (name, value) = read_attribute(attr)?;
+                raw_attributes.push((name, value));
+            }
+        }
+    }
+
+    let element_qname = element_qname.ok_or_else(|| ParseError {
+        message: "element has no name".to_string(),
+        line: node.start_line,
+        column: node.start_column,
+    })?;
+
+    // --- Namespace declarations from this tag's attributes ---
+    let mut declarations: HashMap<String, String> = HashMap::new();
+    let mut normal_attrs: Vec<(String, String)> = Vec::new();
+    for (qname, raw_value) in raw_attributes {
+        let decoded = decode_entities(strip_quotes(&raw_value))?;
+        if qname == "xmlns" {
+            // Default-namespace declaration; key "" in the scope map.
+            declarations.insert(String::new(), decoded);
+        } else if let Some(prefix) = qname.strip_prefix("xmlns:") {
+            if prefix.is_empty() {
+                return Err(ParseError {
+                    message: "malformed namespace declaration 'xmlns:'".to_string(),
+                    line: node.start_line,
+                    column: node.start_column,
+                });
+            }
+            declarations.insert(prefix.to_string(), decoded);
+        } else {
+            normal_attrs.push((qname, decoded));
+        }
+    }
+
+    ns.push(declarations);
+
+    // --- Resolve the element name ---
+    let (prefix, local) = split_qname(&element_qname)?;
+    let namespace_uri = ns.resolve_prefix(prefix)?;
+
+    // --- Resolve attribute names ---
+    // Per the XML Namespaces spec, an *unprefixed* attribute is in no
+    // namespace even when a default namespace is in scope. Only prefixed
+    // attributes get a namespace URI.
+    let mut attributes = Vec::with_capacity(normal_attrs.len());
+    for (qname, value) in normal_attrs {
+        let (aprefix, alocal) = split_qname(&qname)?;
+        let auri = if aprefix.is_empty() {
+            None
+        } else {
+            ns.resolve_prefix(aprefix)?
+        };
+        attributes.push(XmlAttribute {
+            namespace_uri: auri,
+            local_name: alocal.to_string(),
+            value,
+        });
+    }
+
+    // --- Build children ---
+    // Build children, then pop the scope *whether or not* child building
+    // failed, and only then propagate any error. This keeps the scope stack
+    // balanced even on the error path.
+    let result = build_children(content_children, ns);
+    ns.pop();
+    let children = result?;
+
+    Ok(XmlElement {
+        namespace_uri,
+        local_name: local.to_string(),
+        attributes,
+        children,
+    })
+}
+
+/// Build the list of child nodes for an element from its `content` slice.
+fn build_children(
+    content_children: &[ASTNodeOrToken],
+    ns: &mut NamespaceStack,
+) -> Result<Vec<XmlNode>, ParseError> {
+    let mut out = Vec::new();
+    for child in content_children {
+        // Each content item is a `Node(content)` wrapping one thing.
+        let content = match child {
+            ASTNodeOrToken::Node(n) if n.rule_name == "content" => n,
+            _ => continue,
+        };
+        // The content node has exactly one child: a sub-node (element,
+        // comment, cdata, pi) or a leaf token (TEXT, CHAR_REF, ENTITY_REF).
+        let inner = match content.children.first() {
+            Some(c) => c,
+            None => continue,
+        };
+        match inner {
+            ASTNodeOrToken::Node(n) => match n.rule_name.as_str() {
+                "element" => {
+                    let el = build_element(n, ns)?;
+                    out.push(XmlNode::Element(Box::new(el)));
+                }
+                "comment" => out.push(XmlNode::Comment(read_comment(n))),
+                "cdata" => out.push(XmlNode::CData(read_cdata(n))),
+                "pi" => {
+                    if let Some((target, text)) = read_pi(n) {
+                        out.push(XmlNode::ProcessingInstruction { target, text });
+                    }
+                }
+                _ => {}
+            },
+            ASTNodeOrToken::Token(t) => match t.effective_type_name() {
+                "TEXT" | "ENTITY_REF" | "CHAR_REF" => {
+                    let decoded = decode_entities(&t.value)?;
+                    // Merge with a preceding text node so `a&amp;b` yields one
+                    // "a&b" node rather than three fragments.
+                    if let Some(XmlNode::Text(prev)) = out.last_mut() {
+                        prev.push_str(&decoded);
+                    } else {
+                        out.push(XmlNode::Text(decoded));
+                    }
+                }
+                _ => {}
+            },
+        }
+    }
+    Ok(out)
+}
+
+// ===========================================================================
+// Leaf readers
+// ===========================================================================
+
+/// Read an `attribute` node into a `(qname, raw_value_with_quotes)` pair.
+fn read_attribute(node: &GrammarASTNode) -> Result<(String, String), ParseError> {
+    let mut name = None;
+    let mut value = None;
+    for child in &node.children {
+        match token_type(child) {
+            Some("TAG_NAME") => name = token_value(child).map(str::to_string),
+            Some("ATTR_VALUE") => value = token_value(child).map(str::to_string),
+            _ => {}
+        }
+    }
+    match (name, value) {
+        (Some(n), Some(v)) => Ok((n, v)),
+        _ => Err(ParseError {
+            message: "malformed attribute".to_string(),
+            line: node.start_line,
+            column: node.start_column,
+        }),
+    }
+}
+
+/// Read a `comment` node's text (empty for `<!---->`).
+fn read_comment(node: &GrammarASTNode) -> String {
+    node.children
+        .iter()
+        .find_map(|c| {
+            if token_type(c) == Some("COMMENT_TEXT") {
+                token_value(c).map(str::to_string)
+            } else {
+                None
+            }
+        })
+        .unwrap_or_default()
+}
+
+/// Read a `cdata` node's verbatim text (empty for `<![CDATA[]]>`).
+fn read_cdata(node: &GrammarASTNode) -> String {
+    node.children
+        .iter()
+        .find_map(|c| {
+            if token_type(c) == Some("CDATA_TEXT") {
+                token_value(c).map(str::to_string)
+            } else {
+                None
+            }
+        })
+        .unwrap_or_default()
+}
+
+/// Read a `pi` node into `(target, text)`. The text is verbatim, with any
+/// single leading space (which the lexer includes) trimmed for convenience.
+fn read_pi(node: &GrammarASTNode) -> Option<(String, String)> {
+    let mut target = None;
+    let mut text = String::new();
+    for child in &node.children {
+        match token_type(child) {
+            Some("PI_TARGET") => target = token_value(child).map(str::to_string),
+            Some("PI_TEXT") => {
+                text = token_value(child).unwrap_or("").to_string();
+            }
+            _ => {}
+        }
+    }
+    target.map(|t| (t, text.trim_start().to_string()))
+}
+
+// ===========================================================================
+// Small string utilities
+// ===========================================================================
+
+/// Strip one matching pair of surrounding quotes from a raw ATTR_VALUE.
+/// The lexer guarantees the value starts and ends with the same quote char,
+/// but we defensively handle the degenerate case.
+fn strip_quotes(raw: &str) -> &str {
+    let bytes = raw.as_bytes();
+    if bytes.len() >= 2 {
+        let first = bytes[0];
+        let last = bytes[bytes.len() - 1];
+        if (first == b'"' || first == b'\'') && first == last {
+            return &raw[1..raw.len() - 1];
+        }
+    }
+    raw
+}
+
+/// Parse the pseudo-attributes of an XML declaration's text
+/// (`version="1.0" encoding="UTF-8"`) into `(version, encoding)`.
+///
+/// This is a tiny purpose-built scanner: the XML declaration is *not* an
+/// element and its "attributes" are only these fixed pseudo-attributes, so a
+/// full attribute parse is unnecessary.
+fn parse_xml_declaration(text: &str) -> (Option<String>, Option<String>) {
+    (
+        pseudo_attr(text, "version"),
+        pseudo_attr(text, "encoding"),
+    )
+}
+
+/// Extract `name="value"` (or single-quoted) from a declaration fragment.
+fn pseudo_attr(text: &str, name: &str) -> Option<String> {
+    let idx = text.find(name)?;
+    let after = &text[idx + name.len()..];
+    let after = after.trim_start();
+    let after = after.strip_prefix('=')?.trim_start();
+    let quote = after.chars().next()?;
+    if quote != '"' && quote != '\'' {
+        return None;
+    }
+    let rest = &after[1..];
+    let end = rest.find(quote)?;
+    Some(rest[..end].to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strip_quotes_double() {
+        assert_eq!(strip_quotes("\"hi\""), "hi");
+    }
+
+    #[test]
+    fn strip_quotes_single() {
+        assert_eq!(strip_quotes("'hi'"), "hi");
+    }
+
+    #[test]
+    fn strip_quotes_degenerate_passthrough() {
+        // Too short, or mismatched quotes — returned unchanged.
+        assert_eq!(strip_quotes(""), "");
+        assert_eq!(strip_quotes("x"), "x");
+        assert_eq!(strip_quotes("\"mismatch'"), "\"mismatch'");
+    }
+
+    #[test]
+    fn xml_declaration_both_pseudo_attrs() {
+        let (v, e) = parse_xml_declaration(r#" version="1.0" encoding="UTF-8""#);
+        assert_eq!(v.as_deref(), Some("1.0"));
+        assert_eq!(e.as_deref(), Some("UTF-8"));
+    }
+
+    #[test]
+    fn xml_declaration_single_quotes() {
+        let (v, e) = parse_xml_declaration("version='1.1' encoding='us-ascii'");
+        assert_eq!(v.as_deref(), Some("1.1"));
+        assert_eq!(e.as_deref(), Some("us-ascii"));
+    }
+
+    #[test]
+    fn xml_declaration_missing_attr_is_none() {
+        let (v, e) = parse_xml_declaration("version=\"1.0\"");
+        assert_eq!(v.as_deref(), Some("1.0"));
+        assert_eq!(e, None);
+    }
+
+    #[test]
+    fn pseudo_attr_rejects_unquoted_value() {
+        // A value not wrapped in quotes yields None.
+        assert_eq!(pseudo_attr("version=1.0", "version"), None);
+    }
+
+    #[test]
+    fn pseudo_attr_absent_returns_none() {
+        assert_eq!(pseudo_attr("encoding=\"UTF-8\"", "version"), None);
+    }
+}

--- a/code/packages/rust/xml-parser/src/lib.rs
+++ b/code/packages/rust/xml-parser/src/lib.rs
@@ -1,0 +1,626 @@
+//! # xml-parser — a namespace-aware XML parser
+//!
+//! This crate parses XML source text into a typed, namespace-resolved AST
+//! ([`XmlDocument`]). It is milestone **M1** of the OOXML effort: the AST it
+//! produces is designed to be consumed by an OPC (Open Packaging Conventions)
+//! package reader, which walks `[Content_Types].xml` and `.rels` files to find
+//! the parts of a `.docx` / `.xlsx` / `.pptx` package.
+//!
+//! ## The pipeline
+//!
+//! ```text
+//! Source text  ("<w:p xmlns:w=\"...\">hi</w:p>")
+//!       |
+//!       v
+//! xml-lexer            → Vec<Token>            (grammar-driven tokenizer)
+//!       |
+//!       v
+//! xml.grammar          → ParserGrammar         (structural nesting rules)
+//!       |
+//!       v
+//! parser::GrammarParser → GrammarASTNode tree  (generic rule/token tree)
+//!       |
+//!       v
+//! parser.rs (this crate) → XmlDocument          (namespaces + entities + typing)
+//! ```
+//!
+//! The lexer and grammar do the *structural* work. Everything that a
+//! context-free grammar cannot express — matching end-tag names to start
+//! tags, binding namespace prefixes to URIs, and decoding entity references —
+//! lives in this crate's [`parser`] and [`namespace`] modules.
+//!
+//! ## Quick start
+//!
+//! ```
+//! use coding_adventures_xml_parser::parse_xml;
+//!
+//! let doc = parse_xml(r#"<note lang="en"><to>Alice</to></note>"#).unwrap();
+//! assert_eq!(doc.root.local_name, "note");
+//! assert_eq!(doc.root.get_attr(None, "lang"), Some("en"));
+//! let to = doc.root.get_child(None, "to").unwrap();
+//! assert_eq!(to.text_content(), "Alice");
+//! ```
+//!
+//! ## What this parser does *not* do
+//!
+//! It has no DTD support, so the only named entities it understands are the
+//! five predefined ones (`&amp;`, `&lt;`, `&gt;`, `&apos;`, `&quot;`). That is
+//! exactly the subset OOXML uses, which keeps M1 focused.
+
+use coding_adventures_xml_lexer::{create_xml_lexer, tokenize_xml};
+use parser::grammar_parser::{GrammarASTNode, GrammarParser, DEFAULT_MAX_RULE_DEPTH};
+
+mod _grammar;
+pub mod ast;
+mod builder;
+pub mod namespace;
+
+// Re-export the AST vocabulary so callers use one import.
+pub use ast::{ParseError, XmlAttribute, XmlDocument, XmlElement, XmlNode};
+pub use namespace::{XMLNS_NAMESPACE, XML_NAMESPACE};
+
+/// Create a [`GrammarParser`] configured for XML.
+///
+/// This mirrors `create_json_parser`: it tokenizes the source with the XML
+/// lexer and pairs the tokens with the compiled `xml.grammar`. Most callers
+/// want [`parse_xml`] instead, which also builds the typed [`XmlDocument`];
+/// this factory is exposed for callers that want the raw generic tree.
+pub fn create_xml_parser(source: &str) -> GrammarParser {
+    let tokens = tokenize_xml(source);
+    let grammar = _grammar::parser_grammar();
+    // Enable the recursion-depth cap. XML nests without bound (`element →
+    // content → element`), so a deeply-nested (possibly hostile) document would
+    // otherwise recurse the parser past the native stack and abort the whole
+    // process — an uncatchable DoS that no `Result` can report. The cap turns
+    // over-deep input into a normal parse error well below the overflow point.
+    GrammarParser::new(tokens, grammar).with_max_depth(DEFAULT_MAX_RULE_DEPTH)
+}
+
+/// Parse XML source text into a namespace-aware [`XmlDocument`].
+///
+/// Returns a [`ParseError`] if the input is not well-formed, if a namespace
+/// prefix is unbound, or if an entity reference is malformed.
+pub fn parse_xml(source: &str) -> Result<XmlDocument, ParseError> {
+    // Tokenize via the fallible lexer path so a lexer-level problem (e.g. a
+    // stray `&` that starts no valid reference) surfaces as a `ParseError`
+    // rather than a panic. This is why `parse_xml` does not reuse
+    // `create_xml_parser` (which follows the panicking json-parser glue).
+    let tokens = create_xml_lexer(source).tokenize().map_err(|e| ParseError {
+        message: e.message,
+        line: Some(e.line),
+        column: Some(e.column),
+    })?;
+    // Cap recursion depth (see `create_xml_parser`) so deeply-nested input
+    // returns `Err` instead of overflowing the stack and aborting the process.
+    let mut grammar_parser =
+        GrammarParser::new(tokens, _grammar::parser_grammar()).with_max_depth(DEFAULT_MAX_RULE_DEPTH);
+    let root: GrammarASTNode = grammar_parser.parse().map_err(|e| ParseError {
+        message: e.message,
+        line: Some(e.token.line),
+        column: Some(e.token.column),
+    })?;
+    builder::build_document(&root)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The OPC content-types namespace, used by [Content_Types].xml.
+    const CT_NS: &str = "http://schemas.openxmlformats.org/package/2006/content-types";
+
+    // -----------------------------------------------------------------------
+    // Simple structure
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_simple_element() {
+        let doc = parse_xml("<p>text</p>").unwrap();
+        assert_eq!(doc.root.local_name, "p");
+        assert_eq!(doc.root.namespace_uri, None);
+        assert_eq!(doc.root.text_content(), "text");
+        assert!(doc.root.attributes.is_empty());
+    }
+
+    #[test]
+    fn test_self_closing_element() {
+        let doc = parse_xml("<br/>").unwrap();
+        assert_eq!(doc.root.local_name, "br");
+        assert!(doc.root.children.is_empty());
+    }
+
+    #[test]
+    fn test_self_closing_with_space_and_attr() {
+        let doc = parse_xml(r#"<img src="a.png" />"#).unwrap();
+        assert_eq!(doc.root.local_name, "img");
+        assert_eq!(doc.root.get_attr(None, "src"), Some("a.png"));
+        assert!(doc.root.children.is_empty());
+    }
+
+    #[test]
+    fn test_explicit_empty_element() {
+        let doc = parse_xml("<div></div>").unwrap();
+        assert_eq!(doc.root.local_name, "div");
+        assert!(doc.root.children.is_empty());
+        assert_eq!(doc.root.text_content(), "");
+    }
+
+    // -----------------------------------------------------------------------
+    // Attributes — both quote styles
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_double_quoted_attribute() {
+        let doc = parse_xml(r#"<a href="url">x</a>"#).unwrap();
+        assert_eq!(doc.root.get_attr(None, "href"), Some("url"));
+    }
+
+    #[test]
+    fn test_single_quoted_attribute() {
+        let doc = parse_xml("<a href='url'>x</a>").unwrap();
+        assert_eq!(doc.root.get_attr(None, "href"), Some("url"));
+    }
+
+    #[test]
+    fn test_multiple_attributes_order() {
+        let doc = parse_xml(r#"<a href="u" target="_blank" rel="x"/>"#).unwrap();
+        let names: Vec<&str> = doc
+            .root
+            .attributes
+            .iter()
+            .map(|a| a.local_name.as_str())
+            .collect();
+        assert_eq!(names, vec!["href", "target", "rel"]);
+        assert_eq!(doc.root.get_attr(None, "target"), Some("_blank"));
+    }
+
+    #[test]
+    fn test_missing_attribute_is_none() {
+        let doc = parse_xml("<a/>").unwrap();
+        assert_eq!(doc.root.get_attr(None, "nope"), None);
+    }
+
+    // -----------------------------------------------------------------------
+    // Nested and mixed content
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_nested_elements() {
+        let doc = parse_xml("<a><b><c>deep</c></b></a>").unwrap();
+        let b = doc.root.get_child(None, "b").unwrap();
+        let c = b.get_child(None, "c").unwrap();
+        assert_eq!(c.text_content(), "deep");
+        // text_content aggregates descendants:
+        assert_eq!(doc.root.text_content(), "deep");
+    }
+
+    #[test]
+    fn test_mixed_content() {
+        let doc = parse_xml("<p>Hello <b>world</b>!</p>").unwrap();
+        // Children: Text("Hello "), Element(b), Text("!")
+        assert_eq!(doc.root.children.len(), 3);
+        assert!(matches!(&doc.root.children[0], XmlNode::Text(t) if t == "Hello "));
+        assert!(matches!(&doc.root.children[1], XmlNode::Element(_)));
+        assert!(matches!(&doc.root.children[2], XmlNode::Text(t) if t == "!"));
+        assert_eq!(doc.root.text_content(), "Hello world!");
+        // get_child must skip the Text children and find the element `b`.
+        assert!(doc.root.get_child(None, "b").is_some());
+        assert_eq!(doc.root.get_child(None, "missing"), None);
+    }
+
+    #[test]
+    fn test_get_children_repeated() {
+        let doc = parse_xml("<list><item>a</item><item>b</item><other/></list>").unwrap();
+        let items = doc.root.get_children(None, "item");
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].text_content(), "a");
+        assert_eq!(items[1].text_content(), "b");
+        assert_eq!(doc.root.get_children(None, "item").len(), 2);
+    }
+
+    // -----------------------------------------------------------------------
+    // Namespaces
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_default_namespace_applies_to_element() {
+        let doc = parse_xml(r#"<root xmlns="http://example.com/ns"><child/></root>"#).unwrap();
+        assert_eq!(doc.root.namespace_uri.as_deref(), Some("http://example.com/ns"));
+        // The default namespace is inherited by unprefixed child elements.
+        let child = doc.root.children.iter().find_map(|c| match c {
+            XmlNode::Element(e) => Some(e),
+            _ => None,
+        }).unwrap();
+        assert_eq!(child.namespace_uri.as_deref(), Some("http://example.com/ns"));
+    }
+
+    #[test]
+    fn test_prefixed_element_and_attribute_resolve() {
+        let src = r#"<w:document xmlns:w="http://word/ns" w:id="7" plain="p"><w:body/></w:document>"#;
+        let doc = parse_xml(src).unwrap();
+        assert_eq!(doc.root.namespace_uri.as_deref(), Some("http://word/ns"));
+        assert_eq!(doc.root.local_name, "document");
+        // Prefixed attribute resolves to the URI.
+        assert_eq!(doc.root.get_attr(Some("http://word/ns"), "id"), Some("7"));
+        // Unprefixed attribute is in NO namespace, even though the element is
+        // in a namespace.
+        assert_eq!(doc.root.get_attr(None, "plain"), Some("p"));
+        assert_eq!(doc.root.get_attr(Some("http://word/ns"), "plain"), None);
+        // Prefixed child resolves too.
+        let body = doc.root.get_child(Some("http://word/ns"), "body").unwrap();
+        assert_eq!(body.local_name, "body");
+    }
+
+    #[test]
+    fn test_unprefixed_attr_not_in_default_namespace() {
+        let doc = parse_xml(r#"<r xmlns="http://d/ns" a="1"/>"#).unwrap();
+        assert_eq!(doc.root.get_attr(None, "a"), Some("1"));
+        assert_eq!(doc.root.get_attr(Some("http://d/ns"), "a"), None);
+    }
+
+    #[test]
+    fn test_nested_namespace_scoping_and_shadowing() {
+        let src = r#"<a xmlns:p="uri1"><p:b><c xmlns:p="uri2"><p:d/></c></p:b></a>"#;
+        let doc = parse_xml(src).unwrap();
+        let b = doc.root.get_child(Some("uri1"), "b").unwrap();
+        let c = b.get_child(None, "c").unwrap();
+        // Inner redefinition shadows the outer binding for prefix p.
+        let d = c.get_child(Some("uri2"), "d").unwrap();
+        assert_eq!(d.local_name, "d");
+        assert!(c.get_child(Some("uri1"), "d").is_none());
+    }
+
+    #[test]
+    fn test_namespace_uri_is_case_sensitive() {
+        let doc = parse_xml(r#"<r xmlns="http://Example.com/NS"/>"#).unwrap();
+        assert_eq!(doc.root.namespace_uri.as_deref(), Some("http://Example.com/NS"));
+        assert_ne!(doc.root.namespace_uri.as_deref(), Some("http://example.com/ns"));
+    }
+
+    #[test]
+    fn test_unbound_prefix_is_error() {
+        let err = parse_xml("<x:y/>").unwrap_err();
+        assert!(err.message.contains("unbound namespace prefix"));
+    }
+
+    #[test]
+    fn test_reserved_xml_prefix() {
+        let doc = parse_xml(r#"<r xml:lang="en"/>"#).unwrap();
+        assert_eq!(doc.root.get_attr(Some(XML_NAMESPACE), "lang"), Some("en"));
+    }
+
+    #[test]
+    fn test_default_namespace_undeclared_on_child() {
+        // xmlns="" on a child removes the default namespace for that subtree.
+        let src = r#"<a xmlns="U"><b xmlns=""><c/></b></a>"#;
+        let doc = parse_xml(src).unwrap();
+        assert_eq!(doc.root.namespace_uri.as_deref(), Some("U"));
+        let b = doc.root.get_child(None, "b").unwrap();
+        assert_eq!(b.namespace_uri, None);
+        assert!(b.get_child(None, "c").is_some());
+    }
+
+    #[test]
+    fn test_malformed_xmlns_declaration_is_error() {
+        let err = parse_xml(r#"<r xmlns:="u"/>"#).unwrap_err();
+        assert!(err.message.contains("malformed namespace declaration"));
+    }
+
+    #[test]
+    fn test_xmlns_declaration_not_stored_as_attribute() {
+        // The xmlns declaration is consumed, not surfaced as an attribute.
+        let doc = parse_xml(r#"<r xmlns:w="u" w:a="1"/>"#).unwrap();
+        assert_eq!(doc.root.attributes.len(), 1);
+        assert_eq!(doc.root.attributes[0].local_name, "a");
+    }
+
+    // -----------------------------------------------------------------------
+    // Entity and character references
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_entities_in_text() {
+        // Note: the xml-lexer skips whitespace that sits *between* tokens in
+        // the default group, so the space immediately following an entity
+        // reference is consumed by the lexer (a known lexer-layer limitation,
+        // documented in the README). The parser faithfully decodes and
+        // concatenates whatever TEXT / ENTITY_REF tokens it is handed.
+        let doc = parse_xml("<p>a &amp; b &lt; c &gt; d</p>").unwrap();
+        assert_eq!(doc.root.text_content(), "a &b <c >d");
+    }
+
+    #[test]
+    fn test_entity_adjacent_to_text_without_spaces() {
+        // With no surrounding whitespace the lexer keeps every character, so
+        // decoding is exact.
+        let doc = parse_xml("<p>x&amp;y&lt;z</p>").unwrap();
+        assert_eq!(doc.root.text_content(), "x&y<z");
+    }
+
+    #[test]
+    fn test_apos_and_quot_entities() {
+        let doc = parse_xml("<p>&apos;q&quot;</p>").unwrap();
+        assert_eq!(doc.root.text_content(), "'q\"");
+    }
+
+    #[test]
+    fn test_entities_in_attribute() {
+        let doc = parse_xml(r#"<a t="x &amp; y &lt; z"/>"#).unwrap();
+        assert_eq!(doc.root.get_attr(None, "t"), Some("x & y < z"));
+    }
+
+    #[test]
+    fn test_decimal_char_ref() {
+        let doc = parse_xml("<p>&#65;&#66;</p>").unwrap();
+        assert_eq!(doc.root.text_content(), "AB");
+    }
+
+    #[test]
+    fn test_hex_char_ref() {
+        let doc = parse_xml("<p>&#x41;&#x2764;</p>").unwrap();
+        assert_eq!(doc.root.text_content(), "A\u{2764}");
+    }
+
+    #[test]
+    fn test_char_ref_in_attribute() {
+        let doc = parse_xml(r#"<a t="&#72;i"/>"#).unwrap();
+        assert_eq!(doc.root.get_attr(None, "t"), Some("Hi"));
+    }
+
+    #[test]
+    fn test_unknown_entity_is_error() {
+        let err = parse_xml("<p>&bogus;</p>").unwrap_err();
+        assert!(err.message.contains("unknown entity"));
+    }
+
+    #[test]
+    fn test_bare_ampersand_is_error() {
+        // A stray `&` that starts no valid reference is rejected by the lexer.
+        // `parse_xml` surfaces that as a `ParseError` (with position) rather
+        // than panicking.
+        let err = parse_xml("<p>a &amp b</p>").unwrap_err();
+        assert!(!err.message.is_empty());
+        assert!(err.line.is_some());
+    }
+
+    // -----------------------------------------------------------------------
+    // CDATA — verbatim, not decoded
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_cdata_verbatim() {
+        let doc = parse_xml("<p><![CDATA[x < y & z]]></p>").unwrap();
+        assert_eq!(doc.root.children.len(), 1);
+        assert!(matches!(&doc.root.children[0], XmlNode::CData(t) if t == "x < y & z"));
+        // text_content includes CDATA.
+        assert_eq!(doc.root.text_content(), "x < y & z");
+    }
+
+    #[test]
+    fn test_empty_cdata() {
+        let doc = parse_xml("<p><![CDATA[]]></p>").unwrap();
+        assert!(matches!(&doc.root.children[0], XmlNode::CData(t) if t.is_empty()));
+    }
+
+    // -----------------------------------------------------------------------
+    // Comments
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_comment_node() {
+        let doc = parse_xml("<p><!-- hi --></p>").unwrap();
+        assert!(matches!(&doc.root.children[0], XmlNode::Comment(t) if t == " hi "));
+        // Comments contribute nothing to text_content.
+        assert_eq!(doc.root.text_content(), "");
+    }
+
+    #[test]
+    fn test_empty_comment() {
+        let doc = parse_xml("<p><!----></p>").unwrap();
+        assert!(matches!(&doc.root.children[0], XmlNode::Comment(t) if t.is_empty()));
+    }
+
+    #[test]
+    fn test_leading_comment_before_root() {
+        let doc = parse_xml("<!-- header --><root/>").unwrap();
+        assert_eq!(doc.root.local_name, "root");
+    }
+
+    // -----------------------------------------------------------------------
+    // Processing instructions and the XML declaration
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_xml_declaration_version_and_encoding() {
+        let doc = parse_xml(r#"<?xml version="1.0" encoding="UTF-8"?><root/>"#).unwrap();
+        assert_eq!(doc.version.as_deref(), Some("1.0"));
+        assert_eq!(doc.encoding.as_deref(), Some("UTF-8"));
+        assert_eq!(doc.root.local_name, "root");
+    }
+
+    #[test]
+    fn test_xml_declaration_version_only() {
+        let doc = parse_xml(r#"<?xml version="1.0"?><root/>"#).unwrap();
+        assert_eq!(doc.version.as_deref(), Some("1.0"));
+        assert_eq!(doc.encoding, None);
+    }
+
+    #[test]
+    fn test_processing_instruction_node() {
+        let doc =
+            parse_xml(r#"<root><?xml-stylesheet type="text/xsl" href="a.xsl"?></root>"#).unwrap();
+        match &doc.root.children[0] {
+            XmlNode::ProcessingInstruction { target, text } => {
+                assert_eq!(target, "xml-stylesheet");
+                assert!(text.contains("text/xsl"));
+            }
+            other => panic!("expected PI, got {other:?}"),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Whitespace handling
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_whitespace_between_tags_is_skipped() {
+        let doc = parse_xml("<a>  <b/>  <c/>  </a>").unwrap();
+        // Whitespace-only text between elements is consumed by the lexer's
+        // skip pattern, so only the two child elements remain.
+        let elems: Vec<_> = doc
+            .root
+            .children
+            .iter()
+            .filter(|c| matches!(c, XmlNode::Element(_)))
+            .collect();
+        assert_eq!(elems.len(), 2);
+    }
+
+    #[test]
+    fn test_significant_whitespace_in_text_preserved() {
+        let doc = parse_xml("<p>a  b</p>").unwrap();
+        assert_eq!(doc.root.text_content(), "a  b");
+    }
+
+    #[test]
+    fn test_pretty_printed_document() {
+        let src = "<root>\n  <child>hi</child>\n</root>";
+        let doc = parse_xml(src).unwrap();
+        let child = doc.root.get_child(None, "child").unwrap();
+        assert_eq!(child.text_content(), "hi");
+    }
+
+    // -----------------------------------------------------------------------
+    // Well-formedness errors
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_mismatched_tags_is_error() {
+        let err = parse_xml("<a></b>").unwrap_err();
+        // Either the grammar fails to consume, or the AST builder reports the
+        // mismatch; both are acceptable failures. The AST-level message is
+        // more precise, so prefer it when reachable.
+        assert!(!err.message.is_empty());
+    }
+
+    #[test]
+    fn test_prefixed_mismatch_detected_by_builder() {
+        // Structurally valid (both are TAG_NAME tokens) but names differ.
+        let err = parse_xml("<a>x</bb>").unwrap_err();
+        assert!(err.message.contains("mismatched tags"));
+    }
+
+    #[test]
+    fn test_unclosed_element_is_error() {
+        let err = parse_xml("<a>text").unwrap_err();
+        assert!(!err.message.is_empty());
+    }
+
+    #[test]
+    fn test_empty_input_is_error() {
+        let err = parse_xml("").unwrap_err();
+        assert!(!err.message.is_empty());
+    }
+
+    #[test]
+    fn test_parse_error_display() {
+        let err = ParseError {
+            message: "boom".to_string(),
+            line: Some(3),
+            column: Some(5),
+        };
+        assert_eq!(format!("{err}"), "boom (line 3, column 5)");
+        let err2 = ParseError { message: "x".into(), line: None, column: None };
+        assert_eq!(format!("{err2}"), "x");
+        let err3 = ParseError { message: "y".into(), line: Some(2), column: None };
+        assert_eq!(format!("{err3}"), "y (line 2)");
+    }
+
+    // -----------------------------------------------------------------------
+    // Factory function (raw generic tree)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_create_xml_parser_factory() {
+        let mut p = create_xml_parser("<r/>");
+        let ast = p.parse().expect("should parse");
+        assert_eq!(ast.rule_name, "document");
+    }
+
+    // -----------------------------------------------------------------------
+    // OOXML-flavoured integration test: a small [Content_Types].xml
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_content_types_document() {
+        let src = format!(
+            r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="{ns}">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+</Types>"#,
+            ns = CT_NS
+        );
+        let doc = parse_xml(&src).unwrap();
+
+        assert_eq!(doc.version.as_deref(), Some("1.0"));
+        assert_eq!(doc.encoding.as_deref(), Some("UTF-8"));
+
+        // Root <Types> is in the content-types namespace.
+        assert_eq!(doc.root.local_name, "Types");
+        assert_eq!(doc.root.namespace_uri.as_deref(), Some(CT_NS));
+
+        // Two <Default> children (in the default namespace).
+        let defaults = doc.root.get_children(Some(CT_NS), "Default");
+        assert_eq!(defaults.len(), 2);
+        assert_eq!(defaults[0].get_attr(None, "Extension"), Some("rels"));
+
+        // The <Override> — attributes are unprefixed, so live in NO namespace.
+        let override_el = doc.root.get_child(Some(CT_NS), "Override").unwrap();
+        assert_eq!(
+            override_el.get_attr(None, "PartName"),
+            Some("/word/document.xml")
+        );
+        assert!(override_el
+            .get_attr(None, "ContentType")
+            .unwrap()
+            .contains("wordprocessingml.document.main+xml"));
+    }
+
+    #[test]
+    fn test_rels_document() {
+        // A simplified .rels part in the OPC relationships namespace.
+        let rel_ns = "http://schemas.openxmlformats.org/package/2006/relationships";
+        let src = format!(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="{ns}">
+  <Relationship Id="rId1" Type="http://.../officeDocument" Target="word/document.xml"/>
+</Relationships>"#,
+            ns = rel_ns
+        );
+        let doc = parse_xml(&src).unwrap();
+        assert_eq!(doc.root.local_name, "Relationships");
+        let rel = doc.root.get_child(Some(rel_ns), "Relationship").unwrap();
+        assert_eq!(rel.get_attr(None, "Id"), Some("rId1"));
+        assert_eq!(rel.get_attr(None, "Target"), Some("word/document.xml"));
+    }
+
+    #[test]
+    fn test_deeply_nested_input_errors_instead_of_overflowing() {
+        // A hostile document can nest elements without bound. Without a depth
+        // cap the parser recurses past the native stack and *aborts the whole
+        // process* (an uncatchable stack overflow) — a trivial DoS for any
+        // reader of untrusted OOXML. With the cap enabled at the entry points,
+        // over-deep input must instead return a normal `Err`. 20000 levels is
+        // far past both the 128-level cap and any real document, and (crucially)
+        // this test would SIGABRT rather than fail if the cap regressed.
+        let depth = 20_000;
+        let src: String = "<a>".repeat(depth) + &"</a>".repeat(depth);
+        let result = parse_xml(&src);
+        assert!(
+            result.is_err(),
+            "deeply-nested input must error, not overflow the stack"
+        );
+    }
+}

--- a/code/packages/rust/xml-parser/src/namespace.rs
+++ b/code/packages/rust/xml-parser/src/namespace.rs
@@ -1,0 +1,335 @@
+//! Namespace resolution and entity decoding — the two "context-sensitive"
+//! jobs the grammar can't do.
+//!
+//! The grammar in `xml.grammar` produces a raw tree of tokens; it knows
+//! nothing about namespaces or entities. This module holds the two helpers
+//! that turn raw lexeme text into resolved names and decoded strings.
+
+use std::collections::HashMap;
+
+use crate::ast::ParseError;
+
+// ===========================================================================
+// The namespace scope stack
+// ===========================================================================
+
+/// A stack of namespace bindings, one frame per open element.
+///
+/// # Why a stack?
+///
+/// Namespace declarations are *scoped* to the element they appear on and to
+/// that element's descendants. When we enter `<w:body>` we push a frame; when
+/// we leave it we pop, so a binding declared inside `<w:body>` cannot leak out
+/// to a later sibling. Resolution walks the stack from the top (innermost)
+/// down, so an inner declaration shadows an outer one with the same prefix.
+///
+/// Two prefixes are always bound, per the XML Namespaces spec, and callers
+/// never declare them:
+///
+/// - `xml`   → `http://www.w3.org/XML/1998/namespace`
+/// - `xmlns` → `http://www.w3.org/2000/xmlns/`
+#[derive(Debug, Default)]
+pub struct NamespaceStack {
+    /// One map per scope. `frames[0]` is the outermost element's declarations.
+    /// A key of `""` is the *default* namespace (declared with `xmlns="..."`).
+    frames: Vec<HashMap<String, String>>,
+}
+
+/// The reserved URI bound to the `xml` prefix.
+pub const XML_NAMESPACE: &str = "http://www.w3.org/XML/1998/namespace";
+/// The reserved URI bound to the `xmlns` prefix.
+pub const XMLNS_NAMESPACE: &str = "http://www.w3.org/2000/xmlns/";
+
+impl NamespaceStack {
+    /// Create an empty stack (no user declarations yet).
+    pub fn new() -> Self {
+        NamespaceStack { frames: Vec::new() }
+    }
+
+    /// Push a new scope. Call this on entering a start tag, *before* recording
+    /// that tag's `xmlns` declarations, so those declarations land in the new
+    /// frame and are popped when the element closes.
+    pub fn push(&mut self, declarations: HashMap<String, String>) {
+        self.frames.push(declarations);
+    }
+
+    /// Pop the innermost scope. Call this when an element closes.
+    pub fn pop(&mut self) {
+        self.frames.pop();
+    }
+
+    /// Resolve a *prefix* to a namespace URI.
+    ///
+    /// - An empty prefix (`""`) asks for the default namespace; if none is in
+    ///   scope the result is `None` (the "no namespace" case).
+    /// - The reserved `xml` / `xmlns` prefixes always resolve.
+    /// - Any other unbound prefix is an error (a caller decides whether to
+    ///   surface it).
+    pub fn resolve_prefix(&self, prefix: &str) -> Result<Option<String>, ParseError> {
+        if prefix == "xml" {
+            return Ok(Some(XML_NAMESPACE.to_string()));
+        }
+        if prefix == "xmlns" {
+            return Ok(Some(XMLNS_NAMESPACE.to_string()));
+        }
+        // Walk from innermost frame outward.
+        for frame in self.frames.iter().rev() {
+            if let Some(uri) = frame.get(prefix) {
+                // A binding to the empty string "undeclares" the default
+                // namespace (`xmlns=""`), which means "no namespace".
+                if uri.is_empty() {
+                    return Ok(None);
+                }
+                return Ok(Some(uri.clone()));
+            }
+        }
+        if prefix.is_empty() {
+            // No default namespace in scope → element is in no namespace.
+            Ok(None)
+        } else {
+            Err(ParseError {
+                message: format!("unbound namespace prefix '{prefix}'"),
+                line: None,
+                column: None,
+            })
+        }
+    }
+}
+
+// ===========================================================================
+// Splitting a qualified name
+// ===========================================================================
+
+/// Split a raw name like `w:p` into `(prefix, local)`.
+///
+/// A name with no colon has an empty prefix. A name is malformed if it has
+/// more than one colon, an empty prefix before a colon (`:p`), or an empty
+/// local part (`w:`).
+pub fn split_qname(qname: &str) -> Result<(&str, &str), ParseError> {
+    match qname.split_once(':') {
+        None => Ok(("", qname)),
+        Some((prefix, local)) => {
+            if prefix.is_empty() || local.is_empty() || local.contains(':') {
+                Err(ParseError {
+                    message: format!("malformed qualified name '{qname}'"),
+                    line: None,
+                    column: None,
+                })
+            } else {
+                Ok((prefix, local))
+            }
+        }
+    }
+}
+
+// ===========================================================================
+// Entity and character reference decoding
+// ===========================================================================
+
+/// Decode XML entity and character references inside a run of text.
+///
+/// This handles the five predefined entities and both flavours of numeric
+/// character reference:
+///
+/// | Reference        | Decodes to                     |
+/// |------------------|--------------------------------|
+/// | `&amp;`          | `&`                            |
+/// | `&lt;`           | `<`                            |
+/// | `&gt;`           | `>`                            |
+/// | `&apos;`         | `'`                            |
+/// | `&quot;`         | `"`                            |
+/// | `&#N;` (decimal) | the Unicode code point `N`     |
+/// | `&#xH;` (hex)    | the Unicode code point `0xH`   |
+///
+/// CDATA content must **not** be passed through this function — it is verbatim.
+///
+/// An `&` that does not begin a well-formed reference is an error, which is
+/// what a strict XML parser should do.
+pub fn decode_entities(input: &str) -> Result<String, ParseError> {
+    let mut out = String::with_capacity(input.len());
+    let mut chars = input.char_indices().peekable();
+
+    while let Some((_, ch)) = chars.next() {
+        if ch != '&' {
+            out.push(ch);
+            continue;
+        }
+        // Gather everything up to the terminating ';'.
+        let mut name = String::new();
+        let mut terminated = false;
+        for (_, c) in chars.by_ref() {
+            if c == ';' {
+                terminated = true;
+                break;
+            }
+            name.push(c);
+        }
+        if !terminated {
+            return Err(ParseError {
+                message: "unterminated entity reference (missing ';')".to_string(),
+                line: None,
+                column: None,
+            });
+        }
+        out.push_str(&decode_one_reference(&name)?);
+    }
+
+    Ok(out)
+}
+
+/// Decode the body of a single reference — the text between `&` and `;`.
+fn decode_one_reference(name: &str) -> Result<String, ParseError> {
+    // Numeric character references start with '#'.
+    if let Some(rest) = name.strip_prefix('#') {
+        let code = if let Some(hex) = rest.strip_prefix('x').or_else(|| rest.strip_prefix('X')) {
+            u32::from_str_radix(hex, 16).map_err(|_| bad_ref(name))?
+        } else {
+            rest.parse::<u32>().map_err(|_| bad_ref(name))?
+        };
+        let ch = char::from_u32(code).ok_or_else(|| ParseError {
+            message: format!("character reference '&#{name};' is not a valid code point"),
+            line: None,
+            column: None,
+        })?;
+        return Ok(ch.to_string());
+    }
+
+    // Named entity references — only the five predefined ones are supported
+    // (this parser has no DTD, so no custom entities exist).
+    let decoded = match name {
+        "amp" => "&",
+        "lt" => "<",
+        "gt" => ">",
+        "apos" => "'",
+        "quot" => "\"",
+        _ => {
+            return Err(ParseError {
+                message: format!("unknown entity reference '&{name};'"),
+                line: None,
+                column: None,
+            })
+        }
+    };
+    Ok(decoded.to_string())
+}
+
+fn bad_ref(name: &str) -> ParseError {
+    ParseError {
+        message: format!("malformed character reference '&{name};'"),
+        line: None,
+        column: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    // --- NamespaceStack::resolve_prefix ---
+
+    #[test]
+    fn reserved_prefixes_resolve() {
+        let ns = NamespaceStack::new();
+        assert_eq!(ns.resolve_prefix("xml").unwrap().as_deref(), Some(XML_NAMESPACE));
+        assert_eq!(
+            ns.resolve_prefix("xmlns").unwrap().as_deref(),
+            Some(XMLNS_NAMESPACE)
+        );
+    }
+
+    #[test]
+    fn empty_prefix_with_no_default_is_no_namespace() {
+        let ns = NamespaceStack::new();
+        assert_eq!(ns.resolve_prefix("").unwrap(), None);
+    }
+
+    #[test]
+    fn unbound_prefix_errors() {
+        let ns = NamespaceStack::new();
+        assert!(ns.resolve_prefix("nope").is_err());
+    }
+
+    #[test]
+    fn empty_uri_binding_undeclares_default() {
+        // `xmlns=""` maps the default prefix to the empty string, which
+        // resolve_prefix treats as "no namespace".
+        let mut ns = NamespaceStack::new();
+        let mut frame = HashMap::new();
+        frame.insert(String::new(), String::new());
+        ns.push(frame);
+        assert_eq!(ns.resolve_prefix("").unwrap(), None);
+    }
+
+    #[test]
+    fn push_and_pop_scope() {
+        let mut ns = NamespaceStack::new();
+        let mut frame = HashMap::new();
+        frame.insert("p".to_string(), "uri".to_string());
+        ns.push(frame);
+        assert_eq!(ns.resolve_prefix("p").unwrap().as_deref(), Some("uri"));
+        ns.pop();
+        // After popping, the binding is gone.
+        assert!(ns.resolve_prefix("p").is_err());
+    }
+
+    // --- split_qname ---
+
+    #[test]
+    fn split_qname_plain() {
+        assert_eq!(split_qname("name").unwrap(), ("", "name"));
+    }
+
+    #[test]
+    fn split_qname_prefixed() {
+        assert_eq!(split_qname("w:p").unwrap(), ("w", "p"));
+    }
+
+    #[test]
+    fn split_qname_rejects_malformed() {
+        assert!(split_qname(":local").is_err()); // empty prefix
+        assert!(split_qname("prefix:").is_err()); // empty local
+        assert!(split_qname("a:b:c").is_err()); // two colons
+    }
+
+    // --- decode_entities ---
+
+    #[test]
+    fn decode_named_entities() {
+        assert_eq!(decode_entities("a&amp;b&lt;c&gt;d&apos;e&quot;f").unwrap(), "a&b<c>d'e\"f");
+    }
+
+    #[test]
+    fn decode_decimal_and_hex_refs() {
+        assert_eq!(decode_entities("&#65;&#x42;&#X43;").unwrap(), "ABC");
+    }
+
+    #[test]
+    fn decode_plain_text_untouched() {
+        assert_eq!(decode_entities("no entities here").unwrap(), "no entities here");
+    }
+
+    #[test]
+    fn decode_rejects_unterminated() {
+        assert!(decode_entities("a &amp b").unwrap_err().message.contains("unterminated"));
+    }
+
+    #[test]
+    fn decode_rejects_unknown_entity() {
+        assert!(decode_entities("&bogus;").unwrap_err().message.contains("unknown"));
+    }
+
+    #[test]
+    fn decode_rejects_bad_numeric_ref() {
+        assert!(decode_entities("&#zz;").is_err());
+        assert!(decode_entities("&#xZZ;").is_err());
+    }
+
+    #[test]
+    fn decode_rejects_out_of_range_code_point() {
+        // 0xD800 is a surrogate — not a valid scalar value.
+        assert!(decode_entities("&#xD800;").is_err());
+        // Beyond the Unicode range.
+        assert!(decode_entities("&#x110000;").is_err());
+    }
+}

--- a/code/specs/XML01-xml-parser.md
+++ b/code/specs/XML01-xml-parser.md
@@ -1,0 +1,241 @@
+# XML01 — XML Parser (namespace-aware AST)
+
+## Overview
+
+This is milestone **M1** of the OOXML effort. It builds a Rust crate,
+`xml-parser`, that turns XML source text into a typed, **namespace-aware**
+Abstract Syntax Tree (AST). The AST is deliberately shaped for the next
+milestone: an **OPC** (Open Packaging Conventions) package reader that walks
+`[Content_Types].xml` and `.rels` files to discover the parts of a `.docx` /
+`.xlsx` / `.pptx` package.
+
+Like every other language front-end in this repo, the parser is **not**
+hand-written. It reuses the shared grammar tooling:
+
+- The **`xml-lexer`** crate tokenizes the source using `xml_rust.tokens`.
+- A new **`xml.grammar`** file describes how those tokens may nest.
+- The generic **`parser::GrammarParser`** turns tokens + grammar into a raw
+  `GrammarASTNode` tree.
+- A thin, hand-written **AST builder** in this crate walks that raw tree once
+  and produces the typed `XmlDocument`, doing the three jobs a context-free
+  grammar cannot: end-tag matching, namespace resolution, and entity decoding.
+
+```text
+Source text  ("<w:p xmlns:w=\"...\">hi</w:p>")
+      |
+      v
+xml-lexer            → Vec<Token>            (grammar-driven tokenizer)
+      |
+      v
+xml.grammar          → ParserGrammar         (structural nesting rules)
+      |
+      v
+parser::GrammarParser → GrammarASTNode tree  (generic rule/token tree)
+      |
+      v
+xml-parser (this crate) → XmlDocument         (namespaces + entities + typing)
+```
+
+## Historical & standards context
+
+XML (Extensible Markup Language, W3C, 1998) is a text format for tree-shaped
+data. It descends from SGML (1986) but is far simpler. Two later companion
+specs matter here:
+
+- **Namespaces in XML** (1999) — lets documents mix vocabularies without name
+  collisions by binding short *prefixes* to long *URIs*.
+- **ISO/IEC 29500 (OOXML, 2006)** and its packaging layer **OPC** — the format
+  behind modern Word / Excel / PowerPoint files. A `.docx` is a ZIP whose
+  entries are XML parts glued together by relationship (`.rels`) files and a
+  central `[Content_Types].xml` manifest.
+
+M1 targets exactly the XML subset OPC uses. It has **no DTD support**, so the
+only named entities it decodes are the five predefined ones. That is a
+deliberate scope cut, not an oversight.
+
+## Why the grammar can't do everything
+
+A context-free grammar (which is what `GrammarParser` consumes) can describe
+*nesting* — "a start tag, then content, then an end tag" — but it cannot
+express three things that XML requires:
+
+1. **End-tag name matching.** "`<a>` must be closed by `</a>`" is a
+   context-*sensitive* constraint (the two names must be *equal*). The grammar
+   accepts `<a>...</b>` structurally; the AST builder rejects it.
+2. **Namespace resolution.** Binding a prefix to a URI depends on `xmlns`
+   declarations that are in scope — runtime state a grammar has no notion of.
+3. **Entity decoding.** `&amp;` → `&`, `&#65;` → `A`. The lexer emits entity
+   references as separate, *undecoded* tokens on purpose.
+
+So the grammar stays purely structural, and the builder owns everything
+stateful. This mirrors how the other front-ends in the repo split "shape"
+(grammar) from "meaning" (builder).
+
+## The grammar (`code/grammars/xml.grammar`)
+
+```ebnf
+document          = { misc } element { misc } ;
+misc              = pi | comment ;
+element           = empty_element | container_element ;
+empty_element     = OPEN_TAG_START TAG_NAME { attribute } SELF_CLOSE ;
+container_element = OPEN_TAG_START TAG_NAME { attribute } TAG_CLOSE
+                    { content }
+                    CLOSE_TAG_START TAG_NAME TAG_CLOSE ;
+attribute         = TAG_NAME ATTR_EQUALS ATTR_VALUE ;
+content           = element | comment | cdata | pi | CHAR_REF | ENTITY_REF | TEXT ;
+comment           = COMMENT_START [ COMMENT_TEXT ] COMMENT_END ;
+cdata             = CDATA_START [ CDATA_TEXT ] CDATA_END ;
+pi                = PI_START PI_TARGET [ PI_TEXT ] PI_END ;
+```
+
+Design notes:
+
+- **Distinct first tokens.** Every `content` alternative begins with a unique
+  token (`OPEN_TAG_START`, `COMMENT_START`, `CDATA_START`, `PI_START`,
+  `CHAR_REF`, `ENTITY_REF`, `TEXT`), so the backtracking packrat parser never
+  looks far ahead and never mis-commits.
+- **Empty forms parse.** `COMMENT_TEXT`, `CDATA_TEXT`, and `PI_TEXT` are
+  optional so `<!---->`, `<![CDATA[]]>`, and `<?t?>` are well-formed.
+- **The XML declaration is a PI.** `<?xml version="1.0"?>` is lexed as a `pi`
+  whose `PI_TARGET` is `"xml"`. The builder special-cases that target: it lifts
+  `version` / `encoding` onto the document instead of storing a PI node.
+
+`src/_grammar.rs` is generated from this file by the Rust `grammar-tools` CLI
+(see the regen command in that file's header) and is checked in.
+
+## The AST (`src/ast.rs`)
+
+```rust
+struct XmlDocument { root: XmlElement, version: Option<String>, encoding: Option<String> }
+
+struct XmlElement {
+    namespace_uri: Option<String>,   // resolved URI, or None = no namespace
+    local_name: String,              // name after the prefix
+    attributes: Vec<XmlAttribute>,
+    children: Vec<XmlNode>,
+}
+
+struct XmlAttribute { namespace_uri: Option<String>, local_name: String, value: String }
+
+enum XmlNode {
+    Element(Box<XmlElement>),
+    Text(String),                    // entity-decoded
+    CData(String),                   // verbatim (NOT decoded)
+    Comment(String),
+    ProcessingInstruction { target: String, text: String },
+}
+
+struct ParseError { message: String, line: Option<usize>, column: Option<usize> }
+```
+
+`XmlElement` provides the navigation helpers a package reader needs:
+
+| Method | Returns |
+|--------|---------|
+| `get_child(uri, local)`    | first *direct child element* with that resolved name |
+| `get_children(uri, local)` | all such direct children, in order |
+| `get_attr(uri, local)`     | that attribute's decoded value |
+| `text_content()`           | concatenated descendant text + CDATA |
+
+In every case `uri = None` means "in no namespace" and `uri = Some("…")`
+requires that exact URI.
+
+## Namespace resolution rules (`src/namespace.rs`)
+
+A `NamespaceStack` holds one `HashMap<prefix, uri>` frame per open element.
+On entering a start tag the builder collects that tag's `xmlns` /
+`xmlns:prefix` declarations, pushes a frame, resolves names, builds children,
+then pops. Resolution walks frames innermost-first, so an inner declaration
+**shadows** an outer one.
+
+The subtle rules, all tested:
+
+- **Default namespace applies to elements, not unprefixed attributes.** Inside
+  `<r xmlns="U" a="1">`, the element `r` is in namespace `U`, but attribute `a`
+  is in **no** namespace. This asymmetry is in the Namespaces spec and is
+  exactly what OPC relies on (its attributes like `PartName`, `Extension`,
+  `Target` are all unprefixed and thus namespace-free).
+- **URIs are case-sensitive.** `http://x/NS` ≠ `http://x/ns`.
+- **Reserved prefixes.** `xml` and `xmlns` are always bound and never declared.
+- **Unbound prefix is an error.**
+
+## Entity decoding
+
+`decode_entities` handles the five predefined entities plus numeric character
+references:
+
+| Reference | Decodes to |
+|-----------|------------|
+| `&amp;` `&lt;` `&gt;` `&apos;` `&quot;` | `& < > ' "` |
+| `&#N;`  (decimal) | Unicode code point `N` |
+| `&#xH;` (hex)     | Unicode code point `0xH` |
+
+Applied to `TEXT` and to attribute values (after quote-stripping). **CDATA is
+never decoded** — its purpose is to hold `<` and `&` literally.
+
+## Known limitation inherited from the lexer
+
+The `xml-lexer` skips whitespace that sits *between* tokens in the default
+group. As a consequence, a space that immediately follows an entity reference
+in mixed text (e.g. the space in `a &amp; b`) is consumed by the lexer before
+the following `TEXT` token begins, so it does not reach the parser. Whitespace
+*inside* a single text run (`a  b`) is preserved. This is a lexer-layer
+behavior, out of scope for M1; the parser faithfully decodes and concatenates
+whatever tokens it is handed. OPC part files are element-structured with no
+significant mixed-content whitespace, so this does not affect the M1 goal.
+
+## Public API (`src/lib.rs`)
+
+```rust
+pub fn create_xml_parser(source: &str) -> GrammarParser;   // raw generic tree
+pub fn parse_xml(source: &str) -> Result<XmlDocument, ParseError>;
+pub use ast::{ParseError, XmlAttribute, XmlDocument, XmlElement, XmlNode};
+pub use namespace::{XML_NAMESPACE, XMLNS_NAMESPACE};
+```
+
+`parse_xml` tokenizes through the *fallible* lexer path so a lexer-level
+problem (a stray `&`) becomes a `ParseError` with position rather than a
+panic. `create_xml_parser` keeps the standard (panicking) glue shape shared by
+the repo's other `*-parser` crates, for callers who want the raw tree.
+
+## Robustness: bounded recursion
+
+XML nests without limit (`element → content → element`), and the recursive-
+descent parser recurses once per level. A native stack overflow is an
+**uncatchable abort** — no `Result` can report it — so on untrusted input (the
+whole point of an OOXML reader) an unbounded parser is a one-line denial of
+service: a few kilobytes of `<a><a>…` crashes the host process.
+
+Both entry points therefore opt into the parser's recursion-depth cap,
+`with_max_depth(DEFAULT_MAX_RULE_DEPTH)` (128 — comfortably below the overflow
+point and far above any real document's nesting). Over-deep input surfaces as a
+normal `ParseError`. This is the "decode liberally, but never trust depth"
+counterpart to the deflate crate's decompression-bomb cap.
+
+## Testing
+
+46 unit tests plus a doc-test, targeting 95%+ coverage of a library:
+
+- structure: simple, self-closing, empty, nested, mixed content;
+- attributes: both quote styles, order, absence;
+- namespaces: default, prefixed element + prefixed attribute → URI,
+  unprefixed-attr-is-namespace-free, nested scoping + shadowing, case
+  sensitivity, reserved `xml` prefix, unbound-prefix error;
+- entities: named in text and attributes, decimal + hex char refs, unknown
+  entity error, bare-`&` error;
+- CDATA verbatim (and empty), comments (and empty, and leading);
+- XML declaration version + encoding, processing instructions;
+- whitespace handling;
+- well-formedness errors: mismatched tags, unclosed element, empty input;
+- the factory function and `ParseError` `Display`;
+- two OOXML-flavoured integration tests: a `[Content_Types].xml` with
+  `Default` / `Override` entries in the OPC content-types namespace, and a
+  `.rels` document — asserting `get_child(Some(uri), …)` and
+  `get_attr(None, …)`.
+
+## Where this sits in the OOXML effort
+
+- **M1 (this):** `xml-parser` — namespace-aware AST. ✅
+- **M2 (next):** OPC package reader — unzip a `.docx`, parse
+  `[Content_Types].xml` + `.rels` with this crate, resolve parts.
+- Beyond: WordprocessingML / SpreadsheetML part models on top of the OPC layer.


### PR DESCRIPTION
## Summary

**Milestone 1 of the OOXML effort.** An OOXML package is a ZIP of XML *parts*; M0 taught us to unzip real files, and this adds the layer that turns those parts into structured data. New `coding-adventures-xml-parser` crate parses XML into a **namespace-aware, entity-decoded AST**, reusing the repo's `xml-lexer` + generic `GrammarParser` (grammar-driven — no hand-written lexer/parser, per repo convention).

## What ships

- **`code/grammars/xml.grammar`** — parser grammar (documents, elements, attributes, mixed content, comments, CDATA, PIs), compiled to `src/_grammar.rs` via the `grammar-tools` CLI.
- **Spec `code/specs/XML01-xml-parser.md`** (spec-first).
- **Parser layer** owns what the lexer can't: namespace binding by URI via a scope stack (default namespace applies to elements, **not** unprefixed attributes; reserved `xml`/`xmlns` prefixes; unbound-prefix → error), entity/char-reference decoding for text and attribute values (`&amp;`/`&lt;`/`&gt;`/`&apos;`/`&quot;`/`&#N;`/`&#xH;`; CDATA verbatim), and lifting the `<?xml?>` declaration's `version`/`encoding` onto the document.
- **AST** (`XmlDocument`/`XmlElement`/`XmlAttribute`/`XmlNode`) with `get_child`/`get_children`/`get_attr`/`text_content` — shaped for OPC lookup by namespaced name. Two OOXML-flavoured integration tests parse a real `[Content_Types].xml` and a `.rels` file.

## Security — recursion-depth cap (found and fixed pre-merge)

An adversarial review of the crate found a **HIGH** issue and empirically reproduced it: `GrammarParser::new` defaults its depth cap to `usize::MAX`, and XML nests without bound, so a few KB of `<a><a>…` recurses past the native stack and **aborts the process** — an *uncatchable* stack-overflow DoS reachable straight from `parse_xml` on untrusted OOXML. Fixed by enabling the parser's existing backstop `with_max_depth(DEFAULT_MAX_RULE_DEPTH)` (128) at **both** entry points; over-deep input now returns a `ParseError`. Regression-tested at 20 000 levels (the test would `SIGABRT`, not fail, if the cap regressed). This is the parser-side analogue of the deflate crate's decompression-bomb cap.

## Test plan

- [x] 73 unit tests + 1 doc-test pass; `cargo build` warning-free
- [x] Covers: structure, attributes (both quote styles), nested/mixed content, default + prefixed namespaces, unprefixed-attr-not-in-default-ns, entity + char refs (dec/hex), CDATA verbatim, comments, PIs, XML declaration, whitespace, well-formedness errors, the recursion-depth guard, and OOXML `[Content_Types].xml` / `.rels` samples
- [x] Adversarial security review (only finding — the recursion DoS — fixed + regression-tested; `strip_quotes`, entity decode, slicing, no `unsafe`, no ReDoS all verified safe)

## Notes

- Filed a chip for the **same latent gap in `json-parser`** (it also calls `GrammarParser::new` without the depth cap).
- Next (M2): OPC package reader — unzip a `.docx`/`.xlsx`, parse `[Content_Types].xml` + `.rels` with this crate, resolve parts by relationship. Then SpreadsheetML value extraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)