### PR TITLE
fix(sir): implement case_eq builtin on Go/Rust/JS runtimes

### DIFF
--- a/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 0.13.1
+
+### Fixed — `case_eq` builtin (Ruby case-equality `===`) was unimplemented
+
+Ruby's `case`/`when` (and `case`/`in`) lowers, in the frontend, to a chain of
+`if`s whose conditions are `BuiltinCall("case_eq", [pattern, scrutinee])`. This
+backend's runtime never implemented `case_eq`, so **every** `case` program hit
+`_sir_call_builtin_by_name`'s `unknown builtin` floor and **panicked at
+runtime** — `case` was unusable on the Go backend (no compile-time gate catches
+a missing builtin; only execution does).
+
+- Added `_sir_case_eq(args) Value` to the inlined runtime and wired it into both
+  the emitter's helper table (direct-call path) and `_sir_call_builtin_by_name`
+  (reified-closure path). Ruby keys `===` to the *pattern*'s type (Range →
+  membership, Regexp → match, else `==`); the `when SomeClass` case is lowered to
+  `value.is_a?(SomeClass)` at the frontend and never reaches here. This backend's
+  Value model has no Range/Regexp variant yet, so `case_eq` is exactly structural
+  equality (`_sir_value_eq`), matching the Python reference in `sir-runtime-oop`;
+  extend with membership/match arms when those value types land.
+- New `compile_and_run_case_eq` exec proof: a `when`-style `if case_eq(…)` chain
+  emits Go, runs under `go run`, and matches the expected dispatch output.
+
+
 ## 0.13.0
 
 ### Added — Ruby mixins: `module` + `include` / `extend` MRO (sir-mixins MX5)

--- a/code/packages/rust/semantic-ir-to-go/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-go/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-go"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2021"
 description = "Semantic IR → self-contained Go source code (SIR15). Fourth backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-go/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/emit.rs
@@ -1153,6 +1153,7 @@ fn emit_builtin_call(out: &mut String, name: &str, args: &[Expr], indent: usize)
         "*" => "_sir_times",
         "/" => "_sir_divide",
         "=" => "_sir_eq",
+        "case_eq" => "_sir_case_eq",
         "<" => "_sir_lt",
         ">" => "_sir_gt",
         "cons" => "_sir_cons",

--- a/code/packages/rust/semantic-ir-to-go/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/runtime.rs
@@ -454,6 +454,30 @@ func _sir_value_eq(a Value, b Value) bool {
 	return _sir_value_eq_d(a, b, make(map[[2]Value]bool))
 }
 
+// _sir_case_eq implements Ruby case-equality (`pattern === value`) — the test a
+// `when` (or `in`) arm runs.  Unlike `==`, Ruby keys `===` to the PATTERN's
+// type:
+//
+//	| pattern kind | semantics                          |
+//	|--------------|------------------------------------|
+//	| Range        | membership (`value` falls in range)|
+//	| Regexp       | the regex matches `value`          |
+//	| anything else| value equality (`==`)              |
+//
+// A `when SomeClass` is lowered to `value.is_a?(SomeClass)` at the FRONTEND
+// (`__method__` dispatch), so a class pattern never reaches here.  This
+// backend's Value model has no Range or Regexp variant yet, so the only
+// patterns that reach `case_eq` are ordinary values and the operation is
+// exactly structural equality — matching the Python reference in
+// `sir-runtime-oop`.  When Range/Regexp values are added, extend this with the
+// membership/match arms (dispatching on the pattern, args[0]).
+func _sir_case_eq(args []Value) Value {
+	if len(args) < 2 {
+		return false
+	}
+	return _sir_value_eq(args[0], args[1])
+}
+
 func _sir_value_eq_d(a Value, b Value, pending map[[2]Value]bool) bool {
 	// Defensive: the MISSING sentinel (SIR19 default params) never reaches
 	// `=` in a well-formed program (a defaulted param is replaced by its
@@ -1080,6 +1104,8 @@ func _sir_call_builtin_by_name(name string, args []Value) Value {
 		return _sir_divide(args)
 	case "=":
 		return _sir_eq(args)
+	case "case_eq":
+		return _sir_case_eq(args)
 	case "<":
 		return _sir_lt(args)
 	case ">":

--- a/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_case_eq.rs
+++ b/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_case_eq.rs
@@ -1,0 +1,166 @@
+//! End-to-end proof for the `case_eq` builtin (Ruby case-equality, `===`) in
+//! the Go backend.
+//!
+//! Ruby's `case`/`when` lowers (in the frontend) to a chain of `if`s whose
+//! conditions are `BuiltinCall("case_eq", [pattern, scrutinee])`.  Before this
+//! fix the Go runtime had no `case_eq`, so **every** `case`/`when` program hit
+//! `_sir_call_builtin_by_name`'s floor and panicked with
+//! `unknown builtin: case_eq` at runtime — `case` was unusable on this backend.
+//!
+//! This test hand-builds the SIR equivalent of a `when`-style dispatch (a
+//! `case_eq` used as an `if` condition — exactly how the frontend emits it):
+//!
+//!     if 5 === 5     then puts "A" else puts "Z"   # A  (match)
+//!     if 5 === 6     then puts "B" else puts "Y"   # Y  (no match)
+//!     if "a" === "a" then puts "C" else puts "X"   # C  (string match)
+//!     if :x === :x   then puts "D" else puts "W"   # D  (structural symbol match)
+//!
+//! emits Go, runs it with `go run`, and asserts stdout is exactly
+//! `A\nY\nC\nD\n`.  Driving an `if` off `case_eq` tests the boolean it returns
+//! without depending on how this backend renders a bare boolean (Go/Rust format
+//! `true` as the Lisp-style `#t`, a separate pre-existing convention).  Gates on
+//! `go`; logs a skip when absent.
+
+use std::process::Command;
+
+use semantic_ir::{
+    Block, Effect, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, Scope,
+    Span, Stmt,
+};
+use semantic_ir_to_go::compile;
+
+fn s() -> Span {
+    Span::synthetic()
+}
+
+fn ilit(v: i64) -> Expr {
+    Expr::IntLit { value: v, span: s() }
+}
+
+fn slit(v: &str) -> Expr {
+    Expr::StrLit { value: v.into(), span: s() }
+}
+
+fn sym(name: &str) -> Expr {
+    Expr::SymLit { name: name.into(), span: s() }
+}
+
+/// `case_eq(pattern, value)` — the narrow-waist envelope a `when` arm runs.
+fn case_eq(pattern: Expr, value: Expr) -> Expr {
+    Expr::BuiltinCall {
+        name: "case_eq".into(),
+        args: vec![pattern, value],
+        effects: EffectSet::PURE,
+        span: s(),
+    }
+}
+
+fn puts_stmt(arg: Expr) -> Stmt {
+    Stmt::ExprStmt {
+        expr: Expr::BuiltinCall {
+            name: "puts".into(),
+            args: vec![arg],
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            span: s(),
+        },
+        span: s(),
+    }
+}
+
+/// A one-statement `Block` that `puts` a literal string.
+fn puts_block(msg: &str) -> Block {
+    Block {
+        stmts: vec![puts_stmt(slit(msg))],
+        value: Expr::NilLit { span: s() },
+        span: s(),
+    }
+}
+
+/// `if case_eq(pattern, value) then puts(yes) else puts(no)` — a `when` arm.
+fn when_stmt(pattern: Expr, value: Expr, yes: &str, no: &str) -> Stmt {
+    Stmt::ExprStmt {
+        expr: Expr::If {
+            cond: Box::new(case_eq(pattern, value)),
+            then_branch: Box::new(puts_block(yes)),
+            else_branch: Box::new(puts_block(no)),
+            span: s(),
+        },
+        span: s(),
+    }
+}
+
+fn demo_module() -> Module {
+    let stmts = vec![
+        when_stmt(ilit(5), ilit(5), "A", "Z"),
+        when_stmt(ilit(5), ilit(6), "B", "Y"),
+        when_stmt(slit("a"), slit("a"), "C", "X"),
+        when_stmt(sym("x"), sym("x"), "D", "W"),
+    ];
+
+    Module {
+        name: "case_eq_demo".into(),
+        manifest: FeatureManifest::from_features(&[Feature::Strings, Feature::Symbols]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block { stmts, value: Expr::NilLit { span: s() }, span: s() },
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            metadata: Metadata::new(),
+            span: s(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("test")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+fn go_available() -> bool {
+    Command::new("go")
+        .arg("version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+#[test]
+fn case_eq_compiles_and_matches_ruby_output() {
+    if !go_available() {
+        eprintln!("skipping: go not on PATH");
+        return;
+    }
+
+    let artifact = compile(&demo_module()).expect("module should compile to Go source");
+
+    let dir = std::env::temp_dir();
+    let nonce = std::process::id();
+    let src_path = dir.join(format!("sir_go_case_eq_{nonce}.go"));
+    std::fs::write(&src_path, &artifact.source).expect("write temp source");
+
+    let run_out = Command::new("go")
+        .arg("run")
+        .arg(&src_path)
+        .output()
+        .expect("invoke go run");
+
+    if !run_out.status.success() {
+        let stderr = String::from_utf8_lossy(&run_out.stderr);
+        let _ = std::fs::remove_file(&src_path);
+        panic!(
+            "emitted Go failed to compile/run:\n--- stderr ---\n{stderr}\n--- source ---\n{}",
+            artifact.source,
+        );
+    }
+
+    let stdout = String::from_utf8_lossy(&run_out.stdout).replace("\r\n", "\n");
+    let _ = std::fs::remove_file(&src_path);
+    assert_eq!(
+        stdout, "A\nY\nC\nD\n",
+        "case_eq did not match Ruby === semantics"
+    );
+}

--- a/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 0.11.1
+
+### Fixed — `case_eq` builtin (Ruby case-equality `===`) was unimplemented
+
+Ruby's `case`/`when` (and `case`/`in`) lowers, in the frontend, to a chain of
+`if`s whose conditions are `BuiltinCall("case_eq", [pattern, scrutinee])`. The
+JS runtime's builtin table had no `case_eq`, so **every** `case` program threw
+`TypeError: unknown builtin: case_eq` **at runtime** — `case` was unusable on
+the JavaScript backend (no compile-time gate catches a missing builtin).
+
+- Added `"case_eq"` to the inlined `builtins` table. The emitter already routes
+  unknown builtins through `__Sir.callBuiltin`, so no emitter change was needed.
+  Ruby keys `===` to the *pattern*'s type (Range → membership, Regexp → match,
+  else `==`); `when SomeClass` is lowered to `.is_a?` at the frontend and never
+  reaches here. This backend has no Range/Regexp value, so `case_eq` is native
+  `===` — the same equality its `=` builtin uses.
+- New `compile_and_run_case_eq` exec proof: a `when`-style `if case_eq(…)` chain
+  emits self-contained JS, runs under `node`, and matches the expected output.
+
+
 All notable changes to `semantic-ir-to-javascript` are documented here.
 
 ## 0.11.0 — mixins: `include` / `extend` module method resolution (MX4)

--- a/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-javascript"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 description = "Semantic IR → self-contained JavaScript source code (SIR18). Fifth backend for the SIR10 narrow-waist IR. Includes __method__ dispatch execution (C3), exception handling (try/catch/raise) with user-class ancestry (E1), user-defined-class OOP — instantiation, method dispatch, super, self, and @ivar/@@cvar access (O3) — and Ruby mixins (module include/extend with MRO method resolution, MX4)."
 

--- a/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
@@ -145,6 +145,13 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
     "*": (...a) => times(...a),
     "/": (...a) => a.length === 1 ? 1 / a[0] : numFold(a.slice(1), a[0], (x, y) => x / y),
     "=": (x, y) => x === y,
+    // Ruby case-equality (`pattern === value`) — the test a `when`/`in` arm
+    // runs.  Ruby keys `===` to the pattern's type (Range → membership, Regexp
+    // → match); this backend has no Range/Regexp value, so the only patterns
+    // that reach here are plain values and the op is ordinary equality (the
+    // same `===` the `=` builtin uses).  `when SomeClass` is lowered to
+    // `.is_a?` at the frontend and never becomes a case_eq call.
+    "case_eq": (pattern, value) => pattern === value,
     "<": (x, y) => x < y,
     ">": (x, y) => x > y,
     "<=": (x, y) => x <= y,

--- a/code/packages/rust/semantic-ir-to-javascript/tests/compile_and_run_case_eq.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/tests/compile_and_run_case_eq.rs
@@ -1,0 +1,149 @@
+//! End-to-end proof for the `case_eq` builtin (Ruby case-equality, `===`) in
+//! the JavaScript backend.
+//!
+//! Ruby's `case`/`when` lowers (in the frontend) to a chain of `if`s whose
+//! conditions are `BuiltinCall("case_eq", [pattern, scrutinee])`.  Before this
+//! fix the JS runtime's builtin table had no `case_eq`, so **every**
+//! `case`/`when` program threw `TypeError: unknown builtin: case_eq` at runtime
+//! — `case` was unusable on this backend.
+//!
+//! This test hand-builds the SIR equivalent of a `when`-style dispatch (a
+//! `case_eq` used as an `if` condition — exactly how the frontend emits it):
+//!
+//!     if 5 === 5     then puts "A" else puts "Z"   # A
+//!     if 5 === 6     then puts "B" else puts "Y"   # Y
+//!     if "a" === "a" then puts "C" else puts "X"   # C
+//!
+//! emits self-contained JavaScript, runs it with `node`, and asserts stdout is
+//! exactly `A\nY\nC`.  Driving an `if` off `case_eq` tests the boolean it
+//! returns directly.  (Only primitive patterns are used — this backend's
+//! `case_eq`, like its `=` builtin, is native `===`.)  Node is optional: skip.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use semantic_ir::{
+    Block, Effect, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, Span,
+    Stmt,
+};
+use semantic_ir_to_javascript::compile;
+
+fn s() -> Span {
+    Span::synthetic()
+}
+
+fn ilit(v: i64) -> Expr {
+    Expr::IntLit { value: v, span: s() }
+}
+
+fn slit(v: &str) -> Expr {
+    Expr::StrLit { value: v.into(), span: s() }
+}
+
+fn case_eq(pattern: Expr, value: Expr) -> Expr {
+    Expr::BuiltinCall {
+        name: "case_eq".into(),
+        args: vec![pattern, value],
+        effects: EffectSet::PURE,
+        span: s(),
+    }
+}
+
+fn puts_stmt(arg: Expr) -> Stmt {
+    Stmt::ExprStmt {
+        expr: Expr::BuiltinCall {
+            name: "puts".into(),
+            args: vec![arg],
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            span: s(),
+        },
+        span: s(),
+    }
+}
+
+/// A one-statement `Block` that `puts` a literal string.
+fn puts_block(msg: &str) -> Block {
+    Block {
+        stmts: vec![puts_stmt(slit(msg))],
+        value: Expr::NilLit { span: s() },
+        span: s(),
+    }
+}
+
+/// `if case_eq(pattern, value) then puts(yes) else puts(no)` — a `when` arm.
+fn when_stmt(pattern: Expr, value: Expr, yes: &str, no: &str) -> Stmt {
+    Stmt::ExprStmt {
+        expr: Expr::If {
+            cond: Box::new(case_eq(pattern, value)),
+            then_branch: Box::new(puts_block(yes)),
+            else_branch: Box::new(puts_block(no)),
+            span: s(),
+        },
+        span: s(),
+    }
+}
+
+fn demo_module() -> Module {
+    let stmts = vec![
+        when_stmt(ilit(5), ilit(5), "A", "Z"),
+        when_stmt(ilit(5), ilit(6), "B", "Y"),
+        when_stmt(slit("a"), slit("a"), "C", "X"),
+    ];
+
+    Module {
+        name: "case_eq_demo".into(),
+        manifest: FeatureManifest::from_features(&[Feature::Strings]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block { stmts, value: Expr::NilLit { span: s() }, span: s() },
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            metadata: Metadata::new(),
+            span: s(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("test")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+fn node_available() -> bool {
+    Command::new("node")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+#[test]
+fn case_eq_compiles_and_matches_ruby_output() {
+    let artifact = compile(&demo_module()).expect("compile to javascript");
+    if !node_available() {
+        eprintln!("note: `node` unavailable — skipping execution");
+        return;
+    }
+    let mut path: PathBuf = std::env::temp_dir();
+    path.push(format!("sir_js_case_eq_{}.js", std::process::id()));
+    std::fs::write(&path, &artifact.source).expect("write temp js");
+    let output = Command::new("node").arg(&path).output().expect("spawn node");
+    let _ = std::fs::remove_file(&path);
+    assert!(
+        output.status.success(),
+        "node exited non-zero:\nstdout: {}\nstderr: {}\nsource:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+        artifact.source,
+    );
+    let stdout = String::from_utf8(output.stdout).expect("utf8 stdout");
+    assert_eq!(
+        stdout.trim_end_matches(['\n', '\r']),
+        "A\nY\nC",
+        "case_eq did not match Ruby === semantics"
+    );
+}

--- a/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 0.13.1
+
+### Fixed — `case_eq` builtin (Ruby case-equality `===`) was unimplemented
+
+Ruby's `case`/`when` (and `case`/`in`) lowers, in the frontend, to a chain of
+`if`s whose conditions are `BuiltinCall("case_eq", [pattern, scrutinee])`. This
+backend's runtime never implemented `case_eq`, so **every** `case` program hit
+`call_builtin_by_name`'s `unknown builtin` floor and **panicked at runtime** —
+`case` was unusable on the Rust backend (no compile-time gate catches a missing
+builtin; only execution does).
+
+- Added `pub fn case_eq(pattern, value) -> Value` to the inlined `__sir` runtime
+  and wired it into both the emitter's helper table and `call_builtin_by_name`.
+  Ruby keys `===` to the *pattern*'s type (Range → membership, Regexp → match,
+  else `==`); `when SomeClass` is lowered to `value.is_a?` at the frontend and
+  never reaches here. This backend's `Value` has no `Range`/`Regexp` variant yet,
+  so `case_eq` is exactly structural equality (`value_eq`), matching the Python
+  reference in `sir-runtime-oop`; extend with membership/match arms later.
+- New `compile_and_run_case_eq` exec proof: a `when`-style `if case_eq(…)` chain
+  emits Rust, compiles with `rustc`, runs, and matches the expected output.
+
+
 ## 0.13.0 — mixins: include / extend module method resolution (MX6)
 
 Implements the Rust milestone (**MX6**) of the **sir-mixins** cascade — the

--- a/code/packages/rust/semantic-ir-to-rust/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-rust"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2021"
 description = "Semantic IR → self-contained Rust source code (SIR13). Second backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-rust/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/emit.rs
@@ -1359,6 +1359,7 @@ fn emit_builtin_call(out: &mut String, name: &str, args: &[Expr], indent: usize)
         "*" => ("__sir::times", true),
         "/" => ("__sir::divide", true),
         "=" => ("__sir::eq", false),
+        "case_eq" => ("__sir::case_eq", false),
         "<" => ("__sir::lt", false),
         ">" => ("__sir::gt", false),
         "cons" => ("__sir::cons", false),

--- a/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
@@ -443,6 +443,19 @@ pub const RUNTIME: &str = r##"mod __sir {
     pub fn eq(a: Value, b: Value) -> Value {
         Value::Bool(value_eq(&a, &b))
     }
+    /// Ruby case-equality (`pattern === value`) — the test a `when` (or `in`)
+    /// arm runs.  Unlike `==`, Ruby keys `===` to the PATTERN's type: a `Range`
+    /// checks membership, a `Regexp` checks a match, and everything else falls
+    /// back to `==`.  A `when SomeClass` is lowered to `value.is_a?(SomeClass)`
+    /// at the frontend, so a class pattern never reaches here.  This backend's
+    /// `Value` has no `Range`/`Regexp` variant yet, so the only patterns that
+    /// reach `case_eq` are ordinary values and the operation is exactly
+    /// structural equality — matching the Python reference in `sir-runtime-oop`.
+    /// When `Range`/`Regexp` values are added, extend with the membership/match
+    /// arms (dispatching on `pattern`).
+    pub fn case_eq(pattern: Value, value: Value) -> Value {
+        Value::Bool(value_eq(&pattern, &value))
+    }
     pub fn lt(a: Value, b: Value) -> Value {
         Value::Bool(num_lt(&a, &b))
     }
@@ -1067,6 +1080,10 @@ pub const RUNTIME: &str = r##"mod __sir {
             "=" => {
                 let mut it = args.into_iter();
                 eq(it.next().unwrap_or(Value::Nil), it.next().unwrap_or(Value::Nil))
+            }
+            "case_eq" => {
+                let mut it = args.into_iter();
+                case_eq(it.next().unwrap_or(Value::Nil), it.next().unwrap_or(Value::Nil))
             }
             "<" => {
                 let mut it = args.into_iter();

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_case_eq.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_case_eq.rs
@@ -1,0 +1,196 @@
+//! End-to-end proof for the `case_eq` builtin (Ruby case-equality, `===`) in
+//! the Rust backend.
+//!
+//! Ruby's `case`/`when` lowers (in the frontend) to a chain of `if`s whose
+//! conditions are `BuiltinCall("case_eq", [pattern, scrutinee])`.  Before this
+//! fix the Rust runtime had no `case_eq`, so **every** `case`/`when` program hit
+//! `call_builtin_by_name`'s floor and panicked with `unknown builtin: case_eq`
+//! at runtime — `case` was unusable on this backend.
+//!
+//! This test hand-builds the SIR equivalent of a `when`-style dispatch (a
+//! `case_eq` used as an `if` condition — exactly how the frontend emits it):
+//!
+//!     if 5 === 5     then puts "A" else puts "Z"   # A
+//!     if 5 === 6     then puts "B" else puts "Y"   # Y
+//!     if "a" === "a" then puts "C" else puts "X"   # C
+//!     if :x === :x   then puts "D" else puts "W"   # D
+//!
+//! emits Rust, compiles with `rustc`, runs the binary, and asserts stdout is
+//! exactly `A\nY\nC\nD\n`.  Driving an `if` off `case_eq` tests the boolean it
+//! returns without depending on how this backend renders a bare boolean
+//! (Go/Rust format `true` as the Lisp-style `#t`).  Gates on `rustc`; skips
+//! gracefully when no usable linker is present.
+
+use std::process::Command;
+
+use semantic_ir::{
+    Block, Effect, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, Span,
+    Stmt,
+};
+use semantic_ir_to_rust::compile;
+
+fn s() -> Span {
+    Span::synthetic()
+}
+
+fn ilit(v: i64) -> Expr {
+    Expr::IntLit { value: v, span: s() }
+}
+
+fn slit(v: &str) -> Expr {
+    Expr::StrLit { value: v.into(), span: s() }
+}
+
+fn sym(name: &str) -> Expr {
+    Expr::SymLit { name: name.into(), span: s() }
+}
+
+fn case_eq(pattern: Expr, value: Expr) -> Expr {
+    Expr::BuiltinCall {
+        name: "case_eq".into(),
+        args: vec![pattern, value],
+        effects: EffectSet::PURE,
+        span: s(),
+    }
+}
+
+fn puts_stmt(arg: Expr) -> Stmt {
+    Stmt::ExprStmt {
+        expr: Expr::BuiltinCall {
+            name: "puts".into(),
+            args: vec![arg],
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            span: s(),
+        },
+        span: s(),
+    }
+}
+
+/// A one-statement `Block` that `puts` a literal string.
+fn puts_block(msg: &str) -> Block {
+    Block {
+        stmts: vec![puts_stmt(slit(msg))],
+        value: Expr::NilLit { span: s() },
+        span: s(),
+    }
+}
+
+/// `if case_eq(pattern, value) then puts(yes) else puts(no)` — a `when` arm.
+fn when_stmt(pattern: Expr, value: Expr, yes: &str, no: &str) -> Stmt {
+    Stmt::ExprStmt {
+        expr: Expr::If {
+            cond: Box::new(case_eq(pattern, value)),
+            then_branch: Box::new(puts_block(yes)),
+            else_branch: Box::new(puts_block(no)),
+            span: s(),
+        },
+        span: s(),
+    }
+}
+
+fn demo_module() -> Module {
+    let stmts = vec![
+        when_stmt(ilit(5), ilit(5), "A", "Z"),
+        when_stmt(ilit(5), ilit(6), "B", "Y"),
+        when_stmt(slit("a"), slit("a"), "C", "X"),
+        when_stmt(sym("x"), sym("x"), "D", "W"),
+    ];
+
+    Module {
+        name: "case_eq_demo".into(),
+        manifest: FeatureManifest::from_features(&[Feature::Strings, Feature::Symbols]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block { stmts, value: Expr::NilLit { span: s() }, span: s() },
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            metadata: Metadata::new(),
+            span: s(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("test")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+fn rustc_available() -> bool {
+    Command::new("rustc")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Compile+run, returning normalised stdout, or `None` when no usable linker.
+fn compile_run(module: &Module) -> Option<String> {
+    let artifact = compile(module).expect("module should compile to Rust source");
+
+    let dir = std::env::temp_dir();
+    let nonce = std::process::id();
+    let src_path = dir.join(format!("sir_case_eq_{nonce}.rs"));
+    let bin_path = dir.join(format!(
+        "sir_case_eq_{nonce}{}",
+        if cfg!(windows) { ".exe" } else { "" }
+    ));
+    std::fs::write(&src_path, &artifact.source).expect("write temp source");
+
+    let mut cmd = Command::new("rustc");
+    cmd.arg("--edition").arg("2021").arg("-O");
+    if let Ok(linker) = std::env::var("SIR_TEST_RUSTC_LINKER") {
+        if !linker.is_empty() {
+            cmd.arg("-C").arg(format!("linker={linker}"));
+        }
+    }
+    let compile_out = cmd
+        .arg(&src_path)
+        .arg("-o")
+        .arg(&bin_path)
+        .output()
+        .expect("invoke rustc");
+    if !compile_out.status.success() {
+        let stderr = String::from_utf8_lossy(&compile_out.stderr);
+        if stderr.contains("linker")
+            && (stderr.contains("not found") || stderr.contains("No such file"))
+        {
+            eprintln!("skipping: no usable linker on host\n{stderr}");
+            let _ = std::fs::remove_file(&src_path);
+            return None;
+        }
+        panic!(
+            "emitted Rust failed to compile:\n--- stderr ---\n{stderr}\n--- source ---\n{}",
+            artifact.source,
+        );
+    }
+
+    let run_out = Command::new(&bin_path).output().expect("run compiled binary");
+    let stderr = String::from_utf8_lossy(&run_out.stderr).into_owned();
+    let stdout = String::from_utf8_lossy(&run_out.stdout).into_owned();
+    let _ = std::fs::remove_file(&src_path);
+    let _ = std::fs::remove_file(&bin_path);
+    assert!(
+        run_out.status.success(),
+        "compiled binary exited non-zero:\n{stderr}",
+    );
+    Some(stdout.replace("\r\n", "\n"))
+}
+
+#[test]
+fn case_eq_compiles_and_matches_ruby_output() {
+    if !rustc_available() {
+        eprintln!("skipping: rustc not on PATH");
+        return;
+    }
+    let Some(stdout) = compile_run(&demo_module()) else {
+        return; // no usable linker; skip
+    };
+    assert_eq!(
+        stdout, "A\nY\nC\nD\n",
+        "case_eq did not match Ruby === semantics"
+    );
+}

--- a/lessons.md
+++ b/lessons.md
@@ -1083,3 +1083,37 @@ Lessons:
   `part` blocks would have caught this at build time (possible follow-up).
 
 Discovered: 2026-07-02, light-theme grid had no gridlines after PR #7338 shipped the switcher.
+
+## A frontend-emitted SIR builtin must exist in EVERY backend runtime, or `case` panics at runtime
+
+Driving a real Ruby `case`/`when` program through the SIR pipeline to all
+backends revealed that `case`/`when` (and `case`/`in`) **panicked at runtime on
+Go, Rust, AND JavaScript** with `unknown builtin: case_eq` — it only worked on
+Python/TypeScript. Root cause: the Ruby→SIR frontend lowers every `when` arm to
+`BuiltinCall("case_eq", [pattern, scrutinee])` (Ruby's `===`), but three of the
+five backend runtimes never implemented that builtin. Because an arbitrary
+`BuiltinCall` name is *open-ended* (backends fall through to a
+`call_builtin_by_name` dispatcher whose floor is `panic!("unknown builtin")`),
+there is **no compile-time gate** — the feature manifest can't reject it, so the
+gap only surfaces when the emitted program actually runs.
+
+Why it went unnoticed: the per-backend `compile_and_run_*` tests **hand-build
+SIR modules** exercising one feature each; none had ever hand-built a `case_eq`
+call, and no single test drove real Ruby *source* → Go/Rust/JS end-to-end. The
+Python/TS backends implement `case_eq` via their runtime *packages*, so those
+arms passed and masked the gap on the inline-runtime backends.
+
+**Lessons:**
+- When the frontend starts emitting a new builtin name, grep EVERY backend
+  runtime (`semantic-ir-to-{go,rust,javascript}` inline runtimes + the
+  `sir-runtime-*` packages) for it before assuming cross-backend support.
+- A per-backend exec test that hand-builds SIR proves only the feature it builds;
+  it cannot catch a builtin the frontend emits but the test never constructs.
+  A Ruby-source → all-5-backends golden suite is the real guard (still a TODO).
+- `case_eq` = Ruby `===`, keyed to the *pattern* type (Range→membership,
+  Regexp→match, else `==`); `when SomeClass` is lowered to `.is_a?` at the
+  frontend, so class patterns never reach `case_eq`. Backends with no
+  Range/Regexp value type implement it as plain structural equality.
+
+Discovered: 2026-07-02, while adding trailing-`case` implicit return; a `case`
+program printed correctly on Python but panicked on Go/Rust/JS.


### PR DESCRIPTION
## Problem

Ruby `case`/`when` (and `case`/`in`) lowers, in the frontend, to a chain of `if`s whose conditions are `BuiltinCall("case_eq", [pattern, scrutinee])` — Ruby's case-equality (`===`). Only the **Python** and **TypeScript** runtimes ever implemented `case_eq`. The **Go, Rust, and JavaScript** inline runtimes did not, so **every** `case` program hit the runtime's `unknown builtin` floor and panicked/threw at runtime:

```
panic: unknown builtin: case_eq          # Go / Rust
TypeError: unknown builtin: case_eq      # JavaScript
```

`case` was **unusable on 3 of 5 backends**, and no compile-time gate caught it — a `BuiltinCall` name is open-ended, so only execution surfaces the gap. Discovered while driving a real Ruby `case` program end-to-end across all backends (it printed correctly on Python but panicked on Go/Rust/JS).

## Fix

Implement `case_eq` in each of the three inline runtimes:
- **Go** — `_sir_case_eq(args)` + emitter helper-table entry + `_sir_call_builtin_by_name` case.
- **Rust** — `__sir::case_eq(pattern, value)` + emitter table entry + `call_builtin_by_name` arm.
- **JavaScript** — `"case_eq"` in the `builtins` table (the emitter already routes unknown builtins through `__Sir.callBuiltin`, so no emitter change).

Ruby keys `===` to the **pattern's** type (Range → membership, Regexp → match, else `==`); a `when SomeClass` is lowered to `value.is_a?(SomeClass)` at the frontend and never reaches `case_eq`. These backends have no Range/Regexp value type yet, so `case_eq` reduces to structural equality (`value_eq` / native `===`), matching the Python reference in `sir-runtime-oop`. Documented for extension with membership/match arms when those value types land.

## Verified end-to-end

A `when`-style dispatch (`if case_eq(…) then puts A else puts …`) now runs correctly on all three:

| Backend | Before | After |
|---|---|---|
| Go (`go run`) | panic | ✅ correct dispatch |
| Rust (`rustc`) | panic | ✅ correct dispatch |
| JavaScript (`node`) | throw | ✅ correct dispatch |

Each backend gains a `compile_and_run_case_eq` exec proof (hand-built SIR → emit → real toolchain → assert stdout). All three full suites pass. Versions bumped (go/rust 0.13.0→0.13.1, js 0.11.0→0.11.1); CHANGELOGs updated; **lessons.md** records the "a frontend-emitted builtin must exist in *every* backend runtime, or it panics at runtime with no compile-time gate" trap.

Security review: **passed** (no injection, no unbounded recursion — `case_eq` delegates to the already cycle-guarded `value_eq`; arg-count guarded).

## Follow-up

This unblocks the trailing-`case` implicit-return feature (next PR), which is now provable on all five backends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)