### PR TITLE
feat(adj-lang): symbolic / computed power exponents (x^y, x^{a+b}) in latex "…"

### DIFF
--- a/code/packages/rust/adj-lang/CHANGELOG.md
+++ b/code/packages/rust/adj-lang/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.42.0] - 2026-07-02 — symbolic / computed power exponents (`x^y`, `x^{a+b}`) in `latex "…"`
+
+### Changed
+
+- The `latex "x^n"` power exponent may now be **symbolic or computed**, not just a non-negative integer
+  literal: `x^y` (with `y` observed) computes `x` raised to `y`, and `x^{a+b}` raises to a computed
+  exponent. Both the base and the exponent lower as general expressions to a single native
+  `ComputeOp::Pow`; the engine evaluates the exponent at run time and enforces its own rules — the
+  exponent must be dimensionless and finite, and a non-integer exponent on a dimensioned base is
+  rejected (no fractional dimension) — so a symbolic exponent computes for the dimensionless case and
+  is cleanly rejected otherwise. Numeric exponents (`x^{2}`, `x^{10}`) are unchanged. (Root DEGREES
+  `\sqrt[n]{x}` still require a concrete positive integer, since a symbolic degree cannot form the
+  reciprocal `1/n`.) Removed the now-unused `latex_power_exponent` literal-only validator.
+
 ## [0.41.0] - 2026-07-02 — finite `\sum` / `\prod` unroll in `latex "…"`
 
 ### Added

--- a/code/packages/rust/adj-lang/Cargo.toml
+++ b/code/packages/rust/adj-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang"
-version = "0.41.0"
+version = "0.42.0"
 edition = "2021"
 description = "Surface-syntax frontend for the adjudication framework's probabilistic-logic rulebooks. Lexes, parses, and lowers a domain-expert-readable DSL into a `logic-engine` KnowledgeBase. Dissolves ADJ46 awkwardness items A10 (rulebook syntax) and A4 (joint contributions syntactically distinct)."
 

--- a/code/packages/rust/adj-lang/src/adapter.rs
+++ b/code/packages/rust/adj-lang/src/adapter.rs
@@ -1134,14 +1134,20 @@ fn latex_math_to_expr_ast(expr: &MathExpr, source: &str) -> Result<ExprAst, Adap
             // `x^n` lowers to a single native power node (`ArithOp::Pow` →
             // `ComputeOp::Pow`), not the old parse-time `x*x*…` expansion — so
             // there is no integer-exponent cap and the derivation tree shows one
-            // `^` step. The exponent must still be a non-negative integer literal
-            // (a symbolic exponent like `x^y` is a later slice); the engine
-            // computes it and enforces its own dimensional/overflow rules.
-            let n = latex_power_exponent(exponent, source)?;
+            // `^` step. BOTH the base AND the exponent lower as general expressions,
+            // so the exponent may be a literal (`x^{2}`), a SYMBOLIC/observed value
+            // (`x^y` with `y` observed → `x` raised to `y`), or itself computed
+            // (`x^{a+b}`). The engine's `ComputeOp::Pow` evaluates the exponent at
+            // run time and enforces its own rules — the exponent must be
+            // dimensionless (you cannot raise to a `3 dollars` power) and finite,
+            // and a non-integer exponent on a dimensioned base is rejected (no
+            // fractional dimension) — so a symbolic exponent computes for the
+            // dimensionless (Scalar) case and is cleanly rejected otherwise, with no
+            // adapter-side literal restriction.
             Ok(ExprAst::Bin(
                 ArithOp::Pow,
                 Box::new(latex_math_to_expr_ast(base, source)?),
-                Box::new(ExprAst::Lit(n)),
+                Box::new(latex_math_to_expr_ast(exponent, source)?),
             ))
         }
         // A square root `\sqrt{x}` (a `Root` with no explicit degree) lowers to
@@ -1606,35 +1612,6 @@ fn number_to_lit(number: &Number, source: &str) -> Result<ExprAst, AdapterError>
     Ok(ExprAst::Lit(value))
 }
 
-/// Validate a LaTeX power exponent and return it as a whole-number `f64` (for a
-/// `ExprAst::Lit`). The exponent must be a **non-negative integer literal** — a
-/// symbolic exponent (`x^y`) is not yet supported on the `latex "…"` surface. No
-/// upper bound is imposed now that the base lowers to a single native
-/// `ComputeOp::Pow` node (rather than an `x*x*…` expansion whose tree size grew
-/// with the exponent); the engine computes the power and applies its own
-/// dimensional and overflow (`NonFinite`) guards.
-fn latex_power_exponent(expr: &MathExpr, source: &str) -> Result<f64, AdapterError> {
-    let MathExpr::Number(n) = expr else {
-        return Err(AdapterError::UnsupportedLatexMath {
-            source: source.to_string(),
-            detail: "only non-negative integer exponents are supported in ADJ arithmetic".into(),
-        });
-    };
-    let Some(v) = n.to_f64() else {
-        return Err(AdapterError::UnsupportedLatexMath {
-            source: source.to_string(),
-            detail: format!("exponent is outside f64 range: {}", n.as_written()),
-        });
-    };
-    if !(v.is_finite() && v.fract() == 0.0 && v >= 0.0) {
-        return Err(AdapterError::UnsupportedLatexMath {
-            source: source.to_string(),
-            detail: "only non-negative integer exponents are supported".into(),
-        });
-    }
-    Ok(v)
-}
-
 /// Peel a variadic named-function argument (`\min(a, b)`, `\max(a, b, c)`, …) into
 /// its operand list. The latex frontend parses the parenthesised comma-list as a
 /// `Sequence([a, b, …])`, usually wrapped in a `Group`/`Fenced` (the `(…)`), so we
@@ -1693,9 +1670,11 @@ fn latex_nary_fold(
 /// whole-number `f64`, so the caller can build the reciprocal exponent `1/n`. The
 /// degree must be a **positive integer literal** (`\sqrt[3]{…}`, `\sqrt[4]{…}`): a
 /// symbolic degree (`\sqrt[k]{…}`) has no numeric value, and a zero or negative
-/// degree has no root meaning (a `1/0` exponent is undefined). We reuse the same
-/// finite/integer discipline as `latex_power_exponent`, but exclude `0` (the
-/// exponent's denominator) — `n ≥ 1`, so `\sqrt[1]{x}` degenerates cleanly to
+/// degree has no root meaning (a `1/0` exponent is undefined). The degree must be
+/// a finite positive integer literal (unlike the general `x^y` power exponent,
+/// which may be symbolic/computed, a root DEGREE must be a concrete integer to form
+/// the reciprocal `1/n`), excluding `0` (the exponent's denominator) — `n ≥ 1`, so
+/// `\sqrt[1]{x}` degenerates cleanly to
 /// `x^1 = x`, and `\sqrt[3]{27}` becomes `27^(1/3) = 3`.
 fn latex_root_degree(expr: &MathExpr, source: &str) -> Result<f64, AdapterError> {
     let MathExpr::Number(n) = expr else {

--- a/code/packages/rust/adj-lang/src/lower.rs
+++ b/code/packages/rust/adj-lang/src/lower.rs
@@ -1800,6 +1800,36 @@ contributes 1000000 from answer == 60 to correct
     }
 
     #[test]
+    fn native_latex_symbolic_exponent_binds() {
+        // `x^y` — a SYMBOLIC exponent now lowers (base AND exponent are general
+        // expressions): with x=2, y=3 observed, `x^y` = 2^3 = 8. Previously the
+        // adapter required a non-negative integer literal exponent and rejected
+        // `x^y`; the engine's ComputeOp::Pow evaluates the exponent at run time.
+        let sy = crate::compile_and_decide(
+            "observe x(2)\n\
+             observe y(3)\n\
+             let answer = latex \"$x^y$\"\n\
+             prior 0.10 for correct\n\
+             contributes 1000000 from answer == 8 to correct\n\
+             ? correct\n",
+        )
+        .unwrap();
+        assert!(sy.ranked[0].posterior > 0.99, "{sy:?}");
+        // A COMPUTED exponent: `x^{a+b}` with x=2, a=1, b=2 → 2^3 = 8.
+        let comp = crate::compile_and_decide(
+            "observe x(2)\n\
+             observe a(1)\n\
+             observe b(2)\n\
+             let answer = latex \"$x^{a+b}$\"\n\
+             prior 0.10 for correct\n\
+             contributes 1000000 from answer == 8 to correct\n\
+             ? correct\n",
+        )
+        .unwrap();
+        assert!(comp.ranked[0].posterior > 0.99, "{comp:?}");
+    }
+
+    #[test]
     fn native_latex_square_root_computes() {
         // `\sqrt{9}` lowers to `9 ^ 0.5` (reusing ComputeOp::Pow) and computes 3
         // for a dimensionless base.


### PR DESCRIPTION
## LaTeX consumer slice: symbolic / computed power exponents

`latex "x^n"` power exponents may now be **symbolic or computed**, not just a non-negative integer literal.

### Behaviour

Both the base and the exponent lower as general expressions to a single native `ComputeOp::Pow`:

- `x^y` (with `y` observed) → `x` raised to `y`. (x=2, y=3 → **8**.)
- `x^{a+b}` → raise to a *computed* exponent. (x=2, a=1, b=2 → **8**.)
- `x^{2}`, `x^{10}` (numeric) — **unchanged**, still lower to a single power node.

Previously the adapter hard-required a non-negative integer literal exponent (a `latex_power_exponent` validator,
comment: "a symbolic exponent like `x^y` is a later slice") and rejected `x^y`. That validator is removed.

### Why this is safe

The exponent is **not evaluated at adapt time** — it lowers to an `ExprAst` node. The engine's `ComputeOp::Pow`
evaluates it at run time and remains the real safety boundary, enforcing:
- the exponent must be **dimensionless** (you cannot raise to a `3 dollars` power),
- base and exponent must be **finite** (NaN/inf rejected),
- a **non-integer exponent on a dimensioned base** is rejected (no fractional dimension),
- a **non-finite result** is rejected (`NonFinite`).

So a symbolic exponent computes for the dimensionless (Scalar) case and is cleanly rejected otherwise. A huge exponent
(`x^{999999}`) yields a `NonFinite` error at eval — there is no `x*x*…` expansion (a single Pow node), so no
compile-time blowup. The exponent recurses through the **pre-existing** recursive `latex_math_to_expr_ast` (exactly like
the base and every other sub-node) — no new tree-walking helper, so no new stack-overflow surface.

Root **degrees** (`\sqrt[n]{x}`) still require a concrete positive integer, since a symbolic degree cannot form the
reciprocal `1/n` — unchanged.

### What changed

- **`adapter.rs`** — the `Bin(Pow, base, exponent)` arm lowers the exponent generally (`latex_math_to_expr_ast`)
  instead of extracting a literal; removed the now-unused `latex_power_exponent` validator.
- **`lower.rs`** — +1 e2e test `native_latex_symbolic_exponent_binds` (`x^y` = 8, `x^{a+b}` = 8). Existing numeric
  power/root tests unchanged and green.
- Version 0.41.0 → 0.42.0; CHANGELOG prepended.

**Pure adapter recognition: no engine, AST, or lowering change** — the engine's `ComputeOp::Pow` already accepts a
runtime exponent. `cargo test -p logic-engine -p adj-lang -p adj-lang-cli -p adj-constraint-solver` green (124 adj-lang
tests). Security review passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
