### PR TITLE
feat(js-ast): CLOC12.160 PR1 — SequenceExpression atomic node + emit + passes

### DIFF
--- a/code/packages/rust/closure-emitter/CHANGELOG.md
+++ b/code/packages/rust/closure-emitter/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to the `coding-adventures-closure-emitter` crate will be documented in this file.
 
+## [0.24.0] - 2026-07-02
+
+### Added — CLOC12.160: emit `SequenceExpression` (the comma operator)
+
+`emit_sequence` prints the new `Expression::SequenceExpression` node —
+comma-joined operands (`a,b,c`), each at `PREC_ASSIGNMENT`. The sequence
+itself is classified at the new lowest precedence `PREC_SEQUENCE` (0), so a
+parent that emits its child above statement level wraps the whole sequence.
+
+To make that wrapping correct, the four **assignment-position** emit sites now
+emit their child at `PREC_ASSIGNMENT` instead of the parent-precedence-0
+sentinel: call arguments, `new` arguments, array elements, and the assignment
+RHS. A sequence there wraps (`f((a,b),c)`, `[(a,b),c]`, `x=(a,b)`) — never the
+arity-changing `f(a,b,c)` / `[a,b,c]` or the mis-parsed `x=a,b`. This is a
+**no-op for every existing node** (all bind at `PREC_ASSIGNMENT` or higher, so
+nothing new wraps) — the full closurec suite is unchanged. A computed-member
+key keeps parent-precedence 0, so `a[b,c]` prints bare (a sequence is legal
+unparenthesised inside `[ ]`). 8 new unit tests. No bridge output yet (PR2).
+
+
 ## [0.23.1] - 2026-07-02
 
 ### Added — CLOC12.159 PR3: CodePrinter new-operator conformance port

--- a/code/packages/rust/closure-emitter/Cargo.toml
+++ b/code/packages/rust/closure-emitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-emitter"
-version = "0.23.1"
+version = "0.24.0"
 edition = "2021"
 description = "JavaScript code emitter for the Closure Compiler clone. Per CLOC07's emit contract. Takes a finalized Program + sidecar and produces output JavaScript text + companion source map. Runs after every pass in the pipeline."
 

--- a/code/packages/rust/closure-emitter/src/lib.rs
+++ b/code/packages/rust/closure-emitter/src/lib.rs
@@ -74,7 +74,7 @@ use coding_adventures_javascript_ast::{
     ForStatement,
     FunctionDeclaration, FunctionExpression,
     FunctionParam, Identifier, IfStatement, LabeledStatement, LogicalExpression, LogicalOperator,
-    MemberExpression, NewExpression, NullLiteral, NumericLiteral, ObjectExpression, Program, ProgramItem,
+    MemberExpression, NewExpression, NullLiteral, NumericLiteral, ObjectExpression, Program, ProgramItem, SequenceExpression,
     Property, PropertyKey, PropertyKind, ReturnStatement, Statement, StringLiteral,
     SwitchCase, SwitchStatement, ThrowStatement, TryStatement, UnaryExpression, UnaryOperator, UpdateExpression, UpdateOperator,
     UndefinedLiteral, VarKind, VariableDeclaration, VariableDeclarator, WhileStatement,
@@ -1111,6 +1111,7 @@ impl<'a> Emitter<'a> {
             Expression::ConditionalExpression(c) => self.emit_conditional(c),
             Expression::CallExpression(c) => self.emit_call(c),
             Expression::NewExpression(n) => self.emit_new(n),
+            Expression::SequenceExpression(s) => self.emit_sequence(s),
             Expression::MemberExpression(m) => self.emit_member(m),
             Expression::ArrayExpression(a) => self.emit_array(a),
             Expression::ObjectExpression(o) => self.emit_object(o),
@@ -1384,7 +1385,11 @@ impl<'a> Emitter<'a> {
         self.pretty_ws();
         self.write_str(assignment_op_str(a.operator));
         self.pretty_ws();
-        self.emit_expression(&a.right);
+        // The RHS is an `AssignmentExpression`, so it is emitted at
+        // `PREC_ASSIGNMENT`: a looser *sequence* RHS wraps (`x=(a,b)`, never
+        // `x=a,b` which parses as `(x=a),b`). Every other node is
+        // `PREC_ASSIGNMENT` or higher and prints bare.
+        self.emit_expression_inner(&a.right, PREC_ASSIGNMENT);
     }
 
     fn emit_conditional(&mut self, c: &ConditionalExpression) {
@@ -1396,10 +1401,10 @@ impl<'a> Emitter<'a> {
         // delimits them, so `a ? b = 1 : c = 2` reparses identically to
         // `a ? (b=1) : (c=2)` and `a ? b ? c : d : e` to `a ? (b?c:d) : e`.
         //
-        // We therefore emit both branches at `PREC_ASSIGNMENT` — the lowest
-        // precedence in our expression set (there is no SequenceExpression in
-        // the AST, so nothing binds looser) — which means the precedence
-        // wrapper never adds parens to a branch. Previously the consequent was
+        // We therefore emit both branches at `PREC_ASSIGNMENT` — which wraps
+        // only a still-looser SequenceExpression (`a?(b,c):d` — a bare comma
+        // branch would be captured by the enclosing statement), never an
+        // assignment or nested conditional. Previously the consequent was
         // emitted at `PREC_CONDITIONAL + 1` and the alternate at
         // `PREC_CONDITIONAL`, so an assignment branch (`a?b=1:c`) was needlessly
         // parenthesised (`a?(b=1):c`).
@@ -1437,7 +1442,11 @@ impl<'a> Emitter<'a> {
                 self.write_str(",");
                 self.pretty_ws();
             }
-            self.emit_expression(a);
+            // An argument is an `AssignmentExpression` in the grammar, so it is
+            // emitted at `PREC_ASSIGNMENT`: a looser *sequence* argument wraps
+            // (`f((a,b),c)`, never the three-argument `f(a,b,c)`), while every
+            // other node — already `PREC_ASSIGNMENT` or higher — prints bare.
+            self.emit_expression_inner(a, PREC_ASSIGNMENT);
         }
         self.write_str(")");
     }
@@ -1488,9 +1497,32 @@ impl<'a> Emitter<'a> {
                 self.write_str(",");
                 self.pretty_ws();
             }
-            self.emit_expression(a);
+            // Assignment-position argument — a sequence wraps. See `emit_call`.
+            self.emit_expression_inner(a, PREC_ASSIGNMENT);
         }
         self.write_str(")");
+    }
+
+    /// Emit a `SequenceExpression` — the comma operator `a, b, c`.
+    ///
+    /// The operands print comma-separated with no minified inter-operand space
+    /// (`a,b,c`). Each operand is emitted at `PREC_ASSIGNMENT`: an operand that
+    /// is itself a looser sequence (e.g. a pass built `(a,b),c`) is wrapped —
+    /// but every non-sequence operand is `PREC_ASSIGNMENT` or higher, so it
+    /// prints bare. The *sequence itself* is `PREC_SEQUENCE` (the loosest), so a
+    /// parent that emits its child above statement level wraps the whole
+    /// sequence — see the four assignment-position sites (`emit_call` /
+    /// `emit_new` arguments, `emit_array` elements, `emit_assignment` RHS) and
+    /// `expr_prec`.
+    fn emit_sequence(&mut self, s: &SequenceExpression) {
+        self.maybe_map(&s.cv);
+        for (i, e) in s.expressions.iter().enumerate() {
+            if i > 0 {
+                self.write_str(",");
+                self.pretty_ws();
+            }
+            self.emit_expression_inner(e, PREC_ASSIGNMENT);
+        }
     }
 
     fn emit_member(&mut self, m: &MemberExpression) {
@@ -1523,7 +1555,10 @@ impl<'a> Emitter<'a> {
                 self.pretty_ws();
             }
             match el {
-                Some(e) => self.emit_expression(e),
+                // Assignment-position element — a sequence wraps
+                // (`[(a,b),c]`, never the three-element `[a,b,c]`). See
+                // `emit_call`.
+                Some(e) => self.emit_expression_inner(e, PREC_ASSIGNMENT),
                 None => {
                     // Elision. Empty position between commas.
                 }
@@ -1781,6 +1816,12 @@ fn format_exponential_uppercase(n: f64) -> String {
 // of a given AST node.
 // =====================================================================
 
+/// The comma operator — the loosest expression there is (below assignment). A
+/// sequence sub-operand wraps under any parent that emits its child above the
+/// statement level. `0` doubles as the "wrap nothing" sentinel used at
+/// statement position and inside a computed-member key, which is exactly where
+/// a bare sequence is legal.
+const PREC_SEQUENCE: u8 = 0;
 const PREC_CONDITIONAL: u8 = 2;
 const PREC_UNARY: u8 = 14;
 const PREC_PRIMARY: u8 = 18;
@@ -1874,6 +1915,9 @@ fn expr_prec(e: &Expression) -> u8 {
         // empty parens — a future minification — the no-arg form would need the
         // looser bare-`NewExpression` precedence; we don't, so one tag suffices.)
         Expression::NewExpression(_) => PREC_PRIMARY,
+        // The comma operator binds looser than every other expression — a
+        // sequence sub-operand must be wrapped in almost every context.
+        Expression::SequenceExpression(_) => PREC_SEQUENCE,
         // A function expression is primary-*ish*, but two contexts
         // mis-parse a bare one: as a call callee (`function(){}()` is a
         // syntax error) and as a member object (`function(){}.x`). Tag
@@ -4506,5 +4550,97 @@ mod tests {
     fn nested_new_inner_not_wrapped() {
         let inner = new_expr(ident("X"), vec![]);
         assert_eq!(emit_expr(new_expr(inner, vec![])), "new new X()();");
+    }
+
+    // ---- SequenceExpression (CLOC12.160) -------------------------------
+
+    fn seq(exprs: Vec<Expression>) -> Expression {
+        Expression::SequenceExpression(SequenceExpression { cv: None, expressions: exprs })
+    }
+
+    /// A sequence at statement position prints bare — the loosest expression,
+    /// nothing captures it: `a,b,c;`.
+    #[test]
+    fn sequence_at_statement_is_bare() {
+        assert_eq!(emit_expr(seq(vec![ident("a"), ident("b"), ident("c")])), "a,b,c;");
+    }
+
+    /// A sequence as a call argument MUST wrap, or `f(a,b)` would be a
+    /// two-argument call instead of one sequence argument: `f((a,b));`.
+    #[test]
+    fn sequence_as_sole_call_arg_is_wrapped() {
+        let e = call(ident("f"), vec![seq(vec![ident("a"), ident("b")])]);
+        assert_eq!(emit_expr(e), "f((a,b));");
+    }
+
+    /// A sequence as ONE of several call arguments wraps so the arity is
+    /// preserved: `f((a,b),c);` — never the three-argument `f(a,b,c)`.
+    #[test]
+    fn sequence_as_call_arg_preserves_arity() {
+        let e = call(ident("f"), vec![seq(vec![ident("a"), ident("b")]), ident("c")]);
+        assert_eq!(emit_expr(e), "f((a,b),c);");
+    }
+
+    /// A sequence as an array element wraps, or the element count changes:
+    /// `[(a,b),c];` — never the three-element `[a,b,c]`.
+    #[test]
+    fn sequence_as_array_element_is_wrapped() {
+        let e = Expression::ArrayExpression(ArrayExpression {
+            cv: None,
+            elements: vec![Some(seq(vec![ident("a"), ident("b")])), Some(ident("c"))],
+        });
+        assert_eq!(emit_expr(e), "[(a,b),c];");
+    }
+
+    /// A sequence as an assignment RHS wraps: `x=(a,b);` — a bare `x=a,b`
+    /// reparses as `(x=a),b`, a different program.
+    #[test]
+    fn sequence_as_assignment_rhs_is_wrapped() {
+        let e = Expression::AssignmentExpression(AssignmentExpression {
+            cv: None,
+            operator: AssignmentOperator::Eq,
+            left: AssignmentTarget::Identifier(Identifier { cv: None, name: "x".to_string() }),
+            right: Box::new(seq(vec![ident("a"), ident("b")])),
+        });
+        assert_eq!(emit_expr(e), "x=(a,b);");
+    }
+
+    /// A sequence as a computed-member key needs NO parens — the `[ ]` already
+    /// delimits a full `Expression`: `a[b,c];` (which evaluates the key to `c`).
+    #[test]
+    fn sequence_as_computed_member_key_is_bare() {
+        let e = Expression::MemberExpression(MemberExpression {
+            cv: None,
+            object: Box::new(ident("a")),
+            property: Box::new(seq(vec![ident("b"), ident("c")])),
+            computed: true,
+        });
+        assert_eq!(emit_expr(e), "a[b,c];");
+    }
+
+    /// A sequence as a conditional branch wraps (the branch is an
+    /// `AssignmentExpression`): `x?(a,b):c;`.
+    #[test]
+    fn sequence_as_conditional_branch_is_wrapped() {
+        let e = Expression::ConditionalExpression(ConditionalExpression {
+            cv: None,
+            test: Box::new(ident("x")),
+            consequent: Box::new(seq(vec![ident("a"), ident("b")])),
+            alternate: Box::new(ident("c")),
+        });
+        assert_eq!(emit_expr(e), "x?(a,b):c;");
+    }
+
+    /// A sequence as a unary operand wraps: `!(a,b);` — a bare `!a,b` parses as
+    /// `(!a),b`.
+    #[test]
+    fn sequence_as_unary_operand_is_wrapped() {
+        let e = Expression::UnaryExpression(UnaryExpression {
+            cv: None,
+            operator: UnaryOperator::Not,
+            prefix: true,
+            argument: Box::new(seq(vec![ident("a"), ident("b")])),
+        });
+        assert_eq!(emit_expr(e), "!(a,b);");
     }
 }

--- a/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `coding-adventures-closure-pass-constant-fold` crate will be documented in this file.
 
+## [0.85.3] - 2026-07-02
+
+### Changed — CLOC12.160: handle `Expression::SequenceExpression`
+
+Added a `SequenceExpression` match arm recursing into each operand so this
+crate compiles and traverses the new `Expression::SequenceExpression`
+variant. No behaviour change until the bridge produces sequence nodes
+(CLOC12.160 PR2).
+
+
 ## [0.85.2] - 2026-07-02
 
 ### Changed — CLOC12.159: handle `Expression::NewExpression`

--- a/code/packages/rust/closure-pass-constant-fold/Cargo.toml
+++ b/code/packages/rust/closure-pass-constant-fold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-constant-fold"
-version = "0.85.2"
+version = "0.85.3"
 edition = "2021"
 description = "Constant-folding optimization pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Folds compile-time-evaluable expressions like `2 + 3 → 5`."
 

--- a/code/packages/rust/closure-pass-constant-fold/src/lib.rs
+++ b/code/packages/rust/closure-pass-constant-fold/src/lib.rs
@@ -91,7 +91,7 @@ use coding_adventures_closure_pass_pipeline::{
 use coding_adventures_correlation_vector::{CVLog, Contribution};
 use coding_adventures_javascript_ast::{
     statement::TaggedStatement, ArrayExpression, AssignmentExpression, BinaryExpression,
-    BinaryOperator, BlockStatement, BooleanLiteral, CallExpression, ConditionalExpression, NewExpression,
+    BinaryOperator, BlockStatement, BooleanLiteral, CallExpression, ConditionalExpression, NewExpression, SequenceExpression,
     Declaration, Expression, ExpressionStatement, ForInStatement, ForInit, ForOfStatement,
     ForStatement,
     ArrowBody, ArrowFunctionExpression, TemplateLiteral,
@@ -534,6 +534,14 @@ fn fold_expression(expr: &Expression, st: &mut FoldState) -> Expression {
             cv: n.cv.clone(),
             callee: Box::new(fold_expression(&n.callee, st)),
             arguments: n.arguments.iter().map(|a| fold_expression(a, st)).collect(),
+        }),
+        // `a, b, c` — fold each operand independently. We do NOT drop the
+        // earlier operands even if they fold to a constant: they may carry side
+        // effects, and dropping them would change behaviour (that is a separate
+        // useless-code pass's job, gated on purity).
+        Expression::SequenceExpression(s) => Expression::SequenceExpression(SequenceExpression {
+            cv: s.cv.clone(),
+            expressions: s.expressions.iter().map(|e| fold_expression(e, st)).collect(),
         }),
         Expression::MemberExpression(m) => fold_member(m, st),
         Expression::ArrayExpression(a) => Expression::ArrayExpression(ArrayExpression {

--- a/code/packages/rust/closure-pass-dce/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-dce/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `coding-adventures-closure-pass-dce` crate will be documented in this file.
 
+## [0.20.3] - 2026-07-02
+
+### Changed — CLOC12.160: handle `Expression::SequenceExpression`
+
+Added a `SequenceExpression` match arm recursing into each operand so this
+crate compiles and traverses the new `Expression::SequenceExpression`
+variant. No behaviour change until the bridge produces sequence nodes
+(CLOC12.160 PR2).
+
+
 ## [0.20.2] - 2026-07-02
 
 ### Changed — CLOC12.159: handle `Expression::NewExpression`

--- a/code/packages/rust/closure-pass-dce/Cargo.toml
+++ b/code/packages/rust/closure-pass-dce/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-dce"
-version = "0.20.2"
+version = "0.20.3"
 edition = "2021"
 description = "Dead-code elimination pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Drops code after definite-terminator statements and removes EmptyStatement noise."
 

--- a/code/packages/rust/closure-pass-dce/src/lib.rs
+++ b/code/packages/rust/closure-pass-dce/src/lib.rs
@@ -71,7 +71,7 @@ use coding_adventures_closure_pass_pipeline::{
 use coding_adventures_correlation_vector::{CVLog, Contribution};
 use coding_adventures_javascript_ast::{
     statement::TaggedStatement, ArrayExpression, AssignmentExpression, BigIntLiteral,
-    BinaryExpression, BlockStatement, BooleanLiteral, CallExpression, ConditionalExpression, NewExpression,
+    BinaryExpression, BlockStatement, BooleanLiteral, CallExpression, ConditionalExpression, NewExpression, SequenceExpression,
     Declaration, EmptyStatement, Expression, ExpressionStatement, ForInStatement, ForInit,
     ForOfStatement,
     ForStatement,
@@ -1219,6 +1219,12 @@ fn dce_expression(expr: &Expression, st: &mut DceState) -> Expression {
             cv: n.cv.clone(),
             callee: Box::new(dce_expression(&n.callee, st)),
             arguments: n.arguments.iter().map(|a| dce_expression(a, st)).collect(),
+        }),
+        // `a, b, c` — recurse into each operand; the sequence itself is kept
+        // (its operands may have side effects).
+        Expression::SequenceExpression(s) => Expression::SequenceExpression(SequenceExpression {
+            cv: s.cv.clone(),
+            expressions: s.expressions.iter().map(|e| dce_expression(e, st)).collect(),
         }),
         Expression::MemberExpression(m) => Expression::MemberExpression(MemberExpression {
             cv: m.cv.clone(),

--- a/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `coding-adventures-closure-pass-fold-control-flow` crate will be documented in this file.
 
+## [0.20.3] - 2026-07-02
+
+### Changed — CLOC12.160: handle `Expression::SequenceExpression`
+
+Added a `SequenceExpression` match arm recursing into each operand so this
+crate compiles and traverses the new `Expression::SequenceExpression`
+variant. No behaviour change until the bridge produces sequence nodes
+(CLOC12.160 PR2).
+
+
 ## [0.20.2] - 2026-07-02
 
 ### Changed — CLOC12.159: handle `Expression::NewExpression`

--- a/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
+++ b/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-fold-control-flow"
-version = "0.20.2"
+version = "0.20.3"
 edition = "2021"
 description = "Control-flow folding pass for the Closure Compiler clone. Slots between constant-fold and DCE per CLOC06's canonical pass set. Eliminates dead branches (`if (false) A else B → B`), removes unreachable code after `return`/`throw`, and collapses degenerate switch arms."
 

--- a/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
+++ b/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
@@ -56,7 +56,7 @@ use coding_adventures_closure_pass_pipeline::{
 use coding_adventures_correlation_vector::{CVLog, Contribution};
 use coding_adventures_javascript_ast::{
     statement::TaggedStatement, ArrayExpression, AssignmentExpression, AssignmentOperator,
-    AssignmentTarget, BinaryExpression, BindingTarget, BlockStatement, CallExpression, NewExpression,
+    AssignmentTarget, BinaryExpression, BindingTarget, BlockStatement, CallExpression, NewExpression, SequenceExpression,
     ConditionalExpression, Declaration, EmptyStatement, Expression, ExpressionStatement, ForInit,
     ArrowBody, ArrowFunctionExpression, TemplateLiteral,
     ForInStatement, ForOfStatement, ForStatement, FunctionDeclaration, FunctionExpression, Identifier, IfStatement,
@@ -274,6 +274,7 @@ fn expression_cv(expr: &Expression) -> Option<String> {
         ConditionalExpression(e) => e.cv.clone(),
         CallExpression(e) => e.cv.clone(),
         NewExpression(e) => e.cv.clone(),
+        SequenceExpression(e) => e.cv.clone(),
         MemberExpression(e) => e.cv.clone(),
         ArrayExpression(e) => e.cv.clone(),
         ObjectExpression(e) => e.cv.clone(),
@@ -1399,6 +1400,10 @@ fn fold_expression(expr: &Expression, st: &mut FoldState) -> Expression {
             cv: n.cv.clone(),
             callee: Box::new(fold_expression(&n.callee, st)),
             arguments: n.arguments.iter().map(|a| fold_expression(a, st)).collect(),
+        }),
+        Expression::SequenceExpression(s) => Expression::SequenceExpression(SequenceExpression {
+            cv: s.cv.clone(),
+            expressions: s.expressions.iter().map(|e| fold_expression(e, st)).collect(),
         }),
         Expression::MemberExpression(m) => Expression::MemberExpression(MemberExpression {
             cv: m.cv.clone(),

--- a/code/packages/rust/closure-pass-inline-variables/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-inline-variables/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `coding-adventures-closure-pass-inline-variables` crate will be documented in this file.
 
+## [0.11.3] - 2026-07-02
+
+### Changed — CLOC12.160: handle `Expression::SequenceExpression`
+
+Added a `SequenceExpression` match arm recursing into each operand so this
+crate compiles and traverses the new `Expression::SequenceExpression`
+variant. No behaviour change until the bridge produces sequence nodes
+(CLOC12.160 PR2).
+
+
 ## [0.11.2] - 2026-07-02
 
 ### Changed — CLOC12.159: handle `Expression::NewExpression`

--- a/code/packages/rust/closure-pass-inline-variables/Cargo.toml
+++ b/code/packages/rust/closure-pass-inline-variables/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-inline-variables"
-version = "0.11.2"
+version = "0.11.3"
 edition = "2021"
 description = "Constant-propagation pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Replaces references to a top-level `const` bound to a literal with the literal itself, so the binding becomes unused and remove-unused-vars deletes it."
 

--- a/code/packages/rust/closure-pass-inline-variables/src/lib.rs
+++ b/code/packages/rust/closure-pass-inline-variables/src/lib.rs
@@ -767,6 +767,11 @@ fn count_uses_expr(expr: &Expression, name: &str, count: &mut usize) {
                 count_uses_expr(a, name, count);
             }
         }
+        Expression::SequenceExpression(se) => {
+            for e in &se.expressions {
+                count_uses_expr(e, name, count);
+            }
+        }
         Expression::MemberExpression(m) => {
             count_uses_member(&m.object, &m.property, m.computed, name, count)
         }
@@ -1048,6 +1053,11 @@ fn propagate_in_expr(expr: &mut Expression, cand: &ConstCandidate) -> bool {
             changed |= propagate_in_expr(&mut ne.callee, cand);
             for a in &mut ne.arguments {
                 changed |= propagate_in_expr(a, cand);
+            }
+        }
+        Expression::SequenceExpression(se) => {
+            for e in &mut se.expressions {
+                changed |= propagate_in_expr(e, cand);
             }
         }
         Expression::MemberExpression(m) => changed |= propagate_in_member(m, cand),

--- a/code/packages/rust/closure-pass-inline/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-inline/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `coding-adventures-closure-pass-inline` crate will be documented in this file.
 
+## [0.25.3] - 2026-07-02
+
+### Changed — CLOC12.160: handle `Expression::SequenceExpression`
+
+Added a `SequenceExpression` match arm recursing into each operand so this
+crate compiles and traverses the new `Expression::SequenceExpression`
+variant. No behaviour change until the bridge produces sequence nodes
+(CLOC12.160 PR2).
+
+
 ## [0.25.2] - 2026-07-02
 
 ### Changed — CLOC12.159: handle `Expression::NewExpression`

--- a/code/packages/rust/closure-pass-inline/Cargo.toml
+++ b/code/packages/rust/closure-pass-inline/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-inline"
-version = "0.25.2"
+version = "0.25.3"
 edition = "2021"
 description = "Function-inlining pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Substitutes small or single-use function bodies at their call sites to enable downstream folding and shrink call overhead."
 

--- a/code/packages/rust/closure-pass-inline/src/lib.rs
+++ b/code/packages/rust/closure-pass-inline/src/lib.rs
@@ -462,6 +462,7 @@ fn expr_node_count(expr: &Expression) -> usize {
         Expression::NewExpression(ne) => {
             expr_node_count(&ne.callee) + ne.arguments.iter().map(expr_node_count).sum::<usize>()
         }
+        Expression::SequenceExpression(se) => se.expressions.iter().map(expr_node_count).sum(),
         Expression::MemberExpression(m) => {
             expr_node_count(&m.object) + expr_node_count(&m.property)
         }
@@ -775,6 +776,11 @@ fn collect_binding_idents_expr(expr: &Expression, out: &mut HashSet<String>) {
                 collect_binding_idents_expr(a, out);
             }
         }
+        Expression::SequenceExpression(se) => {
+            for e in &se.expressions {
+                collect_binding_idents_expr(e, out);
+            }
+        }
         Expression::MemberExpression(m) => {
             collect_binding_idents_member(&m.object, &m.property, m.computed, out)
         }
@@ -1061,6 +1067,11 @@ fn tally_expr(expr: &Expression, cand: &InlineCandidate, t: &mut Tally) {
             tally_expr(&ne.callee, cand, t);
             for a in &ne.arguments {
                 tally_expr(a, cand, t);
+            }
+        }
+        Expression::SequenceExpression(se) => {
+            for e in &se.expressions {
+                tally_expr(e, cand, t);
             }
         }
         Expression::MemberExpression(m) => {
@@ -1355,6 +1366,11 @@ fn inline_in_expr(expr: &mut Expression, cand: &InlineCandidate) -> bool {
                 changed |= inline_in_expr(a, cand);
             }
         }
+        Expression::SequenceExpression(se) => {
+            for e in &mut se.expressions {
+                changed |= inline_in_expr(e, cand);
+            }
+        }
         Expression::MemberExpression(m) => changed |= inline_in_member(m, cand),
         Expression::ArrayExpression(ae) => {
             for el in ae.elements.iter_mut().flatten() {
@@ -1475,6 +1491,11 @@ fn substitute(expr: &mut Expression, map: &HashMap<String, Expression>) {
             substitute(&mut ne.callee, map);
             for a in &mut ne.arguments {
                 substitute(a, map);
+            }
+        }
+        Expression::SequenceExpression(se) => {
+            for e in &mut se.expressions {
+                substitute(e, map);
             }
         }
         Expression::MemberExpression(m) => {
@@ -1851,6 +1872,11 @@ fn expr_collect_mutated_params(
             expr_collect_mutated_params(&ne.callee, params, out);
             for a in &ne.arguments {
                 expr_collect_mutated_params(a, params, out);
+            }
+        }
+        Expression::SequenceExpression(se) => {
+            for e in &se.expressions {
+                expr_collect_mutated_params(e, params, out);
             }
         }
         Expression::MemberExpression(m) => {
@@ -3300,6 +3326,11 @@ fn rename_in_expr(expr: &mut Expression, map: &HashMap<String, String>) {
             rename_in_expr(&mut ne.callee, map);
             for a in &mut ne.arguments {
                 rename_in_expr(a, map);
+            }
+        }
+        Expression::SequenceExpression(se) => {
+            for e in &mut se.expressions {
+                rename_in_expr(e, map);
             }
         }
         Expression::MemberExpression(m) => {

--- a/code/packages/rust/closure-pass-rename-globals/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename-globals/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename-globals` crate will be documented in this file.
 
+## [0.10.3] - 2026-07-02
+
+### Changed — CLOC12.160: handle `Expression::SequenceExpression`
+
+Added a `SequenceExpression` match arm recursing into each operand so this
+crate compiles and traverses the new `Expression::SequenceExpression`
+variant. No behaviour change until the bridge produces sequence nodes
+(CLOC12.160 PR2).
+
+
 ## [0.10.2] - 2026-07-02
 
 ### Changed — CLOC12.159: handle `Expression::NewExpression`

--- a/code/packages/rust/closure-pass-rename-globals/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename-globals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename-globals"
-version = "0.10.2"
+version = "0.10.3"
 edition = "2021"
 description = "Aggressive top-level (global) renaming pass for the Closure Compiler clone — the ADVANCED-level complement to closure-pass-rename. Shortens program-private top-level names, gated by an externs do-not-rename boundary."
 

--- a/code/packages/rust/closure-pass-rename-globals/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename-globals/src/lib.rs
@@ -673,6 +673,11 @@ fn collect_all_idents_expr(expr: &Expression, out: &mut HashSet<String>) {
                 collect_all_idents_expr(a, out);
             }
         }
+        Expression::SequenceExpression(se) => {
+            for e in &se.expressions {
+                collect_all_idents_expr(e, out);
+            }
+        }
         Expression::MemberExpression(m) => {
             collect_all_idents_member(&m.object, &m.property, m.computed, out)
         }
@@ -979,6 +984,11 @@ fn rename_apply_expr(expr: &mut Expression, map: &HashMap<String, String>) {
             rename_apply_expr(&mut ne.callee, map);
             for a in &mut ne.arguments {
                 rename_apply_expr(a, map);
+            }
+        }
+        Expression::SequenceExpression(se) => {
+            for e in &mut se.expressions {
+                rename_apply_expr(e, map);
             }
         }
         Expression::MemberExpression(m) => {

--- a/code/packages/rust/closure-pass-rename-properties/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename-properties/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename-properties` crate will be documented in this file.
 
+## [0.12.3] - 2026-07-02
+
+### Changed — CLOC12.160: handle `Expression::SequenceExpression`
+
+Added a `SequenceExpression` match arm recursing into each operand so this
+crate compiles and traverses the new `Expression::SequenceExpression`
+variant. No behaviour change until the bridge produces sequence nodes
+(CLOC12.160 PR2).
+
+
 ## [0.12.2] - 2026-07-02
 
 ### Changed — CLOC12.159: handle `Expression::NewExpression`

--- a/code/packages/rust/closure-pass-rename-properties/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename-properties/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename-properties"
-version = "0.12.2"
+version = "0.12.3"
 edition = "2021"
 description = "Aggressive property renaming pass for the Closure Compiler clone (ADVANCED-only). Consistently shortens program-private object property names that are never quoted/computed and not in the built-in or externs do-not-rename boundary."
 

--- a/code/packages/rust/closure-pass-rename-properties/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename-properties/src/lib.rs
@@ -1179,6 +1179,11 @@ fn classify_expr(expr: &Expression, cls: &mut Classify) {
                 classify_expr(a, cls);
             }
         }
+        Expression::SequenceExpression(se) => {
+            for e in &se.expressions {
+                classify_expr(e, cls);
+            }
+        }
         Expression::MemberExpression(m) => classify_member(&m.object, &m.property, m.computed, cls),
         Expression::ArrayExpression(ae) => {
             for el in ae.elements.iter().flatten() {
@@ -1443,6 +1448,11 @@ fn rewrite_expr(expr: &mut Expression, map: &HashMap<String, String>) {
             rewrite_expr(&mut ne.callee, map);
             for a in &mut ne.arguments {
                 rewrite_expr(a, map);
+            }
+        }
+        Expression::SequenceExpression(se) => {
+            for e in &mut se.expressions {
+                rewrite_expr(e, map);
             }
         }
         Expression::MemberExpression(m) => {

--- a/code/packages/rust/closure-pass-rename/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename` crate will be documented in this file.
 
+## [0.14.3] - 2026-07-02
+
+### Changed — CLOC12.160: handle `Expression::SequenceExpression`
+
+Added a `SequenceExpression` match arm recursing into each operand so this
+crate compiles and traverses the new `Expression::SequenceExpression`
+variant. No behaviour change until the bridge produces sequence nodes
+(CLOC12.160 PR2).
+
+
 ## [0.14.2] - 2026-07-02
 
 ### Changed — CLOC12.159: handle `Expression::NewExpression`

--- a/code/packages/rust/closure-pass-rename/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename"
-version = "0.14.2"
+version = "0.14.3"
 edition = "2021"
 description = "Variable renaming pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Replaces non-exported binding names with shorter identifiers to reduce output size while preserving externally-visible names and semantics."
 

--- a/code/packages/rust/closure-pass-rename/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename/src/lib.rs
@@ -951,6 +951,11 @@ fn collect_all_idents_expr(expr: &Expression, out: &mut HashSet<String>) {
                 collect_all_idents_expr(a, out);
             }
         }
+        Expression::SequenceExpression(se) => {
+            for e in &se.expressions {
+                collect_all_idents_expr(e, out);
+            }
+        }
         Expression::MemberExpression(m) => {
             collect_all_idents_member(&m.object, &m.property, m.computed, out)
         }
@@ -1241,6 +1246,11 @@ fn rewrite_uses_expr(expr: &mut Expression, map: &HashMap<String, String>) {
             rewrite_uses_expr(&mut ne.callee, map);
             for a in &mut ne.arguments {
                 rewrite_uses_expr(a, map);
+            }
+        }
+        Expression::SequenceExpression(se) => {
+            for e in &mut se.expressions {
+                rewrite_uses_expr(e, map);
             }
         }
         Expression::MemberExpression(m) => {

--- a/code/packages/rust/closure-scope-analyzer/CHANGELOG.md
+++ b/code/packages/rust/closure-scope-analyzer/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `coding-adventures-closure-scope-analyzer` crate will be documented in this file.
 
+## [0.12.3] - 2026-07-02
+
+### Changed — CLOC12.160: handle `Expression::SequenceExpression`
+
+Added a `SequenceExpression` match arm recursing into each operand so this
+crate compiles and traverses the new `Expression::SequenceExpression`
+variant. No behaviour change until the bridge produces sequence nodes
+(CLOC12.160 PR2).
+
+
 ## [0.12.2] - 2026-07-02
 
 ### Changed — CLOC12.159: handle `Expression::NewExpression`

--- a/code/packages/rust/closure-scope-analyzer/Cargo.toml
+++ b/code/packages/rust/closure-scope-analyzer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-scope-analyzer"
-version = "0.12.2"
+version = "0.12.3"
 edition = "2021"
 description = "Lexical scope + symbol-table analyzer for the Closure Compiler clone. Per CLOC13 — produces a `ScopeAnalysis` consumed by the rename, inline, treeshake, collapse-properties, and remove-unused-vars passes."
 

--- a/code/packages/rust/closure-scope-analyzer/src/lib.rs
+++ b/code/packages/rust/closure-scope-analyzer/src/lib.rs
@@ -899,6 +899,11 @@ fn walk_expression(
                 walk_expression(arg, ctx, analysis, pending);
             }
         }
+        Expression::SequenceExpression(se) => {
+            for e in &se.expressions {
+                walk_expression(e, ctx, analysis, pending);
+            }
+        }
         Expression::MemberExpression(me) => {
             walk_member_expression_inner(&me.object, &me.property, me.computed, ctx, analysis, pending);
         }

--- a/code/packages/rust/javascript-ast/CHANGELOG.md
+++ b/code/packages/rust/javascript-ast/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to the `coding-adventures-javascript-ast` crate will be documented in this file.
 
+## [0.19.0] - 2026-07-02
+
+### Added — CLOC12.160: `Expression::SequenceExpression` (the comma operator)
+
+New `SequenceExpression { cv, expressions: Vec<Expression> }` variant of
+`Expression` for the comma operator `a, b, c` — evaluate each operand left to
+right, yield the last. It is the **loosest** expression (below assignment),
+so a sequence sub-operand almost always needs parentheses. Re-exported from
+the crate root. Atomic node PR (PR1); the bridge conversion (PR2) and the
+CodePrinter conformance port (PR3) follow.
+
+
 ## [0.18.0] - 2026-07-02
 
 ### Added — CLOC12.159: `Expression::NewExpression` (`new X(args)`)

--- a/code/packages/rust/javascript-ast/Cargo.toml
+++ b/code/packages/rust/javascript-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-javascript-ast"
-version = "0.18.0"
+version = "0.19.0"
 edition = "2021"
 description = "Backend-agnostic JavaScript AST — full ESTree-compatible node taxonomy with optional per-node CV id. Reusable by the Closure-Compiler-clone and the future V8-in-Rust clone. Per CLOC02 / CLOC09."
 

--- a/code/packages/rust/javascript-ast/README.md
+++ b/code/packages/rust/javascript-ast/README.md
@@ -68,6 +68,14 @@ emitter grow a need for them — each behind its own `CLOC12.NN` slice:
   callee excludes a trailing call (`new (f())()` needs the parens). Node +
   `closure-emitter` + all pass traversals land in one atomic PR; the
   bridge-enable + conformance port follow (gap-160).
+- `SequenceExpression` (CLOC12.160) — the comma operator: `a, b, c`. Evaluates
+  each operand left to right and yields the last.
+  `SequenceExpression { expressions: Vec<Expression> }`. It is the **loosest**
+  expression (below assignment), so a sequence sub-operand almost always needs
+  parentheses (`f((a,b),c)`, `x=(a,b)`) — the exceptions are statement position
+  (`a,b,c;`) and a computed-member key (`obj[a,b]`). Node + `closure-emitter` +
+  all pass traversals land in one atomic PR; the bridge-enable + conformance
+  port follow (gap-161).
 
 ## What's coming (follow-up PRs)
 

--- a/code/packages/rust/javascript-ast/src/expression.rs
+++ b/code/packages/rust/javascript-ast/src/expression.rs
@@ -59,6 +59,7 @@ pub enum Expression {
     TemplateLiteral(TemplateLiteral),
     UpdateExpression(UpdateExpression),
     NewExpression(NewExpression),
+    SequenceExpression(SequenceExpression),
 }
 
 // ---------------------------------------------------------------------
@@ -417,6 +418,40 @@ pub struct NewExpression {
     pub cv: Option<CvId>,
     pub callee: Box<Expression>,
     pub arguments: Vec<Expression>,
+}
+
+/// `a, b, c` — the **comma operator**. Evaluates each expression left to right
+/// and yields the value of the **last** one; the earlier expressions are
+/// evaluated only for their side effects. `expressions` holds the operands in
+/// source order and always has length ≥ 2 (a single expression is just that
+/// expression, not a sequence).
+///
+/// # Precedence — the loosest expression there is
+///
+/// The comma operator binds **looser than assignment** (it is the entry
+/// production `Expression : AssignmentExpression { , AssignmentExpression }`).
+/// A sequence used as a *sub-expression* almost always needs parentheses, or
+/// the surrounding operator captures only one arm:
+///
+/// ```text
+///   x = (a, b)     without parens `x = a, b` parses as `(x = a), b`
+///   f((a, b), c)   without parens `f(a, b, c)` is a THREE-argument call
+///   [(a, b), c]    without parens `[a, b, c]` is a THREE-element array
+///   return (a, b)  a bare `return a, b` still works (statement position)
+/// ```
+///
+/// The two places a sequence needs **no** parens are a statement-position
+/// expression (`a, b, c;`) and a computed-member key (`obj[a, b]` — the `[ ]`
+/// already delimits a full `Expression`). The emitter encodes this by tagging
+/// `SequenceExpression` at the lowest precedence and emitting the four
+/// assignment-position operands (call/`new` arguments, array elements,
+/// assignment RHS) at assignment precedence so a sequence there wraps.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SequenceExpression {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub cv: Option<CvId>,
+    pub expressions: Vec<Expression>,
 }
 
 /// `obj.prop` or `obj[key]`. `computed = false` ↔ `obj.prop` (the

--- a/code/packages/rust/javascript-ast/src/lib.rs
+++ b/code/packages/rust/javascript-ast/src/lib.rs
@@ -139,6 +139,7 @@ pub use expression::{
     LogicalOperator, MemberExpression,
     NewExpression,
     NullLiteral, NumericLiteral, ObjectExpression, Property, PropertyKey, PropertyKind,
+    SequenceExpression,
     StringLiteral, TemplateElement, TemplateLiteral, UnaryExpression, UnaryOperator,
     UndefinedLiteral, UpdateExpression, UpdateOperator,
 };

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -1769,3 +1769,48 @@ the callee-with-call wraps (`new (f())()`, `new (a.b().c)()`), the
 `#[test]`s, no `#[ignore]` — the emitter conforms to every covered shape. This
 completes the CLOC12.159 `NewExpression` three-PR arc (node+emit → bridge →
 conformance).
+
+## CLOC12.160 — `SequenceExpression` (`a, b, c`): atomic node + emit + passes (PR1)
+
+Adds `Expression::SequenceExpression { cv, expressions }` to `javascript-ast`
+(0.19.0) — the **comma operator**: evaluate each operand left to right, yield
+the last. It is the **loosest** expression in the grammar (the entry production
+`Expression : AssignmentExpression { , AssignmentExpression }`), binding below
+assignment.
+
+`closure-emitter` (0.24.0) `emit_sequence` prints the operands comma-joined
+(`a,b,c`), each at `PREC_ASSIGNMENT`. The sequence itself is the new lowest
+precedence `PREC_SEQUENCE` (0). Correct wrapping of a sequence sub-operand
+required the four **assignment-position** emit sites to emit their child at
+`PREC_ASSIGNMENT` rather than the parent-precedence-0 sentinel: **call
+arguments, `new` arguments, array elements, and the assignment RHS**. A sequence
+there now wraps — `f((a,b),c)` (never the three-argument `f(a,b,c)`),
+`[(a,b),c]` (never the three-element `[a,b,c]`), `x=(a,b)` (never `x=a,b` =
+`(x=a),b`). This is a **no-op for every existing node type** (all bind at
+`PREC_ASSIGNMENT` or higher, so nothing new wraps — the full closurec suite is
+unchanged). Two positions keep a bare sequence: statement position (`a,b,c;`)
+and a computed-member key (`obj[a,b]`, which the surrounding `[ ]` already
+delimits).
+
+All nine downstream pass/analysis crates get a `SequenceExpression` match arm
+recursing into `expressions` (the transforms rebuild it; `constant-fold` folds
+each operand but keeps them all — earlier operands may have side effects), and
+`fold-control-flow`'s exhaustive `expression_cv` accessor gains its arm — all in
+one atomic commit so the workspace never has a broken exhaustive `match`.
+
+8 new emitter unit tests (statement-bare, sole/multi call arg, array element,
+assignment RHS, computed-member-key-bare, conditional branch, unary operand).
+No behaviour change for existing inputs — the bridge still declines the comma
+operator (gap-161), so closurec falls back to WHITESPACE_ONLY on `a, b, c` for
+now. PR2 (bridge-enable) and PR3 (conformance port) follow.
+
+### gap-161 — bridge declines the comma operator (`SequenceExpression`)
+
+The `javascript-parser` bridge's `convert_expression_rule` handles only the
+single-expression form of the grammar's `expression = assignment_expression {
+COMMA assignment_expression }`; a multi-expression comma list returns
+`UnsupportedSyntax { rule: "SequenceExpression" }`, so any file with a top-level
+comma operator drops to WHITESPACE_ONLY. With the `Expression::SequenceExpression`
+node now in place (CLOC12.160 PR1), PR2 will build it from the comma-separated
+`assignment_expression` children and add a closurec e2e diff fixture, closing
+this gap.


### PR DESCRIPTION
## CLOC12.160 PR1 — `SequenceExpression` (`a, b, c`): atomic node + emit + passes

First PR of the CLOC12.160 `SequenceExpression` (comma operator) arc, following the same three-PR shape as CLOC12.158/159: **PR1** atomic node+emit+passes → **PR2** bridge-enable → **PR3** conformance port.

Adds `Expression::SequenceExpression { cv, expressions: Vec<Expression> }` to `javascript-ast` — the comma operator `a, b, c` (evaluate each operand left to right, yield the last). It is the **loosest** expression in the grammar (below assignment). The AST variant, the emitter, and every downstream exhaustive `match` land in **one commit** so the workspace never has a broken build.

### `closure-emitter` — `emit_sequence`
- Prints operands comma-joined (`a,b,c`), each at `PREC_ASSIGNMENT`. The sequence itself is the new lowest precedence `PREC_SEQUENCE` (0).
- **Precedence surgery (the security-relevant part):** the four **assignment-position** emit sites now emit their child at `PREC_ASSIGNMENT` instead of the parent-precedence-0 sentinel — call arguments, `new` arguments, array elements, and the assignment RHS. A sequence there now wraps: `f((a,b),c)` (never the three-argument `f(a,b,c)`), `[(a,b),c]` (never the three-element `[a,b,c]`), `x=(a,b)` (never `x=a,b` = `(x=a),b`).
- This is a **no-op for every existing node type** — all bind at `PREC_ASSIGNMENT` or higher, so nothing new wraps. **The full downstream closurec suite (97 suites) runs with unchanged output**, corroborating the no-op.
- A computed-member key keeps parent-precedence 0, so `a[b,c]` prints bare (a sequence is legal unparenthesised inside `[ ]`).
- 8 new unit tests (statement-bare, sole/multi call arg, array element, assignment RHS, computed-member-key-bare, conditional branch, unary operand).

### 9 downstream pass/analysis crates
Each gets a `SequenceExpression` match arm recursing into `expressions`: `constant-fold` (folds each operand but keeps them all — earlier operands may have side effects), `dce`, `fold-control-flow` (traversal + the exhaustive `expression_cv` provenance accessor), `inline`, `inline-variables`, `rename`, `rename-globals`, `rename-properties`, `scope-analyzer`.

### No behaviour change yet
The bridge still declines the comma operator (gap-161), so closurec falls back to WHITESPACE_ONLY on `a, b, c` for now. PR2 wires the bridge; PR3 ports the upstream CodePrinter cases.

### Versions
javascript-ast `0.18.0` → `0.19.0`, closure-emitter `0.23.1` → `0.24.0` (minor: new node + emit-site precedence), 9 passes patch-bumped, each with a CHANGELOG entry.

### Verification
- `cargo test` green: javascript-ast, closure-emitter (all lib + upstream suites), all 9 pass crates, and the downstream **closurec** CLI (97 suites, unchanged output).
- Inline security review → **PASSED** (verified: only `SequenceExpression` returns `expr_prec` 0, so the four emit-site changes wrap *only* sequences and are a no-op for every existing node; `emit_sequence` is semantically faithful; computed-member key correctly stays bare; recursion bounded like `CallExpression`).

### Docs
javascript-ast README variant note; `CLOC12-gaps.md` CLOC12.160 section + **gap-161** (bridge declines the comma operator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)