### PR TITLE
feat(adj-ladder): rung-56 cardiac stroke work — difference-times-sum (a-b)*(c+d)

### DIFF
--- a/code/specs/data/adj-ladder/rung56_stroke_work/gen_items.py
+++ b/code/specs/data/adj-ladder/rung56_stroke_work/gen_items.py
@@ -1,0 +1,230 @@
+"""Generate rung-56 (cardiac stroke work) items.json for the ADJ-LADDER.
+
+Rung 56 opens the **cardiology / ventricular-mechanics** panel on the quantitative band — the arithmetic of the work a
+ventricle does in one beat. The work is the pressure the ventricle generates against times the volume it moves: the
+DRIVING pressure is the systolic-minus-diastolic DIFFERENCE, and the ejected volume is the forward stroke volume PLUS
+any regurgitant volume — a SUM. The stroke work is the driving pressure times the ejected volume. Multiplying a
+difference by a sum introduces a genuinely NEW arithmetic shape on the ladder: **difference-times-sum** —
+`(a − b) · (c + d)` — a parenthesised difference multiplied by a parenthesised sum.
+
+The setup: a ventricle sees a systolic pressure `systolic_pressure` and a diastolic pressure `diastolic_pressure`, and
+ejects a forward volume `forward_volume` plus a regurgitant volume `regurgitant_volume`. The stroke work is the driving
+pressure times the ejected volume:
+
+  STROKE WORK        (systolic_pressure − diastolic_pressure) · (forward_volume + regurgitant_volume)   [ the whole work ]
+  DRIVING PRESSURE   systolic_pressure − diastolic_pressure                                             [ the difference ]
+  EJECTED VOLUME     forward_volume + regurgitant_volume                                                [ the sum ]
+
+The **stroke work** is what makes this rung distinctive — it is the ladder's first **difference-times-sum**: a
+parenthesised difference multiplied by a parenthesised sum. Contrast the neighbours already on the ladder: rung-55 was a
+*product of two SUMS* `(a+b)·(c+d)` and rung-48 a *sum times a difference* `(a+b)·(c−d)`; neither multiplied a DIFFERENCE
+by a SUM. (The driving pressure `systolic_pressure − diastolic_pressure` and the ejected volume `forward_volume +
+regurgitant_volume` ride alongside as component readouts, so the panel teaches the whole calculation — exactly as rungs
+47-55 shipped their component sums/products/differences beside the headline figure.)
+
+Each index is a `compute_dimensioned` program (`observe` the four quantities + `let answer = formula`); the ADJ engine
+carries the arithmetic — including the parenthesised difference and sum and their product — and the harness reads the
+scalar via the existing `compute_dimensioned` extractor. No harness/engine change, exactly as rungs 8/16/.../54/55. This
+rung exercises the engine across a **difference times a sum** — the distributive law `(a−b)·(c+d) = ac+ad−bc−bd` made
+computable.
+
+Contamination-safe by construction: every formula is built ONLY from the four observed quantities via `+`, `−` and `·`
+— **no structural constants** — so no numeric literal appears in any program, and neither the driving pressure, the
+ejected volume, nor any stroke-work figure is ever a literal (each is computed from the observed quantities). The
+observed quantities carry **digit-free identifiers** (`systolic_pressure`, `diastolic_pressure`, `forward_volume`,
+`regurgitant_volume`) so no numeral hides inside a variable name.
+
+The five options are a tight family over the same four quantities: the three real readouts plus the two classic slips —
+
+  SUM VERSION   (systolic_pressure − diastolic_pressure) + (forward_volume + regurgitant_volume)   ADD the driving
+                                                                                                   pressure and the
+                                                                                                   ejected volume instead
+                                                                                                   of multiplying, and
+  MISGROUPED    (systolic_pressure − diastolic_pressure) · forward_volume + regurgitant_volume      multiply the driving
+                                                                                                   pressure by only the
+                                                                                                   FORWARD volume, then add
+                                                                                                   the regurgitant volume
+                                                                                                   on (`… · forward +
+                                                                                                   regurgitant`, not `… ·
+                                                                                                   (forward + regurgitant)`),
+
+which are exactly the mistakes a student makes (adding a pressure and a volume that should be multiplied, or breaking the
+grouping so the pressure multiplies only the first volume term). Gold rotates A-E by index. QUERIED (used as gold) = the
+three real readouts; all five always appear as options.
+
+Distinctness: all four observed quantities are positive with `systolic_pressure > diastolic_pressure` (the driving
+pressure is positive), so every sum, difference and product is positive; the tables below are chosen so the five family
+values are pairwise distinct with a comfortable margin, asserted at build time.
+"""
+import json
+
+LETTERS = ["A", "B", "C", "D", "E"]
+
+# (SYSTOLIC_PRESSURE, DIASTOLIC_PRESSURE, FORWARD_VOLUME, REGURGITANT_VOLUME) — two pressures (mmHg) with
+# SYSTOLIC > DIASTOLIC, and two volumes (mL), all plain positive numbers. The five family values are asserted
+# pairwise-distinct (with margin) below.
+TABLES = [
+    (120, 80, 60, 20),
+    (140, 90, 55, 25),
+    (110, 70, 70, 10),
+    (130, 85, 50, 30),
+    (150, 100, 45, 15),
+    (125, 75, 65, 35),
+    (135, 95, 40, 28),
+]
+
+# The option family (5 members), all built from the four observed quantities via +, - and *. Every identifier is
+# DIGIT-FREE. key -> (display name, formula-as-adj). Only the first three are *queried* (used as gold); all five
+# always appear as the options.
+FAMILY = [
+    (
+        "stroke_work",
+        "stroke work (the driving pressure times the ejected volume)",
+        "(systolic_pressure - diastolic_pressure) * (forward_volume + regurgitant_volume)",
+    ),
+    (
+        "driving_pressure",
+        "the driving pressure (systolic minus diastolic)",
+        "systolic_pressure - diastolic_pressure",
+    ),
+    (
+        "ejected_volume",
+        "the ejected volume (forward plus regurgitant)",
+        "forward_volume + regurgitant_volume",
+    ),
+    (
+        "sum_version",
+        "the driving pressure and the ejected volume ADDED, not multiplied (a wrong work)",
+        "(systolic_pressure - diastolic_pressure) + (forward_volume + regurgitant_volume)",
+    ),
+    (
+        "misgrouped",
+        "the driving pressure times only the FORWARD volume, with regurgitant added on (broken grouping)",
+        "(systolic_pressure - diastolic_pressure) * forward_volume + regurgitant_volume",
+    ),
+]
+QUERIED = ["stroke_work", "driving_pressure", "ejected_volume"]
+ORDER = [k for k, _, _ in FAMILY]
+
+
+def scalar(v):
+    return {"value": v, "unit": "scalar"}
+
+
+def family_values(systolic_pressure, diastolic_pressure, forward_volume, regurgitant_volume):
+    # Operation order mirrors the ADJ programs exactly (a parenthesised difference times a parenthesised sum; and, for
+    # the misgrouped slip, the driving-times-forward product binds tighter than the trailing addition), so the Python
+    # option value and the engine result are the same IEEE-double (well within the harness's 1e-9 match tolerance).
+    drive = systolic_pressure - diastolic_pressure
+    ejected = forward_volume + regurgitant_volume
+    return {
+        "stroke_work": drive * ejected,
+        "driving_pressure": drive,
+        "ejected_volume": ejected,
+        "sum_version": drive + ejected,
+        "misgrouped": drive * forward_volume + regurgitant_volume,
+    }
+
+
+def build():
+    name_of = {k: nm for k, nm, _ in FAMILY}
+    formula_of = {k: f for k, _, f in FAMILY}
+    items = []
+    idx = 0
+
+    def num(x):
+        return int(x) if float(x).is_integer() else x
+
+    for systolic_pressure, diastolic_pressure, forward_volume, regurgitant_volume in TABLES:
+        assert (
+            systolic_pressure > diastolic_pressure > 0
+            and forward_volume > 0
+            and regurgitant_volume > 0
+        ), (systolic_pressure, diastolic_pressure, forward_volume, regurgitant_volume)
+        fv = family_values(systolic_pressure, diastolic_pressure, forward_volume, regurgitant_volume)
+        # Pairwise-distinct with a comfortable margin so the harness never sees two options
+        # matching the gold value within its 1e-9 tolerance.
+        vals = [fv[key] for key in ORDER]
+        for i in range(len(vals)):
+            for j in range(i + 1, len(vals)):
+                assert abs(vals[i] - vals[j]) > 1e-6, (
+                    systolic_pressure,
+                    diastolic_pressure,
+                    forward_volume,
+                    regurgitant_volume,
+                    ORDER[i],
+                    ORDER[j],
+                    fv,
+                )
+        for key in QUERIED:
+            gold_val = fv[key]
+            gold_pos = idx % 5
+            others = [fv[k2] for k2 in ORDER if abs(fv[k2] - gold_val) > 1e-12]
+            opts_vals = others[:]
+            opts_vals.insert(gold_pos, gold_val)
+            opts_vals = opts_vals[:5]
+            if abs(opts_vals[gold_pos] - gold_val) > 1e-12:
+                opts_vals[gold_pos] = gold_val
+            assert len({round(v, 9) for v in opts_vals}) == 5, (
+                key,
+                systolic_pressure,
+                diastolic_pressure,
+                forward_volume,
+                regurgitant_volume,
+                opts_vals,
+            )
+            options = {LETTERS[i]: scalar(opts_vals[i]) for i in range(5)}
+            items.append({
+                "id": f"r56work-{idx + 1:02d}",
+                "qtype": "stroke_work",
+                "stem": (
+                    f"A ventricle sees a systolic pressure of {num(systolic_pressure)} mmHg and a diastolic pressure of "
+                    f"{num(diastolic_pressure)} mmHg, and ejects a forward volume of {num(forward_volume)} mL plus a "
+                    f"regurgitant volume of {num(regurgitant_volume)} mL. What is the {name_of[key]}?"
+                ),
+                "program": (
+                    f"observe systolic_pressure({num(systolic_pressure)})\n"
+                    f"observe diastolic_pressure({num(diastolic_pressure)})\n"
+                    f"observe forward_volume({num(forward_volume)})\n"
+                    f"observe regurgitant_volume({num(regurgitant_volume)})\n"
+                    f"let answer = {formula_of[key]}\n"
+                    "? answer\n"
+                ),
+                "answer_from": {"type": "compute_dimensioned", "name": "answer"},
+                "options": options,
+                "gold_letter": LETTERS[gold_pos],
+            })
+            idx += 1
+    return {
+        "description": (
+            "ADJ-LADDER rung 56 — cardiac stroke work from four stated quantities (a NEW panel: cardiology / "
+            "ventricular-mechanics). From a systolic and a diastolic pressure and a forward and a regurgitant volume "
+            "compute the stroke work "
+            "((systolic_pressure-diastolic_pressure)*(forward_volume+regurgitant_volume)), the driving pressure "
+            "(systolic_pressure-diastolic_pressure), or the ejected volume (forward_volume+regurgitant_volume). Each "
+            "item is a compute_dimensioned program (observe the four quantities, let answer = formula); the ADJ engine "
+            "carries the arithmetic — a NEW shape, DIFFERENCE-TIMES-SUM (a-b)*(c+d), the first on the ladder to multiply "
+            "a difference by a sum (distinct from rung-55 product-of-two-sums (a+b)*(c+d) and rung-48 "
+            "sum-times-difference (a+b)*(c-d)) — and the harness matches the scalar to the printed options. "
+            "Contamination-safe: every index is built only from the four observed quantities via +, - and * — no "
+            "constant leaks, and neither the driving pressure, the ejected volume, nor any stroke-work figure ever "
+            "appears as a literal (each is computed) — and the observed quantities carry digit-free identifiers so no "
+            "numeral hides inside a variable name. The five options are a family over the same four quantities, so the "
+            "distractors are exactly the slips students make: ADDING the driving pressure and the ejected volume instead "
+            "of multiplying them, and breaking the grouping so the pressure multiplies only the forward volume "
+            "((a-b)*c+d, not (a-b)*(c+d)). The core confusion tested is multiplying a grouped difference by a grouped "
+            "sum."
+        ),
+        "items": items,
+    }
+
+
+if __name__ == "__main__":
+    doc = build()
+    with open("items.json", "w") as f:
+        json.dump(doc, f, indent=2)
+        f.write("\n")
+    print("wrote items.json:", len(doc["items"]), "items")
+    for it in doc["items"]:
+        print(it["id"], it["qtype"], "gold", it["gold_letter"],
+              "=", round(it["options"][it["gold_letter"]]["value"], 6))

--- a/code/specs/data/adj-ladder/rung56_stroke_work/items.json
+++ b/code/specs/data/adj-ladder/rung56_stroke_work/items.json
@@ -1,0 +1,698 @@
+{
+  "description": "ADJ-LADDER rung 56 \u2014 cardiac stroke work from four stated quantities (a NEW panel: cardiology / ventricular-mechanics). From a systolic and a diastolic pressure and a forward and a regurgitant volume compute the stroke work ((systolic_pressure-diastolic_pressure)*(forward_volume+regurgitant_volume)), the driving pressure (systolic_pressure-diastolic_pressure), or the ejected volume (forward_volume+regurgitant_volume). Each item is a compute_dimensioned program (observe the four quantities, let answer = formula); the ADJ engine carries the arithmetic \u2014 a NEW shape, DIFFERENCE-TIMES-SUM (a-b)*(c+d), the first on the ladder to multiply a difference by a sum (distinct from rung-55 product-of-two-sums (a+b)*(c+d) and rung-48 sum-times-difference (a+b)*(c-d)) \u2014 and the harness matches the scalar to the printed options. Contamination-safe: every index is built only from the four observed quantities via +, - and * \u2014 no constant leaks, and neither the driving pressure, the ejected volume, nor any stroke-work figure ever appears as a literal (each is computed) \u2014 and the observed quantities carry digit-free identifiers so no numeral hides inside a variable name. The five options are a family over the same four quantities, so the distractors are exactly the slips students make: ADDING the driving pressure and the ejected volume instead of multiplying them, and breaking the grouping so the pressure multiplies only the forward volume ((a-b)*c+d, not (a-b)*(c+d)). The core confusion tested is multiplying a grouped difference by a grouped sum.",
+  "items": [
+    {
+      "id": "r56work-01",
+      "qtype": "stroke_work",
+      "stem": "A ventricle sees a systolic pressure of 120 mmHg and a diastolic pressure of 80 mmHg, and ejects a forward volume of 60 mL plus a regurgitant volume of 20 mL. What is the stroke work (the driving pressure times the ejected volume)?",
+      "program": "observe systolic_pressure(120)\nobserve diastolic_pressure(80)\nobserve forward_volume(60)\nobserve regurgitant_volume(20)\nlet answer = (systolic_pressure - diastolic_pressure) * (forward_volume + regurgitant_volume)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3200,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 40,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 80,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 120,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 2420,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r56work-02",
+      "qtype": "stroke_work",
+      "stem": "A ventricle sees a systolic pressure of 120 mmHg and a diastolic pressure of 80 mmHg, and ejects a forward volume of 60 mL plus a regurgitant volume of 20 mL. What is the the driving pressure (systolic minus diastolic)?",
+      "program": "observe systolic_pressure(120)\nobserve diastolic_pressure(80)\nobserve forward_volume(60)\nobserve regurgitant_volume(20)\nlet answer = systolic_pressure - diastolic_pressure\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3200,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 40,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 80,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 120,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 2420,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r56work-03",
+      "qtype": "stroke_work",
+      "stem": "A ventricle sees a systolic pressure of 120 mmHg and a diastolic pressure of 80 mmHg, and ejects a forward volume of 60 mL plus a regurgitant volume of 20 mL. What is the the ejected volume (forward plus regurgitant)?",
+      "program": "observe systolic_pressure(120)\nobserve diastolic_pressure(80)\nobserve forward_volume(60)\nobserve regurgitant_volume(20)\nlet answer = forward_volume + regurgitant_volume\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3200,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 40,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 80,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 120,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 2420,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r56work-04",
+      "qtype": "stroke_work",
+      "stem": "A ventricle sees a systolic pressure of 140 mmHg and a diastolic pressure of 90 mmHg, and ejects a forward volume of 55 mL plus a regurgitant volume of 25 mL. What is the stroke work (the driving pressure times the ejected volume)?",
+      "program": "observe systolic_pressure(140)\nobserve diastolic_pressure(90)\nobserve forward_volume(55)\nobserve regurgitant_volume(25)\nlet answer = (systolic_pressure - diastolic_pressure) * (forward_volume + regurgitant_volume)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 50,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 80,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 130,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 4000,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 2775,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r56work-05",
+      "qtype": "stroke_work",
+      "stem": "A ventricle sees a systolic pressure of 140 mmHg and a diastolic pressure of 90 mmHg, and ejects a forward volume of 55 mL plus a regurgitant volume of 25 mL. What is the the driving pressure (systolic minus diastolic)?",
+      "program": "observe systolic_pressure(140)\nobserve diastolic_pressure(90)\nobserve forward_volume(55)\nobserve regurgitant_volume(25)\nlet answer = systolic_pressure - diastolic_pressure\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 4000,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 80,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 130,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 2775,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 50,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r56work-06",
+      "qtype": "stroke_work",
+      "stem": "A ventricle sees a systolic pressure of 140 mmHg and a diastolic pressure of 90 mmHg, and ejects a forward volume of 55 mL plus a regurgitant volume of 25 mL. What is the the ejected volume (forward plus regurgitant)?",
+      "program": "observe systolic_pressure(140)\nobserve diastolic_pressure(90)\nobserve forward_volume(55)\nobserve regurgitant_volume(25)\nlet answer = forward_volume + regurgitant_volume\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 80,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 4000,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 50,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 130,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 2775,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r56work-07",
+      "qtype": "stroke_work",
+      "stem": "A ventricle sees a systolic pressure of 110 mmHg and a diastolic pressure of 70 mmHg, and ejects a forward volume of 70 mL plus a regurgitant volume of 10 mL. What is the stroke work (the driving pressure times the ejected volume)?",
+      "program": "observe systolic_pressure(110)\nobserve diastolic_pressure(70)\nobserve forward_volume(70)\nobserve regurgitant_volume(10)\nlet answer = (systolic_pressure - diastolic_pressure) * (forward_volume + regurgitant_volume)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 40,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 3200,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 80,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 120,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 2810,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r56work-08",
+      "qtype": "stroke_work",
+      "stem": "A ventricle sees a systolic pressure of 110 mmHg and a diastolic pressure of 70 mmHg, and ejects a forward volume of 70 mL plus a regurgitant volume of 10 mL. What is the the driving pressure (systolic minus diastolic)?",
+      "program": "observe systolic_pressure(110)\nobserve diastolic_pressure(70)\nobserve forward_volume(70)\nobserve regurgitant_volume(10)\nlet answer = systolic_pressure - diastolic_pressure\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3200,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 80,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 40,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 120,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 2810,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r56work-09",
+      "qtype": "stroke_work",
+      "stem": "A ventricle sees a systolic pressure of 110 mmHg and a diastolic pressure of 70 mmHg, and ejects a forward volume of 70 mL plus a regurgitant volume of 10 mL. What is the the ejected volume (forward plus regurgitant)?",
+      "program": "observe systolic_pressure(110)\nobserve diastolic_pressure(70)\nobserve forward_volume(70)\nobserve regurgitant_volume(10)\nlet answer = forward_volume + regurgitant_volume\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3200,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 40,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 120,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 80,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 2810,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r56work-10",
+      "qtype": "stroke_work",
+      "stem": "A ventricle sees a systolic pressure of 130 mmHg and a diastolic pressure of 85 mmHg, and ejects a forward volume of 50 mL plus a regurgitant volume of 30 mL. What is the stroke work (the driving pressure times the ejected volume)?",
+      "program": "observe systolic_pressure(130)\nobserve diastolic_pressure(85)\nobserve forward_volume(50)\nobserve regurgitant_volume(30)\nlet answer = (systolic_pressure - diastolic_pressure) * (forward_volume + regurgitant_volume)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 45,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 80,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 125,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 2280,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 3600,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r56work-11",
+      "qtype": "stroke_work",
+      "stem": "A ventricle sees a systolic pressure of 130 mmHg and a diastolic pressure of 85 mmHg, and ejects a forward volume of 50 mL plus a regurgitant volume of 30 mL. What is the the driving pressure (systolic minus diastolic)?",
+      "program": "observe systolic_pressure(130)\nobserve diastolic_pressure(85)\nobserve forward_volume(50)\nobserve regurgitant_volume(30)\nlet answer = systolic_pressure - diastolic_pressure\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 45,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 3600,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 80,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 125,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 2280,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r56work-12",
+      "qtype": "stroke_work",
+      "stem": "A ventricle sees a systolic pressure of 130 mmHg and a diastolic pressure of 85 mmHg, and ejects a forward volume of 50 mL plus a regurgitant volume of 30 mL. What is the the ejected volume (forward plus regurgitant)?",
+      "program": "observe systolic_pressure(130)\nobserve diastolic_pressure(85)\nobserve forward_volume(50)\nobserve regurgitant_volume(30)\nlet answer = forward_volume + regurgitant_volume\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3600,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 80,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 45,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 125,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 2280,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r56work-13",
+      "qtype": "stroke_work",
+      "stem": "A ventricle sees a systolic pressure of 150 mmHg and a diastolic pressure of 100 mmHg, and ejects a forward volume of 45 mL plus a regurgitant volume of 15 mL. What is the stroke work (the driving pressure times the ejected volume)?",
+      "program": "observe systolic_pressure(150)\nobserve diastolic_pressure(100)\nobserve forward_volume(45)\nobserve regurgitant_volume(15)\nlet answer = (systolic_pressure - diastolic_pressure) * (forward_volume + regurgitant_volume)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 50,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 60,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 3000,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 110,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 2265,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r56work-14",
+      "qtype": "stroke_work",
+      "stem": "A ventricle sees a systolic pressure of 150 mmHg and a diastolic pressure of 100 mmHg, and ejects a forward volume of 45 mL plus a regurgitant volume of 15 mL. What is the the driving pressure (systolic minus diastolic)?",
+      "program": "observe systolic_pressure(150)\nobserve diastolic_pressure(100)\nobserve forward_volume(45)\nobserve regurgitant_volume(15)\nlet answer = systolic_pressure - diastolic_pressure\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3000,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 60,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 110,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 50,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 2265,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r56work-15",
+      "qtype": "stroke_work",
+      "stem": "A ventricle sees a systolic pressure of 150 mmHg and a diastolic pressure of 100 mmHg, and ejects a forward volume of 45 mL plus a regurgitant volume of 15 mL. What is the the ejected volume (forward plus regurgitant)?",
+      "program": "observe systolic_pressure(150)\nobserve diastolic_pressure(100)\nobserve forward_volume(45)\nobserve regurgitant_volume(15)\nlet answer = forward_volume + regurgitant_volume\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3000,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 50,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 110,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 2265,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 60,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r56work-16",
+      "qtype": "stroke_work",
+      "stem": "A ventricle sees a systolic pressure of 125 mmHg and a diastolic pressure of 75 mmHg, and ejects a forward volume of 65 mL plus a regurgitant volume of 35 mL. What is the stroke work (the driving pressure times the ejected volume)?",
+      "program": "observe systolic_pressure(125)\nobserve diastolic_pressure(75)\nobserve forward_volume(65)\nobserve regurgitant_volume(35)\nlet answer = (systolic_pressure - diastolic_pressure) * (forward_volume + regurgitant_volume)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 5000,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 50,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 100,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 150,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 3285,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r56work-17",
+      "qtype": "stroke_work",
+      "stem": "A ventricle sees a systolic pressure of 125 mmHg and a diastolic pressure of 75 mmHg, and ejects a forward volume of 65 mL plus a regurgitant volume of 35 mL. What is the the driving pressure (systolic minus diastolic)?",
+      "program": "observe systolic_pressure(125)\nobserve diastolic_pressure(75)\nobserve forward_volume(65)\nobserve regurgitant_volume(35)\nlet answer = systolic_pressure - diastolic_pressure\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 5000,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 50,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 100,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 150,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 3285,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r56work-18",
+      "qtype": "stroke_work",
+      "stem": "A ventricle sees a systolic pressure of 125 mmHg and a diastolic pressure of 75 mmHg, and ejects a forward volume of 65 mL plus a regurgitant volume of 35 mL. What is the the ejected volume (forward plus regurgitant)?",
+      "program": "observe systolic_pressure(125)\nobserve diastolic_pressure(75)\nobserve forward_volume(65)\nobserve regurgitant_volume(35)\nlet answer = forward_volume + regurgitant_volume\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 5000,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 50,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 100,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 150,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 3285,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r56work-19",
+      "qtype": "stroke_work",
+      "stem": "A ventricle sees a systolic pressure of 135 mmHg and a diastolic pressure of 95 mmHg, and ejects a forward volume of 40 mL plus a regurgitant volume of 28 mL. What is the stroke work (the driving pressure times the ejected volume)?",
+      "program": "observe systolic_pressure(135)\nobserve diastolic_pressure(95)\nobserve forward_volume(40)\nobserve regurgitant_volume(28)\nlet answer = (systolic_pressure - diastolic_pressure) * (forward_volume + regurgitant_volume)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 40,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 68,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 108,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 2720,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1628,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r56work-20",
+      "qtype": "stroke_work",
+      "stem": "A ventricle sees a systolic pressure of 135 mmHg and a diastolic pressure of 95 mmHg, and ejects a forward volume of 40 mL plus a regurgitant volume of 28 mL. What is the the driving pressure (systolic minus diastolic)?",
+      "program": "observe systolic_pressure(135)\nobserve diastolic_pressure(95)\nobserve forward_volume(40)\nobserve regurgitant_volume(28)\nlet answer = systolic_pressure - diastolic_pressure\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 2720,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 68,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 108,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 1628,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 40,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r56work-21",
+      "qtype": "stroke_work",
+      "stem": "A ventricle sees a systolic pressure of 135 mmHg and a diastolic pressure of 95 mmHg, and ejects a forward volume of 40 mL plus a regurgitant volume of 28 mL. What is the the ejected volume (forward plus regurgitant)?",
+      "program": "observe systolic_pressure(135)\nobserve diastolic_pressure(95)\nobserve forward_volume(40)\nobserve regurgitant_volume(28)\nlet answer = forward_volume + regurgitant_volume\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 68,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2720,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 40,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 108,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1628,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    }
+  ]
+}

--- a/code/specs/data/adj-ladder/test_ladder_eval.py
+++ b/code/specs/data/adj-ladder/test_ladder_eval.py
@@ -93,6 +93,7 @@ SELF_CONTAINED_RUNGS = (
     "rung53_caloric_density",
     "rung54_neutrophil_ratio",
     "rung55_fresh_gas_volume",
+    "rung56_stroke_work",
 )
 
 


### PR DESCRIPTION
## ADJ-LADDER rung-56 — cardiac stroke work (difference-times-sum `(a-b)*(c+d)`)

Adds the next self-contained rung to the ADJ-LADDER, opening the **cardiology / ventricular-mechanics** panel on the quantitative band.

### New arithmetic shape
The headline readout multiplies a parenthesised **difference** by a parenthesised **sum**:

```
stroke work = (systolic_pressure − diastolic_pressure) · (forward_volume + regurgitant_volume)
```

This is a genuinely NEW shape on the ladder — **difference-times-sum** `(a−b)·(c+d)`, the first to multiply a difference by a sum. It is distinct from:
- rung-55 product-of-two-sums `(a+b)·(c+d)`
- rung-48 sum-times-difference `(a+b)·(c−d)`
- rung-33 product-of-two-differences `(a−b)·(c−d)`

The driving pressure `(systolic − diastolic)` and ejected volume `(forward + regurgitant)` ride alongside as component readouts, so the panel teaches the whole calculation.

### Contents
- 7 tables × 3 queried readouts = **21 items**, each a `compute_dimensioned` program (`observe` the four quantities, `let answer = formula`, `? answer`). The ADJ engine carries the arithmetic — no harness/engine change.
- Five-member option family over the same four quantities: three real readouts + two classic slips (**sum_version**: adding driving pressure and ejected volume instead of multiplying; **misgrouped**: `(a−b)·c + d`, breaking the grouping so the pressure multiplies only the forward volume).
- Gold rotates A–E by index; family values asserted **pairwise-distinct with margin** at build.

### Contamination-safety
Every formula is built ONLY from the four observed quantities via `+`, `−`, `*` — **no numeric constants**, and neither the driving pressure, the ejected volume, nor any stroke-work figure ever appears as a literal (each is computed). Observed quantities carry **digit-free identifiers** (`systolic_pressure`, `diastolic_pressure`, `forward_volume`, `regurgitant_volume`) so no numeral hides inside a variable name.

### Verification
- `gen_items.py` run from the rung subdir → `items.json` (21 items).
- Registered in `SELF_CONTAINED_RUNGS`.
- Gate: `pytest -k rung56` → **3/3 passed**.
- Security review: PASSED (offline data generator, no external input, no injection/eval/path/DoS surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
