### PR TITLE
feat(ruby-sir): implicit return of trailing case from method bodies (FC)

### DIFF
--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.6.2] - 2026-07-02
+
+### Added (FC — implicit return of a trailing `case` from a method body)
+
+Extends the trailing-conditional implicit return (0.6.1's `if`/`unless`) to
+`case`. A Ruby method's value is its last evaluated expression, and `case`
+(both `case/when` value-matching and `case/in` pattern-matching) is an
+expression that already lowers to a chained `Expr::If`. Before this change a
+method body ending in a `case` left it as a discarded statement and returned
+`nil` on every backend; now the `case` is promoted to the block's `value`.
+
+- `lower_tail_value` gains a `case_statement` arm (routing through
+  `lower_case_statement`), so a `def` whose body ends in a `case` returns the
+  matched arm's value; because `case` arms are built with
+  `lower_clause_statements` (which calls `lower_tail_value`), promotion recurses
+  through nested tail conditionals.
+- Verified end to end: `def grade(n); case n; when 90 then "A"; when 80 then
+  "B"; else "C"; end; end` with `puts grade(90/80/50)` prints `A/B/C` on
+  Python, JavaScript, Go, and Rust (was blank/nil before). This is now provable
+  on all backends because the `case_eq` builtin the chain relies on was
+  implemented across Go/Rust/JS in a prior PR.
+- Four new unit tests (tail `case/when`, tail `case/in`,
+  leading-stmts-then-tail-`case`, validator pass). All 427 frontend tests pass.
+
 ## [0.6.1] - 2026-07-02
 
 ### Fixed (FC — implicit return of a trailing `if`/`unless` from a method body)

--- a/code/packages/rust/ruby-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/ruby-to-semantic-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruby-to-semantic-ir"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 description = "Ruby AST → narrow-waist Semantic IR. Phase 5 of the Ruby parser project — first frontend for the ruby-parser → SIR pipeline."
 

--- a/code/packages/rust/ruby-to-semantic-ir/README.md
+++ b/code/packages/rust/ruby-to-semantic-ir/README.md
@@ -57,12 +57,13 @@ parses (see [ruby-parser/src/_grammar.rs](../ruby-parser/src/_grammar.rs)):
   a method's value is its **last evaluated expression**.  The tail statement
   of a `def` body (and of each `if`/`unless` branch) is promoted into the SIR
   `Block.value` slot the backends emit as the implicit return.  Besides bare
-  expressions and calls, a trailing **`if`/`unless`** is now promoted too:
-  `def bigger(a, b); if a > b then a else b end; end` returns the winning
+  expressions and calls, a trailing **`if`/`unless`** and **`case`** (both
+  `case/when` and `case/in`, which lower to a chained `if`) are now promoted
+  too: `def bigger(a, b); if a > b then a else b end; end` returns the winning
   branch (previously the conditional was left as a discarded statement and the
-  method returned `nil` on every backend).  Promotion recurses — a branch that
-  itself ends in an `if` carries its own value — so arbitrarily nested tail
-  conditionals all return correctly.  (A *script's* top-level value is not
+  method returned `nil` on every backend).  Promotion recurses — a branch (or
+  `case` arm) that itself ends in a conditional carries its own value — so
+  arbitrarily nested tail conditionals all return correctly.  (A *script's* top-level value is not
   language-visible, so a bare trailing `if` at program scope stays a
   statement; only method/branch bodies implicitly return.)
 
@@ -111,9 +112,9 @@ function).
 ## What's deferred
 
 - Control flow beyond v0 and refinements.
-- Implicit return of a trailing **`case`** or **`begin`/`rescue`** (only
-  `if`/`unless` tail conditionals promote to the block value so far), and of a
-  block/lambda's tail conditional.
+- Implicit return of a trailing **`begin`/`rescue`** (a trailing `if`/`unless`
+  and `case` — both `case/when` and `case/in` — now promote to the block value),
+  and of a block/lambda's tail conditional.
 - The full set of Ruby's literal forms (regex, ranges, arrays,
   hashes, symbols, heredocs as runtime values — heredocs ARE lexed
   per Phase 3c, just not yet lowered to IR shape).

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -735,6 +735,94 @@ mod tests {
         assert!(result.is_ok(), "validator rejected our output: {:?}", result);
     }
 
+    // ─────────────────────────────────────────────────────────────────
+    // Phase FC (cont.) — implicit return of a trailing `case` from a
+    // method body.  `case` (both `case/when` value-matching and `case/in`
+    // pattern-matching) already lowers to a chained `Expr::If`; promoting
+    // it in tail position makes the method return the matched arm's value
+    // instead of `nil`.
+    // ─────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn def_body_ending_in_case_when_returns_the_chained_if() {
+        // `grade` ends in a `case/when` — the whole chain is the method's
+        // return value, landing in `body.value` (a chained `Expr::If`), and
+        // each arm's own tail (`"A"`, `"B"`, `"C"`) promotes to that arm's
+        // block value.
+        let m = lower(
+            "def grade(n)\n  case n\n  when 90\n    \"A\"\n  when 80\n    \"B\"\n  else\n    \"C\"\n  end\nend\n",
+        );
+        let body = fn_body(&m, "grade");
+        let Expr::If { then_branch, else_branch, .. } = &body.value else {
+            panic!("expected body.value = chained Expr::If, got {:?}", body.value);
+        };
+        // First arm value is the string "A".
+        assert!(
+            matches!(&then_branch.value, Expr::StrLit { value, .. } if value == "A"),
+            "first when-arm value should be \"A\", got {:?}",
+            then_branch.value
+        );
+        // The else_branch is itself another If (the `when 80` step), proving
+        // the chain unwound rather than collapsing to nil.
+        assert!(
+            matches!(&else_branch.value, Expr::If { .. }),
+            "case chain should nest in the else branch, got {:?}",
+            else_branch.value
+        );
+        // The tail `case` was promoted, not left dangling as a statement.
+        assert!(
+            !body
+                .stmts
+                .iter()
+                .any(|s| matches!(s, Stmt::ExprStmt { expr: Expr::If { .. }, .. })),
+            "the tail `case` must be promoted to value, not duplicated as a stmt"
+        );
+    }
+
+    #[test]
+    fn def_body_ending_in_case_in_pattern_returns_value() {
+        // `case/in` pattern matching shares the same `case_statement` rule and
+        // lowers to a chained `Expr::If`; a method ending in one returns the
+        // matched arm's value.
+        let m = lower(
+            "def classify(x)\n  case x\n  in 0\n    \"zero\"\n  else\n    \"other\"\n  end\nend\n",
+        );
+        let body = fn_body(&m, "classify");
+        assert!(
+            matches!(&body.value, Expr::If { .. }),
+            "the tail `case/in` must be the body value, got {:?}",
+            body.value
+        );
+    }
+
+    #[test]
+    fn def_body_leading_stmts_then_tail_case_are_both_kept() {
+        // A statement before the tail `case` stays in `stmts`; only the final
+        // `case` is promoted to `value`.
+        let m = lower(
+            "def label(n)\n  m = n + 1\n  case m\n  when 1\n    \"one\"\n  else\n    \"many\"\n  end\nend\n",
+        );
+        let body = fn_body(&m, "label");
+        assert!(
+            !body.stmts.is_empty(),
+            "the `m = n + 1` binding must remain a statement"
+        );
+        assert!(
+            matches!(&body.value, Expr::If { .. }),
+            "the tail `case` must be the body value, got {:?}",
+            body.value
+        );
+    }
+
+    #[test]
+    fn def_body_tail_case_module_passes_sir_validator() {
+        let m = lower(
+            "def grade(n)\n  case n\n  when 90\n    \"A\"\n  else\n    \"C\"\n  end\nend\n",
+        );
+        let result = semantic_ir::validate(&m);
+        assert!(result.is_ok(), "validator rejected our output: {:?}", result);
+    }
+
     #[test]
     fn def_rest_param_lowers_to_kind_rest() {
         // M3: `def f(*r); end` → one Param whose kind is Rest (previously the

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -1421,6 +1421,7 @@ impl Lowerer {
     /// | `expression_stmt`                    | the bare expression                |
     /// | `method_call` / `method_call_no_paren` | the call's result                |
     /// | `if_statement` / `unless_statement`  | an [`Expr::If`] (branches recurse) |
+    /// | `case_statement` (`case/when`, `case/in`) | a chained [`Expr::If`] (arms recurse) |
     /// | anything else (assignment, `while`…) | `None` — the node stays a `Stmt`   |
     ///
     /// Returning `None` tells the caller to route the node through
@@ -1454,6 +1455,12 @@ impl Lowerer {
             }
             "method_call" | "method_call_no_paren" => self.lower_method_call(inner)?,
             "if_statement" | "unless_statement" => self.lower_if_or_unless(inner)?,
+            // A `case` (both `case/when` value-matching and `case/in` pattern
+            // matching) already lowers to a chained `Expr::If` whose arms are
+            // built with `lower_clause_statements` — so promoting it here makes
+            // a method that ends in a `case` return the matched arm's value
+            // (recursing through the same helper), instead of `nil`.
+            "case_statement" => self.lower_case_statement(inner)?,
             _ => return Ok(None),
         };
         Ok(Some(value))


### PR DESCRIPTION
## What

Extends the trailing-conditional implicit return — [#7451](https://github.com/adhithyan15/coding-adventures/pull/7451) did `if`/`unless`; this does **`case`** (both `case/when` value-matching and `case/in` pattern-matching).

Ruby has no explicit `return`: a method's value is its **last evaluated expression**, and `case` is an expression (it already lowers to a chained `Expr::If`). A method body ending in a `case` previously left it as a discarded statement and returned `nil` on every backend; now the `case` is promoted into the block's implicit-return `value`.

## Change

One new arm in the shared `lower_tail_value` helper:

```rust
"case_statement" => self.lower_case_statement(inner)?,
```

Because `case` arms are built with `lower_clause_statements` (which itself calls `lower_tail_value`), promotion **recurses** through nested tail conditionals — a `case` arm that ends in an `if`/`case` carries its own value.

## Verified end-to-end (all four backends)

```ruby
def grade(n)
  case n
  when 90 then "A"
  when 80 then "B"
  else "C"
  end
end
puts grade(90); puts grade(80); puts grade(50)
```

| Backend | Before | After |
|---|---|---|
| Python | *(nil/blank)* | `A/B/C` |
| JavaScript (`node`) | *(nil/blank)* | `A/B/C` |
| Go (`go run`) | *(nil/blank)* | `A/B/C` |
| Rust (`rustc`) | *(nil/blank)* | `A/B/C` |

This is now provable on **all** backends because the `case_eq` builtin the chain relies on was implemented across Go/Rust/JS in the prior PR ([#7463](https://github.com/adhithyan15/coding-adventures/pull/7463)) — without it, `case` panicked on 3 of 5.

## Also

- 4 new unit tests (tail `case/when`, tail `case/in`, leading-stmts-then-tail-`case`, validator pass); all 427 frontend tests pass.
- Version 0.6.1 → 0.6.2; README (case moved from "deferred" to done) + CHANGELOG updated.
- Security review: **passed** (recursion bounded by source nesting depth, identical to the existing `if` arm; no new panics/unwraps).

## Remaining in this arc

Trailing `begin`/`rescue` implicit return, block/lambda tail conditionals, and a cross-backend golden suite driving Ruby source → all 5 backends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)