### PR TITLE
test(sir): cross-backend golden conformance harness (sir-conformance)

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -520,6 +520,7 @@ members = [
     "repl",
     "ruby-bridge",
     "ruby-to-semantic-ir",
+    "sir-conformance",
     "javascript-to-semantic-ir",
     "scytale-cipher",
     "sha256",

--- a/code/packages/rust/sir-conformance/CHANGELOG.md
+++ b/code/packages/rust/sir-conformance/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+All notable changes to the `sir-conformance` crate will be documented in this file.
+
+## [0.1.0] - 2026-07-02
+
+### Added — cross-backend golden conformance harness
+
+The first test that drives real Ruby **source** all the way to Python,
+JavaScript, Go, and Rust and proves the four agree — closing the long-standing
+gap where no single test exercised Ruby → {Go, Rust} end-to-end, and where a
+frontend-emitted construct missing from a backend runtime (like the `case_eq`
+builtin) could pass every per-backend unit test yet crash at runtime.
+
+- **`Program` corpus + reference oracle.** Each program is Ruby source paired
+  with the exact stdout a Ruby interpreter would produce; every backend is
+  measured against that reference, never against another backend.
+- **`run(program, target)` / `lower(program)`.** Public plumbing that lowers a
+  program through `ruby_to_semantic_ir`, emits it via a backend, and runs it
+  through the real toolchain (`python3` with the `sir-runtime-*` packages
+  auto-discovered onto `PYTHONPATH`; `node`; `go run`; `rustc` + execute),
+  returning normalised stdout. Reusable by future conformance suites (e.g. the
+  SIR21 typed-integer matrix).
+- **Graceful skip + hollow-pass guard.** A backend whose toolchain is absent is
+  skipped (logged), not failed; the matrix test asserts at least one backend
+  actually ran so a toolchain-less host cannot report a hollow pass. The Go
+  toolchain is probed with `go version` (not `--version`, which errors).
+- **Initial corpus (6 programs):** operator precedence, method-with-params
+  implicit return, trailing-`if` return, trailing-`case` return (the `case_eq`
+  regression oracle), string concatenation, and a `class`/`.new`/method call.
+  Verified locally: 6 corpus × 4 backends = 24 runs, 0 skipped, all agree.
+
+This is the first slice of
+[`SIR21` §Provability](../../../specs/SIR21-type-system-and-integer-semantics.md)'s
+conformance matrix (P1).

--- a/code/packages/rust/sir-conformance/Cargo.toml
+++ b/code/packages/rust/sir-conformance/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "sir-conformance"
+version = "0.1.0"
+edition = "2021"
+description = "Cross-backend golden conformance harness for the Semantic IR: lowers real Ruby source and runs the emitted program through every backend's real toolchain, asserting identical output."
+
+[dependencies]
+ruby-to-semantic-ir = { path = "../ruby-to-semantic-ir" }
+semantic-ir = { path = "../semantic-ir" }
+semantic-ir-to-python = { path = "../semantic-ir-to-python" }
+semantic-ir-to-javascript = { path = "../semantic-ir-to-javascript" }
+semantic-ir-to-go = { path = "../semantic-ir-to-go" }
+semantic-ir-to-rust = { path = "../semantic-ir-to-rust" }

--- a/code/packages/rust/sir-conformance/README.md
+++ b/code/packages/rust/sir-conformance/README.md
@@ -1,0 +1,88 @@
+# sir-conformance
+
+**Cross-backend golden conformance harness for the Semantic IR.**
+
+Lowers real Ruby *source* through the actual frontend and runs the emitted
+program through **every** backend's **real** toolchain, asserting the output is
+identical — byte for byte — on each.
+
+## Why
+
+The Semantic IR (SIR) is a narrow waist: one Ruby frontend
+(`ruby-to-semantic-ir`) lowers to a language-agnostic IR, and several backends
+emit target source (`semantic-ir-to-{python,javascript,go,rust}`). The whole
+point is **behavioural equivalence** — a program's result must not depend on
+which backend emitted it.
+
+Nothing enforced that end-to-end. Each backend's own `compile_and_run_*` test
+*hand-builds* an SIR module and checks one feature in isolation, so a construct
+the frontend emits but a backend never implemented can pass every unit test and
+still crash at runtime. That is exactly what happened with the `case_eq` builtin
+(Ruby's `===`): it was missing from three of five runtimes, so every `case`
+program panicked on Go, Rust, and JavaScript while passing on Python — and no
+test caught it (see the repo `lessons.md`).
+
+This harness closes the gap. It is the first concrete slice of the conformance
+matrix specified in
+[`SIR21` §Provability](../../../specs/SIR21-type-system-and-integer-semantics.md).
+
+## How it works
+
+For every program in the corpus, and every backend:
+
+1. **Lower** the Ruby source through `ruby_to_semantic_ir::compile_source`
+   (the frontend runs once per program, as in production).
+2. **Emit** target source via the backend's `compile`.
+3. **Run** it through the real toolchain — `python3` (with the `sir-runtime-*`
+   packages auto-discovered onto `PYTHONPATH`), `node`, `go run`, or
+   `rustc` + execute.
+4. **Assert** the normalised stdout equals the corpus's **reference** output.
+
+Comparison is always against the reference (the value a Ruby interpreter would
+print), never against another backend — so two backends agreeing on a *wrong*
+answer cannot hide a bug.
+
+A backend whose toolchain is absent on the host is **skipped** (logged), not
+failed — mirroring the per-backend exec-test convention. The matrix test also
+asserts that *at least one* backend actually ran, so a toolchain-less CI box
+cannot report a hollow pass.
+
+## The corpus
+
+Small and behavioural (strings/integers only — booleans render differently
+across backends, a separate formatting concern). Current programs:
+
+| program | exercises | reference output |
+|---------|-----------|------------------|
+| `arithmetic` | operator precedence | `14` |
+| `def_params` | method with params + implicit return | `5` |
+| `tail_if` | implicit return of a trailing `if` | `10` |
+| `tail_case` | implicit return of a trailing `case` (the `case_eq` oracle) | `A\nB\nC` |
+| `string_concat` | polymorphic `+` | `abcd` |
+| `oop_method` | `class` / `.new` / instance method | `woof` |
+
+Adding a program is one `Program { name, ruby, expected }` entry in
+`tests/conformance.rs`.
+
+## Usage
+
+```bash
+# Run the whole matrix (skips backends whose toolchain is absent):
+cargo test -p sir-conformance -- --nocapture
+
+# The summary line reports coverage, e.g.:
+#   conformance matrix: 6 corpus x 4 backends = 24 ran, 0 skipped
+```
+
+As a library, `run(&program, target) -> RunOutcome` and `lower(&program)` are
+public so other harnesses (e.g. the eventual typed-integer conformance suite)
+can reuse the emit-and-run plumbing.
+
+## Where it fits
+
+```
+Ruby source ──► ruby-to-semantic-ir ──► SIR ──► semantic-ir-to-{py,js,go,rust} ──► run
+                                                         ▲
+                              sir-conformance drives this whole path and
+                              checks all four outputs agree with the reference.
+```

--- a/code/packages/rust/sir-conformance/src/lib.rs
+++ b/code/packages/rust/sir-conformance/src/lib.rs
@@ -1,0 +1,328 @@
+//! # sir-conformance — cross-backend golden conformance harness
+//!
+//! This crate answers one question, by *running code*: **does the same Ruby
+//! program produce the same output on every backend?**
+//!
+//! The Semantic IR (SIR) is a narrow waist — one Ruby frontend
+//! ([`ruby_to_semantic_ir`]) lowers to a language-agnostic IR, and several
+//! backends emit target source (Python, JavaScript, Go, Rust). The promise of
+//! that design is *behavioural equivalence*: a program's observable result must
+//! not depend on which backend emitted it. Nothing enforced that promise
+//! end-to-end — each backend's own `compile_and_run_*` test hand-builds an SIR
+//! module and checks one feature in isolation, so a construct the frontend
+//! emits but a backend never implemented could pass every unit test and still
+//! crash at runtime. (That is exactly what happened with the `case_eq` builtin,
+//! which was missing from three of five runtimes; see the repo's `lessons.md`.)
+//!
+//! This harness closes that gap. It takes a corpus of **real Ruby source**
+//! programs, each paired with **one expected stdout** (the reference answer,
+//! written once), lowers each through the actual frontend, emits it through
+//! *every* backend, runs the emitted program through that backend's *real*
+//! toolchain (`python3`, `node`, `go`, `rustc`), and asserts the output equals
+//! the reference — **byte for byte, on every backend**. A disagreement is a
+//! faithfulness bug, localised to `(program, backend)`.
+//!
+//! This is the first, concrete slice of the conformance matrix specified in
+//! [`SIR21` §Provability](../../../specs/SIR21-type-system-and-integer-semantics.md).
+//!
+//! ## Reference-oracle discipline
+//!
+//! The expected output is compared against **the reference**, never against
+//! another backend — so two backends agreeing on a *wrong* answer cannot hide a
+//! bug. The reference is the value the Ruby program would print under a real
+//! Ruby interpreter; we encode it as a literal string in the corpus.
+//!
+//! ## Graceful degradation
+//!
+//! A backend whose toolchain is absent on the host is **skipped**, not failed
+//! (mirroring the per-backend `compile_and_run_*` convention). The harness
+//! proves what it can on the host it runs on; locally, with all toolchains
+//! present, it proves the full matrix.
+
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+use ruby_to_semantic_ir::compile_source;
+use semantic_ir::Module;
+
+/// One conformance program: a name, its Ruby source, and the **reference**
+/// stdout it must produce on every backend.
+#[derive(Debug, Clone)]
+pub struct Program {
+    /// Short identifier used in temp filenames and assertion messages.
+    pub name: &'static str,
+    /// The Ruby source to lower and run.
+    pub ruby: &'static str,
+    /// The exact stdout a real Ruby interpreter would produce (trailing
+    /// whitespace is normalised away before comparison, so a single trailing
+    /// newline need not be encoded).
+    pub expected: &'static str,
+}
+
+/// A backend target and the toolchain that runs its emitted source.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Target {
+    Python,
+    JavaScript,
+    Go,
+    Rust,
+}
+
+impl Target {
+    /// Every target the harness knows how to run.
+    pub fn all() -> &'static [Target] {
+        &[Target::Python, Target::JavaScript, Target::Go, Target::Rust]
+    }
+
+    /// Human-readable tag for assertion messages.
+    pub fn tag(self) -> &'static str {
+        match self {
+            Target::Python => "python",
+            Target::JavaScript => "javascript",
+            Target::Go => "go",
+            Target::Rust => "rust",
+        }
+    }
+
+    /// The executable that must be on `PATH` for this target to run.
+    fn toolchain(self) -> &'static str {
+        match self {
+            Target::Python => "python3",
+            Target::JavaScript => "node",
+            Target::Go => "go",
+            Target::Rust => "rustc",
+        }
+    }
+
+    /// The version-probe argument for this toolchain. Most accept `--version`,
+    /// but the Go CLI uses the bare subcommand `go version` (dashes make it
+    /// error), which would otherwise make the harness silently skip Go.
+    fn version_arg(self) -> &'static str {
+        match self {
+            Target::Go => "version",
+            _ => "--version",
+        }
+    }
+
+    /// Is this target's toolchain available on the host? A missing toolchain
+    /// means the caller should *skip* (not fail) that target.
+    pub fn available(self) -> bool {
+        Command::new(self.toolchain())
+            .arg(self.version_arg())
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    }
+}
+
+/// The outcome of running one program through one backend.
+#[derive(Debug)]
+pub enum RunOutcome {
+    /// The program compiled and ran; carries its normalised stdout.
+    Ran(String),
+    /// The toolchain (or a usable linker) was absent — skip, do not fail.
+    Skipped(String),
+    /// A genuine failure: emit error, compile error, or non-zero exit.
+    Failed(String),
+}
+
+/// Lower `program.ruby` to SIR (shared by every backend so the *frontend* runs
+/// exactly once per program, as it would in production).
+pub fn lower(program: &Program) -> Result<Module, String> {
+    compile_source(program.ruby, program.name)
+        .map_err(|e| format!("frontend failed to lower `{}`: {e:?}", program.name))
+}
+
+/// Run one `program` through one `target`: emit, compile if needed, execute
+/// through the real toolchain, and return the normalised stdout.
+pub fn run(program: &Program, target: Target) -> RunOutcome {
+    if !target.available() {
+        return RunOutcome::Skipped(format!("{} not on PATH", target.toolchain()));
+    }
+    let module = match lower(program) {
+        Ok(m) => m,
+        Err(e) => return RunOutcome::Failed(e),
+    };
+    match target {
+        Target::Python => run_python(program, &module),
+        Target::JavaScript => run_javascript(program, &module),
+        Target::Go => run_go(program, &module),
+        Target::Rust => run_rust(program, &module),
+    }
+}
+
+/// Normalise stdout for comparison: unify CRLF→LF and strip trailing newlines
+/// so the assertion tests *content*, not a platform's newline convention.
+fn normalise(s: &str) -> String {
+    s.replace("\r\n", "\n").trim_end_matches('\n').to_string()
+}
+
+fn temp_path(program: &Program, target: Target, ext: &str) -> PathBuf {
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "sir_conf_{}_{}_{}{ext}",
+        program.name,
+        target.tag(),
+        std::process::id()
+    ));
+    p
+}
+
+// ── Python ────────────────────────────────────────────────────────────────
+//
+// The Python backend emits code that imports the `sir-runtime-*` packages
+// rather than inlining a runtime, so `python3` must see them on `PYTHONPATH`.
+// We discover the package `src/` directories relative to this crate (they live
+// under `code/packages/python/sir-runtime-*/src`) so the harness is
+// self-locating and needs no environment setup by the caller.
+
+fn python_runtime_path() -> Option<String> {
+    // CARGO_MANIFEST_DIR = <repo>/code/packages/rust/sir-conformance
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let py_dir = manifest.parent()?.parent()?.join("python");
+    let mut parts: Vec<String> = Vec::new();
+    for entry in fs::read_dir(&py_dir).ok()? {
+        let entry = entry.ok()?;
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if name.starts_with("sir-runtime-") {
+            let src = entry.path().join("src");
+            if src.is_dir() {
+                parts.push(src.to_string_lossy().into_owned());
+            }
+        }
+    }
+    if parts.is_empty() {
+        None
+    } else {
+        Some(parts.join(":"))
+    }
+}
+
+fn run_python(program: &Program, module: &Module) -> RunOutcome {
+    let artifact = match semantic_ir_to_python::compile(module) {
+        Ok(a) => a,
+        Err(e) => return RunOutcome::Failed(format!("python emit failed: {e:?}")),
+    };
+    let path = temp_path(program, Target::Python, ".py");
+    if fs::write(&path, &artifact.source).is_err() {
+        return RunOutcome::Failed("could not write temp .py".into());
+    }
+    let Some(pythonpath) = python_runtime_path() else {
+        return RunOutcome::Skipped("sir-runtime-* python packages not found".into());
+    };
+    let out = Command::new("python3")
+        .arg(&path)
+        .env("PYTHONPATH", pythonpath)
+        .output();
+    let _ = fs::remove_file(&path);
+    finish(out, &artifact.source, "python")
+}
+
+// ── JavaScript ──────────────────────────────────────────────────────────────
+
+fn run_javascript(program: &Program, module: &Module) -> RunOutcome {
+    let artifact = match semantic_ir_to_javascript::compile(module) {
+        Ok(a) => a,
+        Err(e) => return RunOutcome::Failed(format!("javascript emit failed: {e:?}")),
+    };
+    let path = temp_path(program, Target::JavaScript, ".js");
+    if fs::write(&path, &artifact.source).is_err() {
+        return RunOutcome::Failed("could not write temp .js".into());
+    }
+    let out = Command::new("node").arg(&path).output();
+    let _ = fs::remove_file(&path);
+    finish(out, &artifact.source, "javascript")
+}
+
+// ── Go ──────────────────────────────────────────────────────────────────────
+
+fn run_go(program: &Program, module: &Module) -> RunOutcome {
+    let artifact = match semantic_ir_to_go::compile(module) {
+        Ok(a) => a,
+        Err(e) => return RunOutcome::Failed(format!("go emit failed: {e:?}")),
+    };
+    let path = temp_path(program, Target::Go, ".go");
+    if fs::write(&path, &artifact.source).is_err() {
+        return RunOutcome::Failed("could not write temp .go".into());
+    }
+    let out = Command::new("go").arg("run").arg(&path).output();
+    let _ = fs::remove_file(&path);
+    finish(out, &artifact.source, "go")
+}
+
+// ── Rust ────────────────────────────────────────────────────────────────────
+//
+// The Rust backend emits a self-contained `.rs`; we compile with `rustc` (an
+// optional `SIR_TEST_RUSTC_LINKER` override lets hosts without the default
+// linker point at `rust-lld`), then run the binary. A missing linker is a
+// *skip*, not a failure — matching the per-backend exec tests.
+
+fn run_rust(program: &Program, module: &Module) -> RunOutcome {
+    let artifact = match semantic_ir_to_rust::compile(module) {
+        Ok(a) => a,
+        Err(e) => return RunOutcome::Failed(format!("rust emit failed: {e:?}")),
+    };
+    let src = temp_path(program, Target::Rust, ".rs");
+    let bin = temp_path(program, Target::Rust, if cfg!(windows) { ".exe" } else { "" });
+    if fs::write(&src, &artifact.source).is_err() {
+        return RunOutcome::Failed("could not write temp .rs".into());
+    }
+    let mut cmd = Command::new("rustc");
+    cmd.arg("--edition").arg("2021").arg("-O");
+    if let Ok(linker) = std::env::var("SIR_TEST_RUSTC_LINKER") {
+        if !linker.is_empty() {
+            cmd.arg("-C").arg(format!("linker={linker}"));
+        }
+    }
+    let compiled = cmd.arg(&src).arg("-o").arg(&bin).output();
+    match compiled {
+        Ok(o) if o.status.success() => {
+            let run_out = Command::new(&bin).output();
+            let _ = fs::remove_file(&src);
+            let _ = fs::remove_file(&bin);
+            finish(run_out, &artifact.source, "rust")
+        }
+        Ok(o) => {
+            let stderr = String::from_utf8_lossy(&o.stderr);
+            let _ = fs::remove_file(&src);
+            if stderr.contains("linker")
+                && (stderr.contains("not found") || stderr.contains("No such file"))
+            {
+                RunOutcome::Skipped("no usable linker on host".into())
+            } else {
+                RunOutcome::Failed(format!(
+                    "rustc failed:\n{stderr}\n--- source ---\n{}",
+                    artifact.source
+                ))
+            }
+        }
+        Err(e) => {
+            let _ = fs::remove_file(&src);
+            RunOutcome::Skipped(format!("rustc unavailable: {e}"))
+        }
+    }
+}
+
+/// Turn a process result into a [`RunOutcome`]: non-zero exit is a failure
+/// (carrying stderr + the emitted source for debugging), success returns the
+/// normalised stdout.
+fn finish(
+    out: std::io::Result<std::process::Output>,
+    source: &str,
+    tag: &str,
+) -> RunOutcome {
+    match out {
+        Ok(o) if o.status.success() => {
+            RunOutcome::Ran(normalise(&String::from_utf8_lossy(&o.stdout)))
+        }
+        Ok(o) => RunOutcome::Failed(format!(
+            "{tag} program exited {} (should be 0):\n--- stderr ---\n{}\n--- source ---\n{}",
+            o.status.code().unwrap_or(-1),
+            String::from_utf8_lossy(&o.stderr),
+            source,
+        )),
+        Err(e) => RunOutcome::Skipped(format!("{tag} toolchain vanished mid-run: {e}")),
+    }
+}

--- a/code/packages/rust/sir-conformance/tests/conformance.rs
+++ b/code/packages/rust/sir-conformance/tests/conformance.rs
@@ -1,0 +1,116 @@
+//! The golden conformance matrix.
+//!
+//! Each [`Program`] in `CORPUS` is real Ruby source paired with the exact
+//! stdout a Ruby interpreter would produce. The matrix test lowers every
+//! program through the frontend and runs it through **every** backend's real
+//! toolchain, asserting the output equals the reference on each — the single
+//! test that drives Ruby *source* all the way to Python, JavaScript, Go, and
+//! Rust and proves they agree.
+
+use sir_conformance::{run, Program, RunOutcome, Target};
+
+/// The reference corpus. Outputs are intentionally strings and integers only —
+/// booleans render differently across backends (`#t` vs `true`), which is a
+/// separate formatting concern, not a behavioural one, so we keep the oracle
+/// unambiguous.
+const CORPUS: &[Program] = &[
+    // Operator precedence: `*` binds tighter than `+`.
+    Program {
+        name: "arithmetic",
+        ruby: "puts(2 + 3 * 4)\n",
+        expected: "14",
+    },
+    // A method with parameters, returning its last expression.
+    Program {
+        name: "def_params",
+        ruby: "def add(a, b)\n  a + b\nend\n\nputs add(2, 3)\n",
+        expected: "5",
+    },
+    // Implicit return of a trailing `if` (FC — shipped, proven here end-to-end).
+    Program {
+        name: "tail_if",
+        ruby: "def bigger(a, b)\n  if a > b\n    a\n  else\n    b\n  end\nend\n\nputs bigger(10, 7)\n",
+        expected: "10",
+    },
+    // Implicit return of a trailing `case` (relies on the `case_eq` builtin
+    // that had been missing from Go/Rust/JS — this is the regression oracle for
+    // that whole class of bug).
+    Program {
+        name: "tail_case",
+        ruby: "def grade(n)\n  case n\n  when 90\n    \"A\"\n  when 80\n    \"B\"\n  else\n    \"C\"\n  end\nend\n\nputs grade(90)\nputs grade(80)\nputs grade(50)\n",
+        expected: "A\nB\nC",
+    },
+    // String concatenation (polymorphic `+`).
+    Program {
+        name: "string_concat",
+        ruby: "puts(\"ab\" + \"cd\")\n",
+        expected: "abcd",
+    },
+    // A user-defined class, `.new`, and an instance method call.
+    Program {
+        name: "oop_method",
+        ruby: "class Dog\n  def speak\n    \"woof\"\n  end\nend\n\nputs Dog.new.speak\n",
+        expected: "woof",
+    },
+];
+
+/// Every program must produce its reference output on every available backend.
+/// A backend whose toolchain is absent is skipped (logged), never failed; a
+/// mismatch or a crash is a hard failure naming the exact `(program, backend)`.
+#[test]
+fn corpus_agrees_across_all_backends() {
+    let mut ran = 0usize;
+    let mut skipped = 0usize;
+
+    for program in CORPUS {
+        for &target in Target::all() {
+            match run(program, target) {
+                RunOutcome::Ran(stdout) => {
+                    assert_eq!(
+                        stdout, program.expected,
+                        "\nCONFORMANCE MISMATCH\n  program:  {}\n  backend:  {}\n  expected: {:?}\n  actual:   {:?}\n",
+                        program.name,
+                        target.tag(),
+                        program.expected,
+                        stdout,
+                    );
+                    ran += 1;
+                }
+                RunOutcome::Skipped(why) => {
+                    eprintln!("skip {}/{}: {why}", program.name, target.tag());
+                    skipped += 1;
+                }
+                RunOutcome::Failed(msg) => {
+                    panic!(
+                        "\nCONFORMANCE FAILURE\n  program: {}\n  backend: {}\n  {msg}\n",
+                        program.name,
+                        target.tag(),
+                    );
+                }
+            }
+        }
+    }
+
+    eprintln!(
+        "conformance matrix: {} corpus x {} backends = {ran} ran, {skipped} skipped",
+        CORPUS.len(),
+        Target::all().len(),
+    );
+    // The harness is worthless if it proved nothing; require at least one real
+    // run so a fully-toolchain-less CI box can't report a hollow pass.
+    assert!(
+        ran > 0,
+        "no backend toolchain was available — conformance proved nothing"
+    );
+}
+
+/// Sanity: every corpus program lowers through the frontend (independent of any
+/// backend toolchain), so a parse/lower regression is caught even on a host
+/// with no toolchains at all.
+#[test]
+fn corpus_all_lowers() {
+    for program in CORPUS {
+        sir_conformance::lower(program)
+            .unwrap_or_else(|e| panic!("`{}` failed to lower: {e}", program.name));
+    }
+}


### PR DESCRIPTION
## What

A new `sir-conformance` crate: **the first test that drives real Ruby *source* all the way to Python, JavaScript, Go, and Rust and proves the four agree** — byte-for-byte, against a reference oracle.

## Why

The SIR is a narrow waist whose whole point is *behavioural equivalence* — a program's result must not depend on which backend emitted it. But nothing enforced that end-to-end: each backend's `compile_and_run_*` test **hand-builds** an SIR module and checks one feature in isolation, so a construct the frontend emits but a backend never implemented can pass every unit test and still crash at runtime.

That is exactly what happened with `case_eq` (Ruby's `===`): missing from 3 of 5 runtimes, every `case` program panicked on Go/Rust/JS while passing on Python — and no test caught it. This harness is the systemic guard against that whole class of bug, and the first concrete slice of [SIR21 §Provability](code/specs/SIR21-type-system-and-integer-semantics.md)'s conformance matrix (P1).

## How it works

For every corpus program × every backend: **lower** through `ruby_to_semantic_ir` → **emit** via the backend → **run** through the real toolchain (`python3` with `sir-runtime-*` auto-discovered onto `PYTHONPATH`; `node`; `go run`; `rustc` + execute) → **assert** normalised stdout equals the corpus reference. Compared against the reference, *never* another backend, so two backends agreeing on a wrong answer can't hide a bug.

Graceful skip when a toolchain is absent, plus a hollow-pass guard (asserts ≥1 backend actually ran). `run()`/`lower()` are public so the eventual SIR21 typed-integer suite reuses the plumbing.

## Corpus (6 programs)

| program | exercises | reference |
|---|---|---|
| `arithmetic` | operator precedence | `14` |
| `def_params` | method + params + implicit return | `5` |
| `tail_if` | trailing-`if` implicit return | `10` |
| `tail_case` | trailing-`case` implicit return (**the `case_eq` oracle**) | `A\nB\nC` |
| `string_concat` | polymorphic `+` | `abcd` |
| `oop_method` | `class` / `.new` / instance method | `woof` |

## Verified

**6 corpus × 4 backends = 24 runs, 0 skipped, all agree** (locally, all toolchains present). Adding a program is one `Program { name, ruby, expected }` entry.

Also fixed a harness bug found while building it: Go must be probed with `go version` (not `--version`, which errors), else Go is silently skipped.

Clippy clean; README + CHANGELOG. Security review: **passed** (test-only tooling, no untrusted input; commands use `Command`/args with no shell, fixed corpus).

🤖 Generated with [Claude Code](https://claude.com/claude-code)