### PR TITLE
[codex] Lock document-shell audit cross-axis evidence

### DIFF
--- a/code/packages/rust/html-parser/tests/whatwg_document_shell_audit_test.rs
+++ b/code/packages/rust/html-parser/tests/whatwg_document_shell_audit_test.rs
@@ -5,7 +5,177 @@ use serde::Deserialize;
 use std::collections::{BTreeMap, HashMap};
 
 const TREE_CONSTRUCTION_SMOKE: &str = include_str!("fixtures/html5lib-tree-construction-smoke.dat");
+const WHATWG_BLOCK_BOUNDARY_AUDIT: &str = include_str!("fixtures/whatwg-block-boundary-audit.json");
+const WHATWG_CHARACTER_REFERENCE_AUDIT: &str =
+    include_str!("fixtures/whatwg-character-reference-audit.json");
 const WHATWG_DOCUMENT_SHELL_AUDIT: &str = include_str!("fixtures/whatwg-document-shell-audit.json");
+const WHATWG_FOREIGN_AUDIT: &str = include_str!("fixtures/whatwg-foreign-audit.json");
+const WHATWG_FORM_INTERACTIVE_AUDIT: &str =
+    include_str!("fixtures/whatwg-form-interactive-audit.json");
+const WHATWG_FORMATTING_AUDIT: &str = include_str!("fixtures/whatwg-formatting-audit.json");
+const WHATWG_FRAGMENT_CONTEXT_AUDIT: &str =
+    include_str!("fixtures/whatwg-fragment-context-audit.json");
+const WHATWG_FRAMESET_AUDIT: &str = include_str!("fixtures/whatwg-frameset-audit.json");
+const WHATWG_HEAD_BODY_AUDIT: &str = include_str!("fixtures/whatwg-head-body-audit.json");
+const WHATWG_LEGACY_ELEMENT_AUDIT: &str = include_str!("fixtures/whatwg-legacy-element-audit.json");
+const WHATWG_PARAGRAPH_AUDIT: &str = include_str!("fixtures/whatwg-paragraph-audit.json");
+const WHATWG_SELECT_LIST_AUDIT: &str = include_str!("fixtures/whatwg-select-list-audit.json");
+const WHATWG_TABLE_AUDIT: &str = include_str!("fixtures/whatwg-table-audit.json");
+const WHATWG_TEMPLATE_AUDIT: &str = include_str!("fixtures/whatwg-template-audit.json");
+const WHATWG_TEXT_CONTROL_AUDIT: &str = include_str!("fixtures/whatwg-text-control-audit.json");
+const WHATWG_TREE_INSERTION_AUDIT: &str = include_str!("fixtures/whatwg-tree-insertion-audit.json");
+const WHATWG_VOID_ELEMENT_AUDIT: &str = include_str!("fixtures/whatwg-void-element-audit.json");
+struct DocumentShellCrossAxisCase {
+    id: &'static str,
+    document_shell_axis: &'static str,
+    data_snippet: &'static str,
+    suites: &'static [(&'static str, &'static str, &'static str)],
+}
+
+const DOCTYPE_SHELL_CROSS_AXIS_SUITES: &[(&str, &str, &str)] = &[
+    (
+        "formatting",
+        WHATWG_FORMATTING_AUDIT,
+        "formatting-reconstruction",
+    ),
+    ("head-body", WHATWG_HEAD_BODY_AUDIT, "body-boundary"),
+];
+const HTML_SHELL_CROSS_AXIS_SUITES: &[(&str, &str, &str)] = &[
+    (
+        "block-boundary",
+        WHATWG_BLOCK_BOUNDARY_AUDIT,
+        "block-text-mode-boundary",
+    ),
+    (
+        "form-interactive",
+        WHATWG_FORM_INTERACTIVE_AUDIT,
+        "interactive-formatting",
+    ),
+    (
+        "formatting",
+        WHATWG_FORMATTING_AUDIT,
+        "interactive-formatting-boundary",
+    ),
+    ("head-body", WHATWG_HEAD_BODY_AUDIT, "body-boundary"),
+    (
+        "legacy-element",
+        WHATWG_LEGACY_ELEMENT_AUDIT,
+        "tricky-parser-recovery",
+    ),
+    (
+        "text-control",
+        WHATWG_TEXT_CONTROL_AUDIT,
+        "pre-listing-newline",
+    ),
+];
+const HEAD_SHELL_CROSS_AXIS_SUITES: &[(&str, &str, &str)] = &[
+    (
+        "form-interactive",
+        WHATWG_FORM_INTERACTIVE_AUDIT,
+        "select-option",
+    ),
+    ("head-body", WHATWG_HEAD_BODY_AUDIT, "body-boundary"),
+    ("select-list", WHATWG_SELECT_LIST_AUDIT, "select-in-table"),
+    ("table", WHATWG_TABLE_AUDIT, "select-in-table"),
+    ("template", WHATWG_TEMPLATE_AUDIT, "select-template"),
+    (
+        "tree-insertion",
+        WHATWG_TREE_INSERTION_AUDIT,
+        "template-insertion",
+    ),
+];
+const BODY_SHELL_CROSS_AXIS_SUITES: &[(&str, &str, &str)] = &[
+    ("foreign", WHATWG_FOREIGN_AUDIT, "table-foreign-boundary"),
+    (
+        "form-interactive",
+        WHATWG_FORM_INTERACTIVE_AUDIT,
+        "select-option",
+    ),
+    ("formatting", WHATWG_FORMATTING_AUDIT, "paragraph-boundary"),
+    ("head-body", WHATWG_HEAD_BODY_AUDIT, "body-boundary"),
+    (
+        "paragraph",
+        WHATWG_PARAGRAPH_AUDIT,
+        "paragraph-table-boundary",
+    ),
+    ("select-list", WHATWG_SELECT_LIST_AUDIT, "select-in-table"),
+    ("table", WHATWG_TABLE_AUDIT, "select-in-table"),
+];
+const COMMENT_SHELL_CROSS_AXIS_SUITES: &[(&str, &str, &str)] = &[
+    (
+        "character-reference",
+        WHATWG_CHARACTER_REFERENCE_AUDIT,
+        "character-reference-rcdata-boundary",
+    ),
+    ("head-body", WHATWG_HEAD_BODY_AUDIT, "head-text-mode"),
+    ("text-control", WHATWG_TEXT_CONTROL_AUDIT, "rcdata-controls"),
+];
+const FRAGMENT_SHELL_CROSS_AXIS_SUITES: &[(&str, &str, &str)] = &[
+    (
+        "fragment-context",
+        WHATWG_FRAGMENT_CONTEXT_AUDIT,
+        "fragment-shell-context",
+    ),
+    ("frameset", WHATWG_FRAMESET_AUDIT, "frameset-shell"),
+    (
+        "tree-insertion",
+        WHATWG_TREE_INSERTION_AUDIT,
+        "html-fragment",
+    ),
+];
+const IMPLICIT_SHELL_CROSS_AXIS_SUITES: &[(&str, &str, &str)] = &[
+    (
+        "form-interactive",
+        WHATWG_FORM_INTERACTIVE_AUDIT,
+        "form-control",
+    ),
+    ("table", WHATWG_TABLE_AUDIT, "foster-parenting"),
+    ("void-element", WHATWG_VOID_ELEMENT_AUDIT, "void-in-table"),
+];
+const DOCUMENT_SHELL_CROSS_AXIS_CASES: &[DocumentShellCrossAxisCase] = &[
+    DocumentShellCrossAxisCase {
+        id: "doctype01-dat-116",
+        document_shell_axis: "doctype-and-quirks",
+        data_snippet: "<!DOCTYPE HTML SYSTEM \"http://www.w3.org/DTD/HTML4-strict.dtd\"><body><b>Mine!</b></body>",
+        suites: DOCTYPE_SHELL_CROSS_AXIS_SUITES,
+    },
+    DocumentShellCrossAxisCase {
+        id: "tricky01-dat-9",
+        document_shell_axis: "html-element-boundary",
+        data_snippet: "<b><nobr><div>This text is in a div inside a nobr</nobr>",
+        suites: HTML_SHELL_CROSS_AXIS_SUITES,
+    },
+    DocumentShellCrossAxisCase {
+        id: "template-dat-556",
+        document_shell_axis: "head-element-boundary",
+        data_snippet: "<body><table><tr><td><select><template>Foo</template><caption>A</table>",
+        suites: HEAD_SHELL_CROSS_AXIS_SUITES,
+    },
+    DocumentShellCrossAxisCase {
+        id: "tests10-dat-17",
+        document_shell_axis: "body-frameset-boundary",
+        data_snippet: "<!DOCTYPE html><body><table><tr><td><select><svg><g>foo</g><g>bar</g><p>baz</table><p>quux",
+        suites: BODY_SHELL_CROSS_AXIS_SUITES,
+    },
+    DocumentShellCrossAxisCase {
+        id: "tests6-dat-4",
+        document_shell_axis: "comment-whitespace-shell",
+        data_snippet: "<!doctype html><title><!--&amp;--></title>",
+        suites: COMMENT_SHELL_CROSS_AXIS_SUITES,
+    },
+    DocumentShellCrossAxisCase {
+        id: "tests-innerhtml-1-dat-5",
+        document_shell_axis: "shell-fragment-context",
+        data_snippet: "<frameset><span>",
+        suites: FRAGMENT_SHELL_CROSS_AXIS_SUITES,
+    },
+    DocumentShellCrossAxisCase {
+        id: "tests7-dat-19",
+        document_shell_axis: "implicit-document-shell",
+        data_snippet: "<!doctype html><table><input type=hidDEN></table>",
+        suites: IMPLICIT_SHELL_CROSS_AXIS_SUITES,
+    },
+];
 const POST_PARSE_REPAIR_EVIDENCE: &[(&str, &str)] = &[
     ("tricky01-dat-3", "html-element-boundary"),
     ("tests26-dat-1251", "body-frameset-boundary"),
@@ -23,6 +193,19 @@ struct DocumentShellAuditSuite {
 
 #[derive(Debug, Deserialize)]
 struct DocumentShellAuditCase {
+    id: String,
+    source: String,
+    axis: String,
+    reason: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GenericAuditSuite {
+    cases: Vec<GenericAuditCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GenericAuditCase {
     id: String,
     source: String,
     axis: String,
@@ -77,6 +260,76 @@ fn whatwg_document_shell_audit_cases_match_parser_dom_dump() {
 }
 
 #[test]
+fn whatwg_document_shell_audit_keeps_shell_axis_cases_cross_axis() {
+    let suite = load_suite();
+    let document_shell_cases = suite
+        .cases
+        .iter()
+        .map(|case| (case.id.as_str(), case))
+        .collect::<HashMap<_, _>>();
+    let smoke_cases = parse_tree_construction_cases(TREE_CONSTRUCTION_SMOKE)
+        .into_iter()
+        .map(|case| (case.source.clone(), case))
+        .collect::<HashMap<_, _>>();
+
+    for evidence in DOCUMENT_SHELL_CROSS_AXIS_CASES {
+        let document_shell_case = document_shell_cases
+            .get(evidence.id)
+            .unwrap_or_else(|| panic!("document-shell audit should include `{}`", evidence.id));
+        assert_eq!(
+            document_shell_case.axis, evidence.document_shell_axis,
+            "document-shell row `{}` should stay on its focused audit axis",
+            evidence.id
+        );
+        assert!(
+            !document_shell_case.reason.is_empty(),
+            "document-shell row `{}` should keep a fixture reason",
+            evidence.id
+        );
+
+        for (suite_name, fixture, expected_axis) in evidence.suites {
+            let audit_case = generic_audit_case(fixture, suite_name, evidence.id);
+            assert_eq!(
+                audit_case.source, document_shell_case.source,
+                "`{suite_name}` should point document-shell row `{}` at the same html5lib row as the document-shell audit",
+                evidence.id
+            );
+            assert_eq!(
+                audit_case.axis, *expected_axis,
+                "`{suite_name}` should keep document-shell row `{}` on its focused axis",
+                evidence.id
+            );
+            assert!(
+                !audit_case.reason.is_empty(),
+                "`{suite_name}` should keep a reason for document-shell row `{}`",
+                evidence.id
+            );
+        }
+
+        let source_case = smoke_cases
+            .get(&document_shell_case.source)
+            .unwrap_or_else(|| panic!("case `{}` should exist in smoke fixture", evidence.id));
+        assert!(
+            source_case.data.contains(evidence.data_snippet),
+            "document-shell row `{}` should stay tied to its html5lib input",
+            evidence.id
+        );
+        let actual = actual_dom_dump_for_tree_case(source_case).unwrap_or_else(|error| {
+            panic!(
+                "case `{}` ({}) parse failed: {error}",
+                document_shell_case.id, document_shell_case.axis
+            )
+        });
+
+        assert_eq!(
+            actual, source_case.document,
+            "cross-axis document-shell evidence case `{}` ({}) failed for input {:?}",
+            document_shell_case.id, document_shell_case.axis, source_case.data
+        );
+    }
+}
+
+#[test]
 fn whatwg_document_shell_audit_tracks_post_parse_repair_evidence() {
     let suite = load_suite();
     let audit_cases = suite
@@ -119,6 +372,16 @@ fn whatwg_document_shell_audit_tracks_post_parse_repair_evidence() {
 fn load_suite() -> DocumentShellAuditSuite {
     serde_json::from_str(WHATWG_DOCUMENT_SHELL_AUDIT)
         .expect("WHATWG document-shell audit fixture should parse")
+}
+
+fn generic_audit_case(fixture: &str, suite_name: &str, case_id: &str) -> GenericAuditCase {
+    let suite = serde_json::from_str::<GenericAuditSuite>(fixture)
+        .unwrap_or_else(|error| panic!("`{suite_name}` audit fixture should parse: {error}"));
+    suite
+        .cases
+        .into_iter()
+        .find(|case| case.id == case_id)
+        .unwrap_or_else(|| panic!("`{suite_name}` should audit document-shell case `{case_id}`"))
 }
 
 fn assert_axis_count(suite: &DocumentShellAuditSuite, axis: &str, minimum: usize) {


### PR DESCRIPTION
## Summary
- add a document-shell cross-axis evidence guard spanning all document-shell audit axes
- verify each selected html5lib row stays aligned with neighboring audit fixture axes
- rerun parser DOM dumps for the selected rows so the evidence stays executable

## Tests
- cargo fmt --package coding-adventures-html-parser
- cargo test -p coding-adventures-html-parser whatwg_document_shell_audit_keeps_shell_axis_cases_cross_axis
- cargo test -p coding-adventures-html-parser whatwg_document_shell_audit
- cargo test -p coding-adventures-html-parser
- CARGO_BUILD_JOBS=2 cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser
- python3 -m json.tool code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json >/dev/null
- python3 code/packages/rust/html-parser/tests/fixtures/check_whatwg_audit_rust_tests.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py
- git diff --check
