### PR TITLE
feat(adj-ladder): rung-57 renal count rate — sum-of-two-ratios a/b + c/d

### DIFF
--- a/code/specs/data/adj-ladder/rung57_renal_count_rate/gen_items.py
+++ b/code/specs/data/adj-ladder/rung57_renal_count_rate/gen_items.py
@@ -1,0 +1,220 @@
+"""Generate rung-57 (renal count rate) items.json for the ADJ-LADDER.
+
+Rung 57 opens the **nuclear-medicine / renography** panel on the quantitative band — the arithmetic of a dual-kidney
+radionuclide renogram. A gamma camera counts the emissions over each kidney for a timed window; each kidney's COUNT RATE
+is its counts divided by its seconds — a RATIO — and the total renal count rate is the SUM of the two kidneys' ratios.
+Adding one ratio to ANOTHER ratio introduces a genuinely NEW arithmetic shape on the ladder: a **sum of two ratios** —
+`a/b + c/d` — two independent quotients added.
+
+The setup: a renogram counts `left_counts` over the left kidney in `left_seconds`, and `right_counts` over the right
+kidney in `right_seconds`. The total renal count rate is the left count rate plus the right count rate:
+
+  TOTAL RATE   left_counts / left_seconds + right_counts / right_seconds   [ counts per second — both kidneys ]
+  LEFT RATE    left_counts / left_seconds                                  [ one ratio: the left kidney ]
+  RIGHT RATE   right_counts / right_seconds                               [ the other ratio: the right kidney ]
+
+The **total rate** is what makes this rung distinctive — it is the ladder's first **sum of two ratios**: two separate
+quotients (each with its OWN denominator) added. Contrast the neighbours already on the ladder: rung-53 was
+`(a+b+c)/d` (a single sum over one denominator) and rung-37 `(a+b)/(c+d)` (a single ratio of two sums); neither ADDED
+two independent quotients. (The left rate `left_counts/left_seconds` and the right rate `right_counts/right_seconds`
+ride alongside as component readouts, so the panel teaches the whole calculation — exactly as rungs 47-56 shipped their
+component sums/products/differences/ratios beside the headline figure.)
+
+Each index is a `compute_dimensioned` program (`observe` the four quantities + `let answer = formula`); the ADJ engine
+carries the arithmetic — including both quotients and their sum — and the harness reads the scalar via the existing
+`compute_dimensioned` extractor. No harness/engine change, exactly as rungs 8/16/.../55/56. This rung exercises the
+engine across **two divisions folded into an addition** — the fact that `a/b + c/d` is NOT `(a+c)/(b+d)` made computable.
+
+Contamination-safe by construction: every formula is built ONLY from the four observed quantities via `/` and `+` —
+**no structural constants** — so no numeric literal appears in any program, and neither the left rate, the right rate,
+nor any total-rate figure is ever a literal (each is computed from the observed quantities). The observed quantities
+carry **digit-free identifiers** (`left_counts`, `left_seconds`, `right_counts`, `right_seconds`) so no numeral hides
+inside a variable name.
+
+The five options are a tight family over the same four quantities: the three real readouts plus the two classic slips —
+
+  POOLED RATIO   (left_counts + right_counts) / (left_seconds + right_seconds)   POOL the counts over the pooled seconds
+                                                                                 — a RATIO OF TOTALS, not a sum of
+                                                                                 ratios (the classic `a/b + c/d` vs
+                                                                                 `(a+c)/(b+d)` error), and
+  CROSSED        left_counts / right_seconds + right_counts / left_seconds       SWAP the denominators — divide each
+                                                                                 kidney's counts by the OTHER kidney's
+                                                                                 seconds,
+
+which are exactly the mistakes a student makes (pooling numerators over pooled denominators, or pairing each numerator
+with the wrong denominator). Gold rotates A-E by index. QUERIED (used as gold) = the three real readouts; all five
+always appear as options.
+
+Distinctness: all four observed quantities are strictly positive, so every quotient and sum is positive; the tables
+below are chosen so the five family values are pairwise distinct with a comfortable margin, asserted at build time.
+"""
+import json
+
+LETTERS = ["A", "B", "C", "D", "E"]
+
+# (LEFT_COUNTS, LEFT_SECONDS, RIGHT_COUNTS, RIGHT_SECONDS) — gamma counts and timed seconds per kidney, all plain
+# positive numbers (seconds chosen to divide the counts into clean rates). The five family values are asserted
+# pairwise-distinct (with margin) below.
+TABLES = [
+    (2400, 60, 1800, 90),
+    (3600, 90, 2000, 40),
+    (1500, 30, 2800, 70),
+    (4200, 60, 1200, 80),
+    (2000, 50, 3300, 60),
+    (2700, 90, 1600, 40),
+    (5000, 100, 900, 30),
+]
+
+# The option family (5 members), all built from the four observed quantities via / and +. Every identifier is
+# DIGIT-FREE. key -> (display name, formula-as-adj). Only the first three are *queried* (used as gold); all five
+# always appear as the options.
+FAMILY = [
+    (
+        "total_rate",
+        "total renal count rate (the left count rate plus the right count rate)",
+        "left_counts / left_seconds + right_counts / right_seconds",
+    ),
+    (
+        "left_rate",
+        "the left-kidney count rate (left counts per left second)",
+        "left_counts / left_seconds",
+    ),
+    (
+        "right_rate",
+        "the right-kidney count rate (right counts per right second)",
+        "right_counts / right_seconds",
+    ),
+    (
+        "pooled_ratio",
+        "the pooled counts over the pooled seconds, not the sum of the two rates (a wrong total)",
+        "(left_counts + right_counts) / (left_seconds + right_seconds)",
+    ),
+    (
+        "crossed",
+        "each kidney's counts divided by the OTHER kidney's seconds (swapped denominators)",
+        "left_counts / right_seconds + right_counts / left_seconds",
+    ),
+]
+QUERIED = ["total_rate", "left_rate", "right_rate"]
+ORDER = [k for k, _, _ in FAMILY]
+
+
+def scalar(v):
+    return {"value": v, "unit": "scalar"}
+
+
+def family_values(left_counts, left_seconds, right_counts, right_seconds):
+    # Operation order mirrors the ADJ programs exactly (each quotient formed first, then folded with +; and, for the
+    # pooled slip, the parenthesised sums divide), so the Python option value and the engine result are the same
+    # IEEE-double (well within the harness's 1e-9 match tolerance).
+    left = left_counts / left_seconds
+    right = right_counts / right_seconds
+    return {
+        "total_rate": left + right,
+        "left_rate": left,
+        "right_rate": right,
+        "pooled_ratio": (left_counts + right_counts) / (left_seconds + right_seconds),
+        "crossed": left_counts / right_seconds + right_counts / left_seconds,
+    }
+
+
+def build():
+    name_of = {k: nm for k, nm, _ in FAMILY}
+    formula_of = {k: f for k, _, f in FAMILY}
+    items = []
+    idx = 0
+
+    def num(x):
+        return int(x) if float(x).is_integer() else x
+
+    for left_counts, left_seconds, right_counts, right_seconds in TABLES:
+        assert (
+            left_counts > 0
+            and left_seconds > 0
+            and right_counts > 0
+            and right_seconds > 0
+        ), (left_counts, left_seconds, right_counts, right_seconds)
+        fv = family_values(left_counts, left_seconds, right_counts, right_seconds)
+        # Pairwise-distinct with a comfortable margin so the harness never sees two options
+        # matching the gold value within its 1e-9 tolerance.
+        vals = [fv[key] for key in ORDER]
+        for i in range(len(vals)):
+            for j in range(i + 1, len(vals)):
+                assert abs(vals[i] - vals[j]) > 1e-6, (
+                    left_counts,
+                    left_seconds,
+                    right_counts,
+                    right_seconds,
+                    ORDER[i],
+                    ORDER[j],
+                    fv,
+                )
+        for key in QUERIED:
+            gold_val = fv[key]
+            gold_pos = idx % 5
+            others = [fv[k2] for k2 in ORDER if abs(fv[k2] - gold_val) > 1e-12]
+            opts_vals = others[:]
+            opts_vals.insert(gold_pos, gold_val)
+            opts_vals = opts_vals[:5]
+            if abs(opts_vals[gold_pos] - gold_val) > 1e-12:
+                opts_vals[gold_pos] = gold_val
+            assert len({round(v, 9) for v in opts_vals}) == 5, (
+                key,
+                left_counts,
+                left_seconds,
+                right_counts,
+                right_seconds,
+                opts_vals,
+            )
+            options = {LETTERS[i]: scalar(opts_vals[i]) for i in range(5)}
+            items.append({
+                "id": f"r57rate-{idx + 1:02d}",
+                "qtype": "renal_count_rate",
+                "stem": (
+                    f"A renogram counts {num(left_counts)} over the left kidney in {num(left_seconds)} s and "
+                    f"{num(right_counts)} over the right kidney in {num(right_seconds)} s. What is the {name_of[key]}?"
+                ),
+                "program": (
+                    f"observe left_counts({num(left_counts)})\n"
+                    f"observe left_seconds({num(left_seconds)})\n"
+                    f"observe right_counts({num(right_counts)})\n"
+                    f"observe right_seconds({num(right_seconds)})\n"
+                    f"let answer = {formula_of[key]}\n"
+                    "? answer\n"
+                ),
+                "answer_from": {"type": "compute_dimensioned", "name": "answer"},
+                "options": options,
+                "gold_letter": LETTERS[gold_pos],
+            })
+            idx += 1
+    return {
+        "description": (
+            "ADJ-LADDER rung 57 — total renal count rate from four stated quantities (a NEW panel: nuclear medicine / "
+            "renography). From two kidney count totals and their two timed windows compute the total count rate "
+            "(left_counts/left_seconds + right_counts/right_seconds), the left count rate (left_counts/left_seconds), "
+            "or the right count rate (right_counts/right_seconds). Each item is a compute_dimensioned program (observe "
+            "the four quantities, let answer = formula); the ADJ engine carries the arithmetic — a NEW shape, SUM OF "
+            "TWO RATIOS a/b + c/d, the first on the ladder to add two independent quotients each with its own "
+            "denominator (distinct from rung-53 sum-of-three-over-one (a+b+c)/d and rung-37 ratio-of-two-sums "
+            "(a+b)/(c+d)) — and the harness matches the scalar to the printed options. Contamination-safe: every index "
+            "is built only from the four observed quantities via / and + — no constant leaks, and neither the left "
+            "rate, the right rate, nor any total-rate figure ever appears as a literal (each is computed) — and the "
+            "observed quantities carry digit-free identifiers so no numeral hides inside a variable name. The five "
+            "options are a family over the same four quantities, so the distractors are exactly the slips students "
+            "make: POOLING the counts over the pooled seconds ((a+c)/(b+d), a ratio of totals, not a+ b of ratios), "
+            "and SWAPPING the denominators (a/d + c/b). The core confusion tested is that a/b + c/d is not "
+            "(a+c)/(b+d)."
+        ),
+        "items": items,
+    }
+
+
+if __name__ == "__main__":
+    doc = build()
+    with open("items.json", "w") as f:
+        json.dump(doc, f, indent=2)
+        f.write("\n")
+    print("wrote items.json:", len(doc["items"]), "items")
+    for it in doc["items"]:
+        print(it["id"], it["qtype"], "gold", it["gold_letter"],
+              "=", round(it["options"][it["gold_letter"]]["value"], 6))

--- a/code/specs/data/adj-ladder/rung57_renal_count_rate/items.json
+++ b/code/specs/data/adj-ladder/rung57_renal_count_rate/items.json
@@ -1,0 +1,698 @@
+{
+  "description": "ADJ-LADDER rung 57 \u2014 total renal count rate from four stated quantities (a NEW panel: nuclear medicine / renography). From two kidney count totals and their two timed windows compute the total count rate (left_counts/left_seconds + right_counts/right_seconds), the left count rate (left_counts/left_seconds), or the right count rate (right_counts/right_seconds). Each item is a compute_dimensioned program (observe the four quantities, let answer = formula); the ADJ engine carries the arithmetic \u2014 a NEW shape, SUM OF TWO RATIOS a/b + c/d, the first on the ladder to add two independent quotients each with its own denominator (distinct from rung-53 sum-of-three-over-one (a+b+c)/d and rung-37 ratio-of-two-sums (a+b)/(c+d)) \u2014 and the harness matches the scalar to the printed options. Contamination-safe: every index is built only from the four observed quantities via / and + \u2014 no constant leaks, and neither the left rate, the right rate, nor any total-rate figure ever appears as a literal (each is computed) \u2014 and the observed quantities carry digit-free identifiers so no numeral hides inside a variable name. The five options are a family over the same four quantities, so the distractors are exactly the slips students make: POOLING the counts over the pooled seconds ((a+c)/(b+d), a ratio of totals, not a+ b of ratios), and SWAPPING the denominators (a/d + c/b). The core confusion tested is that a/b + c/d is not (a+c)/(b+d).",
+  "items": [
+    {
+      "id": "r57rate-01",
+      "qtype": "renal_count_rate",
+      "stem": "A renogram counts 2400 over the left kidney in 60 s and 1800 over the right kidney in 90 s. What is the total renal count rate (the left count rate plus the right count rate)?",
+      "program": "observe left_counts(2400)\nobserve left_seconds(60)\nobserve right_counts(1800)\nobserve right_seconds(90)\nlet answer = left_counts / left_seconds + right_counts / right_seconds\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 60.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 40.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 20.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 28.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 56.66666666666667,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r57rate-02",
+      "qtype": "renal_count_rate",
+      "stem": "A renogram counts 2400 over the left kidney in 60 s and 1800 over the right kidney in 90 s. What is the the left-kidney count rate (left counts per left second)?",
+      "program": "observe left_counts(2400)\nobserve left_seconds(60)\nobserve right_counts(1800)\nobserve right_seconds(90)\nlet answer = left_counts / left_seconds\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 60.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 40.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 20.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 28.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 56.66666666666667,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r57rate-03",
+      "qtype": "renal_count_rate",
+      "stem": "A renogram counts 2400 over the left kidney in 60 s and 1800 over the right kidney in 90 s. What is the the right-kidney count rate (right counts per right second)?",
+      "program": "observe left_counts(2400)\nobserve left_seconds(60)\nobserve right_counts(1800)\nobserve right_seconds(90)\nlet answer = right_counts / right_seconds\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 60.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 40.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 20.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 28.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 56.66666666666667,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r57rate-04",
+      "qtype": "renal_count_rate",
+      "stem": "A renogram counts 3600 over the left kidney in 90 s and 2000 over the right kidney in 40 s. What is the total renal count rate (the left count rate plus the right count rate)?",
+      "program": "observe left_counts(3600)\nobserve left_seconds(90)\nobserve right_counts(2000)\nobserve right_seconds(40)\nlet answer = left_counts / left_seconds + right_counts / right_seconds\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 40.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 50.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 43.07692307692308,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 90.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 112.22222222222223,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r57rate-05",
+      "qtype": "renal_count_rate",
+      "stem": "A renogram counts 3600 over the left kidney in 90 s and 2000 over the right kidney in 40 s. What is the the left-kidney count rate (left counts per left second)?",
+      "program": "observe left_counts(3600)\nobserve left_seconds(90)\nobserve right_counts(2000)\nobserve right_seconds(40)\nlet answer = left_counts / left_seconds\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 90.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 50.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 43.07692307692308,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 112.22222222222223,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 40.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r57rate-06",
+      "qtype": "renal_count_rate",
+      "stem": "A renogram counts 3600 over the left kidney in 90 s and 2000 over the right kidney in 40 s. What is the the right-kidney count rate (right counts per right second)?",
+      "program": "observe left_counts(3600)\nobserve left_seconds(90)\nobserve right_counts(2000)\nobserve right_seconds(40)\nlet answer = right_counts / right_seconds\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 50.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 90.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 40.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 43.07692307692308,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 112.22222222222223,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r57rate-07",
+      "qtype": "renal_count_rate",
+      "stem": "A renogram counts 1500 over the left kidney in 30 s and 2800 over the right kidney in 70 s. What is the total renal count rate (the left count rate plus the right count rate)?",
+      "program": "observe left_counts(1500)\nobserve left_seconds(30)\nobserve right_counts(2800)\nobserve right_seconds(70)\nlet answer = left_counts / left_seconds + right_counts / right_seconds\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 50.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 90.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 40.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 43.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 114.76190476190476,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r57rate-08",
+      "qtype": "renal_count_rate",
+      "stem": "A renogram counts 1500 over the left kidney in 30 s and 2800 over the right kidney in 70 s. What is the the left-kidney count rate (left counts per left second)?",
+      "program": "observe left_counts(1500)\nobserve left_seconds(30)\nobserve right_counts(2800)\nobserve right_seconds(70)\nlet answer = left_counts / left_seconds\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 90.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 40.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 50.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 43.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 114.76190476190476,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r57rate-09",
+      "qtype": "renal_count_rate",
+      "stem": "A renogram counts 1500 over the left kidney in 30 s and 2800 over the right kidney in 70 s. What is the the right-kidney count rate (right counts per right second)?",
+      "program": "observe left_counts(1500)\nobserve left_seconds(30)\nobserve right_counts(2800)\nobserve right_seconds(70)\nlet answer = right_counts / right_seconds\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 90.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 50.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 43.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 40.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 114.76190476190476,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r57rate-10",
+      "qtype": "renal_count_rate",
+      "stem": "A renogram counts 4200 over the left kidney in 60 s and 1200 over the right kidney in 80 s. What is the total renal count rate (the left count rate plus the right count rate)?",
+      "program": "observe left_counts(4200)\nobserve left_seconds(60)\nobserve right_counts(1200)\nobserve right_seconds(80)\nlet answer = left_counts / left_seconds + right_counts / right_seconds\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 70.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 15.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 38.57142857142857,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 72.5,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 85.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r57rate-11",
+      "qtype": "renal_count_rate",
+      "stem": "A renogram counts 4200 over the left kidney in 60 s and 1200 over the right kidney in 80 s. What is the the left-kidney count rate (left counts per left second)?",
+      "program": "observe left_counts(4200)\nobserve left_seconds(60)\nobserve right_counts(1200)\nobserve right_seconds(80)\nlet answer = left_counts / left_seconds\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 70.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 85.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 15.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 38.57142857142857,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 72.5,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r57rate-12",
+      "qtype": "renal_count_rate",
+      "stem": "A renogram counts 4200 over the left kidney in 60 s and 1200 over the right kidney in 80 s. What is the the right-kidney count rate (right counts per right second)?",
+      "program": "observe left_counts(4200)\nobserve left_seconds(60)\nobserve right_counts(1200)\nobserve right_seconds(80)\nlet answer = right_counts / right_seconds\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 85.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 15.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 70.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 38.57142857142857,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 72.5,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r57rate-13",
+      "qtype": "renal_count_rate",
+      "stem": "A renogram counts 2000 over the left kidney in 50 s and 3300 over the right kidney in 60 s. What is the total renal count rate (the left count rate plus the right count rate)?",
+      "program": "observe left_counts(2000)\nobserve left_seconds(50)\nobserve right_counts(3300)\nobserve right_seconds(60)\nlet answer = left_counts / left_seconds + right_counts / right_seconds\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 40.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 55.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 95.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 48.18181818181818,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 99.33333333333334,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r57rate-14",
+      "qtype": "renal_count_rate",
+      "stem": "A renogram counts 2000 over the left kidney in 50 s and 3300 over the right kidney in 60 s. What is the the left-kidney count rate (left counts per left second)?",
+      "program": "observe left_counts(2000)\nobserve left_seconds(50)\nobserve right_counts(3300)\nobserve right_seconds(60)\nlet answer = left_counts / left_seconds\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 95.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 55.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 48.18181818181818,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 40.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 99.33333333333334,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r57rate-15",
+      "qtype": "renal_count_rate",
+      "stem": "A renogram counts 2000 over the left kidney in 50 s and 3300 over the right kidney in 60 s. What is the the right-kidney count rate (right counts per right second)?",
+      "program": "observe left_counts(2000)\nobserve left_seconds(50)\nobserve right_counts(3300)\nobserve right_seconds(60)\nlet answer = right_counts / right_seconds\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 95.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 40.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 48.18181818181818,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 99.33333333333334,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 55.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r57rate-16",
+      "qtype": "renal_count_rate",
+      "stem": "A renogram counts 2700 over the left kidney in 90 s and 1600 over the right kidney in 40 s. What is the total renal count rate (the left count rate plus the right count rate)?",
+      "program": "observe left_counts(2700)\nobserve left_seconds(90)\nobserve right_counts(1600)\nobserve right_seconds(40)\nlet answer = left_counts / left_seconds + right_counts / right_seconds\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 70.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 30.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 40.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 33.07692307692308,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 85.27777777777777,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r57rate-17",
+      "qtype": "renal_count_rate",
+      "stem": "A renogram counts 2700 over the left kidney in 90 s and 1600 over the right kidney in 40 s. What is the the left-kidney count rate (left counts per left second)?",
+      "program": "observe left_counts(2700)\nobserve left_seconds(90)\nobserve right_counts(1600)\nobserve right_seconds(40)\nlet answer = left_counts / left_seconds\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 70.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 30.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 40.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 33.07692307692308,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 85.27777777777777,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r57rate-18",
+      "qtype": "renal_count_rate",
+      "stem": "A renogram counts 2700 over the left kidney in 90 s and 1600 over the right kidney in 40 s. What is the the right-kidney count rate (right counts per right second)?",
+      "program": "observe left_counts(2700)\nobserve left_seconds(90)\nobserve right_counts(1600)\nobserve right_seconds(40)\nlet answer = right_counts / right_seconds\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 70.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 30.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 40.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 33.07692307692308,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 85.27777777777777,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r57rate-19",
+      "qtype": "renal_count_rate",
+      "stem": "A renogram counts 5000 over the left kidney in 100 s and 900 over the right kidney in 30 s. What is the total renal count rate (the left count rate plus the right count rate)?",
+      "program": "observe left_counts(5000)\nobserve left_seconds(100)\nobserve right_counts(900)\nobserve right_seconds(30)\nlet answer = left_counts / left_seconds + right_counts / right_seconds\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 50.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 30.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 45.38461538461539,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 80.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 175.66666666666666,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r57rate-20",
+      "qtype": "renal_count_rate",
+      "stem": "A renogram counts 5000 over the left kidney in 100 s and 900 over the right kidney in 30 s. What is the the left-kidney count rate (left counts per left second)?",
+      "program": "observe left_counts(5000)\nobserve left_seconds(100)\nobserve right_counts(900)\nobserve right_seconds(30)\nlet answer = left_counts / left_seconds\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 80.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 30.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 45.38461538461539,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 175.66666666666666,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 50.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r57rate-21",
+      "qtype": "renal_count_rate",
+      "stem": "A renogram counts 5000 over the left kidney in 100 s and 900 over the right kidney in 30 s. What is the the right-kidney count rate (right counts per right second)?",
+      "program": "observe left_counts(5000)\nobserve left_seconds(100)\nobserve right_counts(900)\nobserve right_seconds(30)\nlet answer = right_counts / right_seconds\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 30.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 80.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 50.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 45.38461538461539,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 175.66666666666666,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    }
+  ]
+}

--- a/code/specs/data/adj-ladder/test_ladder_eval.py
+++ b/code/specs/data/adj-ladder/test_ladder_eval.py
@@ -94,6 +94,7 @@ SELF_CONTAINED_RUNGS = (
     "rung54_neutrophil_ratio",
     "rung55_fresh_gas_volume",
     "rung56_stroke_work",
+    "rung57_renal_count_rate",
 )
 
 


### PR DESCRIPTION
## ADJ-LADDER rung-57 — total renal count rate (sum-of-two-ratios `a/b + c/d`)

Adds the next self-contained rung to the ADJ-LADDER, opening the **nuclear-medicine / renography** panel on the quantitative band.

### New arithmetic shape
The headline readout adds one ratio to **another** ratio (each with its own denominator):

```
total count rate = left_counts/left_seconds + right_counts/right_seconds
```

This is a genuinely NEW shape on the ladder — **sum of two ratios** `a/b + c/d`, the first to add two independent quotients. It is distinct from:
- rung-53 sum-of-three-over-one `(a+b+c)/d`
- rung-37 ratio-of-two-sums `(a+b)/(c+d)`

The left rate `left_counts/left_seconds` and right rate `right_counts/right_seconds` ride alongside as component readouts, so the panel teaches the whole calculation.

### Contents
- 7 tables × 3 queried readouts = **21 items**, each a `compute_dimensioned` program (`observe` the four quantities, `let answer = formula`, `? answer`). The ADJ engine carries the arithmetic — no harness/engine change.
- Five-member option family over the same four quantities: three real readouts + two classic slips (**pooled_ratio**: `(a+c)/(b+d)` — pooling counts over pooled seconds, a ratio of totals; **crossed**: `a/d + c/b` — swapped denominators).
- Gold rotates A–E by index; family values asserted **pairwise-distinct with margin** at build. The core confusion tested is that `a/b + c/d ≠ (a+c)/(b+d)`.

### Contamination-safety
Every formula is built ONLY from the four observed quantities via `/` and `+` — **no numeric constants**, and neither the left rate, the right rate, nor any total-rate figure ever appears as a literal (each is computed). Observed quantities carry **digit-free identifiers** (`left_counts`, `left_seconds`, `right_counts`, `right_seconds`).

### Verification
- `gen_items.py` run from the rung subdir → `items.json` (21 items).
- Registered in `SELF_CONTAINED_RUNGS`. Gate `pytest -k rung57` → **3/3 passed**.
- Security review: PASSED (offline data generator, no external input, no eval/injection/path/DoS surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
