### PR TITLE
test(closure-emitter): CLOC12.160 PR3 — CodePrinter comma-operator conformance port

### DIFF
--- a/code/packages/rust/closure-emitter/CHANGELOG.md
+++ b/code/packages/rust/closure-emitter/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to the `coding-adventures-closure-emitter` crate will be documented in this file.
 
+## [0.24.1] - 2026-07-02
+
+### Added — CLOC12.160 PR3: CodePrinter comma-operator conformance port
+
+New upstream-cited test file `tests/upstream/code_printer_sequence_test.rs`
+(registered as the `upstream_code_printer_sequence` `[[test]]` target) porting
+the Closure Compiler `CodePrinterTest` comma-operator (`a, b, c`) printing cases
+against `emit_sequence`. 9 active `#[test]`s, **0 `#[ignore]`** — the two bare
+positions (statement `a,b,c`, computed-member key `a[b,c]`) and the wrapped
+positions (sole/multi call argument `f((a,b),c)`, array element `[(a,b),c]`,
+assignment RHS `x=(a,b)`, conditional branch `x?(a,b):c`, unary operand
+`!(a,b)`). Inputs are hand-constructed typed AST; the bridge conversion of the
+comma operator (PR2, gap-161) is exercised separately in `javascript-parser`.
+Test-only change — no library behaviour change. This completes the CLOC12.160
+`SequenceExpression` three-PR arc (node+emit → bridge → conformance).
+
 ## [0.24.0] - 2026-07-02
 
 ### Added — CLOC12.160: emit `SequenceExpression` (the comma operator)

--- a/code/packages/rust/closure-emitter/Cargo.toml
+++ b/code/packages/rust/closure-emitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-emitter"
-version = "0.24.0"
+version = "0.24.1"
 edition = "2021"
 description = "JavaScript code emitter for the Closure Compiler clone. Per CLOC07's emit contract. Takes a finalized Program + sidecar and produces output JavaScript text + companion source map. Runs after every pass in the pipeline."
 
@@ -68,3 +68,7 @@ path = "tests/upstream/code_printer_update_test.rs"
 [[test]]
 name = "upstream_code_printer_new"
 path = "tests/upstream/code_printer_new_test.rs"
+
+[[test]]
+name = "upstream_code_printer_sequence"
+path = "tests/upstream/code_printer_sequence_test.rs"

--- a/code/packages/rust/closure-emitter/README.md
+++ b/code/packages/rust/closure-emitter/README.md
@@ -133,6 +133,12 @@ test-port convention. Each file isolates one printing area:
   (`new X(a).y`, `new X().y`), nested `new new X()()`, and a call on a `new`
   member (`new X().m()`). 10 active `#[test]`s, no `#[ignore]`. Run with
   `cargo test --test upstream_code_printer_new`.
+- `code_printer_sequence_test.rs` — comma-operator (`a, b, c`) printing: the two
+  bare positions (statement `a,b,c`, computed-member key `a[b,c]`) and the
+  assignment-position wraps (call argument `f((a,b),c)`, array element
+  `[(a,b),c]`, assignment RHS `x=(a,b)`, conditional branch `x?(a,b):c`, unary
+  operand `!(a,b)`). 9 active `#[test]`s, no `#[ignore]`. Run with
+  `cargo test --test upstream_code_printer_sequence`.
 
 ## Dependency whitelist
 

--- a/code/packages/rust/closure-emitter/tests/upstream/ATTRIBUTION.md
+++ b/code/packages/rust/closure-emitter/tests/upstream/ATTRIBUTION.md
@@ -92,6 +92,22 @@ under the Apache License, Version 2.0:
       (CLOC12.159 PR2, gap-160) is exercised separately in
       `javascript-parser`.
 
+- `code_printer_sequence_test.rs`
+    - upstream: `test/com/google/javascript/jscomp/CodePrinterTest.java`
+      (the comma-operator `a, b, c` printing cases — bare positions and the
+      assignment-position wraps)
+    - tracked commit: see `UPSTREAM_SHA`
+    - Isolates `emit_sequence` + the `PREC_SEQUENCE` (lowest) classification
+      and the four assignment-position wrap sites that landed with
+      `Expression::SequenceExpression` (CLOC12.160). 9 active `#[test]`s and
+      **0 `#[ignore]`** — the emitter conforms to every covered shape: the two
+      bare positions (statement `a,b,c`, computed-member key `a[b,c]`) and the
+      wrapped positions (sole/multi call argument `f((a,b),c)`, array element
+      `[(a,b),c]`, assignment RHS `x=(a,b)`, conditional branch `x?(a,b):c`,
+      unary operand `!(a,b)`). Inputs are hand-constructed AST; the bridge
+      conversion of the comma operator (CLOC12.160 PR2, gap-161) is exercised
+      separately in `javascript-parser`.
+
 ## Translation notes
 
 Fourth port under CLOC12 (after `closure-pass-constant-fold` in

--- a/code/packages/rust/closure-emitter/tests/upstream/code_printer_sequence_test.rs
+++ b/code/packages/rust/closure-emitter/tests/upstream/code_printer_sequence_test.rs
@@ -1,0 +1,201 @@
+//! Ported from `CodePrinterTest.java` in `google/closure-compiler`,
+//! Apache-2.0. Upstream SHA: see `tests/upstream/UPSTREAM_SHA`.
+//!
+//! Translation policy: see
+//! `code/specs/CLOC12-upstream-test-suite-port.md`.
+//!
+//! # What this file covers
+//!
+//! Upstream `CodePrinterTest`'s **comma-operator** printing cases — the
+//! `SequenceExpression` `a, b, c`. This is the thirteenth CodePrinter port into
+//! `closure-emitter` (after core / declarations / trailing-comma / numbers /
+//! string-escape / ascii-escape / object-literal / function-expression /
+//! arrow-function / template / update / new) and isolates `emit_sequence` + the
+//! `PREC_SEQUENCE` (lowest) classification and the four assignment-position
+//! wrap sites that landed with `Expression::SequenceExpression` (CLOC12.160).
+//!
+//! # How the emitter prints a sequence (recap)
+//!
+//! ```text
+//!   a, b, c            → a,b,c            operands comma-joined, no spaces
+//! ```
+//!
+//! The comma operator is the **loosest** expression there is (below
+//! assignment), so a sequence used as a *sub-operand* almost always needs
+//! parentheses, or the surrounding operator captures only one arm:
+//!
+//! ```text
+//!   f((a, b), c)   without parens `f(a, b, c)` is a THREE-argument call
+//!   [(a, b), c]    without parens `[a, b, c]` is a THREE-element array
+//!   x = (a, b)     without parens `x = a, b` parses as `(x = a), b`
+//!   x ? (a, b) : c  a bare comma branch would be captured by the statement
+//!   !(a, b)        without parens `!a, b` parses as `(!a), b`
+//! ```
+//!
+//! The two contexts where a bare sequence is legal — and therefore printed
+//! **without** parens — are a statement-position expression (`a, b, c;`) and a
+//! computed-member key (`obj[a, b]`, which the surrounding `[ ]` delimits).
+//!
+//! # Note on hand-constructed inputs
+//!
+//! These assertions build typed-AST inputs directly (upstream lex/parses
+//! source). The emitter is the unit under test here — the bridge conversion of
+//! the comma operator (CLOC12.160 PR2, gap-161) is exercised separately in
+//! `javascript-parser`.
+
+use coding_adventures_closure_emitter::{emit, EmitOptions};
+use coding_adventures_correlation_vector::CVLog;
+use coding_adventures_javascript_ast::{
+    AssignmentExpression, AssignmentOperator, AssignmentTarget, CallExpression, ConditionalExpression,
+    Expression, ExpressionStatement, Identifier, MemberExpression, Program, ProgramItem,
+    SequenceExpression, SourceType, Statement, UnaryExpression, UnaryOperator,
+};
+use coding_adventures_javascript_tokens::EsVersion;
+use coding_adventures_type_sidecar::Sidecar;
+
+// =====================================================================
+// Test-support helpers
+// =====================================================================
+
+fn ident(name: &str) -> Expression {
+    Expression::Identifier(Identifier { cv: None, name: name.to_string() })
+}
+
+fn seq(operands: Vec<Expression>) -> Expression {
+    Expression::SequenceExpression(SequenceExpression { cv: None, expressions: operands })
+}
+
+fn call(callee: Expression, arguments: Vec<Expression>) -> Expression {
+    Expression::CallExpression(CallExpression {
+        cv: None,
+        callee: Box::new(callee),
+        arguments,
+    })
+}
+
+fn stmt(expr: Expression) -> ProgramItem {
+    ProgramItem::Statement(Statement::expression_statement(ExpressionStatement {
+        cv: None,
+        expression: expr,
+    }))
+}
+
+fn emit_default(expr: Expression) -> String {
+    let prog =
+        Program::new_untraced(EsVersion::Es2025, SourceType::Module).with_body(vec![stmt(expr)]);
+    let sidecar = Sidecar::new();
+    let mut cv = CVLog::new(false);
+    emit(&prog, &sidecar, &mut cv, &EmitOptions::default())
+        .expect("emit failed")
+        .code
+}
+
+/// Upstream `assertPrint(input, expected)` reshaped: emit the expression as a
+/// single-statement program and assert the emitted code equals `expected`.
+fn assert_emits(expr: Expression, expected: &str) {
+    let code = emit_default(expr);
+    assert_eq!(
+        code, expected,
+        "comma-operator emit output did not match\n  actual:   {:?}\n  expected: {:?}",
+        code, expected
+    );
+}
+
+// =====================================================================
+// Active — bare positions (statement, computed-member key)
+// =====================================================================
+
+/// `assertPrintSame("a,b,c")` — a sequence at statement position prints bare;
+/// nothing captures it.
+#[test]
+fn sequence_at_statement_is_bare() {
+    assert_emits(seq(vec![ident("a"), ident("b"), ident("c")]), "a,b,c;");
+}
+
+/// A two-operand sequence at statement position: `a,b`.
+#[test]
+fn sequence_two_operands_at_statement() {
+    assert_emits(seq(vec![ident("a"), ident("b")]), "a,b;");
+}
+
+/// A sequence as a computed-member key needs NO parens — the `[ ]` already
+/// delimits a full expression: `a[b,c]` (evaluates the key to `c`).
+#[test]
+fn sequence_as_computed_member_key_is_bare() {
+    let e = Expression::MemberExpression(MemberExpression {
+        cv: None,
+        object: Box::new(ident("a")),
+        property: Box::new(seq(vec![ident("b"), ident("c")])),
+        computed: true,
+    });
+    assert_emits(e, "a[b,c];");
+}
+
+// =====================================================================
+// Active — assignment-position wraps
+// =====================================================================
+
+/// `f((a, b))` — a sole sequence argument MUST wrap, or `f(a,b)` would be a
+/// two-argument call instead of one sequence argument.
+#[test]
+fn sequence_as_sole_call_arg_is_wrapped() {
+    assert_emits(call(ident("f"), vec![seq(vec![ident("a"), ident("b")])]), "f((a,b));");
+}
+
+/// `f((a, b), c)` — the arity is preserved; never the three-argument
+/// `f(a,b,c)`.
+#[test]
+fn sequence_as_call_arg_preserves_arity() {
+    let e = call(ident("f"), vec![seq(vec![ident("a"), ident("b")]), ident("c")]);
+    assert_emits(e, "f((a,b),c);");
+}
+
+/// `[(a, b), c]` — a sequence array element wraps, or the element count
+/// changes; never the three-element `[a,b,c]`.
+#[test]
+fn sequence_as_array_element_is_wrapped() {
+    let e = Expression::ArrayExpression(coding_adventures_javascript_ast::ArrayExpression {
+        cv: None,
+        elements: vec![Some(seq(vec![ident("a"), ident("b")])), Some(ident("c"))],
+    });
+    assert_emits(e, "[(a,b),c];");
+}
+
+/// `x = (a, b)` — a sequence assignment RHS wraps; a bare `x=a,b` reparses as
+/// `(x=a),b`.
+#[test]
+fn sequence_as_assignment_rhs_is_wrapped() {
+    let e = Expression::AssignmentExpression(AssignmentExpression {
+        cv: None,
+        operator: AssignmentOperator::Eq,
+        left: AssignmentTarget::Identifier(Identifier { cv: None, name: "x".to_string() }),
+        right: Box::new(seq(vec![ident("a"), ident("b")])),
+    });
+    assert_emits(e, "x=(a,b);");
+}
+
+/// `x ? (a, b) : c` — a sequence conditional branch wraps (the branch is an
+/// assignment-position expression).
+#[test]
+fn sequence_as_conditional_branch_is_wrapped() {
+    let e = Expression::ConditionalExpression(ConditionalExpression {
+        cv: None,
+        test: Box::new(ident("x")),
+        consequent: Box::new(seq(vec![ident("a"), ident("b")])),
+        alternate: Box::new(ident("c")),
+    });
+    assert_emits(e, "x?(a,b):c;");
+}
+
+/// `!(a, b)` — a sequence unary operand wraps; a bare `!a,b` parses as
+/// `(!a),b`.
+#[test]
+fn sequence_as_unary_operand_is_wrapped() {
+    let e = Expression::UnaryExpression(UnaryExpression {
+        cv: None,
+        operator: UnaryOperator::Not,
+        prefix: true,
+        argument: Box::new(seq(vec![ident("a"), ident("b")])),
+    });
+    assert_emits(e, "!(a,b);");
+}


### PR DESCRIPTION
## CLOC12.160 PR3 — CodePrinter comma-operator conformance port

Third and final PR of the CLOC12.160 `SequenceExpression` (comma operator) arc:

- **PR1** ([#7468](https://github.com/adhithyan15/coding-adventures/pull/7468)) — atomic node + `emit_sequence` + all pass match-arms + the 4 assignment-position precedence fixes
- **PR2** ([#7479](https://github.com/adhithyan15/coding-adventures/pull/7479)) — bridge-enable comma operator → `SequenceExpression` (closes gap-161)
- **PR3** (this) — CodePrinter emit conformance port

### What this adds

A new upstream-cited test file `closure-emitter/tests/upstream/code_printer_sequence_test.rs` (registered as the `upstream_code_printer_sequence` `[[test]]` target), porting the Google Closure Compiler `CodePrinterTest` comma-operator (`a, b, c`) printing cases against `emit_sequence`. **9 active `#[test]`s, 0 `#[ignore]`**, all passing:

- the two **bare** positions (a bare comma is legal there): statement position `a,b,c`, computed-member key `a[b,c]` (the `[ ]` delimits a full expression)
- the assignment-position **wraps** (a sequence sub-operand must parenthesise): sole call argument `f((a,b))`, multi call argument `f((a,b),c)` (never the 3-arg `f(a,b,c)`), array element `[(a,b),c]` (never the 3-element `[a,b,c]`), assignment RHS `x=(a,b)` (never `x=a,b` = `(x=a),b`), conditional branch `x?(a,b):c`, unary operand `!(a,b)` (never `!a,b` = `(!a),b`)

Inputs are hand-constructed typed AST, mirroring the merged new/update ports — the emitter is the unit under test. The bridge conversion of the comma operator (PR2, gap-161) is exercised separately in `javascript-parser`.

**Test-only change — no library behaviour change.**

> Note: this PR runs in parallel with PR2 [#7479](https://github.com/adhithyan15/coding-adventures/pull/7479), which owns the `CLOC12-gaps` gap-161 RESOLVED edit — so this PR deliberately does **not** touch the spec (avoids a merge conflict; PR2's RESOLVED note already references this conformance port). PR3 depends only on PR1's node+emit (already in `main`), not on PR2.

### Versions / docs
closure-emitter `0.24.0` → `0.24.1`; ATTRIBUTION entry, CHANGELOG `0.24.1` section, README upstream-ports list.

### Verification
- `cargo test -p coding-adventures-closure-emitter --test upstream_code_printer_sequence` → 9 passed
- Full `cargo test -p coding-adventures-closure-emitter` → all suites green
- Inline security review → PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)