### PR TITLE
feat(adj-lang): reciprocal hyperbolic functions \coth/\sech/\csch in latex "…"

### DIFF
--- a/code/packages/rust/adj-lang/CHANGELOG.md
+++ b/code/packages/rust/adj-lang/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [0.44.0] - 2026-07-02 — reciprocal hyperbolic functions (`\coth`/`\sech`/`\csch`) in `latex "…"`
+
+### Added
+
+- `latex "\coth(x)"`, `\sech(x)`, `\csch(x)` — the reciprocal hyperbolic functions — now lower.
+  The frontend has `Func` variants for `\sinh`/`\cosh`/`\tanh` but not their reciprocals, so `\coth`
+  is an unknown control sequence that arrives as the operator-name juxtaposition
+  `Bin(Mul, Symbol("coth"), (x))` (a bare `Symbol` named `coth` can only come from that macro —
+  plain `coth` in math mode is the product `c·o·t·h`). Each reciprocal is composed exactly from the
+  hyperbolic `NamedFn` it inverts — coth = 1/tanh, sech = 1/cosh, csch = 1/sinh — so no engine op is
+  added. This closes the trig/hyperbolic symmetry: the circular reciprocals `cot`/`sec`/`csc`
+  already lowered; their hyperbolic twins now do too.
+- Both spellings are recognised: the bare macro (`\coth(x)`) and the operator-name form
+  (`\operatorname{coth}(x)` / `\mathrm{coth}(x)`, which the frontend renders as `Text("coth")`).
+- Adapter-only, no engine/AST change. The argument recurses through the SAME
+  `latex_math_to_expr_ast` the `\sin`/`\exp` arms use (no new tree-walk, no new DoS surface); the
+  left-factor match is a shallow `Symbol`/`Text` name check.
+
 ## [0.43.0] - 2026-07-02 — binomial coefficients (`\binom{n}{k}`) in `latex "…"`
 
 ### Added

--- a/code/packages/rust/adj-lang/Cargo.toml
+++ b/code/packages/rust/adj-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang"
-version = "0.43.0"
+version = "0.44.0"
 edition = "2021"
 description = "Surface-syntax frontend for the adjudication framework's probabilistic-logic rulebooks. Lexes, parses, and lowers a domain-expert-readable DSL into a `logic-engine` KnowledgeBase. Dissolves ADJ46 awkwardness items A10 (rulebook syntax) and A4 (joint contributions syntactically distinct)."
 

--- a/code/packages/rust/adj-lang/src/adapter.rs
+++ b/code/packages/rust/adj-lang/src/adapter.rs
@@ -1126,6 +1126,33 @@ fn latex_math_to_expr_ast(expr: &MathExpr, source: &str) -> Result<ExprAst, Adap
                 Box::new(latex_math_to_expr_ast(rhs, source)?),
             ))
         }
+        // `\coth(x)` / `\sech(x)` / `\csch(x)` — the reciprocal hyperbolic functions. The frontend
+        // has `Func` variants for `\sinh`/`\cosh`/`\tanh` (they lower in the `Call` arm) but NOT for
+        // their reciprocals, so `\coth` is an UNKNOWN control sequence: it lowers to a bare
+        // `Symbol("coth")` and the whole `\coth(x)` parses as the operator-name juxtaposition
+        // `Bin(Mul, Symbol("coth"), (x))` — exactly the shape `\operatorname{trunc}(x)` /
+        // `\operatorname{sinh}(x)` take (those arrive as `Bin(Mul, Text("…"), (x))`). A bare
+        // `Symbol("coth")` can ONLY come from the `\coth` macro (plain `coth` in math mode is the
+        // product `c·o·t·h`), so matching it is unambiguous. There is no dedicated engine op, but
+        // each reciprocal hyperbolic is the EXACT reciprocal of a hyperbolic `NamedFn` that IS
+        // wired — coth = 1/tanh, sech = 1/cosh, csch = 1/sinh — so we compose `1 / f(x)` from the
+        // existing `Tanh`/`Cosh`/`Sinh` calls. Pure adapter recognition: no engine, AST, or lowering
+        // change (the argument recurses through the SAME `latex_math_to_expr_ast` the `\sin`/`\exp`
+        // arms use — no new tree-walk). Handles both the bare-macro (`\coth(x)`) and operator-name
+        // (`\operatorname{coth}(x)`) spellings. This closes the trig/hyperbolic symmetry: the
+        // circular reciprocals `cot`/`sec`/`csc` already lower (in the `Call` arm); their hyperbolic
+        // twins now do too.
+        MathExpr::Bin(BinOp::Mul, lhs, rhs) if reciprocal_hyperbolic_den(lhs).is_some() => {
+            let den = reciprocal_hyperbolic_den(lhs).expect("guard guarantees Some");
+            Ok(ExprAst::Bin(
+                ArithOp::Div,
+                Box::new(ExprAst::Lit(1.0)),
+                Box::new(ExprAst::Call(
+                    den,
+                    Box::new(latex_math_to_expr_ast(rhs, source)?),
+                )),
+            ))
+        }
         MathExpr::Bin(BinOp::Mul, lhs, rhs) => latex_bin(ArithOp::Mul, lhs, rhs, source),
         MathExpr::Bin(BinOp::Div, lhs, rhs) | MathExpr::Frac(lhs, rhs) => {
             latex_bin(ArithOp::Div, lhs, rhs, source)
@@ -1296,6 +1323,28 @@ fn latex_math_to_expr_ast(expr: &MathExpr, source: &str) -> Result<ExprAst, Adap
             source: source.to_string(),
             detail: format!("unsupported ADJ arithmetic subset: {other:?}"),
         }),
+    }
+}
+
+/// If `expr` names a reciprocal hyperbolic function (`\coth`/`\sech`/`\csch`), return the
+/// hyperbolic [`NamedFn`] it is the reciprocal OF, so the caller can compose `1 / f(x)`:
+/// coth = 1/tanh → [`NamedFn::Tanh`], sech = 1/cosh → [`NamedFn::Cosh`], csch = 1/sinh →
+/// [`NamedFn::Sinh`]. Matches the bare-macro spelling (`\coth` → `Symbol("coth")`, an unknown
+/// control sequence — and a `Symbol` named exactly `coth` can ONLY arise from that macro) and the
+/// operator-name spelling (`\operatorname{coth}` / `\mathrm{coth}` → `Text("coth")`). Returns
+/// `None` for anything else, so a genuine product (`2x`) or an unrelated symbol falls through to
+/// the general multiplication arm.
+fn reciprocal_hyperbolic_den(expr: &MathExpr) -> Option<NamedFn> {
+    let name = match expr {
+        MathExpr::Symbol(s) => s.as_str(),
+        MathExpr::Text(s) => s.trim(),
+        _ => return None,
+    };
+    match name {
+        "coth" => Some(NamedFn::Tanh),
+        "sech" => Some(NamedFn::Cosh),
+        "csch" => Some(NamedFn::Sinh),
+        _ => None,
     }
 }
 

--- a/code/packages/rust/adj-lang/src/lower.rs
+++ b/code/packages/rust/adj-lang/src/lower.rs
@@ -2458,6 +2458,54 @@ contributes 1000000 from answer == 60 to correct
     }
 
     #[test]
+    fn native_latex_reciprocal_hyperbolic_functions_lower() {
+        // `\coth`/`\sech`/`\csch` — the reciprocal hyperbolics. None is a frontend `Func`, so each
+        // arrives as the operator-name juxtaposition `Bin(Mul, Symbol("coth"), (x))` (bare macro).
+        // The adapter composes `1 / f(x)` from the hyperbolic NamedFn it is the reciprocal of:
+        // coth = 1/tanh, sech = 1/cosh, csch = 1/sinh. Exact anchor: sech(0) = 1/cosh(0) = 1/1 = 1.
+        let sech0 = crate::compile_and_decide(
+            "observe x(0)\n\
+             let answer = latex \"$\\sech(x)$\"\n\
+             prior 0.10 for correct\n\
+             contributes 1000000 from answer == 1 to correct\n\
+             ? correct\n",
+        )
+        .unwrap();
+        assert!(sech0.ranked[0].posterior > 0.99, "{sech0:?}");
+        // coth(1) = 1/tanh(1) ≈ 1.3130352854993315 (matched within the engine's 1e-9 == tolerance).
+        let coth1 = crate::compile_and_decide(
+            "observe x(1)\n\
+             let answer = latex \"$\\coth(x)$\"\n\
+             prior 0.10 for correct\n\
+             contributes 1000000 from answer == 1.3130352854993315 to correct\n\
+             ? correct\n",
+        )
+        .unwrap();
+        assert!(coth1.ranked[0].posterior > 0.99, "{coth1:?}");
+        // csch(1) = 1/sinh(1) ≈ 0.8509181282393216.
+        let csch1 = crate::compile_and_decide(
+            "observe x(1)\n\
+             let answer = latex \"$\\csch(x)$\"\n\
+             prior 0.10 for correct\n\
+             contributes 1000000 from answer == 0.8509181282393216 to correct\n\
+             ? correct\n",
+        )
+        .unwrap();
+        assert!(csch1.ranked[0].posterior > 0.99, "{csch1:?}");
+        // The `\operatorname{sech}(x)` word spelling reaches the SAME composition (Text, not Symbol):
+        // sech(1) = 1/cosh(1) ≈ 0.6480542736638855.
+        let opsech = crate::compile_and_decide(
+            "observe x(1)\n\
+             let answer = latex \"$\\operatorname{sech}(x)$\"\n\
+             prior 0.10 for correct\n\
+             contributes 1000000 from answer == 0.6480542736638855 to correct\n\
+             ? correct\n",
+        )
+        .unwrap();
+        assert!(opsech.ranked[0].posterior > 0.99, "{opsech:?}");
+    }
+
+    #[test]
     fn native_latex_accent_wrapped_operands_are_transparent() {
         // `\hat{x}` / `\bar{x}` / … — an accent is a notational decoration, not an operation. A
         // model that writes a statistics formula (`\hat{p}(1-\hat{p})`, `\bar{x} - \bar{y}`) means


### PR DESCRIPTION
## adj-lang: reciprocal hyperbolic functions `\coth`/`\sech`/`\csch` in `latex "…"`

Adds `\coth(x)`, `\sech(x)`, `\csch(x)` — the reciprocal hyperbolic functions — to the adj-lang LaTeX→ExprAst adapter. The next slice in the `latex "…"` surface after binomials ([#7480](https://github.com/adhithyan15/coding-adventures/pull/7480)).

### What it does
- Closes the **trig/hyperbolic symmetry**: the circular reciprocals `cot`/`sec`/`csc` already lowered (in the `Call` arm); their hyperbolic twins now do too.
- The frontend has `Func` variants for `\sinh`/`\cosh`/`\tanh` but **not** their reciprocals, so `\coth` is an unknown control sequence that arrives as the operator-name juxtaposition `Bin(Mul, Symbol("coth"), (x))` — exactly the shape `\operatorname{trunc}(x)` / `\operatorname{sinh}(x)` take. A bare `Symbol` named exactly `coth` can **only** come from the `\coth` macro (plain `coth` in math mode is the product `c·o·t·h`), so matching it is unambiguous.
- Composed exactly from the hyperbolic `NamedFn` each inverts — **coth = 1/tanh, sech = 1/cosh, csch = 1/sinh** — so **no engine op is added**.
- Both spellings recognised: the bare macro (`\coth(x)`) and the operator-name form (`\operatorname{coth}(x)` / `\mathrm{coth}(x)`, rendered by the frontend as `Text("coth")`).

### Safety
Adapter-only; no engine/AST change. The argument recurses through the **same** `latex_math_to_expr_ast` the `\sin`/`\exp` arms already use (no new tree-walk, no new DoS surface); the left-factor match is a shallow, non-recursive `Symbol`/`Text` name check, and the guarded arm sits above the general multiplication fallthrough so unrelated products pass through untouched.

### Verification
- New test in `lower.rs`: `sech(0) = 1` (exact anchor), plus `coth(1)`, `csch(1)`, and the `\operatorname{sech}(1)` word spelling against precomputed values within the engine's `1e-9` `==` tolerance.
- `cargo test -p adj-lang -p logic-engine -p adj-lang-cli -p adj-constraint-solver` — all green. Doctests + `cargo clippy -p adj-lang` clean (pre-existing warnings only, none in new code).
- Security review: **PASSED** (no panic surface, no new recursion, no unbounded work, no harmful match ambiguity — verified against the pre-existing trig-arm pattern).
- `adj-lang` 0.43.0 → 0.44.0; CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
