### PR TITLE
[codex] Wire Flutter Anki file intents

### DIFF
--- a/code/packages/rust/mosaic-emit-flutter/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-flutter/src/pipeline.rs
@@ -338,6 +338,7 @@ fn build_main_dart(component_name: &str, slots: &[SlotDecl]) -> String {
     format!(
         concat!(
             "{banner}",
+            "import 'dart:async';\n",
             "import 'package:flutter/material.dart';\n",
             "import '../{component_name}.dart';\n",
             "import 'mosaic_host.dart';\n\n",
@@ -356,15 +357,26 @@ fn build_main_dart(component_name: &str, slots: &[SlotDecl]) -> String {
             "  void initState() {{\n",
             "    super.initState();\n",
             "    _mosaicHost = MosaicHost.load();\n",
-            "    _applyMosaicResponse(_mosaicHost?.props());\n",
+            "    _queueMosaicResponse(_mosaicHost?.props());\n",
             "  }}\n\n",
             "  @override\n",
             "  void dispose() {{\n",
             "    _mosaicHost?.dispose();\n",
             "    super.dispose();\n",
             "  }}\n\n",
+            "  void _queueMosaicResponse(\n",
+            "    FutureOr<Map<String, Object?>?>? responseOrFuture,\n",
+            "  ) {{\n",
+            "    if (responseOrFuture == null) return;\n",
+            "    Future<Map<String, Object?>?>.value(responseOrFuture)\n",
+            "        .then(_applyMosaicResponse)\n",
+            "        .catchError((Object error) {{\n",
+            "      debugPrint('host error: $error');\n",
+            "    }});\n",
+            "  }}\n\n",
             "  void _applyMosaicResponse(Map<String, Object?>? response) {{\n",
             "    if (response == null) return;\n",
+            "    if (!mounted) return;\n",
             "    final nextProps = mosaicMap(response['props']);\n",
             "    final hostIntent = mosaicMap(response['hostIntent']);\n",
             "    final error = response['error'];\n",
@@ -482,7 +494,7 @@ fn build_root_widget_constructor(component_name: &str, slots: &[SlotDecl]) -> St
     out.push_str("              if (response == null) {\n");
     out.push_str("                debugPrint(\"event: ${event.mosaicEnvelope}\");\n");
     out.push_str("              }\n");
-    out.push_str("              _applyMosaicResponse(response);\n");
+    out.push_str("              _queueMosaicResponse(response);\n");
     out.push_str("            },\n");
     out.push_str("          )");
     out
@@ -511,11 +523,14 @@ fn host_value_for_slot(slot: &SlotDecl) -> String {
 
 fn build_mosaic_host_dart() -> String {
     let mut out = String::from(BANNER_DART);
+    out.push_str("import 'dart:async';\n\n");
     out.push_str("class MosaicHost {\n");
     out.push_str("  const MosaicHost();\n\n");
     out.push_str("  static MosaicHost? load() => null;\n\n");
-    out.push_str("  Map<String, Object?>? props() => null;\n\n");
-    out.push_str("  Map<String, Object?>? handleEvent(Map<String, Object?> event) => null;\n\n");
+    out.push_str("  FutureOr<Map<String, Object?>?> props() => null;\n\n");
+    out.push_str(
+        "  FutureOr<Map<String, Object?>?> handleEvent(Map<String, Object?> event) => null;\n\n",
+    );
     out.push_str("  void dispose() {}\n");
     out.push_str("}\n");
     out
@@ -4992,7 +5007,7 @@ mod tests {
         );
         assert!(
             proj.main_dart
-                .contains("_applyMosaicResponse(_mosaicHost?.props())"),
+                .contains("_queueMosaicResponse(_mosaicHost?.props())"),
             "main.dart must hydrate initial props through the Mosaic host"
         );
         assert!(
@@ -5013,6 +5028,11 @@ mod tests {
             proj.mosaic_host_dart
                 .contains("static MosaicHost? load() => null;"),
             "default mosaic_host.dart must be a no-op hook"
+        );
+        assert!(
+            proj.mosaic_host_dart
+                .contains("FutureOr<Map<String, Object?>?> handleEvent"),
+            "default mosaic_host.dart must allow async host responses"
         );
     }
 
@@ -5064,7 +5084,7 @@ mod tests {
         assert!(proj
             .main_dart
             .contains("tags: mosaicStringList(_hostProps, \"tags\"),"));
-        assert!(proj.main_dart.contains("_applyMosaicResponse(response);"));
+        assert!(proj.main_dart.contains("_queueMosaicResponse(response);"));
     }
 
     /// Truth table for is_valid_dart_pub_name.

--- a/code/packages/rust/mosaic-package-artifact-builder/src/lib.rs
+++ b/code/packages/rust/mosaic-package-artifact-builder/src/lib.rs
@@ -3904,15 +3904,16 @@ version = "1"
         let main_dart = fs::read_to_string(dir.join("lib/main.dart")).expect("main.dart");
         assert!(main_dart.contains("import 'mosaic_host.dart';"));
         assert!(main_dart.contains("MosaicHost.load()"));
-        assert!(main_dart.contains("_applyMosaicResponse(_mosaicHost?.props())"));
+        assert!(main_dart.contains("_queueMosaicResponse(_mosaicHost?.props())"));
         assert!(main_dart.contains("String mosaicString(Map<String, Object?> props"));
         assert!(main_dart.contains("_mosaicHost?.handleEvent(event.mosaicEnvelope)"));
+        assert!(main_dart.contains("_queueMosaicResponse(response);"));
         assert!(main_dart.contains("debugPrint(\"event: ${event.mosaicEnvelope}\")"));
 
         let host = fs::read_to_string(dir.join("lib/mosaic_host.dart")).expect("mosaic_host.dart");
         assert!(host.contains("class MosaicHost"));
         assert!(host.contains("static MosaicHost? load() => null;"));
-        assert!(host.contains("Map<String, Object?>? handleEvent"));
+        assert!(host.contains("FutureOr<Map<String, Object?>?> handleEvent"));
     }
 
     #[test]

--- a/code/programs/mosaic/engram-app/CHANGELOG.md
+++ b/code/programs/mosaic/engram-app/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Wired the generated Flutter Engram shell to handle Anki import/export
+  `hostIntent` payloads with `file_selector` dialogs and the shared
+  `engram-capi` APKG import/export functions.
 - Wired the generated Compose Desktop Engram shell to handle Anki import/export
   `hostIntent` payloads with desktop file choosers and the shared `engram-capi`
   APKG import/export functions.

--- a/code/programs/mosaic/engram-app/README.md
+++ b/code/programs/mosaic/engram-app/README.md
@@ -80,7 +80,9 @@ editing, and save/delete/cancel controls.
 - The generated Flutter shell has an optional `MosaicHost` hook. Engram's
   `host/flutter/mosaic_host.dart` implements it with Dart FFI and
   `engram-capi`, hydrating Flutter slot props and routing generated Mosaic
-  event envelopes back into the same core.
+  event envelopes back into the same core. It also handles Anki import/export
+  host intents with `file_selector` dialogs, merging `.apkg` / `.colpkg`
+  packages and saving current collection state through the native C ABI.
 - The web, Electron, and native host adapters persist raw Engram state snapshots
   across launches. Set `ENGRAM_SNAPSHOT_PATH` to override the storage file; by
   default host shells use `~/.engram/mosaic-snapshot.v1.json`.
@@ -148,9 +150,10 @@ that host adapters need. Static host adapters are declared in
 bridge sources during project emission. The script adds the JS loader and
 `engram_engine.wasm` for web/Electron shells, `Sources/CEngram` plus the static
 `engram-capi` library for SwiftUI, the dynamic `engram-capi` library for Qt,
-Flutter, and Compose, the Dart FFI dependency for the Flutter host bridge,
-JNA/JSON dependencies for the Compose host bridge, `engram_capi.dll` as XAML
-project content, and `engram-host-cli` for the Electron APKG sidecar.
+Flutter, and Compose, the Dart FFI and `file_selector` dependencies for the
+Flutter host bridge, JNA/JSON dependencies for the Compose host bridge,
+`engram_capi.dll` as XAML project content, and `engram-host-cli` for the
+Electron APKG sidecar.
 Collection actions such as Anki import/export return `hostIntent` payloads so
 hosts can open file pickers, call native package bridges, and keep the Mosaic
 app interface shared.

--- a/code/programs/mosaic/engram-app/host/flutter/mosaic_host.dart
+++ b/code/programs/mosaic/engram-app/host/flutter/mosaic_host.dart
@@ -1,7 +1,9 @@
 import 'dart:convert';
 import 'dart:ffi';
 import 'dart:io';
+import 'dart:typed_data';
 
+import 'package:file_selector/file_selector.dart';
 import 'package:ffi/ffi.dart';
 
 final class EgSession extends Opaque {}
@@ -44,6 +46,18 @@ typedef _EgHandleEngramAppEventDart = Pointer<Utf8> Function(
   Pointer<Utf8>,
   int,
 );
+typedef _EgExportAnkiApkgNative = Pointer<Utf8> Function(Pointer<EgSession>);
+typedef _EgExportAnkiApkgDart = Pointer<Utf8> Function(Pointer<EgSession>);
+typedef _EgMergeAnkiApkgNative = Pointer<Utf8> Function(
+  Pointer<EgSession>,
+  Pointer<Uint8>,
+  Uint64,
+);
+typedef _EgMergeAnkiApkgDart = Pointer<Utf8> Function(
+  Pointer<EgSession>,
+  Pointer<Uint8>,
+  int,
+);
 
 class MosaicHost {
   MosaicHost._(this._api, this._session);
@@ -76,7 +90,7 @@ class MosaicHost {
     });
   }
 
-  Map<String, Object?>? handleEvent(Map<String, Object?> event) {
+  Future<Map<String, Object?>?> handleEvent(Map<String, Object?> event) async {
     if (_disposed) {
       return const <String, Object?>{'error': 'Engram Flutter MosaicHost disposed'};
     }
@@ -91,12 +105,182 @@ class MosaicHost {
           ),
         );
         final response = _hostResponseFromJson(json);
-        if (response?['error'] == null) {
-          _persistSnapshot();
-        }
-        return response;
+        return _handleHostIntent(response).then((handled) {
+          if (handled?['error'] == null) {
+            _persistSnapshot();
+          }
+          return handled;
+        });
       });
     });
+  }
+
+  Future<Map<String, Object?>?> _handleHostIntent(
+    Map<String, Object?>? response,
+  ) async {
+    if (response == null || response['error'] != null) {
+      return response;
+    }
+
+    final hostIntent = _mosaicMap(response['hostIntent']);
+    switch (hostIntent['type']) {
+      case 'importAnki':
+        return _importAnkiPackage(response, hostIntent);
+      case 'exportAnki':
+        return _exportAnkiPackage(response, hostIntent);
+      default:
+        return response;
+    }
+  }
+
+  Future<Map<String, Object?>?> _importAnkiPackage(
+    Map<String, Object?> response,
+    Map<String, Object?> hostIntent,
+  ) async {
+    final XFile? file;
+    try {
+      file = await openFile(
+        acceptedTypeGroups: _ankiTypeGroups(
+          hostIntentExtensions(hostIntent, 'accept', const <String>[
+            '.apkg',
+            '.colpkg',
+          ]),
+        ),
+        confirmButtonText: 'Import',
+      );
+    } catch (error) {
+      return _hostResultResponse(
+        response,
+        hostIntent,
+        'unsupported',
+        error: error,
+      );
+    }
+
+    if (file == null) {
+      return _hostResultResponse(response, hostIntent, 'cancelled');
+    }
+
+    final path = _xFilePath(file);
+    final Uint8List bytes;
+    try {
+      bytes = await file.readAsBytes();
+    } catch (error) {
+      return _hostResultResponse(
+        response,
+        hostIntent,
+        'read-error',
+        path: path,
+        error: error,
+      );
+    }
+
+    if (bytes.isEmpty) {
+      return _hostResultResponse(
+        response,
+        hostIntent,
+        'import-error',
+        path: path,
+        error: 'Anki package was empty',
+      );
+    }
+
+    final json = _mergeAnkiApkg(bytes);
+    if (!_jsonOk(json)) {
+      return _hostResultResponse(
+        response,
+        hostIntent,
+        'import-error',
+        path: path,
+        error: _jsonError(json),
+      );
+    }
+
+    _persistSnapshot();
+    final refreshed = props() ?? const <String, Object?>{};
+    return <String, Object?>{
+      ...refreshed,
+      'hostIntent': hostIntent,
+      'hostResult': <String, Object?>{
+        'status': 'imported',
+        'path': path,
+      },
+    };
+  }
+
+  Future<Map<String, Object?>?> _exportAnkiPackage(
+    Map<String, Object?> response,
+    Map<String, Object?> hostIntent,
+  ) async {
+    final FileSaveLocation? location;
+    try {
+      location = await getSaveLocation(
+        acceptedTypeGroups: _ankiTypeGroups(
+          hostIntentExtensions(hostIntent, 'extensions', const <String>[
+            '.apkg',
+          ]),
+        ),
+        suggestedName: suggestedAnkiFileName(hostIntent),
+        confirmButtonText: 'Export',
+      );
+    } catch (error) {
+      return _hostResultResponse(
+        response,
+        hostIntent,
+        'unsupported',
+        error: error,
+      );
+    }
+
+    if (location == null) {
+      return _hostResultResponse(response, hostIntent, 'cancelled');
+    }
+
+    final outputPath = _ensureApkgExtension(location.path);
+    final json = _takeCString(_api.egExportAnkiApkg(_session));
+    if (!_jsonOk(json)) {
+      return _hostResultResponse(
+        response,
+        hostIntent,
+        'export-error',
+        path: outputPath,
+        error: _jsonError(json),
+      );
+    }
+
+    final bytes = _jsonByteArray(json, 'apkg');
+    if (bytes.isEmpty) {
+      return _hostResultResponse(
+        response,
+        hostIntent,
+        'export-error',
+        path: outputPath,
+        error: 'Engram native host returned an empty APKG',
+      );
+    }
+
+    try {
+      await XFile.fromData(
+        bytes,
+        mimeType: 'application/octet-stream',
+        name: _baseName(outputPath),
+      ).saveTo(outputPath);
+    } catch (error) {
+      return _hostResultResponse(
+        response,
+        hostIntent,
+        'write-error',
+        path: outputPath,
+        error: error,
+      );
+    }
+
+    return _hostResultResponse(
+      response,
+      hostIntent,
+      'exported',
+      path: outputPath,
+    );
   }
 
   void dispose() {
@@ -115,6 +299,16 @@ class MosaicHost {
       return pointer.toDartString();
     } finally {
       _api.egStringFree(pointer);
+    }
+  }
+
+  String _mergeAnkiApkg(Uint8List bytes) {
+    final data = calloc<Uint8>(bytes.length);
+    try {
+      data.asTypedList(bytes.length).setAll(0, bytes);
+      return _takeCString(_api.egMergeAnkiApkg(_session, data, bytes.length));
+    } finally {
+      calloc.free(data);
     }
   }
 
@@ -186,7 +380,15 @@ class _EngramCapi {
         ),
         egHandleEngramAppEvent = library.lookupFunction<
             _EgHandleEngramAppEventNative,
-            _EgHandleEngramAppEventDart>('eg_handle_engram_app_event');
+            _EgHandleEngramAppEventDart>('eg_handle_engram_app_event'),
+        egExportAnkiApkg = library
+            .lookupFunction<_EgExportAnkiApkgNative, _EgExportAnkiApkgDart>(
+          'eg_export_anki_apkg',
+        ),
+        egMergeAnkiApkg = library
+            .lookupFunction<_EgMergeAnkiApkgNative, _EgMergeAnkiApkgDart>(
+          'eg_merge_anki_apkg',
+        );
 
   final _EgSessionNewDart egSessionNewDemo;
   final _EgSessionFreeDart egSessionFree;
@@ -195,6 +397,8 @@ class _EngramCapi {
   final _EgLoadSnapshotDart egLoadSnapshot;
   final _EgEngramAppPropsDart egEngramAppProps;
   final _EgHandleEngramAppEventDart egHandleEngramAppEvent;
+  final _EgExportAnkiApkgDart egExportAnkiApkg;
+  final _EgMergeAnkiApkgDart egMergeAnkiApkg;
 
   static _EngramCapi? load() {
     if (Platform.isIOS) {
@@ -257,6 +461,104 @@ Map<String, Object?> _mosaicMap(Object? value) {
     }
   }
   return out;
+}
+
+Map<String, Object?> _hostResultResponse(
+  Map<String, Object?> response,
+  Map<String, Object?> hostIntent,
+  String status, {
+  String? path,
+  Object? error,
+}) {
+  final out = <String, Object?>{
+    ...response,
+    'hostIntent': hostIntent,
+  };
+  final hostResult = <String, Object?>{'status': status};
+  if (path != null && path.isNotEmpty) {
+    hostResult['path'] = path;
+  }
+  if (error != null) {
+    hostResult['error'] = error.toString();
+  }
+  out['hostResult'] = hostResult;
+  return out;
+}
+
+List<String> hostIntentExtensions(
+  Map<String, Object?> hostIntent,
+  String property,
+  List<String> fallback,
+) {
+  final raw = hostIntent[property];
+  if (raw is! List) {
+    return fallback;
+  }
+
+  final extensions = raw
+      .map((value) => value.toString().trim())
+      .where((value) => value.isNotEmpty)
+      .map((value) => value.startsWith('.') ? value : '.$value')
+      .toList(growable: false);
+  return extensions.isEmpty ? fallback : extensions;
+}
+
+List<XTypeGroup> _ankiTypeGroups(List<String> extensions) {
+  return <XTypeGroup>[
+    XTypeGroup(
+      label: 'Anki packages',
+      extensions: extensions
+          .map((extension) => extension.startsWith('.') ? extension.substring(1) : extension)
+          .toList(growable: false),
+    ),
+  ];
+}
+
+String suggestedAnkiFileName(Map<String, Object?> hostIntent) {
+  final raw = hostIntent['deckId']?.toString().trim();
+  final name = raw == null || raw.isEmpty ? 'engram-collection' : raw;
+  final safe = name.replaceAll(RegExp(r'''[\/\\:*?"<>|]'''), '-');
+  return safe.toLowerCase().endsWith('.apkg') ? safe : '$safe.apkg';
+}
+
+String _xFilePath(XFile file) => file.path.isEmpty ? file.name : file.path;
+
+String _ensureApkgExtension(String path) =>
+    path.toLowerCase().endsWith('.apkg') ? path : '$path.apkg';
+
+String _baseName(String path) {
+  final normalized = path.replaceAll('\\', '/');
+  final index = normalized.lastIndexOf('/');
+  return index < 0 ? normalized : normalized.substring(index + 1);
+}
+
+Uint8List _jsonByteArray(String json, String property) {
+  final Object? decoded;
+  try {
+    decoded = jsonDecode(json);
+  } catch (_) {
+    return Uint8List(0);
+  }
+  if (decoded is! Map || decoded[property] is! List) {
+    return Uint8List(0);
+  }
+  final values = decoded[property] as List;
+  return Uint8List.fromList(
+    values
+        .whereType<num>()
+        .map((value) => value.toInt() & 0xff)
+        .toList(growable: false),
+  );
+}
+
+String _jsonError(String json) {
+  try {
+    final decoded = jsonDecode(json);
+    if (decoded is Map && decoded['error'] != null) {
+      return decoded['error'].toString();
+    }
+  } catch (_) {}
+  return 'Engram native host failed';
 }
 
 T _withNativeUtf8<T>(String value, T Function(Pointer<Utf8>) body) {

--- a/code/programs/mosaic/engram-app/scripts/build-all.ps1
+++ b/code/programs/mosaic/engram-app/scripts/build-all.ps1
@@ -242,18 +242,34 @@ function Add-EngramFlutterHostDependencies {
         return
     }
     $content = Get-Content -LiteralPath $PubspecPath -Raw
-    if ($content.Contains("  ffi:")) {
-        return
+    $lineEnding = if ($content.Contains("`r`n")) { "`r`n" } else { "`n" }
+    if (-not $content.Contains("  ffi:")) {
+        $content = $content.Replace(
+            "dependencies:`n  flutter:`n    sdk: flutter",
+            "dependencies:`n  flutter:`n    sdk: flutter`n  ffi: ^2.1.3"
+        )
+        $content = $content.Replace(
+            "dependencies:`r`n  flutter:`r`n    sdk: flutter",
+            "dependencies:`r`n  flutter:`r`n    sdk: flutter`r`n  ffi: ^2.1.3"
+        )
     }
-
-    $content = $content.Replace(
-        "dependencies:`n  flutter:`n    sdk: flutter",
-        "dependencies:`n  flutter:`n    sdk: flutter`n  ffi: ^2.1.3"
-    )
-    $content = $content.Replace(
-        "dependencies:`r`n  flutter:`r`n    sdk: flutter",
-        "dependencies:`r`n  flutter:`r`n    sdk: flutter`r`n  ffi: ^2.1.3"
-    )
+    if (-not $content.Contains("  file_selector:")) {
+        if ($content.Contains("  ffi: ^2.1.3")) {
+            $content = $content.Replace(
+                "  ffi: ^2.1.3",
+                "  ffi: ^2.1.3${lineEnding}  file_selector: ^1.0.3"
+            )
+        } else {
+            $content = $content.Replace(
+                "dependencies:`n  flutter:`n    sdk: flutter",
+                "dependencies:`n  flutter:`n    sdk: flutter`n  file_selector: ^1.0.3"
+            )
+            $content = $content.Replace(
+                "dependencies:`r`n  flutter:`r`n    sdk: flutter",
+                "dependencies:`r`n  flutter:`r`n    sdk: flutter`r`n  file_selector: ^1.0.3"
+            )
+        }
+    }
     Write-Utf8NoBom -Path $PubspecPath -Content $content
 }
 

--- a/code/programs/mosaic/engram-app/tests/package_compiles.rs
+++ b/code/programs/mosaic/engram-app/tests/package_compiles.rs
@@ -1043,7 +1043,7 @@ fn native_project_shells_expose_engram_host_contract() {
     assert_contains(&flutter_app, "EngramApp(");
     assert_contains(&flutter_app, "import 'mosaic_host.dart';");
     assert_contains(&flutter_app, "MosaicHost.load()");
-    assert_contains(&flutter_app, "_applyMosaicResponse(_mosaicHost?.props())");
+    assert_contains(&flutter_app, "_queueMosaicResponse(_mosaicHost?.props())");
     assert_contains(
         &flutter_app,
         "appTitle: mosaicString(_hostProps, \"app-title\", \"Sample AppTitle\"),",
@@ -1168,7 +1168,7 @@ fn native_project_shells_expose_engram_host_contract() {
         &flutter_app,
         "debugPrint(\"event: ${event.mosaicEnvelope}\");",
     );
-    assert_contains(&flutter_app, "_applyMosaicResponse(response);");
+    assert_contains(&flutter_app, "_queueMosaicResponse(response);");
 
     let flutter_host = fs::read_to_string(
         tmp.path()
@@ -1179,9 +1179,14 @@ fn native_project_shells_expose_engram_host_contract() {
     .expect("flutter/lib/mosaic_host.dart");
     assert_contains(&flutter_host, "class MosaicHost");
     assert_contains(&flutter_host, "DynamicLibrary.open");
+    assert_contains(&flutter_host, "package:file_selector/file_selector.dart");
     assert_contains(&flutter_host, "eg_engram_app_props");
     assert_contains(&flutter_host, "eg_handle_engram_app_event");
+    assert_contains(&flutter_host, "eg_export_anki_apkg");
+    assert_contains(&flutter_host, "eg_merge_anki_apkg");
     assert_contains(&flutter_host, "jsonEncode(event)");
+    assert_contains(&flutter_host, "openFile");
+    assert_contains(&flutter_host, "getSaveLocation");
     assert_contains(&flutter_host, "'props': _mosaicMap(decoded['props'])");
 
     let compose_app =
@@ -2620,8 +2625,13 @@ fn source_tree_has_expected_shape() {
     assert_contains(&flutter_host, "DynamicLibrary.open");
     assert_contains(&flutter_host, "eg_engram_app_props");
     assert_contains(&flutter_host, "eg_handle_engram_app_event");
+    assert_contains(&flutter_host, "eg_export_anki_apkg");
+    assert_contains(&flutter_host, "eg_merge_anki_apkg");
     assert_contains(&flutter_host, "jsonEncode(event)");
+    assert_contains(&flutter_host, "openFile");
+    assert_contains(&flutter_host, "getSaveLocation");
     assert_contains(&flutter_host, "'hostIntent'");
+    assert_contains(&flutter_host, "'hostResult'");
     assert_contains(&flutter_host, "'props'");
     assert_contains(&flutter_host, "ENGRAM_SNAPSHOT_PATH");
     assert_contains(&flutter_host, "mosaic-snapshot.v1.json");
@@ -2640,6 +2650,7 @@ fn source_tree_has_expected_shape() {
     assert_contains(&build_script, "Install-EngramFlutterHost");
     assert_contains(&build_script, "Install-EngramComposeHost");
     assert_contains(&build_script, "ffi: ^2.1.3");
+    assert_contains(&build_script, "file_selector: ^1.0.3");
     assert_contains(&build_script, "net.java.dev.jna:jna:5.19.1");
     assert_contains(&build_script, "org.json:json:20260522");
     assert_contains(&build_script, "module CEngram");


### PR DESCRIPTION
## Summary

- Teach the generated Flutter shell to accept async Mosaic host responses so file-picker-backed hosts can return results after a dialog completes.
- Wire Engram's Flutter `MosaicHost` to handle `importAnki` and `exportAnki` host intents using `file_selector` and the shared `engram-capi` APKG import/export functions.
- Add Flutter dependency injection, docs, and smoke-test assertions for the new Anki file intent bridge.

## Validation

- `git diff --check`
- `cargo test --manifest-path code/packages/rust/mosaic-emit-flutter/Cargo.toml`
- `cargo test --manifest-path code/programs/mosaic/engram-app/Cargo.toml -- --nocapture`
- `code/programs/mosaic/engram-app/scripts/build-all.ps1`

Note: this Windows environment does not currently have `dart` or `flutter` on PATH, so I could not run `dart format` or Flutter analyzer locally.