### PR TITLE
test(sir): expand conformance corpus 6→11; document 3 latent gaps found

### DIFF
--- a/code/packages/rust/sir-conformance/CHANGELOG.md
+++ b/code/packages/rust/sir-conformance/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable changes to the `sir-conformance` crate will be documented in this file.
 
+## [0.2.0] - 2026-07-02
+
+### Added — corpus expansion (6 -> 11 programs) + three latent gaps found
+
+Broadened the conformance corpus to exercise loops, arrays, string methods,
+instance state, and mixins. Five new programs, all green on every backend:
+
+- `while_loop` — a `while` with a mutable accumulator (0+1+2+3+4 = 10).
+- `array_length` — array literal + `.length`.
+- `string_length` — `String#length`.
+- `counter_state` — `@ivar` state mutated across method calls (2).
+- `mixin_include` — a `module` mixed into a class via `include`.
+
+Verified locally: **11 corpus x 4 backends = 44 runs, 0 skipped, all agree.**
+
+### Found (documented, kept OUT of the corpus until fixed; see lessons.md)
+
+Expanding coverage immediately surfaced three real `case_eq`-style gaps — caught
+only because each backend is compared to the reference, not to backend-consensus:
+
+- **Frontend array/hash index** — `puts a[1]` mis-parses as `(puts a)[1]`,
+  `puts(a[1])` fails to parse, and `x = a[1]` fails SIR validation (index base
+  mis-scoped). Index-based programs are therefore excluded for now.
+- **JS string-method rename** — the JS backend renames Ruby method names to
+  native JS at emit time but is missing `upcase`/`downcase` → `NoMethodError`
+  on JS only.
+- **JS `or` builtin** — a multi-value `when 1, 2, 3` lowers to a
+  `BuiltinCall("or", …)` the JS runtime doesn't implement → `unknown builtin`.
+
+Each is tracked for a separate focused fix; adding a program that can't pass
+would only mask them.
+
 ## [0.1.0] - 2026-07-02
 
 ### Added — cross-backend golden conformance harness

--- a/code/packages/rust/sir-conformance/Cargo.toml
+++ b/code/packages/rust/sir-conformance/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sir-conformance"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Cross-backend golden conformance harness for the Semantic IR: lowers real Ruby source and runs the emitted program through every backend's real toolchain, asserting identical output."
 

--- a/code/packages/rust/sir-conformance/README.md
+++ b/code/packages/rust/sir-conformance/README.md
@@ -60,9 +60,29 @@ across backends, a separate formatting concern). Current programs:
 | `tail_case` | implicit return of a trailing `case` (the `case_eq` oracle) | `A\nB\nC` |
 | `string_concat` | polymorphic `+` | `abcd` |
 | `oop_method` | `class` / `.new` / instance method | `woof` |
+| `while_loop` | `while` + mutable accumulator | `10` |
+| `array_length` | array literal + `.length` | `3` |
+| `string_length` | `String#length` | `5` |
+| `counter_state` | `@ivar` state across method calls | `2` |
+| `mixin_include` | `module` mixed into a class via `include` | `hi` |
 
 Adding a program is one `Program { name, ruby, expected }` entry in
 `tests/conformance.rs`.
+
+### Gaps the corpus has surfaced (not yet in the suite)
+
+Every added feature is a chance to catch a `case_eq`-style "works on some
+backends" bug. Programs that hit an **unfixed** gap are kept *out* of the corpus
+(with a pointer to `lessons.md`) so the suite stays green while the gap stays
+visible. Currently tracked:
+
+- **Array/hash index** (`a[i]`, `h[k]`) — frontend parse + lowering bugs
+  (`puts a[1]` mis-parses, `puts(a[1])` won't parse, `x = a[1]` fails
+  validation).
+- **`String#upcase`/`#downcase` on JavaScript** — the JS backend's emit-time
+  Ruby→native method rename is missing the case pair.
+- **`or`/`and` builtin on JavaScript** — a multi-value `when 1, 2, 3` lowers to
+  a `BuiltinCall("or", …)` the JS runtime doesn't implement.
 
 ## Usage
 

--- a/code/packages/rust/sir-conformance/tests/conformance.rs
+++ b/code/packages/rust/sir-conformance/tests/conformance.rs
@@ -52,6 +52,53 @@ const CORPUS: &[Program] = &[
         ruby: "class Dog\n  def speak\n    \"woof\"\n  end\nend\n\nputs Dog.new.speak\n",
         expected: "woof",
     },
+    // A `while` loop with a mutable accumulator: 0+1+2+3+4.
+    Program {
+        name: "while_loop",
+        ruby: "i = 0\nsum = 0\nwhile i < 5\n  sum = sum + i\n  i = i + 1\nend\n\nputs sum\n",
+        expected: "10",
+    },
+    // Array literal + `.length` (a method call, which lowers cleanly).
+    //
+    // NOTE: index *reads* (`a[1]`, `h["k"]`) are deliberately NOT in the corpus
+    // yet — they hit two separate, currently-open Ruby-frontend gaps (see
+    // `lessons.md`): the paren-less `puts a[1]` mis-parses as `(puts a)[1]` and
+    // `puts(a[1])` fails to parse, while `x = a[1]` parses but fails SIR
+    // validation (`var-ref ... unknown name 'a'` — the index base is
+    // mis-scoped). Those are frontend bugs, tracked for a separate fix; adding a
+    // program that can't pass would only mask them. `.length` covers array
+    // construction end-to-end without tripping the index path.
+    Program {
+        name: "array_length",
+        ruby: "a = [10, 20, 30]\nputs a.length\n",
+        expected: "3",
+    },
+    // String `.length` (a method on a String receiver). NOTE: `.upcase` /
+    // `.downcase` are deliberately excluded for now — they expose a real
+    // JavaScript-backend gap: that backend translates Ruby method names to
+    // native JS names *at emit time* (e.g. `upcase` → `toUpperCase`), and the
+    // rename table is missing the case-conversion pair, so `"x".upcase` raises
+    // `NoMethodError` on JS while Python/Go/Rust (which dispatch Ruby names in a
+    // runtime catalog) handle it. Tracked for a separate focused fix; see
+    // `lessons.md`. `.length` is spelled identically across all four, so it
+    // exercises string-method dispatch end-to-end without tripping the gap.
+    Program {
+        name: "string_length",
+        ruby: "puts \"hello\".length\n",
+        expected: "5",
+    },
+    // Instance state via `@ivar` mutated across method calls.
+    Program {
+        name: "counter_state",
+        ruby: "class Counter\n  def initialize\n    @n = 0\n  end\n  def inc\n    @n = @n + 1\n  end\n  def value\n    @n\n  end\nend\n\nc = Counter.new\nc.inc\nc.inc\nputs c.value\n",
+        expected: "2",
+    },
+    // A module mixed into a class with `include`.
+    Program {
+        name: "mixin_include",
+        ruby: "module Greet\n  def hi\n    \"hi\"\n  end\nend\n\nclass P\n  include Greet\nend\n\nputs P.new.hi\n",
+        expected: "hi",
+    },
 ];
 
 /// Every program must produce its reference output on every available backend.

--- a/lessons.md
+++ b/lessons.md
@@ -1117,3 +1117,41 @@ arms passed and masked the gap on the inline-runtime backends.
 
 Discovered: 2026-07-02, while adding trailing-`case` implicit return; a `case`
 program printed correctly on Python but panicked on Go/Rust/JS.
+
+## The conformance harness immediately found three latent cross-backend gaps
+
+Expanding the `sir-conformance` corpus (6 → 11 Ruby programs) surfaced three
+real bugs the moment broader features were exercised — exactly what the harness
+is for. Each is a `case_eq`-style "works on some backends" gap, caught only
+because the harness compares each backend to the **reference**, not to
+backend-consensus (so backends *agreeing on a wrong answer* still fails).
+
+1. **Frontend: array/hash index (`a[i]`, `h[k]`) is under-baked.**
+   - `puts a[1]` (paren-less) **mis-parses** as `(puts a)[1]` — all four backends
+     faithfully print the whole array then index, agreeing on the wrong answer.
+   - `puts(a[1])` **fails to parse** outright ("Expected … got `[`").
+   - `x = a[1]` parses but **fails SIR validation**: `var-ref scope=local
+     references unknown name 'a'` — the index-base variable is mis-scoped during
+     lowering. `x = a[1] + 0` (index inside arithmetic) *does* lower.
+   These are Ruby-frontend parser/lowering bugs, not backend gaps.
+
+2. **JavaScript backend: Ruby string method names aren't all renamed.** The JS
+   backend translates Ruby method names to native JS **at emit time**
+   (`upcase` → `toUpperCase`), unlike Python/Go/Rust which dispatch Ruby names in
+   a runtime catalog. The rename table is missing the case pair, so `"x".upcase`
+   raises `NoMethodError` on JS while the other three succeed. `.length` (spelled
+   identically) works everywhere.
+
+3. **JavaScript (and possibly Go/Rust) runtime: no `or`/`and` builtin.** A
+   multi-value `when 1, 2, 3` lowers to `case_eq(...) or case_eq(...)` as a
+   `BuiltinCall("or", …)`; the JS runtime's builtin table has no `or`, so it
+   throws `unknown builtin: or` — the same shape as the `case_eq` gap. (Go/Rust
+   were not reached before the JS failure, so they may share it.)
+
+**Lesson:** each of these passed every per-backend unit test and only a
+Ruby-source→all-backends run against a reference caught them. Keep growing the
+corpus; every added feature is a chance to surface the next one. Programs that
+hit an *unfixed* gap are kept OUT of the corpus (with a comment pointing here)
+until the gap is fixed, so the suite stays green and the gaps stay visible.
+
+Discovered: 2026-07-02, expanding the conformance corpus (PR after the harness landed).


### PR DESCRIPTION
## What

Broadens the `sir-conformance` golden corpus and, in doing so, has the harness **immediately find three real cross-backend bugs** — exactly what it's for.

## New programs (all green on all 4 backends)

`while_loop` (mutable accumulator → `10`), `array_length` (`[..].length` → `3`), `string_length` (`String#length` → `5`), `counter_state` (`@ivar` state across method calls → `2`), `mixin_include` (`module` + `include` → `hi`).

**Verified locally: 11 corpus × 4 backends = 44 runs, 0 skipped, all agree.**

## Gaps found (documented, kept OUT of the corpus until fixed)

Each is a `case_eq`-style "works on some backends" bug, caught only because every backend is compared to the **reference**, not to backend-consensus (so backends *agreeing on a wrong answer* still fails):

1. **Frontend array/hash index** — `puts a[1]` mis-parses as `(puts a)[1]` (all four backends print the wrong thing *and agree*), `puts(a[1])` fails to parse, `x = a[1]` fails SIR validation (index base mis-scoped).
2. **JS `String#upcase`/`#downcase`** — the JS backend renames Ruby method names to native JS at emit time but is missing the case pair → `NoMethodError` on JS only.
3. **JS `or` builtin** — a multi-value `when 1, 2, 3` lowers to `BuiltinCall("or", …)` the JS runtime doesn't implement → `unknown builtin` (exact `case_eq` shape).

Programs hitting an unfixed gap are excluded (with comments pointing at `lessons.md`) so the suite stays green while the gaps stay visible. **Three follow-up tasks filed**, each re-enabling its conformance program once fixed.

## Notes

- No harness-runner code changed — only corpus data + docs (`lessons.md`, README gap list, CHANGELOG). Version 0.1.0 → 0.2.0.
- Security review: **passed** (new entries are hardcoded benign Ruby literals run through the already-reviewed harness; no new logic/deps/untrusted input).

This is the "prove it works" flywheel: the conformance matrix now actively surfaces the next latent bugs instead of them lurking until someone trips over them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)