### PR TITLE
feat(adj-ladder): rung-58 vasopressor bag concentration — product-over-sum (a*b)/(c+d)

### DIFF
--- a/code/specs/data/adj-ladder/rung58_pressor_concentration/gen_items.py
+++ b/code/specs/data/adj-ladder/rung58_pressor_concentration/gen_items.py
@@ -1,0 +1,224 @@
+"""Generate rung-58 (vasopressor bag concentration) items.json for the ADJ-LADDER.
+
+Rung 58 opens the **critical-care / vasopressor-infusion** panel on the quantitative band — the arithmetic of mixing a
+pressor drip. A nurse draws several ampoules of a drug into a bag: the total drug MASS is the amount per ampoule times
+the number of ampoules (a PRODUCT), and the total fluid VOLUME is the drug volume plus the diluent volume (a SUM). The
+bag's concentration is the total mass divided by the total volume. Dividing a product by a sum introduces a genuinely
+NEW arithmetic shape on the ladder: a **product over a sum** — `(a · b) / (c + d)` — a parenthesised product in the
+numerator over a parenthesised sum in the denominator.
+
+The setup: a bag is mixed from `ampoule_count` ampoules of `amount_per_ampoule` each, drawn up in `drug_volume` of drug
+solution and topped up with `diluent_volume` of diluent. The concentration is the total mass over the total volume:
+
+  CONCENTRATION   (amount_per_ampoule · ampoule_count) / (drug_volume + diluent_volume)   [ the mixed bag strength ]
+  TOTAL MASS      amount_per_ampoule · ampoule_count                                       [ the product: total drug ]
+  TOTAL VOLUME    drug_volume + diluent_volume                                             [ the sum: total fluid ]
+
+The **concentration** is what makes this rung distinctive — it is the ladder's first **product over a sum**: a
+parenthesised product divided by a parenthesised sum. Contrast the neighbours already on the ladder: rung-15 was a
+*product over a PRODUCT* `(a·b)/(c·d)` and rung-37 a *sum over a sum* `(a+b)/(c+d)`; neither divided a PRODUCT by a SUM.
+(The total mass `amount_per_ampoule · ampoule_count` and the total volume `drug_volume + diluent_volume` ride alongside
+as component readouts, so the panel teaches the whole calculation — exactly as rungs 47-57 shipped their component
+products/sums/ratios beside the headline figure.)
+
+Each index is a `compute_dimensioned` program (`observe` the four quantities + `let answer = formula`); the ADJ engine
+carries the arithmetic — including the parenthesised product and sum and their quotient — and the harness reads the
+scalar via the existing `compute_dimensioned` extractor. No harness/engine change, exactly as rungs 8/16/.../56/57. This
+rung exercises the engine across a **product divided by a sum** — the fact that `(a·b)/(c+d)` is NOT `a·b/c + d` and NOT
+`(a·b)/d` made computable.
+
+Contamination-safe by construction: every formula is built ONLY from the four observed quantities via `·`, `+` and `/`
+— **no structural constants** — so no numeric literal appears in any program, and neither the total mass, the total
+volume, nor any concentration figure is ever a literal (each is computed from the observed quantities). The observed
+quantities carry **digit-free identifiers** (`amount_per_ampoule`, `ampoule_count`, `drug_volume`, `diluent_volume`) so
+no numeral hides inside a variable name.
+
+The five options are a tight family over the same four quantities: the three real readouts plus the two classic slips —
+
+  MISGROUPED           (amount_per_ampoule · ampoule_count) / drug_volume + diluent_volume   divide the mass by only the
+                                                                                             DRUG volume, then add the
+                                                                                             diluent on
+                                                                                             (`… / drug + diluent`, not
+                                                                                             `… / (drug + diluent)`), and
+  MASS OVER DILUENT    (amount_per_ampoule · ampoule_count) / diluent_volume                 divide the mass by the
+                                                                                             DILUENT volume alone,
+                                                                                             forgetting the drug volume,
+
+which are exactly the mistakes a student makes (breaking the grouping so the mass divides only the first volume term, or
+dividing by one volume component instead of the total). Gold rotates A-E by index. QUERIED (used as gold) = the three
+real readouts; all five always appear as options.
+
+Distinctness: all four observed quantities are strictly positive, so every product, sum and quotient is positive; the
+tables below are chosen so the five family values are pairwise distinct with a comfortable margin, asserted at build time.
+"""
+import json
+
+LETTERS = ["A", "B", "C", "D", "E"]
+
+# (AMOUNT_PER_AMPOULE, AMPOULE_COUNT, DRUG_VOLUME, DILUENT_VOLUME) — the drug amount in one ampoule and the number of
+# ampoules (their product is the total mass), and the drug and diluent volumes (their sum is the total fluid), all
+# plain positive numbers. The five family values are asserted pairwise-distinct (with margin) below.
+TABLES = [
+    (4, 5, 20, 80),
+    (8, 3, 12, 88),
+    (2, 6, 10, 40),
+    (10, 4, 40, 60),
+    (5, 8, 20, 30),
+    (6, 5, 30, 70),
+    (16, 2, 8, 42),
+]
+
+# The option family (5 members), all built from the four observed quantities via *, + and /. Every identifier is
+# DIGIT-FREE. key -> (display name, formula-as-adj). Only the first three are *queried* (used as gold); all five
+# always appear as the options.
+FAMILY = [
+    (
+        "concentration",
+        "the bag concentration (the total drug mass over the total fluid volume)",
+        "(amount_per_ampoule * ampoule_count) / (drug_volume + diluent_volume)",
+    ),
+    (
+        "total_mass",
+        "the total drug mass (amount per ampoule times the number of ampoules)",
+        "amount_per_ampoule * ampoule_count",
+    ),
+    (
+        "total_volume",
+        "the total fluid volume (drug volume plus diluent volume)",
+        "drug_volume + diluent_volume",
+    ),
+    (
+        "misgrouped",
+        "the mass divided by only the DRUG volume, with diluent volume added on (broken grouping)",
+        "(amount_per_ampoule * ampoule_count) / drug_volume + diluent_volume",
+    ),
+    (
+        "mass_over_diluent",
+        "the mass divided by the DILUENT volume alone (forgetting the drug volume)",
+        "(amount_per_ampoule * ampoule_count) / diluent_volume",
+    ),
+]
+QUERIED = ["concentration", "total_mass", "total_volume"]
+ORDER = [k for k, _, _ in FAMILY]
+
+
+def scalar(v):
+    return {"value": v, "unit": "scalar"}
+
+
+def family_values(amount_per_ampoule, ampoule_count, drug_volume, diluent_volume):
+    # Operation order mirrors the ADJ programs exactly (a parenthesised product over a parenthesised sum; and, for the
+    # misgrouped slip, the mass-over-drug quotient binds tighter than the trailing addition), so the Python option value
+    # and the engine result are the same IEEE-double (well within the harness's 1e-9 match tolerance).
+    mass = amount_per_ampoule * ampoule_count
+    volume = drug_volume + diluent_volume
+    return {
+        "concentration": mass / volume,
+        "total_mass": mass,
+        "total_volume": volume,
+        "misgrouped": mass / drug_volume + diluent_volume,
+        "mass_over_diluent": mass / diluent_volume,
+    }
+
+
+def build():
+    name_of = {k: nm for k, nm, _ in FAMILY}
+    formula_of = {k: f for k, _, f in FAMILY}
+    items = []
+    idx = 0
+
+    def num(x):
+        return int(x) if float(x).is_integer() else x
+
+    for amount_per_ampoule, ampoule_count, drug_volume, diluent_volume in TABLES:
+        assert (
+            amount_per_ampoule > 0
+            and ampoule_count > 0
+            and drug_volume > 0
+            and diluent_volume > 0
+        ), (amount_per_ampoule, ampoule_count, drug_volume, diluent_volume)
+        fv = family_values(amount_per_ampoule, ampoule_count, drug_volume, diluent_volume)
+        # Pairwise-distinct with a comfortable margin so the harness never sees two options
+        # matching the gold value within its 1e-9 tolerance.
+        vals = [fv[key] for key in ORDER]
+        for i in range(len(vals)):
+            for j in range(i + 1, len(vals)):
+                assert abs(vals[i] - vals[j]) > 1e-6, (
+                    amount_per_ampoule,
+                    ampoule_count,
+                    drug_volume,
+                    diluent_volume,
+                    ORDER[i],
+                    ORDER[j],
+                    fv,
+                )
+        for key in QUERIED:
+            gold_val = fv[key]
+            gold_pos = idx % 5
+            others = [fv[k2] for k2 in ORDER if abs(fv[k2] - gold_val) > 1e-12]
+            opts_vals = others[:]
+            opts_vals.insert(gold_pos, gold_val)
+            opts_vals = opts_vals[:5]
+            if abs(opts_vals[gold_pos] - gold_val) > 1e-12:
+                opts_vals[gold_pos] = gold_val
+            assert len({round(v, 9) for v in opts_vals}) == 5, (
+                key,
+                amount_per_ampoule,
+                ampoule_count,
+                drug_volume,
+                diluent_volume,
+                opts_vals,
+            )
+            options = {LETTERS[i]: scalar(opts_vals[i]) for i in range(5)}
+            items.append({
+                "id": f"r58conc-{idx + 1:02d}",
+                "qtype": "pressor_concentration",
+                "stem": (
+                    f"A pressor bag is mixed from {num(ampoule_count)} ampoules of {num(amount_per_ampoule)} mg each, "
+                    f"drawn up in {num(drug_volume)} mL of drug solution and topped up with {num(diluent_volume)} mL of "
+                    f"diluent. What is the {name_of[key]}?"
+                ),
+                "program": (
+                    f"observe amount_per_ampoule({num(amount_per_ampoule)})\n"
+                    f"observe ampoule_count({num(ampoule_count)})\n"
+                    f"observe drug_volume({num(drug_volume)})\n"
+                    f"observe diluent_volume({num(diluent_volume)})\n"
+                    f"let answer = {formula_of[key]}\n"
+                    "? answer\n"
+                ),
+                "answer_from": {"type": "compute_dimensioned", "name": "answer"},
+                "options": options,
+                "gold_letter": LETTERS[gold_pos],
+            })
+            idx += 1
+    return {
+        "description": (
+            "ADJ-LADDER rung 58 — vasopressor bag concentration from four stated quantities (a NEW panel: critical "
+            "care / vasopressor infusion). From an amount per ampoule and an ampoule count (their product is the total "
+            "drug mass) and a drug volume and a diluent volume (their sum is the total fluid), compute the concentration "
+            "((amount_per_ampoule*ampoule_count)/(drug_volume+diluent_volume)), the total mass "
+            "(amount_per_ampoule*ampoule_count), or the total volume (drug_volume+diluent_volume). Each item is a "
+            "compute_dimensioned program (observe the four quantities, let answer = formula); the ADJ engine carries the "
+            "arithmetic — a NEW shape, PRODUCT OVER A SUM (a*b)/(c+d), the first on the ladder to divide a product by a "
+            "sum (distinct from rung-15 product-over-product (a*b)/(c*d) and rung-37 sum-over-sum (a+b)/(c+d)) — and the "
+            "harness matches the scalar to the printed options. Contamination-safe: every index is built only from the "
+            "four observed quantities via *, + and / — no constant leaks, and neither the total mass, the total volume, "
+            "nor any concentration figure ever appears as a literal (each is computed) — and the observed quantities "
+            "carry digit-free identifiers so no numeral hides inside a variable name. The five options are a family over "
+            "the same four quantities, so the distractors are exactly the slips students make: breaking the grouping so "
+            "the mass divides only the drug volume ((a*b)/c+d, not (a*b)/(c+d)), and dividing by the diluent volume "
+            "alone ((a*b)/d). The core confusion tested is dividing a product by a grouped sum."
+        ),
+        "items": items,
+    }
+
+
+if __name__ == "__main__":
+    doc = build()
+    with open("items.json", "w") as f:
+        json.dump(doc, f, indent=2)
+        f.write("\n")
+    print("wrote items.json:", len(doc["items"]), "items")
+    for it in doc["items"]:
+        print(it["id"], it["qtype"], "gold", it["gold_letter"],
+              "=", round(it["options"][it["gold_letter"]]["value"], 6))

--- a/code/specs/data/adj-ladder/rung58_pressor_concentration/items.json
+++ b/code/specs/data/adj-ladder/rung58_pressor_concentration/items.json
@@ -1,0 +1,698 @@
+{
+  "description": "ADJ-LADDER rung 58 \u2014 vasopressor bag concentration from four stated quantities (a NEW panel: critical care / vasopressor infusion). From an amount per ampoule and an ampoule count (their product is the total drug mass) and a drug volume and a diluent volume (their sum is the total fluid), compute the concentration ((amount_per_ampoule*ampoule_count)/(drug_volume+diluent_volume)), the total mass (amount_per_ampoule*ampoule_count), or the total volume (drug_volume+diluent_volume). Each item is a compute_dimensioned program (observe the four quantities, let answer = formula); the ADJ engine carries the arithmetic \u2014 a NEW shape, PRODUCT OVER A SUM (a*b)/(c+d), the first on the ladder to divide a product by a sum (distinct from rung-15 product-over-product (a*b)/(c*d) and rung-37 sum-over-sum (a+b)/(c+d)) \u2014 and the harness matches the scalar to the printed options. Contamination-safe: every index is built only from the four observed quantities via *, + and / \u2014 no constant leaks, and neither the total mass, the total volume, nor any concentration figure ever appears as a literal (each is computed) \u2014 and the observed quantities carry digit-free identifiers so no numeral hides inside a variable name. The five options are a family over the same four quantities, so the distractors are exactly the slips students make: breaking the grouping so the mass divides only the drug volume ((a*b)/c+d, not (a*b)/(c+d)), and dividing by the diluent volume alone ((a*b)/d). The core confusion tested is dividing a product by a grouped sum.",
+  "items": [
+    {
+      "id": "r58conc-01",
+      "qtype": "pressor_concentration",
+      "stem": "A pressor bag is mixed from 5 ampoules of 4 mg each, drawn up in 20 mL of drug solution and topped up with 80 mL of diluent. What is the the bag concentration (the total drug mass over the total fluid volume)?",
+      "program": "observe amount_per_ampoule(4)\nobserve ampoule_count(5)\nobserve drug_volume(20)\nobserve diluent_volume(80)\nlet answer = (amount_per_ampoule * ampoule_count) / (drug_volume + diluent_volume)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 0.2,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 20,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 100,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 81.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.25,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r58conc-02",
+      "qtype": "pressor_concentration",
+      "stem": "A pressor bag is mixed from 5 ampoules of 4 mg each, drawn up in 20 mL of drug solution and topped up with 80 mL of diluent. What is the the total drug mass (amount per ampoule times the number of ampoules)?",
+      "program": "observe amount_per_ampoule(4)\nobserve ampoule_count(5)\nobserve drug_volume(20)\nobserve diluent_volume(80)\nlet answer = amount_per_ampoule * ampoule_count\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 0.2,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 20,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 100,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 81.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.25,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r58conc-03",
+      "qtype": "pressor_concentration",
+      "stem": "A pressor bag is mixed from 5 ampoules of 4 mg each, drawn up in 20 mL of drug solution and topped up with 80 mL of diluent. What is the the total fluid volume (drug volume plus diluent volume)?",
+      "program": "observe amount_per_ampoule(4)\nobserve ampoule_count(5)\nobserve drug_volume(20)\nobserve diluent_volume(80)\nlet answer = drug_volume + diluent_volume\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 0.2,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 20,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 100,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 81.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.25,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r58conc-04",
+      "qtype": "pressor_concentration",
+      "stem": "A pressor bag is mixed from 3 ampoules of 8 mg each, drawn up in 12 mL of drug solution and topped up with 88 mL of diluent. What is the the bag concentration (the total drug mass over the total fluid volume)?",
+      "program": "observe amount_per_ampoule(8)\nobserve ampoule_count(3)\nobserve drug_volume(12)\nobserve diluent_volume(88)\nlet answer = (amount_per_ampoule * ampoule_count) / (drug_volume + diluent_volume)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 24,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 100,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 90.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.24,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.2727272727272727,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r58conc-05",
+      "qtype": "pressor_concentration",
+      "stem": "A pressor bag is mixed from 3 ampoules of 8 mg each, drawn up in 12 mL of drug solution and topped up with 88 mL of diluent. What is the the total drug mass (amount per ampoule times the number of ampoules)?",
+      "program": "observe amount_per_ampoule(8)\nobserve ampoule_count(3)\nobserve drug_volume(12)\nobserve diluent_volume(88)\nlet answer = amount_per_ampoule * ampoule_count\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 0.24,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 100,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 90.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.2727272727272727,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 24,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r58conc-06",
+      "qtype": "pressor_concentration",
+      "stem": "A pressor bag is mixed from 3 ampoules of 8 mg each, drawn up in 12 mL of drug solution and topped up with 88 mL of diluent. What is the the total fluid volume (drug volume plus diluent volume)?",
+      "program": "observe amount_per_ampoule(8)\nobserve ampoule_count(3)\nobserve drug_volume(12)\nobserve diluent_volume(88)\nlet answer = drug_volume + diluent_volume\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 100,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 0.24,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 24,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 90.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.2727272727272727,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r58conc-07",
+      "qtype": "pressor_concentration",
+      "stem": "A pressor bag is mixed from 6 ampoules of 2 mg each, drawn up in 10 mL of drug solution and topped up with 40 mL of diluent. What is the the bag concentration (the total drug mass over the total fluid volume)?",
+      "program": "observe amount_per_ampoule(2)\nobserve ampoule_count(6)\nobserve drug_volume(10)\nobserve diluent_volume(40)\nlet answer = (amount_per_ampoule * ampoule_count) / (drug_volume + diluent_volume)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 12,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 0.24,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 50,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 41.2,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.3,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r58conc-08",
+      "qtype": "pressor_concentration",
+      "stem": "A pressor bag is mixed from 6 ampoules of 2 mg each, drawn up in 10 mL of drug solution and topped up with 40 mL of diluent. What is the the total drug mass (amount per ampoule times the number of ampoules)?",
+      "program": "observe amount_per_ampoule(2)\nobserve ampoule_count(6)\nobserve drug_volume(10)\nobserve diluent_volume(40)\nlet answer = amount_per_ampoule * ampoule_count\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 0.24,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 50,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 12,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 41.2,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.3,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r58conc-09",
+      "qtype": "pressor_concentration",
+      "stem": "A pressor bag is mixed from 6 ampoules of 2 mg each, drawn up in 10 mL of drug solution and topped up with 40 mL of diluent. What is the the total fluid volume (drug volume plus diluent volume)?",
+      "program": "observe amount_per_ampoule(2)\nobserve ampoule_count(6)\nobserve drug_volume(10)\nobserve diluent_volume(40)\nlet answer = drug_volume + diluent_volume\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 0.24,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 12,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 41.2,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 50,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.3,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r58conc-10",
+      "qtype": "pressor_concentration",
+      "stem": "A pressor bag is mixed from 4 ampoules of 10 mg each, drawn up in 40 mL of drug solution and topped up with 60 mL of diluent. What is the the bag concentration (the total drug mass over the total fluid volume)?",
+      "program": "observe amount_per_ampoule(10)\nobserve ampoule_count(4)\nobserve drug_volume(40)\nobserve diluent_volume(60)\nlet answer = (amount_per_ampoule * ampoule_count) / (drug_volume + diluent_volume)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 40,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 100,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 61.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.6666666666666666,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.4,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r58conc-11",
+      "qtype": "pressor_concentration",
+      "stem": "A pressor bag is mixed from 4 ampoules of 10 mg each, drawn up in 40 mL of drug solution and topped up with 60 mL of diluent. What is the the total drug mass (amount per ampoule times the number of ampoules)?",
+      "program": "observe amount_per_ampoule(10)\nobserve ampoule_count(4)\nobserve drug_volume(40)\nobserve diluent_volume(60)\nlet answer = amount_per_ampoule * ampoule_count\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 40,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 0.4,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 100,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 61.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.6666666666666666,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r58conc-12",
+      "qtype": "pressor_concentration",
+      "stem": "A pressor bag is mixed from 4 ampoules of 10 mg each, drawn up in 40 mL of drug solution and topped up with 60 mL of diluent. What is the the total fluid volume (drug volume plus diluent volume)?",
+      "program": "observe amount_per_ampoule(10)\nobserve ampoule_count(4)\nobserve drug_volume(40)\nobserve diluent_volume(60)\nlet answer = drug_volume + diluent_volume\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 0.4,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 100,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 40,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 61.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.6666666666666666,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r58conc-13",
+      "qtype": "pressor_concentration",
+      "stem": "A pressor bag is mixed from 8 ampoules of 5 mg each, drawn up in 20 mL of drug solution and topped up with 30 mL of diluent. What is the the bag concentration (the total drug mass over the total fluid volume)?",
+      "program": "observe amount_per_ampoule(5)\nobserve ampoule_count(8)\nobserve drug_volume(20)\nobserve diluent_volume(30)\nlet answer = (amount_per_ampoule * ampoule_count) / (drug_volume + diluent_volume)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 40,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 50,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.8,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 32.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1.3333333333333333,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r58conc-14",
+      "qtype": "pressor_concentration",
+      "stem": "A pressor bag is mixed from 8 ampoules of 5 mg each, drawn up in 20 mL of drug solution and topped up with 30 mL of diluent. What is the the total drug mass (amount per ampoule times the number of ampoules)?",
+      "program": "observe amount_per_ampoule(5)\nobserve ampoule_count(8)\nobserve drug_volume(20)\nobserve diluent_volume(30)\nlet answer = amount_per_ampoule * ampoule_count\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 0.8,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 50,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 32.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 40,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1.3333333333333333,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r58conc-15",
+      "qtype": "pressor_concentration",
+      "stem": "A pressor bag is mixed from 8 ampoules of 5 mg each, drawn up in 20 mL of drug solution and topped up with 30 mL of diluent. What is the the total fluid volume (drug volume plus diluent volume)?",
+      "program": "observe amount_per_ampoule(5)\nobserve ampoule_count(8)\nobserve drug_volume(20)\nobserve diluent_volume(30)\nlet answer = drug_volume + diluent_volume\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 0.8,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 40,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 32.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 1.3333333333333333,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 50,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r58conc-16",
+      "qtype": "pressor_concentration",
+      "stem": "A pressor bag is mixed from 5 ampoules of 6 mg each, drawn up in 30 mL of drug solution and topped up with 70 mL of diluent. What is the the bag concentration (the total drug mass over the total fluid volume)?",
+      "program": "observe amount_per_ampoule(6)\nobserve ampoule_count(5)\nobserve drug_volume(30)\nobserve diluent_volume(70)\nlet answer = (amount_per_ampoule * ampoule_count) / (drug_volume + diluent_volume)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 0.3,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 30,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 100,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 71.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.42857142857142855,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r58conc-17",
+      "qtype": "pressor_concentration",
+      "stem": "A pressor bag is mixed from 5 ampoules of 6 mg each, drawn up in 30 mL of drug solution and topped up with 70 mL of diluent. What is the the total drug mass (amount per ampoule times the number of ampoules)?",
+      "program": "observe amount_per_ampoule(6)\nobserve ampoule_count(5)\nobserve drug_volume(30)\nobserve diluent_volume(70)\nlet answer = amount_per_ampoule * ampoule_count\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 0.3,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 30,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 100,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 71.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.42857142857142855,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r58conc-18",
+      "qtype": "pressor_concentration",
+      "stem": "A pressor bag is mixed from 5 ampoules of 6 mg each, drawn up in 30 mL of drug solution and topped up with 70 mL of diluent. What is the the total fluid volume (drug volume plus diluent volume)?",
+      "program": "observe amount_per_ampoule(6)\nobserve ampoule_count(5)\nobserve drug_volume(30)\nobserve diluent_volume(70)\nlet answer = drug_volume + diluent_volume\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 0.3,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 30,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 100,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 71.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.42857142857142855,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r58conc-19",
+      "qtype": "pressor_concentration",
+      "stem": "A pressor bag is mixed from 2 ampoules of 16 mg each, drawn up in 8 mL of drug solution and topped up with 42 mL of diluent. What is the the bag concentration (the total drug mass over the total fluid volume)?",
+      "program": "observe amount_per_ampoule(16)\nobserve ampoule_count(2)\nobserve drug_volume(8)\nobserve diluent_volume(42)\nlet answer = (amount_per_ampoule * ampoule_count) / (drug_volume + diluent_volume)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 32,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 50,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 46.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.64,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.7619047619047619,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r58conc-20",
+      "qtype": "pressor_concentration",
+      "stem": "A pressor bag is mixed from 2 ampoules of 16 mg each, drawn up in 8 mL of drug solution and topped up with 42 mL of diluent. What is the the total drug mass (amount per ampoule times the number of ampoules)?",
+      "program": "observe amount_per_ampoule(16)\nobserve ampoule_count(2)\nobserve drug_volume(8)\nobserve diluent_volume(42)\nlet answer = amount_per_ampoule * ampoule_count\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 0.64,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 50,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 46.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.7619047619047619,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 32,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r58conc-21",
+      "qtype": "pressor_concentration",
+      "stem": "A pressor bag is mixed from 2 ampoules of 16 mg each, drawn up in 8 mL of drug solution and topped up with 42 mL of diluent. What is the the total fluid volume (drug volume plus diluent volume)?",
+      "program": "observe amount_per_ampoule(16)\nobserve ampoule_count(2)\nobserve drug_volume(8)\nobserve diluent_volume(42)\nlet answer = drug_volume + diluent_volume\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 50,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 0.64,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 32,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 46.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.7619047619047619,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    }
+  ]
+}

--- a/code/specs/data/adj-ladder/test_ladder_eval.py
+++ b/code/specs/data/adj-ladder/test_ladder_eval.py
@@ -95,6 +95,7 @@ SELF_CONTAINED_RUNGS = (
     "rung55_fresh_gas_volume",
     "rung56_stroke_work",
     "rung57_renal_count_rate",
+    "rung58_pressor_concentration",
 )
 
 


### PR DESCRIPTION
## ADJ-LADDER rung-58 — vasopressor bag concentration (product-over-sum `(a·b)/(c+d)`)

Adds the next self-contained rung to the ADJ-LADDER, opening the **critical-care / vasopressor-infusion** panel on the quantitative band.

### New arithmetic shape
The headline readout divides a parenthesised **product** by a parenthesised **sum**:

```
concentration = (amount_per_ampoule · ampoule_count) / (drug_volume + diluent_volume)
```

This is a genuinely NEW shape on the ladder — **product over a sum** `(a·b)/(c+d)`, the first to divide a product by a sum. Distinct from:
- rung-15 product-over-product `(a·b)/(c·d)`
- rung-37 sum-over-sum `(a+b)/(c+d)`

The total mass `(amount · count)` and total volume `(drug + diluent)` ride alongside as component readouts, so the panel teaches the whole calculation.

### Contents
- 7 tables × 3 queried readouts = **21 items**, each a `compute_dimensioned` program. The ADJ engine carries the arithmetic — no harness/engine change.
- Five-member option family over the same four quantities: three real readouts + two classic slips (**misgrouped**: `(a·b)/c + d` — dividing the mass by only the drug volume, then adding the diluent; **mass_over_diluent**: `(a·b)/d` — dividing by the diluent volume alone).
- Gold rotates A–E; family values asserted **pairwise-distinct with margin** at build. Core confusion tested: `(a·b)/(c+d) ≠ (a·b)/c + d` and `≠ (a·b)/d`.

### Contamination-safety
Every formula is built ONLY from the four observed quantities via `·`, `+`, `/` — **no numeric constants**, and neither the mass, the volume, nor any concentration figure ever appears as a literal. Observed quantities carry **digit-free identifiers** (`amount_per_ampoule`, `ampoule_count`, `drug_volume`, `diluent_volume`).

### Verification
- `gen_items.py` run from the rung subdir → `items.json` (21 items). Registered in `SELF_CONTAINED_RUNGS`. Gate `pytest -k rung58` → **3/3 passed**.
- Security review: PASSED (offline data generator, no external input, all denominators > 0, no eval/injection/path/DoS surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
