### PR TITLE
feat(cloc12.161): TaggedTemplateExpression atomic node + emit + 9 passes (PR1)

### DIFF
--- a/code/packages/rust/closure-emitter/CHANGELOG.md
+++ b/code/packages/rust/closure-emitter/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to the `coding-adventures-closure-emitter` crate will be documented in this file.
 
+## [0.25.0] - 2026-07-02
+
+### Added — CLOC12.161: emit `Expression::TaggedTemplateExpression`
+
+New `emit_tagged_template` method wired into the expression dispatch. A tagged
+template `` tag`abc${x}` `` emits the `tag` callee at `PREC_PRIMARY` (so a
+looser tag such as a sequence wraps — `` (a,b)`x` ``) followed directly by the
+template literal via the existing `emit_template_literal` (no separator seam).
+`expr_prec` classifies the node as `PREC_PRIMARY`, so a member access on a
+tagged template stays paren-free (`` a`x`.length ``). 5 new inline
+`emit_tagged_template` tests. Handles the new `javascript-ast` 0.20.0 variant.
+
+
 ## [0.24.1] - 2026-07-02
 
 ### Added — CLOC12.160 PR3: CodePrinter comma-operator conformance port

--- a/code/packages/rust/closure-emitter/Cargo.toml
+++ b/code/packages/rust/closure-emitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-emitter"
-version = "0.24.1"
+version = "0.25.0"
 edition = "2021"
 description = "JavaScript code emitter for the Closure Compiler clone. Per CLOC07's emit contract. Takes a finalized Program + sidecar and produces output JavaScript text + companion source map. Runs after every pass in the pipeline."
 

--- a/code/packages/rust/closure-emitter/src/lib.rs
+++ b/code/packages/rust/closure-emitter/src/lib.rs
@@ -78,6 +78,7 @@ use coding_adventures_javascript_ast::{
     Property, PropertyKey, PropertyKind, ReturnStatement, Statement, StringLiteral,
     SwitchCase, SwitchStatement, ThrowStatement, TryStatement, UnaryExpression, UnaryOperator, UpdateExpression, UpdateOperator,
     UndefinedLiteral, VarKind, VariableDeclaration, VariableDeclarator, WhileStatement,
+    TaggedTemplateExpression,
 };
 use coding_adventures_type_sidecar::Sidecar;
 use std::fmt;
@@ -1016,6 +1017,22 @@ impl<'a> Emitter<'a> {
         self.write_str("`");
     }
 
+    /// Emit a **tagged** template — `` tag`a${x}b` ``.
+    ///
+    /// The tag is emitted at `PREC_PRIMARY` (member/call strength): a plain
+    /// identifier or member-chain tag prints bare (`` a.b`x` ``), while any
+    /// looser tag is parenthesised (`` (a,b)`x` ``, `` (a=b)`x` `` — unusual but
+    /// handled defensively; a bare `` a,b`x` `` would tag only `b`). The
+    /// template literal follows the tag directly — the `tag`↔`` ` `` boundary
+    /// never token-fuses, so no separator is spent — reusing
+    /// [`Self::emit_template_literal`] verbatim (so the quasi's `raw` segments
+    /// and `${…}` substitutions round-trip exactly as an untagged template).
+    fn emit_tagged_template(&mut self, t: &TaggedTemplateExpression) {
+        self.maybe_map(&t.cv);
+        self.emit_expression_inner(&t.tag, PREC_PRIMARY);
+        self.emit_template_literal(&t.quasi);
+    }
+
     /// Emit one [`TemplateElement`] — its verbatim `raw` text.
     ///
     /// A template quasi is the one *primary* token whose `raw` text may legally
@@ -1118,6 +1135,7 @@ impl<'a> Emitter<'a> {
             Expression::FunctionExpression(f) => self.emit_function_expression(f),
             Expression::ArrowFunctionExpression(a) => self.emit_arrow_function_expression(a),
             Expression::TemplateLiteral(t) => self.emit_template_literal(t),
+            Expression::TaggedTemplateExpression(t) => self.emit_tagged_template(t),
         }
         if needs_parens {
             self.write_str(")");
@@ -1944,6 +1962,10 @@ fn expr_prec(e: &Expression) -> u8 {
         // (`` `x`.length ``, `` f`x` `` as a member/call base are all valid),
         // so it tags at `PREC_PRIMARY` like the array/object literals.
         Expression::TemplateLiteral(_) => PREC_PRIMARY,
+        // A tagged template `` tag`x` `` binds at member/call strength — it is
+        // left-associative like a call and can be a member/call base
+        // (`` a`x`.length ``, `` a`x`() ``), so it tags at `PREC_PRIMARY`.
+        Expression::TaggedTemplateExpression(_) => PREC_PRIMARY,
         // `true`/`false` are emitted as `!0`/`!1` (see `emit_boolean`), which
         // are UnaryExpressions — precedence `PREC_UNARY`, NOT primary. Tagging
         // them here is what makes `emit_expression_inner` parenthesise them in
@@ -4642,5 +4664,66 @@ mod tests {
             argument: Box::new(seq(vec![ident("a"), ident("b")])),
         });
         assert_eq!(emit_expr(e), "!(a,b);");
+    }
+
+    // ---- TaggedTemplateExpression (CLOC12.161) -------------------------
+
+    /// Build a raw `TemplateLiteral` struct (not wrapped in `Expression`) for
+    /// use as a tagged-template quasi.
+    fn raw_template(quasis: Vec<TemplateElement>, expressions: Vec<Expression>) -> TemplateLiteral {
+        TemplateLiteral { cv: None, quasis, expressions }
+    }
+
+    fn tagged(tag: Expression, quasi: TemplateLiteral) -> Expression {
+        Expression::TaggedTemplateExpression(TaggedTemplateExpression {
+            cv: None,
+            tag: Box::new(tag),
+            quasi,
+        })
+    }
+
+    /// `` tag`abc` `` — an identifier tag directly precedes a no-substitution
+    /// template; no separator between the tag and the backtick.
+    #[test]
+    fn tagged_identifier_no_sub() {
+        let e = tagged(ident("tag"), raw_template(vec![tquasi("abc", true)], vec![]));
+        assert_eq!(emit_expr(e), "tag`abc`;");
+    }
+
+    /// `` a.b`x` `` — a member-chain tag stays paren-free (member binds at
+    /// `PREC_PRIMARY`, same as the tagged-template node).
+    #[test]
+    fn tagged_member_tag_not_wrapped() {
+        let tag = member(ident("a"), "b", false);
+        let e = tagged(tag, raw_template(vec![tquasi("x", true)], vec![]));
+        assert_eq!(emit_expr(e), "a.b`x`;");
+    }
+
+    /// `` String.raw`a${x}b` `` — a substitution template as the quasi: the
+    /// `${…}` parts round-trip through the reused template emitter.
+    #[test]
+    fn tagged_with_substitution() {
+        let tag = member(ident("String"), "raw", false);
+        let quasi = raw_template(vec![tquasi("a", false), tquasi("b", true)], vec![ident("x")]);
+        let e = tagged(tag, quasi);
+        assert_eq!(emit_expr(e), "String.raw`a${x}b`;");
+    }
+
+    /// A member access on a tagged template needs no parens — the tagged
+    /// template is `PREC_PRIMARY`: `` a`x`.length ``.
+    #[test]
+    fn member_on_tagged_is_paren_free() {
+        let inner = tagged(ident("a"), raw_template(vec![tquasi("x", true)], vec![]));
+        let e = member(inner, "length", false);
+        assert_eq!(emit_expr(e), "a`x`.length;");
+    }
+
+    /// A looser tag is parenthesised — a sequence tag would otherwise tag only
+    /// its last operand: `` (a,b)`x` ``.
+    #[test]
+    fn sequence_tag_is_wrapped() {
+        let tag = seq(vec![ident("a"), ident("b")]);
+        let e = tagged(tag, raw_template(vec![tquasi("x", true)], vec![]));
+        assert_eq!(emit_expr(e), "(a,b)`x`;");
     }
 }

--- a/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the `coding-adventures-closure-pass-constant-fold` crate will be documented in this file.
 
+## [0.85.4] - 2026-07-02
+
+### Changed — CLOC12.161: handle `Expression::TaggedTemplateExpression`
+
+Added a `TaggedTemplateExpression` match arm recursing into the `tag` callee
+and each `${…}` insert of the applied template, so this pass keeps
+compiling and traverses the new `javascript-ast` 0.20.0 node. No behaviour
+change for any existing node.
+
 ## [0.85.3] - 2026-07-02
 
 ### Changed — CLOC12.160: handle `Expression::SequenceExpression`

--- a/code/packages/rust/closure-pass-constant-fold/Cargo.toml
+++ b/code/packages/rust/closure-pass-constant-fold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-constant-fold"
-version = "0.85.3"
+version = "0.85.4"
 edition = "2021"
 description = "Constant-folding optimization pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Folds compile-time-evaluable expressions like `2 + 3 → 5`."
 

--- a/code/packages/rust/closure-pass-constant-fold/src/lib.rs
+++ b/code/packages/rust/closure-pass-constant-fold/src/lib.rs
@@ -94,7 +94,7 @@ use coding_adventures_javascript_ast::{
     BinaryOperator, BlockStatement, BooleanLiteral, CallExpression, ConditionalExpression, NewExpression, SequenceExpression,
     Declaration, Expression, ExpressionStatement, ForInStatement, ForInit, ForOfStatement,
     ForStatement,
-    ArrowBody, ArrowFunctionExpression, TemplateLiteral,
+    ArrowBody, ArrowFunctionExpression, TaggedTemplateExpression, TemplateLiteral,
     FunctionDeclaration, FunctionExpression, Identifier,
     IfStatement, LogicalExpression, LogicalOperator, MemberExpression, NullLiteral, NumericLiteral,
     ObjectExpression, Program, ProgramItem, Property, PropertyKey, PropertyKind, ReturnStatement, Statement,
@@ -543,6 +543,24 @@ fn fold_expression(expr: &Expression, st: &mut FoldState) -> Expression {
             cv: s.cv.clone(),
             expressions: s.expressions.iter().map(|e| fold_expression(e, st)).collect(),
         }),
+        // `` tag`a${x}b` `` — fold within the tag callee and each `${…}`
+        // substitution; the raw quasi strings are opaque text, left untouched.
+        Expression::TaggedTemplateExpression(t) => {
+            Expression::TaggedTemplateExpression(TaggedTemplateExpression {
+                cv: t.cv.clone(),
+                tag: Box::new(fold_expression(&t.tag, st)),
+                quasi: TemplateLiteral {
+                    cv: t.quasi.cv.clone(),
+                    quasis: t.quasi.quasis.clone(),
+                    expressions: t
+                        .quasi
+                        .expressions
+                        .iter()
+                        .map(|e| fold_expression(e, st))
+                        .collect(),
+                },
+            })
+        }
         Expression::MemberExpression(m) => fold_member(m, st),
         Expression::ArrayExpression(a) => Expression::ArrayExpression(ArrayExpression {
             cv: a.cv.clone(),

--- a/code/packages/rust/closure-pass-dce/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-dce/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the `coding-adventures-closure-pass-dce` crate will be documented in this file.
 
+## [0.20.4] - 2026-07-02
+
+### Changed — CLOC12.161: handle `Expression::TaggedTemplateExpression`
+
+Added a `TaggedTemplateExpression` match arm recursing into the `tag` callee
+and each `${…}` insert of the applied template, so this pass keeps
+compiling and traverses the new `javascript-ast` 0.20.0 node. No behaviour
+change for any existing node.
+
 ## [0.20.3] - 2026-07-02
 
 ### Changed — CLOC12.160: handle `Expression::SequenceExpression`

--- a/code/packages/rust/closure-pass-dce/Cargo.toml
+++ b/code/packages/rust/closure-pass-dce/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-dce"
-version = "0.20.3"
+version = "0.20.4"
 edition = "2021"
 description = "Dead-code elimination pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Drops code after definite-terminator statements and removes EmptyStatement noise."
 

--- a/code/packages/rust/closure-pass-dce/src/lib.rs
+++ b/code/packages/rust/closure-pass-dce/src/lib.rs
@@ -75,7 +75,7 @@ use coding_adventures_javascript_ast::{
     Declaration, EmptyStatement, Expression, ExpressionStatement, ForInStatement, ForInit,
     ForOfStatement,
     ForStatement,
-    ArrowBody, ArrowFunctionExpression, TemplateLiteral,
+    ArrowBody, ArrowFunctionExpression, TaggedTemplateExpression, TemplateLiteral,
     FunctionDeclaration, FunctionExpression, IfStatement, LogicalExpression, MemberExpression, NullLiteral,
     NumericLiteral, ObjectExpression, Program, ProgramItem, Property, PropertyKey,
     ReturnStatement, Statement, StringLiteral, UnaryExpression, UndefinedLiteral, UpdateExpression, VarKind,
@@ -1226,6 +1226,24 @@ fn dce_expression(expr: &Expression, st: &mut DceState) -> Expression {
             cv: s.cv.clone(),
             expressions: s.expressions.iter().map(|e| dce_expression(e, st)).collect(),
         }),
+        // `` tag`a${x}b` `` — a tagged template is kept (the tag call may have
+        // side effects); recurse into the tag and each `${…}` substitution.
+        Expression::TaggedTemplateExpression(t) => {
+            Expression::TaggedTemplateExpression(TaggedTemplateExpression {
+                cv: t.cv.clone(),
+                tag: Box::new(dce_expression(&t.tag, st)),
+                quasi: TemplateLiteral {
+                    cv: t.quasi.cv.clone(),
+                    quasis: t.quasi.quasis.clone(),
+                    expressions: t
+                        .quasi
+                        .expressions
+                        .iter()
+                        .map(|e| dce_expression(e, st))
+                        .collect(),
+                },
+            })
+        }
         Expression::MemberExpression(m) => Expression::MemberExpression(MemberExpression {
             cv: m.cv.clone(),
             object: Box::new(dce_expression(&m.object, st)),

--- a/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the `coding-adventures-closure-pass-fold-control-flow` crate will be documented in this file.
 
+## [0.20.4] - 2026-07-02
+
+### Changed — CLOC12.161: handle `Expression::TaggedTemplateExpression`
+
+Added a `TaggedTemplateExpression` match arm recursing into the `tag` callee
+and each `${…}` insert of the applied template, so this pass keeps
+compiling and traverses the new `javascript-ast` 0.20.0 node. No behaviour
+change for any existing node.
+
 ## [0.20.3] - 2026-07-02
 
 ### Changed — CLOC12.160: handle `Expression::SequenceExpression`

--- a/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
+++ b/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-fold-control-flow"
-version = "0.20.3"
+version = "0.20.4"
 edition = "2021"
 description = "Control-flow folding pass for the Closure Compiler clone. Slots between constant-fold and DCE per CLOC06's canonical pass set. Eliminates dead branches (`if (false) A else B → B`), removes unreachable code after `return`/`throw`, and collapses degenerate switch arms."
 

--- a/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
+++ b/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
@@ -58,7 +58,7 @@ use coding_adventures_javascript_ast::{
     statement::TaggedStatement, ArrayExpression, AssignmentExpression, AssignmentOperator,
     AssignmentTarget, BinaryExpression, BindingTarget, BlockStatement, CallExpression, NewExpression, SequenceExpression,
     ConditionalExpression, Declaration, EmptyStatement, Expression, ExpressionStatement, ForInit,
-    ArrowBody, ArrowFunctionExpression, TemplateLiteral,
+    ArrowBody, ArrowFunctionExpression, TaggedTemplateExpression, TemplateLiteral,
     ForInStatement, ForOfStatement, ForStatement, FunctionDeclaration, FunctionExpression, Identifier, IfStatement,
     LogicalExpression,
     LogicalOperator,
@@ -275,6 +275,7 @@ fn expression_cv(expr: &Expression) -> Option<String> {
         CallExpression(e) => e.cv.clone(),
         NewExpression(e) => e.cv.clone(),
         SequenceExpression(e) => e.cv.clone(),
+        TaggedTemplateExpression(e) => e.cv.clone(),
         MemberExpression(e) => e.cv.clone(),
         ArrayExpression(e) => e.cv.clone(),
         ObjectExpression(e) => e.cv.clone(),
@@ -1405,6 +1406,24 @@ fn fold_expression(expr: &Expression, st: &mut FoldState) -> Expression {
             cv: s.cv.clone(),
             expressions: s.expressions.iter().map(|e| fold_expression(e, st)).collect(),
         }),
+        // `` tag`a${x}b` `` — recurse into the tag callee and each `${…}`
+        // substitution; the raw quasi strings are opaque and untouched.
+        Expression::TaggedTemplateExpression(t) => {
+            Expression::TaggedTemplateExpression(TaggedTemplateExpression {
+                cv: t.cv.clone(),
+                tag: Box::new(fold_expression(&t.tag, st)),
+                quasi: TemplateLiteral {
+                    cv: t.quasi.cv.clone(),
+                    quasis: t.quasi.quasis.clone(),
+                    expressions: t
+                        .quasi
+                        .expressions
+                        .iter()
+                        .map(|e| fold_expression(e, st))
+                        .collect(),
+                },
+            })
+        }
         Expression::MemberExpression(m) => Expression::MemberExpression(MemberExpression {
             cv: m.cv.clone(),
             object: Box::new(fold_expression(&m.object, st)),

--- a/code/packages/rust/closure-pass-inline-variables/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-inline-variables/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the `coding-adventures-closure-pass-inline-variables` crate will be documented in this file.
 
+## [0.11.4] - 2026-07-02
+
+### Changed — CLOC12.161: handle `Expression::TaggedTemplateExpression`
+
+Added a `TaggedTemplateExpression` match arm recursing into the `tag` callee
+and each `${…}` insert of the applied template, so this pass keeps
+compiling and traverses the new `javascript-ast` 0.20.0 node. No behaviour
+change for any existing node.
+
 ## [0.11.3] - 2026-07-02
 
 ### Changed — CLOC12.160: handle `Expression::SequenceExpression`

--- a/code/packages/rust/closure-pass-inline-variables/Cargo.toml
+++ b/code/packages/rust/closure-pass-inline-variables/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-inline-variables"
-version = "0.11.3"
+version = "0.11.4"
 edition = "2021"
 description = "Constant-propagation pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Replaces references to a top-level `const` bound to a literal with the literal itself, so the binding becomes unused and remove-unused-vars deletes it."
 

--- a/code/packages/rust/closure-pass-inline-variables/src/lib.rs
+++ b/code/packages/rust/closure-pass-inline-variables/src/lib.rs
@@ -818,6 +818,13 @@ fn count_uses_expr(expr: &Expression, name: &str, count: &mut usize) {
                 count_uses_expr(e, name, count);
             }
         }
+        // Count uses of `name` in the tag callee and each `${…}` insert.
+        Expression::TaggedTemplateExpression(t) => {
+            count_uses_expr(&t.tag, name, count);
+            for e in &t.quasi.expressions {
+                count_uses_expr(e, name, count);
+            }
+        }
     }
 }
 
@@ -1102,6 +1109,13 @@ fn propagate_in_expr(expr: &mut Expression, cand: &ConstCandidate) -> bool {
         // hold no substitutable reference.
         Expression::TemplateLiteral(t) => {
             for e in &mut t.expressions {
+                changed |= propagate_in_expr(e, cand);
+            }
+        }
+        // Propagate into the tag callee and each `${…}` insert.
+        Expression::TaggedTemplateExpression(t) => {
+            changed |= propagate_in_expr(&mut t.tag, cand);
+            for e in &mut t.quasi.expressions {
                 changed |= propagate_in_expr(e, cand);
             }
         }

--- a/code/packages/rust/closure-pass-inline/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-inline/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the `coding-adventures-closure-pass-inline` crate will be documented in this file.
 
+## [0.25.4] - 2026-07-02
+
+### Changed — CLOC12.161: handle `Expression::TaggedTemplateExpression`
+
+Added a `TaggedTemplateExpression` match arm recursing into the `tag` callee
+and each `${…}` insert of the applied template, so this pass keeps
+compiling and traverses the new `javascript-ast` 0.20.0 node. No behaviour
+change for any existing node.
+
 ## [0.25.3] - 2026-07-02
 
 ### Changed — CLOC12.160: handle `Expression::SequenceExpression`

--- a/code/packages/rust/closure-pass-inline/Cargo.toml
+++ b/code/packages/rust/closure-pass-inline/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-inline"
-version = "0.25.3"
+version = "0.25.4"
 edition = "2021"
 description = "Function-inlining pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Substitutes small or single-use function bodies at their call sites to enable downstream folding and shrink call overhead."
 

--- a/code/packages/rust/closure-pass-inline/src/lib.rs
+++ b/code/packages/rust/closure-pass-inline/src/lib.rs
@@ -499,6 +499,13 @@ fn expr_node_count(expr: &Expression) -> usize {
         Expression::TemplateLiteral(t) => {
             t.quasis.len() + t.expressions.iter().map(expr_node_count).sum::<usize>()
         }
+        // A tagged template weighs its tag callee plus the template it applies
+        // (quasis + each `${…}` insert expression).
+        Expression::TaggedTemplateExpression(t) => {
+            expr_node_count(&t.tag)
+                + t.quasi.quasis.len()
+                + t.quasi.expressions.iter().map(expr_node_count).sum::<usize>()
+        }
     }
 }
 
@@ -828,6 +835,9 @@ fn collect_binding_idents_expr(expr: &Expression, out: &mut HashSet<String>) {
         // leaf strings. Mirror the arrow arm's non-recursion into sub-bodies
         // (it only records params, and a template has none) — nothing to do.
         Expression::TemplateLiteral(_) => {}
+        // A tagged template introduces no boundary bindings either (the tag is
+        // a callee, the quasi a template) — mirror the template arm.
+        Expression::TaggedTemplateExpression(_) => {}
     }
 }
 
@@ -1115,6 +1125,14 @@ fn tally_expr(expr: &Expression, cand: &InlineCandidate, t: &mut Tally) {
         // Quasis are leaf strings — only the insert expressions recurse.
         Expression::TemplateLiteral(t2) => {
             for e in &t2.expressions {
+                tally_expr(e, cand, t);
+            }
+        }
+        // A use of the candidate can hide in the tag callee or inside a `${…}`
+        // insert of the applied template.
+        Expression::TaggedTemplateExpression(t2) => {
+            tally_expr(&t2.tag, cand, t);
+            for e in &t2.quasi.expressions {
                 tally_expr(e, cand, t);
             }
         }
@@ -1415,6 +1433,13 @@ fn inline_in_expr(expr: &mut Expression, cand: &InlineCandidate) -> bool {
                 changed |= inline_in_expr(e, cand);
             }
         }
+        // Inline candidate calls in the tag callee and each `${…}` insert.
+        Expression::TaggedTemplateExpression(t) => {
+            changed |= inline_in_expr(&mut t.tag, cand);
+            for e in &mut t.quasi.expressions {
+                changed |= inline_in_expr(e, cand);
+            }
+        }
     }
     changed
 }
@@ -1559,6 +1584,14 @@ fn substitute(expr: &mut Expression, map: &HashMap<String, Expression>) {
         // strings and never contain a substitutable identifier.
         Expression::TemplateLiteral(t) => {
             for e in &mut t.expressions {
+                substitute(e, map);
+            }
+        }
+        // A tagged template binds nothing — substitute through the tag callee
+        // and each `${…}` insert of the applied template.
+        Expression::TaggedTemplateExpression(t) => {
+            substitute(&mut t.tag, map);
+            for e in &mut t.quasi.expressions {
                 substitute(e, map);
             }
         }
@@ -1931,6 +1964,13 @@ fn expr_collect_mutated_params(
         // Quasis are leaf strings and never mutate anything.
         Expression::TemplateLiteral(t) => {
             for e in &t.expressions {
+                expr_collect_mutated_params(e, params, out);
+            }
+        }
+        // The tag callee or a `${…}` insert can mutate an outer param.
+        Expression::TaggedTemplateExpression(t) => {
+            expr_collect_mutated_params(&t.tag, params, out);
+            for e in &t.quasi.expressions {
                 expr_collect_mutated_params(e, params, out);
             }
         }
@@ -3393,6 +3433,14 @@ fn rename_in_expr(expr: &mut Expression, map: &HashMap<String, String>) {
         // strings and contain no identifier uses.
         Expression::TemplateLiteral(t) => {
             for e in &mut t.expressions {
+                rename_in_expr(e, map);
+            }
+        }
+        // A tagged template binds nothing — alpha-rename through the tag callee
+        // and each `${…}` insert of the applied template.
+        Expression::TaggedTemplateExpression(t) => {
+            rename_in_expr(&mut t.tag, map);
+            for e in &mut t.quasi.expressions {
                 rename_in_expr(e, map);
             }
         }

--- a/code/packages/rust/closure-pass-rename-globals/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename-globals/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename-globals` crate will be documented in this file.
 
+## [0.10.4] - 2026-07-02
+
+### Changed — CLOC12.161: handle `Expression::TaggedTemplateExpression`
+
+Added a `TaggedTemplateExpression` match arm recursing into the `tag` callee
+and each `${…}` insert of the applied template, so this pass keeps
+compiling and traverses the new `javascript-ast` 0.20.0 node. No behaviour
+change for any existing node.
+
 ## [0.10.3] - 2026-07-02
 
 ### Changed — CLOC12.160: handle `Expression::SequenceExpression`

--- a/code/packages/rust/closure-pass-rename-globals/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename-globals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename-globals"
-version = "0.10.3"
+version = "0.10.4"
 edition = "2021"
 description = "Aggressive top-level (global) renaming pass for the Closure Compiler clone — the ADVANCED-level complement to closure-pass-rename. Shortens program-private top-level names, gated by an externs do-not-rename boundary."
 

--- a/code/packages/rust/closure-pass-rename-globals/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename-globals/src/lib.rs
@@ -737,6 +737,14 @@ fn collect_all_idents_expr(expr: &Expression, out: &mut HashSet<String>) {
                 collect_all_idents_expr(e, out);
             }
         }
+        // A tagged template carries identifiers in its tag callee and each
+        // `${…}` insert. Quasis are leaf strings with nothing to record.
+        Expression::TaggedTemplateExpression(t) => {
+            collect_all_idents_expr(&t.tag, out);
+            for e in &t.quasi.expressions {
+                collect_all_idents_expr(e, out);
+            }
+        }
     }
 }
 
@@ -1057,6 +1065,13 @@ fn rename_apply_expr(expr: &mut Expression, map: &HashMap<String, String>) {
         // leaf strings and hold no renamable use.
         Expression::TemplateLiteral(t) => {
             for e in &mut t.expressions {
+                rename_apply_expr(e, map);
+            }
+        }
+        // Rename globals in the tag callee and each `${…}` insert.
+        Expression::TaggedTemplateExpression(t) => {
+            rename_apply_expr(&mut t.tag, map);
+            for e in &mut t.quasi.expressions {
                 rename_apply_expr(e, map);
             }
         }

--- a/code/packages/rust/closure-pass-rename-properties/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename-properties/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename-properties` crate will be documented in this file.
 
+## [0.12.4] - 2026-07-02
+
+### Changed — CLOC12.161: handle `Expression::TaggedTemplateExpression`
+
+Added a `TaggedTemplateExpression` match arm recursing into the `tag` callee
+and each `${…}` insert of the applied template, so this pass keeps
+compiling and traverses the new `javascript-ast` 0.20.0 node. No behaviour
+change for any existing node.
+
 ## [0.12.3] - 2026-07-02
 
 ### Changed — CLOC12.160: handle `Expression::SequenceExpression`

--- a/code/packages/rust/closure-pass-rename-properties/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename-properties/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename-properties"
-version = "0.12.3"
+version = "0.12.4"
 edition = "2021"
 description = "Aggressive property renaming pass for the Closure Compiler clone (ADVANCED-only). Consistently shortens program-private object property names that are never quoted/computed and not in the built-in or externs do-not-rename boundary."
 

--- a/code/packages/rust/closure-pass-rename-properties/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename-properties/src/lib.rs
@@ -1246,6 +1246,14 @@ fn classify_expr(expr: &Expression, cls: &mut Classify) {
                 classify_expr(e, cls);
             }
         }
+        // A member access touching the property namespace can hide in the tag
+        // callee or a `${…}` insert. Quasis are leaf strings — nothing to walk.
+        Expression::TaggedTemplateExpression(t) => {
+            classify_expr(&t.tag, cls);
+            for e in &t.quasi.expressions {
+                classify_expr(e, cls);
+            }
+        }
     }
 }
 
@@ -1500,6 +1508,14 @@ fn rewrite_expr(expr: &mut Expression, map: &HashMap<String, String>) {
         // classifying them above. Quasis are leaf strings — nothing to walk.
         Expression::TemplateLiteral(t) => {
             for e in &mut t.expressions {
+                rewrite_expr(e, map);
+            }
+        }
+        // Rewrite property accesses in the tag callee and each `${…}` insert,
+        // the mirror of classifying them above.
+        Expression::TaggedTemplateExpression(t) => {
+            rewrite_expr(&mut t.tag, map);
+            for e in &mut t.quasi.expressions {
                 rewrite_expr(e, map);
             }
         }

--- a/code/packages/rust/closure-pass-rename/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename` crate will be documented in this file.
 
+## [0.14.4] - 2026-07-02
+
+### Changed — CLOC12.161: handle `Expression::TaggedTemplateExpression`
+
+Added a `TaggedTemplateExpression` match arm recursing into the `tag` callee
+and each `${…}` insert of the applied template, so this pass keeps
+compiling and traverses the new `javascript-ast` 0.20.0 node. No behaviour
+change for any existing node.
+
 ## [0.14.3] - 2026-07-02
 
 ### Changed — CLOC12.160: handle `Expression::SequenceExpression`

--- a/code/packages/rust/closure-pass-rename/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename"
-version = "0.14.3"
+version = "0.14.4"
 edition = "2021"
 description = "Variable renaming pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Replaces non-exported binding names with shorter identifiers to reduce output size while preserving externally-visible names and semantics."
 

--- a/code/packages/rust/closure-pass-rename/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename/src/lib.rs
@@ -1018,6 +1018,14 @@ fn collect_all_idents_expr(expr: &Expression, out: &mut HashSet<String>) {
                 collect_all_idents_expr(e, out);
             }
         }
+        // A tagged template carries identifiers in its tag callee and each
+        // `${…}` insert. Quasis are leaf strings with nothing to record.
+        Expression::TaggedTemplateExpression(t) => {
+            collect_all_idents_expr(&t.tag, out);
+            for e in &t.quasi.expressions {
+                collect_all_idents_expr(e, out);
+            }
+        }
     }
 }
 
@@ -1319,6 +1327,13 @@ fn rewrite_uses_expr(expr: &mut Expression, map: &HashMap<String, String>) {
         // strings and hold no renamable use.
         Expression::TemplateLiteral(t) => {
             for e in &mut t.expressions {
+                rewrite_uses_expr(e, map);
+            }
+        }
+        // Rewrite renamed uses in the tag callee and each `${…}` insert.
+        Expression::TaggedTemplateExpression(t) => {
+            rewrite_uses_expr(&mut t.tag, map);
+            for e in &mut t.quasi.expressions {
                 rewrite_uses_expr(e, map);
             }
         }

--- a/code/packages/rust/closure-scope-analyzer/CHANGELOG.md
+++ b/code/packages/rust/closure-scope-analyzer/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the `coding-adventures-closure-scope-analyzer` crate will be documented in this file.
 
+## [0.12.4] - 2026-07-02
+
+### Changed — CLOC12.161: handle `Expression::TaggedTemplateExpression`
+
+Added a `TaggedTemplateExpression` match arm recursing into the `tag` callee
+and each `${…}` insert of the applied template, so this pass keeps
+compiling and traverses the new `javascript-ast` 0.20.0 node. No behaviour
+change for any existing node.
+
 ## [0.12.3] - 2026-07-02
 
 ### Changed — CLOC12.160: handle `Expression::SequenceExpression`

--- a/code/packages/rust/closure-scope-analyzer/Cargo.toml
+++ b/code/packages/rust/closure-scope-analyzer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-scope-analyzer"
-version = "0.12.3"
+version = "0.12.4"
 edition = "2021"
 description = "Lexical scope + symbol-table analyzer for the Closure Compiler clone. Per CLOC13 — produces a `ScopeAnalysis` consumed by the rename, inline, treeshake, collapse-properties, and remove-unused-vars passes."
 

--- a/code/packages/rust/closure-scope-analyzer/src/lib.rs
+++ b/code/packages/rust/closure-scope-analyzer/src/lib.rs
@@ -933,6 +933,14 @@ fn walk_expression(
                 walk_expression(e, ctx, analysis, pending);
             }
         }
+        // A tagged template resolves references in its tag callee and in each
+        // `${…}` insert. Quasis are leaf strings with nothing to resolve.
+        Expression::TaggedTemplateExpression(t) => {
+            walk_expression(&t.tag, ctx, analysis, pending);
+            for e in &t.quasi.expressions {
+                walk_expression(e, ctx, analysis, pending);
+            }
+        }
     }
 }
 

--- a/code/packages/rust/javascript-ast/CHANGELOG.md
+++ b/code/packages/rust/javascript-ast/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to the `coding-adventures-javascript-ast` crate will be documented in this file.
 
+## [0.20.0] - 2026-07-02
+
+### Added — CLOC12.161: `Expression::TaggedTemplateExpression` (`` tag`...` ``)
+
+New `TaggedTemplateExpression { cv, tag: Box<Expression>, quasi: TemplateLiteral }`
+variant of `Expression` for a tagged template `` tag`abc${x}` `` — the `tag`
+callee is applied to the template literal that directly follows it (no call
+parentheses). The `quasi` field reuses the existing `TemplateLiteral` node
+(CLOC12.154), so no new template shape is introduced. Re-exported from the
+crate root. Atomic node PR (PR1) — the node + `closure-emitter` emit +
+match-arms in all nine downstream passes land in one commit so the workspace
+never breaks. The bridge conversion (PR2) and the CodePrinter conformance
+port (PR3) follow.
+
+
 ## [0.19.0] - 2026-07-02
 
 ### Added — CLOC12.160: `Expression::SequenceExpression` (the comma operator)

--- a/code/packages/rust/javascript-ast/Cargo.toml
+++ b/code/packages/rust/javascript-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-javascript-ast"
-version = "0.19.0"
+version = "0.20.0"
 edition = "2021"
 description = "Backend-agnostic JavaScript AST — full ESTree-compatible node taxonomy with optional per-node CV id. Reusable by the Closure-Compiler-clone and the future V8-in-Rust clone. Per CLOC02 / CLOC09."
 

--- a/code/packages/rust/javascript-ast/README.md
+++ b/code/packages/rust/javascript-ast/README.md
@@ -52,7 +52,7 @@ emitter grow a need for them — each behind its own `CLOC12.NN` slice:
   `quasis.len() == expressions.len() + 1`. `TemplateElement` keeps `raw` /
   `cooked` / `tail`. Node + `closure-emitter` + all pass traversals land in one
   atomic PR; the bridge-enable + conformance port follow. (Tagged templates
-  `` tag`…` `` remain Phase 3.)
+  `` tag`…` `` are the separate `TaggedTemplateExpression` node, CLOC12.161.)
 - `UpdateExpression` (CLOC12.158) — the `++` / `--` read-modify-write forms
   (`++x`, `x++`, `--x`, `x--`). `UpdateExpression { operator: UpdateOperator,
   prefix: bool, argument: Box<Expression> }`. Distinct from `UnaryExpression`
@@ -76,6 +76,14 @@ emitter grow a need for them — each behind its own `CLOC12.NN` slice:
   (`a,b,c;`) and a computed-member key (`obj[a,b]`). Node + `closure-emitter` +
   all pass traversals land in one atomic PR; the bridge-enable + conformance
   port follow (gap-161).
+- `TaggedTemplateExpression` (CLOC12.161) — a tagged template `` tag`abc${x}` ``:
+  the `tag` callee is applied to the template that directly follows it (no call
+  parentheses). `TaggedTemplateExpression { tag: Box<Expression>, quasi:
+  TemplateLiteral }` — the `quasi` reuses the existing `TemplateLiteral` node
+  (CLOC12.154). It is primary (`PREC_PRIMARY`), so a member access on it is
+  paren-free (`` a`x`.length ``) while a looser tag wraps (`` (a,b)`x` ``). Node
+  + `closure-emitter` + all pass traversals land in one atomic PR; the
+  bridge-enable + conformance port follow (gap-162).
 
 ## What's coming (follow-up PRs)
 

--- a/code/packages/rust/javascript-ast/src/expression.rs
+++ b/code/packages/rust/javascript-ast/src/expression.rs
@@ -60,6 +60,7 @@ pub enum Expression {
     UpdateExpression(UpdateExpression),
     NewExpression(NewExpression),
     SequenceExpression(SequenceExpression),
+    TaggedTemplateExpression(TaggedTemplateExpression),
 }
 
 // ---------------------------------------------------------------------
@@ -742,6 +743,40 @@ pub struct TemplateElement {
     pub cooked: Option<String>,
     /// `true` for the final segment (before the closing backtick).
     pub tail: bool,
+}
+
+/// `` tag`a${x}b` `` — a **tagged** template. The `tag` expression is called
+/// with the template's cooked/raw string parts and its `${…}` substitution
+/// values, rather than the template producing a plain string. Common tags:
+/// `String.raw`, `gql`, `css`, `html`.
+///
+/// # Structure
+///
+/// ```text
+///   String.raw`a${x}b`
+///   └── tag ──┘└─ quasi ─┘
+/// ```
+///
+/// `tag` is any expression that evaluates to a function (typically an
+/// identifier or a member access — `String.raw`, `styled.div`). `quasi` is the
+/// [`TemplateLiteral`] being tagged (same node as an untagged template; the
+/// `raw` segments are the ones handed to the tag, and a segment may have
+/// `cooked = None` for an escape that is illegal in an untagged template but
+/// legal here).
+///
+/// # Precedence and the seam
+///
+/// A tagged template binds at member/call strength (`PREC_PRIMARY`): the
+/// backtick follows the tag directly with no separator (`` a.b`x` ``), and a
+/// looser tag is parenthesised (`` (a,b)`x` `` — though such a tag is unusual).
+/// The `tag`↔`` ` `` boundary never fuses, so no seam space is needed.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TaggedTemplateExpression {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub cv: Option<CvId>,
+    pub tag: Box<Expression>,
+    pub quasi: TemplateLiteral,
 }
 
 #[cfg(test)]

--- a/code/packages/rust/javascript-ast/src/lib.rs
+++ b/code/packages/rust/javascript-ast/src/lib.rs
@@ -140,7 +140,7 @@ pub use expression::{
     NewExpression,
     NullLiteral, NumericLiteral, ObjectExpression, Property, PropertyKey, PropertyKind,
     SequenceExpression,
-    StringLiteral, TemplateElement, TemplateLiteral, UnaryExpression, UnaryOperator,
+    StringLiteral, TaggedTemplateExpression, TemplateElement, TemplateLiteral, UnaryExpression, UnaryOperator,
     UndefinedLiteral, UpdateExpression, UpdateOperator,
 };
 pub use statement::{

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -1825,3 +1825,50 @@ round-trips the sequence parenthesised while `1 + 2` folds to `3`.
 
 The **PR3 emit conformance port** — the remaining follow-up — ports upstream
 CodePrinter's comma-operator cases into `closure-emitter/tests/upstream/`.
+
+## CLOC12.161 — `TaggedTemplateExpression` (`` tag`...` ``): atomic node + emit + passes (PR1)
+
+Adds `Expression::TaggedTemplateExpression { cv, tag, quasi }` to `javascript-ast`
+(0.20.0) — a **tagged template**: the `tag` callee is applied to the template
+literal that directly follows it, `` tag`abc${x}` ``, with **no call
+parentheses**. The `quasi` field is a `TemplateLiteral` (the CLOC12.154 node),
+so no new template shape is introduced — a tagged template is "an expression
+applied to a template", nothing more at the AST level. (The runtime semantics —
+the tag receives the cooked/raw strings array plus the substitution values — are
+a call-site concern the minifier never evaluates; structurally it is just the
+two children.)
+
+`closure-emitter` (0.25.0) `emit_tagged_template` prints the `tag` at
+`PREC_PRIMARY` immediately followed by `emit_template_literal(&quasi)` — the
+backtick abuts the tag with no separator seam (`` String.raw`x` ``). The node is
+itself `PREC_PRIMARY` in `expr_prec`, so a member access on a tagged template is
+paren-free (`` a`x`.length ``); a **looser** tag is wrapped by the existing
+`PREC_PRIMARY` object-position rule (a sequence tag becomes `` (a,b)`x` `` so it
+does not tag only its last operand). No new emit-site precedence surgery was
+needed — the `PREC_PRIMARY` classification and the tag callee emitting at
+`PREC_PRIMARY` reuse the machinery the member/call nodes already established.
+
+All nine downstream pass/analysis crates get a `TaggedTemplateExpression` match
+arm recursing into the `tag` callee **and** each `${…}` insert of `quasi`
+(the transforms rebuild the node; `fold-control-flow`'s exhaustive
+`expression_cv` accessor gains its arm) — all in one atomic commit so the
+workspace never has a broken exhaustive `match`.
+
+5 new emitter unit tests (identifier-tag no-substitution, member-chain tag,
+`String.raw` tag with a `${}` substitution, member access on a tagged template,
+sequence tag wrapped). No behaviour change for existing inputs — the bridge
+still declines the tagged-template form (gap-162), so closurec falls back to
+WHITESPACE_ONLY on `` tag`...` `` for now. PR2 (bridge-enable) and PR3
+(conformance port) follow.
+
+### gap-162 — bridge declines tagged templates (`TaggedTemplateExpression`) — **OPEN**
+
+The `javascript-parser` bridge does not yet convert the grammar's
+`tagged_template_expression` (a `member_expression`/`call_expression`-position
+production of the form `<tag> <template_literal>`) into the new
+`Expression::TaggedTemplateExpression` node; it declines to `UnsupportedSyntax`,
+dropping the whole file to WHITESPACE_ONLY. The atomic node PR (CLOC12.161 PR1)
+lands the node + emit + pass traversals; the **PR2 bridge-enable** — the fix for
+this gap — will build the node from the grammar's tag + template-literal
+children (the template child reusing the existing `template_literal` conversion
+from CLOC12.155), gated by a closurec e2e diff fixture.


### PR DESCRIPTION
## CLOC12.161 PR1 — `TaggedTemplateExpression` atomic node

First PR of the CLOC12.161 arc. Adds the tagged-template AST node, its emitter, and the match-arms in all nine downstream passes in **one atomic commit** so no exhaustive `match` ever breaks the workspace.

### What lands
- **javascript-ast 0.20.0** — new `Expression::TaggedTemplateExpression { cv, tag: Box<Expression>, quasi: TemplateLiteral }` for a tagged template `` tag`abc${x}` `` (the `tag` callee applied to the template that directly follows it, no call parens). `quasi` reuses the existing `TemplateLiteral` node (CLOC12.154) — no new template shape. Re-exported from the crate root.
- **closure-emitter 0.25.0** — `emit_tagged_template`: emits the `tag` at `PREC_PRIMARY` then the template via the existing `emit_template_literal` (backtick abuts the tag, no separator seam). `expr_prec` classifies the node as `PREC_PRIMARY`, so:
  - member access on a tagged template is paren-free: `` a`x`.length ``
  - a looser tag wraps: `` (a,b)`x` ``
  - No new emit-site precedence surgery needed.
  - **5 new inline emitter tests** (identifier-tag no-sub, member-chain tag, `String.raw` tag with `${}` substitution, member-on-tagged, sequence-tag-wrapped).
- **9 downstream passes** (constant-fold, dce, fold-control-flow, inline, inline-variables, rename, rename-globals, rename-properties, scope-analyzer) — each gains a `TaggedTemplateExpression` arm recursing into the `tag` callee and each `${…}` insert of `quasi`; fold-control-flow's exhaustive `expression_cv` accessor gets its arm too. Bumped PATCH.

### Not in this PR
The parser bridge still declines the tagged-template form (**new gap-162**), so closurec falls back to WHITESPACE_ONLY on `` tag`...` `` for now. **PR2** (bridge-enable, closes gap-162) and **PR3** (CodePrinter conformance port) follow.

### Verification
- All 11 affected crates build clean (`cargo build -p …` per crate; workspace build unaffected).
- Full test suites green, including the 5 new emitter tests.
- CHANGELOGs, javascript-ast README variant note, and `code/specs/CLOC12-gaps.md` (CLOC12.161 section + gap-162) updated.
- Inline security review passed (round 1, no findings — mechanical AST-traversal PR, node not yet parser-reachable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)