### PR TITLE
[codex] Lock list-item audit cross-axis evidence

### DIFF
--- a/code/packages/rust/html-parser/tests/whatwg_list_item_audit_test.rs
+++ b/code/packages/rust/html-parser/tests/whatwg_list_item_audit_test.rs
@@ -5,7 +5,176 @@ use serde::Deserialize;
 use std::collections::{BTreeMap, HashMap};
 
 const TREE_CONSTRUCTION_SMOKE: &str = include_str!("fixtures/html5lib-tree-construction-smoke.dat");
+const WHATWG_BLOCK_BOUNDARY_AUDIT: &str = include_str!("fixtures/whatwg-block-boundary-audit.json");
+const WHATWG_DOCUMENT_SHELL_AUDIT: &str = include_str!("fixtures/whatwg-document-shell-audit.json");
+const WHATWG_FORM_INTERACTIVE_AUDIT: &str =
+    include_str!("fixtures/whatwg-form-interactive-audit.json");
+const WHATWG_FORMATTING_AUDIT: &str = include_str!("fixtures/whatwg-formatting-audit.json");
+const WHATWG_FRAMESET_AUDIT: &str = include_str!("fixtures/whatwg-frameset-audit.json");
+const WHATWG_HEAD_BODY_AUDIT: &str = include_str!("fixtures/whatwg-head-body-audit.json");
+const WHATWG_LEGACY_ELEMENT_AUDIT: &str = include_str!("fixtures/whatwg-legacy-element-audit.json");
 const WHATWG_LIST_ITEM_AUDIT: &str = include_str!("fixtures/whatwg-list-item-audit.json");
+const WHATWG_PARAGRAPH_AUDIT: &str = include_str!("fixtures/whatwg-paragraph-audit.json");
+const WHATWG_SELECT_LIST_AUDIT: &str = include_str!("fixtures/whatwg-select-list-audit.json");
+const WHATWG_TABLE_AUDIT: &str = include_str!("fixtures/whatwg-table-audit.json");
+const WHATWG_VOID_ELEMENT_AUDIT: &str = include_str!("fixtures/whatwg-void-element-audit.json");
+
+struct ListItemCrossAxisCase {
+    id: &'static str,
+    list_axis: &'static str,
+    data_snippet: &'static str,
+    suites: &'static [(&'static str, &'static str, &'static str)],
+}
+
+const LIST_PARAGRAPH_CROSS_AXIS_SUITES: &[(&str, &str, &str)] = &[
+    (
+        "block-boundary",
+        WHATWG_BLOCK_BOUNDARY_AUDIT,
+        "block-list-container-boundary",
+    ),
+    (
+        "document-shell",
+        WHATWG_DOCUMENT_SHELL_AUDIT,
+        "html-element-boundary",
+    ),
+    (
+        "formatting",
+        WHATWG_FORMATTING_AUDIT,
+        "list-definition-boundary",
+    ),
+    ("head-body", WHATWG_HEAD_BODY_AUDIT, "body-boundary"),
+    (
+        "paragraph",
+        WHATWG_PARAGRAPH_AUDIT,
+        "paragraph-block-boundary",
+    ),
+];
+const NESTED_LIST_CROSS_AXIS_SUITES: &[(&str, &str, &str)] = &[
+    (
+        "block-boundary",
+        WHATWG_BLOCK_BOUNDARY_AUDIT,
+        "block-list-container-boundary",
+    ),
+    (
+        "document-shell",
+        WHATWG_DOCUMENT_SHELL_AUDIT,
+        "body-frameset-boundary",
+    ),
+    (
+        "formatting",
+        WHATWG_FORMATTING_AUDIT,
+        "list-definition-boundary",
+    ),
+    ("head-body", WHATWG_HEAD_BODY_AUDIT, "body-boundary"),
+];
+const LIST_FORMATTING_CROSS_AXIS_SUITES: &[(&str, &str, &str)] = &[
+    (
+        "block-boundary",
+        WHATWG_BLOCK_BOUNDARY_AUDIT,
+        "block-formatting-boundary",
+    ),
+    (
+        "document-shell",
+        WHATWG_DOCUMENT_SHELL_AUDIT,
+        "html-element-boundary",
+    ),
+    (
+        "formatting",
+        WHATWG_FORMATTING_AUDIT,
+        "list-definition-boundary",
+    ),
+    ("head-body", WHATWG_HEAD_BODY_AUDIT, "html-boundary"),
+    (
+        "legacy-element",
+        WHATWG_LEGACY_ELEMENT_AUDIT,
+        "tricky-parser-recovery",
+    ),
+];
+const LIST_TABLE_CROSS_AXIS_SUITES: &[(&str, &str, &str)] = &[
+    (
+        "block-boundary",
+        WHATWG_BLOCK_BOUNDARY_AUDIT,
+        "block-table-boundary",
+    ),
+    (
+        "form-interactive",
+        WHATWG_FORM_INTERACTIVE_AUDIT,
+        "stray-interactive-end-tags",
+    ),
+    (
+        "formatting",
+        WHATWG_FORMATTING_AUDIT,
+        "list-definition-boundary",
+    ),
+    (
+        "paragraph",
+        WHATWG_PARAGRAPH_AUDIT,
+        "paragraph-table-boundary",
+    ),
+    (
+        "select-list",
+        WHATWG_SELECT_LIST_AUDIT,
+        "stray-select-end-tags",
+    ),
+    ("table", WHATWG_TABLE_AUDIT, "caption-colgroup"),
+    ("void-element", WHATWG_VOID_ELEMENT_AUDIT, "void-in-table"),
+];
+const LIST_FRAMESET_CROSS_AXIS_SUITES: &[(&str, &str, &str)] = &[
+    (
+        "document-shell",
+        WHATWG_DOCUMENT_SHELL_AUDIT,
+        "body-frameset-boundary",
+    ),
+    (
+        "formatting",
+        WHATWG_FORMATTING_AUDIT,
+        "list-definition-boundary",
+    ),
+    ("frameset", WHATWG_FRAMESET_AUDIT, "body-compatibility"),
+    (
+        "head-body",
+        WHATWG_HEAD_BODY_AUDIT,
+        "body-frameset-transition",
+    ),
+];
+const LIST_ITEM_CROSS_AXIS_CASES: &[ListItemCrossAxisCase] = &[
+    ListItemCrossAxisCase {
+        id: "tests3-dat-20",
+        list_axis: "list-with-paragraph",
+        data_snippet: "<ul><li><div><p><li>",
+        suites: LIST_PARAGRAPH_CROSS_AXIS_SUITES,
+    },
+    ListItemCrossAxisCase {
+        id: "tests1-dat-34",
+        list_axis: "nested-list-boundary",
+        data_snippet: "<li>hello<li>world<ul>how<li>do</ul>you",
+        suites: NESTED_LIST_CROSS_AXIS_SUITES,
+    },
+    ListItemCrossAxisCase {
+        id: "tricky01-dat-4",
+        list_axis: "list-with-formatting",
+        data_snippet: "<dt><b>Boo\n<dd>Goo?",
+        suites: LIST_FORMATTING_CROSS_AXIS_SUITES,
+    },
+    ListItemCrossAxisCase {
+        id: "tests1-dat-111",
+        list_axis: "list-in-table",
+        data_snippet: "<table><tr></strong></b></em></i>",
+        suites: LIST_TABLE_CROSS_AXIS_SUITES,
+    },
+    ListItemCrossAxisCase {
+        id: "tests19-dat-1064",
+        list_axis: "li-implied-end-tag",
+        data_snippet: "<!doctype html><li><frameset>",
+        suites: LIST_FRAMESET_CROSS_AXIS_SUITES,
+    },
+    ListItemCrossAxisCase {
+        id: "tests19-dat-1065",
+        list_axis: "dt-dd-implied-end-tag",
+        data_snippet: "<!doctype html><dd><frameset>",
+        suites: LIST_FRAMESET_CROSS_AXIS_SUITES,
+    },
+];
 const POST_PARSE_REPAIR_EVIDENCE: &[(&str, &str)] = &[
     ("tests19-dat-1037", "li-implied-end-tag"),
     ("tests19-dat-1043", "dt-dd-implied-end-tag"),
@@ -25,6 +194,19 @@ struct ListItemAuditSuite {
 
 #[derive(Debug, Deserialize)]
 struct ListItemAuditCase {
+    id: String,
+    source: String,
+    axis: String,
+    reason: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GenericAuditSuite {
+    cases: Vec<GenericAuditCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GenericAuditCase {
     id: String,
     source: String,
     axis: String,
@@ -78,6 +260,76 @@ fn whatwg_list_item_audit_cases_match_parser_dom_dump() {
 }
 
 #[test]
+fn whatwg_list_item_audit_keeps_list_axis_cases_cross_axis() {
+    let suite = load_suite();
+    let list_cases = suite
+        .cases
+        .iter()
+        .map(|case| (case.id.as_str(), case))
+        .collect::<HashMap<_, _>>();
+    let smoke_cases = parse_tree_construction_cases(TREE_CONSTRUCTION_SMOKE)
+        .into_iter()
+        .map(|case| (case.source.clone(), case))
+        .collect::<HashMap<_, _>>();
+
+    for evidence in LIST_ITEM_CROSS_AXIS_CASES {
+        let list_case = list_cases
+            .get(evidence.id)
+            .unwrap_or_else(|| panic!("list-item audit should include `{}`", evidence.id));
+        assert_eq!(
+            list_case.axis, evidence.list_axis,
+            "list-item row `{}` should stay on its focused audit axis",
+            evidence.id
+        );
+        assert!(
+            !list_case.reason.is_empty(),
+            "list-item row `{}` should keep a fixture reason",
+            evidence.id
+        );
+
+        for (suite_name, fixture, expected_axis) in evidence.suites {
+            let audit_case = generic_audit_case(fixture, suite_name, evidence.id);
+            assert_eq!(
+                audit_case.source, list_case.source,
+                "`{suite_name}` should point list-item row `{}` at the same html5lib row as the list-item audit",
+                evidence.id
+            );
+            assert_eq!(
+                audit_case.axis, *expected_axis,
+                "`{suite_name}` should keep list-item row `{}` on its focused axis",
+                evidence.id
+            );
+            assert!(
+                !audit_case.reason.is_empty(),
+                "`{suite_name}` should keep a reason for list-item row `{}`",
+                evidence.id
+            );
+        }
+
+        let source_case = smoke_cases
+            .get(&list_case.source)
+            .unwrap_or_else(|| panic!("case `{}` should exist in smoke fixture", evidence.id));
+        assert!(
+            source_case.data.contains(evidence.data_snippet),
+            "list-item row `{}` should stay tied to its html5lib input",
+            evidence.id
+        );
+        let actual = actual_dom_dump_for_tree_case(source_case).unwrap_or_else(|error| {
+            panic!(
+                "case `{}` ({}) parse failed: {error}",
+                list_case.id, list_case.axis
+            )
+        });
+
+        assert_eq!(
+            actual, source_case.document,
+            "cross-axis list-item evidence case `{}` ({}) failed for input {:?}",
+            list_case.id, list_case.axis, source_case.data
+        );
+    }
+}
+
+#[test]
 fn whatwg_list_item_audit_tracks_post_parse_repair_evidence() {
     let suite = load_suite();
     let audit_cases = suite
@@ -120,6 +372,16 @@ fn whatwg_list_item_audit_tracks_post_parse_repair_evidence() {
 fn load_suite() -> ListItemAuditSuite {
     serde_json::from_str(WHATWG_LIST_ITEM_AUDIT)
         .expect("WHATWG list-item audit fixture should parse")
+}
+
+fn generic_audit_case(fixture: &str, suite_name: &str, case_id: &str) -> GenericAuditCase {
+    let suite = serde_json::from_str::<GenericAuditSuite>(fixture)
+        .unwrap_or_else(|error| panic!("`{suite_name}` audit fixture should parse: {error}"));
+    suite
+        .cases
+        .into_iter()
+        .find(|case| case.id == case_id)
+        .unwrap_or_else(|| panic!("`{suite_name}` should audit list-item case `{case_id}`"))
 }
 
 fn assert_axis_count(suite: &ListItemAuditSuite, axis: &str, minimum: usize) {


### PR DESCRIPTION
## Summary
- Adds a list-item audit cross-axis guard covering list-with-paragraph, nested-list, formatting, table, li, and dt/dd evidence rows.
- Verifies the same html5lib rows stay aligned across neighboring audit fixtures such as block-boundary, formatting, document-shell, frameset, paragraph, table, select-list, and void-element.
- Keeps each evidence row executable by parsing the source html5lib case and comparing the DOM dump.

## Validation
- `cargo fmt --package coding-adventures-html-parser`
- `cargo test -p coding-adventures-html-parser whatwg_list_item_audit_keeps_list_axis_cases_cross_axis`
- `cargo test -p coding-adventures-html-parser whatwg_list_item_audit`
- `cargo test -p coding-adventures-html-parser`
- `CARGO_BUILD_JOBS=2 cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser`
- `python3 -m json.tool code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json >/dev/null`
- `python3 code/packages/rust/html-parser/tests/fixtures/check_whatwg_audit_rust_tests.py --check`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py`
- `git diff --check`
