### PR TITLE
feat(adj-lang): inverse hyperbolic functions (arsinh/arcosh/artanh) in latex "…"

### DIFF
--- a/code/packages/rust/adj-lang/CHANGELOG.md
+++ b/code/packages/rust/adj-lang/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## [0.45.0] - 2026-07-03 — inverse hyperbolic functions (`arsinh`/`arcosh`/`artanh`) in `latex "…"`
+
+### Added
+
+- `latex "\operatorname{arsinh}(x)"`, `\operatorname{arcosh}(x)`, `\operatorname{artanh}(x)` — the
+  inverse (area) hyperbolic functions — now lower. The mirror of the reciprocal-hyperbolic arm: none
+  is a frontend `Func`, so each arrives as the operator-name juxtaposition
+  `Bin(Mul, Text("arsinh"), (x))` (or `Bin(Mul, Symbol("arsinh"), (x))` for the bare `\arsinh` macro).
+  Each is composed from its closed-form logarithm identity using only primitives the engine already
+  has — the natural log (`NamedFn::Ln`) and the power op (`ArithOp::Pow`, for both squaring `^2` and
+  the square root `^0.5`) — so **no engine op is added**:
+  `arsinh(x) = ln(x + (x²+1)^0.5)`, `arcosh(x) = ln(x + (x²−1)^0.5)`,
+  `artanh(x) = 0.5·ln((1+x)/(1−x))`. Results are the standard real branch (and NaN outside each
+  function's real domain, matching the underlying `ln`/root). This finishes the hyperbolic family:
+  direct (`sinh`/`cosh`/`tanh`), reciprocal (`coth`/`sech`/`csch`), and now inverse
+  (`arsinh`/`arcosh`/`artanh`) all lower.
+- Common surface spellings are all accepted: the area form (`arsinh`), the inverse-notation form
+  (`arcsinh`), and the terse form (`asinh`) — likewise `arcosh`/`arccosh`/`acosh` and
+  `artanh`/`arctanh`/`atanh` — across both the bare-macro and `\operatorname{…}`/`\mathrm{…}` spellings.
+- Adapter-only, no engine/AST change. The argument recurses through the SAME
+  `latex_math_to_expr_ast` the `\sin`/`\coth` arms use (no new tree-walk, no new DoS surface); the
+  identity clones the already-lowered, already-bounded argument where it is named more than once.
+
 ## [0.44.0] - 2026-07-02 — reciprocal hyperbolic functions (`\coth`/`\sech`/`\csch`) in `latex "…"`
 
 ### Added

--- a/code/packages/rust/adj-lang/Cargo.toml
+++ b/code/packages/rust/adj-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang"
-version = "0.44.0"
+version = "0.45.0"
 edition = "2021"
 description = "Surface-syntax frontend for the adjudication framework's probabilistic-logic rulebooks. Lexes, parses, and lowers a domain-expert-readable DSL into a `logic-engine` KnowledgeBase. Dissolves ADJ46 awkwardness items A10 (rulebook syntax) and A4 (joint contributions syntactically distinct)."
 

--- a/code/packages/rust/adj-lang/src/adapter.rs
+++ b/code/packages/rust/adj-lang/src/adapter.rs
@@ -1153,6 +1153,31 @@ fn latex_math_to_expr_ast(expr: &MathExpr, source: &str) -> Result<ExprAst, Adap
                 )),
             ))
         }
+        // `\operatorname{arsinh}(x)` / `\operatorname{arcosh}(x)` / `\operatorname{artanh}(x)` — the
+        // INVERSE hyperbolic (area-hyperbolic) functions, the mirror of the reciprocal-hyperbolic arm
+        // just above. Like `\coth` these have no dedicated engine op, and like `\coth` they arrive as
+        // an operator-name juxtaposition — `Bin(Mul, Text("arsinh"), (x))` for the `\operatorname{…}`
+        // spelling, or `Bin(Mul, Symbol("arsinh"), (x))` for the bare `\arsinh` macro (an unknown
+        // control sequence). But each inverse hyperbolic has a closed-form LOGARITHM identity built
+        // from primitives the engine ALREADY has — the natural log (`NamedFn::Ln`), the power op
+        // (`ArithOp::Pow`, used here for both squaring `^2` and the square root `^0.5`), and plain
+        // arithmetic — so we compose the identity directly, no engine/AST/lowering change (exactly the
+        // `\coth = 1/tanh` trick, one level richer). The identities:
+        //   arsinh(x) = ln( x + (x^2 + 1)^0.5 )   [ all real x ]
+        //   arcosh(x) = ln( x + (x^2 - 1)^0.5 )   [ x >= 1; the engine yields NaN below, matching the
+        //                                           real-valued function's domain ]
+        //   artanh(x) = 0.5 * ln( (1 + x) / (1 - x) )   [ |x| < 1 ]
+        // The argument recurses through the SAME `latex_math_to_expr_ast` the `\sin`/`\coth` arms use
+        // (no new tree-walk, so no new stack-overflow surface), then is CLONED where the identity names
+        // `x` more than once — cloning an already-lowered, already-bounded `ExprAst` adds no recursion.
+        // Common spellings are all accepted (`arsinh`/`arcsinh`/`asinh`, etc.); see
+        // `inverse_hyperbolic_kind`. This finishes the hyperbolic family: direct (`sinh`/`cosh`/`tanh`),
+        // reciprocal (`coth`/`sech`/`csch`), and now inverse (`arsinh`/`arcosh`/`artanh`) all lower.
+        MathExpr::Bin(BinOp::Mul, lhs, rhs) if inverse_hyperbolic_kind(lhs).is_some() => {
+            let kind = inverse_hyperbolic_kind(lhs).expect("guard guarantees Some");
+            let arg = latex_math_to_expr_ast(rhs, source)?;
+            Ok(lower_inverse_hyperbolic(kind, arg))
+        }
         MathExpr::Bin(BinOp::Mul, lhs, rhs) => latex_bin(ArithOp::Mul, lhs, rhs, source),
         MathExpr::Bin(BinOp::Div, lhs, rhs) | MathExpr::Frac(lhs, rhs) => {
             latex_bin(ArithOp::Div, lhs, rhs, source)
@@ -1345,6 +1370,82 @@ fn reciprocal_hyperbolic_den(expr: &MathExpr) -> Option<NamedFn> {
         "sech" => Some(NamedFn::Cosh),
         "csch" => Some(NamedFn::Sinh),
         _ => None,
+    }
+}
+
+/// Which inverse hyperbolic (area-hyperbolic) function `expr` names, if any. Recognised so the
+/// caller can compose the closed-form logarithm identity (see `lower_inverse_hyperbolic`). Matches
+/// the same two spellings the reciprocal-hyperbolic arm handles — the bare macro (`\arsinh` →
+/// `Symbol("arsinh")`, an unknown control sequence) and the operator name (`\operatorname{arsinh}`
+/// / `\mathrm{arsinh}` → `Text("arsinh")`) — across the three common surface spellings of each: the
+/// ISO/area form (`arsinh`), the inverse-notation form (`arcsinh`), and the terse form (`asinh`).
+/// Returns `None` for anything else, so a genuine product falls through to the general
+/// multiplication arm.
+fn inverse_hyperbolic_kind(expr: &MathExpr) -> Option<InverseHyperbolic> {
+    let name = match expr {
+        MathExpr::Symbol(s) => s.as_str(),
+        MathExpr::Text(s) => s.trim(),
+        _ => return None,
+    };
+    match name {
+        "arsinh" | "arcsinh" | "asinh" => Some(InverseHyperbolic::ArSinh),
+        "arcosh" | "arccosh" | "acosh" => Some(InverseHyperbolic::ArCosh),
+        "artanh" | "arctanh" | "atanh" => Some(InverseHyperbolic::ArTanh),
+        _ => None,
+    }
+}
+
+/// The three inverse hyperbolic functions the adapter lowers via logarithm identities.
+#[derive(Clone, Copy)]
+enum InverseHyperbolic {
+    /// `arsinh(x) = ln(x + (x^2 + 1)^0.5)`.
+    ArSinh,
+    /// `arcosh(x) = ln(x + (x^2 - 1)^0.5)`.
+    ArCosh,
+    /// `artanh(x) = 0.5 * ln((1 + x) / (1 - x))`.
+    ArTanh,
+}
+
+/// Compose an inverse hyperbolic function from its closed-form logarithm identity, using only
+/// primitives the engine already evaluates — `NamedFn::Ln`, `ArithOp::Pow` (squaring and square
+/// root), and plain arithmetic. `arg` is the ALREADY-lowered argument expression; it is cloned
+/// where the identity names `x` more than once (arsinh/arcosh use it twice, artanh twice). Cloning
+/// a bounded `ExprAst` introduces no recursion, so this adds no stack-overflow surface. The results
+/// evaluate to the standard real-valued branch, and to NaN outside each function's real domain
+/// (arcosh below 1, artanh at/outside ±1) — the same as the underlying `ln`/root would give.
+fn lower_inverse_hyperbolic(kind: InverseHyperbolic, arg: ExprAst) -> ExprAst {
+    // Small constructors keep the identity trees readable.
+    fn lit(v: f64) -> Box<ExprAst> {
+        Box::new(ExprAst::Lit(v))
+    }
+    fn bin(op: ArithOp, a: Box<ExprAst>, b: Box<ExprAst>) -> Box<ExprAst> {
+        Box::new(ExprAst::Bin(op, a, b))
+    }
+    match kind {
+        // ln( x + (x^2 + 1)^0.5 )
+        InverseHyperbolic::ArSinh => {
+            let x_squared = bin(ArithOp::Pow, Box::new(arg.clone()), lit(2.0));
+            let radicand = bin(ArithOp::Add, x_squared, lit(1.0));
+            let root = bin(ArithOp::Pow, radicand, lit(0.5));
+            let sum = bin(ArithOp::Add, Box::new(arg), root);
+            ExprAst::Call(NamedFn::Ln, sum)
+        }
+        // ln( x + (x^2 - 1)^0.5 )
+        InverseHyperbolic::ArCosh => {
+            let x_squared = bin(ArithOp::Pow, Box::new(arg.clone()), lit(2.0));
+            let radicand = bin(ArithOp::Sub, x_squared, lit(1.0));
+            let root = bin(ArithOp::Pow, radicand, lit(0.5));
+            let sum = bin(ArithOp::Add, Box::new(arg), root);
+            ExprAst::Call(NamedFn::Ln, sum)
+        }
+        // 0.5 * ln( (1 + x) / (1 - x) )
+        InverseHyperbolic::ArTanh => {
+            let numerator = bin(ArithOp::Add, lit(1.0), Box::new(arg.clone()));
+            let denominator = bin(ArithOp::Sub, lit(1.0), Box::new(arg));
+            let ratio = bin(ArithOp::Div, numerator, denominator);
+            let log = Box::new(ExprAst::Call(NamedFn::Ln, ratio));
+            ExprAst::Bin(ArithOp::Mul, lit(0.5), log)
+        }
     }
 }
 

--- a/code/packages/rust/adj-lang/src/lower.rs
+++ b/code/packages/rust/adj-lang/src/lower.rs
@@ -2506,6 +2506,65 @@ contributes 1000000 from answer == 60 to correct
     }
 
     #[test]
+    fn native_latex_inverse_hyperbolic_functions_lower() {
+        // `\operatorname{arsinh}`/`\operatorname{arcosh}`/`\operatorname{artanh}` — the inverse
+        // (area) hyperbolics. None is a frontend `Func`, so each arrives as the operator-name
+        // juxtaposition `Bin(Mul, Text("arsinh"), (x))` (or `Bin(Mul, Symbol("arsinh"), (x))` for the
+        // bare macro). The adapter composes each from its logarithm identity using only `ln` + `^`,
+        // so the results are the standard real branch. Exact anchor: arsinh(0) = ln(0 + √1) = 0.
+        let arsinh0 = crate::compile_and_decide(
+            "observe x(0)\n\
+             let answer = latex \"$\\operatorname{arsinh}(x)$\"\n\
+             prior 0.10 for correct\n\
+             contributes 1000000 from answer == 0 to correct\n\
+             ? correct\n",
+        )
+        .unwrap();
+        assert!(arsinh0.ranked[0].posterior > 0.99, "{arsinh0:?}");
+        // arsinh(1) = ln(1 + √2) ≈ 0.8813735870195429 (matched within the engine's 1e-9 == tolerance).
+        let arsinh1 = crate::compile_and_decide(
+            "observe x(1)\n\
+             let answer = latex \"$\\operatorname{arsinh}(x)$\"\n\
+             prior 0.10 for correct\n\
+             contributes 1000000 from answer == 0.8813735870195429 to correct\n\
+             ? correct\n",
+        )
+        .unwrap();
+        assert!(arsinh1.ranked[0].posterior > 0.99, "{arsinh1:?}");
+        // arcosh(2) = ln(2 + √3) ≈ 1.3169578969248166.
+        let arcosh2 = crate::compile_and_decide(
+            "observe x(2)\n\
+             let answer = latex \"$\\operatorname{arcosh}(x)$\"\n\
+             prior 0.10 for correct\n\
+             contributes 1000000 from answer == 1.3169578969248166 to correct\n\
+             ? correct\n",
+        )
+        .unwrap();
+        assert!(arcosh2.ranked[0].posterior > 0.99, "{arcosh2:?}");
+        // artanh(0.5) = 0.5·ln(1.5/0.5) = 0.5·ln 3 ≈ 0.5493061443340549. The bare `\artanh` macro
+        // reaches the SAME composition through a `Symbol` (not `Text`) name.
+        let artanh = crate::compile_and_decide(
+            "observe x(0.5)\n\
+             let answer = latex \"$\\artanh(x)$\"\n\
+             prior 0.10 for correct\n\
+             contributes 1000000 from answer == 0.5493061443340549 to correct\n\
+             ? correct\n",
+        )
+        .unwrap();
+        assert!(artanh.ranked[0].posterior > 0.99, "{artanh:?}");
+        // The terse `asinh` spelling reaches the SAME `arsinh` composition: asinh(1) ≈ 0.8813735870195429.
+        let asinh1 = crate::compile_and_decide(
+            "observe x(1)\n\
+             let answer = latex \"$\\operatorname{asinh}(x)$\"\n\
+             prior 0.10 for correct\n\
+             contributes 1000000 from answer == 0.8813735870195429 to correct\n\
+             ? correct\n",
+        )
+        .unwrap();
+        assert!(asinh1.ranked[0].posterior > 0.99, "{asinh1:?}");
+    }
+
+    #[test]
     fn native_latex_accent_wrapped_operands_are_transparent() {
         // `\hat{x}` / `\bar{x}` / … — an accent is a notational decoration, not an operation. A
         // model that writes a statistics formula (`\hat{p}(1-\hat{p})`, `\bar{x} - \bar{y}`) means


### PR DESCRIPTION
## `latex "…"` — inverse hyperbolic functions (`arsinh`/`arcosh`/`artanh`)

Adds the inverse (area) hyperbolic functions to the `latex "…"` adapter — the mirror of the reciprocal-hyperbolic slice ([#7488](https://github.com/adhithyan15/coding-adventures/pull/7488)) that just merged. This **finishes the hyperbolic family**: direct (`sinh`/`cosh`/`tanh`), reciprocal (`coth`/`sech`/`csch`), and now inverse (`arsinh`/`arcosh`/`artanh`) all lower.

### How
Like `\coth`, none of these is a frontend `Func`, so each arrives as an operator-name juxtaposition — `Bin(Mul, Text("arsinh"), (x))` for `\operatorname{arsinh}` / `Bin(Mul, Symbol("arsinh"), (x))` for the bare `\arsinh` macro. There is **no dedicated engine op**, but each has a closed-form **logarithm identity** built from primitives the engine already evaluates — the natural log (`NamedFn::Ln`) and the power op (`ArithOp::Pow`, for both squaring `^2` and the square root `^0.5`):

```text
arsinh(x) = ln( x + (x² + 1)^0.5 )          [ all real x ]
arcosh(x) = ln( x + (x² − 1)^0.5 )          [ x ≥ 1 ]
artanh(x) = 0.5 · ln( (1 + x) / (1 − x) )   [ |x| < 1 ]
```

So the adapter composes each identity directly — **no engine / AST / lowering change** (exactly the `\coth = 1/tanh` trick, one level richer). Results are the standard real branch, and NaN outside each function's real domain (matching the underlying `ln`/root).

### Surface
Common spellings all accepted: the area form (`arsinh`), the inverse-notation form (`arcsinh`), and the terse form (`asinh`) — likewise `arcosh`/`arccosh`/`acosh` and `artanh`/`arctanh`/`atanh` — across both the bare-macro and `\operatorname{…}`/`\mathrm{…}` spellings.

### Safety
Adapter-only. The argument recurses through the **same** `latex_math_to_expr_ast` every other named-function arm uses (no new tree-walk → **no new stack-overflow surface**); the guard is a shallow `Symbol`/`Text` name check; `lower_inverse_hyperbolic` builds a fixed-shape tree from the already-lowered, already-bounded argument with a constant number of clones (no loops, no recursion). No `unsafe`.

### Verification
```
$ cargo test -p logic-engine -p adj-lang -p adj-lang-cli -p adj-constraint-solver
test result: ok. 60 passed  (adj-lang lib, incl. native_latex_inverse_hyperbolic_functions_lower)
… all four crates green …
```
New e2e test asserts exact values through the full `compile_and_decide` pipeline: `arsinh(0)=0`, `arsinh(1)=ln(1+√2)≈0.8813735870195429`, `arcosh(2)=ln(2+√3)≈1.3169578969248166`, `artanh(0.5)=0.5·ln 3≈0.5493061443340549`, and the terse `asinh` + bare-macro `\artanh` spellings reaching the same composition. Version `adj-lang` 0.44.0 → 0.45.0; CHANGELOG updated.
