### PR TITLE
[codex] Wire Engram web Anki file intents

### DIFF
--- a/code/programs/mosaic/engram-app/CHANGELOG.md
+++ b/code/programs/mosaic/engram-app/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Wired the generated HTML, WebComponent, and React Engram web hosts to handle
+  Anki import/export `hostIntent` payloads with browser file input/download
+  helpers and the `engram-wasm` APKG byte API, surfacing `hostResult` errors
+  when the current browser WASM build delegates package parsing to native hosts.
 - Wired the generated Flutter Engram shell to handle Anki import/export
   `hostIntent` payloads with `file_selector` dialogs and the shared
   `engram-capi` APKG import/export functions.

--- a/code/programs/mosaic/engram-app/README.md
+++ b/code/programs/mosaic/engram-app/README.md
@@ -42,6 +42,12 @@ editing, and save/delete/cancel controls.
 - The generated React and Electron renderer shells mount `EngramApp` through
   `window.mosaicHost.getProps` and `window.mosaicHost.handleEvent`, with sample
   slot values as a fallback when no host is installed.
+- The generated HTML, WebComponent, and React web hosts handle Anki
+  import/export `hostIntent` payloads with browser file input/download helpers
+  and the `engram-wasm` APKG byte API. The current browser WASM build still
+  returns a native-host delegation error for APKG parsing/export, so the host
+  reports that through `hostResult` until the package stack is made
+  browser-buildable.
 - The generated Electron preload/main shell exposes those calls over
   context-isolated IPC channels and can delegate them to an optional
   `electron/host.ts` or `MOSAIC_ELECTRON_HOST_MODULE` host module. The
@@ -155,5 +161,5 @@ Flutter host bridge, JNA/JSON dependencies for the Compose host bridge,
 `engram_capi.dll` as XAML project content, and `engram-host-cli` for the
 Electron APKG sidecar.
 Collection actions such as Anki import/export return `hostIntent` payloads so
-hosts can open file pickers, call native package bridges, and keep the Mosaic
-app interface shared.
+hosts can open file pickers, call package bridges, and keep the Mosaic app
+interface shared.

--- a/code/programs/mosaic/engram-app/host/web/engram-host.mjs
+++ b/code/programs/mosaic/engram-app/host/web/engram-host.mjs
@@ -28,13 +28,7 @@ async function installEngramHost() {
   const host = engine.createMosaicHost({
     deckId: selectedDeckId,
     now: () => Date.now(),
-    onHostIntent: (intent, result) => {
-      window.dispatchEvent(
-        new CustomEvent(HOST_INTENT_EVENT, {
-          detail: { intent, result },
-        }),
-      );
-    },
+    onHostIntent: (intent, result) => handleHostIntent(engine, intent, result),
   });
   window.mosaicHost = withSnapshotPersistence(host, engine);
   announceHostReady();
@@ -67,9 +61,160 @@ function withSnapshotPersistence(host, engine) {
       if (!isErrorResult(result)) {
         persistSnapshot(engine);
       }
+      if (hostResultStatus(result) === "imported" && typeof host.getProps === "function") {
+        const refreshed = await host.getProps({
+          component: request?.component ?? "EngramApp",
+        });
+        return {
+          ...recordFrom(refreshed),
+          hostIntent: recordFrom(result).hostIntent,
+          hostResult: recordFrom(result).hostResult,
+        };
+      }
       return result;
     },
   };
+}
+
+async function handleHostIntent(engine, intent, result) {
+  const hostResult = await handleKnownHostIntent(engine, intent);
+  window.dispatchEvent(
+    new CustomEvent(HOST_INTENT_EVENT, {
+      detail: { intent, result, hostResult },
+    }),
+  );
+  return hostResult;
+}
+
+async function handleKnownHostIntent(engine, intent) {
+  if (intent?.type === "importAnki") {
+    return importAnkiPackage(engine, intent);
+  }
+  if (intent?.type === "exportAnki") {
+    return exportAnkiPackage(engine, intent);
+  }
+  return { status: "captured", hostIntent: intent };
+}
+
+async function importAnkiPackage(engine, intent) {
+  const file = await chooseAnkiImportFile(intent);
+  if (file === null) {
+    return { status: "cancelled" };
+  }
+
+  let bytes;
+  try {
+    bytes = new Uint8Array(await file.arrayBuffer());
+  } catch (error) {
+    return hostFileResult("read-error", file, error);
+  }
+
+  if (bytes.length === 0) {
+    return hostFileResult("import-error", file, "Anki package was empty");
+  }
+
+  const imported = engine.mergeAnkiApkg(bytes);
+  if (imported.ok !== true) {
+    return hostFileResult("import-error", file, imported.error);
+  }
+
+  return {
+    status: "imported",
+    name: file.name,
+    size: file.size,
+  };
+}
+
+async function exportAnkiPackage(engine, intent) {
+  const exported = engine.exportAnkiApkg();
+  if (exported.ok !== true) {
+    return {
+      status: "export-error",
+      error: errorText(exported.error),
+    };
+  }
+
+  const bytes = jsonByteArray(exported.apkg);
+  if (bytes.length === 0) {
+    return {
+      status: "export-error",
+      error: "Engram WASM host returned an empty APKG",
+    };
+  }
+
+  const name = suggestedAnkiFileName(intent);
+  try {
+    downloadBytes(bytes, name);
+  } catch (error) {
+    return {
+      status: "write-error",
+      name,
+      error: errorText(error),
+    };
+  }
+
+  return {
+    status: "exported",
+    name,
+    size: bytes.length,
+  };
+}
+
+function chooseAnkiImportFile(intent) {
+  return new Promise((resolve) => {
+    const input = document.createElement("input");
+    input.type = "file";
+    input.accept = hostIntentExtensions(intent, "accept", [".apkg", ".colpkg"]).join(",");
+    input.style.position = "fixed";
+    input.style.left = "-10000px";
+    input.style.top = "0";
+
+    const parent = document.body ?? document.documentElement;
+    let settled = false;
+
+    const finish = (file) => {
+      if (settled) return;
+      settled = true;
+      window.removeEventListener("focus", onFocus);
+      input.remove();
+      resolve(file);
+    };
+
+    const onFocus = () => {
+      window.setTimeout(() => {
+        if (!settled && (input.files?.length ?? 0) === 0) {
+          finish(null);
+        }
+      }, 300);
+    };
+
+    input.addEventListener(
+      "change",
+      () => {
+        finish(input.files?.item(0) ?? null);
+      },
+      { once: true },
+    );
+    input.addEventListener("cancel", () => finish(null), { once: true });
+    window.addEventListener("focus", onFocus, { once: true });
+    parent.appendChild(input);
+    input.click();
+  });
+}
+
+function downloadBytes(bytes, name) {
+  const blob = new Blob([bytes], { type: "application/octet-stream" });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = name;
+  link.style.display = "none";
+
+  const parent = document.body ?? document.documentElement;
+  parent.appendChild(link);
+  link.click();
+  link.remove();
+  window.setTimeout(() => URL.revokeObjectURL(url), 1000);
 }
 
 function persistSnapshot(engine) {
@@ -81,12 +226,59 @@ function persistSnapshot(engine) {
   writeStorage(SNAPSHOT_STORAGE_KEY, JSON.stringify(snapshot.state));
 }
 
+function hostFileResult(status, file, error) {
+  const result = {
+    status,
+    name: file.name,
+    size: file.size,
+  };
+  if (error !== undefined) {
+    result.error = errorText(error);
+  }
+  return result;
+}
+
 function isErrorResult(result) {
   return Boolean(result && typeof result === "object" && result.error);
 }
 
+function hostResultStatus(result) {
+  const status = recordFrom(recordFrom(result).hostResult).status;
+  return typeof status === "string" ? status : undefined;
+}
+
+function recordFrom(value) {
+  return typeof value === "object" && value !== null ? value : {};
+}
+
+function jsonByteArray(value) {
+  if (!Array.isArray(value)) {
+    return new Uint8Array();
+  }
+  return Uint8Array.from(value.map((byte) => Number(byte) & 0xff));
+}
+
 function selectedDeckId() {
   return readStorage(DECK_ID_STORAGE_KEY) ?? "";
+}
+
+function hostIntentExtensions(intent, property, fallback) {
+  const values = Array.isArray(intent?.[property]) ? intent[property] : fallback;
+  const normalized = values
+    .map((value) => String(value).trim())
+    .filter(Boolean)
+    .map((value) => (value.startsWith(".") ? value : `.${value}`));
+  return normalized.length === 0 ? fallback : normalized;
+}
+
+function suggestedAnkiFileName(intent) {
+  const raw = String(intent?.deckId ?? "engram-collection").trim() || "engram-collection";
+  const safe = raw.replace(/[\/\\:*?"<>|]/g, "-");
+  return safe.toLowerCase().endsWith(".apkg") ? safe : `${safe}.apkg`;
+}
+
+function errorText(error) {
+  return error instanceof Error ? error.message : String(error ?? "unknown error");
 }
 
 function readStorage(key) {

--- a/code/programs/mosaic/engram-app/host/web/engram-host.ts
+++ b/code/programs/mosaic/engram-app/host/web/engram-host.ts
@@ -12,10 +12,15 @@ type EngramEngine = {
   resetDemo: () => unknown;
   snapshot: () => { ok?: boolean; state?: unknown; error?: unknown };
   loadSnapshot: (snapshot: string) => { ok?: boolean; error?: unknown };
+  exportAnkiApkg: () => { ok?: boolean; apkg?: unknown; error?: unknown };
+  mergeAnkiApkg: (bytes: Uint8Array) => { ok?: boolean; state?: unknown; error?: unknown };
   createMosaicHost: (options: {
     deckId?: string | (() => string);
     now?: number | (() => number);
-    onHostIntent?: (intent: HostIntent, result: HostResult) => unknown;
+    onHostIntent?: (
+      intent: HostIntent,
+      result: HostResult,
+    ) => unknown | Promise<unknown>;
   }) => EngramMosaicHost;
 };
 type HostedWindow = {
@@ -52,13 +57,8 @@ async function installEngramHost(): Promise<void> {
   const host = engine.createMosaicHost({
     deckId: selectedDeckId,
     now: () => Date.now(),
-    onHostIntent: (intent: HostIntent, result: HostResult) => {
-      window.dispatchEvent(
-        new CustomEvent(HOST_INTENT_EVENT, {
-          detail: { intent, result },
-        }),
-      );
-    },
+    onHostIntent: (intent: HostIntent, result: HostResult) =>
+      handleHostIntent(engine, intent, result),
   });
   target.mosaicHost = withSnapshotPersistence(host, engine);
   announceHostReady();
@@ -94,9 +94,174 @@ function withSnapshotPersistence(
       if (!isErrorResult(result)) {
         persistSnapshot(engine);
       }
+      if (hostResultStatus(result) === "imported" && typeof host.getProps === "function") {
+        const refreshed = await host.getProps({
+          component: request?.component ?? "EngramApp",
+        });
+        return {
+          ...recordFrom(refreshed),
+          hostIntent: recordFrom(result).hostIntent,
+          hostResult: recordFrom(result).hostResult,
+        };
+      }
       return result;
     },
   };
+}
+
+async function handleHostIntent(
+  engine: EngramEngine,
+  intent: HostIntent,
+  result: HostResult,
+): Promise<HostResult> {
+  const hostResult = await handleKnownHostIntent(engine, intent);
+  window.dispatchEvent(
+    new CustomEvent(HOST_INTENT_EVENT, {
+      detail: { intent, result, hostResult },
+    }),
+  );
+  return hostResult;
+}
+
+async function handleKnownHostIntent(
+  engine: EngramEngine,
+  intent: HostIntent,
+): Promise<HostResult> {
+  switch (intent.type) {
+    case "importAnki":
+      return importAnkiPackage(engine, intent);
+    case "exportAnki":
+      return exportAnkiPackage(engine, intent);
+    default:
+      return { status: "captured", hostIntent: intent };
+  }
+}
+
+async function importAnkiPackage(
+  engine: EngramEngine,
+  intent: HostIntent,
+): Promise<HostResult> {
+  const file = await chooseAnkiImportFile(intent);
+  if (file === null) {
+    return { status: "cancelled" };
+  }
+
+  let bytes: Uint8Array;
+  try {
+    bytes = new Uint8Array(await file.arrayBuffer());
+  } catch (error) {
+    return hostFileResult("read-error", file, error);
+  }
+
+  if (bytes.length === 0) {
+    return hostFileResult("import-error", file, "Anki package was empty");
+  }
+
+  const imported = engine.mergeAnkiApkg(bytes);
+  if (imported.ok !== true) {
+    return hostFileResult("import-error", file, imported.error);
+  }
+
+  return {
+    status: "imported",
+    name: file.name,
+    size: file.size,
+  };
+}
+
+async function exportAnkiPackage(
+  engine: EngramEngine,
+  intent: HostIntent,
+): Promise<HostResult> {
+  const exported = engine.exportAnkiApkg();
+  if (exported.ok !== true) {
+    return {
+      status: "export-error",
+      error: errorText(exported.error),
+    };
+  }
+
+  const bytes = jsonByteArray(exported.apkg);
+  if (bytes.length === 0) {
+    return {
+      status: "export-error",
+      error: "Engram WASM host returned an empty APKG",
+    };
+  }
+
+  const name = suggestedAnkiFileName(intent);
+  try {
+    downloadBytes(bytes, name);
+  } catch (error) {
+    return {
+      status: "write-error",
+      name,
+      error: errorText(error),
+    };
+  }
+
+  return {
+    status: "exported",
+    name,
+    size: bytes.length,
+  };
+}
+
+function chooseAnkiImportFile(intent: HostIntent): Promise<File | null> {
+  return new Promise((resolve) => {
+    const input = document.createElement("input");
+    input.type = "file";
+    input.accept = hostIntentExtensions(intent, "accept", [".apkg", ".colpkg"]).join(",");
+    input.style.position = "fixed";
+    input.style.left = "-10000px";
+    input.style.top = "0";
+
+    const parent = document.body ?? document.documentElement;
+    let settled = false;
+
+    const finish = (file: File | null) => {
+      if (settled) return;
+      settled = true;
+      window.removeEventListener("focus", onFocus);
+      input.remove();
+      resolve(file);
+    };
+
+    const onFocus = () => {
+      window.setTimeout(() => {
+        if (!settled && (input.files?.length ?? 0) === 0) {
+          finish(null);
+        }
+      }, 300);
+    };
+
+    input.addEventListener(
+      "change",
+      () => {
+        finish(input.files?.item(0) ?? null);
+      },
+      { once: true },
+    );
+    input.addEventListener("cancel", () => finish(null), { once: true });
+    window.addEventListener("focus", onFocus, { once: true });
+    parent.appendChild(input);
+    input.click();
+  });
+}
+
+function downloadBytes(bytes: Uint8Array, name: string): void {
+  const blob = new Blob([bytes], { type: "application/octet-stream" });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = name;
+  link.style.display = "none";
+
+  const parent = document.body ?? document.documentElement;
+  parent.appendChild(link);
+  link.click();
+  link.remove();
+  window.setTimeout(() => URL.revokeObjectURL(url), 1000);
 }
 
 function persistSnapshot(engine: EngramEngine): void {
@@ -108,6 +273,18 @@ function persistSnapshot(engine: EngramEngine): void {
   writeStorage(SNAPSHOT_STORAGE_KEY, JSON.stringify(snapshot.state));
 }
 
+function hostFileResult(status: string, file: File, error?: unknown): HostResult {
+  const result: HostResult = {
+    status,
+    name: file.name,
+    size: file.size,
+  };
+  if (error !== undefined) {
+    result.error = errorText(error);
+  }
+  return result;
+}
+
 function isErrorResult(result: unknown): boolean {
   return (
     typeof result === "object" &&
@@ -117,8 +294,51 @@ function isErrorResult(result: unknown): boolean {
   );
 }
 
+function hostResultStatus(result: unknown): string | undefined {
+  const hostResult = recordFrom(recordFrom(result).hostResult);
+  const status = hostResult.status;
+  return typeof status === "string" ? status : undefined;
+}
+
+function recordFrom(value: unknown): Record<string, unknown> {
+  return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : {};
+}
+
+function jsonByteArray(value: unknown): Uint8Array {
+  if (!Array.isArray(value)) {
+    return new Uint8Array();
+  }
+  return Uint8Array.from(value.map((byte) => Number(byte) & 0xff));
+}
+
 function selectedDeckId(): string {
   return readStorage(DECK_ID_STORAGE_KEY) ?? "";
+}
+
+function hostIntentExtensions(
+  intent: HostIntent,
+  property: string,
+  fallback: string[],
+): string[] {
+  const values = Array.isArray(intent[property]) ? intent[property] : fallback;
+  const normalized = values
+    .map((value) => String(value).trim())
+    .filter(Boolean)
+    .map((value) => (value.startsWith(".") ? value : `.${value}`));
+  return normalized.length === 0 ? fallback : normalized;
+}
+
+function suggestedAnkiFileName(intent: HostIntent): string {
+  const raw = String(intent.deckId ?? "engram-collection").trim() || "engram-collection";
+  const safe = raw.replace(/[\/\\:*?"<>|]/g, "-");
+  return safe.toLowerCase().endsWith(".apkg") ? safe : `${safe}.apkg`;
+}
+
+function errorText(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error ?? "unknown error");
 }
 
 function readStorage(key: string): string | null {

--- a/code/programs/mosaic/engram-app/host/web/engram-mosaic-host-wasm.d.ts
+++ b/code/programs/mosaic/engram-app/host/web/engram-mosaic-host-wasm.d.ts
@@ -12,10 +12,15 @@ export type EngramEngine = {
   getState: () => unknown;
   loadSnapshot: (snapshot: unknown) => { ok?: boolean; error?: unknown };
   dispatch: (command: unknown) => unknown;
+  exportAnkiApkg: () => { ok?: boolean; apkg?: unknown; error?: unknown };
+  mergeAnkiApkg: (bytes: Uint8Array) => { ok?: boolean; state?: unknown; error?: unknown };
   createMosaicHost: (options?: {
     deckId?: string | (() => string);
     now?: number | (() => number);
-    onHostIntent?: (intent: Record<string, unknown>, result: Record<string, unknown>) => unknown;
+    onHostIntent?: (
+      intent: Record<string, unknown>,
+      result: Record<string, unknown>,
+    ) => unknown | Promise<unknown>;
   }) => EngramMosaicHost;
 };
 
@@ -35,6 +40,9 @@ export function installEngramMosaicHost(
     demo?: boolean;
     deckId?: string | (() => string);
     now?: number | (() => number);
-    onHostIntent?: (intent: Record<string, unknown>, result: Record<string, unknown>) => unknown;
+    onHostIntent?: (
+      intent: Record<string, unknown>,
+      result: Record<string, unknown>,
+    ) => unknown | Promise<unknown>;
   },
 ): EngramMosaicHost;

--- a/code/programs/mosaic/engram-app/tests/package_compiles.rs
+++ b/code/programs/mosaic/engram-app/tests/package_compiles.rs
@@ -682,6 +682,11 @@ fn native_project_shells_expose_engram_host_contract() {
     assert_contains(&html_host, "hydrateEngine(engine);");
     assert_contains(&html_host, "withSnapshotPersistence(host, engine)");
     assert_contains(&html_host, "persistSnapshot(engine);");
+    assert_contains(&html_host, "handleHostIntent(engine, intent, result)");
+    assert_contains(&html_host, "chooseAnkiImportFile(intent)");
+    assert_contains(&html_host, "engine.mergeAnkiApkg(bytes)");
+    assert_contains(&html_host, "engine.exportAnkiApkg()");
+    assert_contains(&html_host, "downloadBytes(bytes, name)");
 
     let webcomponent_index = fs::read_to_string(tmp.path().join("webcomponent").join("index.html"))
         .expect("webcomponent/index.html");
@@ -772,6 +777,11 @@ fn native_project_shells_expose_engram_host_contract() {
     assert_contains(&webcomponent_host, "hydrateEngine(engine);");
     assert_contains(&webcomponent_host, "withSnapshotPersistence(host, engine)");
     assert_contains(&webcomponent_host, "persistSnapshot(engine);");
+    assert_contains(&webcomponent_host, "handleHostIntent(engine, intent, result)");
+    assert_contains(&webcomponent_host, "chooseAnkiImportFile(intent)");
+    assert_contains(&webcomponent_host, "engine.mergeAnkiApkg(bytes)");
+    assert_contains(&webcomponent_host, "engine.exportAnkiApkg()");
+    assert_contains(&webcomponent_host, "downloadBytes(bytes, name)");
 
     let react_app = fs::read_to_string(tmp.path().join("react").join("src").join("main.tsx"))
         .expect("react/src/main.tsx");
@@ -882,6 +892,11 @@ fn native_project_shells_expose_engram_host_contract() {
     assert_contains(&react_host, "hydrateEngine(engine);");
     assert_contains(&react_host, "withSnapshotPersistence(host, engine)");
     assert_contains(&react_host, "persistSnapshot(engine);");
+    assert_contains(&react_host, "handleHostIntent(engine, intent, result)");
+    assert_contains(&react_host, "chooseAnkiImportFile(intent)");
+    assert_contains(&react_host, "engine.mergeAnkiApkg(bytes)");
+    assert_contains(&react_host, "engine.exportAnkiApkg()");
+    assert_contains(&react_host, "downloadBytes(bytes, name)");
     assert!(
         tmp.path()
             .join("react")
@@ -2503,6 +2518,35 @@ fn source_tree_has_expected_shape() {
             path.display()
         );
     }
+
+    let web_ts_host = fs::read_to_string(package_root().join("host/web/engram-host.ts"))
+        .expect("web ts host template");
+    assert_contains(&web_ts_host, "handleHostIntent(engine, intent, result)");
+    assert_contains(&web_ts_host, "importAnkiPackage(engine, intent)");
+    assert_contains(&web_ts_host, "exportAnkiPackage(engine, intent)");
+    assert_contains(&web_ts_host, "chooseAnkiImportFile(intent)");
+    assert_contains(&web_ts_host, "engine.mergeAnkiApkg(bytes)");
+    assert_contains(&web_ts_host, "engine.exportAnkiApkg()");
+    assert_contains(&web_ts_host, "downloadBytes(bytes, name)");
+    assert_contains(&web_ts_host, "hostResultStatus(result) === \"imported\"");
+
+    let web_mjs_host = fs::read_to_string(package_root().join("host/web/engram-host.mjs"))
+        .expect("web mjs host template");
+    assert_contains(&web_mjs_host, "handleHostIntent(engine, intent, result)");
+    assert_contains(&web_mjs_host, "importAnkiPackage(engine, intent)");
+    assert_contains(&web_mjs_host, "exportAnkiPackage(engine, intent)");
+    assert_contains(&web_mjs_host, "chooseAnkiImportFile(intent)");
+    assert_contains(&web_mjs_host, "engine.mergeAnkiApkg(bytes)");
+    assert_contains(&web_mjs_host, "engine.exportAnkiApkg()");
+    assert_contains(&web_mjs_host, "downloadBytes(bytes, name)");
+    assert_contains(&web_mjs_host, "hostResultStatus(result) === \"imported\"");
+
+    let web_wasm_defs =
+        fs::read_to_string(package_root().join("host/web/engram-mosaic-host-wasm.d.ts"))
+            .expect("web wasm declarations");
+    assert_contains(&web_wasm_defs, "exportAnkiApkg");
+    assert_contains(&web_wasm_defs, "mergeAnkiApkg");
+    assert_contains(&web_wasm_defs, "Promise<unknown>");
 
     let xaml_host = fs::read_to_string(package_root().join("host/xaml/MosaicHost.cs"))
         .expect("xaml host template");


### PR DESCRIPTION
﻿## Summary
- wire Engram HTML/WebComponent/React hosts to handle Anki import/export host intents with browser file input/download helpers
- call the existing `engram-wasm` APKG byte APIs and return structured `hostResult` statuses/errors
- refresh props after successful imports and keep the existing `engram-host-intent` browser event for observers
- pin the generated host assets and WASM declarations in Engram package smoke tests

## Notes
The current browser WASM build still returns the explicit native-host delegation error for APKG parsing/export. This PR makes the web host path real and observable, but the deeper follow-up is making the APKG package stack compile into browser WASM.

## Validation
- `git diff --check`
- `cargo test --manifest-path code/programs/mosaic/engram-app/Cargo.toml -- --nocapture`
- `./scripts/build-all.ps1` from `code/programs/mosaic/engram-app`
- `cargo run -p mosaic-compile -- pkg C:\Users\adhit\Downloads\coding-adventures\code\programs\mosaic\engram-app --backend react --output C:\Users\adhit\Downloads\coding-adventures\code\programs\mosaic\engram-app\target\mosaic-engram-app --emit-project`
- `npm install` and `npm run build` in the generated React demo
- `node js/smoke.mjs` from `code/packages/rust/engram-wasm`
