### PR TITLE
feat(adj-lang): second math frontend — asciimath "…" (PFE01)

### DIFF
--- a/code/grammars/adj_lang/adj_lang.grammar
+++ b/code/grammars/adj_lang/adj_lang.grammar
@@ -150,7 +150,7 @@ expr      = term_expr { ( PLUS | MINUS ) term_expr } ;
 
 term_expr = factor { ( STAR | SLASH ) factor } ;
 
-factor    = latex_expr | agg | NUMBER | IDENT | LPAREN expr RPAREN ;
+factor    = latex_expr | asciimath_expr | agg | NUMBER | IDENT | LPAREN expr RPAREN ;
 
 agg       = ( "sum" | "count" | "min" | "max" | "avg" ) LPAREN IDENT RPAREN ;
 
@@ -160,6 +160,17 @@ agg       = ( "sum" | "count" | "min" | "max" | "avg" ) LPAREN IDENT RPAREN ;
 # the same ExprAst used by ASCII formulas. Unsupported math is a compile error,
 # not a host-language fallback.
 latex_expr = "latex" STRING ;
+
+# Native AsciiMath math input — a SECOND math frontend behind the same neutral
+# `MathExpr` tree the LaTeX frontend produces (the pluggable-frontends thesis,
+# PFE01). A math-tuned model that prefers AsciiMath may write `asciimath "(a+b)/c"`
+# anywhere an ADJ arithmetic expression is accepted; the adj-lang frontend parses
+# the string with the repo's AsciiMath `MathFrontend` and lowers it through the
+# EXACT SAME `MathExpr -> ExprAst` lowering used for `latex "..."`. So the whole
+# arithmetic subset (fractions, products, sums, the named-function surface, ...)
+# is available for free — no new lowering, no new engine op. Unsupported math is
+# a compile error, not a host-language fallback, exactly as for `latex`.
+asciimath_expr = "asciimath" STRING ;
 
 # ----------------------------------------------------------------
 # Constraint sublanguage (ADJ constraints track B1). The model

--- a/code/packages/rust/adj-lang/CHANGELOG.md
+++ b/code/packages/rust/adj-lang/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## [0.46.0] - 2026-07-03 — a SECOND math frontend: `asciimath "…"` (pluggable frontends, PFE01)
+
+### Added
+
+- **`asciimath "<math>"`** is now accepted anywhere an ADJ arithmetic expression is (as an `expr`
+  factor), alongside the existing `latex "…"`. AsciiMath is a math dialect many math-tuned models
+  emit — e.g. `(a+b)/c`, `1/2`, `x*x` — and the repo already ships an `asciimath` `MathFrontend`
+  that parses it to the **same neutral `MathExpr`** tree the LaTeX frontend produces.
+- This is the **pluggable-frontends thesis (PFE01)** made concrete: the adapter's only
+  frontend-specific step is the parse call (`parse_asciimath_math`, the counterpart to
+  `parse_latex_math`). The resulting `MathExpr` flows through the **identical**
+  `latex_math_to_expr_ast` lowering, so the entire arithmetic + named-function surface
+  (fractions, products, sums, powers, the trig/hyperbolic families, …) is available to the
+  AsciiMath surface **for free** — no new lowering, and **no new engine op**.
+- New grammar production `asciimath_expr = "asciimath" STRING ;` (regenerated `_lexer_grammar.rs`
+  / `_parser_grammar.rs`); new `AdapterError::AsciiMathParse` for parse failures (unsupported
+  *nodes* still surface via the shared `UnsupportedLatexMath`, since the neutral-tree lowering
+  names its errors after the first frontend).
+- Three end-to-end tests through `compile_and_decide` prove it computes: `asciimath "(3+4)*2"` = 14,
+  `asciimath "(3+4)/2"` = 3.5 (reusing the very `MathExpr::Frac` lowering LaTeX `\frac` uses), and an
+  observed slot binding inside AsciiMath (`observe x(2)` + `asciimath "x*x"` = 4).
+- **Security/DoS:** the adapter adds **no new recursive tree-walker** — it reuses the existing
+  `latex_math_to_expr_ast` lowering. The AsciiMath parser owns its own recursion/DoS discipline in
+  its crate, so no new stack-overflow surface is introduced here (no new deep-input regression test
+  is warranted on the adapter side).
+
 ## [0.45.0] - 2026-07-03 — inverse hyperbolic functions (`arsinh`/`arcosh`/`artanh`) in `latex "…"`
 
 ### Added

--- a/code/packages/rust/adj-lang/Cargo.toml
+++ b/code/packages/rust/adj-lang/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "adj-lang"
-version = "0.45.0"
+version = "0.46.0"
 edition = "2021"
 description = "Surface-syntax frontend for the adjudication framework's probabilistic-logic rulebooks. Lexes, parses, and lowers a domain-expert-readable DSL into a `logic-engine` KnowledgeBase. Dissolves ADJ46 awkwardness items A10 (rulebook syntax) and A4 (joint contributions syntactically distinct)."
 
 [dependencies]
+asciimath = { path = "../asciimath" }
 grammar-tools = { path = "../grammar-tools" }
 latex = { path = "../latex" }
 lexer = { path = "../lexer" }

--- a/code/packages/rust/adj-lang/src/_lexer_grammar.rs
+++ b/code/packages/rust/adj-lang/src/_lexer_grammar.rs
@@ -6,9 +6,7 @@
 // Call `token_grammar()` instead of reading and parsing the .tokens file.
 
 #[allow(unused_imports)]
-use grammar_tools::token_grammar::{
-    ModeTransition, PatternGroup, TokenDefinition, TokenGrammar, TransitionAction,
-};
+use grammar_tools::token_grammar::{ModeTransition, PatternGroup, TokenDefinition, TokenGrammar, TransitionAction};
 #[allow(unused_imports)]
 use std::collections::HashMap;
 
@@ -184,27 +182,7 @@ pub fn token_grammar() -> TokenGrammar {
                 alias: None,
             },
         ],
-        keywords: vec![
-            r#"prior"#.to_string(),
-            r#"for"#.to_string(),
-            r#"contributes"#.to_string(),
-            r#"from"#.to_string(),
-            r#"to"#.to_string(),
-            r#"interacts"#.to_string(),
-            r#"when"#.to_string(),
-            r#"and"#.to_string(),
-            r#"observe"#.to_string(),
-            r#"uncertain"#.to_string(),
-            r#"source"#.to_string(),
-            r#"trust"#.to_string(),
-            r#"locator"#.to_string(),
-            r#"cites"#.to_string(),
-            r#"consensus"#.to_string(),
-            r#"authoritative"#.to_string(),
-            r#"empirical"#.to_string(),
-            r#"inferred"#.to_string(),
-            r#"unattributed"#.to_string(),
-        ],
+        keywords: vec![r#"prior"#.to_string(), r#"for"#.to_string(), r#"contributes"#.to_string(), r#"from"#.to_string(), r#"to"#.to_string(), r#"interacts"#.to_string(), r#"when"#.to_string(), r#"and"#.to_string(), r#"observe"#.to_string(), r#"uncertain"#.to_string(), r#"source"#.to_string(), r#"trust"#.to_string(), r#"locator"#.to_string(), r#"cites"#.to_string(), r#"consensus"#.to_string(), r#"authoritative"#.to_string(), r#"empirical"#.to_string(), r#"inferred"#.to_string(), r#"unattributed"#.to_string()],
         mode: None,
         skip_definitions: vec![
             TokenDefinition {

--- a/code/packages/rust/adj-lang/src/_parser_grammar.rs
+++ b/code/packages/rust/adj-lang/src/_parser_grammar.rs
@@ -10,1196 +10,549 @@ use grammar_tools::parser_grammar::{GrammarElement, GrammarRule, ParserGrammar};
 pub fn parser_grammar() -> ParserGrammar {
     ParserGrammar {
         rules: vec![
-            GrammarRule {
-                name: r#"program"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Repetition {
-                            element: Box::new(GrammarElement::RuleReference {
-                                name: r#"statement"#.to_string(),
-                            }),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"EOF"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 20,
-            },
-            GrammarRule {
-                name: r#"statement"#.to_string(),
-                body: GrammarElement::Alternation {
-                    choices: vec![
-                        GrammarElement::RuleReference {
-                            name: r#"prior_decl"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"contributes_decl"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"interacts_decl"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"uncertain_decl"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"observe_decl"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"relate_decl"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"rule_decl"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"functional_decl"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"context_order_decl"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"query_decl"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"let_decl"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"symbol_decl"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"constrain_latex_decl"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"constrain_decl"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"solve_decl"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"check_decl"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"optimize_decl"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"dictionary_decl"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"define_decl"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"rulebook_decl"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"use_decl"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"import_decl"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 22,
-            },
-            GrammarRule {
-                name: r#"prior_decl"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"prior"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"NUMBER"#.to_string(),
-                        },
-                        GrammarElement::Literal {
-                            value: r#"for"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"term"#.to_string(),
-                        },
-                        GrammarElement::Repetition {
-                            element: Box::new(GrammarElement::RuleReference {
-                                name: r#"annotation"#.to_string(),
-                            }),
-                        },
-                    ],
-                },
-                line_number: 51,
-            },
-            GrammarRule {
-                name: r#"contributes_decl"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"contributes"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"NUMBER"#.to_string(),
-                        },
-                        GrammarElement::Literal {
-                            value: r#"from"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"evidence"#.to_string(),
-                        },
-                        GrammarElement::Literal {
-                            value: r#"to"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"term"#.to_string(),
-                        },
-                        GrammarElement::Repetition {
-                            element: Box::new(GrammarElement::RuleReference {
-                                name: r#"annotation"#.to_string(),
-                            }),
-                        },
-                    ],
-                },
-                line_number: 53,
-            },
-            GrammarRule {
-                name: r#"evidence"#.to_string(),
-                body: GrammarElement::Alternation {
-                    choices: vec![
-                        GrammarElement::RuleReference {
-                            name: r#"predicate"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"term"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 64,
-            },
-            GrammarRule {
-                name: r#"predicate"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::TokenReference {
-                            name: r#"IDENT"#.to_string(),
-                        },
-                        GrammarElement::Group {
-                            element: Box::new(GrammarElement::Alternation {
-                                choices: vec![
-                                    GrammarElement::TokenReference {
-                                        name: r#"GE"#.to_string(),
-                                    },
-                                    GrammarElement::TokenReference {
-                                        name: r#"LE"#.to_string(),
-                                    },
-                                    GrammarElement::TokenReference {
-                                        name: r#"GT"#.to_string(),
-                                    },
-                                    GrammarElement::TokenReference {
-                                        name: r#"LT"#.to_string(),
-                                    },
-                                    GrammarElement::TokenReference {
-                                        name: r#"EQEQ"#.to_string(),
-                                    },
-                                ],
-                            }),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"expr"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 66,
-            },
-            GrammarRule {
-                name: r#"interacts_decl"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"interacts"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"NUMBER"#.to_string(),
-                        },
-                        GrammarElement::Literal {
-                            value: r#"when"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"term"#.to_string(),
-                        },
-                        GrammarElement::Literal {
-                            value: r#"and"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"term"#.to_string(),
-                        },
-                        GrammarElement::Repetition {
-                            element: Box::new(GrammarElement::Sequence {
-                                elements: vec![
-                                    GrammarElement::Literal {
-                                        value: r#"and"#.to_string(),
-                                    },
-                                    GrammarElement::RuleReference {
-                                        name: r#"term"#.to_string(),
-                                    },
-                                ],
-                            }),
-                        },
-                        GrammarElement::Literal {
-                            value: r#"for"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"term"#.to_string(),
-                        },
-                        GrammarElement::Repetition {
-                            element: Box::new(GrammarElement::RuleReference {
-                                name: r#"annotation"#.to_string(),
-                            }),
-                        },
-                    ],
-                },
-                line_number: 68,
-            },
-            GrammarRule {
-                name: r#"uncertain_decl"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"uncertain"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"LBRACE"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"term"#.to_string(),
-                        },
-                        GrammarElement::Repetition {
-                            element: Box::new(GrammarElement::Sequence {
-                                elements: vec![
-                                    GrammarElement::TokenReference {
-                                        name: r#"COMMA"#.to_string(),
-                                    },
-                                    GrammarElement::RuleReference {
-                                        name: r#"term"#.to_string(),
-                                    },
-                                ],
-                            }),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"RBRACE"#.to_string(),
-                        },
-                        GrammarElement::Literal {
-                            value: r#"for"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"term"#.to_string(),
-                        },
-                        GrammarElement::Repetition {
-                            element: Box::new(GrammarElement::RuleReference {
-                                name: r#"annotation"#.to_string(),
-                            }),
-                        },
-                    ],
-                },
-                line_number: 70,
-            },
-            GrammarRule {
-                name: r#"observe_decl"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"observe"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"term"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 72,
-            },
-            GrammarRule {
-                name: r#"relate_decl"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"relate"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"term"#.to_string(),
-                        },
-                        GrammarElement::Repetition {
-                            element: Box::new(GrammarElement::RuleReference {
-                                name: r#"annotation"#.to_string(),
-                            }),
-                        },
-                    ],
-                },
-                line_number: 85,
-            },
-            GrammarRule {
-                name: r#"rule_decl"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"rule"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"LBRACE"#.to_string(),
-                        },
-                        GrammarElement::Literal {
-                            value: r#"head"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"COLON"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"term"#.to_string(),
-                        },
-                        GrammarElement::Literal {
-                            value: r#"when"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"COLON"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"body_literal"#.to_string(),
-                        },
-                        GrammarElement::Repetition {
-                            element: Box::new(GrammarElement::Sequence {
-                                elements: vec![
-                                    GrammarElement::TokenReference {
-                                        name: r#"COMMA"#.to_string(),
-                                    },
-                                    GrammarElement::RuleReference {
-                                        name: r#"body_literal"#.to_string(),
-                                    },
-                                ],
-                            }),
-                        },
-                        GrammarElement::Repetition {
-                            element: Box::new(GrammarElement::RuleReference {
-                                name: r#"annotation"#.to_string(),
-                            }),
-                        },
-                        GrammarElement::Optional {
-                            element: Box::new(GrammarElement::Sequence {
-                                elements: vec![
-                                    GrammarElement::Literal {
-                                        value: r#"priority"#.to_string(),
-                                    },
-                                    GrammarElement::TokenReference {
-                                        name: r#"COLON"#.to_string(),
-                                    },
-                                    GrammarElement::TokenReference {
-                                        name: r#"IDENT"#.to_string(),
-                                    },
-                                ],
-                            }),
-                        },
-                        GrammarElement::Optional {
-                            element: Box::new(GrammarElement::Sequence {
-                                elements: vec![
-                                    GrammarElement::Literal {
-                                        value: r#"context"#.to_string(),
-                                    },
-                                    GrammarElement::TokenReference {
-                                        name: r#"COLON"#.to_string(),
-                                    },
-                                    GrammarElement::TokenReference {
-                                        name: r#"IDENT"#.to_string(),
-                                    },
-                                ],
-                            }),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"RBRACE"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 107,
-            },
-            GrammarRule {
-                name: r#"body_literal"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Optional {
-                            element: Box::new(GrammarElement::Literal {
-                                value: r#"not"#.to_string(),
-                            }),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"term"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 109,
-            },
-            GrammarRule {
-                name: r#"context_order_decl"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"context_order"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"LBRACE"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"IDENT"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"GT"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"IDENT"#.to_string(),
-                        },
-                        GrammarElement::Repetition {
-                            element: Box::new(GrammarElement::Sequence {
-                                elements: vec![
-                                    GrammarElement::TokenReference {
-                                        name: r#"COMMA"#.to_string(),
-                                    },
-                                    GrammarElement::TokenReference {
-                                        name: r#"IDENT"#.to_string(),
-                                    },
-                                    GrammarElement::TokenReference {
-                                        name: r#"GT"#.to_string(),
-                                    },
-                                    GrammarElement::TokenReference {
-                                        name: r#"IDENT"#.to_string(),
-                                    },
-                                ],
-                            }),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"RBRACE"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 120,
-            },
-            GrammarRule {
-                name: r#"functional_decl"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"functional"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"term"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 131,
-            },
-            GrammarRule {
-                name: r#"query_decl"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::TokenReference {
-                            name: r#"QUESTION"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"term"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 133,
-            },
-            GrammarRule {
-                name: r#"let_decl"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"let"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"IDENT"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"EQUALS"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"expr"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 147,
-            },
-            GrammarRule {
-                name: r#"expr"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::RuleReference {
-                            name: r#"term_expr"#.to_string(),
-                        },
-                        GrammarElement::Repetition {
-                            element: Box::new(GrammarElement::Sequence {
-                                elements: vec![
-                                    GrammarElement::Group {
-                                        element: Box::new(GrammarElement::Alternation {
-                                            choices: vec![
-                                                GrammarElement::TokenReference {
-                                                    name: r#"PLUS"#.to_string(),
-                                                },
-                                                GrammarElement::TokenReference {
-                                                    name: r#"MINUS"#.to_string(),
-                                                },
-                                            ],
-                                        }),
-                                    },
-                                    GrammarElement::RuleReference {
-                                        name: r#"term_expr"#.to_string(),
-                                    },
-                                ],
-                            }),
-                        },
-                    ],
-                },
-                line_number: 149,
-            },
-            GrammarRule {
-                name: r#"term_expr"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::RuleReference {
-                            name: r#"factor"#.to_string(),
-                        },
-                        GrammarElement::Repetition {
-                            element: Box::new(GrammarElement::Sequence {
-                                elements: vec![
-                                    GrammarElement::Group {
-                                        element: Box::new(GrammarElement::Alternation {
-                                            choices: vec![
-                                                GrammarElement::TokenReference {
-                                                    name: r#"STAR"#.to_string(),
-                                                },
-                                                GrammarElement::TokenReference {
-                                                    name: r#"SLASH"#.to_string(),
-                                                },
-                                            ],
-                                        }),
-                                    },
-                                    GrammarElement::RuleReference {
-                                        name: r#"factor"#.to_string(),
-                                    },
-                                ],
-                            }),
-                        },
-                    ],
-                },
-                line_number: 151,
-            },
-            GrammarRule {
-                name: r#"factor"#.to_string(),
-                body: GrammarElement::Alternation {
-                    choices: vec![
-                        GrammarElement::RuleReference {
-                            name: r#"latex_expr"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"agg"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"NUMBER"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"IDENT"#.to_string(),
-                        },
-                        GrammarElement::Sequence {
-                            elements: vec![
-                                GrammarElement::TokenReference {
-                                    name: r#"LPAREN"#.to_string(),
-                                },
-                                GrammarElement::RuleReference {
-                                    name: r#"expr"#.to_string(),
-                                },
-                                GrammarElement::TokenReference {
-                                    name: r#"RPAREN"#.to_string(),
-                                },
-                            ],
-                        },
-                    ],
-                },
-                line_number: 153,
-            },
-            GrammarRule {
-                name: r#"agg"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Group {
-                            element: Box::new(GrammarElement::Alternation {
-                                choices: vec![
-                                    GrammarElement::Literal {
-                                        value: r#"sum"#.to_string(),
-                                    },
-                                    GrammarElement::Literal {
-                                        value: r#"count"#.to_string(),
-                                    },
-                                    GrammarElement::Literal {
-                                        value: r#"min"#.to_string(),
-                                    },
-                                    GrammarElement::Literal {
-                                        value: r#"max"#.to_string(),
-                                    },
-                                    GrammarElement::Literal {
-                                        value: r#"avg"#.to_string(),
-                                    },
-                                ],
-                            }),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"LPAREN"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"IDENT"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"RPAREN"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 155,
-            },
-            GrammarRule {
-                name: r#"latex_expr"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"latex"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"STRING"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 162,
-            },
-            GrammarRule {
-                name: r#"symbol_decl"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"symbol"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"IDENT"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"COLON"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"term"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 172,
-            },
-            GrammarRule {
-                name: r#"constrain_latex_decl"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"constrain"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"latex_relation"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 174,
-            },
-            GrammarRule {
-                name: r#"constrain_decl"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"constrain"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"expr"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"relop"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"expr"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 176,
-            },
-            GrammarRule {
-                name: r#"latex_relation"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"latex"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"STRING"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 178,
-            },
-            GrammarRule {
-                name: r#"relop"#.to_string(),
-                body: GrammarElement::Alternation {
-                    choices: vec![
-                        GrammarElement::TokenReference {
-                            name: r#"GE"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"LE"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"GT"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"LT"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"EQEQ"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"EQUALS"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"NE"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 180,
-            },
-            GrammarRule {
-                name: r#"solve_decl"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"solve"#.to_string(),
-                        },
-                        GrammarElement::Literal {
-                            value: r#"for"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"LBRACE"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"IDENT"#.to_string(),
-                        },
-                        GrammarElement::Repetition {
-                            element: Box::new(GrammarElement::Sequence {
-                                elements: vec![
-                                    GrammarElement::TokenReference {
-                                        name: r#"COMMA"#.to_string(),
-                                    },
-                                    GrammarElement::TokenReference {
-                                        name: r#"IDENT"#.to_string(),
-                                    },
-                                ],
-                            }),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"RBRACE"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 182,
-            },
-            GrammarRule {
-                name: r#"check_decl"#.to_string(),
-                body: GrammarElement::Literal {
-                    value: r#"check"#.to_string(),
-                },
-                line_number: 184,
-            },
-            GrammarRule {
-                name: r#"optimize_decl"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Group {
-                            element: Box::new(GrammarElement::Alternation {
-                                choices: vec![
-                                    GrammarElement::Literal {
-                                        value: r#"minimize"#.to_string(),
-                                    },
-                                    GrammarElement::Literal {
-                                        value: r#"maximize"#.to_string(),
-                                    },
-                                ],
-                            }),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"expr"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 191,
-            },
-            GrammarRule {
-                name: r#"dictionary_decl"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"dictionary"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"IDENT"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"LBRACE"#.to_string(),
-                        },
-                        GrammarElement::Repetition {
-                            element: Box::new(GrammarElement::RuleReference {
-                                name: r#"define_decl"#.to_string(),
-                            }),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"RBRACE"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 203,
-            },
-            GrammarRule {
-                name: r#"define_decl"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"define"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"IDENT"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"COLON"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"define_kind"#.to_string(),
-                        },
-                        GrammarElement::Repetition {
-                            element: Box::new(GrammarElement::RuleReference {
-                                name: r#"surface_clause"#.to_string(),
-                            }),
-                        },
-                    ],
-                },
-                line_number: 205,
-            },
-            GrammarRule {
-                name: r#"define_kind"#.to_string(),
-                body: GrammarElement::Alternation {
-                    choices: vec![
-                        GrammarElement::Literal {
-                            value: r#"hypothesis"#.to_string(),
-                        },
-                        GrammarElement::Sequence {
-                            elements: vec![
-                                GrammarElement::Literal {
-                                    value: r#"finding"#.to_string(),
-                                },
-                                GrammarElement::Optional {
-                                    element: Box::new(GrammarElement::Sequence {
-                                        elements: vec![
-                                            GrammarElement::Literal {
-                                                value: r#"values"#.to_string(),
-                                            },
-                                            GrammarElement::TokenReference {
-                                                name: r#"LBRACK"#.to_string(),
-                                            },
-                                            GrammarElement::TokenReference {
-                                                name: r#"IDENT"#.to_string(),
-                                            },
-                                            GrammarElement::Repetition {
-                                                element: Box::new(GrammarElement::Sequence {
-                                                    elements: vec![
-                                                        GrammarElement::TokenReference {
-                                                            name: r#"COMMA"#.to_string(),
-                                                        },
-                                                        GrammarElement::TokenReference {
-                                                            name: r#"IDENT"#.to_string(),
-                                                        },
-                                                    ],
-                                                }),
-                                            },
-                                            GrammarElement::TokenReference {
-                                                name: r#"RBRACK"#.to_string(),
-                                            },
-                                        ],
-                                    }),
-                                },
-                            ],
-                        },
-                        GrammarElement::Literal {
-                            value: r#"entity"#.to_string(),
-                        },
-                        GrammarElement::Sequence {
-                            elements: vec![
-                                GrammarElement::Literal {
-                                    value: r#"relation"#.to_string(),
-                                },
-                                GrammarElement::Literal {
-                                    value: r#"from"#.to_string(),
-                                },
-                                GrammarElement::TokenReference {
-                                    name: r#"IDENT"#.to_string(),
-                                },
-                                GrammarElement::Literal {
-                                    value: r#"to"#.to_string(),
-                                },
-                                GrammarElement::TokenReference {
-                                    name: r#"IDENT"#.to_string(),
-                                },
-                            ],
-                        },
-                    ],
-                },
-                line_number: 207,
-            },
-            GrammarRule {
-                name: r#"surface_clause"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"surface"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"STRING"#.to_string(),
-                        },
-                        GrammarElement::Repetition {
-                            element: Box::new(GrammarElement::Sequence {
-                                elements: vec![
-                                    GrammarElement::TokenReference {
-                                        name: r#"COMMA"#.to_string(),
-                                    },
-                                    GrammarElement::TokenReference {
-                                        name: r#"STRING"#.to_string(),
-                                    },
-                                ],
-                            }),
-                        },
-                    ],
-                },
-                line_number: 213,
-            },
-            GrammarRule {
-                name: r#"rulebook_decl"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"rulebook"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"IDENT"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"LBRACE"#.to_string(),
-                        },
-                        GrammarElement::Repetition {
-                            element: Box::new(GrammarElement::RuleReference {
-                                name: r#"statement"#.to_string(),
-                            }),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"RBRACE"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 230,
-            },
-            GrammarRule {
-                name: r#"use_decl"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"use"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"IDENT"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 232,
-            },
-            GrammarRule {
-                name: r#"import_decl"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"import"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"STRING"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 248,
-            },
-            GrammarRule {
-                name: r#"annotation"#.to_string(),
-                body: GrammarElement::Alternation {
-                    choices: vec![
-                        GrammarElement::RuleReference {
-                            name: r#"source_annotation"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"locator_annotation"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"trust_annotation"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"cites_annotation"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 260,
-            },
-            GrammarRule {
-                name: r#"source_annotation"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"source"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"STRING"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 266,
-            },
-            GrammarRule {
-                name: r#"locator_annotation"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"locator"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"STRING"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 267,
-            },
-            GrammarRule {
-                name: r#"trust_annotation"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"trust"#.to_string(),
-                        },
-                        GrammarElement::RuleReference {
-                            name: r#"trust_tier"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 268,
-            },
-            GrammarRule {
-                name: r#"cites_annotation"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::Literal {
-                            value: r#"cites"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"STRING"#.to_string(),
-                        },
-                        GrammarElement::Literal {
-                            value: r#"locator"#.to_string(),
-                        },
-                        GrammarElement::TokenReference {
-                            name: r#"STRING"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 269,
-            },
-            GrammarRule {
-                name: r#"trust_tier"#.to_string(),
-                body: GrammarElement::Alternation {
-                    choices: vec![
-                        GrammarElement::Literal {
-                            value: r#"consensus"#.to_string(),
-                        },
-                        GrammarElement::Literal {
-                            value: r#"authoritative"#.to_string(),
-                        },
-                        GrammarElement::Literal {
-                            value: r#"empirical"#.to_string(),
-                        },
-                        GrammarElement::Literal {
-                            value: r#"inferred"#.to_string(),
-                        },
-                        GrammarElement::Literal {
-                            value: r#"unattributed"#.to_string(),
-                        },
-                    ],
-                },
-                line_number: 271,
-            },
-            GrammarRule {
-                name: r#"term"#.to_string(),
-                body: GrammarElement::Sequence {
-                    elements: vec![
-                        GrammarElement::TokenReference {
-                            name: r#"IDENT"#.to_string(),
-                        },
-                        GrammarElement::Optional {
-                            element: Box::new(GrammarElement::Sequence {
-                                elements: vec![
-                                    GrammarElement::TokenReference {
-                                        name: r#"LPAREN"#.to_string(),
-                                    },
-                                    GrammarElement::Group {
-                                        element: Box::new(GrammarElement::Alternation {
-                                            choices: vec![
-                                                GrammarElement::RuleReference {
-                                                    name: r#"term"#.to_string(),
-                                                },
-                                                GrammarElement::TokenReference {
-                                                    name: r#"NUMBER"#.to_string(),
-                                                },
-                                                GrammarElement::TokenReference {
-                                                    name: r#"VAR"#.to_string(),
-                                                },
-                                            ],
-                                        }),
-                                    },
-                                    GrammarElement::Repetition {
-                                        element: Box::new(GrammarElement::Sequence {
-                                            elements: vec![
-                                                GrammarElement::TokenReference {
-                                                    name: r#"COMMA"#.to_string(),
-                                                },
-                                                GrammarElement::Group {
-                                                    element: Box::new(
-                                                        GrammarElement::Alternation {
-                                                            choices: vec![
-                                                                GrammarElement::RuleReference {
-                                                                    name: r#"term"#.to_string(),
-                                                                },
-                                                                GrammarElement::TokenReference {
-                                                                    name: r#"NUMBER"#.to_string(),
-                                                                },
-                                                                GrammarElement::TokenReference {
-                                                                    name: r#"VAR"#.to_string(),
-                                                                },
-                                                            ],
-                                                        },
-                                                    ),
-                                                },
-                                            ],
-                                        }),
-                                    },
-                                    GrammarElement::TokenReference {
-                                        name: r#"RPAREN"#.to_string(),
-                                    },
-                                ],
-                            }),
-                        },
-                    ],
-                },
-                line_number: 293,
-            },
-        ],
+        GrammarRule {
+            name: r#"program"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"statement"#.to_string() }) },
+                GrammarElement::TokenReference { name: r#"EOF"#.to_string() },
+            ] },
+            line_number: 20,
+        },
+        GrammarRule {
+            name: r#"statement"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::RuleReference { name: r#"prior_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"contributes_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"interacts_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"uncertain_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"observe_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"relate_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"rule_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"functional_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"context_order_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"query_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"let_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"symbol_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"constrain_latex_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"constrain_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"solve_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"check_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"optimize_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"dictionary_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"define_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"rulebook_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"use_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"import_decl"#.to_string() },
+            ] },
+            line_number: 22,
+        },
+        GrammarRule {
+            name: r#"prior_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"prior"#.to_string() },
+                GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() },
+                GrammarElement::Literal { value: r#"for"#.to_string() },
+                GrammarElement::RuleReference { name: r#"term"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
+            ] },
+            line_number: 51,
+        },
+        GrammarRule {
+            name: r#"contributes_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"contributes"#.to_string() },
+                GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() },
+                GrammarElement::Literal { value: r#"from"#.to_string() },
+                GrammarElement::RuleReference { name: r#"evidence"#.to_string() },
+                GrammarElement::Literal { value: r#"to"#.to_string() },
+                GrammarElement::RuleReference { name: r#"term"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
+            ] },
+            line_number: 53,
+        },
+        GrammarRule {
+            name: r#"evidence"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::RuleReference { name: r#"predicate"#.to_string() },
+                GrammarElement::RuleReference { name: r#"term"#.to_string() },
+            ] },
+            line_number: 64,
+        },
+        GrammarRule {
+            name: r#"predicate"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                        GrammarElement::TokenReference { name: r#"GE"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"LE"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"GT"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"LT"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"EQEQ"#.to_string() },
+                    ] }) },
+                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+            ] },
+            line_number: 66,
+        },
+        GrammarRule {
+            name: r#"interacts_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"interacts"#.to_string() },
+                GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() },
+                GrammarElement::Literal { value: r#"when"#.to_string() },
+                GrammarElement::RuleReference { name: r#"term"#.to_string() },
+                GrammarElement::Literal { value: r#"and"#.to_string() },
+                GrammarElement::RuleReference { name: r#"term"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Literal { value: r#"and"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"term"#.to_string() },
+                    ] }) },
+                GrammarElement::Literal { value: r#"for"#.to_string() },
+                GrammarElement::RuleReference { name: r#"term"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
+            ] },
+            line_number: 68,
+        },
+        GrammarRule {
+            name: r#"uncertain_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"uncertain"#.to_string() },
+                GrammarElement::TokenReference { name: r#"LBRACE"#.to_string() },
+                GrammarElement::RuleReference { name: r#"term"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"term"#.to_string() },
+                    ] }) },
+                GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
+                GrammarElement::Literal { value: r#"for"#.to_string() },
+                GrammarElement::RuleReference { name: r#"term"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
+            ] },
+            line_number: 70,
+        },
+        GrammarRule {
+            name: r#"observe_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"observe"#.to_string() },
+                GrammarElement::RuleReference { name: r#"term"#.to_string() },
+            ] },
+            line_number: 72,
+        },
+        GrammarRule {
+            name: r#"relate_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"relate"#.to_string() },
+                GrammarElement::RuleReference { name: r#"term"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
+            ] },
+            line_number: 85,
+        },
+        GrammarRule {
+            name: r#"rule_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"rule"#.to_string() },
+                GrammarElement::TokenReference { name: r#"LBRACE"#.to_string() },
+                GrammarElement::Literal { value: r#"head"#.to_string() },
+                GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
+                GrammarElement::RuleReference { name: r#"term"#.to_string() },
+                GrammarElement::Literal { value: r#"when"#.to_string() },
+                GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
+                GrammarElement::RuleReference { name: r#"body_literal"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"body_literal"#.to_string() },
+                    ] }) },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Literal { value: r#"priority"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                    ] }) },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Literal { value: r#"context"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                    ] }) },
+                GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
+            ] },
+            line_number: 107,
+        },
+        GrammarRule {
+            name: r#"body_literal"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Optional { element: Box::new(GrammarElement::Literal { value: r#"not"#.to_string() }) },
+                GrammarElement::RuleReference { name: r#"term"#.to_string() },
+            ] },
+            line_number: 109,
+        },
+        GrammarRule {
+            name: r#"context_order_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"context_order"#.to_string() },
+                GrammarElement::TokenReference { name: r#"LBRACE"#.to_string() },
+                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                GrammarElement::TokenReference { name: r#"GT"#.to_string() },
+                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"GT"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                    ] }) },
+                GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
+            ] },
+            line_number: 120,
+        },
+        GrammarRule {
+            name: r#"functional_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"functional"#.to_string() },
+                GrammarElement::RuleReference { name: r#"term"#.to_string() },
+            ] },
+            line_number: 131,
+        },
+        GrammarRule {
+            name: r#"query_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"QUESTION"#.to_string() },
+                GrammarElement::RuleReference { name: r#"term"#.to_string() },
+            ] },
+            line_number: 133,
+        },
+        GrammarRule {
+            name: r#"let_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"let"#.to_string() },
+                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                GrammarElement::TokenReference { name: r#"EQUALS"#.to_string() },
+                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+            ] },
+            line_number: 147,
+        },
+        GrammarRule {
+            name: r#"expr"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"term_expr"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                                GrammarElement::TokenReference { name: r#"PLUS"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"MINUS"#.to_string() },
+                            ] }) },
+                        GrammarElement::RuleReference { name: r#"term_expr"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 149,
+        },
+        GrammarRule {
+            name: r#"term_expr"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"factor"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                                GrammarElement::TokenReference { name: r#"STAR"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"SLASH"#.to_string() },
+                            ] }) },
+                        GrammarElement::RuleReference { name: r#"factor"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 151,
+        },
+        GrammarRule {
+            name: r#"factor"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::RuleReference { name: r#"latex_expr"#.to_string() },
+                GrammarElement::RuleReference { name: r#"asciimath_expr"#.to_string() },
+                GrammarElement::RuleReference { name: r#"agg"#.to_string() },
+                GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() },
+                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::TokenReference { name: r#"LPAREN"#.to_string() },
+                    GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                    GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
+                ] },
+            ] },
+            line_number: 153,
+        },
+        GrammarRule {
+            name: r#"agg"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                        GrammarElement::Literal { value: r#"sum"#.to_string() },
+                        GrammarElement::Literal { value: r#"count"#.to_string() },
+                        GrammarElement::Literal { value: r#"min"#.to_string() },
+                        GrammarElement::Literal { value: r#"max"#.to_string() },
+                        GrammarElement::Literal { value: r#"avg"#.to_string() },
+                    ] }) },
+                GrammarElement::TokenReference { name: r#"LPAREN"#.to_string() },
+                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
+            ] },
+            line_number: 155,
+        },
+        GrammarRule {
+            name: r#"latex_expr"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"latex"#.to_string() },
+                GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
+            ] },
+            line_number: 162,
+        },
+        GrammarRule {
+            name: r#"asciimath_expr"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"asciimath"#.to_string() },
+                GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
+            ] },
+            line_number: 173,
+        },
+        GrammarRule {
+            name: r#"symbol_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"symbol"#.to_string() },
+                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
+                GrammarElement::RuleReference { name: r#"term"#.to_string() },
+            ] },
+            line_number: 183,
+        },
+        GrammarRule {
+            name: r#"constrain_latex_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"constrain"#.to_string() },
+                GrammarElement::RuleReference { name: r#"latex_relation"#.to_string() },
+            ] },
+            line_number: 185,
+        },
+        GrammarRule {
+            name: r#"constrain_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"constrain"#.to_string() },
+                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                GrammarElement::RuleReference { name: r#"relop"#.to_string() },
+                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+            ] },
+            line_number: 187,
+        },
+        GrammarRule {
+            name: r#"latex_relation"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"latex"#.to_string() },
+                GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
+            ] },
+            line_number: 189,
+        },
+        GrammarRule {
+            name: r#"relop"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::TokenReference { name: r#"GE"#.to_string() },
+                GrammarElement::TokenReference { name: r#"LE"#.to_string() },
+                GrammarElement::TokenReference { name: r#"GT"#.to_string() },
+                GrammarElement::TokenReference { name: r#"LT"#.to_string() },
+                GrammarElement::TokenReference { name: r#"EQEQ"#.to_string() },
+                GrammarElement::TokenReference { name: r#"EQUALS"#.to_string() },
+                GrammarElement::TokenReference { name: r#"NE"#.to_string() },
+            ] },
+            line_number: 191,
+        },
+        GrammarRule {
+            name: r#"solve_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"solve"#.to_string() },
+                GrammarElement::Literal { value: r#"for"#.to_string() },
+                GrammarElement::TokenReference { name: r#"LBRACE"#.to_string() },
+                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                    ] }) },
+                GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
+            ] },
+            line_number: 193,
+        },
+        GrammarRule {
+            name: r#"check_decl"#.to_string(),
+            body: GrammarElement::Literal { value: r#"check"#.to_string() },
+            line_number: 195,
+        },
+        GrammarRule {
+            name: r#"optimize_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                        GrammarElement::Literal { value: r#"minimize"#.to_string() },
+                        GrammarElement::Literal { value: r#"maximize"#.to_string() },
+                    ] }) },
+                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+            ] },
+            line_number: 202,
+        },
+        GrammarRule {
+            name: r#"dictionary_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"dictionary"#.to_string() },
+                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                GrammarElement::TokenReference { name: r#"LBRACE"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"define_decl"#.to_string() }) },
+                GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
+            ] },
+            line_number: 214,
+        },
+        GrammarRule {
+            name: r#"define_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"define"#.to_string() },
+                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
+                GrammarElement::RuleReference { name: r#"define_kind"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"surface_clause"#.to_string() }) },
+            ] },
+            line_number: 216,
+        },
+        GrammarRule {
+            name: r#"define_kind"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::Literal { value: r#"hypothesis"#.to_string() },
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::Literal { value: r#"finding"#.to_string() },
+                    GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                            GrammarElement::Literal { value: r#"values"#.to_string() },
+                            GrammarElement::TokenReference { name: r#"LBRACK"#.to_string() },
+                            GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                            GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                                    GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
+                                    GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                                ] }) },
+                            GrammarElement::TokenReference { name: r#"RBRACK"#.to_string() },
+                        ] }) },
+                ] },
+                GrammarElement::Literal { value: r#"entity"#.to_string() },
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::Literal { value: r#"relation"#.to_string() },
+                    GrammarElement::Literal { value: r#"from"#.to_string() },
+                    GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                    GrammarElement::Literal { value: r#"to"#.to_string() },
+                    GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                ] },
+            ] },
+            line_number: 218,
+        },
+        GrammarRule {
+            name: r#"surface_clause"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"surface"#.to_string() },
+                GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 224,
+        },
+        GrammarRule {
+            name: r#"rulebook_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"rulebook"#.to_string() },
+                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                GrammarElement::TokenReference { name: r#"LBRACE"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"statement"#.to_string() }) },
+                GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
+            ] },
+            line_number: 241,
+        },
+        GrammarRule {
+            name: r#"use_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"use"#.to_string() },
+                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+            ] },
+            line_number: 243,
+        },
+        GrammarRule {
+            name: r#"import_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"import"#.to_string() },
+                GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
+            ] },
+            line_number: 259,
+        },
+        GrammarRule {
+            name: r#"annotation"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::RuleReference { name: r#"source_annotation"#.to_string() },
+                GrammarElement::RuleReference { name: r#"locator_annotation"#.to_string() },
+                GrammarElement::RuleReference { name: r#"trust_annotation"#.to_string() },
+                GrammarElement::RuleReference { name: r#"cites_annotation"#.to_string() },
+            ] },
+            line_number: 271,
+        },
+        GrammarRule {
+            name: r#"source_annotation"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"source"#.to_string() },
+                GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
+            ] },
+            line_number: 277,
+        },
+        GrammarRule {
+            name: r#"locator_annotation"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"locator"#.to_string() },
+                GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
+            ] },
+            line_number: 278,
+        },
+        GrammarRule {
+            name: r#"trust_annotation"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"trust"#.to_string() },
+                GrammarElement::RuleReference { name: r#"trust_tier"#.to_string() },
+            ] },
+            line_number: 279,
+        },
+        GrammarRule {
+            name: r#"cites_annotation"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"cites"#.to_string() },
+                GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
+                GrammarElement::Literal { value: r#"locator"#.to_string() },
+                GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
+            ] },
+            line_number: 280,
+        },
+        GrammarRule {
+            name: r#"trust_tier"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::Literal { value: r#"consensus"#.to_string() },
+                GrammarElement::Literal { value: r#"authoritative"#.to_string() },
+                GrammarElement::Literal { value: r#"empirical"#.to_string() },
+                GrammarElement::Literal { value: r#"inferred"#.to_string() },
+                GrammarElement::Literal { value: r#"unattributed"#.to_string() },
+            ] },
+            line_number: 282,
+        },
+        GrammarRule {
+            name: r#"term"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"LPAREN"#.to_string() },
+                        GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                                GrammarElement::RuleReference { name: r#"term"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"VAR"#.to_string() },
+                            ] }) },
+                        GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                                GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
+                                GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                                        GrammarElement::RuleReference { name: r#"term"#.to_string() },
+                                        GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() },
+                                        GrammarElement::TokenReference { name: r#"VAR"#.to_string() },
+                                    ] }) },
+                            ] }) },
+                        GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 304,
+        },
+    ],
         version: 1,
     }
 }

--- a/code/packages/rust/adj-lang/src/adapter.rs
+++ b/code/packages/rust/adj-lang/src/adapter.rs
@@ -75,6 +75,14 @@ pub enum AdapterError {
     /// A `latex "<math>"` expression or `constrain latex "<equation>"`
     /// could not be parsed by the repo's LaTeX MathFrontend.
     LatexParse { source: String, detail: String },
+    /// An `asciimath "<math>"` expression could not be parsed by the repo's
+    /// AsciiMath MathFrontend. AsciiMath is a SECOND math frontend that lowers
+    /// through the same neutral `MathExpr` pipeline as `latex`; only the parse
+    /// step is frontend-specific, so this is its counterpart to
+    /// [`AdapterError::LatexParse`]. Once parsed, an unsupported node still
+    /// surfaces as [`AdapterError::UnsupportedLatexMath`] — the shared
+    /// neutral-tree lowering names its errors after that first frontend.
+    AsciiMathParse { source: String, detail: String },
     /// LaTeX parsed successfully, but used math outside the ADJ arithmetic /
     /// constraint subset this surface can lower faithfully.
     UnsupportedLatexMath { source: String, detail: String },
@@ -838,6 +846,15 @@ fn adapt_factor(node: &GrammarASTNode) -> Result<ExprAst, AdapterError> {
         let math = parse_latex_math(&source)?;
         return latex_math_to_expr_ast(&math, &source);
     }
+    // A SECOND math frontend on the same factor position: `asciimath "..."`.
+    // Only the parse step differs — the resulting neutral `MathExpr` flows
+    // through the identical `latex_math_to_expr_ast` lowering, so the whole
+    // arithmetic + named-function surface is available for free (PFE01).
+    if let Some(am) = first_named_child(node, "asciimath_expr") {
+        let source = latex_string_from_node(am, "asciimath_expr")?;
+        let math = parse_asciimath_math(&source)?;
+        return latex_math_to_expr_ast(&math, &source);
+    }
     if let Some(agg) = first_named_child(node, "agg") {
         return adapt_agg(agg);
     }
@@ -881,6 +898,29 @@ fn parse_latex_math(source: &str) -> Result<MathExpr, AdapterError> {
     registry
         .parse("latex", math)
         .map_err(|e| AdapterError::LatexParse {
+            source: source.to_string(),
+            detail: e.message,
+        })
+}
+
+/// Parse an `asciimath "..."` string with the repo's AsciiMath `MathFrontend`.
+///
+/// This is the AsciiMath counterpart to [`parse_latex_math`] — the ONLY
+/// frontend-specific step in the pipeline. Its output is the same neutral
+/// [`MathExpr`] the LaTeX frontend produces, which the caller lowers with the
+/// shared [`latex_math_to_expr_ast`]. (We strip `$…$`-style math delimiters
+/// first, harmlessly: AsciiMath does not use them, but a model may wrap either
+/// dialect in them, and stripping keeps the two surfaces symmetric.)
+///
+/// The AsciiMath parser lives in its own crate and owns its own recursion/DoS
+/// discipline; this adapter adds no new tree-walker, so it introduces no new
+/// stack-overflow surface here.
+fn parse_asciimath_math(source: &str) -> Result<MathExpr, AdapterError> {
+    use math_frontend::MathFrontend;
+    let math = strip_math_delimiters(source);
+    asciimath::AsciiMath
+        .parse(math)
+        .map_err(|e| AdapterError::AsciiMathParse {
             source: source.to_string(),
             detail: e.message,
         })

--- a/code/packages/rust/adj-lang/src/lower.rs
+++ b/code/packages/rust/adj-lang/src/lower.rs
@@ -1768,6 +1768,57 @@ contributes 1000000 from answer == 60 to correct
         assert!(d.ranked[0].posterior > 0.99, "{d:?}");
     }
 
+    // --- AsciiMath: a SECOND math frontend on the same neutral pipeline (PFE01) ---
+    // These prove that `asciimath "..."` reaches the identical `MathExpr -> ExprAst`
+    // lowering the `latex "..."` surface uses: the ONLY difference is which
+    // MathFrontend parses the string. So the whole arithmetic subset computes
+    // through `compile_and_decide` for free, with no new lowering or engine op.
+
+    #[test]
+    fn native_asciimath_expr_computes_inside_let() {
+        // `(3+4)*2` = 14. AsciiMath `*` is the same Mul the LaTeX `\times`/`\cdot`
+        // lowered to, so the engine derives the same scalar.
+        let d = crate::compile_and_decide(
+            "let answer = asciimath \"(3+4)*2\"\n\
+             prior 0.10 for correct\n\
+             contributes 1000000 from answer == 14 to correct\n\
+             ? correct\n",
+        )
+        .unwrap();
+        assert!(d.ranked[0].posterior > 0.99, "{d:?}");
+    }
+
+    #[test]
+    fn native_asciimath_fraction_reuses_the_latex_frac_lowering() {
+        // AsciiMath `(3+4)/2` parses to the SAME `MathExpr::Frac` that LaTeX
+        // `\frac{3+4}{2}` produces, so it flows through the identical lowering and
+        // computes 7/2 = 3.5 — the clearest demonstration that the second frontend
+        // is consumed for free by the existing neutral-tree path.
+        let d = crate::compile_and_decide(
+            "let answer = asciimath \"(3+4)/2\"\n\
+             prior 0.10 for correct\n\
+             contributes 1000000 from answer == 3.5 to correct\n\
+             ? correct\n",
+        )
+        .unwrap();
+        assert!(d.ranked[0].posterior > 0.99, "{d:?}");
+    }
+
+    #[test]
+    fn native_asciimath_observed_symbol_binds() {
+        // An observed slot referenced from inside an AsciiMath expression binds
+        // exactly as it does for LaTeX: with x=2 observed, `x*x` = 4.
+        let d = crate::compile_and_decide(
+            "observe x(2)\n\
+             let answer = asciimath \"x*x\"\n\
+             prior 0.10 for correct\n\
+             contributes 1000000 from answer == 4 to correct\n\
+             ? correct\n",
+        )
+        .unwrap();
+        assert!(d.ranked[0].posterior > 0.99, "{d:?}");
+    }
+
     #[test]
     fn native_latex_relation_lowers_to_constraint() {
         let lowered =


### PR DESCRIPTION
## adj-lang: a SECOND math frontend — `asciimath "…"` (pluggable-frontends thesis, PFE01)

The LaTeX consumer surface (`latex "…"`) is complete: its `MathExpr → ExprAst` lowering
covers the full arithmetic + named-function surface. This PR proves that lowering is
**frontend-neutral** by wiring a *second* math dialect through the exact same pipeline.

### What changed

- **New surface `asciimath "<math>"`** — accepted anywhere an ADJ arithmetic expression is
  (as an `expr` factor), alongside `latex "…"`. AsciiMath is a dialect many math-tuned models
  emit (`(a+b)/c`, `1/2`, `x*x`).
- The repo already ships an `asciimath` `MathFrontend` that parses to the **same neutral
  `math_frontend::MathExpr`** the LaTeX frontend produces. So the adapter's **only**
  frontend-specific step is the parse call — `parse_asciimath_math`, the direct counterpart
  to `parse_latex_math`. The resulting `MathExpr` flows through the **identical, unchanged**
  `latex_math_to_expr_ast` lowering.
- **Result:** the whole arithmetic + named-function surface (fractions, products, sums,
  powers, trig/hyperbolic families, …) is available to AsciiMath **for free** — no new
  lowering, and **no new engine op**.

### Files

| file | change |
|---|---|
| `code/grammars/adj_lang/adj_lang.grammar` | `factor` gains `asciimath_expr`; new `asciimath_expr = "asciimath" STRING ;` |
| `…/adj-lang/src/_lexer_grammar.rs`, `_parser_grammar.rs` | regenerated (`regen_grammars`) |
| `…/adj-lang/src/adapter.rs` | `AdapterError::AsciiMathParse`; `adapt_factor` branch; `parse_asciimath_math` helper |
| `…/adj-lang/src/lower.rs` | 3 end-to-end tests |
| `…/adj-lang/Cargo.toml` | `asciimath` path dep; 0.45.0 → 0.46.0 |
| `…/adj-lang/CHANGELOG.md` | 0.46.0 entry |

### Proof (end-to-end through `compile_and_decide`)

```
asciimath "(3+4)*2"          == 14     # Mul, same as LaTeX \times/\cdot
asciimath "(3+4)/2"          == 3.5    # MathExpr::Frac — the very lowering LaTeX \frac uses
observe x(2); asciimath "x*x" == 4     # observed slot binds inside AsciiMath, as for LaTeX
```

### Security / DoS

The adapter adds **no new recursive tree-walker** — it reuses the existing
`latex_math_to_expr_ast` lowering. The AsciiMath parser owns its own recursion/DoS discipline
in its own crate, so this diff introduces no new stack-overflow surface (no new deep-input
regression test is warranted on the adapter side). Parse is pure/offline over an in-DSL string
literal: no I/O, shell, or network. Security review: PASSED.

### Verification

- `cargo test -p adj-lang -p adj-lang-cli -p adj-constraint-solver` — all green (new asciimath
  tests 3/3; no regressions in the regenerated-grammar consumers).
- `cargo test -p adj-lang --doc` — 0 doctests (no runnable doc snippets introduced).
- `cargo clippy -p adj-lang` — no new warnings in touched files.
